### PR TITLE
fix(status-bar): guard undefined provider window in usedPercent reduce (crashes d2c1da69, bb74236c)

### DIFF
--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -20,9 +20,13 @@ import type { StatusBarUsageMode } from '../../../../shared/status-bar-usage-mod
 type ProviderId = ProviderRateLimits['provider']
 export type UsageSection = { label: string; window: RateLimitWindow }
 
-// Windows/buckets that actually carry data — the null ones are absent limits.
+// Windows/buckets that actually carry data — absent limits arrive as null, but a
+// partial/rehydrated provider can also carry an undefined window; both must be
+// dropped so downstream consumers never dereference `window.usedPercent`.
 function usedSections(p: ProviderRateLimits): UsageSection[] {
-  return getWindowSections(p).filter((s): s is UsageSection => s.window !== null)
+  return getWindowSections(p).filter(
+    (s): s is UsageSection => s.window !== null && s.window !== undefined
+  )
 }
 
 function providerMaxUsed(sections: UsageSection[]): number {

--- a/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
@@ -168,3 +168,33 @@ describe('ProviderSegment monthly window', () => {
     expect(markup).not.toContain('40% used')
   })
 })
+
+describe('undefined provider window safety (crash d2c1da69 / bb74236c)', () => {
+  // A partial/rehydrated provider can carry an undefined (not null) window even
+  // though the type declares `session`/`weekly` as `RateLimitWindow | null`. The
+  // old `s.window !== null` filter let the undefined-window section through, so
+  // getTightestUsageSection's reduce read `.usedPercent` of undefined and crashed
+  // the status-bar overlay (TypeError in ProviderSegment).
+  const partialProvider = {
+    provider: 'codex',
+    weekly: windowOf(42, 10080),
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok'
+  } as unknown as ProviderRateLimits // `session` omitted -> undefined at runtime
+
+  it('getTightestUsageSection ignores an undefined window instead of crashing', async () => {
+    const { getTightestUsageSection } = await import('./UsageRosterPanel')
+    expect(() => getTightestUsageSection(partialProvider)).not.toThrow()
+    expect(getTightestUsageSection(partialProvider)?.window.usedPercent).toBe(42)
+  })
+
+  it('ProviderSegment renders without crashing when a provider window is undefined', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+    expect(() =>
+      renderToStaticMarkup(
+        <ProviderSegment p={partialProvider} compact={false} display="used" mode="compact" />
+      )
+    ).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Description
Fixes a status-bar overlay crash (`overlay.status-bar` boundary): `TypeError: Cannot read properties of undefined (reading 'usedPercent')` at `getTightestUsageSection` → `ProviderSegment`/`CodexAccountUsageSegment`.

`usedSections()` filtered sections with `s.window !== null`, but a partial/rehydrated provider can carry a window that is **`undefined`** (the type declares `session`/`weekly` as `RateLimitWindow | null`, yet a missing field is `undefined` at runtime). An `undefined` window slipped past the null-only filter, so `getTightestUsageSection`'s `reduce` — and `providerMaxUsed` — dereferenced `undefined.usedPercent` and took down the status bar.

Fix: filter out `undefined` windows too (`s.window !== null && s.window !== undefined`), matching the codebase's existing style. One point covers every consumer of `usedSections`.

Crash reports: `d2c1da69`, `bb74236c` (macOS, 1.4.152).

## ELI5
The status bar shows each AI provider's tightest usage window. It listed the windows and skipped the "empty" ones — but it only checked for one kind of empty (`null`), not the other (`undefined`). A provider that came back with a missing window slipped through, and the code tried to read a percentage off nothing, crashing the bar. Now both kinds of empty are skipped.

## Proof of fix
Regression tests fail on current code, pass after the one-line filter change:
```
BEFORE  provider-segment-monthly-window.test.tsx (8 tests | 2 failed)
  × getTightestUsageSection ignores an undefined window instead of crashing
    TypeError: Cannot read properties of undefined (reading 'usedPercent')
  × ProviderSegment renders without crashing when a provider window is undefined
    TypeError: Cannot read properties of undefined (reading 'usedPercent')
AFTER   Test Files 33 passed · Tests 224 passed
```
The second test reproduces through the real `ProviderSegment` render path (the crash's component stack). `tsc` web typecheck exit 0; `oxlint` clean.

## Proof of zero regression
The only behavior change is that a section whose `window` is `undefined` is now excluded — such a section was never renderable anyway (every consumer reads `window.usedPercent`), so excluding it removes a crash and changes nothing for valid windows. `null` windows were already excluded; `undefined` now joins them. Entire status-bar suite green (33 files / 224 tests), including all pre-existing provider/window/tooltip tests.

Made with [Orca](https://github.com/stablyai/orca) 🐋
