### PR TITLE
fix(cursor): detect Cursor Agent via standard CLI alias

### DIFF
--- a/src/main/ipc/tui-agent-detection-commands.test.ts
+++ b/src/main/ipc/tui-agent-detection-commands.test.ts
@@ -46,4 +46,33 @@ describe('tui agent detection commands', () => {
     expect(getTuiAgentDetectionProbeCommands(commands, 'wsl')).toEqual([])
     expect(resolveDetectedTuiAgentIds(commands, new Set(['orca-ide', 'claude']), 'wsl')).toEqual([])
   })
+
+  it('detects cursor agent via cursor-agent or cursor alias', () => {
+    const commands = KNOWN_TUI_AGENT_DETECTION_COMMANDS.filter((command) => command.id === 'cursor')
+
+    // Should have two detection entries: cursor-agent (primary) and cursor (alias)
+    expect(commands).toEqual([
+      { id: 'cursor', cmd: 'cursor-agent' },
+      { id: 'cursor', cmd: 'cursor' }
+    ])
+
+    // Both commands should be probed
+    expect(getTuiAgentDetectionProbeCommands(commands, 'linux')).toEqual(['cursor-agent', 'cursor'])
+
+    // Detection via standalone cursor-agent binary
+    expect(resolveDetectedTuiAgentIds(commands, new Set(['cursor-agent']), 'linux')).toEqual([
+      'cursor'
+    ])
+
+    // Detection via standard Cursor IDE installation (cursor in PATH)
+    expect(resolveDetectedTuiAgentIds(commands, new Set(['cursor']), 'linux')).toEqual(['cursor'])
+
+    // Detection when both are present
+    expect(
+      resolveDetectedTuiAgentIds(commands, new Set(['cursor-agent', 'cursor']), 'linux')
+    ).toEqual(['cursor'])
+
+    // No detection when neither is present
+    expect(resolveDetectedTuiAgentIds(commands, new Set(['claude']), 'linux')).toEqual([])
+  })
 })

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -213,7 +213,13 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
   },
   cursor: {
     detectCmd: 'cursor-agent',
+    detectCmdAliases: ['cursor'],
     launchCmd: 'cursor-agent',
+    // Why: the detectCmdAlias 'cursor' ensures the agent is detected when the
+    // standard Cursor IDE CLI is installed (which only has `cursor` in $PATH).
+    // The launchCmd stays as 'cursor-agent' to preserve standalone installations.
+    // Users with only the standard Cursor CLI can set cmdOverrides.cursor to
+    // 'cursor agent' to use the subcommand form.
     expectedProcess: 'cursor-agent',
     promptInjectionMode: 'argv',
     // Why: first-launch trust menu swallows the bracketed paste; pre-write the .workspace-trusted marker so it skips (agent-trust-presets.ts).


### PR DESCRIPTION
## Summary

Standard Cursor IDE installs `cursor` in `$PATH`, not `cursor-agent`. The standalone `cursor-agent` binary only exists when users manually run the separate install script. This caused Orca to not detect Cursor Agent at all for standard installations.

This fix adds `cursor` as a detection alias so the agent is detected when either binary is present on PATH.

No visual change.

## Testing

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — 156 test files, 2264 tests pass
- [x] Added test coverage for cursor detection via both `cursor-agent` and `cursor` alias

## Notes

- The `launchCmd` stays as `cursor-agent` to preserve standalone installations
- Users with only the standard Cursor CLI can set `cmdOverrides.cursor` to `'cursor agent'` to use the subcommand form
- Detection now works for both installation types; launch requires the appropriate command or override

Closes #10189
