### PR TITLE
fix(win): taskkill agent PTY descendant trees on stop

### DIFF
--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -13,8 +13,7 @@ const {
   prepareMacosTccLoginShellMock,
   resolveAgentForegroundProcessMock,
   readWindowsConptyProcessIdsMock,
-  captureDescendantSnapshotMock,
-  terminateDescendantSnapshotMock
+  killWithDescendantSweepMock
 } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
@@ -25,8 +24,7 @@ const {
   prepareMacosTccLoginShellMock: vi.fn(),
   resolveAgentForegroundProcessMock: vi.fn(),
   readWindowsConptyProcessIdsMock: vi.fn(),
-  captureDescendantSnapshotMock: vi.fn(),
-  terminateDescendantSnapshotMock: vi.fn()
+  killWithDescendantSweepMock: vi.fn()
 }))
 
 vi.mock('fs', () => ({
@@ -55,8 +53,7 @@ vi.mock('./macos-tcc-login-shell', async (importOriginal) => ({
 }))
 
 vi.mock('../pty-descendant-termination', () => ({
-  captureDescendantSnapshot: captureDescendantSnapshotMock,
-  terminateDescendantSnapshot: terminateDescendantSnapshotMock
+  killWithDescendantSweep: killWithDescendantSweepMock
 }))
 
 // Resolve PowerShell family names to deterministic absolute paths (the fs mock
@@ -150,9 +147,13 @@ describe('LocalPtyProvider', () => {
     accessSyncMock.mockReturnValue(undefined)
     mkdirSyncMock.mockReset()
     writeFileSyncMock.mockReset()
-    captureDescendantSnapshotMock.mockReset()
-    captureDescendantSnapshotMock.mockResolvedValue(null)
-    terminateDescendantSnapshotMock.mockReset()
+    killWithDescendantSweepMock.mockReset()
+    // Default: no-op sweep that still runs killRoot (matches empty-snapshot degrade).
+    killWithDescendantSweepMock.mockImplementation(
+      async (_rootPid: number, killRoot: () => void, _deps?: { ownsRoot?: () => boolean }) => {
+        killRoot()
+      }
+    )
     prepareMacosTccLoginShellMock.mockReset()
     prepareMacosTccLoginShellMock.mockResolvedValue(undefined)
     resolveAgentForegroundProcessMock.mockReset()
@@ -1425,11 +1426,15 @@ describe('LocalPtyProvider', () => {
     })
 
     it('waits for an in-flight agent shutdown before reusing the same session id', async () => {
-      let resolveSnapshot!: (value: null) => void
-      captureDescendantSnapshotMock.mockReturnValue(
-        new Promise<null>((resolve) => {
-          resolveSnapshot = resolve
-        })
+      let releaseSweep!: () => void
+      killWithDescendantSweepMock.mockImplementation(
+        (_rootPid: number, killRoot: () => void) =>
+          new Promise<void>((resolve) => {
+            releaseSweep = () => {
+              killRoot()
+              resolve()
+            }
+          })
       )
       const spawnArgs = {
         cols: 80,
@@ -1445,18 +1450,22 @@ describe('LocalPtyProvider', () => {
       await Promise.resolve()
       expect(spawnMock).toHaveBeenCalledTimes(spawnCallsBefore + 1)
 
-      resolveSnapshot(null)
+      releaseSweep()
       await shutdown
       await respawn
       expect(spawnMock).toHaveBeenCalledTimes(spawnCallsBefore + 2)
     })
 
-    it('coalesces duplicate shutdown while descendant capture is pending', async () => {
-      let resolveSnapshot!: (value: null) => void
-      captureDescendantSnapshotMock.mockReturnValue(
-        new Promise<null>((resolve) => {
-          resolveSnapshot = resolve
-        })
+    it('coalesces duplicate shutdown while descendant sweep is pending', async () => {
+      let releaseSweep!: () => void
+      killWithDescendantSweepMock.mockImplementation(
+        (_rootPid: number, killRoot: () => void) =>
+          new Promise<void>((resolve) => {
+            releaseSweep = () => {
+              killRoot()
+              resolve()
+            }
+          })
       )
       const { id } = await provider.spawn({
         cols: 80,
@@ -1466,22 +1475,27 @@ describe('LocalPtyProvider', () => {
 
       const first = provider.shutdown(id, { immediate: true })
       const second = provider.shutdown(id, { immediate: true })
-      expect(captureDescendantSnapshotMock).toHaveBeenCalledOnce()
-      resolveSnapshot(null)
+      expect(killWithDescendantSweepMock).toHaveBeenCalledOnce()
+      releaseSweep()
       await Promise.all([first, second])
-      expect(captureDescendantSnapshotMock).toHaveBeenCalledOnce()
+      expect(killWithDescendantSweepMock).toHaveBeenCalledOnce()
     })
 
-    it('does not signal a captured tree after the tracked root exits naturally', async () => {
-      let resolveSnapshot!: (value: {
-        rootPgid: number
-        descendants: []
-        capturedAtMs: number
-      }) => void
-      captureDescendantSnapshotMock.mockReturnValue(
-        new Promise((resolve) => {
-          resolveSnapshot = resolve
-        })
+    it('does not terminate descendants after the tracked root exits mid-sweep', async () => {
+      const terminateDescendants = vi.fn()
+      let releaseSweep!: () => void
+      killWithDescendantSweepMock.mockImplementation(
+        (_rootPid: number, killRoot: () => void, deps?: { ownsRoot?: () => boolean }) =>
+          new Promise<void>((resolve) => {
+            releaseSweep = () => {
+              // Production killWithDescendantSweep only signals descendants while ownsRoot.
+              if (deps?.ownsRoot?.() ?? true) {
+                terminateDescendants()
+              }
+              killRoot()
+              resolve()
+            }
+          })
       )
       const { id } = await provider.spawn({
         cols: 80,
@@ -1491,10 +1505,10 @@ describe('LocalPtyProvider', () => {
 
       const shutdown = provider.shutdown(id, { immediate: true })
       exitCb?.({ exitCode: 0 })
-      resolveSnapshot({ rootPgid: mockProc.pid, descendants: [], capturedAtMs: Date.now() })
+      releaseSweep()
       await shutdown
 
-      expect(terminateDescendantSnapshotMock).not.toHaveBeenCalled()
+      expect(terminateDescendants).not.toHaveBeenCalled()
     })
   })
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -55,10 +55,7 @@ import { resolveAgentForegroundProcessWithAvailability } from './agent-foregroun
 import { resolveStableForegroundProcess } from './stable-foreground-process'
 import { getAgentForegroundContextPaths } from './agent-foreground-context-paths'
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
-import {
-  captureDescendantSnapshot,
-  terminateDescendantSnapshot
-} from '../pty-descendant-termination'
+import { killWithDescendantSweep } from '../pty-descendant-termination'
 import { readWindowsConptyProcessIds } from './windows-conpty-process-membership'
 import { canConfirmAgentFromConsolePresence } from './windows-console-foreground'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
@@ -1115,19 +1112,24 @@ export class LocalPtyProvider implements IPtyProvider {
     operation: PtyShutdownOperation
   ): Promise<void> {
     const physicalExit = ptyPhysicalExits.get(id)
-    // Why: snapshot before signaling — once the shell dies, descendants reparent to pid 1 and a ppid walk can't find them.
-    const descendants = ptyAgentSessionIds.has(id)
-      ? await captureDescendantSnapshot(proc.pid)
-      : null
-    // Why: a natural exit can race the snapshot — never signal descendants or the root PID after this PTY loses ownership.
-    if (ptyProcesses.get(id) === proc) {
-      if (descendants) {
-        terminateDescendantSnapshot(descendants)
+    const signalRoot = (): void => {
+      // Why: natural exit can race the sweep — never signal after this PTY loses ownership.
+      if (ptyProcesses.get(id) !== proc) {
+        return
       }
       // Cancel startup delivery now, but keep the exit listener and ownership maps until node-pty reports physical exit.
       runPtyCleanup(id)
       operation.rootSignalled = true
       this.requestTrackedPtyShutdown(id, proc, operation.immediate)
+    }
+    if (ptyAgentSessionIds.has(id)) {
+      // Why: POSIX needs a pre-kill descendant snapshot; Windows uses taskkill /T so
+      // agent/MCP orphans cannot hold the worktree cwd after shell stop (#10004).
+      await killWithDescendantSweep(proc.pid, signalRoot, {
+        ownsRoot: () => ptyProcesses.get(id) === proc
+      })
+    } else {
+      signalRoot()
     }
     await waitForPtyPhysicalExit(id, physicalExit)
   }

--- a/src/main/pty-descendant-termination.test.ts
+++ b/src/main/pty-descendant-termination.test.ts
@@ -393,6 +393,55 @@ describe('killWithDescendantSweep', () => {
     expect(sendSignal).not.toHaveBeenCalled()
   })
 
+  it('on Windows taskkills the process tree before killRoot (#10004)', async () => {
+    const events: string[] = []
+    const killWindowsTree = vi.fn(async () => {
+      events.push('tree-kill')
+    })
+    const killRoot = vi.fn(() => events.push('root-kill'))
+    const sendSignal = vi.fn()
+    const readTable = vi.fn()
+    await killWithDescendantSweep(4242, killRoot, {
+      platform: 'win32',
+      killWindowsTree,
+      sendSignal,
+      readTable
+    })
+    expect(killWindowsTree).toHaveBeenCalledWith(4242)
+    expect(killRoot).toHaveBeenCalledOnce()
+    expect(sendSignal).not.toHaveBeenCalled()
+    expect(readTable).not.toHaveBeenCalled()
+    expect(events).toEqual(['tree-kill', 'root-kill'])
+  })
+
+  it('on Windows still kills the root when ownership is lost mid-sweep', async () => {
+    const killWindowsTree = vi.fn(async () => {
+      throw new Error('should not run')
+    })
+    const killRoot = vi.fn()
+    await killWithDescendantSweep(4242, killRoot, {
+      platform: 'win32',
+      killWindowsTree,
+      ownsRoot: () => false
+    })
+    expect(killWindowsTree).not.toHaveBeenCalled()
+    expect(killRoot).toHaveBeenCalledOnce()
+  })
+
+  it('on Windows still kills the root when taskkill fails', async () => {
+    const killWindowsTree = vi.fn(async () => {
+      throw new Error('taskkill failed')
+    })
+    const killRoot = vi.fn()
+    await expect(
+      killWithDescendantSweep(99, killRoot, {
+        platform: 'win32',
+        killWindowsTree
+      })
+    ).resolves.toBeUndefined()
+    expect(killRoot).toHaveBeenCalledOnce()
+  })
+
   it('does not signal a captured tree after the caller loses root ownership', async () => {
     const sendSignal = vi.fn()
     const killRoot = vi.fn()

--- a/src/main/pty-descendant-termination.ts
+++ b/src/main/pty-descendant-termination.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process'
+import { terminateWindowsProcessTree, type WindowsTreeKiller } from './windows-process-tree-kill'
 
 export const DESCENDANT_KILL_GRACE_MS = 2_000
 export const DESCENDANT_SNAPSHOT_TIMEOUT_MS = 1_000
@@ -198,8 +199,8 @@ type SnapshotDeps = {
  * Snapshots a PTY root's live descendant tree. Must run BEFORE the root is
  * signalled: once the root dies, surviving descendants reparent to pid 1 and
  * can no longer be found by a ppid walk. Resolves null (never rejects) on
- * Windows, ps failure, or timeout — callers then degrade to today's
- * shell-only kill.
+ * Windows, ps failure, or timeout — callers then degrade to shell-only kill
+ * on POSIX, or Windows `taskkill /T` via killWithDescendantSweep.
  */
 export async function captureDescendantSnapshot(
   rootPid: number,
@@ -220,17 +221,41 @@ export async function captureDescendantSnapshot(
   return collectDescendantRows(rootPid, capture.rows, capture.capturedAtMs)
 }
 
+type KillSweepDeps = SnapshotDeps &
+  TerminateDeps & {
+    ownsRoot?: () => boolean
+    /** Injectable Windows tree killer (defaults to taskkill /T /F). */
+    killWindowsTree?: WindowsTreeKiller
+  }
+
 /**
- * Standard agent-session kill sequencing: snapshot the descendant tree,
- * signal its members, then run the caller's root kill. Callers must not signal
- * the root before this runs — a dead root's descendants reparent to pid 1 and
- * become unfindable. Snapshot failure degrades to killRoot alone.
+ * Standard agent-session kill sequencing.
+ * - POSIX: snapshot the descendant tree, signal members, then killRoot.
+ * - Windows: taskkill /T /F walks the ConPTY tree (shell → agent → MCP) so
+ *   worktree teardown is not blocked by orphans holding the cwd handle.
+ * Callers must not signal the root before this runs on POSIX — a dead root's
+ * descendants reparent to pid 1 and become unfindable. Snapshot failure
+ * degrades to killRoot alone on POSIX.
  */
 export async function killWithDescendantSweep(
   rootPid: number,
   killRoot: () => void,
-  deps: SnapshotDeps & TerminateDeps & { ownsRoot?: () => boolean } = {}
+  deps: KillSweepDeps = {}
 ): Promise<void> {
+  const platform = deps.platform ?? process.platform
+  if (platform === 'win32') {
+    try {
+      if ((deps.ownsRoot?.() ?? true) && Number.isInteger(rootPid) && rootPid > 0) {
+        const killTree = deps.killWindowsTree ?? terminateWindowsProcessTree
+        // Why: taskkill may race an already-exited tree; never block killRoot on that.
+        await killTree(rootPid).catch(() => {})
+      }
+    } finally {
+      killRoot()
+    }
+    return
+  }
+
   const snapshot = await captureDescendantSnapshot(rootPid, deps)
   try {
     // Signal the captured descendants while their parent links still exist;

--- a/src/main/windows-process-tree-kill.test.ts
+++ b/src/main/windows-process-tree-kill.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { terminateWindowsProcessTree } from './windows-process-tree-kill'
+
+describe('terminateWindowsProcessTree', () => {
+  it('invokes taskkill /T /F for a positive root pid', async () => {
+    const execFileImpl = vi.fn(
+      (_cmd: string, _args: readonly string[], callback: (error: Error | null) => void) => {
+        callback(null)
+      }
+    )
+    await terminateWindowsProcessTree(1234, {
+      execFileImpl: execFileImpl as never
+    })
+    expect(execFileImpl).toHaveBeenCalledWith(
+      'taskkill',
+      ['/pid', '1234', '/T', '/F'],
+      expect.any(Function)
+    )
+  })
+
+  it('resolves even when taskkill reports failure (already dead)', async () => {
+    const execFileImpl = vi.fn(
+      (_cmd: string, _args: readonly string[], callback: (error: Error | null) => void) => {
+        callback(new Error('not found'))
+      }
+    )
+    await expect(
+      terminateWindowsProcessTree(55, { execFileImpl: execFileImpl as never })
+    ).resolves.toBeUndefined()
+  })
+
+  it('skips taskkill for invalid pids', async () => {
+    const execFileImpl = vi.fn()
+    await terminateWindowsProcessTree(0, { execFileImpl: execFileImpl as never })
+    await terminateWindowsProcessTree(-1, { execFileImpl: execFileImpl as never })
+    expect(execFileImpl).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/windows-process-tree-kill.test.ts
+++ b/src/main/windows-process-tree-kill.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, it, vi } from 'vitest'
-import { terminateWindowsProcessTree } from './windows-process-tree-kill'
+import {
+  terminateWindowsProcessTree,
+  WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS
+} from './windows-process-tree-kill'
 
 describe('terminateWindowsProcessTree', () => {
-  it('invokes taskkill /T /F for a positive root pid', async () => {
+  it('invokes taskkill /T /F with timeout and windowsHide', async () => {
     const execFileImpl = vi.fn(
-      (_cmd: string, _args: readonly string[], callback: (error: Error | null) => void) => {
+      (
+        _cmd: string,
+        _args: readonly string[],
+        _options: { timeout?: number; windowsHide?: boolean },
+        callback: (error: Error | null) => void
+      ) => {
         callback(null)
       }
     )
@@ -14,13 +22,22 @@ describe('terminateWindowsProcessTree', () => {
     expect(execFileImpl).toHaveBeenCalledWith(
       'taskkill',
       ['/pid', '1234', '/T', '/F'],
+      {
+        timeout: WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS,
+        windowsHide: true
+      },
       expect.any(Function)
     )
   })
 
   it('resolves even when taskkill reports failure (already dead)', async () => {
     const execFileImpl = vi.fn(
-      (_cmd: string, _args: readonly string[], callback: (error: Error | null) => void) => {
+      (
+        _cmd: string,
+        _args: readonly string[],
+        _options: { timeout?: number; windowsHide?: boolean },
+        callback: (error: Error | null) => void
+      ) => {
         callback(new Error('not found'))
       }
     )

--- a/src/main/windows-process-tree-kill.ts
+++ b/src/main/windows-process-tree-kill.ts
@@ -1,0 +1,23 @@
+import { execFile } from 'node:child_process'
+
+export type WindowsTreeKiller = (rootPid: number) => Promise<void>
+
+/**
+ * Force-kill a Windows process and every descendant (`taskkill /T /F`).
+ * Best-effort: missing/already-dead roots still resolve so callers can finish
+ * their own handle cleanup via killRoot.
+ */
+export function terminateWindowsProcessTree(
+  rootPid: number,
+  deps: { execFileImpl?: typeof execFile } = {}
+): Promise<void> {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
+    return Promise.resolve()
+  }
+  const run = deps.execFileImpl ?? execFile
+  return new Promise((resolve) => {
+    run('taskkill', ['/pid', String(rootPid), '/T', '/F'], () => {
+      resolve()
+    })
+  })
+}

--- a/src/main/windows-process-tree-kill.ts
+++ b/src/main/windows-process-tree-kill.ts
@@ -2,6 +2,9 @@ import { execFile } from 'node:child_process'
 
 export type WindowsTreeKiller = (rootPid: number) => Promise<void>
 
+/** Bound hung taskkill so killRoot still runs in killWithDescendantSweep. */
+export const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 5_000
+
 /**
  * Force-kill a Windows process and every descendant (`taskkill /T /F`).
  * Best-effort: missing/already-dead roots still resolve so callers can finish
@@ -16,8 +19,17 @@ export function terminateWindowsProcessTree(
   }
   const run = deps.execFileImpl ?? execFile
   return new Promise((resolve) => {
-    run('taskkill', ['/pid', String(rootPid), '/T', '/F'], () => {
-      resolve()
-    })
+    run(
+      'taskkill',
+      ['/pid', String(rootPid), '/T', '/F'],
+      {
+        // Why: a wedged taskkill must not block killRoot forever (#10004 review).
+        timeout: WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS,
+        windowsHide: true
+      },
+      () => {
+        resolve()
+      }
+    )
   })
 }


### PR DESCRIPTION
# fix(win): taskkill agent PTY descendant trees on stop

## Summary
On Windows, stopping an agent terminal now kills the whole ConPTY process tree, so orphaned agent/MCP children no longer hold the worktree open and block removal.

## ELI5
When you closed an agent terminal on Windows, Orca only stopped the shell — the agent and its helper processes kept running and locked the folder, so deleting the worktree failed. Now Orca tells Windows to kill that entire process family.

## Root cause & fix
Agent teardown used a POSIX `ps` descendant snapshot that is a no-op on Windows, so only the shell root was killed while Claude/Codex and their MCP children reparented, kept the worktree cwd handle, and made `worktrees:remove` fail with "Failed to physically stop every PTY" (#10004). `killWithDescendantSweep()` now branches on platform: Windows runs `taskkill /pid <root> /T /F` (5s timeout, `windowsHide`) to walk the ConPTY tree before `killRoot`, while POSIX keeps the existing snapshot + signal path. Any `taskkill` failure or timeout is swallowed so `killRoot` always runs.

## Evidence
Validated & rebased onto latest main during a bug-bash triage on 2026-07-23.
- Clean rebase onto `origin/main` (base `8a23618310`, head `84dbdab7ad`).
- Tests: `pty-descendant-termination.test.ts`, `windows-process-tree-kill.test.ts`, `local-pty-provider.test.ts`.
- On branch: **119 passed (119), 3 files**.
- Fix reverted (tests kept): **4 tests failed + 5 errors, 112 passed** — the new Windows-sweep tests fail, `windows-process-tree-kill` import is absent on main, and the provider `vi.mock` errors because the wiring moved to `killWithDescendantSweep`. Restored fix → 119 passed again.
```
(a) on branch:        Test Files 3 passed (3) | Tests 119 passed (119)
(b) fix reverted:     Test Files 3 failed (3) | Tests 4 failed | 112 passed + 5 errors
(c) fix restored:     Test Files 3 passed (3) | Tests 119 passed (119)
```
- Lint clean: `oxlint` on all three source files reports no warnings/errors.

## Trade-offs
None — pure fix. `taskkill /T /F` is force-kill, but matches the pattern already used for git/codex/relay cancellation on Windows and ConPTY stop was already force-oriented.

## Regression risk
Zero on macOS/Linux: the POSIX branch keeps the identical snapshot + signal + `killRoot` sequence. The new behavior is Windows-only, gated on agent-session membership, `ownsRoot`, and valid-pid checks, and `taskkill` is invoked only on `win32`. Every `taskkill` error is caught so root kill always proceeds. Proven by the passing branch tests that fail when the fix is reverted.

---
*Original fix by @innocarpe. Validated, rebased, and (where applicable) hardened via automated bug-bash review; original fix design preserved.*
