### PR TITLE
oom(03/29): bound shared filesystem/quick-open/markdown listings

### DIFF
--- a/src/shared/bounded-secure-json-file.ts
+++ b/src/shared/bounded-secure-json-file.ts
@@ -1,0 +1,10 @@
+import { stringifyJsonWithinByteLimit } from './node-bounded-json-stringify'
+import { writeSecureFile } from './secure-file'
+
+export function writeSecureJsonFileWithinLimit(
+  targetPath: string,
+  value: unknown,
+  maxBytes: number
+): void {
+  writeSecureFile(targetPath, stringifyJsonWithinByteLimit(value, maxBytes).serialized)
+}

--- a/src/shared/custom-pet-media-limits.ts
+++ b/src/shared/custom-pet-media-limits.ts
@@ -1,0 +1,19 @@
+export const MAX_CUSTOM_PET_FILE_BYTES = 64 * 1024 * 1024
+
+// Why: sprite processing holds decoded image, canvas, ImageData, PNG, and
+// optional bitmap copies at once, so encoded bytes alone are not a safe bound.
+export const MAX_CUSTOM_PET_SHEET_PIXELS = 4 * 1024 * 1024
+export const MAX_CUSTOM_PET_SHEET_DIMENSION = 8_192
+export const MAX_CUSTOM_PET_DETECTED_FRAMES = 128
+
+export function isCustomPetSheetSizeSafe(width: number, height: number): boolean {
+  return (
+    Number.isSafeInteger(width) &&
+    Number.isSafeInteger(height) &&
+    width > 0 &&
+    height > 0 &&
+    width <= MAX_CUSTOM_PET_SHEET_DIMENSION &&
+    height <= MAX_CUSTOM_PET_SHEET_DIMENSION &&
+    width * height <= MAX_CUSTOM_PET_SHEET_PIXELS
+  )
+}

--- a/src/shared/fetch-response-body.ts
+++ b/src/shared/fetch-response-body.ts
@@ -1,0 +1,116 @@
+import {
+  assertJsonTextStructureWithinLimits,
+  type JsonTextStructureLimits
+} from './json-text-structure-limit'
+
+const INITIAL_RESPONSE_CAPACITY_BYTES = 64 * 1024
+
+export const API_RESPONSE_MAX_BYTES = 16 * 1024 * 1024
+export const API_RESPONSE_JSON_LIMITS: JsonTextStructureLimits = {
+  structuralTokens: 1_000_000,
+  nestingDepth: 128
+}
+
+export class FetchResponseBodyTooLargeError extends Error {
+  constructor(
+    readonly observedBytes: number,
+    readonly maxBytes: number
+  ) {
+    super(`Response body exceeds ${maxBytes} byte limit`)
+    this.name = 'FetchResponseBodyTooLargeError'
+  }
+}
+
+function parseContentLength(response: Response): number | null {
+  const raw = response.headers.get('content-length')
+  if (!raw || !/^\d+$/.test(raw)) {
+    return null
+  }
+  const parsed = Number(raw)
+  return Number.isSafeInteger(parsed) ? parsed : null
+}
+
+function isHighLevelOnlyResponse(response: Response): boolean {
+  const partial = response as Partial<Response>
+  // Injected request adapters may expose only the high-level method they implement.
+  return partial.headers === undefined && partial.body === undefined
+}
+
+async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+  try {
+    await reader.cancel()
+  } catch {
+    // An already-errored or closed response needs no further draining.
+  }
+}
+
+export async function readFetchResponseBytesWithinLimit(
+  response: Response,
+  maxBytes = API_RESPONSE_MAX_BYTES
+): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError('Response body limit must be a non-negative safe integer')
+  }
+
+  const contentLength = parseContentLength(response)
+  if (contentLength !== null && contentLength > maxBytes) {
+    await response.body?.cancel().catch(() => undefined)
+    throw new FetchResponseBodyTooLargeError(contentLength, maxBytes)
+  }
+  if (!response.body) {
+    return new Uint8Array()
+  }
+
+  const reader = response.body.getReader()
+  let output = new Uint8Array(Math.min(maxBytes, INITIAL_RESPONSE_CAPACITY_BYTES))
+  let byteLength = 0
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) {
+        return output.subarray(0, byteLength)
+      }
+      const nextLength = byteLength + value.byteLength
+      if (!Number.isSafeInteger(nextLength) || nextLength > maxBytes) {
+        await cancelReader(reader)
+        throw new FetchResponseBodyTooLargeError(nextLength, maxBytes)
+      }
+      if (nextLength > output.byteLength) {
+        const nextCapacity = Math.min(
+          maxBytes,
+          Math.max(INITIAL_RESPONSE_CAPACITY_BYTES, output.byteLength * 2, nextLength)
+        )
+        const expanded = new Uint8Array(nextCapacity)
+        expanded.set(output.subarray(0, byteLength))
+        output = expanded
+      }
+      output.set(value, byteLength)
+      byteLength = nextLength
+    }
+  } finally {
+    reader.releaseLock()
+  }
+}
+
+export async function readFetchResponseTextWithinLimit(
+  response: Response,
+  maxBytes = API_RESPONSE_MAX_BYTES
+): Promise<string> {
+  if (isHighLevelOnlyResponse(response)) {
+    return response.text()
+  }
+  return new TextDecoder().decode(await readFetchResponseBytesWithinLimit(response, maxBytes))
+}
+
+export async function readFetchResponseJsonWithinLimit<T>(
+  response: Response,
+  maxBytes = API_RESPONSE_MAX_BYTES,
+  structureLimits: JsonTextStructureLimits = API_RESPONSE_JSON_LIMITS
+): Promise<T> {
+  if (isHighLevelOnlyResponse(response)) {
+    return response.json() as Promise<T>
+  }
+  const content = await readFetchResponseTextWithinLimit(response, maxBytes)
+  assertJsonTextStructureWithinLimits(content, structureLimits)
+  return JSON.parse(content) as T
+}

--- a/src/shared/filesystem-directory-listing-limit.test.ts
+++ b/src/shared/filesystem-directory-listing-limit.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertFilesystemDirectoryWithinLimit,
+  createFilesystemDirectoryLimitState,
+  FILESYSTEM_DIRECTORY_LIMIT_MESSAGE,
+  FILESYSTEM_DIRECTORY_MAX_ENTRIES,
+  FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES,
+  resolveFilesystemDirectoryListingLimits,
+  trackFilesystemDirectoryEntry
+} from './filesystem-directory-listing-limit'
+
+describe('filesystem directory listing limit', () => {
+  it('accepts ordinary complete listings', () => {
+    expect(() =>
+      assertFilesystemDirectoryWithinLimit([
+        { name: 'src' },
+        { name: 'README.md' },
+        { name: '文件.txt' }
+      ])
+    ).not.toThrow()
+  })
+
+  it('rejects the first entry beyond the count limit', () => {
+    const state = createFilesystemDirectoryLimitState({
+      maxEntries: 2,
+      maxRetainedBytes: FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES
+    })
+
+    trackFilesystemDirectoryEntry(state, { name: 'one' })
+    trackFilesystemDirectoryEntry(state, { name: 'two' })
+    expect(() => trackFilesystemDirectoryEntry(state, { name: 'three' })).toThrow(
+      FILESYSTEM_DIRECTORY_LIMIT_MESSAGE
+    )
+    expect(state.entries).toBe(3)
+  })
+
+  it('rejects names beyond the retained-byte limit', () => {
+    const state = createFilesystemDirectoryLimitState({
+      maxEntries: FILESYSTEM_DIRECTORY_MAX_ENTRIES,
+      maxRetainedBytes: 100
+    })
+
+    expect(() => trackFilesystemDirectoryEntry(state, { name: 'xx' })).toThrow(
+      FILESYSTEM_DIRECTORY_LIMIT_MESSAGE
+    )
+  })
+
+  it('never lets callers raise the process-wide ceilings', () => {
+    expect(
+      resolveFilesystemDirectoryListingLimits({
+        maxEntries: Number.MAX_SAFE_INTEGER,
+        maxRetainedBytes: Number.MAX_SAFE_INTEGER
+      })
+    ).toEqual({
+      maxEntries: FILESYSTEM_DIRECTORY_MAX_ENTRIES,
+      maxRetainedBytes: FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES
+    })
+  })
+})

--- a/src/shared/filesystem-directory-listing-limit.ts
+++ b/src/shared/filesystem-directory-listing-limit.ts
@@ -1,0 +1,75 @@
+export const FILESYSTEM_DIRECTORY_MAX_ENTRIES = 100_000
+export const FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES = 12 * 1024 * 1024
+export const FILESYSTEM_DIRECTORY_LIMIT_MESSAGE =
+  'This folder is too large to list safely (limit: 100,000 items or a 12 MB listing).'
+
+export type FilesystemDirectoryListingLimits = {
+  maxEntries: number
+  maxRetainedBytes: number
+}
+
+type NamedDirectoryEntry = { name: string }
+
+export type FilesystemDirectoryLimitState = {
+  entries: number
+  retainedBytes: number
+  limits: FilesystemDirectoryListingLimits
+}
+
+export function resolveFilesystemDirectoryListingLimits(
+  requested?: Partial<FilesystemDirectoryListingLimits>
+): FilesystemDirectoryListingLimits {
+  return {
+    maxEntries: clampLimit(requested?.maxEntries, FILESYSTEM_DIRECTORY_MAX_ENTRIES),
+    maxRetainedBytes: clampLimit(
+      requested?.maxRetainedBytes,
+      FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES
+    )
+  }
+}
+
+export function createFilesystemDirectoryLimitState(
+  requested?: Partial<FilesystemDirectoryListingLimits>
+): FilesystemDirectoryLimitState {
+  return {
+    entries: 0,
+    retainedBytes: 0,
+    limits: resolveFilesystemDirectoryListingLimits(requested)
+  }
+}
+
+export function trackFilesystemDirectoryEntry(
+  state: FilesystemDirectoryLimitState,
+  entry: NamedDirectoryEntry
+): void {
+  state.entries += 1
+  state.retainedBytes += estimateFilesystemDirectoryEntryBytes(entry)
+  if (
+    state.entries > state.limits.maxEntries ||
+    state.retainedBytes > state.limits.maxRetainedBytes
+  ) {
+    throw new Error(FILESYSTEM_DIRECTORY_LIMIT_MESSAGE)
+  }
+}
+
+export function assertFilesystemDirectoryWithinLimit(
+  entries: readonly NamedDirectoryEntry[],
+  requested?: Partial<FilesystemDirectoryListingLimits>
+): void {
+  const state = createFilesystemDirectoryLimitState(requested)
+  for (const entry of entries) {
+    trackFilesystemDirectoryEntry(state, entry)
+  }
+}
+
+export function estimateFilesystemDirectoryEntryBytes(entry: NamedDirectoryEntry): number {
+  // Why: this covers worst-case JSON escaping plus each result object's fixed overhead.
+  return entry.name.length * 6 + 96
+}
+
+function clampLimit(value: number | undefined, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    return maximum
+  }
+  return Math.min(value, maximum)
+}

--- a/src/shared/growing-byte-buffer.test.ts
+++ b/src/shared/growing-byte-buffer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { GrowingByteBuffer } from './growing-byte-buffer'
+
+describe('GrowingByteBuffer', () => {
+  it('retains 100,000 one-byte fragments in one growable allocation', () => {
+    const buffer = new GrowingByteBuffer()
+    const expected = Buffer.alloc(100_000)
+
+    for (let index = 0; index < expected.byteLength; index += 1) {
+      const value = index % 251
+      expected[index] = value
+      buffer.append(Uint8Array.of(value))
+    }
+
+    expect(buffer.byteLength).toBe(expected.byteLength)
+    expect(buffer.takeString('latin1')).toBe(expected.toString('latin1'))
+    expect(buffer.byteLength).toBe(0)
+  })
+
+  it('consumes delimited prefixes and retains a bounded suffix', () => {
+    const buffer = new GrowingByteBuffer()
+    for (const byte of Buffer.from('first\nsecond-tail')) {
+      buffer.append(Uint8Array.of(byte))
+    }
+
+    const newline = buffer.indexOfByte(0x0a)
+    expect(buffer.takePrefixString(newline)).toBe('first')
+    buffer.discardPrefix(1)
+    buffer.retainSuffix(4)
+
+    expect(buffer.toString()).toBe('tail')
+  })
+
+  it('appends only a bounded copy from an oversized source chunk', () => {
+    const buffer = new GrowingByteBuffer()
+    buffer.append(Buffer.from('old'))
+    const source = Buffer.from('discard-prefix-tail')
+
+    buffer.appendRetainedSuffix(source, 4)
+    source.fill(0)
+
+    expect(buffer.byteLength).toBe(4)
+    expect(buffer.toString()).toBe('tail')
+  })
+
+  it('keeps the newest bytes across bounded suffix appends', () => {
+    const buffer = new GrowingByteBuffer()
+
+    buffer.appendRetainedSuffix(Buffer.from('1234'), 6)
+    buffer.appendRetainedSuffix(Buffer.from('5678'), 6)
+
+    expect(buffer.toString()).toBe('345678')
+  })
+})

--- a/src/shared/growing-byte-buffer.ts
+++ b/src/shared/growing-byte-buffer.ts
@@ -1,0 +1,100 @@
+export class GrowingByteBuffer {
+  private storage = Buffer.alloc(0)
+  private length = 0
+
+  get byteLength(): number {
+    return this.length
+  }
+
+  append(bytes: Buffer | Uint8Array): void {
+    if (bytes.byteLength === 0) {
+      return
+    }
+    const required = this.length + bytes.byteLength
+    if (required > this.storage.byteLength) {
+      const capacity = Math.max(required, Math.max(256, this.storage.byteLength * 2))
+      const next = Buffer.allocUnsafe(capacity)
+      this.storage.copy(next, 0, 0, this.length)
+      this.storage = next
+    }
+    const source = Buffer.isBuffer(bytes)
+      ? bytes
+      : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+    source.copy(this.storage, this.length)
+    this.length = required
+  }
+
+  appendRetainedSuffix(bytes: Buffer | Uint8Array, maxBytes: number): void {
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+      throw new RangeError('Retained suffix limit must be a non-negative safe integer')
+    }
+    if (maxBytes === 0) {
+      this.clear()
+      return
+    }
+    const source = Buffer.isBuffer(bytes)
+      ? bytes
+      : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+    if (source.byteLength >= maxBytes) {
+      this.storage = Buffer.from(source.subarray(source.byteLength - maxBytes))
+      this.length = maxBytes
+      return
+    }
+    const retainedBytes = Math.min(this.length, maxBytes - source.byteLength)
+    if (retainedBytes < this.length) {
+      this.storage.copy(this.storage, 0, this.length - retainedBytes, this.length)
+      this.length = retainedBytes
+    }
+    this.append(source)
+  }
+
+  indexOfByte(value: number, byteOffset = 0): number {
+    return this.storage.subarray(0, this.length).indexOf(value, byteOffset)
+  }
+
+  takePrefixString(byteLength: number, encoding: BufferEncoding = 'utf8'): string {
+    if (!Number.isSafeInteger(byteLength) || byteLength < 0 || byteLength > this.length) {
+      throw new RangeError('Prefix length exceeds retained bytes')
+    }
+    const value = this.storage.toString(encoding, 0, byteLength)
+    this.discardPrefix(byteLength)
+    return value
+  }
+
+  discardPrefix(byteLength: number): void {
+    if (!Number.isSafeInteger(byteLength) || byteLength < 0 || byteLength > this.length) {
+      throw new RangeError('Prefix length exceeds retained bytes')
+    }
+    if (byteLength === 0) {
+      return
+    }
+    this.storage.copy(this.storage, 0, byteLength, this.length)
+    this.length -= byteLength
+  }
+
+  retainSuffix(maxBytes: number): void {
+    if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+      throw new RangeError('Suffix limit must be a non-negative safe integer')
+    }
+    if (this.length <= maxBytes) {
+      return
+    }
+    this.storage.copy(this.storage, 0, this.length - maxBytes, this.length)
+    this.length = maxBytes
+  }
+
+  toString(encoding: BufferEncoding = 'utf8'): string {
+    return this.storage.toString(encoding, 0, this.length)
+  }
+
+  takeString(encoding: BufferEncoding = 'utf8'): string {
+    const value = this.toString(encoding)
+    this.clear()
+    return value
+  }
+
+  clear(): void {
+    this.storage = Buffer.alloc(0)
+    this.length = 0
+  }
+}

--- a/src/shared/html-to-pdf-memory-limit.ts
+++ b/src/shared/html-to-pdf-memory-limit.ts
@@ -1,0 +1,13 @@
+import { measureUtf8ByteLength } from './utf8-byte-limits'
+
+export const HTML_TO_PDF_MAX_INPUT_BYTES = 32 * 1024 * 1024
+export const HTML_TO_PDF_MEMORY_LIMIT_ERROR = 'HTML export exceeds the PDF memory limit'
+
+export function assertHtmlToPdfInputWithinMemoryLimit(
+  html: string,
+  maxBytes = HTML_TO_PDF_MAX_INPUT_BYTES
+): void {
+  if (measureUtf8ByteLength(html, { stopAfterBytes: maxBytes }).exceededLimit) {
+    throw new Error(HTML_TO_PDF_MEMORY_LIMIT_ERROR)
+  }
+}

--- a/src/shared/linux-proc-port-scan-limits.test.ts
+++ b/src/shared/linux-proc-port-scan-limits.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createLinuxProcTextReadBudget,
+  LINUX_PROC_NETWORK_TABLE_MAX_BYTES,
+  readLinuxProcNetworkTable,
+  readLinuxProcTextWithinBudget
+} from './linux-proc-port-scan-limits'
+
+describe('Linux proc port scan limits', () => {
+  it('applies the network-table byte cap before retaining content', async () => {
+    const readFile = vi.fn(async () => Buffer.from('table'))
+
+    await expect(readLinuxProcNetworkTable('/proc/net/tcp', readFile)).resolves.toBe('table')
+    expect(readFile).toHaveBeenCalledWith('/proc/net/tcp', LINUX_PROC_NETWORK_TABLE_MAX_BYTES)
+  })
+
+  it('shares one retained-byte budget across process metadata files', async () => {
+    const budget = createLinuxProcTextReadBudget(5)
+    const readFile = vi
+      .fn<(filePath: string, maxBytes: number) => Promise<Buffer>>()
+      .mockResolvedValueOnce(Buffer.from('abc'))
+      .mockResolvedValueOnce(Buffer.from('de'))
+
+    await expect(readLinuxProcTextWithinBudget('/proc/1/comm', budget, readFile, 4)).resolves.toBe(
+      'abc'
+    )
+    await expect(
+      readLinuxProcTextWithinBudget('/proc/1/cmdline', budget, readFile, 4)
+    ).resolves.toBe('de')
+    await expect(
+      readLinuxProcTextWithinBudget('/proc/2/cmdline', budget, readFile, 4)
+    ).resolves.toBeUndefined()
+
+    expect(readFile.mock.calls).toEqual([
+      ['/proc/1/comm', 4],
+      ['/proc/1/cmdline', 2]
+    ])
+    expect(budget.remainingBytes).toBe(0)
+  })
+
+  it('does not debit failed metadata reads', async () => {
+    const budget = createLinuxProcTextReadBudget(4)
+    const readFile = vi.fn(async () => {
+      throw new Error('oversized')
+    })
+
+    await expect(
+      readLinuxProcTextWithinBudget('/proc/1/cmdline', budget, readFile)
+    ).resolves.toBeUndefined()
+    expect(budget.remainingBytes).toBe(4)
+  })
+})

--- a/src/shared/linux-proc-port-scan-limits.ts
+++ b/src/shared/linux-proc-port-scan-limits.ts
@@ -1,0 +1,55 @@
+import { readNodeFileWithinLimit } from './node-bounded-file-reader'
+
+export const LINUX_PROC_NETWORK_TABLE_MAX_BYTES = 8 * 1024 * 1024
+export const LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES = 2_048
+export const LINUX_PROC_PROCESS_METADATA_MAX_BYTES = 8 * 1024 * 1024
+export const LINUX_PROC_PROCESS_METADATA_FILE_MAX_BYTES = 64 * 1024
+
+export type LinuxProcTextReadBudget = { remainingBytes: number }
+
+type LinuxProcTextReader = (filePath: string, maxBytes: number) => Promise<Buffer>
+
+const readBoundedNodeFile: LinuxProcTextReader = async (filePath, maxBytes) =>
+  (await readNodeFileWithinLimit(filePath, maxBytes)).buffer
+
+export function createLinuxProcTextReadBudget(
+  maxBytes = LINUX_PROC_PROCESS_METADATA_MAX_BYTES
+): LinuxProcTextReadBudget {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError('Linux proc text budget must be a non-negative safe integer')
+  }
+  return { remainingBytes: maxBytes }
+}
+
+export async function readLinuxProcNetworkTable(
+  filePath: string,
+  readFile: LinuxProcTextReader = readBoundedNodeFile
+): Promise<string | null> {
+  try {
+    return (await readFile(filePath, LINUX_PROC_NETWORK_TABLE_MAX_BYTES)).toString('utf8')
+  } catch {
+    return null
+  }
+}
+
+export async function readLinuxProcTextWithinBudget(
+  filePath: string,
+  budget: LinuxProcTextReadBudget,
+  readFile: LinuxProcTextReader = readBoundedNodeFile,
+  perFileMaxBytes = LINUX_PROC_PROCESS_METADATA_FILE_MAX_BYTES
+): Promise<string | undefined> {
+  const maxBytes = Math.min(perFileMaxBytes, budget.remainingBytes)
+  if (maxBytes <= 0) {
+    return undefined
+  }
+  try {
+    const content = await readFile(filePath, maxBytes)
+    if (content.byteLength > maxBytes) {
+      return undefined
+    }
+    budget.remainingBytes -= content.byteLength
+    return content.toString('utf8')
+  } catch {
+    return undefined
+  }
+}

--- a/src/shared/linux-proc-socket-owner-scanner.test.ts
+++ b/src/shared/linux-proc-socket-owner-scanner.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { mapLinuxSocketInodesToPids } from './linux-proc-socket-owner-scanner'
+
+async function* names(values: readonly string[]): AsyncGenerator<string> {
+  yield* values
+}
+
+describe('mapLinuxSocketInodesToPids', () => {
+  it('streams process and descriptor directories while preserving owner resolution', async () => {
+    const visitedDirectories: string[] = []
+    const result = await mapLinuxSocketInodesToPids(new Set([101, 202]), {
+      readDirectoryNames: (directoryPath) => {
+        visitedDirectories.push(directoryPath)
+        if (directoryPath === '/proc') {
+          return names(['self', '41', '42'])
+        }
+        return names(directoryPath.endsWith('/41/fd') ? ['1', '2'] : ['3'])
+      },
+      readLink: async (filePath) => {
+        if (filePath.endsWith('/41/fd/1')) {
+          return 'socket:[101]'
+        }
+        if (filePath.endsWith('/42/fd/3')) {
+          return 'socket:[202]'
+        }
+        return 'pipe:[9]'
+      }
+    })
+
+    expect(result).toEqual(
+      new Map([
+        [101, 41],
+        [202, 42]
+      ])
+    )
+    expect(visitedDirectories).toEqual(['/proc', '/proc/41/fd', '/proc/42/fd'])
+  })
+
+  it('does not retain an arbitrarily large process-name listing', async () => {
+    let yielded = 0
+    const result = await mapLinuxSocketInodesToPids(new Set([7]), {
+      readDirectoryNames: (directoryPath) => {
+        if (directoryPath !== '/proc') {
+          return names([])
+        }
+        return (async function* () {
+          for (let pid = 1; pid <= 20_000; pid += 1) {
+            yielded += 1
+            yield String(pid)
+          }
+        })()
+      },
+      readLink: async () => 'socket:[7]'
+    })
+
+    expect(yielded).toBe(20_000)
+    expect(result.size).toBe(0)
+  })
+})

--- a/src/shared/linux-proc-socket-owner-scanner.ts
+++ b/src/shared/linux-proc-socket-owner-scanner.ts
@@ -1,0 +1,64 @@
+import { opendir, readlink } from 'node:fs/promises'
+import { posix } from 'node:path'
+
+type LinuxProcSocketOwnerScannerDependencies = {
+  readDirectoryNames: (directoryPath: string) => AsyncIterable<string>
+  readLink: (filePath: string) => Promise<string>
+}
+
+async function* readNodeDirectoryNames(directoryPath: string): AsyncGenerator<string> {
+  try {
+    const directory = await opendir(directoryPath)
+    for await (const entry of directory) {
+      yield entry.name
+    }
+  } catch {}
+}
+
+const defaultDependencies: LinuxProcSocketOwnerScannerDependencies = {
+  readDirectoryNames: readNodeDirectoryNames,
+  readLink: readlink
+}
+
+export async function mapLinuxSocketInodesToPids(
+  inodes: ReadonlySet<number>,
+  dependencies: LinuxProcSocketOwnerScannerDependencies = defaultDependencies
+): Promise<Map<number, number>> {
+  const result = new Map<number, number>()
+  if (inodes.size === 0) {
+    return result
+  }
+
+  try {
+    for await (const pidText of dependencies.readDirectoryNames('/proc')) {
+      if (!/^\d+$/.test(pidText)) {
+        continue
+      }
+      const pid = Number.parseInt(pidText, 10)
+      const fdDirectory = posix.join('/proc', pidText, 'fd')
+      try {
+        for await (const fd of dependencies.readDirectoryNames(fdDirectory)) {
+          let link: string
+          try {
+            link = await dependencies.readLink(posix.join(fdDirectory, fd))
+          } catch {
+            continue
+          }
+          const match = /^socket:\[(\d+)\]$/.exec(link)
+          if (!match) {
+            continue
+          }
+          const inode = Number.parseInt(match[1], 10)
+          if (inodes.has(inode)) {
+            result.set(inode, pid)
+          }
+        }
+      } catch {
+        continue
+      }
+    }
+  } catch {
+    return result
+  }
+  return result
+}

--- a/src/shared/markdown-document-listing-limits.test.ts
+++ b/src/shared/markdown-document-listing-limits.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import type { MarkdownDocument } from './types'
+import {
+  assertMarkdownDocumentsWithinLimit,
+  createMarkdownDocumentListingBudget,
+  isMarkdownDocumentListingCapacityError,
+  MARKDOWN_DOCUMENT_LISTING_ERROR_CODE,
+  MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE,
+  MarkdownDocumentListingCapacityError,
+  retainMarkdownDocument,
+  visitMarkdownDocumentListingEntry
+} from './markdown-document-listing-limits'
+
+function document(path: string): MarkdownDocument {
+  return {
+    filePath: `/repo/${path}`,
+    relativePath: path,
+    basename: path,
+    name: path
+  }
+}
+
+describe('Markdown document listing limits', () => {
+  it('preserves an under-limit listing and reports its retained estimate', () => {
+    const documents = [document('README.md'), document('docs/guide.mdx')]
+
+    expect(assertMarkdownDocumentsWithinLimit(documents)).toBeGreaterThan(0)
+  })
+
+  it('rejects the first document beyond the count limit with a typed error', () => {
+    const budget = createMarkdownDocumentListingBudget({ maxDocuments: 2 })
+    retainMarkdownDocument(budget, document('one.md'))
+    retainMarkdownDocument(budget, document('two.md'))
+
+    expect(() => retainMarkdownDocument(budget, document('three.md'))).toThrow(
+      MarkdownDocumentListingCapacityError
+    )
+    expect(() => retainMarkdownDocument(budget, document('three.md'))).toThrow(
+      expect.objectContaining({ code: MARKDOWN_DOCUMENT_LISTING_ERROR_CODE })
+    )
+  })
+
+  it('rejects aggregate metadata, visited-entry, path, and depth overflow', () => {
+    expect(() =>
+      assertMarkdownDocumentsWithinLimit([document('a'.repeat(100))], {
+        maxMetadataBytes: 100
+      })
+    ).toThrow(MarkdownDocumentListingCapacityError)
+
+    const visited = createMarkdownDocumentListingBudget({
+      maxVisitedEntries: 1,
+      maxPathBytes: 4,
+      maxDepth: 1
+    })
+    visitMarkdownDocumentListingEntry(visited, 'a', 1)
+    expect(() => visitMarkdownDocumentListingEntry(visited, 'b', 1)).toThrow(
+      MarkdownDocumentListingCapacityError
+    )
+
+    const path = createMarkdownDocumentListingBudget({ maxPathBytes: 4 })
+    expect(() => visitMarkdownDocumentListingEntry(path, 'ééé', 1)).toThrow(
+      MarkdownDocumentListingCapacityError
+    )
+
+    const depth = createMarkdownDocumentListingBudget({ maxDepth: 1 })
+    expect(() => visitMarkdownDocumentListingEntry(depth, 'a/b', 2)).toThrow(
+      MarkdownDocumentListingCapacityError
+    )
+  })
+
+  it('recognizes structured runtime and Electron-wrapped capacity failures', () => {
+    const structured = Object.assign(new Error('remote listing rejected'), {
+      code: MARKDOWN_DOCUMENT_LISTING_ERROR_CODE
+    })
+    const electronWrapped = new Error(
+      `Error invoking remote method 'fs:listMarkdownDocuments': Error: ${MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE}`
+    )
+
+    expect(isMarkdownDocumentListingCapacityError(structured)).toBe(true)
+    expect(isMarkdownDocumentListingCapacityError(electronWrapped)).toBe(true)
+    expect(isMarkdownDocumentListingCapacityError(new Error('unrelated failure'))).toBe(false)
+  })
+})

--- a/src/shared/markdown-document-listing-limits.ts
+++ b/src/shared/markdown-document-listing-limits.ts
@@ -1,0 +1,170 @@
+import type { MarkdownDocument } from './types'
+import { measureUtf8ByteLength } from './utf8-byte-limits'
+
+export const MARKDOWN_DOCUMENT_LISTING_MAX_DOCUMENTS = 20_000
+export const MARKDOWN_DOCUMENT_LISTING_MAX_METADATA_BYTES = 8 * 1024 * 1024
+export const MARKDOWN_DOCUMENT_LISTING_MAX_PATH_BYTES = 64 * 1024
+export const MARKDOWN_DOCUMENT_LISTING_MAX_VISITED_ENTRIES = 100_000
+export const MARKDOWN_DOCUMENT_LISTING_MAX_DEPTH = 256
+export const MARKDOWN_DOCUMENT_LISTING_ERROR_CODE = 'markdown_document_listing_capacity'
+export const MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE =
+  'Workspace is too large for Markdown link completion.'
+
+const MARKDOWN_DOCUMENT_RETAINED_OVERHEAD_BYTES = 256
+
+export type MarkdownDocumentListingLimits = {
+  maxDocuments: number
+  maxMetadataBytes: number
+  maxPathBytes: number
+  maxVisitedEntries: number
+  maxDepth: number
+}
+
+export type MarkdownDocumentListingBudget = {
+  documents: number
+  metadataBytes: number
+  visitedEntries: number
+  limits: MarkdownDocumentListingLimits
+}
+
+export class MarkdownDocumentListingCapacityError extends Error {
+  readonly code = MARKDOWN_DOCUMENT_LISTING_ERROR_CODE
+
+  constructor() {
+    super(MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE)
+    this.name = 'MarkdownDocumentListingCapacityError'
+  }
+}
+
+export function isMarkdownDocumentListingCapacityError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  return (
+    ('code' in error &&
+      (error as { code?: unknown }).code === MARKDOWN_DOCUMENT_LISTING_ERROR_CODE) ||
+    error.message.includes(MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE)
+  )
+}
+
+export function createMarkdownDocumentListingBudget(
+  requested: Partial<MarkdownDocumentListingLimits> = {}
+): MarkdownDocumentListingBudget {
+  return {
+    documents: 0,
+    metadataBytes: 0,
+    visitedEntries: 0,
+    limits: {
+      maxDocuments: clampLimit(requested.maxDocuments, MARKDOWN_DOCUMENT_LISTING_MAX_DOCUMENTS),
+      maxMetadataBytes: clampLimit(
+        requested.maxMetadataBytes,
+        MARKDOWN_DOCUMENT_LISTING_MAX_METADATA_BYTES
+      ),
+      maxPathBytes: clampLimit(requested.maxPathBytes, MARKDOWN_DOCUMENT_LISTING_MAX_PATH_BYTES),
+      maxVisitedEntries: clampLimit(
+        requested.maxVisitedEntries,
+        MARKDOWN_DOCUMENT_LISTING_MAX_VISITED_ENTRIES
+      ),
+      maxDepth: clampLimit(requested.maxDepth, MARKDOWN_DOCUMENT_LISTING_MAX_DEPTH)
+    }
+  }
+}
+
+export function assertMarkdownDocumentPathWithinLimit(
+  path: string,
+  maxPathBytes = MARKDOWN_DOCUMENT_LISTING_MAX_PATH_BYTES
+): void {
+  if (measureUtf8ByteLength(path, { stopAfterBytes: maxPathBytes }).exceededLimit) {
+    throw new MarkdownDocumentListingCapacityError()
+  }
+}
+
+export function visitMarkdownDocumentListingEntry(
+  budget: MarkdownDocumentListingBudget,
+  path: string,
+  depth: number
+): void {
+  assertMarkdownDocumentPathWithinLimit(path, budget.limits.maxPathBytes)
+  if (budget.visitedEntries >= budget.limits.maxVisitedEntries || depth > budget.limits.maxDepth) {
+    throw new MarkdownDocumentListingCapacityError()
+  }
+  budget.visitedEntries += 1
+}
+
+export function estimateMarkdownDocumentRetainedBytes(document: MarkdownDocument): number {
+  return (
+    (document.filePath.length +
+      document.relativePath.length +
+      document.basename.length +
+      document.name.length) *
+      2 +
+    MARKDOWN_DOCUMENT_RETAINED_OVERHEAD_BYTES
+  )
+}
+
+export function retainMarkdownDocument(
+  budget: MarkdownDocumentListingBudget,
+  document: MarkdownDocument
+): void {
+  if (
+    !document ||
+    typeof document.filePath !== 'string' ||
+    typeof document.relativePath !== 'string' ||
+    typeof document.basename !== 'string' ||
+    typeof document.name !== 'string'
+  ) {
+    throw new MarkdownDocumentListingCapacityError()
+  }
+  assertMarkdownDocumentPathWithinLimit(document.filePath, budget.limits.maxPathBytes)
+  assertMarkdownDocumentPathWithinLimit(document.relativePath, budget.limits.maxPathBytes)
+  const retainedBytes = estimateMarkdownDocumentRetainedBytes(document)
+  if (
+    budget.documents >= budget.limits.maxDocuments ||
+    budget.metadataBytes + retainedBytes > budget.limits.maxMetadataBytes
+  ) {
+    throw new MarkdownDocumentListingCapacityError()
+  }
+  budget.documents += 1
+  budget.metadataBytes += retainedBytes
+}
+
+export function retainMarkdownRelativePath(
+  budget: MarkdownDocumentListingBudget,
+  rootPath: string,
+  relativePath: string
+): void {
+  const normalizedRoot = rootPath.replace(/[\\/]+$/, '')
+  const normalizedRelativePath = relativePath.replaceAll('\\', '/')
+  const basename = normalizedRelativePath.slice(normalizedRelativePath.lastIndexOf('/') + 1)
+  const extensionIndex = basename.lastIndexOf('.')
+  retainMarkdownDocument(budget, {
+    filePath: `${normalizedRoot}/${normalizedRelativePath}`,
+    relativePath: normalizedRelativePath,
+    basename,
+    name: extensionIndex > 0 ? basename.slice(0, extensionIndex) : basename
+  })
+}
+
+export function assertMarkdownDocumentsWithinLimit(
+  documents: unknown,
+  requested: Partial<MarkdownDocumentListingLimits> = {}
+): number {
+  const budget = createMarkdownDocumentListingBudget(requested)
+  if (!Array.isArray(documents)) {
+    throw new MarkdownDocumentListingCapacityError()
+  }
+  if (documents.length > budget.limits.maxDocuments) {
+    throw new MarkdownDocumentListingCapacityError()
+  }
+  for (const document of documents) {
+    retainMarkdownDocument(budget, document as MarkdownDocument)
+  }
+  return budget.metadataBytes
+}
+
+function clampLimit(value: number | undefined, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    return maximum
+  }
+  return Math.min(value, maximum)
+}

--- a/src/shared/mobile-file-directory-limit.test.ts
+++ b/src/shared/mobile-file-directory-limit.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertMobileFileDirectoryWithinLimit,
+  MOBILE_FILE_DIRECTORY_LIMIT_MESSAGE,
+  MOBILE_FILE_DIRECTORY_MAX_ENTRIES,
+  MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES
+} from './mobile-file-directory-limit'
+
+describe('mobile file directory limit', () => {
+  it('accepts a complete directory listing within both limits', () => {
+    expect(() =>
+      assertMobileFileDirectoryWithinLimit([
+        { name: 'src' },
+        { name: 'README.md' },
+        { name: 'package.json' }
+      ])
+    ).not.toThrow()
+  })
+
+  it('rejects rather than truncating an excessive entry count', () => {
+    const entries = Array.from({ length: MOBILE_FILE_DIRECTORY_MAX_ENTRIES + 1 }, () => ({
+      name: 'x'
+    }))
+
+    expect(() => assertMobileFileDirectoryWithinLimit(entries)).toThrow(
+      MOBILE_FILE_DIRECTORY_LIMIT_MESSAGE
+    )
+  })
+
+  it('rejects a listing whose names exceed the retained-byte limit', () => {
+    const name = 'x'.repeat(MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES / 2)
+
+    expect(() => assertMobileFileDirectoryWithinLimit([{ name }])).toThrow(
+      MOBILE_FILE_DIRECTORY_LIMIT_MESSAGE
+    )
+  })
+})

--- a/src/shared/mobile-file-directory-limit.ts
+++ b/src/shared/mobile-file-directory-limit.ts
@@ -1,0 +1,43 @@
+// Why: normal repositories stay complete while pathological fan-out/name payloads fail before retention.
+export const MOBILE_FILE_DIRECTORY_MAX_ENTRIES = 10_000
+export const MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES = 4 * 1024 * 1024
+export const MOBILE_FILE_DIRECTORY_LIMIT_MESSAGE =
+  'This folder is too large to show safely on mobile (limit: 10,000 items or a 4 MB listing).'
+
+type NamedDirectoryEntry = { name: string }
+
+export type MobileFileDirectoryLimitState = {
+  entries: number
+  retainedBytes: number
+}
+
+export function createMobileFileDirectoryLimitState(): MobileFileDirectoryLimitState {
+  return { entries: 0, retainedBytes: 0 }
+}
+
+export function trackMobileFileDirectoryEntry(
+  state: MobileFileDirectoryLimitState,
+  entry: NamedDirectoryEntry
+): void {
+  state.entries += 1
+  state.retainedBytes += estimateMobileDirectoryEntryBytes(entry)
+  if (
+    state.entries > MOBILE_FILE_DIRECTORY_MAX_ENTRIES ||
+    state.retainedBytes > MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES
+  ) {
+    throw new Error(MOBILE_FILE_DIRECTORY_LIMIT_MESSAGE)
+  }
+}
+
+export function assertMobileFileDirectoryWithinLimit(
+  entries: readonly NamedDirectoryEntry[]
+): void {
+  const state = createMobileFileDirectoryLimitState()
+  for (const entry of entries) {
+    trackMobileFileDirectoryEntry(state, entry)
+  }
+}
+
+export function estimateMobileDirectoryEntryBytes(entry: NamedDirectoryEntry): number {
+  return entry.name.length * 2 + 64
+}

--- a/src/shared/node-file-content-equality.test.ts
+++ b/src/shared/node-file-content-equality.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { nodeFileContentsEqual, nodeFileContentsEqualSync } from './node-file-content-equality'
+
+const roots: string[] = []
+
+function createFile(contents: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-file-content-equality-'))
+  roots.push(root)
+  const filePath = join(root, 'owned-launcher')
+  writeFileSync(filePath, contents)
+  return filePath
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('Node file content equality', () => {
+  it('compares UTF-8 content without changing its bytes', async () => {
+    const filePath = createFile('launch 🐋\n')
+
+    await expect(nodeFileContentsEqual(filePath, 'launch 🐋\n')).resolves.toBe(true)
+    expect(nodeFileContentsEqualSync(filePath, 'launch 🐋\n')).toBe(true)
+    await expect(nodeFileContentsEqual(filePath, 'different\n')).resolves.toBe(false)
+    expect(nodeFileContentsEqualSync(filePath, 'different\n')).toBe(false)
+  })
+
+  it('rejects a large sparse replacement from metadata without reading its payload', async () => {
+    const filePath = createFile('owned launcher\n')
+    truncateSync(filePath, 256 * 1024 * 1024)
+
+    await expect(nodeFileContentsEqual(filePath, 'owned launcher\n')).resolves.toBe(false)
+    expect(nodeFileContentsEqualSync(filePath, 'owned launcher\n')).toBe(false)
+  })
+})

--- a/src/shared/node-file-content-equality.ts
+++ b/src/shared/node-file-content-equality.ts
@@ -1,0 +1,72 @@
+import { closeSync, fstatSync, openSync, readSync } from 'node:fs'
+import { open } from 'node:fs/promises'
+
+export const NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES = 64 * 1024
+
+function expectedBytes(contents: string | Buffer): Buffer {
+  return typeof contents === 'string' ? Buffer.from(contents, 'utf8') : contents
+}
+
+export async function nodeFileContentsEqual(
+  filePath: string,
+  expectedContents: string | Buffer
+): Promise<boolean> {
+  const expected = expectedBytes(expectedContents)
+  const handle = await open(filePath, 'r')
+  try {
+    if ((await handle.stat()).size !== expected.length) {
+      return false
+    }
+    const chunk = Buffer.allocUnsafe(
+      Math.min(NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES, expected.length)
+    )
+    let offset = 0
+    while (offset < expected.length) {
+      const length = Math.min(chunk.length, expected.length - offset)
+      const { bytesRead } = await handle.read(chunk, 0, length, offset)
+      if (
+        bytesRead === 0 ||
+        !chunk.subarray(0, bytesRead).equals(expected.subarray(offset, offset + bytesRead))
+      ) {
+        return false
+      }
+      offset += bytesRead
+    }
+    const probe = Buffer.allocUnsafe(1)
+    return (await handle.read(probe, 0, 1, offset)).bytesRead === 0
+  } finally {
+    await handle.close()
+  }
+}
+
+export function nodeFileContentsEqualSync(
+  filePath: string,
+  expectedContents: string | Buffer
+): boolean {
+  const expected = expectedBytes(expectedContents)
+  const descriptor = openSync(filePath, 'r')
+  try {
+    if (fstatSync(descriptor).size !== expected.length) {
+      return false
+    }
+    const chunk = Buffer.allocUnsafe(
+      Math.min(NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES, expected.length)
+    )
+    let offset = 0
+    while (offset < expected.length) {
+      const length = Math.min(chunk.length, expected.length - offset)
+      const bytesRead = readSync(descriptor, chunk, 0, length, offset)
+      if (
+        bytesRead === 0 ||
+        !chunk.subarray(0, bytesRead).equals(expected.subarray(offset, offset + bytesRead))
+      ) {
+        return false
+      }
+      offset += bytesRead
+    }
+    const probe = Buffer.allocUnsafe(1)
+    return readSync(descriptor, probe, 0, 1, offset) === 0
+  } finally {
+    closeSync(descriptor)
+  }
+}

--- a/src/shared/node-markdown-document-discovery.test.ts
+++ b/src/shared/node-markdown-document-discovery.test.ts
@@ -1,0 +1,74 @@
+import type { Dirent } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { MarkdownDocumentListingCapacityError } from './markdown-document-listing-limits'
+import { discoverMarkdownRelativePaths } from './node-markdown-document-discovery'
+
+function entry(name: string, kind: 'directory' | 'file' | 'symlink' = 'file'): Dirent {
+  return {
+    name,
+    isDirectory: () => kind === 'directory',
+    isFile: () => kind === 'file',
+    isSymbolicLink: () => kind === 'symlink'
+  } as Dirent
+}
+
+function reader(entriesByPath: Record<string, Dirent[]>) {
+  return async (path: string): Promise<AsyncIterable<Dirent>> => ({
+    async *[Symbol.asyncIterator]() {
+      yield* entriesByPath[path] ?? []
+    }
+  })
+}
+
+describe('bounded Markdown document discovery', () => {
+  it('preserves depth-first discovery and skips excluded and symlinked directories', async () => {
+    const result = await discoverMarkdownRelativePaths('/repo', {
+      readDirectory: reader({
+        '/repo': [
+          entry('README.md'),
+          entry('.git', 'directory'),
+          entry('docs', 'directory'),
+          entry('linked', 'symlink')
+        ],
+        '/repo/docs': [entry('guide.mdx'), entry('app.ts')]
+      }),
+      shouldDescend: (_relativePath, name) => name !== '.git'
+    })
+
+    expect(result).toEqual(['README.md', 'docs/guide.mdx'])
+  })
+
+  it('stops consuming a wide directory at the visited-entry limit', async () => {
+    let yielded = 0
+    const readDirectory = async (): Promise<AsyncIterable<Dirent>> => ({
+      async *[Symbol.asyncIterator]() {
+        for (let index = 0; index < 10_000; index += 1) {
+          yielded += 1
+          yield entry(`source-${index}.ts`)
+        }
+      }
+    })
+
+    await expect(
+      discoverMarkdownRelativePaths('/repo', {
+        limits: { maxVisitedEntries: 2 },
+        readDirectory,
+        shouldDescend: () => true
+      })
+    ).rejects.toBeInstanceOf(MarkdownDocumentListingCapacityError)
+    expect(yielded).toBe(3)
+  })
+
+  it('rejects a directory deeper than the configured traversal limit', async () => {
+    await expect(
+      discoverMarkdownRelativePaths('/repo', {
+        limits: { maxDepth: 1 },
+        readDirectory: reader({
+          '/repo': [entry('one', 'directory')],
+          '/repo/one': [entry('two', 'directory')]
+        }),
+        shouldDescend: () => true
+      })
+    ).rejects.toBeInstanceOf(MarkdownDocumentListingCapacityError)
+  })
+})

--- a/src/shared/node-markdown-document-discovery.ts
+++ b/src/shared/node-markdown-document-discovery.ts
@@ -1,0 +1,86 @@
+import { opendir } from 'node:fs/promises'
+import type { Dirent, Dir } from 'node:fs'
+import { join } from 'node:path'
+import {
+  assertMarkdownDocumentPathWithinLimit,
+  createMarkdownDocumentListingBudget,
+  MarkdownDocumentListingCapacityError,
+  retainMarkdownRelativePath,
+  visitMarkdownDocumentListingEntry,
+  type MarkdownDocumentListingLimits
+} from './markdown-document-listing-limits'
+
+type MarkdownDirectoryReader = (path: string) => Promise<Dir | AsyncIterable<Dirent>>
+
+export type MarkdownDocumentDiscoveryOptions = {
+  shouldDescend: (relativePath: string, name: string) => boolean
+  ignoreNestedDirectoryErrors?: boolean
+  limits?: Partial<MarkdownDocumentListingLimits>
+  readDirectory?: MarkdownDirectoryReader
+  signal?: AbortSignal
+}
+
+export function isMarkdownDocumentPath(path: string): boolean {
+  const lowerPath = path.toLowerCase()
+  return lowerPath.endsWith('.md') || lowerPath.endsWith('.mdx') || lowerPath.endsWith('.markdown')
+}
+
+export async function discoverMarkdownRelativePaths(
+  rootPath: string,
+  options: MarkdownDocumentDiscoveryOptions
+): Promise<string[]> {
+  const budget = createMarkdownDocumentListingBudget(options.limits)
+  const documents: string[] = []
+  const readDirectory = options.readDirectory ?? opendir
+  assertMarkdownDocumentPathWithinLimit(rootPath, budget.limits.maxPathBytes)
+
+  const visitDirectory = async (
+    absoluteDirectoryPath: string,
+    relativeDirectoryPath: string,
+    depth: number
+  ): Promise<void> => {
+    throwIfAborted(options.signal)
+    let directory: Dir | AsyncIterable<Dirent>
+    try {
+      directory = await readDirectory(absoluteDirectoryPath)
+    } catch (error) {
+      if (depth > 0 && options.ignoreNestedDirectoryErrors) {
+        return
+      }
+      throw error
+    }
+
+    for await (const entry of directory) {
+      throwIfAborted(options.signal)
+      const relativePath = relativeDirectoryPath
+        ? `${relativeDirectoryPath}/${entry.name}`
+        : entry.name
+      const nextDepth = depth + 1
+      const shouldDescend = entry.isDirectory() && options.shouldDescend(relativePath, entry.name)
+      visitMarkdownDocumentListingEntry(budget, relativePath, shouldDescend ? nextDepth : depth)
+      if (entry.isSymbolicLink()) {
+        continue
+      }
+      if (entry.isDirectory()) {
+        if (shouldDescend) {
+          await visitDirectory(join(absoluteDirectoryPath, entry.name), relativePath, nextDepth)
+        }
+        continue
+      }
+      if (entry.isFile() && isMarkdownDocumentPath(entry.name)) {
+        retainMarkdownRelativePath(budget, rootPath, relativePath)
+        documents.push(relativePath)
+      }
+    }
+  }
+
+  await visitDirectory(rootPath, '', 0)
+  return documents
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (!signal?.aborted) {
+    return
+  }
+  throw signal.reason instanceof Error ? signal.reason : new MarkdownDocumentListingCapacityError()
+}

--- a/src/shared/node-readable-text.test.ts
+++ b/src/shared/node-readable-text.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  NodeReadableTextTooLargeError,
+  readNodeReadableTextWithinLimit
+} from './node-readable-text'
+
+async function* chunks(values: unknown[]): AsyncGenerator<unknown> {
+  yield* values
+}
+
+describe('readNodeReadableTextWithinLimit', () => {
+  it('preserves accepted UTF-8 bytes split across chunks', async () => {
+    const encoded = Buffer.from('hello 🌍')
+
+    await expect(
+      readNodeReadableTextWithinLimit(
+        chunks([encoded.subarray(0, 8), encoded.subarray(8)]),
+        encoded.byteLength
+      )
+    ).resolves.toBe('hello 🌍')
+  })
+
+  it('accepts input exactly at the byte limit', async () => {
+    await expect(
+      readNodeReadableTextWithinLimit(chunks(['ab', Buffer.from('cd')]), 4)
+    ).resolves.toBe('abcd')
+  })
+
+  it('rejects before retaining input beyond the byte limit', async () => {
+    await expect(readNodeReadableTextWithinLimit(chunks(['1234', '5']), 4)).rejects.toEqual(
+      new NodeReadableTextTooLargeError(5, 4)
+    )
+  })
+
+  it('does not let an unlimited sequence of empty chunks grow retained state', async () => {
+    await expect(
+      readNodeReadableTextWithinLimit(chunks(Array.from({ length: 10_000 }, () => '')), 0)
+    ).resolves.toBe('')
+  })
+})

--- a/src/shared/node-readable-text.ts
+++ b/src/shared/node-readable-text.ts
@@ -1,0 +1,42 @@
+const INITIAL_READ_CAPACITY_BYTES = 64 * 1024
+
+export class NodeReadableTextTooLargeError extends Error {
+  constructor(
+    readonly observedBytes: number,
+    readonly maxBytes: number
+  ) {
+    super(`Input exceeds ${maxBytes} byte limit (${observedBytes} bytes received)`)
+    this.name = 'NodeReadableTextTooLargeError'
+  }
+}
+
+export async function readNodeReadableTextWithinLimit(
+  readable: AsyncIterable<unknown>,
+  maxBytes: number
+): Promise<string> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError('Readable text limit must be a non-negative safe integer')
+  }
+
+  let buffer = Buffer.allocUnsafe(Math.min(INITIAL_READ_CAPACITY_BYTES, maxBytes))
+  let bytes = 0
+  for await (const value of readable) {
+    const chunk = Buffer.isBuffer(value) ? value : Buffer.from(String(value))
+    const observedBytes = bytes + chunk.byteLength
+    if (!Number.isSafeInteger(observedBytes) || observedBytes > maxBytes) {
+      throw new NodeReadableTextTooLargeError(observedBytes, maxBytes)
+    }
+    if (observedBytes > buffer.byteLength) {
+      const nextCapacity = Math.min(
+        maxBytes,
+        Math.max(observedBytes, INITIAL_READ_CAPACITY_BYTES, buffer.byteLength * 2)
+      )
+      const expanded = Buffer.allocUnsafe(nextCapacity)
+      buffer.copy(expanded, 0, 0, bytes)
+      buffer = expanded
+    }
+    chunk.copy(buffer, bytes)
+    bytes = observedBytes
+  }
+  return buffer.subarray(0, bytes).toString('utf8')
+}

--- a/src/shared/node-source-copy-content-equality.test.ts
+++ b/src/shared/node-source-copy-content-equality.test.ts
@@ -1,0 +1,57 @@
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+  writeSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES,
+  nodeSourceAndCopyContentsEqualSync
+} from './node-source-copy-content-equality'
+
+describe('Node source/copy content equality', () => {
+  const roots: string[] = []
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('compares multi-megabyte sparse files with fixed-size chunks', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-resource-compare-'))
+    roots.push(root)
+    const sourcePath = join(root, 'source.md')
+    const copyPath = join(root, 'copy.md')
+    const sparseBytes = NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES * 128
+    for (const path of [sourcePath, copyPath]) {
+      writeFileSync(path, 'same-prefix')
+      truncateSync(path, sparseBytes)
+    }
+
+    expect(nodeSourceAndCopyContentsEqualSync(sourcePath, copyPath)).toBe(true)
+
+    const descriptor = openSync(copyPath, 'r+')
+    try {
+      writeSync(descriptor, Buffer.from('x'), 0, 1, sparseBytes - 1)
+    } finally {
+      closeSync(descriptor)
+    }
+    expect(nodeSourceAndCopyContentsEqualSync(sourcePath, copyPath)).toBe(false)
+  })
+
+  it('rejects a non-file copy without attempting to consume it', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-resource-compare-dir-'))
+    roots.push(root)
+    const sourcePath = join(root, 'source.md')
+    writeFileSync(sourcePath, 'contents')
+
+    expect(nodeSourceAndCopyContentsEqualSync(sourcePath, root)).toBe(false)
+  })
+})

--- a/src/shared/node-source-copy-content-equality.ts
+++ b/src/shared/node-source-copy-content-equality.ts
@@ -1,0 +1,64 @@
+import { closeSync, lstatSync, openSync, readSync, statSync } from 'node:fs'
+
+export const NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES = 64 * 1024
+
+function readChunk(descriptor: number, buffer: Buffer): number {
+  let offset = 0
+  while (offset < buffer.length) {
+    const bytesRead = readSync(descriptor, buffer, offset, buffer.length - offset, null)
+    if (bytesRead === 0) {
+      break
+    }
+    offset += bytesRead
+  }
+  return offset
+}
+
+export function nodeSourceAndCopyContentsEqualSync(sourcePath: string, copyPath: string): boolean {
+  try {
+    // Why: source links are intentional, but an owned copy must remain a regular file.
+    if (!statSync(sourcePath).isFile() || !lstatSync(copyPath).isFile()) {
+      return false
+    }
+  } catch {
+    return false
+  }
+
+  let sourceDescriptor: number | null = null
+  let copyDescriptor: number | null = null
+  let matches = false
+  let failed = false
+  try {
+    sourceDescriptor = openSync(sourcePath, 'r')
+    copyDescriptor = openSync(copyPath, 'r')
+    const sourceBuffer = Buffer.allocUnsafe(NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES)
+    const copyBuffer = Buffer.allocUnsafe(NODE_FILE_CONTENT_COMPARE_CHUNK_BYTES)
+    while (true) {
+      const sourceBytes = readChunk(sourceDescriptor, sourceBuffer)
+      const copyBytes = readChunk(copyDescriptor, copyBuffer)
+      if (sourceBytes !== copyBytes) {
+        break
+      }
+      if (sourceBytes === 0) {
+        matches = true
+        break
+      }
+      if (!sourceBuffer.subarray(0, sourceBytes).equals(copyBuffer.subarray(0, copyBytes))) {
+        break
+      }
+    }
+  } catch {
+    failed = true
+  }
+  for (const descriptor of [sourceDescriptor, copyDescriptor]) {
+    if (descriptor === null) {
+      continue
+    }
+    try {
+      closeSync(descriptor)
+    } catch {
+      failed = true
+    }
+  }
+  return matches && !failed
+}

--- a/src/shared/nul-delimited-fields.test.ts
+++ b/src/shared/nul-delimited-fields.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { iterateNulDelimitedFields } from './nul-delimited-fields'
+
+describe('iterateNulDelimitedFields', () => {
+  it('preserves empty and trailing fields without materializing a split array', () => {
+    expect([...iterateNulDelimitedFields('one\0\0three\0')]).toEqual(['one', '', 'three', ''])
+  })
+})

--- a/src/shared/nul-delimited-fields.ts
+++ b/src/shared/nul-delimited-fields.ts
@@ -1,0 +1,12 @@
+export function* iterateNulDelimitedFields(value: string): Generator<string> {
+  let start = 0
+  while (start <= value.length) {
+    const end = value.indexOf('\0', start)
+    if (end === -1) {
+      yield value.slice(start)
+      return
+    }
+    yield value.slice(start, end)
+    start = end + 1
+  }
+}

--- a/src/shared/persisted-state-file-bounds.test.ts
+++ b/src/shared/persisted-state-file-bounds.test.ts
@@ -1,0 +1,171 @@
+import { createHash } from 'node:crypto'
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { NodeFileReadTooLargeError } from './node-bounded-file-reader'
+import { JsonStringifyByteLimitError } from './node-bounded-json-stringify'
+import {
+  PersistedStateSecretCapacityError,
+  assertPersistedStateSecretWithinLimit,
+  readPersistedStateJsonFileSync,
+  replacePersistedStateJsonWithinLimit,
+  restorePersistedStateBackupSync,
+  stringifyPrettyPersistedStateWithinLimit,
+  stringifyPersistedStateWithinLimit,
+  updatePersistedStateHashWithJsonRange
+} from './persisted-state-file-bounds'
+
+describe('persisted state file bounds', () => {
+  let root = ''
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-state-bounds-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('reads and parses a state file exactly at the byte limit', () => {
+    const path = join(root, 'state.json')
+    const json = `{"value":"${'x'.repeat(20)}"}`
+    writeFileSync(path, json)
+
+    expect(
+      readPersistedStateJsonFileSync<{ value: string }>(path, Buffer.byteLength(json))
+    ).toEqual({
+      byteLength: Buffer.byteLength(json),
+      value: { value: 'x'.repeat(20) }
+    })
+  })
+
+  it('rejects an oversized sparse state file before reading its body', () => {
+    const path = join(root, 'state.json')
+    writeFileSync(path, '')
+    truncateSync(path, 1025)
+
+    expect(() => readPersistedStateJsonFileSync(path, 1024)).toThrow(NodeFileReadTooLargeError)
+  })
+
+  it('rejects structurally amplified state before parsing it', () => {
+    const path = join(root, 'state.json')
+    const json = '{"rows":[{},{}]}'
+    writeFileSync(path, json)
+
+    expect(() =>
+      readPersistedStateJsonFileSync(path, Buffer.byteLength(json), {
+        structuralTokens: 7,
+        nestingDepth: 3
+      })
+    ).toThrow('JSON structure')
+  })
+
+  it('matches native compact JSON exactly at the output boundary', () => {
+    const state = { quote: '"', unicode: '🐋', nested: [1, true, null] }
+    const native = JSON.stringify(state)
+
+    expect(stringifyPersistedStateWithinLimit(state, Buffer.byteLength(native))).toEqual({
+      byteLength: Buffer.byteLength(native),
+      serialized: native
+    })
+    expect(() => stringifyPersistedStateWithinLimit(state, Buffer.byteLength(native) - 1)).toThrow(
+      JsonStringifyByteLimitError
+    )
+  })
+
+  it('matches native pretty JSON and enforces its whitespace-inclusive boundary', () => {
+    const state = { nested: { value: 'x' }, list: [1, 2] }
+    const native = JSON.stringify(state, null, 2)
+
+    expect(stringifyPrettyPersistedStateWithinLimit(state, Buffer.byteLength(native))).toEqual({
+      byteLength: Buffer.byteLength(native),
+      serialized: native
+    })
+    expect(() =>
+      stringifyPrettyPersistedStateWithinLimit(state, Buffer.byteLength(native) - 1)
+    ).toThrow(JsonStringifyByteLimitError)
+  })
+
+  it('bounds secret plaintext before encryption can expand it', () => {
+    assertPersistedStateSecretWithinLimit('🐋', 4)
+
+    expect(() => assertPersistedStateSecretWithinLimit('🐋x', 4)).toThrow(
+      PersistedStateSecretCapacityError
+    )
+  })
+
+  it('checks replacement growth before constructing the next payload', () => {
+    const serialized = '{"value":"slot"}'
+    const exactBytes =
+      Buffer.byteLength(serialized) - Buffer.byteLength('slot') + Buffer.byteLength('expanded')
+
+    expect(
+      replacePersistedStateJsonWithinLimit({
+        serialized,
+        currentBytes: Buffer.byteLength(serialized),
+        search: 'slot',
+        replacement: 'expanded',
+        maxBytes: exactBytes
+      })
+    ).toEqual({ byteLength: exactBytes, serialized: '{"value":"expanded"}' })
+    expect(() =>
+      replacePersistedStateJsonWithinLimit({
+        serialized,
+        currentBytes: Buffer.byteLength(serialized),
+        search: 'slot',
+        replacement: 'expanded',
+        maxBytes: exactBytes - 1
+      })
+    ).toThrow(JsonStringifyByteLimitError)
+  })
+
+  it('hashes bounded string ranges without splitting UTF-16 surrogate pairs', () => {
+    const value = `prefix-${'x'.repeat(8)}🐋-${'y'.repeat(8)}-suffix`
+    const expected = createHash('sha1').update(value).digest('hex')
+    const actual = createHash('sha1')
+
+    updatePersistedStateHashWithJsonRange(actual, value, 0, value.length, 2)
+
+    expect(actual.digest('hex')).toBe(expected)
+  })
+
+  it('atomically restores only a valid in-limit backup', () => {
+    const backupPath = join(root, 'backup.json')
+    const targetPath = join(root, 'profile', 'orca-data.json')
+    writeFileSync(backupPath, '{"repos":[{"id":"recovered"}]}')
+
+    restorePersistedStateBackupSync(backupPath, targetPath, 1024)
+
+    expect(JSON.parse(readFileSync(targetPath, 'utf8'))).toEqual({
+      repos: [{ id: 'recovered' }]
+    })
+    const originalTarget = readFileSync(targetPath)
+    writeFileSync(backupPath, '{{invalid')
+    expect(() => restorePersistedStateBackupSync(backupPath, targetPath, 1024)).toThrow()
+    expect(readFileSync(targetPath)).toEqual(originalTarget)
+    expect(
+      readdirSync(join(root, 'profile')).filter((name) => name.endsWith('.recovery.tmp'))
+    ).toEqual([])
+  })
+
+  it('leaves the target untouched when a backup exceeds the cap', () => {
+    const backupPath = join(root, 'backup.json')
+    const targetPath = join(root, 'orca-data.json')
+    writeFileSync(targetPath, '{"original":true}')
+    writeFileSync(backupPath, '')
+    truncateSync(backupPath, 1025)
+
+    expect(() => restorePersistedStateBackupSync(backupPath, targetPath, 1024)).toThrow(
+      NodeFileReadTooLargeError
+    )
+    expect(readFileSync(targetPath, 'utf8')).toBe('{"original":true}')
+  })
+})

--- a/src/shared/persisted-state-file-bounds.ts
+++ b/src/shared/persisted-state-file-bounds.ts
@@ -1,0 +1,222 @@
+import { randomUUID, type Hash } from 'node:crypto'
+import { mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileSyncWithinLimit,
+  type BoundedNodeFileRead
+} from './node-bounded-file-reader'
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from './node-bounded-json-stringify'
+import {
+  assertJsonTextStructureWithinLimits,
+  type JsonTextStructureLimits
+} from './json-text-structure-limit'
+
+export const ORCA_PERSISTED_STATE_MAX_BYTES = 64 * 1024 * 1024
+export const ORCA_PERSISTED_STATE_SECRET_MAX_BYTES = 4 * 1024 * 1024
+export const ORCA_PERSISTED_STATE_HASH_CHUNK_CODE_UNITS = 64 * 1024
+export const ORCA_PERSISTED_STATE_JSON_LIMITS: JsonTextStructureLimits = {
+  structuralTokens: 4_000_000,
+  nestingDepth: 256
+}
+
+export type PersistedStateJsonRead<T> = {
+  byteLength: number
+  value: T
+}
+
+export class PersistedStateSecretCapacityError extends Error {
+  constructor(
+    readonly observedBytes: number,
+    readonly maxBytes = ORCA_PERSISTED_STATE_SECRET_MAX_BYTES
+  ) {
+    super(`Persisted state secret exceeds ${maxBytes} bytes`)
+    this.name = 'PersistedStateSecretCapacityError'
+  }
+}
+
+export function isPersistedStateFileCapacityError(
+  error: unknown
+): error is NodeFileReadTooLargeError {
+  return error instanceof NodeFileReadTooLargeError
+}
+
+export function readPersistedStateJsonFileSync<T>(
+  filePath: string,
+  maxBytes = ORCA_PERSISTED_STATE_MAX_BYTES,
+  structureLimits: JsonTextStructureLimits = ORCA_PERSISTED_STATE_JSON_LIMITS
+): PersistedStateJsonRead<T> {
+  const { buffer } = readPersistedStateFileBytesSync(filePath, maxBytes)
+  return {
+    byteLength: buffer.byteLength,
+    value: parsePersistedStateJsonBuffer<T>(buffer, structureLimits)
+  }
+}
+
+export function readPersistedStateFileBytesSync(
+  filePath: string,
+  maxBytes = ORCA_PERSISTED_STATE_MAX_BYTES
+): BoundedNodeFileRead {
+  return readNodeFileSyncWithinLimit(filePath, maxBytes)
+}
+
+export function parsePersistedStateJsonBuffer<T>(
+  buffer: Buffer,
+  structureLimits: JsonTextStructureLimits = ORCA_PERSISTED_STATE_JSON_LIMITS
+): T {
+  const serialized = buffer.toString('utf8')
+  assertJsonTextStructureWithinLimits(serialized, structureLimits)
+  return JSON.parse(serialized) as T
+}
+
+export function stringifyPersistedStateWithinLimit(
+  value: unknown,
+  maxBytes = ORCA_PERSISTED_STATE_MAX_BYTES
+): { byteLength: number; serialized: string } {
+  return stringifyJsonWithinByteLimit(value, maxBytes)
+}
+
+export function stringifyPrettyPersistedStateWithinLimit(
+  value: unknown,
+  maxBytes = ORCA_PERSISTED_STATE_MAX_BYTES
+): { byteLength: number; serialized: string } {
+  return stringifyJsonWithinByteLimit(value, maxBytes, 2)
+}
+
+export function encodePersistedStateJsonStringContent(
+  value: string,
+  maxBytes = ORCA_PERSISTED_STATE_MAX_BYTES
+): string {
+  const { serialized } = stringifyJsonWithinByteLimit(value, maxBytes)
+  return serialized.slice(1, -1)
+}
+
+export function assertPersistedStateSecretWithinLimit(
+  value: string,
+  maxBytes = ORCA_PERSISTED_STATE_SECRET_MAX_BYTES
+): void {
+  const observedBytes = Buffer.byteLength(value, 'utf8')
+  if (observedBytes > maxBytes) {
+    throw new PersistedStateSecretCapacityError(observedBytes, maxBytes)
+  }
+}
+
+export function replacedPersistedStateJsonByteLength(options: {
+  currentBytes: number
+  maxBytes?: number
+  replacement: string
+  search: string
+}): number {
+  const maxBytes = options.maxBytes ?? ORCA_PERSISTED_STATE_MAX_BYTES
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError('Persisted state JSON byte limit must be a non-negative safe integer')
+  }
+  if (!Number.isSafeInteger(options.currentBytes) || options.currentBytes < 0) {
+    throw new RangeError('Persisted state JSON byte count must be a non-negative safe integer')
+  }
+  if (options.currentBytes > maxBytes) {
+    throw new JsonStringifyByteLimitError(options.currentBytes, maxBytes)
+  }
+  const nextBytes =
+    options.currentBytes -
+    Buffer.byteLength(options.search, 'utf8') +
+    Buffer.byteLength(options.replacement, 'utf8')
+  if (!Number.isSafeInteger(nextBytes) || nextBytes < 0 || nextBytes > maxBytes) {
+    throw new JsonStringifyByteLimitError(nextBytes, maxBytes)
+  }
+  return nextBytes
+}
+
+export function replacePersistedStateJsonWithinLimit(options: {
+  currentBytes: number
+  maxBytes?: number
+  replacement: string
+  search: string
+  serialized: string
+}): { byteLength: number; serialized: string } {
+  const byteLength = replacedPersistedStateJsonByteLength(options)
+  const searchIndex = options.serialized.indexOf(options.search)
+  if (searchIndex === -1) {
+    throw new Error('Persisted state JSON replacement slot is missing')
+  }
+  if (options.serialized.includes(options.search, searchIndex + options.search.length)) {
+    throw new Error('Persisted state JSON replacement slot is ambiguous')
+  }
+  return {
+    byteLength,
+    serialized: options.serialized.replace(options.search, () => options.replacement)
+  }
+}
+
+export function updatePersistedStateHashWithJsonRange(
+  hash: Pick<Hash, 'update'>,
+  value: string,
+  start = 0,
+  end = value.length,
+  chunkCodeUnits = ORCA_PERSISTED_STATE_HASH_CHUNK_CODE_UNITS
+): void {
+  if (
+    !Number.isSafeInteger(start) ||
+    !Number.isSafeInteger(end) ||
+    start < 0 ||
+    end < start ||
+    end > value.length
+  ) {
+    throw new RangeError('Persisted state hash range is invalid')
+  }
+  if (!Number.isSafeInteger(chunkCodeUnits) || chunkCodeUnits <= 0) {
+    throw new RangeError('Persisted state hash chunk size must be a positive safe integer')
+  }
+
+  let offset = start
+  while (offset < end) {
+    let nextOffset = Math.min(end, offset + chunkCodeUnits)
+    if (
+      nextOffset < end &&
+      isHighSurrogate(value.charCodeAt(nextOffset - 1)) &&
+      isLowSurrogate(value.charCodeAt(nextOffset))
+    ) {
+      nextOffset += 1
+    }
+    hash.update(value.slice(offset, nextOffset), 'utf8')
+    offset = nextOffset
+  }
+}
+
+export function restorePersistedStateBackupSync(
+  sourcePath: string,
+  targetPath: string,
+  maxBytes = ORCA_PERSISTED_STATE_MAX_BYTES
+): number {
+  const read = readValidatedPersistedStateBytesSync(sourcePath, maxBytes)
+  mkdirSync(dirname(targetPath), { recursive: true })
+  const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.recovery.tmp`
+  try {
+    writeFileSync(temporaryPath, read.buffer)
+    renameSync(temporaryPath, targetPath)
+  } catch (error) {
+    rmSync(temporaryPath, { force: true })
+    throw error
+  }
+  return read.buffer.byteLength
+}
+
+function readValidatedPersistedStateBytesSync(
+  filePath: string,
+  maxBytes: number
+): BoundedNodeFileRead {
+  const read = readPersistedStateFileBytesSync(filePath, maxBytes)
+  parsePersistedStateJsonBuffer(read.buffer)
+  return read
+}
+
+function isHighSurrogate(code: number): boolean {
+  return code >= 0xd800 && code <= 0xdbff
+}
+
+function isLowSurrogate(code: number): boolean {
+  return code >= 0xdc00 && code <= 0xdfff
+}

--- a/src/shared/quick-open-directory-reader.test.ts
+++ b/src/shared/quick-open-directory-reader.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { lstatMock, opendirMock } = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  opendirMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  opendir: opendirMock
+}))
+
+import { readQuickOpenDirectoryEntries } from './quick-open-directory-reader'
+import { createQuickOpenReaddirBudget } from './quick-open-readdir-budget'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  lstatMock.mockResolvedValue({
+    isDirectory: () => true,
+    isSymbolicLink: () => false
+  })
+})
+
+describe('quick-open streaming directory reader', () => {
+  it('stops a huge directory one entry beyond the exact cap and closes its iterator', async () => {
+    let produced = 0
+    let closed = false
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (produced < 1_000_000) {
+            produced += 1
+            yield {
+              name: `directory-${produced}`,
+              isDirectory: () => true,
+              isFile: () => false,
+              isSymbolicLink: () => false
+            }
+          }
+        } finally {
+          closed = true
+        }
+      }
+    })
+
+    await expect(
+      readQuickOpenDirectoryEntries({
+        absPath: '/streamed',
+        allowSymlinkedRoot: false,
+        budget: createQuickOpenReaddirBudget({ maxEntries: 3 })
+      })
+    ).rejects.toThrow('File listing exceeded 3 entries')
+    expect(produced).toBe(4)
+    expect(closed).toBe(true)
+  })
+})

--- a/src/shared/quick-open-directory-reader.ts
+++ b/src/shared/quick-open-directory-reader.ts
@@ -1,0 +1,62 @@
+import { lstat, opendir } from 'node:fs/promises'
+import { isFileListingCancellation, throwIfFileListingCancelled } from './file-listing-cancellation'
+import { isQuickOpenReadableDirectory } from './quick-open-directory-validation'
+import {
+  assertQuickOpenReaddirDeadline,
+  consumeQuickOpenReaddirEntryBudget,
+  consumeQuickOpenReaddirPathBudget,
+  isQuickOpenReaddirBudgetError,
+  type QuickOpenReaddirBudget
+} from './quick-open-readdir-budget'
+
+export type QuickOpenDirectoryEntry = {
+  name: string
+  kind: 'directory' | 'file' | 'symlink' | 'other'
+}
+
+export async function readQuickOpenDirectoryEntries(opts: {
+  absPath: string
+  allowSymlinkedRoot: boolean
+  budget: QuickOpenReaddirBudget
+  signal?: AbortSignal
+}): Promise<QuickOpenDirectoryEntry[]> {
+  try {
+    const stat = await lstat(opts.absPath)
+    if (!isQuickOpenReadableDirectory(stat, opts.allowSymlinkedRoot)) {
+      return []
+    }
+
+    const entries: QuickOpenDirectoryEntry[] = []
+    const directory = await opendir(opts.absPath)
+    throwIfFileListingCancelled(opts.signal)
+    assertQuickOpenReaddirDeadline(opts.budget)
+    for await (const entry of directory) {
+      throwIfFileListingCancelled(opts.signal)
+      assertQuickOpenReaddirDeadline(opts.budget)
+      consumeQuickOpenReaddirEntryBudget(opts.budget)
+      consumeQuickOpenReaddirPathBudget(opts.budget, entry.name)
+      entries.push({
+        name: entry.name,
+        kind: entry.isDirectory()
+          ? 'directory'
+          : entry.isFile()
+            ? 'file'
+            : entry.isSymbolicLink()
+              ? 'symlink'
+              : 'other'
+      })
+    }
+    entries.sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))
+
+    // Why: discard buffered names if the path became a symlink while its
+    // directory handle was open; descendants must never escape the root.
+    const statAfterRead = await lstat(opts.absPath)
+    return isQuickOpenReadableDirectory(statAfterRead, opts.allowSymlinkedRoot) ? entries : []
+  } catch (error) {
+    if (isQuickOpenReaddirBudgetError(error) || isFileListingCancellation(error)) {
+      throw error
+    }
+    // Permission denied or a vanished subtree must not hide readable siblings.
+    return []
+  }
+}

--- a/src/shared/quick-open-git-entry-classification.ts
+++ b/src/shared/quick-open-git-entry-classification.ts
@@ -1,0 +1,68 @@
+import { lstat } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export type QuickOpenGitEntryKind = 'keep' | 'fill-nested-repo' | 'drop-placeholder'
+
+export type QuickOpenGitLsFilesEntry = {
+  path: string
+  isGitlink: boolean
+  isUntrackedDir: boolean
+}
+
+const GIT_LS_FILES_STAGE_ENTRY = /^([0-7]{6}) [0-9a-f]{40,64} [0-3]\t/
+
+export function parseQuickOpenGitLsFilesEntry(entry: string): QuickOpenGitLsFilesEntry {
+  const match = GIT_LS_FILES_STAGE_ENTRY.exec(entry)
+  if (match) {
+    return {
+      path: entry.slice(match[0].length),
+      isGitlink: match[1] === '160000',
+      isUntrackedDir: false
+    }
+  }
+  return {
+    path: entry,
+    isGitlink: false,
+    isUntrackedDir: entry.endsWith('/')
+  }
+}
+
+function joinQuickOpenRootPath(rootPath: string, relPath: string): string {
+  return join(rootPath, ...relPath.split('/').filter(Boolean))
+}
+
+async function hasGitEntry(absPath: string): Promise<boolean> {
+  try {
+    const stat = await lstat(join(absPath, '.git'))
+    return stat.isDirectory() || stat.isFile()
+  } catch {
+    return false
+  }
+}
+
+export async function classifyQuickOpenGitEntry(
+  rootPath: string,
+  entry: string
+): Promise<{ kind: QuickOpenGitEntryKind; relPath: string }> {
+  const parsed = parseQuickOpenGitLsFilesEntry(entry)
+  const relPath = parsed.path.replace(/\/+$/, '')
+  if (!relPath) {
+    return { kind: 'drop-placeholder', relPath }
+  }
+  if (!parsed.isGitlink && !parsed.isUntrackedDir) {
+    return { kind: 'keep', relPath }
+  }
+
+  let stat
+  try {
+    stat = await lstat(joinQuickOpenRootPath(rootPath, relPath))
+  } catch {
+    return { kind: 'drop-placeholder', relPath }
+  }
+  if (!stat.isDirectory()) {
+    return { kind: 'drop-placeholder', relPath }
+  }
+  return (await hasGitEntry(joinQuickOpenRootPath(rootPath, relPath)))
+    ? { kind: 'fill-nested-repo', relPath }
+    : { kind: 'drop-placeholder', relPath }
+}

--- a/src/shared/quick-open-listing-limits.test.ts
+++ b/src/shared/quick-open-listing-limits.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createQuickOpenListingBudget,
+  QuickOpenSubprocessPathAccumulator,
+  resolveQuickOpenResultLimit,
+  retainQuickOpenPath,
+  QUICK_OPEN_LISTING_MAX_PATH_BYTES,
+  QUICK_OPEN_LISTING_MAX_RETAINED_PATH_BYTES,
+  QUICK_OPEN_LISTING_MAX_RETAINED_PATHS,
+  QUICK_OPEN_LISTING_MAX_RESULTS
+} from './quick-open-listing-limits'
+
+describe('Quick Open listing limits', () => {
+  it('uses one hard result cap while preserving smaller requested limits', () => {
+    expect(resolveQuickOpenResultLimit()).toBe(QUICK_OPEN_LISTING_MAX_RESULTS)
+    expect(resolveQuickOpenResultLimit(17)).toBe(17)
+    expect(resolveQuickOpenResultLimit(QUICK_OPEN_LISTING_MAX_RESULTS + 1)).toBe(
+      QUICK_OPEN_LISTING_MAX_RESULTS
+    )
+    expect(resolveQuickOpenResultLimit(0)).toBe(0)
+  })
+
+  it('keeps the production memory ceilings explicit', () => {
+    expect(QUICK_OPEN_LISTING_MAX_RESULTS).toBe(20_001)
+    expect(QUICK_OPEN_LISTING_MAX_RETAINED_PATHS).toBe(100_000)
+    expect(QUICK_OPEN_LISTING_MAX_RETAINED_PATH_BYTES).toBe(32 * 1024 * 1024)
+    expect(QUICK_OPEN_LISTING_MAX_PATH_BYTES).toBe(64 * 1024)
+  })
+
+  it('accepts the exact retained path boundaries without charging duplicates', () => {
+    const paths = new Set<string>()
+    const budget = createQuickOpenListingBudget({
+      maxRetainedPaths: 2,
+      maxRetainedPathBytes: 3,
+      maxPathBytes: 2
+    })
+
+    expect(retainQuickOpenPath(paths, 'ab', budget)).toBe(true)
+    expect(retainQuickOpenPath(paths, 'ab', budget)).toBe(false)
+    expect(retainQuickOpenPath(paths, 'c', budget)).toBe(true)
+    expect(budget).toMatchObject({ retainedPathCount: 2, retainedPathBytes: 3 })
+    expect(() => retainQuickOpenPath(paths, '', budget)).toThrow('2 retained paths')
+  })
+
+  it('rejects path-byte overflow without mutating the retained budget', () => {
+    const paths = new Set<string>()
+    const budget = createQuickOpenListingBudget({
+      maxRetainedPaths: 3,
+      maxRetainedPathBytes: 2,
+      maxPathBytes: 2
+    })
+    retainQuickOpenPath(paths, 'ab', budget)
+
+    expect(() => retainQuickOpenPath(paths, 'c', budget)).toThrow('2 retained path bytes')
+    expect(paths).toEqual(new Set(['ab']))
+    expect(budget).toMatchObject({ retainedPathCount: 1, retainedPathBytes: 2 })
+  })
+
+  it('bounds one fragmented subprocess path and recovers after overflow', () => {
+    const onPath = vi.fn(() => true)
+    const fields = new QuickOpenSubprocessPathAccumulator(0, 3)
+
+    expect(fields.push(Buffer.from('ab'), onPath)).toBe('continue')
+    expect(fields.push(Buffer.from('cd'), onPath)).toBe('path-too-large')
+    expect(fields.push(Buffer.from('ok\0'), onPath)).toBe('continue')
+    expect(onPath).toHaveBeenCalledTimes(1)
+    expect(onPath).toHaveBeenCalledWith('ok')
+  })
+
+  it('stops within a multi-path chunk without visiting later fields', () => {
+    const visited: string[] = []
+    const fields = new QuickOpenSubprocessPathAccumulator(0, 16)
+
+    expect(
+      fields.push(Buffer.from('one\0two\0three\0'), (path) => {
+        visited.push(path)
+        return path !== 'two'
+      })
+    ).toBe('stopped')
+    expect(visited).toEqual(['one', 'two'])
+  })
+})

--- a/src/shared/quick-open-listing-limits.ts
+++ b/src/shared/quick-open-listing-limits.ts
@@ -1,0 +1,142 @@
+import { GrowingByteBuffer } from './growing-byte-buffer'
+
+export const QUICK_OPEN_LISTING_MAX_RESULTS = 20_001
+export const QUICK_OPEN_LISTING_MAX_RETAINED_PATHS = 100_000
+export const QUICK_OPEN_LISTING_MAX_RETAINED_PATH_BYTES = 32 * 1024 * 1024
+export const QUICK_OPEN_LISTING_MAX_PATH_BYTES = 64 * 1024
+
+export type QuickOpenListingBudget = {
+  retainedPathCount: number
+  retainedPathBytes: number
+  maxRetainedPaths: number
+  maxRetainedPathBytes: number
+  maxPathBytes: number
+}
+
+export function resolveQuickOpenResultLimit(requested?: number): number {
+  if (requested === undefined || requested === Number.POSITIVE_INFINITY) {
+    return QUICK_OPEN_LISTING_MAX_RESULTS
+  }
+  if (!Number.isFinite(requested)) {
+    return 0
+  }
+  return Math.min(Math.max(Math.trunc(requested), 0), QUICK_OPEN_LISTING_MAX_RESULTS)
+}
+
+export function createQuickOpenListingBudget(
+  limits: Partial<
+    Pick<QuickOpenListingBudget, 'maxRetainedPaths' | 'maxRetainedPathBytes' | 'maxPathBytes'>
+  > = {}
+): QuickOpenListingBudget {
+  const maxRetainedPaths = limits.maxRetainedPaths ?? QUICK_OPEN_LISTING_MAX_RETAINED_PATHS
+  const maxRetainedPathBytes =
+    limits.maxRetainedPathBytes ?? QUICK_OPEN_LISTING_MAX_RETAINED_PATH_BYTES
+  const maxPathBytes = limits.maxPathBytes ?? QUICK_OPEN_LISTING_MAX_PATH_BYTES
+  for (const [name, value] of Object.entries({
+    maxRetainedPaths,
+    maxRetainedPathBytes,
+    maxPathBytes
+  })) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`${name} must be a non-negative safe integer`)
+    }
+  }
+  return {
+    retainedPathCount: 0,
+    retainedPathBytes: 0,
+    maxRetainedPaths,
+    maxRetainedPathBytes,
+    maxPathBytes
+  }
+}
+
+export function retainQuickOpenPath(
+  paths: Set<string>,
+  path: string,
+  budget: QuickOpenListingBudget
+): boolean {
+  if (paths.has(path)) {
+    return false
+  }
+  const pathBytes = Buffer.byteLength(path, 'utf8')
+  if (pathBytes > budget.maxPathBytes) {
+    throw new Error(`Quick Open file path exceeded ${budget.maxPathBytes} bytes`)
+  }
+  if (budget.retainedPathCount >= budget.maxRetainedPaths) {
+    throw new Error(`Quick Open file listing exceeded ${budget.maxRetainedPaths} retained paths`)
+  }
+  if (pathBytes > budget.maxRetainedPathBytes - budget.retainedPathBytes) {
+    throw new Error(
+      `Quick Open file listing exceeded ${budget.maxRetainedPathBytes} retained path bytes`
+    )
+  }
+  budget.retainedPathCount++
+  budget.retainedPathBytes += pathBytes
+  paths.add(path)
+  return true
+}
+
+export type QuickOpenPathAccumulatorResult = 'continue' | 'stopped' | 'path-too-large'
+
+export class QuickOpenSubprocessPathAccumulator {
+  private readonly field = new GrowingByteBuffer()
+
+  constructor(
+    private readonly delimiter: number,
+    private readonly maxPathBytes = QUICK_OPEN_LISTING_MAX_PATH_BYTES
+  ) {
+    if (!Number.isInteger(delimiter) || delimiter < 0 || delimiter > 0xff) {
+      throw new RangeError('Quick Open path delimiter must be one byte')
+    }
+    if (!Number.isSafeInteger(maxPathBytes) || maxPathBytes < 0) {
+      throw new RangeError('Quick Open path limit must be a non-negative safe integer')
+    }
+  }
+
+  push(
+    rawChunk: Buffer | string,
+    onPath: (path: string) => boolean
+  ): QuickOpenPathAccumulatorResult {
+    const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk, 'utf8')
+    let cursor = 0
+    while (cursor < chunk.length) {
+      const delimiter = chunk.indexOf(this.delimiter, cursor)
+      const end = delimiter === -1 ? chunk.length : delimiter
+      const segmentBytes = end - cursor
+      if (this.field.byteLength + segmentBytes > this.maxPathBytes) {
+        this.clear()
+        return 'path-too-large'
+      }
+      if (delimiter !== -1 && this.field.byteLength === 0) {
+        if (!onPath(chunk.toString('utf8', cursor, end))) {
+          return 'stopped'
+        }
+      } else if (segmentBytes > 0) {
+        // Why: copying prevents a short residual path from retaining the whole read buffer.
+        this.field.append(chunk.subarray(cursor, end))
+        if (delimiter !== -1 && !onPath(this.take())) {
+          return 'stopped'
+        }
+      } else if (delimiter !== -1 && !onPath(this.take())) {
+        return 'stopped'
+      }
+      if (delimiter === -1) {
+        return 'continue'
+      }
+      cursor = delimiter + 1
+    }
+    return 'continue'
+  }
+
+  finish(): string | null {
+    return this.field.byteLength > 0 ? this.take() : null
+  }
+
+  clear(): void {
+    this.field.clear()
+  }
+
+  private take(): string {
+    return this.field.takeString()
+  }
+}

--- a/src/shared/raster-image-base64-preview.ts
+++ b/src/shared/raster-image-base64-preview.ts
@@ -1,0 +1,141 @@
+import type { RasterImageDimensions } from './raster-image-dimensions'
+import {
+  assertRasterImagePreviewWithinLimits,
+  isKnownRasterImageMimeType,
+  RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES
+} from './raster-image-preview-limits'
+
+const BASE64_PADDING = -2
+const INVALID_BASE64 = -1
+
+function base64Value(code: number): number {
+  if (code >= 65 && code <= 90) {
+    return code - 65
+  }
+  if (code >= 97 && code <= 122) {
+    return code - 71
+  }
+  if (code >= 48 && code <= 57) {
+    return code + 4
+  }
+  if (code === 43) {
+    return 62
+  }
+  if (code === 47) {
+    return 63
+  }
+  if (code === 61) {
+    return BASE64_PADDING
+  }
+  return INVALID_BASE64
+}
+
+function isWhitespace(code: number): boolean {
+  return code === 9 || code === 10 || code === 12 || code === 13 || code === 32
+}
+
+function writeQuartet(
+  output: Uint8Array,
+  offset: number,
+  quartet: readonly number[]
+): { bytesWritten: number; padded: boolean } | null {
+  const [a, b, c, d] = quartet
+  if (a === undefined || b === undefined || a < 0 || b < 0) {
+    return null
+  }
+  if (c === BASE64_PADDING) {
+    if (d !== BASE64_PADDING) {
+      return null
+    }
+    if (offset < output.length) {
+      output[offset] = (a << 2) | (b >> 4)
+    }
+    return { bytesWritten: Math.min(1, output.length - offset), padded: true }
+  }
+  if (c === undefined || c < 0) {
+    return null
+  }
+  if (offset < output.length) {
+    output[offset] = (a << 2) | (b >> 4)
+  }
+  if (offset + 1 < output.length) {
+    output[offset + 1] = ((b & 15) << 4) | (c >> 2)
+  }
+  if (d === BASE64_PADDING) {
+    return { bytesWritten: Math.min(2, output.length - offset), padded: true }
+  }
+  if (d === undefined || d < 0) {
+    return null
+  }
+  if (offset + 2 < output.length) {
+    output[offset + 2] = ((c & 3) << 6) | d
+  }
+  return { bytesWritten: Math.min(3, output.length - offset), padded: false }
+}
+
+function decodeBase64Prefix(content: string, maxBytes: number): Uint8Array | null {
+  const capacity = Math.min(maxBytes, Math.ceil(content.length / 4) * 3)
+  const output = new Uint8Array(capacity)
+  const quartet: number[] = []
+  let outputLength = 0
+  let padded = false
+
+  for (let index = 0; index < content.length && outputLength < capacity; index += 1) {
+    const code = content.charCodeAt(index)
+    if (isWhitespace(code)) {
+      continue
+    }
+    if (padded) {
+      return null
+    }
+    const value = base64Value(code)
+    if (value === INVALID_BASE64) {
+      return null
+    }
+    quartet.push(value)
+    if (quartet.length !== 4) {
+      continue
+    }
+    const decoded = writeQuartet(output, outputLength, quartet)
+    if (!decoded) {
+      return null
+    }
+    outputLength += decoded.bytesWritten
+    padded = decoded.padded
+    quartet.length = 0
+  }
+
+  if (!padded && outputLength < capacity && quartet.length > 0) {
+    if (quartet.length === 1 || quartet.includes(BASE64_PADDING)) {
+      return null
+    }
+    while (quartet.length < 4) {
+      quartet.push(BASE64_PADDING)
+    }
+    const decoded = writeQuartet(output, outputLength, quartet)
+    if (!decoded) {
+      return null
+    }
+    outputLength += decoded.bytesWritten
+  }
+  return output.subarray(0, outputLength)
+}
+
+/** Returns undefined for non-raster MIME types and null for rejected raster bytes. */
+export function readRasterImagePreviewDimensionsFromBase64(
+  content: string,
+  mimeType: string | undefined
+): RasterImageDimensions | null | undefined {
+  if (!isKnownRasterImageMimeType(mimeType)) {
+    return undefined
+  }
+  const prefix = decodeBase64Prefix(content, RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES)
+  if (!prefix) {
+    return null
+  }
+  try {
+    return assertRasterImagePreviewWithinLimits(prefix, mimeType) ?? null
+  } catch {
+    return null
+  }
+}

--- a/src/shared/raster-image-dimensions.test.ts
+++ b/src/shared/raster-image-dimensions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { readRasterImageDimensions } from './raster-image-dimensions'
+
+function pngHeader(width: number, height: number): Buffer {
+  const png = Buffer.alloc(24)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(png)
+  png.writeUInt32BE(13, 8)
+  png.write('IHDR', 12, 'ascii')
+  png.writeUInt32BE(width, 16)
+  png.writeUInt32BE(height, 20)
+  return png
+}
+
+function bmpHeader(width: number, height: number): Buffer {
+  const bmp = Buffer.alloc(26)
+  bmp.write('BM', 0, 'ascii')
+  bmp.writeUInt32LE(40, 14)
+  bmp.writeInt32LE(width, 18)
+  bmp.writeInt32LE(height, 22)
+  return bmp
+}
+
+function icoWithPayload(payload: Buffer, width = 1, height = 1): Buffer {
+  const header = Buffer.alloc(22)
+  header.writeUInt16LE(1, 2)
+  header.writeUInt16LE(1, 4)
+  header[6] = width === 256 ? 0 : width
+  header[7] = height === 256 ? 0 : height
+  header.writeUInt32LE(payload.byteLength, 14)
+  header.writeUInt32LE(header.byteLength, 18)
+  return Buffer.concat([header, payload])
+}
+
+describe('readRasterImageDimensions', () => {
+  it('reads BMP dimensions including top-down images', () => {
+    expect(readRasterImageDimensions(bmpHeader(640, -480))).toEqual({
+      width: 640,
+      height: 480
+    })
+  })
+
+  it('uses embedded ICO image dimensions instead of forgeable directory values', () => {
+    expect(readRasterImageDimensions(icoWithPayload(pngHeader(40_000, 2)))).toEqual({
+      width: 40_000,
+      height: 2
+    })
+  })
+
+  it('reads a Uint8Array view without depending on its backing-buffer offset', () => {
+    const wrapped = Buffer.concat([Buffer.from('prefix'), pngHeader(320, 240), Buffer.from('tail')])
+    const view = wrapped.subarray(6, 30)
+
+    expect(readRasterImageDimensions(view)).toEqual({ width: 320, height: 240 })
+  })
+
+  it('rejects truncated ICO payloads and zero raster dimensions', () => {
+    const truncated = icoWithPayload(pngHeader(16, 16)).subarray(0, 30)
+
+    expect(readRasterImageDimensions(truncated)).toBeNull()
+    expect(readRasterImageDimensions(bmpHeader(0, 16))).toBeNull()
+  })
+})

--- a/src/shared/raster-image-dimensions.ts
+++ b/src/shared/raster-image-dimensions.ts
@@ -1,0 +1,252 @@
+export type RasterImageDimensions = { width: number; height: number }
+
+const JPEG_DIMENSION_SCAN_MAX_BYTES = 1024 * 1024
+const JPEG_DIMENSION_SCAN_MAX_MARKERS = 4_096
+const ICO_MAX_IMAGES = 1_024
+const JPEG_START_OF_FRAME_MARKERS = new Set([
+  0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf
+])
+const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10]
+
+function hasBytes(bytes: Uint8Array, offset: number, length: number): boolean {
+  return offset >= 0 && length >= 0 && offset + length <= bytes.byteLength
+}
+
+function matchesBytes(bytes: Uint8Array, offset: number, expected: readonly number[]): boolean {
+  return (
+    hasBytes(bytes, offset, expected.length) &&
+    expected.every((value, index) => bytes[offset + index] === value)
+  )
+}
+
+function matchesAscii(bytes: Uint8Array, offset: number, expected: string): boolean {
+  if (!hasBytes(bytes, offset, expected.length)) {
+    return false
+  }
+  for (let index = 0; index < expected.length; index += 1) {
+    if (bytes[offset + index] !== expected.charCodeAt(index)) {
+      return false
+    }
+  }
+  return true
+}
+
+function readUint16Le(bytes: Uint8Array, offset: number): number {
+  return bytes[offset]! | (bytes[offset + 1]! << 8)
+}
+
+function readUint16Be(bytes: Uint8Array, offset: number): number {
+  return (bytes[offset]! << 8) | bytes[offset + 1]!
+}
+
+function readUint24Le(bytes: Uint8Array, offset: number): number {
+  return bytes[offset]! | (bytes[offset + 1]! << 8) | (bytes[offset + 2]! << 16)
+}
+
+function readUint32Le(bytes: Uint8Array, offset: number): number {
+  return (
+    (bytes[offset]! |
+      (bytes[offset + 1]! << 8) |
+      (bytes[offset + 2]! << 16) |
+      (bytes[offset + 3]! << 24)) >>>
+    0
+  )
+}
+
+function readUint32Be(bytes: Uint8Array, offset: number): number {
+  return (
+    (((bytes[offset]! << 24) >>> 0) |
+      (bytes[offset + 1]! << 16) |
+      (bytes[offset + 2]! << 8) |
+      bytes[offset + 3]!) >>>
+    0
+  )
+}
+
+function readInt32Le(bytes: Uint8Array, offset: number): number {
+  return readUint32Le(bytes, offset) | 0
+}
+
+function positiveDimensions(width: number, height: number): RasterImageDimensions | null {
+  return Number.isSafeInteger(width) && Number.isSafeInteger(height) && width > 0 && height > 0
+    ? { width, height }
+    : null
+}
+
+function readPngDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  if (
+    !matchesBytes(bytes, 0, PNG_SIGNATURE) ||
+    !hasBytes(bytes, 8, 16) ||
+    readUint32Be(bytes, 8) !== 13 ||
+    !matchesAscii(bytes, 12, 'IHDR')
+  ) {
+    return null
+  }
+  return positiveDimensions(readUint32Be(bytes, 16), readUint32Be(bytes, 20))
+}
+
+function readGifDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  if (
+    !hasBytes(bytes, 0, 10) ||
+    (!matchesAscii(bytes, 0, 'GIF87a') && !matchesAscii(bytes, 0, 'GIF89a'))
+  ) {
+    return null
+  }
+  return positiveDimensions(readUint16Le(bytes, 6), readUint16Le(bytes, 8))
+}
+
+function readJpegDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  if (!hasBytes(bytes, 0, 4) || bytes[0] !== 0xff || bytes[1] !== 0xd8) {
+    return null
+  }
+  let offset = 2
+  let markersRead = 0
+  const scanEnd = Math.min(bytes.byteLength, JPEG_DIMENSION_SCAN_MAX_BYTES)
+  while (offset < scanEnd && markersRead < JPEG_DIMENSION_SCAN_MAX_MARKERS) {
+    while (offset < scanEnd && bytes[offset] === 0xff) {
+      offset += 1
+    }
+    const marker = bytes[offset]
+    offset += 1
+    markersRead += 1
+    if (marker === undefined || marker === 0x00 || marker === 0xd9 || marker === 0xda) {
+      return null
+    }
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) {
+      continue
+    }
+    if (!hasBytes(bytes, offset, 2)) {
+      return null
+    }
+    const segmentLength = readUint16Be(bytes, offset)
+    if (segmentLength < 2 || offset + segmentLength > scanEnd) {
+      return null
+    }
+    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
+      return segmentLength >= 7
+        ? positiveDimensions(readUint16Be(bytes, offset + 5), readUint16Be(bytes, offset + 3))
+        : null
+    }
+    offset += segmentLength
+  }
+  return null
+}
+
+function readWebpDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  if (
+    !hasBytes(bytes, 0, 20) ||
+    !matchesAscii(bytes, 0, 'RIFF') ||
+    !matchesAscii(bytes, 8, 'WEBP')
+  ) {
+    return null
+  }
+
+  let offset = 12
+  while (hasBytes(bytes, offset, 8)) {
+    const chunkSize = readUint32Le(bytes, offset + 4)
+    const dataOffset = offset + 8
+    const dataEnd = dataOffset + chunkSize
+
+    if (matchesAscii(bytes, offset, 'VP8X') && chunkSize >= 10 && hasBytes(bytes, dataOffset, 10)) {
+      return positiveDimensions(
+        readUint24Le(bytes, dataOffset + 4) + 1,
+        readUint24Le(bytes, dataOffset + 7) + 1
+      )
+    }
+    if (
+      matchesAscii(bytes, offset, 'VP8L') &&
+      chunkSize >= 5 &&
+      hasBytes(bytes, dataOffset, 5) &&
+      bytes[dataOffset] === 0x2f
+    ) {
+      const b0 = bytes[dataOffset + 1]!
+      const b1 = bytes[dataOffset + 2]!
+      const b2 = bytes[dataOffset + 3]!
+      const b3 = bytes[dataOffset + 4]!
+      return positiveDimensions(
+        1 + (((b1 & 0x3f) << 8) | b0),
+        1 + (((b3 & 0x0f) << 10) | (b2 << 2) | ((b1 & 0xc0) >> 6))
+      )
+    }
+    if (
+      matchesAscii(bytes, offset, 'VP8 ') &&
+      chunkSize >= 10 &&
+      hasBytes(bytes, dataOffset, 10) &&
+      bytes[dataOffset + 3] === 0x9d &&
+      bytes[dataOffset + 4] === 0x01 &&
+      bytes[dataOffset + 5] === 0x2a
+    ) {
+      return positiveDimensions(
+        readUint16Le(bytes, dataOffset + 6) & 0x3fff,
+        readUint16Le(bytes, dataOffset + 8) & 0x3fff
+      )
+    }
+    if (dataEnd > bytes.byteLength) {
+      return null
+    }
+    offset = dataEnd + (chunkSize % 2)
+  }
+  return null
+}
+
+function readDibDimensions(bytes: Uint8Array, offset: number): RasterImageDimensions | null {
+  if (!hasBytes(bytes, offset, 12)) {
+    return null
+  }
+  const headerSize = readUint32Le(bytes, offset)
+  if (headerSize === 12) {
+    return positiveDimensions(readUint16Le(bytes, offset + 4), readUint16Le(bytes, offset + 6))
+  }
+  if (headerSize < 40 || !hasBytes(bytes, offset, 12)) {
+    return null
+  }
+  return positiveDimensions(
+    Math.abs(readInt32Le(bytes, offset + 4)),
+    Math.abs(readInt32Le(bytes, offset + 8))
+  )
+}
+
+function readBmpDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  return matchesAscii(bytes, 0, 'BM') ? readDibDimensions(bytes, 14) : null
+}
+
+function readIcoDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  if (!hasBytes(bytes, 0, 6) || readUint16Le(bytes, 0) !== 0 || readUint16Le(bytes, 2) !== 1) {
+    return null
+  }
+  const imageCount = readUint16Le(bytes, 4)
+  if (imageCount <= 0 || imageCount > ICO_MAX_IMAGES || !hasBytes(bytes, 6, imageCount * 16)) {
+    return null
+  }
+
+  let maxWidth = 0
+  let maxHeight = 0
+  for (let index = 0; index < imageCount; index += 1) {
+    const entryOffset = 6 + index * 16
+    const encodedSize = readUint32Le(bytes, entryOffset + 8)
+    const imageOffset = readUint32Le(bytes, entryOffset + 12)
+    if (encodedSize <= 0 || !hasBytes(bytes, imageOffset, encodedSize)) {
+      return null
+    }
+    const payload = bytes.subarray(imageOffset, imageOffset + encodedSize)
+    const embedded = readPngDimensions(payload) ?? readDibDimensions(payload, 0)
+    const width = embedded?.width ?? (bytes[entryOffset] === 0 ? 256 : bytes[entryOffset]!)
+    const height =
+      embedded?.height ?? (bytes[entryOffset + 1] === 0 ? 256 : bytes[entryOffset + 1]!)
+    maxWidth = Math.max(maxWidth, width)
+    maxHeight = Math.max(maxHeight, height)
+  }
+  return positiveDimensions(maxWidth, maxHeight)
+}
+
+/** Reads encoded raster dimensions without invoking a native or browser image decoder. */
+export function readRasterImageDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  return (
+    readPngDimensions(bytes) ??
+    readGifDimensions(bytes) ??
+    readJpegDimensions(bytes) ??
+    readWebpDimensions(bytes) ??
+    readBmpDimensions(bytes) ??
+    readIcoDimensions(bytes)
+  )
+}

--- a/src/shared/raster-image-preview-limits.test.ts
+++ b/src/shared/raster-image-preview-limits.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  INVALID_RASTER_IMAGE_PREVIEW_ERROR,
+  MAX_RASTER_IMAGE_PREVIEW_DIMENSION_PX,
+  RASTER_IMAGE_PREVIEW_TOO_LARGE_ERROR,
+  assertRasterImagePreviewWithinLimits,
+  isKnownRasterImageMimeType
+} from './raster-image-preview-limits'
+
+function pngHeader(width: number, height: number): Buffer {
+  const bytes = Buffer.alloc(24)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
+  bytes.writeUInt32BE(13, 8)
+  bytes.write('IHDR', 12, 'ascii')
+  bytes.writeUInt32BE(width, 16)
+  bytes.writeUInt32BE(height, 20)
+  return bytes
+}
+
+describe('raster image preview limits', () => {
+  it('accepts ordinary 8K images and returns their dimensions', () => {
+    expect(assertRasterImagePreviewWithinLimits(pngHeader(7680, 4320), 'image/png')).toEqual({
+      width: 7680,
+      height: 4320
+    })
+  })
+
+  it('rejects oversized edges and total pixel counts before decode', () => {
+    expect(() =>
+      assertRasterImagePreviewWithinLimits(
+        pngHeader(MAX_RASTER_IMAGE_PREVIEW_DIMENSION_PX + 1, 1),
+        'image/png'
+      )
+    ).toThrow(RASTER_IMAGE_PREVIEW_TOO_LARGE_ERROR)
+    expect(() => assertRasterImagePreviewWithinLimits(pngHeader(8192, 8192), 'image/png')).toThrow(
+      RASTER_IMAGE_PREVIEW_TOO_LARGE_ERROR
+    )
+  })
+
+  it('rejects invalid known raster bytes but leaves SVG and PDF unchanged', () => {
+    expect(() => assertRasterImagePreviewWithinLimits(new Uint8Array([1]), 'image/gif')).toThrow(
+      INVALID_RASTER_IMAGE_PREVIEW_ERROR
+    )
+    expect(
+      assertRasterImagePreviewWithinLimits(new Uint8Array([1]), 'image/svg+xml')
+    ).toBeUndefined()
+    expect(
+      assertRasterImagePreviewWithinLimits(new Uint8Array([1]), 'application/pdf')
+    ).toBeUndefined()
+  })
+
+  it('recognizes supported MIME aliases case-insensitively', () => {
+    expect(isKnownRasterImageMimeType('IMAGE/JPEG; charset=binary')).toBe(true)
+    expect(isKnownRasterImageMimeType('image/vnd.microsoft.icon')).toBe(true)
+    expect(isKnownRasterImageMimeType('image/tiff')).toBe(false)
+  })
+})

--- a/src/shared/raster-image-preview-limits.ts
+++ b/src/shared/raster-image-preview-limits.ts
@@ -1,0 +1,69 @@
+import { readRasterImageDimensions, type RasterImageDimensions } from './raster-image-dimensions'
+
+export const MAX_RASTER_IMAGE_PREVIEW_DIMENSION_PX = 32_768
+export const MAX_RASTER_IMAGE_PREVIEW_PIXELS = 32 * 1024 * 1024
+export const RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES = 1024 * 1024
+export const INVALID_RASTER_IMAGE_PREVIEW_ERROR =
+  'Image preview has invalid or unsupported raster dimensions'
+export const RASTER_IMAGE_PREVIEW_TOO_LARGE_ERROR =
+  'Image dimensions exceed the preview safety limit'
+
+const RASTER_IMAGE_MIME_TYPES = new Set([
+  'image/apng',
+  'image/bmp',
+  'image/gif',
+  'image/ico',
+  'image/jpeg',
+  'image/jpg',
+  'image/pjpeg',
+  'image/png',
+  'image/vnd.microsoft.icon',
+  'image/webp',
+  'image/x-bmp',
+  'image/x-icon',
+  'image/x-ms-bmp'
+])
+
+function normalizeMimeType(mimeType: string | undefined): string | null {
+  const normalized = mimeType?.split(';', 1)[0]?.trim().toLowerCase()
+  return normalized || null
+}
+
+export function isKnownRasterImageMimeType(mimeType: string | undefined): boolean {
+  const normalized = normalizeMimeType(mimeType)
+  return normalized !== null && RASTER_IMAGE_MIME_TYPES.has(normalized)
+}
+
+export function isRasterImagePreviewDimensions(value: unknown): value is RasterImageDimensions {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const dimensions = value as Partial<RasterImageDimensions>
+  return (
+    Number.isSafeInteger(dimensions.width) &&
+    Number.isSafeInteger(dimensions.height) &&
+    dimensions.width! > 0 &&
+    dimensions.height! > 0 &&
+    dimensions.width! <= MAX_RASTER_IMAGE_PREVIEW_DIMENSION_PX &&
+    dimensions.height! <= MAX_RASTER_IMAGE_PREVIEW_DIMENSION_PX &&
+    dimensions.width! <= Math.floor(MAX_RASTER_IMAGE_PREVIEW_PIXELS / dimensions.height!)
+  )
+}
+
+/** Validates encoded raster dimensions without invoking a native image decoder. */
+export function assertRasterImagePreviewWithinLimits(
+  bytes: Uint8Array,
+  mimeType: string | undefined
+): RasterImageDimensions | undefined {
+  if (!isKnownRasterImageMimeType(mimeType)) {
+    return undefined
+  }
+  const dimensions = readRasterImageDimensions(bytes)
+  if (!dimensions) {
+    throw new Error(INVALID_RASTER_IMAGE_PREVIEW_ERROR)
+  }
+  if (!isRasterImagePreviewDimensions(dimensions)) {
+    throw new Error(RASTER_IMAGE_PREVIEW_TOO_LARGE_ERROR)
+  }
+  return dimensions
+}

--- a/src/shared/search-subprocess-lines.test.ts
+++ b/src/shared/search-subprocess-lines.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { SearchSubprocessLineAccumulator } from './search-subprocess-lines'
+
+describe('SearchSubprocessLineAccumulator', () => {
+  it('preserves UTF-8 records split across raw byte chunks', () => {
+    const parser = new SearchSubprocessLineAccumulator(32)
+    const bytes = Buffer.from('first🐋\nsecond')
+    const lines: string[] = []
+
+    expect(parser.push(bytes.subarray(0, 7), (line) => lines.push(line))).toBe(true)
+    expect(parser.push(bytes.subarray(7), (line) => lines.push(line))).toBe(true)
+
+    expect(lines).toEqual(['first🐋'])
+    expect(parser.finish()).toBe('second')
+  })
+
+  it('accepts an exact byte limit and rejects the next byte without decoding it', () => {
+    const parser = new SearchSubprocessLineAccumulator(4)
+    const lines: string[] = []
+
+    expect(parser.push(Buffer.from('four\n'), (line) => lines.push(line))).toBe(true)
+    expect(parser.push(Buffer.from('fives'), (line) => lines.push(line))).toBe(false)
+
+    expect(lines).toEqual(['four'])
+    expect(parser.finish()).toBeNull()
+  })
+
+  it('preserves empty lines and line order within one chunk', () => {
+    const parser = new SearchSubprocessLineAccumulator(8)
+    const lines: string[] = []
+
+    expect(parser.push(Buffer.from('\na\n\n'), (line) => lines.push(line))).toBe(true)
+
+    expect(lines).toEqual(['', 'a', ''])
+  })
+
+  it('retains one growable buffer for adversarial one-byte fragments', () => {
+    const parser = new SearchSubprocessLineAccumulator(256 * 1024)
+    const byte = Buffer.from('x')
+    let accepted = true
+
+    for (let index = 0; index < 200_000; index += 1) {
+      accepted = parser.push(byte, () => {}) && accepted
+    }
+
+    expect(accepted).toBe(true)
+    expect(Reflect.get(parser, 'buffer')).toBeInstanceOf(Buffer)
+    expect(parser.finish()).toBe('x'.repeat(200_000))
+    expect(Reflect.get(parser, 'buffer')).toBeNull()
+  })
+
+  it('rejects invalid byte limits', () => {
+    expect(() => new SearchSubprocessLineAccumulator(-1)).toThrow(RangeError)
+  })
+})

--- a/src/shared/search-subprocess-lines.ts
+++ b/src/shared/search-subprocess-lines.ts
@@ -1,0 +1,75 @@
+export const SEARCH_SUBPROCESS_MAX_LINE_BYTES = 64 * 1024 * 1024
+const SEARCH_SUBPROCESS_INITIAL_LINE_BUFFER_BYTES = 4 * 1024
+
+export class SearchSubprocessLineAccumulator {
+  private buffer: Buffer | null = null
+  private bytes = 0
+
+  constructor(private readonly maxLineBytes = SEARCH_SUBPROCESS_MAX_LINE_BYTES) {
+    if (!Number.isSafeInteger(maxLineBytes) || maxLineBytes < 0) {
+      throw new RangeError('Search line limit must be a non-negative safe integer')
+    }
+  }
+
+  push(rawChunk: Buffer | string, onLine: (line: string) => void): boolean {
+    const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk, 'utf8')
+    let cursor = 0
+    while (cursor < chunk.length) {
+      const newline = chunk.indexOf(0x0a, cursor)
+      const end = newline === -1 ? chunk.length : newline
+      const segmentBytes = end - cursor
+      if (this.bytes + segmentBytes > this.maxLineBytes) {
+        this.clear()
+        return false
+      }
+
+      if (newline !== -1 && this.bytes === 0) {
+        onLine(chunk.toString('utf8', cursor, end))
+      } else if (segmentBytes > 0) {
+        this.append(chunk.subarray(cursor, end))
+        if (newline !== -1) {
+          onLine(this.takeLine())
+        }
+      } else if (newline !== -1) {
+        onLine(this.takeLine())
+      }
+
+      if (newline === -1) {
+        return true
+      }
+      cursor = newline + 1
+    }
+    return true
+  }
+
+  finish(): string | null {
+    return this.bytes > 0 ? this.takeLine() : null
+  }
+
+  clear(): void {
+    this.buffer = null
+    this.bytes = 0
+  }
+
+  private append(segment: Buffer): void {
+    const requiredBytes = this.bytes + segment.length
+    if (!this.buffer || this.buffer.length < requiredBytes) {
+      const doubledCapacity = this.buffer?.length ? this.buffer.length * 2 : 0
+      const nextCapacity = Math.min(
+        this.maxLineBytes,
+        Math.max(SEARCH_SUBPROCESS_INITIAL_LINE_BUFFER_BYTES, doubledCapacity, requiredBytes)
+      )
+      const next = Buffer.allocUnsafe(nextCapacity)
+      this.buffer?.copy(next, 0, 0, this.bytes)
+      this.buffer = next
+    }
+    segment.copy(this.buffer, this.bytes)
+    this.bytes = requiredBytes
+  }
+
+  private takeLine(): string {
+    const line = this.buffer?.toString('utf8', 0, this.bytes) ?? ''
+    this.clear()
+    return line
+  }
+}

--- a/src/shared/string-chunk-compaction.test.ts
+++ b/src/shared/string-chunk-compaction.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { appendCompactedStringChunk, RETAINED_STRING_CHUNK_LIMIT } from './string-chunk-compaction'
+
+describe('appendCompactedStringChunk', () => {
+  it('preserves 100,000 fragments within the retained chunk limit', () => {
+    const chunks: string[] = []
+    let maxRetainedChunks = 0
+
+    for (let index = 0; index < 100_000; index += 1) {
+      appendCompactedStringChunk(chunks, String.fromCharCode(97 + (index % 26)))
+      maxRetainedChunks = Math.max(maxRetainedChunks, chunks.length)
+    }
+
+    expect(maxRetainedChunks).toBeLessThanOrEqual(RETAINED_STRING_CHUNK_LIMIT)
+    expect(chunks.join('')).toHaveLength(100_000)
+  })
+})

--- a/src/shared/string-chunk-compaction.ts
+++ b/src/shared/string-chunk-compaction.ts
@@ -1,0 +1,11 @@
+export const RETAINED_STRING_CHUNK_LIMIT = 1_024
+
+export function appendCompactedStringChunk(chunks: string[], value: string): void {
+  chunks.push(value)
+  if (chunks.length <= RETAINED_STRING_CHUNK_LIMIT) {
+    return
+  }
+  const compacted = chunks.join('')
+  chunks.length = 0
+  chunks.push(compacted)
+}

--- a/src/shared/workspace-space-entry-traversal.test.ts
+++ b/src/shared/workspace-space-entry-traversal.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest'
+import { scanWorkspaceSpaceEntryTree } from './workspace-space-entry-traversal'
+import { WorkspaceSpaceScanCapacityError } from './workspace-space-scan-budget'
+
+type Entry = { name: string }
+
+function makeTraversal(
+  directories: ReadonlyMap<string, readonly Entry[]>,
+  classifyEntry: (path: string) => Promise<{
+    kind: 'directory' | 'file' | 'symlink'
+    sizeBytes: number
+  }>,
+  limits?: { maxEntries?: number; maxRetainedBytes?: number }
+) {
+  return scanWorkspaceSpaceEntryTree({
+    rootPath: '/root',
+    rootName: 'root',
+    concurrency: 5,
+    entryName: (entry: Entry) => entry.name,
+    joinPath: (parent, child) => `${parent}/${child}`,
+    classifyEntry: (path) => classifyEntry(path),
+    readDirectory: async (path) => {
+      const entries = directories.get(path)
+      if (!entries) {
+        throw new Error(`unreadable ${path}`)
+      }
+      return entries
+    },
+    checkCancelled: () => undefined,
+    createCancellationError: () => new Error('cancelled'),
+    isCancellationError: (error) => error instanceof Error && error.message === 'cancelled',
+    limits
+  })
+}
+
+describe('scanWorkspaceSpaceEntryTree', () => {
+  it('uses a fixed worker pool and preserves source order', async () => {
+    const entries = Array.from({ length: 200 }, (_, index) => ({ name: `file-${index}` }))
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let active = 0
+    let peak = 0
+    let started = 0
+    let saturated!: () => void
+    const saturation = new Promise<void>((resolve) => {
+      saturated = resolve
+    })
+
+    const scan = makeTraversal(new Map([['/root', entries]]), async (path) => {
+      if (path === '/root') {
+        return { kind: 'directory', sizeBytes: 1 }
+      }
+      active += 1
+      started += 1
+      peak = Math.max(peak, active)
+      if (started === 5) {
+        saturated()
+      }
+      await gate
+      active -= 1
+      return { kind: 'file', sizeBytes: 1 }
+    })
+
+    await saturation
+    expect(started).toBe(5)
+    expect(peak).toBe(5)
+    release()
+
+    const result = await scan
+    expect(result.children?.map((child) => child.name)).toEqual(entries.map((entry) => entry.name))
+    expect(result.sizeBytes).toBe(201)
+  })
+
+  it('preserves aggregate sizes and partial-failure accounting', async () => {
+    const directories = new Map<string, readonly Entry[]>([
+      ['/root', [{ name: 'directory' }, { name: 'missing' }, { name: 'link' }, { name: 'file' }]],
+      ['/root/directory', [{ name: 'nested' }, { name: 'unreadable' }]],
+      ['/root/directory/unreadable', []]
+    ])
+    directories.delete('/root/directory/unreadable')
+
+    const result = await makeTraversal(directories, async (path) => {
+      if (path === '/root') {
+        return { kind: 'directory', sizeBytes: 10 }
+      }
+      if (path === '/root/directory') {
+        return { kind: 'directory', sizeBytes: 5 }
+      }
+      if (path === '/root/directory/nested') {
+        return { kind: 'file', sizeBytes: 100 }
+      }
+      if (path === '/root/directory/unreadable') {
+        return { kind: 'directory', sizeBytes: 7 }
+      }
+      if (path === '/root/missing') {
+        throw new Error('missing')
+      }
+      if (path === '/root/link') {
+        return { kind: 'symlink', sizeBytes: 2 }
+      }
+      return { kind: 'file', sizeBytes: 20 }
+    })
+
+    expect(result).toMatchObject({ sizeBytes: 144, skippedEntryCount: 2 })
+    expect(result.children?.map((child) => child.name)).toEqual(['directory', 'link', 'file'])
+    expect(result.children?.[0]).toMatchObject({
+      sizeBytes: 112,
+      skippedEntryCount: 1
+    })
+  })
+
+  it('accepts the exact entry cap without changing order or totals', async () => {
+    const entries = [{ name: 'first' }, { name: 'second' }]
+    const result = await makeTraversal(
+      new Map([['/root', entries]]),
+      async (path) => ({ kind: path === '/root' ? 'directory' : 'file', sizeBytes: 1 }),
+      { maxEntries: entries.length }
+    )
+
+    expect(result.children?.map((child) => child.name)).toEqual(['first', 'second'])
+    expect(result.sizeBytes).toBe(3)
+  })
+
+  it('fails closed instead of retaining entries beyond the scan cap', async () => {
+    const entries = [{ name: 'first' }, { name: 'second' }, { name: 'overflow' }]
+    const scan = makeTraversal(
+      new Map([['/root', entries]]),
+      async (path) => ({ kind: path === '/root' ? 'directory' : 'file', sizeBytes: 1 }),
+      { maxEntries: entries.length - 1 }
+    )
+
+    await expect(scan).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
+  })
+
+  it('aggregates a deep chain exactly at the entry cap without recursive unwinding', async () => {
+    const depth = 256
+    const directories = new Map<string, readonly Entry[]>()
+    let path = '/root'
+    for (let index = 0; index < depth; index += 1) {
+      const name = `directory-${index}`
+      directories.set(path, [{ name }])
+      path = `${path}/${name}`
+    }
+    directories.set(path, [])
+
+    const result = await makeTraversal(
+      directories,
+      async () => ({ kind: 'directory', sizeBytes: 1 }),
+      { maxEntries: depth }
+    )
+
+    expect(result.sizeBytes).toBe(depth + 1)
+    expect(result.children).toEqual([
+      expect.objectContaining({ name: 'directory-0', sizeBytes: depth })
+    ])
+  })
+
+  it('fails closed when a deep chain crosses the cumulative entry cap', async () => {
+    const directories = new Map<string, readonly Entry[]>()
+    let path = '/root'
+    for (let index = 0; index < 5; index += 1) {
+      const name = `directory-${index}`
+      directories.set(path, [{ name }])
+      path = `${path}/${name}`
+    }
+    directories.set(path, [])
+
+    const scan = makeTraversal(directories, async () => ({ kind: 'directory', sizeBytes: 1 }), {
+      maxEntries: 4
+    })
+
+    await expect(scan).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
+  })
+})

--- a/src/shared/workspace-space-entry-traversal.ts
+++ b/src/shared/workspace-space-entry-traversal.ts
@@ -1,0 +1,318 @@
+import type { WorkspaceSpaceItemKind } from './workspace-space-types'
+import {
+  collectWorkspaceSpaceDirectoryEntries,
+  createWorkspaceSpaceScanBudget,
+  WorkspaceSpaceScanCapacityError,
+  type WorkspaceSpaceScanBudget,
+  type WorkspaceSpaceScanLimits
+} from './workspace-space-scan-budget'
+
+type ScannableWorkspaceSpaceItemKind = Exclude<WorkspaceSpaceItemKind, 'other'>
+
+export type WorkspaceSpaceEntryScan = {
+  name: string
+  path: string
+  kind: ScannableWorkspaceSpaceItemKind
+  sizeBytes: number
+  skippedEntryCount: number
+  children?: WorkspaceSpaceEntryScan[]
+}
+
+type WorkspaceSpaceEntryIdentity = {
+  kind: ScannableWorkspaceSpaceItemKind
+  sizeBytes: number
+}
+
+type WorkspaceSpaceEntryTraversalOptions<TEntry> = {
+  rootPath: string
+  rootName: string
+  concurrency: number
+  signal?: AbortSignal
+  entryName: (entry: TEntry) => string
+  joinPath: (parent: string, child: string) => string
+  classifyEntry: (path: string, sourceEntry: TEntry | null) => Promise<WorkspaceSpaceEntryIdentity>
+  readDirectory: (path: string) => Promise<AsyncIterable<TEntry> | Iterable<TEntry>>
+  checkCancelled: () => void
+  createCancellationError: () => Error
+  isCancellationError: (error: unknown) => boolean
+  limits?: Partial<WorkspaceSpaceScanLimits>
+}
+
+type ParentSlot<TEntry> = {
+  frame: DirectoryFrame<TEntry>
+  index: number
+}
+
+type DirectoryFrame<TEntry> = {
+  result: WorkspaceSpaceEntryScan
+  entries: readonly TEntry[]
+  nextIndex: number
+  remainingChildren: number
+  childResults?: (WorkspaceSpaceEntryScan | null | undefined)[]
+  parentSlot?: ParentSlot<TEntry>
+}
+
+type EntryJob<TEntry> = {
+  frame: DirectoryFrame<TEntry>
+  index: number
+  entry: TEntry
+  name: string
+  path: string
+}
+
+function createEntryScan(
+  path: string,
+  name: string,
+  identity: WorkspaceSpaceEntryIdentity
+): WorkspaceSpaceEntryScan {
+  return {
+    name,
+    path,
+    kind: identity.kind,
+    sizeBytes: identity.sizeBytes,
+    skippedEntryCount: 0
+  }
+}
+
+async function readDirectoryOrNull<TEntry>(
+  path: string,
+  options: WorkspaceSpaceEntryTraversalOptions<TEntry>,
+  budget: WorkspaceSpaceScanBudget
+): Promise<readonly TEntry[] | null> {
+  try {
+    const directory = await options.readDirectory(path)
+    const entries = await collectWorkspaceSpaceDirectoryEntries(
+      directory,
+      path,
+      options.entryName,
+      budget,
+      options.checkCancelled
+    )
+    options.checkCancelled()
+    return entries
+  } catch (error) {
+    if (options.isCancellationError(error) || error instanceof WorkspaceSpaceScanCapacityError) {
+      throw error
+    }
+    return null
+  }
+}
+
+/**
+ * Scans one directory tree with a fixed worker pool. Directory frames retain
+ * the source arrays returned by readdir, but never allocate one promise or
+ * queued closure per entry; only the configured workers own live entry jobs.
+ */
+export async function scanWorkspaceSpaceEntryTree<TEntry>(
+  options: WorkspaceSpaceEntryTraversalOptions<TEntry>
+): Promise<WorkspaceSpaceEntryScan> {
+  const budget = createWorkspaceSpaceScanBudget(options.limits)
+  options.checkCancelled()
+  const rootIdentity = await options.classifyEntry(options.rootPath, null)
+  options.checkCancelled()
+  const root = createEntryScan(options.rootPath, options.rootName, rootIdentity)
+  if (root.kind !== 'directory') {
+    return root
+  }
+
+  const rootEntries = await readDirectoryOrNull(options.rootPath, options, budget)
+  if (rootEntries === null) {
+    root.skippedEntryCount = 1
+    return root
+  }
+  if (rootEntries.length === 0) {
+    root.children = []
+    return root
+  }
+
+  const rootFrame: DirectoryFrame<TEntry> = {
+    result: root,
+    entries: rootEntries,
+    nextIndex: 0,
+    remainingChildren: rootEntries.length,
+    childResults: Array.from({ length: rootEntries.length }, () => undefined)
+  }
+  const availableFrames: DirectoryFrame<TEntry>[] = [rootFrame]
+  const waiters = new Set<() => void>()
+  let outstandingEntries = rootEntries.length
+  let fatalError: unknown = null
+
+  const wakeWorkers = (): void => {
+    for (const wake of waiters) {
+      wake()
+    }
+  }
+  const fail = (error: unknown): void => {
+    fatalError ??= error
+    wakeWorkers()
+  }
+  const onAbort = (): void => fail(options.createCancellationError())
+  options.signal?.addEventListener('abort', onAbort, { once: true })
+  if (options.signal?.aborted) {
+    onAbort()
+  }
+
+  const takeAvailableJob = (): EntryJob<TEntry> | null => {
+    while (availableFrames.length > 0) {
+      const frame = availableFrames.at(-1)!
+      if (frame.nextIndex >= frame.entries.length) {
+        availableFrames.pop()
+        continue
+      }
+      const index = frame.nextIndex
+      frame.nextIndex += 1
+      if (frame.nextIndex >= frame.entries.length) {
+        availableFrames.pop()
+      }
+      const entry = frame.entries[index]
+      const name = options.entryName(entry)
+      return {
+        frame,
+        index,
+        entry,
+        name,
+        path: options.joinPath(frame.result.path, name)
+      }
+    }
+    return null
+  }
+
+  const waitForJob = async (): Promise<EntryJob<TEntry> | null> => {
+    while (fatalError === null) {
+      options.checkCancelled()
+      const job = takeAvailableJob()
+      if (job) {
+        return job
+      }
+      if (outstandingEntries === 0) {
+        return null
+      }
+      await new Promise<void>((resolve) => {
+        const wake = (): void => {
+          waiters.delete(wake)
+          resolve()
+        }
+        waiters.add(wake)
+      })
+    }
+    return null
+  }
+
+  const completeChild = (
+    initialFrame: DirectoryFrame<TEntry>,
+    initialIndex: number,
+    initialResult: WorkspaceSpaceEntryScan | null
+  ): void => {
+    let frame = initialFrame
+    let index = initialIndex
+    let result = initialResult
+    while (true) {
+      if (frame.childResults) {
+        frame.childResults[index] = result
+      }
+      if (result) {
+        frame.result.sizeBytes += result.sizeBytes
+        frame.result.skippedEntryCount += result.skippedEntryCount
+      } else {
+        frame.result.skippedEntryCount += 1
+      }
+      frame.remainingChildren -= 1
+      outstandingEntries -= 1
+      if (frame.remainingChildren > 0) {
+        break
+      }
+      if (frame.childResults) {
+        frame.result.children = frame.childResults.filter(
+          (child): child is WorkspaceSpaceEntryScan => child != null
+        )
+      }
+      if (!frame.parentSlot) {
+        break
+      }
+      result = frame.result
+      index = frame.parentSlot.index
+      frame = frame.parentSlot.frame
+    }
+    wakeWorkers()
+  }
+
+  const expandDirectory = (
+    job: EntryJob<TEntry>,
+    result: WorkspaceSpaceEntryScan,
+    entries: readonly TEntry[]
+  ): void => {
+    if (entries.length === 0) {
+      completeChild(job.frame, job.index, result)
+      return
+    }
+    outstandingEntries += entries.length
+    availableFrames.push({
+      result,
+      entries,
+      nextIndex: 0,
+      remainingChildren: entries.length,
+      parentSlot: { frame: job.frame, index: job.index }
+    })
+    wakeWorkers()
+  }
+
+  const processJob = async (job: EntryJob<TEntry>): Promise<void> => {
+    let identity: WorkspaceSpaceEntryIdentity
+    try {
+      identity = await options.classifyEntry(job.path, job.entry)
+      options.checkCancelled()
+    } catch (error) {
+      if (options.isCancellationError(error)) {
+        throw error
+      }
+      completeChild(job.frame, job.index, null)
+      return
+    }
+
+    const result = createEntryScan(job.path, job.name, identity)
+    if (result.kind !== 'directory') {
+      completeChild(job.frame, job.index, result)
+      return
+    }
+    const entries = await readDirectoryOrNull(job.path, options, budget)
+    if (entries === null) {
+      result.skippedEntryCount = 1
+      completeChild(job.frame, job.index, result)
+      return
+    }
+    expandDirectory(job, result, entries)
+  }
+
+  const worker = async (): Promise<void> => {
+    while (fatalError === null) {
+      let job: EntryJob<TEntry> | null
+      try {
+        job = await waitForJob()
+      } catch (error) {
+        fail(error)
+        return
+      }
+      if (!job) {
+        return
+      }
+      try {
+        await processJob(job)
+      } catch (error) {
+        fail(error)
+        return
+      }
+    }
+  }
+
+  const workerCount = Math.max(1, Math.floor(options.concurrency))
+  try {
+    await Promise.all(Array.from({ length: workerCount }, worker))
+  } finally {
+    options.signal?.removeEventListener('abort', onAbort)
+    wakeWorkers()
+  }
+  if (fatalError !== null) {
+    throw fatalError
+  }
+  return root
+}

--- a/src/shared/workspace-space-scan-budget.test.ts
+++ b/src/shared/workspace-space-scan-budget.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  collectWorkspaceSpaceDirectoryEntries,
+  createWorkspaceSpaceScanBudget,
+  estimateWorkspaceSpaceEntryRetainedBytes,
+  WorkspaceSpaceScanCapacityError
+} from './workspace-space-scan-budget'
+
+describe('workspace space scan budget', () => {
+  it('preserves entries exactly at the retained-byte cap', async () => {
+    const entries = [{ name: 'first' }, { name: 'second' }]
+    const parentPath = '/workspace'
+    const exactBytes = entries.reduce(
+      (total, entry) => total + estimateWorkspaceSpaceEntryRetainedBytes(parentPath, entry.name),
+      0
+    )
+
+    await expect(
+      collectWorkspaceSpaceDirectoryEntries(
+        entries,
+        parentPath,
+        (entry) => entry.name,
+        createWorkspaceSpaceScanBudget({ maxRetainedBytes: exactBytes }),
+        () => undefined
+      )
+    ).resolves.toEqual(entries)
+  })
+
+  it('closes an async directory iterator when the next entry exceeds the budget', async () => {
+    let closed = false
+    async function* directory() {
+      try {
+        yield { name: 'accepted' }
+        yield { name: 'overflow' }
+      } finally {
+        closed = true
+      }
+    }
+
+    await expect(
+      collectWorkspaceSpaceDirectoryEntries(
+        directory(),
+        '/workspace',
+        (entry) => entry.name,
+        createWorkspaceSpaceScanBudget({ maxEntries: 1 }),
+        () => undefined
+      )
+    ).rejects.toBeInstanceOf(WorkspaceSpaceScanCapacityError)
+    expect(closed).toBe(true)
+  })
+})

--- a/src/shared/workspace-space-scan-budget.ts
+++ b/src/shared/workspace-space-scan-budget.ts
@@ -1,0 +1,87 @@
+export const WORKSPACE_SPACE_MAX_SCANNED_ENTRIES = 100_000
+export const WORKSPACE_SPACE_MAX_RETAINED_SCAN_BYTES = 64 * 1024 * 1024
+
+const WORKSPACE_SPACE_ENTRY_OVERHEAD_BYTES = 512
+
+export type WorkspaceSpaceScanLimits = {
+  maxEntries: number
+  maxRetainedBytes: number
+}
+
+export type WorkspaceSpaceScanBudget = {
+  entries: number
+  retainedBytes: number
+  limits: WorkspaceSpaceScanLimits
+}
+
+export class WorkspaceSpaceScanCapacityError extends Error {
+  constructor() {
+    super(
+      'Workspace is too large to scan safely (limit: 100,000 entries or 64 MiB retained scan state)'
+    )
+    this.name = 'WorkspaceSpaceScanCapacityError'
+  }
+}
+
+export function createWorkspaceSpaceScanBudget(
+  requested?: Partial<WorkspaceSpaceScanLimits>
+): WorkspaceSpaceScanBudget {
+  return {
+    entries: 0,
+    retainedBytes: 0,
+    limits: {
+      maxEntries: clampLimit(requested?.maxEntries, WORKSPACE_SPACE_MAX_SCANNED_ENTRIES),
+      maxRetainedBytes: clampLimit(
+        requested?.maxRetainedBytes,
+        WORKSPACE_SPACE_MAX_RETAINED_SCAN_BYTES
+      )
+    }
+  }
+}
+
+export function estimateWorkspaceSpaceEntryRetainedBytes(
+  parentPath: string,
+  entryName: string
+): number {
+  return (parentPath.length + entryName.length) * 2 + WORKSPACE_SPACE_ENTRY_OVERHEAD_BYTES
+}
+
+export function retainWorkspaceSpaceScanEntry(
+  budget: WorkspaceSpaceScanBudget,
+  parentPath: string,
+  entryName: string
+): void {
+  const retainedBytes =
+    budget.retainedBytes + estimateWorkspaceSpaceEntryRetainedBytes(parentPath, entryName)
+  if (
+    budget.entries >= budget.limits.maxEntries ||
+    retainedBytes > budget.limits.maxRetainedBytes
+  ) {
+    throw new WorkspaceSpaceScanCapacityError()
+  }
+  budget.entries += 1
+  budget.retainedBytes = retainedBytes
+}
+
+export async function collectWorkspaceSpaceDirectoryEntries<TEntry>(
+  directory: AsyncIterable<TEntry> | Iterable<TEntry>,
+  parentPath: string,
+  entryName: (entry: TEntry) => string,
+  budget: WorkspaceSpaceScanBudget,
+  checkCancelled: () => void
+): Promise<TEntry[]> {
+  const entries: TEntry[] = []
+  for await (const entry of directory) {
+    checkCancelled()
+    retainWorkspaceSpaceScanEntry(budget, parentPath, entryName(entry))
+    entries.push(entry)
+  }
+  return entries
+}
+
+function clampLimit(value: number | undefined, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    return maximum
+  }
+  return Math.min(value, maximum)
+}


### PR DESCRIPTION
## OOM hardening slice 03/29 — bound shared filesystem/quick-open/markdown listings

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **03/29** (base: `oom/02-a2-shared-image-media`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Adds 21 new pure helper modules (plus tests) that impose count/byte/depth ceilings on directory listings, /proc scans, Markdown discovery, Quick Open path collection, and workspace disk-usage scans. No callers are wired in this slice, so it changes no behavior on its own; it supplies the reusable budget/limit primitives the other slices consume.

### ELI5
This is a box of new safety valves for reading folders and file lists. Each valve says "if a folder is absurdly huge, stop instead of trying to hold it all in memory." Nothing is plugged in yet in this batch — it's just the valves and their unit tests — and the cutoffs are set far above what a normal project ever hits.

### Proof of OOM fix
- filesystem-directory-listing-limit.ts: 100,000 entries OR 12 MB retained (estimate name.length*6+96); tests reject at count+1 and at byte cap, and verify callers can't raise the ceiling (filesystem-directory-listing-limit.test.ts)
- mobile-file-directory-limit.ts: 10,000 entries OR 4 MB retained; test rejects MAX+1 entries and oversized-name payload (mobile-file-directory-limit.test.ts)
- markdown-document-listing-limits.ts: 20,000 docs, 8 MB metadata, 64 KB path, 100,000 visited entries, depth 256; tests cover count/metadata/visited/path/depth overflow + Electron-wrapped error detection
- node-markdown-document-discovery.ts: streams opendir, enforces maxVisitedEntries/maxDepth mid-walk; test stops a 10k-wide dir after 3 yields and rejects over-deep chains
- quick-open-listing-limits.ts: 20,001 result cap, 100,000 retained paths, 32 MB retained bytes, 64 KB per path; QuickOpenSubprocessPathAccumulator bounds a single fragmented NUL-delimited path and copies segments so a residual doesn't pin the read buffer (quick-open-listing-limits.test.ts)
- quick-open-directory-reader.ts: streams opendir with per-entry + path budget and a deadline; test confirms it stops one entry past the cap and closes the iterator (finally block runs)
- linux-proc-port-scan-limits.ts: network table 8 MB, per-proc-file 64 KB, shared 8 MB process-metadata budget; tests confirm shared budget debits only successful reads and stops at exhaustion
- linux-proc-socket-owner-scanner.ts: streams /proc and /proc/<pid>/fd without retaining the listing; test drives 20,000 synthetic pids with size-0 result
- workspace-space-scan-budget.ts: 100,000 entries OR 64 MB retained; test closes async dir iterator when next entry exceeds budget
- workspace-space-entry-traversal.ts: fixed worker pool, no per-entry promise/closure allocation; tests verify order preservation, partial-failure accounting, and fail-closed at cumulative entry cap

### Regressions
**Normal-path (ordinary use, below the new limits):** **none** — behavior is unchanged below the ceilings.

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Directory listing of a folder with >100,000 entries (or >12 MB of names) throws a hard 'too large to list safely' error instead of returning a partial list — only reachable on pathological directories
- Mobile file browser hard-fails at 10,000 entries / 4 MB in one directory (the lowest cap in the slice) rather than truncating
- Markdown link completion is disabled ('Workspace is too large for Markdown link completion.') once a workspace exceeds 20k markdown docs / 8 MB metadata / 100k visited entries / depth 256
- Quick Open path collection aborts once retained paths exceed 100,000 or 32 MB, or any single path exceeds 64 KB
- Workspace disk-usage scan rejects the whole scan (WorkspaceSpaceScanCapacityError) at 100,000 entries or 64 MB retained scan state
- Linux /proc port scan silently drops process metadata once the shared 8 MB budget is exhausted or a single /proc file exceeds 64 KB
- Very large single directories now fail with a hard error instead of a partial/truncated listing. Mobile uses the lowest ceiling (10,000 entries / 4 MB), so an unusually large single directory on mobile is the most likely place an ordinary-ish user could hit a cap. _(only when: Only when a single directory contains >10k entries (mobile) or >100k (desktop). Not wired in this slice — surfaces only once the mobile/desktop caller slices land.)_
- Markdown link autocompletion becomes fully unavailable (not degraded) in workspaces exceeding 20k markdown files or 256-deep trees. _(only when: Extremely large/deep documentation monorepos; caller wiring is in another slice.)_

### Build / CI
- Part of the **Shared foundation** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #06** (whole-repo interconnection — see stack README). Content is exact production code.

### Adversarial review
- 1 skeptic lens(es). Sign-off: **yes**. Residual risk: **low**.
- Skeptic pass CONFIRMS the prior reviewer: this slice is 21 brand-new pure helper modules (+tests). git diff shows every entry as `new file mode 100644` — zero existing files modified, so no production caller can reach this code. No runtime behavior change is possible in this slice; all caps only bite once the mobile/desktop/quick-open/markdown/proc/workspace caller slices land.

Verified ceilings vs ordinary use:
- filesystem-directory-listing-limit.ts: 100,000 entries / 12 MB — far above any normal single directory.
- mobile-file-directory-limit.ts: 10,000 entries / 4 MB — the LOWEST cap. This is the one plausibly-reachable-by-an-ordinary-user value (a single mobile directory such as a photos/downloads folder with >10k files hard-errors "too large to show safely" instead of truncating). NOT reachable in this slice (no mobile caller wired). Flag for the human when the mobile-caller slice is reviewed; only low severity even then, and only for pathologically large single dirs.
- markdown-document-listing-limits.ts: 20,000 docs / 8 MB / depth 256 — a workspace with >20k markdown files disables (not degrades) Markdown link completion. Only huge doc monorepos; not wired here.
- quick-open-listing-limits.ts: 20,001 results / 100k retained paths / 32 MB / 64 KB per path — overload-only.
- workspace-space-scan-budget.ts: 100,000 entries / 64 MB — overload-only.
- linux-proc-port-scan-limits.ts: 8 MB budget / 64 KB per /proc file / 2,048 sockets — overload-only, silent metadata drop.

Correctness spot-checks passed: clampLimit blocks callers from raising process-wide ceilings; retain* boundary uses (>= count, > bytes) are consistent with the assertMarkdownDocumentsWithinLimit array guard (documents.length > max); reader modules (quick-open-directory-reader.ts, node-markdown-document-discovery.ts) correctly re-throw cancellation/capacity errors while swallowing permission/vanished-path errors to return [] so readable siblings aren't hidden; workspace-space-entry-traversal.ts removes its abort listener in a finally and re-throws fatalError. No off-by-one, no missing-release, no FIFO break found. Safe to open as draft PR.

### Files
21 files changed (+1899 / −0).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
