### PR TITLE
test(worktree): fix main CI red from #10106 (teardown + watch tests)

### DIFF
--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { appendFile, mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
@@ -362,8 +363,11 @@ describe('worktree git-common polling gate (non-darwin)', () => {
 
     await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
     const worktreesDir = join(commonDir, 'worktrees')
-    await rm(worktreesDir, { recursive: true, force: true })
-    await writeFile(worktreesDir, 'not-a-dir')
+    // Swap dir -> file synchronously so no event-loop turn (and thus no poll
+    // tick) observes the transient ENOENT window, which would legitimately emit
+    // a delete and defeat the non-ENOENT assertion below.
+    rmSync(worktreesDir, { recursive: true, force: true })
+    writeFileSync(worktreesDir, 'not-a-dir')
     await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
 
     expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36951,7 +36951,11 @@ describe('OrcaRuntimeService', () => {
     })
 
     it('does not start Git removal when physical PTY stop cannot be proven', async () => {
-      const localProvider = createProviderStub(async () => [])
+      // A failed stop only rejects when a fresh inventory still shows the PTY
+      // live; keep pty-1 present so the exit cannot be proven.
+      const localProvider = createProviderStub(async () => [
+        { id: 'pty-1', cwd: '/tmp', title: 'shell' }
+      ])
       const runtime = new OrcaRuntimeService(store, undefined, {
         getLocalProvider: () => localProvider as never
       })


### PR DESCRIPTION
## Description
`main` went red after #10106 ("verify exited PTYs before blocking deletion") merged — its `verify` job left two failing tests it didn't update. This isolates the fixes for both.

## Fixes
1. **`orca-runtime.test.ts` → "does not start Git removal when physical PTY stop cannot be proven"** — stale after #10106. The new `killAllProcessesForWorktree` tolerates a failed PTY stop when a fresh `listProcesses` inventory proves the PTY exited. The test's provider stub returned an **empty** inventory (= proven exited), so it resolved `{}` instead of rejecting. Fix keeps `pty-1` live in the inventory so the exit genuinely can't be proven → it rejects as intended.
2. **`worktree-git-common-watch.test.ts` → "does not fabricate worktree deletions when the readdir fails non-ENOENT (transient)"** — a test race exposed under CI load. Between `await rm(worktreesDir)` and `await writeFile(worktreesDir)`, a poll tick could observe the dir as ENOENT (a legitimate "all removed" → emits a `delete`), defeating the non-ENOENT assertion. Swapped to synchronous `rmSync`/`writeFileSync` so no event-loop turn (and thus no poll tick) sees the transient ENOENT window.

## Evidence
```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime.test.ts \
  src/main/ipc/worktree-git-common-watch.test.ts
```
Both pass locally.

## Notes
- Test-only changes; no production code touched.
- Cross-platform: sync swap is `node:fs`, works on macOS/Linux/Windows.

Made with [Orca](https://github.com/stablyai/orca) 🐋
