### PR TITLE
fix(worktree): verify exited PTYs before blocking deletion

### DIFF
--- a/src/main/runtime/worktree-teardown.test.ts
+++ b/src/main/runtime/worktree-teardown.test.ts
@@ -375,6 +375,53 @@ describe('killAllProcessesForWorktree', () => {
     expect(localProvider.shutdown).toHaveBeenCalledTimes(1)
   })
 
+  it('accepts a failed Windows stop when a fresh inventory proves the PTY exited', async () => {
+    const worktreeId = 'repo-1::C:/Users/User/orca/workspaces/repo/feature'
+    const ptyId = `${worktreeId}@@windows-pty`
+    const stopTerminalsForWorktree = vi.fn(
+      async (
+        _worktreeId: string,
+        options: {
+          stopPty: (
+            ptyId: string,
+            stop: () => boolean
+          ) => Promise<{ stopped: boolean; owner: boolean }>
+        }
+      ) => ({
+        stopped: (await options.stopPty(ptyId, () => false)).owner ? 1 : 0
+      })
+    )
+    const runtime = {
+      stopTerminalsForWorktree
+    } as unknown as Parameters<typeof killAllProcessesForWorktree>[1]['runtime']
+    let inventoryCount = 0
+    const localProvider = createProviderStub(async () => {
+      inventoryCount += 1
+      return inventoryCount === 1
+        ? [{ id: ptyId, cwd: 'C:/Users/User/orca/workspaces/repo/feature', title: 'shell' }]
+        : []
+    })
+    ;(localProvider.shutdown as unknown as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error(`Session not found: ${ptyId}`)
+    )
+    listRegisteredPtysMock.mockReturnValue([
+      { ptyId, worktreeId, sessionId: null, paneKey: null, pid: 100 }
+    ])
+
+    await expect(
+      killAllProcessesForWorktree(worktreeId, {
+        runtime,
+        localProvider,
+        requirePhysicalStop: true
+      })
+    ).resolves.toEqual({
+      runtimeStopped: 0,
+      providerStopped: 0,
+      registryStopped: 0
+    })
+    expect(localProvider.listProcesses).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps duplicate sweeps behind the runtime physical-stop promise', async () => {
     let releasePhysicalStop: () => void = () => undefined
     const physicalStop = new Promise<boolean>((resolve) => {

--- a/src/main/runtime/worktree-teardown.ts
+++ b/src/main/runtime/worktree-teardown.ts
@@ -26,9 +26,8 @@ export type WorktreeTeardownResult = {
 
 export const WORKTREE_PROCESS_SWEEP_TIMEOUT_MS = 10_000
 
-// Why: margin so a bounded daemon RPC rejects BEFORE the sweep deadline and its
-// rejection can propagate — otherwise the outer deadline wins with a confusing
-// "Timed out waiting for physical PTY teardown" instead of the accurate stop failure.
+// Why: reserve time after bounded stop RPCs to recheck whether a reported
+// failure actually left a live PTY before the outer sweep deadline.
 export const WORKTREE_TEARDOWN_RPC_MARGIN_MS = 500
 
 // Absolute deadline (epoch ms) threaded into provider RPCs on the destructive
@@ -150,13 +149,39 @@ export async function killAllProcessesForWorktree(
   result.providerStopped = providerStopped
   result.registryStopped = registryStopped
   if (deps.requirePhysicalStop) {
-    const stops = await Promise.all(stopAttempts.values())
-    if (stops.some((stopped) => !stopped)) {
+    const stopResults = await Promise.all(
+      [...stopAttempts].map(async ([ptyId, stopped]) => [ptyId, await stopped] as const)
+    )
+    const failedPtyIds = stopResults.filter(([, stopped]) => !stopped).map(([ptyId]) => ptyId)
+    const failedPtysExited =
+      failedPtyIds.length === 0 ||
+      (await verifyFailedPtysExited(failedPtyIds, deps.localProvider, deadline))
+    if (!failedPtysExited) {
       throw new Error(`Failed to physically stop every PTY for worktree: ${worktreeId}`)
+    }
+    for (const ptyId of failedPtyIds) {
+      clearStoppedPtyState(ptyId, deps.onPtyStopped)
     }
   }
 
   return result
+}
+
+async function verifyFailedPtysExited(
+  failedPtyIds: readonly string[],
+  provider: IPtyProvider,
+  deadline: number
+): Promise<boolean> {
+  const sessions = await settleBeforeDeadline(
+    () => provider.listProcesses({ deadlineMs: deadline }),
+    null,
+    deadline
+  ).catch(() => null)
+  if (!sessions) {
+    return false
+  }
+  const livePtyIds = new Set(sessions.map((session) => session.id))
+  return failedPtyIds.every((ptyId) => !livePtyIds.has(ptyId))
 }
 
 async function settleBeforeDeadline<T>(


### PR DESCRIPTION
## Description

On Windows, deleting a worktree could fail forever with:

> Failed to physically stop every PTY for worktree

The failure occurred when the daemon had already killed the ConPTY, but one stop path lost/timed out on the acknowledgement and the duplicate fallback received `Session not found`. Teardown permanently latched those negative stop results even though the authoritative process inventory was already empty.

This change uses the existing teardown RPC margin for a fresh provider inventory when any stop reports failure:

- deletion continues only when every failed exact PTY ID is confirmed absent;
- stale runtime/provider/registry state is cleared only after that proof;
- a still-live PTY, rejected inventory, or timed-out inventory continues to block deletion.

The behavior applies to local daemon PTYs and connection-scoped SSH providers without changing path matching, persistence, or the worktree removal API.

## ELI5

Orca asks several systems to stop a terminal before deleting its folder. Sometimes Windows stops the terminal successfully, but one system misses the confirmation and says “I couldn't stop it.” Orca used to trust that stale answer forever.

Now Orca checks the live terminal roster one final time. If the terminal is definitely gone, deletion proceeds. If it is still there—or Orca cannot check safely—deletion remains blocked.

## Evidence of fix

### Reproduction first

- Used Orca CLI against the `awin` Windows environment to create disposable worktrees and exercise deletion with a live PowerShell PTY and a long-running child process. Those baseline cases succeeded, narrowing the bug to stale/failed acknowledgement state rather than Windows paths or ordinary live processes.
- Added a native-Windows regression with the same PTY represented across runtime, daemon inventory, and local registry.
- Before the production change, the regression failed with the reported error:

```text
AssertionError: promise rejected "Error: Failed to physically stop every PT…" instead of resolving
Caused by: Error: Failed to physically stop every PTY for worktree: repo-1::C:/Users/User/orca/workspaces/repo/feature
```

- After the change, the same regression passes and requires a second authoritative inventory before deletion.

### Automated verification

```text
27/27  worktree teardown + Windows worktree-removal tests
199/199 worktree-removal IPC tests
226/226 targeted tests total
```

Also passed:

- `pnpm run typecheck:node`
- focused `oxlint`
- focused `oxfmt --check`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

### Adversarial review loop

- First pass verified fail-closed behavior, cleanup ordering, concurrency, Windows daemon authority, SSH scoping, and unchanged macOS/Linux behavior.
- Second pass found one P2 test-fidelity gap: the regression had disabled the local registry and therefore resembled SSH more than native Windows.
- The test was corrected to include the same PTY in runtime, provider inventory, and local registry.
- Re-review found no remaining issues.

## User-facing regression list

Known user-facing regressions: **none**.

Explicitly checked:

- Truly live PTYs still block destructive deletion.
- Inventory errors and timeouts still fail closed.
- One live PTY among several still blocks the whole removal.
- SSH checks remain scoped to the target connection's provider.
- macOS and Linux behavior is unchanged except for the same safety recheck after a reported stop failure.
- No UI, schema, persistence, Git command, or keyboard behavior changed.
