### PR TITLE
fix(ssh): hold premature transport 'connected' until the relay is ready

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -214,6 +214,7 @@ vi.mock('../ssh/ssh-port-scanner', () => ({
 }))
 
 import { getSshConnectionManager, registerSshHandlers, resetSshHandlerStateForTests } from './ssh'
+import { RelayVersionMismatchError } from '../ssh/ssh-relay-version-mismatch-error'
 import {
   SSH_RELAY_CONFIGURE_GRACE_TIME_METHOD,
   type SshConnectionState,
@@ -682,6 +683,154 @@ describe('SSH IPC handlers', () => {
       'SSH connection changed; refresh and try again'
     )
     expect(() => assertSshMutationExpectation('ssh-1', 'ssh-1', 2)).not.toThrow()
+  })
+
+  // Why: reproduces the "Infinite reconnect bug" — when the raw SSH transport
+  // connects but relay deploy fails permanently (dev build missing the platform
+  // relay package), doConnect must not leak the transport's premature 'connected'
+  // to the renderer. The renderer treats 'connected' as "session fully up" and
+  // remounts SSH panes (-> window.api.ssh.connect); a premature 'connected' on
+  // every failing attempt drives an unbounded reconnect loop.
+  it('does not broadcast a premature connected when relay deploy fails', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    const conn = {}
+    mockSshStore.getTarget.mockReturnValue(target)
+    // Why: mirror the real SshConnection — connect() drives the raw transport to
+    // 'connected' via onStateChange BEFORE the relay session establishes. The await
+    // yields a microtask so this lands after connectTarget records connectInFlight,
+    // matching the real ssh2 'ready' event (which fires async, post connect() call).
+    mockConnectionManager.connect.mockImplementation(async () => {
+      await Promise.resolve()
+      const callbacks = mockConnectionManager.callbacksRef.current as {
+        onStateChange: (targetId: string, state: SshConnectionState) => void
+      }
+      callbacks.onStateChange('ssh-1', {
+        targetId: 'ssh-1',
+        status: 'connecting',
+        error: null,
+        reconnectAttempt: 0
+      })
+      callbacks.onStateChange('ssh-1', {
+        targetId: 'ssh-1',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0,
+        supportsFolderDownload: true
+      })
+      return conn
+    })
+    mockConnectionManager.getConnection.mockReturnValue(conn)
+    mockConnectionManager.disconnect.mockResolvedValue(undefined)
+    mockDeployAndLaunchRelay
+      .mockReset()
+      .mockRejectedValue(
+        new Error(
+          'Relay package for linux-x64 not found locally. ' +
+            'This may be a packaging issue — try reinstalling Orca.'
+        )
+      )
+
+    await expect(handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })).rejects.toThrow(
+      'not found locally'
+    )
+
+    // Main performs exactly one connect + one disconnect per IPC (no main-side loop).
+    expect(mockConnectionManager.connect).toHaveBeenCalledTimes(1)
+    expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')
+
+    // The renderer must never see 'connected' for a connect whose relay never
+    // became ready — doConnect broadcasts the authoritative 'connected' only after
+    // establish() succeeds, which it does not here.
+    const connectedBroadcasts = mockWindow.webContents.send.mock.calls.filter(
+      ([channel, payload]) =>
+        channel === 'ssh:state-changed' &&
+        (payload as { state?: SshConnectionState }).state?.status === 'connected'
+    )
+    expect(connectedBroadcasts).toEqual([])
+  })
+
+  // Why: guards the fix's scope. A relay version mismatch during a relay reconnect
+  // strands the session 'idle' in activeSessions (only doConnect deletes it). A later
+  // transport blip then delivers a raw 'connected' with NO connect in flight — the
+  // 'deploying-relay' hold must NOT fire there (it would wedge the UI on an eternal
+  // spinner with every reconnect/reset control disabled). The hold is gated to live
+  // connects via connectInFlight.
+  it('does not hold a stray connected as deploying-relay when no connect is in flight', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    const conn = {}
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue(conn)
+    mockConnectionManager.getConnection.mockReturnValue(conn)
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+
+    try {
+      // Establish a ready relay session, then lose the relay and fail the reconnect with
+      // a version mismatch so the session is left stranded 'idle' in activeSessions.
+      await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+      mockDeployAndLaunchRelay
+        .mockReset()
+        .mockRejectedValue(new RelayVersionMismatchError('2.0.0', '1.0.0'))
+      getLatestRelayDisposeCallback()('connection_lost')
+      await vi.advanceTimersByTimeAsync(relayReconnectDelaysMs[0])
+
+      // The terminal relay error is surfaced; the session is now stranded 'idle'.
+      expect(
+        (handlers.get('ssh:getState')!(null, { targetId: 'ssh-1' }) as SshConnectionState).status
+      ).toBe('error')
+
+      const callbacks = mockConnectionManager.callbacksRef.current as {
+        onStateChange: (targetId: string, state: SshConnectionState) => void
+      }
+      mockWindow.webContents.send.mockClear()
+      // A transport blip on the still-live SSH socket auto-recovers to 'connected' with
+      // no ssh:connect in flight (connectInFlight is empty).
+      callbacks.onStateChange('ssh-1', {
+        targetId: 'ssh-1',
+        status: 'reconnecting',
+        error: null,
+        reconnectAttempt: 0
+      })
+      callbacks.onStateChange('ssh-1', {
+        targetId: 'ssh-1',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      })
+
+      // The stray 'connected' is forwarded as-is — never wedged at 'deploying-relay'.
+      const stateChanges = mockWindow.webContents.send.mock.calls.filter(
+        ([channel]) => channel === 'ssh:state-changed'
+      )
+      const lastStateChange = stateChanges.at(-1)
+      expect(lastStateChange).toBeDefined()
+      expect((lastStateChange![1] as { state: SshConnectionState }).state.status).toBe('connected')
+      const heldAsDeploying = stateChanges.some(
+        ([, payload]) =>
+          (payload as { state?: SshConnectionState }).state?.status === 'deploying-relay'
+      )
+      expect(heldAsDeploying).toBe(false)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('rebuilds instead of reusing a ready session while relay loss is pending', async () => {

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -558,6 +558,29 @@ function createSshConnectionCallbacks(): SshConnectionCallbacks {
       } else if (relayReconnectAlreadyInFlight) {
         // Why: duplicate connected notifications belong to the same socket generation and must not expose providers before relay recovery finishes.
         return
+      } else if (
+        state.status === 'connected' &&
+        session !== undefined &&
+        sessionState !== 'ready' &&
+        !completedTransportReconnect &&
+        connectInFlight.has(targetId)
+      ) {
+        // Why: the raw SSH transport reaches 'connected' before the relay session establishes during an
+        // explicit connect. Forwarding it makes the renderer treat the host as fully up — it remounts
+        // SSH panes (-> window.api.ssh.connect) and fires connected-gated data reads before any provider
+        // exists. On a permanent relay-deploy failure that premature 'connected' drives an unbounded
+        // reconnect loop. Hold it at 'deploying-relay'; the in-flight doConnect broadcasts the
+        // authoritative 'connected' directly (bypassing this callback) after establish() succeeds, or a
+        // terminal state on failure. The connectInFlight gate keeps this scoped to a live connect, so a
+        // stray raw 'connected' with no follow-up (e.g. a transport blip on a session left 'idle' by a
+        // relay version mismatch) is never wedged at 'deploying-relay'.
+        clearRelayStateOverride(targetId)
+        broadcastSshState(getCurrentMainWindow, targetId, {
+          targetId,
+          status: 'deploying-relay',
+          error: state.error,
+          reconnectAttempt: state.reconnectAttempt
+        })
       } else {
         clearRelayStateOverride(targetId)
         broadcastSshState(getCurrentMainWindow, targetId, state)


### PR DESCRIPTION
## What

Fixes the **infinite reconnect bug**: in the Create-worktree dialog, selecting an SSH host whose relay can't deploy (e.g. a `pn dev` build missing the `linux-x64` relay package) sends the app into an unbounded reconnect loop — the dialog flickers between "Connecting SSH…" / connected / "Preparing SSH connection…" and the console spams `ssh:connect` / `fs:readDir` / `gh:listWorkItems` / `linear:listIssues` failures forever.

## ELI5

When you connect to a remote machine, two things happen in order: (1) the SSH pipe opens, then (2) we deploy a small "relay" program on the far side that actually lets the app do work. The bug: we told the whole UI **"connected!"** the instant the pipe opened — *before* the relay existed. The UI believed it and reloaded all the remote terminals, which each tried to connect again… which flashed "connected!" again… forever. It's like flipping the "OPEN" sign the moment you unlock the door but before the lights and register are on — customers pour in, find nothing works, leave, and the door keeps re-flashing "OPEN."

The fix: don't show "connected" until the relay is actually up. If the relay can't deploy, the host settles into a normal disconnected state with a manual **Connect** button instead of thrashing.

## Root cause

`doConnect` creates the relay session (state `'idle'`), then `connectionManager.connect()` drives the **raw SSH transport** to `'connected'` (`ssh-connection.ts:1133`) — *before* `establish()` deploys the relay. That premature `'connected'` was forwarded verbatim to the renderer:

```
main: raw transport 'connected'  ──►  onStateChange else-branch broadcasts 'connected'
renderer (useIpcEvents.ts:2775): bump tab.generation for stranded remote panes
  └─► Terminal.tsx:2169 keys pane by tab.id:tab.generation ─► REMOUNT
        └─► pane connect gate (status ≠ connected) ─► pty-connection.ts:800 window.api.ssh.connect
              └─► raw transport 'connected' again ─► (loop)
```

The two existing backoffs (`scheduleReconnect`, `relayLostBackoff`) never catch it because every cycle is a **fresh** `ssh:connect` IPC that rebuilds the session and resets the counters. The authoritative `'connected'` is broadcast directly by `doConnect` **after** `establish()` succeeds (`ssh.ts:936`), so the premature one is pure noise — it's also why the connected-gated data reads (`fs:readDir` etc.) fire and fail with "Remote connection dropped".

## The fix

Hold the premature transport `'connected'` at `'deploying-relay'` in `onStateChange` until the relay session is actually `'ready'`. One branch in `src/main/ipc/ssh.ts`:

```ts
} else if (
  state.status === 'connected' &&
  session !== undefined &&
  sessionState !== 'ready' &&
  !completedTransportReconnect &&
  connectInFlight.has(targetId)
) {
  // hold at 'deploying-relay' — doConnect broadcasts the authoritative 'connected' after establish()
  broadcastSshState(getCurrentMainWindow, targetId, { targetId, status: 'deploying-relay', ... })
}
```

- Reconnect paths are untouched: transport reconnects carry `completedTransportReconnect=true`; relay-lost/relay reconnects set a `relayStateOverride` first (caught by the earlier `relayReconnectAlreadyInFlight` branch).
- The `connectInFlight` gate scopes the hold to a **live connect** (which is guaranteed to follow up with an authoritative `'connected'` or a terminal state), so a stray transport-blip `'connected'` on a session left `'idle'` by a version mismatch is never wedged — see the adversarial review below.

This one change eliminates **both** the reconnect loop and all four console-spam clusters, because every symptom is downstream of a status the renderer should never have seen.

## Proof of fix

New regression test `does not broadcast a premature connected when relay deploy fails` drives the real `onStateChange` callback (via the connection-manager mock) with a failing `deployAndLaunchRelay`, and asserts the renderer never receives a `'connected'` state.

**Before the fix** (revert `ssh.ts` only) it fails, showing the exact premature broadcast:

```
AssertionError: expected [ [ 'ssh:state-changed', {state:{status:'connected', supportsFolderDownload:true, …}} ] ] to deeply equal []
```

**After the fix** it passes (0 `'connected'` broadcasts; exactly one `connect` + one `disconnect` per IPC → no main-side loop).

## Adversarial review (found + fixed a real edge case)

A panel of adversarial reviewers tried to refute the fix from 5 angles. Four cleared the success/reconnect/loop/perf paths; two independently found the **same** real regression, now fixed:

> A relay **version mismatch** during a relay reconnect leaves the session `'idle'` in `activeSessions` (only `doConnect` deletes it). A later transport blip then delivers a raw `'connected'` with **no connect in flight** — the naive hold would wedge the UI at `'deploying-relay'` forever, disabling every Connect/Reset control.

Fixed by the `connectInFlight.has(targetId)` gate, and guarded by a second **load-bearing** test (`does not hold a stray connected as deploying-relay when no connect is in flight`) — it fails if the gate is removed.

## Proof of no regressions / no perf issues

| Check | Result |
|---|---|
| `src/main/ipc/ssh.test.ts` | **43 passed** (incl. 2 new regression tests) |
| Broad SSH suite (`src/main/ssh/**` + ipc + renderer store / `useIpcEvents` / connect-gate / pane-retry) | **968 passed**, 10 skipped |
| `pty-connection.test.ts` (the renderer loop driver) | **466 passed** |
| `tsc --noEmit -p config/tsconfig.node.json` | clean (exit 0) |
| `oxlint` (changed files) | clean |

**Perf:** broadcast count per failing connect is unchanged (4 → 4); the change is that the loop total drops from **unbounded → one cycle**, so the renderer no longer runs `fetchWorktrees` / `fetchWorktreeLineage` / pane remounts every iteration. The added branch is three boolean checks on an infrequent callback.

## Test plan

- [x] Repro test fails before fix, passes after
- [x] Wedge-regression test fails without the `connectInFlight` gate
- [x] Full SSH + relay + connection suites green
- [x] Loop driver (`pty-connection`) suite green
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
