### PR TITLE
fix(ai-vault): prevent duplicate live session resume

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
@@ -288,6 +288,8 @@ function AiVaultVirtualRow({
 
   const isActiveStickyHeader = row.type === 'group' && activeStickyHeaderIndex === index
   const originalPaneTarget = row.type === 'session' ? getOriginalPaneTarget(row.session) : null
+  const sessionLiveState = row.type === 'session' ? getSessionLiveState(row.session) : null
+  const sessionRunning = sessionLiveState !== null && sessionLiveState !== 'done'
   const worktreeInfo = row.type === 'session' ? getWorktreeInfo(row.session) : null
   // Why: omit the jump affordance when the session already lives in the
   // worktree on screen — jumping there is a no-op.
@@ -307,7 +309,7 @@ function AiVaultVirtualRow({
   // empty conversation, so it is never offered as normally resumable.
   const resumeGating =
     row.type === 'session'
-      ? aiVaultSessionRowResumeGating(row.session, resumeState)
+      ? aiVaultSessionRowResumeGating(row.session, resumeState, sessionRunning)
       : { resumeDisabled: true, canCopyResumeCommand: false }
   const resumeLabel = resumeState ? aiVaultSessionResumeLabel(resumeState) : ''
   const canOpenLocalSessionPaths =
@@ -336,7 +338,7 @@ function AiVaultVirtualRow({
       ) : (
         <VaultSessionRow
           session={row.session}
-          liveState={getSessionLiveState(row.session)}
+          liveState={sessionLiveState}
           resumeStartup={buildResumeStartup(row.session, resumeState?.worktreeId)}
           realHomeResumeStartup={buildResumeStartup(
             { ...row.session, codexHome: null },

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
@@ -7,12 +7,35 @@ import { useAppStore } from '@/store'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import { translate } from '@/i18n/i18n'
-import { findOriginalAiVaultSessionPane } from './ai-vault-original-pane'
+import {
+  findAiVaultSessionLiveState,
+  findOriginalAiVaultSessionPane
+} from './ai-vault-original-pane'
 import {
   createLazyAiVaultOriginalPaneIndex,
   findAiVaultSessionLiveStateInIndex,
   findOriginalAiVaultSessionPaneInIndex
 } from './ai-vault-original-pane-index'
+
+// Why: resume clicks can outlive rendered state; recheck before starting a duplicate process.
+export function jumpToRunningAiVaultSessionPane(session: AiVaultSession): boolean {
+  const state = useAppStore.getState()
+  const liveState = findAiVaultSessionLiveState(state, session)
+  if (liveState === null || liveState === 'done') {
+    return false
+  }
+  const target = findOriginalAiVaultSessionPane(state, session)
+  if (!target || !activateAndRevealWorktree(target.worktreeId)) {
+    return false
+  }
+  const activeState = useAppStore.getState()
+  activeState.setActiveTabType('terminal')
+  activateTabAndFocusPane(target.tabId, target.leafId, {
+    flashFocusedPane: true,
+    scrollToBottomIfOutputSinceLastView: true
+  })
+  return true
+}
 
 export function useAiVaultOriginalPaneActions(): {
   getOriginalPaneTarget: (

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -29,6 +29,7 @@ import {
 import { prepareAiVaultSessionContinuation } from './ai-vault-session-continuation'
 import type { AgentSessionContinuationRequest } from '@/lib/agent-session-continuation'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { jumpToRunningAiVaultSessionPane } from './ai-vault-original-pane-actions'
 
 export function useAiVaultSessionLaunchActions({
   activeWorktree,
@@ -93,13 +94,15 @@ export function useAiVaultSessionLaunchActions({
 
   const handleResume = useCallback(
     (session: AiVaultSession, targetWorktreeId?: string): void => {
-      const targetId = resolveAiVaultSessionLaunchTargetOrNotify({
-        sessionFilePath: session.filePath,
-        sessionExecutionHostId: session.executionHostId,
-        activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null,
-        targetWorktreeId,
-        targetState
-      })
+      const targetId = jumpToRunningAiVaultSessionPane(session)
+        ? null
+        : resolveAiVaultSessionLaunchTargetOrNotify({
+            sessionFilePath: session.filePath,
+            sessionExecutionHostId: session.executionHostId,
+            activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null,
+            targetWorktreeId,
+            targetState
+          })
       if (!targetId) {
         return
       }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts
@@ -608,4 +608,18 @@ describe('aiVaultSessionRowResumeGating', () => {
       canCopyResumeCommand: true
     })
   })
+
+  it('blocks resume while the provider session is still running', () => {
+    expect(aiVaultSessionRowResumeGating(sessionWithTurns, unblocked, true)).toEqual({
+      resumeDisabled: true,
+      canCopyResumeCommand: true
+    })
+  })
+
+  it('allows resume after an agent in the original pane reaches done', () => {
+    expect(aiVaultSessionRowResumeGating(sessionWithTurns, unblocked, false)).toEqual({
+      resumeDisabled: false,
+      canCopyResumeCommand: true
+    })
+  })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-resume.ts
@@ -209,11 +209,13 @@ function resolveAiVaultResumeTargetState(args: {
 // affordance is gated on content alone.
 export function aiVaultSessionRowResumeGating(
   session: Pick<AiVaultSession, 'messageCount' | 'previewMessages'>,
-  state: Pick<AiVaultSessionResumeState, 'blocked'> | null
+  state: Pick<AiVaultSessionResumeState, 'blocked'> | null,
+  sessionRunning = false
 ): { resumeDisabled: boolean; canCopyResumeCommand: boolean } {
   const hasResumableContent = isAiVaultSessionResumableContent(session)
   return {
-    resumeDisabled: (state?.blocked ?? true) || !hasResumableContent,
+    // Why: two agent processes must not concurrently resume the same provider transcript.
+    resumeDisabled: sessionRunning || (state?.blocked ?? true) || !hasResumableContent,
     canCopyResumeCommand: hasResumableContent
   }
 }


### PR DESCRIPTION
## Summary

Prevent AI Vault from starting a second agent process for a provider session that is already running.

- Disable the Resume affordance while the matching session is `working`, `blocked`, or `waiting`.
- Recheck live state at click time and focus the existing pane, closing the stale-render race before process launch.
- Keep Resume available after the existing agent reaches `done`.
- Apply the behavior generically to resumable AI Vault agents rather than special-casing Pi.

## Screenshots

No layout change. This reuses the existing disabled Resume state and original-pane focus behavior.

## Testing

- [ ] `pnpm lint` — changed files pass `oxlint` and `oxfmt --check`; full lint was not run
- [x] `pnpm typecheck`
- [ ] `pnpm test` — targeted tests pass; the full suite completed with 35,215 passing and 7 unrelated environment/timing failures
- [ ] `pnpm build` — not run on this isolated branch
- [x] Added regression coverage for blocking a running session while preserving Resume after `done`

Targeted command:

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts \
  src/renderer/src/components/right-sidebar/ai-vault-original-pane.test.ts \
  src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.test.ts
```

Result: 44 tests passed.

## AI Review Report

Reviewed the live-session identity path, original-pane lookup, stale-render race, and completed-session behavior. The initial implementation blocked Resume whenever an original pane existed; review caught that this would also block completed sessions, so the guard was narrowed to non-`done` live states.

Cross-platform review: this is renderer state/navigation logic only. It adds no shortcuts, labels, paths, shell commands, native APIs, or Electron platform branches, so behavior is the same on macOS, Linux, and Windows, including SSH/runtime workspaces.

## Security Audit

No new external input, command execution, filesystem path handling, authentication, secrets, dependencies, or IPC are introduced. The change reduces the risk of two processes concurrently writing the same provider transcript. The click-time guard uses existing normalized provider-session identity and existing pane activation APIs.

## Notes

The full-suite failures were outside the modified AI Vault files: existing relay/SSH timing tests, Codex stub timing, repository remote URL environment assumptions, and inherited Git environment assertions. Targeted tests, typecheck, formatting, and lint for all changed files pass.

## ELI5

Resume in AI Vault could start a second agent for a session that was already running. Resume is disabled while working/blocked/waiting, and a click rechecks live state and focuses the existing pane instead.
