### PR TITLE
fix(worktree): match created worktrees through symlink roots

### DIFF
--- a/src/main/ipc/find-listed-worktree-by-path.test.ts
+++ b/src/main/ipc/find-listed-worktree-by-path.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest'
+import { findListedWorktreeByPath } from './worktree-path-comparison'
+
+describe('findListedWorktreeByPath', () => {
+  it('matches by normalized path without realpath when strings already equal', async () => {
+    const resolveRealPath = vi.fn(async (pathValue: string) => pathValue)
+    const listed = [{ path: '/home/user/ws/repo/feature' }]
+
+    await expect(
+      findListedWorktreeByPath(listed, '/home/user/ws/repo/feature', {
+        platform: 'linux',
+        resolveRealPath
+      })
+    ).resolves.toEqual(listed[0])
+    expect(resolveRealPath).not.toHaveBeenCalled()
+  })
+
+  it('matches symlink workspace roots via realpath (immutable Linux /home → /var/home)', async () => {
+    // Why: git worktree list reports the canonical path while Orca may request
+    // the user-facing /home path that is a symlink to /var/home.
+    const resolveRealPath = vi.fn(async (pathValue: string) =>
+      pathValue.replace(/^\/home\//, '/var/home/')
+    )
+    const listed = [{ path: '/var/home/user/ws/repo/feature', branch: 'refs/heads/feature' }]
+
+    await expect(
+      findListedWorktreeByPath(listed, '/home/user/ws/repo/feature', {
+        platform: 'linux',
+        resolveRealPath
+      })
+    ).resolves.toEqual(listed[0])
+    expect(resolveRealPath).toHaveBeenCalledWith('/home/user/ws/repo/feature')
+    expect(resolveRealPath).toHaveBeenCalledWith('/var/home/user/ws/repo/feature')
+  })
+
+  it('skips realpath when resolveSymlinks is false (WSL/SSH listings)', async () => {
+    const resolveRealPath = vi.fn(async (pathValue: string) =>
+      pathValue.replace(/^\/home\//, '/var/home/')
+    )
+    const listed = [{ path: '/var/home/user/ws/repo/feature' }]
+
+    await expect(
+      findListedWorktreeByPath(listed, '/home/user/ws/repo/feature', {
+        platform: 'linux',
+        resolveSymlinks: false,
+        resolveRealPath
+      })
+    ).resolves.toBeUndefined()
+    expect(resolveRealPath).not.toHaveBeenCalled()
+  })
+
+  it('returns undefined when realpath cannot resolve the requested path', async () => {
+    const resolveRealPath = vi.fn(async (pathValue: string) => {
+      if (pathValue.startsWith('/home/')) {
+        throw new Error('ENOENT')
+      }
+      return pathValue
+    })
+
+    await expect(
+      findListedWorktreeByPath(
+        [{ path: '/var/home/user/ws/repo/feature' }],
+        '/home/user/ws/repo/feature',
+        {
+          platform: 'linux',
+          resolveRealPath
+        }
+      )
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -14,7 +14,7 @@ export {
   computeValidatedBranchName
 } from './worktree-branch-name'
 export { mergeWorktree } from './worktree-metadata-merge'
-export { areWorktreePathsEqual } from './worktree-path-comparison'
+export { areWorktreePathsEqual, findListedWorktreeByPath } from './worktree-path-comparison'
 
 /**
  * Sanitize a worktree name for use in branch names and directory paths.

--- a/src/main/ipc/worktree-path-comparison.ts
+++ b/src/main/ipc/worktree-path-comparison.ts
@@ -1,3 +1,4 @@
+import { realpath } from 'node:fs/promises'
 import { posix, win32 } from 'node:path'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 
@@ -97,6 +98,57 @@ export function dedupeWorktreesByPath<T extends { path: string }>(
 
 function looksLikePosixAbsolutePath(pathValue: string): boolean {
   return pathValue.startsWith('/') && !pathValue.startsWith('//')
+}
+
+export type FindListedWorktreeByPathOptions = {
+  platform?: NodeJS.Platform
+  /**
+   * When true (default), fall back to filesystem realpath if string comparison
+   * fails. Disable for WSL/SSH listings where host realpath is not authoritative.
+   */
+  resolveSymlinks?: boolean
+  resolveRealPath?: (pathValue: string) => Promise<string>
+}
+
+/**
+ * Find a worktree row for a path we just created. String equality is preferred;
+ * local symlink roots (e.g. /home → /var/home on immutable Linux) need realpath.
+ */
+export async function findListedWorktreeByPath<T extends { path: string }>(
+  worktrees: readonly T[],
+  requestedPath: string,
+  options: FindListedWorktreeByPathOptions = {}
+): Promise<T | undefined> {
+  const platform = options.platform ?? process.platform
+  const direct = worktrees.find((worktree) =>
+    areWorktreePathsEqual(worktree.path, requestedPath, platform)
+  )
+  if (direct) {
+    return direct
+  }
+  if (options.resolveSymlinks === false) {
+    return undefined
+  }
+
+  const resolveRealPath = options.resolveRealPath ?? ((pathValue: string) => realpath(pathValue))
+  let requestedReal: string
+  try {
+    requestedReal = await resolveRealPath(requestedPath)
+  } catch {
+    return undefined
+  }
+
+  for (const worktree of worktrees) {
+    try {
+      const listedReal = await resolveRealPath(worktree.path)
+      if (areWorktreePathsEqual(listedReal, requestedReal, platform)) {
+        return worktree
+      }
+    } catch {
+      // Why: a missing/stale listing path should not abort the search of other rows.
+    }
+  }
+  return undefined
 }
 
 function normalizeWindowsWorktreePathForComparison(pathValue: string): string {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -79,7 +79,8 @@ import {
   getWorktreePathSettings,
   hasRepoWorktreeBasePath,
   shouldSetDisplayName,
-  mergeWorktree
+  mergeWorktree,
+  findListedWorktreeByPath
 } from './worktree-logic'
 import { findCreatedWorktree } from './created-worktree-reconciliation'
 import type { BranchPrefixSettings } from '../../shared/branch-prefix'
@@ -2379,8 +2380,13 @@ export async function createLocalWorktree(
       ? listWorktrees(repo.path, localWorktreeGitOptions)
       : listWorktrees(repo.path)
   )
-  // Why: Git may canonicalize a symlinked create path; its exact branch identifies the listed row.
-  const created = findCreatedWorktree(gitWorktrees, worktreePath, branchName)
+  // Why: local immutable Linux (/home → /var/home) reports the realpath in
+  // `git worktree list`; resolve symlinks only for native host Git (not WSL).
+  // Branch fallback covers remaining Git-canonicalized paths main already handles.
+  const created =
+    (await findListedWorktreeByPath(gitWorktrees, worktreePath, {
+      resolveSymlinks: !localWorktreeGitOptions.wslDistro
+    })) ?? findCreatedWorktree(gitWorktrees, worktreePath, branchName)
   if (!created) {
     throw new Error('Worktree created but not found in listing')
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -809,7 +809,8 @@ import {
   mergeWorktree,
   sanitizeWorktreeName,
   shouldSetDisplayName,
-  areWorktreePathsEqual
+  areWorktreePathsEqual,
+  findListedWorktreeByPath
 } from '../ipc/worktree-logic'
 import { findCreatedWorktree } from '../ipc/created-worktree-reconciliation'
 import { worktreePathComparisonKey } from '../ipc/worktree-path-comparison'
@@ -18760,8 +18761,13 @@ export class OrcaRuntimeService {
     const gitWorktrees = hasLocalWorktreeGitOptions
       ? await listWorktrees(repo.path, localWorktreeGitOptions)
       : await listWorktrees(repo.path)
-    // Why: Git may canonicalize a symlinked create path; its exact branch identifies the listed row.
-    const created = findCreatedWorktree(gitWorktrees, worktreePath, branchName)
+    // Why: native host Git may list the realpath while we requested a symlink path
+    // (e.g. /home → /var/home on immutable Linux). Skip host realpath for WSL.
+    // Branch fallback covers remaining Git-canonicalized paths main already handles.
+    const created =
+      (await findListedWorktreeByPath(gitWorktrees, worktreePath, {
+        resolveSymlinks: !localWorktreeGitOptions.wslDistro
+      })) ?? findCreatedWorktree(gitWorktrees, worktreePath, branchName)
     if (!created) {
       throw new Error('Worktree created but not found in listing')
     }


### PR DESCRIPTION
## Summary

- On Bazzite/Silverblue-style systems, `/home` is a symlink to `/var/home`. `git worktree add` with a `/home/...` path succeeds, but `git worktree list` returns the canonical `/var/home/...` path.
- Orca compared those with string/path normalization only → **Worktree created but not found in listing**, even though the worktree exists on disk.
- After local create, find the listed row with a **realpath fallback** when the direct match fails. **WSL** still uses string comparison only (host realpath is not authoritative for WSL paths). SSH create path unchanged.

Fixes #10170

## Test plan

- [x] Unit: direct path match without realpath
- [x] Unit: `/home` → `/var/home` symlink resolve matches listing
- [x] Unit: `resolveSymlinks: false` skips realpath (WSL)
- [ ] Manual (immutable Linux optional): workspace under `/home/$USER`, create worktree → registers in UI

## ELI5

On systems where /home is a symlink (e.g. Bazzite), created worktrees existed but Orca said not found because list paths differed. Matching now falls back to realpath so symlink roots resolve correctly.
