### PR TITLE
fix(linear): accept numeric-leading issue identifiers

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -83,6 +83,7 @@ import {
 } from '../../../../shared/task-source-context'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import { githubRepoIdentityKey } from '../../../../shared/github-repository-identity-key'
+import { isLinearIssueIdentifier } from '../../../../shared/linear-links'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import {
   getGitHubRuntimeRepoId,
@@ -1092,7 +1093,7 @@ export default function SmartWorkspaceNameField({
     if (parseGitLabIssueOrMRLink(trimmed) !== null) {
       return 'gitlab'
     }
-    if (linearAvailable && /^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(trimmed)) {
+    if (linearAvailable && isLinearIssueIdentifier(trimmed)) {
       return 'linear'
     }
     return null

--- a/src/shared/linear-links.test.ts
+++ b/src/shared/linear-links.test.ts
@@ -5,6 +5,7 @@ import {
   buildLinearTeamUrl,
   buildLinearWorkspaceApiSettingsUrl,
   getLinearOrganizationUrlKeyFromIssueUrl,
+  isLinearIssueIdentifier,
   parseLinearIssueInput
 } from './linear-links'
 
@@ -46,6 +47,24 @@ describe('linear links', () => {
   it('parses bare Linear issue identifiers', () => {
     expect(parseLinearIssueInput('eng-123')).toEqual({ identifier: 'ENG-123' })
     expect(parseLinearIssueInput('2eng-123')).toEqual({ identifier: '2ENG-123' })
+    expect(parseLinearIssueInput('1pass-42')).toEqual({ identifier: '1PASS-42' })
+    expect(parseLinearIssueInput('3d-15')).toEqual({ identifier: '3D-15' })
+  })
+
+  it('rejects all-numeric team keys that look like dates, phone numbers, or ranges', () => {
+    for (const input of [
+      '2026-07',
+      '555-1234',
+      '8080-8090',
+      '123-456',
+      '1-1',
+      '007-42',
+      '1_2-3',
+      '1-800'
+    ]) {
+      expect(parseLinearIssueInput(input)).toBeNull()
+    }
+    expect(parseLinearIssueInput('https://linear.app/acme/issue/2026-07/notes')).toBeNull()
   })
 
   it('parses Linear issue URLs with organization URL keys', () => {
@@ -61,6 +80,13 @@ describe('linear links', () => {
       identifier: 'STA-335',
       organizationUrlKey: 'stably'
     })
+  })
+
+  it('recognizes bare identifiers without parsing them', () => {
+    expect(isLinearIssueIdentifier('  eng-123  ')).toBe(true)
+    expect(isLinearIssueIdentifier('2ENG-1')).toBe(true)
+    expect(isLinearIssueIdentifier('2026-07')).toBe(false)
+    expect(isLinearIssueIdentifier('https://linear.app/acme/issue/ENG-1')).toBe(false)
   })
 
   it('rejects non-Linear issue input', () => {

--- a/src/shared/linear-links.test.ts
+++ b/src/shared/linear-links.test.ts
@@ -45,11 +45,16 @@ describe('linear links', () => {
 
   it('parses bare Linear issue identifiers', () => {
     expect(parseLinearIssueInput('eng-123')).toEqual({ identifier: 'ENG-123' })
+    expect(parseLinearIssueInput('2eng-123')).toEqual({ identifier: '2ENG-123' })
   })
 
   it('parses Linear issue URLs with organization URL keys', () => {
     expect(parseLinearIssueInput('https://linear.app/acme/issue/eng-123/fix-auth')).toEqual({
       identifier: 'ENG-123',
+      organizationUrlKey: 'acme'
+    })
+    expect(parseLinearIssueInput('https://linear.app/acme/issue/2eng-123/fix-auth')).toEqual({
+      identifier: '2ENG-123',
       organizationUrlKey: 'acme'
     })
     expect(parseLinearIssueInput('https://linear.app/stably/issue/STA-335/test-issue')).toEqual({

--- a/src/shared/linear-links.ts
+++ b/src/shared/linear-links.ts
@@ -44,7 +44,14 @@ export type ParsedLinearIssueInput = {
   organizationUrlKey?: string
 }
 
-const LINEAR_IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_]*-\d+$/
+// Team keys may start with a digit (`2ENG-1`), but requiring at least one letter
+// keeps dates, phone numbers, and port ranges (`2026-07`, `555-1234`, `8080-8090`)
+// from being read as issue identifiers.
+const LINEAR_IDENTIFIER_PATTERN = /^(?=[A-Za-z0-9_]*[A-Za-z])[A-Za-z0-9][A-Za-z0-9_]*-\d+$/
+
+export function isLinearIssueIdentifier(value: string): boolean {
+  return LINEAR_IDENTIFIER_PATTERN.test(value.trim())
+}
 
 export function parseLinearIssueInput(input: string): ParsedLinearIssueInput | null {
   const trimmed = input.trim()

--- a/src/shared/linear-links.ts
+++ b/src/shared/linear-links.ts
@@ -44,7 +44,7 @@ export type ParsedLinearIssueInput = {
   organizationUrlKey?: string
 }
 
-const LINEAR_IDENTIFIER_PATTERN = /^[A-Za-z][A-Za-z0-9_]*-\d+$/
+const LINEAR_IDENTIFIER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_]*-\d+$/
 
 export function parseLinearIssueInput(input: string): ParsedLinearIssueInput | null {
   const trimmed = input.trim()


### PR DESCRIPTION
## Summary

Linear team keys may begin with a digit (`2ENG-123`, `1PASS-42`), but the identifier pattern required a leading letter, so Orca rejected those issues everywhere an identifier is accepted — the `orca linear` CLI, the `--linear-issue` worktree flag, and the new-workspace source picker. The root cause is `LINEAR_IDENTIFIER_PATTERN` in `src/shared/linear-links.ts` anchoring on `[A-Za-z]`.

Relaxing the first character alone is not enough: it makes the pattern accept *all-numeric* keys, so ordinary text like `2026-07`, `555-1234`, and `8080-8090` starts parsing as a Linear issue. This PR requires at least one letter somewhere in the team key, and routes the duplicate copy of the pattern in `SmartWorkspaceNameField.tsx` through the shared check so both agree.

## ELI5

Linear issue names look like `ENG-123` — a short team code, a dash, and a number. Orca assumed the team code always starts with a letter, so teams whose code starts with a digit couldn't paste their issue names in. The obvious fix — "allow a number first" — accidentally makes plain numbers like `2026-07` (a date) or `555-1234` (a phone number) look like issue names too. So we allow a digit first but still insist the code contains at least one letter, which lets the real issue names through and keeps dates and phone numbers out.

## Proof of fix

Test file: `src/shared/linear-links.test.ts`.

**On `origin/main` (leading letter required) — 3 failures:**

```
 FAIL  src/shared/linear-links.test.ts > linear links > parses bare Linear issue identifiers
AssertionError: expected null to deeply equal { identifier: '2ENG-123' }

 FAIL  src/shared/linear-links.test.ts > linear links > parses Linear issue URLs with organization URL keys
AssertionError: expected null to deeply equal { identifier: '2ENG-123', …(1) }
- Expected:
{
  "identifier": "2ENG-123",
  "organizationUrlKey": "acme",
}
+ Received:
null

 FAIL  src/shared/linear-links.test.ts > linear links > recognizes bare identifiers without parsing them
TypeError: isLinearIssueIdentifier is not a function

 Test Files  1 failed (1)
      Tests  3 failed | 7 passed (10)
```

**With only the first character relaxed to `[A-Za-z0-9]` — the false-positive test fails:**

```
 FAIL  src/shared/linear-links.test.ts > linear links > rejects all-numeric team keys that look like dates, phone numbers, or ranges
 ❯ src/shared/linear-links.test.ts:65:44
     65|       expect(parseLinearIssueInput(input)).toBeNull()

 Test Files  1 failed (1)
      Tests  2 failed | 8 passed (10)
```

**With this fix:**

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

Behavior change enumerated against the previous pattern — every string below is newly accepted or newly kept out:

| input | before this PR | first-char-only relax | this PR |
| --- | --- | --- | --- |
| `ENG-123`, `A1-7`, `MAN8-456`, `A_B-3` | accept | accept | accept |
| `2ENG-123`, `1PASS-42`, `3D-15` | reject | accept | **accept** |
| `2026-07`, `555-1234`, `8080-8090`, `123-456`, `1-1`, `007-42`, `1_2-3`, `1-800` | reject | accept | **reject** |
| `2026-07-26`, `v1.2-3`, `1.2.3`, `12-34-56` | reject | reject | reject |

`GH-123`, `ISO-8601`, `UTF-8`, `RFC-2119`, `SHA-256`, and `CVE-2026` all matched before this PR and still do — unchanged, and harmless because the pattern is anchored (`^…$`) and only ever applied to a full explicit user-supplied string, never scanned across terminal or commit text.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/shared/linear-links.test.ts \
    src/renderer/src/components/new-workspace/ src/main/linear/ src/shared/new-workspace/
 Test Files  32 passed (32)
      Tests  189 passed (189)

$ npx tsc --noEmit -p config/tsconfig.node.json      # exit 0
$ npx tsc --noEmit -p config/tsconfig.tc.web.json    # exit 0
$ npx oxlint src/shared/linear-links.ts src/shared/linear-links.test.ts \
    src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx   # clean
```

Full `PR Checks / verify` on the rebased head: **pass** (17m34s) — https://github.com/stablyai/orca/actions/runs/30197731474

User-visible behavior that changes:

- Issue identifiers whose team key starts with a digit but contains a letter (`2ENG-123`) are now accepted by the `orca linear` CLI, `--linear-issue`, and the new-workspace source picker. This is the intended fix.
- The new-workspace picker now highlights the Linear row for those identifiers. Previously it had its own copy of the old pattern, so the original patch fixed the parser but left this surface still rejecting `2ENG-1`; both now share `isLinearIssueIdentifier`.

No other behavior changes: no identifier accepted before this PR is rejected now.

## Compatibility

- **Platforms:** macOS / Linux / Windows — a pure TypeScript regex and `URL` parsing in `src/shared`. No paths, shell, key modifiers, native APIs, or Electron surfaces touched. Verified via typecheck + tests on macOS; the code has no platform branches to diverge.
- **SSH / remote:** N/A. `parseLinearIssueInput` is pure string parsing with no filesystem or process access, and runs identically on native, WSL, SSH, and relay hosts. Folder workspaces and git worktrees are unaffected — no Git command is involved.
- **Performance:** No hot-path change. The pattern is anchored and runs once per explicit user input (a CLI flag, a typed query, a stored link), never per terminal line or per render. The added lookahead is bounded by the same character class as the existing star, so matching stays linear; measured at 200k-character adversarial inputs (`'9'*n`, `'_'*n`, `'9'*n + '-' + '9'*n + 'X'`) it stays under 4 ms/op with no super-linear growth, in line with the pre-existing pattern.

## Screenshots

No visual change. The only UI-adjacent effect is that the new-workspace source picker now highlights the Linear row for digit-leading identifiers such as `2ENG-123`, which previously did not match — behavior described under **Proof of no regressions**.

## Testing

- [ ] `pnpm lint` — not run in full. Ran `npx oxlint` on all three changed files: clean.
- [x] `pnpm typecheck` — `npx tsc --noEmit` against both `config/tsconfig.node.json` and `config/tsconfig.tc.web.json`, exit 0.
- [ ] `pnpm test` — not run in full (30+ min). Ran every suite covering the touched surface: `src/shared/linear-links.test.ts`, `src/renderer/src/components/new-workspace/`, `src/main/linear/`, `src/shared/new-workspace/` → 32 files, 189 tests passed.
- [ ] `pnpm build` — not run locally, but **`PR Checks / verify` passes on the rebased head** (17m34s): https://github.com/stablyai/orca/actions/runs/30197731474
- [x] Added or updated high-quality tests that would catch regressions — including a dedicated false-positive test asserting all-numeric keys (dates, phone numbers, port ranges) stay rejected. That test fails under the naive "just allow a leading digit" fix, which is the whole point.

## AI Review Report

Reviewed with Claude Code (Opus 5) and re-verified adversarially against a false-positive corpus. Risks checked:

- **False positives (the dominant risk).** Loosening an identifier pattern silently turns ordinary text into dead links. Ran the *actual* exported parser — not a mental model of the regex — over an adversarial corpus: `2026-07`, `2026-07-26`, `555-1234`, `8080-8090`, `123-456`, `1-1`, `1-800`, `007-42`, `v1.2-3`, `1.2.3`, `12-34-56`. The naive first-char relaxation accepts five of these; this PR rejects all of them by requiring at least one letter in the team key. Full before/after matrix is in the description.
- **Pre-existing matches left alone.** `GH-123`, `ISO-8601`, `UTF-8`, `RFC-2119`, `SHA-256`, `CVE-2026` matched before this PR and still match. That is safe here because the pattern is anchored (`^…$`) and only applied to a complete, explicitly user-supplied string (a CLI flag, a typed query) — it is never scanned across terminal output or commit messages, so no ambient text can be linkified.
- **Duplicate pattern.** `SmartWorkspaceNameField.tsx` carried its own copy of the old regex. Without routing it through the shared `isLinearIssueIdentifier`, the parser would accept `2ENG-1` while the picker still rejected it — a split-brain the original patch would have shipped.
- **ReDoS.** Measured rather than assumed: 200k-character adversarial inputs (`'9'*n`, `'_'*n`, `'9'*n + '-' + '9'*n + 'X'`) stay under 4 ms/op with no super-linear growth. The added lookahead is bounded by the same character class as the existing star, so matching remains linear.
- **Cross-platform (macOS / Linux / Windows):** pure TypeScript regex + `URL` parsing in `src/shared`, with no platform branches, paths, shell invocation, key modifiers, or Electron APIs.

## Security Audit

- **Input handling:** this PR *is* an input-validation change. It widens an anchored pattern by exactly one axis (leading digit) while adding a constraint (must contain a letter) that narrows it against the newly-reachable all-numeric space. No unanchored scanning is introduced.
- **ReDoS:** explicitly measured on adversarial inputs (above) — linear, sub-4 ms at 200k chars.
- **Command execution:** none. The parsed identifier flows into a Linear API lookup and a worktree label, not into a shell.
- **Path handling:** none.
- **Auth / secrets:** none touched.
- **Dependencies:** none added or changed.
- **IPC:** unchanged.

## Notes

### Linear's team-key rules

Linear does not publish the validation regex for team keys. Confirmed from Linear's UI/API behavior and third-party integration docs that keys are alphanumeric, roughly 1–10 characters, and may contain digits. Sources conflict on whether a *leading* digit is permitted, and I could not find a public workspace using one. This PR therefore takes the permissive side of that ambiguity — a digit may lead — while assuming a key is never *entirely* numeric, which is what keeps dates and phone numbers out. If Linear ever allows a fully numeric key, that case would need an explicit opt-in rather than a looser pattern, since the ambiguity with dates is not resolvable from the string alone.

### Attribution

Original patch by @kenfdev.
