### PR TITLE
fix(terminal): hide SSH error toast under the reconnect banner

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { isSshReconnectOwnedTerminalError, shouldOfferDaemonRestart } from './TerminalErrorToast'
+import {
+  isSshReconnectOwnedTerminalError,
+  shouldOfferDaemonRestart,
+  stripSshReconnectOwnedErrorLines
+} from './TerminalErrorToast'
+
+const SSH_FAILURE =
+  "SSH connection failed: Error invoking remote method 'ssh:connect': Error: Relay package for linux-x64 not found locally."
 
 describe('isSshReconnectOwnedTerminalError', () => {
   it('matches raw ssh:connect failures and inactive-host messages', () => {
@@ -18,6 +25,32 @@ describe('isSshReconnectOwnedTerminalError', () => {
   it('leaves unrelated terminal errors for the toast', () => {
     expect(isSshReconnectOwnedTerminalError('Paste failed.')).toBe(false)
     expect(isSshReconnectOwnedTerminalError('node-pty: open_slave failed: EMFILE')).toBe(false)
+  })
+})
+
+describe('stripSshReconnectOwnedErrorLines', () => {
+  it('clears an error that is only SSH reconnect text', () => {
+    expect(stripSshReconnectOwnedErrorLines(SSH_FAILURE)).toBeNull()
+  })
+
+  it('keeps an unrelated error that precedes the SSH failure', () => {
+    expect(stripSshReconnectOwnedErrorLines(`Paste failed.\n${SSH_FAILURE}`)).toBe('Paste failed.')
+  })
+
+  it('keeps an unrelated error that follows the SSH failure', () => {
+    expect(stripSshReconnectOwnedErrorLines(`${SSH_FAILURE}\nPaste failed.`)).toBe('Paste failed.')
+  })
+
+  it('drops every SSH-owned line but preserves the rest', () => {
+    expect(
+      stripSshReconnectOwnedErrorLines(
+        `${SSH_FAILURE}\nPaste failed.\nSSH connection is not active. Use the reconnect dialog.`
+      )
+    ).toBe('Paste failed.')
+  })
+
+  it('leaves an error with no SSH text untouched', () => {
+    expect(stripSshReconnectOwnedErrorLines('Paste failed.')).toBe('Paste failed.')
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -1,5 +1,25 @@
 import { describe, expect, it } from 'vitest'
-import { shouldOfferDaemonRestart } from './TerminalErrorToast'
+import { isSshReconnectOwnedTerminalError, shouldOfferDaemonRestart } from './TerminalErrorToast'
+
+describe('isSshReconnectOwnedTerminalError', () => {
+  it('matches raw ssh:connect failures and inactive-host messages', () => {
+    expect(
+      isSshReconnectOwnedTerminalError(
+        "SSH connection failed: Error invoking remote method 'ssh:connect': Error: Relay package for linux-x64 not found locally."
+      )
+    ).toBe(true)
+    expect(
+      isSshReconnectOwnedTerminalError(
+        'SSH connection is not active. Use the reconnect dialog or Settings to connect.'
+      )
+    ).toBe(true)
+  })
+
+  it('leaves unrelated terminal errors for the toast', () => {
+    expect(isSshReconnectOwnedTerminalError('Paste failed.')).toBe(false)
+    expect(isSshReconnectOwnedTerminalError('node-pty: open_slave failed: EMFILE')).toBe(false)
+  })
+})
 
 describe('shouldOfferDaemonRestart', () => {
   it('matches stale daemon node-pty install failures', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -1,5 +1,7 @@
 import { translate } from '@/i18n/i18n'
 const SSH_PREFIX = 'SSH connection is not active'
+// Produced by pty-connection.ts reportError() when a PTY reattach can't reach its SSH host.
+const SSH_CONNECT_FAILURE_PREFIX = 'SSH connection failed'
 const STALE_NODE_PTY_DAEMON_MARKERS = [
   "Daemon's node-pty install is gone",
   'node-pty: posix_spawn failed: ENOENT'
@@ -13,9 +15,19 @@ function isSshError(error: string): boolean {
   return error.startsWith(SSH_PREFIX)
 }
 
-/** Toast text the SSH reconnect banner already covers — hide instead of stacking under/over it. */
+/** A single error line the SSH reconnect banner already covers — hide instead of stacking under/over it. */
 export function isSshReconnectOwnedTerminalError(error: string): boolean {
-  return error.startsWith('SSH connection failed') || error.startsWith(SSH_PREFIX)
+  return error.startsWith(SSH_CONNECT_FAILURE_PREFIX) || error.startsWith(SSH_PREFIX)
+}
+
+// Why: onPtyError aggregates errors into one newline-joined string, so classify per line —
+// drop only the reconnect-owned lines and keep any unrelated error, regardless of order.
+export function stripSshReconnectOwnedErrorLines(error: string): string | null {
+  const kept = error
+    .split('\n')
+    .filter((line) => !isSshReconnectOwnedTerminalError(line))
+    .join('\n')
+  return kept.length > 0 ? kept : null
 }
 
 export function shouldOfferDaemonRestart(error: string): boolean {

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -13,6 +13,11 @@ function isSshError(error: string): boolean {
   return error.startsWith(SSH_PREFIX)
 }
 
+/** Toast text the SSH reconnect banner already covers — hide instead of stacking under/over it. */
+export function isSshReconnectOwnedTerminalError(error: string): boolean {
+  return error.startsWith('SSH connection failed') || error.startsWith(SSH_PREFIX)
+}
+
 export function shouldOfferDaemonRestart(error: string): boolean {
   return [STALE_NODE_PTY_DAEMON_MARKERS, STALE_DAEMON_CWD_MARKERS].some((markers) =>
     markers.every((marker) => error.includes(marker))

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -56,7 +56,7 @@ import { useEffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/use-effective-
 import { useTerminalFontZoom } from './useTerminalFontZoom'
 import CloseTerminalDialog, { type CloseTerminalDialogCopyKind } from './CloseTerminalDialog'
 import { MobileDriverOverlay } from './MobileDriverOverlay'
-import { TerminalErrorToast } from './TerminalErrorToast'
+import { isSshReconnectOwnedTerminalError, TerminalErrorToast } from './TerminalErrorToast'
 import { TerminalSessionStateSaveFailureDialog } from './TerminalSessionStateSaveFailureDialog'
 import TerminalContextMenu from './TerminalContextMenu'
 import TerminalPaneHeaderOverlay from './TerminalPaneHeaderOverlay'
@@ -2779,6 +2779,17 @@ export default function TerminalPane({
     sshReconnectStatus &&
     sshReconnectStatus !== 'connected'
   )
+  // Why: drop SSH toast text while the reconnect banner owns recovery, so a later
+  // successful connect doesn't flash the raw ssh:connect failure under the banner.
+  useEffect(() => {
+    if (
+      showSshReconnectOverlay &&
+      terminalError != null &&
+      isSshReconnectOwnedTerminalError(terminalError)
+    ) {
+      setTerminalError(null)
+    }
+  }, [showSshReconnectOverlay, terminalError])
   const menuPaneHasCustomTitle =
     contextMenu.menuPaneId !== null && Boolean(paneTitles[contextMenu.menuPaneId])
   const chatLeafStillMounted = chatLeafId
@@ -2889,13 +2900,15 @@ export default function TerminalPane({
           })
         }}
       />
-      {terminalError && isActive && (
+      {/* Why: the reconnect banner already owns SSH recovery UX; the z-50 error
+          toast was painting over it (same bottom strip) with the raw ssh:connect failure. */}
+      {terminalError && isActive && !showSshReconnectOverlay ? (
         <TerminalErrorToast
           error={terminalError}
           onDismiss={() => setTerminalError(null)}
           onRestartDaemon={() => daemonActions.setPending('restart')}
         />
-      )}
+      ) : null}
       {/* Why: portal into the pane so the banner stacks above the xterm canvas (sibling mount painted under WebGL). */}
       {showSshReconnectOverlay && sshReconnectTargetId && sshReconnectStatus
         ? managedPanes.map((pane) =>

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -56,7 +56,7 @@ import { useEffectiveMacOptionAsAlt } from '@/lib/keyboard-layout/use-effective-
 import { useTerminalFontZoom } from './useTerminalFontZoom'
 import CloseTerminalDialog, { type CloseTerminalDialogCopyKind } from './CloseTerminalDialog'
 import { MobileDriverOverlay } from './MobileDriverOverlay'
-import { isSshReconnectOwnedTerminalError, TerminalErrorToast } from './TerminalErrorToast'
+import { stripSshReconnectOwnedErrorLines, TerminalErrorToast } from './TerminalErrorToast'
 import { TerminalSessionStateSaveFailureDialog } from './TerminalSessionStateSaveFailureDialog'
 import TerminalContextMenu from './TerminalContextMenu'
 import TerminalPaneHeaderOverlay from './TerminalPaneHeaderOverlay'
@@ -2779,15 +2779,16 @@ export default function TerminalPane({
     sshReconnectStatus &&
     sshReconnectStatus !== 'connected'
   )
-  // Why: drop SSH toast text while the reconnect banner owns recovery, so a later
-  // successful connect doesn't flash the raw ssh:connect failure under the banner.
+  // Why: while the reconnect banner owns recovery, strip only the SSH-owned lines from the
+  // (possibly aggregated) error, so a later successful connect can't flash the raw ssh:connect
+  // failure and any unrelated error still surfaces after reconnect.
   useEffect(() => {
-    if (
-      showSshReconnectOverlay &&
-      terminalError != null &&
-      isSshReconnectOwnedTerminalError(terminalError)
-    ) {
-      setTerminalError(null)
+    if (!showSshReconnectOverlay || terminalError == null) {
+      return
+    }
+    const kept = stripSshReconnectOwnedErrorLines(terminalError)
+    if (kept !== terminalError) {
+      setTerminalError(kept)
     }
   }, [showSshReconnectOverlay, terminalError])
   const menuPaneHasCustomTitle =


### PR DESCRIPTION
## Summary

- Follow-up to #10242: the reconnect banner now stacks above the terminal, but the red `TerminalErrorToast` (`z-index: 50`) was still painting over it with the raw `ssh:connect` failure
- Hide the terminal error toast while the SSH reconnect banner is visible
- Clear SSH-owned toast text while the banner is up so a successful reconnect cannot flash the stale failure

## Why

Screenshot from the merged fix: left split shows the red "SSH connection failed: Error invoking remote method 'ssh:connect'..." toast on top of the "SSH connection required" banner. Same bottom strip, two competing recovery UIs.

## Tests

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts` (5/5)