### PR TITLE
fix(codex): classify rate-limit windows by duration

### DIFF
--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -53,6 +53,31 @@ function makeRpcChild() {
   return child
 }
 
+function respondToRpcRateLimitRead(
+  rpcChild: ReturnType<typeof makeRpcChild>,
+  rateLimits: unknown
+): void {
+  rpcChild.stdin.write.mockImplementation((line: string) => {
+    const msg = JSON.parse(line) as { id?: number; method?: string }
+    if (msg.method === 'initialize') {
+      setTimeout(() => {
+        rpcChild.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
+        )
+      }, 0)
+    }
+    if (msg.method === 'account/rateLimits/read') {
+      setTimeout(() => {
+        rpcChild.stdout.emit(
+          'data',
+          Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { rateLimits } })}\n`)
+        )
+      }, 0)
+    }
+  })
+}
+
 function makePtyTerm() {
   let dataHandler: ((data: string) => void) | null = null
   let exitHandler: (() => void) | null = null
@@ -325,38 +350,12 @@ describe('fetchCodexRateLimits', () => {
     expect(ptySpawnMock).not.toHaveBeenCalled()
   })
 
-  it('normalizes Codex RPC remaining-minute windows to fixed display durations', async () => {
+  it('normalizes near-canonical Codex RPC windows to fixed display durations', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)
-    rpcChild.stdin.write.mockImplementation((line: string) => {
-      const msg = JSON.parse(line) as { id?: number; method?: string }
-      if (msg.method === 'initialize') {
-        setTimeout(() => {
-          rpcChild.stdout.emit(
-            'data',
-            Buffer.from(`${JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} })}\n`)
-          )
-        }, 0)
-      }
-      if (msg.method === 'account/rateLimits/read') {
-        setTimeout(() => {
-          rpcChild.stdout.emit(
-            'data',
-            Buffer.from(
-              `${JSON.stringify({
-                jsonrpc: '2.0',
-                id: msg.id,
-                result: {
-                  rateLimits: {
-                    primary: { usedPercent: 0, windowDurationMins: 299 },
-                    secondary: { usedPercent: 0, windowDurationMins: 10079 }
-                  }
-                }
-              })}\n`
-            )
-          )
-        }, 0)
-      }
+    respondToRpcRateLimitRead(rpcChild, {
+      primary: { usedPercent: 0, windowDurationMins: 299 },
+      secondary: { usedPercent: 0, windowDurationMins: 10079 }
     })
 
     const resultPromise = fetchCodexRateLimits()
@@ -366,6 +365,24 @@ describe('fetchCodexRateLimits', () => {
 
     expect(result.session?.windowMinutes).toBe(300)
     expect(result.weekly?.windowMinutes).toBe(10080)
+  })
+
+  it('keeps a weekly-only Codex primary window out of the 5-hour slot', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcRateLimitRead(rpcChild, {
+      primary: { usedPercent: 22, windowDurationMins: 10080 },
+      secondary: null
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: null,
+      weekly: { usedPercent: 22, windowMinutes: 10080 }
+    })
   })
 
   it('fills reset-credit count from the backend when the installed app-server omits it', async () => {

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -385,6 +385,24 @@ describe('fetchCodexRateLimits', () => {
     })
   })
 
+  it('does not map a duplicate session-duration window into the weekly slot', async () => {
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+    respondToRpcRateLimitRead(rpcChild, {
+      primary: { usedPercent: 11, windowDurationMins: 300 },
+      secondary: { usedPercent: 12, windowDurationMins: 300 }
+    })
+
+    const resultPromise = fetchCodexRateLimits()
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      session: { usedPercent: 11, windowMinutes: 300 },
+      weekly: null
+    })
+  })
+
   it('fills reset-credit count from the backend when the installed app-server omits it', async () => {
     const rpcChild = makeRpcChild()
     childSpawnMock.mockReturnValue(rpcChild)

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -10,6 +10,13 @@ import { homedir } from 'node:os'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 import { join } from 'node:path'
 import { probeCodexAuthPresence } from './codex-auth-presence'
+import {
+  classifyCodexRateLimitWindows,
+  CODEX_SESSION_WINDOW_MINUTES,
+  CODEX_WEEKLY_WINDOW_MINUTES,
+  type CodexRpcRateLimits,
+  type CodexRpcRateWindow
+} from './codex-rate-limit-window-classification'
 import { resolveCodexCommand } from '../codex-cli/command'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { getCmdExePath, getSpawnArgsForWindows } from '../win32-utils'
@@ -53,12 +60,6 @@ type RpcResponse = {
   error?: { code: number; message: string }
 }
 
-type RpcRateWindow = {
-  usedPercent?: number
-  windowDurationMins?: number
-  resetsAt?: number // Unix seconds
-}
-
 type RateLimitResetCredits = {
   availableCount: number
   totalEarnedCount?: number
@@ -70,14 +71,9 @@ type RateLimitResetCredits = {
   }[]
 }
 
-type RpcRateLimitsResult = {
-  primary?: RpcRateWindow | null
-  secondary?: RpcRateWindow | null
-}
-
 // Why: the Codex app-server wraps rate limit data as { rateLimits: { primary, secondary, ... } }.
 type RpcRateLimitsResponse = {
-  rateLimits?: RpcRateLimitsResult
+  rateLimits?: CodexRpcRateLimits | null
   rateLimitResetCredits?: {
     availableCount?: number
     totalEarnedCount?: number
@@ -447,12 +443,8 @@ export async function consumeCodexRateLimitResetCredit(options: {
   return mapBackendConsumeOutcome(payload.code)
 }
 
-const CODEX_SESSION_WINDOW_MINUTES = 300
-const CODEX_WEEKLY_WINDOW_MINUTES = 10080
-const CODEX_WINDOW_DURATION_TOLERANCE_MINUTES = 1
-
 function mapRpcWindow(
-  raw: RpcRateWindow | null | undefined,
+  raw: CodexRpcRateWindow | null | undefined,
   expectedWindowMinutes: number
 ): RateLimitWindow | null {
   if (!raw || typeof raw.usedPercent !== 'number' || !Number.isFinite(raw.usedPercent)) {
@@ -484,54 +476,6 @@ function mapRpcWindow(
     windowMinutes: expectedWindowMinutes,
     resetsAt,
     resetDescription
-  }
-}
-
-function hasRpcWindowDuration(
-  raw: RpcRateWindow | null | undefined,
-  expectedWindowMinutes: number
-): boolean {
-  return (
-    typeof raw?.windowDurationMins === 'number' &&
-    Number.isFinite(raw.windowDurationMins) &&
-    Math.abs(raw.windowDurationMins - expectedWindowMinutes) <=
-      CODEX_WINDOW_DURATION_TOLERANCE_MINUTES
-  )
-}
-
-function hasMappableRpcWindow(raw: RpcRateWindow | null | undefined): raw is RpcRateWindow {
-  return typeof raw?.usedPercent === 'number' && Number.isFinite(raw.usedPercent)
-}
-
-function mapRpcRateLimitWindows(result: RpcRateLimitsResult | undefined): {
-  session: RateLimitWindow | null
-  weekly: RateLimitWindow | null
-} {
-  const windows = [result?.primary, result?.secondary].filter(hasMappableRpcWindow)
-  const sessionRaw = windows.find((window) =>
-    hasRpcWindowDuration(window, CODEX_SESSION_WINDOW_MINUTES)
-  )
-  const weeklyRaw = windows.find((window) =>
-    hasRpcWindowDuration(window, CODEX_WEEKLY_WINDOW_MINUTES)
-  )
-
-  // Why: preserve legacy ordering for unknown bucket lengths, but never let it override an explicit opposite-slot duration.
-  const sessionFallback =
-    !sessionRaw && hasMappableRpcWindow(result?.primary) && result.primary !== weeklyRaw
-      ? result.primary
-      : undefined
-  const weeklyFallback =
-    !weeklyRaw &&
-    hasMappableRpcWindow(result?.secondary) &&
-    !hasRpcWindowDuration(result.secondary, CODEX_SESSION_WINDOW_MINUTES) &&
-    result.secondary !== sessionRaw &&
-    result.secondary !== sessionFallback
-      ? result.secondary
-      : undefined
-
-  return {
-    session: mapRpcWindow(sessionRaw ?? sessionFallback, CODEX_SESSION_WINDOW_MINUTES),
-    weekly: mapRpcWindow(weeklyRaw ?? weeklyFallback, CODEX_WEEKLY_WINDOW_MINUTES)
   }
 }
 
@@ -753,7 +697,9 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
             const wrapper = msg.result as RpcRateLimitsResponse | undefined
             const result = wrapper?.rateLimits
-            const { session, weekly } = mapRpcRateLimitWindows(result)
+            const classifiedWindows = classifyCodexRateLimitWindows(result)
+            const session = mapRpcWindow(classifiedWindows.session, CODEX_SESSION_WINDOW_MINUTES)
+            const weekly = mapRpcWindow(classifiedWindows.weekly, CODEX_WEEKLY_WINDOW_MINUTES)
             const rateLimitResetCredits = mapRpcRateLimitResetCredits(
               wrapper?.rateLimitResetCredits
             )

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -71,8 +71,8 @@ type RateLimitResetCredits = {
 }
 
 type RpcRateLimitsResult = {
-  primary?: RpcRateWindow
-  secondary?: RpcRateWindow
+  primary?: RpcRateWindow | null
+  secondary?: RpcRateWindow | null
 }
 
 // Why: the Codex app-server wraps rate limit data as { rateLimits: { primary, secondary, ... } }.
@@ -447,8 +447,12 @@ export async function consumeCodexRateLimitResetCredit(options: {
   return mapBackendConsumeOutcome(payload.code)
 }
 
+const CODEX_SESSION_WINDOW_MINUTES = 300
+const CODEX_WEEKLY_WINDOW_MINUTES = 10080
+const CODEX_WINDOW_DURATION_TOLERANCE_MINUTES = 1
+
 function mapRpcWindow(
-  raw: RpcRateWindow | undefined,
+  raw: RpcRateWindow | null | undefined,
   expectedWindowMinutes: number
 ): RateLimitWindow | null {
   if (!raw || typeof raw.usedPercent !== 'number' || !Number.isFinite(raw.usedPercent)) {
@@ -476,10 +480,57 @@ function mapRpcWindow(
 
   return {
     usedPercent: Math.min(100, Math.max(0, raw.usedPercent)),
-    // Why: windowDurationMins reports remaining minutes, but the UI needs the fixed bucket duration for "5h"/"wk" labels.
+    // Why: older app-server builds can report canonical bucket lengths off by one minute.
     windowMinutes: expectedWindowMinutes,
     resetsAt,
     resetDescription
+  }
+}
+
+function hasRpcWindowDuration(
+  raw: RpcRateWindow | null | undefined,
+  expectedWindowMinutes: number
+): boolean {
+  return (
+    typeof raw?.windowDurationMins === 'number' &&
+    Number.isFinite(raw.windowDurationMins) &&
+    Math.abs(raw.windowDurationMins - expectedWindowMinutes) <=
+      CODEX_WINDOW_DURATION_TOLERANCE_MINUTES
+  )
+}
+
+function hasMappableRpcWindow(raw: RpcRateWindow | null | undefined): raw is RpcRateWindow {
+  return typeof raw?.usedPercent === 'number' && Number.isFinite(raw.usedPercent)
+}
+
+function mapRpcRateLimitWindows(result: RpcRateLimitsResult | undefined): {
+  session: RateLimitWindow | null
+  weekly: RateLimitWindow | null
+} {
+  const windows = [result?.primary, result?.secondary].filter(hasMappableRpcWindow)
+  const sessionRaw = windows.find((window) =>
+    hasRpcWindowDuration(window, CODEX_SESSION_WINDOW_MINUTES)
+  )
+  const weeklyRaw = windows.find((window) =>
+    hasRpcWindowDuration(window, CODEX_WEEKLY_WINDOW_MINUTES)
+  )
+
+  // Why: preserve legacy ordering for unknown bucket lengths, but never let it override an explicit opposite-slot duration.
+  const sessionFallback =
+    !sessionRaw && hasMappableRpcWindow(result?.primary) && result.primary !== weeklyRaw
+      ? result.primary
+      : undefined
+  const weeklyFallback =
+    !weeklyRaw &&
+    hasMappableRpcWindow(result?.secondary) &&
+    result.secondary !== sessionRaw &&
+    result.secondary !== sessionFallback
+      ? result.secondary
+      : undefined
+
+  return {
+    session: mapRpcWindow(sessionRaw ?? sessionFallback, CODEX_SESSION_WINDOW_MINUTES),
+    weekly: mapRpcWindow(weeklyRaw ?? weeklyFallback, CODEX_WEEKLY_WINDOW_MINUTES)
   }
 }
 
@@ -701,8 +752,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
 
             const wrapper = msg.result as RpcRateLimitsResponse | undefined
             const result = wrapper?.rateLimits
-            const session = mapRpcWindow(result?.primary, 300)
-            const weekly = mapRpcWindow(result?.secondary, 10080)
+            const { session, weekly } = mapRpcRateLimitWindows(result)
             const rateLimitResetCredits = mapRpcRateLimitResetCredits(
               wrapper?.rateLimitResetCredits
             )

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -523,6 +523,7 @@ function mapRpcRateLimitWindows(result: RpcRateLimitsResult | undefined): {
   const weeklyFallback =
     !weeklyRaw &&
     hasMappableRpcWindow(result?.secondary) &&
+    !hasRpcWindowDuration(result.secondary, CODEX_SESSION_WINDOW_MINUTES) &&
     result.secondary !== sessionRaw &&
     result.secondary !== sessionFallback
       ? result.secondary

--- a/src/main/rate-limits/codex-rate-limit-window-classification.test.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyCodexRateLimitWindows,
+  type CodexRpcRateLimits
+} from './codex-rate-limit-window-classification'
+
+function usedPercentByWindow(result: CodexRpcRateLimits | null): {
+  session: number | null
+  weekly: number | null
+} {
+  const classified = classifyCodexRateLimitWindows(result)
+  return {
+    session: classified.session?.usedPercent ?? null,
+    weekly: classified.weekly?.usedPercent ?? null
+  }
+}
+
+describe('classifyCodexRateLimitWindows', () => {
+  it.each([
+    {
+      name: 'null windows',
+      result: null,
+      expected: { session: null, weekly: null }
+    },
+    {
+      name: 'reordered known windows',
+      result: {
+        primary: { usedPercent: 81, windowDurationMins: 10080 },
+        secondary: { usedPercent: 21, windowDurationMins: 300 }
+      },
+      expected: { session: 21, weekly: 81 }
+    },
+    {
+      name: 'weekly-only primary window',
+      result: {
+        primary: { usedPercent: 22, windowDurationMins: 10080 },
+        secondary: null
+      },
+      expected: { session: null, weekly: 22 }
+    },
+    {
+      name: 'session-only secondary window',
+      result: {
+        primary: null,
+        secondary: { usedPercent: 31, windowDurationMins: 300 }
+      },
+      expected: { session: 31, weekly: null }
+    },
+    {
+      name: 'duplicate session windows',
+      result: {
+        primary: { usedPercent: 41, windowDurationMins: 300 },
+        secondary: { usedPercent: 42, windowDurationMins: 300 }
+      },
+      expected: { session: 41, weekly: null }
+    },
+    {
+      name: 'duplicate weekly windows',
+      result: {
+        primary: { usedPercent: 51, windowDurationMins: 10080 },
+        secondary: { usedPercent: 52, windowDurationMins: 10080 }
+      },
+      expected: { session: null, weekly: 51 }
+    },
+    {
+      name: 'malformed usage',
+      result: {
+        primary: { usedPercent: Number.NaN, windowDurationMins: 300 },
+        secondary: { usedPercent: 61, windowDurationMins: 10080 }
+      },
+      expected: { session: null, weekly: 61 }
+    },
+    {
+      name: 'malformed duration with positional fallback',
+      result: {
+        primary: { usedPercent: 71, windowDurationMins: '300' },
+        secondary: null
+      },
+      expected: { session: 71, weekly: null }
+    },
+    {
+      name: 'reordered near-canonical windows',
+      result: {
+        primary: { usedPercent: 81, windowDurationMins: 10081 },
+        secondary: { usedPercent: 82, windowDurationMins: 299 }
+      },
+      expected: { session: 82, weekly: 81 }
+    },
+    {
+      name: 'opposite near-canonical boundaries',
+      result: {
+        primary: { usedPercent: 83, windowDurationMins: 10079 },
+        secondary: { usedPercent: 84, windowDurationMins: 301 }
+      },
+      expected: { session: 84, weekly: 83 }
+    },
+    {
+      name: 'outside-tolerance unknown windows',
+      result: {
+        primary: { usedPercent: 91, windowDurationMins: 302 },
+        secondary: { usedPercent: 92, windowDurationMins: 10082 }
+      },
+      expected: { session: 91, weekly: 92 }
+    },
+    {
+      name: 'unknown windows without durations',
+      result: {
+        primary: { usedPercent: 101 },
+        secondary: { usedPercent: 102 }
+      },
+      expected: { session: 101, weekly: 102 }
+    },
+    {
+      name: 'known session wins over unknown primary fallback',
+      result: {
+        primary: { usedPercent: 111, windowDurationMins: 60 },
+        secondary: { usedPercent: 112, windowDurationMins: 300 }
+      },
+      expected: { session: 112, weekly: null }
+    },
+    {
+      name: 'known weekly wins over unknown secondary fallback',
+      result: {
+        primary: { usedPercent: 121, windowDurationMins: 10080 },
+        secondary: { usedPercent: 122, windowDurationMins: 60 }
+      },
+      expected: { session: null, weekly: 121 }
+    }
+  ] as const)('$name', ({ result, expected }) => {
+    expect(usedPercentByWindow(result)).toEqual(expected)
+  })
+})

--- a/src/main/rate-limits/codex-rate-limit-window-classification.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.ts
@@ -1,0 +1,73 @@
+export const CODEX_SESSION_WINDOW_MINUTES = 300
+export const CODEX_WEEKLY_WINDOW_MINUTES = 10080
+
+// Why: tolerate the one-minute drift seen in older Codex bucket lengths without absorbing other durations.
+const CODEX_WINDOW_DURATION_TOLERANCE_MINUTES = 1
+
+export type CodexRpcRateWindow = {
+  usedPercent?: unknown
+  windowDurationMins?: unknown
+  resetsAt?: unknown
+}
+
+export type CodexRpcRateLimits = {
+  primary?: CodexRpcRateWindow | null
+  secondary?: CodexRpcRateWindow | null
+}
+
+type MappableCodexRpcRateWindow = CodexRpcRateWindow & { usedPercent: number }
+type CodexRateLimitWindowKind = 'session' | 'weekly' | null
+
+function isMappableCodexRpcRateWindow(
+  raw: CodexRpcRateWindow | null | undefined
+): raw is MappableCodexRpcRateWindow {
+  return typeof raw?.usedPercent === 'number' && Number.isFinite(raw.usedPercent)
+}
+
+function classifyWindowDuration(raw: MappableCodexRpcRateWindow): CodexRateLimitWindowKind {
+  const duration = raw.windowDurationMins
+  if (typeof duration !== 'number' || !Number.isFinite(duration)) {
+    return null
+  }
+  if (
+    Math.abs(duration - CODEX_SESSION_WINDOW_MINUTES) <= CODEX_WINDOW_DURATION_TOLERANCE_MINUTES
+  ) {
+    return 'session'
+  }
+  if (Math.abs(duration - CODEX_WEEKLY_WINDOW_MINUTES) <= CODEX_WINDOW_DURATION_TOLERANCE_MINUTES) {
+    return 'weekly'
+  }
+  return null
+}
+
+export function classifyCodexRateLimitWindows(result: CodexRpcRateLimits | null | undefined): {
+  session: MappableCodexRpcRateWindow | null
+  weekly: MappableCodexRpcRateWindow | null
+} {
+  const primary = isMappableCodexRpcRateWindow(result?.primary) ? result.primary : null
+  const secondary = isMappableCodexRpcRateWindow(result?.secondary) ? result.secondary : null
+  let session: MappableCodexRpcRateWindow | null = null
+  let weekly: MappableCodexRpcRateWindow | null = null
+
+  for (const window of [primary, secondary]) {
+    if (!window) {
+      continue
+    }
+    const kind = classifyWindowDuration(window)
+    if (kind === 'session' && !session) {
+      session = window
+    } else if (kind === 'weekly' && !weekly) {
+      weekly = window
+    }
+  }
+
+  // Why: unknown app-server durations retain Orca's legacy primary/session and secondary/weekly mapping.
+  if (!session && primary && classifyWindowDuration(primary) === null) {
+    session = primary
+  }
+  if (!weekly && secondary && classifyWindowDuration(secondary) === null) {
+    weekly = secondary
+  }
+
+  return { session, weekly }
+}


### PR DESCRIPTION
## Summary

- classify Codex RPC rate-limit windows by `windowDurationMins` instead of assuming `primary` is always the 5-hour bucket and `secondary` is always the weekly bucket
- keep weekly-only plans out of the 5-hour UI slot when Codex returns the weekly window as `primary` with `secondary: null`
- retain the legacy positional fallback for older or unknown window lengths while allowing explicit known durations to take precedence

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — every constituent gate passed when run directly, including source-wide Oxlint, type-aware switch exhaustiveness, styled-scrollbar, reliability, max-lines, bundled-skill, localization catalog, and localization coverage checks. The aggregate local command hung in its nested `pnpm run lint:switch-exhaustiveness` launcher; the exact type-aware Oxlint command passed in 1.4 seconds when invoked directly.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused rate-limit suite passed (19 tests). The first full run completed with 34,785 tests passing and one unrelated packaging-contract failure because the local install lacked the declared optional `windows-native-registry` package. After a repo-local frozen reinstall, all three affected files passed (50 tests). A second full run later hung in the existing terminal-attribution fixture when its temporary Git wrapper recursively invoked itself, so the aggregate suite is not marked green.
- [ ] `pnpm build` — relay binaries for macOS/Linux/Windows/WSL, CLI, Electron main/preload/renderer, web bundle verification, and macOS native helpers all passed when run directly. The aggregate local command hung before the bundler in its nested `pnpm run build:desktop` launcher.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional checks:

- changed-file Oxlint and Oxfmt passed
- `git diff --check` passed
- max-lines ratchet passed with no new bypasses
- production build emitted only existing chunking and CSS `::highlight` warnings

## AI Review Report

The review focused on protocol semantics, nullability, reordered windows, weekly-only plans, unknown-duration backward compatibility, malformed numeric input, and whether a known bucket could be duplicated into both UI slots. The reviewer initially questioned whether `windowDurationMins` meant remaining time; that concern was resolved against the current Codex app-server protocol implementation and documentation, which define it as the quota-window duration. No actionable correctness findings remained after that verification.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows, including WSL and SSH. This change only normalizes app-server JSON in the main process. It adds no shortcut, label, path, shell command, native dependency, Electron IPC contract, or provider-specific behavior, so all targets use the same mapping logic.

## Security Audit

- no authentication token, account credential, filesystem path, command execution, dependency, IPC, or persistence surface changes
- malformed or non-finite `usedPercent` values continue to fail closed instead of producing a rate-limit window
- `windowDurationMins` is used only to choose a display bucket; it does not authorize account switching, reset-credit use, or any provider mutation
- unknown durations retain the prior positional behavior to avoid turning an app-server version mismatch into a hidden availability regression

## Notes

- Codex app-server documents `windowDurationMins` as the quota-window length, and the protocol implementation maps the core `window_minutes` field directly: https://github.com/openai/codex/blob/4462b9deef211723b781b426f5e5d36a5777115f/codex-rs/app-server/README.md and https://github.com/openai/codex/blob/4462b9deef211723b781b426f5e5d36a5777115f/codex-rs/app-server-protocol/src/protocol/v2/account.rs
- weekly-only `primary` responses have also been reported upstream: https://github.com/openai/codex/issues/32707
- this is a small correctness prerequisite for account exhaustion UX; it does not add automatic account failover, restart sessions, replay prompts, or change the mobile account-switch/reset-credit feature in #9394
