### PR TITLE
fix(mobile): unblock iOS releases

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       bump_patch_version:
-        description: 'Bump the iOS marketing version patch number before release. Tick this after a version has shipped to the App Store (the release fails fast if the current version''s train is already closed).'
+        description: 'Use the first open iOS patch version after the checked-in version, skipping versions already closed on the App Store.'
         required: false
         default: false
         type: boolean

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -30,6 +30,11 @@ jobs:
         with:
           node-version-file: package.json
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         with:
@@ -55,6 +60,9 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Test iOS release version resolution
+        run: ruby fastlane/ios_release_version_test.rb
 
       - name: Lint
         run: pnpm lint

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -16,6 +16,7 @@
 
 require "base64"
 require "json"
+require_relative "ios_release_version"
 
 default_platform(:ios)
 
@@ -66,25 +67,6 @@ def current_mobile_version(config)
   config.fetch("expo").fetch("version")
 end
 
-def truthy_option?(value)
-  %w[1 true yes on].include?(value.to_s.strip.downcase)
-end
-
-def bump_patch_version(version)
-  match = version.match(/\A(\d+)\.(\d+)\.(\d+)\z/)
-  UI.user_error!("Cannot bump non-semver mobile version '#{version}'") unless match
-
-  "#{match[1]}.#{match[2]}.#{match[3].to_i + 1}"
-end
-
-def resolve_requested_version(options, config)
-  requested = options[:version].to_s.strip
-  return requested unless requested.empty?
-
-  current_version = current_mobile_version(config)
-  truthy_option?(options[:bump_patch]) ? bump_patch_version(current_version) : current_version
-end
-
 # Returns true when `version`'s App Store train is closed to new build uploads.
 # `app` is a Spaceship::ConnectAPI::App the caller looks up (nil if lookup
 # failed). On a nil app or any API error, degrade to "open": we then proceed as
@@ -113,13 +95,7 @@ platform :ios do
   lane :prepare_release_version do |options|
     api_key = app_store_connect_api_key_from_env
     config = load_mobile_app_config
-    version = resolve_requested_version(options, config)
 
-    # Fail fast (seconds) if the resolved version's App Store train is already
-    # closed: Apple would otherwise reject the upload ~20 min later with 90186.
-    # Bumping the version is left to the human (the bump_patch input or a
-    # "Prepare mobile X" commit) so the marketing version stays a deliberate,
-    # release-notes-bearing decision rather than something CI invents.
     app =
       begin
         Spaceship::ConnectAPI::App.find(BUNDLE_ID)
@@ -127,11 +103,31 @@ platform :ios do
         UI.error("Could not look up App Store app #{BUNDLE_ID} (#{error.message}); skipping closed-train check.")
         nil
       end
+    version =
+      begin
+        IosReleaseVersion.resolve(
+          requested: options[:version],
+          bump_patch: options[:bump_patch],
+          current_version: current_mobile_version(config),
+          train_closed: ->(candidate) { version_train_closed?(app, candidate) },
+        )
+      rescue ArgumentError => error
+        UI.user_error!(error.message)
+      end
+
+    # Explicit and checked-in versions still fail fast when closed. Patch bumps
+    # skip closed trains above because workflow-only releases can outpace Git.
     if version_train_closed?(app, version)
+      retry_guidance =
+        if IosReleaseVersion.truthy?(options[:bump_patch])
+          "Use a higher release_version or land a \"Prepare mobile <version>\" commit."
+        else
+          "Re-dispatch with bump_patch_version: true (or a higher release_version), " \
+            "or land a \"Prepare mobile <version>\" commit."
+        end
       UI.user_error!(
         "iOS version #{version} is already submitted/released on the App Store and cannot accept " \
-        "new builds. Re-dispatch with bump_patch_version: true (or a higher release_version), " \
-        "or land a \"Prepare mobile <version>\" commit.",
+        "new builds. #{retry_guidance}",
       )
     end
 

--- a/mobile/fastlane/ios_release_version.rb
+++ b/mobile/fastlane/ios_release_version.rb
@@ -1,0 +1,24 @@
+module IosReleaseVersion
+  module_function
+
+  def truthy?(value)
+    %w[1 true yes on].include?(value.to_s.strip.downcase)
+  end
+
+  def bump_patch(version)
+    match = version.match(/\A(\d+)\.(\d+)\.(\d+)\z/)
+    raise ArgumentError, "Cannot bump non-semver mobile version '#{version}'" unless match
+
+    "#{match[1]}.#{match[2]}.#{match[3].to_i + 1}"
+  end
+
+  def resolve(requested:, bump_patch:, current_version:, train_closed:)
+    exact_version = requested.to_s.strip
+    return exact_version unless exact_version.empty?
+    return current_version unless truthy?(bump_patch)
+
+    candidate = bump_patch(current_version)
+    candidate = bump_patch(candidate) while train_closed.call(candidate)
+    candidate
+  end
+end

--- a/mobile/fastlane/ios_release_version_test.rb
+++ b/mobile/fastlane/ios_release_version_test.rb
@@ -1,0 +1,48 @@
+require "minitest/autorun"
+require_relative "ios_release_version"
+
+class IosReleaseVersionTest < Minitest::Test
+  def test_exact_version_wins_without_checking_trains
+    checked_versions = []
+
+    version = IosReleaseVersion.resolve(
+      requested: " 0.0.40 ",
+      bump_patch: true,
+      current_version: "0.0.32",
+      train_closed: ->(candidate) { checked_versions << candidate },
+    )
+
+    assert_equal("0.0.40", version)
+    assert_empty(checked_versions)
+  end
+
+  def test_uses_current_version_without_a_patch_bump
+    version = IosReleaseVersion.resolve(
+      requested: "",
+      bump_patch: false,
+      current_version: "0.0.32",
+      train_closed: ->(_) { flunk("should not check trains") },
+    )
+
+    assert_equal("0.0.32", version)
+  end
+
+  def test_skips_closed_patch_versions_from_a_stale_repo_version
+    closed_versions = %w[0.0.33 0.0.34]
+
+    version = IosReleaseVersion.resolve(
+      requested: "",
+      bump_patch: true,
+      current_version: "0.0.32",
+      train_closed: ->(candidate) { closed_versions.include?(candidate) },
+    )
+
+    assert_equal("0.0.35", version)
+  end
+
+  def test_rejects_non_semver_versions
+    error = assert_raises(ArgumentError) { IosReleaseVersion.bump_patch("0.0") }
+
+    assert_equal("Cannot bump non-semver mobile version '0.0'", error.message)
+  end
+end

--- a/mobile/src/session/mobile-native-chat-image-transcript-markers.ts
+++ b/mobile/src/session/mobile-native-chat-image-transcript-markers.ts
@@ -1,4 +1,4 @@
-// Single-sources the desktop marker logic (pure functions over shared types):
+// Single-sources the marker logic (pure functions over shared types):
 // Claude records an attached image as `[Image: source: /path]` (+ `[Image #N]`
 // prefix on the caption turn), and both render and echo reconciliation must
 // agree with desktop on how those marker turns are interpreted.
@@ -6,8 +6,8 @@ export {
   imageSourcePathFromText,
   normalizeImageTranscriptMessages,
   stripImagePromptMarker
-} from '../../../src/renderer/src/components/native-chat/native-chat-image-transcript-markers'
-import { imageSourcePathFromText } from '../../../src/renderer/src/components/native-chat/native-chat-image-transcript-markers'
+} from '../../../src/shared/native-chat-image-transcript-markers'
+import { imageSourcePathFromText } from '../../../src/shared/native-chat-image-transcript-markers'
 import { isTextBlock, type NativeChatMessage } from '../../../src/shared/native-chat-types'
 
 /** A raw (un-normalized) transcript user turn that is an image-source marker —

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -1,4 +1,4 @@
-import { stripImagePromptMarker } from './native-chat-image-transcript-markers'
+import { stripImagePromptMarker } from '../../../../shared/native-chat-image-transcript-markers'
 import {
   isImageRefBlock,
   isTextBlock,

--- a/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-assembler.ts
@@ -7,7 +7,7 @@ import {
   type NativeChatSessionStatus
 } from '../../../../shared/native-chat-types'
 import { NATIVE_CHAT_STREAMING_ID } from '../../../../shared/native-chat-streaming'
-import { normalizeImageTranscriptMessages } from './native-chat-image-transcript-markers'
+import { normalizeImageTranscriptMessages } from '../../../../shared/native-chat-image-transcript-markers'
 import { isLaunchPromptMessageId, isPendingMessageId } from './native-chat-pending'
 
 /** Messages grouped by source. Higher-priority sources (transcript > hook >

--- a/src/shared/native-chat-image-transcript-markers.test.ts
+++ b/src/shared/native-chat-image-transcript-markers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import type { NativeChatMessage } from './native-chat-types'
 import { normalizeImageTranscriptMessages } from './native-chat-image-transcript-markers'
 
 function userText(id: string, text: string): NativeChatMessage {

--- a/src/shared/native-chat-image-transcript-markers.ts
+++ b/src/shared/native-chat-image-transcript-markers.ts
@@ -1,8 +1,4 @@
-import {
-  isTextBlock,
-  type NativeChatBlock,
-  type NativeChatMessage
-} from '../../../../shared/native-chat-types'
+import { isTextBlock, type NativeChatBlock, type NativeChatMessage } from './native-chat-types'
 
 const IMAGE_SOURCE_MARKER = /^\[Image:\s*source:\s*(.+?)\]\s*$/
 const IMAGE_PROMPT_MARKER = /^\[Image #\d+\]\s*/


### PR DESCRIPTION
## Summary
- resolve patch releases by skipping App Store version trains that are already closed
- add focused release-version tests to mobile CI
- move image transcript marker logic into the Metro-visible shared source tree

## Validation
- production iOS Expo export completed successfully (4,448 modules)
- mobile tests: 2,546 passed, 2 skipped
- root and mobile typechecks
- mobile lint and formatting
- Ruby release-version tests