### PR TITLE
fix(terminal): stop the orphan sweep from deleting reconnecting terminals (#9911)

### DIFF
--- a/src/renderer/src/store/slices/bulk-worktree-purge-terminal-maps-leak.test.ts
+++ b/src/renderer/src/store/slices/bulk-worktree-purge-terminal-maps-leak.test.ts
@@ -9,7 +9,8 @@
  * never-reused key spaces.
  *
  * Tab-keyed (evicted via the doomed-tab set):
- *   lastKnownRelayPtyIdByTabId, pendingInitialCwdByTabId,
+ *   lastKnownRelayPtyIdByTabId, pendingReconnectPtyIdByTabId,
+ *   deferredSshSessionIdsByTabId, pendingInitialCwdByTabId,
  *   pendingIssueCommandSplitByTabId, pendingSetupSplitByTabId, pendingStartupByTabId
  * Pty-keyed (evicted via the doomed-pty set derived from live and durable bindings):
  *   codexRestartNoticeByPtyId, migrationUnsupportedByPtyId,
@@ -89,6 +90,8 @@ function seedMaps(store: ReturnType<typeof createTestStore>): void {
       }
     },
     lastKnownRelayPtyIdByTabId: { [TAB1]: PTY1, [TAB2]: PTY2 },
+    pendingReconnectPtyIdByTabId: { [TAB1]: PTY1, [TAB2]: PTY2 },
+    deferredSshSessionIdsByTabId: { [TAB1]: 'ssh-sess-1', [TAB2]: 'ssh-sess-2' },
     pendingInitialCwdByTabId: { [TAB1]: '/path/wt1', [TAB2]: '/path/wt2' },
     pendingIssueCommandSplitByTabId: {
       [TAB1]: { command: 'a' },
@@ -146,6 +149,8 @@ describe('bulk worktree purge evicts the per-tab/per-pty terminal maps it previo
 
     // Removed worktree's tab/pty: every map evicted.
     expect(s.lastKnownRelayPtyIdByTabId[TAB1]).toBeUndefined()
+    expect(s.pendingReconnectPtyIdByTabId[TAB1]).toBeUndefined()
+    expect(s.deferredSshSessionIdsByTabId[TAB1]).toBeUndefined()
     expect(s.pendingInitialCwdByTabId[TAB1]).toBeUndefined()
     expect(s.pendingIssueCommandSplitByTabId[TAB1]).toBeUndefined()
     expect(s.pendingSetupSplitByTabId[TAB1]).toBeUndefined()
@@ -161,6 +166,8 @@ describe('bulk worktree purge evicts the per-tab/per-pty terminal maps it previo
 
     // Surviving worktree's tab/pty: every entry retained (no over-eviction).
     expect(s.lastKnownRelayPtyIdByTabId[TAB2]).toBe(PTY2)
+    expect(s.pendingReconnectPtyIdByTabId[TAB2]).toBe(PTY2)
+    expect(s.deferredSshSessionIdsByTabId[TAB2]).toBe('ssh-sess-2')
     expect(s.pendingInitialCwdByTabId[TAB2]).toBe('/path/wt2')
     expect(s.pendingIssueCommandSplitByTabId[TAB2]).toEqual({ command: 'b' })
     expect(s.pendingSetupSplitByTabId[TAB2]).toEqual({ command: 'setup-b', direction: 'vertical' })

--- a/src/renderer/src/store/slices/ssh-target-cleanup.ts
+++ b/src/renderer/src/store/slices/ssh-target-cleanup.ts
@@ -49,13 +49,35 @@ function isSshTargetSessionId(sessionId: string, targetId: string): boolean {
   return parseAppSshPtyId(sessionId)?.connectionId === targetId
 }
 
-function shouldRemoveDeferredSshSession(
+// Why: a per-tab session map entry belongs to the removed target if the tab is
+// one of the target's, or the session id is an SSH pty id scoped to it. Shared
+// by the deferred-session and pending-reconnect cleanups so both drop the same
+// dead entries (an uncleared entry would keep a dead tab alive in the orphan
+// sweep, which now reads these maps as liveness — #9911).
+function isRemovedSshTargetTabSession(
   tabId: string,
   sessionId: string,
   targetId: string,
   targetTabIds: Set<string>
 ): boolean {
   return targetTabIds.has(tabId) || isSshTargetSessionId(sessionId, targetId)
+}
+
+function omitRemovedSshTargetTabSessions(
+  sessions: Record<string, string>,
+  targetId: string,
+  targetTabIds: Set<string>
+): { next: Record<string, string>; removed: boolean } {
+  const next: Record<string, string> = {}
+  let removed = false
+  for (const [tabId, sessionId] of Object.entries(sessions)) {
+    if (isRemovedSshTargetTabSession(tabId, sessionId, targetId, targetTabIds)) {
+      removed = true
+      continue
+    }
+    next[tabId] = sessionId
+  }
+  return { next, removed }
 }
 
 function clearSshTargetTabPtyState(
@@ -131,15 +153,13 @@ export function buildRemovedSshTargetCleanupPatch(
 ): Partial<AppState> | null {
   const targetTabIds = collectSshTargetTerminalTabIds(state, targetId)
   const tabPtyState = clearSshTargetTabPtyState(state, targetId, targetTabIds)
-  const nextDeferredSessions: Record<string, string> = {}
-  let removedDeferredSession = false
-  for (const [tabId, sessionId] of Object.entries(state.deferredSshSessionIdsByTabId)) {
-    if (shouldRemoveDeferredSshSession(tabId, sessionId, targetId, targetTabIds)) {
-      removedDeferredSession = true
-      continue
-    }
-    nextDeferredSessions[tabId] = sessionId
-  }
+  const { next: nextDeferredSessions, removed: removedDeferredSession } =
+    omitRemovedSshTargetTabSessions(state.deferredSshSessionIdsByTabId, targetId, targetTabIds)
+  // Why: pending-reconnect holds each tab's pre-restart session until reconnect
+  // drains it; if the target is removed first the entry is dead but the orphan
+  // sweep now reads it as liveness, so clear it here too (#9911).
+  const { next: nextPendingReconnect, removed: removedPendingReconnect } =
+    omitRemovedSshTargetTabSessions(state.pendingReconnectPtyIdByTabId, targetId, targetTabIds)
 
   const nextDeferredTargets = state.deferredSshReconnectTargets.filter((id) => id !== targetId)
   const nextTransientClearedConnections = {
@@ -189,7 +209,8 @@ export function buildRemovedSshTargetCleanupPatch(
     tabPtyState.changed ||
     removedCredentialRequest ||
     removedDeferredTarget ||
-    removedDeferredSession
+    removedDeferredSession ||
+    removedPendingReconnect
   if (!changed) {
     return null
   }
@@ -215,6 +236,7 @@ export function buildRemovedSshTargetCleanupPatch(
       : {}),
     ...(removedCredentialRequest ? { sshCredentialQueue: nextCredentialQueue } : {}),
     ...(removedDeferredTarget ? { deferredSshReconnectTargets: nextDeferredTargets } : {}),
-    ...(removedDeferredSession ? { deferredSshSessionIdsByTabId: nextDeferredSessions } : {})
+    ...(removedDeferredSession ? { deferredSshSessionIdsByTabId: nextDeferredSessions } : {}),
+    ...(removedPendingReconnect ? { pendingReconnectPtyIdByTabId: nextPendingReconnect } : {})
   }
 }

--- a/src/renderer/src/store/slices/ssh.test.ts
+++ b/src/renderer/src/store/slices/ssh.test.ts
@@ -106,6 +106,14 @@ describe('createSshSlice', () => {
         'tab-ssh': 'legacy-session-without-target-prefix',
         'tab-stale-encoded': toAppSshPtyId(targetId, 'pty-1'),
         'tab-other': toAppSshPtyId(otherTargetId, 'pty-2')
+      },
+      // Why: a hydrated-but-not-yet-reconnected session for the removed target;
+      // the orphan sweep reads this map as liveness, so removal must clear it or
+      // a dead tab is pinned alive forever (#9911).
+      pendingReconnectPtyIdByTabId: {
+        'tab-ssh': toAppSshPtyId(targetId, 'pty-1'),
+        'tab-stale-encoded': toAppSshPtyId(targetId, 'pty-9'),
+        'tab-other': toAppSshPtyId(otherTargetId, 'pty-2')
       }
     })
 
@@ -124,6 +132,11 @@ describe('createSshSlice', () => {
       [otherTargetId]: true
     })
     expect(state.deferredSshSessionIdsByTabId).toEqual({
+      'tab-other': toAppSshPtyId(otherTargetId, 'pty-2')
+    })
+    // Removed target's pending-reconnect sessions cleared (by tab membership and
+    // by target-scoped session id); the surviving target's entry is retained.
+    expect(state.pendingReconnectPtyIdByTabId).toEqual({
       'tab-other': toAppSshPtyId(otherTargetId, 'pty-2')
     })
     expect(state.tabsByWorktree[worktreeId][0]).toMatchObject({ id: 'tab-ssh', ptyId: null })

--- a/src/renderer/src/store/slices/store-cascades.test.ts
+++ b/src/renderer/src/store/slices/store-cascades.test.ts
@@ -83,7 +83,7 @@ import {
   seedStore
 } from './store-test-helpers'
 import { shutdownBufferCaptures } from '@/components/terminal-pane/shutdown-buffer-captures'
-import { buildOrphanTerminalCleanupPatch } from './terminal-orphan-helpers'
+import { buildOrphanTerminalCleanupPatch, getOrphanTerminalIds } from './terminal-orphan-helpers'
 import {
   loadSessionCommitDrafts,
   saveSessionCommitDrafts
@@ -1300,6 +1300,55 @@ describe('setActiveWorktree', () => {
     expect(state.tabsByWorktree[wt].find((tab) => tab.id === targetTabId)?.ptyId).toBe(
       'pty-detached'
     )
+  })
+
+  // Regression for #9911: a split SSH tab's single relay slot points at the
+  // last-bound pane; when it exits, clearTabPtyId must promote a surviving pane
+  // instead of clearing, or a later relay-drop bulk-clear leaves the survivor
+  // visible only in the layout leaf map and the orphan sweep deletes the live tab.
+  it('promotes a surviving pane into the relay slot so a split tab is not orphaned after a relay drop', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+    const tabId = 'tab-split'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      tabsByWorktree: { [wt]: [makeTab({ id: tabId, worktreeId: wt, ptyId: 'pty-B' })] },
+      ptyIdsByTabId: { [tabId]: ['pty-A', 'pty-B'] },
+      // Newest-bound pane B owns the single relay slot.
+      lastKnownRelayPtyIdByTabId: { [tabId]: 'pty-B' },
+      terminalLayoutsByTabId: {
+        [tabId]: {
+          root: {
+            type: 'split',
+            direction: 'horizontal',
+            first: { type: 'leaf', leafId: 'leaf-a' },
+            second: { type: 'leaf', leafId: 'leaf-b' }
+          },
+          activeLeafId: 'leaf-a',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-a': 'pty-A', 'leaf-b': 'pty-B' }
+        }
+      },
+      // The transiently-absent unified entry is the condition #9911 recovers from.
+      unifiedTabsByWorktree: { [wt]: [] }
+    })
+
+    // Pane B (the relay-slot owner) exits: the slot must fall back to survivor A.
+    store.getState().clearTabPtyId(tabId, 'pty-B')
+    expect(store.getState().ptyIdsByTabId[tabId]).toEqual(['pty-A'])
+    expect(store.getState().lastKnownRelayPtyIdByTabId[tabId]).toBe('pty-A')
+
+    // Relay drop bulk-clears the row + live index but preserves the relay slot.
+    store.getState().clearTabPtyId(tabId)
+    const state = store.getState()
+    expect(state.ptyIdsByTabId[tabId]).toEqual([])
+    expect(state.tabsByWorktree[wt][0].ptyId).toBeNull()
+    expect(state.lastKnownRelayPtyIdByTabId[tabId]).toBe('pty-A')
+    // Survivor A is still reconnectable, so the sweep must not delete the tab.
+    expect(getOrphanTerminalIds(state, wt)).not.toContain(tabId)
   })
 
   it('stores trimmed quick command labels on terminal and unified tabs', () => {

--- a/src/renderer/src/store/slices/tabs.test.ts
+++ b/src/renderer/src/store/slices/tabs.test.ts
@@ -1831,6 +1831,45 @@ describe('TabsSlice', () => {
       expect(store.getState().groupsByWorktree[WT][0].activeTabId).toBeNull()
     })
 
+    // Regression for #9911: a reconnecting terminal (ptyId/ptyIdsByTabId cleared
+    // on SSH-relay drop or hydration, live session held in a reconnect map) whose
+    // unified entry is transiently absent must not be hard-deleted by the orphan
+    // sweep before reconnect rebinds it.
+    it('keeps a reconnecting terminal whose live session survives only in a reconnect map', () => {
+      store.setState({
+        tabsByWorktree: {
+          [WT]: [
+            {
+              id: 'reconnecting-terminal',
+              ptyId: null,
+              worktreeId: WT,
+              title: 'claude',
+              customTitle: null,
+              color: null,
+              sortOrder: 0,
+              createdAt: 1
+            }
+          ]
+        },
+        ptyIdsByTabId: { 'reconnecting-terminal': [] },
+        pendingReconnectPtyIdByTabId: { 'reconnecting-terminal': 'session-live' },
+        unifiedTabsByWorktree: { [WT]: [] },
+        groupsByWorktree: {},
+        activeGroupIdByWorktree: {}
+      })
+
+      const result = store.getState().reconcileWorktreeTabModel(WT)
+      const state = store.getState()
+
+      // The live tab survives the sweep…
+      expect(state.tabsByWorktree[WT].map((tab) => tab.id)).toContain('reconnecting-terminal')
+      // …and is re-migrated into the unified model so it renders and can reattach.
+      expect(state.unifiedTabsByWorktree[WT].map((tab) => tab.entityId)).toContain(
+        'reconnecting-terminal'
+      )
+      expect(result.renderableTabCount).toBe(1)
+    })
+
     it('keeps simulator tabs because they reconnect their own backing stream', () => {
       const terminalGroupId = 'g-terminal'
       const simulatorGroupId = 'g-simulator'

--- a/src/renderer/src/store/slices/tabs.ts
+++ b/src/renderer/src/store/slices/tabs.ts
@@ -27,7 +27,11 @@ import {
 } from './tab-group-state'
 import { isPaneColumnSplitDropNoOp } from './pane-column-split-drop-no-op'
 import { buildHydratedTabState, pruneTabGroupLayoutForGroups } from './tabs-hydration'
-import { buildOrphanTerminalCleanupPatch, getOrphanTerminalIds } from './terminal-orphan-helpers'
+import {
+  buildOrphanTerminalCleanupPatch,
+  getOrphanTerminalIds,
+  terminalTabHasReconnectablePty
+} from './terminal-orphan-helpers'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
@@ -1759,9 +1763,10 @@ export const createTabsSlice: StateCreator<AppState, [], [], TabsSlice> = (set, 
       if (unifiedTerminalEntityIds.has(tab.id)) {
         return false
       }
-      // Why: migration filter — tab.ptyId (preserved sessionId) keeps slept tabs in the sweep for wake reattach; NOT a liveness check (use ptyIdsByTabId).
-      const livePtyIds = state.ptyIdsByTabId[tab.id] ?? []
-      return livePtyIds.length > 0 || tab.ptyId != null
+      // Why: migration filter — keep any tab still owning a live/reconnecting
+      // PTY (preserved sessionId or a reconnect-map session) so it re-enters the
+      // unified model for wake/reconnect reattach instead of vanishing (#9911).
+      return terminalTabHasReconnectablePty(state, tab.id, tab.ptyId)
     })
     const orphanTerminalIds = getOrphanTerminalIds(state, worktreeId)
     const ensuredGroupState =

--- a/src/renderer/src/store/slices/terminal-orphan-helpers.test.ts
+++ b/src/renderer/src/store/slices/terminal-orphan-helpers.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalTab } from '../../../../shared/types'
+import { getOrphanTerminalIds } from './terminal-orphan-helpers'
+import { buildTerminalTabRetirementPlan } from './terminal-tab-retirement'
+
+// Regression coverage for #9911 ("Terminal window auto-closing. Unable to
+// recover."). After hydration / SSH-relay disconnect the tab row's ptyId and
+// ptyIdsByTabId are cleared, but the still-live session survives in one of the
+// reconnect maps (pendingReconnectPtyIdByTabId / lastKnownRelayPtyIdByTabId /
+// deferredSshSessionIdsByTabId). buildTerminalTabRetirementPlan treats those as
+// live ownership; the orphan sweep must agree, or it hard-deletes a live tab
+// (and its scrollback) before reconnect can rebind it.
+
+// Why: superset state that satisfies both getOrphanTerminalIds (orphan sweep)
+// and buildTerminalTabRetirementPlan (retirement authority) so one fixture can
+// prove the two agree on liveness.
+type TestState = Parameters<typeof buildTerminalTabRetirementPlan>[0]
+
+function makeTab(overrides: Partial<TerminalTab> & { id: string }): TerminalTab {
+  return {
+    ptyId: null,
+    worktreeId: 'wt-1',
+    title: 'claude',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0,
+    ...overrides
+  }
+}
+
+function makeState(overrides: Partial<TestState> = {}): TestState {
+  return {
+    worktreesByRepo: { repo: [{ id: 'wt-1', repoId: 'repo', hostId: 'local' }] },
+    tabsByWorktree: {},
+    unifiedTabsByWorktree: {},
+    ptyIdsByTabId: {},
+    terminalLayoutsByTabId: {},
+    lastKnownRelayPtyIdByTabId: {},
+    deferredSshSessionIdsByTabId: {},
+    pendingReconnectPtyIdByTabId: {},
+    ...overrides
+  } as TestState
+}
+
+describe('getOrphanTerminalIds reconnect-map liveness', () => {
+  it('does not orphan a tab whose live session survives in pendingReconnectPtyIdByTabId', () => {
+    const state = makeState({
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'T1', ptyId: null })] },
+      ptyIdsByTabId: { T1: [] },
+      unifiedTabsByWorktree: { 'wt-1': [] },
+      pendingReconnectPtyIdByTabId: { T1: 'session-live' }
+    })
+
+    // The retirement authority already treats the reconnecting session as a
+    // live PTY it must tear down on close…
+    expect(buildTerminalTabRetirementPlan(state, 'T1').ptyIds).toContain('session-live')
+    // …so the orphan sweep must not classify the same tab as dead.
+    expect(getOrphanTerminalIds(state, 'wt-1')).not.toContain('T1')
+  })
+
+  it('does not orphan a tab whose live session survives in lastKnownRelayPtyIdByTabId', () => {
+    const state = makeState({
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'T1' })] },
+      ptyIdsByTabId: { T1: [] },
+      unifiedTabsByWorktree: { 'wt-1': [] },
+      lastKnownRelayPtyIdByTabId: { T1: 'relay:conn@@pty-live' }
+    })
+
+    expect(getOrphanTerminalIds(state, 'wt-1')).not.toContain('T1')
+  })
+
+  it('does not orphan a tab whose live session survives in deferredSshSessionIdsByTabId', () => {
+    const state = makeState({
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'T1' })] },
+      ptyIdsByTabId: { T1: [] },
+      unifiedTabsByWorktree: { 'wt-1': [] },
+      deferredSshSessionIdsByTabId: { T1: 'ssh-session-live' }
+    })
+
+    expect(getOrphanTerminalIds(state, 'wt-1')).not.toContain('T1')
+  })
+
+  it('still orphans a tab with no live PTY evidence anywhere', () => {
+    const state = makeState({
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'dead', ptyId: null })] },
+      ptyIdsByTabId: { dead: [] },
+      unifiedTabsByWorktree: { 'wt-1': [] }
+    })
+
+    expect(getOrphanTerminalIds(state, 'wt-1')).toContain('dead')
+  })
+
+  // A persisted layout leaf binding is NOT a liveness signal: SSH-target removal
+  // nulls ptyId/ptyIdsByTabId/reconnect maps but intentionally leaves the layout
+  // leaf ptyIds pointing at a relay that is gone. Such a tab must still be swept,
+  // or it lingers forever bound to a dead relay it can never reattach.
+  it('still orphans a tab whose only reference is a stale layout leaf binding', () => {
+    const state = makeState({
+      tabsByWorktree: { 'wt-1': [makeTab({ id: 'stale-layout', ptyId: null })] },
+      ptyIdsByTabId: { 'stale-layout': [] },
+      unifiedTabsByWorktree: { 'wt-1': [] },
+      terminalLayoutsByTabId: {
+        'stale-layout': {
+          root: { type: 'leaf', leafId: 'leaf-1' },
+          activeLeafId: 'leaf-1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'leaf-1': 'dead-relay-pty' }
+        }
+      }
+    })
+
+    expect(getOrphanTerminalIds(state, 'wt-1')).toContain('stale-layout')
+  })
+})

--- a/src/renderer/src/store/slices/terminal-orphan-helpers.ts
+++ b/src/renderer/src/store/slices/terminal-orphan-helpers.ts
@@ -1,9 +1,38 @@
 import type { AppState } from '../types'
 
-type OrphanTerminalDetectionState = Pick<
+type TerminalTabReconnectState = Pick<
   AppState,
-  'tabsByWorktree' | 'unifiedTabsByWorktree' | 'ptyIdsByTabId'
+  | 'ptyIdsByTabId'
+  | 'lastKnownRelayPtyIdByTabId'
+  | 'deferredSshSessionIdsByTabId'
+  | 'pendingReconnectPtyIdByTabId'
 >
+
+type OrphanTerminalDetectionState = Pick<AppState, 'tabsByWorktree' | 'unifiedTabsByWorktree'> &
+  TerminalTabReconnectState
+
+/**
+ * Whether a tab is currently attached to, or actively reconnecting to, a live
+ * PTY. This deliberately checks only the live-attachment and reconnect maps —
+ * NOT terminalLayoutsByTabId leaf bindings, which are a persisted layout that
+ * can outlive its session (e.g. after an SSH target is removed) and must not
+ * keep a dead tab pinned in the orphan sweep. The reconnect maps are the ones
+ * retirement planning also honors as live ownership, so a tab it would tear
+ * down on close is never swept as a dead orphan first (#9911).
+ */
+export function terminalTabHasReconnectablePty(
+  state: TerminalTabReconnectState,
+  tabId: string,
+  rowPtyId: string | null | undefined
+): boolean {
+  return Boolean(
+    (state.ptyIdsByTabId[tabId]?.length ?? 0) > 0 ||
+    rowPtyId ||
+    state.lastKnownRelayPtyIdByTabId[tabId] ||
+    state.deferredSshSessionIdsByTabId[tabId] ||
+    state.pendingReconnectPtyIdByTabId[tabId]
+  )
+}
 
 type OrphanTerminalCleanupState = Pick<
   AppState,
@@ -42,8 +71,11 @@ export function getOrphanTerminalIds(
         if (unifiedTerminalEntityIds.has(tab.id)) {
           return false
         }
-        const livePtyIds = state.ptyIdsByTabId[tab.id] ?? []
-        return livePtyIds.length === 0 && tab.ptyId == null
+        // Why: a tab is orphaned only when it owns NO live/reconnecting PTY; a
+        // tab whose session survives in a reconnect map (SSH relay / daemon
+        // reattach) is alive and must not be swept before reconnect rebinds it
+        // (#9911).
+        return !terminalTabHasReconnectablePty(state, tab.id, tab.ptyId)
       })
       .map((tab) => tab.id)
   )

--- a/src/renderer/src/store/slices/terminals-hydration.test.ts
+++ b/src/renderer/src/store/slices/terminals-hydration.test.ts
@@ -481,6 +481,54 @@ describe('hydrateWorkspaceSession', () => {
     })
   })
 
+  it('stops deferring a session once its SSH target is known-absent, but keeps deferring present targets', async () => {
+    // #9911: a repo can outlive its SSH target (removed out of band). Once the
+    // authoritative target list has loaded, its persisted session is dead — don't
+    // re-defer it. A stranded deferred id reads as liveness in the orphan sweep, so
+    // after a later missing-target pane mount clears ptyIdsByTabId it would pin the
+    // dead tab forever. A present (merely disconnected) target must still defer.
+    const store = createTestStore()
+    const goneWt = 'repo-gone::/home/user/remote-gone'
+    const liveWt = 'repo-live::/home/user/remote-live'
+    seedStore(store, {
+      repos: [
+        { ...TEST_REPO, id: 'repo-gone', connectionId: 'ssh-target-removed' },
+        { ...TEST_REPO, id: 'repo-live', connectionId: 'ssh-target-present' }
+      ],
+      worktreesByRepo: {},
+      // Authoritative target list is loaded and lists only the present target.
+      sshTargetsHydrated: true,
+      sshTargetLabels: new Map([['ssh-target-present', 'Present']])
+    })
+
+    const session: WorkspaceSessionState = {
+      activeRepoId: 'repo-live',
+      activeWorktreeId: liveWt,
+      activeTabId: 'tab-live',
+      tabsByWorktree: {
+        [goneWt]: [makeTab({ id: 'tab-gone', worktreeId: goneWt, ptyId: null })],
+        [liveWt]: [makeTab({ id: 'tab-live', worktreeId: liveWt, ptyId: null })]
+      },
+      terminalLayoutsByTabId: {},
+      activeWorktreeIdsOnShutdown: [goneWt, liveWt],
+      remoteSessionIdsByTabId: {
+        'tab-gone': 'ssh:ssh-target-removed@@pty-7',
+        'tab-live': 'ssh:ssh-target-present@@pty-8'
+      }
+    }
+
+    store.getState().hydrateWorkspaceSession(session)
+    await store.getState().reconnectPersistedTerminals()
+
+    // Removed target: no stranded deferred/pending reconnect evidence.
+    expect(store.getState().deferredSshSessionIdsByTabId['tab-gone']).toBeUndefined()
+    expect(store.getState().pendingReconnectPtyIdByTabId['tab-gone']).toBeUndefined()
+    // Present-but-disconnected target: still deferred for a normal reconnect.
+    expect(store.getState().deferredSshSessionIdsByTabId['tab-live']).toBe(
+      'ssh:ssh-target-present@@pty-8'
+    )
+  })
+
   it('resets persisted agent titles to the fallback label on hydration', () => {
     const store = createTestStore()
     const worktreeId = 'repo1::/wt-1'

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -2068,7 +2068,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       // Why: a passed ptyId means the PTY actually exited — drop its lastKnown so restart won't reattach a dead relay; bulk clear (connection_lost) keeps it during relay grace.
       const nextLastKnownRelay = { ...s.lastKnownRelayPtyIdByTabId }
       if (ptyId && nextLastKnownRelay[tabId] === ptyId) {
-        delete nextLastKnownRelay[tabId]
+        // Why: the relay slot holds ONE id per tab (the last pane to bind). If
+        // that pane exits, promote a surviving pane instead of clearing — else the
+        // survivor is left visible only in the layout leaf map, and a later
+        // relay-drop bulk-clear lets the orphan sweep delete the still-live tab
+        // (the orphan predicate reads this map but not layout leaves) (#9911).
+        const survivingPtyId = remainingPtyIds.at(-1)
+        if (survivingPtyId) {
+          nextLastKnownRelay[tabId] = survivingPtyId
+        } else {
+          delete nextLastKnownRelay[tabId]
+        }
       }
 
       return {
@@ -3432,6 +3442,15 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const repoId = worktree?.repoId ?? getRepoIdFromWorktreeId(worktreeId)
       const repo = repoId ? get().repos.find((entry) => entry.id === repoId) : null
       if (!repo?.connectionId) {
+        continue
+      }
+      // Why: a repo can outlive its SSH target when the target was removed out of
+      // band (a crash between removal and cleanup, or edited out of the config).
+      // Once the authoritative target list has loaded, don't re-defer sessions for
+      // a target it no longer lists — a stranded deferred id reads as liveness and
+      // the orphan sweep could never remove the dead tab. Defer while the list is
+      // still unknown so a normal cold-start reconnect isn't dropped (#9911).
+      if (get().sshTargetsHydrated && !get().sshTargetLabels.has(repo.connectionId)) {
         continue
       }
       const sshConnected = get().sshConnectionStates.get(repo.connectionId)?.status === 'connected'

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2155,6 +2155,9 @@ function buildWorktreePurgeState(s: AppState, worktreeIds: string[]): Partial<Ap
     canExpandPaneByTabId: omitByTabId(s.canExpandPaneByTabId),
     // Why: these per-tab/per-pty terminal+agent maps evict on the single removeWorktree teardown path; the bulk reconcile / remove-project / hydration-stale paths run no teardown, so without these each strands an entry per tab/pane of externally-removed worktrees.
     lastKnownRelayPtyIdByTabId: omitByTabId(s.lastKnownRelayPtyIdByTabId),
+    // Why: liveness-authoritative reconnect maps (orphan sweep reads them); drop purged tabs' entries here too so a re-materialized id can't inherit phantom liveness.
+    pendingReconnectPtyIdByTabId: omitByTabId(s.pendingReconnectPtyIdByTabId),
+    deferredSshSessionIdsByTabId: omitByTabId(s.deferredSshSessionIdsByTabId),
     pendingInitialCwdByTabId: omitByTabId(s.pendingInitialCwdByTabId),
     pendingIssueCommandSplitByTabId: omitByTabId(s.pendingIssueCommandSplitByTabId),
     pendingSetupSplitByTabId: omitByTabId(s.pendingSetupSplitByTabId),


### PR DESCRIPTION
## Summary

Fixes #9911 — "Terminal window auto-closing. Unable to recover." A terminal running Claude Code (or any agent) would suddenly vanish from the UI with no way to get it back, even though the underlying PTY was still alive in the background.

**Root cause: two modules disagreed about what counts as a live PTY.** The terminal *retirement planner* (`collectPtyIdsForTab`) treats a tab's reconnect maps — `pendingReconnectPtyIdByTabId`, `lastKnownRelayPtyIdByTabId`, `deferredSshSessionIdsByTabId` — as live PTY ownership (it will tear those sessions down when you close the tab). But the *orphan sweep* (`getOrphanTerminalIds`) judged liveness from only `ptyIdsByTabId` + the tab-row `ptyId`. After hydration or an SSH-relay drop, a tab's row `ptyId`/`ptyIdsByTabId` are cleared while the still-live session survives in a reconnect map. The sweep then classified that live tab as a dead orphan and **hard-deleted it (tab + layout + scrollback) before reconnect could rebind it** — irrecoverable, with the agent still running headless. This is the local, non-remote core of the bug (SSH/remote just widen the window).

The fix makes the orphan sweep and the legacy→unified migration filter judge liveness from the same "attached-or-reconnecting" definition the retirement planner uses, and closes the surrounding lifecycle gaps that could otherwise strand a stale reconnect entry (which would flip the fix into keeping a *dead* tab).

### What changed
- **`terminal-orphan-helpers.ts`** — new `terminalTabHasReconnectablePty` predicate: a tab is live if it has `ptyIdsByTabId`, a row `ptyId`, or an entry in any of the three reconnect maps. `getOrphanTerminalIds` uses it, so a reconnecting tab is never swept. (It deliberately does **not** trust persisted `terminalLayoutsByTabId` leaf bindings, which can outlive their session.)
- **`tabs.ts`** — the `reconcileWorktreeTabModel` legacy-tab migration filter uses the same predicate, so a reconnecting tab whose unified entry is transiently missing is re-migrated into its group (renders + reconnects) instead of lingering invisibly.
- **`ssh-target-cleanup.ts`** — removing an SSH target now also clears `pendingReconnect` + `deferredSsh` for its tabs (previously left stale), so the predicate can't keep a genuinely dead tab alive after target removal.
- **`terminals.ts`**
  - `clearTabPtyId` now **promotes a surviving pane** into the single per-tab relay slot when the slot-owning pane exits (instead of clearing it) — otherwise a split tab's surviving live pane could be visible only in the layout leaf map and get swept on the next relay drop (data loss).
  - `reconnectPersistedTerminals` no longer defers a persisted session whose SSH target is **known-absent** (authoritative target list loaded and doesn't list it), so a removed-out-of-band target can't strand a reconnect entry.
- **`worktrees.ts`** — bulk worktree purge omits the two reconnect maps too (they're now liveness-authoritative), matching the existing `lastKnownRelay` omission.

## ELI5

Every terminal tab has a little "is this alive?" checker. When you're on a flaky/SSH connection, a tab briefly loses its direct phone line but keeps a "call me back on this number" sticky note. One part of the app (the tab-closer) knew that sticky note means "still alive — reconnecting." But the cleanup crew that removes dead tabs didn't read the sticky note, so it saw "no phone line = dead" and threw the whole tab in the trash — deleting your still-running Claude session with no undo.

This PR makes the cleanup crew read the same sticky notes the tab-closer reads, so a tab that's just reconnecting is never thrown away. It also tidies the sticky notes when they're genuinely stale (target removed, split-pane closed) so we don't keep a truly-dead tab around by mistake.

## Proof of fix

Every fix ships a regression test that was **verified to fail on the pre-fix code and pass after** (`git stash` of the source-only change → test fails → restore → passes):

| Scenario | Test |
|---|---|
| Reconnecting tab (session only in a reconnect map) not swept; sweep still agrees with `buildTerminalTabRetirementPlan` | `terminal-orphan-helpers.test.ts` |
| End-to-end: reconnecting tab survives `reconcileWorktreeTabModel` + re-migrates into the unified model | `tabs.test.ts` |
| Stale layout-leaf-only tab *is* still swept (guards the deliberate exclusion) | `terminal-orphan-helpers.test.ts` |
| SSH-target removal clears `pendingReconnect` | `ssh.test.ts` |
| Split-pane relay-slot promotes a survivor → not orphaned after a relay drop | `store-cascades.test.ts` |
| Known-absent SSH target no longer defers (present target still defers) | `terminals-hydration.test.ts` |
| Bulk purge evicts the two reconnect maps | `bulk-worktree-purge-terminal-maps-leak.test.ts` |

## Testing

- [x] `pnpm typecheck` (node + cli + web) — clean
- [x] `pnpm test` — full renderer store-slice suite **1917 tests / 120 files pass**; renderer runtime **491 pass**; targeted slot-consumer suites pass
- [x] `oxlint` on all changed files — clean
- [x] Added high-quality regression tests, each mutation-verified (fails without its fix)
- [ ] `pnpm build`

## AI Review Report

Ran a 6-round adversarial review loop with two independent frontier models (GPT-5.6-Sol at xhigh reasoning, and Claude Fable 5), each instructed to *refute* the fix — hunting correctness bugs, regressions, and edge cases, and to trace every cleanup path that could keep a tab row alive with a stale liveness signal. The loop converged on a **CLEAN (converged) verdict from both reviewers**, with a final round in which both reviewers additionally traced the component-level pane-mount reconnect paths (`pty-connection.ts`) and cross-checked each other's assumptions, finding nothing new. It caught four real edge cases that were fixed before merge:

1. **Persisted-layout leaves as false liveness** (fable R1): an earlier draft trusted `terminalLayoutsByTabId` leaf bindings, which SSH-target removal leaves stale → would *resurrect a dead tab*. Fixed by excluding layout leaves from the predicate; added a regression test that a stale-layout-leaf-only tab is still swept.
2. **`pendingReconnect` not cleared on SSH-target removal** (gpt R2): a hydration-race window left a stale entry → dead tab kept. Fixed in `ssh-target-cleanup.ts`.
3. **Split-pane relay-slot data loss** (gpt R3): the single per-tab relay slot wasn't promoting a survivor when the slot-owning pane exited → a *live* pane could be swept on the next relay drop. Fixed in `clearTabPtyId`.
4. **Absent-target defer stranding** (gpt R4): a target removed out-of-band could strand a `deferredSsh` entry that survives a failed reconnect → dead tab kept. Fixed with a guarded skip in `reconnectPersistedTerminals`.

Both reviewers independently verified: no import cycle, type-clean, genuine-death tabs still swept (every exact-clear site pairs `clearTabPtyId` with `clearExitedPanePtyLayoutBinding`, so a cleared PTY is always genuinely dead and the survivor logic keeps row/slot on a live sibling), no false-drop of legitimate reconnects, and every regression test fails on the pre-fix code (mutation-checked). **Cross-platform** compatibility was explicitly reviewed — the change is platform-agnostic renderer store logic with no shortcuts, labels, filesystem paths, shell behavior, or Electron main/preload surface touched; SSH id handling uses existing shared helpers.

Two non-defects were noted and confirmed out of scope (both pre-existing, neither introduced here): the `ptyIdsByTabId: ['']` length-check edge (no production producer creates it), and the absent-target "ghost tab" — which is intended, user-closable ghost-workspace UX (a tab left *visible*), the opposite failure mode from #9911's silent *deletion*.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, IPC surface, or dependencies. The change is pure renderer store-state reconciliation logic (Zustand slices) operating on already-trusted in-process session state — no external input is parsed or executed. SSH session ids are only compared for membership/scoping, never executed or used to construct commands. No security-relevant risk identified.

## Notes

- **Cross-platform:** no platform-specific code paths, keyboard shortcuts, labels, or filesystem paths are touched. Logic is identical on macOS/Linux/Windows; SSH id parsing uses the existing `parseAppSshPtyId` helper. No Electron main/preload surface changed.
- **Severity ordering of the fixes:** the predicate + split-pane fixes prevent *live-session data loss* (the reported bug). The SSH-target-cleanup, absent-target-defer, and purge changes prevent the inverse — keeping a *dead* tab alive — which the broader predicate would otherwise risk.
- The change is deliberately scoped to the orphan-sweep / reconnect-liveness contract; the broader terminal-session-management rewrite discussed in the issue thread is out of scope here.
