### PR TITLE
fix(worktree): stop terminal removal fence error flashing on delete

### DIFF
--- a/src/main/ipc/watcher-removal-gate.test.ts
+++ b/src/main/ipc/watcher-removal-gate.test.ts
@@ -6,6 +6,7 @@ import {
   TerminalRemovalInProgressError,
   WatcherRemovalInProgressError
 } from './watcher-removal-gate'
+import { isWorktreeRemovalFenceError } from '../../shared/worktree-removal-fence-error'
 
 describe('watcher removal gate', () => {
   it('waits for an existing install and rejects later equivalent-path installs', async () => {
@@ -104,6 +105,36 @@ describe('watcher removal gate', () => {
 
     const finishInstall = beginWatcherInstall('/srv/team/repo')
     finishInstall()
+    removal.release()
+  })
+
+  // Why: the renderer swallows this fence via isWorktreeRemovalFenceError so a
+  // doomed pane never shows the raw error. That only holds if the thrown message
+  // still matches the shared predicate — pin the cross-module contract here.
+  it('throws fence errors the renderer recognizes as benign removal fences', async () => {
+    const removal = acquireWatcherRemovalGate('/repo')
+    await removal.ready
+
+    const terminalError = (() => {
+      try {
+        beginTerminalInstall('/repo')
+      } catch (error) {
+        return error as Error
+      }
+      throw new Error('expected terminal install to be fenced')
+    })()
+    const watcherError = (() => {
+      try {
+        beginWatcherInstall('/repo')
+      } catch (error) {
+        return error as Error
+      }
+      throw new Error('expected watcher install to be fenced')
+    })()
+
+    expect(isWorktreeRemovalFenceError(terminalError.message)).toBe(true)
+    expect(isWorktreeRemovalFenceError(watcherError.message)).toBe(true)
+
     removal.release()
   })
 })

--- a/src/main/ipc/watcher-removal-gate.ts
+++ b/src/main/ipc/watcher-removal-gate.ts
@@ -2,6 +2,10 @@ import {
   isPathInsideOrEqual,
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
+import {
+  TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE,
+  WATCHER_REMOVAL_IN_PROGRESS_MESSAGE
+} from '../../shared/worktree-removal-fence-error'
 
 type WatcherRemovalGateState = {
   connectionId: string | null
@@ -20,7 +24,7 @@ export class WatcherRemovalInProgressError extends Error {
   readonly code = 'watcher_removal_in_progress'
 
   constructor() {
-    super('File watcher cannot start while the worktree is being removed')
+    super(WATCHER_REMOVAL_IN_PROGRESS_MESSAGE)
     this.name = 'WatcherRemovalInProgressError'
   }
 }
@@ -29,7 +33,7 @@ export class TerminalRemovalInProgressError extends Error {
   readonly code = 'terminal_removal_in_progress'
 
   constructor() {
-    super('Terminal cannot start while the worktree is being removed')
+    super(TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE)
     this.name = 'TerminalRemovalInProgressError'
   }
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -121,6 +121,7 @@ type StoreState = {
   ptyIdsByTabId?: Record<string, string[]>
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
   unreadTerminalTabs?: Record<string, true>
+  deleteStateByWorktreeId?: Record<string, { isDeleting?: boolean; phase?: string }>
   worktreesByRepo: Record<
     string,
     {
@@ -783,6 +784,7 @@ describe('connectPanePty', () => {
         }
       },
       unreadTerminalTabs: {},
+      deleteStateByWorktreeId: {},
       worktreesByRepo: {
         repo1: [{ id: 'wt-1', repoId: 'repo1', path: '/tmp/wt-1', displayName: 'feat/notis' }]
       },
@@ -1022,6 +1024,86 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(staleTracker.flags).toBe(0)
+  })
+
+  // Why: deleting a worktree kills its PTYs for the filesystem teardown; the
+  // renderer must not race a doomed respawn into a directory main is deleting
+  // (main fences it with TerminalRemovalInProgressError and the pane is about to
+  // unmount). See docs — bad UI was the raw fence error flashing on the tab.
+  it('skips a fresh spawn while the pane worktree is being deleted', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: { 'wt-1': { isDeleting: true, phase: 'deleting' } }
+    }
+    // Why: a unique tab id keeps this pane's key clear of other tests' pendingSpawnByPaneKey entries so the connect deterministically fresh-spawns.
+    const deps = createDeps({ tabId: 'tab-removal-skip-spawn' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+  })
+
+  it('fresh-spawns normally when the pane worktree is not being deleted', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    // Why: unique tab id → deterministic fresh spawn (mirrors the skip test's control).
+    const deps = createDeps({ tabId: 'tab-removal-control-spawn' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalled()
+  })
+
+  // Why: a doomed pane (or a child pane whose parent worktree is being removed,
+  // which startFreshSpawn's own-worktree skip cannot see) can still race a spawn
+  // that main fences. reportError must swallow that fence so the tab never flashes
+  // the raw "Terminal cannot start while the worktree is being removed" banner.
+  it('swallows a worktree-removal fence error instead of surfacing it', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE } =
+      await import('../../../../shared/worktree-removal-fence-error')
+    const transport = createMockTransport()
+    const capturedOnError: { current: ((message: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedOnError.current = callbacks.onError ?? null
+      return 'pty-1'
+    })
+    transportFactoryQueue.push(transport)
+    const deps = createDeps({ tabId: 'tab-fence-swallow' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    // Electron wraps the rejected ipcMain error with its own prefix; still swallowed.
+    capturedOnError.current?.(
+      `Error invoking remote method 'pty:spawn': Error: ${TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE}`
+    )
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+  })
+
+  it('still surfaces non-fence spawn errors through the pane error sink', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    const capturedOnError: { current: ((message: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedOnError.current = callbacks.onError ?? null
+      return 'pty-1'
+    })
+    transportFactoryQueue.push(transport)
+    const deps = createDeps({ tabId: 'tab-real-error-surface' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    capturedOnError.current?.('shell exited with code 1')
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(1, 'shell exited with code 1')
   })
 
   it('threads the resolved local project runtime into IPC terminal transport options', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -1081,8 +1081,12 @@ describe('connectPanePty', () => {
     connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
     await flushAsyncTicks()
 
+    // Why: assert the callback was captured before invoking — optional invocation
+    // would let this test false-pass (not.toHaveBeenCalled trivially true) if the
+    // transport onError wiring ever broke, exercising no suppression at all.
+    expect(capturedOnError.current).toBeTypeOf('function')
     // Electron wraps the rejected ipcMain error with its own prefix; still swallowed.
-    capturedOnError.current?.(
+    capturedOnError.current!(
       `Error invoking remote method 'pty:spawn': Error: ${TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE}`
     )
     expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
@@ -1102,7 +1106,8 @@ describe('connectPanePty', () => {
     connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
     await flushAsyncTicks()
 
-    capturedOnError.current?.('shell exited with code 1')
+    expect(capturedOnError.current).toBeTypeOf('function')
+    capturedOnError.current!('shell exited with code 1')
     expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(1, 'shell exited with code 1')
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -13,6 +13,7 @@ import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
+import { isWorktreeRemovalFenceError } from '../../../../shared/worktree-removal-fence-error'
 import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
 import {
   HIDDEN_STARTUP_RENDERER_QUERY_PENDING_CHARS,
@@ -4203,6 +4204,14 @@ export function connectPanePty(
       if (disposed) {
         return
       }
+      if (isWorktreeRemovalFenceError(message)) {
+        // Why: main fences a spawn/reattach whose worktree (or an overlapping
+        // parent/child root) is being deleted. That is expected teardown, not a
+        // user-facing failure — the pane unmounts once removal completes, so never
+        // surface the raw fence error. Covers the parent-removal-fences-child case
+        // that startFreshSpawn's own-worktree isDeleting skip cannot see.
+        return
+      }
       deps.onPtyErrorRef?.current?.(pane.id, message)
     }
 
@@ -4740,6 +4749,13 @@ export function connectPanePty(
       startupOverride?: PendingStartupCommand | null,
       options: FreshSpawnOptions = {}
     ): Promise<string | null> => {
+      if (useAppStore.getState().deleteStateByWorktreeId?.[deps.worktreeId]?.isDeleting) {
+        // Why: the worktree is being deleted; its PTYs were just killed for the
+        // filesystem teardown. A fresh shell must not spawn into a directory the
+        // removal is about to delete (main fences it anyway), and the pane is
+        // about to unmount — so skip the doomed respawn instead of racing it.
+        return Promise.resolve(null)
+      }
       clearPaneMode2031State()
       clearHiddenOutputRestoreState()
       // Why: a canceled old replay clear can preserve xterm's native

--- a/src/shared/worktree-removal-fence-error.test.ts
+++ b/src/shared/worktree-removal-fence-error.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import {
+  TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE,
+  WATCHER_REMOVAL_IN_PROGRESS_MESSAGE,
+  isWorktreeRemovalFenceError
+} from './worktree-removal-fence-error'
+
+describe('isWorktreeRemovalFenceError', () => {
+  it('recognizes the raw terminal and watcher fence messages', () => {
+    expect(isWorktreeRemovalFenceError(TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE)).toBe(true)
+    expect(isWorktreeRemovalFenceError(WATCHER_REMOVAL_IN_PROGRESS_MESSAGE)).toBe(true)
+  })
+
+  it('recognizes the message after Electron IPC prefixes the reject', () => {
+    // Electron wraps a rejected ipcMain.handle error with its own prefix.
+    const wrapped = `Error invoking remote method 'pty:spawn': Error: ${TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE}`
+    expect(isWorktreeRemovalFenceError(wrapped)).toBe(true)
+  })
+
+  it('does not match unrelated terminal errors', () => {
+    expect(isWorktreeRemovalFenceError('Failed to save terminal session state')).toBe(false)
+    expect(isWorktreeRemovalFenceError('shell exited with code 1')).toBe(false)
+    expect(isWorktreeRemovalFenceError('')).toBe(false)
+  })
+})

--- a/src/shared/worktree-removal-fence-error.ts
+++ b/src/shared/worktree-removal-fence-error.ts
@@ -1,0 +1,18 @@
+// Shared between main (which throws these at the PTY/watcher install fence while
+// a worktree is being removed) and the renderer (which recognizes them so a
+// doomed pane never surfaces the fence as a user-facing terminal error).
+
+export const TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE =
+  'Terminal cannot start while the worktree is being removed'
+
+export const WATCHER_REMOVAL_IN_PROGRESS_MESSAGE =
+  'File watcher cannot start while the worktree is being removed'
+
+// Why: both fence messages end with this tail. Matching the tail catches the
+// terminal and watcher variants even after Electron IPC prefixes the rejected
+// error with its own "Error invoking remote method ..." text.
+const REMOVAL_IN_PROGRESS_FENCE_TAIL = 'cannot start while the worktree is being removed'
+
+export function isWorktreeRemovalFenceError(message: string): boolean {
+  return message.includes(REMOVAL_IN_PROGRESS_FENCE_TAIL)
+}


### PR DESCRIPTION
## Problem

Deleting a worktree sometimes flashes a scary error on a terminal tab that lived in it:

> `TerminalRemovalInProgressError: Terminal cannot start while the worktree is being removed`

It clears once the worktree fully deletes (~1s later), but it's bad UI.

## Root cause

When a worktree is deleted, main takes the removal fence (`acquireWatcherRemovalGate`) and kills the worktree's PTYs for the filesystem teardown, then runs `git worktree remove` (~1s). During that window the doomed pane races a **fresh respawn**, which main *correctly* fences with `TerminalRemovalInProgressError` (a shell must not spawn into a directory being deleted). The bug is purely renderer-side: `reportError` surfaced that internal fence verbatim as a pane error banner (`TerminalPane` → `setTerminalError`), which only disappeared when the worktree unmounted.

## Fix (renderer-side, no IPC changes)

- **Stop the doomed respawn** — `startFreshSpawn` skips when the pane's own worktree has `deleteStateByWorktreeId[worktreeId].isDeleting` (a signal the renderer already sets at removal start). No shell should spawn into a directory being removed, and the pane is about to unmount.
- **Swallow the fence at the sink** — `reportError` (the single choke point for every pane-error path: connect/reattach/attach/SSH) drops the removal fence instead of surfacing it. This also covers the parent-removal-fences-child case that the own-worktree skip can't see.
- **Shared contract** — the fence messages now live in one module (`src/shared/worktree-removal-fence-error.ts`); main's error classes throw them and the renderer's `isWorktreeRemovalFenceError` predicate matches them (robust to Electron's IPC error prefix), so the thrown text and the predicate can't drift.

## Verification

**Unit (deterministic):** new tests prove — the real gate throws a message the predicate recognizes (main↔renderer contract), `reportError` swallows the fence (raw + IPC-wrapped) while non-fence errors still surface, and `startFreshSpawn` skips during `isDeleting` while normal spawns are unaffected. All affected suites green.

**Live app (Electron via CDP):** created a worktree with a live PTY and deleted it under a DOM+console watcher for the fence text — clean, then 5 rapid create→activate→delete stress cycles. `isDeleting` was observed active during every deletion (the guard is genuinely in the removal window), all deletions completed, and **zero fence hits** (DOM, console, or error events) across all runs.

`tsc` (node + web) and `oxlint` clean on all changed files.

## Notes / scope

- The original banner is timing-dependent ("sometimes"), so the live cycles can't guarantee the exact race fired — but the unit tests deterministically exercise the fence-and-swallow path.
- SSH/remote worktrees are covered: the fence flows through the same `reportError` sink and `isDeleting` is set identically for remote removals.
