### PR TITLE
feat(editor): toggle Word Wrap from file tab actions and Alt+Z

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1749,6 +1749,18 @@ function Terminal(): React.JSX.Element | null {
         }
       }
 
+      // Why: long/structured files need a discoverable unwrap path without Settings (#9974).
+      if (!e.repeat && matchShortcut('editor.toggleWordWrap')) {
+        const state = useAppStore.getState()
+        if (state.activeTabType === 'editor' && state.activeFileId) {
+          e.preventDefault()
+          notifyTerminalCapture('editor.toggleWordWrap')
+          const wrapOn = state.settings?.editorWordWrap !== false
+          void state.updateSettings({ editorWordWrap: !wrapOn })
+          return
+        }
+      }
+
       // Cmd/Ctrl+Shift+M - new markdown file
       if (!e.repeat && matchShortcut('tab.newMarkdown')) {
         e.preventDefault()

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1755,8 +1755,15 @@ function Terminal(): React.JSX.Element | null {
         if (state.activeTabType === 'editor' && state.activeFileId) {
           e.preventDefault()
           notifyTerminalCapture('editor.toggleWordWrap')
-          const wrapOn = state.settings?.editorWordWrap !== false
-          void state.updateSettings({ editorWordWrap: !wrapOn })
+          // Why: diff surfaces use diffWordWrap; plain editors use editorWordWrap (#10086).
+          const activeFile = state.openFiles.find((file) => file.id === state.activeFileId)
+          if (activeFile?.mode === 'diff') {
+            const wrapOn = state.settings?.diffWordWrap === true
+            void state.updateSettings({ diffWordWrap: !wrapOn })
+          } else {
+            const wrapOn = state.settings?.editorWordWrap !== false
+            void state.updateSettings({ editorWordWrap: !wrapOn })
+          }
           return
         }
       }

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -90,6 +90,8 @@ export function EditorPanelHeader({
   )
   const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[activeFile.worktreeId])
   const diffWordWrap = useAppStore((s) => s.settings?.diffWordWrap === true)
+  // Why: undefined/true mean wrap on; only explicit false turns wrap off (#9974).
+  const editorWordWrap = useAppStore((s) => s.settings?.editorWordWrap !== false)
   const updateSettings = useAppStore((s) => s.updateSettings)
   const fileDiffComments = useMemo(
     () => diffComments.filter((comment) => comment.filePath === activeFile.relativePath),
@@ -313,11 +315,13 @@ export function EditorPanelHeader({
         isMarkdown={isMarkdown}
         isDiffSurface={isDiffSurface}
         diffWordWrap={diffWordWrap}
+        editorWordWrap={editorWordWrap}
         shouldShowMarkdownExportAction={shouldShowMarkdownExportAction}
         canExportMarkdownToPdf={canExportMarkdownToPdf}
         canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
         markdownFrontmatterVisible={markdownFrontmatterVisible}
         onToggleDiffWordWrap={() => void updateSettings({ diffWordWrap: !diffWordWrap })}
+        onToggleEditorWordWrap={() => void updateSettings({ editorWordWrap: !editorWordWrap })}
         onToggleMarkdownFrontmatter={onToggleMarkdownFrontmatter}
         onExportMarkdownToPdf={onExportMarkdownToPdf}
       />

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { EditorPanelMarkdownActionsMenu } from './EditorPanelMarkdownActionsMenu'
+
+const checkboxItems = vi.hoisted(() => ({ list: [] as { checked?: boolean; label: string }[] }))
+
+vi.mock('@/components/ui/dropdown-menu', async () => {
+  const React_ = await import('react')
+  const passthrough = ({ children }: { children?: React.ReactNode }) =>
+    React_.createElement(React_.Fragment, null, children)
+  return {
+    DropdownMenu: passthrough,
+    DropdownMenuContent: passthrough,
+    DropdownMenuItem: passthrough,
+    DropdownMenuSeparator: () => null,
+    DropdownMenuTrigger: passthrough,
+    DropdownMenuCheckboxItem: ({
+      checked,
+      children
+    }: {
+      checked?: boolean
+      children?: React.ReactNode
+    }) => {
+      const label = React_.Children.toArray(children)
+        .filter((child): child is string => typeof child === 'string')
+        .join('')
+      checkboxItems.list.push({ checked, label })
+      return React_.createElement(React_.Fragment, null, children)
+    }
+  }
+})
+
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+
+describe('EditorPanelMarkdownActionsMenu', () => {
+  beforeEach(() => {
+    checkboxItems.list = []
+  })
+
+  it('shows Word Wrap for normal file tabs using editorWordWrap (#9974)', () => {
+    renderToStaticMarkup(
+      React.createElement(EditorPanelMarkdownActionsMenu, {
+        isMarkdown: false,
+        isDiffSurface: false,
+        diffWordWrap: false,
+        editorWordWrap: true,
+        shouldShowMarkdownExportAction: false,
+        canExportMarkdownToPdf: false,
+        canShowMarkdownFrontmatterToggle: false,
+        markdownFrontmatterVisible: false,
+        onToggleDiffWordWrap: () => {},
+        onToggleEditorWordWrap: () => {},
+        onToggleMarkdownFrontmatter: () => {},
+        onExportMarkdownToPdf: () => {}
+      })
+    )
+
+    expect(checkboxItems.list).toEqual([{ checked: true, label: 'Word Wrap' }])
+  })
+
+  it('binds Word Wrap to diffWordWrap on diff surfaces', () => {
+    renderToStaticMarkup(
+      React.createElement(EditorPanelMarkdownActionsMenu, {
+        isMarkdown: false,
+        isDiffSurface: true,
+        diffWordWrap: true,
+        editorWordWrap: false,
+        shouldShowMarkdownExportAction: false,
+        canExportMarkdownToPdf: false,
+        canShowMarkdownFrontmatterToggle: false,
+        markdownFrontmatterVisible: false,
+        onToggleDiffWordWrap: () => {},
+        onToggleEditorWordWrap: () => {},
+        onToggleMarkdownFrontmatter: () => {},
+        onExportMarkdownToPdf: () => {}
+      })
+    )
+
+    expect(checkboxItems.list).toEqual([{ checked: true, label: 'Word Wrap' }])
+  })
+})

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.test.tsx
@@ -3,7 +3,13 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EditorPanelMarkdownActionsMenu } from './EditorPanelMarkdownActionsMenu'
 
-const checkboxItems = vi.hoisted(() => ({ list: [] as { checked?: boolean; label: string }[] }))
+const checkboxItems = vi.hoisted(() => ({
+  list: [] as {
+    checked?: boolean
+    label: string
+    onCheckedChange?: (checked: boolean) => void
+  }[]
+}))
 
 vi.mock('@/components/ui/dropdown-menu', async () => {
   const React_ = await import('react')
@@ -17,15 +23,17 @@ vi.mock('@/components/ui/dropdown-menu', async () => {
     DropdownMenuTrigger: passthrough,
     DropdownMenuCheckboxItem: ({
       checked,
-      children
+      children,
+      onCheckedChange
     }: {
       checked?: boolean
       children?: React.ReactNode
+      onCheckedChange?: (checked: boolean) => void
     }) => {
       const label = React_.Children.toArray(children)
         .filter((child): child is string => typeof child === 'string')
         .join('')
-      checkboxItems.list.push({ checked, label })
+      checkboxItems.list.push({ checked, label, onCheckedChange })
       return React_.createElement(React_.Fragment, null, children)
     }
   }
@@ -39,6 +47,8 @@ describe('EditorPanelMarkdownActionsMenu', () => {
   })
 
   it('shows Word Wrap for normal file tabs using editorWordWrap (#9974)', () => {
+    const onToggleDiffWordWrap = vi.fn()
+    const onToggleEditorWordWrap = vi.fn()
     renderToStaticMarkup(
       React.createElement(EditorPanelMarkdownActionsMenu, {
         isMarkdown: false,
@@ -49,17 +59,23 @@ describe('EditorPanelMarkdownActionsMenu', () => {
         canExportMarkdownToPdf: false,
         canShowMarkdownFrontmatterToggle: false,
         markdownFrontmatterVisible: false,
-        onToggleDiffWordWrap: () => {},
-        onToggleEditorWordWrap: () => {},
+        onToggleDiffWordWrap,
+        onToggleEditorWordWrap,
         onToggleMarkdownFrontmatter: () => {},
         onExportMarkdownToPdf: () => {}
       })
     )
 
-    expect(checkboxItems.list).toEqual([{ checked: true, label: 'Word Wrap' }])
+    expect(checkboxItems.list).toHaveLength(1)
+    expect(checkboxItems.list[0]).toMatchObject({ checked: true, label: 'Word Wrap' })
+    checkboxItems.list[0]?.onCheckedChange?.(false)
+    expect(onToggleEditorWordWrap).toHaveBeenCalledOnce()
+    expect(onToggleDiffWordWrap).not.toHaveBeenCalled()
   })
 
   it('binds Word Wrap to diffWordWrap on diff surfaces', () => {
+    const onToggleDiffWordWrap = vi.fn()
+    const onToggleEditorWordWrap = vi.fn()
     renderToStaticMarkup(
       React.createElement(EditorPanelMarkdownActionsMenu, {
         isMarkdown: false,
@@ -70,13 +86,17 @@ describe('EditorPanelMarkdownActionsMenu', () => {
         canExportMarkdownToPdf: false,
         canShowMarkdownFrontmatterToggle: false,
         markdownFrontmatterVisible: false,
-        onToggleDiffWordWrap: () => {},
-        onToggleEditorWordWrap: () => {},
+        onToggleDiffWordWrap,
+        onToggleEditorWordWrap,
         onToggleMarkdownFrontmatter: () => {},
         onExportMarkdownToPdf: () => {}
       })
     )
 
-    expect(checkboxItems.list).toEqual([{ checked: true, label: 'Word Wrap' }])
+    expect(checkboxItems.list).toHaveLength(1)
+    expect(checkboxItems.list[0]).toMatchObject({ checked: true, label: 'Word Wrap' })
+    checkboxItems.list[0]?.onCheckedChange?.(false)
+    expect(onToggleDiffWordWrap).toHaveBeenCalledOnce()
+    expect(onToggleEditorWordWrap).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
+++ b/src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.tsx
@@ -13,12 +13,16 @@ import { translate } from '@/i18n/i18n'
 type EditorPanelMarkdownActionsMenuProps = {
   isMarkdown: boolean
   isDiffSurface: boolean
+  /** Diff-only wrap preference; ignored for normal file tabs. */
   diffWordWrap: boolean
+  /** File editor wrap preference (`settings.editorWordWrap`). */
+  editorWordWrap: boolean
   shouldShowMarkdownExportAction: boolean
   canExportMarkdownToPdf: boolean
   canShowMarkdownFrontmatterToggle: boolean
   markdownFrontmatterVisible: boolean
   onToggleDiffWordWrap: () => void
+  onToggleEditorWordWrap: () => void
   onToggleMarkdownFrontmatter: () => void
   onExportMarkdownToPdf: () => void
 }
@@ -27,19 +31,21 @@ export function EditorPanelMarkdownActionsMenu({
   isMarkdown,
   isDiffSurface,
   diffWordWrap,
+  editorWordWrap,
   shouldShowMarkdownExportAction,
   canExportMarkdownToPdf,
   canShowMarkdownFrontmatterToggle,
   markdownFrontmatterVisible,
   onToggleDiffWordWrap,
+  onToggleEditorWordWrap,
   onToggleMarkdownFrontmatter,
   onExportMarkdownToPdf
 }: EditorPanelMarkdownActionsMenuProps): React.JSX.Element | null {
   const hasMarkdownActions =
     isMarkdown && (shouldShowMarkdownExportAction || canShowMarkdownFrontmatterToggle)
-  if (!isDiffSurface && !hasMarkdownActions) {
-    return null
-  }
+  // Why: normal files always get Word Wrap so long/structured lines can unwrap without Settings (#9974).
+  const wordWrapChecked = isDiffSurface ? diffWordWrap : editorWordWrap
+  const onToggleWordWrap = isDiffSurface ? onToggleDiffWordWrap : onToggleEditorWordWrap
 
   return (
     <DropdownMenu>
@@ -60,17 +66,13 @@ export function EditorPanelMarkdownActionsMenu({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={4}>
-        {isDiffSurface ? (
-          <>
-            <DropdownMenuCheckboxItem checked={diffWordWrap} onCheckedChange={onToggleDiffWordWrap}>
-              {translate(
-                'auto.components.editor.EditorPanelMarkdownActionsMenu.1eef809708',
-                'Word Wrap'
-              )}
-            </DropdownMenuCheckboxItem>
-            {hasMarkdownActions ? <DropdownMenuSeparator /> : null}
-          </>
-        ) : null}
+        <DropdownMenuCheckboxItem checked={wordWrapChecked} onCheckedChange={onToggleWordWrap}>
+          {translate(
+            'auto.components.editor.EditorPanelMarkdownActionsMenu.1eef809708',
+            'Word Wrap'
+          )}
+        </DropdownMenuCheckboxItem>
+        {hasMarkdownActions ? <DropdownMenuSeparator /> : null}
         {canShowMarkdownFrontmatterToggle ? (
           <>
             <DropdownMenuItem

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -214,6 +214,30 @@ describe('keybindings', () => {
     expect(formatKeybindingList(['Mod+Shift+O'], 'darwin')).toBe('⌘⇧O')
   })
 
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'binds editor word wrap to Alt+Z on %s',
+    (platform) => {
+      expect(getEffectiveKeybindingsForAction('editor.toggleWordWrap', platform)).toEqual(['Alt+Z'])
+    }
+  )
+
+  it('matches macOS Option+Z through its composed key', () => {
+    expect(
+      keybindingMatchesAction(
+        'editor.toggleWordWrap',
+        {
+          key: 'Ω',
+          code: 'KeyZ',
+          meta: false,
+          control: false,
+          alt: true,
+          shift: false
+        },
+        'darwin'
+      )
+    ).toBe(true)
+  })
+
   it('defines a default shortcut for adding an editor review note', () => {
     expect(getEffectiveKeybindingsForAction('editor.addReviewNote', 'darwin')).toEqual([
       'Mod+Shift+A'

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -87,6 +87,7 @@ export type KeybindingActionId =
   | 'editor.replace'
   | 'editor.save'
   | 'editor.markdownPreview'
+  | 'editor.toggleWordWrap'
   | 'editor.copyContext'
   | 'editor.previousChange'
   | 'editor.nextChange'
@@ -802,6 +803,15 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'editor',
     searchKeywords: ['shortcut', 'editor', 'markdown', 'preview'],
     defaultBindings: platformBindings(['Mod+Shift+V'])
+  },
+  {
+    id: 'editor.toggleWordWrap',
+    title: 'Toggle Word Wrap',
+    group: 'Editors',
+    scope: 'editor',
+    searchKeywords: ['shortcut', 'editor', 'word wrap', 'wrap', 'long lines', 'soft wrap'],
+    // Why: Alt+Z matches VS Code; bare Alt+letter is not AltGr, so it stays cross-platform (#9974).
+    defaultBindings: platformBindings(['Alt+Z'])
   },
   {
     id: 'editor.copyContext',


### PR DESCRIPTION
## Summary

Long single-line / structured files wrap by default in the editor, which misaligns table-like content (#9974). Diff surfaces already had a Word Wrap checkbox; normal file tabs only had Settings → Editor Word Wrap.

This PR:

- Always shows **Word Wrap** on the editor more-actions (⋯) menu for normal files (toggles `editorWordWrap`)
- Keeps the existing diff Word Wrap control for diff surfaces (`diffWordWrap`)
- Adds `editor.toggleWordWrap` with default **Alt+Z** (VS Code-style) when an editor tab is active

## Screenshots

- Open a code file → ⋯ menu → **Word Wrap** checkbox (on by default)
- Uncheck / press Alt+Z → long lines scroll horizontally instead of wrapping

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/EditorPanelMarkdownActionsMenu.test.tsx src/shared/keybindings.test.ts` (69/69)
- [ ] Full lint / typecheck / suite

## AI Review Report

- Cross-platform: `Alt+Z` via `platformBindings` (not Ctrl+Alt / AltGr)
- No path/SSH/IPC changes
- Diff wrap preference stays independent of file wrap

## Security Audit

- Settings toggle + keybinding only; no new IPC

## Notes

- Settings → Editor Word Wrap remains the durable preference; the menu/chord are discoverability

Fixes #9974