### PR TITLE
feat(mobile): sync native text selection to terminal cursor

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -1063,6 +1063,7 @@ export default function SessionScreen() {
     handleLiveInputAccessoryBytes,
     handleLiveInputChange,
     handleLiveInputKeyPress,
+    handleLiveInputSelectionChange,
     handleLiveInputSubmit
   } = useTerminalLiveInputCommit({
     activeHandle,
@@ -5015,6 +5016,7 @@ export default function SessionScreen() {
                       value={liveInputCapture}
                       onChangeText={handleLiveInputChange}
                       onKeyPress={handleLiveInputKeyPress}
+                      onSelectionChange={handleLiveInputSelectionChange}
                       onSubmitEditing={handleLiveInputSubmit}
                       placeholder=""
                       showSoftInputOnFocus

--- a/mobile/src/terminal/terminal-live-control-payload.ts
+++ b/mobile/src/terminal/terminal-live-control-payload.ts
@@ -1,0 +1,32 @@
+import {
+  planTerminalLiveFieldTextChange,
+  type TerminalLiveSelectionCursorState
+} from './terminal-live-selection-cursor'
+import { normalizeTerminalTextInput } from './terminal-text-input-normalization'
+
+export type TerminalLiveQueueControlOptions = {
+  readonly commitFieldBeforeControl: boolean
+}
+
+/** Snapshot restore/held-commit bytes for a control that ends the field session. */
+export function buildTerminalLiveFieldCommitPrefix(
+  state: TerminalLiveSelectionCursorState
+): string {
+  const fieldText = state.sentText + state.heldText
+  return planTerminalLiveFieldTextChange(state, fieldText, null, {
+    normalize: normalizeTerminalTextInput,
+    commitHeld: true
+  }).payload
+}
+
+export function buildTerminalLiveQueuedControlPayload(options: {
+  readonly state: TerminalLiveSelectionCursorState
+  readonly ownsFieldState: boolean
+  readonly commitFieldBeforeControl: boolean
+  readonly controlBytes: string
+}): string {
+  if (!options.commitFieldBeforeControl || !options.ownsFieldState) {
+    return options.controlBytes
+  }
+  return buildTerminalLiveFieldCommitPrefix(options.state) + options.controlBytes
+}

--- a/mobile/src/terminal/terminal-live-selection-cursor.test.ts
+++ b/mobile/src/terminal/terminal-live-selection-cursor.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeTerminalTextInput } from './terminal-text-input-normalization'
+import {
+  clampUtf16OffsetToCodePointBoundary,
+  codePointIndexToUtf16Offset,
+  nativeSelectionToNormalizedCodePointIndex,
+  planTerminalLiveFieldTextChange,
+  planTerminalLiveSelectionMove,
+  utf16OffsetToCodePointIndex,
+  type TerminalLiveSelectionCursorState
+} from './terminal-live-selection-cursor'
+
+const identity = (text: string): string => text
+
+function state(
+  partial: Partial<TerminalLiveSelectionCursorState>
+): TerminalLiveSelectionCursorState {
+  return {
+    sentText: '',
+    heldText: '',
+    ptyCursorCodePoint: 0,
+    fieldText: '',
+    ...partial
+  }
+}
+
+describe('terminal live selection cursor indexing', () => {
+  it('Given emoji When mapping UTF-16 offsets Then does not split surrogate pairs', () => {
+    const text = 'a👍b'
+    // a=1 unit, 👍=2 units, b=1 unit → length 4
+    expect(text.length).toBe(4)
+    expect(clampUtf16OffsetToCodePointBoundary(text, 2)).toBe(1)
+    expect(utf16OffsetToCodePointIndex(text, 0)).toBe(0)
+    expect(utf16OffsetToCodePointIndex(text, 1)).toBe(1)
+    expect(utf16OffsetToCodePointIndex(text, 2)).toBe(1)
+    expect(utf16OffsetToCodePointIndex(text, 3)).toBe(2)
+    expect(utf16OffsetToCodePointIndex(text, 4)).toBe(3)
+    expect(codePointIndexToUtf16Offset(text, 2)).toBe(3)
+  })
+
+  it('Given CJK When mapping offsets Then one code point per character', () => {
+    const text = '你a好'
+    expect(utf16OffsetToCodePointIndex(text, 1)).toBe(1)
+    expect(utf16OffsetToCodePointIndex(text, 2)).toBe(2)
+    expect(utf16OffsetToCodePointIndex(text, 3)).toBe(3)
+  })
+
+  it('Given smart-dash field text When mapping selection Then expands through normalization', () => {
+    const raw = 'a–b'
+    expect(nativeSelectionToNormalizedCodePointIndex(raw, 2, normalizeTerminalTextInput)).toBe(3)
+    expect(nativeSelectionToNormalizedCodePointIndex(raw, 1, normalizeTerminalTextInput)).toBe(1)
+  })
+})
+
+describe('terminal live selection move plans', () => {
+  it('Given caret at end When moved to middle Then emits ordered ArrowLeft bytes', () => {
+    const plan = planTerminalLiveSelectionMove(
+      state({ sentText: 'abcdef', fieldText: 'abcdef', ptyCursorCodePoint: 6 }),
+      { start: 3, end: 3 },
+      { normalize: identity, rawFieldText: 'abcdef' }
+    )
+
+    expect(plan).not.toBeNull()
+    expect(plan?.payload).toBe('\x1b[D'.repeat(3))
+    expect(plan?.nextPtyCursorCodePoint).toBe(3)
+  })
+
+  it('Given repeated selection at the same collapsed index Then emits nothing', () => {
+    const plan = planTerminalLiveSelectionMove(
+      state({ sentText: 'abc', fieldText: 'abc', ptyCursorCodePoint: 1 }),
+      { start: 1, end: 1 },
+      { normalize: identity, rawFieldText: 'abc' }
+    )
+
+    expect(plan).toBeNull()
+  })
+
+  it('Given caret in the middle When moved right Then emits ordered ArrowRight bytes', () => {
+    const plan = planTerminalLiveSelectionMove(
+      state({ sentText: 'abcdef', fieldText: 'abcdef', ptyCursorCodePoint: 2 }),
+      { start: 5, end: 5 },
+      { normalize: identity, rawFieldText: 'abcdef' }
+    )
+
+    expect(plan).not.toBeNull()
+    expect(plan?.payload).toBe('\x1b[C'.repeat(3))
+    expect(plan?.nextPtyCursorCodePoint).toBe(5)
+  })
+
+  it('Given a non-collapsed range Then emits no PTY bytes', () => {
+    const plan = planTerminalLiveSelectionMove(
+      state({ sentText: 'abcdef', fieldText: 'abcdef', ptyCursorCodePoint: 6 }),
+      { start: 1, end: 4 },
+      { normalize: identity, rawFieldText: 'abcdef' }
+    )
+
+    expect(plan).toBeNull()
+  })
+
+  it('Given held Hangul When selection moves left Then flushes the syllable before arrows', () => {
+    const plan = planTerminalLiveSelectionMove(
+      state({
+        sentText: '한',
+        heldText: '글',
+        fieldText: '한글',
+        ptyCursorCodePoint: 1
+      }),
+      { start: 1, end: 1 },
+      { normalize: identity, rawFieldText: '한글' }
+    )
+
+    expect(plan).not.toBeNull()
+    expect(plan?.payload).toBe('글' + '\x1b[D')
+    expect(plan?.nextSentText).toBe('한글')
+    expect(plan?.heldText).toBe('')
+    expect(plan?.nextPtyCursorCodePoint).toBe(1)
+  })
+
+  it('Given emoji field When caret crosses the emoji Then counts one code point', () => {
+    const text = 'a👍b'
+    const plan = planTerminalLiveSelectionMove(
+      state({ sentText: text, fieldText: text, ptyCursorCodePoint: 3 }),
+      { start: 1, end: 1 },
+      { normalize: identity, rawFieldText: text }
+    )
+
+    expect(plan?.payload).toBe('\x1b[D'.repeat(2))
+    expect(plan?.nextPtyCursorCodePoint).toBe(1)
+  })
+})
+
+describe('terminal live field text change plans', () => {
+  it('Given middle insertion Then yields abcXdef with caret after X in one payload', () => {
+    const plan = planTerminalLiveFieldTextChange(
+      state({ sentText: 'abcdef', fieldText: 'abcdef', ptyCursorCodePoint: 3 }),
+      'abcXdef',
+      { start: 4, end: 4 },
+      { normalize: identity, commitHeld: false }
+    )
+
+    expect(plan.payload).toBe('\x1b[C'.repeat(3) + '\x7f'.repeat(3) + 'Xdef' + '\x1b[D'.repeat(3))
+    expect(plan.nextSentText).toBe('abcXdef')
+    expect(plan.nextPtyCursorCodePoint).toBe(4)
+    expect(plan.heldText).toBe('')
+  })
+
+  it('Given middle deletion Then restores, erases, and reseats the caret', () => {
+    // "abXcd" with caret after X (3) → delete X → "abcd" caret at 2
+    const plan = planTerminalLiveFieldTextChange(
+      state({ sentText: 'abXcd', fieldText: 'abXcd', ptyCursorCodePoint: 3 }),
+      'abcd',
+      { start: 2, end: 2 },
+      { normalize: identity, commitHeld: false }
+    )
+
+    expect(plan.payload).toBe('\x1b[C'.repeat(2) + '\x7f'.repeat(3) + 'cd' + '\x1b[D'.repeat(2))
+    expect(plan.nextSentText).toBe('abcd')
+    expect(plan.nextPtyCursorCodePoint).toBe(2)
+  })
+
+  it('Given end typing Then emits only the appended suffix with no arrows', () => {
+    const plan = planTerminalLiveFieldTextChange(
+      state({ sentText: 'ab', fieldText: 'ab', ptyCursorCodePoint: 2 }),
+      'abc',
+      { start: 3, end: 3 },
+      { normalize: identity, commitHeld: false }
+    )
+
+    expect(plan.payload).toBe('c')
+    expect(plan.nextSentText).toBe('abc')
+    expect(plan.nextPtyCursorCodePoint).toBe(3)
+  })
+
+  it('Given Hangul composition at end Then still holds the trailing syllable', () => {
+    const plan = planTerminalLiveFieldTextChange(
+      state({ sentText: '', fieldText: '', ptyCursorCodePoint: 0 }),
+      '한',
+      { start: 1, end: 1 },
+      { normalize: identity, commitHeld: false }
+    )
+
+    expect(plan.payload).toBe('')
+    expect(plan.nextSentText).toBe('')
+    expect(plan.heldText).toBe('한')
+    expect(plan.nextPtyCursorCodePoint).toBe(0)
+  })
+
+  it('Given dictation rewrite When selection unknown Then converges text and infers caret after the edit span', () => {
+    const plan = planTerminalLiveFieldTextChange(
+      state({ sentText: 'high', fieldText: 'high', ptyCursorCodePoint: 4 }),
+      'hi there',
+      null,
+      { normalize: identity, commitHeld: false }
+    )
+
+    // common prefix "hi", no common suffix → caret at end of "hi there"
+    expect(plan.payload).toBe('\x7f\x7f there')
+    expect(plan.nextSentText).toBe('hi there')
+    expect(plan.nextPtyCursorCodePoint).toBe(8)
+  })
+
+  it('Given middle insertion without selection Then still reseats after the inserted character', () => {
+    const plan = planTerminalLiveFieldTextChange(
+      state({ sentText: 'abcdef', fieldText: 'abcdef', ptyCursorCodePoint: 3 }),
+      'abcXdef',
+      null,
+      { normalize: identity, commitHeld: false }
+    )
+
+    expect(plan.payload).toBe('\x1b[C'.repeat(3) + '\x7f'.repeat(3) + 'Xdef' + '\x1b[D'.repeat(3))
+    expect(plan.nextPtyCursorCodePoint).toBe(4)
+  })
+})

--- a/mobile/src/terminal/terminal-live-selection-cursor.ts
+++ b/mobile/src/terminal/terminal-live-selection-cursor.ts
@@ -1,0 +1,254 @@
+import {
+  buildTerminalLiveMirrorPayload,
+  computeTerminalLiveMirrorStep
+} from './terminal-live-hangul-mirror'
+import { getTerminalLiveSpecialKeyBytes } from './terminal-live-input'
+
+const ARROW_LEFT = getTerminalLiveSpecialKeyBytes('ArrowLeft') ?? '\x1b[D'
+const ARROW_RIGHT = getTerminalLiveSpecialKeyBytes('ArrowRight') ?? '\x1b[C'
+
+export type TerminalLiveNativeSelection = {
+  readonly start: number
+  readonly end: number
+}
+
+export type TerminalLiveSelectionCursorState = {
+  readonly sentText: string
+  readonly heldText: string
+  /** Code-point index of the PTY cursor within sentText (held text is not on the PTY). */
+  readonly ptyCursorCodePoint: number
+  /** Last normalized field text the mirror applied. */
+  readonly fieldText: string
+}
+
+export type TerminalLiveSelectionCursorPlan = {
+  readonly payload: string
+  readonly nextSentText: string
+  readonly heldText: string
+  readonly nextPtyCursorCodePoint: number
+  readonly nextFieldText: string
+}
+
+export function clampUtf16OffsetToCodePointBoundary(text: string, offset: number): number {
+  if (offset <= 0) {
+    return 0
+  }
+  if (offset >= text.length) {
+    return text.length
+  }
+  // Why: native selection is UTF-16; never leave the offset between a surrogate pair.
+  const codeUnit = text.charCodeAt(offset)
+  if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+    return offset - 1
+  }
+  return offset
+}
+
+export function utf16OffsetToCodePointIndex(text: string, utf16Offset: number): number {
+  const safeOffset = clampUtf16OffsetToCodePointBoundary(text, utf16Offset)
+  let index = 0
+  let unit = 0
+  while (unit < safeOffset) {
+    const codePoint = text.codePointAt(unit)
+    if (codePoint === undefined) {
+      break
+    }
+    unit += codePoint > 0xffff ? 2 : 1
+    index += 1
+  }
+  return index
+}
+
+export function codePointIndexToUtf16Offset(text: string, codePointIndex: number): number {
+  if (codePointIndex <= 0) {
+    return 0
+  }
+  let index = 0
+  let unit = 0
+  while (unit < text.length && index < codePointIndex) {
+    const codePoint = text.codePointAt(unit)
+    if (codePoint === undefined) {
+      break
+    }
+    unit += codePoint > 0xffff ? 2 : 1
+    index += 1
+  }
+  return unit
+}
+
+// Normalize only the caret prefix so smart-punctuation expansion stays aligned
+// with the bytes already mirrored to the PTY.
+export function nativeSelectionToNormalizedCodePointIndex(
+  rawFieldText: string,
+  utf16Offset: number,
+  normalize: (text: string) => string
+): number {
+  const safeOffset = clampUtf16OffsetToCodePointBoundary(rawFieldText, utf16Offset)
+  const rawPrefix = rawFieldText.slice(0, safeOffset)
+  return Array.from(normalize(rawPrefix)).length
+}
+
+function codePointLength(text: string): number {
+  return Array.from(text).length
+}
+
+function buildArrowPayload(fromCodePoint: number, toCodePoint: number): string {
+  if (toCodePoint === fromCodePoint) {
+    return ''
+  }
+  if (toCodePoint > fromCodePoint) {
+    return ARROW_RIGHT.repeat(toCodePoint - fromCodePoint)
+  }
+  return ARROW_LEFT.repeat(fromCodePoint - toCodePoint)
+}
+
+function clampCodePointIndex(index: number, maxInclusive: number): number {
+  if (index < 0) {
+    return 0
+  }
+  if (index > maxInclusive) {
+    return maxInclusive
+  }
+  return index
+}
+
+// A terminal has one caret, so ranges wait for collapse; leaving a held Hangul
+// suffix first commits it in the same payload before cursor arrows.
+export function planTerminalLiveSelectionMove(
+  state: TerminalLiveSelectionCursorState,
+  selection: TerminalLiveNativeSelection,
+  options: {
+    readonly normalize: (text: string) => string
+    readonly rawFieldText: string
+  }
+): TerminalLiveSelectionCursorPlan | null {
+  // Why: multi-unit ranges have no single terminal caret; wait for collapse.
+  if (selection.start !== selection.end) {
+    return null
+  }
+
+  let payload = ''
+  let sentText = state.sentText
+  let heldText = state.heldText
+  let ptyCursor = clampCodePointIndex(state.ptyCursorCodePoint, codePointLength(sentText))
+  const fieldText = state.fieldText
+  const targetOnField = nativeSelectionToNormalizedCodePointIndex(
+    options.rawFieldText,
+    selection.start,
+    options.normalize
+  )
+  const visualEnd = codePointLength(sentText + heldText)
+
+  if (heldText.length > 0) {
+    // Why: iOS fires end-of-field selection during composition; flushing here
+    // would commit the held syllable and break Hangul correction.
+    if (targetOnField >= visualEnd) {
+      return null
+    }
+    payload += buildArrowPayload(ptyCursor, codePointLength(sentText))
+    const flushStep = computeTerminalLiveMirrorStep(sentText, fieldText, { commitHeld: true })
+    payload += buildTerminalLiveMirrorPayload(flushStep)
+    sentText = flushStep.nextSentText
+    heldText = flushStep.heldText
+    ptyCursor = codePointLength(sentText)
+  }
+
+  const target = clampCodePointIndex(targetOnField, codePointLength(sentText))
+  const arrows = buildArrowPayload(ptyCursor, target)
+  payload += arrows
+  if (payload.length === 0) {
+    return null
+  }
+
+  return {
+    payload,
+    nextSentText: sentText,
+    heldText,
+    nextPtyCursorCodePoint: target,
+    nextFieldText: fieldText
+  }
+}
+
+// RN reports text before its paired selection, so infer the edit-span end for
+// the first payload and let the later selection event correct any mismatch.
+export function inferTerminalLiveCaretCodePointAfterEdit(
+  previousFieldText: string,
+  nextFieldText: string
+): number {
+  const prev = Array.from(previousFieldText)
+  const next = Array.from(nextFieldText)
+  let prefix = 0
+  while (prefix < prev.length && prefix < next.length && prev[prefix] === next[prefix]) {
+    prefix += 1
+  }
+  let suffix = 0
+  while (
+    suffix < prev.length - prefix &&
+    suffix < next.length - prefix &&
+    prev[prev.length - 1 - suffix] === next[next.length - 1 - suffix]
+  ) {
+    suffix += 1
+  }
+  return next.length - suffix
+}
+
+// Restore, suffix-rewrite, and reseat in one payload so a middle edit cannot
+// interleave its cursor moves with another terminal send.
+export function planTerminalLiveFieldTextChange(
+  state: TerminalLiveSelectionCursorState,
+  nextRawFieldText: string,
+  nextSelection: TerminalLiveNativeSelection | null,
+  options: {
+    readonly normalize: (text: string) => string
+    readonly commitHeld: boolean
+  }
+): TerminalLiveSelectionCursorPlan {
+  const nextFieldText = options.normalize(nextRawFieldText)
+  let payload = ''
+  const sentText = state.sentText
+  let ptyCursor = clampCodePointIndex(state.ptyCursorCodePoint, codePointLength(sentText))
+
+  payload += buildArrowPayload(ptyCursor, codePointLength(sentText))
+
+  const step = computeTerminalLiveMirrorStep(sentText, nextFieldText, {
+    commitHeld: options.commitHeld
+  })
+  payload += buildTerminalLiveMirrorPayload(step)
+  const nextSentText = step.nextSentText
+  const heldText = step.heldText
+  ptyCursor = codePointLength(nextSentText)
+
+  const sentLen = ptyCursor
+  let target: number
+  if (nextSelection && nextSelection.start === nextSelection.end) {
+    target = clampCodePointIndex(
+      nativeSelectionToNormalizedCodePointIndex(
+        nextRawFieldText,
+        nextSelection.start,
+        options.normalize
+      ),
+      // Why: held syllables are not on the PTY yet; the caret cannot enter them.
+      sentLen
+    )
+  } else if (nextSelection && nextSelection.start !== nextSelection.end) {
+    // Non-collapsed: leave the PTY caret at the mirrored end until collapse.
+    target = sentLen
+  } else {
+    // No selection yet: infer from the field diff so mid-insert/delete batch.
+    const previousField = state.fieldText.length > 0 ? state.fieldText : sentText + state.heldText
+    target = clampCodePointIndex(
+      inferTerminalLiveCaretCodePointAfterEdit(previousField, nextFieldText),
+      sentLen
+    )
+  }
+
+  payload += buildArrowPayload(ptyCursor, target)
+
+  return {
+    payload,
+    nextSentText,
+    heldText,
+    nextPtyCursorCodePoint: target,
+    nextFieldText
+  }
+}

--- a/mobile/src/terminal/terminal-live-selection-event-routing.test.ts
+++ b/mobile/src/terminal/terminal-live-selection-event-routing.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyTerminalLiveSelectionEvent,
+  isTerminalLiveFieldOwnedArrowKey,
+  shouldApplyTerminalLiveCursorOnlySelectionMove
+} from './terminal-live-selection-event-routing'
+
+describe('terminal live selection event routing', () => {
+  it('Given a text change When selection follows Then classifies as paired-with-text-change', () => {
+    expect(classifyTerminalLiveSelectionEvent(true)).toBe('paired-with-text-change')
+  })
+
+  it('Given no text change When selection arrives Then classifies as cursor-only', () => {
+    expect(classifyTerminalLiveSelectionEvent(false)).toBe('cursor-only')
+  })
+
+  it('Given paired selection with held Hangul Then does not apply cursor-only move', () => {
+    expect(
+      shouldApplyTerminalLiveCursorOnlySelectionMove({
+        kind: 'paired-with-text-change',
+        heldText: '한',
+        allowSoftReseatWhenPaired: true
+      })
+    ).toBe(false)
+  })
+
+  it('Given paired selection without held text Then allows soft reseat', () => {
+    expect(
+      shouldApplyTerminalLiveCursorOnlySelectionMove({
+        kind: 'paired-with-text-change',
+        heldText: '',
+        allowSoftReseatWhenPaired: true
+      })
+    ).toBe(true)
+  })
+
+  it('Given cursor-only selection Then always applies the move plan', () => {
+    expect(
+      shouldApplyTerminalLiveCursorOnlySelectionMove({
+        kind: 'cursor-only',
+        heldText: '글',
+        allowSoftReseatWhenPaired: false
+      })
+    ).toBe(true)
+  })
+
+  it('Given ArrowLeft/Right Then marks them as field-owned arrow keys', () => {
+    expect(isTerminalLiveFieldOwnedArrowKey('ArrowLeft')).toBe(true)
+    expect(isTerminalLiveFieldOwnedArrowKey('ArrowRight')).toBe(true)
+    expect(isTerminalLiveFieldOwnedArrowKey('ArrowUp')).toBe(false)
+  })
+})

--- a/mobile/src/terminal/terminal-live-selection-event-routing.ts
+++ b/mobile/src/terminal/terminal-live-selection-event-routing.ts
@@ -1,0 +1,30 @@
+// iOS reports text before its paired selection; only an unpaired selection is
+// a trackpad-only move that may commit held Hangul.
+export type TerminalLiveSelectionEventKind = 'paired-with-text-change' | 'cursor-only'
+
+export function classifyTerminalLiveSelectionEvent(
+  expectsPairedAfterTextChange: boolean
+): TerminalLiveSelectionEventKind {
+  return expectsPairedAfterTextChange ? 'paired-with-text-change' : 'cursor-only'
+}
+
+// A paired selection may correct an inferred ASCII caret, but must not flush
+// Hangul preedit that the preceding text event intentionally held.
+export function shouldApplyTerminalLiveCursorOnlySelectionMove(options: {
+  readonly kind: TerminalLiveSelectionEventKind
+  readonly heldText: string
+  readonly allowSoftReseatWhenPaired: boolean
+}): boolean {
+  if (options.kind === 'cursor-only') {
+    return true
+  }
+  if (options.heldText.length > 0) {
+    return false
+  }
+  return options.allowSoftReseatWhenPaired
+}
+
+/** Physical arrows: selection owns PTY steps when the field has text. */
+export function isTerminalLiveFieldOwnedArrowKey(key: string): boolean {
+  return key === 'ArrowLeft' || key === 'ArrowRight'
+}

--- a/mobile/src/terminal/terminal-live-text-commit.test.ts
+++ b/mobile/src/terminal/terminal-live-text-commit.test.ts
@@ -49,6 +49,24 @@ describe('terminal live special key decision', () => {
     })
     expect(decision.kind).toBe('send-now')
   })
+
+  it('Given ArrowLeft/Right with field text Then edits locally so selection sync owns the PTY caret', () => {
+    expect(
+      getTerminalLiveSpecialKeyDecision({ key: 'ArrowLeft', heldText: '', sentText: 'abc' })
+    ).toEqual({ kind: 'local-edit' })
+    expect(
+      getTerminalLiveSpecialKeyDecision({ key: 'ArrowRight', heldText: '한', sentText: '' })
+    ).toEqual({ kind: 'local-edit' })
+  })
+
+  it('Given ArrowLeft with an empty field Then sends terminal arrow bytes', () => {
+    const decision = getTerminalLiveSpecialKeyDecision({
+      key: 'ArrowLeft',
+      heldText: '',
+      sentText: ''
+    })
+    expect(decision.kind).toBe('send-now')
+  })
 })
 
 describe('terminal live accessory bytes decision', () => {

--- a/mobile/src/terminal/terminal-live-text-commit.ts
+++ b/mobile/src/terminal/terminal-live-text-commit.ts
@@ -42,6 +42,15 @@ export function getTerminalLiveSpecialKeyDecision({
     return { kind: 'local-edit' }
   }
 
+  // Why: with field text, iOS trackpad/hardware arrows move the native caret and
+  // onSelectionChange syncs the PTY; sending here would double-step.
+  if (
+    (key === 'ArrowLeft' || key === 'ArrowRight') &&
+    (heldText.length > 0 || sentText.length > 0)
+  ) {
+    return { kind: 'local-edit' }
+  }
+
   if (heldText.length > 0) {
     return { kind: 'commit-held-then-send', bytes }
   }

--- a/mobile/src/terminal/use-terminal-live-accessory-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-accessory-input-commit.test.ts
@@ -3,7 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import type { TextInput } from 'react-native'
 import { describe, expect, it, vi } from 'vitest'
 import type { TerminalLiveAccessoryInput } from './terminal-live-accessory-input'
-import type { TerminalLiveInputSender } from './terminal-live-input-sender'
+import type { TerminalLiveQueueControlOptions } from './use-terminal-live-pending-input-flush'
 import {
   getTerminalLiveAccessoryInactiveInputCommitResult,
   useTerminalLiveAccessoryInputCommit,
@@ -41,8 +41,6 @@ type AccessoryInputCommitHarnessOptions = {
   readonly heldText?: string
   readonly sentText?: string
   readonly pendingHandle?: string | null
-  readonly sendResult?: boolean
-  readonly flushResult?: boolean
   readonly waitResult?: boolean
 }
 
@@ -50,10 +48,14 @@ type AccessoryInputCommitHarness = {
   readonly commit: (
     input: TerminalLiveAccessoryInput
   ) => Promise<TerminalLiveAccessoryInputCommitResult>
-  readonly sent: readonly string[]
-  readonly applyLiveInputMirror: ReturnType<typeof vi.fn>
-  readonly flushPendingLiveInputText: ReturnType<typeof vi.fn>
+  readonly queued: readonly {
+    readonly bytes: string
+    readonly options: TerminalLiveQueueControlOptions
+  }[]
+  readonly clearPendingLiveInputCommit: ReturnType<typeof vi.fn>
+  readonly queueLiveInputControl: ReturnType<typeof vi.fn>
   readonly waitForPendingLiveInputFlush: ReturnType<typeof vi.fn>
+  readonly applyLiveInputMirror: ReturnType<typeof vi.fn>
   readonly unmount: () => void
 }
 
@@ -61,8 +63,6 @@ function createAccessoryInputCommitHarness({
   heldText = '',
   sentText = '',
   pendingHandle = null,
-  sendResult = true,
-  flushResult = true,
   waitResult = true
 }: AccessoryInputCommitHarnessOptions = {}): AccessoryInputCommitHarness {
   const activeHandle = 'terminal-a'
@@ -71,16 +71,15 @@ function createAccessoryInputCommitHarness({
   const pendingLiveInputHandleRef: RefObject<string | null> = { current: pendingHandle }
   const liveInputRef: RefObject<TextInput | null> = { current: null }
   const liveInputTerminalHandles = new Set([activeHandle])
-  const sent: string[] = []
-  const sendLiveTerminalInputRef: RefObject<TerminalLiveInputSender> = {
-    current: async (_handle, bytes) => {
-      sent.push(bytes)
-      return sendResult
+  const queued: { bytes: string; options: TerminalLiveQueueControlOptions }[] = []
+  const queueLiveInputControl = vi.fn(
+    async (_handle: string, bytes: string, options: TerminalLiveQueueControlOptions) => {
+      queued.push({ bytes, options })
+      return true
     }
-  }
+  )
   const applyLiveInputMirror = vi.fn((_handle: string, _fieldText: string) => {})
   const clearPendingLiveInputCommit = vi.fn(() => {})
-  const flushPendingLiveInputText = vi.fn(async (_expectedHandle: string | null) => flushResult)
   const waitForPendingLiveInputFlush = vi.fn(async () => waitResult)
   const setLiveInputCapture = vi.fn((_text: string) => {})
 
@@ -92,13 +91,12 @@ function createAccessoryInputCommitHarness({
       activeHandle,
       applyLiveInputMirror,
       clearPendingLiveInputCommit,
-      flushPendingLiveInputText,
       heldLiveInputTextRef,
       liveInputRef,
       liveInputTerminalHandles,
       pendingLiveInputHandleRef,
+      queueLiveInputControl,
       sentLiveInputTextRef,
-      sendLiveTerminalInputRef,
       setLiveInputCapture,
       waitForPendingLiveInputFlush
     })
@@ -119,10 +117,11 @@ function createAccessoryInputCommitHarness({
 
   return {
     commit,
-    sent,
-    applyLiveInputMirror,
-    flushPendingLiveInputText,
+    queued,
+    clearPendingLiveInputCommit,
+    queueLiveInputControl,
     waitForPendingLiveInputFlush,
+    applyLiveInputMirror,
     unmount: () => {
       act(() => renderer?.unmount())
     }
@@ -131,11 +130,8 @@ function createAccessoryInputCommitHarness({
 
 describe('terminal live accessory inactive input commit result', () => {
   it('Given live input is disabled with an active flush When accessory raw fallback is requested Then waits before allowing raw send', async () => {
-    // Given
     const deferredFlush = createDeferredBoolean()
     let settled = false
-
-    // When
     const resultPromise = getTerminalLiveAccessoryInactiveInputCommitResult(
       () => deferredFlush.promise
     )
@@ -143,87 +139,83 @@ describe('terminal live accessory inactive input commit result', () => {
       settled = true
     })
     await Promise.resolve()
-
-    // Then
     expect(settled).toBe(false)
     deferredFlush.resolve(true)
     await expect(resultPromise).resolves.toEqual({ kind: 'allow-raw' })
   })
 
   it('Given live input is disabled with a failed active flush When accessory raw fallback is requested Then suppresses raw send', async () => {
-    // Given
-    const waitForPendingLiveInputFlush = async (): Promise<boolean> => false
-
-    // When
-    const result = await getTerminalLiveAccessoryInactiveInputCommitResult(
-      waitForPendingLiveInputFlush
-    )
-
-    // Then
+    const result = await getTerminalLiveAccessoryInactiveInputCommitResult(async () => false)
     expect(result).toEqual({ kind: 'suppress-raw' })
   })
 })
 
 describe('terminal live accessory input commit hook', () => {
-  it('Given raw accessory bytes with a held syllable When committed Then flushes held text before sending bytes', async () => {
-    // Given
+  it('Given raw accessory with held syllable When committed Then queues commit-before-control and clears session sync', async () => {
     const harness = createAccessoryInputCommitHarness({
       heldText: '한',
       sentText: '',
       pendingHandle: 'terminal-a'
     })
 
-    // When
     const result = await harness.commit({ bytes: '\x1b' })
 
-    // Then
-    expect(harness.flushPendingLiveInputText).toHaveBeenCalledWith('terminal-a')
-    expect(harness.sent).toEqual(['\x1b'])
+    expect(harness.queueLiveInputControl).toHaveBeenCalledWith('terminal-a', '\x1b', {
+      commitFieldBeforeControl: true
+    })
+    expect(harness.clearPendingLiveInputCommit).toHaveBeenCalledOnce()
     expect(result).toEqual({ kind: 'handled' })
   })
 
-  it('Given raw accessory bytes with no held text When committed Then allows the raw send without flushing', async () => {
-    // Given
+  it('Given raw accessory with sent-only field When committed Then queues control without commit prefix and clears sync', async () => {
+    const harness = createAccessoryInputCommitHarness({
+      heldText: '',
+      sentText: 'abc',
+      pendingHandle: 'terminal-a'
+    })
+
+    const result = await harness.commit({ bytes: '\x1b[D' })
+
+    expect(harness.queueLiveInputControl).toHaveBeenCalledWith('terminal-a', '\x1b[D', {
+      commitFieldBeforeControl: false
+    })
+    expect(harness.clearPendingLiveInputCommit).toHaveBeenCalledOnce()
+    expect(result).toEqual({ kind: 'handled' })
+  })
+
+  it('Given raw accessory with no field session When committed Then allows the raw send without queueing', async () => {
     const harness = createAccessoryInputCommitHarness({ pendingHandle: null })
 
-    // When
     const result = await harness.commit({ bytes: '\x1b' })
 
-    // Then
     expect(result).toEqual({ kind: 'allow-raw' })
-    expect(harness.flushPendingLiveInputText).not.toHaveBeenCalled()
-    expect(harness.sent).toEqual([])
+    expect(harness.queueLiveInputControl).not.toHaveBeenCalled()
+    expect(harness.clearPendingLiveInputCommit).not.toHaveBeenCalled()
   })
 
   it('Given accessory backspace with a held syllable When committed Then mirrors the emptied field without terminal bytes', async () => {
-    // Given
     const harness = createAccessoryInputCommitHarness({
       heldText: '한',
       sentText: '',
       pendingHandle: 'terminal-a'
     })
 
-    // When
     const result = await harness.commit({ bytes: '\x7f', localEdit: 'backspace' })
 
-    // Then
     expect(harness.applyLiveInputMirror).toHaveBeenCalledWith('terminal-a', '')
     expect(result).toEqual({ kind: 'handled' })
-    expect(harness.sent).toEqual([])
+    expect(harness.queueLiveInputControl).not.toHaveBeenCalled()
   })
 
   it('Given accessory backspace with mirrored sent text When committed Then mirrors the shortened field so the diff emits DEL', async () => {
-    // Given
     const harness = createAccessoryInputCommitHarness({
       heldText: '',
       sentText: 'ab',
       pendingHandle: 'terminal-a'
     })
 
-    // When
     const result = await harness.commit({ bytes: '\x7f', localEdit: 'backspace' })
 
-    // Then
     expect(harness.applyLiveInputMirror).toHaveBeenCalledWith('terminal-a', 'a')
     expect(result).toEqual({ kind: 'handled' })
   })

--- a/mobile/src/terminal/use-terminal-live-accessory-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-accessory-input-commit.ts
@@ -5,8 +5,7 @@ import {
   getTerminalLiveAccessoryLocalEditText
 } from './terminal-live-text-commit'
 import type { TerminalLiveAccessoryInput } from './terminal-live-accessory-input'
-import { sendTerminalLiveControlAfterPendingFlush } from './terminal-live-control-send-order'
-import type { TerminalLiveInputSender } from './terminal-live-input-sender'
+import type { TerminalLiveQueueControlOptions } from './terminal-live-control-payload'
 
 export type TerminalLiveAccessoryInputCommitResult =
   | { readonly kind: 'allow-raw' }
@@ -23,13 +22,16 @@ type TerminalLiveAccessoryInputCommitOptions = {
   readonly activeHandle: string | null
   readonly applyLiveInputMirror: (handle: string, fieldText: string) => void
   readonly clearPendingLiveInputCommit: () => void
-  readonly flushPendingLiveInputText: (expectedHandle: string | null) => Promise<boolean>
   readonly heldLiveInputTextRef: RefObject<string>
   readonly liveInputRef: RefObject<TextInput | null>
   readonly liveInputTerminalHandles: ReadonlySet<string>
   readonly pendingLiveInputHandleRef: RefObject<string | null>
+  readonly queueLiveInputControl: (
+    handle: string,
+    bytes: string,
+    options: TerminalLiveQueueControlOptions
+  ) => Promise<boolean>
   readonly sentLiveInputTextRef: RefObject<string>
-  readonly sendLiveTerminalInputRef: RefObject<TerminalLiveInputSender>
   readonly setLiveInputCapture: (text: string) => void
   readonly waitForPendingLiveInputFlush: () => Promise<boolean>
 }
@@ -38,13 +40,12 @@ export function useTerminalLiveAccessoryInputCommit({
   activeHandle,
   applyLiveInputMirror,
   clearPendingLiveInputCommit,
-  flushPendingLiveInputText,
   heldLiveInputTextRef,
   liveInputRef,
   liveInputTerminalHandles,
   pendingLiveInputHandleRef,
+  queueLiveInputControl,
   sentLiveInputTextRef,
-  sendLiveTerminalInputRef,
   setLiveInputCapture,
   waitForPendingLiveInputFlush
 }: TerminalLiveAccessoryInputCommitOptions): (
@@ -67,11 +68,22 @@ export function useTerminalLiveAccessoryInputCommit({
       const decision = getTerminalLiveAccessoryBytesDecision({ ...input, heldText, sentText })
       switch (decision.kind) {
         case 'send-now':
-          // Why: raw accessory bytes must wait behind any in-flight mirror send
-          // so composed Hangul reaches the PTY before follow-up controls.
+        case 'commit-held-then-send': {
+          const bytes = decision.kind === 'send-now' ? input.bytes : decision.bytes
+          if (heldText.length > 0 || sentText.length > 0) {
+            // Queue on the mirror chain, then clear the old session synchronously so a
+            // following onChange starts fresh and chains behind this control payload.
+            const sendPromise = queueLiveInputControl(activeHandle, bytes, {
+              commitFieldBeforeControl: heldText.length > 0
+            })
+            clearPendingLiveInputCommit()
+            await sendPromise
+            return { kind: 'handled' }
+          }
           return (await waitForPendingLiveInputFlush())
             ? { kind: 'allow-raw' }
             : { kind: 'suppress-raw' }
+        }
         case 'local-edit': {
           const editedText = getTerminalLiveAccessoryLocalEditText({
             localEdit: decision.localEdit,
@@ -84,12 +96,6 @@ export function useTerminalLiveAccessoryInputCommit({
           applyLiveInputMirror(activeHandle, editedText)
           return { kind: 'handled' }
         }
-        case 'commit-held-then-send':
-          await sendTerminalLiveControlAfterPendingFlush(
-            () => flushPendingLiveInputText(activeHandle),
-            () => sendLiveTerminalInputRef.current(activeHandle, decision.bytes)
-          )
-          return { kind: 'handled' }
         default:
           decision satisfies never
           return { kind: 'handled' }
@@ -99,13 +105,12 @@ export function useTerminalLiveAccessoryInputCommit({
       activeHandle,
       applyLiveInputMirror,
       clearPendingLiveInputCommit,
-      flushPendingLiveInputText,
       heldLiveInputTextRef,
       liveInputRef,
       liveInputTerminalHandles,
       pendingLiveInputHandleRef,
+      queueLiveInputControl,
       sentLiveInputTextRef,
-      sendLiveTerminalInputRef,
       setLiveInputCapture,
       waitForPendingLiveInputFlush
     ]

--- a/mobile/src/terminal/use-terminal-live-input-commit.test.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.test.ts
@@ -6,10 +6,18 @@ import type { TerminalLiveInputSender } from './terminal-live-input-sender'
 import { TERMINAL_LIVE_HELD_SYLLABLE_COMMIT_DELAY_MS } from './terminal-live-hangul-mirror'
 import { useTerminalLiveInputCommit } from './use-terminal-live-input-commit'
 
+type DeferredSend = {
+  readonly bytes: string
+  readonly resolve: (value: boolean) => void
+}
+
 type TerminalLiveInputCommitHarness = {
   readonly captures: readonly string[]
   readonly handlers: ReturnType<typeof useTerminalLiveInputCommit<string>>
   readonly sent: readonly string[]
+  readonly invokeOrder: readonly string[]
+  readonly pendingSends: DeferredSend[]
+  readonly resolveNextSend: (value?: boolean) => void
   readonly setActiveSessionTabType: (next: string | undefined) => void
   readonly setConnected: (next: boolean) => void
   readonly setSendResult: (next: boolean) => void
@@ -18,6 +26,10 @@ type TerminalLiveInputCommitHarness = {
 
 type TerminalLiveInputCommitHarnessOptions = {
   readonly sendResult?: boolean
+  /** When set, overrides sendResult per payload (for accept/reject control cases). */
+  readonly acceptSend?: (bytes: string) => boolean
+  /** Hold each send until resolveNextSend — for queue-ordering race tests. */
+  readonly deferSends?: boolean
 }
 
 function suppressReactTestRendererDeprecationWarning(): () => void {
@@ -33,7 +45,9 @@ function suppressReactTestRendererDeprecationWarning(): () => void {
 }
 
 function createTerminalLiveInputCommitHarness({
-  sendResult = true
+  sendResult = true,
+  acceptSend,
+  deferSends = false
 }: TerminalLiveInputCommitHarnessOptions = {}): TerminalLiveInputCommitHarness {
   const activeHandle = 'terminal-a'
   const activeHandleRef: RefObject<string | null> = { current: activeHandle }
@@ -49,10 +63,24 @@ function createTerminalLiveInputCommitHarness({
   }
   const sent: string[] = []
   let currentSendResult = sendResult
+  const invokeOrder: string[] = []
+  const pendingSends: DeferredSend[] = []
   const sendLiveTerminalInputRef: RefObject<TerminalLiveInputSender> = {
     current: async (_handle, bytes) => {
+      invokeOrder.push(bytes)
+      if (deferSends) {
+        return new Promise<boolean>((resolve) => {
+          pendingSends.push({
+            bytes,
+            resolve: (value) => {
+              sent.push(bytes)
+              resolve(value)
+            }
+          })
+        })
+      }
       sent.push(bytes)
-      return currentSendResult
+      return acceptSend ? acceptSend(bytes) : currentSendResult
     }
   }
   // Refs never re-render; only these variables re-run the hook's clear effects.
@@ -93,6 +121,15 @@ function createTerminalLiveInputCommitHarness({
     captures,
     handlers,
     sent,
+    invokeOrder,
+    pendingSends,
+    resolveNextSend: (value = true): void => {
+      const next = pendingSends.shift()
+      if (!next) {
+        throw new Error('no deferred send to resolve')
+      }
+      next.resolve(value)
+    },
     setActiveSessionTabType: (next: string | undefined): void => {
       currentActiveSessionTabType = next
       // Ref and prop derive from the same activeSessionTab in the real route, so
@@ -174,8 +211,8 @@ describe('terminal live input commit hook', () => {
     // When
     handlers.handleLiveInputSubmit()
 
-    // Then
-    await vi.waitFor(() => expect(sent).toEqual(['한', '\r']))
+    // Then: held commit + CR are one queued payload
+    await vi.waitFor(() => expect(sent).toEqual(['한\r']))
   })
 
   it('Given no pending text When submit is requested Then sends only carriage return', async () => {
@@ -189,7 +226,7 @@ describe('terminal live input commit hook', () => {
     await vi.waitFor(() => expect(sent).toEqual(['\r']))
   })
 
-  it('Given a rejected held-text send When submit is requested Then suppresses the carriage return', async () => {
+  it('Given a rejected held-text submit When the combined payload fails Then still only one ordered attempt', async () => {
     // Given
     const { handlers, sent } = createTerminalLiveInputCommitHarness({ sendResult: false })
     handlers.handleLiveInputChange('한')
@@ -199,8 +236,8 @@ describe('terminal live input commit hook', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    // Then: the held commit went out but was not accepted, so no \r follows
-    await vi.waitFor(() => expect(sent).toEqual(['한']))
+    // Then: held+\r is one queued payload (cannot suppress only CR after a failed held half)
+    await vi.waitFor(() => expect(sent).toEqual(['한\r']))
   })
 
   it('Given ASCII typing When changes arrive Then mirrors immediately', async () => {
@@ -324,8 +361,8 @@ describe('terminal live input commit hook', () => {
     // When
     handlers.handleLiveInputKeyPress({ nativeEvent: { key: 'Tab' } })
 
-    // Then
-    await vi.waitFor(() => expect(sent).toEqual(['한', '\t']))
+    // Then: held preedit is not on the PTY — one ordered payload holds-before-Tab
+    await vi.waitFor(() => expect(sent).toEqual(['한\t']))
   })
 
   it('Given Hangul pending When the tab type lags to undefined Then keeps the composition state', async () => {
@@ -338,7 +375,7 @@ describe('terminal live input commit hook', () => {
     handlers.handleLiveInputSubmit()
 
     // Then: an unknown tab type is not "left the terminal", so pending still flushes
-    await vi.waitFor(() => expect(sent).toEqual(['한', '\r']))
+    await vi.waitFor(() => expect(sent).toEqual(['한\r']))
   })
 
   it('Given Hangul pending When the tab genuinely changes to non-terminal Then clears the composition state', async () => {
@@ -350,8 +387,398 @@ describe('terminal live input commit hook', () => {
     setActiveSessionTabType('chat')
     handlers.handleLiveInputSubmit()
 
-    // Then: pending was dropped, so submit sends only the carriage return
-    await vi.waitFor(() => expect(sent).toEqual(['\r']))
+    // Then: pending was dropped and the surface is not live — no control is queued
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(sent).toEqual([])
+  })
+
+  /**
+   * RN 0.83.9: onChangeText then onSelectionChange for the edit. Simulate the
+   * paired end-of-field selection, then a later cursor-only trackpad move.
+   */
+  async function typeFieldThenMoveCaret(
+    handlers: ReturnType<typeof createTerminalLiveInputCommitHarness>['handlers'],
+    fieldText: string,
+    nextCollapsedUtf16: number
+  ): Promise<void> {
+    handlers.handleLiveInputChange(fieldText)
+    // Paired selection after the text change (caret at end) — not a trackpad move.
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: fieldText.length, end: fieldText.length } }
+    })
+    await Promise.resolve()
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: nextCollapsedUtf16, end: nextCollapsedUtf16 } }
+    })
+  }
+
+  it('Given end-to-middle trackpad move When selection collapses Then sends ordered ArrowLeft bytes', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abcdef', 3)
+
+    await vi.waitFor(() => expect(sent).toEqual(['abcdef', '\x1b[D'.repeat(3)]))
+  })
+
+  it('Given repeated selection at the same index Then sends nothing more', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abc', 1)
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2)]))
+
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+
+    await Promise.resolve()
+    expect(sent).toEqual(['abc', '\x1b[D'.repeat(2)])
+  })
+
+  it('Given middle caret When moved right Then sends ordered ArrowRight bytes', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abcdef', 2)
+    await vi.waitFor(() => expect(sent).toEqual(['abcdef', '\x1b[D'.repeat(4)]))
+
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 5, end: 5 } }
+    })
+
+    await vi.waitFor(() => expect(sent).toEqual(['abcdef', '\x1b[D'.repeat(4), '\x1b[C'.repeat(3)]))
+  })
+
+  it('Given middle insertion When text changes Then PTY converges to abcXdef with caret after X', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abcdef', 3)
+    await vi.waitFor(() => expect(sent).toEqual(['abcdef', '\x1b[D'.repeat(3)]))
+
+    handlers.handleLiveInputChange('abcXdef')
+    // Paired selection after insert (RN order) must not emit a second arrow plan.
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 4, end: 4 } }
+    })
+
+    await vi.waitFor(() =>
+      expect(sent).toEqual([
+        'abcdef',
+        '\x1b[D'.repeat(3),
+        '\x1b[C'.repeat(3) + '\x7f'.repeat(3) + 'Xdef' + '\x1b[D'.repeat(3)
+      ])
+    )
+  })
+
+  it('Given middle deletion When text shortens Then restores, erases, and reseats the caret', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abXcd', 3)
+    await vi.waitFor(() => expect(sent).toEqual(['abXcd', '\x1b[D'.repeat(2)]))
+
+    handlers.handleLiveInputChange('abcd')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 2, end: 2 } }
+    })
+
+    await vi.waitFor(() =>
+      expect(sent).toEqual([
+        'abXcd',
+        '\x1b[D'.repeat(2),
+        '\x1b[C'.repeat(2) + '\x7f'.repeat(3) + 'cd' + '\x1b[D'.repeat(2)
+      ])
+    )
+  })
+
+  it('Given emoji field When caret crosses the emoji Then arrow counts are code-point safe', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    const text = 'a👍b'
+    // UTF-16: a=0..1, 👍=1..3, b=3..4 — caret before b is utf16 offset 3
+    await typeFieldThenMoveCaret(handlers, text, 3)
+
+    await vi.waitFor(() => expect(sent).toEqual([text, '\x1b[D']))
+  })
+
+  it('Given held Hangul When selection moves left Then flushes the syllable before arrows', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('한')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+    handlers.handleLiveInputChange('한글')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 2, end: 2 } }
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['한']))
+    await Promise.resolve()
+
+    // Cursor-only move (no preceding text change) — flush held then ArrowLeft.
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+
+    await vi.waitFor(() => expect(sent).toEqual(['한', '글' + '\x1b[D']))
+  })
+
+  it('Given held Hangul When end-of-field selection repeats Then does not flush early', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('한')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+
+    await Promise.resolve()
+    expect(sent).toEqual([])
+  })
+
+  it('Given Hangul composition When paired selections follow each change Then does not flush or leak preedit jamo', async () => {
+    // Given / When: RN delivers onChange then onSelectionChange per composition step
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    for (const fieldText of ['ㅎ', '하', '한', '한ㄱ', '한그', '한글']) {
+      handlers.handleLiveInputChange(fieldText)
+      handlers.handleLiveInputSelectionChange({
+        nativeEvent: { selection: { start: fieldText.length, end: fieldText.length } }
+      })
+    }
+
+    // Then: only the stable prefix streamed; held trailing syllable never flushed by selection
+    await vi.waitFor(() => expect(sent).toEqual(['한']))
+    expect(sent.some((payload) => payload.includes('ㅎ') || payload.includes('ㄱ'))).toBe(false)
+  })
+
+  it('Given physical ArrowLeft with field text When keypress and selection both fire Then sends a single arrow', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abc', 3)
+    await vi.waitFor(() => expect(sent).toEqual(['abc']))
+
+    // Hardware keyboards can emit both events; keypress must not PTY-send when the field owns the caret.
+    handlers.handleLiveInputKeyPress({ nativeEvent: { key: 'ArrowLeft' } })
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 2, end: 2 } }
+    })
+
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D']))
+    expect(sent.filter((payload) => payload === '\x1b[D')).toHaveLength(1)
+  })
+
+  it('Given physical ArrowRight with field text When keypress and selection both fire Then sends a single arrow', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abc', 1)
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2)]))
+
+    handlers.handleLiveInputKeyPress({ nativeEvent: { key: 'ArrowRight' } })
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 2, end: 2 } }
+    })
+
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2), '\x1b[C']))
+    expect(sent.filter((payload) => payload === '\x1b[C')).toHaveLength(1)
+  })
+
+  it('Given stale handle When selection arrives Then rejects and sends nothing', async () => {
+    const { handlers, sent, setActiveSessionTabType } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('abc')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 3, end: 3 } }
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['abc']))
+
+    // Tab left the terminal surface — live selection must not move a foreign PTY.
+    setActiveSessionTabType('chat')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 0, end: 0 } }
+    })
+
+    await Promise.resolve()
+    expect(sent).toEqual(['abc'])
+  })
+
+  it('Given pending field When submit runs Then selection state resets so later arrows do not reuse it', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abc', 1)
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2)]))
+
+    handlers.handleLiveInputSubmit()
+    // Mid-caret restore + CR are one control payload after the trackpad lefts.
+    await vi.waitFor(() =>
+      expect(sent).toEqual(['abc', '\x1b[D'.repeat(2), '\x1b[C'.repeat(2) + '\r'])
+    )
+
+    handlers.handleLiveInputChange('z')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+    await vi.waitFor(() =>
+      expect(sent).toEqual(['abc', '\x1b[D'.repeat(2), '\x1b[C'.repeat(2) + '\r', 'z'])
+    )
+  })
+
+  it('Given non-terminal mode change When selection fires Then sends nothing', async () => {
+    const { handlers, sent, setActiveSessionTabType } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('abc')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 3, end: 3 } }
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['abc']))
+    setActiveSessionTabType('chat')
+
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 0, end: 0 } }
+    })
+
+    await Promise.resolve()
+    expect(sent).toEqual(['abc'])
+  })
+
+  it('Given mid-field caret When accessory Left is accepted Then next typed char starts fresh without canceling the control', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    await typeFieldThenMoveCaret(handlers, 'abc', 1)
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2)]))
+
+    const result = await handlers.handleLiveInputAccessoryBytes({ bytes: '\x1b[D' })
+    expect(result).toEqual({ kind: 'handled' })
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2), '\x1b[D']))
+
+    // Fresh field session at the moved PTY position — no restore/suffix repair of "abc".
+    handlers.handleLiveInputChange('z')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 1, end: 1 } }
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2), '\x1b[D', 'z']))
+    expect(sent.some((payload) => payload.includes('\x7f'))).toBe(false)
+  })
+
+  it('Given sent-only accessory control When send fails Then local session still ended so next typing is fresh', async () => {
+    // Trackpad multi-arrow payload still accepts; single accessory Left rejects.
+    const { handlers, sent } = createTerminalLiveInputCommitHarness({
+      acceptSend: (bytes) => bytes !== '\x1b[D'
+    })
+    await typeFieldThenMoveCaret(handlers, 'abc', 1)
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2)]))
+
+    const result = await handlers.handleLiveInputAccessoryBytes({ bytes: '\x1b[D' })
+    expect(result).toEqual({ kind: 'handled' })
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2), '\x1b[D']))
+
+    // Session ended on queue regardless of accept — no suffix repair against "abc".
+    handlers.handleLiveInputChange('z')
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D'.repeat(2), '\x1b[D', 'z']))
+  })
+
+  it('Given accepted Tab with field text When next char is typed Then starts a fresh field session', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('abc')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 3, end: 3 } }
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['abc']))
+
+    handlers.handleLiveInputKeyPress({ nativeEvent: { key: 'Tab' } })
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\t']))
+
+    handlers.handleLiveInputChange('z')
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\t', 'z']))
+  })
+
+  it('Given accepted Escape with field text When next char is typed Then starts a fresh field session', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness()
+    handlers.handleLiveInputChange('abc')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 3, end: 3 } }
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['abc']))
+
+    handlers.handleLiveInputKeyPress({ nativeEvent: { key: 'Escape' } })
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b']))
+
+    handlers.handleLiveInputChange('z')
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b', 'z']))
+  })
+
+  it('Given failed non-arrow special control When send is rejected Then session was still cleared for a fresh next edit', async () => {
+    const { handlers, sent } = createTerminalLiveInputCommitHarness({
+      acceptSend: (bytes) => bytes !== '\x1b'
+    })
+    handlers.handleLiveInputChange('abc')
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 3, end: 3 } }
+    })
+    await vi.waitFor(() => expect(sent).toEqual(['abc']))
+
+    handlers.handleLiveInputKeyPress({ nativeEvent: { key: 'Escape' } })
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b']))
+
+    handlers.handleLiveInputChange('z')
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b', 'z']))
+  })
+
+  it('Given deferred accessory Left When new Hangul arrives Then control settles before the new session payload', async () => {
+    const { handlers, sent, invokeOrder, pendingSends, resolveNextSend } =
+      createTerminalLiveInputCommitHarness({ deferSends: true })
+
+    handlers.handleLiveInputChange('abc')
+    await vi.waitFor(() => expect(pendingSends.length).toBe(1))
+    resolveNextSend(true)
+    await vi.waitFor(() => expect(sent).toEqual(['abc']))
+    handlers.handleLiveInputSelectionChange({
+      nativeEvent: { selection: { start: 3, end: 3 } }
+    })
+
+    const accessoryPromise = handlers.handleLiveInputAccessoryBytes({ bytes: '\x1b[D' })
+    await vi.waitFor(() => expect(pendingSends.map((p) => p.bytes)).toEqual(['\x1b[D']))
+
+    // New IME session while control is still pending — must not be invoked yet.
+    handlers.handleLiveInputChange('한')
+    await Promise.resolve()
+    expect(invokeOrder).toEqual(['abc', '\x1b[D'])
+    expect(pendingSends).toHaveLength(1)
+
+    resolveNextSend(true)
+    await accessoryPromise
+    await vi.waitFor(() => expect(pendingSends.map((p) => p.bytes)).toEqual(['한']))
+    resolveNextSend(true)
+    await vi.waitFor(() => expect(sent).toEqual(['abc', '\x1b[D', '한']))
+  })
+
+  it('Given deferred submit When new Hangul arrives Then submit payload settles before the new Hangul', async () => {
+    const { handlers, sent, invokeOrder, pendingSends, resolveNextSend } =
+      createTerminalLiveInputCommitHarness({ deferSends: true })
+
+    handlers.handleLiveInputChange('한')
+    await vi.waitFor(() => expect(pendingSends.length).toBe(0))
+    // Held is not sent until commit; submit queues held+\r as one payload.
+    handlers.handleLiveInputSubmit()
+    await vi.waitFor(() => expect(pendingSends.map((p) => p.bytes)).toEqual(['한\r']))
+
+    handlers.handleLiveInputChange('가')
+    await Promise.resolve()
+    expect(invokeOrder).toEqual(['한\r'])
+    expect(pendingSends).toHaveLength(1)
+
+    resolveNextSend(true)
+    await vi.waitFor(() => expect(pendingSends.map((p) => p.bytes)).toEqual(['가']))
+    resolveNextSend(true)
+    await vi.waitFor(() => expect(sent).toEqual(['한\r', '가']))
+  })
+
+  it('Given deferred external flush When new Hangul arrives Then flush settles before the new session', async () => {
+    const { handlers, sent, invokeOrder, pendingSends, resolveNextSend } =
+      createTerminalLiveInputCommitHarness({ deferSends: true })
+
+    handlers.handleLiveInputChange('한')
+    const flushPromise = handlers.flushPendingLiveInputBeforeExternalSend('terminal-a')
+    await vi.waitFor(() => expect(pendingSends.map((p) => p.bytes)).toEqual(['한']))
+
+    handlers.handleLiveInputChange('글')
+    await Promise.resolve()
+    expect(invokeOrder).toEqual(['한'])
+    expect(pendingSends).toHaveLength(1)
+
+    resolveNextSend(true)
+    await flushPromise
+    await vi.waitFor(() => expect(pendingSends.map((p) => p.bytes)).toEqual(['글']))
+    resolveNextSend(true)
+    await vi.waitFor(() => expect(sent).toEqual(['한', '글']))
   })
 
   it('Given bytes lost in a silent stall When the disconnect is detected Then the first post-recovery send carries no stale fragment or phantom erases', async () => {

--- a/mobile/src/terminal/use-terminal-live-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.ts
@@ -6,7 +6,6 @@ import type { TerminalLiveInputSender } from './terminal-live-input-sender'
 import type { TerminalLiveNativeSelection } from './terminal-live-selection-cursor'
 import {
   classifyTerminalLiveSelectionEvent,
-  isTerminalLiveFieldOwnedArrowKey,
   shouldApplyTerminalLiveCursorOnlySelectionMove
 } from './terminal-live-selection-event-routing'
 import { useTerminalLivePendingInputFlush } from './use-terminal-live-pending-input-flush'
@@ -220,11 +219,6 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
       const heldText = ownsPendingState ? heldLiveInputTextRef.current : ''
       const sentText = ownsPendingState ? sentLiveInputTextRef.current : ''
       const decision = getTerminalLiveSpecialKeyDecision({ key, heldText, sentText })
-      // Why: physical arrows can emit keypress + selection; with field text the
-      // selection handler owns the single PTY step — never send here too.
-      if (isTerminalLiveFieldOwnedArrowKey(key) && (heldText.length > 0 || sentText.length > 0)) {
-        return
-      }
       switch (decision.kind) {
         case 'ignore':
         case 'local-edit':

--- a/mobile/src/terminal/use-terminal-live-input-commit.ts
+++ b/mobile/src/terminal/use-terminal-live-input-commit.ts
@@ -1,10 +1,14 @@
-import { useCallback, useEffect, type RefObject } from 'react'
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
 import type { TextInput } from 'react-native'
 import { getTerminalLiveSpecialKeyDecision } from './terminal-live-text-commit'
-import { sendTerminalLiveControlAfterPendingFlush } from './terminal-live-control-send-order'
 import type { TerminalLiveAccessoryInput } from './terminal-live-accessory-input'
 import type { TerminalLiveInputSender } from './terminal-live-input-sender'
-import { normalizeTerminalTextInput } from './terminal-text-input-normalization'
+import type { TerminalLiveNativeSelection } from './terminal-live-selection-cursor'
+import {
+  classifyTerminalLiveSelectionEvent,
+  isTerminalLiveFieldOwnedArrowKey,
+  shouldApplyTerminalLiveCursorOnlySelectionMove
+} from './terminal-live-selection-event-routing'
 import { useTerminalLivePendingInputFlush } from './use-terminal-live-pending-input-flush'
 import {
   useTerminalLiveAccessoryInputCommit,
@@ -14,6 +18,12 @@ import {
 type TerminalLiveInputKeyPressEvent = {
   readonly nativeEvent: {
     readonly key: string
+  }
+}
+
+type TerminalLiveInputSelectionChangeEvent = {
+  readonly nativeEvent: {
+    readonly selection: TerminalLiveNativeSelection
   }
 }
 
@@ -38,6 +48,7 @@ type TerminalLiveInputCommitHandlers = {
   ) => Promise<TerminalLiveAccessoryInputCommitResult>
   readonly handleLiveInputChange: (text: string) => void
   readonly handleLiveInputKeyPress: (event: TerminalLiveInputKeyPressEvent) => void
+  readonly handleLiveInputSelectionChange: (event: TerminalLiveInputSelectionChangeEvent) => void
   readonly handleLiveInputSubmit: () => void
 }
 
@@ -55,10 +66,12 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
 }: TerminalLiveInputCommitOptions<TTabType>): TerminalLiveInputCommitHandlers {
   const {
     applyLiveInputMirror,
+    applyLiveInputSelection,
     clearPendingLiveInputCommit,
     flushPendingLiveInputText,
     heldLiveInputTextRef,
     pendingLiveInputHandleRef,
+    queueLiveInputControl,
     sentLiveInputTextRef,
     waitForPendingLiveInputFlush
   } = useTerminalLivePendingInputFlush({
@@ -69,6 +82,30 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
     sendLiveTerminalInputRef,
     setLiveInputCapture
   })
+
+  const rawFieldTextRef = useRef('')
+  // Keep the one-shot marker across task boundaries because native text and
+  // selection callbacks need not share a JS microtask.
+  const expectsPairedSelectionAfterTextChangeRef = useRef(false)
+
+  const resetSelectionSessionLatch = useCallback(() => {
+    rawFieldTextRef.current = ''
+    expectsPairedSelectionAfterTextChangeRef.current = false
+  }, [])
+
+  const clearPendingLiveInputCommitAndSelection = useCallback(() => {
+    resetSelectionSessionLatch()
+    clearPendingLiveInputCommit()
+  }, [clearPendingLiveInputCommit, resetSelectionSessionLatch])
+
+  const flushPendingLiveInputTextAndSelection = useCallback(
+    async (expectedHandle: string | null): Promise<boolean> => {
+      // External sends end the native field session even when its text is empty.
+      resetSelectionSessionLatch()
+      return flushPendingLiveInputText(expectedHandle)
+    },
+    [flushPendingLiveInputText, resetSelectionSessionLatch]
+  )
 
   useEffect(() => {
     // Why: what reached the PTY is unknowable across an outage — stale mirror state corrupts the first post-reconnect send.
@@ -91,46 +128,83 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
       (activeSessionTabType != null && activeSessionTabType !== 'terminal') ||
       !liveInputTerminalHandles.has(activeHandle)
     ) {
-      clearPendingLiveInputCommit()
+      clearPendingLiveInputCommitAndSelection()
     }
-  }, [activeHandle, activeSessionTabType, clearPendingLiveInputCommit, liveInputTerminalHandles])
+  }, [
+    activeHandle,
+    activeSessionTabType,
+    clearPendingLiveInputCommitAndSelection,
+    liveInputTerminalHandles
+  ])
 
   const flushPendingLiveInputBeforeExternalSend = useCallback(
     async (handle: string): Promise<boolean> => {
       const pendingHandle = pendingLiveInputHandleRef.current
       if (pendingHandle && pendingHandle !== handle) {
-        clearPendingLiveInputCommit()
+        clearPendingLiveInputCommitAndSelection()
         return waitForPendingLiveInputFlush()
       }
       // Why: external bytes (dictation/paste) land after the field's echo on the
       // PTY; the field session must fully end or later diffs would erase them.
       if (pendingHandle === handle) {
-        return flushPendingLiveInputText(handle)
+        return flushPendingLiveInputTextAndSelection(handle)
       }
       return waitForPendingLiveInputFlush()
     },
-    [clearPendingLiveInputCommit, flushPendingLiveInputText, waitForPendingLiveInputFlush]
+    [
+      clearPendingLiveInputCommitAndSelection,
+      flushPendingLiveInputTextAndSelection,
+      waitForPendingLiveInputFlush
+    ]
   )
 
   const handleLiveInputChange = useCallback(
     (text: string) => {
       if (!activeHandle || !liveInputTerminalHandles.has(activeHandle)) {
-        clearPendingLiveInputCommit()
+        clearPendingLiveInputCommitAndSelection()
         return
       }
       // Why: iOS kills an active dictation/IME session when JS writes a value
       // that differs from the native field text, so the controlled capture must
       // echo the field verbatim; only the PTY mirror sees normalized text.
       setLiveInputCapture(text)
-      applyLiveInputMirror(activeHandle, normalizeTerminalTextInput(text))
+      rawFieldTextRef.current = text
+      // One-shot pair marker for the selection that follows this text change.
+      expectsPairedSelectionAfterTextChangeRef.current = true
+      applyLiveInputMirror(activeHandle, text, null)
     },
     [
       activeHandle,
       applyLiveInputMirror,
-      clearPendingLiveInputCommit,
+      clearPendingLiveInputCommitAndSelection,
       liveInputTerminalHandles,
       setLiveInputCapture
     ]
+  )
+
+  const handleLiveInputSelectionChange = useCallback(
+    (event: TerminalLiveInputSelectionChangeEvent) => {
+      if (!activeHandle || !liveInputTerminalHandles.has(activeHandle)) {
+        return
+      }
+      const expectsPaired = expectsPairedSelectionAfterTextChangeRef.current
+      expectsPairedSelectionAfterTextChangeRef.current = false
+      const kind = classifyTerminalLiveSelectionEvent(expectsPaired)
+      const ownsPendingState = pendingLiveInputHandleRef.current === activeHandle
+      const heldText = ownsPendingState ? heldLiveInputTextRef.current : ''
+      // Soft reseat after text change only when nothing is held — never flush Hangul.
+      if (
+        !shouldApplyTerminalLiveCursorOnlySelectionMove({
+          kind,
+          heldText,
+          allowSoftReseatWhenPaired: true
+        })
+      ) {
+        return
+      }
+      applyLiveInputSelection(activeHandle, rawFieldTextRef.current, event.nativeEvent.selection)
+    },
+    [activeHandle, applyLiveInputSelection, liveInputTerminalHandles]
   )
 
   const handleLiveInputKeyPress = useCallback(
@@ -140,53 +214,58 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
       }
       const ownsPendingState = pendingLiveInputHandleRef.current === activeHandle
       if (pendingLiveInputHandleRef.current && !ownsPendingState) {
-        clearPendingLiveInputCommit()
+        clearPendingLiveInputCommitAndSelection()
       }
-      const decision = getTerminalLiveSpecialKeyDecision({
-        key: event.nativeEvent.key,
-        heldText: ownsPendingState ? heldLiveInputTextRef.current : '',
-        sentText: ownsPendingState ? sentLiveInputTextRef.current : ''
-      })
+      const key = event.nativeEvent.key
+      const heldText = ownsPendingState ? heldLiveInputTextRef.current : ''
+      const sentText = ownsPendingState ? sentLiveInputTextRef.current : ''
+      const decision = getTerminalLiveSpecialKeyDecision({ key, heldText, sentText })
+      // Why: physical arrows can emit keypress + selection; with field text the
+      // selection handler owns the single PTY step — never send here too.
+      if (isTerminalLiveFieldOwnedArrowKey(key) && (heldText.length > 0 || sentText.length > 0)) {
+        return
+      }
       switch (decision.kind) {
         case 'ignore':
         case 'local-edit':
           return
         case 'send-now':
-          void sendTerminalLiveControlAfterPendingFlush(waitForPendingLiveInputFlush, () =>
-            sendLiveTerminalInputRef.current(activeHandle, decision.bytes)
-          )
+        case 'commit-held-then-send': {
+          const bytes = decision.bytes
+          if (heldText.length > 0 || sentText.length > 0) {
+            const sendPromise = queueLiveInputControl(activeHandle, bytes, {
+              commitFieldBeforeControl: heldText.length > 0
+            })
+            clearPendingLiveInputCommitAndSelection()
+            void sendPromise
+            return
+          }
+          // Empty field: queue without ending a session.
+          void queueLiveInputControl(activeHandle, bytes, { commitFieldBeforeControl: false })
           return
-        case 'commit-held-then-send':
-          void sendTerminalLiveControlAfterPendingFlush(
-            () => flushPendingLiveInputText(activeHandle),
-            () => sendLiveTerminalInputRef.current(activeHandle, decision.bytes)
-          )
-          return
+        }
         default:
           decision satisfies never
       }
     },
     [
       activeHandle,
-      clearPendingLiveInputCommit,
-      flushPendingLiveInputText,
+      clearPendingLiveInputCommitAndSelection,
       liveInputTerminalHandles,
-      sendLiveTerminalInputRef,
-      waitForPendingLiveInputFlush
+      queueLiveInputControl
     ]
   )
 
   const handleLiveInputAccessoryBytes = useTerminalLiveAccessoryInputCommit({
     activeHandle,
     applyLiveInputMirror,
-    clearPendingLiveInputCommit,
-    flushPendingLiveInputText,
+    clearPendingLiveInputCommit: clearPendingLiveInputCommitAndSelection,
     heldLiveInputTextRef,
     liveInputRef,
     liveInputTerminalHandles,
     pendingLiveInputHandleRef,
+    queueLiveInputControl,
     sentLiveInputTextRef,
-    sendLiveTerminalInputRef,
     setLiveInputCapture,
     waitForPendingLiveInputFlush
   })
@@ -195,18 +274,31 @@ export function useTerminalLiveInputCommit<TTabType extends string>({
     if (!activeHandle || !liveInputTerminalHandles.has(activeHandle)) {
       return
     }
-    void sendTerminalLiveControlAfterPendingFlush(
-      () => flushPendingLiveInputText(activeHandle),
-      () => sendLiveTerminalInputRef.current(activeHandle, '\r')
-    )
-  }, [activeHandle, flushPendingLiveInputText, liveInputTerminalHandles, sendLiveTerminalInputRef])
+    const ownsPendingState = pendingLiveInputHandleRef.current === activeHandle
+    const heldText = ownsPendingState ? heldLiveInputTextRef.current : ''
+    const sentText = ownsPendingState ? sentLiveInputTextRef.current : ''
+    const hasFieldSession = heldText.length > 0 || sentText.length > 0
+    const sendPromise = queueLiveInputControl(activeHandle, '\r', {
+      commitFieldBeforeControl: hasFieldSession
+    })
+    if (hasFieldSession) {
+      clearPendingLiveInputCommitAndSelection()
+    }
+    void sendPromise
+  }, [
+    activeHandle,
+    clearPendingLiveInputCommitAndSelection,
+    liveInputTerminalHandles,
+    queueLiveInputControl
+  ])
 
   return {
-    clearPendingLiveInputCommit,
+    clearPendingLiveInputCommit: clearPendingLiveInputCommitAndSelection,
     flushPendingLiveInputBeforeExternalSend,
     handleLiveInputAccessoryBytes,
     handleLiveInputChange,
     handleLiveInputKeyPress,
+    handleLiveInputSelectionChange,
     handleLiveInputSubmit
   }
 }

--- a/mobile/src/terminal/use-terminal-live-pending-input-flush.ts
+++ b/mobile/src/terminal/use-terminal-live-pending-input-flush.ts
@@ -234,9 +234,7 @@ export function useTerminalLivePendingInputFlush<TTabType extends string>({
       }
       const ownsFieldState =
         pendingLiveInputHandleRef.current === handle &&
-        (sentLiveInputTextRef.current.length > 0 ||
-          heldLiveInputTextRef.current.length > 0 ||
-          ptyCursorCodePointRef.current > 0)
+        (sentLiveInputTextRef.current.length > 0 || heldLiveInputTextRef.current.length > 0)
       const payload = buildTerminalLiveQueuedControlPayload({
         state: readCursorState(),
         ownsFieldState,

--- a/mobile/src/terminal/use-terminal-live-pending-input-flush.ts
+++ b/mobile/src/terminal/use-terminal-live-pending-input-flush.ts
@@ -1,15 +1,23 @@
 import { useCallback, useEffect, useRef, type RefObject } from 'react'
 import type { TextInput } from 'react-native'
 import type { TerminalLiveInputSender } from './terminal-live-input-sender'
-import {
-  buildTerminalLiveMirrorPayload,
-  computeTerminalLiveMirrorStep,
-  TERMINAL_LIVE_HELD_SYLLABLE_COMMIT_DELAY_MS
-} from './terminal-live-hangul-mirror'
+import { TERMINAL_LIVE_HELD_SYLLABLE_COMMIT_DELAY_MS } from './terminal-live-hangul-mirror'
 import {
   queueTerminalLiveMirrorSend,
   waitForTerminalLivePendingFlush
 } from './terminal-live-pending-flush-state'
+import {
+  planTerminalLiveFieldTextChange,
+  planTerminalLiveSelectionMove,
+  type TerminalLiveNativeSelection,
+  type TerminalLiveSelectionCursorState
+} from './terminal-live-selection-cursor'
+import {
+  buildTerminalLiveFieldCommitPrefix,
+  buildTerminalLiveQueuedControlPayload,
+  type TerminalLiveQueueControlOptions
+} from './terminal-live-control-payload'
+import { normalizeTerminalTextInput } from './terminal-text-input-normalization'
 
 type TerminalLivePendingInputFlushOptions<TTabType extends string> = {
   readonly activeHandleRef: RefObject<string | null>
@@ -20,16 +28,6 @@ type TerminalLivePendingInputFlushOptions<TTabType extends string> = {
   readonly setLiveInputCapture: (text: string) => void
 }
 
-type TerminalLivePendingInputFlush = {
-  readonly applyLiveInputMirror: (handle: string, fieldText: string) => void
-  readonly clearPendingLiveInputCommit: () => void
-  readonly flushPendingLiveInputText: (expectedHandle: string | null) => Promise<boolean>
-  readonly heldLiveInputTextRef: RefObject<string>
-  readonly pendingLiveInputHandleRef: RefObject<string | null>
-  readonly sentLiveInputTextRef: RefObject<string>
-  readonly waitForPendingLiveInputFlush: () => Promise<boolean>
-}
-
 export function useTerminalLivePendingInputFlush<TTabType extends string>({
   activeHandleRef,
   activeSessionTabTypeRef,
@@ -37,14 +35,16 @@ export function useTerminalLivePendingInputFlush<TTabType extends string>({
   liveInputTerminalHandlesRef,
   sendLiveTerminalInputRef,
   setLiveInputCapture
-}: TerminalLivePendingInputFlushOptions<TTabType>): TerminalLivePendingInputFlush {
+}: TerminalLivePendingInputFlushOptions<TTabType>) {
   const heldCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingLiveInputFlushRef = useRef<Promise<boolean> | null>(null)
   const heldLiveInputTextRef = useRef('')
   const sentLiveInputTextRef = useRef('')
   const pendingLiveInputHandleRef = useRef<string | null>(null)
+  const ptyCursorCodePointRef = useRef(0)
+  const mirroredFieldTextRef = useRef('')
   const runMirrorStepRef = useRef<
-    (handle: string, fieldText: string, commitHeld: boolean) => Promise<boolean>
+    (handle: string, rawFieldText: string, commitHeld: boolean) => Promise<boolean>
   >(async () => false)
 
   const clearHeldCommitTimer = useCallback(() => {
@@ -59,6 +59,8 @@ export function useTerminalLivePendingInputFlush<TTabType extends string>({
     heldLiveInputTextRef.current = ''
     sentLiveInputTextRef.current = ''
     pendingLiveInputHandleRef.current = null
+    ptyCursorCodePointRef.current = 0
+    mirroredFieldTextRef.current = ''
   }, [clearHeldCommitTimer])
 
   const clearPendingLiveInputCommit = useCallback(() => {
@@ -71,39 +73,46 @@ export function useTerminalLivePendingInputFlush<TTabType extends string>({
     return waitForTerminalLivePendingFlush(pendingLiveInputFlushRef)
   }, [])
 
-  const runMirrorStep = useCallback(
-    async (handle: string, fieldText: string, commitHeld: boolean): Promise<boolean> => {
-      if (
-        handle !== activeHandleRef.current ||
-        (activeSessionTabTypeRef.current != null &&
-          activeSessionTabTypeRef.current !== 'terminal') ||
-        !liveInputTerminalHandlesRef.current.has(handle)
-      ) {
-        // Why: a stale handle must not keep local mirror state alive — the next
-        // active terminal would inherit wrong erase counts. A null tab type is
-        // "unknown" during tab-list lag, not "left the terminal", so it must not trip.
-        resetMirrorState()
-        return false
-      }
+  const isHandleLive = useCallback(
+    (handle: string): boolean =>
+      handle === activeHandleRef.current &&
+      (activeSessionTabTypeRef.current == null || activeSessionTabTypeRef.current === 'terminal') &&
+      liveInputTerminalHandlesRef.current.has(handle),
+    [activeHandleRef, activeSessionTabTypeRef, liveInputTerminalHandlesRef]
+  )
 
-      const step = computeTerminalLiveMirrorStep(sentLiveInputTextRef.current, fieldText, {
-        commitHeld
-      })
-      sentLiveInputTextRef.current = step.nextSentText
-      heldLiveInputTextRef.current = step.heldText
+  const readCursorState = useCallback(
+    (): TerminalLiveSelectionCursorState => ({
+      sentText: sentLiveInputTextRef.current,
+      heldText: heldLiveInputTextRef.current,
+      ptyCursorCodePoint: ptyCursorCodePointRef.current,
+      fieldText: mirroredFieldTextRef.current
+    }),
+    []
+  )
+
+  const applyPlanState = useCallback(
+    (
+      handle: string,
+      plan: {
+        readonly nextSentText: string
+        readonly heldText: string
+        readonly nextPtyCursorCodePoint: number
+        readonly nextFieldText: string
+      }
+    ): void => {
+      sentLiveInputTextRef.current = plan.nextSentText
+      heldLiveInputTextRef.current = plan.heldText
+      ptyCursorCodePointRef.current = plan.nextPtyCursorCodePoint
+      mirroredFieldTextRef.current = plan.nextFieldText
       pendingLiveInputHandleRef.current =
-        step.heldText.length > 0 || step.nextSentText.length > 0 ? handle : null
+        plan.heldText.length > 0 || plan.nextSentText.length > 0 ? handle : null
+    },
+    []
+  )
 
-      clearHeldCommitTimer()
-      if (step.heldText.length > 0) {
-        heldCommitTimerRef.current = setTimeout(() => {
-          heldCommitTimerRef.current = null
-          const heldField = sentLiveInputTextRef.current + heldLiveInputTextRef.current
-          void runMirrorStepRef.current(handle, heldField, true)
-        }, TERMINAL_LIVE_HELD_SYLLABLE_COMMIT_DELAY_MS)
-      }
-
-      const payload = buildTerminalLiveMirrorPayload(step)
+  const queuePayload = useCallback(
+    (handle: string, payload: string): Promise<boolean> => {
       if (payload.length === 0) {
         return waitForPendingLiveInputFlush()
       }
@@ -111,23 +120,132 @@ export function useTerminalLivePendingInputFlush<TTabType extends string>({
         sendLiveTerminalInputRef.current(handle, payload)
       )
     },
+    [sendLiveTerminalInputRef, waitForPendingLiveInputFlush]
+  )
+
+  const scheduleHeldCommit = useCallback(
+    (handle: string): void => {
+      clearHeldCommitTimer()
+      if (heldLiveInputTextRef.current.length === 0) {
+        return
+      }
+      heldCommitTimerRef.current = setTimeout(() => {
+        heldCommitTimerRef.current = null
+        const heldField = sentLiveInputTextRef.current + heldLiveInputTextRef.current
+        void runMirrorStepRef.current(handle, heldField, true)
+      }, TERMINAL_LIVE_HELD_SYLLABLE_COMMIT_DELAY_MS)
+    },
+    [clearHeldCommitTimer]
+  )
+
+  const runMirrorStep = useCallback(
+    async (handle: string, rawFieldText: string, commitHeld: boolean): Promise<boolean> => {
+      if (!isHandleLive(handle)) {
+        // Why: stale handle must not keep erase counts; null tab type is unknown lag.
+        resetMirrorState()
+        return false
+      }
+      const plan = planTerminalLiveFieldTextChange(readCursorState(), rawFieldText, null, {
+        normalize: normalizeTerminalTextInput,
+        commitHeld
+      })
+      applyPlanState(handle, plan)
+      scheduleHeldCommit(handle)
+      return queuePayload(handle, plan.payload)
+    },
     [
-      activeHandleRef,
-      activeSessionTabTypeRef,
-      clearHeldCommitTimer,
-      liveInputTerminalHandlesRef,
+      applyPlanState,
+      isHandleLive,
+      queuePayload,
+      readCursorState,
       resetMirrorState,
-      sendLiveTerminalInputRef,
-      waitForPendingLiveInputFlush
+      scheduleHeldCommit
     ]
   )
   runMirrorStepRef.current = runMirrorStep
 
   const applyLiveInputMirror = useCallback(
-    (handle: string, fieldText: string): void => {
-      void runMirrorStep(handle, fieldText, false)
+    (
+      handle: string,
+      rawFieldText: string,
+      selection?: TerminalLiveNativeSelection | null
+    ): void => {
+      if (!isHandleLive(handle)) {
+        resetMirrorState()
+        return
+      }
+      const plan = planTerminalLiveFieldTextChange(
+        readCursorState(),
+        rawFieldText,
+        selection ?? null,
+        {
+          normalize: normalizeTerminalTextInput,
+          commitHeld: false
+        }
+      )
+      applyPlanState(handle, plan)
+      scheduleHeldCommit(handle)
+      void queuePayload(handle, plan.payload)
     },
-    [runMirrorStep]
+    [
+      applyPlanState,
+      isHandleLive,
+      queuePayload,
+      readCursorState,
+      resetMirrorState,
+      scheduleHeldCommit
+    ]
+  )
+
+  const applyLiveInputSelection = useCallback(
+    (handle: string, rawFieldText: string, selection: TerminalLiveNativeSelection): void => {
+      if (!isHandleLive(handle)) {
+        resetMirrorState()
+        return
+      }
+      const plan = planTerminalLiveSelectionMove(readCursorState(), selection, {
+        normalize: normalizeTerminalTextInput,
+        rawFieldText
+      })
+      if (!plan) {
+        return
+      }
+      applyPlanState(handle, plan)
+      scheduleHeldCommit(handle)
+      void queuePayload(handle, plan.payload)
+    },
+    [
+      applyPlanState,
+      isHandleLive,
+      queuePayload,
+      readCursorState,
+      resetMirrorState,
+      scheduleHeldCommit
+    ]
+  )
+
+  // Why: control bytes share the mirror send chain; commit-before-control snapshots
+  // restore/held into the same payload without applying plan state (caller clears).
+  const queueLiveInputControl = useCallback(
+    (handle: string, bytes: string, options: TerminalLiveQueueControlOptions): Promise<boolean> => {
+      if (!isHandleLive(handle)) {
+        resetMirrorState()
+        return Promise.resolve(false)
+      }
+      const ownsFieldState =
+        pendingLiveInputHandleRef.current === handle &&
+        (sentLiveInputTextRef.current.length > 0 ||
+          heldLiveInputTextRef.current.length > 0 ||
+          ptyCursorCodePointRef.current > 0)
+      const payload = buildTerminalLiveQueuedControlPayload({
+        state: readCursorState(),
+        ownsFieldState,
+        commitFieldBeforeControl: options.commitFieldBeforeControl,
+        controlBytes: bytes
+      })
+      return queuePayload(handle, payload)
+    },
+    [isHandleLive, queuePayload, readCursorState, resetMirrorState]
   )
 
   const flushPendingLiveInputText = useCallback(
@@ -140,40 +258,35 @@ export function useTerminalLivePendingInputFlush<TTabType extends string>({
         clearPendingLiveInputCommit()
         return waitForPendingLiveInputFlush()
       }
-
       const heldText = heldLiveInputTextRef.current
-      const result =
-        heldText.length > 0
-          ? await runMirrorStep(handle, sentLiveInputTextRef.current + heldText, true)
-          : await waitForPendingLiveInputFlush()
-
-      // Why: an explicit flush ends the field's editing session; the echoed PTY
-      // text stays, so local mirror state must restart from empty.
+      const sentText = sentLiveInputTextRef.current
+      const needsEndRestore =
+        heldText.length > 0 || ptyCursorCodePointRef.current < Array.from(sentText).length
+      // Snapshot then clear old session sync before await so new IME is not wiped.
+      const sendPromise = needsEndRestore
+        ? queuePayload(handle, buildTerminalLiveFieldCommitPrefix(readCursorState()))
+        : waitForPendingLiveInputFlush()
       clearPendingLiveInputCommit()
-      return result
+      return sendPromise
     },
-    [clearPendingLiveInputCommit, runMirrorStep, waitForPendingLiveInputFlush]
+    [clearPendingLiveInputCommit, queuePayload, readCursorState, waitForPendingLiveInputFlush]
   )
 
   useEffect(() => {
     return () => {
-      if (heldCommitTimerRef.current) {
-        clearTimeout(heldCommitTimerRef.current)
-        heldCommitTimerRef.current = null
-      }
-      heldLiveInputTextRef.current = ''
-      sentLiveInputTextRef.current = ''
-      pendingLiveInputHandleRef.current = null
+      resetMirrorState()
       pendingLiveInputFlushRef.current = null
     }
-  }, [])
+  }, [resetMirrorState])
 
   return {
     applyLiveInputMirror,
+    applyLiveInputSelection,
     clearPendingLiveInputCommit,
     flushPendingLiveInputText,
     heldLiveInputTextRef,
     pendingLiveInputHandleRef,
+    queueLiveInputControl,
     sentLiveInputTextRef,
     waitForPendingLiveInputFlush
   }


### PR DESCRIPTION
## Summary

- Sync native TextInput selection changes to the live terminal cursor, enabling iOS keyboard-trackpad cursor movement.
- Keep middle insertions and deletions consistent by restoring, rewriting, and reseating the PTY cursor in one queued payload.
- Preserve Hangul composition and serialize mirror, control, submit, and external-flush sends to avoid state-loss races.
- Avoid duplicate ArrowLeft/ArrowRight bytes when hardware keypress and native selection events both fire.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — not run through pnpm because the local minimum-release-age policy rejects two newly published lockfile entries; the installed mobile oxlint binary passed instead.
- [ ] `pnpm typecheck` — not run through pnpm for the same policy reason; `mobile/node_modules/.bin/tsc --noEmit` passed.
- [ ] `pnpm test` — not run through pnpm for the same policy reason; `mobile/node_modules/.bin/vitest run` passed 317 files, 2,337 tests, with 2 skipped.
- [ ] `pnpm build` — not run; this checkout has no generated native iOS project and no physical iOS device was online.
- [x] Added or updated high-quality tests that would catch regressions, including UTF-16 selection mapping, middle edits, Hangul composition, duplicate arrow suppression, stale handles, and deferred-send ordering.

Additional checks:

- `mobile/node_modules/.bin/oxlint`
- `mobile/node_modules/.bin/oxfmt --check .` (949 files)
- `node config/scripts/check-max-lines-ratchet.mjs`
- `git diff HEAD^..HEAD --check`

## AI Review Report

Claude reviewed the exact change read-only in three gates: pure selection/control logic, React hook and queue integration, then the combined 13-file commit. All three gates ended with `NO ACTIONABLE FINDINGS`. The review traced UTF-16/code-point boundaries, collapsed versus ranged selection, middle rewrite ordering, Hangul held-syllable behavior, hardware/accessory controls, stale handles, deferred sends, React Native event ordering, and Android shared-path behavior. An earlier queue/state-clear race was identified during implementation and fixed before these final gates by serializing controls on the mirror chain and clearing the prior field session synchronously.

Cross-platform review confirmed this mobile-only change does not touch desktop shortcuts, labels, filesystem paths, shell spawning, or Electron behavior. The shared React Native path and Android selection-event ordering were reviewed; no actionable Android regression was found.

## Security Audit

No dependencies, auth, secrets, filesystem paths, shell commands, native modules, or IPC schemas are added. Terminal output remains limited to normalized field text and existing mapped control bytes. Active-handle and terminal-tab guards reject stale selection/control sends, and all sends use the existing serialized terminal input channel. No security follow-up was identified.

## Notes

- Physical-device behavior remains the main residual validation gap because no iOS device was online; deterministic hook and payload tests cover the event sequences.
- This complements #10101: that PR improves the visible mobile terminal accessory bar, while this PR adds native TextInput selection-to-PTY cursor synchronization.


## ELI5

On iOS, moving the cursor with the keyboard trackpad (or by selecting text) now moves the real terminal cursor too. Insertions and deletions stay in the right place, and Hangul composition is not broken. Hardware arrow keys and trackpad moves no longer send the same key twice.
