### PR TITLE
fix(main): route Codex + PostHog through electron net.fetch

### DIFF
--- a/src/main/global-fetch-call-site-audit.test.ts
+++ b/src/main/global-fetch-call-site-audit.test.ts
@@ -20,7 +20,7 @@ const AUDITED_GLOBAL_FETCH_LINES = new Map<string, number>([
   ['main/gitea/client.ts', 1],
   ['main/orca-profiles/profile-cloud-client.ts', 1],
   ['main/orca-profiles/profile-cloud-org-members-client.ts', 1],
-  ['main/rate-limits/codex-fetcher.ts', 3],
+  // codex-fetcher uses electron net.fetch (not global fetch) — see #10117
   ['main/runtime/relay/relay-http-client.ts', 2],
   ['main/source-control/hosted-review-api-request.ts', 1],
   ['main/speech/openai-transcription-client.ts', 1],

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -2,15 +2,21 @@ import { join } from 'node:path'
 import { cancelTrackingResponse } from '../lib/unread-response-body.test-fixtures'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { childSpawnMock, readFileMock, ptySpawnMock } = vi.hoisted(() => ({
+const { childSpawnMock, readFileMock, ptySpawnMock, netFetchMock } = vi.hoisted(() => ({
   childSpawnMock: vi.fn(),
   readFileMock: vi.fn(),
-  ptySpawnMock: vi.fn()
+  ptySpawnMock: vi.fn(),
+  netFetchMock: vi.fn()
 }))
 
 vi.mock('node:child_process', () => ({ spawn: childSpawnMock }))
 vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
 vi.mock('node-pty', () => ({ spawn: ptySpawnMock }))
+vi.mock('electron', () => ({
+  net: {
+    fetch: netFetchMock
+  }
+}))
 vi.mock('./codex-auth-presence', () => ({
   probeCodexAuthPresence: vi.fn(async () => 'present')
 }))
@@ -21,12 +27,10 @@ describe('Codex backend rate-limit requests', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.clearAllMocks()
-    vi.stubGlobal('fetch', vi.fn())
   })
 
   afterEach(() => {
     vi.useRealTimers()
-    vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
 
@@ -36,7 +40,7 @@ describe('Codex backend rate-limit requests', () => {
         tokens: { access_token: 'access-token', account_id: 'account-id' }
       })
     )
-    vi.mocked(fetch)
+    netFetchMock
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
@@ -87,7 +91,7 @@ describe('Codex backend rate-limit requests', () => {
 
     expect(childSpawnMock).not.toHaveBeenCalled()
     expect(ptySpawnMock).not.toHaveBeenCalled()
-    expect(fetch).toHaveBeenNthCalledWith(
+    expect(netFetchMock).toHaveBeenNthCalledWith(
       1,
       'https://chatgpt.com/backend-api/wham/usage',
       expect.objectContaining({
@@ -168,7 +172,7 @@ describe('Codex backend rate-limit requests', () => {
       status: 'error',
       error: 'Rate-limit fetch aborted'
     })
-    expect(fetch).not.toHaveBeenCalled()
+    expect(netFetchMock).not.toHaveBeenCalled()
     expect(childSpawnMock).not.toHaveBeenCalled()
     expect(ptySpawnMock).not.toHaveBeenCalled()
     resolveRead('{}')
@@ -209,7 +213,7 @@ describe('Codex backend rate-limit requests', () => {
         tokens: { access_token: 'access-token', account_id: 'account-id' }
       })
     )
-    vi.mocked(fetch).mockResolvedValue({
+    netFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({ code: 'already_redeemed' })
     } as Response)
@@ -221,7 +225,7 @@ describe('Codex backend rate-limit requests', () => {
       })
     ).resolves.toBe('alreadyRedeemed')
 
-    expect(fetch).toHaveBeenCalledWith(
+    expect(netFetchMock).toHaveBeenCalledWith(
       'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
       expect.objectContaining({
         method: 'POST',
@@ -243,7 +247,7 @@ describe('Codex backend rate-limit requests', () => {
       })
     )
     let cancelledBodies = 0
-    vi.mocked(fetch).mockResolvedValue(
+    netFetchMock.mockResolvedValue(
       cancelTrackingResponse(429, () => {
         cancelledBodies += 1
       })

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -107,7 +107,7 @@ describe('Codex backend rate-limit requests', () => {
         tokens: { access_token: 'access-token', account_id: 'account-id' }
       })
     )
-    vi.mocked(fetch)
+    netFetchMock
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -1,13 +1,15 @@
 import { EventEmitter } from 'node:events'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { childSpawnMock, readFileMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
-  childSpawnMock: vi.fn(),
-  readFileMock: vi.fn(),
-  resolveCodexCommandMock: vi.fn(),
-  ptySpawnMock: vi.fn()
-}))
+const { childSpawnMock, readFileMock, resolveCodexCommandMock, ptySpawnMock, netFetchMock } =
+  vi.hoisted(() => ({
+    childSpawnMock: vi.fn(),
+    readFileMock: vi.fn(),
+    resolveCodexCommandMock: vi.fn(),
+    ptySpawnMock: vi.fn(),
+    netFetchMock: vi.fn()
+  }))
 
 vi.mock('node:child_process', () => ({
   spawn: childSpawnMock
@@ -15,6 +17,12 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:fs/promises', () => ({
   readFile: readFileMock
+}))
+
+vi.mock('electron', () => ({
+  net: {
+    fetch: netFetchMock
+  }
 }))
 
 vi.mock('../codex-cli/command', () => ({
@@ -116,11 +124,7 @@ describe('fetchCodexRateLimits', () => {
     resolveCodexCommandMock.mockReturnValue('codex')
     vi.mocked(probeCodexAuthPresence).mockResolvedValue('present')
     readFileMock.mockRejectedValue(new Error('no auth fixture'))
-    vi.stubGlobal('fetch', vi.fn())
-  })
-
-  afterEach(() => {
-    vi.unstubAllGlobals()
+    netFetchMock.mockReset()
   })
 
   it('does not spawn Codex when the user is not signed in', async () => {
@@ -475,7 +479,7 @@ describe('fetchCodexRateLimits', () => {
         }
       })
     )
-    vi.mocked(fetch).mockResolvedValue({
+    netFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({
         available_count: 2,
@@ -558,7 +562,7 @@ describe('fetchCodexRateLimits', () => {
       ]
     })
     expect(readFileMock).toHaveBeenCalledWith(join('/managed/codex-home', 'auth.json'), 'utf8')
-    expect(fetch).toHaveBeenCalledWith(
+    expect(netFetchMock).toHaveBeenCalledWith(
       'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
       expect.objectContaining({
         signal: expect.any(AbortSignal),
@@ -630,7 +634,7 @@ describe('fetchCodexRateLimits', () => {
       ]
     })
     expect(readFileMock).not.toHaveBeenCalled()
-    expect(fetch).not.toHaveBeenCalled()
+    expect(netFetchMock).not.toHaveBeenCalled()
   })
 
   it('runs rate-limit RPC through WSL when the Codex home is a WSL managed account', async () => {

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -415,7 +415,7 @@ describe('fetchCodexRateLimits', () => {
         tokens: { access_token: 'access-token', account_id: 'account-id' }
       })
     )
-    vi.mocked(fetch).mockResolvedValue({
+    netFetchMock.mockResolvedValue({
       ok: true,
       json: async () => ({
         plan_type: 'plus',
@@ -447,7 +447,7 @@ describe('fetchCodexRateLimits', () => {
       weekly: { usedPercent: 23, windowMinutes: 10080, resetsAt: 1_800_100_000_000 },
       status: 'ok'
     })
-    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
 
   it('does not map a duplicate session-duration window into the weekly slot', async () => {

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -7,6 +7,7 @@ import type {
 import { spawn } from 'node:child_process'
 import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
+import { net } from 'electron'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
 import { join } from 'node:path'
 import { probeCodexAuthPresence } from './codex-auth-presence'
@@ -388,11 +389,15 @@ async function fetchBackendRateLimitResetCredits(
   if (signal.aborted) {
     return null
   }
+  // Why: net.fetch (Chromium) avoids Node undici's paused-parser crash on closed sockets (#10117, undici#5360).
   // Why: Codex 0.140's app-server strips the reset-credit metadata this backend endpoint still returns.
-  const response = await fetch('https://chatgpt.com/backend-api/wham/rate-limit-reset-credits', {
-    ...auth,
-    signal
-  })
+  const response = await net.fetch(
+    'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
+    {
+      ...auth,
+      signal
+    }
+  )
   if (!response.ok) {
     await cancelUnreadResponseBody(response)
     return null
@@ -448,7 +453,8 @@ export async function consumeCodexRateLimitResetCredit(options: {
   if (!auth) {
     throw new Error('Codex not signed in')
   }
-  const response = await fetch(
+  // Why: net.fetch avoids undici main-process crash when the peer closes mid-body (#10117).
+  const response = await net.fetch(
     'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits/consume',
     {
       method: 'POST',
@@ -539,7 +545,8 @@ async function fetchViaBackend(
     return null
   }
   // Why: reuse Codex's endpoint to avoid an app server and WSL login shell per refresh.
-  const response = await fetch('https://chatgpt.com/backend-api/wham/usage', {
+  // Why: net.fetch avoids undici main-process crash when the peer closes mid-body (#10117).
+  const response = await net.fetch('https://chatgpt.com/backend-api/wham/usage', {
     ...auth,
     signal
   })

--- a/src/main/telemetry/client.ts
+++ b/src/main/telemetry/client.ts
@@ -7,7 +7,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { arch as osArch, platform as osPlatform, release as osRelease } from 'node:os'
-import { app } from 'electron'
+import { app, net } from 'electron'
 import { PostHog } from 'posthog-node'
 import type { CommonProps, EventName, EventProps, OptInVia } from '../../shared/telemetry-events'
 import type { Store } from '../persistence'
@@ -107,7 +107,10 @@ export function initTelemetry(store: Store): void {
     // Strip SDK-auto GeoIP / client-IP enrichment; our wire is exactly CommonProps ∪ EventProps ∪ a small allow-list.
     disableGeoip: true,
     // Bumped from the default 1000 (drops oldest-first past cap) to 5000 to tolerate long-offline sessions.
-    maxQueueSize: 5000
+    maxQueueSize: 5000,
+    // Why: default posthog-node transport is Node global fetch (undici), which can crash the main
+    // process on paused-parser + peer close (orca#10117 / undici#5360). Chromium net.fetch is safe.
+    fetch: (url, options) => net.fetch(url, options)
   })
 
   if (shouldOptOutSdkAtInit(resolveConsent(settings))) {


### PR DESCRIPTION
## Summary

- Replace the three remaining Electron-main Codex `wham/*` global `fetch` calls with `electron.net.fetch` so usage / rate-limit-reset-credits / consume no longer hit Node undici.
- Point official-build PostHog transport at `net.fetch` via the SDK `fetch` option.
- Drop `codex-fetcher.ts` from the global-fetch audit (it is no longer a bare-fetch call site).

Fixes #10117 (validated mitigation from the issue: undici `assert(!this.paused)` main-process crash while Codex is in use after #9142).

## Why

#9142 cancels unread error bodies, but Orca 1.4.152 still crashed with the bundled undici paused-parser assertion. Chromium's network stack does not share that failure mode. This is an application mitigation until Electron ships undici#5474 — not a full removal of every global fetch elsewhere.

## Test plan

- [x] `vitest` codex-fetcher + backend + global-fetch audit + telemetry client
- [x] `pnpm typecheck:node`
- [ ] Manual: Codex usage / rate-limit display still updates; PostHog events still flush on official builds

## ELI5

Some Codex and PostHog network calls in the main process used Node fetch and could crash Electron under load. They now use electron.net.fetch, which is the safer path for main-process HTTP.
