### PR TITLE
fix(terminal): keep SSH reconnect banner above the xterm canvas

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2896,16 +2896,23 @@ export default function TerminalPane({
           onRestartDaemon={() => daemonActions.setPending('restart')}
         />
       )}
-      {showSshReconnectOverlay && sshReconnectTargetId && sshReconnectStatus ? (
-        <TerminalSshReconnectOverlay
-          targetId={sshReconnectTargetId}
-          targetLabel={sshReconnectTargetLabel}
-          status={sshReconnectStatus}
-          targetRemoved={sshReconnectTargetRemoved}
-          worktreeId={worktreeId}
-          sshOwnerEnvironmentId={sshReconnectEnvironmentId}
-        />
-      ) : null}
+      {/* Why: portal into the pane so the banner stacks above the xterm canvas (sibling mount painted under WebGL). */}
+      {showSshReconnectOverlay && sshReconnectTargetId && sshReconnectStatus
+        ? managedPanes.map((pane) =>
+            createPortal(
+              <TerminalSshReconnectOverlay
+                targetId={sshReconnectTargetId}
+                targetLabel={sshReconnectTargetLabel}
+                status={sshReconnectStatus}
+                targetRemoved={sshReconnectTargetRemoved}
+                worktreeId={worktreeId}
+                sshOwnerEnvironmentId={sshReconnectEnvironmentId}
+              />,
+              pane.container,
+              `ssh-reconnect-${pane.id}`
+            )
+          )
+        : null}
       <DaemonActionDialog api={daemonActions} />
       {isActive && (
         <TerminalSessionStateSaveFailureDialog

--- a/src/renderer/src/components/terminal-pane/TerminalSshReconnectOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalSshReconnectOverlay.test.tsx
@@ -86,7 +86,7 @@ describe('TerminalSshReconnectOverlay', () => {
     expect(screen.getByText(/This terminal is waiting for devbox/)).toBeInTheDocument()
     expect(screen.getByRole('status')).toBeInTheDocument()
     const banner = container.querySelector('[data-terminal-ssh-reconnect-banner="disconnected"]')
-    expect(banner).toHaveClass('inset-x-3', 'bottom-3')
+    expect(banner).toHaveClass('inset-x-3', 'bottom-3', 'z-40')
     expect(banner).not.toHaveClass('inset-0', 'bg-background/75')
     await user.click(screen.getByRole('button', { name: 'Connect' }))
 

--- a/src/renderer/src/components/terminal-pane/TerminalSshReconnectOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalSshReconnectOverlay.tsx
@@ -136,13 +136,14 @@ export function TerminalSshReconnectOverlay({
     }
   }, [isConnecting, mountedRef, setSshConnectionState, sshOwnerEnvironmentId, targetId])
 
+  // Why: z-40 clears pane-local chrome (focus rim z-30); bg-card is fully opaque so terminal text cannot paint through.
   return (
     <div
-      className="pointer-events-none absolute inset-x-3 bottom-3 z-30 flex justify-center"
+      className="pointer-events-none absolute inset-x-3 bottom-3 z-40 flex justify-center"
       data-terminal-ssh-reconnect-banner={status}
     >
       <div
-        className="pointer-events-auto flex w-full max-w-xl items-center gap-3 rounded-md border border-border bg-card/95 px-3 py-3 text-card-foreground shadow-xs backdrop-blur-[1px]"
+        className="pointer-events-auto flex w-full max-w-xl items-center gap-3 rounded-md border border-border bg-card px-3 py-3 text-card-foreground shadow-xs"
         role="status"
         aria-live="polite"
       >


### PR DESCRIPTION
## Summary

- Portal the non-blocking SSH reconnect banner into each pane container so WebGL/xterm compositing cannot paint terminal text through it
- Raise the banner z-index above pane-local chrome (focus rim is z-30) and use a fully opaque card background
- Cover the stacking regression with a unit assertion on the banner z-index class

## Before / after

| Before (banner under terminal text) | After (banner on top) |
|---|---|
| ![before](https://github.com/stablyai/orca/blob/155af7821b18ef5aedf47e62efc67d981af912fe/before.png?raw=true) | ![after](https://github.com/stablyai/orca/blob/155af7821b18ef5aedf47e62efc67d981af912fe/after.png?raw=true) |

**After — full pane context**

![after context](https://github.com/stablyai/orca/blob/155af7821b18ef5aedf47e62efc67d981af912fe/after-context.png?raw=true)

## Reproduction and verification

**Before:** the banner was a `TerminalPane` sibling of the terminal host. With WebGL compositing, the canvas painted on top, so terminal output showed through the reconnect UI.

**After:** the banner is portaled into `.pane` (same pattern as `TerminalRemoteRuntimeReconnectBanner`), sits at the bottom of the full-height pane, and `elementFromPoint` hits the banner content.

Verified via `pn dev` + CDP on a disconnected `openclaw` SSH workspace:
- `parentIsPane: true`
- full pane height (1110px)
- `offsetBottom: 12` (`bottom-3`)
- `onTop: true`

## Tests

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/TerminalSshReconnectOverlay.test.tsx` (9/9)
- commit hooks: oxlint, React Doctor, oxfmt