### PR TITLE
fix(terminal): confirm running process on tab X / middle-click close

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -204,6 +204,7 @@ import { resolveMountedLazyModalIds, type LazyModalId } from './lazy-modal-mount
 import { translate } from '@/i18n/i18n'
 import PinnedTabCloseDialog from './components/terminal-pane/PinnedTabCloseDialog'
 import { useOsc52ClipboardDefaultOnNotice } from './components/terminal-pane/osc52-clipboard-default-on-notice'
+import RunningTerminalCloseDialog from './components/terminal-pane/RunningTerminalCloseDialog'
 import {
   hasRequestedBackgroundTerminalWorktreeMount,
   subscribeBackgroundTerminalWorktreeMountRequests
@@ -2741,6 +2742,7 @@ function App(): React.JSX.Element {
       <Toaster closeButton toastOptions={{ className: 'font-sans text-sm' }} />
       <SkillFreshnessNudge />
       <PinnedTabCloseDialog />
+      <RunningTerminalCloseDialog />
       {/* Why: Electron's drag-region hit-test is DOM-order-based (ignores z-index); render last so WindowControls stay clickable. */}
       {hasCustomTitleBar && <WindowControls />}
     </div>

--- a/src/renderer/src/components/terminal-pane/RunningTerminalCloseDialog.tsx
+++ b/src/renderer/src/components/terminal-pane/RunningTerminalCloseDialog.tsx
@@ -1,0 +1,25 @@
+import { useAppStore } from '@/store'
+import CloseTerminalDialog from './CloseTerminalDialog'
+
+/** Store-driven running-process close confirm so tab X / middle-click / Cmd+W
+ *  share one policy without threading React context through every close path. */
+export default function RunningTerminalCloseDialog(): React.JSX.Element {
+  const request = useAppStore((state) => state.runningTerminalCloseConfirm)
+  const confirmRunningTerminalClose = useAppStore((state) => state.confirmRunningTerminalClose)
+  const dismissRunningTerminalClose = useAppStore((state) => state.dismissRunningTerminalClose)
+  const updateSettings = useAppStore((state) => state.updateSettings)
+
+  return (
+    <CloseTerminalDialog
+      open={request !== null}
+      copyKind={request?.copyKind ?? 'command'}
+      onCancel={dismissRunningTerminalClose}
+      onConfirm={(dontAskAgain) => {
+        if (dontAskAgain) {
+          void updateSettings({ skipCloseTerminalWithRunningProcessConfirm: true })
+        }
+        confirmRunningTerminalClose()
+      }}
+    />
+  )
+}

--- a/src/renderer/src/components/terminal-pane/RunningTerminalCloseDialog.tsx
+++ b/src/renderer/src/components/terminal-pane/RunningTerminalCloseDialog.tsx
@@ -17,6 +17,8 @@ export default function RunningTerminalCloseDialog(): React.JSX.Element {
       onConfirm={(dontAskAgain) => {
         if (dontAskAgain) {
           void updateSettings({ skipCloseTerminalWithRunningProcessConfirm: true })
+          confirmRunningTerminalClose({ drainQueue: true })
+          return
         }
         confirmRunningTerminalClose()
       }}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -5,7 +5,6 @@ import { createPortal } from 'react-dom'
 import type { CSSProperties } from 'react'
 import type { IDisposable } from '@xterm/xterm'
 import { useAppStore } from '../../store'
-import { isUnifiedTabPinned } from '@/store/pinned-tab-close-guard'
 import { useLinkRoutingPreferenceDialog } from '@/components/link-routing-preference-dialog'
 import { DaemonActionDialog, useDaemonActions } from '@/components/shared/useDaemonActions'
 import {
@@ -1286,15 +1285,12 @@ export default function TerminalPane({
 
   const handleRequestClosePane = useCallback(
     (paneId: number) => {
-      // Why: closing the last pane of a pinned tab prefers the pin dialog over the running-process prompt; non-pinned tabs keep the process prompt.
+      // Why: last-pane close is whole-tab close — pin + running-process confirm
+      // live in closeTerminalTab so X / middle-click / Cmd+W share one policy.
       const isLastPane = (managerRef.current?.getPanes().length ?? 0) <= 1
       if (isLastPane) {
-        const state = useAppStore.getState()
-        const confirmPinned = state.settings?.confirmClosePinnedTab ?? true
-        if (confirmPinned && isUnifiedTabPinned(state, worktreeId, tabId)) {
-          executeClosePane(paneId)
-          return
-        }
+        executeClosePane(paneId)
+        return
       }
       const transport = paneTransportsRef.current.get(paneId)
       const ptyId = transport?.getPtyId()
@@ -1314,7 +1310,7 @@ export default function TerminalPane({
         // Why: if the child-process probe rejects (wedged IPC, legacy provider), close anyway — Cmd+W doing nothing is worse than closing a pane with a child.
         .catch(() => executeClosePane(paneId))
     },
-    [executeClosePane, tabId, worktreeId, getCloseDialogCopyKind]
+    [executeClosePane, getCloseDialogCopyKind]
   )
 
   const handleSearchSelectedText = useCallback((selectedText: string): void => {

--- a/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.test.ts
@@ -6,6 +6,7 @@ const {
   createWebRuntimeSessionTerminalMock,
   getLatestWebSessionTabsPublicationEpochMock,
   getStateMock,
+  inspectRuntimeTerminalProcessMock,
   isWebRuntimeSessionActiveMock,
   isWebTerminalSurfaceTabIdMock,
   resolveHostSessionTabIdForWebSessionTabMock,
@@ -16,6 +17,7 @@ const {
   createWebRuntimeSessionTerminalMock: vi.fn(),
   getLatestWebSessionTabsPublicationEpochMock: vi.fn(() => 'epoch-1'),
   getStateMock: vi.fn(),
+  inspectRuntimeTerminalProcessMock: vi.fn(),
   isWebRuntimeSessionActiveMock: vi.fn(),
   isWebTerminalSurfaceTabIdMock: vi.fn(() => false),
   resolveHostSessionTabIdForWebSessionTabMock: vi.fn<() => string | null>(() => null),
@@ -40,6 +42,10 @@ vi.mock('@/runtime/web-runtime-session', () => ({
 vi.mock('@/runtime/web-session-tabs-sync', () => ({
   getLatestWebSessionTabsPublicationEpoch: getLatestWebSessionTabsPublicationEpochMock,
   resolveHostSessionTabIdForWebSessionTab: resolveHostSessionTabIdForWebSessionTabMock
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess: inspectRuntimeTerminalProcessMock
 }))
 
 import {
@@ -717,6 +723,80 @@ describe('closeTerminalTab', () => {
 
     closeTerminalTab('tab-1')
 
+    expect(closeTab).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('requests a running-process confirm for tab X / middle-click closes', async () => {
+    const closeTab = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue({
+      settings: {
+        activeRuntimeEnvironmentId: null,
+        skipCloseTerminalWithRunningProcessConfirm: false
+      },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1' }, { id: 'tab-2' }]
+      },
+      unifiedTabsByWorktree: {},
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      terminalLayoutsByTabId: {},
+      agentStatusByPaneKey: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-2',
+      openFiles: [],
+      browserTabsByWorktree: {},
+      closeTab,
+      setActiveTab: vi.fn(),
+      requestRunningTerminalCloseConfirm
+    })
+    inspectRuntimeTerminalProcessMock.mockResolvedValue({
+      foregroundProcess: 'npm',
+      hasChildProcesses: true
+    })
+
+    closeTerminalTab('tab-1')
+    await vi.waitFor(() => expect(requestRunningTerminalCloseConfirm).toHaveBeenCalledTimes(1))
+
+    expect(closeTab).not.toHaveBeenCalled()
+    expect(requestRunningTerminalCloseConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ copyKind: 'command', onConfirm: expect.any(Function) })
+    )
+
+    const { onConfirm } = requestRunningTerminalCloseConfirm.mock.calls[0][0] as {
+      onConfirm: () => void
+    }
+    onConfirm()
+    expect(closeTab).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('force-closes without inspecting processes after confirmation', () => {
+    const closeTab = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue({
+      settings: {
+        activeRuntimeEnvironmentId: null,
+        skipCloseTerminalWithRunningProcessConfirm: false
+      },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1' }, { id: 'tab-2' }]
+      },
+      unifiedTabsByWorktree: {},
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      terminalLayoutsByTabId: {},
+      agentStatusByPaneKey: {},
+      activeWorktreeId: 'wt-1',
+      activeTabId: 'tab-2',
+      openFiles: [],
+      browserTabsByWorktree: {},
+      closeTab,
+      setActiveTab: vi.fn(),
+      requestRunningTerminalCloseConfirm
+    })
+
+    closeTerminalTab('tab-1', { force: true })
+
+    expect(inspectRuntimeTerminalProcessMock).not.toHaveBeenCalled()
+    expect(requestRunningTerminalCloseConfirm).not.toHaveBeenCalled()
     expect(closeTab).toHaveBeenCalledWith('tab-1')
   })
 })

--- a/src/renderer/src/components/terminal/terminal-tab-actions.ts
+++ b/src/renderer/src/components/terminal/terminal-tab-actions.ts
@@ -12,6 +12,7 @@ import {
 } from '@/runtime/web-session-tabs-sync'
 import { resolveTerminalWorktreeRoute } from '@/lib/terminal-worktree-route'
 import { guardPinnedTabClose, resolvePinnedTabLabel } from '@/store/pinned-tab-close-guard'
+import { guardRunningTerminalClose } from '@/store/running-terminal-close-guard'
 import type {
   TerminalTabCloseReason,
   TerminalTabRetirementPlan
@@ -95,6 +96,17 @@ export function closeTerminalTab(
     guardPinnedTabClose({
       isPinned: true,
       tabLabel: resolvePinnedTabLabel(state, owningWorktreeId, terminalTabId),
+      onClose: () => closeTerminalTab(tabId, { ...options, force: true }),
+      ...(options?.onCancel ? { onCancel: options.onCancel } : {})
+    })
+    return
+  }
+
+  // Why: tab X / middle-click must share Cmd+W's running-process confirm. Pin
+  // already took precedence above; `force` skips this after either dialog.
+  if (options?.reason !== 'pty-exit' && !options?.force) {
+    guardRunningTerminalClose({
+      tabId: terminalTabId,
       onClose: () => closeTerminalTab(tabId, { ...options, force: true }),
       ...(options?.onCancel ? { onCancel: options.onCancel } : {})
     })

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -36,6 +36,7 @@ import { createRuntimeStatusSlice } from './slices/runtime-status'
 import { createPullRequestGenerationSlice } from './slices/pull-request-generation'
 import { createCommitMessageGenerationSlice } from './slices/commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-confirm'
+import { createRunningTerminalCloseConfirmSlice } from './slices/running-terminal-close-confirm'
 import { createRecentlyClosedTabsSlice } from './slices/recently-closed-tabs'
 import { createOrcaProfilesSlice } from './slices/orca-profiles'
 import { createNewIssueDraftSlice } from './slices/new-issue-draft'
@@ -89,6 +90,7 @@ export const useAppStore = create<AppState>()((...a) => {
     ...createPullRequestGenerationSlice(...a),
     ...createCommitMessageGenerationSlice(...a),
     ...createPinnedTabCloseConfirmSlice(...a),
+    ...createRunningTerminalCloseConfirmSlice(...a),
     ...createRecentlyClosedTabsSlice(...a),
     ...createOrcaProfilesSlice(...a),
     ...createNewIssueDraftSlice(...a),

--- a/src/renderer/src/store/running-terminal-close-guard.test.ts
+++ b/src/renderer/src/store/running-terminal-close-guard.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getStateMock, inspectRuntimeTerminalProcessMock } = vi.hoisted(() => ({
+  getStateMock: vi.fn(),
+  inspectRuntimeTerminalProcessMock: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: getStateMock
+  }
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  inspectRuntimeTerminalProcess: inspectRuntimeTerminalProcessMock
+}))
+
+import {
+  collectTabPtyIds,
+  guardRunningTerminalClose,
+  resolveTabCloseDialogCopyKind
+} from './running-terminal-close-guard'
+import type { AppState } from './types'
+
+function makeState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    settings: { skipCloseTerminalWithRunningProcessConfirm: false },
+    ptyIdsByTabId: {},
+    terminalLayoutsByTabId: {},
+    agentStatusByPaneKey: {},
+    requestRunningTerminalCloseConfirm: vi.fn(),
+    ...overrides
+  } as unknown as AppState
+}
+
+describe('collectTabPtyIds', () => {
+  it('prefers ptyIdsByTabId when present', () => {
+    expect(
+      collectTabPtyIds(
+        {
+          ptyIdsByTabId: { 'tab-1': ['pty-a', 'pty-b'] },
+          terminalLayoutsByTabId: {
+            'tab-1': { ptyIdsByLeafId: { leaf: 'pty-layout' } }
+          }
+        } as never,
+        'tab-1'
+      )
+    ).toEqual(['pty-a', 'pty-b'])
+  })
+
+  it('falls back to layout bindings when the map is empty', () => {
+    expect(
+      collectTabPtyIds(
+        {
+          ptyIdsByTabId: { 'tab-1': [] },
+          terminalLayoutsByTabId: {
+            'tab-1': { ptyIdsByLeafId: { leaf: 'pty-layout', empty: null } }
+          }
+        } as never,
+        'tab-1'
+      )
+    ).toEqual(['pty-layout'])
+  })
+})
+
+describe('resolveTabCloseDialogCopyKind', () => {
+  it('returns agent when any pane on the tab has a known agent', () => {
+    expect(
+      resolveTabCloseDialogCopyKind(
+        {
+          agentStatusByPaneKey: {
+            'tab-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee': { agentType: 'claude' },
+            'other:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee': { agentType: 'codex' }
+          }
+        } as never,
+        'tab-1'
+      )
+    ).toBe('agent')
+  })
+
+  it('returns command when no known agent is present', () => {
+    expect(
+      resolveTabCloseDialogCopyKind(
+        {
+          agentStatusByPaneKey: {
+            'tab-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee': { agentType: 'unknown' }
+          }
+        } as never,
+        'tab-1'
+      )
+    ).toBe('command')
+  })
+})
+
+describe('guardRunningTerminalClose', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('closes immediately when the skip setting is on', () => {
+    const onClose = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue(
+      makeState({
+        settings: { skipCloseTerminalWithRunningProcessConfirm: true } as AppState['settings'],
+        requestRunningTerminalCloseConfirm
+      })
+    )
+
+    guardRunningTerminalClose({ tabId: 'tab-1', onClose })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(requestRunningTerminalCloseConfirm).not.toHaveBeenCalled()
+    expect(inspectRuntimeTerminalProcessMock).not.toHaveBeenCalled()
+  })
+
+  it('closes immediately when the tab has no live PTYs', () => {
+    const onClose = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue(makeState({ requestRunningTerminalCloseConfirm }))
+
+    guardRunningTerminalClose({ tabId: 'tab-1', onClose })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(requestRunningTerminalCloseConfirm).not.toHaveBeenCalled()
+  })
+
+  it('requests confirmation when a child process is running', async () => {
+    const onClose = vi.fn()
+    const onCancel = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue(
+      makeState({
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        agentStatusByPaneKey: {
+          'tab-1:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee': { agentType: 'claude' }
+        },
+        requestRunningTerminalCloseConfirm
+      })
+    )
+    inspectRuntimeTerminalProcessMock.mockResolvedValue({
+      foregroundProcess: 'claude',
+      hasChildProcesses: true
+    })
+
+    guardRunningTerminalClose({ tabId: 'tab-1', onClose, onCancel })
+    await vi.waitFor(() => expect(requestRunningTerminalCloseConfirm).toHaveBeenCalledTimes(1))
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(requestRunningTerminalCloseConfirm).toHaveBeenCalledWith({
+      copyKind: 'agent',
+      onConfirm: onClose,
+      onCancel
+    })
+  })
+
+  it('closes without confirmation when no child processes are running', async () => {
+    const onClose = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue(
+      makeState({
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        requestRunningTerminalCloseConfirm
+      })
+    )
+    inspectRuntimeTerminalProcessMock.mockResolvedValue({
+      foregroundProcess: 'zsh',
+      hasChildProcesses: false
+    })
+
+    guardRunningTerminalClose({ tabId: 'tab-1', onClose })
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+
+    expect(requestRunningTerminalCloseConfirm).not.toHaveBeenCalled()
+  })
+
+  it('closes when the process probe rejects', async () => {
+    const onClose = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue(
+      makeState({
+        ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+        requestRunningTerminalCloseConfirm
+      })
+    )
+    inspectRuntimeTerminalProcessMock.mockRejectedValue(new Error('wedged'))
+
+    guardRunningTerminalClose({ tabId: 'tab-1', onClose })
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+
+    expect(requestRunningTerminalCloseConfirm).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/store/running-terminal-close-guard.test.ts
+++ b/src/renderer/src/store/running-terminal-close-guard.test.ts
@@ -190,4 +190,45 @@ describe('guardRunningTerminalClose', () => {
 
     expect(requestRunningTerminalCloseConfirm).not.toHaveBeenCalled()
   })
+
+  it('still confirms when one PTY probe fails and another has a child process', async () => {
+    const onClose = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue(
+      makeState({
+        ptyIdsByTabId: { 'tab-1': ['pty-wedged', 'pty-running'] },
+        requestRunningTerminalCloseConfirm
+      })
+    )
+    inspectRuntimeTerminalProcessMock.mockImplementation(async (_settings, ptyId: string) => {
+      if (ptyId === 'pty-wedged') {
+        throw new Error('wedged')
+      }
+      return { foregroundProcess: 'npm', hasChildProcesses: true }
+    })
+
+    guardRunningTerminalClose({ tabId: 'tab-1', onClose })
+    await vi.waitFor(() => expect(requestRunningTerminalCloseConfirm).toHaveBeenCalledTimes(1))
+
+    expect(onClose).not.toHaveBeenCalled()
+    expect(inspectRuntimeTerminalProcessMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('closes when every multi-PTY probe rejects', async () => {
+    const onClose = vi.fn()
+    const requestRunningTerminalCloseConfirm = vi.fn()
+    getStateMock.mockReturnValue(
+      makeState({
+        ptyIdsByTabId: { 'tab-1': ['pty-a', 'pty-b'] },
+        requestRunningTerminalCloseConfirm
+      })
+    )
+    inspectRuntimeTerminalProcessMock.mockRejectedValue(new Error('wedged'))
+
+    guardRunningTerminalClose({ tabId: 'tab-1', onClose })
+    await vi.waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+
+    expect(requestRunningTerminalCloseConfirm).not.toHaveBeenCalled()
+    expect(inspectRuntimeTerminalProcessMock).toHaveBeenCalledTimes(2)
+  })
 })

--- a/src/renderer/src/store/running-terminal-close-guard.ts
+++ b/src/renderer/src/store/running-terminal-close-guard.ts
@@ -39,7 +39,9 @@ export function resolveTabCloseDialogCopyKind(
 /**
  * Routes a tab close through the running-process confirmation when any child
  * process is still live. Idle tabs (and the "don't ask again" setting) close
- * immediately. Async inspect failures close rather than strand the tab.
+ * immediately. Per-PTY inspect failures are treated as idle so one wedged
+ * probe cannot suppress confirmation for another still-running process; if
+ * no successful probe reports children, close rather than strand the tab.
  */
 export function guardRunningTerminalClose(params: {
   tabId: string
@@ -60,9 +62,13 @@ export function guardRunningTerminalClose(params: {
   }
 
   const settings = state.settings
-  void Promise.all(ptyIds.map((ptyId) => inspectRuntimeTerminalProcess(settings, ptyId)))
-    .then((inspections) => {
-      if (!inspections.some((process) => process.hasChildProcesses)) {
+  // allSettled: one rejected inspect must not short-circuit siblings via Promise.all.
+  void Promise.allSettled(ptyIds.map((ptyId) => inspectRuntimeTerminalProcess(settings, ptyId)))
+    .then((results) => {
+      const hasRunningChild = results.some(
+        (result) => result.status === 'fulfilled' && result.value.hasChildProcesses
+      )
+      if (!hasRunningChild) {
         onClose()
         return
       }
@@ -77,7 +83,7 @@ export function guardRunningTerminalClose(params: {
         ...(onCancel ? { onCancel } : {})
       })
     })
-    // Why: wedged IPC / legacy providers must not leave Cmd+W / X unresponsive.
+    // Why: unexpected handler errors must not leave Cmd+W / X unresponsive.
     .catch(() => {
       onClose()
     })

--- a/src/renderer/src/store/running-terminal-close-guard.ts
+++ b/src/renderer/src/store/running-terminal-close-guard.ts
@@ -1,0 +1,84 @@
+import { inspectRuntimeTerminalProcess } from '@/runtime/runtime-terminal-inspection'
+import { useAppStore } from '@/store'
+import type { AppState } from './types'
+import type { RunningTerminalCloseDialogCopyKind } from './slices/running-terminal-close-confirm'
+
+/** Live PTY ids owned by a terminal tab (store map, with layout fallback). */
+export function collectTabPtyIds(
+  state: Pick<AppState, 'ptyIdsByTabId' | 'terminalLayoutsByTabId'>,
+  tabId: string
+): string[] {
+  const fromMap = state.ptyIdsByTabId?.[tabId] ?? []
+  if (fromMap.length > 0) {
+    return fromMap
+  }
+  const layout = state.terminalLayoutsByTabId?.[tabId]
+  const fromLayout = Object.values(layout?.ptyIdsByLeafId ?? {}).filter(
+    (ptyId): ptyId is string => typeof ptyId === 'string' && ptyId.length > 0
+  )
+  return fromLayout
+}
+
+/** Agent copy when any pane on the tab has a known agent type. */
+export function resolveTabCloseDialogCopyKind(
+  state: Pick<AppState, 'agentStatusByPaneKey'>,
+  tabId: string
+): RunningTerminalCloseDialogCopyKind {
+  const prefix = `${tabId}:`
+  for (const [paneKey, status] of Object.entries(state.agentStatusByPaneKey ?? {})) {
+    if (!paneKey.startsWith(prefix)) {
+      continue
+    }
+    if (status?.agentType && status.agentType !== 'unknown') {
+      return 'agent'
+    }
+  }
+  return 'command'
+}
+
+/**
+ * Routes a tab close through the running-process confirmation when any child
+ * process is still live. Idle tabs (and the "don't ask again" setting) close
+ * immediately. Async inspect failures close rather than strand the tab.
+ */
+export function guardRunningTerminalClose(params: {
+  tabId: string
+  onClose: () => void
+  onCancel?: () => void
+}): void {
+  const { tabId, onClose, onCancel } = params
+  const state = useAppStore.getState()
+  if (state.settings?.skipCloseTerminalWithRunningProcessConfirm) {
+    onClose()
+    return
+  }
+
+  const ptyIds = collectTabPtyIds(state, tabId)
+  if (ptyIds.length === 0) {
+    onClose()
+    return
+  }
+
+  const settings = state.settings
+  void Promise.all(ptyIds.map((ptyId) => inspectRuntimeTerminalProcess(settings, ptyId)))
+    .then((inspections) => {
+      if (!inspections.some((process) => process.hasChildProcesses)) {
+        onClose()
+        return
+      }
+      const latest = useAppStore.getState()
+      if (latest.settings?.skipCloseTerminalWithRunningProcessConfirm) {
+        onClose()
+        return
+      }
+      latest.requestRunningTerminalCloseConfirm({
+        copyKind: resolveTabCloseDialogCopyKind(latest, tabId),
+        onConfirm: onClose,
+        ...(onCancel ? { onCancel } : {})
+      })
+    })
+    // Why: wedged IPC / legacy providers must not leave Cmd+W / X unresponsive.
+    .catch(() => {
+      onClose()
+    })
+}

--- a/src/renderer/src/store/slices/diffComments.test.ts
+++ b/src/renderer/src/store/slices/diffComments.test.ts
@@ -141,6 +141,7 @@ import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
+import { createRunningTerminalCloseConfirmSlice } from './running-terminal-close-confirm'
 import { createRecentlyClosedTabsSlice } from './recently-closed-tabs'
 import { createOrcaProfilesSlice } from './orca-profiles'
 import { createNewIssueDraftSlice } from './new-issue-draft'
@@ -184,6 +185,7 @@ function createTestStore() {
     ...createPullRequestGenerationSlice(...a),
     ...createCommitMessageGenerationSlice(...a),
     ...createPinnedTabCloseConfirmSlice(...a),
+    ...createRunningTerminalCloseConfirmSlice(...a),
     ...createRecentlyClosedTabsSlice(...a),
     ...createOrcaProfilesSlice(...a),
     ...createNewIssueDraftSlice(...a),

--- a/src/renderer/src/store/slices/running-terminal-close-confirm.test.ts
+++ b/src/renderer/src/store/slices/running-terminal-close-confirm.test.ts
@@ -1,0 +1,104 @@
+import { create } from 'zustand'
+import { describe, expect, it, vi } from 'vitest'
+import { createRunningTerminalCloseConfirmSlice } from './running-terminal-close-confirm'
+import type { AppState } from '../types'
+
+function makeStore() {
+  return create<
+    Pick<
+      AppState,
+      | 'runningTerminalCloseConfirm'
+      | 'requestRunningTerminalCloseConfirm'
+      | 'confirmRunningTerminalClose'
+      | 'dismissRunningTerminalClose'
+    >
+  >()((...args) =>
+    createRunningTerminalCloseConfirmSlice(
+      ...(args as Parameters<typeof createRunningTerminalCloseConfirmSlice>)
+    )
+  )
+}
+
+describe('createRunningTerminalCloseConfirmSlice', () => {
+  it('starts with no pending request', () => {
+    expect(makeStore().getState().runningTerminalCloseConfirm).toBeNull()
+  })
+
+  it('stores the pending request when one is requested', () => {
+    const store = makeStore()
+    const onConfirm = vi.fn()
+
+    store.getState().requestRunningTerminalCloseConfirm({ copyKind: 'command', onConfirm })
+
+    expect(store.getState().runningTerminalCloseConfirm).toEqual({
+      copyKind: 'command',
+      onConfirm
+    })
+  })
+
+  it('runs onConfirm and clears the request when confirmed', () => {
+    const store = makeStore()
+    const onConfirm = vi.fn()
+    store.getState().requestRunningTerminalCloseConfirm({ copyKind: 'agent', onConfirm })
+
+    store.getState().confirmRunningTerminalClose()
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(store.getState().runningTerminalCloseConfirm).toBeNull()
+  })
+
+  it('clears the request before running onConfirm so re-entrant closes do not loop', () => {
+    const store = makeStore()
+    const onConfirm = vi.fn(() => {
+      expect(store.getState().runningTerminalCloseConfirm).toBeNull()
+    })
+    store.getState().requestRunningTerminalCloseConfirm({ copyKind: 'command', onConfirm })
+
+    store.getState().confirmRunningTerminalClose()
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('dismisses without running onConfirm and runs onCancel', () => {
+    const store = makeStore()
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+    store.getState().requestRunningTerminalCloseConfirm({
+      copyKind: 'command',
+      onConfirm,
+      onCancel
+    })
+
+    store.getState().dismissRunningTerminalClose()
+
+    expect(onConfirm).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(store.getState().runningTerminalCloseConfirm).toBeNull()
+  })
+
+  it('queues concurrent requests and advances them in request order', () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000)
+    const store = makeStore()
+    const firstConfirm = vi.fn()
+    const secondConfirm = vi.fn()
+    store.getState().requestRunningTerminalCloseConfirm({
+      copyKind: 'command',
+      onConfirm: firstConfirm
+    })
+    store.getState().requestRunningTerminalCloseConfirm({
+      copyKind: 'agent',
+      onConfirm: secondConfirm
+    })
+
+    expect(store.getState().runningTerminalCloseConfirm?.copyKind).toBe('command')
+    store.getState().confirmRunningTerminalClose()
+    expect(firstConfirm).toHaveBeenCalledTimes(1)
+    expect(secondConfirm).not.toHaveBeenCalled()
+    expect(store.getState().runningTerminalCloseConfirm?.copyKind).toBe('agent')
+
+    now.mockReturnValue(1_351)
+    store.getState().confirmRunningTerminalClose()
+    expect(secondConfirm).toHaveBeenCalledTimes(1)
+    expect(store.getState().runningTerminalCloseConfirm).toBeNull()
+  })
+})

--- a/src/renderer/src/store/slices/running-terminal-close-confirm.ts
+++ b/src/renderer/src/store/slices/running-terminal-close-confirm.ts
@@ -1,0 +1,79 @@
+import type { StateCreator } from 'zustand'
+import type { AppState } from '../types'
+
+export type RunningTerminalCloseDialogCopyKind = 'command' | 'agent'
+
+/** Pending confirmation before killing a tab that still has a child process. */
+export type RunningTerminalCloseConfirmRequest = {
+  copyKind: RunningTerminalCloseDialogCopyKind
+  onConfirm: () => void
+  onCancel?: () => void
+}
+
+export type RunningTerminalCloseConfirmSlice = {
+  runningTerminalCloseConfirm: RunningTerminalCloseConfirmRequest | null
+  requestRunningTerminalCloseConfirm: (request: RunningTerminalCloseConfirmRequest) => void
+  confirmRunningTerminalClose: () => void
+  dismissRunningTerminalClose: () => void
+}
+
+export const createRunningTerminalCloseConfirmSlice: StateCreator<
+  AppState,
+  [],
+  [],
+  RunningTerminalCloseConfirmSlice
+> = (set, get) => {
+  const queuedRequests: RunningTerminalCloseConfirmRequest[] = []
+  let nextRequestActionAllowedAt = 0
+  const INTER_REQUEST_ACTION_GUARD_MS = 350
+
+  const advanceRequest = (): boolean => {
+    const next = queuedRequests.shift() ?? null
+    set({ runningTerminalCloseConfirm: next })
+    return next !== null
+  }
+
+  return {
+    runningTerminalCloseConfirm: null,
+
+    requestRunningTerminalCloseConfirm: (request) => {
+      if (get().runningTerminalCloseConfirm) {
+        // Why: bulk/rapid closes can request multiple confirmations; queue so a
+        // replacement cannot strand an earlier tab's cleanup callbacks.
+        queuedRequests.push(request)
+        return
+      }
+      set({ runningTerminalCloseConfirm: request })
+    },
+
+    confirmRunningTerminalClose: () => {
+      if (Date.now() < nextRequestActionAllowedAt) {
+        return
+      }
+      const request = get().runningTerminalCloseConfirm
+      if (!request) {
+        return
+      }
+      // Why: advance before onConfirm so re-entrant closes queue behind the next
+      // real request instead of seeing the stale one.
+      if (advanceRequest()) {
+        nextRequestActionAllowedAt = Date.now() + INTER_REQUEST_ACTION_GUARD_MS
+      }
+      request.onConfirm()
+    },
+
+    dismissRunningTerminalClose: () => {
+      if (Date.now() < nextRequestActionAllowedAt) {
+        return
+      }
+      const request = get().runningTerminalCloseConfirm
+      if (!request) {
+        return
+      }
+      if (advanceRequest()) {
+        nextRequestActionAllowedAt = Date.now() + INTER_REQUEST_ACTION_GUARD_MS
+      }
+      request.onCancel?.()
+    }
+  }
+}

--- a/src/renderer/src/store/slices/running-terminal-close-confirm.ts
+++ b/src/renderer/src/store/slices/running-terminal-close-confirm.ts
@@ -13,7 +13,7 @@ export type RunningTerminalCloseConfirmRequest = {
 export type RunningTerminalCloseConfirmSlice = {
   runningTerminalCloseConfirm: RunningTerminalCloseConfirmRequest | null
   requestRunningTerminalCloseConfirm: (request: RunningTerminalCloseConfirmRequest) => void
-  confirmRunningTerminalClose: () => void
+  confirmRunningTerminalClose: (options?: { drainQueue?: boolean }) => void
   dismissRunningTerminalClose: () => void
 }
 
@@ -46,12 +46,22 @@ export const createRunningTerminalCloseConfirmSlice: StateCreator<
       set({ runningTerminalCloseConfirm: request })
     },
 
-    confirmRunningTerminalClose: () => {
+    confirmRunningTerminalClose: (options) => {
       if (Date.now() < nextRequestActionAllowedAt) {
         return
       }
       const request = get().runningTerminalCloseConfirm
       if (!request) {
+        return
+      }
+      if (options?.drainQueue) {
+        // Why: "Don't ask again" already passed the settings guard for queued
+        // requests — finish them all without showing more dialogs (#10167).
+        set({ runningTerminalCloseConfirm: null })
+        const drained = [request, ...queuedRequests.splice(0, queuedRequests.length)]
+        for (const entry of drained) {
+          entry.onConfirm()
+        }
         return
       }
       // Why: advance before onConfirm so re-entrant closes queue behind the next

--- a/src/renderer/src/store/slices/store-test-helpers.ts
+++ b/src/renderer/src/store/slices/store-test-helpers.ts
@@ -44,6 +44,7 @@ import { createRuntimeStatusSlice } from './runtime-status'
 import { createPullRequestGenerationSlice } from './pull-request-generation'
 import { createCommitMessageGenerationSlice } from './commit-message-generation'
 import { createPinnedTabCloseConfirmSlice } from './pinned-tab-close-confirm'
+import { createRunningTerminalCloseConfirmSlice } from './running-terminal-close-confirm'
 import { createRecentlyClosedTabsSlice } from './recently-closed-tabs'
 import { createOrcaProfilesSlice } from './orca-profiles'
 import { createNewIssueDraftSlice } from './new-issue-draft'
@@ -96,6 +97,7 @@ export function createTestStore() {
     ...createPullRequestGenerationSlice(...a),
     ...createCommitMessageGenerationSlice(...a),
     ...createPinnedTabCloseConfirmSlice(...a),
+    ...createRunningTerminalCloseConfirmSlice(...a),
     ...createRecentlyClosedTabsSlice(...a),
     ...createOrcaProfilesSlice(...a),
     ...createNewIssueDraftSlice(...a),

--- a/src/renderer/src/store/types.ts
+++ b/src/renderer/src/store/types.ts
@@ -34,6 +34,7 @@ import type { RuntimeStatusSlice } from './slices/runtime-status'
 import type { PullRequestGenerationSlice } from './slices/pull-request-generation'
 import type { CommitMessageGenerationSlice } from './slices/commit-message-generation'
 import type { PinnedTabCloseConfirmSlice } from './slices/pinned-tab-close-confirm'
+import type { RunningTerminalCloseConfirmSlice } from './slices/running-terminal-close-confirm'
 import type { RecentlyClosedTabsSlice } from './slices/recently-closed-tabs'
 import type { OrcaProfilesSlice } from './slices/orca-profiles'
 import type { NewIssueDraftSlice } from './slices/new-issue-draft'
@@ -75,6 +76,7 @@ export type AppState = RepoSlice &
   PullRequestGenerationSlice &
   CommitMessageGenerationSlice &
   PinnedTabCloseConfirmSlice &
+  RunningTerminalCloseConfirmSlice &
   RecentlyClosedTabsSlice &
   OrcaProfilesSlice &
   NewIssueDraftSlice &


### PR DESCRIPTION
## Summary

- Tab strip **X** and **middle-click** previously called `closeTerminalTab` and skipped the running-process confirm that **Cmd+W** shows via `CloseTerminalDialog`.
- Add a store-driven confirm (same copy as the pane dialog) on `closeTerminalTab`, after the pin guard. Confirm re-enters with `force` so pin/process do not double-prompt.
- Last-pane Cmd+W now closes through `closeTerminalTab` so keyboard / X / middle-click share one policy. Split-pane Cmd+W still uses the existing per-pane dialog.

Fixes #10142

## Test plan

- [x] Unit: `running-terminal-close-guard`, slice, `closeTerminalTab` process confirm + force skip, kill-all force path
- [ ] Manual: start `sleep 100` (or agent) in a tab → Cmd+W shows confirm → cancel → X should show same confirm → cancel → middle-click should show same confirm
- [ ] Manual: idle shell → X / middle-click close immediately (no dialog)
- [ ] Manual: pinned tab with running process → pin dialog first; after pin confirm with force, no second process prompt
- [ ] Manual: "Don't ask again" persists `skipCloseTerminalWithRunningProcessConfirm`

## ELI5

Closing a terminal with the tab X or middle-click skipped the running-process confirm that Cmd+W shows. X, middle-click, and last-pane Cmd+W now share the same confirm so you do not kill long jobs by accident.
