### PR TITLE
fix(mobile): resolve markdown tabs across split groups

### DIFF
--- a/src/renderer/src/runtime/mobile-markdown-bridge-save-guards.test.ts
+++ b/src/renderer/src/runtime/mobile-markdown-bridge-save-guards.test.ts
@@ -15,10 +15,6 @@ import {
   setupWindow
 } from './mobile-markdown-bridge-test-harness'
 
-vi.mock('@/components/tab-bar/group-tab-order', () => ({
-  getActiveTabNavOrder: () => [{ type: 'editor', id: '/repo/README.md', tabId: 'tab-md' }]
-}))
-
 vi.mock('@/lib/connection-context', () => ({
   getConnectionIdForFile: () => null
 }))

--- a/src/renderer/src/runtime/mobile-markdown-bridge-test-harness.ts
+++ b/src/renderer/src/runtime/mobile-markdown-bridge-test-harness.ts
@@ -23,6 +23,9 @@ type WindowStub = {
 }
 
 let mobileMarkdownHandler: ((request: RuntimeMobileMarkdownRequest) => void) | null = null
+const TEST_WORKTREE_ID = 'wt-1'
+const TEST_MARKDOWN_FILE_ID = '/repo/README.md'
+const TEST_MARKDOWN_TAB_ID = 'tab-md'
 
 export function setupWindow({
   readFile,
@@ -60,8 +63,22 @@ export function resetEditorState(): void {
   useAppStore.setState({
     openFiles: [],
     editorDrafts: {},
+    groupsByWorktree: {},
+    activeGroupIdByWorktree: {},
+    unifiedTabsByWorktree: {},
+    layoutByWorktree: {},
+    tabsByWorktree: {},
+    tabBarOrderByWorktree: {},
     worktreesByRepo: {
-      repo: [{ id: 'wt-1', repoId: 'repo', path: '/repo', branch: 'main', hostId: 'local' }]
+      repo: [
+        {
+          id: TEST_WORKTREE_ID,
+          repoId: 'repo',
+          path: '/repo',
+          branch: 'main',
+          hostId: 'local'
+        }
+      ]
     },
     repos: [
       {
@@ -75,12 +92,22 @@ export function resetEditorState(): void {
   } as never)
 }
 
-export function openMarkdownFile(): void {
-  useAppStore.getState().openFile({
-    filePath: '/repo/README.md',
+export function openMarkdownFile(options: { withUnifiedTab?: boolean } = {}): void {
+  const { withUnifiedTab = true } = options
+  const state = useAppStore.getState()
+  if (withUnifiedTab) {
+    state.createUnifiedTab(TEST_WORKTREE_ID, 'editor', {
+      id: TEST_MARKDOWN_TAB_ID,
+      entityId: TEST_MARKDOWN_FILE_ID,
+      recordInteraction: false
+    })
+  }
+  state.openFile({
+    filePath: TEST_MARKDOWN_FILE_ID,
     relativePath: 'README.md',
-    worktreeId: 'wt-1',
+    worktreeId: TEST_WORKTREE_ID,
     language: 'markdown',
+    runtimeEnvironmentId: null,
     mode: 'edit'
   })
 }

--- a/src/renderer/src/runtime/mobile-markdown-bridge.test.ts
+++ b/src/renderer/src/runtime/mobile-markdown-bridge.test.ts
@@ -15,13 +15,56 @@ import {
   setupWindow
 } from './mobile-markdown-bridge-test-harness'
 
-vi.mock('@/components/tab-bar/group-tab-order', () => ({
-  getActiveTabNavOrder: () => [{ type: 'editor', id: '/repo/README.md', tabId: 'tab-md' }]
-}))
-
 vi.mock('@/lib/connection-context', () => ({
   getConnectionIdForFile: () => null
 }))
+
+function activateTerminalSplitBesideMarkdown(): {
+  markdownGroupId: string
+  terminalGroupId: string
+} {
+  const state = useAppStore.getState()
+  const markdownGroupId = state.unifiedTabsByWorktree['wt-1']?.find(
+    (tab) => tab.id === 'tab-md'
+  )?.groupId
+  if (!markdownGroupId) {
+    throw new Error('Missing Markdown group')
+  }
+  useAppStore.setState((current) => ({
+    tabsByWorktree: {
+      ...current.tabsByWorktree,
+      'wt-1': [
+        {
+          id: 'terminal-tab',
+          ptyId: null,
+          worktreeId: 'wt-1',
+          title: 'Terminal',
+          customTitle: null,
+          color: null,
+          sortOrder: 1,
+          createdAt: 2
+        }
+      ]
+    }
+  }))
+  const terminalTab = useAppStore.getState().createUnifiedTabInSplit(
+    'wt-1',
+    'terminal',
+    {
+      sourceGroupId: markdownGroupId,
+      splitDirection: 'right'
+    },
+    {
+      id: 'terminal-tab',
+      entityId: 'terminal-tab',
+      recordInteraction: false
+    }
+  )
+  if (!terminalTab) {
+    throw new Error('Missing terminal split')
+  }
+  return { markdownGroupId, terminalGroupId: terminalTab.groupId }
+}
 
 describe('mobile markdown bridge', () => {
   beforeEach(() => {
@@ -62,6 +105,93 @@ describe('mobile markdown bridge', () => {
     }
   })
 
+  it('reads a hydration fallback markdown tab addressed by its file ID', async () => {
+    openMarkdownFile({ withUnifiedTab: false })
+    setupWindow({
+      readFile: vi.fn().mockResolvedValue({ content: '# fallback\n', isBinary: false })
+    })
+    const detach = attachMobileMarkdownBridge()
+
+    try {
+      const response = await sendRequest({
+        id: 'read-hydration-fallback',
+        operation: 'read',
+        worktreeId: 'wt-1',
+        tabId: '/repo/README.md'
+      })
+
+      expect(response).toMatchObject({
+        id: 'read-hydration-fallback',
+        ok: true,
+        result: { content: '# fallback\n', editable: true }
+      })
+    } finally {
+      detach()
+    }
+  })
+
+  it('rejects an unknown markdown tab ID', async () => {
+    openMarkdownFile()
+    setupWindow({
+      readFile: vi.fn().mockResolvedValue({ content: '# known\n', isBinary: false })
+    })
+    const detach = attachMobileMarkdownBridge()
+
+    try {
+      const response = await sendRequest({
+        id: 'read-unknown',
+        operation: 'read',
+        worktreeId: 'wt-1',
+        tabId: '/repo/MISSING.md'
+      })
+
+      expect(response).toMatchObject({
+        id: 'read-unknown',
+        ok: false,
+        error: 'tab_not_found'
+      })
+    } finally {
+      detach()
+    }
+  })
+
+  it('reads a markdown tab outside the desktop-active split group', async () => {
+    openMarkdownFile()
+    const { markdownGroupId, terminalGroupId } = activateTerminalSplitBesideMarkdown()
+    setupWindow({
+      readFile: vi.fn().mockResolvedValue({ content: '# inactive\n', isBinary: false })
+    })
+    const detach = attachMobileMarkdownBridge()
+
+    try {
+      const response = await sendRequest({
+        id: 'read-inactive-group',
+        operation: 'read',
+        worktreeId: 'wt-1',
+        tabId: 'tab-md'
+      })
+
+      expect(response).toMatchObject({
+        id: 'read-inactive-group',
+        ok: true,
+        result: { content: '# inactive\n', editable: true }
+      })
+      expect(useAppStore.getState().activeGroupIdByWorktree['wt-1']).toBe(terminalGroupId)
+      expect(
+        useAppStore
+          .getState()
+          .groupsByWorktree['wt-1']?.find((group) => group.id === markdownGroupId)?.activeTabId
+      ).toBe('tab-md')
+      expect(
+        useAppStore
+          .getState()
+          .groupsByWorktree['wt-1']?.find((group) => group.id === terminalGroupId)?.activeTabId
+      ).toBe('terminal-tab')
+    } finally {
+      detach()
+    }
+  })
+
   it('rejects save when a clean file changed after mobile read', async () => {
     openMarkdownFile()
     const writeFile = vi.fn().mockResolvedValue(undefined)
@@ -90,6 +220,7 @@ describe('mobile markdown bridge', () => {
 
   it('saves through the editor save controller and verifies written content', async () => {
     openMarkdownFile()
+    const { markdownGroupId, terminalGroupId } = activateTerminalSplitBesideMarkdown()
     let diskContent = 'original'
     const readFile = vi.fn().mockImplementation(async () => ({
       content: diskContent,
@@ -123,6 +254,17 @@ describe('mobile markdown bridge', () => {
         ok: true,
         result: { content: 'mobile edit', isDirty: false }
       })
+      expect(useAppStore.getState().activeGroupIdByWorktree['wt-1']).toBe(terminalGroupId)
+      expect(
+        useAppStore
+          .getState()
+          .groupsByWorktree['wt-1']?.find((group) => group.id === markdownGroupId)?.activeTabId
+      ).toBe('tab-md')
+      expect(
+        useAppStore
+          .getState()
+          .groupsByWorktree['wt-1']?.find((group) => group.id === terminalGroupId)?.activeTabId
+      ).toBe('terminal-tab')
     } finally {
       detachAutosave()
       detachBridge()

--- a/src/renderer/src/runtime/mobile-markdown-bridge.test.ts
+++ b/src/renderer/src/runtime/mobile-markdown-bridge.test.ts
@@ -132,9 +132,8 @@ describe('mobile markdown bridge', () => {
 
   it('rejects an unknown markdown tab ID', async () => {
     openMarkdownFile()
-    setupWindow({
-      readFile: vi.fn().mockResolvedValue({ content: '# known\n', isBinary: false })
-    })
+    const readFile = vi.fn().mockResolvedValue({ content: '# known\n', isBinary: false })
+    setupWindow({ readFile })
     const detach = attachMobileMarkdownBridge()
 
     try {
@@ -150,6 +149,7 @@ describe('mobile markdown bridge', () => {
         ok: false,
         error: 'tab_not_found'
       })
+      expect(readFile).not.toHaveBeenCalled()
     } finally {
       detach()
     }
@@ -164,6 +164,7 @@ describe('mobile markdown bridge', () => {
     const detach = attachMobileMarkdownBridge()
 
     try {
+      expect(useAppStore.getState().activeGroupIdByWorktree['wt-1']).toBe(terminalGroupId)
       const response = await sendRequest({
         id: 'read-inactive-group',
         operation: 'read',
@@ -234,6 +235,7 @@ describe('mobile markdown bridge', () => {
     const detachAutosave = attachEditorAutosaveController(useAppStore as never)
 
     try {
+      expect(useAppStore.getState().activeGroupIdByWorktree['wt-1']).toBe(terminalGroupId)
       const response = await sendRequest({
         id: 'save-2',
         operation: 'save',

--- a/src/renderer/src/runtime/mobile-markdown-bridge.ts
+++ b/src/renderer/src/runtime/mobile-markdown-bridge.ts
@@ -1,4 +1,3 @@
-import { getActiveTabNavOrder } from '@/components/tab-bar/group-tab-order'
 import {
   ORCA_EDITOR_FILE_SAVED_EVENT,
   requestEditorFileSave,
@@ -185,12 +184,13 @@ function resolveMarkdownTarget(
   tabId: string
 ): { tab: OpenFile; sourceFile: OpenFile } {
   const state = useAppStore.getState()
-  const orderItem = getActiveTabNavOrder(state, worktreeId).find(
-    (item) => item.type === 'editor' && (item.tabId === tabId || item.id === tabId)
+  const unifiedTab = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+    (candidate) => candidate.contentType === 'editor' && candidate.id === tabId
   )
-  const tabFileId = orderItem?.type === 'editor' ? orderItem.id : tabId
+  // Why: hydration can publish the file ID before a unified editor wrapper exists.
+  const tabFileId = unifiedTab?.entityId ?? tabId
   const tab = state.openFiles.find(
-    (file) => file.worktreeId === worktreeId && (file.id === tabFileId || file.id === tabId)
+    (file) => file.worktreeId === worktreeId && file.id === tabFileId
   )
   if (!tab || !isMarkdownTab(tab)) {
     throw new Error('tab_not_found')


### PR DESCRIPTION
## Summary

- resolve paired-mobile Markdown requests across every unified editor tab in the requested worktree, not only the desktop-active split
- preserve the direct file-ID hydration fallback while requiring an exact worktree-scoped Markdown `OpenFile`
- preserve the backing file, save controller, desktop-active group, and each split's active tab
- fail closed before filesystem reads for unknown IDs

## Screenshots

No visual change.

## Testing

Exact published head: `3666860c5b38e895d0859561ed12631e3a32e2ba` on base `f71373953baa1d384b75bbdf4845fda17a847da5`.

- bridge suite: 7/7
- inactive-split read and save tests assert the terminal group is desktop-active before each request
- unknown-ID coverage asserts `readFile` is never called
- the combined exact-head desktop matrix passed 3,563 tests
- lint and all three TypeScript projects passed in the stable integration stack
- prior physical Android acceptance read, edited, and saved Markdown from an inactive desktop split without changing desktop-active state

The current installed integration is `e13fa51f38102e1c3bf972e206e68fd323927406`; its rebuilt package passed the Linux compatibility, daemon-entry, and bundled-plugin gates.

## AI Review Report

The review checked the hydration contract, fail-closed boundary, split-state invariants, worktree scoping, SSH/runtime ownership, and O(n) lookup cost. No UI, shortcut, native-module, git-provider, or agent behavior changes.

## Security Audit

Resolution still requires the requested worktree plus an exact unified-editor entity or exact host-published Markdown file ID. Unknown tabs, non-editor tabs, and non-Markdown files fail with `tab_not_found` before file I/O. No new command, path construction, authentication, dependency, IPC, or permission surface is introduced.

## Notes

- This fixes read/save of an already-open Markdown tab in a non-active split; file-explorer opening is separate.
- The direct file-ID fallback is intentionally limited to the host hydration window.
- X handle: not provided.

## ELI5

Mobile now finds an open Markdown file even when it lives in another desktop split, without moving anyone's active tab.
