### PR TITLE
docs(headless-server): fix extraction AppRun invocation, root-unit HOME, ldd target

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -31,14 +31,20 @@ optional: without it, use the AppImage's supported extraction path:
 ```bash
 cd /opt/orca
 ./orca-linux.AppImage --appimage-extract
-/opt/orca/squashfs-root/AppRun serve --port 6768
+APPDIR=/opt/orca/squashfs-root /opt/orca/squashfs-root/AppRun serve --port 6768
 ```
+
+`APPDIR` is required when invoking `AppRun` directly. The AppImage runtime
+sets it automatically, but outside that runtime `AppRun`'s autodetection walks
+up the tree looking for a directory entry named after its first argument
+(`serve`), never finds one, and fails with
+`AppRun: line 45: /orca-ide: No such file or directory`.
 
 Docker commonly has no FUSE device. Use `--appimage-extract` once or
 `--appimage-extract-and-run`; neither requires a privileged container. The
 extract-and-run wrapper can print extracted paths before Orca starts, so
 automation that requires stdout to contain only the ready JSON should extract
-once and invoke `squashfs-root/AppRun`.
+once and invoke `squashfs-root/AppRun` with `APPDIR` set.
 
 Download and make the AppImage executable:
 
@@ -268,6 +274,12 @@ the command:
 
 This disables a security boundary. Prefer a dedicated unprivileged service
 user, especially when the listener is reachable beyond localhost.
+
+A root systemd unit also needs an explicit `HOME`. systemd does not set
+`$HOME` for units without `User=`, and without it Chromium silently splits
+profile state between `/root/.config/orca` and `/tmp/.config/orca` — including
+the pairing device keys, which are then lost on reboot. Set
+`Environment=HOME=/root` in the unit.
 
 ## Pairing troubleshooting
 
@@ -745,6 +757,9 @@ is resolved.
 - Service crash-loops right after an upgrade: use [Roll back](#roll-back) with
   the pre-upgrade `.ready` bundle. Do not rerun the upgrade first; doing so would
   make the crashing version the next rollback binary.
+- `AppRun: line 45: /orca-ide: No such file or directory`: set
+  `APPDIR=/path/to/squashfs-root` in the environment when invoking the
+  extracted `AppRun` directly.
 - Diagnosing other missing libraries: extract the AppImage without launching it
   with `./orca-linux.AppImage --appimage-extract`, then run
-  `ldd squashfs-root/orca` to list any shared libraries the host is missing.
+  `ldd squashfs-root/orca-ide` to list any shared libraries the host is missing.


### PR DESCRIPTION
## Summary

Three fixes to `docs/reference/headless-linux-server.md`, each hit and verified while deploying `orca serve` on a real Ubuntu 24.04 VPS with the v1.4.152 AppImage:

1. **The documented extraction-path command fails as written.** `/opt/orca/squashfs-root/AppRun serve --port 6768` errors with `AppRun: line 45: /orca-ide: No such file or directory`. Outside the AppImage runtime nothing sets `APPDIR`, and AppRun's autodetection walks up the tree looking for a directory entry named after its first argument (`serve`), never finds one, and resolves `APPDIR` to empty. The doc now prefixes `APPDIR=/opt/orca/squashfs-root` and gains a troubleshooting entry keyed on the error message.
2. **Root systemd units lose pairing keys to `/tmp`.** The doc describes running as root with `--no-sandbox` as an alternative to the dedicated `orca` user, but a unit without `User=` gets no `$HOME` from systemd. Chromium then splits profile state between `/root/.config/orca` and `/tmp/.config/orca` — observed via the process's open file descriptors, including a freshly minted E2EE pairing identity in `/tmp` that would vanish on reboot. The doc now says to set `Environment=HOME=/root` (the sample unit avoids this only because `User=orca` makes systemd set `HOME`).
3. **Wrong `ldd` target in troubleshooting.** The extracted binary is `squashfs-root/orca-ide`, not `squashfs-root/orca`.

## Screenshots

No visual change (docs-only).

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Docs-only change; the JS toolchain was not run. Instead, every claim was verified against a live deployment (Ubuntu 24.04, x86_64, v1.4.152):

- `env -u APPDIR /opt/orca/squashfs-root/AppRun serve --help` → `AppRun: line 45: /orca-ide: No such file or directory`; the same command with `APPDIR=/opt/orca/squashfs-root` prints the serve help.
- A root unit without `HOME` produced open FDs under both `/root/.config/orca/…` and `/tmp/.config/orca/…` (Partitions, SharedStorage, Dictionaries) and a different pairing `publicKeyB64` than the interactive run; adding `Environment=HOME=/root` restored a single profile (SingletonLock owned by the service PID, zero `/tmp/.config` FDs) and the original pairing identity.
- `squashfs-root/orca` does not exist in the extracted v1.4.152 AppImage; `squashfs-root/orca-ide` is the ELF the existing `ldd` advice intends.

## AI Review Report

Reviewed with Claude Code. Checks: accuracy of each command against a real deployment (all reproduced, see Testing); cross-platform impact — none, the file is the Linux-specific headless reference and no macOS/Windows guidance is touched; consistency with the surrounding doc voice, 80-column wrap, and the existing troubleshooting-list format; no contradiction introduced with the FUSE path or the `--appimage-extract-and-run` guidance (the runtime sets `APPDIR` in those flows, which is why only direct `AppRun` invocation needs it). Flagged and fixed during review: the Docker paragraph also said to "invoke `squashfs-root/AppRun`" without mentioning `APPDIR`; amended for consistency.

## Security Audit

No code, command execution, or IPC changes. The `HOME` addition is security-relevant in the positive direction: without it, E2EE pairing device keys land in world-writable, reboot-volatile `/tmp`, and the split state silently mints a second server identity. The doc keeps the existing guidance that the pairing URL is a secret and that an unprivileged service user is preferred.

## Notes

- Root cause of item 1 is the stock electron-builder `AppRun` autodetection; a packaging-side fix (custom `AppRun` that falls back to its own directory) would make the doc workaround unnecessary — happy to file that separately if useful.
- Observed but out of scope for this PR: on a headless server with the offscreen browser backend active, some runtime paths (`ensureBrowserWorktreeActive`, renderer navigation notifications, terminal-tab mounting) still require the authoritative window and throw `No renderer window available` instead of falling back like `browserTabCreate` does. Can file as an issue with details.

X: @0xjord4n_

## ELI5

Fixes three real mistakes in the headless Linux server docs (AppRun extraction command, root unit HOME, ldd target) that broke following the guide on Ubuntu VPS installs.
