### PR TITLE
fix(sidebar): keep Idle rows for launchAgent tabs after SSH Codex idles

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-idle-row.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-idle-row.ts
@@ -1,0 +1,50 @@
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { formatAgentTypeLabel } from '@/lib/agent-status'
+import type {
+  AgentStatusEntry,
+  AgentStatusOrchestrationContext,
+  AgentType
+} from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+
+export function buildTitleDerivedIdleAgentRow(args: {
+  paneKey: string
+  tab: TerminalTab
+  title: string
+  launchAgent: AgentType
+  now: number
+  authorityId: string
+  orchestration?: AgentStatusOrchestrationContext
+}): DashboardAgentRow {
+  const rowLabel = formatAgentTypeLabel(args.launchAgent)
+  // Why: title-only rows are renderer snapshots, not provider hook transitions.
+  const entry: AgentStatusEntry = {
+    paneKey: args.paneKey,
+    state: 'working',
+    prompt: rowLabel,
+    updatedAt: args.now,
+    stateStartedAt: args.now,
+    stateHistory: [],
+    agentType: args.launchAgent,
+    terminalTitle: args.title,
+    lastAssistantMessage: 'Idle',
+    ...(args.orchestration ? { orchestration: args.orchestration } : {}),
+    observation: {
+      origin: 'title',
+      authorityId: args.authorityId,
+      incarnation: 0,
+      revision: args.now,
+      observedAt: args.now,
+      kind: 'snapshot'
+    }
+  }
+  return {
+    paneKey: args.paneKey,
+    entry,
+    tab: args.tab,
+    agentType: args.launchAgent,
+    rowSource: 'live',
+    state: 'idle',
+    startedAt: 0
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-owner.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-owner.ts
@@ -1,0 +1,34 @@
+import type { AgentType } from '../../../../shared/agent-status-types'
+import { isTerminalLeafId } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
+import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
+
+export function resolveLaunchAgentOwnerLeafId(
+  tab: TerminalTab,
+  layout: TerminalLayoutSnapshot | undefined,
+  layoutLeafIds: readonly string[]
+): string | null {
+  const layoutActiveLeafId = layout?.activeLeafId
+  const layoutOwnerLeafId =
+    layoutLeafIds.length === 1
+      ? layoutLeafIds[0]
+      : layoutLeafIds.length === 0 && layoutActiveLeafId && isTerminalLeafId(layoutActiveLeafId)
+        ? layoutActiveLeafId
+        : null
+  const retainedLaunchAgentLeafId =
+    tab.launchAgentLeafId && isTerminalLeafId(tab.launchAgentLeafId) ? tab.launchAgentLeafId : null
+  return layoutOwnerLeafId ?? retainedLaunchAgentLeafId
+}
+
+export function resolveTitleDerivedPaneOwner(args: {
+  tab: TerminalTab
+  layout: TerminalLayoutSnapshot | undefined
+  layoutLeafIds: readonly string[]
+  leafId: string
+}): AgentType | null {
+  // Why: a tab-wide launch hint may be the only owner evidence while layout is unhydrated; in a split it still brands only its retained leaf.
+  if (resolveLaunchAgentOwnerLeafId(args.tab, args.layout, args.layoutLeafIds) !== args.leafId) {
+    return null
+  }
+  return resolvePaneAgentOwner({ launchAgent: args.tab.launchAgent })
+}

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -271,4 +271,62 @@ describe('buildTitleDerivedAgentRows', () => {
 
     expect(rows).toHaveLength(0)
   })
+
+  it('keeps an Idle row for a launchAgent tab when the title reverts to a neutral cwd (#10130)', () => {
+    const launchAgent: TuiAgent = 'codex'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        // After the turn finishes, SSH Codex drops the spinner and leaves a bare title.
+        'tab-1': { 1: 'demo-repo' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex-remote-idle'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(
+      rows.map((row) => [
+        row.agentType,
+        row.state,
+        row.entry.prompt,
+        row.entry.lastAssistantMessage
+      ])
+    ).toEqual([['codex', 'idle', 'Codex', 'Idle']])
+  })
+
+  it('keeps Idle for a launchAgent tab at a plain shell title while the PTY is live', () => {
+    const launchAgent: TuiAgent = 'codex'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'zsh' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex-shell'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'idle']])
+  })
+
+  it('does not invent an Idle row for a neutral title without launch identity', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'demo-repo' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-plain'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -329,4 +329,26 @@ describe('buildTitleDerivedAgentRows', () => {
 
     expect(rows).toHaveLength(0)
   })
+
+  it('does not invent Idle launchAgent rows for every split pane with a neutral title', () => {
+    const launchAgent: TuiAgent = 'codex'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        // Both leaves look idle; launchAgent is tab-scoped and must not mint
+        // a row per neutral sibling (CodeRabbit on #10178).
+        'tab-1': {
+          1: 'demo-repo',
+          2: 'zsh'
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -437,4 +437,26 @@ describe('buildTitleDerivedAgentRows', () => {
 
     expect(rows).toHaveLength(0)
   })
+
+  it('does not invent Idle launchAgent rows for every split pane with a neutral title', () => {
+    const launchAgent: TuiAgent = 'codex'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        // Both leaves look idle; launchAgent is tab-scoped and must not mint
+        // a row per neutral sibling (CodeRabbit on #10178).
+        'tab-1': {
+          1: 'demo-repo',
+          2: 'zsh'
+        }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-left', 'pty-right'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -272,7 +272,6 @@ describe('buildTitleDerivedAgentRows', () => {
 
     expect(rows).toHaveLength(0)
   })
-
   // #10258: Cursor's native title is deliberately status-less, which used to hide the pane.
   it('adds an idle Cursor row for the bare native cursor-agent title', () => {
     const rows = buildWorktreeAgentRows({
@@ -376,6 +375,63 @@ describe('buildTitleDerivedAgentRows', () => {
       runtimePaneTitlesByTabId: { 'tab-1': { 1: '⠋ implementing the feature' } },
       ptyIdsByTabId: { 'tab-1': ['pty-a', 'pty-b'] },
       terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },
+      now: 2000
+    })
+
+    expect(rows).toHaveLength(0)
+  })
+  it('keeps an Idle row for a launchAgent tab when the title reverts to a neutral cwd (#10130)', () => {
+    const launchAgent: TuiAgent = 'codex'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        // After the turn finishes, SSH Codex drops the spinner and leaves a bare title.
+        'tab-1': { 1: 'demo-repo' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex-remote-idle'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(
+      rows.map((row) => [
+        row.agentType,
+        row.state,
+        row.entry.prompt,
+        row.entry.lastAssistantMessage
+      ])
+    ).toEqual([['codex', 'idle', 'Codex', 'Idle']])
+  })
+
+  it('keeps Idle for a launchAgent tab at a plain shell title while the PTY is live', () => {
+    const launchAgent: TuiAgent = 'codex'
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'zsh' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-codex-shell'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'idle']])
+  })
+
+  it('does not invent an Idle row for a neutral title without launch identity', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1')],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'demo-repo' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-plain'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
       now: 2000
     })
 

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -422,6 +422,26 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows.map((row) => [row.agentType, row.state])).toEqual([['codex', 'idle']])
   })
 
+  it('keeps an Idle row when the layout snapshot is temporarily unavailable', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [
+        makeTab('tab-1', {
+          title: 'demo-repo',
+          launchAgent: 'codex',
+          launchAgentLeafId: LEAF_ID_1
+        })
+      ],
+      entries: [],
+      retained: [],
+      ptyIdsByTabId: { 'tab-1': ['pty-codex-remote-idle'] },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.paneKey, row.agentType, row.state])).toEqual([
+      [makePaneKey('tab-1', LEAF_ID_1), 'codex', 'idle']
+    ])
+  })
+
   it('does not invent an Idle row for a neutral title without launch identity', () => {
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1')],

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -135,51 +135,84 @@ function buildTitleDerivedAgentRow(args: {
   // the management/list screen as active work.
   const status = isClaudeAgentsTitle ? 'idle' : classifyTitleActivity(title)
   const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
-  if (!status || !label) {
-    return null
-  }
   if (!isTerminalLeafId(args.leafId)) {
     return null
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
-  // Why: a braille spinner proves activity, not identity, so the resolver drops
-  // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd titles;
-  // fall back to the tab's launch identity instead of hiding the pane. Gated on
-  // the spinner on purpose — unlike the hook path's unconditional launchAgent
-  // fallback (resolveRowAgentType), this path manufactures agent-ness from a
-  // title alone, so a non-agent title must never become a row. Residual: a split
-  // pane whose own title carries a braille glyph is still attributed to launchAgent.
-  const agentType =
-    titleAgentType ?? (containsBrailleSpinner(title) ? (args.tab.launchAgent ?? null) : null)
-  if (!agentType) {
+  const launchAgent = args.tab.launchAgent ?? null
+
+  if (status && label) {
+    const titleAgentType = isClaudeAgentsTitle
+      ? 'claude'
+      : resolveTitleDerivedAgentType(title, label)
+    // Why: a braille spinner proves activity, not identity, so the resolver drops
+    // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd titles;
+    // fall back to the tab's launch identity instead of hiding the pane. Gated on
+    // the spinner on purpose — unlike the hook path's unconditional launchAgent
+    // fallback (resolveRowAgentType), this path manufactures agent-ness from a
+    // title alone, so a non-agent title must never become a row. Residual: a split
+    // pane whose own title carries a braille glyph is still attributed to launchAgent.
+    const agentType = titleAgentType ?? (containsBrailleSpinner(title) ? launchAgent : null)
+    if (!agentType) {
+      return null
+    }
+    const rowLabel = titleAgentType ? label : formatAgentTypeLabel(agentType)
+    const rowState = titleStatusToRowState(status)
+    const secondary =
+      status === 'permission' ? 'Needs input' : status === 'working' ? 'Running' : 'Idle'
+    const entryState: AgentStatusState = rowState === 'waiting' ? 'waiting' : 'working'
+    const entry: AgentStatusEntry = {
+      paneKey,
+      state: entryState,
+      prompt: rowLabel,
+      updatedAt: args.now,
+      stateStartedAt: args.now,
+      stateHistory: [],
+      agentType,
+      terminalTitle: title,
+      lastAssistantMessage: secondary,
+      ...(orchestration ? { orchestration } : {})
+    }
+    return {
+      paneKey,
+      entry,
+      tab: args.tab,
+      agentType,
+      rowSource: 'live',
+      state: rowState,
+      startedAt: 0
+    }
+  }
+
+  // Why: after a hook-less SSH Codex turn finishes, the title reverts to a bare
+  // cwd/shell with no spinner and no agent name (#10130). Spinner fallback no
+  // longer applies, and remote hooks are dead (#8711), so without this path the
+  // reusable idle session vanishes from the sidebar while the PTY/tab remain.
+  // Only manufacture Idle when the title is not claiming work/permission.
+  if (!launchAgent || status === 'working' || status === 'permission') {
     return null
   }
-  const rowLabel = titleAgentType ? label : formatAgentTypeLabel(agentType)
-  const rowState = titleStatusToRowState(status)
-  const secondary =
-    status === 'permission' ? 'Needs input' : status === 'working' ? 'Running' : 'Idle'
-  const entryState: AgentStatusState = rowState === 'waiting' ? 'waiting' : 'working'
+  const rowLabel = formatAgentTypeLabel(launchAgent)
   const entry: AgentStatusEntry = {
     paneKey,
-    state: entryState,
+    state: 'working',
     prompt: rowLabel,
     updatedAt: args.now,
     stateStartedAt: args.now,
     stateHistory: [],
-    agentType,
+    agentType: launchAgent,
     terminalTitle: title,
-    lastAssistantMessage: secondary,
+    lastAssistantMessage: 'Idle',
     ...(orchestration ? { orchestration } : {})
   }
   return {
     paneKey,
     entry,
     tab: args.tab,
-    agentType,
+    agentType: launchAgent,
     rowSource: 'live',
-    state: rowState,
+    state: 'idle',
     startedAt: 0
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -63,6 +63,11 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
     const layout = terminalLayoutsByTabId[tab.id]
+    const layoutLeafIds = collectLeafIds(layout?.root ?? null)
+    // Why: launchAgent is tab-scoped. Idle fallback may only bind to the sole
+    // launch-owning leaf — multi-leaf tabs must not mint Idle rows for every
+    // neutral sibling shell (#10130 / CodeRabbit on #10178).
+    const launchAgentOwnerLeafId = layoutLeafIds.length === 1 ? layoutLeafIds[0] : null
     const paneTitles = runtimePaneTitlesByTabId[tab.id]
     const paneTitleEntries =
       paneTitles && Object.keys(paneTitles).length > 0
@@ -85,6 +90,7 @@ export function buildTitleDerivedAgentRows(args: {
           leafId,
           title,
           now: args.now,
+          allowLaunchAgentIdleFallback: launchAgentOwnerLeafId === leafId,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
         })
         if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -96,15 +102,21 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
 
-    const leafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
+    const leafId = layout?.activeLeafId ?? layoutLeafIds[0]
     if (!leafId) {
       continue
     }
+    // Why: tab-title path emits at most one row; allow when that leaf is the
+    // sole owner, or topology is unknown (no layout leaves) so single-pane
+    // SSH idle still surfaces without a hydrated layout snapshot.
+    const allowLaunchAgentIdleFallback =
+      launchAgentOwnerLeafId === leafId || layoutLeafIds.length === 0
     const row = buildTitleDerivedAgentRow({
       tab,
       leafId,
       title: tab.title,
       now: args.now,
+      allowLaunchAgentIdleFallback,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
     })
     if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -126,6 +138,8 @@ function buildTitleDerivedAgentRow(args: {
   leafId: string
   title: string
   now: number
+  /** Why: idle launchAgent fallback is only safe for the launch-owning leaf. */
+  allowLaunchAgentIdleFallback?: boolean
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
   const title = normalizeCompatibleAgentTitleForOwner(args.title, args.tab.launchAgent)
@@ -189,8 +203,14 @@ function buildTitleDerivedAgentRow(args: {
   // cwd/shell with no spinner and no agent name (#10130). Spinner fallback no
   // longer applies, and remote hooks are dead (#8711), so without this path the
   // reusable idle session vanishes from the sidebar while the PTY/tab remain.
-  // Only manufacture Idle when the title is not claiming work/permission.
-  if (!launchAgent || status === 'working' || status === 'permission') {
+  // Only manufacture Idle when the title is not claiming work/permission, and
+  // only for the launch-owning leaf (tab.launchAgent is not per-pane).
+  if (
+    !launchAgent ||
+    !args.allowLaunchAgentIdleFallback ||
+    status === 'working' ||
+    status === 'permission'
+  ) {
     return null
   }
   const rowLabel = formatAgentTypeLabel(launchAgent)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -71,6 +71,11 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
     const layout = terminalLayoutsByTabId[tab.id]
+    const layoutLeafIds = collectLeafIds(layout?.root ?? null)
+    // Why: launchAgent is tab-scoped. Idle fallback may only bind to the sole
+    // launch-owning leaf — multi-leaf tabs must not mint Idle rows for every
+    // neutral sibling shell (#10130 / CodeRabbit on #10178).
+    const launchAgentOwnerLeafId = layoutLeafIds.length === 1 ? layoutLeafIds[0] : null
     const paneTitles = runtimePaneTitlesByTabId[tab.id]
     const paneTitleEntries =
       paneTitles && Object.keys(paneTitles).length > 0
@@ -94,6 +99,7 @@ export function buildTitleDerivedAgentRows(args: {
           title,
           ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
           now: args.now,
+          allowLaunchAgentIdleFallback: launchAgentOwnerLeafId === leafId,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
         })
         if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -105,16 +111,22 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
 
-    const leafId = layout?.activeLeafId ?? collectLeafIds(layout?.root ?? null)[0]
+    const leafId = layout?.activeLeafId ?? layoutLeafIds[0]
     if (!leafId) {
       continue
     }
+    // Why: tab-title path emits at most one row; allow when that leaf is the
+    // sole owner, or topology is unknown (no layout leaves) so single-pane
+    // SSH idle still surfaces without a hydrated layout snapshot.
+    const allowLaunchAgentIdleFallback =
+      launchAgentOwnerLeafId === leafId || layoutLeafIds.length === 0
     const row = buildTitleDerivedAgentRow({
       tab,
       leafId,
       title: tab.title,
       ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
       now: args.now,
+      allowLaunchAgentIdleFallback,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
     })
     if (!row || args.seenPaneKeys.has(row.paneKey)) {
@@ -137,6 +149,8 @@ function buildTitleDerivedAgentRow(args: {
   title: string
   ownerAgentType: AgentType | null
   now: number
+  /** Why: idle launchAgent fallback is only safe for the launch-owning leaf. */
+  allowLaunchAgentIdleFallback?: boolean
   runtimeAgentOrchestrationByPaneKey?: Record<string, AgentStatusOrchestrationContext>
 }): DashboardAgentRow | null {
   // Why launchAgent, not ownerAgentType: this only rewrites a title within its own identity
@@ -212,8 +226,13 @@ function buildTitleDerivedAgentRow(args: {
     }
   }
 
-  // Why: hook-less SSH Codex leaves a live pane at its cwd title after a turn.
-  if (!launchAgent || status === 'working' || status === 'permission') {
+  // Why: idle fallback is only safe for the launch-owning leaf because launchAgent is tab-scoped.
+  if (
+    !launchAgent ||
+    !args.allowLaunchAgentIdleFallback ||
+    status === 'working' ||
+    status === 'permission'
+  ) {
     return null
   }
   const rowLabel = formatAgentTypeLabel(launchAgent)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -20,9 +20,12 @@ import {
   resolveCompatibleAgentTypeForOwner,
   type CompatibleAgentOwnerOptions
 } from '../../../../shared/agent-title-owner'
-import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
 import { buildTitleDerivedIdleAgentRow } from './worktree-title-derived-agent-idle-row'
+import {
+  resolveLaunchAgentOwnerLeafId,
+  resolveTitleDerivedPaneOwner
+} from './worktree-title-derived-agent-owner'
 
 /** Fixed, not per-process: title rows are a pure projection of the current title, so they are
  *  comparable across restarts in a way a sequenced authority's rows are not. Ordering against
@@ -76,7 +79,7 @@ export function buildTitleDerivedAgentRows(args: {
     // Why: launchAgent is tab-scoped. Idle fallback may only bind to the sole
     // launch-owning leaf — multi-leaf tabs must not mint Idle rows for every
     // neutral sibling shell (#10130 / CodeRabbit on #10178).
-    const launchAgentOwnerLeafId = layoutLeafIds.length === 1 ? layoutLeafIds[0] : null
+    const launchAgentOwnerLeafId = resolveLaunchAgentOwnerLeafId(tab, layout, layoutLeafIds)
     const paneTitles = runtimePaneTitlesByTabId[tab.id]
     const paneTitleEntries =
       paneTitles && Object.keys(paneTitles).length > 0
@@ -89,7 +92,8 @@ export function buildTitleDerivedAgentRows(args: {
           layout,
           paneTitleEntries,
           paneId: Number(paneId),
-          title
+          title,
+          fallbackLeafId: launchAgentOwnerLeafId
         })
         if (!leafId) {
           continue
@@ -98,7 +102,7 @@ export function buildTitleDerivedAgentRows(args: {
           tab,
           leafId,
           title,
-          ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+          ownerAgentType: resolveTitleDerivedPaneOwner({ tab, layout, layoutLeafIds, leafId }),
           now: args.now,
           allowLaunchAgentIdleFallback: launchAgentOwnerLeafId === leafId,
           runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
@@ -112,20 +116,17 @@ export function buildTitleDerivedAgentRows(args: {
       continue
     }
 
-    const leafId = layout?.activeLeafId ?? layoutLeafIds[0]
+    // Why: tab-wide title metadata belongs to its retained launch owner even when a split's active leaf or the layout snapshot is unavailable.
+    const leafId = launchAgentOwnerLeafId ?? layout?.activeLeafId ?? layoutLeafIds[0]
     if (!leafId) {
       continue
     }
-    // Why: tab-title path emits at most one row; allow when that leaf is the
-    // sole owner, or topology is unknown (no layout leaves) so single-pane
-    // SSH idle still surfaces without a hydrated layout snapshot.
-    const allowLaunchAgentIdleFallback =
-      launchAgentOwnerLeafId === leafId || layoutLeafIds.length === 0
+    const allowLaunchAgentIdleFallback = launchAgentOwnerLeafId === leafId
     const row = buildTitleDerivedAgentRow({
       tab,
       leafId,
       title: tab.title,
-      ownerAgentType: resolveTitleDerivedPaneOwner(tab, layout, leafId),
+      ownerAgentType: resolveTitleDerivedPaneOwner({ tab, layout, layoutLeafIds, leafId }),
       now: args.now,
       allowLaunchAgentIdleFallback,
       runtimeAgentOrchestrationByPaneKey: args.runtimeAgentOrchestrationByPaneKey
@@ -271,19 +272,6 @@ export function resolveTitleDerivedAgentType(
   return agentType
 }
 
-function resolveTitleDerivedPaneOwner(
-  tab: TerminalTab,
-  layout: TerminalLayoutSnapshot | undefined,
-  leafId: string
-): AgentType | null {
-  // Why: launchAgent is tab-scoped, so it is pane ownership only while the tab has one
-  // leaf; applying it inside a split would let one pane brand its sibling.
-  if (layout?.root?.type !== 'leaf' || layout.root.leafId !== leafId) {
-    return null
-  }
-  return resolvePaneAgentOwner({ launchAgent: tab.launchAgent })
-}
-
 /**
  * Determines the agent type from a terminal title, normalising Pi-compatible
  * agents to their authoritative owner if specified.
@@ -324,12 +312,17 @@ function resolveLeafIdForTitleFallback(args: {
   paneTitleEntries: [string, string][]
   paneId: number
   title: string
+  fallbackLeafId: string | null
 }): string | null {
   const matchingTitleLeafIds = Object.entries(args.layout?.titlesByLeafId ?? {})
     .filter(([, title]) => title === args.title)
     .map(([leafId]) => leafId)
   if (matchingTitleLeafIds.length === 1) {
     return matchingTitleLeafIds[0]
+  }
+
+  if (!args.layout?.root && args.fallbackLeafId && args.paneTitleEntries.length === 1) {
+    return args.fallbackLeafId
   }
 
   const leafIds = collectLeafIds(args.layout?.root ?? null)

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -156,49 +156,78 @@ function buildTitleDerivedAgentRow(args: {
     ? 'idle'
     : (classifyTitleActivity(title) ?? (isCursorAgentTitle(title) ? 'idle' : null))
   const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
-  if (!status || !label) {
-    return null
-  }
   if (!isTerminalLeafId(args.leafId)) {
     return null
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle
-    ? 'claude'
-    : resolveTitleDerivedAgentType(title, label, args.ownerAgentType)
-  // Why: a status frame proves activity, not identity, so the resolver drops it.
-  // Hook-less agents over SSH (Codex, #8711; OpenCode's '. '/'* ' frames, #8940)
-  // surface only decorated task titles; fall back to the pane's known owner instead
-  // of hiding the pane. Safe because the `!status || !label` gate above already
-  // rejects plain shell titles — this path must never manufacture a row from one.
+  const titleAgentType =
+    status && label
+      ? isClaudeAgentsTitle
+        ? 'claude'
+        : resolveTitleDerivedAgentType(title, label, args.ownerAgentType)
+      : null
+  // Why: a status frame proves activity, not identity; use the pane's known owner
+  // for hook-less SSH panes after the title has established agent activity.
   const agentType = titleAgentType ?? args.ownerAgentType
-  if (!agentType) {
+  const launchAgent = args.tab.launchAgent ?? null
+
+  if (status && label) {
+    if (!agentType) {
+      return null
+    }
+    const rowLabel = titleAgentType ? label : formatAgentTypeLabel(agentType)
+    const rowState = titleStatusToRowState(status)
+    const secondary =
+      status === 'permission' ? 'Needs input' : status === 'working' ? 'Running' : 'Idle'
+    const entryState: AgentStatusState = rowState === 'waiting' ? 'waiting' : 'working'
+    const entry: AgentStatusEntry = {
+      paneKey,
+      state: entryState,
+      prompt: rowLabel,
+      updatedAt: args.now,
+      stateStartedAt: args.now,
+      stateHistory: [],
+      agentType,
+      terminalTitle: title,
+      lastAssistantMessage: secondary,
+      ...(orchestration ? { orchestration } : {}),
+      observation: {
+        origin: 'title',
+        authorityId: TITLE_DERIVED_AGENT_ROW_AUTHORITY_ID,
+        incarnation: 0,
+        revision: args.now,
+        observedAt: args.now,
+        kind: 'snapshot'
+      }
+    }
+    return {
+      paneKey,
+      entry,
+      tab: args.tab,
+      agentType,
+      rowSource: 'live',
+      state: rowState,
+      startedAt: 0
+    }
+  }
+
+  // Why: hook-less SSH Codex leaves a live pane at its cwd title after a turn.
+  if (!launchAgent || status === 'working' || status === 'permission') {
     return null
   }
-  const rowLabel = titleAgentType ? label : formatAgentTypeLabel(agentType)
-  const rowState = titleStatusToRowState(status)
-  const secondary =
-    status === 'permission' ? 'Needs input' : status === 'working' ? 'Running' : 'Idle'
-  const entryState: AgentStatusState = rowState === 'waiting' ? 'waiting' : 'working'
+  const rowLabel = formatAgentTypeLabel(launchAgent)
   const entry: AgentStatusEntry = {
     paneKey,
-    state: entryState,
+    state: 'working',
     prompt: rowLabel,
     updatedAt: args.now,
     stateStartedAt: args.now,
     stateHistory: [],
-    agentType,
+    agentType: launchAgent,
     terminalTitle: title,
-    lastAssistantMessage: secondary,
+    lastAssistantMessage: 'Idle',
     ...(orchestration ? { orchestration } : {}),
-    // Why not the renderer sequencer: this row is RE-DERIVED from the pane's title on every
-    // render, not observed once, so a counter would churn a new revision per frame and break
-    // memoization. Deriving revision from `now` keeps the stamp deterministic in the same clock
-    // the row already publishes as updatedAt, and monotonic for the pane.
-    // The origin tag is the point: `entryState` above collapses a title-derived IDLE row to
-    // 'working' while the row itself reports idle. That contradiction is out of scope here —
-    // this tag is what makes it findable instead of indistinguishable from a real hook row.
     observation: {
       origin: 'title',
       authorityId: TITLE_DERIVED_AGENT_ROW_AUTHORITY_ID,
@@ -212,9 +241,9 @@ function buildTitleDerivedAgentRow(args: {
     paneKey,
     entry,
     tab: args.tab,
-    agentType,
+    agentType: launchAgent,
     rowSource: 'live',
-    state: rowState,
+    state: 'idle',
     startedAt: 0
   }
 }

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../../shared/pane-agent-owner'
 import { isClaudeIdentityFrameTitle } from '../../../../shared/terminal-title-agent-type'
+import { buildTitleDerivedIdleAgentRow } from './worktree-title-derived-agent-idle-row'
 
 /** Fixed, not per-process: title rows are a pure projection of the current title, so they are
  *  comparable across restarts in a way a sequenced authority's rows are not. Ordering against
@@ -226,45 +227,24 @@ function buildTitleDerivedAgentRow(args: {
     }
   }
 
-  // Why: idle fallback is only safe for the launch-owning leaf because launchAgent is tab-scoped.
+  // Why: SSH Codex can lose hooks after a turn; other agents must keep title-based identity.
   if (
-    !launchAgent ||
+    launchAgent !== 'codex' ||
     !args.allowLaunchAgentIdleFallback ||
     status === 'working' ||
     status === 'permission'
   ) {
     return null
   }
-  const rowLabel = formatAgentTypeLabel(launchAgent)
-  const entry: AgentStatusEntry = {
+  return buildTitleDerivedIdleAgentRow({
     paneKey,
-    state: 'working',
-    prompt: rowLabel,
-    updatedAt: args.now,
-    stateStartedAt: args.now,
-    stateHistory: [],
-    agentType: launchAgent,
-    terminalTitle: title,
-    lastAssistantMessage: 'Idle',
-    ...(orchestration ? { orchestration } : {}),
-    observation: {
-      origin: 'title',
-      authorityId: TITLE_DERIVED_AGENT_ROW_AUTHORITY_ID,
-      incarnation: 0,
-      revision: args.now,
-      observedAt: args.now,
-      kind: 'snapshot'
-    }
-  }
-  return {
-    paneKey,
-    entry,
     tab: args.tab,
-    agentType: launchAgent,
-    rowSource: 'live',
-    state: 'idle',
-    startedAt: 0
-  }
+    title,
+    launchAgent,
+    now: args.now,
+    authorityId: TITLE_DERIVED_AGENT_ROW_AUTHORITY_ID,
+    orchestration
+  })
 }
 
 export function resolveTitleDerivedAgentType(

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1473,6 +1473,7 @@ function buildMirroredTerminalTabs(
     }
     const launchAgent =
       activeSurface.launchAgent ?? surfaces.find((surface) => surface.launchAgent)?.launchAgent
+    const launchAgentSurface = surfaces.find((surface) => surface.launchAgent)
     const ownerRecord = resolvePaneAgentOwnerRecord({
       launchAgent,
       hookAgent: activeSurface.agentStatus?.agentType,
@@ -1485,6 +1486,12 @@ function buildMirroredTerminalTabs(
       surfaces
         .map((surface) => existingById.get(toWebTerminalSurfaceTabId(surface.id)))
         .find((tab): tab is TerminalTab => Boolean(tab))
+    const launchAgentLeafId =
+      launchAgentSurface && isTerminalLeafId(launchAgentSurface.leafId)
+        ? launchAgentSurface.leafId
+        : launchAgent && existing?.launchAgentLeafId && isTerminalLeafId(existing.launchAgentLeafId)
+          ? existing.launchAgentLeafId
+          : undefined
     // Why: a headless host publishes the literal "Terminal" while an idle pane
     // has no live PTY. Keep the client's known title until a ready surface reports one.
     const hostTitle = activeSurface.title.trim() || surfaces[0]?.title.trim() || ''
@@ -1532,7 +1539,8 @@ function buildMirroredTerminalTabs(
         sortOrder: sortOffset + index,
         createdAt: existing?.createdAt ?? now + index,
         // Why: launchAgent is host-owned lifecycle metadata; once the host omits it, don't resurrect stale startup intent.
-        ...(launchAgent ? { launchAgent } : {})
+        ...(launchAgent ? { launchAgent } : {}),
+        ...(launchAgentLeafId ? { launchAgentLeafId } : {})
       },
       hostTabId: parentTabId,
       ptyIds,

--- a/src/renderer/src/store/terminals/terminal-layout-state.ts
+++ b/src/renderer/src/store/terminals/terminal-layout-state.ts
@@ -1,4 +1,5 @@
-import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import {
   normalizeTerminalLayoutPtyOwnership,
@@ -13,6 +14,32 @@ import {
   withTerminalTabPtyId
 } from './terminal-pty-identities'
 import { transferNormalizedTerminalLayoutPtyOwnership } from './workspace-terminal-hydration-patch'
+
+function retainLaunchAgentLeafId(
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  tabId: string,
+  layout: TerminalLayoutSnapshot
+): Record<string, TerminalTab[]> {
+  const leafId = layout.root?.type === 'leaf' ? layout.root.leafId : null
+  if (!leafId || !isTerminalLeafId(leafId)) {
+    return tabsByWorktree
+  }
+
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    const tabIndex = tabs.findIndex((tab) => tab.id === tabId)
+    if (tabIndex === -1) {
+      continue
+    }
+    const tab = tabs[tabIndex]
+    if (!tab?.launchAgent || tab.launchAgentLeafId === leafId) {
+      return tabsByWorktree
+    }
+    const nextTabs = [...tabs]
+    nextTabs[tabIndex] = { ...tab, launchAgentLeafId: leafId }
+    return { ...tabsByWorktree, [worktreeId]: nextTabs }
+  }
+  return tabsByWorktree
+}
 
 export function createTerminalLayoutActions(
   set: TerminalStoreSet,
@@ -72,13 +99,28 @@ export function createTerminalLayoutActions(
             normalized.snapshot
           )
         }
-        // Why: pane-title churn re-persists structurally identical snapshots; bailing keeps every pane selector asleep.
         const existing = s.terminalLayoutsByTabId[tabId]
-        if (existing && terminalLayoutEqual(existing, normalized.snapshot)) {
+        const nextTabsByWorktree = retainLaunchAgentLeafId(
+          s.tabsByWorktree,
+          tabId,
+          normalized.snapshot
+        )
+        const layoutChanged = !existing || !terminalLayoutEqual(existing, normalized.snapshot)
+        const tabsChanged = nextTabsByWorktree !== s.tabsByWorktree
+        // Why: pane-title churn re-persists structurally identical snapshots; bailing keeps every pane selector asleep.
+        if (!layoutChanged && !tabsChanged) {
           return s
         }
         return {
-          terminalLayoutsByTabId: { ...s.terminalLayoutsByTabId, [tabId]: normalized.snapshot }
+          ...(layoutChanged
+            ? {
+                terminalLayoutsByTabId: {
+                  ...s.terminalLayoutsByTabId,
+                  [tabId]: normalized.snapshot
+                }
+              }
+            : {}),
+          ...(tabsChanged ? { tabsByWorktree: nextTabsByWorktree } : {})
         }
       })
       transferNormalizedTerminalLayoutPtyOwnership(get(), tabId, ownershipTransfers)

--- a/src/renderer/src/store/terminals/terminal-tab-creation.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-creation.ts
@@ -84,11 +84,12 @@ export function createTerminalTabCreationActions(
           options?.initialLeafId && isTerminalLeafId(options.initialLeafId)
             ? options.initialLeafId
             : undefined
-        // Why: startup delivery is pane-owned; pin its first leaf so an aborted/remounted renderer retries against the same spawn reservation.
+        // Why: startup delivery and launch identity are pane-owned; pin the first leaf so an aborted/remounted renderer retries against the same owner.
         const initialLeafId =
-          options?.initialPtyId || options?.pendingStartup
+          options?.initialPtyId || options?.pendingStartup || options?.launchAgent
             ? (requestedInitialLeafId ?? createBrowserUuid())
             : undefined
+        const launchAgentLeafId = options?.launchAgent ? initialLeafId : undefined
         const shouldActivate = options?.activate !== false
         const nextOrdinal = getNextTerminalOrdinal(existing)
         const defaultTitle = `Terminal ${nextOrdinal}`
@@ -129,6 +130,7 @@ export function createTerminalTabCreationActions(
           ...(startupCwd && startupCwd.length > 0 ? { startupCwd } : {}),
           ...(options?.forceHostRuntime ? { forceHostRuntime: true } : {}),
           ...(options?.launchAgent ? { launchAgent: options.launchAgent } : {}),
+          ...(launchAgentLeafId ? { launchAgentLeafId } : {}),
           // Why: mark click-caused (not work-caused) spawns so updateTabPtyId skips the activity/sortEpoch bump that would reorder Recent/Smart on click.
           ...(options?.pendingActivationSpawn ? { pendingActivationSpawn: true } : {})
         }

--- a/src/renderer/src/store/terminals/terminal-tab-presentation.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-presentation.ts
@@ -134,8 +134,13 @@ export function createTerminalTabPresentationActions(
         if (!currentTab?.launchAgent) {
           return s
         }
-        const { launchAgent: _launchAgent, ...tabWithoutLaunchAgent } = currentTab
+        const {
+          launchAgent: _launchAgent,
+          launchAgentLeafId: _launchAgentLeafId,
+          ...tabWithoutLaunchAgent
+        } = currentTab
         void _launchAgent
+        void _launchAgentLeafId
         const nextTabs = [...tabs]
         nextTabs[tabIndex] = tabWithoutLaunchAgent
         scheduleRuntimeGraphSync()

--- a/src/shared/pane-agent-identity-inventory.test.ts
+++ b/src/shared/pane-agent-identity-inventory.test.ts
@@ -202,7 +202,7 @@ const INVENTORY: readonly InventoryGroup[] = [
     helper: 'resolvePaneAgentOwner',
     classification: 'identity-consumer',
     paths: [
-      ['src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts', 2],
+      ['src/renderer/src/components/sidebar/worktree-title-derived-agent-owner.ts', 2],
       ['src/renderer/src/components/terminal-pane/pty-connection/shell-command-inference.ts', 2],
       ['src/renderer/src/lib/use-tab-agent.ts', 2]
     ]

--- a/src/shared/terminal-tab-types.ts
+++ b/src/shared/terminal-tab-types.ts
@@ -43,6 +43,8 @@ export type TerminalTab = {
    *  hook status overrides this once the agent does anything. Plain terminals
    *  and manually-started agents omit it. */
   launchAgent?: TuiAgent
+  /** Stable leaf that owns the tab-scoped launch agent while layout state hydrates. */
+  launchAgentLeafId?: string
   /** Why: when `setActiveWorktree` bumps generation on all-dead tabs to drive a
    *  TerminalPane remount, the fresh PTY that results is caused by navigation,
    *  not by the user doing work. Without this flag the resulting

--- a/src/shared/workspace-session-schema.test.ts
+++ b/src/shared/workspace-session-schema.test.ts
@@ -157,7 +157,8 @@ describe('parseWorkspaceSession', () => {
             color: null,
             sortOrder: 0,
             createdAt: 1,
-            launchAgent: 'codex'
+            launchAgent: 'codex',
+            launchAgentLeafId: '77777777-7777-4777-8777-777777777777'
           }
         ]
       },
@@ -166,6 +167,9 @@ describe('parseWorkspaceSession', () => {
     expect(result.ok).toBe(true)
     if (result.ok) {
       expect(result.value.tabsByWorktree.wt[0].launchAgent).toBe('codex')
+      expect(result.value.tabsByWorktree.wt[0].launchAgentLeafId).toBe(
+        '77777777-7777-4777-8777-777777777777'
+      )
     }
   })
 

--- a/src/shared/workspace-session-schema.ts
+++ b/src/shared/workspace-session-schema.ts
@@ -109,7 +109,8 @@ const terminalTabSchema = z.object({
   launchAgent: z
     .custom<TuiAgent>((v) => isTuiAgent(v))
     .optional()
-    .catch(undefined)
+    .catch(undefined),
+  launchAgentLeafId: z.string().optional().catch(undefined)
 })
 
 // ─── Unified tab model ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Over SSH, Codex status hooks are dead (#8711). Working rows come only from **title-derived** fallback: spinner + `tab.launchAgent` (#9647).
- When the Codex TUI returns to a **neutral idle title** (no spinner, no agent name), that path produced **no row**, so the session looked deleted under the Project while the tab/PTY remained (and Dashboard could still show Idle elsewhere).
- **Fix:** if the tab has `launchAgent`, a live PTY, and the title is **not** classified as working/permission, still show an **Idle** title-derived row for that agent until the terminal is closed.
- Guards preserved: no `launchAgent` → no row; spinner-only without launch metadata → no row; explicit title identity still wins; Claude task-prefix titles on Codex-launched tabs still produce no row.

Fixes #10130

## Test plan

- [x] Unit: spinner + launchAgent still → working Codex row
- [x] Unit: neutral cwd title + launchAgent → Idle Codex row (#10130)
- [x] Unit: plain shell title + launchAgent → Idle
- [x] Unit: neutral title without launchAgent → no row
- [x] Existing title-derived suite green (14 tests)
- [ ] Manual (SSH): start Codex, complete a turn, switch Project → row stays under SSH Project as Idle; click reopens same tab

## ELI5

Over SSH, when Codex went idle the sidebar agent row vanished even though the tab still existed. Idle launchAgent tabs with a live PTY keep an Idle row so the session does not look deleted.
