### PR TITLE
oom(09/29): bound git/worktree/persistence/repo/usage state

### DIFF
--- a/src/main/active-view-preference.test.ts
+++ b/src/main/active-view-preference.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ActiveViewPreference, getActiveViewPreferenceFile } from './active-view-preference'
+import {
+  ActiveViewPreference,
+  getActiveViewPreferenceFile,
+  MAX_ACTIVE_VIEW_PREFERENCE_FILE_BYTES
+} from './active-view-preference'
 
 describe('ActiveViewPreference', () => {
   let dir: string
@@ -87,5 +91,13 @@ describe('ActiveViewPreference', () => {
     expect(preference.get()).toBe('tasks')
     expect(preference.set('__proto__')).toBe(false)
     expect(preference.get()).toBe('tasks')
+  })
+
+  it('falls back without loading an oversized sparse sidecar', () => {
+    const preferenceFile = getActiveViewPreferenceFile(dataFile)
+    writeFileSync(preferenceFile, '{"activeView":"settings"}', 'utf-8')
+    truncateSync(preferenceFile, MAX_ACTIVE_VIEW_PREFERENCE_FILE_BYTES + 1)
+
+    expect(new ActiveViewPreference(dataFile, 'tasks').get()).toBe('tasks')
   })
 })

--- a/src/main/active-view-preference.ts
+++ b/src/main/active-view-preference.ts
@@ -1,11 +1,13 @@
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { mkdirSync, renameSync, writeFileSync } from 'node:fs'
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
 import type { TopLevelView } from '../shared/types'
 import { isTopLevelView } from '../shared/top-level-view'
 
 const ACTIVE_VIEW_FILE_NAME = 'active-view.json'
 const SAVE_DEBOUNCE_MS = 100
+export const MAX_ACTIVE_VIEW_PREFERENCE_FILE_BYTES = 4 * 1024
 
 type ActiveViewFile = {
   activeView: TopLevelView
@@ -17,7 +19,11 @@ export function getActiveViewPreferenceFile(dataFile: string): string {
 
 function readActiveView(file: string): TopLevelView | null {
   try {
-    const parsed = JSON.parse(readFileSync(file, 'utf-8')) as Partial<ActiveViewFile>
+    const parsed = JSON.parse(
+      readNodeFileSyncWithinLimit(file, MAX_ACTIVE_VIEW_PREFERENCE_FILE_BYTES).buffer.toString(
+        'utf8'
+      )
+    ) as Partial<ActiveViewFile>
     return isTopLevelView(parsed.activeView) ? parsed.activeView : null
   } catch {
     return null

--- a/src/main/attribution/terminal-attribution-bounds.test.ts
+++ b/src/main/attribution/terminal-attribution-bounds.test.ts
@@ -1,0 +1,178 @@
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE,
+  ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES,
+  ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES,
+  applyTerminalAttributionEnv
+} from './terminal-attribution'
+
+const roots: string[] = []
+const posixIt = process.platform === 'win32' ? it.skip : it
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-attribution-bounds-'))
+  roots.push(root)
+  return root
+}
+
+function attributionEnv(root: string, binDir: string): Record<string, string> {
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` }
+  applyTerminalAttributionEnv(env as Record<string, string>, {
+    enabled: true,
+    userDataPath: join(root, 'user-data')
+  })
+  return env as Record<string, string>
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('terminal attribution payload bounds', () => {
+  posixIt('accepts a commit message file at the exact byte boundary', () => {
+    const root = makeRoot()
+    const binDir = join(root, 'bin')
+    const messagePath = join(root, 'message.txt')
+    const receivedPath = join(root, 'received-message.txt')
+    mkdirSync(binDir)
+    writeFileSync(messagePath, 'm'.repeat(ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES))
+    writeFileSync(
+      join(binDir, 'git'),
+      `#!/usr/bin/env bash
+set -euo pipefail
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "-F" || "$1" == "--file" ]]; then
+    cp "$2" "${receivedPath}"
+    exit 0
+  fi
+  shift
+done
+exit 2
+`
+    )
+    chmodSync(join(binDir, 'git'), 0o755)
+
+    const result = spawnSync('git', ['commit', '-F', messagePath], {
+      encoding: 'utf8',
+      env: attributionEnv(root, binDir)
+    })
+
+    expect(result.status).toBe(0)
+    expect(readFileSync(receivedPath, 'utf8')).toBe(
+      `${'m'.repeat(ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES)}\n\nCo-authored-by: Orca <help@stably.ai>\n`
+    )
+  })
+
+  posixIt('rejects a sparse commit message file one byte over the boundary', () => {
+    const root = makeRoot()
+    const binDir = join(root, 'bin')
+    const messagePath = join(root, 'message.txt')
+    const calledPath = join(root, 'git-called')
+    mkdirSync(binDir)
+    writeFileSync(messagePath, 'm')
+    truncateSync(messagePath, ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES + 1)
+    writeFileSync(
+      join(binDir, 'git'),
+      `#!/usr/bin/env bash
+touch "${calledPath}"
+exit 0
+`
+    )
+    chmodSync(join(binDir, 'git'), 0o755)
+
+    const result = spawnSync('git', ['commit', '-F', messagePath], {
+      encoding: 'utf8',
+      env: attributionEnv(root, binDir)
+    })
+
+    expect(result.status).toBe(ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE)
+    expect(result.stderr).toContain(
+      `${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES + 1} bytes exceeds the ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}-byte limit`
+    )
+    expect(existsSync(calledPath)).toBe(false)
+  })
+
+  posixIt('preserves gh output at the exact byte boundary', () => {
+    const root = makeRoot()
+    const binDir = join(root, 'bin')
+    const payloadPath = join(root, 'gh-output.txt')
+    mkdirSync(binDir)
+    writeFileSync(payloadPath, 'o'.repeat(ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES))
+    writeFileSync(
+      join(binDir, 'gh'),
+      `#!/usr/bin/env bash
+cat "${payloadPath}"
+`
+    )
+    chmodSync(join(binDir, 'gh'), 0o755)
+
+    const result = spawnSync('gh', ['pr', 'create', '--fill'], {
+      encoding: 'utf8',
+      env: attributionEnv(root, binDir),
+      maxBuffer: ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES + 64 * 1024
+    })
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('o'.repeat(ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES))
+    expect(result.stderr).toBe('')
+  })
+
+  posixIt('fails clearly when gh output is one byte over the boundary', () => {
+    const root = makeRoot()
+    const binDir = join(root, 'bin')
+    const payloadPath = join(root, 'gh-output.txt')
+    mkdirSync(binDir)
+    writeFileSync(payloadPath, 'o'.repeat(ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES + 1))
+    writeFileSync(
+      join(binDir, 'gh'),
+      `#!/usr/bin/env bash
+cat "${payloadPath}"
+`
+    )
+    chmodSync(join(binDir, 'gh'), 0o755)
+
+    const result = spawnSync('gh', ['pr', 'create', '--fill'], {
+      encoding: 'utf8',
+      env: attributionEnv(root, binDir)
+    })
+
+    expect(result.status).toBe(ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toContain(
+      `${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES + 1} bytes exceeds the ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}-byte limit`
+    )
+  })
+
+  it('emits inclusive PowerShell byte boundaries for commit files and gh captures', () => {
+    const root = makeRoot()
+    applyTerminalAttributionEnv(
+      { PATH: process.env.PATH ?? '' },
+      { enabled: true, userDataPath: join(root, 'user-data') }
+    )
+    const shimDir = join(root, 'user-data', 'orca-terminal-attribution', 'win32')
+    const gitWrapper = readFileSync(join(shimDir, 'git-wrapper.ps1'), 'utf8')
+    const ghWrapper = readFileSync(join(shimDir, 'gh-wrapper.ps1'), 'utf8')
+
+    expect(gitWrapper).toContain('$guard.Length -gt $MaxBytes')
+    expect(gitWrapper).toContain(`'commit message file' ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}`)
+    expect(gitWrapper).toContain(`exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}`)
+    expect(ghWrapper).toContain(`$stdoutBytes -gt ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}`)
+    expect(ghWrapper).toContain(`$stderrBytes -gt ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}`)
+    expect(ghWrapper).toContain(`exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}`)
+  })
+})

--- a/src/main/attribution/terminal-attribution-retention.test.ts
+++ b/src/main/attribution/terminal-attribution-retention.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  _getAttributionWrittenRootCountForTests,
+  _isAttributionWrittenRootRetainableForTests,
+  _resetAttributionWrittenRootsForTests,
+  applyTerminalAttributionEnv,
+  ATTRIBUTION_WRITTEN_ROOT_MAX_BYTES,
+  ATTRIBUTION_WRITTEN_ROOT_MAX_ENTRIES
+} from './terminal-attribution'
+
+let fixtureRoot: string | null = null
+
+afterEach(() => {
+  _resetAttributionWrittenRootsForTests()
+  if (fixtureRoot) {
+    rmSync(fixtureRoot, { recursive: true, force: true })
+    fixtureRoot = null
+  }
+})
+
+describe('terminal attribution root retention', () => {
+  it('bounds successfully ensured roots', () => {
+    fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-attribution-roots-'))
+    for (let index = 0; index <= ATTRIBUTION_WRITTEN_ROOT_MAX_ENTRIES; index += 1) {
+      applyTerminalAttributionEnv(
+        { PATH: process.env.PATH ?? '' },
+        { enabled: true, userDataPath: join(fixtureRoot, String(index)) }
+      )
+    }
+    expect(_getAttributionWrittenRootCountForTests()).toBe(ATTRIBUTION_WRITTEN_ROOT_MAX_ENTRIES)
+  })
+
+  it('measures retained roots by UTF-8 bytes', () => {
+    expect(
+      _isAttributionWrittenRootRetainableForTests('x'.repeat(ATTRIBUTION_WRITTEN_ROOT_MAX_BYTES))
+    ).toBe(true)
+    expect(
+      _isAttributionWrittenRootRetainableForTests(
+        '😀'.repeat(ATTRIBUTION_WRITTEN_ROOT_MAX_BYTES / 4 + 1)
+      )
+    ).toBe(false)
+  })
+})

--- a/src/main/attribution/terminal-attribution.test.ts
+++ b/src/main/attribution/terminal-attribution.test.ts
@@ -6,12 +6,18 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
+  truncateSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { applyTerminalAttributionEnv, resolveAttributionShellFamily } from './terminal-attribution'
+import {
+  ATTRIBUTION_SHIM_VERSION_MAX_BYTES,
+  applyTerminalAttributionEnv,
+  resolveAttributionShellFamily
+} from './terminal-attribution'
 
 describe('applyTerminalAttributionEnv', () => {
   let tmpRoot: string | null = null
@@ -78,6 +84,42 @@ describe('applyTerminalAttributionEnv', () => {
     expect(resolveAttributionShellFamily({ platform: 'win32', isWsl: true })).toBe('posix')
     expect(resolveAttributionShellFamily({ platform: 'darwin', shellPath: '/bin/zsh' })).toBe(
       undefined
+    )
+  })
+
+  it('accepts an attribution version marker at the exact byte boundary', () => {
+    const root = makeTmpRoot()
+    const userDataPath = join(root, 'user-data')
+    const shimRoot = join(userDataPath, 'orca-terminal-attribution')
+    const sentinelPath = join(shimRoot, 'posix', 'git')
+    mkdirSync(join(shimRoot, 'posix'), { recursive: true })
+    mkdirSync(join(shimRoot, 'win32'), { recursive: true })
+    writeFileSync(sentinelPath, 'leave-existing-wrapper')
+    writeFileSync(
+      join(shimRoot, 'VERSION'),
+      `7${' '.repeat(ATTRIBUTION_SHIM_VERSION_MAX_BYTES - 1)}`
+    )
+
+    applyTerminalAttributionEnv({}, { enabled: true, userDataPath })
+
+    expect(readFileSync(sentinelPath, 'utf8')).toBe('leave-existing-wrapper')
+    expect(statSync(join(shimRoot, 'VERSION')).size).toBe(ATTRIBUTION_SHIM_VERSION_MAX_BYTES)
+  })
+
+  it('rebuilds attribution shims for a sparse version marker over the boundary', () => {
+    const root = makeTmpRoot()
+    const userDataPath = join(root, 'user-data')
+    const shimRoot = join(userDataPath, 'orca-terminal-attribution')
+    const versionPath = join(shimRoot, 'VERSION')
+    mkdirSync(shimRoot, { recursive: true })
+    writeFileSync(versionPath, '7')
+    truncateSync(versionPath, ATTRIBUTION_SHIM_VERSION_MAX_BYTES + 1)
+
+    applyTerminalAttributionEnv({}, { enabled: true, userDataPath })
+
+    expect(readFileSync(versionPath, 'utf8')).toBe('7\n')
+    expect(readFileSync(join(shimRoot, 'posix', 'git'), 'utf8')).toContain(
+      'ORCA_GIT_COMMIT_TRAILER'
     )
   })
 

--- a/src/main/attribution/terminal-attribution.ts
+++ b/src/main/attribution/terminal-attribution.ts
@@ -2,12 +2,18 @@
 scripts for both POSIX shells and Windows shells. Keeping the scripts adjacent
 to the env injection code makes the attribution behavior auditable as one unit
 instead of scattering generated shell fragments across files. */
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join, win32 as pathWin32 } from 'node:path'
 import { ORCA_GIT_COMMIT_TRAILER } from '../../shared/orca-attribution'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 const ATTRIBUTION_ROOT_DIR = 'orca-terminal-attribution'
-const ATTRIBUTION_SHIM_VERSION = '6'
+const ATTRIBUTION_SHIM_VERSION = '7'
+export const ATTRIBUTION_SHIM_VERSION_MAX_BYTES = 1024
+export const ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES = 1024 * 1024
+export const ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES = 1024 * 1024
+export const ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE = 74
 const ORCA_PRODUCT_URL = 'https://github.com/stablyai/orca'
 const ORCA_GH_FOOTER = `Made with [Orca](${ORCA_PRODUCT_URL}) 🐋`
 const SHELL_DOLLAR = '$'
@@ -23,6 +29,38 @@ const ATTRIBUTION_ENV_KEYS = [
 ] as const
 
 const writtenRoots = new Set<string>()
+export const ATTRIBUTION_WRITTEN_ROOT_MAX_ENTRIES = 64
+export const ATTRIBUTION_WRITTEN_ROOT_MAX_BYTES = 64 * 1024
+
+function hasWrittenRoot(rootDir: string): boolean {
+  if (!writtenRoots.has(rootDir)) {
+    return false
+  }
+  writtenRoots.delete(rootDir)
+  writtenRoots.add(rootDir)
+  return true
+}
+
+function rememberWrittenRoot(rootDir: string): void {
+  if (!isRetainableWrittenRoot(rootDir)) {
+    return
+  }
+  writtenRoots.delete(rootDir)
+  writtenRoots.add(rootDir)
+  while (writtenRoots.size > ATTRIBUTION_WRITTEN_ROOT_MAX_ENTRIES) {
+    const oldest = writtenRoots.values().next().value
+    if (oldest === undefined) {
+      return
+    }
+    writtenRoots.delete(oldest)
+  }
+}
+
+function isRetainableWrittenRoot(rootDir: string): boolean {
+  return !measureUtf8ByteLength(rootDir, {
+    stopAfterBytes: ATTRIBUTION_WRITTEN_ROOT_MAX_BYTES
+  }).exceededLimit
+}
 
 type AttributionShimPaths = {
   posixDir: string
@@ -155,12 +193,12 @@ function ensureAttributionShims(userDataPath: string): AttributionShimPaths {
   const win32Dir = join(rootDir, 'win32')
   const versionFile = join(rootDir, 'VERSION')
 
-  if (writtenRoots.has(rootDir)) {
+  if (hasWrittenRoot(rootDir)) {
     return { posixDir, win32Dir }
   }
 
   if (readShimVersion(versionFile) === ATTRIBUTION_SHIM_VERSION) {
-    writtenRoots.add(rootDir)
+    rememberWrittenRoot(rootDir)
     return { posixDir, win32Dir }
   }
 
@@ -176,14 +214,28 @@ function ensureAttributionShims(userDataPath: string): AttributionShimPaths {
   writeExecutable(join(win32Dir, 'gh-wrapper.ps1'), WIN32_GH_PS_WRAPPER)
   writeFileSync(versionFile, `${ATTRIBUTION_SHIM_VERSION}\n`, 'utf8')
 
-  writtenRoots.add(rootDir)
+  rememberWrittenRoot(rootDir)
 
   return { posixDir, win32Dir }
 }
 
+export function _resetAttributionWrittenRootsForTests(): void {
+  writtenRoots.clear()
+}
+
+export function _getAttributionWrittenRootCountForTests(): number {
+  return writtenRoots.size
+}
+
+export function _isAttributionWrittenRootRetainableForTests(rootDir: string): boolean {
+  return isRetainableWrittenRoot(rootDir)
+}
+
 function readShimVersion(versionFile: string): string | null {
   try {
-    return readFileSync(versionFile, 'utf8').trim()
+    return readNodeFileSyncWithinLimit(versionFile, ATTRIBUTION_SHIM_VERSION_MAX_BYTES)
+      .buffer.toString('utf8')
+      .trim()
   } catch {
     return null
   }
@@ -346,6 +398,60 @@ has_unsupported_commit_message_source() {
   return 1
 }
 
+validate_commit_message_file_sizes() {
+  local arg source_file byte_count
+  while [[ $# -gt 0 ]]; do
+    arg="$1"
+    source_file=""
+    case "$arg" in
+      -F|--file)
+        shift
+        source_file="${SHELL_DOLLAR}{1:-}"
+        ;;
+      --file=*)
+        source_file="${SHELL_DOLLAR}{arg#--file=}"
+        ;;
+      -F?*)
+        source_file="${SHELL_DOLLAR}{arg:2}"
+        ;;
+    esac
+    if [[ -n "$source_file" && -f "$source_file" ]]; then
+      if ! byte_count="$(
+        LC_ALL=C head -c ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES + 1} <"$source_file" |
+          LC_ALL=C wc -c
+      )"; then
+        printf 'Orca attribution wrapper could not inspect commit message file %q.\n' "$source_file" >&2
+        return 1
+      fi
+      if (( byte_count > ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES} )); then
+        printf 'Orca attribution wrapper refused commit message file %q: %s bytes exceeds the ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}-byte limit.\n' "$source_file" "$byte_count" >&2
+        return 1
+      fi
+    fi
+    shift
+  done
+  return 0
+}
+
+read_bounded_commit_message() {
+  local source_file="$1"
+  local snapshot byte_count
+  snapshot="$(mktemp)"
+  if ! LC_ALL=C head -c ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES + 1} <"$source_file" >"$snapshot"; then
+    rm -f "$snapshot"
+    printf 'Orca attribution wrapper could not read commit message file %q.\n' "$source_file" >&2
+    return 1
+  fi
+  byte_count="$(LC_ALL=C wc -c <"$snapshot")"
+  if (( byte_count > ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES} )); then
+    rm -f "$snapshot"
+    printf 'Orca attribution wrapper refused commit message file %q: more than ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES} bytes.\n' "$source_file" >&2
+    return 1
+  fi
+  cat "$snapshot"
+  rm -f "$snapshot"
+}
+
 message_already_has_trailer() {
   local arg next_arg
   while [[ $# -gt 0 ]]; do
@@ -386,7 +492,13 @@ message_already_has_trailer() {
   return 1
 }
 
-if ! has_explicit_commit_message "$@" || has_unsupported_commit_message_source "$@" || message_already_has_trailer "$@"; then
+if ! has_explicit_commit_message "$@" || has_unsupported_commit_message_source "$@"; then
+  PATH="$real_path" exec "$real_git" "$@"
+fi
+if ! validate_commit_message_file_sizes "$@"; then
+  exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+fi
+if message_already_has_trailer "$@"; then
   PATH="$real_path" exec "$real_git" "$@"
 fi
 
@@ -409,7 +521,10 @@ while [[ $# -gt 0 ]]; do
         source_file="${SHELL_DOLLAR}{1:-}"
         tmp_file="$(mktemp)"
         if [[ -n "$source_file" && -f "$source_file" ]]; then
-          printf '%s\n\n%s\n' "$(cat "$source_file")" "$trailer" >"$tmp_file"
+          if ! source_message="$(read_bounded_commit_message "$source_file")"; then
+            exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+          fi
+          printf '%s\n\n%s\n' "$source_message" "$trailer" >"$tmp_file"
           attributed_args+=("$arg" "$tmp_file")
           replaced_file_message=1
         else
@@ -424,7 +539,10 @@ while [[ $# -gt 0 ]]; do
         source_file="${SHELL_DOLLAR}{arg#--file=}"
         tmp_file="$(mktemp)"
         if [[ -f "$source_file" ]]; then
-          printf '%s\n\n%s\n' "$(cat "$source_file")" "$trailer" >"$tmp_file"
+          if ! source_message="$(read_bounded_commit_message "$source_file")"; then
+            exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+          fi
+          printf '%s\n\n%s\n' "$source_message" "$trailer" >"$tmp_file"
           attributed_args+=("--file=$tmp_file")
           replaced_file_message=1
         else
@@ -439,7 +557,10 @@ while [[ $# -gt 0 ]]; do
         source_file="${SHELL_DOLLAR}{arg:2}"
         tmp_file="$(mktemp)"
         if [[ -f "$source_file" ]]; then
-          printf '%s\n\n%s\n' "$(cat "$source_file")" "$trailer" >"$tmp_file"
+          if ! source_message="$(read_bounded_commit_message "$source_file")"; then
+            exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+          fi
+          printf '%s\n\n%s\n' "$source_message" "$trailer" >"$tmp_file"
           attributed_args+=("-F$tmp_file")
           replaced_file_message=1
         else
@@ -473,6 +594,21 @@ if [[ -z "$real_gh" ]]; then
   echo "Orca attribution wrapper could not locate gh on PATH." >&2
   exit 127
 fi
+
+read_bounded_capture() {
+  local capture_path="$1"
+  local stream_name="$2"
+  local byte_count
+  if ! byte_count="$(LC_ALL=C wc -c <"$capture_path")"; then
+    printf 'Orca attribution wrapper could not inspect gh %s capture.\n' "$stream_name" >&2
+    return 1
+  fi
+  if (( byte_count > ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES} )); then
+    printf 'Orca attribution wrapper refused gh %s capture: %s bytes exceeds the ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}-byte limit.\n' "$stream_name" "$byte_count" >&2
+    return 1
+  fi
+  cat "$capture_path"
+}
 
 append_footer() {
   local kind="$1"
@@ -587,8 +723,15 @@ if [[ "\${1:-}" == "pr" && "\${2:-}" == "create" ]]; then
   else
     status=$?
   fi
-  stdout_capture="$(cat "$stdout_file")"
-  stderr_capture="$(cat "$stderr_file")"
+  capture_overflow=0
+  stdout_capture="$(read_bounded_capture "$stdout_file" stdout)" || capture_overflow=1
+  stderr_capture="$(read_bounded_capture "$stderr_file" stderr)" || capture_overflow=1
+  if [[ $capture_overflow -ne 0 ]]; then
+    cleanup_capture
+    trap - EXIT
+    [[ $status -ne 0 ]] && exit $status
+    exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+  fi
   cat "$stderr_file" >&2
   cat "$stdout_file"
   if [[ $status -eq 0 ]]; then
@@ -621,8 +764,15 @@ if [[ "\${1:-}" == "issue" && "\${2:-}" == "create" ]]; then
   else
     status=$?
   fi
-  stdout_capture="$(cat "$stdout_file")"
-  stderr_capture="$(cat "$stderr_file")"
+  capture_overflow=0
+  stdout_capture="$(read_bounded_capture "$stdout_file" stdout)" || capture_overflow=1
+  stderr_capture="$(read_bounded_capture "$stderr_file" stderr)" || capture_overflow=1
+  if [[ $capture_overflow -ne 0 ]]; then
+    cleanup_capture
+    trap - EXIT
+    [[ $status -ne 0 ]] && exit $status
+    exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+  fi
   cat "$stderr_file" >&2
   cat "$stdout_file"
   if [[ $status -eq 0 ]]; then
@@ -701,6 +851,23 @@ exit /b %ERRORLEVEL%
 const WIN32_GIT_PS_WRAPPER = String.raw`$ErrorActionPreference = 'Stop'
 $realGit = if ($env:ORCA_REAL_GIT) { $env:ORCA_REAL_GIT } else { 'git' }
 $trailer = if ($env:ORCA_GIT_COMMIT_TRAILER) { $env:ORCA_GIT_COMMIT_TRAILER } else { 'Co-authored-by: Orca <help@stably.ai>' }
+
+function Get-OrcaBoundedFileContent {
+  param([string]$Path, [string]$Description, [long]$MaxBytes)
+  $guard = $null
+  try {
+    $guard = [System.IO.File]::Open($Path, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::Read)
+    if ($guard.Length -gt $MaxBytes) {
+      [Console]::Error.WriteLine("Orca attribution wrapper refused $($Description): $($guard.Length) bytes exceeds the $MaxBytes-byte limit.")
+      exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+    }
+    return (Get-Content -LiteralPath $Path -Raw)
+  } finally {
+    if ($null -ne $guard) {
+      $guard.Dispose()
+    }
+  }
+}
 
 if ($args -contains '--dry-run') {
   & $realGit @args
@@ -807,17 +974,17 @@ function Test-CommitMessageHasTrailer {
       }
     } elseif ($arg -eq '-F' -or $arg -eq '--file') {
       $i++
-      if ($i -lt $CommandArgs.Count -and (Test-Path -LiteralPath $CommandArgs[$i]) -and (Get-Content -LiteralPath $CommandArgs[$i] -Raw) -match [Regex]::Escape($trailer)) {
+      if ($i -lt $CommandArgs.Count -and (Test-Path -LiteralPath $CommandArgs[$i]) -and (Get-OrcaBoundedFileContent $CommandArgs[$i] 'commit message file' ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}) -match [Regex]::Escape($trailer)) {
         return $true
       }
     } elseif ($arg.StartsWith('--file=')) {
       $path = $arg.Substring('--file='.Length)
-      if ((Test-Path -LiteralPath $path) -and (Get-Content -LiteralPath $path -Raw) -match [Regex]::Escape($trailer)) {
+      if ((Test-Path -LiteralPath $path) -and (Get-OrcaBoundedFileContent $path 'commit message file' ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}) -match [Regex]::Escape($trailer)) {
         return $true
       }
     } elseif ($arg.StartsWith('-F') -and $arg.Length -gt 2) {
       $path = $arg.Substring(2)
-      if ((Test-Path -LiteralPath $path) -and (Get-Content -LiteralPath $path -Raw) -match [Regex]::Escape($trailer)) {
+      if ((Test-Path -LiteralPath $path) -and (Get-OrcaBoundedFileContent $path 'commit message file' ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}) -match [Regex]::Escape($trailer)) {
         return $true
       }
     }
@@ -840,7 +1007,7 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     $sourceFile = if ($i -lt $args.Count) { $args[$i] } else { '' }
     if ($sourceFile -and (Test-Path -LiteralPath $sourceFile)) {
       $tmpFile = [System.IO.Path]::GetTempFileName()
-      Set-Content -LiteralPath $tmpFile -Value ((Get-Content -LiteralPath $sourceFile -Raw).TrimEnd("${POWERSHELL_TICK}r", "${POWERSHELL_TICK}n") + "${POWERSHELL_TICK}r${POWERSHELL_TICK}n${POWERSHELL_TICK}r${POWERSHELL_TICK}n" + $trailer) -NoNewline
+      Set-Content -LiteralPath $tmpFile -Value ((Get-OrcaBoundedFileContent $sourceFile 'commit message file' ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}).TrimEnd("${POWERSHELL_TICK}r", "${POWERSHELL_TICK}n") + "${POWERSHELL_TICK}r${POWERSHELL_TICK}n${POWERSHELL_TICK}r${POWERSHELL_TICK}n" + $trailer) -NoNewline
       $attributedArgs.Add($arg)
       $attributedArgs.Add($tmpFile)
       $replacedFileMessage = $true
@@ -852,7 +1019,7 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     $sourceFile = $arg.Substring('--file='.Length)
     if (Test-Path -LiteralPath $sourceFile) {
       $tmpFile = [System.IO.Path]::GetTempFileName()
-      Set-Content -LiteralPath $tmpFile -Value ((Get-Content -LiteralPath $sourceFile -Raw).TrimEnd("${POWERSHELL_TICK}r", "${POWERSHELL_TICK}n") + "${POWERSHELL_TICK}r${POWERSHELL_TICK}n${POWERSHELL_TICK}r${POWERSHELL_TICK}n" + $trailer) -NoNewline
+      Set-Content -LiteralPath $tmpFile -Value ((Get-OrcaBoundedFileContent $sourceFile 'commit message file' ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}).TrimEnd("${POWERSHELL_TICK}r", "${POWERSHELL_TICK}n") + "${POWERSHELL_TICK}r${POWERSHELL_TICK}n${POWERSHELL_TICK}r${POWERSHELL_TICK}n" + $trailer) -NoNewline
       $attributedArgs.Add("--file=$tmpFile")
       $replacedFileMessage = $true
     } else {
@@ -862,7 +1029,7 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     $sourceFile = $arg.Substring(2)
     if (Test-Path -LiteralPath $sourceFile) {
       $tmpFile = [System.IO.Path]::GetTempFileName()
-      Set-Content -LiteralPath $tmpFile -Value ((Get-Content -LiteralPath $sourceFile -Raw).TrimEnd("${POWERSHELL_TICK}r", "${POWERSHELL_TICK}n") + "${POWERSHELL_TICK}r${POWERSHELL_TICK}n${POWERSHELL_TICK}r${POWERSHELL_TICK}n" + $trailer) -NoNewline
+      Set-Content -LiteralPath $tmpFile -Value ((Get-OrcaBoundedFileContent $sourceFile 'commit message file' ${ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES}).TrimEnd("${POWERSHELL_TICK}r", "${POWERSHELL_TICK}n") + "${POWERSHELL_TICK}r${POWERSHELL_TICK}n${POWERSHELL_TICK}r${POWERSHELL_TICK}n" + $trailer) -NoNewline
       $attributedArgs.Add("-F$tmpFile")
       $replacedFileMessage = $true
     } else {
@@ -951,6 +1118,21 @@ $stdoutFile = [System.IO.Path]::GetTempFileName()
 $stderrFile = [System.IO.Path]::GetTempFileName()
 & $realGh @args > $stdoutFile 2> $stderrFile
 $status = $LASTEXITCODE
+$stdoutBytes = if (Test-Path -LiteralPath $stdoutFile) { (Get-Item -LiteralPath $stdoutFile).Length } else { 0 }
+$stderrBytes = if (Test-Path -LiteralPath $stderrFile) { (Get-Item -LiteralPath $stderrFile).Length } else { 0 }
+if ($stdoutBytes -gt ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES} -or $stderrBytes -gt ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}) {
+  if ($stdoutBytes -gt ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}) {
+    [Console]::Error.WriteLine("Orca attribution wrapper refused gh stdout capture: $stdoutBytes bytes exceeds the ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}-byte limit.")
+  }
+  if ($stderrBytes -gt ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}) {
+    [Console]::Error.WriteLine("Orca attribution wrapper refused gh stderr capture: $stderrBytes bytes exceeds the ${ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES}-byte limit.")
+  }
+  Remove-Item -LiteralPath $stdoutFile, $stderrFile -Force -ErrorAction SilentlyContinue
+  if ($status -ne 0) {
+    exit $status
+  }
+  exit ${ATTRIBUTION_BOUND_EXCEEDED_EXIT_CODE}
+}
 $stdoutCapture = if (Test-Path -LiteralPath $stdoutFile) { Get-Content -LiteralPath $stdoutFile -Raw } else { '' }
 $stderrCapture = if (Test-Path -LiteralPath $stderrFile) { Get-Content -LiteralPath $stderrFile -Raw } else { '' }
 if ($stderrCapture) {

--- a/src/main/cache-identity-digest.ts
+++ b/src/main/cache-identity-digest.ts
@@ -1,0 +1,11 @@
+import { createHash } from 'node:crypto'
+
+/** Fixed-size identity for long-lived maps whose source fields can be arbitrarily large. */
+export function cacheIdentityDigest(parts: readonly string[]): string {
+  const digest = createHash('sha256')
+  for (const part of parts) {
+    digest.update(`${part.length}:`)
+    digest.update(part)
+  }
+  return digest.digest('base64url')
+}

--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -12,8 +12,13 @@ vi.mock('../win32-utils', async (importOriginal) => {
   return { ...actual, grantDirAclAsync: grantDirAclAsyncMock }
 })
 
-import { CrashReportStore } from './crash-report-store'
+import {
+  CrashReportStore,
+  MAX_CRASH_REPORT_FILE_BYTES,
+  MAX_CRASH_REPORT_JSON_STRUCTURAL_TOKENS
+} from './crash-report-store'
 import type { CrashReportCreateInput } from '../../shared/crash-reporting'
+import * as boundedFileReader from '../../shared/node-bounded-file-reader'
 
 const tempDirs: string[] = []
 
@@ -90,6 +95,46 @@ describe('CrashReportStore', () => {
     await fs.writeFile(filePath, '{ nope', 'utf8')
 
     await expect(store.listRecent()).resolves.toEqual([])
+  })
+
+  it('rejects an oversized sparse report file and recovers with the next report', async () => {
+    const { store, filePath } = await createStore()
+    await fs.writeFile(filePath, 'x')
+    await fs.truncate(filePath, MAX_CRASH_REPORT_FILE_BYTES + 1)
+
+    await expect(store.listRecent()).resolves.toEqual([])
+    await expect(store.record(input('after-oversize'))).resolves.toMatchObject({
+      reason: 'after-oversize'
+    })
+    await expect(store.listRecent()).resolves.toHaveLength(1)
+  })
+
+  it('rejects structurally amplified report JSON before parsing', async () => {
+    const { store, filePath } = await createStore()
+    await fs.writeFile(
+      filePath,
+      `{"reports":[${'0,'.repeat(MAX_CRASH_REPORT_JSON_STRUCTURAL_TOKENS)}0]}`,
+      'utf8'
+    )
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    await expect(store.listRecent()).resolves.toEqual([])
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves prior reports when the next report exceeds the write ceiling', async () => {
+    const { store, filePath } = await createStore()
+    await store.record(input('preserved'))
+    const before = await fs.readFile(filePath, 'utf8')
+    const writeSpy = vi.spyOn(fs, 'writeFile')
+
+    await expect(store.record(input('x'.repeat(MAX_CRASH_REPORT_FILE_BYTES)))).rejects.toThrow(
+      'JSON output exceeds'
+    )
+
+    expect(writeSpy).not.toHaveBeenCalled()
+    await expect(fs.readFile(filePath, 'utf8')).resolves.toBe(before)
   })
 
   it('allows a pending report to reach one terminal status only', async () => {
@@ -179,11 +224,13 @@ describe('CrashReportStore', () => {
       const reloaded = new CrashReportStore(filePath)
       vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
       const readError = Object.assign(new Error('temporary read failure'), { code })
-      const readFileSpy = vi.spyOn(fs, 'readFile').mockRejectedValueOnce(readError)
+      const readSpy = vi
+        .spyOn(boundedFileReader, 'readNodeFileWithinLimit')
+        .mockRejectedValueOnce(readError)
 
       await expect(reloaded.getLatestPending()).resolves.toMatchObject({ id: report.id })
 
-      expect(readFileSpy).toHaveBeenCalledTimes(2)
+      expect(readSpy).toHaveBeenCalledTimes(2)
       if (code === 'EBUSY') {
         expect(grantDirAclAsyncMock).not.toHaveBeenCalled()
       } else {

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -12,8 +12,14 @@ import {
   type CrashReportRecord,
   type CrashReportStatus
 } from '../../shared/crash-reporting'
+import * as boundedFileReader from '../../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
 
 const MAX_REPORTS = 5
+export const MAX_CRASH_REPORT_FILE_BYTES = 4 * 1024 * 1024
+export const MAX_CRASH_REPORT_JSON_STRUCTURAL_TOKENS = 1_000_000
+export const MAX_CRASH_REPORT_JSON_NESTING_DEPTH = 128
 const RELATED_CRASH_WINDOW_MS = 5_000
 const WINDOWS_FILE_OPERATION_RETRY_DELAYS_MS = [50, 100, 150, 200, 250]
 
@@ -202,8 +208,18 @@ export class CrashReportStore {
     try {
       const raw = await runCrashReportFileOperationWithWindowsRecovery(
         path.dirname(this.filePath),
-        () => fs.readFile(this.filePath, 'utf8')
+        async () =>
+          (
+            await boundedFileReader.readNodeFileWithinLimit(
+              this.filePath,
+              MAX_CRASH_REPORT_FILE_BYTES
+            )
+          ).buffer.toString('utf8')
       )
+      assertJsonTextStructureWithinLimits(raw, {
+        structuralTokens: MAX_CRASH_REPORT_JSON_STRUCTURAL_TOKENS,
+        nestingDepth: MAX_CRASH_REPORT_JSON_NESTING_DEPTH
+      })
       const parsed = JSON.parse(raw) as Partial<CrashReportFile>
       return Array.isArray(parsed.reports) ? parsed.reports.slice(0, MAX_REPORTS) : []
     } catch (error) {
@@ -219,8 +235,13 @@ export class CrashReportStore {
     const tmpPath = `${this.filePath}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`
     try {
       await runCrashReportFileOperationWithWindowsRecovery(directory, async () => {
+        const { serialized } = stringifyJsonWithinByteLimit(
+          { reports },
+          MAX_CRASH_REPORT_FILE_BYTES - Buffer.byteLength(os.EOL),
+          2
+        )
         await fs.mkdir(directory, { recursive: true })
-        await fs.writeFile(tmpPath, `${JSON.stringify({ reports }, null, 2)}${os.EOL}`, 'utf8')
+        await fs.writeFile(tmpPath, `${serialized}${os.EOL}`, 'utf8')
         await fs.rename(tmpPath, this.filePath)
       })
     } finally {

--- a/src/main/diagnostics/main-thread-churn-probe.test.ts
+++ b/src/main/diagnostics/main-thread-churn-probe.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   MAIN_THREAD_DIAGNOSTICS_ENV,
+  SUBPROCESS_SPAWN_STATS_MAX_ENTRIES,
   classifySubprocessCommand,
   drainSubprocessSpawnStats,
   isMainThreadDiagnosticsEnabled,
@@ -70,5 +71,23 @@ describe('recordSubprocessSpawn', () => {
       'git rev-list': { count: 1, blockMsTotal: 1.5, blockMsMax: 1.5 }
     })
     expect(drainSubprocessSpawnStats()).toEqual({})
+  })
+
+  it('bounds unique diagnostic buckets and aggregates overflow', () => {
+    vi.stubEnv(MAIN_THREAD_DIAGNOSTICS_ENV, '1')
+    for (let index = 0; index < 200; index += 1) {
+      recordSubprocessSpawn(`tool-${index}`, [], 1)
+    }
+
+    const drained = drainSubprocessSpawnStats()
+    expect(Object.keys(drained)).toHaveLength(SUBPROCESS_SPAWN_STATS_MAX_ENTRIES)
+    expect(drained.other).toEqual({ count: 73, blockMsTotal: 73, blockMsMax: 1 })
+  })
+
+  it('materializes a bounded binary bucket from an oversized command path', () => {
+    const command = `/tmp/${'x'.repeat(1024 * 1024)}`
+    const classified = classifySubprocessCommand(command, [])
+    expect(classified).toHaveLength(64)
+    expect(classified).toBe('x'.repeat(64))
   })
 })

--- a/src/main/diagnostics/main-thread-churn-probe.ts
+++ b/src/main/diagnostics/main-thread-churn-probe.ts
@@ -8,6 +8,9 @@ export const MAIN_THREAD_DIAGNOSTICS_ENV = 'ORCA_MAIN_THREAD_DIAGNOSTICS'
 // reported in issue #7576.
 const TICK_MS = 25
 const REPORT_EVERY_MS = 5_000
+const SUBPROCESS_BINARY_NAME_MAX_CHARS = 64
+export const SUBPROCESS_SPAWN_STATS_MAX_ENTRIES = 128
+const SUBPROCESS_SPAWN_STATS_OVERFLOW_KEY = 'other'
 
 export function isMainThreadDiagnosticsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return env[MAIN_THREAD_DIAGNOSTICS_ENV] === '1'
@@ -30,32 +33,39 @@ const SUBCOMMAND_BINARIES = new Set(['git', 'gh', 'glab'])
 // Split on both separators so Windows-style paths classify correctly even
 // when the classifier itself runs in a posix test environment.
 function binaryName(command: string): string {
-  const leaf = command.split(/[\\/]/).pop() ?? command
-  return leaf.replace(/\.exe$/i, '').toLowerCase()
+  const slash = command.lastIndexOf('/')
+  const backslash = command.lastIndexOf('\\')
+  const leaf = command.slice(
+    Math.max(slash, backslash) + 1,
+    Math.max(slash, backslash) + 1 + SUBPROCESS_BINARY_NAME_MAX_CHARS
+  )
+  return leaf
+    .replace(/\.exe$/i, '')
+    .toLowerCase()
+    .replace(/$/u, '')
 }
 
 export function classifySubprocessCommand(command: string, args: readonly string[]): string {
   let binary = binaryName(command)
-  const rest = [...args]
+  let firstArgIndex = 0
   if (binary === 'wsl') {
-    while (rest.length > 0) {
-      const arg = rest.shift()
-      if (arg === '--') {
-        break
-      }
+    const separatorIndex = args.indexOf('--')
+    if (separatorIndex < 0) {
+      return 'wsl'
     }
-    const unwrapped = rest.shift()
+    const unwrapped = args[separatorIndex + 1]
     if (!unwrapped) {
       return 'wsl'
     }
     binary = binaryName(unwrapped)
+    firstArgIndex = separatorIndex + 2
   }
   if (!SUBCOMMAND_BINARIES.has(binary)) {
     return binary
   }
   let subcommand: string | null = null
-  for (let i = 0; i < rest.length; i++) {
-    const arg = rest[i]
+  for (let i = firstArgIndex; i < args.length; i++) {
+    const arg = args[i]
     if (!arg.startsWith('-')) {
       subcommand = arg
       break
@@ -69,7 +79,7 @@ export function classifySubprocessCommand(command: string, args: readonly string
   if (!subcommand) {
     return binary
   }
-  return `${binary} ${subcommand.slice(0, 40)}`
+  return `${binary} ${subcommand.slice(0, 40).replace(/$/u, '')}`
 }
 
 export type SubprocessSpawnStats = {
@@ -95,7 +105,12 @@ export function recordSubprocessSpawn(
   if (!isMainThreadDiagnosticsEnabled()) {
     return
   }
-  const key = classifySubprocessCommand(command, args)
+  const classifiedKey = classifySubprocessCommand(command, args)
+  const key =
+    spawnStatsByCommand.has(classifiedKey) ||
+    spawnStatsByCommand.size < SUBPROCESS_SPAWN_STATS_MAX_ENTRIES - 1
+      ? classifiedKey
+      : SUBPROCESS_SPAWN_STATS_OVERFLOW_KEY
   const stats = spawnStatsByCommand.get(key)
   if (stats) {
     stats.count++

--- a/src/main/filesystem-provider-bounded-text.test.ts
+++ b/src/main/filesystem-provider-bounded-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IFilesystemProvider } from './providers/types'
+import { readFilesystemProviderBoundedText } from './filesystem-provider-bounded-text'
+
+const limits = { maxBytes: 8, maxCodeUnits: 8 }
+
+function provider(args: {
+  size: number
+  content?: string
+  isBinary?: boolean
+}): IFilesystemProvider {
+  return {
+    stat: vi.fn().mockResolvedValue({
+      size: args.size,
+      type: 'file',
+      mtime: 0
+    }),
+    readFile: vi.fn().mockResolvedValue({
+      content: args.content ?? '',
+      isBinary: args.isBinary ?? false
+    })
+  } as unknown as IFilesystemProvider
+}
+
+describe('readFilesystemProviderBoundedText', () => {
+  it('reads a file at the exact byte boundary', async () => {
+    const fsProvider = provider({ size: limits.maxBytes, content: '12345678' })
+
+    await expect(
+      readFilesystemProviderBoundedText(fsProvider, '/repo/orca.yaml', limits)
+    ).resolves.toEqual({ kind: 'text', content: '12345678' })
+    expect(fsProvider.readFile).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a +1 stat before remote materialization', async () => {
+    const fsProvider = provider({ size: limits.maxBytes + 1, content: 'not read' })
+
+    await expect(
+      readFilesystemProviderBoundedText(fsProvider, '/repo/orca.yaml', limits)
+    ).resolves.toEqual({ kind: 'oversized' })
+    expect(fsProvider.readFile).not.toHaveBeenCalled()
+  })
+
+  it('rechecks UTF-8 bytes after a stat/read race', async () => {
+    const fsProvider = provider({ size: 2, content: '🐋🐋🐋' })
+
+    await expect(
+      readFilesystemProviderBoundedText(fsProvider, '/repo/orca.yaml', limits)
+    ).resolves.toEqual({ kind: 'oversized' })
+  })
+
+  it('rechecks code units after a stat/read race', async () => {
+    const fsProvider = provider({ size: 2, content: '123456789' })
+
+    await expect(
+      readFilesystemProviderBoundedText(fsProvider, '/repo/orca.yaml', limits)
+    ).resolves.toEqual({ kind: 'oversized' })
+  })
+
+  it('preserves binary classification', async () => {
+    const fsProvider = provider({ size: 2, content: 'xx', isBinary: true })
+
+    await expect(
+      readFilesystemProviderBoundedText(fsProvider, '/repo/orca.yaml', limits)
+    ).resolves.toEqual({ kind: 'binary' })
+  })
+})

--- a/src/main/filesystem-provider-bounded-text.ts
+++ b/src/main/filesystem-provider-bounded-text.ts
@@ -1,0 +1,34 @@
+import { measureUtf8ByteLength } from '../shared/utf8-byte-limits'
+import type { IFilesystemProvider } from './providers/types'
+
+export type FilesystemProviderBoundedText =
+  | { kind: 'text'; content: string }
+  | { kind: 'binary' }
+  | { kind: 'oversized' }
+
+export async function readFilesystemProviderBoundedText(
+  provider: IFilesystemProvider,
+  filePath: string,
+  limits: { maxBytes: number; maxCodeUnits: number }
+): Promise<FilesystemProviderBoundedText> {
+  const fileStat = await provider.stat(filePath)
+  if (
+    !Number.isSafeInteger(fileStat.size) ||
+    fileStat.size < 0 ||
+    fileStat.size > limits.maxBytes
+  ) {
+    return { kind: 'oversized' }
+  }
+
+  const result = await provider.readFile(filePath)
+  if (result.isBinary) {
+    return { kind: 'binary' }
+  }
+  if (
+    result.content.length > limits.maxCodeUnits ||
+    measureUtf8ByteLength(result.content, { stopAfterBytes: limits.maxBytes }).exceededLimit
+  ) {
+    return { kind: 'oversized' }
+  }
+  return { kind: 'text', content: result.content }
+}

--- a/src/main/generated-node-bounded-file-reader.test.ts
+++ b/src/main/generated-node-bounded-file-reader.test.ts
@@ -1,0 +1,86 @@
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  readSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runInNewContext } from 'node:vm'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  GENERATED_NODE_MANAGED_FILE_MAX_BYTES,
+  getGeneratedNodeBoundedFileReaderSourceLines
+} from './generated-node-bounded-file-reader'
+
+type GeneratedReader = (
+  fs: {
+    closeSync: typeof closeSync
+    openSync: typeof openSync
+    readSync: typeof readSync
+  },
+  path: string
+) => string
+
+const temporaryDirectories: string[] = []
+
+function buildGeneratedReader(): GeneratedReader {
+  const module = { exports: undefined as GeneratedReader | undefined }
+  runInNewContext(
+    [
+      ...getGeneratedNodeBoundedFileReaderSourceLines(),
+      'module.exports = readOrcaManagedFileWithinLimit;'
+    ].join('\n'),
+    { Buffer, module }
+  )
+  if (!module.exports) {
+    throw new Error('generated bounded reader did not export')
+  }
+  return module.exports
+}
+
+function createFile(content: string): string {
+  const directory = mkdtempSync(join(tmpdir(), 'orca-generated-node-read-'))
+  temporaryDirectories.push(directory)
+  const path = join(directory, 'managed-file')
+  writeFileSync(path, content)
+  return path
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('generated Node bounded file reader', () => {
+  it('preserves ordinary managed-file contents', () => {
+    const path = createFile('stable 🐋 endpoint')
+
+    expect(buildGeneratedReader()({ openSync, readSync, closeSync }, path)).toBe(
+      'stable 🐋 endpoint'
+    )
+  })
+
+  it('accepts a file at the exact byte cap', () => {
+    const path = createFile('x'.repeat(GENERATED_NODE_MANAGED_FILE_MAX_BYTES))
+
+    expect(
+      Buffer.byteLength(buildGeneratedReader()({ openSync, readSync, closeSync }, path), 'utf8')
+    ).toBe(GENERATED_NODE_MANAGED_FILE_MAX_BYTES)
+  })
+
+  it('rejects a sparse oversized file and always closes its descriptor', () => {
+    const path = createFile('')
+    truncateSync(path, GENERATED_NODE_MANAGED_FILE_MAX_BYTES + 1)
+    const close = vi.fn(closeSync)
+
+    expect(() => buildGeneratedReader()({ openSync, readSync, closeSync: close }, path)).toThrow(
+      `Managed Orca file exceeds ${GENERATED_NODE_MANAGED_FILE_MAX_BYTES} bytes`
+    )
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/generated-node-bounded-file-reader.ts
+++ b/src/main/generated-node-bounded-file-reader.ts
@@ -1,0 +1,30 @@
+export const GENERATED_NODE_MANAGED_FILE_MAX_BYTES = 64 * 1024
+
+// Why: emitted runtimes cannot import Orca's reader; fixed capacity also catches growth after stat.
+export function getGeneratedNodeBoundedFileReaderSourceLines(options?: {
+  typed?: boolean
+}): string[] {
+  const signature = options?.typed
+    ? `function readOrcaManagedFileWithinLimit(fs: any, path: string, maxBytes = ${GENERATED_NODE_MANAGED_FILE_MAX_BYTES}): string {`
+    : `function readOrcaManagedFileWithinLimit(fs, path, maxBytes = ${GENERATED_NODE_MANAGED_FILE_MAX_BYTES}) {`
+  return [
+    signature,
+    "  const descriptor = fs.openSync(path, 'r');",
+    '  try {',
+    '    const buffer = Buffer.allocUnsafe(maxBytes + 1);',
+    '    let offset = 0;',
+    '    while (offset < buffer.length) {',
+    '      const bytesRead = fs.readSync(descriptor, buffer, offset, buffer.length - offset, null);',
+    '      if (bytesRead === 0) break;',
+    '      offset += bytesRead;',
+    '    }',
+    '    if (offset > maxBytes) {',
+    "      throw Object.assign(new Error('Managed Orca file exceeds ' + maxBytes + ' bytes'), { code: 'EFBIG' });",
+    '    }',
+    "    return buffer.toString('utf8', 0, offset);",
+    '  } finally {',
+    '    fs.closeSync(descriptor);',
+    '  }',
+    '}'
+  ]
+}

--- a/src/main/git/gh-rate-limit-breaker.ts
+++ b/src/main/git/gh-rate-limit-breaker.ts
@@ -12,6 +12,8 @@
  * the github rate-limit prober can use it without an import cycle.
  */
 
+import { cacheIdentityDigest } from '../cache-identity-digest'
+
 export type GhRateLimitBucket = 'core' | 'search' | 'graphql'
 
 // Why: a primary 403 does not carry the reset time. The search window resets
@@ -62,7 +64,7 @@ const blockedUntilMsByScopeAndBucket = new Map<string, number>()
 let resetProbe: ((bucket: GhRateLimitBucket, scope: string) => void) | null = null
 
 function breakerKey(bucket: GhRateLimitBucket, scope = DEFAULT_SCOPE): string {
-  return `${scope}\0${bucket}`
+  return cacheIdentityDigest([scope, bucket])
 }
 
 // gh api flags that take a separate value, so the endpoint arg can be found.

--- a/src/main/git/git-capability-state.test.ts
+++ b/src/main/git/git-capability-state.test.ts
@@ -2,7 +2,9 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   clearGitCapabilityStateForTests,
   getLocalGitCapabilityCache,
-  getSshGitCapabilityCache
+  getSshGitCapabilityCache,
+  LOCAL_GIT_CAPABILITY_HOST_KEY_MAX_BYTES,
+  LOCAL_GIT_CAPABILITY_HOST_MAX_ENTRIES
 } from './git-capability-state'
 
 describe('Git capability execution-host state', () => {
@@ -32,6 +34,29 @@ describe('Git capability execution-host state', () => {
     expect(getSshGitCapabilityCache(provider)).toBe(getSshGitCapabilityCache(provider))
     expect(getSshGitCapabilityCache(provider)).not.toBe(
       getSshGitCapabilityCache(replacementProvider)
+    )
+  })
+
+  it('evicts the oldest local execution host after the host ceiling', () => {
+    const oldest = getLocalGitCapabilityCache({ wslDistro: 'Distro-0' })
+    let newest = oldest
+    for (let index = 1; index <= LOCAL_GIT_CAPABILITY_HOST_MAX_ENTRIES; index++) {
+      newest = getLocalGitCapabilityCache({ wslDistro: `Distro-${index}` })
+    }
+
+    expect(getLocalGitCapabilityCache({ wslDistro: 'Distro-0' })).not.toBe(oldest)
+    expect(
+      getLocalGitCapabilityCache({
+        wslDistro: `Distro-${LOCAL_GIT_CAPABILITY_HOST_MAX_ENTRIES}`
+      })
+    ).toBe(newest)
+  })
+
+  it('does not retain oversized execution-host keys', () => {
+    const oversizedDistro = 'x'.repeat(LOCAL_GIT_CAPABILITY_HOST_KEY_MAX_BYTES + 1)
+
+    expect(getLocalGitCapabilityCache({ wslDistro: oversizedDistro })).not.toBe(
+      getLocalGitCapabilityCache({ wslDistro: oversizedDistro })
     )
   })
 })

--- a/src/main/git/git-capability-state.ts
+++ b/src/main/git/git-capability-state.ts
@@ -1,4 +1,5 @@
 import { GitCapabilityCache } from '../../shared/git-capability-cache'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 
 type LocalGitCapabilityTarget = {
@@ -6,6 +7,8 @@ type LocalGitCapabilityTarget = {
   wslDistro?: string
 }
 
+export const LOCAL_GIT_CAPABILITY_HOST_MAX_ENTRIES = 64
+export const LOCAL_GIT_CAPABILITY_HOST_KEY_MAX_BYTES = 4 * 1024
 const localCapabilitiesByExecutionHost = new Map<string, GitCapabilityCache>()
 // Why: reconnecting creates a new provider, while concurrent IPC/runtime users
 // of one SSH connection must share the same remote Git capability results.
@@ -21,10 +24,24 @@ export function getLocalGitCapabilityCache(
   target: LocalGitCapabilityTarget = {}
 ): GitCapabilityCache {
   const executionHost = getLocalGitExecutionHostKey(target)
+  if (
+    measureUtf8ByteLength(executionHost, {
+      stopAfterBytes: LOCAL_GIT_CAPABILITY_HOST_KEY_MAX_BYTES
+    }).exceededLimit
+  ) {
+    return new GitCapabilityCache()
+  }
   let cache = localCapabilitiesByExecutionHost.get(executionHost)
   if (!cache) {
     cache = new GitCapabilityCache()
     localCapabilitiesByExecutionHost.set(executionHost, cache)
+    while (localCapabilitiesByExecutionHost.size > LOCAL_GIT_CAPABILITY_HOST_MAX_ENTRIES) {
+      const oldestHost = localCapabilitiesByExecutionHost.keys().next().value
+      if (oldestHost === undefined) {
+        break
+      }
+      localCapabilitiesByExecutionHost.delete(oldestHost)
+    }
   }
   return cache
 }

--- a/src/main/git/huge-folder-ignore.test.ts
+++ b/src/main/git/huge-folder-ignore.test.ts
@@ -84,6 +84,35 @@ describe('appendFolderToGitignore', () => {
     expect(wrote).toBe(false)
   })
 
+  it('streams a large single-line file while preserving append semantics', async () => {
+    const gitignorePath = path.join(dir, '.gitignore')
+    await fs.writeFile(gitignorePath, 'x')
+    await fs.truncate(gitignorePath, 8 * 1024 * 1024)
+
+    expect(await appendFolderToGitignore(dir, 'dist')).toBe(true)
+
+    const handle = await fs.open(gitignorePath, 'r')
+    try {
+      const info = await handle.stat()
+      const tail = Buffer.alloc(7)
+      await handle.read(tail, 0, tail.length, info.size - tail.length)
+      expect(tail.toString('utf8')).toBe('\ndist/\n')
+    } finally {
+      await handle.close()
+    }
+  })
+
+  it('preserves trimmed-line matching across streamed chunks', async () => {
+    const gitignorePath = path.join(dir, '.gitignore')
+    await fs.writeFile(gitignorePath, 'x')
+    await fs.truncate(gitignorePath, 8 * 1024 * 1024)
+    await fs.appendFile(gitignorePath, '\n\u00a0node_modules/\u00a0\n')
+    const sizeBefore = (await fs.stat(gitignorePath)).size
+
+    expect(await appendFolderToGitignore(dir, 'node_modules')).toBe(false)
+    expect((await fs.stat(gitignorePath)).size).toBe(sizeBefore)
+  })
+
   it('rejects folder names outside the known allowlist (injection guard)', async () => {
     await expect(appendFolderToGitignore(dir, 'node_modules\n/etc/passwd')).rejects.toThrow(
       /Refusing to add/

--- a/src/main/git/huge-folder-ignore.ts
+++ b/src/main/git/huge-folder-ignore.ts
@@ -1,6 +1,7 @@
-import { existsSync } from 'node:fs'
-import { appendFile, readFile, stat } from 'node:fs/promises'
+import { createReadStream, existsSync } from 'node:fs'
+import { appendFile, stat } from 'node:fs/promises'
 import * as path from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
 import { checkIgnoredPaths } from './check-ignored-paths'
 import type { GitRuntimeOptions } from './git-runtime-options'
 
@@ -9,6 +10,78 @@ import type { GitRuntimeOptions } from './git-runtime-options'
 // to ignore these by name (matching the well-known offenders) the way a mature
 // SCM does, rather than asking the user to hand-edit .gitignore.
 const KNOWN_HUGE_FOLDER_NAMES = ['node_modules', '.next', 'dist', 'build', 'target', 'vendor']
+const GITIGNORE_SCAN_CHUNK_BYTES = 64 * 1024
+
+type GitignoreScanResult = {
+  alreadyListed: boolean
+  hasContent: boolean
+  endsWithNewline: boolean
+}
+
+async function scanGitignoreForFolder(
+  gitignorePath: string,
+  folderName: string
+): Promise<GitignoreScanResult> {
+  const targets = [folderName, `${folderName}/`]
+  const decoder = new StringDecoder('utf8')
+  const input = createReadStream(gitignorePath, { highWaterMark: GITIGNORE_SCAN_CHUNK_BYTES })
+  let phase: 'leading' | 'candidate' | 'trailing' | 'rejected' = 'leading'
+  let candidate = ''
+  let alreadyListed = false
+  let hasContent = false
+  let endsWithNewline = false
+
+  const finishLine = (): void => {
+    if (phase === 'trailing' || (phase === 'candidate' && targets.includes(candidate))) {
+      alreadyListed = true
+    }
+    phase = 'leading'
+    candidate = ''
+  }
+  const acceptText = (text: string): void => {
+    for (const character of text) {
+      if (character === '\n') {
+        finishLine()
+        continue
+      }
+      const whitespace = character.trim().length === 0
+      if (phase === 'leading') {
+        if (whitespace) {
+          continue
+        }
+        candidate = character
+        phase = targets.some((target) => target.startsWith(candidate)) ? 'candidate' : 'rejected'
+        continue
+      }
+      if (phase === 'candidate') {
+        if (whitespace) {
+          phase = targets.includes(candidate) ? 'trailing' : 'rejected'
+          continue
+        }
+        candidate += character
+        if (!targets.some((target) => target.startsWith(candidate))) {
+          phase = 'rejected'
+        }
+        continue
+      }
+      if (phase === 'trailing' && !whitespace) {
+        phase = 'rejected'
+      }
+    }
+  }
+
+  for await (const chunk of input) {
+    const buffer = chunk as Buffer
+    hasContent ||= buffer.length > 0
+    if (buffer.length > 0) {
+      endsWithNewline = buffer.at(-1) === 0x0a
+    }
+    acceptText(decoder.write(buffer))
+  }
+  acceptText(decoder.end())
+  finishLine()
+  return { alreadyListed, hasContent, endsWithNewline }
+}
 
 /**
  * Return the relative names of known-huge folders that exist in the worktree and
@@ -58,21 +131,21 @@ export async function appendFolderToGitignore(
   }
   const gitignorePath = path.join(worktreePath, '.gitignore')
   const line = `${safeFolderName}/`
-  let existingContent = ''
+  let scan: GitignoreScanResult = {
+    alreadyListed: false,
+    hasContent: false,
+    endsWithNewline: false
+  }
   try {
-    existingContent = await readFile(gitignorePath, 'utf-8')
+    scan = await scanGitignoreForFolder(gitignorePath, safeFolderName)
   } catch {
     // .gitignore doesn't exist yet — we'll create it below
   }
-  const alreadyListed = existingContent
-    .split(/\r?\n/)
-    .map((l) => l.trim())
-    .some((l) => l === safeFolderName || l === line)
-  if (alreadyListed) {
+  if (scan.alreadyListed) {
     return false
   }
   // Why: keep a clean trailing newline whether or not the file ended with one.
-  const needsLeadingNewline = existingContent.length > 0 && !existingContent.endsWith('\n')
+  const needsLeadingNewline = scan.hasContent && !scan.endsWithNewline
   await appendFile(gitignorePath, `${needsLeadingNewline ? '\n' : ''}${line}\n`, 'utf-8')
   return true
 }

--- a/src/main/git/repo-metadata-bounds.test.ts
+++ b/src/main/git/repo-metadata-bounds.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, truncateSync, writeFileSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { isGitRepo, MAX_GIT_MARKER_FILE_BYTES } from './repo'
+
+describe.sequential('Git marker fallback metadata bounds', () => {
+  let root: string
+  let originalPath: string | undefined
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-git-marker-bounds-'))
+    originalPath = process.env.PATH
+    process.env.PATH = ''
+  })
+
+  afterEach(async () => {
+    if (originalPath === undefined) {
+      delete process.env.PATH
+    } else {
+      process.env.PATH = originalPath
+    }
+    await rm(root, { recursive: true, force: true })
+  })
+
+  function writeOversizedSparseFile(filePath: string): void {
+    writeFileSync(filePath, 'x')
+    truncateSync(filePath, MAX_GIT_MARKER_FILE_BYTES + 1)
+  }
+
+  it('rejects an oversized .git pointer without loading it', () => {
+    const checkout = join(root, 'checkout')
+    mkdirSync(checkout)
+    writeOversizedSparseFile(join(checkout, '.git'))
+
+    expect(isGitRepo(checkout)).toBe(false)
+  })
+
+  it('rejects an oversized linked-worktree commondir pointer', () => {
+    const checkout = join(root, 'checkout')
+    const adminDir = join(root, 'admin')
+    mkdirSync(checkout)
+    mkdirSync(adminDir)
+    writeFileSync(join(checkout, '.git'), `gitdir: ${adminDir}\n`)
+    writeFileSync(join(adminDir, 'HEAD'), 'ref: refs/heads/main\n')
+    writeOversizedSparseFile(join(adminDir, 'commondir'))
+
+    expect(isGitRepo(checkout)).toBe(false)
+  })
+
+  it('checks a bare marker without retaining an oversized config', () => {
+    const bareRepo = join(root, 'bare.git')
+    mkdirSync(join(bareRepo, 'objects'), { recursive: true })
+    mkdirSync(join(bareRepo, 'refs'))
+    writeFileSync(join(bareRepo, 'HEAD'), 'ref: refs/heads/main\n')
+    writeOversizedSparseFile(join(bareRepo, 'config'))
+
+    expect(isGitRepo(bareRepo)).toBe(true)
+  })
+})

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -1,5 +1,5 @@
 /* oxlint-disable max-lines */
-import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs'
+import { existsSync, realpathSync, statSync } from 'node:fs'
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { gitExecFileSync, gitExecFileAsync } from './runner'
 import type { BaseRefSearchResult } from '../../shared/types'
@@ -10,6 +10,7 @@ import { parseWslUncPath } from '../../shared/wsl-paths'
 import { toWindowsWslPath } from '../wsl'
 import { buildHostedRemoteCommitUrl, buildHostedRemoteFileUrl } from './hosted-remote-url'
 import { getLocalGitCapabilityCache } from './git-capability-state'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 
 type LocalGitExecOptions = {
   wslDistro?: string
@@ -21,6 +22,7 @@ type LocalDefaultBaseRefGitOptions = {
 }
 
 const DEFAULT_BASE_REF_PROBE_TIMEOUT_MS = 15_000
+export const MAX_GIT_MARKER_FILE_BYTES = 64 * 1024
 
 type GitRepoProbeResult = 'repo' | 'not-repo' | 'indeterminate'
 type GitMarkerScanResult = { status: 'valid'; rootPath: string } | { status: 'absent' | 'invalid' }
@@ -276,7 +278,10 @@ function scanWorktreeMarkerSync(worktreePath: string): GitMarkerScanResult {
   if (marker.isFile()) {
     let gitDir: string | null
     try {
-      gitDir = parseGitdirFile(worktreePath, readFileSync(dotGit, 'utf8'))
+      gitDir = parseGitdirFile(
+        worktreePath,
+        readNodeFileSyncWithinLimit(dotGit, MAX_GIT_MARKER_FILE_BYTES).buffer.toString('utf8')
+      )
     } catch {
       return { status: 'invalid' }
     }
@@ -331,7 +336,10 @@ function hasValidLinkedWorktreeGitDirectorySync(gitDir: string): boolean {
     }
     const commonDir = resolveGitMetadataPath(
       gitDir,
-      readFileSync(join(gitDir, 'commondir'), 'utf8')
+      readNodeFileSyncWithinLimit(
+        join(gitDir, 'commondir'),
+        MAX_GIT_MARKER_FILE_BYTES
+      ).buffer.toString('utf8')
     )
     return commonDir !== null && hasValidCommonGitDirectorySync(commonDir)
   } catch {
@@ -345,7 +353,10 @@ function hasValidBareRepoMarkerSync(path: string): boolean {
 
 function gitConfigDeclaresNonBare(gitDir: string): boolean {
   try {
-    const config = readFileSync(join(gitDir, 'config'), 'utf8')
+    const config = readNodeFileSyncWithinLimit(
+      join(gitDir, 'config'),
+      MAX_GIT_MARKER_FILE_BYTES
+    ).buffer.toString('utf8')
     let inCoreSection = false
     for (const line of config.split(/\r?\n/)) {
       const section = line.match(/^\s*\[([^\]]+)\]/)

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:child_process', () => ({
 
 import {
   commandExecFileAsync,
+  DEFAULT_GIT_MAX_BUFFER,
   ghExecFileAsync,
   gitExecFileAsync,
   gitStreamStdout,
@@ -155,6 +156,35 @@ describe('commandExecFileAsync Windows command shims', () => {
     })
   })
 
+  it('applies the default output cap to Windows .cmd shim executions', async () => {
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      const taskkill = createMockTaskkillProcess()
+      spawnMock.mockImplementation((cmd: string) => (cmd === 'taskkill' ? taskkill : command))
+      const toString = vi.fn(() => 'should not decode')
+      const oversizedChunk = {
+        byteLength: DEFAULT_GIT_MAX_BUFFER + 1,
+        toString
+      } as unknown as Buffer
+
+      const promise = commandExecFileAsync('C:\\tools\\pnpm.cmd', ['store', 'prune'], {
+        cwd: 'C:\\repo'
+      })
+      const rejection = expect(promise).rejects.toThrow(
+        'C:\\tools\\pnpm.cmd stdout exceeded maxBuffer.'
+      )
+      command.stdout.emit('data', oversizedChunk)
+
+      await rejection
+      expect(toString).not.toHaveBeenCalled()
+      expect(spawnMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '1234', '/t', '/f'],
+        expect.objectContaining({ stdio: 'ignore', windowsHide: true })
+      )
+    })
+  })
+
   it('removes listeners after successful Windows .cmd shim executions', async () => {
     await withPlatform('win32', async () => {
       const command = createMockChildProcess(1234)
@@ -172,6 +202,26 @@ describe('commandExecFileAsync Windows command shims', () => {
       expect(command.stderr.listenerCount('data')).toBe(0)
       expect(command.listenerCount('error')).toBe(0)
       expect(command.listenerCount('close')).toBe(0)
+    })
+  })
+
+  it('captures 100,000 one-byte fragments from a Windows command shim', async () => {
+    await withPlatform('win32', async () => {
+      const command = createMockChildProcess(1234)
+      spawnMock.mockReturnValue(command)
+      const promise = commandExecFileAsync('C:\\tools\\pnpm.cmd', ['--version'], {
+        cwd: 'C:\\repo'
+      })
+      const fragment = Buffer.from('x')
+
+      for (let index = 0; index < 100_000; index += 1) {
+        command.stdout.emit('data', fragment)
+      }
+      command.emit('close', 0)
+
+      const result = await promise
+      expect(result.stdout).toHaveLength(100_000)
+      expect(result.stdout.slice(-4)).toBe('xxxx')
     })
   })
 })
@@ -643,6 +693,21 @@ describe('gitStreamStdout', () => {
     child.emit('close', 128)
 
     await rejection
+  })
+
+  it('captures streamed stderr delivered as 100,000 one-byte fragments', async () => {
+    const child = createMockChildProcess(1234)
+    spawnMock.mockReturnValue(child)
+    const promise = gitStreamStdout(['status'], { cwd: '/repo', onStdout: () => {} })
+    const fragment = Buffer.from(' ')
+
+    for (let index = 0; index < 100_000; index += 1) {
+      child.stderr.emit('data', fragment)
+    }
+    child.stderr.emit('data', Buffer.from('fatal: fragmented'))
+    child.emit('close', 128)
+
+    await expect(promise).rejects.toThrow(/fatal: fragmented$/)
   })
 
   it('rejects (not crashes) when the onStdout callback throws', async () => {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -33,6 +33,7 @@ import {
   appendGitConfigEnv,
   gitCredentialPromptGuardEnv
 } from '../../shared/git-credential-prompt-env'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 import { getSpawnArgsForWindows, isWindowsBatchScript, resolveWindowsCommand } from '../win32-utils'
 import {
   buildWslLoginShellCommand,
@@ -497,6 +498,7 @@ async function spawnCommandCapture(
   args: string[],
   options: CommandExecOptions
 ): Promise<{ stdout: string; stderr: string }> {
+  const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER
   const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(command, args)
   return new Promise((resolve, reject) => {
     if (options.signal?.aborted) {
@@ -504,10 +506,8 @@ async function spawnCommandCapture(
       return
     }
     let settled = false
-    let stdout = ''
-    let stderr = ''
-    let stdoutBytes = 0
-    let stderrBytes = 0
+    const stdout = new GrowingByteBuffer()
+    const stderr = new GrowingByteBuffer()
     const spawnStartedAt = performance.now()
     const child = spawn(spawnCmd, spawnArgs, {
       cwd: options.cwd,
@@ -538,11 +538,15 @@ async function spawnCommandCapture(
       }
       settled = true
       cleanupListeners()
+      const stdoutText = stdout.toString(options.encoding ?? 'utf-8')
+      const stderrText = stderr.toString(options.encoding ?? 'utf-8')
+      stdout.clear()
+      stderr.clear()
       if (error) {
-        reject(Object.assign(error, { stdout, stderr }))
+        reject(Object.assign(error, { stdout: stdoutText, stderr: stderrText }))
         return
       }
-      resolve({ stdout, stderr })
+      resolve({ stdout: stdoutText, stderr: stderrText })
     }
     timer = options.timeout
       ? setTimeout(() => {
@@ -552,22 +556,20 @@ async function spawnCommandCapture(
       : null
     options.signal?.addEventListener('abort', onAbort, { once: true })
     function onStdoutData(chunk: Buffer): void {
-      stdoutBytes += chunk.byteLength
-      if (options.maxBuffer && stdoutBytes > options.maxBuffer) {
+      if (stdout.byteLength + chunk.byteLength > maxBuffer) {
         void killSpawnedCommandTree(child)
         finish(new Error(`${command} stdout exceeded maxBuffer.`))
         return
       }
-      stdout += chunk.toString(options.encoding ?? 'utf-8')
+      stdout.append(chunk)
     }
     function onStderrData(chunk: Buffer): void {
-      stderrBytes += chunk.byteLength
-      if (options.maxBuffer && stderrBytes > options.maxBuffer) {
+      if (stderr.byteLength + chunk.byteLength > maxBuffer) {
         void killSpawnedCommandTree(child)
         finish(new Error(`${command} stderr exceeded maxBuffer.`))
         return
       }
-      stderr += chunk.toString(options.encoding ?? 'utf-8')
+      stderr.append(chunk)
     }
     function onError(error: Error): void {
       finish(error)
@@ -972,11 +974,9 @@ export async function gitStreamStdout(
       let settled = false
       let stoppedEarly = false
       let stdoutBytes = 0
-      let stderr = ''
-      let stderrBytes = 0
+      const stderr = new GrowingByteBuffer()
       // Why: decode statefully so a multibyte UTF-8 char split across chunks isn't corrupted into replacement chars.
       const stdoutDecoder = new StringDecoder('utf8')
-      const stderrDecoder = new StringDecoder('utf8')
 
       const cleanup = (): void => {
         child.stdout?.off('data', onStdoutData)
@@ -986,7 +986,6 @@ export async function gitStreamStdout(
         options.signal?.removeEventListener('abort', onAbort)
         // Flush any bytes the decoders were holding for an incomplete sequence.
         stdoutDecoder.end()
-        stderrDecoder.end()
       }
       const finish = (error: Error | null): void => {
         if (settled) {
@@ -994,8 +993,10 @@ export async function gitStreamStdout(
         }
         settled = true
         cleanup()
+        const stderrText = stderr.toString()
+        stderr.clear()
         if (error) {
-          reject(Object.assign(error, { stderr }))
+          reject(Object.assign(error, { stderr: stderrText }))
           return
         }
         resolve({ stoppedEarly })
@@ -1029,13 +1030,12 @@ export async function gitStreamStdout(
         }
       }
       function onStderrData(chunk: Buffer): void {
-        stderrBytes += chunk.byteLength
-        if (stderrBytes > maxBuffer) {
+        if (stderr.byteLength + chunk.byteLength > maxBuffer) {
           void killSpawnedCommandTree(child)
           finish(new Error('git stderr exceeded maxBuffer.'))
           return
         }
-        stderr += stderrDecoder.write(chunk)
+        stderr.append(chunk)
       }
       function onError(error: Error): void {
         finish(error)
@@ -1045,7 +1045,7 @@ export async function gitStreamStdout(
           finish(null)
           return
         }
-        finish(new Error(`git exited with ${code}: ${stderr}`))
+        finish(new Error(`git exited with ${code}: ${stderr.toString()}`))
       }
       function onAbort(): void {
         if (!child.pid) {

--- a/src/main/git/status-git-pointer-bounds.test.ts
+++ b/src/main/git/status-git-pointer-bounds.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveGitDir } from './status'
+
+describe('resolveGitDir metadata bounds', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  async function makeWorktree(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-resolve-git-dir-'))
+    roots.push(root)
+    const worktreePath = join(root, 'checkout')
+    await mkdir(worktreePath)
+    return worktreePath
+  }
+
+  it('preserves a normal linked-worktree pointer', async () => {
+    const worktreePath = await makeWorktree()
+    await writeFile(join(worktreePath, '.git'), 'gitdir: ../common/.git/worktrees/checkout\n')
+
+    await expect(resolveGitDir(worktreePath)).resolves.toBe(
+      join(worktreePath, '..', 'common', '.git', 'worktrees', 'checkout')
+    )
+  })
+
+  it('falls back to the .git path for an oversized sparse pointer', async () => {
+    const worktreePath = await makeWorktree()
+    const dotGitPath = join(worktreePath, '.git')
+    await writeFile(dotGitPath, 'x')
+    await truncate(dotGitPath, 64 * 1024 + 1)
+
+    await expect(resolveGitDir(worktreePath)).resolves.toBe(dotGitPath)
+  })
+})

--- a/src/main/git/status-submodule-path-payload-bounds.test.ts
+++ b/src/main/git/status-submodule-path-payload-bounds.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({ gitExecFileAsyncMock: vi.fn() }))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
+    ...env,
+    GIT_OPTIONAL_LOCKS: '0'
+  })
+}))
+
+import {
+  clearSubmodulePathsCacheForTests,
+  getSubmodulePathsCacheCodeUnitsForTests,
+  getSubmodulePathsCacheCountForTests,
+  listSubmodulePaths,
+  MAX_SUBMODULE_PATH_CODE_UNITS,
+  MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS,
+  MAX_SUBMODULE_PATHS_PER_REPO
+} from './status'
+
+describe('submodule path payload bounds', () => {
+  beforeEach(() => {
+    clearSubmodulePathsCacheForTests()
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it('preserves under-limit path order and cache reuse', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: 'submodule.one.path packages/one\nsubmodule.two.path packages/two/\n'
+    })
+
+    await expect(listSubmodulePaths('/repo')).resolves.toEqual(['packages/one', 'packages/two'])
+    await expect(listSubmodulePaths('/repo')).resolves.toEqual(['packages/one', 'packages/two'])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed above the per-repository path count', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: Array.from(
+        { length: MAX_SUBMODULE_PATHS_PER_REPO + 1 },
+        (_, index) => `submodule.s${index}.path modules/${index}\n`
+      ).join('')
+    })
+
+    await expect(listSubmodulePaths('/repo')).resolves.toEqual([])
+  })
+
+  it('fails closed on a single oversized path', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: `submodule.large.path ${'x'.repeat(MAX_SUBMODULE_PATH_CODE_UNITS + 1)}\n`
+    })
+
+    await expect(listSubmodulePaths('/repo')).resolves.toEqual([])
+  })
+
+  it('evicts old payloads at the aggregate retained-code-unit budget', async () => {
+    const segment = 'x'.repeat(60 * 1024)
+    const stdout = Array.from(
+      { length: 16 },
+      (_, index) => `submodule.s${index}.path ${segment}${index}\n`
+    ).join('')
+    gitExecFileAsyncMock.mockResolvedValue({ stdout })
+
+    for (let index = 0; index < 18; index += 1) {
+      await listSubmodulePaths(`/repo-${index}`)
+    }
+
+    expect(getSubmodulePathsCacheCodeUnitsForTests()).toBeLessThanOrEqual(
+      MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS
+    )
+    expect(getSubmodulePathsCacheCountForTests()).toBeLessThan(18)
+  })
+
+  it('does not retain an oversized cache key', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: 'submodule.one.path packages/one\n' })
+    const worktreePath = `/${'r'.repeat(64 * 1024)}`
+
+    await listSubmodulePaths(worktreePath)
+    await listSubmodulePaths(worktreePath)
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(getSubmodulePathsCacheCountForTests()).toBe(0)
+    expect(getSubmodulePathsCacheCodeUnitsForTests()).toBe(0)
+  })
+})

--- a/src/main/git/status-upstream-cache-key-bounds.test.ts
+++ b/src/main/git/status-upstream-cache-key-bounds.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
+
+const { existsSyncMock, gitExecFileAsyncMock, readFileMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitStreamStdout: async (
+    args: string[],
+    options: { onStdout: (chunk: string) => boolean | void }
+  ) => {
+    const { stdout } = await gitExecFileAsyncMock(args)
+    return { stoppedEarly: options.onStdout(stdout ?? '') === true }
+  },
+  gitOptionalLocksDisabledEnv: (env: NodeJS.ProcessEnv = process.env) => ({
+    ...env,
+    GIT_OPTIONAL_LOCKS: '0'
+  })
+}))
+
+vi.mock('fs/promises', () => ({ readFile: readFileMock }))
+vi.mock('fs', () => ({ existsSync: existsSyncMock }))
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof BoundedFileReader>()
+  return {
+    ...actual,
+    readNodeFileWithinLimit: async (filePath: string, maxBytes: number) => {
+      const value = await readFileMock(filePath)
+      const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value)
+      if (buffer.length > maxBytes) {
+        throw new actual.NodeFileReadTooLargeError(buffer.length, maxBytes)
+      }
+      return { buffer, stats: { isFile: () => true, size: buffer.length } }
+    }
+  }
+})
+
+import {
+  clearEffectiveUpstreamNegativeStatusCache,
+  clearEffectiveUpstreamStatusCacheForTests,
+  getEffectiveUpstreamStatusCacheCountForTests,
+  getEffectiveUpstreamStatusGenerationCountForTests,
+  getStatus,
+  MAX_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES
+} from './status'
+
+describe('effective-upstream cache key bounds', () => {
+  beforeEach(() => {
+    clearEffectiveUpstreamStatusCacheForTests()
+    existsSyncMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
+    readFileMock.mockReset()
+    existsSyncMock.mockReturnValue(false)
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args.includes('status')) {
+        return { stdout: '# branch.oid abcdef1234567890\n# branch.head feature\n' }
+      }
+      if (args[0] === 'symbolic-ref') {
+        return { stdout: 'feature\n' }
+      }
+      if (args[0] === 'config' && args[1] === '--list') {
+        return { stdout: 'core.repositoryformatversion\n0\0' }
+      }
+      if (args[0] === 'rev-parse') {
+        throw new Error('missing upstream')
+      }
+      throw new Error(`unexpected git command: ${args.join(' ')}`)
+    })
+  })
+
+  it('re-probes without retaining keys above 64 KiB', async () => {
+    const worktreePath = `/${'p'.repeat(MAX_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES)}`
+
+    await getStatus(worktreePath)
+    await getStatus(worktreePath)
+
+    const upstreamProbes = gitExecFileAsyncMock.mock.calls.filter(
+      ([args]) => (args as string[])[0] === 'rev-parse' && (args as string[]).includes('HEAD@{u}')
+    )
+    expect(upstreamProbes).toHaveLength(2)
+    expect(getEffectiveUpstreamStatusCacheCountForTests()).toBe(0)
+    expect(getEffectiveUpstreamStatusGenerationCountForTests()).toBe(0)
+
+    clearEffectiveUpstreamNegativeStatusCache({ worktreePath, branchName: 'feature' })
+    expect(getEffectiveUpstreamStatusGenerationCountForTests()).toBe(0)
+  })
+})

--- a/src/main/git/status-upstream-negative-cache.test.ts
+++ b/src/main/git/status-upstream-negative-cache.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
 
 const { existsSyncMock, gitExecFileAsyncMock, readFileMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
@@ -29,6 +30,21 @@ vi.mock('fs/promises', () => ({
 vi.mock('fs', () => ({
   existsSync: existsSyncMock
 }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof BoundedFileReader>()
+  return {
+    ...actual,
+    readNodeFileWithinLimit: async (filePath: string, maxBytes: number) => {
+      const value = await readFileMock(filePath)
+      const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value)
+      if (buffer.length > maxBytes) {
+        throw new actual.NodeFileReadTooLargeError(buffer.length, maxBytes)
+      }
+      return { buffer, stats: { isFile: () => true, size: buffer.length } }
+    }
+  }
+})
 
 function isConfigListSnapshotCommand(args: string[]): boolean {
   return args[0] === 'config' && args[1] === '--list' && args[2] === '-z'

--- a/src/main/git/status-upstream-probe-churn.test.ts
+++ b/src/main/git/status-upstream-probe-churn.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
 
 // Repro command:
 //   pnpm exec vitest run --config config/vitest.config.ts src/main/git/status-upstream-probe-churn.test.ts -t "missing-upstream polling churn"
@@ -34,6 +35,21 @@ vi.mock('fs/promises', () => ({
 vi.mock('fs', () => ({
   existsSync: existsSyncMock
 }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof BoundedFileReader>()
+  return {
+    ...actual,
+    readNodeFileWithinLimit: async (filePath: string, maxBytes: number) => {
+      const value = await readFileMock(filePath)
+      const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value)
+      if (buffer.length > maxBytes) {
+        throw new actual.NodeFileReadTooLargeError(buffer.length, maxBytes)
+      }
+      return { buffer, stats: { isFile: () => true, size: buffer.length } }
+    }
+  }
+})
 
 import { clearEffectiveUpstreamStatusCacheForTests, getStatus } from './status'
 

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines */
 import { existsSync } from 'node:fs'
-import { readFile, stat } from 'node:fs/promises'
 import * as path from 'node:path'
 import type {
   GitBranchChangeEntry,
@@ -31,6 +30,8 @@ import {
   type GitLineStats
 } from '../../shared/git-uncommitted-line-stats'
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
+import { iterateNulDelimitedFields } from '../../shared/nul-delimited-fields'
+import { iterateProcessOutputLines } from '../../shared/process-output-field-scanner'
 import {
   gitExecFileAsync,
   gitExecFileAsyncBuffer,
@@ -57,12 +58,18 @@ import {
   clearGitStatusLineStatsCacheKey,
   reuseOrRecomputeGitStatusLineStats
 } from '../../shared/git-status-line-stats-cache'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../../shared/node-bounded-file-reader'
 
 const MAX_GIT_SHOW_BYTES = 10 * 1024 * 1024
+const MAX_GIT_POINTER_FILE_BYTES = 64 * 1024
 const MAX_STAGED_COMMIT_CONTEXT_BYTES = MAX_GIT_SHOW_BYTES
 const BULK_CHUNK_SIZE = 100
 const EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_TTL_MS = 5 * 60_000
 const MAX_EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_ENTRIES = 512
+export const MAX_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES = 64 * 1024
 
 type EffectiveUpstreamStatusCacheEntry = {
   expiresAt: number
@@ -71,9 +78,19 @@ type EffectiveUpstreamStatusCacheEntry = {
 
 const SUBMODULE_PATHS_CACHE_TTL_MS = 5_000
 export const MAX_SUBMODULE_PATHS_CACHE_ENTRIES = 512
-type SubmodulePathsCacheEntry = { paths: string[]; expiresAt: number }
+export const MAX_SUBMODULE_PATHS_PER_REPO = 10_000
+export const MAX_SUBMODULE_PATH_CODE_UNITS = 64 * 1024
+export const MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS = 4 * 1024 * 1024
+export const MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS = 16 * 1024 * 1024
+const MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES = 64 * 1024
+type SubmodulePathsCacheEntry = {
+  paths: string[]
+  expiresAt: number
+  retainedCodeUnits: number
+}
 const submodulePathsCache = new Map<string, SubmodulePathsCacheEntry>()
 let submodulePathsCacheGeneration = 0
+let submodulePathsCacheCodeUnits = 0
 
 // Why: cache the upstream name to skip its 4-5-spawn resolution chain each poll; revalidate via one rev-list (issue #7576).
 const RESOLVED_UPSTREAM_NAME_CACHE_TTL_MS = 60_000
@@ -117,12 +134,17 @@ export function clearSubmodulePathsCacheForTests(): void {
 
 function clearSubmodulePathsCache(): void {
   submodulePathsCache.clear()
+  submodulePathsCacheCodeUnits = 0
   // Why: bump the generation so a pre-mutation read can't repopulate the invalidated cache.
   submodulePathsCacheGeneration += 1
 }
 
 export function getSubmodulePathsCacheCountForTests(): number {
   return submodulePathsCache.size
+}
+
+export function getSubmodulePathsCacheCodeUnitsForTests(): number {
+  return submodulePathsCacheCodeUnits
 }
 
 function gitRuntimeOptionsKey(options: GitRuntimeOptions): readonly unknown[] {
@@ -137,18 +159,30 @@ function getSubmodulePathsCacheKey(worktreePath: string, options: GitRuntimeOpti
 function pruneExpiredSubmodulePathsCache(now: number): void {
   for (const [cacheKey, entry] of submodulePathsCache) {
     if (entry.expiresAt <= now) {
-      submodulePathsCache.delete(cacheKey)
+      deleteSubmodulePathsCacheEntry(cacheKey)
     }
   }
 }
 
+function deleteSubmodulePathsCacheEntry(cacheKey: string): void {
+  const entry = submodulePathsCache.get(cacheKey)
+  if (!entry) {
+    return
+  }
+  submodulePathsCache.delete(cacheKey)
+  submodulePathsCacheCodeUnits -= entry.retainedCodeUnits
+}
+
 function trimSubmodulePathsCache(): void {
-  while (submodulePathsCache.size > MAX_SUBMODULE_PATHS_CACHE_ENTRIES) {
+  while (
+    submodulePathsCache.size > MAX_SUBMODULE_PATHS_CACHE_ENTRIES ||
+    submodulePathsCacheCodeUnits > MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS
+  ) {
     const oldestKey = submodulePathsCache.keys().next().value
     if (oldestKey === undefined) {
       break
     }
-    submodulePathsCache.delete(oldestKey)
+    deleteSubmodulePathsCacheEntry(oldestKey)
   }
 }
 
@@ -158,7 +192,7 @@ function getCachedSubmodulePaths(cacheKey: string, now: number): string[] | null
     return null
   }
   if (cached.expiresAt <= now) {
-    submodulePathsCache.delete(cacheKey)
+    deleteSubmodulePathsCacheEntry(cacheKey)
     return null
   }
   submodulePathsCache.delete(cacheKey)
@@ -167,8 +201,23 @@ function getCachedSubmodulePaths(cacheKey: string, now: number): string[] | null
 }
 
 function rememberSubmodulePaths(cacheKey: string, paths: string[], now: number): void {
-  submodulePathsCache.delete(cacheKey)
-  submodulePathsCache.set(cacheKey, { paths, expiresAt: now + SUBMODULE_PATHS_CACHE_TTL_MS })
+  if (Buffer.byteLength(cacheKey, 'utf8') > MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES) {
+    deleteSubmodulePathsCacheEntry(cacheKey)
+    return
+  }
+  const retainedCodeUnits =
+    cacheKey.length + paths.reduce((total, submodulePath) => total + submodulePath.length, 0)
+  if (retainedCodeUnits > MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS) {
+    deleteSubmodulePathsCacheEntry(cacheKey)
+    return
+  }
+  deleteSubmodulePathsCacheEntry(cacheKey)
+  submodulePathsCache.set(cacheKey, {
+    paths,
+    expiresAt: now + SUBMODULE_PATHS_CACHE_TTL_MS,
+    retainedCodeUnits
+  })
+  submodulePathsCacheCodeUnits += retainedCodeUnits
   trimSubmodulePathsCache()
 }
 
@@ -585,6 +634,10 @@ function getEffectiveUpstreamStatusCacheKey(
   return [worktreePath, options.wslDistro ?? 'host', branchName, upstreamName ?? ''].join('\0')
 }
 
+function canRetainEffectiveUpstreamCacheKey(cacheKey: string): boolean {
+  return Buffer.byteLength(cacheKey, 'utf8') <= MAX_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES
+}
+
 export function clearEffectiveUpstreamNegativeStatusCache(identity: {
   worktreePath: string
   branchName: string
@@ -601,6 +654,9 @@ export function clearEffectiveUpstreamNegativeStatusCache(identity: {
   effectiveUpstreamStatusCache.delete(cacheKey)
   effectiveUpstreamStatusInFlight.delete(cacheKey)
   resolvedUpstreamNameCache.delete(cacheKey)
+  if (!canRetainEffectiveUpstreamCacheKey(cacheKey)) {
+    return
+  }
   effectiveUpstreamStatusWriteGeneration.set(
     cacheKey,
     (effectiveUpstreamStatusWriteGeneration.get(cacheKey) ?? 0) + 1
@@ -666,6 +722,11 @@ function rememberEffectiveUpstreamStatus(
   probedSameNameOriginRef: boolean,
   writeGeneration: number
 ): void {
+  if (!canRetainEffectiveUpstreamCacheKey(cacheKey)) {
+    effectiveUpstreamStatusCache.delete(cacheKey)
+    effectiveUpstreamStatusWriteGeneration.delete(cacheKey)
+    return
+  }
   // Why: hasConfiguredPushTarget gates a write action; re-probe each poll rather than cache a stale positive.
   if (status.hasUpstream || status.hasConfiguredPushTarget) {
     effectiveUpstreamStatusCache.delete(cacheKey)
@@ -702,7 +763,8 @@ async function readOrProbeEffectiveUpstreamStatus(
   options: GitRuntimeOptions = {},
   bypassCache = false
 ): Promise<GitUpstreamStatus> {
-  if (!bypassCache) {
+  const cacheable = !bypassCache && canRetainEffectiveUpstreamCacheKey(cacheKey)
+  if (cacheable) {
     const cached = readCachedEffectiveUpstreamStatus(cacheKey, Date.now())
     if (cached) {
       return cached
@@ -721,7 +783,7 @@ async function readOrProbeEffectiveUpstreamStatus(
     worktreePath,
     branchName,
     options,
-    bypassCache
+    !cacheable
   ).then((result) => {
     rememberEffectiveUpstreamStatus(
       cacheKey,
@@ -732,7 +794,7 @@ async function readOrProbeEffectiveUpstreamStatus(
     )
     return result.status
   })
-  if (!bypassCache) {
+  if (cacheable) {
     effectiveUpstreamStatusInFlight.set(cacheKey, probe)
   }
   try {
@@ -773,7 +835,11 @@ async function probeOrRevalidateEffectiveUpstreamStatus(
     }
   }
   const result = await probeEffectiveUpstreamStatus(worktreePath, branchName, options)
-  if (result.status.hasUpstream && result.status.upstreamName) {
+  if (
+    canRetainEffectiveUpstreamCacheKey(cacheKey) &&
+    result.status.hasUpstream &&
+    result.status.upstreamName
+  ) {
     resolvedUpstreamNameCache.set(cacheKey, {
       upstreamName: result.status.upstreamName,
       expiresAt: Date.now() + RESOLVED_UPSTREAM_NAME_CACHE_TTL_MS
@@ -973,7 +1039,9 @@ export async function resolveGitDir(worktreePath: string): Promise<string> {
   const dotGitPath = path.join(worktreePath, '.git')
 
   try {
-    const dotGitContents = await readFile(dotGitPath, 'utf-8')
+    const dotGitContents = (
+      await readNodeFileWithinLimit(dotGitPath, MAX_GIT_POINTER_FILE_BYTES)
+    ).buffer.toString('utf-8')
     const match = dotGitContents.match(/^gitdir:\s*(.+)\s*$/m)
     if (match) {
       return path.resolve(worktreePath, match[1])
@@ -989,6 +1057,37 @@ export async function resolveGitDir(worktreePath: string): Promise<string> {
  * List configured submodule paths (relative, forward-slash) for a worktree, cached
  * briefly. Read from `.gitmodules` to avoid an index-wide `ls-files` scan.
  */
+function parseSubmodulePaths(stdout: string): string[] | null {
+  const paths: string[] = []
+  let retainedCodeUnits = 0
+  for (const line of iterateProcessOutputLines(stdout)) {
+    if (line.length > MAX_SUBMODULE_PATH_CODE_UNITS + 4_096) {
+      return null
+    }
+    const spaceIndex = line.indexOf(' ')
+    const submodulePath =
+      spaceIndex === -1
+        ? ''
+        : line
+            .slice(spaceIndex + 1)
+            .trim()
+            .replace(/\/+$/, '')
+    if (!submodulePath) {
+      continue
+    }
+    if (
+      paths.length >= MAX_SUBMODULE_PATHS_PER_REPO ||
+      submodulePath.length > MAX_SUBMODULE_PATH_CODE_UNITS ||
+      submodulePath.length > MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS - retainedCodeUnits
+    ) {
+      return null
+    }
+    paths.push(submodulePath)
+    retainedCodeUnits += submodulePath.length
+  }
+  return paths
+}
+
 export async function listSubmodulePaths(
   worktreePath: string,
   options: GitRuntimeOptions = {}
@@ -1008,18 +1107,7 @@ export async function listSubmodulePaths(
       ['config', '--file', '.gitmodules', '--get-regexp', '^submodule\\..*\\.path$'],
       { ...gitOptionsForWorktree(worktreePath, options), env: gitOptionalLocksDisabledEnv() }
     )
-    paths = stdout
-      .split(/\r?\n/)
-      .map((line) => {
-        const spaceIndex = line.indexOf(' ')
-        return spaceIndex === -1
-          ? ''
-          : line
-              .slice(spaceIndex + 1)
-              .trim()
-              .replace(/\/+$/, '')
-      })
-      .filter((value) => value.length > 0)
+    paths = parseSubmodulePaths(stdout) ?? []
   } catch {
     // No .gitmodules (or git config failure) — treat as a repo without submodules.
     paths = []
@@ -1770,30 +1858,22 @@ async function readGitBlobAtOidPath(
 }
 
 async function readWorkingTreeFile(filePath: string): Promise<GitBlobReadResult> {
-  let fileStat
   try {
-    fileStat = await stat(filePath)
+    const { buffer, stats: fileStat } = await readNodeFileWithinLimit(filePath, MAX_GIT_SHOW_BYTES)
+    if (!fileStat.isFile()) {
+      return { content: '', isBinary: false, exists: false }
+    }
+    return bufferToBlob(buffer, filePath)
   } catch (error) {
-    // Why: only ENOENT is a real deletion; other stat errors are read failures, not absence.
+    if (error instanceof NodeFileReadTooLargeError) {
+      return { content: '', isBinary: true, exists: true }
+    }
+    // Why: only ENOENT is a real deletion; other read errors are failures, not absence.
     return {
       content: '',
       isBinary: false,
       exists: (error as NodeJS.ErrnoException)?.code !== 'ENOENT'
     }
-  }
-  if (!fileStat.isFile()) {
-    return { content: '', isBinary: false, exists: false }
-  }
-  if (fileStat.size > MAX_GIT_SHOW_BYTES) {
-    // Why: mirror git's maxBuffer cap for working-tree reads so readFile can't pull in huge assets.
-    return { content: '', isBinary: true, exists: true }
-  }
-  try {
-    const buffer = await readFile(filePath)
-    return bufferToBlob(buffer, filePath)
-  } catch {
-    // Why: the file exists but could not be read — a read failure, not a deletion.
-    return { content: '', isBinary: false, exists: true }
   }
 }
 
@@ -2069,7 +2149,7 @@ async function listTrackedPathSpecs(
       }
     )
     // Why: a tracked directory can hold enough paths to exceed the JS argument limit.
-    for (const trackedPath of stdout.split('\0')) {
+    for (const trackedPath of iterateNulDelimitedFields(stdout)) {
       if (trackedPath) {
         trackedPaths.push(trackedPath)
       }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -18,6 +18,7 @@ import { isSubmoduleWorktreeRemovalRefusal } from '../../shared/worktree-submodu
 import { decodeGitCQuotedPath } from '../../shared/git-cquoted-path'
 import { parseGitRevListAheadBehindCounts } from '../../shared/git-rev-list-output'
 import { parseWslUncPath } from '../../shared/wsl-paths'
+import { iterateNulDelimitedFields } from '../../shared/nul-delimited-fields'
 import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedRevParsePathFormatError,
@@ -548,7 +549,7 @@ function splitNulWorktreeList(output: string): string[][] {
   const blocks: string[][] = []
   let currentBlock: string[] = []
 
-  for (const field of output.split('\0')) {
+  for (const field of iterateNulDelimitedFields(output)) {
     if (field) {
       currentBlock.push(field)
       continue
@@ -1376,10 +1377,12 @@ function hasOnlyIgnoredUntrackedStatus(
       )
       .filter((entry) => entry && !entry.split('/').includes('..'))
   )
-  return status
-    .split('\0')
-    .filter(Boolean)
-    .every((entry) => entry.startsWith('?? ') && ignored.has(entry.slice(3).replace(/\\/g, '/')))
+  for (const entry of iterateNulDelimitedFields(status)) {
+    if (entry && (!entry.startsWith('?? ') || !ignored.has(entry.slice(3).replace(/\\/g, '/')))) {
+      return false
+    }
+  }
+  return true
 }
 
 function translateWorktreePath(

--- a/src/main/local-downloaded-folder-promotion-budget.test.ts
+++ b/src/main/local-downloaded-folder-promotion-budget.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  LocalDownloadedFolderPromotionBudget,
+  type LocalDownloadedFolderPromotionLimits
+} from './local-downloaded-folder-promotion-budget'
+
+const limits: LocalDownloadedFolderPromotionLimits = {
+  maximumEntries: 2,
+  maximumDepth: 2,
+  maximumPathBytes: 4,
+  maximumRetainedPathBytes: 8
+}
+
+describe('LocalDownloadedFolderPromotionBudget', () => {
+  it('accepts every exact boundary', () => {
+    const budget = new LocalDownloadedFolderPromotionBudget(limits)
+
+    budget.recordEntry('12', '34', 2)
+    budget.recordEntry('56', '78', 2)
+  })
+
+  it.each([
+    [
+      'entries',
+      (budget: LocalDownloadedFolderPromotionBudget) => {
+        budget.recordEntry('', '', 0)
+        budget.recordEntry('', '', 0)
+        budget.recordEntry('', '', 0)
+      }
+    ],
+    ['depth', (budget: LocalDownloadedFolderPromotionBudget) => budget.recordEntry('', '', 3)],
+    ['path', (budget: LocalDownloadedFolderPromotionBudget) => budget.recordEntry('12345', '', 0)]
+  ] as const)('rejects one unit beyond the %s boundary', (reason, exceed) => {
+    expect(() => exceed(new LocalDownloadedFolderPromotionBudget(limits))).toThrow(
+      expect.objectContaining({ reason })
+    )
+  })
+
+  it('rejects one unit beyond the retained-path boundary', () => {
+    const budget = new LocalDownloadedFolderPromotionBudget({
+      ...limits,
+      maximumEntries: 3
+    })
+    budget.recordEntry('12', '34', 0)
+    budget.recordEntry('56', '78', 0)
+
+    expect(() => budget.recordEntry('9', '', 0)).toThrow(
+      expect.objectContaining({ reason: 'paths' })
+    )
+  })
+})

--- a/src/main/local-downloaded-folder-promotion-budget.ts
+++ b/src/main/local-downloaded-folder-promotion-budget.ts
@@ -1,0 +1,49 @@
+export type LocalDownloadedFolderPromotionLimits = {
+  maximumEntries: number
+  maximumDepth: number
+  maximumPathBytes: number
+  maximumRetainedPathBytes: number
+}
+
+export const LOCAL_DOWNLOADED_FOLDER_PROMOTION_LIMITS: LocalDownloadedFolderPromotionLimits = {
+  maximumEntries: 50_000,
+  maximumDepth: 64,
+  maximumPathBytes: 64 * 1024,
+  maximumRetainedPathBytes: 16 * 1024 * 1024
+}
+
+export class LocalDownloadedFolderPromotionCapacityError extends Error {
+  constructor(readonly reason: 'entries' | 'depth' | 'path' | 'paths') {
+    super(`Downloaded folder promotion exceeds the ${reason} limit`)
+    this.name = 'LocalDownloadedFolderPromotionCapacityError'
+  }
+}
+
+export class LocalDownloadedFolderPromotionBudget {
+  private entries = 0
+  private retainedPathBytes = 0
+
+  constructor(private readonly limits = LOCAL_DOWNLOADED_FOLDER_PROMOTION_LIMITS) {}
+
+  recordEntry(sourcePath: string, destinationPath: string, depth: number): void {
+    if (depth > this.limits.maximumDepth) {
+      throw new LocalDownloadedFolderPromotionCapacityError('depth')
+    }
+    this.entries += 1
+    if (this.entries > this.limits.maximumEntries) {
+      throw new LocalDownloadedFolderPromotionCapacityError('entries')
+    }
+    const sourceBytes = Buffer.byteLength(sourcePath, 'utf8')
+    const destinationBytes = Buffer.byteLength(destinationPath, 'utf8')
+    if (
+      sourceBytes > this.limits.maximumPathBytes ||
+      destinationBytes > this.limits.maximumPathBytes
+    ) {
+      throw new LocalDownloadedFolderPromotionCapacityError('path')
+    }
+    this.retainedPathBytes += sourceBytes + destinationBytes
+    if (this.retainedPathBytes > this.limits.maximumRetainedPathBytes) {
+      throw new LocalDownloadedFolderPromotionCapacityError('paths')
+    }
+  }
+}

--- a/src/main/local-downloaded-folder-promotion-traversal.ts
+++ b/src/main/local-downloaded-folder-promotion-traversal.ts
@@ -1,0 +1,51 @@
+import type { Dirent } from 'node:fs'
+import { opendir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { LocalDownloadedFolderPromotionBudget } from './local-downloaded-folder-promotion-budget'
+
+export async function readPromotionDirectoryEntries(
+  sourcePath: string,
+  destinationPath: string,
+  budget: LocalDownloadedFolderPromotionBudget,
+  depth: number
+): Promise<Dirent[]> {
+  const entries: Dirent[] = []
+  const directory = await opendir(sourcePath)
+  try {
+    for await (const entry of directory) {
+      budget.recordEntry(join(sourcePath, entry.name), join(destinationPath, entry.name), depth + 1)
+      entries.push(entry)
+    }
+  } finally {
+    await directory.close().catch(() => undefined)
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export async function assertPromotionTreeWithinCapacity(
+  sourceRoot: string,
+  destinationRoot: string,
+  signal?: AbortSignal
+): Promise<void> {
+  const budget = new LocalDownloadedFolderPromotionBudget()
+  const pending = [{ sourcePath: sourceRoot, destinationPath: destinationRoot, depth: 0 }]
+  while (pending.length > 0) {
+    signal?.throwIfAborted()
+    const current = pending.pop()!
+    const directory = await opendir(current.sourcePath)
+    try {
+      for await (const entry of directory) {
+        signal?.throwIfAborted()
+        const sourcePath = join(current.sourcePath, entry.name)
+        const destinationPath = join(current.destinationPath, entry.name)
+        const depth = current.depth + 1
+        budget.recordEntry(sourcePath, destinationPath, depth)
+        if (entry.isDirectory()) {
+          pending.push({ sourcePath, destinationPath, depth })
+        }
+      }
+    } finally {
+      await directory.close().catch(() => undefined)
+    }
+  }
+}

--- a/src/main/local-downloaded-folder-promotion.test.ts
+++ b/src/main/local-downloaded-folder-promotion.test.ts
@@ -19,6 +19,7 @@ import {
   copyLocalDownloadedFileNoClobber,
   publishLocalDownloadedFileNoClobber
 } from './local-downloaded-folder-promotion'
+import { LOCAL_DOWNLOADED_FOLDER_PROMOTION_LIMITS } from './local-downloaded-folder-promotion-budget'
 
 describe('promoteLocalDownloadedFolder', () => {
   const roots: string[] = []
@@ -113,6 +114,30 @@ describe('promoteLocalDownloadedFolder', () => {
 
     await expect(readdir(tempPath)).resolves.toEqual(['nested'])
     await expect(readdir(destinationPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects excessive depth before claiming the destination', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-folder-promotion-'))
+    roots.push(root)
+    const tempPath = join(root, '.transfer.download')
+    const destinationPath = join(root, 'downloaded')
+    await mkdir(tempPath)
+    let nested = tempPath
+    for (
+      let depth = 0;
+      depth <= LOCAL_DOWNLOADED_FOLDER_PROMOTION_LIMITS.maximumDepth;
+      depth += 1
+    ) {
+      nested = join(nested, 'd')
+      await mkdir(nested)
+    }
+
+    await expect(promoteLocalDownloadedFolder(tempPath, destinationPath)).rejects.toMatchObject({
+      reason: 'depth'
+    })
+
+    await expect(lstat(destinationPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(lstat(nested)).resolves.toMatchObject({ isDirectory: expect.any(Function) })
   })
 
   it('rolls back unchanged entries after a mid-publication failure', async () => {

--- a/src/main/local-downloaded-folder-promotion.ts
+++ b/src/main/local-downloaded-folder-promotion.ts
@@ -1,8 +1,12 @@
-import { fstatSync, lstatSync } from 'node:fs'
-import { link, lstat, mkdir, open, readdir, rm, rmdir, unlink } from 'node:fs/promises'
-import type { BigIntStats } from 'node:fs'
+import { fstatSync, lstatSync, type BigIntStats } from 'node:fs'
+import { link, lstat, mkdir, open, rm, rmdir, unlink } from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
 import { join } from 'node:path'
+import { LocalDownloadedFolderPromotionBudget } from './local-downloaded-folder-promotion-budget'
+import {
+  assertPromotionTreeWithinCapacity,
+  readPromotionDirectoryEntries
+} from './local-downloaded-folder-promotion-traversal'
 
 const LOCAL_COPY_CHUNK_BYTES = 1024 * 1024
 
@@ -210,6 +214,8 @@ async function publishDirectoryNoClobber(
   sourcePath: string,
   destinationPath: string,
   publishedEntries: PublishedEntry[],
+  budget: LocalDownloadedFolderPromotionBudget,
+  depth: number,
   signal?: AbortSignal
 ): Promise<void> {
   await mkdir(destinationPath, { recursive: false })
@@ -217,9 +223,7 @@ async function publishDirectoryNoClobber(
   // claim so no async gap exists before rollback ownership is registered.
   const destinationStats = lstatSync(destinationPath, { bigint: true })
   publishedEntries.push(publishedEntryFromStats('directory', destinationPath, destinationStats))
-  const entries = (await readdir(sourcePath, { withFileTypes: true })).toSorted((a, b) =>
-    a.name.localeCompare(b.name)
-  )
+  const entries = await readPromotionDirectoryEntries(sourcePath, destinationPath, budget, depth)
   for (const entry of entries) {
     signal?.throwIfAborted()
     const sourceEntryPath = join(sourcePath, entry.name)
@@ -229,6 +233,8 @@ async function publishDirectoryNoClobber(
         sourceEntryPath,
         destinationEntryPath,
         publishedEntries,
+        budget,
+        depth + 1,
         signal
       )
     } else if (entry.isFile()) {
@@ -252,11 +258,20 @@ export async function promoteLocalDownloadedFolder(
   signal?: AbortSignal
 ): Promise<void> {
   signal?.throwIfAborted()
+  await assertPromotionTreeWithinCapacity(tempPath, destinationPath, signal)
+  signal?.throwIfAborted()
   const publishedEntries: PublishedEntry[] = []
   try {
     // Why: Node has no portable atomic no-replace directory rename. Claiming
     // the destination first preserves no-clobber while promotion stays local.
-    await publishDirectoryNoClobber(tempPath, destinationPath, publishedEntries, signal)
+    await publishDirectoryNoClobber(
+      tempPath,
+      destinationPath,
+      publishedEntries,
+      new LocalDownloadedFolderPromotionBudget(),
+      0,
+      signal
+    )
   } catch (error) {
     await rollbackPublishedEntries(publishedEntries)
     if (isEEXIST(error)) {

--- a/src/main/local-worktree-filesystem.test.ts
+++ b/src/main/local-worktree-filesystem.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock, lstatMock, readFileMock, rmMock } = vi.hoisted(() => ({
+const { execFileMock, lstatMock, readNodeFileWithinLimitMock, rmMock } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
   lstatMock: vi.fn(),
-  readFileMock: vi.fn(),
+  readNodeFileWithinLimitMock: vi.fn(),
   rmMock: vi.fn()
 }))
 
@@ -13,8 +13,11 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:fs/promises', () => ({
   lstat: lstatMock,
-  readFile: readFileMock,
   rm: rmMock
+}))
+
+vi.mock('../shared/node-bounded-file-reader', () => ({
+  readNodeFileWithinLimit: readNodeFileWithinLimitMock
 }))
 
 import {
@@ -49,7 +52,7 @@ describe('local worktree filesystem runtime access', () => {
   beforeEach(() => {
     execFileMock.mockReset()
     lstatMock.mockReset()
-    readFileMock.mockReset()
+    readNodeFileWithinLimitMock.mockReset()
     rmMock.mockReset()
     completeExecFile()
   })
@@ -61,7 +64,9 @@ describe('local worktree filesystem runtime access', () => {
 
   it('uses host filesystem operations when no WSL distro is selected', async () => {
     lstatMock.mockResolvedValue({ type: 'file' })
-    readFileMock.mockResolvedValue('gitdir: ../.git/worktrees/feature')
+    readNodeFileWithinLimitMock.mockResolvedValue({
+      buffer: Buffer.from('gitdir: ../.git/worktrees/feature')
+    })
 
     const access = getLocalWorktreePathAccess()
     await access.statPath('C:\\repo\\.git')
@@ -69,7 +74,7 @@ describe('local worktree filesystem runtime access', () => {
     await removeLocalWorktreePath('C:\\repo\\feature')
 
     expect(lstatMock).toHaveBeenCalledWith('C:\\repo\\.git')
-    expect(readFileMock).toHaveBeenCalledWith('C:\\repo\\.git', 'utf8')
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith('C:\\repo\\.git', 64 * 1024)
     expect(rmMock).toHaveBeenCalledWith(
       toHostRemovalPath('C:\\repo\\feature'),
       expect.objectContaining({
@@ -165,12 +170,25 @@ describe('local worktree filesystem runtime access', () => {
         expect.objectContaining({ encoding: 'utf8' }),
         expect.any(Function)
       )
+      const readArgs = execFileMock.mock.calls[1]?.[1] as string[]
+      expect(readArgs.at(-1)).toContain('head -c 65537 --')
       const removeArgs = execFileMock.mock.calls[2]?.[1] as string[]
       expect(removeArgs.at(-1)).toContain('rm -rf --')
       expect(removeArgs.at(-1)).toContain(
         String.raw`rm -rf -- '\''/mnt/c/Users/me/repo feature'\''`
       )
       expect(rmMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it('rejects oversized WSL Git pointer output', async () => {
+    await withPlatform('win32', async () => {
+      completeExecFile('x'.repeat(64 * 1024 + 1))
+      const access = getLocalWorktreePathAccess({ wslDistro: 'Ubuntu' })
+
+      await expect(access.readPath('/home/me/repo/.git')).rejects.toThrow(
+        'Worktree Git pointer exceeds the safe read limit'
+      )
     })
   })
 

--- a/src/main/local-worktree-filesystem.ts
+++ b/src/main/local-worktree-filesystem.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process'
 import type { RmOptions } from 'node:fs'
-import { lstat, readFile, rm } from 'node:fs/promises'
+import { lstat, rm } from 'node:fs/promises'
 import { win32 } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
 import {
@@ -9,7 +9,12 @@ import {
   quotePosixShell
 } from '../shared/wsl-login-shell-command'
 import { toLinuxPath } from './wsl'
-import type { ReadPath, StatPath } from './worktree-orphan-gitdir-proof'
+import {
+  MAX_WORKTREE_GIT_POINTER_BYTES,
+  type ReadPath,
+  type StatPath
+} from './worktree-orphan-gitdir-proof'
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
 
 export type LocalWorktreeFilesystemOptions = {
   wslDistro?: string
@@ -37,13 +42,13 @@ function shouldUseWslFilesystem(options: LocalWorktreeFilesystemOptions): boolea
 function execFileText(
   file: string,
   args: string[],
-  options: { timeout: number }
+  options: { maxBuffer?: number; timeout: number }
 ): Promise<ExecFileTextResult> {
   return new Promise((resolve, reject) => {
     execFile(
       file,
       args,
-      { encoding: 'utf8', timeout: options.timeout },
+      { encoding: 'utf8', timeout: options.timeout, maxBuffer: options.maxBuffer },
       (error, stdout, stderr) => {
         if (error) {
           reject(error)
@@ -97,7 +102,10 @@ export function getLocalWorktreePathAccess(
   if (!shouldUseWslFilesystem(options) || !distro) {
     return {
       statPath: lstat,
-      readPath: (path) => readFile(path, 'utf8')
+      readPath: async (path) =>
+        (await readNodeFileWithinLimit(path, MAX_WORKTREE_GIT_POINTER_BYTES)).buffer.toString(
+          'utf8'
+        )
     }
   }
 
@@ -120,7 +128,26 @@ export function getLocalWorktreePathAccess(
     },
     readPath: async (path) => {
       const target = quotePosixShell(toLinuxPath(path))
-      const { stdout } = await runWslLoginShellCommand(distro, `cat -- ${target}`)
+      const { stdout } = await execFileText(
+        'wsl.exe',
+        [
+          '-d',
+          distro,
+          '--',
+          'sh',
+          '-lc',
+          escapeWslShCommandForWindows(
+            buildWslLoginShellCommand(`head -c ${MAX_WORKTREE_GIT_POINTER_BYTES + 1} -- ${target}`)
+          )
+        ],
+        {
+          timeout: WSL_FILE_OPERATION_TIMEOUT_MS,
+          maxBuffer: (MAX_WORKTREE_GIT_POINTER_BYTES + 1) * 2
+        }
+      )
+      if (Buffer.byteLength(stdout, 'utf8') > MAX_WORKTREE_GIT_POINTER_BYTES) {
+        throw new Error('Worktree Git pointer exceeds the safe read limit')
+      }
       return stdout
     }
   }

--- a/src/main/observability/bundle.test.ts
+++ b/src/main/observability/bundle.test.ts
@@ -1,7 +1,7 @@
 // Bundle collection + upload tests. Upload helpers live outside bundle.ts, but
 // this suite keeps the diagnostic bundle contract in one place.
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { createServer, type RequestListener, type Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -342,6 +342,23 @@ describe('bundle — collection', () => {
         orcaChannel: 'dev'
       })
     ).not.toThrow()
+  })
+
+  it('skips a sparse source file above the bounded read limit', () => {
+    writeFileSync(traceFile, '')
+    truncateSync(traceFile, 50 * 1024 * 1024 + 1)
+
+    const bundle = collectBundle({
+      traceFilePath: traceFile,
+      maxFiles: 10,
+      appVersion: '1',
+      platform: 'darwin',
+      arch: 'arm64',
+      osRelease: '24',
+      orcaChannel: 'dev'
+    })
+
+    expect(bundle.spanCount).toBe(0)
   })
 
   it('skips valid JSON lines that are not span objects without throwing', () => {

--- a/src/main/observability/bundle.ts
+++ b/src/main/observability/bundle.ts
@@ -7,12 +7,13 @@
 // upload body-size cap, token-handling discipline).
 
 import { randomBytes } from 'node:crypto'
-import { readFileSync, statSync } from 'node:fs'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 import { MAX_BUNDLE_BYTES } from './diagnostic-bundle-limits'
 import { listRotatedFiles } from './local-file-sink'
 import { redactValue } from './redactor'
 
 const DEFAULT_LOOKBACK_MINUTES = 30
+const MAX_BUNDLE_SOURCE_FILE_BYTES = 50 * 1024 * 1024
 
 export type CollectBundleOptions = {
   readonly traceFilePath: string
@@ -103,12 +104,7 @@ export function collectBundle(opts: CollectBundleOptions): CollectedBundle {
   outer: for (const file of files) {
     let text: string
     try {
-      // stat first: the sink caps at 10 MB/file, so a tampered oversize file could panic-allocate on read.
-      const size = statSync(file).size
-      if (size > 50 * 1024 * 1024) {
-        continue
-      }
-      text = readFileSync(file, 'utf8')
+      text = readNodeFileSyncWithinLimit(file, MAX_BUNDLE_SOURCE_FILE_BYTES).buffer.toString('utf8')
     } catch {
       continue
     }

--- a/src/main/observability/diagnostic-upload-http.ts
+++ b/src/main/observability/diagnostic-upload-http.ts
@@ -1,6 +1,7 @@
 import { request as httpRequest, type ClientRequest, type IncomingMessage } from 'node:http'
 import { request as httpsRequest } from 'node:https'
 import { URL } from 'node:url'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 
 export const MAX_RESPONSE_BYTES = 1024 * 1024
 
@@ -40,7 +41,7 @@ function postRaw(
     let settled = false
     let req: ClientRequest | null = null
     let res: IncomingMessage | null = null
-    const chunks: Buffer[] = []
+    const responseBody = new GrowingByteBuffer()
     let responseBytes = 0
     function cleanupListeners(): void {
       req?.off('error', onRequestError)
@@ -54,6 +55,7 @@ function postRaw(
         return
       }
       settled = true
+      responseBody.clear()
       cleanupListeners()
       resolve(value)
     }
@@ -65,6 +67,7 @@ function postRaw(
         return
       }
       settled = true
+      responseBody.clear()
       if (options.destroyRequest) {
         req?.destroy()
       }
@@ -85,11 +88,11 @@ function postRaw(
         })
         return
       }
-      chunks.push(chunk)
+      responseBody.append(chunk)
     }
     function onResponseEnd(): void {
       const status = res?.statusCode ?? 0
-      const text = Buffer.concat(chunks).toString('utf8')
+      const text = responseBody.takeString()
       if (status >= 200 && status < 300) {
         try {
           resolveOnce(text.length > 0 ? JSON.parse(text) : {})

--- a/src/main/observability/local-file-sink.test.ts
+++ b/src/main/observability/local-file-sink.test.ts
@@ -12,7 +12,12 @@ import {
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { createLocalFileSink, getRotatedFamilySize, listRotatedFiles } from './local-file-sink'
+import {
+  createLocalFileSink,
+  DEFAULT_FLUSH_BUFFER_BYTE_THRESHOLD,
+  getRotatedFamilySize,
+  listRotatedFiles
+} from './local-file-sink'
 
 let dir: string
 
@@ -65,6 +70,50 @@ describe('local-file-sink — basic write', () => {
     // 5th push hits the threshold, flushes synchronously.
     expect(statSync(file).size).toBeGreaterThan(0)
     sink.close()
+  })
+
+  it('flushes at the default byte threshold before the count threshold', () => {
+    const file = join(dir, 'test.ndjson')
+    const emptyLineBytes = Buffer.byteLength(`${JSON.stringify({ payload: '' })}\n`, 'utf8')
+    const record = {
+      payload: 'x'.repeat(DEFAULT_FLUSH_BUFFER_BYTE_THRESHOLD - emptyLineBytes)
+    }
+    const sink = createLocalFileSink({
+      filePath: file,
+      batchWindowMs: 100_000,
+      flushBufferThreshold: 10_000
+    })
+
+    sink.push(record)
+
+    expect(statSync(file).size).toBe(DEFAULT_FLUSH_BUFFER_BYTE_THRESHOLD)
+    sink.close()
+  })
+
+  it('flushes a prior byte batch without reordering the next record', () => {
+    const file = join(dir, 'test.ndjson')
+    const first = { i: 1, payload: '😀'.repeat(8) }
+    const second = { i: 2, payload: '😀'.repeat(8) }
+    const firstLineBytes = Buffer.byteLength(`${JSON.stringify(first)}\n`, 'utf8')
+    const secondLineBytes = Buffer.byteLength(`${JSON.stringify(second)}\n`, 'utf8')
+    const sink = createLocalFileSink({
+      filePath: file,
+      batchWindowMs: 100_000,
+      flushBufferThreshold: 100,
+      flushBufferByteThreshold: firstLineBytes + secondLineBytes - 1
+    })
+
+    sink.push(first)
+    expect(statSync(file).size).toBe(0)
+    sink.push(second)
+    expect(statSync(file).size).toBe(firstLineBytes)
+    sink.close()
+
+    const records = readFileSync(file, 'utf8')
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => JSON.parse(line) as { i: number })
+    expect(records.map((record) => record.i)).toEqual([1, 2])
   })
 
   it('creates trace directories and files with private POSIX permissions', () => {
@@ -167,6 +216,31 @@ describe('local-file-sink — rotation', () => {
     const lines = readFileSync(file, 'utf8').split('\n').filter(Boolean)
     expect(lines.map((line) => JSON.parse(line))).toEqual([{ ok: true }])
     expect(getRotatedFamilySize(file, 3)).toBeLessThanOrEqual(100)
+  })
+
+  it('stops serializing an oversized record before visiting the whole value', () => {
+    const file = join(dir, 'test.ndjson')
+    const sink = createLocalFileSink({
+      filePath: file,
+      maxBytes: 100,
+      batchWindowMs: 100_000,
+      flushBufferThreshold: 1
+    })
+    let visits = 0
+    const payload = Array.from({ length: 10_000 }, () => ({
+      toJSON: () => {
+        visits += 1
+        return 'value'
+      }
+    }))
+
+    sink.push({ payload })
+    sink.push({ ok: true })
+    sink.close()
+
+    expect(visits).toBeLessThan(payload.length)
+    const lines = readFileSync(file, 'utf8').split('\n').filter(Boolean)
+    expect(lines.map((line) => JSON.parse(line))).toEqual([{ ok: true }])
   })
 
   it('splits an oversized buffered batch instead of dropping valid records', () => {

--- a/src/main/observability/local-file-sink.ts
+++ b/src/main/observability/local-file-sink.ts
@@ -18,8 +18,10 @@ import {
   writeSync
 } from 'node:fs'
 import { dirname } from 'node:path'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
 
 const DEFAULT_FLUSH_BUFFER_THRESHOLD = 32
+export const DEFAULT_FLUSH_BUFFER_BYTE_THRESHOLD = 1024 * 1024
 export const DEFAULT_MAX_BYTES = 10 * 1024 * 1024 // 10 MB
 export const DEFAULT_MAX_FILES = 10
 export const DEFAULT_BATCH_WINDOW_MS = 200
@@ -32,6 +34,7 @@ export type LocalFileSinkOptions = {
   readonly maxFiles?: number
   readonly batchWindowMs?: number
   readonly flushBufferThreshold?: number
+  readonly flushBufferByteThreshold?: number
 }
 
 export type LocalFileSink = {
@@ -66,6 +69,14 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
   const maxFiles = opts.maxFiles ?? DEFAULT_MAX_FILES
   const batchWindowMs = opts.batchWindowMs ?? DEFAULT_BATCH_WINDOW_MS
   const flushThreshold = opts.flushBufferThreshold ?? DEFAULT_FLUSH_BUFFER_THRESHOLD
+  const requestedFlushByteThreshold =
+    opts.flushBufferByteThreshold ?? DEFAULT_FLUSH_BUFFER_BYTE_THRESHOLD
+  const flushByteThreshold = Number.isFinite(requestedFlushByteThreshold)
+    ? Math.max(
+        1,
+        Math.min(DEFAULT_FLUSH_BUFFER_BYTE_THRESHOLD, Math.trunc(requestedFlushByteThreshold))
+      )
+    : DEFAULT_FLUSH_BUFFER_BYTE_THRESHOLD
 
   // Traces hold paths and crash context; lock to current-user regardless of umask.
   const traceDirectory = dirname(filePath)
@@ -78,6 +89,7 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
   let currentBytes: number = safeFstatSize(fd)
 
   let buffer: string[] = []
+  let bufferBytes = 0
   let timer: NodeJS.Timeout | null = null
   let closed = false
 
@@ -135,6 +147,7 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
     }
     const lines = buffer
     buffer = []
+    bufferBytes = 0
     let pendingChunk: string[] = []
     let pendingChunkBytes = 0
 
@@ -210,14 +223,21 @@ export function createLocalFileSink(opts: LocalFileSinkOptions): LocalFileSink {
         return
       }
       let line: string
+      let lineBytes: number
       try {
-        line = `${JSON.stringify(record)}\n`
+        const serialized = stringifyJsonWithinByteLimit(record, Math.max(0, maxBytes - 1))
+        line = `${serialized.serialized}\n`
+        lineBytes = serialized.byteLength + 1
       } catch {
         // Redactor handles cycles upstream; a throw here means pre-redact data slipped in — drop rather than crash (best-effort).
         return
       }
+      if (bufferBytes > 0 && bufferBytes + lineBytes > flushByteThreshold) {
+        flushBuffer()
+      }
       buffer.push(line)
-      if (buffer.length >= flushThreshold) {
+      bufferBytes += lineBytes
+      if (buffer.length >= flushThreshold || bufferBytes >= flushByteThreshold) {
         flushBuffer()
       } else {
         ensureTimer()

--- a/src/main/orca-profiles/profile-cloud-client.ts
+++ b/src/main/orca-profiles/profile-cloud-client.ts
@@ -7,6 +7,7 @@ import type { OrcaCloudAuthConfig } from './profile-cloud-auth-config'
 import type { OrcaCloudSession } from './profile-cloud-session-store'
 import type { OrcaCloudSessionExchangeResponse } from './profile-cloud-session-exchange'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 type ExchangeCodeArgs = {
   code: string
@@ -177,7 +178,7 @@ async function postJson<T>(url: string, body: unknown, accessToken?: string): Pr
     await cancelUnreadResponseBody(response)
     throw new OrcaCloudRequestError(response.status)
   }
-  return (await response.json()) as T
+  return await readFetchResponseJsonWithinLimit<T>(response)
 }
 
 export async function exchangeOrcaCloudAuthCode(

--- a/src/main/orca-profiles/profile-cloud-dev-org-members.test.ts
+++ b/src/main/orca-profiles/profile-cloud-dev-org-members.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  _getDevOrcaCloudOrgRosterCountForTests,
+  _resetDevOrcaCloudOrgRostersForTests,
+  DEV_ORG_PENDING_INVITE_MAX_ENTRIES,
+  DEV_ORG_ROSTER_MAX_ENTRIES,
+  inviteDevOrcaCloudOrgMember,
+  listDevOrcaCloudOrgMembers
+} from './profile-cloud-dev-org-members'
+
+beforeEach(() => {
+  _resetDevOrcaCloudOrgRostersForTests()
+})
+
+describe('dev organization roster retention', () => {
+  it('bounds retained organizations while keeping recently used rosters', () => {
+    for (let index = 0; index <= DEV_ORG_ROSTER_MAX_ENTRIES; index += 1) {
+      listDevOrcaCloudOrgMembers(`org-${index}`)
+    }
+    expect(_getDevOrcaCloudOrgRosterCountForTests()).toBe(DEV_ORG_ROSTER_MAX_ENTRIES)
+  })
+
+  it('bounds pending invites within one retained roster', () => {
+    const orgId = 'invite-heavy-org'
+    for (let index = 1; index < DEV_ORG_PENDING_INVITE_MAX_ENTRIES; index += 1) {
+      expect(
+        inviteDevOrcaCloudOrgMember({
+          orgId,
+          email: `person-${index}@example.com`,
+          role: 'member'
+        })
+      ).toEqual({ status: 'ok' })
+    }
+    expect(
+      inviteDevOrcaCloudOrgMember({
+        orgId,
+        email: 'overflow@example.com',
+        role: 'member'
+      })
+    ).toEqual({ status: 'failed', error: 'The dev organization invite roster is full.' })
+  })
+
+  it('does not retain oversized invitation text', () => {
+    expect(
+      inviteDevOrcaCloudOrgMember({
+        orgId: 'org',
+        email: `${'x'.repeat(321)}@example.com`,
+        role: 'member'
+      })
+    ).toEqual({ status: 'failed', error: 'The dev organization invite roster is full.' })
+    expect(listDevOrcaCloudOrgMembers('org').pendingInvites).toHaveLength(1)
+  })
+})

--- a/src/main/orca-profiles/profile-cloud-dev-org-members.ts
+++ b/src/main/orca-profiles/profile-cloud-dev-org-members.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type {
   OrcaOrgMember,
   OrcaOrgMembersRoster,
@@ -8,6 +9,7 @@ import type {
   OrcaProfileOrgMemberRemoveArgs,
   OrcaProfileOrgInviteRevokeArgs
 } from '../../shared/orca-profiles'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 // Why: dev-auth mode has no server, so the whole teammate UI is exercised
 // against this in-memory per-org roster. It mirrors the shape the real client
@@ -19,10 +21,17 @@ type DevOrgRoster = {
 }
 
 const devRostersByOrg = new Map<string, DevOrgRoster>()
+export const DEV_ORG_ROSTER_MAX_ENTRIES = 64
+export const DEV_ORG_PENDING_INVITE_MAX_ENTRIES = 256
+const DEV_ORG_ENV_FIELD_MAX_BYTES = 4 * 1024
+const DEV_ORG_INVITE_EMAIL_MAX_BYTES = 320
 
 function cleanEnvString(value: string | undefined, fallback: string): string {
   const trimmed = value?.trim()
-  return trimmed || fallback
+  return trimmed &&
+    !measureUtf8ByteLength(trimmed, { stopAfterBytes: DEV_ORG_ENV_FIELD_MAX_BYTES }).exceededLimit
+    ? trimmed
+    : fallback
 }
 
 function devSelf(): OrcaOrgMember {
@@ -52,12 +61,22 @@ function seedDevRoster(): DevOrgRoster {
 }
 
 function getDevRoster(orgId: string): DevOrgRoster {
-  const existing = devRostersByOrg.get(orgId)
+  const cacheKey = createHash('sha256').update(orgId).digest('base64url')
+  const existing = devRostersByOrg.get(cacheKey)
   if (existing) {
+    devRostersByOrg.delete(cacheKey)
+    devRostersByOrg.set(cacheKey, existing)
     return existing
   }
   const seeded = seedDevRoster()
-  devRostersByOrg.set(orgId, seeded)
+  devRostersByOrg.set(cacheKey, seeded)
+  while (devRostersByOrg.size > DEV_ORG_ROSTER_MAX_ENTRIES) {
+    const oldest = devRostersByOrg.keys().next().value
+    if (oldest === undefined) {
+      break
+    }
+    devRostersByOrg.delete(oldest)
+  }
   return seeded
 }
 
@@ -81,6 +100,14 @@ export function inviteDevOrcaCloudOrgMember(
   }
   if (roster.pendingInvites.some((invite) => invite.email.toLowerCase() === email)) {
     return { status: 'conflict', reason: 'already_invited' }
+  }
+  if (
+    roster.pendingInvites.length >= DEV_ORG_PENDING_INVITE_MAX_ENTRIES ||
+    measureUtf8ByteLength(args.email, {
+      stopAfterBytes: DEV_ORG_INVITE_EMAIL_MAX_BYTES
+    }).exceededLimit
+  ) {
+    return { status: 'failed', error: 'The dev organization invite roster is full.' }
   }
   roster.pendingInvites.push({ email: args.email, role: args.role, createdAt: Date.now() })
   return { status: 'ok' }
@@ -127,4 +154,12 @@ export function removeDevOrcaCloudOrgMember(
   }
   roster.members.splice(index, 1)
   return { status: 'ok' }
+}
+
+export function _resetDevOrcaCloudOrgRostersForTests(): void {
+  devRostersByOrg.clear()
+}
+
+export function _getDevOrcaCloudOrgRosterCountForTests(): number {
+  return devRostersByOrg.size
 }

--- a/src/main/orca-profiles/profile-cloud-org-members-client.ts
+++ b/src/main/orca-profiles/profile-cloud-org-members-client.ts
@@ -7,6 +7,7 @@ import type {
 import type { OrcaCloudAuthConfig } from './profile-cloud-auth-config'
 import type { OrcaCloudSession } from './profile-cloud-session-store'
 import { OrcaCloudRequestError } from './profile-cloud-client'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 const CLOUD_REQUEST_TIMEOUT_MS = 30_000
 const ORG_ROLES: readonly OrcaOrgRole[] = ['owner', 'admin', 'member']
@@ -106,7 +107,7 @@ function orgMembersUrl(config: OrcaCloudAuthConfig, orgId: string, path: string)
 
 async function extractErrorCode(response: Response): Promise<string | undefined> {
   try {
-    const body = (await response.json()) as unknown
+    const body = await readFetchResponseJsonWithinLimit<unknown>(response)
     if (
       body &&
       typeof body === 'object' &&
@@ -145,7 +146,7 @@ async function requestOrgMembers<T>(
   if (!response.ok) {
     throw new OrcaCloudRequestError(response.status, await extractErrorCode(response))
   }
-  return parse((await response.json()) as unknown)
+  return parse(await readFetchResponseJsonWithinLimit<unknown>(response))
 }
 
 export async function listOrcaCloudOrgMembers(

--- a/src/main/orca-profiles/profile-cloud-session-mutation.test.ts
+++ b/src/main/orca-profiles/profile-cloud-session-mutation.test.ts
@@ -1,10 +1,13 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   captureCloudSessionMutation,
   isCloudSessionMutationCurrent,
+  MAX_CLOUD_SESSION_IDENTITY_KEY_BYTES,
+  MAX_CLOUD_SESSION_MUTATION_STATE_FILE_BYTES,
+  MAX_CLOUD_SESSION_TOMBSTONES,
   recordCloudSessionIdentityMutation,
   recordSuccessfulCloudSessionLogin,
   tombstoneCloudSession,
@@ -58,5 +61,59 @@ describe('cloud session mutation fence', () => {
     expect(isCloudSessionMutationCurrent(identity.localProfileId, userDataPath, snapshot)).toBe(
       true
     )
+  })
+
+  it('rejects an oversized sparse mutation fence before parsing it', () => {
+    const profileDirectory = join(userDataPath, 'profiles', identity.localProfileId)
+    mkdirSync(profileDirectory, { recursive: true })
+    const path = join(profileDirectory, 'account-session-mutation.json')
+    writeFileSync(path, '{"version":1}')
+    truncateSync(path, MAX_CLOUD_SESSION_MUTATION_STATE_FILE_BYTES + 1)
+
+    expect(() => captureCloudSessionMutation(identity, userDataPath)).toThrow(
+      'invalid_cloud_session_mutation_state'
+    )
+  })
+
+  it('bounds tombstones while the advancing epoch keeps old snapshots invalid', () => {
+    const firstIdentity = { ...identity, cloudUserId: 'user-0' }
+    const firstSnapshot = captureCloudSessionMutation(firstIdentity, userDataPath)
+
+    for (let index = 0; index <= MAX_CLOUD_SESSION_TOMBSTONES; index += 1) {
+      tombstoneCloudSession({ ...identity, cloudUserId: `user-${index}` }, userDataPath)
+    }
+
+    const path = join(
+      userDataPath,
+      'profiles',
+      identity.localProfileId,
+      'account-session-mutation.json'
+    )
+    const state = JSON.parse(readFileSync(path, 'utf8')) as {
+      tombstonedIdentityKeys: string[]
+    }
+    expect(state.tombstonedIdentityKeys).toHaveLength(MAX_CLOUD_SESSION_TOMBSTONES)
+    expect(
+      isCloudSessionMutationCurrent(identity.localProfileId, userDataPath, firstSnapshot)
+    ).toBe(false)
+  })
+
+  it('rejects an oversized identity before changing the last readable fence', () => {
+    captureCloudSessionMutation(identity, userDataPath)
+    const path = join(
+      userDataPath,
+      'profiles',
+      identity.localProfileId,
+      'account-session-mutation.json'
+    )
+    const before = readFileSync(path, 'utf8')
+
+    expect(() =>
+      recordCloudSessionIdentityMutation(
+        { ...identity, cloudUserId: 'x'.repeat(MAX_CLOUD_SESSION_IDENTITY_KEY_BYTES) },
+        userDataPath
+      )
+    ).toThrow('cloud_session_identity_too_large')
+    expect(readFileSync(path, 'utf8')).toBe(before)
   })
 })

--- a/src/main/orca-profiles/profile-cloud-session-mutation.ts
+++ b/src/main/orca-profiles/profile-cloud-session-mutation.ts
@@ -1,10 +1,15 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { writeSecureJsonFile } from '../../shared/secure-file'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { JsonStringifyByteLimitError } from '../../shared/node-bounded-json-stringify'
+import { writeSecureJsonFileWithinLimit } from '../../shared/bounded-secure-json-file'
 import type { OrcaProfileCloudSummary } from '../../shared/orca-profiles'
 import { getOrcaProfileDirectory } from './profile-storage-paths'
 
 const MUTATION_STATE_VERSION = 1
+export const MAX_CLOUD_SESSION_MUTATION_STATE_FILE_BYTES = 1024 * 1024
+export const MAX_CLOUD_SESSION_IDENTITY_KEY_BYTES = 16 * 1024
+export const MAX_CLOUD_SESSION_TOMBSTONES = 512
 
 export type CloudSessionIdentity = {
   localProfileId: string
@@ -26,7 +31,11 @@ type CloudSessionMutationState = {
 }
 
 function identityKey(identity: CloudSessionIdentity): string {
-  return `${identity.localProfileId}\0${identity.cloudUserId}\0${identity.cloudProfileId}\0${identity.organizationId}`
+  const key = `${identity.localProfileId}\0${identity.cloudUserId}\0${identity.cloudProfileId}\0${identity.organizationId}`
+  if (Buffer.byteLength(key, 'utf8') > MAX_CLOUD_SESSION_IDENTITY_KEY_BYTES) {
+    throw new Error('cloud_session_identity_too_large')
+  }
+  return key
 }
 
 function statePath(profileId: string, userDataPath: string): string {
@@ -54,7 +63,12 @@ function readState(profileId: string, userDataPath: string): CloudSessionMutatio
     return null
   }
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
+    const parsed: unknown = JSON.parse(
+      readNodeFileSyncWithinLimit(
+        path,
+        MAX_CLOUD_SESSION_MUTATION_STATE_FILE_BYTES
+      ).buffer.toString('utf8')
+    )
     if (!isState(parsed)) {
       throw new Error('invalid_cloud_session_mutation_state')
     }
@@ -69,7 +83,22 @@ function saveState(
   userDataPath: string,
   state: CloudSessionMutationState
 ): void {
-  writeSecureJsonFile(statePath(profileId, userDataPath), state)
+  const tombstonedIdentityKeys = state.tombstonedIdentityKeys.slice(-MAX_CLOUD_SESSION_TOMBSTONES)
+  while (true) {
+    try {
+      writeSecureJsonFileWithinLimit(
+        statePath(profileId, userDataPath),
+        { ...state, tombstonedIdentityKeys },
+        MAX_CLOUD_SESSION_MUTATION_STATE_FILE_BYTES
+      )
+      return
+    } catch (error) {
+      if (!(error instanceof JsonStringifyByteLimitError) || tombstonedIdentityKeys.length === 0) {
+        throw error
+      }
+      tombstonedIdentityKeys.shift()
+    }
+  }
 }
 
 export function cloudSessionIdentity(

--- a/src/main/orca-profiles/profile-cloud-session-store.test.ts
+++ b/src/main/orca-profiles/profile-cloud-session-store.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { OrcaCloudSession } from './profile-cloud-session-store'
@@ -167,6 +175,104 @@ describe('Orca cloud session store', () => {
       status: 'decrypt-failed',
       persistence: 'none',
       error: 'Unsafe session format.'
+    })
+  })
+
+  it('rejects an oversized sparse encrypted-session wrapper before decrypting', async () => {
+    writePlaintextSessionFile('profile-1', makeSession())
+    const store = await loadSessionStore()
+    truncateSync(
+      store.getOrcaCloudSessionPath('profile-1', userDataPath),
+      store.MAX_ORCA_CLOUD_SESSION_FILE_BYTES + 1
+    )
+
+    expect(store.readOrcaCloudSession('profile-1', userDataPath)).toEqual({
+      status: 'decrypt-failed',
+      persistence: 'none',
+      error: 'Could not decrypt saved Orca account session.'
+    })
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized session without replacing the prior durable or cached session', async () => {
+    const store = await loadSessionStore()
+    const session = makeSession()
+    store.saveOrcaCloudSession('profile-1', userDataPath, session)
+    const path = store.getOrcaCloudSessionPath('profile-1', userDataPath)
+    const durableBefore = readFileSync(path, 'utf-8')
+
+    expect(() =>
+      store.saveOrcaCloudSession('profile-1', userDataPath, {
+        ...session,
+        accessToken: 'x'.repeat(store.MAX_ORCA_CLOUD_SESSION_PAYLOAD_BYTES)
+      })
+    ).toThrow(`JSON output exceeds ${store.MAX_ORCA_CLOUD_SESSION_PAYLOAD_BYTES} bytes`)
+    expect(readFileSync(path, 'utf-8')).toBe(durableBefore)
+    expect(store.readOrcaCloudSession('profile-1', userDataPath)).toEqual({
+      status: 'found',
+      session,
+      persistence: 'encrypted'
+    })
+  })
+
+  it('removes stale durable credentials when encryption expansion exceeds the file limit', async () => {
+    const store = await loadSessionStore()
+    const prior = makeSession()
+    store.saveOrcaCloudSession('profile-1', userDataPath, prior)
+    const session = {
+      ...prior,
+      accessToken: 'x'.repeat(Math.floor(store.MAX_ORCA_CLOUD_SESSION_FILE_BYTES * 0.8))
+    }
+
+    expect(store.saveOrcaCloudSession('profile-1', userDataPath, session)).toBe('memory-only')
+    expect(existsSync(store.getOrcaCloudSessionPath('profile-1', userDataPath))).toBe(false)
+    expect(store.readOrcaCloudSession('profile-1', userDataPath)).toEqual({
+      status: 'found',
+      session,
+      persistence: 'memory-only'
+    })
+  })
+
+  it('evicts the least-recently-used memory-only session at the entry limit', async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const store = await loadSessionStore()
+    const session = makeSession()
+
+    for (let index = 0; index <= store.MAX_ORCA_CLOUD_MEMORY_SESSIONS; index += 1) {
+      store.saveOrcaCloudSession(`profile-${index}`, userDataPath, session)
+    }
+
+    expect(store.readOrcaCloudSession('profile-0', userDataPath)).toEqual({
+      status: 'missing',
+      persistence: 'none'
+    })
+    expect(
+      store.readOrcaCloudSession(`profile-${store.MAX_ORCA_CLOUD_MEMORY_SESSIONS}`, userDataPath)
+    ).toMatchObject({ status: 'found', session })
+  })
+
+  it('evicts memory-only sessions before exceeding the aggregate byte limit', async () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const store = await loadSessionStore()
+    const session = {
+      ...makeSession(),
+      accessToken: 'x'.repeat(store.MAX_ORCA_CLOUD_SESSION_PAYLOAD_BYTES - 1024)
+    }
+    const writesNeeded =
+      Math.floor(
+        store.MAX_ORCA_CLOUD_MEMORY_SESSION_BYTES / store.MAX_ORCA_CLOUD_SESSION_PAYLOAD_BYTES
+      ) + 2
+
+    for (let index = 0; index < writesNeeded; index += 1) {
+      store.saveOrcaCloudSession(`profile-${index}`, userDataPath, session)
+    }
+
+    expect(store.readOrcaCloudSession('profile-0', userDataPath)).toMatchObject({
+      status: 'missing'
+    })
+    expect(store.readOrcaCloudSession(`profile-${writesNeeded - 1}`, userDataPath)).toMatchObject({
+      status: 'found',
+      session
     })
   })
 })

--- a/src/main/orca-profiles/profile-cloud-session-store.ts
+++ b/src/main/orca-profiles/profile-cloud-session-store.ts
@@ -1,7 +1,12 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import { safeStorage } from 'electron'
-import { writeSecureJsonFile } from '../../shared/secure-file'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../../shared/node-bounded-json-stringify'
+import { writeSecureJsonFileWithinLimit } from '../../shared/bounded-secure-json-file'
 import type {
   OrcaCloudCapabilities,
   OrcaCloudOrgSummary,
@@ -47,12 +52,52 @@ type PersistedPlaintextSession = {
 type CachedOrcaCloudSession = {
   session: OrcaCloudSession
   persistence: Exclude<OrcaCloudSessionPersistence, 'none'>
+  bytes: number
 }
 
 const memorySessions = new Map<string, CachedOrcaCloudSession>()
+export const MAX_ORCA_CLOUD_SESSION_FILE_BYTES = 1024 * 1024
+export const MAX_ORCA_CLOUD_SESSION_PAYLOAD_BYTES = MAX_ORCA_CLOUD_SESSION_FILE_BYTES
+export const MAX_ORCA_CLOUD_MEMORY_SESSIONS = 128
+export const MAX_ORCA_CLOUD_MEMORY_SESSION_BYTES = 16 * 1024 * 1024
+let memorySessionBytes = 0
 
 function sessionCacheKey(profileId: string, userDataPath: string): string {
   return `${userDataPath}\0${profileId}`
+}
+
+function rememberMemorySession(
+  cacheKey: string,
+  session: OrcaCloudSession,
+  persistence: Exclude<OrcaCloudSessionPersistence, 'none'>,
+  bytes: number
+): void {
+  const previous = memorySessions.get(cacheKey)
+  if (previous) {
+    memorySessionBytes -= previous.bytes
+    memorySessions.delete(cacheKey)
+  }
+  while (
+    memorySessions.size >= MAX_ORCA_CLOUD_MEMORY_SESSIONS ||
+    memorySessionBytes + bytes > MAX_ORCA_CLOUD_MEMORY_SESSION_BYTES
+  ) {
+    const oldestKey = memorySessions.keys().next().value as string | undefined
+    if (oldestKey === undefined) {
+      break
+    }
+    const oldest = memorySessions.get(oldestKey)
+    memorySessions.delete(oldestKey)
+    memorySessionBytes -= oldest?.bytes ?? 0
+  }
+  memorySessions.set(cacheKey, { session, persistence, bytes })
+  memorySessionBytes += bytes
+}
+
+function serializedSessionWithinLimit(
+  session: OrcaCloudSession,
+  maxBytes = MAX_ORCA_CLOUD_SESSION_PAYLOAD_BYTES
+): { serialized: string; byteLength: number } {
+  return stringifyJsonWithinByteLimit(session, maxBytes)
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -106,15 +151,29 @@ export function saveOrcaCloudSession(
   session: OrcaCloudSession
 ): OrcaCloudSessionPersistence {
   const cacheKey = sessionCacheKey(profileId, userDataPath)
+  const payload = serializedSessionWithinLimit(session)
   if (safeStorage.isEncryptionAvailable()) {
     const encrypted: PersistedEncryptedSession = {
       version: 1,
       format: 'electron-safe-storage-v1',
       savedAt: Date.now(),
-      ciphertext: safeStorage.encryptString(JSON.stringify(session)).toString('base64')
+      ciphertext: safeStorage.encryptString(payload.serialized).toString('base64')
     }
-    writeSecureJsonFile(getOrcaCloudSessionPath(profileId, userDataPath), encrypted)
-    memorySessions.set(cacheKey, { session, persistence: 'encrypted' })
+    try {
+      writeSecureJsonFileWithinLimit(
+        getOrcaCloudSessionPath(profileId, userDataPath),
+        encrypted,
+        MAX_ORCA_CLOUD_SESSION_FILE_BYTES
+      )
+    } catch (error) {
+      if (!(error instanceof JsonStringifyByteLimitError)) {
+        throw error
+      }
+      rmSync(getOrcaCloudSessionPath(profileId, userDataPath), { force: true })
+      rememberMemorySession(cacheKey, session, 'memory-only', payload.byteLength)
+      return 'memory-only'
+    }
+    rememberMemorySession(cacheKey, session, 'encrypted', payload.byteLength)
     return 'encrypted'
   }
 
@@ -125,14 +184,27 @@ export function saveOrcaCloudSession(
       savedAt: Date.now(),
       session
     }
-    writeSecureJsonFile(getOrcaCloudSessionPath(profileId, userDataPath), plaintext)
-    memorySessions.set(cacheKey, { session, persistence: 'dev-plaintext' })
+    try {
+      writeSecureJsonFileWithinLimit(
+        getOrcaCloudSessionPath(profileId, userDataPath),
+        plaintext,
+        MAX_ORCA_CLOUD_SESSION_FILE_BYTES
+      )
+    } catch (error) {
+      if (!(error instanceof JsonStringifyByteLimitError)) {
+        throw error
+      }
+      rmSync(getOrcaCloudSessionPath(profileId, userDataPath), { force: true })
+      rememberMemorySession(cacheKey, session, 'memory-only', payload.byteLength)
+      return 'memory-only'
+    }
+    rememberMemorySession(cacheKey, session, 'dev-plaintext', payload.byteLength)
     return 'dev-plaintext'
   }
 
   // Why: Orca account refresh tokens must not silently fall back to plaintext
   // in production. Memory-only keeps cloud features usable until restart.
-  memorySessions.set(cacheKey, { session, persistence: 'memory-only' })
+  rememberMemorySession(cacheKey, session, 'memory-only', payload.byteLength)
   return 'memory-only'
 }
 
@@ -172,6 +244,8 @@ export function readOrcaCloudSession(
   const cacheKey = sessionCacheKey(profileId, userDataPath)
   const memorySession = memorySessions.get(cacheKey)
   if (memorySession) {
+    memorySessions.delete(cacheKey)
+    memorySessions.set(cacheKey, memorySession)
     return {
       status: 'found',
       session: memorySession.session,
@@ -185,9 +259,9 @@ export function readOrcaCloudSession(
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as
-      | PersistedEncryptedSession
-      | PersistedPlaintextSession
+    const parsed = JSON.parse(
+      readNodeFileSyncWithinLimit(path, MAX_ORCA_CLOUD_SESSION_FILE_BYTES).buffer.toString('utf8')
+    ) as PersistedEncryptedSession | PersistedPlaintextSession
     if (parsed.version !== 1) {
       return { status: 'decrypt-failed', persistence: 'none', error: 'Unsupported session format.' }
     }
@@ -204,14 +278,19 @@ export function readOrcaCloudSession(
       if (!isOrcaCloudSession(session)) {
         return { status: 'decrypt-failed', persistence: 'none', error: 'Invalid saved session.' }
       }
-      memorySessions.set(cacheKey, { session, persistence: 'encrypted' })
+      const payload = serializedSessionWithinLimit(session, MAX_ORCA_CLOUD_SESSION_FILE_BYTES)
+      rememberMemorySession(cacheKey, session, 'encrypted', payload.byteLength)
       return { status: 'found', session, persistence: 'encrypted' }
     }
     if (parsed.format === 'dev-plaintext-v1' && allowsPlaintextOrcaCloudSession()) {
       if (!isOrcaCloudSession(parsed.session)) {
         return { status: 'decrypt-failed', persistence: 'none', error: 'Invalid saved session.' }
       }
-      memorySessions.set(cacheKey, { session: parsed.session, persistence: 'dev-plaintext' })
+      const payload = serializedSessionWithinLimit(
+        parsed.session,
+        MAX_ORCA_CLOUD_SESSION_FILE_BYTES
+      )
+      rememberMemorySession(cacheKey, parsed.session, 'dev-plaintext', payload.byteLength)
       return { status: 'found', session: parsed.session, persistence: 'dev-plaintext' }
     }
     return { status: 'decrypt-failed', persistence: 'none', error: 'Unsafe session format.' }
@@ -225,6 +304,11 @@ export function readOrcaCloudSession(
 }
 
 export function clearOrcaCloudSession(profileId: string, userDataPath: string): void {
-  memorySessions.delete(sessionCacheKey(profileId, userDataPath))
+  const cacheKey = sessionCacheKey(profileId, userDataPath)
+  const cached = memorySessions.get(cacheKey)
+  if (cached) {
+    memorySessionBytes -= cached.bytes
+    memorySessions.delete(cacheKey)
+  }
   rmSync(getOrcaCloudSessionPath(profileId, userDataPath), { force: true })
 }

--- a/src/main/orca-profiles/profile-index-store.test.ts
+++ b/src/main/orca-profiles/profile-index-store.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import {
@@ -168,6 +176,40 @@ describe('profile index store', () => {
     const recovered = store.getOrcaProfileListState()
     expect(recovered.profiles.map((profile) => profile.id)).toContain(created.profile.id)
     expect(recovered.profiles.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('recovers an oversized sparse profile index from the backup copy', async () => {
+    const store = await loadProfileIndexStore()
+    store.ensureActiveOrcaProfile()
+    const created = store.createLocalOrcaProfile({ name: 'Work' })
+    store.setActiveOrcaProfile(created.profile.id)
+    const indexPath = store.getOrcaProfileIndexPath()
+    truncateSync(indexPath, store.MAX_ORCA_PROFILE_INDEX_FILE_BYTES + 1)
+
+    expect(store.getOrcaProfileListState().profiles.map((profile) => profile.id)).toContain(
+      created.profile.id
+    )
+  })
+
+  it('rejects an oversized profile index without changing the primary or backup', async () => {
+    const store = await loadProfileIndexStore()
+    store.ensureActiveOrcaProfile()
+    store.createLocalOrcaProfile({ name: 'Work' })
+    const indexPath = store.getOrcaProfileIndexPath()
+    const primaryBefore = readFileSync(indexPath, 'utf-8')
+    const backupBefore = readFileSync(`${indexPath}.bak`, 'utf-8')
+    const oversized = store.readProfileIndex(indexPath)!
+    oversized.profiles[0] = {
+      ...oversized.profiles[0],
+      name: 'x'.repeat(store.MAX_ORCA_PROFILE_INDEX_FILE_BYTES)
+    }
+
+    expect(() => store.writeProfileIndex(indexPath, oversized)).toThrow(
+      `JSON output exceeds ${store.MAX_ORCA_PROFILE_INDEX_FILE_BYTES} bytes`
+    )
+    expect(readFileSync(indexPath, 'utf-8')).toBe(primaryBefore)
+    expect(readFileSync(`${indexPath}.bak`, 'utf-8')).toBe(backupBefore)
+    expect(existsSync(`${indexPath}.tmp`)).toBe(false)
   })
 
   it('rejects profile ids that are not safe path segments', async () => {

--- a/src/main/orca-profiles/profile-index-store.ts
+++ b/src/main/orca-profiles/profile-index-store.ts
@@ -1,13 +1,8 @@
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  writeFileSync
-} from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { dirname } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
 import type { GlobalSettings } from '../../shared/types'
 import {
   createDefaultLocalOrcaProfile,
@@ -48,6 +43,8 @@ export type ActiveOrcaProfileState = {
   dataFile: string
   profileDirectory: string
 }
+
+export const MAX_ORCA_PROFILE_INDEX_FILE_BYTES = 1024 * 1024
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -105,7 +102,13 @@ function sanitizeProfileName(value: unknown): string {
 
 function readProfileIndexFile(indexPath: string): OrcaProfileIndex | null {
   try {
-    return normalizeProfileIndex(JSON.parse(readFileSync(indexPath, 'utf-8')))
+    return normalizeProfileIndex(
+      JSON.parse(
+        readNodeFileSyncWithinLimit(indexPath, MAX_ORCA_PROFILE_INDEX_FILE_BYTES).buffer.toString(
+          'utf8'
+        )
+      )
+    )
   } catch {
     return null
   }
@@ -118,6 +121,10 @@ export function readProfileIndex(indexPath: string): OrcaProfileIndex | null {
 }
 
 export function writeProfileIndex(indexPath: string, index: OrcaProfileIndex): void {
+  const serialized = stringifyJsonWithinByteLimit(
+    index,
+    MAX_ORCA_PROFILE_INDEX_FILE_BYTES
+  ).serialized
   mkdirSync(dirname(indexPath), { recursive: true })
   // Why: only a still-parseable current index may refresh the backup;
   // copying a corrupt file over the backup would destroy the recovery copy.
@@ -129,7 +136,7 @@ export function writeProfileIndex(indexPath: string, index: OrcaProfileIndex): v
     }
   }
   const tmpPath = `${indexPath}.tmp`
-  writeFileSync(tmpPath, JSON.stringify(index, null, 2), 'utf-8')
+  writeFileSync(tmpPath, serialized, 'utf-8')
   renameSync(tmpPath, indexPath)
 }
 

--- a/src/main/orca-profiles/profile-project-state-file-bounds.test.ts
+++ b/src/main/orca-profiles/profile-project-state-file-bounds.test.ts
@@ -1,0 +1,71 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState } from '../../shared/constants'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import { JsonStringifyByteLimitError } from '../../shared/node-bounded-json-stringify'
+import { getOrcaProfileDataFile } from './profile-index-store'
+import { readProfileState, writeProfileState } from './profile-project-state-file'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => ''
+  }
+}))
+
+describe('profile project state file bounds', () => {
+  let userDataPath = ''
+  const profileId = 'work'
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(tmpdir(), 'orca-profile-state-bounds-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('round-trips ordinary state with compact JSON semantics unchanged', () => {
+    const state = getDefaultPersistedState('/Users/tester')
+    state.settings.theme = 'dark'
+    const native = JSON.stringify(state)
+
+    writeProfileState(profileId, userDataPath, state, Buffer.byteLength(native))
+
+    expect(readFileSync(getOrcaProfileDataFile(profileId, userDataPath), 'utf8')).toBe(native)
+    expect(readProfileState(profileId, userDataPath).settings.theme).toBe('dark')
+  })
+
+  it('rejects a profile read one byte over its limit before parsing', () => {
+    const dataFile = getOrcaProfileDataFile(profileId, userDataPath)
+    mkdirSync(dirname(dataFile), { recursive: true })
+    writeFileSync(dataFile, '')
+    truncateSync(dataFile, 1025)
+
+    expect(() => readProfileState(profileId, userDataPath, 1024)).toThrow(NodeFileReadTooLargeError)
+  })
+
+  it('leaves the prior profile and no temp file when output exceeds its limit', () => {
+    const state = getDefaultPersistedState('/Users/tester')
+    writeProfileState(profileId, userDataPath, state)
+    const dataFile = getOrcaProfileDataFile(profileId, userDataPath)
+    const prior = readFileSync(dataFile)
+    state.settings.theme = 'light'
+    const nextBytes = Buffer.byteLength(JSON.stringify(state))
+
+    expect(() => writeProfileState(profileId, userDataPath, state, nextBytes - 1)).toThrow(
+      JsonStringifyByteLimitError
+    )
+    expect(readFileSync(dataFile)).toEqual(prior)
+    expect(readdirSync(dirname(dataFile)).filter((name) => name.endsWith('.tmp'))).toEqual([])
+  })
+})

--- a/src/main/orca-profiles/profile-project-state-file.ts
+++ b/src/main/orca-profiles/profile-project-state-file.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname } from 'node:path'
 import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../shared/constants'
@@ -13,6 +13,10 @@ import type {
   SparsePreset,
   WorkspaceSessionState
 } from '../../shared/types'
+import {
+  readPersistedStateJsonFileSync,
+  stringifyPersistedStateWithinLimit
+} from '../../shared/persisted-state-file-bounds'
 import { getOrcaProfileDataFile } from './profile-index-store'
 
 export type TransferProfileState = PersistedState
@@ -29,13 +33,20 @@ function recordOrEmpty<T>(value: unknown): Record<string, T> {
   return isRecord(value) ? (value as Record<string, T>) : {}
 }
 
-export function readProfileState(profileId: string, userDataPath: string): TransferProfileState {
+export function readProfileState(
+  profileId: string,
+  userDataPath: string,
+  maxBytes?: number
+): TransferProfileState {
   const defaults = getDefaultPersistedState(homedir())
   const dataFile = getOrcaProfileDataFile(profileId, userDataPath)
   if (!existsSync(dataFile)) {
     return structuredClone(defaults)
   }
-  const parsed = JSON.parse(readFileSync(dataFile, 'utf-8')) as Partial<PersistedState>
+  const { value: parsed } = readPersistedStateJsonFileSync<Partial<PersistedState>>(
+    dataFile,
+    maxBytes
+  )
   return rebuildRepoBackedProjectState({
     ...defaults,
     ...parsed,
@@ -84,13 +95,20 @@ export function readProfileState(profileId: string, userDataPath: string): Trans
 export function writeProfileState(
   profileId: string,
   userDataPath: string,
-  state: TransferProfileState
+  state: TransferProfileState,
+  maxBytes?: number
 ): void {
   const dataFile = getOrcaProfileDataFile(profileId, userDataPath)
   mkdirSync(dirname(dataFile), { recursive: true })
   const tmpPath = `${dataFile}.${process.pid}.${randomUUID()}.tmp`
-  writeFileSync(tmpPath, JSON.stringify(state, null, 2), 'utf-8')
-  renameSync(tmpPath, dataFile)
+  const { serialized } = stringifyPersistedStateWithinLimit(state, maxBytes)
+  try {
+    writeFileSync(tmpPath, serialized, 'utf-8')
+    renameSync(tmpPath, dataFile)
+  } catch (error) {
+    rmSync(tmpPath, { force: true })
+    throw error
+  }
 }
 
 function isRepoBackedProjectHostSetup(

--- a/src/main/persistence-state-bounds.test.ts
+++ b/src/main/persistence-state-bounds.test.ts
@@ -1,0 +1,157 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ORCA_PERSISTED_STATE_MAX_BYTES,
+  ORCA_PERSISTED_STATE_SECRET_MAX_BYTES
+} from '../shared/persisted-state-file-bounds'
+
+const testState = { dir: '' }
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.dir
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf8').replace(/^encrypted:/, '')
+  }
+}))
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(),
+  sshConfigHostsToTargets: vi.fn()
+}))
+
+vi.mock('./telemetry/client', () => ({
+  track: vi.fn()
+}))
+
+vi.mock('./telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: vi.fn().mockReturnValue({ nth_repo_added: 0 })
+}))
+
+describe('Store persisted-state bounds', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-persistence-bounds-'))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  function dataFile(): string {
+    return join(testState.dir, 'orca-data.json')
+  }
+
+  function backupFile(index: number): string {
+    return `${dataFile()}.bak.${index}`
+  }
+
+  function writeMinimalState(path: string, theme: 'dark' | 'light'): string {
+    const serialized = JSON.stringify({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { theme },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    writeFileSync(path, serialized)
+    return serialized
+  }
+
+  async function createStore() {
+    vi.resetModules()
+    const { Store, initDataPath } = await import('./persistence')
+    initDataPath()
+    return new Store()
+  }
+
+  it('recovers atomically from an in-limit backup when the primary is oversized', async () => {
+    writeFileSync(dataFile(), '')
+    truncateSync(dataFile(), ORCA_PERSISTED_STATE_MAX_BYTES + 1)
+    const backup = writeMinimalState(backupFile(0), 'dark')
+
+    const store = await createStore()
+
+    expect(store.getSettings().theme).toBe('dark')
+    expect(readFileSync(dataFile(), 'utf8')).toBe(backup)
+    store.updateSettings({ theme: 'light' })
+    store.flushOrThrow()
+    expect(JSON.parse(readFileSync(dataFile(), 'utf8')).settings.theme).toBe('light')
+  })
+
+  it('skips an oversized backup slot and recovers from the next bounded slot', async () => {
+    writeFileSync(dataFile(), '{{corrupt')
+    writeFileSync(backupFile(0), '')
+    truncateSync(backupFile(0), ORCA_PERSISTED_STATE_MAX_BYTES + 1)
+    writeMinimalState(backupFile(1), 'light')
+
+    const store = await createStore()
+
+    expect(store.getSettings().theme).toBe('light')
+  })
+
+  it('uses defaults but freezes writes when no bounded recovery source exists', async () => {
+    vi.useFakeTimers()
+    try {
+      writeFileSync(dataFile(), '')
+      truncateSync(dataFile(), ORCA_PERSISTED_STATE_MAX_BYTES + 1)
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const store = await createStore()
+      store.updateSettings({ theme: 'dark' })
+      await vi.advanceTimersByTimeAsync(2000)
+      await store.waitForPendingWrite()
+      store.flushOrThrow()
+
+      expect(statSync(dataFile()).size).toBe(ORCA_PERSISTED_STATE_MAX_BYTES + 1)
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[persistence] State exceeds the safe load limit; using defaults with state writes frozen'
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps the last valid file when a secret makes a sync flush exceed its bound', async () => {
+    const store = await createStore()
+    store.flushOrThrow()
+    const validState = readFileSync(dataFile())
+    store.updateSettings({
+      opencodeSessionCookie: 'x'.repeat(ORCA_PERSISTED_STATE_SECRET_MAX_BYTES + 1)
+    })
+
+    expect(() => store.flushOrThrow()).toThrow('Persisted state secret exceeds')
+    expect(readFileSync(dataFile())).toEqual(validState)
+  })
+
+  it('keeps the last valid file when an asynchronous bounded write is rejected', async () => {
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+      store.flushOrThrow()
+      const validState = readFileSync(dataFile())
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      store.updateSettings({
+        opencodeSessionCookie: 'x'.repeat(ORCA_PERSISTED_STATE_SECRET_MAX_BYTES + 1)
+      })
+
+      await vi.advanceTimersByTimeAsync(2000)
+      await store.waitForPendingWrite()
+
+      expect(readFileSync(dataFile())).toEqual(validState)
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[persistence] Failed to write state:',
+        expect.objectContaining({ name: 'PersistedStateSecretCapacityError' })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -9,7 +9,8 @@ import {
   existsSync,
   realpathSync,
   statSync,
-  symlinkSync
+  symlinkSync,
+  truncateSync
 } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -38,6 +39,7 @@ import {
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
 import { toRuntimeExecutionHostId, toSshExecutionHostId } from '../shared/execution-host'
 import { SshConnectionStore } from './ssh/ssh-connection-store'
+import { ORCA_PERSISTED_STATE_MAX_BYTES } from '../shared/persisted-state-file-bounds'
 import { setSourceControlActionDefault } from '../shared/source-control-ai-actions'
 import { LEGACY_DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { closeTerminalTabInWorkspaceSession } from '../shared/workspace-session-terminal-tab-close'
@@ -5489,6 +5491,16 @@ describe('Store', () => {
 
     const restarted = await createStore()
     expect(restarted.getGitHubCache().pr['o/r#7']).toEqual({ fetchedAt: 7 })
+  })
+
+  it('ignores an oversized sparse GitHub cache sidecar', async () => {
+    const cacheFile = join(testState.dir, 'orca-github-cache.json')
+    writeFileSync(cacheFile, '')
+    truncateSync(cacheFile, ORCA_PERSISTED_STATE_MAX_BYTES + 1)
+
+    const store = await createStore()
+
+    expect(store.getGitHubCache()).toEqual({ pr: {}, issue: {} })
   })
 
   it('keeps GitHub cache sidecars scoped to explicit profile data files', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines -- Why: persistence keeps schema defaults, migration, and load/save/flush in one file so the storage contract reviews as a unit. */
 import { app, safeStorage } from 'electron'
 import {
-  readFileSync,
   writeFileSync,
   mkdirSync,
   existsSync,
@@ -245,6 +244,19 @@ import {
 import { track } from './telemetry/client'
 import { getCohortAtEmit } from './telemetry/cohort-classifier'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from './startup/startup-diagnostics'
+import {
+  assertPersistedStateSecretWithinLimit,
+  encodePersistedStateJsonStringContent,
+  isPersistedStateFileCapacityError,
+  parsePersistedStateJsonBuffer,
+  readPersistedStateJsonFileSync,
+  readPersistedStateFileBytesSync,
+  replacePersistedStateJsonWithinLimit,
+  replacedPersistedStateJsonByteLength,
+  restorePersistedStateBackupSync,
+  stringifyPersistedStateWithinLimit,
+  updatePersistedStateHashWithJsonRange
+} from '../shared/persisted-state-file-bounds'
 
 function encrypt(plaintext: string): string {
   if (!plaintext || !safeStorage.isEncryptionAvailable()) {
@@ -406,7 +418,7 @@ function gcStaleWorktreeMeta(state: PersistedState): number {
 
 function readGithubCacheSnapshot(dataFile: string): PersistedState['githubCache'] | null {
   try {
-    const parsed = JSON.parse(readFileSync(getGithubCacheFile(dataFile), 'utf-8')) as unknown
+    const { value: parsed } = readPersistedStateJsonFileSync<unknown>(getGithubCacheFile(dataFile))
     const isPlainRecord = (value: unknown): value is Record<string, unknown> =>
       typeof value === 'object' && value !== null && !Array.isArray(value)
     if (
@@ -2568,7 +2580,6 @@ export class Store {
   private lastWrittenStateHash: string | null = null
   private firstPendingSaveAt: number | null = null
   private githubCacheDirty = false
-  private gitUsernameCache = new Map<string, string>()
   private loadNeedsSave = false
   private settingsChangeListeners = new Set<
     (
@@ -2757,24 +2768,26 @@ export class Store {
     }
   }
 
-  private restoreFromBackup(dataFile: string): boolean {
+  private restoreFromBackup(dataFile: string): {
+    rejectedOversizedBackup: boolean
+    restored: boolean
+  } {
+    let rejectedOversizedBackup = false
     for (let i = 0; i < BACKUP_COUNT; i++) {
       const path = backupPath(dataFile, i)
       if (!existsSync(path)) {
         continue
       }
       try {
-        const raw = readFileSync(path, 'utf-8')
-        JSON.parse(raw)
-        mkdirSync(dirname(dataFile), { recursive: true })
-        writeFileSync(dataFile, raw, 'utf-8')
+        restorePersistedStateBackupSync(path, dataFile)
         console.warn(`[persistence] Recovered state from backup slot ${i}: ${path}`)
-        return true
+        return { rejectedOversizedBackup, restored: true }
       } catch (err) {
+        rejectedOversizedBackup ||= isPersistedStateFileCapacityError(err)
         console.error(`[persistence] Backup slot ${i} unusable, trying next:`, err)
       }
     }
-    return false
+    return { rejectedOversizedBackup, restored: false }
   }
 
   private load(allowBackupRecovery = true): PersistedState {
@@ -2786,16 +2799,17 @@ export class Store {
     })
 
     let result: PersistedState | null = null
+    let rejectedOversizedState = false
     try {
       if (fileExistedOnLoad) {
         const readStartedAt = performance.now()
-        const raw = readFileSync(dataFile, 'utf-8')
+        const { buffer } = readPersistedStateFileBytesSync(dataFile)
         logPersistenceStartupMilestone('persistence-read-done', {
-          bytes: Buffer.byteLength(raw),
+          bytes: buffer.byteLength,
           durationMs: Math.round(performance.now() - readStartedAt)
         })
         logPersistenceStartupMilestone('persistence-json-parse-start')
-        const parsed = JSON.parse(raw) as PersistedState
+        const parsed = parsePersistedStateJsonBuffer<PersistedState>(buffer)
         logPersistenceStartupMilestone('persistence-json-parse-done')
 
         // Why: secrets are stored encrypted via safeStorage; decrypt at the load boundary so the app sees plaintext.
@@ -3339,6 +3353,7 @@ export class Store {
         }
       }
     } catch (err) {
+      rejectedOversizedState = isPersistedStateFileCapacityError(err)
       console.error('[persistence] Failed to load primary state, trying backups:', err)
     }
 
@@ -3352,14 +3367,23 @@ export class Store {
         }
       }
       if (fileExistedOnLoad || hasBackup) {
-        if (this.restoreFromBackup(dataFile)) {
+        const recovery = this.restoreFromBackup(dataFile)
+        if (recovery.restored) {
           return this.load(false)
         }
+        rejectedOversizedState ||= recovery.rejectedOversizedBackup
         console.error('[persistence] No usable state file or backup found, using defaults')
       }
     }
 
     if (result === null) {
+      if (rejectedOversizedState) {
+        // Why: keep recoverable oversized bytes intact instead of replacing them with fallback defaults.
+        this.writesFrozen = true
+        console.error(
+          '[persistence] State exceeds the safe load limit; using defaults with state writes frozen'
+        )
+      }
       result = getDefaultPersistedState(homedir())
     }
 
@@ -3548,49 +3572,79 @@ export class Store {
     // on deterministic-IV platforms (macOS/legacy-Linux OSCrypt). A per-slot
     // random UUID can't occur anywhere else in the serialized state (the user
     // sets their data before it is minted), so it appears exactly once.
-    const secretSubs: { sentinel: string; blob: string; plaintext: string }[] = []
-    const encryptToSentinel = (plaintext: string): string => {
-      const blob = encrypt(plaintext)
-      // Deterministic already (empty secret / safeStorage unavailable / encrypt
-      // failure): blob === plaintext, so no normalization — and no sentinel,
-      // which also avoids substituting an empty or plaintext-shaped slot.
-      if (blob === plaintext) {
-        return blob
-      }
+    const secretSubs: { sentinel: string; plaintext: string }[] = []
+    const replaceSecretWithSentinel = (plaintext: string): string => {
+      assertPersistedStateSecretWithinLimit(plaintext)
       const sentinel = `orca-secret-slot-${randomUUID()}`
-      secretSubs.push({ sentinel, blob, plaintext })
+      secretSubs.push({ sentinel, plaintext })
       return sentinel
     }
-    // Why: clone before encrypting secrets so in-memory this.state stays plaintext.
+    // Why: clone with sentinels so in-memory this.state stays plaintext.
     const stateToSave = {
       ...this.getDurableState(),
       settings: {
         ...this.state.settings,
-        opencodeSessionCookie: encryptToSentinel(this.state.settings.opencodeSessionCookie),
-        httpProxyUrl: encryptToSentinel(this.state.settings.httpProxyUrl ?? '')
+        opencodeSessionCookie: replaceSecretWithSentinel(this.state.settings.opencodeSessionCookie),
+        httpProxyUrl: replaceSecretWithSentinel(this.state.settings.httpProxyUrl ?? '')
       },
       ui: {
         ...this.state.ui,
         browserKagiSessionLink: this.state.ui.browserKagiSessionLink
-          ? encryptToSentinel(this.state.ui.browserKagiSessionLink)
+          ? replaceSecretWithSentinel(this.state.ui.browserKagiSessionLink)
           : null
       }
     }
     // Why compact: ~20% fewer bytes and less serialize time; all readers JSON.parse so formatting is irrelevant.
     // One full-state stringify; secret slots currently hold sentinels.
-    const serialized = JSON.stringify(stateToSave)
-    // Substitute each unique sentinel exactly once: ciphertext for the on-disk
-    // payload, plaintext for the guard hash. Function-form replacement keeps
-    // `$` in blob/plaintext inert; both sides read the sentinel as JSON-escaped
-    // in `serialized`, so each replace is byte-for-byte position-exact.
-    let payload = serialized
-    let hashInput = serialized
-    for (const { sentinel, blob, plaintext } of secretSubs) {
-      const escapedSentinel = JSON.stringify(sentinel).slice(1, -1)
-      payload = payload.replace(escapedSentinel, () => blob)
-      hashInput = hashInput.replace(escapedSentinel, () => JSON.stringify(plaintext).slice(1, -1))
+    const { serialized, byteLength: serializedBytes } =
+      stringifyPersistedStateWithinLimit(stateToSave)
+    const preparedSecretSubs: {
+      escapedPlaintext: string
+      escapedSentinel: string
+      index: number
+      plaintext: string
+    }[] = []
+    let normalizedBytes = serializedBytes
+    for (const { sentinel, plaintext } of secretSubs) {
+      const escapedSentinel = encodePersistedStateJsonStringContent(sentinel)
+      const escapedPlaintext = encodePersistedStateJsonStringContent(plaintext)
+      const index = serialized.indexOf(escapedSentinel)
+      if (index === -1 || serialized.includes(escapedSentinel, index + escapedSentinel.length)) {
+        throw new Error('Persisted state secret sentinel is missing or ambiguous')
+      }
+      normalizedBytes = replacedPersistedStateJsonByteLength({
+        currentBytes: normalizedBytes,
+        search: escapedSentinel,
+        replacement: escapedPlaintext
+      })
+      preparedSecretSubs.push({ escapedPlaintext, escapedSentinel, index, plaintext })
     }
-    const stateHash = createHash('sha1').update(hashInput).digest('hex')
+
+    const normalizedHash = createHash('sha1')
+    let normalizedOffset = 0
+    for (const { escapedPlaintext, escapedSentinel, index } of preparedSecretSubs.sort(
+      (left, right) => left.index - right.index
+    )) {
+      updatePersistedStateHashWithJsonRange(normalizedHash, serialized, normalizedOffset, index)
+      updatePersistedStateHashWithJsonRange(normalizedHash, escapedPlaintext)
+      normalizedOffset = index + escapedSentinel.length
+    }
+    updatePersistedStateHashWithJsonRange(normalizedHash, serialized, normalizedOffset)
+
+    let payload = serialized
+    let payloadBytes = serializedBytes
+    for (const { escapedSentinel, plaintext } of preparedSecretSubs) {
+      const escapedBlob = encodePersistedStateJsonStringContent(encrypt(plaintext))
+      const nextPayload = replacePersistedStateJsonWithinLimit({
+        serialized: payload,
+        currentBytes: payloadBytes,
+        search: escapedSentinel,
+        replacement: escapedBlob
+      })
+      payload = nextPayload.serialized
+      payloadBytes = nextPayload.byteLength
+    }
+    const stateHash = normalizedHash.digest('hex')
     return { payload, stateHash }
   }
 
@@ -3833,8 +3887,7 @@ export class Store {
     if (!repo) {
       return false
     }
-    const previous = this.gitUsernameCache.get(repo.path) ?? repo.gitUsername ?? ''
-    this.gitUsernameCache.set(repo.path, username)
+    const previous = repo.gitUsername ?? ''
     if (previous === username) {
       return false
     }
@@ -4486,9 +4539,7 @@ export class Store {
     const projectHostSetupMethod = sanitizeRepoProjectHostSetupMethod(rawProjectHostSetupMethod)
     const forkSyncMode = sanitizeForkSyncMode(rawForkSyncMode)
     // Why: never spawn git/gh username resolution in hydration — a stuck probe froze Windows startup for minutes (issue #7225); read only cache/persisted value.
-    const gitUsername = isFolderRepo(repo)
-      ? ''
-      : (this.gitUsernameCache.get(repo.path) ?? repo.gitUsername ?? '')
+    const gitUsername = isFolderRepo(repo) ? '' : (repo.gitUsername ?? '')
 
     return {
       ...repoWithoutIcon,
@@ -6506,7 +6557,8 @@ export class Store {
     const cacheFile = getGithubCacheFile(this.dataFile)
     const tmpFile = `${cacheFile}.${process.pid}.tmp`
     try {
-      writeFileSync(tmpFile, JSON.stringify(this.state.githubCache), 'utf-8')
+      const { serialized } = stringifyPersistedStateWithinLimit(this.state.githubCache)
+      writeFileSync(tmpFile, serialized, 'utf-8')
       renameSync(tmpFile, cacheFile)
       this.githubCacheDirty = false
     } catch (err) {

--- a/src/main/repo-git-remote-identity-enrichment.test.ts
+++ b/src/main/repo-git-remote-identity-enrichment.test.ts
@@ -5,6 +5,9 @@ import { detectGitRemoteIdentity } from './repo-git-remote-identity'
 import {
   enrichMissingRepoGitRemoteIdentities,
   flushRepoGitRemoteIdentityEnrichmentForTests,
+  getRepoGitRemoteIdentityNegativeCacheSizeForTests,
+  REPO_LOCATION_CACHE_KEY_MAX_BYTES,
+  REPO_IDENTITY_NEGATIVE_CACHE_MAX_ENTRIES,
   resetRepoGitRemoteIdentityEnrichmentForTests
 } from './repo-git-remote-identity-enrichment'
 
@@ -118,6 +121,44 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
     await flushRepoGitRemoteIdentityEnrichmentForTests()
 
     expect(detectGitRemoteIdentity).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds negative results across churned repo locations', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    vi.mocked(detectGitRemoteIdentity).mockResolvedValue(null)
+    const repo = makeRepo()
+    const store = makeStore(repo)
+
+    for (let index = 0; index <= REPO_IDENTITY_NEGATIVE_CACHE_MAX_ENTRIES; index++) {
+      repo.path = `/workspace/repo-${index}`
+      enrichMissingRepoGitRemoteIdentities(store)
+      await flushRepoGitRemoteIdentityEnrichmentForTests()
+    }
+
+    expect(getRepoGitRemoteIdentityNegativeCacheSizeForTests()).toBe(
+      REPO_IDENTITY_NEGATIVE_CACHE_MAX_ENTRIES
+    )
+    repo.path = '/workspace/repo-0'
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+    expect(detectGitRemoteIdentity).toHaveBeenCalledTimes(
+      REPO_IDENTITY_NEGATIVE_CACHE_MAX_ENTRIES + 2
+    )
+  })
+
+  it('does not retain oversized repo-location keys', async () => {
+    vi.mocked(detectGitRemoteIdentity).mockResolvedValue(null)
+    const repo = makeRepo({ path: `/${'x'.repeat(REPO_LOCATION_CACHE_KEY_MAX_BYTES)}` })
+    const store = makeStore(repo)
+
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(detectGitRemoteIdentity).toHaveBeenCalledTimes(2)
+    expect(getRepoGitRemoteIdentityNegativeCacheSizeForTests()).toBe(0)
   })
 
   it('does not write stale identity data after the repo path changes', async () => {

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -1,7 +1,11 @@
 import type { Repo } from '../shared/types'
 import { detectGitRemoteIdentity } from './repo-git-remote-identity'
+import { getRepoLocationCacheKey } from './repo-location-cache-key'
+
+export { REPO_LOCATION_CACHE_KEY_MAX_BYTES } from './repo-location-cache-key'
 
 const NO_IDENTITY_RETRY_TTL_MS = 5 * 60 * 1000
+export const REPO_IDENTITY_NEGATIVE_CACHE_MAX_ENTRIES = 512
 
 type RepoIdentityStore = {
   getRepos(): Repo[]
@@ -16,8 +20,25 @@ type EnrichmentOptions = {
 const inFlightProbesByLocation = new Map<string, Promise<boolean>>()
 const noIdentityRetryAfterByLocation = new Map<string, number>()
 
-function getRepoLocationKey(repo: Pick<Repo, 'path' | 'connectionId'>): string {
-  return `${repo.connectionId ?? 'local'}\0${repo.path}`
+function pruneNoIdentityRetryCache(now: number): void {
+  for (const [locationKey, retryAfter] of noIdentityRetryAfterByLocation) {
+    if (retryAfter <= now) {
+      noIdentityRetryAfterByLocation.delete(locationKey)
+    }
+  }
+  while (noIdentityRetryAfterByLocation.size > REPO_IDENTITY_NEGATIVE_CACHE_MAX_ENTRIES) {
+    const oldestLocation = noIdentityRetryAfterByLocation.keys().next().value
+    if (oldestLocation === undefined) {
+      break
+    }
+    noIdentityRetryAfterByLocation.delete(oldestLocation)
+  }
+}
+
+function rememberNoIdentityRetry(locationKey: string, retryAfter: number): void {
+  noIdentityRetryAfterByLocation.delete(locationKey)
+  noIdentityRetryAfterByLocation.set(locationKey, retryAfter)
+  pruneNoIdentityRetryCache(Date.now())
 }
 
 function getCurrentRepo(store: RepoIdentityStore, id: string): Repo | undefined {
@@ -35,12 +56,14 @@ function isSameUnenrichedRepo(snapshot: Repo, current: Repo | undefined): boolea
 }
 
 async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo): Promise<boolean> {
-  const locationKey = getRepoLocationKey(repo)
-  const retryAfter = noIdentityRetryAfterByLocation.get(locationKey) ?? 0
-  if (retryAfter > Date.now()) {
+  const locationKey = getRepoLocationCacheKey(repo)
+  const now = Date.now()
+  pruneNoIdentityRetryCache(now)
+  const retryAfter = locationKey ? (noIdentityRetryAfterByLocation.get(locationKey) ?? 0) : 0
+  if (retryAfter > now) {
     return false
   }
-  const inFlight = inFlightProbesByLocation.get(locationKey)
+  const inFlight = locationKey ? inFlightProbesByLocation.get(locationKey) : undefined
   if (inFlight) {
     return inFlight
   }
@@ -49,22 +72,28 @@ async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo)
     if (!identity) {
       // Why: repos without a parseable remote are common; cache misses briefly so
       // list calls stay cheap while still allowing recent remote changes to land.
-      noIdentityRetryAfterByLocation.set(locationKey, Date.now() + NO_IDENTITY_RETRY_TTL_MS)
+      if (locationKey) {
+        rememberNoIdentityRetry(locationKey, Date.now() + NO_IDENTITY_RETRY_TTL_MS)
+      }
       return false
     }
 
-    noIdentityRetryAfterByLocation.delete(locationKey)
+    if (locationKey) {
+      noIdentityRetryAfterByLocation.delete(locationKey)
+    }
     const current = getCurrentRepo(store, repo.id)
     if (!isSameUnenrichedRepo(repo, current)) {
       return false
     }
     return !!store.updateRepo(repo.id, { gitRemoteIdentity: identity })
   })().finally(() => {
-    if (inFlightProbesByLocation.get(locationKey) === probe) {
+    if (locationKey && inFlightProbesByLocation.get(locationKey) === probe) {
       inFlightProbesByLocation.delete(locationKey)
     }
   })
-  inFlightProbesByLocation.set(locationKey, probe)
+  if (locationKey) {
+    inFlightProbesByLocation.set(locationKey, probe)
+  }
   return probe
 }
 
@@ -104,4 +133,8 @@ export async function flushRepoGitRemoteIdentityEnrichmentForTests(): Promise<vo
 export function resetRepoGitRemoteIdentityEnrichmentForTests(): void {
   inFlightProbesByLocation.clear()
   noIdentityRetryAfterByLocation.clear()
+}
+
+export function getRepoGitRemoteIdentityNegativeCacheSizeForTests(): number {
+  return noIdentityRetryAfterByLocation.size
 }

--- a/src/main/repo-git-username-enrichment.test.ts
+++ b/src/main/repo-git-username-enrichment.test.ts
@@ -11,6 +11,9 @@ vi.mock('./git/git-username', () => ({
 import {
   enrichRepoGitUsernames,
   flushRepoGitUsernameEnrichmentForTests,
+  getRepoGitUsernameAttemptCountForTests,
+  REPO_LOCATION_CACHE_KEY_MAX_BYTES,
+  REPO_GIT_USERNAME_ATTEMPT_MAX_ENTRIES,
   resetRepoGitUsernameEnrichmentForTests
 } from './repo-git-username-enrichment'
 
@@ -80,6 +83,37 @@ describe('enrichRepoGitUsernames', () => {
     await flushRepoGitUsernameEnrichmentForTests()
 
     expect(resolveLocalGitUsernameDetailedMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds remembered attempts across churned repo locations', async () => {
+    const repos = Array.from({ length: REPO_GIT_USERNAME_ATTEMPT_MAX_ENTRIES + 1 }, (_, index) =>
+      makeRepo({ id: `r${index}`, path: `C:/repos/${index}` })
+    )
+    const store = makeStore(repos)
+
+    enrichRepoGitUsernames(store)
+    await flushRepoGitUsernameEnrichmentForTests()
+
+    expect(getRepoGitUsernameAttemptCountForTests()).toBe(REPO_GIT_USERNAME_ATTEMPT_MAX_ENTRIES)
+    enrichRepoGitUsernames(store)
+    await flushRepoGitUsernameEnrichmentForTests()
+    expect(resolveLocalGitUsernameDetailedMock).toHaveBeenCalledTimes(
+      REPO_GIT_USERNAME_ATTEMPT_MAX_ENTRIES + 2
+    )
+  })
+
+  it('does not retain oversized repo-location keys', async () => {
+    const store = makeStore([
+      makeRepo({ path: `C:/${'x'.repeat(REPO_LOCATION_CACHE_KEY_MAX_BYTES)}` })
+    ])
+
+    enrichRepoGitUsernames(store)
+    await flushRepoGitUsernameEnrichmentForTests()
+    enrichRepoGitUsernames(store)
+    await flushRepoGitUsernameEnrichmentForTests()
+
+    expect(resolveLocalGitUsernameDetailedMock).toHaveBeenCalledTimes(2)
+    expect(getRepoGitUsernameAttemptCountForTests()).toBe(0)
   })
 
   it('keeps persisted usernames on a non-authoritative empty resolution', async () => {

--- a/src/main/repo-git-username-enrichment.ts
+++ b/src/main/repo-git-username-enrichment.ts
@@ -1,5 +1,8 @@
 import type { Repo } from '../shared/types'
 import { resolveLocalGitUsernameDetailed } from './git/git-username'
+import { getRepoLocationCacheKey } from './repo-location-cache-key'
+
+export { REPO_LOCATION_CACHE_KEY_MAX_BYTES } from './repo-location-cache-key'
 
 type RepoUsernameStore = {
   getRepos(): Repo[]
@@ -10,6 +13,7 @@ type EnrichmentOptions = {
   onChanged?: () => void
 }
 
+export const REPO_GIT_USERNAME_ATTEMPT_MAX_ENTRIES = 512
 // Why: resolution spawns git (and possibly gh) subprocesses, so run it at most
 // once per repo location per app session — hydrateRepo serves the persisted
 // value in between, and a relaunch picks up config changes.
@@ -17,8 +21,16 @@ const attemptedLocations = new Set<string>()
 let enrichmentInFlight: Promise<void> | null = null
 let rerunRequested = false
 
-function getRepoLocationKey(repo: Pick<Repo, 'path' | 'connectionId'>): string {
-  return `${repo.connectionId ?? 'local'}\0${repo.path}`
+function rememberAttemptedLocation(locationKey: string): void {
+  attemptedLocations.delete(locationKey)
+  attemptedLocations.add(locationKey)
+  while (attemptedLocations.size > REPO_GIT_USERNAME_ATTEMPT_MAX_ENTRIES) {
+    const oldestLocation = attemptedLocations.values().next().value
+    if (oldestLocation === undefined) {
+      break
+    }
+    attemptedLocations.delete(oldestLocation)
+  }
 }
 
 async function enrichRepoGitUsernamesInBackground(
@@ -31,11 +43,14 @@ async function enrichRepoGitUsernamesInBackground(
       // Why: SSH repo paths are remote; local git cannot inspect them. The
       // SSH username path (getSshGitUsername) stays caller-driven.
       !repo.connectionId &&
-      !attemptedLocations.has(getRepoLocationKey(repo))
+      !attemptedLocations.has(getRepoLocationCacheKey(repo) ?? '')
   )
   let changed = false
   for (const repo of candidates) {
-    attemptedLocations.add(getRepoLocationKey(repo))
+    const locationKey = getRepoLocationCacheKey(repo)
+    if (locationKey) {
+      rememberAttemptedLocation(locationKey)
+    }
     const { username, authoritative } = await resolveLocalGitUsernameDetailed(repo.path)
     // Why: a non-authoritative '' means a probe timed out and says nothing
     // about the account — keep the persisted value. An authoritative result
@@ -92,4 +107,8 @@ export function resetRepoGitUsernameEnrichmentForTests(): void {
   attemptedLocations.clear()
   enrichmentInFlight = null
   rerunRequested = false
+}
+
+export function getRepoGitUsernameAttemptCountForTests(): number {
+  return attemptedLocations.size
 }

--- a/src/main/repo-icon-autodetect.test.ts
+++ b/src/main/repo-icon-autodetect.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -9,6 +9,16 @@ const PNG_1X1_BASE64 =
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
 
 const tempDirs: string[] = []
+
+function pngHeader(width: number, height: number): Buffer {
+  const bytes = Buffer.alloc(24)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
+  bytes.writeUInt32BE(13, 8)
+  bytes.write('IHDR', 12, 'ascii')
+  bytes.writeUInt32BE(width, 16)
+  bytes.writeUInt32BE(height, 20)
+  return bytes
+}
 
 async function makeTempRepoDir(): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'orca-repo-icon-'))
@@ -52,6 +62,13 @@ describe('detectRepoIcon', () => {
     })
   })
 
+  it('ignores a repo-local raster dimension bomb', async () => {
+    const repoPath = await makeTempRepoDir()
+    await writeFile(join(repoPath, 'favicon.png'), pngHeader(32_769, 1))
+
+    await expect(detectRepoIcon({ repoPath, kind: 'folder' })).resolves.toBeUndefined()
+  })
+
   it('resolves declared icon hrefs from project source files', async () => {
     const repoPath = await makeTempRepoDir()
     await writeFile(join(repoPath, 'index.html'), '<link rel="icon" href="/brand/icon.png">')
@@ -91,10 +108,9 @@ describe('detectRepoIcon', () => {
 
   it('skips oversized source files when looking for declared icon hrefs', async () => {
     const repoPath = await makeTempRepoDir()
-    await writeFile(
-      join(repoPath, 'index.html'),
-      `${'x'.repeat(256 * 1024 + 1)}<link rel="icon" href="/brand/icon.png">`
-    )
+    const sourcePath = join(repoPath, 'index.html')
+    await writeFile(sourcePath, '<link rel="icon" href="/brand/icon.png">')
+    await truncate(sourcePath, 256 * 1024 + 1)
     await mkdir(join(repoPath, 'public', 'brand'), { recursive: true })
     await writeFile(
       join(repoPath, 'public', 'brand', 'icon.png'),

--- a/src/main/repo-icon-autodetect.ts
+++ b/src/main/repo-icon-autodetect.ts
@@ -1,50 +1,13 @@
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import type { GitHubRepositoryIdentity, RepoKind } from '../shared/types'
-import {
-  faviconUrlFromWebsite,
-  githubAvatarIcon,
-  MAX_REPO_ICON_UPLOAD_BYTES,
-  type RepoIcon
-} from '../shared/repo-icon'
+import { faviconUrlFromWebsite, githubAvatarIcon, type RepoIcon } from '../shared/repo-icon'
 import { getRepoSlug, getRepoUpstream } from './github/client'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import type { IFilesystemProvider } from './providers/types'
 import { detectGitRemoteIdentity } from './repo-git-remote-identity'
-import { iconHrefCandidates } from './repo-icon-href-candidates'
 import { joinWorktreeRelativePath } from './runtime/runtime-relative-paths'
-
-const REPO_ICON_FILE_CANDIDATES = [
-  'favicon.png',
-  'public/favicon.png',
-  'app/favicon.png',
-  'app/icon.png',
-  'src/favicon.png',
-  'src/app/icon.png',
-  'assets/favicon.png',
-  'assets/icon.png',
-  'static/favicon.png',
-  'logo.png',
-  'public/logo.png'
-]
-
-const REPO_ICON_SOURCE_FILE_CANDIDATES = [
-  'index.html',
-  'public/index.html',
-  'app/routes/__root.tsx',
-  'src/routes/__root.tsx',
-  'app/root.tsx',
-  'src/root.tsx',
-  'src/index.html'
-]
-
-// Why: repo icon detection runs while adding repos; declared-icon probing should
-// not read large app entrypoints just to find a small favicon href.
-const MAX_REPO_ICON_SOURCE_BYTES = 256 * 1024
-
-const LINK_ICON_HTML_RE =
-  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
-const LINK_ICON_OBJECT_RE =
-  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
+import { detectLocalRepoPngIcon, detectRemoteRepoPngIcon } from './repo-icon-file-detection'
 
 const WEBSITE_HOSTS_TO_SKIP = new Set([
   'github.com',
@@ -54,21 +17,6 @@ const WEBSITE_HOSTS_TO_SKIP = new Set([
   'bitbucket.org',
   'www.bitbucket.org'
 ])
-
-function isPngBuffer(buffer: Buffer): boolean {
-  return (
-    buffer.length >= 8 &&
-    buffer[0] === 0x89 &&
-    buffer[1] === 0x50 &&
-    buffer[2] === 0x4e &&
-    buffer[3] === 0x47 &&
-    buffer[4] === 0x0d &&
-    buffer[5] === 0x0a &&
-    buffer[6] === 0x1a &&
-    buffer[7] === 0x0a
-  )
-}
-
 function shouldUseWebsiteFavicon(rawUrl: string): boolean {
   try {
     const url = new URL(rawUrl.includes('://') ? rawUrl : `https://${rawUrl}`)
@@ -76,140 +24,6 @@ function shouldUseWebsiteFavicon(rawUrl: string): boolean {
   } catch {
     return false
   }
-}
-
-function extractIconHref(source: string): string | null {
-  return source.match(LINK_ICON_HTML_RE)?.[1] ?? source.match(LINK_ICON_OBJECT_RE)?.[1] ?? null
-}
-
-async function readLocalPngIcon(repoPath: string, relativePath: string): Promise<RepoIcon | null> {
-  const filePath = joinWorktreeRelativePath(repoPath, relativePath)
-  const info = await stat(filePath)
-  if (!info.isFile() || info.size > MAX_REPO_ICON_UPLOAD_BYTES) {
-    return null
-  }
-  const buffer = await readFile(filePath)
-  if (!isPngBuffer(buffer)) {
-    return null
-  }
-  return {
-    type: 'image',
-    src: `data:image/png;base64,${buffer.toString('base64')}`,
-    source: 'file',
-    label: relativePath
-  }
-}
-
-async function readRemotePngIcon(
-  repoPath: string,
-  fsProvider: IFilesystemProvider,
-  relativePath: string
-): Promise<RepoIcon | null> {
-  const filePath = joinWorktreeRelativePath(repoPath, relativePath)
-  const info = await fsProvider.stat(filePath)
-  if (info.type !== 'file' || info.size > MAX_REPO_ICON_UPLOAD_BYTES) {
-    return null
-  }
-  const result = await fsProvider.readFile(filePath)
-  if (!result.isBinary || result.mimeType !== 'image/png' || !result.content) {
-    return null
-  }
-  const buffer = Buffer.from(result.content, 'base64')
-  if (!isPngBuffer(buffer)) {
-    return null
-  }
-  return {
-    type: 'image',
-    src: `data:image/png;base64,${buffer.toString('base64')}`,
-    source: 'file',
-    label: relativePath
-  }
-}
-
-async function detectLocalPngIcon(repoPath: string): Promise<RepoIcon | null> {
-  for (const relativePath of REPO_ICON_FILE_CANDIDATES) {
-    try {
-      const icon = await readLocalPngIcon(repoPath, relativePath)
-      if (icon) {
-        return icon
-      }
-    } catch {
-      // Try the next conventional icon path.
-    }
-  }
-  for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
-    try {
-      const sourcePath = joinWorktreeRelativePath(repoPath, sourceFile)
-      const sourceInfo = await stat(sourcePath)
-      if (!sourceInfo.isFile() || sourceInfo.size > MAX_REPO_ICON_SOURCE_BYTES) {
-        continue
-      }
-      const source = await readFile(sourcePath, 'utf8')
-      const href = extractIconHref(source)
-      if (!href) {
-        continue
-      }
-      for (const relativePath of iconHrefCandidates(href, sourceFile)) {
-        try {
-          const icon = await readLocalPngIcon(repoPath, relativePath)
-          if (icon) {
-            return icon
-          }
-        } catch {
-          // Try the next href resolution.
-        }
-      }
-    } catch {
-      // Try the next source file.
-    }
-  }
-  return null
-}
-
-async function detectRemotePngIcon(
-  repoPath: string,
-  fsProvider: IFilesystemProvider
-): Promise<RepoIcon | null> {
-  for (const relativePath of REPO_ICON_FILE_CANDIDATES) {
-    try {
-      const icon = await readRemotePngIcon(repoPath, fsProvider, relativePath)
-      if (icon) {
-        return icon
-      }
-    } catch {
-      // Try the next conventional icon path.
-    }
-  }
-  for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
-    try {
-      const sourcePath = joinWorktreeRelativePath(repoPath, sourceFile)
-      const sourceInfo = await fsProvider.stat(sourcePath)
-      if (sourceInfo.type !== 'file' || sourceInfo.size > MAX_REPO_ICON_SOURCE_BYTES) {
-        continue
-      }
-      const result = await fsProvider.readFile(sourcePath)
-      if (result.isBinary) {
-        continue
-      }
-      const href = extractIconHref(result.content)
-      if (!href) {
-        continue
-      }
-      for (const relativePath of iconHrefCandidates(href, sourceFile)) {
-        try {
-          const icon = await readRemotePngIcon(repoPath, fsProvider, relativePath)
-          if (icon) {
-            return icon
-          }
-        } catch {
-          // Try the next href resolution.
-        }
-      }
-    } catch {
-      // Try the next source file.
-    }
-  }
-  return null
 }
 
 function packageHomepageIcon(packageJson: unknown): RepoIcon | null {
@@ -231,7 +45,11 @@ async function detectLocalPackageHomepageIcon(repoPath: string): Promise<RepoIco
     if (!info.isFile() || info.size > 128 * 1024) {
       return null
     }
-    return packageHomepageIcon(JSON.parse(await readFile(packageJsonPath, 'utf8')))
+    const packageRead = await readNodeFileWithinLimit(packageJsonPath, 128 * 1024)
+    if (!packageRead.stats.isFile()) {
+      return null
+    }
+    return packageHomepageIcon(JSON.parse(packageRead.buffer.toString('utf8')))
   } catch {
     return null
   }
@@ -249,6 +67,9 @@ async function detectRemotePackageHomepageIcon(
     }
     const result = await fsProvider.readFile(packageJsonPath)
     if (result.isBinary) {
+      return null
+    }
+    if (Buffer.byteLength(result.content, 'utf8') > 128 * 1024) {
       return null
     }
     return packageHomepageIcon(JSON.parse(result.content))
@@ -285,8 +106,8 @@ export async function detectRepoIcon({
   try {
     const fsProvider = connectionId ? getSshFilesystemProvider(connectionId) : undefined
     const fileIcon = fsProvider
-      ? await detectRemotePngIcon(repoPath, fsProvider)
-      : await detectLocalPngIcon(repoPath)
+      ? await detectRemoteRepoPngIcon(repoPath, fsProvider)
+      : await detectLocalRepoPngIcon(repoPath)
     if (fileIcon) {
       return fileIcon
     }

--- a/src/main/repo-icon-file-detection.ts
+++ b/src/main/repo-icon-file-detection.ts
@@ -1,0 +1,190 @@
+import { stat } from 'node:fs/promises'
+import { MAX_REPO_ICON_UPLOAD_BYTES, type RepoIcon } from '../shared/repo-icon'
+import { assertRasterImagePreviewWithinLimits } from '../shared/raster-image-preview-limits'
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
+import type { IFilesystemProvider } from './providers/types'
+import { iconHrefCandidates } from './repo-icon-href-candidates'
+import { joinWorktreeRelativePath } from './runtime/runtime-relative-paths'
+
+const REPO_ICON_FILE_CANDIDATES = [
+  'favicon.png',
+  'public/favicon.png',
+  'app/favicon.png',
+  'app/icon.png',
+  'src/favicon.png',
+  'src/app/icon.png',
+  'assets/favicon.png',
+  'assets/icon.png',
+  'static/favicon.png',
+  'logo.png',
+  'public/logo.png'
+]
+
+const REPO_ICON_SOURCE_FILE_CANDIDATES = [
+  'index.html',
+  'public/index.html',
+  'app/routes/__root.tsx',
+  'src/routes/__root.tsx',
+  'app/root.tsx',
+  'src/root.tsx',
+  'src/index.html'
+]
+
+// Why: repo icon detection runs while adding repos; declared-icon probing should
+// not read large app entrypoints just to find a small favicon href.
+const MAX_REPO_ICON_SOURCE_BYTES = 256 * 1024
+
+const LINK_ICON_HTML_RE =
+  /<link\b(?=[^>]*\brel=["'](?:icon|shortcut icon)["'])(?=[^>]*\bhref=["']([^"'?]+))[^>]*>/i
+const LINK_ICON_OBJECT_RE =
+  /(?=[^}]*\brel\s*:\s*["'](?:icon|shortcut icon)["'])(?=[^}]*\bhref\s*:\s*["']([^"'?]+))[^}]*/i
+const PNG_SIGNATURE = Buffer.from('89504e470d0a1a0a', 'hex')
+
+function isPngBuffer(buffer: Buffer): boolean {
+  return buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)
+}
+
+function extractIconHref(source: string): string | null {
+  return source.match(LINK_ICON_HTML_RE)?.[1] ?? source.match(LINK_ICON_OBJECT_RE)?.[1] ?? null
+}
+
+async function readLocalPngIcon(repoPath: string, relativePath: string): Promise<RepoIcon | null> {
+  const filePath = joinWorktreeRelativePath(repoPath, relativePath)
+  const info = await stat(filePath)
+  if (!info.isFile() || info.size > MAX_REPO_ICON_UPLOAD_BYTES) {
+    return null
+  }
+  const { buffer, stats } = await readNodeFileWithinLimit(filePath, MAX_REPO_ICON_UPLOAD_BYTES)
+  if (!stats.isFile() || !isPngBuffer(buffer)) {
+    return null
+  }
+  assertRasterImagePreviewWithinLimits(buffer, 'image/png')
+  return {
+    type: 'image',
+    src: `data:image/png;base64,${buffer.toString('base64')}`,
+    source: 'file',
+    label: relativePath
+  }
+}
+
+async function readRemotePngIcon(
+  repoPath: string,
+  fsProvider: IFilesystemProvider,
+  relativePath: string
+): Promise<RepoIcon | null> {
+  const filePath = joinWorktreeRelativePath(repoPath, relativePath)
+  const info = await fsProvider.stat(filePath)
+  if (info.type !== 'file' || info.size > MAX_REPO_ICON_UPLOAD_BYTES) {
+    return null
+  }
+  const result = await fsProvider.readFile(filePath)
+  if (!result.isBinary || result.mimeType !== 'image/png' || !result.content) {
+    return null
+  }
+  if (result.content.length > Math.ceil((MAX_REPO_ICON_UPLOAD_BYTES * 4) / 3) + 4) {
+    return null
+  }
+  const buffer = Buffer.from(result.content, 'base64')
+  if (buffer.byteLength > MAX_REPO_ICON_UPLOAD_BYTES || !isPngBuffer(buffer)) {
+    return null
+  }
+  assertRasterImagePreviewWithinLimits(buffer, 'image/png')
+  return {
+    type: 'image',
+    src: `data:image/png;base64,${buffer.toString('base64')}`,
+    source: 'file',
+    label: relativePath
+  }
+}
+
+export async function detectLocalRepoPngIcon(repoPath: string): Promise<RepoIcon | null> {
+  for (const relativePath of REPO_ICON_FILE_CANDIDATES) {
+    try {
+      const icon = await readLocalPngIcon(repoPath, relativePath)
+      if (icon) {
+        return icon
+      }
+    } catch {
+      // Try the next conventional icon path.
+    }
+  }
+  for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
+    try {
+      const sourcePath = joinWorktreeRelativePath(repoPath, sourceFile)
+      const sourceInfo = await stat(sourcePath)
+      if (!sourceInfo.isFile() || sourceInfo.size > MAX_REPO_ICON_SOURCE_BYTES) {
+        continue
+      }
+      const sourceRead = await readNodeFileWithinLimit(sourcePath, MAX_REPO_ICON_SOURCE_BYTES)
+      if (!sourceRead.stats.isFile()) {
+        continue
+      }
+      const href = extractIconHref(sourceRead.buffer.toString('utf8'))
+      if (!href) {
+        continue
+      }
+      for (const relativePath of iconHrefCandidates(href, sourceFile)) {
+        try {
+          const icon = await readLocalPngIcon(repoPath, relativePath)
+          if (icon) {
+            return icon
+          }
+        } catch {
+          // Try the next href resolution.
+        }
+      }
+    } catch {
+      // Try the next source file.
+    }
+  }
+  return null
+}
+
+export async function detectRemoteRepoPngIcon(
+  repoPath: string,
+  fsProvider: IFilesystemProvider
+): Promise<RepoIcon | null> {
+  for (const relativePath of REPO_ICON_FILE_CANDIDATES) {
+    try {
+      const icon = await readRemotePngIcon(repoPath, fsProvider, relativePath)
+      if (icon) {
+        return icon
+      }
+    } catch {
+      // Try the next conventional icon path.
+    }
+  }
+  for (const sourceFile of REPO_ICON_SOURCE_FILE_CANDIDATES) {
+    try {
+      const sourcePath = joinWorktreeRelativePath(repoPath, sourceFile)
+      const sourceInfo = await fsProvider.stat(sourcePath)
+      if (sourceInfo.type !== 'file' || sourceInfo.size > MAX_REPO_ICON_SOURCE_BYTES) {
+        continue
+      }
+      const result = await fsProvider.readFile(sourcePath)
+      if (
+        result.isBinary ||
+        Buffer.byteLength(result.content, 'utf8') > MAX_REPO_ICON_SOURCE_BYTES
+      ) {
+        continue
+      }
+      const href = extractIconHref(result.content)
+      if (!href) {
+        continue
+      }
+      for (const relativePath of iconHrefCandidates(href, sourceFile)) {
+        try {
+          const icon = await readRemotePngIcon(repoPath, fsProvider, relativePath)
+          if (icon) {
+            return icon
+          }
+        } catch {
+          // Try the next href resolution.
+        }
+      }
+    } catch {
+      // Try the next source file.
+    }
+  }
+  return null
+}

--- a/src/main/repo-location-cache-key.ts
+++ b/src/main/repo-location-cache-key.ts
@@ -1,0 +1,23 @@
+import { measureUtf8ByteLength } from '../shared/utf8-byte-limits'
+
+export const REPO_LOCATION_CACHE_KEY_MAX_BYTES = 4 * 1024
+
+export function getRepoLocationCacheKey(repo: {
+  path: string
+  connectionId?: string | null
+}): string | null {
+  const connectionId = repo.connectionId ?? 'local'
+  const connectionBytes = measureUtf8ByteLength(connectionId, {
+    stopAfterBytes: REPO_LOCATION_CACHE_KEY_MAX_BYTES - 1
+  })
+  if (connectionBytes.exceededLimit) {
+    return null
+  }
+  const pathBytes = measureUtf8ByteLength(repo.path, {
+    stopAfterBytes: REPO_LOCATION_CACHE_KEY_MAX_BYTES - connectionBytes.byteLength - 1
+  })
+  if (pathBytes.exceededLimit) {
+    return null
+  }
+  return `${connectionId}\0${repo.path}`
+}

--- a/src/main/serve-update-handoff.test.ts
+++ b/src/main/serve-update-handoff.test.ts
@@ -1,10 +1,12 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { EventEmitter } from 'node:events'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   SERVE_UPDATE_HANDOFF_PATH_ENV,
+  MAX_SERVE_UPDATE_HANDOFF_FILE_BYTES,
+  MAX_SERVE_UPDATE_HANDOFF_JSON_STRUCTURAL_TOKENS,
   getServeUpdateHandoffPath,
   parseServeUpdateHandoffState
 } from '../shared/serve-update-handoff'
@@ -79,6 +81,38 @@ describe('serve update handoff', () => {
 
     expect(hasServeUpdateSupervisor()).toBe(false)
     expect(requestServeUpdateHandoff('1.0.61')).toBe(false)
+  })
+
+  it('ignores oversized sparse handoff state', async () => {
+    const handoffPath = getServeUpdateHandoffPath(root)
+    writeFileSync(handoffPath, '{"schemaVersion":1}')
+    truncateSync(handoffPath, MAX_SERVE_UPDATE_HANDOFF_FILE_BYTES + 1)
+    const { getServeUpdateHandoffFailure } = await import('./serve-update-handoff')
+
+    expect(getServeUpdateHandoffFailure()).toBeNull()
+  })
+
+  it('rejects structurally amplified handoff state before parsing', async () => {
+    const handoffPath = getServeUpdateHandoffPath(root)
+    writeFileSync(
+      handoffPath,
+      `{"padding":[${'0,'.repeat(MAX_SERVE_UPDATE_HANDOFF_JSON_STRUCTURAL_TOKENS)}0]}`
+    )
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    const { getServeUpdateHandoffFailure } = await import('./serve-update-handoff')
+
+    expect(getServeUpdateHandoffFailure()).toBeNull()
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves prior handoff state when the replacement exceeds its read ceiling', async () => {
+    const { requestServeUpdateHandoff } = await import('./serve-update-handoff')
+    expect(requestServeUpdateHandoff('1.0.61')).toBe(true)
+    const handoffPath = getServeUpdateHandoffPath(root)
+    const before = readFileSync(handoffPath, 'utf8')
+
+    expect(requestServeUpdateHandoff('x'.repeat(MAX_SERVE_UPDATE_HANDOFF_FILE_BYTES))).toBe(false)
+    expect(readFileSync(handoffPath, 'utf8')).toBe(before)
   })
 
   it.runIf(process.platform === 'darwin')(

--- a/src/main/serve-update-handoff.ts
+++ b/src/main/serve-update-handoff.ts
@@ -1,10 +1,13 @@
-import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { app } from 'electron'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../shared/node-bounded-json-stringify'
 import {
+  MAX_SERVE_UPDATE_HANDOFF_FILE_BYTES,
   SERVE_UPDATE_HANDOFF_PATH_ENV,
   getServeUpdateHandoffPath,
-  parseServeUpdateHandoffState,
+  parseServeUpdateHandoffJson,
   type ServeSupervisorMessage,
   type ServeUpdateHandoffState
 } from '../shared/serve-update-handoff'
@@ -43,7 +46,11 @@ export function failServeUpdateHandoff(reason: string): void {
     return
   }
   try {
-    const state = parseServeUpdateHandoffState(JSON.parse(readFileSync(handoffPath, 'utf8')))
+    const state = parseServeUpdateHandoffJson(
+      readNodeFileSyncWithinLimit(handoffPath, MAX_SERVE_UPDATE_HANDOFF_FILE_BYTES).buffer.toString(
+        'utf8'
+      )
+    )
     if (state?.phase !== 'install-requested' || state.servingPid !== process.pid) {
       return
     }
@@ -90,7 +97,11 @@ export function getServeUpdateHandoffFailure(): string | null {
     return null
   }
   try {
-    const state = parseServeUpdateHandoffState(JSON.parse(readFileSync(handoffPath, 'utf8')))
+    const state = parseServeUpdateHandoffJson(
+      readNodeFileSyncWithinLimit(handoffPath, MAX_SERVE_UPDATE_HANDOFF_FILE_BYTES).buffer.toString(
+        'utf8'
+      )
+    )
     if (state?.phase !== 'failed') {
       return null
     }
@@ -107,11 +118,17 @@ export function getServeUpdateHandoffFailure(): string | null {
 function writeHandoffState(path: string, state: ServeUpdateHandoffState): boolean {
   const temporaryPath = `${path}.${process.pid}.tmp`
   try {
+    const { serialized } = stringifyJsonWithinByteLimit(state, MAX_SERVE_UPDATE_HANDOFF_FILE_BYTES)
     mkdirSync(dirname(path), { recursive: true })
-    writeFileSync(temporaryPath, JSON.stringify(state), { mode: 0o600 })
+    writeFileSync(temporaryPath, serialized, { mode: 0o600 })
     renameSync(temporaryPath, path)
     return true
   } catch {
+    try {
+      unlinkSync(temporaryPath)
+    } catch {
+      // The temporary handoff is best-effort state and may not have been created.
+    }
     return false
   }
 }

--- a/src/main/setup-script-import-file.test.ts
+++ b/src/main/setup-script-import-file.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { NodeFileReadTooLargeError } from '../shared/node-bounded-file-reader'
+import {
+  isSetupScriptImportTextWithinLimit,
+  readSetupScriptImportFile,
+  SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES
+} from './setup-script-import-file'
+
+describe('setup script import file bounds', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  async function makeFile(contents: string): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-setup-script-import-'))
+    roots.push(root)
+    const filePath = join(root, 'config.json')
+    await writeFile(filePath, contents)
+    return filePath
+  }
+
+  it('preserves ordinary configuration text', async () => {
+    const filePath = await makeFile('{"setup":"pnpm install"}')
+
+    await expect(readSetupScriptImportFile(filePath)).resolves.toBe('{"setup":"pnpm install"}')
+  })
+
+  it('rejects an oversized sparse local configuration', async () => {
+    const filePath = await makeFile('x')
+    await truncate(filePath, SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES + 1)
+
+    await expect(readSetupScriptImportFile(filePath)).rejects.toBeInstanceOf(
+      NodeFileReadTooLargeError
+    )
+  })
+
+  it('measures remote configuration strings by UTF-8 bytes', () => {
+    expect(isSetupScriptImportTextWithinLimit('a'.repeat(SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES))).toBe(
+      true
+    )
+    expect(
+      isSetupScriptImportTextWithinLimit('a'.repeat(SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES + 1))
+    ).toBe(false)
+    expect(
+      isSetupScriptImportTextWithinLimit('é'.repeat(SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES / 2))
+    ).toBe(true)
+    expect(
+      isSetupScriptImportTextWithinLimit('é'.repeat(SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES / 2 + 1))
+    ).toBe(false)
+  })
+})

--- a/src/main/setup-script-import-file.ts
+++ b/src/main/setup-script-import-file.ts
@@ -1,0 +1,18 @@
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
+import {
+  isSetupScriptImportTextWithinLimit,
+  SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES,
+  SETUP_SCRIPT_IMPORT_MAX_CODE_UNITS
+} from '../shared/setup-script-import-limits'
+
+export {
+  isSetupScriptImportTextWithinLimit,
+  SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES,
+  SETUP_SCRIPT_IMPORT_MAX_CODE_UNITS
+}
+
+export async function readSetupScriptImportFile(filePath: string): Promise<string> {
+  return (
+    await readNodeFileWithinLimit(filePath, SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES)
+  ).buffer.toString('utf-8')
+}

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -1,7 +1,8 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ORCA_PERSISTED_STATE_MAX_BYTES } from '../../shared/persisted-state-file-bounds'
 
 vi.mock('electron', () => {
   const paths = new Map<string, string>([['appData', '/tmp/app-data']])
@@ -298,6 +299,14 @@ describe('configureElectronNetworkCompatibility', () => {
   it('leaves HTTP/2 enabled by default', async () => {
     const { shouldDisableHttp2ForElectronNetworking } = await import('./configure-process')
     const userDataPath = createUserDataDir({})
+
+    expect(shouldDisableHttp2ForElectronNetworking({ env: {}, userDataPath })).toBe(false)
+  })
+
+  it('ignores an oversized persisted state file before early startup parsing', async () => {
+    const { shouldDisableHttp2ForElectronNetworking } = await import('./configure-process')
+    const userDataPath = createUserDataDir({ electronHttp1CompatibilityMode: true })
+    truncateSync(join(userDataPath, 'orca-data.json'), ORCA_PERSISTED_STATE_MAX_BYTES + 1)
 
     expect(shouldDisableHttp2ForElectronNetworking({ env: {}, userDataPath })).toBe(false)
   })

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -1,9 +1,10 @@
 import { app } from 'electron'
-import { existsSync, mkdirSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { getVersionManagerBinPaths } from '../codex-cli/command'
 import { getMainE2EConfig } from '../e2e-config'
+import { readPersistedStateJsonFileSync } from '../../shared/persisted-state-file-bounds'
 
 const DEV_PARENT_SHUTDOWN_GRACE_MS = 3000
 const HTTP1_COMPATIBILITY_ENV_VAR = 'ORCA_DISABLE_HTTP2'
@@ -37,9 +38,9 @@ function readPersistedHttp1CompatibilityMode(userDataPath: string): boolean {
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(dataFile, 'utf-8')) as {
+    const { value: parsed } = readPersistedStateJsonFileSync<{
       settings?: { electronHttp1CompatibilityMode?: unknown }
-    }
+    }>(dataFile)
     return parsed.settings?.electronHttp1CompatibilityMode === true
   } catch {
     return false

--- a/src/main/startup/ensure-virtual-display.test.ts
+++ b/src/main/startup/ensure-virtual-display.test.ts
@@ -1,11 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { spawnMock, spawnSyncMock, existsSyncMock, readFileSyncMock, rmSyncMock, appMock } =
+const { spawnMock, spawnSyncMock, existsSyncMock, boundedReadMock, rmSyncMock, appMock } =
   vi.hoisted(() => ({
     spawnMock: vi.fn(),
     spawnSyncMock: vi.fn(),
     existsSyncMock: vi.fn(),
-    readFileSyncMock: vi.fn(),
+    boundedReadMock: vi.fn(),
     rmSyncMock: vi.fn(),
     appMock: {
       disableHardwareAcceleration: vi.fn(),
@@ -17,8 +17,10 @@ const { spawnMock, spawnSyncMock, existsSyncMock, readFileSyncMock, rmSyncMock, 
 vi.mock('child_process', () => ({ spawn: spawnMock, spawnSync: spawnSyncMock }))
 vi.mock('fs', () => ({
   existsSync: existsSyncMock,
-  readFileSync: readFileSyncMock,
   rmSync: rmSyncMock
+}))
+vi.mock('../../shared/node-bounded-file-reader', () => ({
+  readNodeFileSyncWithinLimit: boundedReadMock
 }))
 vi.mock('electron', () => ({ app: appMock }))
 
@@ -34,7 +36,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     spawnMock.mockReset()
     spawnSyncMock.mockReset()
     existsSyncMock.mockReset()
-    readFileSyncMock.mockReset()
+    boundedReadMock.mockReset()
     rmSyncMock.mockReset()
     appMock.disableHardwareAcceleration.mockReset()
     appMock.commandLine.appendSwitch.mockReset()
@@ -115,7 +117,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     setPlatform('linux')
     spawnSyncMock.mockReturnValue({ status: 0 })
     existsSyncMock.mockReturnValue(true) // :99 socket + lock present
-    readFileSyncMock.mockReturnValue('4321\n') // lock holds a PID
+    boundedReadMock.mockReturnValue({ buffer: Buffer.from('4321\n') }) // lock holds a PID
     const killSpy = vi.spyOn(process, 'kill').mockReturnValue(true as never) // PID alive
     const { ensureVirtualDisplayForHeadlessServe } = await import('./ensure-virtual-display')
 
@@ -131,7 +133,7 @@ describe('ensureVirtualDisplayForHeadlessServe', () => {
     setPlatform('linux')
     spawnSyncMock.mockReturnValue({ status: 0 })
     existsSyncMock.mockReturnValue(true) // orphan socket + lock present
-    readFileSyncMock.mockReturnValue('9999\n')
+    boundedReadMock.mockReturnValue({ buffer: Buffer.from('9999\n') })
     // PID is gone: process.kill throws ESRCH.
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
       throw new Error('ESRCH')

--- a/src/main/startup/ensure-virtual-display.ts
+++ b/src/main/startup/ensure-virtual-display.ts
@@ -1,6 +1,7 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process'
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, rmSync } from 'node:fs'
 import { app } from 'electron'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 
 // Why: headless `orca serve` backs browser panes with offscreen BrowserWindows.
 // On Linux, Electron has no display platform without an X server and segfaults
@@ -12,6 +13,7 @@ const XVFB_STARTUP_TIMEOUT_MS = 5_000
 const XVFB_POLL_INTERVAL_MS = 50
 const VIRTUAL_DISPLAY_NUMBER = 99
 const VIRTUAL_DISPLAY = `:${VIRTUAL_DISPLAY_NUMBER}`
+export const X_DISPLAY_LOCK_MAX_BYTES = 64
 
 let xvfbProcess: ChildProcess | null = null
 
@@ -41,13 +43,8 @@ function isDisplayServerAlive(displayNumber: number): boolean {
     // No lock means no server claimed this display; the bare socket is stale.
     return false
   }
-  let pid: number
-  try {
-    pid = Number.parseInt(readFileSync(lockPath, 'utf8').trim(), 10)
-  } catch {
-    return false
-  }
-  if (!Number.isInteger(pid) || pid <= 0) {
+  const pid = readXDisplayLockPid(lockPath)
+  if (pid === null) {
     return false
   }
   try {
@@ -56,6 +53,18 @@ function isDisplayServerAlive(displayNumber: number): boolean {
     return true
   } catch {
     return false
+  }
+}
+
+export function readXDisplayLockPid(lockPath: string): number | null {
+  try {
+    const raw = readNodeFileSyncWithinLimit(lockPath, X_DISPLAY_LOCK_MAX_BYTES)
+      .buffer.toString('utf8')
+      .trim()
+    const pid = Number.parseInt(raw, 10)
+    return Number.isInteger(pid) && pid > 0 ? pid : null
+  } catch {
+    return null
   }
 }
 

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -1,9 +1,10 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   GPU_FALLBACK_MARKER_FILE,
+  MAX_GPU_FALLBACK_MARKER_FILE_BYTES,
   clearGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   readGpuFallbackMarker,
@@ -98,5 +99,14 @@ describe('gpu-fallback-marker', () => {
     writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
     clearGpuFallbackMarker(userDataPath)
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
+  })
+
+  it('clears an oversized sparse marker without loading it', () => {
+    const path = join(userDataPath, GPU_FALLBACK_MARKER_FILE)
+    writeFileSync(path, '{"schemeVersion":2}')
+    truncateSync(path, MAX_GPU_FALLBACK_MARKER_FILE_BYTES + 1)
+
+    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(existsSync(path)).toBe(false)
   })
 })

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 
 /**
  * Persisted "disable hardware acceleration for this build" marker.
@@ -12,6 +13,7 @@ import { join } from 'node:path'
 
 export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
 export const GPU_FALLBACK_SCHEME_VERSION = 2
+export const MAX_GPU_FALLBACK_MARKER_FILE_BYTES = 8 * 1024
 
 export type GpuFallbackEnvironment = {
   appVersion: string
@@ -36,9 +38,12 @@ function markerPath(userDataPath: string): string {
 
 export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
   try {
-    const parsed = JSON.parse(readFileSync(markerPath(userDataPath), 'utf-8')) as Partial<
-      Record<keyof GpuFallbackMarker, unknown>
-    >
+    const parsed = JSON.parse(
+      readNodeFileSyncWithinLimit(
+        markerPath(userDataPath),
+        MAX_GPU_FALLBACK_MARKER_FILE_BYTES
+      ).buffer.toString('utf8')
+    ) as Partial<Record<keyof GpuFallbackMarker, unknown>>
     if (parsed.schemeVersion !== GPU_FALLBACK_SCHEME_VERSION) {
       return null
     }

--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -5,6 +5,7 @@ import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import {
   _resetHydrateShellPathCache,
   hydrateShellPath,
+  MAX_SHELL_PATH_STDOUT_BYTES,
   mergePathSegments,
   type HydrationResult
 } from './hydrate-shell-path'
@@ -156,6 +157,45 @@ describe('hydrateShellPath', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('kills a login shell whose stdout exceeds the PATH capture limit', async () => {
+    const proc = createMockShellProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const resultPromise = hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
+    proc.stdout.emit('data', Buffer.alloc(1024 * 1024 + 1, 0x78))
+
+    await expect(resultPromise).resolves.toEqual({
+      segments: [],
+      ok: false,
+      failureReason: 'empty_path'
+    })
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL')
+    expect(proc.stdout.listenerCount('data')).toBe(0)
+    expect(proc.listenerCount('error')).toBe(0)
+    expect(proc.listenerCount('close')).toBe(0)
+  })
+
+  it('captures PATH after tens of thousands of tiny stdout chunks', async () => {
+    const proc = createMockShellProcess()
+    spawnMock.mockReturnValue(proc)
+    const delimiterText = '__ORCA_SHELL_PATH__'
+    const output = Buffer.from(
+      `${'x'.repeat(MAX_SHELL_PATH_STDOUT_BYTES - 128)}${delimiterText}/bin${delimiterText}`
+    )
+
+    const resultPromise = hydrateShellPath({ shellOverride: '/bin/zsh', force: true })
+    for (let offset = 0; offset < output.byteLength; offset += 16) {
+      proc.stdout.emit('data', output.subarray(offset, offset + 16))
+    }
+    proc.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      segments: ['/bin'],
+      ok: true,
+      failureReason: 'none'
+    })
   })
 })
 

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import { delimiter } from 'node:path'
 import type { ShellHydrationFailureReason } from '../../shared/types'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 
 // Why: GUI-launched Electron on macOS/Linux inherits a minimal PATH from launchd
 // that does not include dirs appended by the user's shell rc files (~/.zshrc,
@@ -16,6 +17,7 @@ import type { ShellHydrationFailureReason } from '../../shared/types'
 
 const DELIMITER = '__ORCA_SHELL_PATH__'
 const SPAWN_TIMEOUT_MS = 5000
+export const MAX_SHELL_PATH_STDOUT_BYTES = 1024 * 1024
 
 // ANSI escape sequences can leak into the captured output when the user's rc
 // files print banners or set colored prompts. Strip them before parsing.
@@ -85,7 +87,7 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
     // and .bashrc/.zshrc are sourced — matches what `which` in Terminal sees.
     const command = `printf '%s' '${DELIMITER}'; printf '%s' "$PATH"; printf '%s' '${DELIMITER}'`
     let finished = false
-    let stdout = ''
+    const stdout = new GrowingByteBuffer()
     let timer: ReturnType<typeof setTimeout> | null = null
 
     const child = spawn(shell, ['-ilc', command], {
@@ -129,7 +131,15 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
     }, SPAWN_TIMEOUT_MS)
 
     const onStdoutData = (chunk: Buffer): void => {
-      stdout += chunk.toString('utf8')
+      if (chunk.byteLength > MAX_SHELL_PATH_STDOUT_BYTES - stdout.byteLength) {
+        try {
+          child.kill('SIGKILL')
+        } catch {}
+        stdout.clear()
+        finish({ segments: [], ok: false, failureReason: 'empty_path' })
+        return
+      }
+      stdout.append(chunk)
     }
 
     const onError = (): void => {
@@ -137,7 +147,7 @@ function spawnShellAndReadPath(shell: string): Promise<HydrationResult> {
     }
 
     const onClose = (): void => {
-      const segments = parseCapturedPath(stdout)
+      const segments = parseCapturedPath(stdout.toString('utf8'))
       if (segments.length === 0) {
         finish({ segments: [], ok: false, failureReason: 'empty_path' })
         return

--- a/src/main/startup/windows-user-data-acl.test.ts
+++ b/src/main/startup/windows-user-data-acl.test.ts
@@ -1,11 +1,12 @@
 import { EventEmitter } from 'node:events'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import {
   ensureWindowsUserDataAclGrant,
   WINDOWS_ACL_GRANT_MARKER_FILE,
+  WINDOWS_ACL_GRANT_MARKER_MAX_BYTES,
   WINDOWS_ACL_GRANT_SCHEME_VERSION,
   type WindowsAclGrantResult
 } from './windows-user-data-acl'
@@ -83,6 +84,43 @@ describe('ensureWindowsUserDataAclGrant', () => {
     })
     expect(result).toEqual({ mode: 'marker-hit' })
     expect(fake.calls).toHaveLength(0)
+  })
+
+  it('accepts a matching ACL marker at the exact byte boundary', async () => {
+    const marker = JSON.stringify({
+      schemeVersion: WINDOWS_ACL_GRANT_SCHEME_VERSION,
+      identity: 'testuser',
+      grantedAt: 1
+    })
+    writeFileSync(
+      join(userDataPath, WINDOWS_ACL_GRANT_MARKER_FILE),
+      marker + ' '.repeat(WINDOWS_ACL_GRANT_MARKER_MAX_BYTES - Buffer.byteLength(marker))
+    )
+    const fake = createFakeSpawn(0)
+
+    expect(
+      await awaitResult(userDataPath, {
+        identity: 'testuser',
+        spawnFn: fake.spawnFn as never
+      })
+    ).toEqual({ mode: 'marker-hit' })
+    expect(fake.calls).toHaveLength(0)
+  })
+
+  it('re-grants and replaces a sparse ACL marker one byte over the boundary', async () => {
+    const markerPath = join(userDataPath, WINDOWS_ACL_GRANT_MARKER_FILE)
+    writeFileSync(markerPath, '{"schemeVersion":1,"identity":"testuser","grantedAt":1}')
+    truncateSync(markerPath, WINDOWS_ACL_GRANT_MARKER_MAX_BYTES + 1)
+    const fake = createFakeSpawn(0)
+
+    expect(
+      await awaitResult(userDataPath, {
+        identity: 'testuser',
+        spawnFn: fake.spawnFn as never
+      })
+    ).toEqual({ mode: 'granted' })
+    expect(fake.calls).toHaveLength(2)
+    expect(statSync(markerPath).size).toBeLessThan(WINDOWS_ACL_GRANT_MARKER_MAX_BYTES)
   })
 
   it('re-grants when the marker belongs to a different identity', async () => {

--- a/src/main/startup/windows-user-data-acl.ts
+++ b/src/main/startup/windows-user-data-acl.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
-import { readFileSync, writeFileSync } from 'node:fs'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 import { getIcaclsExePath, resolveCurrentWindowsIdentity } from '../win32-utils'
 
 /**
@@ -32,6 +33,7 @@ import { getIcaclsExePath, resolveCurrentWindowsIdentity } from '../win32-utils'
 
 export const WINDOWS_ACL_GRANT_MARKER_FILE = 'windows-acl-grant.json'
 export const WINDOWS_ACL_GRANT_SCHEME_VERSION = 1
+export const WINDOWS_ACL_GRANT_MARKER_MAX_BYTES = 8 * 1024
 
 const GRANT_TIMEOUT_MS = 120_000
 
@@ -58,7 +60,10 @@ type EnsureOptions = {
 function readMarker(userDataPath: string): WindowsAclGrantMarker | null {
   try {
     const parsed = JSON.parse(
-      readFileSync(join(userDataPath, WINDOWS_ACL_GRANT_MARKER_FILE), 'utf-8')
+      readNodeFileSyncWithinLimit(
+        join(userDataPath, WINDOWS_ACL_GRANT_MARKER_FILE),
+        WINDOWS_ACL_GRANT_MARKER_MAX_BYTES
+      ).buffer.toString('utf8')
     ) as Partial<WindowsAclGrantMarker>
     if (
       parsed.schemeVersion === WINDOWS_ACL_GRANT_SCHEME_VERSION &&

--- a/src/main/startup/x-display-lock-reader.test.ts
+++ b/src/main/startup/x-display-lock-reader.test.ts
@@ -1,0 +1,46 @@
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    commandLine: { appendSwitch: vi.fn() },
+    disableHardwareAcceleration: vi.fn(),
+    once: vi.fn()
+  }
+}))
+
+import { X_DISPLAY_LOCK_MAX_BYTES, readXDisplayLockPid } from './ensure-virtual-display'
+
+const roots: string[] = []
+
+function createLock(contents: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-x-display-lock-'))
+  roots.push(root)
+  const lockPath = join(root, '.X99-lock')
+  writeFileSync(lockPath, contents)
+  return lockPath
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('X display lock reader', () => {
+  it('accepts a PID marker at the exact byte boundary', () => {
+    const pid = '4321'
+    const lockPath = createLock(pid + ' '.repeat(X_DISPLAY_LOCK_MAX_BYTES - pid.length))
+
+    expect(readXDisplayLockPid(lockPath)).toBe(4321)
+  })
+
+  it('rejects a sparse PID marker one byte over the boundary', () => {
+    const lockPath = createLock('4321')
+    truncateSync(lockPath, X_DISPLAY_LOCK_MAX_BYTES + 1)
+
+    expect(readXDisplayLockPid(lockPath)).toBeNull()
+  })
+})

--- a/src/main/terminal-history-gc.test.ts
+++ b/src/main/terminal-history-gc.test.ts
@@ -1,0 +1,213 @@
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  deleteWslWorktreeHistoryDirectories,
+  runTerminalHistoryGarbageCollection,
+  TERMINAL_HISTORY_GC_META_MAX_BYTES
+} from './terminal-history-gc'
+
+let root = ''
+let mainRoot = ''
+let wslRoot = ''
+
+function oldMetadata(worktreeId: string): string {
+  return JSON.stringify({
+    worktreeId,
+    createdAt: new Date(Date.now() - 10 * 60 * 1000).toISOString()
+  })
+}
+
+async function createHistoryDirectory(
+  historyRoot: string,
+  directoryName: string,
+  worktreeId = directoryName
+): Promise<string> {
+  const directory = join(historyRoot, directoryName)
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, 'meta.json'), oldMetadata(worktreeId))
+  return directory
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-terminal-history-gc-'))
+  mainRoot = join(root, 'terminal-history')
+  wslRoot = join(root, 'terminal-history-wsl')
+  await mkdir(mainRoot)
+  vi.spyOn(console, 'log').mockImplementation(() => {})
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('terminal history GC memory limits', () => {
+  it('preserves ordinary live/orphan and age-guard behavior below the limits', async () => {
+    const liveDirectory = await createHistoryDirectory(mainRoot, 'live-dir', 'live-worktree')
+    const orphanDirectory = await createHistoryDirectory(mainRoot, 'orphan-dir', 'orphan-worktree')
+    const freshDirectory = await createHistoryDirectory(mainRoot, 'fresh-dir', 'fresh-worktree')
+    await writeFile(
+      join(freshDirectory, 'meta.json'),
+      JSON.stringify({ worktreeId: 'fresh-worktree', createdAt: new Date().toISOString() })
+    )
+
+    const summary = runTerminalHistoryGarbageCollection({
+      mainRoot,
+      wslRoot,
+      liveWorktreeIds: new Set(['live-worktree'])
+    })
+
+    expect(summary).toMatchObject({
+      capacityExceeded: false,
+      orphaned: 1,
+      pruned: 1,
+      totalDirs: 3
+    })
+    expect(existsSync(liveDirectory)).toBe(true)
+    expect(existsSync(freshDirectory)).toBe(true)
+    expect(existsSync(orphanDirectory)).toBe(false)
+  })
+
+  it('accepts metadata at the exact byte limit and skips one byte over', async () => {
+    const exactDirectory = await createHistoryDirectory(mainRoot, 'exact-dir', 'exact-worktree')
+    const exactMetaPath = join(exactDirectory, 'meta.json')
+    const exactJson = oldMetadata('exact-worktree')
+    await writeFile(
+      exactMetaPath,
+      `${exactJson}${' '.repeat(TERMINAL_HISTORY_GC_META_MAX_BYTES - exactJson.length)}`
+    )
+
+    expect(
+      runTerminalHistoryGarbageCollection({
+        mainRoot,
+        wslRoot,
+        liveWorktreeIds: new Set()
+      }).pruned
+    ).toBe(1)
+
+    const oversizedDirectory = await createHistoryDirectory(
+      mainRoot,
+      'oversized-dir',
+      'oversized-worktree'
+    )
+    const oversizedMetaPath = join(oversizedDirectory, 'meta.json')
+    await writeFile(oversizedMetaPath, oldMetadata('oversized-worktree'))
+    await truncate(oversizedMetaPath, TERMINAL_HISTORY_GC_META_MAX_BYTES + 8 * 1024 * 1024)
+
+    expect(
+      runTerminalHistoryGarbageCollection({
+        mainRoot,
+        wslRoot,
+        liveWorktreeIds: new Set()
+      }).pruned
+    ).toBe(0)
+    expect(existsSync(oversizedDirectory)).toBe(true)
+  })
+
+  it('accepts the exact discovery-entry budget and stops before the next entry', async () => {
+    await createHistoryDirectory(mainRoot, 'one')
+    await createHistoryDirectory(mainRoot, 'two')
+
+    const exact = runTerminalHistoryGarbageCollection({
+      mainRoot,
+      wslRoot,
+      liveWorktreeIds: new Set(),
+      limits: { maxDiscoveryEntries: 4 }
+    })
+    expect(exact).toMatchObject({ capacityExceeded: false, pruned: 2 })
+
+    await createHistoryDirectory(mainRoot, 'one')
+    await createHistoryDirectory(mainRoot, 'two')
+    await createHistoryDirectory(mainRoot, 'three')
+    const capped = runTerminalHistoryGarbageCollection({
+      mainRoot,
+      wslRoot,
+      liveWorktreeIds: new Set(),
+      limits: { maxDiscoveryEntries: 4 }
+    })
+    expect(capped.capacityExceeded).toBe(true)
+    expect(
+      [join(mainRoot, 'one'), join(mainRoot, 'two'), join(mainRoot, 'three')].some(existsSync)
+    ).toBe(true)
+  })
+
+  it('fails closed when a worktree directory exceeds its flat-file limit', async () => {
+    const directory = await createHistoryDirectory(mainRoot, 'many-files')
+    for (let index = 0; index < 100; index += 1) {
+      await writeFile(join(directory, `history-${index}`), 'x')
+    }
+
+    const summary = runTerminalHistoryGarbageCollection({
+      mainRoot,
+      wslRoot,
+      liveWorktreeIds: new Set(),
+      limits: { maxFilesPerWorktree: 1 }
+    })
+
+    expect(summary).toMatchObject({ capacityExceeded: false, pruned: 0 })
+    expect(existsSync(directory)).toBe(true)
+  })
+
+  it('does not recursively prune an unexpected nested history tree', async () => {
+    const directory = await createHistoryDirectory(mainRoot, 'nested-tree')
+    await mkdir(join(directory, 'unexpected', 'deep'), { recursive: true })
+
+    const summary = runTerminalHistoryGarbageCollection({
+      mainRoot,
+      wslRoot,
+      liveWorktreeIds: new Set()
+    })
+
+    expect(summary).toMatchObject({ capacityExceeded: false, pruned: 0 })
+    expect(existsSync(directory)).toBe(true)
+  })
+
+  it('caps WSL distro roots for both GC and direct worktree cleanup', async () => {
+    const first = join(wslRoot, 'Distro-A')
+    const second = join(wslRoot, 'Distro-B')
+    let firstHistory = await createHistoryDirectory(first, 'hash', 'first-worktree')
+    let secondHistory = await createHistoryDirectory(second, 'hash', 'second-worktree')
+
+    const exactSummary = runTerminalHistoryGarbageCollection({
+      mainRoot,
+      wslRoot,
+      liveWorktreeIds: new Set(),
+      limits: { maxWslDistros: 2 }
+    })
+    expect(exactSummary).toMatchObject({ capacityExceeded: false, pruned: 2 })
+
+    firstHistory = await createHistoryDirectory(first, 'hash', 'first-worktree')
+    secondHistory = await createHistoryDirectory(second, 'hash', 'second-worktree')
+    const cappedSummary = runTerminalHistoryGarbageCollection({
+      mainRoot,
+      wslRoot,
+      liveWorktreeIds: new Set(),
+      limits: { maxWslDistros: 1 }
+    })
+    expect(cappedSummary.capacityExceeded).toBe(true)
+    expect([firstHistory, secondHistory].some(existsSync)).toBe(true)
+
+    await mkdir(firstHistory, { recursive: true })
+    await mkdir(secondHistory, { recursive: true })
+    deleteWslWorktreeHistoryDirectories({
+      wslRoot,
+      worktreeHash: 'hash',
+      limits: { maxWslDistros: 2 }
+    })
+    expect(existsSync(firstHistory)).toBe(false)
+    expect(existsSync(secondHistory)).toBe(false)
+
+    await mkdir(firstHistory, { recursive: true })
+    await mkdir(secondHistory, { recursive: true })
+    deleteWslWorktreeHistoryDirectories({
+      wslRoot,
+      worktreeHash: 'hash',
+      limits: { maxWslDistros: 1 }
+    })
+    expect([firstHistory, secondHistory].some(existsSync)).toBe(true)
+  })
+})

--- a/src/main/terminal-history-gc.ts
+++ b/src/main/terminal-history-gc.ts
@@ -1,0 +1,305 @@
+import { existsSync, opendirSync, rmSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
+
+export const TERMINAL_HISTORY_GC_MAX_DISCOVERY_ENTRIES = 100_000
+export const TERMINAL_HISTORY_GC_MAX_WSL_DISTROS = 256
+export const TERMINAL_HISTORY_GC_MAX_FILES_PER_WORKTREE = 64
+export const TERMINAL_HISTORY_GC_META_MAX_BYTES = 64 * 1024
+
+export type TerminalHistoryGcLimits = {
+  maxDiscoveryEntries: number
+  maxFilesPerWorktree: number
+  maxMetaBytes: number
+  maxWslDistros: number
+}
+
+export type TerminalHistoryGcSummary = {
+  capacityExceeded: boolean
+  orphaned: number
+  pruned: number
+  totalDirs: number
+  totalSizeKB: number
+}
+
+const DEFAULT_LIMITS: TerminalHistoryGcLimits = {
+  maxDiscoveryEntries: TERMINAL_HISTORY_GC_MAX_DISCOVERY_ENTRIES,
+  maxFilesPerWorktree: TERMINAL_HISTORY_GC_MAX_FILES_PER_WORKTREE,
+  maxMetaBytes: TERMINAL_HISTORY_GC_META_MAX_BYTES,
+  maxWslDistros: TERMINAL_HISTORY_GC_MAX_WSL_DISTROS
+}
+
+// Why: the live-worktree snapshot can predate a newly created history directory.
+const GC_MIN_AGE_MS = 5 * 60 * 1000
+
+class TerminalHistoryGcCapacityError extends Error {
+  constructor(
+    readonly resource: 'discovery entries' | 'WSL distros',
+    readonly limit: number
+  ) {
+    super(`Terminal history GC exceeded ${limit} ${resource}`)
+    this.name = 'TerminalHistoryGcCapacityError'
+  }
+}
+
+class TerminalHistoryGcBudget {
+  private discoveryEntries = 0
+  private wslDistros = 0
+
+  constructor(readonly limits: TerminalHistoryGcLimits) {}
+
+  claimDiscoveryEntry(): void {
+    this.discoveryEntries += 1
+    if (this.discoveryEntries > this.limits.maxDiscoveryEntries) {
+      throw new TerminalHistoryGcCapacityError('discovery entries', this.limits.maxDiscoveryEntries)
+    }
+  }
+
+  claimWslDistro(): void {
+    this.wslDistros += 1
+    if (this.wslDistros > this.limits.maxWslDistros) {
+      throw new TerminalHistoryGcCapacityError('WSL distros', this.limits.maxWslDistros)
+    }
+  }
+}
+
+type MutableTerminalHistoryGcSummary = Omit<TerminalHistoryGcSummary, 'capacityExceeded'>
+
+export function runTerminalHistoryGarbageCollection(options: {
+  mainRoot: string
+  wslRoot: string
+  liveWorktreeIds: Set<string>
+  limits?: Partial<TerminalHistoryGcLimits>
+}): TerminalHistoryGcSummary {
+  const limits = resolveTerminalHistoryGcLimits(options.limits)
+  const budget = new TerminalHistoryGcBudget(limits)
+  const summary: TerminalHistoryGcSummary = {
+    capacityExceeded: false,
+    orphaned: 0,
+    pruned: 0,
+    totalDirs: 0,
+    totalSizeKB: 0
+  }
+
+  try {
+    scanTerminalHistoryRoot(options.mainRoot, options.liveWorktreeIds, budget, limits, summary)
+    scanWslHistoryRoots(options.wslRoot, options.liveWorktreeIds, budget, limits, summary)
+  } catch (error) {
+    if (!(error instanceof TerminalHistoryGcCapacityError)) {
+      throw error
+    }
+    summary.capacityExceeded = true
+    console.warn(`[pty:history:gc] ${error.message}; remaining history will be scanned next run`)
+  }
+  return summary
+}
+
+export function deleteWslWorktreeHistoryDirectories(options: {
+  wslRoot: string
+  worktreeHash: string
+  limits?: Partial<TerminalHistoryGcLimits>
+}): void {
+  if (!existsSync(options.wslRoot)) {
+    return
+  }
+  const limits = resolveTerminalHistoryGcLimits(options.limits)
+  const budget = new TerminalHistoryGcBudget(limits)
+  try {
+    forEachDirectoryEntry(options.wslRoot, (distro) => {
+      budget.claimDiscoveryEntry()
+      const distroRoot = join(options.wslRoot, distro)
+      if (!statSync(distroRoot).isDirectory()) {
+        return
+      }
+      budget.claimWslDistro()
+      const historyPath = join(distroRoot, options.worktreeHash)
+      if (existsSync(historyPath)) {
+        rmSync(historyPath, { recursive: true, force: true })
+      }
+    })
+  } catch (error) {
+    if (error instanceof TerminalHistoryGcCapacityError) {
+      console.warn(`[pty:history] ${error.message}; WSL cleanup stopped at the limit`)
+      return
+    }
+    throw error
+  }
+}
+
+function scanWslHistoryRoots(
+  wslRoot: string,
+  liveWorktreeIds: Set<string>,
+  budget: TerminalHistoryGcBudget,
+  limits: TerminalHistoryGcLimits,
+  summary: TerminalHistoryGcSummary
+): void {
+  if (!existsSync(wslRoot)) {
+    return
+  }
+  try {
+    forEachDirectoryEntry(wslRoot, (distro) => {
+      budget.claimDiscoveryEntry()
+      const distroRoot = join(wslRoot, distro)
+      try {
+        if (!statSync(distroRoot).isDirectory()) {
+          return
+        }
+        budget.claimWslDistro()
+        scanTerminalHistoryRoot(distroRoot, liveWorktreeIds, budget, limits, summary)
+      } catch (error) {
+        if (error instanceof TerminalHistoryGcCapacityError) {
+          throw error
+        }
+        // One unavailable distro must not discard the main-root GC result.
+      }
+    })
+  } catch (error) {
+    if (error instanceof TerminalHistoryGcCapacityError) {
+      throw error
+    }
+    // WSL history is optional and may disappear while distributions stop.
+  }
+}
+
+function scanTerminalHistoryRoot(
+  root: string,
+  liveWorktreeIds: Set<string>,
+  budget: TerminalHistoryGcBudget,
+  limits: TerminalHistoryGcLimits,
+  summary: MutableTerminalHistoryGcSummary
+): void {
+  if (!existsSync(root)) {
+    return
+  }
+  const now = Date.now()
+
+  forEachDirectoryEntry(root, (entry) => {
+    budget.claimDiscoveryEntry()
+    const entryPath = join(root, entry)
+    try {
+      if (!statSync(entryPath).isDirectory()) {
+        return
+      }
+      summary.totalDirs += 1
+      const sizeEstimate = estimateHistoryDirectorySize(entryPath, budget, limits)
+      summary.totalSizeKB += sizeEstimate.totalSizeKB
+      if (!sizeEstimate.complete) {
+        return
+      }
+
+      const meta = readTerminalHistoryMetadata(join(entryPath, 'meta.json'), limits.maxMetaBytes)
+      if (!meta || liveWorktreeIds.has(meta.worktreeId)) {
+        return
+      }
+      if (meta.createdAt) {
+        const ageMs = now - new Date(meta.createdAt).getTime()
+        if (ageMs < GC_MIN_AGE_MS) {
+          return
+        }
+      }
+
+      summary.orphaned += 1
+      rmSync(entryPath, { recursive: true, force: true })
+      summary.pruned += 1
+      console.log(`[pty:history:gc] Pruned orphaned history: ${meta.worktreeId}`)
+    } catch (error) {
+      if (error instanceof TerminalHistoryGcCapacityError) {
+        throw error
+      }
+      // One corrupt or concurrently removed history directory must not stop GC.
+    }
+  })
+}
+
+function estimateHistoryDirectorySize(
+  directoryPath: string,
+  budget: TerminalHistoryGcBudget,
+  limits: TerminalHistoryGcLimits
+): { complete: boolean; totalSizeKB: number } {
+  let complete = true
+  let fileCount = 0
+  let totalSizeKB = 0
+  try {
+    forEachDirectoryEntry(directoryPath, (file) => {
+      budget.claimDiscoveryEntry()
+      fileCount += 1
+      if (fileCount > limits.maxFilesPerWorktree) {
+        complete = false
+        return false
+      }
+      const fileStat = statSync(join(directoryPath, file))
+      if (fileStat.isDirectory()) {
+        complete = false
+        return false
+      }
+      totalSizeKB += Math.ceil(fileStat.size / 1024)
+      return undefined
+    })
+  } catch (error) {
+    if (error instanceof TerminalHistoryGcCapacityError) {
+      throw error
+    }
+    complete = false
+  }
+  return { complete, totalSizeKB }
+}
+
+function readTerminalHistoryMetadata(
+  metaPath: string,
+  maxBytes: number
+): { worktreeId: string; createdAt?: string } | null {
+  if (!existsSync(metaPath)) {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(
+      readNodeFileSyncWithinLimit(metaPath, maxBytes).buffer.toString('utf8')
+    ) as unknown
+    if (
+      parsed === null ||
+      typeof parsed !== 'object' ||
+      !('worktreeId' in parsed) ||
+      typeof parsed.worktreeId !== 'string' ||
+      parsed.worktreeId.length === 0
+    ) {
+      return null
+    }
+    const createdAt =
+      'createdAt' in parsed && typeof parsed.createdAt === 'string' ? parsed.createdAt : undefined
+    return { worktreeId: parsed.worktreeId, ...(createdAt ? { createdAt } : {}) }
+  } catch {
+    return null
+  }
+}
+
+function forEachDirectoryEntry(
+  directoryPath: string,
+  visit: (entryName: string) => false | void
+): void {
+  const directory = opendirSync(directoryPath)
+  try {
+    for (let entry = directory.readSync(); entry !== null; entry = directory.readSync()) {
+      if (visit(entry.name) === false) {
+        return
+      }
+    }
+  } finally {
+    try {
+      directory.closeSync()
+    } catch {
+      // The OS may have already closed a failed directory stream.
+    }
+  }
+}
+
+function resolveTerminalHistoryGcLimits(
+  overrides: Partial<TerminalHistoryGcLimits> = {}
+): TerminalHistoryGcLimits {
+  const limits = { ...DEFAULT_LIMITS, ...overrides }
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`${name} must be a non-negative safe integer`)
+    }
+  }
+  return limits
+}

--- a/src/main/terminal-history.test.ts
+++ b/src/main/terminal-history.test.ts
@@ -7,6 +7,7 @@ const {
   readFileSyncMock,
   rmSyncMock,
   readdirSyncMock,
+  opendirSyncMock,
   statSyncMock,
   getPathMock
 } = vi.hoisted(() => ({
@@ -16,6 +17,7 @@ const {
   readFileSyncMock: vi.fn(),
   rmSyncMock: vi.fn(),
   readdirSyncMock: vi.fn(),
+  opendirSyncMock: vi.fn(),
   statSyncMock: vi.fn(),
   getPathMock: vi.fn()
 }))
@@ -27,7 +29,19 @@ vi.mock('fs', () => ({
   readFileSync: readFileSyncMock,
   rmSync: rmSyncMock,
   readdirSync: readdirSyncMock,
+  opendirSync: opendirSyncMock,
   statSync: statSyncMock
+}))
+
+vi.mock('../shared/node-bounded-file-reader', () => ({
+  readNodeFileSyncWithinLimit: (filePath: string, maxBytes: number) => {
+    const value = readFileSyncMock(filePath, 'utf8')
+    const buffer = Buffer.isBuffer(value) ? value : Buffer.from(String(value))
+    if (buffer.byteLength > maxBytes) {
+      throw new Error('File too large')
+    }
+    return { buffer, stats: statSyncMock(filePath) }
+  }
 }))
 
 vi.mock('electron', () => ({
@@ -66,7 +80,22 @@ describe('terminal-history', () => {
     vi.clearAllMocks()
     getPathMock.mockReturnValue('/fake/userData')
     existsSyncMock.mockReturnValue(true)
-    statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
+    statSyncMock.mockImplementation((filePath: string) => ({
+      isDirectory: () => !filePath.endsWith('meta.json'),
+      size: 100
+    }))
+    opendirSyncMock.mockImplementation((directoryPath: string) => {
+      const entries = (readdirSyncMock(directoryPath) ?? []) as string[]
+      let index = 0
+      return {
+        closeSync: vi.fn(),
+        readSync: () => {
+          const name = entries[index]
+          index += 1
+          return name === undefined ? null : { name }
+        }
+      }
+    })
   })
 
   describe('resolveShellKind', () => {
@@ -302,7 +331,10 @@ describe('terminal-history', () => {
         }
         return ['meta.json']
       })
-      statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
+      statSyncMock.mockImplementation((filePath: string) => ({
+        isDirectory: () => !filePath.endsWith('meta.json'),
+        size: 100
+      }))
       readFileSyncMock.mockImplementation((p: string) => {
         // Use a createdAt old enough to pass the GC age threshold
         const oldDate = new Date(Date.now() - 10 * 60 * 1000).toISOString()
@@ -336,7 +368,10 @@ describe('terminal-history', () => {
         }
         return ['meta.json']
       })
-      statSyncMock.mockReturnValue({ isDirectory: () => true, size: 100 })
+      statSyncMock.mockImplementation((filePath: string) => ({
+        isDirectory: () => !filePath.endsWith('meta.json'),
+        size: 100
+      }))
       // createdAt is just now — younger than the 5-minute GC threshold
       readFileSyncMock.mockReturnValue(
         JSON.stringify({ worktreeId: 'unknown-wt', createdAt: new Date().toISOString() })

--- a/src/main/terminal-history.ts
+++ b/src/main/terminal-history.ts
@@ -1,16 +1,12 @@
 import { createHash } from 'node:crypto'
 import { join, basename } from 'node:path'
-import {
-  mkdirSync,
-  existsSync,
-  readFileSync,
-  writeFileSync,
-  readdirSync,
-  rmSync,
-  statSync
-} from 'node:fs'
+import { mkdirSync, existsSync, writeFileSync, rmSync } from 'node:fs'
 import { app } from 'electron'
 import { parseWslPath, toLinuxPath } from './wsl'
+import {
+  deleteWslWorktreeHistoryDirectories,
+  runTerminalHistoryGarbageCollection
+} from './terminal-history-gc'
 
 // ─── Constants ─────────────────────────────────────────────────────
 
@@ -227,14 +223,7 @@ export function deleteWorktreeHistoryDir(worktreeId: string): void {
   if (process.platform === 'win32') {
     try {
       const wslRoot = join(app.getPath('userData'), HISTORY_DIR_NAME_WSL)
-      if (existsSync(wslRoot)) {
-        for (const distro of readdirSync(wslRoot)) {
-          const wslDir = join(wslRoot, distro, worktreeHash)
-          if (existsSync(wslDir)) {
-            rmSync(wslDir, { recursive: true, force: true })
-          }
-        }
-      }
+      deleteWslWorktreeHistoryDirectories({ wslRoot, worktreeHash })
     } catch {
       // Non-fatal.
     }
@@ -243,112 +232,19 @@ export function deleteWorktreeHistoryDir(worktreeId: string): void {
 
 // ─── Garbage Collection ────────────────────────────────────────────
 
-// Why 5 minutes: GC runs ~10s after startup, and the live-worktree snapshot is
-// taken just before. A worktree created between the snapshot and GC execution
-// won't appear in liveWorktreeIds, so without an age guard GC would delete its
-// freshly-created history directory (TOCTOU race). 5 minutes is generous enough
-// to cover any realistic snapshot-to-scan delay.
-const GC_MIN_AGE_MS = 5 * 60 * 1000
-
-/** Scan a single history root directory, pruning orphaned entries.
- *  Returns { totalDirs, orphaned, pruned, totalSizeKB }. */
-function gcScanRoot(
-  root: string,
-  liveWorktreeIds: Set<string>
-): { totalDirs: number; orphaned: number; pruned: number; totalSizeKB: number } {
-  const result = { totalDirs: 0, orphaned: 0, pruned: 0, totalSizeKB: 0 }
-  if (!existsSync(root)) {
-    return result
-  }
-
-  const now = Date.now()
-
-  for (const entry of readdirSync(root)) {
-    const entryPath = join(root, entry)
-    try {
-      const stat = statSync(entryPath)
-      if (!stat.isDirectory()) {
-        continue
-      }
-      result.totalDirs++
-
-      // Estimate directory size from meta.json + history files.
-      try {
-        for (const file of readdirSync(entryPath)) {
-          result.totalSizeKB += Math.ceil(statSync(join(entryPath, file)).size / 1024)
-        }
-      } catch {
-        // Skip size estimation on error.
-      }
-
-      const metaPath = join(entryPath, 'meta.json')
-      if (!existsSync(metaPath)) {
-        // No meta.json — can't determine ownership, skip.
-        continue
-      }
-
-      const meta = JSON.parse(readFileSync(metaPath, 'utf-8')) as {
-        worktreeId?: string
-        createdAt?: string
-      }
-      if (!meta.worktreeId) {
-        continue
-      }
-
-      if (!liveWorktreeIds.has(meta.worktreeId)) {
-        // Why: avoid a TOCTOU race where a worktree is created after the
-        // live-ID snapshot but before GC runs. Directories younger than
-        // GC_MIN_AGE_MS are presumed still live and skipped.
-        if (meta.createdAt) {
-          const ageMs = now - new Date(meta.createdAt).getTime()
-          if (ageMs < GC_MIN_AGE_MS) {
-            continue
-          }
-        }
-
-        result.orphaned++
-        rmSync(entryPath, { recursive: true, force: true })
-        result.pruned++
-        console.log(`[pty:history:gc] Pruned orphaned history: ${meta.worktreeId}`)
-      }
-    } catch {
-      // Skip individual entries that fail.
-    }
-  }
-  return result
-}
-
 /** Run background GC to prune history directories for worktrees that are no
  *  longer in Orca's known live-worktree set. */
 export function runHistoryGc(liveWorktreeIds: Set<string>): void {
   try {
-    const main = gcScanRoot(getHistoryRoot(), liveWorktreeIds)
-
-    // Also scan WSL history directories (each distro has its own subdirectory).
     const wslRoot = join(app.getPath('userData'), HISTORY_DIR_NAME_WSL)
-    let wslTotals = { totalDirs: 0, orphaned: 0, pruned: 0, totalSizeKB: 0 }
-    if (existsSync(wslRoot)) {
-      try {
-        for (const distro of readdirSync(wslRoot)) {
-          const distroRoot = join(wslRoot, distro)
-          const r = gcScanRoot(distroRoot, liveWorktreeIds)
-          wslTotals.totalDirs += r.totalDirs
-          wslTotals.orphaned += r.orphaned
-          wslTotals.pruned += r.pruned
-          wslTotals.totalSizeKB += r.totalSizeKB
-        }
-      } catch {
-        // Non-fatal.
-      }
-    }
-
-    const totalDirs = main.totalDirs + wslTotals.totalDirs
-    const orphaned = main.orphaned + wslTotals.orphaned
-    const pruned = main.pruned + wslTotals.pruned
-    const totalSizeKB = main.totalSizeKB + wslTotals.totalSizeKB
+    const summary = runTerminalHistoryGarbageCollection({
+      mainRoot: getHistoryRoot(),
+      wslRoot,
+      liveWorktreeIds
+    })
 
     console.log(
-      `[pty:history:gc] totalDirs=${totalDirs} orphaned=${orphaned} pruned=${pruned} totalSizeKB=${totalSizeKB}`
+      `[pty:history:gc] totalDirs=${summary.totalDirs} orphaned=${summary.orphaned} pruned=${summary.pruned} totalSizeKB=${summary.totalSizeKB}`
     )
   } catch (err) {
     console.warn(`[pty:history:gc] GC failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/src/main/updater-changelog.test.ts
+++ b/src/main/updater-changelog.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { API_RESPONSE_MAX_BYTES, FetchResponseBodyTooLargeError } from './lib/fetch-response-body'
 
 const fetchMock = vi.fn()
 
@@ -224,6 +225,18 @@ describe('fetchChangelog', () => {
     const result = await fetchChangelog('1.1.21', '1.1.19')
 
     expect(result).toBeNull()
+  })
+
+  it('rejects an oversized successful Electron net response before reading it', async () => {
+    fetchMock.mockResolvedValue(
+      new Response('{', {
+        headers: { 'content-length': String(API_RESPONSE_MAX_BYTES + 1) }
+      })
+    )
+
+    await expect(fetchChangelog('1.1.21', '1.1.19')).rejects.toBeInstanceOf(
+      FetchResponseBodyTooLargeError
+    )
   })
 
   it('prefers exact match over fallback when both have rich content', async () => {

--- a/src/main/updater-changelog.ts
+++ b/src/main/updater-changelog.ts
@@ -1,6 +1,7 @@
 import { net } from 'electron'
 import type { ChangelogData } from '../shared/types'
 import { compareVersions } from './updater-fallback'
+import { readFetchResponseJsonWithinLimit } from './lib/fetch-response-body'
 
 type ChangelogEntry = {
   version: string
@@ -48,7 +49,7 @@ export async function fetchChangelog(
   if (!res.ok) {
     return null
   }
-  const json: unknown = await res.json()
+  const json = await readFetchResponseJsonWithinLimit<unknown>(res)
 
   // Why: the JSON endpoint is external and could serve malformed data.
   // Validate the shape before indexing into it to avoid runtime errors

--- a/src/main/updater-nudge.ts
+++ b/src/main/updater-nudge.ts
@@ -1,5 +1,6 @@
 import { net } from 'electron'
 import { compareVersions, isValidVersion } from './updater-fallback'
+import { readFetchResponseJsonWithinLimit } from './lib/fetch-response-body'
 
 export type NudgeConfig = {
   id: string
@@ -16,7 +17,7 @@ export async function fetchNudge(): Promise<NudgeConfig | null> {
       return null
     }
 
-    const json: unknown = await res.json()
+    const json = await readFetchResponseJsonWithinLimit<unknown>(res)
     if (!json || typeof json !== 'object' || Array.isArray(json)) {
       return null
     }

--- a/src/main/updater-prerelease-feed.ts
+++ b/src/main/updater-prerelease-feed.ts
@@ -1,6 +1,7 @@
 import { net } from 'electron'
 import { parse } from 'yaml'
 import { compareVersions, isPrereleaseVersion, isValidVersion } from './updater-fallback'
+import { readFetchResponseTextWithinLimit } from './lib/fetch-response-body'
 
 const ATOM_FEED_URL = 'https://github.com/stablyai/orca/releases.atom'
 const RELEASES_DOWNLOAD_BASE = 'https://github.com/stablyai/orca/releases/download'
@@ -61,7 +62,7 @@ async function fetchReleaseFeedTags(): Promise<ReleaseFeedTag[] | null> {
     if (!res.ok) {
       return null
     }
-    const body = await res.text()
+    const body = await readFetchResponseTextWithinLimit(res)
     const tags: ReleaseFeedTag[] = []
 
     for (const match of body.matchAll(TAG_HREF_RE)) {
@@ -128,7 +129,7 @@ async function hasReadyPlatformManifest(tag: string): Promise<boolean> {
     if (!res.ok) {
       return false
     }
-    const assetNames = getManifestAssetNames(await res.text())
+    const assetNames = getManifestAssetNames(await readFetchResponseTextWithinLimit(res))
     if (assetNames.length === 0) {
       return false
     }

--- a/src/main/usage-history-file-discovery.ts
+++ b/src/main/usage-history-file-discovery.ts
@@ -1,0 +1,44 @@
+import { opendir } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { UsageHistoryScanBudget } from './usage-history-scan-budget'
+
+export async function walkUsageHistoryJsonlFiles(
+  rootPath: string,
+  budget: UsageHistoryScanBudget
+): Promise<string[]> {
+  const pendingDirectories = [rootPath]
+  const files: string[] = []
+
+  while (pendingDirectories.length > 0) {
+    const directoryPath = pendingDirectories.pop()!
+    let directory: Awaited<ReturnType<typeof opendir>>
+    try {
+      directory = await opendir(directoryPath)
+    } catch (error) {
+      if (directoryPath !== rootPath && isVanishedDirectoryError(error)) {
+        continue
+      }
+      throw error
+    }
+    for await (const entry of directory) {
+      budget.claimDiscoveryEntry()
+      const fullPath = join(directoryPath, entry.name)
+      if (entry.isDirectory()) {
+        budget.claimPath(fullPath)
+        pendingDirectories.push(fullPath)
+      } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        budget.claimFile(fullPath)
+        files.push(fullPath)
+      }
+    }
+  }
+
+  return files
+}
+
+function isVanishedDirectoryError(error: unknown): boolean {
+  if (error === null || typeof error !== 'object' || !('code' in error)) {
+    return false
+  }
+  return error.code === 'ENOENT' || error.code === 'ENOTDIR'
+}

--- a/src/main/usage-history-jsonl-reader.test.ts
+++ b/src/main/usage-history-jsonl-reader.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_USAGE_HISTORY_JSONL_LINE_BYTES,
+  UsageHistoryJsonlLineCapacityError,
+  readUsageHistoryJsonlLines
+} from './usage-history-jsonl-reader'
+
+describe('readUsageHistoryJsonlLines', () => {
+  const temporaryDirectories: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true }))
+    )
+  })
+
+  async function createPath(): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), 'orca-usage-jsonl-'))
+    temporaryDirectories.push(directory)
+    return join(directory, 'history.jsonl')
+  }
+
+  it('preserves ordinary empty, CRLF, and unterminated records', async () => {
+    const filePath = await createPath()
+    await writeFile(filePath, 'first\r\n\nlast')
+
+    const lines: string[] = []
+    for await (const line of readUsageHistoryJsonlLines(filePath)) {
+      lines.push(line)
+    }
+
+    expect(lines).toEqual(['first', '', 'last'])
+  })
+
+  it('accepts a record exactly at the byte limit', async () => {
+    const filePath = await createPath()
+    await writeFile(filePath, Buffer.alloc(MAX_USAGE_HISTORY_JSONL_LINE_BYTES, 0x61))
+
+    const lines: string[] = []
+    for await (const line of readUsageHistoryJsonlLines(filePath)) {
+      lines.push(line)
+    }
+
+    expect(Buffer.byteLength(lines[0])).toBe(MAX_USAGE_HISTORY_JSONL_LINE_BYTES)
+  })
+
+  it('rejects a sparse unterminated record before reading the whole file', async () => {
+    const filePath = await createPath()
+    await writeFile(filePath, '')
+    await truncate(filePath, MAX_USAGE_HISTORY_JSONL_LINE_BYTES + 8 * 1024 * 1024)
+
+    const consume = async (): Promise<void> => {
+      for await (const _line of readUsageHistoryJsonlLines(filePath)) {
+        // The oversized record is unterminated, so no line should be yielded.
+      }
+    }
+
+    await expect(consume()).rejects.toThrow(UsageHistoryJsonlLineCapacityError)
+  })
+})

--- a/src/main/usage-history-jsonl-reader.ts
+++ b/src/main/usage-history-jsonl-reader.ts
@@ -1,0 +1,57 @@
+import { createReadStream } from 'node:fs'
+
+export const MAX_USAGE_HISTORY_JSONL_LINE_BYTES = 4 * 1024 * 1024
+
+export class UsageHistoryJsonlLineCapacityError extends Error {
+  constructor(readonly limit = MAX_USAGE_HISTORY_JSONL_LINE_BYTES) {
+    super(`Usage history JSONL record exceeded ${limit} bytes`)
+    this.name = 'UsageHistoryJsonlLineCapacityError'
+  }
+}
+
+export async function* readUsageHistoryJsonlLines(
+  filePath: string,
+  options: { start?: number; maxLineBytes?: number } = {}
+): AsyncGenerator<string> {
+  const maxLineBytes = options.maxLineBytes ?? MAX_USAGE_HISTORY_JSONL_LINE_BYTES
+  const stream = createReadStream(filePath, {
+    start: options.start ?? 0,
+    highWaterMark: 64 * 1024
+  })
+  let fragments: Buffer[] = []
+  let fragmentBytes = 0
+
+  for await (const rawChunk of stream) {
+    const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk)
+    let offset = 0
+    while (offset < chunk.length) {
+      const newlineIndex = chunk.indexOf(0x0a, offset)
+      const end = newlineIndex === -1 ? chunk.length : newlineIndex
+      const fragment = chunk.subarray(offset, end)
+      if (fragment.length > maxLineBytes - fragmentBytes) {
+        throw new UsageHistoryJsonlLineCapacityError(maxLineBytes)
+      }
+      if (fragment.length > 0) {
+        fragments.push(fragment)
+        fragmentBytes += fragment.length
+      }
+      if (newlineIndex === -1) {
+        break
+      }
+      yield decodeJsonlLine(fragments, fragmentBytes)
+      fragments = []
+      fragmentBytes = 0
+      offset = newlineIndex + 1
+    }
+  }
+
+  if (fragmentBytes > 0) {
+    yield decodeJsonlLine(fragments, fragmentBytes)
+  }
+}
+
+function decodeJsonlLine(fragments: Buffer[], bytes: number): string {
+  const line = fragments.length === 1 ? fragments[0] : Buffer.concat(fragments, bytes)
+  const content = line.at(-1) === 0x0d ? line.subarray(0, -1) : line
+  return content.toString('utf8')
+}

--- a/src/main/usage-history-scan-budget.test.ts
+++ b/src/main/usage-history-scan-budget.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_USAGE_HISTORY_DISCOVERY_ENTRIES,
+  MAX_USAGE_HISTORY_FILES,
+  MAX_USAGE_HISTORY_OWNERSHIP_KEYS,
+  MAX_USAGE_HISTORY_RECORDS,
+  MAX_USAGE_HISTORY_RETAINED_BYTES,
+  UsageHistoryScanBudget,
+  UsageHistoryScanCapacityError
+} from './usage-history-scan-budget'
+
+describe('UsageHistoryScanBudget', () => {
+  it('publishes the production scan limits', () => {
+    expect({
+      files: MAX_USAGE_HISTORY_FILES,
+      discoveryEntries: MAX_USAGE_HISTORY_DISCOVERY_ENTRIES,
+      records: MAX_USAGE_HISTORY_RECORDS,
+      ownershipKeys: MAX_USAGE_HISTORY_OWNERSHIP_KEYS,
+      retainedBytes: MAX_USAGE_HISTORY_RETAINED_BYTES
+    }).toEqual({
+      files: 200_000,
+      discoveryEntries: 1_000_000,
+      records: 100_000,
+      ownershipKeys: 100_000,
+      retainedBytes: 256 * 1024 * 1024
+    })
+  })
+
+  it('accepts exact limits and fails closed before each collection can grow past them', () => {
+    const files = new UsageHistoryScanBudget({ files: 2, retainedBytes: 10_000 })
+    files.claimFile('a')
+    files.claimFile('b')
+    expect(() => files.claimFile('c')).toThrowError(
+      expect.objectContaining({ resource: 'files', limit: 2 })
+    )
+
+    const entries = new UsageHistoryScanBudget({ discoveryEntries: 2 })
+    entries.claimDiscoveryEntry()
+    entries.claimDiscoveryEntry()
+    expect(() => entries.claimDiscoveryEntry()).toThrow(UsageHistoryScanCapacityError)
+
+    const records = new UsageHistoryScanBudget({ records: 2, retainedBytes: 10_000 })
+    records.claimRecord(1)
+    records.claimRecord(1)
+    expect(() => records.claimRecord(1)).toThrowError(
+      expect.objectContaining({ resource: 'records', limit: 2 })
+    )
+
+    const keys = new UsageHistoryScanBudget({ ownershipKeys: 2, retainedBytes: 10_000 })
+    keys.claimOwnershipKey('a')
+    keys.claimOwnershipKey('b')
+    expect(() => keys.claimOwnershipKey('c')).toThrowError(
+      expect.objectContaining({ resource: 'ownershipKeys', limit: 2 })
+    )
+
+    const bytes = new UsageHistoryScanBudget({ retainedBytes: 2 })
+    bytes.claimRetainedBytes(2)
+    expect(() => bytes.claimRetainedBytes(1)).toThrowError(
+      expect.objectContaining({ resource: 'retainedBytes', limit: 2 })
+    )
+  })
+
+  it('charges conservative collection overhead for many tiny values', () => {
+    const records = new UsageHistoryScanBudget({ records: 100, retainedBytes: 10 * 1024 })
+    for (let index = 0; index < 10; index++) {
+      records.claimRecord(0)
+    }
+    expect(() => records.claimRecord(0)).toThrowError(
+      expect.objectContaining({ resource: 'retainedBytes', limit: 10 * 1024 })
+    )
+
+    const paths = new UsageHistoryScanBudget({ files: 100, retainedBytes: 1_940 })
+    for (let index = 0; index < 10; index++) {
+      paths.claimFile('a')
+    }
+    expect(() => paths.claimFile('b')).toThrowError(
+      expect.objectContaining({ resource: 'retainedBytes', limit: 1_940 })
+    )
+  })
+})

--- a/src/main/usage-history-scan-budget.ts
+++ b/src/main/usage-history-scan-budget.ts
@@ -1,0 +1,111 @@
+export const MAX_USAGE_HISTORY_FILES = 200_000
+export const MAX_USAGE_HISTORY_DISCOVERY_ENTRIES = 1_000_000
+export const MAX_USAGE_HISTORY_RECORDS = 100_000
+export const MAX_USAGE_HISTORY_OWNERSHIP_KEYS = 100_000
+export const MAX_USAGE_HISTORY_RETAINED_BYTES = 256 * 1024 * 1024
+
+const FILE_COLLECTION_ENTRY_BYTES = 160
+const OWNERSHIP_COLLECTION_ENTRY_BYTES = 160
+const RECORD_PIPELINE_BYTES = 1024
+const PROJECTION_ENTRY_BYTES = 256
+const STRING_HEADER_BYTES = 32
+
+type UsageHistoryScanLimits = {
+  files: number
+  discoveryEntries: number
+  records: number
+  ownershipKeys: number
+  retainedBytes: number
+}
+
+const DEFAULT_LIMITS: UsageHistoryScanLimits = {
+  files: MAX_USAGE_HISTORY_FILES,
+  discoveryEntries: MAX_USAGE_HISTORY_DISCOVERY_ENTRIES,
+  records: MAX_USAGE_HISTORY_RECORDS,
+  ownershipKeys: MAX_USAGE_HISTORY_OWNERSHIP_KEYS,
+  retainedBytes: MAX_USAGE_HISTORY_RETAINED_BYTES
+}
+
+export class UsageHistoryScanCapacityError extends Error {
+  constructor(
+    readonly resource: keyof UsageHistoryScanLimits,
+    readonly limit: number
+  ) {
+    super(`Usage history scan exceeded ${limit} ${resource}`)
+    this.name = 'UsageHistoryScanCapacityError'
+  }
+}
+
+export class UsageHistoryScanBudget {
+  private readonly limits: UsageHistoryScanLimits
+  private readonly used: UsageHistoryScanLimits = {
+    files: 0,
+    discoveryEntries: 0,
+    records: 0,
+    ownershipKeys: 0,
+    retainedBytes: 0
+  }
+
+  constructor(limits: Partial<UsageHistoryScanLimits> = {}) {
+    this.limits = { ...DEFAULT_LIMITS, ...limits }
+  }
+
+  claimFile(path: string): void {
+    this.claim('files', 1)
+    this.claimPath(path)
+  }
+
+  claimDiscoveryEntry(): void {
+    this.claim('discoveryEntries', 1)
+  }
+
+  claimRecord(retainedBytes: number): void {
+    this.claim('records', 1)
+    this.claim('retainedBytes', RECORD_PIPELINE_BYTES + retainedBytes)
+  }
+
+  claimRecords(count: number): void {
+    this.claim('records', count)
+    this.claim('retainedBytes', RECORD_PIPELINE_BYTES * count)
+  }
+
+  claimRetainedBytes(bytes: number): void {
+    this.claim('retainedBytes', bytes)
+  }
+
+  claimPath(path: string): void {
+    this.claim('retainedBytes', FILE_COLLECTION_ENTRY_BYTES + getUsageHistoryRetainedBytes([path]))
+  }
+
+  claimProjection(retainedStringBytes: number): void {
+    this.claim('retainedBytes', PROJECTION_ENTRY_BYTES + retainedStringBytes)
+  }
+
+  claimOwnershipKey(key: string): void {
+    this.claim('ownershipKeys', 1)
+    this.claim(
+      'retainedBytes',
+      OWNERSHIP_COLLECTION_ENTRY_BYTES + getUsageHistoryRetainedBytes([key])
+    )
+  }
+
+  private claim(resource: keyof UsageHistoryScanLimits, amount: number): void {
+    if (!Number.isSafeInteger(amount) || amount < 0) {
+      throw new UsageHistoryScanCapacityError(resource, this.limits[resource])
+    }
+    if (amount > this.limits[resource] - this.used[resource]) {
+      throw new UsageHistoryScanCapacityError(resource, this.limits[resource])
+    }
+    this.used[resource] += amount
+  }
+}
+
+export function getUsageHistoryRetainedBytes(values: readonly (string | null)[]): number {
+  let bytes = 0
+  for (const value of values) {
+    if (value !== null) {
+      bytes += STRING_HEADER_BYTES + value.length * 2
+    }
+  }
+  return bytes
+}

--- a/src/main/usage-projection-state-file.test.ts
+++ b/src/main/usage-projection-state-file.test.ts
@@ -1,0 +1,96 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  readUsageProjectionStateFile,
+  serializeUsageProjectionState,
+  UsageProjectionStateCapacityError,
+  writeUsageProjectionStateFile,
+  writeUsageProjectionStateFileWithRecovery
+} from './usage-projection-state-file'
+
+const tempRoots: string[] = []
+
+afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('usage projection state files', () => {
+  it('accepts exact serialized bytes and rejects the next byte', () => {
+    expect(serializeUsageProjectionState('x'.repeat(30), 32)).toHaveLength(32)
+    expect(() => serializeUsageProjectionState('x'.repeat(31), 32)).toThrow(
+      UsageProjectionStateCapacityError
+    )
+  })
+
+  it('checks the file size before allocating or decoding it', () => {
+    const root = createTempRoot()
+    const path = join(root, 'usage.json')
+    writeFileSync(path, '{"ok":true}')
+    expect(readUsageProjectionStateFile(path, 11)).toBe('{"ok":true}')
+
+    truncateSync(path, 12)
+    expect(() => readUsageProjectionStateFile(path, 11)).toThrow('File too large')
+    expect(readUsageProjectionStateFile(join(root, 'absent.json'), 11)).toBeNull()
+  })
+
+  it('rejects structurally amplified caches before parsing them', () => {
+    const root = createTempRoot()
+    const path = join(root, 'usage.json')
+    const json = '{"rows":[{},{}]}'
+    writeFileSync(path, json)
+
+    expect(() =>
+      readUsageProjectionStateFile(path, Buffer.byteLength(json), {
+        structuralTokens: 7,
+        nestingDepth: 3
+      })
+    ).toThrow('JSON structure')
+  })
+
+  it('writes atomically and preserves ordinary JSON semantics', () => {
+    const root = createTempRoot()
+    const path = join(root, 'nested', 'usage.json')
+    const state = { enabled: true, rows: [{ id: 'one' }, { id: 'two' }] }
+
+    writeUsageProjectionStateFile(path, state, 1024)
+
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(state)
+    expect(readdirSync(join(root, 'nested'))).toEqual(['usage.json'])
+  })
+
+  it('replaces an oversized rebuildable projection with a bounded error state', () => {
+    const root = createTempRoot()
+    const path = join(root, 'usage.json')
+    const recovered = writeUsageProjectionStateFileWithRecovery<{
+      enabled: boolean
+      rows: string | unknown[]
+      error?: string
+    }>(
+      path,
+      { enabled: true, rows: 'x'.repeat(200) },
+      (error) => ({ enabled: true, rows: [], error: error.message }),
+      160
+    )
+
+    expect(recovered).toMatchObject({ enabled: true, rows: [] })
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual(recovered)
+    expect(readdirSync(root)).toEqual(['usage.json'])
+  })
+})
+
+function createTempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-usage-projection-'))
+  tempRoots.push(root)
+  return root
+}

--- a/src/main/usage-projection-state-file.ts
+++ b/src/main/usage-projection-state-file.ts
@@ -1,0 +1,98 @@
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../shared/node-bounded-json-stringify'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
+import {
+  assertJsonTextStructureWithinLimits,
+  type JsonTextStructureLimits
+} from '../shared/json-text-structure-limit'
+
+export const MAX_USAGE_PROJECTION_STATE_FILE_BYTES = 64 * 1024 * 1024
+export const USAGE_PROJECTION_STATE_JSON_LIMITS: JsonTextStructureLimits = {
+  structuralTokens: 1_000_000,
+  nestingDepth: 256
+}
+
+export class UsageProjectionStateCapacityError extends Error {
+  constructor(readonly maxBytes = MAX_USAGE_PROJECTION_STATE_FILE_BYTES) {
+    super(`Usage analytics cache exceeds ${maxBytes} bytes and must be rebuilt.`)
+    this.name = 'UsageProjectionStateCapacityError'
+  }
+}
+
+export function readUsageProjectionStateFile(
+  filePath: string,
+  maxBytes = MAX_USAGE_PROJECTION_STATE_FILE_BYTES,
+  structureLimits: JsonTextStructureLimits = USAGE_PROJECTION_STATE_JSON_LIMITS
+): string | null {
+  try {
+    const serialized = readNodeFileSyncWithinLimit(filePath, maxBytes).buffer.toString('utf8')
+    assertJsonTextStructureWithinLimits(serialized, structureLimits)
+    return serialized
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null
+    }
+    throw error
+  }
+}
+
+export function serializeUsageProjectionState(
+  state: unknown,
+  maxBytes = MAX_USAGE_PROJECTION_STATE_FILE_BYTES
+): string {
+  try {
+    return stringifyJsonWithinByteLimit(state, maxBytes).serialized
+  } catch (error) {
+    if (error instanceof JsonStringifyByteLimitError) {
+      throw new UsageProjectionStateCapacityError(maxBytes)
+    }
+    throw error
+  }
+}
+
+export function writeUsageProjectionStateFile(
+  filePath: string,
+  state: unknown,
+  maxBytes = MAX_USAGE_PROJECTION_STATE_FILE_BYTES
+): void {
+  const payload = serializeUsageProjectionState(state, maxBytes)
+  mkdirSync(dirname(filePath), { recursive: true })
+  const tmpFile = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
+  let renamed = false
+  try {
+    writeFileSync(tmpFile, payload, 'utf8')
+    renameSync(tmpFile, filePath)
+    renamed = true
+  } finally {
+    if (!renamed) {
+      try {
+        unlinkSync(tmpFile)
+      } catch {
+        // The primary write error is more useful than a best-effort cleanup failure.
+      }
+    }
+  }
+}
+
+export function writeUsageProjectionStateFileWithRecovery<T>(
+  filePath: string,
+  state: T,
+  recover: (error: UsageProjectionStateCapacityError) => T,
+  maxBytes = MAX_USAGE_PROJECTION_STATE_FILE_BYTES
+): T {
+  try {
+    writeUsageProjectionStateFile(filePath, state, maxBytes)
+    return state
+  } catch (error) {
+    if (!(error instanceof UsageProjectionStateCapacityError)) {
+      throw error
+    }
+    const recovered = recover(error)
+    writeUsageProjectionStateFile(filePath, recovered, maxBytes)
+    return recovered
+  }
+}

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -202,17 +202,15 @@ describe('attachMainWindowServices', () => {
   it('reloads the app renderer through main and marks expected renderer teardown', async () => {
     const onBeforeRendererReload = vi.fn()
     const mainWindow = createMainWindow()
+    const store = createStore()
+    const runtime = createRuntime()
 
-    attachMainWindowServices(
-      mainWindow as never,
-      createStore(),
-      createRuntime() as never,
-      undefined,
-      undefined,
-      { onBeforeRendererReload }
-    )
+    attachMainWindowServices(mainWindow as never, store, runtime as never, undefined, undefined, {
+      onBeforeRendererReload
+    })
 
     expect(removeHandlerMock).toHaveBeenCalledWith('app:reload')
+    expect(registerRepoHandlersMock).toHaveBeenCalledWith(mainWindow, store, runtime)
     const reloadHandler = handleMock.mock.calls.find(([channel]) => channel === 'app:reload')?.[1]
     expect(reloadHandler).toBeTypeOf('function')
 

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -87,7 +87,7 @@ export function attachMainWindowServices(
   }
 ): void {
   registerAppReloadHandler(mainWindow, options?.onBeforeRendererReload)
-  registerRepoHandlers(mainWindow, store)
+  registerRepoHandlers(mainWindow, store, runtime)
   registerWorktreeHandlers(mainWindow, store, runtime)
   // Why: repo/settings mutations resync watchers through this attached main-window context.
   setWorktreeBaseDirectoryWatcherSyncContext(store, mainWindow)

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -13,6 +13,7 @@ const {
   childStdinEndMock,
   resolveAuthorizedPathMock,
   fsMkdirMock,
+  fsOpendirMock,
   fsReaddirMock,
   fsRmMock,
   fsWriteFileMock,
@@ -46,6 +47,7 @@ const {
   }),
   resolveAuthorizedPathMock: vi.fn(),
   fsMkdirMock: vi.fn(),
+  fsOpendirMock: vi.fn(),
   fsReaddirMock: vi.fn(),
   fsRmMock: vi.fn(),
   fsWriteFileMock: vi.fn(),
@@ -69,7 +71,7 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:fs/promises', () => ({
   mkdir: fsMkdirMock,
-  readdir: fsReaddirMock,
+  opendir: fsOpendirMock,
   rm: fsRmMock,
   open: fsOpenMock,
   stat: fsStatMock,
@@ -194,6 +196,13 @@ describe('registerClipboardHandlers', () => {
     resolveAuthorizedPathMock.mockImplementation(async (path: string) => path)
     fsMkdirMock.mockReset()
     fsMkdirMock.mockResolvedValue(undefined)
+    fsOpendirMock.mockReset()
+    fsOpendirMock.mockImplementation(async () => ({
+      async *[Symbol.asyncIterator]() {
+        yield* await fsReaddirMock()
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    }))
     fsReaddirMock.mockReset()
     fsReaddirMock.mockResolvedValue([])
     fsRmMock.mockReset()

--- a/src/main/window/clipboard-remote-file-cleanup-memory.test.ts
+++ b/src/main/window/clipboard-remote-file-cleanup-memory.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { opendirMock, rmMock, statMock } = vi.hoisted(() => ({
+  opendirMock: vi.fn(),
+  rmMock: vi.fn(),
+  statMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  opendir: opendirMock,
+  rm: rmMock,
+  stat: statMock
+}))
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  requireSshFilesystemProvider: vi.fn()
+}))
+vi.mock('./clipboard-file-copy', () => ({ writeFileToClipboard: vi.fn() }))
+
+import { cleanupExpiredRemoteClipboardFiles } from './clipboard-remote-file-copy'
+
+describe('remote clipboard cleanup memory bounds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rmMock.mockResolvedValue(undefined)
+  })
+
+  it('streams all entries with at most eight cleanups in flight', async () => {
+    const nowMs = 1_760_000_000_000
+    const entries = Array.from({ length: 257 }, (_, index) => ({
+      name: `orca-clipboard-file-expired-${index}`,
+      isDirectory: () => true
+    }))
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield* entries
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    })
+    let active = 0
+    let peak = 0
+    statMock.mockImplementation(async () => {
+      active += 1
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      active -= 1
+      return { mtimeMs: nowMs - 60 * 60 * 1000 - 1 }
+    })
+
+    await cleanupExpiredRemoteClipboardFiles(nowMs)
+
+    expect(rmMock).toHaveBeenCalledTimes(entries.length)
+    expect(peak).toBe(8)
+  })
+})

--- a/src/main/window/clipboard-remote-file-copy.ts
+++ b/src/main/window/clipboard-remote-file-copy.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import type { Dirent } from 'node:fs'
-import { mkdir, readdir, rm, stat } from 'node:fs/promises'
+import { mkdir, opendir, rm, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { app } from 'electron'
@@ -17,6 +16,7 @@ type RemoteClipboardFileDeps = Omit<ClipboardFileDeps, 'resolveFilePath'>
 
 const REMOTE_CLIPBOARD_FILE_TTL_MS = 60 * 60 * 1000
 const REMOTE_CLIPBOARD_FILE_PREFIX = 'orca-clipboard-file-'
+const REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY = 8
 const WINDOWS_RESERVED_LOCAL_BASENAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i
 const LOCAL_FILENAME_REPLACEMENT_CHARS = new Set(['<', '>', ':', '"', '/', '\\', '|', '?', '*'])
 
@@ -81,30 +81,44 @@ export async function writeRemoteFileToClipboard({
 
 export async function cleanupExpiredRemoteClipboardFiles(nowMs = Date.now()): Promise<void> {
   const tempRoot = app.getPath('temp')
-  let entries: Dirent[]
+  let directory: Awaited<ReturnType<typeof opendir>>
   try {
-    entries = await readdir(tempRoot, { withFileTypes: true })
+    directory = await opendir(tempRoot)
   } catch {
     return
   }
 
-  await Promise.all(
-    entries.map(async (entry) => {
+  const pending = new Set<Promise<void>>()
+  try {
+    for await (const entry of directory) {
       if (!entry.isDirectory() || !entry.name.startsWith(REMOTE_CLIPBOARD_FILE_PREFIX)) {
-        return
+        continue
       }
       const tempDir = join(tempRoot, entry.name)
-      try {
-        const tempStats = await stat(tempDir)
-        if (nowMs - tempStats.mtimeMs < REMOTE_CLIPBOARD_FILE_TTL_MS) {
-          return
-        }
-        await rm(tempDir, { recursive: true, force: true })
-      } catch {
-        // Why: stale staged SSH files should not make startup cleanup noisy.
+      const cleanup = cleanupRemoteClipboardDirectory(tempDir, nowMs)
+      pending.add(cleanup)
+      void cleanup.finally(() => pending.delete(cleanup))
+      if (pending.size >= REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY) {
+        await Promise.race(pending)
       }
-    })
-  )
+    }
+  } catch {
+    // A partial best-effort startup sweep is sufficient.
+  } finally {
+    await directory.close().catch(() => undefined)
+  }
+  await Promise.all(pending)
+}
+
+async function cleanupRemoteClipboardDirectory(tempDir: string, nowMs: number): Promise<void> {
+  try {
+    const tempStats = await stat(tempDir)
+    if (nowMs - tempStats.mtimeMs >= REMOTE_CLIPBOARD_FILE_TTL_MS) {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  } catch {
+    // Why: stale staged SSH files should not make startup cleanup noisy.
+  }
 }
 
 function sanitizeLocalClipboardFilename(remoteBasename: string): string {

--- a/src/main/workspace-space-analysis-capacity.test.ts
+++ b/src/main/workspace-space-analysis-capacity.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeProcess from 'node:process'
+import type { Repo } from '../shared/types'
+import { WORKSPACE_SPACE_MAX_SCANNED_ENTRIES } from '../shared/workspace-space-scan-budget'
+import type { Store } from './persistence'
+
+const { lstatMock, opendirMock, listRepoWorktreesMock } = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  opendirMock: vi.fn(),
+  listRepoWorktreesMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  opendir: opendirMock
+}))
+
+vi.mock('node:process', async () => {
+  const actual = await vi.importActual<typeof NodeProcess>('node:process')
+  return { ...actual, platform: 'win32' }
+})
+
+vi.mock('./repo-worktrees', () => ({
+  createFolderWorktree: (repo: Repo) => ({
+    path: repo.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: true
+  }),
+  listRepoWorktrees: listRepoWorktreesMock
+}))
+
+vi.mock('./providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: vi.fn()
+}))
+
+vi.mock('./providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: vi.fn()
+}))
+
+import { analyzeWorkspaceSpace } from './workspace-space-analysis'
+
+function createStore(repo: Repo): Store {
+  return {
+    getRepos: () => [repo],
+    getWorktreeMeta: () => undefined
+  } as unknown as Store
+}
+
+describe('analyzeWorkspaceSpace portable scan capacity', () => {
+  beforeEach(() => {
+    lstatMock.mockReset()
+    opendirMock.mockReset()
+    listRepoWorktreesMock.mockReset()
+  })
+
+  it('surfaces an over-cap Windows directory as an unavailable row', async () => {
+    const repo: Repo = {
+      id: 'repo-1',
+      path: 'C:\\repo',
+      displayName: 'orca',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    listRepoWorktreesMock.mockResolvedValue([
+      {
+        path: repo.path,
+        head: 'a',
+        branch: 'refs/heads/main',
+        isBare: false,
+        isMainWorktree: true
+      }
+    ])
+    lstatMock.mockResolvedValue({
+      size: 1,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        const entry = { name: 'repeated-entry' }
+        for (let index = 0; index <= WORKSPACE_SPACE_MAX_SCANNED_ENTRIES; index += 1) {
+          yield entry
+        }
+      }
+    })
+
+    const result = await analyzeWorkspaceSpace(createStore(repo))
+
+    expect(result).toMatchObject({
+      scannedWorktreeCount: 0,
+      unavailableWorktreeCount: 1,
+      worktrees: [
+        {
+          status: 'error',
+          error: expect.stringContaining('too large to scan safely'),
+          sizeBytes: 0
+        }
+      ]
+    })
+    expect(lstatMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -1,24 +1,33 @@
 /* eslint-disable max-lines -- Why: this module keeps local and SSH directory-walk
    semantics paired so reclaimable-byte, symlink, and partial-failure behavior cannot drift. */
-import { lstat, readdir } from 'node:fs/promises'
+import { lstat, opendir } from 'node:fs/promises'
 import { execFile } from 'node:child_process'
 import { posix, win32 } from 'node:path'
 import { platform } from 'node:process'
 import type { Dirent } from 'node:fs'
 import type { Store } from './persistence'
 import { isFolderRepo } from '../shared/repo-kind'
-import type { GitWorktreeInfo, Repo, Worktree } from '../shared/types'
+import type { DirEntry, GitWorktreeInfo, Repo, Worktree } from '../shared/types'
 import type {
   WorkspaceSpaceAnalysis,
   WorkspaceSpaceDirectoryScanResult,
   WorkspaceSpaceItem,
-  WorkspaceSpaceItemKind,
   WorkspaceSpaceRepoSummary,
   WorkspaceSpaceScanProgress,
   WorkspaceSpaceScanStatus,
   WorkspaceSpaceWorktree
 } from '../shared/workspace-space-types'
 import { compactWorkspaceSpaceItems } from '../shared/workspace-space-compaction'
+import { mapWithConcurrency } from '../shared/map-with-concurrency'
+import {
+  scanWorkspaceSpaceEntryTree,
+  type WorkspaceSpaceEntryScan
+} from '../shared/workspace-space-entry-traversal'
+import {
+  collectWorkspaceSpaceDirectoryEntries,
+  createWorkspaceSpaceScanBudget,
+  WorkspaceSpaceScanCapacityError
+} from '../shared/workspace-space-scan-budget'
 import type { IFilesystemProvider } from './providers/types'
 import { getSshFilesystemProvider } from './providers/ssh-filesystem-dispatch'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
@@ -31,16 +40,7 @@ const REMOTE_FS_CONCURRENCY = 10
 const DU_TIMEOUT_MS = 120_000
 const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 
-type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
-
-type ScanStats = {
-  name: string
-  path: string
-  kind: WorkspaceSpaceItemKind
-  sizeBytes: number
-  skippedEntryCount: number
-  children?: ScanStats[]
-}
+type ScanStats = WorkspaceSpaceEntryScan
 
 type WorktreeListResult =
   | { ok: true; worktrees: GitWorktreeInfo[] }
@@ -84,67 +84,6 @@ function isRelayMethodNotFoundError(error: unknown): boolean {
     return false
   }
   return (error as { code?: unknown }).code === -32601
-}
-
-function createAsyncLimiter(maxConcurrent: number, signal?: AbortSignal): AsyncLimiter {
-  let active = 0
-  const queue: { resolve: () => void; reject: (error: Error) => void }[] = []
-
-  const acquire = async (): Promise<void> => {
-    throwIfAborted(signal)
-    if (active < maxConcurrent) {
-      active += 1
-      return
-    }
-    await new Promise<void>((resolve, reject) => {
-      let onAbort: (() => void) | null = null
-      const waiter = {
-        resolve: () => {
-          if (onAbort) {
-            signal?.removeEventListener('abort', onAbort)
-          }
-          resolve()
-        },
-        reject
-      }
-      onAbort = () => {
-        const index = queue.indexOf(waiter)
-        if (index !== -1) {
-          queue.splice(index, 1)
-        }
-        reject(new WorkspaceSpaceScanCancelledError())
-      }
-      queue.push(waiter)
-      if (signal) {
-        signal.addEventListener('abort', onAbort, { once: true })
-        if (signal.aborted) {
-          onAbort()
-        }
-      }
-    })
-    throwIfAborted(signal)
-    active += 1
-  }
-
-  return async <T>(task: () => Promise<T>): Promise<T> => {
-    await acquire()
-    try {
-      return await task()
-    } finally {
-      active -= 1
-      const next = queue.shift()
-      next?.resolve()
-    }
-  }
-}
-
-async function mapLimit<T, R>(
-  items: readonly T[],
-  maxConcurrent: number,
-  mapper: (item: T) => Promise<R>
-): Promise<R[]> {
-  const limit = createAsyncLimiter(maxConcurrent)
-  return Promise.all(items.map((item) => limit(() => mapper(item))))
 }
 
 function looksLikeWindowsPath(pathValue: string): boolean {
@@ -355,195 +294,73 @@ function createScannedWorktreeRow(
 async function scanLocalEntry(
   entryPath: string,
   name: string,
-  limit: AsyncLimiter,
   signal?: AbortSignal
 ): Promise<ScanStats> {
-  throwIfAborted(signal)
-  const stats = await limit(() => lstat(entryPath))
-  throwIfAborted(signal)
-
-  if (stats.isSymbolicLink()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      // Why: symlink targets may be shared outside the worktree. Counting the
-      // link itself reflects what deleting this worktree can actually reclaim.
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  if (!stats.isDirectory()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'file',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  let entries: Dirent[]
-  try {
-    entries = await limit(() => readdir(entryPath, { withFileTypes: true }))
-  } catch {
-    return {
-      name,
-      path: entryPath,
-      kind: 'directory',
-      sizeBytes: stats.size,
-      skippedEntryCount: 1
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanLocalEntry(
-          joinFilesystemPath(entryPath, entry.name),
-          entry.name,
-          limit,
-          signal
-        )
-      } catch (error) {
-        if (error instanceof WorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
+  return scanWorkspaceSpaceEntryTree<Dirent>({
+    rootPath: entryPath,
+    rootName: name,
+    concurrency: LOCAL_FS_CONCURRENCY,
+    signal,
+    entryName: (entry) => entry.name,
+    joinPath: joinFilesystemPath,
+    classifyEntry: async (path) => {
+      const stats = await lstat(path)
+      throwIfAborted(signal)
+      if (stats.isSymbolicLink()) {
+        return { kind: 'symlink', sizeBytes: stats.size }
       }
-    })
-  )
-
-  let sizeBytes = stats.size
-  let skippedEntryCount = 0
-  for (const child of childStats) {
-    if (!child) {
-      skippedEntryCount += 1
-      continue
-    }
-    sizeBytes += child.sizeBytes
-    skippedEntryCount += child.skippedEntryCount
-  }
-
-  return {
-    name,
-    path: entryPath,
-    kind: 'directory',
-    sizeBytes,
-    skippedEntryCount,
-    children: childStats.filter((child): child is ScanStats => child !== null)
-  }
+      return stats.isDirectory()
+        ? { kind: 'directory', sizeBytes: stats.size }
+        : { kind: 'file', sizeBytes: stats.size }
+    },
+    readDirectory: (path) => opendir(path),
+    checkCancelled: () => throwIfAborted(signal),
+    createCancellationError: () => new WorkspaceSpaceScanCancelledError(),
+    isCancellationError: (error) => error instanceof WorkspaceSpaceScanCancelledError
+  })
 }
 
 async function scanRemoteEntry(
   entryPath: string,
   name: string,
   provider: IFilesystemProvider,
-  limit: AsyncLimiter,
-  signal?: AbortSignal,
-  knownSymlink = false
+  signal?: AbortSignal
 ): Promise<ScanStats> {
-  throwIfAborted(signal)
-  if (knownSymlink) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      sizeBytes: 0,
-      skippedEntryCount: 0
-    }
-  }
-
-  const stats = await limit(() => provider.stat(entryPath))
-  throwIfAborted(signal)
-  if (stats.type === 'symlink') {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  if (stats.type !== 'directory') {
-    return {
-      name,
-      path: entryPath,
-      kind: 'file',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  let entries
-  try {
-    entries = await limit(() => provider.readDir(entryPath))
-    throwIfAborted(signal)
-  } catch (error) {
-    if (error instanceof WorkspaceSpaceScanCancelledError) {
-      throw error
-    }
-    return {
-      name,
-      path: entryPath,
-      kind: 'directory',
-      sizeBytes: stats.size,
-      skippedEntryCount: 1
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanRemoteEntry(
-          joinFilesystemPath(entryPath, entry.name),
-          entry.name,
-          provider,
-          limit,
-          signal,
-          entry.isSymlink
-        )
-      } catch (error) {
-        if (error instanceof WorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
+  return scanWorkspaceSpaceEntryTree<DirEntry>({
+    rootPath: entryPath,
+    rootName: name,
+    concurrency: REMOTE_FS_CONCURRENCY,
+    signal,
+    entryName: (entry) => entry.name,
+    joinPath: joinFilesystemPath,
+    classifyEntry: async (path, sourceEntry) => {
+      if (sourceEntry?.isSymlink) {
+        return { kind: 'symlink', sizeBytes: 0 }
       }
-    })
-  )
-
-  let sizeBytes = stats.size
-  let skippedEntryCount = 0
-  for (const child of childStats) {
-    if (!child) {
-      skippedEntryCount += 1
-      continue
-    }
-    sizeBytes += child.sizeBytes
-    skippedEntryCount += child.skippedEntryCount
-  }
-
-  return {
-    name,
-    path: entryPath,
-    kind: 'directory',
-    sizeBytes,
-    skippedEntryCount,
-    children: childStats.filter((child): child is ScanStats => child !== null)
-  }
+      const stats = await provider.stat(path)
+      throwIfAborted(signal)
+      if (stats.type === 'symlink') {
+        return { kind: 'symlink', sizeBytes: stats.size }
+      }
+      return stats.type === 'directory'
+        ? { kind: 'directory', sizeBytes: stats.size }
+        : { kind: 'file', sizeBytes: stats.size }
+    },
+    readDirectory: (path) => provider.readDir(path),
+    checkCancelled: () => throwIfAborted(signal),
+    createCancellationError: () => new WorkspaceSpaceScanCancelledError(),
+    isCancellationError: (error) => error instanceof WorkspaceSpaceScanCancelledError
+  })
 }
 
 async function scanLocalTopLevelEntry(
   entryPath: string,
   name: string,
   duSizes: Map<string, number>,
-  limit: AsyncLimiter,
   signal?: AbortSignal
 ): Promise<ScanStats> {
   throwIfAborted(signal)
-  const stats = await limit(() => lstat(entryPath))
+  const stats = await lstat(entryPath)
   throwIfAborted(signal)
 
   if (stats.isSymbolicLink()) {
@@ -584,13 +401,7 @@ async function scanLocalWorktreeWithDu(
   throwIfAborted(signal)
   const rootStats = await lstat(worktree.path)
   if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) {
-    const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY, signal)
-    const root = await scanLocalEntry(
-      worktree.path,
-      basenameFilesystemPath(worktree.path),
-      limit,
-      signal
-    )
+    const root = await scanLocalEntry(worktree.path, basenameFilesystemPath(worktree.path), signal)
     const compact = compactWorkspaceSpaceItems((root.children ?? []).map(toWorkspaceSpaceItem))
     return {
       ...createBaseWorktreeRow(repo, worktree, scannedAt),
@@ -604,19 +415,27 @@ async function scanLocalWorktreeWithDu(
   }
 
   const [entries, duSizes] = await Promise.all([
-    readdir(worktree.path, { withFileTypes: true }),
+    opendir(worktree.path).then((directory) =>
+      collectWorkspaceSpaceDirectoryEntries(
+        directory,
+        worktree.path,
+        (entry) => entry.name,
+        createWorkspaceSpaceScanBudget(),
+        () => throwIfAborted(signal)
+      )
+    ),
     readLocalDuDepthOne(worktree.path, signal)
   ])
   throwIfAborted(signal)
-  const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY, signal)
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
+  const childStats = await mapWithConcurrency(
+    entries,
+    LOCAL_FS_CONCURRENCY,
+    async (entry): Promise<ScanStats | null> => {
       try {
         return await scanLocalTopLevelEntry(
           joinFilesystemPath(worktree.path, entry.name),
           entry.name,
           duSizes,
-          limit,
           signal
         )
       } catch (error) {
@@ -625,7 +444,7 @@ async function scanLocalWorktreeWithDu(
         }
         return null
       }
-    })
+    }
   )
   const children = childStats.filter((child): child is ScanStats => child !== null)
   const skippedEntryCount = childStats.length - children.length
@@ -652,13 +471,7 @@ async function scanLocalWorktreeWithNode(
   signal?: AbortSignal
 ): Promise<WorkspaceSpaceWorktree> {
   try {
-    const limit = createAsyncLimiter(LOCAL_FS_CONCURRENCY, signal)
-    const root = await scanLocalEntry(
-      worktree.path,
-      basenameFilesystemPath(worktree.path),
-      limit,
-      signal
-    )
+    const root = await scanLocalEntry(worktree.path, basenameFilesystemPath(worktree.path), signal)
     const compact = compactWorkspaceSpaceItems((root.children ?? []).map(toWorkspaceSpaceItem))
     return {
       ...createBaseWorktreeRow(repo, worktree, scannedAt),
@@ -701,6 +514,16 @@ async function scanLocalWorktree(
       if (error instanceof WorkspaceSpaceScanCancelledError) {
         throw error
       }
+      if (error instanceof WorkspaceSpaceScanCapacityError) {
+        const classified = classifyError(error)
+        return createUnavailableWorktreeRow(
+          repo,
+          worktree,
+          scannedAt,
+          classified.status,
+          classified.message
+        )
+      }
       // Fall through to the portable scanner so unsupported du variants or
       // permission edge cases still produce partial rows instead of failing.
     }
@@ -733,12 +556,10 @@ async function scanRemoteWorktree(
       }
     }
 
-    const limit = createAsyncLimiter(REMOTE_FS_CONCURRENCY, signal)
     const root = await scanRemoteEntry(
       worktree.path,
       basenameFilesystemPath(worktree.path),
       provider,
-      limit,
       signal
     )
     const compact = compactWorkspaceSpaceItems((root.children ?? []).map(toWorkspaceSpaceItem))
@@ -862,7 +683,7 @@ async function scanRepo(
     options.onProgress
   )
   const remoteProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : undefined
-  const rows = await mapLimit(worktrees, WORKTREE_SCAN_CONCURRENCY, async (worktree) => {
+  const rows = await mapWithConcurrency(worktrees, WORKTREE_SCAN_CONCURRENCY, async (worktree) => {
     throwIfAborted(options.signal)
     reportProgress(
       progress,
@@ -937,7 +758,7 @@ export async function analyzeWorkspaceSpace(
     currentWorktreeDisplayName: null
   }
   options.onProgress?.({ ...progress })
-  const repoResults = await mapLimit(reposToScan, 2, (repo) =>
+  const repoResults = await mapWithConcurrency(reposToScan, 2, (repo) =>
     scanRepo(repo, scannedAt, store, progress, options)
   )
   throwIfAborted(options.signal)

--- a/src/main/worktree-orphan-gitdir-proof.ts
+++ b/src/main/worktree-orphan-gitdir-proof.ts
@@ -1,5 +1,7 @@
 import { type posix, win32 } from 'node:path'
 
+export const MAX_WORKTREE_GIT_POINTER_BYTES = 64 * 1024
+
 type PathOps = typeof posix
 export type StatPath = (path: string) => Promise<unknown>
 export type ReadPath = (path: string) => Promise<unknown>
@@ -41,13 +43,15 @@ function isGitFileStat(stat: unknown): boolean {
 
 function readFileResultToText(result: unknown): string | null {
   if (typeof result === 'string') {
-    return result
+    return Buffer.byteLength(result, 'utf8') <= MAX_WORKTREE_GIT_POINTER_BYTES ? result : null
   }
   if (Buffer.isBuffer(result)) {
-    return result.toString('utf8')
+    return result.byteLength <= MAX_WORKTREE_GIT_POINTER_BYTES ? result.toString('utf8') : null
   }
   if (result instanceof Uint8Array) {
-    return Buffer.from(result).toString('utf8')
+    return result.byteLength <= MAX_WORKTREE_GIT_POINTER_BYTES
+      ? Buffer.from(result).toString('utf8')
+      : null
   }
   if (!result || typeof result !== 'object') {
     return null
@@ -56,7 +60,9 @@ function readFileResultToText(result: unknown): string | null {
   if (remoteRead.isBinary === true || typeof remoteRead.content !== 'string') {
     return null
   }
-  return remoteRead.content
+  return Buffer.byteLength(remoteRead.content, 'utf8') <= MAX_WORKTREE_GIT_POINTER_BYTES
+    ? remoteRead.content
+    : null
 }
 
 function resolveGitdirPath(gitdirPath: string, basePath: string, pathOps: PathOps): string {

--- a/src/main/worktree-removal-safety.test.ts
+++ b/src/main/worktree-removal-safety.test.ts
@@ -190,6 +190,22 @@ describe('canSafelyRemoveOrphanedWorktreeDirectory', () => {
     ).resolves.toBe(false)
   })
 
+  it('rejects oversized git pointer metadata from filesystem providers', async () => {
+    await expect(
+      canSafelyRemoveOrphanedWorktreeDirectory(
+        '/workspaces/orphan',
+        '/repo',
+        makeStatPath(['/workspaces/orphan/.git'], ['/repo/.git']),
+        makeReadPath([
+          [
+            '/workspaces/orphan/.git',
+            `gitdir: /repo/.git/worktrees/orphan\n${'x'.repeat(64 * 1024)}`
+          ]
+        ])
+      )
+    ).resolves.toBe(false)
+  })
+
   it('rejects a copied .git file when the admin entry points at another candidate path', async () => {
     await expect(
       canSafelyRemoveOrphanedWorktreeDirectory(

--- a/src/main/worktree-removal-safety.ts
+++ b/src/main/worktree-removal-safety.ts
@@ -1,4 +1,4 @@
-import { lstat, readFile } from 'node:fs/promises'
+import { lstat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { posix, win32 } from 'node:path'
 import { isWindowsAbsolutePathLike } from '../shared/cross-platform-path'
@@ -6,9 +6,11 @@ import type { GitWorktreeInfo, Repo, WorktreeMeta } from '../shared/types'
 import { areWorktreePathsEqual } from './ipc/worktree-logic'
 import {
   gitFileProvesOrphanedWorktreeDirectory,
+  MAX_WORKTREE_GIT_POINTER_BYTES,
   type ReadPath,
   type StatPath
 } from './worktree-orphan-gitdir-proof'
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
 
 type PathOps = typeof posix
 
@@ -151,7 +153,8 @@ export async function canSafelyRemoveOrphanedWorktreeDirectory(
   worktreePath: string,
   repoPath: string,
   statPath: StatPath = lstat,
-  readPath: ReadPath = (path) => readFile(path, 'utf8')
+  readPath: ReadPath = async (path) =>
+    (await readNodeFileWithinLimit(path, MAX_WORKTREE_GIT_POINTER_BYTES)).buffer.toString('utf8')
 ): Promise<boolean> {
   if (isDangerousWorktreeRemovalPath(worktreePath, repoPath)) {
     return false

--- a/src/main/worktree-root-preparation.test.ts
+++ b/src/main/worktree-root-preparation.test.ts
@@ -14,7 +14,11 @@ vi.mock('./ipc/filesystem-auth', () => ({
   authorizeExternalPath: authorizeExternalPathMock
 }))
 
-import { prepareLocalWorktreeRootForRepo } from './worktree-root-preparation'
+import {
+  LOCAL_WORKTREE_ROOT_PREPARATION_CONCURRENCY,
+  prepareLocalWorktreeRootForRepo,
+  prepareLocalWorktreeRootsForRepos
+} from './worktree-root-preparation'
 
 const repo: Repo = {
   id: 'repo-1',
@@ -75,5 +79,29 @@ describe('prepareLocalWorktreeRootForRepo', () => {
 
     await expect(prepareLocalWorktreeRootForRepo(store as never, repo)).resolves.toBeUndefined()
     expect(authorizeExternalPathMock).not.toHaveBeenCalled()
+  })
+
+  it('prepares every repo with a fixed-size worker pool', async () => {
+    const repos = Array.from({ length: 10_000 }, (_, index) => ({
+      ...repo,
+      id: `repo-${index}`,
+      path: `/projects/repo-${index}`
+    }))
+    let inFlight = 0
+    let peak = 0
+    mkdirMock.mockImplementation(async () => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await Promise.resolve()
+      inFlight -= 1
+    })
+
+    await prepareLocalWorktreeRootsForRepos({
+      ...store,
+      getRepos: () => repos
+    } as never)
+
+    expect(mkdirMock).toHaveBeenCalledTimes(repos.length)
+    expect(peak).toBe(LOCAL_WORKTREE_ROOT_PREPARATION_CONCURRENCY)
   })
 })

--- a/src/main/worktree-root-preparation.ts
+++ b/src/main/worktree-root-preparation.ts
@@ -1,6 +1,7 @@
 import { mkdir } from 'node:fs/promises'
 import type { GlobalSettings, Repo } from '../shared/types'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
+import { forEachWithConcurrency } from '../shared/map-with-concurrency'
 import { isFolderRepo } from '../shared/repo-kind'
 import { computeWorkspaceRoot, getWorktreePathSettings } from './ipc/worktree-logic'
 
@@ -9,6 +10,8 @@ type WorktreeRootPreparationStore = {
   getSettings: () => WorktreeRootPreparationSettings
   getRepos: () => Repo[]
 }
+
+export const LOCAL_WORKTREE_ROOT_PREPARATION_CONCURRENCY = 8
 
 export async function prepareLocalWorktreeRootForRepo(
   store: Pick<WorktreeRootPreparationStore, 'getSettings'>,
@@ -31,5 +34,9 @@ export async function prepareLocalWorktreeRootForRepo(
 export async function prepareLocalWorktreeRootsForRepos(
   store: WorktreeRootPreparationStore
 ): Promise<void> {
-  await Promise.all(store.getRepos().map((repo) => prepareLocalWorktreeRootForRepo(store, repo)))
+  await forEachWithConcurrency(
+    store.getRepos(),
+    LOCAL_WORKTREE_ROOT_PREPARATION_CONCURRENCY,
+    (repo) => prepareLocalWorktreeRootForRepo(store, repo)
+  )
 }


### PR DESCRIPTION
## OOM hardening slice 09/29 — bound git/worktree/persistence/repo/usage state

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **09/29** (base: `oom/08-b-mobile-rest`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
This slice re-introduces ~40 independent count/byte/depth/concurrency ceilings across git worktree persistence, terminal-history GC, crash reporting, cloud-profile session stores, usage-history scanning, and process/persistence state files. The behaviorally significant change is a new 10MB default output cap on ALL local git commands (previously unbounded unless a caller opted in); everything else sits far above ordinary use.

### ELI5
Imagine dozens of buckets in the app that could previously fill up forever and eventually crash it by running out of memory. This change puts a lid on each bucket at a size much bigger than anyone normally uses. The one lid you can actually bump into during normal work is on git: if a single git command spits out more than 10MB of text (a giant diff or log), it now stops with an error instead of risking a crash.

### Proof of OOM fix
- git/runner.ts: DEFAULT_GIT_MAX_BUFFER = 10MB now applied to every git exec (was only enforced when a caller passed maxBuffer); tested in runner-command-exec.test.ts
- persistence.ts: state file > ORCA_PERSISTED_STATE_MAX_BYTES (64MB) -> load defaults + writesFrozen=true; persistence-state-bounds.test.ts
- attribution/terminal-attribution.ts: ATTRIBUTION_COMMIT_MESSAGE_MAX_BYTES=1MB, ATTRIBUTION_COMMAND_OUTPUT_MAX_BYTES=1MB, WRITTEN_ROOT_MAX_ENTRIES=64 (evicted via while size>max), SHIM_VERSION_MAX_BYTES=1KB; terminal-attribution-bounds/retention.test.ts
- git/status.ts: MAX_SUBMODULE_PATHS_PER_REPO=10_000, MAX_SUBMODULE_PATH_CODE_UNITS=64KB, MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS=16MB, MAX_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES=64KB, MAX_GIT_POINTER_FILE_BYTES=64KB; status-submodule/upstream/pointer-bounds tests
- worktree-orphan-gitdir-proof.ts / local-worktree-filesystem.ts / worktree-removal-safety.ts: MAX_WORKTREE_GIT_POINTER_BYTES=64KB, oversized .git pointer -> null
- terminal-history-gc.ts: MAX_DISCOVERY_ENTRIES=100_000, MAX_WSL_DISTROS=256, MAX_FILES_PER_WORKTREE=64, META_MAX_BYTES=64KB; capacity error is caught, remaining scanned next run
- crash-report-store.ts: MAX_CRASH_REPORT_FILE_BYTES=4MB, JSON_STRUCTURAL_TOKENS=1M, JSON_NESTING_DEPTH=128; crash-report-store.test.ts
- orca-profiles: MAX_ORCA_CLOUD_MEMORY_SESSIONS=128, MAX_ORCA_CLOUD_MEMORY_SESSION_BYTES=16MB, MAX_CLOUD_SESSION_TOMBSTONES=512 (FIFO shift()), DEV_ORG_ROSTER_MAX_ENTRIES=64, DEV_ORG_PENDING_INVITE_MAX_ENTRIES=256, MAX_ORCA_PROFILE_INDEX_FILE_BYTES=1MB
- usage-history: MAX_FILES=200_000, MAX_DISCOVERY_ENTRIES=1M, MAX_RECORDS=100_000, MAX_OWNERSHIP_KEYS=100_000, MAX_RETAINED_BYTES=256MB, MAX_JSONL_LINE_BYTES=4MB, MAX_USAGE_PROJECTION_STATE_FILE_BYTES=64MB
- git/git-capability-state.ts: LOCAL_GIT_CAPABILITY_HOST_MAX_ENTRIES=64 (LRU-ish while size>max), HOST_KEY_MAX_BYTES=4KB
- repo enrichment: REPO_IDENTITY_NEGATIVE_CACHE_MAX_ENTRIES=512, REPO_GIT_USERNAME_ATTEMPT_MAX_ENTRIES=512 (both evict via while size>max)
- diagnostics/main-thread-churn-probe.ts: SUBPROCESS_SPAWN_STATS_MAX_ENTRIES=128 (127 real keys + 1 overflow bucket), diagnostics-gated only
- startup markers: X_DISPLAY_LOCK_MAX_BYTES=64, MAX_GPU_FALLBACK_MARKER_FILE_BYTES=8KB, MAX_SHELL_PATH_STDOUT_BYTES=1MB, WINDOWS_ACL_GRANT_MARKER_MAX_BYTES=8KB
- misc file readers: MAX_GIT_MARKER_FILE_BYTES=64KB, GENERATED_NODE_MANAGED_FILE_MAX_BYTES=64KB, MAX_ACTIVE_VIEW_PREFERENCE_FILE_BYTES=4KB, MAX_REPO_ICON_SOURCE_BYTES=256KB, MAX_BUNDLE_SOURCE_FILE_BYTES=50MB, local-downloaded-folder-promotion depth/byte budget

### Regressions
**Normal-path (ordinary use, below the new limits):** **none** — behavior is unchanged below the ceilings.

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- persistence.ts freezes ALL state writes and loads defaults only when the on-disk state file exceeds 64MB (ordinary state is KB-few MB) — extreme/corruption only
- Worktree .git pointer treated as invalid (null) only when the pointer file exceeds 64KB; real pointers are a single 'gitdir:' line
- Submodule enumeration stops at 10,000 submodules / 64KB per path / 16MB cache — normal repos have a handful
- terminal-history GC throws a caught capacity error at 100k discovery entries / 256 WSL distros and simply resumes next run; no data loss
- Attribution wrappers refuse commit-message / gh-capture files over 1MB (exit code 74) — normal commit messages are tiny
- Cloud memory session eviction at 128 sessions / 16MB and tombstone FIFO at 512 — far above interactive use
- usage-history scan caps (200k files, 1M dir entries, 256MB retained) only reached by pathological ~/.orca trees
- Diagnostics spawn-stats map caps at 128 keys and only when main-thread diagnostics are explicitly enabled
- git/runner.ts now applies a 10MB DEFAULT_GIT_MAX_BUFFER to every local git command that does not pass its own maxBuffer. Previously the cap was only enforced when a caller explicitly set maxBuffer (`if (options.maxBuffer && ...)`), so unbounded output was allowed. Git commands whose combined stdout/stderr exceed 10MB now fail with 'stdout exceeded maxBuffer.' instead of returning the output. This is reachable on large monorepos (huge `git diff`, long `git log`, `git status` with very many untracked files). _(only when: Any git operation not passing its own maxBuffer that produces >10MB of output on a large repo (native, WSL, or SSH). Intended anti-OOM cap and kept in sync with relay MAX_GIT_BUFFER, but a human should confirm 10MB is comfortably above real large-repo command output.)_
- persistence.ts: when the state file exceeds 64MB the app loads default state AND sets writesFrozen=true, so the session silently stops persisting (windows/tabs/repos not saved) to avoid clobbering recoverable bytes. Correct by design, but the user gets a defaults-looking session with no persistence until the oversized file is resolved. _(only when: Corrupted or pathologically large (>64MB) persisted state file on startup; not reachable in ordinary use.)_
- spawnCommandCapture now applies the 10MB DEFAULT_GIT_MAX_BUFFER when no explicit maxBuffer is passed (BASE used `if (options.maxBuffer && ...)`, leaving this path unbounded). CORRECTION to the prior reviewer: this is NOT a change to 'every local git command'. The mainline execFileCapture path ALREADY applied `options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER` (10MB) in BASE (runner.ts:442, constant at :253). spawnCommandCapture is reached ONLY for Windows batch-script shims (isWindowsBatchScript at runner.ts:879 and the Windows .cmd retry at :896) — e.g. gh.cmd/glab.cmd. So the newly-capped surface is Windows-only + batch-shim-only. On macOS/Linux and the normal execFile git path, output was already 10MB-capped in BASE; no change. _(only when: On Windows only, a git/gh/glab command that resolves to a batch-script shim, does not pass its own maxBuffer, and emits >10MB combined stdout/stderr. Now fails with 'stdout/stderr exceeded maxBuffer' instead of returning unbounded output.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.
- Touches 1 file(s) also changed on `main` since the revert; git auto-merges them (no conflict): `workspace-space-analysis.ts`.

### Adversarial review
- 2 skeptic lens(es). Sign-off: **FLAGGED — see above**. Residual risk: **low**.
- HEADLINE CLAIM REFUTED (in the direction of LESS risk, so signoff stands). The prior reviewer's medium-severity "new 10MB default cap on ALL local git commands" is OVERSTATED and largely inaccurate relative to THIS PR's diff.

Evidence (git -C ... diff aab112933e 6eb70d8370 -- src/main/git/runner.ts):
- DEFAULT_GIT_MAX_BUFFER (10*1024*1024) is NOT introduced by this slice. It already exists in BASE (post-revert) at src/main/git/runner.ts:253, and BASE already applies it to the two PRIMARY paths:
  * execFileCapture at line 442: `maxBuffer: options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER` (present in BASE, UNCHANGED by the diff). This is the path used by repo-scoped runGit (huge `git diff`/`git log`/`git status`).
  * gitStreamStdout at line 957: `const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER` (present in BASE; the diff only swaps the accumulation mechanism to GrowingByteBuffer, not the cap).
- The ONLY place this diff newly applies the default is spawnCommandCapture (line 498: `const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER`), replacing BASE's `if (options.maxBuffer && stdoutBytes > options.maxBuffer)`. spawnCommandCapture is reached ONLY from commandExecFileAsync for (a) Windows batch scripts (isWindowsBatchScript) and (b) the Windows command-shim retry (shouldRetryWindowsCommandShim). Normal git.exe invocations and the reviewer's cited "large diff/log/status" cases go through execFileCapture, which was ALREADY capped in BASE. So the primary and streaming git paths are behaviorally UNCHANGED by this PR; no new normal-path git-output regression.

Correctness of the GrowingByteBuffer swap: bounds check `stdout.byteLength + chunk.byteLength > maxBuffer` rejects the overflowing chunk before appending — equivalent boundary to BASE (no off-by-one). On overflow it calls killSpawnedCommandTree(child) then finish() (same child-cleanup semantics as BASE). finish() clears both GrowingByteBuffers, releasing memory. Decoding moved from per-chunk `chunk.toString(encoding)` (BASE, which could corrupt multibyte UTF-8 split across chunks) to a single decode-at-end via toString() — this is a CORRECTNESS IMPROVEMENT, not a loss. spawnCommandCapture only returns strings, so the 'buffer' encoding concern does not apply.

Other caps spot-checked and confirmed far above ordinary use (overload/corruption-only):
- persistence.ts writesFrozen on oversized state file (ordinary state is KB-few MB; MAX_AGENT_STATE_FILE_BYTES=4MB is the adjacent agent-state cap).
- status.ts: git pointer 64KB (real pointers are one `gitdir:` line), submodules 10,000 / 64KB per path / 16MB cache.
- terminal-history-gc.ts: 100,000 discovery entries / 256 WSL distros / 64KB meta; MAX_FILES_PER_WORKTREE=64 is a per-run GC throughput bound (cleanup resumes next run, no data loss/user impact).
- attribution: commit-message 1MB, gh-capture output 1MB, exit 74 — normal commit messages/captures are tiny.
- filesystem-provider-bounded-text.ts is a new helper whose limits are PARAMETERIZED (caller-supplied maxBytes/maxCodeUnits); no hardcoded low default in this slice (caller wiring lives in another slice).

Residual: the Windows batch-script / command-shim path now caps arbitrary command output at 10MB where BASE was unbounded — theoretically a >10MB batch/shim command would now fail with 'stdout exceeded maxBuffer'. This is a narrow, non-git, Windows-only path and matches the anti-OOM intent kept in sync with relay MAX_GIT_BUFFER; not a normal-path regression. Signoff=true.

### Files
109 files changed (+4987 / −923).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
