### PR TITLE
feat(rate-limits): add Gemini 3.6 Flash and 3.5 Flash-Lite bucket names

### DIFF
--- a/src/main/rate-limits/gemini-bucket-formatting.ts
+++ b/src/main/rate-limits/gemini-bucket-formatting.ts
@@ -1,6 +1,9 @@
 import type { RateLimitBucket, RateLimitWindow } from '../../shared/rate-limit-types'
 
 const MODEL_ID_TO_BUCKET_NAME: Record<string, string> = {
+  'gemini-3.6-flash': '3.6 Flash',
+  'gemini-3.5-flash': '3.5 Flash',
+  'gemini-3.5-flash-lite': '3.5 Flash Lite',
   'gemini-3.1-pro': '3.1 Pro',
   'gemini-3.1-flash': '3.1 Flash',
   'gemini-3.1-flash-lite': '3.1 Flash Lite',


### PR DESCRIPTION
Adds bucket-name mappings for the new GA Gemini models so the rate-limit UI labels them correctly instead of falling back to the humanized model id.

Additive only: the existing 2.5 / 3.1 entries stay in place so historical usage buckets keep their labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)