### PR TITLE
feat: support jj history graph

### DIFF
--- a/config/scripts/build-computer-macos.mjs
+++ b/config/scripts/build-computer-macos.mjs
@@ -30,10 +30,34 @@ createHelperApp()
 function buildUniversalBinary() {
   const builtBinaries = universalTriples.map((triple) => {
     run('swift', ['build', '-c', 'release', '--package-path', packagePath, '--triple', triple])
-    return path.join(packagePath, '.build', triple, 'release', 'orca-computer-use-macos')
+    const builtBinary = resolveSwiftBuildBinaryPath(triple)
+    const copiedBinary = path.join(
+      packagePath,
+      '.build',
+      'release',
+      `orca-computer-use-macos-${triple}`
+    )
+    mkdirSync(path.dirname(copiedBinary), { recursive: true })
+    // Why: newer SwiftPM can reuse one bin path for different triples, so copy each slice before the next build overwrites it.
+    copyFileSync(builtBinary, copiedBinary)
+    return copiedBinary
   })
   mkdirSync(path.dirname(binaryPath), { recursive: true })
   run('lipo', ['-create', ...builtBinaries, '-output', binaryPath])
+}
+
+function resolveSwiftBuildBinaryPath(triple) {
+  const binPath = runCapture('swift', [
+    'build',
+    '-c',
+    'release',
+    '--package-path',
+    packagePath,
+    '--triple',
+    triple,
+    '--show-bin-path'
+  ]).trim()
+  return path.join(binPath, 'orca-computer-use-macos')
 }
 
 function createHelperApp() {
@@ -91,6 +115,23 @@ function run(command, args) {
   if (result.status !== 0) {
     process.exit(result.status ?? 1)
   }
+}
+
+function runCapture(command, args) {
+  const result = spawnSync(command, args, { encoding: 'utf8' })
+  if (result.signal) {
+    process.kill(process.pid, result.signal)
+  }
+  if (result.status !== 0) {
+    if (result.stdout) {
+      process.stdout.write(result.stdout)
+    }
+    if (result.stderr) {
+      process.stderr.write(result.stderr)
+    }
+    process.exit(result.status ?? 1)
+  }
+  return result.stdout
 }
 
 function infoPlist() {

--- a/src/main/git/history.ts
+++ b/src/main/git/history.ts
@@ -1,15 +1,23 @@
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
-import { loadGitHistoryFromExecutor } from '../../shared/git-history'
+import { loadHistoryFromExecutors } from '../../shared/git-history'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
-import { gitExecFileAsync } from './runner'
+import { commandExecFileAsync, gitExecFileAsync } from './runner'
 
 export async function getHistory(
   worktreePath: string,
   options: GitHistoryOptions & GitRuntimeOptions = {}
 ): Promise<GitHistoryResult> {
-  return loadGitHistoryFromExecutor(
-    (args, cwd) => gitExecFileAsync(args, gitOptionsForWorktree(cwd, options)),
+  return loadHistoryFromExecutors(
+    {
+      git: (args, cwd) => gitExecFileAsync(args, gitOptionsForWorktree(cwd, options)),
+      jj: (args, cwd) =>
+        commandExecFileAsync('jj', args, {
+          cwd,
+          timeout: 15_000,
+          signal: options.signal
+        })
+    },
     worktreePath,
     options
   )

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1215,7 +1215,11 @@ export function registerFilesystemHandlers(
       _event,
       args: { worktreePath: string; connectionId?: string } & GitHistoryOptions
     ): Promise<GitHistoryResult> => {
-      const options: GitHistoryOptions = { limit: args.limit, baseRef: args.baseRef }
+      const options: GitHistoryOptions = {
+        limit: args.limit,
+        baseRef: args.baseRef,
+        provider: args.provider
+      }
       if (args.connectionId) {
         const provider = getSshGitProvider(args.connectionId)
         if (!provider) {

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -70,7 +70,8 @@ export const GitCommitCompare = WorktreeSelector.extend({
 
 export const GitHistory = WorktreeSelector.extend({
   limit: z.number().int().min(1).max(200).optional(),
-  baseRef: z.string().nullable().optional()
+  baseRef: z.string().nullable().optional(),
+  provider: z.enum(['git', 'jj', 'auto']).optional()
 })
 
 export const GitBranchDiff = GitFilePath.extend({

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -128,7 +128,8 @@ export const GIT_METHODS: RpcMethod[] = [
     handler: async (params, { runtime }) =>
       runtime.getRuntimeGitHistory(params.worktree, {
         limit: params.limit,
-        baseRef: params.baseRef
+        baseRef: params.baseRef,
+        ...(params.provider ? { provider: params.provider } : {})
       })
   }),
   defineMethod({

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -60,7 +60,7 @@ import {
   getEffectiveGitUpstreamStatus,
   resolveEffectiveGitUpstream
 } from '../shared/git-effective-upstream'
-import { loadGitHistoryFromExecutor } from '../shared/git-history'
+import { loadHistoryFromExecutors } from '../shared/git-history'
 import { buildRelayGitEnv, buildRelayUnattendedGitEnv } from './relay-command-env'
 import {
   removeSafeUntrackedDiscardTarget,
@@ -333,6 +333,17 @@ export class GitHandler {
     return stdout
   }
 
+  private async jj(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+    const { stdout, stderr } = await execFileAsync('jj', args, {
+      cwd: expandTilde(cwd),
+      env: buildRelayGitEnv(),
+      encoding: 'utf-8',
+      maxBuffer: MAX_GIT_BUFFER,
+      timeout: 15_000
+    })
+    return { stdout: String(stdout), stderr: String(stderr) }
+  }
+
   private async getStatus(params: Record<string, unknown>, context: RequestContext) {
     this.gitDiffReadDedupe.clear()
     return getStatusOp(this.git.bind(this), streamRelayGitStdout, params, {
@@ -397,10 +408,21 @@ export class GitHandler {
 
   private async history(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    return loadGitHistoryFromExecutor(this.git.bind(this), worktreePath, {
-      limit: typeof params.limit === 'number' ? params.limit : undefined,
-      baseRef: typeof params.baseRef === 'string' ? params.baseRef : null
-    })
+    return loadHistoryFromExecutors(
+      {
+        git: this.git.bind(this),
+        jj: this.jj.bind(this)
+      },
+      worktreePath,
+      {
+        limit: typeof params.limit === 'number' ? params.limit : undefined,
+        baseRef: typeof params.baseRef === 'string' ? params.baseRef : null,
+        provider:
+          params.provider === 'git' || params.provider === 'jj' || params.provider === 'auto'
+            ? params.provider
+            : undefined
+      }
+    )
   }
 
   private async getDiff(params: Record<string, unknown>, context?: RequestContext) {

--- a/src/renderer/src/components/right-sidebar/GitHistoryCommitFiles.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryCommitFiles.tsx
@@ -24,7 +24,7 @@ function CommitFileRow({
   onOpen
 }: {
   entry: GitBranchChangeEntry
-  onOpen: (entry: GitBranchChangeEntry, event: SourceControlRowOpenEvent) => void
+  onOpen?: (entry: GitBranchChangeEntry, event: SourceControlRowOpenEvent) => void
 }): React.JSX.Element {
   const status = entry.status as GitFileStatus
   const FileIcon = getFileTypeIcon(entry.path)
@@ -32,15 +32,8 @@ function CommitFileRow({
   const parentDir = dirname(entry.path)
   const dirPath = parentDir === '.' ? '' : parentDir
 
-  return (
-    <button
-      type="button"
-      className="group flex w-full min-w-0 cursor-pointer items-center gap-1 py-1 pl-9 pr-3 text-left text-xs transition-colors hover:bg-accent/40"
-      title={entry.path}
-      data-testid="git-history-commit-file"
-      onClick={(event) => onOpen(entry, toSourceControlRowOpenEvent(event))}
-      onDoubleClick={(event) => onOpen(entry, toPermanentSourceControlRowOpenEvent(event))}
-    >
+  const content = (
+    <>
       <FileIcon className="size-3.5 shrink-0" style={{ color: STATUS_COLORS[status] }} />
       <span className="min-w-0 flex-1 truncate">
         <span className="text-foreground">{fileName}</span>
@@ -52,6 +45,31 @@ function CommitFileRow({
       >
         {STATUS_LABELS[status]}
       </span>
+    </>
+  )
+
+  if (!onOpen) {
+    return (
+      <div
+        className="flex w-full min-w-0 items-center gap-1 py-1 pl-9 pr-3 text-left text-xs"
+        title={entry.path}
+        data-testid="git-history-commit-file"
+      >
+        {content}
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      className="group flex w-full min-w-0 cursor-pointer items-center gap-1 py-1 pl-9 pr-3 text-left text-xs transition-colors hover:bg-accent/40"
+      title={entry.path}
+      data-testid="git-history-commit-file"
+      onClick={(event) => onOpen(entry, toSourceControlRowOpenEvent(event))}
+      onDoubleClick={(event) => onOpen(entry, toPermanentSourceControlRowOpenEvent(event))}
+    >
+      {content}
     </button>
   )
 }
@@ -62,7 +80,7 @@ function CommitFilesBody({
   onOpenAll
 }: {
   state: GitHistoryCommitFilesState
-  onOpenFile: (entry: GitBranchChangeEntry, event: SourceControlRowOpenEvent) => void
+  onOpenFile?: (entry: GitBranchChangeEntry, event: SourceControlRowOpenEvent) => void
   onOpenAll?: () => void
 }): React.JSX.Element {
   if (state.status === 'loading') {
@@ -132,7 +150,7 @@ export function GitHistoryCommitFiles({
   state: GitHistoryCommitFilesState
   author?: string
   timestamp?: number
-  onOpenFile: (entry: GitBranchChangeEntry, event: SourceControlRowOpenEvent) => void
+  onOpenFile?: (entry: GitBranchChangeEntry, event: SourceControlRowOpenEvent) => void
   onOpenAll?: () => void
 }): React.JSX.Element {
   // Author and date move off the dense commit row and surface here on expand.

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx
@@ -51,6 +51,8 @@ describe('GitHistoryPanel', () => {
           state={{ status: 'ready', result }}
           collapsed={false}
           onToggle={vi.fn()}
+          historyProvider="git"
+          onProviderChange={vi.fn()}
           onRefresh={vi.fn()}
           onOpenCommit={vi.fn()}
         />
@@ -68,6 +70,8 @@ describe('GitHistoryPanel', () => {
         state={{ status: 'ready', result: makeHistoryResult() }}
         collapsed={false}
         onToggle={vi.fn()}
+        historyProvider="git"
+        onProviderChange={vi.fn()}
         onRefresh={vi.fn()}
         onOpenCommit={vi.fn()}
       />

--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -4,7 +4,11 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { ContextMenu, ContextMenuTrigger } from '@/components/ui/context-menu'
-import type { GitHistoryItem, GitHistoryResult } from '../../../../shared/git-history'
+import type {
+  GitHistoryItem,
+  GitHistoryProvider,
+  GitHistoryResult
+} from '../../../../shared/git-history'
 import type { GitBranchChangeEntry } from '../../../../shared/types'
 import {
   buildDefaultGitHistoryColorMap,
@@ -18,6 +22,7 @@ import {
 } from './GitHistoryCommitContextMenu'
 import type { SourceControlRowOpenEvent } from './source-control-split-open'
 import { translate } from '@/i18n/i18n'
+import { GitHistoryProviderSelector } from './GitHistoryProviderSelector'
 
 export type GitHistoryPanelState =
   | { status: 'idle' | 'loading'; result?: GitHistoryResult; error?: string }
@@ -44,6 +49,8 @@ export function GitHistoryPanel({
   state,
   collapsed,
   onToggle,
+  historyProvider,
+  onProviderChange,
   onRefresh,
   onOpenCommit,
   onLoadCommitFiles,
@@ -53,6 +60,8 @@ export function GitHistoryPanel({
   state: GitHistoryPanelState
   collapsed: boolean
   onToggle: () => void
+  historyProvider: GitHistoryProvider
+  onProviderChange: (provider: GitHistoryProvider) => void
   onRefresh: () => void
   onOpenCommit?: (item: GitHistoryItem) => void
   onLoadCommitFiles?: (item: GitHistoryItem) => Promise<GitBranchChangeEntry[]>
@@ -82,6 +91,8 @@ export function GitHistoryPanel({
 
   const loading = state.status === 'loading' || state.status === 'refreshing'
   const count = result?.items.length ?? 0
+  const effectiveProvider =
+    result?.provider ?? (historyProvider === 'auto' ? 'git' : historyProvider)
   const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
   const resizeSessionRef = useRef<GitHistoryResizeSession | null>(null)
 
@@ -274,6 +285,7 @@ export function GitHistoryPanel({
               )}
             </TooltipContent>
           </Tooltip>
+          <GitHistoryProviderSelector value={historyProvider} onChange={onProviderChange} />
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -346,7 +358,9 @@ export function GitHistoryPanel({
             const isBoundaryNode =
               viewModel.kind === 'incoming-changes' || viewModel.kind === 'outgoing-changes'
             const canExpand =
-              !isBoundaryNode && Boolean(onLoadCommitFiles) && Boolean(onOpenCommitFile)
+              !isBoundaryNode &&
+              Boolean(onLoadCommitFiles) &&
+              (Boolean(onOpenCommitFile) || effectiveProvider === 'jj')
             const isExpanded = canExpand && expanded.has(item.id)
             const row = (
               <GitHistoryRow
@@ -372,8 +386,16 @@ export function GitHistoryPanel({
                     state={filesByCommit[item.id] ?? { status: 'loading' }}
                     author={item.author}
                     timestamp={item.timestamp}
-                    onOpenFile={(entry, event) => onOpenCommitFile?.(item, entry, event)}
-                    onOpenAll={onOpenCommit ? () => onOpenCommit(item) : undefined}
+                    onOpenFile={
+                      effectiveProvider === 'jj'
+                        ? undefined
+                        : (entry, event) => onOpenCommitFile?.(item, entry, event)
+                    }
+                    onOpenAll={
+                      effectiveProvider !== 'jj' && onOpenCommit
+                        ? () => onOpenCommit(item)
+                        : undefined
+                    }
                   />
                 )}
               </React.Fragment>

--- a/src/renderer/src/components/right-sidebar/GitHistoryProviderSelector.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryProviderSelector.tsx
@@ -1,0 +1,45 @@
+import type React from 'react'
+import { Button } from '@/components/ui/button'
+import { ButtonGroup } from '@/components/ui/button-group'
+import type { GitHistoryProvider } from '../../../../shared/git-history'
+
+const GIT_HISTORY_PROVIDERS: readonly GitHistoryProvider[] = ['auto', 'git', 'jj']
+
+function providerLabel(provider: GitHistoryProvider): string {
+  if (provider === 'auto') {
+    return 'Auto'
+  }
+  if (provider === 'git') {
+    return 'Git'
+  }
+  return 'jj'
+}
+
+export function GitHistoryProviderSelector({
+  value,
+  onChange
+}: {
+  value: GitHistoryProvider
+  onChange: (provider: GitHistoryProvider) => void
+}): React.JSX.Element {
+  return (
+    <ButtonGroup className="my-auto ml-1">
+      {GIT_HISTORY_PROVIDERS.map((provider) => (
+        <Button
+          key={provider}
+          type="button"
+          variant={value === provider ? 'secondary' : 'outline'}
+          size="xs"
+          className="h-5 px-1.5 text-[10px] font-medium"
+          aria-pressed={value === provider}
+          onClick={(event) => {
+            event.stopPropagation()
+            onChange(provider)
+          }}
+        >
+          {providerLabel(provider)}
+        </Button>
+      ))}
+    </ButtonGroup>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryRow.tsx
@@ -68,6 +68,8 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
     const visibleRefs = refs.slice(0, 2)
     const hiddenRefs = refs.slice(2)
     const rowTooltip = item.message || item.subject
+    const changeDisplay = item.displayChangeId ?? item.changeId
+    const commitDisplay = item.displayId ?? item.commitId
     const rowClassName = cn(
       'grid min-h-[26px] w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-1.5 px-3 py-0.5 text-left text-xs transition-colors',
       isInteractive && 'cursor-pointer hover:bg-accent/40 focus-visible:bg-accent/40',
@@ -98,6 +100,14 @@ export const GitHistoryRow = React.forwardRef<HTMLElement, GitHistoryRowProps>(
               {rowTooltip}
             </TooltipContent>
           </Tooltip>
+          {item.provider === 'jj' && (
+            <span className="flex shrink-0 items-center gap-1 font-mono text-[10px] text-muted-foreground">
+              {changeDisplay && <span title={`Change ID ${item.changeId}`}>{changeDisplay}</span>}
+              {commitDisplay && (
+                <span title={`Commit ID ${item.commitId ?? item.id}`}>{commitDisplay}</span>
+              )}
+            </span>
+          )}
         </div>
         {refs.length > 0 && (
           <div className="flex shrink-0 items-center gap-1 overflow-hidden">

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -194,6 +194,7 @@ import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullR
 import { resolveCreateReviewDraftTitle } from './create-review-draft-title'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
 import { useGitHistoryCommitActions } from './useGitHistoryCommitActions'
+import type { GitHistoryProvider } from '../../../../shared/git-history'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import {
   isBehindOnlyUpstream,
@@ -1164,6 +1165,7 @@ function SourceControlInner(): React.JSX.Element {
   const [gitHistoryByWorktree, setGitHistoryByWorktree] = useState<
     Record<string, GitHistoryPanelState>
   >({})
+  const [gitHistoryProvider, setGitHistoryProvider] = useState<GitHistoryProvider>('auto')
   const gitHistoryRequestSeqRef = useRef(0)
   const gitHistoryRequestByWorktreeRef = useRef<Record<string, number>>({})
   const gitHistoryState = activeWorktreeId
@@ -4856,7 +4858,7 @@ function SourceControlInner(): React.JSX.Element {
           worktreePath,
           connectionId
         },
-        { limit: 50, baseRef: compareBaseRef }
+        { limit: 50, baseRef: compareBaseRef, provider: gitHistoryProvider }
       )
       if (gitHistoryRequestByWorktreeRef.current[worktreeId] !== requestId) {
         return
@@ -4881,6 +4883,7 @@ function SourceControlInner(): React.JSX.Element {
     activeRepoSettings,
     activeWorktreeId,
     compareBaseRef,
+    gitHistoryProvider,
     isBranchVisible,
     isFolder,
     isGitHistoryExpanded,
@@ -4911,6 +4914,7 @@ function SourceControlInner(): React.JSX.Element {
     activeGitStatusHead,
     activeWorktreeId,
     compareBaseRef,
+    gitHistoryProvider,
     isBranchVisible,
     isFolder,
     worktreePath
@@ -4939,6 +4943,7 @@ function SourceControlInner(): React.JSX.Element {
   }, [
     activeWorktreeId,
     compareBaseRef,
+    gitHistoryProvider,
     isBranchVisible,
     isFolder,
     remoteStatus?.ahead,
@@ -6166,6 +6171,8 @@ function SourceControlInner(): React.JSX.Element {
                 state={gitHistoryState}
                 collapsed={collapsedSections.has('history')}
                 onToggle={() => toggleSection('history')}
+                historyProvider={gitHistoryProvider}
+                onProviderChange={setGitHistoryProvider}
                 onRefresh={() => void refreshGitHistory()}
                 onOpenCommit={(item) => void openHistoryCommitDiff(item)}
                 onLoadCommitFiles={loadCommitFiles}

--- a/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
+++ b/src/renderer/src/components/right-sidebar/useGitHistoryCommitActions.ts
@@ -62,6 +62,9 @@ export function useGitHistoryCommitActions({
 
   const loadCommitFiles = useCallback(
     async (item: GitHistoryItem): Promise<GitBranchChangeEntry[]> => {
+      if (item.provider === 'jj') {
+        return item.fileEntries ?? EMPTY_BRANCH_CHANGE_ENTRIES
+      }
       if (!activeWorktreeId || !worktreePath) {
         return EMPTY_BRANCH_CHANGE_ENTRIES
       }
@@ -97,6 +100,9 @@ export function useGitHistoryCommitActions({
 
   const openHistoryCommitDiff = useCallback(
     async (item: GitHistoryItem): Promise<void> => {
+      if (item.provider === 'jj') {
+        return
+      }
       if (!activeWorktreeId || !worktreePath) {
         return
       }
@@ -187,6 +193,9 @@ export function useGitHistoryCommitActions({
   const handleCommitAction = useCallback(
     (action: GitHistoryCommitAction, item: GitHistoryItem): void => {
       if (action === 'open-remote') {
+        if (item.provider === 'jj') {
+          return
+        }
         if (!activeWorktreeId || !worktreePath) {
           return
         }

--- a/src/shared/git-history-types.ts
+++ b/src/shared/git-history-types.ts
@@ -1,3 +1,5 @@
+import type { GitBranchChangeEntry } from './types'
+
 export type GitHistoryGraphColorId =
   | 'git-graph-ref'
   | 'git-graph-remote-ref'
@@ -23,7 +25,13 @@ export const GIT_HISTORY_LANE_COLORS: readonly GitHistoryGraphColorId[] = [
 export const GIT_HISTORY_DEFAULT_LIMIT = 50
 export const GIT_HISTORY_MAX_LIMIT = 200
 
-export type GitHistoryRefCategory = 'branches' | 'remote branches' | 'tags' | 'commits'
+export type GitHistoryRefCategory =
+  | 'branches'
+  | 'remote branches'
+  | 'bookmarks'
+  | 'remote bookmarks'
+  | 'tags'
+  | 'commits'
 
 export type GitHistoryItemRef = {
   id: string
@@ -46,20 +54,29 @@ export type GitHistoryItem = {
   subject: string
   message: string
   displayId?: string
+  changeId?: string
+  displayChangeId?: string
+  commitId?: string
+  provider?: GitHistoryProvider
   author?: string
   authorEmail?: string
   timestamp?: number
   statistics?: GitHistoryItemStatistics
   references?: GitHistoryItemRef[]
+  fileEntries?: GitBranchChangeEntry[]
 }
+
+export type GitHistoryProvider = 'git' | 'jj' | 'auto'
 
 export type GitHistoryOptions = {
   limit?: number
   baseRef?: string | null
+  provider?: GitHistoryProvider
 }
 
 export type GitHistoryResult = {
   items: GitHistoryItem[]
+  provider?: Exclude<GitHistoryProvider, 'auto'>
   currentRef?: GitHistoryItemRef
   remoteRef?: GitHistoryItemRef
   baseRef?: GitHistoryItemRef

--- a/src/shared/git-history.test.ts
+++ b/src/shared/git-history.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest'
 import type { GitHistoryExecutor } from './git-history'
 import {
   GIT_HISTORY_MAX_LIMIT,
+  loadHistoryFromExecutors,
   loadGitHistoryFromExecutor,
+  parseJjHistoryLog,
   parseGitHistoryLog
 } from './git-history'
 import { GIT_HISTORY_COMMIT_FORMAT } from './git-history-log-parser'
@@ -261,5 +263,75 @@ describe('git history loader', () => {
       hasMore: false
     })
     expect(executor).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to git history when auto jj history is unavailable', async () => {
+    const { executor } = createHistoryExecutor()
+    const jj = vi.fn(async () => {
+      throw new Error('jj repo not found')
+    })
+
+    const result = await loadHistoryFromExecutors(
+      {
+        git: executor,
+        jj
+      },
+      '/repo',
+      { provider: 'auto' }
+    )
+
+    expect(result.provider).toBe('git')
+    expect(result.items[0]?.id).toBe(HEAD_OID)
+    expect(jj).toHaveBeenCalled()
+  })
+})
+
+describe('jj history parsing', () => {
+  it('parses change ids, commit ids, bookmarks, and changed files', () => {
+    const commit = {
+      commit_id: HEAD_OID,
+      parents: [BASE_OID],
+      change_id: 'xryqywtszkznmqkxoyuovustxovrwxwp',
+      description: 'feat: add jj graph\n\nbody',
+      author: {
+        name: 'Ada Lovelace',
+        email: 'ada@example.com',
+        timestamp: '2026-07-23T12:00:00+09:00'
+      }
+    }
+    const bookmarks = [{ name: 'feature/jj' }, { name: 'feature/jj', remote: 'origin' }]
+    const stdout = [
+      JSON.stringify(commit),
+      JSON.stringify(bookmarks),
+      'true',
+      'false',
+      'false',
+      'false',
+      'M src/a.ts\nA src/b.ts\nD src/c.ts'
+    ].join('\x1f')
+
+    const [item] = parseJjHistoryLog(`${stdout}\0`)
+
+    expect(item).toMatchObject({
+      id: HEAD_OID,
+      parentIds: [BASE_OID],
+      subject: 'feat: add jj graph',
+      changeId: 'xryqywtszkznmqkxoyuovustxovrwxwp',
+      displayChangeId: 'xryqywts',
+      displayId: HEAD_OID.slice(0, 8),
+      provider: 'jj',
+      author: 'Ada Lovelace',
+      authorEmail: 'ada@example.com'
+    })
+    expect(item?.references?.map((ref) => [ref.id, ref.name, ref.category])).toEqual([
+      ['jj:working-copy', '@', 'commits'],
+      ['jj:bookmark:feature/jj', 'feature/jj', 'bookmarks'],
+      ['jj:remote-bookmark:origin/feature/jj', 'origin/feature/jj', 'remote bookmarks']
+    ])
+    expect(item?.fileEntries).toEqual([
+      { path: 'src/a.ts', status: 'modified' },
+      { path: 'src/b.ts', status: 'added' },
+      { path: 'src/c.ts', status: 'deleted' }
+    ])
   })
 })

--- a/src/shared/git-history.ts
+++ b/src/shared/git-history.ts
@@ -10,8 +10,10 @@ import {
   type GitHistoryExecutor,
   type GitHistoryItemRef,
   type GitHistoryOptions,
+  type GitHistoryProvider,
   type GitHistoryResult
 } from './git-history-types'
+import { loadJjHistoryFromExecutor } from './jj-history'
 
 export type {
   GitHistoryExecutor,
@@ -20,6 +22,7 @@ export type {
   GitHistoryItemRef,
   GitHistoryItemStatistics,
   GitHistoryOptions,
+  GitHistoryProvider,
   GitHistoryRefCategory,
   GitHistoryResult
 } from './git-history-types'
@@ -32,6 +35,7 @@ export {
   GIT_HISTORY_REMOTE_REF_COLOR
 } from './git-history-types'
 export { compareGitHistoryItemRefsByCategory, parseGitHistoryLog } from './git-history-log-parser'
+export { loadJjHistoryFromExecutor, parseJjDiffSummary, parseJjHistoryLog } from './jj-history'
 
 function clampHistoryLimit(limit: number | undefined): number {
   if (!Number.isFinite(limit)) {
@@ -219,6 +223,7 @@ export async function loadGitHistoryFromExecutor(
 
   return {
     items,
+    provider: 'git',
     currentRef,
     remoteRef,
     baseRef,
@@ -228,4 +233,29 @@ export async function loadGitHistoryFromExecutor(
     hasMore: parsed.length > limit,
     limit
   }
+}
+
+export async function loadHistoryFromExecutors(
+  executors: {
+    git: GitHistoryExecutor
+    jj?: GitHistoryExecutor
+  },
+  cwd: string,
+  options: GitHistoryOptions = {}
+): Promise<GitHistoryResult> {
+  const provider: GitHistoryProvider = options.provider ?? 'git'
+  if (provider === 'jj') {
+    if (!executors.jj) {
+      throw new Error('jj is not available on this host')
+    }
+    return loadJjHistoryFromExecutor(executors.jj, cwd, options)
+  }
+  if (provider === 'auto' && executors.jj) {
+    try {
+      return await loadJjHistoryFromExecutor(executors.jj, cwd, options)
+    } catch {
+      // Git remains the stable baseline when jj is absent or the repo is not colocated.
+    }
+  }
+  return loadGitHistoryFromExecutor(executors.git, cwd, options)
 }

--- a/src/shared/jj-history.ts
+++ b/src/shared/jj-history.ts
@@ -1,0 +1,275 @@
+import type { GitBranchChangeEntry } from './types'
+import {
+  GIT_HISTORY_DEFAULT_LIMIT,
+  GIT_HISTORY_MAX_LIMIT,
+  type GitHistoryExecutor,
+  type GitHistoryItem,
+  type GitHistoryItemRef,
+  type GitHistoryOptions,
+  type GitHistoryResult
+} from './git-history-types'
+
+const JJ_HISTORY_RECORD_SEPARATOR = '\0'
+const JJ_HISTORY_FIELD_SEPARATOR = '\x1f'
+const JJ_HISTORY_DEFAULT_REVSET = 'present(@) | ancestors(immutable_heads().., 2) | trunk()'
+const JJ_HISTORY_TEMPLATE = [
+  'json(self)',
+  'json(bookmarks)',
+  'json(current_working_copy)',
+  'json(immutable)',
+  'json(empty)',
+  'json(conflict)',
+  'self.diff().summary()'
+].join(` ++ "${JJ_HISTORY_FIELD_SEPARATOR}" ++ `)
+
+type JjCommitRef = {
+  name?: unknown
+  remote?: unknown
+}
+
+type JjCommitRecord = {
+  commit_id?: unknown
+  parents?: unknown
+  change_id?: unknown
+  description?: unknown
+  author?: unknown
+}
+
+type JjAuthor = {
+  name?: unknown
+  email?: unknown
+  timestamp?: unknown
+}
+
+function clampHistoryLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit)) {
+    return GIT_HISTORY_DEFAULT_LIMIT
+  }
+  return Math.min(
+    GIT_HISTORY_MAX_LIMIT,
+    Math.max(1, Math.trunc(limit ?? GIT_HISTORY_DEFAULT_LIMIT))
+  )
+}
+
+function firstLine(message: string): string {
+  return message.split(/\r?\n/, 1)[0]?.trim() || '(no description set)'
+}
+
+function shortId(id: string): string {
+  return id.slice(0, 8)
+}
+
+function parseBoolean(raw: string): boolean {
+  return raw.trim() === 'true'
+}
+
+function parseJjJson<T>(raw: string, fallback: T): T {
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : undefined
+}
+
+function parseParents(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value.filter((parent): parent is string => typeof parent === 'string' && parent.length > 0)
+}
+
+function parseAuthor(value: unknown): {
+  author?: string
+  authorEmail?: string
+  timestamp?: number
+} {
+  if (!value || typeof value !== 'object') {
+    return {}
+  }
+  const author = value as JjAuthor
+  return {
+    ...(typeof author.name === 'string' && author.name ? { author: author.name } : {}),
+    ...(typeof author.email === 'string' && author.email ? { authorEmail: author.email } : {}),
+    ...(parseTimestamp(author.timestamp) !== undefined
+      ? { timestamp: parseTimestamp(author.timestamp) }
+      : {})
+  }
+}
+
+function parseJjBookmarks(raw: string, revision: string): GitHistoryItemRef[] {
+  const refs = parseJjJson<JjCommitRef[]>(raw, [])
+  return refs.flatMap((ref): GitHistoryItemRef[] => {
+    if (typeof ref.name !== 'string' || !ref.name) {
+      return []
+    }
+    if (typeof ref.remote === 'string' && ref.remote) {
+      return [
+        {
+          id: `jj:remote-bookmark:${ref.remote}/${ref.name}`,
+          name: `${ref.remote}/${ref.name}`,
+          revision,
+          category: 'remote bookmarks'
+        }
+      ]
+    }
+    return [
+      {
+        id: `jj:bookmark:${ref.name}`,
+        name: ref.name,
+        revision,
+        category: 'bookmarks'
+      }
+    ]
+  })
+}
+
+function parseJjSummaryLine(line: string): GitBranchChangeEntry | null {
+  const match = line.match(/^([A-Z])\s+(.+)$/)
+  if (!match) {
+    return null
+  }
+  const marker = match[1]
+  const rawPath = match[2].trim()
+  if (!rawPath) {
+    return null
+  }
+  if (marker === 'A') {
+    return { path: rawPath, status: 'added' }
+  }
+  if (marker === 'D') {
+    return { path: rawPath, status: 'deleted' }
+  }
+  if (marker === 'R' || marker === 'C') {
+    const renameMatch = rawPath.match(/^(.*?)\s+(?:=>|->)\s+(.*)$/)
+    const path = renameMatch?.[2]?.trim() || rawPath
+    const oldPath = renameMatch?.[1]?.trim()
+    return {
+      path,
+      status: marker === 'R' ? 'renamed' : 'copied',
+      ...(oldPath ? { oldPath } : {})
+    }
+  }
+  return { path: rawPath, status: 'modified' }
+}
+
+export function parseJjDiffSummary(summary: string): GitBranchChangeEntry[] {
+  return summary
+    .split(/\r?\n/)
+    .map((line) => parseJjSummaryLine(line.trim()))
+    .filter((entry): entry is GitBranchChangeEntry => Boolean(entry))
+}
+
+export function parseJjHistoryLog(stdout: string): GitHistoryItem[] {
+  const items: GitHistoryItem[] = []
+  for (const rawRecord of stdout.split(JJ_HISTORY_RECORD_SEPARATOR)) {
+    if (!rawRecord.trim()) {
+      continue
+    }
+    const [rawCommit, rawBookmarks, rawCurrent, rawImmutable, rawEmpty, rawConflict, ...summary] =
+      rawRecord.split(JJ_HISTORY_FIELD_SEPARATOR)
+    const commit = parseJjJson<JjCommitRecord>(rawCommit ?? '', {})
+    if (typeof commit.commit_id !== 'string' || !commit.commit_id) {
+      continue
+    }
+    const changeId = typeof commit.change_id === 'string' ? commit.change_id : ''
+    const message = typeof commit.description === 'string' ? commit.description.trimEnd() : ''
+    const references = parseJjBookmarks(rawBookmarks ?? '[]', commit.commit_id)
+    if (parseBoolean(rawCurrent ?? 'false')) {
+      references.unshift({
+        id: 'jj:working-copy',
+        name: '@',
+        revision: commit.commit_id,
+        category: 'commits'
+      })
+    }
+    if (parseBoolean(rawImmutable ?? 'false')) {
+      references.push({
+        id: `jj:immutable:${commit.commit_id}`,
+        name: '◆',
+        revision: commit.commit_id,
+        category: 'commits'
+      })
+    }
+    if (parseBoolean(rawConflict ?? 'false')) {
+      references.push({
+        id: `jj:conflict:${commit.commit_id}`,
+        name: 'conflict',
+        revision: commit.commit_id,
+        category: 'commits'
+      })
+    }
+    if (parseBoolean(rawEmpty ?? 'false')) {
+      references.push({
+        id: `jj:empty:${commit.commit_id}`,
+        name: 'empty',
+        revision: commit.commit_id,
+        category: 'commits'
+      })
+    }
+    items.push({
+      id: commit.commit_id,
+      parentIds: parseParents(commit.parents),
+      subject: firstLine(message),
+      message,
+      displayId: shortId(commit.commit_id),
+      changeId,
+      displayChangeId: changeId ? shortId(changeId) : undefined,
+      commitId: commit.commit_id,
+      provider: 'jj',
+      references,
+      fileEntries: parseJjDiffSummary(summary.join(JJ_HISTORY_FIELD_SEPARATOR)),
+      ...parseAuthor(commit.author)
+    })
+  }
+  return items
+}
+
+export async function loadJjHistoryFromExecutor(
+  jj: GitHistoryExecutor,
+  cwd: string,
+  options: GitHistoryOptions = {}
+): Promise<GitHistoryResult> {
+  const limit = clampHistoryLimit(options.limit)
+  const { stdout } = await jj(
+    [
+      '--ignore-working-copy',
+      'log',
+      '--no-graph',
+      '--no-pager',
+      '--color=never',
+      '-r',
+      JJ_HISTORY_DEFAULT_REVSET,
+      `-n${limit + 1}`,
+      '-T',
+      `${JJ_HISTORY_TEMPLATE} ++ "${JJ_HISTORY_RECORD_SEPARATOR}"`
+    ],
+    cwd
+  )
+  const parsed = parseJjHistoryLog(stdout)
+  const items = parsed.slice(0, limit)
+  const current = items.find((item) => item.references?.some((ref) => ref.id === 'jj:working-copy'))
+  return {
+    items,
+    provider: 'jj',
+    currentRef: current
+      ? {
+          id: 'jj:working-copy',
+          name: '@',
+          revision: current.id,
+          category: 'commits'
+        }
+      : undefined,
+    hasIncomingChanges: false,
+    hasOutgoingChanges: false,
+    hasMore: parsed.length > limit,
+    limit
+  }
+}


### PR DESCRIPTION
## Summary
- add a jj-backed history provider for Source Control history
- show jj graph entries with change id, commit id, and changed files
- add an Auto/Git/jj selector and route native, SSH relay, and runtime RPC history requests

## Validation
- pnpm exec vitest run --config config/vitest.config.ts src/shared/git-history.test.ts src/renderer/src/components/right-sidebar/GitHistoryPanel.test.tsx src/renderer/src/runtime/runtime-git-client.test.ts src/main/runtime/rpc/methods/git.test.ts
- pnpm run typecheck
- pnpm run lint
- jj --ignore-working-copy log template smoke test
- pnpm run build:electron-vite

## ELI5

Source Control history can use jj (Jujutsu) as well as Git: graph entries with change/commit ids, plus an Auto/Git/jj selector for local, SSH, and runtime hosts.
