### PR TITLE
feat(windows): enable native Snap Layouts

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -1983,52 +1983,61 @@ describe('createMainWindow', () => {
     expect(destroy).not.toHaveBeenCalled()
   })
 
-  it('ignores traffic light sync IPC on non-macOS', () => {
-    const windowHandlers: Record<string, (...args: any[]) => void> = {}
-    const webContents = {
-      on: vi.fn((event, handler) => {
-        windowHandlers[event] = handler
-      }),
-      setZoomLevel: vi.fn(),
-      setBackgroundThrottling: vi.fn(),
-      invalidate: vi.fn(),
-      setWindowOpenHandler: vi.fn(),
-      send: vi.fn()
+  it('syncs native window chrome with UI zoom by platform', () => {
+    for (const platform of ['darwin', 'win32', 'linux'] satisfies NodeJS.Platform[]) {
+      browserWindowMock.mockReset()
+      vi.mocked(ipcMain.on).mockReset()
+      const webContents = {
+        on: vi.fn(),
+        setZoomLevel: vi.fn(),
+        setBackgroundThrottling: vi.fn(),
+        invalidate: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
+        send: vi.fn()
+      }
+      const browserWindowInstance = {
+        webContents,
+        on: vi.fn(),
+        isDestroyed: vi.fn(() => false),
+        isMaximized: vi.fn(() => true),
+        isFullScreen: vi.fn(() => false),
+        getSize: vi.fn(() => [1200, 800]),
+        setSize: vi.fn(),
+        setWindowButtonPosition: vi.fn(),
+        setTitleBarOverlay: vi.fn(),
+        maximize: vi.fn(),
+        show: vi.fn(),
+        loadFile: vi.fn(),
+        loadURL: vi.fn()
+      }
+      browserWindowMock.mockImplementation(function () {
+        return browserWindowInstance
+      })
+
+      withPlatform(platform, () => {
+        createMainWindow(null)
+        const syncListener = vi
+          .mocked(ipcMain.on)
+          .mock.calls.find(([channel]) => channel === 'ui:sync-window-chrome')?.[1]
+
+        expect(syncListener).toBeTypeOf('function')
+        syncListener?.({} as never, 1.2)
+      })
+
+      if (platform === 'darwin') {
+        expect(browserWindowInstance.setWindowButtonPosition).toHaveBeenCalledWith({
+          x: 16,
+          y: 16
+        })
+      } else {
+        expect(browserWindowInstance.setWindowButtonPosition).not.toHaveBeenCalled()
+      }
+      if (platform === 'win32') {
+        expect(browserWindowInstance.setTitleBarOverlay).toHaveBeenCalledWith({ height: 43 })
+      } else {
+        expect(browserWindowInstance.setTitleBarOverlay).not.toHaveBeenCalled()
+      }
     }
-    const browserWindowInstance = {
-      webContents,
-      on: vi.fn(),
-      isDestroyed: vi.fn(() => false),
-      isMaximized: vi.fn(() => true),
-      isFullScreen: vi.fn(() => false),
-      getSize: vi.fn(() => [1200, 800]),
-      setSize: vi.fn(),
-      setWindowButtonPosition: vi.fn(),
-      maximize: vi.fn(),
-      show: vi.fn(),
-      loadFile: vi.fn(),
-      loadURL: vi.fn()
-    }
-    browserWindowMock.mockImplementation(function () {
-      return browserWindowInstance
-    })
-
-    createMainWindow(null)
-
-    const syncListener = vi
-      .mocked(ipcMain.on)
-      .mock.calls.find(([channel]) => channel === 'ui:sync-traffic-lights')?.[1]
-
-    expect(syncListener).toBeTypeOf('function')
-
-    syncListener?.({} as never, 1.2)
-
-    if (process.platform === 'darwin') {
-      expect(browserWindowInstance.setWindowButtonPosition).toHaveBeenCalledWith({ x: 16, y: 16 })
-      return
-    }
-
-    expect(browserWindowInstance.setWindowButtonPosition).not.toHaveBeenCalled()
   })
 
   it('intercepts Cmd+B for sidebar when the markdown editor is not focused', () => {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -195,7 +195,8 @@ describe('createMainWindow', () => {
       })
     } else if (process.platform === 'win32') {
       expect(browserWindowOptions).toMatchObject({
-        titleBarStyle: 'hidden'
+        titleBarStyle: 'hidden',
+        titleBarOverlay: { height: 36 }
       })
     } else {
       // Linux: native frame is dropped so the renderer titlebar isn't stacked
@@ -265,12 +266,16 @@ describe('createMainWindow', () => {
 
   it('sets platform-specific titlebar and frame options for every desktop platform', () => {
     for (const [platform, expected] of [
-      ['darwin', { titleBarStyle: 'hiddenInset', frame: undefined }],
-      ['win32', { titleBarStyle: 'hidden', frame: undefined }],
-      ['linux', { titleBarStyle: undefined, frame: false }]
+      ['darwin', { titleBarStyle: 'hiddenInset', titleBarOverlay: undefined, frame: undefined }],
+      ['win32', { titleBarStyle: 'hidden', titleBarOverlay: { height: 36 }, frame: undefined }],
+      ['linux', { titleBarStyle: undefined, titleBarOverlay: undefined, frame: false }]
     ] satisfies [
       NodeJS.Platform,
-      { titleBarStyle: string | undefined; frame: boolean | undefined }
+      {
+        titleBarStyle: string | undefined
+        titleBarOverlay: { height: number } | undefined
+        frame: boolean | undefined
+      }
     ][]) {
       browserWindowMock.mockReset()
       const webContents = {
@@ -306,6 +311,7 @@ describe('createMainWindow', () => {
 
       const browserWindowOptions = browserWindowMock.mock.calls[0]?.[0]
       expect(browserWindowOptions.titleBarStyle).toBe(expected.titleBarStyle)
+      expect(browserWindowOptions.titleBarOverlay).toEqual(expected.titleBarOverlay)
       expect(browserWindowOptions.frame).toBe(expected.frame)
     }
   })

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2068,7 +2068,7 @@ describe('createMainWindow', () => {
         nativeThemeMock.shouldUseDarkColors = true
         withPlatform(platform, () => themeListener?.())
         expect(browserWindowInstance.setTitleBarOverlay).toHaveBeenLastCalledWith({
-          color: '#0a0a0a',
+          color: '#171717',
           symbolColor: '#fafafa',
           height: 43
         })

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2066,7 +2066,7 @@ describe('createMainWindow', () => {
         )?.[1]
         expect(themeListener).toBeTypeOf('function')
         nativeThemeMock.shouldUseDarkColors = true
-        themeListener?.()
+        withPlatform(platform, () => themeListener?.())
         expect(browserWindowInstance.setTitleBarOverlay).toHaveBeenLastCalledWith({
           color: '#0a0a0a',
           symbolColor: '#fafafa',

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -9,6 +9,9 @@ const {
   menuPopupMock,
   notificationMock,
   notificationShowMock,
+  nativeThemeMock,
+  nativeThemeOnMock,
+  nativeThemeRemoveListenerMock,
   powerMonitorOnMock,
   powerMonitorRemoveListenerMock,
   isMock,
@@ -16,6 +19,13 @@ const {
 } = vi.hoisted(() => {
   const menuPopupMock = vi.fn()
   const notificationShowMock = vi.fn()
+  const nativeThemeOnMock = vi.fn()
+  const nativeThemeRemoveListenerMock = vi.fn()
+  const nativeThemeMock = {
+    shouldUseDarkColors: false,
+    on: nativeThemeOnMock,
+    removeListener: nativeThemeRemoveListenerMock
+  }
   return {
     browserWindowMock: vi.fn(),
     openExternalMock: vi.fn(),
@@ -26,6 +36,9 @@ const {
       return { show: notificationShowMock }
     }),
     notificationShowMock,
+    nativeThemeMock,
+    nativeThemeOnMock,
+    nativeThemeRemoveListenerMock,
     powerMonitorOnMock: vi.fn(),
     powerMonitorRemoveListenerMock: vi.fn(),
     isMock: { dev: false },
@@ -39,7 +52,7 @@ vi.mock('electron', () => ({
   ipcMain: { on: vi.fn(), removeListener: vi.fn(), handle: vi.fn(), removeHandler: vi.fn() },
   Menu: { buildFromTemplate: buildFromTemplateMock },
   Notification: notificationMock,
-  nativeTheme: { shouldUseDarkColors: false },
+  nativeTheme: nativeThemeMock,
   powerMonitor: { on: powerMonitorOnMock, removeListener: powerMonitorRemoveListenerMock },
   screen: {
     getPrimaryDisplay: () => ({ workAreaSize: { width: 1440, height: 900 } })
@@ -93,6 +106,9 @@ describe('createMainWindow', () => {
     menuPopupMock.mockClear()
     notificationMock.mockClear()
     notificationShowMock.mockClear()
+    nativeThemeMock.shouldUseDarkColors = false
+    nativeThemeOnMock.mockReset()
+    nativeThemeRemoveListenerMock.mockReset()
     powerMonitorOnMock.mockReset()
     powerMonitorRemoveListenerMock.mockReset()
     isMock.dev = false
@@ -196,7 +212,7 @@ describe('createMainWindow', () => {
     } else if (process.platform === 'win32') {
       expect(browserWindowOptions).toMatchObject({
         titleBarStyle: 'hidden',
-        titleBarOverlay: { height: 36 }
+        titleBarOverlay: { color: '#ffffff', symbolColor: '#0a0a0a', height: 36 }
       })
     } else {
       // Linux: native frame is dropped so the renderer titlebar isn't stacked
@@ -267,13 +283,20 @@ describe('createMainWindow', () => {
   it('sets platform-specific titlebar and frame options for every desktop platform', () => {
     for (const [platform, expected] of [
       ['darwin', { titleBarStyle: 'hiddenInset', titleBarOverlay: undefined, frame: undefined }],
-      ['win32', { titleBarStyle: 'hidden', titleBarOverlay: { height: 36 }, frame: undefined }],
+      [
+        'win32',
+        {
+          titleBarStyle: 'hidden',
+          titleBarOverlay: { color: '#ffffff', symbolColor: '#0a0a0a', height: 36 },
+          frame: undefined
+        }
+      ],
       ['linux', { titleBarStyle: undefined, titleBarOverlay: undefined, frame: false }]
     ] satisfies [
       NodeJS.Platform,
       {
         titleBarStyle: string | undefined
-        titleBarOverlay: { height: number } | undefined
+        titleBarOverlay: { color: string; symbolColor: string; height: number } | undefined
         frame: boolean | undefined
       }
     ][]) {
@@ -2033,7 +2056,23 @@ describe('createMainWindow', () => {
         expect(browserWindowInstance.setWindowButtonPosition).not.toHaveBeenCalled()
       }
       if (platform === 'win32') {
-        expect(browserWindowInstance.setTitleBarOverlay).toHaveBeenCalledWith({ height: 43 })
+        expect(browserWindowInstance.setTitleBarOverlay).toHaveBeenCalledWith({
+          color: '#ffffff',
+          symbolColor: '#0a0a0a',
+          height: 43
+        })
+        const themeListener = nativeThemeOnMock.mock.calls.find(
+          ([event]) => event === 'updated'
+        )?.[1]
+        expect(themeListener).toBeTypeOf('function')
+        nativeThemeMock.shouldUseDarkColors = true
+        themeListener?.()
+        expect(browserWindowInstance.setTitleBarOverlay).toHaveBeenLastCalledWith({
+          color: '#0a0a0a',
+          symbolColor: '#fafafa',
+          height: 43
+        })
+        nativeThemeMock.shouldUseDarkColors = false
       } else {
         expect(browserWindowInstance.setTitleBarOverlay).not.toHaveBeenCalled()
       }
@@ -3330,13 +3369,19 @@ describe('createMainWindow', () => {
     })
 
     it('removes the powerMonitor resume listener when the window closes', () => {
-      const { windowHandlers } = setupResumeWindow()
-      createMainWindow(null)
-      const onResume = getPowerResumeListener()
+      withPlatform('win32', () => {
+        const { windowHandlers } = setupResumeWindow()
+        createMainWindow(null)
+        const onResume = getPowerResumeListener()
+        const onNativeThemeUpdated = nativeThemeOnMock.mock.calls.find(
+          ([event]) => event === 'updated'
+        )?.[1]
 
-      windowHandlers.closed()
+        windowHandlers.closed()
 
-      expect(powerMonitorRemoveListenerMock).toHaveBeenCalledWith('resume', onResume)
+        expect(powerMonitorRemoveListenerMock).toHaveBeenCalledWith('resume', onResume)
+        expect(nativeThemeRemoveListenerMock).toHaveBeenCalledWith('updated', onNativeThemeUpdated)
+      })
     })
   })
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -136,12 +136,16 @@ const TRAFFIC_LIGHT_X = 16
 const MIN_WIDTH = 600
 const MIN_HEIGHT = 400
 
-function syncTrafficLightPosition(win: BrowserWindow, zoomFactor: number): void {
-  if (process.platform !== 'darwin' || win.isDestroyed()) {
+function syncWindowChrome(win: BrowserWindow, zoomFactor: number): void {
+  if (win.isDestroyed()) {
     return
   }
-  const y = Math.round(TITLEBAR_CSS_CENTER * zoomFactor - TRAFFIC_LIGHT_RADIUS)
-  win.setWindowButtonPosition({ x: TRAFFIC_LIGHT_X, y })
+  if (process.platform === 'darwin') {
+    const y = Math.round(TITLEBAR_CSS_CENTER * zoomFactor - TRAFFIC_LIGHT_RADIUS)
+    win.setWindowButtonPosition({ x: TRAFFIC_LIGHT_X, y })
+  } else if (process.platform === 'win32') {
+    win.setTitleBarOverlay({ height: Math.round(TITLEBAR_CSS_HEIGHT * zoomFactor) })
+  }
 }
 
 type CreateMainWindowOptions = {
@@ -258,7 +262,7 @@ export function createMainWindow(
       : {}),
     // Why: Linux ignores titleBarStyle 'hidden'; frame:false drops the native frame so we don't get a double title bar (renderer draws its own).
     ...(process.platform === 'linux' ? { frame: false } : {}),
-    // Why: initial position for 1x zoom; syncTrafficLightPosition() adjusts on zoom change.
+    // Why: initial position for 1x zoom; syncWindowChrome() adjusts on zoom change.
     ...(process.platform === 'darwin'
       ? {
           trafficLightPosition: {
@@ -298,10 +302,9 @@ export function createMainWindow(
   mainWindow.webContents.on('dom-ready', () => {
     const level = store?.getUI().uiZoomLevel ?? 0
     mainWindow.webContents.setZoomLevel(level)
-    // Why: native traffic lights don't scale with CSS zoom; reposition on startup to stay aligned with the zoomed titlebar.
-    if (process.platform === 'darwin') {
-      syncTrafficLightPosition(mainWindow, Math.pow(1.2, level))
-    }
+    // Why: native window controls don't scale with webFrame zoom; keep their
+    // platform chrome aligned with the restored CSS titlebar height.
+    syncWindowChrome(mainWindow, Math.pow(1.2, level))
   })
 
   // Why: macOS+Electron 41 re-emits ready-to-show on webview-guest creation; a one-shot guard stops re-running maximize() after resize (#591).
@@ -994,11 +997,11 @@ export function createMainWindow(
       mainWindow.close()
     }
   }
-  const trafficLightChannel = 'ui:sync-traffic-lights'
-  const onSyncTrafficLights = (_event: Electron.IpcMainEvent, zoomFactor: number): void => {
-    syncTrafficLightPosition(mainWindow, zoomFactor)
+  const windowChromeChannel = 'ui:sync-window-chrome'
+  const onSyncWindowChrome = (_event: Electron.IpcMainEvent, zoomFactor: number): void => {
+    syncWindowChrome(mainWindow, zoomFactor)
   }
-  ipcMain.on(trafficLightChannel, onSyncTrafficLights)
+  ipcMain.on(windowChromeChannel, onSyncWindowChrome)
 
   // Why: renderer-drawn window controls on Windows/Linux replicate the native title-bar buttons hidden by custom chrome.
   const minimizeChannel = 'window:minimize'
@@ -1061,7 +1064,7 @@ export function createMainWindow(
     floatingTerminalInputFocused = false
     shortcutRecorderFocused = false
     clearRendererRecoveryTimer()
-    ipcMain.removeListener(trafficLightChannel, onSyncTrafficLights)
+    ipcMain.removeListener(windowChromeChannel, onSyncWindowChrome)
     ipcMain.removeListener(minimizeChannel, onMinimize)
     ipcMain.removeListener(maximizeChannel, onMaximize)
     browserManager.setDictationShortcutForwardingPredicate(null)

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -130,6 +130,7 @@ function isMacAppPasteInput(input: Electron.Input): boolean {
 
 // Why: titlebar content center sits ~18 CSS px from top (×zoom); traffic lights are ~12px tall, so top edge = center − 6.
 const TITLEBAR_CSS_CENTER = 18
+const TITLEBAR_CSS_HEIGHT = TITLEBAR_CSS_CENTER * 2
 const TRAFFIC_LIGHT_RADIUS = 6
 const TRAFFIC_LIGHT_X = 16
 const MIN_WIDTH = 600
@@ -245,6 +246,16 @@ export function createMainWindow(
         : process.platform === 'win32'
           ? 'hidden'
           : undefined,
+    // Why: Windows needs a real native maximize caption button for the Windows 11
+    // Snap Layout hover menu. The overlay preserves our custom titlebar content
+    // while letting Windows own min/max/close hit-testing and system behavior.
+    ...(process.platform === 'win32'
+      ? {
+          titleBarOverlay: {
+            height: TITLEBAR_CSS_HEIGHT
+          }
+        }
+      : {}),
     // Why: Linux ignores titleBarStyle 'hidden'; frame:false drops the native frame so we don't get a double title bar (renderer draws its own).
     ...(process.platform === 'linux' ? { frame: false } : {}),
     // Why: initial position for 1x zoom; syncTrafficLightPosition() adjusts on zoom change.

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -136,14 +136,19 @@ const TRAFFIC_LIGHT_X = 16
 const MIN_WIDTH = 600
 const MIN_HEIGHT = 400
 
-// Why: native WCO cannot read CSS variables; mirror --background/--foreground from main.css.
+// Why: BrowserWindow cannot read CSS variables before the renderer loads; mirror --background.
 function getWindowBackgroundColor(): string {
   return nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff'
 }
 
+// Why: native WCO cannot read CSS variables; mirror the --card titlebar surface from main.css.
+function getWindowTitleBarColor(): string {
+  return nativeTheme.shouldUseDarkColors ? '#171717' : '#ffffff'
+}
+
 function getWindowsTitleBarOverlay(height: number): Electron.TitleBarOverlayOptions {
   return {
-    color: getWindowBackgroundColor(),
+    color: getWindowTitleBarColor(),
     symbolColor: nativeTheme.shouldUseDarkColors ? '#fafafa' : '#0a0a0a',
     height
   }

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -136,6 +136,19 @@ const TRAFFIC_LIGHT_X = 16
 const MIN_WIDTH = 600
 const MIN_HEIGHT = 400
 
+// Why: native WCO cannot read CSS variables; mirror --background/--foreground from main.css.
+function getWindowBackgroundColor(): string {
+  return nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff'
+}
+
+function getWindowsTitleBarOverlay(height: number): Electron.TitleBarOverlayOptions {
+  return {
+    color: getWindowBackgroundColor(),
+    symbolColor: nativeTheme.shouldUseDarkColors ? '#fafafa' : '#0a0a0a',
+    height
+  }
+}
+
 function syncWindowChrome(win: BrowserWindow, zoomFactor: number): void {
   if (win.isDestroyed()) {
     return
@@ -144,7 +157,7 @@ function syncWindowChrome(win: BrowserWindow, zoomFactor: number): void {
     const y = Math.round(TITLEBAR_CSS_CENTER * zoomFactor - TRAFFIC_LIGHT_RADIUS)
     win.setWindowButtonPosition({ x: TRAFFIC_LIGHT_X, y })
   } else if (process.platform === 'win32') {
-    win.setTitleBarOverlay({ height: Math.round(TITLEBAR_CSS_HEIGHT * zoomFactor) })
+    win.setTitleBarOverlay(getWindowsTitleBarOverlay(Math.round(TITLEBAR_CSS_HEIGHT * zoomFactor)))
   }
 }
 
@@ -242,7 +255,7 @@ export function createMainWindow(
     acceptFirstMouse: true,
     // Why: auto-hide the Windows/Linux menu bar to save a row (Alt reveals it); macOS uses the system menu bar anyway.
     autoHideMenuBar: true,
-    backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
+    backgroundColor: getWindowBackgroundColor(),
     // Why: macOS 'hiddenInset' keeps native traffic lights in our custom titlebar; Windows 'hidden' removes the OS title bar so it doesn't double up.
     titleBarStyle:
       process.platform === 'darwin'
@@ -255,9 +268,7 @@ export function createMainWindow(
     // while letting Windows own min/max/close hit-testing and system behavior.
     ...(process.platform === 'win32'
       ? {
-          titleBarOverlay: {
-            height: TITLEBAR_CSS_HEIGHT
-          }
+          titleBarOverlay: getWindowsTitleBarOverlay(TITLEBAR_CSS_HEIGHT)
         }
       : {}),
     // Why: Linux ignores titleBarStyle 'hidden'; frame:false drops the native frame so we don't get a double title bar (renderer draws its own).
@@ -299,12 +310,21 @@ export function createMainWindow(
   }
   powerMonitor.on('resume', onSystemResume)
 
+  let windowChromeZoomFactor = 1
+  const onNativeThemeUpdated = (): void => {
+    syncWindowChrome(mainWindow, windowChromeZoomFactor)
+  }
+  if (process.platform === 'win32') {
+    nativeTheme.on('updated', onNativeThemeUpdated)
+  }
+
   mainWindow.webContents.on('dom-ready', () => {
     const level = store?.getUI().uiZoomLevel ?? 0
     mainWindow.webContents.setZoomLevel(level)
+    windowChromeZoomFactor = Math.pow(1.2, level)
     // Why: native window controls don't scale with webFrame zoom; keep their
     // platform chrome aligned with the restored CSS titlebar height.
-    syncWindowChrome(mainWindow, Math.pow(1.2, level))
+    syncWindowChrome(mainWindow, windowChromeZoomFactor)
   })
 
   // Why: macOS+Electron 41 re-emits ready-to-show on webview-guest creation; a one-shot guard stops re-running maximize() after resize (#591).
@@ -999,6 +1019,7 @@ export function createMainWindow(
   }
   const windowChromeChannel = 'ui:sync-window-chrome'
   const onSyncWindowChrome = (_event: Electron.IpcMainEvent, zoomFactor: number): void => {
+    windowChromeZoomFactor = zoomFactor
     syncWindowChrome(mainWindow, zoomFactor)
   }
   ipcMain.on(windowChromeChannel, onSyncWindowChrome)
@@ -1064,6 +1085,9 @@ export function createMainWindow(
     floatingTerminalInputFocused = false
     shortcutRecorderFocused = false
     clearRendererRecoveryTimer()
+    if (process.platform === 'win32') {
+      nativeTheme.removeListener('updated', onNativeThemeUpdated)
+    }
     ipcMain.removeListener(windowChromeChannel, onSyncWindowChrome)
     ipcMain.removeListener(minimizeChannel, onMinimize)
     ipcMain.removeListener(maximizeChannel, onMaximize)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3033,7 +3033,7 @@ export type PreloadApi = {
     onFileDrop: (callback: (data: NativeFileDropPayload) => void) => () => void
     getZoomLevel: () => number
     setZoomLevel: (level: number) => void
-    syncTrafficLights: (zoomFactor: number) => void
+    syncWindowChrome: (zoomFactor: number) => void
     setMarkdownEditorFocused: (focused: boolean) => void
     setTerminalInputFocused: (focused: boolean) => void
     setFloatingTerminalInputFocused: (focused: boolean) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3813,8 +3813,8 @@ const api = {
       subscribeNativeFileDrop(callback),
     getZoomLevel: (): number => webFrame.getZoomLevel(),
     setZoomLevel: (level: number): void => webFrame.setZoomLevel(level),
-    syncTrafficLights: (zoomFactor: number): void =>
-      ipcRenderer.send('ui:sync-traffic-lights', zoomFactor),
+    syncWindowChrome: (zoomFactor: number): void =>
+      ipcRenderer.send('ui:sync-window-chrome', zoomFactor),
     // Why: one-way send so main's before-input-event can synchronously skip Cmd+B while the markdown editor is focused (TipTap bold).
     setMarkdownEditorFocused: (focused: boolean): void => {
       ipcRenderer.send('ui:setMarkdownEditorFocused', focused)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -27,6 +27,7 @@ import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import {
   isPairedWebClientWindow,
+  shouldRenderCustomWindowControls,
   shouldRenderDesktopWindowChrome
 } from '@/lib/desktop-window-chrome'
 import { resolveLeftTitlebarChromeLayout } from '@/lib/titlebar-left-chrome'
@@ -209,10 +210,18 @@ const SLEEPING_AGENT_RESUME_CAPTURE_INTERVAL_MS = 60_000
 const isMac = navigator.userAgent.includes('Mac')
 const isWindows = !isMac && navigator.userAgent.includes('Windows')
 const shortcutPlatform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
-// Why: Windows and Linux remove the native title bar so the renderer draws its own chrome; paired web clients run in a browser tab and must not.
+const isWebClient = isPairedWebClientWindow()
+// Why: Windows and Linux both place app content in the titlebar area; paired
+// web clients run in a browser tab and must not reserve desktop chrome.
 const hasCustomTitleBar = shouldRenderDesktopWindowChrome({
   platform: shortcutPlatform,
-  isWebClient: isPairedWebClientWindow()
+  isWebClient
+})
+// Why: Windows uses Electron's native Window Controls Overlay for Win11 Snap
+// Layouts. Only frameless Linux still needs renderer-drawn caption buttons.
+const hasCustomWindowControls = shouldRenderCustomWindowControls({
+  platform: shortcutPlatform,
+  isWebClient
 })
 
 async function listRuntimeSessionHostIdsForStartup(): Promise<ExecutionHostId[]> {
@@ -246,7 +255,8 @@ type ShortcutDispatchInput = {
   preventDefault: () => void
 }
 
-// Why: Windows and Linux both remove the native title bar, so we render our own min/max/close buttons (Fluent/Win11-style SVGs).
+// Why: frameless Linux has no native caption buttons, so render our own
+// min/max/close controls. Windows uses the native Window Controls Overlay.
 function WindowControls(): React.JSX.Element {
   const [maximized, setMaximized] = useState(false)
   useEffect(() => {
@@ -2626,8 +2636,8 @@ function App(): React.JSX.Element {
       <Toaster closeButton toastOptions={{ className: 'font-sans text-sm' }} />
       <SkillFreshnessNudge />
       <PinnedTabCloseDialog />
-      {/* Why: Electron's drag-region hit-test is DOM-order-based (ignores z-index); render last so WindowControls stay clickable. */}
-      {hasCustomTitleBar && <WindowControls />}
+      {/* Why: Electron's drag-region hit-test is DOM-order-based (ignores z-index); render last so Linux WindowControls stay clickable. */}
+      {hasCustomWindowControls && <WindowControls />}
     </div>
   )
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -27,6 +27,7 @@ import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { canShowRightSidebarForView } from '@/lib/right-sidebar-visibility'
 import {
   isPairedWebClientWindow,
+  resolveWindowControlsWidth,
   shouldRenderCustomWindowControls,
   shouldRenderDesktopWindowChrome
 } from '@/lib/desktop-window-chrome'
@@ -220,6 +221,10 @@ const hasCustomTitleBar = shouldRenderDesktopWindowChrome({
 // Why: Windows uses Electron's native Window Controls Overlay for Win11 Snap
 // Layouts. Only frameless Linux still needs renderer-drawn caption buttons.
 const hasCustomWindowControls = shouldRenderCustomWindowControls({
+  platform: shortcutPlatform,
+  isWebClient
+})
+const windowControlsWidth = resolveWindowControlsWidth({
   platform: shortcutPlatform,
   isWebClient
 })
@@ -2081,7 +2086,7 @@ function App(): React.JSX.Element {
         {
           '--collapsed-sidebar-header-width': `${collapsedSidebarHeaderWidth}px`,
           // Shared so surfaces can avoid the Windows/Linux window-controls overlay without hardcoding 138px everywhere.
-          '--window-controls-width': hasCustomTitleBar ? '138px' : '0px',
+          '--window-controls-width': windowControlsWidth,
           // Side-position activity bar uses this to push icons below the Windows/Linux window-controls overlay.
           '--window-controls-height': hasCustomTitleBar ? '36px' : '0px'
         } as React.CSSProperties

--- a/src/renderer/src/lib/desktop-window-chrome.test.ts
+++ b/src/renderer/src/lib/desktop-window-chrome.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  resolveWindowControlsWidth,
   shouldRenderCustomWindowControls,
   shouldRenderDesktopWindowChrome
 } from './desktop-window-chrome'
@@ -29,5 +30,22 @@ describe('shouldRenderCustomWindowControls', () => {
 
   it('does not render desktop controls in the paired web client', () => {
     expect(shouldRenderCustomWindowControls({ platform: 'linux', isWebClient: true })).toBe(false)
+  })
+})
+
+describe('resolveWindowControlsWidth', () => {
+  it('keeps native Windows controls fixed-width across UI zoom', () => {
+    expect(resolveWindowControlsWidth({ platform: 'win32', isWebClient: false })).toBe(
+      'calc(138px / var(--ui-zoom-factor, 1))'
+    )
+  })
+
+  it('keeps renderer controls in the zoomed Linux layout', () => {
+    expect(resolveWindowControlsWidth({ platform: 'linux', isWebClient: false })).toBe('138px')
+  })
+
+  it('does not reserve controls outside custom desktop chrome', () => {
+    expect(resolveWindowControlsWidth({ platform: 'darwin', isWebClient: false })).toBe('0px')
+    expect(resolveWindowControlsWidth({ platform: 'win32', isWebClient: true })).toBe('0px')
   })
 })

--- a/src/renderer/src/lib/desktop-window-chrome.test.ts
+++ b/src/renderer/src/lib/desktop-window-chrome.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { shouldRenderDesktopWindowChrome } from './desktop-window-chrome'
+import {
+  shouldRenderCustomWindowControls,
+  shouldRenderDesktopWindowChrome
+} from './desktop-window-chrome'
 
 describe('shouldRenderDesktopWindowChrome', () => {
-  it('renders custom chrome for frameless desktop Linux and Windows windows', () => {
+  it('reserves custom titlebar content for desktop Linux and Windows windows', () => {
     expect(shouldRenderDesktopWindowChrome({ platform: 'linux', isWebClient: false })).toBe(true)
     expect(shouldRenderDesktopWindowChrome({ platform: 'win32', isWebClient: false })).toBe(true)
   })
@@ -14,5 +17,17 @@ describe('shouldRenderDesktopWindowChrome', () => {
   it('does not render desktop-only window controls in the paired web client', () => {
     expect(shouldRenderDesktopWindowChrome({ platform: 'linux', isWebClient: true })).toBe(false)
     expect(shouldRenderDesktopWindowChrome({ platform: 'win32', isWebClient: true })).toBe(false)
+  })
+})
+
+describe('shouldRenderCustomWindowControls', () => {
+  it('uses renderer controls only for frameless Linux', () => {
+    expect(shouldRenderCustomWindowControls({ platform: 'linux', isWebClient: false })).toBe(true)
+    expect(shouldRenderCustomWindowControls({ platform: 'win32', isWebClient: false })).toBe(false)
+    expect(shouldRenderCustomWindowControls({ platform: 'darwin', isWebClient: false })).toBe(false)
+  })
+
+  it('does not render desktop controls in the paired web client', () => {
+    expect(shouldRenderCustomWindowControls({ platform: 'linux', isWebClient: true })).toBe(false)
   })
 })

--- a/src/renderer/src/lib/desktop-window-chrome.ts
+++ b/src/renderer/src/lib/desktop-window-chrome.ts
@@ -13,3 +13,13 @@ export function shouldRenderDesktopWindowChrome({
 }: DesktopWindowChromeInput): boolean {
   return !isWebClient && (platform === 'win32' || platform === 'linux')
 }
+
+export function shouldRenderCustomWindowControls({
+  platform,
+  isWebClient
+}: DesktopWindowChromeInput): boolean {
+  // Why: Windows uses Electron's native Window Controls Overlay so the
+  // maximize button exposes Windows 11 Snap Layouts. Frameless Linux still
+  // needs the renderer-drawn min/max/close controls.
+  return !isWebClient && platform === 'linux'
+}

--- a/src/renderer/src/lib/desktop-window-chrome.ts
+++ b/src/renderer/src/lib/desktop-window-chrome.ts
@@ -23,3 +23,14 @@ export function shouldRenderCustomWindowControls({
   // needs the renderer-drawn min/max/close controls.
   return !isWebClient && platform === 'linux'
 }
+
+export function resolveWindowControlsWidth({
+  platform,
+  isWebClient
+}: DesktopWindowChromeInput): string {
+  if (!shouldRenderDesktopWindowChrome({ platform, isWebClient })) {
+    return '0px'
+  }
+  // Why: webFrame zoom scales CSS pixels while Windows native caption buttons stay fixed-width.
+  return platform === 'win32' ? 'calc(138px / var(--ui-zoom-factor, 1))' : '138px'
+}

--- a/src/renderer/src/lib/ui-zoom.test.ts
+++ b/src/renderer/src/lib/ui-zoom.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+type ZoomMocks = {
+  getZoomLevel: ReturnType<typeof vi.fn>
+  setProperty: ReturnType<typeof vi.fn>
+  setZoomLevel: ReturnType<typeof vi.fn>
+  syncWindowChrome: ReturnType<typeof vi.fn>
+}
+
+type UIZoomModule = {
+  applyUIZoom: (level: number) => void
+  syncZoomCSSVar: () => void
+}
+
+async function loadUIZoom(
+  userAgent: string,
+  currentLevel = 0
+): Promise<{
+  module: UIZoomModule
+  mocks: ZoomMocks
+}> {
+  vi.resetModules()
+  const mocks: ZoomMocks = {
+    getZoomLevel: vi.fn(() => currentLevel),
+    setProperty: vi.fn(),
+    setZoomLevel: vi.fn(),
+    syncWindowChrome: vi.fn()
+  }
+  vi.stubGlobal('navigator', { userAgent })
+  vi.stubGlobal('window', {
+    api: {
+      ui: {
+        getZoomLevel: mocks.getZoomLevel,
+        setZoomLevel: mocks.setZoomLevel,
+        syncWindowChrome: mocks.syncWindowChrome
+      }
+    }
+  })
+  vi.stubGlobal('document', {
+    documentElement: {
+      style: {
+        setProperty: mocks.setProperty
+      }
+    }
+  })
+
+  return { module: await import('./ui-zoom'), mocks }
+}
+
+describe('UI zoom native window chrome sync', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.resetModules()
+  })
+
+  it('updates Windows window-controls overlay geometry when UI zoom changes', async () => {
+    const { module, mocks } = await loadUIZoom('Windows NT 10.0')
+
+    module.applyUIZoom(2)
+
+    expect(mocks.setZoomLevel).toHaveBeenCalledWith(2)
+    expect(mocks.setProperty).toHaveBeenCalledWith('--ui-zoom-factor', '1.44')
+    expect(mocks.syncWindowChrome).toHaveBeenCalledWith(1.44)
+  })
+
+  it('syncs restored native chrome on Windows and macOS but not Linux', async () => {
+    for (const [userAgent, expectedCalls] of [
+      ['Windows NT 10.0', 1],
+      ['Macintosh', 1],
+      ['Linux', 0]
+    ] as const) {
+      const { module, mocks } = await loadUIZoom(userAgent, 1)
+
+      module.syncZoomCSSVar()
+
+      expect(mocks.setProperty).toHaveBeenCalledWith('--ui-zoom-factor', '1.2')
+      expect(mocks.syncWindowChrome).toHaveBeenCalledTimes(expectedCalls)
+    }
+  })
+})

--- a/src/renderer/src/lib/ui-zoom.ts
+++ b/src/renderer/src/lib/ui-zoom.ts
@@ -1,16 +1,17 @@
 const isMac = navigator.userAgent.includes('Mac')
+const hasNativeWindowChrome = isMac || navigator.userAgent.includes('Windows')
 
 /**
  * Apply a UI zoom level change: sets webFrame zoom via the preload API,
- * updates the CSS variable used to compensate the traffic-light pad,
- * and repositions the native macOS traffic lights to stay aligned.
+ * updates the CSS variable used to compensate native chrome, and keeps
+ * native macOS/Windows window controls aligned with the zoomed titlebar.
  */
 export function applyUIZoom(level: number): void {
   const zoomFactor = Math.pow(1.2, level)
   window.api.ui.setZoomLevel(level)
   document.documentElement.style.setProperty('--ui-zoom-factor', String(zoomFactor))
-  if (isMac) {
-    window.api.ui.syncTrafficLights(zoomFactor)
+  if (hasNativeWindowChrome) {
+    window.api.ui.syncWindowChrome(zoomFactor)
   }
 }
 
@@ -22,7 +23,7 @@ export function syncZoomCSSVar(): void {
   const level = window.api.ui.getZoomLevel()
   const zoomFactor = Math.pow(1.2, level)
   document.documentElement.style.setProperty('--ui-zoom-factor', String(zoomFactor))
-  if (isMac) {
-    window.api.ui.syncTrafficLights(zoomFactor)
+  if (hasNativeWindowChrome) {
+    window.api.ui.syncWindowChrome(zoomFactor)
   }
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2565,7 +2565,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     // Why: a paired web client has no OS sleep signal; occlusion-driven visibilitychange already covers wake recovery.
     onSystemResumed: () => noopUnsubscribe,
     onFileDrop: () => noopUnsubscribe,
-    syncTrafficLights: () => {},
+    syncWindowChrome: () => {},
     setMarkdownEditorFocused: () => {},
     setTerminalInputFocused: () => {},
     setFloatingTerminalInputFocused: () => {},


### PR DESCRIPTION
## Summary

- Enable Electron's native Window Controls Overlay on Windows while preserving Orca's custom titlebar content.
- Use native Windows minimize, maximize, and close buttons so hovering the maximize button opens the Windows 11 Snap Layout flyout.
- Keep the native overlay height synchronized with persisted and runtime UI zoom changes.
- Keep renderer-drawn window controls only on frameless Linux; macOS and paired web clients remain unchanged.

## Screenshots

- Manually verified on Windows 11: hovering the native maximize button displays the system Snap Layout flyout and the layouts can be selected.
- Visual change is limited to using native Windows caption controls instead of renderer-drawn copies.

## Testing

- [ ] `pnpm lint` — source lint, switch exhaustiveness, reliability gates, max-lines, localization, and changed-file React lint passed; the final skill-manifest check reports stale upstream release artifacts after fetching the latest release tags.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the focused suites pass (3 files, 83 tests); the full Windows suite did not terminate within 10 minutes in the local Node 22 environment.
- [x] `pnpm run build:desktop`
- [x] Added or updated high-quality tests that catch regressions in platform-specific BrowserWindow options, renderer control selection, and zoom synchronization.

## AI Review Report

Reviewed the complete ten-file diff against current `main`.

- Cross-platform: Windows alone receives `titleBarOverlay`; Linux remains frameless and keeps renderer-drawn controls; macOS keeps `hiddenInset`; paired web clients render no desktop controls.
- Electron behavior: the native maximize caption button owns Windows non-client hit testing, which is required for the Windows 11 Snap Layout hover menu.
- Zoom behavior: persisted zoom is synchronized on `dom-ready`, runtime zoom changes use the shared window-chrome IPC path, and Windows recalculates the overlay height as `Math.round(36 * zoomFactor)`.
- SSH/remote/local: no repository, host, transport, path, shell, or session behavior changes.
- Agent/integration/git-provider compatibility: no agent, integration, or source-control paths are touched.
- Performance: only platform checks and window-chrome synchronization on infrequent zoom changes were added; no hot-path work was introduced.
- UI quality: the native overlay follows the scaled 36 px titlebar geometry, with Windows, macOS, and Linux behavior covered by tests.

No additional issues were found after rebasing onto the latest upstream `main`.

## Security Audit

No new input handling, command execution, path handling, authentication, secrets, dependencies, or network access were introduced. The IPC rename extends an existing trusted renderer-to-main window-chrome synchronization path to Windows without accepting arbitrary data beyond the numeric zoom factor.

## Notes

- Windows 11 exposes Snap Layouts through the native maximize button. Older Windows versions continue to receive normal native caption controls without the Windows 11 flyout.
- X (Twitter) handle: N/A

## ELI5

Windows now uses native minimize/maximize/close with Window Controls Overlay so hovering maximize shows the Windows 11 Snap Layouts flyout, while keeping Orca’s custom titlebar content.
