### PR TITLE
fix(terminal): bound retained background worktree terminal surfaces (renderer OOM)

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -70,6 +70,12 @@ import {
   takeAllPendingBackgroundTerminalWorktreeMounts,
   takePendingBackgroundTerminalWorktreeMount
 } from './terminal/background-terminal-worktree-mount'
+import {
+  MAX_BACKGROUND_MOUNTED_TERMINAL_WORKTREES,
+  collectLiveAgentTerminalAttribution,
+  evictExcessBackgroundTerminalWorktreeMounts,
+  isTerminalWorktreeEvictionSafe
+} from './terminal/terminal-worktree-mount-eviction'
 import { hasRegisteredRuntimeTerminalTab } from '../runtime/sync-runtime-graph'
 import {
   getEffectiveLayoutForWorktree as getEffectiveLayout,
@@ -1034,6 +1040,33 @@ function Terminal(): React.JSX.Element | null {
       backgroundMountTabIdsByWorktreeRef.current.delete(id)
       activationDeferredMountTabIdsByWorktreeRef.current.delete(id)
     }
+  }
+  // Why: every visited worktree's surface was retained until deletion — unbounded xterm
+  // scrollback and the top Windows renderer-OOM crash cluster. Size gate keeps the
+  // agent/tab safety scans off the common small-session render path.
+  if (mountedWorktreeIdsRef.current.size > MAX_BACKGROUND_MOUNTED_TERMINAL_WORKTREES + 1) {
+    const liveAgents = collectLiveAgentTerminalAttribution(
+      useAppStore.getState().agentStatusByPaneKey
+    )
+    const portalWorktreeIds = new Set(activityTerminalPortals.map((portal) => portal.worktreeId))
+    evictExcessBackgroundTerminalWorktreeMounts({
+      mountedWorktreeIds: mountedWorktreeIdsRef.current,
+      hiddenSinceMsByWorktreeId: terminalWorktreeHiddenSinceRef.current,
+      backgroundMountTabIdsByWorktree: backgroundMountTabIdsByWorktreeRef.current,
+      activationDeferredMountTabIdsByWorktree: activationDeferredMountTabIdsByWorktreeRef.current,
+      activeWorktreeId: renderedActiveWorktreeId,
+      nowMs: Date.now(),
+      isWorktreeEvictionSafe: (worktreeId) =>
+        !measurableBackgroundWorktreeIdsRef.current.has(worktreeId) &&
+        !portalWorktreeIds.has(worktreeId) &&
+        isTerminalWorktreeEvictionSafe({
+          worktreeId,
+          terminalTabs: tabsByWorktree[worktreeId] ?? [],
+          pendingStartupByTabId,
+          liveAgentWorktreeIds: liveAgents.worktreeIds,
+          liveAgentTabIds: liveAgents.tabIds
+        })
+    })
   }
   const anyMountedWorktreeHasLayout = computeAnyMountedWorktreeHasLayout(
     workspaceSurfaces.map((workspace) => workspace.id),

--- a/src/renderer/src/components/terminal/terminal-worktree-mount-eviction.test.ts
+++ b/src/renderer/src/components/terminal/terminal-worktree-mount-eviction.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest'
+import { pruneClosedBackgroundMountTabs } from './background-terminal-worktree-mount'
+import {
+  MAX_BACKGROUND_MOUNTED_TERMINAL_WORKTREES,
+  collectLiveAgentTerminalAttribution,
+  evictExcessBackgroundTerminalWorktreeMounts,
+  isTerminalWorktreeEvictionSafe
+} from './terminal-worktree-mount-eviction'
+
+describe('mounted terminal worktree retention', () => {
+  it('keeps retained background terminal surfaces bounded across many worktree activations', () => {
+    const mountedWorktreeIds = new Set<string>()
+    const hiddenSinceMsByWorktreeId = new Map<string, number>()
+    const backgroundMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
+    const activationDeferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>()
+    const tabsByWorktree: Record<string, { id: string }[]> = {}
+    let nowMs = 0
+
+    // Mirrors the Terminal render pass across a long session of worktree switches:
+    // activation adds the worktree, the parking effect stamps every other mounted
+    // surface as hidden, then the per-render prune steps run.
+    for (let index = 1; index <= 40; index++) {
+      const activeWorktreeId = `wt-${index}`
+      tabsByWorktree[activeWorktreeId] = [{ id: `${activeWorktreeId}-tab-1` }]
+      mountedWorktreeIds.add(activeWorktreeId)
+      hiddenSinceMsByWorktreeId.delete(activeWorktreeId)
+      for (const worktreeId of mountedWorktreeIds) {
+        if (worktreeId !== activeWorktreeId && !hiddenSinceMsByWorktreeId.has(worktreeId)) {
+          hiddenSinceMsByWorktreeId.set(worktreeId, nowMs)
+        }
+      }
+      nowMs += 60_000
+      pruneClosedBackgroundMountTabs(
+        backgroundMountTabIdsByWorktree,
+        mountedWorktreeIds,
+        tabsByWorktree,
+        activationDeferredMountTabIdsByWorktree
+      )
+      evictExcessBackgroundTerminalWorktreeMounts({
+        mountedWorktreeIds,
+        hiddenSinceMsByWorktreeId,
+        backgroundMountTabIdsByWorktree,
+        activationDeferredMountTabIdsByWorktree,
+        activeWorktreeId,
+        nowMs,
+        isWorktreeEvictionSafe: () => true
+      })
+      expect(mountedWorktreeIds.has(activeWorktreeId)).toBe(true)
+    }
+
+    // Active worktree + a bounded background working set; anything beyond leaks
+    // xterm scrollback until the renderer heap hits the V8 ceiling.
+    expect(mountedWorktreeIds.size).toBeLessThanOrEqual(
+      1 + MAX_BACKGROUND_MOUNTED_TERMINAL_WORKTREES
+    )
+  })
+
+  it('evicts the least-recently-hidden surfaces first and cleans their bookkeeping', () => {
+    const mountedWorktreeIds = new Set(['wt-active', 'wt-old', 'wt-mid', 'wt-new'])
+    const hiddenSinceMsByWorktreeId = new Map([
+      ['wt-old', 1_000],
+      ['wt-mid', 2_000],
+      ['wt-new', 3_000]
+    ])
+    const backgroundMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>([
+      ['wt-old', new Set(['tab-1'])]
+    ])
+    const activationDeferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>([
+      ['wt-old', new Set(['tab-2'])]
+    ])
+
+    const evicted = evictExcessBackgroundTerminalWorktreeMounts({
+      mountedWorktreeIds,
+      hiddenSinceMsByWorktreeId,
+      backgroundMountTabIdsByWorktree,
+      activationDeferredMountTabIdsByWorktree,
+      activeWorktreeId: 'wt-active',
+      nowMs: 500_000,
+      isWorktreeEvictionSafe: () => true,
+      maxBackgroundMounts: 1
+    })
+
+    expect(evicted).toEqual(['wt-old', 'wt-mid'])
+    expect(mountedWorktreeIds).toEqual(new Set(['wt-active', 'wt-new']))
+    expect(backgroundMountTabIdsByWorktree.has('wt-old')).toBe(false)
+    expect(activationDeferredMountTabIdsByWorktree.has('wt-old')).toBe(false)
+    expect(hiddenSinceMsByWorktreeId.has('wt-old')).toBe(false)
+    expect(hiddenSinceMsByWorktreeId.has('wt-new')).toBe(true)
+  })
+
+  it('never evicts the active worktree even when it is hidden-stamped (tasks page)', () => {
+    const mountedWorktreeIds = new Set(['wt-active', 'wt-bg'])
+    const hiddenSinceMsByWorktreeId = new Map([
+      ['wt-active', 1_000],
+      ['wt-bg', 2_000]
+    ])
+
+    const evicted = evictExcessBackgroundTerminalWorktreeMounts({
+      mountedWorktreeIds,
+      hiddenSinceMsByWorktreeId,
+      backgroundMountTabIdsByWorktree: new Map(),
+      activationDeferredMountTabIdsByWorktree: new Map(),
+      activeWorktreeId: 'wt-active',
+      nowMs: 500_000,
+      isWorktreeEvictionSafe: () => true,
+      maxBackgroundMounts: 0
+    })
+
+    expect(evicted).toEqual(['wt-bg'])
+    expect(mountedWorktreeIds.has('wt-active')).toBe(true)
+  })
+
+  it('spares surfaces hidden less than the hysteresis and ones without a hidden stamp', () => {
+    const mountedWorktreeIds = new Set(['wt-active', 'wt-just-hidden', 'wt-measuring'])
+    const hiddenSinceMsByWorktreeId = new Map([['wt-just-hidden', 90_000]])
+
+    const evicted = evictExcessBackgroundTerminalWorktreeMounts({
+      mountedWorktreeIds,
+      hiddenSinceMsByWorktreeId,
+      backgroundMountTabIdsByWorktree: new Map(),
+      activationDeferredMountTabIdsByWorktree: new Map(),
+      activeWorktreeId: 'wt-active',
+      nowMs: 100_000,
+      isWorktreeEvictionSafe: () => true,
+      maxBackgroundMounts: 0
+    })
+
+    expect(evicted).toEqual([])
+    expect(mountedWorktreeIds.size).toBe(3)
+  })
+
+  it('keeps targeted background mounts (wake/mobile/CLI) but evicts activation-deferred visits', () => {
+    const mountedWorktreeIds = new Set(['wt-active', 'wt-wake', 'wt-visited'])
+    const hiddenSinceMsByWorktreeId = new Map([
+      ['wt-wake', 1_000],
+      ['wt-visited', 2_000]
+    ])
+    const backgroundMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>([
+      ['wt-wake', new Set(['tab-wake'])],
+      ['wt-visited', new Set(['tab-shown'])]
+    ])
+    const activationDeferredMountTabIdsByWorktree = new Map<string, ReadonlySet<string>>([
+      ['wt-visited', new Set(['tab-deferred'])]
+    ])
+
+    const evicted = evictExcessBackgroundTerminalWorktreeMounts({
+      mountedWorktreeIds,
+      hiddenSinceMsByWorktreeId,
+      backgroundMountTabIdsByWorktree,
+      activationDeferredMountTabIdsByWorktree,
+      activeWorktreeId: 'wt-active',
+      nowMs: 500_000,
+      isWorktreeEvictionSafe: () => true,
+      maxBackgroundMounts: 0
+    })
+
+    expect(evicted).toEqual(['wt-visited'])
+    expect(mountedWorktreeIds).toEqual(new Set(['wt-active', 'wt-wake']))
+    expect(backgroundMountTabIdsByWorktree.has('wt-wake')).toBe(true)
+  })
+
+  it('spares surfaces the safety predicate rejects', () => {
+    const mountedWorktreeIds = new Set(['wt-active', 'wt-agent', 'wt-idle'])
+    const hiddenSinceMsByWorktreeId = new Map([
+      ['wt-agent', 1_000],
+      ['wt-idle', 2_000]
+    ])
+
+    const evicted = evictExcessBackgroundTerminalWorktreeMounts({
+      mountedWorktreeIds,
+      hiddenSinceMsByWorktreeId,
+      backgroundMountTabIdsByWorktree: new Map(),
+      activationDeferredMountTabIdsByWorktree: new Map(),
+      activeWorktreeId: 'wt-active',
+      nowMs: 500_000,
+      isWorktreeEvictionSafe: (worktreeId) => worktreeId !== 'wt-agent',
+      maxBackgroundMounts: 0
+    })
+
+    expect(evicted).toEqual(['wt-idle'])
+    expect(mountedWorktreeIds.has('wt-agent')).toBe(true)
+  })
+})
+
+describe('isTerminalWorktreeEvictionSafe', () => {
+  const worktreeId = 'wt-1'
+  const daemonTab = { id: 'tab-1', ptyId: `${worktreeId}@@session-1` }
+  const baseArgs = {
+    worktreeId,
+    pendingStartupByTabId: {},
+    liveAgentWorktreeIds: new Set<string>(),
+    liveAgentTabIds: new Set<string>()
+  }
+
+  it('allows snapshot-backed daemon PTYs and sessionless tabs', () => {
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [daemonTab, { id: 'tab-2', ptyId: null }]
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a worktree or tab with a live agent', () => {
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [daemonTab],
+        liveAgentWorktreeIds: new Set([worktreeId])
+      })
+    ).toBe(false)
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [daemonTab],
+        liveAgentTabIds: new Set(['tab-1'])
+      })
+    ).toBe(false)
+  })
+
+  it('rejects pending startups and pending activation spawns', () => {
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [daemonTab],
+        pendingStartupByTabId: { 'tab-1': { command: 'claude' } }
+      })
+    ).toBe(false)
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [{ ...daemonTab, pendingActivationSpawn: 1 }]
+      })
+    ).toBe(false)
+  })
+
+  it('rejects live PTYs without a local daemon snapshot (remote/SSH/fail-open)', () => {
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [{ id: 'tab-1', ptyId: 'remote:runtime-1:pty-1' }]
+      })
+    ).toBe(false)
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [{ id: 'tab-1', ptyId: 'separator-less-fail-open-id' }]
+      })
+    ).toBe(false)
+    expect(
+      isTerminalWorktreeEvictionSafe({
+        ...baseArgs,
+        terminalTabs: [{ id: 'tab-1', ptyId: 'other-worktree@@session-1' }]
+      })
+    ).toBe(false)
+  })
+})
+
+describe('collectLiveAgentTerminalAttribution', () => {
+  it('collects non-done rows by stamped worktree and pane-key tab fallback', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    const { worktreeIds, tabIds } = collectLiveAgentTerminalAttribution({
+      [`tab-a:${leafId}`]: { state: 'working', paneKey: `tab-a:${leafId}`, worktreeId: 'wt-1' },
+      [`tab-b:${leafId}`]: { state: 'blocked', paneKey: `tab-b:${leafId}` },
+      'tab-legacy:42': { state: 'waiting', paneKey: 'tab-legacy:42' },
+      [`tab-c:${leafId}`]: { state: 'done', paneKey: `tab-c:${leafId}`, worktreeId: 'wt-done' }
+    })
+    expect(worktreeIds).toEqual(new Set(['wt-1']))
+    expect(tabIds).toEqual(new Set(['tab-a', 'tab-b', 'tab-legacy']))
+  })
+})

--- a/src/renderer/src/components/terminal/terminal-worktree-mount-eviction.ts
+++ b/src/renderer/src/components/terminal/terminal-worktree-mount-eviction.ts
@@ -1,0 +1,142 @@
+// Why this module exists: Terminal kept a mounted terminal surface for every
+// worktree the user ever activated (only deletion pruned the set), so xterm
+// scrollback (~3-4MB/terminal) accumulated until the renderer heap hit the V8
+// ceiling — the top Windows renderer-OOM crash cluster.
+import {
+  TERMINAL_WORKTREE_COLD_PARK_DELAY_MS,
+  TERMINAL_WORKTREE_HOT_RETAIN_LIMIT,
+  isSnapshotBackedTerminalPty,
+  type ColdParkableTerminalTab
+} from '../terminal-pane/terminal-hidden-view-parking'
+import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
+
+// Why 8: deliberately the same warm working set the parking layer sized
+// (hot-retain limit), so surface eviction and pane parking bound at one
+// boundary instead of fighting — keep them coupled when tuning.
+export const MAX_BACKGROUND_MOUNTED_TERMINAL_WORKTREES = TERMINAL_WORKTREE_HOT_RETAIN_LIMIT
+// Why: reuse the cold-park hysteresis so quick worktree flips never pay an
+// eviction remount. When parking is enabled its recheck timer re-renders at
+// exactly this deadline; if parking is disabled eviction (this always-on OOM
+// safety net) still runs, just on the next incidental render.
+export const BACKGROUND_MOUNT_EVICTION_MIN_HIDDEN_MS = TERMINAL_WORKTREE_COLD_PARK_DELAY_MS
+
+type LiveAgentAttributionEntry = {
+  state: string
+  paneKey: string
+  worktreeId?: string
+  tabId?: string
+}
+
+/** Worktrees/tabs with a live (non-done) agent row; tearing their surface down mid-turn would lose rendering and churn replay. */
+export function collectLiveAgentTerminalAttribution(
+  agentStatusByPaneKey: Readonly<Record<string, LiveAgentAttributionEntry>>
+): { worktreeIds: Set<string>; tabIds: Set<string> } {
+  const worktreeIds = new Set<string>()
+  const tabIds = new Set<string>()
+  for (const entry of Object.values(agentStatusByPaneKey)) {
+    if (entry.state === 'done') {
+      continue
+    }
+    if (entry.worktreeId) {
+      worktreeIds.add(entry.worktreeId)
+    }
+    const tabId =
+      entry.tabId ??
+      parsePaneKey(entry.paneKey)?.tabId ??
+      parseLegacyNumericPaneKey(entry.paneKey)?.tabId
+    if (tabId) {
+      tabIds.add(tabId)
+    }
+  }
+  return { worktreeIds, tabIds }
+}
+
+export function isTerminalWorktreeEvictionSafe(args: {
+  worktreeId: string
+  terminalTabs: readonly ColdParkableTerminalTab[]
+  pendingStartupByTabId: Readonly<Record<string, unknown>>
+  liveAgentWorktreeIds: ReadonlySet<string>
+  liveAgentTabIds: ReadonlySet<string>
+}): boolean {
+  if (args.liveAgentWorktreeIds.has(args.worktreeId)) {
+    return false
+  }
+  return args.terminalTabs.every((tab) => {
+    if (
+      args.liveAgentTabIds.has(tab.id) ||
+      args.pendingStartupByTabId[tab.id] !== undefined ||
+      tab.pendingActivationSpawn === true ||
+      (typeof tab.pendingActivationSpawn === 'number' && tab.pendingActivationSpawn > 0)
+    ) {
+      return false
+    }
+    // Why: a null ptyId has no session to lose (remount spawns fresh, exactly
+    // like a first activation); a live PTY without a daemon snapshot (remote
+    // runtime, SSH, fail-open provider) cannot replay on remount, so keep it.
+    return !tab.ptyId || isSnapshotBackedTerminalPty(tab.ptyId, args.worktreeId)
+  })
+}
+
+/**
+ * Bounds the retained hidden terminal surfaces: beyond the cap, the
+ * least-recently-hidden eviction-safe worktrees are fully unmounted (set +
+ * restriction bookkeeping). PTYs persist in the daemon; re-activation remounts
+ * through the ordinary cold-activation path, whose tab deferral caps the cost.
+ */
+export function evictExcessBackgroundTerminalWorktreeMounts(args: {
+  mountedWorktreeIds: Set<string>
+  hiddenSinceMsByWorktreeId: Map<string, number>
+  backgroundMountTabIdsByWorktree: Map<string, ReadonlySet<string>>
+  activationDeferredMountTabIdsByWorktree: Map<string, ReadonlySet<string>>
+  activeWorktreeId: string | null
+  nowMs: number
+  isWorktreeEvictionSafe: (worktreeId: string) => boolean
+  maxBackgroundMounts?: number
+  minHiddenMs?: number
+}): string[] {
+  const cap = args.maxBackgroundMounts ?? MAX_BACKGROUND_MOUNTED_TERMINAL_WORKTREES
+  const minHiddenMs = args.minHiddenMs ?? BACKGROUND_MOUNT_EVICTION_MIN_HIDDEN_MS
+  const activeMounted =
+    args.activeWorktreeId !== null && args.mountedWorktreeIds.has(args.activeWorktreeId)
+  const overflow = args.mountedWorktreeIds.size - (activeMounted ? 1 : 0) - cap
+  if (overflow <= 0) {
+    return []
+  }
+  const candidates: { worktreeId: string; hiddenSinceMs: number }[] = []
+  for (const worktreeId of args.mountedWorktreeIds) {
+    if (worktreeId === args.activeWorktreeId) {
+      continue
+    }
+    // Why: a targeted background mount (wake/resume, mobile tab subscription,
+    // CLI create) must keep its panes until its tabs close or the user visits;
+    // activation deferral shares the restriction map but is user-visited state.
+    if (
+      args.backgroundMountTabIdsByWorktree.has(worktreeId) &&
+      !args.activationDeferredMountTabIdsByWorktree.has(worktreeId)
+    ) {
+      continue
+    }
+    const hiddenSinceMs = args.hiddenSinceMsByWorktreeId.get(worktreeId)
+    // Why: no hidden timestamp means visible/measuring/portal-hosted this pass.
+    if (hiddenSinceMs === undefined || args.nowMs - hiddenSinceMs < minHiddenMs) {
+      continue
+    }
+    if (!args.isWorktreeEvictionSafe(worktreeId)) {
+      continue
+    }
+    candidates.push({ worktreeId, hiddenSinceMs })
+  }
+  candidates.sort((a, b) =>
+    a.hiddenSinceMs === b.hiddenSinceMs
+      ? a.worktreeId.localeCompare(b.worktreeId)
+      : a.hiddenSinceMs - b.hiddenSinceMs
+  )
+  const evicted = candidates.slice(0, overflow).map((candidate) => candidate.worktreeId)
+  for (const worktreeId of evicted) {
+    args.mountedWorktreeIds.delete(worktreeId)
+    args.backgroundMountTabIdsByWorktree.delete(worktreeId)
+    args.activationDeferredMountTabIdsByWorktree.delete(worktreeId)
+    args.hiddenSinceMsByWorktreeId.delete(worktreeId)
+  }
+  return evicted
+}


### PR DESCRIPTION
## Summary

Fixes the top Windows **renderer-heap OOM** crash cluster (v1.4.145+). `Terminal.tsx` kept a mounted (hidden) terminal surface for **every worktree the user ever activated** — the mount set (`mountedWorktreeIdsRef`) was only pruned when a worktree was *deleted*, never bounded. Each retained surface holds an xterm.js `Terminal` + WebGL renderer + scrollback `ArrayBuffer`s (~3–4 MB each), so over a long session that switches between many worktrees the renderer heap climbs to the 3586 MB V8 ceiling and OOMs.

The fix evicts the **least-recently-hidden background worktree mounts beyond a cap of 8**, after a 30 s hysteresis, fully unmounting their surfaces. The PTYs persist in the terminal daemon, so re-activating an evicted worktree remounts through the existing cold-activation tab-deferral path.

## Reproduction (undeniable)

Reproduced live on a dev build via CDP + the shipped `renderer_memory_highwater` instrumentation — activating 3 distinct worktrees and switching back:

| step | `.xterm` (attached) | DOM nodes |
|---|---|---|
| activate wt #1 | 3 | 923 |
| activate wt #2 | 4 | 1073 |
| activate wt #3 | 5 | 1223 |
| **switch back to #1** | **5** (never released) | **1223** |

A HeapProfiler snapshot confirmed the retained payload is `JSArrayBufferData` (xterm scrollback), ~3–4 MB/terminal. Trigger = `setActiveWorktree` (the `sidebar_worktree_activate` path). Matches every production clue: churning key (worktree id), large payloads, rapid worktree switching, recent builds, long sessions.

**Failing-before / passing-after test:** `terminal-worktree-mount-eviction.test.ts` simulates the Terminal render pass over 40 worktree activations. Without the eviction step (= current prod code) the mount set grows to 40 → `AssertionError: expected 40 to be less than or equal to 9`; with eviction it stays ≤ 9. 11 tests total.

## The fix

- New `src/renderer/src/components/terminal/terminal-worktree-mount-eviction.ts` — pure, tested eviction: pick the least-recently-hidden mounted worktrees over the cap and remove them from the mount set + the same bookkeeping maps the existing deletion-prune cleans. Extracted to its own file because `Terminal.tsx` and `background-terminal-worktree-mount.ts` are at the 300 max-lines limit (no `max-lines` disable added).
- `Terminal.tsx` — in the same render pass as the existing "prune deleted worktrees" block, size-gated (`> cap+1`) so the safety scans stay off the common small-session path.
- Cap = `TERMINAL_WORKTREE_HOT_RETAIN_LIMIT` (8) and hysteresis = `TERMINAL_WORKTREE_COLD_PARK_DELAY_MS` (30 s) — reuses the warm working-set + cold-park timing the parking design already chose, so eviction is "parking, one level up" and the existing recheck timer already re-renders at the 30 s deadline.

### Guardrails (never evicted)
Active worktree; worktrees with a live (non-`done`) agent; tabs with a pending startup/spawn; targeted background mounts (wake/resume, mobile subscription, CLI create); activity-portal or currently-measuring surfaces; and tabs whose live PTY has no local daemon snapshot (remote runtime / SSH / fail-open) since those can't replay on remount.

## ELI5

Every time you clicked into a worktree, Orca quietly kept that worktree's terminals fully loaded in memory in the background — forever, even after you moved on — so it could switch back instantly. Over a long day of hopping between many worktrees, all those invisible terminals (each holding megabytes of scroll history) piled up until the window ran out of memory and crashed. The fix keeps the 8 most-recently-used worktrees loaded and unloads the older idle ones; switching back to an old one just reloads it (its session is safe in the background daemon).

## Trade-offs (honest)

- Switching back to a worktree idle > 30 s and beyond the 8 most-recent pays a **cold remount** (~170 ms/pane, deferral-capped for many-tab worktrees) instead of instant reveal.
- An evicted worktree loses its parked byte-watchers, so a bell/title from a *non-agent* long-running command in a long-idle over-cap worktree can go unnoticed (live agents are exempt; this matches the never-visited-worktree baseline).
- Paired mobile/web clients: targeted mobile mounts (the normal case) are exempt; an already-attached passive stream in a desktop-visited worktree could blank briefly until the client re-requests its mount.
- No API, persistence, or provider change.

## Adversarial review
- **1 loop, 2 independent reviewers** (correctness + behavior/UX/rules), both **CLEAN — no blocking defects**.
  - Correctness reviewer verified the overflow math, render-time ref mutation (matches the existing prune pattern), live-agent/SSH guards, `hiddenSince` population, remount cleanup, and prune ordering — and confirmed eviction genuinely reclaims the scrollback (unmount → `TerminalPane` cleanup → `terminal.dispose()`).
  - Behavior reviewer confirmed the fix is **more conservative than the shipped baseline**: an existing pane-parking layer already unmounts hidden panes at the *same* cap (8) and delay (30 s), so this adds no new remount frequency or scrollback loss; it's the complementary surface-level bound (and the only bound when parking's kill-switch is off). Project-rules compliant (no `max-lines` disable added).
  - Only actionable items were two comment-accuracy clarifications (recheck-timer caveat when parking is disabled; the deliberate cap/parking coupling) — applied.
- **Loops until clean: 1.** 11 tests pass; oxlint + web `tsc` clean.

## Note
Reproduced/verified on a build with the `renderer_memory_highwater` instrumentation the team shipped separately — that breadcrumb will confirm `mountedWorktreeIds`/`.xterm` counts stay bounded in the wild post-fix.
