### PR TITLE
fix(native-chat): do not exit Chat UI on false agent-title after send

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-exit-suppress.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-exit-suppress.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  clearNativeChatExitSuppressForTests,
+  NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS,
+  recordNativeChatOptimisticSendForExitGuard,
+  shouldSuppressNativeChatExitForPane
+} from './native-chat-exit-suppress'
+
+afterEach(() => {
+  clearNativeChatExitSuppressForTests()
+})
+
+describe('shouldSuppressNativeChatExitForPane', () => {
+  it('suppresses when pending entries exist for the pane', () => {
+    const cache = new Map([['tab:leaf\0codex', [{ sentAt: 10 }]]])
+    expect(shouldSuppressNativeChatExitForPane('tab:leaf', cache, 11)).toBe(true)
+  })
+
+  it('suppresses within grace after recording a send even if pending is empty', () => {
+    recordNativeChatOptimisticSendForExitGuard('tab:leaf', 1_000)
+    const empty = new Map<string, { sentAt: number }[]>()
+    expect(
+      shouldSuppressNativeChatExitForPane(
+        'tab:leaf',
+        empty,
+        1_000 + NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS - 1
+      )
+    ).toBe(true)
+    expect(
+      shouldSuppressNativeChatExitForPane(
+        'tab:leaf',
+        empty,
+        1_000 + NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
+      )
+    ).toBe(false)
+  })
+
+  it('does not suppress other panes', () => {
+    recordNativeChatOptimisticSendForExitGuard('tab:leaf-a', 50)
+    const cache = new Map([['tab:leaf-a\0codex', [{ sentAt: 50 }]]])
+    expect(shouldSuppressNativeChatExitForPane('tab:leaf-b', cache, 60)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-exit-suppress.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-exit-suppress.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   clearNativeChatExitSuppressForTests,
+  getNativeChatExitSuppressRemainingMs,
   NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS,
   recordNativeChatOptimisticSendForExitGuard,
   shouldSuppressNativeChatExitForPane
@@ -39,5 +40,18 @@ describe('shouldSuppressNativeChatExitForPane', () => {
     recordNativeChatOptimisticSendForExitGuard('tab:leaf-a', 50)
     const cache = new Map([['tab:leaf-a\0codex', [{ sentAt: 50 }]]])
     expect(shouldSuppressNativeChatExitForPane('tab:leaf-b', cache, 60)).toBe(false)
+  })
+
+  it('reports remaining grace ms for post-suppress re-evaluation', () => {
+    recordNativeChatOptimisticSendForExitGuard('tab:leaf', 1_000)
+    expect(getNativeChatExitSuppressRemainingMs('tab:leaf', 1_000 + 1_000)).toBe(
+      NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS - 1_000
+    )
+    expect(
+      getNativeChatExitSuppressRemainingMs(
+        'tab:leaf',
+        1_000 + NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
+      )
+    ).toBe(0)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-exit-suppress.ts
+++ b/src/renderer/src/components/native-chat/native-chat-exit-suppress.ts
@@ -1,0 +1,37 @@
+// Why: Codex (and other TUIs) can briefly retitle to a shell-like OSC string
+// while accepting the first PTY write; that false "agent exited" must not kick
+// Chat UI to Terminal mid-send (#10098).
+
+export const NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS = 5_000
+
+const lastOptimisticSendAtByPaneKey = new Map<string, number>()
+
+export function recordNativeChatOptimisticSendForExitGuard(paneKey: string, sentAt: number): void {
+  lastOptimisticSendAtByPaneKey.set(paneKey, sentAt)
+}
+
+/**
+ * True while Chat UI should ignore a title-based "agent exited" handoff for this
+ * pane: unconfirmed optimistic sends, or a recent send still in the grace window.
+ */
+export function shouldSuppressNativeChatExitForPane(
+  paneKey: string,
+  pendingEntriesByScopeKey: ReadonlyMap<string, readonly { sentAt: number }[]>,
+  nowMs = Date.now()
+): boolean {
+  if (!paneKey) {
+    return false
+  }
+  const prefix = `${paneKey}\0`
+  for (const [key, entries] of pendingEntriesByScopeKey) {
+    if (key.startsWith(prefix) && entries.length > 0) {
+      return true
+    }
+  }
+  const lastSentAt = lastOptimisticSendAtByPaneKey.get(paneKey)
+  return lastSentAt !== undefined && nowMs - lastSentAt < NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
+}
+
+export function clearNativeChatExitSuppressForTests(): void {
+  lastOptimisticSendAtByPaneKey.clear()
+}

--- a/src/renderer/src/components/native-chat/native-chat-exit-suppress.ts
+++ b/src/renderer/src/components/native-chat/native-chat-exit-suppress.ts
@@ -32,6 +32,18 @@ export function shouldSuppressNativeChatExitForPane(
   return lastSentAt !== undefined && nowMs - lastSentAt < NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
 }
 
+/** Remaining grace ms for a pane after its last optimistic send (0 if none/expired). */
+export function getNativeChatExitSuppressRemainingMs(paneKey: string, nowMs = Date.now()): number {
+  if (!paneKey) {
+    return 0
+  }
+  const lastSentAt = lastOptimisticSendAtByPaneKey.get(paneKey)
+  if (lastSentAt === undefined) {
+    return 0
+  }
+  return Math.max(NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS - (nowMs - lastSentAt), 0)
+}
+
 export function clearNativeChatExitSuppressForTests(): void {
   lastOptimisticSendAtByPaneKey.clear()
 }

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
@@ -160,6 +160,34 @@ describe('resolveNativeChatLeafRoute', () => {
     ).toEqual({ chatLeafId: null, exitChat: true })
   })
 
+  it('keeps chat open on confirmed exit when a recent send suppresses the handoff (#10098)', () => {
+    expect(
+      resolveNativeChatLeafRoute({
+        isChatViewMode: true,
+        chatLeafId: 'exited-agent',
+        activeLeafId: 'exited-agent',
+        chatLeafStillMounted: true,
+        activeLeafIsEligible: true,
+        chatLeafHasConfirmedAgentExit: true,
+        suppressExitChat: true
+      })
+    ).toEqual({ chatLeafId: 'exited-agent', exitChat: false })
+  })
+
+  it('still exits when suppress is set but the chat leaf is gone', () => {
+    expect(
+      resolveNativeChatLeafRoute({
+        isChatViewMode: true,
+        chatLeafId: 'closed-agent',
+        activeLeafId: 'shell-leaf',
+        chatLeafStillMounted: false,
+        activeLeafIsEligible: false,
+        chatLeafHasConfirmedAgentExit: true,
+        suppressExitChat: true
+      })
+    ).toEqual({ chatLeafId: null, exitChat: true })
+  })
+
   it('moves chat to an eligible sibling after the owning agent exits', () => {
     expect(
       resolveNativeChatLeafRoute({

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts
@@ -174,6 +174,20 @@ describe('resolveNativeChatLeafRoute', () => {
     ).toEqual({ chatLeafId: 'exited-agent', exitChat: false })
   })
 
+  it('does not retarget to an eligible sibling while suppress is active (#10098)', () => {
+    expect(
+      resolveNativeChatLeafRoute({
+        isChatViewMode: true,
+        chatLeafId: 'sending-leaf',
+        activeLeafId: 'agent-sibling',
+        chatLeafStillMounted: true,
+        activeLeafIsEligible: true,
+        chatLeafHasConfirmedAgentExit: true,
+        suppressExitChat: true
+      })
+    ).toEqual({ chatLeafId: 'sending-leaf', exitChat: false })
+  })
+
   it('still exits when suppress is set but the chat leaf is gone', () => {
     expect(
       resolveNativeChatLeafRoute({

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
@@ -85,6 +85,16 @@ export function resolveNativeChatLeafRoute(args: {
     // event, so keep its chat surface until the pane itself is removed.
     return { chatLeafId: args.chatLeafId, exitChat: false }
   }
+  // Why: run before eligible-sibling retarget so a false exit during the send
+  // grace window cannot steal Chat onto a sibling pane (#10098 / CodeRabbit).
+  if (
+    args.suppressExitChat &&
+    args.chatLeafId &&
+    args.chatLeafStillMounted &&
+    args.chatLeafHasConfirmedAgentExit
+  ) {
+    return { chatLeafId: args.chatLeafId, exitChat: false }
+  }
   // Manager hydration can briefly have no active pane; preserve the requested
   // mode until a concrete leaf exists instead of toggling it off during mount.
   if (!args.activeLeafId && !args.chatLeafHasConfirmedAgentExit) {
@@ -95,16 +105,6 @@ export function resolveNativeChatLeafRoute(args: {
     (!args.chatLeafHasConfirmedAgentExit || args.activeLeafId !== args.chatLeafId)
   ) {
     return { chatLeafId: args.activeLeafId, exitChat: false }
-  }
-  // Why: a transient shell-title OSC after a Chat UI send is not a real agent
-  // exit — keep the mounted chat leaf until the grace window ends (#10098).
-  if (
-    args.suppressExitChat &&
-    args.chatLeafId &&
-    args.chatLeafStillMounted &&
-    args.chatLeafHasConfirmedAgentExit
-  ) {
-    return { chatLeafId: args.chatLeafId, exitChat: false }
   }
   // Why: removing the owning leaf or confirming its agent exited must not leave
   // the composer targeting a plain shell. Return the tab to terminal mode.

--- a/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
+++ b/src/renderer/src/components/native-chat/native-chat-leaf-routing.ts
@@ -73,6 +73,8 @@ export function resolveNativeChatLeafRoute(args: {
   chatLeafStillMounted: boolean
   activeLeafIsEligible: boolean
   chatLeafHasConfirmedAgentExit?: boolean
+  /** Suppress exitChat when a recent Chat UI send may race a false title exit. */
+  suppressExitChat?: boolean
 }): NativeChatLeafRoute {
   if (!args.isChatViewMode) {
     return { chatLeafId: null, exitChat: false }
@@ -93,6 +95,16 @@ export function resolveNativeChatLeafRoute(args: {
     (!args.chatLeafHasConfirmedAgentExit || args.activeLeafId !== args.chatLeafId)
   ) {
     return { chatLeafId: args.activeLeafId, exitChat: false }
+  }
+  // Why: a transient shell-title OSC after a Chat UI send is not a real agent
+  // exit — keep the mounted chat leaf until the grace window ends (#10098).
+  if (
+    args.suppressExitChat &&
+    args.chatLeafId &&
+    args.chatLeafStillMounted &&
+    args.chatLeafHasConfirmedAgentExit
+  ) {
+    return { chatLeafId: args.chatLeafId, exitChat: false }
   }
   // Why: removing the owning leaf or confirming its agent exited must not leave
   // the composer targeting a plain shell. Return the tab to terminal mode.

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -11,12 +11,14 @@ import {
   isLaunchPromptMessageId,
   isPendingMessageId,
   launchPromptAsMessage,
+  NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS,
   nextNativeChatPendingSendId,
   pendingSendsAsMessages,
   prunePendingSends,
   readCommandMarkerCache,
   readPendingSendCache,
   shouldPruneLaunchPrompt,
+  shouldSuppressNativeChatExitForPane,
   writePendingSendCache,
   type NativeChatPendingSend
 } from './native-chat-pending'
@@ -386,6 +388,43 @@ describe('launchPromptAsMessage', () => {
 
     expect(launchPromptAsMessage(entry, oldHistory)).not.toBeNull()
     expect(shouldPruneLaunchPrompt(entry, oldHistory)).toBe(false)
+  })
+})
+
+describe('shouldSuppressNativeChatExitForPane', () => {
+  it('suppresses exit while an optimistic send is pending or within grace (#10098)', () => {
+    clearPendingSendCacheForTests()
+    const scope = { paneKey: 'tab-1:leaf-a', agent: 'codex' }
+    const sentAt = 1_000
+    appendPendingSendCache(scope, {
+      id: 'p1',
+      text: 'ordinary prose',
+      sentAt
+    })
+    expect(shouldSuppressNativeChatExitForPane(scope.paneKey, sentAt + 10)).toBe(true)
+    // Pruned (transcript caught up) but still inside grace window.
+    writePendingSendCache(scope, [])
+    expect(
+      shouldSuppressNativeChatExitForPane(
+        scope.paneKey,
+        sentAt + NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS - 1
+      )
+    ).toBe(true)
+    expect(
+      shouldSuppressNativeChatExitForPane(
+        scope.paneKey,
+        sentAt + NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
+      )
+    ).toBe(false)
+  })
+
+  it('does not suppress unrelated panes', () => {
+    clearPendingSendCacheForTests()
+    appendPendingSendCache(
+      { paneKey: 'tab-1:leaf-a', agent: 'codex' },
+      { id: 'p1', text: 'hi', sentAt: 50 }
+    )
+    expect(shouldSuppressNativeChatExitForPane('tab-1:leaf-b', 60)).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -18,6 +18,13 @@ import {
   nativeChatPendingOccurrence,
   selectPendingIndicesRepresentedByUserTexts
 } from './native-chat-pending-occurrence'
+import {
+  clearNativeChatExitSuppressForTests,
+  recordNativeChatOptimisticSendForExitGuard,
+  shouldSuppressNativeChatExitForPane as shouldSuppressNativeChatExitForPaneImpl
+} from './native-chat-exit-suppress'
+
+export { NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS } from './native-chat-exit-suppress'
 
 /** An optimistic, not-yet-confirmed composer send. */
 export type NativeChatPendingSend = {
@@ -80,11 +87,18 @@ export function appendPendingSendCache(
 ): NativeChatPendingSend[] {
   const existing = readPendingSendCache(scope)
   const next = assignNativeChatPendingOccurrence(existing, entry)
+  recordNativeChatOptimisticSendForExitGuard(scope.paneKey, next.sentAt)
   return writePendingSendCache(scope, [...existing, next])
+}
+
+/** Facade so TerminalPane can query without importing the cache Map. */
+export function shouldSuppressNativeChatExitForPane(paneKey: string, nowMs = Date.now()): boolean {
+  return shouldSuppressNativeChatExitForPaneImpl(paneKey, pendingSendCache, nowMs)
 }
 
 export function clearPendingSendCacheForTests(): void {
   pendingSendCache.clear()
+  clearNativeChatExitSuppressForTests()
   pendingSendCounter = 0
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -24,7 +24,10 @@ import {
   shouldSuppressNativeChatExitForPane as shouldSuppressNativeChatExitForPaneImpl
 } from './native-chat-exit-suppress'
 
-export { NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS } from './native-chat-exit-suppress'
+export {
+  getNativeChatExitSuppressRemainingMs,
+  NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
+} from './native-chat-exit-suppress'
 
 /** An optimistic, not-yet-confirmed composer send. */
 export type NativeChatPendingSend = {

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -62,6 +62,10 @@ import TerminalContextMenu from './TerminalContextMenu'
 import TerminalPaneHeaderOverlay from './TerminalPaneHeaderOverlay'
 import NativeChatView from '../native-chat/NativeChatView'
 import { shouldSuppressNativeChatExitForPane } from '../native-chat/native-chat-pending'
+import {
+  getNativeChatExitSuppressRemainingMs,
+  NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
+} from '../native-chat/native-chat-exit-suppress'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { TerminalAgentSessionForkDialog } from './TerminalAgentSessionForkDialog'
@@ -709,17 +713,17 @@ export default function TerminalPane({
       resolveTitleAgentForLeaf
     ]
   )
+  const pendingConfirmedExitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const applyNativeChatLeafRoute = useCallback(
     (route: NativeChatLeafRoute): void => {
       if (route.chatLeafId !== chatLeafId) {
         setChatLeafId(route.chatLeafId)
       }
       if (route.exitChat && unifiedTabId) {
-        // Why: post-hoc triage for #10098 — ordinary send must not flip Chat UI
-        // without a recorded programmatic handoff reason.
+        // Why: exit routes null the leaf — record the pre-route owner for triage (#10098).
         recordRendererCrashBreadcrumb('native_chat_exit_to_terminal', {
           reason: 'leaf_route',
-          chatLeafId: route.chatLeafId
+          chatLeafId
         })
         // Why: event/effect replay must not flip terminal mode back to chat.
         setTabViewMode(unifiedTabId, 'terminal')
@@ -741,6 +745,19 @@ export default function TerminalPane({
           reason: 'recent_chat_send',
           paneKey
         })
+        // Why: re-evaluate after grace so a genuine exit is not stuck forever.
+        if (pendingConfirmedExitTimerRef.current) {
+          clearTimeout(pendingConfirmedExitTimerRef.current)
+        }
+        // Why: pending sends have no fixed end — fall back to the full grace.
+        const remainingMs = Math.max(
+          1,
+          getNativeChatExitSuppressRemainingMs(paneKey) || NATIVE_CHAT_EXIT_SUPPRESS_AFTER_SEND_MS
+        )
+        pendingConfirmedExitTimerRef.current = setTimeout(() => {
+          pendingConfirmedExitTimerRef.current = null
+          onAgentExitedRef.current(leafId)
+        }, remainingMs)
       }
       applyNativeChatLeafRoute(
         resolveNativeChatLeafRoute({
@@ -760,6 +777,14 @@ export default function TerminalPane({
     // Why: transport callbacks must observe only committed chat ownership; render work can be replayed/discarded under concurrent React.
     onAgentExitedRef.current = handleConfirmedAgentExit
   }, [handleConfirmedAgentExit])
+  useEffect(() => {
+    return () => {
+      if (pendingConfirmedExitTimerRef.current) {
+        clearTimeout(pendingConfirmedExitTimerRef.current)
+        pendingConfirmedExitTimerRef.current = null
+      }
+    }
+  }, [])
   const canToggleChatForLeaf = useCallback(
     (leafId: string | null): boolean => {
       // Scope the "always allow toggling back" rule to the leaf showing chat; must not make an unsupported sibling look eligible.

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -61,6 +61,8 @@ import { TerminalSessionStateSaveFailureDialog } from './TerminalSessionStateSav
 import TerminalContextMenu from './TerminalContextMenu'
 import TerminalPaneHeaderOverlay from './TerminalPaneHeaderOverlay'
 import NativeChatView from '../native-chat/NativeChatView'
+import { shouldSuppressNativeChatExitForPane } from '../native-chat/native-chat-pending'
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { TerminalAgentSessionForkDialog } from './TerminalAgentSessionForkDialog'
 import { AgentSessionContinuationDialog } from '@/components/agent-session-continuation/AgentSessionContinuationDialog'
@@ -713,6 +715,12 @@ export default function TerminalPane({
         setChatLeafId(route.chatLeafId)
       }
       if (route.exitChat && unifiedTabId) {
+        // Why: post-hoc triage for #10098 — ordinary send must not flip Chat UI
+        // without a recorded programmatic handoff reason.
+        recordRendererCrashBreadcrumb('native_chat_exit_to_terminal', {
+          reason: 'leaf_route',
+          chatLeafId: route.chatLeafId
+        })
         // Why: event/effect replay must not flip terminal mode back to chat.
         setTabViewMode(unifiedTabId, 'terminal')
       }
@@ -726,6 +734,14 @@ export default function TerminalPane({
       }
       const panes = managerRef.current?.getPanes() ?? []
       const activeLeafId = managerRef.current?.getActivePane()?.leafId ?? null
+      const paneKey = makePaneKey(tabId, leafId)
+      const suppressExitChat = shouldSuppressNativeChatExitForPane(paneKey)
+      if (suppressExitChat) {
+        recordRendererCrashBreadcrumb('native_chat_agent_exit_suppressed', {
+          reason: 'recent_chat_send',
+          paneKey
+        })
+      }
       applyNativeChatLeafRoute(
         resolveNativeChatLeafRoute({
           isChatViewMode,
@@ -733,11 +749,12 @@ export default function TerminalPane({
           activeLeafId,
           chatLeafStillMounted: panes.some((pane) => pane.leafId === chatLeafId),
           activeLeafIsEligible: isChatEligibleForLeaf(activeLeafId),
-          chatLeafHasConfirmedAgentExit: true
+          chatLeafHasConfirmedAgentExit: true,
+          suppressExitChat
         })
       )
     },
-    [applyNativeChatLeafRoute, chatLeafId, isChatEligibleForLeaf, isChatViewMode]
+    [applyNativeChatLeafRoute, chatLeafId, isChatEligibleForLeaf, isChatViewMode, tabId]
   )
   useEffect(() => {
     // Why: transport callbacks must observe only committed chat ownership; render work can be replayed/discarded under concurrent React.


### PR DESCRIPTION
## Description
An ordinary natural-language send from Codex Chat UI could flip the pane back to Terminal, showing the hosted `codex …` command line. Composer ordinary sends never call `onSwitchToTerminal`; the more likely path is a **false agent-exit** from a brief shell-like OSC title while the first PTY write is accepted, which routes through `handleConfirmedAgentExit` → `exitChat`.

This PR suppresses that programmatic Chat→Terminal handoff for a short window after an optimistic chat send (and while pending sends remain), and records renderer breadcrumbs when exit is suppressed vs applied so post-hoc triage can see the branch (#10098 requested).

## Evidence
- Hypothesis matches #10098 source notes (ordinary send path does not switch; `TerminalPane` exitChat does).
- Unit tests:
  ```bash
  pnpm exec vitest run --config config/vitest.config.ts \
    src/renderer/src/components/native-chat/native-chat-pending.test.ts \
    src/renderer/src/components/native-chat/native-chat-leaf-routing.test.ts \
    src/renderer/src/components/native-chat/native-chat-exit-suppress.test.ts
  ```
  **66/66 passed**
- Coverage: grace after prune; pending still suppress; sibling pane isolation; suppress keeps mounted leaf; suppress does not block real leaf-removed exit.

## ELI5
After you hit send in Chat UI, Orca briefly listens for “did the agent quit?”. Sometimes the terminal title flickers and Orca thought it quit, so it yanked you into the raw terminal. Now it waits a few seconds after a chat send before trusting that signal.

## User-regression-tradeoffs
- **Intentional picker / `/model` handoffs** still use `onSwitchToTerminal` and are unchanged.
- If the agent **truly** exits during the 5s post-send grace, Chat UI may stay open until grace ends (or until the leaf unmounts). Preferable to mid-send Terminal thrash; real process death still clears agent rows via process trackers.
- Breadcrumbs are best-effort crash evidence only.

## Checklist notes
- Cross-platform: pure renderer logic (macOS report; same path all platforms).
- SSH/remote: paneKey-scoped; works for remote-hosted PTYs the same way.
- Agents/integrations: any Chat UI agent with optimistic send + title exit path (Codex is the reported case).
- Performance: O(pending scopes) map scan on agent-exit only.
- UI: no layout change.
- Security: no new network surface.

Fixes #10098