### PR TITLE
fix(tab-bar): render tab close shortcut as text, not key caps

### DIFF
--- a/src/renderer/src/components/tab-bar/EditorFileTabCloseButton.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTabCloseButton.tsx
@@ -1,7 +1,6 @@
 import { X } from 'lucide-react'
-import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 
 export function EditorFileTabCloseButton({
@@ -13,7 +12,11 @@ export function EditorFileTabCloseButton({
   showsSelectionChrome: boolean
   onClose: () => void
 }): React.JSX.Element {
-  const closeShortcut = useShortcutKeyDetails('tab.close')
+  const closeShortcut = useOptionalShortcutLabel('tab.close')
+  const closeLabel = translate(
+    'auto.components.tab.bar.EditorFileTabCloseButton.a768f428f1',
+    'Close tab'
+  )
 
   return (
     <Tooltip>
@@ -43,13 +46,8 @@ export function EditorFileTabCloseButton({
           <X className="w-3 h-3" />
         </button>
       </TooltipTrigger>
-      <TooltipContent side="bottom" sideOffset={6} className="flex items-center gap-2">
-        <span>
-          {translate('auto.components.tab.bar.EditorFileTabCloseButton.a768f428f1', 'Close tab')}
-        </span>
-        {closeShortcut.keys.length > 0 && (
-          <ShortcutKeyCombo keys={closeShortcut.keys} doubleTap={closeShortcut.doubleTap} />
-        )}
+      <TooltipContent side="bottom" sideOffset={6}>
+        {closeShortcut ? `${closeLabel} (${closeShortcut})` : closeLabel}
       </TooltipContent>
     </Tooltip>
   )

--- a/src/renderer/src/components/tab-bar/SortableTab.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.tsx
@@ -6,7 +6,6 @@ import { useTabAgent } from '@/lib/use-tab-agent'
 import { isImeCompositionKeyDown } from '@/lib/ime-composition-keyboard-event'
 import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
 import type { TerminalTab } from '../../../../shared/types'
 import type { TabDragItemData } from '../tab-group/useTabDragSplit'
 import { useAppStore } from '../../store'
@@ -21,7 +20,7 @@ import { preventMiddleButtonDefault } from './middle-button-default-guard'
 import { SortableTabContextMenu } from './SortableTabContextMenu'
 import { translate } from '@/i18n/i18n'
 import { TAB_CONTAINER_WIDTH_CLASSES, TAB_LABEL_WIDTH_CLASSES } from './tab-width-rules'
-import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
+import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { useTabStripPointerActivation } from './tab-strip-pointer-activation'
 import { TerminalTabLeadingIcon } from './TerminalTabLeadingIcon'
 import {
@@ -205,7 +204,8 @@ export default function SortableTab({
     onActivate: handleActivate,
     disabled: isEditing
   })
-  const closeShortcut = useShortcutKeyDetails('tab.close')
+  const closeShortcut = useOptionalShortcutLabel('tab.close')
+  const closeLabel = translate('auto.components.tab.bar.SortableTab.95db5f2f7d', 'Close tab')
   const tabTitle = tab.customTitle ?? tab.title
   const tabRoot = (
     <div
@@ -387,11 +387,8 @@ export default function SortableTab({
               <X className="w-3 h-3" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="bottom" sideOffset={6} className="flex items-center gap-2">
-            <span>{translate('auto.components.tab.bar.SortableTab.95db5f2f7d', 'Close tab')}</span>
-            {closeShortcut.keys.length > 0 && (
-              <ShortcutKeyCombo keys={closeShortcut.keys} doubleTap={closeShortcut.doubleTap} />
-            )}
+          <TooltipContent side="bottom" sideOffset={6}>
+            {closeShortcut ? `${closeLabel} (${closeShortcut})` : closeLabel}
           </TooltipContent>
         </Tooltip>
       )}


### PR DESCRIPTION
## Summary

The **Close tab** tooltip rendered its `⌘W` shortcut using `ShortcutKeyCombo` key‑cap chips. Because the tooltip surface is light (`bg-foreground`), those filled grey caps read as heavy, low‑contrast boxes — and they're inconsistent with every other tooltip in the app, which shows its shortcut as plain text (e.g. `Toggle sidebar (⌘B)`, `New workspace (⌘N)`).

This switches **both** tab close tooltips to that same plain‑text convention via `useOptionalShortcutLabel`:

- `EditorFileTabCloseButton` — editor / simulator tabs
- `SortableTab` — terminal / agent / browser tabs

The tooltip now reads `Close tab (⌘W)`, falling back to just `Close tab` when the action is unbound. No new copy or translation keys: it reuses the existing `Close tab` catalog entries, and the shortcut itself is a formatted keybinding (not translated — same as the chips were). Now‑unused `ShortcutKeyCombo` / `useShortcutKeyDetails` imports were removed.

`TabBarQuickCommandsMenu` intentionally keeps its key caps — it renders on a dark command‑palette surface where the chips are appropriate.

## Screenshots

Before → After (rendered from the components' exact markup + Orca dark‑mode tokens + the Geist app font):

![Close tab tooltip — before and after](https://raw.githubusercontent.com/stablyai/orca/pr-assets-cmd-w-tab-close-tooltip/tab-close-tooltip/comparison.png)

_macOS shown; Windows/Linux render `Close tab (Ctrl+W)`._

## Testing

- [x] `pnpm lint` — oxlint, formatting (oxfmt, via pre‑commit), and `verify:localization-catalog` all pass for this change. ⚠️ One **pre‑existing, unrelated** failure remains in `verify:skill-bundle-manifest` ("Released snapshot history changed for orca-cli at revision 9"); it reproduces identically on untouched `main` and does not involve any file in this PR.
- [x] `pnpm typecheck` — passes cleanly.
- [x] `pnpm test` — affected tab‑bar suites pass (`SortableTab.rename-shortcut`, `EditorFileTab`, `EditorFileTabContextMenu`). Full suite: **3567 files / 36654 tests passed**. ⚠️ 2 **pre‑existing, unrelated** failures in `src/relay/agent-exec-handler.test.ts` (codex spawn expectations) — that file and its source are byte‑identical to `main` and fail the same there.
- [ ] `pnpm build` — not run; this is a copy‑only change in two renderer components with no build‑affecting surface.
- [x] Added or updated high‑quality tests, or explained why not — existing tab‑bar tests already mock `useOptionalShortcutLabel` and exercise these components; this is a label‑rendering swap that introduces no new branch beyond the existing unbound‑shortcut fallback, so no new tests were warranted.

## AI Review Report

Self‑review focused on correctness, scope, and cross‑platform behavior:

- **Cross‑platform (macOS / Linux / Windows):** the label comes from `useOptionalShortcutLabel('tab.close')` → `formatKeybindingList`, which yields `⌘W` on macOS and `Ctrl+W` on Windows/Linux. The parenthetical form reads correctly on all three. No paths, shell, or Electron‑specific surfaces are touched.
- **Unbound shortcut:** `useOptionalShortcutLabel` returns `null` when the action is unbound, so the tooltip degrades to plain `Close tab` — no dangling `()`.
- **No behavioral regressions:** the close action, `aria-label` (`"Close tab …"`), and E2E hook (`data-tab-close-button`) are unchanged; only the tooltip's shortcut presentation changed.
- **Scope check:** confirmed these are the only two close‑tab tooltips using key caps; `TabBarQuickCommandsMenu` (dark palette surface) is deliberately left as‑is. Removed the now‑unused imports.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. This is a purely presentational change in two renderer components; the only new runtime value is a formatted keybinding string already used throughout the app. No new dependencies. Nothing to flag.

## Notes

- macOS shows `Close tab (⌘W)`; Windows/Linux show `Close tab (Ctrl+W)`.
- Screenshots are hosted on the throwaway `pr-assets-cmd-w-tab-close-tooltip` branch — safe to delete after merge.
- The pre‑existing lint/test failures noted above are unrelated to this PR and exist on `main`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
