### PR TITLE
Fix duplicate paired hosts in worktree run target picker

### DIFF
--- a/src/renderer/src/store/slices/repos-all-hosts.test.ts
+++ b/src/renderer/src/store/slices/repos-all-hosts.test.ts
@@ -479,7 +479,9 @@ describe('fetchReposForAllHosts', () => {
     await store.getState().fetchReposForAllHosts()
 
     expectSharedProjectMetadata(store.getState().projects, sharedProjectId)
-    expect(store.getState().projectHostSetups).toEqual(
+    const setups = store.getState().projectHostSetups
+    expect(setups).toHaveLength(2)
+    expect(setups).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           projectId: sharedProjectId,

--- a/src/renderer/src/store/slices/repos-nested-ssh-projection.test.ts
+++ b/src/renderer/src/store/slices/repos-nested-ssh-projection.test.ts
@@ -74,7 +74,9 @@ it('preserves distinct SSH execution setups behind the same runtime owner', asyn
 
   await store.getState().fetchRepos()
 
-  expect(store.getState().projectHostSetups).toEqual(
+  const setups = store.getState().projectHostSetups
+  expect(setups).toHaveLength(2)
+  expect(setups).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         id: 'direct-setup',
@@ -90,4 +92,68 @@ it('preserves distinct SSH execution setups behind the same runtime owner', asyn
       })
     ])
   )
+})
+
+it('prefers an authoritative paired-runtime setup over its repo-derived fallback', async () => {
+  const project: Project = {
+    id: `repo:${remoteRepo.id}`,
+    displayName: remoteRepo.displayName,
+    badgeColor: remoteRepo.badgeColor,
+    sourceRepoIds: [remoteRepo.id],
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const setup: ProjectHostSetup = {
+    id: remoteRepo.id,
+    projectId: project.id,
+    hostId: 'local',
+    repoId: remoteRepo.id,
+    path: remoteRepo.path,
+    displayName: remoteRepo.displayName,
+    setupState: 'ready',
+    setupMethod: 'legacy-repo',
+    createdAt: 1,
+    updatedAt: 1
+  }
+  runtimeEnvironmentCall.mockImplementation(({ method }: { method: string }) => {
+    if (method === 'repo.list') {
+      return Promise.resolve({
+        id: 'repo-list',
+        ok: true,
+        result: { repos: [remoteRepo] },
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+    }
+    if (method === 'project.list') {
+      return Promise.resolve({
+        id: 'project-list',
+        ok: true,
+        result: { projects: [project] },
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+    }
+    if (method === 'projectHostSetup.list') {
+      return Promise.resolve({
+        id: 'setup-list',
+        ok: true,
+        result: { setups: [setup] },
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+    }
+    throw new Error(`Unexpected method ${method}`)
+  })
+  const store = createTestStore()
+  store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+  await store.getState().fetchRepos()
+
+  expect(store.getState().projectHostSetups).toEqual([
+    {
+      ...setup,
+      hostId: 'runtime:env-1',
+      executionHostId: 'runtime:env-1',
+      runtimeOwnerEnvironmentId: 'env-1',
+      connectionId: null
+    }
+  ])
 })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -613,9 +613,9 @@ function mergeProjectHostSetupCompatibility(
   derived: Pick<RepoSlice, 'projects' | 'projectHostSetups'>,
   fetched: ProjectHostSetupProjection
 ): Pick<RepoSlice, 'projects' | 'projectHostSetups'> {
-  const fetchedSetupOwners = new Set(fetched.setups.map(getProjectHostSetupOwnerKey))
+  const fetchedRepoSetupKeys = new Set(fetched.setups.map(getRepoDerivedSetupKey))
   const derivedSetups = derived.projectHostSetups.filter(
-    (setup) => !fetchedSetupOwners.has(getProjectHostSetupOwnerKey(setup))
+    (setup) => !fetchedRepoSetupKeys.has(getRepoDerivedSetupKey(setup))
   )
   const projectHostSetups = mergeProjectHostSetupsByOwner(derivedSetups, fetched.setups)
   const setupProjectIds = new Set(projectHostSetups.map((setup) => setup.projectId))
@@ -626,6 +626,11 @@ function mergeProjectHostSetupCompatibility(
     ),
     projectHostSetups
   }
+}
+
+function getRepoDerivedSetupKey(setup: ProjectHostSetup): string {
+  // Why: authoritative routing provenance may be absent from the repo-derived fallback it replaces.
+  return JSON.stringify([setup.hostId, setup.repoId || setup.id])
 }
 
 function getProjectHostSetupOwnerKey(setup: ProjectHostSetup): string {


### PR DESCRIPTION
## Summary

- remove the duplicate paired-runtime row from the Create worktree “Run on” picker
- let an authoritative project-host setup replace its repo-derived compatibility fallback using stable host + repo identity
- preserve the richer routing identity used to keep distinct SSH execution setups behind the same paired runtime
- add cardinality assertions for regular paired runtimes, nested SSH setups, and local + remote all-host catalogs

The regression came from #9994: authoritative setups gained `runtimeOwnerEnvironmentId`, while repo-derived fallbacks did not. Using the richer owner key to decide fallback coverage caused both records to survive even though they represented the same setup.

## Screenshots

Before — one saved `windows 2` runtime and one authoritative setup rendered twice:

![Duplicate windows 2 rows](https://github.com/user-attachments/assets/95602dc8-47a7-49b3-b34a-514408516fa1)

After — no styling changes; the store-level integration oracle requires exactly one authoritative row for this topology.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused and broad validation:

- red-before / green-after: `repos-nested-ssh-projection.test.ts`
- 129 project-host compatibility tests passed across 10 files
- 157 repo/composer/host-registry tests passed across 22 files
- post-rebase focused run: 23 tests passed
- full lint, TypeScript, formatting, reliability manifest, localization, and max-lines ratchet passed

Full-suite note: one run reached 36,509 passing tests with two unrelated relay environment-expectation failures caused by inherited Git config entries; that file passes with a clean Git env. A clean-env rerun reached 36,510 passing tests with one unrelated concurrent E2EE keepalive flake; `remote-runtime-client.test.ts` passes in isolation (9/9). No failed full-suite test imports or exercises the changed renderer store code.

## AI Review Report

The review traced the live topology and confirmed there is one saved runtime, one remote repo, and one authoritative setup. It checked the main regression risks:

- **Nested SSH:** distinct `executionHostId` setups behind one runtime remain separate; the test now asserts exact cardinality of two, with no synthetic third fallback.
- **Older servers:** when project-host APIs are unavailable, the repo-derived fallback remains present; existing capability coverage passes.
- **Multi-host catalogs:** host identity remains part of fallback coverage, and the all-host test asserts one local plus one remote setup.
- **Authority:** fetched project-host metadata remains authoritative; only its compatibility fallback is removed.
- **Performance:** merge complexity stays linear and duplicate downstream rows are eliminated.

Cross-platform review found no OS-specific branches, shortcuts, shell behavior, filesystem operations, or path parsing in the change. Windows, macOS, Linux, SSH, and paired-runtime paths remain opaque catalog data; the Windows path shown in the report is not normalized or rewritten.

## Security Audit

No new input handling, command execution, filesystem access, auth, secrets, dependencies, IPC, or network behavior. The change only compares already-hydrated in-memory setup identity fields. No follow-up security work is needed.

## Notes

Regression risk is low but concentrated in catalog identity. The fix deliberately uses a narrower key only to decide whether an authoritative record covers a repo-derived fallback; authoritative-to-authoritative merging still uses the richer runtime/execution-host identity from #9994. This avoids undoing nested SSH routing while removing the duplicate UI row.

This is client-side and protocol-compatible: updated clients work with both old servers (repo fallback) and current servers (authoritative setup), while older clients can continue showing the duplicate until upgraded.
