### PR TITLE
Centralize built-in Chat UI agent adapters

### DIFF
--- a/docs/structured-agent-adapter-foundation.md
+++ b/docs/structured-agent-adapter-foundation.md
@@ -1,0 +1,45 @@
+# Structured Agent Adapter Foundation
+
+Issue [#10099](https://github.com/stablyai/orca/issues/10099) tracks the versioned external
+adapter contract. This document scopes the first, behavior-preserving migration step.
+
+## Phase 1
+
+`NATIVE_CHAT_AGENT_ADAPTERS` is Orca's immutable built-in registry for Chat UI agent
+policy. Each descriptor owns:
+
+- agent identity and transcript-family aliasing;
+- structured-question answer pacing;
+- skill grammar and source owner;
+- verified command-catalog policy.
+
+`nativeChatTranscriptAdapterForAgent()` maps those descriptors to main-process line and
+turn-lifecycle decoders. Readers, tailers, and watchers consume the adapter instead of
+branching on provider IDs independently.
+
+The registry rejects duplicate agent ownership and snapshots descriptors before exposing
+them. Existing Claude, OpenClaude, Codex, and Grok behavior remains built in.
+
+## Not Yet A Plugin Loader
+
+Phase 1 does not discover packages or execute third-party code. In particular, it does not
+expose renderer, Electron IPC, filesystem, or PTY primitives to adapters.
+
+A later external contract must preserve these boundaries:
+
+- executable adapters run outside the renderer;
+- Orca owns desktop, Web, and mobile rendering from normalized data;
+- filesystem and input operations execute on the runtime that owns the pane;
+- provider-session identity remains separate from Orca pane and client identities;
+- one active session owner/writer is authoritative;
+- unsupported interactions request an explicit terminal handoff;
+- adapter events are bounded, cancellable, and safe under disconnects.
+
+## Adding A Built-In Adapter
+
+A built-in integration should add one descriptor, its transcript adapter, and conformance
+fixtures. If the integration needs a new transcript family, extend the
+`NativeChatTranscriptAgent` union and the exhaustive main-process transcript adapter map.
+
+Do not infer interaction policy from transcript family. Agents that share a transcript
+format can still have different composer, question, command, or session semantics.

--- a/src/main/native-chat/native-chat-transcript-adapters.test.ts
+++ b/src/main/native-chat/native-chat-transcript-adapters.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeNativeChatTranscriptLine,
+  decodeNativeChatTurnLifecycle,
+  nativeChatTranscriptAdapterForAgent
+} from './native-chat-transcript-adapters'
+
+describe('native chat transcript adapters', () => {
+  it('shares Claude decoding with OpenClaude without sharing agent identity', () => {
+    const claude = nativeChatTranscriptAdapterForAgent('claude')
+    const openclaude = nativeChatTranscriptAdapterForAgent('openclaude')
+
+    expect(claude).not.toBeNull()
+    expect(openclaude).toBe(claude)
+  })
+
+  it('routes Codex records through its registered decoder', () => {
+    const adapter = nativeChatTranscriptAdapterForAgent('codex')!
+    const message = decodeNativeChatTranscriptLine(
+      adapter,
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-01-01T00:00:00.000Z',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'adapter output' }]
+        }
+      }),
+      'fallback-id'
+    )
+
+    expect(message).toMatchObject({ role: 'assistant' })
+    expect(message?.blocks).toContainEqual({ type: 'text', text: 'adapter output' })
+  })
+
+  it('keeps line and lifecycle decoders in the same registered adapter', () => {
+    const codex = nativeChatTranscriptAdapterForAgent('codex')!
+    const grok = nativeChatTranscriptAdapterForAgent('grok')!
+    const lifecycleLine = JSON.stringify({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      type: 'event_msg',
+      payload: { type: 'task_started', turn_id: 'turn-1' }
+    })
+
+    expect(decodeNativeChatTurnLifecycle(codex, lifecycleLine, 'fallback-id')).toMatchObject({
+      state: 'working',
+      turnId: 'turn-1'
+    })
+    expect(decodeNativeChatTurnLifecycle(grok, lifecycleLine, 'fallback-id')).toBeNull()
+  })
+
+  it('rejects agents without a transcript adapter', () => {
+    expect(nativeChatTranscriptAdapterForAgent('cursor')).toBeNull()
+    expect(nativeChatTranscriptAdapterForAgent(null)).toBeNull()
+  })
+})

--- a/src/main/native-chat/native-chat-transcript-adapters.ts
+++ b/src/main/native-chat/native-chat-transcript-adapters.ts
@@ -1,0 +1,68 @@
+import type { NativeChatMessage, NativeChatTurnLifecycle } from '../../shared/native-chat-types'
+import {
+  NATIVE_CHAT_AGENT_ADAPTERS,
+  type NativeChatTranscriptAgent
+} from '../../shared/native-chat-agent-adapters'
+import {
+  decodeClaudeTranscriptLine,
+  decodeCodexTranscriptLine,
+  decodeGrokTranscriptLine
+} from './transcript-line-decoders'
+import {
+  decodeClaudeTurnLifecycle,
+  decodeCodexTurnLifecycle,
+  type NativeChatTurnLifecycleDecoder
+} from './transcript-turn-lifecycle'
+
+/** Decodes one provider JSONL record into a normalized Chat UI message. */
+export type NativeChatLineDecoder = (line: string, fallbackId: string) => NativeChatMessage | null
+
+export type NativeChatTranscriptAdapter = Readonly<{
+  /** Maps one provider JSONL record into Orca's normalized message model. */
+  decodeLine: NativeChatLineDecoder
+  /** Maps explicit provider turn boundaries when the transcript family exposes them. */
+  decodeLifecycle: NativeChatTurnLifecycleDecoder | null
+}>
+
+const NATIVE_CHAT_TRANSCRIPT_ADAPTERS: Readonly<
+  Record<NativeChatTranscriptAgent, NativeChatTranscriptAdapter>
+> = Object.freeze({
+  claude: Object.freeze({
+    decodeLine: decodeClaudeTranscriptLine,
+    decodeLifecycle: decodeClaudeTurnLifecycle
+  }),
+  codex: Object.freeze({
+    decodeLine: decodeCodexTranscriptLine,
+    decodeLifecycle: decodeCodexTurnLifecycle
+  }),
+  grok: Object.freeze({
+    decodeLine: decodeGrokTranscriptLine,
+    decodeLifecycle: null
+  })
+})
+
+/** Resolves the main-process line and lifecycle decoders registered for an agent. */
+export function nativeChatTranscriptAdapterForAgent(
+  agent: string | null | undefined
+): NativeChatTranscriptAdapter | null {
+  const descriptor = NATIVE_CHAT_AGENT_ADAPTERS.get(agent)
+  return descriptor ? NATIVE_CHAT_TRANSCRIPT_ADAPTERS[descriptor.transcriptAgent] : null
+}
+
+/** Decodes one provider transcript record with the adapter's line decoder. */
+export function decodeNativeChatTranscriptLine(
+  adapter: NativeChatTranscriptAdapter,
+  line: string,
+  fallbackId: string
+): NativeChatMessage | null {
+  return adapter.decodeLine(line, fallbackId)
+}
+
+/** Decodes an optional turn boundary without inferring lifecycle from visible messages. */
+export function decodeNativeChatTurnLifecycle(
+  adapter: NativeChatTranscriptAdapter,
+  line: string,
+  fallbackId: string
+): NativeChatTurnLifecycle | null {
+  return adapter.decodeLifecycle?.(line, fallbackId) ?? null
+}

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -4,14 +4,9 @@ import type {
   NativeChatMessage,
   NativeChatTurnLifecycle
 } from '../../shared/native-chat-types'
-import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
 import { errorMessage } from '../ai-vault/session-scanner-values'
 import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
-import {
-  decodeClaudeTranscriptLine,
-  decodeCodexTranscriptLine,
-  decodeGrokTranscriptLine
-} from './transcript-line-decoders'
+import { nativeChatTranscriptAdapterForAgent } from './native-chat-transcript-adapters'
 import { decodeTranscriptStream } from './transcript-stream-lines'
 
 export type ReadTranscriptResult =
@@ -45,17 +40,11 @@ export async function readNativeChatTranscript(
     return { error: `No transcript found for ${agent} session ${sessionId}`, notFound: true }
   }
   try {
-    const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-    if (transcriptAgent === 'claude') {
-      return { messages: await readTranscript(filePath, decodeClaudeTranscriptLine) }
+    const adapter = nativeChatTranscriptAdapterForAgent(agent)
+    if (!adapter) {
+      return { error: `Unsupported agent for Chat UI transcript: ${agent}` }
     }
-    if (transcriptAgent === 'codex') {
-      return { messages: await readTranscript(filePath, decodeCodexTranscriptLine) }
-    }
-    if (transcriptAgent === 'grok') {
-      return { messages: await readTranscript(filePath, decodeGrokTranscriptLine) }
-    }
-    return { error: `Unsupported agent for Chat UI transcript: ${agent}` }
+    return { messages: await readTranscript(filePath, adapter.decodeLine) }
   } catch (err) {
     // Why: ENOENT after a successful resolve is the same first-flush/rotation
     // race as an unresolved path — keep it retry-worthy (#8401).
@@ -66,6 +55,7 @@ export async function readNativeChatTranscript(
   }
 }
 
+/** Streams and decodes every complete transcript record from a resolved file. */
 async function readTranscript(
   filePath: string,
   decode: (line: string, fallbackId: string) => NativeChatMessage | null

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -4,38 +4,27 @@ import type {
   NativeChatMessage,
   NativeChatTurnLifecycle
 } from '../../shared/native-chat-types'
-import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
 import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
 import {
-  decodeClaudeTranscriptLine,
-  decodeCodexTranscriptLine,
-  decodeGrokTranscriptLine
-} from './transcript-line-decoders'
+  nativeChatTranscriptAdapterForAgent,
+  type NativeChatLineDecoder
+} from './native-chat-transcript-adapters'
 import { transcriptFallbackId } from './transcript-fallback-id'
-import {
-  nativeChatTurnLifecycleDecoderForAgent,
-  type NativeChatTurnLifecycleDecoder
-} from './transcript-turn-lifecycle'
+import type { NativeChatTurnLifecycleDecoder } from './transcript-turn-lifecycle'
 
 export const MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES = 2 * 1024 * 1024
 const TAIL_CHUNK_BYTES = 64 * 1024
 
-export type NativeChatLineDecoder = (line: string, fallbackId: string) => NativeChatMessage | null
+export type { NativeChatLineDecoder } from './native-chat-transcript-adapters'
 
+/** Resolves the registered line decoder while preserving the legacy tail-reader API. */
 export function nativeChatLineDecoderForAgent(agent: AgentType): NativeChatLineDecoder | null {
-  const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  if (transcriptAgent === 'claude') {
-    return decodeClaudeTranscriptLine
-  }
-  if (transcriptAgent === 'codex') {
-    return decodeCodexTranscriptLine
-  }
-  if (transcriptAgent === 'grok') {
-    return decodeGrokTranscriptLine
-  }
-  return null
+  return nativeChatTranscriptAdapterForAgent(agent)?.decodeLine ?? null
 }
 
+/**
+ * Reads a bounded transcript window from the end of a file, including optional lifecycle state.
+ */
 export async function readNativeChatTranscriptTailFile(
   filePath: string,
   limit: number,
@@ -107,6 +96,7 @@ export async function readNativeChatTranscriptTailFile(
     await handle.close()
   }
 
+  /** Retains one reverse-scanned line segment unless the record exceeds the byte limit. */
   function retainPart(part: Buffer): void {
     if (lineOversized) {
       return
@@ -120,12 +110,14 @@ export async function readNativeChatTranscriptTailFile(
     lineParts.push(part)
   }
 
+  /** Clears reverse-scan state before collecting the next transcript record. */
   function resetLine(): void {
     lineParts.length = 0
     lineBytes = 0
     lineOversized = false
   }
 
+  /** Decodes one reconstructed line and records its message and lifecycle state. */
   function decodeLine(
     lineOffset: number,
     messages: { message: NativeChatMessage; offset: number }[]
@@ -149,6 +141,7 @@ export async function readNativeChatTranscriptTailFile(
   }
 }
 
+/** Finds the byte offset immediately after the final complete newline-delimited record. */
 async function findLastCompleteLineEnd(
   handle: Awaited<ReturnType<typeof open>>,
   end: number
@@ -172,6 +165,7 @@ async function findLastCompleteLineEnd(
   return 0
 }
 
+/** Resolves an agent transcript and returns its bounded, paginated tail snapshot. */
 export async function readNativeChatTranscriptTail(
   args: ResolveSessionFileOptions & {
     agent: AgentType
@@ -190,8 +184,9 @@ export async function readNativeChatTranscriptTail(
     }
   | { error: string; notFound?: true }
 > {
-  const decode = nativeChatLineDecoderForAgent(args.agent)
-  const decodeLifecycle = nativeChatTurnLifecycleDecoderForAgent(args.agent)
+  const adapter = nativeChatTranscriptAdapterForAgent(args.agent)
+  const decode = adapter?.decodeLine ?? null
+  const decodeLifecycle = adapter?.decodeLifecycle ?? null
   const filePath = args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args))
   if (!decode) {
     return { error: 'Transcript unavailable' }

--- a/src/main/native-chat/transcript-watch-engine.ts
+++ b/src/main/native-chat/transcript-watch-engine.ts
@@ -12,7 +12,7 @@ import {
 } from './transcript-incremental-reader'
 import { createTranscriptNativeWatcher } from './transcript-native-watcher'
 import { readNativeChatTranscriptTailFile } from './transcript-tail-reader'
-import { nativeChatTurnLifecycleDecoderForAgent } from './transcript-turn-lifecycle'
+import { nativeChatTranscriptAdapterForAgent } from './native-chat-transcript-adapters'
 import type {
   NativeChatTranscriptSubscription,
   SubscribeNativeChatTranscriptArgs
@@ -23,10 +23,12 @@ const ROTATION_RETRY_MS = 25
 const MAX_ROTATION_RETRY_MS = 2_000
 let activeWatcherCount = 0
 
+/** Returns the number of installed transcript watchers for diagnostics and tests. */
 export function getActiveNativeChatWatcherCount(): number {
   return activeWatcherCount
 }
 
+/** Captures bytes immediately before an offset to detect same-size transcript replacement. */
 async function boundaryFingerprint(filePath: string, offset: number): Promise<string> {
   if (offset <= 0) {
     return ''
@@ -43,10 +45,11 @@ async function boundaryFingerprint(filePath: string, offset: number): Promise<st
 }
 
 /**
- * Install the live-tail engine on an already-resolved file path. Returns null
- * when the file doesn't exist yet, so the caller falls back to resolve-polling.
- * A failed native watch still installs a reconciliation-only subscription: some
- * remote filesystems allow stat/read while rejecting fs.watch entirely.
+ * Installs the live-tail engine on an already-resolved file path with the
+ * registered line and lifecycle decoders. Returns null when the file doesn't
+ * exist yet, so the caller falls back to resolve-polling. A failed native watch
+ * still installs a reconciliation-only subscription: some remote filesystems
+ * allow stat/read while rejecting fs.watch entirely.
  */
 export async function installTranscriptWatcher(
   filePath: string,
@@ -59,7 +62,7 @@ export async function installTranscriptWatcher(
     return null
   }
   const { onAppend, onInitialSnapshot, onReplace, initialLimit } = args
-  const decodeLifecycle = nativeChatTurnLifecycleDecoderForAgent(args.agent)
+  const decodeLifecycle = nativeChatTranscriptAdapterForAgent(args.agent)?.decodeLifecycle ?? null
 
   const state: IncrementalTranscriptState = {
     offset: 0,
@@ -79,6 +82,7 @@ export async function installTranscriptWatcher(
   let pendingReadRequested = false
   let rotationRetryCount = 0
 
+  /** Schedules bounded exponential retry when a watcher cannot rebind after rotation. */
   function scheduleRotationRetry(): void {
     if (closed) {
       return
@@ -92,6 +96,7 @@ export async function installTranscriptWatcher(
     }
   }
 
+  /** Reads newly appended records and emits visible messages with authoritative lifecycle state. */
   async function readAndEmitAppends(): Promise<void> {
     let lifecycle: NativeChatTurnLifecycle | undefined
     const remaining = await readIncrementalTranscriptMessages(
@@ -113,6 +118,7 @@ export async function installTranscriptWatcher(
     }
   }
 
+  /** Commits file identity after a drain and schedules another pass for concurrent writes. */
   async function finishSuccessfulDrain(startVersion: TranscriptFileVersion): Promise<void> {
     watchedBoundary = await boundaryFingerprint(filePath, state.offset)
     const completedVersion = await readTranscriptFileVersion(filePath)
@@ -134,6 +140,7 @@ export async function installTranscriptWatcher(
     scheduleRotationRetry()
   }
 
+  /** Reconciles one observed file version against the incremental reader state. */
   async function drainOnce(): Promise<void> {
     const current = await readTranscriptFileVersion(filePath)
     const currentBoundary = await boundaryFingerprint(filePath, state.offset)
@@ -239,6 +246,7 @@ export async function installTranscriptWatcher(
     await finishSuccessfulDrain(current)
   }
 
+  /** Serializes requested drains while coalescing writes that arrive during an active read. */
   async function drain(): Promise<void> {
     if (closed) {
       return
@@ -272,6 +280,7 @@ export async function installTranscriptWatcher(
     }
   }
 
+  /** Requests reconciliation from either a native watch event or the fallback scheduler. */
   async function reconcile(): Promise<void> {
     if (closed) {
       return

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -2,11 +2,11 @@ import { extname } from 'node:path'
 import type { NativeChatMessage } from '../../shared/native-chat-types'
 import { resolveSessionFilePath } from './session-file-resolver'
 import { installTranscriptWatcher } from './transcript-watch-engine'
+import { nativeChatTranscriptAdapterForAgent } from './native-chat-transcript-adapters'
 import type {
   NativeChatTranscriptSubscription,
   SubscribeNativeChatTranscriptArgs
 } from './transcript-watch-contract'
-import { nativeChatLineDecoderForAgent } from './transcript-tail-reader'
 
 export { readNativeChatTranscriptTail } from './transcript-tail-reader'
 export { getActiveNativeChatWatcherCount } from './transcript-watch-engine'
@@ -37,6 +37,7 @@ const INITIAL_RESOLVE_POLL_MS = 500
 const MAX_RESOLVE_POLL_MS = 5_000
 const FALLBACK_RESOLVE_POLL_MS = 5_000
 
+/** Returns a trusted explicit JSONL path that can be retried without recursive discovery. */
 function exactTranscriptPath(args: SubscribeNativeChatTranscriptArgs): string | null {
   const path = args.transcriptPath?.trim()
   return path && extname(path) === '.jsonl' ? path : null
@@ -61,6 +62,7 @@ function subscribeViaResolvePoll(
   let lastFallbackResolveAt = Date.now()
   const exactPath = exactTranscriptPath(args)
 
+  /** Schedules the next resolve attempt with bounded backoff. */
   function scheduleAttempt(): void {
     if (closed) {
       return
@@ -85,6 +87,7 @@ function subscribeViaResolvePoll(
     }
   }
 
+  /** Resolves and installs the watcher once, then backs off when the file is not flushed yet. */
   async function runAttempt(): Promise<void> {
     if (closed) {
       return
@@ -151,7 +154,7 @@ function subscribeViaResolvePoll(
 export async function subscribeNativeChatTranscript(
   args: SubscribeNativeChatTranscriptArgs
 ): Promise<NativeChatTranscriptSubscription> {
-  const decode = nativeChatLineDecoderForAgent(args.agent)
+  const decode = nativeChatTranscriptAdapterForAgent(args.agent)?.decodeLine ?? null
   if (!decode) {
     // Nothing watchable — return a no-op teardown so callers can unconditionally
     // unsubscribe without null-checks.

--- a/src/shared/native-chat-agent-adapters.test.ts
+++ b/src/shared/native-chat-agent-adapters.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatAgentAdapter } from './native-chat-agent-adapters'
+import {
+  createNativeChatAgentAdapterRegistry,
+  NATIVE_CHAT_AGENT_ADAPTERS
+} from './native-chat-agent-adapters'
+
+describe('native chat agent adapter registry', () => {
+  it('describes the built-in agent families and interaction policies', () => {
+    expect(NATIVE_CHAT_AGENT_ADAPTERS.list()).toHaveLength(4)
+    expect(NATIVE_CHAT_AGENT_ADAPTERS.get('openclaude')).toMatchObject({
+      transcriptAgent: 'claude',
+      askAnswerMode: 'step-lines',
+      skillSourceOwner: 'claude'
+    })
+    expect(NATIVE_CHAT_AGENT_ADAPTERS.get('codex')).toMatchObject({
+      transcriptAgent: 'codex',
+      askAnswerMode: 'step-lines',
+      skillPrefix: '$'
+    })
+    expect(NATIVE_CHAT_AGENT_ADAPTERS.get('cursor')).toBeNull()
+  })
+
+  it('rejects duplicate agent ownership', () => {
+    const adapter = NATIVE_CHAT_AGENT_ADAPTERS.get('codex') as NativeChatAgentAdapter
+    expect(() => createNativeChatAgentAdapterRegistry([adapter, adapter])).toThrow(
+      'Duplicate native chat agent adapter: codex'
+    )
+  })
+
+  it('snapshots adapter descriptors before exposing them', () => {
+    const adapter = {
+      ...NATIVE_CHAT_AGENT_ADAPTERS.get('codex')!
+    } as NativeChatAgentAdapter
+    const registry = createNativeChatAgentAdapterRegistry([adapter])
+
+    expect(registry.get('codex')).not.toBe(adapter)
+    expect(Object.isFrozen(registry.get('codex'))).toBe(true)
+    expect(Object.isFrozen(registry.list())).toBe(true)
+    expect(Object.isFrozen(registry)).toBe(true)
+  })
+})

--- a/src/shared/native-chat-agent-adapters.ts
+++ b/src/shared/native-chat-agent-adapters.ts
@@ -1,0 +1,99 @@
+import type { AgentType } from './agent-status-types'
+
+export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok'
+export type NativeChatAskAnswerMode = 'single-submit' | 'step-lines'
+export type NativeChatCommandCatalog = 'agent' | 'none'
+
+export type NativeChatAgentAdapter = Readonly<{
+  agent: AgentType
+  transcriptAgent: NativeChatTranscriptAgent
+  askAnswerMode: NativeChatAskAnswerMode
+  skillPrefix: '$' | '/'
+  groupedSlash: boolean
+  skillSourceOwner: AgentType
+  commandCatalog: NativeChatCommandCatalog
+}>
+
+export type NativeChatAgentAdapterRegistry = Readonly<{
+  /** Returns the immutable descriptor registered for an agent, or null when unsupported. */
+  get(agent: string | null | undefined): NativeChatAgentAdapter | null
+  /** Returns the frozen registration-order snapshot used to derive supported-agent projections. */
+  list(): readonly NativeChatAgentAdapter[]
+}>
+
+/** Clones and freezes one descriptor before it enters the public registry snapshot. */
+function freezeNativeChatAgentAdapter(adapter: NativeChatAgentAdapter): NativeChatAgentAdapter {
+  return Object.freeze({ ...adapter })
+}
+
+/**
+ * Builds an immutable lookup registry from built-in Chat UI adapter descriptors.
+ * Descriptors are snapshotted and duplicate agent ownership fails fast.
+ */
+export function createNativeChatAgentAdapterRegistry(
+  adapters: readonly NativeChatAgentAdapter[]
+): NativeChatAgentAdapterRegistry {
+  const adaptersByAgent = new Map<string, NativeChatAgentAdapter>()
+  const snapshot = Object.freeze(adapters.map(freezeNativeChatAgentAdapter))
+  for (const adapter of snapshot) {
+    if (adaptersByAgent.has(adapter.agent)) {
+      throw new Error(`Duplicate native chat agent adapter: ${adapter.agent}`)
+    }
+    adaptersByAgent.set(adapter.agent, adapter)
+  }
+
+  /** Returns the frozen descriptor owned by an agent, or null when it is unsupported. */
+  function get(agent: string | null | undefined): NativeChatAgentAdapter | null {
+    return agent ? (adaptersByAgent.get(agent) ?? null) : null
+  }
+
+  /** Returns the stable frozen descriptor snapshot in registration order. */
+  function list(): readonly NativeChatAgentAdapter[] {
+    return snapshot
+  }
+
+  return Object.freeze({ get, list })
+}
+
+const BUILTIN_NATIVE_CHAT_AGENT_ADAPTERS = [
+  {
+    agent: 'claude',
+    transcriptAgent: 'claude',
+    askAnswerMode: 'step-lines',
+    skillPrefix: '/',
+    groupedSlash: true,
+    skillSourceOwner: 'claude',
+    commandCatalog: 'agent'
+  },
+  {
+    agent: 'openclaude',
+    transcriptAgent: 'claude',
+    askAnswerMode: 'step-lines',
+    skillPrefix: '/',
+    groupedSlash: true,
+    skillSourceOwner: 'claude',
+    commandCatalog: 'agent'
+  },
+  {
+    agent: 'codex',
+    transcriptAgent: 'codex',
+    askAnswerMode: 'step-lines',
+    skillPrefix: '$',
+    groupedSlash: false,
+    skillSourceOwner: 'codex',
+    commandCatalog: 'agent'
+  },
+  {
+    agent: 'grok',
+    transcriptAgent: 'grok',
+    askAnswerMode: 'single-submit',
+    skillPrefix: '/',
+    groupedSlash: true,
+    skillSourceOwner: 'grok',
+    commandCatalog: 'none'
+  }
+] as const satisfies readonly NativeChatAgentAdapter[]
+
+export const NATIVE_CHAT_AGENT_ADAPTERS = createNativeChatAgentAdapterRegistry(
+  BUILTIN_NATIVE_CHAT_AGENT_ADAPTERS
+)

--- a/src/shared/native-chat-agent-profiles.test.ts
+++ b/src/shared/native-chat-agent-profiles.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest'
 import { getNativeChatAgentProfile } from './native-chat-agent-profiles'
 
 describe('native chat agent picker profiles', () => {
+  it('returns stable frozen profiles for hook dependency safety', () => {
+    const first = getNativeChatAgentProfile('codex')
+    const second = getNativeChatAgentProfile('codex')
+
+    expect(second).toBe(first)
+    expect(Object.isFrozen(first)).toBe(true)
+  })
+
   it('keeps Codex dollar skills separate from slash commands', () => {
     expect(getNativeChatAgentProfile('codex')).toMatchObject({
       skillPrefix: '$',

--- a/src/shared/native-chat-agent-profiles.ts
+++ b/src/shared/native-chat-agent-profiles.ts
@@ -1,45 +1,27 @@
 import type { AgentType } from './agent-status-types'
+import { NATIVE_CHAT_AGENT_ADAPTERS } from './native-chat-agent-adapters'
 import { getAgentSlashCommands, type SlashCommandSuggestion } from './native-chat-slash-commands'
 
-export type NativeChatAgentProfile = {
+export type NativeChatAgentProfile = Readonly<{
   skillPrefix: '$' | '/'
   groupedSlash: boolean
   /** OpenClaude reads Claude-owned roots, so this can differ from the agent. */
   skillSourceOwner: AgentType
-}
+}>
 
-const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfile>> = {
-  codex: {
-    skillPrefix: '$',
-    groupedSlash: false,
-    skillSourceOwner: 'codex'
-  },
-  claude: {
-    skillPrefix: '/',
-    groupedSlash: true,
-    skillSourceOwner: 'claude'
-  },
-  openclaude: {
-    skillPrefix: '/',
-    groupedSlash: true,
-    skillSourceOwner: 'claude'
-  },
-  grok: {
-    skillPrefix: '/',
-    groupedSlash: true,
-    skillSourceOwner: 'grok'
-  }
-}
-
+/**
+ * Returns the adapter-backed skill profile with stable reference identity for React consumers.
+ */
 export function getNativeChatAgentProfile(
   agent: AgentType | null | undefined
 ): NativeChatAgentProfile | null {
-  return agent ? (NATIVE_CHAT_AGENT_PROFILES[agent] ?? null) : null
+  return NATIVE_CHAT_AGENT_ADAPTERS.get(agent)
 }
 
 /** The catalog that send classification, collision detection, and transcript
- *  envelope surfacing key off. Grok has no verified catalog yet, so its slash
- *  surface stays skills-only — this is the single place that policy lives. */
+ *  envelope surfacing key off. */
 export function getVerifiedNativeChatCommands(agent: AgentType): readonly SlashCommandSuggestion[] {
-  return agent === 'grok' ? [] : getAgentSlashCommands(agent)
+  return NATIVE_CHAT_AGENT_ADAPTERS.get(agent)?.commandCatalog === 'agent'
+    ? getAgentSlashCommands(agent)
+    : []
 }

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -1,37 +1,35 @@
-export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok'
+import {
+  NATIVE_CHAT_AGENT_ADAPTERS,
+  type NativeChatTranscriptAgent
+} from './native-chat-agent-adapters'
+
+export type { NativeChatTranscriptAgent } from './native-chat-agent-adapters'
+
+/** Projects a registry descriptor to its supported-agent identity. */
+function nativeChatAgentId({ agent }: { agent: string }): string {
+  return agent
+}
 
 /** Agents whose transcripts the native chat view can parse and render. */
-export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set([
-  'claude',
-  'openclaude',
-  'codex',
-  'grok'
-])
+export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set(
+  NATIVE_CHAT_AGENT_ADAPTERS.list().map(nativeChatAgentId)
+)
 
+/** Returns whether an agent has a built-in Chat UI adapter. */
 export function isNativeChatSupportedAgent(agent: string | null | undefined): boolean {
-  return agent != null && NATIVE_CHAT_SUPPORTED_AGENTS.has(agent)
+  return NATIVE_CHAT_AGENT_ADAPTERS.get(agent) !== null
 }
 
 /** True when the agent renders a digit-commit question selector that ignores
- *  typed label text (pasting "Blue" + Enter commits the highlighted FIRST
- *  option — STA-1860): Claude's AskUserQuestion and Codex 0.145's
- *  request_user_input card both behave this way, so answers must be delivered
- *  as per-option keystrokes. Other agents commit a pasted answer. */
+ *  typed label text. The adapter owns this input policy independently from its
+ *  transcript family. */
 export function shouldStepNativeChatAskAnswer(agent: string | null | undefined): boolean {
-  const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  return transcriptAgent === 'claude' || transcriptAgent === 'codex'
+  return NATIVE_CHAT_AGENT_ADAPTERS.get(agent)?.askAnswerMode === 'step-lines'
 }
 
+/** Resolves the transcript format family used by an agent's built-in adapter. */
 export function resolveNativeChatTranscriptAgent(
   agent: string | null | undefined
 ): NativeChatTranscriptAgent | null {
-  // Why: OpenClaude writes the Claude transcript format and layout even though
-  // Orca preserves its distinct agent identity for launch and UI behavior.
-  if (agent === 'claude' || agent === 'openclaude') {
-    return 'claude'
-  }
-  if (agent === 'codex' || agent === 'grok') {
-    return agent
-  }
-  return null
+  return NATIVE_CHAT_AGENT_ADAPTERS.get(agent)?.transcriptAgent ?? null
 }


### PR DESCRIPTION
## Summary

- add an immutable typed registry for Orca's built-in Chat UI agent adapters
- centralize supported-agent, transcript-family, structured-question pacing, skill grammar/source ownership, and command-catalog policy
- centralize main-process transcript line and lifecycle decoder selection for full reads, tails, and live watches
- fail fast on duplicate built-in agent ownership and preserve stable frozen profile references
- document the Phase 1 boundary: this is a behavior-preserving built-in foundation, **not** a third-party code/plugin loader

This is the first implementation slice of #10099 and keeps the current Claude, OpenClaude, Codex, and Grok behavior. It also creates a narrower reviewable base for the versioned structured-agent contract proposed there. The explicit handoff/diagnostic work discussed in #10098 remains separate.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 3,316 files and 35,228 tests passed; the harness-injected `GIT_CONFIG_*` entries were removed for the run because an unrelated relay test assumes a clean Git-config environment
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Additional focused verification:

- 70 Native Chat registry/profile/transcript/watch/skill-hook tests passed
- duplicate registration, immutable snapshots, transcript aliasing, line/lifecycle dispatch, unsupported agents, and stable profile reference identity are covered
- pre-commit oxlint, React Doctor, and oxfmt hooks passed

## AI Review Report

The AI review inspected the complete diff and all provider dispatch references for correctness, regressions, compatibility, performance, and scope.

It flagged one real regression before commit: `getNativeChatAgentProfile()` initially returned a fresh projection on every call. Because the React skills hook uses that profile as an effect dependency, this caused an infinite render/effect loop and eventual OOM. An A/B run against clean `upstream/main` isolated the regression. The implementation now returns the registry's stable frozen descriptor, and a regression test explicitly checks reference stability and immutability. The affected React hook test and the full suite pass after the fix.

Compatibility review:

- **macOS / Linux / Windows:** no platform branches, shortcuts, labels, shell commands, native APIs, or path handling were added or changed
- **local / SSH / remote / Web:** the change only centralizes existing pure metadata and main-process decoder selection; runtime ownership, transcript path resolution, watchers, and transport boundaries are unchanged
- **agents:** Claude, OpenClaude, Codex, and Grok policies were compared against `main`; OpenClaude still aliases Claude transcripts, Codex and Claude retain step-line answer pacing, and Grok retains a skills-only command catalog
- **integrations / git providers:** no integration or git-provider behavior changed
- **performance:** registry construction happens once; lookups are `Map` lookups, descriptors are reused, and no new work was added to transcript decoding loops
- **UI quality:** no visual or interaction change; stable profile identity avoids extra React effects/renders

No unresolved review findings remain.

## Security Audit

The AI security review found no new command execution, network request, IPC, filesystem read/write, path resolution, authentication, secret handling, dependency, or dynamic-code surface.

- adapters remain compiled-in static data
- decoder functions remain in the main process
- no renderer, Electron IPC, PTY, filesystem, or network capability is exposed to third-party code
- registry descriptors and the exposed snapshot are frozen
- duplicate agent ownership fails during registry construction
- unsupported agents continue to fail closed with no transcript adapter

A future external adapter/plugin contract still requires separate isolation, capability, schema/version, locality, and conformance work tracked in #10099.

## Notes

- Rebased onto `upstream/main` commit `381e81e7b`; the topic history is one commit (`4c6a1ccfb`).
- This PR intentionally does not dynamically discover or execute third-party adapters.
- X: not provided.

## ELI5

Built-in Chat UI agent adapters were scattered. This centralizes them in a typed registry (transcripts, questions, skills, commands) without changing behavior—cleaner place for future agents.
