### PR TITLE
perf(renderer): batch dashboard orchestration selection

### DIFF
--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot-orchestration-routing.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot-orchestration-routing.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusOrchestrationContext } from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab, Worktree } from '../../../../shared/types'
+
+const batchMocks = vi.hoisted(() => ({
+  release: vi.fn(),
+  select: vi.fn(() => new Map())
+}))
+
+vi.mock('../sidebar/worktree-agent-orchestration-batch', () => ({
+  EMPTY_WORKTREE_AGENT_ORCHESTRATION: {},
+  releaseRuntimeAgentOrchestrationBatchCache: batchMocks.release,
+  selectRuntimeAgentOrchestrationBatch: batchMocks.select
+}))
+
+import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
+
+function worktree(index: number): Worktree {
+  return {
+    id: `w${index}`,
+    repoId: 'r1',
+    path: `/r1/w${index}`,
+    head: 'abc123',
+    branch: 'main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: `wt-${index}`,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: index,
+    lastActivityAt: 1
+  }
+}
+
+function tab(index: number): TerminalTab {
+  return {
+    id: `tab-${index}`,
+    ptyId: null,
+    worktreeId: `w${index}`,
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function state(
+  worktreeCount: number,
+  runtimeAgentOrchestrationByPaneKey: Record<string, AgentStatusOrchestrationContext>
+): DashboardSnapshotState {
+  const worktrees = Array.from({ length: worktreeCount }, (_, index) => worktree(index))
+  return {
+    repos: [{ id: 'r1', path: '/r1', displayName: 'Repo One', badgeColor: '#000' }],
+    worktreesByRepo: { r1: worktrees },
+    tabsByWorktree: Object.fromEntries(
+      worktrees.map((currentWorktree, index) => [currentWorktree.id, [tab(index)]])
+    ),
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    migrationUnsupportedByPtyId: {},
+    runtimeAgentOrchestrationByPaneKey,
+    terminalLayoutsByTabId: {},
+    ptyIdsByTabId: {},
+    runtimePaneTitlesByTabId: {},
+    acknowledgedAgentsByPaneKey: {}
+  } as unknown as DashboardSnapshotState
+}
+
+describe('buildDashboardSnapshot orchestration routing', () => {
+  beforeEach(() => {
+    batchMocks.release.mockClear()
+    batchMocks.select.mockClear()
+  })
+
+  it('keeps the production singleton on one legacy runtime pass', () => {
+    const contextCount = 8
+    let runtimeEnumerations = 0
+    let runtimeValueReads = 0
+    let contextVisits = 0
+    const runtimeRecords: Record<string, AgentStatusOrchestrationContext> = {}
+    for (let index = 0; index < contextCount; index += 1) {
+      const paneKey = makePaneKey(
+        'tab-0',
+        `88888888-8888-4888-8888-${index.toString(16).padStart(12, '0')}`
+      )
+      runtimeRecords[paneKey] = {
+        taskId: `task-${index}`,
+        dispatchId: `dispatch-${index}`,
+        get parentPaneKey() {
+          contextVisits += 1
+          return undefined
+        }
+      }
+    }
+    const runtime = new Proxy(runtimeRecords, {
+      ownKeys(target) {
+        runtimeEnumerations += 1
+        return Reflect.ownKeys(target)
+      },
+      get(target, key, receiver) {
+        if (typeof key === 'string' && Object.hasOwn(target, key)) {
+          runtimeValueReads += 1
+        }
+        return Reflect.get(target, key, receiver)
+      }
+    })
+
+    buildDashboardSnapshot(state(1, runtime), 1)
+
+    expect(batchMocks.release).toHaveBeenCalledOnce()
+    expect(batchMocks.select).not.toHaveBeenCalled()
+    expect({ runtimeEnumerations, runtimeValueReads, contextVisits }).toEqual({
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount
+    })
+  })
+
+  it('releases batch state without reading runtime when no worktree is active', () => {
+    const runtime = new Proxy<Record<string, AgentStatusOrchestrationContext>>(
+      {},
+      {
+        ownKeys() {
+          throw new Error('zero-worktree build must not enumerate runtime')
+        }
+      }
+    )
+
+    buildDashboardSnapshot(state(0, runtime), 1)
+
+    expect(batchMocks.release).toHaveBeenCalledOnce()
+    expect(batchMocks.select).not.toHaveBeenCalled()
+  })
+
+  it('uses the explicit batch only when at least two worktrees are active', () => {
+    const currentState = state(2, {})
+
+    buildDashboardSnapshot(currentState, 1)
+
+    expect(batchMocks.release).not.toHaveBeenCalled()
+    expect(batchMocks.select).toHaveBeenCalledOnce()
+    expect(batchMocks.select).toHaveBeenCalledWith(currentState, ['w0', 'w1'])
+  })
+})

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { buildDashboardSnapshot, type DashboardSnapshotState } from './build-dashboard-snapshot'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
-  type AgentStatusEntry
+  type AgentStatusEntry,
+  type AgentStatusOrchestrationContext
 } from '../../../../shared/agent-status-types'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab, Worktree } from '../../../../shared/types'
+import { selectRuntimeAgentOrchestrationBatch } from '../sidebar/worktree-agent-orchestration-batch'
 
 const NOW = 1_000_000_000
 const TAB_ID = 'tab1'
@@ -27,11 +30,11 @@ function entry(overrides: Partial<AgentStatusEntry>): AgentStatusEntry {
   }
 }
 
-function tab(): unknown {
+function tab(id = TAB_ID, worktreeId = 'w1'): TerminalTab {
   return {
-    id: TAB_ID,
+    id,
     ptyId: 'pty1',
-    worktreeId: 'w1',
+    worktreeId,
     title: 'agent',
     customTitle: null,
     color: null,
@@ -40,10 +43,32 @@ function tab(): unknown {
   }
 }
 
+function worktree(id = 'w1', displayName = 'wt-one'): Worktree {
+  return {
+    id,
+    repoId: 'r1',
+    path: `/r1/${id}`,
+    head: 'abc123',
+    branch: 'main',
+    isBare: false,
+    isMainWorktree: false,
+    displayName,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: NOW
+  }
+}
+
 function baseState(overrides: Partial<DashboardSnapshotState>): DashboardSnapshotState {
   return {
     repos: [{ id: 'r1', path: '/r1', displayName: 'Repo One', badgeColor: '#000' }],
-    worktreesByRepo: { r1: [{ id: 'w1', displayName: 'wt-one', isArchived: false }] },
+    worktreesByRepo: { r1: [worktree()] },
     tabsByWorktree: { w1: [tab()] },
     agentStatusByPaneKey: {},
     retainedAgentsByPaneKey: {},
@@ -182,5 +207,124 @@ describe('buildDashboardSnapshot', () => {
     const done = snapshot.cards.find((c) => c.dotState === 'done')
     expect(done).toBeDefined()
     expect(done?.bucket).toBe('idle')
+  })
+
+  it('attaches batched runtime orchestration metadata to dashboard rows', () => {
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        worktreesByRepo: { r1: [worktree(), worktree('w2')] },
+        tabsByWorktree: {
+          w1: [tab()],
+          w2: [tab('tab2', 'w2')]
+        },
+        agentStatusByPaneKey: {
+          [PANE_KEY]: entry({})
+        },
+        runtimeAgentOrchestrationByPaneKey: {
+          [PANE_KEY]: {
+            taskId: 'task-1',
+            dispatchId: 'dispatch-1',
+            taskTitle: 'Batched orchestration task'
+          }
+        }
+      }),
+      NOW
+    )
+
+    expect(snapshot.cards).toHaveLength(1)
+    expect(snapshot.cards[0].task).toBe('Batched orchestration task')
+  })
+
+  it('releases stale batch references when production moves from multi to singleton to zero', () => {
+    const secondLeafId = '77777777-7777-4777-8777-777777777777'
+    const firstPaneKey = makePaneKey('tab-w1', LEAF_ID)
+    const secondPaneKey = makePaneKey('tab-w2', secondLeafId)
+    const runtimeAgentOrchestrationByPaneKey = {
+      [firstPaneKey]: {
+        taskId: 'task-1',
+        dispatchId: 'dispatch-1'
+      },
+      [secondPaneKey]: {
+        taskId: 'task-2',
+        dispatchId: 'dispatch-2'
+      }
+    }
+    const multiState = baseState({
+      worktreesByRepo: { r1: [worktree('w1'), worktree('w2')] },
+      tabsByWorktree: {
+        w1: [tab('tab-w1', 'w1')],
+        w2: [tab('tab-w2', 'w2')]
+      },
+      runtimeAgentOrchestrationByPaneKey
+    })
+    const requested = ['w1', 'w2']
+    const firstBatch = selectRuntimeAgentOrchestrationBatch(multiState, requested)
+    const firstW1 = firstBatch.get('w1')
+
+    buildDashboardSnapshot(
+      baseState({
+        worktreesByRepo: { r1: [worktree('w1')] },
+        tabsByWorktree: multiState.tabsByWorktree,
+        runtimeAgentOrchestrationByPaneKey
+      }),
+      NOW
+    )
+    const afterSingleton = selectRuntimeAgentOrchestrationBatch(multiState, requested)
+    expect(afterSingleton).not.toBe(firstBatch)
+    expect(afterSingleton.get('w1')).not.toBe(firstW1)
+
+    buildDashboardSnapshot(baseState({ repos: [], worktreesByRepo: {} }), NOW)
+    const afterZero = selectRuntimeAgentOrchestrationBatch(multiState, requested)
+    expect(afterZero).not.toBe(afterSingleton)
+    expect(afterZero.get('w1')).not.toBe(afterSingleton.get('w1'))
+  })
+
+  it('scans orchestration runtime once for a dashboard snapshot', () => {
+    const worktreeCount = 24
+    const contextCount = 128
+    let runtimeEnumerations = 0
+    let contextVisits = 0
+    const runtimeRecords: Record<string, AgentStatusOrchestrationContext> = {}
+
+    for (let index = 0; index < contextCount; index += 1) {
+      const paneKey = makePaneKey(
+        `tab-${index % worktreeCount}`,
+        `33333333-3333-4333-8333-${index.toString(16).padStart(12, '0')}`
+      )
+      runtimeRecords[paneKey] = {
+        taskId: `task-${index}`,
+        dispatchId: `dispatch-${index}`,
+        get parentPaneKey() {
+          contextVisits += 1
+          return undefined
+        }
+      }
+    }
+
+    const runtimeAgentOrchestrationByPaneKey = new Proxy(runtimeRecords, {
+      ownKeys(target) {
+        runtimeEnumerations += 1
+        return Reflect.ownKeys(target)
+      }
+    })
+    const worktrees = Array.from({ length: worktreeCount }, (_, index) =>
+      worktree(`w${index}`, `wt-${index}`)
+    )
+    const tabsByWorktree = Object.fromEntries(
+      worktrees.map((worktree, index) => [worktree.id, [tab(`tab-${index}`, worktree.id)]])
+    )
+
+    const snapshot = buildDashboardSnapshot(
+      baseState({
+        worktreesByRepo: { r1: worktrees },
+        tabsByWorktree,
+        runtimeAgentOrchestrationByPaneKey
+      }),
+      NOW
+    )
+
+    expect(snapshot.cards).toEqual([])
+    expect(runtimeEnumerations).toBe(1)
+    expect(contextVisits).toBe(contextCount)
   })
 })

--- a/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
+++ b/src/renderer/src/components/dashboard/build-dashboard-snapshot.ts
@@ -19,6 +19,11 @@ import {
   selectTerminalLayoutsForWorktree
 } from '../sidebar/worktree-agent-row-selectors'
 import {
+  EMPTY_WORKTREE_AGENT_ORCHESTRATION,
+  releaseRuntimeAgentOrchestrationBatchCache,
+  selectRuntimeAgentOrchestrationBatch
+} from '../sidebar/worktree-agent-orchestration-batch'
+import {
   selectLivePtyIdsForWorktree,
   selectRuntimePaneTitlesForWorktree
 } from '../sidebar/worktree-card-status-inputs'
@@ -77,96 +82,119 @@ export function buildDashboardSnapshot(
   now: number
 ): DashboardSnapshot {
   const cards: DashboardCard[] = []
+  const activeWorktrees: {
+    repo: AppState['repos'][number]
+    worktree: AppState['worktreesByRepo'][string][number]
+  }[] = []
 
   for (const repo of state.repos ?? []) {
     for (const worktree of state.worktreesByRepo?.[repo.id] ?? []) {
-      if (worktree.isArchived) {
+      if (!worktree.isArchived) {
+        activeWorktrees.push({ repo, worktree })
+      }
+    }
+  }
+  let singletonOrchestration: ReturnType<typeof selectRuntimeAgentOrchestrationForWorktree> | null =
+    null
+  let orchestrationByWorktree: ReturnType<typeof selectRuntimeAgentOrchestrationBatch> | null = null
+  if (activeWorktrees.length >= 2) {
+    orchestrationByWorktree = selectRuntimeAgentOrchestrationBatch(
+      state,
+      activeWorktrees.map(({ worktree }) => worktree.id)
+    )
+  } else {
+    releaseRuntimeAgentOrchestrationBatchCache()
+    if (activeWorktrees.length === 1) {
+      singletonOrchestration = selectRuntimeAgentOrchestrationForWorktree(
+        state,
+        activeWorktrees[0].worktree.id
+      )
+    }
+  }
+
+  for (const { repo, worktree } of activeWorktrees) {
+    const worktreeId = worktree.id
+    const liveEntries = selectLiveAgentStatusEntriesForWorktree(state, worktreeId)
+    const migrationUnsupported = selectMigrationUnsupportedEntriesForWorktree(state, worktreeId)
+    const entries =
+      migrationUnsupported.length > 0
+        ? [
+            ...liveEntries,
+            ...migrationUnsupported.flatMap((unsupported) => {
+              const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
+              return entry ? [entry] : []
+            })
+          ]
+        : liveEntries
+    const terminalLayoutsByTabId = selectTerminalLayoutsForWorktree(state, worktreeId)
+
+    const rows = applyAgentRowLineage(
+      buildWorktreeAgentRows({
+        tabs: state.tabsByWorktree[worktreeId] ?? [],
+        entries,
+        retained: selectRetainedAgentEntriesForWorktree(state, worktreeId),
+        runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
+        ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
+        terminalLayoutsByTabId,
+        runtimeAgentOrchestrationByPaneKey:
+          singletonOrchestration ??
+          orchestrationByWorktree?.get(worktreeId) ??
+          EMPTY_WORKTREE_AGENT_ORCHESTRATION,
+        now
+      })
+    )
+
+    for (const row of rows) {
+      // Child rows have no pane of their own; the board lists top-level agents.
+      if (row.rowSource === 'subagent') {
         continue
       }
-      const worktreeId = worktree.id
-      const liveEntries = selectLiveAgentStatusEntriesForWorktree(state, worktreeId)
-      const migrationUnsupported = selectMigrationUnsupportedEntriesForWorktree(state, worktreeId)
-      const entries =
-        migrationUnsupported.length > 0
-          ? [
-              ...liveEntries,
-              ...migrationUnsupported.flatMap((unsupported) => {
-                const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
-                return entry ? [entry] : []
-              })
-            ]
-          : liveEntries
-      const terminalLayoutsByTabId = selectTerminalLayoutsForWorktree(state, worktreeId)
+      // Title-derived rows (a live pane read only from its terminal title, no
+      // agent-hook status) carry synthetic prompt/lastAssistantMessage — the
+      // agent LABEL and a status word like "Idle". They're marked by
+      // startedAt === 0, and must NOT be shown as real conversation.
+      const isTitleDerived = row.startedAt === 0
+      const routingPaneKey = row.activationPaneKey ?? row.paneKey
+      const parsed = parsePaneKey(routingPaneKey)
+      const tabId = parsed?.tabId ?? row.tab.id
+      const leafId = parsed?.leafId ?? null
+      const layoutPtyId =
+        (leafId ? terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId] : undefined) ?? null
+      // Layout entries survive app restarts, but their PTYs may not (parked
+      // tabs keep the pre-restart id). Only advertise a pty the terminal
+      // preview can actually serialize — ptyIdsByTabId is the liveness truth.
+      const ptyId =
+        layoutPtyId && (state.ptyIdsByTabId?.[tabId] ?? []).includes(layoutPtyId)
+          ? layoutPtyId
+          : null
+      const dotState = row.state as DashboardCardDotState
+      const bucket = bucketForState(row.state)
 
-      const rows = applyAgentRowLineage(
-        buildWorktreeAgentRows({
-          tabs: state.tabsByWorktree[worktreeId] ?? [],
-          entries,
-          retained: selectRetainedAgentEntriesForWorktree(state, worktreeId),
-          runtimePaneTitlesByTabId: selectRuntimePaneTitlesForWorktree(state, worktreeId),
-          ptyIdsByTabId: selectLivePtyIdsForWorktree(state, worktreeId),
-          terminalLayoutsByTabId,
-          runtimeAgentOrchestrationByPaneKey: selectRuntimeAgentOrchestrationForWorktree(
-            state,
-            worktreeId
-          ),
-          now
-        })
-      )
-
-      for (const row of rows) {
-        // Child rows have no pane of their own; the board lists top-level agents.
-        if (row.rowSource === 'subagent') {
-          continue
-        }
-        // Title-derived rows (a live pane read only from its terminal title, no
-        // agent-hook status) carry synthetic prompt/lastAssistantMessage — the
-        // agent LABEL and a status word like "Idle". They're marked by
-        // startedAt === 0, and must NOT be shown as real conversation.
-        const isTitleDerived = row.startedAt === 0
-        const routingPaneKey = row.activationPaneKey ?? row.paneKey
-        const parsed = parsePaneKey(routingPaneKey)
-        const tabId = parsed?.tabId ?? row.tab.id
-        const leafId = parsed?.leafId ?? null
-        const layoutPtyId =
-          (leafId ? terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[leafId] : undefined) ?? null
-        // Layout entries survive app restarts, but their PTYs may not (parked
-        // tabs keep the pre-restart id). Only advertise a pty the terminal
-        // preview can actually serialize — ptyIdsByTabId is the liveness truth.
-        const ptyId =
-          layoutPtyId && (state.ptyIdsByTabId?.[tabId] ?? []).includes(layoutPtyId)
-            ? layoutPtyId
-            : null
-        const dotState = row.state as DashboardCardDotState
-        const bucket = bucketForState(row.state)
-
-        cards.push({
-          paneKey: row.paneKey,
-          ptyId,
-          agentType: row.agentType,
-          bucket,
-          dotState,
-          task: isTitleDerived ? '' : rowTask(row),
-          repoId: repo.id,
-          worktreeId,
-          tabId,
-          leafId,
-          repoName: repo.displayName,
-          worktreeName: worktree.displayName,
-          lastUserMessage: isTitleDerived ? undefined : nonEmpty(row.entry.prompt),
-          lastAgentMessage: isTitleDerived ? undefined : nonEmpty(row.entry.lastAssistantMessage),
-          startedAt: row.startedAt,
-          finishedAt: lastEnteredDoneAt(row),
-          stateChangedAt: row.entry.stateStartedAt || row.startedAt,
-          // Same derivation as WorktreeCardAgents' unvisitedByPaneKey, so the
-          // board and the sidebar bold/mute the same agents at the same time.
-          unseen:
-            !isTitleDerived &&
-            (state.acknowledgedAgentsByPaneKey?.[row.paneKey] ?? 0) < row.entry.stateStartedAt,
-          askSummary:
-            bucket === 'attention' ? (row.entry.interactivePrompt ?? undefined) : undefined
-        })
-      }
+      cards.push({
+        paneKey: row.paneKey,
+        ptyId,
+        agentType: row.agentType,
+        bucket,
+        dotState,
+        task: isTitleDerived ? '' : rowTask(row),
+        repoId: repo.id,
+        worktreeId,
+        tabId,
+        leafId,
+        repoName: repo.displayName,
+        worktreeName: worktree.displayName,
+        lastUserMessage: isTitleDerived ? undefined : nonEmpty(row.entry.prompt),
+        lastAgentMessage: isTitleDerived ? undefined : nonEmpty(row.entry.lastAssistantMessage),
+        startedAt: row.startedAt,
+        finishedAt: lastEnteredDoneAt(row),
+        stateChangedAt: row.entry.stateStartedAt || row.startedAt,
+        // Same derivation as WorktreeCardAgents' unvisitedByPaneKey, so the
+        // board and the sidebar bold/mute the same agents at the same time.
+        unseen:
+          !isTitleDerived &&
+          (state.acknowledgedAgentsByPaneKey?.[row.paneKey] ?? 0) < row.entry.stateStartedAt,
+        askSummary: bucket === 'attention' ? (row.entry.interactivePrompt ?? undefined) : undefined
+      })
     }
   }
 

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.test.ts
@@ -1,0 +1,522 @@
+import { describe, expect, it } from 'vitest'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type {
+  AgentStatusEntry,
+  AgentStatusOrchestrationContext
+} from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+import {
+  EMPTY_WORKTREE_AGENT_ORCHESTRATION,
+  selectRuntimeAgentOrchestrationBatch
+} from './worktree-agent-orchestration-batch'
+import { selectRuntimeAgentOrchestrationForWorktree } from './worktree-agent-row-selectors'
+
+type BatchState = Parameters<typeof selectRuntimeAgentOrchestrationBatch>[0]
+
+const CHILD_KEY = makePaneKey('tab-child', '11111111-1111-4111-8111-111111111111')
+const SECOND_CHILD_KEY = makePaneKey('tab-child', '22222222-2222-4222-8222-222222222222')
+const ORPHAN_KEY = makePaneKey('tab-orphan', '33333333-3333-4333-8333-333333333333')
+const PARENT_KEY = makePaneKey('tab-parent', '44444444-4444-4444-8444-444444444444')
+const MALFORMED_KEY = makePaneKey('tab-none', '55555555-5555-4555-8555-555555555555')
+const DIFFERENT_STORE_KEY = makePaneKey('tab-other', '66666666-6666-4666-8666-666666666666')
+const LEGACY_KEY = 'tab-legacy:1'
+
+function makeTab(id: string, worktreeId = 'stored-worktree-id'): TerminalTab {
+  return {
+    id,
+    worktreeId,
+    ptyId: null,
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeCountedTab(id: string, onIdRead: () => void): TerminalTab {
+  const tab = makeTab(id)
+  Object.defineProperty(tab, 'id', {
+    enumerable: true,
+    get: () => {
+      onIdRead()
+      return id
+    }
+  })
+  return tab
+}
+
+function makeEntry(mapKey: string, worktreeId: string, entryPaneKey = mapKey): AgentStatusEntry {
+  return {
+    paneKey: entryPaneKey,
+    state: 'working',
+    stateStartedAt: 1,
+    updatedAt: 1,
+    stateHistory: [],
+    prompt: 'working',
+    agentType: 'claude',
+    worktreeId
+  }
+}
+
+function makeRetained(mapKey: string, worktreeId: string): RetainedAgentEntry {
+  return {
+    entry: makeEntry(mapKey, worktreeId),
+    worktreeId,
+    tab: makeTab('retained-tab'),
+    agentType: 'claude',
+    startedAt: 1
+  }
+}
+
+function makeContext(
+  taskId: string,
+  overrides: Partial<AgentStatusOrchestrationContext> = {}
+): AgentStatusOrchestrationContext {
+  return {
+    taskId,
+    dispatchId: `dispatch-${taskId}`,
+    ...overrides
+  }
+}
+
+function getBatchRecord(
+  batch: ReadonlyMap<string, Record<string, AgentStatusOrchestrationContext>>,
+  worktreeId: string
+): Record<string, AgentStatusOrchestrationContext> {
+  return batch.get(worktreeId) ?? EMPTY_WORKTREE_AGENT_ORCHESTRATION
+}
+
+function expectReferenceParity(state: BatchState, worktreeIds: string[]): void {
+  const batch = selectRuntimeAgentOrchestrationBatch(state, worktreeIds)
+  for (const worktreeId of new Set(worktreeIds)) {
+    const expected = selectRuntimeAgentOrchestrationForWorktree(state, worktreeId)
+    const actual = getBatchRecord(batch, worktreeId)
+    expect(Object.keys(actual)).toEqual(Object.keys(expected))
+    for (const paneKey of Object.keys(expected)) {
+      expect(actual[paneKey]).toBe(expected[paneKey])
+    }
+  }
+}
+
+describe('selectRuntimeAgentOrchestrationBatch', () => {
+  it('short-circuits empty requests and empty runtime before reading unrelated slices', () => {
+    let forbiddenAccesses = 0
+    const noRequestsState = {
+      get runtimeAgentOrchestrationByPaneKey() {
+        forbiddenAccesses += 1
+        throw new Error('runtime must stay cold')
+      },
+      get tabsByWorktree() {
+        forbiddenAccesses += 1
+        throw new Error('tabs must stay cold')
+      }
+    } as unknown as BatchState
+    const noRequests = selectRuntimeAgentOrchestrationBatch(noRequestsState, [])
+
+    const emptyRuntimeState = {
+      runtimeAgentOrchestrationByPaneKey: {},
+      get tabsByWorktree() {
+        forbiddenAccesses += 1
+        throw new Error('tabs must stay cold')
+      },
+      get agentStatusByPaneKey() {
+        forbiddenAccesses += 1
+        throw new Error('live status must stay cold')
+      },
+      get retainedAgentsByPaneKey() {
+        forbiddenAccesses += 1
+        throw new Error('retained status must stay cold')
+      }
+    } as unknown as BatchState
+    const emptyRuntime = selectRuntimeAgentOrchestrationBatch(emptyRuntimeState, ['target'])
+
+    expect(noRequests).toBe(emptyRuntime)
+    expect(emptyRuntime.size).toBe(0)
+    expect(forbiddenAccesses).toBe(0)
+  })
+
+  it('matches the per-worktree selector across every attribution path and runtime order', () => {
+    const childContext = makeContext('child')
+    const secondChildContext = makeContext('second-child')
+    const parentContext = makeContext('parent', { parentPaneKey: PARENT_KEY })
+    const legacyContext = makeContext('legacy', { parentPaneKey: 'tab-parent:7' })
+    const malformedContext = makeContext('malformed', { parentPaneKey: 'bad:parent:key' })
+    const state = {
+      tabsByWorktree: {
+        'wt-child': [makeTab('tab-child'), makeTab('tab-child')],
+        'wt-child-copy': [makeTab('tab-child')],
+        'wt-orphan': [makeTab('tab-orphan')],
+        'wt-parent': [makeTab('tab-parent')],
+        'wt-legacy': [makeTab('tab-legacy')],
+        'wt-empty-tab': [makeTab('')],
+        'wt-unrelated-null': null
+      } as unknown as BatchState['tabsByWorktree'],
+      runtimeAgentOrchestrationByPaneKey: {
+        [CHILD_KEY]: childContext,
+        [SECOND_CHILD_KEY]: secondChildContext,
+        [ORPHAN_KEY]: parentContext,
+        [LEGACY_KEY]: legacyContext,
+        [MALFORMED_KEY]: malformedContext
+      },
+      agentStatusByPaneKey: {
+        [CHILD_KEY]: {
+          ...makeEntry(CHILD_KEY, 'wt-live', DIFFERENT_STORE_KEY),
+          orchestration: makeContext('live-is-not-the-value-domain')
+        },
+        [LEGACY_KEY]: makeEntry(LEGACY_KEY, 'wt-legacy-exact'),
+        [MALFORMED_KEY]: makeEntry(MALFORMED_KEY, ''),
+        [DIFFERENT_STORE_KEY]: makeEntry(DIFFERENT_STORE_KEY, 'wt-must-not-appear', ORPHAN_KEY)
+      },
+      retainedAgentsByPaneKey: {
+        [CHILD_KEY]: makeRetained(CHILD_KEY, 'wt-retained')
+      }
+    } as BatchState
+    const requested = [
+      'wt-child',
+      'wt-child',
+      'wt-child-copy',
+      'wt-orphan',
+      'wt-parent',
+      'wt-legacy',
+      'wt-empty-tab',
+      'wt-legacy-exact',
+      'wt-live',
+      'wt-retained',
+      '',
+      'wt-must-not-appear',
+      'wt-unrelated-null',
+      'missing'
+    ]
+
+    expectReferenceParity(state, requested)
+    const batch = selectRuntimeAgentOrchestrationBatch(state, requested)
+    expect(Object.keys(getBatchRecord(batch, 'wt-child'))).toEqual([CHILD_KEY, SECOND_CHILD_KEY])
+    expect(getBatchRecord(batch, 'wt-parent')[ORPHAN_KEY]).toBe(parentContext)
+    expect(getBatchRecord(batch, 'wt-orphan')[ORPHAN_KEY]).toBe(parentContext)
+    expect(getBatchRecord(batch, 'wt-live')[CHILD_KEY]).toBe(childContext)
+    expect(getBatchRecord(batch, 'wt-retained')[CHILD_KEY]).toBe(childContext)
+    expect(getBatchRecord(batch, 'wt-legacy')).toBe(EMPTY_WORKTREE_AGENT_ORCHESTRATION)
+    expect(getBatchRecord(batch, 'wt-legacy-exact')[LEGACY_KEY]).toBe(legacyContext)
+    expect(getBatchRecord(batch, '')[MALFORMED_KEY]).toBe(malformedContext)
+    expect(getBatchRecord(batch, 'wt-must-not-appear')).toBe(EMPTY_WORKTREE_AGENT_ORCHESTRATION)
+  })
+
+  it('invalidates every source while preserving unchanged ordered bucket identities', () => {
+    const firstContext = makeContext('first')
+    const secondContext = makeContext('second')
+    const otherContext = makeContext('other')
+    const otherKey = makePaneKey('tab-other', '77777777-7777-4777-8777-777777777777')
+    const baseState = {
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-child'), makeTab('unrelated-tab')],
+        'wt-2': [makeTab('tab-other')]
+      },
+      runtimeAgentOrchestrationByPaneKey: {
+        [CHILD_KEY]: firstContext,
+        [SECOND_CHILD_KEY]: secondContext,
+        [otherKey]: otherContext
+      },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as BatchState
+    const requested = ['wt-1', 'wt-2']
+    const firstBatch = selectRuntimeAgentOrchestrationBatch(baseState, requested)
+    const firstWt1 = getBatchRecord(firstBatch, 'wt-1')
+    const firstWt2 = getBatchRecord(firstBatch, 'wt-2')
+    expect(selectRuntimeAgentOrchestrationBatch({ ...baseState }, [...requested])).toBe(firstBatch)
+
+    const reorderedTabs = {
+      ...baseState,
+      tabsByWorktree: {
+        'wt-2': [makeTab('tab-other')],
+        'wt-1': [makeTab('unrelated-tab'), makeTab('tab-child')]
+      }
+    }
+    expectReferenceParity(reorderedTabs, requested)
+    const reorderedTabBatch = selectRuntimeAgentOrchestrationBatch(reorderedTabs, requested)
+    expect(getBatchRecord(reorderedTabBatch, 'wt-1')).toBe(firstWt1)
+    expect(getBatchRecord(reorderedTabBatch, 'wt-2')).toBe(firstWt2)
+
+    const liveChurn = {
+      ...reorderedTabs,
+      agentStatusByPaneKey: { unrelated: makeEntry('unrelated', 'wt-3') }
+    }
+    const liveBatch = selectRuntimeAgentOrchestrationBatch(liveChurn, requested)
+    expect(getBatchRecord(liveBatch, 'wt-1')).toBe(firstWt1)
+    expect(getBatchRecord(liveBatch, 'wt-2')).toBe(firstWt2)
+
+    const retainedChurn = {
+      ...liveChurn,
+      retainedAgentsByPaneKey: { unrelated: makeRetained('unrelated', 'wt-3') }
+    }
+    const retainedBatch = selectRuntimeAgentOrchestrationBatch(retainedChurn, requested)
+    expect(getBatchRecord(retainedBatch, 'wt-1')).toBe(firstWt1)
+    expect(getBatchRecord(retainedBatch, 'wt-2')).toBe(firstWt2)
+
+    const reorderedRuntime = {
+      ...retainedChurn,
+      runtimeAgentOrchestrationByPaneKey: {
+        [SECOND_CHILD_KEY]: secondContext,
+        [CHILD_KEY]: firstContext,
+        [otherKey]: otherContext
+      }
+    }
+    expectReferenceParity(reorderedRuntime, requested)
+    const reorderedRuntimeBatch = selectRuntimeAgentOrchestrationBatch(reorderedRuntime, requested)
+    const reorderedWt1 = getBatchRecord(reorderedRuntimeBatch, 'wt-1')
+    expect(Object.keys(reorderedWt1)).toEqual([SECOND_CHILD_KEY, CHILD_KEY])
+    expect(reorderedWt1).not.toBe(firstWt1)
+    expect(getBatchRecord(reorderedRuntimeBatch, 'wt-2')).toBe(firstWt2)
+
+    const replacementContext = makeContext('replacement')
+    const replacedRuntime = {
+      ...reorderedRuntime,
+      runtimeAgentOrchestrationByPaneKey: {
+        [SECOND_CHILD_KEY]: replacementContext,
+        [CHILD_KEY]: firstContext,
+        [otherKey]: otherContext
+      }
+    }
+    const replacedBatch = selectRuntimeAgentOrchestrationBatch(replacedRuntime, requested)
+    expect(getBatchRecord(replacedBatch, 'wt-1')).not.toBe(reorderedWt1)
+    expect(getBatchRecord(replacedBatch, 'wt-1')[SECOND_CHILD_KEY]).toBe(replacementContext)
+    expect(getBatchRecord(replacedBatch, 'wt-2')).toBe(firstWt2)
+  })
+
+  it('releases raw and derived caches for empty requests and empty runtime', () => {
+    let tabIdReads = 0
+    const state = {
+      tabsByWorktree: {
+        target: [
+          makeCountedTab('tab-child', () => {
+            tabIdReads += 1
+          })
+        ]
+      },
+      runtimeAgentOrchestrationByPaneKey: {
+        [CHILD_KEY]: makeContext('child')
+      },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as BatchState
+
+    const first = getBatchRecord(selectRuntimeAgentOrchestrationBatch(state, ['target']), 'target')
+    expect(tabIdReads).toBe(1)
+
+    selectRuntimeAgentOrchestrationBatch(state, [])
+    const afterEmptyRequest = getBatchRecord(
+      selectRuntimeAgentOrchestrationBatch(state, ['target']),
+      'target'
+    )
+    expect(tabIdReads).toBe(2)
+    expect(afterEmptyRequest).not.toBe(first)
+
+    selectRuntimeAgentOrchestrationBatch({ ...state, runtimeAgentOrchestrationByPaneKey: {} }, [
+      'target'
+    ])
+    const afterEmptyRuntime = getBatchRecord(
+      selectRuntimeAgentOrchestrationBatch(state, ['target']),
+      'target'
+    )
+    expect(tabIdReads).toBe(3)
+    expect(afterEmptyRuntime).not.toBe(afterEmptyRequest)
+  })
+
+  it('keeps singleton tab work target-local', () => {
+    const tabCount = 10
+    const contextCount = 8
+    const makeCountedState = () => {
+      let runtimeEnumerations = 0
+      let runtimeValueReads = 0
+      let contextVisits = 0
+      let targetTabIdReads = 0
+      let unrelatedTabIdReads = 0
+      const rawRuntime: Record<string, AgentStatusOrchestrationContext> = {}
+      for (let index = 0; index < contextCount; index += 1) {
+        const paneKey = makePaneKey(
+          'tab-target',
+          `88888888-8888-4888-8888-${index.toString(16).padStart(12, '0')}`
+        )
+        rawRuntime[paneKey] = {
+          taskId: `task-${index}`,
+          dispatchId: `dispatch-${index}`,
+          get parentPaneKey() {
+            contextVisits += 1
+            return undefined
+          }
+        }
+      }
+      const runtime = new Proxy(rawRuntime, {
+        ownKeys(target) {
+          runtimeEnumerations += 1
+          return Reflect.ownKeys(target)
+        },
+        get(target, key, receiver) {
+          if (typeof key === 'string' && Object.hasOwn(target, key)) {
+            runtimeValueReads += 1
+          }
+          return Reflect.get(target, key, receiver)
+        }
+      })
+      const tabsByWorktree = Object.fromEntries(
+        Array.from({ length: tabCount }, (_, index) => {
+          const isTarget = index === 0
+          return [
+            isTarget ? 'target' : `unrelated-${index}`,
+            [
+              makeCountedTab(isTarget ? 'tab-target' : `tab-unrelated-${index}`, () => {
+                if (isTarget) {
+                  targetTabIdReads += 1
+                } else {
+                  unrelatedTabIdReads += 1
+                }
+              })
+            ]
+          ]
+        })
+      )
+      return {
+        state: {
+          tabsByWorktree,
+          runtimeAgentOrchestrationByPaneKey: runtime,
+          agentStatusByPaneKey: {},
+          retainedAgentsByPaneKey: {}
+        } as BatchState,
+        counts: () => ({
+          runtimeEnumerations,
+          runtimeValueReads,
+          contextVisits,
+          targetTabIdReads,
+          unrelatedTabIdReads
+        })
+      }
+    }
+    const reference = makeCountedState()
+    const batched = makeCountedState()
+
+    const expected = selectRuntimeAgentOrchestrationForWorktree(reference.state, 'target')
+    const actual = getBatchRecord(
+      selectRuntimeAgentOrchestrationBatch(batched.state, ['target']),
+      'target'
+    )
+
+    expect(Object.keys(actual)).toEqual(Object.keys(expected))
+    const operationBudget = {
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount,
+      targetTabIdReads: 1,
+      unrelatedTabIdReads: 0
+    }
+    expect(reference.counts()).toEqual(operationBudget)
+    expect(batched.counts()).toEqual(operationBudget)
+  })
+
+  it('collapses multi-worktree runtime scans and caches unchanged publications', () => {
+    const worktreeCount = 12
+    const contextCount = 24
+    const publicationCount = 40
+    const makeCountedState = () => {
+      let runtimeEnumerations = 0
+      let runtimeValueReads = 0
+      let contextVisits = 0
+      let tabIdReads = 0
+      const rawRuntime: Record<string, AgentStatusOrchestrationContext> = {}
+      for (let index = 0; index < contextCount; index += 1) {
+        const paneKey = makePaneKey(
+          `tab-${index % worktreeCount}`,
+          `99999999-9999-4999-8999-${index.toString(16).padStart(12, '0')}`
+        )
+        rawRuntime[paneKey] = {
+          taskId: `task-${index}`,
+          dispatchId: `dispatch-${index}`,
+          get parentPaneKey() {
+            contextVisits += 1
+            return undefined
+          }
+        }
+      }
+      const runtime = new Proxy(rawRuntime, {
+        ownKeys(target) {
+          runtimeEnumerations += 1
+          return Reflect.ownKeys(target)
+        },
+        get(target, key, receiver) {
+          if (typeof key === 'string' && Object.hasOwn(target, key)) {
+            runtimeValueReads += 1
+          }
+          return Reflect.get(target, key, receiver)
+        }
+      })
+      return {
+        state: {
+          tabsByWorktree: Object.fromEntries(
+            Array.from({ length: worktreeCount }, (_, index) => [
+              `wt-${index}`,
+              [
+                makeCountedTab(`tab-${index}`, () => {
+                  tabIdReads += 1
+                })
+              ]
+            ])
+          ),
+          runtimeAgentOrchestrationByPaneKey: runtime,
+          agentStatusByPaneKey: {},
+          retainedAgentsByPaneKey: {}
+        } as BatchState,
+        counts: () => ({ runtimeEnumerations, runtimeValueReads, contextVisits, tabIdReads })
+      }
+    }
+    const requested = Array.from({ length: worktreeCount }, (_, index) => `wt-${index}`)
+    const reference = makeCountedState()
+    const batched = makeCountedState()
+
+    for (const worktreeId of requested) {
+      selectRuntimeAgentOrchestrationForWorktree(reference.state, worktreeId)
+    }
+    selectRuntimeAgentOrchestrationBatch(batched.state, requested)
+
+    expect(reference.counts()).toEqual({
+      runtimeEnumerations: worktreeCount,
+      runtimeValueReads: worktreeCount * contextCount,
+      contextVisits: worktreeCount * contextCount,
+      tabIdReads: worktreeCount
+    })
+    expect(batched.counts()).toEqual({
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount,
+      tabIdReads: worktreeCount
+    })
+
+    for (let publication = 0; publication < publicationCount; publication += 1) {
+      selectRuntimeAgentOrchestrationBatch({ ...batched.state }, [...requested])
+    }
+    expect(batched.counts()).toEqual({
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount,
+      tabIdReads: worktreeCount
+    })
+
+    for (let publication = 0; publication < publicationCount; publication += 1) {
+      selectRuntimeAgentOrchestrationBatch(
+        {
+          ...batched.state,
+          agentStatusByPaneKey: {
+            [`unrelated-${publication}`]: makeEntry(`unrelated-${publication}`, 'elsewhere')
+          }
+        },
+        requested
+      )
+    }
+    expect(batched.counts()).toEqual({
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount * (publicationCount + 1),
+      tabIdReads: worktreeCount
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.ts
@@ -1,0 +1,249 @@
+import type { AppState } from '@/store/types'
+import type { AgentStatusOrchestrationContext } from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+
+type RuntimeOrchestrationState = Pick<
+  AppState,
+  | 'agentStatusByPaneKey'
+  | 'retainedAgentsByPaneKey'
+  | 'runtimeAgentOrchestrationByPaneKey'
+  | 'tabsByWorktree'
+>
+
+type RuntimeOrchestrationMap = RuntimeOrchestrationState['runtimeAgentOrchestrationByPaneKey']
+type RuntimeOrchestrationRecord = Record<string, AgentStatusOrchestrationContext>
+
+type RuntimeDomainCache = {
+  source: RuntimeOrchestrationMap
+  orderedEntries: [string, AgentStatusOrchestrationContext][]
+}
+
+type RequestedTabMembershipCache = {
+  tabsSource: RuntimeOrchestrationState['tabsByWorktree']
+  requestedWorktreeIds: string[]
+  requestedIds: Set<string>
+  worktreeIdsByTabId: Map<string, Set<string>>
+}
+
+type RuntimeBatchCache = {
+  runtimeSource: RuntimeOrchestrationMap
+  tabsSource: RuntimeOrchestrationState['tabsByWorktree']
+  liveSource: RuntimeOrchestrationState['agentStatusByPaneKey']
+  retainedSource: RuntimeOrchestrationState['retainedAgentsByPaneKey']
+  requestedWorktreeIds: string[]
+  recordsByWorktree: ReadonlyMap<string, RuntimeOrchestrationRecord>
+}
+
+const EMPTY_RUNTIME_ORCHESTRATION: RuntimeOrchestrationMap = {}
+const EMPTY_TABS_BY_WORKTREE: RuntimeOrchestrationState['tabsByWorktree'] = {}
+const EMPTY_AGENT_STATUS: RuntimeOrchestrationState['agentStatusByPaneKey'] = {}
+const EMPTY_RETAINED_AGENTS: RuntimeOrchestrationState['retainedAgentsByPaneKey'] = {}
+const EMPTY_BATCH: ReadonlyMap<string, RuntimeOrchestrationRecord> = new Map()
+
+export const EMPTY_WORKTREE_AGENT_ORCHESTRATION: RuntimeOrchestrationRecord = {}
+
+let runtimeDomainCache: RuntimeDomainCache | null = null
+let requestedTabMembershipCache: RequestedTabMembershipCache | null = null
+let runtimeBatchCache: RuntimeBatchCache | null = null
+
+export function releaseRuntimeAgentOrchestrationBatchCache(): void {
+  runtimeDomainCache = null
+  requestedTabMembershipCache = null
+  runtimeBatchCache = null
+}
+
+function getOrderedRuntimeEntries(
+  runtimeAgentOrchestrationByPaneKey: RuntimeOrchestrationMap
+): [string, AgentStatusOrchestrationContext][] {
+  if (runtimeDomainCache?.source === runtimeAgentOrchestrationByPaneKey) {
+    return runtimeDomainCache.orderedEntries
+  }
+  const orderedEntries = Object.entries(runtimeAgentOrchestrationByPaneKey)
+  runtimeDomainCache = { source: runtimeAgentOrchestrationByPaneKey, orderedEntries }
+  return orderedEntries
+}
+
+function uniqueWorktreeIds(worktreeIds: readonly string[]): string[] {
+  const uniqueIds: string[] = []
+  const seen = new Set<string>()
+  for (const worktreeId of worktreeIds) {
+    if (!seen.has(worktreeId)) {
+      seen.add(worktreeId)
+      uniqueIds.push(worktreeId)
+    }
+  }
+  return uniqueIds
+}
+
+function hasSameWorktreeIds(previous: readonly string[], next: readonly string[]): boolean {
+  if (previous.length !== next.length) {
+    return false
+  }
+  return previous.every((worktreeId, index) => worktreeId === next[index])
+}
+
+function getRequestedTabMembership(
+  tabsByWorktree: RuntimeOrchestrationState['tabsByWorktree'],
+  requestedWorktreeIds: string[]
+): RequestedTabMembershipCache {
+  if (
+    requestedTabMembershipCache?.tabsSource === tabsByWorktree &&
+    hasSameWorktreeIds(requestedTabMembershipCache.requestedWorktreeIds, requestedWorktreeIds)
+  ) {
+    return requestedTabMembershipCache
+  }
+
+  const requestedIds = new Set(requestedWorktreeIds)
+  const worktreeIdsByTabId = new Map<string, Set<string>>()
+  for (const worktreeId of requestedWorktreeIds) {
+    // Why: the batch must not make a singleton dashboard scan unrelated tabs.
+    for (const tab of tabsByWorktree[worktreeId] ?? []) {
+      const tabId = tab.id
+      const existing = worktreeIdsByTabId.get(tabId)
+      if (existing) {
+        existing.add(worktreeId)
+      } else {
+        worktreeIdsByTabId.set(tabId, new Set([worktreeId]))
+      }
+    }
+  }
+  requestedTabMembershipCache = {
+    tabsSource: tabsByWorktree,
+    requestedWorktreeIds,
+    requestedIds,
+    worktreeIdsByTabId
+  }
+  return requestedTabMembershipCache
+}
+
+function reuseRecordIfOrderedEqual(
+  previous: RuntimeOrchestrationRecord | undefined,
+  next: RuntimeOrchestrationRecord
+): RuntimeOrchestrationRecord {
+  if (!previous) {
+    return next
+  }
+  const previousEntries = Object.entries(previous)
+  const nextEntries = Object.entries(next)
+  if (previousEntries.length !== nextEntries.length) {
+    return next
+  }
+  for (let index = 0; index < nextEntries.length; index += 1) {
+    if (
+      previousEntries[index]?.[0] !== nextEntries[index]?.[0] ||
+      previousEntries[index]?.[1] !== nextEntries[index]?.[1]
+    ) {
+      return next
+    }
+  }
+  return previous
+}
+
+function buildRuntimeBatch(
+  requestedWorktreeIds: string[],
+  orderedRuntimeEntries: [string, AgentStatusOrchestrationContext][],
+  tabsByWorktree: RuntimeOrchestrationState['tabsByWorktree'],
+  agentStatusByPaneKey: RuntimeOrchestrationState['agentStatusByPaneKey'],
+  retainedAgentsByPaneKey: RuntimeOrchestrationState['retainedAgentsByPaneKey']
+): ReadonlyMap<string, RuntimeOrchestrationRecord> {
+  const { requestedIds, worktreeIdsByTabId } = getRequestedTabMembership(
+    tabsByWorktree,
+    requestedWorktreeIds
+  )
+
+  const recordsByWorktree = new Map<string, RuntimeOrchestrationRecord>()
+  for (const [paneKey, orchestration] of orderedRuntimeEntries) {
+    const targets = new Set<string>()
+    const parsed = parsePaneKey(paneKey)
+    const parsedParent = orchestration.parentPaneKey
+      ? parsePaneKey(orchestration.parentPaneKey)
+      : null
+    if (parsed) {
+      for (const worktreeId of worktreeIdsByTabId.get(parsed.tabId) ?? []) {
+        targets.add(worktreeId)
+      }
+    }
+    if (parsedParent) {
+      for (const worktreeId of worktreeIdsByTabId.get(parsedParent.tabId) ?? []) {
+        targets.add(worktreeId)
+      }
+    }
+
+    // Why: exact runtime keys preserve early SSH attribution and ignore stale
+    // entry.paneKey fields carried by a live or retained row.
+    const liveWorktreeId = agentStatusByPaneKey[paneKey]?.worktreeId
+    const retainedWorktreeId = retainedAgentsByPaneKey[paneKey]?.worktreeId
+    if (typeof liveWorktreeId === 'string' && requestedIds.has(liveWorktreeId)) {
+      targets.add(liveWorktreeId)
+    }
+    if (typeof retainedWorktreeId === 'string' && requestedIds.has(retainedWorktreeId)) {
+      targets.add(retainedWorktreeId)
+    }
+
+    for (const worktreeId of targets) {
+      const existing = recordsByWorktree.get(worktreeId)
+      if (existing) {
+        existing[paneKey] = orchestration
+      } else {
+        recordsByWorktree.set(worktreeId, { [paneKey]: orchestration })
+      }
+    }
+  }
+
+  const previousRecords = runtimeBatchCache?.recordsByWorktree
+  for (const [worktreeId, record] of recordsByWorktree) {
+    recordsByWorktree.set(
+      worktreeId,
+      reuseRecordIfOrderedEqual(previousRecords?.get(worktreeId), record)
+    )
+  }
+  return recordsByWorktree
+}
+
+export function selectRuntimeAgentOrchestrationBatch(
+  state: RuntimeOrchestrationState,
+  worktreeIds: readonly string[]
+): ReadonlyMap<string, RuntimeOrchestrationRecord> {
+  const requestedWorktreeIds = uniqueWorktreeIds(worktreeIds)
+  if (requestedWorktreeIds.length === 0) {
+    releaseRuntimeAgentOrchestrationBatchCache()
+    return EMPTY_BATCH
+  }
+
+  const runtimeAgentOrchestrationByPaneKey =
+    state.runtimeAgentOrchestrationByPaneKey ?? EMPTY_RUNTIME_ORCHESTRATION
+  const orderedRuntimeEntries = getOrderedRuntimeEntries(runtimeAgentOrchestrationByPaneKey)
+  if (orderedRuntimeEntries.length === 0) {
+    releaseRuntimeAgentOrchestrationBatchCache()
+    return EMPTY_BATCH
+  }
+
+  const tabsByWorktree = state.tabsByWorktree ?? EMPTY_TABS_BY_WORKTREE
+  const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_AGENT_STATUS
+  const retainedAgentsByPaneKey = state.retainedAgentsByPaneKey ?? EMPTY_RETAINED_AGENTS
+  if (
+    runtimeBatchCache?.runtimeSource === runtimeAgentOrchestrationByPaneKey &&
+    runtimeBatchCache.tabsSource === tabsByWorktree &&
+    runtimeBatchCache.liveSource === agentStatusByPaneKey &&
+    runtimeBatchCache.retainedSource === retainedAgentsByPaneKey &&
+    hasSameWorktreeIds(runtimeBatchCache.requestedWorktreeIds, requestedWorktreeIds)
+  ) {
+    return runtimeBatchCache.recordsByWorktree
+  }
+
+  runtimeBatchCache = {
+    runtimeSource: runtimeAgentOrchestrationByPaneKey,
+    tabsSource: tabsByWorktree,
+    liveSource: agentStatusByPaneKey,
+    retainedSource: retainedAgentsByPaneKey,
+    requestedWorktreeIds,
+    recordsByWorktree: buildRuntimeBatch(
+      requestedWorktreeIds,
+      orderedRuntimeEntries,
+      tabsByWorktree,
+      agentStatusByPaneKey,
+      retainedAgentsByPaneKey
+    )
+  }
+  return runtimeBatchCache.recordsByWorktree
+}


### PR DESCRIPTION
## Description

- Batch runtime-orchestration attribution once for dashboard snapshots containing
  two or more unarchived worktrees, instead of rescanning the global runtime map
  for every dashboard card.
- Read tab membership only for the worktrees requested by the dashboard and
  preserve runtime order, duplicate-tab fanout, parent-pane attribution, and
  exact-key live/retained attribution.
- Keep the existing per-worktree selector unchanged. A zero-worktree snapshot
  releases the batch cache, and a one-worktree snapshot uses the legacy selector
  exactly; only the multi-worktree path batches.
- Reuse unchanged per-worktree result identities and bound all raw and derived
  cache state to the latest source generation.

## ELI5

The dashboard used to reread the same global agent address book once for every
worktree card. It now reads that address book once and sorts the answers into the
requested cards. A dashboard with only one card still takes the original path,
so the optimization does not make that small case heavier.

## Proof of zero regression

- The first implementation was held after independent review found a 31%
  singleton slowdown. The final production route sends zero/one-worktree
  snapshots through the empty/legacy paths and batches only two or more
  worktrees; the same reviewer found no remaining correctness, lifecycle,
  platform, or material performance issue.
- The final review checked attribution, runtime order, duplicate fanout, exact
  live/retained lookup, parent panes, archived filtering, partial store mocks,
  SSH-before-tab attribution, cache transitions, and bounded cache ownership.
- Focused and related validation: 109/109 tests passed.
- Full post-rebase suite: 3,276 files and 34,845 tests passed; 8 files and 60
  tests were skipped by the existing suite.
- Full Node/CLI/web TypeScript checks, touched ordinary and type-aware lint,
  formatting, max-lines ratchet, localization catalog/coverage, and
  `git diff --check` passed.
- Full lint passed oxlint, switch exhaustiveness, styled-scrollbar checks, 47
  reliability gates, max-lines, and bundled-guide checks. Its only failure was
  the released `orca-cli` revision-9 skill-manifest blocker, reproduced
  identically on clean `origin/main`; this diff changes no skill files.
- The change is renderer-local and introduces no timers, I/O, paths, Git
  commands, provider behavior, or native dependencies. macOS, Linux, Windows,
  WSL, SSH, relay, and runtime hosts continue to supply the same immutable store
  snapshots.

## Proof of performance improvement

- Actual `buildDashboardSnapshot` benchmark, seven alternating runs of 5,000
  live-status invalidations with 128 runtime contexts:
  - 24 worktrees: 2,994.226 ms → 202.581 ms median, 93.23% lower and 14.78×
    faster.
  - 1 worktree: 145.497 ms → 146.274 ms median, +0.53%, within measurement
    noise and independently confirmed as no material regression.
- For one invalidating 24-worktree snapshot, runtime-map enumerations fall from
  24 to 1 and runtime-context visits fall from 3,072 to 128 (95.83% fewer).
- Unchanged source publications reuse the batch without rescanning; live-status
  churn rescans the 128 runtime contexts once while retaining the requested tab
  membership index.
- The claim is dashboard-snapshot-only. `useWorktreeAgentRows` and its existing
  per-worktree selector are intentionally unchanged, so mounted consumers that
  do not receive dashboard-precomputed rows retain their prior per-consumer
  scan cost.
