### PR TITLE
fix(terminal): preserve remote alt-screen scrollback on restore

### DIFF
--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -668,11 +668,9 @@ function sendSnapshotFrames(
       source: options.source,
       oscLinks: options.oscLinks,
       pendingEscapeTailAnsi: options.pendingEscapeTailAnsi,
-      ...(options.alternateScreen
-        ? {
-            alternateScreen: true,
-            scrollbackAnsiLength: options.scrollbackAnsiLength ?? 0
-          }
+      ...(options.alternateScreen === true ? { alternateScreen: true } : {}),
+      ...(typeof options.scrollbackAnsiLength === 'number'
+        ? { scrollbackAnsiLength: options.scrollbackAnsiLength }
         : {}),
       truncated: options.truncated === true,
       truncatedByByteBudget: options.truncatedByByteBudget === true
@@ -2106,7 +2104,10 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             oscLinks: serialized?.oscLinks,
             pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
             alternateScreen: serialized?.alternateScreen,
-            scrollbackAnsiLength: serialized?.scrollbackAnsi?.length,
+            scrollbackAnsiLength:
+              typeof serialized?.scrollbackAnsi === 'string'
+                ? serialized.scrollbackAnsi.length
+                : undefined,
             truncated: false,
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
             data: serialized?.data ?? ''
@@ -2394,8 +2395,6 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             source: serialized?.source,
             oscLinks: serialized?.oscLinks,
             pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
-            alternateScreen: serialized?.alternateScreen,
-            scrollbackAnsiLength: serialized?.scrollbackAnsi?.length,
             data: serialized?.data ?? (read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : '')
           })
           // Why: baseline for resize re-stream gating; the client already rewrapped to these cols via the initial snapshot replay.

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -77,11 +77,14 @@ type SnapshotFrameOptions = {
   source?: 'headless' | 'renderer'
   oscLinks?: TerminalOscLinkRange[]
   pendingEscapeTailAnsi?: string
+  alternateScreen?: boolean
+  scrollbackAnsiLength?: number
 }
 
 type SerializedSnapshot = {
   data: string
   scrollbackAnsi?: string
+  alternateScreen?: boolean
   cols: number
   rows: number
   seq?: number
@@ -665,6 +668,12 @@ function sendSnapshotFrames(
       source: options.source,
       oscLinks: options.oscLinks,
       pendingEscapeTailAnsi: options.pendingEscapeTailAnsi,
+      ...(options.alternateScreen
+        ? {
+            alternateScreen: true,
+            scrollbackAnsiLength: options.scrollbackAnsiLength ?? 0
+          }
+        : {}),
       truncated: options.truncated === true,
       truncatedByByteBudget: options.truncatedByByteBudget === true
     })
@@ -2096,6 +2105,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             source: serialized?.source,
             oscLinks: serialized?.oscLinks,
             pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
+            alternateScreen: serialized?.alternateScreen,
+            scrollbackAnsiLength: serialized?.scrollbackAnsi?.length,
             truncated: false,
             truncatedByByteBudget: serialized?.truncatedByByteBudget,
             data: serialized?.data ?? ''
@@ -2383,6 +2394,8 @@ export const TERMINAL_METHODS: RpcAnyMethod[] = [
             source: serialized?.source,
             oscLinks: serialized?.oscLinks,
             pendingEscapeTailAnsi: serialized?.pendingEscapeTailAnsi,
+            alternateScreen: serialized?.alternateScreen,
+            scrollbackAnsiLength: serialized?.scrollbackAnsi?.length,
             data: serialized?.data ?? (read.tail.length > 0 ? `${read.tail.join('\r\n')}\r\n` : '')
           })
           // Why: baseline for resize re-stream gating; the client already rewrapped to these cols via the initial snapshot replay.

--- a/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
@@ -48,7 +48,9 @@ describe('terminal.multiplex pending-escape-tail threading (#7329)', () => {
           cols: 80,
           rows: 24,
           // The dangling partial the emulator could not serialize.
-          pendingEscapeTailAnsi: '\x1b[3'
+          pendingEscapeTailAnsi: '\x1b[3',
+          alternateScreen: true,
+          scrollbackAnsi: 'history'
         }),
         getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
         getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
@@ -119,7 +121,9 @@ describe('terminal.multiplex pending-escape-tail threading (#7329)', () => {
         .map((frame) => decodeTerminalStreamFrame(frame))
         .find((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart)!
       expect(decodeTerminalStreamJson(snapshotStart.payload)).toMatchObject({
-        pendingEscapeTailAnsi: '\x1b[3'
+        pendingEscapeTailAnsi: '\x1b[3',
+        alternateScreen: true,
+        scrollbackAnsiLength: 'history'.length
       })
 
       runtime.cleanupSubscription('terminal-multiplex:conn-1')

--- a/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
@@ -48,9 +48,7 @@ describe('terminal.multiplex pending-escape-tail threading (#7329)', () => {
           cols: 80,
           rows: 24,
           // The dangling partial the emulator could not serialize.
-          pendingEscapeTailAnsi: '\x1b[3',
-          alternateScreen: true,
-          scrollbackAnsi: 'history'
+          pendingEscapeTailAnsi: '\x1b[3'
         }),
         getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
         getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
@@ -121,9 +119,136 @@ describe('terminal.multiplex pending-escape-tail threading (#7329)', () => {
         .map((frame) => decodeTerminalStreamFrame(frame))
         .find((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotStart)!
       expect(decodeTerminalStreamJson(snapshotStart.payload)).toMatchObject({
-        pendingEscapeTailAnsi: '\x1b[3',
+        pendingEscapeTailAnsi: '\x1b[3'
+      })
+
+      runtime.cleanupSubscription('terminal-multiplex:conn-1')
+      await dispatchPromise
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('carries requested-snapshot alternate-screen metadata through the SnapshotStart frame', async () => {
+    vi.useFakeTimers()
+    try {
+      const messages: string[] = []
+      const binaryFrames: Uint8Array<ArrayBufferLike>[] = []
+      const handlers = new Map<
+        number,
+        (frame: NonNullable<ReturnType<typeof decodeTerminalStreamFrame>>) => void
+      >()
+      const cleanups = new Map<string, () => void>()
+      const runtime = stubRuntime({
+        resolveLiveLeafForHandle: vi.fn().mockReturnValue({ ptyId: 'pty-1' }),
+        readTerminal: vi.fn().mockResolvedValue({ tail: [], truncated: false }),
+        serializeTerminalBuffer: vi
+          .fn()
+          .mockResolvedValueOnce({
+            data: 'user@host:~$ ',
+            cols: 80,
+            rows: 24
+          })
+          .mockResolvedValueOnce({
+            data: 'alternate frame',
+            cols: 80,
+            rows: 24,
+            alternateScreen: true,
+            scrollbackAnsi: 'history\r\n'
+          }),
+        getTerminalSize: vi.fn().mockReturnValue({ cols: 80, rows: 24 }),
+        getMobileDisplayMode: vi.fn().mockReturnValue('auto'),
+        getLayout: vi.fn().mockReturnValue({ seq: 1 }),
+        registerRemoteTerminalViewSubscriber: vi.fn(() => () => {}),
+        subscribeToTerminalData: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToTerminalResize: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToFitOverrideChanges: vi.fn().mockReturnValue(vi.fn()),
+        subscribeToDriverChanges: vi.fn().mockReturnValue(vi.fn()),
+        getTerminalFitOverride: vi.fn().mockReturnValue(null),
+        getDriver: vi.fn().mockReturnValue({ kind: 'idle' }),
+        registerSubscriptionCleanup: vi.fn((id: string, cleanup: () => void) => {
+          cleanups.set(id, cleanup)
+        }),
+        cleanupSubscription: vi.fn((id: string) => {
+          const cleanup = cleanups.get(id)
+          cleanups.delete(id)
+          cleanup?.()
+        }),
+        waitForTerminal: vi.fn(() => new Promise<RuntimeTerminalWait>(() => {})),
+        updateDesktopViewport: vi.fn().mockResolvedValue(true)
+      })
+      const dispatcher = new RpcDispatcher({
+        runtime,
+        methods: TERMINAL_METHODS
+      })
+
+      const dispatchPromise = dispatcher.dispatchStreaming(
+        makeRequest('terminal.multiplex', {}),
+        (msg) => messages.push(msg),
+        {
+          connectionId: 'conn-1',
+          sendBinary: (bytes) => {
+            binaryFrames.push(bytes)
+          },
+          registerBinaryStreamHandler: (streamId, handler) => {
+            handlers.set(streamId, handler)
+            return () => handlers.delete(streamId)
+          }
+        }
+      )
+
+      await vi.runOnlyPendingTimersAsync()
+      expect(messages.some((msg) => JSON.parse(msg).result?.type === 'ready')).toBe(true)
+
+      const handler = handlers.get(0)!
+      handler(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.Subscribe,
+            streamId: 0,
+            seq: 1,
+            payload: encodeTerminalStreamJson({
+              streamId: 5,
+              terminal: 'terminal-1',
+              client: { id: 'desktop-1', type: 'desktop' }
+            })
+          })
+        )!
+      )
+      for (let i = 0; i < 5; i += 1) {
+        await vi.runOnlyPendingTimersAsync()
+      }
+
+      handlers.get(5)!(
+        decodeTerminalStreamFrame(
+          encodeTerminalStreamFrame({
+            opcode: TerminalStreamOpcode.SnapshotRequest,
+            streamId: 5,
+            seq: 2,
+            payload: encodeTerminalStreamJson({
+              requestId: 99,
+              scrollbackRows: 100
+            })
+          })
+        )!
+      )
+      for (let i = 0; i < 5; i += 1) {
+        await vi.runOnlyPendingTimersAsync()
+      }
+
+      const requestedSnapshotStart = binaryFrames
+        .map((frame) => decodeTerminalStreamFrame(frame))
+        .find((frame) => {
+          if (frame?.opcode !== TerminalStreamOpcode.SnapshotStart) {
+            return false
+          }
+          const payload = decodeTerminalStreamJson<{ requestId?: unknown }>(frame.payload)
+          return payload?.requestId === 99
+        })!
+      expect(decodeTerminalStreamJson(requestedSnapshotStart.payload)).toMatchObject({
+        requestId: 99,
         alternateScreen: true,
-        scrollbackAnsiLength: 'history'.length
+        scrollbackAnsiLength: 'history\r\n'.length
       })
 
       runtime.cleanupSubscription('terminal-multiplex:conn-1')

--- a/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts
@@ -8,6 +8,7 @@ import {
   TerminalStreamOpcode,
   decodeTerminalStreamFrame,
   decodeTerminalStreamJson,
+  decodeTerminalStreamText,
   encodeTerminalStreamFrame,
   encodeTerminalStreamJson
 } from '../../../shared/terminal-stream-protocol'
@@ -250,6 +251,22 @@ describe('terminal.multiplex pending-escape-tail threading (#7329)', () => {
         alternateScreen: true,
         scrollbackAnsiLength: 'history\r\n'.length
       })
+      const requestedSnapshotStartIndex = binaryFrames.findIndex((frame) => {
+        const decoded = decodeTerminalStreamFrame(frame)
+        if (decoded?.opcode !== TerminalStreamOpcode.SnapshotStart) {
+          return false
+        }
+        const payload = decodeTerminalStreamJson<{ requestId?: unknown }>(decoded.payload)
+        return payload?.requestId === 99
+      })
+      const requestedSnapshotChunk = binaryFrames
+        .slice(requestedSnapshotStartIndex + 1)
+        .map((frame) => decodeTerminalStreamFrame(frame))
+        .find((frame) => frame?.opcode === TerminalStreamOpcode.SnapshotChunk)
+      expect(requestedSnapshotChunk).toBeTruthy()
+      expect(decodeTerminalStreamText(requestedSnapshotChunk!.payload)).toBe(
+        'history\r\nalternate frame'
+      )
 
       runtime.cleanupSubscription('terminal-multiplex:conn-1')
       await dispatchPromise

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11627,6 +11627,10 @@ describe('connectPanePty', () => {
       '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
       expect.any(Function)
     )
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      expect.any(Function)
+    )
     expect(pane.terminal.write).toHaveBeenCalledWith(
       'remote alt snapshot without history\r\n',
       expect.any(Function)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11527,6 +11527,11 @@ describe('connectPanePty', () => {
     expect(getMainBufferSnapshot).not.toHaveBeenCalled()
     expect(transport.serializeBuffer).toHaveBeenCalledWith({ scrollbackRows: 5000 })
     expect(pane.terminal.write).not.toHaveBeenCalledWith(hidden)
+    expect(pane.terminal.write).toHaveBeenCalledWith('\x1b[2J\x1b[3J\x1b[H', expect.any(Function))
+    expect(pane.terminal.write).not.toHaveBeenCalledWith(
+      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+      expect.any(Function)
+    )
     expect(pane.terminal.write).toHaveBeenCalledWith(
       expect.stringContaining('remote snapshot with hidden remote output'),
       expect.any(Function)

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -11534,6 +11534,106 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
+  it('restores remote alternate-screen snapshots with preserved scrollback', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('remote:env-1@@terminal-1')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible remote output\r\n'
+    transport.serializeBuffer = vi.fn().mockResolvedValueOnce({
+      data: 'remote alt snapshot with history\r\n',
+      cols: 120,
+      rows: 40,
+      seq: hidden.length + live.length,
+      source: 'headless',
+      alternateScreen: true,
+      scrollbackAnsi: 'remote shell history\r\n'
+    })
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'remote:env-1@@terminal-1'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'remote shell history\r\n',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'remote alt snapshot with history\r\n',
+      expect.any(Function)
+    )
+
+    disposable.dispose()
+  })
+
+  it('restores remote alternate-screen snapshots without preserved scrollback', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('remote:env-1@@terminal-1')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    const live = 'visible remote output\r\n'
+    transport.serializeBuffer = vi.fn().mockResolvedValue({
+      data: 'remote alt snapshot without history\r\n',
+      cols: 120,
+      rows: 40,
+      seq: hidden.length + live.length,
+      source: 'headless',
+      alternateScreen: true
+    })
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'remote:env-1@@terminal-1'
+    })
+    transportFactoryQueue.push(transport)
+
+    const pane = createPane(1)
+    const manager = createManager(1)
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const disposable = connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(6)
+
+    capturedDataCallback.current?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    capturedDataCallback.current?.(live, {
+      seq: hidden.length + live.length,
+      rawLength: live.length
+    })
+    await flushAsyncTicks(20)
+
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+      expect.any(Function)
+    )
+    expect(pane.terminal.write).toHaveBeenCalledWith(
+      'remote alt snapshot without history\r\n',
+      expect.any(Function)
+    )
+    disposable.dispose()
+  })
+
   it('defers inactive split-pane plain hidden output restore until the pane returns', async () => {
     const { resetHiddenOutputRestoreSchedulerForTests } =
       await import('./hidden-output-restore-scheduler')

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -45,6 +45,8 @@ class FakeMultiplexServer {
   snapshotRequests: (number | undefined)[] = []
   private heldManualRequestId: number | null = null
   private snapshotData = 'INITIAL'
+  private snapshotAlternateScreen = false
+  private snapshotScrollbackAnsiLength = 0
 
   constructor(
     private readonly toClient: (bytes: Uint8Array<ArrayBufferLike>) => void,
@@ -73,7 +75,9 @@ class FakeMultiplexServer {
       }
       // Resync request: the server serializes the *current* buffer, so recovery
       // includes everything the client missed.
-      this.snapshotData = 'RECOVERED'
+      if (typeof payload?.requestId !== 'number') {
+        this.snapshotData = 'RECOVERED'
+      }
       if (typeof payload?.requestId !== 'number' && this.holdNextRecoverySnapshot) {
         // The reply's binary frames were all dropped under backpressure.
         this.holdNextRecoverySnapshot = false
@@ -108,7 +112,13 @@ class FakeMultiplexServer {
         rows: 24,
         seq: options?.truncated ? undefined : this.cursorUnits,
         requestId,
-        truncated: options?.truncated
+        truncated: options?.truncated,
+        ...(this.snapshotAlternateScreen
+          ? {
+              alternateScreen: true,
+              scrollbackAnsiLength: this.snapshotScrollbackAnsiLength
+            }
+          : {})
       }),
       0
     )
@@ -166,6 +176,15 @@ class FakeMultiplexServer {
     this.heldManualRequestId = null
     this.snapshotData = 'MANUAL'
     this.sendSnapshot(requestId)
+  }
+
+  setSnapshot(
+    data: string,
+    options: { alternateScreen?: boolean; scrollbackAnsiLength?: number } = {}
+  ) {
+    this.snapshotData = data
+    this.snapshotAlternateScreen = options.alternateScreen === true
+    this.snapshotScrollbackAnsiLength = options.scrollbackAnsiLength ?? 0
   }
 }
 
@@ -248,6 +267,20 @@ describe('remote terminal frame-drop resync', () => {
     server.replaySnapshotCoveredOutput('ccc')
     server.output('ddd')
     expect(data).toEqual(['aaa', 'ddd'])
+  })
+
+  it('splits remote alternate-screen scrollback from a requested snapshot', async () => {
+    const { stream } = await subscribeClient()
+    server.setSnapshot('shell history\ralternate frame', {
+      alternateScreen: true,
+      scrollbackAnsiLength: 'shell history\r'.length
+    })
+
+    await expect(stream.serializeBuffer({ scrollbackRows: 100 })).resolves.toMatchObject({
+      data: 'alternate frame',
+      alternateScreen: true,
+      scrollbackAnsi: 'shell history\r'
+    })
   })
 
   it('retries a truncated recovery on a backoff without accepting output across the gap', async () => {

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -46,7 +46,7 @@ class FakeMultiplexServer {
   private heldManualRequestId: number | null = null
   private snapshotData = 'INITIAL'
   private snapshotAlternateScreen = false
-  private snapshotScrollbackAnsiLength = 0
+  private snapshotScrollbackAnsiLength: number | undefined
 
   constructor(
     private readonly toClient: (bytes: Uint8Array<ArrayBufferLike>) => void,
@@ -113,11 +113,9 @@ class FakeMultiplexServer {
         seq: options?.truncated ? undefined : this.cursorUnits,
         requestId,
         truncated: options?.truncated,
-        ...(this.snapshotAlternateScreen
-          ? {
-              alternateScreen: true,
-              scrollbackAnsiLength: this.snapshotScrollbackAnsiLength
-            }
+        ...(this.snapshotAlternateScreen ? { alternateScreen: true } : {}),
+        ...(typeof this.snapshotScrollbackAnsiLength === 'number'
+          ? { scrollbackAnsiLength: this.snapshotScrollbackAnsiLength }
           : {})
       }),
       0
@@ -184,7 +182,8 @@ class FakeMultiplexServer {
   ) {
     this.snapshotData = data
     this.snapshotAlternateScreen = options.alternateScreen === true
-    this.snapshotScrollbackAnsiLength = options.scrollbackAnsiLength ?? 0
+    this.snapshotScrollbackAnsiLength =
+      typeof options.scrollbackAnsiLength === 'number' ? options.scrollbackAnsiLength : undefined
   }
 }
 
@@ -281,6 +280,20 @@ describe('remote terminal frame-drop resync', () => {
       alternateScreen: true,
       scrollbackAnsi: 'shell history\r'
     })
+  })
+
+  it('preserves remote alternate-screen snapshots when no scrollback boundary is present', async () => {
+    const { stream } = await subscribeClient()
+    server.setSnapshot('alternate frame', {
+      alternateScreen: true
+    })
+
+    const snapshot = await stream.serializeBuffer({ scrollbackRows: 100 })
+    expect(snapshot).toMatchObject({
+      data: 'alternate frame',
+      alternateScreen: true
+    })
+    expect(snapshot?.scrollbackAnsi).toBeUndefined()
   })
 
   it('retries a truncated recovery on a backoff without accepting output across the gap', async () => {

--- a/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts
@@ -533,7 +533,10 @@ describe('remote terminal frame-drop resync', () => {
     await Promise.resolve()
     await Promise.resolve()
 
-    await expect(manualSnapshot).resolves.toMatchObject({ data: 'MANUAL' })
+    const snapshot = await manualSnapshot
+    expect(snapshot).toMatchObject({ data: 'MANUAL' })
+    expect(snapshot?.alternateScreen).toBeUndefined()
+    expect(snapshot?.scrollbackAnsi).toBeUndefined()
     expect(server.snapshotRequests).toHaveLength(2)
     expect(snapshots).toEqual(['INITIAL', '\x1b[2J\x1b[3J\x1b[HRECOVERED'])
 

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -71,6 +71,8 @@ export type RemoteRuntimeMultiplexedTerminal = {
     rows: number
     seq?: number
     source?: 'headless' | 'renderer'
+    alternateScreen?: boolean
+    scrollbackAnsi?: string
   } | null>
   close: () => void
 }
@@ -114,6 +116,8 @@ type RemoteRuntimeSnapshotInfo = {
   // must write it AFTER the replay reset so the next live chunk completes it
   // instead of rendering literally (#7329).
   pendingEscapeTailAnsi?: string
+  alternateScreen?: boolean
+  scrollbackAnsiLength?: number
 }
 
 type RemoteRuntimeSnapshotRequest = {
@@ -126,6 +130,8 @@ type RemoteRuntimeSnapshotRequest = {
       seq?: number
       source?: 'headless' | 'renderer'
       pendingEscapeTailAnsi?: string
+      alternateScreen?: boolean
+      scrollbackAnsi?: string
     } | null
   ) => void
   reject: (error: Error) => void
@@ -634,14 +640,28 @@ class RemoteRuntimeTerminalMultiplexer {
           ? info.requestId === pendingRequest.requestId
           : stream.initialSnapshotReceived)
       if (snapshotApplied) {
+        const foldedData = data ?? ''
+        const hasAltScreenBoundary =
+          info?.alternateScreen === true &&
+          typeof info.scrollbackAnsiLength === 'number' &&
+          Number.isInteger(info.scrollbackAnsiLength) &&
+          info.scrollbackAnsiLength >= 0 &&
+          info.scrollbackAnsiLength <= foldedData.length
+        const scrollbackAnsi = hasAltScreenBoundary
+          ? foldedData.slice(0, info.scrollbackAnsiLength)
+          : undefined
+        const snapshotData = hasAltScreenBoundary
+          ? foldedData.slice(info.scrollbackAnsiLength)
+          : foldedData
         if (matchesPendingRequest) {
           pendingRequest.resolve({
-            data: data ?? '',
+            data: snapshotData,
             cols: info?.cols ?? 80,
             rows: info?.rows ?? 24,
             seq: info?.seq,
             source: info?.source,
-            pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi
+            pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
+            ...(hasAltScreenBoundary ? { alternateScreen: true, scrollbackAnsi } : {})
           })
           clearPendingSnapshotRequest(stream)
         } else if (target === 'initial') {
@@ -1118,6 +1138,8 @@ function decodeSnapshotInfo(
     requestId?: unknown
     truncated?: unknown
     pendingEscapeTailAnsi?: unknown
+    alternateScreen?: unknown
+    scrollbackAnsiLength?: unknown
   }>(payload)
   if (!raw) {
     return null
@@ -1130,7 +1152,10 @@ function decodeSnapshotInfo(
     requestId: typeof raw.requestId === 'number' ? raw.requestId : undefined,
     truncated: raw.truncated === true,
     pendingEscapeTailAnsi:
-      typeof raw.pendingEscapeTailAnsi === 'string' ? raw.pendingEscapeTailAnsi : undefined
+      typeof raw.pendingEscapeTailAnsi === 'string' ? raw.pendingEscapeTailAnsi : undefined,
+    alternateScreen: raw.alternateScreen === true ? true : undefined,
+    scrollbackAnsiLength:
+      typeof raw.scrollbackAnsiLength === 'number' ? raw.scrollbackAnsiLength : undefined
   }
 }
 

--- a/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
+++ b/src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts
@@ -661,7 +661,8 @@ class RemoteRuntimeTerminalMultiplexer {
             seq: info?.seq,
             source: info?.source,
             pendingEscapeTailAnsi: info?.pendingEscapeTailAnsi,
-            ...(hasAltScreenBoundary ? { alternateScreen: true, scrollbackAnsi } : {})
+            ...(info?.alternateScreen === true ? { alternateScreen: true } : {}),
+            ...(hasAltScreenBoundary ? { scrollbackAnsi } : {})
           })
           clearPendingSnapshotRequest(stream)
         } else if (target === 'initial') {


### PR DESCRIPTION
## Summary

- Preserve pre-TUI shell scrollback when a remote alternate-screen terminal is hidden and restored.
- Root cause: the requested remote snapshot path folded scrollback into `data` and dropped the alt-screen metadata that the renderer restore path already uses locally.
- Carry requested-snapshot alt-screen metadata through the remote snapshot frame, re-split the folded payload on the multiplexer boundary, and let the renderer take the same scrollback-preserving branch it already uses for local restores. Keep subscribe and mobile snapshot frames unchanged, and preserve the local alt-screen contract when remote scrollback is unavailable.

Closes #6106.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation to run:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `pnpm run typecheck:node`
- `pnpm run typecheck:web`

Focused validation completed:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts`: passed, `Test Files  1 passed (1)`, `Tests  2 passed (2)`.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts`: passed, `Test Files  1 passed (1)`, `Tests  15 passed (15)`.
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts`: passed, `Test Files  1 passed (1)`, `Tests  471 passed (471)`.
- `pnpm run typecheck:node`: passed, `tsc --noEmit -p config/tsconfig.node.json`.
- `pnpm run typecheck:web`: passed, `tsc --noEmit -p config/tsconfig.tc.web.json`.
- `pnpm exec oxlint src/main/runtime/rpc/methods/terminal.ts src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts`: passed, no diagnostics.
- `pnpm exec oxfmt --check src/main/runtime/rpc/methods/terminal.ts src/renderer/src/runtime/remote-runtime-terminal-multiplexer.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts src/main/runtime/rpc/terminal-multiplex-escape-tail.test.ts src/renderer/src/runtime/remote-runtime-terminal-frame-drop-resync.test.ts`: passed, `All matched files use the correct format.`
- Dependency setup: `pnpm install --frozen-lockfile` completed successfully before validation.

The generic `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` commands were not run; their template boxes remain unchecked. The targeted changed-file checks above passed.

## Security Audit

This change adds no new auth, filesystem, network, or command surface. It threads metadata through an existing remote terminal snapshot frame and re-splits it in the renderer transport.

## Notes

Scope is limited to remote snapshot metadata parity. It does not widen into the broader visible-TUI-output work.

## ELI5

Hiding and restoring a remote terminal running a full-screen TUI could drop the shell scrollback from before the TUI. Remote snapshots now carry alt-screen metadata so restore keeps that history like local does.
