### PR TITLE
fix(remote-runtime): self-heal stale subscriptions after serve restarts

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1587,22 +1587,29 @@
       "providers": ["remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["remote-runtime"],
-      "coverageNotes": "Deterministic fake-timer and encrypted-WebSocket tests cover active cadence, exact socket-generation fencing, subscription replay, idle cleanup, and in-flight final-subscription retirement. Byte-identical headed desktop and headless serve journeys use a loopback terminating relay that keeps answering control pings after losing the server-facing encrypted session, then require host worktree authority and the paired client's rendered sidebar to converge. Linux, Windows, production relay, mixed-version, and folder-workspace live evidence remain uncollected.",
+      "coverageNotes": "Deterministic fake-timer and encrypted-WebSocket tests cover active cadence, admission saturation, exact socket-generation fencing, subscription replay, server-driven retirement, idle cleanup, and in-flight final-subscription retirement. Byte-identical headed desktop and headless serve journeys use a loopback terminating relay that keeps answering control pings after losing the server-facing encrypted session, then require a newer authenticated shared-control generation, host worktree authority, and the paired client's rendered sidebar to converge. Linux, Windows, production relay, mixed-version, and folder-workspace live evidence remain uncollected.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/10235",
         "https://github.com/stablyai/orca/issues/7718"
       ],
       "invariant": "A shared-control connection with passive subscriptions must not treat RFC 6455 pong traffic from a terminating relay as proof that the server still owns its encrypted session or subscription registry. While ready and subscribed, one bounded encrypted session probe per connection must detect lost authority, close only the probed socket generation, reconnect, and replay every live logical subscription. No probe timer or recovery may survive the last subscription, intentional close, socket replacement, or idle one-shot request.",
-      "oracle": "Use fake timers to require zero retained probe timers without subscriptions, exactly one timer while ready and subscribed, one successful re-arm, and no re-arm or forced recovery when the last subscription retires during an in-flight success or failure. In both a visible isolated desktop host and a separate headless `orca serve`, forward the initial encrypted session through a terminating relay, sever only its server-facing socket, retain the client-facing socket and automatic pongs, and add a real host repo/worktree. Require the host inventory to contain the worktree while the paired client's store and sidebar are initially absent, require at least one control ping during that false-liveness window, then require a replacement authenticated connection plus the exact worktree in both client state and rendered DOM.",
+      "oracle": "Use fake timers to require zero retained probe timers without subscriptions, exactly one timer while ready and subscribed, one successful re-arm, and no re-arm or forced recovery when the last subscription retires during an in-flight success or failure. Saturate all 256 local request admissions and require a probe to re-arm without an encrypted send, socket close, or pending-RPC rejection. Deliver a server-driven final `{type:end}` and require immediate probe retirement. In both a visible isolated desktop host and a separate headless `orca serve`, forward the initial encrypted session through a terminating relay, sever only its server-facing socket, retain the client-facing socket and automatic pongs, and add a real host repo/worktree. Require the host inventory to contain the worktree while the paired client's store and sidebar are initially absent, require at least one control ping during that false-liveness window, then require the shared-control `lastConnectedAt` generation to advance plus the exact worktree in both client state and rendered DOM.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-connection.test.ts --reporter=dot",
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-boundary.test.ts src/shared/remote-runtime-shared-control-connection.test.ts src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts src/shared/remote-runtime-shared-control-reconnect.test.ts src/shared/remote-runtime-shared-control-retired-request-ids.test.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-socket-generation.test.ts src/shared/remote-runtime-shared-control-subscription-close.test.ts src/shared/remote-runtime-shared-control-subscriptions.test.ts --reporter=dot",
         "pnpm exec electron-vite build --mode e2e",
         "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
         "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
       ],
       "testFiles": [
+        "src/shared/remote-runtime-shared-control-boundary.test.ts",
+        "src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts",
+        "src/shared/remote-runtime-shared-control-reconnect.test.ts",
+        "src/shared/remote-runtime-shared-control-retired-request-ids.test.ts",
         "src/shared/remote-runtime-shared-control-session-probe.test.ts",
         "src/shared/remote-runtime-shared-control-connection.test.ts",
+        "src/shared/remote-runtime-shared-control-socket-generation.test.ts",
+        "src/shared/remote-runtime-shared-control-subscription-close.test.ts",
+        "src/shared/remote-runtime-shared-control-subscriptions.test.ts",
         "tests/e2e/pr10235-stale-subscription-restart.spec.ts"
       ],
       "assertionRefs": [
@@ -1619,8 +1626,16 @@
           "file": "src/shared/remote-runtime-shared-control-connection.test.ts",
           "assertions": [
             "detects a dead E2EE session via the session probe when the relay still answers pings",
+            "reschedules a locally admission-blocked probe without closing a healthy socket",
+            "clears the session probe when the server ends the final subscription",
             "keeps a responsive connection on one socket while session probes succeed",
             "does not run session probes when no subscriptions are active"
+          ]
+        },
+        {
+          "file": "src/shared/remote-runtime-shared-control-socket-generation.test.ts",
+          "assertions": [
+            "ignores stale close callbacks and accepts one close for the current socket"
           ]
         },
         {
@@ -1636,10 +1651,10 @@
           "date": "2026-07-31",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-connection.test.ts --reporter=dot",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-boundary.test.ts src/shared/remote-runtime-shared-control-connection.test.ts src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts src/shared/remote-runtime-shared-control-reconnect.test.ts src/shared/remote-runtime-shared-control-retired-request-ids.test.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-socket-generation.test.ts src/shared/remote-runtime-shared-control-subscription-close.test.ts src/shared/remote-runtime-shared-control-subscriptions.test.ts --reporter=dot",
           "result": "passed",
           "durationSeconds": 4,
-          "summary": "Two shared-control files and 34 tests passed with encrypted-session failure recovery, exact socket-generation fencing, responsive-session stability, fake-timer cadence, and zero idle re-arm or recovery."
+          "summary": "Nine shared-control files and 55 tests passed with encrypted-session failure recovery, 256-request admission saturation, server-driven final-subscription retirement, exact socket-generation fencing, responsive-session stability, fake-timer cadence, and zero idle re-arm or recovery."
         },
         {
           "date": "2026-07-31",
@@ -1647,8 +1662,8 @@
           "platform": "macos",
           "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
           "result": "passed",
-          "durationSeconds": 32,
-          "summary": "A visible isolated Orca host and separate paired desktop client recovered one zombified encrypted session after two relay-served control pings; a replacement connection delivered the new host worktree to client state and the rendered sidebar."
+          "durationSeconds": 33,
+          "summary": "A visible isolated Orca host and separate paired desktop client recovered one zombified encrypted session after two relay-served control pings; the authenticated shared-control generation advanced and delivered the new host worktree to client state and the rendered sidebar."
         },
         {
           "date": "2026-07-31",
@@ -1656,8 +1671,8 @@
           "platform": "macos",
           "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 30,
-          "summary": "An isolated headless `orca serve` and separate paired desktop client passed the same relay-pong, host-inventory, replacement-connection, client-state, and rendered-sidebar oracle."
+          "durationSeconds": 29,
+          "summary": "An isolated headless `orca serve` and separate paired desktop client passed the same relay-pong, host-inventory, authenticated-generation, client-state, and rendered-sidebar oracle."
         }
       ],
       "runtimeBudget": {
@@ -1666,11 +1681,11 @@
       },
       "flakeHistory": {
         "status": "unknown",
-        "evidence": "Deterministic contracts plus two consecutive headed and three consecutive isolated-headless macOS journeys pass. CI and cross-platform soak history are not yet available."
+        "evidence": "Deterministic contracts, earlier fixture-isolation repeats, and the current causal-generation headed/headless macOS journeys pass. CI and cross-platform soak history are not yet available."
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical headed and headless oracle stayed stale for 40 seconds on pinned latest main and on the candidate reverted, despite at least three relay-served control pings and authoritative host inventory. The rebased candidate and factory head opened a replacement authenticated connection and rendered the new worktree without reload. The original idle-timer implementation retained a scheduled wakeup after subscriptions closed; the factory lifecycle tests fail that implementation and pass with subscription-owned scheduling and in-flight retirement guards."
+        "evidence": "The byte-identical headed and headless oracle stayed stale for 40 seconds on pinned latest main and on the candidate reverted, despite at least three relay-served control pings, authoritative host inventory, and possible unrelated connection churn. The revised factory target advanced the authenticated shared-control generation and rendered the new worktree without reload. The original idle-timer implementation retained a scheduled wakeup after subscriptions closed; the factory lifecycle tests fail that implementation and pass with subscription-owned scheduling, admission-safe rescheduling, server-driven retirement reconciliation, and in-flight retirement guards."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1592,8 +1592,8 @@
         "https://github.com/stablyai/orca/pull/10235",
         "https://github.com/stablyai/orca/issues/7718"
       ],
-      "invariant": "A shared-control connection with passive subscriptions must not treat RFC 6455 pong traffic from a terminating relay as proof that the server still owns its encrypted session or subscription registry. While ready and subscribed, one bounded encrypted session probe per connection must detect lost authority, close only the probed socket generation, reconnect, and replay every live logical subscription. No probe timer or recovery may survive the last subscription, intentional close, socket replacement, or idle one-shot request.",
-      "oracle": "Use fake timers to require zero retained probe timers without subscriptions, exactly one timer while ready and subscribed, one successful re-arm, and no re-arm or forced recovery when the last subscription retires during an in-flight success or failure. Saturate all 256 local request admissions and require a probe to re-arm without an encrypted send, socket close, or pending-RPC rejection. Deliver a server-driven final `{type:end}` and require immediate probe retirement. In both a visible isolated desktop host and a separate headless `orca serve`, forward the initial encrypted session through a terminating relay, sever only its server-facing socket, retain the client-facing socket and automatic pongs, and add a real host repo/worktree. Require the host inventory to contain the worktree while the paired client's store and sidebar are initially absent, require at least one control ping during that false-liveness window, then require the shared-control `lastConnectedAt` generation to advance plus the exact worktree in both client state and rendered DOM.",
+      "invariant": "A shared-control connection with passive subscriptions must not treat RFC 6455 pong traffic from a terminating relay as proof that the server still owns its encrypted session or subscription registry. While ready and subscribed, one bounded encrypted session probe per connection must detect lost authority, close only the probed socket generation, reconnect, and replay every live logical subscription. Lifecycle reconciliation cannot postpone an armed probe deadline. No probe timer, in-flight probe RPC, retained admission, or recovery may survive the last subscription, intentional close, socket replacement, or idle one-shot request.",
+      "oracle": "Use fake timers to require zero retained probe timers without subscriptions, exactly one timer while ready and subscribed, one successful re-arm, and nine probes during 990 milliseconds of 90-millisecond lifecycle reconciliation against a 100-millisecond cadence. Require no re-arm or forced recovery when the last subscription retires during an in-flight success or failure. Saturate all 256 local request admissions and require a probe to re-arm without an encrypted send, socket close, or pending-RPC rejection. Hold a real encrypted `status.get` probe open, deliver a server-driven final `{type:end}`, and require immediate probe abort, request-id retirement, timeout/listener cleanup, and zero retained admission while the socket stays ready. In both a visible isolated desktop host and a separate headless `orca serve`, forward the initial encrypted session through a terminating relay, sever only its server-facing socket, retain the client-facing socket and automatic pongs, and add a real host repo/worktree. Require the host inventory to contain the worktree while the paired client's store and sidebar are initially absent, require at least one control ping during that false-liveness window, then require the shared-control `lastConnectedAt` generation to advance plus the exact worktree in both client state and rendered DOM.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-boundary.test.ts src/shared/remote-runtime-shared-control-connection.test.ts src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts src/shared/remote-runtime-shared-control-reconnect.test.ts src/shared/remote-runtime-shared-control-retired-request-ids.test.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-socket-generation.test.ts src/shared/remote-runtime-shared-control-subscription-close.test.ts src/shared/remote-runtime-shared-control-subscriptions.test.ts --reporter=dot",
         "pnpm exec electron-vite build --mode e2e",
@@ -1618,6 +1618,7 @@
           "assertions": [
             "does not retain a timer without an active subscription",
             "probes while ready and subscribed",
+            "keeps a hard probe cadence through continuous lifecycle reconciliation",
             "does not re-arm after the last subscription closes during a probe",
             "does not recover an idle connection when its final probe fails"
           ]
@@ -1628,6 +1629,7 @@
             "detects a dead E2EE session via the session probe when the relay still answers pings",
             "reschedules a locally admission-blocked probe without closing a healthy socket",
             "clears the session probe when the server ends the final subscription",
+            "retires an in-flight probe when the server ends the final subscription",
             "keeps a responsive connection on one socket while session probes succeed",
             "does not run session probes when no subscriptions are active"
           ]
@@ -1654,7 +1656,7 @@
           "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-boundary.test.ts src/shared/remote-runtime-shared-control-connection.test.ts src/shared/remote-runtime-shared-control-keepalive-refresh.test.ts src/shared/remote-runtime-shared-control-reconnect.test.ts src/shared/remote-runtime-shared-control-retired-request-ids.test.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-socket-generation.test.ts src/shared/remote-runtime-shared-control-subscription-close.test.ts src/shared/remote-runtime-shared-control-subscriptions.test.ts --reporter=dot",
           "result": "passed",
           "durationSeconds": 4,
-          "summary": "Nine shared-control files and 55 tests passed with encrypted-session failure recovery, 256-request admission saturation, server-driven final-subscription retirement, exact socket-generation fencing, responsive-session stability, fake-timer cadence, and zero idle re-arm or recovery."
+          "summary": "Nine shared-control files and 57 tests passed with encrypted-session failure recovery, hard non-sliding cadence under reconciliation churn, immediate in-flight probe cancellation on final subscription end, 256-request admission saturation, exact socket-generation fencing, responsive-session stability, and zero idle re-arm or recovery."
         },
         {
           "date": "2026-07-31",
@@ -1685,11 +1687,11 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical headed and headless oracle stayed stale for 40 seconds on pinned latest main and on the candidate reverted, despite at least three relay-served control pings, authoritative host inventory, and possible unrelated connection churn. The revised factory target advanced the authenticated shared-control generation and rendered the new worktree without reload. The original idle-timer implementation retained a scheduled wakeup after subscriptions closed; the factory lifecycle tests fail that implementation and pass with subscription-owned scheduling, admission-safe rescheduling, server-driven retirement reconciliation, and in-flight retirement guards."
+        "evidence": "The byte-identical headed and headless oracle stayed stale for 40 seconds on pinned latest main and on the candidate reverted, despite at least three relay-served control pings, authoritative host inventory, and possible unrelated connection churn. The revised factory target advanced the authenticated shared-control generation and rendered the new worktree without reload. Earlier factory revisions allowed continuous reconciliation to postpone the probe forever and retained an in-flight probe request after final server-driven retirement; the current lifecycle tests fail those revisions and pass with non-sliding deadlines, abort-owned request cleanup, admission-safe rescheduling, exact generation fencing, and in-flight retirement guards."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Each ready shared-control connection retains at most one unrefed timer and emits at most one encrypted status request every 15 seconds regardless of logical subscription count. The probe timeout is 10 seconds. Closing the final subscription, replacing the socket, or intentionally closing retains zero timers and cannot trigger a later recovery; there are no subprocesses, provider scans, or per-subscription probes."
+        "evidence": "Each ready shared-control connection retains at most one unrefed timer and one in-flight probe, emitting at most one encrypted status request every 15 seconds regardless of logical subscription count. Reconciliation cannot postpone an armed deadline. The probe timeout is 10 seconds. Closing the final subscription, replacing the socket, or intentionally closing aborts the actual probe RPC and retains zero timers, admission records, or cancellation listeners; there are no subprocesses, provider scans, or per-subscription probes."
       },
       "promotionCriteria": [
         "Collect at least 100 consecutive CI or soak passes or 14 days without an unexplained flake.",
@@ -1704,7 +1706,7 @@
         "Linux, Windows, mixed-version, sleep/wake, and multi-client fanout remain untested.",
         "The live worktree assertion uses a Git repository; folder workspaces share the transport but lack an explicit live journey."
       ],
-      "demotionRule": "Demote if relay-served pongs can suppress encrypted-session recovery, recovery closes a replacement generation, active subscriptions fail to replay, idle connections retain a probe timer, or headed/headless behavior diverges."
+      "demotionRule": "Demote if relay-served pongs or lifecycle churn can suppress encrypted-session probing, recovery closes a replacement generation, active subscriptions fail to replay, final retirement retains a timer or in-flight request, or headed/headless behavior diverges."
     },
     {
       "id": "editor.live-log-append-stability",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1571,6 +1571,127 @@
       "demotionRule": "Keep experimental or demote if retries can stop before recovery or exhaustion, continue after exhaustion, run in parallel, mutate a superseded pane, hide the Reconnect control, leak a subscription or timer, or fail to paint a new frame after manual reconnect."
     },
     {
+      "id": "remote-runtime.shared-control-session-authority",
+      "title": "Shared-control subscriptions recover from lost encrypted session authority",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "runtime-platform",
+      "layer": "paired-runtime-shared-control-lifecycle",
+      "surfaces": [
+        "headed paired runtime",
+        "headless orca serve",
+        "WebSocket-terminating relay",
+        "passive remote-runtime subscriptions"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["remote-runtime"],
+      "coverageNotes": "Deterministic fake-timer and encrypted-WebSocket tests cover active cadence, exact socket-generation fencing, subscription replay, idle cleanup, and in-flight final-subscription retirement. Byte-identical headed desktop and headless serve journeys use a loopback terminating relay that keeps answering control pings after losing the server-facing encrypted session, then require host worktree authority and the paired client's rendered sidebar to converge. Linux, Windows, production relay, mixed-version, and folder-workspace live evidence remain uncollected.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/10235",
+        "https://github.com/stablyai/orca/issues/7718"
+      ],
+      "invariant": "A shared-control connection with passive subscriptions must not treat RFC 6455 pong traffic from a terminating relay as proof that the server still owns its encrypted session or subscription registry. While ready and subscribed, one bounded encrypted session probe per connection must detect lost authority, close only the probed socket generation, reconnect, and replay every live logical subscription. No probe timer or recovery may survive the last subscription, intentional close, socket replacement, or idle one-shot request.",
+      "oracle": "Use fake timers to require zero retained probe timers without subscriptions, exactly one timer while ready and subscribed, one successful re-arm, and no re-arm or forced recovery when the last subscription retires during an in-flight success or failure. In both a visible isolated desktop host and a separate headless `orca serve`, forward the initial encrypted session through a terminating relay, sever only its server-facing socket, retain the client-facing socket and automatic pongs, and add a real host repo/worktree. Require the host inventory to contain the worktree while the paired client's store and sidebar are initially absent, require at least one control ping during that false-liveness window, then require a replacement authenticated connection plus the exact worktree in both client state and rendered DOM.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-connection.test.ts --reporter=dot",
+        "pnpm exec electron-vite build --mode e2e",
+        "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+        "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
+      ],
+      "testFiles": [
+        "src/shared/remote-runtime-shared-control-session-probe.test.ts",
+        "src/shared/remote-runtime-shared-control-connection.test.ts",
+        "tests/e2e/pr10235-stale-subscription-restart.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/shared/remote-runtime-shared-control-session-probe.test.ts",
+          "assertions": [
+            "does not retain a timer without an active subscription",
+            "probes while ready and subscribed",
+            "does not re-arm after the last subscription closes during a probe",
+            "does not recover an idle connection when its final probe fails"
+          ]
+        },
+        {
+          "file": "src/shared/remote-runtime-shared-control-connection.test.ts",
+          "assertions": [
+            "detects a dead E2EE session via the session probe when the relay still answers pings",
+            "keeps a responsive connection on one socket while session probes succeed",
+            "does not run session probes when no subscriptions are active"
+          ]
+        },
+        {
+          "file": "tests/e2e/pr10235-stale-subscription-restart.spec.ts",
+          "assertions": [
+            "self-heals a headed server worktree subscription behind a zombie relay",
+            "self-heals a headless serve worktree subscription behind a zombie relay"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-07-31",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/shared/remote-runtime-shared-control-session-probe.test.ts src/shared/remote-runtime-shared-control-connection.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 4,
+          "summary": "Two shared-control files and 34 tests passed with encrypted-session failure recovery, exact socket-generation fencing, responsive-session stability, fake-timer cadence, and zero idle re-arm or recovery."
+        },
+        {
+          "date": "2026-07-31",
+          "runner": "local",
+          "platform": "macos",
+          "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 32,
+          "summary": "A visible isolated Orca host and separate paired desktop client recovered one zombified encrypted session after two relay-served control pings; a replacement connection delivered the new host worktree to client state and the rendered sidebar."
+        },
+        {
+          "date": "2026-07-31",
+          "runner": "local",
+          "platform": "macos",
+          "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/pr10235-stale-subscription-restart.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 30,
+          "summary": "An isolated headless `orca serve` and separate paired desktop client passed the same relay-pong, host-inventory, replacement-connection, client-state, and rendered-sidebar oracle."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 150,
+        "scope": "focused shared-control contracts plus one isolated headed or headless paired-runtime journey"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "Deterministic contracts plus two consecutive headed and three consecutive isolated-headless macOS journeys pass. CI and cross-platform soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The byte-identical headed and headless oracle stayed stale for 40 seconds on pinned latest main and on the candidate reverted, despite at least three relay-served control pings and authoritative host inventory. The rebased candidate and factory head opened a replacement authenticated connection and rendered the new worktree without reload. The original idle-timer implementation retained a scheduled wakeup after subscriptions closed; the factory lifecycle tests fail that implementation and pass with subscription-owned scheduling and in-flight retirement guards."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Each ready shared-control connection retains at most one unrefed timer and emits at most one encrypted status request every 15 seconds regardless of logical subscription count. The probe timeout is 10 seconds. Closing the final subscription, replacing the socket, or intentionally closing retains zero timers and cannot trigger a later recovery; there are no subprocesses, provider scans, or per-subscription probes."
+      },
+      "promotionCriteria": [
+        "Collect at least 100 consecutive CI or soak passes or 14 days without an unexplained flake.",
+        "Collect live Linux and Windows headed/headless paired-runtime evidence.",
+        "Run the oracle through a production-like terminating relay and add a live folder-workspace subscription journey.",
+        "Add a process-replacement journey that preserves pairing material while restarting `orca serve` and rebinding its runtime generation."
+      ],
+      "knownGaps": [
+        "Live evidence currently uses a loopback terminating relay on macOS rather than production relay infrastructure.",
+        "The relay asserts received control pings and uses `ws` default automatic pong handling; it does not separately instrument the outbound pong write.",
+        "The live fault severs the host-facing encrypted session at the ownership boundary; it does not literally replace an `orca serve` process, rebind its endpoint, or rotate the runtime generation.",
+        "Linux, Windows, mixed-version, sleep/wake, and multi-client fanout remain untested.",
+        "The live worktree assertion uses a Git repository; folder workspaces share the transport but lack an explicit live journey."
+      ],
+      "demotionRule": "Demote if relay-served pongs can suppress encrypted-session recovery, recovery closes a replacement generation, active subscriptions fail to replay, idle connections retain a probe timer, or headed/headless behavior diverges."
+    },
+    {
       "id": "editor.live-log-append-stability",
       "title": "Long live session logs retain their Monaco viewport while appending",
       "maturity": "experimental",

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  REMOTE_RUNTIME_MAX_PENDING_REQUESTS,
   REMOTE_RUNTIME_MAX_PENDING_RPC_BYTES,
   retainedRemoteRuntimeJsonStringBytes,
   serializeRemoteRuntimeRpcRequest
@@ -561,6 +562,80 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     expect(onClose).not.toHaveBeenCalled()
 
     connection.close()
+  })
+
+  it('reschedules a locally admission-blocked probe without closing a healthy socket', async () => {
+    const server = await createServer({ silentMethods: ['worktree.hang'] })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 60_000,
+      sessionProbeTimeoutMs: 1000
+    })
+    const onClose = vi.fn()
+    const onError = vi.fn()
+    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+      onResponse: vi.fn(),
+      onError,
+      onClose
+    })
+    const pending = Array.from({ length: REMOTE_RUNTIME_MAX_PENDING_REQUESTS }, () =>
+      connection.request('worktree.hang', undefined, 60_000).catch(() => undefined)
+    )
+    try {
+      await vi.waitFor(
+        () =>
+          expect(
+            server.requests.filter((request) => request.method === 'worktree.hang')
+          ).toHaveLength(REMOTE_RUNTIME_MAX_PENDING_REQUESTS),
+        { timeout: 5000 }
+      )
+      const unsafe = connection as unknown as {
+        sessionProbe: {
+          runProbe: () => Promise<void>
+          timer: ReturnType<typeof setTimeout> | null
+        }
+      }
+
+      await unsafe.sessionProbe.runProbe()
+
+      expect(server.requests.map((request) => request.method)).not.toContain('status.get')
+      expect(unsafe.sessionProbe.timer).not.toBeNull()
+      expect(server.connectionCount()).toBe(1)
+      expect(connection.getDiagnostics()).toMatchObject({
+        state: 'ready',
+        pendingRequestCount: REMOTE_RUNTIME_MAX_PENDING_REQUESTS,
+        subscriptionCount: 1
+      })
+      expect(onError).not.toHaveBeenCalled()
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      connection.close()
+      await Promise.all(pending)
+    }
+  })
+
+  it('clears the session probe when the server ends the final subscription', async () => {
+    const server = await createServer({ endStreamingResponseAfterReady: true })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 15_000
+    })
+    const onResponse = vi.fn()
+
+    try {
+      await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+        onResponse,
+        onError: vi.fn()
+      })
+      await vi.waitFor(() => expect(onResponse).toHaveBeenCalledTimes(2))
+      const unsafe = connection as unknown as {
+        sessionProbe: { timer: ReturnType<typeof setTimeout> | null }
+      }
+
+      expect(connection.getDiagnostics().subscriptionCount).toBe(0)
+      expect(unsafe.sessionProbe.timer).toBeNull()
+      expect(server.requests.map((request) => request.method)).not.toContain('status.get')
+    } finally {
+      connection.close()
+    }
   })
 
   it('keeps a responsive connection on one socket while session probes succeed', async () => {

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -1,16 +1,5 @@
 import path from 'node:path'
-import type { AddressInfo } from 'node:net'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { WebSocketServer, type WebSocket } from 'ws'
-import {
-  decrypt,
-  deriveSharedKey,
-  encrypt,
-  generateKeyPair,
-  publicKeyFromBase64,
-  publicKeyToBase64
-} from './e2ee-crypto'
-import { encodePairingOffer, parsePairingCode, type PairingOffer } from './pairing'
 import {
   REMOTE_RUNTIME_MAX_PENDING_RPC_BYTES,
   retainedRemoteRuntimeJsonStringBytes,
@@ -19,6 +8,10 @@ import {
 import { getRemoteRuntimeRequestAdmissionEvidence } from './remote-runtime-prepared-request-admission'
 import { RemoteRuntimeSharedControlConnection } from './remote-runtime-shared-control-connection'
 import * as sharedControlProtocol from './remote-runtime-shared-control-protocol'
+import {
+  closeSharedControlTestServers,
+  createSharedControlTestServer as createServer
+} from './remote-runtime-shared-control-test-server'
 import { isRuntimeSubscriptionReplayResponse } from './runtime-subscription-replay'
 import {
   AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
@@ -27,29 +20,7 @@ import {
 
 const TEST_PROJECT_PATH = path.join('tmp', 'project')
 
-type TestServer = {
-  pairing: PairingOffer
-  requests: { id: string; method: string; params?: unknown }[]
-  auths: unknown[]
-  connectionCount: () => number
-  flushDelayedResponses: () => void
-}
-
-const servers: WebSocketServer[] = []
-
-afterEach(async () => {
-  await Promise.all(
-    servers.splice(0).map(
-      (server) =>
-        new Promise<void>((resolve) => {
-          for (const client of server.clients) {
-            client.close()
-          }
-          server.close(() => resolve())
-        })
-    )
-  )
-})
+afterEach(closeSharedControlTestServers)
 
 describe('RemoteRuntimeSharedControlConnection', () => {
   it('routes multiple one-shot RPCs over one authenticated WebSocket', async () => {
@@ -563,12 +534,10 @@ describe('RemoteRuntimeSharedControlConnection', () => {
   })
 
   it('detects a dead E2EE session via the session probe when the relay still answers pings', async () => {
-    // Repro of the serve-restart-behind-a-relay bug: a WS-terminating relay
-    // answers protocol pings itself (autoPong stays enabled), so socket-level
-    // liveness sees inbound traffic — but the server process behind it
-    // restarted, its subscription registry is empty, and encrypted requests go
-    // unanswered. Only the session probe can prove the E2EE session is dead.
-    const server = await createServer({ goSilentOnFirstConnectionAfterFirstStreamingResponse: true })
+    // Why: relay pongs survive after the server-side encrypted session disappears.
+    const server = await createServer({
+      goSilentOnFirstConnectionAfterFirstStreamingResponse: true
+    })
     const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
       sessionProbeIntervalMs: 40,
       sessionProbeTimeoutMs: 80
@@ -749,225 +718,3 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 })
-
-async function createServer(
-  options: {
-    delaySubscriptionReady?: boolean
-    sendKeepaliveBeforeResponse?: boolean
-    keepaliveDelayMs?: number
-    responseDelayMs?: number
-    sendBinaryAfterAuth?: boolean
-    sendUnknownResponseBeforeResponse?: boolean
-    closeAfterFirstStreamingResponse?: boolean
-    closeBeforeResponse?: boolean
-    suppressReadyFrame?: boolean
-    suppressReadyFrameCount?: number
-    // Why: half-open simulation — the socket stays open but never answers
-    // protocol pings, like a wedged tunnel that swallows frames silently.
-    disableAutoPong?: boolean
-    delayedMethods?: string[]
-    silentMethods?: string[]
-    goSilentOnFirstConnectionAfterFirstStreamingResponse?: boolean
-  } = {}
-): Promise<TestServer> {
-  const serverKeyPair = generateKeyPair()
-  const requests: TestServer['requests'] = []
-  const auths: unknown[] = []
-  const delayedResponses: (() => void)[] = []
-  let connectionCount = 0
-  let closedAfterFirstStreamingResponse = false
-  const wss = new WebSocketServer({ port: 0, autoPong: options.disableAutoPong !== true })
-  servers.push(wss)
-
-  wss.on('connection', (ws) => {
-    connectionCount += 1
-    const isFirstConnection = connectionCount === 1
-    // Zombie mode: record requests but never answer and never close, like a
-    // restarted server process behind a relay that holds the socket open and
-    // keeps answering ws pings itself.
-    let goneSilent = false
-    let sharedKey: Uint8Array | null = null
-    let authenticated = false
-    ws.on('message', (data, isBinary) => {
-      if (isBinary) {
-        return
-      }
-      const frame = data.toString()
-      if (!sharedKey) {
-        const hello = JSON.parse(frame) as { publicKeyB64: string }
-        sharedKey = deriveSharedKey(
-          serverKeyPair.secretKey,
-          publicKeyFromBase64(hello.publicKeyB64)
-        )
-        if (
-          options.suppressReadyFrame ||
-          connectionCount <= (options.suppressReadyFrameCount ?? 0)
-        ) {
-          return
-        }
-        ws.send(JSON.stringify({ type: 'e2ee_ready' }))
-        return
-      }
-      const plaintext = decrypt(frame, sharedKey)
-      if (!plaintext) {
-        return
-      }
-      if (!authenticated) {
-        auths.push(JSON.parse(plaintext))
-        authenticated = true
-        sendEncrypted(ws, sharedKey, { type: 'e2ee_authenticated' })
-        if (options.sendBinaryAfterAuth) {
-          ws.send(Buffer.from([1, 2, 3]), { binary: true })
-        }
-        return
-      }
-      const request = JSON.parse(plaintext) as { id: string; method: string; params?: unknown }
-      if (goneSilent) {
-        requests.push(request)
-        return
-      }
-      if (
-        options.goSilentOnFirstConnectionAfterFirstStreamingResponse &&
-        isFirstConnection &&
-        isStreamingMethod(request.method)
-      ) {
-        goneSilent = true
-      }
-      handleRequest(
-        ws,
-        sharedKey,
-        requests,
-        request,
-        {
-          ...options,
-          closeAfterStreamingResponse: () => {
-            if (!options.closeAfterFirstStreamingResponse || closedAfterFirstStreamingResponse) {
-              return false
-            }
-            closedAfterFirstStreamingResponse = true
-            return true
-          }
-        },
-        delayedResponses
-      )
-    })
-  })
-
-  await new Promise<void>((resolve) => wss.once('listening', resolve))
-  const address = wss.address() as AddressInfo
-  const pairing = parsePairingCode(
-    encodePairingOffer({
-      v: 2,
-      endpoint: `ws://127.0.0.1:${address.port}`,
-      deviceToken: 'device-token',
-      publicKeyB64: publicKeyToBase64(serverKeyPair.publicKey)
-    })
-  )
-  if (!pairing) {
-    throw new Error('Failed to create test pairing')
-  }
-  return {
-    pairing,
-    requests,
-    auths,
-    connectionCount: () => connectionCount,
-    flushDelayedResponses: () => delayedResponses.splice(0).forEach((send) => send())
-  }
-}
-
-function handleRequest(
-  ws: WebSocket,
-  sharedKey: Uint8Array,
-  requests: TestServer['requests'],
-  request: { id: string; method: string; params?: unknown },
-  options: {
-    delaySubscriptionReady?: boolean
-    sendKeepaliveBeforeResponse?: boolean
-    keepaliveDelayMs?: number
-    responseDelayMs?: number
-    sendUnknownResponseBeforeResponse?: boolean
-    closeAfterStreamingResponse?: () => boolean
-    closeBeforeResponse?: boolean
-    delayedMethods?: string[]
-    silentMethods?: string[]
-  },
-  delayedResponses: (() => void)[]
-): void {
-  requests.push(request)
-  // Why: keepalives are armed by an unrelated long-poll and keep flowing even
-  // while a method is deliberately silent — emit them before the silent return.
-  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs !== undefined) {
-    const timer = setInterval(
-      () => sendEncrypted(ws, sharedKey, { _keepalive: true }),
-      options.keepaliveDelayMs
-    )
-    ws.once('close', () => clearInterval(timer))
-  }
-  if (options.silentMethods?.includes(request.method)) {
-    return
-  }
-  if (options.closeBeforeResponse) {
-    ws.close(4001, 'test close')
-    return
-  }
-  const streaming = isStreamingMethod(request.method)
-  const result = streaming
-    ? { type: 'ready', subscriptionId: `${request.method}:subscription` }
-    : { method: request.method }
-  const sendResponse = (): void => {
-    if (options.sendUnknownResponseBeforeResponse) {
-      sendEncrypted(ws, sharedKey, {
-        id: 'unknown-response-id',
-        ok: true,
-        result: { method: 'unknown' },
-        _meta: { runtimeId: 'runtime-test' }
-      })
-    }
-    sendEncrypted(ws, sharedKey, {
-      id: request.id,
-      ok: true,
-      result,
-      streaming: streaming ? true : undefined,
-      _meta: { runtimeId: 'runtime-test' }
-    })
-  }
-  const closeAfterResponse = streaming && options.closeAfterStreamingResponse?.() === true
-  // Delayed/periodic keepalives are handled by the interval above; here we only
-  // cover the immediate single-keepalive-before-response case.
-  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs === undefined) {
-    sendEncrypted(ws, sharedKey, { _keepalive: true })
-  }
-  if (options.delaySubscriptionReady && streaming) {
-    delayedResponses.push(sendResponse)
-    return
-  }
-  if (options.delayedMethods?.includes(request.method)) {
-    delayedResponses.push(sendResponse)
-    return
-  }
-  if (options.responseDelayMs !== undefined) {
-    setTimeout(() => {
-      sendResponse()
-      if (closeAfterResponse) {
-        setTimeout(() => ws.close(), 0)
-      }
-    }, options.responseDelayMs)
-    return
-  }
-  sendResponse()
-  if (closeAfterResponse) {
-    setTimeout(() => ws.close(), 0)
-  }
-}
-
-function isStreamingMethod(method: string): boolean {
-  return (
-    method.endsWith('.subscribe') ||
-    method === 'session.tabs.subscribeAll' ||
-    method === 'files.watch'
-  )
-}
-
-function sendEncrypted(ws: WebSocket, sharedKey: Uint8Array, message: unknown): void {
-  ws.send(encrypt(JSON.stringify(message), sharedKey))
-}

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -545,23 +545,25 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     })
     const onClose = vi.fn()
 
-    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
-      onResponse: vi.fn(),
-      onError: vi.fn(),
-      onClose
-    })
+    try {
+      await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+        onResponse: vi.fn(),
+        onError: vi.fn(),
+        onClose
+      })
 
-    await vi.waitFor(() => expect(server.connectionCount()).toBe(2), { timeout: 5000 })
-    await vi.waitFor(
-      () =>
-        expect(
-          server.requests.filter((request) => request.method === 'runtime.clientEvents.subscribe')
-        ).toHaveLength(2),
-      { timeout: 5000 }
-    )
-    expect(onClose).not.toHaveBeenCalled()
-
-    connection.close()
+      await vi.waitFor(() => expect(server.connectionCount()).toBe(2), { timeout: 5000 })
+      await vi.waitFor(
+        () =>
+          expect(
+            server.requests.filter((request) => request.method === 'runtime.clientEvents.subscribe')
+          ).toHaveLength(2),
+        { timeout: 5000 }
+      )
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      connection.close()
+    }
   })
 
   it('reschedules a locally admission-blocked probe without closing a healthy socket', async () => {
@@ -693,6 +695,27 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     }
   })
 
+  it('recovers when a session probe resolves with a failure response', async () => {
+    const server = await createServer({ failMethods: ['status.get'] })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 40,
+      sessionProbeTimeoutMs: 500
+    })
+
+    try {
+      await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+        onResponse: vi.fn(),
+        onError: vi.fn()
+      })
+
+      // Why: an ok:false status.get must count as lost session authority and
+      // force a replacement connection, not a quiet reschedule.
+      await vi.waitFor(() => expect(server.connectionCount()).toBe(2), { timeout: 5000 })
+    } finally {
+      connection.close()
+    }
+  })
+
   it('keeps a responsive connection on one socket while session probes succeed', async () => {
     const server = await createServer()
     const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
@@ -700,17 +723,19 @@ describe('RemoteRuntimeSharedControlConnection', () => {
       sessionProbeTimeoutMs: 500
     })
 
-    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
-      onResponse: vi.fn(),
-      onError: vi.fn()
-    })
+    try {
+      await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+        onResponse: vi.fn(),
+        onError: vi.fn()
+      })
 
-    await vi.waitFor(() =>
-      expect(server.requests.map((request) => request.method)).toContain('status.get')
-    )
-    expect(server.connectionCount()).toBe(1)
-
-    connection.close()
+      await vi.waitFor(() =>
+        expect(server.requests.map((request) => request.method)).toContain('status.get')
+      )
+      expect(server.connectionCount()).toBe(1)
+    } finally {
+      connection.close()
+    }
   })
 
   it('does not run session probes when no subscriptions are active', async () => {
@@ -720,12 +745,14 @@ describe('RemoteRuntimeSharedControlConnection', () => {
       sessionProbeTimeoutMs: 50
     })
 
-    await connection.request('worktree.ps', undefined, 1000)
-    await new Promise((resolve) => setTimeout(resolve, 60))
+    try {
+      await connection.request('worktree.ps', undefined, 1000)
+      await new Promise((resolve) => setTimeout(resolve, 60))
 
-    expect(server.requests.map((request) => request.method)).not.toContain('status.get')
-
-    connection.close()
+      expect(server.requests.map((request) => request.method)).not.toContain('status.get')
+    } finally {
+      connection.close()
+    }
   })
 
   it('keeps unrelated pending requests alive when one request times out', async () => {

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -562,6 +562,73 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     connection.close()
   })
 
+  it('detects a dead E2EE session via the session probe when the relay still answers pings', async () => {
+    // Repro of the serve-restart-behind-a-relay bug: a WS-terminating relay
+    // answers protocol pings itself (autoPong stays enabled), so socket-level
+    // liveness sees inbound traffic — but the server process behind it
+    // restarted, its subscription registry is empty, and encrypted requests go
+    // unanswered. Only the session probe can prove the E2EE session is dead.
+    const server = await createServer({ goSilentOnFirstConnectionAfterFirstStreamingResponse: true })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 40,
+      sessionProbeTimeoutMs: 80
+    })
+    const onClose = vi.fn()
+
+    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+      onResponse: vi.fn(),
+      onError: vi.fn(),
+      onClose
+    })
+
+    await vi.waitFor(() => expect(server.connectionCount()).toBe(2), { timeout: 5000 })
+    await vi.waitFor(
+      () =>
+        expect(
+          server.requests.filter((request) => request.method === 'runtime.clientEvents.subscribe')
+        ).toHaveLength(2),
+      { timeout: 5000 }
+    )
+    expect(onClose).not.toHaveBeenCalled()
+
+    connection.close()
+  })
+
+  it('keeps a responsive connection on one socket while session probes succeed', async () => {
+    const server = await createServer()
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 20,
+      sessionProbeTimeoutMs: 500
+    })
+
+    await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+      onResponse: vi.fn(),
+      onError: vi.fn()
+    })
+
+    await vi.waitFor(() =>
+      expect(server.requests.map((request) => request.method)).toContain('status.get')
+    )
+    expect(server.connectionCount()).toBe(1)
+
+    connection.close()
+  })
+
+  it('does not run session probes when no subscriptions are active', async () => {
+    const server = await createServer()
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 10,
+      sessionProbeTimeoutMs: 50
+    })
+
+    await connection.request('worktree.ps', undefined, 1000)
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    expect(server.requests.map((request) => request.method)).not.toContain('status.get')
+
+    connection.close()
+  })
+
   it('keeps unrelated pending requests alive when one request times out', async () => {
     const server = await createServer({
       silentMethods: ['worktree.hang'],
@@ -700,6 +767,7 @@ async function createServer(
     disableAutoPong?: boolean
     delayedMethods?: string[]
     silentMethods?: string[]
+    goSilentOnFirstConnectionAfterFirstStreamingResponse?: boolean
   } = {}
 ): Promise<TestServer> {
   const serverKeyPair = generateKeyPair()
@@ -713,6 +781,11 @@ async function createServer(
 
   wss.on('connection', (ws) => {
     connectionCount += 1
+    const isFirstConnection = connectionCount === 1
+    // Zombie mode: record requests but never answer and never close, like a
+    // restarted server process behind a relay that holds the socket open and
+    // keeps answering ws pings itself.
+    let goneSilent = false
     let sharedKey: Uint8Array | null = null
     let authenticated = false
     ws.on('message', (data, isBinary) => {
@@ -748,11 +821,23 @@ async function createServer(
         }
         return
       }
+      const request = JSON.parse(plaintext) as { id: string; method: string; params?: unknown }
+      if (goneSilent) {
+        requests.push(request)
+        return
+      }
+      if (
+        options.goSilentOnFirstConnectionAfterFirstStreamingResponse &&
+        isFirstConnection &&
+        isStreamingMethod(request.method)
+      ) {
+        goneSilent = true
+      }
       handleRequest(
         ws,
         sharedKey,
         requests,
-        JSON.parse(plaintext),
+        request,
         {
           ...options,
           closeAfterStreamingResponse: () => {

--- a/src/shared/remote-runtime-shared-control-connection.test.ts
+++ b/src/shared/remote-runtime-shared-control-connection.test.ts
@@ -638,6 +638,61 @@ describe('RemoteRuntimeSharedControlConnection', () => {
     }
   })
 
+  it('retires an in-flight probe when the server ends the final subscription', async () => {
+    const server = await createServer({ silentMethods: ['status.get'] })
+    const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {
+      sessionProbeIntervalMs: 20,
+      sessionProbeTimeoutMs: 10_000
+    })
+    const onClose = vi.fn()
+    const onResponse = vi.fn()
+
+    try {
+      await connection.subscribe('runtime.clientEvents.subscribe', null, 1000, {
+        onResponse,
+        onError: vi.fn(),
+        onClose
+      })
+      await vi.waitFor(() =>
+        expect(server.requests.map((request) => request.method)).toContain('status.get')
+      )
+      expect(connection.getDiagnostics()).toMatchObject({
+        state: 'ready',
+        pendingRequestCount: 1,
+        subscriptionCount: 1
+      })
+      expect(getRemoteRuntimeRequestAdmissionEvidence().pendingRequestCount).toBe(1)
+      const probeRequestId = server.requests.find((request) => request.method === 'status.get')!.id
+
+      server.endActiveSubscriptions()
+
+      await vi.waitFor(() => expect(onResponse).toHaveBeenCalledTimes(2))
+      const unsafe = connection as unknown as {
+        retiredRequestIds: { has: (requestId: string) => boolean }
+        sessionProbe: {
+          probeAbortController: AbortController | null
+          timer: ReturnType<typeof setTimeout> | null
+        }
+      }
+      expect(connection.getDiagnostics()).toMatchObject({
+        state: 'ready',
+        pendingRequestCount: 0,
+        subscriptionCount: 0
+      })
+      expect(getRemoteRuntimeRequestAdmissionEvidence()).toEqual({
+        pendingRequestCount: 0,
+        retainedBytes: 0
+      })
+      expect(unsafe.sessionProbe.probeAbortController).toBeNull()
+      expect(unsafe.sessionProbe.timer).toBeNull()
+      expect(unsafe.retiredRequestIds.has(probeRequestId)).toBe(true)
+      expect(server.connectionCount()).toBe(1)
+      expect(onClose).not.toHaveBeenCalled()
+    } finally {
+      connection.close()
+    }
+  })
+
   it('keeps a responsive connection on one socket while session probes succeed', async () => {
     const server = await createServer()
     const connection = new RemoteRuntimeSharedControlConnection(server.pairing, {

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -2,7 +2,6 @@ import type WebSocket from 'ws'
 import type { PairingOffer } from './pairing'
 import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
 import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
-import { remoteRuntimeUnavailableError } from './remote-runtime-request-frames'
 import { openSharedControlSocket } from './remote-runtime-shared-control-open'
 import { handleSharedControlTextFrame } from './remote-runtime-shared-control-frame-handler'
 import * as sharedControlProtocol from './remote-runtime-shared-control-protocol'
@@ -12,11 +11,11 @@ import {
   waitForSharedControlReadyWithTimeout
 } from './remote-runtime-shared-control-ready'
 import { SharedControlReconnectScheduler } from './remote-runtime-shared-control-reconnect'
+import { reconnectSharedControlNow } from './remote-runtime-shared-control-manual-reconnect'
 import { requestSharedControl } from './remote-runtime-shared-control-requests'
 import {
-  SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
-  SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS,
-  SharedControlSessionProbe
+  createSharedControlSessionProbe,
+  type SharedControlSessionProbe
 } from './remote-runtime-shared-control-session-probe'
 import { SharedControlRetiredRequestIds } from './remote-runtime-shared-control-retired-request-ids'
 import { SharedControlReadyStableResetTimer } from './remote-runtime-shared-control-stability'
@@ -27,19 +26,13 @@ import { closeSharedControlConnectionSubscription } from './remote-runtime-share
 import * as sharedControlSubscriptions from './remote-runtime-shared-control-subscriptions'
 import { startSharedControlSubscription } from './remote-runtime-shared-control-subscription-start'
 import { SharedControlSocketGeneration } from './remote-runtime-shared-control-socket-generation'
-import type {
-  RemoteRuntimeSharedConnectionDiagnostics,
-  RemoteRuntimeSharedControlConnectionOptions,
-  RemoteRuntimeSharedSubscription,
-  SharedControlConnectionState,
-  SharedControlLogicalSubscription,
-  SharedControlPendingRequest,
-  SharedControlReadyWaiter,
-  SharedControlSubscriptionCallbacks
-} from './remote-runtime-shared-control-types'
+import type * as SharedControlTypes from './remote-runtime-shared-control-types'
+
+type PendingRequest = SharedControlTypes.SharedControlPendingRequest<unknown>
+type LogicalSubscription = SharedControlTypes.SharedControlLogicalSubscription<unknown>
 
 export class RemoteRuntimeSharedControlConnection {
-  private state: SharedControlConnectionState = 'closed'
+  private state: SharedControlTypes.SharedControlConnectionState = 'closed'
   private ws: WebSocket | null = null
   private sharedKey: Uint8Array | null = null
   private socketCleanup: (() => void) | null = null
@@ -50,30 +43,28 @@ export class RemoteRuntimeSharedControlConnection {
   private lastConnectedAt: number | null = null
   private lastClose: { code: number; reason: string } | null = null
   private lastError: string | null = null
-  private readonly pendingRequests = new Map<string, SharedControlPendingRequest<unknown>>()
-  private readonly subscriptions = new Map<string, SharedControlLogicalSubscription<unknown>>()
+  private readonly pendingRequests = new Map<string, PendingRequest>()
+  private readonly subscriptions = new Map<string, LogicalSubscription>()
   private readonly retiredRequestIds = new SharedControlRetiredRequestIds()
-  private readonly readyWaiters: SharedControlReadyWaiter[] = []
+  private readonly readyWaiters: SharedControlTypes.SharedControlReadyWaiter[] = []
   private everReady = false
   private readonly socketGeneration = new SharedControlSocketGeneration()
 
   constructor(
     private readonly pairing: PairingOffer,
-    private readonly options: RemoteRuntimeSharedControlConnectionOptions = {}
+    private readonly options: SharedControlTypes.RemoteRuntimeSharedControlConnectionOptions = {}
   ) {
     this.readyStableReset = new SharedControlReadyStableResetTimer(
       options.reconnectStableResetMs ?? 30_000
     )
-    this.sessionProbe = new SharedControlSessionProbe({
-      intervalMs: options.sessionProbeIntervalMs ?? SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
-      timeoutMs: options.sessionProbeTimeoutMs ?? SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS,
+    this.sessionProbe = createSharedControlSessionProbe(options, {
       isIntentionallyClosed: () => this.intentionallyClosed,
       hasSubscriptions: () => this.subscriptions.size > 0,
       isReady: () =>
         isSharedControlReady({ state: this.state, ws: this.ws, sharedKey: this.sharedKey }),
       getSocket: () => this.ws,
       probe: (timeoutMs) => this.request('status.get', undefined, timeoutMs),
-      // Why: the probe verified it is closing the socket it probed, so it always targets the current generation.
+      // Why: the probe's socket identity guard makes the current generation authoritative.
       forceClose: (error) =>
         this.handleSocketClosed(error, this.socketGeneration.currentGeneration())
     })
@@ -100,8 +91,8 @@ export class RemoteRuntimeSharedControlConnection {
     method: string,
     params: unknown,
     timeoutMs: number,
-    callbacks: SharedControlSubscriptionCallbacks<TResult>
-  ): Promise<RemoteRuntimeSharedSubscription> {
+    callbacks: SharedControlTypes.SharedControlSubscriptionCallbacks<TResult>
+  ): Promise<SharedControlTypes.RemoteRuntimeSharedSubscription> {
     return startSharedControlSubscription({
       subscriptions: this.subscriptions,
       deviceToken: this.pairing.deviceToken,
@@ -127,7 +118,7 @@ export class RemoteRuntimeSharedControlConnection {
   // Why: pending timers only exist while a logical subscription owns reconnect.
   readonly retryNow = (): boolean => this.reconnect.retryNow()
 
-  getDiagnostics(): RemoteRuntimeSharedConnectionDiagnostics {
+  getDiagnostics(): SharedControlTypes.RemoteRuntimeSharedConnectionDiagnostics {
     return sharedControlState.buildSharedControlDiagnostics({
       state: this.state,
       reconnecting: this.reconnect.isScheduled,
@@ -141,20 +132,12 @@ export class RemoteRuntimeSharedControlConnection {
   }
 
   reconnectNow(): void {
-    const ready = isSharedControlReady({
-      state: this.state,
-      ws: this.ws,
-      sharedKey: this.sharedKey
-    })
-    if (this.intentionallyClosed || ready) {
-      return
-    }
-    // Why: a successful one-shot status probe proves the restarted endpoint is reachable; replace even a stuck CONNECTING/awaiting-ready socket instead of waiting behind stale backoff.
-    this.closeSocket(
-      remoteRuntimeUnavailableError('Refreshing remote runtime control transport.'),
-      true
+    reconnectSharedControlNow(
+      !this.intentionallyClosed &&
+        !isSharedControlReady({ state: this.state, ws: this.ws, sharedKey: this.sharedKey }),
+      (error) => this.closeSocket(error, true),
+      () => this.open()
     )
-    this.open()
   }
 
   private ensureReadyWithTimeout(timeoutMs: number): Promise<void> {
@@ -174,10 +157,7 @@ export class RemoteRuntimeSharedControlConnection {
 
   private open(): void {
     if (this.intentionallyClosed) {
-      sharedControlState.rejectSharedControlReadyWaiters(
-        this.readyWaiters,
-        remoteRuntimeUnavailableError()
-      )
+      sharedControlState.rejectSharedControlReadyWaiters(this.readyWaiters)
       return
     }
     this.reconnect.clear()
@@ -255,13 +235,14 @@ export class RemoteRuntimeSharedControlConnection {
     })
   }
 
-  private sendSubscription(subscription: SharedControlLogicalSubscription<unknown>): void {
+  private sendSubscription(subscription: LogicalSubscription): void {
     sharedControlSend.sendSharedControlSubscription({
       subscriptions: this.subscriptions,
       subscription,
       deviceToken: this.pairing.deviceToken,
       send: (payload) => this.sendEncrypted(payload)
     })
+    this.sessionProbe.schedule()
   }
 
   private replaySubscriptions(): void {
@@ -281,6 +262,7 @@ export class RemoteRuntimeSharedControlConnection {
       deviceToken: this.pairing.deviceToken,
       send: (payload) => this.sendEncrypted(payload)
     })
+    this.sessionProbe.schedule()
     this.reconnect.clearWhenIdle(this.subscriptions.size === 0 && this.state === 'closed')
   }
 

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -215,7 +215,8 @@ export class RemoteRuntimeSharedControlConnection {
         })
         this.sessionProbe.schedule()
       },
-      replaySubscriptions: () => this.replaySubscriptions()
+      replaySubscriptions: () => this.replaySubscriptions(),
+      reconcileSubscriptionLifecycle: () => this.reconcileSubscriptionLifecycle()
     })
   }
 
@@ -262,6 +263,10 @@ export class RemoteRuntimeSharedControlConnection {
       deviceToken: this.pairing.deviceToken,
       send: (payload) => this.sendEncrypted(payload)
     })
+    this.reconcileSubscriptionLifecycle()
+  }
+
+  private reconcileSubscriptionLifecycle(): void {
     this.sessionProbe.schedule()
     this.reconnect.clearWhenIdle(this.subscriptions.size === 0 && this.state === 'closed')
   }

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -1,4 +1,4 @@
-import WebSocket from 'ws'
+import type WebSocket from 'ws'
 import type { PairingOffer } from './pairing'
 import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
 import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
@@ -8,22 +8,28 @@ import { handleSharedControlTextFrame } from './remote-runtime-shared-control-fr
 import * as sharedControlProtocol from './remote-runtime-shared-control-protocol'
 import {
   isSharedControlReady,
+  isSharedControlSocketGone,
   waitForSharedControlReadyWithTimeout
 } from './remote-runtime-shared-control-ready'
 import { SharedControlReconnectScheduler } from './remote-runtime-shared-control-reconnect'
 import { requestSharedControl } from './remote-runtime-shared-control-requests'
+import {
+  SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
+  SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS,
+  SharedControlSessionProbe
+} from './remote-runtime-shared-control-session-probe'
 import { SharedControlRetiredRequestIds } from './remote-runtime-shared-control-retired-request-ids'
 import { SharedControlReadyStableResetTimer } from './remote-runtime-shared-control-stability'
 import * as sharedControlState from './remote-runtime-shared-control-state'
 import * as sharedControlSend from './remote-runtime-shared-control-send'
 import { closeSharedControlSocket } from './remote-runtime-shared-control-socket-close'
 import { closeSharedControlConnectionSubscription } from './remote-runtime-shared-control-subscription-close'
-import type { RemoteRuntimeSocketLivenessOptions } from './remote-runtime-socket-liveness'
 import * as sharedControlSubscriptions from './remote-runtime-shared-control-subscriptions'
 import { startSharedControlSubscription } from './remote-runtime-shared-control-subscription-start'
 import { SharedControlSocketGeneration } from './remote-runtime-shared-control-socket-generation'
 import type {
   RemoteRuntimeSharedConnectionDiagnostics,
+  RemoteRuntimeSharedControlConnectionOptions,
   RemoteRuntimeSharedSubscription,
   SharedControlConnectionState,
   SharedControlLogicalSubscription,
@@ -39,6 +45,7 @@ export class RemoteRuntimeSharedControlConnection {
   private socketCleanup: (() => void) | null = null
   private readonly reconnect = new SharedControlReconnectScheduler()
   private readonly readyStableReset: SharedControlReadyStableResetTimer
+  private readonly sessionProbe: SharedControlSessionProbe
   private intentionallyClosed = false
   private lastConnectedAt: number | null = null
   private lastClose: { code: number; reason: string } | null = null
@@ -52,15 +59,24 @@ export class RemoteRuntimeSharedControlConnection {
 
   constructor(
     private readonly pairing: PairingOffer,
-    private readonly options: {
-      environmentId?: string
-      reconnectStableResetMs?: number
-      liveness?: RemoteRuntimeSocketLivenessOptions
-    } = {}
+    private readonly options: RemoteRuntimeSharedControlConnectionOptions = {}
   ) {
     this.readyStableReset = new SharedControlReadyStableResetTimer(
       options.reconnectStableResetMs ?? 30_000
     )
+    this.sessionProbe = new SharedControlSessionProbe({
+      intervalMs: options.sessionProbeIntervalMs ?? SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
+      timeoutMs: options.sessionProbeTimeoutMs ?? SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS,
+      isIntentionallyClosed: () => this.intentionallyClosed,
+      hasSubscriptions: () => this.subscriptions.size > 0,
+      isReady: () =>
+        isSharedControlReady({ state: this.state, ws: this.ws, sharedKey: this.sharedKey }),
+      getSocket: () => this.ws,
+      probe: (timeoutMs) => this.request('status.get', undefined, timeoutMs),
+      // Why: the probe verified it is closing the socket it probed, so it always targets the current generation.
+      forceClose: (error) =>
+        this.handleSocketClosed(error, this.socketGeneration.currentGeneration())
+    })
   }
 
   request<TResult>(
@@ -149,11 +165,7 @@ export class RemoteRuntimeSharedControlConnection {
       readyWaiters: this.readyWaiters,
       timeoutMs,
       open: () => {
-        if (
-          !this.ws ||
-          this.ws.readyState === WebSocket.CLOSED ||
-          this.ws.readyState === WebSocket.CLOSING
-        ) {
+        if (isSharedControlSocketGone(this.ws)) {
           this.open()
         }
       }
@@ -221,6 +233,7 @@ export class RemoteRuntimeSharedControlConnection {
           getSocket: () => this.ws,
           reset: () => this.reconnect.resetAttempt()
         })
+        this.sessionProbe.schedule()
       },
       replaySubscriptions: () => this.replaySubscriptions()
     })
@@ -312,6 +325,7 @@ export class RemoteRuntimeSharedControlConnection {
       preserveReadyWaitersAndPendingRequests,
       clearReadyStableTimer: () => this.readyStableReset.clear()
     })
+    this.sessionProbe.clear()
     this.ws = this.sharedKey = null
     this.socketCleanup = null
     this.state = 'closed'

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -63,7 +63,7 @@ export class RemoteRuntimeSharedControlConnection {
       isReady: () =>
         isSharedControlReady({ state: this.state, ws: this.ws, sharedKey: this.sharedKey }),
       getSocket: () => this.ws,
-      probe: (timeoutMs) => this.request('status.get', undefined, timeoutMs),
+      probe: (timeoutMs, signal) => this.request('status.get', undefined, timeoutMs, signal),
       // Why: the probe's socket identity guard makes the current generation authoritative.
       forceClose: (error) =>
         this.handleSocketClosed(error, this.socketGeneration.currentGeneration())
@@ -73,7 +73,8 @@ export class RemoteRuntimeSharedControlConnection {
   request<TResult>(
     method: string,
     params: unknown,
-    timeoutMs: number
+    timeoutMs: number,
+    signal?: AbortSignal
   ): Promise<RuntimeRpcResponse<TResult>> {
     return requestSharedControl({
       pendingRequests: this.pendingRequests,
@@ -83,7 +84,8 @@ export class RemoteRuntimeSharedControlConnection {
       timeoutMs,
       ensureReady: () => this.ensureReadyWithTimeout(timeoutMs),
       send: (requestId) => this.sendRequest(requestId),
-      retireRequestId: (requestId) => this.retiredRequestIds.retire(requestId)
+      retireRequestId: (requestId) => this.retiredRequestIds.retire(requestId),
+      signal
     })
   }
 

--- a/src/shared/remote-runtime-shared-control-connection.ts
+++ b/src/shared/remote-runtime-shared-control-connection.ts
@@ -15,6 +15,7 @@ import { reconnectSharedControlNow } from './remote-runtime-shared-control-manua
 import { requestSharedControl } from './remote-runtime-shared-control-requests'
 import {
   createSharedControlSessionProbe,
+  requireSessionProbeSuccess,
   type SharedControlSessionProbe
 } from './remote-runtime-shared-control-session-probe'
 import { SharedControlRetiredRequestIds } from './remote-runtime-shared-control-retired-request-ids'
@@ -63,7 +64,8 @@ export class RemoteRuntimeSharedControlConnection {
       isReady: () =>
         isSharedControlReady({ state: this.state, ws: this.ws, sharedKey: this.sharedKey }),
       getSocket: () => this.ws,
-      probe: (timeoutMs, signal) => this.request('status.get', undefined, timeoutMs, signal),
+      probe: async (timeoutMs, signal) =>
+        requireSessionProbeSuccess(await this.request('status.get', undefined, timeoutMs, signal)),
       // Why: the probe's socket identity guard makes the current generation authoritative.
       forceClose: (error) =>
         this.handleSocketClosed(error, this.socketGeneration.currentGeneration())
@@ -111,9 +113,7 @@ export class RemoteRuntimeSharedControlConnection {
     this.intentionallyClosed = true
     this.socketGeneration.invalidate()
     this.reconnect.clear()
-    for (const subscription of Array.from(this.subscriptions.values())) {
-      this.closeSubscription(subscription.requestId)
-    }
+    Array.from(this.subscriptions.values()).forEach((s) => this.closeSubscription(s.requestId))
     this.closeSocket(error)
   }
 

--- a/src/shared/remote-runtime-shared-control-frame-dispatch.ts
+++ b/src/shared/remote-runtime-shared-control-frame-dispatch.ts
@@ -22,6 +22,7 @@ export function dispatchSharedControlFrame(args: {
   retiredRequestIds: SharedControlRetiredRequestIds
   deviceToken: string
   send: (payload: unknown) => boolean
+  reconcileSubscriptionLifecycle: () => void
 }): void {
   if (args.frame.type === 'keepalive') {
     refreshSharedControlPendingRequestTimeouts(args.pendingRequests)
@@ -46,6 +47,7 @@ export function dispatchSharedControlFrame(args: {
     })
     if (!args.subscriptions.has(response.id)) {
       args.retiredRequestIds.retire(response.id)
+      args.reconcileSubscriptionLifecycle()
     }
     return
   }

--- a/src/shared/remote-runtime-shared-control-frame-handler.ts
+++ b/src/shared/remote-runtime-shared-control-frame-handler.ts
@@ -30,6 +30,7 @@ export function handleSharedControlTextFrame(args: {
   sendEncrypted: (payload: unknown) => boolean
   markReady: () => void
   replaySubscriptions: () => void
+  reconcileSubscriptionLifecycle: () => void
 }): void {
   if (args.state === 'awaiting_ready') {
     const error = parseReadyFrame(args.frame)
@@ -75,6 +76,7 @@ export function handleSharedControlTextFrame(args: {
     subscriptions: args.subscriptions,
     retiredRequestIds: args.retiredRequestIds,
     deviceToken: args.deviceToken,
-    send: args.sendEncrypted
+    send: args.sendEncrypted,
+    reconcileSubscriptionLifecycle: args.reconcileSubscriptionLifecycle
   })
 }

--- a/src/shared/remote-runtime-shared-control-manual-reconnect.ts
+++ b/src/shared/remote-runtime-shared-control-manual-reconnect.ts
@@ -1,0 +1,14 @@
+import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import { remoteRuntimeUnavailableError } from './remote-runtime-request-frames'
+
+export function reconnectSharedControlNow(
+  unavailable: boolean,
+  closeSocket: (error: RemoteRuntimeClientError) => void,
+  open: () => void
+): void {
+  if (!unavailable) {
+    return
+  }
+  closeSocket(remoteRuntimeUnavailableError('Refreshing remote runtime control transport.'))
+  open()
+}

--- a/src/shared/remote-runtime-shared-control-manual-reconnect.ts
+++ b/src/shared/remote-runtime-shared-control-manual-reconnect.ts
@@ -9,6 +9,8 @@ export function reconnectSharedControlNow(
   if (!unavailable) {
     return
   }
+  // Why: replace even a stuck CONNECTING/awaiting-ready socket instead of waiting
+  // behind stale backoff when the caller has proof the endpoint is reachable.
   closeSocket(remoteRuntimeUnavailableError('Refreshing remote runtime control transport.'))
   open()
 }

--- a/src/shared/remote-runtime-shared-control-ready.ts
+++ b/src/shared/remote-runtime-shared-control-ready.ts
@@ -15,6 +15,10 @@ export function isSharedControlReady(args: {
   return args.state === 'ready' && args.ws?.readyState === WebSocket.OPEN && !!args.sharedKey
 }
 
+export function isSharedControlSocketGone(ws: WebSocket | null): boolean {
+  return !ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING
+}
+
 export function waitForSharedControlReadyWithTimeout(args: {
   readyWaiters: SharedControlReadyWaiter[]
   timeoutMs: number

--- a/src/shared/remote-runtime-shared-control-requests.ts
+++ b/src/shared/remote-runtime-shared-control-requests.ts
@@ -2,7 +2,6 @@ import { randomUUID } from 'node:crypto'
 import { serializeRemoteRuntimeRpcRequest } from './remote-runtime-memory-limits'
 import {
   prepareRemoteRuntimeRequest,
-  releaseRemoteRuntimePreparedRequest,
   type RemoteRuntimePreparedRequest
 } from './remote-runtime-prepared-request-admission'
 import { remoteRuntimeTimeoutError } from './remote-runtime-request-frames'
@@ -22,12 +21,16 @@ export function requestSharedControl<TResult>(args: {
   ensureReady: () => Promise<void>
   send: (requestId: string) => void
   retireRequestId?: (requestId: string) => void
+  signal?: AbortSignal
   // Why: default off — ordinary short RPCs keep an absolute deadline. Only
   // long-polls routed through this path opt in so keepalives extend them.
   refreshTimeoutOnKeepalive?: boolean
 }): Promise<RuntimeRpcResponse<TResult>> {
   const { ensureReady, pendingRequests, send } = args
   const requestId = randomUUID()
+  if (args.signal?.aborted) {
+    return Promise.reject(createSharedControlRequestAbortError())
+  }
   let preparedRequest: RemoteRuntimePreparedRequest
   try {
     preparedRequest = prepareRemoteRuntimeRequest(pendingRequests, () =>
@@ -43,33 +46,58 @@ export function requestSharedControl<TResult>(args: {
   }
   return new Promise<RuntimeRpcResponse<TResult>>((resolve, reject) => {
     const timeout = setTimeout(() => {
-      const pending = pendingRequests.get(requestId)
-      if (!pending) {
+      if (!pendingRequests.has(requestId)) {
         return
       }
-      pendingRequests.delete(requestId)
-      releaseRemoteRuntimePreparedRequest(pending)
       args.retireRequestId?.(requestId)
       // Why: one stalled method does not prove the shared socket is dead;
       // socket liveness owns connection-wide teardown so other RPCs survive.
-      pending.reject(remoteRuntimeTimeoutError())
+      rejectSharedControlPendingRequest(pendingRequests, requestId, remoteRuntimeTimeoutError())
     }, args.timeoutMs)
-    pendingRequests.set(requestId, {
+    const pending: SharedControlPendingRequest<unknown> = {
       method: args.method.slice(0, MAX_RETAINED_METHOD_CHARS),
       resolve: resolve as (response: RuntimeRpcResponse<unknown>) => void,
       reject,
       timeout,
       preparedRequest,
       refreshTimeoutOnKeepalive: args.refreshTimeoutOnKeepalive ?? false
-    })
-    void ensureReady().then(
-      () => send(requestId),
-      (error) =>
+    }
+    pendingRequests.set(requestId, pending)
+    if (args.signal) {
+      const signal = args.signal
+      const abort = (): void => {
+        if (!pendingRequests.has(requestId)) {
+          return
+        }
+        args.retireRequestId?.(requestId)
         rejectSharedControlPendingRequest(
           pendingRequests,
           requestId,
-          toRemoteRuntimeClientError(error)
+          createSharedControlRequestAbortError()
         )
-    )
+      }
+      pending.releaseCancellation = () => signal.removeEventListener('abort', abort)
+      signal.addEventListener('abort', abort, { once: true })
+      if (signal.aborted) {
+        abort()
+      }
+    }
+    if (pendingRequests.has(requestId)) {
+      void ensureReady().then(
+        () => send(requestId),
+        (error) =>
+          rejectSharedControlPendingRequest(
+            pendingRequests,
+            requestId,
+            toRemoteRuntimeClientError(error)
+          )
+      )
+    }
   })
+}
+
+function createSharedControlRequestAbortError(): Error {
+  const error = new Error('Remote runtime request was cancelled.')
+  error.name = 'AbortError'
+  return error
 }

--- a/src/shared/remote-runtime-shared-control-session-probe.test.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.test.ts
@@ -37,6 +37,21 @@ describe('SharedControlSessionProbe', () => {
     expect(vi.getTimerCount()).toBe(1)
   })
 
+  it('keeps a hard probe cadence through continuous lifecycle reconciliation', async () => {
+    vi.useFakeTimers()
+    const { probe, run, state } = createProbe()
+    state.hasSubscriptions = true
+
+    probe.schedule()
+    for (let elapsed = 90; elapsed <= 990; elapsed += 90) {
+      await vi.advanceTimersByTimeAsync(90)
+      probe.schedule()
+    }
+
+    expect(run).toHaveBeenCalledTimes(9)
+    expect(vi.getTimerCount()).toBe(1)
+  })
+
   it('does not re-arm after the last subscription closes during a probe', async () => {
     vi.useFakeTimers()
     let resolveProbe: () => void = () => undefined

--- a/src/shared/remote-runtime-shared-control-session-probe.test.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type WebSocket from 'ws'
-import { SharedControlSessionProbe } from './remote-runtime-shared-control-session-probe'
+import {
+  createSharedControlSessionProbe,
+  SharedControlSessionProbe
+} from './remote-runtime-shared-control-session-probe'
 
 type ProbeState = {
   intentionallyClosed: boolean
@@ -14,6 +17,25 @@ afterEach(() => {
 })
 
 describe('SharedControlSessionProbe', () => {
+  it('rejects non-positive or non-finite probe timing overrides', () => {
+    const hooks = {
+      isIntentionallyClosed: () => false,
+      hasSubscriptions: () => false,
+      isReady: () => false,
+      getSocket: () => null,
+      probe: () => Promise.resolve(),
+      forceClose: () => {}
+    }
+    for (const value of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(() =>
+        createSharedControlSessionProbe({ sessionProbeIntervalMs: value }, hooks)
+      ).toThrow(RangeError)
+      expect(() =>
+        createSharedControlSessionProbe({ sessionProbeTimeoutMs: value }, hooks)
+      ).toThrow(RangeError)
+    }
+  })
+
   it('does not retain a timer without an active subscription', () => {
     vi.useFakeTimers()
     const { probe, run } = createProbe()

--- a/src/shared/remote-runtime-shared-control-session-probe.test.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type WebSocket from 'ws'
+import { SharedControlSessionProbe } from './remote-runtime-shared-control-session-probe'
+
+type ProbeState = {
+  intentionallyClosed: boolean
+  hasSubscriptions: boolean
+  ready: boolean
+  socket: WebSocket | null
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('SharedControlSessionProbe', () => {
+  it('does not retain a timer without an active subscription', () => {
+    vi.useFakeTimers()
+    const { probe, run } = createProbe()
+
+    probe.schedule()
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it('probes while ready and subscribed', async () => {
+    vi.useFakeTimers()
+    const { probe, run, state } = createProbe()
+    state.hasSubscriptions = true
+
+    probe.schedule()
+    expect(vi.getTimerCount()).toBe(1)
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(run).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(1)
+  })
+
+  it('does not re-arm after the last subscription closes during a probe', async () => {
+    vi.useFakeTimers()
+    let resolveProbe: () => void = () => undefined
+    const pendingProbe = new Promise<void>((resolve) => {
+      resolveProbe = resolve
+    })
+    const { probe, run, state } = createProbe(() => pendingProbe)
+    state.hasSubscriptions = true
+
+    probe.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    state.hasSubscriptions = false
+    probe.clear()
+    resolveProbe()
+    await pendingProbe
+    await Promise.resolve()
+
+    expect(run).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('does not recover an idle connection when its final probe fails', async () => {
+    vi.useFakeTimers()
+    let rejectProbe: (error: Error) => void = () => undefined
+    const pendingProbe = new Promise<void>((_resolve, reject) => {
+      rejectProbe = reject
+    })
+    const { forceClose, probe, state } = createProbe(() => pendingProbe)
+    state.hasSubscriptions = true
+
+    probe.schedule()
+    await vi.advanceTimersByTimeAsync(100)
+    state.hasSubscriptions = false
+    probe.clear()
+    rejectProbe(new Error('session lost'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(forceClose).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+function createProbe(runProbe: () => Promise<unknown> = async () => undefined): {
+  probe: SharedControlSessionProbe
+  run: ReturnType<typeof vi.fn<() => Promise<unknown>>>
+  forceClose: ReturnType<typeof vi.fn>
+  state: ProbeState
+} {
+  const state: ProbeState = {
+    intentionallyClosed: false,
+    hasSubscriptions: false,
+    ready: true,
+    socket: {} as WebSocket
+  }
+  const run = vi.fn(runProbe)
+  const forceClose = vi.fn()
+  const probe = new SharedControlSessionProbe({
+    intervalMs: 100,
+    timeoutMs: 50,
+    isIntentionallyClosed: () => state.intentionallyClosed,
+    hasSubscriptions: () => state.hasSubscriptions,
+    isReady: () => state.ready,
+    getSocket: () => state.socket,
+    probe: run,
+    forceClose
+  })
+  return { forceClose, probe, run, state }
+}

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -1,0 +1,89 @@
+import type WebSocket from 'ws'
+import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import { toRemoteRuntimeClientError } from './remote-runtime-shared-control-protocol'
+
+// Why: the socket-level liveness monitor (remote-runtime-socket-liveness.ts,
+// #7827) pings at the RFC 6455 control-frame layer, but a WS-terminating
+// relay answers those pings itself — so pongs prove only that the relay is
+// reachable. When `orca serve` restarts behind such a relay, the client's
+// E2EE session and the server's in-memory subscription registry are gone
+// while the socket still looks alive, and worktrees created after the
+// restart never reach the sidebar until an app reload. This probe sends an
+// encrypted RPC on a cadence: only the server holding this connection's
+// session keys can answer, so a failed probe proves the session is dead and
+// routes into the existing close → reconnect → replay machinery.
+export const SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS = 15_000
+export const SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS = 10_000
+
+export type SharedControlSessionProbeHooks = {
+  intervalMs: number
+  timeoutMs: number
+  isIntentionallyClosed: () => boolean
+  hasSubscriptions: () => boolean
+  isReady: () => boolean
+  getSocket: () => WebSocket | null
+  probe: (timeoutMs: number) => Promise<unknown>
+  // Why: routes through the socket-closed path so probe failure reuses the
+  // existing reconnect + subscription-replay machinery.
+  forceClose: (error: RemoteRuntimeClientError) => void
+}
+
+export class SharedControlSessionProbe {
+  private timer: ReturnType<typeof setTimeout> | null = null
+
+  constructor(private readonly hooks: SharedControlSessionProbeHooks) {}
+
+  schedule(): void {
+    this.clear()
+    const timer = setTimeout(() => {
+      this.timer = null
+      void this.runProbe()
+    }, this.hooks.intervalMs)
+    // Why: mobile typechecks shared code with DOM timer types where unref is absent.
+    const unrefable = timer as unknown as { unref?: () => void }
+    if (typeof unrefable.unref === 'function') {
+      unrefable.unref()
+    }
+    this.timer = timer
+  }
+
+  clear(): void {
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+  }
+
+  private async runProbe(): Promise<void> {
+    if (this.hooks.isIntentionallyClosed()) {
+      return
+    }
+    // Why: every path back to ready runs markReady, which restarts probing;
+    // rescheduling here would keep an idle timer loop alive on a dead socket.
+    if (!this.hooks.isReady()) {
+      return
+    }
+    // Why: only subscriptions need silent-staleness detection; one-shot
+    // requests already surface their own failures. Reconnects gate on
+    // subscriptions the same way.
+    if (!this.hooks.hasSubscriptions()) {
+      this.schedule()
+      return
+    }
+    const probedSocket = this.hooks.getSocket()
+    try {
+      await this.hooks.probe(this.hooks.timeoutMs)
+      // Why: same stale-socket guard as the failure branch — a reconnect that
+      // replaced the socket mid-probe owns the probe schedule for it.
+      if (this.hooks.getSocket() === probedSocket) {
+        this.schedule()
+      }
+    } catch (error) {
+      // Why: if the socket already changed, a reconnect handled recovery and
+      // scheduled its own probe; force-closing here would kill the new socket.
+      if (this.hooks.getSocket() === probedSocket && !this.hooks.isIntentionallyClosed()) {
+        this.hooks.forceClose(toRemoteRuntimeClientError(error))
+      }
+    }
+  }
+}

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -1,17 +1,9 @@
 import type WebSocket from 'ws'
 import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
 import { toRemoteRuntimeClientError } from './remote-runtime-shared-control-protocol'
+import type { RemoteRuntimeSharedControlConnectionOptions } from './remote-runtime-shared-control-types'
 
-// Why: the socket-level liveness monitor (remote-runtime-socket-liveness.ts,
-// #7827) pings at the RFC 6455 control-frame layer, but a WS-terminating
-// relay answers those pings itself — so pongs prove only that the relay is
-// reachable. When `orca serve` restarts behind such a relay, the client's
-// E2EE session and the server's in-memory subscription registry are gone
-// while the socket still looks alive, and worktrees created after the
-// restart never reach the sidebar until an app reload. This probe sends an
-// encrypted RPC on a cadence: only the server holding this connection's
-// session keys can answer, so a failed probe proves the session is dead and
-// routes into the existing close → reconnect → replay machinery.
+// Why: relay pongs cannot prove the server still owns the encrypted session and its subscriptions.
 export const SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS = 15_000
 export const SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS = 10_000
 
@@ -23,8 +15,7 @@ export type SharedControlSessionProbeHooks = {
   isReady: () => boolean
   getSocket: () => WebSocket | null
   probe: (timeoutMs: number) => Promise<unknown>
-  // Why: routes through the socket-closed path so probe failure reuses the
-  // existing reconnect + subscription-replay machinery.
+  // Why: the socket-closed path already owns reconnect and subscription replay.
   forceClose: (error: RemoteRuntimeClientError) => void
 }
 
@@ -35,6 +26,13 @@ export class SharedControlSessionProbe {
 
   schedule(): void {
     this.clear()
+    if (
+      this.hooks.isIntentionallyClosed() ||
+      !this.hooks.hasSubscriptions() ||
+      !this.hooks.isReady()
+    ) {
+      return
+    }
     const timer = setTimeout(() => {
       this.timer = null
       void this.runProbe()
@@ -55,35 +53,40 @@ export class SharedControlSessionProbe {
   }
 
   private async runProbe(): Promise<void> {
-    if (this.hooks.isIntentionallyClosed()) {
-      return
-    }
-    // Why: every path back to ready runs markReady, which restarts probing;
-    // rescheduling here would keep an idle timer loop alive on a dead socket.
-    if (!this.hooks.isReady()) {
-      return
-    }
-    // Why: only subscriptions need silent-staleness detection; one-shot
-    // requests already surface their own failures. Reconnects gate on
-    // subscriptions the same way.
-    if (!this.hooks.hasSubscriptions()) {
-      this.schedule()
+    if (
+      this.hooks.isIntentionallyClosed() ||
+      !this.hooks.hasSubscriptions() ||
+      !this.hooks.isReady()
+    ) {
       return
     }
     const probedSocket = this.hooks.getSocket()
     try {
       await this.hooks.probe(this.hooks.timeoutMs)
-      // Why: same stale-socket guard as the failure branch — a reconnect that
-      // replaced the socket mid-probe owns the probe schedule for it.
+      // Why: a replacement socket owns its own probe schedule.
       if (this.hooks.getSocket() === probedSocket) {
         this.schedule()
       }
     } catch (error) {
-      // Why: if the socket already changed, a reconnect handled recovery and
-      // scheduled its own probe; force-closing here would kill the new socket.
-      if (this.hooks.getSocket() === probedSocket && !this.hooks.isIntentionallyClosed()) {
+      // Why: force-closing a replacement socket would kill a recovered session.
+      if (
+        this.hooks.getSocket() === probedSocket &&
+        this.hooks.hasSubscriptions() &&
+        !this.hooks.isIntentionallyClosed()
+      ) {
         this.hooks.forceClose(toRemoteRuntimeClientError(error))
       }
     }
   }
+}
+
+export function createSharedControlSessionProbe(
+  options: RemoteRuntimeSharedControlConnectionOptions,
+  hooks: Omit<SharedControlSessionProbeHooks, 'intervalMs' | 'timeoutMs'>
+): SharedControlSessionProbe {
+  return new SharedControlSessionProbe({
+    ...hooks,
+    intervalMs: options.sessionProbeIntervalMs ?? SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
+    timeoutMs: options.sessionProbeTimeoutMs ?? SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS
+  })
 }

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -31,6 +31,8 @@ export class SharedControlSessionProbe {
       !this.hooks.hasSubscriptions() ||
       !this.hooks.isReady()
     ) {
+      // Why: a connection that stops qualifying must also retire any in-flight probe,
+      // so schedule() doubles as teardown when its guards fail.
       this.clear()
       return
     }

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -14,23 +14,27 @@ export type SharedControlSessionProbeHooks = {
   hasSubscriptions: () => boolean
   isReady: () => boolean
   getSocket: () => WebSocket | null
-  probe: (timeoutMs: number) => Promise<unknown>
+  probe: (timeoutMs: number, signal: AbortSignal) => Promise<unknown>
   // Why: the socket-closed path already owns reconnect and subscription replay.
   forceClose: (error: RemoteRuntimeClientError) => void
 }
 
 export class SharedControlSessionProbe {
   private timer: ReturnType<typeof setTimeout> | null = null
+  private probeAbortController: AbortController | null = null
 
   constructor(private readonly hooks: SharedControlSessionProbeHooks) {}
 
   schedule(): void {
-    this.clear()
     if (
       this.hooks.isIntentionallyClosed() ||
       !this.hooks.hasSubscriptions() ||
       !this.hooks.isReady()
     ) {
+      this.clear()
+      return
+    }
+    if (this.timer || this.probeAbortController) {
       return
     }
     const timer = setTimeout(() => {
@@ -50,6 +54,9 @@ export class SharedControlSessionProbe {
       clearTimeout(this.timer)
       this.timer = null
     }
+    const probeAbortController = this.probeAbortController
+    this.probeAbortController = null
+    probeAbortController?.abort()
   }
 
   private async runProbe(): Promise<void> {
@@ -61,13 +68,26 @@ export class SharedControlSessionProbe {
       return
     }
     const probedSocket = this.hooks.getSocket()
+    const probeAbortController = new AbortController()
+    this.probeAbortController = probeAbortController
     try {
-      await this.hooks.probe(this.hooks.timeoutMs)
+      await this.hooks.probe(this.hooks.timeoutMs, probeAbortController.signal)
+      if (this.probeAbortController !== probeAbortController) {
+        return
+      }
+      this.probeAbortController = null
       // Why: a replacement socket owns its own probe schedule.
       if (this.hooks.getSocket() === probedSocket) {
         this.schedule()
       }
     } catch (error) {
+      const wasCancelled = probeAbortController.signal.aborted
+      if (this.probeAbortController === probeAbortController) {
+        this.probeAbortController = null
+      }
+      if (wasCancelled) {
+        return
+      }
       const probeError = toRemoteRuntimeClientError(error)
       if (probeError.code === 'remote_runtime_busy' && this.hooks.getSocket() === probedSocket) {
         this.schedule()

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -68,13 +68,18 @@ export class SharedControlSessionProbe {
         this.schedule()
       }
     } catch (error) {
+      const probeError = toRemoteRuntimeClientError(error)
+      if (probeError.code === 'remote_runtime_busy' && this.hooks.getSocket() === probedSocket) {
+        this.schedule()
+        return
+      }
       // Why: force-closing a replacement socket would kill a recovered session.
       if (
         this.hooks.getSocket() === probedSocket &&
         this.hooks.hasSubscriptions() &&
         !this.hooks.isIntentionallyClosed()
       ) {
-        this.hooks.forceClose(toRemoteRuntimeClientError(error))
+        this.hooks.forceClose(probeError)
       }
     }
   }

--- a/src/shared/remote-runtime-shared-control-session-probe.ts
+++ b/src/shared/remote-runtime-shared-control-session-probe.ts
@@ -1,5 +1,6 @@
 import type WebSocket from 'ws'
-import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
 import { toRemoteRuntimeClientError } from './remote-runtime-shared-control-protocol'
 import type { RemoteRuntimeSharedControlConnectionOptions } from './remote-runtime-shared-control-types'
 
@@ -107,13 +108,35 @@ export class SharedControlSessionProbe {
   }
 }
 
+// Why: an ok:false response proves lost session authority just like a rejected
+// request — resolving it would reschedule the probe instead of recovering.
+export function requireSessionProbeSuccess<T>(
+  response: RuntimeRpcResponse<T>
+): RuntimeRpcResponse<T> {
+  if (!response.ok) {
+    throw new RemoteRuntimeClientError(response.error.code, response.error.message)
+  }
+  return response
+}
+
+function requirePositiveFiniteMs(value: number | undefined, name: string): number | undefined {
+  if (value !== undefined && (!Number.isFinite(value) || value <= 0)) {
+    throw new RangeError(`${name} must be a positive finite number of milliseconds`)
+  }
+  return value
+}
+
 export function createSharedControlSessionProbe(
   options: RemoteRuntimeSharedControlConnectionOptions,
   hooks: Omit<SharedControlSessionProbeHooks, 'intervalMs' | 'timeoutMs'>
 ): SharedControlSessionProbe {
   return new SharedControlSessionProbe({
     ...hooks,
-    intervalMs: options.sessionProbeIntervalMs ?? SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
-    timeoutMs: options.sessionProbeTimeoutMs ?? SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS
+    intervalMs:
+      requirePositiveFiniteMs(options.sessionProbeIntervalMs, 'sessionProbeIntervalMs') ??
+      SHARED_CONTROL_SESSION_PROBE_INTERVAL_MS,
+    timeoutMs:
+      requirePositiveFiniteMs(options.sessionProbeTimeoutMs, 'sessionProbeTimeoutMs') ??
+      SHARED_CONTROL_SESSION_PROBE_TIMEOUT_MS
   })
 }

--- a/src/shared/remote-runtime-shared-control-socket-generation.ts
+++ b/src/shared/remote-runtime-shared-control-socket-generation.ts
@@ -8,6 +8,10 @@ export class SharedControlSocketGeneration {
     return generation === this.current
   }
 
+  currentGeneration(): number {
+    return this.current
+  }
+
   begin(): number {
     this.current += 1
     return this.current

--- a/src/shared/remote-runtime-shared-control-state.ts
+++ b/src/shared/remote-runtime-shared-control-state.ts
@@ -45,6 +45,7 @@ export function rejectSharedControlPendingRequest(
   }
   pendingRequests.delete(requestId)
   clearTimeout(pending.timeout)
+  releasePendingRequestCancellation(pending)
   releaseRemoteRuntimePreparedRequest(pending)
   pending.reject(error)
 }
@@ -60,6 +61,7 @@ export function resolveSharedControlPendingResponse(
   }
   pendingRequests.delete(requestId)
   clearTimeout(pending.timeout)
+  releasePendingRequestCancellation(pending)
   releaseRemoteRuntimePreparedRequest(pending)
   pending.resolve(response)
 }
@@ -86,9 +88,15 @@ export function rejectAllSharedControlPendingRequests(
   for (const [requestId, pending] of pendingRequests) {
     clearTimeout(pending.timeout)
     pendingRequests.delete(requestId)
+    releasePendingRequestCancellation(pending)
     releaseRemoteRuntimePreparedRequest(pending)
     pending.reject(closeError)
   }
+}
+
+function releasePendingRequestCancellation(pending: SharedControlPendingRequest<unknown>): void {
+  pending.releaseCancellation?.()
+  pending.releaseCancellation = undefined
 }
 
 export function markSharedControlSubscriptionsUnsent(

--- a/src/shared/remote-runtime-shared-control-state.ts
+++ b/src/shared/remote-runtime-shared-control-state.ts
@@ -126,7 +126,7 @@ export function resolveSharedControlReadyWaiters(waiters: SharedControlReadyWait
 
 export function rejectSharedControlReadyWaiters(
   waiters: SharedControlReadyWaiter[],
-  error: Error
+  error: Error = remoteRuntimeUnavailableError()
 ): void {
   for (const waiter of waiters.splice(0)) {
     waiter.reject(error)

--- a/src/shared/remote-runtime-shared-control-test-server.ts
+++ b/src/shared/remote-runtime-shared-control-test-server.ts
@@ -15,6 +15,7 @@ export type SharedControlTestServer = {
   requests: { id: string; method: string; params?: unknown }[]
   auths: unknown[]
   connectionCount: () => number
+  endActiveSubscriptions: () => void
   flushDelayedResponses: () => void
 }
 
@@ -59,6 +60,7 @@ export async function createSharedControlTestServer(
   const requests: SharedControlTestServer['requests'] = []
   const auths: unknown[] = []
   const delayedResponses: (() => void)[] = []
+  const subscriptionEnds: (() => void)[] = []
   let connectionCount = 0
   let closedAfterFirstStreamingResponse = false
   const wss = new WebSocketServer({ port: 0, autoPong: options.disableAutoPong !== true })
@@ -130,7 +132,8 @@ export async function createSharedControlTestServer(
             return true
           }
         },
-        delayedResponses
+        delayedResponses,
+        subscriptionEnds
       )
     })
   })
@@ -153,6 +156,7 @@ export async function createSharedControlTestServer(
     requests,
     auths,
     connectionCount: () => connectionCount,
+    endActiveSubscriptions: () => subscriptionEnds.splice(0).forEach((send) => send()),
     flushDelayedResponses: () => delayedResponses.splice(0).forEach((send) => send())
   }
 }
@@ -163,7 +167,8 @@ function handleRequest(
   requests: SharedControlTestServer['requests'],
   request: { id: string; method: string; params?: unknown },
   options: SharedControlTestServerOptions & { closeAfterStreamingResponse: () => boolean },
-  delayedResponses: (() => void)[]
+  delayedResponses: (() => void)[],
+  subscriptionEnds: (() => void)[]
 ): void {
   requests.push(request)
   if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs !== undefined) {
@@ -200,7 +205,7 @@ function handleRequest(
       streaming: streaming ? true : undefined,
       _meta: { runtimeId: 'runtime-test' }
     })
-    if (streaming && options.endStreamingResponseAfterReady) {
+    const sendEnd = (): void => {
       sendEncrypted(ws, sharedKey, {
         id: request.id,
         ok: true,
@@ -208,6 +213,11 @@ function handleRequest(
         streaming: true,
         _meta: { runtimeId: 'runtime-test' }
       })
+    }
+    if (streaming && options.endStreamingResponseAfterReady) {
+      sendEnd()
+    } else if (streaming) {
+      subscriptionEnds.push(sendEnd)
     }
   }
   const closeAfterResponse = streaming && options.closeAfterStreamingResponse()

--- a/src/shared/remote-runtime-shared-control-test-server.ts
+++ b/src/shared/remote-runtime-shared-control-test-server.ts
@@ -63,7 +63,14 @@ export async function createSharedControlTestServer(
   const subscriptionEnds: (() => void)[] = []
   let connectionCount = 0
   let closedAfterFirstStreamingResponse = false
-  const wss = new WebSocketServer({ port: 0, autoPong: options.disableAutoPong !== true })
+  // Why: bind loopback-specific, not wildcard — on macOS another process binding
+  // 127.0.0.1 on the same ephemeral port would shadow a wildcard listener and
+  // hijack the tests' connections (observed with a running Orca app's browser bridge).
+  const wss = new WebSocketServer({
+    port: 0,
+    host: '127.0.0.1',
+    autoPong: options.disableAutoPong !== true
+  })
   servers.push(wss)
 
   wss.on('connection', (ws) => {

--- a/src/shared/remote-runtime-shared-control-test-server.ts
+++ b/src/shared/remote-runtime-shared-control-test-server.ts
@@ -33,6 +33,7 @@ export type SharedControlTestServerOptions = {
   delayedMethods?: string[]
   silentMethods?: string[]
   goSilentOnFirstConnectionAfterFirstStreamingResponse?: boolean
+  endStreamingResponseAfterReady?: boolean
 }
 
 const servers: WebSocketServer[] = []
@@ -199,6 +200,15 @@ function handleRequest(
       streaming: streaming ? true : undefined,
       _meta: { runtimeId: 'runtime-test' }
     })
+    if (streaming && options.endStreamingResponseAfterReady) {
+      sendEncrypted(ws, sharedKey, {
+        id: request.id,
+        ok: true,
+        result: { type: 'end' },
+        streaming: true,
+        _meta: { runtimeId: 'runtime-test' }
+      })
+    }
   }
   const closeAfterResponse = streaming && options.closeAfterStreamingResponse()
   if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs === undefined) {

--- a/src/shared/remote-runtime-shared-control-test-server.ts
+++ b/src/shared/remote-runtime-shared-control-test-server.ts
@@ -33,6 +33,7 @@ export type SharedControlTestServerOptions = {
   disableAutoPong?: boolean
   delayedMethods?: string[]
   silentMethods?: string[]
+  failMethods?: string[]
   goSilentOnFirstConnectionAfterFirstStreamingResponse?: boolean
   endStreamingResponseAfterReady?: boolean
 }
@@ -75,7 +76,10 @@ export async function createSharedControlTestServer(
 
   wss.on('connection', (ws) => {
     connectionCount += 1
-    const isFirstConnection = connectionCount === 1
+    // Why: captured per connection — the outer count keeps moving, so reading it
+    // at hello time would mis-suppress a first socket that raced a second connect.
+    const connectionIndex = connectionCount
+    const isFirstConnection = connectionIndex === 1
     let goneSilent = false
     let sharedKey: Uint8Array | null = null
     let authenticated = false
@@ -92,7 +96,7 @@ export async function createSharedControlTestServer(
         )
         if (
           options.suppressReadyFrame ||
-          connectionCount <= (options.suppressReadyFrameCount ?? 0)
+          connectionIndex <= (options.suppressReadyFrameCount ?? 0)
         ) {
           return
         }
@@ -188,6 +192,15 @@ function handleRequest(
   if (options.silentMethods?.includes(request.method)) {
     return
   }
+  if (options.failMethods?.includes(request.method)) {
+    sendEncrypted(ws, sharedKey, {
+      id: request.id,
+      ok: false,
+      error: { code: 'session_authority_lost', message: 'test failure response' },
+      _meta: { runtimeId: 'runtime-test' }
+    })
+    return
+  }
   if (options.closeBeforeResponse) {
     ws.close(4001, 'test close')
     return
@@ -226,8 +239,12 @@ function handleRequest(
     } else if (streaming) {
       subscriptionEnds.push(sendEnd)
     }
+    // Why: consume the one-shot close flag only when a streaming response is
+    // actually sent, so delayed/flushed responses still observe the close.
+    if (streaming && options.closeAfterStreamingResponse()) {
+      setTimeout(() => ws.close(), 0)
+    }
   }
-  const closeAfterResponse = streaming && options.closeAfterStreamingResponse()
   if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs === undefined) {
     sendEncrypted(ws, sharedKey, { _keepalive: true })
   }
@@ -240,18 +257,10 @@ function handleRequest(
     return
   }
   if (options.responseDelayMs !== undefined) {
-    setTimeout(() => {
-      sendResponse()
-      if (closeAfterResponse) {
-        setTimeout(() => ws.close(), 0)
-      }
-    }, options.responseDelayMs)
+    setTimeout(sendResponse, options.responseDelayMs)
     return
   }
   sendResponse()
-  if (closeAfterResponse) {
-    setTimeout(() => ws.close(), 0)
-  }
 }
 
 function isStreamingMethod(method: string): boolean {

--- a/src/shared/remote-runtime-shared-control-test-server.ts
+++ b/src/shared/remote-runtime-shared-control-test-server.ts
@@ -1,0 +1,240 @@
+import type { AddressInfo } from 'node:net'
+import { WebSocketServer, type WebSocket } from 'ws'
+import {
+  decrypt,
+  deriveSharedKey,
+  encrypt,
+  generateKeyPair,
+  publicKeyFromBase64,
+  publicKeyToBase64
+} from './e2ee-crypto'
+import { encodePairingOffer, parsePairingCode, type PairingOffer } from './pairing'
+
+export type SharedControlTestServer = {
+  pairing: PairingOffer
+  requests: { id: string; method: string; params?: unknown }[]
+  auths: unknown[]
+  connectionCount: () => number
+  flushDelayedResponses: () => void
+}
+
+export type SharedControlTestServerOptions = {
+  delaySubscriptionReady?: boolean
+  sendKeepaliveBeforeResponse?: boolean
+  keepaliveDelayMs?: number
+  responseDelayMs?: number
+  sendBinaryAfterAuth?: boolean
+  sendUnknownResponseBeforeResponse?: boolean
+  closeAfterFirstStreamingResponse?: boolean
+  closeBeforeResponse?: boolean
+  suppressReadyFrame?: boolean
+  suppressReadyFrameCount?: number
+  disableAutoPong?: boolean
+  delayedMethods?: string[]
+  silentMethods?: string[]
+  goSilentOnFirstConnectionAfterFirstStreamingResponse?: boolean
+}
+
+const servers: WebSocketServer[] = []
+
+export async function closeSharedControlTestServers(): Promise<void> {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          for (const client of server.clients) {
+            client.close()
+          }
+          server.close(() => resolve())
+        })
+    )
+  )
+}
+
+export async function createSharedControlTestServer(
+  options: SharedControlTestServerOptions = {}
+): Promise<SharedControlTestServer> {
+  const serverKeyPair = generateKeyPair()
+  const requests: SharedControlTestServer['requests'] = []
+  const auths: unknown[] = []
+  const delayedResponses: (() => void)[] = []
+  let connectionCount = 0
+  let closedAfterFirstStreamingResponse = false
+  const wss = new WebSocketServer({ port: 0, autoPong: options.disableAutoPong !== true })
+  servers.push(wss)
+
+  wss.on('connection', (ws) => {
+    connectionCount += 1
+    const isFirstConnection = connectionCount === 1
+    let goneSilent = false
+    let sharedKey: Uint8Array | null = null
+    let authenticated = false
+    ws.on('message', (data, isBinary) => {
+      if (isBinary) {
+        return
+      }
+      const frame = data.toString()
+      if (!sharedKey) {
+        const hello = JSON.parse(frame) as { publicKeyB64: string }
+        sharedKey = deriveSharedKey(
+          serverKeyPair.secretKey,
+          publicKeyFromBase64(hello.publicKeyB64)
+        )
+        if (
+          options.suppressReadyFrame ||
+          connectionCount <= (options.suppressReadyFrameCount ?? 0)
+        ) {
+          return
+        }
+        ws.send(JSON.stringify({ type: 'e2ee_ready' }))
+        return
+      }
+      const plaintext = decrypt(frame, sharedKey)
+      if (!plaintext) {
+        return
+      }
+      if (!authenticated) {
+        auths.push(JSON.parse(plaintext))
+        authenticated = true
+        sendEncrypted(ws, sharedKey, { type: 'e2ee_authenticated' })
+        if (options.sendBinaryAfterAuth) {
+          ws.send(Buffer.from([1, 2, 3]), { binary: true })
+        }
+        return
+      }
+      const request = JSON.parse(plaintext) as { id: string; method: string; params?: unknown }
+      if (goneSilent) {
+        requests.push(request)
+        return
+      }
+      if (
+        options.goSilentOnFirstConnectionAfterFirstStreamingResponse &&
+        isFirstConnection &&
+        isStreamingMethod(request.method)
+      ) {
+        goneSilent = true
+      }
+      handleRequest(
+        ws,
+        sharedKey,
+        requests,
+        request,
+        {
+          ...options,
+          closeAfterStreamingResponse: () => {
+            if (!options.closeAfterFirstStreamingResponse || closedAfterFirstStreamingResponse) {
+              return false
+            }
+            closedAfterFirstStreamingResponse = true
+            return true
+          }
+        },
+        delayedResponses
+      )
+    })
+  })
+
+  await new Promise<void>((resolve) => wss.once('listening', resolve))
+  const address = wss.address() as AddressInfo
+  const pairing = parsePairingCode(
+    encodePairingOffer({
+      v: 2,
+      endpoint: `ws://127.0.0.1:${address.port}`,
+      deviceToken: 'device-token',
+      publicKeyB64: publicKeyToBase64(serverKeyPair.publicKey)
+    })
+  )
+  if (!pairing) {
+    throw new Error('Failed to create test pairing')
+  }
+  return {
+    pairing,
+    requests,
+    auths,
+    connectionCount: () => connectionCount,
+    flushDelayedResponses: () => delayedResponses.splice(0).forEach((send) => send())
+  }
+}
+
+function handleRequest(
+  ws: WebSocket,
+  sharedKey: Uint8Array,
+  requests: SharedControlTestServer['requests'],
+  request: { id: string; method: string; params?: unknown },
+  options: SharedControlTestServerOptions & { closeAfterStreamingResponse: () => boolean },
+  delayedResponses: (() => void)[]
+): void {
+  requests.push(request)
+  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs !== undefined) {
+    const timer = setInterval(
+      () => sendEncrypted(ws, sharedKey, { _keepalive: true }),
+      options.keepaliveDelayMs
+    )
+    ws.once('close', () => clearInterval(timer))
+  }
+  if (options.silentMethods?.includes(request.method)) {
+    return
+  }
+  if (options.closeBeforeResponse) {
+    ws.close(4001, 'test close')
+    return
+  }
+  const streaming = isStreamingMethod(request.method)
+  const result = streaming
+    ? { type: 'ready', subscriptionId: `${request.method}:subscription` }
+    : { method: request.method }
+  const sendResponse = (): void => {
+    if (options.sendUnknownResponseBeforeResponse) {
+      sendEncrypted(ws, sharedKey, {
+        id: 'unknown-response-id',
+        ok: true,
+        result: { method: 'unknown' },
+        _meta: { runtimeId: 'runtime-test' }
+      })
+    }
+    sendEncrypted(ws, sharedKey, {
+      id: request.id,
+      ok: true,
+      result,
+      streaming: streaming ? true : undefined,
+      _meta: { runtimeId: 'runtime-test' }
+    })
+  }
+  const closeAfterResponse = streaming && options.closeAfterStreamingResponse()
+  if (options.sendKeepaliveBeforeResponse && options.keepaliveDelayMs === undefined) {
+    sendEncrypted(ws, sharedKey, { _keepalive: true })
+  }
+  if (options.delaySubscriptionReady && streaming) {
+    delayedResponses.push(sendResponse)
+    return
+  }
+  if (options.delayedMethods?.includes(request.method)) {
+    delayedResponses.push(sendResponse)
+    return
+  }
+  if (options.responseDelayMs !== undefined) {
+    setTimeout(() => {
+      sendResponse()
+      if (closeAfterResponse) {
+        setTimeout(() => ws.close(), 0)
+      }
+    }, options.responseDelayMs)
+    return
+  }
+  sendResponse()
+  if (closeAfterResponse) {
+    setTimeout(() => ws.close(), 0)
+  }
+}
+
+function isStreamingMethod(method: string): boolean {
+  return (
+    method.endsWith('.subscribe') ||
+    method === 'session.tabs.subscribeAll' ||
+    method === 'files.watch'
+  )
+}
+
+function sendEncrypted(ws: WebSocket, sharedKey: Uint8Array, message: unknown): void {
+  ws.send(encrypt(JSON.stringify(message), sharedKey))
+}

--- a/src/shared/remote-runtime-shared-control-types.ts
+++ b/src/shared/remote-runtime-shared-control-types.ts
@@ -1,12 +1,21 @@
 import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
 import type { RemoteRuntimeClientError } from './remote-runtime-client-error'
 import type { RemoteRuntimePreparedRequest } from './remote-runtime-prepared-request-admission'
+import type { RemoteRuntimeSocketLivenessOptions } from './remote-runtime-socket-liveness'
 
 export type SharedControlConnectionState =
   | 'closed'
   | 'awaiting_ready'
   | 'awaiting_authenticated'
   | 'ready'
+
+export type RemoteRuntimeSharedControlConnectionOptions = {
+  environmentId?: string
+  reconnectStableResetMs?: number
+  liveness?: RemoteRuntimeSocketLivenessOptions
+  sessionProbeIntervalMs?: number
+  sessionProbeTimeoutMs?: number
+}
 
 export type SharedControlPendingRequest<TResult> = {
   method: string

--- a/src/shared/remote-runtime-shared-control-types.ts
+++ b/src/shared/remote-runtime-shared-control-types.ts
@@ -23,6 +23,7 @@ export type SharedControlPendingRequest<TResult> = {
   reject: (error: Error) => void
   timeout: ReturnType<typeof setTimeout>
   preparedRequest?: RemoteRuntimePreparedRequest | null
+  releaseCancellation?: () => void
   // Why: keepalives on the shared socket are armed for an unrelated long-poll,
   // not this request. Only requests that opt in (long-polls issued via the
   // short-RPC path) may have their deadline refreshed by a keepalive; ordinary

--- a/tests/e2e/helpers/zombie-runtime-relay.ts
+++ b/tests/e2e/helpers/zombie-runtime-relay.ts
@@ -1,0 +1,120 @@
+import type { RawData } from 'ws'
+import WebSocket, { WebSocketServer } from 'ws'
+
+type QueuedFrame = { data: RawData; isBinary: boolean }
+
+type RelayConnection = {
+  downstream: WebSocket
+  preserveUpstream: boolean
+  upstream: WebSocket
+}
+
+export type ZombieRuntimeRelay = {
+  close: () => Promise<void>
+  endpoint: string
+  evidence: () => {
+    activeConnectionCount: number
+    controlPingCount: number
+    connectionCount: number
+    zombifiedConnectionCount: number
+  }
+  zombifyActiveSessions: () => Promise<void>
+}
+
+export async function createZombieRuntimeRelay(
+  targetEndpoint: string
+): Promise<ZombieRuntimeRelay> {
+  const server = new WebSocketServer({ host: '127.0.0.1', port: 0 })
+  const connections = new Set<RelayConnection>()
+  let connectionCount = 0
+  let controlPingCount = 0
+  let zombifiedConnectionCount = 0
+
+  server.on('connection', (upstream) => {
+    connectionCount += 1
+    const downstream = new WebSocket(targetEndpoint)
+    const connection: RelayConnection = { downstream, preserveUpstream: false, upstream }
+    const queuedFrames: QueuedFrame[] = []
+    connections.add(connection)
+
+    upstream.on('ping', () => {
+      controlPingCount += 1
+    })
+    upstream.on('message', (data, isBinary) => {
+      if (downstream.readyState === WebSocket.OPEN) {
+        downstream.send(data, { binary: isBinary })
+      } else if (downstream.readyState === WebSocket.CONNECTING) {
+        queuedFrames.push({ data, isBinary })
+      }
+    })
+    upstream.on('close', () => {
+      connections.delete(connection)
+      downstream.terminate()
+    })
+    upstream.on('error', () => undefined)
+
+    downstream.on('open', () => {
+      for (const frame of queuedFrames.splice(0)) {
+        downstream.send(frame.data, { binary: frame.isBinary })
+      }
+    })
+    downstream.on('message', (data, isBinary) => {
+      if (upstream.readyState === WebSocket.OPEN) {
+        upstream.send(data, { binary: isBinary })
+      }
+    })
+    downstream.on('close', () => {
+      if (!connection.preserveUpstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.close()
+      }
+    })
+    downstream.on('error', () => undefined)
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('listening', resolve)
+    server.once('error', reject)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') {
+    throw new Error('Zombie runtime relay did not bind a TCP port')
+  }
+
+  return {
+    endpoint: `ws://127.0.0.1:${address.port}`,
+    evidence: () => ({
+      activeConnectionCount: connections.size,
+      controlPingCount,
+      connectionCount,
+      zombifiedConnectionCount
+    }),
+    zombifyActiveSessions: async () => {
+      const active = Array.from(connections).filter(
+        ({ downstream, upstream }) =>
+          downstream.readyState === WebSocket.OPEN && upstream.readyState === WebSocket.OPEN
+      )
+      if (active.length === 0) {
+        throw new Error('Zombie runtime relay has no active session to sever')
+      }
+      zombifiedConnectionCount += active.length
+      await Promise.all(
+        active.map(
+          ({ downstream }, index) =>
+            new Promise<void>((resolve) => {
+              active[index].preserveUpstream = true
+              downstream.once('close', resolve)
+              downstream.terminate()
+            })
+        )
+      )
+    },
+    close: async () => {
+      for (const { downstream, upstream } of connections) {
+        upstream.terminate()
+        downstream.terminate()
+      }
+      connections.clear()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  }
+}

--- a/tests/e2e/pr10235-stale-subscription-restart.spec.ts
+++ b/tests/e2e/pr10235-stale-subscription-restart.spec.ts
@@ -15,25 +15,31 @@ import { createZombieRuntimeRelay } from './helpers/zombie-runtime-relay'
 
 function createGitRepo(): string {
   const repoPath = mkdtempSync(path.join(os.tmpdir(), 'orca-pr10235-repo-'))
-  execFileSync('git', ['init'], { cwd: repoPath, stdio: 'ignore' })
-  writeFileSync(path.join(repoPath, 'README.md'), '# PR 10235 relay oracle\n')
-  execFileSync('git', ['add', 'README.md'], { cwd: repoPath, stdio: 'ignore' })
-  execFileSync(
-    'git',
-    [
-      '-c',
-      'user.name=Orca E2E',
-      '-c',
-      'user.email=orca-e2e@example.invalid',
-      // Why: ambient commit.gpgsign=true would fail the seed commit opaquely.
-      '-c',
-      'commit.gpgsign=false',
-      'commit',
-      '-m',
-      'seed'
-    ],
-    { cwd: repoPath, stdio: 'ignore' }
-  )
+  // Why: a git failure after mkdtempSync must not orphan the temp directory.
+  try {
+    execFileSync('git', ['init'], { cwd: repoPath, stdio: 'ignore' })
+    writeFileSync(path.join(repoPath, 'README.md'), '# PR 10235 relay oracle\n')
+    execFileSync('git', ['add', 'README.md'], { cwd: repoPath, stdio: 'ignore' })
+    execFileSync(
+      'git',
+      [
+        '-c',
+        'user.name=Orca E2E',
+        '-c',
+        'user.email=orca-e2e@example.invalid',
+        // Why: ambient commit.gpgsign=true would fail the seed commit opaquely.
+        '-c',
+        'commit.gpgsign=false',
+        'commit',
+        '-m',
+        'seed'
+      ],
+      { cwd: repoPath, stdio: 'ignore' }
+    )
+  } catch (error) {
+    rmSync(repoPath, { recursive: true, force: true })
+    throw error
+  }
   return repoPath
 }
 
@@ -103,9 +109,12 @@ async function runStaleSubscriptionOracle(args: {
     await relay.close()
     throw error
   })
-  const addedRepoPath = createGitRepo()
+  // Why: created inside try so a git failure still disposes the client/relay.
+  let repoPathToCleanUp: string | null = null
 
   try {
+    const addedRepoPath = createGitRepo()
+    repoPathToCleanUp = addedRepoPath
     await client.page.evaluate(async (environmentId) => {
       const store = window.__store
       if (!store) {
@@ -197,9 +206,13 @@ async function runStaleSubscriptionOracle(args: {
       })}`
     )
   } finally {
-    await client.dispose()
-    await relay.close()
-    rmSync(addedRepoPath, { recursive: true, force: true })
+    // Why: a rejected teardown step must not skip the others or replace the
+    // assertion error that actually failed the test.
+    await client.dispose().catch(() => {})
+    await relay.close().catch(() => {})
+    if (repoPathToCleanUp) {
+      rmSync(repoPathToCleanUp, { recursive: true, force: true })
+    }
   }
 }
 
@@ -260,7 +273,7 @@ test('self-heals a headless serve worktree subscription behind a zombie relay', 
       topology: 'headless'
     })
   } finally {
-    await host.dispose()
+    await host.dispose().catch(() => {})
     rmSync(initialRepoPath, { recursive: true, force: true })
   }
 })

--- a/tests/e2e/pr10235-stale-subscription-restart.spec.ts
+++ b/tests/e2e/pr10235-stale-subscription-restart.spec.ts
@@ -69,6 +69,20 @@ async function readWorktreeSurface(
   )
 }
 
+async function readSharedControlGeneration(page: Page, environmentId: string): Promise<number> {
+  return page.evaluate(async (selector) => {
+    const response = await window.api.runtimeEnvironments.getStatus({
+      selector,
+      timeoutMs: 5000
+    })
+    const generation = response.ok ? response.result.remoteControl?.lastConnectedAt : null
+    if (typeof generation !== 'number') {
+      throw new Error('Shared-control generation is unavailable')
+    }
+    return generation
+  }, environmentId)
+}
+
 async function runStaleSubscriptionOracle(args: {
   host: RuntimeClient
   initialRepoPath: string
@@ -105,7 +119,10 @@ async function runStaleSubscriptionOracle(args: {
       .poll(() => relay.evidence().activeConnectionCount, { timeout: 10_000 })
       .toBeGreaterThan(0)
 
-    const connectionCountBeforeFault = relay.evidence().connectionCount
+    const sharedControlGenerationBeforeFault = await readSharedControlGeneration(
+      client.page,
+      client.environmentId
+    )
     await relay.zombifyActiveSessions()
     const added = await args.host.call<{ repo: { id: string } }>('repo.add', {
       path: addedRepoPath,
@@ -150,14 +167,31 @@ async function runStaleSubscriptionOracle(args: {
       )
     }
 
+    await expect
+      .poll(() => readSharedControlGeneration(client.page, client.environmentId), {
+        timeout: 10_000
+      })
+      .toBeGreaterThan(sharedControlGenerationBeforeFault)
+
     const evidence = relay.evidence()
     expect(evidence.controlPingCount).toBeGreaterThan(0)
-    expect(evidence.connectionCount).toBeGreaterThan(connectionCountBeforeFault)
+    expect(evidence.zombifiedConnectionCount).toBeGreaterThan(0)
+    const sharedControlGenerationAfterFault = await readSharedControlGeneration(
+      client.page,
+      client.environmentId
+    )
     await client.page.screenshot({
       path: args.testInfo.outputPath(`${args.topology}-self-healed.png`),
       fullPage: true
     })
-    console.info(`[pr10235] ${JSON.stringify({ topology: args.topology, ...evidence })}`)
+    console.info(
+      `[pr10235] ${JSON.stringify({
+        topology: args.topology,
+        sharedControlGenerationBeforeFault,
+        sharedControlGenerationAfterFault,
+        ...evidence
+      })}`
+    )
   } finally {
     await client.dispose()
     await relay.close()

--- a/tests/e2e/pr10235-stale-subscription-restart.spec.ts
+++ b/tests/e2e/pr10235-stale-subscription-restart.spec.ts
@@ -25,6 +25,9 @@ function createGitRepo(): string {
       'user.name=Orca E2E',
       '-c',
       'user.email=orca-e2e@example.invalid',
+      // Why: ambient commit.gpgsign=true would fail the seed commit opaquely.
+      '-c',
+      'commit.gpgsign=false',
       'commit',
       '-m',
       'seed'
@@ -143,11 +146,12 @@ async function runStaleSubscriptionOracle(args: {
         { timeout: 30_000 }
       )
       .toBeGreaterThan(0)
-    await expect
-      .poll(() => readWorktreeSurface(client.page, addedRepoPath, client.environmentId), {
-        timeout: 2_000
-      })
-      .toEqual({ rendered: false, worktreeId: null })
+    // Why: a single immediate read — polling "stays stale" would fail a client
+    // that legitimately self-heals faster than the poll window.
+    expect(await readWorktreeSurface(client.page, addedRepoPath, client.environmentId)).toEqual({
+      rendered: false,
+      worktreeId: null
+    })
 
     try {
       await expect

--- a/tests/e2e/pr10235-stale-subscription-restart.spec.ts
+++ b/tests/e2e/pr10235-stale-subscription-restart.spec.ts
@@ -1,0 +1,221 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { RuntimeClient } from '../../src/cli/runtime/client'
+import { decodePairingOffer, encodePairingOffer } from '../../src/shared/pairing'
+import { expect, test } from './helpers/orca-app'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import {
+  launchPairedElectronClient,
+  type RuntimeDesktopPairingOffer
+} from './helpers/paired-electron-client'
+import { createZombieRuntimeRelay } from './helpers/zombie-runtime-relay'
+
+function createGitRepo(): string {
+  const repoPath = mkdtempSync(path.join(os.tmpdir(), 'orca-pr10235-repo-'))
+  execFileSync('git', ['init'], { cwd: repoPath, stdio: 'ignore' })
+  writeFileSync(path.join(repoPath, 'README.md'), '# PR 10235 relay oracle\n')
+  execFileSync('git', ['add', 'README.md'], { cwd: repoPath, stdio: 'ignore' })
+  execFileSync(
+    'git',
+    [
+      '-c',
+      'user.name=Orca E2E',
+      '-c',
+      'user.email=orca-e2e@example.invalid',
+      'commit',
+      '-m',
+      'seed'
+    ],
+    { cwd: repoPath, stdio: 'ignore' }
+  )
+  return repoPath
+}
+
+function withRelayEndpoint(
+  offer: RuntimeDesktopPairingOffer,
+  endpoint: string
+): RuntimeDesktopPairingOffer {
+  return {
+    pairingUrl: encodePairingOffer({ ...decodePairingOffer(offer.pairingUrl), endpoint })
+  }
+}
+
+async function readWorktreeSurface(
+  page: Page,
+  repoPath: string,
+  environmentId: string
+): Promise<{ rendered: boolean; worktreeId: string | null }> {
+  return page.evaluate(
+    ({ environmentId, repoName, repoPath }) => {
+      const worktree = window.__store
+        ?.getState()
+        .allWorktrees()
+        .find(
+          (candidate) =>
+            candidate.hostId === `runtime:${environmentId}` &&
+            (candidate.id.endsWith(`::${repoPath}`) ||
+              candidate.id.split(/[\\/]/).at(-1) === repoName)
+        )
+      const worktreeId = worktree?.id ?? null
+      const rendered = Array.from(document.querySelectorAll('[data-worktree-id]')).some(
+        (element) => element.getAttribute('data-worktree-id') === worktreeId
+      )
+      return { rendered, worktreeId }
+    },
+    { environmentId, repoName: path.basename(repoPath), repoPath }
+  )
+}
+
+async function runStaleSubscriptionOracle(args: {
+  host: RuntimeClient
+  initialRepoPath: string
+  offer: RuntimeDesktopPairingOffer
+  testInfo: TestInfo
+  topology: 'headed' | 'headless'
+}): Promise<void> {
+  const targetOffer = decodePairingOffer(args.offer.pairingUrl)
+  const relay = await createZombieRuntimeRelay(targetOffer.endpoint)
+  const client = await launchPairedElectronClient(
+    withRelayEndpoint(args.offer, relay.endpoint),
+    args.testInfo,
+    `PR 10235 ${args.topology}`
+  ).catch(async (error) => {
+    await relay.close()
+    throw error
+  })
+  const addedRepoPath = createGitRepo()
+
+  try {
+    await client.page.evaluate(async (environmentId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Paired desktop store is unavailable')
+      }
+      await store.getState().fetchRepos({ runtimeEnvironmentId: environmentId })
+    }, client.environmentId)
+    await expect
+      .poll(() => readWorktreeSurface(client.page, args.initialRepoPath, client.environmentId), {
+        timeout: 30_000
+      })
+      .toMatchObject({ rendered: true, worktreeId: expect.any(String) })
+    await expect
+      .poll(() => relay.evidence().activeConnectionCount, { timeout: 10_000 })
+      .toBeGreaterThan(0)
+
+    await relay.zombifyActiveSessions()
+    const added = await args.host.call<{ repo: { id: string } }>('repo.add', {
+      path: addedRepoPath,
+      kind: 'git'
+    })
+    await args.host.call('repo.update', {
+      repo: added.result.repo.id,
+      updates: { externalWorktreeVisibility: 'show' }
+    })
+    await expect
+      .poll(
+        async () => {
+          const result = await args.host.call<{ totalCount: number }>('worktree.list', {
+            repo: `id:${added.result.repo.id}`
+          })
+          return result.result.totalCount
+        },
+        { timeout: 30_000 }
+      )
+      .toBeGreaterThan(0)
+    await expect
+      .poll(() => readWorktreeSurface(client.page, addedRepoPath, client.environmentId), {
+        timeout: 2_000
+      })
+      .toEqual({ rendered: false, worktreeId: null })
+
+    try {
+      await expect
+        .poll(() => readWorktreeSurface(client.page, addedRepoPath, client.environmentId), {
+          timeout: 40_000
+        })
+        .toMatchObject({ rendered: true, worktreeId: expect.any(String) })
+    } catch (error) {
+      const staleEvidence = relay.evidence()
+      await client.page.screenshot({
+        path: args.testInfo.outputPath(`${args.topology}-stale-before-reload.png`),
+        fullPage: true
+      })
+      throw new Error(
+        `${args.topology} subscription stayed stale behind a control-responsive relay: ${JSON.stringify(staleEvidence)}`,
+        { cause: error }
+      )
+    }
+
+    const evidence = relay.evidence()
+    expect(evidence.connectionCount).toBeGreaterThan(evidence.zombifiedConnectionCount)
+    await client.page.screenshot({
+      path: args.testInfo.outputPath(`${args.topology}-self-healed.png`),
+      fullPage: true
+    })
+    console.info(`[pr10235] ${JSON.stringify({ topology: args.topology, ...evidence })}`)
+  } finally {
+    await client.dispose()
+    await relay.close()
+    rmSync(addedRepoPath, { recursive: true, force: true })
+  }
+}
+
+test('self-heals a headed server worktree subscription behind a zombie relay @headful', async ({
+  electronApp,
+  orcaPage,
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(150_000)
+  expect(
+    await electronApp.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().some((window) => window.isVisible())
+    )
+  ).toBe(true)
+  const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+  const offer = await orcaPage.evaluate(async () => {
+    const result = await window.api.mobile.getRuntimePairingUrl({
+      address: '127.0.0.1',
+      rotate: true
+    })
+    if (!result.available || !result.pairingUrl) {
+      throw new Error('Headed runtime did not publish a pairing offer')
+    }
+    return { pairingUrl: result.pairingUrl }
+  })
+  await runStaleSubscriptionOracle({
+    host: new RuntimeClient(userDataDir),
+    initialRepoPath: testRepoPath,
+    offer,
+    testInfo,
+    topology: 'headed'
+  })
+})
+
+test('self-heals a headless serve worktree subscription behind a zombie relay', async ({
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(150_000)
+  const host = await launchHeadlessPairedRuntimeHost()
+  try {
+    const added = await host.client.call<{ repo: { id: string } }>('repo.add', {
+      path: testRepoPath,
+      kind: 'git'
+    })
+    await host.client.call('repo.update', {
+      repo: added.result.repo.id,
+      updates: { externalWorktreeVisibility: 'show' }
+    })
+    await runStaleSubscriptionOracle({
+      host: host.client,
+      initialRepoPath: testRepoPath,
+      offer: host.offer,
+      testInfo,
+      topology: 'headless'
+    })
+  } finally {
+    await host.dispose()
+  }
+})

--- a/tests/e2e/pr10235-stale-subscription-restart.spec.ts
+++ b/tests/e2e/pr10235-stale-subscription-restart.spec.ts
@@ -105,6 +105,7 @@ async function runStaleSubscriptionOracle(args: {
       .poll(() => relay.evidence().activeConnectionCount, { timeout: 10_000 })
       .toBeGreaterThan(0)
 
+    const connectionCountBeforeFault = relay.evidence().connectionCount
     await relay.zombifyActiveSessions()
     const added = await args.host.call<{ repo: { id: string } }>('repo.add', {
       path: addedRepoPath,
@@ -150,7 +151,8 @@ async function runStaleSubscriptionOracle(args: {
     }
 
     const evidence = relay.evidence()
-    expect(evidence.connectionCount).toBeGreaterThan(evidence.zombifiedConnectionCount)
+    expect(evidence.controlPingCount).toBeGreaterThan(0)
+    expect(evidence.connectionCount).toBeGreaterThan(connectionCountBeforeFault)
     await client.page.screenshot({
       path: args.testInfo.outputPath(`${args.topology}-self-healed.png`),
       fullPage: true
@@ -195,13 +197,17 @@ test('self-heals a headed server worktree subscription behind a zombie relay @he
 })
 
 test('self-heals a headless serve worktree subscription behind a zombie relay', async ({
-  testRepoPath
+  testRepoPath: _testRepoPath
 }, testInfo) => {
   test.setTimeout(150_000)
-  const host = await launchHeadlessPairedRuntimeHost()
+  const initialRepoPath = createGitRepo()
+  const host = await launchHeadlessPairedRuntimeHost().catch((error) => {
+    rmSync(initialRepoPath, { recursive: true, force: true })
+    throw error
+  })
   try {
     const added = await host.client.call<{ repo: { id: string } }>('repo.add', {
-      path: testRepoPath,
+      path: initialRepoPath,
       kind: 'git'
     })
     await host.client.call('repo.update', {
@@ -210,12 +216,13 @@ test('self-heals a headless serve worktree subscription behind a zombie relay', 
     })
     await runStaleSubscriptionOracle({
       host: host.client,
-      initialRepoPath: testRepoPath,
+      initialRepoPath,
       offer: host.offer,
       testInfo,
       topology: 'headless'
     })
   } finally {
     await host.dispose()
+    rmSync(initialRepoPath, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary

Fixes stale subscriptions after `orca serve` restarts behind a WS-terminating relay. The socket-level liveness monitor pings at the RFC 6455 control-frame layer, but such a relay answers those pings itself — so when the server process restarts, the client's E2EE session and the server's in-memory subscription registry are gone while the socket still looks alive, and worktrees created after the restart never reach the sidebar until an app reload. This PR adds an encrypted session probe (`status.get` every 15s while subscriptions are active): only the server holding this connection's session keys can answer, so a failed probe proves the session is dead and force-closes into the existing close → reconnect → subscription-replay machinery. Responsive connections stay on their socket; probing stops when no subscriptions are active.

Split out of #9614, which bundled this with the unrelated app-version-skew feature; #9614 will be rebased down once the split PRs land.

**Tests:** new cases in `remote-runtime-shared-control-connection.test.ts`, including a zombie-relay repro (server records requests but never answers while ws pings keep succeeding → probe forces reconnect and the subscription is re-established on a fresh connection), plus no-reconnect-while-probes-succeed and no-probes-without-subscriptions. `pnpm typecheck` and the test file green locally.

**Review starting point:** the header comment in `src/shared/remote-runtime-shared-control-session-probe.ts`.

cc @OrcaWin

## ELI5

After orca serve restarts behind a relay that answers WebSocket pings, the client still looked connected but missed new worktrees. An encrypted session probe self-heals stale subscriptions without a full app reload.
