### PR TITLE
fix(editor): preserve PDF zoom when file content reloads

### DIFF
--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -17,12 +17,18 @@ import { keybindingMatchesAction } from '../../../../shared/keybindings'
 
 import workerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
 import { translate } from '@/i18n/i18n'
+import {
+  applyPdfScalePreference,
+  stepPdfScalePreference,
+  type PdfScalePreference
+} from './pdf-scale-preference'
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl
 
 const MIN_SCALE = 0.25
 const MAX_SCALE = 5
 const SCALE_STEP = 1.25
+const SCALE_BOUNDS = { min: MIN_SCALE, max: MAX_SCALE, step: SCALE_STEP }
 
 type PdfViewerProps = {
   content: string
@@ -40,6 +46,15 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
   const eventBusRef = useRef<InstanceType<typeof EventBus> | null>(null)
   const findControllerRef = useRef<InstanceType<typeof PDFFindController> | null>(null)
   const pdfViewerRef = useRef<InstanceType<typeof PdfJsViewer> | null>(null)
+  // Why: content reloads rebuild the pdf.js viewer; keep zoom across updates of
+  // the same file, and only reset when the open path changes.
+  const scalePreferenceRef = useRef<PdfScalePreference>('page-width')
+  const scalePreferenceFilePathRef = useRef(filePath)
+
+  if (scalePreferenceFilePathRef.current !== filePath) {
+    scalePreferenceFilePathRef.current = filePath
+    scalePreferenceRef.current = 'page-width'
+  }
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
   const cleanedContent = useMemo(() => content.replace(/\s/g, ''), [content])
@@ -107,7 +122,7 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
         viewer.setDocument(doc)
         linkService.setDocument(doc)
         findController.setDocument(doc)
-        viewer.currentScaleValue = 'page-width'
+        applyPdfScalePreference(viewer, scalePreferenceRef.current, SCALE_BOUNDS)
       })
       .catch((err) => {
         if (cancelled) {
@@ -161,19 +176,24 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
         e.preventDefault()
         const viewer = pdfViewerRef.current
         if (viewer) {
-          viewer.currentScale = Math.min(MAX_SCALE, viewer.currentScale * SCALE_STEP)
+          const next = stepPdfScalePreference(viewer.currentScale, 'in', SCALE_BOUNDS)
+          viewer.currentScale = next.scale
+          scalePreferenceRef.current = next.preference
         }
       } else if (keybindingMatchesAction('zoom.out', e, platform, keybindings)) {
         e.preventDefault()
         const viewer = pdfViewerRef.current
         if (viewer) {
-          viewer.currentScale = Math.max(MIN_SCALE, viewer.currentScale / SCALE_STEP)
+          const next = stepPdfScalePreference(viewer.currentScale, 'out', SCALE_BOUNDS)
+          viewer.currentScale = next.scale
+          scalePreferenceRef.current = next.preference
         }
       } else if (keybindingMatchesAction('zoom.reset', e, platform, keybindings)) {
         e.preventDefault()
         const viewer = pdfViewerRef.current
         if (viewer) {
-          viewer.currentScaleValue = 'page-width'
+          scalePreferenceRef.current = 'page-width'
+          applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
         }
       }
     }
@@ -184,21 +204,26 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
   const zoomIn = useCallback(() => {
     const viewer = pdfViewerRef.current
     if (viewer) {
-      viewer.currentScale = Math.min(MAX_SCALE, viewer.currentScale * SCALE_STEP)
+      const next = stepPdfScalePreference(viewer.currentScale, 'in', SCALE_BOUNDS)
+      viewer.currentScale = next.scale
+      scalePreferenceRef.current = next.preference
     }
   }, [])
 
   const zoomOut = useCallback(() => {
     const viewer = pdfViewerRef.current
     if (viewer) {
-      viewer.currentScale = Math.max(MIN_SCALE, viewer.currentScale / SCALE_STEP)
+      const next = stepPdfScalePreference(viewer.currentScale, 'out', SCALE_BOUNDS)
+      viewer.currentScale = next.scale
+      scalePreferenceRef.current = next.preference
     }
   }, [])
 
   const zoomReset = useCallback(() => {
     const viewer = pdfViewerRef.current
     if (viewer) {
-      viewer.currentScaleValue = 'page-width'
+      scalePreferenceRef.current = 'page-width'
+      applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
     }
   }, [])
 

--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -49,15 +49,20 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
   // Why: content reloads rebuild the pdf.js viewer; keep zoom across updates of
   // the same file, and only reset when the open path changes.
   const scalePreferenceRef = useRef<PdfScalePreference>('page-width')
-  const scalePreferenceFilePathRef = useRef(filePath)
-
-  if (scalePreferenceFilePathRef.current !== filePath) {
-    scalePreferenceFilePathRef.current = filePath
-    scalePreferenceRef.current = 'page-width'
-  }
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
   const cleanedContent = useMemo(() => content.replace(/\s/g, ''), [content])
+
+  // Why: reset zoom to fit-width when the open path changes. An effect keeps the
+  // reset out of render (refs mutated in render can leak from discarded renders)
+  // and covers same-content/different-path opens the load effect skips.
+  useEffect(() => {
+    scalePreferenceRef.current = 'page-width'
+    const viewer = pdfViewerRef.current
+    if (viewer) {
+      applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
+    }
+  }, [filePath])
 
   useEffect(() => {
     const container = containerRef.current
@@ -163,6 +168,30 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
     setFindOpen(false)
   }, [])
 
+  // Why: every zoom entry point (toolbar + keyboard) must record the scale
+  // preference so the next content reload restores it (see scalePreferenceRef).
+  const stepZoom = useCallback((direction: 'in' | 'out') => {
+    const viewer = pdfViewerRef.current
+    if (!viewer) {
+      return
+    }
+    const next = stepPdfScalePreference(viewer.currentScale, direction, SCALE_BOUNDS)
+    viewer.currentScale = next.scale
+    scalePreferenceRef.current = next.preference
+  }, [])
+
+  const zoomIn = useCallback(() => stepZoom('in'), [stepZoom])
+  const zoomOut = useCallback(() => stepZoom('out'), [stepZoom])
+
+  const zoomReset = useCallback(() => {
+    const viewer = pdfViewerRef.current
+    if (!viewer) {
+      return
+    }
+    scalePreferenceRef.current = 'page-width'
+    applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
+  }, [])
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
       const platform = getShortcutPlatform()
@@ -174,58 +203,18 @@ export default function PdfViewer({ content, filePath }: PdfViewerProps): JSX.El
       }
       if (keybindingMatchesAction('zoom.in', e, platform, keybindings)) {
         e.preventDefault()
-        const viewer = pdfViewerRef.current
-        if (viewer) {
-          const next = stepPdfScalePreference(viewer.currentScale, 'in', SCALE_BOUNDS)
-          viewer.currentScale = next.scale
-          scalePreferenceRef.current = next.preference
-        }
+        zoomIn()
       } else if (keybindingMatchesAction('zoom.out', e, platform, keybindings)) {
         e.preventDefault()
-        const viewer = pdfViewerRef.current
-        if (viewer) {
-          const next = stepPdfScalePreference(viewer.currentScale, 'out', SCALE_BOUNDS)
-          viewer.currentScale = next.scale
-          scalePreferenceRef.current = next.preference
-        }
+        zoomOut()
       } else if (keybindingMatchesAction('zoom.reset', e, platform, keybindings)) {
         e.preventDefault()
-        const viewer = pdfViewerRef.current
-        if (viewer) {
-          scalePreferenceRef.current = 'page-width'
-          applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
-        }
+        zoomReset()
       }
     }
     window.addEventListener('keydown', handleKeyDown, true)
     return () => window.removeEventListener('keydown', handleKeyDown, true)
-  }, [keybindings])
-
-  const zoomIn = useCallback(() => {
-    const viewer = pdfViewerRef.current
-    if (viewer) {
-      const next = stepPdfScalePreference(viewer.currentScale, 'in', SCALE_BOUNDS)
-      viewer.currentScale = next.scale
-      scalePreferenceRef.current = next.preference
-    }
-  }, [])
-
-  const zoomOut = useCallback(() => {
-    const viewer = pdfViewerRef.current
-    if (viewer) {
-      const next = stepPdfScalePreference(viewer.currentScale, 'out', SCALE_BOUNDS)
-      viewer.currentScale = next.scale
-      scalePreferenceRef.current = next.preference
-    }
-  }, [])
-
-  const zoomReset = useCallback(() => {
-    const viewer = pdfViewerRef.current
-    if (viewer) {
-      scalePreferenceRef.current = 'page-width'
-      applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
-    }
-  }, [])
+  }, [keybindings, zoomIn, zoomOut, zoomReset])
 
   const zoomPercent = Math.round(scale * 100)
 

--- a/src/renderer/src/components/editor/pdf-scale-preference.test.ts
+++ b/src/renderer/src/components/editor/pdf-scale-preference.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyPdfScalePreference,
+  clampPdfScale,
+  stepPdfScalePreference
+} from './pdf-scale-preference'
+
+const BOUNDS = { min: 0.25, max: 5, step: 1.25 }
+
+describe('clampPdfScale', () => {
+  it('clamps to the configured range', () => {
+    expect(clampPdfScale(0.1, BOUNDS.min, BOUNDS.max)).toBe(0.25)
+    expect(clampPdfScale(9, BOUNDS.min, BOUNDS.max)).toBe(5)
+    expect(clampPdfScale(1.5, BOUNDS.min, BOUNDS.max)).toBe(1.5)
+  })
+})
+
+describe('applyPdfScalePreference', () => {
+  it('restores an absolute scale after a content reload', () => {
+    const viewer = { currentScale: 1, currentScaleValue: 'auto' }
+    applyPdfScalePreference(viewer, 2.5, BOUNDS)
+    expect(viewer.currentScale).toBe(2.5)
+  })
+
+  it('uses fit-to-width for the default preference', () => {
+    const viewer = { currentScale: 1, currentScaleValue: 'auto' }
+    applyPdfScalePreference(viewer, 'page-width', BOUNDS)
+    expect(viewer.currentScaleValue).toBe('page-width')
+  })
+
+  it('clamps an out-of-range absolute preference', () => {
+    const viewer = { currentScale: 1, currentScaleValue: 'auto' }
+    applyPdfScalePreference(viewer, 99, BOUNDS)
+    expect(viewer.currentScale).toBe(5)
+  })
+})
+
+describe('stepPdfScalePreference', () => {
+  it('records the absolute scale so a later reload can restore it', () => {
+    const zoomedIn = stepPdfScalePreference(1, 'in', BOUNDS)
+    expect(zoomedIn.preference).toBe(1.25)
+    expect(zoomedIn.scale).toBe(1.25)
+
+    const zoomedOut = stepPdfScalePreference(1.25, 'out', BOUNDS)
+    expect(zoomedOut.preference).toBe(1)
+    expect(zoomedOut.scale).toBe(1)
+  })
+})

--- a/src/renderer/src/components/editor/pdf-scale-preference.ts
+++ b/src/renderer/src/components/editor/pdf-scale-preference.ts
@@ -1,0 +1,31 @@
+export type PdfScalePreference = 'page-width' | number
+
+export function clampPdfScale(scale: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, scale))
+}
+
+/** Apply a stored zoom preference after pdf.js loads a (re)document. */
+export function applyPdfScalePreference(
+  viewer: { currentScale: number; currentScaleValue: string },
+  preference: PdfScalePreference,
+  bounds: { min: number; max: number }
+): void {
+  if (typeof preference === 'number') {
+    viewer.currentScale = clampPdfScale(preference, bounds.min, bounds.max)
+    return
+  }
+  viewer.currentScaleValue = 'page-width'
+}
+
+/** Zoom in/out while recording the resulting absolute scale preference. */
+export function stepPdfScalePreference(
+  currentScale: number,
+  direction: 'in' | 'out',
+  bounds: { min: number; max: number; step: number }
+): { scale: number; preference: number } {
+  const next =
+    direction === 'in'
+      ? clampPdfScale(currentScale * bounds.step, bounds.min, bounds.max)
+      : clampPdfScale(currentScale / bounds.step, bounds.min, bounds.max)
+  return { scale: next, preference: next }
+}


### PR DESCRIPTION
## Summary

- Opening/updating a PDF always rebuilt the pdf.js viewer and forced `currentScaleValue = 'page-width'`, so any user zoom was lost after an on-disk update.
- Track a per-file scale preference (fit-to-width vs absolute) across content reloads; reset only when the open file path changes.
- Toolbar / shortcut zoom in·out·reset update the same preference so the next reload restores it.

Fixes #10165

## Test plan

- [x] Unit: `pdf-scale-preference` apply / step / clamp
- [ ] Manual: open a PDF → zoom in → save/overwrite the file externally → preview reloads at the same zoom
- [ ] Manual: fit-to-width then reload → stays fit-to-width
- [ ] Manual: switch to a different PDF path → zoom resets to fit-to-width