### PR TITLE
feat(runtime): detect client/server app-version skew on status ingestion

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4893,7 +4893,8 @@ export class OrcaRuntimeService {
       minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
       // Why: read from env (stamped at startup in main/index.ts) so this module
       // stays importable without Electron in unit tests.
-      appVersion: process.env.ORCA_APP_VERSION ?? null,
+      // Why: an empty env value must read as missing, not as an unparseable version string.
+      appVersion: process.env.ORCA_APP_VERSION?.trim() || null,
       // Why: headless orca serve cannot create/stream BrowserViews, so clients
       // must not treat browser panes as supported just because runtime RPC is up.
       capabilities,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4891,6 +4891,9 @@ export class OrcaRuntimeService {
       liveLeafCount: this.leaves.size,
       runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
       minCompatibleRuntimeClientVersion: MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
+      // Why: read from env (stamped at startup in main/index.ts) so this module
+      // stays importable without Electron in unit tests.
+      appVersion: process.env.ORCA_APP_VERSION ?? null,
       // Why: headless orca serve cannot create/stream BrowserViews, so clients
       // must not treat browser panes as supported just because runtime RPC is up.
       capabilities,

--- a/src/renderer/src/runtime/client-app-version.ts
+++ b/src/renderer/src/runtime/client-app-version.ts
@@ -1,0 +1,17 @@
+// Why: version-skew evaluation needs this build's own app version wherever a
+// remote runtime status is ingested. The IPC answer never changes within a
+// session, so cache the promise instead of re-asking per status probe.
+let cachedClientAppVersion: Promise<string | null> | null = null
+
+export function getClientAppVersion(): Promise<string | null> {
+  // Why: resolve inside the chain so a missing preload surface (minimal test
+  // store assemblies) degrades to "unknown version" instead of throwing.
+  cachedClientAppVersion ??= Promise.resolve()
+    .then(() => window.api.updater.getVersion())
+    .catch(() => null)
+  return cachedClientAppVersion
+}
+
+export function resetClientAppVersionForTests(): void {
+  cachedClientAppVersion = null
+}

--- a/src/renderer/src/runtime/client-app-version.ts
+++ b/src/renderer/src/runtime/client-app-version.ts
@@ -8,7 +8,12 @@ export function getClientAppVersion(): Promise<string | null> {
   // store assemblies) degrades to "unknown version" instead of throwing.
   cachedClientAppVersion ??= Promise.resolve()
     .then(() => window.api.updater.getVersion())
-    .catch(() => null)
+    .catch(() => {
+      // Why: a rejected lookup must not poison the cache — clear it so the next
+      // status ingestion retries instead of skipping skew detection all session.
+      cachedClientAppVersion = null
+      return null
+    })
   return cachedClientAppVersion
 }
 

--- a/src/renderer/src/store/slices/runtime-disconnected-toast.ts
+++ b/src/renderer/src/store/slices/runtime-disconnected-toast.ts
@@ -1,0 +1,86 @@
+import { toast } from 'sonner'
+import type { AppState } from '../types'
+import { translate } from '@/i18n/i18n'
+
+const activeRuntimeDisconnectedToasts = new Map<string, symbol>()
+const RUNTIME_DISCONNECTED_TOAST_DURATION_MS = 4_000
+
+function getRuntimeDisconnectedToastId(environmentId: string): string {
+  return `runtime-environment-disconnected:${environmentId}`
+}
+
+export function showRuntimeDisconnectedToast(
+  environmentId: string,
+  getState: () => AppState
+): void {
+  const environment = getState().runtimeEnvironments.find((entry) => entry.id === environmentId)
+  const toastId = getRuntimeDisconnectedToastId(environmentId)
+  const activation = Symbol(toastId)
+  const title = environment?.name
+    ? translate(
+        'auto.store.slices.runtime.status.runtimeHostUnreachableNamed',
+        "Can't reach {{hostName}}",
+        { hostName: environment.name }
+      )
+    : translate(
+        'auto.store.slices.runtime.status.runtimeHostUnreachable',
+        "Can't reach Orca server"
+      )
+  activeRuntimeDisconnectedToasts.set(toastId, activation)
+  const clearActiveToast = (): void => {
+    if (activeRuntimeDisconnectedToasts.get(toastId) === activation) {
+      activeRuntimeDisconnectedToasts.delete(toastId)
+    }
+  }
+  let retrying = false
+  const showToast = (duration = RUNTIME_DISCONNECTED_TOAST_DURATION_MS): void => {
+    toast.warning(title, {
+      id: toastId,
+      description: translate(
+        'auto.store.slices.runtime.status.runtimeHostDisconnectedDescription',
+        'Check that Orca is running on this server and that your network connection is working, then try again.'
+      ),
+      duration,
+      action: {
+        label: translate('auto.store.slices.runtime.status.tryAgain', 'Try again'),
+        onClick: (event) => {
+          // Why: Sonner otherwise deletes the keyed toast after the action callback.
+          event.preventDefault()
+          if (retrying) {
+            return
+          }
+          retrying = true
+          showToast(Number.POSITIVE_INFINITY)
+          void getState()
+            .refreshRuntimeEnvironmentStatus(environmentId)
+            .then((reachable) => {
+              const stillSaved = getState().runtimeEnvironments.some(
+                (entry) => entry.id === environmentId
+              )
+              if (
+                !reachable &&
+                stillSaved &&
+                activeRuntimeDisconnectedToasts.get(toastId) === activation
+              ) {
+                showToast()
+              }
+            })
+            .finally(() => {
+              retrying = false
+            })
+        }
+      },
+      onDismiss: clearActiveToast,
+      onAutoClose: clearActiveToast
+    })
+  }
+  showToast()
+}
+
+export function dismissRuntimeDisconnectedToast(environmentId: string): void {
+  const toastId = getRuntimeDisconnectedToastId(environmentId)
+  if (!activeRuntimeDisconnectedToasts.delete(toastId)) {
+    return
+  }
+  toast.dismiss?.(toastId)
+}

--- a/src/renderer/src/store/slices/runtime-environment-status-entry.ts
+++ b/src/renderer/src/store/slices/runtime-environment-status-entry.ts
@@ -1,0 +1,58 @@
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import { evaluateAppVersionSkew, type AppVersionSkew } from '../../../../shared/app-version-skew'
+import { getClientAppVersion } from '@/runtime/client-app-version'
+
+/** Live status for one saved runtime environment, as last observed by the
+ * renderer. `status === null` records a probe that failed or timed out so the
+ * sidebar can still distinguish "unknown/unreachable" from "never checked". */
+export type RuntimeEnvironmentStatus = {
+  status: RuntimeStatus | null
+  appVersion?: string | null
+  /** Non-blocking client/server app-version skew; null when versions match,
+   * the server is unreachable, or this build's version is unknown. */
+  versionSkew?: AppVersionSkew | null
+  checkedAt: number
+  connectionGeneration?: number
+}
+
+// Why: skew detection is best-effort decoration — a stalled version IPC must
+// never delay or block publishing a live server status.
+const CLIENT_APP_VERSION_TIMEOUT_MS = 2_000
+
+async function getClientAppVersionBounded(): Promise<string | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      getClientAppVersion(),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), CLIENT_APP_VERSION_TIMEOUT_MS)
+      })
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/** Builds a store entry from one probe result, deriving app-version skew
+ * against this build. Shared by the boot/refresh probes and the host menu's
+ * manual "Check connection" so no ingestion path drops the skew verdict. */
+export async function buildRuntimeEnvironmentStatusEntry(
+  status: RuntimeStatus | null
+): Promise<RuntimeEnvironmentStatus> {
+  // Why: stamp before the version lookup so checkedAt reflects when the server
+  // answered, not when the (possibly first-call) version IPC resolved.
+  const checkedAt = Date.now()
+  if (!status) {
+    return { status: null, checkedAt }
+  }
+  const clientAppVersion = await getClientAppVersionBounded()
+  return {
+    status,
+    appVersion: status.appVersion ?? null,
+    versionSkew: evaluateAppVersionSkew({
+      clientAppVersion,
+      serverAppVersion: status.appVersion ?? null
+    }),
+    checkedAt
+  }
+}

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -433,6 +433,23 @@ describe('runtime-status slice', () => {
     expect(store.getState().runtimeStatusByEnvironmentId.has('env-removed-midflight')).toBe(false)
   })
 
+  it('does not commit a pre-removal probe after the same id is re-added', async () => {
+    let resolveStatus!: (value: unknown) => void
+    const getStatus = vi.fn().mockReturnValue(new Promise((resolve) => (resolveStatus = resolve)))
+    stubRuntimeEnvironmentApi({ getStatus })
+    const store = createSliceStore()
+    store.getState().setRuntimeEnvironments([{ id: 'env-readded', createdAt: 1 } as never])
+
+    // First probe: no status has been cached yet when the env is removed.
+    const refresh = store.getState().refreshRuntimeEnvironmentStatus('env-readded')
+    store.getState().setRuntimeEnvironments([])
+    store.getState().setRuntimeEnvironments([{ id: 'env-readded', createdAt: 2 } as never])
+    resolveStatus(createCompatibleRuntimeStatusResponse('runtime-a'))
+
+    await expect(refresh).resolves.toBe(false)
+    expect(store.getState().runtimeStatusByEnvironmentId.has('env-readded')).toBe(false)
+  })
+
   it('does not commit a probe that started before the environment was re-paired', async () => {
     let resolveStatus!: (value: unknown) => void
     const getStatus = vi.fn().mockReturnValue(new Promise((resolve) => (resolveStatus = resolve)))

--- a/src/renderer/src/store/slices/runtime-status.test.ts
+++ b/src/renderer/src/store/slices/runtime-status.test.ts
@@ -8,6 +8,7 @@ import {
   callRuntimeRpc,
   clearRuntimeCompatibilityCacheForTests
 } from '../../runtime/runtime-rpc-client'
+import { resetClientAppVersionForTests } from '../../runtime/client-app-version'
 import {
   createRuntimeStatusSlice,
   type RuntimeStatusSlice,
@@ -57,17 +58,20 @@ function makeEnvironment(
 
 function stubRuntimeEnvironmentApi({
   getStatus = vi.fn(),
-  list = vi.fn()
+  list = vi.fn(),
+  updater
 }: {
   getStatus?: ReturnType<typeof vi.fn>
   list?: ReturnType<typeof vi.fn>
+  updater?: { getVersion: () => Promise<string> }
 }) {
   vi.stubGlobal('window', {
     api: {
       runtimeEnvironments: {
         getStatus,
         list
-      }
+      },
+      ...(updater ? { updater } : {})
     }
   })
   return { getStatus, list }
@@ -357,6 +361,95 @@ describe('runtime-status slice', () => {
       'runtime-a'
     )
     expect(store.getState().runtimeStatusByEnvironmentId.get('env-a')?.connectionGeneration).toBe(1)
+  })
+
+  it('publishes a reachable status even when the client-version lookup stalls', async () => {
+    vi.useFakeTimers()
+    try {
+      resetClientAppVersionForTests()
+      const getStatus = vi
+        .fn()
+        .mockResolvedValue(createCompatibleRuntimeStatusResponse('runtime-a'))
+      stubRuntimeEnvironmentApi({
+        getStatus,
+        updater: { getVersion: () => new Promise<string>(() => {}) }
+      })
+      const store = createSliceStore()
+
+      const refresh = store.getState().refreshRuntimeEnvironmentStatus('env-stalled-version')
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      await expect(refresh).resolves.toBe(true)
+      const entry = store.getState().runtimeStatusByEnvironmentId.get('env-stalled-version')
+      expect(entry?.status?.runtimeId).toBe('runtime-a')
+      expect(entry?.versionSkew).toBeNull()
+    } finally {
+      vi.useRealTimers()
+      resetClientAppVersionForTests()
+    }
+  })
+
+  it('stamps checkedAt when the server answered, not after the version lookup', async () => {
+    vi.useFakeTimers()
+    try {
+      resetClientAppVersionForTests()
+      const getStatus = vi
+        .fn()
+        .mockResolvedValue(createCompatibleRuntimeStatusResponse('runtime-a'))
+      const getVersion = vi
+        .fn()
+        .mockReturnValue(new Promise<string>((resolve) => setTimeout(() => resolve('1.2.3'), 500)))
+      stubRuntimeEnvironmentApi({ getStatus, updater: { getVersion } })
+      const store = createSliceStore()
+      const statusReceivedAt = Date.now()
+
+      const refresh = store.getState().refreshRuntimeEnvironmentStatus('env-checked-at')
+      await vi.advanceTimersByTimeAsync(500)
+
+      await expect(refresh).resolves.toBe(true)
+      expect(store.getState().runtimeStatusByEnvironmentId.get('env-checked-at')?.checkedAt).toBe(
+        statusReceivedAt
+      )
+    } finally {
+      vi.useRealTimers()
+      resetClientAppVersionForTests()
+    }
+  })
+
+  it('does not commit a probe for an environment removed while the probe was in flight', async () => {
+    let resolveStatus!: (value: unknown) => void
+    const getStatus = vi.fn().mockReturnValue(new Promise((resolve) => (resolveStatus = resolve)))
+    stubRuntimeEnvironmentApi({ getStatus })
+    const store = createSliceStore()
+    store
+      .getState()
+      .setRuntimeEnvironments([{ id: 'env-removed-midflight', createdAt: 1 } as never])
+
+    const refresh = store.getState().refreshRuntimeEnvironmentStatus('env-removed-midflight')
+    store.getState().setRuntimeEnvironments([])
+    resolveStatus(createCompatibleRuntimeStatusResponse('runtime-a'))
+
+    await expect(refresh).resolves.toBe(false)
+    expect(store.getState().runtimeStatusByEnvironmentId.has('env-removed-midflight')).toBe(false)
+  })
+
+  it('does not commit a probe that started before the environment was re-paired', async () => {
+    let resolveStatus!: (value: unknown) => void
+    const getStatus = vi.fn().mockReturnValue(new Promise((resolve) => (resolveStatus = resolve)))
+    stubRuntimeEnvironmentApi({ getStatus })
+    const store = createSliceStore()
+    store
+      .getState()
+      .setRuntimeEnvironments([{ id: 'env-repaired', createdAt: 1, pairingRevision: 1 } as never])
+
+    const refresh = store.getState().refreshRuntimeEnvironmentStatus('env-repaired')
+    store
+      .getState()
+      .setRuntimeEnvironments([{ id: 'env-repaired', createdAt: 1, pairingRevision: 2 } as never])
+    resolveStatus(createCompatibleRuntimeStatusResponse('runtime-a'))
+
+    await expect(refresh).resolves.toBe(false)
+    expect(store.getState().runtimeStatusByEnvironmentId.has('env-repaired')).toBe(false)
   })
 
   it('advances connection generation after recovery without churning stable status polls', () => {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -110,12 +110,15 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       .filter((id) => !nextIds.has(id))
     set((s) => {
       const keep = new Set(environments.map((environment) => environment.id))
+      const removedIdSet = new Set(removedIds)
       const nextStatuses = new Map(s.runtimeStatusByEnvironmentId)
       let statusesChanged = false
       for (const id of nextStatuses.keys()) {
         if (!keep.has(id)) {
           nextStatuses.delete(id)
-          advanceRuntimeEnvironmentConnectionGeneration(id)
+          if (!removedIdSet.has(id)) {
+            advanceRuntimeEnvironmentConnectionGeneration(id)
+          }
           statusesChanged = true
         }
       }
@@ -131,6 +134,11 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       const nextRemoved = new Set(s.removedRuntimeEnvironmentIds)
       let removedChanged = false
       for (const id of removedIds) {
+        // Why: advance for every removed id, cached status or not — a first
+        // probe can be in flight before any status exists, and a remove +
+        // same-id re-add clears the tombstone, so only the generation can stop
+        // that stale probe committing to the new pairing.
+        advanceRuntimeEnvironmentConnectionGeneration(id)
         if (!nextRemoved.has(id)) {
           nextRemoved.add(id)
           removedChanged = true

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -3,6 +3,8 @@ import { toast } from 'sonner'
 import type { AppState } from '../types'
 import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import { evaluateAppVersionSkew, type AppVersionSkew } from '../../../../shared/app-version-skew'
+import { getClientAppVersion } from '@/runtime/client-app-version'
 import {
   clearRecentRuntimeCompatibilityFailure,
   clearRuntimeCompatibilityCache,
@@ -18,8 +20,32 @@ import { bumpProviderRuntimeSessionGeneration } from '@/lib/provider-runtime-con
 export type RuntimeEnvironmentStatus = {
   status: RuntimeStatus | null
   appVersion?: string | null
+  /** Non-blocking client/server app-version skew; null when versions match,
+   * the server is unreachable, or this build's version is unknown. */
+  versionSkew?: AppVersionSkew | null
   checkedAt: number
   connectionGeneration?: number
+}
+
+/** Builds a store entry from one probe result, deriving app-version skew
+ * against this build. Shared by the boot/refresh probes and the host menu's
+ * manual "Check connection" so no ingestion path drops the skew verdict. */
+export async function buildRuntimeEnvironmentStatusEntry(
+  status: RuntimeStatus | null
+): Promise<RuntimeEnvironmentStatus> {
+  if (!status) {
+    return { status: null, checkedAt: Date.now() }
+  }
+  const clientAppVersion = await getClientAppVersion()
+  return {
+    status,
+    appVersion: status.appVersion ?? null,
+    versionSkew: evaluateAppVersionSkew({
+      clientAppVersion,
+      serverAppVersion: status.appVersion ?? null
+    }),
+    checkedAt: Date.now()
+  }
 }
 
 export type RuntimeStatusSlice = {
@@ -328,7 +354,10 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
       const status = unwrapRuntimeRpcResult<RuntimeStatus>(response)
       // setRuntimeEnvironmentStatus drops any stale compat failure on a non-null
       // (reachable) status, so a recovered host's reuse-flagged refetches re-probe.
-      get().setRuntimeEnvironmentStatus(environmentId, { status, checkedAt: Date.now() })
+      get().setRuntimeEnvironmentStatus(
+        environmentId,
+        await buildRuntimeEnvironmentStatusEntry(status)
+      )
       return true
     } catch {
       get().setRuntimeEnvironmentStatus(environmentId, {

--- a/src/renderer/src/store/slices/runtime-status.ts
+++ b/src/renderer/src/store/slices/runtime-status.ts
@@ -1,52 +1,25 @@
 import type { StateCreator } from 'zustand'
-import { toast } from 'sonner'
 import type { AppState } from '../types'
 import type { PublicKnownRuntimeEnvironment } from '../../../../shared/runtime-environments'
 import type { RuntimeStatus } from '../../../../shared/runtime-types'
-import { evaluateAppVersionSkew, type AppVersionSkew } from '../../../../shared/app-version-skew'
-import { getClientAppVersion } from '@/runtime/client-app-version'
+import {
+  buildRuntimeEnvironmentStatusEntry,
+  type RuntimeEnvironmentStatus
+} from './runtime-environment-status-entry'
+import {
+  dismissRuntimeDisconnectedToast,
+  showRuntimeDisconnectedToast
+} from './runtime-disconnected-toast'
 import {
   clearRecentRuntimeCompatibilityFailure,
   clearRuntimeCompatibilityCache,
   unwrapRuntimeRpcResult
 } from '@/runtime/runtime-rpc-client'
 import { replaceRuntimeEnvironmentRevisions } from '@/runtime/runtime-environment-revision'
-import { translate } from '@/i18n/i18n'
 import { bumpProviderRuntimeSessionGeneration } from '@/lib/provider-runtime-context'
 
-/** Live status for one saved runtime environment, as last observed by the
- * renderer. `status === null` records a probe that failed or timed out so the
- * sidebar can still distinguish "unknown/unreachable" from "never checked". */
-export type RuntimeEnvironmentStatus = {
-  status: RuntimeStatus | null
-  appVersion?: string | null
-  /** Non-blocking client/server app-version skew; null when versions match,
-   * the server is unreachable, or this build's version is unknown. */
-  versionSkew?: AppVersionSkew | null
-  checkedAt: number
-  connectionGeneration?: number
-}
-
-/** Builds a store entry from one probe result, deriving app-version skew
- * against this build. Shared by the boot/refresh probes and the host menu's
- * manual "Check connection" so no ingestion path drops the skew verdict. */
-export async function buildRuntimeEnvironmentStatusEntry(
-  status: RuntimeStatus | null
-): Promise<RuntimeEnvironmentStatus> {
-  if (!status) {
-    return { status: null, checkedAt: Date.now() }
-  }
-  const clientAppVersion = await getClientAppVersion()
-  return {
-    status,
-    appVersion: status.appVersion ?? null,
-    versionSkew: evaluateAppVersionSkew({
-      clientAppVersion,
-      serverAppVersion: status.appVersion ?? null
-    }),
-    checkedAt: Date.now()
-  }
-}
+export { buildRuntimeEnvironmentStatusEntry }
+export type { RuntimeEnvironmentStatus }
 
 export type RuntimeStatusSlice = {
   /** Saved remote Orca servers. Host pickers use this to show user-chosen names
@@ -90,85 +63,6 @@ export type RuntimeStatusSlice = {
 }
 
 const connectionGenerationByEnvironment = new Map<string, number>()
-const activeRuntimeDisconnectedToasts = new Map<string, symbol>()
-const RUNTIME_DISCONNECTED_TOAST_DURATION_MS = 4_000
-
-function getRuntimeDisconnectedToastId(environmentId: string): string {
-  return `runtime-environment-disconnected:${environmentId}`
-}
-
-function showRuntimeDisconnectedToast(environmentId: string, getState: () => AppState): void {
-  const environment = getState().runtimeEnvironments.find((entry) => entry.id === environmentId)
-  const toastId = getRuntimeDisconnectedToastId(environmentId)
-  const activation = Symbol(toastId)
-  const title = environment?.name
-    ? translate(
-        'auto.store.slices.runtime.status.runtimeHostUnreachableNamed',
-        "Can't reach {{hostName}}",
-        { hostName: environment.name }
-      )
-    : translate(
-        'auto.store.slices.runtime.status.runtimeHostUnreachable',
-        "Can't reach Orca server"
-      )
-  activeRuntimeDisconnectedToasts.set(toastId, activation)
-  const clearActiveToast = (): void => {
-    if (activeRuntimeDisconnectedToasts.get(toastId) === activation) {
-      activeRuntimeDisconnectedToasts.delete(toastId)
-    }
-  }
-  let retrying = false
-  const showToast = (duration = RUNTIME_DISCONNECTED_TOAST_DURATION_MS): void => {
-    toast.warning(title, {
-      id: toastId,
-      description: translate(
-        'auto.store.slices.runtime.status.runtimeHostDisconnectedDescription',
-        'Check that Orca is running on this server and that your network connection is working, then try again.'
-      ),
-      duration,
-      action: {
-        label: translate('auto.store.slices.runtime.status.tryAgain', 'Try again'),
-        onClick: (event) => {
-          // Why: Sonner otherwise deletes the keyed toast after the action callback.
-          event.preventDefault()
-          if (retrying) {
-            return
-          }
-          retrying = true
-          showToast(Number.POSITIVE_INFINITY)
-          void getState()
-            .refreshRuntimeEnvironmentStatus(environmentId)
-            .then((reachable) => {
-              const stillSaved = getState().runtimeEnvironments.some(
-                (entry) => entry.id === environmentId
-              )
-              if (
-                !reachable &&
-                stillSaved &&
-                activeRuntimeDisconnectedToasts.get(toastId) === activation
-              ) {
-                showToast()
-              }
-            })
-            .finally(() => {
-              retrying = false
-            })
-        }
-      },
-      onDismiss: clearActiveToast,
-      onAutoClose: clearActiveToast
-    })
-  }
-  showToast()
-}
-
-function dismissRuntimeDisconnectedToast(environmentId: string): void {
-  const toastId = getRuntimeDisconnectedToastId(environmentId)
-  if (!activeRuntimeDisconnectedToasts.delete(toastId)) {
-    return
-  }
-  toast.dismiss?.(toastId)
-}
 
 export function getRuntimeEnvironmentConnectionGeneration(environmentId: string): number {
   return connectionGenerationByEnvironment.get(environmentId) ?? 0
@@ -346,20 +240,31 @@ export const createRuntimeStatusSlice: StateCreator<AppState, [], [], RuntimeSta
   },
 
   refreshRuntimeEnvironmentStatus: async (environmentId, timeoutMs = 10_000) => {
+    // Why: the probe awaits across removal/re-pair windows; a result whose
+    // environment was tombstoned or whose connection generation advanced
+    // belongs to a retired peer and must not be committed (#8881).
+    const probeGeneration = getRuntimeEnvironmentConnectionGeneration(environmentId)
+    const probeRetired = (): boolean =>
+      get().removedRuntimeEnvironmentIds.has(environmentId) ||
+      getRuntimeEnvironmentConnectionGeneration(environmentId) !== probeGeneration
     try {
       const response = await window.api.runtimeEnvironments.getStatus({
         selector: environmentId,
         timeoutMs
       })
       const status = unwrapRuntimeRpcResult<RuntimeStatus>(response)
+      const entry = await buildRuntimeEnvironmentStatusEntry(status)
+      if (probeRetired()) {
+        return false
+      }
       // setRuntimeEnvironmentStatus drops any stale compat failure on a non-null
       // (reachable) status, so a recovered host's reuse-flagged refetches re-probe.
-      get().setRuntimeEnvironmentStatus(
-        environmentId,
-        await buildRuntimeEnvironmentStatusEntry(status)
-      )
+      get().setRuntimeEnvironmentStatus(environmentId, entry)
       return true
     } catch {
+      if (probeRetired()) {
+        return false
+      }
       get().setRuntimeEnvironmentStatus(environmentId, {
         status: null,
         checkedAt: Date.now()

--- a/src/shared/app-version-skew.test.ts
+++ b/src/shared/app-version-skew.test.ts
@@ -96,6 +96,24 @@ describe('parseAppVersion', () => {
     expect(parseAppVersion('1.4')).toBeNull()
     expect(parseAppVersion('v1.4.147')).toBeNull()
   })
+
+  it('rejects leading-zero and empty identifiers instead of mis-ranking them', () => {
+    expect(parseAppVersion('01.4.147')).toBeNull()
+    expect(parseAppVersion('1.04.147')).toBeNull()
+    expect(parseAppVersion('1.4.147-rc..1')).toBeNull()
+    expect(parseAppVersion('1.4.147-rc.01')).toBeNull()
+    expect(parseAppVersion('1.4.147-.rc')).toBeNull()
+    expect(parseAppVersion('1.4.147+build..1')).toBeNull()
+    // Zero itself and zero-containing alphanumerics stay valid per SemVer.
+    expect(parseAppVersion('1.4.147-rc.0')).toEqual({
+      release: [1, 4, 147],
+      prerelease: ['rc', '0']
+    })
+    expect(parseAppVersion('1.4.147-01a')).toEqual({
+      release: [1, 4, 147],
+      prerelease: ['01a']
+    })
+  })
 })
 
 describe('describeAppVersionSkew', () => {

--- a/src/shared/app-version-skew.test.ts
+++ b/src/shared/app-version-skew.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { describeAppVersionSkew, evaluateAppVersionSkew, parseAppVersion } from './app-version-skew'
+
+describe('evaluateAppVersionSkew', () => {
+  it('returns null when client and server versions match', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: '1.4.147' })
+    ).toBeNull()
+  })
+
+  it('flags a server running behind the client', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: '1.4.146' })
+    ).toEqual({
+      direction: 'server-older',
+      clientAppVersion: '1.4.147',
+      serverAppVersion: '1.4.146'
+    })
+  })
+
+  it('flags a server running ahead of the client', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: '1.5.0' })
+    ).toEqual({
+      direction: 'server-newer',
+      clientAppVersion: '1.4.147',
+      serverAppVersion: '1.5.0'
+    })
+  })
+
+  it('treats a server that reports no version as older', () => {
+    expect(evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: null })).toEqual(
+      {
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: null
+      }
+    )
+  })
+
+  it('ranks a release above its own release candidates', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.124', serverAppVersion: '1.4.124-rc.1' })
+    ).toMatchObject({ direction: 'server-older' })
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.124-rc.1', serverAppVersion: '1.4.124' })
+    ).toMatchObject({ direction: 'server-newer' })
+  })
+
+  it('orders release candidates numerically', () => {
+    expect(
+      evaluateAppVersionSkew({
+        clientAppVersion: '1.4.124-rc.10',
+        serverAppVersion: '1.4.124-rc.2'
+      })
+    ).toMatchObject({ direction: 'server-older' })
+  })
+
+  it('stays silent when the client version is unknown or unparseable', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: null, serverAppVersion: '1.4.146' })
+    ).toBeNull()
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: 'dev', serverAppVersion: '1.4.146' })
+    ).toBeNull()
+  })
+
+  it('stays silent when the server version is present but unparseable', () => {
+    expect(
+      evaluateAppVersionSkew({ clientAppVersion: '1.4.147', serverAppVersion: 'weird-build' })
+    ).toBeNull()
+  })
+
+  it('ignores build metadata when comparing', () => {
+    expect(
+      evaluateAppVersionSkew({
+        clientAppVersion: '1.4.147+abc123',
+        serverAppVersion: '1.4.147+def456'
+      })
+    ).toBeNull()
+  })
+})
+
+describe('parseAppVersion', () => {
+  it('parses release and prerelease forms', () => {
+    expect(parseAppVersion('1.4.147')).toEqual({ release: [1, 4, 147], prerelease: null })
+    expect(parseAppVersion('1.4.124-rc.1')).toEqual({
+      release: [1, 4, 124],
+      prerelease: ['rc', '1']
+    })
+  })
+
+  it('rejects malformed versions', () => {
+    expect(parseAppVersion('')).toBeNull()
+    expect(parseAppVersion(undefined)).toBeNull()
+    expect(parseAppVersion('1.4')).toBeNull()
+    expect(parseAppVersion('v1.4.147')).toBeNull()
+  })
+})
+
+describe('describeAppVersionSkew', () => {
+  it('tells the user to update the server when it is older', () => {
+    expect(
+      describeAppVersionSkew({
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: '1.4.146'
+      })
+    ).toBe(
+      'This Orca server (1.4.146) is older than your app (1.4.147). Update the server, or some features may fail.'
+    )
+  })
+
+  it('handles servers that predate version reporting', () => {
+    expect(
+      describeAppVersionSkew({
+        direction: 'server-older',
+        clientAppVersion: '1.4.147',
+        serverAppVersion: null
+      })
+    ).toBe(
+      'This Orca server is older than your app (1.4.147). Update the server, or some features may fail.'
+    )
+  })
+
+  it('tells the user to update the app when the server is newer', () => {
+    expect(
+      describeAppVersionSkew({
+        direction: 'server-newer',
+        clientAppVersion: '1.4.146',
+        serverAppVersion: '1.4.147'
+      })
+    ).toBe(
+      'This Orca server (1.4.147) is newer than your app (1.4.146). Update this app, or some features may fail.'
+    )
+  })
+})

--- a/src/shared/app-version-skew.test.ts
+++ b/src/shared/app-version-skew.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { describeAppVersionSkew, evaluateAppVersionSkew, parseAppVersion } from './app-version-skew'
+import {
+  compareAppVersions,
+  describeAppVersionSkew,
+  evaluateAppVersionSkew,
+  parseAppVersion
+} from './app-version-skew'
 
 describe('evaluateAppVersionSkew', () => {
   it('returns null when client and server versions match', () => {
@@ -113,6 +118,24 @@ describe('parseAppVersion', () => {
       release: [1, 4, 147],
       prerelease: ['01a']
     })
+  })
+
+  it('rejects release segments beyond safe-integer precision instead of mis-comparing them', () => {
+    expect(parseAppVersion('9007199254740993.0.0')).toBeNull()
+    expect(parseAppVersion('1.2.9007199254740993')).toBeNull()
+    // The safe-integer boundary itself still parses.
+    expect(parseAppVersion('9007199254740991.0.0')).toEqual({
+      release: [9007199254740991, 0, 0],
+      prerelease: null
+    })
+  })
+
+  it('compares huge numeric prerelease identifiers exactly', () => {
+    const older = parseAppVersion('1.0.0-rc.9007199254740992')
+    const newer = parseAppVersion('1.0.0-rc.9007199254740993')
+    expect(older).not.toBeNull()
+    expect(newer).not.toBeNull()
+    expect(compareAppVersions(older!, newer!)).toBeLessThan(0)
   })
 })
 

--- a/src/shared/app-version-skew.ts
+++ b/src/shared/app-version-skew.ts
@@ -26,13 +26,24 @@ export function parseAppVersion(version: string | null | undefined): ParsedAppVe
   if (!trimmed) {
     return null
   }
-  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(trimmed)
+  // Why: strict SemVer shapes only — a malformed identifier must read as
+  // "unknown version" (null), never produce a false skew verdict.
+  const match =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+      trimmed
+    )
   if (!match) {
+    return null
+  }
+  const prerelease = match[4] ? match[4].split('.') : null
+  if (
+    prerelease?.some((id) => id === '' || (/^\d+$/.test(id) && id.length > 1 && id.startsWith('0')))
+  ) {
     return null
   }
   return {
     release: [Number(match[1]), Number(match[2]), Number(match[3])],
-    prerelease: match[4] ? match[4].split('.') : null
+    prerelease
   }
 }
 

--- a/src/shared/app-version-skew.ts
+++ b/src/shared/app-version-skew.ts
@@ -1,0 +1,123 @@
+// Why: protocol-version compat (protocol-compat.ts) only blocks truly
+// incompatible pairs. App-version skew between a desktop client and a remote
+// `orca serve` host is still worth a non-blocking warning: a client that
+// auto-updated ahead of its server can hit missing-RPC failures with
+// misleading downstream errors (e.g. "could not launch claude in a new
+// terminal") when the real fix is updating the server.
+
+export type AppVersionSkewDirection = 'server-older' | 'server-newer'
+
+export type AppVersionSkew = {
+  direction: AppVersionSkewDirection
+  clientAppVersion: string
+  /** null when the server predates app-version reporting in status.get. */
+  serverAppVersion: string | null
+}
+
+type ParsedAppVersion = {
+  release: [number, number, number]
+  prerelease: string[] | null
+}
+
+// Why: hand-rolled instead of the semver package so the evaluator stays
+// dependency-free and safe to mirror in the Expo mobile build.
+export function parseAppVersion(version: string | null | undefined): ParsedAppVersion | null {
+  const trimmed = version?.trim()
+  if (!trimmed) {
+    return null
+  }
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(trimmed)
+  if (!match) {
+    return null
+  }
+  return {
+    release: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : null
+  }
+}
+
+function comparePrereleaseIds(a: string, b: string): number {
+  const aNumeric = /^\d+$/.test(a)
+  const bNumeric = /^\d+$/.test(b)
+  if (aNumeric && bNumeric) {
+    return Number(a) - Number(b)
+  }
+  // Why: semver rule — numeric identifiers sort below alphanumeric ones.
+  if (aNumeric !== bNumeric) {
+    return aNumeric ? -1 : 1
+  }
+  return a < b ? -1 : a > b ? 1 : 0
+}
+
+export function compareAppVersions(a: ParsedAppVersion, b: ParsedAppVersion): number {
+  for (let i = 0; i < 3; i++) {
+    const diff = a.release[i]! - b.release[i]!
+    if (diff !== 0) {
+      return diff
+    }
+  }
+  // Why: a release (no prerelease) outranks any rc of the same triple.
+  if (!a.prerelease && !b.prerelease) {
+    return 0
+  }
+  if (!a.prerelease || !b.prerelease) {
+    return a.prerelease ? -1 : 1
+  }
+  const length = Math.max(a.prerelease.length, b.prerelease.length)
+  for (let i = 0; i < length; i++) {
+    const aId = a.prerelease[i]
+    const bId = b.prerelease[i]
+    if (aId === undefined || bId === undefined) {
+      return aId === undefined ? -1 : 1
+    }
+    const diff = comparePrereleaseIds(aId, bId)
+    if (diff !== 0) {
+      return diff
+    }
+  }
+  return 0
+}
+
+export function evaluateAppVersionSkew(input: {
+  clientAppVersion: string | null | undefined
+  serverAppVersion: string | null | undefined
+}): AppVersionSkew | null {
+  const client = parseAppVersion(input.clientAppVersion)
+  if (!client) {
+    return null
+  }
+  const reportedServerVersion = input.serverAppVersion?.trim()
+  if (!reportedServerVersion) {
+    // Why: every server that reports a live status but no appVersion predates
+    // this feature, so it is provably older than any client evaluating it.
+    return {
+      direction: 'server-older',
+      clientAppVersion: input.clientAppVersion!.trim(),
+      serverAppVersion: null
+    }
+  }
+  const server = parseAppVersion(reportedServerVersion)
+  if (!server) {
+    // Why: a reported-but-unparseable version (custom build) proves nothing
+    // about age, so stay silent rather than mislabeling it as older.
+    return null
+  }
+  const diff = compareAppVersions(server, client)
+  if (diff === 0) {
+    return null
+  }
+  return {
+    direction: diff < 0 ? 'server-older' : 'server-newer',
+    clientAppVersion: input.clientAppVersion!.trim(),
+    serverAppVersion: input.serverAppVersion!.trim()
+  }
+}
+
+export function describeAppVersionSkew(skew: AppVersionSkew): string {
+  if (skew.direction === 'server-older') {
+    return skew.serverAppVersion
+      ? `This Orca server (${skew.serverAppVersion}) is older than your app (${skew.clientAppVersion}). Update the server, or some features may fail.`
+      : `This Orca server is older than your app (${skew.clientAppVersion}). Update the server, or some features may fail.`
+  }
+  return `This Orca server (${skew.serverAppVersion}) is newer than your app (${skew.clientAppVersion}). Update this app, or some features may fail.`
+}

--- a/src/shared/app-version-skew.ts
+++ b/src/shared/app-version-skew.ts
@@ -41,17 +41,25 @@ export function parseAppVersion(version: string | null | undefined): ParsedAppVe
   ) {
     return null
   }
-  return {
-    release: [Number(match[1]), Number(match[2]), Number(match[3])],
-    prerelease
+  const release = [Number(match[1]), Number(match[2]), Number(match[3])] as [number, number, number]
+  // Why: Number() is lossy past 2^53, so two distinct huge segments would compare
+  // equal and produce a false "no skew"; no real version gets near this.
+  if (release.some((segment) => !Number.isSafeInteger(segment))) {
+    return null
   }
+  return { release, prerelease }
 }
 
 function comparePrereleaseIds(a: string, b: string): number {
   const aNumeric = /^\d+$/.test(a)
   const bNumeric = /^\d+$/.test(b)
   if (aNumeric && bNumeric) {
-    return Number(a) - Number(b)
+    // Why: length-then-lexicographic is exact for any magnitude (the strict
+    // parse forbids leading zeros), where Number() would lose precision.
+    if (a.length !== b.length) {
+      return a.length - b.length
+    }
+    return a < b ? -1 : a > b ? 1 : 0
   }
   // Why: semver rule — numeric identifiers sort below alphanumeric ones.
   if (aNumeric !== bNumeric) {

--- a/src/shared/app-version-skew.ts
+++ b/src/shared/app-version-skew.ts
@@ -7,12 +7,20 @@
 
 export type AppVersionSkewDirection = 'server-older' | 'server-newer'
 
-export type AppVersionSkew = {
-  direction: AppVersionSkewDirection
-  clientAppVersion: string
-  /** null when the server predates app-version reporting in status.get. */
-  serverAppVersion: string | null
-}
+// Why: a union so the compiler enforces that 'server-newer' — only ever produced
+// from a parsed server version — always carries a non-null serverAppVersion.
+export type AppVersionSkew =
+  | {
+      direction: 'server-older'
+      clientAppVersion: string
+      /** null when the server predates app-version reporting in status.get. */
+      serverAppVersion: string | null
+    }
+  | {
+      direction: 'server-newer'
+      clientAppVersion: string
+      serverAppVersion: string
+    }
 
 type ParsedAppVersion = {
   release: [number, number, number]
@@ -105,15 +113,12 @@ export function evaluateAppVersionSkew(input: {
   if (!client) {
     return null
   }
+  const clientAppVersion = input.clientAppVersion!.trim()
   const reportedServerVersion = input.serverAppVersion?.trim()
   if (!reportedServerVersion) {
     // Why: every server that reports a live status but no appVersion predates
     // this feature, so it is provably older than any client evaluating it.
-    return {
-      direction: 'server-older',
-      clientAppVersion: input.clientAppVersion!.trim(),
-      serverAppVersion: null
-    }
+    return { direction: 'server-older', clientAppVersion, serverAppVersion: null }
   }
   const server = parseAppVersion(reportedServerVersion)
   if (!server) {
@@ -125,11 +130,9 @@ export function evaluateAppVersionSkew(input: {
   if (diff === 0) {
     return null
   }
-  return {
-    direction: diff < 0 ? 'server-older' : 'server-newer',
-    clientAppVersion: input.clientAppVersion!.trim(),
-    serverAppVersion: input.serverAppVersion!.trim()
-  }
+  return diff < 0
+    ? { direction: 'server-older', clientAppVersion, serverAppVersion: reportedServerVersion }
+    : { direction: 'server-newer', clientAppVersion, serverAppVersion: reportedServerVersion }
 }
 
 export function describeAppVersionSkew(skew: AppVersionSkew): string {

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -78,8 +78,10 @@ export type RuntimeStatus = {
   runtimeProtocolVersion?: number
   minCompatibleRuntimeClientVersion?: number
   capabilities?: RuntimeCapability[]
-  // Why: optional fields let updated clients inventory both new and legacy paired servers.
-  appVersion?: string
+  // Why: optional fields let updated clients inventory both new and legacy paired
+  // servers. Absence or null means the server predates version reporting and is
+  // treated as older by the skew evaluator.
+  appVersion?: string | null
   remoteUpdateSupport?: RemoteServerUpdateSupport
   remoteControl?: RemoteRuntimeSharedConnectionDiagnostics | null
   hostPlatform?: NodeJS.Platform


### PR DESCRIPTION
## Summary

Adds non-blocking client/server app-version skew detection. `orca serve` now reports its `appVersion` in `status.get` (read from `ORCA_APP_VERSION`, already stamped at startup in `main/index.ts`), and the renderer derives an `AppVersionSkew` verdict (`server-older` / `server-newer`) whenever it ingests a runtime status, via a new shared, dependency-free semver-ish evaluator (`src/shared/app-version-skew.ts`). A reachable server that reports no version is provably older than any client evaluating it and is flagged as such; an unparseable version (custom build) stays silent. Before, protocol-compat only blocked truly incompatible pairs and mere app-version skew was invisible — a client that auto-updated ahead of its server hit missing-RPC failures with misleading downstream errors.

The verdict is computed centrally in `buildRuntimeEnvironmentStatusEntry` (store slice) so every status-ingestion path gets it for free. This PR is detection + plumbing only; the UI surfacing (sidebar host-header warning, proactive toast nudge, i18n strings) stays in #9614, which will be rebased down to that layer once this and #10235 land.

Split out of #9614.

**Tests:** new `app-version-skew.test.ts` (14 cases: skew directions, rc ordering, missing/unparseable versions, build metadata). `pnpm typecheck` and the test file green locally.

**Review starting point:** `evaluateAppVersionSkew` in `src/shared/app-version-skew.ts`, then `buildRuntimeEnvironmentStatusEntry` in `src/renderer/src/store/slices/runtime-status.ts`.

cc @OrcaWin

## ELI5

Detects when the desktop app version and orca serve version do not match and surfaces a non-blocking skew signal (server older or newer) so you know when to upgrade one side.
