### PR TITLE
feat(diagnostics): census renderer heap collections at high-water so OOMs self-attribute

### DIFF
--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -172,4 +172,42 @@ describe('renderer crash diagnostics', () => {
       diagnostics.recordRendererCrashBreadcrumb('renderer_bootstrap_started')
     ).not.toThrow()
   })
+
+  describe('shouldRecordHeapCensus', () => {
+    const mem = (used: number, limit: number) => ({
+      usedJSHeapSize: used,
+      jsHeapSizeLimit: limit
+    })
+
+    it('is false below the high-water fraction', () => {
+      expect(diagnostics.shouldRecordHeapCensus(mem(50, 100), 10_000_000, 0)).toBe(false)
+    })
+
+    it('fires the first census immediately at high-water (lastCensusAt === 0)', () => {
+      expect(diagnostics.shouldRecordHeapCensus(mem(90, 100), 10_000, 0)).toBe(true)
+    })
+
+    it('fires exactly at the high-water fraction', () => {
+      // 0.85 is not below 0.85, so it proceeds.
+      expect(diagnostics.shouldRecordHeapCensus(mem(85, 100), 10_000_000, 0)).toBe(true)
+    })
+
+    it('re-fires once the throttle interval has elapsed after a prior census', () => {
+      const now = 10_000_000
+      expect(diagnostics.shouldRecordHeapCensus(mem(90, 100), now, now - 5 * 60_000)).toBe(true)
+    })
+
+    it('throttles repeat censuses within the interval', () => {
+      const now = 10_000_000
+      expect(diagnostics.shouldRecordHeapCensus(mem(90, 100), now, now - 60_000)).toBe(false)
+    })
+
+    it('is false when heap fields are missing', () => {
+      expect(diagnostics.shouldRecordHeapCensus({}, 10_000_000, 0)).toBe(false)
+    })
+
+    it('is false when the limit is zero (no divide-by-zero)', () => {
+      expect(diagnostics.shouldRecordHeapCensus(mem(0, 0), 10_000_000, 0)).toBe(false)
+    })
+  })
 })

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -8,6 +8,13 @@ import { recordRendererCrashBreadcrumb } from './crash-breadcrumb-recorder'
 const RENDERER_MEMORY_SAMPLE_INTERVAL_MS = 60_000
 const BYTES_PER_MEGABYTE = 1024 * 1024
 
+// Why: production OOMs sit at the heap ceiling for a long time before dying, so
+// a census taken once the heap crosses this fraction of its limit still lands in
+// the bundle. Throttled so a pegged renderer emits it periodically, not every sample.
+const HEAP_CENSUS_HIGH_WATER_FRACTION = 0.85
+const HEAP_CENSUS_MIN_INTERVAL_MS = 5 * 60_000
+let lastHeapCensusAt = 0
+
 type BrowserPerformanceMemory = {
   usedJSHeapSize?: number
   totalJSHeapSize?: number
@@ -112,6 +119,47 @@ function recordRendererMemory(reason: string): void {
       registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount
     })
   )
+
+  maybeRecordHeapCensus(memory, nowMs())
+}
+
+// Exposed for tests; real callers pass nowMs() (monotonic performance.now()).
+// lastCensusAt === 0 means "never censused this renderer" → fire immediately so a
+// fast leak (or a post-crash reload that re-inflates within 5 min) isn't missed.
+export function shouldRecordHeapCensus(
+  memory: BrowserPerformanceMemory,
+  now: number,
+  lastCensusAt: number
+): boolean {
+  const used = memory.usedJSHeapSize
+  const limit = memory.jsHeapSizeLimit
+  if (typeof used !== 'number' || typeof limit !== 'number' || limit <= 0) {
+    return false
+  }
+  if (used / limit < HEAP_CENSUS_HIGH_WATER_FRACTION) {
+    return false
+  }
+  return lastCensusAt === 0 || now - lastCensusAt >= HEAP_CENSUS_MIN_INTERVAL_MS
+}
+
+function maybeRecordHeapCensus(memory: BrowserPerformanceMemory, now: number): void {
+  if (!shouldRecordHeapCensus(memory, now, lastHeapCensusAt)) {
+    return
+  }
+  lastHeapCensusAt = now
+  // Why: dynamic import keeps the census's store dependency off this leaf
+  // module's hot import chain (terminal modules import this file — see below).
+  void import('./renderer-heap-census')
+    .then(({ collectRendererHeapCensus }) => {
+      recordRendererCrashBreadcrumb('renderer_heap_census', collectRendererHeapCensus())
+    })
+    .catch(() => {
+      // Census is best-effort diagnostics; never let it disrupt the sampler.
+    })
+}
+
+function nowMs(): number {
+  return typeof performance !== 'undefined' ? Math.round(performance.now()) : Date.now()
 }
 
 function getPerformanceMemory(): BrowserPerformanceMemory | undefined {

--- a/src/renderer/src/lib/renderer-heap-census.test.ts
+++ b/src/renderer/src/lib/renderer-heap-census.test.ts
@@ -1,0 +1,117 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it, vi } from 'vitest'
+import {
+  HEAP_CENSUS_MAX_COLLECTIONS,
+  HEAP_CENSUS_MIN_COLLECTION_SIZE,
+  censusFromStoreState,
+  collectRendererHeapCensus
+} from './renderer-heap-census'
+
+const storeState: Record<string, unknown> = {}
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => storeState }
+}))
+
+function record(size: number): Record<string, true> {
+  const out: Record<string, true> = {}
+  for (let i = 0; i < size; i++) {
+    out[`k${i}`] = true
+  }
+  return out
+}
+
+describe('censusFromStoreState', () => {
+  it('always reports domNodes and the total across every collection', () => {
+    const census = censusFromStoreState(
+      {
+        smallMap: record(3),
+        someArray: [1, 2, 3, 4],
+        aSet: new Set([1, 2])
+      },
+      1234
+    )
+    expect(census.domNodes).toBe(1234)
+    // total sums ALL collections regardless of the reporting threshold: 3+4+2
+    expect(census.storeCollectionsTotalEntries).toBe(9)
+  })
+
+  it('counts Maps, Sets, arrays, and plain records; ignores functions/primitives/class instances', () => {
+    class NotData {
+      value = 1
+    }
+    const census = censusFromStoreState(
+      {
+        bigRecord: record(HEAP_CENSUS_MIN_COLLECTION_SIZE),
+        bigMap: new Map(Array.from({ length: 150 }, (_, i) => [i, i])),
+        action: () => undefined,
+        scalar: 42,
+        text: 'hello',
+        classInstance: new NotData(),
+        nothing: null
+      },
+      0
+    )
+    expect(census['store.bigRecord']).toBe(HEAP_CENSUS_MIN_COLLECTION_SIZE)
+    expect(census['store.bigMap']).toBe(150)
+    // class instance / function / scalar / null contribute nothing
+    expect(census['store.action']).toBeUndefined()
+    expect(census['store.classInstance']).toBeUndefined()
+    expect(census.storeCollectionsTotalEntries).toBe(HEAP_CENSUS_MIN_COLLECTION_SIZE + 150)
+  })
+
+  it('only surfaces collections at or above the minimum size', () => {
+    const census = censusFromStoreState(
+      {
+        justUnder: record(HEAP_CENSUS_MIN_COLLECTION_SIZE - 1),
+        atThreshold: record(HEAP_CENSUS_MIN_COLLECTION_SIZE)
+      },
+      0
+    )
+    expect(census['store.justUnder']).toBeUndefined()
+    expect(census['store.atThreshold']).toBe(HEAP_CENSUS_MIN_COLLECTION_SIZE)
+    // but the small one still counts toward the total
+    expect(census.storeCollectionsTotalEntries).toBe(
+      HEAP_CENSUS_MIN_COLLECTION_SIZE - 1 + HEAP_CENSUS_MIN_COLLECTION_SIZE
+    )
+  })
+
+  it('caps the reported collections and keeps the largest (the leak stands out)', () => {
+    const state: Record<string, unknown> = {}
+    for (let i = 0; i < HEAP_CENSUS_MAX_COLLECTIONS + 5; i++) {
+      state[`c${i}`] = record(HEAP_CENSUS_MIN_COLLECTION_SIZE + i)
+    }
+    const census = censusFromStoreState(state, 0)
+    const reported = Object.keys(census).filter((k) => k.startsWith('store.'))
+    expect(reported.length).toBe(HEAP_CENSUS_MAX_COLLECTIONS)
+    // The single largest collection must be present; the smallest must be dropped.
+    const largest = HEAP_CENSUS_MIN_COLLECTION_SIZE + (HEAP_CENSUS_MAX_COLLECTIONS + 4)
+    expect(census[`store.c${HEAP_CENSUS_MAX_COLLECTIONS + 4}`]).toBe(largest)
+    expect(census['store.c0']).toBeUndefined()
+  })
+})
+
+describe('collectRendererHeapCensus', () => {
+  it('reads the live store + attached DOM node count', () => {
+    for (const key of Object.keys(storeState)) {
+      delete storeState[key]
+    }
+    storeState.bigByPaneKey = record(HEAP_CENSUS_MIN_COLLECTION_SIZE + 7)
+    storeState.setSomething = (): void => undefined
+
+    const parent = document.createElement('div')
+    const child = document.createElement('span')
+    parent.appendChild(child)
+    document.body.appendChild(parent)
+
+    const census = collectRendererHeapCensus()
+
+    expect(census['store.bigByPaneKey']).toBe(HEAP_CENSUS_MIN_COLLECTION_SIZE + 7)
+    expect(census['store.setSomething']).toBeUndefined()
+    // domNodes is the live attached count; our two nodes are included.
+    expect(typeof census.domNodes).toBe('number')
+    expect(census.domNodes as number).toBeGreaterThanOrEqual(2)
+
+    document.body.removeChild(parent)
+  })
+})

--- a/src/renderer/src/lib/renderer-heap-census.ts
+++ b/src/renderer/src/lib/renderer-heap-census.ts
@@ -1,0 +1,86 @@
+import type { CrashReportBreadcrumbData } from '../../../shared/crash-reporting'
+import { useAppStore } from '@/store'
+
+// Why: production renderer OOMs report the heap pegged at the V8 ceiling but the
+// crash bundle only carries heap *totals*, never an object breakdown — so a leak
+// can be proven yet impossible to attribute (see crash-diagnostics.ts sampler).
+// This takes a cheap, privacy-safe census (entry COUNTS only, never contents) of
+// the renderer's long-lived collections when the heap is near its limit, so the
+// next OOM report names the collection that grew instead of guessing.
+//
+// Scope: store collections + ATTACHED DOM node count. It does NOT see detached
+// DOM, closures, or non-store JS objects — for those it narrows the field (rules
+// store maps in/out, flags attached-DOM growth) rather than naming the leak; a
+// full heap snapshot would be needed to attribute those, at PII/size/perf cost.
+
+/** Only surface collections at least this large — at high-water the leaking
+ *  collection is big, and small/steady maps would just be noise. */
+export const HEAP_CENSUS_MIN_COLLECTION_SIZE = 100
+
+/** Cap the reported collections so one census can't bloat the breadcrumb buffer
+ *  it is meant to diagnose; the largest are the ones worth naming. */
+export const HEAP_CENSUS_MAX_COLLECTIONS = 20
+
+function collectionSize(value: unknown): number | null {
+  if (value instanceof Map || value instanceof Set) {
+    return value.size
+  }
+  if (Array.isArray(value)) {
+    return value.length
+  }
+  // Plain record used as a keyed map (the store's `${x}By${Y}` shape). Exclude
+  // class instances / null-proto objects so we count only data collections.
+  if (value !== null && typeof value === 'object' && isPlainRecord(value)) {
+    return Object.keys(value).length
+  }
+  return null
+}
+
+function isPlainRecord(value: object): boolean {
+  const proto = Object.getPrototypeOf(value)
+  return proto === Object.prototype || proto === null
+}
+
+/**
+ * Build the census from an already-captured store state + DOM node count. Pure
+ * and deterministic so it is unit-testable without a live renderer.
+ */
+export function censusFromStoreState(
+  state: Record<string, unknown>,
+  domNodeCount: number
+): CrashReportBreadcrumbData {
+  const sized: { key: string; size: number }[] = []
+  let collectionsTotalEntries = 0
+
+  for (const [key, value] of Object.entries(state)) {
+    const size = collectionSize(value)
+    if (size === null) {
+      continue
+    }
+    collectionsTotalEntries += size
+    if (size >= HEAP_CENSUS_MIN_COLLECTION_SIZE) {
+      sized.push({ key, size })
+    }
+  }
+
+  sized.sort((a, b) => b.size - a.size)
+
+  const census: CrashReportBreadcrumbData = {
+    domNodes: domNodeCount,
+    storeCollectionsTotalEntries: collectionsTotalEntries
+  }
+  for (const { key, size } of sized.slice(0, HEAP_CENSUS_MAX_COLLECTIONS)) {
+    census[`store.${key}`] = size
+  }
+  return census
+}
+
+/** Live-renderer entry point: snapshot the store + DOM and build the census.
+ *  crash-diagnostics.ts imports this module dynamically (only at a high-water
+ *  sample), so the store dependency stays off its hot import chain. */
+export function collectRendererHeapCensus(): CrashReportBreadcrumbData {
+  const state = useAppStore.getState() as unknown as Record<string, unknown>
+  const domNodeCount =
+    typeof document !== 'undefined' ? document.getElementsByTagName('*').length : 0
+  return censusFromStoreState(state, domNodeCount)
+}


### PR DESCRIPTION
## Summary

Production Windows renderer OOMs report the JS heap **pegged at the 3586 MB V8 ceiling for hours** before the process dies — but the crash bundle only carries heap *totals* (`renderer_memory: usedHeapMB/totalHeapMB/heapLimitMB`), never an object breakdown. So the leak is provable yet unattributable: you can see the heap is full, not *what* filled it.

This adds a cheap, privacy-safe **heap census** that runs when the renderer heap crosses 85% of its limit, recording the entry *counts* of the renderer's long-lived collections into the diagnostic bundle. The next OOM report then names the collection that grew (e.g. `store.someMapByPaneKey=412031`, `domNodes=1_900_000`) instead of leaving us to guess.

### What it captures
- `domNodes` — attached DOM node count (catches retained editor/terminal DOM subtrees).
- `storeCollectionsTotalEntries` — sum across every store collection.
- The largest store collections (`store.<field>`), generically over the Zustand state so a *future* leaking map self-identifies too — reported only when ≥ 100 entries, capped at the 20 largest so one census can't bloat the very buffer it diagnoses.

**Counts only — never keys, values, or contents.** No PII; no cross-origin-isolation requirement (so it works where `measureUserAgentSpecificMemory()` doesn't).

### How it's gated (cheap by default)
`shouldRecordHeapCensus` gates on `usedJSHeapSize / jsHeapSizeLimit ≥ 0.85` **and** ≥ 5 min since the last census. Under normal memory the census never runs; a pegged renderer emits it periodically, not every 60 s sample. The census module is imported **dynamically** only when a high-water sample fires, so its store dependency stays off the `crash-diagnostics` leaf module's hot import chain (terminal modules import that file).

## Fix evidence
- New `renderer-heap-census.test.ts` (pure `censusFromStoreState`): counts Maps/Sets/arrays/plain-records, ignores functions/scalars/class-instances, threshold + top-N cap, always emits `domNodes` + total. `shouldRecordHeapCensus` cases in `crash-diagnostics.test.ts`: below high-water → off; at high-water past throttle → on; within throttle → off; missing heap fields → off.
- 14 tests pass; `oxlint` clean; web `tsc --noEmit` exit 0.

## ELI5
When the app runs out of memory we currently get "the box is full" but not "the box is full of *these*." This adds a quick headcount of the app's biggest internal lists — taken only when memory is nearly full — so the next crash report tells us which list ballooned. It's just counts, no private data, and it does nothing until memory is already dangerously high.

## Trade-offs
- Does **not** capture detached DOM or non-store JS objects — `getElementsByTagName('*')` counts attached nodes only. It catches the store-collection and attached-DOM/editor/terminal classes; a full heap snapshot (bigger, PII-laden, perf-heavy) is deliberately out of scope. Called out as a known limitation.
- One extra full-DOM + full-store iteration per census — bounded by the 5-min throttle and only at high-water. Negligible vs. the OOM it diagnoses.
- Purely additive diagnostics: no product behavior, API, persistence, SSH, or provider change.

## Context
This is the observability half of an investigation into a v1.4.145+ renderer-heap OOM regression (heap pegged at ceiling, reproducible per-user). Static analysis ruled the leak out of the store maps, github/PR caches, subscriptions, and native-chat transcript paths (all bounded/leak-tested) but couldn't attribute it without an object breakdown — which the reports lack. This makes the next occurrence self-attributing.

## Adversarial review
- **Round 1:** essentially clean, no hard bugs. Notes addressed: corrected a wrong clock comment (`performance.now`, not `Date.now`); made the first high-water census fire immediately (was suppressed for the first 5 min of a renderer load); documented the detached-DOM/non-store limitation in code and here; added boundary + integration test coverage.
- **Round 2:** re-review of the fixes → **CLEAN**, no regressions.
- **Loops until clean: 2.** 18 tests pass.
