### PR TITLE
feat(worktrees): add manual Run setup script for existing worktrees

### DIFF
--- a/src/main/hooks-runner.test.ts
+++ b/src/main/hooks-runner.test.ts
@@ -16,8 +16,16 @@ vi.mock('fs', () => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
   writeFileSync: vi.fn(),
-  chmodSync: vi.fn()
+  chmodSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn()
 }))
+
+// Why: runner scripts are written to a unique tmp path then renamed over the target.
+const tmpPathFor = (finalPath: string) =>
+  expect.stringMatching(
+    new RegExp(`^${finalPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.tmp-\\d+-\\d+$`)
+  )
 
 vi.mock('child_process', () => ({
   exec: vi.fn(),
@@ -67,7 +75,7 @@ describe('createSetupRunnerScript', () => {
         shell: { family: 'cmd' }
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.cmd',
+        tmpPathFor('C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.cmd'),
         [
           '@echo off',
           'setlocal EnableExtensions DisableDelayedExpansion',
@@ -78,6 +86,39 @@ describe('createSetupRunnerScript', () => {
           ''
         ].join('\r\n'),
         'utf-8'
+      )
+      expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+        tmpPathFor('C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.cmd'),
+        'C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.cmd'
+      )
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
+  it('absolutizes the relative --git-path a main worktree returns', async () => {
+    const fs = await import('node:fs')
+    const originalPlatform = process.platform
+
+    // Why: --git-path is worktree-relative in a main worktree; the runner must not
+    // land relative to the app process cwd.
+    execFileSyncMock.mockReturnValue('.git/orca/setup-runner.sh')
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'linux'
+    })
+
+    try {
+      const { createSetupRunnerScript } = await import('./hooks')
+      const result = createSetupRunnerScript(makeRepo(), '/test/repo', 'pnpm install')
+
+      expect(result.runnerScriptPath).toBe('/test/repo/.git/orca/setup-runner.sh')
+      expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+        tmpPathFor('/test/repo/.git/orca/setup-runner.sh'),
+        '/test/repo/.git/orca/setup-runner.sh'
       )
     } finally {
       Object.defineProperty(process, 'platform', {
@@ -300,13 +341,23 @@ describe('createSetupRunnerScript', () => {
         })
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
-        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
+        tmpPathFor(
+          '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.git\\worktrees\\feature\\orca\\setup-runner.sh'
+        ),
         '#!/usr/bin/env bash\nset -e\npnpm install\n',
         'utf-8'
       )
       expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(
-        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
+        tmpPathFor(
+          '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.git\\worktrees\\feature\\orca\\setup-runner.sh'
+        ),
         0o755
+      )
+      expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+        tmpPathFor(
+          '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.git\\worktrees\\feature\\orca\\setup-runner.sh'
+        ),
+        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\.git\\worktrees\\feature\\orca\\setup-runner.sh'
       )
     } finally {
       Object.defineProperty(process, 'platform', {
@@ -346,13 +397,17 @@ describe('createSetupRunnerScript', () => {
         })
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
-        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
+        tmpPathFor(
+          '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh'
+        ),
         '#!/usr/bin/env bash\nset -e\npnpm install\n',
         'utf-8'
       )
-      expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(
-        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
-        0o755
+      expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+        tmpPathFor(
+          '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh'
+        ),
+        '\\\\wsl.localhost\\Ubuntu\\home\\jin\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh'
       )
     } finally {
       Object.defineProperty(process, 'platform', {
@@ -401,13 +456,17 @@ describe('createIssueCommandRunnerScript', () => {
         })
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
-        '/test/repo/.git/worktrees/feature/orca/issue-command-runner.sh',
+        tmpPathFor('/test/repo/.git/worktrees/feature/orca/issue-command-runner.sh'),
         '#!/usr/bin/env bash\nset -e\ncodex exec "long command"\nclaude -p "review it"\n',
         'utf-8'
       )
       expect(vi.mocked(fs.chmodSync)).toHaveBeenCalledWith(
-        '/test/repo/.git/worktrees/feature/orca/issue-command-runner.sh',
+        tmpPathFor('/test/repo/.git/worktrees/feature/orca/issue-command-runner.sh'),
         0o755
+      )
+      expect(vi.mocked(fs.renameSync)).toHaveBeenCalledWith(
+        tmpPathFor('/test/repo/.git/worktrees/feature/orca/issue-command-runner.sh'),
+        '/test/repo/.git/worktrees/feature/orca/issue-command-runner.sh'
       )
     } finally {
       Object.defineProperty(process, 'platform', {

--- a/src/main/hooks-runner.test.ts
+++ b/src/main/hooks-runner.test.ts
@@ -158,13 +158,13 @@ describe('createSetupRunnerScript', () => {
         shell: { family: 'posix' }
       })
       expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
+        tmpPathFor('C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh'),
         '#!/usr/bin/env bash\nset -e\npnpm install\n',
         'utf-8'
       )
       // Why: chmod over a native Windows path is meaningless; only the WSL branch sets the bit.
       expect(vi.mocked(fs.chmodSync)).not.toHaveBeenCalledWith(
-        'C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh',
+        tmpPathFor('C:\\repo\\.git\\worktrees\\feature\\orca\\setup-runner.sh'),
         0o755
       )
     } finally {

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -13,6 +13,7 @@ vi.mock('fs', () => ({
   mkdirSync: vi.fn(),
   writeFileSync: vi.fn(),
   rmSync: vi.fn(),
+  renameSync: vi.fn(),
   chmodSync: vi.fn()
 }))
 
@@ -823,6 +824,21 @@ describe('getEffectiveHooks', () => {
     const result = getEffectiveHooks(repo)
 
     expect(result).toBeNull()
+  })
+
+  it('runs the local script alone under run-both when yaml has no setup', async () => {
+    const fs = await import('node:fs')
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+
+    const { getSetupCommandSource } = await import('./hooks')
+    const repo = makeRepo({
+      commandSourcePolicy: 'run-both',
+      scripts: { setup: 'echo "local setup"', archive: '' }
+    })
+    const result = getSetupCommandSource(repo)
+
+    // Why: parity with create — getEffectiveHookScript merges with filter(Boolean).
+    expect(result).toEqual({ source: 'local', command: 'echo "local setup"' })
   })
 
   it('falls back to legacy local setup source only when yaml is missing', async () => {

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -36,6 +36,12 @@ vi.mock('./git/runner', async () => ({
   gitExecFileSync: gitExecFileSyncMock
 }))
 
+// Why: runner scripts are written to a unique tmp path then renamed over the target.
+const tmpPathFor = (finalPath: string) =>
+  expect.stringMatching(
+    new RegExp(`^${finalPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.tmp-\\d+-\\d+$`)
+  )
+
 const TEST_REPO_PATH = join('/test/repo')
 const TEST_WORKTREE_PATH = join('/test/worktree')
 const TEST_REPO_ORCA_YAML_PATH = join(TEST_REPO_PATH, 'orca.yaml')
@@ -1297,7 +1303,7 @@ describe('createSetupRunnerScript', () => {
         { cwd: 'C:\\repo-worktree' }
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\orca\\setup-runner.sh',
+        tmpPathFor('C:\\repo\\.git\\orca\\setup-runner.sh'),
         '#!/usr/bin/env bash\nset -e\npnpm install\nnpm run build\n',
         'utf-8'
       )
@@ -1337,7 +1343,7 @@ describe('createSetupRunnerScript', () => {
         { cwd: 'C:\\repo-worktree' }
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\orca\\setup-runner.cmd',
+        tmpPathFor('C:\\repo\\.git\\orca\\setup-runner.cmd'),
         expect.stringContaining('call copy .env.example .env\r\n'),
         'utf-8'
       )
@@ -1404,7 +1410,7 @@ describe('createSetupRunnerScript', () => {
       )
 
       expect(writeFileSyncMock).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\orca\\setup-runner.sh',
+        tmpPathFor('C:\\repo\\.git\\orca\\setup-runner.sh'),
         '#!/usr/bin/env bash\nset -e\nset -euo pipefail\nmake build | tee build.log\n',
         'utf-8'
       )
@@ -1437,12 +1443,12 @@ describe('createSetupRunnerScript', () => {
         { cwd: 'C:\\repo-worktree' }
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\orca\\setup-runner.cmd',
+        tmpPathFor('C:\\repo\\.git\\orca\\setup-runner.cmd'),
         expect.stringContaining('call pnpm install\r\nif errorlevel 1 exit /b %errorlevel%'),
         'utf-8'
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\orca\\setup-runner.cmd',
+        tmpPathFor('C:\\repo\\.git\\orca\\setup-runner.cmd'),
         expect.stringContaining('call npm run build\r\nif errorlevel 1 exit /b %errorlevel%'),
         'utf-8'
       )
@@ -1472,11 +1478,14 @@ describe('createSetupRunnerScript', () => {
         { cwd: '/test/worktree' }
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
-        '/test/repo/.git/orca/setup-runner.sh',
+        tmpPathFor('/test/repo/.git/orca/setup-runner.sh'),
         '#!/usr/bin/env bash\nset -e\npnpm install\n',
         'utf-8'
       )
-      expect(chmodSyncMock).toHaveBeenCalledWith('/test/repo/.git/orca/setup-runner.sh', 0o755)
+      expect(chmodSyncMock).toHaveBeenCalledWith(
+        tmpPathFor('/test/repo/.git/orca/setup-runner.sh'),
+        0o755
+      )
       expect(result.shell).toBeUndefined()
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
@@ -1551,7 +1560,7 @@ describe('createIssueCommandRunnerScript', () => {
         { cwd: 'C:\\repo-worktree' }
       )
       expect(writeFileSyncMock).toHaveBeenCalledWith(
-        'C:\\repo\\.git\\orca\\issue-command-runner.sh',
+        tmpPathFor('C:\\repo\\.git\\orca\\issue-command-runner.sh'),
         '#!/usr/bin/env bash\nset -e\ngh issue view 42\n',
         'utf-8'
       )

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -1,6 +1,14 @@
 /* eslint-disable max-lines -- Why: hook parsing, layered issue-command resolution, and cross-platform runner setup share one execution surface, so keeping them together avoids subtle drift across create/read/write paths. */
-import { readFileSync, existsSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import {
+  readFileSync,
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  chmodSync,
+  renameSync,
+  rmSync
+} from 'node:fs'
+import { dirname, isAbsolute, join } from 'node:path'
 import { exec, execFile } from 'node:child_process'
 import { getDefaultRepoHookSettings } from '../shared/constants'
 import { getRuntimePathBasename } from '../shared/cross-platform-path'
@@ -584,24 +592,40 @@ function createWorktreeRunnerScript(args: {
   const gitRelPath = `orca/${runnerBaseName}.${runnerExtension}`
   let runnerScriptPath = getGitPath(worktreePath, gitRelPath, runtimeTarget)
 
+  // Why: a main worktree's --git-path is worktree-relative, and the fs calls below
+  // would resolve it against the app process cwd instead of the worktree.
+  if (!isAbsolute(runnerScriptPath) && !runnerScriptPath.startsWith('/')) {
+    runnerScriptPath = join(worktreePath, runnerScriptPath)
+  }
+
   // Why: git runs inside WSL and returns a Linux path; convert to a UNC path so the Windows fs calls can reach it.
   if (wslWorktree) {
     const wslInfo = getHookWslContext(worktreePath, runtimeTarget)
-    if (wslInfo?.distro) {
+    if (wslInfo?.distro && runnerScriptPath.startsWith('/')) {
       runnerScriptPath = toWindowsWslPath(runnerScriptPath.trim(), wslInfo.distro)
     }
   }
 
   mkdirSync(dirname(runnerScriptPath), { recursive: true })
 
-  if (runnerShell.family === 'cmd') {
-    writeFileSync(runnerScriptPath, buildWindowsRunnerScript(script), 'utf-8')
-  } else {
-    writeFileSync(runnerScriptPath, buildPosixRunnerScript(script), 'utf-8')
-    if (!nativeWindowsWorktree) {
-      // Why: chmod over a UNC path to the WSL filesystem sets the execute bit correctly inside WSL.
-      chmodSync(runnerScriptPath, 0o755)
-    }
+  const runnerContent =
+    runnerShell.family === 'cmd'
+      ? buildWindowsRunnerScript(script)
+      : buildPosixRunnerScript(script)
+  // Why: a manual re-run can overwrite a script bash is still reading by byte offset;
+  // rename swaps the inode so the running shell keeps its own copy.
+  const tmpRunnerPath = `${runnerScriptPath}.tmp`
+  writeFileSync(tmpRunnerPath, runnerContent, 'utf-8')
+  if (runnerShell.family !== 'cmd' && !nativeWindowsWorktree) {
+    // Why: chmod over a UNC path to the WSL filesystem sets the execute bit correctly inside WSL.
+    chmodSync(tmpRunnerPath, 0o755)
+  }
+  try {
+    renameSync(tmpRunnerPath, runnerScriptPath)
+  } catch {
+    // Why: Windows can refuse to replace a runner cmd.exe still holds open.
+    writeFileSync(runnerScriptPath, runnerContent, 'utf-8')
+    rmSync(tmpRunnerPath, { force: true })
   }
 
   // Why: setup script runs inside WSL bash, so translate the Windows UNC env-var paths to Linux paths.

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -626,16 +626,17 @@ function createWorktreeRunnerScript(args: {
   // rename swaps the inode so the running shell keeps its own copy. The suffix is
   // per-call so overlapping preparations cannot race each other into the fallback.
   const tmpRunnerPath = `${runnerScriptPath}.tmp-${process.pid}-${++runnerTmpSequence}`
-  writeFileSync(tmpRunnerPath, runnerContent, 'utf-8')
-  if (runnerShell.family !== 'cmd' && !nativeWindowsWorktree) {
-    // Why: chmod over a UNC path to the WSL filesystem sets the execute bit correctly inside WSL.
-    chmodSync(tmpRunnerPath, 0o755)
-  }
   try {
+    writeFileSync(tmpRunnerPath, runnerContent, 'utf-8')
+    if (runnerShell.family !== 'cmd' && !nativeWindowsWorktree) {
+      // Why: chmod over a UNC path to the WSL filesystem sets the execute bit correctly inside WSL.
+      chmodSync(tmpRunnerPath, 0o755)
+    }
     renameSync(tmpRunnerPath, runnerScriptPath)
   } catch {
     try {
-      // Why: Windows can refuse to replace a runner cmd.exe still holds open.
+      // Why: Windows can refuse to replace a runner cmd.exe still holds open. The mode
+      // stays 0644 here, which is fine only while consumers run `bash <path>`.
       writeFileSync(runnerScriptPath, runnerContent, 'utf-8')
     } finally {
       rmSync(tmpRunnerPath, { force: true })

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -8,7 +8,7 @@ import {
   renameSync,
   rmSync
 } from 'node:fs'
-import { dirname, isAbsolute, join } from 'node:path'
+import { dirname, join, posix as posixPath, win32 as win32Path } from 'node:path'
 import { exec, execFile } from 'node:child_process'
 import { getDefaultRepoHookSettings } from '../shared/constants'
 import { getRuntimePathBasename } from '../shared/cross-platform-path'
@@ -331,8 +331,14 @@ export function getSetupCommandSource(
     return localSetup ? { source: 'local', command: localSetup } : null
   }
 
-  if (policy === 'run-both' && yamlSetup && localSetup) {
-    return { source: 'both', command: `${yamlSetup}\n${localSetup}` }
+  // Why: run-both must degrade like the create path's merge — either script alone still runs.
+  if (policy === 'run-both' && (yamlSetup || localSetup)) {
+    if (yamlSetup && localSetup) {
+      return { source: 'both', command: `${yamlSetup}\n${localSetup}` }
+    }
+    return yamlSetup
+      ? { source: 'yaml', command: yamlSetup }
+      : { source: 'local', command: localSetup as string }
   }
 
   if (yamlSetup) {
@@ -547,6 +553,8 @@ export function createIssueCommandRunnerScript(
   })
 }
 
+let runnerTmpSequence = 0
+
 function createWorktreeRunnerScript(args: {
   repo: Repo
   worktreePath: string
@@ -593,8 +601,10 @@ function createWorktreeRunnerScript(args: {
   let runnerScriptPath = getGitPath(worktreePath, gitRelPath, runtimeTarget)
 
   // Why: a main worktree's --git-path is worktree-relative, and the fs calls below
-  // would resolve it against the app process cwd instead of the worktree.
-  if (!isAbsolute(runnerScriptPath) && !runnerScriptPath.startsWith('/')) {
+  // would resolve it against the app process cwd instead of the worktree. win32's
+  // check also accepts the rooted Linux paths git-in-WSL returns.
+  const isPathAbsolute = process.platform === 'win32' ? win32Path.isAbsolute : posixPath.isAbsolute
+  if (!isPathAbsolute(runnerScriptPath)) {
     runnerScriptPath = join(worktreePath, runnerScriptPath)
   }
 
@@ -613,8 +623,9 @@ function createWorktreeRunnerScript(args: {
       ? buildWindowsRunnerScript(script)
       : buildPosixRunnerScript(script)
   // Why: a manual re-run can overwrite a script bash is still reading by byte offset;
-  // rename swaps the inode so the running shell keeps its own copy.
-  const tmpRunnerPath = `${runnerScriptPath}.tmp`
+  // rename swaps the inode so the running shell keeps its own copy. The suffix is
+  // per-call so overlapping preparations cannot race each other into the fallback.
+  const tmpRunnerPath = `${runnerScriptPath}.tmp-${process.pid}-${++runnerTmpSequence}`
   writeFileSync(tmpRunnerPath, runnerContent, 'utf-8')
   if (runnerShell.family !== 'cmd' && !nativeWindowsWorktree) {
     // Why: chmod over a UNC path to the WSL filesystem sets the execute bit correctly inside WSL.
@@ -623,9 +634,12 @@ function createWorktreeRunnerScript(args: {
   try {
     renameSync(tmpRunnerPath, runnerScriptPath)
   } catch {
-    // Why: Windows can refuse to replace a runner cmd.exe still holds open.
-    writeFileSync(runnerScriptPath, runnerContent, 'utf-8')
-    rmSync(tmpRunnerPath, { force: true })
+    try {
+      // Why: Windows can refuse to replace a runner cmd.exe still holds open.
+      writeFileSync(runnerScriptPath, runnerContent, 'utf-8')
+    } finally {
+      rmSync(tmpRunnerPath, { force: true })
+    }
   }
 
   // Why: setup script runs inside WSL bash, so translate the Windows UNC env-var paths to Linux paths.

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -6805,14 +6805,16 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('returns folder-repo without creating a setup runner for folder workspaces', async () => {
-    store.getRepo.mockReturnValue({
-      id: 'repo-1',
-      path: '/workspace/folder',
-      displayName: 'folder',
-      badgeColor: '#000',
-      addedAt: 0,
-      kind: 'folder'
-    })
+    store.getRepos.mockReturnValue([
+      {
+        id: 'repo-1',
+        path: '/workspace/folder',
+        displayName: 'folder',
+        badgeColor: '#000',
+        addedAt: 0,
+        kind: 'folder'
+      }
+    ])
 
     const result = await handlers['hooks:prepareSetupRunner'](null, {
       repoId: 'repo-1',
@@ -6825,6 +6827,61 @@ describe('registerWorktreeHandlers', () => {
       status: 'ok',
       setup: null,
       reason: 'folder-repo'
+    })
+  })
+
+  it('rejects setup runner preparation for SSH repos', async () => {
+    store.getRepos.mockReturnValue([
+      {
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: 'ssh-target'
+      }
+    ])
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/improve-dashboard'
+    })
+
+    expect(getEffectiveHooksMock).not.toHaveBeenCalled()
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      status: 'error',
+      setup: null,
+      reason: 'runner-failed',
+      message: expect.stringContaining('not yet supported for remote worktrees')
+    })
+  })
+
+  it('rejects setup runner preparation for runtime-host repos without a connectionId', async () => {
+    store.getRepos.mockReturnValue([
+      {
+        id: 'repo-1',
+        path: '/workspace/repo',
+        displayName: 'repo',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: null,
+        executionHostId: 'runtime:env-1'
+      }
+    ])
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/improve-dashboard'
+    })
+
+    expect(getEffectiveHooksMock).not.toHaveBeenCalled()
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      status: 'error',
+      setup: null,
+      reason: 'runner-failed',
+      message: expect.stringContaining('not yet supported for remote worktrees')
     })
   })
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -6758,6 +6758,76 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('prepares a setup runner for an existing worktree when setup is configured', async () => {
+    getEffectiveHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/improve-dashboard'
+    })
+
+    expect(getEffectiveHooksMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'repo-1' }),
+      '/workspace/improve-dashboard'
+    )
+    expect(createSetupRunnerScriptMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'repo-1' }),
+      '/workspace/improve-dashboard',
+      'pnpm install',
+      {}
+    )
+    expect(result).toEqual({
+      status: 'ok',
+      setup: {
+        runnerScriptPath: '/workspace/repo/.git/orca/setup-runner.sh',
+        envVars: {
+          ORCA_ROOT_PATH: '/workspace/repo',
+          ORCA_WORKTREE_PATH: '/workspace/improve-dashboard'
+        }
+      }
+    })
+  })
+
+  it('returns no-setup-configured without creating a runner when setup is missing', async () => {
+    getEffectiveHooksMock.mockReturnValue(null)
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/improve-dashboard'
+    })
+
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      status: 'ok',
+      setup: null,
+      reason: 'no-setup-configured'
+    })
+  })
+
+  it('returns folder-repo without creating a setup runner for folder workspaces', async () => {
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      kind: 'folder'
+    })
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/folder'
+    })
+
+    expect(getEffectiveHooksMock).not.toHaveBeenCalled()
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      status: 'ok',
+      setup: null,
+      reason: 'folder-repo'
+    })
+  })
+
   it('lists a synthetic worktree for folder-mode repos', async () => {
     const rootWorktreeId = 'repo-1::/workspace/folder'
     const priorWorktreeIds = ['repo-1::/workspace/old-folder']

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -42,6 +42,7 @@ const {
   getPullRequestPushTargetMock,
   getEffectiveHooksMock,
   getSetupCommandSourceMock,
+  getDefaultTabCommandTrustContentMock,
   createIssueCommandRunnerScriptMock,
   createSetupRunnerScriptMock,
   getEffectiveHooksFromConfigMock,
@@ -94,6 +95,7 @@ const {
   getPullRequestPushTargetMock: vi.fn(),
   getEffectiveHooksMock: vi.fn(),
   getSetupCommandSourceMock: vi.fn(),
+  getDefaultTabCommandTrustContentMock: vi.fn(),
   createIssueCommandRunnerScriptMock: vi.fn(),
   createSetupRunnerScriptMock: vi.fn(),
   getEffectiveHooksFromConfigMock: vi.fn(),
@@ -199,6 +201,7 @@ vi.mock('../hooks', () => ({
   createSetupRunnerScript: createSetupRunnerScriptMock,
   getEffectiveHooks: getEffectiveHooksMock,
   getSetupCommandSource: getSetupCommandSourceMock,
+  getDefaultTabCommandTrustContent: getDefaultTabCommandTrustContentMock,
   getEffectiveHooksFromConfig: getEffectiveHooksFromConfigMock,
   getDefaultTabsLaunch: getDefaultTabsLaunchMock,
   getSetupRunnerEnvVars: getSetupRunnerEnvVarsMock,
@@ -368,6 +371,7 @@ describe('registerWorktreeHandlers', () => {
       getPullRequestPushTargetMock,
       getEffectiveHooksMock,
       getSetupCommandSourceMock,
+      getDefaultTabCommandTrustContentMock,
       getEffectiveHooksFromConfigMock,
       getDefaultTabsLaunchMock,
       parseOrcaYamlMock,
@@ -6794,6 +6798,23 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('returns the canonical trust content for the worktree yaml', async () => {
+    getSetupCommandSourceMock.mockReturnValue({ source: 'yaml', command: 'pnpm install' })
+    getDefaultTabCommandTrustContentMock.mockReturnValue(
+      'pnpm install\n\n# defaultTabs[1]\nnpm run dev'
+    )
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/improve-dashboard'
+    })
+
+    expect(result).toMatchObject({
+      status: 'ok',
+      trustContent: 'pnpm install\n\n# defaultTabs[1]\nnpm run dev'
+    })
+  })
+
   it('resolves the host-matching repo row when duplicate repo ids exist across hosts', async () => {
     const localRepo = {
       id: 'repo-1',
@@ -6841,7 +6862,7 @@ describe('registerWorktreeHandlers', () => {
     expect(result).toMatchObject({
       status: 'error',
       reason: 'runner-failed',
-      message: expect.stringContaining('multiple hosts')
+      message: expect.stringContaining('Multiple project entries share this id')
     })
   })
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -41,6 +41,7 @@ const {
   getWorkItemMock,
   getPullRequestPushTargetMock,
   getEffectiveHooksMock,
+  getSetupCommandSourceMock,
   createIssueCommandRunnerScriptMock,
   createSetupRunnerScriptMock,
   getEffectiveHooksFromConfigMock,
@@ -92,6 +93,7 @@ const {
   getWorkItemMock: vi.fn(),
   getPullRequestPushTargetMock: vi.fn(),
   getEffectiveHooksMock: vi.fn(),
+  getSetupCommandSourceMock: vi.fn(),
   createIssueCommandRunnerScriptMock: vi.fn(),
   createSetupRunnerScriptMock: vi.fn(),
   getEffectiveHooksFromConfigMock: vi.fn(),
@@ -196,6 +198,7 @@ vi.mock('../hooks', () => ({
   createIssueCommandRunnerScript: createIssueCommandRunnerScriptMock,
   createSetupRunnerScript: createSetupRunnerScriptMock,
   getEffectiveHooks: getEffectiveHooksMock,
+  getSetupCommandSource: getSetupCommandSourceMock,
   getEffectiveHooksFromConfig: getEffectiveHooksFromConfigMock,
   getDefaultTabsLaunch: getDefaultTabsLaunchMock,
   getSetupRunnerEnvVars: getSetupRunnerEnvVarsMock,
@@ -364,6 +367,7 @@ describe('registerWorktreeHandlers', () => {
       getWorkItemMock,
       getPullRequestPushTargetMock,
       getEffectiveHooksMock,
+      getSetupCommandSourceMock,
       getEffectiveHooksFromConfigMock,
       getDefaultTabsLaunchMock,
       parseOrcaYamlMock,
@@ -6759,14 +6763,14 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('prepares a setup runner for an existing worktree when setup is configured', async () => {
-    getEffectiveHooksMock.mockReturnValue({ scripts: { setup: 'pnpm install' } })
+    getSetupCommandSourceMock.mockReturnValue({ source: 'yaml', command: 'pnpm install' })
 
     const result = await handlers['hooks:prepareSetupRunner'](null, {
       repoId: 'repo-1',
       worktreePath: '/workspace/improve-dashboard'
     })
 
-    expect(getEffectiveHooksMock).toHaveBeenCalledWith(
+    expect(getSetupCommandSourceMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'repo-1' }),
       '/workspace/improve-dashboard'
     )
@@ -6784,12 +6788,65 @@ describe('registerWorktreeHandlers', () => {
           ORCA_ROOT_PATH: '/workspace/repo',
           ORCA_WORKTREE_PATH: '/workspace/improve-dashboard'
         }
-      }
+      },
+      setupScript: 'pnpm install',
+      setupScriptSource: 'yaml'
+    })
+  })
+
+  it('resolves the host-matching repo row when duplicate repo ids exist across hosts', async () => {
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const sshRepo = { ...localRepo, path: '/remote/repo', connectionId: 'ssh-target' }
+    store.getRepos.mockReturnValue([sshRepo, localRepo])
+    getSetupCommandSourceMock.mockReturnValue({ source: 'yaml', command: 'pnpm install' })
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/improve-dashboard',
+      hostId: 'local'
+    })
+
+    expect(getSetupCommandSourceMock).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/workspace/repo' }),
+      '/workspace/improve-dashboard'
+    )
+    expect(result).toMatchObject({ status: 'ok' })
+  })
+
+  it('returns a structured error for ambiguous duplicate repo ids without a hostId', async () => {
+    const localRepo = {
+      id: 'repo-1',
+      path: '/workspace/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    store.getRepos.mockReturnValue([
+      { ...localRepo, connectionId: 'ssh-target' },
+      { ...localRepo, path: '/other/repo' }
+    ])
+
+    const result = await handlers['hooks:prepareSetupRunner'](null, {
+      repoId: 'repo-1',
+      worktreePath: '/workspace/improve-dashboard'
+    })
+
+    expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      status: 'error',
+      reason: 'runner-failed',
+      message: expect.stringContaining('multiple hosts')
     })
   })
 
   it('returns no-setup-configured without creating a runner when setup is missing', async () => {
-    getEffectiveHooksMock.mockReturnValue(null)
+    getSetupCommandSourceMock.mockReturnValue(null)
 
     const result = await handlers['hooks:prepareSetupRunner'](null, {
       repoId: 'repo-1',
@@ -6821,7 +6878,7 @@ describe('registerWorktreeHandlers', () => {
       worktreePath: '/workspace/folder'
     })
 
-    expect(getEffectiveHooksMock).not.toHaveBeenCalled()
+    expect(getSetupCommandSourceMock).not.toHaveBeenCalled()
     expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
     expect(result).toEqual({
       status: 'ok',
@@ -6847,12 +6904,12 @@ describe('registerWorktreeHandlers', () => {
       worktreePath: '/workspace/improve-dashboard'
     })
 
-    expect(getEffectiveHooksMock).not.toHaveBeenCalled()
+    expect(getSetupCommandSourceMock).not.toHaveBeenCalled()
     expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       status: 'error',
       setup: null,
-      reason: 'runner-failed',
+      reason: 'remote-host',
       message: expect.stringContaining('not yet supported for remote worktrees')
     })
   })
@@ -6875,12 +6932,12 @@ describe('registerWorktreeHandlers', () => {
       worktreePath: '/workspace/improve-dashboard'
     })
 
-    expect(getEffectiveHooksMock).not.toHaveBeenCalled()
+    expect(getSetupCommandSourceMock).not.toHaveBeenCalled()
     expect(createSetupRunnerScriptMock).not.toHaveBeenCalled()
     expect(result).toMatchObject({
       status: 'error',
       setup: null,
-      reason: 'runner-failed',
+      reason: 'remote-host',
       message: expect.stringContaining('not yet supported for remote worktrees')
     })
   })

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -6766,8 +6766,13 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
-  it('prepares a setup runner for an existing worktree when setup is configured', async () => {
+  it('prepares a setup runner with the selected Windows shell for an existing worktree', async () => {
     getSetupCommandSourceMock.mockReturnValue({ source: 'yaml', command: 'pnpm install' })
+    const setupShell = {
+      family: 'posix' as const,
+      executable: 'C:\\Program Files\\Git\\bin\\bash.exe'
+    }
+    resolveSetupRunnerShellMock.mockReturnValue(setupShell)
 
     const result = await handlers['hooks:prepareSetupRunner'](null, {
       repoId: 'repo-1',
@@ -6778,11 +6783,13 @@ describe('registerWorktreeHandlers', () => {
       expect.objectContaining({ id: 'repo-1' }),
       '/workspace/improve-dashboard'
     )
+    expect(resolveSetupRunnerShellMock).toHaveBeenCalledWith(store.getSettings())
     expect(createSetupRunnerScriptMock).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'repo-1' }),
       '/workspace/improve-dashboard',
       'pnpm install',
-      {}
+      {},
+      setupShell
     )
     expect(result).toEqual({
       status: 'ok',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -3240,7 +3240,8 @@ export function registerWorktreeHandlers(
           repo,
           args.worktreePath,
           setupScript,
-          getLocalProjectWorktreeGitOptions(store, repo)
+          getLocalProjectWorktreeGitOptions(store, repo),
+          resolveSetupRunnerShell(store.getSettings())
         )
         // Why: trust hashes must match the create path's canonical shape (setup +
         // defaultTabs commands) or the one per-repo slot ping-pongs between flows.

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -3189,6 +3189,17 @@ export function registerWorktreeHandlers(
       if (isFolderRepo(repo)) {
         return { status: 'ok', setup: null, reason: 'folder-repo' }
       }
+      // Why: getEffectiveHooks/createSetupRunnerScript are local-FS only today;
+      // SSH worktrees need the remote setup path (CodeRabbit / #10077).
+      if (repo.connectionId) {
+        return {
+          status: 'error',
+          setup: null,
+          reason: 'runner-failed',
+          message:
+            'Run setup script is not yet supported for remote/SSH worktrees. Create a new worktree to run setup on that host, or open a local clone.'
+        }
+      }
 
       let setupScript: string | undefined
       try {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -86,6 +86,7 @@ import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   createIssueCommandRunnerScript,
   createSetupRunnerScript,
+  getDefaultTabCommandTrustContent,
   getEffectiveHooks,
   getEffectiveHooksFromConfig,
   getSetupCommandSource,
@@ -3182,6 +3183,7 @@ export function registerWorktreeHandlers(
       setup: ReturnType<typeof createSetupRunnerScript> | null
       setupScript?: string
       setupScriptSource?: 'yaml' | 'local' | 'both'
+      trustContent?: string
       reason?: 'no-setup-configured' | 'folder-repo' | 'remote-host' | 'runner-failed'
       message?: string
     } => {
@@ -3194,7 +3196,7 @@ export function registerWorktreeHandlers(
             setup: null,
             reason: 'runner-failed',
             message:
-              'This project exists on multiple hosts; retry from the workspace list of the host that owns it.'
+              'Multiple project entries share this id; remove the duplicate project, or retry from the host that owns this workspace.'
           }
         }
         throw new Error(`Repo not found: ${args.repoId}`)
@@ -3240,7 +3242,16 @@ export function registerWorktreeHandlers(
           setupScript,
           getLocalProjectWorktreeGitOptions(store, repo)
         )
-        return { status: 'ok', setup, setupScript, setupScriptSource: commandSource?.source }
+        // Why: trust hashes must match the create path's canonical shape (setup +
+        // defaultTabs commands) or the one per-repo slot ping-pongs between flows.
+        const trustContent = getDefaultTabCommandTrustContent(loadHooks(args.worktreePath))
+        return {
+          status: 'ok',
+          setup,
+          setupScript,
+          setupScriptSource: commandSource?.source,
+          ...(trustContent ? { trustContent } : {})
+        }
       } catch (error) {
         return {
           status: 'error',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -88,6 +88,7 @@ import {
   createSetupRunnerScript,
   getEffectiveHooks,
   getEffectiveHooksFromConfig,
+  getSetupCommandSource,
   getSetupRunnerEnvVars,
   loadHooks,
   parseOrcaYaml,
@@ -3179,11 +3180,23 @@ export function registerWorktreeHandlers(
     ): {
       status: 'ok' | 'error'
       setup: ReturnType<typeof createSetupRunnerScript> | null
-      reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
+      setupScript?: string
+      setupScriptSource?: 'yaml' | 'local' | 'both'
+      reason?: 'no-setup-configured' | 'folder-repo' | 'remote-host' | 'runner-failed'
       message?: string
     } => {
       const repo = getRepoForWorktreeRemoval(store, args.repoId, args.hostId)
       if (!repo) {
+        const matches = store.getRepos().filter((entry) => entry.id === args.repoId)
+        if (matches.length > 1) {
+          return {
+            status: 'error',
+            setup: null,
+            reason: 'runner-failed',
+            message:
+              'This project exists on multiple hosts; retry from the workspace list of the host that owns it.'
+          }
+        }
         throw new Error(`Repo not found: ${args.repoId}`)
       }
       if (isFolderRepo(repo)) {
@@ -3195,17 +3208,17 @@ export function registerWorktreeHandlers(
         return {
           status: 'error',
           setup: null,
-          reason: 'runner-failed',
+          reason: 'remote-host',
           message:
             'Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.'
         }
       }
 
-      let setupScript: string | undefined
+      let commandSource: ReturnType<typeof getSetupCommandSource>
       try {
-        // Prefer the worktree's orca.yaml so branch-specific setup matches create.
-        const hooks = getEffectiveHooks(repo, args.worktreePath)
-        setupScript = hooks?.scripts.setup?.trim()
+        // Prefer the worktree's orca.yaml so branch-specific setup matches create; the
+        // source lets the renderer confirm trust against the exact script that will run.
+        commandSource = getSetupCommandSource(repo, args.worktreePath)
       } catch (error) {
         return {
           status: 'error',
@@ -3215,6 +3228,7 @@ export function registerWorktreeHandlers(
         }
       }
 
+      const setupScript = commandSource?.command.trim()
       if (!setupScript) {
         return { status: 'ok', setup: null, reason: 'no-setup-configured' }
       }
@@ -3226,7 +3240,7 @@ export function registerWorktreeHandlers(
           setupScript,
           getLocalProjectWorktreeGitOptions(store, repo)
         )
-        return { status: 'ok', setup }
+        return { status: 'ok', setup, setupScript, setupScriptSource: commandSource?.source }
       } catch (error) {
         return {
           status: 'error',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -85,6 +85,7 @@ import { getSshGitProvider, requireSshGitProvider } from '../providers/ssh-git-d
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   createIssueCommandRunnerScript,
+  createSetupRunnerScript,
   getEffectiveHooks,
   getEffectiveHooksFromConfig,
   getSetupRunnerEnvVars,
@@ -1843,6 +1844,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('hooks:check')
   ipcMain.removeHandler('hooks:inspectSetupScriptImports')
   ipcMain.removeHandler('hooks:createIssueCommandRunner')
+  ipcMain.removeHandler('hooks:prepareSetupRunner')
   ipcMain.removeHandler('hooks:readIssueCommand')
   ipcMain.removeHandler('hooks:writeIssueCommand')
 
@@ -3164,6 +3166,64 @@ export function registerWorktreeHandlers(
         getLocalProjectWorktreeGitOptions(store, repo),
         resolveSetupRunnerShell(store.getSettings())
       )
+    }
+  )
+
+  // Why: worktree create already materializes a setup runner; existing worktrees need
+  // the same launcher for manual re-run (#10015) without re-creating the worktree.
+  ipcMain.handle(
+    'hooks:prepareSetupRunner',
+    (
+      _event,
+      args: { repoId: string; worktreePath: string }
+    ): {
+      status: 'ok' | 'error'
+      setup: ReturnType<typeof createSetupRunnerScript> | null
+      reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
+      message?: string
+    } => {
+      const repo = store.getRepo(args.repoId)
+      if (!repo) {
+        throw new Error(`Repo not found: ${args.repoId}`)
+      }
+      if (isFolderRepo(repo)) {
+        return { status: 'ok', setup: null, reason: 'folder-repo' }
+      }
+
+      let setupScript: string | undefined
+      try {
+        // Prefer the worktree's orca.yaml so branch-specific setup matches create.
+        const hooks = getEffectiveHooks(repo, args.worktreePath)
+        setupScript = hooks?.scripts.setup?.trim()
+      } catch (error) {
+        return {
+          status: 'error',
+          setup: null,
+          reason: 'runner-failed',
+          message: error instanceof Error ? error.message : String(error)
+        }
+      }
+
+      if (!setupScript) {
+        return { status: 'ok', setup: null, reason: 'no-setup-configured' }
+      }
+
+      try {
+        const setup = createSetupRunnerScript(
+          repo,
+          args.worktreePath,
+          setupScript,
+          getLocalProjectWorktreeGitOptions(store, repo)
+        )
+        return { status: 'ok', setup }
+      } catch (error) {
+        return {
+          status: 'error',
+          setup: null,
+          reason: 'runner-failed',
+          message: error instanceof Error ? error.message : String(error)
+        }
+      }
     }
   )
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -3175,29 +3175,29 @@ export function registerWorktreeHandlers(
     'hooks:prepareSetupRunner',
     (
       _event,
-      args: { repoId: string; worktreePath: string }
+      args: { repoId: string; worktreePath: string; hostId?: ExecutionHostId }
     ): {
       status: 'ok' | 'error'
       setup: ReturnType<typeof createSetupRunnerScript> | null
       reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
       message?: string
     } => {
-      const repo = store.getRepo(args.repoId)
+      const repo = getRepoForWorktreeRemoval(store, args.repoId, args.hostId)
       if (!repo) {
         throw new Error(`Repo not found: ${args.repoId}`)
       }
       if (isFolderRepo(repo)) {
         return { status: 'ok', setup: null, reason: 'folder-repo' }
       }
-      // Why: getEffectiveHooks/createSetupRunnerScript are local-FS only today;
-      // SSH worktrees need the remote setup path (CodeRabbit / #10077).
-      if (repo.connectionId) {
+      // Why: getEffectiveHooks/createSetupRunnerScript are local-FS only today; runtime-host
+      // repos have no connectionId, so gate on the execution host, not the SSH target.
+      if (getRepoExecutionHostId(repo) !== LOCAL_EXECUTION_HOST_ID) {
         return {
           status: 'error',
           setup: null,
           reason: 'runner-failed',
           message:
-            'Run setup script is not yet supported for remote/SSH worktrees. Create a new worktree to run setup on that host, or open a local clone.'
+            'Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.'
         }
       }
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2596,6 +2596,7 @@ export type PreloadApi = {
       setup: WorktreeSetupLaunch | null
       setupScript?: string
       setupScriptSource?: 'yaml' | 'local' | 'both'
+      trustContent?: string
       reason?: 'no-setup-configured' | 'folder-repo' | 'remote-host' | 'runner-failed'
       message?: string
     }>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2587,6 +2587,15 @@ export type PreloadApi = {
       worktreePath: string
       command: string
     }) => Promise<WorktreeSetupLaunch>
+    prepareSetupRunner: (args: {
+      repoId: string
+      worktreePath: string
+    }) => Promise<{
+      status: 'ok' | 'error'
+      setup: WorktreeSetupLaunch | null
+      reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
+      message?: string
+    }>
     readIssueCommand: (args: { repoId: string; hostId?: ExecutionHostId }) => Promise<{
       status?: 'ok' | 'error'
       localContent: string | null

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2594,7 +2594,9 @@ export type PreloadApi = {
     }) => Promise<{
       status: 'ok' | 'error'
       setup: WorktreeSetupLaunch | null
-      reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
+      setupScript?: string
+      setupScriptSource?: 'yaml' | 'local' | 'both'
+      reason?: 'no-setup-configured' | 'folder-repo' | 'remote-host' | 'runner-failed'
       message?: string
     }>
     readIssueCommand: (args: { repoId: string; hostId?: ExecutionHostId }) => Promise<{

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2590,6 +2590,7 @@ export type PreloadApi = {
     prepareSetupRunner: (args: {
       repoId: string
       worktreePath: string
+      hostId?: ExecutionHostId
     }) => Promise<{
       status: 'ok' | 'error'
       setup: WorktreeSetupLaunch | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2896,6 +2896,16 @@ const api = {
       command: string
     }): Promise<WorktreeSetupLaunch> => ipcRenderer.invoke('hooks:createIssueCommandRunner', args),
 
+    prepareSetupRunner: (args: {
+      repoId: string
+      worktreePath: string
+    }): Promise<{
+      status: 'ok' | 'error'
+      setup: { runnerScriptPath: string; envVars: Record<string, string>; command?: string } | null
+      reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
+      message?: string
+    }> => ipcRenderer.invoke('hooks:prepareSetupRunner', args),
+
     readIssueCommand: (args: {
       repoId: string
       hostId?: ExecutionHostId

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2903,7 +2903,9 @@ const api = {
     }): Promise<{
       status: 'ok' | 'error'
       setup: { runnerScriptPath: string; envVars: Record<string, string> } | null
-      reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
+      setupScript?: string
+      setupScriptSource?: 'yaml' | 'local' | 'both'
+      reason?: 'no-setup-configured' | 'folder-repo' | 'remote-host' | 'runner-failed'
       message?: string
     }> => ipcRenderer.invoke('hooks:prepareSetupRunner', args),
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2902,7 +2902,7 @@ const api = {
       hostId?: ExecutionHostId
     }): Promise<{
       status: 'ok' | 'error'
-      setup: { runnerScriptPath: string; envVars: Record<string, string> } | null
+      setup: WorktreeSetupLaunch | null
       setupScript?: string
       setupScriptSource?: 'yaml' | 'local' | 'both'
       trustContent?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2899,6 +2899,7 @@ const api = {
     prepareSetupRunner: (args: {
       repoId: string
       worktreePath: string
+      hostId?: ExecutionHostId
     }): Promise<{
       status: 'ok' | 'error'
       setup: { runnerScriptPath: string; envVars: Record<string, string>; command?: string } | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2902,7 +2902,7 @@ const api = {
       hostId?: ExecutionHostId
     }): Promise<{
       status: 'ok' | 'error'
-      setup: { runnerScriptPath: string; envVars: Record<string, string>; command?: string } | null
+      setup: { runnerScriptPath: string; envVars: Record<string, string> } | null
       reason?: 'no-setup-configured' | 'folder-repo' | 'runner-failed'
       message?: string
     }> => ipcRenderer.invoke('hooks:prepareSetupRunner', args),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2905,6 +2905,7 @@ const api = {
       setup: { runnerScriptPath: string; envVars: Record<string, string> } | null
       setupScript?: string
       setupScriptSource?: 'yaml' | 'local' | 'both'
+      trustContent?: string
       reason?: 'no-setup-configured' | 'folder-repo' | 'remote-host' | 'runner-failed'
       message?: string
     }> => ipcRenderer.invoke('hooks:prepareSetupRunner', args),

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -22,6 +22,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  Play,
   Kanban,
   Trash2,
   Unlink,
@@ -43,6 +44,8 @@ import type {
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { runWorktreeSetupScript } from '@/lib/run-worktree-setup-script'
+import { isFolderRepo } from '../../../../shared/repo-kind'
 import { VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT } from '@/hooks/useVirtualizedScrollAnchor'
 import {
   getCyclicProjectedWorktreeLineageIds,
@@ -636,6 +639,18 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     sleepWorktreesAfterMenuClose(subtreeSleepableWorktrees.map((item) => item.id))
   }, [sleepWorktreesAfterMenuClose, subtreeSleepableWorktrees])
 
+  const handleRunSetupScript = useCallback(() => {
+    setMenuOpenState(false)
+    // Why: close the menu before trust prompts / activation so focus teardown
+    // does not fight the setup terminal launch.
+    window.setTimeout(() => {
+      void runWorktreeSetupScript(worktree.id)
+    }, 50)
+  }, [setMenuOpenState, worktree.id])
+
+  const canRunSetupScript =
+    !isMultiContext && !folderWorkspaceId && repo != null && !isFolderRepo(repo)
+
   const handleDelete = useCallback(() => {
     // Folder mode handled inline because it routes to a different modal;
     // standard delete delegates to the shared runWorktreeDelete helper.
@@ -987,6 +1002,16 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
               </DropdownMenuItem>
               <DropdownMenuSeparator />
             </>
+          ) : null}
+
+          {canRunSetupScript ? (
+            <DropdownMenuItem onSelect={handleRunSetupScript} disabled={isDeleting}>
+              <Play className="size-3.5" />
+              {translate(
+                'auto.components.sidebar.WorktreeContextMenu.runSetupScript',
+                'Run setup script'
+              )}
+            </DropdownMenuItem>
           ) : null}
 
           {shouldRevealWorktreeDeveloperMenu({ developerMenuRevealed, isMultiContext }) ? (

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -709,6 +709,16 @@
             "additionalErrors": "{{count}} additional images could not be attached."
           }
         }
+      },
+      "runWorktreeSetupScript": {
+        "worktreeMissing": "Workspace is no longer available.",
+        "repoMissing": "Project is no longer available.",
+        "folderRepo": "Folder workspaces do not use setup scripts.",
+        "remoteHost": "Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.",
+        "prepareFailed": "Could not prepare the setup script.",
+        "runnerFailed": "Could not prepare the setup script.",
+        "noSetup": "No setup script is configured for this project.",
+        "activationFailed": "Could not open the workspace to run setup."
       }
     },
     "hooks": {
@@ -4617,7 +4627,8 @@
           "deleteWorktree": "Delete Worktree",
           "sleepWithDescendants": "Sleep with Descendants ({{value0}})",
           "sleepWithDescendantsDescription": "Close active panels in this workspace and every nested descendant to free up memory and CPU.",
-          "deleteWithDescendants": "Delete with Descendants…"
+          "deleteWithDescendants": "Delete with Descendants…",
+          "runSetupScript": "Run setup script"
         },
         "WorktreeList": {
           "7a8b9c0d1e": "Update required",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -715,8 +715,8 @@
         "repoMissing": "Project is no longer available.",
         "folderRepo": "Folder workspaces do not use setup scripts.",
         "remoteHost": "Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.",
-        "prepareFailed": "Could not prepare the setup script.",
-        "runnerFailed": "Could not prepare the setup script.",
+        "prepareFailed": "Could not reach the setup service.",
+        "runnerFailed": "Could not prepare the setup runner.",
         "noSetup": "No setup script is configured for this project.",
         "activationFailed": "Could not open the workspace to run setup."
       }

--- a/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
@@ -463,6 +463,35 @@ describe('ensureHooksConfirmed', () => {
     expect(pending).toHaveLength(0)
   })
 
+  it('confirms the scriptContentOverride without inspecting the repo', async () => {
+    const { state, pending } = createTestState()
+
+    const decision = ensureHooksConfirmed(state, 'repo-1', 'setup', undefined, undefined, {
+      scriptContentOverride: 'echo "worktree-resolved setup"'
+    })
+    await vi.waitFor(() => expect(pending).toHaveLength(1))
+
+    expect(hooksCheckMock).not.toHaveBeenCalled()
+    expect(pending[0].data.scriptContent).toBe('echo "worktree-resolved setup"')
+    pending[0].resolve('run')
+    await expect(decision).resolves.toBe('run')
+  })
+
+  it('skips the prompt when the override matches the approved content hash', async () => {
+    const contentHash = await hashOrcaHookScript('echo "worktree-resolved setup"')
+    const { state, pending } = createTestState({
+      trustedOrcaHooks: { 'repo-1': { setup: { contentHash } } }
+    } as never)
+
+    const decision = await ensureHooksConfirmed(state, 'repo-1', 'setup', undefined, undefined, {
+      scriptContentOverride: 'echo "worktree-resolved setup"'
+    })
+
+    expect(decision).toBe('run')
+    expect(pending).toHaveLength(0)
+    expect(hooksCheckMock).not.toHaveBeenCalled()
+  })
+
   it('fails closed when hook inspection reports an error status', async () => {
     const { state, pending } = createTestState()
     hooksCheckMock.mockResolvedValue({

--- a/src/renderer/src/lib/ensure-hooks-confirmed.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.ts
@@ -93,7 +93,12 @@ export async function ensureHooksConfirmed(
   repoId: string,
   scriptKind: HookScriptKind,
   hostId?: ExecutionHostId,
-  runtimeOwnerEnvironmentId?: string | null
+  runtimeOwnerEnvironmentId?: string | null,
+  options?: {
+    /** Confirm this exact script instead of re-inspecting the repo root — for callers
+     *  that already resolved what will run (e.g. a worktree-scoped setup script). */
+    scriptContentOverride?: string
+  }
 ): Promise<'run' | 'skip'> {
   return enqueueTrustPrompt(async () => {
     const hasDuplicateRepoId = state.repos.filter((repo) => repo.id === repoId).length > 1
@@ -103,7 +108,9 @@ export async function ensureHooksConfirmed(
 
     let scriptContent = ''
     try {
-      if (scriptKind === 'issueCommand') {
+      if (options?.scriptContentOverride !== undefined) {
+        scriptContent = options.scriptContentOverride.trim()
+      } else if (scriptKind === 'issueCommand') {
         // Local overrides are user-owned; only shared orca.yaml commands need repo trust.
         // Why: hostId disambiguates duplicate repo ids on the local IPC path,
         // matching the checkRuntimeHooks call below.

--- a/src/renderer/src/lib/run-worktree-setup-script.test.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  toastInfo,
+  toastError,
+  ensureHooksConfirmed,
+  activateAndRevealWorktree,
+  getState,
+  prepareSetupRunner
+} = vi.hoisted(() => ({
+  toastInfo: vi.fn(),
+  toastError: vi.fn(),
+  ensureHooksConfirmed: vi.fn(),
+  activateAndRevealWorktree: vi.fn(),
+  getState: vi.fn(),
+  prepareSetupRunner: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { info: toastInfo, error: toastError })
+}))
+
+vi.mock('@/lib/ensure-hooks-confirmed', () => ({
+  ensureHooksConfirmed
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState }
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+import { runWorktreeSetupScript } from './run-worktree-setup-script'
+
+const setupLaunch = {
+  runnerScriptPath: '/repo/.git/orca/setup-runner.sh',
+  envVars: { ORCA_ROOT_PATH: '/repo', ORCA_WORKTREE_PATH: '/repo-feature' }
+}
+
+function mockStore(overrides?: {
+  worktree?: { id: string; repoId: string; path: string } | null
+  repo?: { id: string; kind?: 'git' | 'folder'; connectionId?: string | null } | null
+}): void {
+  const worktree =
+    overrides && 'worktree' in overrides
+      ? overrides.worktree
+      : { id: 'wt-1', repoId: 'repo-1', path: '/repo-feature' }
+  const repo =
+    overrides && 'repo' in overrides
+      ? overrides.repo
+      : { id: 'repo-1', kind: 'git' as const, connectionId: null }
+
+  getState.mockReturnValue({
+    getKnownWorktreeById: (id: string) => (worktree && worktree.id === id ? worktree : undefined),
+    repos: repo ? [repo] : []
+  })
+}
+
+describe('runWorktreeSetupScript', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockStore()
+    ensureHooksConfirmed.mockResolvedValue('run')
+    prepareSetupRunner.mockResolvedValue({ status: 'ok', setup: setupLaunch })
+    activateAndRevealWorktree.mockReturnValue({ primaryTabId: 'tab-1' })
+    // @ts-expect-error test stub
+    globalThis.window = {
+      api: {
+        hooks: {
+          prepareSetupRunner
+        }
+      }
+    }
+  })
+
+  it('skips when the worktree is missing', async () => {
+    mockStore({ worktree: null })
+
+    const result = await runWorktreeSetupScript('wt-missing')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'worktree-missing' })
+    expect(toastError).toHaveBeenCalled()
+    expect(prepareSetupRunner).not.toHaveBeenCalled()
+  })
+
+  it('skips folder repos without preparing a runner', async () => {
+    mockStore({ repo: { id: 'repo-1', kind: 'folder' } })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'folder-repo' })
+    expect(toastInfo).toHaveBeenCalledWith('Folder workspaces do not use setup scripts.')
+    expect(prepareSetupRunner).not.toHaveBeenCalled()
+  })
+
+  it('stops when setup trust is declined', async () => {
+    ensureHooksConfirmed.mockResolvedValue('skip')
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'trust-skipped' })
+    expect(prepareSetupRunner).not.toHaveBeenCalled()
+  })
+
+  it('toasts when no setup script is configured', async () => {
+    prepareSetupRunner.mockResolvedValue({
+      status: 'ok',
+      setup: null,
+      reason: 'no-setup-configured'
+    })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'no-setup-configured' })
+    expect(toastInfo).toHaveBeenCalledWith(
+      'No setup script is configured for this project.'
+    )
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+
+  it('surfaces runner preparation failures without activating', async () => {
+    prepareSetupRunner.mockResolvedValue({
+      status: 'error',
+      setup: null,
+      reason: 'runner-failed',
+      message: 'permission denied'
+    })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'error', message: 'permission denied' })
+    expect(toastError).toHaveBeenCalled()
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+
+  it('prepares the runner and launches via activateAndRevealWorktree', async () => {
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(prepareSetupRunner).toHaveBeenCalledWith({
+      repoId: 'repo-1',
+      worktreePath: '/repo-feature'
+    })
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', { setup: setupLaunch })
+    expect(result).toEqual({ status: 'launched', primaryTabId: 'tab-1' })
+  })
+})

--- a/src/renderer/src/lib/run-worktree-setup-script.test.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.test.ts
@@ -213,6 +213,27 @@ describe('runWorktreeSetupScript', () => {
     expect(result).toEqual({ status: 'launched', primaryTabId: 'tab-1' })
   })
 
+  it('prefers the canonical trustContent over the raw script for the trust gate', async () => {
+    prepareSetupRunner.mockResolvedValue({
+      status: 'ok',
+      setup: setupLaunch,
+      setupScript: 'pnpm install',
+      setupScriptSource: 'yaml',
+      trustContent: 'pnpm install\n\n# defaultTabs[1]\nnpm run dev'
+    })
+
+    await runWorktreeSetupScript('wt-1')
+
+    expect(ensureHooksConfirmed).toHaveBeenCalledWith(
+      expect.anything(),
+      'repo-1',
+      'setup',
+      'local',
+      undefined,
+      { scriptContentOverride: 'pnpm install\n\n# defaultTabs[1]\nnpm run dev' }
+    )
+  })
+
   it('skips the trust prompt for user-owned local Settings scripts', async () => {
     prepareSetupRunner.mockResolvedValue({
       status: 'ok',

--- a/src/renderer/src/lib/run-worktree-setup-script.test.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.test.ts
@@ -45,7 +45,12 @@ const setupLaunch = {
 
 function mockStore(overrides?: {
   worktree?: { id: string; repoId: string; path: string } | null
-  repo?: { id: string; kind?: 'git' | 'folder'; connectionId?: string | null } | null
+  repo?: {
+    id: string
+    kind?: 'git' | 'folder'
+    connectionId?: string | null
+    executionHostId?: string | null
+  } | null
 }): void {
   const worktree =
     overrides && 'worktree' in overrides
@@ -69,14 +74,13 @@ describe('runWorktreeSetupScript', () => {
     ensureHooksConfirmed.mockResolvedValue('run')
     prepareSetupRunner.mockResolvedValue({ status: 'ok', setup: setupLaunch })
     activateAndRevealWorktree.mockReturnValue({ primaryTabId: 'tab-1' })
-    // @ts-expect-error test stub
     globalThis.window = {
       api: {
         hooks: {
           prepareSetupRunner
         }
       }
-    }
+    } as unknown as typeof globalThis.window
   })
 
   it('skips when the worktree is missing', async () => {
@@ -99,6 +103,29 @@ describe('runWorktreeSetupScript', () => {
     expect(prepareSetupRunner).not.toHaveBeenCalled()
   })
 
+  it('rejects SSH repos before the trust gate with a visible toast', async () => {
+    mockStore({ repo: { id: 'repo-1', kind: 'git', connectionId: 'ssh-target' } })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'remote-host' })
+    expect(toastInfo).toHaveBeenCalledWith(expect.stringContaining('not yet supported'))
+    expect(ensureHooksConfirmed).not.toHaveBeenCalled()
+    expect(prepareSetupRunner).not.toHaveBeenCalled()
+  })
+
+  it('rejects runtime-host repos even without a connectionId', async () => {
+    mockStore({
+      repo: { id: 'repo-1', kind: 'git', connectionId: null, executionHostId: 'runtime:env-1' }
+    })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'remote-host' })
+    expect(ensureHooksConfirmed).not.toHaveBeenCalled()
+    expect(prepareSetupRunner).not.toHaveBeenCalled()
+  })
+
   it('stops when setup trust is declined', async () => {
     ensureHooksConfirmed.mockResolvedValue('skip')
 
@@ -118,9 +145,7 @@ describe('runWorktreeSetupScript', () => {
     const result = await runWorktreeSetupScript('wt-1')
 
     expect(result).toEqual({ status: 'skipped', reason: 'no-setup-configured' })
-    expect(toastInfo).toHaveBeenCalledWith(
-      'No setup script is configured for this project.'
-    )
+    expect(toastInfo).toHaveBeenCalledWith('No setup script is configured for this project.')
     expect(activateAndRevealWorktree).not.toHaveBeenCalled()
   })
 
@@ -144,7 +169,8 @@ describe('runWorktreeSetupScript', () => {
 
     expect(prepareSetupRunner).toHaveBeenCalledWith({
       repoId: 'repo-1',
-      worktreePath: '/repo-feature'
+      worktreePath: '/repo-feature',
+      hostId: 'local'
     })
     expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', { setup: setupLaunch })
     expect(result).toEqual({ status: 'launched', primaryTabId: 'tab-1' })

--- a/src/renderer/src/lib/run-worktree-setup-script.test.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.test.ts
@@ -43,27 +43,27 @@ const setupLaunch = {
   envVars: { ORCA_ROOT_PATH: '/repo', ORCA_WORKTREE_PATH: '/repo-feature' }
 }
 
+type MockRepo = {
+  id: string
+  kind?: 'git' | 'folder'
+  connectionId?: string | null
+  executionHostId?: string | null
+}
+
 function mockStore(overrides?: {
-  worktree?: { id: string; repoId: string; path: string } | null
-  repo?: {
-    id: string
-    kind?: 'git' | 'folder'
-    connectionId?: string | null
-    executionHostId?: string | null
-  } | null
+  worktree?: { id: string; repoId: string; path: string; hostId?: string } | null
+  repos?: MockRepo[]
 }): void {
   const worktree =
     overrides && 'worktree' in overrides
       ? overrides.worktree
       : { id: 'wt-1', repoId: 'repo-1', path: '/repo-feature' }
-  const repo =
-    overrides && 'repo' in overrides
-      ? overrides.repo
-      : { id: 'repo-1', kind: 'git' as const, connectionId: null }
+  const repos = overrides?.repos ?? [{ id: 'repo-1', kind: 'git' as const, connectionId: null }]
 
   getState.mockReturnValue({
     getKnownWorktreeById: (id: string) => (worktree && worktree.id === id ? worktree : undefined),
-    repos: repo ? [repo] : []
+    repos,
+    settings: undefined
   })
 }
 
@@ -72,7 +72,12 @@ describe('runWorktreeSetupScript', () => {
     vi.clearAllMocks()
     mockStore()
     ensureHooksConfirmed.mockResolvedValue('run')
-    prepareSetupRunner.mockResolvedValue({ status: 'ok', setup: setupLaunch })
+    prepareSetupRunner.mockResolvedValue({
+      status: 'ok',
+      setup: setupLaunch,
+      setupScript: 'pnpm install',
+      setupScriptSource: 'yaml'
+    })
     activateAndRevealWorktree.mockReturnValue({ primaryTabId: 'tab-1' })
     globalThis.window = {
       api: {
@@ -93,8 +98,37 @@ describe('runWorktreeSetupScript', () => {
     expect(prepareSetupRunner).not.toHaveBeenCalled()
   })
 
+  it('skips when the repo row is gone', async () => {
+    mockStore({ repos: [] })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'repo-missing' })
+    expect(toastError).toHaveBeenCalled()
+    expect(prepareSetupRunner).not.toHaveBeenCalled()
+  })
+
+  it('resolves the repo row by the worktree host when repo ids are duplicated', async () => {
+    mockStore({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/repo-feature', hostId: 'local' },
+      repos: [
+        { id: 'repo-1', kind: 'git', connectionId: 'ssh-target' },
+        { id: 'repo-1', kind: 'git', connectionId: null }
+      ]
+    })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'launched', primaryTabId: 'tab-1' })
+    expect(prepareSetupRunner).toHaveBeenCalledWith({
+      repoId: 'repo-1',
+      worktreePath: '/repo-feature',
+      hostId: 'local'
+    })
+  })
+
   it('skips folder repos without preparing a runner', async () => {
-    mockStore({ repo: { id: 'repo-1', kind: 'folder' } })
+    mockStore({ repos: [{ id: 'repo-1', kind: 'folder' }] })
 
     const result = await runWorktreeSetupScript('wt-1')
 
@@ -104,7 +138,7 @@ describe('runWorktreeSetupScript', () => {
   })
 
   it('rejects SSH repos before the trust gate with a visible toast', async () => {
-    mockStore({ repo: { id: 'repo-1', kind: 'git', connectionId: 'ssh-target' } })
+    mockStore({ repos: [{ id: 'repo-1', kind: 'git', connectionId: 'ssh-target' }] })
 
     const result = await runWorktreeSetupScript('wt-1')
 
@@ -116,7 +150,7 @@ describe('runWorktreeSetupScript', () => {
 
   it('rejects runtime-host repos even without a connectionId', async () => {
     mockStore({
-      repo: { id: 'repo-1', kind: 'git', connectionId: null, executionHostId: 'runtime:env-1' }
+      repos: [{ id: 'repo-1', kind: 'git', connectionId: null, executionHostId: 'runtime:env-1' }]
     })
 
     const result = await runWorktreeSetupScript('wt-1')
@@ -126,13 +160,80 @@ describe('runWorktreeSetupScript', () => {
     expect(prepareSetupRunner).not.toHaveBeenCalled()
   })
 
+  it('rejects worktrees owned by a non-local host even when the repo row is local', async () => {
+    mockStore({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/repo-feature', hostId: 'ssh:box' },
+      repos: [
+        { id: 'repo-1', kind: 'git', connectionId: null },
+        { id: 'repo-1', kind: 'git', connectionId: 'box' }
+      ]
+    })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'remote-host' })
+    expect(prepareSetupRunner).not.toHaveBeenCalled()
+  })
+
+  it('maps an IPC remote-host rejection to an info toast', async () => {
+    prepareSetupRunner.mockResolvedValue({
+      status: 'error',
+      setup: null,
+      reason: 'remote-host',
+      message: 'Run setup script is not yet supported for remote worktrees.'
+    })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'remote-host' })
+    expect(toastInfo).toHaveBeenCalledWith(expect.stringContaining('not yet supported'))
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('confirms trust against the script returned by the runner preparation', async () => {
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(prepareSetupRunner).toHaveBeenCalledWith({
+      repoId: 'repo-1',
+      worktreePath: '/repo-feature',
+      hostId: 'local'
+    })
+    expect(ensureHooksConfirmed).toHaveBeenCalledWith(
+      expect.anything(),
+      'repo-1',
+      'setup',
+      'local',
+      undefined,
+      { scriptContentOverride: 'pnpm install' }
+    )
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', {
+      setup: setupLaunch,
+      executionHostId: 'local'
+    })
+    expect(result).toEqual({ status: 'launched', primaryTabId: 'tab-1' })
+  })
+
+  it('skips the trust prompt for user-owned local Settings scripts', async () => {
+    prepareSetupRunner.mockResolvedValue({
+      status: 'ok',
+      setup: setupLaunch,
+      setupScript: 'pnpm install',
+      setupScriptSource: 'local'
+    })
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(ensureHooksConfirmed).not.toHaveBeenCalled()
+    expect(result).toEqual({ status: 'launched', primaryTabId: 'tab-1' })
+  })
+
   it('stops when setup trust is declined', async () => {
     ensureHooksConfirmed.mockResolvedValue('skip')
 
     const result = await runWorktreeSetupScript('wt-1')
 
     expect(result).toEqual({ status: 'skipped', reason: 'trust-skipped' })
-    expect(prepareSetupRunner).not.toHaveBeenCalled()
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
   })
 
   it('toasts when no setup script is configured', async () => {
@@ -164,15 +265,22 @@ describe('runWorktreeSetupScript', () => {
     expect(activateAndRevealWorktree).not.toHaveBeenCalled()
   })
 
-  it('prepares the runner and launches via activateAndRevealWorktree', async () => {
+  it('surfaces rejected preparation IPC calls as errors', async () => {
+    prepareSetupRunner.mockRejectedValue(new Error('ipc unavailable'))
+
     const result = await runWorktreeSetupScript('wt-1')
 
-    expect(prepareSetupRunner).toHaveBeenCalledWith({
-      repoId: 'repo-1',
-      worktreePath: '/repo-feature',
-      hostId: 'local'
-    })
-    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-1', { setup: setupLaunch })
-    expect(result).toEqual({ status: 'launched', primaryTabId: 'tab-1' })
+    expect(result).toEqual({ status: 'error', message: 'ipc unavailable' })
+    expect(toastError).toHaveBeenCalled()
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+  })
+
+  it('reports activation failures with a toast', async () => {
+    activateAndRevealWorktree.mockReturnValue(false)
+
+    const result = await runWorktreeSetupScript('wt-1')
+
+    expect(result).toEqual({ status: 'skipped', reason: 'activation-failed' })
+    expect(toastError).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/run-worktree-setup-script.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.ts
@@ -1,0 +1,133 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { translate } from '@/i18n/i18n'
+import { isFolderRepo } from '../../../shared/repo-kind'
+import { getRepoExecutionHostId } from '../../../shared/execution-host'
+
+export type RunWorktreeSetupScriptResult =
+  | { status: 'launched'; primaryTabId: string | null }
+  | {
+      status: 'skipped'
+      reason:
+        | 'worktree-missing'
+        | 'repo-missing'
+        | 'folder-repo'
+        | 'no-setup-configured'
+        | 'trust-skipped'
+        | 'activation-failed'
+    }
+  | { status: 'error'; message: string }
+
+/**
+ * Manual re-run of the worktree setup script (#10015).
+ * Materializes the same setup runner used at create, then launches via the
+ * existing Setup tab / split path (`setupScriptLaunchMode`).
+ */
+export async function runWorktreeSetupScript(
+  worktreeId: string
+): Promise<RunWorktreeSetupScriptResult> {
+  const state = useAppStore.getState()
+  const worktree = state.getKnownWorktreeById(worktreeId)
+  if (!worktree) {
+    toast.error(
+      translate(
+        'auto.lib.runWorktreeSetupScript.worktreeMissing',
+        'Workspace is no longer available.'
+      )
+    )
+    return { status: 'skipped', reason: 'worktree-missing' }
+  }
+
+  const repo = state.repos.find((entry) => entry.id === worktree.repoId)
+  if (!repo) {
+    toast.error(
+      translate('auto.lib.runWorktreeSetupScript.repoMissing', 'Project is no longer available.')
+    )
+    return { status: 'skipped', reason: 'repo-missing' }
+  }
+
+  if (isFolderRepo(repo)) {
+    toast.info(
+      translate(
+        'auto.lib.runWorktreeSetupScript.folderRepo',
+        'Folder workspaces do not use setup scripts.'
+      )
+    )
+    return { status: 'skipped', reason: 'folder-repo' }
+  }
+
+  // Why: same trust gate as create — shared orca.yaml setup must be confirmed before run.
+  const trust = await ensureHooksConfirmed(
+    useAppStore.getState(),
+    repo.id,
+    'setup',
+    getRepoExecutionHostId(repo)
+  )
+  if (trust !== 'run') {
+    return { status: 'skipped', reason: 'trust-skipped' }
+  }
+
+  let prepared: Awaited<ReturnType<typeof window.api.hooks.prepareSetupRunner>>
+  try {
+    prepared = await window.api.hooks.prepareSetupRunner({
+      repoId: repo.id,
+      worktreePath: worktree.path
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    toast.error(
+      translate(
+        'auto.lib.runWorktreeSetupScript.prepareFailed',
+        'Could not prepare the setup script.'
+      ),
+      { description: message }
+    )
+    return { status: 'error', message }
+  }
+
+  if (prepared.status === 'error') {
+    const message = prepared.message ?? 'Could not prepare the setup script.'
+    toast.error(
+      translate(
+        'auto.lib.runWorktreeSetupScript.runnerFailed',
+        'Could not prepare the setup script.'
+      ),
+      { description: message }
+    )
+    return { status: 'error', message }
+  }
+
+  if (!prepared.setup) {
+    if (prepared.reason === 'folder-repo') {
+      toast.info(
+        translate(
+          'auto.lib.runWorktreeSetupScript.folderRepo',
+          'Folder workspaces do not use setup scripts.'
+        )
+      )
+      return { status: 'skipped', reason: 'folder-repo' }
+    }
+    toast.info(
+      translate(
+        'auto.lib.runWorktreeSetupScript.noSetup',
+        'No setup script is configured for this project.'
+      )
+    )
+    return { status: 'skipped', reason: 'no-setup-configured' }
+  }
+
+  const activation = activateAndRevealWorktree(worktreeId, { setup: prepared.setup })
+  if (!activation) {
+    toast.error(
+      translate(
+        'auto.lib.runWorktreeSetupScript.activationFailed',
+        'Could not open the workspace to run setup.'
+      )
+    )
+    return { status: 'skipped', reason: 'activation-failed' }
+  }
+
+  return { status: 'launched', primaryTabId: activation.primaryTabId }
+}

--- a/src/renderer/src/lib/run-worktree-setup-script.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.ts
@@ -2,9 +2,10 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
 import { translate } from '@/i18n/i18n'
 import { isFolderRepo } from '../../../shared/repo-kind'
-import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+import { getWorktreeExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 
 export type RunWorktreeSetupScriptResult =
   | { status: 'launched'; primaryTabId: string | null }
@@ -41,7 +42,14 @@ export async function runWorktreeSetupScript(
     return { status: 'skipped', reason: 'worktree-missing' }
   }
 
-  const repo = state.repos.find((entry) => entry.id === worktree.repoId)
+  // Why: duplicate repo ids across hosts are a supported state; resolve the row the
+  // worktree actually belongs to instead of taking the first id match.
+  const matchingRepos = state.repos.filter((entry) => entry.id === worktree.repoId)
+  const repo = worktree.hostId
+    ? findRepoForHost(matchingRepos, worktree.repoId, { hostId: worktree.hostId })
+    : matchingRepos.length === 1
+      ? matchingRepos[0]
+      : findRepoForHost(matchingRepos, worktree.repoId, { settings: state.settings })
   if (!repo) {
     toast.error(
       translate('auto.lib.runWorktreeSetupScript.repoMissing', 'Project is no longer available.')
@@ -59,9 +67,9 @@ export async function runWorktreeSetupScript(
     return { status: 'skipped', reason: 'folder-repo' }
   }
 
-  // Why: reject before the trust gate — a remote-host trust fetch can fail and end the
-  // flow silently, hiding the main process's explicit unsupported message.
-  const hostId = getRepoExecutionHostId(repo)
+  // Why: reject before any trust or IPC work — the worktree's own host wins over the
+  // repo fallback, and a remote-host trust fetch can fail and end the flow silently.
+  const hostId = getWorktreeExecutionHostId(worktree, repo)
   if (hostId !== LOCAL_EXECUTION_HOST_ID) {
     toast.info(
       translate(
@@ -70,12 +78,6 @@ export async function runWorktreeSetupScript(
       )
     )
     return { status: 'skipped', reason: 'remote-host' }
-  }
-
-  // Why: same trust gate as create — shared orca.yaml setup must be confirmed before run.
-  const trust = await ensureHooksConfirmed(useAppStore.getState(), repo.id, 'setup', hostId)
-  if (trust !== 'run') {
-    return { status: 'skipped', reason: 'trust-skipped' }
   }
 
   let prepared: Awaited<ReturnType<typeof window.api.hooks.prepareSetupRunner>>
@@ -99,6 +101,10 @@ export async function runWorktreeSetupScript(
 
   if (prepared.status === 'error') {
     const message = prepared.message ?? 'Could not prepare the setup script.'
+    if (prepared.reason === 'remote-host') {
+      toast.info(message)
+      return { status: 'skipped', reason: 'remote-host' }
+    }
     toast.error(
       translate(
         'auto.lib.runWorktreeSetupScript.runnerFailed',
@@ -128,7 +134,27 @@ export async function runWorktreeSetupScript(
     return { status: 'skipped', reason: 'no-setup-configured' }
   }
 
-  const activation = activateAndRevealWorktree(worktreeId, { setup: prepared.setup })
+  // Why: confirm the exact script the runner will execute — the worktree's orca.yaml can
+  // differ from the repo root the generic trust inspection reads. Purely local Settings
+  // scripts are user-owned and need no repo trust.
+  if (prepared.setupScriptSource !== 'local') {
+    const trust = await ensureHooksConfirmed(
+      useAppStore.getState(),
+      repo.id,
+      'setup',
+      hostId,
+      undefined,
+      { scriptContentOverride: prepared.setupScript ?? '' }
+    )
+    if (trust !== 'run') {
+      return { status: 'skipped', reason: 'trust-skipped' }
+    }
+  }
+
+  const activation = activateAndRevealWorktree(worktreeId, {
+    setup: prepared.setup,
+    executionHostId: hostId
+  })
   if (!activation) {
     toast.error(
       translate(

--- a/src/renderer/src/lib/run-worktree-setup-script.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.ts
@@ -134,17 +134,19 @@ export async function runWorktreeSetupScript(
     return { status: 'skipped', reason: 'no-setup-configured' }
   }
 
-  // Why: confirm the exact script the runner will execute — the worktree's orca.yaml can
-  // differ from the repo root the generic trust inspection reads. Purely local Settings
-  // scripts are user-owned and need no repo trust.
+  // Why: confirm the script the runner will execute — the worktree's orca.yaml can
+  // differ from the repo root the generic trust inspection reads. The canonical
+  // trustContent (setup + defaultTabs commands) keeps the per-repo hash slot in sync
+  // with the create flow. Purely local Settings scripts are user-owned: no repo trust.
   if (prepared.setupScriptSource !== 'local') {
+    const trustContent = (prepared.trustContent ?? prepared.setupScript ?? '').trim()
     const trust = await ensureHooksConfirmed(
       useAppStore.getState(),
       repo.id,
       'setup',
       hostId,
       undefined,
-      { scriptContentOverride: prepared.setupScript ?? '' }
+      trustContent ? { scriptContentOverride: trustContent } : undefined
     )
     if (trust !== 'run') {
       return { status: 'skipped', reason: 'trust-skipped' }

--- a/src/renderer/src/lib/run-worktree-setup-script.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.ts
@@ -22,6 +22,15 @@ export type RunWorktreeSetupScriptResult =
     }
   | { status: 'error'; message: string }
 
+function notifyRemoteHostUnsupported(): void {
+  toast.info(
+    translate(
+      'auto.lib.runWorktreeSetupScript.remoteHost',
+      'Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.'
+    )
+  )
+}
+
 /**
  * Manual re-run of the worktree setup script (#10015).
  * Materializes the same setup runner used at create, then launches via the
@@ -71,12 +80,7 @@ export async function runWorktreeSetupScript(
   // repo fallback, and a remote-host trust fetch can fail and end the flow silently.
   const hostId = getWorktreeExecutionHostId(worktree, repo)
   if (hostId !== LOCAL_EXECUTION_HOST_ID) {
-    toast.info(
-      translate(
-        'auto.lib.runWorktreeSetupScript.remoteHost',
-        'Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.'
-      )
-    )
+    notifyRemoteHostUnsupported()
     return { status: 'skipped', reason: 'remote-host' }
   }
 
@@ -102,12 +106,7 @@ export async function runWorktreeSetupScript(
   if (prepared.status === 'error') {
     const message = prepared.message ?? 'Could not prepare the setup script.'
     if (prepared.reason === 'remote-host') {
-      toast.info(
-        translate(
-          'auto.lib.runWorktreeSetupScript.remoteHost',
-          'Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.'
-        )
-      )
+      notifyRemoteHostUnsupported()
       return { status: 'skipped', reason: 'remote-host' }
     }
     toast.error(

--- a/src/renderer/src/lib/run-worktree-setup-script.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.ts
@@ -102,7 +102,12 @@ export async function runWorktreeSetupScript(
   if (prepared.status === 'error') {
     const message = prepared.message ?? 'Could not prepare the setup script.'
     if (prepared.reason === 'remote-host') {
-      toast.info(message)
+      toast.info(
+        translate(
+          'auto.lib.runWorktreeSetupScript.remoteHost',
+          'Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.'
+        )
+      )
       return { status: 'skipped', reason: 'remote-host' }
     }
     toast.error(

--- a/src/renderer/src/lib/run-worktree-setup-script.ts
+++ b/src/renderer/src/lib/run-worktree-setup-script.ts
@@ -4,7 +4,7 @@ import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { translate } from '@/i18n/i18n'
 import { isFolderRepo } from '../../../shared/repo-kind'
-import { getRepoExecutionHostId } from '../../../shared/execution-host'
+import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 
 export type RunWorktreeSetupScriptResult =
   | { status: 'launched'; primaryTabId: string | null }
@@ -14,6 +14,7 @@ export type RunWorktreeSetupScriptResult =
         | 'worktree-missing'
         | 'repo-missing'
         | 'folder-repo'
+        | 'remote-host'
         | 'no-setup-configured'
         | 'trust-skipped'
         | 'activation-failed'
@@ -58,13 +59,21 @@ export async function runWorktreeSetupScript(
     return { status: 'skipped', reason: 'folder-repo' }
   }
 
+  // Why: reject before the trust gate — a remote-host trust fetch can fail and end the
+  // flow silently, hiding the main process's explicit unsupported message.
+  const hostId = getRepoExecutionHostId(repo)
+  if (hostId !== LOCAL_EXECUTION_HOST_ID) {
+    toast.info(
+      translate(
+        'auto.lib.runWorktreeSetupScript.remoteHost',
+        'Run setup script is not yet supported for remote worktrees. Create a new worktree to run setup on that host, or open a local clone.'
+      )
+    )
+    return { status: 'skipped', reason: 'remote-host' }
+  }
+
   // Why: same trust gate as create — shared orca.yaml setup must be confirmed before run.
-  const trust = await ensureHooksConfirmed(
-    useAppStore.getState(),
-    repo.id,
-    'setup',
-    getRepoExecutionHostId(repo)
-  )
+  const trust = await ensureHooksConfirmed(useAppStore.getState(), repo.id, 'setup', hostId)
   if (trust !== 'run') {
     return { status: 'skipped', reason: 'trust-skipped' }
   }
@@ -73,7 +82,8 @@ export async function runWorktreeSetupScript(
   try {
     prepared = await window.api.hooks.prepareSetupRunner({
       repoId: repo.id,
-      worktreePath: worktree.path
+      worktreePath: worktree.path,
+      hostId
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -390,21 +390,34 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     expect(store.setActiveTab).toHaveBeenCalledWith('tab-1')
   })
 
-  it('does not create or queue anything when the worktree already has renderable content', () => {
+  it('does not create or queue anything for renderable-only worktrees without a launch', () => {
     const store = createMockStore({
       reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 1 }))
     })
 
-    ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, {
-      runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
-      envVars: {}
-    })
+    ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, undefined)
 
     expect(store.createTab).not.toHaveBeenCalled()
     expect(store.setActiveTab).not.toHaveBeenCalled()
     expect(store.queueTabStartupCommand).not.toHaveBeenCalled()
     expect(store.queueTabSetupSplit).not.toHaveBeenCalled()
     expect(store.queueTabIssueCommandSplit).not.toHaveBeenCalled()
+  })
+
+  it('creates a terminal to carry setup when the worktree has only non-terminal tabs', () => {
+    // Why: editor/browser-only worktrees must not silently drop a requested setup launch.
+    const store = createMockStore({
+      reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 1 }))
+    })
+
+    const result = ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, {
+      runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+      envVars: {}
+    })
+
+    expect(result).not.toBeNull()
+    expect(store.createTab).toHaveBeenCalled()
+    expect(store.queueTabStartupCommand).toHaveBeenCalled()
   })
 
   it('queues returned setup on an existing terminal tab when startup was already adopted', () => {

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -404,6 +404,26 @@ describe('ensureWorktreeHasInitialTerminal', () => {
     expect(store.queueTabIssueCommandSplit).not.toHaveBeenCalled()
   })
 
+  it('targets the active terminal tab instead of the oldest when queueing setup', () => {
+    let createdIndex = 10
+    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+    const store = createMockStore({
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-old' }, { id: 'tab-active' }] },
+      getActiveTab: vi.fn(() => ({ id: 'tab-active' })),
+      createTab,
+      reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 2 }))
+    })
+
+    const result = ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, {
+      runnerScriptPath: '/tmp/repo/.git/orca/setup-runner.sh',
+      envVars: {}
+    })
+
+    expect(result).toBe('tab-active')
+    // Why: the new-tab mode reverts focus to the targeted terminal, not tabsByWorktree[0].
+    expect(store.setActiveTab).toHaveBeenCalledWith('tab-active')
+  })
+
   it('creates a terminal to carry setup when the worktree has only non-terminal tabs', () => {
     // Why: editor/browser-only worktrees must not silently drop a requested setup launch.
     const store = createMockStore({

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -487,7 +487,12 @@ export function ensureWorktreeHasInitialTerminal(
   }
 
   if (!shouldAutoCreateInitialTerminal(renderableTabCount)) {
-    const existingTerminalTabId = store.tabsByWorktree[worktreeId]?.[0]?.id
+    const terminalTabs = store.tabsByWorktree[worktreeId] ?? []
+    // Why: on an existing worktree the oldest terminal is unrelated to where the user
+    // is; target the active tab when it is a terminal so focus and splits stay put.
+    const activeTabId = useAppStore.getState().getActiveTab?.(worktreeId)?.id
+    const existingTerminalTabId =
+      terminalTabs.find((tab) => tab.id === activeTabId)?.id ?? terminalTabs[0]?.id
     if (existingTerminalTabId && (setup || issueCommand)) {
       // Why: main may have adopted the startup tab but failed to spawn setup; renderer must still launch the returned fallback setup.
       queueSetupAndIssueCommands(
@@ -501,7 +506,11 @@ export function ensureWorktreeHasInitialTerminal(
       )
       return existingTerminalTabId
     }
-    return null
+    if (!setup && !issueCommand) {
+      return null
+    }
+    // Why: editor/browser-only worktrees have no terminal to carry the launch; fall
+    // through and create one instead of silently dropping setup.
   }
 
   const templatedTabId = applyDefaultTerminalTabs(

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -121,6 +121,7 @@ function getSetupRunnerCommandPlatformForLaunch(setup: WorktreeSetupLaunch): 'wi
 
 type WorktreeActivationStore = Partial<WorktreeRuntimeOwnerState> & {
   tabsByWorktree: Record<string, { id: string }[]>
+  getActiveTab?: (worktreeId: string) => { id: string } | null
   defaultTerminalTabsAppliedByWorktreeId: Record<string, true>
   createTab: (
     worktreeId: string,
@@ -490,7 +491,9 @@ export function ensureWorktreeHasInitialTerminal(
     const terminalTabs = store.tabsByWorktree[worktreeId] ?? []
     // Why: on an existing worktree the oldest terminal is unrelated to where the user
     // is; target the active tab when it is a terminal so focus and splits stay put.
-    const activeTabId = useAppStore.getState().getActiveTab?.(worktreeId)?.id
+    const activeTabId = (store.getActiveTab ?? useAppStore.getState().getActiveTab)?.(
+      worktreeId
+    )?.id
     const existingTerminalTabId =
       terminalTabs.find((tab) => tab.id === activeTabId)?.id ?? terminalTabs[0]?.id
     if (existingTerminalTabId && (setup || issueCommand)) {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2549,6 +2549,11 @@ function createHooksApi(): NonNullable<Partial<PreloadApi>['hooks']> {
     inspectSetupScriptImports: async ({ repoId }) =>
       callRuntimeResult('repo.setupScriptImports', { repo: repoId }),
     createIssueCommandRunner: async () => ({ launched: false }) as never,
+    prepareSetupRunner: async () => ({
+      status: 'ok' as const,
+      setup: null,
+      reason: 'no-setup-configured' as const
+    }),
     readIssueCommand: async ({ repoId }) =>
       callRuntimeResult('repo.issueCommandRead', { repo: repoId }),
     writeIssueCommand: async ({ repoId, content }) => {

--- a/tests/tools/benchmarks/terminal-perf-bench.mjs
+++ b/tests/tools/benchmarks/terminal-perf-bench.mjs
@@ -591,8 +591,7 @@ async function main() {
       args.reportPath ??
         path.join(
           rootDir,
-          'tests',
-          'tools',
+          'tests', 'tools',
           'benchmarks',
           'results',
           `terminal-perf-${args.label}-${stamp}.json`


### PR DESCRIPTION
## Description

Adds a **Run setup script** action for existing Git worktrees, so users can run or re-run repository setup without recreating the worktree.

The action reuses the create-time setup path: worktree-scoped hook resolution, canonical trust content, runner materialization, the configured Windows setup shell, and the existing Setup tab/split launch behavior.

## Focused fix

- **In scope:** single-worktree context-menu action, local setup-runner preparation, trust confirmation for the exact resolved worktree script, launch/error handling, and regression coverage.
- **Out of scope:** remote-host execution and command-palette support. Remote worktrees receive an explicit unsupported toast; folder workspaces omit the action.

## Preserves

- Setup content and trust hashes stay aligned with worktree creation, including worktree-specific `orca.yaml`, local Settings fallback, and default-tab command trust content.
- Non-local execution hosts never reach local-filesystem setup helpers.
- Primary/main and linked worktrees use their real per-worktree Git directory.
- Existing worktrees are not recreated or removed; runner/launch failures are non-destructive.
- Setup honors `setupScriptLaunchMode`, the active terminal, editor/browser-only worktrees, and the configured cmd/Git Bash runner shell on Windows.

## Implementation notes

- New `hooks:prepareSetupRunner` resolves the host-owning repo row, rejects non-local hosts, materializes the create-path runner atomically, and returns the exact setup/trust payload.
- `runWorktreeSetupScript` performs the host guard before trust/IPC work, distinguishes transport and runner-preparation failures, and launches through `activateAndRevealWorktree`.
- Per-run temporary files prevent a re-run from truncating a runner that a shell is still reading.

## Evidence

- `pnpm exec vitest run --config config/vitest.config.ts src/main/hooks-runner.test.ts src/main/hooks.test.ts src/main/ipc/worktrees.test.ts src/renderer/src/lib/ensure-hooks-confirmed.test.ts src/renderer/src/lib/run-worktree-setup-script.test.ts src/renderer/src/lib/worktree-activation.test.ts` — **413 passed**
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `ORCA_CODE_QUALITY_BASE=upstream/main pnpm check:code-quality:changed` — 0 findings across 15 changed files
- `ORCA_CODE_QUALITY_BASE=upstream/main pnpm check:react-doctor:changed` — 0 issues
- Live app validation and screenshots: https://github.com/stablyai/orca/pull/10077#issuecomment-5152658295

## User-regression-tradeoffs

- Manual setup remains intentionally local-only until the remote setup path can resolve and launch worktree-scoped hooks on the owning host.
- The action is single-selection only; multi-select behavior is unchanged.
- Repository setup commands still require the same trust decision as create-time setup.

Fixes #10015