### PR TITLE
fix(orchestration): wake coordinator after worker_done in preamble

### DIFF
--- a/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
+++ b/src/main/runtime/orchestration/__snapshots__/preamble.test.ts.snap
@@ -74,11 +74,13 @@ Slack, GitHub comments, or any other channel to reach a human during the run.
 
 === AFTER YOU SEND worker_done ===
 
-worker_done ends your turn for this task. Your dispatched work is complete:
-stop, return to an idle prompt, and take no further actions — do NOT start
-new or unrelated work, do NOT run a sleep/poll loop, and do NOT keep calling
-\`orca orchestration check\`. The coordinator has already recorded your
-completion and expects no further output.
+worker_done ends your turn for this task. Your dispatched work is complete.
+First, send exactly one wake line so the coordinator sees the completion:
+\`orca terminal send --terminal term_COORD --text "[wake] task task_SNAP done — check inbox" --enter\`
+Then stop, return to an idle prompt, and take no further actions — do NOT
+start new or unrelated work, do NOT run a sleep/poll loop, do NOT send
+additional wake messages, and do NOT keep calling
+\`orca orchestration check\`.
 
 Do not exit the shell. Your terminal stays available, and if the
 coordinator has more for you it will re-engage this terminal with a fresh

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -125,15 +125,20 @@ describe('buildDispatchPreamble', () => {
     expect(result).not.toContain('"dispatchCapability"')
   })
 
-  it('tells prompt-returning workers to idle without post-done polling', () => {
+  it('tells prompt-returning workers to wake the coordinator then idle (#9968)', () => {
     const result = buildDispatchPreamble(baseParams())
     const section = afterWorkerDoneSection(result)
 
     expect(section).toContain('=== AFTER YOU SEND worker_done ===')
     expect(section).toContain('worker_done ends your turn for this task')
+    expect(section).toContain(
+      'orca terminal send --terminal term_coord --text "[wake] task task_abc123 done — check inbox" --enter'
+    )
+    expect(section).toContain('exactly one wake line')
     expect(section).toContain('return to an idle prompt')
     expect(section).toContain('Do not exit the shell')
     expect(section).toContain('do NOT run a sleep/poll loop')
+    expect(section).toMatch(/do NOT send\s+additional wake messages/)
     expect(section).toContain('do NOT keep calling')
     expect(section).toMatch(/fresh\s+preamble \+ TASK block/)
     expect(section).not.toMatch(/2 minutes/)
@@ -142,11 +147,14 @@ describe('buildDispatchPreamble', () => {
     expect(section).not.toMatch(/grace period/)
   })
 
-  it('tells bare-shell workers to exit after worker_done', () => {
+  it('tells bare-shell workers to wake the coordinator then exit (#9968)', () => {
     const result = buildDispatchPreamble(baseParams({ workerKind: 'bare-shell' }))
     const section = afterWorkerDoneSection(result)
 
-    expect(section).toContain('Exit the shell after completion')
+    expect(section).toContain(
+      'orca terminal send --terminal term_coord --text "[wake] task task_abc123 done — check inbox" --enter'
+    )
+    expect(section).toContain('Exit the shell after that single wake')
     expect(section).toContain('Bare-shell workers have no idle agent')
     expect(section).toContain('do NOT run a sleep/poll loop')
     expect(section).not.toContain('Do not exit the shell')

--- a/src/main/runtime/orchestration/preamble.test.ts
+++ b/src/main/runtime/orchestration/preamble.test.ts
@@ -131,9 +131,10 @@ describe('buildDispatchPreamble', () => {
 
     expect(section).toContain('=== AFTER YOU SEND worker_done ===')
     expect(section).toContain('worker_done ends your turn for this task')
-    expect(section).toContain(
+    const wakeLine =
       'orca terminal send --terminal term_coord --text "[wake] task task_abc123 done — check inbox" --enter'
-    )
+    // Why: enforce exactly one wake (split → [before, after] length 2).
+    expect(section.split(wakeLine)).toHaveLength(2)
     expect(section).toContain('exactly one wake line')
     expect(section).toContain('return to an idle prompt')
     expect(section).toContain('Do not exit the shell')
@@ -151,9 +152,9 @@ describe('buildDispatchPreamble', () => {
     const result = buildDispatchPreamble(baseParams({ workerKind: 'bare-shell' }))
     const section = afterWorkerDoneSection(result)
 
-    expect(section).toContain(
+    const wakeLine =
       'orca terminal send --terminal term_coord --text "[wake] task task_abc123 done — check inbox" --enter'
-    )
+    expect(section.split(wakeLine)).toHaveLength(2)
     expect(section).toContain('Exit the shell after that single wake')
     expect(section).toContain('Bare-shell workers have no idle agent')
     expect(section).toContain('do NOT run a sleep/poll loop')

--- a/src/main/runtime/orchestration/preamble.ts
+++ b/src/main/runtime/orchestration/preamble.ts
@@ -51,7 +51,9 @@ export function buildDispatchPreamble(params: PreambleParams): string {
   const cli = params.devMode ? 'orca-dev' : (params.cliCommand ?? 'orca')
   const postDoneInstructions = buildPostWorkerDoneInstructions({
     cli,
-    workerKind: params.workerKind ?? 'prompt-returning-agent'
+    workerKind: params.workerKind ?? 'prompt-returning-agent',
+    coordinatorHandle: params.coordinatorHandle,
+    taskId: params.taskId
   })
   const capabilityFlag = params.dispatchCapability
     ? ` --dispatch-capability ${params.dispatchCapability}`
@@ -146,34 +148,46 @@ ${params.taskSpec}`
 
 function buildPostWorkerDoneInstructions({
   cli,
-  workerKind
+  workerKind,
+  coordinatorHandle,
+  taskId
 }: {
   cli: string
   workerKind: NonNullable<PreambleParams['workerKind']>
+  coordinatorHandle: string
+  taskId: string
 }): string {
+  // Why: worker_done only persists to the coordinator inbox; idle coordinators
+  // are not auto-woken (#8698). Without one terminal-send wake, compliant
+  // workers leave the coordinator asleep indefinitely (#9968).
+  const wakeLine = `${cli} terminal send --terminal ${coordinatorHandle} --text "[wake] task ${taskId} done — check inbox" --enter`
+
   // Why: re-dispatch reaches idle agents as terminal input; inbox polling
   // after completion cannot receive that new TASK block and looks hung.
   if (workerKind === 'bare-shell') {
     return `=== AFTER YOU SEND worker_done ===
 
-worker_done ends your turn for this task. Your dispatched work is complete:
-stop and take no further actions — do NOT start new or unrelated work,
-do NOT run a sleep/poll loop, and do NOT keep calling
-\`${cli} orchestration check\`. The coordinator has already recorded your
-completion and expects no further output.
+worker_done ends your turn for this task. Your dispatched work is complete.
+First, send exactly one wake line so the coordinator sees the completion:
+\`${wakeLine}\`
+Then stop and take no further actions — do NOT start new or unrelated work,
+do NOT run a sleep/poll loop, do NOT send additional wake messages, and
+do NOT keep calling \`${cli} orchestration check\`.
 
-Exit the shell after completion. Bare-shell workers have no idle agent
+Exit the shell after that single wake. Bare-shell workers have no idle agent
 prompt for Orca to reuse; if the coordinator has more for you it will
 dispatch or prompt another worker with a fresh TASK block.`
   }
 
   return `=== AFTER YOU SEND worker_done ===
 
-worker_done ends your turn for this task. Your dispatched work is complete:
-stop, return to an idle prompt, and take no further actions — do NOT start
-new or unrelated work, do NOT run a sleep/poll loop, and do NOT keep calling
-\`${cli} orchestration check\`. The coordinator has already recorded your
-completion and expects no further output.
+worker_done ends your turn for this task. Your dispatched work is complete.
+First, send exactly one wake line so the coordinator sees the completion:
+\`${wakeLine}\`
+Then stop, return to an idle prompt, and take no further actions — do NOT
+start new or unrelated work, do NOT run a sleep/poll loop, do NOT send
+additional wake messages, and do NOT keep calling
+\`${cli} orchestration check\`.
 
 Do not exit the shell. Your terminal stays available, and if the
 coordinator has more for you it will re-engage this terminal with a fresh


### PR DESCRIPTION
## Summary

- After `worker_done`, the dispatch preamble now tells workers to send **exactly one** coordinator wake line via `terminal send --enter`.
- Then idle at the agent prompt (or exit for bare-shell workers) without polling / extra wakes.
- Unit tests + snapshot updated.

Fixes #9968.

## Why

`worker_done` only writes the coordinator inbox; idle coordinators are not auto-woken (#8698). The old preamble said “take no further actions,” so workers that obeyed left coordinators asleep until a human intervened. Runtime-level auto-wake (#9228) remains the longer-term fix; this is the cheap preamble correction.

## Test plan

- [x] `preamble.test.ts` (18) including wake-line content for prompt-returning and bare-shell workers
- [x] Snapshot update
- [ ] Manual: `orchestration dispatch --inject` and confirm the post-`worker_done` section includes the wake command with the real coordinator handle

## ELI5

After worker_done, workers were told to do nothing, so sleeping coordinators never woke. The preamble now sends one coordinator wake via terminal send, then idles cleanly.
