### PR TITLE
fix(window): defer the repaint size nudge and skip it on macOS 26

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -11,7 +11,8 @@ const {
   notificationShowMock,
   powerMonitorOnMock,
   powerMonitorRemoveListenerMock,
-  isMock
+  isMock,
+  macosTahoeMock
 } = vi.hoisted(() => {
   const menuPopupMock = vi.fn()
   const notificationShowMock = vi.fn()
@@ -27,7 +28,8 @@ const {
     notificationShowMock,
     powerMonitorOnMock: vi.fn(),
     powerMonitorRemoveListenerMock: vi.fn(),
-    isMock: { dev: false }
+    isMock: { dev: false },
+    macosTahoeMock: { value: false }
   }
 })
 
@@ -47,6 +49,10 @@ vi.mock('electron', () => ({
 
 vi.mock('@electron-toolkit/utils', () => ({
   is: isMock
+}))
+
+vi.mock('./macos-tahoe-release', () => ({
+  isMacosTahoeOrNewer: vi.fn(() => macosTahoeMock.value)
 }))
 
 vi.mock('../app-icon', () => ({
@@ -86,6 +92,7 @@ describe('createMainWindow', () => {
     powerMonitorOnMock.mockReset()
     powerMonitorRemoveListenerMock.mockReset()
     isMock.dev = false
+    macosTahoeMock.value = false
     vi.mocked(ipcMain.on).mockReset()
     vi.mocked(ipcMain.removeListener).mockReset()
     vi.mocked(ipcMain.handle).mockReset()
@@ -353,6 +360,10 @@ describe('createMainWindow', () => {
     windowHandlers.get('restore')?.[0]?.()
 
     expect(webContents.invalidate).toHaveBeenCalledTimes(2)
+    // Why: the size nudge must never run inside the show/restore dispatch itself.
+    expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(0)
     expect(browserWindowInstance.setSize).toHaveBeenNthCalledWith(1, 1201, 800)
     expect(browserWindowInstance.setSize).toHaveBeenCalledTimes(1)
 
@@ -371,6 +382,54 @@ describe('createMainWindow', () => {
     windowHandlers.get('focus')?.[0]?.()
     expect(webContents.invalidate).toHaveBeenCalledTimes(4)
     expect(browserWindowInstance.setSize).toHaveBeenCalledTimes(setSizeCalls)
+  })
+
+  it('repaints without the size nudge on macOS 26+ where re-entrant frame updates can deadlock AppKit', () => {
+    vi.useFakeTimers()
+    macosTahoeMock.value = true
+    const windowHandlers = new Map<string, ((...args: any[]) => void)[]>()
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        const handlers = windowHandlers.get(event) ?? []
+        handlers.push(handler)
+        windowHandlers.set(event, handlers)
+      }),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    withPlatform('darwin', () => createMainWindow(null))
+
+    windowHandlers.get('show')?.[0]?.()
+    expect(webContents.invalidate).toHaveBeenCalledTimes(1)
+
+    // Why: the delayed second repaint must also stay setSize-free on Tahoe.
+    vi.advanceTimersByTime(300)
+    expect(webContents.invalidate).toHaveBeenCalledTimes(2)
+    expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
   })
 
   it('supports all minus key variants for terminal zoom out', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -48,6 +48,7 @@ import { resolveWindowCloseAction } from './window-close-decision'
 import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { closeDashboardPopout } from './dashboard-popout-window'
 import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
+import { isMacosTahoeOrNewer } from './macos-tahoe-release'
 
 // Why: show/restore/resume can overlap before the size nudge resets; never capture the temporary width as the next baseline.
 const activeRepaintJiggles = new WeakSet<BrowserWindow>()
@@ -61,15 +62,26 @@ function forceRepaint(window: BrowserWindow): void {
   if (window.isMaximized() || window.isFullScreen() || activeRepaintJiggles.has(window)) {
     return
   }
+  // Why: macOS 26 scene-backed windows can deadlock the main thread on re-entrant frame updates; invalidate alone recovers the compositor there.
+  if (isMacosTahoeOrNewer()) {
+    return
+  }
   activeRepaintJiggles.add(window)
-  const [width, height] = window.getSize()
-  window.setSize(width + 1, height)
+  // Why: show/restore fire from inside AppKit's window-state dispatch; mutating the frame there re-enters scene handling, so nudge on a fresh turn.
   setTimeout(() => {
-    if (!window.isDestroyed()) {
-      window.setSize(width, height)
+    if (window.isDestroyed()) {
+      activeRepaintJiggles.delete(window)
+      return
     }
-    activeRepaintJiggles.delete(window)
-  }, 32)
+    const [width, height] = window.getSize()
+    window.setSize(width + 1, height)
+    setTimeout(() => {
+      if (!window.isDestroyed()) {
+        window.setSize(width, height)
+      }
+      activeRepaintJiggles.delete(window)
+    }, 32)
+  }, 0)
 }
 
 function installMacosVisibilityRepaint(window: BrowserWindow): void {

--- a/src/main/window/macos-tahoe-release.test.ts
+++ b/src/main/window/macos-tahoe-release.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { isMacosTahoeOrNewer } from './macos-tahoe-release'
+
+describe('isMacosTahoeOrNewer', () => {
+  it('detects Darwin 25+ (macOS 26) as Tahoe or newer', () => {
+    expect(isMacosTahoeOrNewer('25.5.0')).toBe(true)
+    expect(isMacosTahoeOrNewer('26.0.0')).toBe(true)
+  })
+
+  it('treats older Darwin releases as pre-Tahoe', () => {
+    expect(isMacosTahoeOrNewer('24.6.0')).toBe(false)
+    expect(isMacosTahoeOrNewer('23.0.0')).toBe(false)
+  })
+
+  it('treats unparseable releases as pre-Tahoe', () => {
+    expect(isMacosTahoeOrNewer('')).toBe(false)
+    expect(isMacosTahoeOrNewer('unknown')).toBe(false)
+  })
+})

--- a/src/main/window/macos-tahoe-release.ts
+++ b/src/main/window/macos-tahoe-release.ts
@@ -1,0 +1,8 @@
+import os from 'node:os'
+
+// Why: Darwin 25.x = macOS 26 (Tahoe), where AppKit windows are scene-backed and
+// re-entrant frame updates can self-deadlock the main thread in FrontBoardServices.
+export function isMacosTahoeOrNewer(darwinRelease: string = os.release()): boolean {
+  const major = Number.parseInt(darwinRelease, 10)
+  return Number.isFinite(major) && major >= 25
+}


### PR DESCRIPTION
## Problem

A macOS 26.5.1 user hit a permanent main-thread deadlock (kernel-confirmed via spindump: unresponsive 1305+s) inside AppKit/FrontBoardServices scene-update handling: a window-frame update delivered from the window server re-entered frame code, sent a scene update back with `performAsyncAndWait` on the FrontBoard callout queue the main thread was already draining, and waited on itself forever. The deadlock stack is entirely Apple frames, but it requires re-entrant frame updates — and our `show`/`restore` repaint jiggle calls `setSize` **synchronously inside AppKit's window-state dispatch**, which is exactly that re-entrant shape. The jiggle also fires up to 4 frame updates per visibility transition since #9395 doubled it.

macOS 26 (Tahoe) windows are scene-backed; this machinery does not exist pre-26.

## Fix

- **Defer the size nudge to a fresh event-loop turn** so it never runs inside `show`/`restore` dispatch (applies to all macOS versions; frame mutation from inside a windowing callback is never safe).
- **Skip the nudge entirely on Darwin 25+ (macOS 26)** and rely on `webContents.invalidate()` alone. The nudge exists to work around a pre-Tahoe black-surface compositor bug; on Tahoe it is unneeded risk. New `macos-tahoe-release.ts` holds the version gate.

Behavior is unchanged pre-Tahoe apart from the one-turn deferral (revert still lands 32ms later; the terminal SIGWINCH pattern is identical).

## Testing

- Updated the visibility-repaint test to assert the nudge never runs inside the show/restore dispatch and still completes after timers advance.
- New test: on Tahoe, both immediate and delayed repaints invalidate without any `setSize`.
- New unit tests for the Darwin-version gate (25+, older, unparseable).
- `vitest` (77 tests), `oxlint`, `typecheck:node` all green.

## ELI5

When the Orca window comes back on screen (un-minimize, reopen), macOS sometimes forgets to repaint it, leaving it black. Our workaround was to "wiggle" the window — make it 1px wider, then put it back — which forces a repaint. The problem: we did the wiggle at the exact moment macOS was in the middle of its own window bookkeeping, and on macOS 26 interrupting that bookkeeping can freeze the entire app forever (that's the deadlock a user hit). This PR waits until macOS finishes its bookkeeping before wiggling, and on macOS 26 it doesn't wiggle at all — it just asks the window to repaint directly, because the wiggle is dangerous there and the bug it worked around is a pre-macOS-26 bug.

## Trade-offs

- **The nudge is skipped on Tahoe without proof the black-surface bug is gone there.** If macOS 26 still has the compositor bug, Tahoe users could see a black window after restore that `invalidate()` alone doesn't fix. Accepted deliberately: a black flash is recoverable; the deadlock is not. If reports come in, the follow-up is a Tahoe-safe repaint path, not restoring the nudge.
- **The nudge now lands one event-loop turn later** on pre-Tahoe macOS, so black-surface recovery is delayed by ~one tick (imperceptible), in exchange for never mutating the frame inside AppKit's dispatch.
- **The nudge is kept (deferred) pre-Tahoe rather than deleted everywhere**, because its need there is proven and the deadlock machinery doesn't exist pre-26.
- **OS gate reads the Darwin major version only** (`25+` = macOS 26) — no build/minor granularity. If Apple fixes the deadlock in a later 26.x, we still skip the nudge there; that stays correct since it's unneeded on 26 anyway.
