### PR TITLE
feat(native-chat): recognize mobile orca-file upload names as pasted images

### DIFF
--- a/src/main/native-chat/transcript-line-decoders-grok.ts
+++ b/src/main/native-chat/transcript-line-decoders-grok.ts
@@ -216,14 +216,16 @@ function normalizeGrokUserQueryBlock(block: NativeChatBlock): NativeChatBlock[] 
 
 // Mobile Files-picker uploads use `orca-file-<ts>-<uuid>-<name>.<ext>`; only
 // image extensions (from the shared list) are recovered as image attachments.
-// The name segment is restricted to the host sanitizer's allowlist charset and
-// matched greedily, so a multi-dot name (`photo.jpg.backup.png`) resolves to
-// its LAST image extension instead of truncating at the first. A non-image
-// name whose interior contains an image extension (`photo.jpg.tmp`) is still
-// ambiguous — Grok concatenates path and prompt with no delimiter — and will
-// mis-split; that is inherent to the format, not recoverable here.
+// The `<ts>-<uuid>` segment is matched structurally (digits + v4-shaped UUID,
+// mirroring buildAttachmentTempFileName) so prose or user files that merely
+// start with `orca-file-` never convert. The name segment is restricted to the
+// host sanitizer's allowlist charset and matched greedily, so a multi-dot name
+// (`photo.jpg.backup.png`) resolves to its LAST image extension instead of
+// truncating at the first.
 // (Regex is assembled from the static shared extension list, not user input.)
-const GROK_PASTED_IMAGE_NAME = `(?:orca-paste-[^\\\\/\\r\\n]+?\\.png|orca-file-[\\p{L}\\p{N}\\p{M}._-]+\\.(?:${IMAGE_FILE_EXTENSIONS.map((ext) => ext.slice(1)).join('|')}))`
+const GROK_MOBILE_UPLOAD_NAME_PREFIX =
+  'orca-file-\\d+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-'
+const GROK_PASTED_IMAGE_NAME = `(?:orca-paste-[^\\\\/\\r\\n]+?\\.png|${GROK_MOBILE_UPLOAD_NAME_PREFIX}[\\p{L}\\p{N}\\p{M}._-]+\\.(?:${IMAGE_FILE_EXTENSIONS.map((ext) => ext.slice(1)).join('|')}))`
 
 const GROK_PASTED_IMAGE_RE = new RegExp(
   `^((?:[a-z]:[\\\\/]|\\/|[\\\\/]{2}[^\\\\/\\r\\n]+[\\\\/][^\\\\/\\r\\n]+[\\\\/])(?:.*?[\\\\/])?${GROK_PASTED_IMAGE_NAME})([\\s\\S]*)$`,
@@ -237,7 +239,15 @@ function splitGrokPastedImageQuery(text: string): { path: string; query: string 
   if (!match?.[1]) {
     return null
   }
-  return { path: match[1], query: (match[2] ?? '').trim() }
+  const query = match[2] ?? ''
+  // Why: for mobile names the tail is user-controlled, so a remainder that
+  // continues with separator+name characters (`.tmp summarize`) more plausibly
+  // extends a non-image filename than starts a prompt. The delimiter-free
+  // format cannot distinguish — fail safe to plain text rather than mis-split.
+  if (/orca-file-/i.test(match[1]) && /^[._-][\p{L}\p{N}\p{M}]/u.test(query)) {
+    return null
+  }
+  return { path: match[1], query: query.trim() }
 }
 
 function stripGrokUserQueryEnvelope(text: string): string {

--- a/src/main/native-chat/transcript-line-decoders-grok.ts
+++ b/src/main/native-chat/transcript-line-decoders-grok.ts
@@ -1,6 +1,7 @@
 // Grok chat_history.jsonl line → NativeChatMessage decoder.
 
 import type { NativeChatBlock, NativeChatMessage } from '../../shared/native-chat-types'
+import { IMAGE_FILE_EXTENSIONS } from '../../shared/image-file-extensions'
 import {
   asRecord,
   extractString,
@@ -213,12 +214,26 @@ function normalizeGrokUserQueryBlock(block: NativeChatBlock): NativeChatBlock[] 
   ]
 }
 
+// Mobile Files-picker uploads use `orca-file-<ts>-<uuid>-<name>.<ext>`; only
+// image extensions (from the shared list) are recovered as image attachments.
+// The name segment is restricted to the host sanitizer's allowlist charset and
+// matched greedily, so a multi-dot name (`photo.jpg.backup.png`) resolves to
+// its LAST image extension instead of truncating at the first. A non-image
+// name whose interior contains an image extension (`photo.jpg.tmp`) is still
+// ambiguous — Grok concatenates path and prompt with no delimiter — and will
+// mis-split; that is inherent to the format, not recoverable here.
+// (Regex is assembled from the static shared extension list, not user input.)
+const GROK_PASTED_IMAGE_NAME = `(?:orca-paste-[^\\\\/\\r\\n]+?\\.png|orca-file-[\\p{L}\\p{N}\\p{M}._-]+\\.(?:${IMAGE_FILE_EXTENSIONS.map((ext) => ext.slice(1)).join('|')}))`
+
+const GROK_PASTED_IMAGE_RE = new RegExp(
+  `^((?:[a-z]:[\\\\/]|\\/|[\\\\/]{2}[^\\\\/\\r\\n]+[\\\\/][^\\\\/\\r\\n]+[\\\\/])(?:.*?[\\\\/])?${GROK_PASTED_IMAGE_NAME})([\\s\\S]*)$`,
+  'iu'
+)
+
 function splitGrokPastedImageQuery(text: string): { path: string; query: string } | null {
   // Why: Grok 0.2.93 persists clipboard images as an absolute temp path directly
   // concatenated with the prompt; recover Orca's attachment without exposing it.
-  const match = text.match(
-    /^((?:[a-z]:[\\/]|\/|[\\/]{2}[^\\/\r\n]+[\\/][^\\/\r\n]+[\\/])(?:.*?[\\/])?orca-paste-[^\\/\r\n]+?\.png)([\s\S]*)$/i
-  )
+  const match = text.match(GROK_PASTED_IMAGE_RE)
   if (!match?.[1]) {
     return null
   }

--- a/src/main/native-chat/transcript-line-decoders-grok.ts
+++ b/src/main/native-chat/transcript-line-decoders-grok.ts
@@ -240,11 +240,10 @@ function splitGrokPastedImageQuery(text: string): { path: string; query: string 
     return null
   }
   const query = match[2] ?? ''
-  // Why: for mobile names the tail is user-controlled, so a remainder that
-  // continues with separator+name characters (`.tmp summarize`) more plausibly
-  // extends a non-image filename than starts a prompt. The delimiter-free
-  // format cannot distinguish — fail safe to plain text rather than mis-split.
-  if (/orca-file-/i.test(match[1]) && /^[._-][\p{L}\p{N}\p{M}]/u.test(query)) {
+  // Why: generated names never continue past their extension, so a remainder
+  // resuming with separator+name characters (`.tmp summarize`) more plausibly
+  // extends a non-image filename than starts a prompt — fail safe to plain text.
+  if (/^[._-][\p{L}\p{N}\p{M}]/u.test(query)) {
     return null
   }
   return { path: match[1], query: query.trim() }

--- a/src/main/native-chat/transcript-line-decoders.grok.test.ts
+++ b/src/main/native-chat/transcript-line-decoders.grok.test.ts
@@ -59,6 +59,56 @@ describe('decodeGrokTranscriptLine', () => {
     })
   })
 
+  it('restores a mobile Files-picker image upload (orca-file-… name) as an image-ref', () => {
+    const imagePath = '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.jpg'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [
+        { type: 'text', text: `<user_query>\n${imagePath}Describe this image\n</user_query>` }
+      ]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-mobile-image')).toMatchObject({
+      role: 'user',
+      blocks: [
+        { type: 'image-ref', path: imagePath },
+        { type: 'text', text: 'Describe this image' }
+      ]
+    })
+  })
+
+  it('resolves multi-dot mobile upload names to their last image extension', () => {
+    const imagePath = '/tmp/orca-file-1784234906335-f54c579b-photo.jpg.backup.png'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [
+        { type: 'text', text: `<user_query>\n${imagePath}Describe this image\n</user_query>` }
+      ]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-multidot')).toMatchObject({
+      role: 'user',
+      blocks: [
+        { type: 'image-ref', path: imagePath },
+        { type: 'text', text: 'Describe this image' }
+      ]
+    })
+  })
+
+  it('leaves non-image mobile uploads (orca-file-… .pdf) as plain text', () => {
+    const text =
+      '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-report.pdf summarize this'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [{ type: 'text', text: `<user_query>${text}</user_query>` }]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-mobile-pdf')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text }]
+    })
+  })
+
   it('restores an attachment-only pasted image from Grok transcript text', () => {
     const imagePath = '/tmp/orca-paste-1783675302563-2207c073-535f-4b83-a181-61127c8bbd68.png'
     const line = JSON.stringify({

--- a/src/main/native-chat/transcript-line-decoders.grok.test.ts
+++ b/src/main/native-chat/transcript-line-decoders.grok.test.ts
@@ -78,7 +78,8 @@ describe('decodeGrokTranscriptLine', () => {
   })
 
   it('resolves multi-dot mobile upload names to their last image extension', () => {
-    const imagePath = '/tmp/orca-file-1784234906335-f54c579b-photo.jpg.backup.png'
+    const imagePath =
+      '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.jpg.backup.png'
     const line = JSON.stringify({
       type: 'user',
       content: [
@@ -104,6 +105,64 @@ describe('decodeGrokTranscriptLine', () => {
     })
 
     expect(decodeGrokTranscriptLine(line, 'fb-mobile-pdf')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text }]
+    })
+  })
+
+  it('rejects the ambiguous interior-image-extension split instead of truncating the path', () => {
+    // A non-image file (`photo.jpg.tmp`) whose interior contains an image
+    // extension must stay plain text, not become image-ref + garbled prompt.
+    const text =
+      '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.jpg.tmp summarize'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [{ type: 'text', text: `<user_query>${text}</user_query>` }]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-ambiguous-split')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text }]
+    })
+  })
+
+  it('rejects an attachment-only ambiguous name the same way', () => {
+    const text = '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.jpg.tmp'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [{ type: 'text', text: `<user_query>${text}</user_query>` }]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-ambiguous-only')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text }]
+    })
+  })
+
+  it('still splits prompt punctuation that cannot extend a filename', () => {
+    const imagePath = '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.jpg'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [{ type: 'text', text: `<user_query>${imagePath}. What is this?</user_query>` }]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-punctuation')).toMatchObject({
+      role: 'user',
+      blocks: [
+        { type: 'image-ref', path: imagePath },
+        { type: 'text', text: '. What is this?' }
+      ]
+    })
+  })
+
+  it('never converts names without the structural ts-uuid prefix', () => {
+    const text = '/tmp/orca-file-mynotes.png explain'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [{ type: 'text', text: `<user_query>${text}</user_query>` }]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-no-structure')).toMatchObject({
       role: 'user',
       blocks: [{ type: 'text', text }]
     })

--- a/src/main/native-chat/transcript-line-decoders.grok.test.ts
+++ b/src/main/native-chat/transcript-line-decoders.grok.test.ts
@@ -126,6 +126,39 @@ describe('decodeGrokTranscriptLine', () => {
     })
   })
 
+  it('keeps orca-paste handling when a parent directory is named orca-file-…', () => {
+    // The ambiguity guard is branch-free, so a directory name must not
+    // suppress a clipboard-paste split.
+    const imagePath = '/tmp/orca-file-cache/orca-paste-1755000000000-abc.png'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [{ type: 'text', text: `<user_query>${imagePath}what does it show?</user_query>` }]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-paste-dir')).toMatchObject({
+      role: 'user',
+      blocks: [
+        { type: 'image-ref', path: imagePath },
+        { type: 'text', text: 'what does it show?' }
+      ]
+    })
+  })
+
+  it('rejects a separator continuation after an orca-paste name the same way', () => {
+    // Paste names are fully generated (`orca-paste-<ts>-<uuid>.png`), so a
+    // `.backup`-style remainder means the real filename continued past .png.
+    const text = '/tmp/orca-file-cache/orca-paste-report.png.backup summarize'
+    const line = JSON.stringify({
+      type: 'user',
+      content: [{ type: 'text', text: `<user_query>${text}</user_query>` }]
+    })
+
+    expect(decodeGrokTranscriptLine(line, 'fb-paste-sep')).toMatchObject({
+      role: 'user',
+      blocks: [{ type: 'text', text }]
+    })
+  })
+
   it('rejects an attachment-only ambiguous name the same way', () => {
     const text = '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.jpg.tmp'
     const line = JSON.stringify({

--- a/src/renderer/src/components/native-chat/native-chat-image-paste.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-paste.test.ts
@@ -53,14 +53,29 @@ describe('isNativeChatPastedImagePath', () => {
   })
 
   it('detects mobile Files-picker image uploads (orca-file-… with an image extension)', () => {
-    expect(isNativeChatPastedImagePath('/tmp/orca-file-1784234906335-f54c579b-photo.jpg')).toBe(
-      true
-    )
-    expect(isNativeChatPastedImagePath('C:\\Temp\\orca-file-1-2-photo.png')).toBe(true)
+    expect(
+      isNativeChatPastedImagePath(
+        '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.jpg'
+      )
+    ).toBe(true)
+    expect(
+      isNativeChatPastedImagePath(
+        'C:\\Temp\\orca-file-1-f54c579b-819c-4c33-8bd1-2d34ebf871ab-photo.png'
+      )
+    ).toBe(true)
   })
 
   it('does not treat non-image mobile uploads as pasted images', () => {
-    expect(isNativeChatPastedImagePath('/tmp/orca-file-1784234906335-f54c579b-report.pdf')).toBe(
+    expect(
+      isNativeChatPastedImagePath(
+        '/tmp/orca-file-1784234906335-f54c579b-819c-4c33-8bd1-2d34ebf871ab-report.pdf'
+      )
+    ).toBe(false)
+  })
+
+  it('keeps the real name for files without the structural ts-uuid prefix', () => {
+    expect(isNativeChatPastedImagePath('/tmp/orca-file-mynotes.png')).toBe(false)
+    expect(isNativeChatPastedImagePath('/tmp/orca-file-1784234906335-f54c579b-photo.jpg')).toBe(
       false
     )
   })

--- a/src/renderer/src/components/native-chat/native-chat-image-paste.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-paste.test.ts
@@ -51,4 +51,17 @@ describe('isNativeChatPastedImagePath', () => {
     expect(isNativeChatPastedImagePath('/Users/me/Pictures/hero-image-2.png')).toBe(false)
     expect(isNativeChatPastedImagePath('/tmp/screenshot.png')).toBe(false)
   })
+
+  it('detects mobile Files-picker image uploads (orca-file-… with an image extension)', () => {
+    expect(isNativeChatPastedImagePath('/tmp/orca-file-1784234906335-f54c579b-photo.jpg')).toBe(
+      true
+    )
+    expect(isNativeChatPastedImagePath('C:\\Temp\\orca-file-1-2-photo.png')).toBe(true)
+  })
+
+  it('does not treat non-image mobile uploads as pasted images', () => {
+    expect(isNativeChatPastedImagePath('/tmp/orca-file-1784234906335-f54c579b-report.pdf')).toBe(
+      false
+    )
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-image-paste.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-paste.ts
@@ -55,5 +55,10 @@ export function isNativeChatImageAttachmentPath(path: string): boolean {
  *  instead of the basename. */
 export function isNativeChatPastedImagePath(path: string): boolean {
   const base = path.split(/[\\/]/).findLast(Boolean) ?? path
-  return /^orca-paste-.+\.png$/i.test(base)
+  if (/^orca-paste-.+\.png$/i.test(base)) {
+    return true
+  }
+  // Mobile Files-picker uploads keep the original (sanitized) name behind an
+  // `orca-file-<ts>-<uuid>-` prefix; only image extensions are pasted images.
+  return /^orca-file-/i.test(base) && isImageDropPath(base)
 }

--- a/src/renderer/src/components/native-chat/native-chat-image-paste.ts
+++ b/src/renderer/src/components/native-chat/native-chat-image-paste.ts
@@ -60,5 +60,10 @@ export function isNativeChatPastedImagePath(path: string): boolean {
   }
   // Mobile Files-picker uploads keep the original (sanitized) name behind an
   // `orca-file-<ts>-<uuid>-` prefix; only image extensions are pasted images.
-  return /^orca-file-/i.test(base) && isImageDropPath(base)
+  // Match the ts-uuid segment structurally so a user's own file that merely
+  // starts with `orca-file-` keeps its real name in the composer.
+  return (
+    /^orca-file-\d+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}-/i.test(base) &&
+    isImageDropPath(base)
+  )
 }


### PR DESCRIPTION
## Summary

Teaches the two desktop-side pasted-image matchers to recognize mobile Files-picker uploads, which are named `orca-file-<ts>-<uuid>-<original-name>` (naming introduced host-side in #10232): `isNativeChatPastedImagePath` now also matches `orca-file-…` basenames with an image extension (from the shared `IMAGE_FILE_EXTENSIONS` list), and the Grok transcript decoder's path-recovery regex accepts the same names, resolving multi-dot names to their last image extension. Before, an image attached from the mobile Files picker would render as a raw temp path instead of an image chip; non-image uploads (e.g. `.pdf`) intentionally stay plain text. Existing `orca-paste-*.png` behavior is unchanged.

Split out of #9072 — companion foundation to #10232; #9072 will be rebased down to the mobile UI layer once these land.

**Tests:** new cases in `transcript-line-decoders.grok.test.ts` (image-ref recovery for `orca-file` names, multi-dot resolution, `.pdf` left as text) and `native-chat-image-paste.test.ts` (image vs non-image `orca-file` basenames). `pnpm typecheck` and both test files green locally.

**Review starting point:** `GROK_PASTED_IMAGE_NAME` in `src/main/native-chat/transcript-line-decoders-grok.ts`.

cc @OrcaWin

## ELI5

Images uploaded from the mobile Files picker use orca-file- names that desktop chat did not treat as pasted images. Those names are recognized so attachments show and recover correctly in native chat.
