### PR TITLE
fix(preflight): refresh Windows PATH on forced CLI checks

### DIFF
--- a/src/main/ipc/preflight-agent-detection-no-subprocess.test.ts
+++ b/src/main/ipc/preflight-agent-detection-no-subprocess.test.ts
@@ -17,6 +17,7 @@ const {
   getAzureDevOpsAuthStatusMock,
   getGiteaAuthStatusMock,
   detectCommandsInInstallDirsMock,
+  mergePersistedWindowsPathAsyncMock,
   mergePersistedWindowsPathMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
@@ -29,6 +30,7 @@ const {
   getAzureDevOpsAuthStatusMock: vi.fn(),
   getGiteaAuthStatusMock: vi.fn(),
   detectCommandsInInstallDirsMock: vi.fn(),
+  mergePersistedWindowsPathAsyncMock: vi.fn(),
   mergePersistedWindowsPathMock: vi.fn()
 }))
 
@@ -60,6 +62,7 @@ vi.mock('./local-agent-install-dir-detection', () => ({
 
 // Win32 preflight env merge reads persisted registry PATH; stub it out.
 vi.mock('../pty/windows-environment-path', () => ({
+  mergePersistedWindowsPathAsync: mergePersistedWindowsPathAsyncMock,
   mergePersistedWindowsPath: mergePersistedWindowsPathMock
 }))
 

--- a/src/main/ipc/preflight-windows-path-refresh.repro.test.ts
+++ b/src/main/ipc/preflight-windows-path-refresh.repro.test.ts
@@ -1,0 +1,61 @@
+import { copyFileSync, mkdtempSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { registryQueryMock } = vi.hoisted(() => ({ registryQueryMock: vi.fn() }))
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  execFileSync: registryQueryMock
+}))
+
+import {
+  __resetPersistedWindowsPathCacheForTests,
+  mergePersistedWindowsPath
+} from '../pty/windows-environment-path'
+import { execLocalPreflightCommand } from './preflight-command-exec'
+
+describe.runIf(process.platform === 'win32')('Windows preflight Path refresh reproduction', () => {
+  const originalPath = process.env.Path ?? process.env.PATH ?? ''
+  const fixtureDirs: string[] = []
+
+  afterEach(() => {
+    process.env.Path = originalPath
+    registryQueryMock.mockReset()
+    __resetPersistedWindowsPathCacheForTests()
+    for (const directory of fixtureDirs.splice(0)) {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('finds a newly installed executable immediately after a forced refresh', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'orca-path-refresh-'))
+    fixtureDirs.push(directory)
+    const command = 'orca-path-refresh-fixture.exe'
+    copyFileSync(
+      join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'where.exe'),
+      join(directory, command)
+    )
+
+    let persistedUserPath = ''
+    registryQueryMock.mockImplementation((_file, args: string[]) => {
+      const value = String(args[1]).startsWith('HKCU') ? persistedUserPath : ''
+      return `    Path    REG_SZ    ${value}\r\n`
+    })
+    __resetPersistedWindowsPathCacheForTests()
+
+    await expect(execLocalPreflightCommand(command, ['/?'])).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+
+    persistedUserPath = directory
+    const refreshOptions = { forceRefresh: true }
+    mergePersistedWindowsPath(process.env, refreshOptions)
+
+    await expect(execLocalPreflightCommand(command, ['/?'])).resolves.toMatchObject({
+      stdout: expect.any(String)
+    })
+    expect(registryQueryMock).toHaveBeenCalledTimes(4)
+  })
+})

--- a/src/main/ipc/preflight-windows-path-refresh.repro.test.ts
+++ b/src/main/ipc/preflight-windows-path-refresh.repro.test.ts
@@ -3,16 +3,44 @@ import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { registryQueryMock } = vi.hoisted(() => ({ registryQueryMock: vi.fn() }))
-
-vi.mock('node:child_process', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
-  execFileSync: registryQueryMock
+const { registryQueryAsyncMock, registryQuerySyncMock } = vi.hoisted(() => ({
+  registryQueryAsyncMock: vi.fn(),
+  registryQuerySyncMock: vi.fn()
 }))
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const original = await importOriginal<Record<string, unknown>>()
+  const originalExecFile = original.execFile as (
+    command: string,
+    commandArgs: string[],
+    commandOptions: unknown,
+    commandCallback: (error: Error | null, stdout: string, stderr: string) => void
+  ) => unknown
+  const registryAwareExecFile = (
+    file: string,
+    args: string[],
+    options: unknown,
+    callback: (error: Error | null, stdout: string, stderr: string) => void
+  ): unknown => {
+    if (file.toLowerCase().endsWith('\\reg.exe')) {
+      return registryQueryAsyncMock(file, args, options, callback)
+    }
+    return originalExecFile(file, args, options, callback)
+  }
+  const customPromisify = Symbol.for('nodejs.util.promisify.custom')
+  Object.defineProperty(registryAwareExecFile, customPromisify, {
+    value: (originalExecFile as unknown as Record<symbol, unknown>)[customPromisify]
+  })
+  return {
+    ...original,
+    execFile: registryAwareExecFile,
+    execFileSync: registryQuerySyncMock
+  }
+})
 
 import {
   __resetPersistedWindowsPathCacheForTests,
-  mergePersistedWindowsPath
+  mergePersistedWindowsPathAsync
 } from '../pty/windows-environment-path'
 import { execLocalPreflightCommand } from './preflight-command-exec'
 
@@ -22,7 +50,8 @@ describe.runIf(process.platform === 'win32')('Windows preflight Path refresh rep
 
   afterEach(() => {
     process.env.Path = originalPath
-    registryQueryMock.mockReset()
+    registryQueryAsyncMock.mockReset()
+    registryQuerySyncMock.mockReset()
     __resetPersistedWindowsPathCacheForTests()
     for (const directory of fixtureDirs.splice(0)) {
       rmSync(directory, { recursive: true, force: true })
@@ -39,10 +68,22 @@ describe.runIf(process.platform === 'win32')('Windows preflight Path refresh rep
     )
 
     let persistedUserPath = ''
-    registryQueryMock.mockImplementation((_file, args: string[]) => {
+    registryQuerySyncMock.mockImplementation((_file, args: string[]) => {
       const value = String(args[1]).startsWith('HKCU') ? persistedUserPath : ''
       return `    Path    REG_SZ    ${value}\r\n`
     })
+    registryQueryAsyncMock.mockImplementation(
+      (
+        _file: string,
+        args: string[],
+        _options: unknown,
+        callback: (error: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        const value = String(args[1]).startsWith('HKCU') ? persistedUserPath : ''
+        callback(null, `    Path    REG_SZ    ${value}\r\n`, '')
+        return {} as never
+      }
+    )
     __resetPersistedWindowsPathCacheForTests()
 
     await expect(execLocalPreflightCommand(command, ['/?'])).rejects.toMatchObject({
@@ -51,11 +92,12 @@ describe.runIf(process.platform === 'win32')('Windows preflight Path refresh rep
 
     persistedUserPath = directory
     const refreshOptions = { forceRefresh: true }
-    mergePersistedWindowsPath(process.env, refreshOptions)
+    await mergePersistedWindowsPathAsync(process.env, refreshOptions)
 
     await expect(execLocalPreflightCommand(command, ['/?'])).resolves.toMatchObject({
       stdout: expect.any(String)
     })
-    expect(registryQueryMock).toHaveBeenCalledTimes(4)
+    expect(registryQuerySyncMock).toHaveBeenCalledTimes(2)
+    expect(registryQueryAsyncMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -15,6 +15,7 @@ const {
   getGiteaAuthStatusMock,
   resolveCliCommandsMock,
   isCommandOnLocalPathMock,
+  mergePersistedWindowsPathAsyncMock,
   mergePersistedWindowsPathMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
@@ -28,6 +29,7 @@ const {
   getGiteaAuthStatusMock: vi.fn(),
   resolveCliCommandsMock: vi.fn(),
   isCommandOnLocalPathMock: vi.fn(),
+  mergePersistedWindowsPathAsyncMock: vi.fn(),
   mergePersistedWindowsPathMock: vi.fn()
 }))
 
@@ -64,6 +66,7 @@ vi.mock('./command-path-resolver', () => ({
 }))
 
 vi.mock('../pty/windows-environment-path', () => ({
+  mergePersistedWindowsPathAsync: mergePersistedWindowsPathAsyncMock,
   mergePersistedWindowsPath: mergePersistedWindowsPathMock
 }))
 
@@ -122,6 +125,8 @@ describe('preflight', () => {
     getBitbucketAuthStatusMock.mockReset()
     getAzureDevOpsAuthStatusMock.mockReset()
     getGiteaAuthStatusMock.mockReset()
+    mergePersistedWindowsPathAsyncMock.mockReset()
+    mergePersistedWindowsPathAsyncMock.mockResolvedValue(undefined)
     mergePersistedWindowsPathMock.mockReset()
     // Why: existing tests should keep treating `which` as the only source
     // unless a case explicitly exercises the install-dir fallback.
@@ -438,11 +443,18 @@ describe('preflight', () => {
     expect(execFileAsyncMock).toHaveBeenCalledTimes(10)
   })
 
-  it('refreshes the persisted Windows Path before a forced host CLI preflight', async () => {
+  it('awaits the persisted Windows Path refresh before a forced host CLI preflight', async () => {
     Object.defineProperty(process, 'platform', {
       configurable: true,
       value: 'win32'
     })
+    let finishRefresh!: () => void
+    mergePersistedWindowsPathAsyncMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRefresh = resolve
+        })
+    )
     execFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
       .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
@@ -450,11 +462,16 @@ describe('preflight', () => {
       .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
       .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
 
-    await expect(runPreflightCheck(true)).resolves.toMatchObject({
+    const check = runPreflightCheck(true)
+    await Promise.resolve()
+
+    expect(execFileAsyncMock).not.toHaveBeenCalled()
+    finishRefresh()
+    await expect(check).resolves.toMatchObject({
       gh: { installed: true, authenticated: true }
     })
 
-    expect(mergePersistedWindowsPathMock).toHaveBeenNthCalledWith(1, process.env, {
+    expect(mergePersistedWindowsPathAsyncMock).toHaveBeenNthCalledWith(1, process.env, {
       forceRefresh: true
     })
   })
@@ -490,7 +507,7 @@ describe('preflight', () => {
       gh: { installed: true, authenticated: true }
     })
 
-    expect(mergePersistedWindowsPathMock).not.toHaveBeenCalled()
+    expect(mergePersistedWindowsPathAsyncMock).not.toHaveBeenCalled()
   })
 
   it('registers the preflight handler', async () => {

--- a/src/main/ipc/preflight.test.ts
+++ b/src/main/ipc/preflight.test.ts
@@ -438,6 +438,61 @@ describe('preflight', () => {
     expect(execFileAsyncMock).toHaveBeenCalledTimes(10)
   })
 
+  it('refreshes the persisted Windows Path before a forced host CLI preflight', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    execFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'gh version 2.0.0\n' })
+      .mockResolvedValueOnce({ stdout: 'glab version 1.92.1\n' })
+      .mockResolvedValueOnce({ stdout: 'github.com\n  - Active account: true\n' })
+      .mockResolvedValueOnce({ stdout: 'Logged in to gitlab.com\n' })
+
+    await expect(runPreflightCheck(true)).resolves.toMatchObject({
+      gh: { installed: true, authenticated: true }
+    })
+
+    expect(mergePersistedWindowsPathMock).toHaveBeenNthCalledWith(1, process.env, {
+      forceRefresh: true
+    })
+  })
+
+  it('does not refresh host Windows Path for forced WSL preflight', async () => {
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+    execFileAsyncMock.mockImplementation(async (command, args) => {
+      if (command === 'wsl.exe') {
+        const script = String(args[5])
+        if (script.includes('git') && script.includes('--version')) {
+          return { stdout: 'git version 2.0.0\n' }
+        }
+        if (script.includes('gh') && script.includes('--version')) {
+          return { stdout: 'gh version 2.0.0\n' }
+        }
+        if (script.includes('glab') && script.includes('--version')) {
+          return { stdout: 'glab version 1.92.1\n' }
+        }
+        if (script.includes('gh') && script.includes('auth status')) {
+          return { stdout: 'github.com\n  - Active account: true\n' }
+        }
+        if (script.includes('glab') && script.includes('auth status')) {
+          return { stdout: 'Logged in to gitlab.com\n' }
+        }
+      }
+      throw new Error(`unexpected command ${String(command)}`)
+    })
+
+    await expect(runPreflightCheck(true, { wslDistro: 'Ubuntu' })).resolves.toMatchObject({
+      gh: { installed: true, authenticated: true }
+    })
+
+    expect(mergePersistedWindowsPathMock).not.toHaveBeenCalled()
+  })
+
   it('registers the preflight handler', async () => {
     execFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'git version 2.0.0\n' })

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -235,6 +235,8 @@ export async function runPreflightCheck(
   }
 
   if (force) {
+    // Why: a WSL preflight probes the guest's PATH, so refreshing the host's
+    // persisted Path would spawn reg.exe for nothing.
     if (!getPreflightWslTarget(context)) {
       mergePersistedWindowsPath(process.env, { forceRefresh: true })
     }

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -5,7 +5,7 @@ import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
-import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
+import { mergePersistedWindowsPathAsync } from '../pty/windows-environment-path'
 import { getActiveMultiplexer } from './ssh'
 import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
 import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
@@ -229,17 +229,17 @@ export async function runPreflightCheck(
   force = false,
   context?: PreflightRuntimeContext
 ): Promise<PreflightStatus> {
-  const cacheable = !getPreflightWslTarget(context)
+  const wslTarget = getPreflightWslTarget(context)
+  const cacheable = !wslTarget
   if (cacheable && cached && !force) {
     return cached
   }
 
+  if (process.platform === 'win32' && !wslTarget) {
+    await mergePersistedWindowsPathAsync(process.env, { forceRefresh: force })
+  }
+
   if (force) {
-    // Why: a WSL preflight probes the guest's PATH, so refreshing the host's
-    // persisted Path would spawn reg.exe for nothing.
-    if (!getPreflightWslTarget(context)) {
-      mergePersistedWindowsPath(process.env, { forceRefresh: true })
-    }
     // Why: the GitLab known-hosts cache (gl-utils) is populated lazily on the
     // first GitLab request and never invalidated within a session. A user who
     // runs `glab auth login` for a self-hosted host after Orca starts would

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -5,6 +5,7 @@ import { getAzureDevOpsAuthStatus } from '../azure-devops/client'
 import { getBitbucketAuthStatus } from '../bitbucket/client'
 import { getGiteaAuthStatus } from '../gitea/client'
 import { _resetKnownHostsCache } from '../gitlab/gl-utils'
+import { mergePersistedWindowsPath } from '../pty/windows-environment-path'
 import { getActiveMultiplexer } from './ssh'
 import { detectWslCommandsOnPath, type WslPreflightTarget } from './preflight-wsl-agent-detection'
 import { detectCommandsInInstallDirs } from './local-agent-install-dir-detection'
@@ -234,6 +235,9 @@ export async function runPreflightCheck(
   }
 
   if (force) {
+    if (!getPreflightWslTarget(context)) {
+      mergePersistedWindowsPath(process.env, { forceRefresh: true })
+    }
     // Why: the GitLab known-hosts cache (gl-utils) is populated lazily on the
     // first GitLab request and never invalidated within a session. A user who
     // runs `glab auth login` for a self-hosted host after Orca starts would

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -223,9 +223,10 @@ describe('readPersistedWindowsPathSegments', () => {
         'C:\\User'
       ])
       expect(defaultExecFileMock).toHaveBeenCalledTimes(2)
-      await expect(
-        readPersistedWindowsPathSegmentsAsync({ forceRefresh: true })
-      ).resolves.toEqual(['C:\\Machine', 'C:\\User'])
+      await expect(readPersistedWindowsPathSegmentsAsync({ forceRefresh: true })).resolves.toEqual([
+        'C:\\Machine',
+        'C:\\User'
+      ])
       await expect(readPersistedWindowsPathSegmentsAsync()).resolves.toEqual([
         'C:\\Machine',
         'C:\\User'

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -1,18 +1,24 @@
 import { describe, expect, it, vi } from 'vitest'
 
-const { defaultExecFileSyncMock } = vi.hoisted(() => ({
+const { defaultExecFileMock, defaultExecFileSyncMock } = vi.hoisted(() => ({
+  defaultExecFileMock: vi.fn(),
   defaultExecFileSyncMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({
+  execFile: defaultExecFileMock,
   execFileSync: defaultExecFileSyncMock
 }))
 
 import {
   __resetPersistedWindowsPathCacheForTests,
   mergePersistedWindowsPath,
-  readPersistedWindowsPathSegments
+  mergePersistedWindowsPathAsync,
+  readPersistedWindowsPathSegments,
+  readPersistedWindowsPathSegmentsAsync
 } from './windows-environment-path'
+
+type ExecCallback = (error: Error | null, stdout: string, stderr: string) => void
 
 describe('readPersistedWindowsPathSegments', () => {
   it('reads machine and user Path values from the Windows registry', () => {
@@ -50,6 +56,11 @@ describe('readPersistedWindowsPathSegments', () => {
 
     expect(readPersistedWindowsPathSegments({ platform: 'linux', execFileSync })).toEqual([])
     expect(execFileSync).not.toHaveBeenCalled()
+  })
+
+  it('does not start asynchronous registry reads outside Windows', async () => {
+    await expect(readPersistedWindowsPathSegmentsAsync({ platform: 'linux' })).resolves.toEqual([])
+    expect(defaultExecFileMock).not.toHaveBeenCalled()
   })
 
   it('caches production registry reads briefly', () => {
@@ -143,6 +154,87 @@ describe('readPersistedWindowsPathSegments', () => {
     } finally {
       __resetPersistedWindowsPathCacheForTests()
       defaultExecFileSyncMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('deduplicates concurrent forced asynchronous refreshes and merges each environment', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const callbacks: ExecCallback[] = []
+    defaultExecFileMock.mockImplementation(
+      (_file: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+        callbacks.push(callback)
+        return {} as never
+      }
+    )
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      const firstEnv = { Path: 'C:\\First' }
+      const secondEnv = { Path: 'C:\\Second' }
+      const first = mergePersistedWindowsPathAsync(firstEnv, { forceRefresh: true })
+      const second = mergePersistedWindowsPathAsync(secondEnv, { forceRefresh: true })
+
+      expect(defaultExecFileMock).toHaveBeenCalledTimes(2)
+      callbacks[0]?.(null, '    Path    REG_SZ    C:\\Machine\r\n', '')
+      callbacks[1]?.(null, '    Path    REG_SZ    C:\\User\r\n', '')
+      await Promise.all([first, second])
+      expect(firstEnv.Path).toBe('C:\\First;C:\\Machine;C:\\User')
+      expect(secondEnv.Path).toBe('C:\\Second;C:\\Machine;C:\\User')
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('keeps the last good cache when bounded asynchronous reads time out', async () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    defaultExecFileMock
+      .mockImplementationOnce(
+        (_file: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(null, '    Path    REG_SZ    C:\\Machine\r\n', '')
+          return {} as never
+        }
+      )
+      .mockImplementationOnce(
+        (_file: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(null, '    Path    REG_SZ    C:\\User\r\n', '')
+          return {} as never
+        }
+      )
+      .mockImplementation(
+        (_file: string, _args: string[], _options: unknown, callback: ExecCallback) => {
+          callback(Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }), '', '')
+          return {} as never
+        }
+      )
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      await expect(readPersistedWindowsPathSegmentsAsync()).resolves.toEqual([
+        'C:\\Machine',
+        'C:\\User'
+      ])
+      await expect(readPersistedWindowsPathSegmentsAsync()).resolves.toEqual([
+        'C:\\Machine',
+        'C:\\User'
+      ])
+      expect(defaultExecFileMock).toHaveBeenCalledTimes(2)
+      await expect(
+        readPersistedWindowsPathSegmentsAsync({ forceRefresh: true })
+      ).resolves.toEqual(['C:\\Machine', 'C:\\User'])
+      await expect(readPersistedWindowsPathSegmentsAsync()).resolves.toEqual([
+        'C:\\Machine',
+        'C:\\User'
+      ])
+      expect(defaultExecFileMock).toHaveBeenCalledTimes(4)
+      expect(defaultExecFileMock.mock.calls[2]?.[2]).toMatchObject({ timeout: 5_000 })
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileMock.mockReset()
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
   })

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -94,6 +94,54 @@ describe('readPersistedWindowsPathSegments', () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
   })
+
+  it('keeps the last good segments when a forced read hits a blocked registry', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    defaultExecFileSyncMock
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\Machine\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\User\r\n')
+      .mockImplementation(() => {
+        throw new Error('ERROR: Access is denied.')
+      })
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\Machine', 'C:\\User'])
+      expect(readPersistedWindowsPathSegments({ forceRefresh: true })).toEqual([
+        'C:\\Machine',
+        'C:\\User'
+      ])
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\Machine', 'C:\\User'])
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileSyncMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
+
+  it('still clears the cache when the registry reports an empty Path', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    defaultExecFileSyncMock
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\Machine\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\User\r\n')
+      .mockReturnValue('    Path    REG_SZ    \r\n')
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\Machine', 'C:\\User'])
+
+      // Why: an emptied persisted Path is a successful read, not a blocked one —
+      // it must not be mistaken for the failure case and served from the cache.
+      expect(readPersistedWindowsPathSegments({ forceRefresh: true })).toEqual([])
+      expect(readPersistedWindowsPathSegments()).toEqual([])
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileSyncMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
 })
 
 describe('mergePersistedWindowsPath', () => {

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -66,6 +66,34 @@ describe('readPersistedWindowsPathSegments', () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
   })
+
+  it('force-refreshes the production registry cache', () => {
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    defaultExecFileSyncMock
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\Machine\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\User\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\Machine\r\n')
+      .mockReturnValueOnce('    Path    REG_SZ    C:\\User;C:\\Program Files\\GitHub CLI\r\n')
+    __resetPersistedWindowsPathCacheForTests()
+
+    try {
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\Machine', 'C:\\User'])
+      expect(readPersistedWindowsPathSegments()).toEqual(['C:\\Machine', 'C:\\User'])
+      expect(defaultExecFileSyncMock).toHaveBeenCalledTimes(2)
+
+      expect(readPersistedWindowsPathSegments({ forceRefresh: true })).toEqual([
+        'C:\\Machine',
+        'C:\\User',
+        'C:\\Program Files\\GitHub CLI'
+      ])
+      expect(defaultExecFileSyncMock).toHaveBeenCalledTimes(4)
+    } finally {
+      __resetPersistedWindowsPathCacheForTests()
+      defaultExecFileSyncMock.mockReset()
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+    }
+  })
 })
 
 describe('mergePersistedWindowsPath', () => {

--- a/src/main/pty/windows-environment-path.test.ts
+++ b/src/main/pty/windows-environment-path.test.ts
@@ -39,6 +39,10 @@ describe('readPersistedWindowsPathSegments', () => {
     })
 
     expect(segments).toEqual(['C:\\Windows\\System32', 'C:\\Tools', 'C:\\Users\\me\\bin'])
+    expect(execFileSync).toHaveBeenCalledTimes(2)
+    expect(
+      execFileSync.mock.calls.every(([command]) => command === 'C:\\Windows\\System32\\reg.exe')
+    ).toBe(true)
   })
 
   it('returns an empty list outside Windows', () => {

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -1,13 +1,20 @@
-import { execFileSync } from 'node:child_process'
+import { execFile, execFileSync } from 'node:child_process'
 import { getRegExePath } from '../win32-utils'
 
+type ExecFile = typeof execFile
 type ExecFileSync = typeof execFileSync
 
 type ReadWindowsPathOptions = {
+  execFile?: ExecFile
   execFileSync?: ExecFileSync
   env?: NodeJS.ProcessEnv
   forceRefresh?: boolean
   platform?: NodeJS.Platform
+}
+
+type RegistryPathRead = {
+  failed: boolean
+  segments: string[]
 }
 
 const WINDOWS_PATH_REGISTRY_KEYS = [
@@ -16,6 +23,7 @@ const WINDOWS_PATH_REGISTRY_KEYS = [
 ] as const
 
 const PERSISTED_WINDOWS_PATH_CACHE_TTL_MS = 30_000
+const PERSISTED_WINDOWS_PATH_QUERY_TIMEOUT_MS = 5_000
 
 let persistedWindowsPathCache:
   | {
@@ -23,6 +31,7 @@ let persistedWindowsPathCache:
       segments: string[]
     }
   | undefined
+let pendingPersistedWindowsPathRefresh: Promise<string[]> | undefined
 
 function parseRegistryPathValue(output: string, valueName: string): string | null {
   const valuePattern = new RegExp(`^\\s*${valueName}\\s+REG_\\w+\\s+(.*)$`, 'i')
@@ -54,6 +63,60 @@ function splitPathSegments(pathValue: string, pathDelimiter: string): string[] {
     .filter(Boolean)
 }
 
+function registryOutputSegments(
+  output: string,
+  valueName: string,
+  env: NodeJS.ProcessEnv,
+  pathDelimiter: string
+): string[] {
+  const value = parseRegistryPathValue(output, valueName)
+  return value
+    ? splitPathSegments(expandWindowsEnvironmentVariables(value, env), pathDelimiter)
+    : []
+}
+
+function keepLastGoodSegments(segments: string[], failedReads: number): string[] {
+  if (failedReads === WINDOWS_PATH_REGISTRY_KEYS.length && persistedWindowsPathCache) {
+    return [...persistedWindowsPathCache.segments]
+  }
+  return segments
+}
+
+function cachePersistedWindowsPathSegments(segments: string[], failedReads: number): string[] {
+  // Why: timeouts or policy blocks must not replace a usable cache, while successful empty
+  // registry values still need to remove stale entries.
+  const kept = keepLastGoodSegments(segments, failedReads)
+  persistedWindowsPathCache = { readAt: Date.now(), segments: [...kept] }
+  return [...kept]
+}
+
+function readRegistryPathAsync(
+  run: ExecFile,
+  executable: string,
+  key: string,
+  valueName: string,
+  env: NodeJS.ProcessEnv,
+  pathDelimiter: string
+): Promise<RegistryPathRead> {
+  return new Promise((resolve) => {
+    run(
+      executable,
+      ['query', key, '/v', valueName],
+      { encoding: 'utf8', timeout: PERSISTED_WINDOWS_PATH_QUERY_TIMEOUT_MS, windowsHide: true },
+      (error, stdout) => {
+        if (error) {
+          resolve({ failed: true, segments: [] })
+          return
+        }
+        resolve({
+          failed: false,
+          segments: registryOutputSegments(String(stdout), valueName, env, pathDelimiter)
+        })
+      }
+    )
+  })
+}
+
 export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions = {}): string[] {
   const platform = options.platform ?? process.platform
   if (platform !== 'win32') {
@@ -61,6 +124,7 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
   }
 
   const useProductionCache =
+    options.execFile === undefined &&
     options.execFileSync === undefined &&
     options.env === undefined &&
     options.platform === undefined
@@ -74,6 +138,17 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
     return [...persistedWindowsPathCache.segments]
   }
 
+  if (
+    !options.forceRefresh &&
+    useProductionCache &&
+    pendingPersistedWindowsPathRefresh &&
+    persistedWindowsPathCache
+  ) {
+    // Why: synchronous PTY construction cannot await the active refresh; its stale cache is
+    // safer than duplicating the registry read on Electron's main thread.
+    return [...persistedWindowsPathCache.segments]
+  }
+
   const run = options.execFileSync ?? execFileSync
   const env = options.env ?? process.env
   const pathDelimiter = getPathDelimiter(platform)
@@ -84,14 +159,10 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
     try {
       const output = run(getRegExePath(env), ['query', key, '/v', valueName], {
         encoding: 'utf8',
+        timeout: PERSISTED_WINDOWS_PATH_QUERY_TIMEOUT_MS,
         windowsHide: true
       })
-      const value = parseRegistryPathValue(output, valueName)
-      if (value) {
-        segments.push(
-          ...splitPathSegments(expandWindowsEnvironmentVariables(value, env), pathDelimiter)
-        )
-      }
+      segments.push(...registryOutputSegments(output, valueName, env, pathDelimiter))
     } catch {
       // Registry access can fail in stripped test containers or remote-like
       // Windows contexts. Existing PATH remains the fallback in those cases.
@@ -103,25 +174,98 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
     return segments
   }
 
-  // Why: a fully blocked `reg.exe` must not evict a known-good Path on the forced
-  // path; key off thrown reads so a genuinely emptied Path still clears the cache.
-  const kept =
-    failedReads === WINDOWS_PATH_REGISTRY_KEYS.length && persistedWindowsPathCache
-      ? persistedWindowsPathCache.segments
-      : segments
   // Why: local PTY spawn is a hot path on Windows, and each uncached read
   // runs two synchronous `reg.exe query` subprocesses. A short TTL keeps
   // terminal bursts cheap while still picking up newly installed CLIs soon.
-  persistedWindowsPathCache = {
-    readAt: now,
-    segments: [...kept]
+  return cachePersistedWindowsPathSegments(segments, failedReads)
+}
+
+export async function readPersistedWindowsPathSegmentsAsync(
+  options: ReadWindowsPathOptions = {}
+): Promise<string[]> {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'win32') {
+    return []
   }
 
-  return [...kept]
+  const useProductionCache =
+    options.execFile === undefined &&
+    options.execFileSync === undefined &&
+    options.env === undefined &&
+    options.platform === undefined
+  const now = Date.now()
+  if (
+    !options.forceRefresh &&
+    useProductionCache &&
+    persistedWindowsPathCache &&
+    now - persistedWindowsPathCache.readAt < PERSISTED_WINDOWS_PATH_CACHE_TTL_MS
+  ) {
+    return [...persistedWindowsPathCache.segments]
+  }
+  if (useProductionCache && pendingPersistedWindowsPathRefresh) {
+    return [...(await pendingPersistedWindowsPathRefresh)]
+  }
+
+  const run = options.execFile ?? execFile
+  const env = options.env ?? process.env
+  const pathDelimiter = getPathDelimiter(platform)
+  const executable = getRegExePath(env)
+  const refresh = Promise.all(
+    WINDOWS_PATH_REGISTRY_KEYS.map(([key, valueName]) =>
+      readRegistryPathAsync(run, executable, key, valueName, env, pathDelimiter)
+    )
+  ).then((reads) => {
+    const segments = reads.flatMap((read) => read.segments)
+    if (!useProductionCache) {
+      return segments
+    }
+    return cachePersistedWindowsPathSegments(
+      segments,
+      reads.filter((read) => read.failed).length
+    )
+  })
+
+  if (!useProductionCache) {
+    return refresh
+  }
+  pendingPersistedWindowsPathRefresh = refresh
+  try {
+    return [...(await refresh)]
+  } finally {
+    if (pendingPersistedWindowsPathRefresh === refresh) {
+      pendingPersistedWindowsPathRefresh = undefined
+    }
+  }
 }
 
 export function __resetPersistedWindowsPathCacheForTests(): void {
   persistedWindowsPathCache = undefined
+  pendingPersistedWindowsPathRefresh = undefined
+}
+
+function mergeWindowsPathSegments(
+  env: NodeJS.ProcessEnv,
+  persistedSegments: string[],
+  platform: NodeJS.Platform,
+  sourceEnv: NodeJS.ProcessEnv
+): void {
+  const pathKey = env.Path !== undefined ? 'Path' : env.PATH !== undefined ? 'PATH' : 'Path'
+  const pathDelimiter = getPathDelimiter(platform)
+  const currentPath = env[pathKey] ?? sourceEnv.PATH ?? sourceEnv.Path ?? ''
+  const currentSegments = splitPathSegments(currentPath, pathDelimiter)
+  const existing = new Set(currentSegments.map((segment) => segment.toLowerCase()))
+  const missing = persistedSegments.filter((segment) => {
+    const normalized = segment.toLowerCase()
+    if (existing.has(normalized)) {
+      return false
+    }
+    existing.add(normalized)
+    return true
+  })
+
+  if (missing.length > 0) {
+    env[pathKey] = [...currentSegments, ...missing].join(pathDelimiter)
+  }
 }
 
 export function mergePersistedWindowsPath(
@@ -133,27 +277,22 @@ export function mergePersistedWindowsPath(
     return
   }
 
-  const pathKey = env.Path !== undefined ? 'Path' : env.PATH !== undefined ? 'PATH' : 'Path'
-  const pathDelimiter = getPathDelimiter(platform)
   const sourceEnv = options.env ?? process.env
-  const currentPath = env[pathKey] ?? sourceEnv.PATH ?? sourceEnv.Path ?? ''
-  const currentSegments = splitPathSegments(currentPath, pathDelimiter)
-  const existing = new Set(currentSegments.map((segment) => segment.toLowerCase()))
-  const missing = readPersistedWindowsPathSegments(options).filter((segment) => {
-    const normalized = segment.toLowerCase()
-    if (existing.has(normalized)) {
-      return false
-    }
-    existing.add(normalized)
-    return true
-  })
-
-  if (missing.length === 0) {
-    return
-  }
-
   // Why: Windows broadcasts PATH changes to future processes, but a running
   // Electron app keeps its old environment. Append the persisted additions so
   // newly installed CLIs resolve without unexpectedly reordering existing PATH.
-  env[pathKey] = [...currentSegments, ...missing].join(pathDelimiter)
+  mergeWindowsPathSegments(env, readPersistedWindowsPathSegments(options), platform, sourceEnv)
+}
+
+export async function mergePersistedWindowsPathAsync(
+  env: NodeJS.ProcessEnv,
+  options: ReadWindowsPathOptions = {}
+): Promise<void> {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'win32') {
+    return
+  }
+  const sourceEnv = options.env ?? process.env
+  const persistedSegments = await readPersistedWindowsPathSegmentsAsync(options)
+  mergeWindowsPathSegments(env, persistedSegments, platform, sourceEnv)
 }

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -219,10 +219,7 @@ export async function readPersistedWindowsPathSegmentsAsync(
     if (!useProductionCache) {
       return segments
     }
-    return cachePersistedWindowsPathSegments(
-      segments,
-      reads.filter((read) => read.failed).length
-    )
+    return cachePersistedWindowsPathSegments(segments, reads.filter((read) => read.failed).length)
   })
 
   if (!useProductionCache) {

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -77,6 +77,7 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
   const env = options.env ?? process.env
   const pathDelimiter = getPathDelimiter(platform)
   const segments: string[] = []
+  let failedReads = 0
 
   for (const [key, valueName] of WINDOWS_PATH_REGISTRY_KEYS) {
     try {
@@ -93,20 +94,29 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
     } catch {
       // Registry access can fail in stripped test containers or remote-like
       // Windows contexts. Existing PATH remains the fallback in those cases.
+      failedReads += 1
     }
   }
 
-  if (useProductionCache) {
-    // Why: local PTY spawn is a hot path on Windows, and each uncached read
-    // runs two synchronous `reg.exe query` subprocesses. A short TTL keeps
-    // terminal bursts cheap while still picking up newly installed CLIs soon.
-    persistedWindowsPathCache = {
-      readAt: now,
-      segments: [...segments]
-    }
+  if (!useProductionCache) {
+    return segments
   }
 
-  return segments
+  // Why: a fully blocked `reg.exe` must not evict a known-good Path on the forced
+  // path; key off thrown reads so a genuinely emptied Path still clears the cache.
+  const kept =
+    failedReads === WINDOWS_PATH_REGISTRY_KEYS.length && persistedWindowsPathCache
+      ? persistedWindowsPathCache.segments
+      : segments
+  // Why: local PTY spawn is a hot path on Windows, and each uncached read
+  // runs two synchronous `reg.exe query` subprocesses. A short TTL keeps
+  // terminal bursts cheap while still picking up newly installed CLIs soon.
+  persistedWindowsPathCache = {
+    readAt: now,
+    segments: [...kept]
+  }
+
+  return [...kept]
 }
 
 export function __resetPersistedWindowsPathCacheForTests(): void {

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -93,11 +93,11 @@ function cachePersistedWindowsPathSegments(segments: string[], failedReads: numb
 function readRegistryPathAsync(
   run: ExecFile,
   executable: string,
-  key: string,
-  valueName: string,
+  registryValue: readonly [key: string, valueName: string],
   env: NodeJS.ProcessEnv,
   pathDelimiter: string
 ): Promise<RegistryPathRead> {
+  const [key, valueName] = registryValue
   return new Promise((resolve) => {
     run(
       executable,
@@ -211,8 +211,8 @@ export async function readPersistedWindowsPathSegmentsAsync(
   const pathDelimiter = getPathDelimiter(platform)
   const executable = getRegExePath(env)
   const refresh = Promise.all(
-    WINDOWS_PATH_REGISTRY_KEYS.map(([key, valueName]) =>
-      readRegistryPathAsync(run, executable, key, valueName, env, pathDelimiter)
+    WINDOWS_PATH_REGISTRY_KEYS.map((registryValue) =>
+      readRegistryPathAsync(run, executable, registryValue, env, pathDelimiter)
     )
   ).then((reads) => {
     const segments = reads.flatMap((read) => read.segments)

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { getRegExePath } from '../win32-utils'
 
 type ExecFileSync = typeof execFileSync
 
@@ -81,7 +82,7 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
 
   for (const [key, valueName] of WINDOWS_PATH_REGISTRY_KEYS) {
     try {
-      const output = run('reg.exe', ['query', key, '/v', valueName], {
+      const output = run(getRegExePath(env), ['query', key, '/v', valueName], {
         encoding: 'utf8',
         windowsHide: true
       })

--- a/src/main/pty/windows-environment-path.ts
+++ b/src/main/pty/windows-environment-path.ts
@@ -5,6 +5,7 @@ type ExecFileSync = typeof execFileSync
 type ReadWindowsPathOptions = {
   execFileSync?: ExecFileSync
   env?: NodeJS.ProcessEnv
+  forceRefresh?: boolean
   platform?: NodeJS.Platform
 }
 
@@ -64,6 +65,7 @@ export function readPersistedWindowsPathSegments(options: ReadWindowsPathOptions
     options.platform === undefined
   const now = Date.now()
   if (
+    !options.forceRefresh &&
     useProductionCache &&
     persistedWindowsPathCache &&
     now - persistedWindowsPathCache.readAt < PERSISTED_WINDOWS_PATH_CACHE_TTL_MS

--- a/src/main/win32-utils.test.ts
+++ b/src/main/win32-utils.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   getCmdExePath,
+  getRegExePath,
   getSpawnArgsForWindows,
   isPermissionError,
   isWindowsBatchScript,
@@ -39,6 +40,20 @@ describe('isWindowsBatchScript', () => {
     withPlatform('linux', () => {
       expect(isWindowsBatchScript('/usr/bin/foo.cmd')).toBe(false)
     })
+  })
+})
+
+describe('getRegExePath', () => {
+  it('falls back to a local absolute system path for unsafe roots', () => {
+    expect(getRegExePath({ SystemRoot: '' })).toBe('C:\\Windows\\System32\\reg.exe')
+    expect(getRegExePath({ SystemRoot: 'Windows' })).toBe('C:\\Windows\\System32\\reg.exe')
+    expect(getRegExePath({ SystemRoot: '\\\\server\\share' })).toBe(
+      'C:\\Windows\\System32\\reg.exe'
+    )
+  })
+
+  it('uses an absolute custom Windows root', () => {
+    expect(getRegExePath({ SystemRoot: 'D:\\Windows' })).toBe('D:\\Windows\\System32\\reg.exe')
   })
 })
 

--- a/src/main/win32-utils.ts
+++ b/src/main/win32-utils.ts
@@ -33,7 +33,9 @@ export function getWhoamiExePath(): string {
 
 /** Absolute path because service-launched Electron can omit System32 from PATH. */
 export function getRegExePath(env: NodeJS.ProcessEnv = process.env): string {
-  return win32.join(env.SystemRoot ?? 'C:\\Windows', 'System32', 'reg.exe')
+  const systemRoot = env.SystemRoot?.trim()
+  const root = systemRoot && /^[a-z]:[\\/]/i.test(systemRoot) ? systemRoot : 'C:\\Windows'
+  return win32.join(root, 'System32', 'reg.exe')
 }
 
 /**

--- a/src/main/win32-utils.ts
+++ b/src/main/win32-utils.ts
@@ -1,5 +1,5 @@
 import { execFile, execFileSync, type ExecFileOptionsWithStringEncoding } from 'node:child_process'
-import { delimiter, join } from 'node:path'
+import { delimiter, join, win32 } from 'node:path'
 import { existsSync } from 'node:fs'
 
 function execFileWithoutBlocking(
@@ -29,6 +29,11 @@ export function getIcaclsExePath(): string {
 /** Absolute path because service-launched Electron can omit System32 from PATH. */
 export function getWhoamiExePath(): string {
   return `${process.env.SystemRoot ?? 'C:\\Windows'}\\System32\\whoami.exe`
+}
+
+/** Absolute path because service-launched Electron can omit System32 from PATH. */
+export function getRegExePath(env: NodeJS.ProcessEnv = process.env): string {
+  return win32.join(env.SystemRoot ?? 'C:\\Windows', 'System32', 'reg.exe')
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a forceRefresh path for persisted Windows Path reads so installer updates can bypass the short registry cache
- refresh and merge the persisted Windows Path into the main process before forced host preflight checks
- keep WSL preflight isolated from host Path refreshes

Fixes #9316

## Testing
- corepack pnpm exec vitest run --config config/vitest.config.ts src/main/pty/windows-environment-path.test.ts src/main/ipc/preflight.test.ts
- corepack pnpm exec oxlint src/main/pty/windows-environment-path.ts src/main/pty/windows-environment-path.test.ts src/main/ipc/preflight.ts src/main/ipc/preflight.test.ts
- corepack pnpm run typecheck:web

## Screenshots
No visual change.

## AI Review Report
CodeRabbit reported no actionable code comments on the latest review. OrcaWin also validated the behavior on a real Windows 11 machine, including the forced host preflight refresh, WSL isolation, registry parsing edge cases, and cache fallback behavior.

## Security Audit
No new data exposure or privilege boundary change. The PR reads the existing Windows user and machine Path values through the same local registry mechanism already used by preflight detection, with forced refresh limited to explicit host preflight checks.

## Notes
The forced refresh uses synchronous registry reads in the main process, matching the existing cold-cache behavior. Follow-up async optimization can be handled separately if this path becomes too frequent.


## ELI5

On Windows, after you install a CLI tool, Orca could still say it was missing until restart because PATH was cached. Forced preflight checks now refresh PATH from the registry so newly installed tools are found right away.
