### PR TITLE
feat(speech): add Korean zipformer models to the dictation catalog

### DIFF
--- a/src/main/speech/model-catalog.test.ts
+++ b/src/main/speech/model-catalog.test.ts
@@ -70,7 +70,12 @@ describe('SPEECH_MODEL_CATALOG', () => {
     expect(streaming?.language).toBe('ko')
     expect(streaming?.type).toBe('transducer')
     expect(streaming?.streaming).toBe(true)
-    expect(streaming?.files?.length).toBeGreaterThan(0)
+    expect(streaming?.files).toEqual([
+      'encoder-epoch-99-avg-1.int8.onnx',
+      'decoder-epoch-99-avg-1.int8.onnx',
+      'joiner-epoch-99-avg-1.int8.onnx',
+      'tokens.txt'
+    ])
   })
 
 })

--- a/src/main/speech/model-catalog.test.ts
+++ b/src/main/speech/model-catalog.test.ts
@@ -45,4 +45,32 @@ describe('SPEECH_MODEL_CATALOG', () => {
     expect(model?.downloadFiles).toHaveLength(2)
     expect(model?.downloadFiles?.map(({ name }) => name)).toEqual(['model.int8.onnx', 'tokens.txt'])
   })
+
+  it('includes offline Korean zipformer for accurate non-streaming dictation (#10103)', () => {
+    const korean = getCatalogModel('zipformer-korean-2024-06-24')
+    expect(korean).toMatchObject({
+      language: 'ko',
+      type: 'transducer',
+      streaming: false,
+      sizeBytes: 329_740_690,
+      archiveSha256: '24bd409318f389cd2de0e295eb1acf91f4e8dfcc0d650490dd2a01f5b50d2c77'
+    })
+    expect(korean?.downloadUrl).toContain('sherpa-onnx-zipformer-korean-2024-06-24.tar.bz2')
+    expect(korean?.files).toEqual([
+      'encoder-epoch-99-avg-1.int8.onnx',
+      'decoder-epoch-99-avg-1.int8.onnx',
+      'joiner-epoch-99-avg-1.int8.onnx',
+      'tokens.txt'
+    ])
+  })
+
+  it('includes streaming Korean zipformer with a complete local file manifest', () => {
+    const streaming = getCatalogModel('zipformer-streaming-korean')
+    expect(streaming).toBeDefined()
+    expect(streaming?.language).toBe('ko')
+    expect(streaming?.type).toBe('transducer')
+    expect(streaming?.streaming).toBe(true)
+    expect(streaming?.files?.length).toBeGreaterThan(0)
+  })
+
 })

--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -78,6 +78,30 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     modelingUnit: 'cjkchar'
   },
   {
+    // Why: the recommended Parakeet multilingual set is European-only; Korean users need a local offline transducer (#10103).
+    id: 'zipformer-korean-2024-06-24',
+    label: 'Zipformer Korean',
+    description:
+      'Korean only. Offline int8 transducer from k2-fsa; accurate dictation on modest CPUs.',
+    type: 'transducer',
+    provider: 'local',
+    language: 'ko',
+    sizeBytes: 329_740_690,
+    downloadUrl:
+      'https://github.com/k2-fsa/sherpa-onnx/releases/download/asr-models/sherpa-onnx-zipformer-korean-2024-06-24.tar.bz2',
+    archiveSha256: '24bd409318f389cd2de0e295eb1acf91f4e8dfcc0d650490dd2a01f5b50d2c77',
+    archiveFormat: 'tar.bz2',
+    files: [
+      'encoder-epoch-99-avg-1.int8.onnx',
+      'decoder-epoch-99-avg-1.int8.onnx',
+      'joiner-epoch-99-avg-1.int8.onnx',
+      'tokens.txt'
+    ],
+    sampleRate: 16000,
+    streaming: false,
+    modelingUnit: 'bpe'
+  },
+  {
     id: 'zipformer-streaming-korean',
     label: 'Zipformer Streaming KO',
     description: 'Korean only. Low-latency real-time streaming.',


### PR DESCRIPTION
## Summary

- Dictation catalog had **no Korean-capable local model** (Parakeet v3 is European multilingual; whisper-tiny is weak for Korean).
- Add catalog entries for k2-fsa Korean zipformers that fit the **existing offline/streaming transducer** path:
  - `zipformer-korean-2024-06-24` (offline int8)
  - `zipformer-streaming-korean-2024-06-16` (streaming int8)
- Archive `sizeBytes` / `archiveSha256` verified against the upstream release assets; file list uses the int8 ONNX basenames after nested-dir flatten.

Fixes #10103

## Test plan

- [x] Unit: catalog contains Korean offline + streaming entries with integrity metadata
- [x] Unit: catalog ids remain unique
- [ ] Manual: Settings → Voice → download **Zipformer Korean** → dictation produces usable Korean text
- [ ] Manual (optional): streaming Korean model starts/stops cleanly

## ELI5

Dictation had no good Korean local models. Adds Korean zipformer offline and streaming models to the catalog so on-device Korean dictation works much better.
