### PR TITLE
fix(tasks): select only project when clicking from All projects

### DIFF
--- a/src/renderer/src/components/task-project-source-combobox-model.test.ts
+++ b/src/renderer/src/components/task-project-source-combobox-model.test.ts
@@ -73,7 +73,7 @@ describe('nextTaskProjectSelectionAfterToggle', () => {
     const multi = group('proj', [local, remote])
     // Three groups so deselecting multi is not the "all selected → only this" path.
     const groupsWithMulti = [multi, group('other', [b]), group('c', [c])]
-    const selected = new Set(['proj-local', 'b'])
+    const selected = new Set(['proj-local', 'proj-ssh', 'b'])
     const next = nextTaskProjectSelectionAfterToggle({
       groups: groupsWithMulti,
       selected,
@@ -82,7 +82,7 @@ describe('nextTaskProjectSelectionAfterToggle', () => {
     expect(next).toEqual(new Set(['b']))
   })
 
-  it('from All projects with multi-host groups, click keeps the group primary source', () => {
+  it('from All projects with multi-host groups, click keeps the selected source', () => {
     const local = repo('proj-local', 'proj')
     const remote = repo('proj-ssh', 'proj')
     const multi = group('proj', [local, remote])
@@ -94,5 +94,20 @@ describe('nextTaskProjectSelectionAfterToggle', () => {
       group: multi
     })
     expect(next).toEqual(new Set(['proj-local']))
+  })
+
+  it('from All projects, narrowing preserves a non-primary selected host', () => {
+    const local = repo('proj-local', 'proj')
+    const remote = repo('proj-ssh', 'proj')
+    // group.repo is sources[0] (local), but the user had the ssh host selected.
+    const multi = group('proj', [local, remote])
+    const groupsWithMulti = [multi, group('other', [b])]
+    const selected = new Set(['proj-ssh', 'b'])
+    const next = nextTaskProjectSelectionAfterToggle({
+      groups: groupsWithMulti,
+      selected,
+      group: multi
+    })
+    expect(next).toEqual(new Set(['proj-ssh']))
   })
 })

--- a/src/renderer/src/components/task-project-source-combobox-model.test.ts
+++ b/src/renderer/src/components/task-project-source-combobox-model.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Repo } from '../../../shared/types'
+import type { TaskProjectPickerGroup } from './task-page-default-repo-selection'
+import { nextTaskProjectSelectionAfterToggle } from './task-project-source-combobox-model'
+
+function repo(id: string, displayName = id): Repo {
+  return {
+    id,
+    displayName,
+    path: `/repos/${id}`,
+    badgeColor: '#000'
+  } as Repo
+}
+
+function group(projectKey: string, sources: Repo[]): TaskProjectPickerGroup {
+  return {
+    projectKey,
+    repo: sources[0]!,
+    sources
+  }
+}
+
+describe('nextTaskProjectSelectionAfterToggle', () => {
+  const a = repo('a')
+  const b = repo('b')
+  const c = repo('c')
+  const groups = [group('a', [a]), group('b', [b]), group('c', [c])]
+
+  it('from All projects, clicking a project selects only that project (#10182)', () => {
+    const selected = new Set(['a', 'b', 'c'])
+    const next = nextTaskProjectSelectionAfterToggle({
+      groups,
+      selected,
+      group: groups[1]!
+    })
+    expect(next).toEqual(new Set(['b']))
+  })
+
+  it('adds an unselected project to a partial selection', () => {
+    const selected = new Set(['a'])
+    const next = nextTaskProjectSelectionAfterToggle({
+      groups,
+      selected,
+      group: groups[1]!
+    })
+    expect(next).toEqual(new Set(['a', 'b']))
+  })
+
+  it('removes a selected project from a multi selection', () => {
+    const selected = new Set(['a', 'b'])
+    const next = nextTaskProjectSelectionAfterToggle({
+      groups,
+      selected,
+      group: groups[0]!
+    })
+    expect(next).toEqual(new Set(['b']))
+  })
+
+  it('does not deselect the last remaining project', () => {
+    const selected = new Set(['a'])
+    const next = nextTaskProjectSelectionAfterToggle({
+      groups,
+      selected,
+      group: groups[0]!
+    })
+    expect(next).toBeNull()
+  })
+
+  it('removes every host source of a multi-host project when deselecting', () => {
+    const local = repo('proj-local', 'proj')
+    const remote = repo('proj-ssh', 'proj')
+    const multi = group('proj', [local, remote])
+    // Three groups so deselecting multi is not the "all selected → only this" path.
+    const groupsWithMulti = [multi, group('other', [b]), group('c', [c])]
+    const selected = new Set(['proj-local', 'b'])
+    const next = nextTaskProjectSelectionAfterToggle({
+      groups: groupsWithMulti,
+      selected,
+      group: multi
+    })
+    expect(next).toEqual(new Set(['b']))
+  })
+
+  it('from All projects with multi-host groups, click keeps the group primary source', () => {
+    const local = repo('proj-local', 'proj')
+    const remote = repo('proj-ssh', 'proj')
+    const multi = group('proj', [local, remote])
+    const groupsWithMulti = [multi, group('other', [b])]
+    const selected = new Set(['proj-local', 'b'])
+    const next = nextTaskProjectSelectionAfterToggle({
+      groups: groupsWithMulti,
+      selected,
+      group: multi
+    })
+    expect(next).toEqual(new Set(['proj-local']))
+  })
+})

--- a/src/renderer/src/components/task-project-source-combobox-model.ts
+++ b/src/renderer/src/components/task-project-source-combobox-model.ts
@@ -40,6 +40,13 @@ export function hasMultipleTaskProjectHostsInGroup(group: TaskProjectPickerGroup
   return hasMultipleTaskProjectHosts([group])
 }
 
+export function isAllTaskProjectsSelected(
+  groups: readonly TaskProjectPickerGroup[],
+  selected: ReadonlySet<string>
+): boolean {
+  return groups.length > 0 && selectedTaskProjectGroups(groups, selected).length === groups.length
+}
+
 /**
  * Toggle a project group in the Tasks project selector.
  * Returns null when the click is a no-op (cannot deselect the last project).
@@ -53,16 +60,13 @@ export function nextTaskProjectSelectionAfterToggle(args: {
   selected: ReadonlySet<string>
   group: TaskProjectPickerGroup
 }): Set<string> | null {
-  const selectedGroups = selectedTaskProjectGroups(args.groups, args.selected)
-  const allSelected = args.groups.length > 0 && selectedGroups.length === args.groups.length
-  if (allSelected) {
+  if (isAllTaskProjectsSelected(args.groups, args.selected)) {
     return new Set([args.group.repo.id])
   }
 
   const next = new Set(args.selected)
-  const selectedSource = args.group.sources.find((source) => next.has(source.id))
-  if (selectedSource) {
-    if (selectedGroups.length <= 1) {
+  if (isTaskProjectGroupSelected(args.group, next)) {
+    if (selectedTaskProjectGroups(args.groups, args.selected).length <= 1) {
       return null
     }
     for (const source of args.group.sources) {

--- a/src/renderer/src/components/task-project-source-combobox-model.ts
+++ b/src/renderer/src/components/task-project-source-combobox-model.ts
@@ -39,3 +39,37 @@ export function hasMultipleTaskProjectHosts(groups: readonly TaskProjectPickerGr
 export function hasMultipleTaskProjectHostsInGroup(group: TaskProjectPickerGroup): boolean {
   return hasMultipleTaskProjectHosts([group])
 }
+
+/**
+ * Toggle a project group in the Tasks project selector.
+ * Returns null when the click is a no-op (cannot deselect the last project).
+ *
+ * Why: when every project is selected ("All projects"), clicking one project
+ * must mean "only this project" — the old toggle treated it as exclude, which
+ * is not discoverable (#10182).
+ */
+export function nextTaskProjectSelectionAfterToggle(args: {
+  groups: readonly TaskProjectPickerGroup[]
+  selected: ReadonlySet<string>
+  group: TaskProjectPickerGroup
+}): Set<string> | null {
+  const selectedGroups = selectedTaskProjectGroups(args.groups, args.selected)
+  const allSelected = args.groups.length > 0 && selectedGroups.length === args.groups.length
+  if (allSelected) {
+    return new Set([args.group.repo.id])
+  }
+
+  const next = new Set(args.selected)
+  const selectedSource = args.group.sources.find((source) => next.has(source.id))
+  if (selectedSource) {
+    if (selectedGroups.length <= 1) {
+      return null
+    }
+    for (const source of args.group.sources) {
+      next.delete(source.id)
+    }
+    return next
+  }
+  next.add(args.group.repo.id)
+  return next
+}

--- a/src/renderer/src/components/task-project-source-combobox-model.ts
+++ b/src/renderer/src/components/task-project-source-combobox-model.ts
@@ -61,7 +61,8 @@ export function nextTaskProjectSelectionAfterToggle(args: {
   group: TaskProjectPickerGroup
 }): Set<string> | null {
   if (isAllTaskProjectsSelected(args.groups, args.selected)) {
-    return new Set([args.group.repo.id])
+    // Keep the host the user actually had selected, not just the group primary.
+    return new Set([getSelectedTaskProjectSource(args.group, args.selected).id])
   }
 
   const next = new Set(args.selected)

--- a/src/renderer/src/components/task-project-source-combobox.tsx
+++ b/src/renderer/src/components/task-project-source-combobox.tsx
@@ -14,6 +14,7 @@ import {
   hasMultipleTaskProjectHosts,
   hasMultipleTaskProjectHostsInGroup,
   isTaskProjectGroupSelected,
+  nextTaskProjectSelectionAfterToggle,
   selectedTaskProjectGroups
 } from './task-project-source-combobox-model'
 
@@ -170,19 +171,10 @@ export default function TaskProjectSourceCombobox({
 
   const toggleProject = useCallback(
     (group: TaskProjectPickerGroup) => {
-      const next = new Set(selected)
-      const selectedSource = group.sources.find((source) => next.has(source.id))
-      if (selectedSource) {
-        if (selectedTaskProjectGroups(groups, selected).length <= 1) {
-          return
-        }
-        for (const source of group.sources) {
-          next.delete(source.id)
-        }
-      } else {
-        next.add(group.repo.id)
+      const next = nextTaskProjectSelectionAfterToggle({ groups, selected, group })
+      if (next) {
+        onChange(next)
       }
-      onChange(next)
     },
     [groups, onChange, selected]
   )

--- a/src/renderer/src/components/task-project-source-combobox.tsx
+++ b/src/renderer/src/components/task-project-source-combobox.tsx
@@ -13,6 +13,7 @@ import {
   getSelectedTaskProjectSource,
   hasMultipleTaskProjectHosts,
   hasMultipleTaskProjectHostsInGroup,
+  isAllTaskProjectsSelected,
   isTaskProjectGroupSelected,
   nextTaskProjectSelectionAfterToggle,
   selectedTaskProjectGroups
@@ -125,8 +126,7 @@ export default function TaskProjectSourceCombobox({
     return groups.filter((group) => searchRepos(group.sources, trimmed).length > 0)
   }, [groups, query])
   const showHostLabels = useMemo(() => hasMultipleTaskProjectHosts(groups), [groups])
-  const allSelected =
-    groups.length > 0 && selectedTaskProjectGroups(groups, selected).length === groups.length
+  const allSelected = isAllTaskProjectsSelected(groups, selected)
 
   const handleOpenChange = useCallback((nextOpen: boolean) => {
     setOpen(nextOpen)


### PR DESCRIPTION
## Summary

- From **All projects**, clicking a project filters to **only that project** instead of excluding it.
- Partial multi-select keeps add/remove behavior and still refuses to deselect the last project.
- The selected execution host is preserved when narrowing a multi-host project.

Fixes #10182.

## ELI5

When everything was selected, clicking one project removed it. Now that click keeps only that project, while normal multi-selection still works.

## Takeover / attribution

Originally implemented by @innocarpe. This takeover re-validated the existing commits without changing their authorship or force-pushing the branch.

## Fix proof

- Deterministic regression test: `src/renderer/src/components/task-project-source-combobox-model.test.ts` covers All → only, partial add/remove, last-project guard, multi-host removal, and preservation of a non-primary SSH source.
- `pnpm vitest run src/renderer/src/components/task-project-source-combobox-model.test.ts --config config/vitest.config.ts` — 1 file, 7 tests passed.

## No-regression proof / trade-offs

- Cross-platform, SSH, and folder-workspace review: selection operates on repository IDs only; the test covers preserving a selected SSH/non-primary source, and folder-workspace eligibility is unchanged.
- Performance: only an explicit user click gets the additional all-selected group scan; no polling, I/O, or render-loop work was added. The affected resource is CPU on click, with deterministic work bounded by project groups plus sources.
- `0 regressions / risk`: **UNKNOWN** — focused model coverage is clean, but no Electron surface was attached in this session for manual UI proof.

## Review loop

- Loop 1: independent review, verdict **clean**; verified group-based All selection, SSH-source preservation, partial selection, and last-project guard.

## Validation

- `pnpm vitest run src/renderer/src/components/task-project-source-combobox-model.test.ts --config config/vitest.config.ts` — passed (7/7).
- `pnpm exec oxlint src/renderer/src/components/task-project-source-combobox-model.ts src/renderer/src/components/task-project-source-combobox.tsx src/renderer/src/components/task-project-source-combobox-model.test.ts` — passed.
- `git diff --check` and `git diff origin/main...HEAD --check` — passed.

## UI evidence

No screenshot: the in-app browser/Electron surface list was empty for this dispatched session.