### PR TITLE
oom(04/29): bound shared remote-runtime/relay admission

### DIFF
--- a/src/shared/relay-json-admission.ts
+++ b/src/shared/relay-json-admission.ts
@@ -1,0 +1,12 @@
+import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
+
+export const RELAY_JSON_MAX_STRUCTURAL_TOKENS = 1_000_000
+export const RELAY_JSON_MAX_NESTING_DEPTH = 128
+
+export function parseRelayJsonText<T>(text: string): T {
+  assertJsonTextStructureWithinLimits(text, {
+    structuralTokens: RELAY_JSON_MAX_STRUCTURAL_TOKENS,
+    nestingDepth: RELAY_JSON_MAX_NESTING_DEPTH
+  })
+  return JSON.parse(text) as T
+}

--- a/src/shared/relay-version-marker.test.ts
+++ b/src/shared/relay-version-marker.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { NodeFileReadTooLargeError } from './node-bounded-file-reader'
+import { RELAY_VERSION_MARKER_MAX_BYTES, readRelayVersionMarkerSync } from './relay-version-marker'
+
+const roots: string[] = []
+
+function createVersionFile(contents: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-relay-version-marker-'))
+  roots.push(root)
+  const filePath = join(root, '.version')
+  writeFileSync(filePath, contents)
+  return filePath
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('relay version marker', () => {
+  it('accepts a trimmed marker at the exact byte boundary', () => {
+    const version = '1.2.3+deadbeef'
+    const filePath = createVersionFile(
+      version + ' '.repeat(RELAY_VERSION_MARKER_MAX_BYTES - Buffer.byteLength(version))
+    )
+
+    expect(readRelayVersionMarkerSync(filePath)).toBe(version)
+  })
+
+  it('rejects a sparse marker one byte over the boundary', () => {
+    const filePath = createVersionFile('1.2.3')
+    truncateSync(filePath, RELAY_VERSION_MARKER_MAX_BYTES + 1)
+
+    expect(() => readRelayVersionMarkerSync(filePath)).toThrow(NodeFileReadTooLargeError)
+  })
+})

--- a/src/shared/relay-version-marker.ts
+++ b/src/shared/relay-version-marker.ts
@@ -1,0 +1,9 @@
+import { readNodeFileSyncWithinLimit } from './node-bounded-file-reader'
+
+export const RELAY_VERSION_MARKER_MAX_BYTES = 4 * 1024
+
+export function readRelayVersionMarkerSync(versionFile: string): string {
+  return readNodeFileSyncWithinLimit(versionFile, RELAY_VERSION_MARKER_MAX_BYTES)
+    .buffer.toString('utf8')
+    .trim()
+}

--- a/src/shared/remote-runtime-prepared-request-admission.ts
+++ b/src/shared/remote-runtime-prepared-request-admission.ts
@@ -1,0 +1,123 @@
+import { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import {
+  REMOTE_RUNTIME_MAX_PENDING_REQUESTS,
+  REMOTE_RUNTIME_MAX_PENDING_RPC_BYTES,
+  REMOTE_RUNTIME_MAX_PROCESS_PENDING_REQUESTS,
+  REMOTE_RUNTIME_MAX_PROCESS_PENDING_RPC_BYTES,
+  retainedRemoteRuntimeJsonStringBytes
+} from './remote-runtime-memory-limits'
+import type { RuntimeRpcResponse } from './runtime-rpc-envelope'
+
+export type RemoteRuntimePreparedRequest = {
+  retainedBytes: number
+  serializedRequest: string | null
+  releaseProcessAdmission: () => void
+}
+
+export type RemoteRuntimePendingRequest<TResult> = {
+  resolve: (response: RuntimeRpcResponse<TResult>) => void
+  reject: (error: Error) => void
+  timeout: ReturnType<typeof setTimeout>
+  preparedRequest: RemoteRuntimePreparedRequest | null
+}
+
+type PendingPreparedRequest = {
+  preparedRequest?: RemoteRuntimePreparedRequest | null
+}
+
+type ProcessRequestAdmission = {
+  retainedBytes: number
+}
+
+const processRequestAdmissions = new Set<ProcessRequestAdmission>()
+
+export function prepareRemoteRuntimeRequest(
+  pendingRequests: ReadonlyMap<string, PendingPreparedRequest>,
+  serialize: () => string
+): RemoteRuntimePreparedRequest {
+  if (
+    pendingRequests.size >= REMOTE_RUNTIME_MAX_PENDING_REQUESTS ||
+    processRequestAdmissions.size >= REMOTE_RUNTIME_MAX_PROCESS_PENDING_REQUESTS
+  ) {
+    throw remoteRuntimeRequestBusyError()
+  }
+  const serializedRequest = serialize()
+  const retainedBytes = retainedRemoteRuntimeJsonStringBytes(serializedRequest)
+  let alreadyRetainedBytes = 0
+  for (const pending of pendingRequests.values()) {
+    alreadyRetainedBytes += pending.preparedRequest?.retainedBytes ?? 0
+  }
+  if (retainedBytes > REMOTE_RUNTIME_MAX_PENDING_RPC_BYTES - alreadyRetainedBytes) {
+    throw remoteRuntimeRequestBusyError()
+  }
+  const releaseProcessAdmission = reserveProcessRequestAdmission(retainedBytes)
+  if (!releaseProcessAdmission) {
+    throw remoteRuntimeRequestBusyError()
+  }
+  return { retainedBytes, serializedRequest, releaseProcessAdmission }
+}
+
+export function takeRemoteRuntimePreparedRequest(pending: PendingPreparedRequest): string | null {
+  const prepared = pending.preparedRequest
+  if (!prepared || prepared.serializedRequest === null) {
+    return null
+  }
+  const serializedRequest = prepared.serializedRequest
+  prepared.serializedRequest = null
+  return serializedRequest
+}
+
+export function releaseRemoteRuntimePreparedRequest(pending: PendingPreparedRequest): void {
+  const prepared = pending.preparedRequest
+  if (!prepared) {
+    return
+  }
+  prepared.serializedRequest = null
+  prepared.releaseProcessAdmission()
+  prepared.retainedBytes = 0
+  pending.preparedRequest = null
+}
+
+export function getRemoteRuntimeRequestAdmissionEvidence(): {
+  pendingRequestCount: number
+  retainedBytes: number
+} {
+  let retainedBytes = 0
+  for (const admission of processRequestAdmissions) {
+    retainedBytes += admission.retainedBytes
+  }
+  return { pendingRequestCount: processRequestAdmissions.size, retainedBytes }
+}
+
+export function toRemoteRuntimeRequestError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error
+  }
+  return new RemoteRuntimeClientError('runtime_error', String(error))
+}
+
+function remoteRuntimeRequestBusyError(): RemoteRuntimeClientError {
+  return new RemoteRuntimeClientError(
+    'remote_runtime_busy',
+    'Remote runtime request limit reached; retry after pending requests finish.'
+  )
+}
+
+function reserveProcessRequestAdmission(retainedBytes: number): (() => void) | null {
+  let alreadyRetainedBytes = 0
+  for (const admission of processRequestAdmissions) {
+    alreadyRetainedBytes += admission.retainedBytes
+  }
+  if (
+    processRequestAdmissions.size >= REMOTE_RUNTIME_MAX_PROCESS_PENDING_REQUESTS ||
+    retainedBytes > REMOTE_RUNTIME_MAX_PROCESS_PENDING_RPC_BYTES - alreadyRetainedBytes
+  ) {
+    return null
+  }
+  const admission = { retainedBytes }
+  processRequestAdmissions.add(admission)
+  return () => {
+    admission.retainedBytes = 0
+    processRequestAdmissions.delete(admission)
+  }
+}

--- a/src/shared/remote-runtime-request-ready-waiters.ts
+++ b/src/shared/remote-runtime-request-ready-waiters.ts
@@ -1,0 +1,29 @@
+export type RemoteRuntimeRequestReadyWaiter = {
+  resolve: () => void
+  reject: (error: Error) => void
+}
+
+export function waitForRemoteRuntimeRequestReady(
+  waiters: RemoteRuntimeRequestReadyWaiter[]
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    waiters.push({ resolve, reject })
+  })
+}
+
+export function resolveRemoteRuntimeRequestReadyWaiters(
+  waiters: RemoteRuntimeRequestReadyWaiter[]
+): void {
+  for (const waiter of waiters.splice(0)) {
+    waiter.resolve()
+  }
+}
+
+export function rejectRemoteRuntimeRequestReadyWaiters(
+  waiters: RemoteRuntimeRequestReadyWaiter[],
+  error: Error
+): void {
+  for (const waiter of waiters.splice(0)) {
+    waiter.reject(error)
+  }
+}

--- a/src/shared/remote-runtime-shared-control-admission.ts
+++ b/src/shared/remote-runtime-shared-control-admission.ts
@@ -1,0 +1,53 @@
+import { RemoteRuntimeClientError } from './remote-runtime-client-error'
+import {
+  measureRemoteRuntimeSubscriptionParams,
+  REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES,
+  REMOTE_RUNTIME_MAX_SUBSCRIPTIONS,
+  serializeRemoteRuntimeRpcRequest
+} from './remote-runtime-memory-limits'
+import type { SharedControlLogicalSubscription } from './remote-runtime-shared-control-types'
+
+export function admitSharedControlSubscription(args: {
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+  deviceToken: string
+  method: string
+  params: unknown
+}): number {
+  if (args.subscriptions.size >= REMOTE_RUNTIME_MAX_SUBSCRIPTIONS) {
+    throw new RemoteRuntimeClientError(
+      'remote_runtime_busy',
+      'Remote runtime subscription limit reached; close a subscription and retry.'
+    )
+  }
+  const retainedParamsBytes = measureRemoteRuntimeSubscriptionParams(args.params)
+  if (
+    retainedSubscriptionBytes(args.subscriptions) + retainedParamsBytes >
+    REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES
+  ) {
+    throw new RemoteRuntimeClientError(
+      'remote_runtime_busy',
+      'Remote runtime subscription memory limit reached; close a subscription and retry.'
+    )
+  }
+  serializeRequest(args)
+  return retainedParamsBytes
+}
+
+function serializeRequest(args: { deviceToken: string; method: string; params: unknown }): void {
+  serializeRemoteRuntimeRpcRequest({
+    requestId: '00000000-0000-4000-8000-000000000000',
+    deviceToken: args.deviceToken,
+    method: args.method,
+    params: args.params
+  })
+}
+
+function retainedSubscriptionBytes(
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+): number {
+  let bytes = 0
+  for (const subscription of subscriptions.values()) {
+    bytes += subscription.retainedParamsBytes
+  }
+  return bytes
+}

--- a/src/shared/ssh-retained-payload-admission.test.ts
+++ b/src/shared/ssh-retained-payload-admission.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import { getUtf8ByteLength } from './utf8-byte-limits'
+import {
+  admitSshConnectionState,
+  admitSshDetectedPorts,
+  SSH_CONNECTION_ERROR_MAX_UTF8_BYTES,
+  SSH_DETECTED_PORTS_MAX_ENTRIES,
+  SSH_DETECTED_PORT_ADVERTISED_URL_MAX_UTF8_BYTES,
+  SSH_DETECTED_PORT_PROCESS_NAME_MAX_UTF8_BYTES,
+  SSH_RETAINED_IDENTIFIER_MAX_UTF8_BYTES
+} from './ssh-retained-payload-admission'
+
+describe('SSH retained payload admission', () => {
+  it('keeps ordinary connection state while stripping unknown payload fields', () => {
+    const admitted = admitSshConnectionState(
+      {
+        targetId: 'ssh-a',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 2,
+        connectionGeneration: 3,
+        supportsFolderDownload: true,
+        remotePlatform: 'linux',
+        unexpected: 'x'.repeat(1024)
+      },
+      'ssh-a'
+    )
+
+    expect(admitted).toEqual({
+      targetId: 'ssh-a',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 2,
+      connectionGeneration: 3,
+      supportsFolderDownload: true,
+      remotePlatform: 'linux'
+    })
+  })
+
+  it('caps connection errors without splitting a UTF-8 code point', () => {
+    const admitted = admitSshConnectionState(
+      {
+        targetId: 'ssh-a',
+        status: 'error',
+        error: `${'x'.repeat(SSH_CONNECTION_ERROR_MAX_UTF8_BYTES - 1)}🙂tail`,
+        reconnectAttempt: 0
+      },
+      'ssh-a'
+    )
+
+    expect(admitted).not.toBeNull()
+    expect(getUtf8ByteLength(admitted?.error ?? '')).toBeLessThanOrEqual(
+      SSH_CONNECTION_ERROR_MAX_UTF8_BYTES
+    )
+    expect(admitted?.error?.endsWith('\ud83d')).toBe(false)
+  })
+
+  it('rejects mismatched and oversized target identifiers', () => {
+    const state = {
+      targetId: 'ssh-a',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    }
+
+    expect(admitSshConnectionState(state, 'ssh-b')).toBeNull()
+    expect(
+      admitSshConnectionState(
+        { ...state, targetId: 'x'.repeat(SSH_RETAINED_IDENTIFIER_MAX_UTF8_BYTES + 1) },
+        'x'.repeat(SSH_RETAINED_IDENTIFIER_MAX_UTF8_BYTES + 1)
+      )
+    ).toBeNull()
+  })
+
+  it('caps port rows and their retained strings', () => {
+    const rows = Array.from({ length: SSH_DETECTED_PORTS_MAX_ENTRIES + 10 }, (_, index) => ({
+      port: 1000 + index,
+      host: '127.0.0.1',
+      pid: index + 1,
+      processName: '🙂'.repeat(SSH_DETECTED_PORT_PROCESS_NAME_MAX_UTF8_BYTES),
+      advertisedUrl: `https://example.test/${'x'.repeat(
+        SSH_DETECTED_PORT_ADVERTISED_URL_MAX_UTF8_BYTES
+      )}`,
+      unexpected: 'retained only without admission'
+    }))
+
+    const admitted = admitSshDetectedPorts(rows)
+
+    expect(admitted).toHaveLength(SSH_DETECTED_PORTS_MAX_ENTRIES)
+    expect(getUtf8ByteLength(admitted[0].processName ?? '')).toBeLessThanOrEqual(
+      SSH_DETECTED_PORT_PROCESS_NAME_MAX_UTF8_BYTES
+    )
+    expect(admitted[0].advertisedUrl).toBeUndefined()
+    expect(admitted[0]).not.toHaveProperty('unexpected')
+  })
+
+  it('drops malformed rows instead of retaining their payloads', () => {
+    expect(
+      admitSshDetectedPorts([
+        { port: 0, host: '127.0.0.1' },
+        { port: 3000, host: '' },
+        { port: 3001, host: '127.0.0.1', processName: 'node' }
+      ])
+    ).toEqual([{ port: 3001, host: '127.0.0.1', processName: 'node' }])
+  })
+})

--- a/src/shared/ssh-retained-payload-admission.ts
+++ b/src/shared/ssh-retained-payload-admission.ts
@@ -1,0 +1,138 @@
+import type { EnrichedDetectedPort, SshConnectionState, SshConnectionStatus } from './ssh-types'
+import { clampUtf8TextPrefix, measureUtf8ByteLength } from './utf8-byte-limits'
+
+export const SSH_RETAINED_IDENTIFIER_MAX_UTF8_BYTES = 1024
+export const SSH_CONNECTION_ERROR_MAX_UTF8_BYTES = 16 * 1024
+export const SSH_CREDENTIAL_DETAIL_MAX_UTF8_BYTES = 16 * 1024
+export const SSH_DETECTED_PORTS_MAX_ENTRIES = 50
+export const SSH_DETECTED_PORT_HOST_MAX_UTF8_BYTES = 1024
+export const SSH_DETECTED_PORT_PROCESS_NAME_MAX_UTF8_BYTES = 4 * 1024
+export const SSH_DETECTED_PORT_ADVERTISED_URL_MAX_UTF8_BYTES = 2048
+
+const CONNECTION_STATUSES = new Set<SshConnectionStatus>([
+  'disconnected',
+  'connecting',
+  'auth-failed',
+  'deploying-relay',
+  'connected',
+  'reconnecting',
+  'reconnection-failed',
+  'error'
+])
+
+export function isSshRetainedIdentifier(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    !measureUtf8ByteLength(value, {
+      stopAfterBytes: SSH_RETAINED_IDENTIFIER_MAX_UTF8_BYTES
+    }).exceededLimit
+  )
+}
+
+export function admitSshConnectionState(
+  value: unknown,
+  expectedTargetId: string
+): SshConnectionState | null {
+  if (!value || typeof value !== 'object' || !isSshRetainedIdentifier(expectedTargetId)) {
+    return null
+  }
+  const input = value as Record<string, unknown>
+  if (
+    (input.targetId !== undefined &&
+      (!isSshRetainedIdentifier(input.targetId) || input.targetId !== expectedTargetId)) ||
+    typeof input.status !== 'string' ||
+    !CONNECTION_STATUSES.has(input.status as SshConnectionStatus) ||
+    !isNonNegativeSafeInteger(input.reconnectAttempt) ||
+    (input.error !== null && typeof input.error !== 'string')
+  ) {
+    return null
+  }
+
+  const error = clampSshConnectionError(input.error)
+  return {
+    targetId: expectedTargetId,
+    status: input.status as SshConnectionStatus,
+    error,
+    reconnectAttempt: input.reconnectAttempt,
+    ...(isNonNegativeSafeInteger(input.connectionGeneration)
+      ? { connectionGeneration: input.connectionGeneration }
+      : {}),
+    ...(typeof input.supportsFolderDownload === 'boolean'
+      ? { supportsFolderDownload: input.supportsFolderDownload }
+      : {}),
+    ...(input.remotePlatform === 'linux' ||
+    input.remotePlatform === 'darwin' ||
+    input.remotePlatform === 'win32'
+      ? { remotePlatform: input.remotePlatform }
+      : {})
+  }
+}
+
+export function clampSshConnectionError(error: string | null): string | null {
+  return typeof error === 'string'
+    ? clampUtf8TextPrefix(error, SSH_CONNECTION_ERROR_MAX_UTF8_BYTES)
+    : null
+}
+
+export function admitSshDetectedPorts(value: unknown): EnrichedDetectedPort[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const retained: EnrichedDetectedPort[] = []
+  const scanLimit = Math.min(value.length, SSH_DETECTED_PORTS_MAX_ENTRIES)
+  for (let index = 0; index < scanLimit; index += 1) {
+    const port = admitDetectedPort(value[index])
+    if (port) {
+      retained.push(port)
+    }
+  }
+  return retained
+}
+
+function admitDetectedPort(value: unknown): EnrichedDetectedPort | null {
+  if (!value || typeof value !== 'object') {
+    return null
+  }
+  const input = value as Record<string, unknown>
+  if (
+    !Number.isSafeInteger(input.port) ||
+    (input.port as number) < 1 ||
+    (input.port as number) > 65_535 ||
+    !isStringWithinLimit(input.host, SSH_DETECTED_PORT_HOST_MAX_UTF8_BYTES)
+  ) {
+    return null
+  }
+  const processName =
+    typeof input.processName === 'string'
+      ? clampUtf8TextPrefix(input.processName, SSH_DETECTED_PORT_PROCESS_NAME_MAX_UTF8_BYTES)
+      : undefined
+  const advertisedUrl = isStringWithinLimit(
+    input.advertisedUrl,
+    SSH_DETECTED_PORT_ADVERTISED_URL_MAX_UTF8_BYTES
+  )
+    ? input.advertisedUrl
+    : undefined
+  return {
+    port: input.port as number,
+    host: input.host,
+    ...(isNonNegativeSafeInteger(input.pid) && input.pid > 0 ? { pid: input.pid } : {}),
+    ...(processName ? { processName } : {}),
+    ...(advertisedUrl ? { advertisedUrl } : {}),
+    ...(input.advertisedProtocol === 'http' || input.advertisedProtocol === 'https'
+      ? { advertisedProtocol: input.advertisedProtocol }
+      : {})
+  }
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0
+}
+
+function isStringWithinLimit(value: unknown, maxBytes: number): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    !measureUtf8ByteLength(value, { stopAfterBytes: maxBytes }).exceededLimit
+  )
+}


### PR DESCRIPTION
## OOM hardening slice 04/29 — bound shared remote-runtime/relay admission

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **04/29** (base: `oom/03-a3-shared-fs-listing`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Adds 8 new self-contained shared modules that impose count/byte/depth admission ceilings on relay JSON parsing, relay .version marker reads, remote-runtime pending RPC requests/subscriptions, and retained SSH connection-state/port-forward payloads. No existing callers are modified in this slice, so the code is inert until wired by other slices; the two included tests exercise boundary behavior.

### ELI5
Imagine bouncers added at several doors of the app that talk to remote/SSH machines. Each bouncer counts how many requests are waiting, how big they are, and throws away junk fields or oversized text before it piles up in memory. This PR only installs the bouncers (as reusable helpers) and their unit tests; nothing else changed, so ordinary users see no difference unless a remote machine floods the app with abnormally large or numerous payloads.

### Proof of OOM fix
- relay-json-admission.ts: RELAY_JSON_MAX_STRUCTURAL_TOKENS=1,000,000 and RELAY_JSON_MAX_NESTING_DEPTH=128 gate every relay JSON.parse via assertJsonTextStructureWithinLimits
- relay-version-marker.ts: RELAY_VERSION_MARKER_MAX_BYTES=4KiB caps the .version file read; tested at exact boundary (accept) and +1 byte (throws NodeFileReadTooLargeError) in relay-version-marker.test.ts
- remote-runtime-memory-limits.ts (dep): MAX_PENDING_REQUESTS=256, MAX_PENDING_RPC_BYTES=32MiB, process-level = 2x (512 reqs / 64MiB); enforced in remote-runtime-prepared-request-admission.ts prepare/reserve
- remote-runtime-shared-control-admission.ts: MAX_SUBSCRIPTIONS=256 and MAX_RETAINED_SUBSCRIPTION_BYTES=16MiB gate subscription admission
- ssh-retained-payload-admission.ts: SSH_DETECTED_PORTS_MAX_ENTRIES=50, CONNECTION_ERROR=16KiB, IDENTIFIER=1KiB, PROCESS_NAME=4KiB, ADVERTISED_URL=2KiB; tests in ssh-retained-payload-admission.test.ts cover row cap, UTF-8-safe clamping (no split code point), identifier mismatch/oversize rejection, malformed-row drops

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **low**: admitSshConnectionState whitelists fields: unknown/extra properties are stripped and optional fields (connectionGeneration, supportsFolderDownload, remotePlatform) are dropped unless they pass type checks. Callers that previously forwarded extra fields would no longer round-trip them. _(trigger: Only once callers in other slices route SSH connection state through this admitter, and only for payloads carrying fields outside the known schema.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- prepareRemoteRuntimeRequest throws 'remote_runtime_busy' only past 256 pending client requests or 512 process-wide, or when retained bytes would exceed 32MiB/64MiB — far above ordinary concurrent RPC counts
- admitSharedControlSubscription throws 'remote_runtime_busy' only past 256 live subscriptions or 16MiB retained params
- admitSshDetectedPorts scans only the first 50 rows (Math.min(length,50)); ports beyond index 50 are never examined — far above typical forwarded-port counts
- relay JSON with >1M structural tokens or >128 nesting depth is rejected instead of parsed — only reachable with pathological/abusive payloads
- SSH detected-port rows are validated: rows with port<1/>65535 or empty/oversized host are dropped, and advertisedUrl exceeding 2KiB is discarded (undefined) rather than shown. Malformed or oversized-URL rows stop surfacing. _(only when: Only when a port-forward advertises an anomalously long URL or malformed row, and once callers adopt admitSshDetectedPorts.)_

### Build / CI
- Part of the **Shared foundation** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #06** (whole-repo interconnection — see stack README). Content is exact production code.

### Adversarial review
- 1 skeptic lens(es). Sign-off: **yes**. Residual risk: **low**.
- Slice adds 8 new self-contained shared modules under src/shared/. Within THIS slice no callers are modified (the wiring lives in other slices), so the code is inert until wired; I confirmed the caller files exist at TARGET but are outside this filelist. I verified every numeric ceiling is far above ordinary use, refuting the possibility of a normal-path regression:\n\n- relay-json-admission.ts: RELAY_JSON_MAX_STRUCTURAL_TOKENS=1,000,000 and RELAY_JSON_MAX_NESTING_DEPTH=128. A structural token is each of {}[],: (json-text-structure-limit.ts); ~8 tokens per file/list entry means ~125k array elements are needed to trip the cap. Only pathological/abusive relay payloads reach it. Depth 128 is non-pathological JSON. OVERLOAD-ONLY.\n- relay-version-marker.ts: RELAY_VERSION_MARKER_MAX_BYTES=4KiB for a version-string marker file — enormous headroom.\n- remote-runtime-prepared-request-admission.ts: 256 pending/connection, 512 process-wide; 32MiB/64MiB retained. Ordinary concurrent RPC counts are tiny. Admission Set is a module-level global (process-wide by design; MAX_PROCESS_*=2x per-connection), released via returned closure + releaseRemoteRuntimePreparedRequest (both null out retainedBytes and delete from the Set) — no leak on normal or error path. OVERLOAD-ONLY.\n- remote-runtime-shared-control-admission.ts: 256 subscriptions / 16MiB retained params — far above normal. OVERLOAD-ONLY.\n- remote-runtime-request-ready-waiters.ts: plain waiter list with splice-based drain on resolve/reject; no bound logic itself, no regression.\n- ssh-retained-payload-admission.ts: CONNECTION_STATUSES set matches the SshConnectionStatus union exactly (all 8 values) and the whitelisted output fields match SshConnectionState exactly (targetId/status/error/reconnectAttempt + optional connectionGeneration/supportsFolderDownload/remotePlatform), so no valid status or documented field is dropped — only genuinely unknown/extra fields are stripped. Clamps: connection error 16KiB, host 1KiB, processName 4KiB, advertisedUrl 2KiB, 50 detected-port rows — all far above realistic SSH values (hosts like 127.0.0.1, short banner URLs, few dev ports).\n\nTests confirm boundary behavior: ssh-retained-payload-admission.test.ts checks unknown-field stripping, UTF-8-safe error clamping (no split code point), targetId mismatch/oversize rejection, port-row cap at SSH_DETECTED_PORTS_MAX_ENTRIES, and dropping malformed rows. relay-version-marker.test.ts covers the marker read/limit.\n\nNo confirmed normal-path regression or correctness bug; signoff=true. The two low-severity notes above are by-design bounds worth a human glance but do not affect ordinary users.

### Files
8 files changed (+510 / −0).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
