### PR TITLE
fix(agent-status): keep parent resume when nested Codex shares pane key

### DIFF
--- a/src/renderer/src/store/slices/agent-status-provider-session.test.ts
+++ b/src/renderer/src/store/slices/agent-status-provider-session.test.ts
@@ -121,6 +121,74 @@ describe('recordAgentProviderSession', () => {
     expect(store.getState().agentStatusByPaneKey['tab-1:leaf-1']?.providerSession).toBeUndefined()
   })
 
+  it('does not let nested Codex overwrite a live Claude parent resume identity (#10105)', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+      }
+    } as Partial<AppState>)
+    const claudeSession = {
+      key: 'session_id' as const,
+      id: 'claude-session-1',
+      transcriptPath: '/tmp/claude.jsonl'
+    }
+    const nestedCodexSession = {
+      key: 'session_id' as const,
+      id: 'codex-worker-1',
+      transcriptPath: '/tmp/codex-worker.jsonl'
+    }
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'parent turn', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 10, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession: claudeSession }
+      )
+
+    store
+      .getState()
+      .recordAgentProviderSession(
+        'tab-1:leaf-1',
+        'codex',
+        nestedCodexSession,
+        { updatedAt: 20 },
+        { tabId: 'tab-1', worktreeId: 'wt-1', connectionId: null }
+      )
+
+    expect(store.getState().agentStatusByPaneKey['tab-1:leaf-1']).toMatchObject({
+      agentType: 'claude',
+      state: 'working',
+      providerSession: claudeSession
+    })
+    // Nested claim must not demote the live parent into a codex sleeping resume.
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.agent).not.toBe('codex')
+    expect(
+      store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']?.providerSession
+    ).not.toEqual(nestedCodexSession)
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'nested worker', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 30, stateStartedAt: 30 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession: nestedCodexSession }
+      )
+
+    expect(store.getState().agentStatusByPaneKey['tab-1:leaf-1']).toMatchObject({
+      agentType: 'claude',
+      state: 'working',
+      providerSession: claudeSession
+    })
+  })
+
   it('uses the session file as part of Pi resume ownership only', () => {
     const base = {
       paneKey: 'tab-1:leaf-1',

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -23,6 +23,7 @@ import {
 } from '../../../../shared/agent-session-resume'
 import {
   resolveAgentStatusIdentity,
+  shouldIgnoreNestedProviderSessionClaim,
   shouldSuppressInheritedTerminalStatus
 } from '../../../../shared/agent-status-identity'
 import { isCommandCodeNewTurnWhileWorking } from '../../../../shared/command-code-turn-boundary'
@@ -1603,6 +1604,22 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         ) {
           return s
         }
+        // Why: nested Codex (etc.) inherits ORCA_PANE_KEY from Claude; its session
+        // claim must not demote the live parent into a wrong-agent resume (#10105).
+        if (
+          existingStatus &&
+          shouldIgnoreNestedProviderSessionClaim({
+            live: {
+              agentType: existingStatus.agentType,
+              state: existingStatus.state,
+              updatedAt: existingStatus.updatedAt
+            },
+            claimedAgent: agent,
+            now: updatedAt
+          })
+        ) {
+          return s
+        }
         const tabId = routing?.tabId ?? getTabIdFromPaneKey(paneKey) ?? existingRecord?.tabId
         const worktreeId =
           routing?.worktreeId ??
@@ -1830,17 +1847,22 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const canReuseExistingProviderSession =
           existing?.agentType === identity.agentType &&
           (existing.state !== 'done' || payload.state === 'done')
+        // Why: when identity is inherited from the active parent, nested child
+        // hooks must not overwrite the parent's resume session (#10105).
+        const incomingProviderSession = identity.inheritedFromActivePane
+          ? undefined
+          : metadata?.providerSession
         const providerSession =
-          metadata?.providerSession ??
+          incomingProviderSession ??
           (canReuseExistingProviderSession ? existing.providerSession : undefined)
         const existingProviderSession = canReuseExistingProviderSession
           ? existing.providerSession
           : undefined
         const providerSessionChanged =
-          Boolean(metadata?.providerSession && existingProviderSession) &&
+          Boolean(incomingProviderSession && existingProviderSession) &&
           !agentProviderSessionsEqual(
             identity.agentType,
-            metadata?.providerSession,
+            incomingProviderSession,
             existingProviderSession
           )
         const statusTabId =

--- a/src/shared/agent-status-identity.test.ts
+++ b/src/shared/agent-status-identity.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveAgentStatusIdentity,
+  shouldIgnoreNestedProviderSessionClaim,
+  shouldSuppressInheritedTerminalStatus
+} from './agent-status-identity'
+
+describe('resolveAgentStatusIdentity', () => {
+  it('keeps the active parent agent when a nested hook claims a different type', () => {
+    expect(
+      resolveAgentStatusIdentity({
+        existing: { agentType: 'claude', state: 'working', updatedAt: 1_000 },
+        incoming: 'codex',
+        now: 1_100
+      })
+    ).toEqual({ agentType: 'claude', inheritedFromActivePane: true })
+  })
+})
+
+describe('shouldIgnoreNestedProviderSessionClaim', () => {
+  it('ignores nested Codex claims while Claude is a fresh non-done parent (#10105)', () => {
+    expect(
+      shouldIgnoreNestedProviderSessionClaim({
+        live: { agentType: 'claude', state: 'working', updatedAt: 1_000 },
+        claimedAgent: 'codex',
+        now: 1_100
+      })
+    ).toBe(true)
+  })
+
+  it('allows the same agent to refresh its own provider session', () => {
+    expect(
+      shouldIgnoreNestedProviderSessionClaim({
+        live: { agentType: 'claude', state: 'working', updatedAt: 1_000 },
+        claimedAgent: 'claude',
+        now: 1_100
+      })
+    ).toBe(false)
+  })
+
+  it('allows a new agent after the parent turn is done', () => {
+    expect(
+      shouldIgnoreNestedProviderSessionClaim({
+        live: { agentType: 'claude', state: 'done', updatedAt: 1_000 },
+        claimedAgent: 'codex',
+        now: 1_100
+      })
+    ).toBe(false)
+  })
+})
+
+describe('shouldSuppressInheritedTerminalStatus', () => {
+  it('suppresses nested done while identity was inherited from the parent pane', () => {
+    expect(
+      shouldSuppressInheritedTerminalStatus({
+        inheritedFromActivePane: true,
+        incomingState: 'done'
+      })
+    ).toBe(true)
+  })
+})

--- a/src/shared/agent-status-identity.ts
+++ b/src/shared/agent-status-identity.ts
@@ -78,3 +78,23 @@ export function resolveAgentStatusIdentity(args: {
     inheritedFromActivePane: false
   }
 }
+
+/**
+ * Nested child CLIs inherit ORCA_PANE_KEY. While the parent turn is still a
+ * fresh non-done identity, do not let the child install its resume provenance
+ * (or replace the live row) as if it owned the pane (#10105).
+ */
+export function shouldIgnoreNestedProviderSessionClaim(args: {
+  live?: ExistingAgentIdentity
+  claimedAgent?: AgentType | null
+  now: number
+  staleAfterMs?: number
+}): boolean {
+  const staleAfterMs = args.staleAfterMs ?? AGENT_STATUS_STALE_AFTER_MS
+  const liveAgentType = normalizedKnownAgentType(args.live?.agentType)
+  const claimedAgentType = normalizedKnownAgentType(args.claimedAgent)
+  if (!args.live || !liveAgentType || !claimedAgentType || liveAgentType === claimedAgentType) {
+    return false
+  }
+  return isActiveExistingIdentity(args.live, args.now, staleAfterMs)
+}


### PR DESCRIPTION
## Summary

- Keep the active parent agent as the pane owner when a nested provider hook reuses the parent's pane key.
- Ignore nested provider-session claims from a different agent while the parent identity is fresh and non-done.
- Prevent inherited child metadata from replacing the parent's resume session in the status update path.

Fixes #10105.

## Why

When Claude starts a nested Codex worker, both CLIs can inherit the same ORCA_PANE_KEY. The nested hook could then write a Codex resume record or attach the Codex session id to the live Claude row. A later cold restore or Agents return could launch the wrong provider/session file.

## Scope and design

- The guard is applied at both provider-session claim and status-metadata ingress points.
- A different provider may claim the pane after the existing parent is done or stale.
- Same-agent session refreshes remain allowed.
- Existing done-state provider-session retention and recovery semantics on main are preserved.
- The change is O(1) per identity/provider update and does not change the visible UI model beyond keeping the correct parent identity.

## Test plan

- [x] Parent Claude + nested Codex provider-session regression
- [x] Inherited identity and stale/done boundary unit tests
- [x] Existing provider-session suite: 18 passed
- [x] Typecheck
- [x] Oxlint, React Doctor lint, Oxfmt, and diff checks
- [ ] Manual: return from Agents after a Claude session starts a nested Codex worker and verify Claude resume remains selected

## Screenshots

No visual chrome changes.

## Security audit

The guard prevents a nested provider from substituting another account's session file during resume. No new filesystem, network, persistence, or credential behavior is introduced.

## Platform review

The identity logic is shared renderer state and applies equally to macOS, Linux, Windows, and SSH/remote panes. It does not depend on a provider-specific shell or path format.

## ELI5

Claude can start a Codex helper in the same terminal slot. Orca now remembers that Claude still owns the slot until Claude actually finishes, so returning later does not open the helper's session by mistake.
