### PR TITLE
feat(app): open OS Markdown files in the floating workspace

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -65,6 +65,30 @@ module.exports = {
   appId,
   productName: 'Orca',
   ...(localBuildVersion ? { extraMetadata: { version: localBuildVersion } } : {}),
+  // Why: OS "Open With" / double-click markdown opens the floating workspace editor (#10138).
+  fileAssociations: [
+    {
+      ext: 'md',
+      name: 'Markdown Document',
+      description: 'Markdown Document',
+      mimeType: 'text/markdown',
+      role: 'Editor'
+    },
+    {
+      ext: 'mdx',
+      name: 'MDX Document',
+      description: 'MDX Document',
+      mimeType: 'text/mdx',
+      role: 'Editor'
+    },
+    {
+      ext: 'markdown',
+      name: 'Markdown Document',
+      description: 'Markdown Document',
+      mimeType: 'text/markdown',
+      role: 'Editor'
+    }
+  ],
   directories: {
     buildResources: 'resources/build'
   },

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -147,6 +147,7 @@ import {
 import { ensureWindowsUserDataAclGrant } from './startup/windows-user-data-acl'
 import { shouldQuitWhenAllWindowsClosed } from './startup/window-all-closed-quit-policy'
 import { createServeDesktopActivationGate } from './startup/serve-desktop-activation'
+import { createOsOpenMarkdownBridge } from './startup/os-open-markdown-bridge'
 import { RateLimitService } from './rate-limits/service'
 import { readMiniMaxSessionCookie } from './minimax/minimax-cookie-store'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
@@ -342,6 +343,15 @@ const isServeMode = process.argv.includes('--serve')
 if (isServeMode) {
   reserveServeStdoutForReadiness()
 }
+// Why: OS "Open With" / double-click markdown paths may arrive before the main window exists.
+const osOpenMarkdownBridge = createOsOpenMarkdownBridge()
+
+function flushOsOpenMarkdownDocuments(): void {
+  void osOpenMarkdownBridge.flush(() =>
+    mainWindow && !mainWindow.isDestroyed() ? mainWindow : null
+  )
+}
+
 const desktopActivationGate = createServeDesktopActivationGate({
   initialState: isServeMode ? 'initializing' : 'ready',
   activateWindow: () => {
@@ -349,6 +359,8 @@ const desktopActivationGate = createServeDesktopActivationGate({
     if (!isQuittingForUpdate()) {
       focusExistingWindow()
     }
+    // Why: second-instance Open With may focus an already-loaded window without did-finish-load.
+    flushOsOpenMarkdownDocuments()
   },
   onBlocked: (reason) => console.error(`[serve] Desktop activation blocked: ${reason}`)
 })
@@ -554,8 +566,12 @@ function focusExistingWindow(): void {
   })
 }
 
-function requestDesktopActivation(): void {
+function requestDesktopActivation(commandLine?: string[]): void {
+  if (commandLine && commandLine.length > 0) {
+    osOpenMarkdownBridge.enqueueArgv(commandLine)
+  }
   desktopActivationGate.requestActivation()
+  flushOsOpenMarkdownDocuments()
 }
 
 const handleMacAppActivation = createMacAppActivationHandler({
@@ -663,7 +679,23 @@ const hasSingleInstanceLock = skipSingleInstanceLock
   ? true
   : bypassSingleInstanceLock
     ? true
-    : acquireSingleInstanceLock(app, requestDesktopActivation)
+    : acquireSingleInstanceLock(app, (commandLine) => {
+        requestDesktopActivation(commandLine)
+      })
+
+// Why: macOS delivers open-file before ready; queue early so cold start does not drop Finder opens.
+if (process.platform === 'darwin') {
+  app.on('open-file', (event, filePath) => {
+    event.preventDefault()
+    osOpenMarkdownBridge.enqueuePaths([filePath])
+    if (app.isReady()) {
+      requestDesktopActivation()
+    }
+  })
+}
+
+// Why: Windows/Linux pass absolute paths on the initial argv when launched via "Open with".
+osOpenMarkdownBridge.enqueueArgv(process.argv)
 if (startupDiagnosticsEnabled) {
   logStartupDiagnostic('single-instance-lock-result', {
     acquired: hasSingleInstanceLock,
@@ -1163,6 +1195,8 @@ function openMainWindow(): BrowserWindow {
     clearExpectedRendererReload(rendererWebContentsId)
     recordCrashBreadcrumb('main_window_loaded')
     logStartupMilestone('did-finish-load')
+    // Why: cold-start Open With may have queued before the renderer mounted listeners.
+    flushOsOpenMarkdownDocuments()
     if (!store) {
       return
     }

--- a/src/main/startup/os-open-markdown-bridge.test.ts
+++ b/src/main/startup/os-open-markdown-bridge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createOsOpenMarkdownBridge } from './os-open-markdown-bridge'
+
+function makeWindow(send = vi.fn()) {
+  return {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      send
+    }
+  }
+}
+
+describe('createOsOpenMarkdownBridge', () => {
+  it('queues argv markdown paths and flushes MarkdownDocuments to the renderer', async () => {
+    const send = vi.fn()
+    const authorizePath = vi.fn()
+    const bridge = createOsOpenMarkdownBridge({
+      platform: 'linux',
+      resolveFloatingRoot: async () => '/tmp/floating',
+      authorizePath
+    })
+
+    bridge.enqueueArgv(['/usr/bin/orca-ide', '/home/dev/notes.md', '--foo'])
+    expect(bridge.peekQueuedPaths()).toEqual(['/home/dev/notes.md'])
+
+    await bridge.flush(() => makeWindow(send) as never)
+
+    expect(authorizePath).toHaveBeenCalledWith('/home/dev/notes.md')
+    expect(send).toHaveBeenCalledWith('ui:openFloatingMarkdownDocuments', [
+      expect.objectContaining({
+        filePath: '/home/dev/notes.md',
+        relativePath: 'notes.md',
+        basename: 'notes.md'
+      })
+    ])
+    expect(bridge.peekQueuedPaths()).toEqual([])
+  })
+
+  it('keeps the queue when no main window is available yet', async () => {
+    const bridge = createOsOpenMarkdownBridge({
+      platform: 'linux',
+      resolveFloatingRoot: async () => '/tmp/floating',
+      authorizePath: vi.fn()
+    })
+    bridge.enqueuePaths(['/tmp/a.md'])
+    await bridge.flush(() => null)
+    expect(bridge.peekQueuedPaths()).toEqual(['/tmp/a.md'])
+  })
+
+  it('skips paths that fail authorization without aborting the batch', async () => {
+    const send = vi.fn()
+    const authorizePath = vi.fn((filePath: string) => {
+      if (filePath.endsWith('bad.md')) {
+        throw new Error('denied')
+      }
+    })
+    const bridge = createOsOpenMarkdownBridge({
+      platform: 'linux',
+      resolveFloatingRoot: async () => '/tmp/floating',
+      authorizePath
+    })
+    bridge.enqueuePaths(['/tmp/bad.md', '/tmp/good.md'])
+    await bridge.flush(() => makeWindow(send) as never)
+    expect(send).toHaveBeenCalledWith('ui:openFloatingMarkdownDocuments', [
+      expect.objectContaining({ filePath: '/tmp/good.md' })
+    ])
+  })
+})

--- a/src/main/startup/os-open-markdown-bridge.ts
+++ b/src/main/startup/os-open-markdown-bridge.ts
@@ -1,0 +1,83 @@
+import type { BrowserWindow } from 'electron'
+import type { MarkdownDocument } from '../../shared/types'
+import { authorizeExternalPath } from '../ipc/filesystem-auth'
+import { ensureDefaultFloatingWorkspacePath } from '../ipc/floating-workspace-directory'
+import { isMarkdownDocumentName, markdownDocumentFromFilePath } from '../ipc/markdown-documents'
+import { extractMarkdownPathsFromArgv, mergeMarkdownOpenPaths } from './os-open-markdown-paths'
+
+export type OsOpenMarkdownBridge = {
+  enqueuePaths: (paths: readonly string[]) => void
+  enqueueArgv: (argv: readonly string[]) => void
+  /** Deliver queued paths to the main window when the renderer can receive IPC. */
+  flush: (getMainWindow: () => BrowserWindow | null) => Promise<void>
+  peekQueuedPaths: () => readonly string[]
+}
+
+export function createOsOpenMarkdownBridge(options: {
+  platform?: NodeJS.Platform
+  resolveFloatingRoot?: () => Promise<string>
+  authorizePath?: (filePath: string) => void
+}): OsOpenMarkdownBridge {
+  const platform = options.platform ?? process.platform
+  const resolveFloatingRoot =
+    options.resolveFloatingRoot ?? (() => ensureDefaultFloatingWorkspacePath())
+  const authorizePath = options.authorizePath ?? authorizeExternalPath
+  let queued: string[] = []
+  let flushInFlight: Promise<void> | null = null
+
+  const enqueuePaths = (paths: readonly string[]): void => {
+    queued = mergeMarkdownOpenPaths(queued, paths, { platform })
+  }
+
+  return {
+    enqueuePaths,
+    enqueueArgv: (argv) => {
+      enqueuePaths(extractMarkdownPathsFromArgv(argv, { platform }))
+    },
+    peekQueuedPaths: () => queued,
+    flush: async (getMainWindow) => {
+      if (flushInFlight) {
+        return flushInFlight
+      }
+      flushInFlight = (async () => {
+        if (queued.length === 0) {
+          return
+        }
+        const mainWindow = getMainWindow()
+        if (!mainWindow || mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
+          return
+        }
+
+        const pending = queued
+        queued = []
+        const root = await resolveFloatingRoot()
+        const documents: MarkdownDocument[] = []
+        for (const filePath of pending) {
+          if (!isMarkdownDocumentName(filePath)) {
+            continue
+          }
+          try {
+            authorizePath(filePath)
+            documents.push(
+              markdownDocumentFromFilePath(root, filePath, { outsideRootRelativePath: 'basename' })
+            )
+          } catch (error) {
+            console.warn(
+              '[os-open-markdown] Skipping path that failed authorization or resolution:',
+              filePath,
+              error instanceof Error ? error.message : error
+            )
+          }
+        }
+        if (documents.length === 0) {
+          return
+        }
+        // Why: renderer may still be mounting listeners on a cold start; a short retry covers that race.
+        mainWindow.webContents.send('ui:openFloatingMarkdownDocuments', documents)
+      })().finally(() => {
+        flushInFlight = null
+      })
+      return flushInFlight
+    }
+  }
+}

--- a/src/main/startup/os-open-markdown-bridge.ts
+++ b/src/main/startup/os-open-markdown-bridge.ts
@@ -51,6 +51,11 @@ export function createOsOpenMarkdownBridge(options: {
         const pending = queued
         queued = []
         const root = await resolveFloatingRoot()
+        // Why: window can close during await; never send on a destroyed webContents.
+        if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
+          queued = mergeMarkdownOpenPaths(queued, pending, { platform })
+          return
+        }
         const documents: MarkdownDocument[] = []
         for (const filePath of pending) {
           if (!isMarkdownDocumentName(filePath)) {
@@ -72,8 +77,30 @@ export function createOsOpenMarkdownBridge(options: {
         if (documents.length === 0) {
           return
         }
-        // Why: renderer may still be mounting listeners on a cold start; a short retry covers that race.
-        mainWindow.webContents.send('ui:openFloatingMarkdownDocuments', documents)
+        // Why: cold-start renderer may not have subscribed yet — retry once, re-queue on total miss.
+        const deliver = (): void => {
+          mainWindow.webContents.send('ui:openFloatingMarkdownDocuments', documents)
+        }
+        try {
+          deliver()
+        } catch (error) {
+          console.warn('[os-open-markdown] Failed to deliver documents to the renderer:', error)
+          queued = mergeMarkdownOpenPaths(
+            queued,
+            pending,
+            { platform }
+          )
+          return
+        }
+        await new Promise((resolve) => setTimeout(resolve, 250))
+        if (mainWindow.isDestroyed() || mainWindow.webContents.isDestroyed()) {
+          return
+        }
+        try {
+          deliver()
+        } catch (error) {
+          console.warn('[os-open-markdown] Retry deliver failed:', error)
+        }
       })().finally(() => {
         flushInFlight = null
       })

--- a/src/main/startup/os-open-markdown-paths.test.ts
+++ b/src/main/startup/os-open-markdown-paths.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { extractMarkdownPathsFromArgv, mergeMarkdownOpenPaths } from './os-open-markdown-paths'
+
+describe('extractMarkdownPathsFromArgv', () => {
+  it('keeps absolute markdown paths and drops switches', () => {
+    expect(
+      extractMarkdownPathsFromArgv(
+        [
+          '/Applications/Orca.app/Contents/MacOS/Orca',
+          '--allow-file-access-from-files',
+          '/Users/dev/notes/readme.md',
+          '/Users/dev/notes/guide.markdown',
+          '/Users/dev/notes/app.tsx'
+        ],
+        { platform: 'darwin' }
+      )
+    ).toEqual(['/Users/dev/notes/readme.md', '/Users/dev/notes/guide.markdown'])
+  })
+
+  it('accepts Windows drive-letter markdown paths', () => {
+    expect(
+      extractMarkdownPathsFromArgv(
+        ['C:\\Program Files\\Orca\\Orca.exe', 'C:\\Users\\dev\\todo.md', '--serve'],
+        { platform: 'win32' }
+      )
+    ).toEqual(['C:\\Users\\dev\\todo.md'])
+  })
+
+  it('dedupes case-insensitively on Windows', () => {
+    expect(
+      extractMarkdownPathsFromArgv(['C:\\notes\\A.md', 'c:\\notes\\a.md'], { platform: 'win32' })
+    ).toEqual(['C:\\notes\\A.md'])
+  })
+
+  it('ignores relative paths', () => {
+    expect(
+      extractMarkdownPathsFromArgv(['readme.md', './docs/a.md'], { platform: 'linux' })
+    ).toEqual([])
+  })
+})
+
+describe('mergeMarkdownOpenPaths', () => {
+  it('appends new absolute markdown paths', () => {
+    expect(
+      mergeMarkdownOpenPaths(['/tmp/a.md'], ['/tmp/b.mdx', '/tmp/a.md'], { platform: 'linux' })
+    ).toEqual(['/tmp/a.md', '/tmp/b.mdx'])
+  })
+})

--- a/src/main/startup/os-open-markdown-paths.test.ts
+++ b/src/main/startup/os-open-markdown-paths.test.ts
@@ -32,6 +32,21 @@ describe('extractMarkdownPathsFromArgv', () => {
     ).toEqual(['C:\\notes\\A.md'])
   })
 
+  it('normalizes dot-segment aliases before dedupe', () => {
+    expect(
+      extractMarkdownPathsFromArgv(
+        ['/tmp/notes/../notes/a.md', '/tmp/notes/a.md'],
+        { platform: 'linux' }
+      )
+    ).toEqual(['/tmp/notes/a.md'])
+    expect(
+      extractMarkdownPathsFromArgv(
+        ['C:\\temp\\..\\temp\\notes\\a.md', 'C:\\temp\\notes\\a.md'],
+        { platform: 'win32' }
+      )
+    ).toEqual(['C:\\temp\\notes\\a.md'])
+  })
+
   it('ignores relative paths', () => {
     expect(
       extractMarkdownPathsFromArgv(['readme.md', './docs/a.md'], { platform: 'linux' })

--- a/src/main/startup/os-open-markdown-paths.ts
+++ b/src/main/startup/os-open-markdown-paths.ts
@@ -1,0 +1,55 @@
+import { isAbsolute } from 'node:path'
+import { isMarkdownDocumentName } from '../ipc/markdown-documents'
+
+/** True for Electron/Chromium switches that must never be treated as file paths. */
+function isElectronArgvSwitch(arg: string): boolean {
+  return arg.startsWith('-') || arg.startsWith('--')
+}
+
+/**
+ * Collect absolute markdown paths from a process argv / second-instance commandLine.
+ * Skips the electron binary, script entry, and chromium switches.
+ */
+export function extractMarkdownPathsFromArgv(
+  argv: readonly string[],
+  options: { platform?: NodeJS.Platform } = {}
+): string[] {
+  const platform = options.platform ?? process.platform
+  const seen = new Set<string>()
+  const paths: string[] = []
+
+  for (const raw of argv) {
+    if (!raw || isElectronArgvSwitch(raw)) {
+      continue
+    }
+    // Why: electron packaging puts the app path / asar path early in argv; those are not open targets.
+    if (raw.endsWith('.asar') || raw.endsWith('electron') || raw.endsWith('Electron')) {
+      continue
+    }
+    if (raw.includes('node_modules') && raw.includes('electron')) {
+      continue
+    }
+    // Why: relative argv entries are ambiguous for OS "Open With"; require absolute paths.
+    if (!isAbsolute(raw) && !(platform === 'win32' && /^[A-Za-z]:[\\/]/.test(raw))) {
+      continue
+    }
+    if (!isMarkdownDocumentName(raw)) {
+      continue
+    }
+    const key = platform === 'win32' ? raw.toLowerCase() : raw
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    paths.push(raw)
+  }
+  return paths
+}
+
+export function mergeMarkdownOpenPaths(
+  existing: readonly string[],
+  incoming: readonly string[],
+  options: { platform?: NodeJS.Platform } = {}
+): string[] {
+  return extractMarkdownPathsFromArgv([...existing, ...incoming], options)
+}

--- a/src/main/startup/os-open-markdown-paths.ts
+++ b/src/main/startup/os-open-markdown-paths.ts
@@ -1,9 +1,13 @@
-import { isAbsolute, normalize } from 'node:path'
+import path from 'node:path'
 import { isMarkdownDocumentName } from '../ipc/markdown-documents'
 
 /** True for Electron/Chromium switches that must never be treated as file paths. */
 function isElectronArgvSwitch(arg: string): boolean {
   return arg.startsWith('-') || arg.startsWith('--')
+}
+
+function pathApiForPlatform(platform: NodeJS.Platform): path.PlatformPath {
+  return platform === 'win32' ? path.win32 : path.posix
 }
 
 /**
@@ -15,6 +19,7 @@ export function extractMarkdownPathsFromArgv(
   options: { platform?: NodeJS.Platform } = {}
 ): string[] {
   const platform = options.platform ?? process.platform
+  const pathApi = pathApiForPlatform(platform)
   const seen = new Set<string>()
   const paths: string[] = []
 
@@ -30,14 +35,15 @@ export function extractMarkdownPathsFromArgv(
       continue
     }
     // Why: relative argv entries are ambiguous for OS "Open With"; require absolute paths.
-    if (!isAbsolute(raw) && !(platform === 'win32' && /^[A-Za-z]:[\\/]/.test(raw))) {
+    if (!pathApi.isAbsolute(raw) && !(platform === 'win32' && /^[A-Za-z]:[\\/]/.test(raw))) {
       continue
     }
     if (!isMarkdownDocumentName(raw)) {
       continue
     }
-    // Why: argv may carry equivalent paths with `..` segments; normalize before dedupe.
-    const normalized = normalize(raw)
+    // Why: argv may carry equivalent paths with `..` segments; normalize with
+    // platform semantics before dedupe (win32 tests must not depend on host OS).
+    const normalized = pathApi.normalize(raw)
     const key = platform === 'win32' ? normalized.toLowerCase() : normalized
     if (seen.has(key)) {
       continue

--- a/src/main/startup/os-open-markdown-paths.ts
+++ b/src/main/startup/os-open-markdown-paths.ts
@@ -1,4 +1,4 @@
-import { isAbsolute } from 'node:path'
+import { isAbsolute, normalize } from 'node:path'
 import { isMarkdownDocumentName } from '../ipc/markdown-documents'
 
 /** True for Electron/Chromium switches that must never be treated as file paths. */
@@ -36,12 +36,14 @@ export function extractMarkdownPathsFromArgv(
     if (!isMarkdownDocumentName(raw)) {
       continue
     }
-    const key = platform === 'win32' ? raw.toLowerCase() : raw
+    // Why: argv may carry equivalent paths with `..` segments; normalize before dedupe.
+    const normalized = normalize(raw)
+    const key = platform === 'win32' ? normalized.toLowerCase() : normalized
     if (seen.has(key)) {
       continue
     }
     seen.add(key)
-    paths.push(raw)
+    paths.push(normalized)
   }
   return paths
 }

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -56,11 +56,11 @@ describe('acquireSingleInstanceLock', () => {
     expect(acquired).toBe(true)
     expect(fake.requestSingleInstanceLock).toHaveBeenCalledTimes(1)
     expect(fake.on).toHaveBeenCalledTimes(1)
-    expect(fake.on).toHaveBeenCalledWith('second-instance', onSecondInstance)
+    expect(fake.on).toHaveBeenCalledWith('second-instance', expect.any(Function))
     expect(fake.listeners['second-instance']).toHaveLength(1)
   })
 
-  it('fires the registered callback when second-instance dispatches', () => {
+  it('fires the registered callback with the second-instance commandLine', () => {
     const onSecondInstance = vi.fn()
     const fake = makeFakeApp(true)
 
@@ -68,9 +68,10 @@ describe('acquireSingleInstanceLock', () => {
 
     const [registered] = fake.listeners['second-instance'] ?? []
     expect(registered).toBeDefined()
-    registered?.()
+    registered?.({}, ['/tmp/Orca', '/tmp/notes.md'])
 
     expect(onSecondInstance).toHaveBeenCalledTimes(1)
+    expect(onSecondInstance).toHaveBeenCalledWith(['/tmp/Orca', '/tmp/notes.md'])
   })
 })
 

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -26,11 +26,17 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
  * way dev (`orca-dev` userData) and packaged (`orca` userData) runs lock in
  * separate namespaces instead of serialising against each other.
  */
-export function acquireSingleInstanceLock(app: App, onSecondInstance: () => void): boolean {
+export function acquireSingleInstanceLock(
+  app: App,
+  onSecondInstance: (commandLine: string[]) => void
+): boolean {
   if (!app.requestSingleInstanceLock()) {
     return false
   }
-  app.on('second-instance', onSecondInstance)
+  // Why: second-instance carries the OS "Open With" argv so we can open markdown paths.
+  app.on('second-instance', (_event, commandLine) => {
+    onSecondInstance(commandLine)
+  })
   return true
 }
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3019,6 +3019,9 @@ export type PreloadApi = {
     onToggleRightSidebar: (callback: () => void) => () => void
     onToggleWorktreePalette: (callback: () => void) => () => void
     onToggleFloatingTerminal: (callback: () => void) => () => void
+    onOpenFloatingMarkdownDocuments: (
+      callback: (documents: MarkdownDocument[]) => void
+    ) => () => void
     onTerminalShortcutCaptured: (
       callback: (data: { actionId: KeybindingActionId }) => void
     ) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3366,6 +3366,14 @@ const api = {
       ipcRenderer.on('ui:toggleFloatingTerminal', listener)
       return () => ipcRenderer.removeListener('ui:toggleFloatingTerminal', listener)
     },
+    onOpenFloatingMarkdownDocuments: (
+      callback: (documents: MarkdownDocument[]) => void
+    ): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, documents: MarkdownDocument[]) =>
+        callback(documents)
+      ipcRenderer.on('ui:openFloatingMarkdownDocuments', listener)
+      return () => ipcRenderer.removeListener('ui:openFloatingMarkdownDocuments', listener)
+    },
     onTerminalShortcutCaptured: (
       callback: (data: { actionId: KeybindingActionId }) => void
     ): (() => void) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -70,6 +70,7 @@ import { MarkdownTemplatePicker } from './components/editor/MarkdownTemplatePick
 import { FloatingTerminalToggleButton } from './components/floating-terminal/FloatingTerminalToggleButton'
 import { OrcaProfileSwitcher } from './components/orca-profiles/OrcaProfileSwitcher'
 import {
+  OPEN_FLOATING_TERMINAL_EVENT,
   TOGGLE_FLOATING_TERMINAL_EVENT,
   requestFloatingTerminalOpenMaximized
 } from '@/lib/floating-terminal'
@@ -627,8 +628,16 @@ function App(): React.JSX.Element {
         setFloatingTerminalOpenWithFocus((open) => !open)
       }
     }
+    // Why: OS Open With may enable the floating workspace in the same turn; always honor force-open.
+    const openFloatingTerminal = (): void => {
+      setFloatingTerminalOpenWithFocus(true)
+    }
     window.addEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
-    return () => window.removeEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
+    window.addEventListener(OPEN_FLOATING_TERMINAL_EVENT, openFloatingTerminal)
+    return () => {
+      window.removeEventListener(TOGGLE_FLOATING_TERMINAL_EVENT, toggleFloatingTerminal)
+      window.removeEventListener(OPEN_FLOATING_TERMINAL_EVENT, openFloatingTerminal)
+    }
   }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
 
   useEffect(() => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -71,7 +71,11 @@ import {
   shouldSuppressInheritedTerminalStatus
 } from '../../../shared/agent-status-identity'
 import { isGitRepoKind } from '../../../shared/repo-kind'
-import { TOGGLE_FLOATING_TERMINAL_EVENT } from '@/lib/floating-terminal'
+import {
+  OPEN_FLOATING_TERMINAL_EVENT,
+  TOGGLE_FLOATING_TERMINAL_EVENT
+} from '@/lib/floating-terminal'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import { TOGGLE_QUICK_COMMANDS_MENU_EVENT } from '@/lib/quick-commands-menu-events'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
@@ -1343,6 +1347,37 @@ export function useIpcEvents(): void {
         window.dispatchEvent(new CustomEvent(TOGGLE_FLOATING_TERMINAL_EVENT))
       })
     )
+
+    if (window.api.ui.onOpenFloatingMarkdownDocuments) {
+      unsubs.push(
+        window.api.ui.onOpenFloatingMarkdownDocuments((documents) => {
+          void (async () => {
+            const store = useAppStore.getState()
+            // Why: OS Open With should surface the floating workspace even if the user hid it.
+            if (store.settings?.floatingTerminalEnabled === false) {
+              await store.updateSettings({ floatingTerminalEnabled: true })
+            }
+            window.dispatchEvent(new CustomEvent(OPEN_FLOATING_TERMINAL_EVENT))
+            for (const document of documents) {
+              useAppStore.getState().openFile(
+                {
+                  filePath: document.filePath,
+                  relativePath: document.relativePath,
+                  worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+                  language: detectLanguage(document.relativePath),
+                  mode: 'edit',
+                  runtimeEnvironmentId: null
+                },
+                {
+                  preview: false,
+                  suppressActiveRuntimeFallback: true
+                }
+              )
+            }
+          })()
+        })
+      )
+    }
 
     if (window.api.ui.onTerminalShortcutCaptured) {
       unsubs.push(

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1353,26 +1353,35 @@ export function useIpcEvents(): void {
         window.api.ui.onOpenFloatingMarkdownDocuments((documents) => {
           void (async () => {
             const store = useAppStore.getState()
-            // Why: OS Open With should surface the floating workspace even if the user hid it.
-            if (store.settings?.floatingTerminalEnabled === false) {
+            // Why: cold start has settings=null; treat unhydrated as disabled so OS
+            // Open With still enables the floating workspace before hydration.
+            if (store.settings?.floatingTerminalEnabled !== true) {
               await store.updateSettings({ floatingTerminalEnabled: true })
             }
             window.dispatchEvent(new CustomEvent(OPEN_FLOATING_TERMINAL_EVENT))
             for (const document of documents) {
-              useAppStore.getState().openFile(
-                {
-                  filePath: document.filePath,
-                  relativePath: document.relativePath,
-                  worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
-                  language: detectLanguage(document.relativePath),
-                  mode: 'edit',
-                  runtimeEnvironmentId: null
-                },
-                {
-                  preview: false,
-                  suppressActiveRuntimeFallback: true
-                }
-              )
+              try {
+                useAppStore.getState().openFile(
+                  {
+                    filePath: document.filePath,
+                    relativePath: document.relativePath,
+                    worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+                    language: detectLanguage(document.relativePath),
+                    mode: 'edit',
+                    runtimeEnvironmentId: null
+                  },
+                  {
+                    preview: false,
+                    suppressActiveRuntimeFallback: true
+                  }
+                )
+              } catch (error) {
+                console.warn(
+                  '[os-open-markdown] Failed to open document:',
+                  document.filePath,
+                  error
+                )
+              }
             }
           })().catch((error) => {
             console.warn('[os-open-markdown] Failed to open floating markdown documents:', error)

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -1374,7 +1374,9 @@ export function useIpcEvents(): void {
                 }
               )
             }
-          })()
+          })().catch((error) => {
+            console.warn('[os-open-markdown] Failed to open floating markdown documents:', error)
+          })
         })
       )
     }

--- a/src/renderer/src/lib/floating-terminal.ts
+++ b/src/renderer/src/lib/floating-terminal.ts
@@ -1,4 +1,6 @@
 export const TOGGLE_FLOATING_TERMINAL_EVENT = 'orca-toggle-floating-terminal'
+/** Force the floating workspace open (not toggle) for OS Open With markdown. */
+export const OPEN_FLOATING_TERMINAL_EVENT = 'orca-open-floating-terminal'
 
 // Why: maximize/restore lives in the panel's own keydown handler, but that
 // handler is unmounted while the panel is closed. When Cmd+Opt+Shift+A is

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2536,6 +2536,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onToggleRightSidebar: () => noopUnsubscribe,
     onToggleWorktreePalette: () => noopUnsubscribe,
     onToggleFloatingTerminal: () => noopUnsubscribe,
+    onOpenFloatingMarkdownDocuments: () => noopUnsubscribe,
     onTerminalShortcutCaptured: () => noopUnsubscribe,
     onOpenQuickOpen: () => noopUnsubscribe,
     onToggleQuickCommandsMenu: () => noopUnsubscribe,


### PR DESCRIPTION
## Summary

- Register Orca as an **Open With** handler for `.md` / `.mdx` / `.markdown` (electron-builder `fileAssociations`).
- Queue OS open paths from:
  - cold-start `process.argv` (Windows/Linux)
  - macOS `open-file` (early, before ready)
  - second-instance `commandLine` when Orca is already running
- When the main window can receive IPC, open the **floating workspace** and each document via the existing floating markdown open path (`MarkdownDocument` + `openFile`).
- Re-enables the floating workspace setting if it was turned off, so Open With still works.

Fixes #10138

## Test plan

- [x] Unit: argv extraction (absolute markdown only, switches ignored, Windows paths)
- [x] Unit: bridge queue / flush / auth skip
- [x] Unit: second-instance passes commandLine
- [ ] Manual (packaged preferred): double-click `.md` → Orca opens floating workspace with that file
- [ ] Manual: Orca already running → Open With another `.md` → focuses Orca and opens the file
- [ ] Manual: non-markdown path ignored

## ELI5

Orca can be chosen as Open With for .md/.mdx/.markdown files. OS open (cold start, second instance, macOS open-file) opens those files in the floating workspace markdown viewer.
