### PR TITLE
feat(clipboard): accept an optional fileName on the blob-to-temp-file upload RPC

### DIFF
--- a/src/main/runtime/rpc/methods/clipboard.test.ts
+++ b/src/main/runtime/rpc/methods/clipboard.test.ts
@@ -64,6 +64,52 @@ describe('clipboard RPC methods', () => {
     })
   })
 
+  it('forwards fileName on the single-frame save so named attachments keep their name', async () => {
+    saveClipboardImageBufferAsTempFile.mockResolvedValue('/tmp/orca-file-1-uuid-report.pdf')
+    const dispatcher = makeDispatcher()
+
+    const response = await dispatcher.dispatch(
+      makeRequest('clipboard.saveImageAsTempFile', {
+        contentBase64: Buffer.from('pdf-bytes').toString('base64'),
+        connectionId: null,
+        fileName: 'report.pdf'
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(saveClipboardImageBufferAsTempFile).toHaveBeenCalledWith(Buffer.from('pdf-bytes'), {
+      connectionId: null,
+      fileName: 'report.pdf'
+    })
+  })
+
+  it('records fileName at upload start and forwards it on commit', async () => {
+    saveClipboardImageBufferAsTempFile.mockResolvedValue('/tmp/orca-file-1-uuid-notes.txt')
+    const dispatcher = makeDispatcher()
+    const contentBase64 = Buffer.from('txt-bytes').toString('base64')
+
+    const start = await dispatcher.dispatch(
+      makeRequest('clipboard.startImageUpload', {
+        expectedBase64Length: contentBase64.length,
+        connectionId: 'ssh-1',
+        fileName: 'notes.txt'
+      })
+    )
+    expect(start.ok).toBe(true)
+    const { uploadId } = (start.ok ? start.result : null) as { uploadId: string }
+    await dispatcher.dispatch(
+      makeRequest('clipboard.appendImageUploadChunk', { uploadId, offset: 0, contentBase64 })
+    )
+
+    await expect(
+      dispatcher.dispatch(makeRequest('clipboard.commitImageUpload', { uploadId }))
+    ).resolves.toMatchObject({ ok: true, result: '/tmp/orca-file-1-uuid-notes.txt' })
+    expect(saveClipboardImageBufferAsTempFile).toHaveBeenCalledWith(Buffer.from('txt-bytes'), {
+      connectionId: 'ssh-1',
+      fileName: 'notes.txt'
+    })
+  })
+
   it('rejects non-base64 clipboard image payloads', async () => {
     const dispatcher = makeDispatcher()
 

--- a/src/main/runtime/rpc/methods/clipboard.ts
+++ b/src/main/runtime/rpc/methods/clipboard.ts
@@ -16,6 +16,7 @@ const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/
 type ClipboardImageUpload = {
   expectedBase64Length: number
   connectionId?: string | null
+  fileName?: string | null
   chunks: string[]
   receivedBase64Length: number
   expiresAt: number
@@ -93,12 +94,16 @@ function clipboardImageBase64Payload(maxChars: number, tooLargeMessage: string) 
   })
 }
 
+// Why: despite the "image" method names (kept for compatibility), these are the
+// generic blob-to-temp-file channel; fileName support is advertised via the
+// clipboard.file-upload.v1 capability, and the host sanitizes the name.
 const SaveImageAsTempFile = z.object({
   contentBase64: clipboardImageBase64Payload(
     MAX_CLIPBOARD_IMAGE_BASE64_CHARS,
     CLIPBOARD_IMAGE_TOO_LARGE_ERROR
   ),
-  connectionId: z.string().min(1).nullable().optional()
+  connectionId: z.string().min(1).nullable().optional(),
+  fileName: z.string().min(1).max(1024).nullable().optional()
 })
 
 const StartImageUpload = z.object({
@@ -107,7 +112,8 @@ const StartImageUpload = z.object({
     .int()
     .nonnegative()
     .max(MAX_CLIPBOARD_IMAGE_BASE64_CHARS, CLIPBOARD_IMAGE_TOO_LARGE_ERROR),
-  connectionId: z.string().min(1).nullable().optional()
+  connectionId: z.string().min(1).nullable().optional(),
+  fileName: z.string().min(1).max(1024).nullable().optional()
 })
 
 const AppendImageUploadChunk = z.object({
@@ -133,7 +139,8 @@ export const CLIPBOARD_METHODS: RpcMethod[] = [
     params: SaveImageAsTempFile,
     handler: async (params) =>
       saveClipboardImageBufferAsTempFile(Buffer.from(params.contentBase64, 'base64'), {
-        connectionId: params.connectionId
+        connectionId: params.connectionId,
+        fileName: params.fileName
       })
   }),
   defineMethod({
@@ -148,6 +155,7 @@ export const CLIPBOARD_METHODS: RpcMethod[] = [
       clipboardImageUploads.set(uploadId, {
         expectedBase64Length: params.expectedBase64Length,
         connectionId: params.connectionId,
+        fileName: params.fileName,
         chunks: [],
         receivedBase64Length: 0,
         expiresAt: Date.now() + CLIPBOARD_IMAGE_UPLOAD_TTL_MS,
@@ -186,7 +194,8 @@ export const CLIPBOARD_METHODS: RpcMethod[] = [
         const contentBase64 = upload.chunks.join('')
         assertValidBase64Content(contentBase64)
         return await saveClipboardImageBufferAsTempFile(Buffer.from(contentBase64, 'base64'), {
-          connectionId: upload.connectionId
+          connectionId: upload.connectionId,
+          fileName: upload.fileName
         })
       } finally {
         // Why: failed SSH or filesystem commits must not leave bounded upload

--- a/src/main/window/clipboard-image-temp-file.test.ts
+++ b/src/main/window/clipboard-image-temp-file.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { fsWriteFileMock, randomUUIDMock, getSshFilesystemProviderMock } = vi.hoisted(() => ({
+  fsWriteFileMock: vi.fn(),
+  randomUUIDMock: vi.fn(() => '00000000-0000-4000-8000-000000000000'),
+  getSshFilesystemProviderMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  default: {
+    writeFile: fsWriteFileMock
+  }
+}))
+
+vi.mock('node:crypto', () => ({
+  randomUUID: randomUUIDMock
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: vi.fn(() => '/local-temp')
+  }
+}))
+
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  requireSshFilesystemProvider: getSshFilesystemProviderMock
+}))
+
+import {
+  sanitizeAttachmentFileName,
+  saveClipboardImageBufferAsTempFile
+} from './clipboard-image-temp-file'
+
+const UUID = '00000000-0000-4000-8000-000000000000'
+
+describe('sanitizeAttachmentFileName', () => {
+  it('keeps an ordinary file name unchanged', () => {
+    expect(sanitizeAttachmentFileName('report.pdf')).toBe('report.pdf')
+  })
+
+  it('neutralizes path traversal names', () => {
+    expect(sanitizeAttachmentFileName('../../x')).toBe('x')
+  })
+
+  it('removes path separators of both flavors', () => {
+    expect(sanitizeAttachmentFileName('a/b\\c.txt')).toBe('abc.txt')
+  })
+
+  it('removes control characters', () => {
+    // Escapes, not raw bytes, so this test file stays text-diffable in review.
+    expect(sanitizeAttachmentFileName('a\x00b\x1fc\x7f.log')).toBe('abc.log')
+  })
+
+  it('strips leading dots so temp files cannot hide', () => {
+    expect(sanitizeAttachmentFileName('...hidden.txt')).toBe('hidden.txt')
+  })
+
+  it('returns null when nothing survives sanitization', () => {
+    expect(sanitizeAttachmentFileName('')).toBeNull()
+    expect(sanitizeAttachmentFileName('...')).toBeNull()
+    expect(sanitizeAttachmentFileName('///\\\\')).toBeNull()
+    expect(sanitizeAttachmentFileName(' ')).toBeNull()
+  })
+
+  it('drops shell metacharacters so a pasted path cannot execute on Enter', () => {
+    expect(sanitizeAttachmentFileName('notes;curl evil.sh -o- $(id).pdf')).toBe(
+      'notescurlevil.sh-o-id.pdf'
+    )
+    expect(sanitizeAttachmentFileName('a`b|c&d.txt')).toBe('abcd.txt')
+  })
+
+  it('drops interior spaces so the path stays a single shell token', () => {
+    expect(sanitizeAttachmentFileName('meeting notes.pdf')).toBe('meetingnotes.pdf')
+  })
+
+  it('drops Unicode line/format separators that would break the pasted path', () => {
+    expect(sanitizeAttachmentFileName('a b\u202ec\u200b.txt')).toBe('abc.txt')
+  })
+
+  it('removes characters Windows filesystems reject', () => {
+    expect(sanitizeAttachmentFileName('report:v2<final>?.pdf')).toBe('reportv2final.pdf')
+    expect(sanitizeAttachmentFileName('a"b|c*d.txt')).toBe('abcd.txt')
+  })
+
+  it('slices attacker-sized input before per-code-point work', () => {
+    // A frame-cap-sized name must not cost O(input) sanitization: only the
+    // first 1024 chars are ever examined, and the result still lands ≤ 80 bytes.
+    const sanitized = sanitizeAttachmentFileName(`${'x'.repeat(1_000_000)}.pdf`)
+    expect(Buffer.byteLength(sanitized ?? '')).toBeLessThanOrEqual(80)
+    expect(sanitized?.startsWith('x')).toBe(true)
+  })
+
+  it('caps long names at 80 bytes preserving the extension', () => {
+    const sanitized = sanitizeAttachmentFileName(`${'a'.repeat(100)}.pdf`)
+    expect(Buffer.byteLength(sanitized ?? '')).toBe(80)
+    expect(sanitized?.endsWith('.pdf')).toBe(true)
+    expect(sanitized?.startsWith('a'.repeat(76))).toBe(true)
+  })
+
+  it('caps multibyte names by byte length, not code units', () => {
+    // 80 CJK chars = 240 UTF-8 bytes; must be truncated to <= 80 bytes.
+    const sanitized = sanitizeAttachmentFileName(`${'历'.repeat(80)}.txt`)
+    expect(Buffer.byteLength(sanitized ?? '')).toBeLessThanOrEqual(80)
+    expect(sanitized?.endsWith('.txt')).toBe(true)
+  })
+
+  it('never splits a multibyte character at the byte cap', () => {
+    // A trailing emoji straddling the cut must not leave a lone surrogate (U+FFFD).
+    const sanitized = sanitizeAttachmentFileName(`${'a'.repeat(78)}😀😀😀.txt`)
+    expect(sanitized).not.toContain('�')
+    expect(Buffer.byteLength(sanitized ?? '')).toBeLessThanOrEqual(80)
+  })
+
+  it('truncates outright when the extension itself cannot fit', () => {
+    const sanitized = sanitizeAttachmentFileName(`a.${'x'.repeat(120)}`)
+    expect(Buffer.byteLength(sanitized ?? '')).toBe(80)
+  })
+
+  it('preserves unicode letters while dropping the interior space', () => {
+    expect(sanitizeAttachmentFileName('résumé 简历.txt')).toBe('résumé简历.txt')
+  })
+
+  it('strips trailing dots that Windows drops silently', () => {
+    expect(sanitizeAttachmentFileName('archive...')).toBe('archive')
+  })
+})
+
+describe('saveClipboardImageBufferAsTempFile', () => {
+  it('keeps the byte-identical orca-paste png name when no fileName is given', async () => {
+    fsWriteFileMock.mockResolvedValue(undefined)
+
+    const savedPath = await saveClipboardImageBufferAsTempFile(Buffer.from('bytes'))
+
+    expect(savedPath).toMatch(new RegExp(`^/local-temp/orca-paste-\\d+-${UUID}\\.png$`))
+  })
+
+  it('appends the sanitized original name for named attachments', async () => {
+    fsWriteFileMock.mockResolvedValue(undefined)
+
+    const savedPath = await saveClipboardImageBufferAsTempFile(Buffer.from('bytes'), {
+      fileName: '../notes/agenda.md'
+    })
+
+    expect(savedPath).toMatch(new RegExp(`^/local-temp/orca-file-\\d+-${UUID}-notesagenda\\.md$`))
+  })
+
+  it('falls back to the generated name with no suffix when the name sanitizes away', async () => {
+    fsWriteFileMock.mockResolvedValue(undefined)
+
+    const savedPath = await saveClipboardImageBufferAsTempFile(Buffer.from('bytes'), {
+      fileName: '///'
+    })
+
+    expect(savedPath).toMatch(new RegExp(`^/local-temp/orca-file-\\d+-${UUID}$`))
+  })
+
+  it('uses identical naming for SSH remote writes', async () => {
+    const writeFileBase64 = vi.fn().mockResolvedValue(undefined)
+    getSshFilesystemProviderMock.mockReturnValue({
+      getTempDir: async () => '/remote/tmp',
+      writeFileBase64
+    })
+
+    const savedPath = await saveClipboardImageBufferAsTempFile(Buffer.from('bytes'), {
+      connectionId: 'ssh-1',
+      fileName: 'trace.log'
+    })
+
+    expect(savedPath).toMatch(new RegExp(`^/remote/tmp/orca-file-\\d+-${UUID}-trace\\.log$`))
+    expect(writeFileBase64).toHaveBeenCalledWith(savedPath, Buffer.from('bytes').toString('base64'))
+  })
+})

--- a/src/main/window/clipboard-image-temp-file.test.ts
+++ b/src/main/window/clipboard-image-temp-file.test.ts
@@ -123,6 +123,14 @@ describe('sanitizeAttachmentFileName', () => {
   it('strips trailing dots that Windows drops silently', () => {
     expect(sanitizeAttachmentFileName('archive...')).toBe('archive')
   })
+
+  it('never exposes a leading dot when truncation drops the whole body', () => {
+    // 4-byte emoji body + 77-byte extension: the body cannot fit the 3-byte
+    // budget, so only the extension survives the cut.
+    const sanitized = sanitizeAttachmentFileName(`😀.${'a'.repeat(76)}`)
+    expect(sanitized).not.toBeNull()
+    expect(sanitized?.startsWith('.')).toBe(false)
+  })
 })
 
 describe('saveClipboardImageBufferAsTempFile', () => {

--- a/src/main/window/clipboard-image-temp-file.test.ts
+++ b/src/main/window/clipboard-image-temp-file.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 
 const { fsWriteFileMock, randomUUIDMock, getSshFilesystemProviderMock } = vi.hoisted(() => ({
@@ -32,6 +33,9 @@ import {
 } from './clipboard-image-temp-file'
 
 const UUID = '00000000-0000-4000-8000-000000000000'
+// Why: local temp paths go through path.join, which emits backslashes on Windows.
+const SEP = path.sep === '\\' ? '\\\\' : path.sep
+const LOCAL_TEMP = `${SEP}local-temp${SEP}`
 
 describe('sanitizeAttachmentFileName', () => {
   it('keeps an ordinary file name unchanged', () => {
@@ -139,7 +143,7 @@ describe('saveClipboardImageBufferAsTempFile', () => {
 
     const savedPath = await saveClipboardImageBufferAsTempFile(Buffer.from('bytes'))
 
-    expect(savedPath).toMatch(new RegExp(`^/local-temp/orca-paste-\\d+-${UUID}\\.png$`))
+    expect(savedPath).toMatch(new RegExp(`^${LOCAL_TEMP}orca-paste-\\d+-${UUID}\\.png$`))
   })
 
   it('appends the sanitized original name for named attachments', async () => {
@@ -149,7 +153,7 @@ describe('saveClipboardImageBufferAsTempFile', () => {
       fileName: '../notes/agenda.md'
     })
 
-    expect(savedPath).toMatch(new RegExp(`^/local-temp/orca-file-\\d+-${UUID}-notesagenda\\.md$`))
+    expect(savedPath).toMatch(new RegExp(`^${LOCAL_TEMP}orca-file-\\d+-${UUID}-notesagenda\\.md$`))
   })
 
   it('falls back to the generated name with no suffix when the name sanitizes away', async () => {
@@ -159,7 +163,7 @@ describe('saveClipboardImageBufferAsTempFile', () => {
       fileName: '///'
     })
 
-    expect(savedPath).toMatch(new RegExp(`^/local-temp/orca-file-\\d+-${UUID}$`))
+    expect(savedPath).toMatch(new RegExp(`^${LOCAL_TEMP}orca-file-\\d+-${UUID}$`))
   })
 
   it('uses identical naming for SSH remote writes', async () => {

--- a/src/main/window/clipboard-image-temp-file.ts
+++ b/src/main/window/clipboard-image-temp-file.ts
@@ -10,9 +10,73 @@ import { assertClipboardImageByteLengthWithinLimit } from '../../shared/clipboar
 export type SaveClipboardImageAsTempFileArgs = {
   connectionId?: string | null
   runtimeEnvironmentId?: string | null
+  fileName?: string | null
 }
 
 const REMOTE_CLIPBOARD_IMAGE_TEMP_DIR = '/tmp'
+// Bytes, not code units: the name is appended to a temp path and must stay under
+// the 255-byte NAME_MAX on ext4/APFS (local temp and SSH-remote /tmp alike),
+// leaving headroom for the `orca-file-<ts>-<uuid>-` prefix.
+const ATTACHMENT_FILE_NAME_MAX_BYTES = 80
+// Safe = Unicode letters/numbers/marks plus ASCII dot, dash, underscore.
+// Everything else — whitespace, shell metacharacters, path separators, control
+// and Unicode format/separator characters — is dropped, because the sanitized
+// name lands in a path pasted verbatim into the user's live terminal, where a
+// space breaks path tokenization and `;`/`$()`/backticks would execute on Enter.
+const SAFE_ATTACHMENT_FILE_NAME_CHAR = /[\p{L}\p{N}\p{M}._-]/u
+// Cap the raw input before any per-code-point work: the RPC layer also bounds
+// fileName, but sanitization cost must never scale with attacker-sized input.
+const ATTACHMENT_FILE_NAME_MAX_INPUT_CHARS = 1024
+
+export function sanitizeAttachmentFileName(fileName: string): string | null {
+  // NFC first so accented letters are single code points the allowlist keeps.
+  // (A surrogate pair split by the slice fails the allowlist and is dropped.)
+  const filtered = Array.from(
+    fileName.slice(0, ATTACHMENT_FILE_NAME_MAX_INPUT_CHARS).normalize('NFC')
+  )
+    .filter((char) => SAFE_ATTACHMENT_FILE_NAME_CHAR.test(char))
+    .join('')
+    .replace(/^\.+/, '')
+    .replace(/\.+$/, '')
+  if (!filtered) {
+    return null
+  }
+  return truncateFileNameToBytes(filtered, ATTACHMENT_FILE_NAME_MAX_BYTES)
+}
+
+function truncateFileNameToBytes(name: string, maxBytes: number): string {
+  if (Buffer.byteLength(name) <= maxBytes) {
+    return name
+  }
+  const extension = path.posix.extname(name)
+  const keepExtension = extension.length > 0 && Buffer.byteLength(extension) < maxBytes
+  const budget = keepExtension ? maxBytes - Buffer.byteLength(extension) : maxBytes
+  const body = keepExtension ? name.slice(0, name.length - extension.length) : name
+  let truncated = ''
+  let usedBytes = 0
+  // Iterate by code point so a multibyte character is never split at the cut.
+  for (const char of body) {
+    const charBytes = Buffer.byteLength(char)
+    if (usedBytes + charBytes > budget) {
+      break
+    }
+    truncated += char
+    usedBytes += charBytes
+  }
+  // Re-strip a trailing dot the cut may have exposed (Windows drops it silently).
+  const result = (truncated + (keepExtension ? extension : '')).replace(/\.+$/, '')
+  return result || truncated
+}
+
+function buildAttachmentTempFileName(originalFileName: string | null | undefined): string {
+  if (originalFileName == null) {
+    // Byte-identical to the historical clipboard-paste name for existing callers.
+    return `orca-paste-${Date.now()}-${randomUUID()}.png`
+  }
+  const sanitized = sanitizeAttachmentFileName(originalFileName)
+  const generated = `orca-file-${Date.now()}-${randomUUID()}`
+  return sanitized ? `${generated}-${sanitized}` : generated
+}
 
 function joinRemotePath(basePath: string, fileName: string): string {
   if (isWindowsAbsolutePathLike(basePath)) {
@@ -27,7 +91,7 @@ export async function saveClipboardImageBufferAsTempFile(
 ): Promise<string> {
   assertClipboardImageByteLengthWithinLimit(buffer.byteLength)
 
-  const fileName = `orca-paste-${Date.now()}-${randomUUID()}.png`
+  const fileName = buildAttachmentTempFileName(args?.fileName)
 
   if (args?.connectionId) {
     const provider = requireSshFilesystemProvider(args.connectionId)

--- a/src/main/window/clipboard-image-temp-file.ts
+++ b/src/main/window/clipboard-image-temp-file.ts
@@ -63,8 +63,12 @@ function truncateFileNameToBytes(name: string, maxBytes: number): string {
     truncated += char
     usedBytes += charBytes
   }
-  // Re-strip a trailing dot the cut may have exposed (Windows drops it silently).
-  const result = (truncated + (keepExtension ? extension : '')).replace(/\.+$/, '')
+  // Re-strip dots the cut may expose: trailing (Windows drops it silently) and
+  // leading, which reappears when the body truncates away entirely and only the
+  // extension remains — the hidden-file shape the upstream strip exists to prevent.
+  const result = (truncated + (keepExtension ? extension : ''))
+    .replace(/\.+$/, '')
+    .replace(/^\.+/, '')
   return result || truncated
 }
 

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -83,6 +83,10 @@ export const AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY =
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
   'Remote file changes require a newer Orca server. Update the HUB and try again.'
+// Why: hosts without this strip fileName from the clipboard upload methods
+// (zod drops unknown keys) and would save a PDF as `….png`, so mobile keeps
+// the image-only picker unless the host advertises filename support.
+export const CLIPBOARD_FILE_UPLOAD_RUNTIME_CAPABILITY = 'clipboard.file-upload.v1' as const
 
 export const RUNTIME_CAPABILITIES = [
   'runtime.status.compat.v1',
@@ -116,7 +120,8 @@ export const RUNTIME_CAPABILITIES = [
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   ACCOUNT_IMPORT_RUNTIME_CAPABILITY,
-  CODEX_RESET_CREDIT_RUNTIME_CAPABILITY
+  CODEX_RESET_CREDIT_RUNTIME_CAPABILITY,
+  CLIPBOARD_FILE_UPLOAD_RUNTIME_CAPABILITY
 ] as const
 
 export type RuntimeCapability = (typeof RUNTIME_CAPABILITIES)[number] | (string & {})


### PR DESCRIPTION
## Summary

The clipboard upload RPCs (`clipboard.saveImageAsTempFile`, `clipboard.startImageUpload`) gain one optional field, `fileName`, so a client can ask the host to keep an attachment's original name: with `fileName` the host writes `orca-file-<ts>-<uuid>-<sanitized-name>`, without it behavior is byte-identical to today (`orca-paste-<ts>-<uuid>.png`), for local temp writes and SSH SFTP writes alike. The name is treated as untrusted input and sanitized host-side: allowlist charset (Unicode letters/numbers/marks plus `.`/`-`/`_`), input capped at 1024 chars before any per-code-point work, path separators / Windows-invalid / control / shell-hazard characters dropped, leading/trailing dots stripped, and the result byte-capped at 80 preserving the extension.

No protocol-version bump — per the policy in `protocol-version.ts`, new optional fields on existing methods don't bump. Instead the host advertises a new `clipboard.file-upload.v1` capability, because old hosts silently strip unknown zod fields and would save a PDF as `….png`; the capability is what lets a client know `fileName` is honored. Existing callers are unchanged.

Split out of #9072 — this is the host-side foundation for mobile any-file attachments (desktop-side matcher counterpart: #10233); #9072 will be rebased down to the mobile UI layer once this lands.

**Tests:** new `clipboard-image-temp-file.test.ts` (21 cases: sanitization table incl. traversal, control chars, shell metacharacters, multibyte byte-capping; naming with/without `fileName`; identical SSH naming) and new cases in `clipboard.test.ts` (fileName forwarded on single-frame save; recorded at upload start and applied on commit). `pnpm typecheck` and both test files green locally.

**Review starting point:** `sanitizeAttachmentFileName` in `src/main/window/clipboard-image-temp-file.ts`, then the zod schema changes in `src/main/runtime/rpc/methods/clipboard.ts`.

cc @OrcaWin

## ELI5

Clipboard image upload RPCs accept an optional fileName so the host can keep a sanitized original name instead of always using orca-paste-…. Without fileName, behavior is unchanged.
