### PR TITLE
perf(mobile): trust healthy session tab streams

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -213,6 +213,12 @@ import { useMobileNativeChatTerminalStream } from '../../../../src/session/use-m
 import { subscribeMobileTerminalSafely } from '../../../../src/session/mobile-terminal-stream-subscribe'
 import { activateMobileSessionTab } from '../../../../src/session/mobile-session-tab-activation'
 import { MobileTerminalDiagnostics } from '../../../../src/session/mobile-terminal-diagnostics'
+import { runAcceptedMobileSessionTabsEffects } from '../../../../src/session/mobile-session-tabs-accepted-effects'
+import type {
+  SessionTabsApplyOutcome,
+  SessionTabsStreamSource
+} from '../../../../src/session/mobile-session-tabs-stream-health'
+import { useMobileSessionTabsReconciliation } from '../../../../src/session/use-mobile-session-tabs-reconciliation'
 import {
   getRepoIdFromMobileWorktreeId,
   getActiveTabIdForHandle,
@@ -866,6 +872,7 @@ export default function SessionScreen() {
   const sessionTabsRef = useRef<MobileSessionTab[]>([])
   // Why: track the last applied (epoch, version) so a late older snapshot can't overwrite a newer one and resurrect closed tabs (session-tab-snapshot-gate).
   const appliedSnapshotMarkerRef = useRef<AppliedSnapshotMarker>({ epoch: null, version: -1 })
+  const appliedSessionTabsRevisionRef = useRef(0)
   // Why: after an optimistic close, suppress the tab (with expiry) until the publisher confirms, so an in-flight snapshot can't flash it back.
   const closedTabTombstonesRef = useRef<Map<string, number>>(new Map())
   const [terminalsLoaded, setTerminalsLoaded] = useState(false)
@@ -1689,12 +1696,13 @@ export default function SessionScreen() {
   )
 
   const applySessionTabs = useCallback(
-    (result: SessionTabsResult) => {
+    (result: SessionTabsResult): SessionTabsApplyOutcome<MobileSessionTab> => {
       const diagnostics = terminalDiagnosticsRef.current
       // Reject stale snapshots; suppress just-closed tabs until the publisher confirms absence — see session-tab-snapshot-gate.
       if (!acceptSessionSnapshot(result, appliedSnapshotMarkerRef.current)) {
-        return
+        return { accepted: false }
       }
+      const applicationRevision = ++appliedSessionTabsRevisionRef.current
       let nextTabs = applyClosedTabTombstones(
         result.tabs,
         closedTabTombstonesRef.current,
@@ -1739,6 +1747,11 @@ export default function SessionScreen() {
         terminalTabs.length
       )
       setTerminalsLoaded(true)
+      const outcome = {
+        accepted: true as const,
+        effectiveTabs: nextTabs,
+        applicationRevision
+      }
 
       const snapshotActive = nextTabs.find((tab) => tab.isActive) ?? nextTabs[0] ?? null
       const pendingActiveSessionTabId = pendingActiveSessionTabIdRef.current
@@ -1791,7 +1804,7 @@ export default function SessionScreen() {
           activeSessionTabTypeRef.current = 'terminal'
           setActiveHandle(pendingActiveTerminalHandle)
           subscribeToTerminal(pendingActiveTerminalHandle)
-          return
+          return outcome
         } else {
           pendingActiveTerminalHandleRef.current = null
         }
@@ -1809,7 +1822,7 @@ export default function SessionScreen() {
           }
           activeHandleRef.current = null
           setActiveHandle(null)
-          return
+          return outcome
         }
         const previous = activeHandleRef.current
         if (previous && previous !== active.terminal) {
@@ -1828,6 +1841,7 @@ export default function SessionScreen() {
         activeHandleRef.current = null
         setActiveHandle(null)
       }
+      return outcome
     },
     [defaultTerminalHandlesToLiveInput, subscribeToTerminal, unsubscribeTerminal]
   )
@@ -2252,48 +2266,70 @@ export default function SessionScreen() {
     [client, markdownDocs, showToast, worktreeId]
   )
 
-  const fetchSessionTabsInFlightRef = useRef(false)
-
-  const fetchSessionTabs = useCallback(async () => {
-    if (!client) {
-      terminalDiagnosticsRef.current.tabsFetchSkipped('no-client')
-      return
-    }
-    if (fetchSessionTabsInFlightRef.current) {
-      terminalDiagnosticsRef.current.tabsFetchSkipped('already-in-flight')
-      return
-    }
-    fetchSessionTabsInFlightRef.current = true
-    terminalDiagnosticsRef.current.tabsFetchStarted(worktreeId)
-    try {
-      const response = await client.sendRequest('session.tabs.list', {
-        worktree: `id:${worktreeId}`
-      })
-      if (!response.ok) {
-        terminalDiagnosticsRef.current.tabsFetchFailed((response as RpcFailure).error.code)
-        return
-      }
-      const result = (response as RpcSuccess).result as SessionTabsResult
-      terminalDiagnosticsRef.current.tabsFetchSucceeded(result)
-      applySessionTabs(result)
-      // Focus a just-opened browser tab when it appears, via the normal activate path so it sticks yet stays switchable.
-      const pendingPageId = pendingBrowserFocusPageIdRef.current
-      if (pendingPageId) {
-        const browserTab = result.tabs.find(
-          (tab) => tab.type === 'browser' && tab.browserPageId === pendingPageId
-        )
-        if (browserTab) {
-          pendingBrowserFocusPageIdRef.current = null
-          switchSessionTabRef.current?.(browserTab)
+  const consumeAcceptedSessionTabs = useCallback(
+    (
+      _result: SessionTabsResult,
+      effectiveTabs: readonly MobileSessionTab[],
+      source: SessionTabsStreamSource
+    ): void => {
+      runAcceptedMobileSessionTabsEffects<MobileSessionTab>({
+        effectiveTabs,
+        source,
+        getPendingBrowserPageId: () => pendingBrowserFocusPageIdRef.current,
+        clearPendingBrowserPageId: (pageId) => {
+          if (pendingBrowserFocusPageIdRef.current === pageId) {
+            pendingBrowserFocusPageIdRef.current = null
+          }
+        },
+        activateBrowserTab: (tab) => switchSessionTabRef.current?.(tab),
+        markActiveMarkdownStale: (tabId) => {
+          setMarkdownDocs((prev) => {
+            const current = prev.get(tabId)
+            if (current?.status !== 'ready' || current.isDirty) {
+              return prev
+            }
+            return new Map(prev).set(tabId, { ...current, stale: true })
+          })
         }
-      }
-    } catch (error) {
-      terminalDiagnosticsRef.current.tabsFetchErrored(error)
-      // Keep the last tab snapshot visible during reconnect/backoff.
-    } finally {
-      fetchSessionTabsInFlightRef.current = false
-    }
-  }, [applySessionTabs, client, worktreeId])
+      })
+    },
+    []
+  )
+  const hasSessionTabsRecoveryNeed = useCallback(
+    () => closedTabTombstonesRef.current.size > 0 || pendingBrowserFocusPageIdRef.current !== null,
+    []
+  )
+  const getSessionTabsApplicationRevision = useCallback(
+    () => appliedSessionTabsRevisionRef.current,
+    []
+  )
+  const reportSessionTabsFetchStarted = useCallback(() => {
+    terminalDiagnosticsRef.current.tabsFetchStarted(worktreeId)
+  }, [worktreeId])
+  const reportSessionTabsFetchSucceeded = useCallback((result: SessionTabsResult) => {
+    terminalDiagnosticsRef.current.tabsFetchSucceeded(result)
+  }, [])
+  const reportSessionTabsFetchFailed = useCallback((code: string) => {
+    terminalDiagnosticsRef.current.tabsFetchFailed(code)
+  }, [])
+  const reportSessionTabsFetchErrored = useCallback((error: unknown) => {
+    terminalDiagnosticsRef.current.tabsFetchErrored(error)
+  }, [])
+  const { fetchSessionTabs, ensureSessionTabs, fetchPendingBrowserSessionTabs } =
+    useMobileSessionTabsReconciliation<SessionTabsResult, MobileSessionTab>({
+      client,
+      connState,
+      worktreeId,
+      applySessionTabs,
+      consumeAcceptedSessionTabs,
+      fetchTerminals,
+      hasRecoveryNeed: hasSessionTabsRecoveryNeed,
+      getApplicationRevision: getSessionTabsApplicationRevision,
+      onFetchStarted: reportSessionTabsFetchStarted,
+      onFetchSucceeded: reportSessionTabsFetchSucceeded,
+      onFetchFailed: reportSessionTabsFetchFailed,
+      onFetchErrored: reportSessionTabsFetchErrored
+    })
 
   useEffect(() => {
     if (connState === 'connected') {
@@ -2624,7 +2660,7 @@ export default function SessionScreen() {
       if (disposed) {
         return
       }
-      await fetchSessionTabs().catch(() => null)
+      await ensureSessionTabs().catch(() => null)
       if (disposed) {
         return
       }
@@ -2667,71 +2703,12 @@ export default function SessionScreen() {
     client,
     connState,
     created,
-    fetchSessionTabs,
     fetchTerminals,
+    ensureSessionTabs,
     isFloatingWorkspaceRoute,
     showToast,
     worktreeId
   ])
-
-  useEffect(() => {
-    if (!client || connState !== 'connected') {
-      return
-    }
-    const unsubscribe = client.subscribe(
-      'session.tabs.subscribe',
-      { worktree: `id:${worktreeId}` },
-      (payload) => {
-        const event = payload as { type?: string } & SessionTabsResult
-        if (event.type === 'snapshot' || event.type === 'updated') {
-          applySessionTabs(event)
-          const activeMarkdown = event.tabs.find(
-            (tab): tab is Extract<MobileSessionTab, { type: 'markdown' }> =>
-              tab.type === 'markdown' && tab.isActive
-          )
-          if (activeMarkdown) {
-            setMarkdownDocs((prev) => {
-              const current = prev.get(activeMarkdown.id)
-              if (current?.status === 'ready' && activeMarkdown.isDirty && !current.isDirty) {
-                const next = new Map(prev)
-                next.set(activeMarkdown.id, { ...current, stale: true })
-                return next
-              }
-              return prev
-            })
-          }
-        }
-      }
-    )
-    return () => unsubscribe()
-  }, [applySessionTabs, client, connState, worktreeId])
-
-  useFocusEffect(
-    useCallback(() => {
-      if (connState !== 'connected') {
-        return
-      }
-      const refreshOnForeground = () => {
-        if (AppState.currentState !== 'active') {
-          return
-        }
-        void fetchSessionTabs()
-        void fetchTerminals()
-      }
-      const appStateSubscription = AppState.addEventListener('change', (state) => {
-        if (state === 'active') {
-          refreshOnForeground()
-        }
-      })
-      // Why: live subscription keeps stream ownership, but the fallback list poll should stop while this route is hidden or backgrounded.
-      const interval = setInterval(refreshOnForeground, 2000)
-      refreshOnForeground()
-      return () => {
-        clearInterval(interval)
-        appStateSubscription.remove()
-      }
-    }, [connState, fetchSessionTabs, fetchTerminals])
-  )
 
   // Why: pick up Settings → Terminal text size on return; panes stay mounted and update in place.
   useFocusEffect(
@@ -3978,8 +3955,8 @@ export default function SessionScreen() {
         pendingBrowserFocusPageIdRef.current = created.browserPageId
       }
       void fetchSessionTabs()
-      scheduleDelayedAction(() => void fetchSessionTabs(), 400)
-      scheduleDelayedAction(() => void fetchSessionTabs(), 1200)
+      scheduleDelayedAction(() => void fetchPendingBrowserSessionTabs(), 400)
+      scheduleDelayedAction(() => void fetchPendingBrowserSessionTabs(), 1200)
       return true
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to create browser'
@@ -4095,6 +4072,9 @@ export default function SessionScreen() {
         reason: 'user'
       })
       if (response.ok) {
+        if (tab.type === 'browser' && tab.browserPageId === pendingBrowserFocusPageIdRef.current) {
+          pendingBrowserFocusPageIdRef.current = null
+        }
         if (tab.type === 'terminal' && typeof tab.terminal === 'string') {
           const terminalHandle = tab.terminal
           unsubscribeTerminal(terminalHandle)

--- a/mobile/src/session/mobile-session-startup-source.test.ts
+++ b/mobile/src/session/mobile-session-startup-source.test.ts
@@ -5,6 +5,10 @@ const source = readFileSync(
   new URL('../../app/h/[hostId]/session/[worktreeId].tsx', import.meta.url),
   'utf8'
 )
+const reconciliationHookSource = readFileSync(
+  new URL('./use-mobile-session-tabs-reconciliation.ts', import.meta.url),
+  'utf8'
+)
 
 function sliceBetween(startPattern: string, endPattern: string): string {
   const start = source.indexOf(startPattern)
@@ -29,24 +33,23 @@ describe('mobile session startup', () => {
     expect(autoCreateEffect).toContain('void handleCreateTerminal()')
   })
 
-  it('stops fallback list polling in the background and reconciles on resume', () => {
-    const pollEffect = sliceBetween(
-      "const refreshOnForeground = () => {\n        if (AppState.currentState !== 'active')",
-      '// Why: pick up Settings → Terminal text size on return'
+  it('delegates stream ownership while retaining the exact terminal polling cadence', () => {
+    expect(source).toContain('useMobileSessionTabsReconciliation<')
+    expect(source).toContain('const applicationRevision = ++appliedSessionTabsRevisionRef.current')
+    expect(source).toContain('getApplicationRevision: getSessionTabsApplicationRevision')
+    expect(source).not.toContain("client.subscribe(\n      'session.tabs.subscribe'")
+    expect(reconciliationHookSource).toContain("client.subscribe(\n      'session.tabs.subscribe'")
+    expect(reconciliationHookSource).toContain(
+      "if (AppState.currentState !== 'active') {\n          controller.setReconciliationActive(false)"
     )
-
-    expect(pollEffect).toContain(
-      "if (AppState.currentState !== 'active') {\n          return\n        }\n        void fetchSessionTabs()"
-    )
-    expect(pollEffect).toContain('void fetchTerminals()')
-    expect(pollEffect).toContain("AppState.addEventListener('change'")
-    expect(pollEffect).toContain("if (state === 'active') {\n          refreshOnForeground()")
-    expect(pollEffect).toContain('const interval = setInterval(refreshOnForeground, 2000)')
-    expect(pollEffect.lastIndexOf('\n      refreshOnForeground()')).toBeGreaterThan(
-      pollEffect.indexOf("AppState.addEventListener('change'")
-    )
-    expect(pollEffect).toContain('clearInterval(interval)')
-    expect(pollEffect).toContain('appStateSubscription.remove()')
+    expect(reconciliationHookSource).toContain('void controller.poll()')
+    expect(reconciliationHookSource).toContain('void fetchTerminals()')
+    expect(reconciliationHookSource).toContain("AppState.addEventListener('change'")
+    expect(reconciliationHookSource).toContain('const interval = setInterval(')
+    expect(reconciliationHookSource).toContain('2000')
+    expect(reconciliationHookSource).toContain('controller.setReconciliationActive(false)')
+    expect(reconciliationHookSource).toContain('clearInterval(interval)')
+    expect(reconciliationHookSource).toContain('appStateSubscription.remove()')
   })
 
   it('loads session tabs without waiting for desktop activation', () => {
@@ -62,7 +65,7 @@ describe('mobile session startup', () => {
     expect(startupEffect).toContain("navigation: 'caller'")
     expect(startupEffect).not.toContain("await client\n          .sendRequest('worktree.activate'")
     expect(startupEffect.indexOf("sendRequest('worktree.activate'")).toBeLessThan(
-      startupEffect.indexOf('await fetchSessionTabs()')
+      startupEffect.indexOf('await ensureSessionTabs()')
     )
     expect(startupEffect).toContain('headlessActivationNeedsHostRenderer(response.result)')
     expect(startupEffect).toContain("showToast('Open Orca on the host to wake sleeping agents.'")

--- a/mobile/src/session/mobile-session-tabs-accepted-effects.test.ts
+++ b/mobile/src/session/mobile-session-tabs-accepted-effects.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runAcceptedMobileSessionTabsEffects } from './mobile-session-tabs-accepted-effects'
+
+type Tab = {
+  id: string
+  type: 'browser' | 'markdown'
+  isActive: boolean
+  browserPageId?: string
+  isDirty?: boolean
+}
+
+describe('runAcceptedMobileSessionTabsEffects', () => {
+  it.each(['list', 'stream'] as const)(
+    'resolves pending browser focus exactly once from an accepted %s result',
+    (source) => {
+      let pendingPageId: string | null = 'page-1'
+      const activateBrowserTab = vi.fn()
+      const options = {
+        effectiveTabs: [
+          {
+            id: 'browser-1',
+            type: 'browser' as const,
+            isActive: true,
+            browserPageId: 'page-1'
+          }
+        ],
+        source,
+        getPendingBrowserPageId: () => pendingPageId,
+        clearPendingBrowserPageId: (pageId: string) => {
+          if (pendingPageId === pageId) {
+            pendingPageId = null
+          }
+        },
+        activateBrowserTab,
+        markActiveMarkdownStale: vi.fn()
+      }
+
+      runAcceptedMobileSessionTabsEffects(options)
+      runAcceptedMobileSessionTabsEffects(options)
+
+      expect(pendingPageId).toBeNull()
+      expect(activateBrowserTab).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('does not resolve a pending browser omitted by tombstone filtering', () => {
+    const activateBrowserTab = vi.fn()
+    runAcceptedMobileSessionTabsEffects<Tab>({
+      effectiveTabs: [],
+      source: 'stream',
+      getPendingBrowserPageId: () => 'page-1',
+      clearPendingBrowserPageId: vi.fn(),
+      activateBrowserTab,
+      markActiveMarkdownStale: vi.fn()
+    })
+
+    expect(activateBrowserTab).not.toHaveBeenCalled()
+  })
+
+  it('marks only an effective active dirty markdown stream tab stale', () => {
+    const markActiveMarkdownStale = vi.fn()
+    const base = {
+      getPendingBrowserPageId: () => null,
+      clearPendingBrowserPageId: vi.fn(),
+      activateBrowserTab: vi.fn(),
+      markActiveMarkdownStale
+    }
+    const markdown: Tab = {
+      id: 'markdown-1',
+      type: 'markdown',
+      isActive: true,
+      isDirty: true
+    }
+
+    runAcceptedMobileSessionTabsEffects({
+      ...base,
+      effectiveTabs: [markdown],
+      source: 'list'
+    })
+    runAcceptedMobileSessionTabsEffects({
+      ...base,
+      effectiveTabs: [],
+      source: 'stream'
+    })
+    expect(markActiveMarkdownStale).not.toHaveBeenCalled()
+
+    runAcceptedMobileSessionTabsEffects({
+      ...base,
+      effectiveTabs: [markdown],
+      source: 'stream'
+    })
+    expect(markActiveMarkdownStale).toHaveBeenCalledExactlyOnceWith('markdown-1')
+  })
+})

--- a/mobile/src/session/mobile-session-tabs-accepted-effects.ts
+++ b/mobile/src/session/mobile-session-tabs-accepted-effects.ts
@@ -1,0 +1,47 @@
+import type { SessionTabsStreamSource } from './mobile-session-tabs-stream-health'
+
+type AcceptedSessionTab = {
+  id: string
+  type: string
+  isActive: boolean
+  browserPageId?: string | null
+  isDirty?: boolean
+}
+
+type Options<Tab extends AcceptedSessionTab> = {
+  effectiveTabs: readonly Tab[]
+  source: SessionTabsStreamSource
+  getPendingBrowserPageId: () => string | null
+  clearPendingBrowserPageId: (pageId: string) => void
+  activateBrowserTab: (tab: Tab) => void
+  markActiveMarkdownStale: (tabId: string) => void
+}
+
+export function runAcceptedMobileSessionTabsEffects<Tab extends AcceptedSessionTab>({
+  effectiveTabs,
+  source,
+  getPendingBrowserPageId,
+  clearPendingBrowserPageId,
+  activateBrowserTab,
+  markActiveMarkdownStale
+}: Options<Tab>): void {
+  const pendingPageId = getPendingBrowserPageId()
+  if (pendingPageId) {
+    const browserTab = effectiveTabs.find(
+      (tab) => tab.type === 'browser' && tab.browserPageId === pendingPageId
+    )
+    if (browserTab) {
+      clearPendingBrowserPageId(pendingPageId)
+      activateBrowserTab(browserTab)
+    }
+  }
+  if (source !== 'stream') {
+    return
+  }
+  const activeMarkdown = effectiveTabs.find(
+    (tab) => tab.type === 'markdown' && tab.isActive && tab.isDirty
+  )
+  if (activeMarkdown) {
+    markActiveMarkdownStale(activeMarkdown.id)
+  }
+}

--- a/mobile/src/session/mobile-session-tabs-stream-health.test.ts
+++ b/mobile/src/session/mobile-session-tabs-stream-health.test.ts
@@ -1,0 +1,398 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcResponse } from '../transport/types'
+import {
+  MobileSessionTabsStreamHealth,
+  type SessionTabsApplyOutcome
+} from './mobile-session-tabs-stream-health'
+
+type TestResult = {
+  type?: 'snapshot' | 'updated' | 'error' | 'end'
+  snapshotVersion: number
+  tabs: string[]
+}
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: Error) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (error: Error) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function result(
+  snapshotVersion: number,
+  type?: TestResult['type'],
+  tabs = [`tab-${snapshotVersion}`]
+): TestResult {
+  return { snapshotVersion, tabs, ...(type ? { type } : {}) }
+}
+
+function success(value: TestResult): RpcResponse {
+  return {
+    id: `list-${value.snapshotVersion}`,
+    ok: true,
+    result: value,
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+function failure(): RpcResponse {
+  return {
+    id: 'list-failure',
+    ok: false,
+    error: { code: 'unavailable', message: 'try again' },
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+function makeHarness(options?: {
+  generation?: { current: number }
+  apply?: (value: TestResult) => SessionTabsApplyOutcome<string>
+  getApplicationRevision?: () => number
+}) {
+  const requests: Deferred<RpcResponse>[] = []
+  const sendRequest = vi.fn(() => {
+    const request = deferred<RpcResponse>()
+    requests.push(request)
+    return request.promise
+  })
+  const generation = options?.generation ?? { current: 1 }
+  const client = {
+    sendRequest,
+    getGeneration: () => generation.current
+  } as unknown as RpcClient
+  const apply =
+    options?.apply ??
+    vi.fn(
+      (value: TestResult): SessionTabsApplyOutcome<string> => ({
+        accepted: true,
+        effectiveTabs: value.tabs
+      })
+    )
+  const consumeAccepted = vi.fn()
+  let recoveryNeeded = false
+  const controller = new MobileSessionTabsStreamHealth<TestResult, string>({
+    client,
+    scope: 'id:repo::worktree',
+    apply,
+    consumeAccepted,
+    hasRecoveryNeed: () => recoveryNeeded,
+    getApplicationRevision: options?.getApplicationRevision
+  })
+  return {
+    apply,
+    client,
+    consumeAccepted,
+    controller,
+    generation,
+    requests,
+    sendRequest,
+    setRecoveryNeeded(value: boolean) {
+      recoveryNeeded = value
+    }
+  }
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('MobileSessionTabsStreamHealth', () => {
+  it('coalesces a cohort and runs one trailing request for a newer requirement', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+
+    const first = harness.controller.requestReconciliation()
+    const shared = harness.controller.requestReconciliation()
+
+    expect(shared).toBe(first)
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+    let sharedSettled = false
+    void shared.then(() => {
+      sharedSettled = true
+    })
+
+    harness.requests[0]!.resolve(success(result(1)))
+    await settle()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+    expect(sharedSettled).toBe(false)
+
+    harness.requests[1]!.resolve(success(result(2)))
+    await first
+    expect(sharedSettled).toBe(true)
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+    expect(harness.apply).toHaveBeenCalledTimes(2)
+  })
+
+  it('starts distinct pre- and post-snapshot lists and discards the stale barrier', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const subscription = harness.controller.beginSubscription()
+
+    const preSnapshot = harness.controller.ensureReconciliation()
+    subscription.listener(result(2, 'snapshot'))
+    const postSnapshot = harness.controller.ensureReconciliation()
+    expect(harness.controller.ensureReconciliation()).toBe(postSnapshot)
+
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+    expect(harness.controller.isCertified()).toBe(false)
+
+    harness.requests[0]!.resolve(success(result(1, undefined, ['stale-list'])))
+    await preSnapshot
+    expect(harness.consumeAccepted).toHaveBeenCalledTimes(1)
+
+    harness.requests[1]!.resolve(success(result(2, undefined, ['post-snapshot'])))
+    await postSnapshot
+    expect(harness.controller.isCertified()).toBe(true)
+    expect(harness.consumeAccepted).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ tabs: ['post-snapshot'] }),
+      ['post-snapshot'],
+      'list'
+    )
+  })
+
+  it('invalidates live state for a same-generation replayed snapshot', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const subscription = harness.controller.beginSubscription()
+    subscription.listener(result(1, 'updated'))
+    expect(harness.controller.isCertified()).toBe(true)
+
+    subscription.listener(result(2, 'snapshot'))
+    expect(harness.controller.isCertified()).toBe(false)
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+
+    harness.requests[0]!.resolve(success(result(2)))
+    await settle()
+    expect(harness.controller.isCertified()).toBe(true)
+  })
+
+  it('requires a pre-snapshot and post-snapshot list after stable generation migration', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const subscription = harness.controller.beginSubscription()
+    subscription.listener(result(1, 'updated'))
+    expect(harness.controller.isCertified()).toBe(true)
+
+    harness.generation.current = 2
+    const preSnapshot = harness.controller.poll()
+    expect(preSnapshot).not.toBeNull()
+    expect(harness.controller.isCertified()).toBe(false)
+
+    subscription.listener(result(2, 'snapshot'))
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+
+    harness.requests[0]!.resolve(success(result(2, undefined, ['generation-pre'])))
+    await preSnapshot
+    harness.requests[1]!.resolve(success(result(2, undefined, ['generation-post'])))
+    await settle()
+
+    expect(harness.controller.isCertified()).toBe(true)
+    expect(harness.controller.poll()).toBeNull()
+    expect(harness.consumeAccepted).not.toHaveBeenCalledWith(
+      expect.objectContaining({ tabs: ['generation-pre'] }),
+      expect.anything(),
+      'list'
+    )
+  })
+
+  it('ignores old generation results even before the next polling tick', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const pending = harness.controller.requestReconciliation()
+    harness.generation.current = 2
+
+    harness.requests[0]!.resolve(success(result(1)))
+    await pending
+
+    expect(harness.apply).not.toHaveBeenCalled()
+    expect(harness.consumeAccepted).not.toHaveBeenCalled()
+  })
+
+  it('keeps a failed requirement pending without an immediate or trailing retry', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const pending = harness.controller.requestReconciliation()
+    harness.requests[0]!.resolve(failure())
+    await pending
+    await settle()
+
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+    const retry = harness.controller.poll()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+    harness.requests[1]!.resolve(success(result(1)))
+    await retry
+    await settle()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a failed explicit reconciliation even while stream health stays live', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const subscription = harness.controller.beginSubscription()
+    subscription.listener(result(1, 'updated'))
+
+    const failed = harness.controller.requestReconciliation()
+    harness.requests[0]!.resolve(failure())
+    await failed
+    const retry = harness.controller.poll()
+
+    expect(retry).not.toBeNull()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+    harness.requests[1]!.resolve(success(result(1)))
+    await retry
+    expect(harness.controller.poll()).toBeNull()
+  })
+
+  it('lets an accepted update satisfy only requirements raised before apply', async () => {
+    let controller: MobileSessionTabsStreamHealth<TestResult, string>
+    let raisedRequirement: Promise<void> | null = null
+    const apply = vi.fn((value: TestResult): SessionTabsApplyOutcome<string> => {
+      if (value.type === 'updated') {
+        raisedRequirement = controller.requestReconciliation()
+      }
+      return { accepted: true, effectiveTabs: value.tabs }
+    })
+    const harness = makeHarness({ apply })
+    controller = harness.controller
+    controller.setReconciliationActive(true)
+    const subscription = controller.beginSubscription()
+
+    subscription.listener(result(1, 'updated'))
+
+    expect(controller.isCertified()).toBe(true)
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+    harness.requests[0]!.resolve(success(result(1)))
+    await raisedRequirement
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+    const retry = controller.poll()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+    harness.requests[1]!.resolve(success(result(1)))
+    await retry
+  })
+
+  it('does not consume a rejected stream snapshot or update', () => {
+    const apply = vi.fn(
+      (value: TestResult): SessionTabsApplyOutcome<string> =>
+        value.type ? { accepted: false } : { accepted: true, effectiveTabs: value.tabs }
+    )
+    const harness = makeHarness({ apply })
+    const subscription = harness.controller.beginSubscription()
+
+    subscription.listener(result(1, 'snapshot'))
+    subscription.listener(result(2, 'updated'))
+
+    expect(harness.consumeAccepted).not.toHaveBeenCalled()
+    expect(harness.controller.isCertified()).toBe(false)
+    expect(harness.sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('fences cancelled subscription frames', () => {
+    const harness = makeHarness()
+    const subscription = harness.controller.beginSubscription()
+    subscription.cancel()
+
+    subscription.listener(result(1, 'updated'))
+
+    expect(harness.apply).not.toHaveBeenCalled()
+    expect(harness.consumeAccepted).not.toHaveBeenCalled()
+  })
+
+  it('records requirements while inactive without issuing background requests', async () => {
+    const harness = makeHarness()
+    const subscription = harness.controller.beginSubscription()
+
+    subscription.listener(result(1, 'snapshot'))
+    subscription.listener({
+      type: 'error',
+      snapshotVersion: 1,
+      tabs: []
+    })
+    await harness.controller.requestReconciliation()
+
+    expect(harness.sendRequest).not.toHaveBeenCalled()
+    harness.controller.setReconciliationActive(true)
+    const resumed = harness.controller.ensureReconciliation()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+    harness.requests[0]!.resolve(success(result(1)))
+    await resumed
+  })
+
+  it('keeps polling a certified stream while local recovery work remains', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const subscription = harness.controller.beginSubscription()
+    subscription.listener(result(1, 'updated'))
+    harness.setRecoveryNeeded(true)
+
+    const poll = harness.controller.poll()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+    harness.requests[0]!.resolve(success(result(1)))
+    await poll
+
+    harness.setRecoveryNeeded(false)
+    expect(harness.controller.poll()).toBeNull()
+  })
+
+  it('makes delayed pending-recovery requests no-ops after accepted consumption resolves them', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    expect(await harness.controller.requestPendingRecovery()).toBeUndefined()
+    expect(harness.sendRequest).not.toHaveBeenCalled()
+
+    harness.setRecoveryNeeded(true)
+    const pending = harness.controller.requestPendingRecovery()
+    harness.requests[0]!.resolve(success(result(1)))
+    await pending
+    harness.setRecoveryNeeded(false)
+
+    await harness.controller.requestPendingRecovery()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores list results owned by a disposed route controller', async () => {
+    const harness = makeHarness()
+    harness.controller.setReconciliationActive(true)
+    const pending = harness.controller.requestReconciliation()
+    harness.controller.dispose()
+
+    harness.requests[0]!.resolve(success(result(1)))
+    await pending
+
+    expect(harness.apply).not.toHaveBeenCalled()
+    expect(harness.consumeAccepted).not.toHaveBeenCalled()
+  })
+
+  it('discards a list after a newer accepted application outside the controller', async () => {
+    let applicationRevision = 0
+    const harness = makeHarness({
+      getApplicationRevision: () => applicationRevision
+    })
+    harness.controller.setReconciliationActive(true)
+    const pending = harness.controller.requestReconciliation()
+
+    applicationRevision += 1
+    harness.requests[0]!.resolve(success(result(1)))
+    await pending
+
+    expect(harness.apply).not.toHaveBeenCalled()
+    expect(harness.consumeAccepted).not.toHaveBeenCalled()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(1)
+    const retry = harness.controller.poll()
+    expect(harness.sendRequest).toHaveBeenCalledTimes(2)
+    harness.requests[1]!.resolve(success(result(2)))
+    await retry
+    expect(harness.apply).toHaveBeenCalledTimes(1)
+  })
+})

--- a/mobile/src/session/mobile-session-tabs-stream-health.ts
+++ b/mobile/src/session/mobile-session-tabs-stream-health.ts
@@ -1,0 +1,308 @@
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcFailure, RpcSuccess } from '../transport/types'
+
+export type SessionTabsApplyOutcome<Tab> =
+  | { accepted: false }
+  | { accepted: true; effectiveTabs: readonly Tab[]; applicationRevision?: number }
+
+export type SessionTabsStreamSource = 'list' | 'stream'
+
+type StreamHealth = 'probing' | 'live' | 'degraded'
+
+type RequestOwner = {
+  generation: number
+  barrier: number
+  requirement: number
+  applicationRevision: number
+}
+
+type RequestCohort = {
+  promise: Promise<void>
+  resolve: () => void
+}
+
+type ControllerOptions<Result, Tab> = {
+  client: RpcClient
+  scope: string
+  apply: (result: Result) => SessionTabsApplyOutcome<Tab>
+  consumeAccepted: (
+    result: Result,
+    effectiveTabs: readonly Tab[],
+    source: SessionTabsStreamSource
+  ) => void
+  hasRecoveryNeed: () => boolean
+  getApplicationRevision?: () => number
+  onFetchStarted?: () => void
+  onFetchSucceeded?: (result: Result) => void
+  onFetchFailed?: (failure: RpcFailure) => void
+  onFetchErrored?: (error: unknown) => void
+}
+
+type StreamSubscription = {
+  listener: (payload: unknown) => void
+  cancel: () => void
+}
+
+type GenerationClient = RpcClient & { getGeneration?: () => number }
+
+export class MobileSessionTabsStreamHealth<Result, Tab> {
+  private readonly inFlight = new Map<string, RequestCohort>()
+  private generation: number
+  private barrier = 0
+  private subscriptionEpoch = 0
+  private requirementRevision = 0
+  private satisfiedRevision = 0
+  private applicationRevision = 0
+  private health: StreamHealth = 'probing'
+  private snapshotSeen = false
+  private reconciliationActive = false
+  private disposed = false
+
+  constructor(private readonly options: ControllerOptions<Result, Tab>) {
+    this.generation = this.readGeneration()
+    this.applicationRevision = this.readApplicationRevision()
+  }
+
+  requestReconciliation(): Promise<void> {
+    this.syncGeneration()
+    this.requirementRevision += 1
+    return this.startCurrentRequest()
+  }
+
+  ensureReconciliation(): Promise<void> {
+    this.syncGeneration()
+    if (this.requirementRevision <= this.satisfiedRevision) {
+      this.requirementRevision += 1
+    }
+    return this.startCurrentRequest()
+  }
+
+  requestPendingRecovery(): Promise<void> {
+    if (!this.options.hasRecoveryNeed()) {
+      return Promise.resolve()
+    }
+    return this.requestReconciliation()
+  }
+
+  poll(): Promise<void> | null {
+    this.syncGeneration()
+    if (
+      !this.reconciliationActive ||
+      (this.health === 'live' &&
+        !this.options.hasRecoveryNeed() &&
+        this.requirementRevision <= this.satisfiedRevision)
+    ) {
+      return null
+    }
+    return this.ensureReconciliation()
+  }
+
+  setReconciliationActive(active: boolean): void {
+    this.reconciliationActive = active
+  }
+
+  beginSubscription(): StreamSubscription {
+    this.syncGeneration()
+    const epoch = ++this.subscriptionEpoch
+    this.invalidateStream('probing')
+    return {
+      listener: (payload) => {
+        if (this.disposed || epoch !== this.subscriptionEpoch) {
+          return
+        }
+        this.handleStreamPayload(payload)
+      },
+      cancel: () => {
+        if (epoch === this.subscriptionEpoch) {
+          this.subscriptionEpoch += 1
+          this.invalidateStream('degraded')
+        }
+      }
+    }
+  }
+
+  isCertified(): boolean {
+    this.syncGeneration()
+    return this.health === 'live'
+  }
+
+  dispose(): void {
+    this.disposed = true
+    this.subscriptionEpoch += 1
+  }
+
+  private handleStreamPayload(payload: unknown): void {
+    this.syncGeneration()
+    if (!payload || typeof payload !== 'object') {
+      return
+    }
+    const event = payload as Result & { type?: string }
+    if (event.type === 'snapshot') {
+      this.invalidateStream('probing')
+      this.snapshotSeen = true
+      this.applyCurrent(event, 'stream')
+      this.startCurrentRequest()
+      return
+    }
+    if (event.type === 'updated') {
+      const capturedRequirement = this.requirementRevision
+      const ownerGeneration = this.generation
+      const outcome = this.applyCurrent(event, 'stream')
+      if (!outcome.accepted || !this.isCurrentGeneration(ownerGeneration)) {
+        return
+      }
+      this.health = 'live'
+      this.satisfiedRevision = Math.max(this.satisfiedRevision, capturedRequirement)
+      this.startTrailingRequest()
+      return
+    }
+    if (event.type === 'error' || event.type === 'end') {
+      this.invalidateStream('degraded')
+      this.startCurrentRequest()
+    }
+  }
+
+  private applyCurrent(
+    result: Result,
+    source: SessionTabsStreamSource
+  ): SessionTabsApplyOutcome<Tab> {
+    const generation = this.generation
+    const outcome = this.options.apply(result)
+    if (!outcome.accepted || !this.isCurrentGeneration(generation)) {
+      return { accepted: false }
+    }
+    this.applicationRevision =
+      outcome.applicationRevision === undefined
+        ? this.applicationRevision + 1
+        : Math.max(this.applicationRevision, outcome.applicationRevision)
+    this.options.consumeAccepted(result, outcome.effectiveTabs, source)
+    return outcome
+  }
+
+  private invalidateStream(health: Exclude<StreamHealth, 'live'>): void {
+    this.barrier += 1
+    this.health = health
+    this.snapshotSeen = false
+    this.requirementRevision += 1
+  }
+
+  private startCurrentRequest(): Promise<void> {
+    if (this.disposed || !this.reconciliationActive) {
+      return Promise.resolve()
+    }
+    const key = `${this.generation}:${this.barrier}`
+    const shared = this.inFlight.get(key)
+    if (shared) {
+      return shared.promise
+    }
+    let resolveRequest!: () => void
+    const promise = new Promise<void>((resolve) => {
+      resolveRequest = resolve
+    })
+    const cohort = { promise, resolve: resolveRequest }
+    this.inFlight.set(key, cohort)
+    this.runCohortRequest(key, cohort)
+    return promise
+  }
+
+  private runCohortRequest(key: string, cohort: RequestCohort): void {
+    const owner: RequestOwner = {
+      generation: this.generation,
+      barrier: this.barrier,
+      requirement: this.requirementRevision,
+      applicationRevision: this.readApplicationRevision()
+    }
+    const finish = (canDrain: boolean): void => {
+      if (
+        canDrain &&
+        this.inFlight.get(key) === cohort &&
+        key === `${this.generation}:${this.barrier}` &&
+        this.reconciliationActive &&
+        this.requirementRevision > this.satisfiedRevision
+      ) {
+        this.runCohortRequest(key, cohort)
+        return
+      }
+      if (this.inFlight.get(key) === cohort) {
+        this.inFlight.delete(key)
+      }
+      cohort.resolve()
+    }
+    void this.runRequest(owner).then(finish, () => finish(false))
+  }
+
+  private async runRequest(owner: RequestOwner): Promise<boolean> {
+    try {
+      this.options.onFetchStarted?.()
+      const response = await this.options.client.sendRequest('session.tabs.list', {
+        worktree: this.options.scope
+      })
+      if (!this.isCurrentGeneration(owner.generation)) {
+        return false
+      }
+      if (!response.ok) {
+        if (owner.barrier === this.barrier) {
+          this.options.onFetchFailed?.(response as RpcFailure)
+        }
+        return false
+      }
+      const result = (response as RpcSuccess).result as Result
+      if (owner.barrier !== this.barrier) {
+        return false
+      }
+      if (owner.applicationRevision !== this.readApplicationRevision()) {
+        return false
+      }
+      this.options.onFetchSucceeded?.(result)
+      const outcome = this.applyCurrent(result, 'list')
+      if (!outcome.accepted || !this.isCurrentGeneration(owner.generation)) {
+        return false
+      }
+      this.satisfiedRevision = Math.max(this.satisfiedRevision, owner.requirement)
+      if (this.snapshotSeen) {
+        this.health = 'live'
+      }
+      return true
+    } catch (error) {
+      if (this.isCurrentGeneration(owner.generation) && owner.barrier === this.barrier) {
+        this.options.onFetchErrored?.(error)
+      }
+      return false
+    }
+  }
+
+  private startTrailingRequest(): void {
+    if (
+      !this.disposed &&
+      this.reconciliationActive &&
+      this.requirementRevision > this.satisfiedRevision &&
+      !this.inFlight.has(`${this.generation}:${this.barrier}`)
+    ) {
+      void this.startCurrentRequest()
+    }
+  }
+
+  private syncGeneration(): void {
+    if (this.disposed) {
+      return
+    }
+    const generation = this.readGeneration()
+    if (generation === this.generation) {
+      return
+    }
+    this.generation = generation
+    this.invalidateStream('probing')
+  }
+
+  private isCurrentGeneration(generation: number): boolean {
+    return !this.disposed && generation === this.generation && generation === this.readGeneration()
+  }
+
+  private readGeneration(): number {
+    return (this.options.client as GenerationClient).getGeneration?.() ?? 0
+  }
+
+  private readApplicationRevision(): number {
+    return Math.max(this.applicationRevision, this.options.getApplicationRevision?.() ?? 0)
+  }
+}

--- a/mobile/src/session/use-mobile-session-tabs-reconciliation.test.ts
+++ b/mobile/src/session/use-mobile-session-tabs-reconciliation.test.ts
@@ -1,0 +1,293 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { SessionTabsApplyOutcome } from './mobile-session-tabs-stream-health'
+import { useMobileSessionTabsReconciliation } from './use-mobile-session-tabs-reconciliation'
+
+const lifecycle = vi.hoisted(() => ({
+  appState: 'active',
+  focused: true,
+  listeners: new Set<(state: string) => void>()
+}))
+
+vi.mock('react-native', () => ({
+  AppState: {
+    get currentState() {
+      return lifecycle.appState
+    },
+    addEventListener(_event: string, listener: (state: string) => void) {
+      lifecycle.listeners.add(listener)
+      return { remove: () => lifecycle.listeners.delete(listener) }
+    }
+  }
+}))
+
+vi.mock('expo-router', async () => {
+  const React = await import('react')
+  return {
+    useFocusEffect(effect: () => void | (() => void)): void {
+      React.useEffect(() => (lifecycle.focused ? effect() : undefined), [effect, lifecycle.focused])
+    }
+  }
+})
+
+type TestResult = {
+  type?: 'snapshot' | 'updated' | 'error' | 'end'
+  snapshotVersion: number
+  tabs: string[]
+}
+
+const fetchTerminals = vi.fn(async () => {})
+const applySessionTabs = vi.fn(
+  (value: TestResult): SessionTabsApplyOutcome<string> => ({
+    accepted: true,
+    effectiveTabs: value.tabs
+  })
+)
+const consumeAcceptedSessionTabs = vi.fn()
+let recoveryNeeded = false
+let clearRecoveryAt = Number.POSITIVE_INFINITY
+const hasRecoveryNeed = () => recoveryNeeded
+const subscribe = vi.fn()
+const unsubscribe = vi.fn()
+let streamListener: ((payload: unknown) => void) | null = null
+let listSequence = 0
+const sendRequest = vi.fn(async () => ({
+  id: `list-${++listSequence}`,
+  ok: true as const,
+  result: {
+    snapshotVersion: listSequence,
+    tabs: [`tab-${listSequence}`]
+  },
+  _meta: { runtimeId: 'runtime-1' }
+}))
+const client = {
+  sendRequest,
+  subscribe
+} as unknown as RpcClient
+
+function applyWithRecovery(value: TestResult): SessionTabsApplyOutcome<string> {
+  const outcome = applySessionTabs(value)
+  if (outcome.accepted && Date.now() >= clearRecoveryAt) {
+    recoveryNeeded = false
+  }
+  return outcome
+}
+
+function Harness(): null {
+  useMobileSessionTabsReconciliation<TestResult, string>({
+    client,
+    connState: 'connected',
+    worktreeId: 'repo::worktree',
+    applySessionTabs: applyWithRecovery,
+    consumeAcceptedSessionTabs,
+    fetchTerminals,
+    hasRecoveryNeed
+  })
+  return null
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function emitStream(payload: TestResult): Promise<void> {
+  await act(async () => {
+    streamListener?.(payload)
+    await flush()
+  })
+}
+
+async function setAppState(state: string): Promise<void> {
+  lifecycle.appState = state
+  await act(async () => {
+    for (const listener of lifecycle.listeners) {
+      listener(state)
+    }
+    await flush()
+  })
+}
+
+describe('useMobileSessionTabsReconciliation', () => {
+  let renderer: ReactTestRenderer | null = null
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+  async function mount(): Promise<void> {
+    await act(async () => {
+      renderer = create(createElement(Harness))
+      await flush()
+    })
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const originalConsoleError = console.error
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation((...args) => {
+      if (typeof args[0] === 'string' && args[0].includes('react-test-renderer is deprecated')) {
+        return
+      }
+      originalConsoleError(...args)
+    })
+    lifecycle.appState = 'active'
+    lifecycle.focused = true
+    lifecycle.listeners.clear()
+    recoveryNeeded = false
+    clearRecoveryAt = Number.POSITIVE_INFINITY
+    listSequence = 0
+    fetchTerminals.mockClear()
+    applySessionTabs.mockClear()
+    consumeAcceptedSessionTabs.mockClear()
+    unsubscribe.mockClear()
+    sendRequest.mockClear()
+    subscribe
+      .mockReset()
+      .mockImplementation(
+        (_method: string, _params: unknown, listener: (payload: unknown) => void) => {
+          streamListener = listener
+          return unsubscribe
+        }
+      )
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    streamListener = null
+    consoleErrorSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('does zero tab lists and thirty terminal lists in a certified warm minute', async () => {
+    await mount()
+    await emitStream({ type: 'updated', snapshotVersion: 1, tabs: ['tab-1'] })
+    sendRequest.mockClear()
+    fetchTerminals.mockClear()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(fetchTerminals).toHaveBeenCalledTimes(30)
+  })
+
+  it('runs an immediate list plus five fallback lists over ten probing seconds', async () => {
+    await mount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000)
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(6)
+    expect(fetchTerminals).toHaveBeenCalledTimes(6)
+  })
+
+  it('runs an immediate list plus five fallback lists after stream degradation', async () => {
+    await mount()
+    await emitStream({ type: 'updated', snapshotVersion: 1, tabs: ['tab-1'] })
+    sendRequest.mockClear()
+    fetchTerminals.mockClear()
+    await emitStream({ type: 'error', snapshotVersion: 1, tabs: [] })
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000)
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(6)
+    expect(fetchTerminals).toHaveBeenCalledTimes(5)
+  })
+
+  it('does no reconciliation work while backgrounded or blurred', async () => {
+    lifecycle.appState = 'background'
+    await mount()
+    await emitStream({ type: 'snapshot', snapshotVersion: 1, tabs: ['tab-1'] })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(fetchTerminals).not.toHaveBeenCalled()
+
+    lifecycle.appState = 'active'
+    lifecycle.focused = false
+    await act(async () => {
+      renderer?.update(createElement(Harness))
+      await flush()
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(sendRequest).not.toHaveBeenCalled()
+    expect(fetchTerminals).not.toHaveBeenCalled()
+  })
+
+  it('reconciles immediately on resume even while the stream is certified', async () => {
+    await mount()
+    await emitStream({ type: 'updated', snapshotVersion: 1, tabs: ['tab-1'] })
+    await setAppState('background')
+    sendRequest.mockClear()
+    fetchTerminals.mockClear()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    await setAppState('active')
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(fetchTerminals).toHaveBeenCalledTimes(1)
+  })
+
+  it('reconciles immediately when a certified route regains focus', async () => {
+    await mount()
+    await emitStream({ type: 'updated', snapshotVersion: 1, tabs: ['tab-1'] })
+    lifecycle.focused = false
+    await act(async () => {
+      renderer?.update(createElement(Harness))
+      await flush()
+    })
+    sendRequest.mockClear()
+    fetchTerminals.mockClear()
+
+    lifecycle.focused = true
+    await act(async () => {
+      renderer?.update(createElement(Harness))
+      await flush()
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(fetchTerminals).toHaveBeenCalledTimes(1)
+  })
+
+  it('polls five times through a ten-second close tombstone and then stops', async () => {
+    await mount()
+    await emitStream({ type: 'updated', snapshotVersion: 1, tabs: ['tab-1'] })
+    sendRequest.mockClear()
+    fetchTerminals.mockClear()
+    recoveryNeeded = true
+    clearRecoveryAt = 10_000
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(12_000)
+    })
+
+    expect(sendRequest).toHaveBeenCalledTimes(5)
+    expect(fetchTerminals).toHaveBeenCalledTimes(6)
+    expect(recoveryNeeded).toBe(false)
+  })
+
+  it('keeps the controller and physical subscription stable across route rerenders', async () => {
+    await mount()
+    const initialListener = streamListener
+
+    await act(async () => {
+      renderer?.update(createElement(Harness))
+      await flush()
+    })
+
+    expect(subscribe).toHaveBeenCalledTimes(1)
+    expect(unsubscribe).not.toHaveBeenCalled()
+    expect(streamListener).toBe(initialListener)
+  })
+})

--- a/mobile/src/session/use-mobile-session-tabs-reconciliation.ts
+++ b/mobile/src/session/use-mobile-session-tabs-reconciliation.ts
@@ -1,0 +1,155 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import { AppState } from 'react-native'
+import { useFocusEffect } from 'expo-router'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ConnectionState } from '../transport/types'
+import {
+  MobileSessionTabsStreamHealth,
+  type SessionTabsApplyOutcome,
+  type SessionTabsStreamSource
+} from './mobile-session-tabs-stream-health'
+
+type Params<Result, Tab> = {
+  client: RpcClient | null
+  connState: ConnectionState
+  worktreeId: string
+  applySessionTabs: (result: Result) => SessionTabsApplyOutcome<Tab>
+  consumeAcceptedSessionTabs: (
+    result: Result,
+    effectiveTabs: readonly Tab[],
+    source: SessionTabsStreamSource
+  ) => void
+  fetchTerminals: () => Promise<void>
+  hasRecoveryNeed: () => boolean
+  getApplicationRevision?: () => number
+  onFetchStarted?: () => void
+  onFetchSucceeded?: (result: Result) => void
+  onFetchFailed?: (code: string) => void
+  onFetchErrored?: (error: unknown) => void
+}
+
+type ResultActions = {
+  fetchSessionTabs: () => Promise<void>
+  ensureSessionTabs: () => Promise<void>
+  fetchPendingBrowserSessionTabs: () => Promise<void>
+}
+
+const resolved = Promise.resolve()
+
+export function useMobileSessionTabsReconciliation<Result, Tab>({
+  client,
+  connState,
+  worktreeId,
+  applySessionTabs,
+  consumeAcceptedSessionTabs,
+  fetchTerminals,
+  hasRecoveryNeed,
+  getApplicationRevision,
+  onFetchStarted,
+  onFetchSucceeded,
+  onFetchFailed,
+  onFetchErrored
+}: Params<Result, Tab>): ResultActions {
+  const controller = useMemo(
+    () =>
+      client
+        ? new MobileSessionTabsStreamHealth<Result, Tab>({
+            client,
+            scope: `id:${worktreeId}`,
+            apply: applySessionTabs,
+            consumeAccepted: consumeAcceptedSessionTabs,
+            hasRecoveryNeed,
+            getApplicationRevision,
+            onFetchStarted,
+            onFetchSucceeded,
+            onFetchFailed: (failure) => onFetchFailed?.(failure.error.code),
+            onFetchErrored
+          })
+        : null,
+    [
+      applySessionTabs,
+      client,
+      consumeAcceptedSessionTabs,
+      getApplicationRevision,
+      hasRecoveryNeed,
+      onFetchErrored,
+      onFetchFailed,
+      onFetchStarted,
+      onFetchSucceeded,
+      worktreeId
+    ]
+  )
+
+  useEffect(
+    () => () => {
+      controller?.dispose()
+    },
+    [controller]
+  )
+
+  useEffect(() => {
+    if (!client || !controller || connState !== 'connected') {
+      return
+    }
+    const subscription = controller.beginSubscription()
+    const unsubscribe = client.subscribe(
+      'session.tabs.subscribe',
+      { worktree: `id:${worktreeId}` },
+      subscription.listener
+    )
+    return () => {
+      subscription.cancel()
+      unsubscribe()
+    }
+  }, [client, connState, controller, worktreeId])
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!controller || connState !== 'connected') {
+        return
+      }
+      const refresh = (forceTabs: boolean): void => {
+        if (AppState.currentState !== 'active') {
+          controller.setReconciliationActive(false)
+          return
+        }
+        controller.setReconciliationActive(true)
+        if (forceTabs) {
+          void controller.requestReconciliation()
+        } else {
+          void controller.poll()
+        }
+        void fetchTerminals()
+      }
+      const appStateSubscription = AppState.addEventListener('change', (state) => {
+        if (state === 'active') {
+          refresh(true)
+        } else {
+          controller.setReconciliationActive(false)
+        }
+      })
+      const interval = setInterval(() => refresh(false), 2000)
+      refresh(true)
+      return () => {
+        controller.setReconciliationActive(false)
+        clearInterval(interval)
+        appStateSubscription.remove()
+      }
+    }, [connState, controller, fetchTerminals])
+  )
+
+  return {
+    fetchSessionTabs: useCallback(
+      () => controller?.requestReconciliation() ?? resolved,
+      [controller]
+    ),
+    ensureSessionTabs: useCallback(
+      () => controller?.ensureReconciliation() ?? resolved,
+      [controller]
+    ),
+    fetchPendingBrowserSessionTabs: useCallback(
+      () => controller?.requestPendingRecovery() ?? resolved,
+      [controller]
+    )
+  }
+}

--- a/mobile/src/transport/mobile-relay-rpc-streams.test.ts
+++ b/mobile/src/transport/mobile-relay-rpc-streams.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcFailure } from './types'
+import { MobileRelayRpcStreams } from './mobile-relay-rpc-streams'
+
+function rpcFailure(id: string): RpcFailure {
+  return {
+    id,
+    ok: false,
+    error: { code: 'unsupported', message: 'Unknown method' },
+    _meta: { runtimeId: 'runtime-1' }
+  }
+}
+
+describe('MobileRelayRpcStreams failure parity', () => {
+  it('emits an RPC failure exactly once before removing the stream', async () => {
+    const listener = vi.fn()
+    const sendFrame = vi.fn(() => true)
+    const streams = new MobileRelayRpcStreams({
+      nextId: () => 'stream-1',
+      sendFrame,
+      waitForConnected: async () => {}
+    })
+    const cancel = streams.subscribe(
+      'session.tabs.subscribe',
+      { worktree: 'id:worktree-1' },
+      listener
+    )
+    await Promise.resolve()
+
+    expect(streams.handleResponse(rpcFailure('stream-1'))).toBe(true)
+    expect(listener).toHaveBeenCalledExactlyOnceWith({
+      type: 'error',
+      message: 'Unknown method',
+      error: { code: 'unsupported', message: 'Unknown method' }
+    })
+    expect(streams.handleResponse(rpcFailure('stream-1'))).toBe(false)
+    cancel()
+    expect(sendFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits a connection-wait rejection exactly once without sending or cancelling', async () => {
+    const listener = vi.fn()
+    const sendFrame = vi.fn(() => true)
+    const waitError = new Error('relay session closed')
+    const streams = new MobileRelayRpcStreams({
+      nextId: () => 'stream-1',
+      sendFrame,
+      waitForConnected: () => Promise.reject(waitError)
+    })
+    const cancel = streams.subscribe(
+      'session.tabs.subscribe',
+      { worktree: 'id:worktree-1' },
+      listener
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({
+      type: 'error',
+      message: 'relay session closed',
+      error: waitError
+    })
+    expect(streams.handleResponse(rpcFailure('stream-1'))).toBe(false)
+    cancel()
+    expect(sendFrame).not.toHaveBeenCalled()
+  })
+
+  it('emits a send failure exactly once and fences cancellation and late frames', async () => {
+    const listener = vi.fn()
+    const sendFrame = vi.fn(() => false)
+    const streams = new MobileRelayRpcStreams({
+      nextId: () => 'stream-1',
+      sendFrame,
+      waitForConnected: async () => {}
+    })
+    const cancel = streams.subscribe(
+      'session.tabs.subscribe',
+      { worktree: 'id:worktree-1' },
+      listener
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({
+      type: 'error',
+      message: 'Connection interrupted',
+      error: undefined
+    })
+    cancel()
+    expect(streams.handleResponse(rpcFailure('stream-1'))).toBe(false)
+    expect(sendFrame).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not emit a failure after the caller cancels a queued stream', async () => {
+    const listener = vi.fn()
+    const sendFrame = vi.fn(() => true)
+    const connection = Promise.withResolvers<void>()
+    const streams = new MobileRelayRpcStreams({
+      nextId: () => 'stream-1',
+      sendFrame,
+      waitForConnected: () => connection.promise
+    })
+    const cancel = streams.subscribe(
+      'session.tabs.subscribe',
+      { worktree: 'id:worktree-1' },
+      listener
+    )
+    cancel()
+    connection.reject(new Error('late failure'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(sendFrame).not.toHaveBeenCalled()
+  })
+
+  it('does not send or emit after session clear settles a connection wait', async () => {
+    const listener = vi.fn()
+    const sendFrame = vi.fn(() => true)
+    const connection = Promise.withResolvers<void>()
+    const streams = new MobileRelayRpcStreams({
+      nextId: () => 'stream-1',
+      sendFrame,
+      waitForConnected: () => connection.promise
+    })
+    streams.subscribe('session.tabs.subscribe', { worktree: 'id:worktree-1' }, listener)
+    streams.clear()
+    connection.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(listener).not.toHaveBeenCalled()
+    expect(sendFrame).not.toHaveBeenCalled()
+  })
+
+  it('removes a failed stream even when its listener throws', async () => {
+    const listener = vi.fn(() => {
+      throw new Error('listener failed')
+    })
+    const streams = new MobileRelayRpcStreams({
+      nextId: () => 'stream-1',
+      sendFrame: () => true,
+      waitForConnected: async () => {}
+    })
+    streams.subscribe('session.tabs.subscribe', { worktree: 'id:worktree-1' }, listener)
+    await Promise.resolve()
+
+    expect(() => streams.handleResponse(rpcFailure('stream-1'))).toThrow('listener failed')
+    expect(streams.handleResponse(rpcFailure('stream-1'))).toBe(false)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+})

--- a/mobile/src/transport/mobile-relay-rpc-streams.ts
+++ b/mobile/src/transport/mobile-relay-rpc-streams.ts
@@ -58,10 +58,13 @@ export class MobileRelayRpcStreams {
       .waitForConnected()
       .then(() => {
         if (!stream.cancelled && !this.options.sendFrame({ id, method, params: stream.params })) {
-          this.remove(id)
+          this.fail(id, stream, 'Connection interrupted')
         }
       })
-      .catch(() => this.remove(id))
+      .catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : 'Connection interrupted'
+        this.fail(id, stream, message, error)
+      })
     return () => this.cancel(id)
   }
 
@@ -75,7 +78,7 @@ export class MobileRelayRpcStreams {
       return false
     }
     if (!response.ok) {
-      this.remove(response.id)
+      this.fail(response.id, stream, response.error.message, response.error)
       return true
     }
     const result = (response as RpcSuccess).result
@@ -117,6 +120,9 @@ export class MobileRelayRpcStreams {
   }
 
   clear(): void {
+    for (const stream of this.streams.values()) {
+      stream.cancelled = true
+    }
     this.streams.clear()
     this.terminalListeners.clear()
     this.terminalSnapshots.clear()
@@ -161,5 +167,16 @@ export class MobileRelayRpcStreams {
       this.activeBrowserStream = null
     }
     this.streams.delete(id)
+  }
+
+  private fail(id: string, stream: StreamRecord, message: string, error?: unknown): void {
+    if (stream.cancelled || this.streams.get(id) !== stream) {
+      return
+    }
+    try {
+      stream.listener({ type: 'error', message, error })
+    } finally {
+      this.remove(id)
+    }
   }
 }


### PR DESCRIPTION
## Description

- Certify `session.tabs.subscribe` only after an accepted full `updated` frame or a
  list request physically begun after the subscription snapshot.
- Stop the focused route's two-second `session.tabs.list` fallback while that
  stream is certified and no close/browser recovery is pending.
- Fence results by client generation, subscription cycle, stream barrier,
  requirement, route lifetime, and accepted-application revision; coalesce one
  physical request cohort while preserving a required post-mutation trailing list.
- Run browser-focus and markdown-stale effects only for accepted,
  tombstone-filtered snapshots.
- Give relay subscriptions the same exactly-once error frame as direct transport.
  Keep `terminal.list`, unsubscribe behavior, and terminal lifetime handling
  unchanged.

## ELI5

The phone used to ask the desktop for the whole tab list every two seconds even
while the desktop was already sending every tab change live. It now stops the
duplicate question only after proving the live feed is trustworthy. If the feed
ends, reconnects, or local close/focus work is unfinished, the old safety poll
automatically resumes.

## Proof of zero regression

- Independent final correctness, performance/transport, and
  platform/integration reviews found no remaining issues.
- Post-rebase focused D-003 behavior: 8 files, 61/61 tests passed.
- Post-rebase full mobile suite: 320 files; 2,330 tests passed and 2 skipped.
- Mobile TypeScript, full oxlint, and the 952-file format check passed.
- Root Node/CLI/web TypeScript, max-lines ratchet, and `git diff --check` passed.
- Normal bootstrap proves a pre-snapshot list cannot certify the stream: the
  initial snapshot creates a new barrier, the old result is discarded, and a
  distinct post-snapshot list must apply. An accepted full `updated` frame may
  certify immediately.
- Old client generations, canceled subscriptions, stale barriers, late lists,
  rejected snapshots, and results superseded by any accepted application cannot
  mutate current UI state.
- Concurrent same-barrier callers receive one exact promise. If a newer
  mutation requirement arrives during the request, that promise remains pending
  until its one trailing physical list settles; failures wait for the next tick
  rather than spinning.
- Backgrounded or blurred routes perform zero tab and terminal polls. Focus,
  foreground resume, reconnect, and stable connected-to-connected generation
  cutover invalidate prior health and reconcile immediately or on the current
  generation's next frame/tick.
- Close tombstones keep the tab fallback active through expiry. Pending browser
  focus resolves from either list or stream effective tabs. Rejected snapshots
  perform no browser, markdown, tombstone, or reconciliation side effects.
- Direct and relay subscription failures emit one compatible
  `{ type: 'error', message, error }` frame and fence late callbacks. Existing
  unsubscribe behavior is unchanged for mixed-version compatibility.
- Local, daemon, WSL, SSH, and relay hosts share the same session-tab RPC
  contract. The change adds no host path, process, Git, shell, or native-module
  assumptions.
- Full post-rebase root suite: 3,272 files and 34,817 tests passed; 8 files and
  60 tests skipped by the existing suite.
- Full root lint reaches the known pre-existing released `orca-cli` revision-9
  append-only manifest blocker after oxlint, switch-exhaustiveness, reliability,
  max-lines, and bundled-guide checks pass. Direct localization catalog and
  coverage checks also pass. This diff changes no skill files.

## Proof of performance improvement

- Deterministic fake-clock route budget, one focused certified session for
  60 seconds:
  - Before: 30 `session.tabs.list` + 30 `terminal.list` RPCs.
  - After: 0 `session.tabs.list` + exactly 30 `terminal.list` RPCs.
- That removes 30 redundant tab inventory RPCs and 30 host
  `listMobileSessionTabs` executions per focused idle minute.
- Safety fallback remains bounded exactly as designed:
  - PROBING or DEGRADED for 10 seconds: one immediate + five interval tab lists.
  - Backgrounded or blurred for 60 seconds: 0 tab / 0 terminal lists.
  - A close tombstone through 10 seconds: tab lists at 2/4/6/8/10 seconds, then
    none after accepted expiry processing.
- Same-barrier requests coalesce to one physical list; one newer ordinary
  requirement creates one trailing physical list instead of parallel duplicates.
- This PR does **not** claim fewer mobile radio wakes or fewer terminal
  inventories: the justified `terminal.list` request intentionally remains every
  two seconds.
- A physical-device battery trace was not used; the improvement proof is the
  deterministic production-hook request budget plus transport/controller tests.
