### PR TITLE
fix: version-gate Claude Code hook events to avoid invalidating settings.json on older clients

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -15,6 +15,7 @@
     "../src/main/agent-hooks/managed-agent-hook-controls.ts",
     "../src/main/amp/hook-service.ts",
     "../src/main/antigravity/hook-service.ts",
+    "../src/main/claude/hook-event-versions.ts",
     "../src/main/claude/hook-settings.ts",
     "../src/main/claude/hook-service.ts",
     "../src/main/claude/statusline-script.ts",

--- a/src/main/claude/hook-event-versions.test.ts
+++ b/src/main/claude/hook-event-versions.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { CLAUDE_EVENTS } from './hook-settings'
+import {
+  detectClaudeCodeVersion,
+  parseClaudeCodeVersion,
+  selectClaudeEventsForVersion,
+  UNKNOWN_VERSION_EVENT_FLOOR
+} from './hook-event-versions'
+
+const names = (events: readonly { eventName: string }[]): string[] =>
+  events.map((event) => event.eventName)
+
+describe('parseClaudeCodeVersion', () => {
+  it('parses the leading semver from `claude --version` output', () => {
+    expect(parseClaudeCodeVersion('2.1.218 (Claude Code)')).toBe('2.1.218')
+    expect(parseClaudeCodeVersion('1.0.38\n')).toBe('1.0.38')
+  })
+
+  it('returns null when no semver is present', () => {
+    expect(parseClaudeCodeVersion('not a version')).toBeNull()
+    expect(parseClaudeCodeVersion('')).toBeNull()
+  })
+})
+
+describe('selectClaudeEventsForVersion', () => {
+  const BASE_EVENTS = ['UserPromptSubmit', 'Stop', 'SubagentStop', 'PreToolUse', 'PostToolUse']
+
+  it('includes only base events on the unknown-version floor', () => {
+    expect(names(selectClaudeEventsForVersion(UNKNOWN_VERSION_EVENT_FLOOR)).sort()).toEqual(
+      [...BASE_EVENTS].sort()
+    )
+  })
+
+  it('falls back to the base set when the version is null', () => {
+    expect(names(selectClaudeEventsForVersion(null)).sort()).toEqual([...BASE_EVENTS].sort())
+  })
+
+  it('includes every event for a recent version', () => {
+    expect(names(selectClaudeEventsForVersion('2.1.218')).sort()).toEqual(
+      names(CLAUDE_EVENTS).sort()
+    )
+  })
+
+  it('gates a mid-range version to the events it recognizes', () => {
+    const selected = names(selectClaudeEventsForVersion('2.0.45'))
+    // 2.0.45 introduced PermissionRequest but predates TeammateIdle (2.1.33).
+    expect(selected).toContain('PermissionRequest')
+    expect(selected).toContain('SubagentStart')
+    expect(selected).not.toContain('TeammateIdle')
+    expect(selected).not.toContain('StopFailure')
+  })
+})
+
+describe('detectClaudeCodeVersion', () => {
+  it('returns null when the binary cannot be spawned', () => {
+    expect(detectClaudeCodeVersion(() => '/nonexistent/orca-test-claude-binary')).toBeNull()
+  })
+})

--- a/src/main/claude/hook-event-versions.ts
+++ b/src/main/claude/hook-event-versions.ts
@@ -1,0 +1,68 @@
+import { execFileSync } from 'node:child_process'
+import { compareAppVersions } from '../../shared/app-version'
+import { resolveClaudeCommand } from '../codex-cli/command'
+import { CLAUDE_EVENTS, type ClaudeHookEventSpec } from './hook-settings'
+
+// Why: Claude Code < 2.1.101 rejects the whole settings.json on an unknown hook
+// key (2.1.101 added tolerance and ignores them). When the client version is
+// unknown, inject only events present on long-stable clients (minVersion <=
+// this floor): UserPromptSubmit, Stop, PreToolUse, PostToolUse, SubagentStop.
+// An undetectable version is exactly the unknown-old client that breaks.
+export const UNKNOWN_VERSION_EVENT_FLOOR = '1.0.54'
+
+// `claude --version` prints a bare semver, e.g. "2.1.218 (Claude Code)".
+const CLAUDE_VERSION_PATTERN = /(\d+\.\d+\.\d+)/
+
+export function parseClaudeCodeVersion(output: string): string | null {
+  return output.match(CLAUDE_VERSION_PATTERN)?.[1] ?? null
+}
+
+// Why: probe the installed Claude Code version so gating matches the client that
+// will read settings.json. Returns null on any failure (binary missing, spawn
+// error, unparseable output) so callers fall back to the safe base set.
+export function detectClaudeCodeVersion(
+  resolveCommand: () => string = resolveClaudeCommand
+): string | null {
+  try {
+    const output = execFileSync(resolveCommand(), ['--version'], {
+      encoding: 'utf-8',
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore']
+    })
+    return parseClaudeCodeVersion(output)
+  } catch {
+    return null
+  }
+}
+
+// Why: keep only events the detected client recognizes; an unknown version drops
+// to the always-safe base set (see UNKNOWN_VERSION_EVENT_FLOOR). install() and
+// getStatus() share this so an older client doesn't perpetually report "partial".
+export function selectClaudeEventsForVersion(
+  detectedVersion: string | null,
+  events: readonly ClaudeHookEventSpec[] = CLAUDE_EVENTS
+): readonly ClaudeHookEventSpec[] {
+  const ceiling = detectedVersion ?? UNKNOWN_VERSION_EVENT_FLOOR
+  return events.filter((event) => compareAppVersions(event.minVersion, ceiling) <= 0)
+}
+
+export type EventGatingOptions = {
+  versionGated: boolean
+  detectVersion: () => string | null
+}
+
+// Why: local install gates on the detected version; an ungated agent (OpenClaude,
+// independent versioning) keeps the full set.
+export function resolveLocalEligibleEvents(
+  options: EventGatingOptions
+): readonly ClaudeHookEventSpec[] {
+  return options.versionGated
+    ? selectClaudeEventsForVersion(options.detectVersion())
+    : CLAUDE_EVENTS
+}
+
+// Why: the remote box's version is unknown and unprobed, so gate conservatively
+// to the always-safe base set; ungated agents keep the full set.
+export function resolveRemoteEligibleEvents(versionGated: boolean): readonly ClaudeHookEventSpec[] {
+  return versionGated ? selectClaudeEventsForVersion(null) : CLAUDE_EVENTS
+}

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -14,7 +14,16 @@ vi.mock('electron', () => ({
   }
 }))
 
+// Why: keep the default (uninjected) service deterministic — never spawn a real
+// `claude --version` in unit tests. Pin a recent version so the full event set
+// is eligible; gating-specific tests inject their own `detectVersion`.
+vi.mock('./hook-event-versions', async (importActual) => {
+  const actual = await importActual<typeof HookEventVersionsModule>()
+  return { ...actual, detectClaudeCodeVersion: () => '2.1.218' }
+})
+
 import type { SFTPWrapper } from 'ssh2'
+import type * as HookEventVersionsModule from './hook-event-versions'
 import { createManagedCommandMatcher } from '../agent-hooks/installer-utils'
 import { ClaudeHookService } from './hook-service'
 import { OPENCLAUDE_HOOK_SETTINGS } from './hook-settings'
@@ -149,7 +158,8 @@ describe('ClaudeHookService.install', () => {
         })
       )
 
-      const status = new ClaudeHookService().install()
+      // Why: pin a recent version so StopFailure (minVersion 2.1.78) is eligible.
+      const status = new ClaudeHookService({ detectVersion: () => '2.1.218' }).install()
       expect(status.state).toBe('installed')
 
       const legacy = JSON.parse(readFileSync(legacyPath, 'utf-8'))
@@ -318,7 +328,9 @@ describe('ClaudeHookService.install', () => {
       vi.stubEnv('HOME', tmpHome)
       vi.stubEnv('USERPROFILE', tmpHome)
       try {
-        expect(new ClaudeHookService().install().state).toBe('installed')
+        expect(new ClaudeHookService({ detectVersion: () => '2.1.218' }).install().state).toBe(
+          'installed'
+        )
 
         const settings = JSON.parse(
           readFileSync(join(tmpHome, '.claude', 'settings.json'), 'utf-8')
@@ -362,6 +374,108 @@ describe('ClaudeHookService.install', () => {
   )
 })
 
+describe('ClaudeHookService version gating', () => {
+  const GATED_EVENTS = [
+    'StopFailure',
+    'SubagentStart',
+    'TeammateIdle',
+    'PostToolUseFailure',
+    'PermissionRequest'
+  ]
+  const BASE_EVENTS = ['UserPromptSubmit', 'Stop', 'SubagentStop', 'PreToolUse', 'PostToolUse']
+
+  const withTmpHome = (fn: (home: string) => void): void => {
+    const tmpHome = mkdtempSync(join(tmpdir(), 'orca-claude-gating-'))
+    vi.stubEnv('HOME', tmpHome)
+    vi.stubEnv('USERPROFILE', tmpHome)
+    try {
+      fn(tmpHome)
+    } finally {
+      vi.unstubAllEnvs()
+      rmSync(tmpHome, { recursive: true, force: true })
+    }
+  }
+
+  const readHooks = (home: string): Record<string, unknown> =>
+    JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf-8')).hooks
+
+  // Why: an older client that never received StopFailure et al. must not be told
+  // its install is degraded forever — getStatus() gates on the same version.
+  it('omits gated keys for an old client and does not report perpetual partial', () => {
+    withTmpHome((home) => {
+      const svc = new ClaudeHookService({ detectVersion: () => '2.0.44' })
+      const status = svc.install()
+      expect(status.state).toBe('installed')
+      const hooks = readHooks(home)
+      // 2.0.44 has the base set plus SubagentStart (2.0.43)...
+      for (const event of ['UserPromptSubmit', 'Stop', 'PreToolUse', 'SubagentStart']) {
+        expect(hooks[event]).toBeTruthy()
+      }
+      // ...but predates PermissionRequest (2.0.45), TeammateIdle (2.1.33) and StopFailure (2.1.78).
+      for (const event of [
+        'PermissionRequest',
+        'TeammateIdle',
+        'StopFailure',
+        'PostToolUseFailure'
+      ]) {
+        expect(hooks[event]).toBeUndefined()
+      }
+      // A fresh instance reading the same file still reports installed, not partial.
+      expect(new ClaudeHookService({ detectVersion: () => '2.0.44' }).getStatus().state).toBe(
+        'installed'
+      )
+    })
+  })
+
+  it('injects the full event set for a new client', () => {
+    withTmpHome((home) => {
+      const status = new ClaudeHookService({ detectVersion: () => '2.1.218' }).install()
+      expect(status.state).toBe('installed')
+      const hooks = readHooks(home)
+      for (const event of [...BASE_EVENTS, ...GATED_EVENTS]) {
+        expect(hooks[event]).toBeTruthy()
+      }
+    })
+  })
+
+  it('injects only the safe base set when the version is undetectable', () => {
+    withTmpHome((home) => {
+      const status = new ClaudeHookService({ detectVersion: () => null }).install()
+      expect(status.state).toBe('installed')
+      const hooks = readHooks(home)
+      for (const event of BASE_EVENTS) {
+        expect(hooks[event]).toBeTruthy()
+      }
+      for (const event of GATED_EVENTS) {
+        expect(hooks[event]).toBeUndefined()
+      }
+      expect(new ClaudeHookService({ detectVersion: () => null }).getStatus().state).toBe(
+        'installed'
+      )
+    })
+  })
+
+  // Why: OpenClaude forks Claude Code with its own versioning, so it stays
+  // ungated and keeps receiving StopFailure regardless of Claude Code floors.
+  it('keeps OpenClaude ungated (full set) even with an old detected version', () => {
+    withTmpHome((home) => {
+      const svc = new ClaudeHookService({
+        agent: 'openclaude',
+        displayName: 'OpenClaude',
+        settings: OPENCLAUDE_HOOK_SETTINGS,
+        detectVersion: () => '1.0.0'
+      })
+      expect(svc.install().state).toBe('installed')
+      const hooks = JSON.parse(
+        readFileSync(join(home, '.openclaude', 'settings.json'), 'utf-8')
+      ).hooks
+      for (const event of [...BASE_EVENTS, ...GATED_EVENTS]) {
+        expect(hooks[event]).toBeTruthy()
+      }
+    })
+  })
+})
+
 describe('ClaudeHookService.installRemote', () => {
   it('writes Claude settings + managed script under the remote $HOME', async () => {
     const svc = new ClaudeHookService()
@@ -372,27 +486,24 @@ describe('ClaudeHookService.installRemote', () => {
     const settings = fs.files.get('/home/dev/.claude/settings.json')
     expect(settings).toBeTruthy()
     const parsed = JSON.parse(settings!)
-    // Why: every load-bearing event must be present and point at the
-    // remote-shaped script path with the guarded launcher applied. Drift in
-    // any of these is a real bug — Claude
-    // Code rejects unknown shapes silently and the agent-hooks pipeline
-    // goes dark.
-    for (const event of [
-      'UserPromptSubmit',
-      'Stop',
-      'StopFailure',
-      'SubagentStart',
-      'SubagentStop',
-      'TeammateIdle',
-      'PreToolUse',
-      'PostToolUse',
-      'PostToolUseFailure',
-      'PermissionRequest'
-    ]) {
+    // Why: the remote box's Claude version is unknown and unprobed, so remote
+    // installs inject only the always-safe base events. A gated key would make
+    // an older remote client reject the entire settings.json.
+    for (const event of ['UserPromptSubmit', 'Stop', 'SubagentStop', 'PreToolUse', 'PostToolUse']) {
       expect(parsed.hooks[event]).toBeTruthy()
       const cmd = parsed.hooks[event][0].hooks[0].command as string
       expect(cmd).toContain('/home/dev/.orca/agent-hooks/claude-hook.sh')
       expect(cmd).toMatch(/^if \[ -f /)
+    }
+    // Gated events are omitted remotely — see the base-set rationale above.
+    for (const event of [
+      'StopFailure',
+      'SubagentStart',
+      'TeammateIdle',
+      'PostToolUseFailure',
+      'PermissionRequest'
+    ]) {
+      expect(parsed.hooks[event]).toBeUndefined()
     }
     // Managed script body
     const script = fs.files.get('/home/dev/.orca/agent-hooks/claude-hook.sh')

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -23,7 +23,6 @@ import { getManagedStatusLineScript } from './statusline-script'
 import {
   applyManagedHooks,
   applyManagedStatusLine,
-  CLAUDE_EVENTS,
   CLAUDE_HOOK_SETTINGS,
   getManagedScriptFileName,
   getConfigPath,
@@ -38,19 +37,34 @@ import {
   getStatusLineSlotState,
   removeManagedHooks,
   removeManagedStatusLine,
-  type ClaudeCompatibleHookSettings
+  type ClaudeCompatibleHookSettings,
+  type ClaudeHookEventSpec
 } from './hook-settings'
+import {
+  detectClaudeCodeVersion,
+  resolveLocalEligibleEvents,
+  resolveRemoteEligibleEvents
+} from './hook-event-versions'
 
 type ClaudeHookServiceOptions = {
   agent: AgentHookInstallStatus['agent']
   displayName: string
   settings: ClaudeCompatibleHookSettings
+  // Why: gate injected event keys on the installed Claude Code version so an
+  // older client never sees a key it would reject. OpenClaude forks Claude Code
+  // with independent versioning, so the changelog floors don't apply — it stays
+  // ungated (defaults from `agent`).
+  versionGated: boolean
+  // Why: injectable so tests can drive the gating without spawning `claude`.
+  detectVersion: () => string | null
 }
 
 const DEFAULT_CLAUDE_HOOK_SERVICE_OPTIONS: ClaudeHookServiceOptions = {
   agent: 'claude',
   displayName: 'Claude',
-  settings: CLAUDE_HOOK_SETTINGS
+  settings: CLAUDE_HOOK_SETTINGS,
+  versionGated: true,
+  detectVersion: detectClaudeCodeVersion
 }
 
 function getManagedScript(
@@ -117,9 +131,24 @@ function getManagedScript(
 
 export class ClaudeHookService {
   private readonly options: ClaudeHookServiceOptions
+  private localEventsCache: readonly ClaudeHookEventSpec[] | null = null
 
-  constructor(options: ClaudeHookServiceOptions = DEFAULT_CLAUDE_HOOK_SERVICE_OPTIONS) {
-    this.options = options
+  constructor(options: Partial<ClaudeHookServiceOptions> = {}) {
+    this.options = {
+      ...DEFAULT_CLAUDE_HOOK_SERVICE_OPTIONS,
+      ...options,
+      // Why: OpenClaude versioning is independent of Claude Code; leave it
+      // ungated unless the caller opts in explicitly.
+      versionGated: options.versionGated ?? (options.agent ?? 'claude') !== 'openclaude'
+    }
+  }
+
+  // Why: memoize per instance so getStatus() polling doesn't re-spawn `claude`.
+  // install() and getStatus() share the list so an older client (which omits
+  // gated keys) can't report perpetual "partial".
+  private getLocalEligibleEvents(): readonly ClaudeHookEventSpec[] {
+    this.localEventsCache ??= resolveLocalEligibleEvents(this.options)
+    return this.localEventsCache
   }
 
   getStatus(): AgentHookInstallStatus {
@@ -140,7 +169,7 @@ export class ClaudeHookService {
     const command = getManagedCommand(scriptPath)
     const missing: string[] = []
     let presentCount = 0
-    for (const event of CLAUDE_EVENTS) {
+    for (const event of this.getLocalEligibleEvents()) {
       const definitions = Array.isArray(config.hooks?.[event.eventName])
         ? config.hooks![event.eventName]!
         : []
@@ -187,7 +216,8 @@ export class ClaudeHookService {
     let nextConfig = applyManagedHooks(
       config,
       command,
-      getManagedScriptFileName(this.options.settings)
+      getManagedScriptFileName(this.options.settings),
+      this.getLocalEligibleEvents()
     )
     writeManagedScript(
       scriptPath,
@@ -245,8 +275,16 @@ export class ClaudeHookService {
       }
 
       // Why: the POSIX wrapper is identical regardless of where the script lands; only the path differs.
+      // Why: the remote's Claude version is unknown and unprobed here, so inject
+      // only the always-safe base events — an older remote client would otherwise
+      // reject the entire settings.json on a gated key.
       const command = getRemoteManagedCommand(remoteScriptPath)
-      const nextConfig = applyManagedHooks(config, command, remoteScriptFileName)
+      const nextConfig = applyManagedHooks(
+        config,
+        command,
+        remoteScriptFileName,
+        resolveRemoteEligibleEvents(this.options.versionGated)
+      )
 
       // Why: write script before settings — a mid-install failure then leaves a harmless orphan script, not settings.json pointing at a missing one.
       // Why: SSH remotes use POSIX `.sh` paths even when Orca runs on Windows; never derive remote script syntax from the local OS.

--- a/src/main/claude/hook-settings.ts
+++ b/src/main/claude/hook-settings.ts
@@ -27,39 +27,82 @@ export const OPENCLAUDE_HOOK_SETTINGS: ClaudeCompatibleHookSettings = {
   scriptBaseName: 'openclaude-hook'
 }
 
-export const CLAUDE_EVENTS = [
-  { eventName: 'UserPromptSubmit', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'Stop', definition: { hooks: [{ type: 'command', command: '' }] } },
+export type ClaudeHookEventSpec = {
+  eventName: string
+  // Minimum Claude Code version that recognizes this hook event. Claude Code
+  // < 2.1.101 validates the hooks object against a strict enum and rejects the
+  // ENTIRE settings.json on an unknown key, so injecting a newer event wipes the
+  // user's theme/permissions/MCP config. Callers gate injection on this floor;
+  // see hook-event-versions.ts. Versions taken from the Claude Code CHANGELOG.
+  minVersion: string
+  definition: HookDefinition
+}
+
+// Why: version-gated at install time (hook-event-versions.ts) — the 1.0.x base
+// events are effectively always-on, but the minVersion is annotated for every
+// entry so the floor for each key is self-documenting.
+export const CLAUDE_EVENTS: readonly ClaudeHookEventSpec[] = [
+  {
+    eventName: 'UserPromptSubmit',
+    minVersion: '1.0.54',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
+  {
+    eventName: 'Stop',
+    minVersion: '1.0.38',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
   // Why: OpenClaude skips normal Stop hooks after API/model errors and emits
   // StopFailure instead; without this hook Orca leaves the turn spinning.
-  { eventName: 'StopFailure', definition: { hooks: [{ type: 'command', command: '' }] } },
+  {
+    eventName: 'StopFailure',
+    minVersion: '2.1.78',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
   // Why: subagent/teammate lifecycle feeds the sidebar's child rows and keeps
   // a pane 'working' while background children outlive the lead's turn.
   // TeammateIdle parks turn-based teammates without trusting their permanently
   // "running" background_tasks entry to gate the pane.
-  // Older Claude builds ignore unregistered event names (StopFailure precedent).
-  { eventName: 'SubagentStart', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'SubagentStop', definition: { hooks: [{ type: 'command', command: '' }] } },
-  { eventName: 'TeammateIdle', definition: { hooks: [{ type: 'command', command: '' }] } },
+  {
+    eventName: 'SubagentStart',
+    minVersion: '2.0.43',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
+  {
+    eventName: 'SubagentStop',
+    minVersion: '1.0.41',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
+  {
+    eventName: 'TeammateIdle',
+    minVersion: '2.1.33',
+    definition: { hooks: [{ type: 'command', command: '' }] }
+  },
   // Why: PreToolUse gives the dashboard a live readout of the in-flight tool
   // (name + input preview) before it completes.
   {
     eventName: 'PreToolUse',
+    minVersion: '1.0.38',
     definition: { matcher: '*', hooks: [{ type: 'command', command: '' }] }
   },
   {
     eventName: 'PostToolUse',
+    minVersion: '1.0.38',
     definition: { matcher: '*', hooks: [{ type: 'command', command: '' }] }
   },
+  // Why: 2.1.119 is a conservative floor — PostToolUseFailure has no explicit
+  // "Added" changelog entry; its first changelog mention is 2.1.119.
   {
     eventName: 'PostToolUseFailure',
+    minVersion: '2.1.119',
     definition: { matcher: '*', hooks: [{ type: 'command', command: '' }] }
   },
   {
     eventName: 'PermissionRequest',
+    minVersion: '2.0.45',
     definition: { matcher: '*', hooks: [{ type: 'command', command: '' }] }
   }
-] as const
+]
 
 export function getConfigPath(settings = CLAUDE_HOOK_SETTINGS): string {
   return join(homedir(), settings.configDirName, 'settings.json')
@@ -114,12 +157,15 @@ export function getRemoteManagedCommand(scriptPath: string): string {
 export function applyManagedHooks(
   config: HooksConfig,
   command: string,
-  scriptFileName = getManagedScriptFileName()
+  scriptFileName = getManagedScriptFileName(),
+  // Why: callers pass a version-gated subset so an older Claude Code client
+  // never receives an event key it would reject; defaults to the full set.
+  events: readonly ClaudeHookEventSpec[] = CLAUDE_EVENTS
 ): HooksConfig {
   const nextHooks = { ...config.hooks }
   const isManagedCommand = createManagedCommandMatcher(scriptFileName)
 
-  for (const event of CLAUDE_EVENTS) {
+  for (const event of events) {
     const current = Array.isArray(nextHooks[event.eventName]) ? nextHooks[event.eventName] : []
     const cleaned = removeManagedCommands(current, isManagedCommand)
     const definition: HookDefinition = {


### PR DESCRIPTION
## Problem

Orca installs Claude Code lifecycle hooks into the shared `~/.claude/settings.json`. `src/main/claude/hook-settings.ts` injected every event key unconditionally, including recent ones: `SubagentStart`, `PermissionRequest`, `TeammateIdle`, `StopFailure`, `PostToolUseFailure`.

Claude Code validates the `hooks` object against a strict enum of event names. In versions **older than 2.1.101**, an unknown hook event key causes Claude Code to **reject the entire `settings.json` file**, not just the offending key. The user sees:

> Settings Error … hooks > StopFailure: Invalid key in record … Files with errors are skipped entirely

and loses **all** of their settings — theme, permissions, MCP servers, env, etc. Claude Code 2.1.101 later added tolerance (unknown hook keys are ignored), so newer clients are fine, but anyone on an older client is broken the moment Orca writes a key their build doesn't recognize.

The existing code comment asserted *"Older Claude builds ignore unregistered event names (StopFailure precedent)."* That assumption is false for Claude Code < 2.1.101 and was the root cause; this PR corrects it.

## Fix: per-event version gating with a fail-safe base set

Each entry in `CLAUDE_EVENTS` now carries a `minVersion` (the Claude Code release that introduced that event). At install time we detect the installed Claude Code version via `claude --version` (parsing the leading `x.y.z` from output like `2.1.218 (Claude Code)`, reusing the existing `resolveClaudeCommand()` binary resolver and the shared `compareAppVersions()` semver comparator) and inject only events whose `minVersion <= detectedVersion`.

**Fail safe:** if the version can't be detected (binary missing, spawn error, unparseable output) we inject only the long-stable base events (`minVersion <= 1.0.54`): `UserPromptSubmit`, `Stop`, `PreToolUse`, `PostToolUse`, `SubagentStop`. An undetectable version is exactly the unknown-old client that breaks, so we never inject a gated key when the version is unknown.

`getStatus()`'s partial-vs-installed logic now iterates the **same** version-filtered list as `install()` (shared, memoized per service instance), so an older client no longer reports a perpetual "partial" install for events it was never eligible to receive.

### Event → minimum Claude Code version

Sourced from the official CHANGELOG (https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md):

| Event | Min version |
|---|---|
| PreToolUse | 1.0.38 |
| PostToolUse | 1.0.38 |
| Stop | 1.0.38 |
| SubagentStop | 1.0.41 |
| UserPromptSubmit | 1.0.54 |
| SubagentStart | 2.0.43 |
| PermissionRequest | 2.0.45 |
| TeammateIdle | 2.1.33 |
| StopFailure | 2.1.78 |
| PostToolUseFailure | 2.1.119 |

Tolerance for unknown hook keys was added in **2.1.101**; clients at or above that never trip the bug regardless of gating, but gating keeps older clients safe. `PostToolUseFailure` has no explicit "Added" changelog entry — its first changelog mention is 2.1.119, so that is used as a conservative floor (noted in a code comment).

## Design decisions / caveats

- **Remote (SFTP) installs** (`installRemote()`): the local `claude --version` is not the remote box's version, and Orca has no ready way to probe the remote client here (a pre-existing comment already notes the platform mismatch). Rather than risk breaking a remote client, remote installs conservatively fall back to the **safe base set**. This is strictly better than today's unconditional injection; documented in a code comment.
- **OpenClaude** (`.openclaude`): OpenClaude forks Claude Code with independent versioning, so the Claude Code changelog floors don't apply to it (and it is the fork whose `StopFailure` the original comment referenced). It stays **ungated** and keeps receiving the full event set — no behavior change. Gating defaults from the `agent` field, so only the real Claude Code path is gated.
- Version detection is injectable on the service so it can be unit-tested without spawning a binary, and memoized per instance so `getStatus()` polling doesn't repeatedly spawn `claude`.
- The version logic lives in a new, concretely named module `src/main/claude/hook-event-versions.ts` (per AGENTS.md file-naming rules) rather than bloating `hook-service.ts` or adding a `max-lines` disable.

## Tests

- `src/main/claude/hook-event-versions.test.ts` (new): `parseClaudeCodeVersion` parsing, `selectClaudeEventsForVersion` gating (base-only on the unknown floor, full set on recent, correct mid-range cutoffs), and `detectClaudeCodeVersion` returning `null` when the binary can't be spawned.
- `src/main/claude/hook-service.test.ts` (extended): old version omits gated keys and still reports `installed` (not perpetual `partial`); new version includes all keys; undetectable version → base set only; OpenClaude stays ungated with an old detected version; remote install now uses the conservative base set.

## Verification

Run locally on macOS with Node 24 / pnpm 10.24.0:

- `pnpm run typecheck` — pass
- `pnpm exec vitest run` on `hook-event-versions.test.ts`, `hook-service.test.ts`, and `remote-hook-service-installers.test.ts` — pass (44 passed, 2 skipped Windows-only)
- `pnpm run lint` (oxlint + switch-exhaustiveness + reliability-gates + max-lines-ratchet + skill/localization verifiers) — pass (exit 0; only a pre-existing unrelated warning in `keyboard-handlers.ts`)
- oxfmt applied to changed files

Not run: the full `pnpm run test` suite and any app build/packaging (out of scope for this change and heavy in this environment). The changed logic is covered by the unit tests above.

## ELI5

Orca wrote newer Claude Code hook event names into settings.json that older Claude clients reject entirely, breaking hooks. Hook keys are version-gated so older clients only get events they understand.
