### PR TITLE
fix(terminal): infer keydown-captured interrupts on fire-and-forget SSH transports

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3401,9 +3401,11 @@ describe('connectPanePty', () => {
       onDataHandler = handler
       return { dispose: vi.fn() }
     }) as typeof pane.terminal.onData)
+    const manager = createManager(1)
+    manager.getActivePane.mockReturnValue({ id: 1 })
     const deps = createDeps()
 
-    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    connectPanePty(pane as never, manager as never, deps as never)
     if (!onDataHandler) {
       throw new Error('expected onData handler to be registered')
     }
@@ -3414,7 +3416,81 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(transport.sendInput).toHaveBeenCalledWith('\x03')
-    expect(deps.setRuntimePaneTitle).toHaveBeenCalled()
+    expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Terminal')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Terminal')
+  })
+
+  it('does not infer a fire-and-forget interrupt from an Alt chord that emits an Escape prefix', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    delete transport.sendInputAccepted
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'working',
+      prompt: 'keep working',
+      updatedAt: 1_000,
+      stateStartedAt: 900,
+      agentType: 'claude',
+      paneKey,
+      terminalTitle: '⠂ keep working',
+      stateHistory: []
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    // Alt+b sends ESC+b; the leading \x1b must not read as a user interrupt.
+    terminalTarget.dispatch(keyEvent({ key: 'b', altKey: true }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1bb')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1bb')
+    expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
+  })
+
+  it('does not infer a fire-and-forget interrupt for a pane with no working agent status', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    delete transport.sendInputAccepted
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    // Esc in a plain shell/vim pane: no agent turn to interrupt.
+    terminalTarget.dispatch(keyEvent({ key: 'Escape' }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(500)
+    await flushAsyncTicks()
+
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b')
+    expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
   })
 
   it('infers exact Ctrl+C terminal input when keydown capture misses the press', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -3334,7 +3334,54 @@ describe('connectPanePty', () => {
     expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Terminal')
   })
 
-  it('does not clear title-only working indicators when interrupt writes are unacknowledged', async () => {
+  it('infers a keydown-captured interrupt on fire-and-forget transports (#SSH stuck working)', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    delete transport.sendInputAccepted
+    transportFactoryQueue.push(transport)
+    vi.useFakeTimers()
+    vi.setSystemTime(1_100)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState.agentStatusByPaneKey[paneKey] = {
+      state: 'working',
+      prompt: 'stop this task',
+      updatedAt: 1_000,
+      stateStartedAt: 900,
+      agentType: 'claude',
+      paneKey,
+      terminalTitle: '⠂ stop this task',
+      stateHistory: []
+    }
+    const terminalTarget = createKeyboardEventTarget()
+    const pane = createPane(1)
+    ;(pane.terminal as { element?: unknown }).element = terminalTarget.target
+    let onDataHandler: ((data: string) => void) | null = null
+    pane.terminal.onData = vi.fn(((handler: (data: string) => void) => {
+      onDataHandler = handler
+      return { dispose: vi.fn() }
+    }) as typeof pane.terminal.onData)
+
+    connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    if (!onDataHandler) {
+      throw new Error('expected onData handler to be registered')
+    }
+    terminalTarget.dispatch(keyEvent({ key: 'Escape' }))
+    ;(onDataHandler as unknown as (data: string) => void)('\x1b')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(500)
+
+    expect(transport.sendInput).toHaveBeenCalledWith('\x1b')
+    expect(window.api.agentStatus.inferInterrupt).toHaveBeenCalledWith({
+      paneKey,
+      baselineUpdatedAt: 1_000,
+      baselineStateStartedAt: 900,
+      baselinePrompt: 'stop this task',
+      baselineAgentType: 'claude',
+      intent: 'plain-escape'
+    })
+  })
+
+  it('clears title-only working indicators after a keydown-captured fire-and-forget interrupt', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
     delete transport.sendInputAccepted
@@ -3367,9 +3414,7 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(transport.sendInput).toHaveBeenCalledWith('\x03')
-    expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
-    expect(deps.setRuntimePaneTitle).not.toHaveBeenCalled()
-    expect(deps.updateTabTitle).not.toHaveBeenCalled()
+    expect(deps.setRuntimePaneTitle).toHaveBeenCalled()
   })
 
   it('infers exact Ctrl+C terminal input when keydown capture misses the press', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3753,6 +3753,15 @@ export function connectPanePty(
         markAcceptedTerminalInputSent()
         observeAcceptedShellCommandInput(data)
         observeAcceptedTerminalInput(data, intent)
+        // Why: fire-and-forget transports (SSH) can't confirm delivery, but a
+        // DOM-captured Esc/Ctrl+C is a real user interrupt; without inference a
+        // Claude turn interrupted over SSH stays 'working' forever (no Stop
+        // hook fires on interrupt). The inference settle window re-checks the
+        // status entry, so an undelivered keystroke self-corrects on the next
+        // hook ping. Exact-byte inference stays excluded — bytes without a
+        // keydown are not proof of a user interrupt.
+        interruptInference.observeInputIntent(intent)
+        observeTitleOnlyInterrupt()
       } else {
         requestRecoveryForUndeliverableInput()
       }


### PR DESCRIPTION
## Summary

Pressing Esc to interrupt a Claude turn in an **SSH** worktree left the pane stuck showing "working" forever. Interrupting an agent produces no Stop hook, so the only signal that the turn ended is the interrupt itself — and on SSH the input transport is fire-and-forget, so the renderer never learns the keystroke was delivered and never clears the status.

The fix feeds DOM-captured interrupt intents (`Esc`, `Ctrl+C`) into the existing interrupt-inference path on fire-and-forget transports. Crucially it infers only from a **keydown-derived intent**, never from raw bytes: bytes alone are not proof of a user interrupt.

Closes #10114

## ELI5

When you press Esc to stop the AI mid-answer, Orca normally notices and flips the little "working…" badge back to idle. Over a remote SSH connection, Orca sends the keystroke but never gets a receipt, so it kept showing "working…" forever even though the AI had already stopped — and nothing would ever clear it.

Now, when *you* physically press Esc, Orca takes that as good enough evidence to clear the badge. It's careful about what counts: holding Alt and pressing a letter technically sends the same invisible character as Esc, and that does **not** count. And if the keystroke somehow never made it, the next real status update from the AI puts the badge back.

## Proof of fix

Two tests fail against this branch's merge base and pass here:

```
$ git checkout $(git merge-base HEAD origin/main) -- src/renderer/src/components/terminal-pane/pty-connection.ts
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/pty-connection.test.ts \
    -t "fire-and-forget"

 × infers a keydown-captured interrupt on fire-and-forget transports (#SSH stuck working)
     AssertionError: expected "vi.fn()" to be called with arguments: [ { …(6) } ]
     Number of calls: 0
 × clears title-only working indicators after a keydown-captured fire-and-forget interrupt
     AssertionError: expected "vi.fn()" to be called with arguments: [ 'tab-1', 1, 'Terminal' ]
     Number of calls: 0

      Tests  2 failed | 2 passed | 465 skipped (469)
```

```
$ git checkout HEAD -- src/renderer/src/components/terminal-pane/pty-connection.ts
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/pty-connection.test.ts \
    -t "fire-and-forget"

      Tests  4 passed | 465 skipped (469)
```

Use the **merge-base** copy of the file, not `origin/main`. An earlier version of this section checked out `origin/main`; `main` has since drifted and now imports `../../../../shared/worktree-removal-fence-error`, whose sibling does not exist on this branch, so that run dies with `Cannot find module` before a single assertion executes — a module-resolution failure, not evidence.

The `2 passed` in the first run are the two false-positive guards. They pass at the merge base **by construction** — code that never infers cannot infer wrongly — so they are not proof that this change does anything. They exist to pin the two ways the inference goes wrong once it exists:

- **Alt chord emitting an ESC prefix.** `Alt+f`, `Alt+b`, and every other Alt shortcut send `0x1b` + the key — byte-identical to a bare Esc. Inferring from bytes would mark an agent idle every time a user pressed an Alt shortcut while it was working. Inference is therefore keydown-derived only.
- **Pane with no working agent status.** The inference must be inert unless the pane is actually in a `working` state, so an Esc in a plain shell (or in vim, or dismissing a TUI menu) cannot manufacture a status transition.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/
 Test Files  182 passed (182)
      Tests  2340 passed (2340)

$ npx tsc --noEmit -p config/tsconfig.tc.web.json      # exit 0
```

User-visible behavior that changes:

- On a **fire-and-forget (SSH) transport**, a DOM-captured Esc/Ctrl+C while an agent is `working` now clears the stuck status. Intended fix.
- The **local** path is untouched: it has real delivery acknowledgement, so it keeps using that and gains no inference.
- Exact-byte interrupt inference remains excluded, so pasted or programmatically-written `0x1b` cannot flip status.

## Compatibility

- **Platforms:** macOS / Linux / Windows. The inference keys off a keydown-derived intent already normalized upstream of this code, so no `e.metaKey` is introduced or hardcoded here — per `AGENTS.md`, the Cmd/Ctrl platform branch lives in the existing key handling and is untouched.
- **SSH / remote:** This is the entire point of the change, and the scoping is the load-bearing part. Inference is applied **only** where the transport cannot acknowledge delivery; transports that do acknowledge keep their existing, stronger signal. The failure mode of a dropped keystroke is bounded: the inference settle window re-checks the status entry, so a keystroke that never arrived self-corrects on the next hook ping rather than latching a wrong idle state. Optimistic, not authoritative.
- **Performance:** No hot-path change. One call on an input path that already ran `observeAcceptedTerminalInput`; no new timers per keystroke, no added IPC, no re-render trigger. Terminal panes are created and destroyed constantly, and this adds no per-pane resource to leak.

## Screenshots

No visual change beyond the agent-status badge clearing when it previously stuck. The behavior is asserted in `pty-connection.test.ts` — including both false-positive guards — rather than captured as an image. I did not record a screen capture of an SSH interrupt; noting that plainly rather than implying a manual check that was not performed.

## Testing

- [ ] `pnpm lint` — not run in full.
- [x] `pnpm typecheck` — `npx tsc --noEmit -p config/tsconfig.tc.web.json`, exit 0.
- [ ] `pnpm test` — not run in full (30+ min). Ran the whole touched directory: `src/renderer/src/components/terminal-pane/` → 182 files, 2340 tests passed.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions — two behaviour tests that fail at the merge base (keydown-captured interrupt inference; title-only indicator clearing) plus two false-positive guards (Alt-chord ESC prefix; no-working-status pane).

## AI Review Report

Reviewed with Claude Code (Opus 5) and re-verified independently. Risks checked:

- **False positives — the dominant risk.** Inferring intent is only safe if the signal cannot be produced accidentally. Enumerated the ways `0x1b` reaches a PTY without being a user interrupt: Alt chords (ESC-prefixed), Esc in vim normal mode, Esc dismissing a TUI completion menu, and bracketed paste containing `0x1b`. The fix infers from a keydown-derived intent rather than bytes, and is inert unless the pane is `working` — so none of these can flip an agent to idle. The Alt-chord case is pinned by a dedicated test because it is the one most likely to be missed.
- **The mirror-image bug.** Marking an agent idle while it is genuinely still working is arguably worse than the stuck badge, since the user stops waiting. Verified the inferred state is optimistic and correctable: the settle window re-checks the status entry, and a real hook event overrides it. It is not a latch.
- **Scope to fire-and-forget only:** confirmed the local acknowledged path is unchanged, so no status handling regresses for the majority of users.
- **Lifetime/leaks:** no new per-pane timer or listener is introduced on the keystroke path.
- **Cross-platform:** no paths, shell behavior, or Electron APIs touched; no new modifier handling.

## Security Audit

- **Input handling:** the change consumes an already-parsed keydown intent; it adds no new parsing of untrusted terminal bytes. Notably it *declines* to infer from raw bytes, which is the safer choice — remote output or a paste cannot synthesize an interrupt.
- **Command execution:** none. No new input is written to the PTY; this only affects how an already-sent keystroke updates local UI status.
- **Path handling:** none.
- **Auth / secrets:** none touched.
- **Dependencies:** none added or changed.
- **IPC:** no new channel or payload; the existing send path is unchanged.

## Notes

- Adjacent in-flight work that touches neighbouring agent-status / PTY-write paths and is worth sequencing against: **#9507** (suppressing "Task complete" while a Codex tool is still running) and **#9716** (reporting writes to a gone PTY as not-written). No file overlap with either, but all three shape when a pane's agent status changes.
- The inference is deliberately optimistic. If a future change makes SSH input delivery acknowledgeable, this path should be retired in favour of the real signal rather than kept alongside it.
- **Known residual — title-only panes do not get the per-agent intent rules.** `observeTitleOnlyInterrupt` runs only when a pane has *no* explicit agent-status row, and it is agent-agnostic by design (`pty-connection.ts` — "title-only agents such as Pi can miss their own idle title after Ctrl+C"). It therefore skips the per-agent rules in `agent-interrupt-inference.ts`: double-Escape for `opencode`/`copilot`, ignored Ctrl+C for `droid`. So a single Escape on a title-only OpenCode pane can neutralize a still-working spinner title after the settle window. That gap is pre-existing — the acknowledged path at `:3737` calls the same helper unconditionally, so local panes have it today — but SSH panes are disproportionately title-only because hooks are unavailable there (#8711), which raises its exposure. Resolving the agent from the title / `launchAgent` before arming title-only cleanup is the fix; deliberately left out of scope here rather than widening a shared path in a bug PR.

Original patch by @choihjin.


