### PR TITLE
fix(workspace-board): sync Linear on context-menu Move to Status

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Pin } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
-import type { Repo, Worktree } from '../../../../shared/types'
+import type { Repo, WorkspaceStatus, Worktree } from '../../../../shared/types'
 import WorktreeCard from './WorktreeCard'
 import { translate } from '@/i18n/i18n'
 
@@ -18,6 +18,7 @@ type WorkspaceKanbanCardProps = {
     event: React.MouseEvent<HTMLElement>,
     worktree: Worktree
   ) => readonly Worktree[]
+  onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
 }
 
 function WorkspaceKanbanCard({
@@ -29,7 +30,8 @@ function WorkspaceKanbanCard({
   nativeDragEnabled = true,
   onActivate,
   onSelectionGesture,
-  onContextMenuSelect
+  onContextMenuSelect,
+  onAssignWorkspaceStatus
 }: WorkspaceKanbanCardProps): React.JSX.Element {
   const contextWorktrees =
     isSelected && selectedWorktrees && selectedWorktrees.length > 0 ? selectedWorktrees : undefined
@@ -61,6 +63,7 @@ function WorkspaceKanbanCard({
         onActivate={onActivate}
         onSelectionGesture={onSelectionGesture}
         onContextMenuSelect={(event) => onContextMenuSelect(event, worktree)}
+        onAssignWorkspaceStatus={onAssignWorkspaceStatus}
       />
     </div>
   )

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.task-status-sync.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.task-status-sync.test.tsx
@@ -31,7 +31,8 @@ const {
   toastErrorMock,
   toastWarningMock,
   pointerDragState,
-  documentDropState
+  documentDropState,
+  laneAssignStatusState
 } = vi.hoisted(() => ({
   syncWorkspaceBoardTaskStatusesMock: vi.fn(() =>
     Promise.resolve({
@@ -44,7 +45,10 @@ const {
   toastErrorMock: vi.fn(),
   toastWarningMock: vi.fn(),
   pointerDragState: { current: null as PointerDragParams | null },
-  documentDropState: { current: null as DocumentDropCapture | null }
+  documentDropState: { current: null as DocumentDropCapture | null },
+  laneAssignStatusState: {
+    current: null as ((worktreeIds: readonly string[], status: string) => void) | null
+  }
 }))
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -81,7 +85,14 @@ vi.mock('./WorkspaceKanbanDrawerHeader', () => ({
 }))
 
 vi.mock('./WorkspaceKanbanLaneGrid', () => ({
-  default: () => <div data-testid="workspace-board-lanes" />
+  default: ({
+    onAssignWorkspaceStatus
+  }: {
+    onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: string) => void
+  }) => {
+    laneAssignStatusState.current = onAssignWorkspaceStatus ?? null
+    return <div data-testid="workspace-board-lanes" />
+  }
 }))
 
 vi.mock('./WorkspaceKanbanAreaSelectionOverlay', () => ({
@@ -255,6 +266,7 @@ beforeEach(() => {
   root = createRoot(container)
   pointerDragState.current = null
   documentDropState.current = null
+  laneAssignStatusState.current = null
   syncWorkspaceBoardTaskStatusesMock.mockClear()
   toastErrorMock.mockClear()
   toastWarningMock.mockClear()
@@ -398,6 +410,44 @@ describe('WorkspaceKanbanDrawer task status sync wiring', () => {
         description: '1 skipped. No matching Linear workflow state for In review.'
       })
     )
+  })
+
+  it('syncs Linear when the board context-menu "Move to Status" assigns a status', () => {
+    const item = worktree()
+    renderDrawer(item)
+
+    act(() => {
+      laneAssignStatusState.current?.([item.id], 'in-review')
+    })
+
+    expect(syncWorkspaceBoardTaskStatusesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeIds: [item.id],
+        targetStatus: { id: 'in-review', label: 'In review' }
+      })
+    )
+  })
+
+  it('does not sync a context-menu status move when the setting is disabled', () => {
+    const item = worktree()
+    renderDrawer(item, false)
+
+    act(() => {
+      laneAssignStatusState.current?.([item.id], 'in-review')
+    })
+
+    expect(syncWorkspaceBoardTaskStatusesMock).not.toHaveBeenCalled()
+  })
+
+  it('does not sync a context-menu status move that keeps the same board status', () => {
+    const item = worktree({ workspaceStatus: 'in-review' })
+    renderDrawer(item)
+
+    act(() => {
+      laneAssignStatusState.current?.([item.id], 'in-review')
+    })
+
+    expect(syncWorkspaceBoardTaskStatusesMock).not.toHaveBeenCalled()
   })
 
   it('shows an error toast when task status sync unexpectedly rejects', async () => {

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -288,6 +288,30 @@ export default function WorkspaceKanbanDrawer({
     },
     [maybeSyncWorkspaceBoardTaskStatuses, updateWorktreeMeta, workspaceStatuses, worktreeById]
   )
+  // Why: the board's context-menu "Move to Status" must funnel through the same
+  // local-first + Linear-sync path as drag-and-drop. Without this callback the
+  // menu only writes the local status and silently drops the Linear sync.
+  const moveWorktreesToStatus = useCallback(
+    (worktreeIds: readonly string[], status: WorkspaceStatus) => {
+      const updates = new Map<string, Partial<WorktreeMeta>>()
+      const changedIds: string[] = []
+      for (const worktreeId of worktreeIds) {
+        const current = worktreeById.get(worktreeId)
+        if (!current || getWorkspaceStatus(current, workspaceStatuses) === status) {
+          continue
+        }
+        changedIds.push(worktreeId)
+        updates.set(worktreeId, { workspaceStatus: status })
+      }
+      if (changedIds.length === 0) {
+        return
+      }
+      useAppStore.getState().recordFeatureInteraction('workspace-board-actions')
+      void updateWorktreesMeta(updates)
+      maybeSyncWorkspaceBoardTaskStatuses(changedIds, status)
+    },
+    [maybeSyncWorkspaceBoardTaskStatuses, updateWorktreesMeta, workspaceStatuses, worktreeById]
+  )
   const getSourceStatusKeys = useCallback(
     (worktreeIds: readonly string[]): WorkspaceStatus[] =>
       worktreeIds.flatMap((worktreeId) => {
@@ -775,6 +799,7 @@ export default function WorkspaceKanbanDrawer({
               onActivate={handleWorktreeActivate}
               onSelectionGesture={updateSelectionForGesture}
               onContextMenuSelect={selectForContextMenu}
+              onAssignWorkspaceStatus={moveWorktreesToStatus}
               onCreateWorktree={createWorktreeForStatus}
               onColumnResizeStart={onColumnResizeStart}
               onColumnResizeKeyDown={onColumnResizeKeyDown}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanLaneGrid.tsx
@@ -27,6 +27,7 @@ type WorkspaceKanbanLaneGridProps = {
     event: React.MouseEvent<HTMLElement>,
     worktree: Worktree
   ) => readonly Worktree[]
+  onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
   onCreateWorktree: (statusId: string) => void
   onColumnResizeStart: (event: React.PointerEvent<HTMLElement>) => void
   onColumnResizeKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void
@@ -49,6 +50,7 @@ export default function WorkspaceKanbanLaneGrid({
   onActivate,
   onSelectionGesture,
   onContextMenuSelect,
+  onAssignWorkspaceStatus,
   onCreateWorktree,
   onColumnResizeStart,
   onColumnResizeKeyDown
@@ -81,6 +83,7 @@ export default function WorkspaceKanbanLaneGrid({
           onActivate={onActivate}
           onSelectionGesture={onSelectionGesture}
           onContextMenuSelect={onContextMenuSelect}
+          onAssignWorkspaceStatus={onAssignWorkspaceStatus}
           onCreateWorktree={onCreateWorktree}
           onColumnResizeStart={onColumnResizeStart}
           onColumnResizeKeyDown={onColumnResizeKeyDown}

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanStatusLane.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanStatusLane.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { Plus } from 'lucide-react'
-import type { Repo, WorkspaceStatusDefinition, Worktree } from '../../../../shared/types'
+import type {
+  Repo,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition,
+  Worktree
+} from '../../../../shared/types'
 import {
   WORKSPACE_BOARD_COLUMN_WIDTH_MAX,
   WORKSPACE_BOARD_COLUMN_WIDTH_MIN
@@ -33,6 +38,7 @@ type WorkspaceKanbanStatusLaneProps = {
     event: React.MouseEvent<HTMLElement>,
     worktree: Worktree
   ) => readonly Worktree[]
+  onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
   onCreateWorktree: (statusId: string) => void
   onColumnResizeStart: (event: React.PointerEvent<HTMLElement>) => void
   onColumnResizeKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void
@@ -56,6 +62,7 @@ export default function WorkspaceKanbanStatusLane({
   onActivate,
   onSelectionGesture,
   onContextMenuSelect,
+  onAssignWorkspaceStatus,
   onCreateWorktree,
   onColumnResizeStart,
   onColumnResizeKeyDown
@@ -166,6 +173,7 @@ export default function WorkspaceKanbanStatusLane({
                   onActivate={onActivate}
                   onSelectionGesture={onSelectionGesture}
                   onContextMenuSelect={onContextMenuSelect}
+                  onAssignWorkspaceStatus={onAssignWorkspaceStatus}
                 />
               )
             })}

--- a/src/renderer/src/components/sidebar/WorktreeCard.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.tsx
@@ -35,6 +35,7 @@ import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-revi
 import type {
   GitHubWorkItem,
   Worktree,
+  WorkspaceStatus,
   Repo,
   IssueInfo,
   LinearIssue
@@ -133,6 +134,7 @@ type WorktreeCardProps = {
     event: React.MouseEvent<HTMLElement>,
     worktree: Worktree
   ) => readonly Worktree[]
+  onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
   onCardDragStart?: (
     event: React.DragEvent<HTMLDivElement>,
     worktreeId: string,
@@ -216,6 +218,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
   onImmediateActivate,
   onSelectionGesture,
   onContextMenuSelect,
+  onAssignWorkspaceStatus,
   onCardDragStart,
   onCardDragEnd,
   nativeDragEnabled = true,
@@ -1905,6 +1908,7 @@ const WorktreeCard = React.memo(function WorktreeCard({
           worktree={worktree}
           selectedWorktrees={selectedWorktrees}
           onContextMenuSelect={handleContextMenuSelect}
+          onAssignWorkspaceStatus={onAssignWorkspaceStatus}
         >
           {cardBody}
         </WorktreeContextMenu>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -11,9 +11,10 @@ import {
   getWorktreeParentPickerLabel,
   hasWorktreeParentLink,
   isWorktreeParentPickerDisabled,
+  planWorkspaceStatusAssignment,
   selectMenuScopedMap
 } from './WorktreeContextMenu'
-import type { Worktree, WorktreeLineage } from '../../../../shared/types'
+import type { Worktree, WorktreeLineage, WorkspaceStatusDefinition } from '../../../../shared/types'
 
 describe('selectMenuScopedMap (delete-teardown re-render guard)', () => {
   // Why: the closed menu wrapper must stay inert to delete teardown's high-churn
@@ -232,5 +233,51 @@ describe('project removal from workspace context menus', () => {
     expect(isContextWorktreeDeletable({ isMainWorktree: false }, folderRepo)).toBe(true)
     expect(isContextWorktreeDeletable({ isMainWorktree: true }, folderRepo)).toBe(false)
     expect(isContextWorktreeDeletable({ isMainWorktree: false }, null)).toBe(false)
+  })
+})
+
+describe('planWorkspaceStatusAssignment (context-menu "Move to Status" routing)', () => {
+  // Why: this is the exact branch #10175 regressed on — the board must funnel
+  // through the Linear-sync callback, the sidebar list must stay local-only. A
+  // silent flip of either branch re-introduces the bug, so pin both here.
+  const statuses: WorkspaceStatusDefinition[] = [
+    { id: 'todo', label: 'Todo' },
+    { id: 'in-review', label: 'In review' }
+  ]
+  const wt = (id: string, workspaceStatus: string): Worktree =>
+    ({ id, workspaceStatus }) as Worktree
+
+  it('routes to board Linear-sync with ALL selected ids when the board wired a callback', () => {
+    // The board path forwards every id; moveWorktreesToStatus filters no-ops downstream.
+    expect(
+      planWorkspaceStatusAssignment(
+        [wt('a', 'todo'), wt('b', 'in-review')],
+        'in-review',
+        statuses,
+        true
+      )
+    ).toEqual({ kind: 'board-sync', worktreeIds: ['a', 'b'] })
+  })
+
+  it('falls back to local-only writes of only status-changed worktrees off the board', () => {
+    expect(
+      planWorkspaceStatusAssignment(
+        [wt('a', 'todo'), wt('b', 'in-review')],
+        'in-review',
+        statuses,
+        false
+      )
+    ).toEqual({ kind: 'local-only', localWriteIds: ['a'] })
+  })
+
+  it('writes nothing on the local-only path when every worktree already has the target status', () => {
+    expect(
+      planWorkspaceStatusAssignment(
+        [wt('a', 'in-review'), wt('b', 'in-review')],
+        'in-review',
+        statuses,
+        false
+      )
+    ).toEqual({ kind: 'local-only', localWriteIds: [] })
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -35,7 +35,7 @@ import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
-import type { Repo, Worktree } from '../../../../shared/types'
+import type { Repo, Worktree, WorkspaceStatus } from '../../../../shared/types'
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
@@ -65,6 +65,7 @@ type Props = {
   contentClassName?: string
   selectedWorktrees?: readonly Worktree[]
   onContextMenuSelect?: (event: React.MouseEvent<HTMLElement>) => readonly Worktree[]
+  onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: WorkspaceStatus) => void
   onOpenChange?: (open: boolean) => void
 }
 
@@ -284,6 +285,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   contentClassName,
   selectedWorktrees,
   onContextMenuSelect,
+  onAssignWorkspaceStatus,
   onOpenChange
 }: Props) {
   const defaultSelectedWorktrees = useMemo(() => [worktree], [worktree])
@@ -504,6 +506,15 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const handleAssignWorkspaceStatus = useCallback(
     (status: string) => {
       setMenuOpenState(false)
+      if (onAssignWorkspaceStatus) {
+        onAssignWorkspaceStatus(
+          activeContextWorktrees.map((item) => item.id),
+          status
+        )
+        return
+      }
+      // Why: outside the workspace board (e.g. the sidebar list) status changes
+      // are local-only; Linear sync is scoped to board moves like drag-and-drop.
       void Promise.all(
         activeContextWorktrees.map((item) =>
           getWorkspaceStatus(item, workspaceStatuses) === status
@@ -512,7 +523,13 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
         )
       )
     },
-    [activeContextWorktrees, setMenuOpenState, updateWorktreeMeta, workspaceStatuses]
+    [
+      activeContextWorktrees,
+      onAssignWorkspaceStatus,
+      setMenuOpenState,
+      updateWorktreeMeta,
+      workspaceStatuses
+    ]
   )
 
   const handleRename = useCallback(() => {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -35,7 +35,12 @@ import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
-import type { Repo, Worktree, WorkspaceStatus } from '../../../../shared/types'
+import type {
+  Repo,
+  Worktree,
+  WorkspaceStatus,
+  WorkspaceStatusDefinition
+} from '../../../../shared/types'
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
@@ -279,6 +284,29 @@ function preserveDeleteSiblingPosition(scope: HTMLElement | null): () => void {
   }
 }
 
+export type WorkspaceStatusAssignmentPlan =
+  | { readonly kind: 'board-sync'; readonly worktreeIds: readonly string[] }
+  | { readonly kind: 'local-only'; readonly localWriteIds: readonly string[] }
+
+// Why: the context-menu "Move to Status" routes to the board's local-first +
+// Linear-sync path when the board wired a callback, else a local-only write of
+// only the status-changed worktrees. Extracted pure so the routing and the
+// no-op filter stay unit-testable without opening the Radix menu.
+export function planWorkspaceStatusAssignment(
+  worktrees: readonly Worktree[],
+  status: WorkspaceStatus,
+  workspaceStatuses: readonly WorkspaceStatusDefinition[],
+  boardSyncEnabled: boolean
+): WorkspaceStatusAssignmentPlan {
+  if (boardSyncEnabled) {
+    return { kind: 'board-sync', worktreeIds: worktrees.map((item) => item.id) }
+  }
+  const localWriteIds = worktrees
+    .filter((item) => getWorkspaceStatus(item, workspaceStatuses) !== status)
+    .map((item) => item.id)
+  return { kind: 'local-only', localWriteIds }
+}
+
 const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   worktree,
   children,
@@ -506,21 +534,20 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const handleAssignWorkspaceStatus = useCallback(
     (status: string) => {
       setMenuOpenState(false)
-      if (onAssignWorkspaceStatus) {
-        onAssignWorkspaceStatus(
-          activeContextWorktrees.map((item) => item.id),
-          status
-        )
+      const plan = planWorkspaceStatusAssignment(
+        activeContextWorktrees,
+        status,
+        workspaceStatuses,
+        Boolean(onAssignWorkspaceStatus)
+      )
+      if (plan.kind === 'board-sync') {
+        onAssignWorkspaceStatus?.(plan.worktreeIds, status)
         return
       }
       // Why: outside the workspace board (e.g. the sidebar list) status changes
       // are local-only; Linear sync is scoped to board moves like drag-and-drop.
       void Promise.all(
-        activeContextWorktrees.map((item) =>
-          getWorkspaceStatus(item, workspaceStatuses) === status
-            ? Promise.resolve()
-            : updateWorktreeMeta(item.id, { workspaceStatus: status })
-        )
+        plan.localWriteIds.map((id) => updateWorktreeMeta(id, { workspaceStatus: status }))
       )
     },
     [


### PR DESCRIPTION
## Summary

Fixes #10175 — the workspace board context-menu "Move to Status" silently drops the Linear sync that drag-and-drop performs.

## Root cause

`handleAssignWorkspaceStatus` in `WorktreeContextMenu` only wrote the local `workspaceStatus`. The Linear sync (`maybeSyncWorkspaceBoardTaskStatuses`) lived in `WorkspaceKanbanDrawer` and was unreachable from the shared menu component, which receives no sync callback. So drag-and-drop synced to Linear, but the right-click menu did not.

## Fix

Thread an `onAssignWorkspaceStatus` callback from the drawer through the kanban card chain (`LaneGrid → StatusLane → KanbanCard → WorktreeCard → WorktreeContextMenu`). The menu now funnels through the new `moveWorktreesToStatus` (batch equivalent of the existing single-worktree `moveWorktreeToStatus`), which performs the local-first write **and** the Linear sync — identical to drag-and-drop. Outside the board (sidebar list) the menu keeps its existing local-only behavior, since Linear sync is scoped to workspace-board moves.

## Screenshots

N/A — pure logic fix; no visual change. The board context menu and lanes render exactly as before.

## AI Review Report

- **Approach chosen:** prop-threading (Option 1) over calling the sync directly from the menu (Option 2). This keeps the sync orchestration, gating (`getWorkspaceBoardTaskStatusSyncRequest`), settings resolution, and toast handling in a single place (`WorkspaceKanbanDrawer`), avoiding duplication and matching the existing drag-drop path exactly.
- **Scope:** the callback is optional. The sidebar-list usage does not pass it, so its behavior is unchanged (local-only) — consistent with the fact that drag-drop (the only other sync trigger) also only exists on the board.
- **Multi-select:** the handler accepts a `worktreeIds[]` and the batch path filters out no-op (same-status) entries before writing or syncing, mirroring `dropWorktreesInStatus`.
- **Risks:** low. No change to the sync module itself, no store middleware added, no new network paths. The only behavioral change is that the board context-menu now also triggers the already-existing sync.

## Security Audit

- No secrets, tokens, or credentials introduced or logged.
- No new network calls — the Linear update goes through the existing `linearUpdateIssue` runtime client already used by drag-drop.
- Worktree ids and status ids are already-trusted store values; no untrusted input reaches the Linear API.
- No changes to auth, IPC, or filesystem paths.

## Testing

- [x] New regression tests in `WorkspaceKanbanDrawer.task-status-sync.test.tsx`:
  - syncs Linear when the board context-menu assigns a status (enabled)
  - does not sync when the setting is disabled
  - does not sync a no-op move that keeps the same status
- [x] `tsc --noEmit -p config/tsconfig.tc.web.json` — clean
- [x] `oxlint` (+ react-doctor via lint-staged) and `oxfmt` — clean
- [x] Existing sidebar test suite green (`workspace-board-task-status-sync`, `WorktreeCard.*`, `workspace-kanban.*`)

## Notes

- The fix is intentionally scoped to the workspace board. Extending Linear sync to the sidebar-list context menu would be a separate, deliberate behavior change (the setting is named "Sync task status **from workspace board**").
- No `max-lines` disables added; the prop-threading touches several files but each change is a single optional prop.

Closes #10175