### PR TITLE
perf(terminal): avoid repeated pending drain snapshots

### DIFF
--- a/src/main/ipc/pty-pending-data-drain-contract.ts
+++ b/src/main/ipc/pty-pending-data-drain-contract.ts
@@ -1,0 +1,22 @@
+export type PendingPtyData = {
+  data: string
+  startSeq?: number
+  rawLength?: number
+  transformed?: true
+  containsBackgroundOutput?: boolean
+  droppedOutput?: true
+}
+
+export type PtyPendingDataDrainDisposition = 'active' | 'background' | 'blocked'
+
+type DrainPhase = 'active' | 'background' | 'done'
+
+export type PtyPendingDataDrainRound = {
+  readonly round: number
+  activeFrontier: number
+  backgroundFrontier: number
+  phase: DrainPhase
+  aborted: boolean
+}
+
+export type PtyPendingDataDrainSelection = Readonly<{ id: string; pending: PendingPtyData }>

--- a/src/main/ipc/pty-pending-data-drain-queue-differential.test.ts
+++ b/src/main/ipc/pty-pending-data-drain-queue-differential.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it } from 'vitest'
+import { PtyPendingDataDrainQueue, type PendingPtyData } from './pty-pending-data-drain-queue'
+
+const CHUNK_CHARS = 4
+const MAX_WRITES = 2
+
+type Policy = {
+  active: Set<string>
+  hidden: Set<string>
+  interested: Set<string>
+  credit: number
+}
+
+type DrainEvent = {
+  kind: 'data' | 'drop' | 'marker' | 'sentinel'
+  id: string
+  data?: string
+  startSeq?: number
+  rawLength?: number
+  transformed?: true
+  containsBackgroundOutput?: boolean
+}
+
+type DrainResult = {
+  events: DrainEvent[]
+  flow: { id: string; pendingChars: number }[]
+  timer: 'blocked' | 'continue' | 'idle'
+  writes: number
+}
+
+function createPolicy(): Policy {
+  return {
+    active: new Set(),
+    hidden: new Set(),
+    interested: new Set(),
+    credit: 2
+  }
+}
+
+function isDroppable(policy: Policy, id: string): boolean {
+  return policy.hidden.has(id) && !policy.interested.has(id)
+}
+
+function classify(policy: Policy, id: string) {
+  if (!isDroppable(policy, id) && policy.credit <= 0) {
+    return 'blocked' as const
+  }
+  return policy.active.has(id) ? ('active' as const) : ('background' as const)
+}
+
+function clonePending(value: PendingPtyData): PendingPtyData {
+  return { ...value }
+}
+
+function remainderFor(pending: PendingPtyData, chunk: string, remaining: string): PendingPtyData {
+  const next: PendingPtyData = { data: remaining }
+  if (typeof pending.startSeq === 'number') {
+    next.startSeq = pending.startSeq + chunk.length
+  }
+  if (pending.containsBackgroundOutput === true) {
+    next.containsBackgroundOutput = true
+  }
+  return next
+}
+
+function dataEvent(id: string, pending: PendingPtyData, data: string): DrainEvent {
+  return {
+    kind: 'data',
+    id,
+    data,
+    ...(typeof pending.startSeq === 'number' ? { startSeq: pending.startSeq } : {}),
+    ...(typeof pending.rawLength === 'number' ? { rawLength: pending.rawLength } : {}),
+    ...(pending.transformed === true ? { transformed: true } : {}),
+    ...(pending.containsBackgroundOutput === true ? { containsBackgroundOutput: true } : {})
+  }
+}
+
+function recordExit(timeline: unknown[], id: string, pending: PendingPtyData | undefined): void {
+  if (pending) {
+    timeline.push(
+      pending.droppedOutput === true
+        ? { kind: 'sentinel', id, data: pending.data }
+        : dataEvent(id, pending, pending.data)
+    )
+    timeline.push({ kind: 'flow', id, pendingChars: 0 })
+  }
+  timeline.push({ kind: 'exit', id, hadPending: pending !== undefined })
+}
+
+function timerDecision(size: number, writes: number): DrainResult['timer'] {
+  if (size === 0) {
+    return 'idle'
+  }
+  return writes > 0 ? 'continue' : 'blocked'
+}
+
+function recordDrop(
+  events: DrainEvent[],
+  markedDrops: Set<string>,
+  id: string,
+  pending: PendingPtyData
+): void {
+  events.push({ kind: 'drop', id, data: pending.data })
+  if (!markedDrops.has(id)) {
+    markedDrops.add(id)
+    events.push({ kind: 'marker', id })
+  }
+}
+
+function drainLegacy(
+  pendingById: Map<string, PendingPtyData>,
+  policy: Policy,
+  markedDrops: Set<string>
+): DrainResult {
+  const entries = [...pendingById.entries()]
+  const ordered = [
+    ...entries.filter(([id]) => policy.active.has(id)),
+    ...entries.filter(([id]) => !policy.active.has(id))
+  ]
+  const events: DrainEvent[] = []
+  const flow: DrainResult['flow'] = []
+  let writes = 0
+  for (const [id, pending] of ordered) {
+    if (writes >= MAX_WRITES) {
+      break
+    }
+    if (isDroppable(policy, id)) {
+      pendingById.delete(id)
+      recordDrop(events, markedDrops, id, pending)
+      flow.push({ id, pendingChars: 0 })
+      continue
+    }
+    if (policy.credit <= 0) {
+      continue
+    }
+    pendingById.delete(id)
+    if (pending.droppedOutput === true) {
+      events.push({ kind: 'sentinel', id, data: pending.data })
+    } else {
+      const chunk = pending.transformed === true ? pending.data : pending.data.slice(0, CHUNK_CHARS)
+      const remaining = pending.transformed === true ? '' : pending.data.slice(CHUNK_CHARS)
+      if (remaining) {
+        pendingById.set(id, remainderFor(pending, chunk, remaining))
+      }
+      events.push(dataEvent(id, pending, chunk))
+    }
+    flow.push({ id, pendingChars: pendingById.get(id)?.data.length ?? 0 })
+    policy.credit -= 1
+    writes += 1
+  }
+  return { events, flow, timer: timerDecision(pendingById.size, writes), writes }
+}
+
+function drainQueue(
+  queue: PtyPendingDataDrainQueue,
+  policy: Policy,
+  markedDrops: Set<string>
+): DrainResult {
+  const events: DrainEvent[] = []
+  const flow: DrainResult['flow'] = []
+  let writes = 0
+  const round = queue.beginRound()
+  try {
+    while (writes < MAX_WRITES) {
+      const selection = queue.takeNext(round)
+      if (!selection) {
+        break
+      }
+      const { id, pending } = selection
+      if (isDroppable(policy, id)) {
+        queue.remove(selection)
+        recordDrop(events, markedDrops, id, pending)
+        flow.push({ id, pendingChars: 0 })
+        continue
+      }
+      if (policy.credit <= 0) {
+        queue.block(selection)
+        continue
+      }
+      if (pending.droppedOutput === true) {
+        queue.remove(selection)
+        events.push({ kind: 'sentinel', id, data: pending.data })
+      } else {
+        const chunk =
+          pending.transformed === true ? pending.data : pending.data.slice(0, CHUNK_CHARS)
+        const remaining = pending.transformed === true ? '' : pending.data.slice(CHUNK_CHARS)
+        if (remaining) {
+          queue.replaceWithRemainder(selection, remainderFor(pending, chunk, remaining))
+        } else {
+          queue.remove(selection)
+        }
+        events.push(dataEvent(id, pending, chunk))
+      }
+      flow.push({ id, pendingChars: queue.get(id)?.data.length ?? 0 })
+      policy.credit -= 1
+      writes += 1
+    }
+  } finally {
+    queue.endRound(round)
+  }
+  return { events, flow, timer: timerDecision(queue.size, writes), writes }
+}
+
+function nextRandom(state: { value: number }): number {
+  let value = state.value
+  value ^= value << 13
+  value ^= value >>> 17
+  value ^= value << 5
+  state.value = value >>> 0
+  return state.value
+}
+
+function setMembership(set: Set<string>, id: string, present: boolean): boolean {
+  if (present) {
+    const changed = !set.has(id)
+    set.add(id)
+    return changed
+  }
+  return set.delete(id)
+}
+
+function expectEquivalent(
+  legacy: Map<string, PendingPtyData>,
+  queue: PtyPendingDataDrainQueue,
+  legacyPolicy: Policy,
+  queuePolicy: Policy,
+  legacyTimeline: unknown[],
+  queueTimeline: unknown[]
+): void {
+  expect([...queue.keys()]).toEqual([...legacy.keys()])
+  expect([...queue.values()]).toEqual([...legacy.values()])
+  expect(queuePolicy.credit).toBe(legacyPolicy.credit)
+  expect(queueTimeline).toEqual(legacyTimeline)
+}
+
+function runSeed(seed: number): void {
+  const legacy = new Map<string, PendingPtyData>()
+  const legacyPolicy = createPolicy()
+  const queuePolicy = createPolicy()
+  const queue = new PtyPendingDataDrainQueue((id) => classify(queuePolicy, id))
+  const legacyMarkedDrops = new Set<string>()
+  const queueMarkedDrops = new Set<string>()
+  const legacyTimeline: unknown[] = []
+  const queueTimeline: unknown[] = []
+  const random = { value: seed }
+  const ids = ['a', 'b', 'c', 'd', 'e', 'f']
+
+  for (let step = 0; step < 800; step++) {
+    const choice = nextRandom(random) % 13
+    const id = ids[nextRandom(random) % ids.length]!
+    if (choice <= 2) {
+      const suffix = String.fromCharCode(97 + (nextRandom(random) % 26)).repeat(
+        1 + (nextRandom(random) % 6)
+      )
+      const current = legacy.get(id)
+      const next: PendingPtyData = current
+        ? { ...current, data: current.data + suffix }
+        : {
+            data: suffix,
+            startSeq: nextRandom(random) % 40,
+            ...(nextRandom(random) % 3 === 0 ? { containsBackgroundOutput: true } : {})
+          }
+      legacy.set(id, clonePending(next))
+      queue.set(id, clonePending(next))
+    } else if (choice === 3) {
+      const active = nextRandom(random) % 2 === 0
+      const changed = setMembership(legacyPolicy.active, id, active)
+      setMembership(queuePolicy.active, id, active)
+      if (changed) {
+        queue.invalidateAll()
+      }
+    } else if (choice === 4 || choice === 5) {
+      const setName = choice === 4 ? 'hidden' : 'interested'
+      const before = isDroppable(queuePolicy, id)
+      const present = nextRandom(random) % 2 === 0
+      setMembership(legacyPolicy[setName], id, present)
+      setMembership(queuePolicy[setName], id, present)
+      if (!present && setName === 'hidden') {
+        legacyMarkedDrops.delete(id)
+        queueMarkedDrops.delete(id)
+      }
+      if (before !== isDroppable(queuePolicy, id)) {
+        queue.invalidateAll()
+      }
+    } else if (choice === 6) {
+      legacyPolicy.credit += 1
+      queuePolicy.credit += 1
+      queue.reactivateBlocked()
+    } else if (choice === 7) {
+      const sentinel = { data: `q${nextRandom(random) % 10}`, droppedOutput: true as const }
+      legacy.set(id, clonePending(sentinel))
+      queue.set(id, clonePending(sentinel))
+    } else if (choice === 8) {
+      const legacyPending = legacy.get(id)
+      legacy.delete(id)
+      const queuePending = queue.delete(id)
+      recordExit(legacyTimeline, id, legacyPending)
+      recordExit(queueTimeline, id, queuePending)
+    } else if (choice === 9) {
+      legacy.clear()
+      queue.clear()
+      legacyMarkedDrops.clear()
+      queueMarkedDrops.clear()
+      legacyTimeline.push({ kind: 'clear' })
+      queueTimeline.push({ kind: 'clear' })
+    } else {
+      const legacyRound = drainLegacy(legacy, legacyPolicy, legacyMarkedDrops)
+      const queueRound = drainQueue(queue, queuePolicy, queueMarkedDrops)
+      legacyTimeline.push(legacyRound)
+      queueTimeline.push(queueRound)
+    }
+    expectEquivalent(legacy, queue, legacyPolicy, queuePolicy, legacyTimeline, queueTimeline)
+  }
+}
+
+describe('PtyPendingDataDrainQueue legacy differential', () => {
+  it.each([0x1a2b3c4d, 0x5eedc0de, 0x7f4a7c15])(
+    'matches frozen Map drain behavior for seed %i',
+    (seed) => {
+      runSeed(seed)
+    }
+  )
+
+  it('defers every form of reentrant work until owner mutation is committed', () => {
+    const policy = createPolicy()
+    const queue = new PtyPendingDataDrainQueue((id) => classify(policy, id))
+    queue.set('partial', { data: 'abcdefgh', startSeq: 10 })
+    queue.set('unvisited', { data: 'old' })
+
+    const round = queue.beginRound()
+    const partial = queue.takeNext(round)!
+    queue.replaceWithRemainder(partial, { data: 'efgh', startSeq: 14 })
+    queue.set('new', { data: 'new' })
+    queue.set('partial', { data: 'efgh+same', startSeq: 14 })
+    queue.set('unvisited', { data: 'old+append' })
+    expect(queue.takeNext(round)).toBeNull()
+    queue.endRound(round)
+
+    const next = queue.beginRound()
+    const ids: string[] = []
+    for (;;) {
+      const selection = queue.takeNext(next)
+      if (!selection) {
+        break
+      }
+      ids.push(selection.id)
+      queue.remove(selection)
+    }
+    queue.endRound(next)
+    expect(ids).toEqual(['unvisited', 'partial', 'new'])
+  })
+
+  it('preserves transformed indivisibility and raw metadata', () => {
+    const policy = createPolicy()
+    policy.credit = 1
+    const queue = new PtyPendingDataDrainQueue((id) => classify(policy, id))
+    queue.set('transformed', {
+      data: 'abcdef',
+      startSeq: 7,
+      rawLength: 19,
+      transformed: true,
+      containsBackgroundOutput: true
+    })
+
+    expect(drainQueue(queue, policy, new Set())).toEqual({
+      events: [
+        {
+          kind: 'data',
+          id: 'transformed',
+          data: 'abcdef',
+          startSeq: 7,
+          rawLength: 19,
+          transformed: true,
+          containsBackgroundOutput: true
+        }
+      ],
+      flow: [{ id: 'transformed', pendingChars: 0 }],
+      timer: 'idle',
+      writes: 1
+    })
+  })
+
+  it('applies reentrant active and interest flips at the next frontier rebuild', () => {
+    const policy = createPolicy()
+    policy.credit = 0
+    policy.hidden.add('drop-first')
+    policy.hidden.add('blocked')
+    policy.interested.add('blocked')
+    const queue = new PtyPendingDataDrainQueue((id) => classify(policy, id))
+    queue.set('drop-first', { data: 'drop' })
+    queue.set('blocked', { data: 'held' })
+
+    const round = queue.beginRound()
+    const first = queue.takeNext(round)!
+    expect(first.id).toBe('drop-first')
+    queue.remove(first)
+    policy.active.add('blocked')
+    policy.interested.delete('blocked')
+    queue.invalidateAll()
+    expect(queue.takeNext(round)).toBeNull()
+    queue.endRound(round)
+
+    const next = queue.beginRound()
+    const reclassified = queue.takeNext(next)!
+    expect(reclassified.id).toBe('blocked')
+    queue.remove(reclassified)
+    queue.endRound(next)
+  })
+})

--- a/src/main/ipc/pty-pending-data-drain-queue-differential.test.ts
+++ b/src/main/ipc/pty-pending-data-drain-queue-differential.test.ts
@@ -229,6 +229,9 @@ function expectEquivalent(
 ): void {
   expect([...queue.keys()]).toEqual([...legacy.keys()])
   expect([...queue.values()]).toEqual([...legacy.values()])
+  expect(queue.totalPendingChars).toBe(
+    [...legacy.values()].reduce((total, pending) => total + pending.data.length, 0)
+  )
   expect(queuePolicy.credit).toBe(legacyPolicy.credit)
   expect(queueTimeline).toEqual(legacyTimeline)
 }
@@ -313,9 +316,9 @@ function runSeed(seed: number): void {
   }
 }
 
-describe('PtyPendingDataDrainQueue legacy differential', () => {
+describe('PtyPendingDataDrainQueue shared-domain differential', () => {
   it.each([0x1a2b3c4d, 0x5eedc0de, 0x7f4a7c15])(
-    'matches frozen Map drain behavior for seed %i',
+    'matches frozen Map behavior in the ordinary non-reentrant domain for seed %i',
     (seed) => {
       runSeed(seed)
     }

--- a/src/main/ipc/pty-pending-data-drain-queue.test.ts
+++ b/src/main/ipc/pty-pending-data-drain-queue.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PtyPendingDataDrainQueue,
+  type PendingPtyData,
+  type PtyPendingDataDrainSelection
+} from './pty-pending-data-drain-queue'
+
+function pending(data: string): PendingPtyData {
+  return { data }
+}
+
+function createQueueState() {
+  const active = new Set<string>()
+  const blocked = new Set<string>()
+  const queue = new PtyPendingDataDrainQueue((id) =>
+    blocked.has(id) ? 'blocked' : active.has(id) ? 'active' : 'background'
+  )
+  return { active, blocked, queue }
+}
+
+function takeId(
+  queue: PtyPendingDataDrainQueue,
+  round: ReturnType<PtyPendingDataDrainQueue['beginRound']>
+): string | null {
+  return queue.takeNext(round)?.id ?? null
+}
+
+describe('PtyPendingDataDrainQueue', () => {
+  it('drains active IDs first while preserving Map order within each lane', () => {
+    const { active, queue } = createQueueState()
+    queue.set('background-1', pending('b1'))
+    queue.set('active-1', pending('a1'))
+    queue.set('background-2', pending('b2'))
+    queue.set('active-2', pending('a2'))
+    active.add('active-1')
+    active.add('active-2')
+    queue.invalidateAll()
+
+    const round = queue.beginRound()
+    const order: string[] = []
+    for (;;) {
+      const selection = queue.takeNext(round)
+      if (!selection) {
+        break
+      }
+      order.push(selection.id)
+      queue.remove(selection)
+    }
+    queue.endRound(round)
+
+    expect(order).toEqual(['active-1', 'active-2', 'background-1', 'background-2'])
+  })
+
+  it('defers partial remainders beyond the current round frontier without replacing the node', () => {
+    const { queue } = createQueueState()
+    queue.set('pty-1', { data: 'firsttail', startSeq: 10 })
+    const initialDebug = queue.getDebugSnapshot()
+
+    const firstRound = queue.beginRound()
+    const selection = queue.takeNext(firstRound)
+    expect(selection).toMatchObject({ id: 'pty-1', pending: { data: 'firsttail', startSeq: 10 } })
+    queue.replaceWithRemainder(selection!, { data: 'tail', startSeq: 15 })
+    expect(queue.takeNext(firstRound)).toBeNull()
+    queue.endRound(firstRound)
+
+    const secondRound = queue.beginRound()
+    const remainder = queue.takeNext(secondRound)!
+    expect(remainder).toBe(selection)
+    expect(remainder).toMatchObject({
+      id: 'pty-1',
+      pending: { data: 'tail', startSeq: 15 }
+    })
+    queue.remove(remainder)
+    queue.endRound(secondRound)
+
+    expect(queue.getDebugSnapshot()).toMatchObject({
+      pendingSize: 0,
+      createdNodeCount: initialDebug.createdNodeCount,
+      peakNodeCount: 1,
+      allocationIdsByPty: {}
+    })
+  })
+
+  it('defers a reentrant append to an unvisited ID and preserves its Map position', () => {
+    const { queue } = createQueueState()
+    queue.set('a', pending('a'))
+    queue.set('b', pending('b'))
+    queue.set('c', pending('c'))
+
+    const firstRound = queue.beginRound()
+    const first = queue.takeNext(firstRound)!
+    expect(first.id).toBe('a')
+    queue.remove(first)
+    queue.set('b', pending('b+reentrant'))
+    expect(queue.getDebugSnapshot().allocationIdsByPty.b).toBe(2)
+
+    const currentRoundOrder: string[] = []
+    for (;;) {
+      const selection = queue.takeNext(firstRound)
+      if (!selection) {
+        break
+      }
+      currentRoundOrder.push(selection.id)
+      queue.remove(selection)
+    }
+    queue.endRound(firstRound)
+
+    expect(currentRoundOrder).toEqual(['c'])
+    expect([...queue.keys()]).toEqual(['b'])
+    const secondRound = queue.beginRound()
+    expect(queue.takeNext(secondRound)).toMatchObject({
+      id: 'b',
+      pending: { data: 'b+reentrant' }
+    })
+    queue.endRound(secondRound)
+    expect(queue.getDebugSnapshot().createdNodeCount).toBe(3)
+  })
+
+  it('does not follow a detached successor after reentrant delete or clear', () => {
+    const deleted = createQueueState().queue
+    deleted.set('a', pending('a'))
+    deleted.set('b', pending('b'))
+    deleted.set('c', pending('c'))
+    const deleteRound = deleted.beginRound()
+    const first = deleted.takeNext(deleteRound)!
+    deleted.remove(first)
+    deleted.delete('b')
+    expect(takeId(deleted, deleteRound)).toBe('c')
+    deleted.endRound(deleteRound)
+
+    const cleared = createQueueState().queue
+    cleared.set('a', pending('a'))
+    cleared.set('b', pending('b'))
+    const clearRound = cleared.beginRound()
+    cleared.remove(cleared.takeNext(clearRound)!)
+    cleared.clear()
+    expect(cleared.takeNext(clearRound)).toBeNull()
+    cleared.endRound(clearRound)
+    expect(cleared.getDebugSnapshot()).toMatchObject({
+      pendingSize: 0,
+      activeRunnableSize: 0,
+      backgroundRunnableSize: 0,
+      blockedSize: 0,
+      activeHeadId: null,
+      activeTailId: null,
+      backgroundHeadId: null,
+      backgroundTailId: null,
+      blockedHeadId: null,
+      blockedTailId: null,
+      openRound: null,
+      activeFrontier: 0,
+      backgroundFrontier: 0,
+      allocationIdsByPty: {}
+    })
+  })
+
+  it('reuses nodes through partial, update, and relink churn', () => {
+    const { queue } = createQueueState()
+    queue.set('a', pending('a'))
+    queue.set('b', pending('b'))
+    queue.set('c', pending('c'))
+    const initialAllocations = queue.getDebugSnapshot().allocationIdsByPty
+
+    for (let index = 0; index < 60; index++) {
+      const round = queue.beginRound()
+      const selection = queue.takeNext(round)!
+      queue.replaceWithRemainder(selection, pending(`${selection.id}-${index}`))
+      queue.endRound(round)
+      queue.set(selection.id, pending(`${selection.id}-${index}-updated`))
+      queue.invalidateAll()
+    }
+
+    expect(queue.getDebugSnapshot()).toMatchObject({
+      pendingSize: 3,
+      createdNodeCount: 3,
+      peakNodeCount: 3,
+      allocationIdsByPty: initialAllocations
+    })
+
+    const finalRound = queue.beginRound()
+    queue.clear()
+    expect(queue.takeNext(finalRound)).toBeNull()
+    expect(queue.getDebugSnapshot()).toMatchObject({
+      pendingSize: 0,
+      activeRunnableSize: 0,
+      backgroundRunnableSize: 0,
+      blockedSize: 0,
+      activeHeadId: null,
+      activeTailId: null,
+      backgroundHeadId: null,
+      backgroundTailId: null,
+      blockedHeadId: null,
+      blockedTailId: null,
+      openRound: null,
+      activeFrontier: 0,
+      backgroundFrontier: 0,
+      allocationIdsByPty: {}
+    })
+  })
+
+  it('freezes active classification until the next round', () => {
+    const { active, queue } = createQueueState()
+    queue.set('a', pending('a'))
+    queue.set('b', pending('b'))
+
+    const firstRound = queue.beginRound()
+    const first = queue.takeNext(firstRound)!
+    expect(first.id).toBe('a')
+    queue.remove(first)
+    active.add('b')
+    queue.invalidateAll()
+    expect(takeId(queue, firstRound)).toBe('b')
+    queue.endRound(firstRound)
+
+    queue.set('c', pending('c'))
+    active.add('c')
+    queue.invalidateAll()
+    const secondRound = queue.beginRound()
+    expect(takeId(queue, secondRound)).toBe('b')
+    queue.endRound(secondRound)
+  })
+
+  it('reactivates blocked candidates in authoritative Map order', () => {
+    const { blocked, queue } = createQueueState()
+    blocked.add('a')
+    blocked.add('b')
+    queue.set('a', pending('a'))
+    queue.set('b', pending('b'))
+
+    const blockedRound = queue.beginRound()
+    expect(queue.takeNext(blockedRound)).toBeNull()
+    queue.endRound(blockedRound)
+    expect(queue.getDebugSnapshot().blockedSize).toBe(2)
+
+    blocked.clear()
+    expect(queue.reactivateBlocked()).toBe(true)
+    const creditedRound = queue.beginRound()
+    const first = queue.takeNext(creditedRound)!
+    queue.remove(first)
+    const second = queue.takeNext(creditedRound)!
+    queue.remove(second)
+    queue.endRound(creditedRound)
+    expect([first.id, second.id]).toEqual(['a', 'b'])
+  })
+
+  it('visits 100 one-chunk candidates exactly once across 50 bounded rounds', () => {
+    const { queue } = createQueueState()
+    const legacy = new Map<string, PendingPtyData>()
+    for (let index = 0; index < 100; index++) {
+      const id = `pty-${index}`
+      const value = pending(String(index))
+      queue.set(id, value)
+      legacy.set(id, value)
+    }
+
+    let rounds = 0
+    let timerDecisions = 1
+    while (queue.size > 0) {
+      rounds += 1
+      const round = queue.beginRound()
+      for (let writes = 0; writes < 2; writes++) {
+        const selection = queue.takeNext(round)
+        if (!selection) {
+          break
+        }
+        queue.remove(selection)
+      }
+      queue.endRound(round)
+      if (queue.size > 0) {
+        timerDecisions += 1
+      }
+    }
+
+    let legacySelectionVisits = 0
+    let legacyTimerDecisions = 1
+    while (legacy.size > 0) {
+      const snapshot = [...legacy.keys()]
+      legacySelectionVisits += snapshot.length
+      for (const id of snapshot.slice(0, 2)) {
+        legacy.delete(id)
+      }
+      if (legacy.size > 0) {
+        legacyTimerDecisions += 1
+      }
+    }
+
+    expect(rounds).toBe(50)
+    expect(timerDecisions).toBe(50)
+    expect(legacySelectionVisits).toBe(2_550)
+    expect(legacyTimerDecisions).toBe(50)
+    expect(queue.getDebugSnapshot()).toMatchObject({
+      selectionVisitCount: 100,
+      createdNodeCount: 100,
+      peakNodeCount: 100,
+      pendingSize: 0,
+      activeRunnableSize: 0,
+      backgroundRunnableSize: 0,
+      blockedSize: 0,
+      activeHeadId: null,
+      activeTailId: null,
+      backgroundHeadId: null,
+      backgroundTailId: null,
+      blockedHeadId: null,
+      blockedTailId: null,
+      openRound: null,
+      activeFrontier: 0,
+      backgroundFrontier: 0,
+      allocationIdsByPty: {}
+    })
+  })
+
+  it('requires each selection to commit before advancing', () => {
+    const { queue } = createQueueState()
+    queue.set('a', pending('a'))
+    queue.set('b', pending('b'))
+    const round = queue.beginRound()
+    const selection = queue.takeNext(round)
+
+    expect(() => queue.takeNext(round)).toThrow(
+      'PTY pending-data selection must be committed before advancing'
+    )
+    expect(() => queue.set('a', pending('replacement'))).toThrow(
+      'Selected PTY pending data must commit before update'
+    )
+    queue.block(selection as PtyPendingDataDrainSelection)
+    expect(takeId(queue, round)).toBe('b')
+    queue.endRound(round)
+  })
+})

--- a/src/main/ipc/pty-pending-data-drain-queue.test.ts
+++ b/src/main/ipc/pty-pending-data-drain-queue.test.ts
@@ -116,6 +116,103 @@ describe('PtyPendingDataDrainQueue', () => {
     expect(queue.getDebugSnapshot().createdNodeCount).toBe(3)
   })
 
+  it('rebuilds an earlier reentrant update before an untouched later ID in Map order', () => {
+    const { queue } = createQueueState()
+    queue.set('trigger', pending('trigger'))
+    queue.set('earlier', pending('old'))
+    queue.set('later', pending('later'))
+
+    const firstRound = queue.beginRound()
+    queue.remove(queue.takeNext(firstRound)!)
+    queue.set('earlier', pending('new'))
+    queue.endRound(firstRound)
+
+    const secondRound = queue.beginRound()
+    const order: string[] = []
+    for (;;) {
+      const selection = queue.takeNext(secondRound)
+      if (!selection) {
+        break
+      }
+      order.push(selection.id)
+      queue.remove(selection)
+    }
+    queue.endRound(secondRound)
+
+    expect(order).toEqual(['earlier', 'later'])
+  })
+
+  it('keeps aggregate pending chars exact across every owner transition', () => {
+    const { blocked, queue } = createQueueState()
+    queue.set('a', pending('abc'))
+    queue.set('b', pending('12345'))
+    expect(queue.totalPendingChars).toBe(8)
+
+    queue.set('a', pending('abcdef'))
+    expect(queue.totalPendingChars).toBe(11)
+    blocked.add('a')
+    queue.invalidate('a')
+    const blockedRound = queue.beginRound()
+    const b = queue.takeNext(blockedRound)!
+    queue.replaceWithRemainder(b, pending('12'))
+    queue.endRound(blockedRound)
+    expect(queue.totalPendingChars).toBe(8)
+
+    blocked.delete('a')
+    queue.reactivateBlocked()
+    const removalRound = queue.beginRound()
+    const first = queue.takeNext(removalRound)!
+    queue.remove(first)
+    queue.endRound(removalRound)
+    expect(queue.totalPendingChars).toBe(2)
+
+    expect(queue.delete('b')).toEqual(pending('12'))
+    expect(queue.totalPendingChars).toBe(0)
+    queue.set('c', pending('tail'))
+    queue.clear()
+    expect(queue.getDebugSnapshot()).toMatchObject({
+      pendingSize: 0,
+      totalPendingChars: 0
+    })
+  })
+
+  it('relinks only when the exact derived settings token changes', () => {
+    const settings = {
+      terminalMainSideEffectAuthority: true,
+      terminalHiddenDeliveryGate: true,
+      unrelated: 0
+    }
+    const queue = new PtyPendingDataDrainQueue(
+      () => 'background',
+      () => settings.terminalMainSideEffectAuthority && settings.terminalHiddenDeliveryGate
+    )
+    queue.set('a', pending('a'))
+    const firstRound = queue.beginRound()
+    queue.endRound(firstRound)
+    const baseline = queue.getDebugSnapshot().laneRebuildCount
+
+    settings.unrelated += 1
+    const unrelatedRound = queue.beginRound()
+    queue.endRound(unrelatedRound)
+    expect(queue.getDebugSnapshot().laneRebuildCount).toBe(baseline)
+
+    settings.terminalHiddenDeliveryGate = false
+    const disabledRound = queue.beginRound()
+    queue.endRound(disabledRound)
+    expect(queue.getDebugSnapshot().laneRebuildCount).toBe(baseline + 1)
+
+    settings.terminalMainSideEffectAuthority = false
+    settings.terminalHiddenDeliveryGate = true
+    const equivalentRound = queue.beginRound()
+    queue.endRound(equivalentRound)
+    expect(queue.getDebugSnapshot().laneRebuildCount).toBe(baseline + 1)
+
+    settings.terminalMainSideEffectAuthority = true
+    const enabledRound = queue.beginRound()
+    queue.endRound(enabledRound)
+    expect(queue.getDebugSnapshot().laneRebuildCount).toBe(baseline + 2)
+  })
+
   it('does not follow a detached successor after reentrant delete or clear', () => {
     const deleted = createQueueState().queue
     deleted.set('a', pending('a'))

--- a/src/main/ipc/pty-pending-data-drain-queue.ts
+++ b/src/main/ipc/pty-pending-data-drain-queue.ts
@@ -1,0 +1,334 @@
+export type PendingPtyData = {
+  data: string
+  startSeq?: number
+  rawLength?: number
+  transformed?: true
+  containsBackgroundOutput?: boolean
+  droppedOutput?: true
+}
+
+export type PtyPendingDataDrainDisposition = 'active' | 'background' | 'blocked'
+
+type LinkedLaneName = PtyPendingDataDrainDisposition
+type NodeLaneName = LinkedLaneName | 'none' | 'selected'
+
+type PendingNode = {
+  id: string
+  allocationId: number
+  pending: PendingPtyData
+  previous: PendingNode | null
+  next: PendingNode | null
+  lane: NodeLaneName
+  lanePosition: number
+  eligibleRound: number
+}
+
+type Lane = { head: PendingNode | null; tail: PendingNode | null; size: number }
+
+type DrainPhase = 'active' | 'background' | 'done'
+
+export type PtyPendingDataDrainRound = {
+  readonly round: number
+  activeFrontier: number
+  backgroundFrontier: number
+  phase: DrainPhase
+  aborted: boolean
+}
+
+export type PtyPendingDataDrainSelection = Readonly<{ id: string; pending: PendingPtyData }>
+
+function createLane(): Lane {
+  return { head: null, tail: null, size: 0 }
+}
+
+export class PtyPendingDataDrainQueue {
+  private readonly nodes = new Map<string, PendingNode>()
+  private readonly active = createLane()
+  private readonly background = createLane()
+  private readonly blocked = createLane()
+  private roundSerial = 0
+  private lanePositionSerial = 0
+  private openRound: PtyPendingDataDrainRound | null = null
+  private selectedNode: PendingNode | null = null
+  private relinkPending = false
+  private createdNodeCount = 0
+  private peakNodeCount = 0
+  private selectionVisitCount = 0
+  private laneRebuildCount = 0
+
+  constructor(private readonly classify: (id: string) => PtyPendingDataDrainDisposition) {}
+
+  get size(): number {
+    return this.nodes.size
+  }
+
+  get(id: string): PendingPtyData | undefined {
+    return this.nodes.get(id)?.pending
+  }
+
+  keys(): IterableIterator<string> {
+    return this.nodes.keys()
+  }
+
+  *values(): IterableIterator<PendingPtyData> {
+    for (const node of this.nodes.values()) {
+      yield node.pending
+    }
+  }
+
+  set(id: string, pending: PendingPtyData): void {
+    const existing = this.nodes.get(id)
+    if (!existing) {
+      const node: PendingNode = {
+        id,
+        allocationId: this.createdNodeCount + 1,
+        pending,
+        previous: null,
+        next: null,
+        lane: 'none',
+        lanePosition: 0,
+        eligibleRound: this.roundSerial + 1
+      }
+      this.nodes.set(id, node)
+      this.createdNodeCount += 1
+      this.peakNodeCount = Math.max(this.peakNodeCount, this.nodes.size)
+      this.appendToLane(node, this.classify(id))
+      return
+    }
+
+    if (existing === this.selectedNode) {
+      throw new Error('Selected PTY pending data must commit before update')
+    }
+    existing.pending = pending
+    if (this.openRound) {
+      // Why: renderer notification can synchronously append; defer the whole ID past this round's frontier.
+      this.unlink(existing)
+      existing.eligibleRound = this.openRound.round + 1
+      this.appendToLane(existing, this.classify(id))
+      this.relinkPending = true
+    }
+  }
+
+  delete(id: string): PendingPtyData | undefined {
+    const node = this.nodes.get(id)
+    if (!node) {
+      return undefined
+    }
+    this.nodes.delete(id)
+    this.unlink(node)
+    if (this.selectedNode === node) {
+      this.selectedNode = null
+    }
+    return node.pending
+  }
+
+  clear(): void {
+    if (this.openRound) {
+      this.openRound.aborted = true
+    }
+    this.nodes.clear()
+    this.resetLane(this.active)
+    this.resetLane(this.background)
+    this.resetLane(this.blocked)
+    this.openRound = null
+    this.selectedNode = null
+    this.relinkPending = false
+    this.lanePositionSerial = 0
+  }
+
+  invalidateAll(): boolean {
+    return this.requestRelink(this.nodes.size > 0)
+  }
+
+  reactivateBlocked(): boolean {
+    return this.requestRelink(this.blocked.size > 0)
+  }
+
+  beginRound(): PtyPendingDataDrainRound {
+    if (this.openRound) {
+      throw new Error('PTY pending-data drain round already open')
+    }
+    this.roundSerial += 1
+    if (this.relinkPending) {
+      this.rebuildLanes()
+    }
+    const round: PtyPendingDataDrainRound = {
+      round: this.roundSerial,
+      activeFrontier: this.active.tail?.lanePosition ?? 0,
+      backgroundFrontier: this.background.tail?.lanePosition ?? 0,
+      phase: 'active',
+      aborted: false
+    }
+    this.openRound = round
+    return round
+  }
+
+  takeNext(round: PtyPendingDataDrainRound): PtyPendingDataDrainSelection | null {
+    if (this.openRound !== round || round.aborted || round.phase === 'done') {
+      return null
+    }
+    if (this.selectedNode) {
+      throw new Error('PTY pending-data selection must be committed before advancing')
+    }
+
+    while (round.phase !== 'done') {
+      const lane = round.phase === 'active' ? this.active : this.background
+      const frontier = round.phase === 'active' ? round.activeFrontier : round.backgroundFrontier
+      const node = lane.head
+      if (!node || node.lanePosition > frontier || node.eligibleRound > round.round) {
+        round.phase = round.phase === 'active' ? 'background' : 'done'
+        continue
+      }
+      this.unlink(node)
+      node.lane = 'selected'
+      this.selectedNode = node
+      this.selectionVisitCount += 1
+      return node
+    }
+    return null
+  }
+
+  block(selection: PtyPendingDataDrainSelection): void {
+    const node = this.requireSelectedNode(selection)
+    this.selectedNode = null
+    this.appendToLane(node, 'blocked')
+  }
+
+  remove(selection: PtyPendingDataDrainSelection): void {
+    const node = this.requireSelectedNode(selection)
+    this.selectedNode = null
+    this.nodes.delete(node.id)
+    node.lane = 'none'
+  }
+
+  replaceWithRemainder(selection: PtyPendingDataDrainSelection, pending: PendingPtyData): void {
+    const node = this.requireSelectedNode(selection)
+    this.selectedNode = null
+    this.nodes.delete(node.id)
+    node.pending = pending
+    node.eligibleRound = (this.openRound?.round ?? this.roundSerial) + 1
+    this.nodes.set(node.id, node)
+    this.appendToLane(node, this.classify(node.id))
+  }
+
+  endRound(round: PtyPendingDataDrainRound): void {
+    if (this.openRound !== round) {
+      return
+    }
+    if (this.selectedNode) {
+      const selected = this.selectedNode
+      this.selectedNode = null
+      selected.eligibleRound = round.round + 1
+      this.appendToLane(selected, this.classify(selected.id))
+      this.relinkPending = true
+    }
+    this.openRound = null
+  }
+
+  getDebugSnapshot() {
+    return {
+      pendingSize: this.nodes.size,
+      activeRunnableSize: this.active.size,
+      backgroundRunnableSize: this.background.size,
+      blockedSize: this.blocked.size,
+      activeHeadId: this.active.head?.id ?? null,
+      activeTailId: this.active.tail?.id ?? null,
+      backgroundHeadId: this.background.head?.id ?? null,
+      backgroundTailId: this.background.tail?.id ?? null,
+      blockedHeadId: this.blocked.head?.id ?? null,
+      blockedTailId: this.blocked.tail?.id ?? null,
+      openRound: this.openRound?.round ?? null,
+      activeFrontier: this.openRound?.activeFrontier ?? 0,
+      backgroundFrontier: this.openRound?.backgroundFrontier ?? 0,
+      createdNodeCount: this.createdNodeCount,
+      peakNodeCount: this.peakNodeCount,
+      selectionVisitCount: this.selectionVisitCount,
+      laneRebuildCount: this.laneRebuildCount,
+      allocationIdsByPty: Object.fromEntries(
+        Array.from(this.nodes, ([id, node]) => [id, node.allocationId])
+      )
+    }
+  }
+
+  private requireSelectedNode(selection: PtyPendingDataDrainSelection): PendingNode {
+    const node = selection as PendingNode
+    if (this.selectedNode !== node || this.nodes.get(node.id) !== node) {
+      throw new Error('Stale PTY pending-data drain selection')
+    }
+    return node
+  }
+
+  private requestRelink(needed: boolean): boolean {
+    this.relinkPending ||= needed
+    return needed
+  }
+
+  private rebuildLanes(): void {
+    this.laneRebuildCount += 1
+    this.resetLane(this.active)
+    this.resetLane(this.background)
+    this.resetLane(this.blocked)
+    for (const node of this.nodes.values()) {
+      node.previous = null
+      node.next = null
+      node.lane = 'none'
+      this.appendToLane(node, this.classify(node.id))
+    }
+    this.relinkPending = false
+  }
+
+  private laneFor(name: LinkedLaneName): Lane {
+    if (name === 'active') {
+      return this.active
+    }
+    return name === 'background' ? this.background : this.blocked
+  }
+
+  private appendToLane(node: PendingNode, name: LinkedLaneName): void {
+    const lane = this.laneFor(name)
+    node.previous = lane.tail
+    node.next = null
+    node.lane = name
+    if (name !== 'blocked') {
+      this.lanePositionSerial += 1
+      node.lanePosition = this.lanePositionSerial
+    }
+    if (lane.tail) {
+      lane.tail.next = node
+    } else {
+      lane.head = node
+    }
+    lane.tail = node
+    lane.size += 1
+  }
+
+  private unlink(node: PendingNode): void {
+    if (node.lane === 'none' || node.lane === 'selected') {
+      node.previous = null
+      node.next = null
+      node.lane = 'none'
+      return
+    }
+    const lane = this.laneFor(node.lane)
+    if (node.previous) {
+      node.previous.next = node.next
+    } else {
+      lane.head = node.next
+    }
+    if (node.next) {
+      node.next.previous = node.previous
+    } else {
+      lane.tail = node.previous
+    }
+    lane.size -= 1
+    node.previous = null
+    node.next = null
+    node.lane = 'none'
+  }
+
+  private resetLane(lane: Lane): void {
+    lane.head = null
+    lane.tail = null
+    lane.size = 0
+  }
+}

--- a/src/main/ipc/pty-pending-data-drain-queue.ts
+++ b/src/main/ipc/pty-pending-data-drain-queue.ts
@@ -1,21 +1,14 @@
-export type PendingPtyData = {
-  data: string
-  startSeq?: number
-  rawLength?: number
-  transformed?: true
-  containsBackgroundOutput?: boolean
-  droppedOutput?: true
-}
+import type * as Contract from './pty-pending-data-drain-contract'
 
-export type PtyPendingDataDrainDisposition = 'active' | 'background' | 'blocked'
+export type * from './pty-pending-data-drain-contract'
 
-type LinkedLaneName = PtyPendingDataDrainDisposition
+type LinkedLaneName = Contract.PtyPendingDataDrainDisposition
 type NodeLaneName = LinkedLaneName | 'none' | 'selected'
 
 type PendingNode = {
   id: string
   allocationId: number
-  pending: PendingPtyData
+  pending: Contract.PendingPtyData
   previous: PendingNode | null
   next: PendingNode | null
   lane: NodeLaneName
@@ -24,18 +17,6 @@ type PendingNode = {
 }
 
 type Lane = { head: PendingNode | null; tail: PendingNode | null; size: number }
-
-type DrainPhase = 'active' | 'background' | 'done'
-
-export type PtyPendingDataDrainRound = {
-  readonly round: number
-  activeFrontier: number
-  backgroundFrontier: number
-  phase: DrainPhase
-  aborted: boolean
-}
-
-export type PtyPendingDataDrainSelection = Readonly<{ id: string; pending: PendingPtyData }>
 
 function createLane(): Lane {
   return { head: null, tail: null, size: 0 }
@@ -48,21 +29,32 @@ export class PtyPendingDataDrainQueue {
   private readonly blocked = createLane()
   private roundSerial = 0
   private lanePositionSerial = 0
-  private openRound: PtyPendingDataDrainRound | null = null
+  private openRound: Contract.PtyPendingDataDrainRound | null = null
   private selectedNode: PendingNode | null = null
   private relinkPending = false
   private createdNodeCount = 0
   private peakNodeCount = 0
   private selectionVisitCount = 0
   private laneRebuildCount = 0
+  private pendingChars = 0
+  private lastPolicyToken: unknown
 
-  constructor(private readonly classify: (id: string) => PtyPendingDataDrainDisposition) {}
+  constructor(
+    private readonly classify: (id: string) => Contract.PtyPendingDataDrainDisposition,
+    private readonly readPolicyToken?: () => unknown
+  ) {
+    this.lastPolicyToken = readPolicyToken?.()
+  }
 
   get size(): number {
     return this.nodes.size
   }
 
-  get(id: string): PendingPtyData | undefined {
+  get totalPendingChars(): number {
+    return this.pendingChars
+  }
+
+  get(id: string): Contract.PendingPtyData | undefined {
     return this.nodes.get(id)?.pending
   }
 
@@ -70,13 +62,13 @@ export class PtyPendingDataDrainQueue {
     return this.nodes.keys()
   }
 
-  *values(): IterableIterator<PendingPtyData> {
+  *values(): IterableIterator<Contract.PendingPtyData> {
     for (const node of this.nodes.values()) {
       yield node.pending
     }
   }
 
-  set(id: string, pending: PendingPtyData): void {
+  set(id: string, pending: Contract.PendingPtyData): void {
     const existing = this.nodes.get(id)
     if (!existing) {
       const node: PendingNode = {
@@ -90,6 +82,7 @@ export class PtyPendingDataDrainQueue {
         eligibleRound: this.roundSerial + 1
       }
       this.nodes.set(id, node)
+      this.pendingChars += pending.data.length
       this.createdNodeCount += 1
       this.peakNodeCount = Math.max(this.peakNodeCount, this.nodes.size)
       this.appendToLane(node, this.classify(id))
@@ -99,6 +92,7 @@ export class PtyPendingDataDrainQueue {
     if (existing === this.selectedNode) {
       throw new Error('Selected PTY pending data must commit before update')
     }
+    this.pendingChars += pending.data.length - existing.pending.data.length
     existing.pending = pending
     if (this.openRound) {
       // Why: renderer notification can synchronously append; defer the whole ID past this round's frontier.
@@ -109,12 +103,13 @@ export class PtyPendingDataDrainQueue {
     }
   }
 
-  delete(id: string): PendingPtyData | undefined {
+  delete(id: string): Contract.PendingPtyData | undefined {
     const node = this.nodes.get(id)
     if (!node) {
       return undefined
     }
     this.nodes.delete(id)
+    this.pendingChars -= node.pending.data.length
     this.unlink(node)
     if (this.selectedNode === node) {
       this.selectedNode = null
@@ -127,6 +122,7 @@ export class PtyPendingDataDrainQueue {
       this.openRound.aborted = true
     }
     this.nodes.clear()
+    this.pendingChars = 0
     this.resetLane(this.active)
     this.resetLane(this.background)
     this.resetLane(this.blocked)
@@ -140,19 +136,28 @@ export class PtyPendingDataDrainQueue {
     return this.requestRelink(this.nodes.size > 0)
   }
 
+  invalidate(id: string): boolean {
+    return this.requestRelink(this.nodes.has(id))
+  }
+
   reactivateBlocked(): boolean {
     return this.requestRelink(this.blocked.size > 0)
   }
 
-  beginRound(): PtyPendingDataDrainRound {
+  beginRound(): Contract.PtyPendingDataDrainRound {
     if (this.openRound) {
       throw new Error('PTY pending-data drain round already open')
     }
     this.roundSerial += 1
+    const policyToken = this.readPolicyToken?.()
+    if (!Object.is(policyToken, this.lastPolicyToken)) {
+      this.lastPolicyToken = policyToken
+      this.requestRelink(this.nodes.size > 0)
+    }
     if (this.relinkPending) {
       this.rebuildLanes()
     }
-    const round: PtyPendingDataDrainRound = {
+    const round: Contract.PtyPendingDataDrainRound = {
       round: this.roundSerial,
       activeFrontier: this.active.tail?.lanePosition ?? 0,
       backgroundFrontier: this.background.tail?.lanePosition ?? 0,
@@ -163,7 +168,7 @@ export class PtyPendingDataDrainQueue {
     return round
   }
 
-  takeNext(round: PtyPendingDataDrainRound): PtyPendingDataDrainSelection | null {
+  takeNext(round: Contract.PtyPendingDataDrainRound): Contract.PtyPendingDataDrainSelection | null {
     if (this.openRound !== round || round.aborted || round.phase === 'done') {
       return null
     }
@@ -188,30 +193,35 @@ export class PtyPendingDataDrainQueue {
     return null
   }
 
-  block(selection: PtyPendingDataDrainSelection): void {
+  block(selection: Contract.PtyPendingDataDrainSelection): void {
     const node = this.requireSelectedNode(selection)
     this.selectedNode = null
     this.appendToLane(node, 'blocked')
   }
 
-  remove(selection: PtyPendingDataDrainSelection): void {
+  remove(selection: Contract.PtyPendingDataDrainSelection): void {
     const node = this.requireSelectedNode(selection)
     this.selectedNode = null
     this.nodes.delete(node.id)
+    this.pendingChars -= node.pending.data.length
     node.lane = 'none'
   }
 
-  replaceWithRemainder(selection: PtyPendingDataDrainSelection, pending: PendingPtyData): void {
+  replaceWithRemainder(
+    selection: Contract.PtyPendingDataDrainSelection,
+    pending: Contract.PendingPtyData
+  ): void {
     const node = this.requireSelectedNode(selection)
     this.selectedNode = null
     this.nodes.delete(node.id)
+    this.pendingChars += pending.data.length - node.pending.data.length
     node.pending = pending
     node.eligibleRound = (this.openRound?.round ?? this.roundSerial) + 1
     this.nodes.set(node.id, node)
     this.appendToLane(node, this.classify(node.id))
   }
 
-  endRound(round: PtyPendingDataDrainRound): void {
+  endRound(round: Contract.PtyPendingDataDrainRound): void {
     if (this.openRound !== round) {
       return
     }
@@ -228,6 +238,7 @@ export class PtyPendingDataDrainQueue {
   getDebugSnapshot() {
     return {
       pendingSize: this.nodes.size,
+      totalPendingChars: this.pendingChars,
       activeRunnableSize: this.active.size,
       backgroundRunnableSize: this.background.size,
       blockedSize: this.blocked.size,
@@ -250,7 +261,7 @@ export class PtyPendingDataDrainQueue {
     }
   }
 
-  private requireSelectedNode(selection: PtyPendingDataDrainSelection): PendingNode {
+  private requireSelectedNode(selection: Contract.PtyPendingDataDrainSelection): PendingNode {
     const node = selection as PendingNode
     if (this.selectedNode !== node || this.nodes.get(node.id) !== node) {
       throw new Error('Stale PTY pending-data drain selection')
@@ -269,19 +280,15 @@ export class PtyPendingDataDrainQueue {
     this.resetLane(this.background)
     this.resetLane(this.blocked)
     for (const node of this.nodes.values()) {
-      node.previous = null
-      node.next = null
-      node.lane = 'none'
+      Object.assign(node, { previous: null, next: null, lane: 'none' as const })
+      node.eligibleRound = this.roundSerial
       this.appendToLane(node, this.classify(node.id))
     }
     this.relinkPending = false
   }
 
   private laneFor(name: LinkedLaneName): Lane {
-    if (name === 'active') {
-      return this.active
-    }
-    return name === 'background' ? this.background : this.blocked
+    return name === 'active' ? this.active : name === 'background' ? this.background : this.blocked
   }
 
   private appendToLane(node: PendingNode, name: LinkedLaneName): void {
@@ -304,9 +311,7 @@ export class PtyPendingDataDrainQueue {
 
   private unlink(node: PendingNode): void {
     if (node.lane === 'none' || node.lane === 'selected') {
-      node.previous = null
-      node.next = null
-      node.lane = 'none'
+      Object.assign(node, { previous: null, next: null, lane: 'none' as const })
       return
     }
     const lane = this.laneFor(node.lane)
@@ -321,14 +326,10 @@ export class PtyPendingDataDrainQueue {
       lane.tail = node.previous
     }
     lane.size -= 1
-    node.previous = null
-    node.next = null
-    node.lane = 'none'
+    Object.assign(node, { previous: null, next: null, lane: 'none' as const })
   }
 
   private resetLane(lane: Lane): void {
-    lane.head = null
-    lane.tail = null
-    lane.size = 0
+    Object.assign(lane, { head: null, tail: null, size: 0 })
   }
 }

--- a/src/main/ipc/pty-pending-data-drain-scheduler-differential.test.ts
+++ b/src/main/ipc/pty-pending-data-drain-scheduler-differential.test.ts
@@ -1,0 +1,694 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PtyPendingDataDrainQueue,
+  type PendingPtyData,
+  type PtyPendingDataDrainSelection
+} from './pty-pending-data-drain-queue'
+
+const CHUNK_CHARS = 4
+const MAX_WRITES = 2
+const PER_PTY_LIMIT = 8
+const TOTAL_LIMIT = 12
+const ACTIVE_PER_PTY_RESERVE = 4
+const ACTIVE_TOTAL_RESERVE = 4
+
+type EngineKind = 'legacy' | 'queue'
+type Accounting = { sent: number; acked: number }
+type DeliveryEvent =
+  | {
+      kind: 'data'
+      id: string
+      data: string
+      rawLength: number
+      transformed?: true
+      droppedOutput?: true
+    }
+  | { kind: 'exit'; id: string }
+  | { kind: 'ack'; id: string; processedChars: number; creditedChars: number }
+  | { kind: 'tick'; delayMs: number }
+  | { kind: 'drop'; id: string; data: string }
+  | { kind: 'clear' }
+
+type Candidate = {
+  id: string
+  pending: PendingPtyData
+  block(): void
+  remove(): void
+  replace(pending: PendingPtyData): void
+}
+
+type EngineSnapshot = {
+  pending: [string, PendingPtyData][]
+  accounting: [string, Accounting][]
+  totalInFlight: number
+  flowPending: [string, number][]
+  scheduledDelay: number | null
+  timerArmCount: number
+  events: DeliveryEvent[]
+}
+
+class DrainSchedulerEngine {
+  private readonly legacyPending = new Map<string, PendingPtyData>()
+  private readonly queue: PtyPendingDataDrainQueue | null
+  private readonly active = new Set<string>()
+  private readonly droppable = new Set<string>()
+  private readonly accounting = new Map<string, Accounting>()
+  private readonly flowPending = new Map<string, number>()
+  private readonly exiting = new Set<string>()
+  private totalInFlight = 0
+  private scheduledDelay: number | null = null
+  private timerArmCount = 0
+  private clearGeneration = 0
+  private draining = false
+  private creditReleasedWhileDraining = false
+  private notify: ((event: DeliveryEvent) => void) | null = null
+  readonly events: DeliveryEvent[] = []
+  legacySnapshotEntryVisits = 0
+
+  constructor(private readonly kind: EngineKind) {
+    this.queue =
+      kind === 'queue'
+        ? new PtyPendingDataDrainQueue((id) => {
+            if (this.droppable.has(id)) {
+              return this.active.has(id) ? 'active' : 'background'
+            }
+            if (!this.canSend(id)) {
+              return 'blocked'
+            }
+            return this.active.has(id) ? 'active' : 'background'
+          })
+        : null
+  }
+
+  enqueue(id: string, pending: PendingPtyData): void {
+    this.setPending(id, { ...pending })
+    this.flowPending.set(id, pending.data.length)
+    this.schedule(2)
+  }
+
+  setActive(id: string, active: boolean): void {
+    const changed = active ? !this.active.has(id) : this.active.has(id)
+    if (!changed) {
+      return
+    }
+    if (active) {
+      this.active.add(id)
+    } else {
+      this.active.delete(id)
+    }
+    if (this.getPending(id)) {
+      this.queue?.invalidateAll()
+      this.schedule(0)
+    }
+  }
+
+  setDroppable(id: string, droppable: boolean): void {
+    const changed = droppable ? !this.droppable.has(id) : this.droppable.has(id)
+    if (!changed) {
+      return
+    }
+    if (droppable) {
+      this.droppable.add(id)
+    } else {
+      this.droppable.delete(id)
+    }
+    if (this.getPending(id)) {
+      this.queue?.invalidateAll()
+      this.schedule(0)
+    }
+  }
+
+  acknowledge(id: string, processedChars: number): number {
+    const creditedChars = this.applyCumulativeAck(id, Math.max(0, processedChars))
+    this.events.push({ kind: 'ack', id, processedChars, creditedChars })
+    if (creditedChars > 0) {
+      this.queue?.reactivateBlocked()
+    }
+    if (this.pendingSize > 0) {
+      this.schedule(0)
+    }
+    return creditedChars
+  }
+
+  tick(): void {
+    const delayMs = this.scheduledDelay
+    if (delayMs === null) {
+      throw new Error('No pending drain timer')
+    }
+    this.scheduledDelay = null
+    this.events.push({ kind: 'tick', delayMs })
+    const generation = this.clearGeneration
+    let writes = 0
+    this.draining = true
+    this.creditReleasedWhileDraining = false
+
+    if (this.queue) {
+      const round = this.queue.beginRound()
+      try {
+        while (writes < MAX_WRITES) {
+          const selection = this.queue.takeNext(round)
+          if (!selection) {
+            break
+          }
+          writes += this.processCandidate(this.queueCandidate(selection))
+          if (generation !== this.clearGeneration) {
+            break
+          }
+        }
+      } finally {
+        this.queue.endRound(round)
+      }
+    } else {
+      const entries = [...this.legacyPending.entries()]
+      const ordered = [
+        ...entries.filter(([id]) => this.active.has(id)),
+        ...entries.filter(([id]) => !this.active.has(id))
+      ]
+      this.legacySnapshotEntryVisits += entries.length
+      for (const [id, pending] of ordered) {
+        if (writes >= MAX_WRITES || generation !== this.clearGeneration) {
+          break
+        }
+        if (!this.legacyPending.has(id)) {
+          continue
+        }
+        writes += this.processCandidate(this.legacyCandidate(id, pending))
+      }
+    }
+    this.draining = false
+    const creditReleasedWhileDraining = this.creditReleasedWhileDraining
+    this.creditReleasedWhileDraining = false
+
+    if (this.pendingSize > 0 && (writes > 0 || creditReleasedWhileDraining)) {
+      this.schedule(writes > 0 ? 1 : 0)
+    }
+  }
+
+  exit(id: string): void {
+    if (this.exiting.has(id)) {
+      return
+    }
+    this.exiting.add(id)
+    try {
+      const hadReleasableCredit = this.inFlightFor(id) > 0
+      const remaining = this.deletePending(id)
+      if (this.pendingSize === 0) {
+        this.scheduledDelay = null
+      }
+      this.flowPending.delete(id)
+      if (remaining) {
+        this.sendFinal(id, remaining)
+      }
+      const releasedChars = this.inFlightFor(id)
+      this.totalInFlight = Math.max(0, this.totalInFlight - releasedChars)
+      this.accounting.delete(id)
+      if (hadReleasableCredit && this.kind === 'queue') {
+        const reactivatedBlocked = this.queue?.reactivateBlocked() === true
+        if (this.draining) {
+          this.creditReleasedWhileDraining ||= reactivatedBlocked
+        } else if (this.pendingSize > 0) {
+          this.schedule(0)
+        }
+      }
+      this.events.push({ kind: 'exit', id })
+    } finally {
+      this.exiting.delete(id)
+    }
+  }
+
+  clear(): void {
+    this.clearGeneration += 1
+    if (this.queue) {
+      this.queue.clear()
+    } else {
+      this.legacyPending.clear()
+    }
+    this.flowPending.clear()
+    this.accounting.clear()
+    this.totalInFlight = 0
+    this.events.push({ kind: 'clear' })
+  }
+
+  setNotification(callback: ((event: DeliveryEvent) => void) | null): void {
+    this.notify = callback
+  }
+
+  snapshot(): EngineSnapshot {
+    return {
+      pending: this.pendingEntries().map(([id, pending]) => [id, { ...pending }]),
+      accounting: Array.from(this.accounting, ([id, value]) => [id, { ...value }]),
+      totalInFlight: this.totalInFlight,
+      flowPending: [...this.flowPending.entries()],
+      scheduledDelay: this.scheduledDelay,
+      timerArmCount: this.timerArmCount,
+      events: this.events.map((event) => ({ ...event }))
+    }
+  }
+
+  debugQueue(): ReturnType<PtyPendingDataDrainQueue['getDebugSnapshot']> {
+    if (!this.queue) {
+      throw new Error('Legacy engine has no queue debug state')
+    }
+    return this.queue.getDebugSnapshot()
+  }
+
+  private get pendingSize(): number {
+    return this.queue?.size ?? this.legacyPending.size
+  }
+
+  private pendingEntries(): [string, PendingPtyData][] {
+    if (!this.queue) {
+      return [...this.legacyPending.entries()]
+    }
+    return [...this.queue.keys()].map((id) => [id, this.queue!.get(id)!])
+  }
+
+  private getPending(id: string): PendingPtyData | undefined {
+    return this.queue?.get(id) ?? this.legacyPending.get(id)
+  }
+
+  private setPending(id: string, pending: PendingPtyData): void {
+    if (this.queue) {
+      this.queue.set(id, pending)
+    } else {
+      this.legacyPending.set(id, pending)
+    }
+  }
+
+  private deletePending(id: string): PendingPtyData | undefined {
+    if (this.queue) {
+      return this.queue.delete(id)
+    }
+    const pending = this.legacyPending.get(id)
+    this.legacyPending.delete(id)
+    return pending
+  }
+
+  private schedule(delayMs: number): void {
+    if (this.scheduledDelay !== null) {
+      return
+    }
+    this.scheduledDelay = delayMs
+    this.timerArmCount += 1
+  }
+
+  private inFlightFor(id: string): number {
+    const accounting = this.accounting.get(id)
+    return accounting ? accounting.sent - accounting.acked : 0
+  }
+
+  private canSend(id: string): boolean {
+    const active = this.active.has(id)
+    const perPtyLimit = PER_PTY_LIMIT + (active ? ACTIVE_PER_PTY_RESERVE : 0)
+    const totalLimit = TOTAL_LIMIT + (active ? ACTIVE_TOTAL_RESERVE : 0)
+    return this.inFlightFor(id) < perPtyLimit && this.totalInFlight < totalLimit
+  }
+
+  private applyCumulativeAck(id: string, processedChars: number): number {
+    const accounting = this.accounting.get(id)
+    if (!accounting) {
+      return 0
+    }
+    const nextAcked = Math.min(accounting.sent, Math.max(accounting.acked, processedChars))
+    const credited = nextAcked - accounting.acked
+    accounting.acked = nextAcked
+    this.totalInFlight = Math.max(0, this.totalInFlight - credited)
+    return credited
+  }
+
+  private recordSend(id: string, rawLength: number): void {
+    const accounting = this.accounting.get(id)
+    if (accounting) {
+      accounting.sent += rawLength
+    } else {
+      this.accounting.set(id, { sent: rawLength, acked: 0 })
+    }
+    this.totalInFlight += rawLength
+  }
+
+  private sendFinal(id: string, pending: PendingPtyData): void {
+    const rawLength = pending.rawLength ?? pending.data.length
+    this.recordSend(id, rawLength)
+    const event: DeliveryEvent = {
+      kind: 'data',
+      id,
+      data: pending.data,
+      rawLength,
+      ...(pending.transformed === true ? { transformed: true } : {}),
+      ...(pending.droppedOutput === true ? { droppedOutput: true } : {})
+    }
+    this.events.push(event)
+    this.notify?.(event)
+  }
+
+  private processCandidate(candidate: Candidate): number {
+    const { id, pending } = candidate
+    if (this.droppable.has(id)) {
+      candidate.remove()
+      this.flowPending.delete(id)
+      const event: DeliveryEvent = { kind: 'drop', id, data: pending.data }
+      this.events.push(event)
+      this.notify?.(event)
+      return 0
+    }
+    if (!this.canSend(id)) {
+      candidate.block()
+      return 0
+    }
+    if (pending.droppedOutput === true) {
+      candidate.remove()
+      this.flowPending.delete(id)
+      this.sendFinal(id, pending)
+      return 1
+    }
+
+    const indivisible = pending.transformed === true
+    const data = indivisible ? pending.data : pending.data.slice(0, CHUNK_CHARS)
+    const remaining = indivisible ? '' : pending.data.slice(CHUNK_CHARS)
+    if (remaining) {
+      const next: PendingPtyData = { data: remaining }
+      if (typeof pending.startSeq === 'number') {
+        next.startSeq = pending.startSeq + data.length
+      }
+      candidate.replace(next)
+      this.flowPending.set(id, remaining.length)
+    } else {
+      candidate.remove()
+      this.flowPending.delete(id)
+    }
+
+    const rawLength = pending.rawLength ?? data.length
+    this.recordSend(id, rawLength)
+    const event: DeliveryEvent = {
+      kind: 'data',
+      id,
+      data,
+      rawLength,
+      ...(pending.transformed === true ? { transformed: true } : {})
+    }
+    this.events.push(event)
+    this.notify?.(event)
+    return 1
+  }
+
+  private legacyCandidate(id: string, pending: PendingPtyData): Candidate {
+    return {
+      id,
+      pending,
+      block: () => {},
+      remove: () => {
+        this.legacyPending.delete(id)
+      },
+      replace: (next) => {
+        this.legacyPending.delete(id)
+        this.legacyPending.set(id, next)
+      }
+    }
+  }
+
+  private queueCandidate(selection: PtyPendingDataDrainSelection): Candidate {
+    const queue = this.queue!
+    return {
+      id: selection.id,
+      pending: selection.pending,
+      block: () => queue.block(selection),
+      remove: () => queue.remove(selection),
+      replace: (pending) => queue.replaceWithRemainder(selection, pending)
+    }
+  }
+}
+
+type EnginePair = { legacy: DrainSchedulerEngine; queue: DrainSchedulerEngine }
+
+function createPair(): EnginePair {
+  return {
+    legacy: new DrainSchedulerEngine('legacy'),
+    queue: new DrainSchedulerEngine('queue')
+  }
+}
+
+function applyBoth(pair: EnginePair, operation: (engine: DrainSchedulerEngine) => void): void {
+  operation(pair.legacy)
+  operation(pair.queue)
+  expect(pair.queue.snapshot()).toEqual(pair.legacy.snapshot())
+}
+
+function dataEvents(engine: DrainSchedulerEngine): Extract<DeliveryEvent, { kind: 'data' }>[] {
+  return engine.events.filter(
+    (event): event is Extract<DeliveryEvent, { kind: 'data' }> => event.kind === 'data'
+  )
+}
+
+describe('PTY pending-data scheduler legacy differential', () => {
+  it('models scheduled ticks and positive, zero, duplicate, stale, and clamped ACKs', () => {
+    const pair = createPair()
+    applyBoth(pair, (engine) => engine.enqueue('a', { data: 'abcdefghijklmnopqrst' }))
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.tick())
+
+    const rebuildsBeforeZeroCredit = pair.queue.debugQueue().laneRebuildCount
+    applyBoth(pair, (engine) => engine.acknowledge('a', 0))
+    const armsAfterZeroCredit = pair.queue.snapshot().timerArmCount
+    applyBoth(pair, (engine) => engine.acknowledge('a', -4))
+    expect(pair.queue.snapshot().timerArmCount).toBe(armsAfterZeroCredit)
+    applyBoth(pair, (engine) => engine.tick())
+    expect(pair.queue.debugQueue().laneRebuildCount).toBe(rebuildsBeforeZeroCredit)
+
+    applyBoth(pair, (engine) => engine.acknowledge('a', 4))
+    applyBoth(pair, (engine) => engine.tick())
+    expect(pair.queue.debugQueue().laneRebuildCount).toBe(rebuildsBeforeZeroCredit + 1)
+
+    const scheduledBeforeReplay = pair.queue.snapshot().scheduledDelay
+    const armsBeforeReplay = pair.queue.snapshot().timerArmCount
+    applyBoth(pair, (engine) => engine.acknowledge('a', 4))
+    applyBoth(pair, (engine) => engine.acknowledge('a', 2))
+    applyBoth(pair, (engine) => engine.acknowledge('a', 999))
+    applyBoth(pair, (engine) => engine.acknowledge('a', 999))
+    expect(pair.queue.snapshot()).toMatchObject({
+      scheduledDelay: scheduledBeforeReplay,
+      timerArmCount: armsBeforeReplay
+    })
+
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.tick())
+    expect(pair.queue.snapshot()).toMatchObject({
+      pending: [],
+      scheduledDelay: null,
+      totalInFlight: 8
+    })
+  })
+
+  it('wakes all globally blocked IDs when credit arrives for a different PTY', () => {
+    const pair = createPair()
+    applyBoth(pair, (engine) =>
+      engine.enqueue('creditor', { data: '12345678', rawLength: 8, transformed: true })
+    )
+    applyBoth(pair, (engine) => engine.enqueue('blocked-b', { data: 'bbbbbbbb' }))
+    applyBoth(pair, (engine) => engine.enqueue('blocked-c', { data: 'cccc' }))
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.tick())
+
+    expect(pair.queue.snapshot()).toMatchObject({
+      totalInFlight: TOTAL_LIMIT,
+      scheduledDelay: null
+    })
+    applyBoth(pair, (engine) => engine.acknowledge('creditor', 4))
+    applyBoth(pair, (engine) => engine.tick())
+
+    expect(dataEvents(pair.queue).at(-1)).toMatchObject({
+      id: 'blocked-c',
+      data: 'cccc'
+    })
+  })
+
+  it('reclassifies blocked work for per-PTY and global active reserves', () => {
+    const perPty = createPair()
+    applyBoth(perPty, (engine) => engine.enqueue('active-later', { data: 'abcdefghijkl' }))
+    applyBoth(perPty, (engine) => engine.tick())
+    applyBoth(perPty, (engine) => engine.tick())
+    applyBoth(perPty, (engine) => engine.tick())
+    applyBoth(perPty, (engine) => engine.setActive('active-later', true))
+    applyBoth(perPty, (engine) => engine.tick())
+    expect(perPty.queue.snapshot()).toMatchObject({ pending: [], totalInFlight: 12 })
+
+    const global = createPair()
+    applyBoth(global, (engine) =>
+      engine.enqueue('bulk-a', { data: 'aaaaaaaa', rawLength: 8, transformed: true })
+    )
+    applyBoth(global, (engine) =>
+      engine.enqueue('bulk-b', { data: 'bbbb', rawLength: 4, transformed: true })
+    )
+    applyBoth(global, (engine) => engine.tick())
+    applyBoth(global, (engine) => engine.enqueue('active-at-cap', { data: 'cccc' }))
+    applyBoth(global, (engine) => engine.tick())
+    applyBoth(global, (engine) => engine.setActive('active-at-cap', true))
+    applyBoth(global, (engine) => engine.tick())
+    expect(dataEvents(global.queue).at(-1)).toMatchObject({
+      id: 'active-at-cap',
+      data: 'cccc'
+    })
+  })
+
+  it('orders final payloads before exit and only wakes blocked work for net-new credit', () => {
+    const pair = createPair()
+    applyBoth(pair, (engine) =>
+      engine.enqueue('credit-a', { data: 'aaaaaaaa', rawLength: 8, transformed: true })
+    )
+    applyBoth(pair, (engine) =>
+      engine.enqueue('credit-b', { data: 'bbbb', rawLength: 4, transformed: true })
+    )
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.enqueue('final', { data: 'tail' }))
+    applyBoth(pair, (engine) => engine.enqueue('held', { data: 'held' }))
+    applyBoth(pair, (engine) => engine.tick())
+
+    const eventStart = pair.queue.events.length
+    const rebuildsBeforeNoopExit = pair.queue.debugQueue().laneRebuildCount
+    applyBoth(pair, (engine) => engine.exit('final'))
+    expect(pair.queue.events.slice(eventStart)).toEqual([
+      { kind: 'data', id: 'final', data: 'tail', rawLength: 4 },
+      { kind: 'exit', id: 'final' }
+    ])
+    expect(pair.queue.snapshot()).toMatchObject({
+      totalInFlight: TOTAL_LIMIT,
+      flowPending: [['held', 4]],
+      scheduledDelay: null
+    })
+    expect(pair.queue.debugQueue().laneRebuildCount).toBe(rebuildsBeforeNoopExit)
+
+    pair.legacy.exit('credit-a')
+    pair.queue.exit('credit-a')
+    expect(pair.legacy.snapshot().scheduledDelay).toBeNull()
+    expect(pair.queue.snapshot().scheduledDelay).toBe(0)
+    expect(pair.queue.snapshot()).toMatchObject({
+      pending: pair.legacy.snapshot().pending,
+      accounting: pair.legacy.snapshot().accounting,
+      totalInFlight: pair.legacy.snapshot().totalInFlight,
+      flowPending: pair.legacy.snapshot().flowPending,
+      events: pair.legacy.snapshot().events
+    })
+  })
+
+  it('coalesces zero-write reentrant exit credit into a post-round wakeup', () => {
+    const pair = createPair()
+    applyBoth(pair, (engine) =>
+      engine.enqueue('credit-a', { data: 'aaaaaaaa', rawLength: 8, transformed: true })
+    )
+    applyBoth(pair, (engine) =>
+      engine.enqueue('credit-b', { data: 'bbbb', rawLength: 4, transformed: true })
+    )
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.enqueue('held', { data: 'held' }))
+    applyBoth(pair, (engine) => engine.enqueue('hidden', { data: 'drop' }))
+    applyBoth(pair, (engine) => engine.setDroppable('hidden', true))
+    for (const engine of [pair.legacy, pair.queue]) {
+      let exited = false
+      engine.setNotification((event) => {
+        if (!exited && event.kind === 'drop' && event.id === 'hidden') {
+          exited = true
+          engine.exit('credit-a')
+        }
+      })
+    }
+
+    pair.legacy.tick()
+    pair.queue.tick()
+
+    expect(pair.legacy.snapshot().scheduledDelay).toBeNull()
+    expect(pair.queue.snapshot().scheduledDelay).toBe(0)
+    expect(pair.queue.snapshot()).toMatchObject({
+      pending: pair.legacy.snapshot().pending,
+      accounting: pair.legacy.snapshot().accounting,
+      totalInFlight: pair.legacy.snapshot().totalInFlight,
+      flowPending: pair.legacy.snapshot().flowPending,
+      events: pair.legacy.snapshot().events
+    })
+    pair.queue.tick()
+    expect(dataEvents(pair.queue).at(-1)).toMatchObject({ id: 'held', data: 'held' })
+  })
+
+  it('preserves dropped sentinel payloads before exit without leaving its timer armed', () => {
+    const pair = createPair()
+    applyBoth(pair, (engine) => engine.enqueue('sentinel', { data: 'query', droppedOutput: true }))
+    applyBoth(pair, (engine) => engine.exit('sentinel'))
+    expect(pair.queue.events).toEqual([
+      {
+        kind: 'data',
+        id: 'sentinel',
+        data: 'query',
+        rawLength: 5,
+        droppedOutput: true
+      },
+      { kind: 'exit', id: 'sentinel' }
+    ])
+    expect(pair.queue.snapshot()).toMatchObject({
+      pending: [],
+      scheduledDelay: null,
+      totalInFlight: 0
+    })
+  })
+
+  it('matches notification-reentrant exit and clear ordering', () => {
+    const exitPair = createPair()
+    applyBoth(exitPair, (engine) => engine.enqueue('partial', { data: 'abcdefgh' }))
+    applyBoth(exitPair, (engine) => engine.enqueue('next', { data: 'next' }))
+    for (const engine of [exitPair.legacy, exitPair.queue]) {
+      let exited = false
+      engine.setNotification((event) => {
+        if (!exited && event.kind === 'data' && event.id === 'partial') {
+          exited = true
+          engine.exit('partial')
+        }
+      })
+    }
+    applyBoth(exitPair, (engine) => engine.tick())
+    expect(exitPair.queue.events).toEqual([
+      { kind: 'tick', delayMs: 2 },
+      { kind: 'data', id: 'partial', data: 'abcd', rawLength: 4 },
+      { kind: 'data', id: 'partial', data: 'efgh', rawLength: 4 },
+      { kind: 'exit', id: 'partial' },
+      { kind: 'data', id: 'next', data: 'next', rawLength: 4 }
+    ])
+    expect(exitPair.queue.snapshot()).toMatchObject({
+      pending: [],
+      flowPending: [],
+      scheduledDelay: null
+    })
+
+    const clearPair = createPair()
+    applyBoth(clearPair, (engine) => engine.enqueue('first', { data: 'abcdefgh' }))
+    applyBoth(clearPair, (engine) => engine.enqueue('detached', { data: 'detached' }))
+    for (const engine of [clearPair.legacy, clearPair.queue]) {
+      let cleared = false
+      engine.setNotification((event) => {
+        if (!cleared && event.kind === 'data') {
+          cleared = true
+          engine.clear()
+        }
+      })
+    }
+    applyBoth(clearPair, (engine) => engine.tick())
+    expect(clearPair.queue.events).toEqual([
+      { kind: 'tick', delayMs: 2 },
+      { kind: 'data', id: 'first', data: 'abcd', rawLength: 4 },
+      { kind: 'clear' }
+    ])
+    expect(clearPair.queue.snapshot()).toMatchObject({
+      pending: [],
+      accounting: [],
+      flowPending: [],
+      scheduledDelay: null,
+      totalInFlight: 0
+    })
+    expect(clearPair.queue.debugQueue()).toMatchObject({
+      activeHeadId: null,
+      activeTailId: null,
+      backgroundHeadId: null,
+      backgroundTailId: null,
+      blockedHeadId: null,
+      blockedTailId: null,
+      openRound: null
+    })
+  })
+})

--- a/src/main/ipc/pty-pending-data-drain-scheduler-differential.test.ts
+++ b/src/main/ipc/pty-pending-data-drain-scheduler-differential.test.ts
@@ -12,7 +12,7 @@ const TOTAL_LIMIT = 12
 const ACTIVE_PER_PTY_RESERVE = 4
 const ACTIVE_TOTAL_RESERVE = 4
 
-type EngineKind = 'legacy' | 'queue'
+type EngineKind = 'reference' | 'queue'
 type Accounting = { sent: number; acked: number }
 type DeliveryEvent =
   | {
@@ -63,7 +63,7 @@ class DrainSchedulerEngine {
   private creditReleasedWhileDraining = false
   private notify: ((event: DeliveryEvent) => void) | null = null
   readonly events: DeliveryEvent[] = []
-  legacySnapshotEntryVisits = 0
+  referenceSnapshotEntryVisits = 0
 
   constructor(private readonly kind: EngineKind) {
     this.queue =
@@ -164,7 +164,7 @@ class DrainSchedulerEngine {
         ...entries.filter(([id]) => this.active.has(id)),
         ...entries.filter(([id]) => !this.active.has(id))
       ]
-      this.legacySnapshotEntryVisits += entries.length
+      this.referenceSnapshotEntryVisits += entries.length
       for (const [id, pending] of ordered) {
         if (writes >= MAX_WRITES || generation !== this.clearGeneration) {
           break
@@ -418,19 +418,19 @@ class DrainSchedulerEngine {
   }
 }
 
-type EnginePair = { legacy: DrainSchedulerEngine; queue: DrainSchedulerEngine }
+type EnginePair = { reference: DrainSchedulerEngine; queue: DrainSchedulerEngine }
 
 function createPair(): EnginePair {
   return {
-    legacy: new DrainSchedulerEngine('legacy'),
+    reference: new DrainSchedulerEngine('reference'),
     queue: new DrainSchedulerEngine('queue')
   }
 }
 
 function applyBoth(pair: EnginePair, operation: (engine: DrainSchedulerEngine) => void): void {
-  operation(pair.legacy)
+  operation(pair.reference)
   operation(pair.queue)
-  expect(pair.queue.snapshot()).toEqual(pair.legacy.snapshot())
+  expect(pair.queue.snapshot()).toEqual(pair.reference.snapshot())
 }
 
 function dataEvents(engine: DrainSchedulerEngine): Extract<DeliveryEvent, { kind: 'data' }>[] {
@@ -439,7 +439,7 @@ function dataEvents(engine: DrainSchedulerEngine): Extract<DeliveryEvent, { kind
   )
 }
 
-describe('PTY pending-data scheduler legacy differential', () => {
+describe('PTY pending-data hardened scheduler reference', () => {
   it('models scheduled ticks and positive, zero, duplicate, stale, and clamped ACKs', () => {
     const pair = createPair()
     applyBoth(pair, (engine) => engine.enqueue('a', { data: 'abcdefghijklmnopqrst' }))
@@ -530,6 +530,68 @@ describe('PTY pending-data scheduler legacy differential', () => {
     })
   })
 
+  it('freezes lane order while a background candidate gains live active reserve', () => {
+    const pair = createPair()
+    applyBoth(pair, (engine) =>
+      engine.enqueue('credit', { data: 'aaaaaaaa', rawLength: 8, transformed: true })
+    )
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.setActive('trigger', true))
+    applyBoth(pair, (engine) => engine.setActive('active-before', true))
+    applyBoth(pair, (engine) => engine.setDroppable('trigger', true))
+    applyBoth(pair, (engine) => engine.enqueue('trigger', { data: 'drop' }))
+    applyBoth(pair, (engine) => engine.enqueue('active-before', { data: 'aaaa' }))
+    applyBoth(pair, (engine) => engine.enqueue('reserve-later', { data: 'bbbb' }))
+    for (const engine of [pair.reference, pair.queue]) {
+      engine.setNotification((event) => {
+        if (event.kind === 'drop' && event.id === 'trigger') {
+          engine.setActive('reserve-later', true)
+        }
+      })
+    }
+
+    applyBoth(pair, (engine) => engine.tick())
+
+    expect(pair.queue.events.slice(-3)).toEqual([
+      { kind: 'drop', id: 'trigger', data: 'drop' },
+      { kind: 'data', id: 'active-before', data: 'aaaa', rawLength: 4 },
+      { kind: 'data', id: 'reserve-later', data: 'bbbb', rawLength: 4 }
+    ])
+  })
+
+  it('freezes lane order while an active candidate loses live reserve', () => {
+    const pair = createPair()
+    applyBoth(pair, (engine) =>
+      engine.enqueue('credit-a', { data: 'aaaaaaaa', rawLength: 8, transformed: true })
+    )
+    applyBoth(pair, (engine) =>
+      engine.enqueue('credit-b', { data: 'bbbb', rawLength: 4, transformed: true })
+    )
+    applyBoth(pair, (engine) => engine.tick())
+    applyBoth(pair, (engine) => engine.setActive('trigger', true))
+    applyBoth(pair, (engine) => engine.setActive('reserve-later', true))
+    applyBoth(pair, (engine) => engine.setDroppable('trigger', true))
+    applyBoth(pair, (engine) => engine.enqueue('trigger', { data: 'drop' }))
+    applyBoth(pair, (engine) => engine.enqueue('reserve-later', { data: 'held' }))
+    for (const engine of [pair.reference, pair.queue]) {
+      engine.setNotification((event) => {
+        if (event.kind === 'drop' && event.id === 'trigger') {
+          engine.setActive('reserve-later', false)
+        }
+      })
+    }
+
+    applyBoth(pair, (engine) => engine.tick())
+
+    expect(dataEvents(pair.queue).some((event) => event.id === 'reserve-later')).toBe(false)
+    expect(pair.queue.snapshot()).toMatchObject({
+      pending: [['reserve-later', { data: 'held' }]],
+      scheduledDelay: 0
+    })
+    applyBoth(pair, (engine) => engine.tick())
+    expect(pair.queue.debugQueue().blockedSize).toBe(1)
+  })
+
   it('orders final payloads before exit and only wakes blocked work for net-new credit', () => {
     const pair = createPair()
     applyBoth(pair, (engine) =>
@@ -557,16 +619,16 @@ describe('PTY pending-data scheduler legacy differential', () => {
     })
     expect(pair.queue.debugQueue().laneRebuildCount).toBe(rebuildsBeforeNoopExit)
 
-    pair.legacy.exit('credit-a')
+    pair.reference.exit('credit-a')
     pair.queue.exit('credit-a')
-    expect(pair.legacy.snapshot().scheduledDelay).toBeNull()
+    expect(pair.reference.snapshot().scheduledDelay).toBeNull()
     expect(pair.queue.snapshot().scheduledDelay).toBe(0)
     expect(pair.queue.snapshot()).toMatchObject({
-      pending: pair.legacy.snapshot().pending,
-      accounting: pair.legacy.snapshot().accounting,
-      totalInFlight: pair.legacy.snapshot().totalInFlight,
-      flowPending: pair.legacy.snapshot().flowPending,
-      events: pair.legacy.snapshot().events
+      pending: pair.reference.snapshot().pending,
+      accounting: pair.reference.snapshot().accounting,
+      totalInFlight: pair.reference.snapshot().totalInFlight,
+      flowPending: pair.reference.snapshot().flowPending,
+      events: pair.reference.snapshot().events
     })
   })
 
@@ -582,7 +644,7 @@ describe('PTY pending-data scheduler legacy differential', () => {
     applyBoth(pair, (engine) => engine.enqueue('held', { data: 'held' }))
     applyBoth(pair, (engine) => engine.enqueue('hidden', { data: 'drop' }))
     applyBoth(pair, (engine) => engine.setDroppable('hidden', true))
-    for (const engine of [pair.legacy, pair.queue]) {
+    for (const engine of [pair.reference, pair.queue]) {
       let exited = false
       engine.setNotification((event) => {
         if (!exited && event.kind === 'drop' && event.id === 'hidden') {
@@ -592,17 +654,17 @@ describe('PTY pending-data scheduler legacy differential', () => {
       })
     }
 
-    pair.legacy.tick()
+    pair.reference.tick()
     pair.queue.tick()
 
-    expect(pair.legacy.snapshot().scheduledDelay).toBeNull()
+    expect(pair.reference.snapshot().scheduledDelay).toBeNull()
     expect(pair.queue.snapshot().scheduledDelay).toBe(0)
     expect(pair.queue.snapshot()).toMatchObject({
-      pending: pair.legacy.snapshot().pending,
-      accounting: pair.legacy.snapshot().accounting,
-      totalInFlight: pair.legacy.snapshot().totalInFlight,
-      flowPending: pair.legacy.snapshot().flowPending,
-      events: pair.legacy.snapshot().events
+      pending: pair.reference.snapshot().pending,
+      accounting: pair.reference.snapshot().accounting,
+      totalInFlight: pair.reference.snapshot().totalInFlight,
+      flowPending: pair.reference.snapshot().flowPending,
+      events: pair.reference.snapshot().events
     })
     pair.queue.tick()
     expect(dataEvents(pair.queue).at(-1)).toMatchObject({ id: 'held', data: 'held' })
@@ -633,7 +695,7 @@ describe('PTY pending-data scheduler legacy differential', () => {
     const exitPair = createPair()
     applyBoth(exitPair, (engine) => engine.enqueue('partial', { data: 'abcdefgh' }))
     applyBoth(exitPair, (engine) => engine.enqueue('next', { data: 'next' }))
-    for (const engine of [exitPair.legacy, exitPair.queue]) {
+    for (const engine of [exitPair.reference, exitPair.queue]) {
       let exited = false
       engine.setNotification((event) => {
         if (!exited && event.kind === 'data' && event.id === 'partial') {
@@ -659,7 +721,7 @@ describe('PTY pending-data scheduler legacy differential', () => {
     const clearPair = createPair()
     applyBoth(clearPair, (engine) => engine.enqueue('first', { data: 'abcdefgh' }))
     applyBoth(clearPair, (engine) => engine.enqueue('detached', { data: 'detached' }))
-    for (const engine of [clearPair.legacy, clearPair.queue]) {
+    for (const engine of [clearPair.reference, clearPair.queue]) {
       let cleared = false
       engine.setNotification((event) => {
         if (!cleared && event.kind === 'data') {

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -10327,6 +10327,172 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('defers reentrant new, unvisited, and same-partial output to the next drain round', async () => {
+    vi.useFakeTimers()
+    const firstProc = createMockProc()
+    const secondProc = createMockProc()
+    const newProc = createMockProc()
+    spawnMock.mockReturnValueOnce(firstProc.proc)
+    spawnMock.mockReturnValueOnce(secondProc.proc)
+    spawnMock.mockReturnValueOnce(newProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const firstSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const secondSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const newSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const firstChunk = 'x'.repeat(16 * 1024)
+      const setActiveRendererPty = getPtySetActiveRendererPtyListener()
+      let reentered = false
+      mainWindow.webContents.send.mockImplementation(
+        (channel: string, payload: { id?: string }) => {
+          if (channel !== 'pty:data' || payload.id !== firstSpawn.id || reentered) {
+            return
+          }
+          reentered = true
+          firstProc.emitData('+same')
+          secondProc.emitData('+append')
+          newProc.emitData('new')
+          setActiveRendererPty(null, { id: newSpawn.id, active: true })
+        }
+      )
+
+      firstProc.emitData(`${firstChunk}tail`)
+      secondProc.emitData('second')
+      vi.advanceTimersByTime(2)
+      expect(getPtyDataSendCalls()).toEqual([['pty:data', { id: firstSpawn.id, data: firstChunk }]])
+
+      vi.advanceTimersByTime(2)
+      expect(getPtyDataSendCalls().slice(1)).toEqual([
+        ['pty:data', { id: newSpawn.id, data: 'new' }],
+        ['pty:data', { id: secondSpawn.id, data: 'second+append' }]
+      ])
+
+      vi.advanceTimersByTime(1)
+      expect(getPtyDataSendCalls().at(-1)).toEqual([
+        'pty:data',
+        { id: firstSpawn.id, data: 'tail+same' }
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('commits a partial remainder before notification-reentrant exit', async () => {
+    vi.useFakeTimers()
+    const firstProc = createMockProc()
+    const secondProc = createMockProc()
+    spawnMock.mockReturnValueOnce(firstProc.proc).mockReturnValueOnce(secondProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const firstSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string; incarnationId: string }
+      const secondSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const firstChunk = 'x'.repeat(16 * 1024)
+      let exited = false
+      mainWindow.webContents.send.mockImplementation(
+        (channel: string, payload: { id?: string; data?: string }) => {
+          if (
+            channel === 'pty:data' &&
+            payload.id === firstSpawn.id &&
+            payload.data === firstChunk &&
+            !exited
+          ) {
+            exited = true
+            firstProc.emitExit(0)
+          }
+        }
+      )
+
+      firstProc.emitData(`${firstChunk}tail`)
+      secondProc.emitData('next')
+      vi.advanceTimersByTime(2)
+
+      expect(mainWindow.webContents.send.mock.calls).toEqual([
+        ['pty:data', { id: firstSpawn.id, data: firstChunk }],
+        ['pty:data', { id: firstSpawn.id, data: 'tail' }],
+        ['pty:exit', { id: firstSpawn.id, code: 0, incarnationId: firstSpawn.incarnationId }],
+        ['pty:data', { id: secondSpawn.id, data: 'next' }]
+      ])
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        rendererInFlightPtyCount: 1,
+        rendererInFlightChars: 'next'.length,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('aborts the open drain when renderer lifecycle clear reenters notification', async () => {
+    vi.useFakeTimers()
+    const firstProc = createMockProc()
+    const detachedProc = createMockProc()
+    spawnMock.mockReturnValueOnce(firstProc.proc).mockReturnValueOnce(detachedProc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const firstSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })
+      const handleRendererLoading = getMainWindowWebContentsListener('did-start-loading')
+      let cleared = false
+      mainWindow.webContents.send.mockImplementation(
+        (channel: string, payload: { id?: string }) => {
+          if (channel === 'pty:data' && payload.id === firstSpawn.id && !cleared) {
+            cleared = true
+            handleRendererLoading()
+          }
+        }
+      )
+
+      firstProc.emitData('first')
+      detachedProc.emitData('must-not-send')
+      vi.advanceTimersByTime(2)
+
+      expect(getPtyDataSendCalls()).toEqual([['pty:data', { id: firstSpawn.id, data: 'first' }]])
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        rendererInFlightPtyCount: 0,
+        rendererInFlightChars: 0,
+        flushScheduled: false,
+        rendererPtyDispatcherReady: false
+      })
+      expect(vi.getTimerCount()).toBe(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('waits for renderer ACKs before sending more output for a saturated PTY', async () => {
     vi.useFakeTimers()
     const firstProc = createMockProc()
@@ -10642,7 +10808,8 @@ describe('registerPtyHandlers', () => {
       registerPtyHandlers(mainWindow as never)
       mainWindow.webContents.send.mockClear()
 
-      provider.emitData('flood-pty', 'x'.repeat(320 * 1024))
+      const finalPendingData = 'x'.repeat(320 * 1024)
+      provider.emitData('flood-pty', finalPendingData)
       expect(provider.pauseProducer).toHaveBeenCalledTimes(1)
 
       // Exit while pending is above the low watermark: the exit path must release the pause, not leave a stale mark.
@@ -10650,6 +10817,81 @@ describe('registerPtyHandlers', () => {
       expect(provider.resumeProducer).toHaveBeenCalledTimes(1)
       expect(provider.resumeProducer).toHaveBeenCalledWith('flood-pty')
     } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fences synchronous producer data and duplicate exit while releasing an exiting PTY', () => {
+    vi.useFakeTimers()
+    try {
+      const provider = installObservableDaemonTestProvider()
+      registerPtyHandlers(mainWindow as never)
+      mainWindow.webContents.send.mockClear()
+
+      const finalPendingData = 'x'.repeat(320 * 1024)
+      provider.emitData('flood-pty', finalPendingData)
+      expect(provider.pauseProducer).toHaveBeenCalledTimes(1)
+      provider.resumeProducer.mockImplementation((id: string) => {
+        provider.emitData(id, 'must-not-follow-exit')
+        provider.emitExit(id, 0)
+      })
+
+      provider.emitExit('flood-pty', 0)
+
+      expect(provider.resumeProducer).toHaveBeenCalledTimes(1)
+      expect(mainWindow.webContents.send.mock.calls).toEqual([
+        ['pty:data', { id: 'flood-pty', data: finalPendingData }],
+        ['pty:exit', { id: 'flood-pty', code: 0 }]
+      ])
+      expect(
+        getPtyDataSendCalls().some(
+          (call) => (call[1] as { data?: string } | undefined)?.data === 'must-not-follow-exit'
+        )
+      ).toBe(false)
+      expect(
+        mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')
+      ).toHaveLength(1)
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        rendererInFlightPtyCount: 0,
+        rendererInFlightChars: 0,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('delivers a pending-cap sentinel before exit and clears its pending timer', () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const provider = installObservableDaemonTestProvider()
+      registerPtyHandlers(mainWindow as never)
+      provider.emitData('flood-pty', 'x'.repeat(3 * 1024 * 1024))
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 1,
+        pendingChars: 0,
+        flushScheduled: true
+      })
+      mainWindow.webContents.send.mockClear()
+
+      provider.emitExit('flood-pty', 0)
+
+      expect(mainWindow.webContents.send.mock.calls).toEqual([
+        ['pty:data', { id: 'flood-pty', data: '', droppedOutput: true }],
+        ['pty:exit', { id: 'flood-pty', code: 0 }]
+      ])
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        rendererInFlightPtyCount: 0,
+        rendererInFlightChars: 0,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      errorSpy.mockRestore()
       vi.useRealTimers()
     }
   })
@@ -10764,6 +11006,37 @@ describe('registerPtyHandlers', () => {
       expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
         rendererInFlightChars: 256 * 1024
       })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps zero, duplicate, and stale ACKs to one legacy no-write timer', async () => {
+    vi.useFakeTimers()
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+
+    try {
+      const spawnResult = await spawnAndSaturateRendererDeliveryGate(mockProc)
+      const ackData = getPtyAckDataListener()
+      expect(getPtyDataSendCalls()).toHaveLength(32)
+      expect(vi.getTimerCount()).toBe(0)
+
+      ackData(null, { id: spawnResult.id, processedChars: 0 })
+      expect(getPtyRendererDeliveryDebugSnapshot().flushScheduled).toBe(true)
+      expect(vi.getTimerCount()).toBe(1)
+      ackData(null, { id: spawnResult.id, processedChars: 0 })
+      ackData(null, { id: spawnResult.id, processedChars: -1 })
+      expect(vi.getTimerCount()).toBe(1)
+
+      vi.runOnlyPendingTimers()
+      expect(getPtyDataSendCalls()).toHaveLength(32)
+      expect(getPtyRendererDeliveryDebugSnapshot().flushScheduled).toBe(false)
+      expect(vi.getTimerCount()).toBe(0)
+
+      ackData(null, { id: spawnResult.id, processedChars: 16 * 1024 })
+      vi.runOnlyPendingTimers()
+      expect(getPtyDataSendCalls()).toHaveLength(33)
     } finally {
       vi.useRealTimers()
     }
@@ -11371,6 +11644,242 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('reactivates every globally blocked PTY when an exit releases renderer credit', async () => {
+    vi.useFakeTimers()
+    const procs = Array.from({ length: 17 }, () => createMockProc())
+    for (const proc of procs) {
+      spawnMock.mockReturnValueOnce(proc.proc)
+    }
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawns: { id: string }[] = []
+      for (const _proc of procs) {
+        spawns.push(
+          (await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            cwd: '/tmp'
+          })) as { id: string }
+        )
+      }
+      mainWindow.webContents.send.mockClear()
+      for (const proc of procs) {
+        proc.emitData('x'.repeat(600 * 1024))
+      }
+      vi.advanceTimersByTime(2)
+      for (let index = 0; index < 400; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      expect(getPtyDataSendCalls()).toHaveLength(512)
+      expect(vi.getTimerCount()).toBe(0)
+
+      mainWindow.webContents.send.mockClear()
+      procs[0]!.emitExit(0)
+      const exitIndex = mainWindow.webContents.send.mock.calls.findIndex(
+        (call) => call[0] === 'pty:exit'
+      )
+      expect(exitIndex).toBeGreaterThanOrEqual(0)
+      vi.advanceTimersByTime(0)
+
+      expect(
+        mainWindow.webContents.send.mock.calls
+          .slice(exitIndex + 1)
+          .some(
+            (call) =>
+              call[0] === 'pty:data' &&
+              (call[1] as { id?: string } | undefined)?.id !== spawns[0]!.id
+          )
+      ).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('wakes blocked PTYs when a zero-write hidden drop reentrantly releases exit credit', async () => {
+    vi.useFakeTimers()
+    const bulkProcs = Array.from({ length: 16 }, () => createMockProc())
+    const hiddenProc = createMockProc()
+    const heldProc = createMockProc()
+    for (const proc of [...bulkProcs, hiddenProc, heldProc]) {
+      spawnMock.mockReturnValueOnce(proc.proc)
+    }
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const bulkSpawns: { id: string }[] = []
+      for (const _proc of bulkProcs) {
+        bulkSpawns.push(
+          (await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            cwd: '/tmp'
+          })) as { id: string }
+        )
+      }
+      const hiddenSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })
+
+      for (const proc of bulkProcs) {
+        proc.emitData('x'.repeat(600 * 1024))
+      }
+      vi.advanceTimersByTime(2)
+      for (let index = 0; index < 400; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        rendererInFlightChars: 8 * 1024 * 1024,
+        flushScheduled: false
+      })
+
+      const setHidden = getPtySetHiddenRendererPtyListener()
+      const setInterest = getPtySetDeliveryInterestListener()
+      setHidden(null, { id: hiddenSpawn.id, hidden: true })
+      setInterest(null, { id: hiddenSpawn.id, interested: true })
+      hiddenProc.emitData('drop-without-write')
+      heldProc.emitData('held')
+      setInterest(null, { id: hiddenSpawn.id, interested: false })
+      mainWindow.webContents.send.mockClear()
+      let reentered = false
+      mainWindow.webContents.send.mockImplementation(
+        (channel: string, payload: { id?: string }) => {
+          if (channel === 'pty:modelRestoreNeeded' && payload.id === hiddenSpawn.id && !reentered) {
+            reentered = true
+            bulkProcs[0]!.emitExit(0)
+          }
+        }
+      )
+
+      vi.advanceTimersByTime(2)
+
+      const exitIndex = mainWindow.webContents.send.mock.calls.findIndex(
+        (call) => call[0] === 'pty:exit'
+      )
+      expect(exitIndex).toBeGreaterThanOrEqual(0)
+      expect(getPtyRendererDeliveryDebugSnapshot().flushScheduled).toBe(true)
+      vi.advanceTimersByTime(1)
+      expect(
+        mainWindow.webContents.send.mock.calls
+          .slice(exitIndex + 1)
+          .some(
+            (call) =>
+              call[0] === 'pty:data' &&
+              (call[1] as { id?: string } | undefined)?.id !== bulkSpawns[0]!.id
+          )
+      ).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not reactivate globally blocked PTYs when exit releases no prior credit', async () => {
+    vi.useFakeTimers()
+    const bulkProcs = Array.from({ length: 16 }, () => createMockProc())
+    const finalProc = createMockProc()
+    const heldProc = createMockProc()
+    for (const proc of [...bulkProcs, finalProc, heldProc]) {
+      spawnMock.mockReturnValueOnce(proc.proc)
+    }
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      for (const _proc of bulkProcs) {
+        await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          cwd: '/tmp'
+        })
+      }
+      const finalSpawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string; incarnationId: string }
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })
+
+      for (const proc of bulkProcs) {
+        proc.emitData('x'.repeat(600 * 1024))
+      }
+      vi.advanceTimersByTime(2)
+      for (let index = 0; index < 400; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        rendererInFlightChars: 8 * 1024 * 1024,
+        flushScheduled: false
+      })
+
+      finalProc.emitData('final-tail')
+      heldProc.emitData('held')
+      vi.advanceTimersByTime(2)
+      expect(getPtyRendererDeliveryDebugSnapshot().flushScheduled).toBe(false)
+      const timerCountBeforeExit = vi.getTimerCount()
+      mainWindow.webContents.send.mockClear()
+
+      finalProc.emitExit(0)
+
+      expect(mainWindow.webContents.send.mock.calls).toEqual([
+        ['pty:data', { id: finalSpawn.id, data: 'final-tail' }],
+        ['pty:exit', { id: finalSpawn.id, code: 0, incarnationId: finalSpawn.incarnationId }]
+      ])
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        rendererInFlightChars: 8 * 1024 * 1024,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(timerCountBeforeExit)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not schedule a teardown-only flush for the last active blocked PTY', async () => {
+    vi.useFakeTimers()
+    const proc = createMockProc()
+    spawnMock.mockReturnValue(proc.proc)
+
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      getPtySetActiveRendererPtyListener()(null, { id: spawn.id, active: true })
+      proc.emitData('x'.repeat(1200 * 1024))
+      vi.advanceTimersByTime(2)
+      for (let index = 0; index < 80; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 1,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+
+      proc.emitExit(0)
+
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('prioritizes active PTY pending output during renderer backpressure', async () => {
     vi.useFakeTimers()
     const procs = Array.from({ length: 18 }, () => createMockProc())
@@ -11690,6 +12199,58 @@ describe('registerPtyHandlers', () => {
         expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
           id: spawnResult.id,
           reason: 'hidden-drop'
+        })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('drops queued hidden data when interest ends before dispatcher readiness', async () => {
+      vi.useFakeTimers()
+      const mockProc = createMockProc()
+      spawnMock.mockReturnValue(mockProc.proc)
+
+      try {
+        registerPtyHandlers(mainWindow as never)
+        const spawnResult = (await handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          cwd: '/tmp'
+        })) as { id: string }
+        const setHidden = getPtySetHiddenRendererPtyListener()
+        const setInterest = getPtySetDeliveryInterestListener()
+        const setActive = getPtySetActiveRendererPtyListener()
+        getMainWindowWebContentsListener('did-start-loading')()
+        mainWindow.webContents.send.mockClear()
+
+        setHidden(null, { id: spawnResult.id, hidden: true })
+        setInterest(null, { id: spawnResult.id, interested: true })
+        mockProc.emitData('boot-window sidecar bytes')
+        vi.advanceTimersByTime(2)
+        expect(mainWindow.webContents.send).not.toHaveBeenCalled()
+        expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+          pendingPtyCount: 1,
+          rendererPtyDispatcherReady: false,
+          ackGatedFlushSkipCount: 0
+        })
+
+        const timerCountBeforeNoops = vi.getTimerCount()
+        setHidden(null, { id: spawnResult.id, hidden: true })
+        setInterest(null, { id: spawnResult.id, interested: true })
+        setActive(null, { id: spawnResult.id, active: false })
+        expect(vi.getTimerCount()).toBe(timerCountBeforeNoops)
+
+        setInterest(null, { id: spawnResult.id, interested: false })
+        vi.advanceTimersByTime(0)
+
+        expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
+          id: spawnResult.id,
+          reason: 'hidden-drop'
+        })
+        expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+          pendingPtyCount: 0,
+          rendererPtyDispatcherReady: false,
+          ackGatedFlushSkipCount: 0
         })
       } finally {
         vi.useRealTimers()

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -10409,6 +10409,7 @@ describe('registerPtyHandlers', () => {
         cwd: '/tmp'
       })) as { id: string }
       const firstChunk = 'x'.repeat(16 * 1024)
+      mainWindow.webContents.send.mockClear()
       let exited = false
       mainWindow.webContents.send.mockImplementation(
         (channel: string, payload: { id?: string; data?: string }) => {
@@ -10859,6 +10860,246 @@ describe('registerPtyHandlers', () => {
       })
       expect(vi.getTimerCount()).toBe(0)
     } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not retry a complete payload after a synchronous renderer send failure', () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const provider = installObservableDaemonTestProvider()
+      registerPtyHandlers(mainWindow as never)
+      mainWindow.webContents.send.mockClear()
+      let failed = false
+      let markerFailed = false
+      mainWindow.webContents.send.mockImplementation(
+        (channel: string, payload: { id?: string }) => {
+          if (channel === 'pty:data' && payload.id === 'send-fail-complete' && !failed) {
+            failed = true
+            throw new Error('synthetic send failure')
+          }
+          if (channel === 'pty:modelRestoreNeeded' && !markerFailed) {
+            markerFailed = true
+            throw new Error('synthetic marker failure')
+          }
+        }
+      )
+
+      provider.emitData('send-fail-complete', 'lost-once')
+      vi.advanceTimersByTime(2)
+
+      expect(getPtyDataSendCalls()).toEqual([
+        ['pty:data', { id: 'send-fail-complete', data: 'lost-once' }]
+      ])
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        pendingChars: 0,
+        rendererInFlightPtyCount: 0,
+        rendererInFlightChars: 0,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+
+      provider.emitData('send-fail-complete', 'recovery')
+      vi.advanceTimersByTime(2)
+      expect(getPtyDataSendCalls()).toEqual([
+        ['pty:data', { id: 'send-fail-complete', data: 'lost-once' }],
+        ['pty:data', { id: 'send-fail-complete', data: 'recovery' }]
+      ])
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
+        id: 'send-fail-complete',
+        reason: 'delivery-heal'
+      })
+      provider.emitData('send-fail-complete', 'after-marker-failure')
+      vi.advanceTimersByTime(2)
+      expect(
+        mainWindow.webContents.send.mock.calls.filter(
+          (call) => call[0] === 'pty:modelRestoreNeeded'
+        )
+      ).toHaveLength(2)
+      expect(getPtyDataSendCalls().at(-1)).toEqual([
+        'pty:data',
+        { id: 'send-fail-complete', data: 'after-marker-failure' }
+      ])
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps only a partial remainder after a synchronous renderer send failure', () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const provider = installObservableDaemonTestProvider()
+      registerPtyHandlers(mainWindow as never)
+      mainWindow.webContents.send.mockClear()
+      const firstChunk = 'x'.repeat(16 * 1024)
+      let failed = false
+      mainWindow.webContents.send.mockImplementation((channel: string) => {
+        if (channel === 'pty:data' && !failed) {
+          failed = true
+          throw new Error('synthetic send failure')
+        }
+      })
+
+      provider.emitData('send-fail-partial', `${firstChunk}tail`)
+      vi.advanceTimersByTime(2)
+
+      expect(getPtyDataSendCalls()).toEqual([
+        ['pty:data', { id: 'send-fail-partial', data: firstChunk }]
+      ])
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 1,
+        pendingChars: 4,
+        rendererInFlightChars: 0,
+        flushScheduled: true
+      })
+      expect(vi.getTimerCount()).toBe(1)
+
+      vi.advanceTimersByTime(1)
+      expect(getPtyDataSendCalls()).toEqual([
+        ['pty:data', { id: 'send-fail-partial', data: firstChunk }],
+        ['pty:data', { id: 'send-fail-partial', data: 'tail' }]
+      ])
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
+        id: 'send-fail-partial',
+        reason: 'delivery-heal'
+      })
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        rendererInFlightChars: 4,
+        flushScheduled: false
+      })
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('clears failed-delivery restore state when the renderer lifecycle resets', () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const provider = installObservableDaemonTestProvider()
+      registerPtyHandlers(mainWindow as never)
+      const resetRenderer = getMainWindowWebContentsListener('did-start-loading')
+      const readyRenderer = getPtyRendererDispatcherReadyListener()
+      let failed = false
+      mainWindow.webContents.send.mockImplementation((channel: string) => {
+        if (channel === 'pty:data' && !failed) {
+          failed = true
+          throw new Error('synthetic send failure')
+        }
+      })
+
+      provider.emitData('send-fail-reset', 'lost-once')
+      vi.advanceTimersByTime(2)
+      resetRenderer()
+      readyRenderer()
+      mainWindow.webContents.send.mockClear()
+      provider.emitData('send-fail-reset', 'repainted-page-data')
+      vi.advanceTimersByTime(2)
+
+      expect(getPtyDataSendCalls()).toEqual([
+        ['pty:data', { id: 'send-fail-reset', data: 'repainted-page-data' }]
+      ])
+      expect(
+        mainWindow.webContents.send.mock.calls.filter(
+          (call) => call[0] === 'pty:modelRestoreNeeded'
+        )
+      ).toHaveLength(0)
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('commits interactive bypass removal and producer flow after a synchronous send failure', async () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const mockProc = createMockProc()
+    spawnMock.mockReturnValue(mockProc.proc)
+    try {
+      registerPtyHandlers(mainWindow as never)
+      const spawn = (await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp'
+      })) as { id: string }
+      const writePty = getPtyWriteListener()
+      mainWindow.webContents.send.mockClear()
+      let failed = false
+      mainWindow.webContents.send.mockImplementation((channel: string) => {
+        if (channel === 'pty:data' && !failed) {
+          failed = true
+          throw new Error('synthetic send failure')
+        }
+      })
+
+      mockProc.emitData('older-')
+      writePty(mainWindowIpcEvent, { id: spawn.id, data: 'x' })
+      mockProc.emitData('redraw')
+
+      expect(getPtyDataSendCalls()).toEqual([['pty:data', { id: spawn.id, data: 'older-redraw' }]])
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        pendingChars: 0,
+        rendererInFlightChars: 0,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+
+      mockProc.emitData('recovery')
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
+        id: spawn.id,
+        reason: 'delivery-heal'
+      })
+    } finally {
+      errorSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('cleans up and emits exit once when the final data send fails synchronously', () => {
+    vi.useFakeTimers()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      const provider = installObservableDaemonTestProvider()
+      registerPtyHandlers(mainWindow as never)
+      const pending = 'x'.repeat(320 * 1024)
+      provider.emitData('send-fail-exit', pending)
+      expect(provider.pauseProducer).toHaveBeenCalledWith('send-fail-exit')
+      mainWindow.webContents.send.mockClear()
+      mainWindow.webContents.send.mockImplementation((channel: string) => {
+        if (channel === 'pty:data') {
+          throw new Error('synthetic send failure')
+        }
+      })
+
+      provider.emitExit('send-fail-exit', 7)
+
+      expect(getPtyDataSendCalls()).toEqual([['pty:data', { id: 'send-fail-exit', data: pending }]])
+      expect(
+        mainWindow.webContents.send.mock.calls.filter((call) => call[0] === 'pty:exit')
+      ).toEqual([['pty:exit', { id: 'send-fail-exit', code: 7 }]])
+      expect(
+        mainWindow.webContents.send.mock.calls.filter(
+          (call) => call[0] === 'pty:modelRestoreNeeded'
+        )
+      ).toHaveLength(0)
+      expect(provider.resumeProducer).toHaveBeenCalledWith('send-fail-exit')
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        pendingPtyCount: 0,
+        pendingChars: 0,
+        rendererInFlightPtyCount: 0,
+        rendererInFlightChars: 0,
+        flushScheduled: false
+      })
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      errorSpy.mockRestore()
       vi.useRealTimers()
     }
   })
@@ -11372,6 +11613,54 @@ describe('registerPtyHandlers', () => {
       mockProc.emitData('after-heal')
       vi.advanceTimersByTime(2)
       expect(getPtyDataSendCalls()).toHaveLength(33)
+    } finally {
+      warnSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('reactivates globally blocked work immediately after a delivery writeoff', () => {
+    vi.useFakeTimers()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const provider = installObservableDaemonTestProvider()
+      registerPtyHandlers(mainWindow as never)
+      const bulkIds = Array.from({ length: 16 }, (_, index) => `writeoff-bulk-${index}`)
+      mainWindow.webContents.send.mockClear()
+      for (const id of bulkIds) {
+        provider.emitData(id, 'x'.repeat(600 * 1024))
+      }
+      vi.advanceTimersByTime(2)
+      for (let index = 0; index < 400; index++) {
+        vi.advanceTimersByTime(1)
+      }
+      expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+        rendererInFlightChars: 8 * 1024 * 1024,
+        flushScheduled: false
+      })
+
+      provider.emitData('writeoff-held', 'held')
+      vi.advanceTimersByTime(2)
+      expect(
+        getPtyDataSendCalls().some(
+          (call) => (call[1] as { id?: string } | undefined)?.id === 'writeoff-held'
+        )
+      ).toBe(false)
+      expect(getPtyRendererDeliveryDebugSnapshot().flushScheduled).toBe(false)
+
+      reportRendererDeliveryState({
+        receivedCharsByPty: {},
+        processedCharsByPty: {},
+        heal: true,
+        rendererPtyDataListenerCount: 1
+      })
+      expect(getPtyRendererDeliveryDebugSnapshot().flushScheduled).toBe(true)
+      vi.advanceTimersByTime(0)
+
+      expect(getPtyDataSendCalls().at(-1)).toEqual([
+        'pty:data',
+        { id: 'writeoff-held', data: 'held' }
+      ])
     } finally {
       warnSpy.mockRestore()
       vi.useRealTimers()
@@ -12288,6 +12577,53 @@ describe('registerPtyHandlers', () => {
         vi.useRealTimers()
       }
     })
+
+    it.each(['terminalHiddenDeliveryGate', 'terminalMainSideEffectAuthority'] as const)(
+      'reevaluates blocked hidden data when the live %s setting enables the derived gate',
+      async (settingName) => {
+        vi.useFakeTimers()
+        const mockProc = createMockProc()
+        spawnMock.mockReturnValue(mockProc.proc)
+        const settings = {
+          terminalHiddenDeliveryGate: true,
+          terminalMainSideEffectAuthority: true
+        }
+        settings[settingName] = false
+
+        try {
+          registerPtyHandlers(mainWindow as never, undefined, undefined, (() => settings) as never)
+          const spawnResult = (await handlers.get('pty:spawn')!(null, {
+            cols: 80,
+            rows: 24,
+            cwd: '/tmp'
+          })) as { id: string }
+          getMainWindowWebContentsListener('did-start-loading')()
+          getPtySetHiddenRendererPtyListener()(null, { id: spawnResult.id, hidden: true })
+          mainWindow.webContents.send.mockClear()
+          mockProc.emitData('blocked while gate disabled')
+          vi.advanceTimersByTime(2)
+          expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+            pendingPtyCount: 1,
+            rendererPtyDispatcherReady: false
+          })
+
+          settings[settingName] = true
+          getPtyAckDataListener()(null, { id: spawnResult.id, processedChars: 0 })
+          vi.advanceTimersByTime(0)
+
+          expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
+            id: spawnResult.id,
+            reason: 'hidden-drop'
+          })
+          expect(getPtyRendererDeliveryDebugSnapshot()).toMatchObject({
+            pendingPtyCount: 0,
+            rendererPtyDispatcherReady: false
+          })
+        } finally {
+          vi.useRealTimers()
+        }
+      }
+    )
 
     it('drops queued pending data when a PTY is marked hidden', async () => {
       vi.useFakeTimers()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -151,6 +151,7 @@ import {
   shouldDropHiddenRendererPtyData,
   unmarkHiddenRendererPty
 } from './pty-hidden-delivery-gate'
+import { PtyPendingDataDrainQueue, type PendingPtyData } from './pty-pending-data-drain-queue'
 import {
   clearNativeWindowsConptyPty,
   isNativeWindowsLocalPtySpawn,
@@ -214,6 +215,8 @@ const interactiveOutputCharsByPty = new Map<string, number>()
 const activeRendererPtys = new Set<string>()
 const visibleRendererPtys = new Set<string>()
 const rendererVisibilityKnownPtys = new Set<string>()
+let invalidatePendingPtyDrainPriority = (_id?: string, _schedule?: boolean): void => {}
+let invalidatePendingPtyDrainPolicy = (_id?: string, _schedule?: boolean): void => {}
 const pendingHiddenRendererResizeOutputPtys = new Set<string>()
 const deliveredHiddenRendererResizeOutputPtys = new Set<string>()
 const KEEP_HISTORY_STOP_SETTLE_MS = 1_000
@@ -1283,13 +1286,20 @@ export function clearProviderPtyState(
   ptyIncarnationById.delete(id)
   lastInputAtByPty.delete(id)
   interactiveOutputCharsByPty.delete(id)
-  activeRendererPtys.delete(id)
+  const activeChanged = activeRendererPtys.delete(id)
   visibleRendererPtys.delete(id)
   rendererVisibilityKnownPtys.delete(id)
   pendingHiddenRendererResizeOutputPtys.delete(id)
   deliveredHiddenRendererResizeOutputPtys.delete(id)
   // Why: every teardown path funnels through here — hidden/interest gate bits must not outlive the PTY or a reused map entry could silently gate a new one.
+  const deliveryPolicyChanged = isHiddenRendererPty(id)
   clearHiddenRendererPtyDeliveryState(id)
+  if (activeChanged) {
+    invalidatePendingPtyDrainPriority(id, false)
+  }
+  if (deliveryPolicyChanged) {
+    invalidatePendingPtyDrainPolicy(id, false)
+  }
   clearBackgroundedDeliverySyncForPty(id)
   providerSnapshotRequiredPtys.delete(id)
   // Why: the Phase-5 ConPTY DA1 spawn record must not leak onto a reused id.
@@ -1486,10 +1496,14 @@ function markRendererPtysHiddenForRendererLifecycleReset(): void {
   // A reload/crash in the breadcrumb history is load-bearing context for any freeze report.
   mainDeliveryBreadcrumbs.record('renderer-lifecycle-reset')
   // Why: renderer-owned hints die with the page; clear visibility so surviving daemon/SSH PTYs fail closed until the new renderer reports.
+  const activePriorityChanged = activeRendererPtys.size > 0
   activeRendererPtys.clear()
   visibleRendererPtys.clear()
   // Why: the dead page never ACKs its in-flight bytes, so leaked accounting would delivery-gate surviving PTYs forever after a reload/crash.
   resetRendererDeliveryAccountingForLifecycleReset()
+  if (activePriorityChanged) {
+    invalidatePendingPtyDrainPriority()
+  }
 }
 
 function clearRendererLifecycleResetHandlers(): void {
@@ -1578,6 +1592,8 @@ export function registerPtyHandlers(
   // Why: a re-registration means a new window owns delivery — cancel the prior closure's watchdog and neutralize its bridged reset so mark-hidden below can't arm a timer against the dead closure.
   clearRendererDispatcherReadyWatchdog()
   resetRendererDeliveryAccountingForLifecycleReset = () => {}
+  invalidatePendingPtyDrainPriority = () => {}
+  invalidatePendingPtyDrainPolicy = () => {}
   registerRendererLifecycleResetHandlers(mainWindow.webContents)
 
   const getLocalPtyStartupPromise = (connectionId?: string | null): Promise<void> | undefined => {
@@ -1702,17 +1718,6 @@ export function registerPtyHandlers(
     })
   }
 
-  // Why: batching PTY data into short flush windows cuts IPC round-trips from hundreds/sec to ~120/sec; keystroke echo/redraws bypass it below.
-  type PendingPtyData = {
-    data: string
-    startSeq?: number
-    rawLength?: number
-    transformed?: true
-    containsBackgroundOutput?: boolean
-    // Why droppedOutput (not main's droppedBacklog trim): this branch's drop-to-sentinel + snapshot-restore supersedes #7630's 2MB-tail trim; both would race two cap policies over one buffer.
-    droppedOutput?: true
-  }
-
   type PtyDataPayload = {
     id: string
     data: string
@@ -1723,8 +1728,43 @@ export function registerPtyHandlers(
     droppedOutput?: boolean
   }
 
-  const pendingData = new Map<string, PendingPtyData>()
-  let pendingDataTotalChars = 0
+  // Why: batching PTY data into short flush windows cuts IPC round-trips from hundreds/sec to ~120/sec; keystroke echo/redraws bypass it below.
+  const pendingData = new PtyPendingDataDrainQueue((id) => {
+    const runnableLane = activeRendererPtys.has(id) ? 'active' : 'background'
+    // Why first: hidden bytes are dropped from main's pending queue even when renderer credit is exhausted.
+    if (shouldDropHiddenRendererPtyData(id, getSettings?.())) {
+      return runnableLane
+    }
+    if (
+      !rendererPtyDispatcherReady ||
+      !canSendPtyDataToRenderer(id, { interactive: activeRendererPtys.has(id) })
+    ) {
+      return 'blocked'
+    }
+    return runnableLane
+  })
+  // Why: resuming a paused producer during exit can synchronously emit; those bytes must not queue behind pty:exit.
+  const rendererExitingPtyIds = new Set<string>()
+
+  function transitionHiddenRendererPtyDeliveryState(id: string, hidden: boolean) {
+    const settings = getSettings?.()
+    const wasDroppable = shouldDropHiddenRendererPtyData(id, settings)
+    let droppedWhileHidden = false
+    if (hidden) {
+      markHiddenRendererPty(id)
+    } else {
+      droppedWhileHidden = unmarkHiddenRendererPty(id).droppedWhileHidden
+    }
+    const droppable = shouldDropHiddenRendererPtyData(id, settings)
+    return { droppable, droppedWhileHidden, policyChanged: wasDroppable !== droppable }
+  }
+
+  function transitionSpawnHiddenRendererPtyDeliveryState(id: string, hidden: boolean): void {
+    const transition = transitionHiddenRendererPtyDeliveryState(id, hidden)
+    if (transition.policyChanged) {
+      invalidatePendingPtyDrainPolicy(id)
+    }
+  }
   // Why: one restore marker per overflow episode — cleared on full drain so a later overflow re-marks exactly once.
   const pendingOverflowMarkedPtys = new Set<string>()
   // Why: TCP-style cumulative accounting — monotonic sent/acked totals self-heal on any later ACK, where relative in-flight counters would make each lost ACK a permanent debt.
@@ -1737,6 +1777,8 @@ export function registerPtyHandlers(
   const rendererDeliveryAccountingByPty = new Map<string, RendererPtyDeliveryAccounting>()
   const trustedTerminalHandleEnv = new Set<string>()
   let flushTimer: ReturnType<typeof setTimeout> | null = null
+  let pendingDataFlushActive = false
+  let pendingDataCreditReleasedDuringFlush = false
   let rendererInFlightTotalChars = 0
   let pendingDroppedChars = 0
   let deliveryResyncRequestSerial = 0
@@ -2135,6 +2177,15 @@ export function registerPtyHandlers(
     return acknowledged
   }
 
+  function schedulePendingDataAfterCreditReport(creditedAny: boolean): void {
+    if (creditedAny) {
+      pendingData.reactivateBlocked()
+    }
+    if (pendingData.size > 0 && !flushTimer) {
+      schedulePendingDataFlush(0)
+    }
+  }
+
   function clearDeliveryResyncProbe(): void {
     deliveryResyncOutstandingRequestId = null
     if (deliveryResyncTimer) {
@@ -2285,20 +2336,6 @@ export function registerPtyHandlers(
     })
   }
 
-  function getPendingPtyFlushEntries(): [string, PendingPtyData][] {
-    const entries = Array.from(pendingData.entries())
-    const active: [string, PendingPtyData][] = []
-    const background: [string, PendingPtyData][] = []
-    for (const entry of entries) {
-      if (activeRendererPtys.has(entry[0])) {
-        active.push(entry)
-      } else {
-        background.push(entry)
-      }
-    }
-    return [...active, ...background]
-  }
-
   const pendingDataDropWarnedPtys = new Set<string>()
 
   // Why capped: keeps O(1) memory per PTY; salvaged query bytes are tiny, so past the cap a pathological stream can degrade to the plain sentinel.
@@ -2329,10 +2366,8 @@ export function registerPtyHandlers(
         capChars
       })
     }
-    // Why the marker: the snapshot can recover the dropped middle; emit it once per overflow episode so a fresh or reloaded view latches restore too.
     if (isHiddenPtyDeliveryGateEnabled(getSettings?.()) && !pendingOverflowMarkedPtys.has(id)) {
       pendingOverflowMarkedPtys.add(id)
-      sendModelRestoreNeededMarker(id, 'pending-cap', runtime?.getPtyOutputSequence(id))
     }
     pendingDroppedChars += pending.data.length
     // Why no trimmed content tail: a mid-stream gap would corrupt the pane; the droppedOutput sentinel repaints from the snapshot and realigns by sequence (only query bytes ride along).
@@ -2392,6 +2427,17 @@ export function registerPtyHandlers(
     flushTimer = setTimeout(flushPendingData, delayMs)
   }
 
+  function invalidatePendingPtyDrainClassification(id?: string, schedule = true): void {
+    if (typeof id === 'string' && pendingData.get(id) === undefined) {
+      return
+    }
+    if (pendingData.invalidateAll() && schedule && !flushTimer) {
+      schedulePendingDataFlush(0)
+    }
+  }
+  invalidatePendingPtyDrainPriority = invalidatePendingPtyDrainClassification
+  invalidatePendingPtyDrainPolicy = invalidatePendingPtyDrainClassification
+
   function clearDispatcherReadyWatchdog(): void {
     if (dispatcherReadyWatchdogTimer) {
       clearTimeout(dispatcherReadyWatchdogTimer)
@@ -2412,6 +2458,7 @@ export function registerPtyHandlers(
       }
       rendererPtyDispatcherReady = true
       rendererDispatcherReadyForcedCount += 1
+      pendingData.reactivateBlocked()
       schedulePendingDataFlush(0)
     }, PTY_DISPATCHER_READY_WATCHDOG_MS)
     dispatcherReadyWatchdogTimer.unref?.()
@@ -2430,75 +2477,88 @@ export function registerPtyHandlers(
       clearDispatcherReadyWatchdog()
       return
     }
-    // Why hold: the page's pty:data listener isn't registered yet; bytes accrue in pendingData (rebuilt losslessly) and the ready handshake reschedules this flush.
-    if (!rendererPtyDispatcherReady) {
-      return
-    }
+    // Ordinary boot-window data is blocked in the queue; hidden-droppable entries still retire before renderer readiness.
     const settings = getSettings?.()
     let writes = 0
-    for (const [id, pending] of getPendingPtyFlushEntries()) {
-      if (writes >= PTY_BATCH_FLUSH_MAX_WRITES) {
-        break
-      }
-      // Why drop, never re-queue: the model already ingested hidden-gated bytes; reveal restores from the snapshot+seq machinery.
-      if (shouldDropHiddenRendererPtyData(id, settings)) {
-        deletePendingPtyData(id)
-        pendingOverflowMarkedPtys.delete(id)
+    const round = pendingData.beginRound()
+    let creditReleasedDuringFlush = false
+    pendingDataFlushActive = true
+    pendingDataCreditReleasedDuringFlush = false
+    try {
+      while (writes < PTY_BATCH_FLUSH_MAX_WRITES) {
+        const selection = pendingData.takeNext(round)
+        if (!selection) {
+          break
+        }
+        const { id, pending } = selection
+        // Why drop, never re-queue: the model already ingested hidden-gated bytes; reveal restores from the snapshot+seq machinery.
+        if (shouldDropHiddenRendererPtyData(id, settings)) {
+          pendingData.remove(selection)
+          pendingOverflowMarkedPtys.delete(id)
+          updateProducerFlowControl(id)
+          const drop = recordHiddenRendererPtyDataDrop(id, pending.data.length)
+          warnIfDroppingHiddenBytesForVisiblePty(id, pending.data.length)
+          if (drop.shouldEmitRestoreMarker) {
+            sendModelRestoreNeededMarker(id, 'hidden-drop', runtime?.getPtyOutputSequence(id))
+          }
+          continue
+        }
+        if (!canSendPtyDataToRenderer(id, { interactive: activeRendererPtys.has(id) })) {
+          pendingData.block(selection)
+          continue
+        }
+        if (pending.droppedOutput === true) {
+          pendingData.remove(selection)
+          updateProducerFlowControl(id)
+          // Why droppedOutput sentinel: pending-cap drop means the pane must repaint from the snapshot, not continue a gapped stream (data = carved query bytes only).
+          sendPtyDataToRenderer(id, { id, data: pending.data, droppedOutput: true })
+          writes++
+          continue
+        }
+        const { data } = pending
+        const indivisible = pending.transformed === true
+        const chunk = indivisible ? data : data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
+        const remaining = indivisible ? '' : data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
+        if (remaining) {
+          const nextPending: PendingPtyData = { data: remaining }
+          if (typeof pending.startSeq === 'number') {
+            nextPending.startSeq = pending.startSeq + chunk.length
+          }
+          if (pending.containsBackgroundOutput === true) {
+            nextPending.containsBackgroundOutput = true
+          }
+          pendingData.replaceWithRemainder(selection, nextPending)
+        } else {
+          pendingData.remove(selection)
+          pendingOverflowMarkedPtys.delete(id)
+        }
         updateProducerFlowControl(id)
-        const drop = recordHiddenRendererPtyDataDrop(id, pending.data.length)
-        warnIfDroppingHiddenBytesForVisiblePty(id, pending.data.length)
-        if (drop.shouldEmitRestoreMarker) {
-          sendModelRestoreNeededMarker(id, 'hidden-drop', runtime?.getPtyOutputSequence(id))
-        }
-        continue
-      }
-      if (!canSendPtyDataToRenderer(id, { interactive: activeRendererPtys.has(id) })) {
-        continue
-      }
-      deletePendingPtyData(id)
-      if (pending.droppedOutput === true) {
-        updateProducerFlowControl(id)
-        // Why droppedOutput sentinel: pending-cap drop means the pane must repaint from the snapshot, not continue a gapped stream (data = carved query bytes only).
-        sendPtyDataToRenderer(id, { id, data: pending.data, droppedOutput: true })
-        writes++
-        continue
-      }
-      const { data } = pending
-      const indivisible = pending.transformed === true
-      const chunk = indivisible ? data : data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
-      const remaining = indivisible ? '' : data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
-      if (remaining) {
-        const nextPending: PendingPtyData = { data: remaining }
-        if (typeof pending.startSeq === 'number') {
-          nextPending.startSeq = pending.startSeq + chunk.length
-        }
-        if (pending.containsBackgroundOutput === true) {
-          nextPending.containsBackgroundOutput = true
-        }
-        setPendingPtyData(id, nextPending)
-      } else {
-        pendingOverflowMarkedPtys.delete(id)
-      }
-      updateProducerFlowControl(id)
-      sendPtyDataToRenderer(
-        id,
-        makePtyDataPayload(
+        sendPtyDataToRenderer(
           id,
-          chunk,
-          pending.startSeq,
-          pending.containsBackgroundOutput,
-          pending.rawLength,
-          pending.transformed
+          makePtyDataPayload(
+            id,
+            chunk,
+            pending.startSeq,
+            pending.containsBackgroundOutput,
+            pending.rawLength,
+            pending.transformed
+          )
         )
-      )
-      writes++
+        writes++
+      }
+    } finally {
+      pendingDataFlushActive = false
+      creditReleasedDuringFlush = pendingDataCreditReleasedDuringFlush
+      pendingDataCreditReleasedDuringFlush = false
+      pendingData.endRound(round)
     }
-    if (pendingData.size > 0 && writes === 0) {
+    if (rendererPtyDispatcherReady && pendingData.size > 0 && writes === 0) {
       ackGatedFlushSkipCount++
     }
-    if (pendingData.size > 0 && writes > 0) {
+    recordPtyRendererDeliveryPressure()
+    if (pendingData.size > 0 && (writes > 0 || creditReleasedDuringFlush)) {
       // Why yield between slices: a background terminal can dump megabytes at once, and keystroke writes must not stall behind one flush.
-      schedulePendingDataFlush(PTY_BATCH_DRAIN_CONTINUE_MS)
+      schedulePendingDataFlush(writes > 0 ? PTY_BATCH_DRAIN_CONTINUE_MS : 0)
     }
   }
 
@@ -2540,46 +2600,63 @@ export function registerPtyHandlers(
     if (mainWindow.isDestroyed()) {
       return
     }
-    // Why flush before exit: the renderer tears down the terminal on pty:exit, so any batched output not yet flushed would be silently lost.
-    const remaining = pendingData.get(payload.id)
-    if (remaining) {
-      if (remaining.droppedOutput === true) {
-        // Sentinel entry: only salvaged query bytes remain; keep the flag so the renderer knows the span was dropped.
-        sendPtyDataToRenderer(payload.id, {
-          id: payload.id,
-          data: remaining.data,
-          droppedOutput: true
-        })
-      } else {
-        sendPtyDataToRenderer(
-          payload.id,
-          makePtyDataPayload(
-            payload.id,
-            remaining.data,
-            remaining.startSeq,
-            remaining.containsBackgroundOutput,
-            remaining.rawLength,
-            remaining.transformed
-          )
-        )
-      }
-      deletePendingPtyData(payload.id)
+    if (rendererExitingPtyIds.has(payload.id)) {
+      return
     }
-    // Why resume a dead PTY (no-op): avoid leaving a stale paused mark behind for a reused id.
-    producerFlowControl.release(payload.id)
-    pendingOverflowMarkedPtys.delete(payload.id)
-    lastInputAtByPty.delete(payload.id)
-    interactiveOutputCharsByPty.delete(payload.id)
-    rendererInFlightTotalChars = Math.max(
-      0,
-      rendererInFlightTotalChars - getRendererInFlightCharsForPty(payload.id)
-    )
-    // Why: the renderer also drops its cumulative total on pty:exit, so a reused id restarts aligned at zero on both sides.
-    rendererDeliveryAccountingByPty.delete(payload.id)
-    mainWindow.webContents.send('pty:exit', {
-      ...payload,
-      ...(reversibleStopOwnersByPtyId.has(payload.id) ? { preserveRendererBinding: true } : {})
-    })
+    rendererExitingPtyIds.add(payload.id)
+    try {
+      const hadReleasableRendererCredit = getRendererInFlightCharsForPty(payload.id) > 0
+      // Why flush before exit: the renderer tears down the terminal on pty:exit, so any batched output not yet flushed would be silently lost.
+      const remaining = pendingData.delete(payload.id)
+      clearFlushTimerIfIdle()
+      if (remaining) {
+        if (remaining.droppedOutput === true) {
+          // Sentinel entry: only salvaged query bytes remain; keep the flag so the renderer knows the span was dropped.
+          sendPtyDataToRenderer(payload.id, {
+            id: payload.id,
+            data: remaining.data,
+            droppedOutput: true
+          })
+        } else {
+          sendPtyDataToRenderer(
+            payload.id,
+            makePtyDataPayload(
+              payload.id,
+              remaining.data,
+              remaining.startSeq,
+              remaining.containsBackgroundOutput,
+              remaining.rawLength,
+              remaining.transformed
+            )
+          )
+        }
+      }
+      // Why resume a dead PTY (no-op): avoid leaving a stale paused mark behind for a reused id.
+      producerFlowControl.release(payload.id)
+      pendingOverflowMarkedPtys.delete(payload.id)
+      lastInputAtByPty.delete(payload.id)
+      interactiveOutputCharsByPty.delete(payload.id)
+      const releasedRendererCredit = getRendererInFlightCharsForPty(payload.id)
+      rendererInFlightTotalChars = Math.max(0, rendererInFlightTotalChars - releasedRendererCredit)
+      // Why: the renderer also drops its cumulative total on pty:exit, so a reused id restarts aligned at zero on both sides.
+      rendererDeliveryAccountingByPty.delete(payload.id)
+      if (hadReleasableRendererCredit) {
+        if (pendingDataFlushActive) {
+          // Why: let the open round coalesce this wake into its one post-round continuation.
+          const reactivatedBlocked = pendingData.reactivateBlocked()
+          pendingDataCreditReleasedDuringFlush ||= reactivatedBlocked
+        } else {
+          schedulePendingDataAfterCreditReport(true)
+        }
+      }
+      recordPtyRendererDeliveryPressure()
+      mainWindow.webContents.send('pty:exit', {
+        ...payload,
+        ...(reversibleStopOwnersByPtyId.has(payload.id) ? { preserveRendererBinding: true } : {})
+      })
+    } finally {
+      rendererExitingPtyIds.delete(payload.id)
+    }
   }
 
   function sendPtySpawnedToRenderer(id: string): void {
@@ -2668,6 +2745,9 @@ export function registerPtyHandlers(
         clearDispatcherReadyWatchdog()
         return
       }
+      if (rendererExitingPtyIds.size > 0 && rendererExitingPtyIds.has(payload.id)) {
+        return
+      }
       const settings = getSettings?.()
       // Why drop before the interactive bypass: runtime already ingested the chunk, so gated PTYs skip both renderer paths and reveal restores from the snapshot.
       if (shouldDropHiddenRendererPtyData(payload.id, settings)) {
@@ -2687,6 +2767,7 @@ export function registerPtyHandlers(
         markHiddenRendererResizeOutputDelivered(payload.id)
       }
       const existing = pendingData.get(payload.id)
+      const overflowMarkedBeforeAppend = pendingOverflowMarkedPtys.has(payload.id)
       const pending = appendPendingPtyData(
         payload.id,
         existing,
@@ -2697,6 +2778,10 @@ export function registerPtyHandlers(
         rawLength,
         payload.transformed === true
       )
+      const shouldEmitPendingCapRestoreMarker =
+        pending.droppedOutput === true &&
+        !overflowMarkedBeforeAppend &&
+        pendingOverflowMarkedPtys.has(payload.id)
       const nextData = pending.data
       const isInteractiveOutput = shouldSendInteractiveOutputNow(
         payload.id,
@@ -2707,32 +2792,45 @@ export function registerPtyHandlers(
       if (isInteractiveOutput && rendererPtyDispatcherReady) {
         // Why the reserve: keep input echo from being pinned behind unrelated bulk output; it's bounded and the per-PTY cap still prevents an active TUI runaway.
         if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
-          requestDeliveryResyncForGatedPty()
-          setPendingPtyData(payload.id, pending)
+          pendingData.set(payload.id, pending)
+          if (shouldEmitPendingCapRestoreMarker) {
+            sendModelRestoreNeededMarker(payload.id, 'pending-cap', outputSeq)
+          }
           updateProducerFlowControl(payload.id)
+          recordPtyRendererDeliveryPressure()
+          requestDeliveryResyncForGatedPty()
           return
         }
-        deletePendingPtyData(payload.id)
-        updateProducerFlowControl(payload.id)
-        pendingOverflowMarkedPtys.delete(payload.id)
+        pendingData.delete(payload.id)
         clearFlushTimerIfIdle()
+        if (shouldEmitPendingCapRestoreMarker) {
+          sendModelRestoreNeededMarker(payload.id, 'pending-cap', outputSeq)
+        }
+        pendingOverflowMarkedPtys.delete(payload.id)
         // Why immediate: agent TUIs redraw small prompt regions per keystroke; the throughput batch timer would add visible input latency.
-        sendPtyDataToRenderer(payload.id, {
-          id: payload.id,
-          data: nextData,
-          ...(typeof pending.startSeq === 'number'
-            ? {
-                seq: pending.startSeq + (pending.rawLength ?? nextData.length),
-                rawLength: pending.rawLength ?? nextData.length
-              }
-            : {}),
-          ...(pending.transformed ? { transformed: true } : {}),
-          ...(pending.containsBackgroundOutput === true ? { background: true } : {}),
-          ...(pending.droppedOutput === true ? { droppedOutput: true } : {})
-        })
+        try {
+          sendPtyDataToRenderer(payload.id, {
+            id: payload.id,
+            data: nextData,
+            ...(typeof pending.startSeq === 'number'
+              ? {
+                  seq: pending.startSeq + (pending.rawLength ?? nextData.length),
+                  rawLength: pending.rawLength ?? nextData.length
+                }
+              : {}),
+            ...(pending.transformed ? { transformed: true } : {}),
+            ...(pending.containsBackgroundOutput === true ? { background: true } : {}),
+            ...(pending.droppedOutput === true ? { droppedOutput: true } : {})
+          })
+        } finally {
+          updateProducerFlowControl(payload.id)
+        }
         return
       }
-      setPendingPtyData(payload.id, pending)
+      pendingData.set(payload.id, pending)
+      if (shouldEmitPendingCapRestoreMarker) {
+        sendModelRestoreNeededMarker(payload.id, 'pending-cap', outputSeq)
+      }
       updateProducerFlowControl(payload.id)
       // Why probe on data arrival (not flush skips): new output for a fully gated PTY is the moment stuck delivery becomes observable.
       if (
@@ -2864,15 +2962,17 @@ export function registerPtyHandlers(
 
   // Why: reload/crash orphans delivery-interest holds and hidden marks; reset so surviving PTYs aren't stuck force-fed or gated — each pane's first sync re-marks.
   clearRendererGateResetHandlers()
-  rendererGateResetLoadHandler = () => {
+  const resetRendererPtyDeliveryGateState = (): void => {
+    const gateDebug = getHiddenRendererPtyDeliveryDebug()
     resetRendererScopedHiddenPtyDeliveryState()
+    if (gateDebug.hiddenDeliveryGatedPtyCount > 0 || gateDebug.deliveryInterestPtyCount > 0) {
+      invalidatePendingPtyDrainPolicy()
+    }
     // Why: the daemon pacer must not keep throttling ptys whose hidden marks died with the renderer; the fresh renderer's sync re-marks the still-hidden ones.
     resyncBackgroundedDeliveriesAfterGateReset()
   }
-  rendererGateResetGoneHandler = () => {
-    resetRendererScopedHiddenPtyDeliveryState()
-    resyncBackgroundedDeliveriesAfterGateReset()
-  }
+  rendererGateResetLoadHandler = resetRendererPtyDeliveryGateState
+  rendererGateResetGoneHandler = resetRendererPtyDeliveryGateState
   rendererGateResetWebContents = mainWindow.webContents
   mainWindow.webContents.on('did-finish-load', rendererGateResetLoadHandler)
   mainWindow.webContents.on('render-process-gone', rendererGateResetGoneHandler)
@@ -4391,7 +4491,7 @@ export function registerPtyHandlers(
           ? effectiveSessionAppId
           : null
       if (preSpawnHiddenMarkId !== null) {
-        markHiddenRendererPty(preSpawnHiddenMarkId)
+        transitionSpawnHiddenRendererPtyDeliveryState(preSpawnHiddenMarkId, true)
       }
       let result: PtySpawnResult
       let rejectedRegistrationCandidate: PtySpawnResult | null = null
@@ -4455,7 +4555,7 @@ export function registerPtyHandlers(
           }
           // Why: a stale hidden mark on this session id would gate a later visible attach that reuses it.
           if (preSpawnHiddenMarkId !== null) {
-            unmarkHiddenRendererPty(preSpawnHiddenMarkId)
+            transitionSpawnHiddenRendererPtyDeliveryState(preSpawnHiddenMarkId, false)
           }
           const rawMessage = err instanceof Error ? err.message : String(err)
           if (rawMessage === 'agent_session_exited_during_start' && rejectedRegistrationCandidate) {
@@ -4534,10 +4634,10 @@ export function registerPtyHandlers(
         }
         if (initiallyHidden) {
           // Why marked synchronously here: provider data events dispatch on later tasks, so this still lands ahead of the first byte's delivery decision (idempotent if already marked pre-spawn).
-          markHiddenRendererPty(result.id)
+          transitionSpawnHiddenRendererPtyDeliveryState(result.id, true)
           if (preSpawnHiddenMarkId !== null && preSpawnHiddenMarkId !== result.id) {
             // Defense: never strand a mark on an id the provider renamed.
-            unmarkHiddenRendererPty(preSpawnHiddenMarkId)
+            transitionSpawnHiddenRendererPtyDeliveryState(preSpawnHiddenMarkId, false)
           }
           // Why after ptyOwnership.set: provider lookup routes by ownership, and a hidden-spawned agent should be paceable from its first flood.
           syncPtyBackgroundedDelivery(result.id, 'spawn')
@@ -5050,9 +5150,8 @@ export function registerPtyHandlers(
         acknowledged = accounting ? applyCumulativeAck(args.id, accounting.ackedChars + delta) : 0
       }
       tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, acknowledged)
-      if (pendingData.size > 0 && !flushTimer) {
-        schedulePendingDataFlush(0)
-      }
+      recordPtyRendererDeliveryPressure()
+      schedulePendingDataAfterCreditReport(acknowledged > 0)
     }
   )
 
@@ -5068,18 +5167,19 @@ export function registerPtyHandlers(
       clearDeliveryResyncProbe()
       deliveryResyncUnansweredWarnLogged = false
       // Why max-merge: the renderer's cumulative totals are authoritative for what it processed, draining exactly the in-flight debt from lost ACKs.
+      let creditedAny = false
       for (const [id, processedChars] of Object.entries(args.processedCharsByPty ?? {})) {
         if (typeof processedChars !== 'number' || !Number.isFinite(processedChars)) {
           continue
         }
         const acknowledged = applyCumulativeAck(id, Math.max(0, processedChars))
         if (acknowledged > 0) {
+          creditedAny = true
           tryGetProviderForPty(id)?.acknowledgeDataEvent(id, acknowledged)
         }
       }
-      if (pendingData.size > 0 && !flushTimer) {
-        schedulePendingDataFlush(0)
-      }
+      recordPtyRendererDeliveryPressure()
+      schedulePendingDataAfterCreditReport(creditedAny)
     }
   )
 
@@ -5088,12 +5188,14 @@ export function registerPtyHandlers(
     'pty:reportRendererDeliveryState',
     (_event, args: PtyRendererDeliveryStateReport): PtyRendererDeliveryHealthReply => {
       // Extra repair lane for the lost-ACK variant: identical max-merge to the resync response, so a heal is only reached when merging cannot drain.
+      let creditedAny = false
       for (const [id, processedChars] of Object.entries(args?.processedCharsByPty ?? {})) {
         if (typeof processedChars !== 'number' || !Number.isFinite(processedChars)) {
           continue
         }
         const acknowledged = applyCumulativeAck(id, Math.max(0, processedChars))
         if (acknowledged > 0) {
+          creditedAny = true
           tryGetProviderForPty(id)?.acknowledgeDataEvent(id, acknowledged)
         }
       }
@@ -5106,10 +5208,10 @@ export function registerPtyHandlers(
           Date.now() - lastAckReceivedAtMs >= PTY_DELIVERY_HEAL_MIN_ACK_SILENCE_MS)
       ) {
         writtenOff = writeOffLostRendererDelivery(args)
+        creditedAny ||= writtenOff.length > 0
       }
-      if (pendingData.size > 0 && !flushTimer) {
-        schedulePendingDataFlush(0)
-      }
+      recordPtyRendererDeliveryPressure()
+      schedulePendingDataAfterCreditReport(creditedAny)
       let inFlightPtyCount = 0
       for (const accounting of rendererDeliveryAccountingByPty.values()) {
         if (accounting.sentChars - accounting.ackedChars > 0) {
@@ -5139,6 +5241,7 @@ export function registerPtyHandlers(
     // Why: real handshake landed — cancel the self-heal watchdog so it can't later force-open the gate.
     clearDispatcherReadyWatchdog()
     rendererPtyDispatcherReady = true
+    pendingData.reactivateBlocked()
     schedulePendingDataFlush(0)
   })
 
@@ -5149,13 +5252,14 @@ export function registerPtyHandlers(
     }
     // Why: renderer scheduling hint only — active panes just get first chance at the bounded output reserve; reads/state/notifications continue for inactive terminals.
     if (args.active) {
+      if (activeRendererPtys.has(args.id)) {
+        return
+      }
       activeRendererPtys.add(args.id)
-    } else {
-      activeRendererPtys.delete(args.id)
+    } else if (!activeRendererPtys.delete(args.id)) {
+      return
     }
-    if (pendingData.size > 0 && !flushTimer) {
-      schedulePendingDataFlush(0)
-    }
+    invalidatePendingPtyDrainPriority(args.id)
   })
 
   ipcMain.removeAllListeners('pty:setRendererPtyVisible')
@@ -5182,13 +5286,13 @@ export function registerPtyHandlers(
     mainDeliveryBreadcrumbs.record(args.hidden === true ? 'gate-mark' : 'gate-unmark', {
       id: redactPtyIdForDiagnostics(args.id)
     })
+    const transition = transitionHiddenRendererPtyDeliveryState(args.id, args.hidden === true)
     if (args.hidden === true) {
-      markHiddenRendererPty(args.id)
       closeStartupQueryAuthorityForPty(args.id)
       // Why: drop bytes queued for a newly hidden PTY instead of holding them under ACK starvation; reveal restores from the snapshot.
       const pending = pendingData.get(args.id)
-      if (pending && shouldDropHiddenRendererPtyData(args.id, getSettings?.())) {
-        deletePendingPtyData(args.id)
+      if (pending && transition.droppable) {
+        pendingData.delete(args.id)
         updateProducerFlowControl(args.id)
         pendingOverflowMarkedPtys.delete(args.id)
         const drop = recordHiddenRendererPtyDataDrop(args.id, pending.data.length)
@@ -5200,13 +5304,18 @@ export function registerPtyHandlers(
           )
         }
       }
+      if (transition.policyChanged) {
+        invalidatePendingPtyDrainPolicy(args.id)
+      }
       syncPtyBackgroundedDelivery(args.id, 'gate-mark')
       return
     }
-    const { droppedWhileHidden } = unmarkHiddenRendererPty(args.id)
+    if (transition.policyChanged) {
+      invalidatePendingPtyDrainPolicy(args.id)
+    }
     syncPtyBackgroundedDelivery(args.id, 'gate-unmark')
     // Why: a reload/remount may have replaced the view that latched restore-needed, so re-emit on unhide; a redundant replay is cheap/idempotent, a missed restore corrupts the pane.
-    if (droppedWhileHidden) {
+    if (transition.droppedWhileHidden) {
       sendModelRestoreNeededMarker(args.id, 'unhide', runtime?.getPtyOutputSequence(args.id))
     }
   })
@@ -5226,7 +5335,12 @@ export function registerPtyHandlers(
       return
     }
     // Why: any delivery interest suppresses the hidden-delivery gate (raw-byte consumers keep receiving while hidden); not synced to the daemon pacer so interest churn can't un-pace a flood.
+    const settings = getSettings?.()
+    const wasDroppable = shouldDropHiddenRendererPtyData(args.id, settings)
     setRendererPtyDeliveryInterest(args.id, args.interested === true)
+    if (wasDroppable !== shouldDropHiddenRendererPtyData(args.id, settings)) {
+      invalidatePendingPtyDrainPolicy(args.id)
+    }
   })
 
   ipcMain.removeAllListeners('pty:signal')

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1728,23 +1728,27 @@ export function registerPtyHandlers(
     droppedOutput?: boolean
   }
 
-  // Why: batching PTY data into short flush windows cuts IPC round-trips from hundreds/sec to ~120/sec; keystroke echo/redraws bypass it below.
-  const pendingData = new PtyPendingDataDrainQueue((id) => {
-    const runnableLane = activeRendererPtys.has(id) ? 'active' : 'background'
-    // Why first: hidden bytes are dropped from main's pending queue even when renderer credit is exhausted.
-    if (shouldDropHiddenRendererPtyData(id, getSettings?.())) {
+  // Why: bounded batch windows amortize renderer IPC; keystroke echo/redraws bypass them below.
+  const pendingData = new PtyPendingDataDrainQueue(
+    (id) => {
+      const runnableLane = activeRendererPtys.has(id) ? 'active' : 'background'
+      // Why first: hidden bytes are dropped from main's pending queue even when renderer credit is exhausted.
+      if (shouldDropHiddenRendererPtyData(id, getSettings?.())) {
+        return runnableLane
+      }
+      if (
+        !rendererPtyDispatcherReady ||
+        !canSendPtyDataToRenderer(id, { interactive: activeRendererPtys.has(id) })
+      ) {
+        return 'blocked'
+      }
       return runnableLane
-    }
-    if (
-      !rendererPtyDispatcherReady ||
-      !canSendPtyDataToRenderer(id, { interactive: activeRendererPtys.has(id) })
-    ) {
-      return 'blocked'
-    }
-    return runnableLane
-  })
+    },
+    () => isHiddenPtyDeliveryGateEnabled(getSettings?.())
+  )
   // Why: resuming a paused producer during exit can synchronously emit; those bytes must not queue behind pty:exit.
   const rendererExitingPtyIds = new Set<string>()
+  const rendererDeliveryRestoreNeededPtys = new Set<string>()
 
   function transitionHiddenRendererPtyDeliveryState(id: string, hidden: boolean) {
     const settings = getSettings?.()
@@ -1880,7 +1884,7 @@ export function registerPtyHandlers(
 
   // Why touched PTY only: pressure peaks are monotonic between explicit resets.
   function recordPtyRendererDeliveryPressure(id: string): void {
-    peakPendingChars = Math.max(peakPendingChars, pendingDataTotalChars)
+    peakPendingChars = Math.max(peakPendingChars, pendingData.totalPendingChars)
     peakMaxPendingCharsByPty = Math.max(
       peakMaxPendingCharsByPty,
       pendingData.get(id)?.data.length ?? 0
@@ -1893,24 +1897,16 @@ export function registerPtyHandlers(
   }
 
   function setPendingPtyData(id: string, pending: PendingPtyData): void {
-    const previousChars = pendingData.get(id)?.data.length ?? 0
     pendingData.set(id, pending)
-    pendingDataTotalChars += pending.data.length - previousChars
     recordPtyRendererDeliveryPressure(id)
   }
 
-  function deletePendingPtyData(id: string): boolean {
-    const previousChars = pendingData.get(id)?.data.length
-    if (previousChars === undefined) {
-      return false
-    }
-    pendingDataTotalChars -= previousChars
-    return pendingData.delete(id)
+  function deletePendingPtyData(id: string): void {
+    pendingData.delete(id)
   }
 
   function clearPendingPtyData(): void {
     pendingData.clear()
-    pendingDataTotalChars = 0
   }
 
   function readCurrentPtyRendererDeliveryDebugSnapshot(): PtyRendererDeliveryDebugSnapshot {
@@ -2083,6 +2079,7 @@ export function registerPtyHandlers(
     rendererInFlightTotalChars = 0
     clearPendingPtyData()
     pendingOverflowMarkedPtys.clear()
+    rendererDeliveryRestoreNeededPtys.clear()
     // Why hold sends: the reloading page's pty:data listener is gone until it re-registers/handshakes, so bytes would drop into a listener-less page and re-pin the gate.
     rendererPtyDispatcherReady = false
     // Why: arm the self-heal watchdog so a never-arriving handshake can't hold the gate forever; the real handshake cancels it.
@@ -2274,9 +2271,10 @@ export function registerPtyHandlers(
     return writtenOff
   }
 
-  function sendPtyDataToRenderer(id: string, payload: PtyDataPayload): void {
+  function sendPtyDataToRenderer(id: string, payload: PtyDataPayload): boolean {
     const charCount = getPtyPayloadCharCount(payload)
     const accounting = rendererDeliveryAccountingByPty.get(id)
+    const hadAccounting = accounting !== undefined
     if (accounting) {
       accounting.sentChars += charCount
       accounting.lastSendAtMs = Date.now()
@@ -2290,7 +2288,43 @@ export function registerPtyHandlers(
     }
     rendererInFlightTotalChars += charCount
     recordPtyRendererDeliveryPressure(id)
-    mainWindow.webContents.send('pty:data', payload)
+    try {
+      mainWindow.webContents.send('pty:data', payload)
+    } catch (error) {
+      const current = rendererDeliveryAccountingByPty.get(id)
+      if (current) {
+        const inFlightBeforeRollback = current.sentChars - current.ackedChars
+        current.sentChars = Math.max(0, current.sentChars - charCount)
+        current.ackedChars = Math.min(current.ackedChars, current.sentChars)
+        const inFlightAfterRollback = current.sentChars - current.ackedChars
+        rendererInFlightTotalChars = Math.max(
+          0,
+          rendererInFlightTotalChars - (inFlightBeforeRollback - inFlightAfterRollback)
+        )
+        if (!hadAccounting && current.sentChars === 0) {
+          rendererDeliveryAccountingByPty.delete(id)
+        }
+      }
+      rendererDeliveryRestoreNeededPtys.add(id)
+      mainDeliveryBreadcrumbs.record('pty-data-send-failed', {
+        id: redactPtyIdForDiagnostics(id),
+        chars: charCount
+      })
+      console.error('[pty] renderer data send failed; payload will not be retried', error)
+      return false
+    }
+    if (rendererDeliveryRestoreNeededPtys.has(id)) {
+      try {
+        sendModelRestoreNeededMarker(id, 'delivery-heal', runtime?.getPtyOutputSequence(id))
+        rendererDeliveryRestoreNeededPtys.delete(id)
+      } catch (error) {
+        console.error(
+          '[pty] renderer delivery-heal marker send failed; restore remains pending',
+          error
+        )
+      }
+    }
+    return true
   }
 
   function rendererPtyIsKnownHidden(id: string): boolean {
@@ -2428,10 +2462,9 @@ export function registerPtyHandlers(
   }
 
   function invalidatePendingPtyDrainClassification(id?: string, schedule = true): void {
-    if (typeof id === 'string' && pendingData.get(id) === undefined) {
-      return
-    }
-    if (pendingData.invalidateAll() && schedule && !flushTimer) {
+    const invalidated =
+      typeof id === 'string' ? pendingData.invalidate(id) : pendingData.invalidateAll()
+    if (invalidated && schedule && !flushTimer) {
       schedulePendingDataFlush(0)
     }
   }
@@ -2480,6 +2513,7 @@ export function registerPtyHandlers(
     // Ordinary boot-window data is blocked in the queue; hidden-droppable entries still retire before renderer readiness.
     const settings = getSettings?.()
     let writes = 0
+    let sendFailed = false
     const round = pendingData.beginRound()
     let creditReleasedDuringFlush = false
     pendingDataFlushActive = true
@@ -2511,7 +2545,10 @@ export function registerPtyHandlers(
           pendingData.remove(selection)
           updateProducerFlowControl(id)
           // Why droppedOutput sentinel: pending-cap drop means the pane must repaint from the snapshot, not continue a gapped stream (data = carved query bytes only).
-          sendPtyDataToRenderer(id, { id, data: pending.data, droppedOutput: true })
+          if (!sendPtyDataToRenderer(id, { id, data: pending.data, droppedOutput: true })) {
+            sendFailed = true
+            break
+          }
           writes++
           continue
         }
@@ -2533,17 +2570,22 @@ export function registerPtyHandlers(
           pendingOverflowMarkedPtys.delete(id)
         }
         updateProducerFlowControl(id)
-        sendPtyDataToRenderer(
-          id,
-          makePtyDataPayload(
+        if (
+          !sendPtyDataToRenderer(
             id,
-            chunk,
-            pending.startSeq,
-            pending.containsBackgroundOutput,
-            pending.rawLength,
-            pending.transformed
+            makePtyDataPayload(
+              id,
+              chunk,
+              pending.startSeq,
+              pending.containsBackgroundOutput,
+              pending.rawLength,
+              pending.transformed
+            )
           )
-        )
+        ) {
+          sendFailed = true
+          break
+        }
         writes++
       }
     } finally {
@@ -2552,10 +2594,17 @@ export function registerPtyHandlers(
       pendingDataCreditReleasedDuringFlush = false
       pendingData.endRound(round)
     }
-    if (rendererPtyDispatcherReady && pendingData.size > 0 && writes === 0) {
+    if (rendererPtyDispatcherReady && pendingData.size > 0 && writes === 0 && !sendFailed) {
       ackGatedFlushSkipCount++
     }
-    recordPtyRendererDeliveryPressure()
+    if (sendFailed && pendingData.size > 0) {
+      if (flushTimer) {
+        clearTimeout(flushTimer)
+        flushTimer = null
+      }
+      schedulePendingDataFlush(PTY_BATCH_DRAIN_CONTINUE_MS)
+      return
+    }
     if (pendingData.size > 0 && (writes > 0 || creditReleasedDuringFlush)) {
       // Why yield between slices: a background terminal can dump megabytes at once, and keystroke writes must not stall behind one flush.
       schedulePendingDataFlush(writes > 0 ? PTY_BATCH_DRAIN_CONTINUE_MS : 0)
@@ -2634,6 +2683,7 @@ export function registerPtyHandlers(
       // Why resume a dead PTY (no-op): avoid leaving a stale paused mark behind for a reused id.
       producerFlowControl.release(payload.id)
       pendingOverflowMarkedPtys.delete(payload.id)
+      rendererDeliveryRestoreNeededPtys.delete(payload.id)
       lastInputAtByPty.delete(payload.id)
       interactiveOutputCharsByPty.delete(payload.id)
       const releasedRendererCredit = getRendererInFlightCharsForPty(payload.id)
@@ -2649,7 +2699,6 @@ export function registerPtyHandlers(
           schedulePendingDataAfterCreditReport(true)
         }
       }
-      recordPtyRendererDeliveryPressure()
       mainWindow.webContents.send('pty:exit', {
         ...payload,
         ...(reversibleStopOwnersByPtyId.has(payload.id) ? { preserveRendererBinding: true } : {})
@@ -2792,16 +2841,15 @@ export function registerPtyHandlers(
       if (isInteractiveOutput && rendererPtyDispatcherReady) {
         // Why the reserve: keep input echo from being pinned behind unrelated bulk output; it's bounded and the per-PTY cap still prevents an active TUI runaway.
         if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
-          pendingData.set(payload.id, pending)
+          setPendingPtyData(payload.id, pending)
           if (shouldEmitPendingCapRestoreMarker) {
             sendModelRestoreNeededMarker(payload.id, 'pending-cap', outputSeq)
           }
           updateProducerFlowControl(payload.id)
-          recordPtyRendererDeliveryPressure()
           requestDeliveryResyncForGatedPty()
           return
         }
-        pendingData.delete(payload.id)
+        deletePendingPtyData(payload.id)
         clearFlushTimerIfIdle()
         if (shouldEmitPendingCapRestoreMarker) {
           sendModelRestoreNeededMarker(payload.id, 'pending-cap', outputSeq)
@@ -2827,7 +2875,7 @@ export function registerPtyHandlers(
         }
         return
       }
-      pendingData.set(payload.id, pending)
+      setPendingPtyData(payload.id, pending)
       if (shouldEmitPendingCapRestoreMarker) {
         sendModelRestoreNeededMarker(payload.id, 'pending-cap', outputSeq)
       }
@@ -5150,7 +5198,6 @@ export function registerPtyHandlers(
         acknowledged = accounting ? applyCumulativeAck(args.id, accounting.ackedChars + delta) : 0
       }
       tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, acknowledged)
-      recordPtyRendererDeliveryPressure()
       schedulePendingDataAfterCreditReport(acknowledged > 0)
     }
   )
@@ -5178,7 +5225,6 @@ export function registerPtyHandlers(
           tryGetProviderForPty(id)?.acknowledgeDataEvent(id, acknowledged)
         }
       }
-      recordPtyRendererDeliveryPressure()
       schedulePendingDataAfterCreditReport(creditedAny)
     }
   )
@@ -5210,7 +5256,6 @@ export function registerPtyHandlers(
         writtenOff = writeOffLostRendererDelivery(args)
         creditedAny ||= writtenOff.length > 0
       }
-      recordPtyRendererDeliveryPressure()
       schedulePendingDataAfterCreditReport(creditedAny)
       let inFlightPtyCount = 0
       for (const accounting of rendererDeliveryAccountingByPty.values()) {


### PR DESCRIPTION
## Description

- Replace the main-process local/daemon PTY renderer-delivery drain's per-flush `Map` snapshot and active/background partition with a map-backed intrusive queue.
- Keep one node per pending PTY across active, background, and ACK-blocked lanes while preserving authoritative `Map` order, active-first priority, two writes per flush, 16 KiB slicing, sequence metadata, hidden-output policy, renderer-credit gating, producer flow control, and final queued data before exit.
- Move pending-character accounting into the queue owner so enqueue, partial replacement, deletion, exit, and clear update the data, links, and total atomically.
- Harden synchronous reentrancy and lifecycle cleanup across renderer reload/crash, destroyed windows, provider teardown, active/hidden/interest changes, ACK/resync/heal/writeoff, partial drains, sentinels, exits, clears, and synchronous send failure.
- Leave relay and direct-SSH delivery code unchanged.

## ELI5

The old drain reread and reorganized the whole waiting list every time it was allowed to send two terminal chunks. The new drain keeps that waiting list organized as data arrives, so each flush can take the next eligible entries directly. It still uses the same two-chunk limit, timer cadence, ordering, credit checks, and exit behavior.

## Proof of zero regression

- Four adversarial design rounds with **GPT-5.6-Sol xhigh** and **Fable xhigh** ended `CLEAN`. The resulting design fixes queue/accounting ownership, live active reserves, round frontiers, settings invalidation, writeoff/credit wakeups, send-failure rollback, final-exit fencing, and cleanup before implementation approval.
- Adversarial implementation loops with both requested models ended `CLEAN`. GPT-5.6-Sol reviewed the implementation and its byte-identical rebase `CLEAN`; Fable also returned `CLEAN` on final exact head `ffc412ac73`. Together the reviews covered queue links and ownership, `Map` ordering, active/background/blocked transitions, ACK/resync/heal/writeoff recovery, hidden/readiness/settings gates, producer flow control, synchronous reentrancy, timers, send failures, exits, lifecycle cleanup, local/daemon/WSL integration, and unchanged relay/direct-SSH delivery.
- Final reviewed head `ffc412ac73` over base `559f04d297` is byte-equivalent to the prior reviewed implementation: both commits are `=` under `git range-diff`; binary diff SHA-256 is `530edc27644b040f8bf5a3d0ee51fab74a0574c9c6576840faf83cfd2e0a19cc`; stable patch ID is `410d00dde613f146b467eca3f83a6363c38d5b6d`.
- Frozen legacy-vs-queue differential oracles cover enqueue/update, partial drain, active priority, ACK gating and credit, hidden-interest changes, dropped sentinels, exits, clears, timer decisions, synchronous notification reentrancy, queue/accounting invariants, and bounded node churn.
- Focused four-file suite: **381 passed; 7 failed**. Related 20-file local/daemon/relay/SSH/renderer-credit slice: **744 passed, 6 skipped; 7 failed**. The exact seven failures are stale PowerShell spawn-argument fixtures and reproduce on untouched base `9ced27eca8` (**335 passed; the same 7 failed**).
- Full repository suite on final head: **3,327 files passed, 8 skipped, 4 failed; 35,478 tests passed, 60 skipped, 13 failed**. The seven PowerShell failures above and all six additional failures reproduce on untouched base behavior: five fail in isolated clean-base runs, and the sixth is a same-file mock-state leak that reproduces in the same clean-base combined run. The clean-base three-file reproduction matched all six exactly (**910 passed; the same 6 failed**).
- Fresh GitHub checks: **Windows terminal restart passed** and **packaged Windows crash-survival passed**. `verify` completed **35,507 passed, 84 skipped, 13 failed**; its failed-test names are exactly the same 13 clean-base-attributed tests above, with no drain-queue or differential-oracle failure.
- Full Node/CLI/web TypeScript check, touched ordinary and type-aware lint, formatting, max-lines ratchet, and `git diff --check` passed. No max-lines bypass, threshold bump, or lint configuration change was added.
- Full `pnpm run lint` passed repository Oxlint, type-aware lint, styled-scrollbar checks, 48 reliability gates, max-lines, and bundled-guide verification, then stopped at the pre-existing released `orca-cli` revision-9 append-only manifest error.
- Main drift adjacent to provider shutdown was reviewed explicitly: local provider data remains live until physical `onExit`, final pending data still precedes `pty:exit`, daemon changes are spawn-only, WSL PTY routing is unchanged, and relay/direct SSH continue to bypass this queue.

## Proof of performance improvement

A deterministic production-limit oracle preloads **100 simultaneously pending, runnable, one-chunk PTYs** before the first flush and drains at the existing maximum of two writes per flush.

- Legacy snapshot selection: **2,550 pending-selection candidate visits** (`100 + 98 + ... + 2`).
- Intrusive queue selection: **100 selected-node visits**.
- Scheduled flush callbacks: **exactly 50 in both models** — one initial 2 ms flush and 49 one-ms continuations.
- The merged pending-character diagnostic path performs **zero full-map scans** during ACK updates; queue totals are checked against independent recomputation throughout the differential trace.

This claim is intentionally limited to selection traversal and pending-byte scan elimination for that main-process local/daemon workload. It does not claim measured wall-time, CPU, battery/power, OS wakeup, latency, throughput, memory, relay, or direct-SSH improvement; enqueue work and rare priority/policy invalidation relinks are outside the measured visit count.
