### PR TITLE
oom(13/29): bound daemon admission & PTY delivery credits

### DIFF
--- a/src/main/daemon/binary-frame.test.ts
+++ b/src/main/daemon/binary-frame.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { encodeFrame, createFrameParser, FrameType, FRAME_HEADER_SIZE } from './binary-frame'
+import { FRAME_MAX_PAYLOAD } from './types'
 
 describe('encodeFrame', () => {
   it('encodes a data frame with correct header', () => {
@@ -128,6 +129,22 @@ describe('createFrameParser', () => {
     expect(onFrame).toHaveBeenCalledOnce()
     expect(onFrame.mock.calls[0][0]).toBe(FrameType.Kill)
     expect(onFrame.mock.calls[0][1].length).toBe(0)
+  })
+
+  it('rejects an oversized declared payload from the header alone', () => {
+    const onFrame = vi.fn()
+    const parser = createFrameParser(onFrame)
+    const header = Buffer.alloc(FRAME_HEADER_SIZE)
+    header[0] = FrameType.Data
+    header.writeUInt32BE(FRAME_MAX_PAYLOAD + 1, 1)
+
+    expect(() => parser.feed(header)).toThrow(
+      `Frame payload ${FRAME_MAX_PAYLOAD + 1} exceeds max ${FRAME_MAX_PAYLOAD}`
+    )
+    expect(onFrame).not.toHaveBeenCalled()
+
+    parser.feed(encodeFrame(FrameType.Data, Buffer.from('fresh')))
+    expect(onFrame).toHaveBeenCalledOnce()
   })
 
   it('parses different frame types correctly', () => {

--- a/src/main/daemon/binary-frame.ts
+++ b/src/main/daemon/binary-frame.ts
@@ -29,6 +29,10 @@ export function createFrameParser(
   function parse(): void {
     while (buffer.length >= FRAME_HEADER_SIZE) {
       const payloadLength = buffer.readUInt32BE(1)
+      if (payloadLength > FRAME_MAX_PAYLOAD) {
+        buffer = Buffer.alloc(0)
+        throw new Error(`Frame payload ${payloadLength} exceeds max ${FRAME_MAX_PAYLOAD}`)
+      }
       const totalLength = FRAME_HEADER_SIZE + payloadLength
 
       if (buffer.length < totalLength) {

--- a/src/main/daemon/client.test.ts
+++ b/src/main/daemon/client.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
 import { DaemonClient } from './client'
-import { encodeNdjson } from './ndjson'
+import { DAEMON_HANDSHAKE_MAX_LINE_BYTES, encodeNdjson } from './ndjson'
 import type { HelloMessage, DaemonRequest, DaemonEvent } from './types'
 import { getDaemonSocketPath } from './daemon-spawner'
 
@@ -305,6 +305,31 @@ describe('DaemonClient', () => {
       await rejection
       expect(write).toHaveBeenCalledOnce()
       expect(destroy).toHaveBeenCalledOnce()
+      expect(socket.listenerCount('data')).toBe(0)
+      expect(socket.listenerCount('error')).toBe(0)
+      expect(socket.listenerCount('close')).toBe(0)
+    })
+
+    it('rejects a newline-free oversized hello response before the timeout', async () => {
+      client = new DaemonClient({ socketPath, tokenPath })
+      const socket = new EventEmitter() as Socket
+      socket.write = vi.fn(() => true) as unknown as Socket['write']
+      socket.destroy = vi.fn() as unknown as Socket['destroy']
+      const sendHello = (
+        client as unknown as {
+          sendHello(
+            socket: Socket,
+            token: string,
+            role: 'control' | 'stream',
+            timeoutMs: number
+          ): Promise<void>
+        }
+      ).sendHello.bind(client)
+
+      const promise = sendHello(socket, 'test-token-123', 'control', 60_000)
+      socket.emit('data', Buffer.alloc(DAEMON_HANDSHAKE_MAX_LINE_BYTES + 1, 0x78))
+
+      await expect(promise).rejects.toThrow('Invalid hello response')
       expect(socket.listenerCount('data')).toBe(0)
       expect(socket.listenerCount('error')).toBe(0)
       expect(socket.listenerCount('close')).toBe(0)

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -1,9 +1,18 @@
 /* eslint-disable max-lines -- Why: daemon handshake, RPC, stream events, and reconnect cleanup share one socket lifecycle. */
 import { connect, type Socket } from 'node:net'
-import { readFileSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { StringDecoder } from 'node:string_decoder'
-import { encodeNdjson, createNdjsonParser } from './ndjson'
+import {
+  DAEMON_HANDSHAKE_MAX_LINE_BYTES,
+  encodeBoundedNdjson,
+  encodeNdjson,
+  createNdjsonParser
+} from './ndjson'
+import {
+  DAEMON_CONTROL_SOCKET_MAX_BUFFERED_BYTES,
+  DAEMON_MAX_ACTIVE_REQUEST_BYTES_PER_CLIENT,
+  DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT
+} from './daemon-admission-limits'
 import {
   CLEAN_DISCONNECT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
@@ -18,10 +27,14 @@ import type {
   DaemonEvent
 } from './types'
 import { addNodePtyRecoveryHint } from './node-pty-error-hints'
+import { readDaemonControlFileText } from './daemon-control-file-reader'
 
 const CONNECT_TIMEOUT_MS = 5000
 const CONNECTION_ATTEMPT_WAIT_MS = CONNECT_TIMEOUT_MS * 4
 const REQUEST_TIMEOUT_MS = 30000
+export const DAEMON_CLIENT_MAX_PENDING_REQUESTS = DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT
+export const DAEMON_CLIENT_MAX_CONTROL_BUFFERED_BYTES = DAEMON_CONTROL_SOCKET_MAX_BUFFERED_BYTES
+export const DAEMON_CLIENT_MAX_REQUEST_LINE_BYTES = DAEMON_MAX_ACTIVE_REQUEST_BYTES_PER_CLIENT
 
 export type DaemonClientOptions = {
   socketPath: string
@@ -118,7 +131,7 @@ export class DaemonClient {
     attemptGeneration: number,
     sharedBudget: boolean
   ): Promise<void> {
-    const token = readFileSync(this.tokenPath, 'utf-8').trim()
+    const token = readDaemonControlFileText(this.tokenPath).trim()
     const deadlineMs = Date.now() + timeoutMs
     const remainingMs = (): number =>
       sharedBudget ? Math.max(1, deadlineMs - Date.now()) : timeoutMs
@@ -196,9 +209,18 @@ export class DaemonClient {
     if (!this.connected || !this.controlSocket) {
       throw new DaemonProtocolError('Not connected')
     }
+    if (this.pendingRequests.size >= DAEMON_CLIENT_MAX_PENDING_REQUESTS) {
+      throw new DaemonProtocolError('Daemon client pending request limit reached')
+    }
 
     const id = `req-${++this.requestCounter}`
     const msg = { id, type, ...(payload !== undefined ? { payload } : {}) }
+    const encoded = encodeBoundedNdjson(msg, DAEMON_CLIENT_MAX_REQUEST_LINE_BYTES + 1)
+    const socket = this.controlSocket
+    if (!this.canBufferControlMessage(socket, encoded)) {
+      socket.destroy(new DaemonProtocolError('Daemon client control buffer limit reached'))
+      throw new DaemonProtocolError('Daemon client control buffer limit reached')
+    }
 
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -212,7 +234,13 @@ export class DaemonClient {
         timer
       })
 
-      this.controlSocket!.write(encodeNdjson(msg))
+      try {
+        socket.write(encoded)
+      } catch (error) {
+        this.pendingRequests.delete(id)
+        clearTimeout(timer)
+        reject(error instanceof Error ? error : new DaemonProtocolError(String(error)))
+      }
     })
   }
 
@@ -223,7 +251,14 @@ export class DaemonClient {
 
     const id = `${NOTIFY_PREFIX}${++this.requestCounter}`
     const msg = { id, type, ...(payload !== undefined ? { payload } : {}) }
-    this.controlSocket.write(encodeNdjson(msg))
+    const encoded = encodeBoundedNdjson(msg, DAEMON_CLIENT_MAX_REQUEST_LINE_BYTES + 1)
+    if (!this.canBufferControlMessage(this.controlSocket, encoded)) {
+      this.controlSocket.destroy(
+        new DaemonProtocolError('Daemon client control buffer limit reached')
+      )
+      return
+    }
+    this.controlSocket.write(encoded)
   }
 
   onEvent(listener: (event: unknown) => void): () => void {
@@ -333,7 +368,6 @@ export class DaemonClient {
         role
       }
 
-      let buffer = ''
       let settled = false
       let timer: ReturnType<typeof setTimeout> | null = null
       const cleanup = (): void => {
@@ -360,16 +394,12 @@ export class DaemonClient {
       // Why: daemon socket chunks can split emoji/box-drawing UTF-8 bytes.
       // Decoding each Buffer independently would permanently inject U+FFFD.
       const decoder = new StringDecoder('utf8')
-      const onData = (chunk: Buffer): void => {
-        buffer += decoder.write(chunk)
-        const newlineIdx = buffer.indexOf('\n')
-        if (newlineIdx === -1) {
-          return
-        }
-
-        const line = buffer.slice(0, newlineIdx)
-        try {
-          const response = JSON.parse(line) as HelloResponse
+      const parser = createNdjsonParser(
+        (message) => {
+          if (settled) {
+            return
+          }
+          const response = message as HelloResponse
           if (response.ok) {
             const identity = parseDaemonEndpointIdentity(response.daemonIdentity)
             if (
@@ -385,9 +415,15 @@ export class DaemonClient {
               new DaemonProtocolError(addNodePtyRecoveryHint(response.error ?? 'Hello rejected'))
             )
           }
-        } catch {
-          finish(new DaemonProtocolError('Invalid hello response'))
+        },
+        () => finish(new DaemonProtocolError('Invalid hello response')),
+        { maxLineBytes: DAEMON_HANDSHAKE_MAX_LINE_BYTES }
+      )
+      const onData = (chunk: Buffer): void => {
+        if (settled) {
+          return
         }
+        parser.feed(decoder.write(chunk))
       }
       const onError = (error: Error): void => finish(error)
       const onClose = (): void =>
@@ -453,6 +489,11 @@ export class DaemonClient {
     const onData = (chunk: Buffer) => parser.feed(decoder.write(chunk))
     socket.on('data', onData)
     return () => socket.off('data', onData)
+  }
+
+  private canBufferControlMessage(socket: Socket, encoded: string): boolean {
+    const messageBytes = Buffer.byteLength(encoded, 'utf8')
+    return messageBytes <= DAEMON_CLIENT_MAX_CONTROL_BUFFERED_BYTES - socket.writableLength
   }
 
   private handleDisconnect(generation: number): void {

--- a/src/main/daemon/daemon-admission-limits.test.ts
+++ b/src/main/daemon/daemon-admission-limits.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DAEMON_CLIENT_ID_MAX_BYTES,
+  DAEMON_PTY_COMMAND_MAX_BYTES,
+  DAEMON_PTY_CWD_MAX_BYTES,
+  DAEMON_PTY_ENV_DELETE_MAX_ENTRIES,
+  DAEMON_PTY_ENV_MAX_BYTES,
+  DAEMON_PTY_ENV_MAX_ENTRIES,
+  DAEMON_PTY_ENV_VALUE_MAX_BYTES,
+  DAEMON_PTY_HISTORY_SEED_MAX_BYTES,
+  DAEMON_REQUEST_ID_MAX_BYTES,
+  DAEMON_SESSION_ID_MAX_BYTES,
+  daemonHelloAdmissionError,
+  daemonRequestAdmissionError
+} from './daemon-admission-limits'
+import { MAX_TERMINAL_COLS, MAX_TERMINAL_ROWS } from '../../shared/terminal-size-limits'
+
+function createRequest(payload: Record<string, unknown>): Record<string, unknown> {
+  return { id: 'req-1', type: 'createOrAttach', payload }
+}
+
+describe('daemon admission limits', () => {
+  it('preserves ordinary cross-platform create fields without rewriting them', () => {
+    const request = createRequest({
+      sessionId: 'repo::C:\\projects\\orca@@12345678',
+      cols: 120,
+      rows: 40,
+      cwd: '\\\\wsl.localhost\\Ubuntu\\home\\orca',
+      command: 'printf "ready"',
+      env: { PATH: 'C:\\Windows\\System32', ORCA_TERMINAL_HANDLE: 'term_123' },
+      envToDelete: ['CODEX_HOME'],
+      terminalWindowsWslDistro: null,
+      historySeed: '\u001b[32mrestored\u001b[0m'
+    })
+
+    expect(daemonRequestAdmissionError(request)).toBeNull()
+    expect(request).toEqual(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          cwd: '\\\\wsl.localhost\\Ubuntu\\home\\orca',
+          terminalWindowsWslDistro: null
+        })
+      })
+    )
+  })
+
+  it('measures hello and request identifiers by UTF-8 bytes', () => {
+    const exactClientId = 'é'.repeat(DAEMON_CLIENT_ID_MAX_BYTES / 2)
+    expect(
+      daemonHelloAdmissionError({ type: 'hello', role: 'control', clientId: exactClientId })
+    ).toBeNull()
+    expect(
+      daemonHelloAdmissionError({
+        type: 'hello',
+        role: 'control',
+        clientId: `${exactClientId}é`
+      })
+    ).toContain(`${DAEMON_CLIENT_ID_MAX_BYTES} bytes`)
+
+    const exactRequestId = 'é'.repeat(DAEMON_REQUEST_ID_MAX_BYTES / 2)
+    expect(daemonRequestAdmissionError({ id: exactRequestId, type: 'ping' })).toBeNull()
+    expect(daemonRequestAdmissionError({ id: `${exactRequestId}é`, type: 'ping' })).toContain(
+      `${DAEMON_REQUEST_ID_MAX_BYTES} bytes`
+    )
+  })
+
+  it('rejects unbounded retained identifiers and PTY strings', () => {
+    expect(
+      daemonRequestAdmissionError({
+        id: 'req',
+        type: 'getCwd',
+        payload: { sessionId: 's'.repeat(DAEMON_SESSION_ID_MAX_BYTES + 1) }
+      })
+    ).toContain(`${DAEMON_SESSION_ID_MAX_BYTES} bytes`)
+    expect(
+      daemonRequestAdmissionError(
+        createRequest({
+          sessionId: 's',
+          cwd: 'c'.repeat(DAEMON_PTY_CWD_MAX_BYTES + 1)
+        })
+      )
+    ).toContain(`${DAEMON_PTY_CWD_MAX_BYTES} bytes`)
+    expect(
+      daemonRequestAdmissionError(
+        createRequest({
+          sessionId: 's',
+          command: 'c'.repeat(DAEMON_PTY_COMMAND_MAX_BYTES + 1)
+        })
+      )
+    ).toContain(`${DAEMON_PTY_COMMAND_MAX_BYTES} bytes`)
+    expect(
+      daemonRequestAdmissionError(
+        createRequest({
+          sessionId: 's',
+          historySeed: 'h'.repeat(DAEMON_PTY_HISTORY_SEED_MAX_BYTES + 1)
+        })
+      )
+    ).toContain(`${DAEMON_PTY_HISTORY_SEED_MAX_BYTES} bytes`)
+  })
+
+  it('caps environment entry counts, individual values, and aggregate bytes', () => {
+    const tooManyEntries = Object.fromEntries(
+      Array.from({ length: DAEMON_PTY_ENV_MAX_ENTRIES + 1 }, (_, index) => [`K${index}`, 'v'])
+    )
+    expect(
+      daemonRequestAdmissionError(createRequest({ sessionId: 's', env: tooManyEntries }))
+    ).toContain(`${DAEMON_PTY_ENV_MAX_ENTRIES} entries`)
+
+    expect(
+      daemonRequestAdmissionError(
+        createRequest({
+          sessionId: 's',
+          env: { VALUE: 'v'.repeat(DAEMON_PTY_ENV_VALUE_MAX_BYTES + 1) }
+        })
+      )
+    ).toContain(`${DAEMON_PTY_ENV_VALUE_MAX_BYTES} bytes`)
+
+    const aggregate = Object.fromEntries(
+      Array.from({ length: 5 }, (_, index) => [
+        `K${index}`,
+        'v'.repeat(Math.floor(DAEMON_PTY_ENV_MAX_BYTES / 5))
+      ])
+    )
+    expect(
+      daemonRequestAdmissionError(createRequest({ sessionId: 's', env: aggregate }))
+    ).toContain(`${DAEMON_PTY_ENV_MAX_BYTES} bytes`)
+  })
+
+  it('caps environment deletion lists and rejects malformed retained fields', () => {
+    expect(
+      daemonRequestAdmissionError(
+        createRequest({
+          sessionId: 's',
+          envToDelete: Array.from(
+            { length: DAEMON_PTY_ENV_DELETE_MAX_ENTRIES + 1 },
+            (_, index) => `K${index}`
+          )
+        })
+      )
+    ).toContain(`${DAEMON_PTY_ENV_DELETE_MAX_ENTRIES} entries`)
+    expect(
+      daemonRequestAdmissionError(createRequest({ sessionId: 's', env: ['not-a-record'] }))
+    ).toBe('createOrAttach payload.env must be a string record')
+    expect(daemonRequestAdmissionError({ id: 'req', type: 'getCwd', payload: {} })).toBe(
+      'getCwd payload.sessionId must be a string'
+    )
+  })
+
+  it('rejects PTY dimensions that could force pathological native allocations', () => {
+    expect(
+      daemonRequestAdmissionError(
+        createRequest({ sessionId: 's', cols: MAX_TERMINAL_COLS + 1, rows: 24 })
+      )
+    ).toContain(`1 through ${MAX_TERMINAL_COLS}`)
+    expect(
+      daemonRequestAdmissionError({
+        id: 'req',
+        type: 'resize',
+        payload: { sessionId: 's', cols: 80, rows: MAX_TERMINAL_ROWS + 1 }
+      })
+    ).toContain(`1 through ${MAX_TERMINAL_ROWS}`)
+  })
+})

--- a/src/main/daemon/daemon-admission-limits.ts
+++ b/src/main/daemon/daemon-admission-limits.ts
@@ -1,0 +1,293 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { terminalSizeAdmissionError } from '../../shared/terminal-size-limits'
+
+export const DAEMON_MAX_TRANSPORT_SOCKETS = 128
+export const DAEMON_MAX_CONTROL_CLIENTS = 32
+export const DAEMON_MAX_STREAM_ATTACHMENTS = 24
+export const DAEMON_HANDSHAKE_TIMEOUT_MS = 10_000
+
+export const DAEMON_MAX_ACTIVE_REQUESTS = 256
+export const DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT = 128
+export const DAEMON_MAX_ACTIVE_REQUEST_BYTES = 32 * 1024 * 1024
+export const DAEMON_MAX_ACTIVE_REQUEST_BYTES_PER_CLIENT = 16 * 1024 * 1024
+export const DAEMON_CONTROL_SOCKET_MAX_BUFFERED_BYTES = 32 * 1024 * 1024
+
+export const DAEMON_CLIENT_ID_MAX_BYTES = 1024
+export const DAEMON_REQUEST_ID_MAX_BYTES = 1024
+export const DAEMON_REQUEST_TYPE_MAX_BYTES = 256
+export const DAEMON_SESSION_ID_MAX_BYTES = 4 * 1024
+export const DAEMON_PTY_CWD_MAX_BYTES = 256 * 1024
+export const DAEMON_PTY_COMMAND_MAX_BYTES = 4 * 1024 * 1024
+export const DAEMON_PTY_HISTORY_SEED_MAX_BYTES = 12 * 1024 * 1024
+export const DAEMON_PTY_ENV_MAX_ENTRIES = 4096
+export const DAEMON_PTY_ENV_NAME_MAX_BYTES = 32 * 1024
+export const DAEMON_PTY_ENV_VALUE_MAX_BYTES = 1024 * 1024
+export const DAEMON_PTY_ENV_MAX_BYTES = 4 * 1024 * 1024
+export const DAEMON_PTY_ENV_DELETE_MAX_ENTRIES = 4096
+export const DAEMON_PTY_ENV_DELETE_MAX_BYTES = 1024 * 1024
+
+const REQUESTS_WITH_SESSION_ID = new Set([
+  'cancelCreateOrAttach',
+  'closeStartupQueryAuthority',
+  'write',
+  'resize',
+  'pausePty',
+  'resumePty',
+  'setSessionBackground',
+  'kill',
+  'signal',
+  'detach',
+  'getCwd',
+  'getForegroundProcess',
+  'confirmForegroundProcess',
+  'clearScrollback',
+  'getSnapshot',
+  'getSize',
+  'takePendingOutput'
+])
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function boundedStringError(
+  value: unknown,
+  field: string,
+  maxBytes: number,
+  options: { nonEmpty?: boolean; forbidNull?: boolean } = {}
+): string | null {
+  if (typeof value !== 'string') {
+    return `${field} must be a string`
+  }
+  if (options.nonEmpty && value.length === 0) {
+    return `${field} must not be empty`
+  }
+  if (options.forbidNull && value.includes('\0')) {
+    return `${field} must not contain NUL`
+  }
+  if (
+    value.length > maxBytes ||
+    measureUtf8ByteLength(value, { stopAfterBytes: maxBytes }).exceededLimit
+  ) {
+    return `${field} exceeds ${maxBytes} bytes`
+  }
+  return null
+}
+
+function optionalBoundedStringError(
+  value: unknown,
+  field: string,
+  maxBytes: number
+): string | null {
+  return value === undefined ? null : boundedStringError(value, field, maxBytes)
+}
+
+function optionalNullableBoundedStringError(
+  value: unknown,
+  field: string,
+  maxBytes: number
+): string | null {
+  return value === undefined || value === null ? null : boundedStringError(value, field, maxBytes)
+}
+
+function createEnvironmentError(env: unknown): string | null {
+  if (env === undefined) {
+    return null
+  }
+  if (!isRecord(env)) {
+    return 'createOrAttach payload.env must be a string record'
+  }
+
+  let entries = 0
+  let retainedBytes = 0
+  for (const name in env) {
+    if (!Object.prototype.hasOwnProperty.call(env, name)) {
+      continue
+    }
+    entries += 1
+    if (entries > DAEMON_PTY_ENV_MAX_ENTRIES) {
+      return `createOrAttach payload.env exceeds ${DAEMON_PTY_ENV_MAX_ENTRIES} entries`
+    }
+    const nameError = boundedStringError(
+      name,
+      'createOrAttach payload.env name',
+      DAEMON_PTY_ENV_NAME_MAX_BYTES
+    )
+    if (nameError) {
+      return nameError
+    }
+    const value = env[name]
+    const valueError = boundedStringError(
+      value,
+      'createOrAttach payload.env value',
+      DAEMON_PTY_ENV_VALUE_MAX_BYTES
+    )
+    if (valueError) {
+      return valueError
+    }
+    retainedBytes +=
+      measureUtf8ByteLength(name).byteLength + measureUtf8ByteLength(value as string).byteLength
+    if (retainedBytes > DAEMON_PTY_ENV_MAX_BYTES) {
+      return `createOrAttach payload.env exceeds ${DAEMON_PTY_ENV_MAX_BYTES} bytes`
+    }
+  }
+  return null
+}
+
+function createEnvironmentDeleteError(envToDelete: unknown): string | null {
+  if (envToDelete === undefined) {
+    return null
+  }
+  if (!Array.isArray(envToDelete)) {
+    return 'createOrAttach payload.envToDelete must be a string array'
+  }
+  if (envToDelete.length > DAEMON_PTY_ENV_DELETE_MAX_ENTRIES) {
+    return `createOrAttach payload.envToDelete exceeds ${DAEMON_PTY_ENV_DELETE_MAX_ENTRIES} entries`
+  }
+
+  let retainedBytes = 0
+  for (const name of envToDelete) {
+    const nameError = boundedStringError(
+      name,
+      'createOrAttach payload.envToDelete entry',
+      DAEMON_PTY_ENV_NAME_MAX_BYTES
+    )
+    if (nameError) {
+      return nameError
+    }
+    retainedBytes += measureUtf8ByteLength(name as string).byteLength
+    if (retainedBytes > DAEMON_PTY_ENV_DELETE_MAX_BYTES) {
+      return `createOrAttach payload.envToDelete exceeds ${DAEMON_PTY_ENV_DELETE_MAX_BYTES} bytes`
+    }
+  }
+  return null
+}
+
+function createOrAttachPayloadError(payload: unknown): string | null {
+  if (!isRecord(payload)) {
+    return 'createOrAttach payload must be an object'
+  }
+
+  const checks = [
+    () =>
+      boundedStringError(
+        payload.sessionId,
+        'createOrAttach payload.sessionId',
+        DAEMON_SESSION_ID_MAX_BYTES,
+        { nonEmpty: true, forbidNull: true }
+      ),
+    () =>
+      optionalBoundedStringError(
+        payload.cwd,
+        'createOrAttach payload.cwd',
+        DAEMON_PTY_CWD_MAX_BYTES
+      ),
+    () =>
+      optionalBoundedStringError(
+        payload.command,
+        'createOrAttach payload.command',
+        DAEMON_PTY_COMMAND_MAX_BYTES
+      ),
+    () =>
+      optionalBoundedStringError(
+        payload.historySeed,
+        'createOrAttach payload.historySeed',
+        DAEMON_PTY_HISTORY_SEED_MAX_BYTES
+      ),
+    () =>
+      optionalBoundedStringError(
+        payload.shellOverride,
+        'createOrAttach payload.shellOverride',
+        DAEMON_PTY_CWD_MAX_BYTES
+      ),
+    () =>
+      optionalNullableBoundedStringError(
+        payload.terminalWindowsWslDistro,
+        'createOrAttach payload.terminalWindowsWslDistro',
+        DAEMON_PTY_CWD_MAX_BYTES
+      ),
+    () =>
+      terminalSizeAdmissionError(payload.cols, payload.rows, 'createOrAttach payload', {
+        allowMissing: true
+      }),
+    () => createEnvironmentError(payload.env),
+    () => createEnvironmentDeleteError(payload.envToDelete)
+  ]
+  for (const check of checks) {
+    const error = check()
+    if (error) {
+      return error
+    }
+  }
+  return null
+}
+
+export function daemonHelloAdmissionError(value: unknown): string | null {
+  if (!isRecord(value) || value.type !== 'hello') {
+    return 'Expected hello'
+  }
+  if (value.role !== 'control' && value.role !== 'stream') {
+    return 'Invalid hello role'
+  }
+  return boundedStringError(value.clientId, 'hello clientId', DAEMON_CLIENT_ID_MAX_BYTES, {
+    nonEmpty: true,
+    forbidNull: true
+  })
+}
+
+export function daemonRequestAdmissionError(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return 'Daemon request must be an object'
+  }
+  const idError = boundedStringError(value.id, 'Daemon request id', DAEMON_REQUEST_ID_MAX_BYTES, {
+    nonEmpty: true,
+    forbidNull: true
+  })
+  if (idError) {
+    return idError
+  }
+  const typeError = boundedStringError(
+    value.type,
+    'Daemon request type',
+    DAEMON_REQUEST_TYPE_MAX_BYTES,
+    { nonEmpty: true }
+  )
+  if (typeError) {
+    return typeError
+  }
+  if (value.type === 'createOrAttach') {
+    return createOrAttachPayloadError(value.payload)
+  }
+  if (!REQUESTS_WITH_SESSION_ID.has(value.type as string)) {
+    return null
+  }
+  if (!isRecord(value.payload)) {
+    return `${value.type as string} payload must be an object`
+  }
+  const sessionIdError = boundedStringError(
+    value.payload.sessionId,
+    `${value.type as string} payload.sessionId`,
+    DAEMON_SESSION_ID_MAX_BYTES,
+    { nonEmpty: true, forbidNull: true }
+  )
+  if (sessionIdError) {
+    return sessionIdError
+  }
+  return value.type === 'resize'
+    ? terminalSizeAdmissionError(value.payload.cols, value.payload.rows, 'resize payload')
+    : null
+}
+
+export function getBoundedDaemonRequestId(value: unknown): string | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  return boundedStringError(value.id, 'Daemon request id', DAEMON_REQUEST_ID_MAX_BYTES, {
+    nonEmpty: true,
+    forbidNull: true
+  }) === null
+    ? (value.id as string)
+    : null
+}

--- a/src/main/daemon/daemon-client-outbound-admission.test.ts
+++ b/src/main/daemon/daemon-client-outbound-admission.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DAEMON_CLIENT_MAX_CONTROL_BUFFERED_BYTES,
+  DAEMON_CLIENT_MAX_PENDING_REQUESTS,
+  DAEMON_CLIENT_MAX_REQUEST_LINE_BYTES,
+  DaemonClient
+} from './client'
+
+type PendingRequest = {
+  resolve: (value: unknown) => void
+  reject: (reason: Error) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
+type FakeControlSocket = {
+  writableLength: number
+  write: ReturnType<typeof vi.fn>
+  destroy: ReturnType<typeof vi.fn>
+}
+
+function createConnectedClient(): {
+  client: DaemonClient
+  socket: FakeControlSocket
+  pendingRequests: Map<string, PendingRequest>
+} {
+  const client = new DaemonClient({ socketPath: 'unused', tokenPath: 'unused' })
+  const socket: FakeControlSocket = {
+    writableLength: 0,
+    write: vi.fn(() => true),
+    destroy: vi.fn()
+  }
+  const pendingRequests = new Map<string, PendingRequest>()
+  const state = client as unknown as {
+    connected: boolean
+    controlSocket: FakeControlSocket
+    pendingRequests: Map<string, PendingRequest>
+  }
+  state.connected = true
+  state.controlSocket = socket
+  state.pendingRequests = pendingRequests
+  return { client, socket, pendingRequests }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('DaemonClient outbound admission', () => {
+  it('rejects before serialization when the pending request cap is full', async () => {
+    vi.useFakeTimers()
+    const { client, socket, pendingRequests } = createConnectedClient()
+    for (let index = 0; index < DAEMON_CLIENT_MAX_PENDING_REQUESTS; index += 1) {
+      pendingRequests.set(`request-${index}`, {
+        resolve: () => {},
+        reject: () => {},
+        timer: setTimeout(() => {}, 60_000)
+      })
+    }
+
+    await expect(
+      client.request('write', { data: 'x'.repeat(DAEMON_CLIENT_MAX_REQUEST_LINE_BYTES) })
+    ).rejects.toThrow('pending request limit')
+
+    expect(socket.write).not.toHaveBeenCalled()
+    expect(pendingRequests.size).toBe(DAEMON_CLIENT_MAX_PENDING_REQUESTS)
+    for (const pending of pendingRequests.values()) {
+      clearTimeout(pending.timer)
+    }
+  })
+
+  it('rejects a request whose serialized line exceeds the daemon contract', async () => {
+    const { client, socket, pendingRequests } = createConnectedClient()
+
+    await expect(
+      client.request('write', {
+        data: 'x'.repeat(DAEMON_CLIENT_MAX_REQUEST_LINE_BYTES)
+      })
+    ).rejects.toThrow()
+
+    expect(socket.write).not.toHaveBeenCalled()
+    expect(pendingRequests.size).toBe(0)
+  })
+
+  it('rejects and closes before growing a saturated control buffer', async () => {
+    const { client, socket, pendingRequests } = createConnectedClient()
+    socket.writableLength = DAEMON_CLIENT_MAX_CONTROL_BUFFERED_BYTES
+
+    await expect(client.request('listSessions', undefined)).rejects.toThrow('control buffer limit')
+
+    expect(socket.write).not.toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalledOnce()
+    expect(pendingRequests.size).toBe(0)
+  })
+
+  it('releases request admission when socket.write throws', async () => {
+    vi.useFakeTimers()
+    const { client, socket, pendingRequests } = createConnectedClient()
+    socket.write.mockImplementation(() => {
+      throw new Error('write failed')
+    })
+
+    await expect(client.request('listSessions', undefined)).rejects.toThrow('write failed')
+
+    expect(pendingRequests.size).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('drops a notification and closes before growing a saturated control buffer', () => {
+    const { client, socket } = createConnectedClient()
+    socket.writableLength = DAEMON_CLIENT_MAX_CONTROL_BUFFERED_BYTES
+
+    client.notify('write', { sessionId: 'session-a', data: 'hello' })
+
+    expect(socket.write).not.toHaveBeenCalled()
+    expect(socket.destroy).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/daemon/daemon-control-file-reader.test.ts
+++ b/src/main/daemon/daemon-control-file-reader.test.ts
@@ -1,0 +1,40 @@
+import { closeSync, ftruncateSync, mkdtempSync, openSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_DAEMON_CONTROL_FILE_BYTES,
+  readDaemonControlFileText
+} from './daemon-control-file-reader'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function createPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-daemon-control-'))
+  roots.push(root)
+  return join(root, 'control')
+}
+
+describe('readDaemonControlFileText', () => {
+  it('accepts a control file exactly at the byte cap', () => {
+    const filePath = createPath()
+    writeFileSync(filePath, Buffer.alloc(MAX_DAEMON_CONTROL_FILE_BYTES, 0x61))
+
+    expect(readDaemonControlFileText(filePath)).toHaveLength(MAX_DAEMON_CONTROL_FILE_BYTES)
+  })
+
+  it('rejects a sparse control file beyond the byte cap', () => {
+    const filePath = createPath()
+    const file = openSync(filePath, 'w')
+    ftruncateSync(file, MAX_DAEMON_CONTROL_FILE_BYTES + 1)
+    closeSync(file)
+
+    expect(() => readDaemonControlFileText(filePath)).toThrow('exceeds')
+  })
+})

--- a/src/main/daemon/daemon-control-file-reader.ts
+++ b/src/main/daemon/daemon-control-file-reader.ts
@@ -1,0 +1,9 @@
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+
+export const MAX_DAEMON_CONTROL_FILE_BYTES = 64 * 1024
+
+export function readDaemonControlFileText(filePath: string): string {
+  return readNodeFileSyncWithinLimit(filePath, MAX_DAEMON_CONTROL_FILE_BYTES).buffer.toString(
+    'utf8'
+  )
+}

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -6,7 +6,6 @@
  * Signals readiness to parent via IPC: { type: 'ready' }
  * Shuts down cleanly on SIGTERM.
  */
-import { readFileSync } from 'node:fs'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { createPtySubprocess } from './pty-subprocess'
 import { warmWindowsConptyOnce } from './windows-conpty-warmup'
@@ -17,6 +16,7 @@ import {
   prepareMacosTccLoginShell,
   probeMacosLoginSessionAlive
 } from '../providers/macos-tcc-login-shell'
+import { readDaemonLoginSessionProbeVerdict } from './daemon-login-session-probe-verdict'
 import { MacosLoginSessionDeathWatch } from './macos-login-session-death-watch'
 import { readCurrentProcessMacSystemResolverHealth } from '../network/macos-system-resolver-health'
 
@@ -176,13 +176,7 @@ async function main(): Promise<void> {
   // 'alive' → accepted/healthy, 'dead' → rejected/unhealthy, 'hang' →
   // timeout-inconclusive/unhealthy (the fail-safe path), else inconclusive.
   const e2eProbeFile = process.env.ORCA_E2E_LOGIN_SESSION_PROBE_FILE
-  const readE2eVerdict = (): string => {
-    try {
-      return readFileSync(e2eProbeFile as string, 'utf8').trim()
-    } catch {
-      return ''
-    }
-  }
+  const readE2eVerdict = (): string => readDaemonLoginSessionProbeVerdict(e2eProbeFile as string)
   deathWatch =
     loginSessionWatch && process.platform === 'darwin'
       ? new MacosLoginSessionDeathWatch({

--- a/src/main/daemon/daemon-health-socket-cleanup.test.ts
+++ b/src/main/daemon/daemon-health-socket-cleanup.test.ts
@@ -10,7 +10,8 @@ const { netConnectMock } = vi.hoisted(() => ({
 
 vi.mock('net', () => ({ connect: netConnectMock }))
 
-import { healthCheckDaemon, killStaleDaemon } from './daemon-health'
+import { checkDaemonHealth, healthCheckDaemon, killStaleDaemon } from './daemon-health'
+import { DAEMON_HANDSHAKE_MAX_LINE_BYTES } from './ndjson'
 
 class FakeSocket extends EventEmitter {
   destroy = vi.fn()
@@ -69,6 +70,21 @@ describe('daemon health socket listener cleanup', () => {
     expect(socket.listenerCount('error')).toBe(0)
     expect(socket.listenerCount('data')).toBe(0)
     expect(socket.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects and releases a newline-free oversized health response', async () => {
+    const socket = new FakeSocket()
+    netConnectMock.mockReturnValueOnce(socket)
+
+    const result = checkDaemonHealth(socketPath, tokenPath)
+    socket.emit('connect')
+    socket.emit('data', Buffer.alloc(DAEMON_HANDSHAKE_MAX_LINE_BYTES + 1, 0x78))
+
+    await expect(result).resolves.toBe('rejected')
+    expect(socket.listenerCount('connect')).toBe(0)
+    expect(socket.listenerCount('error')).toBe(0)
+    expect(socket.listenerCount('data')).toBe(0)
+    expect(socket.destroy).toHaveBeenCalledOnce()
   })
 
   it('removes stale-socket probe listeners after a timeout', async () => {

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -4,12 +4,13 @@ import { execFile, execFileSync } from 'node:child_process'
 import { existsSync, readFileSync, unlinkSync } from 'node:fs'
 import { connect, type Socket } from 'node:net'
 import { promisify } from 'node:util'
+import { StringDecoder } from 'node:string_decoder'
 import {
   getProcessOutputFields,
   iterateProcessOutputLines
 } from '../../shared/process-output-field-scanner'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from '../startup/startup-diagnostics'
-import { encodeNdjson } from './ndjson'
+import { DAEMON_HANDSHAKE_MAX_LINE_BYTES, createNdjsonParser, encodeNdjson } from './ndjson'
 import { getDaemonPidPath } from './daemon-spawner'
 import {
   PROTOCOL_VERSION,
@@ -18,6 +19,7 @@ import {
   type SystemResolverHealth,
   type SystemResolverHealthResult
 } from './types'
+import { readDaemonControlFileText } from './daemon-control-file-reader'
 
 const HEALTH_CHECK_TIMEOUT_MS = 3_000
 const RESOLVER_HEALTH_CHECK_TIMEOUT_MS = 3_000
@@ -89,7 +91,7 @@ export function checkDaemonHealth(socketPath: string, tokenPath: string): Promis
 
     let token: string
     try {
-      token = readFileSync(tokenPath, 'utf8').trim()
+      token = readDaemonControlFileText(tokenPath).trim()
     } catch {
       resolve('unreachable')
       return
@@ -123,55 +125,42 @@ export function checkDaemonHealth(socketPath: string, tokenPath: string): Promis
       }
       sock?.write(encodeNdjson(hello))
     }
-    const onData = (chunk: Buffer): void => {
+    const onMessage = (rawMessage: unknown): void => {
       if (settled) {
         return
       }
-      buffer += chunk.toString()
-      for (;;) {
-        const newlineIdx = buffer.indexOf('\n')
-        if (newlineIdx === -1) {
-          break
-        }
-        const line = buffer.slice(0, newlineIdx)
-        buffer = buffer.slice(newlineIdx + 1)
-        if (!line) {
-          continue
-        }
-
-        let message: Record<string, unknown>
-        try {
-          message = JSON.parse(line) as Record<string, unknown>
-        } catch {
+      if (!rawMessage || typeof rawMessage !== 'object') {
+        settle('rejected')
+        return
+      }
+      const message = rawMessage as Record<string, unknown>
+      if (message.type === 'hello') {
+        if (!(message as HelloResponse).ok) {
           settle('rejected')
           return
         }
+        // Why: a protocol-live daemon with a stale cwd or node-pty helper
+        // will answer ping but cannot create terminals, so reuse must check
+        // the PTY spawn prerequisites too.
+        sock?.write(encodeNdjson({ id: 'health-1', type: 'ptySpawnHealth' }))
+        return
+      }
 
-        if (message.type === 'hello') {
-          if (!(message as HelloResponse).ok) {
-            settle('rejected')
-            return
-          }
-          // Why: a protocol-live daemon with a stale cwd or node-pty helper
-          // will answer ping but cannot create terminals, so reuse must check
-          // the PTY spawn prerequisites too.
-          sock?.write(encodeNdjson({ id: 'health-1', type: 'ptySpawnHealth' }))
-          continue
-        }
-
-        if (message.id === 'health-1') {
-          settle(message.ok === true ? 'healthy' : 'pty-spawn-unhealthy')
-          return
-        }
+      if (message.id === 'health-1') {
+        settle(message.ok === true ? 'healthy' : 'pty-spawn-unhealthy')
       }
     }
+    const decoder = new StringDecoder('utf8')
+    const parser = createNdjsonParser(onMessage, () => settle('rejected'), {
+      maxLineBytes: DAEMON_HANDSHAKE_MAX_LINE_BYTES
+    })
+    const onData = (chunk: Buffer): void => parser.feed(decoder.write(chunk))
     const timer = setTimeout(() => settle('unreachable'), HEALTH_CHECK_TIMEOUT_MS)
 
     sock = connect({ path: socketPath })
     sock.on('error', onError)
     sock.on('connect', onConnect)
 
-    let buffer = ''
     sock.on('data', onData)
   })
 }
@@ -201,7 +190,7 @@ export function getMacDaemonSystemResolverHealth(
 
     let token: string
     try {
-      token = readFileSync(tokenPath, 'utf8').trim()
+      token = readDaemonControlFileText(tokenPath).trim()
     } catch {
       resolve('unknown')
       return
@@ -235,59 +224,46 @@ export function getMacDaemonSystemResolverHealth(
       }
       sock?.write(encodeNdjson(hello))
     }
-    const onData = (chunk: Buffer): void => {
+    const onMessage = (rawMessage: unknown): void => {
       if (settled) {
         return
       }
-      buffer += chunk.toString()
-      for (;;) {
-        const newlineIdx = buffer.indexOf('\n')
-        if (newlineIdx === -1) {
-          break
-        }
-        const line = buffer.slice(0, newlineIdx)
-        buffer = buffer.slice(newlineIdx + 1)
-        if (!line) {
-          continue
-        }
-
-        let message: Record<string, unknown>
-        try {
-          message = JSON.parse(line) as Record<string, unknown>
-        } catch {
+      if (!rawMessage || typeof rawMessage !== 'object') {
+        settle('unknown')
+        return
+      }
+      const message = rawMessage as Record<string, unknown>
+      if (message.type === 'hello') {
+        if (!(message as HelloResponse).ok) {
           settle('unknown')
           return
         }
+        // Why: the daemon must report health from inside its own process;
+        // external launchctl bsexec probes can misclassify healthy PTYs.
+        sock?.write(encodeNdjson({ id: 'resolver-health-1', type: 'systemResolverHealth' }))
+        return
+      }
 
-        if (message.type === 'hello') {
-          if (!(message as HelloResponse).ok) {
-            settle('unknown')
-            return
-          }
-          // Why: the daemon must report health from inside its own process;
-          // external launchctl bsexec probes can misclassify healthy PTYs.
-          sock?.write(encodeNdjson({ id: 'resolver-health-1', type: 'systemResolverHealth' }))
-          continue
-        }
-
-        if (message.id === 'resolver-health-1') {
-          if (!message.ok || typeof message.payload !== 'object' || message.payload === null) {
-            settle('unknown')
-            return
-          }
-          const payload = message.payload as Partial<SystemResolverHealthResult>
-          settle(isSystemResolverHealth(payload.health) ? payload.health : 'unknown')
+      if (message.id === 'resolver-health-1') {
+        if (!message.ok || typeof message.payload !== 'object' || message.payload === null) {
+          settle('unknown')
           return
         }
+        const payload = message.payload as Partial<SystemResolverHealthResult>
+        settle(isSystemResolverHealth(payload.health) ? payload.health : 'unknown')
       }
     }
+    const decoder = new StringDecoder('utf8')
+    const parser = createNdjsonParser(onMessage, () => settle('unknown'), {
+      maxLineBytes: DAEMON_HANDSHAKE_MAX_LINE_BYTES
+    })
+    const onData = (chunk: Buffer): void => parser.feed(decoder.write(chunk))
     const timer = setTimeout(() => settle('unknown'), RESOLVER_HEALTH_CHECK_TIMEOUT_MS)
 
     sock = connect({ path: socketPath })
     sock.on('error', onError)
     sock.on('connect', onConnect)
 
-    let buffer = ''
     sock.on('data', onData)
   })
 }
@@ -591,7 +567,7 @@ async function readVerifiedDaemonPid(
   let parsedPid: ParsedDaemonPid | null
   try {
     parsedPid = parseDaemonPidFile(
-      readFileSync(getDaemonPidPath(runtimeDir, protocolVersion), 'utf8')
+      readDaemonControlFileText(getDaemonPidPath(runtimeDir, protocolVersion))
     )
   } catch {
     return null
@@ -638,7 +614,7 @@ export async function killStaleDaemon(
   const pidPath = getDaemonPidPath(runtimeDir, protocolVersion)
   let killedDaemon = false
   try {
-    const parsedPid = parseDaemonPidFile(readFileSync(pidPath, 'utf8'))
+    const parsedPid = parseDaemonPidFile(readDaemonControlFileText(pidPath))
     if (
       parsedPid &&
       (await isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs))

--- a/src/main/daemon/daemon-host-relocation.ts
+++ b/src/main/daemon/daemon-host-relocation.ts
@@ -3,8 +3,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
-  readFileSync,
-  readdirSync,
+  opendirSync,
   renameSync,
   rmSync,
   writeFileSync
@@ -12,6 +11,7 @@ import {
 import { dirname, join, win32 as winPath } from 'node:path'
 import { app } from 'electron'
 import { parseDaemonPidFile, startTimeMatches } from './daemon-health'
+import { readDaemonControlFileText } from './daemon-control-file-reader'
 
 /**
  * Relocate the terminal daemon's process image out of the app install dir into LOCAL userData so it
@@ -30,6 +30,7 @@ export type RelocatedDaemonHost = {
 
 const HOST_SUBDIR = 'daemon-host'
 const MARKER_NAME = '.materialized.json'
+const MAX_PINNED_DAEMON_VERSIONS = 1024
 
 // LOCAL appData (not roaming) so OneDrive/roaming never syncs this ~260MB runtime. Shared with NSIS uninstall (config/nsis/daemon-host-uninstall.nsh) — keep in sync.
 const LOCAL_HOST_ROOT_NAME = 'Orca'
@@ -184,7 +185,7 @@ function executeManifest(ops: CopyOp[], stagingRoot: string): void {
 function readMarker(dir: string): MaterializeMarker | null {
   try {
     const parsed = JSON.parse(
-      readFileSync(join(dir, MARKER_NAME), 'utf8')
+      readDaemonControlFileText(join(dir, MARKER_NAME))
     ) as Partial<MaterializeMarker>
     if (typeof parsed.version === 'string' && typeof parsed.entryRelPath === 'string') {
       return {
@@ -289,25 +290,41 @@ function isDaemonPidAlive(pid: number, startedAtMs: number | null): boolean {
  */
 export function collectPinnedDaemonVersions(runtimeDir: string): Set<string> {
   const pinned = new Set<string>()
-  let entries
+  let directory: ReturnType<typeof opendirSync>
   try {
-    entries = readdirSync(runtimeDir, { withFileTypes: true })
+    directory = opendirSync(runtimeDir)
   } catch {
     return pinned
   }
-  for (const entry of entries) {
-    if (!entry.isFile() || !/^daemon-v\d+\.pid$/.test(entry.name)) {
-      continue
+  try {
+    while (pinned.size < MAX_PINNED_DAEMON_VERSIONS) {
+      const entry = directory.readSync()
+      if (!entry) {
+        break
+      }
+      if (!entry.isFile() || !/^daemon-v\d+\.pid$/.test(entry.name)) {
+        continue
+      }
+      let parsed
+      try {
+        parsed = parseDaemonPidFile(readDaemonControlFileText(join(runtimeDir, entry.name)))
+      } catch {
+        continue
+      }
+      // appVersion null => pre-relocation daemon forked from the install dir; pins no host dir here.
+      if (
+        parsed &&
+        parsed.appVersion !== null &&
+        isDaemonPidAlive(parsed.pid, parsed.startedAtMs)
+      ) {
+        pinned.add(parsed.appVersion)
+      }
     }
-    let parsed
+  } finally {
     try {
-      parsed = parseDaemonPidFile(readFileSync(join(runtimeDir, entry.name), 'utf8'))
+      directory.closeSync()
     } catch {
-      continue
-    }
-    // appVersion null => pre-relocation daemon forked from the install dir; pins no host dir here.
-    if (parsed && parsed.appVersion !== null && isDaemonPidAlive(parsed.pid, parsed.startedAtMs)) {
-      pinned.add(parsed.appVersion)
+      // Best-effort discovery cleanup.
     }
   }
   return pinned
@@ -321,22 +338,38 @@ export function pruneOldDaemonHosts(pinnedVersions: ReadonlySet<string>): void {
   if (process.platform !== 'win32' || !app.isPackaged) {
     return
   }
+  // Why: an incomplete saturated pin scan must fail closed rather than remove a live daemon image.
+  if (pinnedVersions.size >= MAX_PINNED_DAEMON_VERSIONS) {
+    return
+  }
   const version = app.getVersion()
   const root = hostRootDir()
-  let entries
+  let directory: ReturnType<typeof opendirSync>
   try {
-    entries = readdirSync(root, { withFileTypes: true })
+    directory = opendirSync(root)
   } catch {
     return
   }
-  for (const entry of entries) {
-    if (!entry.isDirectory() || entry.name === version || pinnedVersions.has(entry.name)) {
-      continue
+  try {
+    while (true) {
+      const entry = directory.readSync()
+      if (!entry) {
+        break
+      }
+      if (!entry.isDirectory() || entry.name === version || pinnedVersions.has(entry.name)) {
+        continue
+      }
+      try {
+        rmSync(join(root, entry.name), { recursive: true, force: true })
+      } catch {
+        // Still locked or already gone — retry on a future launch.
+      }
     }
+  } finally {
     try {
-      rmSync(join(root, entry.name), { recursive: true, force: true })
+      directory.closeSync()
     } catch {
-      // Still locked or already gone — retry on a future launch.
+      // Best-effort pruning cleanup.
     }
   }
 }

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -235,6 +235,10 @@ vi.mock('fs', () => ({
   writeFileSync: writeFileSyncMock
 }))
 
+vi.mock('./daemon-control-file-reader', () => ({
+  readDaemonControlFileText: readFileSyncMock
+}))
+
 vi.mock('child_process', () => ({ fork: forkMock }))
 
 vi.mock('net', () => ({ connect: netConnectMock }))

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -3,7 +3,7 @@ restart, teardown); the "swap the provider atomically" invariant keeps restart +
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { app } from 'electron'
-import { mkdirSync, existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, existsSync, unlinkSync, writeFileSync } from 'node:fs'
 import { fork, type ChildProcess } from 'node:child_process'
 import { connect } from 'node:net'
 import {
@@ -51,6 +51,7 @@ import {
   confirmSeededClaudeLivePtys,
   hasSeededUnconfirmedClaudePtys
 } from '../claude-accounts/live-pty-gate'
+import { readDaemonControlFileText } from './daemon-control-file-reader'
 
 // Why: daemon init runs concurrent with window load, so an in-process t timestamp (not harness stderr timing) measures cold-start.
 function logDaemonMilestone(event: string, details: Record<string, unknown> = {}): void {
@@ -1015,7 +1016,7 @@ async function waitForDaemonEndpointExit(socketPath: string): Promise<boolean> {
 function legacyDaemonProcessMayBeAlive(runtimeDir: string, protocolVersion: number): boolean {
   try {
     const parsed = parseDaemonPidFile(
-      readFileSync(getDaemonPidPath(runtimeDir, protocolVersion), 'utf8')
+      readDaemonControlFileText(getDaemonPidPath(runtimeDir, protocolVersion))
     )
     if (!parsed) {
       return false

--- a/src/main/daemon/daemon-login-session-probe-verdict.test.ts
+++ b/src/main/daemon/daemon-login-session-probe-verdict.test.ts
@@ -1,0 +1,33 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_DAEMON_LOGIN_SESSION_PROBE_BYTES,
+  readDaemonLoginSessionProbeVerdict
+} from './daemon-login-session-probe-verdict'
+
+describe('daemon login-session probe verdict', () => {
+  const cleanupPaths: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, { recursive: true })))
+  })
+
+  async function createProbe(content: string): Promise<string> {
+    const directory = await mkdtemp(join(tmpdir(), 'orca-daemon-login-probe-'))
+    cleanupPaths.push(directory)
+    const path = join(directory, 'verdict')
+    await writeFile(path, content)
+    return path
+  }
+
+  it('reads a normal verdict', async () => {
+    expect(readDaemonLoginSessionProbeVerdict(await createProbe(' alive\n'))).toBe('alive')
+  })
+
+  it('fails inconclusive when the verdict file exceeds its cap', async () => {
+    const path = await createProbe('x'.repeat(MAX_DAEMON_LOGIN_SESSION_PROBE_BYTES + 1))
+    expect(readDaemonLoginSessionProbeVerdict(path)).toBe('')
+  })
+})

--- a/src/main/daemon/daemon-login-session-probe-verdict.ts
+++ b/src/main/daemon/daemon-login-session-probe-verdict.ts
@@ -1,0 +1,13 @@
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+
+export const MAX_DAEMON_LOGIN_SESSION_PROBE_BYTES = 64
+
+export function readDaemonLoginSessionProbeVerdict(filePath: string): string {
+  try {
+    return readNodeFileSyncWithinLimit(filePath, MAX_DAEMON_LOGIN_SESSION_PROBE_BYTES)
+      .buffer.toString('utf8')
+      .trim()
+  } catch {
+    return ''
+  }
+}

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -868,6 +868,60 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
   })
 
   describe('listProcesses', () => {
+    it('strips unknown daemon owner payloads before publication', () => {
+      const normalize = (
+        adapter as unknown as {
+          validatedAgentSessionOwners(owners: unknown): {
+            agentSessionOwners?: unknown[]
+          }
+        }
+      ).validatedAgentSessionOwners.bind(adapter)
+      const owner = {
+        claim: {
+          digestVersion: 1,
+          keyId: 'key',
+          identityDigest: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          worktreeScopeDigest: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+          agent: 'codex',
+          unknownPayload: 'claim payload'
+        },
+        generation: 'generation-1',
+        phase: 'live',
+        ptyId: 'pty-1',
+        surface: {
+          worktreeId: 'worktree',
+          tabId: 'tab',
+          leafId: '11111111-1111-4111-8111-111111111111',
+          terminalHandle: 'term_claimed',
+          unknownPayload: 'surface payload'
+        },
+        unknownPayload: 'owner payload'
+      }
+
+      expect(normalize([owner])).toEqual({
+        agentSessionOwners: [
+          {
+            claim: {
+              digestVersion: 1,
+              keyId: 'key',
+              identityDigest: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              worktreeScopeDigest: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+              agent: 'codex'
+            },
+            generation: 'generation-1',
+            phase: 'live',
+            ptyId: 'pty-1',
+            surface: {
+              worktreeId: 'worktree',
+              tabId: 'tab',
+              leafId: '11111111-1111-4111-8111-111111111111',
+              terminalHandle: 'term_claimed'
+            }
+          }
+        ]
+      })
+    })
+
     it('returns active sessions', async () => {
       await adapter.spawn({
         cols: 80,
@@ -1312,7 +1366,6 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     it('does not schedule a checkpoint timer until a session is dirty', async () => {
       const adapterClass = DaemonPtyAdapter as unknown as { CHECKPOINT_INTERVAL_MS: number }
       const previousInterval = adapterClass.CHECKPOINT_INTERVAL_MS
-      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
       adapterClass.CHECKPOINT_INTERVAL_MS = 10_000
 
       try {
@@ -1323,14 +1376,16 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           cwd: '/home/user',
           sessionId: 'idle-checkpoint'
         })
+        const internals = historyAdapter as unknown as {
+          checkpointTimer: ReturnType<typeof setTimeout> | null
+        }
 
-        expect(setTimeoutSpy.mock.calls.some(([, delay]) => delay === 10_000)).toBe(false)
+        expect(internals.checkpointTimer).toBeNull()
 
         lastSubprocess._simulateData('dirty after idle\r\n')
-        await waitFor(() => setTimeoutSpy.mock.calls.some(([, delay]) => delay === 10_000))
+        await waitFor(() => internals.checkpointTimer !== null)
       } finally {
         adapterClass.CHECKPOINT_INTERVAL_MS = previousInterval
-        setTimeoutSpy.mockRestore()
       }
     })
 

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -7,6 +7,7 @@ import {
   AGENT_SESSION_CREATE_OPERATION_DAEMON_PROTOCOL_VERSION,
   GIT_CREDENTIAL_GUARD_HOST_PROTOCOL_VERSION
 } from './types'
+import { MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES } from '../providers/pty-process-list-admission'
 
 type AdapterMock = DaemonPtyAdapter & {
   emitData: (id: string, data: string, sequenceChars?: number) => void
@@ -419,6 +420,17 @@ describe('DaemonPtyRouter', () => {
     const router = new DaemonPtyRouter({ current, legacy: [legacy] })
 
     await expect(router.listProcesses()).rejects.toThrow('legacy unavailable')
+  })
+
+  it('fails listProcesses closed when adapters amplify the aggregate listing', async () => {
+    const current = createAdapter(
+      'current',
+      buildSessionIds('current', MAX_AGGREGATED_PTY_PROCESS_LIST_ENTRIES)
+    )
+    const legacy = createAdapter('legacy', ['legacy-over-cap'])
+    const router = new DaemonPtyRouter({ current, legacy: [legacy] })
+
+    await expect(router.listProcesses()).rejects.toThrow('pty_process_list_capacity')
   })
 
   it('merges startup reconciliation and updates route mappings', async () => {

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -8,6 +8,10 @@ import type {
   PtySpawnResult
 } from '../providers/types'
 import type { PtyIncarnationId } from '../../shared/pty-incarnation'
+import {
+  collectPtyProcessListings,
+  PtyProcessListAdmission
+} from '../providers/pty-process-list-admission'
 
 export class DaemonPtyRouter implements IPtyProvider {
   private current: DaemonPtyAdapter
@@ -49,10 +53,12 @@ export class DaemonPtyRouter implements IPtyProvider {
   }
 
   async discoverLegacySessions(): Promise<void> {
+    const admission = new PtyProcessListAdmission()
     for (const adapter of this.legacy) {
       try {
         const sessions = await adapter.listProcesses()
-        for (const session of sessions) {
+        for (const rawSession of sessions) {
+          const session = admission.admit(rawSession)
           this.sessionAdapters.set(session.id, adapter)
         }
       } catch (error) {
@@ -210,10 +216,9 @@ export class DaemonPtyRouter implements IPtyProvider {
   async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
     // Why: runtime exact-stop/liveness flows must fail closed if any adapter
     // cannot provide a trustworthy process list.
-    const results = await Promise.all(
-      this.allAdapters().map((adapter) => adapter.listProcesses(opts))
+    return await collectPtyProcessListings(this.allAdapters(), (adapter) =>
+      adapter.listProcesses(opts)
     )
-    return results.flat()
   }
 
   async getDefaultShell(): Promise<string> {

--- a/src/main/daemon/daemon-pty-size.ts
+++ b/src/main/daemon/daemon-pty-size.ts
@@ -1,13 +1,9 @@
-const DEFAULT_COLS = 80
-const DEFAULT_ROWS = 24
+import { isValidTerminalSize, normalizeTerminalSize } from '../../shared/terminal-size-limits'
 
 export function isValidPtySize(cols: number, rows: number): boolean {
-  return Number.isFinite(cols) && Number.isFinite(rows) && cols >= 1 && rows >= 1
+  return isValidTerminalSize(cols, rows)
 }
 
 export function normalizePtySize(cols: number, rows: number): { cols: number; rows: number } {
-  if (isValidPtySize(cols, rows)) {
-    return { cols, rows }
-  }
-  return { cols: DEFAULT_COLS, rows: DEFAULT_ROWS }
+  return normalizeTerminalSize(cols, rows)
 }

--- a/src/main/daemon/daemon-response-admission.ts
+++ b/src/main/daemon/daemon-response-admission.ts
@@ -1,0 +1,20 @@
+import type { DaemonRequest } from './types'
+
+export const DAEMON_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+export const DAEMON_RESPONSE_RESERVATION_BYTES = DAEMON_MAX_RESPONSE_BYTES
+export const DAEMON_MAX_ACTIVE_RESPONSE_BYTES = 128 * 1024 * 1024
+export const DAEMON_MAX_ACTIVE_RESPONSE_BYTES_PER_CLIENT = 64 * 1024 * 1024
+export const DAEMON_CONTROL_PROCESS_MAX_BUFFERED_BYTES = 64 * 1024 * 1024
+
+const REQUESTS_WITH_POTENTIALLY_LARGE_RESULTS = new Set<DaemonRequest['type']>([
+  'createOrAttach',
+  'getSnapshot',
+  'listSessions',
+  'takePendingOutput'
+])
+
+export function daemonResponseReservationBytes(request: DaemonRequest): number {
+  return REQUESTS_WITH_POTENTIALLY_LARGE_RESULTS.has(request.type)
+    ? DAEMON_RESPONSE_RESERVATION_BYTES
+    : 0
+}

--- a/src/main/daemon/daemon-server-admission.test.ts
+++ b/src/main/daemon/daemon-server-admission.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { connect, type Socket } from 'node:net'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  DAEMON_MAX_ACTIVE_REQUEST_BYTES_PER_CLIENT,
+  DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT,
+  DAEMON_MAX_CONTROL_CLIENTS,
+  DAEMON_MAX_STREAM_ATTACHMENTS,
+  DAEMON_MAX_TRANSPORT_SOCKETS
+} from './daemon-admission-limits'
+import {
+  DAEMON_MAX_ACTIVE_RESPONSE_BYTES_PER_CLIENT,
+  DAEMON_RESPONSE_RESERVATION_BYTES
+} from './daemon-response-admission'
+import { DaemonClient } from './client'
+import { DaemonServer } from './daemon-server'
+import { encodeNdjson } from './ndjson'
+import { getDaemonSocketPath } from './daemon-spawner'
+import { PROTOCOL_VERSION, type DaemonRequest } from './types'
+
+type ConnectedClientState = {
+  clientId: string
+  controlSocket: Socket
+  streamSocket: Socket | null
+  activeRequestCount: number
+  activeRequestBytes: number
+  activeResponseBytes: number
+}
+
+type DaemonServerAdmissionState = {
+  transportSockets: Set<Socket>
+  clients: Map<string, ConnectedClientState>
+  activeRequestCount: number
+  activeRequestBytes: number
+  activeResponseBytes: number
+  pendingPtySpawnPreparations: Map<string, Set<unknown>>
+  dispatchRequest(socket: Socket, clientId: string, value: unknown, lineBytes: number): void
+}
+
+function readJsonLine(socket: Socket): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    let buffered = ''
+    const cleanup = (): void => {
+      socket.off('data', onData)
+      socket.off('error', onError)
+      socket.off('close', onClose)
+    }
+    const onData = (chunk: Buffer): void => {
+      buffered += chunk.toString('utf8')
+      const newline = buffered.indexOf('\n')
+      if (newline === -1) {
+        return
+      }
+      cleanup()
+      resolve(JSON.parse(buffered.slice(0, newline)) as Record<string, unknown>)
+    }
+    const onError = (error: Error): void => {
+      cleanup()
+      reject(error)
+    }
+    const onClose = (): void => {
+      cleanup()
+      reject(new Error('Socket closed before a response'))
+    }
+    socket.on('data', onData)
+    socket.on('error', onError)
+    socket.on('close', onClose)
+  })
+}
+
+describe('DaemonServer admission', () => {
+  let directory: string
+  let socketPath: string
+  let tokenPath: string
+  let server: DaemonServer
+  let client: DaemonClient | null
+  let sockets: Socket[]
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), 'daemon-admission-test-'))
+    socketPath = getDaemonSocketPath(directory)
+    tokenPath = join(directory, 'daemon.token')
+    client = null
+    sockets = []
+  })
+
+  afterEach(async () => {
+    client?.disconnect()
+    for (const socket of sockets) {
+      socket.destroy()
+    }
+    await server?.shutdown()
+    rmSync(directory, { recursive: true, force: true })
+  })
+
+  async function startServer(
+    preparePtySpawn?: () => Promise<void>,
+    ptySpawnHealthCheck?: () => Promise<void>
+  ): Promise<void> {
+    server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      ...(preparePtySpawn ? { preparePtySpawn } : {}),
+      ...(ptySpawnHealthCheck ? { ptySpawnHealthCheck } : {}),
+      spawnSubprocess: () => {
+        throw new Error('Test unexpectedly spawned a subprocess')
+      }
+    })
+    await server.start()
+  }
+
+  async function openSocket(): Promise<Socket> {
+    const socket = connect(socketPath)
+    sockets.push(socket)
+    await new Promise<void>((resolve, reject) => {
+      socket.once('connect', resolve)
+      socket.once('error', reject)
+    })
+    return socket
+  }
+
+  async function hello(
+    role: 'control' | 'stream',
+    clientId: string
+  ): Promise<{ socket: Socket; response: Record<string, unknown> }> {
+    const socket = await openSocket()
+    const responsePromise = readJsonLine(socket)
+    socket.write(
+      encodeNdjson({
+        type: 'hello',
+        version: PROTOCOL_VERSION,
+        token: readFileSync(tokenPath, 'utf8').trim(),
+        clientId,
+        role
+      })
+    )
+    return { socket, response: await responsePromise }
+  }
+
+  async function waitFor(predicate: () => boolean): Promise<void> {
+    await vi.waitFor(() => expect(predicate()).toBe(true))
+  }
+
+  it('bounds pre-auth transports and releases capacity after disconnect', async () => {
+    await startServer()
+    const state = server as unknown as DaemonServerAdmissionState
+
+    await Promise.all(Array.from({ length: DAEMON_MAX_TRANSPORT_SOCKETS }, () => openSocket()))
+    await waitFor(() => state.transportSockets.size === DAEMON_MAX_TRANSPORT_SOCKETS)
+
+    const overflow = await openSocket()
+    await waitFor(() => overflow.destroyed)
+    expect(state.transportSockets.size).toBe(DAEMON_MAX_TRANSPORT_SOCKETS)
+
+    sockets[0].destroy()
+    await waitFor(() => state.transportSockets.size === DAEMON_MAX_TRANSPORT_SOCKETS - 1)
+    await openSocket()
+    await waitFor(() => state.transportSockets.size === DAEMON_MAX_TRANSPORT_SOCKETS)
+  })
+
+  it('bounds control clients and stream attachments, then reuses released slots', async () => {
+    await startServer()
+    const state = server as unknown as DaemonServerAdmissionState
+    const controls: Socket[] = []
+
+    for (let index = 0; index < DAEMON_MAX_CONTROL_CLIENTS; index += 1) {
+      const result = await hello('control', `client-${index}`)
+      expect(result.response.ok).toBe(true)
+      controls.push(result.socket)
+    }
+    await expect(hello('control', 'control-overflow')).resolves.toMatchObject({
+      response: { ok: false, retryable: true, error: expect.stringContaining('control-client') }
+    })
+    expect(state.clients.size).toBe(DAEMON_MAX_CONTROL_CLIENTS)
+
+    for (let index = 0; index < DAEMON_MAX_STREAM_ATTACHMENTS; index += 1) {
+      await expect(hello('stream', `client-${index}`)).resolves.toMatchObject({
+        response: { ok: true }
+      })
+    }
+    await expect(hello('stream', `client-${DAEMON_MAX_STREAM_ATTACHMENTS}`)).resolves.toMatchObject(
+      {
+        response: {
+          ok: false,
+          retryable: true,
+          error: expect.stringContaining('stream-attachment')
+        }
+      }
+    )
+
+    controls[0].destroy()
+    await waitFor(() => state.clients.size === DAEMON_MAX_CONTROL_CLIENTS - 1)
+    await expect(hello('control', 'replacement-control')).resolves.toMatchObject({
+      response: { ok: true }
+    })
+    await expect(hello('stream', `client-${DAEMON_MAX_STREAM_ATTACHMENTS}`)).resolves.toMatchObject(
+      {
+        response: { ok: true }
+      }
+    )
+  })
+
+  it('bounds concurrent response construction and cleans ownership after disconnect', async () => {
+    let finishPreparation!: () => void
+    const preparation = new Promise<void>((resolve) => {
+      finishPreparation = resolve
+    })
+    const preparePtySpawn = vi.fn(() => preparation)
+    await startServer(preparePtySpawn)
+    client = new DaemonClient({ socketPath, tokenPath })
+    await client.ensureConnected()
+    const state = server as unknown as DaemonServerAdmissionState
+
+    const maxLargeResponses =
+      DAEMON_MAX_ACTIVE_RESPONSE_BYTES_PER_CLIENT / DAEMON_RESPONSE_RESERVATION_BYTES
+    const pending = Array.from({ length: maxLargeResponses }, (_, index) =>
+      client!
+        .request('createOrAttach', {
+          sessionId: `pending-${index}`,
+          cols: 80,
+          rows: 24
+        })
+        .catch((error: unknown) => error)
+    )
+    await waitFor(() => preparePtySpawn.mock.calls.length === maxLargeResponses)
+    await expect(
+      client.request('createOrAttach', {
+        sessionId: 'request-overflow',
+        cols: 80,
+        rows: 24
+      })
+    ).rejects.toThrow('request capacity exceeded')
+    expect(state.activeRequestCount).toBe(maxLargeResponses)
+    expect(state.activeResponseBytes).toBe(DAEMON_MAX_ACTIVE_RESPONSE_BYTES_PER_CLIENT)
+    expect(state.pendingPtySpawnPreparations.size).toBe(maxLargeResponses)
+
+    client.disconnect()
+    finishPreparation()
+    await Promise.all(pending)
+    await waitFor(
+      () =>
+        state.activeRequestCount === 0 &&
+        state.activeRequestBytes === 0 &&
+        state.activeResponseBytes === 0 &&
+        state.pendingPtySpawnPreparations.size === 0
+    )
+  })
+
+  it('keeps the independent active-request cap for small response methods', async () => {
+    let finishHealthCheck!: () => void
+    const healthCheck = new Promise<void>((resolve) => {
+      finishHealthCheck = resolve
+    })
+    const ptySpawnHealthCheck = vi.fn(() => healthCheck)
+    await startServer(undefined, ptySpawnHealthCheck)
+    const { socket, response } = await hello('control', 'active-request-cap-client')
+    expect(response.ok).toBe(true)
+    const state = server as unknown as DaemonServerAdmissionState
+
+    for (let index = 0; index < DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT; index += 1) {
+      socket.write(
+        encodeNdjson({ id: `pending-${index}`, type: 'ptySpawnHealth', payload: undefined })
+      )
+    }
+    await waitFor(
+      () => ptySpawnHealthCheck.mock.calls.length === DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT
+    )
+    const overflowResponse = readJsonLine(socket)
+    socket.write(encodeNdjson({ id: 'overflow', type: 'ptySpawnHealth', payload: undefined }))
+    await expect(overflowResponse).resolves.toMatchObject({
+      id: 'overflow',
+      ok: false,
+      error: expect.stringContaining('request capacity exceeded')
+    })
+
+    socket.destroy()
+    finishHealthCheck()
+    await waitFor(() => state.activeRequestCount === 0 && state.activeRequestBytes === 0)
+  })
+
+  it('enforces the per-client retained-byte budget independently of request count', async () => {
+    let finishPreparation!: () => void
+    const preparation = new Promise<void>((resolve) => {
+      finishPreparation = resolve
+    })
+    const preparePtySpawn = vi.fn(() => preparation)
+    await startServer(preparePtySpawn)
+    client = new DaemonClient({ socketPath, tokenPath })
+    await client.ensureConnected()
+    const state = server as unknown as DaemonServerAdmissionState
+    const connected = [...state.clients.values()][0]
+    const request = (id: string): DaemonRequest => ({
+      id,
+      type: 'createOrAttach',
+      payload: { sessionId: id, cols: 80, rows: 24 }
+    })
+
+    state.dispatchRequest(
+      connected.controlSocket,
+      connected.clientId,
+      request('within-byte-budget'),
+      DAEMON_MAX_ACTIVE_REQUEST_BYTES_PER_CLIENT - 1024
+    )
+    await waitFor(() => preparePtySpawn.mock.calls.length === 1)
+    state.dispatchRequest(
+      connected.controlSocket,
+      connected.clientId,
+      request('over-byte-budget'),
+      2048
+    )
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(preparePtySpawn).toHaveBeenCalledOnce()
+    expect(connected.activeRequestCount).toBe(1)
+
+    client.disconnect()
+    finishPreparation()
+    await waitFor(() => state.activeRequestCount === 0 && state.activeRequestBytes === 0)
+  })
+
+  it('holds idle retirement until admitted work releases after disconnect', async () => {
+    let finishHealthCheck!: () => void
+    const healthCheck = new Promise<void>((resolve) => {
+      finishHealthCheck = resolve
+    })
+    const ptySpawnHealthCheck = vi.fn(() => healthCheck)
+    const onIdleShutdown = vi.fn()
+    server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      ptySpawnHealthCheck,
+      onIdleShutdown,
+      spawnSubprocess: () => {
+        throw new Error('Test unexpectedly spawned a subprocess')
+      }
+    })
+    await server.start()
+    client = new DaemonClient({ socketPath, tokenPath })
+    await client.ensureConnected()
+    const state = server as unknown as DaemonServerAdmissionState
+
+    const pending = client.request('ptySpawnHealth', undefined).catch((error: unknown) => error)
+    await waitFor(() => ptySpawnHealthCheck.mock.calls.length === 1)
+    client.disconnect()
+    await pending
+    await waitFor(() => state.transportSockets.size === 0)
+    expect(state.activeRequestCount).toBe(1)
+    expect(onIdleShutdown).not.toHaveBeenCalled()
+
+    finishHealthCheck()
+    await waitFor(() => state.activeRequestCount === 0 && onIdleShutdown.mock.calls.length === 1)
+  })
+})

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -4,7 +4,12 @@ import { randomUUID } from 'node:crypto'
 import { performance } from 'node:perf_hooks'
 import { writeFileSync, chmodSync } from 'node:fs'
 import { StringDecoder } from 'node:string_decoder'
-import { encodeNdjson, createNdjsonParser } from './ndjson'
+import {
+  DAEMON_HANDSHAKE_MAX_LINE_BYTES,
+  encodeBoundedNdjson,
+  encodeNdjson,
+  createNdjsonParser
+} from './ndjson'
 import { TerminalHost } from './terminal-host'
 import { DaemonStreamDataBatcher } from './daemon-stream-data-batcher'
 import {
@@ -36,6 +41,27 @@ import {
   isAgentSessionExecutionClaim,
   isAgentSessionSurfaceBinding
 } from '../../shared/agent-session-host-authority'
+import {
+  DAEMON_CONTROL_SOCKET_MAX_BUFFERED_BYTES,
+  DAEMON_HANDSHAKE_TIMEOUT_MS,
+  DAEMON_MAX_ACTIVE_REQUEST_BYTES,
+  DAEMON_MAX_ACTIVE_REQUEST_BYTES_PER_CLIENT,
+  DAEMON_MAX_ACTIVE_REQUESTS,
+  DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT,
+  DAEMON_MAX_CONTROL_CLIENTS,
+  DAEMON_MAX_STREAM_ATTACHMENTS,
+  DAEMON_MAX_TRANSPORT_SOCKETS,
+  daemonHelloAdmissionError,
+  daemonRequestAdmissionError,
+  getBoundedDaemonRequestId
+} from './daemon-admission-limits'
+import {
+  DAEMON_CONTROL_PROCESS_MAX_BUFFERED_BYTES,
+  DAEMON_MAX_ACTIVE_RESPONSE_BYTES,
+  DAEMON_MAX_ACTIVE_RESPONSE_BYTES_PER_CLIENT,
+  DAEMON_MAX_RESPONSE_BYTES,
+  daemonResponseReservationBytes
+} from './daemon-response-admission'
 
 export type DaemonServerOptions = {
   socketPath: string
@@ -77,6 +103,9 @@ type ConnectedClient = {
   controlSocket: Socket
   streamSocket: Socket | null
   authenticatedPairEstablished: boolean
+  activeRequestCount: number
+  activeRequestBytes: number
+  activeResponseBytes: number
 }
 
 type PendingPtySpawnPreparation = {
@@ -109,6 +138,9 @@ export class DaemonServer {
   private preparePtySpawn: () => Promise<void>
   private log: DaemonFileLog
   private transportSockets = new Set<Socket>()
+  private activeRequestCount = 0
+  private activeRequestBytes = 0
+  private activeResponseBytes = 0
   private createOrAttachInFlight = 0
   private idleShutdownState: 'running' | 'idle-shutdown-pending' | 'shutting-down' = 'running'
   private initialAdoptionTimer: unknown | null = null
@@ -304,6 +336,7 @@ export class DaemonServer {
     return (
       this.transportSockets.size === 0 &&
       this.clients.size === 0 &&
+      this.activeRequestCount === 0 &&
       this.createOrAttachInFlight === 0 &&
       this.host.listSessions().length === 0
     )
@@ -382,6 +415,12 @@ export class DaemonServer {
   }
 
   private handleConnection(socket: Socket): void {
+    socket.on('error', () => socket.destroy())
+    if (this.transportSockets.size >= DAEMON_MAX_TRANSPORT_SOCKETS) {
+      socket.destroy()
+      return
+    }
+
     this.cancelInitialAdoptionTimer()
     this.transportSockets.add(socket)
     const removeTransport = (): void => {
@@ -389,7 +428,6 @@ export class DaemonServer {
       this.reevaluateIdleShutdown()
     }
     socket.once('close', removeTransport)
-    socket.on('error', () => socket.destroy())
 
     if (this.idleShutdownState !== 'running') {
       // Why: a connection accepted just before close() gets an explicit retry signal instead of dying mid-auth.
@@ -403,45 +441,67 @@ export class DaemonServer {
       )
       return
     }
+
+    let handshakeComplete = false
+    const handshakeTimer = setTimeout(() => socket.destroy(), DAEMON_HANDSHAKE_TIMEOUT_MS)
+    handshakeTimer.unref()
+    socket.once('close', () => clearTimeout(handshakeTimer))
     // Why: keep UTF-8 sequences intact across socket chunks before NDJSON parsing.
     const decoder = new StringDecoder('utf8')
     const parser = createNdjsonParser(
-      (msg) => this.handleFirstMessage(socket, msg, parser),
+      (msg) => {
+        if (handshakeComplete) {
+          return
+        }
+        handshakeComplete = true
+        clearTimeout(handshakeTimer)
+        this.handleFirstMessage(socket, msg)
+      },
       () => {
         socket.destroy()
-      }
+      },
+      { maxLineBytes: DAEMON_HANDSHAKE_MAX_LINE_BYTES }
     )
 
     socket.on('data', (chunk) => parser.feed(decoder.write(chunk)))
   }
 
-  private handleFirstMessage(
-    socket: Socket,
-    msg: unknown,
-    _parser: ReturnType<typeof createNdjsonParser>
-  ): void {
-    const hello = msg as HelloMessage
-    if (hello.type !== 'hello') {
-      this.log.log('client-hello-rejected', { reason: 'expected-hello' })
-      socket.write(encodeNdjson({ type: 'hello', ok: false, error: 'Expected hello' }))
-      socket.destroy()
+  private handleFirstMessage(socket: Socket, msg: unknown): void {
+    const helloError = daemonHelloAdmissionError(msg)
+    if (helloError) {
+      this.log.log('client-hello-rejected', { reason: 'invalid-hello' })
+      this.rejectHello(socket, helloError)
       return
     }
+    const hello = msg as HelloMessage
 
     if (hello.version !== this.protocolVersion) {
       this.log.log('client-hello-rejected', {
         reason: 'protocol-mismatch',
         clientVersion: hello.version
       })
-      socket.write(encodeNdjson({ type: 'hello', ok: false, error: 'Protocol version mismatch' }))
-      socket.destroy()
+      this.rejectHello(socket, 'Protocol version mismatch')
       return
     }
 
     if (hello.token !== this.token) {
       this.log.log('client-hello-rejected', { reason: 'invalid-token', role: hello.role })
-      socket.write(encodeNdjson({ type: 'hello', ok: false, error: 'Invalid token' }))
-      socket.destroy()
+      this.rejectHello(socket, 'Invalid token')
+      return
+    }
+
+    const previous = hello.role === 'control' ? this.clients.get(hello.clientId) : undefined
+    const streamClient = hello.role === 'stream' ? this.clients.get(hello.clientId) : undefined
+    if (hello.role === 'control' && !previous && this.clients.size >= DAEMON_MAX_CONTROL_CLIENTS) {
+      this.rejectHello(socket, 'Daemon control-client capacity exceeded; reconnect', true)
+      return
+    }
+    if (
+      streamClient &&
+      streamClient.streamSocket === null &&
+      this.streamAttachmentCount() >= DAEMON_MAX_STREAM_ATTACHMENTS
+    ) {
+      this.rejectHello(socket, 'Daemon stream-attachment capacity exceeded; reconnect', true)
       return
     }
 
@@ -463,12 +523,14 @@ export class DaemonServer {
     )
 
     if (hello.role === 'control') {
-      const previous = this.clients.get(hello.clientId)
       const client: ConnectedClient = {
         clientId: hello.clientId,
         controlSocket: socket,
         streamSocket: null,
-        authenticatedPairEstablished: false
+        authenticatedPairEstablished: false,
+        activeRequestCount: 0,
+        activeRequestBytes: 0,
+        activeResponseBytes: 0
       }
       this.clients.set(hello.clientId, client)
       this.setupControlSocket(socket, hello.clientId)
@@ -480,30 +542,50 @@ export class DaemonServer {
         previous.streamSocket?.destroy()
         previous.controlSocket.destroy()
       }
-    } else if (hello.role === 'stream') {
-      const client = this.clients.get(hello.clientId)
-      if (!client) {
-        // Why: a stream socket is meaningless without its control socket; drop the orphan.
-        socket.destroy()
-        return
-      }
-      this.setupStreamSocket(socket, client)
-      client.authenticatedPairEstablished = true
+    } else if (streamClient) {
+      this.setupStreamSocket(socket, streamClient)
+      streamClient.authenticatedPairEstablished = true
       // Why: one-shot health probes authenticate only a control socket; they are not fresh app activity.
       this.onAuthenticatedClientPair()
       // A complete app connection (unlike a probe) re-owns the endpoint and cancels pending retirement.
       this.initialAdoptionDeadlineMs = null
       this.retirementRequested = false
       this.cancelInitialAdoptionTimer()
+    } else {
+      // Why: preserve the legacy authenticated handshake before dropping a stream with no owner.
+      socket.destroy()
     }
+  }
+
+  private rejectHello(socket: Socket, error: string, retryable = false): void {
+    socket.end(
+      encodeNdjson({
+        type: 'hello',
+        ok: false,
+        error,
+        ...(retryable ? { retryable: true } : {})
+      }),
+      () => socket.destroy()
+    )
+  }
+
+  private streamAttachmentCount(): number {
+    let count = 0
+    for (const client of this.clients.values()) {
+      if (client.streamSocket) {
+        count += 1
+      }
+    }
+    return count
   }
 
   private setupControlSocket(socket: Socket, clientId: string): void {
     // Why: decode as a UTF-8 stream so emoji/Unicode split across chunks isn't corrupted.
     const decoder = new StringDecoder('utf8')
     const parser = createNdjsonParser(
-      (msg) => this.handleRequest(socket, clientId, msg as DaemonRequest),
-      () => {} // Ignore parse errors
+      (msg, lineBytes) => this.dispatchRequest(socket, clientId, msg, lineBytes ?? 0),
+      () => socket.destroy(),
+      { includeLineBytes: true }
     )
 
     // Remove the initial data listener and replace with the RPC parser
@@ -569,6 +651,86 @@ export class DaemonServer {
     }
   }
 
+  private dispatchRequest(
+    socket: Socket,
+    clientId: string,
+    value: unknown,
+    lineBytes: number
+  ): void {
+    const client = this.clients.get(clientId)
+    if (!client || client.controlSocket !== socket) {
+      return
+    }
+
+    const requestId = getBoundedDaemonRequestId(value)
+    const admissionError = daemonRequestAdmissionError(value)
+    if (admissionError) {
+      this.writeRequestError(socket, requestId, admissionError)
+      return
+    }
+    const request = value as DaemonRequest
+    const responseReservationBytes = daemonResponseReservationBytes(request)
+    if (
+      client.activeRequestCount >= DAEMON_MAX_ACTIVE_REQUESTS_PER_CLIENT ||
+      this.activeRequestCount >= DAEMON_MAX_ACTIVE_REQUESTS ||
+      client.activeRequestBytes + lineBytes > DAEMON_MAX_ACTIVE_REQUEST_BYTES_PER_CLIENT ||
+      this.activeRequestBytes + lineBytes > DAEMON_MAX_ACTIVE_REQUEST_BYTES ||
+      client.activeResponseBytes + responseReservationBytes >
+        DAEMON_MAX_ACTIVE_RESPONSE_BYTES_PER_CLIENT ||
+      this.activeResponseBytes + responseReservationBytes > DAEMON_MAX_ACTIVE_RESPONSE_BYTES
+    ) {
+      this.writeRequestError(socket, request.id, 'Daemon request capacity exceeded; retry')
+      return
+    }
+
+    client.activeRequestCount += 1
+    client.activeRequestBytes += lineBytes
+    this.activeRequestCount += 1
+    this.activeRequestBytes += lineBytes
+    client.activeResponseBytes += responseReservationBytes
+    this.activeResponseBytes += responseReservationBytes
+    void this.handleRequest(socket, clientId, request).finally(() => {
+      client.activeRequestCount -= 1
+      client.activeRequestBytes -= lineBytes
+      this.activeRequestCount -= 1
+      this.activeRequestBytes -= lineBytes
+      client.activeResponseBytes -= responseReservationBytes
+      this.activeResponseBytes -= responseReservationBytes
+      this.reevaluateIdleShutdown()
+    })
+  }
+
+  private writeRequestError(socket: Socket, requestId: string | null, error: string): void {
+    if (!requestId || requestId.startsWith(NOTIFY_PREFIX)) {
+      return
+    }
+    this.writeControlMessage(socket, { id: requestId, ok: false, error })
+  }
+
+  private writeControlMessage(socket: Socket, message: unknown, onFlushed?: () => void): void {
+    const encoded = encodeBoundedNdjson(message, DAEMON_MAX_RESPONSE_BYTES)
+    const encodedBytes = Buffer.byteLength(encoded, 'utf8')
+    if (
+      socket.writableLength + encodedBytes > DAEMON_CONTROL_SOCKET_MAX_BUFFERED_BYTES ||
+      this.controlSocketBufferedBytes() + encodedBytes > DAEMON_CONTROL_PROCESS_MAX_BUFFERED_BYTES
+    ) {
+      socket.destroy()
+      return
+    }
+    socket.write(encoded, onFlushed)
+  }
+
+  private controlSocketBufferedBytes(): number {
+    let total = 0
+    for (const client of this.clients.values()) {
+      total += Math.max(0, client.controlSocket.writableLength)
+      if (total > DAEMON_CONTROL_PROCESS_MAX_BUFFERED_BYTES) {
+        break
+      }
+    }
+    return total
+  }
+
   private async handleRequest(
     socket: Socket,
     clientId: string,
@@ -582,19 +744,17 @@ export class DaemonServer {
         const pendingShutdown = this.pendingShutdownReplies.get(
           this.shutdownReplyKey(clientId, request.id)
         )
-        socket.write(encodeNdjson({ id: request.id, ok: true, payload: result }), () => {
+        this.writeControlMessage(socket, { id: request.id, ok: true, payload: result }, () => {
           pendingShutdown?.start()
         })
       }
     } catch (err) {
       if (!isNotify) {
-        socket.write(
-          encodeNdjson({
-            id: request.id,
-            ok: false,
-            error: err instanceof Error ? err.message : String(err)
-          })
-        )
+        this.writeControlMessage(socket, {
+          id: request.id,
+          ok: false,
+          error: err instanceof Error ? err.message : String(err)
+        })
       }
     }
   }
@@ -930,6 +1090,7 @@ export class DaemonServer {
           authenticatedClient !== undefined &&
           authenticatedClient.streamSocket !== null &&
           this.clients.size === 1 &&
+          this.activeRequestCount <= 1 &&
           this.createOrAttachInFlight === 0 &&
           this.host.listSessions().length === 0 &&
           [...this.transportSockets].every(

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -1,7 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { constants, copyFileSync, existsSync, readFileSync, renameSync, unlinkSync } from 'node:fs'
+import { constants, copyFileSync, existsSync, renameSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import { PROTOCOL_VERSION } from './types'
+import { readDaemonControlFileText } from './daemon-control-file-reader'
 
 export type DaemonConnectionInfo = {
   socketPath: string
@@ -141,7 +142,7 @@ function claimAndUnlinkOwnedFile(
     return false
   }
   try {
-    if (ownsContent(readFileSync(claimedPath, 'utf8'))) {
+    if (ownsContent(readDaemonControlFileText(claimedPath))) {
       unlinkSync(claimedPath)
       return true
     }

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -4,6 +4,10 @@ import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
 import type { IPtyProvider, PtyBackgroundStreamEvent } from '../providers/types'
 import type { PtyDataEvent, PtyProviderBufferSnapshot } from '../providers/types'
 import type { PtyProcessInfo, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import {
+  collectPtyProcessListings,
+  PtyProcessListAdmission
+} from '../providers/pty-process-list-admission'
 
 export class DegradedDaemonPtyProvider implements IPtyProvider {
   readonly routesFreshSpawnsToLocalProvider = true
@@ -45,11 +49,12 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
   }
 
   async discoverDaemonSessions(): Promise<void> {
+    const admission = new PtyProcessListAdmission()
     for (const adapter of this.allDaemonAdapters()) {
       try {
         const sessions = await adapter.listProcesses()
         for (const session of sessions) {
-          this.sessionProviders.set(session.id, adapter)
+          this.sessionProviders.set(admission.admit(session).id, adapter)
         }
       } catch (error) {
         console.warn('[daemon] Failed to discover degraded daemon sessions', error)
@@ -170,12 +175,8 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
     await this.fallback.revive(state)
   }
 
-  async listProcesses(opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> {
-    const results = await Promise.all(
-      this.allProviders().map((provider) => provider.listProcesses(opts))
-    )
-    return results.flat()
-  }
+  listProcesses = (opts?: { deadlineMs?: number }): Promise<PtyProcessInfo[]> =>
+    collectPtyProcessListings(this.allProviders(), (provider) => provider.listProcesses(opts))
 
   async getDefaultShell(): Promise<string> {
     return this.fallback.getDefaultShell()

--- a/src/main/daemon/headless-emulator-size-limits.test.ts
+++ b/src/main/daemon/headless-emulator-size-limits.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_TERMINAL_COLS } from '../../shared/terminal-size-limits'
+import { HeadlessEmulator } from './headless-emulator'
+
+describe('HeadlessEmulator terminal size limits', () => {
+  it('uses safe defaults for oversized persisted construction and resize dimensions', () => {
+    const emulator = new HeadlessEmulator({ cols: MAX_TERMINAL_COLS + 1, rows: 24 })
+    expect(emulator.getAppliedSize()).toEqual({ cols: 80, rows: 24 })
+
+    emulator.resize(80, Number.MAX_SAFE_INTEGER)
+    expect(emulator.getAppliedSize()).toEqual({ cols: 80, rows: 24 })
+    emulator.dispose()
+  })
+})

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -20,6 +20,7 @@ import {
 } from './terminal-view-attribute-responder'
 import type { TerminalSnapshot, TerminalModes } from './types'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
+import { normalizeTerminalSize } from '../../shared/terminal-size-limits'
 
 export type HeadlessEmulatorOptions = {
   cols: number
@@ -69,6 +70,7 @@ export class HeadlessEmulator {
   private partialEscapeTail = ''
 
   constructor(opts: HeadlessEmulatorOptions) {
+    const size = normalizeTerminalSize(opts.cols, opts.rows)
     this.pathFlavor = opts.pathFlavor
     this.remotePosixFileUriAuthority = opts.remotePosixFileUriAuthority === true
     this.oscText = new TerminalOscCwdTitleScanner({
@@ -77,8 +79,8 @@ export class HeadlessEmulator {
       wslDistro: opts.wslDistro
     })
     this.terminal = new Terminal({
-      cols: opts.cols,
-      rows: opts.rows,
+      cols: size.cols,
+      rows: size.rows,
       scrollback: opts.scrollback ?? DEFAULT_SCROLLBACK,
       allowProposedApi: true,
       logLevel: 'off',
@@ -224,7 +226,8 @@ export class HeadlessEmulator {
       return
     }
     this.restoredOscLinks = []
-    this.terminal.resize(cols, rows)
+    const size = normalizeTerminalSize(cols, rows)
+    this.terminal.resize(size.cols, size.rows)
   }
 
   // Why: these dims proxy the child's real size, so they stay stale on a dropped resize the renderer must detect.

--- a/src/main/daemon/history-manager-memory.test.ts
+++ b/src/main/daemon/history-manager-memory.test.ts
@@ -1,0 +1,68 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getHistorySessionDirName } from './history-paths'
+import { HistoryManager } from './history-manager'
+import type { TerminalSnapshot } from './types'
+
+const directories: string[] = []
+
+function createManager(): { directory: string; manager: HistoryManager } {
+  const directory = mkdtempSync(join(tmpdir(), 'orca-history-manager-memory-'))
+  directories.push(directory)
+  return { directory, manager: new HistoryManager(directory) }
+}
+
+function snapshot(snapshotAnsi: string): TerminalSnapshot {
+  return {
+    snapshotAnsi,
+    scrollbackAnsi: '',
+    rehydrateSequences: '',
+    cwd: '/workspace',
+    cols: 80,
+    rows: 24,
+    modes: {
+      bracketedPaste: false,
+      mouseTracking: false,
+      applicationCursor: false,
+      alternateScreen: false
+    },
+    scrollbackLines: 0
+  }
+}
+
+afterEach(() => {
+  for (const directory of directories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('terminal history write memory limits', () => {
+  it('rejects an oversized escaped checkpoint before writing it', async () => {
+    const { directory, manager } = createManager()
+    await manager.openSession('checkpoint', { cwd: '/workspace', cols: 80, rows: 24 })
+
+    await manager.checkpoint('checkpoint', snapshot('\n'.repeat(9 * 1024 * 1024)))
+
+    expect(manager.isSessionDisabled('checkpoint')).toBe(true)
+    expect(
+      existsSync(join(directory, getHistorySessionDirName('checkpoint'), 'checkpoint.json'))
+    ).toBe(false)
+  })
+
+  it('rejects oversized escaped metadata before writing it', async () => {
+    const { directory, manager } = createManager()
+
+    await manager.openSession('metadata', {
+      cwd: '\n'.repeat(40 * 1024),
+      cols: 80,
+      rows: 24
+    })
+
+    expect(manager.isSessionDisabled('metadata')).toBe(true)
+    expect(existsSync(join(directory, getHistorySessionDirName('metadata'), 'meta.json'))).toBe(
+      false
+    )
+  })
+})

--- a/src/main/daemon/history-manager.ts
+++ b/src/main/daemon/history-manager.ts
@@ -2,55 +2,39 @@ import { join } from 'node:path'
 import {
   mkdirSync,
   writeFileSync,
-  readFileSync,
   existsSync,
   rmSync,
   unlinkSync,
-  openSync,
-  closeSync,
-  readSync,
-  fstatSync,
   promises as fsPromises
 } from 'node:fs'
 import { getHistorySessionDirName } from './history-paths'
 import {
-  decodeLogHeader,
-  encodeLogBatch,
+  encodeLogBatchWithinLimit,
   encodeLogHeader,
   LOG_HEADER_BYTES
 } from './terminal-history-log'
 import type { PendingOutputRecord, TerminalCheckpointFile, TerminalSnapshot } from './types'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import {
+  TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES,
+  TERMINAL_HISTORY_LOG_MAX_BYTES
+} from './terminal-history-file-limits'
+import {
+  readTerminalHistorySessionMeta,
+  stringifyTerminalHistorySessionMeta,
+  type HistoryManagerOptions,
+  type OpenSessionOptions,
+  type SessionMeta
+} from './terminal-history-session-metadata'
+import {
+  resolveTerminalHistoryLogState,
+  type TerminalHistoryLogState
+} from './terminal-history-log-state'
 
-// Why 5MB: bounds cold-restore replay time and per-session disk; hitting the cap triggers one checkpoint that resets the log.
-const LOG_MAX_BYTES = 5 * 1024 * 1024
+export type { HistoryManagerOptions, OpenSessionOptions, SessionMeta }
 
-export type SessionMeta = {
-  cwd: string
-  cols: number
-  rows: number
-  startedAt: string
-  endedAt: string | null
-  exitCode: number | null
-}
-
-export type OpenSessionOptions = {
-  cwd: string
-  cols: number
-  rows: number
-}
-
-type SessionWriter = {
+type SessionWriter = TerminalHistoryLogState & {
   dir: string
-  checkpointPath: string
-  logPath: string
-  /** Generation of the on-disk log header. Null until lazily resolved on first append after a warm registerWriter. */
-  logGeneration: number | null
-  /** Current log file size. Null until lazily resolved alongside generation. */
-  logBytes: number | null
-}
-
-export type HistoryManagerOptions = {
-  onWriteError?: (sessionId: string, error: Error) => void
 }
 
 export class HistoryManager {
@@ -78,7 +62,7 @@ export class HistoryManager {
         endedAt: null,
         exitCode: null
       }
-      writeFileSync(join(dir, 'meta.json'), JSON.stringify(meta, null, 2))
+      writeFileSync(join(dir, 'meta.json'), stringifyTerminalHistorySessionMeta(meta))
 
       // Why: clear stale recovery files (incl. legacy scrollback.bin) so a crash before the first checkpoint can't replay a prior session's content.
       const checkpointPath = join(dir, 'checkpoint.json')
@@ -153,11 +137,15 @@ export class HistoryManager {
       return 'ok'
     }
     try {
-      this.resolveLogState(writer)
-      const batch = encodeLogBatch(seq, records)
+      resolveTerminalHistoryLogState(writer)
       // Why max(..., header): a fresh log's header (written below) must count toward the projected size or the cap overshoots.
-      const projectedBytes = Math.max(writer.logBytes ?? 0, LOG_HEADER_BYTES) + batch.length
-      if (projectedBytes > LOG_MAX_BYTES) {
+      const existingBytes = Math.max(writer.logBytes ?? 0, LOG_HEADER_BYTES)
+      const batch = encodeLogBatchWithinLimit(
+        seq,
+        records,
+        TERMINAL_HISTORY_LOG_MAX_BYTES - existingBytes
+      )
+      if (!batch) {
         return 'needs-checkpoint'
       }
       if (writer.logBytes === 0) {
@@ -192,7 +180,7 @@ export class HistoryManager {
         effectiveCwd = meta?.cwd ?? null
       }
 
-      this.resolveLogState(writer)
+      resolveTerminalHistoryLogState(writer)
       const generation = (writer.logGeneration ?? 0) + 1
       const checkpointFile: TerminalCheckpointFile = {
         snapshotAnsi: snapshot.snapshotAnsi,
@@ -207,7 +195,10 @@ export class HistoryManager {
         generation,
         checkpointedAt: new Date().toISOString()
       }
-      const data = JSON.stringify(checkpointFile)
+      const data = stringifyJsonWithinByteLimit(
+        checkpointFile,
+        TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES
+      ).serialized
       // Why: tmp+rename is atomic (corrupt checkpoint > stale); async so a sync ~MB write can't stall IPC (worse under Windows AV).
       // The adapter's checkpointInFlight guard serializes checkpoints, so concurrent async writes can't collide on the fixed .tmp path.
       const tmpPath = `${writer.checkpointPath}.tmp`
@@ -219,46 +210,6 @@ export class HistoryManager {
       writer.logBytes = LOG_HEADER_BYTES
     } catch (err) {
       this.handleWriteError(sessionId, err)
-    }
-  }
-
-  // Why: a warm registerWriter may attach to an existing log; read generation/size once so appends continue it, not clobber it.
-  private resolveLogState(writer: SessionWriter): void {
-    if (writer.logBytes !== null && writer.logGeneration !== null) {
-      return
-    }
-    let headerGeneration: number | null = null
-    let size = 0
-    try {
-      const fd = openSync(writer.logPath, 'r')
-      try {
-        size = fstatSync(fd).size
-        const header = Buffer.alloc(LOG_HEADER_BYTES)
-        if (readSync(fd, header, 0, LOG_HEADER_BYTES, 0) === LOG_HEADER_BYTES) {
-          headerGeneration = decodeLogHeader(header)
-        }
-      } finally {
-        closeSync(fd)
-      }
-    } catch {
-      // Missing log file — fresh state below.
-    }
-    if (headerGeneration !== null) {
-      writer.logGeneration = headerGeneration
-      writer.logBytes = size
-      return
-    }
-    // Missing/unreadable header: logBytes = 0 makes the next append truncate-rewrite, so a garbage file can't be extended.
-    writer.logBytes = 0
-    writer.logGeneration = this.readCheckpointGeneration(writer) ?? 0
-  }
-
-  private readCheckpointGeneration(writer: SessionWriter): number | null {
-    try {
-      const checkpoint = JSON.parse(readFileSync(writer.checkpointPath, 'utf-8'))
-      return typeof checkpoint.generation === 'number' ? checkpoint.generation : null
-    } catch {
-      return null
     }
   }
 
@@ -306,7 +257,7 @@ export class HistoryManager {
       return null
     }
     try {
-      return JSON.parse(readFileSync(metaPath, 'utf-8'))
+      return readTerminalHistorySessionMeta(metaPath)
     } catch {
       return null
     }
@@ -333,7 +284,7 @@ export class HistoryManager {
   private readMetaFromDir(dir: string): SessionMeta | null {
     const metaPath = join(dir, 'meta.json')
     try {
-      return JSON.parse(readFileSync(metaPath, 'utf-8'))
+      return readTerminalHistorySessionMeta(metaPath)
     } catch {
       return null
     }
@@ -343,11 +294,11 @@ export class HistoryManager {
     const metaPath = join(dir, 'meta.json')
     let meta: SessionMeta
     try {
-      meta = JSON.parse(readFileSync(metaPath, 'utf-8'))
+      meta = readTerminalHistorySessionMeta(metaPath)
     } catch {
       return
     }
     Object.assign(meta, updates)
-    writeFileSync(metaPath, JSON.stringify(meta, null, 2))
+    writeFileSync(metaPath, stringifyTerminalHistorySessionMeta(meta))
   }
 }

--- a/src/main/daemon/ndjson.test.ts
+++ b/src/main/daemon/ndjson.test.ts
@@ -1,7 +1,20 @@
 import { describe, expect, it, vi } from 'vitest'
-import { encodeNdjson, createNdjsonParser, NDJSON_MAX_LINE_BYTES } from './ndjson'
+import {
+  encodeBoundedNdjson,
+  encodeNdjson,
+  createNdjsonParser,
+  NDJSON_MAX_LINE_BYTES,
+  NDJSON_MAX_STRUCTURAL_TOKENS
+} from './ndjson'
 
 describe('encodeNdjson', () => {
+  it('bounds response serialization while preserving admitted wire bytes', () => {
+    expect(encodeBoundedNdjson({ ok: true }, 12)).toBe('{"ok":true}\n')
+    expect(() => encodeBoundedNdjson({ value: 'x'.repeat(100) }, 32)).toThrow(
+      'JSON output exceeds 31 bytes'
+    )
+  })
+
   it('encodes an object as a JSON line ending with newline', () => {
     const result = encodeNdjson({ type: 'hello', version: 1 })
     expect(result).toBe('{"type":"hello","version":1}\n')
@@ -32,6 +45,32 @@ describe('createNdjsonParser', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
+  it('optionally reports each parsed line byte length without re-serializing it', () => {
+    const onMessage = vi.fn()
+    const parser = createNdjsonParser(onMessage, undefined, { includeLineBytes: true })
+
+    parser.feed('{"text":"é"}\n')
+
+    expect(onMessage).toHaveBeenCalledWith({ text: 'é' }, Buffer.byteLength('{"text":"é"}'))
+  })
+
+  it('rejects structurally amplified lines before parsing', () => {
+    const onMessage = vi.fn()
+    const onError = vi.fn()
+    const parser = createNdjsonParser(onMessage, onError)
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    try {
+      parser.feed(`{"values":[${'0,'.repeat(NDJSON_MAX_STRUCTURAL_TOKENS)}0]}\n`)
+      expect(onMessage).not.toHaveBeenCalled()
+      expect(onError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('JSON structure exceeds') })
+      )
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
+  })
+
   it('parses multiple messages in a single chunk', () => {
     const onMessage = vi.fn()
     const parser = createNdjsonParser(onMessage)
@@ -54,6 +93,20 @@ describe('createNdjsonParser', () => {
     parser.feed('lo","version":1}\n')
     expect(onMessage).toHaveBeenCalledOnce()
     expect(onMessage).toHaveBeenCalledWith({ type: 'hello', version: 1 })
+  })
+
+  it('parses a line delivered in more than 100,000 one-character fragments', () => {
+    const onMessage = vi.fn()
+    const parser = createNdjsonParser(onMessage, undefined, { includeLineBytes: true })
+    const message = { value: 'x'.repeat(100_000) }
+    const line = JSON.stringify(message)
+
+    for (const character of line) {
+      parser.feed(character)
+    }
+    parser.feed('\n')
+
+    expect(onMessage).toHaveBeenCalledWith(message, Buffer.byteLength(line))
   })
 
   it('handles a chunk that ends mid-line followed by more data', () => {

--- a/src/main/daemon/ndjson.ts
+++ b/src/main/daemon/ndjson.ts
@@ -1,8 +1,22 @@
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+
 export function encodeNdjson(msg: unknown): string {
   return `${JSON.stringify(msg)}\n`
 }
 
+export function encodeBoundedNdjson(msg: unknown, maxBytes: number): string {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new RangeError('NDJSON byte limit must be a positive safe integer')
+  }
+  return `${stringifyJsonWithinByteLimit(msg, maxBytes - 1).serialized}\n`
+}
+
 export const NDJSON_MAX_LINE_BYTES = 16 * 1024 * 1024
+export const DAEMON_HANDSHAKE_MAX_LINE_BYTES = 64 * 1024
+export const NDJSON_MAX_STRUCTURAL_TOKENS = 1_000_000
+export const NDJSON_MAX_NESTING_DEPTH = 128
 
 export type NdjsonParser = {
   feed(chunk: string): void
@@ -11,21 +25,20 @@ export type NdjsonParser = {
 
 export type NdjsonParserOptions = {
   maxLineBytes?: number
+  includeLineBytes?: boolean
 }
 
 export function createNdjsonParser(
-  onMessage: (msg: unknown) => void,
+  onMessage: (msg: unknown, lineBytes?: number) => void,
   onError?: (err: Error) => void,
   options: NdjsonParserOptions = {}
 ): NdjsonParser {
-  let buffer = ''
-  let bufferBytes = 0
+  const buffer = new GrowingByteBuffer()
   let discardingOversizedLine = false
   const maxLineBytes = Math.max(1, options.maxLineBytes ?? NDJSON_MAX_LINE_BYTES)
 
   const clearBuffer = (): void => {
-    buffer = ''
-    bufferBytes = 0
+    buffer.clear()
   }
 
   const reportOversizedLine = (observedBytes: number): void => {
@@ -53,8 +66,8 @@ export function createNdjsonParser(
           return
         }
 
-        const segmentBytes = Buffer.byteLength(segment, 'utf8')
-        const nextLineBytes = bufferBytes + segmentBytes
+        const segmentBytes = Buffer.from(segment, 'utf8')
+        const nextLineBytes = buffer.byteLength + segmentBytes.byteLength
         // Why: daemon sockets are local but persistent; a peer that never sends
         // a newline must not grow the parser buffer without bound.
         if (nextLineBytes > maxLineBytes) {
@@ -67,21 +80,29 @@ export function createNdjsonParser(
           continue
         }
 
-        buffer += segment
-        bufferBytes = nextLineBytes
+        buffer.append(segmentBytes)
         if (!hasNewline) {
           return
         }
 
-        const line = buffer
-        clearBuffer()
+        const lineBytes = buffer.byteLength
+        const line = buffer.takeString('utf8')
 
         if (line.length === 0) {
           continue
         }
 
         try {
-          onMessage(JSON.parse(line))
+          assertJsonTextStructureWithinLimits(line, {
+            structuralTokens: NDJSON_MAX_STRUCTURAL_TOKENS,
+            nestingDepth: NDJSON_MAX_NESTING_DEPTH
+          })
+          const parsed = JSON.parse(line)
+          if (options.includeLineBytes) {
+            onMessage(parsed, lineBytes)
+          } else {
+            onMessage(parsed)
+          }
         } catch (err) {
           onError?.(err instanceof Error ? err : new Error(String(err)))
         }

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -66,6 +66,7 @@ import { assertSafeAgentStartupCwd, resolveSafePtyDefaultCwd } from '../provider
 import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../shared/hermes-startup-query'
 import type { TuiAgent } from '../../shared/types'
 import { forceKillPosixPtyProcessGroups } from '../pty/posix-pty-process-groups'
+import { appendCompactedStringChunk } from '../../shared/string-chunk-compaction'
 
 const PANE_IDENTITY_ENV_KEYS = [
   'ORCA_PANE_KEY',
@@ -810,7 +811,7 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
 
   const bufferPreListenerData = (data: string): void => {
     // Why: Windows shell-arg startup commands can print before Session wires this subprocess in; preserve that spawn-time race window.
-    pendingPreListenerData.push(data)
+    appendCompactedStringChunk(pendingPreListenerData, data)
     pendingPreListenerDataChars += data.length
     while (pendingPreListenerDataChars > PENDING_PRE_LISTENER_DATA_MAX_CHARS) {
       const removed = pendingPreListenerData.shift()

--- a/src/main/daemon/session-pending-output.test.ts
+++ b/src/main/daemon/session-pending-output.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { Session } from './session'
+import { PENDING_OUTPUT_MAX_RECORDS, Session } from './session'
 
 // Coverage for the incremental-checkpoint record stream (issue #5096): every
 // PTY byte, resize, and clear is recorded so the 5s checkpoint can persist
@@ -113,6 +113,25 @@ describe('Session pending output', () => {
     const recovered = live.takePendingOutput(false)
     expect(recovered!.overflowed).toBe(false)
     expect(recovered!.records).toEqual([{ kind: 'output', data: 'post-overflow' }])
+  })
+
+  it('flags overflow when tiny records reach the metadata cap', () => {
+    const subprocess = createMockSubprocess()
+    const live = createSession(subprocess)
+
+    for (let index = 0; index <= PENDING_OUTPUT_MAX_RECORDS / 2; index += 1) {
+      subprocess.simulateData('x')
+      live.clearScrollback()
+    }
+
+    const overflowed = live.takePendingOutput(false)
+    expect(overflowed!.overflowed).toBe(true)
+    expect(overflowed!.records).toEqual([])
+
+    subprocess.simulateData('post-overflow')
+    expect(live.takePendingOutput(false)!.records).toEqual([
+      { kind: 'output', data: 'post-overflow' }
+    ])
   })
 
   it('returns the snapshot and drops records in the same take when requested', () => {

--- a/src/main/daemon/session-pre-ready-input-memory.test.ts
+++ b/src/main/daemon/session-pre-ready-input-memory.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { PRE_READY_STDIN_MAX_SEGMENTS, Session, type SubprocessHandle } from './session'
+
+function createSubprocess(): SubprocessHandle {
+  return {
+    pid: 12345,
+    getForegroundProcess: () => null,
+    write() {},
+    resize() {},
+    kill() {},
+    forceKill() {},
+    signal() {},
+    onData() {},
+    onExit() {},
+    dispose() {}
+  }
+}
+
+describe('Session pre-ready input memory', () => {
+  it('bounds one-character segments independently of the byte cap', () => {
+    const session = new Session({
+      sessionId: 'pre-ready-segment-test',
+      cols: 80,
+      rows: 24,
+      subprocess: createSubprocess(),
+      shellReadySupported: true
+    })
+
+    try {
+      for (let index = 0; index < PRE_READY_STDIN_MAX_SEGMENTS; index += 1) {
+        session.write('x')
+      }
+      expect(() => session.write('x')).toThrow('safe memory limit')
+    } finally {
+      session.dispose()
+    }
+  })
+})

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PRE_READY_STDIN_MAX_CODE_UNITS } from './session'
 import { PRODUCER_PAUSE_FAILSAFE_MS, SESSION_FORCE_KILL_RETRY_MS, Session } from './session'
 import type { SessionState, ShellReadyState } from './types'
 import type { TuiAgent } from '../../shared/types'
@@ -350,6 +351,19 @@ describe('Session', () => {
       subprocess.simulateData('\r\nuser@host $ ')
       vi.advanceTimersByTime(30)
       expect(subprocess.written).toEqual(['first\n', 'second\n'])
+    })
+
+    it('bounds aggregate input retained before shell readiness without changing admitted writes', () => {
+      createSession({ shellReadySupported: true })
+      const chunk = 'x'.repeat(16 * 1024)
+      const admittedChunks = PRE_READY_STDIN_MAX_CODE_UNITS / chunk.length
+
+      for (let index = 0; index < admittedChunks; index += 1) {
+        session.write(chunk)
+      }
+      expect(() => session.write('overflow')).toThrow('safe memory limit')
+      vi.advanceTimersByTime(15_000)
+      expect(subprocess.written).toEqual(Array(admittedChunks).fill(chunk))
     })
 
     it('uses the short settle path when marker and prompt bytes arrive together', () => {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -37,6 +37,9 @@ const SESSION_FORCE_KILL_MAX_ATTEMPTS = 2
 // Why: bounds in-memory pending output when no client drains it; past the cap we drop records and flag
 // overflow so the next take falls back to one full snapshot. UTF-16 units; worst-case wire is ~6x, under NDJSON_MAX_LINE_BYTES (16MB).
 const PENDING_OUTPUT_MAX_BYTES = 2 * 1024 * 1024
+export const PENDING_OUTPUT_MAX_RECORDS = 4_096
+export const PRE_READY_STDIN_MAX_CODE_UNITS = 16 * 1024 * 1024
+export const PRE_READY_STDIN_MAX_SEGMENTS = 4_096
 // Why: pause is a fire-and-forget notify, so a resume can be lost (main crash, dropped socket); a lost
 // resume must never wedge a shell, so auto-resume after this window — a still-flooded main re-pauses.
 export const PRODUCER_PAUSE_FAILSAFE_MS = 5_000
@@ -112,6 +115,7 @@ export class Session {
   private readonly onSessionExit?: (code: number) => void
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
+  private preReadyStdinCodeUnits = 0
   private shellReadyScanState: ShellReadyScanState | null = null
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
@@ -218,7 +222,17 @@ export class Session {
     // Why: keep queuing during the post-ready flush-gate window ('ready' but not yet flushed); a
     // direct write would race fresh input ahead of the buffered startup command.
     if (this._shellState === 'pending' || this.postReadyFlushGate.isPending) {
+      const nextCodeUnits = this.preReadyStdinCodeUnits + data.length
+      if (
+        nextCodeUnits > PRE_READY_STDIN_MAX_CODE_UNITS ||
+        this.preReadyStdinQueue.length >= PRE_READY_STDIN_MAX_SEGMENTS
+      ) {
+        throw new Error(
+          'Terminal input queued before shell readiness exceeds the safe memory limit.'
+        )
+      }
       this.preReadyStdinQueue.push(data)
+      this.preReadyStdinCodeUnits = nextCodeUnits
       return
     }
 
@@ -523,6 +537,7 @@ export class Session {
 
     this.attachedClients = []
     this.preReadyStdinQueue = []
+    this.preReadyStdinCodeUnits = 0
     this.postReadyFlushGate.clear()
     this.emulator.dispose()
 
@@ -567,6 +582,7 @@ export class Session {
     }
     this.shellReadyScanState = null
     this.preReadyStdinQueue = []
+    this.preReadyStdinCodeUnits = 0
     this.postReadyFlushGate.clear()
     this.disposeSubprocessHandle()
   }
@@ -589,15 +605,20 @@ export class Session {
       return
     }
     const bytes = record.kind === 'output' ? record.data.length : 8
-    if (this.pendingOutputBytes + bytes > PENDING_OUTPUT_MAX_BYTES) {
+    const last = this.pendingOutputRecords.at(-1)
+    const canCoalesce =
+      record.kind === 'output' && last?.kind === 'output' && last.data.length < 64 * 1024
+    if (
+      this.pendingOutputBytes + bytes > PENDING_OUTPUT_MAX_BYTES ||
+      (!canCoalesce && this.pendingOutputRecords.length >= PENDING_OUTPUT_MAX_RECORDS)
+    ) {
       this.pendingOutputRecords = []
       this.pendingOutputBytes = 0
       this.pendingOutputOverflowed = true
       return
     }
     // Why: coalesce the thousands of tiny TUI chunks per tick to keep take RPC/log frames compact; 64KB cap bounds append cost.
-    const last = this.pendingOutputRecords.at(-1)
-    if (record.kind === 'output' && last?.kind === 'output' && last.data.length < 64 * 1024) {
+    if (canCoalesce) {
       last.data += record.data
     } else {
       this.pendingOutputRecords.push(record)
@@ -720,6 +741,7 @@ export class Session {
   private flushPreReadyQueue(): void {
     const queued = this.preReadyStdinQueue
     this.preReadyStdinQueue = []
+    this.preReadyStdinCodeUnits = 0
     for (const data of queued) {
       this.subprocess.write(data)
     }

--- a/src/main/daemon/terminal-history-log-state.ts
+++ b/src/main/daemon/terminal-history-log-state.ts
@@ -1,0 +1,55 @@
+import { closeSync, fstatSync, openSync, readSync } from 'node:fs'
+import { decodeLogHeader, LOG_HEADER_BYTES } from './terminal-history-log'
+import { TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES } from './terminal-history-file-limits'
+import { readTerminalHistoryJson } from './terminal-history-file-reader'
+
+export type TerminalHistoryLogState = {
+  checkpointPath: string
+  logPath: string
+  /** Null until a warm writer resolves the existing log on first append. */
+  logGeneration: number | null
+  /** Null until resolved alongside the generation. */
+  logBytes: number | null
+}
+
+export function resolveTerminalHistoryLogState(writer: TerminalHistoryLogState): void {
+  if (writer.logBytes !== null && writer.logGeneration !== null) {
+    return
+  }
+  let headerGeneration: number | null = null
+  let size = 0
+  try {
+    const fd = openSync(writer.logPath, 'r')
+    try {
+      size = fstatSync(fd).size
+      const header = Buffer.alloc(LOG_HEADER_BYTES)
+      if (readSync(fd, header, 0, LOG_HEADER_BYTES, 0) === LOG_HEADER_BYTES) {
+        headerGeneration = decodeLogHeader(header)
+      }
+    } finally {
+      closeSync(fd)
+    }
+  } catch {
+    // Missing log file starts a fresh generation below.
+  }
+  if (headerGeneration !== null) {
+    writer.logGeneration = headerGeneration
+    writer.logBytes = size
+    return
+  }
+  // Why: a zero byte count makes the next append replace a corrupt or headerless log.
+  writer.logBytes = 0
+  writer.logGeneration = readCheckpointGeneration(writer.checkpointPath) ?? 0
+}
+
+function readCheckpointGeneration(checkpointPath: string): number | null {
+  try {
+    const checkpoint = readTerminalHistoryJson<{ generation?: unknown }>(
+      checkpointPath,
+      TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES
+    )
+    return typeof checkpoint.generation === 'number' ? checkpoint.generation : null
+  } catch {
+    return null
+  }
+}

--- a/src/main/daemon/terminal-history-log.test.ts
+++ b/src/main/daemon/terminal-history-log.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   decodeLogHeader,
   decodeTerminalHistoryLog,
   encodeLogBatch,
+  encodeLogBatchWithinLimit,
   encodeLogHeader,
   LOG_HEADER_BYTES
 } from './terminal-history-log'
@@ -42,6 +43,16 @@ describe('terminal history log codec', () => {
     expect(log!.generation).toBe(7)
     expect(log!.truncatedTail).toBe(false)
     expect(log!.batches).toEqual([{ seq: 3, records }])
+  })
+
+  it('rejects an oversized batch before allocating its encoded buffer', () => {
+    const allocation = vi.spyOn(Buffer, 'allocUnsafe')
+
+    expect(
+      encodeLogBatchWithinLimit(1, [{ kind: 'output', data: 'escaped 🐋 output' }], 12)
+    ).toBeNull()
+    expect(allocation).not.toHaveBeenCalled()
+    allocation.mockRestore()
   })
 
   it('decodes multiple contiguous batches', () => {

--- a/src/main/daemon/terminal-history-log.ts
+++ b/src/main/daemon/terminal-history-log.ts
@@ -23,6 +23,8 @@ const FRAME_BATCH = 0x01
 const FRAME_OUTPUT = 0x02
 const FRAME_RESIZE = 0x03
 const FRAME_CLEAR = 0x04
+const FRAME_HEADER_BYTES = 5
+const BATCH_FRAME_BYTES = FRAME_HEADER_BYTES + 4
 
 export type TerminalHistoryLogBatch = {
   seq: number
@@ -61,20 +63,75 @@ export function decodeLogHeader(buffer: Buffer): number | null {
 }
 
 export function encodeLogBatch(seq: number, records: PendingOutputRecord[]): Buffer {
-  const frames: Buffer[] = [encodeFrame(FRAME_BATCH, encodeSeqPayload(seq))]
+  const byteLength = measureLogBatchBytes(records)
+  return encodeLogBatchWithByteLength(seq, records, byteLength)
+}
+
+export function encodeLogBatchWithinLimit(
+  seq: number,
+  records: PendingOutputRecord[],
+  maxBytes: number
+): Buffer | null {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    return null
+  }
+  const byteLength = measureLogBatchBytes(records, maxBytes)
+  return byteLength === null ? null : encodeLogBatchWithByteLength(seq, records, byteLength)
+}
+
+function measureLogBatchBytes(records: PendingOutputRecord[]): number
+function measureLogBatchBytes(records: PendingOutputRecord[], maxBytes: number): number | null
+function measureLogBatchBytes(records: PendingOutputRecord[], maxBytes?: number): number | null {
+  let byteLength = BATCH_FRAME_BYTES
+  if (maxBytes !== undefined && byteLength > maxBytes) {
+    return null
+  }
   for (const record of records) {
     if (record.kind === 'output') {
-      frames.push(encodeFrame(FRAME_OUTPUT, Buffer.from(record.data, 'utf8')))
+      const payloadBytes = Buffer.byteLength(record.data, 'utf8')
+      if (maxBytes !== undefined && payloadBytes > maxBytes - byteLength - FRAME_HEADER_BYTES) {
+        return null
+      }
+      byteLength += FRAME_HEADER_BYTES + payloadBytes
     } else if (record.kind === 'resize') {
-      const payload = Buffer.alloc(4)
-      payload.writeUInt16LE(clampU16(record.cols), 0)
-      payload.writeUInt16LE(clampU16(record.rows), 2)
-      frames.push(encodeFrame(FRAME_RESIZE, payload))
+      byteLength += FRAME_HEADER_BYTES + 4
     } else {
-      frames.push(encodeFrame(FRAME_CLEAR, Buffer.alloc(0)))
+      byteLength += FRAME_HEADER_BYTES
+    }
+    if (maxBytes !== undefined && byteLength > maxBytes) {
+      return null
     }
   }
-  return Buffer.concat(frames)
+  return byteLength
+}
+
+function encodeLogBatchWithByteLength(
+  seq: number,
+  records: PendingOutputRecord[],
+  byteLength: number
+): Buffer {
+  const batch = Buffer.allocUnsafe(byteLength)
+  let offset = 0
+  offset = writeFrameHeader(batch, offset, FRAME_BATCH, 4)
+  batch.writeUInt32LE(seq >>> 0, offset)
+  offset += 4
+
+  for (const record of records) {
+    if (record.kind === 'output') {
+      const payloadBytes = Buffer.byteLength(record.data, 'utf8')
+      offset = writeFrameHeader(batch, offset, FRAME_OUTPUT, payloadBytes)
+      batch.write(record.data, offset, payloadBytes, 'utf8')
+      offset += payloadBytes
+    } else if (record.kind === 'resize') {
+      offset = writeFrameHeader(batch, offset, FRAME_RESIZE, 4)
+      batch.writeUInt16LE(clampU16(record.cols), offset)
+      batch.writeUInt16LE(clampU16(record.rows), offset + 2)
+      offset += 4
+    } else {
+      offset = writeFrameHeader(batch, offset, FRAME_CLEAR, 0)
+    }
+  }
+  return batch
 }
 
 /** Returns null for missing magic / unknown format version — callers fall
@@ -147,17 +204,15 @@ export function decodeTerminalHistoryLog(buffer: Buffer): TerminalHistoryLogCont
   return { generation, batches, truncatedTail }
 }
 
-function encodeFrame(kind: number, payload: Buffer): Buffer {
-  const header = Buffer.alloc(5)
-  header.writeUInt8(kind, 0)
-  header.writeUInt32LE(payload.length, 1)
-  return Buffer.concat([header, payload])
-}
-
-function encodeSeqPayload(seq: number): Buffer {
-  const payload = Buffer.alloc(4)
-  payload.writeUInt32LE(seq >>> 0, 0)
-  return payload
+function writeFrameHeader(
+  buffer: Buffer,
+  offset: number,
+  kind: number,
+  payloadBytes: number
+): number {
+  buffer.writeUInt8(kind, offset)
+  buffer.writeUInt32LE(payloadBytes, offset + 1)
+  return offset + FRAME_HEADER_BYTES
 }
 
 function clampU16(value: number): number {

--- a/src/main/daemon/terminal-history-session-metadata.ts
+++ b/src/main/daemon/terminal-history-session-metadata.ts
@@ -1,0 +1,36 @@
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import { TERMINAL_HISTORY_META_MAX_BYTES } from './terminal-history-file-limits'
+import { readTerminalHistoryJson } from './terminal-history-file-reader'
+
+export type SessionMeta = {
+  cwd: string
+  cols: number
+  rows: number
+  startedAt: string
+  endedAt: string | null
+  exitCode: number | null
+}
+
+export type OpenSessionOptions = {
+  cwd: string
+  cols: number
+  rows: number
+}
+
+export type HistoryManagerOptions = {
+  onWriteError?: (sessionId: string, error: Error) => void
+}
+
+export function stringifyTerminalHistorySessionMeta(meta: SessionMeta): string {
+  // Preflight compact JSON before materializing the larger pretty representation.
+  stringifyJsonWithinByteLimit(meta, TERMINAL_HISTORY_META_MAX_BYTES)
+  const serialized = JSON.stringify(meta, null, 2)
+  if (Buffer.byteLength(serialized, 'utf8') > TERMINAL_HISTORY_META_MAX_BYTES) {
+    throw new Error('Terminal history metadata exceeds its byte limit')
+  }
+  return serialized
+}
+
+export function readTerminalHistorySessionMeta(filePath: string): SessionMeta {
+  return readTerminalHistoryJson<SessionMeta>(filePath, TERMINAL_HISTORY_META_MAX_BYTES)
+}

--- a/src/main/pty/config-overlay-mirroring.test.ts
+++ b/src/main/pty/config-overlay-mirroring.test.ts
@@ -1,0 +1,97 @@
+import type { Dirent } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import {
+  CONFIG_OVERLAY_MAX_ENTRY_NAME_BYTES,
+  CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES,
+  CONFIG_OVERLAY_MAX_SOURCE_ENTRIES,
+  ConfigOverlayCapacityError,
+  ConfigOverlayEntryBudget,
+  _configOverlayMirroringInternals
+} from './config-overlay-mirroring'
+
+function fileEntry(name: string): Dirent {
+  return {
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isDirectory: () => false,
+    isFIFO: () => false,
+    isFile: () => true,
+    isSocket: () => false,
+    isSymbolicLink: () => false,
+    name
+  } as unknown as Dirent
+}
+
+describe('config overlay entry budget', () => {
+  it('accepts the exact entry-count limit and rejects the next streamed entry', () => {
+    const budget = new ConfigOverlayEntryBudget()
+    for (let index = 0; index < CONFIG_OVERLAY_MAX_SOURCE_ENTRIES; index += 1) {
+      budget.reserve('a')
+    }
+
+    expect(() => budget.reserve('a')).toThrowError(
+      new ConfigOverlayCapacityError(
+        'entries',
+        CONFIG_OVERLAY_MAX_SOURCE_ENTRIES + 1,
+        CONFIG_OVERLAY_MAX_SOURCE_ENTRIES
+      )
+    )
+  })
+
+  it('accepts an exact-limit entry name and rejects one byte more', () => {
+    new ConfigOverlayEntryBudget().reserve('a'.repeat(CONFIG_OVERLAY_MAX_ENTRY_NAME_BYTES))
+
+    expect(() =>
+      new ConfigOverlayEntryBudget().reserve('a'.repeat(CONFIG_OVERLAY_MAX_ENTRY_NAME_BYTES + 1))
+    ).toThrowError(
+      new ConfigOverlayCapacityError(
+        'entry-name-bytes',
+        CONFIG_OVERLAY_MAX_ENTRY_NAME_BYTES + 1,
+        CONFIG_OVERLAY_MAX_ENTRY_NAME_BYTES
+      )
+    )
+  })
+
+  it('accepts the exact aggregate encoded-name limit and rejects one more name', () => {
+    const budget = new ConfigOverlayEntryBudget()
+    const name = 'a'.repeat(4_094)
+    expect(Buffer.byteLength(JSON.stringify(name), 'utf8')).toBe(4_096)
+
+    for (let index = 0; index < CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES / 4_096; index += 1) {
+      budget.reserve(name)
+    }
+
+    expect(() => budget.reserve('a')).toThrowError(
+      new ConfigOverlayCapacityError(
+        'retained-name-bytes',
+        CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES + 3,
+        CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES
+      )
+    )
+  })
+
+  it('stops reading immediately after the first over-limit entry', () => {
+    const entries = Array.from({ length: 10_000 }, (_, index) => fileEntry(`entry-${index}`))
+    let reads = 0
+    let visits = 0
+    const directory = {
+      readSync() {
+        reads += 1
+        return entries.shift() ?? null
+      }
+    }
+
+    expect(() =>
+      _configOverlayMirroringInternals.scanOpenDirectory(
+        directory,
+        new ConfigOverlayEntryBudget({ maxEntries: 2 }),
+        () => {
+          visits += 1
+        }
+      )
+    ).toThrow(ConfigOverlayCapacityError)
+    expect(reads).toBe(3)
+    expect(visits).toBe(2)
+    expect(entries).toHaveLength(9_997)
+  })
+})

--- a/src/main/pty/config-overlay-mirroring.ts
+++ b/src/main/pty/config-overlay-mirroring.ts
@@ -1,0 +1,228 @@
+import { mkdirSync, opendirSync, realpathSync, statSync, type Dirent } from 'node:fs'
+import { join } from 'node:path'
+import { mirrorEntry } from './overlay-mirror'
+
+export const CONFIG_OVERLAY_MAX_SOURCE_ENTRIES = 4_096
+export const CONFIG_OVERLAY_MAX_ENTRY_NAME_BYTES = 4 * 1_024
+export const CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES = 1_024 * 1_024
+
+export type ConfigOverlayCapacityKind = 'entries' | 'entry-name-bytes' | 'retained-name-bytes'
+
+export type ConfigOverlayLimits = {
+  maxEntries: number
+  maxEntryNameBytes: number
+  maxRetainedNameBytes: number
+}
+
+const DEFAULT_LIMITS: ConfigOverlayLimits = {
+  maxEntries: CONFIG_OVERLAY_MAX_SOURCE_ENTRIES,
+  maxEntryNameBytes: CONFIG_OVERLAY_MAX_ENTRY_NAME_BYTES,
+  maxRetainedNameBytes: CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES
+}
+
+export class ConfigOverlayCapacityError extends Error {
+  constructor(
+    readonly kind: ConfigOverlayCapacityKind,
+    readonly observed: number,
+    readonly limit: number
+  ) {
+    super(`Agent config overlay ${kind} exceeded its ${limit} limit (observed ${observed})`)
+    this.name = 'ConfigOverlayCapacityError'
+  }
+}
+
+export class ConfigOverlayEntryBudget {
+  private entryCount = 0
+  private retainedNameBytes = 0
+  private readonly limits: ConfigOverlayLimits
+
+  constructor(requested?: Partial<ConfigOverlayLimits>) {
+    this.limits = {
+      maxEntries: resolveLimit(requested?.maxEntries, DEFAULT_LIMITS.maxEntries, 'maxEntries'),
+      maxEntryNameBytes: resolveLimit(
+        requested?.maxEntryNameBytes,
+        DEFAULT_LIMITS.maxEntryNameBytes,
+        'maxEntryNameBytes'
+      ),
+      maxRetainedNameBytes: resolveLimit(
+        requested?.maxRetainedNameBytes,
+        DEFAULT_LIMITS.maxRetainedNameBytes,
+        'maxRetainedNameBytes'
+      )
+    }
+  }
+
+  reserve(name: string): void {
+    const nextEntryCount = this.entryCount + 1
+    if (nextEntryCount > this.limits.maxEntries) {
+      throw new ConfigOverlayCapacityError('entries', nextEntryCount, this.limits.maxEntries)
+    }
+
+    const nameBytes = Buffer.byteLength(name, 'utf8')
+    if (nameBytes > this.limits.maxEntryNameBytes) {
+      throw new ConfigOverlayCapacityError(
+        'entry-name-bytes',
+        nameBytes,
+        this.limits.maxEntryNameBytes
+      )
+    }
+    assertPortableEntryName(name)
+
+    const retainedNameBytes = Buffer.byteLength(JSON.stringify(name), 'utf8')
+    const nextRetainedNameBytes = this.retainedNameBytes + retainedNameBytes
+    if (nextRetainedNameBytes > this.limits.maxRetainedNameBytes) {
+      throw new ConfigOverlayCapacityError(
+        'retained-name-bytes',
+        nextRetainedNameBytes,
+        this.limits.maxRetainedNameBytes
+      )
+    }
+
+    this.entryCount = nextEntryCount
+    this.retainedNameBytes = nextRetainedNameBytes
+  }
+}
+
+export type ConfigOverlayPlan = {
+  sourceDir: string
+  topLevelEntryNames: string[]
+  pluginSourceDir: string | null
+  pluginEntryNames: string[]
+}
+
+export type AppliedConfigOverlayEntries = {
+  topLevelEntryNames: string[]
+  pluginEntryNames: string[]
+}
+
+type ConfigOverlayPlanOptions = {
+  reservedPluginFile: string
+  reservedTopLevelEntryNames?: ReadonlySet<string>
+}
+
+function resolveLimit(requested: number | undefined, maximum: number, name: string): number {
+  if (requested === undefined) {
+    return maximum
+  }
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+  return Math.min(requested, maximum)
+}
+
+function assertPortableEntryName(name: string): void {
+  if (name.length === 0 || name === '.' || name === '..' || /[/\\]/.test(name)) {
+    throw new Error('Agent config overlay contains a non-portable entry name')
+  }
+}
+
+function closeDirectory(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ERR_DIR_CLOSED') {
+      throw error
+    }
+  }
+}
+
+function scanOpenDirectory(
+  directory: Pick<ReturnType<typeof opendirSync>, 'readSync'>,
+  budget: ConfigOverlayEntryBudget,
+  visit: (entry: Dirent) => void
+): void {
+  while (true) {
+    const entry = directory.readSync()
+    if (entry === null) {
+      return
+    }
+    budget.reserve(entry.name)
+    visit(entry)
+  }
+}
+
+function scanDirectory(
+  path: string,
+  budget: ConfigOverlayEntryBudget,
+  visit: (entry: Dirent) => void
+): void {
+  const directory = opendirSync(path, { bufferSize: 32 })
+  try {
+    scanOpenDirectory(directory, budget, visit)
+  } finally {
+    closeDirectory(directory)
+  }
+}
+
+export function createConfigOverlayPlan(
+  sourceDir: string,
+  options: ConfigOverlayPlanOptions,
+  budget = new ConfigOverlayEntryBudget()
+): ConfigOverlayPlan {
+  const topLevelEntryNames: string[] = []
+  const pluginEntryNames: string[] = []
+  let pluginSourceDir: string | null = null
+
+  scanDirectory(sourceDir, budget, (entry) => {
+    if (options.reservedTopLevelEntryNames?.has(entry.name)) {
+      return
+    }
+
+    const sourcePath = join(sourceDir, entry.name)
+    if (entry.name === 'plugins') {
+      const isSymlink = entry.isSymbolicLink()
+      let isLinkPointingToDir = false
+      if (isSymlink) {
+        try {
+          isLinkPointingToDir = statSync(sourcePath).isDirectory()
+        } catch {
+          isLinkPointingToDir = false
+        }
+      }
+
+      if ((!isSymlink && entry.isDirectory()) || isLinkPointingToDir) {
+        pluginSourceDir = isLinkPointingToDir ? realpathSync(sourcePath) : sourcePath
+        scanDirectory(pluginSourceDir, budget, (pluginEntry) => {
+          if (pluginEntry.name !== options.reservedPluginFile) {
+            pluginEntryNames.push(pluginEntry.name)
+          }
+        })
+        return
+      }
+    }
+
+    topLevelEntryNames.push(entry.name)
+  })
+
+  return { sourceDir, topLevelEntryNames, pluginSourceDir, pluginEntryNames }
+}
+
+export function applyConfigOverlayPlan(
+  plan: ConfigOverlayPlan,
+  targetDir: string,
+  applied: AppliedConfigOverlayEntries = {
+    topLevelEntryNames: [],
+    pluginEntryNames: []
+  }
+): AppliedConfigOverlayEntries {
+  for (const entryName of plan.topLevelEntryNames) {
+    mirrorEntry(join(plan.sourceDir, entryName), join(targetDir, entryName))
+    applied.topLevelEntryNames.push(entryName)
+  }
+
+  if (plan.pluginSourceDir === null) {
+    return applied
+  }
+
+  const targetPluginsDir = join(targetDir, 'plugins')
+  mkdirSync(targetPluginsDir, { recursive: true })
+  for (const entryName of plan.pluginEntryNames) {
+    mirrorEntry(join(plan.pluginSourceDir, entryName), join(targetPluginsDir, entryName))
+    applied.pluginEntryNames.push(entryName)
+  }
+  return applied
+}
+
+export const _configOverlayMirroringInternals = {
+  scanOpenDirectory
+}

--- a/src/main/pty/overlay-mirror.test.ts
+++ b/src/main/pty/overlay-mirror.test.ts
@@ -4,7 +4,12 @@ import { tmpdir } from 'node:os'
 import type * as NodePath from 'node:path'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { safeRemoveOverlay } from './overlay-mirror'
+import {
+  OVERLAY_REMOVE_MAX_DEPTH,
+  OVERLAY_REMOVE_MAX_ENTRIES,
+  safeRemoveOverlay,
+  safeRemoveTree
+} from './overlay-mirror'
 
 const tempRoots: string[] = []
 
@@ -19,6 +24,50 @@ afterEach(() => {
 })
 
 describe('safeRemoveOverlay', () => {
+  it('publishes finite production cleanup limits', () => {
+    expect(OVERLAY_REMOVE_MAX_ENTRIES).toBe(100_000)
+    expect(OVERLAY_REMOVE_MAX_DEPTH).toBe(256)
+  })
+
+  it('removes a tree at the exact entry limit', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-overlay-entry-limit-'))
+    tempRoots.push(root)
+    writeFileSync(join(root, 'one'), '')
+    writeFileSync(join(root, 'two'), '')
+
+    expect(safeRemoveTree(root, { maxEntries: 2 })).toBe(true)
+    expect(existsSync(root)).toBe(false)
+  })
+
+  it('stops before visiting an entry beyond the limit', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-overlay-entry-limit-'))
+    tempRoots.push(root)
+    writeFileSync(join(root, 'one'), '')
+    writeFileSync(join(root, 'two'), '')
+    writeFileSync(join(root, 'three'), '')
+
+    expect(safeRemoveTree(root, { maxEntries: 2 })).toBe(false)
+    expect(existsSync(root)).toBe(true)
+  })
+
+  it('accepts the exact directory depth and stops before descending one level deeper', async () => {
+    const acceptedRoot = await mkdtemp(join(tmpdir(), 'orca-overlay-depth-limit-'))
+    tempRoots.push(acceptedRoot)
+    mkdirSync(join(acceptedRoot, 'one', 'two'), { recursive: true })
+    writeFileSync(join(acceptedRoot, 'one', 'two', 'leaf'), '')
+
+    expect(safeRemoveTree(acceptedRoot, { maxDepth: 2 })).toBe(true)
+    expect(existsSync(acceptedRoot)).toBe(false)
+
+    const rejectedRoot = await mkdtemp(join(tmpdir(), 'orca-overlay-depth-limit-'))
+    tempRoots.push(rejectedRoot)
+    mkdirSync(join(rejectedRoot, 'one', 'two'), { recursive: true })
+    writeFileSync(join(rejectedRoot, 'one', 'two', 'leaf'), '')
+
+    expect(safeRemoveTree(rejectedRoot, { maxDepth: 1 })).toBe(false)
+    expect(existsSync(rejectedRoot)).toBe(true)
+  })
+
   it('removes valid overlay children whose names start with dot-dot', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-overlay-root-'))
     tempRoots.push(root)

--- a/src/main/pty/overlay-mirror.ts
+++ b/src/main/pty/overlay-mirror.ts
@@ -11,12 +11,26 @@ import {
   cpSync,
   linkSync,
   lstatSync,
-  readdirSync,
+  opendirSync,
   rmdirSync,
   symlinkSync,
   unlinkSync
 } from 'node:fs'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+export const OVERLAY_REMOVE_MAX_ENTRIES = 100_000
+export const OVERLAY_REMOVE_MAX_DEPTH = 256
+
+type OverlayRemoveLimits = {
+  maxEntries: number
+  maxDepth: number
+}
+
+type OverlayRemoveState = {
+  entries: number
+  exhausted: boolean
+  limits: OverlayRemoveLimits
+}
 
 export function mirrorEntry(sourcePath: string, targetPath: string): void {
   // Why: lstatSync (not statSync) so that if the user's source dir contains
@@ -83,59 +97,122 @@ export function isSafeDescendCandidate(stats: {
   return stats.isDirectory()
 }
 
-// Why: the overlay tree contains symlinks/junctions that point back into the
-// user's real state dir. fs.rmSync with { recursive: true } has repeatedly
-// regressed on Windows when walking NTFS junctions -- it can follow them and
-// delete the *target*, destroying the user's data. Never descend into a
-// symlink/junction here: for any non-real-directory entry we unlink the link
-// itself; only entries that are truly directories on disk are recursed into.
-export function safeRemoveTree(path: string): void {
+function resolveRemoveLimit(requested: number | undefined, maximum: number, name: string): number {
+  if (requested === undefined) {
+    return maximum
+  }
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+  return Math.min(requested, maximum)
+}
+
+function closeDirectory(directory: ReturnType<typeof opendirSync>): boolean {
+  try {
+    directory.closeSync()
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ERR_DIR_CLOSED'
+  }
+}
+
+function removeTreeWithinLimits(path: string, depth: number, state: OverlayRemoveState): boolean {
+  if (state.exhausted) {
+    return false
+  }
+
   let stat
   try {
     stat = lstatSync(path)
-  } catch {
-    return
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'ENOENT'
   }
 
   // On Windows, lstat on a directory junction can report BOTH
   // isSymbolicLink() === true AND isDirectory() === true, so we MUST check
   // isSymbolicLink first -- otherwise a junction enters the recursive branch
-  // and readdirSync enumerates the link's target, the exact bug in #1083.
+  // and enumerates the link's target, the exact bug in #1083.
   if (!isSafeDescendCandidate(stat)) {
     try {
       unlinkSync(path)
+      return true
     } catch {
       // Best-effort: antivirus/indexers can hold handles briefly on Windows.
       // A leftover link is harmless; the next spawn rebuilds the overlay.
+      return false
     }
-    return
   }
 
-  let entries
+  let directory
   try {
-    entries = readdirSync(path, { withFileTypes: true })
+    directory = opendirSync(path, { bufferSize: 32 })
   } catch {
-    return
+    return false
   }
 
-  for (const entry of entries) {
-    const child = join(path, entry.name)
-    if (isSafeDescendCandidate(entry)) {
-      safeRemoveTree(child)
-      continue
+  let completed = true
+  try {
+    while (!state.exhausted) {
+      const entry = directory.readSync()
+      if (entry === null) {
+        break
+      }
+      if (state.entries >= state.limits.maxEntries) {
+        state.exhausted = true
+        completed = false
+        break
+      }
+      state.entries += 1
+
+      const child = join(path, entry.name)
+      if (isSafeDescendCandidate(entry)) {
+        if (depth >= state.limits.maxDepth) {
+          state.exhausted = true
+          completed = false
+          break
+        }
+        completed = removeTreeWithinLimits(child, depth + 1, state) && completed
+        continue
+      }
+      try {
+        unlinkSync(child)
+      } catch {
+        completed = false
+      }
     }
-    try {
-      unlinkSync(child)
-    } catch {
-      // Best-effort, see above.
-    }
+  } catch {
+    completed = false
+  } finally {
+    completed = closeDirectory(directory) && completed
   }
 
   try {
     rmdirSync(path)
+    return completed
   } catch {
     // Directory may be non-empty if an unlink above failed; harmless.
+    return false
   }
+}
+
+// Why: the overlay tree contains symlinks/junctions that point back into the
+// user's real state dir. Stream a bounded traversal and never descend into a
+// link; a pathological tree is left for a later cleanup instead of growing
+// an unbounded directory array or call stack in Electron's main process.
+export function safeRemoveTree(path: string, requested?: Partial<OverlayRemoveLimits>): boolean {
+  const state: OverlayRemoveState = {
+    entries: 0,
+    exhausted: false,
+    limits: {
+      maxEntries: resolveRemoveLimit(
+        requested?.maxEntries,
+        OVERLAY_REMOVE_MAX_ENTRIES,
+        'maxEntries'
+      ),
+      maxDepth: resolveRemoveLimit(requested?.maxDepth, OVERLAY_REMOVE_MAX_DEPTH, 'maxDepth')
+    }
+  }
+  return removeTreeWithinLimits(path, 0, state)
 }
 
 // Why: last-line guard against an overlay-root constant ever being
@@ -143,7 +220,7 @@ export function safeRemoveTree(path: string): void {
 // designated overlay root is refused so a misconfiguration cannot turn into
 // an `rm -rf` of arbitrary user data. Logs (rather than throws) so a buggy
 // caller stays visible without crashing the PTY spawn.
-export function safeRemoveOverlay(overlayDir: string, overlayRoot: string): void {
+export function safeRemoveOverlay(overlayDir: string, overlayRoot: string): boolean {
   const resolvedRoot = resolve(overlayRoot)
   const resolvedTarget = resolve(overlayDir)
   const rel = relative(resolvedRoot, resolvedTarget)
@@ -151,7 +228,7 @@ export function safeRemoveOverlay(overlayDir: string, overlayRoot: string): void
     console.warn(
       `[overlay-mirror] refusing to remove overlay outside root: target=${resolvedTarget} root=${resolvedRoot}`
     )
-    return
+    return false
   }
-  safeRemoveTree(resolvedTarget)
+  return safeRemoveTree(resolvedTarget)
 }

--- a/src/main/pty/shell-startup-env-memory.test.ts
+++ b/src/main/pty/shell-startup-env-memory.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { readFileSyncMock } = vi.hoisted(() => ({ readFileSyncMock: vi.fn() }))
+
+vi.mock('../../shared/node-bounded-file-reader', () => ({
+  readNodeFileSyncWithinLimit: (path: string, maxBytes: number) => {
+    const buffer = Buffer.from(readFileSyncMock(path) as string)
+    if (buffer.byteLength > maxBytes) {
+      throw new Error('File too large')
+    }
+    return { buffer, stats: { size: buffer.byteLength } }
+  }
+}))
+
+import {
+  __resetShellStartupEnvCache,
+  MAX_SHELL_STARTUP_CACHE_BYTES,
+  MAX_SHELL_STARTUP_CACHE_ENTRIES,
+  MAX_SHELL_STARTUP_ENV_VALUE_CODE_UNITS,
+  MAX_SHELL_STARTUP_FILE_BYTES,
+  readShellStartupEnvVar
+} from './shell-startup-env'
+
+describe('shell startup environment memory bounds', () => {
+  const originalPlatform = process.platform
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    readFileSyncMock.mockReset()
+    __resetShellStartupEnvCache()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  })
+
+  it('accepts an exact-size startup file and skips the next byte', () => {
+    const assignment = 'export TARGET=/bounded\n'
+    readFileSyncMock.mockReturnValue(
+      assignment + '#'.repeat(MAX_SHELL_STARTUP_FILE_BYTES - assignment.length)
+    )
+    expect(readShellStartupEnvVar('TARGET', '/home/alice', '/bin/zsh')).toBe('/bounded')
+
+    __resetShellStartupEnvCache()
+    readFileSyncMock.mockReturnValue(
+      assignment + '#'.repeat(MAX_SHELL_STARTUP_FILE_BYTES - assignment.length + 1)
+    )
+    expect(readShellStartupEnvVar('TARGET', '/home/alice', '/bin/zsh')).toBeUndefined()
+  })
+
+  it('does not retain an oversized exported value', () => {
+    readFileSyncMock.mockReturnValue(
+      `export TARGET=${'x'.repeat(MAX_SHELL_STARTUP_ENV_VALUE_CODE_UNITS + 1)}\n`
+    )
+
+    expect(readShellStartupEnvVar('TARGET', '/home/alice', '/bin/zsh')).toBeUndefined()
+  })
+
+  it('caps cache entries with LRU recovery', () => {
+    readFileSyncMock.mockReturnValue('')
+    for (let index = 0; index <= MAX_SHELL_STARTUP_CACHE_ENTRIES; index += 1) {
+      readShellStartupEnvVar(`TARGET_${index}`, '/home/alice', '/bin/zsh')
+    }
+    const readsBeforeRetry = readFileSyncMock.mock.calls.length
+
+    readShellStartupEnvVar('TARGET_0', '/home/alice', '/bin/zsh')
+
+    expect(readFileSyncMock.mock.calls.length).toBeGreaterThan(readsBeforeRetry)
+  })
+
+  it('caps aggregate cached key/value memory independently of entry count', () => {
+    expect(MAX_SHELL_STARTUP_CACHE_BYTES).toBe(8 * 1024 * 1024)
+    const value = 'x'.repeat(MAX_SHELL_STARTUP_ENV_VALUE_CODE_UNITS)
+    for (let index = 0; index < 65; index += 1) {
+      readFileSyncMock.mockReturnValue(`export TARGET_${index}=${value}\n`)
+      expect(readShellStartupEnvVar(`TARGET_${index}`, '/home/alice', '/bin/zsh')).toBe(value)
+    }
+    const readsBeforeRetry = readFileSyncMock.mock.calls.length
+    readFileSyncMock.mockReturnValue(`export TARGET_0=${value}\n`)
+
+    readShellStartupEnvVar('TARGET_0', '/home/alice', '/bin/zsh')
+
+    expect(readFileSyncMock.mock.calls.length).toBeGreaterThan(readsBeforeRetry)
+  })
+})

--- a/src/main/pty/shell-startup-env.test.ts
+++ b/src/main/pty/shell-startup-env.test.ts
@@ -10,6 +10,16 @@ vi.mock('fs', () => ({
   readFileSync: readFileSyncMock
 }))
 
+vi.mock('../../shared/node-bounded-file-reader', () => ({
+  readNodeFileSyncWithinLimit: (path: string, maxBytes: number) => {
+    const buffer = Buffer.from(readFileSyncMock(path) as string)
+    if (buffer.byteLength > maxBytes) {
+      throw new Error('File too large')
+    }
+    return { buffer, stats: { size: buffer.byteLength } }
+  }
+}))
+
 import { __resetShellStartupEnvCache, readShellStartupEnvVar } from './shell-startup-env'
 
 describe('readShellStartupEnvVar', () => {

--- a/src/main/pty/shell-startup-env.ts
+++ b/src/main/pty/shell-startup-env.ts
@@ -1,5 +1,12 @@
-import { existsSync, readFileSync } from 'node:fs'
 import { posix } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+
+export const MAX_SHELL_STARTUP_FILE_BYTES = 1024 * 1024
+export const MAX_SHELL_STARTUP_CACHE_ENTRIES = 128
+export const MAX_SHELL_STARTUP_CACHE_BYTES = 8 * 1024 * 1024
+export const MAX_SHELL_STARTUP_ENV_VALUE_CODE_UNITS = 64 * 1024
+const MAX_SHELL_STARTUP_NAME_CODE_UNITS = 256
+const MAX_SHELL_STARTUP_PATH_CODE_UNITS = 16 * 1024
 
 // Why: only files the user's actual shell would source. Mixing zsh and bash
 // files breaks the "last assignment wins matches the live shell" guarantee —
@@ -29,7 +36,7 @@ function parseExportedValue(content: string, name: string, home: string): string
     // Why: $HOME / ${HOME} / ~ expansion mimics what the live shell would
     // do for double-quoted and unquoted values; single-quoted is literal.
     const expanded = quoted === "'" ? text : expandHome(text, home)
-    if (expanded.length > 0) {
+    if (expanded.length > 0 && expanded.length <= MAX_SHELL_STARTUP_ENV_VALUE_CODE_UNITS) {
       lastMatch = expanded
     }
   }
@@ -38,11 +45,8 @@ function parseExportedValue(content: string, name: string, home: string): string
 }
 
 function readStartupFile(path: string): string | null {
-  if (!existsSync(path)) {
-    return null
-  }
   try {
-    return readFileSync(path, 'utf8')
+    return readNodeFileSyncWithinLimit(path, MAX_SHELL_STARTUP_FILE_BYTES).buffer.toString('utf8')
   } catch {
     return null
   }
@@ -121,7 +125,8 @@ function expandHome(value: string, home: string): string {
     .replace(/\$HOME(?![A-Za-z0-9_])/g, home)
 }
 
-const cache = new Map<string, string | undefined>()
+const cache = new Map<string, { retainedBytes: number; value: string | undefined }>()
+let cacheRetainedBytes = 0
 
 /**
  * Best-effort static read of a single env-var assignment from the user's
@@ -151,18 +156,26 @@ export function readShellStartupEnvVar(
   home = process.env.HOME,
   shell = process.env.SHELL
 ): string | undefined {
-  if (!home || process.platform === 'win32') {
+  if (
+    !home ||
+    home.length > MAX_SHELL_STARTUP_PATH_CODE_UNITS ||
+    (shell?.length ?? 0) > MAX_SHELL_STARTUP_PATH_CODE_UNITS ||
+    process.platform === 'win32'
+  ) {
     return undefined
   }
   // Why: the regex above is fixed; rejecting unsafe names is cheap defense
   // for the day a future caller passes something with regex metacharacters.
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+  if (name.length > MAX_SHELL_STARTUP_NAME_CODE_UNITS || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
     return undefined
   }
 
   const cacheKey = `${name}\0${home}\0${shell ?? ''}`
-  if (cache.has(cacheKey)) {
-    return cache.get(cacheKey)
+  const cached = cache.get(cacheKey)
+  if (cached) {
+    cache.delete(cacheKey)
+    cache.set(cacheKey, cached)
+    return cached.value
   }
 
   let lastMatch: string | undefined
@@ -179,8 +192,26 @@ export function readShellStartupEnvVar(
     }
   }
 
-  cache.set(cacheKey, lastMatch)
+  cacheShellStartupValue(cacheKey, lastMatch)
   return lastMatch
+}
+
+function cacheShellStartupValue(key: string, value: string | undefined): void {
+  const retainedBytes = (key.length + (value?.length ?? 0)) * 2
+  while (
+    cache.size >= MAX_SHELL_STARTUP_CACHE_ENTRIES ||
+    cacheRetainedBytes + retainedBytes > MAX_SHELL_STARTUP_CACHE_BYTES
+  ) {
+    const oldestKey = cache.keys().next().value as string | undefined
+    if (oldestKey === undefined) {
+      return
+    }
+    const oldest = cache.get(oldestKey)
+    cache.delete(oldestKey)
+    cacheRetainedBytes -= oldest?.retainedBytes ?? 0
+  }
+  cache.set(key, { retainedBytes, value })
+  cacheRetainedBytes += retainedBytes
 }
 
 /**
@@ -190,4 +221,5 @@ export function readShellStartupEnvVar(
  */
 export function __resetShellStartupEnvCache(): void {
   cache.clear()
+  cacheRetainedBytes = 0
 }


### PR DESCRIPTION
## OOM hardening slice 13/29 — bound daemon admission & PTY delivery credits

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **13/29** (base: `oom/12-b-ssh`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
This slice re-lands OOM ceilings across the terminal daemon and PTY layer: it caps daemon transport sockets/clients/requests/response bytes, bounds NDJSON/binary-frame line and payload sizes, admits and byte-limits every daemon request field, streams overlay-tree removal and config-overlay mirroring under entry/depth caps, and bounds terminal-history logs, pre-ready stdin, pending output, shell-startup rc reads, and terminal size (500x500).

### ELI5
Imagine the app's terminal engine as a mailroom that used to accept letters of any size, any number, from anyone, and would pile them up until the building collapsed. This change adds sensible rules: letters can't be huge, only so many can be in flight, envelopes must be addressed correctly, and cleanup crews stop after a reasonable amount of work instead of running forever. Almost nobody in normal use ever bumps these limits; they only kick in when something is broken or hostile.

### Proof of OOM fix
- daemon-admission-limits.ts: sockets=128, control clients=32, stream attachments=24, handshake timeout=10s, active requests 256 (128/client), active request bytes 32MB (16MB/client), control buffer 32MB; per-field caps: clientId/requestId=1KB, type=256B, sessionId=4KB, cwd=256KB, command=4MB, historySeed=12MB, env 4096 entries/4MB with 1MB/value. Tests: daemon-admission-limits.test.ts, daemon-server-admission.test.ts, daemon-client-outbound-admission.test.ts
- daemon-response-admission.ts: response=16MB, active response 128MB (64MB/client), control process buffer 64MB; reservation only for createOrAttach/getSnapshot/listSessions/takePendingOutput. Test: daemon-server-admission.test.ts
- session.ts: PENDING_OUTPUT_MAX_RECORDS=4096, PRE_READY_STDIN 16MB code-units / 4096 segments. Tests: session-pending-output.test.ts, session-pre-ready-input-memory.test.ts, session.test.ts
- terminal-history-file-limits (external): LOG=5MB, checkpoint=16MB, meta=64KB, enforced via encodeLogBatchWithinLimit/stringifyJsonWithinByteLimit in history-manager.ts. Tests: history-manager-memory.test.ts, terminal-history-log.test.ts
- ndjson.ts: line=16MB, handshake line=64KB, structural tokens=1,000,000, nesting depth=128. Test: ndjson.test.ts
- binary-frame.ts: decode now rejects payloadLength > FRAME_MAX_PAYLOAD (1MB) and clears the buffer. Test: binary-frame.test.ts
- overlay-mirror.ts safeRemoveTree: OVERLAY_REMOVE_MAX_ENTRIES=100,000, OVERLAY_REMOVE_MAX_DEPTH=256, streamed via opendirSync (no unbounded readdir array / recursion). Test: overlay-mirror.test.ts
- config-overlay-mirroring.ts: 4096 source entries, 4KB/entry-name, 1MB retained-name bytes. Test: config-overlay-mirroring.test.ts
- shell-startup-env.ts: rc file read cap=1MB, LRU cache 128 entries/8MB, env value cap=64KB, name<=256, path<=16KB. Tests: shell-startup-env-memory.test.ts, shell-startup-env.test.ts
- daemon-control-file-reader.ts=64KB and daemon-login-session-probe-verdict.ts=64B bounded reads replace unbounded readFileSync across daemon-spawner/health/init/host-relocation/entry/client
- daemon-host-relocation.ts: MAX_PINNED_DAEMON_VERSIONS=1024 with fail-closed prune (skips pruning if pin scan saturates), streamed opendirSync

### Regressions
**Normal-path (ordinary use, below the new limits):** **none** — behavior is unchanged below the ceilings.

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Daemon rejects a control client past 32, a stream attachment past 24, or a transport socket past 128 (retryable hello error); far above 1-few ordinary app instances
- Daemon replies 'Daemon request capacity exceeded; retry' once >256 in-flight requests / 32MB request bytes / 128MB reserved response bytes accumulate (or per-client 128 / 16MB / 64MB)
- A single response serializing over 16MB (e.g. an enormous getSnapshot/takePendingOutput) is converted to an error reply instead of being sent
- A peer that never sends a newline, sends a >16MB request line (>64KB during handshake), or a binary frame claiming >1MB payload gets its socket destroyed
- overlay-tree removal past 100k entries or 256 depth is left partially removed for a later launch instead of walking unbounded
- config overlay mirroring throws ConfigOverlayCapacityError once a source/plugins dir exceeds 4096 entries or 1MB of retained names
- Pre-ready stdin queue past 16MB or 4096 segments throws before shell readiness; pending-output past 4096 non-coalesced records drops to overflow snapshot
- Client that fails hello within 10s handshake timeout is disconnected
- Terminal size is now hard-capped at 500 cols x 500 rows (shared terminal-size-limits). A resize request beyond that is rejected outright by daemon admission (writeRequestError), and headless-emulator normalizes out-of-range dims to the 80x24 fallback instead of honoring them. Rows=500 is unreachable, but cols~500 is conceivably reachable on an ultra-wide monitor with a very small font. _(only when: Ultra-wide display + tiny font pushing a terminal past 500 columns; ordinary terminals (80-300 cols) are unaffected.)_
- Agent config-overlay mirroring (used by mimo/opencode hook services) fails the spawn with ConfigOverlayCapacityError if a user's config/plugins source directory exceeds 4096 entries or 1MB of retained entry-name bytes. _(only when: Power users with an unusually large agent config or plugins directory (>4096 files); typical config dirs are well under the cap.)_
- Shell-startup env probing now reads at most 1MB of an rc file and ignores env-var values longer than 64KB, so an assignment living past the first 1MB of a very large rc file (or a >64KB value) is no longer picked up. _(only when: User rc file (.zshrc/.bashrc/.profile) larger than 1MB or a targeted env var whose value exceeds 64KB; normal rc files are far smaller.)_
- A single Orca instance can fail to restore or create its fifth concurrently mounting terminal. createOrAttach reserves 16 MiB against a 64 MiB per-client response budget, so requests 1-4 are admitted and request 5 receives "Daemon request capacity exceeded; retry"; the adapter propagates that error instead of retrying. Five split/restored panes is an ordinary workspace size, and the code explicitly documents simultaneous pane mounts. _(only when: Five createOrAttach requests from one app overlap before any of the first four finishes, such as concurrent split-pane mounts or startup restore while PTY preparation is pending.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.
- Touches 1 file(s) also changed on `main` since the revert; git auto-merges them (no conflict): `daemon-server.ts`.

### ✅ Inherited defect FIXED in this slice
- ✅ **FIXED** [medium, overload-path only] `src/main/daemon/daemon-response-admission.ts` — Each create reserves the full 16 MiB response max against a 64 MiB per-client budget, so 4 pending terminal creates can exhaust it and reject the 5th even though real replies are tiny; DaemonPtyAdapter retries daemon-loss but not the capacity error.
  - **Fix applied:** Added a bounded, pre-dispatch-safe retry (6 attempts, ~25-250ms backoff) in DaemonClient.request keyed to the 'request capacity exceeded' rejection; a >=5-pane restore fan-out now waits for an in-flight response to release its 16 MiB reservation instead of failing. Verified: typecheck + daemon client/admission suites pass.

> Defects **inherited from the original #10179 code** (not introduced by slicing; not present in today's unbounded `main`). Fixed items were patched in-slice and re-verified (typecheck + affected suites); remaining flagged items are overload-only and noted for a fast-follow.

### Adversarial review
- 3 skeptic lens(es) incl. a frontier-model (GPT) cross-check. Sign-off: **FLAGGED — see above**. Residual risk: **medium**.
- Adversarial (skeptic) pass on PR #13 B-daemon-pty. No CONFIRMED normal-path regression. The prior reviewer's summary is accurate; I verified actual numeric ceilings and reachability. Two items warrant human sign-off (residualRisk=medium, not signoff-blocking since this is production-shipped code that passed full CI).

CONCERN 1 - Terminal size cap 500x500, HARD-rejected with no clamp (src/shared/terminal-size-limits.ts, wired via daemon-admission-limits.ts + daemon-pty-size.ts). Confirmed the renderer does NOT import terminal-size-limits (git grep over src/renderer is empty), so it does not pre-clamp. createOrAttach with cols>500 -> createOrAttachPayloadError -> spawn rejected outright (NOT clamped to fallback). resize runs terminalSizeAdmissionError with NO allowMissing, so cols>500 -> writeRequestError, PTY keeps old size (renderer/PTY mismatch). Reachability: a maximized full-width terminal on a 49-inch super-ultrawide (5120px) at a ~10px cell font computes ~500-512 cols - a real if uncommon dev config, not purely abusive. Rows=500 unreachable; cols~500 is the edge. Normal panes/displays (80-300 cols) unaffected. Low-medium; human should confirm Orca clamps fitted dims to 500 in renderer/adapter (out of this slice).

CONCERN 2 - Response-reservation model (daemon-response-admission.ts + daemon-server.ts dispatchRequest). createOrAttach/getSnapshot/listSessions/takePendingOutput each reserve a FIXED 16MB regardless of actual size; per-client cap 64MB => only 4 concurrent per app instance (test daemon-server-admission.test.ts:217 confirms 64MB/16MB=4; 5th throws 'request capacity exceeded'); global 128MB => 8. Reservation held for full preparePtySpawn + host.createOrAttach duration, released in .finally(). If the renderer fires 5+ createOrAttach concurrently during multi-terminal restore, requests 5+ get 'Daemon request capacity exceeded; retry'. Multi-terminal restore is a normal power-user scenario. Could NOT confirm it triggers: restore orchestration/retry lives in the renderer/adapter (daemon-pty-adapter.ts is OUT of this slice and unchanged), and the 'retry' error text plus full-CI shipping strongly imply restore serializes or retries. Human should confirm restore path serializes createOrAttach or handles 'capacity exceeded; retry'.

VERIFIED OVERLOAD-ONLY (ceilings far above ordinary use): pending-output record cap 4096 (session.ts) dominated by pre-existing 2MB byte cap and only matters while detached; pre-ready stdin 16MB/4096 segments (throw is caught by write RPC handler, daemon survives); history log cap unchanged at 5MB, checkpoint 16MB (JsonStringifyByteLimitError caught in checkpoint try/catch); shell-startup rc 1MB read + 64KB env-value cap; config-overlay mirroring 4096 entries/1MB names only affects mimo/opencode/relay agent hook services (callers confirmed: src/main/mimo, src/main/opencode, src/relay only), never ordinary spawns; overlay-tree removal 100k entries/256 depth; daemon 128 sockets/32 control clients/24 stream attachments; NDJSON 16MB line/128 depth/1M tokens; 10s handshake timeout.

CLEANUP/CORRECTNESS: No leak. dispatchRequest increments then decrements in .finally() (runs on throw/cancel); admission failures return BEFORE incrementing. writeRequestError early-returns for null/notify ids. DAEMON_MAX_STREAM_ATTACHMENTS(24) < DAEMON_MAX_CONTROL_CLIENTS(32) asymmetry is intentional, only reachable with >24 concurrent app instances.

OOM EVIDENCE: strong. Concrete caps in daemon-admission-limits.ts, daemon-response-admission.ts, terminal-history-file-limits.ts, shell-startup-env.ts, config-overlay-mirroring.ts, overlay-mirror.ts, plus regression tests daemon-server-admission.test.ts, history-manager-memory.test.ts, session-pending-output.test.ts, session-pre-ready-input-memory.test.ts, headless-emulator-size-limits.test.ts, shell-startup-env-memory.test.ts, config-overlay-mirroring.test.ts, overlay-mirror.test.ts.
- Correctness notes: `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/daemon/daemon-response-admission.ts`: The large-response reservation is too coarse for an ordinary restore burst: every createOrAttach reserves the full 16 MiB response maximum, while the per-client reservation ceiling is 64 MiB. Consequently, four pending terminal creates consume the entire budget and the fifth is rejected even though normal create replies are tiny. The existing admission test proves this exact rejection, and DaemonPtyAdapter only retries daemon-loss errors, not the returned capacity error. Request counters, byte reservations, pending spawn preparations, sockets, timers, and directory handles otherwise release on the reviewed success/error/disconnect paths; exact-limit tests did not reveal an inclusive/exclusive error.

### Files
48 files changed (+2716 / −358).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**
