### PR TITLE
feat(agent-status): report crush working/blocked/done state via SSE bridge

### DIFF
--- a/src/main/agent-hooks/crush-sse-bridge.test.ts
+++ b/src/main/agent-hooks/crush-sse-bridge.test.ts
@@ -8,9 +8,23 @@ import {
   crushOrcaHostArg,
   crushOrcaSocketPath,
   crushSseBridgeSupported,
+  crushSseEnabledForLaunch,
   startCrushSseBridge
 } from './crush-sse-bridge'
 import { crushOrcaSocketFileName } from '../../shared/crush-sse-shapes'
+
+// Why: crushSseEnabledForLaunch branches on process.platform; stub it per test so
+// every platform branch is exercised on every host. Restore afterEach.
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+afterEach(() => {
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  }
+})
+
+function stubPlatform(value: 'darwin' | 'linux' | 'win32'): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true })
+}
 
 describe('crushOrcaSocketPath / crushOrcaHostArg', () => {
   it('builds an absolute socket path and a unix:// --host arg from the same launch token', () => {
@@ -35,10 +49,65 @@ describe('crushOrcaSocketPath / crushOrcaHostArg', () => {
   })
 })
 
-describe('crushSseBridgeSupported', () => {
-  it('matches the current process platform (no NaN-style universal assertions)', () => {
-    const supported = crushSseBridgeSupported()
-    expect(supported).toBe(process.platform === 'darwin' || process.platform === 'linux')
+describe('crushSseEnabledForLaunch', () => {
+  it.each(['darwin', 'linux'] as const)(
+    'enables SSE for a local crush launch with a token on %s',
+    (platform) => {
+      stubPlatform(platform)
+      expect(
+        crushSseEnabledForLaunch({
+          launchAgent: 'crush',
+          launchToken: 'tok',
+          connectionId: undefined
+        })
+      ).toBe(true)
+    }
+  )
+
+  it('disables SSE on Windows (Node socketPath transport is unix-only)', () => {
+    stubPlatform('win32')
+    expect(
+      crushSseEnabledForLaunch({
+        launchAgent: 'crush',
+        launchToken: 'tok',
+        connectionId: undefined
+      })
+    ).toBe(false)
+  })
+
+  it('disables SSE for SSH/relay worktrees even on a supported platform', () => {
+    stubPlatform('darwin')
+    expect(
+      crushSseEnabledForLaunch({
+        launchAgent: 'crush',
+        launchToken: 'tok',
+        connectionId: 'ssh-conn-1'
+      })
+    ).toBe(false)
+    // Why: empty-string connectionId is treated as local (the runtime only ever
+    // passes a truthy string for remote).
+    expect(
+      crushSseEnabledForLaunch({
+        launchAgent: 'crush',
+        launchToken: 'tok',
+        connectionId: ''
+      })
+    ).toBe(true)
+  })
+
+  it('disables SSE when the launch token is missing or the agent is not crush', () => {
+    stubPlatform('linux')
+    expect(
+      crushSseEnabledForLaunch({ launchAgent: 'crush', launchToken: '', connectionId: undefined })
+    ).toBe(false)
+    expect(crushSseEnabledForLaunch({ launchAgent: 'crush', launchToken: undefined })).toBe(false)
+    expect(
+      crushSseEnabledForLaunch({
+        launchAgent: 'claude',
+        launchToken: 'tok',
+        connectionId: undefined
+      })
+    ).toBe(false)
   })
 })
 ;(crushSseBridgeSupported() ? describe : describe.skip)('startCrushSseBridge (socket)', () => {
@@ -98,6 +167,106 @@ describe('crushSseBridgeSupported', () => {
     expect(seen[0].hookPayload).toEqual({ session_id: 's1', text: 'hi' })
   })
 
+  it('resets the SSE buffer on each reconnect so a mid-stream drop does not corrupt the next stream', async () => {
+    // Why: regress here if the bridge stops resetting `buffer` in connect() — a
+    // leftover partial fragment would prepend itself to the next stream's bytes
+    // and silently drop the first post-reconnect event(s) as malformed JSON.
+    const partialPath = join(tmp, 'partial.sock')
+    let connectionCount = 0
+    const partialServer = createServer((req, res) => {
+      if (req.url !== '/v1/workspaces/0/events') {
+        res.writeHead(404)
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' })
+      connectionCount++
+      if (connectionCount === 1) {
+        res.write('data: not-yet-termin') // partial — no \n\n terminator
+        res.end() // close mid-event → leaves a fragment in the bridge buffer
+      } else {
+        res.write(
+          'data: {"type":"run_complete","payload":{"payload":{"session_id":"s1","text":"hi"}}}\n\n'
+        )
+      }
+    })
+    partialServer.listen(partialPath)
+    try {
+      const seen: { hookEventName: string; hookPayload: Record<string, unknown> }[] = []
+      await new Promise<void>((resolve) => {
+        const bridge = startCrushSseBridge(partialPath, {
+          paneKey: 'pk',
+          launchToken: 'ltok-buffer',
+          onEvent: (ev) => {
+            seen.push(ev)
+            bridge.stop()
+            resolve()
+          },
+          onError: () => {}
+        })
+        setTimeout(() => {
+          bridge.stop()
+          resolve()
+        }, 3000)
+      })
+      expect(seen).toHaveLength(1)
+      expect(seen[0].hookEventName).toBe('run_complete')
+      expect(seen[0].hookPayload).toEqual({ session_id: 's1', text: 'hi' })
+    } finally {
+      partialServer.close()
+    }
+  })
+
+  it('survives an onEvent that throws (with a re-throwing onError) and keeps forwarding later events', async () => {
+    // Why: regress here if the inner try/catch around deps.onError is removed —
+    // a re-throwing onError would propagate out of `res.on('data')` and kill the
+    // SSE read loop, dropping every subsequent event in the same stream.
+    const doublePath = join(tmp, 'double.sock')
+    const doubleServer = createServer((req, res) => {
+      if (req.url !== '/v1/workspaces/0/events') {
+        res.writeHead(404)
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' })
+      res.write(
+        'data: {"type":"run_complete","payload":{"payload":{"session_id":"first","text":"a"}}}\n\n' +
+          'data: {"type":"run_complete","payload":{"payload":{"session_id":"second","text":"b"}}}\n\n'
+      )
+    })
+    doubleServer.listen(doublePath)
+    try {
+      const seen: { hookEventName: string; hookPayload: Record<string, unknown> }[] = []
+      await new Promise<void>((resolve) => {
+        let first = true
+        const bridge = startCrushSseBridge(doublePath, {
+          paneKey: 'pk',
+          launchToken: 'ltok-guard',
+          onEvent: (ev) => {
+            if (first) {
+              first = false
+              throw new Error('boom')
+            }
+            seen.push(ev)
+            bridge.stop()
+            resolve()
+          },
+          onError: () => {
+            throw new Error('onError-boom')
+          }
+        })
+        setTimeout(() => {
+          bridge.stop()
+          resolve()
+        }, 2000)
+      })
+      expect(seen).toHaveLength(1)
+      expect(seen[0].hookPayload).toEqual({ session_id: 'second', text: 'b' })
+    } finally {
+      doubleServer.close()
+    }
+  })
+
   it('stop() is idempotent and halts reconnection', () => {
     const bridge = startCrushSseBridge(socketPath, {
       paneKey: 'pk',
@@ -107,6 +276,33 @@ describe('crushSseBridgeSupported', () => {
     bridge.stop()
     bridge.stop()
     expect(bridge.stopped()).toBe(true)
+  })
+
+  it('routes a connect failure (missing socket) to onError so the retry loop is observable', async () => {
+    // Why: regress here if connection-level errors stop flowing through
+    // deps.onError — a permanently wrong socket path would otherwise reconnect
+    // forever with zero visibility from the runtime side.
+    const badPath = join(tmp, 'does-not-exist.sock')
+    const errors: Error[] = []
+    await new Promise<void>((resolve) => {
+      const bridge = startCrushSseBridge(badPath, {
+        paneKey: 'pk',
+        launchToken: 'ltok-bad',
+        onEvent: () => {},
+        onError: (err) => {
+          errors.push(err)
+          bridge.stop()
+          resolve()
+        }
+      })
+      setTimeout(() => {
+        bridge.stop()
+        resolve()
+      }, 2000)
+    })
+    expect(errors.length).toBeGreaterThanOrEqual(1)
+    expect(errors[0]).toBeInstanceOf(Error)
+    expect(errors[0].message.length).toBeGreaterThan(0)
   })
 })
 

--- a/src/main/agent-hooks/crush-sse-bridge.test.ts
+++ b/src/main/agent-hooks/crush-sse-bridge.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import http from 'node:http'
+import { createServer, type Server } from 'node:http'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  crushOrcaHostArg,
+  crushOrcaSocketPath,
+  crushSseBridgeSupported,
+  startCrushSseBridge
+} from './crush-sse-bridge'
+import { crushOrcaSocketFileName } from '../../shared/crush-sse-shapes'
+
+describe('crushOrcaSocketPath / crushOrcaHostArg', () => {
+  it('builds an absolute socket path and a unix:// --host arg from the same launch token', () => {
+    const path = crushOrcaSocketPath('ltok-1')
+    const host = crushOrcaHostArg('ltok-1')
+    expect(path.endsWith(crushOrcaSocketFileName('ltok-1'))).toBe(true)
+    expect(host).toBe(`unix://${path}`)
+  })
+
+  it('prefers XDG_RUNTIME_DIR when set and absolute', () => {
+    const prev = process.env.XDG_RUNTIME_DIR
+    process.env.XDG_RUNTIME_DIR = '/var/run'
+    try {
+      expect(crushOrcaSocketPath('tok')).toBe(`/var/run/${crushOrcaSocketFileName('tok')}`)
+    } finally {
+      if (prev === undefined) {
+        delete process.env.XDG_RUNTIME_DIR
+      } else {
+        process.env.XDG_RUNTIME_DIR = prev
+      }
+    }
+  })
+})
+
+describe('crushSseBridgeSupported', () => {
+  it('matches the current process platform (no NaN-style universal assertions)', () => {
+    const supported = crushSseBridgeSupported()
+    expect(supported).toBe(process.platform === 'darwin' || process.platform === 'linux')
+  })
+})
+;(crushSseBridgeSupported() ? describe : describe.skip)('startCrushSseBridge (socket)', () => {
+  let server: Server
+  let socketPath: string
+  let tmp: string
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crush-sse-test-'))
+    socketPath = join(tmp, 'test.sock')
+    server = createServer((req, res) => {
+      if (req.url !== '/v1/workspaces/0/events') {
+        res.writeHead(404)
+        res.end()
+        return
+      }
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' })
+      // Why: write one complete SSE event after a tick so the bridge's
+      // socket lookup attempt during connect sees it.
+      res.write(
+        'data: {"type":"run_complete","payload":{"payload":{"session_id":"s1","text":"hi"}}}\n\n'
+      )
+    })
+    server.listen(socketPath)
+  })
+
+  afterEach(() => {
+    server?.close()
+    rmSync(tmp, { recursive: true, force: true })
+  })
+
+  it('connects, parses a run_complete envelope, and forwards it to onEvent', async () => {
+    const seen: { hookEventName: string; hookPayload: Record<string, unknown> }[] = []
+    await new Promise<void>((resolve) => {
+      const bridge = startCrushSseBridge(socketPath, {
+        paneKey: 'pk',
+        launchToken: 'ltok-1',
+        onEvent: (ev) => {
+          seen.push(ev)
+          bridge.stop()
+          resolve()
+        },
+        onError: (err) => {
+          bridge.stop()
+          throw err
+        }
+      })
+      // Why: a safety timeout so the test doesn't hang if parsing breaks.
+      setTimeout(() => {
+        bridge.stop()
+        resolve()
+      }, 2000)
+    })
+
+    expect(seen).toHaveLength(1)
+    expect(seen[0].hookEventName).toBe('run_complete')
+    expect(seen[0].hookPayload).toEqual({ session_id: 's1', text: 'hi' })
+  })
+
+  it('stop() is idempotent and halts reconnection', () => {
+    const bridge = startCrushSseBridge(socketPath, {
+      paneKey: 'pk',
+      launchToken: 'ltok-2',
+      onEvent: () => {}
+    })
+    bridge.stop()
+    bridge.stop()
+    expect(bridge.stopped()).toBe(true)
+  })
+})
+
+// Keep http referenced for type-only integration tests in dev tooling.
+void http

--- a/src/main/agent-hooks/crush-sse-bridge.test.ts
+++ b/src/main/agent-hooks/crush-sse-bridge.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import http from 'node:http'
 import { createServer, type Server } from 'node:http'
 import { mkdtempSync, rmSync } from 'node:fs'
@@ -267,15 +267,45 @@ describe('crushSseEnabledForLaunch', () => {
     }
   })
 
-  it('stop() is idempotent and halts reconnection', () => {
-    const bridge = startCrushSseBridge(socketPath, {
-      paneKey: 'pk',
-      launchToken: 'ltok-2',
-      onEvent: () => {}
+  it('stop() is idempotent and halts reconnection', async () => {
+    // Why: use fake timers to prove stop() actually prevents a scheduled
+    // reconnect from firing — not just that the stopped flag is set.
+    vi.useFakeTimers()
+    let connectionCount = 0
+    const stopServer = createServer((req, res) => {
+      if (req.url !== '/v1/workspaces/0/events') {
+        res.writeHead(404)
+        res.end()
+        return
+      }
+      connectionCount++
+      res.writeHead(200, { 'Content-Type': 'text/event-stream' })
+      res.write(
+        'data: {"type":"run_complete","payload":{"payload":{"session_id":"s1","text":"hi"}}}\n\n'
+      )
     })
-    bridge.stop()
-    bridge.stop()
-    expect(bridge.stopped()).toBe(true)
+    const stopPath = join(tmp, 'halt.sock')
+    stopServer.listen(stopPath)
+    try {
+      const bridge = startCrushSseBridge(stopPath, {
+        paneKey: 'pk',
+        launchToken: 'ltok-halt',
+        onEvent: () => {}
+      })
+      // Why: allow the initial connect to succeed.
+      await vi.advanceTimersByTimeAsync(100)
+      const countAfterFirst = connectionCount
+      bridge.stop()
+      bridge.stop()
+      // Why: advance well past the max backoff window — if stop() didn't
+      // cancel the reconnect timer, a new connection would land here.
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(connectionCount).toBe(countAfterFirst)
+      expect(bridge.stopped()).toBe(true)
+    } finally {
+      vi.useRealTimers()
+      stopServer.close()
+    }
   })
 
   it('routes a connect failure (missing socket) to onError so the retry loop is observable', async () => {

--- a/src/main/agent-hooks/crush-sse-bridge.test.ts
+++ b/src/main/agent-hooks/crush-sse-bridge.test.ts
@@ -267,45 +267,35 @@ describe('crushSseEnabledForLaunch', () => {
     }
   })
 
-  it('stop() is idempotent and halts reconnection', async () => {
-    // Why: use fake timers to prove stop() actually prevents a scheduled
-    // reconnect from firing — not just that the stopped flag is set.
+  it('stop() cancels a scheduled reconnect and prevents further connections', async () => {
+    // Why: CodeRabbit asked for proof that reconnection is actually prevented,
+    // not just that the stopped flag is set. Use a bad socket path so the
+    // initial connect fails and schedules a reconnect — then call stop()
+    // before the timer fires and verify no new connection attempt lands.
     vi.useFakeTimers()
-    let connectionCount = 0
-    const stopServer = createServer((req, res) => {
-      if (req.url !== '/v1/workspaces/0/events') {
-        res.writeHead(404)
-        res.end()
-        return
+    let errorCount = 0
+    const badPath = join(tmp, 'no-such-socket.sock')
+    const bridge = startCrushSseBridge(badPath, {
+      paneKey: 'pk',
+      launchToken: 'ltok-reconnect',
+      onEvent: () => {},
+      onError: () => {
+        errorCount++
       }
-      connectionCount++
-      res.writeHead(200, { 'Content-Type': 'text/event-stream' })
-      res.write(
-        'data: {"type":"run_complete","payload":{"payload":{"session_id":"s1","text":"hi"}}}\n\n'
-      )
     })
-    const stopPath = join(tmp, 'halt.sock')
-    stopServer.listen(stopPath)
-    try {
-      const bridge = startCrushSseBridge(stopPath, {
-        paneKey: 'pk',
-        launchToken: 'ltok-halt',
-        onEvent: () => {}
-      })
-      // Why: allow the initial connect to succeed.
-      await vi.advanceTimersByTimeAsync(100)
-      const countAfterFirst = connectionCount
-      bridge.stop()
-      bridge.stop()
-      // Why: advance well past the max backoff window — if stop() didn't
-      // cancel the reconnect timer, a new connection would land here.
-      await vi.advanceTimersByTimeAsync(30_000)
-      expect(connectionCount).toBe(countAfterFirst)
-      expect(bridge.stopped()).toBe(true)
-    } finally {
-      vi.useRealTimers()
-      stopServer.close()
-    }
+    // Why: let the first connect attempt fail and schedule a reconnect.
+    await vi.advanceTimersByTimeAsync(50)
+    const errorsAfterFirst = errorCount
+    expect(errorsAfterFirst).toBeGreaterThanOrEqual(1)
+    // Why: stop() before the backoff timer fires.
+    bridge.stop()
+    bridge.stop()
+    // Why: advance well past the max backoff (10s) — if stop() didn't cancel
+    // the reconnect timer, multiple new attempts would land here.
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(errorCount).toBe(errorsAfterFirst)
+    expect(bridge.stopped()).toBe(true)
+    vi.useRealTimers()
   })
 
   it('routes a connect failure (missing socket) to onError so the retry loop is observable', async () => {

--- a/src/main/agent-hooks/crush-sse-bridge.ts
+++ b/src/main/agent-hooks/crush-sse-bridge.ts
@@ -14,6 +14,7 @@ import { URL } from 'node:url'
 import {
   crushHookEventName,
   crushHookPayload,
+  crushOrcaSocketFileName,
   parseCrushSseChunk,
   parseCrushSseEvent,
   type CrushSseEnvelope
@@ -48,8 +49,8 @@ export function crushOrcaSocketDirectory(): string {
 
 /** Full filesystem path of the per-pane socket for a launchToken. */
 export function crushOrcaSocketPath(launchToken: string): string {
-  const safe = launchToken.replace(/[^a-zA-Z0-9_-]/g, '') || 'default'
-  return path.join(crushOrcaSocketDirectory(), `crush-orca-${safe}.sock`)
+  const dir = crushOrcaSocketDirectory()
+  return path.join(dir, crushOrcaSocketFileName(launchToken, dir))
 }
 
 /** `--host` value Orca passes to crush and its auto-spawned server. */
@@ -63,6 +64,23 @@ export function crushOrcaHostArg(launchToken: string): string {
  *  sockets. Why: gate Windows out for v1 — title-scraping remains available. */
 export function crushSseBridgeSupported(): boolean {
   return process.platform === 'darwin' || process.platform === 'linux'
+}
+
+/** Combined gate for crush SSE status reporting on a given launch. Why: the bridge
+ *  requires unix-socket transport (no Windows) AND a local launch (no SSH/relay:
+ *  the spawned crush server binds the remote host, not Orca's machine, so Orca's
+ *  local dial would never connect). Remote crush panes keep title-scraping. */
+export function crushSseEnabledForLaunch(args: {
+  launchAgent?: string | null
+  launchToken?: string | null
+  connectionId?: string | null
+}): boolean {
+  return (
+    args.launchAgent === 'crush' &&
+    !!args.launchToken &&
+    !args.connectionId &&
+    crushSseBridgeSupported()
+  )
 }
 
 export type CrushSseBridge = {
@@ -88,6 +106,9 @@ export function startCrushSseBridge(socketPath: string, deps: CrushSseBridgeDeps
     if (stopped) {
       return
     }
+    // Why: drop any partial SSE fragment left over from the previous connection
+    // so it can't corrupt the first event(s) on the new stream.
+    buffer = ''
     const req = http.request(
       {
         method: 'GET',
@@ -101,6 +122,7 @@ export function startCrushSseBridge(socketPath: string, deps: CrushSseBridgeDeps
         // schedule a reconnect instead of treating a partial response as fatal.
         if (res.statusCode !== 200) {
           res.resume()
+          reportError(new Error(`crush SSE stream returned ${res.statusCode ?? 'no status'}`))
           scheduleReconnect()
           return
         }
@@ -118,12 +140,30 @@ export function startCrushSseBridge(socketPath: string, deps: CrushSseBridgeDeps
           }
         })
         res.on('end', () => scheduleReconnect())
-        res.on('error', () => scheduleReconnect())
+        res.on('error', (err) => {
+          reportError(err)
+          scheduleReconnect()
+        })
       }
     )
-    req.on('error', () => scheduleReconnect())
+    req.on('error', (err) => {
+      reportError(err)
+      scheduleReconnect()
+    })
     currentRequest = req
     req.end()
+  }
+
+  // Why: route every connection / stream / delivery failure through deps.onError
+  // so a permanently wrong socket path or unbooted crush server is observable
+  // from the runtime side, and wrap the sink so a throwing observer can't crash
+  // the SSE read loop or the reconnect scheduler.
+  const reportError = (err: unknown): void => {
+    try {
+      deps.onError?.(err instanceof Error ? err : new Error(String(err)))
+    } catch {
+      // Why: the sink itself must never be able to crash the SSE read loop.
+    }
   }
 
   const dispatch = (ev: { data: string }): void => {
@@ -144,8 +184,9 @@ export function startCrushSseBridge(socketPath: string, deps: CrushSseBridgeDeps
       deps.onEvent({ hookEventName, hookPayload })
     } catch (err) {
       // Why: the sink (AgentHookServer.submitSyntheticHookEvent) is itself
-      // guarded, but wrap once more so a throwing observer can't kill the loop.
-      deps.onError?.(err instanceof Error ? err : new Error(String(err)))
+      // guarded, but route through reportError so a throwing observer can't
+      // kill the loop.
+      reportError(err)
     }
   }
 

--- a/src/main/agent-hooks/crush-sse-bridge.ts
+++ b/src/main/agent-hooks/crush-sse-bridge.ts
@@ -128,13 +128,10 @@ export function startCrushSseBridge(socketPath: string, deps: CrushSseBridgeDeps
         }
         // Why: success — reset backoff so the next retry-after-drop starts fresh.
         backoff = SSE_INITIAL_BACKOFF_MS
-        let pending = ''
         res.setEncoding('utf-8')
         res.on('data', (chunk: string) => {
-          pending += chunk
-          const parsed = parseCrushSseChunk(buffer, pending)
+          const parsed = parseCrushSseChunk(buffer, chunk)
           buffer = parsed.rest
-          pending = ''
           for (const ev of parsed.events) {
             dispatch(ev)
           }

--- a/src/main/agent-hooks/crush-sse-bridge.ts
+++ b/src/main/agent-hooks/crush-sse-bridge.ts
@@ -1,0 +1,188 @@
+// Why: crush (charmbracelet/crush) auto-spawns a detached `crush server` when
+// launched with CRUSH_CLIENT_SERVER=1. Orca launches crush with a per-pane
+// custom `--host unix://...` so each agent pane owns a private crush server +
+// SSE stream (see crush startDetachedServer in internal/cmd/root.go — the
+// auto-spawned server inherits `--host`). This module is Orca's in-process SSE
+// subscriber: it connects to the pane's socket, parses the chunked SSE stream,
+// and forwards each envelope to the AgentHookServer as a synthetic hook event.
+
+import http from 'node:http'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { URL } from 'node:url'
+import {
+  crushHookEventName,
+  crushHookPayload,
+  parseCrushSseChunk,
+  parseCrushSseEvent,
+  type CrushSseEnvelope
+} from '../../shared/crush-sse-shapes'
+
+export type CrushSseBridgeDeps = {
+  paneKey: string
+  launchToken: string
+  tabId?: string
+  worktreeId?: string
+  /** Called per parsed SSE envelope. Why: indirection lets tests inject a
+   *  recorder without spinning up a real crush server. */
+  onEvent: (args: { hookEventName: string; hookPayload: Record<string, unknown> }) => void
+  /** Optional sink for unrecoverable client errors (logs in prod, assertions in tests). */
+  onError?: (err: Error) => void
+}
+
+const SSE_INITIAL_BACKOFF_MS = 250
+const SSE_MAX_BACKOFF_MS = 10_000
+const SSE_REQUEST_TIMEOUT_MS = 0 // Why: 0 = no socket idle timeout; SSE is long-lived.
+
+/** Resolve the per-pane socket directory crush's auto-spawned server will bind
+ *  to. Match crush's server.DefaultHost socketDir() so the --host value we
+ *  hand it lines up byte-for-byte with what the server actually binds. */
+export function crushOrcaSocketDirectory(): string {
+  const xdg = process.env.XDG_RUNTIME_DIR
+  if (xdg && path.isAbsolute(xdg)) {
+    return xdg
+  }
+  return os.tmpdir()
+}
+
+/** Full filesystem path of the per-pane socket for a launchToken. */
+export function crushOrcaSocketPath(launchToken: string): string {
+  const safe = launchToken.replace(/[^a-zA-Z0-9_-]/g, '') || 'default'
+  return path.join(crushOrcaSocketDirectory(), `crush-orca-${safe}.sock`)
+}
+
+/** `--host` value Orca passes to crush and its auto-spawned server. */
+export function crushOrcaHostArg(launchToken: string): string {
+  return `unix://${crushOrcaSocketPath(launchToken)}` as const
+}
+
+/** Whether the SSE bridge can run on the current platform. crush's
+ *  client-server transport supports unix sockets (macOS, Linux) and Windows
+ *  named pipes; Node's `http.request({ socketPath })` only supports unix
+ *  sockets. Why: gate Windows out for v1 — title-scraping remains available. */
+export function crushSseBridgeSupported(): boolean {
+  return process.platform === 'darwin' || process.platform === 'linux'
+}
+
+export type CrushSseBridge = {
+  /** Stop the client and stop reconnecting. Idempotent. */
+  stop: () => void
+  /** True once `stop` was called. */
+  stopped: () => boolean
+}
+
+export function startCrushSseBridge(socketPath: string, deps: CrushSseBridgeDeps): CrushSseBridge {
+  // Why: Windows / unsupported runtimes return a no-op bridge so the caller
+  // does not need to branch per-platform. The failure is logged once.
+  if (!crushSseBridgeSupported()) {
+    return { stop: () => {}, stopped: () => true }
+  }
+  let stopped = false
+  let currentRequest: http.ClientRequest | null = null
+  let backoff = SSE_INITIAL_BACKOFF_MS
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  let buffer = ''
+
+  const connect = (): void => {
+    if (stopped) {
+      return
+    }
+    const req = http.request(
+      {
+        method: 'GET',
+        socketPath,
+        path: '/v1/workspaces/0/events',
+        headers: { Accept: 'text/event-stream' },
+        timeout: SSE_REQUEST_TIMEOUT_MS
+      },
+      (res) => {
+        // Why: crush returns 404/no-body if the server hasn't finished booting;
+        // schedule a reconnect instead of treating a partial response as fatal.
+        if (res.statusCode !== 200) {
+          res.resume()
+          scheduleReconnect()
+          return
+        }
+        // Why: success — reset backoff so the next retry-after-drop starts fresh.
+        backoff = SSE_INITIAL_BACKOFF_MS
+        let pending = ''
+        res.setEncoding('utf-8')
+        res.on('data', (chunk: string) => {
+          pending += chunk
+          const parsed = parseCrushSseChunk(buffer, pending)
+          buffer = parsed.rest
+          pending = ''
+          for (const ev of parsed.events) {
+            dispatch(ev)
+          }
+        })
+        res.on('end', () => scheduleReconnect())
+        res.on('error', () => scheduleReconnect())
+      }
+    )
+    req.on('error', () => scheduleReconnect())
+    currentRequest = req
+    req.end()
+  }
+
+  const dispatch = (ev: { data: string }): void => {
+    const envelope = parseCrushSseEvent(ev)
+    if (!envelope) {
+      return
+    }
+    forward(envelope)
+  }
+
+  const forward = (envelope: CrushSseEnvelope): void => {
+    const hookEventName = crushHookEventName(envelope)
+    if (!hookEventName) {
+      return
+    }
+    const hookPayload = crushHookPayload(envelope)
+    try {
+      deps.onEvent({ hookEventName, hookPayload })
+    } catch (err) {
+      // Why: the sink (AgentHookServer.submitSyntheticHookEvent) is itself
+      // guarded, but wrap once more so a throwing observer can't kill the loop.
+      deps.onError?.(err instanceof Error ? err : new Error(String(err)))
+    }
+  }
+
+  const scheduleReconnect = (): void => {
+    if (stopped) {
+      return
+    }
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer)
+    }
+    currentRequest?.destroy()
+    currentRequest = null
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null
+      backoff = Math.min(backoff * 2, SSE_MAX_BACKOFF_MS)
+      connect()
+    }, backoff)
+    if (typeof reconnectTimer.unref === 'function') {
+      reconnectTimer.unref()
+    }
+  }
+
+  connect()
+
+  return {
+    stop: () => {
+      stopped = true
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      currentRequest?.destroy()
+      currentRequest = null
+    },
+    stopped: () => stopped
+  }
+}
+
+/** Re-exported for tests that need to assert the URL form. */
+export { URL }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -642,6 +642,51 @@ export class AgentHookServer {
     this.onPaneStatusCleared = listener
   }
 
+  /** Submit a hook event synthesized by an in-process Orca subsystem (no HTTP
+   *  POST). Why: crush has no CLI hook contract; Orca subscribes to its SSE
+   *  stream and re-emits each envelope as a synthetic hook event via this
+   *  method so it flows through the same normalize→apply pipeline as real hooks.
+   *  Source-specific jurisprudence (exhaustive switch in normalizeHookPayload)
+   *  still applies because the synthesized body carries source-tagged fields. */
+  submitSyntheticHookEvent(args: {
+    source: AgentHookSource
+    paneKey: string
+    launchToken?: string
+    tabId?: string
+    worktreeId?: string
+    hookEventName: string
+    hookPayload: Record<string, unknown>
+  }): void {
+    if (!args.paneKey) {
+      return
+    }
+    const body: Record<string, unknown> = {
+      paneKey: args.paneKey,
+      hook_event_name: args.hookEventName,
+      payload: args.hookPayload,
+      env: 'production'
+    }
+    if (args.launchToken) {
+      body.launchToken = args.launchToken
+    }
+    if (args.tabId) {
+      body.tabId = args.tabId
+    }
+    if (args.worktreeId) {
+      body.worktreeId = args.worktreeId
+    }
+    try {
+      const normalized = normalizeHookPayload(this.state, args.source, body, this.env)
+      if (!normalized || this.shouldSuppressClosedTabStatus(normalized.paneKey)) {
+        return
+      }
+      this.applyNormalizedStatus(normalized)
+    } catch (err) {
+      // Why: a malformed SSE envelope must never crash the SSE client loop.
+      console.error('[agent-hooks] synthetic hook event failed', err)
+    }
+  }
+
   /** Snapshot of cached statuses in IPC shape. Used by `agentStatus:getSnapshot` after tabs hydrate so the
    *  dashboard catches up on hook events that fired during startup. */
   getStatusSnapshot(): AgentStatusIpcPayload[] {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -664,7 +664,7 @@ export class AgentHookServer {
       paneKey: args.paneKey,
       hook_event_name: args.hookEventName,
       payload: args.hookPayload,
-      env: 'production'
+      env: this.env
     }
     if (args.launchToken) {
       body.launchToken = args.launchToken

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -385,7 +385,7 @@ import {
 import {
   crushOrcaHostArg,
   crushOrcaSocketPath,
-  crushSseBridgeSupported,
+  crushSseEnabledForLaunch,
   startCrushSseBridge,
   type CrushSseBridge
 } from '../agent-hooks/crush-sse-bridge'
@@ -24224,11 +24224,15 @@ export class OrcaRuntimeService {
       // Why: crush has no CLI hook contract. Orca enables crush's client-server
       // mode (CRUSH_CLIENT_SERVER=1) and points crush at a per-pane custom unix
       // socket via --host so each agent pane owns a private crush server + SSE
-      // stream that Orca subscribes to for status reporting. Gated to non-Windows
-      // because Node's socketPath HTTP transport is unix-only; on Windows crush
-      // falls back to the generic title-scraping status detector.
-      const crushSseEnabled =
-        launchOpts.launchAgent === 'crush' && !!launchToken && crushSseBridgeSupported()
+      // stream that Orca subscribes to for status reporting. Gated to local
+      // non-Windows launches: Node's socketPath HTTP transport is unix-only, and
+      // remote (SSH/relay) crush spawns its server on the remote host, so Orca's
+      // local dial would never connect — remote crush keeps title-scraping.
+      const crushSseEnabled = crushSseEnabledForLaunch({
+        launchAgent: launchOpts.launchAgent,
+        launchToken,
+        connectionId: workspace.connectionId
+      })
       const crushHostArg = crushSseEnabled && launchToken ? crushOrcaHostArg(launchToken) : null
       const baseEnv = {
         ...launchOpts.env,
@@ -28251,9 +28255,12 @@ export class OrcaRuntimeService {
   }
 
   private dropDisconnectedPtyRecord(ptyId: string): void {
-    // Why: pruning can remove a PTY without the normal exit callback.
+    // Why: pruning can remove a PTY without the normal exit callback, so the
+    // crush SSE bridge must be stopped here too — otherwise its reconnect loop
+    // outlives the pane and dials a socket that will never come back.
     this.advancePtyLifecycleGeneration(ptyId)
     this.pairedRendererSessionOwnedPtyIds.delete(ptyId)
+    this.ptysById.get(ptyId)?.crushSseBridge?.stop()
     this.ptysById.delete(ptyId)
     this.recentPtyOutputById.delete(ptyId)
     this.setupCompletionTokenByPtyId.delete(ptyId)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -382,6 +382,14 @@ import {
   buildAgentResumeStartupPlan,
   buildAgentStartupPlan
 } from '../../shared/tui-agent-startup'
+import {
+  crushOrcaHostArg,
+  crushOrcaSocketPath,
+  crushSseBridgeSupported,
+  startCrushSseBridge,
+  type CrushSseBridge
+} from '../agent-hooks/crush-sse-bridge'
+import { agentHookServer } from '../agent-hooks/server'
 import { repoIsRemote } from '../../shared/agent-launch-remote'
 import {
   isAgentForegroundWrapperProcess,
@@ -1255,6 +1263,11 @@ type RuntimePtyWorktreeRecord = {
   waitBlockedAt: number | null
   // Why: memoized wait scan of the current retained tail (see RuntimeLeafRecord).
   tailWaitState?: TerminalTailWaitState
+  // Why: crush (charmbracelet/crush) SSE bridge for agent-status reporting.
+  // crush has no CLI hook contract; Orca subscribes to its per-pane SSE stream
+  // and stops the subscriber when the crush PTY exits. Field is optional because
+  // non-crush PTYs never carry one and crush on Windows is unsupported.
+  crushSseBridge?: CrushSseBridge
 }
 
 type TerminalCreateOptions = {
@@ -12886,6 +12899,13 @@ export class OrcaRuntimeService {
       this.intentionalHandlelessPtyStops.has(ptyId) &&
       (intentionalStopIncarnation === null || intentionalStopIncarnation === incarnationId)
     advertisedUrlWatcher.unbindPty(ptyId)
+    // Why: stop the crush SSE subscriber synchronously so reconnect timers
+    // don't outlive the crush PTY; idempotent if crush was never enabled.
+    const ptyForBridge = this.ptysById.get(ptyId)
+    ptyForBridge?.crushSseBridge?.stop()
+    if (ptyForBridge) {
+      ptyForBridge.crushSseBridge = undefined
+    }
     // Clean up new mobile state for this PTY
     this.mobileSubscribers.delete(ptyId)
     this.remoteTerminalViewSubscriberCounts.delete(ptyId)
@@ -24201,9 +24221,19 @@ export class OrcaRuntimeService {
       const launchToken = launchOpts.launchConfig
         ? (launchOpts.launchToken ?? randomUUID())
         : undefined
+      // Why: crush has no CLI hook contract. Orca enables crush's client-server
+      // mode (CRUSH_CLIENT_SERVER=1) and points crush at a per-pane custom unix
+      // socket via --host so each agent pane owns a private crush server + SSE
+      // stream that Orca subscribes to for status reporting. Gated to non-Windows
+      // because Node's socketPath HTTP transport is unix-only; on Windows crush
+      // falls back to the generic title-scraping status detector.
+      const crushSseEnabled =
+        launchOpts.launchAgent === 'crush' && !!launchToken && crushSseBridgeSupported()
+      const crushHostArg = crushSseEnabled && launchToken ? crushOrcaHostArg(launchToken) : null
       const baseEnv = {
         ...launchOpts.env,
-        ...(launchToken ? { ORCA_AGENT_LAUNCH_TOKEN: launchToken } : {})
+        ...(launchToken ? { ORCA_AGENT_LAUNCH_TOKEN: launchToken } : {}),
+        ...(crushSseEnabled ? { CRUSH_CLIENT_SERVER: '1' } : {})
       }
       const claudeAgentTeamsSourceCommand =
         launchOpts.claudeAgentTeamsSourceCommand?.trim() || launchOpts.command?.trim() || undefined
@@ -24273,13 +24303,23 @@ export class OrcaRuntimeService {
       if (launchOpts.signal?.aborted) {
         throw new Error('client_disconnected')
       }
+      // Why: crush's `--host` arg must be appended to the launch command so
+      // crush's auto-spawned `crush server` binds the per-pane socket Orca
+      // subscribes to. crush's promptInjectionMode is stdin-after-start, so the
+      // command here is pre-prompt and a trailing --host is safe. Other agents
+      // and Windows crush (no socketPath support) leave the command verbatim.
+      const launchCommandForSpawn = sequencedStartupCommand
+        ? launchOpts.command
+        : (agentTeamsPlan?.command ?? launchOpts.command)
+      const crushCommandWithHost =
+        crushHostArg && launchCommandForSpawn
+          ? `${launchCommandForSpawn} --host ${crushHostArg}`
+          : launchCommandForSpawn
       const result = await this.ptyController.spawn({
         cols: 120,
         rows: 40,
         cwd,
-        command: sequencedStartupCommand
-          ? launchOpts.command
-          : (agentTeamsPlan?.command ?? launchOpts.command),
+        command: crushCommandWithHost,
         launchAgent: launchOpts.launchAgent,
         commandDelivery: 'provider',
         startupCommandDelivery: launchOpts.startupCommandDelivery,
@@ -24370,6 +24410,33 @@ export class OrcaRuntimeService {
           : null
         pty.launchToken = launchToken ?? null
         pty.launchAgent = launchOpts.launchAgent ?? null
+        // Why: start the crush SSE subscriber once the PTY record exists so
+        // status events flow through the same hook ingest pipeline as native
+        // hooks. Pass launchToken/tabId/worktreeId so synthetic events carry
+        // the same attribution real hook posts do.
+        if (crushSseEnabled && launchToken) {
+          const bridge = startCrushSseBridge(crushOrcaSocketPath(launchToken), {
+            paneKey,
+            launchToken,
+            tabId,
+            worktreeId: workspace.id,
+            onEvent: ({ hookEventName, hookPayload }) => {
+              agentHookServer.submitSyntheticHookEvent({
+                source: 'crush',
+                paneKey,
+                launchToken,
+                tabId,
+                worktreeId: workspace.id,
+                hookEventName,
+                hookPayload
+              })
+            },
+            onError: (err) => {
+              console.warn('[crush-sse-bridge]', err.message)
+            }
+          })
+          pty.crushSseBridge = bridge
+        }
       }
       const handle = pty ? this.issuePtyHandle(pty) : preAllocatedHandle
       if (pty && launchOpts.deferMobileSessionPublish !== true) {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2314,6 +2314,9 @@ function isNewTurnEvent(source: AgentHookSource, eventName: unknown): boolean {
     case 'devin':
       // Why: SessionStart is handled by an early return in normalizeDevinEvent, so UserPromptSubmit is Devin's real new-turn boundary here.
       return eventName === 'UserPromptSubmit'
+    case 'crush':
+      // Why: crush SSE role=user messages are the new-turn boundary (user submitted a prompt); assistant messages are working updates.
+      return eventName === 'message:user'
   }
 }
 
@@ -2405,6 +2408,8 @@ function extractToolFields(
       return extractHermesToolFields(eventName, hookPayload)
     case 'devin':
       return extractClaudeToolFields(eventName, hookPayload)
+    case 'crush':
+      return extractCrushToolFields(eventName, hookPayload)
   }
 }
 
@@ -3100,6 +3105,201 @@ function pruneAmpThreadCacheKeys(
     state.ampCompletedCacheKeys.delete(key)
     overflow--
   }
+}
+
+// ─── Crush (charmbracelet/crush) SSE bridge normalizer ────────────────────────
+// Why: crush has no CLI hook contract. Orca subscribes to crush's per-pane SSE
+// stream (CRUSH_CLIENT_SERVER=1 + custom --host socket per pane) and synthesizes
+// a hook event per envelope. hookEventName is the SSE payload type, with `message`
+// split into `message:user` (new turn) / `message:assistant` (working update) so
+// the existing isNewTurnEvent(source, eventName) contract (eventName-only) can
+// discriminate the two roles. hookPayload carries the inner SSE payload verbatim.
+
+function extractCrushToolFields(
+  eventName: unknown,
+  hookPayload: Record<string, unknown>
+): ToolSnapshot {
+  if (eventName === 'message:assistant') {
+    const parts = hookPayload.parts
+    if (!Array.isArray(parts)) {
+      return {}
+    }
+    // Why: the latest unfinished tool_call is the active tool; finished ones are stale tool_result waits already shown as permission blockers.
+    for (const partRaw of parts) {
+      if (
+        typeof partRaw !== 'object' ||
+        partRaw === null ||
+        (partRaw as { type?: string }).type !== 'tool_call'
+      ) {
+        continue
+      }
+      const data = (partRaw as { data?: Record<string, unknown> }).data
+      if (!data) {
+        continue
+      }
+      const toolName = typeof data.name === 'string' ? data.name : undefined
+      const toolInputSource = data.input
+      return toolUpdate(
+        {
+          toolName,
+          toolInput:
+            deriveToolInputPreview(toolName, toolInputSource) ??
+            deriveFallbackToolInputPreview(toolInputSource)
+        },
+        { hasToolInputField: toolInputSource !== undefined }
+      )
+    }
+    return {}
+  }
+  if (eventName === 'permission_request') {
+    const toolName = readString(hookPayload, 'tool_name')
+    const params = hookPayload.params
+    const toolInput =
+      deriveToolInputPreview(toolName, params) ??
+      deriveToolInputPreview(toolName, hookPayload.path) ??
+      deriveFallbackToolInputPreview(params)
+    return toolUpdate(
+      { toolName, toolInput },
+      { hasToolInputField: params !== undefined || hookPayload.path !== undefined }
+    )
+  }
+  if (eventName === 'run_complete') {
+    const text = readString(hookPayload, 'text')
+    if (text) {
+      return { lastAssistantMessage: text }
+    }
+    return {}
+  }
+  return {}
+}
+
+function crushUserMessageText(hookPayload: Record<string, unknown>): string {
+  const parts = hookPayload.parts
+  if (!Array.isArray(parts)) {
+    return ''
+  }
+  let text = ''
+  for (const partRaw of parts) {
+    if (
+      typeof partRaw !== 'object' ||
+      partRaw === null ||
+      (partRaw as { type?: string }).type !== 'text'
+    ) {
+      continue
+    }
+    const data = (partRaw as { data?: { text?: unknown } }).data
+    if (data && typeof data.text === 'string') {
+      text += data.text
+    }
+  }
+  return text
+}
+
+function crushAssistantMessageText(hookPayload: Record<string, unknown>): string {
+  const parts = hookPayload.parts
+  if (!Array.isArray(parts)) {
+    return ''
+  }
+  let text = ''
+  for (const partRaw of parts) {
+    if (
+      typeof partRaw !== 'object' ||
+      partRaw === null ||
+      (partRaw as { type?: string }).type !== 'text'
+    ) {
+      continue
+    }
+    const data = (partRaw as { data?: { text?: unknown } }).data
+    if (data && typeof data.text === 'string') {
+      text += data.text
+    }
+  }
+  return text
+}
+
+function normalizeCrushEvent(
+  state: HookListenerState,
+  eventName: unknown,
+  _promptText: string,
+  paneKey: string,
+  hookPayload: Record<string, unknown>
+): ParsedAgentStatusPayload | null {
+  // Why: crush SSE gives us the user's prompt directly via the role=user message
+  // (a turn-start boundary). _promptText arrives empty from the SSE bridge since
+  // crush never POSTs a hook; the prompt is resolved from the user-message parts.
+  const isNewUserTurn = eventName === 'message:user'
+  let stateName: 'working' | 'blocked' | 'done' | null = null
+  let interrupted: boolean | undefined
+  let assistantMessage: string | undefined
+
+  if (eventName === 'message:user' || eventName === 'message:assistant') {
+    stateName = 'working'
+  } else if (eventName === 'permission_request') {
+    stateName = 'blocked'
+  } else if (eventName === 'run_complete') {
+    stateName = 'done'
+    interrupted = hookPayload.cancelled === true ? true : undefined
+    const text = readString(hookPayload, 'text')
+    if (text) {
+      assistantMessage = text
+    }
+  } else if (eventName === 'agent_event') {
+    // Why: agent_event with type=response fires just before run_complete and
+    // confirms the agent's turn has ended; type=error/error surface agent failures.
+    // Treat both as terminal `done`. run_complete (if it follows) is idempotent.
+    const eventType = readString(hookPayload, 'type')
+    if (eventType === 'response' || eventType === 'error' || eventType === 'summarize') {
+      stateName = 'done'
+      if (eventType === 'error') {
+        const errMsg = readString(hookPayload, 'error')
+        if (errMsg) {
+          assistantMessage = errMsg
+        }
+      }
+    } else {
+      return null
+    }
+  } else {
+    return null
+  }
+
+  const resetOnNewTurn = isNewUserTurn
+  const snapshot = resolveToolState(
+    state,
+    paneKey,
+    extractCrushToolFields(eventName, hookPayload),
+    {
+      resetOnNewTurn
+    }
+  )
+
+  let promptText = ''
+  if (isNewUserTurn) {
+    promptText = crushUserMessageText(hookPayload)
+  } else if (eventName === 'message:assistant' && !state.lastPromptByPaneKey.has(paneKey)) {
+    // Why: the first assistant message after launch implies the user already
+    // submitted (Orca pre-injected a prompt via stdin). Fall back to that prompt,
+    // carried indirectly through resolvePrompt's retained last value.
+    promptText = ''
+  }
+
+  const lastAssistant =
+    assistantMessage ??
+    (eventName === 'message:assistant' ? crushAssistantMessageText(hookPayload) : undefined)
+
+  return parseAgentStatusPayload(
+    JSON.stringify({
+      state: stateName,
+      prompt: resolvePrompt(state, paneKey, promptText, { resetOnNewTurn }),
+      agentType: 'crush',
+      ...(readString(hookPayload, 'model') ? { model: readString(hookPayload, 'model') } : {}),
+      toolName: snapshot.toolName,
+      toolInput: snapshot.toolInput,
+      interactivePrompt: snapshot.interactivePrompt,
+      ...(lastAssistant ? { lastAssistantMessage: lastAssistant } : {}),
+      ...(interrupted ? { interrupted } : {})
+    })
+  )
 }
 
 function hasExplicitPromptForSource(
@@ -4043,6 +4243,9 @@ export function normalizeHookPayload(
     case 'kimi':
       payload = normalizeKimiEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
       break
+    case 'crush':
+      payload = normalizeCrushEvent(state, eventName, promptText, paneKey, hookPayloadRecord)
+      break
   }
 
   // Why: connectionId is null here; ingestRemote stamps it from mux identity on receive. See docs/design/agent-status-over-ssh.md §5.
@@ -4110,7 +4313,10 @@ export const HOOK_SOURCE_BY_PATHNAME: Readonly<Record<string, AgentHookSource>> 
   '/hook/copilot': 'copilot',
   '/hook/hermes': 'hermes',
   '/hook/devin': 'devin',
-  '/hook/kimi': 'kimi'
+  '/hook/kimi': 'kimi',
+  // Why: crush never POSTs here — its SSE bridge feeds via submitSyntheticHookEvent.
+  // Kept so resolveHookSource round-trips an explicit /hook/crush POST (tests, future).
+  '/hook/crush': 'crush'
 })
 
 export function resolveHookSource(pathname: string): AgentHookSource | null {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -3228,7 +3228,7 @@ function normalizeCrushEvent(
     // confirms the agent's turn has ended; type=error/error surface agent failures.
     // Treat both as terminal `done`. run_complete (if it follows) is idempotent.
     const eventType = readString(hookPayload, 'type')
-    if (eventType === 'response' || eventType === 'error' || eventType === 'summarize') {
+    if (eventType === 'response' || eventType === 'error') {
       stateName = 'done'
       if (eventType === 'error') {
         const errMsg = readString(hookPayload, 'error')

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -20,6 +20,7 @@ import { isAbsolute, join } from 'node:path'
 import {
   AGENT_MODEL_MAX_LENGTH,
   normalizeAgentStatusPayload,
+  parseAgentStatusPayload,
   type AgentStatusState,
   type AgentSubagentSnapshot,
   type ParsedAgentStatusPayload
@@ -3125,7 +3126,8 @@ function extractCrushToolFields(
       return {}
     }
     // Why: the latest unfinished tool_call is the active tool; finished ones are stale tool_result waits already shown as permission blockers.
-    for (const partRaw of parts) {
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const partRaw = parts[i]
       if (
         typeof partRaw !== 'object' ||
         partRaw === null ||
@@ -3134,7 +3136,7 @@ function extractCrushToolFields(
         continue
       }
       const data = (partRaw as { data?: Record<string, unknown> }).data
-      if (!data) {
+      if (!data || data.finished === true) {
         continue
       }
       const toolName = typeof data.name === 'string' ? data.name : undefined
@@ -3173,29 +3175,7 @@ function extractCrushToolFields(
   return {}
 }
 
-function crushUserMessageText(hookPayload: Record<string, unknown>): string {
-  const parts = hookPayload.parts
-  if (!Array.isArray(parts)) {
-    return ''
-  }
-  let text = ''
-  for (const partRaw of parts) {
-    if (
-      typeof partRaw !== 'object' ||
-      partRaw === null ||
-      (partRaw as { type?: string }).type !== 'text'
-    ) {
-      continue
-    }
-    const data = (partRaw as { data?: { text?: unknown } }).data
-    if (data && typeof data.text === 'string') {
-      text += data.text
-    }
-  }
-  return text
-}
-
-function crushAssistantMessageText(hookPayload: Record<string, unknown>): string {
+function crushMessageText(hookPayload: Record<string, unknown>): string {
   const parts = hookPayload.parts
   if (!Array.isArray(parts)) {
     return ''
@@ -3275,7 +3255,7 @@ function normalizeCrushEvent(
 
   let promptText = ''
   if (isNewUserTurn) {
-    promptText = crushUserMessageText(hookPayload)
+    promptText = crushMessageText(hookPayload)
   } else if (eventName === 'message:assistant' && !state.lastPromptByPaneKey.has(paneKey)) {
     // Why: the first assistant message after launch implies the user already
     // submitted (Orca pre-injected a prompt via stdin). Fall back to that prompt,
@@ -3285,7 +3265,7 @@ function normalizeCrushEvent(
 
   const lastAssistant =
     assistantMessage ??
-    (eventName === 'message:assistant' ? crushAssistantMessageText(hookPayload) : undefined)
+    (eventName === 'message:assistant' ? crushMessageText(hookPayload) : undefined)
 
   return parseAgentStatusPayload(
     JSON.stringify({

--- a/src/shared/agent-hook-relay.ts
+++ b/src/shared/agent-hook-relay.ts
@@ -50,6 +50,7 @@ export type AgentHookSource =
   | 'hermes'
   | 'devin'
   | 'kimi'
+  | 'crush'
 
 /** Env marker used by the remote relay. It is a transport/location marker, not
  *  a dev-vs-prod build tag, so main-process env mismatch diagnostics ignore it. */

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -228,6 +228,7 @@ export function extractAgentProviderSession(
     case 'command-code':
     case 'copilot':
     case 'hermes':
+    case 'crush':
       return null
   }
 }

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -38,6 +38,7 @@ export type WellKnownAgentType =
   | 'devin'
   | 'ante'
   | 'trae'
+  | 'crush'
   | 'unknown'
 export type AgentType = WellKnownAgentType | (string & {})
 

--- a/src/shared/crush-normalizer.test.ts
+++ b/src/shared/crush-normalizer.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: crush's SSE pipeline is one subsystem; keeping the end-to-end normalize path, SSE parser, and cache semantics together surfaces regressions. */
 import { describe, expect, it } from 'vitest'
 import { normalizeHookPayload, createHookListenerState } from './agent-hook-listener'
 import type { HookListenerState } from './agent-hook-listener'
@@ -80,6 +79,73 @@ describe('normalizeHookPayload — crush (charmbracelet/crush) SSE bridge', () =
     expect(normalized!.payload.toolInput).toBe('ls -la')
     // Why: prompt persists from the previous user message — assistant turns don't reset.
     expect(normalized!.payload.prompt).toBe('do something')
+  })
+
+  it('skips finished tool_calls and surfaces the latest unfinished one as active', () => {
+    const s = state()
+    normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:user',
+        hookPayload: { role: 'user', parts: [{ type: 'text', data: { text: 'multi-step' } }] }
+      }),
+      'production'
+    )
+    const normalized = normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:assistant',
+        hookPayload: {
+          role: 'assistant',
+          parts: [
+            // Why: an earlier finished tool_call must NOT be reported as active.
+            {
+              type: 'tool_call',
+              data: { id: 'call-stale', name: 'grep', input: 'foo', finished: true }
+            },
+            {
+              type: 'tool_call',
+              data: { id: 'call-live', name: 'bash', input: 'ls -la', finished: false }
+            }
+          ]
+        }
+      }),
+      'production'
+    )
+    expect(normalized!.payload.state).toBe('working')
+    expect(normalized!.payload.toolName).toBe('bash')
+    expect(normalized!.payload.toolInput).toBe('ls -la')
+  })
+
+  it('reports no active tool when every tool_call in an assistant message is finished', () => {
+    const s = state()
+    normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:user',
+        hookPayload: { role: 'user', parts: [{ type: 'text', data: { text: 'done-step' } }] }
+      }),
+      'production'
+    )
+    const normalized = normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:assistant',
+        hookPayload: {
+          role: 'assistant',
+          parts: [
+            { type: 'tool_call', data: { id: 'c1', name: 'bash', input: 'pwd', finished: true } }
+          ]
+        }
+      }),
+      'production'
+    )
+    expect(normalized!.payload.state).toBe('working')
+    expect(normalized!.payload.toolName).toBeUndefined()
   })
 
   it('maps a permission_request to blocked with the requesting tool', () => {

--- a/src/shared/crush-normalizer.test.ts
+++ b/src/shared/crush-normalizer.test.ts
@@ -262,6 +262,22 @@ describe('normalizeHookPayload — crush (charmbracelet/crush) SSE bridge', () =
     expect(normalized).toBeNull()
   })
 
+  it('ignores agent_event:summarize (mid-run context compression, not terminal)', () => {
+    // Why: crush emits summarize during context compaction mid-run — mapping
+    // it to done would flash the pane as finished then flip back to working
+    // on the next message:assistant event.
+    const normalized = normalizeHookPayload(
+      state(),
+      'crush',
+      crushBody({
+        hookEventName: 'agent_event',
+        hookPayload: { type: 'summarize', session_id: 's1' }
+      }),
+      'production'
+    )
+    expect(normalized).toBeNull()
+  })
+
   it('returns null for a non-crush SSE type (e.g. session)', () => {
     const normalized = normalizeHookPayload(
       state(),

--- a/src/shared/crush-normalizer.test.ts
+++ b/src/shared/crush-normalizer.test.ts
@@ -1,0 +1,211 @@
+/* eslint-disable max-lines -- Why: crush's SSE pipeline is one subsystem; keeping the end-to-end normalize path, SSE parser, and cache semantics together surfaces regressions. */
+import { describe, expect, it } from 'vitest'
+import { normalizeHookPayload, createHookListenerState } from './agent-hook-listener'
+import type { HookListenerState } from './agent-hook-listener'
+import { makePaneKey } from './stable-pane-id'
+
+const LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const PANE_KEY = makePaneKey('tab-1', LEAF_ID)
+
+function state(): HookListenerState {
+  return createHookListenerState()
+}
+
+/** Build a synthetic crush SSE body the way Orca's SSE bridge does.
+ *  Mirrors AgentHookServer.submitSyntheticHookEvent. */
+function crushBody(args: { hookEventName: string; hookPayload: unknown }): Record<string, unknown> {
+  return {
+    paneKey: PANE_KEY,
+    hook_event_name: args.hookEventName,
+    payload: args.hookPayload
+  }
+}
+
+describe('normalizeHookPayload — crush (charmbracelet/crush) SSE bridge', () => {
+  it('treats a role=user message as a new turn and captures the prompt', () => {
+    const normalized = normalizeHookPayload(
+      state(),
+      'crush',
+      crushBody({
+        hookEventName: 'message:user',
+        hookPayload: {
+          id: 'm1',
+          role: 'user',
+          parts: [{ type: 'text', data: { text: 'refactor the parser' } }]
+        }
+      }),
+      'production'
+    )
+    expect(normalized).not.toBeNull()
+    expect(normalized!.payload.state).toBe('working')
+    expect(normalized!.payload.agentType).toBe('crush')
+    expect(normalized!.payload.prompt).toBe('refactor the parser')
+  })
+
+  it('maps an assistant message with an unfinished tool_call to working + tool fields', () => {
+    const s = state()
+    // Why: seed the prompt so it survives a tool-only update (assistant turns don't reset prompt).
+    normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:user',
+        hookPayload: {
+          role: 'user',
+          parts: [{ type: 'text', data: { text: 'do something' } }]
+        }
+      }),
+      'production'
+    )
+    const normalized = normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:assistant',
+        hookPayload: {
+          role: 'assistant',
+          parts: [
+            {
+              type: 'tool_call',
+              data: { id: 'call-1', name: 'bash', input: 'ls -la', finished: false }
+            }
+          ]
+        }
+      }),
+      'production'
+    )
+    expect(normalized).not.toBeNull()
+    expect(normalized!.payload.state).toBe('working')
+    expect(normalized!.payload.toolName).toBe('bash')
+    expect(normalized!.payload.toolInput).toBe('ls -la')
+    // Why: prompt persists from the previous user message — assistant turns don't reset.
+    expect(normalized!.payload.prompt).toBe('do something')
+  })
+
+  it('maps a permission_request to blocked with the requesting tool', () => {
+    const s = state()
+    normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:user',
+        hookPayload: { role: 'user', parts: [{ type: 'text', data: { text: 'write a file' } }] }
+      }),
+      'production'
+    )
+    const normalized = normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'permission_request',
+        hookPayload: {
+          id: 'p1',
+          tool_name: 'write',
+          path: '/repo/foo.txt',
+          params: { file_path: '/repo/foo.txt' }
+        }
+      }),
+      'production'
+    )
+    expect(normalized!.payload.state).toBe('blocked')
+    expect(normalized!.payload.toolName).toBe('write')
+  })
+
+  it('maps run_complete to done with the final assistant text', () => {
+    const s = state()
+    normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'message:user',
+        hookPayload: { role: 'user', parts: [{ type: 'text', data: { text: 'hello' } }] }
+      }),
+      'production'
+    )
+    const normalized = normalizeHookPayload(
+      s,
+      'crush',
+      crushBody({
+        hookEventName: 'run_complete',
+        hookPayload: {
+          session_id: 's1',
+          run_id: 'r1',
+          message_id: 'm1',
+          text: 'hi there',
+          cancelled: false
+        }
+      }),
+      'production'
+    )
+    expect(normalized!.payload.state).toBe('done')
+    expect(normalized!.payload.lastAssistantMessage).toBe('hi there')
+    expect(normalized!.payload.interrupted).toBeUndefined()
+  })
+
+  it('sets interrupted when run_complete carries cancelled=true', () => {
+    const normalized = normalizeHookPayload(
+      state(),
+      'crush',
+      crushBody({
+        hookEventName: 'run_complete',
+        hookPayload: { session_id: 's1', message_id: 'm1', cancelled: true }
+      }),
+      'production'
+    )
+    expect(normalized!.payload.state).toBe('done')
+    expect(normalized!.payload.interrupted).toBe(true)
+  })
+
+  it('maps an agent_event with type=response to done', () => {
+    const normalized = normalizeHookPayload(
+      state(),
+      'crush',
+      crushBody({
+        hookEventName: 'agent_event',
+        hookPayload: { type: 'response', session_id: 's1' }
+      }),
+      'production'
+    )
+    expect(normalized!.payload.state).toBe('done')
+  })
+
+  it('maps an agent_event with type=error to done with the error as lastAssistantMessage', () => {
+    const normalized = normalizeHookPayload(
+      state(),
+      'crush',
+      crushBody({
+        hookEventName: 'agent_event',
+        hookPayload: { type: 'error', error: 'API 401' }
+      }),
+      'production'
+    )
+    expect(normalized!.payload.state).toBe('done')
+    expect(normalized!.payload.lastAssistantMessage).toBe('API 401')
+  })
+
+  it('ignores agent_event with an unknown inner type', () => {
+    const normalized = normalizeHookPayload(
+      state(),
+      'crush',
+      crushBody({
+        hookEventName: 'agent_event',
+        hookPayload: { type: 'unknown-event' }
+      }),
+      'production'
+    )
+    expect(normalized).toBeNull()
+  })
+
+  it('returns null for a non-crush SSE type (e.g. session)', () => {
+    const normalized = normalizeHookPayload(
+      state(),
+      'crush',
+      crushBody({
+        hookEventName: 'session',
+        hookPayload: { id: 's1', title: 'New session' }
+      }),
+      'production'
+    )
+    expect(normalized).toBeNull()
+  })
+})

--- a/src/shared/crush-sse-shapes.test.ts
+++ b/src/shared/crush-sse-shapes.test.ts
@@ -104,6 +104,30 @@ describe('parseCrushSseChunk', () => {
     const { events } = parseCrushSseChunk('', 'event: noop\n\n')
     expect(events).toHaveLength(0)
   })
+
+  it('parses CRLF-terminated events (\\r\\n\\r\\n separator)', () => {
+    const { events, rest } = parseCrushSseChunk('', 'data: {"type":"run_complete"}\r\n\r\n')
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toBe('{"type":"run_complete"}')
+    expect(rest).toBe('')
+  })
+
+  it('parses CR-only-terminated events (\\r\\r separator)', () => {
+    const { events, rest } = parseCrushSseChunk('', 'data: {"type":"message"}\r\r')
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toBe('{"type":"message"}')
+    expect(rest).toBe('')
+  })
+
+  it('parses mixed line endings within a single chunk', () => {
+    const { events } = parseCrushSseChunk(
+      '',
+      'data: line-1\r\ndata: line-2\r\n\r\ndata: {"type":"done"}\n\n'
+    )
+    expect(events).toHaveLength(2)
+    expect(events[0].data).toBe('line-1\nline-2')
+    expect(events[1].data).toBe('{"type":"done"}')
+  })
 })
 
 describe('parseCrushSseEvent', () => {

--- a/src/shared/crush-sse-shapes.test.ts
+++ b/src/shared/crush-sse-shapes.test.ts
@@ -28,6 +28,31 @@ describe('crushOrcaHostUrl', () => {
     expect(crushOrcaHostUrl('/tmp', 'tok-id')).toBe('unix:///tmp/crush-orca-tok-id.sock')
     expect(crushOrcaHostUrl('/var/run/', 'tok-id')).toBe('unix:///var/run/crush-orca-tok-id.sock')
   })
+
+  it('keeps the full path under sun_path even with a long tmpdir + UUID token', () => {
+    // Why: a 60-char tmpdir + 36-char UUID token would be 60+1+52=113 (> macOS
+    // sun_path 104). The hash fallback collapses the token to 12 hex chars
+    // (60+1+28=89 ✓). Larger tmpdirs show up on some CI/dev sandboxes.
+    const longDir = `/${'x'.repeat(59)}` // 60 chars
+    const url = crushOrcaHostUrl(longDir, '550e8400-e29b-41d4-a716-446655440000')
+    expect(url.startsWith('unix://')).toBe(true)
+    const socketPath = url.slice('unix://'.length)
+    expect(socketPath.length).toBeLessThanOrEqual(103)
+    // Why: hashed filenames are deterministic — Orca's dial path must match the
+    // path crush's auto-spawned server binds (both derive from the same launchToken).
+    expect(crushOrcaHostUrl(longDir, '550e8400-e29b-41d4-a716-446655440000')).toBe(url)
+    // Sanity: a short dir with the same token keeps the literal form (no hash).
+    expect(crushOrcaHostUrl('/tmp', '550e8400-e29b-41d4-a716-446655440000')).toBe(
+      'unix:///tmp/crush-orca-550e8400-e29b-41d4-a716-446655440000.sock'
+    )
+  })
+
+  it('produces distinct hashed filenames for distinct tokens on a long dir', () => {
+    const longDir = `/${'x'.repeat(59)}`
+    const a = crushOrcaHostUrl(longDir, '550e8400-e29b-41d4-a716-446655440000')
+    const b = crushOrcaHostUrl(longDir, '6ba7b810-9dad-11d1-80b4-00c04fd430c8')
+    expect(a).not.toBe(b)
+  })
 })
 
 describe('parseCrushSseChunk', () => {

--- a/src/shared/crush-sse-shapes.test.ts
+++ b/src/shared/crush-sse-shapes.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest'
+import { vi } from 'vitest'
+import {
+  crushHookEventName,
+  crushHookPayload,
+  crushOrcaHostUrl,
+  crushOrcaSocketFileName,
+  parseCrushSseChunk,
+  parseCrushSseEvent
+} from './crush-sse-shapes'
+
+describe('crushOrcaSocketFileName', () => {
+  it('sanitizes the launch token', () => {
+    expect(crushOrcaSocketFileName('abc-123_XYZ')).toBe('crush-orca-abc-123_XYZ.sock')
+  })
+
+  it('strips filesystem-unsafe characters', () => {
+    expect(crushOrcaSocketFileName('a/b:c')).toBe('crush-orca-abc.sock')
+  })
+
+  it('falls back when empty', () => {
+    expect(crushOrcaSocketFileName('')).toBe('crush-orca-default.sock')
+  })
+})
+
+describe('crushOrcaHostUrl', () => {
+  it('builds a unix:// URL with a trailing-slash-stripped dir', () => {
+    expect(crushOrcaHostUrl('/tmp', 'tok-id')).toBe('unix:///tmp/crush-orca-tok-id.sock')
+    expect(crushOrcaHostUrl('/var/run/', 'tok-id')).toBe('unix:///var/run/crush-orca-tok-id.sock')
+  })
+})
+
+describe('parseCrushSseChunk', () => {
+  it('parses single-line data: payloads', () => {
+    const { events, rest } = parseCrushSseChunk('', 'data: {"type":"run_complete"}\n\n')
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toBe('{"type":"run_complete"}')
+    expect(rest).toBe('')
+  })
+
+  it('parses multi-line data: payloads (joins with newline per SSE spec)', () => {
+    const { events } = parseCrushSseChunk('', 'data: line-1\ndata: line-2\n\n')
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toBe('line-1\nline-2')
+  })
+
+  it('strips a single leading space after `data:` per SSE spec', () => {
+    const { events } = parseCrushSseChunk('', 'data: hello\n\n')
+    expect(events[0].data).toBe('hello')
+  })
+
+  it('buffers an incomplete event across calls', () => {
+    const first = parseCrushSseChunk('', 'data: not-yet')
+    expect(first.events).toHaveLength(0)
+    expect(first.rest).toBe('data: not-yet')
+    const second = parseCrushSseChunk(first.rest, '-done\n\n')
+    expect(second.events).toHaveLength(1)
+    expect(second.events[0].data).toBe('not-yet-done')
+    expect(second.rest).toBe('')
+  })
+
+  it('ignores comment/field lines that are not data:', () => {
+    const { events } = parseCrushSseChunk('', ': ping\nevent: add\ndata: x\n\n')
+    expect(events).toHaveLength(1)
+    expect(events[0].data).toBe('x')
+  })
+
+  it('parses multiple events in one chunk', () => {
+    const { events } = parseCrushSseChunk(
+      '',
+      'data: {"type":"message"}\n\ndata: {"type":"run_complete"}\n\n'
+    )
+    expect(events).toHaveLength(2)
+    expect(events[0].data).toBe('{"type":"message"}')
+    expect(events[1].data).toBe('{"type":"run_complete"}')
+  })
+
+  it('skips events with no data lines', () => {
+    const { events } = parseCrushSseChunk('', 'event: noop\n\n')
+    expect(events).toHaveLength(0)
+  })
+})
+
+describe('parseCrushSseEvent', () => {
+  it('returns null for malformed JSON', () => {
+    expect(parseCrushSseEvent({ data: 'not-json' })).toBeNull()
+  })
+
+  it('parses a valid crush envelope', () => {
+    const ev = parseCrushSseEvent({
+      data: '{"type":"run_complete","payload":{"type":"updated","payload":{"session_id":"s1"}}}'
+    })
+    expect(ev?.type).toBe('run_complete')
+  })
+})
+
+describe('crushHookEventName', () => {
+  it('splits message by role', () => {
+    expect(crushHookEventName({ type: 'message', payload: { payload: { role: 'user' } } })).toBe(
+      'message:user'
+    )
+    expect(
+      crushHookEventName({ type: 'message', payload: { payload: { role: 'assistant' } } })
+    ).toBe('message:assistant')
+    expect(crushHookEventName({ type: 'message', payload: { payload: { role: 'tool' } } })).toBe(
+      'message'
+    )
+  })
+
+  it('returns the SSE type for non-message envelopes', () => {
+    expect(crushHookEventName({ type: 'run_complete' })).toBe('run_complete')
+    expect(crushHookEventName({ type: 'permission_request' })).toBe('permission_request')
+    expect(crushHookEventName({ type: 'agent_event' })).toBe('agent_event')
+  })
+
+  it('returns null for unhandled types', () => {
+    expect(crushHookEventName({ type: 'session' })).toBeNull()
+  })
+})
+
+describe('crushHookPayload', () => {
+  it('extracts the inner payload', () => {
+    expect(
+      crushHookPayload({
+        type: 'run_complete',
+        payload: { payload: { session_id: 's1', text: 'hi' } }
+      })
+    ).toEqual({ session_id: 's1', text: 'hi' })
+  })
+
+  it('returns empty record when inner payload is missing', () => {
+    expect(crushHookPayload({ type: 'run_complete' })).toEqual({})
+  })
+})
+
+// Why: ensure vi is referenced so type-only imports don't trip tree-shake warnings.
+describe('vitest wiring sanity', () => {
+  it('exposes vi', () => {
+    expect(vi.fn).toBeDefined()
+  })
+})

--- a/src/shared/crush-sse-shapes.ts
+++ b/src/shared/crush-sse-shapes.ts
@@ -5,25 +5,45 @@
 // derivation, and a stateful SSE line parser. The normalizer (agent-hook-listener)
 // and the main-process SSE client (crush-sse-bridge) both depend on these.
 
+import { createHash } from 'node:crypto'
+
 export const CRUSH_ORCA_SOCKET_PREFIX = 'crush-orca-'
+const CRUSH_ORCA_SOCKET_SUFFIX = '.sock'
+// Why: macOS sun_path is 104 bytes incl. NUL, Linux 108. Use the lower bound so
+// the bound socket path fits on both platforms; longer paths fail bind(2)/connect(2).
+const CRUSH_ORCA_SOCKET_PATH_MAX = 103
 
 /** Derive the per-pane unix socket filename Orca instructs crush to bind.
  *  Why: per-pane socket → one crush server per pane → SSE attribution is trivial
  *  (events on socket X belong to pane X), sidestepping crush's single-global-socket
- *  workspace multiplexing which would otherwise need session_id→paneKey mapping. */
-export function crushOrcaSocketFileName(launchToken: string): string {
-  // Why: launch tokens are already filesystem-safe (uuid-ish); strip just in
-  // case. Empty → `default` so a probe without a bound pane still yields a
-  // stable, unique filename (used only in tests + path validation).
-  const safe = (launchToken || 'default').replace(/[^a-zA-Z0-9_-]/g, '')
-  return `${CRUSH_ORCA_SOCKET_PREFIX}${safe}.sock`
+ *  workspace multiplexing which would otherwise need session_id→paneKey mapping.
+ *
+ *  Pass `socketDir` to enable the sun_path-safe fallback: when `dir + sep + name`
+ *  would exceed the platform's sockaddr_un limit, the token is replaced by a
+ *  12-hex sha1 digest. Deterministic → crush's auto-spawned server (which inherits
+ *  `--host`) lands on the same path Orca dials. */
+export function crushOrcaSocketFileName(launchToken: string, socketDir?: string): string {
+  const raw = (launchToken || 'default').replace(/[^a-zA-Z0-9_-]/g, '') || 'default'
+  const inline = `${CRUSH_ORCA_SOCKET_PREFIX}${raw}${CRUSH_ORCA_SOCKET_SUFFIX}`
+  if (socketDir !== undefined) {
+    const dirLen = (socketDir.endsWith('/') ? socketDir.slice(0, -1) : socketDir).length
+    if (dirLen + 1 + inline.length > CRUSH_ORCA_SOCKET_PATH_MAX) {
+      const digest = createHash('sha1')
+        .update(launchToken || 'default')
+        .digest('hex')
+        .slice(0, 12)
+      return `${CRUSH_ORCA_SOCKET_PREFIX}${digest}${CRUSH_ORCA_SOCKET_SUFFIX}`
+    }
+  }
+  return inline
 }
 
 /** Full `--host` value Orca passes to crush. `unix://` scheme + absolute socket path.
  *  Empty launchToken falls back to a generic name so callers can probe without a
- *  bound pane (used only in tests). */
+ *  bound pane (used only in tests). Truncates the token to a hash when the full
+ *  path would exceed sun_path on the host platform. */
 export function crushOrcaHostUrl(socketDir: string, launchToken: string): string {
-  const fileName = crushOrcaSocketFileName(launchToken || 'default')
+  const fileName = crushOrcaSocketFileName(launchToken || 'default', socketDir)
   return `unix://${socketDir.endsWith('/') ? socketDir.slice(0, -1) : socketDir}/${fileName}`
 }
 

--- a/src/shared/crush-sse-shapes.ts
+++ b/src/shared/crush-sse-shapes.ts
@@ -52,7 +52,7 @@ export function crushOrcaHostUrl(socketDir: string, launchToken: string): string
 /** Outer SSE envelope. `type` is the pubsub PayloadType discriminator. */
 export type CrushSseEnvelope = {
   type: 'message' | 'session' | 'permission_request' | 'agent_event' | 'run_complete' | string
-  payload?: { type: 'created' | 'updated' | 'deleted'; payload?: unknown } | unknown
+  payload?: Record<string, unknown>
 }
 
 export type CrushContentPart =
@@ -149,8 +149,9 @@ export type ParsedSseEvent = {
 
 /** Parse an SSE byte stream incrementally. Returns events fully received this
  *  call plus the leftover buffer to carry into the next call. SSE events are
- *  delimited by a blank line (`\n\n`); within an event, only `data:` lines are
- *  consumed (per spec, leading single space after `data:` is stripped). */
+ *  delimited by a blank line; per spec the line ending may be `\n`, `\r\n`,
+ *  or `\r`. Within an event, only `data:` lines are consumed (leading single
+ *  space after `data:` is stripped). */
 export function parseCrushSseChunk(
   buffer: string,
   incoming: string
@@ -158,18 +159,43 @@ export function parseCrushSseChunk(
   events: ParsedSseEvent[]
   rest: string
 } {
-  const combined = buffer + incoming
+  let combined = buffer + incoming
   const events: ParsedSseEvent[] = []
   let cursor = 0
   while (cursor < combined.length) {
-    const sep = combined.indexOf('\n\n', cursor)
-    if (sep === -1) {
+    // Why: find the next blank line — event separator. SSE allows \n, \r\n, or \r.
+    const lf = combined.indexOf('\n', cursor)
+    const cr = combined.indexOf('\r', cursor)
+    let lineEnd: number
+    let lineEndLen: number
+    if (lf === -1 && cr === -1) {
       break
+    } else if (lf === -1) {
+      lineEnd = cr
+      lineEndLen = 1
+    } else if (cr === -1) {
+      lineEnd = lf
+      lineEndLen = 1
+    } else if (cr < lf) {
+      // Why: \r\n or \r-only; skip the \n if it immediately follows \r.
+      lineEnd = cr
+      lineEndLen = lf === cr + 1 ? 2 : 1
+    } else {
+      lineEnd = lf
+      lineEndLen = 1
     }
-    const rawEvent = combined.slice(cursor, sep)
-    cursor = sep + 2
+    // Why: non-empty line — not the event separator yet. Skip ahead.
+    if (lineEnd > cursor) {
+      cursor = lineEnd + lineEndLen
+      continue
+    }
+    // Why: empty line at `cursor` — event separator. Everything up to here
+    // (minus leading content already consumed) is one complete event.
+    const rawEvent = combined.slice(0, lineEnd)
+    cursor = lineEnd + lineEndLen
+    const lines = rawEvent.split(/\r\n|\r|\n/)
     const dataLines: string[] = []
-    for (const line of rawEvent.split('\n')) {
+    for (const line of lines) {
       if (!line.startsWith('data:')) {
         continue
       }
@@ -180,6 +206,9 @@ export function parseCrushSseChunk(
     if (dataLines.length > 0) {
       events.push({ data: dataLines.join('\n') })
     }
+    // Why: drop the consumed portion, keep the remainder as new buffer.
+    combined = combined.slice(cursor)
+    cursor = 0
   }
   return { events, rest: combined.slice(cursor) }
 }

--- a/src/shared/crush-sse-shapes.ts
+++ b/src/shared/crush-sse-shapes.ts
@@ -1,0 +1,174 @@
+// Why: crush (charmbracelet/crush) runs an interactive TUI even in client-server mode.
+// Orca launches crush with `CRUSH_CLIENT_SERVER=1` and a per-pane custom `--host`
+// unix socket so each pane owns a private crush server + SSE stream. This module
+// is the pure, Electron-free shape of that stream: payload types, socket path
+// derivation, and a stateful SSE line parser. The normalizer (agent-hook-listener)
+// and the main-process SSE client (crush-sse-bridge) both depend on these.
+
+export const CRUSH_ORCA_SOCKET_PREFIX = 'crush-orca-'
+
+/** Derive the per-pane unix socket filename Orca instructs crush to bind.
+ *  Why: per-pane socket → one crush server per pane → SSE attribution is trivial
+ *  (events on socket X belong to pane X), sidestepping crush's single-global-socket
+ *  workspace multiplexing which would otherwise need session_id→paneKey mapping. */
+export function crushOrcaSocketFileName(launchToken: string): string {
+  // Why: launch tokens are already filesystem-safe (uuid-ish); strip just in
+  // case. Empty → `default` so a probe without a bound pane still yields a
+  // stable, unique filename (used only in tests + path validation).
+  const safe = (launchToken || 'default').replace(/[^a-zA-Z0-9_-]/g, '')
+  return `${CRUSH_ORCA_SOCKET_PREFIX}${safe}.sock`
+}
+
+/** Full `--host` value Orca passes to crush. `unix://` scheme + absolute socket path.
+ *  Empty launchToken falls back to a generic name so callers can probe without a
+ *  bound pane (used only in tests). */
+export function crushOrcaHostUrl(socketDir: string, launchToken: string): string {
+  const fileName = crushOrcaSocketFileName(launchToken || 'default')
+  return `unix://${socketDir.endsWith('/') ? socketDir.slice(0, -1) : socketDir}/${fileName}`
+}
+
+// ─── SSE payload wire shapes (from internal/proto + internal/pubsub/events.go) ─
+
+/** Outer SSE envelope. `type` is the pubsub PayloadType discriminator. */
+export type CrushSseEnvelope = {
+  type: 'message' | 'session' | 'permission_request' | 'agent_event' | 'run_complete' | string
+  payload?: { type: 'created' | 'updated' | 'deleted'; payload?: unknown } | unknown
+}
+
+export type CrushContentPart =
+  | { type: 'text'; data: { text: string } }
+  | { type: 'reasoning'; data: { thinking: string } }
+  | { type: 'tool_call'; data: { id: string; name: string; input: string; finished?: boolean } }
+  | {
+      type: 'tool_result'
+      data: { tool_call_id: string; name: string; content: string; is_error?: boolean }
+    }
+  | { type: 'finish'; data: { reason: string; time: number } }
+  | { type: string; data: Record<string, unknown> }
+
+export type CrushMessage = {
+  id: string
+  role: 'assistant' | 'user' | 'system' | 'tool' | string
+  session_id?: string
+  parts?: CrushContentPart[]
+  model?: string
+  provider?: string
+}
+
+export type CrushPermissionRequest = {
+  id: string
+  session_id?: string
+  tool_call_id?: string
+  tool_name: string
+  description?: string
+  action?: string
+  params?: unknown
+  path?: string
+}
+
+export type CrushRunComplete = {
+  session_id?: string
+  run_id?: string
+  message_id?: string
+  text?: string
+  error?: string
+  cancelled?: boolean
+}
+
+export type CrushAgentEvent = {
+  type: 'response' | 'error' | 'summarize' | string
+  session_id?: string
+  run_id?: string
+  message?: CrushMessage
+  error?: string
+  progress?: string
+  done?: boolean
+}
+
+/** Encode SSE payload type + (for `message`) role into a stable hook-event-name
+ *  Orca's normalizer can switch on. Why: `message` events with role=user act as a
+ *  new-turn boundary (reset tool cache) while role=assistant/tool are working
+ *  updates; the existing `isNewTurnEvent(source, eventName)` signature takes only
+ *  an eventName, so we encode role = `message:user` / `message:assistant`. */
+export function crushHookEventName(envelope: CrushSseEnvelope): string | null {
+  switch (envelope.type) {
+    case 'message': {
+      const inner = envelope.payload as { payload?: CrushMessage } | undefined
+      const msg = inner?.payload
+      const role = typeof msg === 'object' && msg !== null ? msg.role : undefined
+      return role === 'user'
+        ? 'message:user'
+        : role === 'assistant'
+          ? 'message:assistant'
+          : 'message'
+    }
+    case 'permission_request':
+    case 'run_complete':
+    case 'agent_event':
+      return envelope.type
+    default:
+      return null
+  }
+}
+
+/** Pull the event-type-specific inner payload out of the SSE envelope. */
+export function crushHookPayload(envelope: CrushSseEnvelope): Record<string, unknown> {
+  const inner = (envelope.payload as { payload?: unknown } | undefined)?.payload
+  if (inner && typeof inner === 'object' && inner !== null) {
+    return inner as Record<string, unknown>
+  }
+  return {}
+}
+
+// ─── SSE line parser (stateful, chunk-boundary tolerant) ──────────────────────
+
+export type ParsedSseEvent = {
+  /** Concatenated `data:` lines for one event. */
+  data: string
+}
+
+/** Parse an SSE byte stream incrementally. Returns events fully received this
+ *  call plus the leftover buffer to carry into the next call. SSE events are
+ *  delimited by a blank line (`\n\n`); within an event, only `data:` lines are
+ *  consumed (per spec, leading single space after `data:` is stripped). */
+export function parseCrushSseChunk(
+  buffer: string,
+  incoming: string
+): {
+  events: ParsedSseEvent[]
+  rest: string
+} {
+  const combined = buffer + incoming
+  const events: ParsedSseEvent[] = []
+  let cursor = 0
+  while (cursor < combined.length) {
+    const sep = combined.indexOf('\n\n', cursor)
+    if (sep === -1) {
+      break
+    }
+    const rawEvent = combined.slice(cursor, sep)
+    cursor = sep + 2
+    const dataLines: string[] = []
+    for (const line of rawEvent.split('\n')) {
+      if (!line.startsWith('data:')) {
+        continue
+      }
+      const value = line.slice('data:'.length)
+      // Why: SSE spec strips a single leading space after the colon.
+      dataLines.push(value.startsWith(' ') ? value.slice(1) : value)
+    }
+    if (dataLines.length > 0) {
+      events.push({ data: dataLines.join('\n') })
+    }
+  }
+  return { events, rest: combined.slice(cursor) }
+}
+
+/** Parse one SSE event's data as a crush envelope. Returns null on malformed JSON. */
+export function parseCrushSseEvent(event: ParsedSseEvent): CrushSseEnvelope | null {
+  try {
+    return JSON.parse(event.data) as CrushSseEnvelope
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

crush (charmbracelet/crush) was already registered as a launchable TUI agent, but it showed no working/thinking/editing status line — crush has no CLI hook contract like Claude/Codex/Gemini. Orca now enables crush's **client-server mode** (`CRUSH_CLIENT_SERVER=1`) with a per-pane custom unix socket passed via `--host`; the interactive TUI keeps running while Orca subscribes to the auto-spawned server's SSE stream (`GET /v1/workspaces/0/events`) and forwards each envelope as a synthetic hook event through the existing hook ingest pipeline, so crush panes get the same rich status reporting as the other supported agents.

### Why SSE and not OSC 9999
crush's own server-mode HTTP API + SSE endpoint is a first-class transport the project documents and supports. By contrast, OSC 9999 is Orca's private status protocol that other terminals don't read, and asking crush to emit it upstream would be a one-consumer private-channel request. The SSE bridge consumes crush's own event model (message / permission_request / run_complete / agent_event) with no per-side channel and no coordination needed from the crush maintainers.

## How it works

1. On crush PTY launch, Orca appends `--host unix://<tmp>/crush-orca-<launchToken>.sock` to the launch command and sets `CRUSH_CLIENT_SERVER=1` in the PTY env (gated to `crushSseBridgeSupported()`, i.e. macOS/Linux — Node's `http` unix-socket transport is unix-only).
2. crush's auto-spawned `crush server` binds the same `--host` (verified in crush's `startDetachedServer`: the spawned server inherits `--host`).
3. Orca's `startCrushSseBridge()` opens a long-lived `GET /v1/workspaces/0/events` connection on that socket, parses the chunked SSE stream in a stateful buffer-aware parser, and forwards each parsed envelope to `AgentHookServer.submitSyntheticHookEvent`.
4. The `crush` `AgentHookSource` normalizer maps SSE payload types to the standard `AgentStatusPayload` schema:
   - `message` role=user → `working` (new turn boundary; prompt resolved from text parts)
   - `message` role=assistant → `working` + active `tool_call` part's toolName/toolInput
   - `permission_request` → `blocked` with tool_name/params
   - `run_complete` → `done` with final `text` as `lastAssistantMessage`; `cancelled=true` → `interrupted: true`
   - `agent_event` type=response/error → `done`
5. On PTY exit (`onPtyExit`), the bridge's `stop()` halts reconnects and frees the handle.

## Files

- `src/shared/agent-hook-relay.ts` — add `'crush'` to `AgentHookSource` (exhaustive checks across the listener drive the remaining edits).
- `src/shared/agent-hook-listener.ts` — `normalizeCrushEvent` + `extractCrushToolFields` + four exhaustive `switch` cases (`isNewTurnEvent`, `extractToolFields`, `normalizeHookPayload` dispatch) + a `/hook/crush` route for symmetry/testing.
- `src/shared/agent-status-types.ts` — add `'crush'` to `WellKnownAgentType`.
- `src/shared/agent-session-resume.ts` — exhaustive `case 'crush'` (no provider session).
- `src/shared/crush-sse-shapes.ts` (new) — crush SSE payload wire types, stateful SSE line parser, per-pane socket path/host helpers.
- `src/main/agent-hooks/server.ts` — public `submitSyntheticHookEvent()` method so in-process subsystems can feed synthetic hook events through the same normalize→apply pipeline as HTTP POSTs.
- `src/main/agent-hooks/crush-sse-bridge.ts` (new) — node `http` unix-socket SSE client with capped exponential reconnect backoff.
- `src/main/runtime/orca-runtime.ts` — inject `CRUSH_CLIENT_SERVER=1` env and `--host unix://...` argv on crush launches; start the bridge after PTY spawn; stop it on `onPtyExit`.

## Tests

- `src/shared/crush-sse-shapes.test.ts` — 19 unit tests for socket path sanitization, SSE line/multi-line/chunk-boundary parsing, and envelope event-name/payload extraction.
- `src/shared/crush-normalizer.test.ts` — 9 end-to-end tests driving `normalizeHookPayload('crush', ...)` across every SSE payload type: user/assistant message, permission_request, run_complete (success/cancelled), agent_event (response/error/unknown), and non-hook SSE types.
- `src/main/agent-hooks/crush-sse-bridge.test.ts` — 5 socket integration tests (real unix-domain SSE server → bridge → `onEvent` forwarding, plus `stop()` idempotency). Skipped on Windows.

`pnpm typecheck`, `pnpm lint`, `pnpm test` (full suite, 35267 passing), and `pnpm build` all green.

## Reviewer summary (per CONTRIBUTING)

- **Cross-platform compatibility:** Unix-socket SSE is macOS/Linux only; Windows crush panes get a no-op bridge and continue to rely on the existing generic title-scraping detector. `crushSseBridgeSupported()` gates both the env injection and the bridge lifecycle. The socket directory uses `XDG_RUNTIME_DIR` when set and absolute, otherwise `os.tmpdir()` — matching crush's own `server.DefaultHost` resolution so the `--host` value lines up byte-for-byte with what the auto-spawned server binds.
- **SSH/remote compatibility:** The `CRUSH_CLIENT_SERVER` gateway plus an unknown-authority socket make remote crush unergonomic for v1, so the runtime guard further gates env injection to local launches; remote crush panes fall back to title-scraping just like today.
- **Supported agent / integration compatibility:** crush's `TUI_AGENT_CONFIG` entry is unchanged. Other agents are untouched — the `crush` branch is added as a new `AgentHookSource` case behind explicit `'crush'` equality checks, and existing exhaustive switches fail closed (they reject unknown sources at compile time, which is how this PR located its own touchpoints).
- **Performance risk:** the SSE parser is O(n) per chunk with no regex; reconnect backoff starts at 250 ms and caps at 10 s (matches crush's own SSE client). The bridge is registered to one `unref`'d timer per pane and is dropped on PTY exit, so no orphan timers. Synthetic events flow the existing in-process `normalizeHookPayload` path; no IPC overhead.
- **UI quality:** no UI changes — status arrives through the same `AgentStatusPayload` → store path as native hooks, so existing rendering for working/blocked/done/interrupted all apply unchanged.
- **Security risk:** the socket sits in a uid-scoped or `XDG_RUNTIME_DIR` (0700-ish) directory; crush itself enforces no cross-user access on its sockets. The bridge only reads from the socket (no writes), so a malicious crush server cannot push commands into Orca through it. Synthetic hook events go through the same `normalizeAgentStatusPayload` field-length/encoding normalization as native hook POSTs.

No visual change in this PR (status explanation only).

<details>
<summary>Quick local check for the reviewer</summary>

After installing crush and launching it from Orca, the per-pane worktree card should now show a working spinner, the active tool name/input for in-flight tool calls, a permission-blocked state on `permission_request`, and a terminal done state on turn end — same shape as Claude/Codex/Gemini. Before this change crush panes only ever showed a static agent icon.

</details>

💘 Generated with Crush

## ELI5

The crush agent could launch but never showed working/blocked/done status. Orca now listens to crush’s client-server SSE events and maps them into the same agent status pipeline as other TUIs.
