### PR TITLE
fix(terminal): stop the reveal fit from reflow-garbling inline TUIs on minimize→restore

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -40,6 +40,8 @@ type FakeManager = {
   resumeRendering: ReturnType<typeof vi.fn>
   scheduleRevealRepaint: ReturnType<typeof vi.fn>
   scheduleRevealPresent: ReturnType<typeof vi.fn>
+  fitAllPanes: ReturnType<typeof vi.fn>
+  fitAllPanesStable: ReturnType<typeof vi.fn>
 }
 
 function createManager(order: string[] = []): FakeManager {
@@ -47,7 +49,12 @@ function createManager(order: string[] = []): FakeManager {
     getPanes: vi.fn(() => []),
     resumeRendering: vi.fn(() => order.push('resume-rendering')),
     scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint')),
-    scheduleRevealPresent: vi.fn(() => order.push('reveal-present'))
+    scheduleRevealPresent: vi.fn(() => order.push('reveal-present')),
+    // Why: the reveal must fit through the wobble-resistant stable path, never
+    // the synchronous fitAllPanes, so a transient cell-metric grid is not
+    // applied and reflow-garbled onto inline TUIs on minimize→restore.
+    fitAllPanes: vi.fn(() => order.push('fit-sync')),
+    fitAllPanesStable: vi.fn(() => order.push('fit-stable'))
   }
 }
 
@@ -114,7 +121,42 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     const manager = createManager(order)
     resumeTerminalVisibility(resumeArgs(manager, false))
 
-    expect(order).toEqual(['resume-rendering', 'reveal-repaint'])
+    expect(order).toEqual(['resume-rendering', 'fit-stable', 'reveal-repaint'])
+  })
+
+  it('fits a heavy reveal through the wobble-resistant stable path, not the sync fit', () => {
+    // Regression: minimize→restore garbled an inline TUI (grok) because the
+    // synchronous reveal fit applied a transient one-column DOM↔WebGL
+    // cell-metric grid, reflowing the buffer it then diff-painted over.
+    const manager = createManager()
+    resumeTerminalVisibility(resumeArgs(manager, false))
+
+    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    expect(manager.fitAllPanes).not.toHaveBeenCalled()
+    // The stable fit must run only after WebGL resumes (metrics settle first).
+    expect(manager.fitAllPanesStable.mock.invocationCallOrder[0]).toBeGreaterThan(
+      manager.resumeRendering.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('does not fit on a light tab reveal', () => {
+    const manager = createManager()
+    resumeTerminalVisibility(resumeArgs(manager, true))
+
+    expect(manager.fitAllPanesStable).not.toHaveBeenCalled()
+    expect(manager.fitAllPanes).not.toHaveBeenCalled()
+  })
+
+  it('fits window wake recovery through the stable path, not the sync fit', () => {
+    const manager = createManager()
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: true,
+      clearGlyphAtlases: false
+    })
+
+    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    expect(manager.fitAllPanes).not.toHaveBeenCalled()
   })
 
   it('resets each pane linkifier hover cache on window wake recovery so links recover without a scroll', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -41,7 +41,7 @@ type FakeManager = {
   scheduleRevealRepaint: ReturnType<typeof vi.fn>
   scheduleRevealPresent: ReturnType<typeof vi.fn>
   fitAllPanes: ReturnType<typeof vi.fn>
-  fitAllPanesStable: ReturnType<typeof vi.fn>
+  fitAllRevealedPanes: ReturnType<typeof vi.fn>
 }
 
 function createManager(order: string[] = []): FakeManager {
@@ -50,11 +50,9 @@ function createManager(order: string[] = []): FakeManager {
     resumeRendering: vi.fn(() => order.push('resume-rendering')),
     scheduleRevealRepaint: vi.fn(() => order.push('reveal-repaint')),
     scheduleRevealPresent: vi.fn(() => order.push('reveal-present')),
-    // Why: the reveal must fit through the wobble-resistant stable path, never
-    // the synchronous fitAllPanes, so a transient cell-metric grid is not
-    // applied and reflow-garbled onto inline TUIs on minimize→restore.
+    // Stubbed to assert reveals route through fitAllRevealedPanes, never fitAllPanes.
     fitAllPanes: vi.fn(() => order.push('fit-sync')),
-    fitAllPanesStable: vi.fn(() => order.push('fit-stable'))
+    fitAllRevealedPanes: vi.fn(() => order.push('fit-reveal'))
   }
 }
 
@@ -121,29 +119,23 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     const manager = createManager(order)
     resumeTerminalVisibility(resumeArgs(manager, false))
 
-    expect(order).toEqual(['resume-rendering', 'fit-stable', 'reveal-repaint'])
+    expect(order).toEqual(['resume-rendering', 'fit-reveal', 'reveal-repaint'])
   })
 
-  it('fits a heavy reveal through the wobble-resistant stable path, not the sync fit', () => {
-    // Regression: minimize→restore garbled an inline TUI (grok) because the
-    // synchronous reveal fit applied a transient one-column DOM↔WebGL
-    // cell-metric grid, reflowing the buffer it then diff-painted over.
+  it('routes a heavy reveal through fitAllRevealedPanes, not the sync fit', () => {
+    // Regression: the sync reveal fit applied a transient one-column DOM↔WebGL grid, garbling grok on restore.
     const manager = createManager()
     resumeTerminalVisibility(resumeArgs(manager, false))
 
-    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    expect(manager.fitAllRevealedPanes).toHaveBeenCalledTimes(1)
     expect(manager.fitAllPanes).not.toHaveBeenCalled()
-    // The stable fit must run only after WebGL resumes (metrics settle first).
-    expect(manager.fitAllPanesStable.mock.invocationCallOrder[0]).toBeGreaterThan(
-      manager.resumeRendering.mock.invocationCallOrder[0]
-    )
   })
 
   it('does not fit on a light tab reveal', () => {
     const manager = createManager()
     resumeTerminalVisibility(resumeArgs(manager, true))
 
-    expect(manager.fitAllPanesStable).not.toHaveBeenCalled()
+    expect(manager.fitAllRevealedPanes).not.toHaveBeenCalled()
     expect(manager.fitAllPanes).not.toHaveBeenCalled()
   })
 
@@ -155,7 +147,7 @@ describe('resumeTerminalVisibility reveal repaint', () => {
       clearGlyphAtlases: false
     })
 
-    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    expect(manager.fitAllRevealedPanes).toHaveBeenCalledTimes(1)
     expect(manager.fitAllPanes).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -13,7 +13,7 @@ import {
   isTerminalLinkifierHoverActive,
   resetTerminalLinkifierHoverState
 } from '@/lib/pane-manager/terminal-linkifier-hover-reset'
-import { fitAndFocusPanes, fitPanes, focusActivePane } from './pane-helpers'
+import { focusActivePane } from './pane-helpers'
 import { scheduleTabRevealWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
@@ -156,10 +156,13 @@ export function recoverVisibleTerminalWindowWake({
   }
   syncTerminalViewportIntents(manager)
   manager.resumeRendering()
+  // Why: same reveal wobble guard as resumeTerminalVisibilityHeavy — a window
+  // wake re-attaches WebGL, so a raw fit can apply a transient cell-metric grid
+  // and reflow-garble inline TUIs. fitAllPanesStable fits an element whose pixels
+  // changed, repairs a grid that diverged at unchanged pixels, else leaves it be.
+  manager.fitAllPanesStable()
   if (isActive) {
-    fitAndFocusPanes(manager)
-  } else {
-    fitPanes(manager)
+    focusActivePane(manager)
   }
   enforceTerminalViewportIntents(manager)
   if (clearGlyphAtlases) {
@@ -198,13 +201,16 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   // Windows (ANGLE -> D3D11) it can be 100-500 ms but a deferred resume
   // would paint a stretched DOM-fallback flash, which is worse UX.
   manager.resumeRendering()
-  // Single fit on resume. Background bytes have been pushed into xterm
-  // above, so this fit only absorbs container dimension changes that
-  // happened while hidden (e.g. sidebar toggle on another worktree).
+  // Why: resumeRendering just re-attached WebGL, whose cell metrics differ from
+  // the DOM renderer's, so a raw synchronous fit can propose a one-column-off
+  // grid and reflow xterm before the metrics settle, then snap back — a net-zero
+  // reflow "wiggle" that garbles inline TUIs that diff-paint over it (grok
+  // minimize→restore). fitAllPanesStable fits synchronously only when the fit
+  // element's pixels actually changed while hidden; an unchanged element is left
+  // alone (or repaired on a steady grid if its grid diverged while hidden).
+  manager.fitAllPanesStable()
   if (isActive) {
-    fitAndFocusPanes(manager)
-  } else {
-    fitPanes(manager)
+    focusActivePane(manager)
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -156,11 +156,8 @@ export function recoverVisibleTerminalWindowWake({
   }
   syncTerminalViewportIntents(manager)
   manager.resumeRendering()
-  // Why: same reveal wobble guard as resumeTerminalVisibilityHeavy — a window
-  // wake re-attaches WebGL, so a raw fit can apply a transient cell-metric grid
-  // and reflow-garble inline TUIs. fitAllPanesStable fits an element whose pixels
-  // changed, repairs a grid that diverged at unchanged pixels, else leaves it be.
-  manager.fitAllPanesStable()
+  // Why: wake re-attaches WebGL — same transient cell-metric wobble guard as the heavy resume.
+  manager.fitAllRevealedPanes()
   if (isActive) {
     focusActivePane(manager)
   }
@@ -201,14 +198,10 @@ function resumeTerminalVisibilityHeavy(manager: PaneManager, isActive: boolean):
   // Windows (ANGLE -> D3D11) it can be 100-500 ms but a deferred resume
   // would paint a stretched DOM-fallback flash, which is worse UX.
   manager.resumeRendering()
-  // Why: resumeRendering just re-attached WebGL, whose cell metrics differ from
-  // the DOM renderer's, so a raw synchronous fit can propose a one-column-off
-  // grid and reflow xterm before the metrics settle, then snap back — a net-zero
-  // reflow "wiggle" that garbles inline TUIs that diff-paint over it (grok
-  // minimize→restore). fitAllPanesStable fits synchronously only when the fit
-  // element's pixels actually changed while hidden; an unchanged element is left
-  // alone (or repaired on a steady grid if its grid diverged while hidden).
-  manager.fitAllPanesStable()
+  // Why: resumeRendering just re-attached WebGL, whose cell metrics briefly differ
+  // from the DOM renderer's; a raw fit here reflows on a transient one-column-off
+  // grid and garbles diff-painting inline TUIs (grok minimize→restore).
+  manager.fitAllRevealedPanes()
   if (isActive) {
     focusActivePane(manager)
   }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -152,7 +152,7 @@ function useMountForFileDrop(
     scheduleRevealPresent: ReturnType<typeof vi.fn>
     suspendRendering: ReturnType<typeof vi.fn>
     getActivePane: ReturnType<typeof vi.fn>
-    fitAllPanesStable: ReturnType<typeof vi.fn>
+    fitAllRevealedPanes: ReturnType<typeof vi.fn>
   }
   paneTransports: Map<number, never>
 } {
@@ -171,7 +171,7 @@ function useMountForFileDrop(
     scheduleRevealPresent: vi.fn(),
     suspendRendering: vi.fn(),
     getActivePane: vi.fn(() => null),
-    fitAllPanesStable: vi.fn()
+    fitAllRevealedPanes: vi.fn()
   }
   const paneTransports = new Map<number, never>()
 
@@ -252,7 +252,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(() => order.push('refresh')),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(() => order.push('fit-stable')),
+      fitAllRevealedPanes: vi.fn(() => order.push('fit-reveal')),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -304,7 +304,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       'recover:terminal-b',
       'flush:terminal-b',
       'resume',
-      'fit-stable',
+      'fit-reveal',
       'intent:terminal-a',
       'intent:terminal-b',
       'reset-atlas',
@@ -342,7 +342,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -424,7 +424,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -488,7 +488,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -544,7 +544,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -594,7 +594,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     manager.resumeRendering.mockClear()
     manager.resetWebglTextureAtlases.mockClear()
     manager.refreshAllPanes.mockClear()
-    manager.fitAllPanesStable.mockClear()
+    manager.fitAllRevealedPanes.mockClear()
     mocks.fitAndFocusPanes.mockClear()
     mocks.focusActivePane.mockClear()
     mocks.flushTerminalOutput.mockClear()
@@ -611,10 +611,8 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.requestTerminalBacklogRecovery).toHaveBeenCalledWith(terminal)
     expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, { maxChars: 256 * 1024 })
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
-    // Why: the reveal must fit through the wobble-resistant stable path (never
-    // the synchronous fitAllPanes) so a transient cell-metric grid is not
-    // reflow-garbled onto inline TUIs on minimize→restore.
-    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    // Reveal must route through fitAllRevealedPanes, never the sync fitAllPanes.
+    expect(manager.fitAllRevealedPanes).toHaveBeenCalledTimes(1)
     expect(manager.fitAllPanes).not.toHaveBeenCalled()
     expect(mocks.focusActivePane).toHaveBeenCalledWith(manager)
     expect(mocks.fitAndFocusPanes).not.toHaveBeenCalled()
@@ -642,7 +640,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     scheduleRevealRepaint: ReturnType<typeof vi.fn>
     scheduleRevealPresent: ReturnType<typeof vi.fn>
     suspendRendering: ReturnType<typeof vi.fn>
-    fitAllPanesStable: ReturnType<typeof vi.fn>
+    fitAllRevealedPanes: ReturnType<typeof vi.fn>
     getActivePane: ReturnType<typeof vi.fn>
   } {
     return {
@@ -652,7 +650,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
     }
   }
@@ -746,7 +744,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -806,7 +804,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
 
@@ -866,7 +864,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal }))
     }
 
@@ -903,7 +901,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     // focus event, not the initial visibility resume.
     manager.scheduleRevealRepaint.mockClear()
     manager.scheduleRevealPresent.mockClear()
-    manager.fitAllPanesStable.mockClear()
+    manager.fitAllRevealedPanes.mockClear()
     mocks.fitAndFocusPanes.mockClear()
     mocks.focusActivePane.mockClear()
     mocks.flushTerminalOutput.mockClear()
@@ -914,9 +912,8 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.requestTerminalBacklogRecovery).toHaveBeenCalledWith(terminal)
     expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, { maxChars: 64 * 1024 })
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
-    // Why: window refocus recovery fits through the same wobble-resistant stable
-    // path so a transient cell-metric grid never reflow-garbles inline TUIs.
-    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    // Refocus recovery uses the same wobble-resistant reveal fit path.
+    expect(manager.fitAllRevealedPanes).toHaveBeenCalledTimes(1)
     expect(mocks.focusActivePane).toHaveBeenCalledWith(manager)
     expect(mocks.fitAndFocusPanes).not.toHaveBeenCalled()
     // Why: refocus recovery is atlas-preserving — no shared-atlas reset, no
@@ -937,7 +934,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
     const captured: { onSystemResumed: (() => void) | null } = { onSystemResumed: null }
@@ -996,7 +993,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
     const siblingManager = {
@@ -1053,7 +1050,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
     const useMountForVisibilityRecovery = (options: {
@@ -1101,7 +1098,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
     const transport = {
@@ -1159,7 +1156,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
     const transport = {
@@ -1278,7 +1275,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
 
@@ -1314,7 +1311,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
-      fitAllPanesStable: vi.fn(),
+      fitAllRevealedPanes: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.test.ts
@@ -152,6 +152,7 @@ function useMountForFileDrop(
     scheduleRevealPresent: ReturnType<typeof vi.fn>
     suspendRendering: ReturnType<typeof vi.fn>
     getActivePane: ReturnType<typeof vi.fn>
+    fitAllPanesStable: ReturnType<typeof vi.fn>
   }
   paneTransports: Map<number, never>
 } {
@@ -169,7 +170,8 @@ function useMountForFileDrop(
     scheduleRevealRepaint: vi.fn(),
     scheduleRevealPresent: vi.fn(),
     suspendRendering: vi.fn(),
-    getActivePane: vi.fn(() => null)
+    getActivePane: vi.fn(() => null),
+    fitAllPanesStable: vi.fn()
   }
   const paneTransports = new Map<number, never>()
 
@@ -250,6 +252,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(() => order.push('refresh')),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(() => order.push('fit-stable')),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -301,7 +304,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       'recover:terminal-b',
       'flush:terminal-b',
       'resume',
-      'fit-focus',
+      'fit-stable',
       'intent:terminal-a',
       'intent:terminal-b',
       'reset-atlas',
@@ -339,6 +342,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -420,6 +424,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -483,6 +488,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -538,6 +544,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -587,7 +594,9 @@ describe('useTerminalPaneGlobalEffects', () => {
     manager.resumeRendering.mockClear()
     manager.resetWebglTextureAtlases.mockClear()
     manager.refreshAllPanes.mockClear()
+    manager.fitAllPanesStable.mockClear()
     mocks.fitAndFocusPanes.mockClear()
+    mocks.focusActivePane.mockClear()
     mocks.flushTerminalOutput.mockClear()
     mocks.requestTerminalBacklogRecovery.mockClear()
 
@@ -602,7 +611,13 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.requestTerminalBacklogRecovery).toHaveBeenCalledWith(terminal)
     expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, { maxChars: 256 * 1024 })
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
-    expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager)
+    // Why: the reveal must fit through the wobble-resistant stable path (never
+    // the synchronous fitAllPanes) so a transient cell-metric grid is not
+    // reflow-garbled onto inline TUIs on minimize→restore.
+    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    expect(manager.fitAllPanes).not.toHaveBeenCalled()
+    expect(mocks.focusActivePane).toHaveBeenCalledWith(manager)
+    expect(mocks.fitAndFocusPanes).not.toHaveBeenCalled()
     expect(manager.resetWebglTextureAtlases).toHaveBeenCalledTimes(1)
     expect(manager.refreshAllPanes).toHaveBeenCalledTimes(1)
   })
@@ -627,6 +642,7 @@ describe('useTerminalPaneGlobalEffects', () => {
     scheduleRevealRepaint: ReturnType<typeof vi.fn>
     scheduleRevealPresent: ReturnType<typeof vi.fn>
     suspendRendering: ReturnType<typeof vi.fn>
+    fitAllPanesStable: ReturnType<typeof vi.fn>
     getActivePane: ReturnType<typeof vi.fn>
   } {
     return {
@@ -636,6 +652,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal: { name: 'terminal-a' } }))
     }
   }
@@ -729,6 +746,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null),
       setActivePane: vi.fn()
     }
@@ -788,6 +806,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
 
@@ -847,6 +866,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => ({ id: 1, terminal }))
     }
 
@@ -883,7 +903,9 @@ describe('useTerminalPaneGlobalEffects', () => {
     // focus event, not the initial visibility resume.
     manager.scheduleRevealRepaint.mockClear()
     manager.scheduleRevealPresent.mockClear()
+    manager.fitAllPanesStable.mockClear()
     mocks.fitAndFocusPanes.mockClear()
+    mocks.focusActivePane.mockClear()
     mocks.flushTerminalOutput.mockClear()
     mocks.requestTerminalBacklogRecovery.mockClear()
 
@@ -892,7 +914,11 @@ describe('useTerminalPaneGlobalEffects', () => {
     expect(mocks.requestTerminalBacklogRecovery).toHaveBeenCalledWith(terminal)
     expect(mocks.flushTerminalOutput).toHaveBeenCalledWith(terminal, { maxChars: 64 * 1024 })
     expect(manager.resumeRendering).toHaveBeenCalledTimes(1)
-    expect(mocks.fitAndFocusPanes).toHaveBeenCalledWith(manager)
+    // Why: window refocus recovery fits through the same wobble-resistant stable
+    // path so a transient cell-metric grid never reflow-garbles inline TUIs.
+    expect(manager.fitAllPanesStable).toHaveBeenCalledTimes(1)
+    expect(mocks.focusActivePane).toHaveBeenCalledWith(manager)
+    expect(mocks.fitAndFocusPanes).not.toHaveBeenCalled()
     // Why: refocus recovery is atlas-preserving — no shared-atlas reset, no
     // registry-wide repaint, and no atlas-clearing reveal repaint; the
     // atlas-preserving present covers stale pixels.
@@ -911,6 +937,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       refreshAllPanes: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
     const captured: { onSystemResumed: (() => void) | null } = { onSystemResumed: null }
@@ -969,6 +996,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
     const siblingManager = {
@@ -1025,6 +1053,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
     const useMountForVisibilityRecovery = (options: {
@@ -1072,6 +1101,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
     const transport = {
@@ -1129,6 +1159,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealRepaint: vi.fn(),
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => pane)
     }
     const transport = {
@@ -1247,6 +1278,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
 
@@ -1282,6 +1314,7 @@ describe('useTerminalPaneGlobalEffects', () => {
       scheduleRevealPresent: vi.fn(),
       suspendRendering: vi.fn(),
       fitAllPanes: vi.fn(),
+      fitAllPanesStable: vi.fn(),
       getActivePane: vi.fn(() => null)
     }
 

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import type { ManagedPane, ScrollState } from './pane-manager-types'
 import { safeFit, safeFitAndThen } from './pane-fit'
+import { paneFitClientSizeChanged } from './pane-reveal-fit'
 
 vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
   recordRendererCrashBreadcrumb: vi.fn()
@@ -18,11 +19,19 @@ function flushAnimationFrames(timestamp = 16): void {
   }
 }
 
+type TestPane = ManagedPane & {
+  setRect: (rect: { width: number; height: number }) => void
+  setXtermRect: (rect: { width: number; height: number }) => void
+}
+
 function createPane(options: {
   rect: { width: number; height: number }
   proposed?: () => { cols: number; rows: number } | undefined
-}): ManagedPane & { setRect: (rect: { width: number; height: number }) => void } {
+}): TestPane {
   let rect = options.rect
+  // Why: the inner xterm host can differ from the outer .pane (title/banner,
+  // padding); the reveal gate measures this element, so tests can move it alone.
+  let xtermRect: { width: number; height: number } | null = null
   const leafId = '22222222-2222-4222-8222-222222222222'
   const pane = {
     id: 7,
@@ -34,7 +43,10 @@ function createPane(options: {
       getBoundingClientRect: () => ({ width: rect.width, height: rect.height })
     },
     xtermContainer: {
-      getBoundingClientRect: () => ({ width: rect.width, height: rect.height })
+      getBoundingClientRect: () => ({
+        width: (xtermRect ?? rect).width,
+        height: (xtermRect ?? rect).height
+      })
     },
     fitAddon: {
       fit: vi.fn(),
@@ -45,11 +57,12 @@ function createPane(options: {
     pendingSplitScrollState: null as ScrollState | null,
     setRect: (next: { width: number; height: number }) => {
       rect = next
+    },
+    setXtermRect: (next: { width: number; height: number }) => {
+      xtermRect = next
     }
   }
-  return pane as unknown as ManagedPane & {
-    setRect: (rect: { width: number; height: number }) => void
-  }
+  return pane as unknown as TestPane
 }
 
 describe('safeFitAndThen unmeasurable-pane retry', () => {
@@ -165,5 +178,63 @@ describe('safeFitAndThen unmeasurable-pane retry', () => {
     pane.setRect({ width: 800, height: 600 })
     safeFit(pane)
     expect(continuation).not.toHaveBeenCalled()
+  })
+})
+
+describe('paneFitClientSizeChanged (reveal fit gate)', () => {
+  it('treats a pane with no recorded fit size as changed', () => {
+    const pane = createPane({ rect: { width: 800, height: 600 } })
+    expect(paneFitClientSizeChanged(pane)).toBe(true)
+  })
+
+  it('is unchanged after a fit when the container size is the same', () => {
+    const pane = createPane({
+      rect: { width: 800, height: 600 },
+      proposed: () => ({ cols: 80, rows: 24 })
+    })
+    safeFit(pane)
+    expect(paneFitClientSizeChanged(pane)).toBe(false)
+  })
+
+  it('reports changed when the container resized since the last fit', () => {
+    const pane = createPane({
+      rect: { width: 800, height: 600 },
+      proposed: () => ({ cols: 80, rows: 24 })
+    })
+    safeFit(pane)
+    pane.setRect({ width: 640, height: 480 })
+    expect(paneFitClientSizeChanged(pane)).toBe(true)
+  })
+
+  it('ignores sub-pixel jitter at the same rounded size (no reflow on reveal)', () => {
+    const pane = createPane({
+      rect: { width: 800, height: 600 },
+      proposed: () => ({ cols: 80, rows: 24 })
+    })
+    safeFit(pane)
+    pane.setRect({ width: 800.4, height: 599.6 })
+    expect(paneFitClientSizeChanged(pane)).toBe(false)
+  })
+
+  it('counts an unmeasurable (hidden) pane as changed rather than a false no-op', () => {
+    const pane = createPane({
+      rect: { width: 800, height: 600 },
+      proposed: () => ({ cols: 80, rows: 24 })
+    })
+    safeFit(pane)
+    pane.setRect({ width: 0, height: 0 })
+    expect(paneFitClientSizeChanged(pane)).toBe(true)
+  })
+
+  it('reports changed when the inner xterm host shrank but the outer pane did not', () => {
+    // A title bar / restored-session banner reduces the fittable area while the
+    // outer .pane pixels stay constant; the reveal must fit, not skip.
+    const pane = createPane({
+      rect: { width: 800, height: 600 },
+      proposed: () => ({ cols: 80, rows: 24 })
+    })
+    safeFit(pane)
+    pane.setXtermRect({ width: 800, height: 560 })
+    expect(paneFitClientSizeChanged(pane)).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -29,8 +29,7 @@ function createPane(options: {
   proposed?: () => { cols: number; rows: number } | undefined
 }): TestPane {
   let rect = options.rect
-  // Why: the inner xterm host can differ from the outer .pane (title/banner,
-  // padding); the reveal gate measures this element, so tests can move it alone.
+  // Why: the reveal gate measures the inner xterm host, which can differ from the outer .pane.
   let xtermRect: { width: number; height: number } | null = null
   const leafId = '22222222-2222-4222-8222-222222222222'
   const pane = {

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -214,8 +214,7 @@ export function flushPendingSafeFitContinuations(pane: ManagedPane): void {
 export function safeFit(pane: ManagedPane): boolean {
   const completed = performSafeFit(pane)
   if (completed) {
-    // Why: record the container size this grid was fit for so the reveal fit can
-    // later tell a real resize from a metric-only wobble at the same size.
+    // Why: baseline for the reveal fit to tell a real resize from a metric wobble.
     recordPaneFitClientSize(pane)
     // Why: replay transactions may be waiting for renderer dimensions; any
     // successful ordinary fit is the event that makes their PTY grid authoritative.

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -50,7 +50,27 @@ function getProposedDimensions(pane: ManagedPane): { cols: number; rows: number 
   }
 }
 
-function canMeasurePaneForFit(pane: ManagedPane): boolean {
+// Why: measure the element FitAddon fits (the xterm host), not the outer .pane —
+// a title/banner can shrink the inner fittable area while the outer stays put.
+// Round to whole pixels so sub-pixel jitter never reads as a resize.
+export function readFitClientSize(pane: ManagedPane): { width: number; height: number } | null {
+  const element = (pane as ManagedPaneInternal).xtermContainer ?? pane.container
+  const measure = element?.getBoundingClientRect
+  if (typeof measure !== 'function') {
+    return null
+  }
+  const rect = measure.call(element)
+  return { width: Math.round(rect.width), height: Math.round(rect.height) }
+}
+
+function recordPaneFitClientSize(pane: ManagedPane): void {
+  const size = readFitClientSize(pane)
+  if (size && size.width > 0 && size.height > 0) {
+    ;(pane as ManagedPaneInternal).lastFitClientSize = size
+  }
+}
+
+export function canMeasurePaneForFit(pane: ManagedPane): boolean {
   const measure = pane.container?.getBoundingClientRect
   if (typeof measure === 'function') {
     const rect = measure.call(pane.container)
@@ -172,7 +192,7 @@ function settlePendingSafeFitContinuation(
   pending.resolve(completed)
 }
 
-function flushPendingSafeFitContinuations(pane: ManagedPane): void {
+export function flushPendingSafeFitContinuations(pane: ManagedPane): void {
   const operations = pendingSafeFitContinuations.get(pane)
   if (!operations) {
     return
@@ -194,6 +214,9 @@ function flushPendingSafeFitContinuations(pane: ManagedPane): void {
 export function safeFit(pane: ManagedPane): boolean {
   const completed = performSafeFit(pane)
   if (completed) {
+    // Why: record the container size this grid was fit for so the reveal fit can
+    // later tell a real resize from a metric-only wobble at the same size.
+    recordPaneFitClientSize(pane)
     // Why: replay transactions may be waiting for renderer dimensions; any
     // successful ordinary fit is the event that makes their PTY grid authoritative.
     flushPendingSafeFitContinuations(pane)

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -145,10 +145,8 @@ export type ManagedPaneInternal = {
   // value means "currently disabled".
   ligaturesAddon: LigaturesAddon | null
   fitResizeObserver: ResizeObserver | null
-  // Why: the fit element's pixel size at the last successful fit. The reveal fit
-  // compares against it to tell a genuine hidden-time resize (fit now) from an
-  // unchanged element whose grid only appears to move under a transient
-  // DOM<->WebGL cell-metric wobble (skip the reflow).
+  // Why: fit-element pixel size at the last successful fit; the reveal fit compares
+  // against it to tell a real hidden-time resize from a transient cell-metric wobble.
   lastFitClientSize?: { width: number; height: number }
   // Stored so disposePane() can cancel the first post-open fit if a pane closes before paint.
   pendingInitialFitRafId?: number | null

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -145,6 +145,11 @@ export type ManagedPaneInternal = {
   // value means "currently disabled".
   ligaturesAddon: LigaturesAddon | null
   fitResizeObserver: ResizeObserver | null
+  // Why: the fit element's pixel size at the last successful fit. The reveal fit
+  // compares against it to tell a genuine hidden-time resize (fit now) from an
+  // unchanged element whose grid only appears to move under a transient
+  // DOM<->WebGL cell-metric wobble (skip the reflow).
+  lastFitClientSize?: { width: number; height: number }
   // Stored so disposePane() can cancel the first post-open fit if a pane closes before paint.
   pendingInitialFitRafId?: number | null
   // Stored so disposePane() can cancel the post-WebGL-teardown refresh frame.

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -198,15 +198,9 @@ export class PaneManager {
     fitAllPanesInternal(this.panes)
   }
 
-  // Reveal fit (minimize→restore, worktree foreground, window wake). A raw
-  // synchronous fit here reflow-garbles inline TUIs (grok, Codex): resuming
-  // WebGL swaps cell metrics vs the DOM renderer, so proposeDimensions can
-  // momentarily return a one-column-off grid, reflow xterm, then snap back — and
-  // xterm's main-buffer wrap→unwrap is not a perfect inverse, so a diff-painting
-  // TUI is left corrupted. fitRevealedPane fits synchronously only when the fit
-  // element's pixels changed while hidden, repairs a grid that diverged at
-  // unchanged pixels on a steady grid, and otherwise leaves the pane alone.
-  fitAllPanesStable(): void {
+  // Why: a raw synchronous fit on reveal can apply a transient DOM<->WebGL
+  // cell-metric grid and reflow-garble diff-painting inline TUIs; see fitRevealedPane.
+  fitAllRevealedPanes(): void {
     for (const pane of this.panes.values()) {
       fitRevealedPane(pane)
     }

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -42,6 +42,7 @@ import {
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { registerLivePaneManager, unregisterLivePaneManager } from './pane-manager-registry'
 import { schedulePaneRevealPresent, schedulePaneRevealRepaint } from './pane-reveal-repaint'
+import { fitRevealedPane } from './pane-reveal-fit'
 import { PaneIdentityRegistry } from './pane-identity-registry'
 import {
   closeManagedPane,
@@ -195,6 +196,20 @@ export class PaneManager {
 
   fitAllPanes(): void {
     fitAllPanesInternal(this.panes)
+  }
+
+  // Reveal fit (minimize→restore, worktree foreground, window wake). A raw
+  // synchronous fit here reflow-garbles inline TUIs (grok, Codex): resuming
+  // WebGL swaps cell metrics vs the DOM renderer, so proposeDimensions can
+  // momentarily return a one-column-off grid, reflow xterm, then snap back — and
+  // xterm's main-buffer wrap→unwrap is not a perfect inverse, so a diff-painting
+  // TUI is left corrupted. fitRevealedPane fits synchronously only when the fit
+  // element's pixels changed while hidden, repairs a grid that diverged at
+  // unchanged pixels on a steady grid, and otherwise leaves the pane alone.
+  fitAllPanesStable(): void {
+    for (const pane of this.panes.values()) {
+      fitRevealedPane(pane)
+    }
   }
 
   refreshAllPanes(): void {

--- a/src/renderer/src/lib/pane-manager/pane-reveal-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-fit.test.ts
@@ -39,7 +39,7 @@ function createPane(options: {
   const pane = {
     id: 3,
     lastFitClientSize: options.lastFitClientSize,
-    terminal: { cols: options.terminal.cols, rows: options.terminal.rows },
+    terminal: options.terminal,
     fitAddon: { proposeDimensions: vi.fn(() => options.proposed ?? undefined) }
   } as unknown as RevealTestPane
   mocks.readFitClientSize.mockImplementation(() => options.currentSize)

--- a/src/renderer/src/lib/pane-manager/pane-reveal-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-fit.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPane } from './pane-manager-types'
+import { fitRevealedPane } from './pane-reveal-fit'
+
+const mocks = vi.hoisted(() => ({
+  safeFit: vi.fn(),
+  canMeasurePaneForFit: vi.fn(() => true),
+  flushPendingSafeFitContinuations: vi.fn(),
+  readFitClientSize: vi.fn<(pane: ManagedPane) => { width: number; height: number } | null>(),
+  requestStablePaneFit: vi.fn(),
+  clearPaneFitContinuationRetry: vi.fn(),
+  resumePendingFitScrollRestoreAfterFit: vi.fn()
+}))
+
+vi.mock('./pane-fit', () => ({
+  safeFit: mocks.safeFit,
+  canMeasurePaneForFit: mocks.canMeasurePaneForFit,
+  flushPendingSafeFitContinuations: mocks.flushPendingSafeFitContinuations,
+  readFitClientSize: mocks.readFitClientSize
+}))
+vi.mock('./pane-fit-resize-observer', () => ({
+  requestStablePaneFit: mocks.requestStablePaneFit
+}))
+vi.mock('./pane-fit-continuation-retry', () => ({
+  clearPaneFitContinuationRetry: mocks.clearPaneFitContinuationRetry
+}))
+vi.mock('./pane-scroll', () => ({
+  resumePendingFitScrollRestoreAfterFit: mocks.resumePendingFitScrollRestoreAfterFit
+}))
+
+type RevealTestPane = ManagedPane & { lastFitClientSize?: { width: number; height: number } }
+
+function createPane(options: {
+  lastFitClientSize?: { width: number; height: number }
+  currentSize: { width: number; height: number } | null
+  terminal: { cols: number; rows: number }
+  proposed: { cols: number; rows: number } | null
+}): RevealTestPane {
+  const pane = {
+    id: 3,
+    lastFitClientSize: options.lastFitClientSize,
+    terminal: { cols: options.terminal.cols, rows: options.terminal.rows },
+    fitAddon: { proposeDimensions: vi.fn(() => options.proposed ?? undefined) }
+  } as unknown as RevealTestPane
+  mocks.readFitClientSize.mockImplementation(() => options.currentSize)
+  return pane
+}
+
+describe('fitRevealedPane routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.canMeasurePaneForFit.mockReturnValue(true)
+  })
+
+  it('fits synchronously when the fit element resized while hidden', () => {
+    const pane = createPane({
+      lastFitClientSize: { width: 800, height: 600 },
+      currentSize: { width: 640, height: 480 },
+      terminal: { cols: 80, rows: 24 },
+      proposed: { cols: 64, rows: 20 }
+    })
+
+    fitRevealedPane(pane)
+
+    expect(mocks.safeFit).toHaveBeenCalledTimes(1)
+    expect(mocks.requestStablePaneFit).not.toHaveBeenCalled()
+    expect(mocks.flushPendingSafeFitContinuations).not.toHaveBeenCalled()
+  })
+
+  it('fits with no baseline (first reveal) rather than skipping', () => {
+    const pane = createPane({
+      lastFitClientSize: undefined,
+      currentSize: { width: 800, height: 600 },
+      terminal: { cols: 80, rows: 24 },
+      proposed: { cols: 132, rows: 40 }
+    })
+
+    fitRevealedPane(pane)
+
+    expect(mocks.safeFit).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the fit (no reflow) when pixels are unchanged and the grid already matches', () => {
+    // A metric wobble would move proposed cols WITHOUT moving the element pixels;
+    // here the grid matches, so reveal must not reflow a diff-painting inline TUI.
+    const pane = createPane({
+      lastFitClientSize: { width: 800, height: 600 },
+      currentSize: { width: 800, height: 600 },
+      terminal: { cols: 80, rows: 24 },
+      proposed: { cols: 80, rows: 24 }
+    })
+
+    fitRevealedPane(pane)
+
+    expect(mocks.safeFit).not.toHaveBeenCalled()
+    expect(mocks.requestStablePaneFit).not.toHaveBeenCalled()
+    // Parked replay/reattach continuations still get released.
+    expect(mocks.flushPendingSafeFitContinuations).toHaveBeenCalledTimes(1)
+    expect(mocks.clearPaneFitContinuationRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('repairs on a steady grid when pixels are unchanged but the grid diverged while hidden', () => {
+    // e.g. a hidden snapshot/SSH-reattach did a direct terminal.resize to dims
+    // that differ from the container-fit grid; reveal must refit, not skip.
+    const pane = createPane({
+      lastFitClientSize: { width: 800, height: 600 },
+      currentSize: { width: 800, height: 600 },
+      terminal: { cols: 100, rows: 30 },
+      proposed: { cols: 80, rows: 24 }
+    })
+
+    fitRevealedPane(pane)
+
+    expect(mocks.requestStablePaneFit).toHaveBeenCalledTimes(1)
+    expect(mocks.safeFit).not.toHaveBeenCalled()
+    // Not the plain-release path — the stable fit owns continuation release here.
+    expect(mocks.flushPendingSafeFitContinuations).not.toHaveBeenCalled()
+  })
+
+  it('does not release continuations when an unchanged pane is unmeasurable', () => {
+    mocks.canMeasurePaneForFit.mockReturnValue(false)
+    const pane = createPane({
+      lastFitClientSize: { width: 800, height: 600 },
+      currentSize: { width: 800, height: 600 },
+      terminal: { cols: 80, rows: 24 },
+      proposed: { cols: 80, rows: 24 }
+    })
+
+    fitRevealedPane(pane)
+
+    expect(mocks.flushPendingSafeFitContinuations).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-reveal-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-fit.ts
@@ -1,0 +1,75 @@
+import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
+import {
+  canMeasurePaneForFit,
+  flushPendingSafeFitContinuations,
+  readFitClientSize,
+  safeFit
+} from './pane-fit'
+import { requestStablePaneFit } from './pane-fit-resize-observer'
+import { clearPaneFitContinuationRetry } from './pane-fit-continuation-retry'
+import { resumePendingFitScrollRestoreAfterFit } from './pane-scroll'
+
+// Why: reveal uses this to tell a real hidden-time geometry change (fit) from an
+// unchanged element whose proposed grid could only move under the DOM<->WebGL
+// cell-metric swap (skip). No baseline / unmeasurable counts as changed.
+export function paneFitClientSizeChanged(pane: ManagedPane): boolean {
+  const last = (pane as ManagedPaneInternal).lastFitClientSize
+  if (!last) {
+    return true
+  }
+  const current = readFitClientSize(pane)
+  if (!current || current.width <= 0 || current.height <= 0) {
+    return true
+  }
+  return current.width !== last.width || current.height !== last.height
+}
+
+function releaseMeasurableFitContinuations(pane: ManagedPane): void {
+  // Why: the grid is already correct so no reflow is needed, but a pane that
+  // mounted hidden can have replay/reattach continuations parked on a measurable
+  // fit — release them now it is visible, without resizing.
+  if (!canMeasurePaneForFit(pane)) {
+    return
+  }
+  // Why: parity with safeFit's equal-dims path — resume a scroll restore parked
+  // "for the next fit" so a matching-grid reveal does not strand it.
+  resumePendingFitScrollRestoreAfterFit(pane.terminal)
+  flushPendingSafeFitContinuations(pane)
+  clearPaneFitContinuationRetry(pane)
+}
+
+// Why: does the fit element propose the grid xterm already holds? Missing/failed
+// measurement counts as "matches" — releaseMeasurableFitContinuations re-guards
+// measurability and safeFit would no-op anyway, so it must not force a reflow.
+function proposedGridMatchesTerminal(pane: ManagedPane): boolean {
+  try {
+    const proposed = pane.fitAddon.proposeDimensions()
+    if (!proposed) {
+      return true
+    }
+    return proposed.cols === pane.terminal.cols && proposed.rows === pane.terminal.rows
+  } catch {
+    return true
+  }
+}
+
+// Reveal fit (minimize→restore, worktree foreground, window wake). Fit
+// synchronously when the fit element's pixels changed while hidden — a real
+// resize (which also keeps xterm ahead of the async {fit:false} PTY size reassert
+// so it can't forward a stale grid). If the pixels are unchanged but the grid
+// diverged while hidden (a direct terminal.resize from snapshot / SSH-reattach,
+// or an appearance/DPI change), repair it on a steady grid — a sustained mismatch
+// refits, a transient DOM<->WebGL cell-metric wobble does not reflow (which is
+// what garbles diff-painting inline TUIs like grok/Codex on reveal). An unchanged
+// grid is left alone.
+export function fitRevealedPane(pane: ManagedPane): void {
+  if (paneFitClientSizeChanged(pane)) {
+    safeFit(pane)
+    return
+  }
+  if (proposedGridMatchesTerminal(pane)) {
+    releaseMeasurableFitContinuations(pane)
+  } else {
+    requestStablePaneFit(pane)
+  }
+}

--- a/src/renderer/src/lib/pane-manager/pane-reveal-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-fit.ts
@@ -9,9 +9,8 @@ import { requestStablePaneFit } from './pane-fit-resize-observer'
 import { clearPaneFitContinuationRetry } from './pane-fit-continuation-retry'
 import { resumePendingFitScrollRestoreAfterFit } from './pane-scroll'
 
-// Why: reveal uses this to tell a real hidden-time geometry change (fit) from an
-// unchanged element whose proposed grid could only move under the DOM<->WebGL
-// cell-metric swap (skip). No baseline / unmeasurable counts as changed.
+// Why: a real resize changes the element's pixels; a metric-only wobble does not.
+// No baseline / unmeasurable counts as changed so a first reveal still fits.
 export function paneFitClientSizeChanged(pane: ManagedPane): boolean {
   const last = (pane as ManagedPaneInternal).lastFitClientSize
   if (!last) {
@@ -24,23 +23,8 @@ export function paneFitClientSizeChanged(pane: ManagedPane): boolean {
   return current.width !== last.width || current.height !== last.height
 }
 
-function releaseMeasurableFitContinuations(pane: ManagedPane): void {
-  // Why: the grid is already correct so no reflow is needed, but a pane that
-  // mounted hidden can have replay/reattach continuations parked on a measurable
-  // fit — release them now it is visible, without resizing.
-  if (!canMeasurePaneForFit(pane)) {
-    return
-  }
-  // Why: parity with safeFit's equal-dims path — resume a scroll restore parked
-  // "for the next fit" so a matching-grid reveal does not strand it.
-  resumePendingFitScrollRestoreAfterFit(pane.terminal)
-  flushPendingSafeFitContinuations(pane)
-  clearPaneFitContinuationRetry(pane)
-}
-
-// Why: does the fit element propose the grid xterm already holds? Missing/failed
-// measurement counts as "matches" — releaseMeasurableFitContinuations re-guards
-// measurability and safeFit would no-op anyway, so it must not force a reflow.
+// Why: missing/failed measurement counts as "matches" — safeFit would no-op
+// there anyway, so reveal must not force a reflow.
 function proposedGridMatchesTerminal(pane: ManagedPane): boolean {
   try {
     const proposed = pane.fitAddon.proposeDimensions()
@@ -53,23 +37,37 @@ function proposedGridMatchesTerminal(pane: ManagedPane): boolean {
   }
 }
 
-// Reveal fit (minimize→restore, worktree foreground, window wake). Fit
-// synchronously when the fit element's pixels changed while hidden — a real
-// resize (which also keeps xterm ahead of the async {fit:false} PTY size reassert
-// so it can't forward a stale grid). If the pixels are unchanged but the grid
-// diverged while hidden (a direct terminal.resize from snapshot / SSH-reattach,
-// or an appearance/DPI change), repair it on a steady grid — a sustained mismatch
-// refits, a transient DOM<->WebGL cell-metric wobble does not reflow (which is
-// what garbles diff-painting inline TUIs like grok/Codex on reveal). An unchanged
-// grid is left alone.
+function releaseMeasurableFitContinuations(pane: ManagedPane): void {
+  // Why: no reflow needed, but a pane that mounted hidden can have replay/reattach
+  // continuations parked on a measurable fit — release them (and any parked scroll
+  // restore, mirroring safeFit's equal-dims path) now it is visible.
+  if (!canMeasurePaneForFit(pane)) {
+    return
+  }
+  resumePendingFitScrollRestoreAfterFit(pane.terminal)
+  flushPendingSafeFitContinuations(pane)
+  clearPaneFitContinuationRetry(pane)
+}
+
+// Reveal fit (minimize→restore, worktree foreground, window wake). resumeRendering
+// re-attaches WebGL, whose cell metrics briefly differ from the DOM renderer's, so
+// a raw fit can propose a one-column-off grid, reflow xterm, then snap back — and
+// xterm's wrap→unwrap is not a perfect inverse, so a diff-painting inline TUI
+// (grok, Codex) is left corrupted. So:
+//  - pixels changed while hidden → real resize: fit now (also keeps xterm ahead of
+//    the async {fit:false} PTY size reassert so it can't forward a stale grid);
+//  - pixels unchanged but grid diverged (a direct terminal.resize from snapshot /
+//    SSH-reattach, or a DPI change) → repair on a steady grid, so a sustained
+//    mismatch refits but a transient metric wobble does not reflow;
+//  - grid already correct → leave it alone.
 export function fitRevealedPane(pane: ManagedPane): void {
   if (paneFitClientSizeChanged(pane)) {
     safeFit(pane)
     return
   }
-  if (proposedGridMatchesTerminal(pane)) {
-    releaseMeasurableFitContinuations(pane)
-  } else {
+  if (!proposedGridMatchesTerminal(pane)) {
     requestStablePaneFit(pane)
+    return
   }
+  releaseMeasurableFitContinuations(pane)
 }


### PR DESCRIPTION
## What & why

`grok` (and other **inline-viewport** TUIs like Codex) render badly garbled — overlapping / duplicated / misaligned frames — after Orca's **floating terminal is minimized and brought back up**. Reported in [Slack](https://stablygroup.slack.com/archives/C0ASMDT6LQZ/p1784788515610149) ("grok is pretty fucked in floating terminal after minimize + bring back up").

**Root cause.** On reveal, the resume path fit xterm **synchronously** right after `resumeRendering()` re-attaches the WebGL renderer. WebGL rounds cell dimensions to device pixels differently from the DOM renderer, so for a frame `FitAddon.proposeDimensions()` can return a **one-column-off** grid. The synchronous fit commits it, reflowing xterm, and the ~150 ms container `ResizeObserver` fits it back — a **net-zero resize "wiggle"**. xterm's main-buffer wrap→unwrap is **not a perfect inverse**, and an inline TUI that only diff-paints its pinned region (never a full clear, unless it detects a multiplexer) redraws over the corrupted buffer. The reveal fit was the one fit path that skipped the stability gate the ResizeObserver and drift-check paths already use.

**Fix.** Replace the unconditional synchronous reveal fit (`fitAllPanes`) with a gated one — `PaneManager.fitAllPanesStable()` → `fitRevealedPane(pane)`:

| On reveal, the fit element's pixels… | action |
|---|---|
| **changed** while hidden (a real resize) | **synchronous `safeFit`** — the app must reflow anyway, and doing it now keeps xterm ahead of the async `{fit:false}` PTY size reassert so it can't forward a stale grid |
| **unchanged**, and the proposed grid **matches** the terminal (the common minimize→restore) | **skip** — the grid is already correct; only release parked replay/reattach continuations |
| **unchanged**, but the grid **diverged** while hidden (snapshot / SSH-reattach `terminal.resize`, or an appearance/DPI change) | **`requestStablePaneFit`** — repair on a steady grid, so a *sustained* mismatch refits but a *transient* metric wobble does not reflow |

The pixel comparison measures the actual element FitAddon fits (`xtermContainer`), rounded to whole pixels so sub-pixel jitter never reads as a resize. Same gate applied to the window-wake reveal path.

The result: **the reported minimize→restore is now a hard no-op with zero reflow.**

## ELI5

grok draws its screen by only touching the characters that changed since last frame (it trusts everything else to stay put). When you minimized and reopened the floating terminal, Orca briefly told the terminal it was one column narrower, then a column wider again — snapping the text back and forth. The terminal's text-rewrapping isn't perfectly reversible, so the "everything else stays put" assumption broke, and grok painted new text on top of shuffled old text → garbage.

The fix: on reopen, Orca now only re-measures the terminal **when the window actually changed size**. If it's the same size (the usual case), it leaves the terminal exactly as it was — no snap, no garbage.

## Proof of fix

Reproduced end-to-end with **real grok in a real PTY piped into the same `@xterm/headless` build Orca ships**, then isolated the trigger:

| restore scenario | grok pinned region |
|---|---|
| `120→80→120` (transient wrong-size fit, net size unchanged) | **CORRUPTED** — box border mangled, `[1X`/`[40X` erase-patch fragments and footer text bleeding across the border (matches the screenshot) |
| `120→120` (same-size fit, no-op) | **CLEAN** |
| never resized | **CLEAN** |

So a resize that lands *back* on the original size is the worst case (grok's `autoresize` only clears when the area actually changes, so returning to a known size triggers **no clear**). The fix guarantees the same-size reveal never resizes xterm at all → no wiggle. A same-size fit was already a no-op in `safeFit`, so no needed SIGWINCH is lost; only the transient wiggle is removed.

Also confirmed deterministically via a recorded grok byte-stream replayed through xterm with the wiggle vs. a clean control (4 corrupted rows vs. 0).

## Regressions — none expected

- **`safeFit` was already a no-op on same-size**, so removing the synchronous reveal fit for unchanged panes loses no legitimate resize/SIGWINCH.
- **Genuine hidden-time resizes still fit** (pixel-changed branch → synchronous `safeFit`), preserving the existing convergence guarded by `tests/e2e/terminal-inline-tui-reveal-convergence.spec.ts` (incl. its "reveal after a hidden-time window resize" case).
- **Snapshot / SSH-reattach / appearance-change divergence still repairs** (diverged-grid branch → `requestStablePaneFit`), which forwards the *corrected* grid to the PTY (fit runs before the parked continuation flushes).
- **Focus parity** preserved (focus applied in exactly the same `isActive` cases as before).
- Every container-resizing path (divider drags, `SYNC_FIT_PANES_EVENT`, ResizeObserver, splits) still funnels through `safeFit`, which records the pixel baseline — so a genuine reveal resize can't be misclassified as "unchanged."

### Adversarial review

Ran a 3-round adversarial review loop with two independent frontier reviewers (Claude Fable + GPT‑5.6). Findings surfaced and fixed along the way: a fit↔PTY-reassert timing race, measuring the wrong (outer) element, a residual transient-commit in the stable fitter, and a snapshot-divergence repair regression. Final round: both reviewers confirm all concrete/blocking findings closed; the only remaining items are narrow, self-healing, explicitly non-blocking edges (a rare transient double-SIGWINCH on the uncommon divergence branch that self-corrects within a frame).

### Tests

- New unit coverage: `pane-reveal-fit.test.ts` (all four routing branches incl. snapshot-divergence repair + unmeasurable) and `pane-fit.test.ts` (`paneFitClientSizeChanged`: no-baseline, same-size, resized, sub-pixel jitter, inner-host shrink, unmeasurable). Manager/visibility paths assert the reveal routes through the stable fit and never the raw `fitAllPanes`.
- Full `pane-manager` + affected `terminal-pane` suites: **624 pass / 1 skipped**. `oxlint` clean. `tsc` (renderer) clean.

## Note on scope

The fix lives entirely on Orca's side (hosting inline TUIs correctly across reveal); `grok`/`grok-build` was used only to reproduce and understand the corruption, not modified.

Made with [Orca](https://github.com/stablyai/orca) 🐋
