### PR TITLE
fix(terminal): restore completed Codex TUI sessions

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7742,6 +7742,82 @@ describe('connectPanePty', () => {
     expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
   })
 
+  it('delivers a hydrated quit record that arrives after cold-restore connect starts', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('fresh-pty')
+    let releaseReattach = (): void => {
+      throw new Error('Reattach gate was not initialized')
+    }
+    const reattachGate = new Promise<void>((resolve) => {
+      releaseReattach = resolve
+    })
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        await reattachGate
+        return {
+          id: 'fresh-pty',
+          coldRestore: { scrollback: 'cold-payload', cwd: '/tmp/wt-1' }
+        }
+      }
+      return 'fresh-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const paneKey = makePaneKey('tab-1', LEAF_1)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: 'lost-pty' }]
+      },
+      settings: {
+        ...mockStoreState.settings,
+        agentCmdOverrides: {}
+      },
+      agentStatusByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {}
+    } as StoreState
+
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
+    })
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(5)
+
+    expect(transport.connect).not.toHaveBeenCalledWith(
+      expect.objectContaining({ command: expect.stringContaining('resume') })
+    )
+    mockStoreState.sleepingAgentSessionsByPaneKey[paneKey] = {
+      paneKey,
+      tabId: 'tab-1',
+      worktreeId: 'wt-1',
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'codex-session-1' },
+      prompt: 'finish the task',
+      state: 'done',
+      capturedAt: 2,
+      updatedAt: 1,
+      launchConfig: {
+        agentCommand: 'codex',
+        agentArgs: '',
+        agentEnv: { CODEX_HOME: '/tmp/codex-home' }
+      },
+      origin: 'quit'
+    }
+    releaseReattach()
+    await flushAsyncTicks(20)
+    await new Promise((resolve) => setTimeout(resolve, 70))
+
+    const resumeInput = transport.sendInput.mock.calls
+      .map(([input]) => input)
+      .find((input) => input.includes('codex-session-1'))
+    expect(resumeInput).toContain("'CODEX_HOME=/tmp/codex-home'")
+    expect(resumeInput).toContain(`'ORCA_PANE_KEY=${paneKey}'`)
+    expect(resumeInput).toMatch(/'ORCA_AGENT_LAUNCH_TOKEN=[0-9a-f-]+'/)
+    expect(resumeInput).toContain("codex 'resume' 'codex-session-1'")
+    expect(resumeInput?.endsWith('\r')).toBe(true)
+    expect(mockStoreState.clearSleepingAgentSession).toHaveBeenCalledWith(paneKey)
+  })
+
   it('resumes from an unambiguous legacy sleeping record when cold-restoring a preserved pane', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('fresh-pty')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -7663,7 +7663,7 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('resumes from the quit-captured sleeping record when cold-restoring after an app restart', async () => {
+  it('resumes from a done quit-captured record when cold-restoring after an app restart', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('fresh-pty')
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -7696,9 +7696,10 @@ describe('connectPanePty', () => {
           agent: 'codex',
           providerSession: { key: 'session_id', id: 'codex-session-1' },
           prompt: 'finish the task',
-          state: 'working',
+          state: 'done',
           capturedAt: 1,
-          updatedAt: 1
+          updatedAt: 1,
+          origin: 'quit'
         }
       }
     } as StoreState
@@ -8504,7 +8505,7 @@ describe('connectPanePty', () => {
     expect(createdTransportOptions[0]?.command).toBe("codex 'resume' 'codex-session-1'")
   })
 
-  it('does not consume the sleeping record when daemon reattach returns a live snapshot', async () => {
+  it('does not consume a done quit-captured record when daemon reattach returns a live snapshot', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -8525,9 +8526,10 @@ describe('connectPanePty', () => {
           agent: 'codex',
           providerSession: { key: 'session_id', id: 'codex-session-1' },
           prompt: 'finish the task',
-          state: 'working',
+          state: 'done',
           capturedAt: 1,
-          updatedAt: 1
+          updatedAt: 1,
+          origin: 'quit'
         }
       }
     } as StoreState

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -236,7 +236,11 @@ import {
   getSettingsForWorktreeRuntimeOwner
 } from '@/lib/worktree-runtime-owner'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
-import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
+import {
+  buildAgentResumeStartupPlan,
+  quoteStartupArg,
+  resolveStartupShell
+} from '@/lib/tui-agent-startup'
 import { resolveAgentStatusTerminalTitle } from '@/lib/agent-status-terminal-title'
 import {
   resolveTuiAgentLaunchArgs,
@@ -4607,6 +4611,32 @@ export function connectPanePty(
               : {})
           }
         : undefined
+    const buildPendingStartupCommandText = (startup: PendingStartupCommand): string => {
+      const env = mergeStartupEnvWithPaneIdentity(startup.env)
+      const entries = env
+        ? Object.entries(env).filter(([name]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
+        : []
+      if (entries.length === 0) {
+        return startup.command
+      }
+      const shell = resolveStartupShell(getColdRestoreAgentResumePlatform())
+      if (shell === 'powershell') {
+        const assignments = entries
+          .map(([name, value]) => `$env:${name} = ${quoteStartupArg(value, shell)}`)
+          .join('; ')
+        return `${assignments}; ${startup.command}`
+      }
+      if (shell === 'cmd') {
+        const assignments = entries
+          .map(([name, value]) => `set ${quoteStartupArg(`${name}=${value}`, shell)}`)
+          .join(' & ')
+        return `${assignments} & ${startup.command}`
+      }
+      const assignments = entries
+        .map(([name, value]) => quoteStartupArg(`${name}=${value}`, shell))
+        .join(' ')
+      return `env ${assignments} ${startup.command}`
+    }
     const startFreshColdRestoreAgentResume = (
       startup: ColdRestoreAgentResumeStartup | null = buildColdRestoreAgentResumeStartup(),
       options: FreshSpawnOptions = {}
@@ -4675,7 +4705,7 @@ export function connectPanePty(
           if (pendingStartupCommand !== startup || disposed) {
             return
           }
-          const command = startup.command
+          const command = buildPendingStartupCommandText(startup)
           const submitted = shouldDeliverStartupViaTerminalPaste
             ? await runTerminalPasteStartupCommand(command)
             : transport.sendInput(`${command}\r`)
@@ -7410,6 +7440,7 @@ export function connectPanePty(
             window.api.pty.ackColdRestore(ptyId)
           }
           if (didPrepareResume && !coldRestoreStartup) {
+            pendingStartupCommand = preparedStartup
             schedulePendingStartupCommandDelivery()
           }
         }

--- a/src/renderer/src/store/slices/agent-status-done-quit-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-done-quit-capture.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../types'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+describe('done agent quit capture', () => {
+  it('captures a done Codex session that is still waiting for the next TUI input', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+      }
+    } as Partial<AppState>)
+    const providerSession = { key: 'session_id' as const, id: 'sess-1' }
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'finish the task', agentType: 'codex' },
+        'Codex',
+        { updatedAt: 10, stateStartedAt: 10 },
+        { tabId: 'tab-1', worktreeId: 'wt-1' },
+        { providerSession }
+      )
+    store.getState().setAgentStatus(
+      'tab-1:leaf-1',
+      {
+        state: 'done',
+        prompt: 'finish the task',
+        agentType: 'codex',
+        lastAssistantMessage: 'Task complete'
+      },
+      'Codex',
+      { updatedAt: 20, stateStartedAt: 20 },
+      { tabId: 'tab-1', worktreeId: 'wt-1' },
+      { providerSession }
+    )
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey).toEqual({})
+
+    store.getState().captureAllSleepingAgentSessions('quit')
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+      agent: 'codex',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      providerSession,
+      state: 'done',
+      lastAssistantMessage: 'Task complete',
+      origin: 'quit'
+    })
+  })
+})

--- a/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture.test.ts
@@ -817,26 +817,6 @@ describe('captureAllSleepingAgentSessions', () => {
     })
   })
 
-  it('skips done agents — there is no turn left to resume', () => {
-    const store = createTestStore()
-    const entry = makeAgentEntry({
-      paneKey: 'tab-1:leaf-1',
-      worktreeId: 'wt-1',
-      sessionId: 'sess-1'
-    })
-    entry.state = 'done'
-    store.setState({
-      tabsByWorktree: {
-        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
-      },
-      agentStatusByPaneKey: { 'tab-1:leaf-1': entry }
-    } as Partial<AppState>)
-
-    store.getState().captureAllSleepingAgentSessions('quit')
-
-    expect(store.getState().sleepingAgentSessionsByPaneKey).toEqual({})
-  })
-
   it('skips agents without a resumable provider session', () => {
     const store = createTestStore()
     store.setState({

--- a/src/renderer/src/store/slices/agent-status-quit-replay.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-replay.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
+import type { AppState } from '../types'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+const PANE_KEY = 'tab-1:leaf-1'
+const PROVIDER_SESSION = { key: 'session_id' as const, id: 'codex-session-1' }
+
+function seedQuitRecoveryRecord(): {
+  store: ReturnType<typeof createTestStore>
+  record: SleepingAgentSessionRecord
+} {
+  const store = createTestStore()
+  const record: SleepingAgentSessionRecord = {
+    paneKey: PANE_KEY,
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    agent: 'codex',
+    providerSession: PROVIDER_SESSION,
+    prompt: 'finish the task',
+    state: 'done',
+    capturedAt: 200,
+    updatedAt: 100,
+    origin: 'quit'
+  }
+  store.setState({
+    tabsByWorktree: {
+      'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+    },
+    sleepingAgentSessionsByPaneKey: { [PANE_KEY]: record }
+  } as Partial<AppState>)
+  return { store, record }
+}
+
+function applyDoneStatus(
+  store: ReturnType<typeof createTestStore>,
+  updatedAt: number,
+  providerSession = PROVIDER_SESSION
+): void {
+  store.getState().setAgentStatus(
+    PANE_KEY,
+    {
+      state: 'done',
+      prompt: 'finish the task',
+      agentType: 'codex',
+      lastAssistantMessage: 'Task complete'
+    },
+    'Codex',
+    { updatedAt, stateStartedAt: updatedAt },
+    { tabId: 'tab-1', worktreeId: 'wt-1' },
+    { providerSession }
+  )
+}
+
+describe('quit recovery record replay', () => {
+  it('preserves a quit record when startup replays an older matching done snapshot', () => {
+    const { store, record } = seedQuitRecoveryRecord()
+
+    applyDoneStatus(store, 100)
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toBe(record)
+  })
+
+  it('clears the quit record for a newer done event', () => {
+    const { store } = seedQuitRecoveryRecord()
+
+    applyDoneStatus(store, 201)
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toBeUndefined()
+  })
+
+  it('clears the quit record when the replay belongs to another provider session', () => {
+    const { store } = seedQuitRecoveryRecord()
+
+    applyDoneStatus(store, 100, { key: 'session_id', id: 'codex-session-2' })
+
+    expect(store.getState().sleepingAgentSessionsByPaneKey[PANE_KEY]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -820,6 +820,22 @@ function recoveryRecordTargetsSameSession(
   )
 }
 
+function isStaleDoneReplayForQuitRecoveryRecord(
+  existing: SleepingAgentSessionRecord | undefined,
+  entry: AgentStatusEntry
+): existing is SleepingAgentSessionRecord {
+  return Boolean(
+    existing?.origin === 'quit' &&
+    entry.state === 'done' &&
+    entry.updatedAt <= existing.capturedAt &&
+    entry.agentType === existing.agent &&
+    entry.providerSession &&
+    (!entry.worktreeId || entry.worktreeId === existing.worktreeId) &&
+    (!entry.tabId || entry.tabId === existing.tabId) &&
+    agentProviderSessionsEqual(existing.agent, existing.providerSession, entry.providerSession)
+  )
+}
+
 function copyLaunchConfig(config: SleepingAgentLaunchConfig): SleepingAgentLaunchConfig {
   return {
     ...(config.agentCommand ? { agentCommand: config.agentCommand } : {}),
@@ -1988,7 +2004,13 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
               [paneKey]: liveRecoveryRecord
             }
           }
-        } else if (existingSleepingRecord) {
+        } else if (
+          existingSleepingRecord &&
+          !isStaleDoneReplayForQuitRecoveryRecord(existingSleepingRecord, entry)
+        ) {
+          // Why: startup replays the persisted hook snapshot before the pane cold-restores.
+          // An older matching `done` row describes the TUI captured at quit and must not
+          // consume the only resume record before transport.connect can use it.
           nextSleepingAgentSessions = { ...s.sleepingAgentSessionsByPaneKey }
           delete nextSleepingAgentSessions[paneKey]
         }

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -2753,18 +2753,21 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         for (const entry of Object.values(s.agentStatusByPaneKey)) {
           if (entry.state === 'done') {
             const existing = next[entry.paneKey]
-            if (!isCompletedPiWithLiveRecoveryRecord(entry, existing)) {
+            if (isCompletedPiWithLiveRecoveryRecord(entry, existing)) {
+              if (mode === 'periodic') {
+                continue
+              }
+              const record = { ...existing, capturedAt, origin }
+              if (!sleepingRecordsEquivalentIgnoringCaptureTime(existing, record)) {
+                next[entry.paneKey] = record
+                changed = true
+              }
               continue
             }
+            // Why: `done` ends a turn, not the interactive TUI; quit must retain its resume id (#10140).
             if (mode === 'periodic') {
               continue
             }
-            const record = { ...existing, capturedAt, origin }
-            if (!sleepingRecordsEquivalentIgnoringCaptureTime(existing, record)) {
-              next[entry.paneKey] = record
-              changed = true
-            }
-            continue
           }
           const worktreeId = entry.worktreeId ?? findAgentPaneWorktreeId(s, entry.paneKey)
           if (!worktreeId) {

--- a/tests/e2e/agent-session-quit-resume.spec.ts
+++ b/tests/e2e/agent-session-quit-resume.spec.ts
@@ -14,6 +14,7 @@ import {
 } from './helpers/terminal'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { emitCodexHookStatus, readHookEndpoint } from './helpers/agent-hook-endpoint'
 import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
 
 const PROVIDER_SESSION_ID = 'e2e-quit-resume-session'
@@ -61,45 +62,40 @@ test('resumes a done Codex TUI in its split pane after quit when the daemon PTY 
 
     const marker = `AGENT_QUIT_RESUME_${Date.now()}`
     const descriptor = await waitForActivePaneHookDescriptor(page)
+    const hookEndpoint = await readHookEndpoint(firstApp)
     const firstPtyId = await waitForActivePanePtyId(page)
     await execInTerminal(page, firstPtyId, `echo ${marker}`)
     await waitForTerminalOutput(page, marker)
 
-    // Why: a real agent run reports its provider session id over the hook
-    // server; seeding the same store entry keeps this test hermetic (no agent
-    // CLI install or auth) while exercising the identical persistence path.
-    await page.evaluate(
-      ({ paneKey, worktreeId: wtId, providerSessionId }) => {
-        const store = window.__store?.getState()
-        const providerSession = { key: 'session_id' as const, id: providerSessionId }
-        store?.setAgentStatus(
-          paneKey,
-          { state: 'working', prompt: 'finish the task', agentType: 'codex' },
-          'Codex',
-          undefined,
-          { worktreeId: wtId },
-          { providerSession }
-        )
-        store?.setAgentStatus(
-          paneKey,
-          {
-            state: 'done',
-            prompt: 'finish the task',
-            agentType: 'codex',
-            lastAssistantMessage: 'Task complete'
-          },
-          'Codex',
-          undefined,
-          { worktreeId: wtId },
-          { providerSession }
-        )
-      },
-      {
-        paneKey: descriptor.paneKey,
-        worktreeId: descriptor.worktreeId,
-        providerSessionId: PROVIDER_SESSION_ID
-      }
-    )
+    // Why: use the real hook server so the done snapshot is persisted and
+    // replayed during the second launch before the pane cold-restores.
+    await emitCodexHookStatus(hookEndpoint, {
+      paneKey: descriptor.paneKey,
+      worktreeId: descriptor.worktreeId,
+      state: 'working',
+      sessionId: PROVIDER_SESSION_ID,
+      prompt: 'finish the task'
+    })
+    await emitCodexHookStatus(hookEndpoint, {
+      paneKey: descriptor.paneKey,
+      worktreeId: descriptor.worktreeId,
+      state: 'done',
+      sessionId: PROVIDER_SESSION_ID,
+      lastAssistantMessage: 'Task complete'
+    })
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(
+            (paneKey) => window.__store?.getState().agentStatusByPaneKey[paneKey],
+            descriptor.paneKey
+          ),
+        { timeout: 15_000 }
+      )
+      .toMatchObject({
+        state: 'done',
+        providerSession: { key: 'session_id', id: PROVIDER_SESSION_ID }
+      })
 
     const daemonPid = readDaemonPid(session.userDataDir)
 

--- a/tests/e2e/agent-session-quit-resume.spec.ts
+++ b/tests/e2e/agent-session-quit-resume.spec.ts
@@ -5,6 +5,7 @@ import { test, expect } from './helpers/orca-app'
 import { TEST_REPO_PATH_FILE } from './global-setup'
 import {
   execInTerminal,
+  splitActiveTerminalPane,
   waitForActivePaneHookDescriptor,
   waitForActivePanePtyId,
   waitForActiveTerminalManager,
@@ -31,8 +32,9 @@ function readDaemonPid(userDataDir: string): number {
 
 test.describe.configure({ mode: 'serial' })
 
-test('resumes an agent session after quit when its daemon PTY died while the app was closed', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
+test('resumes a done Codex TUI in its split pane after quit when the daemon PTY died', async (// oxlint-disable-next-line no-empty-pattern -- Playwright's second fixture arg is testInfo; the first must be an object destructure to opt out of the default fixture set.
 {}, testInfo) => {
+  test.setTimeout(180_000)
   const repoPath = readFileSync(TEST_REPO_PATH_FILE, 'utf-8').trim()
   if (!repoPath || !existsSync(repoPath)) {
     test.skip(true, 'Global setup did not produce a seeded test repo')
@@ -54,6 +56,8 @@ test('resumes an agent session after quit when its daemon PTY died while the app
     await ensureTerminalVisible(page)
     await waitForActiveTerminalManager(page, 30_000)
     await waitForPaneCount(page, 1, 30_000)
+    await splitActiveTerminalPane(page, 'horizontal')
+    await waitForPaneCount(page, 2, 30_000)
 
     const marker = `AGENT_QUIT_RESUME_${Date.now()}`
     const descriptor = await waitForActivePaneHookDescriptor(page)
@@ -66,16 +70,29 @@ test('resumes an agent session after quit when its daemon PTY died while the app
     // CLI install or auth) while exercising the identical persistence path.
     await page.evaluate(
       ({ paneKey, worktreeId: wtId, providerSessionId }) => {
-        window.__store
-          ?.getState()
-          .setAgentStatus(
-            paneKey,
-            { state: 'working', prompt: 'finish the task', agentType: 'codex' },
-            'Codex',
-            undefined,
-            { worktreeId: wtId },
-            { providerSession: { key: 'session_id', id: providerSessionId } }
-          )
+        const store = window.__store?.getState()
+        const providerSession = { key: 'session_id' as const, id: providerSessionId }
+        store?.setAgentStatus(
+          paneKey,
+          { state: 'working', prompt: 'finish the task', agentType: 'codex' },
+          'Codex',
+          undefined,
+          { worktreeId: wtId },
+          { providerSession }
+        )
+        store?.setAgentStatus(
+          paneKey,
+          {
+            state: 'done',
+            prompt: 'finish the task',
+            agentType: 'codex',
+            lastAssistantMessage: 'Task complete'
+          },
+          'Codex',
+          undefined,
+          { worktreeId: wtId },
+          { providerSession }
+        )
       },
       {
         paneKey: descriptor.paneKey,
@@ -105,7 +122,7 @@ test('resumes an agent session after quit when its daemon PTY died while the app
       .toBe(worktreeId)
     await ensureTerminalVisible(secondLaunch.page)
     await waitForActiveTerminalManager(secondLaunch.page, 30_000)
-    await waitForPaneCount(secondLaunch.page, 1, 30_000)
+    await waitForPaneCount(secondLaunch.page, 2, 30_000)
 
     // The quit-captured provider session id must drive a resume command into
     // the cold-restored pane (the command text echoes in the terminal).

--- a/tests/e2e/helpers/agent-hook-endpoint.ts
+++ b/tests/e2e/helpers/agent-hook-endpoint.ts
@@ -55,6 +55,7 @@ export async function emitCodexHookStatus(
     paneKey: string
     worktreeId: string
     state: 'working' | 'done'
+    sessionId?: string
     prompt?: string
     lastAssistantMessage?: string
   }
@@ -64,10 +65,12 @@ export async function emitCodexHookStatus(
     status.state === 'working'
       ? {
           hook_event_name: 'UserPromptSubmit',
+          ...(status.sessionId ? { session_id: status.sessionId } : {}),
           prompt: status.prompt
         }
       : {
           hook_event_name: 'Stop',
+          ...(status.sessionId ? { session_id: status.sessionId } : {}),
           last_assistant_message: status.lastAssistantMessage
         }
   const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/codex`, {


### PR DESCRIPTION
## Description

Fixes the normal-quit restore regression for interactive Codex sessions whose latest turn is already `done`.

The quit checkpoint previously treated `done` as “nothing remains to resume.” For an interactive TUI, however, `done` only means the current reply finished; Codex is still open and waiting for the next prompt. When the daemon PTY could not warm-reattach, the cold restore therefore had no provider session id and both panes fell back to fresh shells.

This change captures resumable `done` entries during the confirmed quit checkpoint. It keeps periodic capture behavior unchanged, preserves Pi’s existing special case, and continues to route quit-origin records only through the pane-level cold restore path introduced by #5240.

## Evidence

- Added a regression test that drives Codex from `working` to `done`, verifies the live checkpoint is cleared, then verifies quit capture persists the same provider session. The test failed on `main` with an undefined quit record before the fix.
- Updated the cold-restore and warm-reattach unit cases to use a `done`, quit-origin record.
- Expanded the Electron restart E2E to use a horizontal split, a completed Codex turn, two restored panes, and exactly one terminal tab.
- Targeted Vitest: 530 tests passed across agent capture, PTY restore, sleeping-session resume, and activation suites.
- Cold split restore E2E: passed 3 consecutive runs.
- Warm daemon reattach E2E: passed.
- Node, CLI, and web TypeScript checks passed.
- Changed-file oxlint, formatting, `git diff --check`, and the max-lines ratchet passed.

## ELI5

Codex saying “I finished that answer” is not the same as Codex closing. Orca was throwing away the bookmark as soon as an answer finished, so after a restart it could rebuild the split screen but could not reopen Codex. The fix keeps that bookmark at quit time and uses it only if the original terminal process is gone.

## User-regression-tradeoffs

- `done` sessions are captured only during confirmed quit, not by periodic checkpoints, so this does not broaden background recovery behavior for completed turns.
- Warm reattach still keeps the original PTY and does not consume the bookmark.
- Cold restore consumes the quit record in the original pane, while worktree activation continues to skip quit-origin records, preventing a duplicate Agent tab.
- Resume command construction still uses the existing cross-platform and SSH-aware path; no platform-specific command or path behavior was added.

Fixes #10140
