### PR TITLE
oom(11/29): bound provider rate-limit/usage/account scans

### DIFF
--- a/src/main/amp/hook-service.test.ts
+++ b/src/main/amp/hook-service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { GENERATED_NODE_MANAGED_FILE_MAX_BYTES } from '../generated-node-bounded-file-reader'
 
 const { homedirMock } = vi.hoisted(() => ({
   homedirMock: vi.fn<() => string>()
@@ -59,6 +60,11 @@ describe('AmpHookService', () => {
     expect(source).not.toContain('postQueue = postQueue.then')
     expect(source).toContain('process.env.ORCA_PANE_KEY')
     expect(source).toContain('process.env.ORCA_AGENT_HOOK_ENDPOINT')
+    expect(source).toContain(
+      `function readOrcaManagedFileWithinLimit(fs: any, path: string, maxBytes = ${GENERATED_NODE_MANAGED_FILE_MAX_BYTES})`
+    )
+    expect(source).toContain('readOrcaManagedFileWithinLimit(fs, endpointPath)')
+    expect(source).not.toContain('readFileSync')
   })
 
   it('does not overwrite an existing user-authored Amp plugin file', () => {

--- a/src/main/amp/hook-service.ts
+++ b/src/main/amp/hook-service.ts
@@ -3,12 +3,18 @@
    emitted plugin bytes drift from the installer checks that protect user
    plugin files from being overwritten. */
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 
 import type { AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileSyncWithinLimit
+} from '../../shared/node-bounded-file-reader'
+import { getGeneratedNodeBoundedFileReaderSourceLines } from '../generated-node-bounded-file-reader'
+import { AGENT_HOOK_PLUGIN_MAX_BYTES } from '../agent-hooks/agent-hook-file-limits'
 import {
   readTextFileRemote,
   writeTextFileRemoteAtomic
@@ -53,7 +59,10 @@ function readLocalPluginState(pluginPath: string): PluginFileState {
     return { kind: 'absent' }
   }
   try {
-    const content = readFileSync(pluginPath, 'utf-8')
+    const content = readNodeFileSyncWithinLimit(
+      pluginPath,
+      AGENT_HOOK_PLUGIN_MAX_BYTES
+    ).buffer.toString('utf8')
     if (!isManagedPlugin(content)) {
       return { kind: 'unmanaged' }
     }
@@ -105,10 +114,17 @@ function writeTextFileAtomic(filePath: string, content: string): void {
   mkdirSync(dir, { recursive: true })
   if (existsSync(filePath)) {
     try {
-      if (readFileSync(filePath, 'utf-8') === content) {
+      const existing = readNodeFileSyncWithinLimit(
+        filePath,
+        AGENT_HOOK_PLUGIN_MAX_BYTES
+      ).buffer.toString('utf8')
+      if (existing === content) {
         return
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
+        throw error
+      }
       // Fall through to the atomic write path.
     }
   }
@@ -130,11 +146,13 @@ function writeTextFileAtomic(filePath: string, content: string): void {
 
 function getAmpPluginSource(): string {
   return [
-    "import { readFileSync, statSync } from 'fs'",
+    "import * as fs from 'fs'",
     "import type { PluginAPI } from '@ampcode/plugin'",
     '',
     `// ${AMP_PLUGIN_MARKER}`,
     'type HookCoords = { port?: string; token?: string; env?: string; version?: string }',
+    '',
+    ...getGeneratedNodeBoundedFileReaderSourceLines({ typed: true }),
     '',
     'let warnedBadEndpoint = false',
     "let cachedEndpointKey = ''",
@@ -144,12 +162,12 @@ function getAmpPluginSource(): string {
     '  const endpointPath = process.env.ORCA_AGENT_HOOK_ENDPOINT',
     '  if (!endpointPath) return null',
     '  try {',
-    '    const stat = statSync(endpointPath)',
+    '    const stat = fs.statSync(endpointPath)',
     '    const cacheKey = `${stat.mtimeMs}:${stat.size}:${stat.ino}`',
     '    if (cacheKey === cachedEndpointKey && cachedEndpointValues) {',
     '      return cachedEndpointValues',
     '    }',
-    "    const contents = readFileSync(endpointPath, 'utf8')",
+    '    const contents = readOrcaManagedFileWithinLimit(fs, endpointPath)',
     '    const out: HookCoords = {}',
     '    for (const line of contents.split(/\\r?\\n/)) {',
     '      const match = line.match(/^(?:set\\s+)?([A-Z0-9_]+)=(.*)$/)',
@@ -346,11 +364,16 @@ export class AmpHookService {
   async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
     const remotePluginPath = getRemotePluginPath(remoteHome)
     try {
-      const existing = await readTextFileRemote(sftp, remotePluginPath)
+      const existing = await readTextFileRemote(sftp, remotePluginPath, AGENT_HOOK_PLUGIN_MAX_BYTES)
       if (existing !== null && !isManagedPlugin(existing)) {
         return statusFromState(remotePluginPath, { kind: 'unmanaged' })
       }
-      await writeTextFileRemoteAtomic(sftp, remotePluginPath, getAmpPluginSource())
+      await writeTextFileRemoteAtomic(
+        sftp,
+        remotePluginPath,
+        getAmpPluginSource(),
+        AGENT_HOOK_PLUGIN_MAX_BYTES
+      )
       return {
         agent: 'amp',
         state: 'installed',

--- a/src/main/claude-accounts/managed-auth-path.ts
+++ b/src/main/claude-accounts/managed-auth-path.ts
@@ -1,7 +1,9 @@
-import { existsSync, lstatSync, readFileSync, realpathSync, writeFileSync } from 'node:fs'
+import { existsSync, lstatSync, realpathSync, writeFileSync } from 'node:fs'
 import { join, relative, resolve, sep } from 'node:path'
 import { app } from 'electron'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 
 const MANAGED_AUTH_MARKER = '.orca-managed-claude-auth'
 
@@ -65,8 +67,11 @@ export function readClaudeManagedAuthFile(
     if (!isOwnedChildFile(managedAuthPath, filePath)) {
       return null
     }
-    return readFileSync(filePath, 'utf-8')
-  } catch {
+    return readAgentStateFileSync(filePath)
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw error
+    }
     return null
   }
 }
@@ -80,6 +85,9 @@ export function writeClaudeManagedAuthFile(
   if (existsSync(filePath) && !isOwnedChildFile(managedAuthPath, filePath)) {
     throw new Error('Managed Claude auth child file is not owned by Orca.')
   }
+  if (existsSync(filePath)) {
+    readAgentStateFileSync(filePath)
+  }
   writeFileAtomically(filePath, contents, { mode: 0o600 })
 }
 
@@ -92,7 +100,7 @@ function isManagedAuthMarkerValid(markerPath: string, accountId: string): boolea
     ) {
       return false
     }
-    return readFileSync(markerPath, 'utf-8').trim() === accountId
+    return readAgentStateFileSync(markerPath).trim() === accountId
   } catch {
     return false
   }

--- a/src/main/claude-accounts/oauth-refresh.ts
+++ b/src/main/claude-accounts/oauth-refresh.ts
@@ -1,5 +1,6 @@
 import { net, session } from 'electron'
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 // Why: the OAuth client id and token endpoint are the public Claude Code
 // values, verified against the installed `claude` binary (2.1.177) and the
@@ -158,7 +159,7 @@ export async function refreshClaudeOauthCredentials(
       console.warn(`[claude-oauth-refresh] token endpoint returned ${res.status}`)
       return null
     }
-    const data = (await res.json()) as TokenEndpointResponse
+    const data = await readFetchResponseJsonWithinLimit<TokenEndpointResponse>(res)
     return applyRefreshedToken(credentialsJson, data, now)
   } catch (error) {
     console.warn(

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -1,10 +1,11 @@
 /* eslint-disable max-lines -- Why: keeps file/Keychain/snapshot/env-patch auth semantics together so PTY launch and quota-fetch paths can't drift. */
 import { execFileSync } from 'node:child_process'
-import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, rmSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { app } from 'electron'
 import type { ClaudeManagedAccount } from '../../shared/types'
 import type { Store } from '../persistence'
+import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import type { ClaudeEnvPatch } from './environment'
 import {
@@ -35,6 +36,7 @@ import {
   setSelectedClaudeAccountIdForTarget,
   type ClaudeAccountSelectionTarget
 } from './runtime-selection'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 
 export type ClaudeRuntimeAuthPreparation = {
   configDir: string
@@ -346,7 +348,7 @@ export class ClaudeRuntimeAuthService {
     if (this.lastSyncedAccountId === null) {
       const paths = this.pathResolver.getRuntimePaths()
       const runtimeCredentialsJson = existsSync(paths.credentialsPath)
-        ? readFileSync(paths.credentialsPath, 'utf-8')
+        ? readAgentStateFileSync(paths.credentialsPath)
         : null
       await this.captureSystemDefaultSnapshotForManagedEntry(
         runtimeCredentialsJson,
@@ -569,7 +571,7 @@ export class ClaudeRuntimeAuthService {
   ): Promise<ClaudeRuntimeCredentialCandidate[]> {
     const paths = this.pathResolver.getRuntimePaths()
     const fileCredentials = existsSync(paths.credentialsPath)
-      ? readFileSync(paths.credentialsPath, 'utf-8')
+      ? readAgentStateFileSync(paths.credentialsPath)
       : null
     const runtimeOauthAccount = this.readRuntimeOauthAccount()
     const candidates: ClaudeRuntimeCredentialCandidate[] = []
@@ -1162,7 +1164,7 @@ export class ClaudeRuntimeAuthService {
       options.credentialsJsonOverride !== undefined
         ? options.credentialsJsonOverride
         : existsSync(paths.credentialsPath)
-          ? readFileSync(paths.credentialsPath, 'utf-8')
+          ? readAgentStateFileSync(paths.credentialsPath)
           : null
     const keychainCredentialsJson = await this.readAggregateClaudeKeychainCredentialsBestEffort(
       paths.configDir
@@ -1293,7 +1295,7 @@ export class ClaudeRuntimeAuthService {
       return null
     }
     try {
-      const parsed = JSON.parse(readFileSync(snapshotPath, 'utf-8')) as unknown
+      const parsed = readAgentStateJsonFileSync(snapshotPath)
       if (this.isSystemDefaultSnapshot(parsed)) {
         return parsed
       }
@@ -1411,7 +1413,7 @@ export class ClaudeRuntimeAuthService {
 
   private readRuntimeCredentialsFile(): string | null {
     const credentialsPath = this.pathResolver.getRuntimePaths().credentialsPath
-    return existsSync(credentialsPath) ? readFileSync(credentialsPath, 'utf-8') : null
+    return existsSync(credentialsPath) ? readAgentStateFileSync(credentialsPath) : null
   }
 
   private runtimeCredentialsBelongToAccount(
@@ -1452,7 +1454,7 @@ export class ClaudeRuntimeAuthService {
     }
     const paths = this.pathResolver.getRuntimePaths()
     const currentCredentialsJson = existsSync(paths.credentialsPath)
-      ? readFileSync(paths.credentialsPath, 'utf-8')
+      ? readAgentStateFileSync(paths.credentialsPath)
       : null
     return currentCredentialsJson === previouslyWrittenCredentialsJson
   }
@@ -1461,7 +1463,7 @@ export class ClaudeRuntimeAuthService {
     const paths = this.pathResolver.getRuntimePaths()
     try {
       const currentCredentialsJson = existsSync(paths.credentialsPath)
-        ? readFileSync(paths.credentialsPath, 'utf-8')
+        ? readAgentStateFileSync(paths.credentialsPath)
         : null
       return (
         currentCredentialsJson !== null &&
@@ -1551,7 +1553,7 @@ export class ClaudeRuntimeAuthService {
       return null
     }
     try {
-      const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as unknown
+      const parsed = readAgentStateJsonFileSync(configPath)
       const record = this.asRecord(parsed)
       if (!record) {
         return RUNTIME_OAUTH_ACCOUNT_PARSE_ERROR
@@ -1761,8 +1763,11 @@ export class ClaudeRuntimeAuthService {
 
   private fileContentsEqual(targetPath: string, contents: string): boolean {
     try {
-      return existsSync(targetPath) && readFileSync(targetPath, 'utf-8') === contents
-    } catch {
+      return existsSync(targetPath) && readAgentStateFileSync(targetPath) === contents
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
+        throw error
+      }
       return false
     }
   }
@@ -1783,7 +1788,7 @@ export class ClaudeRuntimeAuthService {
       return {}
     }
     try {
-      const parsed = JSON.parse(readFileSync(targetPath, 'utf-8')) as unknown
+      const parsed = readAgentStateJsonFileSync(targetPath)
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         return parsed as Record<string, unknown>
       }

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -2,7 +2,7 @@
 for login, credential capture, Keychain storage, selection, and rate-limit refresh. */
 import { randomUUID } from 'node:crypto'
 import { execFileSync, spawn } from 'node:child_process'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
 import type {
@@ -12,6 +12,7 @@ import type {
 } from '../../shared/types'
 import type { Store } from '../persistence'
 import type { RateLimitService } from '../rate-limits/service'
+import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
 import { resolveClaudeCommand } from '../codex-cli/command'
 import type { ClaudeRuntimeAuthService } from './runtime-auth-service'
 import {
@@ -613,7 +614,7 @@ export class ClaudeAccountService {
       }
     }
     const credentialsPath = join(configDir, '.credentials.json')
-    return existsSync(credentialsPath) ? readFileSync(credentialsPath, 'utf-8') : null
+    return existsSync(credentialsPath) ? readAgentStateFileSync(credentialsPath) : null
   }
 
   private readOauthAccountFromConfigDir(configDir: string): unknown {
@@ -622,7 +623,7 @@ export class ClaudeAccountService {
         continue
       }
       try {
-        const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>
+        const parsed = readAgentStateJsonFileSync(configPath) as Record<string, unknown>
         if (parsed.oauthAccount) {
           return parsed.oauthAccount
         }

--- a/src/main/claude-usage/scanner-large-directory.test.ts
+++ b/src/main/claude-usage/scanner-large-directory.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
-import type { Dirent } from 'node:fs'
+import type { Dir, Dirent } from 'node:fs'
 import type * as FsPromises from 'node:fs/promises'
 import type * as NodeOs from 'node:os'
 import { join } from 'node:path'
 
-const { homedirMock, readdirMock } = vi.hoisted(() => ({
+const { homedirMock, opendirMock } = vi.hoisted(() => ({
   homedirMock: vi.fn<() => string>(),
-  readdirMock: vi.fn<(dirPath: string) => Promise<Dirent[]>>()
+  opendirMock: vi.fn<(dirPath: string) => Promise<Dir>>()
 }))
 
 vi.mock('os', async () => {
@@ -21,7 +21,7 @@ vi.mock('fs/promises', async () => {
   const actual = await vi.importActual<typeof FsPromises>('fs/promises')
   return {
     ...actual,
-    readdir: readdirMock
+    opendir: opendirMock
   }
 })
 
@@ -43,24 +43,84 @@ const largeTranscriptEntries = Array.from({ length: FILE_COUNT }, (_, index) =>
   dirent(`session-${index}.jsonl`, 'file')
 )
 
+function directory(entries: Dirent[]): Dir {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* entries
+    }
+  } as Dir
+}
+
+function generatedFileDirectory(count: number): Dir {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let index = 0; index < count; index++) {
+        yield dirent(`session-${index}.jsonl`, 'file')
+      }
+    }
+  } as Dir
+}
+
 describe('listClaudeTranscriptFiles large directories', () => {
   it('keeps nested transcript scans past the JavaScript spread-argument limit', async () => {
     homedirMock.mockReturnValue(FAKE_HOME)
-    readdirMock.mockImplementation(async (dirPath) => {
+    opendirMock.mockImplementation(async (dirPath) => {
       if (dirPath === PROJECTS_ROOT) {
-        return [dirent('large-project', 'directory')]
+        return directory([dirent('large-project', 'directory')])
       }
       if (dirPath === PROJECT_DIR) {
-        return largeTranscriptEntries
+        return directory(largeTranscriptEntries)
       }
       if (dirPath === TRANSCRIPTS_ROOT) {
-        return []
+        return directory([])
       }
-      throw new Error(`Unexpected readdir path: ${dirPath}`)
+      throw new Error(`Unexpected opendir path: ${dirPath}`)
     })
 
     const { listClaudeTranscriptFiles } = await import('./scanner')
 
     await expect(listClaudeTranscriptFiles()).resolves.toHaveLength(FILE_COUNT)
+  })
+
+  it('fails closed instead of silently omitting a transcript past capacity', async () => {
+    opendirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === PROJECTS_ROOT) {
+        return generatedFileDirectory(200_001)
+      }
+      if (dirPath === TRANSCRIPTS_ROOT) {
+        return directory([])
+      }
+      throw new Error(`Unexpected opendir path: ${dirPath}`)
+    })
+
+    const { listClaudeTranscriptFiles } = await import('./scanner')
+
+    await expect(listClaudeTranscriptFiles()).rejects.toMatchObject({
+      name: 'UsageHistoryScanCapacityError',
+      resource: 'files',
+      limit: 200_000
+    })
+  })
+
+  it('keeps stable transcripts when a nested directory vanishes during discovery', async () => {
+    const vanishedDirectory = join(PROJECTS_ROOT, 'vanished')
+    opendirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === PROJECTS_ROOT) {
+        return directory([dirent('stable.jsonl', 'file'), dirent('vanished', 'directory')])
+      }
+      if (dirPath === vanishedDirectory) {
+        throw Object.assign(new Error('directory vanished'), { code: 'ENOENT' })
+      }
+      if (dirPath === TRANSCRIPTS_ROOT) {
+        return directory([])
+      }
+      throw new Error(`Unexpected opendir path: ${dirPath}`)
+    })
+
+    const { listClaudeTranscriptFiles } = await import('./scanner')
+
+    await expect(listClaudeTranscriptFiles()).resolves.toEqual([
+      join(PROJECTS_ROOT, 'stable.jsonl')
+    ])
   })
 })

--- a/src/main/claude-usage/scanner.test.ts
+++ b/src/main/claude-usage/scanner.test.ts
@@ -8,6 +8,7 @@ import {
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { UsageHistoryScanBudget } from '../usage-history-scan-budget'
 
 describe('parseClaudeUsageRecord', () => {
   it('extracts token usage from assistant transcript lines', () => {
@@ -98,6 +99,31 @@ describe('parseClaudeUsageRecord', () => {
           cacheWriteTokens: 7
         }
       ])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('fails the whole parse when retained usage records exceed capacity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-claude-capacity-'))
+    const filePath = join(root, 'session.jsonl')
+    const record = (uuid: string) =>
+      JSON.stringify({
+        type: 'assistant',
+        sessionId: 'session-1',
+        uuid,
+        timestamp: '2026-04-09T10:00:00.000Z',
+        message: { usage: { input_tokens: 1 } }
+      })
+    try {
+      await writeFile(filePath, [record('turn-1'), record('turn-2')].join('\n'))
+      const budget = new UsageHistoryScanBudget({ records: 1 })
+
+      await expect(parseClaudeUsageFile(filePath, budget)).rejects.toMatchObject({
+        name: 'UsageHistoryScanCapacityError',
+        resource: 'records',
+        limit: 1
+      })
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/claude-usage/scanner.ts
+++ b/src/main/claude-usage/scanner.ts
@@ -1,10 +1,16 @@
 /* eslint-disable max-lines -- Why: transcript discovery, parsing, attribution, and aggregation share one data shape pipeline. Keeping them co-located makes it easier to audit correctness when Claude usage numbers look surprising. */
 import { homedir } from 'node:os'
 import { join, basename } from 'node:path'
-import { realpath, readdir, stat } from 'node:fs/promises'
-import { createReadStream } from 'node:fs'
-import { createInterface } from 'node:readline'
+import { realpath, stat } from 'node:fs/promises'
 import type { Repo } from '../../shared/types'
+import { walkUsageHistoryJsonlFiles } from '../usage-history-file-discovery'
+import { readUsageHistoryJsonlLines } from '../usage-history-jsonl-reader'
+import {
+  MAX_USAGE_HISTORY_FILES,
+  UsageHistoryScanBudget,
+  UsageHistoryScanCapacityError,
+  getUsageHistoryRetainedBytes
+} from '../usage-history-scan-budget'
 import type {
   ClaudeUsageAttributedTurn,
   ClaudeUsageDailyAggregate,
@@ -128,54 +134,29 @@ async function yieldToEventLoop(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0))
 }
 
-async function walkJsonlFiles(dirPath: string): Promise<string[]> {
-  const entries = await readdir(dirPath, { withFileTypes: true })
-  const files: string[] = []
-
-  for (const entry of entries) {
-    const fullPath = join(dirPath, entry.name)
-    if (entry.isDirectory()) {
-      appendDiscoveredFiles(files, await walkJsonlFiles(fullPath))
-      continue
-    }
-    if (entry.isFile() && entry.name.endsWith('.jsonl')) {
-      files.push(fullPath)
-    }
-  }
-
-  return files
-}
-
-function appendDiscoveredFiles(target: string[], source: readonly string[]): void {
-  // Why: long-lived transcript directories can exceed V8's argument limit if
-  // child file arrays are spread into push().
-  for (const filePath of source) {
-    target.push(filePath)
-  }
-}
-
-export async function listClaudeTranscriptFiles(): Promise<string[]> {
+export async function listClaudeTranscriptFiles(
+  budget = new UsageHistoryScanBudget()
+): Promise<string[]> {
   const roots = [CLAUDE_PROJECTS_DIR, CLAUDE_TRANSCRIPTS_DIR]
-  const files = await Promise.all(
-    roots.map(async (root) => {
-      try {
-        return await walkJsonlFiles(root)
-      } catch {
-        return []
+  const files: string[] = []
+  for (const root of roots) {
+    try {
+      for (const filePath of await walkUsageHistoryJsonlFiles(root, budget)) {
+        files.push(filePath)
       }
-    })
-  )
-  return [...new Set(files.flat())].sort()
+    } catch (error) {
+      if (error instanceof UsageHistoryScanCapacityError) {
+        throw error
+      }
+    }
+  }
+  return [...new Set(files)].sort()
 }
 
 export async function getProcessedFileInfo(filePath: string): Promise<ClaudeUsageProcessedFile> {
   const fileStat = await stat(filePath)
   let lineCount = 0
-  const lines = createInterface({
-    input: createReadStream(filePath, { encoding: 'utf-8' }),
-    crlfDelay: Infinity
-  })
-  for await (const _line of lines) {
+  for await (const _line of readUsageHistoryJsonlLines(filePath)) {
     lineCount++
   }
   return {
@@ -308,17 +289,17 @@ export function parseClaudeUsageRecord(line: string): ClaudeUsageParsedTurn | nu
   return parsed ? stripClaudeSourceMetadata(parsed) : null
 }
 
-export async function parseClaudeUsageFile(filePath: string): Promise<ClaudeUsageParsedTurn[]> {
+export async function parseClaudeUsageFile(
+  filePath: string,
+  budget = new UsageHistoryScanBudget()
+): Promise<ClaudeUsageParsedTurn[]> {
   const turns: ClaudeUsageParsedSourceTurn[] = []
   const fallbackSessionId = basename(filePath, '.jsonl')
-  const lines = createInterface({
-    input: createReadStream(filePath, { encoding: 'utf-8' }),
-    crlfDelay: Infinity
-  })
 
-  for await (const line of lines) {
+  for await (const line of readUsageHistoryJsonlLines(filePath)) {
     const parsed = parseClaudeUsageSourceRecord(line, fallbackSessionId)
     if (parsed) {
+      claimClaudeTurn(budget, parsed)
       turns.push(parsed)
     }
   }
@@ -326,7 +307,10 @@ export async function parseClaudeUsageFile(filePath: string): Promise<ClaudeUsag
   return dedupeClaudeUsageTurns(turns).map(stripClaudeSourceMetadata)
 }
 
-async function readClaudeUsageScanFile(filePath: string): Promise<{
+async function readClaudeUsageScanFile(
+  filePath: string,
+  budget: UsageHistoryScanBudget
+): Promise<{
   processedFile: ClaudeUsageProcessedFile
   turns: ClaudeUsageParsedSourceTurn[]
 }> {
@@ -334,15 +318,12 @@ async function readClaudeUsageScanFile(filePath: string): Promise<{
   let lineCount = 0
   const turns: ClaudeUsageParsedSourceTurn[] = []
   const fallbackSessionId = basename(filePath, '.jsonl')
-  const lines = createInterface({
-    input: createReadStream(filePath, { encoding: 'utf-8' }),
-    crlfDelay: Infinity
-  })
 
-  for await (const line of lines) {
+  for await (const line of readUsageHistoryJsonlLines(filePath)) {
     lineCount++
     const parsed = parseClaudeUsageSourceRecord(line, fallbackSessionId)
     if (parsed) {
+      claimClaudeTurn(budget, parsed)
       turns.push(parsed)
     }
   }
@@ -356,6 +337,19 @@ async function readClaudeUsageScanFile(filePath: string): Promise<{
     },
     turns: dedupeClaudeUsageTurns(turns)
   }
+}
+
+function claimClaudeTurn(budget: UsageHistoryScanBudget, turn: ClaudeUsageParsedSourceTurn): void {
+  budget.claimRecord(
+    getUsageHistoryRetainedBytes([
+      turn.sessionId,
+      turn.timestamp,
+      turn.model,
+      turn.cwd,
+      turn.gitBranch,
+      turn.dedupeKey
+    ])
+  )
 }
 
 function localDayFromTimestamp(timestamp: string): string | null {
@@ -489,6 +483,49 @@ function mergeClaudeDailyAggregates(
     existing.outputTokens += aggregate.outputTokens
     existing.cacheReadTokens += aggregate.cacheReadTokens
     existing.cacheWriteTokens += aggregate.cacheWriteTokens
+  }
+}
+
+function claimClaudeUsageProjection(
+  budget: UsageHistoryScanBudget,
+  sessions: readonly ClaudeUsageSession[],
+  dailyAggregates: readonly ClaudeUsageDailyAggregate[]
+): void {
+  for (const session of sessions) {
+    budget.claimProjection(
+      getUsageHistoryRetainedBytes([
+        session.sessionId,
+        session.firstTimestamp,
+        session.lastTimestamp,
+        session.model,
+        session.lastCwd,
+        session.lastGitBranch,
+        session.primaryWorktreeId,
+        session.primaryRepoId
+      ])
+    )
+    for (const location of session.locationBreakdown) {
+      budget.claimProjection(
+        getUsageHistoryRetainedBytes([
+          location.locationKey,
+          location.projectLabel,
+          location.repoId,
+          location.worktreeId
+        ])
+      )
+    }
+  }
+  for (const daily of dailyAggregates) {
+    budget.claimProjection(
+      getUsageHistoryRetainedBytes([
+        daily.day,
+        daily.model,
+        daily.projectKey,
+        daily.projectLabel,
+        daily.repoId,
+        daily.worktreeId
+      ])
+    )
   }
 }
 
@@ -626,7 +663,14 @@ export async function scanClaudeUsageFiles(
   sessions: ClaudeUsageSession[]
   dailyAggregates: ClaudeUsageDailyAggregate[]
 }> {
-  const files = await listClaudeTranscriptFiles()
+  if (previousProcessedFiles.length > MAX_USAGE_HISTORY_FILES) {
+    throw new UsageHistoryScanCapacityError('files', MAX_USAGE_HISTORY_FILES)
+  }
+  const budget = new UsageHistoryScanBudget()
+  const files = await listClaudeTranscriptFiles(budget)
+  for (const previous of previousProcessedFiles) {
+    budget.claimPath(previous.path)
+  }
   const previousByPath = new Map(previousProcessedFiles.map((file) => [file.path, file]))
   const worktreeLookup = await buildWorktreeLookup(worktrees)
 
@@ -685,7 +729,12 @@ export async function scanClaudeUsageFiles(
   // turn for exactly one file; cached files keep the claims they persisted.
   const turnOwnerByDedupeKey = new Map<string, string>()
   for (const [filePath, previous] of reusedByPath) {
+    for (const session of previous.sessions) {
+      budget.claimRecords(session.turnCount)
+    }
+    claimClaudeUsageProjection(budget, previous.sessions, previous.dailyAggregates)
     for (const dedupeKey of previous.ownedDedupeKeys) {
+      budget.claimOwnershipKey(dedupeKey)
       // First cached claim wins so conflicting projections stay deterministic.
       if (!turnOwnerByDedupeKey.has(dedupeKey)) {
         turnOwnerByDedupeKey.set(dedupeKey, filePath)
@@ -698,7 +747,9 @@ export async function scanClaudeUsageFiles(
     const batch = pathsToParse.slice(index, index + FILE_SCAN_BATCH_SIZE)
     // Why: transcript scans run in Electron's main process. Small parallel
     // batches cut independent file I/O without letting Settings stay blocked.
-    const reads = await Promise.all(batch.map((filePath) => readClaudeUsageScanFile(filePath)))
+    const reads = await Promise.all(
+      batch.map((filePath) => readClaudeUsageScanFile(filePath, budget))
+    )
     for (const [batchIndex, filePath] of batch.entries()) {
       const { processedFile, turns } = reads[batchIndex]
       // Why: ownership claims must be sequential in sorted-path order so
@@ -713,15 +764,20 @@ export async function scanClaudeUsageFiles(
             hasDeferredClaims = true
             continue
           }
+          if (owner === undefined) {
+            budget.claimOwnershipKey(turn.dedupeKey)
+          }
           turnOwnerByDedupeKey.set(turn.dedupeKey, filePath)
           ownedDedupeKeys.push(turn.dedupeKey)
         }
         ownedTurns.push(stripClaudeSourceMetadata(turn))
       }
       const attributed = await attributeClaudeUsageTurns(ownedTurns, worktreeLookup)
+      const aggregates = aggregateClaudeUsage(attributed)
+      claimClaudeUsageProjection(budget, aggregates.sessions, aggregates.dailyAggregates)
       parsedByPath.set(filePath, {
         ...processedFile,
-        ...aggregateClaudeUsage(attributed),
+        ...aggregates,
         ownedDedupeKeys,
         hasDeferredClaims
       })
@@ -744,14 +800,17 @@ export async function scanClaudeUsageFiles(
     mergeClaudeDailyAggregates(dailyByKey, processed.dailyAggregates)
   }
 
+  const sessions = finalizeClaudeSessions(sessionsById)
+  const dailyAggregates = [...dailyByKey.values()].sort((left, right) =>
+    left.day === right.day
+      ? left.projectLabel.localeCompare(right.projectLabel)
+      : left.day.localeCompare(right.day)
+  )
+  claimClaudeUsageProjection(budget, sessions, dailyAggregates)
   return {
     processedFiles,
-    sessions: finalizeClaudeSessions(sessionsById),
-    dailyAggregates: [...dailyByKey.values()].sort((left, right) =>
-      left.day === right.day
-        ? left.projectLabel.localeCompare(right.projectLabel)
-        : left.day.localeCompare(right.day)
-    )
+    sessions,
+    dailyAggregates
   }
 }
 

--- a/src/main/claude-usage/store.ts
+++ b/src/main/claude-usage/store.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines -- Why: this store is the single main-process owner for Claude usage persistence, scan gating, and query semantics. Keeping those policy decisions together avoids split-brain range/scope logic across multiple files. */
 import { app } from 'electron'
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
-import { dirname, join } from 'node:path'
+import { join } from 'node:path'
 import type {
   ClaudeUsageBreakdownKind,
   ClaudeUsageBreakdownRow,
@@ -15,6 +14,10 @@ import type {
 } from '../../shared/claude-usage-types'
 import type { AutomationRunUsage } from '../../shared/automations-types'
 import type { Store } from '../persistence'
+import {
+  readUsageProjectionStateFile,
+  writeUsageProjectionStateFileWithRecovery
+} from '../usage-projection-state-file'
 import { loadKnownUsageWorktreesByRepo, type UsageWorktreeRef } from '../usage-worktree-metadata'
 import type { ClaudeUsagePersistedState } from './types'
 import { createWorktreeRefs, getSessionProjectLabel, scanClaudeUsageFiles } from './scanner'
@@ -326,10 +329,11 @@ export class ClaudeUsageStore {
   private load(): ClaudeUsagePersistedState {
     try {
       const usageFile = getClaudeUsageFile()
-      if (!existsSync(usageFile)) {
+      const raw = readUsageProjectionStateFile(usageFile)
+      if (raw === null) {
         return getDefaultState()
       }
-      const parsed = JSON.parse(readFileSync(usageFile, 'utf-8')) as ClaudeUsagePersistedState
+      const parsed = JSON.parse(raw) as ClaudeUsagePersistedState
       if (parsed.schemaVersion !== SCHEMA_VERSION) {
         // Why: scanner semantics affect persisted totals, so old Claude caches
         // must be rebuilt after parser/source changes instead of reused briefly.
@@ -363,16 +367,12 @@ export class ClaudeUsageStore {
 
   private writeToDisk(): void {
     const usageFile = getClaudeUsageFile()
-    const dir = dirname(usageFile)
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
-    }
-    // Why: scans can refresh while the app is in active use. Use the same
-    // atomic temp-file pattern as the main store so a crash or concurrent write
-    // cannot leave a truncated analytics file as the common failure mode.
-    const tmpFile = `${usageFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-    writeFileSync(tmpFile, JSON.stringify(this.state, null, 2), 'utf-8')
-    renameSync(tmpFile, usageFile)
+    this.state = writeUsageProjectionStateFileWithRecovery(usageFile, this.state, (error) => {
+      const reset = getDefaultState()
+      reset.scanState.enabled = this.state.scanState.enabled
+      reset.scanState.lastScanError = error.message
+      return reset
+    })
   }
 
   async setEnabled(enabled: boolean): Promise<ClaudeUsageScanState> {

--- a/src/main/devin/hook-config-json.ts
+++ b/src/main/devin/hook-config-json.ts
@@ -1,5 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { parse as parseJsonc, type ParseError } from 'jsonc-parser'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { AGENT_HOOK_CONFIG_MAX_BYTES } from '../agent-hooks/agent-hook-file-limits'
 import { isPlainObject, type HooksConfig } from '../agent-hooks/installer-utils'
 
 /** Devin documents config.json as JSONC; stock JSON.parse rejects comments. */
@@ -9,7 +11,10 @@ export function readDevinHooksConfig(configPath: string): HooksConfig | null {
   }
 
   try {
-    const text = readFileSync(configPath, 'utf-8')
+    const text = readNodeFileSyncWithinLimit(
+      configPath,
+      AGENT_HOOK_CONFIG_MAX_BYTES
+    ).buffer.toString('utf8')
     return parseDevinHooksConfigText(text, 'Devin config.json')
   } catch {
     return null

--- a/src/main/hermes/hook-service.ts
+++ b/src/main/hermes/hook-service.ts
@@ -4,7 +4,6 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
-  readFileSync,
   renameSync,
   rmSync,
   unlinkSync,
@@ -16,6 +15,14 @@ import type { SFTPWrapper } from 'ssh2'
 import { parse, stringify } from 'yaml'
 
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileSyncWithinLimit
+} from '../../shared/node-bounded-file-reader'
+import {
+  AGENT_HOOK_CONFIG_MAX_BYTES,
+  AGENT_HOOK_PLUGIN_MAX_BYTES
+} from '../agent-hooks/agent-hook-file-limits'
 import {
   readTextFileRemote,
   writeTextFileRemoteAtomic
@@ -137,7 +144,18 @@ function readConfigFile(configPath: string): ConfigParseResult {
   if (!existsSync(configPath)) {
     return { ok: true, config: {} }
   }
-  return parseHermesConfig(readFileSync(configPath, 'utf-8'))
+  try {
+    const content = readNodeFileSyncWithinLimit(
+      configPath,
+      AGENT_HOOK_CONFIG_MAX_BYTES
+    ).buffer.toString('utf8')
+    return parseHermesConfig(content)
+  } catch (error) {
+    return {
+      ok: false,
+      detail: error instanceof Error ? error.message : String(error)
+    }
+  }
 }
 
 function writeConfigFile(configPath: string, config: HermesConfig): void {
@@ -146,10 +164,17 @@ function writeConfigFile(configPath: string, config: HermesConfig): void {
   const serialized = serializeHermesConfig(config)
   if (existsSync(configPath)) {
     try {
-      if (readFileSync(configPath, 'utf-8') === serialized) {
+      const existing = readNodeFileSyncWithinLimit(
+        configPath,
+        AGENT_HOOK_CONFIG_MAX_BYTES
+      ).buffer.toString('utf8')
+      if (existing === serialized) {
         return
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
+        throw error
+      }
       // Fall through to the atomic write path.
     }
   }
@@ -186,27 +211,56 @@ function updateConfigContent(
 function getPluginFilesState(pluginDir = getPluginDir()): {
   present: boolean
   managed: boolean
+  blocked: boolean
   detail: string | null
 } {
   const manifestPath = getManifestPath(pluginDir)
   const initPath = getInitPath(pluginDir)
-  if (!existsSync(manifestPath) || !existsSync(initPath)) {
-    return { present: false, managed: false, detail: 'Managed Hermes plugin files are missing' }
+  const manifest = readPluginFile(manifestPath, 'plugin.yaml')
+  const init = readPluginFile(initPath, '__init__.py')
+  if (manifest.kind === 'error') {
+    return { present: true, managed: false, blocked: manifest.blocked, detail: manifest.detail }
+  }
+  if (init.kind === 'error') {
+    return { present: true, managed: false, blocked: init.blocked, detail: init.detail }
+  }
+  if (manifest.kind === 'absent' || init.kind === 'absent') {
+    return {
+      present: false,
+      managed: false,
+      blocked: false,
+      detail: 'Managed Hermes plugin files are missing'
+    }
+  }
+  const managed =
+    manifest.content.includes(HERMES_PLUGIN_MARKER) && init.content.includes(HERMES_PLUGIN_MARKER)
+  return {
+    present: true,
+    managed,
+    blocked: false,
+    detail: managed ? null : 'Hermes orca-status plugin exists but is not Orca-managed'
+  }
+}
+
+type PluginFileRead =
+  | { kind: 'absent' }
+  | { kind: 'content'; content: string }
+  | { kind: 'error'; blocked: boolean; detail: string }
+
+function readPluginFile(path: string, name: string): PluginFileRead {
+  if (!existsSync(path)) {
+    return { kind: 'absent' }
   }
   try {
-    const manifest = readFileSync(manifestPath, 'utf-8')
-    const init = readFileSync(initPath, 'utf-8')
-    const managed = manifest.includes(HERMES_PLUGIN_MARKER) && init.includes(HERMES_PLUGIN_MARKER)
-    return {
-      present: true,
-      managed,
-      detail: managed ? null : 'Hermes orca-status plugin exists but is not Orca-managed'
-    }
+    const content = readNodeFileSyncWithinLimit(path, AGENT_HOOK_PLUGIN_MAX_BYTES).buffer.toString(
+      'utf8'
+    )
+    return { kind: 'content', content }
   } catch (error) {
     return {
-      present: true,
-      managed: false,
-      detail: error instanceof Error ? error.message : String(error)
+      kind: 'error',
+      blocked: error instanceof NodeFileReadTooLargeError,
+      detail: `Could not read Hermes ${name}: ${error instanceof Error ? error.message : String(error)}`
     }
   }
 }
@@ -234,8 +288,11 @@ function getConfigEnablement(config: HermesConfig): {
   }
 }
 
-function buildStatus(configPath: string, config: HermesConfig): AgentHookInstallStatus {
-  const pluginFiles = getPluginFilesState()
+function buildStatus(
+  configPath: string,
+  config: HermesConfig,
+  pluginFiles = getPluginFilesState()
+): AgentHookInstallStatus {
   const enablement = getConfigEnablement(config)
   const details = [
     pluginFiles.detail,
@@ -245,7 +302,9 @@ function buildStatus(configPath: string, config: HermesConfig): AgentHookInstall
   ].filter((detail): detail is string => Boolean(detail))
 
   let state: AgentHookInstallState
-  if (!pluginFiles.present && !enablement.enabled) {
+  if (pluginFiles.blocked) {
+    state = 'error'
+  } else if (!pluginFiles.present && !enablement.enabled) {
     state = 'not_installed'
   } else if (
     pluginFiles.present &&
@@ -438,12 +497,41 @@ def register(ctx: Any) -> None:
 
 function writePluginFiles(pluginDir = getPluginDir()): void {
   mkdirSync(pluginDir, { recursive: true })
-  writeFileSync(getManifestPath(pluginDir), getPluginManifest(), 'utf-8')
-  writeFileSync(getInitPath(pluginDir), getPluginInitSource(), 'utf-8')
+  writePluginFile(getManifestPath(pluginDir), getPluginManifest())
+  writePluginFile(getInitPath(pluginDir), getPluginInitSource())
+}
+
+function writePluginFile(path: string, content: string): void {
+  if (existsSync(path)) {
+    try {
+      const existing = readNodeFileSyncWithinLimit(
+        path,
+        AGENT_HOOK_PLUGIN_MAX_BYTES
+      ).buffer.toString('utf8')
+      if (existing === content) {
+        return
+      }
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
+        throw error
+      }
+    }
+  }
+  writeFileSync(path, content, 'utf-8')
 }
 
 function stripTrailingSlash(path: string): string {
   return path.replace(/\/+$/, '')
+}
+
+async function guardRemotePluginFileSize(sftp: SFTPWrapper, path: string): Promise<void> {
+  try {
+    await readTextFileRemote(sftp, path, AGENT_HOOK_PLUGIN_MAX_BYTES)
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw error
+    }
+  }
 }
 
 export class HermesHookService {
@@ -474,6 +562,10 @@ export class HermesHookService {
         detail: `Could not parse Hermes config.yaml: ${parsed.detail}`
       }
     }
+    const pluginFiles = getPluginFilesState()
+    if (pluginFiles.blocked) {
+      return buildStatus(configPath, parsed.config, pluginFiles)
+    }
 
     writePluginFiles()
     writeConfigFile(configPath, enablePlugin(parsed.config))
@@ -486,6 +578,12 @@ export class HermesHookService {
     const remotePluginDir = `${remoteRoot}/.hermes/plugins/${HERMES_PLUGIN_NAME}`
     try {
       const existing = await readTextFileRemote(sftp, remoteConfigPath)
+      const remoteManifestPath = `${remotePluginDir}/plugin.yaml`
+      const remoteInitPath = `${remotePluginDir}/__init__.py`
+      await Promise.all([
+        guardRemotePluginFileSize(sftp, remoteManifestPath),
+        guardRemotePluginFileSize(sftp, remoteInitPath)
+      ])
       const next = updateConfigContent(existing, enablePlugin)
       if (next.content === null) {
         return {
@@ -496,8 +594,18 @@ export class HermesHookService {
           detail: `Could not parse remote Hermes config.yaml: ${next.detail ?? 'unknown error'}`
         }
       }
-      await writeTextFileRemoteAtomic(sftp, `${remotePluginDir}/plugin.yaml`, getPluginManifest())
-      await writeTextFileRemoteAtomic(sftp, `${remotePluginDir}/__init__.py`, getPluginInitSource())
+      await writeTextFileRemoteAtomic(
+        sftp,
+        remoteManifestPath,
+        getPluginManifest(),
+        AGENT_HOOK_PLUGIN_MAX_BYTES
+      )
+      await writeTextFileRemoteAtomic(
+        sftp,
+        remoteInitPath,
+        getPluginInitSource(),
+        AGENT_HOOK_PLUGIN_MAX_BYTES
+      )
       await writeTextFileRemoteAtomic(sftp, remoteConfigPath, next.content)
       return {
         agent: 'hermes',
@@ -530,7 +638,11 @@ export class HermesHookService {
       }
     }
     const pluginDir = getPluginDir()
-    if (getPluginFilesState(pluginDir).managed) {
+    const pluginFiles = getPluginFilesState(pluginDir)
+    if (pluginFiles.blocked) {
+      return buildStatus(configPath, parsed.config, pluginFiles)
+    }
+    if (pluginFiles.managed) {
       rmSync(pluginDir, { recursive: true, force: true })
     }
     writeConfigFile(configPath, disablePlugin(parsed.config))

--- a/src/main/keybindings/keybinding-file-bounds.test.ts
+++ b/src/main/keybindings/keybinding-file-bounds.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  MAX_KEYBINDING_FILE_BYTES,
+  MAX_KEYBINDING_JSON_STRUCTURAL_TOKENS,
+  readKeybindingFile,
+  writeKeybindingOverride
+} from './keybinding-file'
+
+describe('keybinding file bounds', () => {
+  const roots: string[] = []
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  function makePath(): string {
+    const root = mkdtempSync(join(tmpdir(), 'orca-keybinding-bounds-'))
+    roots.push(root)
+    return join(root, 'keybindings.json')
+  }
+
+  it('parses a valid document exactly at the byte limit', () => {
+    const filePath = makePath()
+    const prefix = '{"padding":"'
+    const suffix = '"}'
+    writeFileSync(
+      filePath,
+      `${prefix}${'x'.repeat(MAX_KEYBINDING_FILE_BYTES - prefix.length - suffix.length)}${suffix}`
+    )
+
+    const snapshot = readKeybindingFile(filePath, 'linux')
+
+    expect(snapshot.exists).toBe(true)
+    expect(snapshot.diagnostics.some((entry) => entry.message.startsWith('Could not read'))).toBe(
+      false
+    )
+  })
+
+  it('rejects an oversized sparse document and never overwrites it', () => {
+    const filePath = makePath()
+    writeFileSync(filePath, '{}')
+    truncateSync(filePath, MAX_KEYBINDING_FILE_BYTES + 1)
+    const originalSize = statSync(filePath).size
+
+    expect(readKeybindingFile(filePath, 'linux')).toMatchObject({
+      exists: true,
+      overrides: {},
+      diagnostics: [{ severity: 'error' }]
+    })
+    expect(() =>
+      writeKeybindingOverride(filePath, 'linux', 'worktree.quickOpen', ['Ctrl+P'])
+    ).toThrow()
+    expect(statSync(filePath).size).toBe(originalSize)
+  })
+
+  it('rejects structurally amplified JSON before parsing', () => {
+    const filePath = makePath()
+    writeFileSync(filePath, `{"padding":[${'0,'.repeat(MAX_KEYBINDING_JSON_STRUCTURAL_TOKENS)}0]}`)
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    expect(readKeybindingFile(filePath, 'linux')).toMatchObject({
+      exists: true,
+      overrides: {},
+      diagnostics: [{ severity: 'error' }]
+    })
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves the prior file when pretty serialization exceeds the read ceiling', () => {
+    const filePath = makePath()
+    const prefix = '{"padding":"'
+    const suffix = '"}'
+    const before = `${prefix}${'x'.repeat(
+      MAX_KEYBINDING_FILE_BYTES - prefix.length - suffix.length
+    )}${suffix}`
+    writeFileSync(filePath, before)
+
+    expect(() =>
+      writeKeybindingOverride(filePath, 'linux', 'terminal.search', ['Ctrl+Shift+F'])
+    ).toThrow('JSON output exceeds')
+    expect(readFileSync(filePath, 'utf8')).toBe(before)
+  })
+})

--- a/src/main/keybindings/keybinding-file.ts
+++ b/src/main/keybindings/keybinding-file.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: parsing, sanitizing, migrating, and writing the keybindings file must stay together so file-format edge cases share one validation path. */
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import {
   findKeybindingConflicts,
@@ -15,12 +15,18 @@ import {
   type KeybindingOverrides,
   type KeybindingPlatform
 } from '../../shared/keybindings'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
 
 type JsonObject = Record<string, unknown>
 
 const FILE_VERSION = 1
 const PLATFORM_KEYS: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
 const ROOT_KEYS = new Set(['$schema', 'version', 'keybindings', 'platforms'])
+export const MAX_KEYBINDING_FILE_BYTES = 1024 * 1024
+export const MAX_KEYBINDING_JSON_STRUCTURAL_TOKENS = 256 * 1024
+export const MAX_KEYBINDING_JSON_NESTING_DEPTH = 64
 
 export function getUserKeybindingsPath(homePath: string): string {
   return join(homePath, '.orca', 'keybindings.json')
@@ -51,7 +57,14 @@ function readJsonDocument(path: string): {
     return { exists: false, document: createEmptyDocument() }
   }
   try {
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown
+    const serialized = readNodeFileSyncWithinLimit(path, MAX_KEYBINDING_FILE_BYTES).buffer.toString(
+      'utf8'
+    )
+    assertJsonTextStructureWithinLimits(serialized, {
+      structuralTokens: MAX_KEYBINDING_JSON_STRUCTURAL_TOKENS,
+      nestingDepth: MAX_KEYBINDING_JSON_NESTING_DEPTH
+    })
+    const parsed = JSON.parse(serialized) as unknown
     if (!isJsonObject(parsed)) {
       return { exists: true, document: null, error: 'Keybindings file must contain a JSON object.' }
     }
@@ -69,7 +82,8 @@ function writeJsonDocument(path: string, document: JsonObject): void {
   mkdirSync(dirname(path), { recursive: true })
   const tempPath = `${path}.tmp`
   try {
-    writeFileSync(tempPath, `${JSON.stringify(document, null, 2)}\n`, 'utf8')
+    const { serialized } = stringifyJsonWithinByteLimit(document, MAX_KEYBINDING_FILE_BYTES - 1, 2)
+    writeFileSync(tempPath, `${serialized}\n`, 'utf8')
     renameSync(tempPath, path)
   } catch (error) {
     try {

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -1,17 +1,14 @@
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync
-} from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join, posix as pathPosix } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileSyncWithinLimit
+} from '../../shared/node-bounded-file-reader'
+import { AGENT_HOOK_CONFIG_MAX_BYTES } from '../agent-hooks/agent-hook-file-limits'
 import {
   createManagedCommandMatcher,
   getSharedManagedScriptPath,
@@ -99,7 +96,9 @@ function readConfigToml(configPath: string): string | null {
     return ''
   }
   try {
-    return readFileSync(configPath, 'utf-8')
+    return readNodeFileSyncWithinLimit(configPath, AGENT_HOOK_CONFIG_MAX_BYTES).buffer.toString(
+      'utf8'
+    )
   } catch {
     return null
   }
@@ -112,10 +111,17 @@ function writeConfigToml(configPath: string, text: string): void {
   mkdirSync(dir, { recursive: true })
   if (existsSync(configPath)) {
     try {
-      if (readFileSync(configPath, 'utf-8') === text) {
+      const existing = readNodeFileSyncWithinLimit(
+        configPath,
+        AGENT_HOOK_CONFIG_MAX_BYTES
+      ).buffer.toString('utf8')
+      if (existing === text) {
         return
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
+        throw error
+      }
       // Fall through to the atomic write path.
     }
   }

--- a/src/main/memory/collector.test.ts
+++ b/src/main/memory/collector.test.ts
@@ -653,6 +653,53 @@ describe('collectMemorySnapshot', () => {
     expectProcessSweepCount(2)
   })
 
+  it('bounds retained worktree histories and recovers an evicted active history', async () => {
+    mockPsResponse('')
+    const {
+      collectMemorySnapshot,
+      getMemoryHistoryWorktreeCountForTests,
+      MEMORY_HISTORY_MAX_WORKTREES
+    } = await loadCollector()
+    const registrations = Array.from({ length: MEMORY_HISTORY_MAX_WORKTREES }, (_, index) => ({
+      ptyId: `pty-${index}`,
+      worktreeId: `repo::/worktree-${index}`,
+      sessionId: `session-${index}`,
+      paneKey: `pane-${index}`,
+      pid: null
+    }))
+    listRegisteredPtysMock.mockReturnValue(registrations)
+
+    await collectMemorySnapshot(emptyStore)
+    const atBoundary = await collectMemorySnapshot(emptyStore)
+
+    expect(atBoundary.worktrees.every((worktree) => worktree.history.length === 2)).toBe(true)
+    expect(getMemoryHistoryWorktreeCountForTests()).toBe(MEMORY_HISTORY_MAX_WORKTREES)
+
+    listRegisteredPtysMock.mockReturnValue([
+      ...registrations,
+      {
+        ptyId: 'pty-overflow',
+        worktreeId: 'repo::/worktree-overflow',
+        sessionId: 'session-overflow',
+        paneKey: 'pane-overflow',
+        pid: null
+      }
+    ])
+    const overflow = await collectMemorySnapshot(emptyStore)
+
+    expect(overflow.worktrees).toHaveLength(MEMORY_HISTORY_MAX_WORKTREES + 1)
+    expect(overflow.worktrees[0].history).toEqual([0])
+    expect(getMemoryHistoryWorktreeCountForTests()).toBe(MEMORY_HISTORY_MAX_WORKTREES)
+
+    listRegisteredPtysMock.mockReturnValue([registrations[0]])
+    const reactivated = await collectMemorySnapshot(emptyStore)
+    const retained = await collectMemorySnapshot(emptyStore)
+
+    expect(reactivated.worktrees[0].history).toEqual([0])
+    expect(retained.worktrees[0].history).toEqual([0, 0])
+    expect(getMemoryHistoryWorktreeCountForTests()).toBe(MEMORY_HISTORY_MAX_WORKTREES)
+  })
+
   it('uses host process RSS for Electron app metrics when available', async () => {
     mockPsResponse(['10 1 1.5 111', '20 10 2.5 222', '30 10 3.5 333'].join('\n'))
     appMetricsMock.mockReturnValue([

--- a/src/main/memory/collector.ts
+++ b/src/main/memory/collector.ts
@@ -126,6 +126,7 @@ function emptySnapshot(): MemorySnapshot {
 const APP_HISTORY_KEY = '__app__'
 const HISTORY_CAPACITY = 60
 const HISTORY_STALE_MS = 10 * 60 * 1000
+export const MEMORY_HISTORY_MAX_WORKTREES = 1024
 
 type HistoryRing = {
   samples: number[]
@@ -138,18 +139,39 @@ function pushHistorySample(key: string, memoryBytes: number, now: number): void 
   let ring = historyByKey.get(key)
   if (!ring) {
     ring = { samples: [], touchedAt: now }
-    historyByKey.set(key, ring)
   }
   ring.samples.push(memoryBytes)
   if (ring.samples.length > HISTORY_CAPACITY) {
     ring.samples.shift()
   }
   ring.touchedAt = now
+  // Why: worktree ids can churn faster than the stale TTL in a long-lived
+  // main process; recency ordering gives the history cache a hard ceiling.
+  historyByKey.delete(key)
+  historyByKey.set(key, ring)
+  trimWorktreeHistory()
 }
 
-function readHistory(key: string): number[] {
+function trimWorktreeHistory(): void {
+  const appEntryCount = historyByKey.has(APP_HISTORY_KEY) ? 1 : 0
+  while (historyByKey.size - appEntryCount > MEMORY_HISTORY_MAX_WORKTREES) {
+    let oldestWorktreeKey: string | undefined
+    for (const key of historyByKey.keys()) {
+      if (key !== APP_HISTORY_KEY) {
+        oldestWorktreeKey = key
+        break
+      }
+    }
+    if (oldestWorktreeKey === undefined) {
+      break
+    }
+    historyByKey.delete(oldestWorktreeKey)
+  }
+}
+
+function readHistory(key: string, currentSample?: number): number[] {
   const ring = historyByKey.get(key)
-  return ring ? [...ring.samples] : []
+  return ring ? [...ring.samples] : currentSample === undefined ? [] : [currentSample]
 }
 
 function sweepStaleHistory(now: number): void {
@@ -158,6 +180,11 @@ function sweepStaleHistory(now: number): void {
       historyByKey.delete(key)
     }
   }
+}
+
+/** @internal — test-only */
+export function getMemoryHistoryWorktreeCountForTests(): number {
+  return historyByKey.size - (historyByKey.has(APP_HISTORY_KEY) ? 1 : 0)
 }
 
 // ─── Host process enumeration ───────────────────────────────────────
@@ -433,7 +460,9 @@ async function runSnapshot(store: MemorySnapshotStore): Promise<MemorySnapshot> 
 
   const worktrees: WorktreeMemory[] = bucketList.map((b) => ({
     ...b,
-    history: readHistory(b.worktreeId)
+    // Why: an over-cap active worktree still gets its current point even when
+    // an older retained ring had to be evicted during this same snapshot.
+    history: readHistory(b.worktreeId, b.memory)
   }))
 
   let sessionCpuTotal = 0

--- a/src/main/mimo/hook-service.test.ts
+++ b/src/main/mimo/hook-service.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -74,5 +83,48 @@ describe('MimoCodeHookService buildPtyEnv', () => {
     expect(
       readFileSync(join(overlayHome, 'config', 'plugins', 'orca-mimocode-status.js'), 'utf8')
     ).toContain('/hook/mimo-code')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps a symlinked user plugins directory isolated from Orca writes',
+    () => {
+      const sourcePlugins = join(mimocodeHome, 'config', 'plugins')
+      const realPlugins = join(mimocodeHome, 'real-plugins')
+      rmSync(sourcePlugins, { recursive: true, force: true })
+      mkdirSync(realPlugins)
+      writeFileSync(join(realPlugins, 'user-plugin.js'), 'USER PLUGIN')
+      symlinkSync(realPlugins, sourcePlugins, 'dir')
+
+      const env = new MimoCodeHookService().buildPtyEnv('pty-1', mimocodeHome)
+      const overlayPlugins = join(env.MIMOCODE_HOME!, 'config', 'plugins')
+
+      expect(existsSync(join(realPlugins, 'orca-mimocode-status.js'))).toBe(false)
+      expect(lstatSync(overlayPlugins).isSymbolicLink()).toBe(false)
+      expect(readFileSync(join(overlayPlugins, 'user-plugin.js'), 'utf8')).toBe('USER PLUGIN')
+      expect(readFileSync(join(overlayPlugins, 'orca-mimocode-status.js'), 'utf8')).toContain(
+        '/hook/mimo-code'
+      )
+    }
+  )
+
+  it('falls back to the original home when the config plan exceeds capacity', async () => {
+    const mirroring = await import('../pty/config-overlay-mirroring')
+    const planSpy = vi.spyOn(mirroring, 'createConfigOverlayPlan').mockImplementation(() => {
+      throw new mirroring.ConfigOverlayCapacityError('entries', 4_097, 4_096)
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      expect(new MimoCodeHookService().buildPtyEnv('pty-1', mimocodeHome)).toEqual({
+        MIMOCODE_HOME: mimocodeHome
+      })
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[mimocode-hooks] config overlay exceeded its memory limit; using the original MiMo home without Orca status integration'
+      )
+      expect(readFileSync(join(mimocodeHome, 'config', 'mimocode.json'), 'utf8')).toBe(
+        '{"theme":"dark"}'
+      )
+    } finally {
+      planSpy.mockRestore()
+    }
   })
 })

--- a/src/main/mimo/hook-service.ts
+++ b/src/main/mimo/hook-service.ts
@@ -1,9 +1,14 @@
 import { app } from 'electron'
 import { join } from 'node:path'
-import { existsSync, mkdirSync, readdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { getOpenCodeFamilyPluginSource } from '../opencode/hook-service'
-import { mirrorEntry, safeRemoveTree } from '../pty/overlay-mirror'
+import {
+  ConfigOverlayCapacityError,
+  applyConfigOverlayPlan,
+  createConfigOverlayPlan
+} from '../pty/config-overlay-mirroring'
+import { safeRemoveTree } from '../pty/overlay-mirror'
 
 const ORCA_MIMOCODE_PLUGIN_FILE = 'orca-mimocode-status.js'
 const MIMOCODE_HOOKS_DIR = 'mimocode-hooks'
@@ -24,30 +29,9 @@ function resolveSourceConfigDir(existingHome: string | undefined): string | unde
   return existsSync(xdg) ? xdg : undefined
 }
 
-function mirrorConfigDir(sourceConfigDir: string, targetConfigDir: string): void {
-  mkdirSync(targetConfigDir, { recursive: true })
-  for (const entry of readdirSync(sourceConfigDir, { withFileTypes: true })) {
-    if (entry.name === 'plugins' && entry.isDirectory()) {
-      const overlayPlugins = join(targetConfigDir, 'plugins')
-      mkdirSync(overlayPlugins, { recursive: true })
-      for (const pluginEntry of readdirSync(join(sourceConfigDir, 'plugins'), {
-        withFileTypes: true
-      })) {
-        if (pluginEntry.name === ORCA_MIMOCODE_PLUGIN_FILE) {
-          continue
-        }
-        mirrorEntry(
-          join(sourceConfigDir, 'plugins', pluginEntry.name),
-          join(overlayPlugins, pluginEntry.name)
-        )
-      }
-      continue
-    }
-    mirrorEntry(join(sourceConfigDir, entry.name), join(targetConfigDir, entry.name))
-  }
-}
-
 export class MimoCodeHookService {
+  private warnedOverlayCapacity = false
+
   clearPty(_ptyId: string): void {}
 
   buildPtyEnv(_ptyId: string, existingMimocodeHome?: string): Record<string, string> {
@@ -61,16 +45,33 @@ export class MimoCodeHookService {
       const overlayConfig = join(home, 'config')
       const sourceConfig = resolveSourceConfigDir(existingMimocodeHome)
       if (sourceConfig) {
-        safeRemoveTree(overlayConfig)
-        mirrorConfigDir(sourceConfig, overlayConfig)
+        const plan = createConfigOverlayPlan(sourceConfig, {
+          reservedPluginFile: ORCA_MIMOCODE_PLUGIN_FILE
+        })
+        if (!safeRemoveTree(overlayConfig)) {
+          throw new Error('Unable to clear the MiMo config overlay')
+        }
+        mkdirSync(overlayConfig, { recursive: true })
+        applyConfigOverlayPlan(plan, overlayConfig)
       }
       const pluginsDir = join(home, 'config', 'plugins')
       mkdirSync(pluginsDir, { recursive: true })
-      writeFileSync(
-        join(pluginsDir, ORCA_MIMOCODE_PLUGIN_FILE),
-        getOpenCodeFamilyPluginSource('/hook/mimo-code')
-      )
-    } catch {
+      const pluginPath = join(pluginsDir, ORCA_MIMOCODE_PLUGIN_FILE)
+      try {
+        unlinkSync(pluginPath)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+          throw error
+        }
+      }
+      writeFileSync(pluginPath, getOpenCodeFamilyPluginSource('/hook/mimo-code'))
+    } catch (error) {
+      if (!this.warnedOverlayCapacity && error instanceof ConfigOverlayCapacityError) {
+        this.warnedOverlayCapacity = true
+        console.warn(
+          '[mimocode-hooks] config overlay exceeded its memory limit; using the original MiMo home without Orca status integration'
+        )
+      }
       return existingMimocodeHome ? { MIMOCODE_HOME: existingMimocodeHome } : {}
     }
     return { MIMOCODE_HOME: home }

--- a/src/main/minimax/minimax-cookie-store.test.ts
+++ b/src/main/minimax/minimax-cookie-store.test.ts
@@ -22,8 +22,11 @@ const homedirMock = vi.fn(() => '/home/test')
 
 vi.mock('node:fs', () => ({
   existsSync: existsSyncMock,
-  readFileSync: readFileSyncMock,
   rmSync: rmSyncMock
+}))
+
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileSync: readFileSyncMock
 }))
 
 vi.mock('node:os', () => ({

--- a/src/main/minimax/minimax-cookie-store.ts
+++ b/src/main/minimax/minimax-cookie-store.ts
@@ -1,8 +1,9 @@
 import { safeStorage } from 'electron'
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, rmSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { hardenExistingSecureFile, writeSecureFile } from '../../shared/secure-file'
+import { readIntegrationCredentialFileSync } from '../integration-credential-file'
 
 const MINIMAX_COOKIE_FILE = 'minimax-session-cookie.enc'
 const COOKIE_ENVELOPE_PREFIX = 'orca-minimax-cookie:v1:'
@@ -149,7 +150,7 @@ export function readMiniMaxSessionCookie(): string | null {
     console.warn('[minimax] Failed to harden MiniMax cookie file while reading', error)
   }
   try {
-    const raw = readFileSync(keyPath)
+    const raw = readIntegrationCredentialFileSync(keyPath)
     const envelope = decodeCookieEnvelope(raw)
     cachedMiniMaxCookie = envelope ? readEnvelope(envelope) : readLegacyCookie(raw)
     return cachedMiniMaxCookie

--- a/src/main/network/macos-system-resolver-health.test.ts
+++ b/src/main/network/macos-system-resolver-health.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawn } from 'node:child_process'
 import {
   classifyMacSystemResolverHealth,
+  MAC_RESOLVER_OUTPUT_MAX_BYTES,
   readCurrentProcessMacSystemResolverHealth
 } from './macos-system-resolver-health'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
@@ -108,6 +109,44 @@ resolver #1
 
     await expect(healthPromise).resolves.toBe('unknown')
     expect(child.kill).toHaveBeenCalledTimes(1)
+  })
+
+  it('kills scutil and fails open before decoding oversized output', async () => {
+    mockPlatform('darwin')
+    const child = createMockScutilProcess()
+    vi.mocked(spawn).mockReturnValue(child)
+
+    const healthPromise = readCurrentProcessMacSystemResolverHealth()
+    child.stdout.emit('data', 'x'.repeat(MAC_RESOLVER_OUTPUT_MAX_BYTES + 1))
+
+    await expect(healthPromise).resolves.toBe('unknown')
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.stdout.listenerCount('data')).toBe(0)
+    expect(child.stderr.listenerCount('data')).toBe(0)
+  })
+
+  it('accepts the exact combined output cap across many tiny chunks', async () => {
+    mockPlatform('darwin')
+    const child = createMockScutilProcess()
+    vi.mocked(spawn).mockReturnValue(child)
+
+    const healthPromise = readCurrentProcessMacSystemResolverHealth()
+    const resolverOutput = Buffer.from(
+      'DNS configuration\nresolver #1\n  nameserver[0] : 1.1.1.1\n'
+    )
+    child.stdout.emit('data', resolverOutput)
+    const tinyChunk = Buffer.alloc(16, 0x20)
+    let remainingBytes = MAC_RESOLVER_OUTPUT_MAX_BYTES - resolverOutput.byteLength
+    while (remainingBytes > 0) {
+      const chunk =
+        remainingBytes >= tinyChunk.byteLength ? tinyChunk : tinyChunk.subarray(0, remainingBytes)
+      child.stderr.emit('data', chunk)
+      remainingBytes -= chunk.byteLength
+    }
+    child.emit('close', 0)
+
+    await expect(healthPromise).resolves.toBe('healthy')
+    expect(child.kill).not.toHaveBeenCalled()
   })
 
   it('removes scutil listeners when the timeout settles before child close', async () => {

--- a/src/main/network/macos-system-resolver-health.ts
+++ b/src/main/network/macos-system-resolver-health.ts
@@ -1,7 +1,9 @@
 import { spawn } from 'node:child_process'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 import type { SystemResolverHealth } from '../daemon/types'
 
 const MAC_RESOLVER_CHECK_TIMEOUT_MS = 1_500
+export const MAC_RESOLVER_OUTPUT_MAX_BYTES = 1024 * 1024
 const MAC_NO_DNS_CONFIGURATION_RE = /\bNo DNS configuration available\b/i
 const MAC_DNS_CONFIGURATION_RE = /^DNS configuration\b/m
 const MAC_NAMESERVER_RE = /nameserver\[\d+\]\s*:/m
@@ -24,18 +26,33 @@ export async function readCurrentProcessMacSystemResolverHealth(
   }
 
   return new Promise((resolve) => {
-    let stdout = ''
-    let stderr = ''
+    const stdout = new GrowingByteBuffer()
+    const stderr = new GrowingByteBuffer()
+    let outputBytes = 0
+    let outputLimitExceeded = false
     let settled = false
     let timer: ReturnType<typeof setTimeout> | null = null
     const child = spawn('/usr/sbin/scutil', ['--dns'], {
       stdio: ['ignore', 'pipe', 'pipe']
     })
-    const onStdoutData = (chunk: string): void => {
-      stdout += chunk
+    const retainOutput = (target: GrowingByteBuffer, chunk: Buffer | string): void => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8')
+      if (bytes.byteLength > MAC_RESOLVER_OUTPUT_MAX_BYTES - outputBytes) {
+        outputLimitExceeded = true
+        stdout.clear()
+        stderr.clear()
+        child.kill()
+        finish()
+        return
+      }
+      target.append(bytes)
+      outputBytes += bytes.byteLength
     }
-    const onStderrData = (chunk: string): void => {
-      stderr += chunk
+    const onStdoutData = (chunk: Buffer | string): void => {
+      retainOutput(stdout, chunk)
+    }
+    const onStderrData = (chunk: Buffer | string): void => {
+      retainOutput(stderr, chunk)
     }
     const onAbort = (): void => {
       child.kill('SIGKILL')
@@ -55,7 +72,11 @@ export async function readCurrentProcessMacSystemResolverHealth(
       child.off('error', finish)
       child.off('close', finish)
       signal?.removeEventListener('abort', onAbort)
-      resolve(classifyMacSystemResolverHealth(`${stdout}\n${stderr}`))
+      resolve(
+        outputLimitExceeded
+          ? 'unknown'
+          : classifyMacSystemResolverHealth(`${stdout.takeString()}\n${stderr.takeString()}`)
+      )
     }
     timer = setTimeout(() => {
       child.kill()
@@ -63,8 +84,6 @@ export async function readCurrentProcessMacSystemResolverHealth(
       // cap the RPC even if scutil is slow to exit after SIGTERM.
       finish()
     }, MAC_RESOLVER_CHECK_TIMEOUT_MS)
-    child.stdout.setEncoding('utf8')
-    child.stderr.setEncoding('utf8')
     child.stdout.on('data', onStdoutData)
     child.stderr.on('data', onStderrData)
     child.on('error', finish)

--- a/src/main/pi/agent-status-extension-source.test.ts
+++ b/src/main/pi/agent-status-extension-source.test.ts
@@ -3,6 +3,7 @@ import { runInNewContext } from 'node:vm'
 import ts from 'typescript-api'
 import { describe, expect, it, vi } from 'vitest'
 
+import { GENERATED_NODE_MANAGED_FILE_MAX_BYTES } from '../generated-node-bounded-file-reader'
 import { getPiAgentStatusExtensionSource } from './agent-status-extension-source'
 
 type HookContext = {
@@ -28,11 +29,16 @@ type Harness = {
   spawnMock: ReturnType<typeof vi.fn>
   spawnedChildren: FakeCurlChild[]
   fsMock: {
+    closeSync: ReturnType<typeof vi.fn>
     existsSync: ReturnType<typeof vi.fn>
+    openSync: ReturnType<typeof vi.fn>
+    readSync: ReturnType<typeof vi.fn>
     readFileSync: ReturnType<typeof vi.fn>
+    statSync: ReturnType<typeof vi.fn>
   }
   handlers: Record<string, HookHandler>
   processEnv: Record<string, string | undefined>
+  warnMock: ReturnType<typeof vi.fn>
   callHook: (name: string, event?: unknown, context?: HookContext) => Promise<void>
   // Re-invoke the extension factory in the same process (as Pi does on an
   // in-process extension reload), swapping in the freshly registered handlers.
@@ -62,6 +68,7 @@ function createHarness(args: {
   argv?: string[]
   existsSync?: (path: string) => boolean
   readFileSync?: (path: string, encoding: string) => string
+  statSync?: (path: string) => { ino: number; mtimeMs: number; size: number }
   fetchImpl?: (...params: Parameters<typeof fetch>) => Promise<unknown>
 }): Harness {
   const fetchMock = vi.fn(
@@ -84,14 +91,50 @@ function createHarness(args: {
     return child
   })
 
+  const readFileSyncMock = vi.fn(
+    args.readFileSync ??
+      ((path: string) => {
+        throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+      })
+  )
+  const openFiles = new Map<number, { bytes: Buffer; offset: number }>()
+  let nextDescriptor = 10
   const fsMock = {
     existsSync: vi.fn(args.existsSync ?? (() => false)),
-    readFileSync: vi.fn(
-      args.readFileSync ??
-        ((path: string) => {
-          throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
-        })
-    )
+    readFileSync: readFileSyncMock,
+    statSync: vi.fn(args.statSync ?? (() => ({ ino: 1, mtimeMs: 1, size: 0 }))),
+    openSync: vi.fn((path: string) => {
+      const descriptor = nextDescriptor++
+      openFiles.set(descriptor, {
+        bytes: Buffer.from(String(readFileSyncMock(path, 'utf8')), 'utf8'),
+        offset: 0
+      })
+      return descriptor
+    }),
+    readSync: vi.fn(
+      (
+        descriptor: number,
+        target: Buffer,
+        offset: number,
+        length: number,
+        position: number | null
+      ) => {
+        const opened = openFiles.get(descriptor)
+        if (!opened) {
+          throw new Error(`bad descriptor: ${descriptor}`)
+        }
+        const start = position ?? opened.offset
+        const bytesRead = Math.min(length, Math.max(0, opened.bytes.byteLength - start))
+        opened.bytes.copy(target, offset, start, start + bytesRead)
+        if (position === null) {
+          opened.offset += bytesRead
+        }
+        return bytesRead
+      }
+    ),
+    closeSync: vi.fn((descriptor: number) => {
+      openFiles.delete(descriptor)
+    })
   }
 
   const module = {
@@ -117,6 +160,7 @@ function createHarness(args: {
     argv: args.argv ?? ['node', '/usr/bin/orca']
   }
 
+  const warnMock = vi.fn()
   const context = {
     module,
     exports: module.exports,
@@ -124,7 +168,7 @@ function createHarness(args: {
     process: processMock,
     fetch: fetchMock,
     console: {
-      warn: vi.fn(),
+      warn: warnMock,
       error: vi.fn(),
       log: vi.fn()
     },
@@ -168,6 +212,7 @@ function createHarness(args: {
     fsMock,
     handlers,
     processEnv: processMock.env,
+    warnMock,
     callHook: async (name, event, hookContext) => {
       await handlers[name]?.(event, hookContext)
     },
@@ -181,6 +226,72 @@ function createHarness(args: {
 }
 
 describe('getPiAgentStatusExtensionSource', () => {
+  it('routes every whole-file runtime probe through the emitted bounded reader', () => {
+    const source = getPiAgentStatusExtensionSource('pi')
+
+    expect(source).toContain(
+      `function readOrcaManagedFileWithinLimit(fs: any, path: string, maxBytes = ${GENERATED_NODE_MANAGED_FILE_MAX_BYTES})`
+    )
+    expect(source).not.toContain('readFileSync')
+  })
+
+  it('uses an ordinary endpoint file before the stale process environment', async () => {
+    const endpointPath = '/tmp/orca-endpoint.env'
+    const endpoint =
+      'ORCA_AGENT_HOOK_PORT=9876\nORCA_AGENT_HOOK_TOKEN=fresh-token\nORCA_AGENT_HOOK_ENV=fresh-env\n'
+    const harness = createHarness({
+      kind: 'pi',
+      env: { ORCA_AGENT_HOOK_ENDPOINT: endpointPath },
+      readFileSync: (path) => {
+        if (path === endpointPath) {
+          return endpoint
+        }
+        throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+      },
+      statSync: () => ({ ino: 1, mtimeMs: 1, size: Buffer.byteLength(endpoint) })
+    })
+
+    await harness.callHook('agent_start')
+
+    expect(harness.fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:9876/hook/pi',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Orca-Agent-Hook-Token': 'fresh-token'
+        })
+      })
+    )
+  })
+
+  it('fails open to process env when the endpoint file exceeds the generated byte cap', async () => {
+    const endpointPath = '/tmp/orca-endpoint.env'
+    const oversized = 'x'.repeat(GENERATED_NODE_MANAGED_FILE_MAX_BYTES + 1)
+    const harness = createHarness({
+      kind: 'pi',
+      env: { ORCA_AGENT_HOOK_ENDPOINT: endpointPath },
+      readFileSync: (path) => {
+        if (path === endpointPath) {
+          return oversized
+        }
+        throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+      },
+      statSync: () => ({ ino: 1, mtimeMs: 1, size: oversized.length })
+    })
+
+    await harness.callHook('agent_start')
+
+    expect(harness.fetchMock).toHaveBeenCalledWith(
+      'http://127.0.0.1:4321/hook/pi',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-Orca-Agent-Hook-Token': 'token-1'
+        })
+      })
+    )
+    expect(harness.warnMock).toHaveBeenCalledOnce()
+    expect(harness.fsMock.closeSync).toHaveBeenCalledOnce()
+  })
+
   it('includes the session id and file path in Pi status posts after session_start', async () => {
     const harness = createHarness({
       kind: 'pi',

--- a/src/main/pi/agent-status-extension-source.ts
+++ b/src/main/pi/agent-status-extension-source.ts
@@ -11,6 +11,7 @@
 // keep the source body in plain JS without TS types and avoid pulling pi or
 // any Orca dep into the pi runtime.
 import type { PiAgentKind } from '../../shared/pi-agent-kind'
+import { getGeneratedNodeBoundedFileReaderSourceLines } from '../generated-node-bounded-file-reader'
 import { getPiAgentStatusHandlerSourceLines } from './agent-status-handler-source'
 
 export const ORCA_PI_AGENT_STATUS_EXTENSION_FILE = 'orca-agent-status.ts'
@@ -65,6 +66,7 @@ export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): strin
     '// critical path, and the latest-only pending slot prevents a stalled',
     '// Orca receiver from building an unbounded queue of obsolete snapshots.',
     'const HOOK_POST_TIMEOUT_MS = 1000',
+    ...getGeneratedNodeBoundedFileReaderSourceLines({ typed: true }),
     'let activePost = false',
     'let pendingPost: { hookEventName: string; extra: Record<string, unknown> } | null = null',
     ...sessionMetadataSourceLines,
@@ -86,7 +88,7 @@ export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): strin
     '      if (cacheKey === cachedEndpointKey && cachedEndpointValues) {',
     '        return cachedEndpointValues',
     '      }',
-    "      const contents: string = fs.readFileSync(path, 'utf8')",
+    '      const contents = readOrcaManagedFileWithinLimit(fs, path)',
     '      const out: Record<string, string> = {}',
     '      for (const line of contents.split(/\\r?\\n/)) {',
     '        // Why: parse `KEY=VALUE` (POSIX endpoint.env) and `set KEY=VALUE`',
@@ -232,7 +234,7 @@ export function getPiAgentStatusExtensionSource(kind: PiAgentKind = 'pi'): strin
     "    const fs = require('fs')",
     "    for (const path of ['/proc/sys/kernel/osrelease', '/proc/version']) {",
     '      try {',
-    "        const contents = String(fs.readFileSync(path, 'utf8'))",
+    '        const contents = readOrcaManagedFileWithinLimit(fs, path)',
     '        if (/microsoft|wsl/i.test(contents)) return true',
     '      } catch {',
     '        // Why: probe the next runtime hint when a proc file is absent or unreadable.',

--- a/src/main/pi/legacy-omp-overlay-migration-bounds.test.ts
+++ b/src/main/pi/legacy-omp-overlay-migration-bounds.test.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_DEPTH,
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_ENTRIES,
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_PATH_BYTES,
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_RETAINED_PATH_BYTES,
+  migrateLegacyOmpOverlayState
+} from './legacy-omp-overlay-migration'
+
+const roots: string[] = []
+const MARKER = '.orca-omp-overlay-migration-complete'
+
+function tempPair(): { overlay: string; source: string } {
+  const root = mkdtempSync(join(tmpdir(), 'orca-legacy-overlay-bounds-'))
+  roots.push(root)
+  const overlay = join(root, 'overlay')
+  const source = join(root, 'source')
+  mkdirSync(overlay)
+  return { overlay, source }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('legacy OMP overlay migration bounds', () => {
+  it('publishes finite production traversal and retention limits', () => {
+    expect(LEGACY_OMP_OVERLAY_MIGRATION_MAX_ENTRIES).toBe(100_000)
+    expect(LEGACY_OMP_OVERLAY_MIGRATION_MAX_DEPTH).toBe(256)
+    expect(LEGACY_OMP_OVERLAY_MIGRATION_MAX_PATH_BYTES).toBe(64 * 1_024)
+    expect(LEGACY_OMP_OVERLAY_MIGRATION_MAX_RETAINED_PATH_BYTES).toBe(16 * 1_024 * 1_024)
+  })
+
+  it('marks a migration at the exact entry limit', () => {
+    const { overlay, source } = tempPair()
+    writeFileSync(join(overlay, 'one'), '1')
+    writeFileSync(join(overlay, 'two'), '2')
+
+    migrateLegacyOmpOverlayState(source, overlay, { maxEntries: 2 })
+
+    expect(readFileSync(join(source, 'one'), 'utf8')).toBe('1')
+    expect(readFileSync(join(source, 'two'), 'utf8')).toBe('2')
+    expect(existsSync(join(overlay, MARKER))).toBe(true)
+  })
+
+  it('withholds the marker when the next streamed entry exceeds the limit', () => {
+    const { overlay, source } = tempPair()
+    writeFileSync(join(overlay, 'one'), '1')
+    writeFileSync(join(overlay, 'two'), '2')
+    writeFileSync(join(overlay, 'three'), '3')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    migrateLegacyOmpOverlayState(source, overlay, { maxEntries: 2 })
+
+    expect(existsSync(join(overlay, MARKER))).toBe(false)
+    expect(existsSync(join(source, 'one'))).toBe(false)
+    expect(existsSync(join(source, 'two'))).toBe(false)
+    expect(existsSync(join(source, 'three'))).toBe(false)
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[pi-titlebar-extension] failed to migrate legacy OMP overlay state:',
+      expect.objectContaining({ name: 'LegacyOverlayMigrationCapacityError' })
+    )
+  })
+
+  it('accepts the exact path and retained-path byte boundaries', () => {
+    const exact = tempPair()
+    const exactOverlayPath = join(exact.overlay, 'state')
+    const exactTargetPath = join(exact.source, 'state')
+    writeFileSync(exactOverlayPath, 'state')
+    const exactPathBytes = Math.max(
+      Buffer.byteLength(exactOverlayPath, 'utf8'),
+      Buffer.byteLength(exactTargetPath, 'utf8')
+    )
+    const exactRetainedBytes = Buffer.byteLength(exactTargetPath, 'utf8')
+
+    migrateLegacyOmpOverlayState(exact.source, exact.overlay, {
+      maxPathBytes: exactPathBytes,
+      maxRetainedPathBytes: exactRetainedBytes
+    })
+
+    expect(readFileSync(exactTargetPath, 'utf8')).toBe('state')
+    expect(existsSync(join(exact.overlay, MARKER))).toBe(true)
+
+    const rejected = tempPair()
+    const rejectedOverlayPath = join(rejected.overlay, 'state')
+    const rejectedTargetPath = join(rejected.source, 'state')
+    writeFileSync(rejectedOverlayPath, 'state')
+    const retainedLimit = Buffer.byteLength(rejectedTargetPath, 'utf8') - 1
+
+    migrateLegacyOmpOverlayState(rejected.source, rejected.overlay, {
+      maxRetainedPathBytes: retainedLimit
+    })
+
+    expect(existsSync(rejectedTargetPath)).toBe(false)
+    expect(existsSync(join(rejected.overlay, MARKER))).toBe(false)
+  })
+
+  it('accepts the exact path depth and rejects the next level', () => {
+    const accepted = tempPair()
+    mkdirSync(join(accepted.overlay, 'one', 'two'), { recursive: true })
+    writeFileSync(join(accepted.overlay, 'one', 'two', 'leaf'), 'leaf')
+
+    migrateLegacyOmpOverlayState(accepted.source, accepted.overlay, { maxDepth: 3 })
+
+    expect(readFileSync(join(accepted.source, 'one', 'two', 'leaf'), 'utf8')).toBe('leaf')
+    expect(existsSync(join(accepted.overlay, MARKER))).toBe(true)
+
+    const rejected = tempPair()
+    mkdirSync(join(rejected.overlay, 'one', 'two'), { recursive: true })
+    writeFileSync(join(rejected.overlay, 'one', 'two', 'leaf'), 'leaf')
+
+    migrateLegacyOmpOverlayState(rejected.source, rejected.overlay, { maxDepth: 2 })
+
+    expect(existsSync(join(rejected.overlay, MARKER))).toBe(false)
+  })
+})

--- a/src/main/pi/legacy-omp-overlay-migration-budget.ts
+++ b/src/main/pi/legacy-omp-overlay-migration-budget.ts
@@ -1,0 +1,98 @@
+export const LEGACY_OMP_OVERLAY_MIGRATION_MAX_ENTRIES = 100_000
+export const LEGACY_OMP_OVERLAY_MIGRATION_MAX_DEPTH = 256
+export const LEGACY_OMP_OVERLAY_MIGRATION_MAX_PATH_BYTES = 64 * 1_024
+export const LEGACY_OMP_OVERLAY_MIGRATION_MAX_RETAINED_PATH_BYTES = 16 * 1_024 * 1_024
+
+export type LegacyOverlayMigrationLimits = {
+  maxDepth: number
+  maxEntries: number
+  maxPathBytes: number
+  maxRetainedPathBytes: number
+}
+
+const DEFAULT_LIMITS: LegacyOverlayMigrationLimits = {
+  maxDepth: LEGACY_OMP_OVERLAY_MIGRATION_MAX_DEPTH,
+  maxEntries: LEGACY_OMP_OVERLAY_MIGRATION_MAX_ENTRIES,
+  maxPathBytes: LEGACY_OMP_OVERLAY_MIGRATION_MAX_PATH_BYTES,
+  maxRetainedPathBytes: LEGACY_OMP_OVERLAY_MIGRATION_MAX_RETAINED_PATH_BYTES
+}
+
+export class LegacyOverlayMigrationCapacityError extends Error {
+  constructor(kind: string, observed: number, limit: number) {
+    super(`Legacy OMP overlay ${kind} exceeded its ${limit} limit (observed ${observed})`)
+    this.name = 'LegacyOverlayMigrationCapacityError'
+  }
+}
+
+export class LegacyOverlayMigrationBudget {
+  private entries = 0
+  private retainedPathBytes = 0
+  readonly limits: LegacyOverlayMigrationLimits
+
+  constructor(requested?: Partial<LegacyOverlayMigrationLimits>) {
+    this.limits = {
+      maxDepth: resolveLimit(requested?.maxDepth, DEFAULT_LIMITS.maxDepth, 'maxDepth'),
+      maxEntries: resolveLimit(requested?.maxEntries, DEFAULT_LIMITS.maxEntries, 'maxEntries'),
+      maxPathBytes: resolveLimit(
+        requested?.maxPathBytes,
+        DEFAULT_LIMITS.maxPathBytes,
+        'maxPathBytes'
+      ),
+      maxRetainedPathBytes: resolveLimit(
+        requested?.maxRetainedPathBytes,
+        DEFAULT_LIMITS.maxRetainedPathBytes,
+        'maxRetainedPathBytes'
+      )
+    }
+  }
+
+  visit(depth: number, ...paths: string[]): void {
+    const nextEntries = this.entries + 1
+    if (nextEntries > this.limits.maxEntries) {
+      throw new LegacyOverlayMigrationCapacityError('entries', nextEntries, this.limits.maxEntries)
+    }
+    if (depth > this.limits.maxDepth) {
+      throw new LegacyOverlayMigrationCapacityError('depth', depth, this.limits.maxDepth)
+    }
+    for (const path of paths) {
+      this.measurePath(path)
+    }
+    this.entries = nextEntries
+  }
+
+  retainPaths(...paths: string[]): number {
+    const retainedBytes = paths.reduce((total, path) => total + this.measurePath(path), 0)
+    const nextRetainedBytes = this.retainedPathBytes + retainedBytes
+    if (nextRetainedBytes > this.limits.maxRetainedPathBytes) {
+      throw new LegacyOverlayMigrationCapacityError(
+        'retained-path-bytes',
+        nextRetainedBytes,
+        this.limits.maxRetainedPathBytes
+      )
+    }
+    this.retainedPathBytes = nextRetainedBytes
+    return retainedBytes
+  }
+
+  releasePaths(retainedBytes: number): void {
+    this.retainedPathBytes = Math.max(0, this.retainedPathBytes - retainedBytes)
+  }
+
+  private measurePath(path: string): number {
+    const bytes = Buffer.byteLength(path, 'utf8')
+    if (bytes > this.limits.maxPathBytes) {
+      throw new LegacyOverlayMigrationCapacityError('path-bytes', bytes, this.limits.maxPathBytes)
+    }
+    return bytes
+  }
+}
+
+function resolveLimit(requested: number | undefined, maximum: number, name: string): number {
+  if (requested === undefined) {
+    return maximum
+  }
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+  return Math.min(requested, maximum)
+}

--- a/src/main/pi/legacy-omp-overlay-migration.ts
+++ b/src/main/pi/legacy-omp-overlay-migration.ts
@@ -1,7 +1,11 @@
-import { cpSync, lstatSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
-import type { Dirent, Stats } from 'node:fs'
+import { cpSync, lstatSync, mkdirSync, opendirSync, unlinkSync, writeFileSync } from 'node:fs'
+import type { Stats } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { ORCA_PI_AGENT_STATUS_EXTENSION_FILE } from './agent-status-extension-source'
+import {
+  LegacyOverlayMigrationBudget,
+  type LegacyOverlayMigrationLimits
+} from './legacy-omp-overlay-migration-budget'
 import { ORCA_PI_PREFILL_EXTENSION_FILE } from './prefill-extension-source'
 import { ORCA_PI_EXTENSION_FILE } from './titlebar-extension-source'
 import { isSafeDescendCandidate } from '../pty/overlay-mirror'
@@ -19,8 +23,27 @@ const MANAGED_EXTENSION_FILES = new Set([
 
 type DeferredSidecar = {
   baseTargetPath: string
-  entry: Dirent
-  nextSegments: string[]
+  overlayPath: string
+  retainedBytes: number
+  targetPath: string
+}
+
+export {
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_DEPTH,
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_ENTRIES,
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_PATH_BYTES,
+  LEGACY_OMP_OVERLAY_MIGRATION_MAX_RETAINED_PATH_BYTES
+} from './legacy-omp-overlay-migration-budget'
+export type { LegacyOverlayMigrationLimits } from './legacy-omp-overlay-migration-budget'
+
+function closeDirectory(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ERR_DIR_CLOSED') {
+      throw error
+    }
+  }
 }
 
 function getPathStats(path: string): Stats | undefined {
@@ -64,11 +87,13 @@ function shouldSkipLegacyOverlayEntry(pathSegments: string[]): boolean {
 function copyLegacyFile(
   overlayPath: string,
   targetPath: string,
-  copiedFilePaths: Set<string>
+  copiedFilePaths: Set<string>,
+  budget: LegacyOverlayMigrationBudget
 ): boolean {
   if (getPathStats(targetPath)) {
     return true
   }
+  const retainedBytes = budget.retainPaths(targetPath)
   try {
     mkdirSync(dirname(targetPath), { recursive: true })
     cpSync(overlayPath, targetPath, {
@@ -79,15 +104,21 @@ function copyLegacyFile(
     copiedFilePaths.add(targetPath)
     return true
   } catch {
+    budget.releasePaths(retainedBytes)
     return false
   }
 }
 
-function removeCopiedFiles(paths: string[], copiedFilePaths: Set<string>): void {
+function removeCopiedFiles(
+  paths: string[],
+  copiedFilePaths: Set<string>,
+  budget: LegacyOverlayMigrationBudget
+): void {
   for (const path of paths) {
     if (!copiedFilePaths.delete(path)) {
       continue
     }
+    budget.releasePaths(Buffer.byteLength(path, 'utf8'))
     try {
       unlinkSync(path)
     } catch {
@@ -97,46 +128,50 @@ function removeCopiedFiles(paths: string[], copiedFilePaths: Set<string>): void 
 }
 
 function copyDeferredSidecars(
-  overlayDir: string,
-  sourceAgentDir: string,
+  budget: LegacyOverlayMigrationBudget,
   copiedFilePaths: Set<string>,
   deferredSidecars: DeferredSidecar[]
 ): boolean {
   let completed = true
   const copiedSidecarsByBase = new Map<string, string[]>()
-  for (const { baseTargetPath, entry, nextSegments } of deferredSidecars) {
-    if (!copiedFilePaths.has(baseTargetPath)) {
-      continue
-    }
+  for (const sidecar of deferredSidecars) {
+    const { baseTargetPath, overlayPath, targetPath } = sidecar
+    try {
+      if (!copiedFilePaths.has(baseTargetPath)) {
+        continue
+      }
 
-    const overlayPath = join(overlayDir, entry.name)
-    const targetPath = join(sourceAgentDir, ...nextSegments)
-    const stats = getPathStats(overlayPath)
-    if (!stats) {
-      removeCopiedFiles(
-        [baseTargetPath, ...(copiedSidecarsByBase.get(baseTargetPath) ?? [])],
-        copiedFilePaths
-      )
-      completed = false
-      continue
-    }
-    if (stats.isSymbolicLink() || !stats.isFile()) {
-      continue
-    }
-    const wasCopied = copiedFilePaths.has(targetPath)
-    if (!copyLegacyFile(overlayPath, targetPath, copiedFilePaths)) {
-      removeCopiedFiles(
-        [baseTargetPath, ...(copiedSidecarsByBase.get(baseTargetPath) ?? [])],
-        copiedFilePaths
-      )
-      completed = false
-      continue
-    }
-    if (!wasCopied && copiedFilePaths.has(targetPath)) {
-      copiedSidecarsByBase.set(baseTargetPath, [
-        ...(copiedSidecarsByBase.get(baseTargetPath) ?? []),
-        targetPath
-      ])
+      const stats = getPathStats(overlayPath)
+      if (!stats) {
+        removeCopiedFiles(
+          [baseTargetPath, ...(copiedSidecarsByBase.get(baseTargetPath) ?? [])],
+          copiedFilePaths,
+          budget
+        )
+        completed = false
+        continue
+      }
+      if (stats.isSymbolicLink() || !stats.isFile()) {
+        continue
+      }
+      const wasCopied = copiedFilePaths.has(targetPath)
+      if (!copyLegacyFile(overlayPath, targetPath, copiedFilePaths, budget)) {
+        removeCopiedFiles(
+          [baseTargetPath, ...(copiedSidecarsByBase.get(baseTargetPath) ?? [])],
+          copiedFilePaths,
+          budget
+        )
+        completed = false
+        continue
+      }
+      if (!wasCopied && copiedFilePaths.has(targetPath)) {
+        copiedSidecarsByBase.set(baseTargetPath, [
+          ...(copiedSidecarsByBase.get(baseTargetPath) ?? []),
+          targetPath
+        ])
+      }
+    } finally {
+      budget.releasePaths(sidecar.retainedBytes)
     }
   }
   return completed
@@ -145,78 +180,93 @@ function copyDeferredSidecars(
 function copyMissingLegacyOmpOverlayEntries(
   overlayDir: string,
   sourceAgentDir: string,
-  pathSegments: string[] = [],
-  copiedFilePaths: Set<string> = new Set()
+  pathSegments: string[],
+  copiedFilePaths: Set<string>,
+  budget: LegacyOverlayMigrationBudget
 ): boolean {
   let completed = true
-  let entries: Dirent[]
+  let directory
   try {
-    entries = readdirSync(overlayDir, { withFileTypes: true })
+    directory = opendirSync(overlayDir, { bufferSize: 32 })
   } catch {
     return false
   }
 
   const deferredSidecars: DeferredSidecar[] = []
-  for (const entry of entries) {
-    const nextSegments = [...pathSegments, entry.name]
-    if (shouldSkipLegacyOverlayEntry(nextSegments)) {
-      continue
-    }
-
-    const sidecarBaseName = getSqliteSidecarBaseName(entry.name)
-    if (sidecarBaseName) {
-      deferredSidecars.push({
-        baseTargetPath: join(sourceAgentDir, ...pathSegments, sidecarBaseName),
-        entry,
-        nextSegments
-      })
-      continue
-    }
-
-    const overlayPath = join(overlayDir, entry.name)
-    const targetPath = join(sourceAgentDir, ...nextSegments)
-    const stats = getPathStats(overlayPath)
-    if (!stats) {
-      completed = false
-      continue
-    }
-    if (stats.isSymbolicLink()) {
-      continue
-    }
-    if (stats.isDirectory()) {
-      const targetStats = getPathStats(targetPath)
-      if (targetStats && !isSafeDescendCandidate(targetStats)) {
+  try {
+    while (true) {
+      const entry = directory.readSync()
+      if (entry === null) {
+        break
+      }
+      const nextSegments = [...pathSegments, entry.name]
+      const overlayPath = join(overlayDir, entry.name)
+      const targetPath = join(sourceAgentDir, ...nextSegments)
+      budget.visit(nextSegments.length, overlayPath, targetPath)
+      if (shouldSkipLegacyOverlayEntry(nextSegments)) {
         continue
       }
-      if (!targetStats) {
-        try {
-          mkdirSync(targetPath, { recursive: true })
-        } catch {
-          completed = false
+
+      const sidecarBaseName = getSqliteSidecarBaseName(entry.name)
+      if (sidecarBaseName) {
+        const baseTargetPath = join(sourceAgentDir, ...pathSegments, sidecarBaseName)
+        deferredSidecars.push({
+          baseTargetPath,
+          overlayPath,
+          retainedBytes: budget.retainPaths(baseTargetPath, overlayPath, targetPath),
+          targetPath
+        })
+        continue
+      }
+
+      const stats = getPathStats(overlayPath)
+      if (!stats) {
+        completed = false
+        continue
+      }
+      if (stats.isSymbolicLink()) {
+        continue
+      }
+      if (stats.isDirectory()) {
+        const targetStats = getPathStats(targetPath)
+        if (targetStats && !isSafeDescendCandidate(targetStats)) {
           continue
         }
+        if (!targetStats) {
+          try {
+            mkdirSync(targetPath, { recursive: true })
+          } catch {
+            completed = false
+            continue
+          }
+        }
+        completed =
+          copyMissingLegacyOmpOverlayEntries(
+            overlayPath,
+            sourceAgentDir,
+            nextSegments,
+            copiedFilePaths,
+            budget
+          ) && completed
+        continue
       }
-      completed =
-        copyMissingLegacyOmpOverlayEntries(
-          overlayPath,
-          sourceAgentDir,
-          nextSegments,
-          copiedFilePaths
-        ) && completed
-      continue
+      if (!stats.isFile()) {
+        continue
+      }
+      completed = copyLegacyFile(overlayPath, targetPath, copiedFilePaths, budget) && completed
     }
-    if (!stats.isFile()) {
-      continue
-    }
-    completed = copyLegacyFile(overlayPath, targetPath, copiedFilePaths) && completed
+  } finally {
+    closeDirectory(directory)
   }
 
-  return (
-    copyDeferredSidecars(overlayDir, sourceAgentDir, copiedFilePaths, deferredSidecars) && completed
-  )
+  return copyDeferredSidecars(budget, copiedFilePaths, deferredSidecars) && completed
 }
 
-export function migrateLegacyOmpOverlayState(sourceAgentDir: string, overlayDir: string): void {
+export function migrateLegacyOmpOverlayState(
+  sourceAgentDir: string,
+  overlayDir: string,
+  limits?: Partial<LegacyOverlayMigrationLimits>
+): void {
   // Why: temporary rescue shim for OMP builds from the legacy overlay window.
   // Remove after 2026-08-07 once affected users have had a full upgrade window.
   const overlayStats = getPathStats(overlayDir)
@@ -227,16 +277,23 @@ export function migrateLegacyOmpOverlayState(sourceAgentDir: string, overlayDir:
   if (getPathStats(markerPath)) {
     return
   }
+  const budget = new LegacyOverlayMigrationBudget(limits)
+  const copiedFilePaths = new Set<string>()
   try {
     mkdirSync(sourceAgentDir, { recursive: true })
     // Why: some pre-managed-extension builds pointed OMP at this overlay, so
     // first-login auth/session files can exist only there after an update.
-    if (copyMissingLegacyOmpOverlayEntries(overlayDir, sourceAgentDir)) {
+    if (
+      copyMissingLegacyOmpOverlayEntries(overlayDir, sourceAgentDir, [], copiedFilePaths, budget)
+    ) {
       // Why: legacy source overlays can be large and are intentionally kept
       // for recovery; mark clean migrations so future OMP spawns stay cheap.
       writeFileSync(markerPath, 'complete\n')
     }
   } catch (error) {
+    // Why: a capacity stop must not strand a copied SQLite base without a
+    // deferred sidecar; remove only files this attempt created, then retry later.
+    removeCopiedFiles([...copiedFilePaths], copiedFilePaths, budget)
     console.warn('[pi-titlebar-extension] failed to migrate legacy OMP overlay state:', error)
   }
 }

--- a/src/main/pi/managed-extension-ownership.test.ts
+++ b/src/main/pi/managed-extension-ownership.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  ORCA_MANAGED_PI_EXTENSION_MARKER,
+  PI_MANAGED_EXTENSION_OWNERSHIP_MAX_BYTES,
+  isManagedPiExtensionFile
+} from './managed-extension-ownership'
+
+const roots: string[] = []
+
+function tempFile(contents: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-managed-extension-ownership-'))
+  roots.push(root)
+  const path = join(root, 'orca-agent-status.ts')
+  writeFileSync(path, contents)
+  return path
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('managed Pi extension ownership', () => {
+  it('accepts a marked file at the exact byte limit', () => {
+    const prefix = `// ${ORCA_MANAGED_PI_EXTENSION_MARKER}\n`
+    const path = tempFile(
+      prefix + 'x'.repeat(PI_MANAGED_EXTENSION_OWNERSHIP_MAX_BYTES - prefix.length)
+    )
+
+    expect(isManagedPiExtensionFile(path)).toBe(true)
+  })
+
+  it('treats a marked file one byte over the limit as user-owned', () => {
+    const prefix = `// ${ORCA_MANAGED_PI_EXTENSION_MARKER}\n`
+    const path = tempFile(
+      prefix + 'x'.repeat(PI_MANAGED_EXTENSION_OWNERSHIP_MAX_BYTES - prefix.length + 1)
+    )
+
+    expect(isManagedPiExtensionFile(path)).toBe(false)
+  })
+
+  it('treats missing and unmarked files as user-owned', () => {
+    const path = tempFile('user extension')
+
+    expect(isManagedPiExtensionFile(path)).toBe(false)
+    expect(isManagedPiExtensionFile(`${path}.missing`)).toBe(false)
+  })
+})

--- a/src/main/pi/managed-extension-ownership.ts
+++ b/src/main/pi/managed-extension-ownership.ts
@@ -1,0 +1,21 @@
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+
+export const ORCA_MANAGED_PI_EXTENSION_MARKER = '@orca-managed-pi-extension'
+export const PI_MANAGED_EXTENSION_OWNERSHIP_MAX_BYTES = 1_024 * 1_024
+
+export function withOrcaManagedPiExtensionMarker(source: string): string {
+  return source.includes(ORCA_MANAGED_PI_EXTENSION_MARKER)
+    ? source
+    : `// ${ORCA_MANAGED_PI_EXTENSION_MARKER}\n${source}`
+}
+
+export function isManagedPiExtensionFile(path: string): boolean {
+  try {
+    return readNodeFileSyncWithinLimit(path, PI_MANAGED_EXTENSION_OWNERSHIP_MAX_BYTES)
+      .buffer.toString('utf8')
+      .includes(ORCA_MANAGED_PI_EXTENSION_MARKER)
+  } catch {
+    // Unreadable or oversized files cannot safely be claimed as Orca-owned.
+    return false
+  }
+}

--- a/src/main/pi/titlebar-extension-service.ts
+++ b/src/main/pi/titlebar-extension-service.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { app } from 'electron'
@@ -18,6 +18,10 @@ import {
   safeRemoveOverlay
 } from '../pty/overlay-mirror'
 import { migrateLegacyOmpOverlayState } from './legacy-omp-overlay-migration'
+import {
+  isManagedPiExtensionFile,
+  withOrcaManagedPiExtensionMarker
+} from './managed-extension-ownership'
 import type { PiAgentKind } from '../../shared/pi-agent-kind'
 
 // Why: the Pi test suite imports `isSafeDescendCandidate` from this module's
@@ -27,7 +31,6 @@ import type { PiAgentKind } from '../../shared/pi-agent-kind'
 export const isSafeDescendCandidate = sharedIsSafeDescendCandidate
 
 const PI_AGENT_SUBDIR = 'agent'
-const ORCA_MANAGED_EXTENSION_MARKER = '@orca-managed-pi-extension'
 const OMP_MANAGED_STATUS_EXTENSION_DIR = 'omp-managed-status-extension'
 
 type ManagedExtensionWriteResult = 'written' | 'skipped-user-owned' | 'failed'
@@ -64,12 +67,6 @@ function toSafeOverlayDirName(ptyId: string): string {
   return createHash('sha256').update(ptyId).digest('hex').slice(0, 32)
 }
 
-function withOrcaManagedExtensionMarker(source: string): string {
-  return source.includes(ORCA_MANAGED_EXTENSION_MARKER)
-    ? source
-    : `// ${ORCA_MANAGED_EXTENSION_MARKER}\n${source}`
-}
-
 export class PiTitlebarExtensionService {
   private getOverlayRoot(kind: PiAgentKind): string {
     return join(app.getPath('userData'), OVERLAY_ROOT_DIR_NAME[kind])
@@ -98,16 +95,8 @@ export class PiTitlebarExtensionService {
     safeRemoveOverlay(overlayDir, this.getOverlayRoot(kind))
   }
 
-  private canOverwriteManagedExtension(path: string): boolean {
-    try {
-      return readFileSync(path, 'utf8').includes(ORCA_MANAGED_EXTENSION_MARKER)
-    } catch {
-      return true
-    }
-  }
-
   private writeManagedExtension(path: string, source: string): ManagedExtensionWriteResult {
-    if (existsSync(path) && !this.canOverwriteManagedExtension(path)) {
+    if (existsSync(path) && !isManagedPiExtensionFile(path)) {
       return 'skipped-user-owned'
     }
 
@@ -144,14 +133,14 @@ export class PiTitlebarExtensionService {
 
     this.writeManagedExtension(
       join(extensionsDir, ORCA_PI_EXTENSION_FILE),
-      withOrcaManagedExtensionMarker(getPiTitlebarExtensionSource())
+      withOrcaManagedPiExtensionMarker(getPiTitlebarExtensionSource())
     )
     this.writeManagedExtension(
       join(extensionsDir, ORCA_PI_PREFILL_EXTENSION_FILE),
-      withOrcaManagedExtensionMarker(getPiPrefillExtensionSource(kind))
+      withOrcaManagedPiExtensionMarker(getPiPrefillExtensionSource(kind))
     )
     const statusExtensionPath = join(extensionsDir, ORCA_PI_AGENT_STATUS_EXTENSION_FILE)
-    const statusSource = withOrcaManagedExtensionMarker(getPiAgentStatusExtensionSource(kind))
+    const statusSource = withOrcaManagedPiExtensionMarker(getPiAgentStatusExtensionSource(kind))
     const statusResult = this.writeManagedExtension(statusExtensionPath, statusSource)
 
     return {

--- a/src/main/ports/local-workspace-port-scanner.test.ts
+++ b/src/main/ports/local-workspace-port-scanner.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import path from 'node:path'
+import { LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES } from '../../shared/linux-proc-port-scan-limits'
 import {
   attributePortToWorkspace,
   isContainerProcess,
@@ -109,6 +110,18 @@ describe('local workspace port scanner parsing', () => {
 
     expect(ports).toEqual([{ host: '127.0.0.1', port: 3000, inode: 12345 }])
     expect(usedWhitespaceFieldSplit).toBe(false)
+  })
+
+  it('caps retained Linux proc listeners before process attribution', () => {
+    const rows = Array.from(
+      { length: LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES + 5 },
+      (_, index) =>
+        ` ${index}: 0100007F:${(index + 1).toString(16).padStart(4, '0')} 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 ${index + 1}`
+    )
+
+    expect(parseProcNetTcp(['header', ...rows].join('\n'))).toHaveLength(
+      LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES
+    )
   })
 })
 

--- a/src/main/ports/local-workspace-port-scanner.ts
+++ b/src/main/ports/local-workspace-port-scanner.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the platform-specific scan paths share parsing,
 attribution, and normalization rules that must stay in lockstep. */
 import { execFile } from 'node:child_process'
-import { readFile, readdir, readlink } from 'node:fs/promises'
+import { readlink } from 'node:fs/promises'
 import path from 'node:path'
 import type {
   WorkspacePort,
@@ -10,6 +10,14 @@ import type {
   WorkspacePortScanResult
 } from '../../shared/workspace-ports'
 import { getProcessOutputFields } from '../../shared/process-output-field-scanner'
+import { mapLinuxSocketInodesToPids } from '../../shared/linux-proc-socket-owner-scanner'
+import {
+  createLinuxProcTextReadBudget,
+  LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES,
+  readLinuxProcNetworkTable,
+  readLinuxProcTextWithinBudget,
+  type LinuxProcTextReadBudget
+} from '../../shared/linux-proc-port-scan-limits'
 import { advertisedUrlWatcher, type AdvertisedUrlWatcher } from './advertised-url-watcher'
 import { WorkspacePortScanTimeoutBackoff } from './workspace-port-scan-timeout-backoff'
 
@@ -190,6 +198,9 @@ export function parseProcNetTcp(content: string): { host: string; port: number; 
       continue
     }
     results.push({ ...parsed, inode })
+    if (results.length >= LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES) {
+      break
+    }
   }
   return results
 }
@@ -230,15 +241,18 @@ async function scanLinuxProcPorts(): Promise<RawListeningPort[]> {
     readProcNet('/proc/net/tcp'),
     readProcNet('/proc/net/tcp6')
   ])
-  const sockets = [...tcp4, ...tcp6]
-  const inodeToPid = await mapLinuxInodesToPids(new Set(sockets.map((socket) => socket.inode)))
+  const sockets = [...tcp4, ...tcp6].slice(0, LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES)
+  const inodeToPid = await mapLinuxSocketInodesToPids(
+    new Set(sockets.map((socket) => socket.inode))
+  )
   const metadata = new Map<number, ProcessMetadata>()
+  const metadataBudget = createLinuxProcTextReadBudget()
   const rawPorts: RawListeningPort[] = []
 
   for (const socket of sockets) {
     const pid = inodeToPid.get(socket.inode)
     if (pid != null && !metadata.has(pid)) {
-      metadata.set(pid, await loadLinuxProcessMetadata(pid))
+      metadata.set(pid, await loadLinuxProcessMetadata(pid, metadataBudget))
     }
     rawPorts.push({
       host: socket.host,
@@ -254,59 +268,17 @@ async function scanLinuxProcPorts(): Promise<RawListeningPort[]> {
 async function readProcNet(
   filePath: string
 ): Promise<{ host: string; port: number; inode: number }[]> {
-  try {
-    return parseProcNetTcp(await readFile(filePath, 'utf-8'))
-  } catch {
-    return []
-  }
+  const content = await readLinuxProcNetworkTable(filePath)
+  return content === null ? [] : parseProcNetTcp(content)
 }
 
-async function mapLinuxInodesToPids(inodes: Set<number>): Promise<Map<number, number>> {
-  const result = new Map<number, number>()
-  if (inodes.size === 0) {
-    return result
-  }
-  let pids: string[]
-  try {
-    pids = (await readdir('/proc')).filter((entry) => /^\d+$/.test(entry))
-  } catch {
-    return result
-  }
-
-  for (const pidText of pids) {
-    let fds: string[]
-    try {
-      fds = await readdir(`/proc/${pidText}/fd`)
-    } catch {
-      continue
-    }
-    const pid = Number.parseInt(pidText, 10)
-    for (const fd of fds) {
-      let link: string
-      try {
-        link = await readlink(`/proc/${pidText}/fd/${fd}`)
-      } catch {
-        continue
-      }
-      const match = link.match(/^socket:\[(\d+)\]$/)
-      if (!match) {
-        continue
-      }
-      const inode = Number.parseInt(match[1], 10)
-      if (inodes.has(inode)) {
-        result.set(inode, pid)
-      }
-    }
-  }
-  return result
-}
-
-async function loadLinuxProcessMetadata(pid: number): Promise<ProcessMetadata> {
-  const [comm, cmdline, cwd] = await Promise.all([
-    readTextIfAvailable(`/proc/${pid}/comm`),
-    readTextIfAvailable(`/proc/${pid}/cmdline`),
-    readlink(`/proc/${pid}/cwd`).catch(() => undefined)
-  ])
+async function loadLinuxProcessMetadata(
+  pid: number,
+  budget: LinuxProcTextReadBudget
+): Promise<ProcessMetadata> {
+  const comm = await readLinuxProcTextWithinBudget(`/proc/${pid}/comm`, budget)
+  const cmdline = await readLinuxProcTextWithinBudget(`/proc/${pid}/cmdline`, budget)
+  const cwd = await readlink(`/proc/${pid}/cwd`).catch(() => undefined)
   return {
     processName: comm?.trim() || undefined,
     commandLine: cmdline?.split('\u0000').join(' ').trim() || undefined,
@@ -438,14 +410,6 @@ class CommandTimeoutError extends Error {
 
 function isCommandTimeoutError(error: unknown): boolean {
   return error instanceof CommandTimeoutError
-}
-
-async function readTextIfAvailable(filePath: string): Promise<string | undefined> {
-  try {
-    return await readFile(filePath, 'utf-8')
-  } catch {
-    return undefined
-  }
 }
 
 function enrichPort(

--- a/src/main/rate-limits/auth-filesystem-operation.test.ts
+++ b/src/main/rate-limits/auth-filesystem-operation.test.ts
@@ -1,5 +1,24 @@
 import { describe, expect, it, vi } from 'vitest'
-import { createAuthFilesystemOperation } from './auth-filesystem-operation'
+import {
+  AuthFilesystemOperationLimitError,
+  AuthFilesystemOperationRegistry,
+  createAuthFilesystemOperation,
+  MAX_AUTH_FILESYSTEM_OPERATION_PATH_BYTES,
+  MAX_AUTH_FILESYSTEM_OPERATION_WAITERS,
+  MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES,
+  MAX_QUEUED_WSL_AUTH_OPERATIONS
+} from './auth-filesystem-operation'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
 
 describe('createAuthFilesystemOperation', () => {
   it('serializes WSL aliases by distro and drops an abandoned queued read', async () => {
@@ -115,5 +134,153 @@ describe('createAuthFilesystemOperation', () => {
     resolveDebian('debian')
     await expect(Promise.all([ubuntuWait, debianWait])).resolves.toEqual(['ubuntu', 'debian'])
     expect(fedoraRaw).not.toHaveBeenCalled()
+  })
+
+  it('caps retained operations, coalesces existing paths at saturation, and recovers', async () => {
+    const registry = new AuthFilesystemOperationRegistry<string>()
+    const deferredReads = Array.from({ length: MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES + 1 }, () =>
+      deferred<string>()
+    )
+    const operations = deferredReads
+      .slice(0, MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES)
+      .map((read, index) => registry.getOrCreate(`/auth/${index}`, () => read.promise))
+
+    expect(operations.every((operation) => operation !== null)).toBe(true)
+    expect(registry.size).toBe(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES)
+    expect(registry.getOrCreate('/auth/0', async () => 'duplicate')).toBe(operations[0])
+    const overflowRaw = vi.fn(async () => 'overflow')
+    expect(registry.getOrCreate('/auth/overflow', overflowRaw)).toBeNull()
+    expect(overflowRaw).not.toHaveBeenCalled()
+
+    deferredReads[0]!.resolve('first')
+    await expect(operations[0]!.result).resolves.toBe('first')
+    expect(registry.size).toBe(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES - 1)
+
+    const recovered = registry.getOrCreate(
+      '/auth/recovered',
+      () => deferredReads[MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES]!.promise
+    )
+    expect(recovered).not.toBeNull()
+    expect(registry.size).toBe(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES)
+
+    for (let index = 1; index < MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES; index += 1) {
+      deferredReads[index]!.resolve(`read-${index}`)
+    }
+    deferredReads[MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES]!.resolve('recovered')
+    await Promise.all([
+      ...operations.slice(1).map((operation) => operation!.result),
+      recovered!.result
+    ])
+    expect(registry.size).toBe(0)
+  })
+
+  it('accepts an exact-limit auth path and rejects one byte more without starting it', async () => {
+    const exactPath = 'x'.repeat(MAX_AUTH_FILESYSTEM_OPERATION_PATH_BYTES)
+    const exactRaw = vi.fn(async () => 'exact')
+    const exact = createAuthFilesystemOperation(exactPath, exactRaw)
+    const controller = new AbortController()
+
+    await expect(exact.wait(controller.signal)).resolves.toBe('exact')
+    expect(exactRaw).toHaveBeenCalledOnce()
+
+    const oversizedRaw = vi.fn(async () => 'oversized')
+    const oversized = createAuthFilesystemOperation(`${exactPath}x`, oversizedRaw)
+    await expect(oversized.wait(controller.signal)).rejects.toBeInstanceOf(
+      AuthFilesystemOperationLimitError
+    )
+    expect(oversizedRaw).not.toHaveBeenCalled()
+  })
+
+  it('caps coalesced waiters and admits another after one leaves', async () => {
+    const read = deferred<string>()
+    const operation = createAuthFilesystemOperation('/auth/shared', () => read.promise)
+    const controllers = Array.from(
+      { length: MAX_AUTH_FILESYSTEM_OPERATION_WAITERS },
+      () => new AbortController()
+    )
+    const waits = controllers.map((controller) => operation.wait(controller.signal))
+
+    await expect(operation.wait(new AbortController().signal)).rejects.toBeInstanceOf(
+      AuthFilesystemOperationLimitError
+    )
+
+    const abandoned = new Error('first waiter left')
+    controllers[0]!.abort(abandoned)
+    await expect(waits[0]).rejects.toBe(abandoned)
+    const recovered = operation.wait(new AbortController().signal)
+
+    read.resolve('shared')
+    await expect(recovered).resolves.toBe('shared')
+    await expect(Promise.all(waits.slice(1))).resolves.toEqual(
+      Array.from({ length: MAX_AUTH_FILESYSTEM_OPERATION_WAITERS - 1 }, () => 'shared')
+    )
+  })
+
+  it('caps the WSL wait queue and recovers as soon as a queued operation leaves', async () => {
+    const ubuntuRead = deferred<string>()
+    const debianRead = deferred<string>()
+    const ubuntuRaw = vi.fn(() => ubuntuRead.promise)
+    const debianRaw = vi.fn(() => debianRead.promise)
+    const activeController = new AbortController()
+    const ubuntu = createAuthFilesystemOperation(
+      '\\\\wsl$\\Ubuntu\\home\\alice\\auth.json',
+      ubuntuRaw
+    )
+    const debian = createAuthFilesystemOperation(
+      '\\\\wsl$\\Debian\\home\\alice\\auth.json',
+      debianRaw
+    )
+    const ubuntuWait = ubuntu.wait(activeController.signal)
+    const debianWait = debian.wait(activeController.signal)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(ubuntuRaw).toHaveBeenCalledOnce()
+    expect(debianRaw).toHaveBeenCalledOnce()
+
+    const queuedControllers: AbortController[] = []
+    const queuedWaits: Promise<string>[] = []
+    for (let index = 0; index < MAX_QUEUED_WSL_AUTH_OPERATIONS; index += 1) {
+      const controller = new AbortController()
+      const operation = createAuthFilesystemOperation(
+        `\\\\wsl$\\Queued-${index}\\home\\alice\\auth.json`,
+        async () => `queued-${index}`
+      )
+      queuedControllers.push(controller)
+      queuedWaits.push(operation.wait(controller.signal))
+    }
+
+    const overflowRaw = vi.fn(async () => 'overflow')
+    const overflow = createAuthFilesystemOperation(
+      '\\\\wsl$\\Overflow\\home\\alice\\auth.json',
+      overflowRaw
+    )
+    await expect(overflow.wait(new AbortController().signal)).rejects.toBeInstanceOf(
+      AuthFilesystemOperationLimitError
+    )
+    expect(overflowRaw).not.toHaveBeenCalled()
+
+    const released = new Error('release queue slot')
+    queuedControllers[0]!.abort(released)
+    await expect(queuedWaits[0]).rejects.toBe(released)
+
+    const recoveredController = new AbortController()
+    const recoveredRaw = vi.fn(async () => 'recovered')
+    const recovered = createAuthFilesystemOperation(
+      '\\\\wsl$\\Recovered\\home\\alice\\auth.json',
+      recoveredRaw
+    )
+    const recoveredWait = recovered.wait(recoveredController.signal)
+    const recoveredAbort = new Error('recovered queue entry admitted')
+    recoveredController.abort(recoveredAbort)
+    await expect(recoveredWait).rejects.toBe(recoveredAbort)
+    expect(recoveredRaw).not.toHaveBeenCalled()
+
+    for (const controller of queuedControllers.slice(1)) {
+      controller.abort(new Error('test cleanup'))
+    }
+    await Promise.allSettled(queuedWaits.slice(1))
+    ubuntuRead.resolve('ubuntu')
+    debianRead.resolve('debian')
+    await expect(Promise.all([ubuntuWait, debianWait])).resolves.toEqual(['ubuntu', 'debian'])
   })
 })

--- a/src/main/rate-limits/auth-filesystem-operation.ts
+++ b/src/main/rate-limits/auth-filesystem-operation.ts
@@ -1,9 +1,21 @@
 import { parseWslUncPath } from '../../shared/wsl-paths'
 
 const MAX_CONCURRENT_WSL_AUTH_OPERATIONS = 2
+export const MAX_QUEUED_WSL_AUTH_OPERATIONS = 128
+export const MAX_AUTH_FILESYSTEM_OPERATION_WAITERS = 256
+export const MAX_AUTH_FILESYSTEM_OPERATION_PATH_BYTES = 64 * 1024
+export const MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES = 128
+export const MAX_AUTH_FILESYSTEM_REGISTRY_PATH_BYTES = 8 * 1024 * 1024
 const activeWslOperationDistros = new Set<string>()
 const queuedWslOperations: QueuedWslOperation<unknown>[] = []
 let activeWslOperationCount = 0
+
+export class AuthFilesystemOperationLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'AuthFilesystemOperationLimitError'
+  }
+}
 
 type QueuedWslOperation<T> = {
   distroKey: string
@@ -70,6 +82,13 @@ function scheduleWslAuthFilesystemOperation<T>(
   neededSignal: AbortSignal,
   operation: () => Promise<T>
 ): Promise<T> {
+  if (queuedWslOperations.length >= MAX_QUEUED_WSL_AUTH_OPERATIONS) {
+    return Promise.reject(
+      new AuthFilesystemOperationLimitError(
+        `Auth filesystem queue exceeds ${MAX_QUEUED_WSL_AUTH_OPERATIONS} operations`
+      )
+    )
+  }
   return new Promise<T>((resolve, reject) => {
     const task: QueuedWslOperation<T> = {
       distroKey,
@@ -126,6 +145,19 @@ export type SharedAuthFilesystemOperation<T> = {
   wait: (signal: AbortSignal) => Promise<T>
 }
 
+function rejectedAuthFilesystemOperation<T>(
+  error: AuthFilesystemOperationLimitError
+): SharedAuthFilesystemOperation<T> {
+  const result = Promise.reject<T>(error)
+  void result.catch(() => undefined)
+  return {
+    result,
+    wait(signal) {
+      return Promise.reject(signal.aborted ? getAbortReason(signal) : error)
+    }
+  }
+}
+
 /**
  * Shares one raw operation with all callers for an auth path. WSL paths also
  * serialize by normalized distro because one stuck UNC request per account can
@@ -135,8 +167,15 @@ export function createAuthFilesystemOperation<T>(
   authPath: string,
   operation: () => Promise<T>
 ): SharedAuthFilesystemOperation<T> {
+  if (Buffer.byteLength(authPath, 'utf8') > MAX_AUTH_FILESYSTEM_OPERATION_PATH_BYTES) {
+    return rejectedAuthFilesystemOperation(
+      new AuthFilesystemOperationLimitError(
+        `Auth filesystem path exceeds ${MAX_AUTH_FILESYSTEM_OPERATION_PATH_BYTES} bytes`
+      )
+    )
+  }
   const neededController = new AbortController()
-  const waiters = new Set<symbol>()
+  let waiterCount = 0
   let settled = false
   const result = scheduleAuthFilesystemOperation(authPath, neededController.signal, operation)
   const markSettled = (): void => {
@@ -148,14 +187,23 @@ export function createAuthFilesystemOperation<T>(
     result,
     wait(signal) {
       if (signal.aborted) {
-        if (!settled && waiters.size === 0) {
+        if (!settled && waiterCount === 0) {
           neededController.abort(getAbortReason(signal))
         }
         return Promise.reject(getAbortReason(signal))
       }
 
-      const waiter = Symbol('auth-filesystem-waiter')
-      waiters.add(waiter)
+      if (settled) {
+        return result
+      }
+      if (waiterCount >= MAX_AUTH_FILESYSTEM_OPERATION_WAITERS) {
+        return Promise.reject(
+          new AuthFilesystemOperationLimitError(
+            `Auth filesystem operation exceeds ${MAX_AUTH_FILESYSTEM_OPERATION_WAITERS} waiters`
+          )
+        )
+      }
+      waiterCount += 1
       let onAbort: (() => void) | null = null
       const aborted = new Promise<never>((_resolve, reject) => {
         onAbort = () => reject(getAbortReason(signal))
@@ -165,11 +213,53 @@ export function createAuthFilesystemOperation<T>(
         if (onAbort) {
           signal.removeEventListener('abort', onAbort)
         }
-        waiters.delete(waiter)
-        if (!settled && waiters.size === 0) {
+        waiterCount -= 1
+        if (!settled && waiterCount === 0) {
           neededController.abort(getAbortReason(signal))
         }
       })
     }
+  }
+}
+
+export class AuthFilesystemOperationRegistry<T> {
+  private readonly operations = new Map<string, SharedAuthFilesystemOperation<T>>()
+  private retainedPathBytes = 0
+
+  get size(): number {
+    return this.operations.size
+  }
+
+  getOrCreate(
+    authPath: string,
+    operation: () => Promise<T>
+  ): SharedAuthFilesystemOperation<T> | null {
+    const pathBytes = Buffer.byteLength(authPath, 'utf8')
+    if (pathBytes > MAX_AUTH_FILESYSTEM_OPERATION_PATH_BYTES) {
+      return null
+    }
+    const existing = this.operations.get(authPath)
+    if (existing) {
+      return existing
+    }
+    if (
+      this.operations.size >= MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES ||
+      pathBytes > MAX_AUTH_FILESYSTEM_REGISTRY_PATH_BYTES - this.retainedPathBytes
+    ) {
+      return null
+    }
+
+    const shared = createAuthFilesystemOperation(authPath, operation)
+    this.operations.set(authPath, shared)
+    this.retainedPathBytes += pathBytes
+    const clear = (): void => {
+      if (this.operations.get(authPath) !== shared) {
+        return
+      }
+      this.operations.delete(authPath)
+      this.retainedPathBytes -= pathBytes
+    }
+    void shared.result.then(clear, clear)
+    return shared
   }
 }

--- a/src/main/rate-limits/claude-fetcher.test.ts
+++ b/src/main/rate-limits/claude-fetcher.test.ts
@@ -15,18 +15,25 @@ import {
 } from '../claude-accounts/keychain'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 
-const { netFetchMock, readFileMock, resolveProxyMock, setProxyMock, appGetPathMock } = vi.hoisted(
-  () => ({
-    netFetchMock: vi.fn(),
-    readFileMock: vi.fn(),
-    resolveProxyMock: vi.fn(),
-    setProxyMock: vi.fn(),
-    appGetPathMock: vi.fn()
-  })
-)
+const {
+  netFetchMock,
+  readFileMock,
+  readFileSyncMock,
+  resolveProxyMock,
+  setProxyMock,
+  appGetPathMock
+} = vi.hoisted(() => ({
+  netFetchMock: vi.fn(),
+  readFileMock: vi.fn(),
+  readFileSyncMock: vi.fn(),
+  resolveProxyMock: vi.fn(),
+  setProxyMock: vi.fn(),
+  appGetPathMock: vi.fn()
+}))
 
-vi.mock('node:fs/promises', () => ({
-  readFile: readFileMock
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileSyncText: readFileSyncMock,
+  readIntegrationCredentialFileText: readFileMock
 }))
 
 vi.mock('electron', () => ({
@@ -74,6 +81,7 @@ describe('fetchClaudeRateLimits', () => {
     tempDir = null
     vi.clearAllMocks()
     readFileMock.mockRejectedValue(new Error('missing file'))
+    readFileSyncMock.mockImplementation((filePath: string) => readFileSync(filePath, 'utf8'))
     vi.mocked(readActiveClaudeKeychainCredentials).mockResolvedValue(null)
     vi.mocked(readActiveClaudeKeychainCredentialsStrict).mockResolvedValue(null)
     vi.mocked(readManagedClaudeKeychainCredentials).mockResolvedValue(null)
@@ -744,10 +752,7 @@ describe('fetchClaudeRateLimits', () => {
       status: 'ok'
     })
 
-    expect(readFileMock).toHaveBeenCalledWith(
-      join('/Users/test/.claude', '.credentials.json'),
-      'utf-8'
-    )
+    expect(readFileMock).toHaveBeenCalledWith(join('/Users/test/.claude', '.credentials.json'))
     expect(netFetchMock).toHaveBeenCalledWith(
       'https://api.anthropic.com/api/oauth/usage',
       expect.objectContaining({

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -1,6 +1,5 @@
 /* eslint-disable max-lines -- Why: keep Claude credential ordering, OAuth usage fetch, and PTY fallback together so usage state can't drift across paths. */
-import { existsSync, lstatSync, readFileSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
+import { existsSync, lstatSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { net, session } from 'electron'
@@ -42,6 +41,11 @@ import {
   classifyClaudeOAuthUsageError,
   type ClaudeUsageErrorClassification
 } from './claude-usage-error-classification'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
+import {
+  readIntegrationCredentialFileSyncText,
+  readIntegrationCredentialFileText
+} from '../integration-credential-file'
 
 const OAUTH_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage'
 const OAUTH_BETA_HEADER = 'oauth-2025-04-20'
@@ -193,7 +197,7 @@ async function readCredentialsFromStrictKeychain(
 async function readFromCredentialsFile(configDir?: string): Promise<OAuthCredentialReadResult> {
   const credPath = path.join(configDir ?? path.join(homedir(), '.claude'), '.credentials.json')
   try {
-    const raw = await readFile(credPath, 'utf-8')
+    const raw = await readIntegrationCredentialFileText(credPath)
     return parseOAuthCredentialsJson(raw, 'credentials-file')
   } catch {
     return emptyOAuthCredentialReadResult()
@@ -366,7 +370,7 @@ async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<Provi
       throw await createOAuthUsageError(res)
     }
 
-    const data = (await res.json()) as OAuthUsageResponse
+    const data = await readFetchResponseJsonWithinLimit<OAuthUsageResponse>(res)
     if (signal?.aborted) {
       return abortedClaudeRateLimitResult()
     }
@@ -1042,7 +1046,7 @@ function resolveOwnedWslClaudeManagedAuthPath(account: InactiveClaudeAccountInfo
     if (
       !existsSync(markerPath) ||
       lstatSync(markerPath).isSymbolicLink() ||
-      readFileSync(markerPath, 'utf-8').trim() !== account.id
+      readIntegrationCredentialFileSyncText(markerPath).trim() !== account.id
     ) {
       return null
     }

--- a/src/main/rate-limits/claude-oauth-usage-error.ts
+++ b/src/main/rate-limits/claude-oauth-usage-error.ts
@@ -1,3 +1,5 @@
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
+
 // Why: a corrupt/hostile Retry-After must not gate usage refreshes for days.
 const MAX_RETRY_AFTER_MS = 24 * 60 * 60 * 1000
 
@@ -45,7 +47,7 @@ async function describeOAuthUsageError(res: Response): Promise<string> {
     return 'Claude usage is rate limited right now.'
   }
   try {
-    const data = (await res.json()) as { error?: { message?: string } }
+    const data = await readFetchResponseJsonWithinLimit<{ error?: { message?: string } }>(res)
     if (typeof data.error?.message === 'string' && data.error.message.trim()) {
       return data.error.message
     }

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -13,6 +13,7 @@ import {
   getHiddenRateLimitWslCwdSetupCommands,
   resolveHiddenRateLimitPtyCwd
 } from './hidden-rate-limit-pty-cwd'
+import { appendRateLimitPtyOutputTail } from './rate-limit-pty-output-tail'
 
 const PTY_TIMEOUT_MS = 25_000
 const MAX_OUTPUT_LENGTH = 100_000 // 100KB buffer limit
@@ -441,13 +442,10 @@ export async function fetchViaPty(options?: {
     }, STARTUP_DELAY_MS)
 
     const onDataDisposable = term.onData((data) => {
-      output += data
-      // Why: prevent memory exhaustion if the CLI process floods output
-      if (output.length > MAX_OUTPUT_LENGTH) {
-        output = output.slice(-MAX_OUTPUT_LENGTH)
-      }
+      const appended = appendRateLimitPtyOutputTail(output, data, MAX_OUTPUT_LENGTH)
+      output = appended.output
 
-      const cleanChunk = stripTerminalControlSequences(data)
+      const cleanChunk = stripTerminalControlSequences(appended.scannedChunk)
 
       // Why: the Claude CLI may prompt for first-run setup (trust files,
       // workspace directory). Auto-accept so we can reach /usage.

--- a/src/main/rate-limits/codex-auth-presence.test.ts
+++ b/src/main/rate-limits/codex-auth-presence.test.ts
@@ -15,6 +15,7 @@ vi.mock('node:os', () => ({
 }))
 
 import { probeCodexAuthPresence } from './codex-auth-presence'
+import { MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES } from './auth-filesystem-operation'
 
 function fsError(code: string): NodeJS.ErrnoException {
   return Object.assign(new Error(code), { code })
@@ -151,5 +152,51 @@ describe('probeCodexAuthPresence', () => {
 
     resolveAccess()
     await Promise.resolve()
+  })
+
+  it('caps distinct stalled probes and admits a new path after one settles', async () => {
+    const accessResolvers = new Map<string, () => void>()
+    accessMock.mockImplementation(
+      (path: string) =>
+        new Promise<void>((resolve) => {
+          accessResolvers.set(path, resolve)
+        })
+    )
+    const controllers = Array.from(
+      { length: MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES + 2 },
+      () => new AbortController()
+    )
+    const probes = Array.from({ length: MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES }, (_, index) =>
+      probeCodexAuthPresence(`/managed/${index}`, { signal: controllers[index]!.signal })
+    )
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(accessMock).toHaveBeenCalledTimes(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES)
+    await expect(
+      probeCodexAuthPresence('/managed/overflow', {
+        signal: controllers[MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES]!.signal
+      })
+    ).resolves.toBe('unavailable')
+    expect(accessMock).toHaveBeenCalledTimes(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES)
+
+    accessResolvers.get(join('/managed/0', 'auth.json'))!()
+    await expect(probes[0]).resolves.toBe('present')
+
+    const recovered = probeCodexAuthPresence('/managed/recovered', {
+      signal: controllers[MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES + 1]!.signal
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(accessMock).toHaveBeenCalledTimes(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES + 1)
+    accessResolvers.get(join('/managed/recovered', 'auth.json'))!()
+    await expect(recovered).resolves.toBe('present')
+
+    for (let index = 1; index < MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES; index += 1) {
+      accessResolvers.get(join(`/managed/${index}`, 'auth.json'))!()
+    }
+    await expect(Promise.all(probes.slice(1))).resolves.toEqual(
+      Array.from({ length: MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES - 1 }, () => 'present')
+    )
   })
 })

--- a/src/main/rate-limits/codex-auth-presence.ts
+++ b/src/main/rate-limits/codex-auth-presence.ts
@@ -3,12 +3,12 @@ import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
-  createAuthFilesystemOperation,
+  AuthFilesystemOperationRegistry,
   type SharedAuthFilesystemOperation
 } from './auth-filesystem-operation'
 
 const AUTH_PRESENCE_TIMEOUT_MS = 5_000
-const authPresenceProbeByPath = new Map<string, SharedAuthFilesystemOperation<CodexAuthPresence>>()
+const authPresenceProbes = new AuthFilesystemOperationRegistry<CodexAuthPresence>()
 
 export type CodexAuthPresence = 'present' | 'absent' | 'timeout' | 'unavailable'
 
@@ -22,15 +22,13 @@ function isMissingPathError(error: unknown): boolean {
   return code === 'ENOENT' || code === 'ENOTDIR'
 }
 
-function getAuthPresenceProbe(authPath: string): SharedAuthFilesystemOperation<CodexAuthPresence> {
-  const existing = authPresenceProbeByPath.get(authPath)
-  if (existing) {
-    return existing
-  }
+function getAuthPresenceProbe(
+  authPath: string
+): SharedAuthFilesystemOperation<CodexAuthPresence> | null {
   // Why: aborting a Node fs promise does not necessarily cancel an already
   // issued UNC operation. Share the raw probe until it really settles so a
   // disconnected WSL home cannot accumulate native requests across polls.
-  const probe = createAuthFilesystemOperation(authPath, async () => {
+  return authPresenceProbes.getOrCreate(authPath, async () => {
     try {
       await access(authPath)
       return 'present'
@@ -38,14 +36,6 @@ function getAuthPresenceProbe(authPath: string): SharedAuthFilesystemOperation<C
       return isMissingPathError(error) ? 'absent' : 'unavailable'
     }
   })
-  authPresenceProbeByPath.set(authPath, probe)
-  const clearProbe = (): void => {
-    if (authPresenceProbeByPath.get(authPath) === probe) {
-      authPresenceProbeByPath.delete(authPath)
-    }
-  }
-  void probe.result.then(clearProbe, clearProbe)
-  return probe
 }
 
 // Why: the background quota poller spawns the real `codex` binary to read rate
@@ -68,14 +58,22 @@ export async function probeCodexAuthPresence(
     // Why: managed WSL homes are UNC paths. A synchronous stat can park
     // Electron main while Windows wakes or reconnects the distro; the race
     // also keeps a disconnected distro from serializing all later refreshes.
-    const authPresence = await getAuthPresenceProbe(authPath).wait(signal)
+    const authProbe = getAuthPresenceProbe(authPath)
+    if (!authProbe) {
+      return 'unavailable'
+    }
+    const authPresence = await authProbe.wait(signal)
     if (authPresence !== 'absent' || !parseWslUncPath(home)) {
       return authPresence
     }
 
     // Why: ENOENT on a WSL UNC auth path can mean either a missing auth file or
     // an unavailable distro. Only an accessible Codex home proves signed-out.
-    const homePresence = await getAuthPresenceProbe(home).wait(signal)
+    const homeProbe = getAuthPresenceProbe(home)
+    if (!homeProbe) {
+      return 'unavailable'
+    }
+    const homePresence = await homeProbe.wait(signal)
     return homePresence === 'present' ? 'absent' : 'unavailable'
   } catch {
     return timeoutSignal.aborted && !options.signal?.aborted ? 'timeout' : 'unavailable'

--- a/src/main/rate-limits/codex-fetcher-auth-file-bounds.test.ts
+++ b/src/main/rate-limits/codex-fetcher-auth-file-bounds.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import { MAX_INTEGRATION_CREDENTIAL_FILE_BYTES } from '../integration-credential-file'
+import { consumeCodexRateLimitResetCredit } from './codex-fetcher'
+
+const fetchMock = vi.hoisted(() => vi.fn())
+const roots: string[] = []
+
+function createCodexHome(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-codex-auth-bounds-'))
+  roots.push(root)
+  return root
+}
+
+function successfulConsumeResponse(): Response {
+  return new Response(JSON.stringify({ code: 'already_redeemed' }), {
+    headers: { 'content-type': 'application/json' },
+    status: 200
+  })
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  fetchMock.mockResolvedValue(successfulConsumeResponse())
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('Codex backend auth file bounds', () => {
+  it('preserves normal auth JSON and backend headers', async () => {
+    const codexHomePath = createCodexHome()
+    writeFileSync(
+      join(codexHomePath, 'auth.json'),
+      JSON.stringify({
+        tokens: { access_token: 'normal-token', account_id: 'normal-account' }
+      })
+    )
+
+    await expect(
+      consumeCodexRateLimitResetCredit({
+        codexHomePath,
+        idempotencyKey: 'normal-auth'
+      })
+    ).resolves.toBe('alreadyRedeemed')
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer normal-token',
+          'ChatGPT-Account-Id': 'normal-account'
+        })
+      })
+    )
+  })
+
+  it('accepts valid auth JSON at the exact credential byte limit', async () => {
+    const codexHomePath = createCodexHome()
+    const authPath = join(codexHomePath, 'auth.json')
+    const json = JSON.stringify({
+      tokens: { access_token: 'boundary-token', account_id: 'boundary-account' }
+    })
+    writeFileSync(
+      authPath,
+      json + ' '.repeat(MAX_INTEGRATION_CREDENTIAL_FILE_BYTES - Buffer.byteLength(json))
+    )
+
+    expect(statSync(authPath).size).toBe(MAX_INTEGRATION_CREDENTIAL_FILE_BYTES)
+    await expect(
+      consumeCodexRateLimitResetCredit({
+        codexHomePath,
+        idempotencyKey: 'boundary-auth'
+      })
+    ).resolves.toBe('alreadyRedeemed')
+    expect(fetchMock).toHaveBeenCalledOnce()
+  })
+
+  it('rejects an oversized sparse auth file before making a request', async () => {
+    const codexHomePath = createCodexHome()
+    const authPath = join(codexHomePath, 'auth.json')
+    writeFileSync(authPath, '')
+    truncateSync(authPath, MAX_INTEGRATION_CREDENTIAL_FILE_BYTES + 1)
+
+    await expect(
+      consumeCodexRateLimitResetCredit({
+        codexHomePath,
+        idempotencyKey: 'oversized-auth'
+      })
+    ).rejects.toBeInstanceOf(NodeFileReadTooLargeError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -9,13 +9,19 @@ const { childSpawnMock, readFileMock, ptySpawnMock } = vi.hoisted(() => ({
 }))
 
 vi.mock('node:child_process', () => ({ spawn: childSpawnMock }))
-vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileText: readFileMock
+}))
 vi.mock('node-pty', () => ({ spawn: ptySpawnMock }))
 vi.mock('./codex-auth-presence', () => ({
   probeCodexAuthPresence: vi.fn(async () => 'present')
 }))
 
 import { consumeCodexRateLimitResetCredit, fetchCodexRateLimits } from './codex-fetcher'
+import {
+  AuthFilesystemOperationLimitError,
+  MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES
+} from './auth-filesystem-operation'
 
 describe('Codex backend rate-limit requests', () => {
   beforeEach(() => {
@@ -113,7 +119,7 @@ describe('Codex backend rate-limit requests', () => {
     const second = fetchCodexRateLimits({ codexHomePath, signal: secondController.signal })
     await vi.advanceTimersByTimeAsync(0)
     expect(readFileMock).toHaveBeenCalledTimes(1)
-    expect(readFileMock).toHaveBeenCalledWith(expect.stringContaining('auth.json'), 'utf8')
+    expect(readFileMock).toHaveBeenCalledWith(expect.stringContaining('auth.json'))
 
     firstController.abort()
     secondController.abort()
@@ -154,7 +160,7 @@ describe('Codex backend rate-limit requests', () => {
     await vi.advanceTimersByTimeAsync(0)
     // Why: redeem is user-triggered, so it gets the longer redeem deadline.
     expect(timeout).toHaveBeenCalledWith(30_000)
-    expect(readFileMock).toHaveBeenCalledWith(join('/managed/deadline-home', 'auth.json'), 'utf8')
+    expect(readFileMock).toHaveBeenCalledWith(join('/managed/deadline-home', 'auth.json'))
 
     timeoutController.abort(deadlineError)
 
@@ -216,5 +222,60 @@ describe('Codex backend rate-limit requests', () => {
       })
     ).rejects.toThrow('Codex reset failed: HTTP 429')
     expect(cancelledBodies).toBe(1)
+  })
+
+  it('caps distinct stalled backend auth reads and recovers after one settles', async () => {
+    const authResolvers = new Map<string, (content: string) => void>()
+    readFileMock.mockImplementation(
+      (authPath: string) =>
+        new Promise<string>((resolve) => {
+          authResolvers.set(authPath, resolve)
+        })
+    )
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      json: async () => ({ code: 'already_redeemed' })
+    } as Response)
+    const requests = Array.from({ length: MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES }, (_, index) =>
+      consumeCodexRateLimitResetCredit({
+        codexHomePath: `/managed/saturated-${index}`,
+        idempotencyKey: `saturated-${index}`
+      })
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(readFileMock).toHaveBeenCalledTimes(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES)
+    await expect(
+      consumeCodexRateLimitResetCredit({
+        codexHomePath: '/managed/overflow',
+        idempotencyKey: 'overflow'
+      })
+    ).rejects.toBeInstanceOf(AuthFilesystemOperationLimitError)
+    expect(readFileMock).toHaveBeenCalledTimes(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES)
+
+    const authJson = JSON.stringify({
+      tokens: { access_token: 'capacity-token', account_id: 'capacity-account' }
+    })
+    authResolvers.get(join('/managed/saturated-0', 'auth.json'))!(authJson)
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(requests[0]).resolves.toBe('alreadyRedeemed')
+
+    const recovered = consumeCodexRateLimitResetCredit({
+      codexHomePath: '/managed/recovered',
+      idempotencyKey: 'recovered'
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(readFileMock).toHaveBeenCalledTimes(MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES + 1)
+    authResolvers.get(join('/managed/recovered', 'auth.json'))!(authJson)
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(recovered).resolves.toBe('alreadyRedeemed')
+
+    for (let index = 1; index < MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES; index += 1) {
+      authResolvers.get(join(`/managed/saturated-${index}`, 'auth.json'))!(authJson)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(Promise.all(requests.slice(1))).resolves.toEqual(
+      Array.from({ length: MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES - 1 }, () => 'alreadyRedeemed')
+    )
   })
 })

--- a/src/main/rate-limits/codex-fetcher-rpc-buffer.test.ts
+++ b/src/main/rate-limits/codex-fetcher-rpc-buffer.test.ts
@@ -1,0 +1,123 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, resolveCodexCommandMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(() => 'codex')
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: childSpawnMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('./codex-auth-presence', () => ({
+  probeCodexAuthPresence: vi.fn(async () => 'present')
+}))
+
+import { fetchCodexRateLimits, MAX_RPC_RESPONSE_LINE_BYTES } from './codex-fetcher'
+
+function createRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: { write: ReturnType<typeof vi.fn> }
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdin = { write: vi.fn() }
+  child.kill = vi.fn()
+  return child
+}
+
+describe('Codex RPC response buffering', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('processes a valid response after tens of thousands of tiny stdout chunks', async () => {
+    vi.useRealTimers()
+    const child = createRpcChild()
+    childSpawnMock.mockReturnValue(child)
+    child.stdin.write.mockImplementation((line: string) => {
+      const message = JSON.parse(line) as { id?: number; method?: string }
+      if (message.method === 'initialize') {
+        setTimeout(() => {
+          const noise = Buffer.alloc(1_000_000, 0x78)
+          for (let offset = 0; offset < noise.byteLength; offset += 16) {
+            child.stdout.emit('data', noise.subarray(offset, offset + 16))
+          }
+          child.stdout.emit(
+            'data',
+            Buffer.from(`\n${JSON.stringify({ jsonrpc: '2.0', id: message.id, result: {} })}\n`)
+          )
+        }, 0)
+      }
+      if (message.method === 'account/rateLimits/read') {
+        setTimeout(() => {
+          child.stdout.emit(
+            'data',
+            Buffer.from(
+              `${JSON.stringify({
+                jsonrpc: '2.0',
+                id: message.id,
+                result: {
+                  rateLimits: {
+                    primary: { usedPercent: 7 },
+                    secondary: { usedPercent: 12 }
+                  },
+                  rateLimitResetCredits: {
+                    availableCount: 0,
+                    nextExpiresAt: Date.now() + 60_000
+                  }
+                }
+              })}\n`
+            )
+          )
+        }, 0)
+      }
+      return true
+    })
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'ok',
+      session: { usedPercent: 7 },
+      weekly: { usedPercent: 12 }
+    })
+  })
+
+  it('kills the RPC process before retaining an oversized line', async () => {
+    vi.useRealTimers()
+    const child = createRpcChild()
+    childSpawnMock.mockReturnValue(child)
+    child.stdin.write.mockImplementation((line: string) => {
+      const message = JSON.parse(line) as { method?: string }
+      if (message.method === 'initialize') {
+        setTimeout(() => {
+          child.stdout.emit('data', Buffer.alloc(MAX_RPC_RESPONSE_LINE_BYTES + 1, 0x78))
+        }, 0)
+      }
+      return true
+    })
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'error',
+      error: `RPC response exceeded ${MAX_RPC_RESPONSE_LINE_BYTES} byte line limit`
+    })
+    expect(child.kill).toHaveBeenCalledOnce()
+    expect(child.stdout.listenerCount('data')).toBe(0)
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.test.ts
+++ b/src/main/rate-limits/codex-fetcher.test.ts
@@ -13,8 +13,8 @@ vi.mock('node:child_process', () => ({
   spawn: childSpawnMock
 }))
 
-vi.mock('node:fs/promises', () => ({
-  readFile: readFileMock
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileText: readFileMock
 }))
 
 vi.mock('../codex-cli/command', () => ({
@@ -496,7 +496,7 @@ describe('fetchCodexRateLimits', () => {
         }
       ]
     })
-    expect(readFileMock).toHaveBeenCalledWith(join('/managed/codex-home', 'auth.json'), 'utf8')
+    expect(readFileMock).toHaveBeenCalledWith(join('/managed/codex-home', 'auth.json'))
     expect(fetch).toHaveBeenCalledWith(
       'https://chatgpt.com/backend-api/wham/rate-limit-reset-credits',
       expect.objectContaining({

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -5,9 +5,10 @@ import type {
   RateLimitWindow
 } from '../../shared/rate-limit-types'
 import { spawn } from 'node:child_process'
-import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
+import { readIntegrationCredentialFileText } from '../integration-credential-file'
 import { join } from 'node:path'
 import { probeCodexAuthPresence } from './codex-auth-presence'
 import {
@@ -32,9 +33,12 @@ import {
   resolveHiddenRateLimitPtyCwd
 } from './hidden-rate-limit-pty-cwd'
 import {
-  createAuthFilesystemOperation,
+  AuthFilesystemOperationLimitError,
+  AuthFilesystemOperationRegistry,
   type SharedAuthFilesystemOperation
 } from './auth-filesystem-operation'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
+import { appendRateLimitPtyOutputTail } from './rate-limit-pty-output-tail'
 
 const RPC_TIMEOUT_MS = 10_000
 const WSL_RPC_TIMEOUT_MS = 25_000
@@ -43,6 +47,7 @@ const BACKEND_TIMEOUT_MS = 10_000
 // Why: redeeming a reset credit is an explicit user action, not a poll — allow more time for a slow backend.
 const REDEEM_BACKEND_TIMEOUT_MS = 30_000
 const MAX_DIAGNOSTIC_OUTPUT_LENGTH = 100_000
+export const MAX_RPC_RESPONSE_LINE_BYTES = 4 * 1024 * 1024
 
 export type FetchCodexRateLimitsOptions = {
   codexHomePath?: string | null
@@ -130,10 +135,7 @@ type BackendAuthReadResult =
   | { content: string; error?: never }
   | { content?: never; error: unknown }
 
-const backendAuthReadByPath = new Map<
-  string,
-  SharedAuthFilesystemOperation<BackendAuthReadResult>
->()
+const backendAuthReads = new AuthFilesystemOperationRegistry<BackendAuthReadResult>()
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
@@ -292,30 +294,22 @@ function createBackendRequestSignal(
 
 function getBackendAuthRead(
   authPath: string
-): SharedAuthFilesystemOperation<BackendAuthReadResult> {
-  const existing = backendAuthReadByPath.get(authPath)
-  if (existing) {
-    return existing
-  }
+): SharedAuthFilesystemOperation<BackendAuthReadResult> | null {
   // Why: Node can't cancel an in-flight UNC read; keep one read per auth path so repeated refreshes don't stack them.
-  const read = createAuthFilesystemOperation(authPath, () =>
-    readFile(authPath, 'utf8').then(
+  return backendAuthReads.getOrCreate(authPath, () =>
+    readIntegrationCredentialFileText(authPath).then(
       (content) => ({ content }),
       (error: unknown) => ({ error })
     )
   )
-  backendAuthReadByPath.set(authPath, read)
-  const clearRead = (): void => {
-    if (backendAuthReadByPath.get(authPath) === read) {
-      backendAuthReadByPath.delete(authPath)
-    }
-  }
-  void read.result.then(clearRead, clearRead)
-  return read
 }
 
 async function readBackendAuth(authPath: string, signal: AbortSignal): Promise<string> {
-  const result = await getBackendAuthRead(authPath).wait(signal)
+  const read = getBackendAuthRead(authPath)
+  if (!read) {
+    throw new AuthFilesystemOperationLimitError('Codex backend auth read capacity exceeded')
+  }
+  const result = await read.wait(signal)
   if ('error' in result) {
     throw result.error
   }
@@ -371,7 +365,8 @@ async function fetchBackendRateLimitResetCredits(
     await cancelUnreadResponseBody(response)
     return null
   }
-  const payload = (await response.json()) as BackendRateLimitResetCreditsResponse
+  const payload =
+    await readFetchResponseJsonWithinLimit<BackendRateLimitResetCreditsResponse>(response)
   return mapBackendRateLimitResetCredits(payload) ?? null
 }
 
@@ -439,7 +434,8 @@ export async function consumeCodexRateLimitResetCredit(options: {
     await cancelUnreadResponseBody(response)
     throw new Error(`Codex reset failed: HTTP ${response.status}`)
   }
-  const payload = (await response.json()) as BackendConsumeRateLimitResetCreditResponse
+  const payload =
+    await readFetchResponseJsonWithinLimit<BackendConsumeRateLimitResetCreditResponse>(response)
   return mapBackendConsumeOutcome(payload.code)
 }
 
@@ -519,7 +515,7 @@ async function fetchViaBackend(
     await cancelUnreadResponseBody(response)
     return null
   }
-  const payload = (await response.json()) as BackendUsageResponse
+  const payload = await readFetchResponseJsonWithinLimit<BackendUsageResponse>(response)
   // Why: plan_type is required by Codex's RateLimitStatusPayload; reject malformed JSON so the app-server fallback still runs.
   if (typeof payload.plan_type !== 'string') {
     return null
@@ -551,8 +547,8 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     return abortedCodexRateLimitResult()
   }
   return new Promise<ProviderRateLimits>((resolve) => {
-    let buffer = ''
-    let stderr = ''
+    const buffer = new GrowingByteBuffer()
+    const stderr = new GrowingByteBuffer()
     let resolved = false
     let rpcId = 0
 
@@ -599,6 +595,8 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       }
       resolved = true
       cleanupListeners()
+      buffer.clear()
+      stderr.clear()
       if (options?.kill) {
         child.kill()
       }
@@ -649,13 +647,34 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     }
 
     function onStdoutData(chunk: Buffer): void {
-      buffer += chunk.toString()
-
-      // JSON-RPC messages are newline-delimited
-      let newlineIdx: number
-      while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
-        const line = buffer.slice(0, newlineIdx).trim()
-        buffer = buffer.slice(newlineIdx + 1)
+      if (resolved) {
+        return
+      }
+      let offset = 0
+      while (offset <= chunk.byteLength) {
+        const newlineIdx = chunk.indexOf(0x0a, offset)
+        const hasNewline = newlineIdx !== -1
+        const segment = chunk.subarray(offset, hasNewline ? newlineIdx : chunk.byteLength)
+        if (segment.byteLength > MAX_RPC_RESPONSE_LINE_BYTES - buffer.byteLength) {
+          settle(
+            {
+              provider: 'codex',
+              session: null,
+              weekly: null,
+              updatedAt: Date.now(),
+              error: `RPC response exceeded ${MAX_RPC_RESPONSE_LINE_BYTES} byte line limit`,
+              status: 'error'
+            },
+            { kill: true }
+          )
+          return
+        }
+        buffer.append(segment)
+        if (!hasNewline) {
+          return
+        }
+        offset = newlineIdx + 1
+        const line = buffer.takeString('utf8').trim()
         if (!line) {
           continue
         }
@@ -687,7 +706,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
                   session: null,
                   weekly: null,
                   updatedAt: Date.now(),
-                  error: withMacTailscaleDnsHint(msg.error.message, stderr),
+                  error: withMacTailscaleDnsHint(msg.error.message, stderr.toString()),
                   status: 'error'
                 },
                 { kill: true }
@@ -724,11 +743,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
     }
 
     function onStderrData(chunk: Buffer): void {
-      stderr += chunk.toString()
-      // Why: this background poll only needs recent failure context for hints.
-      if (stderr.length > MAX_DIAGNOSTIC_OUTPUT_LENGTH) {
-        stderr = stderr.slice(-MAX_DIAGNOSTIC_OUTPUT_LENGTH)
-      }
+      stderr.appendRetainedSuffix(chunk, MAX_DIAGNOSTIC_OUTPUT_LENGTH)
     }
 
     function onError(err: Error): void {
@@ -743,7 +758,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
           ? isBareCommand
             ? 'Codex CLI not found'
             : 'Codex CLI found but could not run — Node.js may not be in your PATH'
-          : withMacTailscaleDnsHint(err.message, stderr),
+          : withMacTailscaleDnsHint(err.message, stderr.toString()),
         status: isEnoent && isBareCommand ? 'unavailable' : 'error'
       })
     }
@@ -754,7 +769,7 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
         session: null,
         weekly: null,
         updatedAt: Date.now(),
-        error: withMacTailscaleDnsHint('RPC process exited unexpectedly', stderr),
+        error: withMacTailscaleDnsHint('RPC process exited unexpectedly', stderr.toString()),
         status: 'error'
       })
     }
@@ -893,14 +908,11 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
     }, PTY_TIMEOUT_MS)
 
     const onDataDisposable = term.onData((data) => {
-      output += data
-      // Why: only recent status output is needed; cap noisy TUI output like the Claude fallback.
-      if (output.length > MAX_DIAGNOSTIC_OUTPUT_LENGTH) {
-        output = output.slice(-MAX_DIAGNOSTIC_OUTPUT_LENGTH)
-      }
+      const appended = appendRateLimitPtyOutputTail(output, data, MAX_DIAGNOSTIC_OUTPUT_LENGTH)
+      output = appended.output
 
       // Wait for prompt, then send /status
-      if (!sentStatus && />\s*$/.test(data)) {
+      if (!sentStatus && />\s*$/.test(appended.scannedChunk)) {
         sentStatus = true
         term.write('/status\r')
         return

--- a/src/main/rate-limits/gemini-cli-oauth-extractor-bounds.test.ts
+++ b/src/main/rate-limits/gemini-cli-oauth-extractor-bounds.test.ts
@@ -1,0 +1,204 @@
+import { mkdirSync, mkdtempSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs'
+import type * as FsPromises from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const opendirMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof FsPromises>()),
+  opendir: opendirMock
+}))
+
+import {
+  extractGeminiOAuthCredentialsFromBundleDir,
+  findGeminiPackageRoot,
+  MAX_GEMINI_CLI_BUNDLE_ENTRIES,
+  MAX_GEMINI_CLI_BUNDLE_FILES,
+  MAX_GEMINI_CLI_OAUTH_SOURCE_BYTES,
+  MAX_GEMINI_CLI_PACKAGE_JSON_BYTES,
+  readGeminiOAuthCredentialsFile
+} from './gemini-cli-oauth-extractor'
+
+const roots: string[] = []
+
+function createRoot(): string {
+  const root = mkdtempSync(path.join(tmpdir(), 'orca-gemini-oauth-bounds-'))
+  roots.push(root)
+  return root
+}
+
+function useDirectoryEntries(names: string[]): {
+  close: ReturnType<typeof vi.fn>
+  read: ReturnType<typeof vi.fn>
+} {
+  let index = 0
+  const directory = {
+    close: vi.fn(async () => undefined),
+    read: vi.fn(async () => {
+      const name = names[index]
+      index += 1
+      return name === undefined ? null : { name }
+    })
+  }
+  opendirMock.mockResolvedValueOnce(directory)
+  return directory
+}
+
+function oauthSource(clientId: string, clientSecret: string): string {
+  return [
+    `const OAUTH_CLIENT_ID = '${clientId}'`,
+    `const OAUTH_CLIENT_SECRET = "${clientSecret}"`
+  ].join('\n')
+}
+
+beforeEach(() => {
+  opendirMock.mockReset()
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('Gemini CLI OAuth extraction bounds', () => {
+  it('preserves credentials from a normal installed source file', async () => {
+    const sourcePath = path.join(createRoot(), 'oauth2.js')
+    writeFileSync(sourcePath, oauthSource('normal-client', 'normal-secret'))
+
+    await expect(readGeminiOAuthCredentialsFile(sourcePath)).resolves.toEqual({
+      clientId: 'normal-client',
+      clientSecret: 'normal-secret'
+    })
+  })
+
+  it('skips an oversized sparse installed source file', async () => {
+    const sourcePath = path.join(createRoot(), 'oauth2.js')
+    writeFileSync(sourcePath, '')
+    truncateSync(sourcePath, MAX_GEMINI_CLI_OAUTH_SOURCE_BYTES + 1)
+
+    await expect(readGeminiOAuthCredentialsFile(sourcePath)).resolves.toBeNull()
+  })
+
+  it('accepts package metadata at the exact byte limit', async () => {
+    const packageRoot = createRoot()
+    const packagePath = path.join(packageRoot, 'package.json')
+    const manifest = JSON.stringify({ name: '@google/gemini-cli' })
+    writeFileSync(
+      packagePath,
+      manifest + ' '.repeat(MAX_GEMINI_CLI_PACKAGE_JSON_BYTES - Buffer.byteLength(manifest))
+    )
+
+    expect(statSync(packagePath).size).toBe(MAX_GEMINI_CLI_PACKAGE_JSON_BYTES)
+    await expect(findGeminiPackageRoot(path.join(packageRoot, 'bin', 'gemini'))).resolves.toBe(
+      packageRoot
+    )
+  })
+
+  it('skips oversized sparse package metadata and keeps walking', async () => {
+    const packageRoot = createRoot()
+    const nestedRoot = path.join(packageRoot, 'nested')
+    mkdirSync(path.join(nestedRoot, 'bin'), { recursive: true })
+    writeFileSync(path.join(packageRoot, 'package.json'), manifestForGemini())
+    const oversizedManifest = path.join(nestedRoot, 'package.json')
+    writeFileSync(oversizedManifest, '')
+    truncateSync(oversizedManifest, MAX_GEMINI_CLI_PACKAGE_JSON_BYTES + 1)
+
+    await expect(findGeminiPackageRoot(path.join(nestedRoot, 'bin', 'gemini'))).resolves.toBe(
+      packageRoot
+    )
+  })
+
+  it('streams bundle entries and continues after an oversized sparse chunk', async () => {
+    const packageRoot = createRoot()
+    const bundleDir = path.join(packageRoot, 'bundle')
+    mkdirSync(bundleDir)
+    const oversizedPath = path.join(bundleDir, 'old.js')
+    writeFileSync(oversizedPath, '')
+    truncateSync(oversizedPath, MAX_GEMINI_CLI_OAUTH_SOURCE_BYTES + 1)
+    writeFileSync(path.join(bundleDir, 'current.js'), oauthSource('bundle-client', 'bundle-secret'))
+    const directory = useDirectoryEntries(['old.js', 'current.js'])
+
+    await expect(extractGeminiOAuthCredentialsFromBundleDir(packageRoot)).resolves.toEqual({
+      clientId: 'bundle-client',
+      clientSecret: 'bundle-secret'
+    })
+    expect(directory.read).toHaveBeenCalledTimes(2)
+    expect(directory.close).toHaveBeenCalledOnce()
+  })
+
+  it('admits a credential chunk at the exact directory entry limit', async () => {
+    const packageRoot = createRoot()
+    const bundleDir = path.join(packageRoot, 'bundle')
+    mkdirSync(bundleDir)
+    writeFileSync(path.join(bundleDir, 'credentials.js'), oauthSource('last-client', 'last-secret'))
+    const names = [
+      ...Array.from({ length: MAX_GEMINI_CLI_BUNDLE_ENTRIES - 1 }, (_, index) => `${index}.txt`),
+      'credentials.js'
+    ]
+    const directory = useDirectoryEntries(names)
+
+    await expect(extractGeminiOAuthCredentialsFromBundleDir(packageRoot)).resolves.toEqual({
+      clientId: 'last-client',
+      clientSecret: 'last-secret'
+    })
+    expect(directory.read).toHaveBeenCalledTimes(MAX_GEMINI_CLI_BUNDLE_ENTRIES)
+  })
+
+  it('does not retain or inspect a directory entry beyond the cap', async () => {
+    const packageRoot = createRoot()
+    const bundleDir = path.join(packageRoot, 'bundle')
+    mkdirSync(bundleDir)
+    writeFileSync(path.join(bundleDir, 'too-late.js'), oauthSource('late-client', 'late-secret'))
+    const names = [
+      ...Array.from({ length: MAX_GEMINI_CLI_BUNDLE_ENTRIES }, (_, index) => `${index}.txt`),
+      'too-late.js'
+    ]
+    const directory = useDirectoryEntries(names)
+
+    await expect(extractGeminiOAuthCredentialsFromBundleDir(packageRoot)).resolves.toBeNull()
+    expect(directory.read).toHaveBeenCalledTimes(MAX_GEMINI_CLI_BUNDLE_ENTRIES)
+  })
+
+  it('admits a credential chunk at the exact JavaScript file limit', async () => {
+    const packageRoot = createRoot()
+    const bundleDir = path.join(packageRoot, 'bundle')
+    mkdirSync(bundleDir)
+    writeFileSync(path.join(bundleDir, 'credentials.js'), oauthSource('file-client', 'file-secret'))
+    const names = [
+      ...Array.from(
+        { length: MAX_GEMINI_CLI_BUNDLE_FILES - 1 },
+        (_, index) => `missing-${index}.js`
+      ),
+      'credentials.js'
+    ]
+    const directory = useDirectoryEntries(names)
+
+    await expect(extractGeminiOAuthCredentialsFromBundleDir(packageRoot)).resolves.toEqual({
+      clientId: 'file-client',
+      clientSecret: 'file-secret'
+    })
+    expect(directory.read).toHaveBeenCalledTimes(MAX_GEMINI_CLI_BUNDLE_FILES)
+  })
+
+  it('does not inspect a JavaScript file beyond the file cap', async () => {
+    const packageRoot = createRoot()
+    const bundleDir = path.join(packageRoot, 'bundle')
+    mkdirSync(bundleDir)
+    writeFileSync(path.join(bundleDir, 'too-late.js'), oauthSource('late-client', 'late-secret'))
+    const names = [
+      ...Array.from({ length: MAX_GEMINI_CLI_BUNDLE_FILES }, (_, index) => `missing-${index}.js`),
+      'too-late.js'
+    ]
+    const directory = useDirectoryEntries(names)
+
+    await expect(extractGeminiOAuthCredentialsFromBundleDir(packageRoot)).resolves.toBeNull()
+    expect(directory.read).toHaveBeenCalledTimes(MAX_GEMINI_CLI_BUNDLE_FILES)
+  })
+})
+
+function manifestForGemini(): string {
+  return JSON.stringify({ name: '@google/gemini-cli' })
+}

--- a/src/main/rate-limits/gemini-cli-oauth-extractor.ts
+++ b/src/main/rate-limits/gemini-cli-oauth-extractor.ts
@@ -1,10 +1,17 @@
 import { exec } from 'node:child_process'
-import { access, readdir, readFile, realpath } from 'node:fs/promises'
+import { access, opendir, realpath } from 'node:fs/promises'
 import { promisify } from 'node:util'
 import { homedir } from 'node:os'
 import path from 'node:path'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 
 const execAsync = promisify(exec)
+const MAX_BINARY_LOOKUP_OUTPUT_BYTES = 64 * 1024
+export const MAX_GEMINI_CLI_OAUTH_SOURCE_BYTES = 32 * 1024 * 1024
+export const MAX_GEMINI_CLI_PACKAGE_JSON_BYTES = 1024 * 1024
+export const MAX_GEMINI_CLI_BUNDLE_ENTRIES = 4_096
+export const MAX_GEMINI_CLI_BUNDLE_FILES = 512
+export const MAX_GEMINI_CLI_BUNDLE_BYTES = 128 * 1024 * 1024
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -21,8 +28,13 @@ const OAUTH2_SUBPATH = path.join('dist', 'src', 'code_assist', 'oauth2.js')
 async function resolveGeminiBinary(): Promise<string | null> {
   const whichCmd = process.platform === 'win32' ? 'where gemini' : 'which gemini'
   try {
-    const { stdout } = await execAsync(whichCmd, { encoding: 'utf-8' })
-    const fromPath = stdout.trim().split(/\r?\n/)[0]
+    const { stdout } = await execAsync(whichCmd, {
+      encoding: 'utf-8',
+      maxBuffer: MAX_BINARY_LOOKUP_OUTPUT_BYTES
+    })
+    const trimmedOutput = stdout.trim()
+    const firstLineEnd = trimmedOutput.search(/\r?\n/)
+    const fromPath = trimmedOutput.slice(0, firstLineEnd === -1 ? undefined : firstLineEnd)
     if (fromPath && (await fileExists(fromPath))) {
       return fromPath
     }
@@ -69,15 +81,33 @@ function parseOAuthCredentials(content: string): { clientId: string; clientSecre
   return null
 }
 
-async function tryReadCredentials(
-  filePath: string
-): Promise<{ clientId: string; clientSecret: string } | null> {
+type GeminiOAuthSourceRead = {
+  credentials: { clientId: string; clientSecret: string } | null
+  bytesRead: number
+}
+
+async function readOAuthSource(
+  filePath: string,
+  maxBytes = MAX_GEMINI_CLI_OAUTH_SOURCE_BYTES
+): Promise<GeminiOAuthSourceRead | null> {
   try {
-    const content = await readFile(filePath, 'utf-8')
-    return parseOAuthCredentials(content)
+    const { buffer } = await readNodeFileWithinLimit(
+      filePath,
+      Math.min(MAX_GEMINI_CLI_OAUTH_SOURCE_BYTES, maxBytes)
+    )
+    return {
+      credentials: parseOAuthCredentials(buffer.toString('utf8')),
+      bytesRead: buffer.length
+    }
   } catch {
     return null
   }
+}
+
+export async function readGeminiOAuthCredentialsFile(
+  filePath: string
+): Promise<{ clientId: string; clientSecret: string } | null> {
+  return (await readOAuthSource(filePath))?.credentials ?? null
 }
 
 // Why: these are the known stable layouts for every major Gemini CLI install method.
@@ -131,7 +161,7 @@ async function extractFromKnownPaths(
   ]
 
   for (const candidate of candidates) {
-    const creds = await tryReadCredentials(path.normalize(candidate))
+    const creds = await readGeminiOAuthCredentialsFile(path.normalize(candidate))
     if (creds) {
       return creds
     }
@@ -143,50 +173,79 @@ async function extractFromKnownPaths(
 // Why: newer Gemini CLI versions (>=0.38) ship everything bundled into hash-named
 // chunks with no oauth2.js source file. Scanning the bundle dir for the credential
 // constants is the only reliable fallback for those installs.
-async function extractFromBundleDir(
+export async function extractGeminiOAuthCredentialsFromBundleDir(
   geminiCliPackageRoot: string
 ): Promise<{ clientId: string; clientSecret: string } | null> {
   const bundleDir = path.join(geminiCliPackageRoot, 'bundle')
-  if (!(await fileExists(bundleDir))) {
-    return null
-  }
-
-  let entries: string[]
+  let directory: Awaited<ReturnType<typeof opendir>>
   try {
-    entries = (await readdir(bundleDir)).filter((f) => f.endsWith('.js'))
+    directory = await opendir(bundleDir, { bufferSize: 32 })
   } catch {
     return null
   }
 
-  for (const entry of entries) {
-    const creds = await tryReadCredentials(path.join(bundleDir, entry))
-    if (creds) {
-      return creds
+  let inspectedEntries = 0
+  let inspectedFiles = 0
+  let inspectedBytes = 0
+  try {
+    while (
+      inspectedEntries < MAX_GEMINI_CLI_BUNDLE_ENTRIES &&
+      inspectedFiles < MAX_GEMINI_CLI_BUNDLE_FILES
+    ) {
+      const entry = await directory.read()
+      if (!entry) {
+        return null
+      }
+      inspectedEntries += 1
+      if (!entry.name.endsWith('.js')) {
+        continue
+      }
+      inspectedFiles += 1
+      const remainingBytes = MAX_GEMINI_CLI_BUNDLE_BYTES - inspectedBytes
+      if (remainingBytes === 0) {
+        return null
+      }
+      const source = await readOAuthSource(path.join(bundleDir, entry.name), remainingBytes)
+      if (!source) {
+        continue
+      }
+      if (source.bytesRead > MAX_GEMINI_CLI_BUNDLE_BYTES - inspectedBytes) {
+        return null
+      }
+      inspectedBytes += source.bytesRead
+      if (source.credentials) {
+        return source.credentials
+      }
+    }
+    return null
+  } catch {
+    return null
+  } finally {
+    try {
+      await directory.close()
+    } catch {
+      // Cleanup failure must not mask credential discovery.
     }
   }
-
-  return null
 }
 
 // Resolves the gemini-cli package root directory by walking up the directory
 // tree from the real binary path, looking for package.json with the right name,
 // or the global Node layout under lib/node_modules.
-async function findGeminiPackageRoot(realGeminiPath: string): Promise<string | null> {
+export async function findGeminiPackageRoot(realGeminiPath: string): Promise<string | null> {
   const MAX_ASCENTS = 8
   let current = path.dirname(realGeminiPath)
 
   for (let i = 0; i <= MAX_ASCENTS; i++) {
     const pkgJson = path.join(current, 'package.json')
-    if (await fileExists(pkgJson)) {
-      try {
-        const raw = await readFile(pkgJson, 'utf-8')
-        const pkg = JSON.parse(raw) as { name?: string }
-        if (pkg.name === '@google/gemini-cli') {
-          return current
-        }
-      } catch {
-        // malformed package.json — keep walking
+    try {
+      const { buffer } = await readNodeFileWithinLimit(pkgJson, MAX_GEMINI_CLI_PACKAGE_JSON_BYTES)
+      const pkg = JSON.parse(buffer.toString('utf8')) as { name?: string }
+      if (pkg.name === '@google/gemini-cli') {
+        return current
       }
+    } catch {
+      // Missing, malformed, or oversized package.json — keep walking.
     }
 
     // Global Node layout: <current>/lib/node_modules/@google/gemini-cli
@@ -245,14 +304,14 @@ export async function extractOAuthClientCredentials(): Promise<{
   const packageRoot = await findGeminiPackageRoot(realPath)
   if (packageRoot) {
     const fromSource =
-      (await tryReadCredentials(
+      (await readGeminiOAuthCredentialsFile(
         path.join(packageRoot, 'node_modules', '@google', 'gemini-cli-core', OAUTH2_SUBPATH)
-      )) ?? (await tryReadCredentials(path.join(packageRoot, OAUTH2_SUBPATH)))
+      )) ?? (await readGeminiOAuthCredentialsFile(path.join(packageRoot, OAUTH2_SUBPATH)))
     if (fromSource) {
       return fromSource
     }
 
-    const fromBundle = await extractFromBundleDir(packageRoot)
+    const fromBundle = await extractGeminiOAuthCredentialsFromBundleDir(packageRoot)
     if (fromBundle) {
       return fromBundle
     }

--- a/src/main/rate-limits/gemini-oauth-sources.ts
+++ b/src/main/rate-limits/gemini-oauth-sources.ts
@@ -1,8 +1,10 @@
-import { readFile, writeFile, rename } from 'node:fs/promises'
+import { writeFile, rename } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { net } from 'electron'
 import { extractOAuthClientCredentials } from './gemini-cli-oauth-extractor'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
+import { readIntegrationCredentialFileText } from '../integration-credential-file'
 
 const API_TIMEOUT_MS = 10_000
 const OAUTH_CREDS_PATH = path.join(homedir(), '.gemini', 'oauth_creds.json')
@@ -39,7 +41,7 @@ export async function readAuthJson(): Promise<AuthJson | null> {
 
   for (const candidate of candidates) {
     try {
-      const raw = await readFile(candidate, 'utf-8')
+      const raw = await readIntegrationCredentialFileText(candidate)
       return JSON.parse(raw) as AuthJson
     } catch (err) {
       if (err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT') {
@@ -54,7 +56,7 @@ export async function readAuthJson(): Promise<AuthJson | null> {
 
 export async function readGeminiCredentials(): Promise<GeminiCredentials | null> {
   try {
-    const raw = await readFile(OAUTH_CREDS_PATH, 'utf-8')
+    const raw = await readIntegrationCredentialFileText(OAUTH_CREDS_PATH)
     const parsed = JSON.parse(raw) as unknown
     if (
       parsed &&
@@ -110,11 +112,11 @@ export async function refreshAccessToken(
     return { accessToken: null, newRefreshToken: null }
   }
 
-  const data = (await res.json()) as {
+  const data = await readFetchResponseJsonWithinLimit<{
     access_token?: string
     refresh_token?: string
     expires_in?: number
-  }
+  }>(res)
   return {
     accessToken: typeof data.access_token === 'string' ? data.access_token : null,
     newRefreshToken: typeof data.refresh_token === 'string' ? data.refresh_token : null,
@@ -137,7 +139,7 @@ export async function loadProjectId(accessToken: string): Promise<string> {
     throw new Error(`Failed to load Gemini project ID (HTTP ${res.status})`)
   }
 
-  const data = (await res.json()) as { cloudaicompanionProject?: string }
+  const data = await readFetchResponseJsonWithinLimit<{ cloudaicompanionProject?: string }>(res)
   if (typeof data.cloudaicompanionProject !== 'string') {
     throw new Error('Gemini project ID not found in API response')
   }

--- a/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.fallback.test.ts
@@ -23,12 +23,14 @@ vi.mock('./gemini-cli-oauth-extractor', () => ({
 }))
 
 vi.mock('node:fs/promises', () => ({
-  readFile: readFileMock,
   // Why: saveGeminiCredentials is exercised on the refresh path. The atomic
   // tmp+rename write has no observable side effect in these tests, so the
   // stubs just resolve.
   writeFile: vi.fn().mockResolvedValue(undefined),
   rename: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileText: readFileMock
 }))
 
 vi.mock('electron', () => ({

--- a/src/main/rate-limits/gemini-usage-fetcher.test.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.test.ts
@@ -22,9 +22,11 @@ vi.mock('./gemini-cli-oauth-extractor', () => ({
 }))
 
 vi.mock('node:fs/promises', () => ({
-  readFile: readFileMock,
   writeFile: vi.fn().mockResolvedValue(undefined),
   rename: vi.fn().mockResolvedValue(undefined)
+}))
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileText: readFileMock
 }))
 vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
 

--- a/src/main/rate-limits/gemini-usage-fetcher.ts
+++ b/src/main/rate-limits/gemini-usage-fetcher.ts
@@ -1,5 +1,6 @@
 import { net } from 'electron'
 import type { ProviderRateLimits } from '../../shared/rate-limit-types'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 import {
   loadProjectId,
   readAuthJson,
@@ -63,7 +64,7 @@ async function fetchQuota(accessToken: string, projectId: string): Promise<Provi
         status: 'error'
       }
     }
-    const data = (await res.json()) as unknown
+    const data = await readFetchResponseJsonWithinLimit<unknown>(res)
     const buckets = deduplicateBuckets(
       parseQuotaResponse(data).map((b) => ({ ...buildRateLimitBucket(b), modelId: b.modelId }))
     )

--- a/src/main/rate-limits/grok-auth-file-bounds.test.ts
+++ b/src/main/rate-limits/grok-auth-file-bounds.test.ts
@@ -1,0 +1,75 @@
+import { mkdtempSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MAX_INTEGRATION_CREDENTIAL_FILE_BYTES } from '../integration-credential-file'
+import { readGrokAuthSession } from './grok-auth'
+
+const roots: string[] = []
+
+function createGrokHome(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-grok-auth-bounds-'))
+  roots.push(root)
+  vi.stubEnv('GROK_HOME', root)
+  return root
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('Grok auth file bounds', () => {
+  it('preserves a normal Grok auth session', () => {
+    const root = createGrokHome()
+    writeFileSync(
+      join(root, 'auth.json'),
+      JSON.stringify({
+        'https://auth.x.ai::client': {
+          key: 'normal-token',
+          email: 'alice@example.com'
+        }
+      })
+    )
+
+    expect(readGrokAuthSession()).toMatchObject({
+      status: 'ok',
+      session: {
+        accessToken: 'normal-token',
+        email: 'alice@example.com'
+      }
+    })
+  })
+
+  it('accepts valid auth JSON at the exact credential byte limit', () => {
+    const root = createGrokHome()
+    const prefix = '{"https://auth.x.ai":{"key":"'
+    const suffix = '"}}'
+    const tokenLength = MAX_INTEGRATION_CREDENTIAL_FILE_BYTES - Buffer.byteLength(prefix + suffix)
+    const authPath = join(root, 'auth.json')
+    writeFileSync(authPath, `${prefix}${'x'.repeat(tokenLength)}${suffix}`)
+
+    expect(statSync(authPath).size).toBe(MAX_INTEGRATION_CREDENTIAL_FILE_BYTES)
+    const result = readGrokAuthSession()
+    expect(result.status).toBe('ok')
+    if (result.status === 'ok') {
+      expect(result.session.accessToken).toHaveLength(tokenLength)
+      expect(result.session.accessToken.at(0)).toBe('x')
+      expect(result.session.accessToken.at(-1)).toBe('x')
+    }
+  })
+
+  it('rejects an oversized sparse auth file without loading its payload', () => {
+    const root = createGrokHome()
+    const authPath = join(root, 'auth.json')
+    writeFileSync(authPath, '')
+    truncateSync(authPath, MAX_INTEGRATION_CREDENTIAL_FILE_BYTES + 1)
+
+    expect(readGrokAuthSession()).toEqual({
+      status: 'error',
+      error: 'Unable to read Grok auth file'
+    })
+  })
+})

--- a/src/main/rate-limits/grok-auth.test.ts
+++ b/src/main/rate-limits/grok-auth.test.ts
@@ -1,21 +1,40 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authFile = vi.hoisted<{ contents: string | null; error: Error | null }>(() => ({
+  contents: null,
+  error: null
+}))
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFs>()),
+  existsSync: vi.fn(() => authFile.contents !== null || authFile.error !== null)
+}))
+
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileSyncText: vi.fn(() => {
+    if (authFile.error) {
+      throw authFile.error
+    }
+    if (authFile.contents === null) {
+      throw new Error('Auth file is missing')
+    }
+    return authFile.contents
+  })
+}))
+
+import { readGrokAuthSession } from './grok-auth'
 
 describe('readGrokAuthSession', () => {
-  afterEach(() => {
-    vi.resetModules()
-    vi.doUnmock('node:fs')
+  beforeEach(() => {
+    authFile.contents = null
+    authFile.error = null
   })
 
-  it('redacts filesystem paths from auth read failures', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() => {
-        throw new Error(
-          'EACCES: permission denied, open /Users/brennanbenson/private/.grok/auth.json'
-        )
-      })
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+  it('redacts filesystem paths from auth read failures', () => {
+    authFile.error = new Error(
+      'EACCES: permission denied, open /Users/brennanbenson/private/.grok/auth.json'
+    )
 
     expect(readGrokAuthSession()).toEqual({
       status: 'error',
@@ -23,22 +42,16 @@ describe('readGrokAuthSession', () => {
     })
   })
 
-  it('treats a token-less auth file as signed out, not an error', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() => JSON.stringify({ 'https://auth.x.ai::client': { user_id: 'u1' } }))
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+  it('treats a token-less auth file as signed out, not an error', () => {
+    authFile.contents = JSON.stringify({
+      'https://auth.x.ai::client': { user_id: 'u1' }
+    })
 
     expect(readGrokAuthSession()).toEqual({ status: 'missing' })
   })
 
-  it('reports malformed auth JSON without parser details', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() => '{')
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+  it('reports malformed auth JSON without parser details', () => {
+    authFile.contents = '{'
 
     expect(readGrokAuthSession()).toEqual({
       status: 'error',
@@ -48,29 +61,23 @@ describe('readGrokAuthSession', () => {
 
   it.each(['https://auth.x.ai', 'https://auth.x.ai::client'])(
     'prefers the %s issuer entry over an earlier alternate issuer',
-    async (preferredIssuer) => {
-      vi.doMock('node:fs', () => ({
-        existsSync: vi.fn(() => true),
-        readFileSync: vi.fn(() =>
-          JSON.stringify({
-            'https://stale.example.com::client': {
-              key: 'stale-token',
-              user_id: 'stale-user',
-              email: 'stale@example.com',
-              expires_at: '2099-01-01T00:00:00.000Z'
-            },
-            [preferredIssuer]: {
-              key: 'live-token',
-              user_id: 'live-user',
-              email: 'live@example.com',
-              team_id: 'team-1',
-              expires_at: '2099-06-01T00:00:00.000Z',
-              oidc_client_id: 'client-1'
-            }
-          })
-        )
-      }))
-      const { readGrokAuthSession } = await import('./grok-auth')
+    (preferredIssuer) => {
+      authFile.contents = JSON.stringify({
+        'https://stale.example.com::client': {
+          key: 'stale-token',
+          user_id: 'stale-user',
+          email: 'stale@example.com',
+          expires_at: '2099-01-01T00:00:00.000Z'
+        },
+        [preferredIssuer]: {
+          key: 'live-token',
+          user_id: 'live-user',
+          email: 'live@example.com',
+          team_id: 'team-1',
+          expires_at: '2099-06-01T00:00:00.000Z',
+          oidc_client_id: 'client-1'
+        }
+      })
 
       expect(readGrokAuthSession()).toEqual({
         status: 'ok',
@@ -86,21 +93,15 @@ describe('readGrokAuthSession', () => {
     }
   )
 
-  it('falls back to the first tokenized entry when no auth.x.ai key exists', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() =>
-        JSON.stringify({
-          'https://alternate.example.com::client': {
-            key: 'alt-token',
-            user_id: 'alt-user',
-            email: 'alt@example.com',
-            expires_at: '2099-01-01T00:00:00.000Z'
-          }
-        })
-      )
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+  it('falls back to the first tokenized entry when no auth.x.ai key exists', () => {
+    authFile.contents = JSON.stringify({
+      'https://alternate.example.com::client': {
+        key: 'alt-token',
+        user_id: 'alt-user',
+        email: 'alt@example.com',
+        expires_at: '2099-01-01T00:00:00.000Z'
+      }
+    })
 
     expect(readGrokAuthSession()).toEqual({
       status: 'ok',
@@ -115,23 +116,17 @@ describe('readGrokAuthSession', () => {
     })
   })
 
-  it('skips an expired auth.x.ai client entry when a fresh one follows it', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() =>
-        JSON.stringify({
-          'https://auth.x.ai::old-client': {
-            key: 'expired-token',
-            expires_at: '2020-01-01T00:00:00.000Z'
-          },
-          'https://auth.x.ai::current-client': {
-            key: 'fresh-token',
-            expires_at: '2099-01-01T00:00:00.000Z'
-          }
-        })
-      )
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+  it('skips an expired auth.x.ai client entry when a fresh one follows it', () => {
+    authFile.contents = JSON.stringify({
+      'https://auth.x.ai::old-client': {
+        key: 'expired-token',
+        expires_at: '2020-01-01T00:00:00.000Z'
+      },
+      'https://auth.x.ai::current-client': {
+        key: 'fresh-token',
+        expires_at: '2099-01-01T00:00:00.000Z'
+      }
+    })
 
     expect(readGrokAuthSession()).toMatchObject({
       status: 'ok',
@@ -139,17 +134,11 @@ describe('readGrokAuthSession', () => {
     })
   })
 
-  it('does not resurrect an alternate issuer when an auth.x.ai entry is tokenless', async () => {
-    vi.doMock('node:fs', () => ({
-      existsSync: vi.fn(() => true),
-      readFileSync: vi.fn(() =>
-        JSON.stringify({
-          'https://alternate.example.com::client': { key: 'stale-token' },
-          'https://auth.x.ai::client': { user_id: 'signed-out-user' }
-        })
-      )
-    }))
-    const { readGrokAuthSession } = await import('./grok-auth')
+  it('does not resurrect an alternate issuer when an auth.x.ai entry is tokenless', () => {
+    authFile.contents = JSON.stringify({
+      'https://alternate.example.com::client': { key: 'stale-token' },
+      'https://auth.x.ai::client': { user_id: 'signed-out-user' }
+    })
 
     expect(readGrokAuthSession()).toEqual({ status: 'missing' })
   })

--- a/src/main/rate-limits/grok-auth.ts
+++ b/src/main/rate-limits/grok-auth.ts
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { resolveGrokHomeDir } from '../../shared/grok-session-paths'
+import { readIntegrationCredentialFileSyncText } from '../integration-credential-file'
 
 // Why: when GROK_HOME is set, auth.json must be the same path Grok CLI uses.
 export function getGrokHome(): string {
@@ -88,7 +89,7 @@ export function readGrokAuthSession(): GrokAuthReadResult {
     return { status: 'missing' }
   }
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
+    const parsed: unknown = JSON.parse(readIntegrationCredentialFileSyncText(path))
     if (typeof parsed !== 'object' || parsed === null) {
       return { status: 'error', error: 'Grok auth file is invalid' }
     }

--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -11,8 +11,11 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('node:fs', () => ({
-  existsSync: () => authState.file !== null,
-  readFileSync: () => {
+  existsSync: () => authState.file !== null
+}))
+
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileSyncText: () => {
     if (authState.readError) {
       throw authState.readError
     }

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -10,6 +10,7 @@ import {
   type GrokAuthReadResult,
   type GrokAuthSession
 } from './grok-auth'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 // Why: billing URL and headers must match Grok CLI or xAI rejects the request.
 const GROK_CLI_PROXY_BASE =
@@ -211,7 +212,7 @@ async function fetchBillingData(
       result: result('error', `Grok usage request failed (HTTP ${res.status})`)
     }
   }
-  const data: unknown = await res.json()
+  const data = await readFetchResponseJsonWithinLimit<unknown>(res)
   return {
     kind: 'data',
     data: typeof data === 'object' && data !== null ? (data as GrokBillingResponse) : {}

--- a/src/main/rate-limits/hidden-pty-cleanup.test.ts
+++ b/src/main/rate-limits/hidden-pty-cleanup.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   cleanupHiddenRateLimitPty,
   getActiveHiddenRateLimitPtyCount,
+  HiddenRateLimitPtyCapacityError,
+  MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS,
   registerHiddenRateLimitPty
 } from './hidden-pty-cleanup'
 
@@ -130,6 +132,31 @@ describe('cleanupHiddenRateLimitPty', () => {
 
     cleanupHiddenRateLimitPty(term, [registration], { kill: false })
 
+    expect(getActiveHiddenRateLimitPtyCount()).toBe(0)
+  })
+
+  it('caps active hidden PTYs, tears down overflow, and recovers after disposal', () => {
+    setPlatform('darwin')
+    const registrations = Array.from({ length: MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS }, () =>
+      registerHiddenRateLimitPty({ kill: vi.fn(), destroy: vi.fn() })
+    )
+    expect(getActiveHiddenRateLimitPtyCount()).toBe(MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS)
+
+    const overflowKill = vi.fn()
+    const overflow = { kill: overflowKill, destroy: vi.fn() }
+    expect(() => registerHiddenRateLimitPty(overflow)).toThrow(HiddenRateLimitPtyCapacityError)
+    expect(overflowKill).toHaveBeenCalledOnce()
+    expect(overflow.destroy).toHaveBeenCalledOnce()
+    expect(getActiveHiddenRateLimitPtyCount()).toBe(MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS)
+
+    registrations[0]!.dispose()
+    const recovered = registerHiddenRateLimitPty({ kill: vi.fn(), destroy: vi.fn() })
+    expect(getActiveHiddenRateLimitPtyCount()).toBe(MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS)
+
+    for (const registration of registrations.slice(1)) {
+      registration.dispose()
+    }
+    recovered.dispose()
     expect(getActiveHiddenRateLimitPtyCount()).toBe(0)
   })
 })

--- a/src/main/rate-limits/hidden-pty-cleanup.ts
+++ b/src/main/rate-limits/hidden-pty-cleanup.ts
@@ -7,9 +7,24 @@ type Disposable = {
   dispose: () => void
 }
 
+export const MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS = 16
 const activeHiddenRateLimitPtys = new Set<HiddenPty>()
 
+export class HiddenRateLimitPtyCapacityError extends Error {
+  constructor() {
+    super(`Hidden rate-limit PTY capacity exceeds ${MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS}`)
+    this.name = 'HiddenRateLimitPtyCapacityError'
+  }
+}
+
 export function registerHiddenRateLimitPty(term: HiddenPty): Disposable {
+  if (
+    !activeHiddenRateLimitPtys.has(term) &&
+    activeHiddenRateLimitPtys.size >= MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS
+  ) {
+    cleanupHiddenRateLimitPty(term, [], { kill: true })
+    throw new HiddenRateLimitPtyCapacityError()
+  }
   activeHiddenRateLimitPtys.add(term)
   return {
     dispose: () => {

--- a/src/main/rate-limits/kimi-fetcher.test.ts
+++ b/src/main/rate-limits/kimi-fetcher.test.ts
@@ -12,7 +12,12 @@ vi.mock('electron', () => ({
 
 vi.mock('node:fs', () => ({
   existsSync: () => fsState.credentials !== null,
-  readFileSync: () => {
+  writeFileSync: () => {},
+  renameSync: () => {}
+}))
+
+vi.mock('../integration-credential-file', () => ({
+  readIntegrationCredentialFileSyncText: () => {
     if (fsState.readError) {
       throw fsState.readError
     }
@@ -20,9 +25,7 @@ vi.mock('node:fs', () => ({
       throw new Error('ENOENT')
     }
     return fsState.credentials
-  },
-  writeFileSync: () => {},
-  renameSync: () => {}
+  }
 }))
 
 vi.mock('node:os', () => ({ homedir: () => '/home/test' }))

--- a/src/main/rate-limits/kimi-fetcher.ts
+++ b/src/main/rate-limits/kimi-fetcher.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { net } from 'electron'
@@ -7,6 +7,8 @@ import type {
   RateLimitWindow,
   UsageRateLimitMetadata
 } from '../../shared/rate-limit-types'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
+import { readIntegrationCredentialFileSyncText } from '../integration-credential-file'
 
 // Why: Kimi Code's managed coding plan exposes subscription usage at
 // `${base}/usages` (see packages/oauth/src/managed-usage.ts in the CLI bundle).
@@ -58,7 +60,7 @@ function readCredentials(): CredentialsReadResult {
     return { status: 'missing' }
   }
   try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf-8'))
+    const parsed: unknown = JSON.parse(readIntegrationCredentialFileSyncText(path))
     const credentials = parseCredentials(parsed)
     return credentials
       ? { status: 'ok', credentials }
@@ -275,7 +277,7 @@ export async function fetchKimiRateLimits(): Promise<ProviderRateLimits> {
     if (!res.ok) {
       return result('error', `Kimi usage request failed (HTTP ${res.status})`)
     }
-    const data: unknown = await res.json()
+    const data = await readFetchResponseJsonWithinLimit<unknown>(res)
     return mapUsageResponse(typeof data === 'object' && data !== null ? data : {})
   } catch (err) {
     return result('error', err instanceof Error ? err.message : 'Kimi usage request failed')

--- a/src/main/rate-limits/minimax-fetcher.ts
+++ b/src/main/rate-limits/minimax-fetcher.ts
@@ -1,4 +1,5 @@
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 import {
   extractMiniMaxCookieValue,
   fetchMiniMaxWithManualCookieHeader,
@@ -244,7 +245,7 @@ export async function fetchMiniMaxRateLimits(
     }
     let payload: MiniMaxUsageResponse
     try {
-      payload = (await fetchResult.response.json()) as MiniMaxUsageResponse
+      payload = await readFetchResponseJsonWithinLimit<MiniMaxUsageResponse>(fetchResult.response)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Invalid MiniMax usage response'
       return makeError(redactMiniMaxSecret(message), 'parse')

--- a/src/main/rate-limits/minimax-request-context.test.ts
+++ b/src/main/rate-limits/minimax-request-context.test.ts
@@ -27,6 +27,7 @@ import {
   getUniqueMiniMaxCookieNames,
   logMiniMaxFetchFailure,
   makeMiniMaxRequestHeaders,
+  MINIMAX_COOKIE_WRITE_CONCURRENCY,
   MINIMAX_USAGE_ENDPOINT,
   normalizeMiniMaxCookieHeader,
   redactMiniMaxSecret
@@ -164,7 +165,7 @@ describe('makeMiniMaxRequestHeaders', () => {
 describe('fetchMiniMaxWithSessionCookieJar', () => {
   beforeEach(() => {
     clearStorageDataMock.mockClear()
-    cookiesSetMock.mockClear()
+    cookiesSetMock.mockReset().mockResolvedValue(undefined)
     netFetchMock.mockReset()
     sessionFromPartitionMock.mockClear()
     sessionFromPartitionMock.mockImplementation(() => ({
@@ -276,6 +277,42 @@ describe('fetchMiniMaxWithSessionCookieJar', () => {
     )
   })
 
+  it.each([
+    ['at the limit', MINIMAX_COOKIE_WRITE_CONCURRENCY],
+    ['above the limit', MINIMAX_COOKIE_WRITE_CONCURRENCY + 1]
+  ])('bounds session cookie writes %s', async (_, count) => {
+    netFetchMock.mockResolvedValueOnce({ ok: true, status: 200 })
+    let active = 0
+    let peak = 0
+    const releases: (() => void)[] = []
+    cookiesSetMock.mockImplementation(async () => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => releases.push(resolve))
+      active--
+    })
+
+    const fetchResult = fetchMiniMaxWithSessionCookieJar({
+      cookie: Array.from({ length: count }, (_, index) => `cookie_${index}=value`).join('; '),
+      endpoint: MINIMAX_USAGE_ENDPOINT,
+      groupId: null,
+      signal: new AbortController().signal
+    })
+    await vi.waitFor(() =>
+      expect(cookiesSetMock).toHaveBeenCalledTimes(
+        Math.min(count, MINIMAX_COOKIE_WRITE_CONCURRENCY)
+      )
+    )
+    if (count > MINIMAX_COOKIE_WRITE_CONCURRENCY) {
+      releases.shift()?.()
+      await vi.waitFor(() => expect(cookiesSetMock).toHaveBeenCalledTimes(count))
+    }
+    releases.splice(0).forEach((release) => release())
+
+    await fetchResult
+    expect(peak).toBe(Math.min(count, MINIMAX_COOKIE_WRITE_CONCURRENCY))
+  })
+
   it('reports the transport name as session-cookie-jar on success', async () => {
     netFetchMock.mockResolvedValueOnce({
       ok: true,
@@ -303,7 +340,7 @@ describe('fetchMiniMaxWithSessionCookieJar', () => {
 describe('fetchMiniMaxWithManualCookieHeader', () => {
   beforeEach(() => {
     clearStorageDataMock.mockClear()
-    cookiesSetMock.mockClear()
+    cookiesSetMock.mockReset().mockResolvedValue(undefined)
     netFetchMock.mockReset()
     sessionFromPartitionMock.mockClear()
     sessionFromPartitionMock.mockImplementation(() => ({

--- a/src/main/rate-limits/minimax-request-context.ts
+++ b/src/main/rate-limits/minimax-request-context.ts
@@ -1,4 +1,5 @@
 import { session, type Session } from 'electron'
+import { mapSettledWithConcurrency } from '../../shared/map-with-concurrency'
 
 export const MINIMAX_USAGE_ENDPOINT =
   'https://platform.minimax.io/v1/api/openplatform/coding_plan/remains'
@@ -6,6 +7,7 @@ export const MINIMAX_USAGE_ENDPOINT =
 const MINIMAX_ORIGIN = 'https://platform.minimax.io'
 const MINIMAX_REFERER = 'https://platform.minimax.io/console/usage'
 const MINIMAX_SESSION_PARTITION = 'orca-minimax-rate-limit-fetch'
+export const MINIMAX_COOKIE_WRITE_CONCURRENCY = 8
 const SENSITIVE_COOKIE_NAMES = new Set([
   '_token',
   '_twpid',
@@ -122,8 +124,10 @@ export async function fetchMiniMaxWithSessionCookieJar(args: {
   const cookiePairs = parseCookiePairs(args.cookie)
   try {
     await clearMiniMaxSessionCookieJarForSession(miniMaxSession)
-    await Promise.all(
-      cookiePairs.map((pair) =>
+    const writes = await mapSettledWithConcurrency(
+      cookiePairs,
+      MINIMAX_COOKIE_WRITE_CONCURRENCY,
+      (pair) =>
         miniMaxSession.cookies.set({
           url: MINIMAX_ORIGIN,
           name: pair.name,
@@ -131,8 +135,13 @@ export async function fetchMiniMaxWithSessionCookieJar(args: {
           secure: true,
           path: '/'
         })
-      )
     )
+    const failedWrite = writes.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+    if (failedWrite) {
+      throw failedWrite.reason
+    }
     const headers = makeMiniMaxRequestHeaders(args.groupId)
     return {
       response: await miniMaxSession.fetch(args.endpoint, {

--- a/src/main/rate-limits/opencode-go-usage-fetcher.ts
+++ b/src/main/rate-limits/opencode-go-usage-fetcher.ts
@@ -8,6 +8,7 @@ import {
   OPENCODE_BASE_URL
 } from './opencode-go-request-session'
 import { parseSubscriptionFromPageText } from './opencode-go-page-scraper'
+import { readFetchResponseTextWithinLimit } from '../lib/fetch-response-body'
 
 const OPENCODE_SERVER_URL = 'https://opencode.ai/_server'
 const API_TIMEOUT_MS = 15_000
@@ -201,7 +202,7 @@ async function fetchOpenCodeGoRateLimitsWithSession(
         }
       }
 
-      const workspacesText = await workspacesRes.text()
+      const workspacesText = await readFetchResponseTextWithinLimit(workspacesRes)
       ids = parseWorkspaceIds(workspacesText)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unknown error'
@@ -251,7 +252,7 @@ async function fetchOpenCodeGoRateLimitsWithSession(
         continue
       }
 
-      const pageText = await pageRes.text()
+      const pageText = await readFetchResponseTextWithinLimit(pageRes)
       const parsed = parseSubscriptionFromPageText(pageText)
       if (parsed) {
         const monthly =

--- a/src/main/rate-limits/rate-limit-pty-output-tail.test.ts
+++ b/src/main/rate-limits/rate-limit-pty-output-tail.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { appendRateLimitPtyOutputTail } from './rate-limit-pty-output-tail'
+
+describe('appendRateLimitPtyOutputTail', () => {
+  it('preserves ordinary output exactly', () => {
+    const first = appendRateLimitPtyOutputTail('', 'first', 16)
+    const second = appendRateLimitPtyOutputTail(first.output, ' second', 16)
+
+    expect(second).toEqual({
+      output: 'first second',
+      scannedChunk: ' second'
+    })
+  })
+
+  it('keeps the exact newest characters across chunks', () => {
+    const first = appendRateLimitPtyOutputTail('', '123456', 8)
+    const second = appendRateLimitPtyOutputTail(first.output, '789tail', 8)
+
+    expect(second.output).toBe('6789tail')
+  })
+
+  it('copies only a bounded suffix from one oversized PTY chunk', () => {
+    const result = appendRateLimitPtyOutputTail('old', `HEAD${'x'.repeat(1_000_000)}TAIL`, 16)
+
+    expect(result.output).toHaveLength(16)
+    expect(result.output).toBe(result.scannedChunk)
+    expect(result.output).toBe(`${'x'.repeat(12)}TAIL`)
+    expect(result.output).not.toContain('HEAD')
+  })
+
+  it('preserves UTF-16 code units at the retained boundary', () => {
+    const result = appendRateLimitPtyOutputTail('', `${'x'.repeat(20)}😀`, 2)
+
+    expect(result.output).toBe('😀')
+  })
+})

--- a/src/main/rate-limits/rate-limit-pty-output-tail.ts
+++ b/src/main/rate-limits/rate-limit-pty-output-tail.ts
@@ -1,0 +1,33 @@
+export type RateLimitPtyOutputAppend = {
+  output: string
+  scannedChunk: string
+}
+
+export function appendRateLimitPtyOutputTail(
+  existing: string,
+  chunk: string,
+  maxChars: number
+): RateLimitPtyOutputAppend {
+  if (!Number.isSafeInteger(maxChars) || maxChars < 0) {
+    throw new RangeError('Rate-limit PTY output limit must be a non-negative safe integer')
+  }
+  if (maxChars === 0) {
+    return { output: '', scannedChunk: '' }
+  }
+
+  const scannedChunk = chunk.length > maxChars ? copyUtf16Suffix(chunk, maxChars) : chunk
+  if (scannedChunk.length >= maxChars) {
+    return { output: scannedChunk, scannedChunk }
+  }
+  const existingBudget = maxChars - scannedChunk.length
+  const existingTail = existing.length > existingBudget ? existing.slice(-existingBudget) : existing
+  return {
+    output: `${existingTail}${scannedChunk}`,
+    scannedChunk
+  }
+}
+
+function copyUtf16Suffix(value: string, maxChars: number): string {
+  // Why: a sliced string may retain the oversized PTY chunk's backing store; this bounded round trip detaches it.
+  return Buffer.from(value.slice(-maxChars), 'utf16le').toString('utf16le')
+}

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -5,7 +5,12 @@ Keeping them in one file makes the ordering contract reviewable as a unit. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { EventEmitter } from 'node:events'
 import type { ProviderRateLimits } from '../../shared/rate-limit-types'
-import { RateLimitService } from './service'
+import {
+  MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES,
+  MAX_INACTIVE_RATE_LIMIT_ACCOUNTS,
+  RateLimitFetchCycleCapacityError,
+  RateLimitService
+} from './service'
 import { fetchClaudeRateLimits, fetchManagedAccountUsage } from './claude-fetcher'
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
@@ -1220,6 +1225,60 @@ describe('RateLimitService', () => {
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(2)
   })
 
+  it('shares one idle promise across a burst of queued refresh waiters and recovers', async () => {
+    const service = new RateLimitService()
+    const internals = service as unknown as {
+      fetchIdlePromise: Promise<void> | null
+      isFetching: boolean
+      resolveFetchIdleWaiters: () => void
+      waitForFetchIdle: () => Promise<void>
+    }
+    internals.isFetching = true
+    const shared = internals.waitForFetchIdle()
+
+    for (let index = 0; index < 10_000; index += 1) {
+      expect(internals.waitForFetchIdle()).toBe(shared)
+    }
+    expect(internals.fetchIdlePromise).toBe(shared)
+
+    internals.isFetching = false
+    internals.resolveFetchIdleWaiters()
+    await expect(shared).resolves.toBeUndefined()
+    expect(internals.fetchIdlePromise).toBeNull()
+
+    internals.isFetching = true
+    const recovered = internals.waitForFetchIdle()
+    expect(recovered).not.toBe(shared)
+    internals.isFetching = false
+    internals.resolveFetchIdleWaiters()
+    await expect(recovered).resolves.toBeUndefined()
+  })
+
+  it('caps active fetch controllers and recovers when a cycle finishes', () => {
+    const service = new RateLimitService()
+    const internals = service as unknown as {
+      activeFetchAbortControllers: Set<AbortController>
+      beginFetchCycle: () => AbortController
+      finishFetchCycle: (controller: AbortController) => void
+    }
+    const controllers = Array.from({ length: MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES }, () =>
+      internals.beginFetchCycle()
+    )
+
+    expect(internals.activeFetchAbortControllers.size).toBe(MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES)
+    expect(() => internals.beginFetchCycle()).toThrow(RateLimitFetchCycleCapacityError)
+
+    internals.finishFetchCycle(controllers[0]!)
+    const recovered = internals.beginFetchCycle()
+    expect(internals.activeFetchAbortControllers.size).toBe(MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES)
+
+    for (const controller of controllers.slice(1)) {
+      internals.finishFetchCycle(controller)
+    }
+    internals.finishFetchCycle(recovered)
+    expect(internals.activeFetchAbortControllers.size).toBe(0)
+  })
+
   it('publishes non-Grok provider results before a slow Grok fetch completes', async () => {
     const service = new RateLimitService()
     const grok = deferred<ProviderRateLimits>()
@@ -1745,6 +1804,24 @@ describe('RateLimitService', () => {
 
     accountFetch.resolve(okProvider('codex', 50, Date.now()))
     await firstFetch
+  })
+
+  it('caps inactive Codex preview state at the account admission limit', async () => {
+    const service = new RateLimitService()
+    const accounts = Array.from({ length: MAX_INACTIVE_RATE_LIMIT_ACCOUNTS + 1 }, (_, index) => ({
+      id: `account-${index}`,
+      managedHomePath: `/tmp/account-${index}/home`
+    }))
+    service.setInactiveCodexAccountsResolver(() => accounts)
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 50, Date.now()))
+
+    await service.fetchInactiveCodexAccountsOnOpen()
+
+    expect(fetchCodexRateLimits).toHaveBeenCalledTimes(MAX_INACTIVE_RATE_LIMIT_ACCOUNTS)
+    expect(service.getState().inactiveCodexAccounts).toHaveLength(MAX_INACTIVE_RATE_LIMIT_ACCOUNTS)
+    expect(service.getState().inactiveCodexAccounts.at(-1)?.accountId).toBe(
+      `account-${MAX_INACTIVE_RATE_LIMIT_ACCOUNTS - 1}`
+    )
   })
 
   it('keeps sibling inactive Codex preview fetches alive when one account is evicted', async () => {

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -91,6 +91,16 @@ const RATE_LIMITED_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000
 const LIVE_CLAUDE_INGEST_DEDUPE_MS = 30 * 1000
 const INACTIVE_FETCH_DEBOUNCE_MS = 60 * 1000 // 60 seconds — debounce fetch-on-open
 const DEFERRED_STARTUP_ACTIVE_REFRESH_MS = 1000
+export const MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES = 8
+export const MAX_INACTIVE_RATE_LIMIT_ACCOUNTS = 256
+export const MAX_RATE_LIMIT_ACCOUNT_ID_BYTES = 1024
+
+export class RateLimitFetchCycleCapacityError extends Error {
+  constructor() {
+    super(`Active rate-limit fetch cycles exceed ${MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES}`)
+    this.name = 'RateLimitFetchCycleCapacityError'
+  }
+}
 
 // Why: inactive account arrays are derived from provider caches on demand in getState()/pushToRenderer().
 type InternalRateLimitState = {
@@ -109,6 +119,36 @@ function normalizePollingInterval(ms: number): number {
     return DEFAULT_POLL_MS
   }
   return Math.min(MAX_POLL_MS, Math.max(MIN_POLL_MS, ms))
+}
+
+function boundedInactiveAccounts<T extends { id: string }>(accounts: T[]): T[] {
+  const bounded: T[] = []
+  const inspectedCount = Math.min(accounts.length, MAX_INACTIVE_RATE_LIMIT_ACCOUNTS)
+  for (let index = 0; index < inspectedCount; index += 1) {
+    const account = accounts[index]
+    if (account && Buffer.byteLength(account.id, 'utf8') <= MAX_RATE_LIMIT_ACCOUNT_ID_BYTES) {
+      bounded.push(account)
+    }
+  }
+  return bounded
+}
+
+function hasBoundedInactiveAccount<T extends { id: string }>(
+  accounts: T[],
+  accountId: string
+): boolean {
+  const inspectedCount = Math.min(accounts.length, MAX_INACTIVE_RATE_LIMIT_ACCOUNTS)
+  for (let index = 0; index < inspectedCount; index += 1) {
+    const account = accounts[index]
+    if (
+      account &&
+      Buffer.byteLength(account.id, 'utf8') <= MAX_RATE_LIMIT_ACCOUNT_ID_BYTES &&
+      account.id === accountId
+    ) {
+      return true
+    }
+  }
+  return false
 }
 
 function isSystemDefaultClaudeAuth(
@@ -187,7 +227,8 @@ export class RateLimitService {
   private claudeOnlyFetchQueued = false
   private grokOnlyFetchQueued = false
   private activeFetchAbortControllers = new Set<AbortController>()
-  private fetchIdleResolvers: (() => void)[] = []
+  private fetchIdlePromise: Promise<void> | null = null
+  private resolveFetchIdlePromise: (() => void) | null = null
   private codexFetchGeneration = 0
   private claudeFetchGeneration = 0
   // Why: statusline ingest must attribute live windows to the selected account without re-running the side-effectful auth sync per post.
@@ -494,7 +535,7 @@ export class RateLimitService {
     if (this.inactiveClaudeFetching.size > 0) {
       return
     }
-    const accounts = this.inactiveClaudeAccountsResolver?.() ?? []
+    const accounts = boundedInactiveAccounts(this.inactiveClaudeAccountsResolver?.() ?? [])
     if (accounts.length === 0) {
       return
     }
@@ -571,7 +612,7 @@ export class RateLimitService {
     if (this.inactiveCodexFetching.size > 0) {
       return
     }
-    const accounts = this.inactiveCodexAccountsResolver?.() ?? []
+    const accounts = boundedInactiveAccounts(this.inactiveCodexAccountsResolver?.() ?? [])
     if (accounts.length === 0) {
       return
     }
@@ -651,20 +692,18 @@ export class RateLimitService {
   }
 
   private isCurrentInactiveClaudeAccount(accountId: string): boolean {
-    return (this.inactiveClaudeAccountsResolver?.() ?? []).some(
-      (account) => account.id === accountId
-    )
+    return hasBoundedInactiveAccount(this.inactiveClaudeAccountsResolver?.() ?? [], accountId)
   }
 
   private isCurrentInactiveCodexAccount(accountId: string): boolean {
-    return (this.inactiveCodexAccountsResolver?.() ?? []).some(
-      (account) => account.id === accountId
-    )
+    return hasBoundedInactiveAccount(this.inactiveCodexAccountsResolver?.() ?? [], accountId)
   }
 
   private pruneInactiveClaudeState(): void {
     const currentIds = new Set(
-      (this.inactiveClaudeAccountsResolver?.() ?? []).map((account) => account.id)
+      boundedInactiveAccounts(this.inactiveClaudeAccountsResolver?.() ?? []).map(
+        (account) => account.id
+      )
     )
     for (const accountId of this.inactiveClaudeCache.keys()) {
       if (!currentIds.has(accountId)) {
@@ -680,7 +719,9 @@ export class RateLimitService {
 
   private pruneInactiveCodexState(): void {
     const currentIds = new Set(
-      (this.inactiveCodexAccountsResolver?.() ?? []).map((account) => account.id)
+      boundedInactiveAccounts(this.inactiveCodexAccountsResolver?.() ?? []).map(
+        (account) => account.id
+      )
     )
     for (const accountId of this.inactiveCodexCache.keys()) {
       if (!currentIds.has(accountId)) {
@@ -1122,9 +1163,10 @@ export class RateLimitService {
       return Promise.resolve()
     }
     // Why: explicit-refresh callers must await the queued follow-up cycle when a poll is in flight, else the UI stops spinning early.
-    return new Promise((resolve) => {
-      this.fetchIdleResolvers.push(resolve)
+    this.fetchIdlePromise ??= new Promise((resolve) => {
+      this.resolveFetchIdlePromise = resolve
     })
+    return this.fetchIdlePromise
   }
 
   private resolveFetchIdleWaiters(): void {
@@ -1137,14 +1179,16 @@ export class RateLimitService {
     ) {
       return
     }
-    const resolvers = this.fetchIdleResolvers
-    this.fetchIdleResolvers = []
-    for (const resolve of resolvers) {
-      resolve()
-    }
+    const resolve = this.resolveFetchIdlePromise
+    this.fetchIdlePromise = null
+    this.resolveFetchIdlePromise = null
+    resolve?.()
   }
 
   private beginFetchCycle(): AbortController {
+    if (this.activeFetchAbortControllers.size >= MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES) {
+      throw new RateLimitFetchCycleCapacityError()
+    }
     const controller = new AbortController()
     this.activeFetchAbortControllers.add(controller)
     return controller
@@ -1181,11 +1225,10 @@ export class RateLimitService {
   }
 
   private resolveAndClearFetchIdleWaiters(): void {
-    const resolvers = this.fetchIdleResolvers
-    this.fetchIdleResolvers = []
-    for (const resolve of resolvers) {
-      resolve()
-    }
+    const resolve = this.resolveFetchIdlePromise
+    this.fetchIdlePromise = null
+    this.resolveFetchIdlePromise = null
+    resolve?.()
   }
 
   private isSameCodexTarget(

--- a/src/main/stats/collector-retention.test.ts
+++ b/src/main/stats/collector-retention.test.ts
@@ -1,0 +1,244 @@
+import {
+  closeSync,
+  ftruncateSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let userDataDir: string
+const statsPath = (): string => join(userDataDir, 'orca-stats.json')
+
+vi.mock('electron', () => ({
+  app: { getPath: () => userDataDir }
+}))
+
+async function importCollector() {
+  return import('./collector')
+}
+
+describe('StatsCollector retention bounds', () => {
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-stats-retention-'))
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    rmSync(userDataDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('starts fresh without reading an oversized sparse stats file', async () => {
+    const { StatsCollector, STATS_FILE_MAX_BYTES, initStatsPath } = await importCollector()
+    const descriptor = openSync(statsPath(), 'w')
+    ftruncateSync(descriptor, STATS_FILE_MAX_BYTES + 1)
+    closeSync(descriptor)
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    initStatsPath()
+
+    const collector = new StatsCollector()
+
+    expect(collector.getSummary()).toEqual({
+      totalAgentsSpawned: 0,
+      totalPRsCreated: 0,
+      totalAgentTimeMs: 0,
+      firstEventAt: null
+    })
+    expect(error).toHaveBeenCalledWith(
+      '[stats] Failed to load stats, starting fresh:',
+      expect.objectContaining({ name: 'NodeFileReadTooLargeError' })
+    )
+    collector.flush()
+  })
+
+  it('normalizes loaded event and PR-dedup arrays to their persisted limits', async () => {
+    const { StatsCollector, STATS_COUNTED_PR_MAX_ENTRIES, STATS_EVENT_MAX_ENTRIES, initStatsPath } =
+      await importCollector()
+    writeFileSync(
+      statsPath(),
+      JSON.stringify({
+        schemaVersion: 1,
+        events: Array.from({ length: STATS_EVENT_MAX_ENTRIES + 3 }, (_, at) => ({
+          type: 'agent_start',
+          at
+        })),
+        aggregates: {
+          totalAgentsSpawned: 123,
+          totalPRsCreated: 456,
+          totalAgentTimeMs: 789,
+          countedPRs: Array.from(
+            { length: STATS_COUNTED_PR_MAX_ENTRIES + 3 },
+            (_, index) => `https://example.test/pr/${index}`
+          ),
+          firstEventAt: 0
+        }
+      })
+    )
+    initStatsPath()
+    const collector = new StatsCollector()
+
+    collector.flush()
+
+    const persisted = JSON.parse(readFileSync(statsPath(), 'utf8'))
+    expect(persisted.events).toHaveLength(STATS_EVENT_MAX_ENTRIES)
+    expect(persisted.events[0].at).toBe(3)
+    expect(persisted.aggregates.countedPRs).toHaveLength(STATS_COUNTED_PR_MAX_ENTRIES)
+    expect(persisted.aggregates.countedPRs[0]).toBe('https://example.test/pr/3')
+    expect(collector.getSummary()).toMatchObject({
+      totalAgentsSpawned: 123,
+      totalPRsCreated: 456,
+      totalAgentTimeMs: 789
+    })
+  })
+
+  it('retains only the newest events immediately and persists them in order', async () => {
+    const { StatsCollector, STATS_EVENT_MAX_ENTRIES, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    const internals = collector as unknown as { events: unknown[] }
+
+    for (let at = 0; at < STATS_EVENT_MAX_ENTRIES + 3; at++) {
+      collector.record({ type: 'agent_start', at })
+      expect(internals.events.length).toBeLessThanOrEqual(STATS_EVENT_MAX_ENTRIES)
+    }
+
+    collector.flush()
+    const persisted = JSON.parse(readFileSync(statsPath(), 'utf8'))
+    expect(persisted.events).toHaveLength(STATS_EVENT_MAX_ENTRIES)
+    expect(persisted.events[0].at).toBe(3)
+    expect(persisted.events.at(-1).at).toBe(STATS_EVENT_MAX_ENTRIES + 2)
+  })
+
+  it('accepts an exact-limit event and drops a one-byte-larger event', async () => {
+    const { StatsCollector, STATS_EVENT_MAX_BYTES, STATS_FILE_MAX_BYTES, initStatsPath } =
+      await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    const exactEvent = { type: 'agent_start' as const, at: 1, meta: { payload: '' } }
+    const eventOverhead = Buffer.byteLength(JSON.stringify(exactEvent), 'utf8')
+    exactEvent.meta.payload = 'x'.repeat(STATS_EVENT_MAX_BYTES - eventOverhead)
+    const oversizedEvent = {
+      ...exactEvent,
+      meta: { payload: `${exactEvent.meta.payload}x` }
+    }
+
+    expect(Buffer.byteLength(JSON.stringify(exactEvent), 'utf8')).toBe(STATS_EVENT_MAX_BYTES)
+    collector.record(exactEvent)
+    collector.record(oversizedEvent)
+    collector.flush()
+
+    const persisted = JSON.parse(readFileSync(statsPath(), 'utf8'))
+    expect(persisted.events).toEqual([exactEvent])
+    expect(collector.getSummary().totalAgentsSpawned).toBe(2)
+    expect(Buffer.byteLength(JSON.stringify(persisted), 'utf8')).toBeLessThanOrEqual(
+      STATS_FILE_MAX_BYTES
+    )
+  })
+
+  it('evicts oldest events until the aggregate event-byte budget fits', async () => {
+    const { StatsCollector, STATS_EVENT_MAX_BYTES, STATS_EVENT_MAX_RETAINED_BYTES, initStatsPath } =
+      await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    const eventCount = STATS_EVENT_MAX_RETAINED_BYTES / STATS_EVENT_MAX_BYTES + 1
+    for (let at = 0; at < eventCount; at++) {
+      const event = { type: 'agent_start' as const, at, meta: { payload: '' } }
+      const overhead = Buffer.byteLength(JSON.stringify(event), 'utf8')
+      event.meta.payload = 'x'.repeat(STATS_EVENT_MAX_BYTES - overhead)
+      collector.record(event)
+    }
+
+    collector.flush()
+
+    const persisted = JSON.parse(readFileSync(statsPath(), 'utf8'))
+    expect(persisted.events).toHaveLength(eventCount - 1)
+    expect(persisted.events[0].at).toBe(1)
+    expect(persisted.events.at(-1).at).toBe(eventCount - 1)
+  })
+
+  it('closes the oldest live agent when the live-session ceiling is reached', async () => {
+    const { StatsCollector, STATS_LIVE_AGENT_MAX_ENTRIES, initStatsPath } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    const internals = collector as unknown as { liveAgents: Map<string, number> }
+
+    for (let index = 0; index <= STATS_LIVE_AGENT_MAX_ENTRIES; index++) {
+      collector.onAgentStart(`pty-${index}`, 1_000 + index)
+    }
+
+    expect(internals.liveAgents).toHaveLength(STATS_LIVE_AGENT_MAX_ENTRIES)
+    expect(internals.liveAgents.has('pty-0')).toBe(false)
+    expect(internals.liveAgents.has(`pty-${STATS_LIVE_AGENT_MAX_ENTRIES}`)).toBe(true)
+    expect(collector.getSummary().totalAgentTimeMs).toBe(STATS_LIVE_AGENT_MAX_ENTRIES)
+
+    collector.onAgentStop('pty-0', 100_000)
+    expect(collector.getSummary().totalAgentTimeMs).toBe(STATS_LIVE_AGENT_MAX_ENTRIES)
+    collector.flush()
+  })
+
+  it('bounds live-agent ids by individual and aggregate bytes', async () => {
+    const {
+      StatsCollector,
+      STATS_LIVE_AGENT_ID_MAX_BYTES,
+      STATS_LIVE_AGENT_MAX_RETAINED_ID_BYTES,
+      initStatsPath
+    } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    const internals = collector as unknown as { liveAgents: Map<string, number> }
+    const retainedCount = STATS_LIVE_AGENT_MAX_RETAINED_ID_BYTES / STATS_LIVE_AGENT_ID_MAX_BYTES
+    const id = (index: number): string =>
+      `${String(index).padStart(4, '0')}${'x'.repeat(STATS_LIVE_AGENT_ID_MAX_BYTES - 4)}`
+
+    for (let index = 0; index <= retainedCount; index++) {
+      collector.onAgentStart(id(index), index)
+    }
+    collector.onAgentStart('x'.repeat(STATS_LIVE_AGENT_ID_MAX_BYTES + 1), 10_000)
+
+    expect(internals.liveAgents).toHaveLength(retainedCount)
+    expect(internals.liveAgents.has(id(0))).toBe(false)
+    expect(internals.liveAgents.has(id(retainedCount))).toBe(true)
+    expect(
+      [...internals.liveAgents.keys()].reduce(
+        (bytes, ptyId) => bytes + Buffer.byteLength(ptyId, 'utf8'),
+        0
+      )
+    ).toBe(STATS_LIVE_AGENT_MAX_RETAINED_ID_BYTES)
+    collector.flush()
+  })
+
+  it('bounds counted PR urls by individual and aggregate serialized bytes', async () => {
+    const {
+      StatsCollector,
+      STATS_COUNTED_PR_MAX_RETAINED_BYTES,
+      STATS_COUNTED_PR_URL_MAX_BYTES,
+      initStatsPath
+    } = await importCollector()
+    initStatsPath()
+    const collector = new StatsCollector()
+    const internals = collector as unknown as { aggregates: { countedPRs: string[] } }
+    const retainedCount = STATS_COUNTED_PR_MAX_RETAINED_BYTES / STATS_COUNTED_PR_URL_MAX_BYTES
+    const url = (index: number): string => {
+      const prefix = `https://example.test/${String(index).padStart(4, '0')}/`
+      return `${prefix}${'x'.repeat(STATS_COUNTED_PR_URL_MAX_BYTES - 2 - prefix.length)}`
+    }
+
+    for (let index = 0; index <= retainedCount; index++) {
+      collector.record({ type: 'pr_created', at: index, meta: { prUrl: url(index) } })
+    }
+    const oversizedUrl = 'x'.repeat(STATS_COUNTED_PR_URL_MAX_BYTES - 1)
+    collector.record({ type: 'pr_created', at: 10_000, meta: { prUrl: oversizedUrl } })
+
+    expect(Buffer.byteLength(JSON.stringify(url(0)), 'utf8')).toBe(STATS_COUNTED_PR_URL_MAX_BYTES)
+    expect(internals.aggregates.countedPRs).toHaveLength(retainedCount)
+    expect(collector.hasCountedPR(url(0))).toBe(false)
+    expect(collector.hasCountedPR(url(retainedCount))).toBe(true)
+    expect(collector.hasCountedPR(oversizedUrl)).toBe(false)
+    collector.flush()
+  })
+})

--- a/src/main/stats/collector.ts
+++ b/src/main/stats/collector.ts
@@ -1,17 +1,25 @@
 import { app } from 'electron'
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'node:fs'
+import { writeFileSync, mkdirSync, existsSync, renameSync } from 'node:fs'
 import { writeFile, mkdir, rm } from 'node:fs/promises'
 import { join, dirname } from 'node:path'
 import type { StatsSummary } from '../../shared/types'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 import type { StatsEvent, StatsAggregates, StatsFile } from './types'
+import { StatsAggregateTracker } from './stats-aggregate-tracker'
+import {
+  createDefaultStatsFile,
+  parseLoadedStatsFile,
+  STATS_FILE_MAX_BYTES,
+  STATS_LIVE_AGENT_ID_MAX_BYTES,
+  STATS_LIVE_AGENT_MAX_ENTRIES,
+  STATS_LIVE_AGENT_MAX_RETAINED_ID_BYTES,
+  STATS_SCHEMA_VERSION,
+  StatsEventLog
+} from './stats-retention'
 
-const STATS_SCHEMA_VERSION = 1
-const MAX_EVENTS = 10_000
-// Why: countedPRs is a deduplication registry that grows with every PR created
-// through Orca. Without a cap, a heavily-used instance accumulates thousands of
-// URL strings across months. 2000 entries is about 6-12 months of active use
-// for a power user, and at ~50 chars per URL the overhead is ~100KB max.
-const MAX_COUNTED_PRS = 2_000
+export * from './stats-retention'
 // Why 5s instead of the main store's 300ms: stat events are infrequent
 // (a few per session) and not latency-sensitive for the UI.
 const DEBOUNCE_MS = 5_000
@@ -33,28 +41,11 @@ function getStatsFile(): string {
   return _statsFile
 }
 
-function getDefaultAggregates(): StatsAggregates {
-  return {
-    totalAgentsSpawned: 0,
-    totalPRsCreated: 0,
-    totalAgentTimeMs: 0,
-    countedPRs: [],
-    firstEventAt: null
-  }
-}
-
-function getDefaultStatsFile(): StatsFile {
-  return {
-    schemaVersion: STATS_SCHEMA_VERSION,
-    events: [],
-    aggregates: getDefaultAggregates()
-  }
-}
-
 export class StatsCollector {
-  private events: StatsEvent[]
-  private aggregates: StatsAggregates
+  private eventLog: StatsEventLog
+  private aggregateTracker: StatsAggregateTracker
   private liveAgents = new Map<string, number>() // ptyId → startTimestamp
+  private liveAgentIdBytes = 0
   private writeTimer: ReturnType<typeof setTimeout> | null = null
   // Monotonic id stamped on each prepared payload; the highest committed one
   // wins so a slow in-flight async write can't clobber a newer sync flush.
@@ -67,8 +58,16 @@ export class StatsCollector {
 
   constructor() {
     const data = this.load()
-    this.events = data.events
-    this.aggregates = data.aggregates
+    this.eventLog = new StatsEventLog(data.events)
+    this.aggregateTracker = new StatsAggregateTracker(data.aggregates)
+  }
+
+  private get aggregates(): StatsAggregates {
+    return this.aggregateTracker.aggregates
+  }
+
+  private get events(): StatsEvent[] {
+    return this.eventLog.events
   }
 
   onAgentStarted(listener: (totalAgentsSpawned: number) => void): () => void {
@@ -85,15 +84,36 @@ export class StatsCollector {
   // ── Recording ──────────────────────────────────────────────────────
 
   record(event: StatsEvent): void {
-    this.events.push(event)
-    this.updateAggregates(event)
+    this.eventLog.retain(event)
+    this.aggregateTracker.record(event, this.agentStartListeners)
     this.scheduleSave()
   }
 
   // ── Agent lifecycle (called by AgentDetector) ─────────────────────
 
   onAgentStart(ptyId: string, at: number, repoId?: string, worktreeId?: string): void {
-    this.liveAgents.set(ptyId, at)
+    const idMeasurement = measureUtf8ByteLength(ptyId, {
+      stopAfterBytes: STATS_LIVE_AGENT_ID_MAX_BYTES
+    })
+    if (!idMeasurement.exceededLimit) {
+      if (!this.liveAgents.has(ptyId)) {
+        while (
+          this.liveAgents.size >= STATS_LIVE_AGENT_MAX_ENTRIES ||
+          this.liveAgentIdBytes + idMeasurement.byteLength > STATS_LIVE_AGENT_MAX_RETAINED_ID_BYTES
+        ) {
+          const oldest = this.liveAgents.entries().next()
+          if (oldest.done) {
+            break
+          }
+          const [oldestPtyId, oldestStartAt] = oldest.value
+          this.liveAgents.delete(oldestPtyId)
+          this.liveAgentIdBytes -= measureUtf8ByteLength(oldestPtyId).byteLength
+          this.recordAgentStop(oldestPtyId, oldestStartAt, at)
+        }
+        this.liveAgentIdBytes += idMeasurement.byteLength
+      }
+      this.liveAgents.set(ptyId, at)
+    }
     this.record({
       type: 'agent_start',
       at,
@@ -109,6 +129,11 @@ export class StatsCollector {
       return
     }
     this.liveAgents.delete(ptyId)
+    this.liveAgentIdBytes -= measureUtf8ByteLength(ptyId).byteLength
+    this.recordAgentStop(ptyId, startAt, at)
+  }
+
+  private recordAgentStop(ptyId: string, startAt: number, at: number): void {
     const durationMs = Math.max(0, at - startAt)
     this.aggregates.totalAgentTimeMs += durationMs
     this.record({
@@ -127,12 +152,7 @@ export class StatsCollector {
   // ── Query ─────────────────────────────────────────────────────────
 
   getSummary(): StatsSummary {
-    return {
-      totalAgentsSpawned: this.aggregates.totalAgentsSpawned,
-      totalPRsCreated: this.aggregates.totalPRsCreated,
-      totalAgentTimeMs: this.aggregates.totalAgentTimeMs,
-      firstEventAt: this.aggregates.firstEventAt
-    }
+    return this.aggregateTracker.getSummary()
   }
 
   // ── Shutdown flush ────────────────────────────────────────────────
@@ -163,17 +183,10 @@ export class StatsCollector {
     try {
       const statsFile = getStatsFile()
       if (existsSync(statsFile)) {
-        const raw = readFileSync(statsFile, 'utf-8')
-        const parsed = JSON.parse(raw) as StatsFile
-        // Merge with defaults for forward compatibility
-        return {
-          ...getDefaultStatsFile(),
-          ...parsed,
-          aggregates: {
-            ...getDefaultAggregates(),
-            ...parsed.aggregates
-          }
-        }
+        const raw = readNodeFileSyncWithinLimit(statsFile, STATS_FILE_MAX_BYTES).buffer.toString(
+          'utf8'
+        )
+        return parseLoadedStatsFile(raw)
       }
     } catch (err) {
       // Why "start fresh" instead of crashing: lifetime aggregates are lost
@@ -182,47 +195,7 @@ export class StatsCollector {
       // disk so it can be inspected for debugging.
       console.error('[stats] Failed to load stats, starting fresh:', err)
     }
-    return getDefaultStatsFile()
-  }
-
-  private updateAggregates(event: StatsEvent): void {
-    if (this.aggregates.firstEventAt === null) {
-      this.aggregates.firstEventAt = event.at
-    }
-
-    switch (event.type) {
-      case 'agent_start':
-        this.aggregates.totalAgentsSpawned++
-        // Why: notify listeners synchronously AFTER increment so observers
-        // see the post-increment count. Listener errors are swallowed to
-        // keep stat recording robust — a buggy listener must not lose the
-        // event from the on-disk log.
-        for (const listener of this.agentStartListeners) {
-          try {
-            listener(this.aggregates.totalAgentsSpawned)
-          } catch (err) {
-            console.error('[stats] agent-start listener threw:', err)
-          }
-        }
-        break
-      case 'pr_created':
-        this.aggregates.totalPRsCreated++
-        if (event.meta?.prUrl) {
-          this.aggregates.countedPRs.push(String(event.meta.prUrl))
-          // Why: trim oldest entries so the dedup array does not grow without
-          // bound. The aggregate totalPRsCreated counter remains accurate; only
-          // the dedup lookup for very old PRs is lost, which is acceptable
-          // since PRs that old would never be re-counted in practice.
-          if (this.aggregates.countedPRs.length > MAX_COUNTED_PRS) {
-            this.aggregates.countedPRs = this.aggregates.countedPRs.slice(-MAX_COUNTED_PRS)
-          }
-        }
-        break
-      // agent_stop duration is handled directly in onAgentStop() to avoid
-      // double-counting — the duration is added to totalAgentTimeMs there.
-      case 'agent_stop':
-        break
-    }
+    return createDefaultStatsFile()
   }
 
   private scheduleSave(): void {
@@ -250,9 +223,9 @@ export class StatsCollector {
     }
   }
 
-  // Serialize the current state and pick a unique temp path. Trimming mutates
-  // in-memory state and JSON.stringify must see a consistent snapshot, so both
-  // writers call this synchronously before any await to avoid a torn snapshot.
+  // Serialize the current state and pick a unique temp path. JSON.stringify
+  // must see a consistent snapshot, so both writers call this synchronously
+  // before any await to avoid a torn snapshot.
   // The monotonic generation lets a later write veto an earlier, still-in-flight
   // one so a stale rename can never win (see writeToDiskAsync).
   private prepareWritePayload(): {
@@ -262,11 +235,6 @@ export class StatsCollector {
     generation: number
   } {
     const statsFile = getStatsFile()
-
-    // Trim events to bounded size before writing
-    if (this.events.length > MAX_EVENTS) {
-      this.events = this.events.slice(-MAX_EVENTS)
-    }
 
     const data: StatsFile = {
       schemaVersion: STATS_SCHEMA_VERSION,
@@ -278,7 +246,8 @@ export class StatsCollector {
     // Unique temp file so the async debounced writer and the sync shutdown
     // flush never write the same temp path (same pattern as persistence.ts).
     const tmpFile = `${statsFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-    return { statsFile, tmpFile, json: JSON.stringify(data), generation }
+    const json = stringifyJsonWithinByteLimit(data, STATS_FILE_MAX_BYTES).serialized
+    return { statsFile, tmpFile, json, generation }
   }
 
   private writeToDiskSync(): void {

--- a/src/main/stats/stats-aggregate-tracker.ts
+++ b/src/main/stats/stats-aggregate-tracker.ts
@@ -1,0 +1,71 @@
+import type { StatsSummary } from '../../shared/types'
+import type { StatsAggregates, StatsEvent } from './types'
+import {
+  jsonByteLengthWithinLimit,
+  STATS_COUNTED_PR_MAX_ENTRIES,
+  STATS_COUNTED_PR_MAX_RETAINED_BYTES,
+  STATS_COUNTED_PR_URL_MAX_BYTES
+} from './stats-retention'
+
+export class StatsAggregateTracker {
+  private countedPrRetainedBytes: number
+
+  constructor(readonly aggregates: StatsAggregates) {
+    this.countedPrRetainedBytes = aggregates.countedPRs.reduce(
+      (total, value) =>
+        total + (jsonByteLengthWithinLimit(value, STATS_COUNTED_PR_URL_MAX_BYTES) ?? 0),
+      0
+    )
+  }
+
+  record(event: StatsEvent, agentStartListeners: ((total: number) => void)[]): void {
+    if (this.aggregates.firstEventAt === null) {
+      this.aggregates.firstEventAt = event.at
+    }
+    if (event.type === 'agent_start') {
+      this.aggregates.totalAgentsSpawned++
+      for (const listener of agentStartListeners) {
+        try {
+          listener(this.aggregates.totalAgentsSpawned)
+        } catch (err) {
+          console.error('[stats] agent-start listener threw:', err)
+        }
+      }
+      return
+    }
+    if (event.type !== 'pr_created') {
+      return
+    }
+    this.aggregates.totalPRsCreated++
+    if (!event.meta?.prUrl) {
+      return
+    }
+    const prUrl = String(event.meta.prUrl)
+    const prUrlBytes = jsonByteLengthWithinLimit(prUrl, STATS_COUNTED_PR_URL_MAX_BYTES)
+    if (prUrlBytes === null) {
+      return
+    }
+    this.aggregates.countedPRs.push(prUrl)
+    this.countedPrRetainedBytes += prUrlBytes
+    while (
+      this.aggregates.countedPRs.length > STATS_COUNTED_PR_MAX_ENTRIES ||
+      this.countedPrRetainedBytes > STATS_COUNTED_PR_MAX_RETAINED_BYTES
+    ) {
+      const oldestPrUrl = this.aggregates.countedPRs.shift()
+      if (oldestPrUrl === undefined) {
+        break
+      }
+      this.countedPrRetainedBytes -=
+        jsonByteLengthWithinLimit(oldestPrUrl, STATS_COUNTED_PR_URL_MAX_BYTES) ?? 0
+    }
+  }
+
+  getSummary(): StatsSummary {
+    return {
+      totalAgentsSpawned: this.aggregates.totalAgentsSpawned,
+      totalPRsCreated: this.aggregates.totalPRsCreated,
+      totalAgentTimeMs: this.aggregates.totalAgentTimeMs,
+      firstEventAt: this.aggregates.firstEventAt
+    }
+  }
+}

--- a/src/main/stats/stats-file-json-admission.test.ts
+++ b/src/main/stats/stats-file-json-admission.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { parseLoadedStatsFile } from './stats-retention'
+
+describe('stats file JSON admission', () => {
+  it('preserves ordinary stats under the structure limits', () => {
+    expect(
+      parseLoadedStatsFile('{"schemaVersion":1,"events":[],"aggregates":{}}', {
+        structuralTokens: 11,
+        nestingDepth: 2
+      })
+    ).toMatchObject({ schemaVersion: 1, events: [] })
+  })
+
+  it('rejects structural amplification before parsing stats', () => {
+    expect(() =>
+      parseLoadedStatsFile('{"events":[{},{}]}', {
+        structuralTokens: 7,
+        nestingDepth: 3
+      })
+    ).toThrow('JSON structure')
+  })
+})

--- a/src/main/stats/stats-retention.ts
+++ b/src/main/stats/stats-retention.ts
@@ -1,0 +1,170 @@
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import {
+  assertJsonTextStructureWithinLimits,
+  type JsonTextStructureLimits
+} from '../../shared/json-text-structure-limit'
+import type { StatsAggregates, StatsEvent, StatsFile } from './types'
+
+export const STATS_SCHEMA_VERSION = 1
+export const STATS_FILE_MAX_BYTES = 16 * 1024 * 1024
+export const STATS_EVENT_MAX_ENTRIES = 10_000
+export const STATS_EVENT_MAX_BYTES = 1024 * 1024
+export const STATS_EVENT_MAX_RETAINED_BYTES = 12 * 1024 * 1024
+export const STATS_LIVE_AGENT_MAX_ENTRIES = 4_096
+export const STATS_LIVE_AGENT_ID_MAX_BYTES = 4 * 1024
+export const STATS_LIVE_AGENT_MAX_RETAINED_ID_BYTES = 1024 * 1024
+export const STATS_COUNTED_PR_MAX_ENTRIES = 2_000
+export const STATS_COUNTED_PR_URL_MAX_BYTES = 8 * 1024
+export const STATS_COUNTED_PR_MAX_RETAINED_BYTES = 1024 * 1024
+export const STATS_FILE_JSON_LIMITS: JsonTextStructureLimits = {
+  structuralTokens: 1_000_000,
+  nestingDepth: 128
+}
+
+export function jsonByteLengthWithinLimit(value: unknown, maxBytes: number): number | null {
+  try {
+    return stringifyJsonWithinByteLimit(value, maxBytes).byteLength
+  } catch {
+    return null
+  }
+}
+
+function normalizeLoadedEvents(values: unknown[]): StatsEvent[] {
+  const newest: StatsEvent[] = []
+  let retainedBytes = 0
+  for (
+    let index = values.length - 1;
+    index >= 0 && newest.length < STATS_EVENT_MAX_ENTRIES;
+    index--
+  ) {
+    const value = values[index]
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      continue
+    }
+    const event = value as StatsEvent
+    const eventBytes = jsonByteLengthWithinLimit(event, STATS_EVENT_MAX_BYTES)
+    if (eventBytes === null) {
+      continue
+    }
+    if (retainedBytes + eventBytes > STATS_EVENT_MAX_RETAINED_BYTES) {
+      break
+    }
+    retainedBytes += eventBytes
+    newest.push(event)
+  }
+  return newest.toReversed()
+}
+
+function normalizeCountedPrUrls(values: unknown[]): string[] {
+  const newest: string[] = []
+  let retainedBytes = 0
+  for (
+    let index = values.length - 1;
+    index >= 0 && newest.length < STATS_COUNTED_PR_MAX_ENTRIES;
+    index--
+  ) {
+    const value = values[index]
+    if (typeof value !== 'string') {
+      continue
+    }
+    const valueBytes = jsonByteLengthWithinLimit(value, STATS_COUNTED_PR_URL_MAX_BYTES)
+    if (valueBytes === null) {
+      continue
+    }
+    if (retainedBytes + valueBytes > STATS_COUNTED_PR_MAX_RETAINED_BYTES) {
+      break
+    }
+    retainedBytes += valueBytes
+    newest.push(value)
+  }
+  return newest.toReversed()
+}
+
+export function createDefaultStatsFile(): StatsFile {
+  return {
+    schemaVersion: STATS_SCHEMA_VERSION,
+    events: [],
+    aggregates: {
+      totalAgentsSpawned: 0,
+      totalPRsCreated: 0,
+      totalAgentTimeMs: 0,
+      countedPRs: [],
+      firstEventAt: null
+    }
+  }
+}
+
+export function normalizeLoadedStatsFile(parsed: unknown): StatsFile {
+  const candidate =
+    typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? (parsed as Partial<StatsFile>)
+      : {}
+  const aggregateCandidate: Partial<StatsAggregates> =
+    typeof candidate.aggregates === 'object' &&
+    candidate.aggregates !== null &&
+    !Array.isArray(candidate.aggregates)
+      ? candidate.aggregates
+      : {}
+  const countedPRs = Array.isArray(aggregateCandidate.countedPRs)
+    ? normalizeCountedPrUrls(aggregateCandidate.countedPRs)
+    : []
+  return {
+    schemaVersion:
+      typeof candidate.schemaVersion === 'number' ? candidate.schemaVersion : STATS_SCHEMA_VERSION,
+    events: Array.isArray(candidate.events) ? normalizeLoadedEvents(candidate.events) : [],
+    aggregates: {
+      totalAgentsSpawned:
+        typeof aggregateCandidate.totalAgentsSpawned === 'number'
+          ? aggregateCandidate.totalAgentsSpawned
+          : 0,
+      totalPRsCreated:
+        typeof aggregateCandidate.totalPRsCreated === 'number'
+          ? aggregateCandidate.totalPRsCreated
+          : 0,
+      totalAgentTimeMs:
+        typeof aggregateCandidate.totalAgentTimeMs === 'number'
+          ? aggregateCandidate.totalAgentTimeMs
+          : 0,
+      countedPRs,
+      firstEventAt:
+        typeof aggregateCandidate.firstEventAt === 'number' ? aggregateCandidate.firstEventAt : null
+    }
+  }
+}
+
+export function parseLoadedStatsFile(
+  serialized: string,
+  structureLimits: JsonTextStructureLimits = STATS_FILE_JSON_LIMITS
+): StatsFile {
+  assertJsonTextStructureWithinLimits(serialized, structureLimits)
+  return normalizeLoadedStatsFile(JSON.parse(serialized))
+}
+
+export class StatsEventLog {
+  private eventByteLengths: number[]
+  private retainedEventBytes: number
+
+  constructor(readonly events: StatsEvent[]) {
+    this.eventByteLengths = events.map(
+      (event) => jsonByteLengthWithinLimit(event, STATS_EVENT_MAX_BYTES) ?? 0
+    )
+    this.retainedEventBytes = this.eventByteLengths.reduce((total, bytes) => total + bytes, 0)
+  }
+
+  retain(event: StatsEvent): void {
+    const eventBytes = jsonByteLengthWithinLimit(event, STATS_EVENT_MAX_BYTES)
+    if (eventBytes === null) {
+      return
+    }
+    this.events.push(event)
+    this.eventByteLengths.push(eventBytes)
+    this.retainedEventBytes += eventBytes
+    while (
+      this.events.length > STATS_EVENT_MAX_ENTRIES ||
+      this.retainedEventBytes > STATS_EVENT_MAX_RETAINED_BYTES
+    ) {
+      this.events.shift()
+      this.retainedEventBytes -= this.eventByteLengths.shift() ?? 0
+    }
+  }
+}

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -16,6 +16,7 @@ import {
   generateBranchNameFromContext,
   generateCommitMessageFromContext,
   generatePullRequestFieldsFromContext,
+  MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS,
   resolveCommitMessageSettings,
   trimGeneratedCommitMessage
 } from './commit-message-text-generation'
@@ -479,6 +480,119 @@ describe('discoverCommitMessageModelsLocal', () => {
     })
   })
 
+  it('shares one child process for concurrent identical model discovery', async () => {
+    const children: MockDiscoveryChild[] = []
+    spawnMock.mockImplementation(() => {
+      const child = createMockDiscoveryChild()
+      children.push(child)
+      return child as never
+    })
+
+    const first = discoverCommitMessageModelsLocal('cursor', { TOKEN: 'secret' })
+    const second = discoverCommitMessageModelsLocal('cursor', { TOKEN: 'secret' })
+
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+    children[0]!.stdout.emit('data', Buffer.from('auto - Auto\n'))
+    children[0]!.emit('close', 0)
+
+    const [firstResult, secondResult] = await Promise.all([first, second])
+    expect(firstResult).toMatchObject({ success: true, defaultModelId: 'auto' })
+    expect(secondResult).toEqual(firstResult)
+
+    const retry = discoverCommitMessageModelsLocal('cursor', { TOKEN: 'secret' })
+    expect(spawnMock).toHaveBeenCalledTimes(2)
+    children[1]!.stdout.emit('data', Buffer.from('auto - Auto\n'))
+    children[1]!.emit('close', 0)
+    await expect(retry).resolves.toEqual(firstResult)
+  })
+
+  it('keeps different agent parsers isolated when discovery commands match', async () => {
+    const children: MockDiscoveryChild[] = []
+    spawnMock.mockImplementation(() => {
+      const child = createMockDiscoveryChild()
+      children.push(child)
+      return child as never
+    })
+
+    const cursor = discoverCommitMessageModelsLocal('cursor', undefined, 'custom-discovery')
+    const pi = discoverCommitMessageModelsLocal('pi', undefined, 'custom-discovery')
+
+    expect(children).toHaveLength(2)
+    children[0]!.stdout.emit('data', Buffer.from('auto - Auto\n'))
+    children[0]!.emit('close', 0)
+    children[1]!.stderr.emit(
+      'data',
+      Buffer.from(
+        [
+          'provider        model                   context  max-out  thinking  images',
+          'github-copilot  gpt-5.4-mini            400K     128K     yes       yes'
+        ].join('\n')
+      )
+    )
+    children[1]!.emit('close', 0)
+
+    await expect(cursor).resolves.toMatchObject({ success: true, defaultModelId: 'auto' })
+    await expect(pi).resolves.toMatchObject({
+      success: true,
+      defaultModelId: 'github-copilot/gpt-5.4-mini'
+    })
+  })
+
+  it('shares the local process cap across discovery and generation, then releases on close', async () => {
+    const children: MockDiscoveryChild[] = []
+    spawnMock.mockImplementation(() => {
+      const child = createMockDiscoveryChild()
+      child.pid += children.length
+      children.push(child)
+      return child as never
+    })
+    const active = Array.from({ length: MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS }, (_, index) =>
+      discoverCommitMessageModelsLocal('cursor', undefined, undefined, {
+        cwd: `/repo-${index}`
+      })
+    )
+
+    expect(children).toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS)
+    await expect(
+      discoverCommitMessageModelsLocal('cursor', undefined, undefined, {
+        cwd: '/repo-overflow'
+      })
+    ).resolves.toEqual({
+      success: false,
+      error:
+        'Too many local AI generations are already running. Wait for one to finish and try again.'
+    })
+    await expect(
+      generateCommitMessageFromContext(
+        { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' },
+        { agentId: 'custom', model: '', customAgentCommand: 'agent' },
+        { kind: 'local', cwd: '/generation-overflow' }
+      )
+    ).resolves.toEqual({
+      success: false,
+      error:
+        'Too many local AI generations are already running. Wait for one to finish and try again.'
+    })
+    expect(spawnMock).toHaveBeenCalledTimes(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS)
+
+    children[0]!.stdout.emit('data', Buffer.from('auto - Auto\n'))
+    children[0]!.emit('close', 0)
+    await active[0]
+
+    const retry = discoverCommitMessageModelsLocal('cursor', undefined, undefined, {
+      cwd: '/repo-overflow'
+    })
+    expect(children).toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS + 1)
+
+    for (const child of children.slice(1)) {
+      child.stdout.emit('data', Buffer.from('auto - Auto\n'))
+      child.emit('close', 0)
+    }
+    await expect(Promise.all([...active, retry])).resolves.toHaveLength(
+      MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS + 1
+    )
+  })
+
   it('settles and detaches model discovery when timeout kill is ignored', async () => {
     vi.useFakeTimers()
     const child = createMockDiscoveryChild()
@@ -498,6 +612,8 @@ describe('discoverCommitMessageModelsLocal', () => {
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
+      expect(child.listenerCount('close')).toBe(1)
+      child.emit('close', null)
       expect(child.listenerCount('close')).toBe(0)
     } finally {
       vi.useRealTimers()
@@ -520,6 +636,8 @@ describe('discoverCommitMessageModelsLocal', () => {
     expect(child.stdout.listenerCount('data')).toBe(0)
     expect(child.stderr.listenerCount('data')).toBe(0)
     expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(1)
+    child.emit('close', null)
     expect(child.listenerCount('close')).toBe(0)
   })
 })
@@ -1141,6 +1259,36 @@ describe('generateCommitMessageFromContext', () => {
     expectChildTerminated(child)
   })
 
+  it('preserves local agent output delivered as 100,000 one-byte fragments', async () => {
+    const child = createMockDiscoveryChild()
+    spawnMock.mockReturnValue(child as never)
+    const pending = generateCommitMessageFromContext(
+      {
+        branch: 'main',
+        stagedSummary: 'M\tREADME.md',
+        stagedPatch: '+hello'
+      },
+      {
+        agentId: 'custom',
+        model: '',
+        customAgentCommand: 'agent'
+      },
+      { kind: 'local', cwd: '/fragmented-repo' }
+    )
+
+    for (let index = 0; index < 100_000; index += 1) {
+      child.stdout.emit('data', Buffer.from(' '))
+    }
+    child.stdout.emit('data', Buffer.from('Update README\n'))
+    child.emit('close', 0)
+
+    await expect(pending).resolves.toEqual({
+      success: true,
+      message: 'Update README',
+      agentLabel: 'agent'
+    })
+  })
+
   it('passes prepared provider environment to local agent subprocesses', async () => {
     const listeners = new Map<string, (value: unknown) => void>()
     const child = {
@@ -1336,6 +1484,207 @@ describe('generateCommitMessageFromContext', () => {
 
     cancelGeneratePullRequestFieldsLocal('/repo')
     expect(children[1]?.kill).not.toHaveBeenCalled()
+  })
+
+  it('cancels the previous process before replacing one local lane', async () => {
+    const children: {
+      kill: ReturnType<typeof vi.fn>
+      listeners: Map<string, (value: unknown) => void>
+    }[] = []
+    spawnMock.mockImplementation(() => {
+      const listeners = new Map<string, (value: unknown) => void>()
+      const child = {
+        pid: 123 + children.length,
+        kill: vi.fn(),
+        stdout: { on: vi.fn((event, callback) => listeners.set(`stdout:${event}`, callback)) },
+        stderr: { on: vi.fn((event, callback) => listeners.set(`stderr:${event}`, callback)) },
+        stdin: { end: vi.fn() },
+        on: vi.fn((event, callback) => listeners.set(event, callback))
+      }
+      children.push({ kill: child.kill, listeners })
+      return child as never
+    })
+    const context = { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' }
+    const params = { agentId: 'custom' as const, model: '', customAgentCommand: 'agent' }
+    const target = { kind: 'local' as const, cwd: '/same-repo' }
+
+    const first = generateCommitMessageFromContext(context, params, target)
+    const second = generateCommitMessageFromContext(context, params, target)
+
+    expectChildTerminated({ pid: 123, kill: children[0]!.kill })
+    expect(children).toHaveLength(2)
+    children[0]?.listeners.get('close')?.(null)
+    children[1]?.listeners.get('stdout:data')?.(Buffer.from('Update README\n'))
+    children[1]?.listeners.get('close')?.(0)
+    await expect(first).resolves.toMatchObject({ success: false, canceled: true })
+    await expect(second).resolves.toMatchObject({ success: true, message: 'Update README' })
+  })
+
+  it('caps concurrent local text-generation child processes', async () => {
+    const children: Map<string, (value: unknown) => void>[] = []
+    spawnMock.mockImplementation(() => {
+      const listeners = new Map<string, (value: unknown) => void>()
+      const child = {
+        pid: 200 + children.length,
+        kill: vi.fn(),
+        stdout: { on: vi.fn((event, callback) => listeners.set(`stdout:${event}`, callback)) },
+        stderr: { on: vi.fn((event, callback) => listeners.set(`stderr:${event}`, callback)) },
+        stdin: { end: vi.fn() },
+        on: vi.fn((event, callback) => listeners.set(event, callback))
+      }
+      children.push(listeners)
+      return child as never
+    })
+    const context = { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' }
+    const params = { agentId: 'custom' as const, model: '', customAgentCommand: 'agent' }
+    const active = Array.from({ length: MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS }, (_, index) =>
+      generateCommitMessageFromContext(context, params, {
+        kind: 'local',
+        cwd: `/repo-${index}`
+      })
+    )
+
+    await expect(
+      generateCommitMessageFromContext(context, params, {
+        kind: 'local',
+        cwd: '/repo-overflow'
+      })
+    ).resolves.toEqual({
+      success: false,
+      error:
+        'Too many local AI generations are already running. Wait for one to finish and try again.'
+    })
+    expect(spawnMock).toHaveBeenCalledTimes(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS)
+
+    for (const listeners of children) {
+      listeners.get('stdout:data')?.(Buffer.from('Update README\n'))
+      listeners.get('close')?.(0)
+    }
+    await expect(Promise.all(active)).resolves.toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS)
+  })
+
+  it('waits for a full-capacity lane to close before spawning its replacement', async () => {
+    const children: {
+      pid: number
+      kill: ReturnType<typeof vi.fn>
+      listeners: Map<string, (value: unknown) => void>
+      closed: boolean
+    }[] = []
+    spawnMock.mockImplementation(() => {
+      const listeners = new Map<string, (value: unknown) => void>()
+      const child = {
+        pid: 300 + children.length,
+        kill: vi.fn(),
+        stdout: { on: vi.fn((event, callback) => listeners.set(`stdout:${event}`, callback)) },
+        stderr: { on: vi.fn((event, callback) => listeners.set(`stderr:${event}`, callback)) },
+        stdin: { end: vi.fn() },
+        on: vi.fn((event, callback) => listeners.set(event, callback))
+      }
+      children.push({ pid: child.pid, kill: child.kill, listeners, closed: false })
+      return child as never
+    })
+    const context = { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' }
+    const params = { agentId: 'custom' as const, model: '', customAgentCommand: 'agent' }
+    const active = Array.from({ length: MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS }, (_, index) =>
+      generateCommitMessageFromContext(context, params, {
+        kind: 'local',
+        cwd: `/full-repo-${index}`
+      })
+    )
+
+    const replacement = generateCommitMessageFromContext(context, params, {
+      kind: 'local',
+      cwd: '/full-repo-0'
+    })
+
+    expectChildTerminated(children[0]!)
+    expect(children).toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS)
+    expect(children.filter((child) => !child.closed)).toHaveLength(
+      MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS
+    )
+
+    children[0]!.closed = true
+    children[0]!.listeners.get('close')?.(null)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(children).toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS + 1)
+    expect(children.filter((child) => !child.closed)).toHaveLength(
+      MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS
+    )
+
+    for (const child of children.slice(1)) {
+      child.listeners.get('stdout:data')?.(Buffer.from('Update README\n'))
+      child.closed = true
+      child.listeners.get('close')?.(0)
+    }
+    await expect(active[0]).resolves.toMatchObject({ success: false, canceled: true })
+    await expect(Promise.all([...active.slice(1), replacement])).resolves.toHaveLength(
+      MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS
+    )
+  })
+
+  it('cancels and supersedes replacements queued behind a full lane', async () => {
+    const children: {
+      pid: number
+      kill: ReturnType<typeof vi.fn>
+      listeners: Map<string, (value: unknown) => void>
+    }[] = []
+    spawnMock.mockImplementation(() => {
+      const listeners = new Map<string, (value: unknown) => void>()
+      const child = {
+        pid: 400 + children.length,
+        kill: vi.fn(),
+        stdout: { on: vi.fn((event, callback) => listeners.set(`stdout:${event}`, callback)) },
+        stderr: { on: vi.fn((event, callback) => listeners.set(`stderr:${event}`, callback)) },
+        stdin: { end: vi.fn() },
+        on: vi.fn((event, callback) => listeners.set(event, callback))
+      }
+      children.push({ pid: child.pid, kill: child.kill, listeners })
+      return child as never
+    })
+    const context = { branch: 'main', stagedSummary: 'M\tREADME.md', stagedPatch: '+hello' }
+    const params = { agentId: 'custom' as const, model: '', customAgentCommand: 'agent' }
+    const active = Array.from({ length: MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS }, (_, index) =>
+      generateCommitMessageFromContext(context, params, {
+        kind: 'local',
+        cwd: `/queued-repo-${index}`
+      })
+    )
+
+    const superseded = generateCommitMessageFromContext(context, params, {
+      kind: 'local',
+      cwd: '/queued-repo-0'
+    })
+    const canceled = generateCommitMessageFromContext(context, params, {
+      kind: 'local',
+      cwd: '/queued-repo-0'
+    })
+
+    await expect(superseded).resolves.toMatchObject({ success: false, canceled: true })
+    expect(children).toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS)
+    cancelGenerateCommitMessageLocal('/queued-repo-0')
+    await expect(canceled).resolves.toMatchObject({ success: false, canceled: true })
+
+    const replacement = generateCommitMessageFromContext(context, params, {
+      kind: 'local',
+      cwd: '/queued-repo-0'
+    })
+    expect(children).toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS)
+
+    children[0]!.listeners.get('close')?.(null)
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(children).toHaveLength(MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS + 1)
+
+    for (const child of children.slice(1)) {
+      child.listeners.get('stdout:data')?.(Buffer.from('Update README\n'))
+      child.listeners.get('close')?.(0)
+    }
+    await expect(active[0]).resolves.toMatchObject({ success: false, canceled: true })
+    await expect(Promise.all([...active.slice(1), replacement])).resolves.toHaveLength(
+      MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS
+    )
   })
 
   it('keeps local pull-request cancellation from stopping commit-message generation', async () => {
@@ -1612,7 +1961,8 @@ describe('generateCommitMessageFromContext', () => {
       expect(listeners.has('stdout:data')).toBe(false)
       expect(listeners.has('stderr:data')).toBe(false)
       expect(listeners.has('error')).toBe(false)
-      expect(listeners.has('close')).toBe(false)
+      expect(listeners.has('close')).toBe(true)
+      listeners.get('close')?.(null)
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -2,6 +2,8 @@
    spawn failure handling, and output normalization; keeping them together
    prevents those paths from drifting. */
 import { exec, spawn, type ChildProcess } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 import type { GlobalSettings, Repo, TuiAgent } from '../../shared/types'
 import {
   buildCommitMessagePrompt,
@@ -53,6 +55,10 @@ import {
 } from '../win32-utils'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { wslAwareSpawn } from '../git/runner'
+import {
+  MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS,
+  reserveLocalAiProcess
+} from './local-ai-process-budget'
 
 const GENERATION_TIMEOUT_MS = 60_000
 const MAX_AGENT_OUTPUT_BYTES = 4 * 1024 * 1024
@@ -296,6 +302,29 @@ function planModelDiscovery(
   }
 }
 
+const inFlightLocalModelDiscoveries = new Map<string, Promise<DiscoverCommitMessageModelsResult>>()
+
+function localModelDiscoveryKey(
+  agentId: TuiAgent,
+  plan: CommitMessagePlan,
+  env: NodeJS.ProcessEnv,
+  options: CommitMessageModelDiscoveryLocalOptions
+): string {
+  // Hash the full identity so environment and command secrets never remain in map keys.
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        agentId,
+        plan.binary,
+        plan.args,
+        options.cwd ?? null,
+        options.wslDistro ?? null,
+        Object.entries(env).sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+      ])
+    )
+    .digest('hex')
+}
+
 export async function discoverCommitMessageModelsLocal(
   agentId: TuiAgent,
   env: NodeJS.ProcessEnv | undefined,
@@ -311,19 +340,49 @@ export async function discoverCommitMessageModelsLocal(
     return toModelDiscoveryCapability(spec)
   }
 
+  const planned = planModelDiscovery(spec, agentCommandOverride)
+  if (!planned.ok) {
+    return { success: false, error: planned.error }
+  }
+  const spawnEnv = env ?? process.env
+  const discoveryKey = localModelDiscoveryKey(spec.id, planned.plan, spawnEnv, options)
+  const inFlight = inFlightLocalModelDiscoveries.get(discoveryKey)
+  if (inFlight) {
+    return inFlight
+  }
+  const pending = runLocalModelDiscovery(spec, planned.plan, env, spawnEnv, options)
+  inFlightLocalModelDiscoveries.set(discoveryKey, pending)
+  const clearPending = (): void => {
+    if (inFlightLocalModelDiscoveries.get(discoveryKey) === pending) {
+      inFlightLocalModelDiscoveries.delete(discoveryKey)
+    }
+  }
+  void pending.then(clearPending, clearPending)
+  return pending
+}
+
+function runLocalModelDiscovery(
+  spec: NonNullable<ReturnType<typeof getCommitMessageAgentSpec>>,
+  plan: CommitMessagePlan,
+  explicitEnv: NodeJS.ProcessEnv | undefined,
+  spawnEnv: NodeJS.ProcessEnv,
+  options: CommitMessageModelDiscoveryLocalOptions
+): Promise<DiscoverCommitMessageModelsResult> {
+  const reservation = reserveLocalAiProcess()
+  if (!reservation) {
+    return Promise.resolve({
+      success: false,
+      error:
+        'Too many local AI generations are already running. Wait for one to finish and try again.'
+    })
+  }
   return new Promise((resolve) => {
     let child: ChildProcess
-    const spawnEnv = env ?? process.env
     try {
-      const planned = planModelDiscovery(spec, agentCommandOverride)
-      if (!planned.ok) {
-        resolve({ success: false, error: planned.error })
-        return
-      }
       if (process.platform === 'win32' && options.wslDistro) {
-        child = wslAwareSpawn(planned.plan.binary, planned.plan.args, {
+        child = wslAwareSpawn(plan.binary, plan.args, {
           cwd: options.cwd,
-          env: buildWslLauncherEnv(env),
+          env: buildWslLauncherEnv(explicitEnv),
           stdio: ['ignore', 'pipe', 'pipe'],
           windowsHide: true,
           wslDistro: options.wslDistro,
@@ -332,11 +391,11 @@ export async function discoverCommitMessageModelsLocal(
       } else {
         const resolvedBinary =
           process.platform === 'win32'
-            ? resolveCliCommand(planned.plan.binary, {
+            ? resolveCliCommand(plan.binary, {
                 pathEnv: spawnEnv.PATH ?? spawnEnv.Path ?? null
               })
-            : planned.plan.binary
-        const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(resolvedBinary, planned.plan.args)
+            : plan.binary
+        const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(resolvedBinary, plan.args)
         child = spawn(spawnCmd, spawnArgs, {
           env: spawnEnv,
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -344,6 +403,7 @@ export async function discoverCommitMessageModelsLocal(
         })
       }
     } catch (error) {
+      reservation.release()
       console.error('[commit-message] Failed to spawn model discovery:', error)
       resolve({
         success: false,
@@ -351,9 +411,10 @@ export async function discoverCommitMessageModelsLocal(
       })
       return
     }
+    const owner = reservation.register(child)
 
-    let stdout = ''
-    let stderr = ''
+    const stdout = new GrowingByteBuffer()
+    const stderr = new GrowingByteBuffer()
     let outputLimitExceeded = false
     let settled = false
     let timer: ReturnType<typeof setTimeout> | null = null
@@ -368,6 +429,8 @@ export async function discoverCommitMessageModelsLocal(
         timer = null
       }
       detachChildListeners()
+      stdout.clear()
+      stderr.clear()
       resolve(result)
     }
     timer = setTimeout(() => {
@@ -378,18 +441,18 @@ export async function discoverCommitMessageModelsLocal(
       })
     }, GENERATION_TIMEOUT_MS)
 
-    const onData = (chunk: Buffer, append: (text: string) => void): void => {
-      if (stdout.length + stderr.length + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
+    const onData = (chunk: Buffer, append: (value: Buffer) => void): void => {
+      if (stdout.byteLength + stderr.byteLength + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
         killProcessTree(child)
         finish({ success: false, error: `${spec.label} returned too much model data.` })
         return
       }
-      append(chunk.toString('utf-8'))
+      append(chunk)
     }
 
-    const onStdoutData = (chunk: Buffer): void => onData(chunk, (text) => (stdout += text))
-    const onStderrData = (chunk: Buffer): void => onData(chunk, (text) => (stderr += text))
+    const onStdoutData = (chunk: Buffer): void => onData(chunk, (value) => stdout.append(value))
+    const onStderrData = (chunk: Buffer): void => onData(chunk, (value) => stderr.append(value))
     const onError = (error: Error): void => {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
         finish({
@@ -404,15 +467,17 @@ export async function discoverCommitMessageModelsLocal(
       })
     }
     const onClose = (code: number | null): void => {
+      child.off?.('close', onClose)
+      owner.release()
       if (outputLimitExceeded) {
         finish({ success: false, error: `${spec.label} returned too much model data.` })
         return
       }
       if (code !== 0) {
-        finish(finalizeModelDiscoveryOutput(spec, stdout, stderr, code))
+        finish(finalizeModelDiscoveryOutput(spec, stdout.toString(), stderr.toString(), code))
         return
       }
-      finish(finalizeModelDiscoveryOutput(spec, stdout, stderr, code))
+      finish(finalizeModelDiscoveryOutput(spec, stdout.toString(), stderr.toString(), code))
     }
 
     child.stdout?.on('data', onStdoutData)
@@ -423,7 +488,6 @@ export async function discoverCommitMessageModelsLocal(
       child.stdout?.off?.('data', onStdoutData)
       child.stderr?.off?.('data', onStderrData)
       child.off?.('error', onError)
-      child.off?.('close', onClose)
     }
   })
 }
@@ -514,6 +578,8 @@ function killProcessTree(child: ChildProcess): void {
 // Keying by operation plus `local:${cwd}` keeps local cancellation independent
 // from SSH worktrees and from other generation features in the same worktree.
 const cancelTokensByLane = new Map<string, () => void>()
+const pendingReservationCancelTokensByLane = new Map<string, () => void>()
+export { MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS }
 const WSL_LAUNCHER_ENV_KEYS = [
   'ComSpec',
   'COMSPEC',
@@ -530,8 +596,17 @@ function localLaneKey(operation: TextGenerationOperation, cwd: string): string {
   return `${operation}:local:${cwd}`
 }
 
+function cancelLocalGenerationLane(laneKey: string): void {
+  const cancelPendingReservation = pendingReservationCancelTokensByLane.get(laneKey)
+  if (cancelPendingReservation) {
+    cancelPendingReservation()
+    return
+  }
+  cancelTokensByLane.get(laneKey)?.()
+}
+
 export function cancelGenerateCommitMessageLocal(cwd: string): void {
-  cancelTokensByLane.get(localLaneKey('commit-message', cwd))?.()
+  cancelLocalGenerationLane(localLaneKey('commit-message', cwd))
 }
 
 function buildWslLauncherEnv(explicitEnv: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
@@ -559,6 +634,46 @@ async function runLocalPlan(
   wslDistro?: string
 ): Promise<InternalTextGenerationResult> {
   const { binary, args, stdinPayload, label } = plan
+  const laneKey = localLaneKey(operation, cwd)
+  pendingReservationCancelTokensByLane.get(laneKey)?.()
+  const reservation = reserveLocalAiProcess(laneKey)
+  if (!reservation) {
+    return {
+      success: false,
+      error:
+        'Too many local AI generations are already running. Wait for one to finish and try again.'
+    }
+  }
+  const previousCancelToken = cancelTokensByLane.get(laneKey)
+  if (reservation.waitForClose) {
+    let canceledWhileWaiting = false
+    let resolvePendingCancellation = (): void => {}
+    const pendingCancellation = new Promise<void>((resolve) => {
+      resolvePendingCancellation = resolve
+    })
+    const cancelPendingReservation = (): void => {
+      if (canceledWhileWaiting) {
+        return
+      }
+      canceledWhileWaiting = true
+      reservation.release()
+      if (pendingReservationCancelTokensByLane.get(laneKey) === cancelPendingReservation) {
+        pendingReservationCancelTokensByLane.delete(laneKey)
+      }
+      resolvePendingCancellation()
+    }
+    pendingReservationCancelTokensByLane.set(laneKey, cancelPendingReservation)
+    previousCancelToken?.()
+    await Promise.race([reservation.waitForClose, pendingCancellation])
+    if (pendingReservationCancelTokensByLane.get(laneKey) === cancelPendingReservation) {
+      pendingReservationCancelTokensByLane.delete(laneKey)
+    }
+    if (canceledWhileWaiting) {
+      return { success: false, error: 'Generation canceled.', canceled: true }
+    }
+  } else {
+    previousCancelToken?.()
+  }
   return new Promise((resolve) => {
     let child: ChildProcess
     try {
@@ -586,6 +701,7 @@ async function runLocalPlan(
         })
       }
     } catch (error) {
+      reservation.release()
       if (error instanceof UnsafeWindowsBatchArgumentsError) {
         resolve({
           success: false,
@@ -600,15 +716,13 @@ async function runLocalPlan(
       })
       return
     }
+    const owner = reservation.register(child, laneKey)
 
-    let stdout = ''
-    let stderr = ''
-    let stdoutBytes = 0
-    let stderrBytes = 0
+    const stdout = new GrowingByteBuffer()
+    const stderr = new GrowingByteBuffer()
     let outputLimitExceeded = false
     let settled = false
     let canceledByUser = false
-    const laneKey = localLaneKey(operation, cwd)
     let cancelToken: (() => void) | null = null
     let timer: ReturnType<typeof setTimeout> | null = null
     let detachChildListeners = (): void => {}
@@ -625,6 +739,8 @@ async function runLocalPlan(
       if (cancelToken && cancelTokensByLane.get(laneKey) === cancelToken) {
         cancelTokensByLane.delete(laneKey)
       }
+      stdout.clear()
+      stderr.clear()
       resolve(result)
     }
 
@@ -646,22 +762,20 @@ async function runLocalPlan(
     }, GENERATION_TIMEOUT_MS)
 
     const onStdoutData = (chunk: Buffer): void => {
-      stdoutBytes += chunk.byteLength
-      if (stdoutBytes > MAX_AGENT_OUTPUT_BYTES) {
+      if (stdout.byteLength + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
         killProcessTree(child)
         return
       }
-      stdout += chunk.toString('utf-8')
+      stdout.append(chunk)
     }
     const onStderrData = (chunk: Buffer): void => {
-      stderrBytes += chunk.byteLength
-      if (stderrBytes > MAX_AGENT_OUTPUT_BYTES) {
+      if (stderr.byteLength + chunk.byteLength > MAX_AGENT_OUTPUT_BYTES) {
         outputLimitExceeded = true
         killProcessTree(child)
         return
       }
-      stderr += chunk.toString('utf-8')
+      stderr.append(chunk)
     }
     const onError = (error: Error): void => {
       const code = (error as NodeJS.ErrnoException).code
@@ -679,6 +793,8 @@ async function runLocalPlan(
       })
     }
     const onClose = (code: number | null): void => {
+      child.off?.('close', onClose)
+      owner.release()
       if (canceledByUser) {
         finalize({ success: false, error: 'Generation canceled.', canceled: true })
         return
@@ -692,8 +808,8 @@ async function runLocalPlan(
       }
       finalizeFromAgentOutput({
         code,
-        stdout,
-        stderr,
+        stdout: stdout.toString(),
+        stderr: stderr.toString(),
         label,
         emptyResultName,
         finalize,
@@ -708,7 +824,6 @@ async function runLocalPlan(
       child.stdout?.off?.('data', onStdoutData)
       child.stderr?.off?.('data', onStderrData)
       child.off?.('error', onError)
-      child.off?.('close', onClose)
     }
 
     child.stdin?.end(stdinPayload ?? undefined)
@@ -899,7 +1014,7 @@ export async function generateCommitMessageFromContext(
 }
 
 export function cancelGeneratePullRequestFieldsLocal(cwd: string): void {
-  cancelTokensByLane.get(localLaneKey('pull-request-fields', cwd))?.()
+  cancelLocalGenerationLane(localLaneKey('pull-request-fields', cwd))
 }
 
 function formatPullRequestFieldsGenerationResult(

--- a/src/main/text-generation/local-ai-process-budget.ts
+++ b/src/main/text-generation/local-ai-process-budget.ts
@@ -1,0 +1,110 @@
+import type { ChildProcess } from 'node:child_process'
+
+export const MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS = 8
+
+type LocalAiProcessOwner = {
+  child: ChildProcess
+  closed: Promise<void>
+  release: () => void
+}
+
+export type LocalAiProcessReservation = {
+  waitForClose?: Promise<void>
+  register: (child: ChildProcess, laneKey?: string) => LocalAiProcessOwner
+  release: () => void
+}
+
+type ReplacementReservation = {
+  reservation: LocalAiProcessReservation
+  activate: () => void
+}
+
+const activeOwners = new Set<LocalAiProcessOwner>()
+const reservedSlots = new Set<LocalAiProcessReservation>()
+const ownerByLane = new Map<string, LocalAiProcessOwner>()
+const replacementByOwner = new Map<LocalAiProcessOwner, ReplacementReservation>()
+
+export function reserveLocalAiProcess(laneKey?: string): LocalAiProcessReservation | null {
+  let predecessor: LocalAiProcessOwner | undefined
+  if (activeOwners.size + reservedSlots.size >= MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS) {
+    predecessor = laneKey ? ownerByLane.get(laneKey) : undefined
+    if (!predecessor || replacementByOwner.has(predecessor)) {
+      return null
+    }
+  }
+
+  let state: 'waiting' | 'reserved' | 'registered' | 'released' = predecessor
+    ? 'waiting'
+    : 'reserved'
+  let reservation: LocalAiProcessReservation
+  const activate = (): void => {
+    if (state !== 'waiting') {
+      return
+    }
+    state = 'reserved'
+    reservedSlots.add(reservation)
+  }
+  reservation = {
+    waitForClose: predecessor?.closed,
+    register: (child, ownerLaneKey) => {
+      if (state !== 'reserved') {
+        throw new Error('Local AI process reservation is not ready.')
+      }
+      reservedSlots.delete(reservation)
+      state = 'registered'
+
+      let released = false
+      let resolveClosed = (): void => {}
+      const closed = new Promise<void>((resolve) => {
+        resolveClosed = resolve
+      })
+      const owner: LocalAiProcessOwner = {
+        child,
+        closed,
+        release: () => {
+          if (released) {
+            return
+          }
+          released = true
+          activeOwners.delete(owner)
+          if (ownerLaneKey && ownerByLane.get(ownerLaneKey) === owner) {
+            ownerByLane.delete(ownerLaneKey)
+          }
+          const replacement = replacementByOwner.get(owner)
+          if (replacement) {
+            replacementByOwner.delete(owner)
+            // Preserve the claimed slot before `closed` lets the replacement resume.
+            replacement.activate()
+          }
+          resolveClosed()
+        }
+      }
+      activeOwners.add(owner)
+      if (ownerLaneKey) {
+        ownerByLane.set(ownerLaneKey, owner)
+      }
+      return owner
+    },
+    release: () => {
+      if (state === 'waiting' && predecessor) {
+        const replacement = replacementByOwner.get(predecessor)
+        if (replacement?.reservation === reservation) {
+          replacementByOwner.delete(predecessor)
+        }
+        state = 'released'
+        return
+      }
+      if (state === 'reserved') {
+        reservedSlots.delete(reservation)
+        state = 'released'
+      }
+    }
+  }
+
+  if (predecessor) {
+    replacementByOwner.set(predecessor, { reservation, activate })
+  } else {
+    reservedSlots.add(reservation)
+  }
+  return reservation
+}

--- a/src/main/warp-themes/discovery.test.ts
+++ b/src/main/warp-themes/discovery.test.ts
@@ -7,10 +7,10 @@ type MockDirectoryEntry = {
   isDirectory: () => boolean
 }
 
-const readdirSyncMock = vi.hoisted(() => vi.fn<() => MockDirectoryEntry[]>(() => []))
+const opendirSyncMock = vi.hoisted(() => vi.fn())
 
 vi.mock('fs', () => ({
-  readdirSync: readdirSyncMock
+  opendirSync: opendirSyncMock
 }))
 
 vi.mock('os', () => ({
@@ -34,13 +34,21 @@ function fileEntry(name: string): MockDirectoryEntry {
   }
 }
 
+function mockDirectory(entries: MockDirectoryEntry[]) {
+  let index = 0
+  const readSync = vi.fn(() => entries[index++] ?? null)
+  const closeSync = vi.fn()
+  opendirSyncMock.mockReturnValue({ readSync, closeSync })
+  return { readSync, closeSync }
+}
+
 describe('getWarpThemeDirectories', () => {
   beforeEach(() => {
     vi.unstubAllEnvs()
     platformMock.mockReset()
     homedirMock.mockReturnValue('/Users/alice')
-    readdirSyncMock.mockReset()
-    readdirSyncMock.mockReturnValue([])
+    opendirSyncMock.mockReset()
+    mockDirectory([])
   })
 
   it('returns macOS Warp channel theme directories in stable-first order', () => {
@@ -57,11 +65,12 @@ describe('getWarpThemeDirectories', () => {
 
   it('adds dynamic macOS .warp directories after known channels', () => {
     platformMock.mockReturnValue('darwin')
-    readdirSyncMock.mockReturnValue([
-      directoryEntry('.warp-future'),
+    mockDirectory([
+      directoryEntry('.warp-z'),
       fileEntry('.warp-note'),
       directoryEntry('.not-warp'),
-      directoryEntry('.warp-preview')
+      directoryEntry('.warp-preview'),
+      directoryEntry('.warp-a')
     ])
 
     expect(getWarpThemeDirectories()).toEqual([
@@ -71,7 +80,8 @@ describe('getWarpThemeDirectories', () => {
       '/Users/alice/.warp-dev/themes',
       '/Users/alice/.warp-local/themes',
       '/Users/alice/.warp-integration/themes',
-      '/Users/alice/.warp-future/themes'
+      '/Users/alice/.warp-a/themes',
+      '/Users/alice/.warp-z/themes'
     ])
   })
 
@@ -91,7 +101,7 @@ describe('getWarpThemeDirectories', () => {
   it('adds dynamic Linux warp data directories', () => {
     platformMock.mockReturnValue('linux')
     vi.stubEnv('XDG_DATA_HOME', '/data/alice')
-    readdirSyncMock.mockReturnValue([
+    mockDirectory([
       directoryEntry('warp-future'),
       directoryEntry('warp-terminal'),
       directoryEntry('not-warp'),
@@ -121,8 +131,8 @@ describe('getWarpThemeDirectories', () => {
       '/Users/alice/.local/share/warp-terminal-local/themes',
       '/Users/alice/.local/share/warp-terminal-integration/themes'
     ])
-    expect(readdirSyncMock).toHaveBeenCalledWith('/Users/alice/.local/share', {
-      withFileTypes: true
+    expect(opendirSyncMock).toHaveBeenCalledWith('/Users/alice/.local/share', {
+      bufferSize: 32
     })
   })
 
@@ -143,7 +153,7 @@ describe('getWarpThemeDirectories', () => {
   it('adds dynamic Windows Warp app data directories', () => {
     platformMock.mockReturnValue('win32')
     vi.stubEnv('APPDATA', 'C:\\Users\\alice\\AppData\\Roaming')
-    readdirSyncMock.mockReturnValue([
+    mockDirectory([
       directoryEntry('WarpFuture'),
       directoryEntry('WarpPreview'),
       fileEntry('WarpNote')
@@ -158,6 +168,34 @@ describe('getWarpThemeDirectories', () => {
       'C:\\Users\\alice\\AppData\\Roaming\\warp\\WarpIntegration\\data\\themes',
       'C:\\Users\\alice\\AppData\\Roaming\\warp\\WarpFuture\\data\\themes'
     ])
+  })
+
+  it('caps dynamic discovery while closing the streamed directory', () => {
+    platformMock.mockReturnValue('darwin')
+    const { readSync, closeSync } = mockDirectory(
+      Array.from({ length: 1_025 }, (_, index) =>
+        directoryEntry(`.warp-dynamic-${String(index).padStart(4, '0')}`)
+      )
+    )
+
+    const directories = getWarpThemeDirectories()
+
+    expect(directories).toHaveLength(1_030)
+    expect(directories).toContain('/Users/alice/.warp-dynamic-1023/themes')
+    expect(directories).not.toContain('/Users/alice/.warp-dynamic-1024/themes')
+    expect(readSync).toHaveBeenCalledTimes(1_024)
+    expect(closeSync).toHaveBeenCalledOnce()
+  })
+
+  it('streams past unrelated entries without consuming the match budget', () => {
+    platformMock.mockReturnValue('darwin')
+    const { readSync } = mockDirectory([
+      ...Array.from({ length: 1_024 }, (_, index) => fileEntry(`note-${index}`)),
+      directoryEntry('.warp-future')
+    ])
+
+    expect(getWarpThemeDirectories()).toContain('/Users/alice/.warp-future/themes')
+    expect(readSync).toHaveBeenCalledTimes(1_026)
   })
 })
 

--- a/src/main/warp-themes/discovery.ts
+++ b/src/main/warp-themes/discovery.ts
@@ -1,7 +1,9 @@
-import { readdirSync } from 'node:fs'
-import type { Dirent } from 'node:fs'
+import { opendirSync, type Dir, type Dirent } from 'node:fs'
 import { homedir, platform } from 'node:os'
 import path from 'node:path'
+
+const MAX_DYNAMIC_DISCOVERY_MATCHES = 1_024
+const MAX_DYNAMIC_DISCOVERY_SCANNED_ENTRIES = 100_000
 
 const WARP_CHANNELS = [
   { macName: '.warp', linuxName: 'warp-terminal', windowsName: 'Warp' },
@@ -16,13 +18,39 @@ const WARP_CHANNELS = [
   }
 ]
 
-function readDirectoryEntries(directoryPath: string): Dirent[] {
+function readDirectoryEntries(
+  directoryPath: string,
+  includeEntry: (entry: Dirent) => boolean
+): Dirent[] {
+  let directory: Dir | undefined
   try {
-    return readdirSync(directoryPath, { withFileTypes: true }).sort((left, right) =>
+    directory = opendirSync(directoryPath, { bufferSize: 32 })
+    const entries: Dirent[] = []
+    let scannedEntries = 0
+    while (
+      entries.length < MAX_DYNAMIC_DISCOVERY_MATCHES &&
+      scannedEntries < MAX_DYNAMIC_DISCOVERY_SCANNED_ENTRIES
+    ) {
+      const entry = directory.readSync()
+      if (entry === null) {
+        break
+      }
+      scannedEntries += 1
+      if (includeEntry(entry)) {
+        entries.push(entry)
+      }
+    }
+    return entries.sort((left, right) =>
       left.name.localeCompare(right.name, undefined, { sensitivity: 'base' })
     )
   } catch {
     return []
+  } finally {
+    try {
+      directory?.closeSync()
+    } catch {
+      // A failed close cannot make already bounded discovery unsafe.
+    }
   }
 }
 
@@ -57,9 +85,10 @@ function getMacWarpThemeDirectories(home: string): string[] {
   return warpThemeDirectoriesFromDataHomes(
     [
       ...WARP_CHANNELS.map((channel) => pathImpl.join(home, channel.macName)),
-      ...readDirectoryEntries(home)
-        .filter((entry) => entry.isDirectory() && entry.name.startsWith('.warp'))
-        .map((entry) => pathImpl.join(home, entry.name))
+      ...readDirectoryEntries(
+        home,
+        (entry) => entry.isDirectory() && entry.name.startsWith('.warp')
+      ).map((entry) => pathImpl.join(home, entry.name))
     ],
     pathImpl
   )
@@ -77,13 +106,11 @@ function getLinuxWarpThemeDirectories(home: string): string[] {
   return warpThemeDirectoriesFromDataHomes(
     [
       ...WARP_CHANNELS.map((channel) => pathImpl.join(dataHome, channel.linuxName)),
-      ...readDirectoryEntries(dataHome)
-        .filter(
-          (entry) =>
-            entry.isDirectory() &&
-            (entry.name === 'warp-terminal' || entry.name.startsWith('warp-'))
-        )
-        .map((entry) => pathImpl.join(dataHome, entry.name))
+      ...readDirectoryEntries(
+        dataHome,
+        (entry) =>
+          entry.isDirectory() && (entry.name === 'warp-terminal' || entry.name.startsWith('warp-'))
+      ).map((entry) => pathImpl.join(dataHome, entry.name))
     ],
     pathImpl
   )
@@ -102,10 +129,7 @@ function getWindowsWarpThemeDirectories(home: string): string[] {
       path.win32
     )
   }
-  for (const entry of readDirectoryEntries(warpAppData)) {
-    if (!entry.isDirectory()) {
-      continue
-    }
+  for (const entry of readDirectoryEntries(warpAppData, (candidate) => candidate.isDirectory())) {
     addDedupeDirectory(
       directories,
       seenDirectories,

--- a/src/main/warp-themes/index.test.ts
+++ b/src/main/warp-themes/index.test.ts
@@ -1,9 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import path from 'node:path'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
 import type * as WarpThemeDiscovery from './discovery'
 
 const opendirMock = vi.hoisted(() => vi.fn())
-const readFileMock = vi.hoisted(() => vi.fn())
+const readNodeFileWithinLimitMock = vi.hoisted(() => vi.fn())
 const realpathMock = vi.hoisted(() => vi.fn((filePath: string) => Promise.resolve(filePath)))
 const statMock = vi.hoisted(() => vi.fn())
 const getWarpThemeDirectoriesMock = vi.hoisted(() => vi.fn(() => ['/Users/alice/.warp/themes']))
@@ -17,9 +18,13 @@ vi.mock('electron', () => ({
 
 vi.mock('fs/promises', () => ({
   opendir: opendirMock,
-  readFile: readFileMock,
   realpath: realpathMock,
   stat: statMock
+}))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => ({
+  ...(await importOriginal<typeof BoundedFileReader>()),
+  readNodeFileWithinLimit: readNodeFileWithinLimitMock
 }))
 
 vi.mock('./discovery', async (importOriginal) => {
@@ -36,6 +41,7 @@ vi.mock('./parser-runner', () => ({
 
 import { previewWarpThemeImport } from './index'
 import { parseWarpThemeYaml } from './parser'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import type { Store } from '../persistence'
 
 const VALID_THEME = `
@@ -97,12 +103,19 @@ function mockStat(filePath: string) {
     : { isFile: () => true, size: VALID_THEME.length }
 }
 
+function fileRead(content: string, size = Buffer.byteLength(content)) {
+  return {
+    buffer: Buffer.from(content),
+    stats: { isFile: () => true, size }
+  }
+}
+
 describe('previewWarpThemeImport', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getWarpThemeDirectoriesMock.mockReturnValue(['/Users/alice/.warp/themes'])
     statMock.mockImplementation(mockStat)
-    readFileMock.mockResolvedValue(VALID_THEME)
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead(VALID_THEME))
     realpathMock.mockImplementation((filePath: string) => Promise.resolve(filePath))
     opendirMock.mockResolvedValue(mockDirectory([fileEntry('z.yml'), fileEntry('a.yml')]))
     parseWarpThemeYamlWithTimeoutMock.mockImplementation(parseWarpThemeYaml)
@@ -115,10 +128,9 @@ describe('previewWarpThemeImport', () => {
       'warp:duplicate:a-yml',
       'warp:duplicate:z-yml'
     ])
-    expect(readFileMock.mock.calls.map(([filePath]) => path.basename(filePath as string))).toEqual([
-      'a.yml',
-      'z.yml'
-    ])
+    expect(
+      readNodeFileWithinLimitMock.mock.calls.map(([filePath]) => path.basename(filePath as string))
+    ).toEqual(['a.yml', 'z.yml'])
   })
 
   it('returns an empty errorless preview when no local Warp theme folder exists', async () => {
@@ -135,7 +147,7 @@ describe('previewWarpThemeImport', () => {
       skippedFiles: []
     })
     expect(preview.error).toBeUndefined()
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(readNodeFileWithinLimitMock).not.toHaveBeenCalled()
   })
 
   it('returns an empty errorless preview for an empty readable local Warp theme folder', async () => {
@@ -150,7 +162,7 @@ describe('previewWarpThemeImport', () => {
       skippedFiles: []
     })
     expect(preview.error).toBeUndefined()
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(readNodeFileWithinLimitMock).not.toHaveBeenCalled()
   })
 
   it('merges themes from multiple readable Warp directories', async () => {
@@ -170,7 +182,7 @@ describe('previewWarpThemeImport', () => {
 
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
-    expect(readFileMock.mock.calls.map(([filePath]) => filePath)).toEqual([
+    expect(readNodeFileWithinLimitMock.mock.calls.map(([filePath]) => filePath)).toEqual([
       path.join('/Users/alice/.warp/themes', 'stable.yaml'),
       path.join('/Users/alice/.warp-preview/themes', 'preview.yaml')
     ])
@@ -195,7 +207,7 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.found).toBe(true)
-    expect(readFileMock.mock.calls.map(([filePath]) => filePath)).toEqual([
+    expect(readNodeFileWithinLimitMock.mock.calls.map(([filePath]) => filePath)).toEqual([
       path.join('/Users/alice/.warp-oss/themes', 'oss.yaml')
     ])
     expect(preview.themes.map((theme) => theme.sourceLabel)).toEqual(['.warp-oss'])
@@ -220,9 +232,9 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.themes).toHaveLength(1)
-    expect(readFileMock).toHaveBeenCalledWith(
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith(
       path.join('/Users/alice/.warp/themes', 'shared.yaml'),
-      'utf-8'
+      1_000_000
     )
     expect(preview.themes[0]?.sourceLabel).toBe('.warp')
     expect(preview.skippedFiles).not.toContainEqual({
@@ -237,9 +249,9 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.found).toBe(true)
-    expect(readFileMock).toHaveBeenCalledWith(
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith(
       path.join('/Users/alice/.warp/themes', 'linked.yaml'),
-      'utf-8'
+      1_000_000
     )
   })
 
@@ -254,7 +266,7 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.themes).toHaveLength(1)
-    expect(readFileMock).toHaveBeenCalledTimes(1)
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledTimes(1)
   })
 
   it('applies the theme file cap globally across merged auto-discovery directories', async () => {
@@ -283,7 +295,7 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.themes).toHaveLength(200)
-    expect(readFileMock).toHaveBeenCalledTimes(200)
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledTimes(200)
     expect(preview.skippedFiles).toContainEqual({
       label: 'Warp themes',
       reason: 'Only the first 200 theme files were scanned.'
@@ -312,9 +324,9 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.themes).toHaveLength(200)
-    expect(readFileMock).not.toHaveBeenCalledWith(
+    expect(readNodeFileWithinLimitMock).not.toHaveBeenCalledWith(
       path.join('/Users/alice/.warp-preview/themes', 'preview.yaml'),
-      'utf-8'
+      1_000_000
     )
     expect(preview.skippedFiles).toContainEqual({
       label: 'Warp themes',
@@ -358,7 +370,10 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.themes).toHaveLength(200)
-    expect(readFileMock).toHaveBeenCalledWith(path.join(previewDirectory, 'unique.yaml'), 'utf-8')
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith(
+      path.join(previewDirectory, 'unique.yaml'),
+      1_000_000
+    )
   })
 
   it('reports bounded skips when local Warp folders are unreadable', async () => {
@@ -466,10 +481,12 @@ describe('previewWarpThemeImport', () => {
   it('keeps same-basename manual file ids stable independent of dialog order', async () => {
     const firstPath = path.join('/Users/alice/light', 'duplicate.yaml')
     const secondPath = path.join('/Users/alice/dark', 'duplicate.yaml')
-    readFileMock.mockImplementation((filePath: string) =>
-      filePath === firstPath
-        ? VALID_THEME.replace("background: '#111111'", "background: '#222222'")
-        : VALID_THEME.replace("background: '#111111'", "background: '#333333'")
+    readNodeFileWithinLimitMock.mockImplementation((filePath: string) =>
+      fileRead(
+        filePath === firstPath
+          ? VALID_THEME.replace("background: '#111111'", "background: '#222222'")
+          : VALID_THEME.replace("background: '#111111'", "background: '#333333'")
+      )
     )
     showOpenDialogMock.mockResolvedValueOnce({
       canceled: false,
@@ -560,7 +577,7 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.found).toBe(true)
-    expect(readFileMock.mock.calls.map(([filePath]) => filePath)).toEqual([
+    expect(readNodeFileWithinLimitMock.mock.calls.map(([filePath]) => filePath)).toEqual([
       path.join('/Users/alice/.warp/themes', 'standard', 'tokyo-night.yaml'),
       path.join('/Users/alice/.warp/themes', 'warp_bundled', 'dracula.yml')
     ])
@@ -711,8 +728,8 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'chooseFile' })
 
     expect(preview.themes).toHaveLength(200)
-    expect(readFileMock.mock.calls[0]?.[0]).toBe(themePaths[0])
-    expect(readFileMock.mock.calls.at(-1)?.[0]).toBe(themePaths[199])
+    expect(readNodeFileWithinLimitMock.mock.calls[0]?.[0]).toBe(themePaths[0])
+    expect(readNodeFileWithinLimitMock.mock.calls.at(-1)?.[0]).toBe(themePaths[199])
     expect(preview.skippedFiles).toContainEqual({
       label: 'Selected Warp themes',
       reason: 'Only the first 200 theme files were scanned.'
@@ -778,5 +795,42 @@ describe('previewWarpThemeImport', () => {
     const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
 
     expect(preview.skippedFiles).toEqual([{ label: 'private.yml', reason: 'Could not read file.' }])
+  })
+
+  it('accepts a theme at the exact byte limit', async () => {
+    const themePath = path.join('/Users/alice/.warp/themes', 'boundary.yml')
+    opendirMock.mockResolvedValue(mockDirectory([fileEntry('boundary.yml')]))
+    statMock.mockImplementation((filePath: string) =>
+      filePath === themePath ? { isFile: () => true, size: 1_000_000 } : mockStat(filePath)
+    )
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead(VALID_THEME, 1_000_000))
+
+    const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
+
+    expect(preview.found).toBe(true)
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith(themePath, 1_000_000)
+    expect(parseWarpThemeYamlWithTimeoutMock).toHaveBeenCalledOnce()
+  })
+
+  it('rejects theme growth beyond the limit before parsing', async () => {
+    const themePath = path.join('/Users/alice/.warp/themes', 'growing.yml')
+    opendirMock.mockResolvedValue(mockDirectory([fileEntry('growing.yml')]))
+    statMock.mockImplementation((filePath: string) =>
+      filePath === themePath ? { isFile: () => true, size: 128 } : mockStat(filePath)
+    )
+    readNodeFileWithinLimitMock.mockRejectedValue(
+      new NodeFileReadTooLargeError(1_000_001, 1_000_000)
+    )
+
+    const preview = await previewWarpThemeImport({} as Store, { kind: 'auto' })
+
+    expect(preview.found).toBe(false)
+    expect(preview.skippedFiles).toEqual([
+      {
+        label: 'growing.yml',
+        reason: 'File is too large to import (1000001 bytes, limit 1000000).'
+      }
+    ])
+    expect(parseWarpThemeYamlWithTimeoutMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/warp-themes/index.ts
+++ b/src/main/warp-themes/index.ts
@@ -1,6 +1,10 @@
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import type { WebContents } from 'electron'
 import type { Store } from '../persistence'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../../shared/node-bounded-file-reader'
 import type {
   WarpThemeImportPreview,
   WarpThemeImportSource
@@ -109,8 +113,20 @@ export async function previewWarpThemeImport(
           })
           continue
         }
-        content = await readFile(file.path, 'utf-8')
-      } catch {
+        const result = await readNodeFileWithinLimit(file.path, MAX_THEME_FILE_BYTES)
+        if (!result.stats.isFile()) {
+          skippedFiles.push({ label: file.label, reason: 'Not a file.' })
+          continue
+        }
+        content = result.buffer.toString('utf8')
+      } catch (error) {
+        if (error instanceof NodeFileReadTooLargeError) {
+          skippedFiles.push({
+            label: file.label,
+            reason: `File is too large to import (${error.observedBytes} bytes, limit ${MAX_THEME_FILE_BYTES}).`
+          })
+          continue
+        }
         skippedFiles.push({
           label: file.label,
           reason: sanitizeReadError('Could not read file.')


### PR DESCRIPTION
## OOM hardening slice 11/29 — bound provider rate-limit/usage/account scans

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **11/29** (base: `oom/10-b-providers`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
This slice re-introduces OOM ceilings across provider auth/usage/rate-limit/hook/stats/theme code: bounded file reads (byte caps + streamed opendir), bounded fetch-response bodies, bounded child-process stdout/stderr buffers, and count/byte/concurrency caps on caches, queues, waiters, retained records, and live-agent/PR/worktree maps. Nearly all limits sit far above ordinary use; the few user-visible ones are the 8-way local-AI-generation cap and the Claude usage-scan capacity errors.

### ELI5
Think of every place the app slurps a whole file, a web reply, or a program's output into memory — this change puts a lid on each bucket so a giant or malicious input can't fill up RAM and crash the app. Most lids are set enormously high (megabytes, thousands of entries), so normal users never touch them. Two lids are low enough to notice: you can only run 8 local AI text generations at once, and the Claude usage dashboard refuses to load if you somehow accumulate 100k+ usage records.

### Proof of OOM fix
- Agent-hook file reads bounded: AGENT_HOOK_PLUGIN_MAX_BYTES=1MB, AGENT_HOOK_CONFIG_MAX_BYTES=64MB; injected plugin reader GENERATED_NODE_MANAGED_FILE_MAX_BYTES=64KB (amp/hermes/kimi/devin/pi hook-service.ts). Tests: amp/hook-service.test.ts, pi/agent-status-extension-source.test.ts, pi/managed-extension-ownership.test.ts
- Provider credential reads bounded to MAX_INTEGRATION_CREDENTIAL_FILE_BYTES=1MB (grok/kimi/claude/codex/gemini + minimax cookie). Tests: rate-limits/codex-fetcher-auth-file-bounds.test.ts, rate-limits/grok-auth-file-bounds.test.ts
- Claude usage scan budget: MAX_USAGE_HISTORY_FILES=200_000, MAX_USAGE_HISTORY_RECORDS=100_000, MAX_USAGE_HISTORY_OWNERSHIP_KEYS=100_000, MAX_USAGE_HISTORY_RETAINED_BYTES=256MB; discovery via streamed opendir. Tests: claude-usage/scanner-large-directory.test.ts, claude-usage/scanner.test.ts
- Keybinding file: MAX_KEYBINDING_FILE_BYTES=1MB, MAX_KEYBINDING_JSON_STRUCTURAL_TOKENS=256K, nesting depth 64, bounded pretty-serialize on write. Test: keybindings/keybinding-file-bounds.test.ts
- Stats retention: STATS_FILE_MAX_BYTES=16MB, STATS_EVENT_MAX_ENTRIES=10_000, STATS_EVENT_MAX_BYTES=1MB, STATS_EVENT_MAX_RETAINED_BYTES=12MB, live agents 4096/id 4KB/1MB retained, countedPRs 2000/8KB/1MB. Tests: stats/collector-retention.test.ts, stats/stats-file-json-admission.test.ts
- Rate-limit service: MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES=8, MAX_INACTIVE_RATE_LIMIT_ACCOUNTS=256, account-id 1KB; single shared fetch-idle promise. Test: rate-limits/service.test.ts
- Auth filesystem: MAX_QUEUED_WSL_AUTH_OPERATIONS=128, MAX_AUTH_FILESYSTEM_OPERATION_WAITERS=256, MAX_AUTH_FILESYSTEM_REGISTRY_ENTRIES=128, path 64KB, registry 8MB. Tests: rate-limits/auth-filesystem-operation.test.ts, codex-auth-presence.test.ts, codex-fetcher-backend.test.ts
- Codex RPC stdout line cap MAX_RPC_RESPONSE_LINE_BYTES=4MB (kills child), stderr tail 100KB via GrowingByteBuffer. Test: rate-limits/codex-fetcher-rpc-buffer.test.ts
- Hidden rate-limit PTYs MAX_ACTIVE_HIDDEN_RATE_LIMIT_PTYS=16 (over-cap torn down). Test: rate-limits/hidden-pty-cleanup.test.ts
- mac resolver scutil output MAC_RESOLVER_OUTPUT_MAX_BYTES=1MB (kills child, fails to 'unknown'). Test: network/macos-system-resolver-health.test.ts
- Gemini CLI extraction: source 32MB, package.json 1MB, bundle entries 4096/files 512/128MB, which-output 64KB; streamed opendir. Test: rate-limits/gemini-cli-oauth-extractor-bounds.test.ts
- Legacy OMP overlay migration (temp shim, remove after 2026-08-07): entries 100_000, depth 256, path 64KB, retained-path 16MB; streamed opendirSync. Test: pi/legacy-omp-overlay-migration-bounds.test.ts
- Linux port scanner LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES=2_048, proc text 8MB/per-file 64KB. Test: ports/local-workspace-port-scanner.test.ts
- Warp theme discovery: 1024 dynamic-match cap + 100_000 scanned-entry cap via streamed opendirSync; per-file MAX_THEME_FILE_BYTES=1MB. Tests: warp-themes/discovery.test.ts, warp-themes/index.test.ts
- Local AI text generation MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS=8 with lane-replacement; memory collector MEMORY_HISTORY_MAX_WORKTREES=1024; MiniMax cookie-write concurrency 8. Tests: text-generation/commit-message-text-generation.test.ts, memory/collector.test.ts, rate-limits/minimax-request-context.test.ts
- All provider HTTP bodies routed through readFetchResponseJsonWithinLimit / readFetchResponseTextWithinLimit (claude/codex/gemini/grok/kimi/minimax/opencode fetchers); PTY tails via bounded appendRateLimitPtyOutputTail. Test: rate-limits/rate-limit-pty-output-tail.test.ts

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **medium**: Concurrent local AI text generations (commit-message / PR-field / model discovery) are capped at 8 distinct lanes; the 9th returns 'Too many local AI generations are already running. Wait for one to finish and try again.' Same-lane (same cwd+operation) requests still supersede correctly. _(trigger: A user triggering local-agent commit-message/PR generation across 9+ worktrees or repos simultaneously — reachable in heavy multi-worktree use, though 8 concurrent local subprocess generations is uncommon.)_
- **medium**: Concurrent local AI generations (commit-message / PR-field / local model discovery) are globally capped at 8 distinct lanes. The 9th distinct-lane request resolves with success:false, error 'Too many local AI generations are already running. Wait for one to finish and try again.' Same-lane (same operation+cwd) requests correctly supersede the running one (kill + replace) rather than being rejected. This is the intended ceiling, not a bug; it is only reachable at/above the limit (8 simultaneous distinct-lane local subprocess generations), not below it. _(trigger: A user triggering local-agent commit-message/PR/model-discovery generation across 9+ distinct worktrees/repos simultaneously. Verified by tests 'caps concurrent local text-generation child processes' and 'waits for a full-capacity lane to close before spawning its replacement'.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Provider auth/credential files (grok/kimi/claude/codex auth.json, minimax cookie) over 1MB now fail the read (throw NodeFileReadTooLargeError / return error status) instead of loading — real auth files are KB-sized.
- Hermes/amp/kimi hook config or plugin files exceeding their byte caps now surface an 'error'/'blocked' install status (and refuse to overwrite) rather than silently proceeding.
- Claude usage scan throws UsageHistoryScanCapacityError when previousProcessedFiles>200k or retained records/bytes exceed 100k/256MB, aborting the whole scan; usage-projection state that fails the byte cap on write is reset to default keeping only scanState.enabled + lastScanError.
- Codex RPC responses with a single >4MB line, or mac scutil output >1MB, kill the child and return an error/'unknown' instead of buffering.
- WSL/Codex auth probes beyond 128 distinct in-flight paths (or 256 waiters / 128 queued) return 'unavailable' / reject with AuthFilesystemOperationLimitError; hidden rate-limit PTYs beyond 16 are torn down and throw.
- Warp dynamic theme directories beyond 1024 matches (or 100k scanned entries) are ignored; keybinding/stats files beyond their byte or structural-token caps start fresh / preserve prior file.
- Stats events over 1MB each, live-agent ids over 4KB, or countedPR urls over 8KB are silently dropped from their retained collections (aggregate counters still increment).
- The Claude usage/analytics scan aborts with a capacity error (and the persisted projection can reset) once retained usage records exceed 100k or the projection exceeds 256MB, showing empty/errored usage instead of partial data. _(only when: A very heavy, long-lived Claude user accumulating 100k+ deduped assistant turns across transcripts over many months.)_
- Only the first 1024 dynamically-discovered warp-* theme directories (and first 100k scanned dir entries) are considered; extra Warp channel dirs beyond that are silently skipped. _(only when: A home/XDG data dir containing >1024 directories starting with .warp/warp- — effectively never in normal use.)_
- Only the first 1024 dynamically discovered warp-* theme directories (and first 100k scanned dir entries) are considered; extra Warp channel dirs beyond that are silently skipped. _(only when: A home/XDG data dir containing >1024 directories matching the warp channel pattern — effectively never in normal use.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.
- Touches 2 file(s) also changed on `main` since the revert; git auto-merges them (no conflict): `agent-status-extension-source.test.ts`, `agent-status-extension-source.ts`.

### Adversarial review
- 2 skeptic lens(es). Sign-off: **FLAGGED — see above**. Residual risk: **low**.
- Verified all key ceilings in TARGET (6eb70d8370). Caps and their real values: MAX_CONCURRENT_LOCAL_TEXT_GENERATIONS=8 (global, cross-lane; supersede same-lane; discovery deduped by sha256 identity in commit-message-text-generation.ts); usage-history-scan-budget.ts records=100k, retainedBytes=256MB, files=200k, discoveryEntries=1M, ownershipKeys=100k; usage-history-jsonl-reader.ts line cap=4MB; service.ts MAX_ACTIVE_RATE_LIMIT_FETCH_CYCLES=8 / MAX_INACTIVE_RATE_LIMIT_ACCOUNTS=256 / account-id 1KB; keybinding-file.ts 1MB/256k tokens/depth64; warp discovery 1024 matches/100k entries; stats-retention.ts 16MB file, 10k events, 1MB/event, 12MB retained, 4096 live agents (4KB id), 2000 counted PRs (8KB url); auth-filesystem-operation.ts 2 concurrent/128 queued/256 waiters/64KB path; codex-fetcher MAX_RPC_RESPONSE_LINE_BYTES=4MB. Two prior-review correctness concerns are resolved: (1) scanClaudeUsageFiles capacity error is caught in store.ts runScan try/catch (line 448) and degraded to a visible lastScanError, not an unhandled rejection; (2) beginFetchCycle's throw at 8 is unreachable because each cycle kind (active, inactive-claude, inactive-codex) is guarded against duplicate concurrent runs, so distinct concurrent cycles stay well below 8. Reservation activate()-before-resolveClosed() ordering in local-ai-process-budget.ts is correct — the predecessor's slot is reclaimed before the awaiting waiter resumes to register(). GrowingByteBuffer.toString() is read before clear() in the finish path, so no output loss. Model discovery is user-initiated per native-chat tab (native-chat-session-option-discovery.ts), not a background fan-out. No normal-path (below-limit) behavior change found; all remaining caps sit far above ordinary repos/files/sessions. Safe to open as a draft PR for human sign-off; the 8-way local-AI cap and 100k usage-record cap are the only user-visible changes and both require heavy/overload use.

### Files
81 files changed (+4322 / −875).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
