### PR TITLE
test(main): deflake worktree-watch non-ENOENT readdir test with atomic EACCES injection

### DIFF
--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { appendFile, mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
-import { rmSync, writeFileSync } from 'node:fs'
+import { chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
@@ -349,30 +349,36 @@ describe('worktree git-common polling gate (non-darwin)', () => {
     })
   })
 
-  it('does not fabricate worktree deletions when the readdir fails non-ENOENT (transient)', async () => {
-    // Why: a transient readdir failure (EIO/ESTALE/EMFILE/ENOTDIR, network/SSH hiccup) must not be read
-    // as "every linked worktree removed". Simulate a non-ENOENT failure by replacing the worktrees dir
-    // with a file so readdir throws ENOTDIR; the known entry must NOT be reported deleted. On the old
-    // catch-all (entryPaths = []) this emitted a false delete for every entry.
-    const commonDir = await makePollingCommonDir()
-    const entry = join(commonDir, 'worktrees', 'keep')
-    await mkdir(entry)
-    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
-    const received: WorktreeBasePollEvent[][] = []
-    await startPollingWatch(commonDir, received)
+  // Why runIf: chmod 0 cannot revoke directory listing on Windows or for root, so the EACCES injection is inert there.
+  it.runIf(process.platform !== 'win32' && process.getuid?.() !== 0)(
+    'does not fabricate worktree deletions when the readdir fails non-ENOENT (transient)',
+    async () => {
+      // Why: a transient readdir failure (EIO/ESTALE/EMFILE/EACCES, network/SSH hiccup) must not be read
+      // as "every linked worktree removed". Revoke dir permissions so readdir throws EACCES; the known
+      // entry must NOT be reported deleted. On the old catch-all (entryPaths = []) this emitted a false
+      // delete for every entry. chmod (not a dir->file swap) because it is one atomic syscall: an
+      // in-flight tick's threadpool readdir sees success or EACCES, never a transient ENOENT window
+      // that would legitimately emit a delete and flake this assertion.
+      const commonDir = await makePollingCommonDir()
+      const entry = join(commonDir, 'worktrees', 'keep')
+      await mkdir(entry)
+      await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
+      const received: WorktreeBasePollEvent[][] = []
+      await startPollingWatch(commonDir, received)
 
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
-    const worktreesDir = join(commonDir, 'worktrees')
-    // Swap dir -> file synchronously so no event-loop turn (and thus no poll
-    // tick) observes the transient ENOENT window, which would legitimately emit
-    // a delete and defeat the non-ENOENT assertion below.
-    rmSync(worktreesDir, { recursive: true, force: true })
-    writeFileSync(worktreesDir, 'not-a-dir')
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
+      await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+      const worktreesDir = join(commonDir, 'worktrees')
+      chmodSync(worktreesDir, 0o000)
+      try {
+        await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
+      } finally {
+        // Why: restore before cleanup so the afterEach recursive rm can traverse the dir.
+        chmodSync(worktreesDir, 0o755)
+      }
 
-    expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })
-    await rm(worktreesDir, { force: true })
-  })
+      expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })
+    }
+  )
 
   it('detects an in-place structural (HEAD) write on a known entry every tick, without the index backstop', async () => {
     // Why: a raw HEAD/gitdir/config.worktree rewrite does not bump the entry-dir mtime, so the


### PR DESCRIPTION
## Summary

Deflakes `worktree-git-common-watch.test.ts > does not fabricate worktree deletions when the readdir fails non-ENOENT (transient)`, which failed `verify` on #9970's CI run ([failed job](https://github.com/stablyai/orca/actions/runs/30054734825/job/89363984712)) and passed on rerun.

## The race

The test simulated a non-ENOENT readdir failure by replacing the worktrees dir with a file (`rmSync` + `writeFileSync`), reasoning that a synchronous swap leaves no event-loop turn to observe the transient ENOENT window. That reasoning misses libuv threadpool concurrency: an in-flight poll tick's async `opendir` executes on a worker thread and can land in the wall-clock window **between** the two sync calls. It then legitimately observes ENOENT (dir gone = all worktrees removed) and emits exactly the `delete keep` + `update worktrees` events seen in the CI failure.

There is no atomic way to replace a non-empty directory with a file, so the window cannot be closed by reordering.

## The fix

Inject the failure with `chmodSync(worktreesDir, 0o000)` instead — one atomic syscall, zero ENOENT window. A concurrent `opendir` observes either success or EACCES, never ENOENT, and EACCES exercises the same retain-previous-entries branch in `snapshotGitCommon` that the test protects. Gated with `it.runIf` off Windows and root, where chmod 0 cannot revoke directory listing and the injection would be inert.

## Validation

- Mutation check: with the non-ENOENT guard in `worktree-git-common-snapshot.ts` temporarily broken (old catch-all behavior), the reworked test fails — it still catches the regression it exists for.
- 30 consecutive runs of the test: 0 failures.
- Full file 14/14 passing; `tsc --noEmit -p config/tsconfig.node.json` clean; oxlint clean.

## Notes

- Test-only change; no production code touched.
- `process.getuid?.()` optional-chaining keeps the gate expression portable on Windows, where the API is absent.