### PR TITLE
Rename 'Local Network' to 'LAN' across mobile and settings UI

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -18,7 +18,7 @@
       "bundleIdentifier": "com.stably.orca.mobile",
       "buildNumber": "1",
       "infoPlist": {
-        "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your local network.",
+        "NSLocalNetworkUsageDescription": "Orca connects to the desktop app on your LAN.",
         "NSMicrophoneUsageDescription": "Allow Orca to record voice dictation and transcribe it on your paired desktop.",
         "NSPhotoLibraryUsageDescription": "Allow Orca to attach photos from your library to a terminal session on your paired desktop.",
         "NSAppTransportSecurity": {

--- a/mobile/src/diagnostics/troubleshoot-common-issues.tsx
+++ b/mobile/src/diagnostics/troubleshoot-common-issues.tsx
@@ -14,7 +14,7 @@ export const troubleshootCommonIssues: TroubleshootSection[] = [
     icon: <WifiOff size={16} color={colors.textSecondary} />,
     title: 'Different WiFi Networks',
     steps: [
-      'Both devices must be on the same local network (unless connected through Tailscale).',
+      'Both devices must be on the same LAN (unless connected through Tailscale).',
       'Ethernet and WiFi must share the same subnet.',
       'Try reconnecting WiFi on both devices.'
     ]

--- a/src/renderer/src/components/mobile/MobileHero.test.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.test.tsx
@@ -139,7 +139,7 @@ describe('HeroFlow height', () => {
       relayDegraded: true
     })
     const notice = screen.getByTestId('relay-degraded-notice')
-    expect(notice).toHaveTextContent('only works on your local network')
+    expect(notice).toHaveTextContent('only works on your LAN or Tailscale')
     // Why: wrap-capable text item inside the fixed QR track (#9700); bare text
     // nodes in a flex row cannot shrink below max-content and overflow the track.
     expect(notice.querySelector('.min-w-0')).not.toBeNull()

--- a/src/renderer/src/components/mobile/MobileHero.tsx
+++ b/src/renderer/src/components/mobile/MobileHero.tsx
@@ -279,7 +279,7 @@ export function HeroFlow({
                 onClick={onRegeneratePairing}
                 // Why: signed-out Anywhere can't serve Relay; disabling avoids
                 // minting a local-only QR under the Relay label. Sign in or pick
-                // Local network (shown in the path options above) to enable it.
+                // LAN (shown in the path options above) to enable it.
                 disabled={pairLoading || !canGeneratePairing}
               >
                 {pairLoading
@@ -298,7 +298,7 @@ export function HeroFlow({
                   <span className="min-w-0">
                     {translate(
                       'auto.components.mobile.MobileHero.relayDegradedNotice',
-                      'Relay couldn’t be reached — this code only works on your local network.'
+                      'Relay couldn’t be reached — this code only works on your LAN or Tailscale.'
                     )}
                   </span>
                 </p>

--- a/src/renderer/src/components/mobile/MobilePage.test.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.test.tsx
@@ -66,7 +66,7 @@ vi.mock('./MobilePageContent', () => ({
         Orca Relay
       </button>
       <button type="button" onClick={() => props.handleConnectionModeChange('local-only')}>
-        Local network
+        LAN
       </button>
       <button type="button" onClick={() => props.handleAddressChange('10.0.0.2')}>
         Change address
@@ -131,7 +131,7 @@ describe('MobilePage pairing connection mode', () => {
           resolveRotatedLocalQr = resolve
         })
     )
-    await user.click(screen.getByRole('button', { name: 'Local network' }))
+    await user.click(screen.getByRole('button', { name: 'LAN' }))
     // No rotate flag: the main process rotates exactly once on the policy
     // mismatch, so concurrent windows converge on the same fresh token.
     await waitFor(() =>
@@ -180,15 +180,15 @@ describe('MobilePage pairing connection mode', () => {
     expect(screen.getByTestId('can-generate')).toHaveTextContent('false')
   })
 
-  it('mints a local-only QR when switching to Local network while signed out', async () => {
+  it('mints a local-only QR when switching to LAN while signed out', async () => {
     mocks.storeState.orcaProfileAuthStatus = { state: 'local' }
     const user = userEvent.setup()
     await openPairingStep()
     await new Promise((resolve) => setTimeout(resolve, 20))
     expect(getPairingQR).not.toHaveBeenCalled()
 
-    // Picking Local network is an honest local-only path, so a QR mints.
-    await user.click(screen.getByRole('button', { name: 'Local network' }))
+    // Picking LAN is an honest local-only path, so a QR mints.
+    await user.click(screen.getByRole('button', { name: 'LAN' }))
     await waitFor(() => expect(getPairingQR).toHaveBeenCalledWith({ connectionMode: 'local-only' }))
     await waitFor(() => expect(screen.getByTestId('pairing-qr')).toHaveTextContent('base64,qr'))
     expect(screen.getByTestId('mode')).toHaveTextContent('local-only')
@@ -199,7 +199,7 @@ describe('MobilePage pairing connection mode', () => {
     const user = userEvent.setup()
     await openPairingStep()
 
-    await user.click(screen.getByRole('button', { name: 'Local network' }))
+    await user.click(screen.getByRole('button', { name: 'LAN' }))
     await waitFor(() => expect(screen.getByTestId('pairing-qr')).toHaveTextContent('base64,qr'))
     getPairingQR.mockClear()
 
@@ -272,7 +272,7 @@ describe('MobilePage pairing connection mode', () => {
     await waitFor(() => expect(screen.getByTestId('pairing-qr')).toHaveTextContent('base64,qr'))
 
     getPairingQR.mockRejectedValueOnce(new Error('rotation failed'))
-    await user.click(screen.getByRole('button', { name: 'Local network' }))
+    await user.click(screen.getByRole('button', { name: 'LAN' }))
 
     await waitFor(() => expect(screen.getByTestId('pairing-qr')).toHaveTextContent('none'))
     expect(screen.getByTestId('pairing-url')).toHaveTextContent('none')

--- a/src/renderer/src/components/mobile/MobilePage.tsx
+++ b/src/renderer/src/components/mobile/MobilePage.tsx
@@ -205,7 +205,7 @@ export default function MobilePage(): React.JSX.Element {
     }
     // Why: signed-out Anywhere cannot serve Relay; auto-minting here would show a
     // scannable local-only QR under the Relay label. Wait for sign-in or a switch
-    // to Local network (both flip canGenerate and re-run this effect) instead.
+    // to LAN (both flip canGenerate and re-run this effect) instead.
     if (!canGenerate) {
       return
     }

--- a/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
+++ b/src/renderer/src/components/settings/DeveloperPermissionsPane.tsx
@@ -128,10 +128,7 @@ const PERMISSIONS: PermissionDefinition[] = [
   {
     id: 'local-network',
     get label() {
-      return translate(
-        'auto.components.settings.DeveloperPermissionsPane.e7bb06007c',
-        'Local Network'
-      )
+      return translate('auto.components.settings.DeveloperPermissionsPane.e7bb06007c', 'LAN')
     },
     get description() {
       return translate(

--- a/src/renderer/src/components/settings/MobilePairingConnectionOptions.test.tsx
+++ b/src/renderer/src/components/settings/MobilePairingConnectionOptions.test.tsx
@@ -80,7 +80,7 @@ describe('MobilePairingConnectionOptions', () => {
     expect(connect).toHaveBeenCalledOnce()
   })
 
-  it('hides Sign in when local network is selected', () => {
+  it('hides Sign in when LAN is selected', () => {
     render(<MobilePairingConnectionOptions value="local-only" onChange={vi.fn()} />)
     expect(screen.queryByTestId('anywhere-sign-in-panel')).toBeNull()
   })
@@ -159,7 +159,7 @@ describe('MobilePairingConnectionOptions', () => {
     await waitFor(() => expect(screen.getByText('Ready')).toBeVisible())
     expect(screen.queryByTestId('anywhere-sign-in-panel')).toBeNull()
 
-    await user.click(screen.getByRole('radio', { name: /Local network/i }))
+    await user.click(screen.getByRole('radio', { name: /^LAN\b/i }))
     expect(onChange).toHaveBeenCalledWith('local-only')
     statusListener?.('standby')
   })

--- a/src/renderer/src/components/settings/MobilePairingConnectionOptions.tsx
+++ b/src/renderer/src/components/settings/MobilePairingConnectionOptions.tsx
@@ -213,7 +213,7 @@ export function MobilePairingConnectionOptions({
           onSelect={() => onChange('local-only')}
           title={translate(
             'auto.components.settings.MobilePairingConnectionOptions.localTitle',
-            'Local network'
+            'LAN'
           )}
           description={translate(
             'auto.components.settings.MobilePairingConnectionOptions.localDescription',
@@ -264,7 +264,7 @@ export function MobilePairingConnectionOptions({
           <p className="min-w-0 flex-1 text-xs text-muted-foreground">
             {translate(
               'auto.components.settings.MobilePairingConnectionOptions.relayUnavailable',
-              'Orca Relay isn’t available in this build. Use Local network.'
+              'Orca Relay isn’t available in this build. Use LAN.'
             )}
           </p>
           <Badge variant="outline" className="shrink-0">

--- a/src/renderer/src/components/settings/MobilePane.test.tsx
+++ b/src/renderer/src/components/settings/MobilePane.test.tsx
@@ -204,11 +204,11 @@ describe('MobilePane pairing connection mode', () => {
     await user.click(screen.getByRole('button', { name: 'Generate' }))
     await waitFor(() =>
       expect(screen.getByTestId('relay-degraded-notice')).toHaveTextContent(
-        'only works on your local network'
+        'only works on your LAN or Tailscale'
       )
     )
 
-    // Switching to Local network clears the mismatch along with the QR.
+    // Switching to LAN clears the mismatch along with the QR.
     await user.click(screen.getByRole('button', { name: 'choose-local' }))
     await waitFor(() =>
       expect(screen.queryByTestId('relay-degraded-notice')).not.toBeInTheDocument()
@@ -301,7 +301,7 @@ describe('MobilePane pairing connection mode', () => {
     await new Promise((resolve) => setTimeout(resolve, 10))
     expect(screen.getByTestId('loading')).toHaveTextContent('false')
 
-    // Switching to Local network re-enables Generate (no signed-in gate).
+    // Switching to LAN re-enables Generate (no signed-in gate).
     await user.click(screen.getByRole('button', { name: 'choose-local' }))
     expect(screen.getByRole('button', { name: 'Generate' })).toBeEnabled()
   })
@@ -314,7 +314,7 @@ describe('MobilePane pairing connection mode', () => {
     await waitFor(() => expect(getPairingQR).toHaveBeenCalledWith({ connectionMode: 'automatic' }))
     expect(screen.getByTestId('loading')).toHaveTextContent('true')
 
-    // Switch to Local network before the mint resolves; loading must clear so
+    // Switch to LAN before the mint resolves; loading must clear so
     // Generate can be used again for the new path.
     await user.click(screen.getByRole('button', { name: 'choose-local' }))
     await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'))
@@ -352,7 +352,7 @@ describe('MobilePane pairing connection mode', () => {
     await user.click(screen.getByRole('button', { name: 'Generate' }))
     await waitFor(() => expect(getPairingQR).toHaveBeenCalledWith({ connectionMode: 'automatic' }))
 
-    // Switch to Local network before the Relay mint resolves.
+    // Switch to LAN before the Relay mint resolves.
     await user.click(screen.getByRole('button', { name: 'choose-local' }))
 
     resolveQr?.({

--- a/src/renderer/src/components/settings/MobilePane.tsx
+++ b/src/renderer/src/components/settings/MobilePane.tsx
@@ -351,7 +351,7 @@ export function MobilePane(): React.JSX.Element {
           <p className="text-xs text-muted-foreground">
             {translate(
               'auto.components.settings.MobilePane.relayDegradedNotice',
-              'Relay couldn’t be reached — this code only works on your local network. Regenerate to try again.'
+              'Relay couldn’t be reached — this code only works on your LAN or Tailscale. Regenerate to try again.'
             )}
           </p>
         </div>

--- a/src/renderer/src/components/settings/developer-permissions-search.ts
+++ b/src/renderer/src/components/settings/developer-permissions-search.ts
@@ -146,16 +146,19 @@ export const getDeveloperPermissionsPaneSearchEntries = createLocalizedCatalog((
   {
     title: translate(
       'auto.components.settings.developer.permissions.search.3363889768',
-      'Local Network, USB, and Bluetooth'
+      'LAN, USB, and Bluetooth'
     ),
     description: translate(
       'auto.components.settings.developer.permissions.search.acad3d4743',
-      'Allow device and local-network tools used from terminal sessions.'
+      'Allow device tools and LAN access used from terminal sessions.'
     ),
     keywords: [
-      translate(
+      // Why: UI says LAN (aligned with mobile), but macOS System Settings still
+      // labels the privacy toggle "Local Network" — keep both findable.
+      ...translateSearchKeyword(
         'auto.components.settings.developer.permissions.search.fa3239cd42',
-        'local network'
+        'lan',
+        { aliases: ['local network', 'local-network'] }
       ),
       ...translateSearchKeyword(
         'auto.components.settings.developer.permissions.search.c4a4a02ea4',

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -91,7 +91,7 @@ export function handleOscLink(
     // Why: file:// URIs should open inside Orca, not via the OS default editor
     // (shell.openPath). We extract the path from the URI and route it through
     // the same openDetectedFilePath logic used for detected file-path links.
-    // Remote file hosts stay rejected; Windows local network shares are the
+    // Remote file hosts stay rejected; Windows LAN shares are the
     // exception because their standard URI form is file://server/share/path.
     const allowUncHost =
       navigator.userAgent.includes('Windows') &&

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5506,7 +5506,7 @@
           "dfbc12c8c8": "Hardware debugging and device tools that talk to USB devices.",
           "bf51e4a542": "USB Devices",
           "f903bf20b5": "Discovery and access for development servers on your network.",
-          "e7bb06007c": "Local Network",
+          "e7bb06007c": "LAN",
           "4a73f5217a": "Apple Events for scripts that control other local apps.",
           "e119f0d66b": "Automation",
           "7ca17b62c8": "Recommended when projects, worktrees, or symlinked files touch macOS-protected folders.",
@@ -6014,7 +6014,7 @@
           "668016be7a": "on your computer and phone.",
           "1dc87a7fbc": "Tailscale",
           "51d29927eb": "Install",
-          "9fc5d203ff": "Orca Mobile connects directly to this computer. To use it away from the same local network, put your computer and phone on the same private overlay network, then generate the QR code with that network address selected.",
+          "9fc5d203ff": "Orca Mobile connects directly to this computer. To use it away from the same LAN, put your computer and phone on the same private overlay network, then generate the QR code with that network address selected.",
           "39fad211d9": "Connect outside your Wi-Fi with a tailnet",
           "a9db5d771d": "Refresh network interfaces",
           "b2c384cfd6": "No interfaces found",
@@ -6045,7 +6045,7 @@
           "6436e56546": "QR Code for mobile pairing",
           "1b1b70279a": "No devices paired yet.",
           "1592afcc7a": "No devices paired yet. Scan the QR code with the Orca mobile app.",
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network. Regenerate to try again."
+          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your LAN or Tailscale. Regenerate to try again."
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub Releases",
@@ -7678,14 +7678,14 @@
         "developer": {
           "permissions": {
             "search": {
-              "3363889768": "Local Network, USB, and Bluetooth",
+              "3363889768": "LAN, USB, and Bluetooth",
               "6c82846f66": "device",
               "11653d3f42": "mdns",
               "78a10b826f": "bonjour",
               "e3fbc48083": "bluetooth",
               "c4a4a02ea4": "usb",
-              "fa3239cd42": "local network",
-              "acad3d4743": "Allow device and local-network tools used from terminal sessions.",
+              "fa3239cd42": "lan",
+              "acad3d4743": "Allow device tools and LAN access used from terminal sessions.",
               "3e0131e45d": "icloud",
               "ce07159ff5": "desktop",
               "a0c19119fb": "downloads",
@@ -9308,10 +9308,10 @@
           "anywhereTitle": "Orca Relay",
           "anywhereDescription": "Phone can be on cellular or any Wi‑Fi. Sign-in required.",
           "signInRequired": "Sign in to use Orca Mobile Relay.",
-          "relayUnavailable": "Orca Relay isn’t available in this build. Use Local network.",
+          "relayUnavailable": "Orca Relay isn’t available in this build. Use LAN.",
           "signIn": "Sign in",
           "signInAgain": "Sign in again",
-          "localTitle": "Local network",
+          "localTitle": "LAN",
           "localDescription": "Phone must be on this Wi‑Fi or your Tailscale. No sign-in."
         },
         "MobilePairingSetupSection": {
@@ -11058,7 +11058,7 @@
             "preview": "Preview",
             "stable": "Stable"
           },
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network."
+          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your LAN or Tailscale."
         },
         "MobilePage": {
           "e17393c6a3": "Phone preview",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5483,7 +5483,7 @@
           "dfbc12c8c8": "Depuración de hardware y herramientas que se comunican con dispositivos USB.",
           "bf51e4a542": "Dispositivos USB",
           "f903bf20b5": "Descubrimiento y acceso para servidores de desarrollo en tu red.",
-          "e7bb06007c": "Red local",
+          "e7bb06007c": "LAN",
           "4a73f5217a": "Apple Events para scripts que controlan otras apps locales.",
           "e119f0d66b": "Automatización",
           "7ca17b62c8": "Recomendado cuando proyectos, worktrees o archivos symlinked tocan carpetas protegidas de macOS.",
@@ -5954,7 +5954,7 @@
           "668016be7a": "en su computadora y teléfono.",
           "1dc87a7fbc": "Tailscale",
           "51d29927eb": "Instalar",
-          "9fc5d203ff": "Orca Mobile se conecta directamente a esta computadora. Para usarlo fuera de la misma red local, coloque su computadora y teléfono en la misma red superpuesta privada, luego genere el código QR con esa dirección de red seleccionada.",
+          "9fc5d203ff": "Orca Mobile se conecta directamente a esta computadora. Para usarlo fuera de la misma LAN, coloque su computadora y teléfono en la misma red superpuesta privada, luego genere el código QR con esa dirección de red seleccionada.",
           "39fad211d9": "Conéctate fuera de tu Wi-Fi con una tailnet",
           "a9db5d771d": "Actualizar interfaces de red",
           "b2c384cfd6": "No se encontraron interfaces",
@@ -5985,7 +5985,7 @@
           "6436e56546": "Código QR para emparejamiento móvil",
           "1b1b70279a": "Aún no hay dispositivos emparejados.",
           "1592afcc7a": "Aún no hay dispositivos emparejados. Escanea el código QR con la aplicación móvil de Orca.",
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network. Regenerate to try again."
+          "relayDegradedNotice": "No se pudo contactar con Relay: este código solo funciona en tu LAN o Tailscale. Genera uno nuevo e inténtalo de nuevo."
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub Releases",
@@ -7618,14 +7618,14 @@
         "developer": {
           "permissions": {
             "search": {
-              "3363889768": "Red local, USB y Bluetooth",
+              "3363889768": "LAN, USB y Bluetooth",
               "6c82846f66": "dispositivo",
               "11653d3f42": "mdns",
               "78a10b826f": "bonjour",
               "e3fbc48083": "bluetooth",
               "c4a4a02ea4": "USB",
               "fa3239cd42": "red local",
-              "acad3d4743": "Permitir que las herramientas del dispositivo y de la red local se utilicen desde sesiones de terminal.",
+              "acad3d4743": "Permitir herramientas de dispositivo y acceso LAN desde sesiones de terminal.",
               "3e0131e45d": "iCloud",
               "ce07159ff5": "escritorio",
               "a0c19119fb": "descargas",
@@ -9287,9 +9287,9 @@
           "anywhereTitle": "Orca Relay",
           "anywhereDescription": "El teléfono puede estar en datos móviles o cualquier Wi‑Fi. Se requiere inicio de sesión.",
           "signInRequired": "Inicia sesión para usar Orca Mobile Relay.",
-          "relayUnavailable": "Orca Relay no está disponible en esta compilación. Usa Red local.",
+          "relayUnavailable": "Orca Relay no está disponible en esta compilación. Usa LAN.",
           "signInAgain": "Iniciar sesión de nuevo",
-          "localTitle": "Red local"
+          "localTitle": "LAN"
         },
         "MobilePairingSetupSection": {
           "title": "Vincular un teléfono",
@@ -11035,7 +11035,7 @@
             "preview": "Vista previa",
             "stable": "Estable"
           },
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network."
+          "relayDegradedNotice": "No se pudo contactar con Relay: este código solo funciona en tu LAN o Tailscale."
         },
         "MobilePage": {
           "e17393c6a3": "Vista previa del teléfono",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5468,7 +5468,7 @@
           "dfbc12c8c8": "ハードウェア デバッグおよび USB デバイスと通信するデバイス ツール。",
           "bf51e4a542": "USB デバイス",
           "f903bf20b5": "ネットワーク上の開発サーバーを検出してアクセスします。",
-          "e7bb06007c": "ローカルネットワーク",
+          "e7bb06007c": "LAN",
           "4a73f5217a": "他のローカル アプリを制御するスクリプトの Apple Events。",
           "e119f0d66b": "オートメーション",
           "7ca17b62c8": "プロジェクト、worktree、またはシンボリックリンクされたファイルが macOS の保護フォルダーに触れる場合に推奨されます。",
@@ -5976,7 +5976,7 @@
           "668016be7a": "コンピューターとスマートフォンで。",
           "1dc87a7fbc": "Tailscale",
           "51d29927eb": "インストール",
-          "9fc5d203ff": "Orca Mobile はこのコンピュータに直接接続します。同じローカル ネットワークから離れた場所で使用するには、コンピューターとスマートフォンを同じプライベート オーバーレイ ネットワーク上に配置し、そのネットワーク アドレスを選択して QR コードを生成します。",
+          "9fc5d203ff": "Orca Mobile はこのコンピュータに直接接続します。同じ LAN から離れた場所で使用するには、コンピューターとスマートフォンを同じプライベート オーバーレイ ネットワーク上に配置し、そのネットワーク アドレスを選択して QR コードを生成します。",
           "39fad211d9": "テールネットを使用して Wi-Fi の外部に接続する",
           "a9db5d771d": "ネットワークインターフェースを更新する",
           "b2c384cfd6": "インターフェースが見つかりません",
@@ -6007,7 +6007,7 @@
           "6436e56546": "モバイルペアリング用のQRコード",
           "1b1b70279a": "まだデバイスがペアリングされていません。",
           "1592afcc7a": "まだデバイスがペアリングされていません。 Orca モバイル アプリで QR コードをスキャンします。",
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network. Regenerate to try again."
+          "relayDegradedNotice": "Relay に接続できませんでした — このコードは LAN または Tailscale でのみ動作します。再生成してからお試しください。"
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub リリース",
@@ -7640,14 +7640,14 @@
         "developer": {
           "permissions": {
             "search": {
-              "3363889768": "ローカルネットワーク、USB、Bluetooth",
+              "3363889768": "LAN、USB、Bluetooth",
               "6c82846f66": "デバイス",
               "11653d3f42": "MDNS",
               "78a10b826f": "ボンジュール",
               "e3fbc48083": "ブルートゥース",
               "c4a4a02ea4": "USB",
               "fa3239cd42": "ローカルネットワーク",
-              "acad3d4743": "terminal セッションから使用されるデバイスおよびローカル ネットワーク ツールを許可します。",
+              "acad3d4743": "terminal セッションから使用されるデバイス ツールと LAN アクセスを許可します。",
               "3e0131e45d": "icloud",
               "ce07159ff5": "デスクトップ",
               "a0c19119fb": "ダウンロード",
@@ -9287,9 +9287,9 @@
           "anywhereTitle": "Orca Relay",
           "anywhereDescription": "スマートフォンはモバイル回線または Wi‑Fi から接続できます。サインインが必要です。",
           "signInRequired": "Orca Mobile Relay を使用するにはサインインしてください。",
-          "relayUnavailable": "このビルドでは Orca Relay を利用できません。ローカルネットワークをご利用ください。",
+          "relayUnavailable": "このビルドでは Orca Relay を利用できません。LAN をご利用ください。",
           "signInAgain": "再サインイン",
-          "localTitle": "ローカルネットワーク"
+          "localTitle": "LAN"
         },
         "MobilePairingSetupSection": {
           "title": "スマートフォンをペアリング",
@@ -11035,7 +11035,7 @@
             "preview": "プレビュー",
             "stable": "安定版"
           },
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network."
+          "relayDegradedNotice": "Relay に接続できませんでした — このコードは LAN または Tailscale でのみ動作します。"
         },
         "MobilePage": {
           "e17393c6a3": "スマートフォンプレビュー",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5468,7 +5468,7 @@
           "dfbc12c8c8": "USB 장치와 통신하는 하드웨어 디버깅 및 장치 도구입니다.",
           "bf51e4a542": "USB 장치",
           "f903bf20b5": "네트워크의 개발 서버를 검색하고 액세스합니다.",
-          "e7bb06007c": "로컬 네트워크",
+          "e7bb06007c": "LAN",
           "4a73f5217a": "다른 로컬 앱을 제어하는 ​​스크립트를 위한 Apple 이벤트.",
           "e119f0d66b": "자동화",
           "7ca17b62c8": "프로젝트, 워크트리 또는 심볼릭 링크된 파일이 macOS 보호 폴더에 닿을 때 권장됩니다.",
@@ -5939,7 +5939,7 @@
           "668016be7a": "컴퓨터와 휴대폰에서.",
           "1dc87a7fbc": "Tailscale",
           "51d29927eb": "설치",
-          "9fc5d203ff": "Orca Mobile은 이 컴퓨터에 직접 연결됩니다. 동일한 로컬 네트워크가 아닌 곳에서 사용하려면 컴퓨터와 휴대폰을 동일한 개인 오버레이 네트워크에 놓은 다음 해당 네트워크 주소를 선택하여 QR 코드를 생성하세요.",
+          "9fc5d203ff": "Orca Mobile은 이 컴퓨터에 직접 연결됩니다. 동일한 LAN이 아닌 곳에서 사용하려면 컴퓨터와 휴대폰을 동일한 개인 오버레이 네트워크에 놓은 다음 해당 네트워크 주소를 선택하여 QR 코드를 생성하세요.",
           "39fad211d9": "tailnet을 사용하여 Wi-Fi 외부에서 연결",
           "a9db5d771d": "네트워크 인터페이스 새로 고침",
           "b2c384cfd6": "인터페이스를 찾을 수 없습니다.",
@@ -5970,7 +5970,7 @@
           "6436e56546": "모바일 페어링을 위한 QR 코드",
           "1b1b70279a": "아직 페어링된 기기가 없습니다.",
           "1592afcc7a": "아직 페어링된 기기가 없습니다. Orca 모바일 앱으로 QR 코드를 스캔하세요.",
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network. Regenerate to try again."
+          "relayDegradedNotice": "Relay에 연결할 수 없습니다 — 이 코드는 LAN 또는 Tailscale에서만 작동합니다. 다시 생성해 보세요."
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub 릴리스",
@@ -7603,14 +7603,14 @@
         "developer": {
           "permissions": {
             "search": {
-              "3363889768": "로컬 네트워크, USB 및 블루투스",
+              "3363889768": "LAN, USB 및 블루투스",
               "6c82846f66": "장치",
               "11653d3f42": "mdns",
               "78a10b826f": "Bonjour",
               "e3fbc48083": "블루투스",
               "c4a4a02ea4": "USB",
               "fa3239cd42": "로컬 네트워크",
-              "acad3d4743": "terminal 세션에서 사용되는 장치 및 로컬 네트워크 도구를 허용합니다.",
+              "acad3d4743": "terminal 세션에서 사용되는 장치 도구와 LAN 액세스를 허용합니다.",
               "3e0131e45d": "icloud",
               "ce07159ff5": "데스크탑",
               "a0c19119fb": "다운로드",
@@ -9287,9 +9287,9 @@
           "anywhereTitle": "Orca Relay",
           "anywhereDescription": "휴대폰이 모바일 네트워크 또는 모든 Wi‑Fi에서 연결 가능합니다. 로그인이 필요합니다.",
           "signInRequired": "Orca Mobile Relay를 사용하려면 로그인하세요.",
-          "relayUnavailable": "이 빌드에서는 Orca Relay를 사용할 수 없습니다. 로컬 네트워크를 사용하세요.",
+          "relayUnavailable": "이 빌드에서는 Orca Relay를 사용할 수 없습니다. LAN을 사용하세요.",
           "signInAgain": "다시 로그인",
-          "localTitle": "로컬 네트워크"
+          "localTitle": "LAN"
         },
         "MobilePairingSetupSection": {
           "title": "휴대폰 페어링",
@@ -11035,7 +11035,7 @@
             "preview": "미리 보기",
             "stable": "안정 버전"
           },
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network."
+          "relayDegradedNotice": "Relay에 연결할 수 없습니다 — 이 코드는 LAN 또는 Tailscale에서만 작동합니다."
         },
         "MobilePage": {
           "e17393c6a3": "휴대폰 미리보기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5468,7 +5468,7 @@
           "dfbc12c8c8": "与 USB 设备通信的硬件调试和设备工具。",
           "bf51e4a542": "USB 设备",
           "f903bf20b5": "发现和访问网络上的开发服务器。",
-          "e7bb06007c": "本地网络",
+          "e7bb06007c": "局域网",
           "4a73f5217a": "用于控制其他本地应用程序的脚本的 Apple 事件。",
           "e119f0d66b": "自动化",
           "7ca17b62c8": "当项目、worktree 或符号链接文件会访问 macOS 受保护文件夹时推荐启用。",
@@ -5939,7 +5939,7 @@
           "668016be7a": "在您的计算机和手机上。",
           "1dc87a7fbc": "Tailscale",
           "51d29927eb": "安装",
-          "9fc5d203ff": "Orca 手机端 直接连接到此计算机。要在远离同一本地网络的地方使用它，请将您的计算机和手机置于同一私有覆盖网络上，然后使用所选的网络地址生成二维码。",
+          "9fc5d203ff": "Orca 手机端 直接连接到此计算机。要在远离同一局域网的地方使用它，请将您的计算机和手机置于同一私有覆盖网络上，然后使用所选的网络地址生成二维码。",
           "39fad211d9": "使用尾网连接 Wi-Fi 外部",
           "a9db5d771d": "刷新网络接口",
           "b2c384cfd6": "没有找到接口",
@@ -5970,7 +5970,7 @@
           "6436e56546": "用于手机配对的二维码",
           "1b1b70279a": "尚未配对任何设备。",
           "1592afcc7a": "尚未配对任何设备。使用 Orca 手机应用程序扫描二维码。",
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network. Regenerate to try again."
+          "relayDegradedNotice": "无法连接 Relay — 此二维码仅在局域网或 Tailscale 内可用。请重新生成后再试。"
         },
         "MobileSettingsPane": {
           "9a3c280e49": "GitHub 发布",
@@ -7603,14 +7603,14 @@
         "developer": {
           "permissions": {
             "search": {
-              "3363889768": "本地网络、USB 和蓝牙",
+              "3363889768": "局域网、USB 和蓝牙",
               "6c82846f66": "设备",
               "11653d3f42": "域名服务器",
               "78a10b826f": "你好",
               "e3fbc48083": "蓝牙",
               "c4a4a02ea4": "USB",
-              "fa3239cd42": "本地网络",
-              "acad3d4743": "允许从终端会话使用设备和本地网络工具。",
+              "fa3239cd42": "局域网",
+              "acad3d4743": "允许从终端会话使用设备工具和局域网访问。",
               "3e0131e45d": "云",
               "ce07159ff5": "桌面",
               "a0c19119fb": "下载",
@@ -9287,9 +9287,9 @@
           "anywhereTitle": "Orca Relay",
           "anywhereDescription": "手机可通过蜂窝网络或任意 Wi‑Fi 连接。需要登录。",
           "signInRequired": "请登录以使用 Orca Mobile Relay。",
-          "relayUnavailable": "此版本不支持 Orca Relay。请使用本地网络。",
+          "relayUnavailable": "此版本不支持 Orca Relay。请使用局域网。",
           "signInAgain": "重新登录",
-          "localTitle": "本地网络"
+          "localTitle": "局域网"
         },
         "MobilePairingSetupSection": {
           "title": "配对手机",
@@ -11035,7 +11035,7 @@
             "preview": "预览版",
             "stable": "稳定版"
           },
-          "relayDegradedNotice": "Relay couldn’t be reached — this code only works on your local network."
+          "relayDegradedNotice": "无法连接 Relay — 此二维码仅在局域网或 Tailscale 内可用。"
         },
         "MobilePage": {
           "e17393c6a3": "手机预览",


### PR DESCRIPTION
## Summary

Rename "Local Network" to "LAN" in mobile pairing connection options, developer permissions label, and related descriptions for improved clarity. Updates descriptions to mention Tailscale alongside LAN as a connectivity option.

## Screenshots

UI text changes visible in:
- Mobile pairing connection mode selector (now shows "LAN" instead of "Local network")
- Developer Permissions pane (permission label changed to "LAN")
- Error/information messages mentioning LAN connectivity

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Test files updated: MobileHero.test.tsx, MobilePage.test.tsx, MobilePane.test.tsx, MobilePairingConnectionOptions.test.tsx to match new label text and updated relay-degraded messaging.

## AI Review Report

This is a straightforward text rename with no functional logic changes. Label updates are consistent across mobile, renderer, and localization layers (5 languages). Search keywords preserved "local network" as an alias for backwards discoverability. Cross-platform compatibility confirmed — rename applies uniformly across macOS, Linux, and Windows pairing flows. No network handling, permission logic, or sensitive operations modified.

## Security Audit

No security implications. Changes are UI text updates only. NSLocalNetworkUsageDescription in iOS app.json updated to user-facing message "LAN" rather than implementation detail "local network."

## Notes

- Localization synchronized across en, es, ja, ko, zh
- Search keywords support both "lan" and "local network" for UX migration
- Descriptions now consistently pair "LAN or Tailscale" as connectivity options
- Comment in terminal-osc-link-routing updated (Windows LAN shares reference)