### PR TITLE
fix(release): regenerate Windows blockmap via app-builder-lib JS

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1330,7 +1330,8 @@ jobs:
           }
 
           Copy-Item -Path $signedInstaller.FullName -Destination 'dist/orca-windows-setup.exe' -Force
-          & 'node_modules/app-builder-bin/win/x64/app-builder.exe' blockmap --input 'dist/orca-windows-setup.exe' --output 'dist/orca-windows-setup.exe.blockmap'
+          node config/scripts/generate-windows-blockmap.mjs 'dist/orca-windows-setup.exe' 'dist/orca-windows-setup.exe.blockmap'
+          if ($LASTEXITCODE -ne 0) { throw "blockmap generation failed with exit code $LASTEXITCODE" }
 
           $installer = Get-Item 'dist/orca-windows-setup.exe'
           $blockmap = Get-Item 'dist/orca-windows-setup.exe.blockmap'

--- a/.github/workflows/windows-signing-rehearsal.yml
+++ b/.github/workflows/windows-signing-rehearsal.yml
@@ -271,7 +271,7 @@ jobs:
             throw 'Signed Windows installer was not returned by SignPath.'
           }
           Copy-Item -Path $signedInstaller.FullName -Destination 'dist/orca-windows-setup.exe' -Force
-          & 'node_modules/app-builder-bin/win/x64/app-builder.exe' blockmap --input 'dist/orca-windows-setup.exe' --output 'dist/orca-windows-setup.exe.blockmap'
+          node config/scripts/generate-windows-blockmap.mjs 'dist/orca-windows-setup.exe' 'dist/orca-windows-setup.exe.blockmap'
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
           $installer = Get-Item 'dist/orca-windows-setup.exe'

--- a/config/scripts/generate-windows-blockmap.mjs
+++ b/config/scripts/generate-windows-blockmap.mjs
@@ -1,0 +1,18 @@
+// Regenerate the electron-updater `.blockmap` for a (re-signed) Windows installer.
+// electron-builder 26 dropped the app-builder-bin Go binary; blockmap generation
+// now lives in app-builder-lib's pure-JS `buildBlockMap`. Mirrors createBlockmap's
+// "gzip" format for the standalone NSIS installer blockmap.
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+
+const [input, output] = process.argv.slice(2)
+if (!input || !output) {
+  console.error('usage: generate-windows-blockmap.mjs <input.exe> <output.exe.blockmap>')
+  process.exit(1)
+}
+
+const { buildBlockMap } = require('app-builder-lib/out/targets/blockmap/blockmap')
+
+const info = await buildBlockMap(input, 'gzip', output)
+console.log(`blockmap written: ${output} (installer sha512=${info.sha512}, size=${info.size})`)


### PR DESCRIPTION
## Problem

The `main Cut Release` Windows build fails at **Stage signed Windows release assets** ([run 29982009818](https://github.com/stablyai/orca/actions/runs/29982009818)):

```
The term 'node_modules/app-builder-bin/win/x64/app-builder.exe' is not recognized
as a name of a cmdlet, function, script file, or executable program.
```

## Root cause

electron-builder was bumped to `^26.15.3`. **electron-builder 26 dropped the `app-builder-bin` Go binary** — that package is no longer installed, so `app-builder.exe blockmap` doesn't exist. Blockmap generation moved into `app-builder-lib`'s pure-JS `buildBlockMap` (`app-builder-lib/out/targets/blockmap/blockmap.js`), which `createBlockmap` calls with the `gzip` format for the standalone NSIS installer `.blockmap`.

## Fix

- Add `config/scripts/generate-windows-blockmap.mjs`, which calls `buildBlockMap(input, 'gzip', output)` — the same code path electron-builder itself uses for the installer blockmap.
- Replace the dead `app-builder.exe blockmap` call in **both** `release-cut.yml` and `windows-signing-rehearsal.yml` (identical usage) with the script, keeping the exit-code guard.

The surrounding PowerShell already computes `sha512`/`size`/`blockMapSize` from the files itself, so only the `.blockmap` file needs producing. `shamefully-hoist=true` guarantees `app-builder-lib` resolves from the project root in CI.

## Testing

- Verified `buildBlockMap` produces a valid gzip `.blockmap` and returns `{sha512,size}` locally against a dummy binary.
- Both workflow YAMLs parse cleanly.

Made with [Orca](https://github.com/stablyai/orca) 🐋
