### PR TITLE
fix(projects): route project host setup update/delete by host-qualified identity

### DIFF
--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -394,7 +394,10 @@ describe('RepositoryHostSetupsSection', () => {
       removeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     })
 
-    expect(deleteProjectHostSetup).toHaveBeenCalledWith({ setupId: 'gpu-setup' })
+    expect(deleteProjectHostSetup).toHaveBeenCalledWith({
+      setupId: 'gpu-setup',
+      hostId: 'runtime:gpu'
+    })
     expect(openSettingsPage).not.toHaveBeenCalled()
     expect(openSettingsTarget).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx
@@ -308,6 +308,48 @@ describe('RepositoryHostSetupsSection', () => {
     expect(currentSetup?.textContent).not.toContain('Ready')
   })
 
+  it('keeps same-id setups on different hosts distinct in the current-row UI', () => {
+    const localRepo = makeRepo({
+      id: 'local-repo',
+      displayName: 'Orca',
+      path: '/Users/alice/orca'
+    })
+    const remoteRepo = makeRepo({
+      id: 'remote-repo',
+      displayName: 'Orca',
+      path: '/srv/orca',
+      executionHostId: 'runtime:hub'
+    })
+    useAppStore.setState({
+      repos: [localRepo, remoteRepo],
+      projects: [makeProject({ id: 'github:stablyai/orca' })],
+      projectHostSetups: [
+        makeSetup({
+          id: 'shared-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: 'local-repo',
+          hostId: 'local',
+          path: '/Users/alice/orca'
+        }),
+        makeSetup({
+          id: 'shared-setup',
+          projectId: 'github:stablyai/orca',
+          repoId: 'remote-repo',
+          hostId: 'runtime:hub',
+          path: '/srv/orca'
+        })
+      ]
+    })
+
+    renderSection(remoteRepo, 'shared-setup')
+
+    const currentSetups = container.querySelectorAll('[data-current="true"]')
+    expect(currentSetups).toHaveLength(1)
+    expect(currentSetups[0]?.textContent).toContain('/srv/orca')
+    expect(currentSetups[0]?.textContent).not.toContain('/Users/alice/orca')
+    expect(findButton('Open')).toBeTruthy()
+  })
+
   it('shows HUB-local setups as disconnected when their owning runtime is unreachable', () => {
     const remoteRepo = makeRepo({
       id: 'remote-repo',

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -51,6 +51,10 @@ function setupsByOwnedExecutionHost(
   return [...byHost.values()]
 }
 
+function getProjectHostSetupIdentity(setup: Pick<ProjectHostSetup, 'hostId' | 'id'>): string {
+  return JSON.stringify([setup.hostId, setup.id])
+}
+
 export function RepositoryHostSetupsSection({
   repo,
   selectedProjectSetupId,
@@ -127,7 +131,10 @@ export function RepositoryHostSetupsSection({
     hostOptions
   })
   const hostOptionById = new Map(hostOptions.map((option) => [option.id, option]))
-  const [deletingSetupId, setDeletingSetupId] = useState<string | null>(null)
+  const selectedProjectHostSetupIdentity = selectedProjectHostSetup
+    ? getProjectHostSetupIdentity(selectedProjectHostSetup)
+    : undefined
+  const [deletingSetupIdentity, setDeletingSetupIdentity] = useState<string | null>(null)
   const projectId = selectedProjectHostSetup?.projectId
   // Why: the single project pane switches host in place — set the ephemeral
   // per-project selection instead of navigating to a separate repo section.
@@ -170,13 +177,13 @@ export function RepositoryHostSetupsSection({
                 {translate('auto.components.settings.RepositoryPane.viewingHost', 'Viewing host')}
               </span>
               <Select
-                value={selectedProjectHostSetup?.id}
-                onValueChange={(setupId) => {
-                  if (setupId === selectedProjectHostSetup?.id) {
+                value={selectedProjectHostSetupIdentity}
+                onValueChange={(setupIdentity) => {
+                  if (setupIdentity === selectedProjectHostSetupIdentity) {
                     return
                   }
                   const setup = switchableProjectHostSetups.find(
-                    (candidate) => candidate.id === setupId
+                    (candidate) => getProjectHostSetupIdentity(candidate) === setupIdentity
                   )
                   if (setup) {
                     selectSetup(setup)
@@ -188,7 +195,10 @@ export function RepositoryHostSetupsSection({
                 </SelectTrigger>
                 <SelectContent>
                   {switchableProjectHostSetups.map((setup) => (
-                    <SelectItem key={setup.id} value={setup.id}>
+                    <SelectItem
+                      key={getProjectHostSetupIdentity(setup)}
+                      value={getProjectHostSetupIdentity(setup)}
+                    >
                       <span className="block min-w-0 truncate">
                         {hostOptionById.get(setup.executionHostId ?? setup.hostId)?.label ??
                           getExecutionHostLabel(setup.executionHostId ?? setup.hostId)}
@@ -209,6 +219,7 @@ export function RepositoryHostSetupsSection({
       </div>
       <div className="divide-y divide-border rounded-md border border-border">
         {projectHostSetups.map((setup) => {
+          const setupIdentity = getProjectHostSetupIdentity(setup)
           const executionHost = parseExecutionHostId(setup.executionHostId ?? setup.hostId)
           const transportHost = parseExecutionHostId(setup.hostId)
           const runtimeOwnerEnvironmentId =
@@ -272,12 +283,12 @@ export function RepositoryHostSetupsSection({
                   }
                 )
               : (hostOptionById.get(setup.hostId)?.label ?? getExecutionHostLabel(setup.hostId))
-          const isCurrentSetup = setup.id === selectedProjectHostSetup?.id
+          const isCurrentSetup = setupIdentity === selectedProjectHostSetupIdentity
           const canOpenSetup = setup.repoId.trim().length > 0
-          const canRemoveSetup = !canOpenSetup && deletingSetupId !== setup.id
+          const canRemoveSetup = !canOpenSetup && deletingSetupIdentity !== setupIdentity
           return (
             <div
-              key={setup.id}
+              key={setupIdentity}
               data-current={isCurrentSetup ? 'true' : undefined}
               className={cn(
                 'flex w-full items-start gap-3 px-3 py-2.5 text-left transition-colors',
@@ -322,9 +333,9 @@ export function RepositoryHostSetupsSection({
                   variant="outline"
                   size="sm"
                   onClick={async () => {
-                    setDeletingSetupId(setup.id)
+                    setDeletingSetupIdentity(setupIdentity)
                     await deleteProjectHostSetup({ setupId: setup.id, hostId: setup.hostId })
-                    setDeletingSetupId(null)
+                    setDeletingSetupIdentity(null)
                   }}
                 >
                   {translate('auto.components.settings.RepositoryPane.removeSetup', 'Remove')}

--- a/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx
@@ -323,7 +323,7 @@ export function RepositoryHostSetupsSection({
                   size="sm"
                   onClick={async () => {
                     setDeletingSetupId(setup.id)
-                    await deleteProjectHostSetup({ setupId: setup.id })
+                    await deleteProjectHostSetup({ setupId: setup.id, hostId: setup.hostId })
                     setDeletingSetupId(null)
                   }}
                 >

--- a/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
@@ -166,10 +166,11 @@ describe('repo slice project host setup lifecycle', () => {
   })
 
   it('deletes runtime-owned project host setups through their owning runtime', async () => {
+    const runtimeDeleteResponse = { ...runtimeSetup, hostId: 'local' }
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-delete-setup',
       ok: true,
-      result: { result: { project, setup: runtimeSetup } },
+      result: { result: { project, setup: runtimeDeleteResponse } },
       _meta: { runtimeId: 'runtime-remote' }
     })
     const store = createTestStore()
@@ -186,7 +187,12 @@ describe('repo slice project host setup lifecycle', () => {
       })
     ).resolves.toEqual({
       project,
-      setup: runtimeSetup,
+      setup: {
+        ...runtimeSetup,
+        executionHostId: 'runtime:env-1',
+        runtimeOwnerEnvironmentId: 'env-1',
+        connectionId: null
+      },
       repo: undefined
     })
 

--- a/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts
@@ -44,6 +44,13 @@ const runtimeSetup: ProjectHostSetup = {
   updatedAt: 1
 }
 
+const localSetup: ProjectHostSetup = {
+  ...runtimeSetup,
+  hostId: 'local',
+  path: '/Users/alice/project',
+  displayName: 'Local project'
+}
+
 beforeEach(() => {
   clearRuntimeCompatibilityCacheForTests()
   projectsCreateHostSetup.mockReset()
@@ -115,13 +122,14 @@ describe('repo slice project host setup lifecycle', () => {
     })
     const store = createTestStore()
     store.setState({
-      projectHostSetups: [runtimeSetup],
+      projectHostSetups: [localSetup, runtimeSetup],
       settings: { activeRuntimeEnvironmentId: null } as never
     })
 
     await expect(
       store.getState().updateProjectHostSetup({
         setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId,
         updates: { displayName: 'GPU VM renamed' }
       })
     ).resolves.toEqual({
@@ -145,6 +153,16 @@ describe('repo slice project host setup lifecycle', () => {
       },
       timeoutMs: 15_000
     })
+    expect(store.getState().projectHostSetups).toEqual([
+      localSetup,
+      {
+        ...runtimeSetup,
+        displayName: 'GPU VM renamed',
+        executionHostId: 'runtime:env-1',
+        runtimeOwnerEnvironmentId: 'env-1',
+        connectionId: null
+      }
+    ])
   })
 
   it('deletes runtime-owned project host setups through their owning runtime', async () => {
@@ -157,12 +175,15 @@ describe('repo slice project host setup lifecycle', () => {
     const store = createTestStore()
     store.setState({
       projects: [project],
-      projectHostSetups: [runtimeSetup],
+      projectHostSetups: [localSetup, runtimeSetup],
       settings: { activeRuntimeEnvironmentId: null } as never
     })
 
     await expect(
-      store.getState().deleteProjectHostSetup({ setupId: runtimeSetup.id })
+      store.getState().deleteProjectHostSetup({
+        setupId: runtimeSetup.id,
+        hostId: runtimeSetup.hostId
+      })
     ).resolves.toEqual({
       project,
       setup: runtimeSetup,
@@ -170,13 +191,43 @@ describe('repo slice project host setup lifecycle', () => {
     })
 
     expect(store.getState().projects).toEqual([project])
-    expect(store.getState().projectHostSetups).toEqual([])
+    expect(store.getState().projectHostSetups).toEqual([localSetup])
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'projectHostSetup.delete',
       params: { setupId: runtimeSetup.id },
       timeoutMs: 15_000
     })
+  })
+
+  it('keeps unique local project host setup mutations on local IPC', async () => {
+    const localOnlySetup = { ...localSetup, id: 'local-only-setup' }
+    projectsUpdateHostSetup.mockResolvedValue({
+      project,
+      setup: { ...localOnlySetup, displayName: 'Local renamed' }
+    })
+    projectsDeleteHostSetup.mockResolvedValue({ project, setup: localOnlySetup })
+    const store = createTestStore()
+    store.setState({ projectHostSetups: [localOnlySetup] })
+
+    await store.getState().updateProjectHostSetup({
+      setupId: localOnlySetup.id,
+      hostId: localOnlySetup.hostId,
+      updates: { displayName: 'Local renamed' }
+    })
+    await store.getState().deleteProjectHostSetup({
+      setupId: localOnlySetup.id,
+      hostId: localOnlySetup.hostId
+    })
+
+    expect(projectsUpdateHostSetup).toHaveBeenCalledWith({
+      setupId: localOnlySetup.id,
+      updates: { displayName: 'Local renamed' }
+    })
+    expect(projectsDeleteHostSetup).toHaveBeenCalledWith({ setupId: localOnlySetup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: expect.stringMatching(/^projectHostSetup\./) })
+    )
   })
 
   it('preserves runtime-fetched setup-only states during repo hydration', async () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -92,6 +92,14 @@ import { getRuntimeEnvironmentConnectionGeneration } from './runtime-status'
 import { SafeAutoForkSyncAttempts } from './safe-auto-fork-sync-attempts'
 import { RuntimeRepoFetchTracker } from './runtime-repo-fetch-tracker'
 
+type RendererProjectHostSetupUpdateArgs = ProjectHostSetupUpdateArgs & {
+  hostId: ProjectHostSetup['hostId']
+}
+
+type RendererProjectHostSetupDeleteArgs = ProjectHostSetupDeleteArgs & {
+  hostId: ProjectHostSetup['hostId']
+}
+
 const ERROR_TOAST_DURATION = 60_000
 const RUNTIME_CATALOG_FETCH_CONCURRENCY = 4
 const safeAutoForkSyncAttempts = new SafeAutoForkSyncAttempts()
@@ -1399,10 +1407,10 @@ export type RepoSlice = {
     args: ProjectHostSetupCreateArgs
   ) => Promise<ProjectHostSetupCreateResult | null>
   updateProjectHostSetup: (
-    args: ProjectHostSetupUpdateArgs
+    args: RendererProjectHostSetupUpdateArgs
   ) => Promise<ProjectHostSetupUpdateResult | null>
   deleteProjectHostSetup: (
-    args: ProjectHostSetupDeleteArgs
+    args: RendererProjectHostSetupDeleteArgs
   ) => Promise<ProjectHostSetupDeleteResult | null>
   setupProjectClone: (args: ProjectHostSetupCloneArgs) => Promise<ProjectHostSetupResult | null>
   addNonGitFolder: (path: string, options?: AddRepoPathRouteOptions) => Promise<Repo | null>
@@ -2541,19 +2549,17 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   updateProjectHostSetup: async (args) => {
     try {
-      const currentSetup = get().projectHostSetups.find((setup) => setup.id === args.setupId)
-      const target = currentSetup
-        ? getProjectSetupRuntimeTarget(currentSetup.hostId)
-        : { kind: 'local' as const }
+      const { hostId, ...request } = args
+      const target = getProjectSetupRuntimeTarget(hostId)
       await assertProjectHostSetupMutationRuntimeCapabilities(target)
       const result =
         target.kind === 'local'
-          ? await window.api.projects.updateHostSetup(args)
+          ? await window.api.projects.updateHostSetup(request)
           : (
               await callRuntimeRpc<{ result: ProjectHostSetupUpdateResult }>(
                 target,
                 'projectHostSetup.update',
-                args,
+                request,
                 { timeoutMs: 15_000 }
               )
             ).result
@@ -2571,8 +2577,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         projects: s.projects.some((entry) => entry.id === result.project.id)
           ? s.projects.map((entry) => (entry.id === result.project.id ? result.project : entry))
           : [...s.projects, result.project],
-        projectHostSetups: s.projectHostSetups.some((entry) => entry.id === setup.id)
-          ? s.projectHostSetups.map((entry) => (entry.id === setup.id ? setup : entry))
+        projectHostSetups: s.projectHostSetups.some(
+          (entry) => entry.hostId === setup.hostId && entry.id === setup.id
+        )
+          ? s.projectHostSetups.map((entry) =>
+              entry.hostId === setup.hostId && entry.id === setup.id ? setup : entry
+            )
           : [...s.projectHostSetups, setup]
       }))
       return { ...result, repo, setup }
@@ -2589,19 +2599,17 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   deleteProjectHostSetup: async (args) => {
     try {
-      const currentSetup = get().projectHostSetups.find((setup) => setup.id === args.setupId)
-      const target = currentSetup
-        ? getProjectSetupRuntimeTarget(currentSetup.hostId)
-        : { kind: 'local' as const }
+      const { hostId, ...request } = args
+      const target = getProjectSetupRuntimeTarget(hostId)
       await assertProjectHostSetupMutationRuntimeCapabilities(target)
       const result =
         target.kind === 'local'
-          ? await window.api.projects.deleteHostSetup(args)
+          ? await window.api.projects.deleteHostSetup(request)
           : (
               await callRuntimeRpc<{ result: ProjectHostSetupDeleteResult }>(
                 target,
                 'projectHostSetup.delete',
-                args,
+                request,
                 { timeoutMs: 15_000 }
               )
             ).result
@@ -2609,7 +2617,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const repoHostId = repo ? getRepoExecutionHostId(repo) : null
       set((s) => {
         const projectHostSetups = s.projectHostSetups.filter(
-          (setup) => setup.id !== result.setup.id
+          (setup) => setup.hostId !== result.setup.hostId || setup.id !== result.setup.id
         )
         const repos =
           repo && repoHostId

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -2613,11 +2613,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
                 { timeoutMs: 15_000 }
               )
             ).result
+      const setup = setupWithFetchedOwner(result.setup, target)
       const repo = result.repo ? repoWithFetchedOwner(result.repo, target) : undefined
       const repoHostId = repo ? getRepoExecutionHostId(repo) : null
       set((s) => {
         const projectHostSetups = s.projectHostSetups.filter(
-          (setup) => setup.hostId !== result.setup.hostId || setup.id !== result.setup.id
+          (entry) => entry.hostId !== setup.hostId || entry.id !== setup.id
         )
         const repos =
           repo && repoHostId
@@ -2636,7 +2637,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
           ...omitSparsePresetsForRepos(s, removedRepoIds)
         }
       })
-      return { ...result, repo }
+      return { ...result, repo, setup }
     } catch (err) {
       console.error('Failed to delete project host setup:', err)
       const message = err instanceof Error ? err.message : String(err)

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -3721,7 +3721,10 @@ describe('removeWorktree state cleanup', () => {
 
     // Only the orphaned runtime-owned project setup is purged; the user's SSH project is untouched.
     expect(deleteProjectHostSetup).toHaveBeenCalledTimes(1)
-    expect(deleteProjectHostSetup).toHaveBeenCalledWith({ setupId: 'setup-runtime-ssh' })
+    expect(deleteProjectHostSetup).toHaveBeenCalledWith({
+      setupId: 'setup-runtime-ssh',
+      hostId: 'ssh:runtime-ssh-orca-1'
+    })
   })
 
   it('cleans up editorDrafts for files in the removed worktree', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1314,11 +1314,11 @@ async function purgeOrphanedRuntimeSshProjects(
   )
   const orphanedSetupIds = get()
     .projectHostSetups.filter((setup) => destroyedHostIds.has(setup.hostId))
-    .map((setup) => setup.id)
+    .map((setup) => ({ id: setup.id, hostId: setup.hostId }))
   const purgedRepoIds = new Set<string>()
-  for (const setupId of orphanedSetupIds) {
+  for (const { id: setupId, hostId } of orphanedSetupIds) {
     try {
-      const result = await get().deleteProjectHostSetup({ setupId })
+      const result = await get().deleteProjectHostSetup({ setupId, hostId })
       if (result?.repo) {
         purgedRepoIds.add(result.repo.id)
       }


### PR DESCRIPTION
## Summary

- Fixes project host setup rename and remove corrupting or deleting the same-named setup on a different host in multi-host projects. `updateProjectHostSetup` and `deleteProjectHostSetup` now route and reconcile by host-qualified setup identity instead of by the bare setup id.
- Root cause: setup ids are only unique within one host's persistence, but the renderer store aggregates setups across every connected host. The update and delete paths inferred the owner with a bare-id lookup, then reconciled state with bare-id `map` and `filter`, so a same-id setup on another host could be targeted and then overwritten or removed. This change keeps host provenance in the renderer action contract and leaves the shared IPC/RPC payload unchanged.
- Threads the selected setup host through the two live delete callers, the Settings Remove button and orphaned-runtime SSH cleanup, and adds focused regression coverage for same-id local/runtime collisions.

Refs #9783. This is gap 1 only. Gaps 2-4 are already owned by https://github.com/stablyai/orca/pull/9784 .

## Screenshots

Settings > Repository host setups after the host-qualified delete payload change. Layout and copy stay unchanged.

![Repository host setups after the fix](https://raw.githubusercontent.com/rodboev/orca/screenshots/orca-9783-1-after.png)

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused local validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts` - passed, `Test Files 1 passed (1)`, `Tests 5 passed (5)`.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx` - passed, `Test Files 1 passed (1)`, `Tests 10 passed (10)`.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts` - passed, `Test Files 1 passed (1)`, `Tests 217 passed (217)`.
- `pnpm run typecheck:web` - passed, `tsc --noEmit -p config/tsconfig.tc.web.json`.
- `pnpm exec oxlint src/renderer/src/store/slices/repos.ts src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx src/renderer/src/store/slices/worktrees.ts src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx src/renderer/src/store/slices/worktrees.test.ts` - passed with no diagnostics.
- `pnpm exec oxfmt --check src/renderer/src/store/slices/repos.ts src/renderer/src/components/settings/RepositoryHostSetupsSection.tsx src/renderer/src/store/slices/worktrees.ts src/renderer/src/store/slices/repos-project-host-lifecycle.test.ts src/renderer/src/components/settings/RepositoryHostSetupsSection.test.tsx src/renderer/src/store/slices/worktrees.test.ts` - passed, `All matched files use the correct format.`

## Security Audit

- Input handling: `hostId` is existing trusted setup state, used only for renderer-local routing and in-memory reconciliation.
- Command execution, filesystem, auth, secrets, dependencies: unchanged.
- IPC and RPC: no new methods, no wider server-facing payload, no new trust boundary.
- Follow-up: none.

## Notes

- Scope is limited to `projectHostSetup` update and delete routing in the renderer. Create-path same-id follow-up, SSH snapshot scoping, runtime-event refresh, composer state, workspace-target resolution, and option filtering remain out of scope.
- Main-process persistence and the existing IPC/RPC schemas are deliberately unchanged.
- Residual risk is low because the change is limited to renderer routing and covered by deterministic unit tests.

## ELI5

Renaming or deleting a project host setup could hit the wrong host when multiple hosts share the same setup id. Updates and deletes now key by host plus setup id so multi-host projects stay correct.
