### PR TITLE
fix(sidebar): do not sticky-pin Project header without mounted geometry

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts
@@ -127,6 +127,45 @@ describe('getActiveStickyIndexesForScroll', () => {
       })
     ).toEqual({ hostIndex: null, groupIndex: 0 })
   })
+
+  it('does not pin a Project header whose virtual item is not mounted yet (#10088)', () => {
+    // Why: after scrollToIndex/reveal, rangeStart can sit on group-b1 while
+    // TanStack has only mounted host-b (and maybe a later item) this frame.
+    const partialItems = [virtualItem(4, 400), virtualItem(6, 600)]
+    const result = getActiveStickyIndexesForScroll({
+      rows,
+      rangeStartIndex: 5,
+      scrollOffset: 500,
+      stickyHeaderIndexes,
+      virtualItems: partialItems
+    })
+    expect(result.hostIndex).toBe(4)
+    // group-b1 (index 5) must not become sticky without geometry — that is what
+    // paints the project label across the host card.
+    expect(result.groupIndex).toBeNull()
+  })
+
+  it('keeps the previous mounted Project sticky when the next group is unmounted', () => {
+    const multiGroupRows: RenderRow[] = [
+      hostRow('a'),
+      groupRow('a1'),
+      itemStub('wt-1'),
+      groupRow('a2'),
+      itemStub('wt-2')
+    ]
+    const multiSticky = getStickyHeaderIndexes(multiGroupRows)
+    // rangeStart points at a2 (index 3) but only host + a1 + item are mounted.
+    const partialItems = [virtualItem(0, 0), virtualItem(1, 100), virtualItem(2, 200)]
+    const result = getActiveStickyIndexesForScroll({
+      rows: multiGroupRows,
+      rangeStartIndex: 3,
+      scrollOffset: 250,
+      stickyHeaderIndexes: multiSticky,
+      virtualItems: partialItems
+    })
+    expect(result.hostIndex).toBe(0)
+    expect(result.groupIndex).toBe(1)
+  })
 })
 
 describe('extractWorktreeVirtualRowIndexes', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-virtual-rows.ts
@@ -155,7 +155,18 @@ export function getActiveStickyIndexesForScroll(args: {
     }
     const candidate = args.virtualItems.find((item) => item.index === candidateIndex)
     if (!candidate) {
-      return candidateIndex
+      // Why: scrollToIndex/reveal can advance rangeStartIndex before TanStack
+      // mounts the candidate row. Pinning without geometry lets a Project
+      // sticky paint over the Host card (#10088). Prefer a previous mounted
+      // sticky; group tier waits for geometry, host tier may keep the id.
+      const previous = getPreviousStickyHeaderIndex(candidates, candidateIndex)
+      if (previous !== null) {
+        const previousItem = args.virtualItems.find((item) => item.index === previous)
+        if (previousItem) {
+          return previous
+        }
+      }
+      return fallbackToCandidate ? candidateIndex : null
     }
     // Why: hand off the moment the incoming header reaches its pinned slot
     // (top of the viewport, or the bottom edge of the pinned host card).


### PR DESCRIPTION
# fix(sidebar): do not sticky-pin Project header without mounted geometry

## Summary

Fixes the multi-host Projects sidebar painting a project-group sticky header over the host card when revealing or scrolling to a workspace (#10088).

## ELI5

In the sidebar, jumping to a project under a host could make the project's name label overlap and cover the host's card. This makes the sticky labels stay in the right place while you scroll.

## Root cause & fix

`getActiveStickyIndexesForScroll` → `resolveWithHandoff` returned the candidate sticky header index even when that virtual row wasn't mounted yet — which happens when `scrollToIndex`/reveal advances `rangeStartIndex` before TanStack mounts the row. A Project sticky then activated without any geometry while the Host sticky was still active. The fix now prefers a previously-mounted sticky header when the candidate is unmounted, and only falls back to the raw candidate when `fallbackToCandidate` is true (host tier). The group tier (`fallbackToCandidate=false`) returns `null` instead of pinning without geometry.

## Evidence

Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.

- Test file: `src/renderer/src/components/sidebar/worktree-list-virtual-rows.test.ts`
- On branch: **9/9 passed** (1 file). With the fix reverted (test kept): **2 failed | 7 passed**, proving the tests catch the regression.
- Failing assertions when fix reverted:

```
✗ does not pin a Project header whose virtual item is not mounted yet (#10088)
    AssertionError: expected 5 to be null (groupIndex was 5)
✗ keeps the previous mounted Project sticky when the next group is unmounted
    AssertionError: expected 3 to be 1 (groupIndex was 3, should hold previous)
```

- Lint: `oxlint` clean (no warnings/errors) on the fix file.
- Rebase: clean onto `origin/main`.

## Trade-offs

None — pure fix. Host tier retains its legacy fallback so a re-mounting host section keeps sticky identity.

## Regression risk

Effectively zero. Only the branch that handled an unmounted candidate changes; every path with a mounted candidate or a truthy `fallbackToCandidate` behaves identically. The host tier is byte-for-byte preserved, and the passing test proves both the new group-tier and previous-sticky-hold behaviors.

---

*Original fix by @innocarpe. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
