### PR TITLE
feat(keybindings): add tab.moveToSplitRight for Move Tab to Split

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -89,6 +89,11 @@ import { RecoverableRenderErrorBoundary } from './components/error-boundaries/Re
 import { ConfirmationDialogProvider } from './components/confirmation-dialog'
 import { LinkRoutingPreferenceDialogProvider } from './components/link-routing-preference-dialog'
 import RecentTabSwitcher from './components/tab-bar/RecentTabSwitcher'
+import {
+  TAB_SPLIT_SHORTCUT_DIRECTIONS,
+  resolveActiveTabPaneColumnTarget
+} from './components/tab-bar/active-tab-pane-column-split'
+import { moveTabToNewPaneColumn } from './components/tab-bar/tab-move-to-pane-column'
 import { useGitStatusPolling } from './components/right-sidebar/useGitStatusPolling'
 import { useEditorExternalWatch } from './hooks/useEditorExternalWatch'
 import { useAutoAckViewedAgent } from './hooks/useAutoAckViewedAgent'
@@ -1819,6 +1824,25 @@ function App(): React.JSX.Element {
         requestFloatingTerminalOpenMaximized()
         setFloatingTerminalOpenWithFocus(true)
         return
+      }
+
+      // Keyboard path for "Move Tab to Split". Ahead of the editable-target guard because it is a
+      // layout command, not text input: Monaco's EditContext div passes the guard today, but its
+      // legacy textarea path would not. A single-tab group has nothing to split, so the chord falls through.
+      if (workspaceChromeActive && !isFloatingWorkspacePanelFocused()) {
+        for (const [actionId, direction] of TAB_SPLIT_SHORTCUT_DIRECTIONS) {
+          if (!matchShortcut(actionId)) {
+            continue
+          }
+          const target = resolveActiveTabPaneColumnTarget(activeWorktreeId)
+          if (!target) {
+            break
+          }
+          input.preventDefault()
+          notifyTerminalCapture(actionId)
+          moveTabToNewPaneColumn({ ...target, direction })
+          return
+        }
       }
 
       // Skip editable surfaces so TipTap's Cmd+B bold works; this renderer-side fallback covers the blur→press IPC race (docs/markdown-cmd-b-bold-design.md).

--- a/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabContextMenu.test.tsx
@@ -96,6 +96,7 @@ vi.mock('@/i18n/i18n', () => ({
 // Why: the menu reads live shortcut bindings; stub them to fixed labels so
 // the test asserts each assigned action surfaces its own shortcut chip.
 vi.mock('@/hooks/useShortcutLabel', () => ({
+  formatOptionalShortcutLabel: shortcutLabelMock,
   useOptionalShortcutLabel: shortcutLabelMock
 }))
 

--- a/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
@@ -126,6 +126,7 @@ vi.mock('lucide-react', () => ({
 }))
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
+  formatOptionalShortcutLabel: () => '⌘\\',
   formatShortcutLabel: () => '⌘⇧\\',
   useOptionalShortcutLabel: () => '⌘W',
   useShortcutKeyDetails: () => ({ keys: ['⌘', 'W'], doubleTap: false })

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -19,6 +19,7 @@ const storeMock = vi.hoisted(() => ({
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
   formatShortcutLabel: () => '⌘D',
+  formatOptionalShortcutLabel: () => '⌘D',
   useOptionalShortcutLabel: () => '⌘D'
 }))
 
@@ -261,6 +262,14 @@ describe('SortableTabContextMenu', () => {
 
     expect(getButton(container, 'Close Tabs To The Left').disabled).toBe(true)
     expect(getButton(container, 'Close Tabs To The Right').disabled).toBe(true)
+  })
+
+  it('shows the bound shortcut on the Right split item only', () => {
+    const { container } = renderMenu()
+
+    const rightItem = getButton(container, 'Right')
+    expect(rightItem.textContent).toContain('⌘D')
+    expect(getButton(container, 'Left').textContent).not.toContain('⌘D')
   })
 
   it('hides move-tab split actions for a single-tab group', () => {

--- a/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
+++ b/src/renderer/src/components/tab-bar/TabWorkspaceLayoutMenuSection.tsx
@@ -3,11 +3,14 @@ import {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuItem
+  DropdownMenuItem,
+  DropdownMenuShortcut
 } from '@/components/ui/dropdown-menu'
 import { ArrowDown, ArrowLeft, ArrowRight, ArrowUp, Columns2 } from 'lucide-react'
 import type { TabSplitDirection } from '../../store/slices/tabs'
 import { translate } from '@/i18n/i18n'
+import { formatOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
+import { useAppStore } from '../../store'
 import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
 import { TAB_CONTEXT_SUBMENU_CONTENT_CLASS } from './tab-context-menu-sizing'
 
@@ -48,6 +51,13 @@ export function TabWorkspaceLayoutMenuSection({
   groupId: string
   trailingSeparator?: boolean
 }): React.JSX.Element | null {
+  // Why: read without a hook to match the sibling guard below — BrowserTab renders this
+  // section through a shallow function-call harness where hooks are not available.
+  const moveToSplitRightShortcut = formatOptionalShortcutLabel(
+    'tab.moveToSplitRight',
+    useAppStore.getState().keybindings
+  )
+
   if (!canMoveTabToNewPaneColumn(unifiedTabId, groupId)) {
     return null
   }
@@ -72,6 +82,9 @@ export function TabWorkspaceLayoutMenuSection({
             >
               {paneColumnDirectionIcon(direction)}
               {paneColumnDirectionLabel(direction)}
+              {direction === 'right' && moveToSplitRightShortcut ? (
+                <DropdownMenuShortcut>{moveToSplitRightShortcut}</DropdownMenuShortcut>
+              ) : null}
             </DropdownMenuItem>
           ))}
         </DropdownMenuSubContent>

--- a/src/renderer/src/components/tab-bar/active-tab-pane-column-split.test.ts
+++ b/src/renderer/src/components/tab-bar/active-tab-pane-column-split.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '../../store'
+import type { Tab } from '../../../../shared/types'
+import {
+  TAB_SPLIT_SHORTCUT_DIRECTIONS,
+  resolveActiveTabPaneColumnTarget
+} from './active-tab-pane-column-split'
+
+const WT = 'wt-1'
+
+function unifiedTab(id: string, sortOrder: number): Tab {
+  return {
+    id,
+    groupId: 'group-1',
+    worktreeId: WT,
+    contentType: 'terminal',
+    entityId: `term-${id}`,
+    label: id,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+describe('active-tab-pane-column-split', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      activeWorktreeId: WT,
+      activeGroupIdByWorktree: { [WT]: 'group-1' },
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: 'group-1',
+            worktreeId: WT,
+            activeTabId: 'tab-a',
+            tabOrder: ['tab-a', 'tab-b']
+          }
+        ]
+      },
+      unifiedTabsByWorktree: {
+        [WT]: [unifiedTab('tab-a', 0), unifiedTab('tab-b', 1)]
+      },
+      layoutByWorktree: {
+        [WT]: { type: 'leaf', groupId: 'group-1' }
+      }
+    })
+  })
+
+  it('maps each split shortcut to its pane column direction', () => {
+    expect(TAB_SPLIT_SHORTCUT_DIRECTIONS).toEqual([['tab.moveToSplitRight', 'right']])
+  })
+
+  it('resolves the active tab and its group for the active worktree', () => {
+    expect(resolveActiveTabPaneColumnTarget(WT)).toEqual({
+      unifiedTabId: 'tab-a',
+      groupId: 'group-1'
+    })
+  })
+
+  it('returns null without a worktree', () => {
+    expect(resolveActiveTabPaneColumnTarget(null)).toBeNull()
+    expect(resolveActiveTabPaneColumnTarget(undefined)).toBeNull()
+  })
+
+  it('returns null for an unknown worktree', () => {
+    expect(resolveActiveTabPaneColumnTarget('wt-missing')).toBeNull()
+  })
+
+  it('returns null when the active group has a single tab', () => {
+    useAppStore.setState({
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: 'group-1',
+            worktreeId: WT,
+            activeTabId: 'tab-a',
+            tabOrder: ['tab-a']
+          }
+        ]
+      },
+      unifiedTabsByWorktree: { [WT]: [unifiedTab('tab-a', 0)] }
+    })
+
+    expect(resolveActiveTabPaneColumnTarget(WT)).toBeNull()
+  })
+
+  it('returns null when the active group has no active tab', () => {
+    useAppStore.setState({
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: 'group-1',
+            worktreeId: WT,
+            activeTabId: null,
+            tabOrder: ['tab-a', 'tab-b']
+          }
+        ]
+      }
+    })
+
+    expect(resolveActiveTabPaneColumnTarget(WT)).toBeNull()
+  })
+})

--- a/src/renderer/src/components/tab-bar/active-tab-pane-column-split.ts
+++ b/src/renderer/src/components/tab-bar/active-tab-pane-column-split.ts
@@ -1,0 +1,28 @@
+import type { KeybindingActionId } from '../../../../shared/keybindings'
+import { useAppStore } from '../../store'
+import type { TabSplitDirection } from '../../store/slices/tabs'
+import { canMoveTabToNewPaneColumn } from './tab-move-to-pane-column'
+
+export type TabPaneColumnTarget = {
+  unifiedTabId: string
+  groupId: string
+}
+
+export const TAB_SPLIT_SHORTCUT_DIRECTIONS: readonly (readonly [
+  KeybindingActionId,
+  TabSplitDirection
+])[] = [['tab.moveToSplitRight', 'right']]
+
+/** The active tab of a worktree, or null when it cannot be split into a sibling pane column. */
+export function resolveActiveTabPaneColumnTarget(
+  worktreeId: string | null | undefined
+): TabPaneColumnTarget | null {
+  if (!worktreeId) {
+    return null
+  }
+  const activeTab = useAppStore.getState().getActiveTab(worktreeId)
+  if (!activeTab || !canMoveTabToNewPaneColumn(activeTab.id, activeTab.groupId)) {
+    return null
+  }
+  return { unifiedTabId: activeTab.id, groupId: activeTab.groupId }
+}

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -762,6 +762,39 @@ describe('keybindings', () => {
     )
   })
 
+  it('binds move-tab-to-split-right to the Cursor/VS Code split chord on every platform', () => {
+    const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
+
+    for (const platform of platforms) {
+      expect(getEffectiveKeybindingsForAction('tab.moveToSplitRight', platform)).toEqual([
+        'Mod+Backslash'
+      ])
+    }
+
+    const definition = getKeybindingDefinition('tab.moveToSplitRight')
+    expect(definition?.group).toBe('Tabs')
+    expect(definition?.scope).toBe('tabs')
+    expect(definition?.title).toBe('Move active tab to split right')
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['shortcut', 'tab', 'split', 'pane', 'editor'])
+    )
+
+    expect(
+      keybindingMatchesAction(
+        'tab.moveToSplitRight',
+        { key: '\\', code: 'Backslash', meta: true, control: false, alt: false, shift: false },
+        'darwin'
+      )
+    ).toBe(true)
+  })
+
+  // Why: the two split actions live in different conflict buckets (tabs vs terminal), so a terminal.splitRight rebind must not evict the default.
+  it('does not report a conflict when terminal.splitRight is rebound onto the same chord', () => {
+    expect(findKeybindingConflicts('darwin', { 'terminal.splitRight': ['Mod+Backslash'] })).toEqual(
+      []
+    )
+  })
+
   it('keeps the quick commands menu toggle unassigned until users customize it', () => {
     const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
 

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -68,6 +68,7 @@ export type KeybindingActionId =
   | 'tab.closeAll'
   | 'tab.rename'
   | 'tab.reopenClosed'
+  | 'tab.moveToSplitRight'
   | 'tab.nextSameType'
   | 'tab.previousSameType'
   | 'tab.nextAllTypes'
@@ -621,6 +622,24 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'reopen', 'restore', 'closed'],
     defaultBindings: platformBindings(['Mod+Shift+T'])
+  },
+  {
+    id: 'tab.moveToSplitRight',
+    title: 'Move active tab to split right',
+    group: 'Tabs',
+    scope: 'tabs',
+    searchKeywords: [
+      'shortcut',
+      'tab',
+      'split',
+      'pane',
+      'column',
+      'editor',
+      'move',
+      'right',
+      'side by side'
+    ],
+    defaultBindings: platformBindings(['Mod+Backslash'])
   },
   {
     id: 'tab.nextSameType',

--- a/tests/e2e/tab-move-to-split-shortcut.spec.ts
+++ b/tests/e2e/tab-move-to-split-shortcut.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * E2E test for the `tab.moveToSplitRight` keybinding (default Mod+\).
+ *
+ * Why E2E rather than a store-slice unit test: the split itself is already
+ * covered at the slice level, but the thing under test here is the global
+ * keyboard path — the window capture-phase handler in App.tsx resolving the
+ * active tab and reaching `moveTabToNewPaneColumn`. Per tests/e2e/AGENTS.md,
+ * keyboard shortcuts are one of the cases a unit test cannot reach.
+ *
+ * The final assertion counts rendered tab-group bodies, so a render regression
+ * that leaves the layout tree correct but paints one pane still fails.
+ */
+
+import { test, expect } from './helpers/orca-app'
+import type { Page } from '@stablyai/playwright-test'
+import {
+  waitForSessionReady,
+  waitForActiveWorktree,
+  ensureTerminalVisible,
+  getActiveTabType
+} from './helpers/store'
+import { clickFileInExplorer, openFileExplorer } from './helpers/file-explorer'
+
+const GROUP_BODY = '[data-tab-group-body-id]'
+const SORTABLE_TAB = '[data-testid="sortable-tab"]'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function countGroupBodies(page: Page): Promise<number> {
+  return page.locator(GROUP_BODY).count()
+}
+
+async function countRenderedTabs(page: Page): Promise<number> {
+  return page.locator(SORTABLE_TAB).count()
+}
+
+test.describe('Move tab to split shortcut', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+  })
+
+  test(`${MOD}+\\ moves the active tab into a new pane column`, async ({ orcaPage }) => {
+    // The guard declines on a single-tab group, so seed a second tab first.
+    // Setup goes through the store on purpose: the "+" menu's accessible name is
+    // localized, and this spec is about Mod+\, not tab creation.
+    await orcaPage.evaluate(() => {
+      const store = window.__store
+      const state = store?.getState()
+      const worktreeId = state?.activeWorktreeId
+      if (state && worktreeId) {
+        state.createTab(worktreeId)
+      }
+    })
+    await expect
+      .poll(() => countRenderedTabs(orcaPage), {
+        timeout: 10_000,
+        message: 'Could not seed a second tab to split'
+      })
+      .toBeGreaterThan(1)
+
+    const groupsBefore = await countGroupBodies(orcaPage)
+
+    await orcaPage.evaluate(() => document.body.focus())
+    await orcaPage.keyboard.press(`${MOD}+\\`)
+
+    await expect
+      .poll(() => countGroupBodies(orcaPage), {
+        timeout: 5_000,
+        message: `${MOD}+\\ did not render a second tab group body`
+      })
+      .toBe(groupsBefore + 1)
+  })
+
+  test(`${MOD}+\\ still splits while the Monaco editor holds focus`, async ({ orcaPage }) => {
+    // Why this case exists: the global handler sits behind an `isEditableTarget`
+    // guard, and Monaco's input is a <textarea>. Cursor/VS Code split while the
+    // editor is focused, so the parity claim only holds if this passes.
+    await openFileExplorer(orcaPage)
+    const clickedFile = await clickFileInExplorer(orcaPage, [
+      'package.json',
+      'tsconfig.json',
+      'README.md',
+      '.gitignore'
+    ])
+    expect(clickedFile).not.toBeNull()
+    await expect.poll(() => getActiveTabType(orcaPage), { timeout: 10_000 }).toBe('editor')
+
+    const monaco = orcaPage.locator('.monaco-editor').first()
+    await expect(monaco).toBeVisible({ timeout: 25_000 })
+    await monaco.click()
+
+    // Guard against a vacuous pass: if focus never reached Monaco's <textarea>,
+    // the isEditableTarget branch was never exercised and this test proves nothing.
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate(() => {
+            const active = document.activeElement
+            return active instanceof HTMLElement ? active.className : null
+          }),
+        { timeout: 5_000, message: 'Monaco never took keyboard focus' }
+      )
+      // Monaco's focused input is `native-edit-context` on the EditContext path
+      // and `inputarea` on the legacy textarea path; accept either.
+      .toMatch(/native-edit-context|inputarea/)
+
+    const groupsBefore = await countGroupBodies(orcaPage)
+    await orcaPage.keyboard.press(`${MOD}+\\`)
+
+    await expect
+      .poll(() => countGroupBodies(orcaPage), {
+        timeout: 5_000,
+        message: `${MOD}+\\ did not split while Monaco held focus`
+      })
+      .toBe(groupsBefore + 1)
+  })
+
+  test(`${MOD}+\\ still splits while a text input holds focus`, async ({ orcaPage }) => {
+    // Why: the chord is dispatched ahead of the isEditableTarget guard, since it is a layout
+    // command rather than text input. This pins that ordering — Monaco's EditContext div passes
+    // the guard today, but its legacy textarea path would not.
+    await openFileExplorer(orcaPage)
+    await clickFileInExplorer(orcaPage, ['package.json', 'README.md', '.gitignore'])
+    await expect.poll(() => getActiveTabType(orcaPage), { timeout: 10_000 }).toBe('editor')
+
+    const focusedTag = await orcaPage.evaluate(() => {
+      const input = document.querySelector('input:not([type="hidden"])')
+      if (input instanceof HTMLElement) {
+        input.focus()
+      }
+      return document.activeElement?.tagName ?? null
+    })
+    expect(focusedTag).toBe('INPUT')
+
+    const groupsBefore = await countGroupBodies(orcaPage)
+    await orcaPage.keyboard.press(`${MOD}+\\`)
+
+    await expect
+      .poll(() => countGroupBodies(orcaPage), {
+        timeout: 5_000,
+        message: `${MOD}+\\ did not split while a text input held focus`
+      })
+      .toBe(groupsBefore + 1)
+  })
+
+  test(`${MOD}+\\ is a no-op for a group holding a single tab`, async ({ orcaPage }) => {
+    // Why: the chord must fall through rather than preventDefault, so a lone
+    // tab is never moved into an empty column it would immediately re-merge from.
+    await expect.poll(() => countRenderedTabs(orcaPage), { timeout: 5_000 }).toBe(1)
+    const groupsBefore = await countGroupBodies(orcaPage)
+
+    await orcaPage.evaluate(() => document.body.focus())
+    await orcaPage.keyboard.press(`${MOD}+\\`)
+
+    await expect(orcaPage.locator(GROUP_BODY)).toHaveCount(groupsBefore)
+  })
+})


### PR DESCRIPTION
## Summary

Registers `tab.moveToSplitRight` (default `Mod+\`) so the existing **Move Tab to Split → Right** action has a keyboard path. It works for any active tab type — editor, terminal, browser — because it reuses the tab-type-agnostic `moveTabToNewPaneColumn`, not the terminal-only pane split.

Two split layers already existed and only one was bindable, so a user searching "split" in Settings found only `terminal.splitRight`, which silently no-ops when an editor tab is focused:

| Layer | Applies to | Shortcut before |
|---|---|---|
| Group / tab split | any tab | **none** (context menu only) |
| Terminal pane split | terminal panes | `terminal.splitRight` (`Cmd+D`) |

- `tab.moveToSplitRight` — group `Tabs`, scope `tabs`, default `Mod+\` on all platforms (previously unbound registry-wide)
- Active-tab resolution extracted to `active-tab-pane-column-split.ts`; reuses the existing `canMoveTabToNewPaneColumn` guard
- When the guard declines (single-tab group), the chord falls through without `preventDefault`, so nothing is swallowed
- Dispatched ahead of the `isEditableTarget` guard, since this is a layout command rather than text input (see review note below)
- The context menu's **Right** item now shows the bound shortcut
- Right-only first pass; Left/Down/Up stay menu-only

Closes #10055

## Screenshots

<!-- before -->
<img width="4608" height="2532" alt="tab-split-before-masked" src="https://github.com/user-attachments/assets/8ef2d7d5-b6e7-4c85-9a18-1e3acf4aa923" />
<!-- after -->
<img width="4608" height="2532" alt="tab-split-after-masked" src="https://github.com/user-attachments/assets/fdcf73ec-5821-4beb-8f14-7c67578b2066" />

## Testing

- [x] `pnpm lint` — see note below; the failing step is unrelated to this change and is not the lint CI runs
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`pnpm test`: 3254 files pass. 5 files / 30 tests fail — **all pre-existing**, verified by stashing this branch's changes and re-running the same 5 files on a clean tree, which produces the identical 30 failures (`clipboard-ipc-handlers`, `agent-exec-handler`, `runner-command-exec`, `orchestration`, `coordinator` — all unrelated areas).

`pnpm lint`: fails on `verify:localization-catalog`, reporting `translate()` keys missing from `en.json` in `NewWorkspaceComposerCard.tsx`, `SshHostAdvancedFields.tsx` and `sleep-worktree-flow.ts` — all files this PR does not touch, and this PR adds no `translate()` calls at all. Pre-existing on current `main`. CI's `pnpm exec oxlint --format github` is clean with these changes: 27 warnings, 0 errors.

Tests added:

- `tests/e2e/tab-move-to-split-shortcut.spec.ts` — four specs: the split happens; it still happens while Monaco holds focus; it still happens while a plain `<input>` holds focus; and it is a no-op for a single-tab group. `tests/e2e/AGENTS.md` names keyboard shortcuts as a case a unit test cannot reach.
- `src/shared/keybindings.test.ts` — definition shape plus a regression test that a `terminal.splitRight` rebind onto the same chord reports **no** conflict.
- `src/renderer/src/components/tab-bar/active-tab-pane-column-split.test.ts` — active-tab resolution against real store state.
- `src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx` — the shortcut label renders on **Right** only.

## AI Review Report

Reviewed for cross-platform, remote/SSH, agent/integration, performance, UI, and security risk.

- **Cross-platform**: `platformBindings(['Mod+Backslash'])` resolves to Cmd on macOS and Ctrl on Linux/Windows. Label rendering goes through the existing `formatKeyToken` map (`Backslash` → `\`). No hardcoded `metaKey`.
- **SSH / remote / mobile**: split layout is renderer state, and `moveTabToNewPaneColumn` already calls `mirrorWebRuntimeTabMove`, so remote and web runtimes inherit the existing mirror path unchanged. No new IPC and no new main-process surface.
- **Agents / integrations / git providers**: none touched. The action is agent- and provider-neutral.
- **Performance**: one additional keybinding match per keydown; the store read only happens after the chord matches. No hot-path work, no IPC.
- **UI**: no new surface. Reuses the existing split rendering and the existing menu row, so no new tokens or components.
- **Focus handling — verified, then hardened.** The dispatch originally sat behind `isEditableTarget`. Probing the running app showed that guard does *not* block the chord today: Monaco's focused element is `{"tag":"DIV","cls":"native-edit-context","isContentEditable":false,"closestEditable":null}`, and `xterm-helper-textarea` is explicitly exempted for terminals. Worth stating plainly that the first version of that E2E case **passed vacuously** — it only became meaningful after adding an explicit `document.activeElement` assertion. Even so, the dispatch now runs ahead of the guard: Monaco's legacy `textarea.inputarea` path *would* be blocked, and this is a layout command rather than text input. A fourth E2E case pins the ordering by splitting while a real `<input>` holds focus.
- **Flagged during review and resolved — the menu label cannot use a hook.** Adding `useOptionalShortcutLabel` to `TabWorkspaceLayoutMenuSection` breaks `BrowserTab.test.tsx`, whose harness calls the component as a plain function with no React render, so any hook throws `Invalid hook call`. The label is read without a hook instead, matching the sibling `canMoveTabToNewPaneColumn` guard in the same component. Two further tab-bar suites mock `@/hooks/useShortcutLabel` and needed the new export added to their mocks.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, network access, or IPC. The change adds one keybinding registry entry plus a renderer-local store read and an existing store action. The keybindings file parser is untouched, and the new action id flows through the same `isKeybindingActionId` validation as every other action, so a hand-edited `keybindings.json` cannot introduce an unvalidated id. No follow-up needed.

## Notes

- New default binding `Mod+\`, unbound registry-wide before this.
- Users who rebound `terminal.splitRight` onto `Mod+\` keep their override: `findKeybindingConflicts` buckets by `conflictGroup ?? scope`, and `tabs` ≠ `terminal`, so `removeConflictingOverrides` does not evict it. But with the default `orca-first` terminal policy both actions stay active inside a focused terminal, so the chord is ambiguous there until the old override is dropped. Worth a release note.
- No platform-specific, remote-specific, agent-specific, or git-provider-specific behavior beyond the modifier mapping above.
- Rebased onto current `main` (`8448557b`).
- X handle: N/A



## ELI5

You can press a shortcut (default Mod+\) to move the active tab into a new split on the right. It works for editor, terminal, and browser tabs, not only the terminal-only split command.
