### PR TITLE
feat(mobile): show Claude Fable weekly usage in account usage bars

### DIFF
--- a/mobile/app/h/[hostId]/accounts.tsx
+++ b/mobile/app/h/[hostId]/accounts.tsx
@@ -203,6 +203,7 @@ export default function AccountsScreen() {
     const activeSessionBar = getUsageBarState(activeUsage, 'session')
     const activeWeeklyBar = getUsageBarState(activeUsage, 'weekly')
     const resetCredit = provider === 'codex' ? getCodexResetCreditSummary(activeUsage, now) : null
+    const activeFableBar = getUsageBarState(activeUsage, 'fableWeekly')
     const Icon = provider === 'claude' ? ClaudeIcon : OpenAIIcon
     return (
       <View style={styles.section}>
@@ -239,6 +240,15 @@ export default function AccountsScreen() {
                     loading={activeWeeklyBar.loading}
                     resetText={getWindowResetLabel(activeUsage, 'weekly', now)}
                   />
+                  {activeUsage?.fableWeekly != null ? (
+                    <UsageBar
+                      label="Fable"
+                      usedPercent={activeFableBar.usedPercent}
+                      unavailable={activeFableBar.unavailable}
+                      loading={activeFableBar.loading}
+                      resetText={getWindowResetLabel(activeUsage, 'fableWeekly', now)}
+                    />
+                  ) : null}
                 </View>
               ) : null}
             </View>
@@ -262,6 +272,7 @@ export default function AccountsScreen() {
               (!isActive && inactiveEntry?.isFetching === true)
             const sessionBar = getUsageBarState(usage, 'session', isFetching)
             const weeklyBar = getUsageBarState(usage, 'weekly', isFetching)
+            const fableBar = getUsageBarState(usage, 'fableWeekly', isFetching)
             return (
               <View key={account.id}>
                 <View style={styles.separator} />
@@ -294,6 +305,15 @@ export default function AccountsScreen() {
                         loading={weeklyBar.loading}
                         resetText={getWindowResetLabel(usage, 'weekly', now)}
                       />
+                      {usage?.fableWeekly != null ? (
+                        <UsageBar
+                          label="Fable"
+                          usedPercent={fableBar.usedPercent}
+                          unavailable={fableBar.unavailable}
+                          loading={fableBar.loading}
+                          resetText={getWindowResetLabel(usage, 'fableWeekly', now)}
+                        />
+                      ) : null}
                     </View>
                     {usage?.error ? (
                       <Text style={styles.errorText} numberOfLines={1}>

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -900,6 +900,7 @@ export default function HomeScreen() {
                           }
                           const sessionBar = getUsageBarState(limits, 'session')
                           const weeklyBar = getUsageBarState(limits, 'weekly')
+                          const fableBar = getUsageBarState(limits, 'fableWeekly')
                           return (
                             <View key={provider} style={styles.accountsRow}>
                               <View style={styles.accountsIcon}>
@@ -926,6 +927,14 @@ export default function HomeScreen() {
                                     unavailable={weeklyBar.unavailable}
                                     loading={weeklyBar.loading}
                                   />
+                                  {limits?.fableWeekly != null ? (
+                                    <UsageBar
+                                      label="Fable"
+                                      usedPercent={fableBar.usedPercent}
+                                      unavailable={fableBar.unavailable}
+                                      loading={fableBar.loading}
+                                    />
+                                  ) : null}
                                 </View>
                               </View>
                             </View>

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -76,9 +76,19 @@ export function UsageBar({
         )}
       </View>
       {resetText ? (
-        <Text style={styles.usageResetText} numberOfLines={1}>
-          {resetText}
-        </Text>
+        <View style={styles.usageBar}>
+          {/* Why: invisible copy of the label reserves its exact width, so the countdown stays aligned with the track for any label ("7d" or "Fable"). */}
+          <Text
+            style={[styles.usageLabel, styles.usageResetSpacer]}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+          >
+            {label}
+          </Text>
+          <Text style={styles.usageResetText} numberOfLines={1}>
+            {resetText}
+          </Text>
+        </View>
       ) : null}
     </View>
   )
@@ -122,9 +132,11 @@ const styles = StyleSheet.create({
   },
   // Why: indented past the window label so the countdown aligns with the
   // start of the track above it.
+  usageResetSpacer: {
+    opacity: 0
+  },
   usageResetText: {
     fontSize: typography.metaSize,
-    color: colors.textMuted,
-    marginLeft: 22 + spacing.xs
+    color: colors.textMuted
   }
 })

--- a/mobile/src/components/AccountUsage.tsx
+++ b/mobile/src/components/AccountUsage.tsx
@@ -97,7 +97,8 @@ const styles = StyleSheet.create({
   usageLabel: {
     fontSize: typography.metaSize,
     color: colors.textMuted,
-    width: 22
+    // Why: minWidth keeps the short 5h/7d columns aligned while letting the wider Fable label take its natural width instead of wrapping.
+    minWidth: 22
   },
   usageTrack: {
     flex: 1,

--- a/mobile/src/components/account-usage-state.test.ts
+++ b/mobile/src/components/account-usage-state.test.ts
@@ -208,4 +208,47 @@ describe('getUsageBarState', () => {
       loading: true
     })
   })
+
+  it('reads the Claude Fable weekly window', () => {
+    const bar = getUsageBarState(
+      makeLimits({
+        status: 'ok',
+        fableWeekly: {
+          usedPercent: 37,
+          windowMinutes: 10_080,
+          resetsAt: null,
+          resetDescription: null
+        }
+      }),
+      'fableWeekly'
+    )
+
+    expect(bar).toEqual({ usedPercent: 37, unavailable: false, loading: false })
+  })
+
+  it('reports the Fable window unavailable when the host omits it', () => {
+    expect(getUsageBarState(makeLimits({ status: 'ok' }), 'fableWeekly')).toEqual({
+      usedPercent: null,
+      unavailable: true,
+      loading: false
+    })
+  })
+})
+
+describe('hasActiveProviderUsage with fableWeekly only', () => {
+  it('treats a Fable-only payload as renderable usage', () => {
+    expect(
+      hasActiveProviderUsage(
+        makeLimits({
+          status: 'error',
+          fableWeekly: {
+            usedPercent: 5,
+            windowMinutes: 10_080,
+            resetsAt: null,
+            resetDescription: null
+          }
+        })
+      )
+    ).toBe(true)
+  })
 })

--- a/mobile/src/components/account-usage-state.ts
+++ b/mobile/src/components/account-usage-state.ts
@@ -26,6 +26,8 @@ export {
   type RateLimitWindow
 } from './accounts-snapshot'
 
+export type UsageWindowKey = 'session' | 'weekly' | 'fableWeekly'
+
 export type ProviderKey = 'claude' | 'codex'
 
 export type UsageBarState = {
@@ -65,6 +67,7 @@ export function hasActiveProviderUsage(limits: ProviderRateLimits | null): boole
   if (
     limits.session != null ||
     limits.weekly != null ||
+    limits.fableWeekly != null ||
     limits.monthly != null ||
     (limits.buckets && limits.buckets.length > 0)
   ) {
@@ -77,7 +80,7 @@ export function hasActiveProviderUsage(limits: ProviderRateLimits | null): boole
 // is per window rather than per provider status.
 export function getUsageBarState(
   limits: ProviderRateLimits | null,
-  windowKey: 'session' | 'weekly',
+  windowKey: UsageWindowKey,
   isFetchingOverride?: boolean
 ): UsageBarState {
   const window = limits?.[windowKey] ?? null
@@ -101,7 +104,7 @@ export function getUsageBarState(
  */
 export function getWindowResetLabel(
   limits: ProviderRateLimits | null,
-  windowKey: 'session' | 'weekly',
+  windowKey: UsageWindowKey,
   now: number
 ): string | null {
   const resetsAt = limits?.[windowKey]?.resetsAt


### PR DESCRIPTION
## Summary

The desktop app surfaces the Claude Fable weekly usage window (status-bar meter, tooltip, account switcher), but the iOS app never showed it — mobile's local mirror of `ProviderRateLimits` predates the `fableWeekly` field, so the data the host already sends over `accounts.list` / `accounts.subscribe` was silently dropped on the phone.

This PR adds the Fable weekly bar to both mobile usage surfaces:

- **Home screen → Account Usage card**: a third `Fable` bar next to `5h` / `7d`.
- **Host → Accounts screen**: the same bar with a reset countdown, on the system-default row, active accounts, and inactive accounts.

The bar renders only when the host reports a `fableWeekly` window, so older hosts and accounts without Fable access are unaffected (no empty placeholder). `hasActiveProviderUsage` now also counts a Fable-only payload as renderable so the row can't vanish for an account whose only populated window is Fable.

No protocol change: the payload already carried the field; this is purely the mobile type mirror, selector, and rendering.

## Screenshots

Captured on the iOS simulator paired to a dev host with a real Claude account (Fable at 47%): home Account Usage card and the host Accounts screen, posted in a comment below (evidence images are hosted as fork release assets per contributor guidelines).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (desktop suite not run — change is mobile-only; `mobile: pnpm test` full suite passes, 2,294 tests)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions: new `getUsageBarState` cases for the `fableWeekly` window (present, and absent → unavailable) and a `hasActiveProviderUsage` case for a Fable-only payload

Also ran `mobile: pnpm lint` (oxlint) — clean, including the session-route max-lines caps.

## AI Review Report

Reviewed with Claude Code. Risks checked: type-mirror drift (mobile deliberately re-declares the shared `ProviderRateLimits` shape — the new optional `fableWeekly` field matches `src/shared/rate-limit-types.ts` including nullability), backwards compatibility with older hosts (field is optional; bar is conditionally rendered only when non-null, and `getUsageBarState` treats absence as unavailable), stale-data behavior during transient errors (unchanged — same window-level staleness rules as session/weekly), and layout regression (the fixed 22px label width wrapped the wider "Fable" label; switched to `minWidth` so 5h/7d columns stay aligned while Fable takes natural width — verified in the simulator). Cross-platform: change is entirely in the React Native mobile app; no shortcuts, paths, shells, or Electron surfaces touched. Desktop and non-Claude providers are unaffected (codex/gemini/etc. never populate `fableWeekly`). SSH/remote: usage data originates host-side and flows over the existing E2EE RPC — no local-only assumption added.

## Security Audit

No new input handling, command execution, path handling, auth, or secrets. No IPC/RPC surface change — the mobile app renders a field the host already included in the existing authenticated `accounts.list` / `accounts.subscribe` payloads. No new dependencies.

## Notes

- Older hosts that predate `fableWeekly` simply never trigger the bar — no update coupling.
- Follow-up candidate (out of scope): the desktop status-bar chip also gained a used/remaining preference (#7574); the mobile bars always show used %, matching the current mobile convention.

## ELI5

Desktop shows Claude Fable weekly usage; mobile dropped that field and never drew the bar. Mobile Account Usage and related surfaces now show the Fable weekly window next to the other meters.
