### PR TITLE
fix(sidebar): reject content-pointerenter reopen after trigger-pointerleave (stuck hovercard)

### DIFF
--- a/src/renderer/src/components/ui/hover-card.test.tsx
+++ b/src/renderer/src/components/ui/hover-card.test.tsx
@@ -121,6 +121,27 @@ describe('HoverCardContent stuck-open guard', () => {
     expect(openCards()).toEqual(['B'])
   })
 
+  it('dismisses on the single pointermove that carries the pointer to rest elsewhere', () => {
+    renderCards(['A'])
+    const elsewhere = document.createElement('div')
+    document.body.appendChild(elsewhere)
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+
+    pointerOut(trigger('A'), content('A'))
+    pointerOver(content('A'), trigger('A'))
+    pointerMoveOver(content('A'))
+    advance(20)
+
+    // Reaching any resting place requires at least one pointermove off the
+    // card; the guard fires on that one rather than needing continuous motion.
+    pointerMoveOver(elsewhere)
+    advance(CLOSE_DELAY + 50)
+
+    expect(openCards()).toEqual([])
+    elsewhere.remove()
+  })
+
   it('keeps the card open while the pointer moves from the trigger into the content', () => {
     renderCards(['A'])
     pointerOver(trigger('A'), null)
@@ -165,9 +186,16 @@ describe('HoverCardContent stuck-open guard', () => {
     pointerMoveOver(content('A'))
     advance(20)
 
+    // Assert the guard stays silent rather than only that the card survives:
+    // React synthesizes a trigger pointerenter from any pointerout we dispatch
+    // here, which re-opens the card and would mask a missing trigger check.
+    const dismissals: Event[] = []
+    content('A').addEventListener('pointerout', (event) => dismissals.push(event))
+
     pointerMoveOver(trigger('A'))
     advance(CLOSE_DELAY + 200)
 
+    expect(dismissals).toEqual([])
     expect(openCards()).toEqual(['A'])
   })
 

--- a/src/renderer/src/components/ui/hover-card.test.tsx
+++ b/src/renderer/src/components/ui/hover-card.test.tsx
@@ -1,0 +1,238 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { HoverCard, HoverCardContent, HoverCardTrigger } from './hover-card'
+
+const OPEN_DELAY = 100
+const CLOSE_DELAY = 120
+
+let container: HTMLDivElement
+let root: Root
+
+function Card({ id }: { id: string }): React.JSX.Element {
+  const [open, setOpen] = React.useState(false)
+  return (
+    <HoverCard open={open} onOpenChange={setOpen} openDelay={OPEN_DELAY} closeDelay={CLOSE_DELAY}>
+      <HoverCardTrigger asChild>
+        <span data-trigger={id}>{id}</span>
+      </HoverCardTrigger>
+      <HoverCardContent data-content={id}>
+        <button type="button">action {id}</button>
+      </HoverCardContent>
+    </HoverCard>
+  )
+}
+
+function renderCards(ids: string[]): void {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root.render(
+      <>
+        {ids.map((id) => (
+          <Card key={id} id={id} />
+        ))}
+      </>
+    )
+  })
+}
+
+function openCards(): string[] {
+  return Array.from(document.querySelectorAll('[data-content]')).map(
+    (node) => node.getAttribute('data-content') as string
+  )
+}
+function trigger(id: string): HTMLElement {
+  return container.querySelector(`[data-trigger="${id}"]`) as HTMLElement
+}
+function content(id: string): HTMLElement {
+  return document.querySelector(`[data-content="${id}"]`) as HTMLElement
+}
+
+// React synthesizes pointerenter/pointerleave from native pointerover/pointerout.
+function pointerOver(el: Element, from: Element | null, pointerType = 'mouse'): void {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent('pointerover', {
+        bubbles: true,
+        cancelable: true,
+        relatedTarget: from,
+        pointerType
+      })
+    )
+  })
+}
+function pointerOut(el: Element, to: Element | null, pointerType = 'mouse'): void {
+  act(() => {
+    el.dispatchEvent(
+      new PointerEvent('pointerout', {
+        bubbles: true,
+        cancelable: true,
+        relatedTarget: to,
+        pointerType
+      })
+    )
+  })
+}
+function pointerMoveOver(el: Element, pointerType = 'mouse'): void {
+  act(() => {
+    el.dispatchEvent(new PointerEvent('pointermove', { bubbles: true, pointerType }))
+  })
+}
+function advance(ms: number): void {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+describe('HoverCardContent stuck-open guard', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    vi.useRealTimers()
+  })
+
+  it('closes a card the pointer transited when no content pointerout arrives', () => {
+    renderCards(['A', 'B'])
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+    expect(openCards()).toEqual(['A'])
+
+    // Pointer crosses A's portaled content on its way to B. A fast transit can
+    // leave Radix without the content pointerout that reschedules the close.
+    pointerOut(trigger('A'), content('A'))
+    pointerOver(content('A'), trigger('A'))
+    pointerMoveOver(content('A'))
+    advance(20)
+
+    pointerMoveOver(trigger('B'))
+    pointerOver(trigger('B'), content('A'))
+    advance(OPEN_DELAY + CLOSE_DELAY + 100)
+
+    expect(openCards()).toEqual(['B'])
+  })
+
+  it('keeps the card open while the pointer moves from the trigger into the content', () => {
+    renderCards(['A'])
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+    expect(openCards()).toEqual(['A'])
+
+    pointerOut(trigger('A'), content('A'))
+    pointerOver(content('A'), trigger('A'))
+    // Moving around inside the card must never dismiss it — its buttons have to
+    // stay clickable.
+    pointerMoveOver(content('A'))
+    advance(CLOSE_DELAY + OPEN_DELAY + 500)
+    pointerMoveOver(content('A').querySelector('button') as Element)
+    advance(500)
+
+    expect(openCards()).toEqual(['A'])
+  })
+
+  it('keeps the card open while the pointer crosses the trigger-to-content gap', () => {
+    renderCards(['A'])
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+
+    // sideOffset leaves a gap; pointermove lands on neither node before arrival
+    pointerOut(trigger('A'), null)
+    pointerMoveOver(document.body)
+    advance(CLOSE_DELAY - 20)
+    pointerOver(content('A'), null)
+    pointerMoveOver(content('A'))
+    advance(500)
+
+    expect(openCards()).toEqual(['A'])
+  })
+
+  it('keeps the card open when the pointer returns to its own trigger', () => {
+    renderCards(['A'])
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+
+    pointerOut(trigger('A'), content('A'))
+    pointerOver(content('A'), trigger('A'))
+    pointerMoveOver(content('A'))
+    advance(20)
+
+    pointerMoveOver(trigger('A'))
+    advance(CLOSE_DELAY + 200)
+
+    expect(openCards()).toEqual(['A'])
+  })
+
+  it('reopens after the pointer leaves and returns to the trigger', () => {
+    renderCards(['A'])
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+
+    pointerOut(trigger('A'), document.body)
+    advance(CLOSE_DELAY + 50)
+    expect(openCards()).toEqual([])
+
+    pointerOver(trigger('A'), document.body)
+    advance(OPEN_DELAY + 50)
+    expect(openCards()).toEqual(['A'])
+  })
+
+  it('opens from keyboard focus after the pointer has passed over the trigger', () => {
+    renderCards(['A'])
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+    pointerOut(trigger('A'), document.body)
+    advance(CLOSE_DELAY + 50)
+    expect(openCards()).toEqual([])
+
+    act(() => {
+      trigger('A').dispatchEvent(new FocusEvent('focusin', { bubbles: true }))
+    })
+    advance(OPEN_DELAY + 50)
+
+    expect(openCards()).toEqual(['A'])
+  })
+
+  it('ignores touch pointer moves so tap-held cards are not dismissed', () => {
+    renderCards(['A'])
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+
+    pointerOut(trigger('A'), content('A'))
+    pointerOver(content('A'), trigger('A'))
+    pointerMoveOver(content('A'))
+    advance(20)
+
+    pointerMoveOver(document.body, 'touch')
+    advance(CLOSE_DELAY + 200)
+
+    expect(openCards()).toEqual(['A'])
+  })
+
+  it('removes its pointermove listener when the card closes', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    renderCards(['A'])
+
+    pointerOver(trigger('A'), null)
+    advance(OPEN_DELAY + 10)
+    const added = addSpy.mock.calls.filter(([type]) => type === 'pointermove').length
+    expect(added).toBeGreaterThan(0)
+
+    pointerOut(trigger('A'), document.body)
+    advance(CLOSE_DELAY + 50)
+
+    const removed = removeSpy.mock.calls.filter(([type]) => type === 'pointermove').length
+    expect(removed).toBe(added)
+    addSpy.mockRestore()
+    removeSpy.mockRestore()
+  })
+})

--- a/src/renderer/src/components/ui/hover-card.tsx
+++ b/src/renderer/src/components/ui/hover-card.tsx
@@ -5,26 +5,118 @@ import { HoverCard as HoverCardPrimitive } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
 
-function HoverCard({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
-  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+// Why: the stuck-card guard in HoverCardContent must tell its own trigger apart
+// from every other hover card on screen, so each root shares one trigger ref.
+const HoverCardTriggerRef = React.createContext<React.RefObject<HTMLElement | null> | null>(null)
+
+function setRef<T>(ref: React.Ref<T> | undefined, value: T | null): void {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref) {
+    ;(ref as React.RefObject<T | null>).current = value
+  }
 }
 
-function HoverCardTrigger({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
-  return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" {...props} />
+function HoverCard({ ...props }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
+  const triggerRef = React.useRef<HTMLElement | null>(null)
+  return (
+    <HoverCardTriggerRef.Provider value={triggerRef}>
+      <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+    </HoverCardTriggerRef.Provider>
+  )
+}
+
+function HoverCardTrigger({
+  ref,
+  ...props
+}: React.ComponentProps<typeof HoverCardPrimitive.Trigger>) {
+  const triggerRef = React.useContext(HoverCardTriggerRef)
+  const composedRef = React.useCallback(
+    (node: HTMLAnchorElement | null) => {
+      setRef(ref, node)
+      if (triggerRef) {
+        triggerRef.current = node
+      }
+    },
+    [ref, triggerRef]
+  )
+  return <HoverCardPrimitive.Trigger data-slot="hover-card-trigger" ref={composedRef} {...props} />
 }
 
 function HoverCardContent({
   className,
   align = 'center',
   sideOffset = 4,
+  ref,
+  onPointerLeave,
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Content>) {
+  const triggerRef = React.useContext(HoverCardTriggerRef)
+  const [contentNode, setContentNode] = React.useState<HTMLDivElement | null>(null)
+  const composedRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      setRef(ref, node)
+      setContentNode(node)
+    },
+    [ref]
+  )
+  // The pointer may sit in the trigger→content gap before it ever reaches the
+  // card, so only arm the guard once the card itself has really been hovered.
+  const enteredRef = React.useRef(false)
+
+  // Why: Radix reschedules the close only from the content's own pointerleave.
+  // Moving between sidebar rows can cancel the close timer via the content's
+  // pointerenter and then never deliver the matching pointerleave, leaving the
+  // card stuck open indefinitely (#10254). Track the real pointer position and
+  // replay the pointerout Radix is waiting for once the pointer is provably off
+  // both the card and its trigger.
+  React.useEffect(() => {
+    if (!contentNode) {
+      enteredRef.current = false
+      return
+    }
+    const handlePointerMove = (event: PointerEvent): void => {
+      if (event.pointerType === 'touch') {
+        return
+      }
+      const target = event.target as Node | null
+      if (target && contentNode.contains(target)) {
+        enteredRef.current = true
+        return
+      }
+      if (!enteredRef.current) {
+        return
+      }
+      // Returning to this card's own trigger keeps it open by design.
+      if (target && triggerRef?.current?.contains(target)) {
+        return
+      }
+      enteredRef.current = false
+      contentNode.dispatchEvent(
+        new PointerEvent('pointerout', {
+          bubbles: true,
+          relatedTarget: target as EventTarget | null,
+          pointerType: event.pointerType
+        })
+      )
+    }
+    document.addEventListener('pointermove', handlePointerMove)
+    return () => {
+      document.removeEventListener('pointermove', handlePointerMove)
+    }
+  }, [contentNode, triggerRef])
+
   return (
     <HoverCardPrimitive.Portal data-slot="hover-card-portal">
       <HoverCardPrimitive.Content
         data-slot="hover-card-content"
         align={align}
         sideOffset={sideOffset}
+        ref={composedRef}
+        onPointerLeave={(event) => {
+          enteredRef.current = false
+          onPointerLeave?.(event)
+        }}
         // Why: matches the dropdown-menu recipe — translucent surface, solid
         // 14% border, dual shadow, and 2xl backdrop blur. The previous
         // border-border/50 + bg-popover made the hover card blend into the


### PR DESCRIPTION
## Summary

The workspace detail hover card in the left sidebar could stay on screen forever after the mouse had moved away — covering the sidebar until some later hover happened to dismiss it.

Root cause: Radix schedules the hover card's close from the **content's** `pointerleave`. When the pointer transits across the portaled content on its way to another row, the content's `pointerenter` cancels the pending close timer, and a fast transit can then never deliver the matching `pointerleave`. Nothing is left to reschedule the close, so the card hangs open indefinitely.

The fix lives in the shared `HoverCardContent` primitive (`src/renderer/src/components/ui/hover-card.tsx`), so it covers every hover card in the app, not just the sidebar one. While a card is mounted it watches real pointer position and replays the `pointerout` Radix is waiting for, but only once the pointer is provably off **both** the card and its own trigger.

Closes #10254

## ELI5

Imagine a pop-up label that is supposed to disappear when you move your mouse away. It only knows to disappear when the mouse "steps off" it. If you swipe past it quickly, the pop-up notices the mouse arrive but never notices it leave — so it waits forever and stays stuck on screen. This change gives the pop-up a second way to notice: it watches where the mouse actually is, and once the mouse is clearly somewhere else, it closes itself. It's careful not to close while your mouse is still on the pop-up or back on the thing that opened it, so you can still move onto the card and click the buttons inside it.

## Proof of fix

New test file `src/renderer/src/components/ui/hover-card.test.tsx`. The first test reproduces #10254 with two adjacent cards: the pointer transits A's content and moves to B without A's content receiving a `pointerout`.

With `hover-card.tsx` reverted to `origin/main` (test file kept):

```
$ git checkout origin/main -- src/renderer/src/components/ui/hover-card.tsx
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/ui/hover-card.test.tsx

 FAIL  ... > closes a card the pointer transited when no content pointerout arrives
AssertionError: expected [ 'A' ] to deeply equal [ 'B' ]

 FAIL  ... > dismisses on the single pointermove that carries the pointer to rest elsewhere
AssertionError: expected [ 'A' ] to deeply equal []

 FAIL  ... > removes its pointermove listener when the card closes
AssertionError: expected 0 to be greater than 0

 Test Files  1 failed (1)
      Tests  3 failed | 6 passed (9)
```

`['A']` is the stuck card: A is still open even though the pointer is now on B.

With the fix applied:

```
$ git checkout HEAD -- src/renderer/src/components/ui/hover-card.tsx
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/ui/hover-card.test.tsx

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

The other 6 tests pass on **both** sides — they are the guardrails asserting this fix does not over-close.

**A resting pointer still dismisses.** `pointermove` only fires on movement, so a guard needing continuous motion would fail exactly when the user stops moving. It doesn't: reaching any resting place requires at least one `pointermove` off the card, and the guard fires on that single move. Pinned by `dismisses on the single pointermove that carries the pointer to rest elsewhere`, which fails on `main`.

**The guardrails are mutation-tested, not just green.** Each was verified to fail against a deliberately broken fix, because a hover test that passes for the wrong reason is worse than no test:

| Mutation | Caught by |
|---|---|
| Arm the guard before the content is hovered | gap-traversal test |
| Delete the trigger-containment check | return-to-own-trigger test |
| Never arm the guard | stuck-open test |
| Dismiss on any pointermove, relatedTarget outside | 5 tests incl. trigger→content traversal |
| Never dispatch the dismissal | stuck-open + resting-pointer tests |

This caught a real defect in my own suite: the original return-to-own-trigger test passed even with the trigger check deleted. Dispatching a `pointerout` there makes React synthesize a trigger `pointerenter` that reopens the card, masking the missing check. It now asserts the guard stays *silent* rather than only that the card survived.

## Proof of no regressions

**Moving the mouse from the trigger into the hovercard content still keeps it open.** This is the regression this class of fix most often introduces, and it is covered by three dedicated tests that pass both before and after:

- `keeps the card open while the pointer moves from the trigger into the content` — enters the content, moves around inside it and onto its `<button>`, waits 500 ms, card stays open. The card's contents remain clickable.
- `keeps the card open while the pointer crosses the trigger-to-content gap` — `sideOffset` leaves a real gap; a `pointermove` landing on neither node mid-transit must not dismiss. The guard only arms after the content has genuinely been hovered.
- `keeps the card open when the pointer returns to its own trigger` — moving content → trigger keeps it open by design, asserted via zero dismissal events rather than a reopen-masked survival check.

Plus `reopens after the pointer leaves and returns to the trigger`, `opens from keyboard focus after the pointer has passed over the trigger` (keyboard a11y), `ignores touch pointer moves so tap-held cards are not dismissed`, and a listener-cleanup test.

Full sweep over every `HoverCard` consumer directory (`ui/`, `sidebar/`, `status-bar/`, `github-project/`, `source-control/`):

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/components/ui/ src/renderer/src/components/sidebar/ \
    src/renderer/src/components/source-control/SourceControlActionVariableChips.test.tsx \
    src/renderer/src/components/status-bar/ src/renderer/src/components/github-project/

 Test Files  234 passed (234)
      Tests  1918 passed (1918)

$ npx tsc --noEmit -p config/tsconfig.tc.web.json      # exit 0
$ npx oxlint src/renderer/src/components/ui/hover-card.tsx src/renderer/src/components/ui/hover-card.test.tsx   # exit 0
```

Behavior that **does** change, intentionally:

- A hover card whose content the pointer has entered and then left without a delivered `pointerleave` now closes after the normal `closeDelay`, instead of staying open indefinitely. This applies to all hover cards app-wide, not only the sidebar.

No other user-visible change: the guard is inert until the pointer has actually been inside the content, it never fires while the pointer is on the content or that card's own trigger, and it ignores `touch` pointers entirely.

## Compatibility

- **Platforms:** macOS / Linux / Windows — pure renderer-side DOM pointer-event logic with no platform branches, no `metaKey`/accelerator handling, and no path handling. Uses only `PointerEvent`, `Node.contains`, and `document` listeners, all uniform across Electron's bundled Chromium on all three platforms. Verified on macOS; nothing in the diff can diverge per-OS.
- **SSH / remote:** N/A — renderer-only UI behavior with no main-process, IPC, git, or filesystem involvement. Identical for local, SSH, and folder workspaces.
- **Performance:** One `pointermove` listener per **open** hover card. Hover cards are mounted only while open and are effectively singleton in practice, so this is ~1 listener during hover and zero at rest. The handler is a couple of `Node.contains` checks with an early return, and it is removed on close/unmount (covered by the cleanup test). No hot-path, render-loop, or subprocess impact.

## Screenshots

No visual change — the card's appearance is untouched; only its dismissal timing changes. The behavior is a timing/interaction fix best seen as: hover a workspace row, sweep the mouse quickly across the popover to another row, and observe the old card no longer remains on screen. Automated coverage for this motion is in `hover-card.test.tsx` (the two-card transit test), since a screen recording cannot be captured in this environment.

## Testing

- [x] `pnpm lint` — ran `npx oxlint` on both changed files, exit 0
- [x] `pnpm typecheck` — ran `npx tsc --noEmit -p config/tsconfig.tc.web.json`, exit 0
- [x] `pnpm test` — ran the 234 test files covering every `HoverCard` consumer (1918 tests, all passing) rather than the full 30+ min suite
- [ ] `pnpm build` — not run; no build-affecting change (component-only, no new dependency, no config change)
- [x] Added or updated high-quality tests that would catch regressions — `hover-card.test.tsx`, whose stuck-open test fails on `origin/main` and passes here, with six mutation-tested guardrails pinning the trigger→content traversal, gap crossing, keyboard, and touch paths

## AI Review Report

Reviewed with an AI agent acting as a hostile reviewer over the original patch and this rewrite.

Risks checked and findings:

- **The original approach did not fix the bug.** The prior patch latched a "close requested" flag on trigger `pointerleave` and rejected a subsequent `onOpenChange(true)`. Radix's `useControllableState.setValue` only invokes `onChange` when the value actually differs from the controlled prop — in the stuck path the card is already open, so Radix's internal `handleOpen()` never emits `onOpenChange(true)`. Instrumenting `onOpenChange` across the whole stuck sequence logged exactly `[true]` (the initial open) and the card stayed open, proving the rejection branch was unreachable dead code for this bug. Rewritten against the actual mechanism.
- **Keyboard accessibility regression in the original approach.** Radix opens on `focus` → `onOpenChange(true)`, which *is* a real transition, so the stale latch swallowed it: once the pointer had passed over a card, a keyboard user could never open it again. Now covered by a passing regression test.
- **Over-closing (the dangerous failure mode).** The main risk of this class of fix is dismissing the card as the user moves onto it, making its contents unclickable. Guarded by the `enteredRef` arming condition plus the trigger-containment check, and pinned by three explicit tests including the `sideOffset` gap case.
- **Listener leak.** The `pointermove` listener is registered in an effect keyed on the content node and removed in its cleanup; a card unmounting (workspace deleted, list re-sorted) removes it. Asserted by a test comparing add/remove counts.
- **Layering.** Confirmed the defect is in the Radix primitive's contract, not the sidebar, so the fix belongs in `components/ui/hover-card.tsx` where it protects all six hover-card call sites.
- **No timer-based guard** was used — the fix is state/geometry-based, so it cannot flake on a slow machine or with slow mouse movement. Tests use `vi.useFakeTimers()`, never real timers.
- **Cross-platform (macOS / Linux / Windows):** explicitly verified — no shortcuts, labels, paths, shell behavior, or Electron platform-specific APIs are touched. The diff is standard DOM pointer-event code with no platform branches.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC risk. The change is confined to a renderer-side React component's pointer-event bookkeeping: it adds a `document` `pointermove` listener and dispatches a synthetic `pointerout` on a node this component owns. No new dependencies (deliberately avoided a `radix-ui/internal` import that nothing else in the repo uses, in favor of plain React refs). No user-controlled data reaches a sink. No follow-up needed.

## Notes

- The fix is in the shared primitive, so it changes dismissal behavior for **all** hover cards (sidebar workspace details, workspace ports, source-control variable chips, status-bar usage CTA, GitHub project rows). This is intentional — the same latent bug existed at every call site.
- This branch was rebuilt on current `main` and force-pushed. The original commits targeted `WorktreeCardMeta.tsx`, which `main` has since refactored (the badge row moved to `WorktreeCardMetaBadges.tsx`); the old head no longer imported cleanly. Previous head was `dd6b034`.
- The PR's original test passed identically on `origin/main` and on the PR head, so it did not demonstrate the fix; it has been replaced with a test that genuinely fails without the change.

Original patch by @fsdwen.
