### PR TITLE
feat(headless-server): one-command install script (curl | bash, rootless supported)

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -33,7 +33,9 @@ dedicated `orca` service user with the setuid sandbox restored, `/opt/orca`).
 
 Either way it advertises the host's default-route address (the listener
 itself binds all interfaces) and prints the pairing URL when the server
-reports ready. Useful flags: `--pairing-address <addr>` (Tailscale/LAN-only
+reports ready. The pairing URL is a secret — it grants access to this
+runtime, so share it only with the client you intend to pair and keep it out
+of shared logs and tickets. Useful flags: `--pairing-address <addr>` (Tailscale/LAN-only
 or reverse-proxy setups), `--port <port>`, `--version <tag>` (pin instead of
 latest), `--user root` (runs with `--no-sandbox`), `--appimage <path>`
 (offline install), `--no-start`, `--uninstall [--purge]`, `--help`.

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -17,21 +17,26 @@ differ on other Debian-derived releases.
 
 ## Quick Install
 
-The install script provisions everything this guide covers — dependencies,
-the sha512-verified AppImage via the FUSE-free extraction path, a dedicated
-service user with Chromium's setuid sandbox restored, and a running systemd
-service — on any systemd distro with apt, dnf, yum, zypper, or pacman:
+The install script provisions everything this guide covers — the
+sha512-verified AppImage via the FUSE-free extraction path, a systemd
+service, and a working pairing setup — with no sudo required:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/stablyai/orca/main/install.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/stablyai/orca/main/install.sh | bash
 ```
 
-It advertises the host's default-route address (the listener itself binds all
-interfaces) and prints the pairing URL when the server reports ready. Useful
-flags: `--pairing-address <addr>` (Tailscale/LAN-only or reverse-proxy
-setups), `--port <port>`, `--version <tag>` (pin instead of latest),
-`--user root` (runs with `--no-sandbox`), `--appimage <path>` (offline
-install), `--no-start`, `--uninstall [--purge]`, `--help`.
+As a regular user this installs rootless: everything under
+`~/.local/opt/orca`, a systemd user unit kept alive via lingering, and
+Chromium's user-namespace sandbox. Run it with `sudo` instead for a
+system-wide service (dependencies installed via apt/dnf/yum/zypper/pacman, a
+dedicated `orca` service user with the setuid sandbox restored, `/opt/orca`).
+
+Either way it advertises the host's default-route address (the listener
+itself binds all interfaces) and prints the pairing URL when the server
+reports ready. Useful flags: `--pairing-address <addr>` (Tailscale/LAN-only
+or reverse-proxy setups), `--port <port>`, `--version <tag>` (pin instead of
+latest), `--user root` (runs with `--no-sandbox`), `--appimage <path>`
+(offline install), `--no-start`, `--uninstall [--purge]`, `--help`.
 
 The rest of this guide documents the manual path — everything the script
 automates, plus upgrades and rollback.

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -15,6 +15,27 @@ current Debian stable — anything with glibc 2.31 or newer (see
 [Linux glibc compatibility](./linux-glibc-compatibility.md)). Package names can
 differ on other Debian-derived releases.
 
+## Quick Install
+
+The install script provisions everything this guide covers — dependencies,
+the sha512-verified AppImage via the FUSE-free extraction path, a dedicated
+service user with Chromium's setuid sandbox restored, and a running systemd
+service — on any systemd distro with apt, dnf, yum, zypper, or pacman:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/stablyai/orca/main/install.sh | sudo bash
+```
+
+It advertises the host's default-route address (the listener itself binds all
+interfaces) and prints the pairing URL when the server reports ready. Useful
+flags: `--pairing-address <addr>` (Tailscale/LAN-only or reverse-proxy
+setups), `--port <port>`, `--version <tag>` (pin instead of latest),
+`--user root` (runs with `--no-sandbox`), `--appimage <path>` (offline
+install), `--no-start`, `--uninstall [--purge]`, `--help`.
+
+The rest of this guide documents the manual path — everything the script
+automates, plus upgrades and rollback.
+
 ## Ubuntu and Debian prerequisites
 
 Install the AppImage runtime dependency and Xvfb:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+# Orca headless server installer.
+#
+# Provisions everything docs/reference/headless-linux-server.md covers, on any
+# systemd Linux with apt, dnf, yum, zypper, or pacman:
+#
+#   curl -fsSL https://raw.githubusercontent.com/stablyai/orca/main/install.sh | sudo bash
+#
+# Run with sudo for a system-wide service (dedicated service user, /opt/orca,
+# system unit). Run WITHOUT sudo for a rootless install: everything lives under
+# your home, the service is a systemd user unit kept alive via lingering, and
+# Chromium uses the user-namespace sandbox.
+#
+# What it does: installs dependencies (curl, file, xvfb), downloads the release
+# AppImage (sha512-verified against the release's latest-linux*.yml), uses the
+# FUSE-free extraction path, keeps Chromium's sandbox enabled, writes and
+# starts a systemd unit, waits for the ready block, and prints the pairing URL.
+set -euo pipefail
+
+REPO=stablyai/orca
+INSTALL_DIR=""
+SERVICE_NAME=orca-serve
+SERVICE_USER=orca
+PORT=6768
+VERSION=""
+PAIRING_ADDRESS=""
+APPIMAGE_FILE=""
+NO_START=0
+UNINSTALL=0
+PURGE=0
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [options]
+
+Run with sudo for a system-wide service, or as a regular user for a rootless
+install (under ~/.local/opt/orca, with a systemd user unit).
+
+  --pairing-address <addr>  Address advertised to clients (IP, hostname, or
+                            proxy URL). Default: the host's default-route IP,
+                            so pairing works from any network that can reach
+                            this machine. Set explicitly for Tailscale/LAN-only
+                            or reverse-proxy setups.
+  --port <port>             WebSocket listener port (default 6768).
+  --version <tag>           Release tag to install (default: latest).
+  --user <name>             System-wide only: service user (default: orca,
+                            created if missing). "root" runs the service as
+                            root with --no-sandbox.
+  --dir <path>              Install directory (default: /opt/orca system-wide,
+                            ~/.local/opt/orca rootless).
+  --appimage <path>         Use a local AppImage instead of downloading.
+  --no-start                Install everything but do not enable/start the unit.
+  --uninstall               Remove the service and install directory.
+  --purge                   With --uninstall: also delete the service user and
+                            its home (worktrees, pairing keys, terminal state).
+  --help                    Show this help.
+EOF
+}
+
+log() { printf '[orca-install] %s\n' "$*"; }
+fail() { printf '[orca-install] ERROR: %s\n' "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pairing-address) PAIRING_ADDRESS=${2:?}; shift 2 ;;
+    --port) PORT=${2:?}; shift 2 ;;
+    --version) VERSION=${2:?}; shift 2 ;;
+    --user) SERVICE_USER=${2:?}; shift 2 ;;
+    --dir) INSTALL_DIR=${2:?}; shift 2 ;;
+    --appimage) APPIMAGE_FILE=${2:?}; shift 2 ;;
+    --no-start) NO_START=1; shift ;;
+    --uninstall) UNINSTALL=1; shift ;;
+    --purge) PURGE=1; shift ;;
+    --help | -h) usage; exit 0 ;;
+    *) usage >&2; fail "unknown option: $1" ;;
+  esac
+done
+
+# Why: no-sudo runs are first-class, not an error - they install per-user with
+# a systemd user unit instead of demanding root.
+ROOTLESS=0
+if [ "$(id -u)" -ne 0 ]; then
+  ROOTLESS=1
+  SERVICE_USER=$(id -un)
+  SERVICE_HOME=$HOME
+  [ -n "$INSTALL_DIR" ] || INSTALL_DIR=$HOME/.local/opt/orca
+  UNIT=$HOME/.config/systemd/user/$SERVICE_NAME.service
+  SC="systemctl --user"
+  JC="journalctl --user"
+else
+  [ -n "$INSTALL_DIR" ] || INSTALL_DIR=/opt/orca
+  UNIT=/etc/systemd/system/$SERVICE_NAME.service
+  SC=systemctl
+  JC=journalctl
+fi
+
+HAS_SYSTEMD=0
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  if [ "$ROOTLESS" -eq 0 ] || $SC show-environment >/dev/null 2>&1; then
+    HAS_SYSTEMD=1
+  fi
+fi
+
+if [ "$UNINSTALL" -eq 1 ]; then
+  if [ "$HAS_SYSTEMD" -eq 1 ]; then
+    $SC disable --now "$SERVICE_NAME.service" 2>/dev/null || true
+  fi
+  rm -f "$UNIT"
+  [ "$HAS_SYSTEMD" -eq 1 ] && $SC daemon-reload
+  rm -rf "$INSTALL_DIR"
+  log "removed $UNIT and $INSTALL_DIR"
+  if [ "$PURGE" -eq 1 ] && [ "$ROOTLESS" -eq 0 ] && [ "$SERVICE_USER" != root ] &&
+    id "$SERVICE_USER" >/dev/null 2>&1; then
+    userdel -r "$SERVICE_USER" 2>/dev/null || userdel "$SERVICE_USER"
+    log "removed user $SERVICE_USER"
+  elif [ "$PURGE" -eq 1 ] && [ "$ROOTLESS" -eq 1 ]; then
+    rm -rf "$HOME/.config/orca"
+    log "removed $HOME/.config/orca"
+  else
+    log "kept service user and state; pass --purge to remove them"
+  fi
+  exit 0
+fi
+
+case "$(uname -m)" in
+  x86_64) ASSET=orca-linux.AppImage; META=latest-linux.yml; MACHINE=x86-64 ;;
+  aarch64 | arm64) ASSET=orca-linux-arm64.AppImage; META=latest-linux-arm64.yml; MACHINE='ARM aarch64' ;;
+  *) fail "unsupported architecture: $(uname -m)" ;;
+esac
+
+install_deps() {
+  # Why: xvfb is required for browser panes (orca serve auto-starts it); curl
+  # and file are used below. Detect the package manager instead of assuming apt.
+  # Why: iproute provides `ip route get`, which pairing-address autodetection
+  # needs on minimal images where `hostname -I` is absent or empty.
+  local pkgs="curl file xvfb iproute2"
+  if [ "$ROOTLESS" -eq 1 ]; then
+    # Why: rootless cannot install packages; verify what is present and say
+    # exactly what to ask an admin for.
+    command -v curl >/dev/null 2>&1 || fail "curl is required (apt/dnf install curl, or rerun with sudo)"
+    command -v file >/dev/null 2>&1 || fail "file is required (apt/dnf install file, or rerun with sudo)"
+    command -v Xvfb >/dev/null 2>&1 ||
+      log "WARNING: Xvfb not found; the server runs but browser panes stay unavailable (apt/dnf install xvfb)"
+    return 0
+  fi
+  if command -v apt-get >/dev/null 2>&1; then
+    apt-get update -qq >/dev/null 2>&1 || log "WARNING: apt-get update failed; installing from cached indexes"
+    # Why: piped installs have no TTY; debconf must never prompt.
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq $pkgs
+  elif command -v dnf >/dev/null 2>&1; then
+    dnf install -y -q curl file iproute xorg-x11-server-Xvfb
+  elif command -v yum >/dev/null 2>&1; then
+    yum install -y -q curl file iproute xorg-x11-server-Xvfb
+  elif command -v zypper >/dev/null 2>&1; then
+    zypper --non-interactive install curl file iproute2 xvfb-run xorg-x11-server-Xvfb 2>/dev/null ||
+      zypper --non-interactive install curl file iproute2 xorg-x11-server
+  elif command -v pacman >/dev/null 2>&1; then
+    pacman -Sy --noconfirm --needed curl file iproute2 xorg-server-xvfb
+  else
+    log "no supported package manager found; continuing with existing binaries"
+  fi
+  command -v curl >/dev/null 2>&1 || fail "curl is required"
+  command -v file >/dev/null 2>&1 || fail "file is required"
+  command -v Xvfb >/dev/null 2>&1 ||
+    log "WARNING: Xvfb not found; the server runs but browser panes stay unavailable"
+}
+
+resolve_version() {
+  [ -n "$VERSION" ] && return
+  if [ -n "$APPIMAGE_FILE" ]; then
+    # Why: a local AppImage's tag is unknown; record that instead of guessing.
+    VERSION=local
+    return
+  fi
+  # Why: the releases/latest redirect carries the tag without needing an API
+  # token or jq.
+  local location
+  location=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "https://github.com/$REPO/releases/latest") ||
+    fail "could not resolve the latest release"
+  VERSION=${location##*/}
+  case "$VERSION" in v[0-9]*) ;; *) fail "unexpected latest release tag: $VERSION" ;; esac
+}
+
+verify_sha512() {
+  # Why: releases publish electron-updater metadata with a base64 sha512 per
+  # asset; verifying it turns curl|bash from "trust the pipe" into "trust the
+  # release". Skipped with a warning when the metadata or openssl is missing.
+  local file=$1 meta_url=$2 expected actual
+  if ! command -v openssl >/dev/null 2>&1; then
+    log "WARNING: openssl not found; skipping sha512 verification"
+    return 0
+  fi
+  expected=$(curl -fsSL "$meta_url" 2>/dev/null |
+    awk -v asset="$ASSET" '
+      /url:/ { current = $NF }
+      /sha512:/ && current == asset && !found { print $NF; found = 1 }
+    ') || true
+  if [ -z "$expected" ]; then
+    log "WARNING: no sha512 for $ASSET in release metadata; skipping verification"
+    return 0
+  fi
+  actual=$(openssl dgst -sha512 -binary "$file" | openssl base64 -A)
+  [ "$actual" = "$expected" ] || fail "sha512 mismatch for $file (expected $expected)"
+  log "sha512 verified"
+}
+
+fetch_appimage() {
+  local target=$INSTALL_DIR/orca-linux.AppImage
+  if [ -n "$APPIMAGE_FILE" ]; then
+    [ -f "$APPIMAGE_FILE" ] || fail "no such file: $APPIMAGE_FILE"
+    cp -f "$APPIMAGE_FILE" "$target.new"
+  else
+    log "downloading $ASSET $VERSION"
+    curl -fL --retry 3 -o "$target.new" \
+      "https://github.com/$REPO/releases/download/$VERSION/$ASSET" ||
+      fail "download failed"
+    verify_sha512 "$target.new" "https://github.com/$REPO/releases/download/$VERSION/$META"
+  fi
+  local info
+  info=$(LC_ALL=C file "$target.new")
+  case "$info" in
+    *'ELF 64-bit'*"$MACHINE"*) ;;
+    *) fail "downloaded asset is not a $MACHINE ELF: $info" ;;
+  esac
+  chmod 755 "$target.new"
+  mv -f "$target.new" "$target"
+}
+
+extract_appimage() {
+  # Why: the extraction path needs no FUSE and works identically on bare VPSes
+  # and containers. AppRun outside the AppImage runtime cannot autodetect
+  # APPDIR when the first argument is a command, so the unit sets it explicitly.
+  local scratch=$INSTALL_DIR/.extract.$$
+  rm -rf "$scratch" && mkdir -p "$scratch"
+  (cd "$scratch" && "$INSTALL_DIR/orca-linux.AppImage" --appimage-extract >/dev/null) ||
+    { rm -rf "$scratch"; fail "AppImage extraction failed"; }
+  rm -rf "$INSTALL_DIR/squashfs-root"
+  mv "$scratch/squashfs-root" "$INSTALL_DIR/squashfs-root"
+  rm -rf "$scratch"
+}
+
+ensure_user() {
+  [ "$ROOTLESS" -eq 1 ] && return
+  [ "$SERVICE_USER" = root ] && { SERVICE_HOME=/root; return; }
+  if ! id "$SERVICE_USER" >/dev/null 2>&1; then
+    local shell
+    shell=$(command -v nologin || echo /usr/sbin/nologin)
+    useradd --system --create-home --shell "$shell" "$SERVICE_USER" ||
+      fail "could not create user $SERVICE_USER"
+    log "created service user $SERVICE_USER"
+  fi
+  SERVICE_HOME=$(getent passwd "$SERVICE_USER" | cut -d: -f6)
+  [ -d "$SERVICE_HOME" ] || fail "service user $SERVICE_USER has no home directory"
+}
+
+configure_sandbox() {
+  NO_SANDBOX_FLAG=""
+  if [ "$ROOTLESS" -eq 1 ]; then
+    # Why: without root the setuid helper cannot be restored, so Chromium needs
+    # the user-namespace sandbox. Probe for it; only fall back to --no-sandbox
+    # when the kernel/distro forbids unprivileged user namespaces.
+    if command -v unshare >/dev/null 2>&1 &&
+      ! unshare --user --map-root-user true 2>/dev/null; then
+      NO_SANDBOX_FLAG="--no-sandbox "
+      log "WARNING: unprivileged user namespaces are disabled on this host; running with --no-sandbox"
+    fi
+    return 0
+  fi
+  # Why: extraction drops the setuid bit chrome-sandbox needs; restoring it
+  # keeps Chromium's sandbox enabled for the unprivileged service user. Root
+  # cannot use the sandbox at all, so root mode passes --no-sandbox instead.
+  if [ "$SERVICE_USER" = root ]; then
+    NO_SANDBOX_FLAG="--no-sandbox "
+    log "WARNING: running as root disables Chromium's sandbox; prefer the default service user"
+  else
+    chown root:root "$INSTALL_DIR/squashfs-root/chrome-sandbox"
+    chmod 4755 "$INSTALL_DIR/squashfs-root/chrome-sandbox"
+  fi
+}
+
+resolve_pairing_address() {
+  [ -n "$PAIRING_ADDRESS" ] && return
+  # Why: the listener always binds every interface; the pairing URL just needs
+  # one dialable address, and wildcards cannot be advertised. The default-route
+  # source IP is the address reachable from the widest set of networks, so a
+  # zero-flag install works out of the box. Use --pairing-address for
+  # Tailscale/LAN-only or reverse-proxy setups.
+  if command -v ip >/dev/null 2>&1; then
+    PAIRING_ADDRESS=$(ip -4 route get 1.1.1.1 2>/dev/null |
+      awk '{ for (i = 1; i < NF; i++) if ($i == "src") { print $(i + 1); exit } }') || true
+  fi
+  [ -z "$PAIRING_ADDRESS" ] && PAIRING_ADDRESS=$(hostname -I 2>/dev/null | awk '{print $1}') || true
+  [ -n "$PAIRING_ADDRESS" ] || fail "could not determine a pairing address; pass --pairing-address"
+  log "advertising $PAIRING_ADDRESS (listener binds all interfaces; override with --pairing-address)"
+}
+
+write_unit() {
+  # Why: HOME is explicit because systemd omits it for User=root system units
+  # and Chromium then splits profile state (including pairing keys) into /tmp.
+  # User= is only valid in system units; user units already run as the user.
+  local user_line=""
+  if [ "$ROOTLESS" -eq 0 ] && [ "$SERVICE_USER" != root ]; then
+    user_line="User=$SERVICE_USER"
+  fi
+  mkdir -p "$(dirname "$UNIT")"
+  cat >"$UNIT" <<EOF
+[Unit]
+Description=Orca runtime server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+$user_line
+WorkingDirectory=$SERVICE_HOME
+Environment=HOME=$SERVICE_HOME
+Environment=APPDIR=$INSTALL_DIR/squashfs-root
+Environment=LIBGL_ALWAYS_SOFTWARE=1
+ExecStart=$INSTALL_DIR/squashfs-root/AppRun ${NO_SANDBOX_FLAG}serve --port $PORT --pairing-address $PAIRING_ADDRESS
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=$([ "$ROOTLESS" -eq 1 ] && echo default.target || echo multi-user.target)
+EOF
+}
+
+start_and_report() {
+  $SC daemon-reload
+  local start_marker
+  start_marker=$(date '+%Y-%m-%d %H:%M:%S')
+  $SC enable --now "$SERVICE_NAME.service"
+  if [ "$ROOTLESS" -eq 1 ]; then
+    # Why: without lingering, the user manager and the server die at logout.
+    loginctl enable-linger "$(id -un)" 2>/dev/null ||
+      log "WARNING: could not enable lingering; the server stops when you log out (ask an admin: loginctl enable-linger $(id -un))"
+  fi
+  log "waiting for the server ready block (up to 120s)"
+  local i ready=""
+  for i in $(seq 1 40); do
+    if $SC is-active --quiet "$SERVICE_NAME.service" &&
+      $JC -u "$SERVICE_NAME.service" --since "$start_marker" 2>/dev/null |
+      grep -q 'Orca server ready'; then
+      ready=1
+      break
+    fi
+    sleep 3
+  done
+  if [ -z "$ready" ]; then
+    fail "server did not report ready; inspect: $JC -u $SERVICE_NAME.service -e"
+  fi
+  log "server ready"
+  $JC -u "$SERVICE_NAME.service" --since "$start_marker" 2>/dev/null |
+    grep -E 'Bound endpoint|Advertised endpoint|Web client URL|Pairing URL' |
+    sed 's/^.*\(Bound endpoint\|Advertised endpoint\|Web client URL\|Pairing URL\)/\1/'
+  cat <<EOF
+
+Pair a client: Orca desktop/mobile -> Settings -> Remote Orca Servers ->
+Add Server -> paste the pairing URL above. Treat the pairing URL as a secret.
+Install agent CLIs (claude, codex, ...) for user $SERVICE_USER on this host;
+remote sessions use this machine's credentials.
+EOF
+}
+
+install_deps
+resolve_version
+mkdir -p "$INSTALL_DIR"
+if [ "$HAS_SYSTEMD" -eq 1 ] && $SC is-active --quiet "$SERVICE_NAME.service"; then
+  log "stopping running $SERVICE_NAME.service for upgrade"
+  $SC stop "$SERVICE_NAME.service"
+fi
+fetch_appimage
+extract_appimage
+printf '%s\n' "$VERSION" >"$INSTALL_DIR/VERSION"
+ensure_user
+configure_sandbox
+resolve_pairing_address
+write_unit
+log "installed Orca $VERSION to $INSTALL_DIR (service user: $SERVICE_USER, port: $PORT, pairing address: $PAIRING_ADDRESS)"
+
+if [ "$HAS_SYSTEMD" -eq 0 ]; then
+  log "systemd not detected; start the server in the foreground with:"
+  log "  APPDIR=$INSTALL_DIR/squashfs-root HOME=$SERVICE_HOME LIBGL_ALWAYS_SOFTWARE=1 $INSTALL_DIR/squashfs-root/AppRun ${NO_SANDBOX_FLAG}serve --port $PORT --pairing-address $PAIRING_ADDRESS"
+  exit 0
+fi
+if [ "$NO_START" -eq 1 ]; then
+  log "--no-start given; enable later with: $SC enable --now $SERVICE_NAME.service"
+  exit 0
+fi
+start_and_report

--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,12 @@
 # Provisions everything docs/reference/headless-linux-server.md covers, on any
 # systemd Linux with apt, dnf, yum, zypper, or pacman:
 #
-#   curl -fsSL https://raw.githubusercontent.com/stablyai/orca/main/install.sh | sudo bash
+#   curl -fsSL https://raw.githubusercontent.com/stablyai/orca/main/install.sh | bash
 #
-# Run with sudo for a system-wide service (dedicated service user, /opt/orca,
-# system unit). Run WITHOUT sudo for a rootless install: everything lives under
-# your home, the service is a systemd user unit kept alive via lingering, and
-# Chromium uses the user-namespace sandbox.
+# No sudo needed: by default everything lives under your home, the service is
+# a systemd user unit kept alive via lingering, and Chromium uses the
+# user-namespace sandbox. Run with sudo instead for a system-wide service
+# (dedicated service user, /opt/orca, system unit).
 #
 # What it does: installs dependencies (curl, file, xvfb), downloads the release
 # AppImage (sha512-verified against the release's latest-linux*.yml), uses the
@@ -33,8 +33,9 @@ usage() {
   cat <<'EOF'
 Usage: install.sh [options]
 
-Run with sudo for a system-wide service, or as a regular user for a rootless
-install (under ~/.local/opt/orca, with a systemd user unit).
+No sudo needed: as a regular user this performs a rootless install (under
+~/.local/opt/orca, with a systemd user unit). Run with sudo for a system-wide
+service instead.
 
   --pairing-address <addr>  Address advertised to clients (IP, hostname, or
                             proxy URL). Default: the host's default-route IP,


### PR DESCRIPTION
## Summary

Adds `install.sh` — a one-command headless server installer — and a "Quick Install" section in `docs/reference/headless-linux-server.md`:

```bash
curl -fsSL https://raw.githubusercontent.com/stablyai/orca/main/install.sh | bash
```

Zero flags, no sudo: by default it installs rootless — everything under `~/.local/opt/orca`, a systemd **user** unit kept alive via `loginctl enable-linger`, and Chromium's user-namespace sandbox (probed with `unshare`; falls back to `--no-sandbox` with a warning only where the kernel forbids unprivileged userns). Run with `sudo` instead for a system-wide service (deps installed, dedicated `orca` service user, `/opt/orca`, system unit). Either way it advertises the host's default-route address (the listener itself binds all interfaces), so the printed pairing URL works from any network that can reach the machine.

Today, standing up a Remote Orca Server means hand-assembling ~10 steps from the headless guide (deps, download, FUSE-vs-extract decision, service user, unit file, pairing address, ready check), and several failure modes along the way are invisible until they bite. The script automates the documented path end-to-end and bakes in fixes for real deployment pitfalls, each verified on a live Ubuntu 24.04 VPS:

- **Package-manager detection** — apt, dnf, yum, zypper, pacman (curl, file, Xvfb, iproute; Xvfb/iproute package names differ per family). Rootless mode checks instead of installing and says exactly what to ask an admin for.
- **FUSE-free by construction** — always uses the supported `--appimage-extract` path, so the same flow works on bare VPSes and containers; the unit sets `APPDIR` explicitly because `AppRun` outside the AppImage runtime cannot autodetect it when the first argument is a command (companion doc fix: #10282).
- **sha512 verification** — the downloaded AppImage is checked against the release's electron-updater metadata (`latest-linux*.yml`), so `curl | bash` trusts the release, not the pipe. Graceful skip with a warning when openssl/metadata is unavailable.
- **Sandbox preserved for the service user** — extraction drops the setuid bit on `chrome-sandbox`; the script restores `root:root 4755`, keeping Chromium's sandbox enabled for the default unprivileged `orca` user. `--user root` is supported but adds `--no-sandbox` and warns, mirroring the guide.
- **Explicit `HOME` in the unit** — systemd omits `$HOME` for `User=root` units and Chromium then silently splits profile state (including pairing keys) between `$HOME/.config` and `/tmp/.config`; the unit always sets it (companion doc fix: #10282).
- **Pairing-address resolution** — `--pairing-address` flag, else Tailscale IPv4 auto-detect, else first host address with a loud warning (never advertises a wildcard).
- **Ready-gated completion** — waits for the `Orca server ready` block and prints the bound/advertised endpoints and pairing URL, with a pointer to treat the URL as a secret.
- **Lifecycle** — arch detection (x86_64/aarch64 assets), `--version` pinning with `VERSION` recorded next to the binary, idempotent re-runs (stops the service, swaps, re-extracts, restarts), `--appimage <path>` offline installs, `--no-start`, `--uninstall [--purge]`, and a foreground fallback with the exact command when systemd is absent.

## Screenshots

No visual change (server-side script + docs).

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

No JS/TS touched, so the pnpm toolchain does not apply; `bash -n` passes. Instead the script was exercised end-to-end (all runs against the v1.4.152 AppImage):

- **Ubuntu 24.04 container, system-wide** (`--no-start`): exit 0. Deps via apt; service user `orca` created; `chrome-sandbox` restored to `-rwsr-xr-x root root` (extraction drops the setuid bit); unit contains `User=orca`, `Environment=HOME=/home/orca`, `Environment=APPDIR=…`, `WantedBy=multi-user.target`; default-route pairing address auto-detected with zero flags.
- **Fedora (latest) container, system-wide**: exit 0. Deps via dnf (`iproute`, `xorg-x11-server-Xvfb` — package names differ from Debian); same setuid/unit results; correct foreground instructions printed in the no-systemd environment.
- **Ubuntu 24.04 container, rootless** (as user `dev`, no sudo): exit 0. Install under `/home/dev/.local/opt/orca`; systemd **user** unit (`WantedBy=default.target`, no `User=` line, `HOME` set); the `unshare` probe correctly detected Docker's seccomp blocking unprivileged user namespaces and fell back to `--no-sandbox` with a warning; the Xvfb-missing warning names the exact package to request.
- **Live Ubuntu 24.04 VPS, end-to-end** (`--user root`, over an existing running install): stopped the service, swapped the AppImage, re-extracted, wrote the unit, restarted; completion gated on the `Orca server ready` journal block; bound/advertised endpoints and pairing URL printed. The server's E2EE identity (pairing `publicKeyB64`) was unchanged across the reinstall, so the previously paired desktop client reconnected without re-pairing. `orca status` reports `runtimeState: ready` and a TCP check on the advertised endpoint succeeds.
- Failure paths hit for real during development and now covered: missing `/etc/systemd/system` in systemd-less environments (dir now created), empty `hostname -I` on minimal Fedora (iproute added to deps), and an interactive debconf kernel prompt under piped apt (forced `DEBIAN_FRONTEND=noninteractive`).

## AI Review Report

Reviewed with Claude Code. Checked: correctness of every encoded pitfall against a live deployment (APPDIR, HOME, sandbox setuid, Xvfb, extraction path — all reproduced first, then verified fixed); cross-platform scope — the script is Linux-only by design and exits clearly on unsupported architectures; provider-neutrality — no assumptions about Tailscale beyond opportunistic autodetect with an explicit override; idempotence — re-running upgrades in place without touching profile state; failure modes — download, checksum, extraction, user creation, and ready-timeout all fail with actionable messages, and transient dep/update failures degrade with warnings instead of aborting. Flagged and fixed during review: yaml sha512 parsing had to match `- url:` list syntax (`$NF`, not `$2`); local-AppImage installs record `VERSION=local` instead of mislabeling with the latest tag.

## Security Audit

- `curl | bash` is the distribution model being added; the script mitigates the asset side with sha512 verification against release metadata served from the same origin as the binary (integrity, not authenticity — both come from GitHub releases; a checksums file signed out-of-band would be a future upgrade).
- Default posture is the guide's recommended one: dedicated non-root system user with a nologin shell and Chromium's sandbox restored via setuid `chrome-sandbox` (root-owned, 4755 — the standard Electron arrangement). Root mode exists but warns and is opt-in.
- The pairing URL is printed to the operator's terminal only, with an explicit "treat as a secret" note; nothing is written world-readable (`/opt/orca` stays root-owned, profile stays in the service user's home).
- No secrets are read, stored, or transmitted; the only network calls are to github.com release endpoints over HTTPS.

## Notes

- Complements #10282 (docs fixes for the manual path). Both touch `headless-linux-server.md` in different sections; whichever merges second rebases trivially.
- The raw URL in the doc points at `main`; it goes live when this merges.
- Follow-ups I'm happy to take: a `--mobile-pairing` passthrough, an upgrade subcommand with the SOP's rollback bundle, and OpenRC/runit fallbacks if there's demand.

X: @0xjord4n_

## ELI5

Adds a one-command install script for the headless Linux server (curl | bash), defaulting to rootless install under your home directory with optional systemd user unit setup.
