### PR TITLE
feat(workspace): Upstream/Origin issue source switch on branch create

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -1447,7 +1447,7 @@ export default function SmartWorkspaceNameField({
               ))}
             </TabsList>
           </Tabs>
-          {selectedRepo && issueSourceCandidates ? (
+          {!repoBackedSourcesDisabled && selectedRepo && issueSourceCandidates ? (
             <div className={cn(issueSourceChipClass, 'shrink-0')} data-composer-issue-source="true">
               <IssueSourceSelector
                 preference={selectedRepo.issueSourcePreference}

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -97,6 +97,8 @@ import {
   type WorkspaceEmojiSuggestion
 } from '@/lib/workspace-emoji-shortcodes'
 import { WorkspaceEmojiSuggestionPopover } from './WorkspaceEmojiSuggestionPopover'
+import IssueSourceSelector, { issueSourceChipClass } from '@/components/github/IssueSourceSelector'
+import { selectComposerIssueSourceCandidates } from './composer-issue-source'
 
 type RepoOption = ReturnType<typeof useAppStore.getState>['repos'][number]
 const EMPTY_REPO_SEARCH_REPOS: readonly RepoOption[] = []
@@ -210,7 +212,10 @@ export default function SmartWorkspaceNameField({
     expectedPreflightContextKey,
     refreshPreflightStatus,
     searchLinearIssues,
-    settings
+    settings,
+    setIssueSourcePreference,
+    workItemsCache,
+    workItemsInvalidationNonce
   } = useAppStore(
     useShallow((s) => ({
       addRepo: s.addRepo,
@@ -227,7 +232,10 @@ export default function SmartWorkspaceNameField({
       expectedPreflightContextKey: localPreflightContextKey(getLocalPreflightContext(s)),
       refreshPreflightStatus: s.refreshPreflightStatus,
       searchLinearIssues: s.searchLinearIssues,
-      settings: s.settings
+      settings: s.settings,
+      setIssueSourcePreference: s.setIssueSourcePreference,
+      workItemsCache: s.workItemsCache,
+      workItemsInvalidationNonce: s.workItemsInvalidationNonce
     }))
   )
   const selectedRepo = useMemo(
@@ -237,6 +245,12 @@ export default function SmartWorkspaceNameField({
   const selectedRepoOwnerSettings = useMemo(
     () => getRepoOwnerRoutedSettings(settings, selectedRepo),
     [selectedRepo, settings]
+  )
+  // Why: fork checkouts need an explicit Upstream|Origin control on branch-from-issue
+  // create flow; Tasks already has it, the composer did not (#9281).
+  const issueSourceCandidates = useMemo(
+    () => selectComposerIssueSourceCandidates(workItemsCache, selectedRepo?.id),
+    [selectedRepo?.id, workItemsCache]
   )
   const githubSourceContext = useMemo(() => {
     if (githubSourceContextOverride?.provider === 'github') {
@@ -250,6 +264,31 @@ export default function SmartWorkspaceNameField({
         })
       : null
   }, [githubSourceContextOverride, selectedRepo])
+
+  // Why: warm listWorkItems so origin/upstream candidates exist for the selector
+  // even before the user opens the smart picker dropdown (#9281).
+  useEffect(() => {
+    if (textOnly || disabled || repoBackedSourcesDisabled || !selectedRepo?.path) {
+      return
+    }
+    if (issueSourceCandidates) {
+      return
+    }
+    void fetchWorkItems(selectedRepo.id, selectedRepo.path, RESULT_LIMIT, '', {
+      sourceContext: githubSourceContext
+    }).catch(() => {
+      // Why: selector is optional polish; a failed warm fetch must not toast.
+    })
+  }, [
+    disabled,
+    fetchWorkItems,
+    githubSourceContext,
+    issueSourceCandidates,
+    repoBackedSourcesDisabled,
+    selectedRepo,
+    textOnly,
+    workItemsInvalidationNonce
+  ])
   const gitlabSourceContext = useMemo(
     () =>
       selectedRepo
@@ -799,7 +838,11 @@ export default function SmartWorkspaceNameField({
     githubSourceContext,
     selectedRepo,
     crossRepoSwitchTarget,
-    shouldQueryGithub
+    shouldQueryGithub,
+    // Why: preference flips evict the work-items cache and bump this nonce; re-run so
+    // the smart picker lists issues from the newly selected origin/upstream (#9281).
+    selectedRepo?.issueSourcePreference,
+    workItemsInvalidationNonce
   ])
 
   const branchSearchRequest = useMemo(
@@ -1404,6 +1447,23 @@ export default function SmartWorkspaceNameField({
               ))}
             </TabsList>
           </Tabs>
+          {selectedRepo && issueSourceCandidates ? (
+            <div className={cn(issueSourceChipClass, 'shrink-0')} data-composer-issue-source="true">
+              <IssueSourceSelector
+                preference={selectedRepo.issueSourcePreference}
+                origin={issueSourceCandidates.origin}
+                upstream={issueSourceCandidates.upstream}
+                density="compact"
+                // Why: composer only picks issue/PR sources for branch create, so the
+                // mixed-surface PR caveat tooltip is redundant (Tasks header keeps it).
+                suppressTooltip
+                disabled={disabled}
+                onChange={(next) => {
+                  void setIssueSourcePreference(selectedRepo.id, selectedRepo.path, next)
+                }}
+              />
+            </div>
+          ) : null}
         </div>
       )}
 

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -1454,9 +1454,8 @@ export default function SmartWorkspaceNameField({
                 origin={issueSourceCandidates.origin}
                 upstream={issueSourceCandidates.upstream}
                 density="compact"
-                // Why: composer only picks issue/PR sources for branch create, so the
-                // mixed-surface PR caveat tooltip is redundant (Tasks header keeps it).
-                suppressTooltip
+                // Why: compact U/O only changes issue routing, not PR routing — keep
+                // "Showing issues from …" so the control does not look PR-scoped.
                 disabled={disabled}
                 onChange={(next) => {
                   void setIssueSourcePreference(selectedRepo.id, selectedRepo.path, next)

--- a/src/renderer/src/components/new-workspace/composer-issue-source.test.ts
+++ b/src/renderer/src/components/new-workspace/composer-issue-source.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { cacheKeyLooksLikeRepo, selectComposerIssueSourceCandidates } from './composer-issue-source'
+
+describe('cacheKeyLooksLikeRepo', () => {
+  it('matches plain and host-scoped work-items keys', () => {
+    expect(cacheKeyLooksLikeRepo('repo-1::12::', 'repo-1')).toBe(true)
+    expect(cacheKeyLooksLikeRepo('ssh:abc::repo-1::12::', 'repo-1')).toBe(true)
+    expect(cacheKeyLooksLikeRepo('repo-2::12::', 'repo-1')).toBe(false)
+  })
+})
+
+describe('selectComposerIssueSourceCandidates', () => {
+  it('returns divergent origin/upstream from a matching cache entry', () => {
+    const result = selectComposerIssueSourceCandidates(
+      {
+        'repo-1::12::': {
+          sources: {
+            issues: { owner: 'up', repo: 'orca' },
+            prs: { owner: 'up', repo: 'orca' },
+            originCandidate: { owner: 'me', repo: 'orca' },
+            upstreamCandidate: { owner: 'stablyai', repo: 'orca' }
+          }
+        }
+      },
+      'repo-1'
+    )
+    expect(result).toEqual({
+      origin: { owner: 'me', repo: 'orca' },
+      upstream: { owner: 'stablyai', repo: 'orca' }
+    })
+  })
+
+  it('skips same-slug origin/upstream and missing candidates', () => {
+    expect(
+      selectComposerIssueSourceCandidates(
+        {
+          'repo-1::12::': {
+            sources: {
+              issues: null,
+              prs: null,
+              originCandidate: { owner: 'me', repo: 'orca' },
+              upstreamCandidate: { owner: 'me', repo: 'orca' }
+            }
+          }
+        },
+        'repo-1'
+      )
+    ).toBeNull()
+
+    expect(
+      selectComposerIssueSourceCandidates(
+        {
+          'repo-1::12::': {
+            sources: {
+              issues: null,
+              prs: null,
+              originCandidate: { owner: 'me', repo: 'orca' },
+              upstreamCandidate: null
+            }
+          }
+        },
+        'repo-1'
+      )
+    ).toBeNull()
+  })
+
+  it('finds host-scoped cache keys for the selected repo', () => {
+    const result = selectComposerIssueSourceCandidates(
+      {
+        'ssh:server::repo-1::12::q': {
+          sources: {
+            issues: { owner: 'up', repo: 'orca' },
+            prs: { owner: 'up', repo: 'orca' },
+            originCandidate: { owner: 'me', repo: 'orca' },
+            upstreamCandidate: { owner: 'up', repo: 'orca' }
+          }
+        }
+      },
+      'repo-1'
+    )
+    expect(result?.upstream.owner).toBe('up')
+  })
+})

--- a/src/renderer/src/components/new-workspace/composer-issue-source.ts
+++ b/src/renderer/src/components/new-workspace/composer-issue-source.ts
@@ -1,0 +1,46 @@
+import { sameGitHubOwnerRepo } from '@/components/github/IssueSourceIndicator'
+import type { WorkItemsCacheSources } from '@/store/slices/github'
+import type { GitHubOwnerRepo } from '../../../../shared/types'
+
+export type ComposerIssueSourceCandidates = {
+  origin: GitHubOwnerRepo
+  upstream: GitHubOwnerRepo
+}
+
+export function cacheKeyLooksLikeRepo(key: string, repoId: string): boolean {
+  if (key.startsWith(`${repoId}::`)) {
+    return true
+  }
+  // Host-scoped: `<hostId>::<repoId>::…`
+  const parts = key.split('::')
+  return parts.length >= 2 && parts.includes(repoId)
+}
+
+/**
+ * Prefer a warm work-items cache entry that already carries origin/upstream
+ * remote candidates (populated by listWorkItems). Used to show Upstream|Origin
+ * on the New Workspace smart name field without an extra IPC (#9281).
+ */
+export function selectComposerIssueSourceCandidates(
+  workItemsCache: Record<string, { sources?: WorkItemsCacheSources }>,
+  repoId: string | null | undefined
+): ComposerIssueSourceCandidates | null {
+  if (!repoId) {
+    return null
+  }
+  for (const [key, entry] of Object.entries(workItemsCache)) {
+    if (!cacheKeyLooksLikeRepo(key, repoId)) {
+      continue
+    }
+    const origin = entry.sources?.originCandidate
+    const upstream = entry.sources?.upstreamCandidate
+    if (!origin || !upstream) {
+      continue
+    }
+    if (sameGitHubOwnerRepo(origin, upstream)) {
+      continue
+    }
+    return { origin, upstream }
+  }
+  return null
+}

--- a/src/renderer/src/components/new-workspace/composer-issue-source.ts
+++ b/src/renderer/src/components/new-workspace/composer-issue-source.ts
@@ -11,9 +11,9 @@ export function cacheKeyLooksLikeRepo(key: string, repoId: string): boolean {
   if (key.startsWith(`${repoId}::`)) {
     return true
   }
-  // Host-scoped: `<hostId>::<repoId>::…`
+  // Host-scoped: `<hostId>::<repoId>::…` — match only host or repo segments, not query tails.
   const parts = key.split('::')
-  return parts.length >= 2 && parts.includes(repoId)
+  return parts[0] === repoId || parts[1] === repoId
 }
 
 /**


### PR DESCRIPTION
## Summary

Fork-based contributors often need to pick issues from **upstream** when creating a branch, not only from their fork. Tasks and Create Issue already expose `IssueSourceSelector`; the New Workspace smart name field (branch-from-issue create) did not.

This PR:

- Shows the compact **Upstream | Origin** control on the New Workspace smart name tabs when the selected repo has divergent origin/upstream remotes
- Reuses persisted `issueSourcePreference` + `setIssueSourcePreference` (same as Tasks)
- Warms `listWorkItems` so remote candidates are available before the dropdown opens
- Re-fetches smart GitHub results when the preference flips (`workItemsInvalidationNonce`)

Fixes #9281

## Screenshots

- New Workspace composer → Name / Create From row: compact **U | O** pill appears for forks with an upstream remote
- No change for non-fork / same-slug origin+upstream repos (selector still suppresses itself)

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/new-workspace/composer-issue-source.test.ts` (4/4)
- [ ] Full `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build`
- [x] Unit tests for cache key matching + divergent candidate selection

## AI Review Report

- **Reuse**: no new preference store; same IPC/persistence path as Tasks
- **Non-destructive**: warm fetch failures are silent; selector is optional polish
- **Cross-platform**: UI-only; no keyboard/path/shell changes
- **SSH**: host-scoped work-items cache keys still match via `cacheKeyLooksLikeRepo`

## Security Audit

- No new IPC channels or secrets
- Preference write goes through existing `repos:update` / runtime `repo.update`

## Notes

- Default remains heuristic (upstream-if-present) until the user clicks a pill
- Clicking a pill pins the explicit preference (same Tasks semantics)


## ELI5

When creating a branch from an issue on a forked repo, you can pick Upstream or Origin as the issue source. That matches Tasks and Create Issue, so fork contributors can pull issues from the upstream project.
