### PR TITLE
fix(computer-use): settle Accessibility trust before failing on fresh helper processes

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -601,7 +601,7 @@ final class Provider {
         windowIndex: Int?,
         restoreWindow: Bool
     ) throws -> Snapshot {
-        guard accessibilityTrusted() else {
+        guard accessibilityTrustedSettled() else {
             // Why: agents retry failed observations. Only the explicit setup flow
             // should open macOS privacy prompts/settings; runtime calls stay quiet.
             throw ProviderError.coded(
@@ -1034,6 +1034,15 @@ private func accessibilityTrusted() -> Bool {
     AXIsProcessTrusted()
 }
 
+/// One-shot `AXIsProcessTrusted()` lies to fresh processes: tccd answers a
+/// just-spawned helper with `preflight_unknown`/`do_not_cache` before settling
+/// on the real grant (#9458), and every CLI call spawns a fresh helper. Poll
+/// briefly so a real grant is never mistaken for a denial; already-trusted
+/// processes pass on the first probe with no added latency.
+private func accessibilityTrustedSettled() -> Bool {
+    AccessibilityTrustSettling.settle(probe: accessibilityTrusted).settled
+}
+
 private func screenCaptureTrusted() -> Bool {
     CGPreflightScreenCaptureAccess()
 }
@@ -1065,6 +1074,37 @@ private func enableManualAccessibilityIfNeeded(_ appElement: AXUIElement, app: A
 
 private func focusedWindow(appElement: AXUIElement, app: AppDescriptor, visibleWindowCount: Int, allowRecovery: Bool) throws -> AXUIElement {
     let systemWide = AXUIElementCreateSystemWide()
+    if let window = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app) {
+        return window
+    }
+    if allowRecovery {
+        recoverWindow(app)
+        if let window = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app) {
+            return window
+        }
+    }
+    if visibleWindowCount > 0 {
+        // Why: on a fresh helper process AX reads can be denied by tccd's
+        // uncached preflight answer for a moment even though trust is granted
+        // (#9458) — the "visible windows but no accessibility window" state.
+        // Give the AX session time to settle before declaring it broken.
+        var settledWindow: AXUIElement?
+        let outcome = AccessibilityTrustSettling.settle {
+            settledWindow = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app)
+            return settledWindow != nil
+        }
+        if let window = settledWindow, outcome.settled {
+            return window
+        }
+        throw ProviderError.coded(
+            "permission_denied",
+            "app '\(app.name)' has visible windows but no accessibility window (AX reads stayed blocked for \(outcome.waitedMs)ms after retries). macOS Accessibility may need Orca Computer Use toggled off and on again in System Settings."
+        )
+    }
+    throw ProviderError.coded("window_not_found", "app '\(app.name)' has no accessibility window; make sure the app has a visible window, then retry with --restore-window.")
+}
+
+private func lookupUsableWindow(systemWide: AXUIElement, appElement: AXUIElement, app: AppDescriptor) -> AXUIElement? {
     if let window = focusedSystemWindow(systemWide: systemWide, app: app) {
         return window
     }
@@ -1076,27 +1116,7 @@ private func focusedWindow(appElement: AXUIElement, app: AppDescriptor, visibleW
             return window
         }
     }
-    if allowRecovery {
-        recoverWindow(app)
-        if let window = focusedSystemWindow(systemWide: systemWide, app: app) {
-            return window
-        }
-        if let window = copyElement(appElement, kAXFocusedWindowAttribute as String), usableWindow(window) {
-            return window
-        }
-        if let windows = copyArray(appElement, kAXWindowsAttribute as String) {
-            if let window = windows.first(where: usableWindow) {
-                return window
-            }
-        }
-    }
-    let permissionHint = visibleWindowCount > 0
-        ? " The app has visible windows, so macOS Accessibility may need Orca Computer Use toggled off and on again in System Settings."
-        : ""
-    if visibleWindowCount > 0 {
-        throw ProviderError.coded("permission_denied", "app '\(app.name)' has visible windows but no accessibility window.\(permissionHint)")
-    }
-    throw ProviderError.coded("window_not_found", "app '\(app.name)' has no accessibility window; make sure the app has a visible window, then retry with --restore-window.")
+    return nil
 }
 
 private func focusedSystemWindow(systemWide: AXUIElement, app: AppDescriptor) -> AXUIElement? {
@@ -4039,13 +4059,13 @@ private func runPermissionCheck(initialPermission: PermissionKind? = nil) {
 }
 
 private func printPermissionStatus() {
-    let accessibility = accessibilityTrusted() ? "granted" : "not-granted"
+    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
     let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
     print(#"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#)
 }
 
 private func writePermissionStatus(to path: String) {
-    let accessibility = accessibilityTrusted() ? "granted" : "not-granted"
+    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
     let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
     let text = #"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#
     do {

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Retries a trust/readability probe until it succeeds or a deadline passes.
+///
+/// Why: tccd answers a freshly spawned helper process with
+/// `preflight_unknown` / `do_not_cache` for a short window after spawn, so the
+/// first Accessibility answers a new process sees can be `denied` even though
+/// the grant is real, flipping to `granted` moments later within the same pid
+/// (stablyai/orca#9458). Every CLI invocation spawns a fresh helper, so a
+/// one-shot check loses that race on every call.
+public enum AccessibilityTrustSettling {
+    public struct Outcome: Equatable {
+        public let settled: Bool
+        public let attempts: Int
+        public let waitedMs: Int
+
+        public init(settled: Bool, attempts: Int, waitedMs: Int) {
+            self.settled = settled
+            self.attempts = attempts
+            self.waitedMs = waitedMs
+        }
+    }
+
+    public static let defaultTimeoutMs = 1500
+    public static let defaultIntervalMs = 100
+
+    /// Probes immediately, then keeps probing on `intervalMs` boundaries until
+    /// `probe` returns true or `timeoutMs` has been spent sleeping. The happy
+    /// path (already trusted) returns after one probe with zero sleeps.
+    public static func settle(
+        timeoutMs: Int = defaultTimeoutMs,
+        intervalMs: Int = defaultIntervalMs,
+        sleepMs: (Int) -> Void = { interval in
+            usleep(useconds_t(interval * 1000))
+        },
+        probe: () -> Bool
+    ) -> Outcome {
+        precondition(intervalMs > 0, "intervalMs must be positive")
+        var attempts = 0
+        var waitedMs = 0
+        while true {
+            attempts += 1
+            if probe() {
+                return Outcome(settled: true, attempts: attempts, waitedMs: waitedMs)
+            }
+            if waitedMs >= timeoutMs {
+                return Outcome(settled: false, attempts: attempts, waitedMs: waitedMs)
+            }
+            let interval = min(intervalMs, timeoutMs - waitedMs)
+            sleepMs(interval)
+            waitedMs += interval
+        }
+    }
+}

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
@@ -21,6 +21,9 @@ public enum AccessibilityTrustSettling {
         }
     }
 
+    /// Why: a snapshot can run two settle phases back-to-back (process trust,
+    /// then AX window reads), so the worst-case stall is 2x this value; in
+    /// practice tccd's cached answer makes the second phase near-instant.
     public static let defaultTimeoutMs = 1500
     public static let defaultIntervalMs = 100
 

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AccessibilityTrustSettlingTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AccessibilityTrustSettlingTests.swift
@@ -1,0 +1,62 @@
+import Testing
+@testable import OrcaComputerUseMacOSCore
+
+@Suite("AccessibilityTrustSettling")
+struct AccessibilityTrustSettlingTests {
+    @Test("already-trusted probe returns immediately with zero waiting")
+    func immediateSuccess() {
+        var sleeps: [Int] = []
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 1500,
+            intervalMs: 100,
+            sleepMs: { sleeps.append($0) },
+            probe: { true }
+        )
+        #expect(outcome == .init(settled: true, attempts: 1, waitedMs: 0))
+        #expect(sleeps.isEmpty)
+    }
+
+    @Test("probe that turns true after a few denials settles with the elapsed wait")
+    func lateGrant() {
+        var calls = 0
+        var sleeps: [Int] = []
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 1500,
+            intervalMs: 100,
+            sleepMs: { sleeps.append($0) },
+            probe: {
+                calls += 1
+                return calls >= 4
+            }
+        )
+        #expect(outcome == .init(settled: true, attempts: 4, waitedMs: 300))
+        #expect(sleeps == [100, 100, 100])
+    }
+
+    @Test("probe that never turns true stops at the timeout")
+    func neverGranted() {
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 1000,
+            intervalMs: 300,
+            sleepMs: { _ in },
+            probe: { false }
+        )
+        #expect(outcome.settled == false)
+        #expect(outcome.waitedMs == 1000)
+        // 4 sleeps (300+300+300+100 clamped) plus the final probe after the last wait.
+        #expect(outcome.attempts == 5)
+    }
+
+    @Test("final interval is clamped so total wait never exceeds the timeout")
+    func clampsFinalInterval() {
+        var sleeps: [Int] = []
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 250,
+            intervalMs: 100,
+            sleepMs: { sleeps.append($0) },
+            probe: { false }
+        )
+        #expect(sleeps == [100, 100, 50])
+        #expect(outcome.waitedMs == 250)
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AccessibilityTrustSettlingTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AccessibilityTrustSettlingTests.swift
@@ -58,5 +58,6 @@ struct AccessibilityTrustSettlingTests {
         )
         #expect(sleeps == [100, 100, 50])
         #expect(outcome.waitedMs == 250)
+        #expect(outcome.attempts == 4)
     }
 }


### PR DESCRIPTION
## Problem

`orca computer permissions` reports `accessibility: granted` while every windowed action (`get-app-state`, `click`, …) fails `permission_denied` — the diagnostic says healthy while the tool is unusable. Filed as #9159, consolidated into #9458.

## Root cause (from the tccd IPC trace in #9458)

Every CLI invocation spawns a fresh, short-lived helper process. `tccd` answers a freshly spawned process with `preflight_unknown` / `do_not_cache` (`auth_reason=5`), so the first Accessibility answers a new pid sees can be **denied while the grant is real** — the same pid flips to granted moments later in the trace. One-shot checks therefore lose the race on every invocation:

- `AXIsProcessTrusted()` one-shots gate `buildSnapshot` and the permission-status printers.
- The AX window reads behind "app has visible windows but no accessibility window" hit the same uncached-denial window.

## Fix

- New `AccessibilityTrustSettling.settle`: probe immediately, then poll on 100 ms boundaries, capped at 1.5 s. Already-trusted processes pass on the first probe — **zero added latency on the happy path**; the cap only spends time in the exact state that used to hard-fail.
- Wired into: the `buildSnapshot` trust gate, both permission-status printers, and the "visible windows but no accessibility window" path — which now retries the actual AX window lookup (not just the trust bit) and reports how long reads stayed blocked if it still fails.
- Extracted `lookupUsableWindow` to dedupe the identical pre-/post-recovery lookup blocks.
- Deterministic unit tests for the settle policy via injected sleep (no timing flake).

## Validation

- `swift build` clean; full suite passes (37 existing + 4 new).
- The failure state reproduces 100% on one of our machines (every `get-app-state` → `permission_denied` with `permissions` → granted, matching #9458's trace signature). We could not E2E the patched binary against that machine's TCC state: a dev-built helper has a different code identity, so it gets a fresh TCC row rather than inheriting the raced one. Review therefore leans on the #9458 trace: answers change across probes within one pid, which is exactly what a bounded settle loop addresses. Happy to iterate if maintainers with a repro rig can run this against it.

Fixes #9458 (and the already-consolidated #9159).



## ELI5

macOS said Accessibility was allowed, but every computer-use click still failed right after a fresh helper start. The app now waits for that permission check to settle before giving up, so tools work once you have granted access.
