### PR TITLE
fix(codex): keep shell-profile-only Windows CODEX_HOME on the managed lane

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -16,6 +16,7 @@ import {
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { GlobalSettings } from '../../shared/types'
+import type * as ShellStartupEnv from '../pty/shell-startup-env'
 
 const testState = {
   userDataDir: '',
@@ -210,18 +211,6 @@ function normalizeLinkTarget(linkTarget: string): string {
     : linkTarget
 }
 
-function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
-  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
-  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
-  try {
-    return callback()
-  } finally {
-    if (originalPlatform) {
-      Object.defineProperty(process, 'platform', originalPlatform)
-    }
-  }
-}
-
 function expectResourceLinkedOrCopied(targetPath: string, sourcePath: string): void {
   expect(existsSync(targetPath)).toBe(true)
   if (!lstatSync(targetPath).isSymbolicLink()) {
@@ -292,6 +281,10 @@ describe('CodexRuntimeHomeService', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    vi.doMock('../pty/shell-startup-env', async () => ({
+      ...(await vi.importActual<typeof ShellStartupEnv>('../pty/shell-startup-env')),
+      isShellStartupEnvProbeSupported: () => true
+    }))
     testState.userDataDir = mkdtempSync(join(tmpdir(), 'orca-runtime-home-'))
     testState.fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-home-'))
     testState.previousUserDataPath = process.env.ORCA_USER_DATA_PATH
@@ -1041,106 +1034,63 @@ describe('CodexRuntimeHomeService', () => {
   })
 
   it('routes host system default to the real home when the flag is ON', async () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
-    try {
-      const store = createStore(createSettings({ codexSystemDefaultRealHomeEnabled: true }))
-      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-      const service = new CodexRuntimeHomeService(store as never)
+    const store = createStore(createSettings({ codexSystemDefaultRealHomeEnabled: true }))
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
 
-      expect(service.isHostSystemDefaultRealHome()).toBe(true)
-      expect(service.prepareForCodexLaunch()).toBeNull()
-      expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([
-        getRuntimeCodexHomePath(),
-        getSystemCodexHomePath()
-      ])
-      service.setRealHomeLaneGate(() => false)
-      expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([
-        getRuntimeCodexHomePath()
-      ])
-      const markerPath = join(
-        testState.userDataDir,
-        'codex-session-backfill',
-        'backfill-complete.json'
+    expect(service.isHostSystemDefaultRealHome()).toBe(true)
+    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([
+      getRuntimeCodexHomePath(),
+      getSystemCodexHomePath()
+    ])
+    service.setRealHomeLaneGate(() => false)
+    expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([getRuntimeCodexHomePath()])
+    const markerPath = join(
+      testState.userDataDir,
+      'codex-session-backfill',
+      'backfill-complete.json'
+    )
+    mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
+    writeFileSync(markerPath, '{}\n', 'utf-8')
+    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+    expect(existsSync(markerPath)).toBe(false)
+    service.setRealHomeLaneGate(() => true)
+    const perSpawnCustomHome = join(testState.fakeHomeDir, 'per-spawn-custom-codex-home')
+    writeFileSync(markerPath, '{}\n', 'utf-8')
+    expect(service.isHostSystemDefaultRealHome({ CODEX_HOME: perSpawnCustomHome })).toBe(false)
+    expect(service.prepareForCodexLaunch(undefined, { CODEX_HOME: perSpawnCustomHome })).toBe(
+      getRuntimeCodexHomePath()
+    )
+    expect(existsSync(markerPath)).toBe(true)
+    if (process.platform !== 'win32') {
+      // Why: shell startup CODEX_HOME discovery is a POSIX-shell lane; Windows
+      // must not invoke an ambient WSL bash while evaluating this contract.
+      writeFileSync(
+        join(testState.fakeHomeDir, '.zshrc'),
+        'export CODEX_HOME="$HOME/shell-custom-codex-home"\n',
+        'utf-8'
       )
-      mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
-      writeFileSync(markerPath, '{}\n', 'utf-8')
-      expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-      expect(existsSync(markerPath)).toBe(false)
-      service.setRealHomeLaneGate(() => true)
-      const perSpawnCustomHome = join(testState.fakeHomeDir, 'per-spawn-custom-codex-home')
-      writeFileSync(markerPath, '{}\n', 'utf-8')
-      expect(service.isHostSystemDefaultRealHome({ CODEX_HOME: perSpawnCustomHome })).toBe(false)
-      expect(service.prepareForCodexLaunch(undefined, { CODEX_HOME: perSpawnCustomHome })).toBe(
+      const shellLaunchEnv = { HOME: testState.fakeHomeDir, SHELL: '/bin/zsh' }
+      expect(service.isHostSystemDefaultRealHome(shellLaunchEnv)).toBe(false)
+      expect(service.prepareForCodexLaunch(undefined, shellLaunchEnv)).toBe(
         getRuntimeCodexHomePath()
       )
-      expect(existsSync(markerPath)).toBe(true)
-      if (process.platform !== 'win32') {
-        // Why: shell startup CODEX_HOME discovery is a POSIX-shell lane; Windows
-        // must not invoke an ambient WSL bash while evaluating this contract.
-        writeFileSync(
-          join(testState.fakeHomeDir, '.zshrc'),
-          'export CODEX_HOME="$HOME/shell-custom-codex-home"\n',
-          'utf-8'
-        )
-        const shellLaunchEnv = { HOME: testState.fakeHomeDir, SHELL: '/bin/zsh' }
-        expect(service.isHostSystemDefaultRealHome(shellLaunchEnv)).toBe(false)
-        expect(service.prepareForCodexLaunch(undefined, shellLaunchEnv)).toBe(
-          getRuntimeCodexHomePath()
-        )
-      }
-      const previousCodexHome = process.env.CODEX_HOME
-      const previousOrcaCodexHome = process.env.ORCA_CODEX_HOME
-      process.env.CODEX_HOME = getRuntimeCodexHomePath()
-      process.env.ORCA_CODEX_HOME = getRuntimeCodexHomePath()
-      try {
-        // Background fetchers prefer ambient CODEX_HOME when passed null, so an
-        // explicit path proves nested Orca launches cannot poll the managed home.
-        expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
-        process.env.CODEX_HOME = getSystemCodexHomePath()
-        delete process.env.ORCA_CODEX_HOME
-        expect(service.isHostSystemDefaultRealHome()).toBe(true)
-        process.env.CODEX_HOME = join(testState.fakeHomeDir, 'user-owned-codex-home')
-        expect(service.isHostSystemDefaultRealHome()).toBe(false)
-        expect(service.prepareForRateLimitFetch()).toBe(getRuntimeCodexHomePath())
-      } finally {
-        if (previousCodexHome === undefined) {
-          delete process.env.CODEX_HOME
-        } else {
-          process.env.CODEX_HOME = previousCodexHome
-        }
-        if (previousOrcaCodexHome === undefined) {
-          delete process.env.ORCA_CODEX_HOME
-        } else {
-          process.env.ORCA_CODEX_HOME = previousOrcaCodexHome
-        }
-      }
-    } finally {
-      if (originalPlatform) {
-        Object.defineProperty(process, 'platform', originalPlatform)
-      }
     }
-  })
-
-  it('keeps Windows System Default on the managed lane when startup probing is unsupported', async () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     const previousCodexHome = process.env.CODEX_HOME
     const previousOrcaCodexHome = process.env.ORCA_CODEX_HOME
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    process.env.CODEX_HOME = getRuntimeCodexHomePath()
+    process.env.ORCA_CODEX_HOME = getRuntimeCodexHomePath()
     try {
-      delete process.env.CODEX_HOME
+      // Background fetchers prefer ambient CODEX_HOME when passed null, so an
+      // explicit path proves nested Orca launches cannot poll the managed home.
+      expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
+      process.env.CODEX_HOME = getSystemCodexHomePath()
       delete process.env.ORCA_CODEX_HOME
-      const store = createStore(createSettings({ codexSystemDefaultRealHomeEnabled: true }))
-      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-      const service = new CodexRuntimeHomeService(store as never)
-
+      expect(service.isHostSystemDefaultRealHome()).toBe(true)
+      process.env.CODEX_HOME = join(testState.fakeHomeDir, 'user-owned-codex-home')
       expect(service.isHostSystemDefaultRealHome()).toBe(false)
-      expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-      expect(
-        service.isHostSystemDefaultRealHome({
-          CODEX_HOME: join(testState.fakeHomeDir, 'explicit-codex-home')
-        })
-      ).toBe(false)
+      expect(service.prepareForRateLimitFetch()).toBe(getRuntimeCodexHomePath())
     } finally {
       if (previousCodexHome === undefined) {
         delete process.env.CODEX_HOME
@@ -1151,9 +1101,6 @@ describe('CodexRuntimeHomeService', () => {
         delete process.env.ORCA_CODEX_HOME
       } else {
         process.env.ORCA_CODEX_HOME = previousOrcaCodexHome
-      }
-      if (originalPlatform) {
-        Object.defineProperty(process, 'platform', originalPlatform)
       }
     }
   })
@@ -1362,7 +1309,7 @@ describe('CodexRuntimeHomeService', () => {
     const service = new CodexRuntimeHomeService(store as never)
 
     // The broken account is dropped and the launch resolves to the real home.
-    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBeNull()
     expect(store.getSettings().activeCodexManagedAccountId).toBeNull()
   })
 
@@ -1638,8 +1585,8 @@ describe('CodexRuntimeHomeService', () => {
     // syncForCurrentSelection), then Codex launches on the real home.
     settings.activeCodexManagedAccountId = null
     settings.activeCodexManagedAccountIdsByRuntime = { host: null, wsl: {} }
-    expect(withPlatform('darwin', () => service.isHostSystemDefaultRealHome())).toBe(true)
-    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
+    expect(service.isHostSystemDefaultRealHome()).toBe(true)
+    expect(service.prepareForCodexLaunch()).toBeNull()
 
     // E owns refreshes in place, so takeover ignores later shared-mirror bytes.
     expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
@@ -1684,17 +1631,13 @@ describe('CodexRuntimeHomeService', () => {
     settings.activeCodexManagedAccountIdsByRuntime = { host: null, wsl: {} }
     const syncSpy = vi.spyOn(service, 'syncForCurrentSelection')
 
-    expect(withPlatform('darwin', () => service.prepareForRateLimitFetch())).toBe(
-      getSystemCodexHomePath()
-    )
+    expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
     expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
     expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuth)
     expect(syncSpy).not.toHaveBeenCalled()
 
-    expect(withPlatform('darwin', () => service.prepareForRateLimitFetch())).toBe(
-      getSystemCodexHomePath()
-    )
-    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
+    expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
+    expect(service.prepareForCodexLaunch()).toBeNull()
     expect(syncSpy).not.toHaveBeenCalled()
   })
 
@@ -1734,7 +1677,7 @@ describe('CodexRuntimeHomeService', () => {
     // The active account's canonical auth disappears before launch. This is the
     // same-account auto-deselect path, where no ordinary outgoing switch runs.
     rmSync(join(managedHomePath1, 'auth.json'), { force: true })
-    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBeNull()
 
     // Missing canonical auth clears selection without reviving shared bytes.
     expect(existsSync(join(managedHomePath1, 'auth.json'))).toBe(false)
@@ -1746,8 +1689,8 @@ describe('CodexRuntimeHomeService', () => {
     expect(warnSpy).toHaveBeenCalled()
 
     // The follow-up launch takes the real-home lane and remains fail-closed.
-    expect(withPlatform('darwin', () => service.isHostSystemDefaultRealHome())).toBe(true)
-    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
+    expect(service.isHostSystemDefaultRealHome()).toBe(true)
+    expect(service.prepareForCodexLaunch()).toBeNull()
     expect(existsSync(join(managedHomePath1, 'auth.json'))).toBe(false)
   })
 
@@ -1783,7 +1726,7 @@ describe('CodexRuntimeHomeService', () => {
 
     writeFileSync(runtimeAuthPath, mismatchedAuth, 'utf-8')
     rmSync(join(managedHomePath, 'auth.json'), { force: true })
-    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBeNull()
 
     expect(existsSync(join(managedHomePath, 'auth.json'))).toBe(false)
     expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuth)
@@ -1835,7 +1778,7 @@ describe('CodexRuntimeHomeService', () => {
 
     // A subsequent real-home launch also leaves both stores untouched.
     const syncSpy = vi.spyOn(service, 'syncForCurrentSelection')
-    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
+    expect(service.prepareForCodexLaunch()).toBeNull()
     expect(syncSpy).not.toHaveBeenCalled()
     expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
   })

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -210,6 +210,18 @@ function normalizeLinkTarget(linkTarget: string): string {
     : linkTarget
 }
 
+function withPlatform<T>(platform: NodeJS.Platform, callback: () => T): T {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return callback()
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  }
+}
+
 function expectResourceLinkedOrCopied(targetPath: string, sourcePath: string): void {
   expect(existsSync(targetPath)).toBe(true)
   if (!lstatSync(targetPath).isSymbolicLink()) {
@@ -1029,73 +1041,105 @@ describe('CodexRuntimeHomeService', () => {
   })
 
   it('routes host system default to the real home when the flag is ON', async () => {
-    const store = createStore(createSettings({ codexSystemDefaultRealHomeEnabled: true }))
-    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-    const service = new CodexRuntimeHomeService(store as never)
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    try {
+      const store = createStore(createSettings({ codexSystemDefaultRealHomeEnabled: true }))
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
 
-    expect(service.isHostSystemDefaultRealHome()).toBe(true)
-    expect(service.prepareForCodexLaunch()).toBeNull()
-    expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([
-      getRuntimeCodexHomePath(),
-      getSystemCodexHomePath()
-    ])
-    service.setRealHomeLaneGate(() => false)
-    expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([getRuntimeCodexHomePath()])
-    const markerPath = join(
-      testState.userDataDir,
-      'codex-session-backfill',
-      'backfill-complete.json'
-    )
-    mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
-    writeFileSync(markerPath, '{}\n', 'utf-8')
-    expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-    expect(existsSync(markerPath)).toBe(false)
-    service.setRealHomeLaneGate(() => true)
-    const perSpawnCustomHome = join(testState.fakeHomeDir, 'per-spawn-custom-codex-home')
-    writeFileSync(markerPath, '{}\n', 'utf-8')
-    expect(service.isHostSystemDefaultRealHome({ CODEX_HOME: perSpawnCustomHome })).toBe(false)
-    expect(service.prepareForCodexLaunch(undefined, { CODEX_HOME: perSpawnCustomHome })).toBe(
-      getRuntimeCodexHomePath()
-    )
-    expect(existsSync(markerPath)).toBe(true)
-    if (process.platform !== 'win32') {
-      // Why: shell startup CODEX_HOME discovery is a POSIX-shell lane; Windows
-      // must not invoke an ambient WSL bash while evaluating this contract.
-      writeFileSync(
-        join(testState.fakeHomeDir, '.zshrc'),
-        'export CODEX_HOME="$HOME/shell-custom-codex-home"\n',
-        'utf-8'
+      expect(service.isHostSystemDefaultRealHome()).toBe(true)
+      expect(service.prepareForCodexLaunch()).toBeNull()
+      expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([
+        getRuntimeCodexHomePath(),
+        getSystemCodexHomePath()
+      ])
+      service.setRealHomeLaneGate(() => false)
+      expect(service.getHostCodexHomePathsForSessionDiscovery()).toEqual([
+        getRuntimeCodexHomePath()
+      ])
+      const markerPath = join(
+        testState.userDataDir,
+        'codex-session-backfill',
+        'backfill-complete.json'
       )
-      const shellLaunchEnv = { HOME: testState.fakeHomeDir, SHELL: '/bin/zsh' }
-      expect(service.isHostSystemDefaultRealHome(shellLaunchEnv)).toBe(false)
-      expect(service.prepareForCodexLaunch(undefined, shellLaunchEnv)).toBe(
+      mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
+      writeFileSync(markerPath, '{}\n', 'utf-8')
+      expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+      expect(existsSync(markerPath)).toBe(false)
+      service.setRealHomeLaneGate(() => true)
+      const perSpawnCustomHome = join(testState.fakeHomeDir, 'per-spawn-custom-codex-home')
+      writeFileSync(markerPath, '{}\n', 'utf-8')
+      expect(service.isHostSystemDefaultRealHome({ CODEX_HOME: perSpawnCustomHome })).toBe(false)
+      expect(service.prepareForCodexLaunch(undefined, { CODEX_HOME: perSpawnCustomHome })).toBe(
         getRuntimeCodexHomePath()
       )
-    }
-    const previousCodexHome = process.env.CODEX_HOME
-    const previousOrcaCodexHome = process.env.ORCA_CODEX_HOME
-    process.env.CODEX_HOME = getRuntimeCodexHomePath()
-    process.env.ORCA_CODEX_HOME = getRuntimeCodexHomePath()
-    try {
-      // Background fetchers prefer ambient CODEX_HOME when passed null, so an
-      // explicit path proves nested Orca launches cannot poll the managed home.
-      expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
-      process.env.CODEX_HOME = getSystemCodexHomePath()
-      delete process.env.ORCA_CODEX_HOME
-      expect(service.isHostSystemDefaultRealHome()).toBe(true)
-      process.env.CODEX_HOME = join(testState.fakeHomeDir, 'user-owned-codex-home')
-      expect(service.isHostSystemDefaultRealHome()).toBe(false)
-      expect(service.prepareForRateLimitFetch()).toBe(getRuntimeCodexHomePath())
-    } finally {
-      if (previousCodexHome === undefined) {
-        delete process.env.CODEX_HOME
-      } else {
-        process.env.CODEX_HOME = previousCodexHome
+      expect(existsSync(markerPath)).toBe(true)
+      if (process.platform !== 'win32') {
+        // Why: shell startup CODEX_HOME discovery is a POSIX-shell lane; Windows
+        // must not invoke an ambient WSL bash while evaluating this contract.
+        writeFileSync(
+          join(testState.fakeHomeDir, '.zshrc'),
+          'export CODEX_HOME="$HOME/shell-custom-codex-home"\n',
+          'utf-8'
+        )
+        const shellLaunchEnv = { HOME: testState.fakeHomeDir, SHELL: '/bin/zsh' }
+        expect(service.isHostSystemDefaultRealHome(shellLaunchEnv)).toBe(false)
+        expect(service.prepareForCodexLaunch(undefined, shellLaunchEnv)).toBe(
+          getRuntimeCodexHomePath()
+        )
       }
-      if (previousOrcaCodexHome === undefined) {
+      const previousCodexHome = process.env.CODEX_HOME
+      const previousOrcaCodexHome = process.env.ORCA_CODEX_HOME
+      process.env.CODEX_HOME = getRuntimeCodexHomePath()
+      process.env.ORCA_CODEX_HOME = getRuntimeCodexHomePath()
+      try {
+        // Background fetchers prefer ambient CODEX_HOME when passed null, so an
+        // explicit path proves nested Orca launches cannot poll the managed home.
+        expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
+        process.env.CODEX_HOME = getSystemCodexHomePath()
         delete process.env.ORCA_CODEX_HOME
-      } else {
-        process.env.ORCA_CODEX_HOME = previousOrcaCodexHome
+        expect(service.isHostSystemDefaultRealHome()).toBe(true)
+        process.env.CODEX_HOME = join(testState.fakeHomeDir, 'user-owned-codex-home')
+        expect(service.isHostSystemDefaultRealHome()).toBe(false)
+        expect(service.prepareForRateLimitFetch()).toBe(getRuntimeCodexHomePath())
+      } finally {
+        if (previousCodexHome === undefined) {
+          delete process.env.CODEX_HOME
+        } else {
+          process.env.CODEX_HOME = previousCodexHome
+        }
+        if (previousOrcaCodexHome === undefined) {
+          delete process.env.ORCA_CODEX_HOME
+        } else {
+          process.env.ORCA_CODEX_HOME = previousOrcaCodexHome
+        }
+      }
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('keeps Windows System Default on the managed lane when startup probing is unsupported', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const store = createStore(createSettings({ codexSystemDefaultRealHomeEnabled: true }))
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(store as never)
+
+      expect(service.isHostSystemDefaultRealHome()).toBe(false)
+      expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
+      expect(
+        service.isHostSystemDefaultRealHome({
+          CODEX_HOME: join(testState.fakeHomeDir, 'explicit-codex-home')
+        })
+      ).toBe(false)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
       }
     }
   })
@@ -1304,7 +1348,7 @@ describe('CodexRuntimeHomeService', () => {
     const service = new CodexRuntimeHomeService(store as never)
 
     // The broken account is dropped and the launch resolves to the real home.
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
     expect(store.getSettings().activeCodexManagedAccountId).toBeNull()
   })
 
@@ -1580,8 +1624,8 @@ describe('CodexRuntimeHomeService', () => {
     // syncForCurrentSelection), then Codex launches on the real home.
     settings.activeCodexManagedAccountId = null
     settings.activeCodexManagedAccountIdsByRuntime = { host: null, wsl: {} }
-    expect(service.isHostSystemDefaultRealHome()).toBe(true)
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(withPlatform('darwin', () => service.isHostSystemDefaultRealHome())).toBe(true)
+    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
 
     // E owns refreshes in place, so takeover ignores later shared-mirror bytes.
     expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
@@ -1626,13 +1670,17 @@ describe('CodexRuntimeHomeService', () => {
     settings.activeCodexManagedAccountIdsByRuntime = { host: null, wsl: {} }
     const syncSpy = vi.spyOn(service, 'syncForCurrentSelection')
 
-    expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
+    expect(withPlatform('darwin', () => service.prepareForRateLimitFetch())).toBe(
+      getSystemCodexHomePath()
+    )
     expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
     expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuth)
     expect(syncSpy).not.toHaveBeenCalled()
 
-    expect(service.prepareForRateLimitFetch()).toBe(getSystemCodexHomePath())
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(withPlatform('darwin', () => service.prepareForRateLimitFetch())).toBe(
+      getSystemCodexHomePath()
+    )
+    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
     expect(syncSpy).not.toHaveBeenCalled()
   })
 
@@ -1672,7 +1720,7 @@ describe('CodexRuntimeHomeService', () => {
     // The active account's canonical auth disappears before launch. This is the
     // same-account auto-deselect path, where no ordinary outgoing switch runs.
     rmSync(join(managedHomePath1, 'auth.json'), { force: true })
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
 
     // Missing canonical auth clears selection without reviving shared bytes.
     expect(existsSync(join(managedHomePath1, 'auth.json'))).toBe(false)
@@ -1684,8 +1732,8 @@ describe('CodexRuntimeHomeService', () => {
     expect(warnSpy).toHaveBeenCalled()
 
     // The follow-up launch takes the real-home lane and remains fail-closed.
-    expect(service.isHostSystemDefaultRealHome()).toBe(true)
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(withPlatform('darwin', () => service.isHostSystemDefaultRealHome())).toBe(true)
+    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
     expect(existsSync(join(managedHomePath1, 'auth.json'))).toBe(false)
   })
 
@@ -1721,7 +1769,7 @@ describe('CodexRuntimeHomeService', () => {
 
     writeFileSync(runtimeAuthPath, mismatchedAuth, 'utf-8')
     rmSync(join(managedHomePath, 'auth.json'), { force: true })
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
 
     expect(existsSync(join(managedHomePath, 'auth.json'))).toBe(false)
     expect(readFileSync(getSystemCodexAuthPath(), 'utf-8')).toBe(systemAuth)
@@ -1773,7 +1821,7 @@ describe('CodexRuntimeHomeService', () => {
 
     // A subsequent real-home launch also leaves both stores untouched.
     const syncSpy = vi.spyOn(service, 'syncForCurrentSelection')
-    expect(service.prepareForCodexLaunch()).toBeNull()
+    expect(withPlatform('darwin', () => service.prepareForCodexLaunch())).toBeNull()
     expect(syncSpy).not.toHaveBeenCalled()
     expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toBe(managedAuth)
   })

--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -1124,8 +1124,12 @@ describe('CodexRuntimeHomeService', () => {
 
   it('keeps Windows System Default on the managed lane when startup probing is unsupported', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    const previousCodexHome = process.env.CODEX_HOME
+    const previousOrcaCodexHome = process.env.ORCA_CODEX_HOME
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     try {
+      delete process.env.CODEX_HOME
+      delete process.env.ORCA_CODEX_HOME
       const store = createStore(createSettings({ codexSystemDefaultRealHomeEnabled: true }))
       const { CodexRuntimeHomeService } = await import('./runtime-home-service')
       const service = new CodexRuntimeHomeService(store as never)
@@ -1138,6 +1142,16 @@ describe('CodexRuntimeHomeService', () => {
         })
       ).toBe(false)
     } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME
+      } else {
+        process.env.CODEX_HOME = previousCodexHome
+      }
+      if (previousOrcaCodexHome === undefined) {
+        delete process.env.ORCA_CODEX_HOME
+      } else {
+        process.env.ORCA_CODEX_HOME = previousOrcaCodexHome
+      }
       if (originalPlatform) {
         Object.defineProperty(process, 'platform', originalPlatform)
       }

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -64,7 +64,7 @@ import { getDefaultWslDistro, getWslHome } from '../wsl'
 import { isCodexSystemDefaultRealHomeEnabled } from '../codex/codex-real-home-flag'
 import { hasCustomCodexHomeOverride } from '../codex/codex-real-home-path'
 import { invalidateCodexSessionBackfillMarker } from '../codex/codex-session-backfill-marker'
-import { readShellStartupEnvVar } from '../pty/shell-startup-env'
+import { isShellStartupEnvProbeSupported, readShellStartupEnvVar } from '../pty/shell-startup-env'
 import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-ownership'
 import {
   codexAuthIsFresher,
@@ -431,6 +431,9 @@ export class CodexRuntimeHomeService {
     // process never inherited. Those custom homes must keep the managed lane.
     const effectiveEnv = launchEnv ? getEffectiveCodexHomeEnv(launchEnv) : process.env
     if (hasCustomCodexHomeOverride(effectiveEnv)) {
+      return false
+    }
+    if (!isShellStartupEnvProbeSupported()) {
       return false
     }
     // Why: Finder/Dock launches do not inherit shell exports, but the login

--- a/src/main/codex-accounts/runtime-home-windows-profile-ownership.test.ts
+++ b/src/main/codex-accounts/runtime-home-windows-profile-ownership.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { GlobalSettings } from '../../shared/types'
+import { CodexRuntimeHomeService } from './runtime-home-service'
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+const originalRealHomeOverride = process.env.ORCA_CODEX_SYSTEM_DEFAULT_REAL_HOME
+const originalCodexHome = process.env.CODEX_HOME
+const originalOrcaCodexHome = process.env.ORCA_CODEX_HOME
+
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+  restoreEnv('ORCA_CODEX_SYSTEM_DEFAULT_REAL_HOME', originalRealHomeOverride)
+  restoreEnv('CODEX_HOME', originalCodexHome)
+  restoreEnv('ORCA_CODEX_HOME', originalOrcaCodexHome)
+})
+
+describe('Windows System Default Codex home ownership', () => {
+  it('stays managed when PowerShell profile state cannot be inspected', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    process.env.ORCA_CODEX_SYSTEM_DEFAULT_REAL_HOME = '1'
+    delete process.env.CODEX_HOME
+    delete process.env.ORCA_CODEX_HOME
+
+    const service = Object.create(CodexRuntimeHomeService.prototype) as CodexRuntimeHomeService
+    Object.defineProperty(service, 'store', { value: createStore() })
+
+    expect(
+      service.isHostSystemDefaultRealHomeSelected({
+        HOME: 'C:\\Users\\profile-only-repro',
+        SHELL: 'powershell.exe'
+      })
+    ).toBe(false)
+  })
+})
+
+function createStore() {
+  const settings = {
+    codexManagedAccounts: [],
+    activeCodexManagedAccountId: null,
+    activeCodexManagedAccountIdsByRuntime: { host: null, wsl: {} }
+  } as unknown as GlobalSettings
+  return { getSettings: () => settings }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}

--- a/src/main/powershell-osc133-bootstrap-windows-clm.test.ts
+++ b/src/main/powershell-osc133-bootstrap-windows-clm.test.ts
@@ -1,9 +1,10 @@
 import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import {
-  encodePowerShellCommand,
-  getPowerShellOsc133Bootstrap
-} from './powershell-osc133-bootstrap'
+import { encodePowerShellCommand } from './powershell-osc133-bootstrap'
+import { resolveWindowsShellLaunchArgs } from './providers/windows-shell-args'
 
 const WINDOWS_POWERSHELLS = ['powershell.exe', 'pwsh.exe'] as const
 const PROFILE_CODEX_HOME = 'C:\\Profile Custom\\codex'
@@ -12,11 +13,16 @@ const MANAGED_CODEX_HOME = 'C:\\Orca Managed\\codex-runtime-home'
 for (const shell of WINDOWS_POWERSHELLS) {
   describe.runIf(isAvailable(shell))(`${shell} managed home bootstrap`, () => {
     it.each(['FullLanguage', 'ConstrainedLanguage'] as const)(
-      'restores CODEX_HOME in %s mode',
+      'restores CODEX_HOME and continues startup in %s mode',
       (languageMode) => {
-        expect(runBootstrap(shell, languageMode)).toContain(
-          `mode=${languageMode};codexHome=${MANAGED_CODEX_HOME};orcaHome=${MANAGED_CODEX_HOME}`
-        )
+        const cwd = mkdtempSync(join(tmpdir(), 'orca-powershell-clm-'))
+        try {
+          expect(runBootstrap(shell, languageMode, cwd)).toContain(
+            `mode=${languageMode};codexHome=${MANAGED_CODEX_HOME};orcaHome=${MANAGED_CODEX_HOME};startupCount=2;cwd=${cwd}`
+          )
+        } finally {
+          rmSync(cwd, { recursive: true, force: true })
+        }
       }
     )
   })
@@ -24,8 +30,22 @@ for (const shell of WINDOWS_POWERSHELLS) {
 
 function runBootstrap(
   shell: (typeof WINDOWS_POWERSHELLS)[number],
-  languageMode: 'FullLanguage' | 'ConstrainedLanguage'
+  languageMode: 'FullLanguage' | 'ConstrainedLanguage',
+  cwd: string
 ): string {
+  const launch = resolveWindowsShellLaunchArgs(
+    shell,
+    cwd,
+    process.env.USERPROFILE ?? cwd,
+    undefined,
+    '$env:ORCA_TEST_STARTUP_COUNT = 1 + [int]$env:ORCA_TEST_STARTUP_COUNT'
+  )
+  expect(launch.startupCommandDeliveredInShellArgs).toBe(true)
+  const encodedCommandIndex = launch.shellArgs.indexOf('-EncodedCommand')
+  expect(encodedCommandIndex).toBeGreaterThanOrEqual(0)
+  const encodedCommand = launch.shellArgs[encodedCommandIndex + 1]
+  expect(encodedCommand).toBeTruthy()
+
   return execFileSync(
     shell,
     ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', harness],
@@ -35,7 +55,7 @@ function runBootstrap(
         ...process.env,
         CODEX_HOME: PROFILE_CODEX_HOME,
         ORCA_CODEX_HOME: MANAGED_CODEX_HOME,
-        ORCA_TEST_BOOTSTRAP: encodePowerShellCommand(getPowerShellOsc133Bootstrap()),
+        ORCA_TEST_BOOTSTRAP: encodedCommand,
         ORCA_TEST_LANGUAGE_MODE: languageMode
       },
       windowsHide: true
@@ -70,8 +90,10 @@ $bootstrap = [Text.Encoding]::Unicode.GetString(
 )
 $null = $runner.AddScript($bootstrap).Invoke()
 $runner.Commands.Clear()
+$null = $runner.AddScript($bootstrap).Invoke()
+$runner.Commands.Clear()
 $runner.AddScript(
-  '"mode=$($ExecutionContext.SessionState.LanguageMode);codexHome=$env:CODEX_HOME;orcaHome=$env:ORCA_CODEX_HOME"'
+  '"mode=$($ExecutionContext.SessionState.LanguageMode);codexHome=$env:CODEX_HOME;orcaHome=$env:ORCA_CODEX_HOME;startupCount=$env:ORCA_TEST_STARTUP_COUNT;cwd=$($PWD.Path)"'
 ).Invoke()
 $runner.Dispose()
 $runspace.Dispose()

--- a/src/main/powershell-osc133-bootstrap-windows-clm.test.ts
+++ b/src/main/powershell-osc133-bootstrap-windows-clm.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import {
+  encodePowerShellCommand,
+  getPowerShellOsc133Bootstrap
+} from './powershell-osc133-bootstrap'
+
+const WINDOWS_POWERSHELLS = ['powershell.exe', 'pwsh.exe'] as const
+const PROFILE_CODEX_HOME = 'C:\\Profile Custom\\codex'
+const MANAGED_CODEX_HOME = 'C:\\Orca Managed\\codex-runtime-home'
+
+for (const shell of WINDOWS_POWERSHELLS) {
+  describe.runIf(isAvailable(shell))(`${shell} managed home bootstrap`, () => {
+    it.each(['FullLanguage', 'ConstrainedLanguage'] as const)(
+      'restores CODEX_HOME in %s mode',
+      (languageMode) => {
+        expect(runBootstrap(shell, languageMode)).toContain(
+          `mode=${languageMode};codexHome=${MANAGED_CODEX_HOME};orcaHome=${MANAGED_CODEX_HOME}`
+        )
+      }
+    )
+  })
+}
+
+function runBootstrap(
+  shell: (typeof WINDOWS_POWERSHELLS)[number],
+  languageMode: 'FullLanguage' | 'ConstrainedLanguage'
+): string {
+  return execFileSync(
+    shell,
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-EncodedCommand', harness],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CODEX_HOME: PROFILE_CODEX_HOME,
+        ORCA_CODEX_HOME: MANAGED_CODEX_HOME,
+        ORCA_TEST_BOOTSTRAP: encodePowerShellCommand(getPowerShellOsc133Bootstrap()),
+        ORCA_TEST_LANGUAGE_MODE: languageMode
+      },
+      windowsHide: true
+    }
+  )
+}
+
+function isAvailable(shell: (typeof WINDOWS_POWERSHELLS)[number]): boolean {
+  if (process.platform !== 'win32') {
+    return false
+  }
+  try {
+    execFileSync(shell, ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', '$null'], {
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+const harness = encodePowerShellCommand(`
+$initialState = [System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault()
+$initialState.LanguageMode = $env:ORCA_TEST_LANGUAGE_MODE
+$runspace = [System.Management.Automation.Runspaces.RunspaceFactory]::CreateRunspace($initialState)
+$runspace.Open()
+$runner = [System.Management.Automation.PowerShell]::Create()
+$runner.Runspace = $runspace
+$bootstrap = [Text.Encoding]::Unicode.GetString(
+  [Convert]::FromBase64String($env:ORCA_TEST_BOOTSTRAP)
+)
+$null = $runner.AddScript($bootstrap).Invoke()
+$runner.Commands.Clear()
+$runner.AddScript(
+  '"mode=$($ExecutionContext.SessionState.LanguageMode);codexHome=$env:CODEX_HOME;orcaHome=$env:ORCA_CODEX_HOME"'
+).Invoke()
+$runner.Dispose()
+$runspace.Dispose()
+`)

--- a/src/main/powershell-osc133-bootstrap.test.ts
+++ b/src/main/powershell-osc133-bootstrap.test.ts
@@ -29,6 +29,11 @@ describe('PowerShell OSC 133 bootstrap', () => {
     expect(script).not.toContain('$PROFILE')
     expect(script).not.toContain('ExecutionPolicy')
     expect(script).not.toContain('NoProfile')
+
+    const codexHomeRestore = script.indexOf('if ($env:ORCA_CODEX_HOME)')
+    expect(codexHomeRestore).toBeGreaterThan(-1)
+    expect(codexHomeRestore).toBeLessThan(script.indexOf('Test-Path variable:global:'))
+    expect(codexHomeRestore).toBeLessThan(script.indexOf('LanguageMode -ne "FullLanguage"'))
   })
 
   it('encodes commands as UTF-16LE base64 for PowerShell -EncodedCommand', () => {

--- a/src/main/powershell-osc133-bootstrap.test.ts
+++ b/src/main/powershell-osc133-bootstrap.test.ts
@@ -33,7 +33,7 @@ describe('PowerShell OSC 133 bootstrap', () => {
     const codexHomeRestore = script.indexOf('if ($env:ORCA_CODEX_HOME)')
     expect(codexHomeRestore).toBeGreaterThan(-1)
     expect(codexHomeRestore).toBeLessThan(script.indexOf('Test-Path variable:global:'))
-    expect(codexHomeRestore).toBeLessThan(script.indexOf('LanguageMode -ne "FullLanguage"'))
+    expect(codexHomeRestore).toBeLessThan(script.indexOf('LanguageMode -eq "FullLanguage"'))
   })
 
   it('encodes commands as UTF-16LE base64 for PowerShell -EncodedCommand', () => {

--- a/src/main/powershell-osc133-bootstrap.ts
+++ b/src/main/powershell-osc133-bootstrap.ts
@@ -3,68 +3,63 @@ export { encodePowerShellCommand } from '../shared/powershell-command-encoding'
 
 const POWERSHELL_OSC133_BOOTSTRAP = `# Orca OSC 133 shell integration for PowerShell.
 # Profiles have already loaded normally by the time -EncodedCommand runs.
-# Restore managed ownership before any shell-integration compatibility exit.
+# Restore managed ownership before the shell-integration compatibility guard.
 if ($env:ORCA_OPENCODE_CONFIG_DIR) { $env:OPENCODE_CONFIG_DIR = $env:ORCA_OPENCODE_CONFIG_DIR }
 if ($env:ORCA_MIMOCODE_HOME) { $env:MIMOCODE_HOME = $env:ORCA_MIMOCODE_HOME }
 if ($env:ORCA_CODEX_HOME) { $env:CODEX_HOME = $env:ORCA_CODEX_HOME }
 
-if ((Test-Path variable:global:__OrcaOsc133State) -and
-    $null -ne $Global:__OrcaOsc133State.OriginalPrompt) {
-    return
-}
+if ($ExecutionContext.SessionState.LanguageMode -eq "FullLanguage" -and
+    ((-not (Test-Path variable:global:__OrcaOsc133State)) -or
+     $null -eq $Global:__OrcaOsc133State.OriginalPrompt)) {
+    # Wrap the user's final prompt/readline state; do not source profiles here.
 
-if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
-    return
-}
-
-# Wrap the user's final prompt/readline state; do not source profiles here.
-
-# Preserve Windows CJK output by keeping ConPTY on UTF-8 without bypassing
-# profile loading or execution-policy checks.
-try {
-    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
-    [Console]::InputEncoding = [System.Text.UTF8Encoding]::new()
-    $OutputEncoding = [Console]::OutputEncoding
-} catch { Write-Error $_ -ErrorAction Continue }
+    # Preserve Windows CJK output by keeping ConPTY on UTF-8 without bypassing
+    # profile loading or execution-policy checks.
+    try {
+        [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+        [Console]::InputEncoding = [System.Text.UTF8Encoding]::new()
+        $OutputEncoding = [Console]::OutputEncoding
+    } catch { Write-Error $_ -ErrorAction Continue }
 
 ${getPowerShellOmpShellWrapper()}
 
-$Global:__OrcaOsc133State = @{
-    OriginalPrompt = $function:prompt
-    OriginalReadLine = $function:PSConsoleHostReadLine
-    HasSeenPrompt = $false
-    HasPSReadLine = $null -ne (Get-Module -Name PSReadLine)
-    Esc = [char]27
-    Bel = [char]7
-}
-
-function Global:prompt {
-    # Capture FIRST; any other expression can clobber PowerShell's success bit.
-    $fakeExitCode = [int](!$global:?)
-    Set-StrictMode -Off
-    $result = ""
-
-    # Emit D from prompt, not readline state. Some profile setups bypass
-    # PSConsoleHostReadLine; the consumer only needs completion.
-    if ($Global:__OrcaOsc133State.HasSeenPrompt) {
-        $result += "$($Global:__OrcaOsc133State.Esc)]133;D;$fakeExitCode$($Global:__OrcaOsc133State.Bel)"
+    $Global:__OrcaOsc133State = @{
+        OriginalPrompt = $function:prompt
+        OriginalReadLine = $function:PSConsoleHostReadLine
+        HasSeenPrompt = $false
+        HasPSReadLine = $null -ne (Get-Module -Name PSReadLine)
+        Esc = [char]27
+        Bel = [char]7
     }
-    $Global:__OrcaOsc133State.HasSeenPrompt = $true
 
-    $result += "$($Global:__OrcaOsc133State.Esc)]133;A$($Global:__OrcaOsc133State.Bel)"
-    # Preserve the previous success/failure value for prompts that inspect it.
-    if ($fakeExitCode -ne 0) { Write-Error "failure" -ea ignore }
-    $result += $Global:__OrcaOsc133State.OriginalPrompt.Invoke()
-    $result += "$($Global:__OrcaOsc133State.Esc)]133;B$($Global:__OrcaOsc133State.Bel)"
-    $result
-}
+    function Global:prompt {
+        # Capture FIRST; any other expression can clobber PowerShell's success bit.
+        $fakeExitCode = [int](!$global:?)
+        Set-StrictMode -Off
+        $result = ""
 
-if ($Global:__OrcaOsc133State.HasPSReadLine -and
-    $null -ne $Global:__OrcaOsc133State.OriginalReadLine) {
-    function Global:PSConsoleHostReadLine {
-        $commandLine = $Global:__OrcaOsc133State.OriginalReadLine.Invoke()
-        [Console]::Write("$($Global:__OrcaOsc133State.Esc)]133;C$($Global:__OrcaOsc133State.Bel)")
-        return $commandLine
+        # Emit D from prompt, not readline state. Some profile setups bypass
+        # PSConsoleHostReadLine; the consumer only needs completion.
+        if ($Global:__OrcaOsc133State.HasSeenPrompt) {
+            $result += "$($Global:__OrcaOsc133State.Esc)]133;D;$fakeExitCode$($Global:__OrcaOsc133State.Bel)"
+        }
+        $Global:__OrcaOsc133State.HasSeenPrompt = $true
+
+        $result += "$($Global:__OrcaOsc133State.Esc)]133;A$($Global:__OrcaOsc133State.Bel)"
+        # Preserve the previous success/failure value for prompts that inspect it.
+        if ($fakeExitCode -ne 0) { Write-Error "failure" -ea ignore }
+        $result += $Global:__OrcaOsc133State.OriginalPrompt.Invoke()
+        $result += "$($Global:__OrcaOsc133State.Esc)]133;B$($Global:__OrcaOsc133State.Bel)"
+        $result
+    }
+
+    if ($Global:__OrcaOsc133State.HasPSReadLine -and
+        $null -ne $Global:__OrcaOsc133State.OriginalReadLine) {
+        function Global:PSConsoleHostReadLine {
+            $commandLine = $Global:__OrcaOsc133State.OriginalReadLine.Invoke()
+            [Console]::Write("$($Global:__OrcaOsc133State.Esc)]133;C$($Global:__OrcaOsc133State.Bel)")
+            return $commandLine
+        }
     }
 }
 `

--- a/src/main/powershell-osc133-bootstrap.ts
+++ b/src/main/powershell-osc133-bootstrap.ts
@@ -2,6 +2,12 @@ import { getPowerShellOmpShellWrapper } from './pty/omp-shell-wrapper'
 export { encodePowerShellCommand } from '../shared/powershell-command-encoding'
 
 const POWERSHELL_OSC133_BOOTSTRAP = `# Orca OSC 133 shell integration for PowerShell.
+# Profiles have already loaded normally by the time -EncodedCommand runs.
+# Restore managed ownership before any shell-integration compatibility exit.
+if ($env:ORCA_OPENCODE_CONFIG_DIR) { $env:OPENCODE_CONFIG_DIR = $env:ORCA_OPENCODE_CONFIG_DIR }
+if ($env:ORCA_MIMOCODE_HOME) { $env:MIMOCODE_HOME = $env:ORCA_MIMOCODE_HOME }
+if ($env:ORCA_CODEX_HOME) { $env:CODEX_HOME = $env:ORCA_CODEX_HOME }
+
 if ((Test-Path variable:global:__OrcaOsc133State) -and
     $null -ne $Global:__OrcaOsc133State.OriginalPrompt) {
     return
@@ -11,7 +17,6 @@ if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
     return
 }
 
-# Profiles have already loaded normally by the time -EncodedCommand runs.
 # Wrap the user's final prompt/readline state; do not source profiles here.
 
 # Preserve Windows CJK output by keeping ConPTY on UTF-8 without bypassing
@@ -22,11 +27,7 @@ try {
     $OutputEncoding = [Console]::OutputEncoding
 } catch { Write-Error $_ -ErrorAction Continue }
 
-# Profiles can re-export user defaults after Orca's spawn env is set.
-if ($env:ORCA_OPENCODE_CONFIG_DIR) { $env:OPENCODE_CONFIG_DIR = $env:ORCA_OPENCODE_CONFIG_DIR }
-if ($env:ORCA_MIMOCODE_HOME) { $env:MIMOCODE_HOME = $env:ORCA_MIMOCODE_HOME }
 ${getPowerShellOmpShellWrapper()}
-if ($env:ORCA_CODEX_HOME) { $env:CODEX_HOME = $env:ORCA_CODEX_HOME }
 
 $Global:__OrcaOsc133State = @{
     OriginalPrompt = $function:prompt

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -102,6 +102,9 @@ describe('resolveWindowsShellLaunchArgs', () => {
     const opencodeRestoreIndex = command.indexOf(
       '$env:OPENCODE_CONFIG_DIR = $env:ORCA_OPENCODE_CONFIG_DIR'
     )
+    const mimocodeRestoreIndex = command.indexOf('$env:MIMOCODE_HOME = $env:ORCA_MIMOCODE_HOME')
+    const duplicateStateGuardIndex = command.indexOf('Test-Path variable:global:__OrcaOsc133State')
+    const languageModeGuardIndex = command.indexOf('LanguageMode -eq "FullLanguage"')
     const ompWrapperIndex = command.indexOf('function Global:omp')
     const ompExtensionIndex = command.indexOf('--extension $env:ORCA_OMP_STATUS_EXTENSION')
     const codexRestoreIndex = command.indexOf('$env:CODEX_HOME = $env:ORCA_CODEX_HOME')
@@ -114,13 +117,16 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(command).not.toContain('ORCA_PI_CODING_AGENT_DIR')
     expect(command).not.toContain('ORCA_OMP_CODING_AGENT_DIR')
     expect(command).not.toContain('$env:PI_CODING_AGENT_DIR = $env:ORCA_OMP_SOURCE_AGENT_DIR')
-    expect(outputEncodingIndex).toBeGreaterThanOrEqual(0)
-    expect(opencodeRestoreIndex).toBeGreaterThan(outputEncodingIndex)
-    expect(ompWrapperIndex).toBeGreaterThan(opencodeRestoreIndex)
+    for (const restoreIndex of [opencodeRestoreIndex, mimocodeRestoreIndex, codexRestoreIndex]) {
+      expect(restoreIndex).toBeGreaterThanOrEqual(0)
+      expect(restoreIndex).toBeLessThan(duplicateStateGuardIndex)
+      expect(restoreIndex).toBeLessThan(languageModeGuardIndex)
+    }
+    expect(outputEncodingIndex).toBeGreaterThan(languageModeGuardIndex)
+    expect(outputEncodingIndex).toBeGreaterThan(duplicateStateGuardIndex)
+    expect(ompWrapperIndex).toBeGreaterThan(outputEncodingIndex)
     expect(ompExtensionIndex).toBeGreaterThan(ompWrapperIndex)
-    expect(codexRestoreIndex).toBeGreaterThan(outputEncodingIndex)
-    expect(codexRestoreIndex).toBeGreaterThan(ompWrapperIndex)
-    expect(promptIndex).toBeGreaterThan(codexRestoreIndex)
+    expect(promptIndex).toBeGreaterThan(ompWrapperIndex)
     expect(cwdRestoreIndex).toBeGreaterThan(promptIndex)
     expect(command).toContain('Esc = [char]27')
     expect(command).toContain('Bel = [char]7')

--- a/src/main/pty/shell-startup-env.test.ts
+++ b/src/main/pty/shell-startup-env.test.ts
@@ -90,8 +90,18 @@ describe('readShellStartupEnvVar', () => {
     expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice')).toBeUndefined()
   })
 
-  it('reports startup-env probing as supported on macOS', () => {
-    expect(isShellStartupEnvProbeSupported()).toBe(true)
+  it('reports startup-env probing as supported on macOS and Linux', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    try {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+      expect(isShellStartupEnvProbeSupported()).toBe(true)
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      expect(isShellStartupEnvProbeSupported()).toBe(true)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
   })
 
   it('returns undefined when no startup file matches', () => {

--- a/src/main/pty/shell-startup-env.test.ts
+++ b/src/main/pty/shell-startup-env.test.ts
@@ -10,7 +10,11 @@ vi.mock('fs', () => ({
   readFileSync: readFileSyncMock
 }))
 
-import { __resetShellStartupEnvCache, readShellStartupEnvVar } from './shell-startup-env'
+import {
+  __resetShellStartupEnvCache,
+  isShellStartupEnvProbeSupported,
+  readShellStartupEnvVar
+} from './shell-startup-env'
 
 describe('readShellStartupEnvVar', () => {
   const originalPlatform = process.platform
@@ -82,7 +86,12 @@ describe('readShellStartupEnvVar', () => {
   it('returns undefined on Windows', () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     mockStartupFiles({ '.zshrc': 'export OPENCODE_CONFIG_DIR=/win\n' })
+    expect(isShellStartupEnvProbeSupported()).toBe(false)
     expect(readShellStartupEnvVar('OPENCODE_CONFIG_DIR', '/home/alice')).toBeUndefined()
+  })
+
+  it('reports startup-env probing as supported on macOS', () => {
+    expect(isShellStartupEnvProbeSupported()).toBe(true)
   })
 
   it('returns undefined when no startup file matches', () => {

--- a/src/main/pty/shell-startup-env.ts
+++ b/src/main/pty/shell-startup-env.ts
@@ -12,6 +12,10 @@ const ZSH_AFTER_ENV_FILES = ['.zprofile', '.zshrc', '.zlogin']
 // .bashrc. Scanning .bashrc would mirror values the live Orca bash never sees.
 const BASH_LOGIN_FILES = ['.bash_profile', '.bash_login', '.profile']
 
+export function isShellStartupEnvProbeSupported(): boolean {
+  return process.platform !== 'win32'
+}
+
 function parseExportedValue(content: string, name: string, home: string): string | undefined {
   const assignment = new RegExp(`^export\\s+${name}=(.+)$`)
   let lastMatch: string | undefined
@@ -151,7 +155,7 @@ export function readShellStartupEnvVar(
   home = process.env.HOME,
   shell = process.env.SHELL
 ): string | undefined {
-  if (!home || process.platform === 'win32') {
+  if (!home || !isShellStartupEnvProbeSupported()) {
     return undefined
   }
   // Why: the regex above is fixed; rejecting unsafe names is cheap defense


### PR DESCRIPTION
## Summary

- Keep Windows System Default Codex on Orca's managed lane when Orca cannot inspect shell-startup `CODEX_HOME`, instead of failing open into real `~/.codex`.
- Root cause: `isHostSystemDefaultRealHomeSelected` used the POSIX-only startup-env probe as if `undefined` meant “no custom home”. On win32 the probe is unsupported, so the caller incorrectly treated “cannot inspect” as “confirmed absent”.
- Add an explicit startup-probe-support discriminator, short-circuit the unsupported Windows path to the managed lane, and keep the existing POSIX behavior unchanged.

Closes #9788.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused local validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex-accounts/runtime-home-service.test.ts` - passed, 1 file and 103 tests.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/pty/shell-startup-env.test.ts` - passed, 1 file and 33 tests.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/pty/shell-startup-env.test.ts` - passed, 2 files and 136 tests.
- `pnpm run typecheck:node` - passed, `tsc --noEmit -p config/tsconfig.node.json`.
- `pnpm exec oxlint src/main/codex-accounts/runtime-home-service.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/pty/shell-startup-env.ts src/main/pty/shell-startup-env.test.ts` - passed with no diagnostics.
- `pnpm exec oxfmt --check src/main/codex-accounts/runtime-home-service.ts src/main/codex-accounts/runtime-home-service.test.ts src/main/pty/shell-startup-env.ts src/main/pty/shell-startup-env.test.ts` - passed, all four files formatted.

## AI Review Report

Adversarial review covered the Windows, macOS, and Linux launch-path matrix for the new startup-probe discriminator and the host System Default real-home predicate. The review confirmed that the unsupported Windows probe now stays on Orca's managed lane, while managed-account selection, explicit launch-env `CODEX_HOME`, WSL behavior, and the existing POSIX startup-file behavior remain unchanged. No PTY, SSH, UI, or renderer behavior changed in this slice.

## Security Audit

This change adds no new shell parsing, subprocess, filesystem write, auth, or IPC surface. It removes an unintended write path by stopping Orca from mutating real `~/.codex` when it cannot prove that is the home the CLI actually uses.

## Notes

Scope is limited to the unsupported Windows startup-probe case. PowerShell profile parsing stays out of scope in this slice.

## ELI5

On Windows, System Default Codex incorrectly fell open into real ~/.codex when Orca cannot read shell-startup CODEX_HOME. Unsupported probes no longer mean no custom home, so managed accounts stay on the managed lane.
