### PR TITLE
fix(runtime): confirm cloned project path readiness before first cwd attach

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -6970,9 +6970,13 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('keeps project clone setup on the cloned host-qualified repo', async () => {
-    const destination = await mkdtemp(join(tmpdir(), 'orca-runtime-project-clone-'))
+    const parentRepo = await mkdtemp(join(tmpdir(), 'orca-runtime-project-parent-'))
+    execFileSync('git', ['init'], { cwd: parentRepo, stdio: 'ignore' })
+    const destination = join(parentRepo, 'clones')
     const clonePath = join(destination, 'orca')
     const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn')
+    const materializeChildRepo = makeDeferred()
+    let cloneClosed = false
     const repos: Record<string, unknown>[] = []
     getRepoUpstreamMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
     const runtimeStore = {
@@ -6998,22 +7002,49 @@ describe('OrcaRuntimeService', () => {
       const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
       proc.stderr = new EventEmitter()
       queueMicrotask(() => {
-        mkdirSync(clonePath, { recursive: true })
-        execFileSync('git', ['init'], { cwd: clonePath, stdio: 'ignore' })
+        cloneClosed = true
         proc.emit('close', 0, null)
+        void materializeChildRepo.promise.then(() => {
+          mkdirSync(clonePath, { recursive: true })
+          execFileSync('git', ['init'], { cwd: clonePath, stdio: 'ignore' })
+        })
       })
       return proc as never
     })
     const runtime = new OrcaRuntimeService(runtimeStore as never)
 
     try {
-      const result = await runtime.setupProjectClone({
-        projectId: 'github:stablyai/orca',
-        hostId: 'runtime:env-1',
-        url: 'https://example.com/orca.git',
-        destination
-      })
+      let settled = false
+      const resultPromise = runtime
+        .setupProjectClone({
+          projectId: 'github:stablyai/orca',
+          hostId: 'runtime:env-1',
+          url: 'https://example.com/orca.git',
+          destination
+        })
+        .then((result) => {
+          settled = true
+          return result
+        })
 
+      await vi.waitFor(() => expect(cloneClosed).toBe(true))
+      expect(settled).toBe(false)
+      expect(
+        execFileSync('git', ['rev-parse', '--show-toplevel'], {
+          cwd: clonePath,
+          encoding: 'utf-8'
+        }).trim()
+      ).toBe(parentRepo.replaceAll('\\', '/'))
+
+      materializeChildRepo.resolve()
+      const result = await resultPromise
+
+      expect(
+        execFileSync('git', ['rev-parse', '--show-toplevel'], {
+          cwd: clonePath,
+          encoding: 'utf-8'
+        }).trim()
+      ).toBe(clonePath.replaceAll('\\', '/'))
       expect(repos).toHaveLength(1)
       expect(result.repo).toMatchObject({
         path: clonePath,
@@ -7027,7 +7058,82 @@ describe('OrcaRuntimeService', () => {
       })
     } finally {
       spawnSpy.mockRestore()
-      await rm(destination, { recursive: true, force: true })
+      await rm(parentRepo, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+    }
+  })
+
+  it('fails clearly when a completed clone never becomes ready', async () => {
+    const parentRepo = await mkdtemp(join(tmpdir(), 'orca-runtime-project-parent-'))
+    execFileSync('git', ['init'], { cwd: parentRepo, stdio: 'ignore' })
+    const destination = join(parentRepo, 'clones')
+    const clonePath = join(destination, 'orca')
+    const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn')
+    const gitExecSpy = vi.spyOn(gitRunner, 'gitExecFileAsync')
+    getRepoUpstreamMock.mockResolvedValue({ owner: 'stablyai', repo: 'orca' })
+    spawnSpy.mockImplementation(() => {
+      const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
+      proc.stderr = new EventEmitter()
+      queueMicrotask(() => {
+        mkdirSync(clonePath, { recursive: true })
+        proc.emit('close', 0, null)
+      })
+      return proc as never
+    })
+    gitExecSpy.mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      throw new Error('not ready')
+    })
+    const runtime = new OrcaRuntimeService(store as never)
+
+    try {
+      const startedAt = Date.now()
+      await expect(runtime.cloneRepo('https://example.com/orca.git', destination)).rejects.toThrow(
+        'Clone completed but repository path was not ready'
+      )
+      expect(Date.now() - startedAt).toBeLessThan(1700)
+      await expect(lstat(clonePath)).rejects.toThrow()
+    } finally {
+      gitExecSpy.mockRestore()
+      spawnSpy.mockRestore()
+      await rm(parentRepo, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
+    }
+  })
+
+  it('releases the clone path lock after a readiness failure so a retry can succeed', async () => {
+    const destination = await mkdtemp(join(tmpdir(), 'orca-runtime-clone-retry-'))
+    const clonePath = join(destination, 'repo-badge-color')
+    const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn')
+    const firstProc = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
+    firstProc.stderr = new EventEmitter()
+    const secondProc = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
+    secondProc.stderr = new EventEmitter()
+    spawnSpy.mockReturnValueOnce(firstProc as never).mockReturnValueOnce(secondProc as never)
+    const runtime = createRuntime()
+
+    try {
+      const firstClonePromise = runtime.cloneRepo(
+        'https://example.com/repo-badge-color.git',
+        destination
+      )
+      await vi.waitFor(() => expect(spawnSpy).toHaveBeenCalledTimes(1))
+      await mkdir(clonePath, { recursive: true })
+      firstProc.emit('close', 0, null)
+      await expect(firstClonePromise).rejects.toThrow(
+        'Clone completed but repository path was not ready'
+      )
+
+      const secondClonePromise = runtime.cloneRepo(
+        'https://example.com/repo-badge-color.git',
+        destination
+      )
+      await vi.waitFor(() => expect(spawnSpy).toHaveBeenCalledTimes(2))
+      await mkdir(clonePath, { recursive: true })
+      execFileSync('git', ['init'], { cwd: clonePath, stdio: 'ignore' })
+      secondProc.emit('close', 0, null)
+      await expect(secondClonePromise).resolves.toMatchObject({ path: clonePath })
+    } finally {
+      spawnSpy.mockRestore()
+      await rm(destination, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 })
     }
   })
 
@@ -7277,6 +7383,8 @@ describe('OrcaRuntimeService', () => {
 
   it('defaults runtime cloneRepo badgeColor to DEFAULT_REPO_BADGE_COLOR', async () => {
     const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn')
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-runtime-badge-color-'))
+    const clonePath = join(tempRoot, 'repo-badge-color')
     const added: Record<string, unknown>[] = []
     const colorStore = {
       ...store,
@@ -7289,13 +7397,17 @@ describe('OrcaRuntimeService', () => {
     spawnSpy.mockImplementation(() => {
       const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
       proc.stderr = new EventEmitter()
-      queueMicrotask(() => proc.emit('close', 0, null))
+      queueMicrotask(() => {
+        mkdirSync(clonePath, { recursive: true })
+        execFileSync('git', ['init'], { cwd: clonePath, stdio: 'ignore' })
+        proc.emit('close', 0, null)
+      })
       return proc as never
     })
     const runtime = new OrcaRuntimeService(colorStore as never)
 
     try {
-      const repo = await runtime.cloneRepo('https://example.com/repo-badge-color.git', '/tmp')
+      const repo = await runtime.cloneRepo('https://example.com/repo-badge-color.git', tempRoot)
       expect(repo.badgeColor).toBe(DEFAULT_REPO_BADGE_COLOR)
       expect(added).toEqual([
         expect.objectContaining({
@@ -7308,6 +7420,7 @@ describe('OrcaRuntimeService', () => {
       expect(prepareLocalWorktreeRootForRepoMock).toHaveBeenCalledWith(colorStore, repo)
     } finally {
       spawnSpy.mockRestore()
+      await rm(tempRoot, { recursive: true, force: true })
     }
   })
 
@@ -7327,6 +7440,7 @@ describe('OrcaRuntimeService', () => {
       proc.stderr = new EventEmitter()
       queueMicrotask(() => {
         void mkdir(clonePath, { recursive: true })
+          .then(() => execFileSync('git', ['init'], { cwd: clonePath, stdio: 'ignore' }))
           .then(() =>
             writeFile(join(clonePath, '.gitmodules'), '[submodule "lib"]\n\tpath = vendor/lib\n')
           )
@@ -7350,15 +7464,21 @@ describe('OrcaRuntimeService', () => {
 
   it('preserves existing badgeColor on runtime cloneRepo folder->git dedupe upgrade', async () => {
     const spawnSpy = vi.spyOn(gitRunner, 'gitSpawn')
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-runtime-badge-color-'))
+    const clonePath = join(tempRoot, 'repo-badge-color')
     spawnSpy.mockImplementation(() => {
       const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter }
       proc.stderr = new EventEmitter()
-      queueMicrotask(() => proc.emit('close', 0, null))
+      queueMicrotask(() => {
+        mkdirSync(clonePath, { recursive: true })
+        execFileSync('git', ['init'], { cwd: clonePath, stdio: 'ignore' })
+        proc.emit('close', 0, null)
+      })
       return proc as never
     })
     const existing = {
       id: 'runtime-folder-upgrade',
-      path: '/tmp/repo-badge-color',
+      path: clonePath,
       displayName: 'repo-badge-color',
       badgeColor: '#ec4899',
       addedAt: 1,
@@ -7377,7 +7497,7 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(colorStore as never)
 
     try {
-      const repo = await runtime.cloneRepo('https://example.com/repo-badge-color.git', '/tmp')
+      const repo = await runtime.cloneRepo('https://example.com/repo-badge-color.git', tempRoot)
       expect(updates).toEqual([{ id: existing.id, updates: { kind: 'git' } }])
       expect(repo).toEqual(upgraded)
       expect(repo.badgeColor).toBe('#ec4899')
@@ -7385,6 +7505,7 @@ describe('OrcaRuntimeService', () => {
       expect(invalidateAuthorizedRootsCacheMock).toHaveBeenCalled()
     } finally {
       spawnSpy.mockRestore()
+      await rm(tempRoot, { recursive: true, force: true })
     }
   })
 
@@ -7579,6 +7700,7 @@ describe('OrcaRuntimeService', () => {
     }
     const runtime = new OrcaRuntimeService(colorStore as never)
     const destination = await mkdtemp(join(tmpdir(), 'orca-runtime-clone-'))
+    const clonePath = join(destination, 'repo-badge-color')
 
     try {
       const firstClonePromise = runtime.cloneRepo(
@@ -7593,12 +7715,14 @@ describe('OrcaRuntimeService', () => {
       await new Promise((resolve) => setImmediate(resolve))
       expect(spawnSpy).toHaveBeenCalledTimes(1)
 
+      await mkdir(clonePath, { recursive: true })
+      execFileSync('git', ['init'], { cwd: clonePath, stdio: 'ignore' })
       firstProc.emit('close', 0, null)
       await expect(firstClonePromise).resolves.toMatchObject({
-        path: join(destination, 'repo-badge-color')
+        path: clonePath
       })
       await expect(secondClonePromise).resolves.toMatchObject({
-        path: join(destination, 'repo-badge-color')
+        path: clonePath
       })
       expect(spawnSpy).toHaveBeenCalledTimes(1)
     } finally {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -742,6 +742,7 @@ import {
   searchBaseRefDetails,
   getRemoteCount,
   normalizeRefSearchQuery,
+  normalizeGitRepoRootForInputPath,
   parseAndFilterSearchRefDetails,
   parseRemoteCount,
   resolveDefaultBaseRefViaExec,
@@ -15498,6 +15499,54 @@ export class OrcaRuntimeService {
     }
   }
 
+  private async isClonePathReady(
+    clonePath: string,
+    clonePathKey: string,
+    deadlineAt: number
+  ): Promise<boolean> {
+    const runBeforeDeadline = async <T>(work: (remainingMs: number) => Promise<T>): Promise<T> => {
+      const remainingMs = deadlineAt - Date.now()
+      if (remainingMs <= 0) {
+        throw new Error('clone_readiness_timeout')
+      }
+      let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => reject(new Error('clone_readiness_timeout')), remainingMs)
+        timeoutHandle.unref?.()
+      })
+      try {
+        return await Promise.race([work(remainingMs), timeoutPromise])
+      } finally {
+        if (timeoutHandle) {
+          clearTimeout(timeoutHandle)
+        }
+      }
+    }
+    try {
+      if (
+        !(await runBeforeDeadline(async () => {
+          const stats = await stat(clonePath)
+          return stats.isDirectory()
+        }))
+      ) {
+        return false
+      }
+      const { stdout } = await runBeforeDeadline((remainingMs) =>
+        gitExecFileAsync(['rev-parse', '--show-toplevel'], {
+          cwd: clonePath,
+          timeout: remainingMs
+        })
+      )
+      // Why: an empty nested dir under a parent worktree still reports "inside work tree"; readiness needs the clone root itself.
+      return (
+        getClonePathComparisonKey(normalizeGitRepoRootForInputPath(clonePath, stdout.trim())) ===
+        clonePathKey
+      )
+    } catch {
+      return false
+    }
+  }
+
   private async cloneRepoAfterPathLock(
     trimmedUrl: string,
     trimmedDestination: string,
@@ -15577,6 +15626,23 @@ export class OrcaRuntimeService {
         void finishClone(code, signal)
       })
     })
+
+    const cloneReadinessAttempts = 20
+    const cloneReadinessDelayMs = 50
+    const cloneReadinessDeadlineAt = Date.now() + cloneReadinessAttempts * cloneReadinessDelayMs
+    for (let attempt = 0; attempt < cloneReadinessAttempts; attempt += 1) {
+      if (await this.isClonePathReady(clonePath, clonePathKey, cloneReadinessDeadlineAt)) {
+        break
+      }
+      const remainingMs = cloneReadinessDeadlineAt - Date.now()
+      if (attempt === cloneReadinessAttempts - 1 || remainingMs <= 0) {
+        await cleanupClaimedCloneTarget(clonePath, claimedTarget)
+        throw new Error(`Clone completed but repository path was not ready: ${clonePath}`)
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(cloneReadinessDelayMs, remainingMs))
+      )
+    }
 
     const existing = this.store
       .getRepos()


### PR DESCRIPTION
## Summary

- Make remote create-from-URL wait until the cloned path is actually ready before Orca announces the repo and the first terminal or agent tries to attach.
- Root cause: clone completion currently assumes git close code 0 means the checkout is already visible and git-queryable on the runtime host.
- Add one bounded runtime-host readiness confirmation inside the clone seam, without changing the generic missing-cwd preflight.

Closes #10204.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation run in this session:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` - passed, `Tests 868 passed (868)`
- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/pty-subprocess.test.ts` - failed on an unrelated existing test, `expected undefined to be '/daemon/user/codex-home'`
- `pnpm run typecheck:node` - passed, `tsc --noEmit -p config/tsconfig.node.json`
- `pnpm exec oxlint src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` - passed, `Exit code: 0`
- `pnpm exec oxfmt --check src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts` - passed after formatting, `All matched files use the correct format.`
- `pnpm install --frozen-lockfile` - passed, `Done in 51.4s using pnpm v10.24.0`

## Security Audit

This change adds only a bounded read-only filesystem readiness check on a path Orca already derived for clone output. No new auth, network, IPC, or command surface is added.

## Notes

Scope is limited to the clone-completion seam. It does not widen into generic deleted-cwd recovery or terminal spawn retry logic. The readiness helper now uses a real wall-clock deadline across both directory and git probes, it still normalizes WSL UNC roots through Orca’s existing `normalizeGitRepoRootForInputPath` helper, and a bounded readiness failure still releases same-path clone ownership so retries can proceed.

## ELI5

Create-from-URL on a remote host sometimes announced the repo before the clone path was fully ready, so the first terminal failed. Clone now waits for a short readiness check before attach.
