### PR TITLE
feat(terminal): Open/Copy/Reveal actions on link right-click

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
@@ -116,6 +116,55 @@ describe('TerminalContextMenu', () => {
     expect(onForkAgentSession).not.toHaveBeenCalled()
   })
 
+  it('renders link-aware actions when right-click lands on a URL (#9279)', () => {
+    const onOpenLinkTarget = vi.fn()
+    const onCopyLinkTarget = vi.fn()
+    renderMenu({
+      linkTarget: { kind: 'http', url: 'https://example.com' },
+      onOpenLinkTarget,
+      onCopyLinkTarget,
+      onRevealLinkTarget: vi.fn()
+    })
+
+    const openItem = items.list.find((item) => childrenText(item.children) === 'Open Link')
+    const copyItem = items.list.find((item) => childrenText(item.children) === 'Copy Link')
+    expect(openItem).toBeDefined()
+    expect(copyItem).toBeDefined()
+    expect(
+      items.list.some((item) => childrenText(item.children) === 'Reveal in File Manager')
+    ).toBe(false)
+
+    openItem?.onSelect?.()
+    copyItem?.onSelect?.()
+    expect(onOpenLinkTarget).toHaveBeenCalledTimes(1)
+    expect(onCopyLinkTarget).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders path reveal for file link targets (#9279)', () => {
+    const onRevealLinkTarget = vi.fn()
+    renderMenu({
+      linkTarget: {
+        kind: 'file',
+        absolutePath: '/tmp/repo/src/main.ts',
+        line: 1,
+        column: null,
+        pathText: 'src/main.ts'
+      },
+      onOpenLinkTarget: vi.fn(),
+      onCopyLinkTarget: vi.fn(),
+      onRevealLinkTarget
+    })
+
+    const openItem = items.list.find((item) => childrenText(item.children) === 'Open Path')
+    const revealItem = items.list.find(
+      (item) => childrenText(item.children) === 'Reveal in File Manager'
+    )
+    expect(openItem).toBeDefined()
+    expect(revealItem).toBeDefined()
+    revealItem?.onSelect?.()
+    expect(onRevealLinkTarget).toHaveBeenCalledTimes(1)
+  })
+
   it('shows new-session continuation only for eligible agent panes', () => {
     const onContinueAgentSessionInNewSession = vi.fn()
     renderMenu({

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
@@ -120,7 +120,7 @@ describe('TerminalContextMenu', () => {
     const onOpenLinkTarget = vi.fn()
     const onCopyLinkTarget = vi.fn()
     renderMenu({
-      linkTarget: { kind: 'http', url: 'https://example.com' },
+      linkTarget: { kind: 'http', url: 'https://example.com', sourceOwner: { kind: 'local' } },
       onOpenLinkTarget,
       onCopyLinkTarget,
       onRevealLinkTarget: vi.fn()

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -30,51 +30,14 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { shouldIgnoreTerminalMenuPointerDownOutside } from './terminal-context-menu-dismiss'
-import type { TerminalQuickCommand } from '../../../../shared/types'
 import { isTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-commands'
 import { formatPrimaryShortcutLabel } from '@/hooks/useShortcutLabel'
 import { AgentIcon } from '@/lib/agent-catalog'
-import type { KeybindingOverrides } from '../../../../shared/keybindings'
 import { translate } from '@/i18n/i18n'
 import { isMacPlatform, nativeChatToggleShortcutLabel } from '../native-chat/native-chat-shortcut'
 import { AgentSessionContinuationMenuItem } from './AgentSessionContinuationMenuItem'
-
-type TerminalContextMenuProps = {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  menuPoint: { x: number; y: number }
-  menuOpenedAtRef: React.RefObject<number>
-  canClosePane: boolean
-  canExpandPane: boolean
-  menuPaneIsExpanded: boolean
-  onCopy: () => void
-  onPaste: () => void
-  onSplitRight: () => void
-  onSplitDown: () => void
-  keybindings: KeybindingOverrides
-  canEqualizePaneSizes: boolean
-  onEqualizePaneSizes: () => void
-  onClosePane: () => void
-  onClearScreen: () => void
-  canContinueAgentSessionInNewSession: boolean
-  onContinueAgentSessionInNewSession: () => void
-  onForkAgentSession: () => void
-  canToggleNativeChat: boolean
-  isNativeChatView: boolean
-  onToggleNativeChat: () => void
-  onCopyAgentSessionContext: () => void
-  repoQuickCommands: TerminalQuickCommand[]
-  globalQuickCommands: TerminalQuickCommand[]
-  quickCommandRepoLabel: string | null
-  onQuickCommand: (command: TerminalQuickCommand) => void
-  onAddQuickCommand: () => void
-  onToggleExpand: () => void
-  onSetTitle: () => void
-  onClearPaneTitle: () => void
-  canClearPaneTitle: boolean
-  onCopyTerminalId: () => void
-  onCopyPaneId: () => void
-}
+import type { TerminalContextMenuProps } from './terminal-context-menu-props'
+import { TerminalContextMenuLinkActions } from './TerminalContextMenuLinkActions'
 
 export default function TerminalContextMenu({
   open,
@@ -84,6 +47,10 @@ export default function TerminalContextMenu({
   canClosePane,
   canExpandPane,
   menuPaneIsExpanded,
+  linkTarget = null,
+  onOpenLinkTarget,
+  onCopyLinkTarget,
+  onRevealLinkTarget,
   onCopy,
   onPaste,
   onSplitRight,
@@ -199,6 +166,14 @@ export default function TerminalContextMenu({
           }
         }}
       >
+        {linkTarget ? (
+          <TerminalContextMenuLinkActions
+            linkTarget={linkTarget}
+            onOpenLinkTarget={onOpenLinkTarget}
+            onCopyLinkTarget={onCopyLinkTarget}
+            onRevealLinkTarget={onRevealLinkTarget}
+          />
+        ) : null}
         <DropdownMenuItem onSelect={onCopy}>
           <Copy />
           {translate('auto.components.terminal.pane.TerminalContextMenu.f3eeb1de13', 'Copy')}

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -30,6 +30,7 @@ import {
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu'
 import { shouldIgnoreTerminalMenuPointerDownOutside } from './terminal-context-menu-dismiss'
+import type { TerminalQuickCommand } from '../../../../shared/types'
 import { isTerminalAgentQuickCommand } from '../../../../shared/terminal-quick-commands'
 import { formatPrimaryShortcutLabel } from '@/hooks/useShortcutLabel'
 import { AgentIcon } from '@/lib/agent-catalog'

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenuLinkActions.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenuLinkActions.tsx
@@ -1,0 +1,46 @@
+import { Copy, ExternalLink, FolderOpen, Link2 } from 'lucide-react'
+import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
+import { translate } from '@/i18n/i18n'
+import type { TerminalContextMenuLinkTarget } from './terminal-context-menu-link-target'
+
+type TerminalContextMenuLinkActionsProps = {
+  linkTarget: TerminalContextMenuLinkTarget
+  onOpenLinkTarget?: () => void
+  onCopyLinkTarget?: () => void
+  onRevealLinkTarget?: () => void
+}
+
+/** Link/path actions shown at the top of the terminal context menu (#9279). */
+export function TerminalContextMenuLinkActions({
+  linkTarget,
+  onOpenLinkTarget,
+  onCopyLinkTarget,
+  onRevealLinkTarget
+}: TerminalContextMenuLinkActionsProps): React.JSX.Element {
+  return (
+    <>
+      <DropdownMenuItem onSelect={onOpenLinkTarget}>
+        {linkTarget.kind === 'http' ? <ExternalLink /> : <Link2 />}
+        {linkTarget.kind === 'http'
+          ? translate('auto.components.terminal.pane.TerminalContextMenu.openLink', 'Open Link')
+          : translate('auto.components.terminal.pane.TerminalContextMenu.openPath', 'Open Path')}
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={onCopyLinkTarget}>
+        <Copy />
+        {linkTarget.kind === 'http'
+          ? translate('auto.components.terminal.pane.TerminalContextMenu.copyLink', 'Copy Link')
+          : translate('auto.components.terminal.pane.TerminalContextMenu.copyPath', 'Copy Path')}
+      </DropdownMenuItem>
+      {linkTarget.kind === 'file' ? (
+        <DropdownMenuItem onSelect={onRevealLinkTarget}>
+          <FolderOpen />
+          {translate(
+            'auto.components.terminal.pane.TerminalContextMenu.revealInFileManager',
+            'Reveal in File Manager'
+          )}
+        </DropdownMenuItem>
+      ) : null}
+      <DropdownMenuSeparator />
+    </>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2999,6 +2999,10 @@ function TerminalPane(
         menuPaneIsExpanded={
           contextMenu.menuPaneId !== null && contextMenu.menuPaneId === expandedPaneId
         }
+        linkTarget={contextMenu.linkTarget}
+        onOpenLinkTarget={contextMenu.onOpenLinkTarget}
+        onCopyLinkTarget={() => void contextMenu.onCopyLinkTarget()}
+        onRevealLinkTarget={contextMenu.onRevealLinkTarget}
         onCopy={() => void contextMenu.onCopy()}
         onPaste={() => void contextMenu.onPaste()}
         onSplitRight={contextMenu.onSplitRight}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2474,7 +2474,8 @@ function TerminalPane(
     onAgentSessionForkReady: setAgentSessionFork,
     onAgentSessionContinuationReady: setAgentSessionContinuation,
     forceBracketedMultilineTextPaste,
-    rightClickToPaste
+    rightClickToPaste,
+    requestOpenLinksInAppPreference
   })
   const getContextMenuLeafId = useCallback((): string | null => {
     const paneId = contextMenu.menuPaneId

--- a/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getTerminalContextMenuLinkCopyText,
+  type TerminalContextMenuLinkTarget
+} from './terminal-context-menu-link-target'
+
+describe('getTerminalContextMenuLinkCopyText', () => {
+  it('copies the full URL for http targets', () => {
+    const target: TerminalContextMenuLinkTarget = {
+      kind: 'http',
+      url: 'https://example.com/path?q=1'
+    }
+    expect(getTerminalContextMenuLinkCopyText(target)).toBe('https://example.com/path?q=1')
+  })
+
+  it('copies the absolute path for file targets', () => {
+    const target: TerminalContextMenuLinkTarget = {
+      kind: 'file',
+      absolutePath: '/tmp/repo/src/main.ts',
+      line: 12,
+      column: 3,
+      pathText: 'src/main.ts:12:3'
+    }
+    expect(getTerminalContextMenuLinkCopyText(target)).toBe('/tmp/repo/src/main.ts')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.test.ts
@@ -1,14 +1,27 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   getTerminalContextMenuLinkCopyText,
   type TerminalContextMenuLinkTarget
 } from './terminal-context-menu-link-target'
 
+const linkMocks = vi.hoisted(() => ({
+  getPosition: vi.fn(),
+  findHttp: vi.fn()
+}))
+
+vi.mock('./terminal-mouse-buffer-position', () => ({
+  getTerminalBufferPositionForMouseEvent: linkMocks.getPosition
+}))
+vi.mock('./terminal-url-link-hit-testing', () => ({
+  findHttpLinkAtBufferPosition: linkMocks.findHttp
+}))
+
 describe('getTerminalContextMenuLinkCopyText', () => {
   it('copies the full URL for http targets', () => {
     const target: TerminalContextMenuLinkTarget = {
       kind: 'http',
-      url: 'https://example.com/path?q=1'
+      url: 'https://example.com/path?q=1',
+      sourceOwner: { kind: 'local' }
     }
     expect(getTerminalContextMenuLinkCopyText(target)).toBe('https://example.com/path?q=1')
   })
@@ -22,5 +35,28 @@ describe('getTerminalContextMenuLinkCopyText', () => {
       pathText: 'src/main.ts:12:3'
     }
     expect(getTerminalContextMenuLinkCopyText(target)).toBe('/tmp/repo/src/main.ts')
+  })
+})
+
+describe('resolveTerminalContextMenuLinkTarget', () => {
+  it('retains the clicked pane host for HTTP link actions', async () => {
+    linkMocks.getPosition.mockReturnValue({ x: 1, y: 1 })
+    linkMocks.findHttp.mockReturnValue('https://example.com')
+    const { resolveTerminalContextMenuLinkTarget } =
+      await import('./terminal-context-menu-link-target')
+    const sourceOwner = { kind: 'runtime', runtimeEnvironmentId: 'env-1' } as const
+
+    expect(
+      resolveTerminalContextMenuLinkTarget(
+        { cols: 80, buffer: { active: {} } } as never,
+        {} as never,
+        {
+          startupCwd: '/repo',
+          worktreeId: 'repo::/repo',
+          worktreePath: '/repo',
+          sourceOwner
+        }
+      )
+    ).toEqual({ kind: 'http', url: 'https://example.com', sourceOwner })
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.ts
@@ -1,0 +1,68 @@
+import type { Terminal } from '@xterm/xterm'
+import { findFilePathLinkAtBufferPosition } from './terminal-file-link-hit-testing'
+import { getTerminalBufferPositionForMouseEvent } from './terminal-mouse-buffer-position'
+import { findHttpLinkAtBufferPosition } from './terminal-url-link-hit-testing'
+
+export type TerminalContextMenuHttpLinkTarget = {
+  kind: 'http'
+  url: string
+}
+
+export type TerminalContextMenuFileLinkTarget = {
+  kind: 'file'
+  absolutePath: string
+  line: number | null
+  column: number | null
+  pathText: string
+}
+
+export type TerminalContextMenuLinkTarget =
+  | TerminalContextMenuHttpLinkTarget
+  | TerminalContextMenuFileLinkTarget
+
+export type ResolveTerminalContextMenuLinkTargetDeps = {
+  startupCwd: string
+  worktreeId: string
+  worktreePath: string
+  terminalHomePath?: string | null
+  runtimeEnvironmentId?: string | null
+  pathExistsCache?: Map<string, boolean>
+}
+
+/**
+ * Resolve the HTTP URL or file path under a context-menu mouse event (#9279).
+ * HTTP wins over file when both match (e.g. path-looking query strings in URLs).
+ */
+export function resolveTerminalContextMenuLinkTarget(
+  terminal: Terminal,
+  event: Pick<MouseEvent, 'clientX' | 'clientY'>,
+  deps: ResolveTerminalContextMenuLinkTargetDeps
+): TerminalContextMenuLinkTarget | null {
+  const position = getTerminalBufferPositionForMouseEvent(terminal, event as MouseEvent)
+  if (!position) {
+    return null
+  }
+  const buffer = terminal.buffer.active
+  const httpUrl = findHttpLinkAtBufferPosition(buffer, position, terminal.cols)
+  if (httpUrl) {
+    return { kind: 'http', url: httpUrl }
+  }
+  if (!deps.startupCwd) {
+    return null
+  }
+  const file = findFilePathLinkAtBufferPosition(buffer, position, terminal.cols, deps)
+  if (!file) {
+    return null
+  }
+  return {
+    kind: 'file',
+    absolutePath: file.absolutePath,
+    line: file.line,
+    column: file.column,
+    pathText: file.pathText
+  }
+}
+
+export function getTerminalContextMenuLinkCopyText(target: TerminalContextMenuLinkTarget): string {
+  return target.kind === 'http' ? target.url : target.absolutePath
+}

--- a/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
+import type { HttpLinkSourceOwner } from '@/lib/http-link-routing'
 import { findFilePathLinkAtBufferPosition } from './terminal-file-link-hit-testing'
 import { getTerminalBufferPositionForMouseEvent } from './terminal-mouse-buffer-position'
 import { findHttpLinkAtBufferPosition } from './terminal-url-link-hit-testing'
@@ -6,6 +7,7 @@ import { findHttpLinkAtBufferPosition } from './terminal-url-link-hit-testing'
 export type TerminalContextMenuHttpLinkTarget = {
   kind: 'http'
   url: string
+  sourceOwner: HttpLinkSourceOwner
 }
 
 export type TerminalContextMenuFileLinkTarget = {
@@ -26,6 +28,7 @@ export type ResolveTerminalContextMenuLinkTargetDeps = {
   worktreePath: string
   terminalHomePath?: string | null
   runtimeEnvironmentId?: string | null
+  sourceOwner?: HttpLinkSourceOwner
   pathExistsCache?: Map<string, boolean>
 }
 
@@ -45,7 +48,7 @@ export function resolveTerminalContextMenuLinkTarget(
   const buffer = terminal.buffer.active
   const httpUrl = findHttpLinkAtBufferPosition(buffer, position, terminal.cols)
   if (httpUrl) {
-    return { kind: 'http', url: httpUrl }
+    return { kind: 'http', url: httpUrl, sourceOwner: deps.sourceOwner ?? { kind: 'local' } }
   }
   if (!deps.startupCwd) {
     return null

--- a/src/renderer/src/components/terminal-pane/terminal-context-menu-props.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-context-menu-props.ts
@@ -1,0 +1,44 @@
+import type { KeybindingOverrides } from '../../../../shared/keybindings'
+import type { TerminalQuickCommand } from '../../../../shared/types'
+import type { TerminalContextMenuLinkTarget } from './terminal-context-menu-link-target'
+
+export type TerminalContextMenuProps = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  menuPoint: { x: number; y: number }
+  menuOpenedAtRef: React.RefObject<number>
+  canClosePane: boolean
+  canExpandPane: boolean
+  menuPaneIsExpanded: boolean
+  linkTarget?: TerminalContextMenuLinkTarget | null
+  onOpenLinkTarget?: () => void
+  onCopyLinkTarget?: () => void
+  onRevealLinkTarget?: () => void
+  onCopy: () => void
+  onPaste: () => void
+  onSplitRight: () => void
+  onSplitDown: () => void
+  keybindings: KeybindingOverrides
+  canEqualizePaneSizes: boolean
+  onEqualizePaneSizes: () => void
+  onClosePane: () => void
+  onClearScreen: () => void
+  canContinueAgentSessionInNewSession: boolean
+  onContinueAgentSessionInNewSession: () => void
+  onForkAgentSession: () => void
+  canToggleNativeChat: boolean
+  isNativeChatView: boolean
+  onToggleNativeChat: () => void
+  onCopyAgentSessionContext: () => void
+  repoQuickCommands: TerminalQuickCommand[]
+  globalQuickCommands: TerminalQuickCommand[]
+  quickCommandRepoLabel: string | null
+  onQuickCommand: (command: TerminalQuickCommand) => void
+  onAddQuickCommand: () => void
+  onToggleExpand: () => void
+  onSetTitle: () => void
+  onClearPaneTitle: () => void
+  canClearPaneTitle: boolean
+  onCopyTerminalId: () => void
+  onCopyPaneId: () => void
+}

--- a/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-file-link-hit-testing.ts
@@ -25,15 +25,30 @@ type FileLinkHitTestDeps = {
   openWithSystemDefault?: boolean
 }
 
-export function openFilePathLinkAtBufferPosition(
+export type ResolvedTerminalFilePathLink = {
+  absolutePath: string
+  line: number | null
+  column: number | null
+  pathText: string
+}
+
+export function findFilePathLinkAtBufferPosition(
   buffer: { getLine(y: number): IBufferLine | undefined },
   position: { x: number; y: number },
   terminalColumns: number,
-  deps: FileLinkHitTestDeps
-): boolean {
+  deps: Pick<
+    FileLinkHitTestDeps,
+    | 'startupCwd'
+    | 'terminalHomePath'
+    | 'worktreeId'
+    | 'worktreePath'
+    | 'runtimeEnvironmentId'
+    | 'pathExistsCache'
+  >
+): ResolvedTerminalFilePathLink | null {
   const logicalLines = buildCandidateLogicalLinesForBufferPosition(buffer, position.y)
   if (logicalLines.length === 0) {
-    return false
+    return null
   }
 
   for (const logicalLine of logicalLines) {
@@ -91,15 +106,33 @@ export function openFilePathLinkAtBufferPosition(
     const uncachedMatch = matches.find((match) => match.cachedExists !== false)
     const match = cachedMatch ?? knownWorktreeRootMatch ?? uncachedMatch
     if (match) {
-      openDetectedFilePath(match.absolutePath, match.line, match.column, {
-        ...deps,
-        openWithSystemDefault: deps.openWithSystemDefault === true
-      })
-      return true
+      return {
+        absolutePath: match.absolutePath,
+        line: match.line,
+        column: match.column,
+        pathText: match.pathText
+      }
     }
   }
 
-  return false
+  return null
+}
+
+export function openFilePathLinkAtBufferPosition(
+  buffer: { getLine(y: number): IBufferLine | undefined },
+  position: { x: number; y: number },
+  terminalColumns: number,
+  deps: FileLinkHitTestDeps
+): boolean {
+  const match = findFilePathLinkAtBufferPosition(buffer, position, terminalColumns, deps)
+  if (!match) {
+    return false
+  }
+  openDetectedFilePath(match.absolutePath, match.line, match.column, {
+    ...deps,
+    openWithSystemDefault: deps.openWithSystemDefault === true
+  })
+  return true
 }
 
 export function buildCandidateLogicalLinesForBufferPosition(

--- a/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
@@ -113,7 +113,7 @@ export function openHttpLinkAtBufferPosition(
   return true
 }
 
-function findHttpLinkAtBufferPosition(
+export function findHttpLinkAtBufferPosition(
   buffer: { getLine(y: number): IBufferLine | undefined },
   position: { x: number; y: number },
   terminalColumns: number

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -51,6 +51,7 @@ import {
   type TerminalContextMenuLinkTarget
 } from './terminal-context-menu-link-target'
 import { openDetectedFilePath } from './terminal-file-open-routing'
+import { resolveTerminalHttpLinkSourceOwner } from './terminal-http-link-source-owner'
 import {
   openTerminalHttpLink,
   type TerminalLinkRoutingPreferenceRequester
@@ -540,7 +541,8 @@ export function useTerminalPaneContextMenu({
       startupCwd,
       worktreeId,
       worktreePath: worktreePath || startupCwd,
-      runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+      runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId),
+      sourceOwner: resolveTerminalHttpLinkSourceOwner(paneTransportsRef.current.get(clickedPane.id))
     })
   }
 
@@ -634,6 +636,7 @@ export function useTerminalPaneContextMenu({
     if (linkTarget.kind === 'http') {
       openTerminalHttpLink(linkTarget.url, {
         worktreeId,
+        sourceOwner: linkTarget.sourceOwner,
         requestOpenLinksInAppPreference
       })
       return
@@ -655,8 +658,17 @@ export function useTerminalPaneContextMenu({
     if (!linkTarget) {
       return
     }
-    await window.api.ui.writeClipboardText(getTerminalContextMenuLinkCopyText(linkTarget))
-    resolveMenuPane()?.terminal.focus()
+    const pane = resolveMenuPane()
+    if (!pane) {
+      return
+    }
+    await runTerminalCopy({
+      selection: getTerminalContextMenuLinkCopyText(linkTarget),
+      writeClipboardText: window.api.ui.writeClipboardText,
+      // Why: a rejected clipboard write must not leave xterm unfocused after
+      // Radix closes the context menu.
+      focus: () => pane.terminal.focus()
+    })
   }, [linkTarget, resolveMenuPane])
 
   const onRevealLinkTarget = useCallback((): void => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -45,6 +45,13 @@ import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
 import { runCopyPaneId, runTerminalCopy } from './terminal-copy-rejection-guards'
 import { copyTerminalSelection } from './terminal-selection-copy'
+import {
+  getTerminalContextMenuLinkCopyText,
+  resolveTerminalContextMenuLinkTarget,
+  type TerminalContextMenuLinkTarget
+} from './terminal-context-menu-link-target'
+import { openDetectedFilePath } from './terminal-file-open-routing'
+import { openTerminalHttpLink } from './terminal-url-link-hit-testing'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -86,12 +93,16 @@ type TerminalMenuState = {
   menuOpenedAtRef: React.RefObject<number>
   paneCount: number
   menuPaneId: number | null
+  linkTarget: TerminalContextMenuLinkTarget | null
   onContextMenuCapture: (event: React.MouseEvent<HTMLDivElement>) => void
   onPaneTitleContextMenu: (event: React.MouseEvent<HTMLElement>, paneId: number) => void
   onCopy: () => Promise<void>
   onCopyTerminalId: () => Promise<void>
   onCopyPaneId: () => Promise<void>
   onPaste: () => Promise<void>
+  onOpenLinkTarget: () => void
+  onCopyLinkTarget: () => Promise<void>
+  onRevealLinkTarget: () => void
   onSplitRight: () => void
   onSplitDown: () => void
   onEqualizePaneSizes: () => void
@@ -131,6 +142,7 @@ export function useTerminalPaneContextMenu({
   const menuOpenedAtRef = useRef(0)
   const [open, setOpen] = useState(false)
   const [point, setPoint] = useState({ x: 0, y: 0 })
+  const [linkTarget, setLinkTarget] = useState<TerminalContextMenuLinkTarget | null>(null)
 
   useEffect(() => {
     const closeMenu = (): void => {
@@ -138,6 +150,7 @@ export function useTerminalPaneContextMenu({
         return
       }
       setOpen(false)
+      setLinkTarget(null)
     }
     window.addEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeMenu)
     return () => window.removeEventListener(CLOSE_ALL_CONTEXT_MENUS_EVENT, closeMenu)
@@ -501,6 +514,31 @@ export function useTerminalPaneContextMenu({
     }
   }
 
+  const resolveLinkTargetForEvent = (
+    event: React.MouseEvent<HTMLElement>,
+    clickedPane: ManagedPane | null
+  ): TerminalContextMenuLinkTarget | null => {
+    if (!clickedPane) {
+      return null
+    }
+    const state = useAppStore.getState()
+    const worktree = state.getKnownWorktreeById(worktreeId)
+    const worktreePath =
+      worktree && 'path' in worktree && typeof worktree.path === 'string'
+        ? worktree.path
+        : fallbackCwd
+    const startupCwd = paneCwdRef.current.get(clickedPane.id)?.cwd || fallbackCwd || worktreePath
+    if (!startupCwd) {
+      return null
+    }
+    return resolveTerminalContextMenuLinkTarget(clickedPane.terminal, event.nativeEvent, {
+      startupCwd,
+      worktreeId,
+      worktreePath: worktreePath || startupCwd,
+      runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    })
+  }
+
   const openContextMenu = (
     event: React.MouseEvent<HTMLElement>,
     clickedPaneId: number | null,
@@ -511,6 +549,7 @@ export function useTerminalPaneContextMenu({
     const manager = managerRef.current
     if (!manager) {
       contextPaneIdRef.current = null
+      setLinkTarget(null)
       return
     }
     const clickedPane =
@@ -518,11 +557,15 @@ export function useTerminalPaneContextMenu({
         ? (manager.getPanes().find((pane) => pane.id === clickedPaneId) ?? null)
         : null
     contextPaneIdRef.current = clickedPane?.id ?? null
+    const resolvedLinkTarget = resolveLinkTargetForEvent(event, clickedPane)
 
     // Why: when users opt into terminal-style right-click, a selection copies
     // and no selection pastes. Ctrl+right-click keeps the app menu reachable.
-    if (rightClickToPaste && !event.ctrlKey) {
+    // Why link exception: right-click on a detected URL/path opens the richer
+    // link menu so users do not need ⌘-click (#9279).
+    if (rightClickToPaste && !event.ctrlKey && !resolvedLinkTarget) {
       event.stopPropagation()
+      setLinkTarget(null)
       if (!clickedPane) {
         return
       }
@@ -543,6 +586,7 @@ export function useTerminalPaneContextMenu({
     menuOpenedAtRef.current = Date.now()
     const bounds = boundsElement.getBoundingClientRect()
     setPoint({ x: event.clientX - bounds.left, y: event.clientY - bounds.top })
+    setLinkTarget(resolvedLinkTarget)
     setOpen(true)
   }
 
@@ -578,19 +622,69 @@ export function useTerminalPaneContextMenu({
   const paneCount = open ? (managerRef.current?.getPanes().length ?? 1) : 1
   const menuPaneId = open ? (resolveMenuPane()?.id ?? null) : null
 
+  const onOpenLinkTarget = useCallback((): void => {
+    if (!linkTarget) {
+      return
+    }
+    if (linkTarget.kind === 'http') {
+      openTerminalHttpLink(linkTarget.url, { worktreeId })
+      return
+    }
+    const state = useAppStore.getState()
+    const worktree = state.getKnownWorktreeById(worktreeId)
+    const worktreePath =
+      worktree && 'path' in worktree && typeof worktree.path === 'string'
+        ? worktree.path
+        : fallbackCwd
+    openDetectedFilePath(linkTarget.absolutePath, linkTarget.line, linkTarget.column, {
+      worktreeId,
+      worktreePath: worktreePath || fallbackCwd,
+      runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId)
+    })
+  }, [fallbackCwd, linkTarget, worktreeId])
+
+  const onCopyLinkTarget = useCallback(async (): Promise<void> => {
+    if (!linkTarget) {
+      return
+    }
+    await window.api.ui.writeClipboardText(getTerminalContextMenuLinkCopyText(linkTarget))
+    resolveMenuPane()?.terminal.focus()
+  }, [linkTarget, resolveMenuPane])
+
+  const onRevealLinkTarget = useCallback((): void => {
+    if (!linkTarget || linkTarget.kind !== 'file') {
+      return
+    }
+    void window.api.shell.openInFileManager(linkTarget.absolutePath)
+  }, [linkTarget])
+
+  const setOpenAndClearLink = useCallback((next: boolean | ((prev: boolean) => boolean)): void => {
+    setOpen((prev) => {
+      const resolved = typeof next === 'function' ? next(prev) : next
+      if (!resolved) {
+        setLinkTarget(null)
+      }
+      return resolved
+    })
+  }, [])
+
   return {
     open,
-    setOpen,
+    setOpen: setOpenAndClearLink,
     point,
     menuOpenedAtRef,
     paneCount,
     menuPaneId,
+    linkTarget,
     onContextMenuCapture,
     onPaneTitleContextMenu,
     onCopy,
     onCopyTerminalId,
     onCopyPaneId,
     onPaste,
+    onOpenLinkTarget,
+    onCopyLinkTarget,
+    onRevealLinkTarget,
     onSplitRight,
     onSplitDown,
     onEqualizePaneSizes,

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -51,7 +51,10 @@ import {
   type TerminalContextMenuLinkTarget
 } from './terminal-context-menu-link-target'
 import { openDetectedFilePath } from './terminal-file-open-routing'
-import { openTerminalHttpLink } from './terminal-url-link-hit-testing'
+import {
+  openTerminalHttpLink,
+  type TerminalLinkRoutingPreferenceRequester
+} from './terminal-url-link-hit-testing'
 
 const CLOSE_ALL_CONTEXT_MENUS_EVENT = 'orca-close-all-context-menus'
 
@@ -84,6 +87,7 @@ type UseTerminalPaneContextMenuDeps = {
   onAgentSessionContinuationReady: (request: AgentSessionContinuationRequest) => void
   forceBracketedMultilineTextPaste: boolean
   rightClickToPaste: boolean
+  requestOpenLinksInAppPreference?: TerminalLinkRoutingPreferenceRequester
 }
 
 type TerminalMenuState = {
@@ -136,7 +140,8 @@ export function useTerminalPaneContextMenu({
   onAgentSessionForkReady,
   onAgentSessionContinuationReady,
   forceBracketedMultilineTextPaste,
-  rightClickToPaste
+  rightClickToPaste,
+  requestOpenLinksInAppPreference
 }: UseTerminalPaneContextMenuDeps): TerminalMenuState {
   const contextPaneIdRef = useRef<number | null>(null)
   const menuOpenedAtRef = useRef(0)
@@ -627,7 +632,10 @@ export function useTerminalPaneContextMenu({
       return
     }
     if (linkTarget.kind === 'http') {
-      openTerminalHttpLink(linkTarget.url, { worktreeId })
+      openTerminalHttpLink(linkTarget.url, {
+        worktreeId,
+        requestOpenLinksInAppPreference
+      })
       return
     }
     const state = useAppStore.getState()
@@ -641,7 +649,7 @@ export function useTerminalPaneContextMenu({
       worktreePath: worktreePath || fallbackCwd,
       runtimeEnvironmentId: getRuntimeEnvironmentIdForWorktree(state, worktreeId)
     })
-  }, [fallbackCwd, linkTarget, worktreeId])
+  }, [fallbackCwd, linkTarget, requestOpenLinksInAppPreference, worktreeId])
 
   const onCopyLinkTarget = useCallback(async (): Promise<void> => {
     if (!linkTarget) {


### PR DESCRIPTION
## Summary

Terminal links today mostly need ⌘/Ctrl-click, which is hard to discover. This PR adds link-aware actions to the existing terminal context menu when right-click lands on a detected HTTP URL or file path (#9279).

- **Open Link** / **Open Path** — reuse existing HTTP and file open routing
- **Copy Link** / **Copy Path**
- **Reveal in File Manager** for file paths (`shell.openInFileManager`)
- Over a link, right-click prefers the menu even when right-click-to-paste is enabled (Ctrl+right-click still works elsewhere)

## Screenshots

- Right-click a `https://…` URL in the terminal → Open Link, Copy Link above Copy/Paste
- Right-click a path like `src/main.ts` → Open Path, Copy Path, Reveal in File Manager
- No change when right-click is not on a link

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-context-menu-link-target.test.ts src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx src/renderer/src/components/terminal-pane/terminal-copy-rejection-handling.test.ts src/renderer/src/components/terminal-pane/terminal-runtime-host-link-routing.test.ts` (22 tests)
- [x] Full typecheck (`pnpm run typecheck`)
- [x] Native/type-aware Oxlint and Oxfmt on changed terminal files
- [x] Unit coverage for menu items, copy-text helper, runtime host propagation, and clipboard-failure focus recovery

## AI Review Report

- Reuses existing hit-test (`findHttpLinkAtBufferPosition`, file path resolution) and open helpers
- Cross-platform: “Reveal in File Manager” uses Electron `showItemInFolder` via existing IPC
- right-click-to-paste preserved when not on a link
- max-lines kept under limit by extracting props + link actions components

## Security Audit

- No new IPC; reveal validates absolute paths in existing shell handler
- Remote paths: reveal is local-only API (same as other file-manager opens)

## Notes

- Plain-click primary activation (no modifier) left out of this slice to avoid fighting TUI mouse modes
- Folder trailing-slash paths still follow existing link-provider rules

Fixes #9279


## ELI5

Right-clicking a URL or file path in the terminal now offers Open, Copy, and (for files) Reveal in File Manager. You no longer have to discover that only Cmd/Ctrl-click works.
