### PR TITLE
fix(remote): create paired agent sessions without host focus

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1387,6 +1387,7 @@
       "surfaces": [
         "remote agent launch and explicit resume",
         "multi-client remote runtime sessions",
+        "paired viewer-local structured agent focus",
         "headed desktop remote-server pairing",
         "headless remote-server parity",
         "daemon and relay reconnect",
@@ -1416,19 +1417,26 @@
         "wsl",
         "remote-runtime"
       ],
-      "coverageNotes": "Deterministic macOS tests cover controller claims, daemon and SSH/relay operation replay, mixed-version selection, runtime ownership, exact provisional handoff, durable terminal retirement, two independent viewer mirrors, guarded adoption of legacy live PTYs, and completion classification when either the outer remote transport or authoritative host/provider process inspection becomes unreachable. The adoption harness models v1.4.150 agent/setup/shell tabs, current-generation restart and reconnect, exact handle/incarnation/worktree/host checks, topology CAS, competing clients, split-pane/group restoration, WSL ownership, and SSH owner rejection. The secondary parity repro runs independent clients against one headless remote Orca runtime over encrypted pairing and a real daemon-backed PTY. The primary headed topology was exercised with an isolated macOS Orca desktop server, a separate paired Edge client, a real Codex process, injected WebSocket loss, reconnect, and explicit stop; host inspection and visible client state agreed throughout. SSH coverage is provider/relay contract and fault-injection coverage only; it does not substitute for paired-server coverage. Live Windows, Linux, WSL, and SSH hosts remain gaps.",
+      "coverageNotes": "Deterministic macOS tests cover controller claims, daemon and SSH/relay operation replay, mixed-version selection, runtime ownership, exact provisional handoff, durable terminal retirement, two independent viewer mirrors, guarded adoption of legacy live PTYs, and completion classification when either the outer remote transport or authoritative host/provider process inspection becomes unreachable. The adoption harness models v1.4.150 agent/setup/shell tabs, current-generation restart and reconnect, exact handle/incarnation/worktree/host checks, topology CAS, competing clients, split-pane/group restoration, WSL ownership, and SSH owner rejection. The secondary parity repro runs independent clients against one headless remote Orca runtime over encrypted pairing and a real daemon-backed PTY, with tokened fixture-process identity separated from unrelated Codex app-server startup probes. The automated primary topology runs an isolated headed macOS Orca desktop server plus a separate paired web client and proves viewer-local fresh/resume focus, exact legacy placement, writable PTYs, unrelated-terminal survival, and host/client cleanup. SSH coverage is provider/relay contract and fault-injection coverage only; it does not substitute for paired-server coverage. Live Windows, Linux, WSL, SSH, and physical paired-Linux hosts remain gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/issues/8878",
         "https://github.com/stablyai/orca/issues/9151",
         "https://github.com/stablyai/orca/issues/9352",
-        "https://github.com/stablyai/orca/pull/9687"
+        "https://github.com/stablyai/orca/pull/9687",
+        "https://github.com/stablyai/orca/issues/10192",
+        "https://github.com/stablyai/orca/pull/10193"
       ],
-      "invariant": "For every claim-capable execution route, one provider-session identity has at most one live PTY owner and one canonical host surface across concurrent clients, retries, reconnects, and stale publications. A live orphan may be adopted only when the controller proves its exact handle and incarnation, its worktree and host owner match, no competing visual owner exists, and a host topology CAS wins. A viewer may classify completion only from successful host/provider inspection or explicit lifecycle evidence; transport, handle, or provider unavailability remains unknown and breaks any consecutive-idle proof. A physical exit retires that exact incarnation durably so stale client state and host restart cannot recreate it. Mixed-version routes select the unchanged legacy request before any authority side effect or execution-owner-local filesystem access.",
-      "oracle": "Race independent clients and repeated operation IDs, then assert one physical spawn and one canonical PTY/surface; inject exit-before-reply, provider disconnect, conflicting claim scope, old daemon/relay capabilities, reused handles, stale incarnations, owner mismatch, and topology revision conflict; assert safe adoption or explicit failure without a second spawn or wrong-process attachment. Restore legacy split panes and groups beside a newer host-owned tab, preserving output, input, resize, titles, tab/leaf identity, active group, and multi-client convergence. For completion, drive a known running agent through outer transport loss, authoritative provider rejection, reconnect, explicit stop, real exit status, and successful hook completion; assert unavailable evidence never dispatches completion and two fresh authoritative idle samples are required after the gap. After exact exit, assert terminal and tab listings omit the surface, a stale publication cannot restore it, restart cannot resurrect it, and an exact provisional handoff is consumed even when exit wins before the next snapshot.",
+      "invariant": "For every claim-capable execution route, one provider-session identity has at most one live PTY owner and one canonical host surface across concurrent clients, retries, reconnects, and stale publications. For paired structured fresh and resume requests, the authenticated owning runtime creates in background without a renderer window; activate=true focuses the exact requested leaf only on the requesting viewer, while activate=false changes no viewer focus. A live orphan may be adopted only when the controller proves its exact handle and incarnation, its worktree and host owner match, no competing visual owner exists, and a host topology CAS wins. A viewer may classify completion only from successful host/provider inspection or explicit lifecycle evidence; transport, handle, or provider unavailability remains unknown and breaks any consecutive-idle proof. A physical exit retires that exact incarnation durably so stale client state and host restart cannot recreate it. Mixed-version routes select the unchanged legacy request before any authority side effect or execution-owner-local filesystem access.",
+      "oracle": "Race independent clients and repeated operation IDs, then assert one physical spawn and one canonical PTY/surface; inject exit-before-reply, provider disconnect, conflicting claim scope, old daemon/relay capabilities, reused handles, stale incarnations, owner mismatch, and topology revision conflict; assert safe adoption or explicit failure without a second spawn or wrong-process attachment. Run fresh/resume with activate true/false against an isolated headed desktop host and a separate paired client, then against isolated headless serve: assert host presentation stays background, only the requesting viewer focuses the exact leaf, inactive calls preserve client/DOM focus, a same-version publication replay cannot lose focus intent, and sibling-first split publication cannot consume exact-leaf intent. Restore legacy split panes and groups beside a newer host-owned tab, preserving exact predecessor/new/successor order, output, input, resize, titles, tab/leaf identity, active group, and multi-client convergence. For completion, drive a known running agent through outer transport loss, authoritative provider rejection, reconnect, explicit stop, real exit status, and successful hook completion; assert unavailable evidence never dispatches completion and two fresh authoritative idle samples are required after the gap. After exact exit, assert terminal and tab listings omit the surface, a stale publication cannot restore it, restart cannot resurrect it, exact tokened fixture PIDs are dead, and unrelated tabs/processes survive until scoped cleanup.",
       "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/agent-session.test.ts src/renderer/src/runtime/web-runtime-session.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/runtime/web-session-intent-owner.test.ts src/renderer/src/runtime/remote-server-parity.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/claimed-agent-pty-owner.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts src/main/runtime/orca-runtime-agent-session-operation.test.ts src/main/runtime/remote-agent-session-host-authority.integration.test.ts src/main/runtime/orca-runtime-terminal-retirement.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts src/renderer/src/runtime/remote-runtime-session-tabs-inflight.test.ts src/renderer/src/runtime/web-runtime-session.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/remote-terminal-tab-retirement.unit.test.ts",
         "pnpm test:repro:remote-agent-session",
+        "pnpm run build:cli && pnpm run build:electron-vite && node config/scripts/remote-agent-session-authority-repro.mjs",
+        "pnpm exec electron-vite build --mode e2e",
+        "VITE_EXPOSE_STORE=true pnpm run build:web",
+        "ORCA_E2E_WEB_CLIENT=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/remote-agent-session-focus-authority.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
         "Manual headed paired-server journey: isolated Orca desktop host + separate paired web client + real Codex process + 20-second WebSocket fault + reconnect + explicit stop",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts src/main/runtime/terminal-orphan-owner.test.ts src/main/runtime/terminal-orphan-topology.test.ts src/renderer/src/runtime/web-session-terminal-orphan-recovery.test.ts src/renderer/src/runtime/web-session-terminal-orphan-mixed-version.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts --maxWorkers=1",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/providers/pty-process-inspection.test.ts src/main/daemon/terminal-host.test.ts src/main/daemon/daemon-pty-router.test.ts src/main/daemon/degraded-daemon-pty-provider.test.ts src/relay/pty-handler.test.ts src/main/daemon/daemon-pty-adapter.test.ts src/main/runtime/orca-runtime.test.ts tests/e2e/remote-agent-completion-authority.unit.test.ts src/renderer/src/runtime/runtime-terminal-inspection.test.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts",
@@ -1451,11 +1459,16 @@
         "src/main/providers/ssh-pty-provider-agent-session-create-operation.test.ts",
         "src/main/runtime/orca-runtime-agent-session-operation.test.ts",
         "src/main/runtime/remote-agent-session-host-authority.integration.test.ts",
+        "src/main/runtime/rpc/methods/agent-session.test.ts",
         "src/main/runtime/orca-runtime-terminal-retirement.test.ts",
         "src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.test.ts",
         "src/renderer/src/runtime/remote-runtime-session-tabs-inflight.test.ts",
         "src/renderer/src/runtime/web-runtime-session.test.ts",
         "src/renderer/src/runtime/web-session-tabs-sync.test.ts",
+        "src/renderer/src/runtime/web-session-intent-owner.test.ts",
+        "src/renderer/src/runtime/remote-server-parity.test.ts",
+        "tests/e2e/remote-agent-session-focus-authority.spec.ts",
+        "config/scripts/remote-agent-session-authority-repro.mjs",
         "tests/e2e/remote-terminal-tab-retirement.unit.test.ts",
         "src/main/runtime/orca-runtime.test.ts",
         "src/main/runtime/terminal-orphan-owner.test.ts",
@@ -1557,16 +1570,41 @@
           ]
         },
         {
+          "file": "src/main/runtime/rpc/methods/agent-session.test.ts",
+          "assertions": [
+            "authenticated runtime and mobile structured requests normalize focused presentation to background before reaching the owning runtime",
+            "trusted in-process structured callers retain focused presentation"
+          ]
+        },
+        {
           "file": "src/renderer/src/runtime/web-runtime-session.test.ts",
           "assertions": [
-            "a causally post-create list confirms only the exact provisional tab and terminal-handle generation when another create is in flight"
+            "fresh/resume activate true/false always request background host presentation and record focus intent only for active calls",
+            "a publication that beats the RPC response is replayed once without broad polling"
           ]
         },
         {
           "file": "src/renderer/src/runtime/web-session-tabs-sync.test.ts",
           "assertions": [
             "only an exact structured-create handoff retires its provisional tab",
-            "an absent host tab retires its exact provisional handoff only after a causally post-create snapshot while unrelated tabs remain"
+            "an absent host tab retires its exact provisional handoff only after a causally post-create snapshot while unrelated tabs remain",
+            "adopted split sessions focus the exact requested leaf, preserve expanded-leaf state, and retain intent when a sibling publishes first"
+          ]
+        },
+        {
+          "file": "tests/e2e/remote-agent-session-focus-authority.spec.ts",
+          "assertions": [
+            "headed desktop host remains unfocused while the paired requester alone follows active fresh/resume sessions and inactive rows preserve exact client/DOM focus",
+            "legacy afterTabId placement is exact in authoritative, mirrored, and rendered order with a pre-existing successor",
+            "host PTY inventory plus writable agent/unrelated shell markers prove liveness, unrelated survival, and exact terminal/tab/PTY/process cleanup"
+          ]
+        },
+        {
+          "file": "config/scripts/remote-agent-session-authority-repro.mjs",
+          "assertions": [
+            "headless focused fresh/resume requests create background host surfaces without a renderer window",
+            "dropped committed responses replay the same operation identity without another tokened agent spawn",
+            "exact terminal/tab/process identity survives retries and stale-write rejection, then retires without restart resurrection while unrelated shells survive until scoped cleanup"
           ]
         },
         {
@@ -1604,6 +1642,33 @@
         }
       ],
       "evidenceRuns": [
+        {
+          "date": "2026-07-23",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/agent-session.test.ts src/renderer/src/runtime/web-runtime-session.test.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts src/renderer/src/runtime/web-session-intent-owner.test.ts src/renderer/src/runtime/remote-server-parity.test.ts",
+          "result": "passed",
+          "durationSeconds": 2.28,
+          "summary": "Five focused files and 140 tests passed on the structural candidate, covering authenticated host presentation normalization, trusted local preservation, fresh/resume viewer intent, same-version response/publication replay, exact split-leaf focus, sibling-first publication, and paired-runtime parity."
+        },
+        {
+          "date": "2026-07-23",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm test:repro:remote-agent-session",
+          "result": "passed",
+          "durationSeconds": 53.6,
+          "summary": "The build-backed isolated headless serve harness passed over encrypted pairing. Tokened fresh/resume fixture processes were distinguished from unrelated Codex app-server startup probes; response-loss replay, exact spawn identity/count, writable PTYs, unrelated survival, stale rejection, exact PID death, empty restart inventory, and no session resurrection all passed."
+        },
+        {
+          "date": "2026-07-23",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_E2E_WEB_CLIENT=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/remote-agent-session-focus-authority.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 5.8,
+          "summary": "After fresh Electron E2E and exposed-store web builds, the isolated headed desktop host plus separate paired web client passed fresh/resume activate true/false, exact non-tail legacy placement in host/mirror/DOM, host focus isolation, requester-only exact focus, writable agent and unrelated shell markers, unrelated survival, and terminal/tab/PTY/process cleanup."
+        },
         {
           "date": "2026-07-22",
           "runner": "manual",
@@ -1678,20 +1743,20 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Issue #9151 has local red/green evidence: current main dispatches process-exit from a stale remote handle, while the fix preserves unknown liveness and requires fresh consecutive idle evidence after reconnect. The exact retirement oracle is red on pre-#9687 commit 2a32c5c9a and PR #9053 head d3a1d3047 because the pinned persisted surface remains in the host publication, and green on main@4fce2de49. Duplicate-resume red evidence remains encoded in lower-layer tests; saved CI artifacts are still needed."
+        "evidence": "Issue #10192 has byte-identical renderer-oracle evidence: origin/main@94d3db4a2 fails activated fresh and resume rows by requesting focused host presentation, the PR client change passes all four rows, and disabling it turns the activated rows red again. The original PR still fails an old-client focused request against a new headless host; host-boundary normalization turns that mixed-version control green while trusted local callers remain focused. Issue #9151 has local red/green evidence for completion authority. The exact retirement oracle is red on pre-#9687 commit 2a32c5c9a and PR #9053 head d3a1d3047, and green on main@4fce2de49. Saved CI artifacts are still needed."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Agent-session reconciliation runs only at explicit claim admission, dedupes concurrent provider listing, and adds no polling or renderer output work. Completion inspection reuses the coordinator's per-pane in-flight guard, global concurrency/rate queue, and existing error backoff; the strict daemon path reduces two foreground RPCs to one. Create-operation ledgers are capped globally and per client, expire after 24 hours, and reject rather than evict live replay fences. Capability caches are bounded or connection-scoped, and exact handoffs are consumed by the next authoritative snapshot."
+        "evidence": "Agent-session reconciliation runs only at explicit claim admission, dedupes concurrent provider listing, and adds no polling or renderer output work. Viewer focus reconciliation reuses the existing one post-create list and bounded intent map; same-version replay permits one already-received snapshot, and exact-leaf matching adds one conditional scan over the bounded tab snapshot. Completion inspection reuses the coordinator's per-pane in-flight guard, global concurrency/rate queue, and existing error backoff; the strict daemon path reduces two foreground RPCs to one. Create-operation ledgers are capped globally and per client, expire after 24 hours, and reject rather than evict live replay fences. Capability caches are bounded or connection-scoped, and exact handoffs are consumed by the next authoritative snapshot."
       },
       "promotionCriteria": [
         "Run the focused gate and remote-server repro for at least 100 consecutive passes or 14 days across required CI platforms.",
         "Attach saved red/green evidence for duplicate remote resume and exit-before-snapshot retirement.",
-        "Automate the headed Orca desktop-server journey with a separate paired client; add a physical host only when OS, ConPTY, update, sleep, firewall, or window lifecycle is causal.",
+        "Run the automated headed Orca desktop-server and paired-client journey in required CI lanes; add a physical host when OS, ConPTY, update, sleep, firewall, or window lifecycle is causal.",
         "Add live SSH/WSL provider evidence before claiming full provider coverage; Docker SSH proves only the SSH provider/relay path."
       ],
       "knownGaps": [
-        "The primary headed macOS desktop-server journey is collected but not automated in CI; Windows and Linux window, ConPTY, update, sleep/wake, and firewall behavior remain uncollected.",
+        "The primary headed macOS desktop-server journey is automated locally but not yet run in CI; Windows and Linux window, ConPTY, update, sleep/wake, and firewall behavior remain uncollected.",
         "Mixed-version pairings remain conservative only when the completion-aware client and strict-inspection host changes are both present; older peers retain their legacy classification behavior.",
         "The secondary headless parity harness runs on macOS with a local daemon-backed execution owner and independent short-lived encrypted RPC clients; two persistent viewer-store mirrors and reconnect ordering are joined deterministically in the cross-boundary unit test rather than mounted live.",
         "SSH and relay failure ordering is deterministic provider-contract coverage, not a live SSH-host journey or paired-Orca-server proof; WSL has no provider-specific run, and Linux and Windows runs remain uncollected.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1434,6 +1434,7 @@
         "pnpm exec vitest run --config config/vitest.config.ts tests/e2e/remote-terminal-tab-retirement.unit.test.ts",
         "pnpm test:repro:remote-agent-session",
         "pnpm run build:cli && pnpm run build:electron-vite && node config/scripts/remote-agent-session-authority-repro.mjs",
+        "node --check config/scripts/remote-agent-session-process-cleanup.mjs && node config/scripts/remote-agent-session-authority-repro.mjs",
         "pnpm exec electron-vite build --mode e2e",
         "VITE_EXPOSE_STORE=true pnpm run build:web",
         "ORCA_E2E_WEB_CLIENT=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/remote-agent-session-focus-authority.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
@@ -1469,6 +1470,7 @@
         "src/renderer/src/runtime/remote-server-parity.test.ts",
         "tests/e2e/remote-agent-session-focus-authority.spec.ts",
         "config/scripts/remote-agent-session-authority-repro.mjs",
+        "config/scripts/remote-agent-session-process-cleanup.mjs",
         "tests/e2e/remote-terminal-tab-retirement.unit.test.ts",
         "src/main/runtime/orca-runtime.test.ts",
         "src/main/runtime/terminal-orphan-owner.test.ts",
@@ -1608,6 +1610,12 @@
           ]
         },
         {
+          "file": "config/scripts/remote-agent-session-process-cleanup.mjs",
+          "assertions": [
+            "isolated daemon roots and captured descendants are verified dead before profile PID records are removed"
+          ]
+        },
+        {
           "file": "tests/e2e/remote-terminal-tab-retirement.unit.test.ts",
           "assertions": [
             "a durable host exit removes the terminal from two independent viewer mirrors instead of publishing a handle-less phantom",
@@ -1743,7 +1751,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "Issue #10192 has byte-identical renderer-oracle evidence: origin/main@94d3db4a2 fails activated fresh and resume rows by requesting focused host presentation, the PR client change passes all four rows, and disabling it turns the activated rows red again. The original PR still fails an old-client focused request against a new headless host; host-boundary normalization turns that mixed-version control green while trusted local callers remain focused. Issue #9151 has local red/green evidence for completion authority. The exact retirement oracle is red on pre-#9687 commit 2a32c5c9a and PR #9053 head d3a1d3047, and green on main@4fce2de49. Saved CI artifacts are still needed."
+        "evidence": "Issue #10192 has byte-identical renderer-oracle evidence: origin/main@ee87bb38d (and earlier ef985ed80 and 94d3db4a2) fails activated fresh and resume rows by requesting focused host presentation, the PR client change passes all four rows, and disabling it turns the activated rows red again. The original PR still fails an old-client focused request against a new headless host; host-boundary normalization turns that mixed-version control green while trusted local callers remain focused. Issue #9151 has local red/green evidence for completion authority. The exact retirement oracle is red on pre-#9687 commit 2a32c5c9a and PR #9053 head d3a1d3047, and green on main@4fce2de49. Saved CI artifacts are still needed."
       },
       "performanceBudget": {
         "required": true,

--- a/config/scripts/remote-agent-session-authority-repro.mjs
+++ b/config/scripts/remote-agent-session-authority-repro.mjs
@@ -10,6 +10,7 @@ import {
   rmSync,
   writeFileSync
 } from 'node:fs'
+import { createRequire } from 'node:module'
 import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
@@ -17,6 +18,9 @@ import { createInterface } from 'node:readline'
 import { cleanupIsolatedDaemons, isProcessAlive } from './remote-agent-session-process-cleanup.mjs'
 
 const repoRoot = path.resolve(import.meta.dirname, '..', '..')
+const { parsePaneKey } = createRequire(import.meta.url)(
+  path.join(repoRoot, 'out', 'shared', 'stable-pane-id.js')
+)
 const clientScript = path.join(import.meta.dirname, 'remote-agent-session-repro-client.mjs')
 const fixtureScript = path.join(import.meta.dirname, 'remote-agent-session-repro-fixture.mjs')
 const writableShellScript = path.join(
@@ -204,7 +208,11 @@ try {
   if (!oldTerminal.tabId || !oldTerminal.paneKey || !oldTerminal.ptyId) {
     throw new Error(`retired terminal identity is incomplete: ${JSON.stringify(oldTerminal)}`)
   }
-  const leafId = oldTerminal.paneKey.slice(oldTerminal.paneKey.indexOf(':') + 1)
+  const parsedPaneKey = parsePaneKey(oldTerminal.paneKey)
+  if (!parsedPaneKey || parsedPaneKey.tabId !== oldTerminal.tabId) {
+    throw new Error(`retired terminal pane identity is invalid: ${JSON.stringify(oldTerminal)}`)
+  }
+  const leafId = parsedPaneKey.leafId
   const staleWrite = await callClient(pairingCode, 'session.tabs.updatePaneLayout', {
     worktree,
     tabId: oldTerminal.tabId,

--- a/config/scripts/remote-agent-session-authority-repro.mjs
+++ b/config/scripts/remote-agent-session-authority-repro.mjs
@@ -18,6 +18,10 @@ import { createInterface } from 'node:readline'
 const repoRoot = path.resolve(import.meta.dirname, '..', '..')
 const clientScript = path.join(import.meta.dirname, 'remote-agent-session-repro-client.mjs')
 const fixtureScript = path.join(import.meta.dirname, 'remote-agent-session-repro-fixture.mjs')
+const writableShellScript = path.join(
+  import.meta.dirname,
+  'remote-agent-session-repro-writable-shell.mjs'
+)
 // Why: macOS limits Unix-domain socket paths to 104 bytes; the server profile
 // creates nested daemon/runtime sockets below this disposable directory.
 const scratch = mkdtempSync(path.join(os.tmpdir(), 'oa-'))
@@ -25,7 +29,9 @@ const profilePath = path.join(scratch, 'profile')
 const projectPath = path.join(scratch, 'repo')
 const binPath = path.join(scratch, 'bin')
 const spawnMarkerPath = path.join(scratch, 'agent-spawns.txt')
+const inputMarkerPath = path.join(scratch, 'agent-input.txt')
 const exitTriggerPath = path.join(scratch, 'exit-agent')
+const agentSessionToken = '--orca-repro-agent-session'
 const childProcesses = new Set()
 let server = null
 
@@ -77,12 +83,57 @@ try {
     )
   }
   const worktree = `id:${fixtureWorktree.id}`
+  const freshRequest = {
+    clientOperationId: `${Date.now()}-0123456789abcdef0123456789abcdef`,
+    worktree,
+    agent: 'codex',
+    presentation: 'focused'
+  }
+  const droppedFresh = await callClient(
+    pairingCode,
+    'terminal.createAgentSession',
+    freshRequest,
+    'drop-response'
+  )
+  if (!droppedFresh.droppedResponse) {
+    throw new Error(`fresh response was not dropped: ${JSON.stringify(droppedFresh)}`)
+  }
+  let committedFreshTerminal = null
+  await waitFor(async () => {
+    const terminals = await callClient(pairingCode, 'terminal.list', { worktree })
+    if (!terminals.ok || terminals.result.terminals.length !== 1 || countSpawnMarkers() !== 1) {
+      return false
+    }
+    committedFreshTerminal = terminals.result.terminals[0]
+    return true
+  }, 'fresh host commit after response loss')
+  const fresh = await callClient(pairingCode, 'terminal.createAgentSession', freshRequest)
+  assertOk(fresh, 'focused fresh retry after response loss')
+  if (fresh.result.disposition !== 'replayed') {
+    throw new Error(`fresh retry was ${fresh.result.disposition}, expected replayed`)
+  }
+  assertTerminalInventoryIdentity(committedFreshTerminal, fresh.result.terminal)
+  if (fresh.result.terminal.surface !== 'background') {
+    throw new Error(`execution host returned ${fresh.result.terminal.surface}, expected background`)
+  }
+  if (countSpawnMarkers() !== 1) {
+    throw new Error('fresh retry after response loss started a second agent')
+  }
+  await sendMarker(pairingCode, fresh.result.terminal.handle, 'fresh-agent-writable')
+  const shell = await callClient(pairingCode, 'terminal.create', {
+    worktree,
+    command: fixtureCommand(writableShellScript, inputMarkerPath),
+    presentation: 'background'
+  })
+  assertOk(shell, 'unrelated writable shell creation')
+  await sendMarker(pairingCode, shell.result.terminal.handle, 'shell-writable')
+
   const resumeRequest = {
     kind: 'explicit',
     worktree,
     agent: 'codex',
     providerSession: { key: 'session_id', id: 'remote-authority-repro' },
-    presentation: 'background'
+    presentation: 'focused'
   }
 
   const [first, second] = await Promise.all([
@@ -94,7 +145,7 @@ try {
   const dispositions = [first.result.disposition, second.result.disposition].sort()
   assertJsonEqual(dispositions, ['adopted', 'created'], 'race dispositions')
   assertSameTerminal(first.result.terminal, second.result.terminal)
-  await waitFor(() => countSpawnMarkers() === 1, 'exactly one fixture agent spawn')
+  await waitFor(() => countSpawnMarkers() === 2, 'exactly one fresh and one resumed spawn')
 
   const retry = await callClient(pairingCode, 'terminal.ensureAgentSession', resumeRequest)
   assertOk(retry, 'resume retry')
@@ -102,9 +153,13 @@ try {
     throw new Error(`resume retry was ${retry.result.disposition}, expected adopted`)
   }
   assertSameTerminal(first.result.terminal, retry.result.terminal)
-  if (countSpawnMarkers() !== 1) {
-    throw new Error('resume retry started a second agent')
+  const spawnCountAfterRetry = countSpawnMarkers()
+  if (spawnCountAfterRetry !== 2) {
+    throw new Error(
+      `resume retry changed spawn count to ${spawnCountAfterRetry}: ${readFileSync(spawnMarkerPath, 'utf8')}`
+    )
   }
+  await sendMarker(pairingCode, retry.result.terminal.handle, 'resume-agent-writable')
 
   const closed = await callClient(pairingCode, 'terminal.close', {
     terminal: first.result.terminal.handle
@@ -115,22 +170,40 @@ try {
       callClient(pairingCode, 'terminal.list', { worktree }),
       callClient(pairingCode, 'session.tabs.list', { worktree })
     ])
+    const expectedParentTabIds = [fresh.result.terminal.tabId, shell.result.terminal.tabId].sort()
+    const actualParentTabIds = tabs.ok
+      ? tabs.result.tabs
+          .filter((tab) => tab.type === 'terminal')
+          .map((tab) => tab.parentTabId)
+          .sort()
+      : []
     return (
       terminals.ok &&
       tabs.ok &&
-      terminals.result.terminals.length === 0 &&
-      tabs.result.tabs.length === 0
+      terminals.result.terminals.length === 2 &&
+      terminals.result.terminals.some(
+        (terminal) => terminal.handle === fresh.result.terminal.handle
+      ) &&
+      terminals.result.terminals.some(
+        (terminal) => terminal.handle === shell.result.terminal.handle
+      ) &&
+      JSON.stringify(actualParentTabIds) === JSON.stringify(expectedParentTabIds) &&
+      !actualParentTabIds.includes(first.result.terminal.tabId)
     )
-  }, 'exited surface retirement')
+  }, 'resume retirement without unrelated terminal loss')
 
   const oldTerminal = first.result.terminal
-  if (oldTerminal.tabId && oldTerminal.paneKey) {
-    const leafId = oldTerminal.paneKey.slice(oldTerminal.paneKey.indexOf(':') + 1)
-    await callClient(pairingCode, 'session.tabs.updatePaneLayout', {
-      worktree,
-      tabId: oldTerminal.tabId,
-      root: { type: 'leaf', id: leafId, ptyId: oldTerminal.ptyId ?? undefined }
-    }).catch(() => null)
+  if (!oldTerminal.tabId || !oldTerminal.paneKey) {
+    throw new Error(`retired terminal identity is incomplete: ${JSON.stringify(oldTerminal)}`)
+  }
+  const leafId = oldTerminal.paneKey.slice(oldTerminal.paneKey.indexOf(':') + 1)
+  const staleWrite = await callClient(pairingCode, 'session.tabs.updatePaneLayout', {
+    worktree,
+    tabId: oldTerminal.tabId,
+    root: { type: 'leaf', id: leafId, ptyId: oldTerminal.ptyId ?? undefined }
+  })
+  if (staleWrite.ok || staleWrite.error?.code !== 'invalid_argument') {
+    throw new Error(`stale pane publication was not rejected: ${JSON.stringify(staleWrite)}`)
   }
 
   const [afterStaleTerminals, afterStaleTabs] = await Promise.all([
@@ -139,8 +212,48 @@ try {
   ])
   assertOk(afterStaleTerminals, 'terminal list after stale publication')
   assertOk(afterStaleTabs, 'tab list after stale publication')
-  assertJsonEqual(afterStaleTerminals.result.terminals, [], 'terminal stale-write resurrection')
-  assertJsonEqual(afterStaleTabs.result.tabs, [], 'tab stale-write resurrection')
+  assertJsonEqual(
+    afterStaleTerminals.result.terminals.map((terminal) => terminal.handle).sort(),
+    [fresh.result.terminal.handle, shell.result.terminal.handle].sort(),
+    'terminal stale-write resurrection'
+  )
+  assertJsonEqual(
+    afterStaleTabs.result.tabs
+      .filter((tab) => tab.type === 'terminal')
+      .map((tab) => tab.parentTabId)
+      .sort(),
+    [fresh.result.terminal.tabId, shell.result.terminal.tabId].sort(),
+    'tab stale-write resurrection'
+  )
+  if (
+    afterStaleTabs.result.tabs.some(
+      (tab) => tab.type === 'terminal' && tab.parentTabId === oldTerminal.tabId
+    )
+  ) {
+    throw new Error('stale publication restored the retired resume tab')
+  }
+
+  const freshClosed = await callClient(pairingCode, 'terminal.close', {
+    terminal: fresh.result.terminal.handle
+  })
+  assertOk(freshClosed, 'unrelated fresh terminal close')
+  const remainingClosed = await callClient(pairingCode, 'terminal.stop', { worktree })
+  assertOk(remainingClosed, 'isolated fixture terminal cleanup')
+  await waitFor(async () => {
+    const terminals = await callClient(pairingCode, 'terminal.list', { worktree })
+    return terminals.ok && terminals.result.terminals.length === 0
+  }, 'fresh terminal retirement')
+  await waitFor(
+    () =>
+      readAgentSpawnPids().length === 2 &&
+      readAgentSpawnPids().every((pid) => !isProcessAlive(pid)),
+    'fixture agent process exit'
+  )
+  if (countSpawnMarkers() !== 2) {
+    throw new Error(
+      `cleanup observed a delayed extra spawn: ${readFileSync(spawnMarkerPath, 'utf8')}`
+    )
+  }
 
   await stopServer()
   const restarted = await startServer(port)
@@ -153,9 +266,16 @@ try {
   assertOk(afterRestartTabs, 'tab list after restart')
   assertJsonEqual(afterRestartTerminals.result.terminals, [], 'terminal resurrection after restart')
   assertJsonEqual(afterRestartTabs.result.tabs, [], 'tab resurrection after restart')
+  const aliveAfterRestart = readAgentSpawnPids().filter(isProcessAlive)
+  const spawnCountAfterRestart = countSpawnMarkers()
+  if (aliveAfterRestart.length > 0 || spawnCountAfterRestart !== 2) {
+    throw new Error(
+      `restart restored or respawned a retired fixture agent: alive=${JSON.stringify(aliveAfterRestart)}, spawns=${JSON.stringify(readFileSync(spawnMarkerPath, 'utf8').trim().split(/\r?\n/))}`
+    )
+  }
 
   process.stdout.write(
-    'PASS remote agent-session authority: one spawn, retry adoption, durable exit retirement, no restart resurrection\n'
+    'PASS remote agent-session authority: fresh/resume focus isolation, response-loss replay, writable PTYs, one spawn per operation, retry adoption, unrelated survival, stale rejection, durable retirement\n'
   )
 } finally {
   await stopServer().catch(() => {})
@@ -183,12 +303,21 @@ function installFixtureAgent(targetDir) {
 
 function quoteFixtureAgentCommand(commandPath) {
   return process.platform === 'win32'
-    ? `"${commandPath.replaceAll('"', '""')}"`
-    : shellQuote(commandPath)
+    ? `"${commandPath.replaceAll('"', '""')}" ${agentSessionToken}`
+    : `${shellQuote(commandPath)} ${agentSessionToken}`
 }
 
 function shellQuote(value) {
   return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function fixtureCommand(scriptPath, markerPath) {
+  if (process.platform === 'win32') {
+    return [process.execPath, scriptPath, markerPath]
+      .map((value) => `"${value.replaceAll('"', '""')}"`)
+      .join(' ')
+  }
+  return [process.execPath, scriptPath, markerPath].map(shellQuote).join(' ')
 }
 
 async function reservePort() {
@@ -214,6 +343,8 @@ async function startServer(port) {
     ORCA_USER_DATA_PATH: profilePath,
     ORCA_REPRO_SPAWN_MARKER: spawnMarkerPath,
     ORCA_REPRO_EXIT_TRIGGER: exitTriggerPath,
+    ORCA_REPRO_INPUT_MARKER: inputMarkerPath,
+    ORCA_REPRO_AGENT_SESSION_TOKEN: agentSessionToken,
     ...(process.platform === 'linux' ? { ELECTRON_DISABLE_SANDBOX: '1' } : {})
   }
   server = spawn(
@@ -281,13 +412,17 @@ async function stopServer() {
   })
 }
 
-async function callClient(pairingCode, method, params) {
+async function callClient(pairingCode, method, params, responseMode) {
   return await new Promise((resolve, reject) => {
-    const child = spawn(
-      process.execPath,
-      [clientScript, pairingCode, method, JSON.stringify(params)],
-      { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true }
-    )
+    const args = [clientScript, pairingCode, method, JSON.stringify(params)]
+    if (responseMode) {
+      args.push(responseMode)
+    }
+    const child = spawn(process.execPath, args, {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true
+    })
     childProcesses.add(child)
     let stdout = ''
     let stderr = ''
@@ -325,6 +460,41 @@ function countSpawnMarkers() {
   return readFileSync(spawnMarkerPath, 'utf8').split(/\r?\n/).filter(Boolean).length
 }
 
+function readAgentSpawnPids() {
+  if (!existsSync(spawnMarkerPath)) {
+    return []
+  }
+  return readFileSync(spawnMarkerPath, 'utf8')
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => Number(line.split(':', 1)[0]))
+    .filter((pid) => Number.isInteger(pid) && pid > 0)
+}
+
+function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error?.code !== 'ESRCH'
+  }
+}
+
+async function sendMarker(pairingCode, terminal, marker) {
+  const response = await callClient(pairingCode, 'terminal.send', {
+    terminal,
+    text: `${marker}\n`
+  })
+  assertOk(response, `${marker} terminal send`)
+  if (!response.result.send.accepted) {
+    throw new Error(`${marker} terminal send was refused`)
+  }
+  await waitFor(
+    () => existsSync(inputMarkerPath) && readFileSync(inputMarkerPath, 'utf8').includes(marker),
+    `${marker} input delivery`
+  )
+}
+
 async function waitFor(predicate, description) {
   const deadline = Date.now() + 15_000
   let lastError = null
@@ -352,6 +522,14 @@ function assertSameTerminal(left, right) {
     [left.handle, left.tabId, left.paneKey, left.ptyId],
     [right.handle, right.tabId, right.paneKey, right.ptyId],
     'canonical terminal identity'
+  )
+}
+
+function assertTerminalInventoryIdentity(left, right) {
+  assertJsonEqual(
+    [left.handle, left.tabId, left.ptyId],
+    [right.handle, right.tabId, right.ptyId],
+    'committed terminal inventory identity'
   )
 }
 

--- a/config/scripts/remote-agent-session-authority-repro.mjs
+++ b/config/scripts/remote-agent-session-authority-repro.mjs
@@ -14,6 +14,7 @@ import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { createInterface } from 'node:readline'
+import { cleanupIsolatedDaemons, isProcessAlive } from './remote-agent-session-process-cleanup.mjs'
 
 const repoRoot = path.resolve(import.meta.dirname, '..', '..')
 const clientScript = path.join(import.meta.dirname, 'remote-agent-session-repro-client.mjs')
@@ -34,6 +35,8 @@ const exitTriggerPath = path.join(scratch, 'exit-agent')
 const agentSessionToken = '--orca-repro-agent-session'
 const childProcesses = new Set()
 let server = null
+let activePairingCode = null
+let activeWorktree = null
 
 try {
   mkdirSync(profilePath, { recursive: true })
@@ -67,6 +70,7 @@ try {
   const port = await reservePort()
   const firstReady = await startServer(port)
   const pairingCode = firstReady.pairing.url
+  activePairingCode = pairingCode
 
   const addedRepo = await callClient(pairingCode, 'repo.add', { path: projectPath })
   assertOk(addedRepo, 'fixture repo registration')
@@ -83,6 +87,7 @@ try {
     )
   }
   const worktree = `id:${fixtureWorktree.id}`
+  activeWorktree = worktree
   const freshRequest = {
     clientOperationId: `${Date.now()}-0123456789abcdef0123456789abcdef`,
     worktree,
@@ -145,6 +150,8 @@ try {
   const dispositions = [first.result.disposition, second.result.disposition].sort()
   assertJsonEqual(dispositions, ['adopted', 'created'], 'race dispositions')
   assertSameTerminal(first.result.terminal, second.result.terminal)
+  assertBackgroundSurface(first.result.terminal, 'first racing resume')
+  assertBackgroundSurface(second.result.terminal, 'second racing resume')
   await waitFor(() => countSpawnMarkers() === 2, 'exactly one fresh and one resumed spawn')
 
   const retry = await callClient(pairingCode, 'terminal.ensureAgentSession', resumeRequest)
@@ -153,6 +160,7 @@ try {
     throw new Error(`resume retry was ${retry.result.disposition}, expected adopted`)
   }
   assertSameTerminal(first.result.terminal, retry.result.terminal)
+  assertBackgroundSurface(retry.result.terminal, 'resume retry')
   const spawnCountAfterRetry = countSpawnMarkers()
   if (spawnCountAfterRetry !== 2) {
     throw new Error(
@@ -193,14 +201,14 @@ try {
   }, 'resume retirement without unrelated terminal loss')
 
   const oldTerminal = first.result.terminal
-  if (!oldTerminal.tabId || !oldTerminal.paneKey) {
+  if (!oldTerminal.tabId || !oldTerminal.paneKey || !oldTerminal.ptyId) {
     throw new Error(`retired terminal identity is incomplete: ${JSON.stringify(oldTerminal)}`)
   }
   const leafId = oldTerminal.paneKey.slice(oldTerminal.paneKey.indexOf(':') + 1)
   const staleWrite = await callClient(pairingCode, 'session.tabs.updatePaneLayout', {
     worktree,
     tabId: oldTerminal.tabId,
-    root: { type: 'leaf', id: leafId, ptyId: oldTerminal.ptyId ?? undefined }
+    root: { type: 'leaf', id: leafId, ptyId: oldTerminal.ptyId }
   })
   if (staleWrite.ok || staleWrite.error?.code !== 'invalid_argument') {
     throw new Error(`stale pane publication was not rejected: ${JSON.stringify(staleWrite)}`)
@@ -258,6 +266,7 @@ try {
   await stopServer()
   const restarted = await startServer(port)
   const restartPairingCode = restarted.pairing.url
+  activePairingCode = restartPairingCode
   const [afterRestartTerminals, afterRestartTabs] = await Promise.all([
     callClient(restartPairingCode, 'terminal.list', { worktree }),
     callClient(restartPairingCode, 'session.tabs.list', { worktree })
@@ -278,10 +287,17 @@ try {
     'PASS remote agent-session authority: fresh/resume focus isolation, response-loss replay, writable PTYs, one spawn per operation, retry adoption, unrelated survival, stale rejection, durable retirement\n'
   )
 } finally {
+  if (activePairingCode && activeWorktree) {
+    await callClient(activePairingCode, 'terminal.stop', { worktree: activeWorktree }).catch(
+      () => null
+    )
+  }
+  writeFileSync(exitTriggerPath, '')
   await stopServer().catch(() => {})
   for (const child of childProcesses) {
     child.kill()
   }
+  await cleanupIsolatedDaemons(profilePath)
   rmSync(scratch, { recursive: true, force: true })
 }
 
@@ -471,12 +487,9 @@ function readAgentSpawnPids() {
     .filter((pid) => Number.isInteger(pid) && pid > 0)
 }
 
-function isProcessAlive(pid) {
-  try {
-    process.kill(pid, 0)
-    return true
-  } catch (error) {
-    return error?.code !== 'ESRCH'
+function assertBackgroundSurface(terminal, description) {
+  if (terminal.surface !== 'background') {
+    throw new Error(`${description} returned ${terminal.surface}, expected background`)
   }
 }
 

--- a/config/scripts/remote-agent-session-process-cleanup.mjs
+++ b/config/scripts/remote-agent-session-process-cleanup.mjs
@@ -1,0 +1,121 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+
+export function isProcessAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return error?.code !== 'ESRCH'
+  }
+}
+
+function readDaemonPids(userDataPath) {
+  const daemonDir = path.join(userDataPath, 'daemon')
+  if (!existsSync(daemonDir)) {
+    return []
+  }
+  const pids = []
+  for (const entry of readdirSync(daemonDir)) {
+    if (!entry.endsWith('.pid')) {
+      continue
+    }
+    try {
+      const raw = readFileSync(path.join(daemonDir, entry), 'utf8').trim()
+      try {
+        const parsed = JSON.parse(raw)
+        if (Number.isInteger(parsed?.pid)) {
+          pids.push(parsed.pid)
+        }
+      } catch {
+        const pid = Number(raw)
+        if (Number.isInteger(pid)) {
+          pids.push(pid)
+        }
+      }
+    } catch {
+      // Another isolated process may retire its PID record during cleanup.
+    }
+  }
+  return pids
+}
+
+function readPosixDescendants(rootPid) {
+  try {
+    const output = execFileSync('ps', ['-eo', 'pid=,ppid='], { encoding: 'utf8' })
+    const childrenByParent = new Map()
+    for (const line of output.split('\n')) {
+      const [pidText, parentText] = line.trim().split(/\s+/)
+      const pid = Number(pidText)
+      const parent = Number(parentText)
+      if (!Number.isInteger(pid) || !Number.isInteger(parent)) {
+        continue
+      }
+      childrenByParent.set(parent, [...(childrenByParent.get(parent) ?? []), pid])
+    }
+    const descendants = []
+    const pending = [...(childrenByParent.get(rootPid) ?? [])]
+    while (pending.length > 0) {
+      const pid = pending.pop()
+      if (!pid) {
+        continue
+      }
+      descendants.push(pid)
+      pending.push(...(childrenByParent.get(pid) ?? []))
+    }
+    return descendants
+  } catch {
+    return []
+  }
+}
+
+export async function cleanupIsolatedDaemons(userDataPath) {
+  const trackedPids = new Set()
+  for (const pid of readDaemonPids(userDataPath)) {
+    if (process.platform === 'win32') {
+      trackedPids.add(pid)
+      try {
+        execFileSync('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' })
+      } catch {
+        // The isolated daemon may already have exited.
+      }
+      continue
+    }
+    const pids = [...readPosixDescendants(pid), pid].toReversed()
+    pids.forEach((targetPid) => trackedPids.add(targetPid))
+    for (const targetPid of pids) {
+      try {
+        process.kill(targetPid, 'SIGTERM')
+      } catch {
+        // The isolated process may already have exited.
+      }
+    }
+  }
+
+  let survivors = await waitForProcessExit([...trackedPids], 1_000)
+  for (const targetPid of survivors) {
+    if (process.platform === 'win32') {
+      continue
+    }
+    try {
+      process.kill(targetPid, 'SIGKILL')
+    } catch {
+      // The isolated process may already have exited.
+    }
+  }
+  survivors = await waitForProcessExit(survivors, 5_000)
+  if (survivors.length > 0) {
+    throw new Error(`isolated daemon cleanup left live processes: ${survivors.join(', ')}`)
+  }
+}
+
+async function waitForProcessExit(pids, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  let survivors = pids.filter(isProcessAlive)
+  while (survivors.length > 0 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    survivors = survivors.filter(isProcessAlive)
+  }
+  return survivors
+}

--- a/config/scripts/remote-agent-session-repro-client.mjs
+++ b/config/scripts/remote-agent-session-repro-client.mjs
@@ -10,20 +10,37 @@ const { RemoteRuntimeRequestConnection } = require(
   path.join(repoRoot, 'out', 'shared', 'remote-runtime-request-connection.js')
 )
 
-const [pairingCode, method, rawParams] = process.argv.slice(2)
+const [pairingCode, method, rawParams, responseMode] = process.argv.slice(2)
 const pairing = pairingCode ? parsePairingCode(pairingCode) : null
 if (!pairing || !method || rawParams === undefined) {
-  console.error('usage: remote-agent-session-repro-client <pairing> <method> <json-params>')
+  console.error(
+    'usage: remote-agent-session-repro-client <pairing> <method> <json-params> [drop-response]'
+  )
   process.exit(2)
 }
 
 const connection = new RemoteRuntimeRequestConnection(pairing)
+let droppedResponse = false
+if (responseMode === 'drop-response') {
+  if (typeof connection.handleRpcFrame !== 'function') {
+    throw new Error('response-loss seam is unavailable')
+  }
+  connection.handleRpcFrame = () => {
+    droppedResponse = true
+    connection.close(new Error('repro dropped committed response before caller acknowledgement'))
+  }
+}
 try {
   const response = await connection.request(method, JSON.parse(rawParams), 20_000)
   process.stdout.write(`${JSON.stringify(response)}\n`)
   if (!response.ok) {
     process.exitCode = 1
   }
+} catch (error) {
+  if (!droppedResponse) {
+    throw error
+  }
+  process.stdout.write(`${JSON.stringify({ ok: true, droppedResponse: true })}\n`)
 } finally {
   connection.close()
 }

--- a/config/scripts/remote-agent-session-repro-fixture.mjs
+++ b/config/scripts/remote-agent-session-repro-fixture.mjs
@@ -4,11 +4,25 @@ import { appendFileSync, existsSync } from 'node:fs'
 
 const markerPath = process.env.ORCA_REPRO_SPAWN_MARKER
 const exitTriggerPath = process.env.ORCA_REPRO_EXIT_TRIGGER
+const inputMarkerPath = process.env.ORCA_REPRO_INPUT_MARKER
+const agentSessionToken = process.env.ORCA_REPRO_AGENT_SESSION_TOKEN
 if (!markerPath || !exitTriggerPath) {
   process.exit(2)
 }
 
-appendFileSync(markerPath, `${process.pid}:${process.ppid}\n`)
+if (agentSessionToken && !process.argv.slice(2).includes(agentSessionToken)) {
+  process.stderr.write("error: unrecognized subcommand 'app-server'\n")
+  process.exit(2)
+}
+
+appendFileSync(
+  markerPath,
+  `${process.pid}:${process.ppid}:${Date.now()}:${JSON.stringify(process.argv.slice(2))}\n`
+)
+if (inputMarkerPath) {
+  process.stdin.setEncoding('utf8')
+  process.stdin.on('data', (chunk) => appendFileSync(inputMarkerPath, chunk))
+}
 
 const interval = setInterval(() => {
   if (!existsSync(exitTriggerPath)) {

--- a/config/scripts/remote-agent-session-repro-writable-shell.mjs
+++ b/config/scripts/remote-agent-session-repro-writable-shell.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import { appendFileSync } from 'node:fs'
+
+const markerPath = process.argv[2]
+if (!markerPath) {
+  process.exit(2)
+}
+
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (data) => appendFileSync(markerPath, data))
+setInterval(() => {}, 1_000)
+process.on('SIGTERM', () => process.exit(0))
+process.on('SIGINT', () => process.exit(0))

--- a/src/main/runtime/rpc/methods/agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/agent-session.test.ts
@@ -73,6 +73,52 @@ describe('agent session RPC methods', () => {
     )
   })
 
+  it.each([
+    {
+      method: 'terminal.createAgentSession',
+      params: {
+        clientOperationId: '1752883200000-0123456789abcdef0123456789abcdef',
+        worktree: 'id:worktree-1',
+        agent: 'codex',
+        presentation: 'focused'
+      },
+      runtimeMethod: 'createAgentSession' as const
+    },
+    {
+      method: 'terminal.ensureAgentSession',
+      params: {
+        kind: 'explicit',
+        worktree: 'id:worktree-1',
+        agent: 'codex',
+        providerSession: { key: 'session_id', id: 'provider-session-1' },
+        presentation: 'focused'
+      },
+      runtimeMethod: 'ensureAgentSession' as const
+    }
+  ])('keeps $method presentation viewer-local for paired clients', async (testCase) => {
+    for (const clientKind of ['runtime', 'mobile'] as const) {
+      const runtime = runtimeStub()
+      const dispatcher = new RpcDispatcher({
+        runtime: runtime as unknown as OrcaRuntimeService,
+        methods: AGENT_SESSION_METHODS
+      })
+      const replies: RpcResponse[] = []
+
+      await dispatcher.dispatchStreaming(
+        request(testCase.method, testCase.params),
+        (response) => replies.push(JSON.parse(response) as RpcResponse),
+        { pairedDeviceId: `paired-${clientKind}`, clientKind }
+      )
+
+      expect(replies).toHaveLength(1)
+      expect(replies[0]).toMatchObject({ ok: true })
+      expect(runtime[testCase.runtimeMethod]).toHaveBeenCalledWith(
+        { ...testCase.params, presentation: 'background' },
+        { clientId: `paired-${clientKind}`, clientKind }
+      )
+    }
+  })
+
   it('keeps automatic authority checkpoint-only', async () => {
     const runtime = runtimeStub()
     const dispatcher = new RpcDispatcher({

--- a/src/main/runtime/rpc/methods/agent-session.ts
+++ b/src/main/runtime/rpc/methods/agent-session.ts
@@ -196,6 +196,16 @@ function callerContext(
   }
 }
 
+function withExecutionHostAgentPresentation<T extends { presentation?: 'background' | 'focused' }>(
+  params: T,
+  clientKind: 'mobile' | 'runtime' | undefined
+): T {
+  // Why: paired viewers focus their own mirror; the execution host may have no renderer.
+  return clientKind && params.presentation === 'focused'
+    ? { ...params, presentation: 'background' }
+    : params
+}
+
 function assertOperationTimestampWithinFutureSkew(clientOperationId: string): void {
   const timestamp = parseAgentSessionOperationTimestamp(clientOperationId)
   if (timestamp === null || timestamp > Date.now() + AGENT_SESSION_OPERATION_FUTURE_SKEW_MS) {
@@ -210,7 +220,7 @@ export const AGENT_SESSION_METHODS: RpcAnyMethod[] = [
     params: EnsureAgentSessionParams,
     handler: (params, { runtime, pairedDeviceId, clientId, clientKind, signal }) =>
       (runtime as AgentSessionRuntime).ensureAgentSession(
-        params,
+        withExecutionHostAgentPresentation(params, clientKind),
         callerContext(pairedDeviceId ?? clientId, clientKind, signal)
       )
   }),
@@ -220,7 +230,7 @@ export const AGENT_SESSION_METHODS: RpcAnyMethod[] = [
     handler: (params, { runtime, pairedDeviceId, clientId, clientKind, signal }) => {
       assertOperationTimestampWithinFutureSkew(params.clientOperationId)
       return (runtime as AgentSessionRuntime).createAgentSession(
-        params,
+        withExecutionHostAgentPresentation(params, clientKind),
         callerContext(pairedDeviceId ?? clientId, clientKind, signal)
       )
     }

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -17,6 +17,10 @@ import {
   splitWebRuntimeTerminal
 } from './web-runtime-session'
 import {
+  peekWebSessionFocusIntent,
+  resetWebSessionFocusIntentForTests
+} from './web-session-focus-intent'
+import {
   isWebSessionCloseIntentPending,
   recordWebSessionCloseIntent,
   resetWebSessionCloseIntentForTests
@@ -551,8 +555,87 @@ describe('createWebRuntimeSessionTerminal', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     clearRuntimeCompatibilityCacheForTests()
+    resetWebSessionFocusIntentForTests()
     vi.clearAllMocks()
   })
+
+  it.each([
+    { sessionKind: 'fresh' as const, activate: true },
+    { sessionKind: 'fresh' as const, activate: false },
+    { sessionKind: 'resume' as const, activate: true },
+    { sessionKind: 'resume' as const, activate: false }
+  ])(
+    'keeps $sessionKind host creation background with activate=$activate while focus stays client-owned',
+    async ({ sessionKind, activate }) => {
+      const hostTabId = `host-${sessionKind}-${activate ? 'active' : 'background'}`
+      const runtimeCall = vi.fn(async (request: { method: string }) => {
+        if (request.method === 'status.get') {
+          return {
+            id: 'status',
+            ok: true,
+            result: {
+              runtimeId: 'runtime-1',
+              graphStatus: 'ready',
+              runtimeProtocolVersion: 3,
+              minCompatibleRuntimeClientVersion: 2,
+              capabilities: ['agent-session.host-authority.v1']
+            }
+          }
+        }
+        if (
+          request.method === 'terminal.createAgentSession' ||
+          request.method === 'terminal.ensureAgentSession'
+        ) {
+          return {
+            id: 'agent-session',
+            ok: true,
+            result: {
+              terminal: {
+                handle: `term-${sessionKind}`,
+                worktreeId: WORKTREE_ID,
+                tabId: hostTabId,
+                leafId: 'leaf-1'
+              },
+              disposition: 'created'
+            }
+          }
+        }
+        return { id: 'list', ok: true, result: makeSnapshot() }
+      })
+      vi.stubGlobal('window', {
+        api: { runtimeEnvironments: { call: runtimeCall } }
+      })
+
+      await expect(
+        createWebRuntimeSessionTerminal({
+          worktreeId: WORKTREE_ID,
+          agentSessionKind: sessionKind,
+          launchAgent: 'codex',
+          ...(sessionKind === 'resume'
+            ? {
+                command: "codex resume 'session-1'",
+                providerSession: { key: 'session_id' as const, id: 'session-1' }
+              }
+            : {}),
+          activate
+        })
+      ).resolves.toEqual({ status: 'created' })
+
+      const authorityMethod =
+        sessionKind === 'resume' ? 'terminal.ensureAgentSession' : 'terminal.createAgentSession'
+      const authorityRequest = runtimeCall.mock.calls.find(
+        ([request]) => request.method === authorityMethod
+      )?.[0]
+      expect(authorityRequest).toMatchObject({
+        selector: ENVIRONMENT_ID,
+        method: authorityMethod,
+        params: { presentation: 'background' }
+      })
+      expect(peekWebSessionFocusIntent({ environmentId: ENVIRONMENT_ID }, WORKTREE_ID)).toBe(
+        activate ? hostTabId : null
+      )
+    }
+  )
 
   it('creates paired web agents through host authority so activation is mirrored', async () => {
     const snapshot = {

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -646,6 +646,7 @@ describe('createWebRuntimeSessionTerminal', () => {
 
     expect(runtimeCall).toHaveBeenNthCalledWith(2, {
       selector: ENVIRONMENT_ID,
+      expectedEnvironmentPairingRevision: undefined,
       method: 'terminal.createAgentSession',
       params: {
         clientOperationId: expect.stringMatching(/^\d{13}-[0-9a-f]{32}$/),
@@ -657,7 +658,7 @@ describe('createWebRuntimeSessionTerminal', () => {
         launchPreferences: { model: 'gpt-5', effort: 'high' },
         startupCwd: '/repo/packages/app',
         viewMode: 'chat',
-        presentation: 'focused'
+        presentation: 'background'
       },
       timeoutMs: 15_000
     })
@@ -1093,6 +1094,11 @@ describe('createWebRuntimeSessionTerminal', () => {
       'session.tabs.createTerminal',
       'session.tabs.list'
     ])
+    expect(runtimeCall.mock.calls[1]?.[0]).toMatchObject({
+      params: {
+        presentation: 'background'
+      }
+    })
     expect(runtimeCall.mock.calls[2]?.[0]).toMatchObject({
       params: {
         command: "codex resume 'session-1'",

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -631,9 +631,10 @@ describe('createWebRuntimeSessionTerminal', () => {
         method: authorityMethod,
         params: { presentation: 'background' }
       })
-      expect(peekWebSessionFocusIntent({ environmentId: ENVIRONMENT_ID }, WORKTREE_ID)).toBe(
-        activate ? hostTabId : null
+      expect(peekWebSessionFocusIntent({ environmentId: ENVIRONMENT_ID }, WORKTREE_ID)).toEqual(
+        activate ? { hostTabId, leafId: 'leaf-1' } : null
       )
+      expect(mocks.acceptReplayedWebSessionTabsSnapshot).toHaveBeenCalledTimes(activate ? 1 : 0)
     }
   )
 

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -1095,7 +1095,13 @@ describe('createWebRuntimeSessionTerminal', () => {
       'session.tabs.list'
     ])
     expect(runtimeCall.mock.calls[1]?.[0]).toMatchObject({
+      selector: ENVIRONMENT_ID,
+      method: 'terminal.ensureAgentSession',
       params: {
+        kind: 'explicit',
+        worktree: `id:${WORKTREE_ID}`,
+        agent: 'codex',
+        providerSession: { key: 'session_id', id: 'session-1' },
         presentation: 'background'
       }
     })

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -1088,24 +1088,8 @@ describe('createWebRuntimeSessionTerminal', () => {
       })
     ).resolves.toEqual({ status: 'created' })
 
-    expect(methods).toEqual([
-      'status.get',
-      'terminal.ensureAgentSession',
-      'session.tabs.createTerminal',
-      'session.tabs.list'
-    ])
+    expect(methods).toEqual(['status.get', 'session.tabs.createTerminal', 'session.tabs.list'])
     expect(runtimeCall.mock.calls[1]?.[0]).toMatchObject({
-      selector: ENVIRONMENT_ID,
-      method: 'terminal.ensureAgentSession',
-      params: {
-        kind: 'explicit',
-        worktree: `id:${WORKTREE_ID}`,
-        agent: 'codex',
-        providerSession: { key: 'session_id', id: 'session-1' },
-        presentation: 'background'
-      }
-    })
-    expect(runtimeCall.mock.calls[2]?.[0]).toMatchObject({
       params: {
         command: "codex resume 'session-1'",
         env: { CODEX_PROFILE: 'captured' },

--- a/src/renderer/src/runtime/web-runtime-session.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session.test.ts
@@ -77,6 +77,7 @@ vi.mock('@/lib/agent-launch-prompt-delivery', () => ({
 
 const ENVIRONMENT_ID = 'web-env-1'
 const WORKTREE_ID = 'repo::/worktree'
+const FOCUS_LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
 afterEach(() => resetWebSessionCloseIntentForTests())
 
@@ -594,7 +595,7 @@ describe('createWebRuntimeSessionTerminal', () => {
                 handle: `term-${sessionKind}`,
                 worktreeId: WORKTREE_ID,
                 tabId: hostTabId,
-                leafId: 'leaf-1'
+                paneKey: `${hostTabId}:${FOCUS_LEAF_ID}`
               },
               disposition: 'created'
             }
@@ -632,7 +633,7 @@ describe('createWebRuntimeSessionTerminal', () => {
         params: { presentation: 'background' }
       })
       expect(peekWebSessionFocusIntent({ environmentId: ENVIRONMENT_ID }, WORKTREE_ID)).toEqual(
-        activate ? { hostTabId, leafId: 'leaf-1' } : null
+        activate ? { hostTabId, leafId: FOCUS_LEAF_ID } : null
       )
       expect(mocks.acceptReplayedWebSessionTabsSnapshot).toHaveBeenCalledTimes(activate ? 1 : 0)
     }
@@ -681,7 +682,7 @@ describe('createWebRuntimeSessionTerminal', () => {
             cwd: '/repo/packages/app',
             worktreeId: WORKTREE_ID,
             tabId: 'host-tab-2',
-            leafId: 'leaf-1'
+            paneKey: `host-tab-2:${FOCUS_LEAF_ID}`
           },
           disposition: 'created'
         }
@@ -906,7 +907,7 @@ describe('createWebRuntimeSessionTerminal', () => {
                 cwd: '/repo',
                 worktreeId: WORKTREE_ID,
                 tabId: 'host-tab-created',
-                leafId: 'leaf-created'
+                paneKey: `host-tab-created:${FOCUS_LEAF_ID}`
               },
               disposition: 'created'
             }
@@ -969,7 +970,7 @@ describe('createWebRuntimeSessionTerminal', () => {
               handle: 'term_replayed',
               worktreeId: WORKTREE_ID,
               tabId: 'host-tab-replayed',
-              leafId: 'leaf-replayed'
+              paneKey: `host-tab-replayed:${FOCUS_LEAF_ID}`
             },
             disposition: 'replayed'
           }
@@ -1206,7 +1207,7 @@ describe('createWebRuntimeSessionTerminal', () => {
               handle: 'term_created',
               worktreeId: WORKTREE_ID,
               tabId: 'host-tab-2',
-              leafId: 'leaf-1'
+              paneKey: `host-tab-2:${FOCUS_LEAF_ID}`
             },
             disposition: 'created'
           }

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -201,6 +201,7 @@ async function createWebRuntimeSessionTerminalResult(
     if (agent) {
       let legacyAlreadyPlacedInGroup = false
       // Why: structured creation cannot yet express afterTabId; keep the exact legacy placement contract until it can.
+      // Why: focus belongs to the paired client; a headless execution host has no renderer to focus.
       const hostAuthority = args.afterTabId
         ? undefined
         : args.agentSessionKind === 'resume'
@@ -218,7 +219,7 @@ async function createWebRuntimeSessionTerminalResult(
                       ...(args.launchPreferences
                         ? { launchPreferences: args.launchPreferences }
                         : {}),
-                      presentation: args.activate === false ? 'background' : 'focused'
+                      presentation: 'background'
                     },
                     timeoutMs: 15_000
                   })) as RuntimeRpcResponse<RuntimeEnsureAgentSessionResult>
@@ -243,7 +244,7 @@ async function createWebRuntimeSessionTerminalResult(
                           : {}),
                         ...(args.cwd ? { startupCwd: args.cwd } : {}),
                         ...(args.viewMode ? { viewMode: args.viewMode } : {}),
-                        presentation: args.activate === false ? 'background' : 'focused'
+                        presentation: 'background'
                       },
                       clientOperationId
                     ),

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -194,6 +194,7 @@ async function createWebRuntimeSessionTerminalResult(
   }
   let hostCreated = false
   let createdTabId: string | undefined
+  let createdLeafId: string | undefined
   try {
     const agent = args.launchAgent ?? args.agent
     const agentArgsOverride =
@@ -252,7 +253,9 @@ async function createWebRuntimeSessionTerminalResult(
                   })) as RuntimeRpcResponse<RuntimeCreateAgentSessionResult>
                 )
               )
-      const created = await runRemoteAgentSessionLaunch<{ terminal: { tabId?: string } }>({
+      const created = await runRemoteAgentSessionLaunch<{
+        terminal: { tabId?: string; leafId?: string }
+      }>({
         environmentId,
         ...(hostAuthority ? { hostAuthority } : {}),
         legacy: async () => {
@@ -283,11 +286,17 @@ async function createWebRuntimeSessionTerminalResult(
             response as RuntimeRpcResponse<RuntimeMobileSessionCreateTerminalResult>
           )
           legacyAlreadyPlacedInGroup = true
-          return { terminal: { tabId: legacyCreated.tab.id } }
+          return {
+            terminal: {
+              tabId: legacyCreated.tab.id,
+              leafId: legacyCreated.tab.leafId
+            }
+          }
         }
       })
       hostCreated = true
       createdTabId = created.terminal.tabId
+      createdLeafId = created.terminal.leafId
       if (args.targetGroupId && createdTabId && !legacyAlreadyPlacedInGroup) {
         await callEnvironment({
           method: 'session.tabs.move',
@@ -327,14 +336,17 @@ async function createWebRuntimeSessionTerminalResult(
       )
       hostCreated = true
       createdTabId = created.tab.id
+      createdLeafId = created.tab.leafId
     }
     if (args.activate !== false && createdTabId && matchesWebSessionIntentOwner(intentOwner)) {
       // Why: record focus intent so the reconcile follows the snapshot's active
       // tab to THIS new terminal, instead of sticky-keeping the prior tab.
-      recordWebSessionFocusIntent(intentOwner, args.worktreeId, createdTabId)
+      recordWebSessionFocusIntent(intentOwner, args.worktreeId, createdTabId, createdLeafId)
     }
     await refreshWebRuntimeSessionTabsSnapshot(environmentId, args.worktreeId, {
-      expectedEnvironmentPairingRevision: intentOwner.pairingRevision
+      expectedEnvironmentPairingRevision: intentOwner.pairingRevision,
+      // Why: the publication can beat the RPC response; replay it once after caller focus intent exists.
+      acceptCurrentSnapshot: args.activate !== false && Boolean(createdTabId)
     })
     return {
       outcome: { status: 'created' },

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeMobileSessionTabMoveResult,
   RuntimeMobileSessionTabsResult,
   RuntimeSessionTabCloseReason,
+  RuntimeTerminalCreate,
   RuntimeTerminalClose,
   RuntimeTerminalSplit
 } from '../../../shared/runtime-types'
@@ -52,6 +53,7 @@ import {
 import { runRemoteAgentSessionLaunch } from './remote-agent-session-launch'
 import { translate } from '../i18n/i18n'
 import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
 
 export {
   HOST_TERMINAL_SURFACE_SEPARATOR,
@@ -134,6 +136,15 @@ type CreateWebRuntimeSessionTerminalArgs = {
 type CreatedWebRuntimeSessionTerminal = {
   outcome: WebRuntimeTerminalCreateOutcome
   hostTabId?: string
+}
+
+type CreatedAgentTerminalIdentity = Pick<RuntimeTerminalCreate, 'tabId' | 'paneKey'> & {
+  leafId?: string
+}
+
+function createdTerminalLeafId(terminal: CreatedAgentTerminalIdentity): string | undefined {
+  const pane = parsePaneKey(terminal.paneKey ?? '')
+  return pane && pane.tabId === terminal.tabId ? pane.leafId : undefined
 }
 
 export async function createWebRuntimeSessionTerminal(
@@ -254,7 +265,7 @@ async function createWebRuntimeSessionTerminalResult(
                 )
               )
       const created = await runRemoteAgentSessionLaunch<{
-        terminal: { tabId?: string; leafId?: string }
+        terminal: CreatedAgentTerminalIdentity
       }>({
         environmentId,
         ...(hostAuthority ? { hostAuthority } : {}),
@@ -296,7 +307,9 @@ async function createWebRuntimeSessionTerminalResult(
       })
       hostCreated = true
       createdTabId = created.terminal.tabId
-      createdLeafId = created.terminal.leafId
+      createdLeafId = legacyAlreadyPlacedInGroup
+        ? created.terminal.leafId
+        : createdTerminalLeafId(created.terminal)
       if (args.targetGroupId && createdTabId && !legacyAlreadyPlacedInGroup) {
         await callEnvironment({
           method: 'session.tabs.move',

--- a/src/renderer/src/runtime/web-session-focus-intent.ts
+++ b/src/renderer/src/runtime/web-session-focus-intent.ts
@@ -5,13 +5,18 @@
 // activation intent here: the reconcile only follows the snapshot's active tab
 // when it matches a pending intent the client itself initiated.
 //
-// Keyed by worktree id → the host session tab id the client expects to focus.
+// Keyed by worktree id → the host session surface the client expects to focus.
 // The intent persists until a snapshot matches it (surviving racing/duplicate
 // snapshots, unlike a transient per-snapshot flag).
 
 import { webSessionIntentOwnerKey, type WebSessionIntentOwner } from './web-session-intent-owner'
 
-const pendingFocusByOwnerAndWorktree = new Map<string, string>()
+export type WebSessionFocusIntent = {
+  hostTabId: string
+  leafId?: string
+}
+
+const pendingFocusByOwnerAndWorktree = new Map<string, WebSessionFocusIntent>()
 
 function focusIntentPartitionKey(owner: WebSessionIntentOwner, worktreeId: string): string {
   return `${webSessionIntentOwnerKey(owner)}\0${worktreeId}`
@@ -20,19 +25,24 @@ function focusIntentPartitionKey(owner: WebSessionIntentOwner, worktreeId: strin
 export function recordWebSessionFocusIntent(
   owner: WebSessionIntentOwner,
   worktreeId: string,
-  hostTabId: string
+  hostTabId: string,
+  leafId?: string
 ): void {
   const trimmed = hostTabId.trim()
   if (!worktreeId || !trimmed) {
     return
   }
-  pendingFocusByOwnerAndWorktree.set(focusIntentPartitionKey(owner, worktreeId), trimmed)
+  const trimmedLeafId = leafId?.trim()
+  pendingFocusByOwnerAndWorktree.set(focusIntentPartitionKey(owner, worktreeId), {
+    hostTabId: trimmed,
+    ...(trimmedLeafId ? { leafId: trimmedLeafId } : {})
+  })
 }
 
 export function peekWebSessionFocusIntent(
   owner: WebSessionIntentOwner,
   worktreeId: string
-): string | null {
+): WebSessionFocusIntent | null {
   return pendingFocusByOwnerAndWorktree.get(focusIntentPartitionKey(owner, worktreeId)) ?? null
 }
 

--- a/src/renderer/src/runtime/web-session-intent-owner.test.ts
+++ b/src/renderer/src/runtime/web-session-intent-owner.test.ts
@@ -40,7 +40,9 @@ describe('web session intent ownership', () => {
   it('isolates focus intents across runtimes and same-id re-pairs', () => {
     recordWebSessionFocusIntent(OWNER_A, WORKTREE_ID, 'host-tab')
 
-    expect(peekWebSessionFocusIntent(OWNER_A, WORKTREE_ID)).toBe('host-tab')
+    expect(peekWebSessionFocusIntent(OWNER_A, WORKTREE_ID)).toEqual({
+      hostTabId: 'host-tab'
+    })
     expect(peekWebSessionFocusIntent(OWNER_A_REPAIRED, WORKTREE_ID)).toBeNull()
     expect(peekWebSessionFocusIntent(OWNER_B, WORKTREE_ID)).toBeNull()
   })

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -2364,7 +2364,7 @@ describe('applyWebSessionTabsSnapshot', () => {
     const existingTabId = toWebTerminalSurfaceTabId('host-tab-1')
     const newTabId = toWebTerminalSurfaceTabId('host-tab-2')
     // Simulate createWebRuntimeSessionTerminal recording focus intent for the new tab.
-    recordWebSessionFocusIntent({ environmentId: ENV }, WT, `host-tab-2::${SECOND_LEAF_ID}`)
+    recordWebSessionFocusIntent({ environmentId: ENV }, WT, 'host-tab-2')
     const existingUnifiedTab: Tab = {
       id: existingTabId,
       entityId: existingTabId,
@@ -2455,6 +2455,168 @@ describe('applyWebSessionTabsSnapshot', () => {
 
     expect(patch.activeTabIdByWorktree?.[WT]).toBe(newTabId)
     expect(patch.groupsByWorktree?.[WT]?.[0]?.activeTabId).toBe(newTabId)
+  })
+
+  it('replays a snapshot that beat the RPC response and focuses the exact adopted leaf', () => {
+    const mirroredTabId = toWebTerminalSurfaceTabId('host-tab-1')
+    const root = {
+      type: 'split' as const,
+      direction: 'horizontal' as const,
+      first: { type: 'leaf' as const, leafId: LEAF_ID },
+      second: { type: 'leaf' as const, leafId: SECOND_LEAF_ID }
+    }
+    const currentLayout = {
+      root,
+      activeLeafId: SECOND_LEAF_ID,
+      expandedLeafId: SECOND_LEAF_ID,
+      ptyIdsByLeafId: {
+        [LEAF_ID]: 'remote:web-env-1@@terminal-1',
+        [SECOND_LEAF_ID]: 'remote:web-env-1@@terminal-2'
+      }
+    }
+    const state = makeState({
+      activeTabId: mirroredTabId,
+      activeTabIdByWorktree: { [WT]: mirroredTabId },
+      tabsByWorktree: {
+        [WT]: [
+          {
+            id: mirroredTabId,
+            ptyId: 'remote:web-env-1@@terminal-2',
+            worktreeId: WT,
+            title: 'shell',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: NOW
+          }
+        ]
+      },
+      terminalLayoutsByTabId: { [mirroredTabId]: currentLayout }
+    })
+    const snapshot = makeSnapshot(
+      [
+        {
+          type: 'terminal',
+          id: `host-tab-1::${LEAF_ID}`,
+          title: 'codex',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          parentLayout: currentLayout,
+          isActive: false,
+          status: 'ready',
+          terminal: 'terminal-1'
+        },
+        {
+          type: 'terminal',
+          id: `host-tab-1::${SECOND_LEAF_ID}`,
+          title: 'shell',
+          parentTabId: 'host-tab-1',
+          leafId: SECOND_LEAF_ID,
+          parentLayout: currentLayout,
+          isActive: true,
+          status: 'ready',
+          terminal: 'terminal-2'
+        }
+      ],
+      {
+        tabGroups: [
+          {
+            id: 'host-group-1',
+            activeTabId: 'host-tab-1',
+            tabOrder: ['host-tab-1']
+          }
+        ]
+      }
+    )
+
+    const subscriptionPatch = applyFreshWebSessionTabsSnapshot(state, snapshot, ENV, NOW)
+    const afterSubscription = {
+      ...state,
+      ...(subscriptionPatch as Partial<WebSessionTabsSyncState>)
+    }
+    expect(afterSubscription.terminalLayoutsByTabId[mirroredTabId]?.activeLeafId).toBe(
+      SECOND_LEAF_ID
+    )
+
+    recordWebSessionFocusIntent({ environmentId: ENV }, WT, 'host-tab-1', LEAF_ID)
+    acceptReplayedWebSessionTabsSnapshot(ENV, WT)
+    const replayPatch = applyFreshWebSessionTabsSnapshot(
+      afterSubscription,
+      snapshot,
+      ENV,
+      NOW + 10
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(replayPatch.tabsByWorktree?.[WT]?.[0]?.ptyId).toBe('remote:web-env-1@@terminal-1')
+    expect(replayPatch.terminalLayoutsByTabId?.[mirroredTabId]).toMatchObject({
+      activeLeafId: LEAF_ID,
+      expandedLeafId: LEAF_ID
+    })
+  })
+
+  it('retains exact-leaf focus intent when a split sibling publishes first', () => {
+    const mirroredTabId = toWebTerminalSurfaceTabId('host-tab-1')
+    const siblingPtyId = 'remote:web-env-1@@terminal-2'
+    const state = makeState({
+      activeTabId: mirroredTabId,
+      activeTabIdByWorktree: { [WT]: mirroredTabId },
+      tabsByWorktree: {
+        [WT]: [
+          {
+            id: mirroredTabId,
+            ptyId: siblingPtyId,
+            worktreeId: WT,
+            title: 'shell',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: NOW
+          }
+        ]
+      }
+    })
+    const sibling = {
+      type: 'terminal' as const,
+      id: `host-tab-1::${SECOND_LEAF_ID}`,
+      title: 'shell',
+      parentTabId: 'host-tab-1',
+      leafId: SECOND_LEAF_ID,
+      isActive: true,
+      status: 'ready' as const,
+      terminal: 'terminal-2'
+    }
+    recordWebSessionFocusIntent({ environmentId: ENV }, WT, 'host-tab-1', LEAF_ID)
+
+    const partialPatch = applyWebSessionTabsSnapshot(
+      state,
+      makeSnapshot([sibling]),
+      ENV,
+      NOW
+    ) as Partial<WebSessionTabsSyncState>
+    expect(partialPatch.tabsByWorktree?.[WT]?.[0]?.ptyId).toBe(siblingPtyId)
+
+    const afterPartial = { ...state, ...partialPatch }
+    const completePatch = applyWebSessionTabsSnapshot(
+      afterPartial,
+      makeSnapshot([
+        sibling,
+        {
+          type: 'terminal',
+          id: `host-tab-1::${LEAF_ID}`,
+          title: 'codex',
+          parentTabId: 'host-tab-1',
+          leafId: LEAF_ID,
+          isActive: false,
+          status: 'ready',
+          terminal: 'terminal-1'
+        }
+      ]),
+      ENV,
+      NOW + 1
+    ) as Partial<WebSessionTabsSyncState>
+
+    expect(completePatch.tabsByWorktree?.[WT]?.[0]?.ptyId).toBe('remote:web-env-1@@terminal-1')
+    expect(completePatch.terminalLayoutsByTabId?.[mirroredTabId]?.activeLeafId).toBe(LEAF_ID)
   })
 
   it('does not let repeated remote split status snapshots steal local pane focus', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -470,7 +470,8 @@ function isMirroredTerminalSurfaceId(tabId: string): boolean {
 function chooseRemoteTerminalLayout(
   surfaces: readonly TerminalSurface[],
   ptyIdsByLeafId: Record<string, string>,
-  existingLayout?: TerminalLayoutSnapshot
+  existingLayout?: TerminalLayoutSnapshot,
+  requestedActiveLeafId?: string
 ): TerminalLayoutSnapshot {
   const leafIds = surfaces.map((surface) => surface.leafId)
   const knownLeafIds = new Set(leafIds)
@@ -481,6 +482,9 @@ function chooseRemoteTerminalLayout(
       ])
     : undefined
   const activeLeafId =
+    (requestedActiveLeafId && knownLeafIds.has(requestedActiveLeafId)
+      ? requestedActiveLeafId
+      : null) ??
     // Why: host title/status snapshots may still mark an agent pane active after this client selected a different split pane.
     (existingLayout?.activeLeafId && knownLeafIds.has(existingLayout.activeLeafId)
       ? existingLayout.activeLeafId
@@ -492,9 +496,12 @@ function chooseRemoteTerminalLayout(
     leafIds[0] ??
     null
   const expandedLeafId =
-    parentLayout?.expandedLeafId && knownLeafIds.has(parentLayout.expandedLeafId)
-      ? parentLayout.expandedLeafId
-      : null
+    requestedActiveLeafId &&
+    (Boolean(existingLayout?.expandedLeafId) || Boolean(parentLayout?.expandedLeafId))
+      ? requestedActiveLeafId
+      : parentLayout?.expandedLeafId && knownLeafIds.has(parentLayout.expandedLeafId)
+        ? parentLayout.expandedLeafId
+        : null
   return {
     // Why: host parentLayout is authoritative for split direction; else keep the prior client tree, then degenerate — never re-guess a direction.
     root: resolveTerminalLayoutRoot({
@@ -551,7 +558,8 @@ function buildMirroredTerminalTabs(
   existingById: ReadonlyMap<string, TerminalTab>,
   existingLayoutsByTabId: Readonly<Record<string, TerminalLayoutSnapshot>>,
   sortOffset: number,
-  now: number
+  now: number,
+  focusTarget?: { parentTabId: string; leafId: string }
 ): MirroredTerminalTab[] {
   const groups = new Map<string, TerminalSurface[]>()
   for (const tab of snapshot.tabs.filter(isTerminalSurfaceTab)) {
@@ -563,7 +571,12 @@ function buildMirroredTerminalTabs(
   return [...groups.entries()].map(([parentTabId, surfaces], index) => {
     const localTabId = toWebTerminalSurfaceTabId(parentTabId)
     const existingLayout = existingLayoutsByTabId[localTabId]
+    const requestedActiveLeafId =
+      focusTarget?.parentTabId === parentTabId ? focusTarget.leafId : undefined
     const activeSurface =
+      (requestedActiveLeafId
+        ? surfaces.find((surface) => surface.leafId === requestedActiveLeafId)
+        : undefined) ??
       (existingLayout?.activeLeafId
         ? surfaces.find((surface) => surface.leafId === existingLayout.activeLeafId)
         : undefined) ??
@@ -631,7 +644,12 @@ function buildMirroredTerminalTabs(
       },
       hostTabId: parentTabId,
       ptyIds,
-      layout: chooseRemoteTerminalLayout(surfaces, ptyIdsByLeafId, existingLayout)
+      layout: chooseRemoteTerminalLayout(
+        surfaces,
+        ptyIdsByLeafId,
+        existingLayout,
+        requestedActiveLeafId
+      )
     }
   })
 }
@@ -1720,15 +1738,24 @@ export function applyWebSessionTabsSnapshot(
       }
     : rawSnapshot
   // Why: only a caller-recorded create intent may focus its arriving tab; unsolicited server-active must not steal focus (#5435).
-  const focusIntentHostTabId = peekWebSessionFocusIntent({ environmentId }, worktreeId)
+  const focusIntent = peekWebSessionFocusIntent({ environmentId }, worktreeId)
+  const focusIntentHostTabId = focusIntent?.hostTabId ?? null
   const callerFocusIntentTab =
     focusIntentHostTabId === null
       ? null
-      : (snapshot.tabs.find(
-          (tab) =>
-            tab.id === focusIntentHostTabId ||
-            (tab.type === 'browser' && tab.browserPageId === focusIntentHostTabId)
-        ) ?? null)
+      : focusIntent?.leafId
+        ? (snapshot.tabs.find(
+            (tab) =>
+              tab.type === 'terminal' &&
+              tab.leafId === focusIntent.leafId &&
+              (tab.id === focusIntentHostTabId || tab.parentTabId === focusIntentHostTabId)
+          ) ?? null)
+        : (snapshot.tabs.find(
+            (tab) =>
+              tab.id === focusIntentHostTabId ||
+              (tab.type === 'terminal' && tab.parentTabId === focusIntentHostTabId) ||
+              (tab.type === 'browser' && tab.browserPageId === focusIntentHostTabId)
+          ) ?? null)
   const followIntentTab =
     snapshot.navigationIntent === 'follow'
       ? (snapshot.tabs.find((tab) => tab.id === snapshot.activeTabId) ?? null)
@@ -1786,7 +1813,13 @@ export function applyWebSessionTabsSnapshot(
     existingTerminalById,
     state.terminalLayoutsByTabId,
     retainedTerminalTabs.length,
-    now
+    now,
+    callerFocusIntentTab?.type === 'terminal'
+      ? {
+          parentTabId: callerFocusIntentTab.parentTabId,
+          leafId: callerFocusIntentTab.leafId
+        }
+      : undefined
   )
   const mirroredTerminalTabEntries = mirroredTerminalTabs.map((entry) => entry.tab)
   const retainedTerminalIds = new Set(retainedTerminalTabs.map((tab) => tab.id))

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -41,6 +41,7 @@ import { createOrcaProfilesSlice } from './slices/orca-profiles'
 import { createNewIssueDraftSlice } from './slices/new-issue-draft'
 import { createRemoteServerUpdatesSlice } from './slices/remote-server-updates'
 import { e2eConfig } from '@/lib/e2e-config'
+import type { createWebRuntimeSessionTerminal } from '@/runtime/web-runtime-session'
 import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
 
 export const useAppStore = create<AppState>()((...a) => ({
@@ -95,5 +96,12 @@ export type { AppState } from './types'
 // to avoid fragile DOM scraping. Harmless — the store is already reachable
 // via React DevTools in any environment.
 if ((import.meta.env.DEV || e2eConfig.exposeStore) && typeof window !== 'undefined') {
-  ;(window as unknown as Record<string, unknown>).__store = useAppStore
+  const testWindow = window as unknown as Record<string, unknown>
+  testWindow.__store = useAppStore
+  if (e2eConfig.exposeStore) {
+    testWindow.__webRuntimeSessionE2E = {
+      createTerminal: async (args: Parameters<typeof createWebRuntimeSessionTerminal>[0]) =>
+        (await import('@/runtime/web-runtime-session')).createWebRuntimeSessionTerminal(args)
+    }
+  }
 }

--- a/tests/e2e/remote-agent-session-focus-authority.spec.ts
+++ b/tests/e2e/remote-agent-session-focus-authority.spec.ts
@@ -426,6 +426,7 @@ test('headed paired host keeps structured agent focus viewer-local @headful', as
       legacy
     ].map(({ terminal }) => terminal.ptyId)
     expect(structuredPtyIds.every(Boolean)).toBe(true)
+    expect(new Set(structuredPtyIds).size).toBe(5)
     await expect
       .poll(
         () =>
@@ -480,6 +481,8 @@ test('headed paired host keeps structured agent focus viewer-local @headful', as
     expect(resumeBackground.mirror.activeTabId).toBe(resumeFocused.mirror.activeTabId)
     const fixturePids = readAgentSpawnPids()
     expect(fixturePids).toHaveLength(5)
+    expect(new Set(fixturePids).size).toBe(5)
+    expect(fixturePids.every(isProcessAlive)).toBe(true)
     const fixturePtyIds = finalTerminals
       .map((terminal) => terminal.ptyId)
       .filter((ptyId): ptyId is string => Boolean(ptyId))

--- a/tests/e2e/remote-agent-session-focus-authority.spec.ts
+++ b/tests/e2e/remote-agent-session-focus-authority.spec.ts
@@ -1,0 +1,555 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedWebClient
+} from './helpers/paired-electron-client'
+import { toWebTerminalSurfaceTabId } from '../../src/shared/terminal-surface-id'
+import type { RuntimeTerminalSummary } from '../../src/shared/runtime-types'
+
+type ClientMirror = {
+  activeTabId: string | null
+  tabIds: string[]
+  tabGroups: { id: string; tabOrder: string[] }[]
+}
+
+const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-headed-agent-focus-'))
+const spawnMarkerPath = path.join(scratch, 'agent-spawns.txt')
+const inputMarkerPath = path.join(scratch, 'agent-input.txt')
+const exitTriggerPath = path.join(scratch, 'exit-agent')
+const fixtureScript = path.join(
+  process.cwd(),
+  'config',
+  'scripts',
+  'remote-agent-session-repro-fixture.mjs'
+)
+const writableShellScript = path.join(
+  process.cwd(),
+  'config',
+  'scripts',
+  'remote-agent-session-repro-writable-shell.mjs'
+)
+
+test.use({
+  launchEnv: {
+    ORCA_REPRO_EXIT_TRIGGER: exitTriggerPath,
+    ORCA_REPRO_INPUT_MARKER: inputMarkerPath,
+    ORCA_REPRO_SPAWN_MARKER: spawnMarkerPath
+  }
+})
+
+test.afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true })
+})
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function fixtureCommand(scriptPath: string, ...args: string[]): string {
+  const command = [process.execPath, scriptPath, ...args]
+  return process.platform === 'win32'
+    ? command.map((value) => `"${value.replaceAll('"', '""')}"`).join(' ')
+    : command.map(shellQuote).join(' ')
+}
+
+function countAgentSpawns(): number {
+  if (!existsSync(spawnMarkerPath)) {
+    return 0
+  }
+  return readFileSync(spawnMarkerPath, 'utf8').split(/\r?\n/).filter(Boolean).length
+}
+
+function readAgentSpawnPids(): number[] {
+  if (!existsSync(spawnMarkerPath)) {
+    return []
+  }
+  return readFileSync(spawnMarkerPath, 'utf8')
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => Number(line.split(':', 1)[0]))
+    .filter((pid) => Number.isInteger(pid) && pid > 0)
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+async function callClient<TResult>(page: Page, method: string, params: unknown): Promise<TResult> {
+  return page.evaluate(
+    async ({ method, params }) => {
+      const response = await window.api.runtime.call({ method, params })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { method, params }
+  ) as Promise<TResult>
+}
+
+async function listTerminals(page: Page, worktreeId: string): Promise<RuntimeTerminalSummary[]> {
+  return (
+    await callClient<{ terminals: RuntimeTerminalSummary[] }>(page, 'terminal.list', {
+      worktree: `id:${worktreeId}`
+    })
+  ).terminals
+}
+
+async function readClientMirror(page: Page, worktreeId: string): Promise<ClientMirror> {
+  return page.evaluate((id) => {
+    const state = window.__store?.getState()
+    const tabIds = (state?.tabsByWorktree[id] ?? []).map((tab) => tab.id)
+    return {
+      activeTabId: state?.activeTabIdByWorktree[id] ?? null,
+      tabIds,
+      tabGroups: (state?.groupsByWorktree[id] ?? []).map((group) => ({
+        id: group.id,
+        tabOrder: group.tabOrder
+      }))
+    }
+  }, worktreeId)
+}
+
+async function readRenderedActiveTabId(page: Page): Promise<string | null> {
+  return page.evaluate(
+    () =>
+      document
+        .querySelector('[data-testid="sortable-tab"][data-active="true"]')
+        ?.getAttribute('data-tab-id') ?? null
+  )
+}
+
+async function readRenderedTabOrder(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-testid="sortable-tab"]')
+    .evaluateAll((tabs) =>
+      tabs
+        .map((tab) => tab.getAttribute('data-tab-id'))
+        .filter((tabId): tabId is string => tabId !== null)
+    )
+}
+
+function expectImmediatelyAfter(order: string[], predecessor: string, created: string): void {
+  const predecessorIndex = order.indexOf(predecessor)
+  if (predecessorIndex < 0) {
+    throw new Error(
+      `placement predecessor ${predecessor} missing before ${created}: ${JSON.stringify(order)}`
+    )
+  }
+  expect(order[predecessorIndex + 1]).toBe(created)
+}
+
+async function launchAgent(
+  page: Page,
+  args: {
+    worktreeId: string
+    environmentId: string
+    hostPage: Page
+    kind: 'fresh' | 'resume'
+    activate: boolean
+    providerSessionId?: string
+    afterTabId?: string
+  }
+): Promise<{ terminal: RuntimeTerminalSummary; mirror: ClientMirror }> {
+  const before = await listTerminals(page, args.worktreeId)
+  const beforeHandles = new Set(before.map((terminal) => terminal.handle))
+  const priorMirror = await readClientMirror(page, args.worktreeId)
+  const priorRenderedActiveTabId = await readRenderedActiveTabId(page)
+  const priorHostMirror = await readClientMirror(args.hostPage, args.worktreeId)
+  const priorHostRenderedActiveTabId = await readRenderedActiveTabId(args.hostPage)
+  const { hostPage: _hostPage, ...clientArgs } = args
+
+  const outcome = await page.evaluate(
+    async ({ args, fixtureCommand }) => {
+      const bridge = (
+        window as unknown as {
+          __webRuntimeSessionE2E?: {
+            createTerminal: (
+              launch: Record<string, unknown>
+            ) => Promise<{ status: string; message?: string }>
+          }
+        }
+      ).__webRuntimeSessionE2E
+      if (!bridge) {
+        throw new Error('Web runtime session E2E bridge is unavailable')
+      }
+      return bridge.createTerminal({
+        worktreeId: args.worktreeId,
+        environmentId: args.environmentId,
+        agentSessionKind: args.kind,
+        agent: 'codex',
+        command: fixtureCommand,
+        activate: args.activate,
+        ...(args.providerSessionId
+          ? {
+              providerSession: { key: 'session_id', id: args.providerSessionId }
+            }
+          : {}),
+        ...(args.afterTabId ? { afterTabId: args.afterTabId } : {})
+      })
+    },
+    {
+      args: clientArgs,
+      fixtureCommand: fixtureCommand(fixtureScript)
+    }
+  )
+  expect(outcome).toEqual({ status: 'created' })
+
+  let createdTerminals: RuntimeTerminalSummary[] = []
+  await expect
+    .poll(
+      async () => {
+        const terminals = await listTerminals(page, args.worktreeId)
+        createdTerminals = terminals.filter((candidate) => !beforeHandles.has(candidate.handle))
+        return createdTerminals.length
+      },
+      { timeout: 15_000 }
+    )
+    .toBe(1)
+  const terminal = createdTerminals[0]
+  if (!terminal) {
+    throw new Error('Exactly one created agent terminal was not published')
+  }
+
+  const expectedActiveId = toWebTerminalSurfaceTabId(terminal.tabId)
+  await expect
+    .poll(() => readClientMirror(page, args.worktreeId), { timeout: 15_000 })
+    .toMatchObject({
+      activeTabId: args.activate ? expectedActiveId : priorMirror.activeTabId,
+      tabIds: expect.arrayContaining([expectedActiveId])
+    })
+  await expect
+    .poll(() => readRenderedActiveTabId(page), { timeout: 15_000 })
+    .toBe(args.activate ? expectedActiveId : priorRenderedActiveTabId)
+  await expect(
+    page.locator(
+      `[data-testid="sortable-tab"][data-tab-id="${expectedActiveId}"][data-active="${args.activate ? 'true' : 'false'}"]`
+    )
+  ).toBeVisible()
+  await expect
+    .poll(() => readClientMirror(args.hostPage, args.worktreeId), { timeout: 15_000 })
+    .toMatchObject({ activeTabId: priorHostMirror.activeTabId })
+  await expect
+    .poll(() => readRenderedActiveTabId(args.hostPage), { timeout: 15_000 })
+    .toBe(priorHostRenderedActiveTabId)
+  return { terminal, mirror: await readClientMirror(page, args.worktreeId) }
+}
+
+test('headed paired host keeps structured agent focus viewer-local @headful', async ({
+  electronApp,
+  orcaPage
+}) => {
+  test.setTimeout(180_000)
+  const override = fixtureCommand(fixtureScript)
+  await orcaPage.evaluate(async (agentCommand) => {
+    const settings = await window.api.settings.set({
+      agentCmdOverrides: { codex: agentCommand }
+    })
+    window.__store?.setState({ settings })
+  }, override)
+
+  const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+  const client = await launchPairedWebClient(electronApp, offer)
+  let cleanupWorktreeId: string | null = null
+  try {
+    const worktreeId = await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      if (!state?.activeWorktreeId) {
+        throw new Error('Headed host did not select its seeded worktree')
+      }
+      return state.activeWorktreeId
+    })
+    await expect
+      .poll(
+        () =>
+          client.page.evaluate(
+            (id) =>
+              window.__store
+                ?.getState()
+                .allWorktrees()
+                .some((worktree) => worktree.id === id),
+            worktreeId
+          ),
+        { timeout: 30_000 }
+      )
+      .toBe(true)
+    const session = await client.page.evaluate(async (selectedWorktreeId) => {
+      const environment = (await window.api.runtimeEnvironments.list())[0]
+      if (!environment) {
+        throw new Error('Paired client did not retain its runtime environment')
+      }
+      return { worktreeId: selectedWorktreeId, environmentId: environment.id }
+    }, worktreeId)
+    cleanupWorktreeId = session.worktreeId
+    await client.page.evaluate((id) => window.__store?.getState().setActiveWorktree(id), worktreeId)
+    await expect
+      .poll(() => readRenderedActiveTabId(client.page), { timeout: 15_000 })
+      .not.toBeNull()
+
+    const unrelatedMarkerPath = path.join(scratch, 'unrelated-input.txt')
+    const unrelatedCreated = await callClient<{
+      tab: {
+        type: 'terminal'
+        parentTabId: string
+        leafId: string
+        terminal: string | null
+      }
+    }>(client.page, 'session.tabs.createTerminal', {
+      worktree: `id:${session.worktreeId}`,
+      command: fixtureCommand(writableShellScript, unrelatedMarkerPath),
+      activate: false,
+      select: false,
+      navigation: 'caller'
+    })
+    if (!unrelatedCreated.tab.terminal) {
+      throw new Error('Unrelated headed terminal did not publish a ready handle')
+    }
+    await expect
+      .poll(
+        async () =>
+          (await listTerminals(client.page, session.worktreeId)).some(
+            (terminal) => terminal.handle === unrelatedCreated.tab.terminal
+          ),
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+    const unrelatedTerminal = (await listTerminals(client.page, session.worktreeId)).find(
+      (terminal) => terminal.handle === unrelatedCreated.tab.terminal
+    )
+    if (!unrelatedTerminal) {
+      throw new Error('Unrelated headed terminal was absent from authoritative inventory')
+    }
+    const unrelatedWebTabId = toWebTerminalSurfaceTabId(unrelatedCreated.tab.parentTabId)
+    await expect
+      .poll(async () => (await readClientMirror(client.page, session.worktreeId)).tabIds, {
+        timeout: 15_000
+      })
+      .toEqual(expect.arrayContaining([unrelatedWebTabId]))
+
+    const authoritativeBeforeLegacy = await callClient<{
+      tabGroups?: { id: string; tabOrder: string[] }[]
+      tabs: { type: string; parentTabId?: string; leafId?: string }[]
+    }>(client.page, 'session.tabs.list', {
+      worktree: `id:${session.worktreeId}`
+    })
+    const legacyGroup = authoritativeBeforeLegacy.tabGroups?.find((group) => {
+      const unrelatedIndex = group.tabOrder.indexOf(unrelatedCreated.tab.parentTabId)
+      const predecessorId = unrelatedIndex > 0 ? group.tabOrder[unrelatedIndex - 1] : null
+      return authoritativeBeforeLegacy.tabs.some(
+        (tab) => tab.type === 'terminal' && tab.parentTabId === predecessorId
+      )
+    })
+    const successorHostTabId = unrelatedCreated.tab.parentTabId
+    const successorIndex = legacyGroup?.tabOrder.indexOf(successorHostTabId) ?? -1
+    const predecessorHostTabId =
+      successorIndex > 0 ? legacyGroup?.tabOrder[successorIndex - 1] : undefined
+    const predecessorHostLeafId = authoritativeBeforeLegacy.tabs.find(
+      (tab) => tab.type === 'terminal' && tab.parentTabId === predecessorHostTabId
+    )?.leafId
+    if (!legacyGroup || !predecessorHostTabId || !successorHostTabId || !predecessorHostLeafId) {
+      throw new Error('Legacy placement host predecessor or successor is missing')
+    }
+    const predecessorWebTabId = toWebTerminalSurfaceTabId(predecessorHostTabId)
+    const successorWebTabId = toWebTerminalSurfaceTabId(successorHostTabId)
+    await expect
+      .poll(() => readRenderedTabOrder(client.page), { timeout: 15_000 })
+      .toEqual(expect.arrayContaining([predecessorWebTabId, successorWebTabId]))
+    await expect
+      .poll(() => readRenderedActiveTabId(client.page), { timeout: 15_000 })
+      .not.toBeNull()
+    const legacy = await launchAgent(client.page, {
+      ...session,
+      hostPage: orcaPage,
+      kind: 'fresh',
+      activate: false,
+      afterTabId: toWebTerminalSurfaceTabId(`${predecessorHostTabId}::${predecessorHostLeafId}`)
+    })
+    const legacyWebTabId = toWebTerminalSurfaceTabId(legacy.terminal.tabId)
+    const mirroredLegacyGroup = legacy.mirror.tabGroups.find((group) => group.id === legacyGroup.id)
+    if (!mirroredLegacyGroup) {
+      throw new Error('Legacy placement mirrored group is missing')
+    }
+    expectImmediatelyAfter(mirroredLegacyGroup.tabOrder, predecessorWebTabId, legacyWebTabId)
+    expectImmediatelyAfter(mirroredLegacyGroup.tabOrder, legacyWebTabId, successorWebTabId)
+    const renderedOrder = await readRenderedTabOrder(client.page)
+    expectImmediatelyAfter(renderedOrder, predecessorWebTabId, legacyWebTabId)
+    expectImmediatelyAfter(renderedOrder, legacyWebTabId, successorWebTabId)
+    const authoritativeTabs = await callClient<{
+      tabGroups?: { id: string; tabOrder: string[] }[]
+    }>(client.page, 'session.tabs.list', { worktree: `id:${session.worktreeId}` })
+    const authoritativeTabOrder =
+      authoritativeTabs.tabGroups?.find((group) => group.id === legacyGroup.id)?.tabOrder ?? []
+    expectImmediatelyAfter(authoritativeTabOrder, predecessorHostTabId, legacy.terminal.tabId)
+    expectImmediatelyAfter(authoritativeTabOrder, legacy.terminal.tabId, successorHostTabId)
+    const freshFocused = await launchAgent(client.page, {
+      ...session,
+      hostPage: orcaPage,
+      kind: 'fresh',
+      activate: true
+    })
+    const freshBackground = await launchAgent(client.page, {
+      ...session,
+      hostPage: orcaPage,
+      kind: 'fresh',
+      activate: false
+    })
+    const resumeFocused = await launchAgent(client.page, {
+      ...session,
+      hostPage: orcaPage,
+      kind: 'resume',
+      activate: true,
+      providerSessionId: 'headed-focus-resume'
+    })
+    const resumeBackground = await launchAgent(client.page, {
+      ...session,
+      hostPage: orcaPage,
+      kind: 'resume',
+      activate: false,
+      providerSessionId: 'headed-background-resume'
+    })
+
+    await expect.poll(countAgentSpawns, { timeout: 15_000 }).toBe(5)
+    const structuredPtyIds = [
+      freshFocused,
+      freshBackground,
+      resumeFocused,
+      resumeBackground,
+      legacy
+    ].map(({ terminal }) => terminal.ptyId)
+    expect(structuredPtyIds.every(Boolean)).toBe(true)
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate(async () =>
+            (await window.api.pty.listSessions()).map((session) => session.id)
+          ),
+        { timeout: 15_000 }
+      )
+      .toEqual(expect.arrayContaining(structuredPtyIds))
+
+    const marker = `headed-paired-writable-${Date.now()}`
+    const sent = await callClient<{ send: { accepted: boolean } }>(client.page, 'terminal.send', {
+      terminal: freshFocused.terminal.handle,
+      text: `${marker}\n`
+    })
+    expect(sent.send.accepted).toBe(true)
+    await expect
+      .poll(
+        () =>
+          existsSync(inputMarkerPath)
+            ? readFileSync(inputMarkerPath, 'utf8').includes(marker)
+            : false,
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+
+    const unrelatedMarker = `unrelated-survived-${Date.now()}`
+    const unrelatedSent = await callClient<{ send: { accepted: boolean } }>(
+      client.page,
+      'terminal.send',
+      {
+        terminal: unrelatedTerminal.handle,
+        text: `${unrelatedMarker}\n`
+      }
+    )
+    expect(unrelatedSent.send.accepted).toBe(true)
+    await expect
+      .poll(
+        () =>
+          existsSync(unrelatedMarkerPath)
+            ? readFileSync(unrelatedMarkerPath, 'utf8').includes(unrelatedMarker)
+            : false,
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+
+    const finalTerminals = await listTerminals(client.page, session.worktreeId)
+    expect(finalTerminals.map((terminal) => terminal.handle)).toContain(unrelatedTerminal.handle)
+    expect((await readClientMirror(client.page, session.worktreeId)).tabIds).toContain(
+      unrelatedWebTabId
+    )
+    expect(resumeBackground.mirror.activeTabId).toBe(resumeFocused.mirror.activeTabId)
+    const fixturePids = readAgentSpawnPids()
+    expect(fixturePids).toHaveLength(5)
+    const fixturePtyIds = finalTerminals
+      .map((terminal) => terminal.ptyId)
+      .filter((ptyId): ptyId is string => Boolean(ptyId))
+    const retiredHostTabIds = [
+      unrelatedCreated.tab.parentTabId,
+      ...[legacy, freshFocused, freshBackground, resumeFocused, resumeBackground].map(
+        ({ terminal }) => terminal.tabId
+      )
+    ]
+    const retiredWebTabIds = retiredHostTabIds.map(toWebTerminalSurfaceTabId)
+
+    await callClient(client.page, 'terminal.stop', {
+      worktree: `id:${session.worktreeId}`
+    })
+    await expect
+      .poll(() => listTerminals(client.page, session.worktreeId), { timeout: 15_000 })
+      .toEqual([])
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate(
+            async (ptyIds) =>
+              (await window.api.pty.listSessions())
+                .map((session) => session.id)
+                .filter((ptyId) => ptyIds.includes(ptyId)),
+            fixturePtyIds
+          ),
+        { timeout: 15_000 }
+      )
+      .toEqual([])
+    await expect
+      .poll(
+        async () => {
+          const tabs = await callClient<{ tabs: { parentTabId?: string }[] }>(
+            client.page,
+            'session.tabs.list',
+            { worktree: `id:${session.worktreeId}` }
+          )
+          return tabs.tabs
+            .map((tab) => tab.parentTabId)
+            .filter((tabId) => tabId && retiredHostTabIds.includes(tabId))
+        },
+        { timeout: 15_000 }
+      )
+      .toEqual([])
+    await expect
+      .poll(
+        async () =>
+          (await readClientMirror(client.page, session.worktreeId)).tabIds.filter((tabId) =>
+            retiredWebTabIds.includes(tabId)
+          ),
+        { timeout: 15_000 }
+      )
+      .toEqual([])
+    await expect
+      .poll(
+        async () =>
+          (await readRenderedTabOrder(client.page)).filter((tabId) =>
+            retiredWebTabIds.includes(tabId)
+          ),
+        { timeout: 15_000 }
+      )
+      .toEqual([])
+    await expect.poll(() => fixturePids.filter(isProcessAlive), { timeout: 15_000 }).toEqual([])
+  } finally {
+    if (cleanupWorktreeId) {
+      await callClient(client.page, 'terminal.stop', {
+        worktree: `id:${cleanupWorktreeId}`
+      }).catch(() => undefined)
+    }
+    await client.dispose()
+  }
+})


### PR DESCRIPTION
## Summary

- create paired structured agent sessions with background presentation on the execution host
- keep activation and focus owned by the paired client through the existing focus-intent reconciliation
- cover both fresh `terminal.createAgentSession` and resume `terminal.ensureAgentSession` requests

Fixes #10192.

## Root cause

The remote renderer sent `presentation: "focused"` when an activated agent session was requested. A headless `orca serve` host has no authoritative renderer window, so terminal creation failed with `No renderer window available` before spawning a PTY.

Plain paired terminal creation already separates background host creation from caller-local focus. This change applies the same ownership boundary to structured agent sessions.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- `vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-runtime-session.test.ts` — 37 passed
- `pnpm test:repro:remote-agent-session` — passed: one spawn, retry adoption, durable exit retirement, no restart resurrection
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `oxfmt --check` and focused `oxlint` — passed
- `git diff --check` — passed
- CLI and Electron Vite builds completed as part of the reproduction harness

The full test run completed 36,443 passing tests with two unrelated failures:

- `src/main/runtime/multi-client-navigation-isolation.integration.test.ts` failed in the aggregate run and then passed in isolation (5/5).
- `src/relay/git-handler.test.ts` expects `not a git repository`, while this temporary checkout returns `Stopping at filesystem boundary`; it remains reproducible in isolation and does not touch the changed renderer path.

The repository requests Node 24; local validation ran on Node 22.22.2 with pnpm 10.24.0 and emitted the engine warning.

## AI Review Report

Reviewed the complete two-file diff for host/client focus ownership, legacy fallback behavior, duplicate-spawn risk, and fresh/resume parity. The change leaves legacy `session.tabs.createTerminal` behavior and the existing caller-local focus intent unchanged.

Cross-platform compatibility was checked for macOS, Linux, and Windows. The patch contains no platform-specific shortcuts, labels, paths, shell behavior, native modules, or Electron window APIs. It also preserves SSH and paired-runtime host ownership.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, permissions, or IPC methods are introduced. The only runtime change selects the existing `background` presentation enum for paired structured agent-session RPCs. Operation IDs, provider claims, compatibility fallback, and host-side authorization remain unchanged.

## Notes

This is intentionally client-side and scoped to paired remote structured-agent launches. It does not change the server fallback for ordinary local focused terminal creation and does not mask local renderer startup failures.
