### PR TITLE
perf(daemon): make droppable stream tracking constant-time

### DIFF
--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -759,6 +759,7 @@ export class DaemonServer {
                   sessionIdSuffix: routedSessionId.slice(-10)
                 })
                 this.transientFactRelay.onSessionExit(routedSessionId)
+                this.streamDataBatcher.refreshSessionDroppability(routedSessionId)
                 this.streamClientIdBySessionId.delete(routedSessionId)
                 this.lastInputAtBySessionId.delete(routedSessionId)
                 this.reevaluateIdleShutdown()
@@ -771,6 +772,7 @@ export class DaemonServer {
         }
         routedSessionId = result.agentSessionEnsure?.owner.ptyId ?? p.sessionId
         this.streamClientIdBySessionId.set(routedSessionId, clientId)
+        this.streamDataBatcher.refreshSessionDroppability(routedSessionId)
         // Why an attach-time marker: background resync can precede this attach, so scan suppression must start at the new stream's head.
         if (this.transientFactRelay.isBackgrounded(routedSessionId)) {
           this.streamDataBatcher.enqueueControlEvent(clientId, routedSessionId, {
@@ -845,7 +847,12 @@ export class DaemonServer {
           sessionIdSuffix: sessionId.slice(-10),
           background
         })
-        if (!this.transientFactRelay.setSessionBackground(sessionId, background)) {
+        const backgroundChanged = this.transientFactRelay.setSessionBackground(
+          sessionId,
+          background
+        )
+        this.streamDataBatcher.refreshSessionDroppability(sessionId)
+        if (!backgroundChanged) {
           return {}
         }
         if (background) {

--- a/src/main/daemon/daemon-stream-data-batcher.ts
+++ b/src/main/daemon/daemon-stream-data-batcher.ts
@@ -6,14 +6,13 @@ import {
   encodeStreamDataEvent,
   writeStreamDataEvents
 } from './daemon-stream-data-split'
-import {
-  backgroundSessionDropCapChars,
-  backgroundSessionKeepTailChars,
-  dropOldestQueuedForSession,
-  type PendingStreamDataBatch
-} from './daemon-stream-keep-tail-drop'
+import type { PendingStreamDataBatch } from './daemon-stream-keep-tail-drop'
 import type { DaemonEvent } from './types'
 import { appendDaemonStreamData, type DaemonStreamEnqueueOptions } from './daemon-stream-data-entry'
+import {
+  evaluateDroppableEnqueue,
+  refreshDroppableSessionMembership
+} from './daemon-stream-droppable-membership'
 
 type StreamDataClient = {
   streamSocket: Socket | null
@@ -74,30 +73,16 @@ export class DaemonStreamDataBatcher {
     }
 
     const batch = this.getOrCreateBatch(clientId)
-    appendDaemonStreamData(batch, sessionId, data, options)
-
-    if (this.isSessionDroppable(sessionId)) {
-      // Keep-tail scales down as more backgrounded sessions queue, bounding the aggregate a reveal must drain (see daemon-stream-keep-tail-drop).
-      const droppableQueued = this.countDroppableSessionsWithQueuedData(batch)
-      const dropCap = backgroundSessionDropCapChars(droppableQueued)
-      const keepTail = backgroundSessionKeepTailChars(droppableQueued)
-      if ((batch.queuedCharsBySession.get(sessionId) ?? 0) > dropCap) {
-        dropOldestQueuedForSession(batch, sessionId, keepTail, this.salvageDroppedData)
-      }
-      if (droppableQueued > (batch.lastDroppableSessionCount ?? 0)) {
-        // Shared budget tightened: re-trim sessions that already finished producing — they never re-enter this path on their own.
-        for (const [queuedSessionId, queued] of Array.from(batch.queuedCharsBySession)) {
-          if (
-            queued > dropCap &&
-            queuedSessionId !== sessionId &&
-            this.isSessionDroppable(queuedSessionId)
-          ) {
-            dropOldestQueuedForSession(batch, queuedSessionId, keepTail, this.salvageDroppedData)
-          }
-        }
-      }
-      batch.lastDroppableSessionCount = droppableQueued
-    }
+    const queuedAfter = appendDaemonStreamData(batch, sessionId, data, options)
+    const queuedBefore = queuedAfter - data.length
+    evaluateDroppableEnqueue(
+      batch,
+      sessionId,
+      queuedBefore,
+      queuedAfter,
+      this.isSessionDroppable,
+      this.salvageDroppedData
+    )
 
     if (
       options.flushImmediately === true &&
@@ -125,20 +110,21 @@ export class DaemonStreamDataBatcher {
     }
   }
 
-  private countDroppableSessionsWithQueuedData(batch: PendingStreamDataBatch): number {
-    let count = 0
-    for (const [sessionId, queued] of batch.queuedCharsBySession) {
-      if (queued > 0 && this.isSessionDroppable(sessionId)) {
-        count++
-      }
-    }
-    return count
+  refreshSessionDroppability(sessionId: string): void {
+    const droppable = this.isSessionDroppable(sessionId)
+    refreshDroppableSessionMembership(this.pendingByClient.values(), sessionId, droppable)
   }
 
   private getOrCreateBatch(clientId: string): PendingStreamDataBatch {
     let batch = this.pendingByClient.get(clientId)
     if (!batch) {
-      batch = { timer: null, queue: [], queuedChars: 0, queuedCharsBySession: new Map() }
+      batch = {
+        timer: null,
+        queue: [],
+        queuedChars: 0,
+        queuedCharsBySession: new Map(),
+        droppableQueuedSessionIds: new Set()
+      }
       this.pendingByClient.set(clientId, batch)
     }
     return batch
@@ -225,6 +211,7 @@ export class DaemonStreamDataBatcher {
         (batch.queuedCharsBySession.get(entry.sessionId) ?? slice.length) - slice.length
       if (sessionHeldAfter <= 0) {
         batch.queuedCharsBySession.delete(entry.sessionId)
+        batch.droppableQueuedSessionIds.delete(entry.sessionId)
       } else {
         batch.queuedCharsBySession.set(entry.sessionId, sessionHeldAfter)
       }
@@ -296,6 +283,7 @@ export class DaemonStreamDataBatcher {
     batch.queue = retained
     batch.queuedChars -= flushedChars
     batch.queuedCharsBySession.delete(sessionId)
+    batch.droppableQueuedSessionIds.delete(sessionId)
     if (batch.queue.length === 0) {
       if (batch.timer) {
         clearTimeout(batch.timer)

--- a/src/main/daemon/daemon-stream-data-entry.ts
+++ b/src/main/daemon/daemon-stream-data-entry.ts
@@ -13,7 +13,7 @@ export function appendDaemonStreamData(
   sessionId: string,
   data: string,
   options: DaemonStreamEnqueueOptions
-): void {
+): number {
   const last = batch.queue.at(-1)
   // Why: control and transformed spans mark indivisible source-stream positions.
   if (
@@ -39,8 +39,7 @@ export function appendDaemonStreamData(
     })
   }
   batch.queuedChars += data.length
-  batch.queuedCharsBySession.set(
-    sessionId,
-    (batch.queuedCharsBySession.get(sessionId) ?? 0) + data.length
-  )
+  const queuedAfter = (batch.queuedCharsBySession.get(sessionId) ?? 0) + data.length
+  batch.queuedCharsBySession.set(sessionId, queuedAfter)
+  return queuedAfter
 }

--- a/src/main/daemon/daemon-stream-droppability-lifecycle.test.ts
+++ b/src/main/daemon/daemon-stream-droppability-lifecycle.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import type { Socket } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonServer } from './daemon-server'
+import type { DaemonStreamDataBatcher } from './daemon-stream-data-batcher'
+import type { BackgroundTransientFactRelay } from './daemon-background-transient-facts'
+import type { PendingStreamDataBatch } from './daemon-stream-keep-tail-drop'
+import type { SubprocessHandle } from './session'
+import type { DaemonRequest } from './types'
+
+type MockSubprocess = SubprocessHandle & {
+  emitData(data: string): void
+  emitExit(code: number): void
+}
+
+type DaemonLifecyclePrivate = {
+  clients: Map<
+    string,
+    {
+      clientId: string
+      controlSocket: Socket
+      streamSocket: Socket | null
+      authenticatedPairEstablished: boolean
+    }
+  >
+  host: {
+    getPartialEscapeTailAnsi(sessionId: string): string
+  }
+  routeRequest(clientId: string, request: DaemonRequest): Promise<unknown>
+  streamDataBatcher: DaemonStreamDataBatcher
+  transientFactRelay: BackgroundTransientFactRelay
+  streamClientIdBySessionId: Map<string, string>
+}
+
+function createMockSubprocess(): MockSubprocess {
+  let onData: ((data: string) => void) | undefined
+  let onExit: ((code: number) => void) | undefined
+  return {
+    pid: 55_555,
+    getForegroundProcess: () => null,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(() => onExit?.(0)),
+    forceKill: vi.fn(() => onExit?.(137)),
+    signal: vi.fn(),
+    onData(callback) {
+      onData = callback
+    },
+    onExit(callback) {
+      onExit = callback
+    },
+    dispose: vi.fn(),
+    emitData(data) {
+      onData?.(data)
+    },
+    emitExit(code) {
+      onExit?.(code)
+    }
+  }
+}
+
+function createServerHarness() {
+  const subprocesses: MockSubprocess[] = []
+  const unique = randomUUID()
+  const server = new DaemonServer({
+    socketPath: join(tmpdir(), `orca-droppability-${unique}.sock`),
+    tokenPath: join(tmpdir(), `orca-droppability-${unique}.token`),
+    spawnSubprocess: () => {
+      const subprocess = createMockSubprocess()
+      subprocesses.push(subprocess)
+      return subprocess
+    }
+  })
+  return {
+    server,
+    daemon: server as unknown as DaemonLifecyclePrivate,
+    subprocesses
+  }
+}
+
+function addClient(
+  daemon: DaemonLifecyclePrivate,
+  writableLength = 0
+): Socket & { write: ReturnType<typeof vi.fn>; writableLength: number } {
+  const controlSocket = { destroy: vi.fn() } as unknown as Socket
+  const streamSocket = {
+    destroyed: false,
+    writableLength,
+    destroy: vi.fn(),
+    write: vi.fn(() => true)
+  } as unknown as Socket & {
+    write: ReturnType<typeof vi.fn>
+    writableLength: number
+  }
+  daemon.clients.set('client-1', {
+    clientId: 'client-1',
+    controlSocket,
+    streamSocket,
+    authenticatedPairEstablished: true
+  })
+  return streamSocket
+}
+
+function pendingBatch(batcher: DaemonStreamDataBatcher): PendingStreamDataBatch {
+  const pending = (
+    batcher as unknown as {
+      pendingByClient: Map<string, PendingStreamDataBatch>
+    }
+  ).pendingByClient.get('client-1')
+  if (!pending) {
+    throw new Error('Missing client-1 stream batch')
+  }
+  return pending
+}
+
+describe('daemon stream droppability lifecycle', () => {
+  let server: DaemonServer | undefined
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(async () => {
+    await server?.shutdown()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('refreshes after every background mutation and before changed markers', async () => {
+    const harness = createServerHarness()
+    server = harness.server
+    const { daemon } = harness
+    addClient(daemon)
+    daemon.streamClientIdBySessionId.set('session-toggle', 'client-1')
+    vi.spyOn(daemon.host, 'getPartialEscapeTailAnsi').mockReturnValue('')
+    const lifecycle: string[] = []
+    vi.spyOn(daemon.streamDataBatcher, 'refreshSessionDroppability').mockImplementation(
+      (sessionId) => {
+        lifecycle.push(`refresh:${String(daemon.transientFactRelay.isBackgrounded(sessionId))}`)
+      }
+    )
+    vi.spyOn(daemon.streamDataBatcher, 'enqueueControlEvent').mockImplementation(
+      (_clientId, _sessionId, control) => {
+        lifecycle.push(
+          `marker:${String(
+            control.event === 'sessionBackgroundMarker' && control.payload.background
+          )}`
+        )
+      }
+    )
+
+    await daemon.routeRequest('client-1', {
+      id: 'background',
+      type: 'setSessionBackground',
+      payload: { sessionId: 'session-toggle', background: true }
+    })
+    expect(lifecycle).toEqual(['refresh:true', 'marker:true'])
+
+    lifecycle.length = 0
+    await daemon.routeRequest('client-1', {
+      id: 'duplicate-background',
+      type: 'setSessionBackground',
+      payload: { sessionId: 'session-toggle', background: true }
+    })
+    expect(lifecycle).toEqual(['refresh:true'])
+
+    lifecycle.length = 0
+    await daemon.routeRequest('client-1', {
+      id: 'foreground',
+      type: 'setSessionBackground',
+      payload: { sessionId: 'session-toggle', background: false }
+    })
+    expect(lifecycle).toEqual(['refresh:false', 'marker:false'])
+  })
+
+  it('routes an attached session before refresh and emits its background marker after', async () => {
+    const harness = createServerHarness()
+    server = harness.server
+    const { daemon } = harness
+    addClient(daemon)
+    daemon.transientFactRelay.setSessionBackground('session-attach', true)
+    const lifecycle: string[] = []
+    vi.spyOn(daemon.streamDataBatcher, 'refreshSessionDroppability').mockImplementation(
+      (sessionId) => {
+        lifecycle.push(`refresh:${daemon.streamClientIdBySessionId.get(sessionId) ?? 'unrouted'}`)
+      }
+    )
+    vi.spyOn(daemon.streamDataBatcher, 'enqueueControlEvent').mockImplementation(
+      (_clientId, _sessionId, control) => {
+        lifecycle.push(`marker:${control.event}`)
+      }
+    )
+
+    await daemon.routeRequest('client-1', {
+      id: 'attach',
+      type: 'createOrAttach',
+      payload: { sessionId: 'session-attach', cols: 80, rows: 24 }
+    })
+
+    expect(lifecycle).toEqual(['refresh:client-1', 'marker:sessionBackgroundMarker'])
+  })
+
+  it('invalidates droppable membership for final output held behind a deep socket', async () => {
+    const harness = createServerHarness()
+    server = harness.server
+    const { daemon, subprocesses } = harness
+    addClient(daemon, 128 * 1024)
+    daemon.transientFactRelay.setSessionBackground('session-exit', true)
+
+    await daemon.routeRequest('client-1', {
+      id: 'attach',
+      type: 'createOrAttach',
+      payload: { sessionId: 'session-exit', cols: 80, rows: 24 }
+    })
+    const subprocess = subprocesses[0]
+    subprocess.emitData('final-output'.repeat(1024))
+    expect(pendingBatch(daemon.streamDataBatcher).droppableQueuedSessionIds).toContain(
+      'session-exit'
+    )
+
+    subprocess.emitExit(42)
+
+    const batch = pendingBatch(daemon.streamDataBatcher)
+    expect(batch.droppableQueuedSessionIds).not.toContain('session-exit')
+    expect(batch.queuedCharsBySession.get('session-exit')).toBeGreaterThan(0)
+    expect(batch.queue.at(-1)?.control).toMatchObject({
+      event: 'exit',
+      payload: { code: 42 }
+    })
+    expect(daemon.transientFactRelay.isBackgrounded('session-exit')).toBe(false)
+    expect(daemon.streamClientIdBySessionId.has('session-exit')).toBe(false)
+  })
+})

--- a/src/main/daemon/daemon-stream-droppable-membership.test.ts
+++ b/src/main/daemon/daemon-stream-droppable-membership.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Socket } from 'node:net'
+import { DaemonStreamDataBatcher } from './daemon-stream-data-batcher'
+import type { PendingStreamDataBatch } from './daemon-stream-keep-tail-drop'
+
+type TestSocket = Socket & {
+  write: ReturnType<typeof vi.fn>
+  writableLength: number
+}
+
+function createSocket(): TestSocket {
+  return {
+    destroyed: false,
+    writableLength: 0,
+    write: vi.fn(() => true)
+  } as unknown as TestSocket
+}
+
+function createBatcher(options?: ConstructorParameters<typeof DaemonStreamDataBatcher>[1]) {
+  const sockets = new Map<string, TestSocket>()
+  const socketFor = (clientId: string): TestSocket => {
+    let socket = sockets.get(clientId)
+    if (!socket) {
+      socket = createSocket()
+      sockets.set(clientId, socket)
+    }
+    return socket
+  }
+  const batcher = new DaemonStreamDataBatcher(
+    (clientId) => ({ streamSocket: socketFor(clientId) }),
+    options
+  )
+  return { batcher, socketFor }
+}
+
+function pendingBatch(
+  batcher: DaemonStreamDataBatcher,
+  clientId = 'client-1'
+): PendingStreamDataBatch {
+  const pendingByClient = (
+    batcher as unknown as {
+      pendingByClient: Map<string, PendingStreamDataBatch>
+    }
+  ).pendingByClient
+  const batch = pendingByClient.get(clientId)
+  if (!batch) {
+    throw new Error(`Missing pending batch for ${clientId}`)
+  }
+  return batch
+}
+
+function pendingByClient(batcher: DaemonStreamDataBatcher): Map<string, PendingStreamDataBatch> {
+  return (
+    batcher as unknown as {
+      pendingByClient: Map<string, PendingStreamDataBatch>
+    }
+  ).pendingByClient
+}
+
+describe('DaemonStreamDataBatcher droppable membership', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('does no droppability scans for steady-state output from an existing member', () => {
+    const isSessionDroppable = vi.fn(() => true)
+    const { batcher } = createBatcher({ isSessionDroppable })
+    const sessionCount = 100
+    const chunkCount = 1_000
+
+    for (let index = 0; index < sessionCount; index++) {
+      batcher.enqueue('client-1', `session-${index}`, 'seed')
+    }
+    const batch = pendingBatch(batcher)
+    const mapGet = vi.spyOn(batch.queuedCharsBySession, 'get')
+    const mapSet = vi.spyOn(batch.queuedCharsBySession, 'set')
+    const mapIterator = vi.spyOn(batch.queuedCharsBySession, Symbol.iterator)
+    const mapEntries = vi.spyOn(batch.queuedCharsBySession, 'entries')
+    const mapValues = vi.spyOn(batch.queuedCharsBySession, 'values')
+    const mapForEach = vi.spyOn(batch.queuedCharsBySession, 'forEach')
+    const membershipHas = vi.spyOn(batch.droppableQueuedSessionIds, 'has')
+    isSessionDroppable.mockClear()
+
+    for (let index = 0; index < chunkCount; index++) {
+      batcher.enqueue('client-1', 'session-0', 'x')
+    }
+
+    // Legacy evaluated the producer plus all 100 queued sessions per chunk: 101,000 calls.
+    expect(isSessionDroppable).toHaveBeenCalledTimes(0)
+    expect(mapIterator).toHaveBeenCalledTimes(0)
+    expect(mapEntries).toHaveBeenCalledTimes(0)
+    expect(mapValues).toHaveBeenCalledTimes(0)
+    expect(mapForEach).toHaveBeenCalledTimes(0)
+    expect(mapGet).toHaveBeenCalledTimes(chunkCount)
+    expect(mapSet).toHaveBeenCalledTimes(chunkCount)
+    expect(membershipHas).toHaveBeenCalledTimes(chunkCount)
+    expect(batcher.queuedCharsForClient('client-1')).toBe(1_400)
+    expect(batch.queuedCharsBySession.get('session-0')).toBe(1_004)
+    expect(batch.droppableQueuedSessionIds).toHaveLength(sessionCount)
+  })
+
+  it('evaluates a new positive session exactly once and records membership', () => {
+    const isSessionDroppable = vi.fn(() => true)
+    const { batcher } = createBatcher({ isSessionDroppable })
+
+    batcher.enqueue('client-1', 'session-new', 'x')
+
+    expect(isSessionDroppable).toHaveBeenCalledTimes(1)
+    expect(isSessionDroppable).toHaveBeenCalledWith('session-new')
+    expect(pendingBatch(batcher).droppableQueuedSessionIds).toEqual(new Set(['session-new']))
+  })
+
+  it('evaluates a transformed zero span without adding it and preserves growth re-trimming', () => {
+    let droppable = false
+    const isSessionDroppable = vi.fn(() => droppable)
+    const { batcher } = createBatcher({ isSessionDroppable })
+    const queued = 1_100 * 1024
+
+    batcher.enqueue('client-1', 'session-held', 'h'.repeat(queued))
+    droppable = true
+    batcher.refreshSessionDroppability('session-held')
+    expect(batcher.queuedCharsForClient('client-1')).toBe(queued)
+    isSessionDroppable.mockClear()
+
+    batcher.enqueue('client-1', 'session-empty', '', {
+      rawLength: 9,
+      transformed: true
+    })
+
+    const batch = pendingBatch(batcher)
+    expect(isSessionDroppable).toHaveBeenCalledTimes(1)
+    expect(batch.droppableQueuedSessionIds).toEqual(new Set(['session-held']))
+    expect(batch.queuedCharsBySession.get('session-empty')).toBe(0)
+    expect(batch.lastEvaluatedDroppableSessionCount).toBe(1)
+    expect(batch.queuedCharsBySession.get('session-held')).toBe(512 * 1024)
+
+    isSessionDroppable.mockClear()
+    batcher.enqueue('client-1', 'session-held', 'z')
+    expect(isSessionDroppable).toHaveBeenCalledTimes(0)
+    expect(batch.queuedCharsBySession.get('session-held')).toBe(512 * 1024 + 1)
+    expect(batch.queue.find((entry) => entry.control?.event === 'dataGap')?.control).toMatchObject({
+      event: 'dataGap',
+      payload: { droppedChars: queued - 512 * 1024 }
+    })
+  })
+
+  it('refreshes one session across every client batch with one predicate call', () => {
+    let droppable = false
+    const isSessionDroppable = vi.fn(() => droppable)
+    const { batcher } = createBatcher({ isSessionDroppable })
+
+    batcher.enqueue('client-1', 'session-routed', 'a')
+    batcher.enqueue('client-2', 'session-routed', 'b')
+    batcher.enqueue('client-3', 'session-routed', '', { transformed: true })
+    droppable = true
+    isSessionDroppable.mockClear()
+
+    batcher.refreshSessionDroppability('session-routed')
+
+    expect(isSessionDroppable).toHaveBeenCalledTimes(1)
+    expect(pendingBatch(batcher, 'client-1').droppableQueuedSessionIds).toContain('session-routed')
+    expect(pendingBatch(batcher, 'client-2').droppableQueuedSessionIds).toContain('session-routed')
+    expect(pendingBatch(batcher, 'client-3').droppableQueuedSessionIds).not.toContain(
+      'session-routed'
+    )
+  })
+
+  it('preserves queued-session Map order when growth re-trims members', () => {
+    const salvageDroppedData = vi.fn((_dropped: string) => '')
+    const { batcher } = createBatcher({
+      isSessionDroppable: () => true,
+      salvageDroppedData
+    })
+    const queuedPerSession = 800 * 1024
+
+    // A zero total reserves the first Map position without joining the Set.
+    batcher.enqueue('client-1', 'session-a', '', { transformed: true })
+    for (const id of ['b', 'c', 'd', 'e']) {
+      batcher.enqueue('client-1', `session-${id}`, id.repeat(queuedPerSession))
+    }
+    batcher.enqueue('client-1', 'session-a', 'a'.repeat(queuedPerSession))
+    salvageDroppedData.mockClear()
+
+    // The sixth member tightens the cap below 800 KiB. Map order is A→E,
+    // while Set insertion order is B→E→A.
+    batcher.enqueue('client-1', 'session-f', 'f')
+
+    expect(
+      salvageDroppedData.mock.calls
+        .map(([dropped]) => dropped)
+        .filter((dropped) => dropped.length > 0)
+        .map((dropped) => dropped[0])
+    ).toEqual(['a', 'b', 'c', 'd', 'e'])
+  })
+
+  it('reconciles foreground transitions without eagerly changing queued bytes', () => {
+    let droppable = false
+    const isSessionDroppable = vi.fn(() => droppable)
+    const { batcher } = createBatcher({ isSessionDroppable })
+    const initialChars = 1_100 * 1024
+
+    batcher.enqueue('client-1', 'session-toggle', 'x'.repeat(initialChars))
+    droppable = true
+    batcher.refreshSessionDroppability('session-toggle')
+    expect(batcher.queuedCharsForClient('client-1')).toBe(initialChars)
+
+    isSessionDroppable.mockClear()
+    batcher.enqueue('client-1', 'session-toggle', 'x')
+    expect(isSessionDroppable).toHaveBeenCalledTimes(0)
+    expect(pendingBatch(batcher).queuedCharsBySession.get('session-toggle')).toBe(512 * 1024)
+
+    droppable = false
+    batcher.refreshSessionDroppability('session-toggle')
+    const foregroundChars = 512 * 1024 + 600 * 1024
+    isSessionDroppable.mockClear()
+    batcher.enqueue('client-1', 'session-toggle', 'y'.repeat(600 * 1024))
+    expect(isSessionDroppable).toHaveBeenCalledTimes(0)
+    expect(pendingBatch(batcher).queuedCharsBySession.get('session-toggle')).toBe(foregroundChars)
+
+    droppable = true
+    batcher.refreshSessionDroppability('session-toggle')
+    expect(pendingBatch(batcher).queuedCharsBySession.get('session-toggle')).toBe(foregroundChars)
+  })
+
+  it('does not lower the last evaluated count during shrink and regrow refreshes', () => {
+    const backgrounded = new Set<string>()
+    const { batcher } = createBatcher({
+      isSessionDroppable: (sessionId) => backgrounded.has(sessionId)
+    })
+    const queuedPerSession = 600 * 1024
+
+    for (let index = 0; index < 6; index++) {
+      const sessionId = `session-${index}`
+      backgrounded.add(sessionId)
+      batcher.enqueue('client-1', sessionId, 'x'.repeat(queuedPerSession))
+    }
+    const batch = pendingBatch(batcher)
+    expect(batch.lastEvaluatedDroppableSessionCount).toBe(6)
+
+    backgrounded.delete('session-0')
+    batcher.refreshSessionDroppability('session-0')
+    batcher.enqueue('client-1', 'session-0', 'x'.repeat(300 * 1024))
+    backgrounded.add('session-0')
+    batcher.refreshSessionDroppability('session-0')
+    expect(batch.queuedCharsBySession.get('session-0')).toBe(900 * 1024)
+    expect(batch.lastEvaluatedDroppableSessionCount).toBe(6)
+
+    batcher.enqueue('client-1', 'session-1', 'x')
+    expect(batch.queuedCharsBySession.get('session-0')).toBe(900 * 1024)
+  })
+
+  it('retains membership after a partial drain and removes it after the final drain', () => {
+    const { batcher, socketFor } = createBatcher({ isSessionDroppable: () => true })
+    const socket = socketFor('client-1')
+    const refillCallbacks: (() => void)[] = []
+    socket.write.mockImplementation((line: string, callback?: () => void) => {
+      if (callback) {
+        refillCallbacks.push(callback)
+      } else if ((JSON.parse(String(line)) as { payload?: { data?: string } }).payload?.data) {
+        socket.writableLength = 128 * 1024
+      }
+      return true
+    })
+
+    batcher.enqueue('client-1', 'session-drain', 'x'.repeat(128 * 1024))
+    batcher.flush('client-1')
+
+    expect(pendingBatch(batcher).queuedCharsBySession.get('session-drain')).toBe(64 * 1024)
+    expect(pendingBatch(batcher).droppableQueuedSessionIds).toContain('session-drain')
+    expect(refillCallbacks).toHaveLength(1)
+
+    socket.writableLength = 0
+    refillCallbacks[0]()
+    expect(pendingByClient(batcher).has('client-1')).toBe(false)
+  })
+
+  it('removes only the flushed session membership during an immediate session flush', () => {
+    const { batcher } = createBatcher({ isSessionDroppable: () => true })
+    batcher.enqueue('client-1', 'session-flushed', 'flush-me')
+    batcher.enqueue('client-1', 'session-retained', 'keep-me')
+
+    batcher.enqueue('client-1', 'session-flushed', '', {
+      flushImmediately: true
+    })
+
+    const batch = pendingBatch(batcher)
+    expect(batch.queuedCharsBySession.has('session-flushed')).toBe(false)
+    expect(batch.droppableQueuedSessionIds).toEqual(new Set(['session-retained']))
+  })
+
+  it('never evaluates or tracks control-only entries', () => {
+    const isSessionDroppable = vi.fn(() => true)
+    const { batcher } = createBatcher({ isSessionDroppable })
+
+    batcher.enqueueControlEvent('client-1', 'session-control', {
+      type: 'event',
+      event: 'sessionBackgroundMarker',
+      sessionId: 'session-control',
+      payload: { background: true }
+    })
+
+    const batch = pendingBatch(batcher)
+    expect(isSessionDroppable).toHaveBeenCalledTimes(0)
+    expect(batch.queuedCharsBySession.has('session-control')).toBe(false)
+    expect(batch.droppableQueuedSessionIds).toHaveLength(0)
+    expect(batch.lastEvaluatedDroppableSessionCount).toBeUndefined()
+  })
+})

--- a/src/main/daemon/daemon-stream-droppable-membership.ts
+++ b/src/main/daemon/daemon-stream-droppable-membership.ts
@@ -1,0 +1,64 @@
+import {
+  backgroundSessionDropCapChars,
+  backgroundSessionKeepTailChars,
+  dropOldestQueuedForSession,
+  type PendingStreamDataBatch
+} from './daemon-stream-keep-tail-drop'
+
+export function evaluateDroppableEnqueue(
+  batch: PendingStreamDataBatch,
+  sessionId: string,
+  queuedBefore: number,
+  queuedAfter: number,
+  isSessionDroppable: (sessionId: string) => boolean,
+  salvageDroppedData: (dropped: string) => string
+): void {
+  let sessionDroppable: boolean
+  if (queuedBefore <= 0) {
+    sessionDroppable = isSessionDroppable(sessionId)
+    if (queuedAfter > 0 && sessionDroppable) {
+      batch.droppableQueuedSessionIds.add(sessionId)
+    } else {
+      batch.droppableQueuedSessionIds.delete(sessionId)
+    }
+  } else {
+    sessionDroppable = batch.droppableQueuedSessionIds.has(sessionId)
+  }
+  if (!sessionDroppable) {
+    return
+  }
+
+  const droppableQueued = batch.droppableQueuedSessionIds.size
+  const dropCap = backgroundSessionDropCapChars(droppableQueued)
+  const keepTail = backgroundSessionKeepTailChars(droppableQueued)
+  if (queuedAfter > dropCap) {
+    dropOldestQueuedForSession(batch, sessionId, keepTail, salvageDroppedData)
+  }
+  if (droppableQueued > (batch.lastEvaluatedDroppableSessionCount ?? 0)) {
+    // Shared budget tightened, so producers that stopped enqueueing must also be re-trimmed.
+    for (const [queuedSessionId, queued] of Array.from(batch.queuedCharsBySession)) {
+      if (
+        queued > dropCap &&
+        queuedSessionId !== sessionId &&
+        batch.droppableQueuedSessionIds.has(queuedSessionId)
+      ) {
+        dropOldestQueuedForSession(batch, queuedSessionId, keepTail, salvageDroppedData)
+      }
+    }
+  }
+  batch.lastEvaluatedDroppableSessionCount = droppableQueued
+}
+
+export function refreshDroppableSessionMembership(
+  batches: Iterable<PendingStreamDataBatch>,
+  sessionId: string,
+  droppable: boolean
+): void {
+  for (const batch of batches) {
+    if ((batch.queuedCharsBySession.get(sessionId) ?? 0) > 0 && droppable) {
+      batch.droppableQueuedSessionIds.add(sessionId)
+    } else {
+      batch.droppableQueuedSessionIds.delete(sessionId)
+    }
+  }
+}

--- a/src/main/daemon/daemon-stream-keep-tail-drop.ts
+++ b/src/main/daemon/daemon-stream-keep-tail-drop.ts
@@ -33,10 +33,13 @@ export type PendingStreamDataBatch = {
   // Per-session held totals so the flush hold can spare small talkers
   // (echo/replies) from waiting behind other sessions' floods.
   queuedCharsBySession: Map<string, number>
+  // Membership is reconciled when queued data first appears and on rare
+  // background lifecycle changes, keeping steady-state enqueue constant-time.
+  droppableQueuedSessionIds: Set<string>
   // Last droppable-sessions-with-queued-data count seen by the keep-tail
   // logic: when it GROWS the shared budget tightens, and sessions that
   // finished producing must be re-trimmed (they will never re-enqueue).
-  lastDroppableSessionCount?: number
+  lastEvaluatedDroppableSessionCount?: number
 }
 
 // The keep-tail must comfortably cover a full TUI repaint (~cols×rows×SGR ≈


### PR DESCRIPTION
## Description

- Track queued droppable daemon sessions with one per-client-batch membership Set instead of
  recounting every queued session on every hidden-output chunk.
- Discover membership when queued data first becomes positive, and reconcile it across every
  pending client batch on background changes, attach completion, and exit.
- Preserve the existing rare Map-order re-trim when the evaluated membership count grows, including
  transformed empty spans, gap/query salvage ordering, and the legacy last-evaluated-count timing.
- Remove membership on final drain and targeted flush; whole-batch clear/disconnect continues to
  discard all state.
- Add deterministic operation budgets and lifecycle coverage for background toggles, reattach,
  cross-client held batches, and exit output held behind socket backpressure.

## ELI5

Orca used to ask every waiting hidden terminal, “Are you hidden?” whenever one hidden terminal
produced another piece of output. Now each delivery batch keeps a small attendance list and updates it
only when a terminal joins, leaves, hides, reveals, attaches, or exits. The existing rules for which
old output is kept are unchanged.

## Proof of zero regression

- Three independent final reviews—correctness, performance, and platform/integration—report no
  remaining findings after tracing every membership mutation and lifecycle boundary.
- Full suite: 3,270 files and 34,812 tests passed; 8 files and 60 tests skipped by the existing suite.
- Focused batcher/server slice: 71/71 tests passed.
- Full daemon slice: 1,011 tests passed; 5 existing skips.
- Full Node/CLI/web TypeScript check passed.
- Touched-file oxlint and oxfmt, reliability gates, max-lines ratchet, and `git diff --check` passed.
- Full `pnpm run lint` passes oxlint, switch exhaustiveness, styled-scrollbar, reliability,
  max-lines, and bundled-guide stages before the pre-existing released `orca-cli` revision-9
  manifest blocker. This diff changes no skill or manifest files.
- Tests preserve Map-order gap/salvage behavior, transformed empty spans, control-only entries,
  delayed count updates after shrink/regrow, foreground/background marker order, attach routing,
  partial/final drain, targeted flush, cross-client refresh, and exit-held tails.
- The code is platform-neutral. macOS, Linux, native Windows/ConPTY, and WSL daemon sessions use the
  same batcher. Direct SSH/relay PTY delivery uses its separate existing batching path and is
  unchanged.

## Proof of performance improvement

- Deterministic pre-change state: 100 positive queued droppable sessions, then 1,000 one-character
  chunks to one already-queued hidden producer.
- Before: every chunk made 1 producer predicate call plus 100 queued-session predicate calls and
  visits: exactly 101,000 `isSessionDroppable` calls and 100,000 Map-entry visits.
- After: the production-path test records 0 droppability predicate calls and 0 Map iterator,
  `entries`, `values`, or `forEach` calls. It performs exactly 1,000 keyed Map reads, 1,000 keyed Map
  writes, and 1,000 Set membership checks while preserving exactly 1,400 total queued characters.
- Steady-state membership work changes from O(P × N) to O(N), where P is queued producers and N is
  chunks. A newly queued session and a cross-client lifecycle refresh each make exactly one
  droppability predicate call.
- The intentional O(P) re-trim remains only when the evaluated droppable-session count grows, so the
  aggregate keep-tail budget and reveal-latency protection are unchanged.
