### PR TITLE
fix(quick-open): opt-in follow symlinked directories (#9895)

### DIFF
--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -21,7 +21,8 @@ export async function listQuickOpenFiles(
   store: Store,
   excludePaths?: string[],
   signal?: AbortSignal,
-  maxResults?: number
+  maxResults?: number,
+  followSymlinks?: boolean
 ): Promise<string[]> {
   const authorizedRootPath = await resolveAuthorizedPath(rootPath, store)
   const localGitOptions = getLocalGitOptionsForRegisteredWorktree(
@@ -69,7 +70,8 @@ export async function listQuickOpenFiles(
     excludePathPrefixes,
     // On Windows, rg outputs '\\'-separated paths; force '/'. Also force on
     // macOS/Linux for idempotence — it's a no-op there.
-    forceSlashSeparator: sep === '\\'
+    forceSlashSeparator: sep === '\\',
+    followSymlinks
   })
 
   const runRg = (args: string[]): Promise<void> => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1035,6 +1035,7 @@ export function registerFilesystemHandlers(
         connectionId?: string
         excludePaths?: string[]
         requestToken?: string
+        followSymlinks?: boolean
       }
     ): Promise<string[]> => {
       const controller = listFilesCancellations.begin(event, args.requestToken)
@@ -1048,10 +1049,18 @@ export function registerFilesystemHandlers(
           // Why: forward excludePaths or nested linked worktrees get double-scanned over SSH, causing timeout-induced partial results.
           return await provider.listFiles(args.rootPath, {
             excludePaths: args.excludePaths,
-            signal: controller?.signal
+            signal: controller?.signal,
+            followSymlinks: args.followSymlinks
           })
         }
-        return await listQuickOpenFiles(args.rootPath, store, args.excludePaths, controller?.signal)
+        return await listQuickOpenFiles(
+          args.rootPath,
+          store,
+          args.excludePaths,
+          controller?.signal,
+          undefined,
+          args.followSymlinks
+        )
       } finally {
         listFilesCancellations.finish(event, args.requestToken, controller)
       }

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -302,7 +302,12 @@ export class SshFilesystemProvider implements IFilesystemProvider {
 
   async listFiles(
     rootPath: string,
-    options?: { excludePaths?: string[]; signal?: AbortSignal; maxResults?: number }
+    options?: {
+      excludePaths?: string[]
+      signal?: AbortSignal
+      maxResults?: number
+      followSymlinks?: boolean
+    }
   ): Promise<string[]> {
     const params: Record<string, unknown> = { rootPath }
     if (options?.excludePaths && options.excludePaths.length > 0) {
@@ -310,6 +315,9 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     }
     if (options?.maxResults !== undefined) {
       params.maxResults = options.maxResults
+    }
+    if (options?.followSymlinks) {
+      params.followSymlinks = true
     }
     // Why #7721: the signal lets a workspace switch send rpc.cancel so the
     // relay aborts the full-tree scan instead of stacking abandoned scans

--- a/src/main/providers/types.ts
+++ b/src/main/providers/types.ts
@@ -271,7 +271,12 @@ export type IFilesystemProvider = {
   search(opts: SearchOptions): Promise<SearchResult>
   listFiles(
     rootPath: string,
-    options?: { excludePaths?: string[]; signal?: AbortSignal; maxResults?: number }
+    options?: {
+      excludePaths?: string[]
+      signal?: AbortSignal
+      maxResults?: number
+      followSymlinks?: boolean
+    }
   ): Promise<string[]>
   scanWorkspaceSpace?(
     rootPath: string,

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -1604,7 +1604,7 @@ export class RuntimeFileCommands {
 
   async listRuntimeFiles(
     worktreeSelector: string,
-    options: { excludePaths?: string[] } = {}
+    options: { excludePaths?: string[]; followSymlinks?: boolean } = {}
   ): Promise<string[]> {
     const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
     const provider = target.connectionId ? getSshFilesystemProvider(target.connectionId) : null
@@ -1612,9 +1612,19 @@ export class RuntimeFileCommands {
       if (!provider) {
         return []
       }
-      return provider.listFiles(target.worktree.path, { excludePaths: options.excludePaths })
+      return provider.listFiles(target.worktree.path, {
+        excludePaths: options.excludePaths,
+        followSymlinks: options.followSymlinks
+      })
     }
-    return listQuickOpenFiles(target.worktree.path, this.host.requireStore(), options.excludePaths)
+    return listQuickOpenFiles(
+      target.worktree.path,
+      this.host.requireStore(),
+      options.excludePaths,
+      undefined,
+      undefined,
+      options.followSymlinks
+    )
   }
 
   async listRuntimeMarkdownDocuments(worktreeSelector: string): Promise<MarkdownDocument[]> {

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -165,7 +165,8 @@ const FileSearch = WorktreeSelector.extend({
 })
 
 const FileListAll = WorktreeSelector.extend({
-  excludePaths: z.array(z.string()).optional()
+  excludePaths: z.array(z.string()).optional(),
+  followSymlinks: z.boolean().optional()
 })
 
 const FileUnwatch = z.object({
@@ -378,7 +379,10 @@ export const FILE_METHODS: RpcAnyMethod[] = [
     name: 'files.listAll',
     params: FileListAll,
     handler: async (params, { runtime }) =>
-      runtime.listRuntimeFiles(params.worktree, { excludePaths: params.excludePaths })
+      runtime.listRuntimeFiles(params.worktree, {
+        excludePaths: params.excludePaths,
+        followSymlinks: params.followSymlinks
+      })
   }),
   defineMethod({
     name: 'files.listMarkdownDocuments',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2518,6 +2518,7 @@ export type PreloadApi = {
       connectionId?: string
       excludePaths?: string[]
       requestToken?: string
+      followSymlinks?: boolean
     }) => Promise<string[]>
     cancelListFiles: (args: { requestToken: string }) => Promise<void>
     search: (args: SearchOptions & { connectionId?: string }) => Promise<SearchResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2891,6 +2891,7 @@ const api = {
       connectionId?: string
       excludePaths?: string[]
       requestToken?: string
+      followSymlinks?: boolean
     }): Promise<string[]> => ipcRenderer.invoke('fs:listFiles', args),
     cancelListFiles: (args: { requestToken: string }): Promise<void> =>
       ipcRenderer.invoke('fs:cancelListFiles', args),

--- a/src/relay/fs-handler-list-files.ts
+++ b/src/relay/fs-handler-list-files.ts
@@ -29,9 +29,9 @@ export const LIST_FILES_TIMEOUT_MS = 25_000
 export function listFilesWithRg(
   rootPath: string,
   excludePathPrefixes: readonly string[] = [],
-  options: { signal?: AbortSignal; maxResults?: number } = {}
+  options: { signal?: AbortSignal; maxResults?: number; followSymlinks?: boolean } = {}
 ): Promise<string[]> {
-  const { signal, maxResults } = options
+  const { signal, maxResults, followSymlinks } = options
   if (signal?.aborted) {
     return Promise.reject(fileListingCancellationError(signal))
   }
@@ -50,7 +50,8 @@ export function listFilesWithRg(
       // emit root-relative-looking paths for filters, but they do not prune.
       searchRoot: '.',
       excludePathPrefixes,
-      forceSlashSeparator: true
+      forceSlashSeparator: true,
+      followSymlinks
     })
 
     const processLine = (rawLine: string): boolean => {

--- a/src/relay/fs-handler-readdir-fallback.ts
+++ b/src/relay/fs-handler-readdir-fallback.ts
@@ -24,12 +24,13 @@ import {
 export async function listFilesWithReaddir(
   rootPath: string,
   excludePathPrefixes: readonly string[] = [],
-  options: { signal?: AbortSignal; maxResults?: number } = {}
+  options: { signal?: AbortSignal; maxResults?: number; followSymlinks?: boolean } = {}
 ): Promise<string[]> {
   return listQuickOpenFilesWithReaddir(rootPath, {
     excludePathPrefixes,
     budget: createQuickOpenReaddirBudget(),
     maxResults: options.maxResults,
-    signal: options.signal
+    signal: options.signal,
+    followSymlinks: options.followSymlinks
   })
 }

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -367,14 +367,19 @@ export class FsHandler {
     // normalizes into root-relative prefixes; malformed input yields [] so
     // the request still succeeds (older apps omit the field entirely).
     const excludePathPrefixes = buildExcludePathPrefixes(rootPath, params.excludePaths)
+    // Opt-in (default off): follow in-root symlinked directories so Quick Open
+    // surfaces files reached through a link, matching the file tree. Off keeps
+    // the secure default where a symlink can't pull in content outside the root.
+    const followSymlinks = params.followSymlinks === true
     // Why #7721: full-tree scans are the relay's most expensive request; the
     // coordinator caps them at one per client, coalescing duplicates and
     // aborting a stale scan when the workspace changes or the host cancels.
     return this.listFilesScans.run({
       clientId: context?.clientId ?? 0,
-      key: JSON.stringify([rootPath, excludePathPrefixes, maxResults]),
+      key: JSON.stringify([rootPath, excludePathPrefixes, maxResults, followSymlinks]),
       signal: context?.signal,
-      start: (signal) => this.runListFilesScan(rootPath, excludePathPrefixes, signal, maxResults)
+      start: (signal) =>
+        this.runListFilesScan(rootPath, excludePathPrefixes, signal, maxResults, followSymlinks)
     })
   }
 
@@ -382,12 +387,13 @@ export class FsHandler {
     rootPath: string,
     excludePathPrefixes: string[],
     signal: AbortSignal,
-    maxResults?: number
+    maxResults?: number,
+    followSymlinks?: boolean
   ): Promise<string[]> {
     const rgAvailable = await checkRgAvailable()
     throwIfFileListingCancelled(signal)
     if (rgAvailable) {
-      return listFilesWithRg(rootPath, excludePathPrefixes, { signal, maxResults })
+      return listFilesWithRg(rootPath, excludePathPrefixes, { signal, maxResults, followSymlinks })
     }
     // Why: git ls-files only works inside git repos. Use rev-parse to detect
     // git ancestry — unlike checking for a local .git entry, this works from
@@ -422,7 +428,11 @@ export class FsHandler {
     // problem, so translate the opaque cap error into actionable guidance
     // the user can act on directly from the error toast.
     try {
-      return await listFilesWithReaddir(rootPath, excludePathPrefixes, { signal, maxResults })
+      return await listFilesWithReaddir(rootPath, excludePathPrefixes, {
+        signal,
+        maxResults,
+        followSymlinks
+      })
     } catch (err) {
       // Why: a cancelled scan is not an rg-availability problem; wrapping it
       // in install-rg guidance would surface bogus advice on the client.

--- a/src/renderer/src/components/quick-open-file-list.ts
+++ b/src/renderer/src/components/quick-open-file-list.ts
@@ -152,10 +152,12 @@ export function useRuntimeFileListForWorktree({
     activeTargetStatus === 'connecting' ||
     activeTargetStatus === 'deploying-relay' ||
     activeTargetStatus === 'reconnecting'
+  // Opt-in (default off): include files reachable through in-root symlinked dirs.
+  const followSymlinks = useAppStore((state) => state.settings?.quickOpenFollowSymlinks ?? false)
   const requestKey = useMemo(
     () =>
-      `${worktreePath ?? ''}\n${operationOwnerKey}\n${excludeRequest.key}\n${activeTargetStatus ?? ''}`,
-    [activeTargetStatus, excludeRequest.key, operationOwnerKey, worktreePath]
+      `${worktreePath ?? ''}\n${operationOwnerKey}\n${excludeRequest.key}\n${activeTargetStatus ?? ''}\n${followSymlinks}`,
+    [activeTargetStatus, excludeRequest.key, followSymlinks, operationOwnerKey, worktreePath]
   )
 
   useEffect(() => {
@@ -195,6 +197,7 @@ export function useRuntimeFileListForWorktree({
     void listRuntimeFiles(requestContext, {
       rootPath: worktreePath,
       excludePaths,
+      followSymlinks,
       requestToken
     })
       .then((result) => {
@@ -227,6 +230,7 @@ export function useRuntimeFileListForWorktree({
     enabled,
     excludeRequest,
     connectionId,
+    followSymlinks,
     operationOwnerKey,
     operationRouteAvailable,
     requestKey,

--- a/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralEditorSettingsSection.tsx
@@ -18,6 +18,7 @@ import {
 import { translate } from '@/i18n/i18n'
 import { RichMarkdownSpellcheckSetting } from './RichMarkdownSpellcheckSetting'
 import { EditorWordWrapSetting } from './EditorWordWrapSetting'
+import { QuickOpenFollowSymlinksSetting } from './QuickOpenFollowSymlinksSetting'
 import { EditorFontFamilySetting } from './EditorFontFamilySetting'
 import {
   createAutoSaveDelayDraftState,
@@ -231,6 +232,8 @@ export function GeneralEditorSettingsSection({
       />
 
       <EditorWordWrapSetting settings={settings} updateSettings={updateSettings} />
+
+      <QuickOpenFollowSymlinksSetting settings={settings} updateSettings={updateSettings} />
 
       <SearchableSetting
         title={translate(

--- a/src/renderer/src/components/settings/QuickOpenFollowSymlinksSetting.tsx
+++ b/src/renderer/src/components/settings/QuickOpenFollowSymlinksSetting.tsx
@@ -1,0 +1,68 @@
+import type { GlobalSettings } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { SearchableSetting } from './SearchableSetting'
+import { Label } from '../ui/label'
+import { SettingsSegmentedControl } from './SettingsFormControls'
+
+type QuickOpenFollowSymlinksSettingProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+const TITLE_KEY =
+  'auto.components.settings.GeneralEditorSettingsSection.quickOpenFollowSymlinksTitle'
+const TITLE_FALLBACK = 'Quick Open Follows Symlinks'
+const DESCRIPTION_KEY =
+  'auto.components.settings.GeneralEditorSettingsSection.quickOpenFollowSymlinksDescription'
+const DESCRIPTION_FALLBACK =
+  'Include files inside symlinked directories in Quick Open (Cmd/Ctrl+P). Off by default because following symlinks can reach content outside the workspace.'
+
+export function QuickOpenFollowSymlinksSetting({
+  settings,
+  updateSettings
+}: QuickOpenFollowSymlinksSettingProps): React.JSX.Element {
+  return (
+    <SearchableSetting
+      title={translate(TITLE_KEY, TITLE_FALLBACK)}
+      description={translate(DESCRIPTION_KEY, DESCRIPTION_FALLBACK)}
+      keywords={[
+        'quick open',
+        'cmd+p',
+        'ctrl+p',
+        'symlink',
+        'symbolic link',
+        'file search',
+        'follow'
+      ]}
+      className="flex items-center justify-between gap-4 py-2"
+    >
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <Label>{translate(TITLE_KEY, TITLE_FALLBACK)}</Label>
+        <p className="text-xs text-muted-foreground">
+          {translate(DESCRIPTION_KEY, DESCRIPTION_FALLBACK)}
+        </p>
+      </div>
+      <SettingsSegmentedControl
+        ariaLabel={translate(TITLE_KEY, TITLE_FALLBACK)}
+        value={settings.quickOpenFollowSymlinks === true ? 'on' : 'off'}
+        onChange={(option) => updateSettings({ quickOpenFollowSymlinks: option === 'on' })}
+        options={[
+          {
+            value: 'off',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.bf16ef0af2',
+              'Off'
+            )
+          },
+          {
+            value: 'on',
+            label: translate(
+              'auto.components.settings.GeneralEditorSettingsSection.3f6892f307',
+              'On'
+            )
+          }
+        ]}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/QuickOpenFollowSymlinksSetting.tsx
+++ b/src/renderer/src/components/settings/QuickOpenFollowSymlinksSetting.tsx
@@ -17,6 +17,10 @@ const DESCRIPTION_KEY =
 const DESCRIPTION_FALLBACK =
   'Include files inside symlinked directories in Quick Open (Cmd/Ctrl+P). Off by default because following symlinks can reach content outside the workspace.'
 
+/**
+ * Settings toggle for `quickOpenFollowSymlinks`: when on, Quick Open descends
+ * into in-root symlinked directories. Off by default (secure default).
+ */
 export function QuickOpenFollowSymlinksSetting({
   settings,
   updateSettings

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5565,7 +5565,9 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
           "7ddd66fede": "Editor Word Wrap",
-          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling."
+          "9b18de6eea": "Wrap long lines in file editors instead of requiring horizontal scrolling.",
+          "quickOpenFollowSymlinksTitle": "Quick Open Follows Symlinks",
+          "quickOpenFollowSymlinksDescription": "Include files inside symlinked directories in Quick Open (Cmd/Ctrl+P). Off by default because following symlinks can reach content outside the workspace."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5542,7 +5542,9 @@
           "b82f86d7d2": "Corrector ortográfico de Rich Markdown",
           "5195f0b9ef": "Muestra subrayados y sugerencias ortográficas del navegador al editar Rich Markdown.",
           "7ddd66fede": "Ajuste de línea en el editor",
-          "9b18de6eea": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal."
+          "9b18de6eea": "Ajusta las líneas largas en editores de archivos en lugar de requerir desplazamiento horizontal.",
+          "quickOpenFollowSymlinksTitle": "Quick Open Follows Symlinks",
+          "quickOpenFollowSymlinksDescription": "Include files inside symlinked directories in Quick Open (Cmd/Ctrl+P). Off by default because following symlinks can reach content outside the workspace."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "localhost, 127.0.0.1, *.internal",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5527,7 +5527,9 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "Show browser spelling underlines and suggestions while editing rich Markdown.",
           "7ddd66fede": "エディターのワードラップ",
-          "9b18de6eea": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。"
+          "9b18de6eea": "水平スクロールを使わずに、ファイルエディターで長い行を折り返します。",
+          "quickOpenFollowSymlinksTitle": "Quick Open Follows Symlinks",
+          "quickOpenFollowSymlinksDescription": "Include files inside symlinked directories in Quick Open (Cmd/Ctrl+P). Off by default because following symlinks can reach content outside the workspace."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "ローカルホスト、127.0.0.1、*.internal",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5527,7 +5527,9 @@
           "b82f86d7d2": "리치 Markdown 맞춤법 검사",
           "5195f0b9ef": "리치 Markdown을 편집하는 동안 브라우저 맞춤법 밑줄과 제안을 표시합니다.",
           "7ddd66fede": "편집기 자동 줄 바꿈",
-          "9b18de6eea": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다."
+          "9b18de6eea": "가로 스크롤 대신 파일 편집기에서 긴 줄을 자동으로 줄 바꿈합니다.",
+          "quickOpenFollowSymlinksTitle": "Quick Open Follows Symlinks",
+          "quickOpenFollowSymlinksDescription": "Include files inside symlinked directories in Quick Open (Cmd/Ctrl+P). Off by default because following symlinks can reach content outside the workspace."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "로컬호스트, 127.0.0.1, *.internal",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5527,7 +5527,9 @@
           "b82f86d7d2": "Rich Markdown Spellcheck",
           "5195f0b9ef": "在编辑富 Markdown 时显示浏览器拼写下划线和建议。",
           "7ddd66fede": "编辑器自动换行",
-          "9b18de6eea": "在文件编辑器中自动换行长行，而无需水平滚动。"
+          "9b18de6eea": "在文件编辑器中自动换行长行，而无需水平滚动。",
+          "quickOpenFollowSymlinksTitle": "Quick Open Follows Symlinks",
+          "quickOpenFollowSymlinksDescription": "Include files inside symlinked directories in Quick Open (Cmd/Ctrl+P). Off by default because following symlinks can reach content outside the workspace."
         },
         "AdvancedNetworkSettingsSection": {
           "3e431564b5": "本地主机，127.0.0.1，*.internal",

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -740,7 +740,12 @@ export async function searchRuntimeFiles(
 
 export async function listRuntimeFiles(
   context: RuntimeFileOperationArgs,
-  args: { rootPath: string; excludePaths?: string[]; requestToken?: string }
+  args: {
+    rootPath: string
+    excludePaths?: string[]
+    requestToken?: string
+    followSymlinks?: boolean
+  }
 ): Promise<string[]> {
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind !== 'environment' || !context.worktreeId) {
@@ -748,7 +753,8 @@ export async function listRuntimeFiles(
       rootPath: args.rootPath,
       connectionId: context.connectionId,
       excludePaths: args.excludePaths,
-      requestToken: args.requestToken
+      requestToken: args.requestToken,
+      followSymlinks: args.followSymlinks
     })
   }
   return callRuntimeRpc<string[]>(
@@ -756,7 +762,8 @@ export async function listRuntimeFiles(
     'files.listAll',
     {
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
-      excludePaths: args.excludePaths
+      excludePaths: args.excludePaths,
+      followSymlinks: args.followSymlinks
     },
     { timeoutMs: 15_000 }
   )

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -196,6 +196,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     editorWordWrap: true,
     richMarkdownSpellcheckEnabled: true,
     markdownReviewToolsEnabled: true,
+    quickOpenFollowSymlinks: false,
     primarySelectionMiddleClickPaste: getDefaultPrimarySelectionMiddleClickPaste(),
     primarySelectionMiddleClickPasteDefaultedForLinux:
       typeof process !== 'undefined' && process.platform === 'linux',

--- a/src/shared/quick-open-filter.test.ts
+++ b/src/shared/quick-open-filter.test.ts
@@ -173,6 +173,33 @@ describe('buildRgArgsForQuickOpen', () => {
     // Glob metacharacters in a literal name must be escaped.
     expect(primary).toContain('!feature\\[1\\]')
   })
+
+  it('followSymlinks adds --follow to both passes', () => {
+    const { primary, ignoredPass } = buildRgArgsForQuickOpen({
+      searchRoot: '/root',
+      excludePathPrefixes: [],
+      forceSlashSeparator: false,
+      followSymlinks: true
+    })
+    expect(primary).toContain('--follow')
+    expect(ignoredPass).toContain('--follow')
+  })
+
+  it('followSymlinks omitted or false keeps --follow off (secure default)', () => {
+    for (const opts of [
+      { searchRoot: '/root', excludePathPrefixes: [], forceSlashSeparator: false },
+      {
+        searchRoot: '/root',
+        excludePathPrefixes: [],
+        forceSlashSeparator: false,
+        followSymlinks: false
+      }
+    ]) {
+      const { primary, ignoredPass } = buildRgArgsForQuickOpen(opts)
+      expect(primary).not.toContain('--follow')
+      expect(ignoredPass).not.toContain('--follow')
+    }
+  })
 })
 
 describe('normalizeQuickOpenRgLine', () => {

--- a/src/shared/quick-open-filter.ts
+++ b/src/shared/quick-open-filter.ts
@@ -203,6 +203,16 @@ export type RgArgsOptions = {
   excludePathPrefixes: readonly string[]
   /** On Windows rg emits `\\`-separated paths; pass true to force `/` output. */
   forceSlashSeparator: boolean
+  /**
+   * Opt-in: follow symlinked directories so files reached through an in-root
+   * symlink (e.g. a workspace that links a sibling notes vault into itself)
+   * become discoverable — matching what the file tree already shows. Off by
+   * default: `--follow` lets a symlink target content outside the authorized
+   * root, so enabling it is a deliberate user choice. rg's own symlink-loop
+   * detection guards against traversal cycles, and cwd-relative output keeps
+   * every emitted path rooted under the workspace.
+   */
+  followSymlinks?: boolean
 }
 
 export type RgArgs = {
@@ -215,10 +225,13 @@ export type RgArgs = {
 /**
  * Build the two rg arg arrays for Quick Open. Caller must spawn with `cwd: rootPath` — root-relative
  * globs are evaluated against rg's cwd, so omitting it silently breaks nested-worktree exclusions.
- * Deliberately omits `--follow` so symlinks can't escape the authorized root or cause traversal loops.
+ * Omits `--follow` unless `followSymlinks` is set: following symlinks lets a link's target escape the
+ * authorized root, so it is an explicit opt-in. When enabled, rg's built-in symlink-loop detection
+ * prevents traversal cycles and cwd-relative output keeps every emitted path rooted under the workspace.
  */
 export function buildRgArgsForQuickOpen(opts: RgArgsOptions): RgArgs {
   const sepArgs = opts.forceSlashSeparator ? ['--path-separator', '/'] : []
+  const followArgs = opts.followSymlinks ? ['--follow'] : []
   const hiddenDirGlobs = buildHiddenDirExcludeGlobs()
   const excludeGlobs: string[] = []
   for (const prefix of opts.excludePathPrefixes) {
@@ -230,6 +243,7 @@ export function buildRgArgsForQuickOpen(opts: RgArgsOptions): RgArgs {
   const primary = [
     '--files',
     '--hidden',
+    ...followArgs,
     ...sepArgs,
     ...hiddenDirGlobs,
     ...excludeGlobs,
@@ -241,6 +255,7 @@ export function buildRgArgsForQuickOpen(opts: RgArgsOptions): RgArgs {
     '--files',
     '--hidden',
     '--no-ignore-vcs',
+    ...followArgs,
     ...sepArgs,
     ...hiddenDirGlobs,
     ...excludeGlobs,

--- a/src/shared/quick-open-git-entry.ts
+++ b/src/shared/quick-open-git-entry.ts
@@ -17,6 +17,7 @@ export type QuickOpenGitLsFilesEntry = {
 
 const GIT_LS_FILES_STAGE_ENTRY = /^([0-7]{6}) [0-9a-f]{40,64} [0-3]\t/
 
+/** Parse one `git ls-files -s -z` line into its path plus gitlink/untracked-dir flags. */
 export function parseQuickOpenGitLsFilesEntry(entry: string): QuickOpenGitLsFilesEntry {
   const match = GIT_LS_FILES_STAGE_ENTRY.exec(entry)
   if (match) {
@@ -33,14 +34,17 @@ export function parseQuickOpenGitLsFilesEntry(entry: string): QuickOpenGitLsFile
   }
 }
 
+/** Join a root-relative POSIX path onto an absolute root, honoring the local separator. */
 export function joinRootRel(rootPath: string, relPath: string): string {
   return join(rootPath, ...relPath.split('/').filter(Boolean))
 }
 
+/** Strip trailing slashes so a git directory placeholder compares as a plain path. */
 export function normalizeGitEntry(entry: string): string {
   return entry.replace(/\/+$/, '')
 }
 
+/** True when `absPath` contains a `.git` dir or file — i.e. it is a nested repo root. */
 async function hasGitEntry(absPath: string): Promise<boolean> {
   try {
     const stat = await lstat(join(absPath, '.git'))
@@ -50,6 +54,10 @@ async function hasGitEntry(absPath: string): Promise<boolean> {
   }
 }
 
+/**
+ * Decide how Quick Open should treat one git ls-files entry: keep it as a file,
+ * fill it in as a nested repo, or drop it as a stale placeholder.
+ */
 export async function classifyQuickOpenGitEntry(
   rootPath: string,
   entry: string

--- a/src/shared/quick-open-git-entry.ts
+++ b/src/shared/quick-open-git-entry.ts
@@ -1,0 +1,83 @@
+/**
+ * Parsing and classification of `git ls-files` entries for Quick Open.
+ * Split out of quick-open-readdir-walk.ts to keep that module under the
+ * oxlint max-lines cap; the walk re-exports the public members so existing
+ * importers and tests keep their `./quick-open-readdir-walk` path.
+ */
+import { lstat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export type QuickOpenGitEntryKind = 'keep' | 'fill-nested-repo' | 'drop-placeholder'
+
+export type QuickOpenGitLsFilesEntry = {
+  path: string
+  isGitlink: boolean
+  isUntrackedDir: boolean
+}
+
+const GIT_LS_FILES_STAGE_ENTRY = /^([0-7]{6}) [0-9a-f]{40,64} [0-3]\t/
+
+export function parseQuickOpenGitLsFilesEntry(entry: string): QuickOpenGitLsFilesEntry {
+  const match = GIT_LS_FILES_STAGE_ENTRY.exec(entry)
+  if (match) {
+    return {
+      path: entry.slice(match[0].length),
+      isGitlink: match[1] === '160000',
+      isUntrackedDir: false
+    }
+  }
+  return {
+    path: entry,
+    isGitlink: false,
+    isUntrackedDir: entry.endsWith('/')
+  }
+}
+
+export function joinRootRel(rootPath: string, relPath: string): string {
+  return join(rootPath, ...relPath.split('/').filter(Boolean))
+}
+
+export function normalizeGitEntry(entry: string): string {
+  return entry.replace(/\/+$/, '')
+}
+
+async function hasGitEntry(absPath: string): Promise<boolean> {
+  try {
+    const stat = await lstat(join(absPath, '.git'))
+    return stat.isDirectory() || stat.isFile()
+  } catch {
+    return false
+  }
+}
+
+export async function classifyQuickOpenGitEntry(
+  rootPath: string,
+  entry: string
+): Promise<{ kind: QuickOpenGitEntryKind; relPath: string }> {
+  const parsed = parseQuickOpenGitLsFilesEntry(entry)
+  const relPath = normalizeGitEntry(parsed.path)
+  if (!relPath) {
+    return { kind: 'drop-placeholder', relPath }
+  }
+
+  if (!parsed.isGitlink && !parsed.isUntrackedDir) {
+    return { kind: 'keep', relPath }
+  }
+
+  let stat
+  try {
+    stat = await lstat(joinRootRel(rootPath, relPath))
+  } catch {
+    return { kind: 'drop-placeholder', relPath }
+  }
+
+  if (!stat.isDirectory()) {
+    return { kind: 'drop-placeholder', relPath }
+  }
+
+  if (await hasGitEntry(joinRootRel(rootPath, relPath))) {
+    return { kind: 'fill-nested-repo', relPath }
+  }
+
+  return { kind: 'drop-placeholder', relPath }
+}

--- a/src/shared/quick-open-readdir-walk.test.ts
+++ b/src/shared/quick-open-readdir-walk.test.ts
@@ -466,6 +466,46 @@ describe('quick-open readdir walk', () => {
     expect(files).not.toContain('linked-dir/file.ts')
   })
 
+  it('followSymlinks surfaces files inside a symlinked directory', async () => {
+    const root = await makeTempRoot()
+    await writeRel(root, 'src/index.ts')
+    await writeRel(root, 'target/file.ts')
+
+    try {
+      await symlink(join(root, 'target'), join(root, 'linked-dir'), 'dir')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        return
+      }
+      throw err
+    }
+
+    const files = await listQuickOpenFilesWithReaddir(root, { followSymlinks: true })
+    expect(files).toEqual(
+      expect.arrayContaining(['src/index.ts', 'target/file.ts', 'linked-dir/file.ts'])
+    )
+  })
+
+  it('followSymlinks does not loop when a symlink points back to an ancestor', async () => {
+    const root = await makeTempRoot()
+    await writeRel(root, 'src/index.ts')
+
+    try {
+      // Cycle: root/src/loop -> root. Without the realpath visited-set the walk
+      // would descend root → src → loop → root → … forever.
+      await symlink(root, join(root, 'src', 'loop'), 'dir')
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EPERM') {
+        return
+      }
+      throw err
+    }
+
+    const files = await listQuickOpenFilesWithReaddir(root, { followSymlinks: true })
+    // Terminates and still lists the real file; the cycle is entered at most once.
+    expect(files).toContain('src/index.ts')
+  })
+
   it('walks an explicitly selected symlinked workspace root', async () => {
     const targetRoot = await makeTempRoot()
     const linkContainer = await makeTempRoot()

--- a/src/shared/quick-open-readdir-walk.ts
+++ b/src/shared/quick-open-readdir-walk.ts
@@ -1,5 +1,6 @@
-import { lstat, readdir } from 'node:fs/promises'
+import { lstat, readdir, realpath, stat } from 'node:fs/promises'
 import { join, relative } from 'node:path'
+import { classifyQuickOpenGitEntry, joinRootRel, normalizeGitEntry } from './quick-open-git-entry'
 import { throwIfFileListingCancelled } from './file-listing-cancellation'
 import { isQuickOpenReadableDirectory } from './quick-open-directory-validation'
 import { collapseQuickOpenExpansionPaths } from './quick-open-expansion-paths'
@@ -21,51 +22,43 @@ export {
   QUICK_OPEN_READDIR_MAX_FILES,
   QUICK_OPEN_READDIR_TIMEOUT_MS
 } from './quick-open-readdir-budget'
+// Re-exported so existing importers/tests keep the './quick-open-readdir-walk' path
+// after the git-entry parsers moved to their own module (max-lines split).
+export {
+  classifyQuickOpenGitEntry,
+  parseQuickOpenGitLsFilesEntry,
+  type QuickOpenGitEntryKind,
+  type QuickOpenGitLsFilesEntry
+} from './quick-open-git-entry'
 
 const QUICK_OPEN_READDIR_CONCURRENCY = 32
 
-export type QuickOpenGitEntryKind = 'keep' | 'fill-nested-repo' | 'drop-placeholder'
-
-export type QuickOpenGitLsFilesEntry = {
-  path: string
-  isGitlink: boolean
-  isUntrackedDir: boolean
-}
-
-const GIT_LS_FILES_STAGE_ENTRY = /^([0-7]{6}) [0-9a-f]{40,64} [0-3]\t/
-
-export function parseQuickOpenGitLsFilesEntry(entry: string): QuickOpenGitLsFilesEntry {
-  const match = GIT_LS_FILES_STAGE_ENTRY.exec(entry)
-  if (match) {
-    return {
-      path: entry.slice(match[0].length),
-      isGitlink: match[1] === '160000',
-      isUntrackedDir: false
-    }
-  }
-  return {
-    path: entry,
-    isGitlink: false,
-    isUntrackedDir: entry.endsWith('/')
-  }
-}
-
 function shouldDescend(name: string): boolean {
   return name !== 'node_modules' && !HIDDEN_DIR_BLOCKLIST.has(name)
+}
+
+/**
+ * Resolve a symlink entry: returns its realpath when it points to a directory,
+ * else null. The realpath is what the cycle guard dedupes on, so a link and its
+ * target (or two links to the same target) are followed only once.
+ */
+async function resolveSymlinkedDirectory(absPath: string): Promise<string | null> {
+  try {
+    const target = await stat(absPath)
+    if (!target.isDirectory()) {
+      return null
+    }
+    return await realpath(absPath)
+  } catch {
+    // Broken link, permission denied, or a race — treat as non-followable.
+    return null
+  }
 }
 
 function toRelPath(rootPath: string, absPath: string): string {
   // Why: path.relative returns backslashes on Windows, while Quick Open paths
   // are always stored and matched with POSIX separators.
   return relative(rootPath, absPath).replace(/\\/g, '/')
-}
-
-function joinRootRel(rootPath: string, relPath: string): string {
-  return join(rootPath, ...relPath.split('/').filter(Boolean))
-}
-
-function normalizeGitEntry(entry: string): string {
-  return entry.replace(/\/+$/, '')
 }
 
 // Translate workspace-root-relative exclude prefixes into prefixes relative to
@@ -85,47 +78,6 @@ function rebaseExcludePrefixesForSubtree(
   return rebased
 }
 
-async function hasGitEntry(absPath: string): Promise<boolean> {
-  try {
-    const stat = await lstat(join(absPath, '.git'))
-    return stat.isDirectory() || stat.isFile()
-  } catch {
-    return false
-  }
-}
-
-export async function classifyQuickOpenGitEntry(
-  rootPath: string,
-  entry: string
-): Promise<{ kind: QuickOpenGitEntryKind; relPath: string }> {
-  const parsed = parseQuickOpenGitLsFilesEntry(entry)
-  const relPath = normalizeGitEntry(parsed.path)
-  if (!relPath) {
-    return { kind: 'drop-placeholder', relPath }
-  }
-
-  if (!parsed.isGitlink && !parsed.isUntrackedDir) {
-    return { kind: 'keep', relPath }
-  }
-
-  let stat
-  try {
-    stat = await lstat(joinRootRel(rootPath, relPath))
-  } catch {
-    return { kind: 'drop-placeholder', relPath }
-  }
-
-  if (!stat.isDirectory()) {
-    return { kind: 'drop-placeholder', relPath }
-  }
-
-  if (await hasGitEntry(joinRootRel(rootPath, relPath))) {
-    return { kind: 'fill-nested-repo', relPath }
-  }
-
-  return { kind: 'drop-placeholder', relPath }
-}
-
 export async function listQuickOpenFilesWithReaddir(
   rootPath: string,
   opts: {
@@ -134,6 +86,7 @@ export async function listQuickOpenFilesWithReaddir(
     budget?: QuickOpenReaddirBudget
     maxResults?: number
     signal?: AbortSignal
+    followSymlinks?: boolean
   } = {}
 ): Promise<string[]> {
   return listQuickOpenFilesFromRoots(
@@ -142,7 +95,8 @@ export async function listQuickOpenFilesWithReaddir(
         rootPath,
         excludePathPrefixes: opts.excludePathPrefixes ?? [],
         workspaceRelPathPrefix: opts.workspaceRelPathPrefix,
-        allowRootSymlink: true
+        allowRootSymlink: true,
+        followSymlinks: opts.followSymlinks
       }
     ],
     opts.budget ?? createQuickOpenReaddirBudget(),
@@ -158,6 +112,12 @@ type QuickOpenReaddirRoot = {
   outputPathPrefix?: string
   includeSymlinks?: boolean
   allowRootSymlink?: boolean
+  /**
+   * Opt-in: descend into symlinked directories (default off keeps traversal
+   * inside the authorized root). Cycles are broken by a shared realpath
+   * visited-set seeded with each followed directory's resolved path.
+   */
+  followSymlinks?: boolean
 }
 
 async function listQuickOpenFilesFromRoots(
@@ -170,7 +130,17 @@ async function listQuickOpenFilesFromRoots(
   if (maxResults !== undefined && maxResults <= 0) {
     return files
   }
-  let pendingDirectories = roots.map((root) => ({
+  // Cycle guard for followSymlinks: resolved paths of directories already
+  // entered through a symlink. Only populated when a root opts in, so ordinary
+  // walks pay no realpath cost. Seeded lazily as symlinked dirs are followed.
+  const followedRealPaths = new Set<string>()
+  let pendingDirectories: {
+    root: QuickOpenReaddirRoot
+    absPath: string
+    isRoot: boolean
+    /** Entered via a followed symlink — the lstat guard must accept the link. */
+    viaSymlink?: boolean
+  }[] = roots.map((root) => ({
     root,
     absPath: root.rootPath,
     isRoot: true
@@ -195,15 +165,18 @@ async function listQuickOpenFilesFromRoots(
             // Why: Git's placeholder may have been replaced with a symlink
             // before expansion. Never let readdir follow it outside the root.
             const stat = await lstat(pending.absPath)
-            const allowSymlinkedRoot = pending.isRoot && pending.root.allowRootSymlink
-            if (!isQuickOpenReadableDirectory(stat, allowSymlinkedRoot)) {
+            // A followed symlinked dir (viaSymlink) is accepted like a symlinked
+            // root — readdir resolves the link and reads the target's entries.
+            const allowSymlinkedDir =
+              (pending.isRoot && pending.root.allowRootSymlink) || pending.viaSymlink === true
+            if (!isQuickOpenReadableDirectory(stat, allowSymlinkedDir)) {
               return { pending, entries: [] }
             }
             const entries = await readdir(pending.absPath, { withFileTypes: true })
             // Why: close the ordinary check/use race. If the directory became
             // a symlink while readdir was pending, discard everything read.
             const statAfterRead = await lstat(pending.absPath)
-            if (!isQuickOpenReadableDirectory(statAfterRead, allowSymlinkedRoot)) {
+            if (!isQuickOpenReadableDirectory(statAfterRead, allowSymlinkedDir)) {
               return { pending, entries: [] }
             }
             return { pending, entries }
@@ -235,6 +208,23 @@ async function listQuickOpenFilesFromRoots(
           if (entry.isDirectory()) {
             if (shouldDescend(name) && shouldIncludeQuickOpenPath(workspaceRelPath)) {
               nextDirectories.push({ root: pending.root, absPath, isRoot: false })
+            }
+            continue
+          }
+          // Opt-in: a symlink that resolves to a directory is descended into, so
+          // files behind an in-root link surface. Guarded by shouldDescend/blocklist
+          // and a realpath visited-set that breaks cycles (link back to an ancestor
+          // or a mutual A↔B pair).
+          if (
+            pending.root.followSymlinks &&
+            entry.isSymbolicLink() &&
+            shouldDescend(name) &&
+            shouldIncludeQuickOpenPath(workspaceRelPath)
+          ) {
+            const resolved = await resolveSymlinkedDirectory(absPath)
+            if (resolved && !followedRealPaths.has(resolved)) {
+              followedRealPaths.add(resolved)
+              nextDirectories.push({ root: pending.root, absPath, isRoot: false, viaSymlink: true })
             }
             continue
           }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2630,6 +2630,10 @@ export type GlobalSettings = {
   richMarkdownSpellcheckEnabled?: boolean
   /** Whether local markdown review note controls and the review panel are shown. */
   markdownReviewToolsEnabled: boolean
+  /** Opt-in: Quick Open follows in-root symlinked directories so files behind a
+   *  link (e.g. a linked notes vault) are searchable. Off by default because
+   *  `--follow` lets a symlink reach content outside the authorized workspace. */
+  quickOpenFollowSymlinks?: boolean
   /** Why: mirrors terminal selection-paste muscle memory without mutating the
    *  normal system clipboard; Linux and macOS enable it by default, Windows
    *  leaves middle-click semantics unchanged unless the user opts in. */


### PR DESCRIPTION
## Summary

Fixes #9895. Quick Open (Cmd/Ctrl+P) never lists files inside a **symlinked directory** under the workspace root, even though the file tree opens them fine. The file listers deliberately omit `rg --follow` (and git ls-files / readdir don't descend symlinked dirs) so a link can't reach content outside the authorized root — sound as a default, but it leaves a common setup (a workspace that symlinks a sibling notes vault into itself) with on-disk files unreachable from Quick Open.

This adds an **opt-in** `quickOpenFollowSymlinks` global setting (**default off**, preserving today's secure behavior), threaded renderer → IPC / runtime RPC → provider → relay → shared arg builders:

- **rg** (`buildRgArgsForQuickOpen`): `followSymlinks` adds `--follow` to both passes. rg's own symlink-loop detection prevents cycles; cwd-relative output keeps every path rooted under the workspace.
- **readdir walker**: descends into symlinked dirs when enabled, guarded by a **realpath visited-set** that breaks cycles (link back to an ancestor, or a mutual A↔B pair). Ordinary walks pay no realpath cost.
- **git ls-files** path unchanged (records symlinked dirs as link entries); rg/readdir cover the case.
- New **Settings toggle** under General → Editor, with i18n keys in all five locale catalogs.

`git ls-files` entry parsers were split into `quick-open-git-entry.ts` (re-exported from `quick-open-readdir-walk.ts`) to keep that module under the `max-lines` cap after the walker grew.

## Screenshots

No visual change beyond one new General → Editor settings row ("Quick Open Follows Symlinks", off by default).

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm test` (affected suites: `quick-open-filter`, `quick-open-readdir-walk`, `fs-handler-readdir-fallback`, `filesystem-list-files-git-fallback-real` — 68 tests pass)
- [x] `oxlint` on all touched files
- [ ] `pnpm build` (not run locally)
- [x] Added tests: `--follow` present iff `followSymlinks` true; files inside a symlinked dir surface when enabled; a symlink back to an ancestor terminates (cycle guard).

Also verified end-to-end against the reported scenario (non-git root with a symlinked vault dir): with the flag off `linked-vault/note.md` is absent; with it on the walker returns `['inside/normal.ts', 'linked-vault/note-in-vault.md']`, and raw `rg --files --follow` shows the same difference.

## AI Review Report

Self-reviewed the full change chain. Main risks checked:
- **Root escape**: the deliberately-omitted `--follow` exists for this reason, so the change is opt-in and default-off; the "symlinks can't leave the authorized root by default" guarantee is unchanged.
- **Traversal cycles**: rg has built-in symlink-loop detection; the readdir walker adds an explicit realpath visited-set (covered by a cycle test).
- **Cross-platform**: paths stay POSIX-normalized via existing helpers; `--follow` and `realpath`/`stat` behave consistently on macOS/Linux; Windows rg output still forced to `/`. No shell/shortcut/label changes.

## Security Audit

- **Path handling**: followed paths remain cwd-relative and pass the existing `normalizeQuickOpenRgLine` / `shouldExcludeQuickOpenRelPath` filters; blocklist (`node_modules`, `.git`, caches) still prunes.
- **No new input/command/IPC surface**: the new field is a boolean threaded through existing typed IPC/RPC params; no new exec, no secrets, no auth changes.
- Follow-up: none required. Enabling the option is a conscious user choice to include content reachable via in-root links.

## Notes

Default off = no behavior change unless a user opts in. The CodeRabbit "Checkov" warning on this PR is a CodeRabbit tooling error (`ModuleNotFoundError: No module named 'checkov'`) unrelated to the diff.


## ELI5

Quick Open skipped files that lived inside a symlink folder under your workspace. There is now an opt-in to follow those links so notes vaults and similar setups show up in Cmd/Ctrl+P without leaving the safe default off.
