### PR TITLE
oom(15/29): bound browser capture & emulator video replay

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -1,22 +1,24 @@
 /* eslint-disable max-lines */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-const { execFileMock, webContentsFromIdMock, existsSyncMock, readFileSyncMock, stdinWrites } =
+const { execFileMock, webContentsFromIdMock, existsSyncMock, readScreenshotFileMock, stdinWrites } =
   vi.hoisted(() => ({
     execFileMock: vi.fn(),
     webContentsFromIdMock: vi.fn(),
     existsSyncMock: vi.fn(() => false),
-    readFileSyncMock: vi.fn(() => Buffer.from('')),
+    readScreenshotFileMock: vi.fn(() => Buffer.from('')),
     stdinWrites: [] as string[]
   }))
 
 vi.mock('child_process', () => ({ execFile: execFileMock }))
 vi.mock('fs', () => ({
   existsSync: existsSyncMock,
-  readFileSync: readFileSyncMock,
   accessSync: vi.fn(),
   chmodSync: vi.fn(),
   constants: { X_OK: 1 }
+}))
+vi.mock('./browser-screenshot-file-reader', () => ({
+  readBrowserScreenshotFile: readScreenshotFileMock
 }))
 vi.mock('os', () => ({ platform: () => 'darwin', arch: () => 'arm64' }))
 vi.mock('electron', () => {
@@ -53,10 +55,16 @@ vi.mock('./cdp-bridge', () => ({
 
 import {
   AGENT_BROWSER_CLIPBOARD_WRITE_MAX_BYTES,
+  AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION,
   AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES,
   AgentBrowserBridge
 } from './agent-browser-bridge'
 import type { BrowserManager } from './browser-manager'
+import {
+  BROWSER_SCREENSHOT_MAX_DIMENSION_PX,
+  BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+} from './browser-screenshot-limits'
+import { CDP_PDF_MAX_RETAINED_BYTES, CDP_PDF_MEMORY_LIMIT_ERROR } from './cdp-print-to-pdf'
 import {
   CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS,
   CLIPBOARD_TEXT_WRITE_MAX_BYTES,
@@ -298,7 +306,7 @@ describe('AgentBrowserBridge', () => {
     stdinWrites.length = 0
     CdpWsProxyMock.instances.length = 0
     existsSyncMock.mockReturnValue(false)
-    readFileSyncMock.mockReturnValue(Buffer.from(''))
+    readScreenshotFileMock.mockReturnValue(Buffer.from(''))
     const wc = mockWebContents(100)
     webContentsFromIdMock.mockReturnValue(wc)
     bridge = new AgentBrowserBridge(mockBrowserManager())
@@ -763,6 +771,68 @@ describe('AgentBrowserBridge', () => {
     expect(snapshotIdx).toBeLessThan(clickIdx)
   })
 
+  it('rejects overload instead of retaining an unbounded per-session command queue', async () => {
+    let releaseFirst!: () => void
+    const firstTurn = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const internals = bridge as unknown as {
+      enqueueTargetedCommand: <T>(
+        worktreeId: string | undefined,
+        browserPageId: string | undefined,
+        execute: () => Promise<T>,
+        options: { ensureSession: boolean; ensureVisible: boolean }
+      ) => Promise<T>
+    }
+    const enqueue = (execute: () => Promise<void>) =>
+      internals.enqueueTargetedCommand(undefined, undefined, execute, {
+        ensureSession: false,
+        ensureVisible: false
+      })
+
+    const active = enqueue(() => firstTurn)
+    await vi.waitFor(() =>
+      expect((bridge as unknown as { processingQueues: Set<string> }).processingQueues.size).toBe(1)
+    )
+    const queued = Array.from({ length: AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION }, () =>
+      enqueue(async () => {})
+    )
+
+    await expect(enqueue(async () => {})).rejects.toMatchObject({ code: 'browser_busy' })
+    releaseFirst()
+    await expect(Promise.all([active, ...queued])).resolves.toHaveLength(
+      AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION + 1
+    )
+  })
+
+  it('bounds callers waiting for hung browser session setup before they reach the queue', async () => {
+    let releaseSetup!: () => void
+    const setup = new Promise<void>((resolve) => {
+      releaseSetup = resolve
+    })
+    const internals = bridge as unknown as {
+      ensureSession: () => Promise<void>
+      enqueueTargetedCommand: <T>(
+        worktreeId: string | undefined,
+        browserPageId: string | undefined,
+        execute: () => Promise<T>,
+        options: { ensureVisible: boolean }
+      ) => Promise<T>
+    }
+    internals.ensureSession = vi.fn(() => setup)
+    const enqueue = () =>
+      internals.enqueueTargetedCommand(undefined, undefined, async () => {}, {
+        ensureVisible: false
+      })
+    const pending = Array.from({ length: AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION }, enqueue)
+
+    await expect(enqueue()).rejects.toMatchObject({ code: 'browser_busy' })
+    releaseSetup()
+    await expect(Promise.all(pending)).resolves.toHaveLength(
+      AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION
+    )
+  })
+
   it('acquires an automation visibility lease while running snapshot commands', async () => {
     const lifecycleEvents: string[] = []
     const restore = vi.fn(() => {
@@ -1012,7 +1082,7 @@ describe('AgentBrowserBridge', () => {
       )
       existsSyncMock.mockReturnValue(true)
       const screenshotBytes = Buffer.from('serialized-screenshot')
-      readFileSyncMock.mockReturnValue(screenshotBytes)
+      readScreenshotFileMock.mockReturnValue(screenshotBytes)
 
       const b = new AgentBrowserBridge(
         mockBrowserManager(tabs, worktrees, {
@@ -1084,6 +1154,22 @@ describe('AgentBrowserBridge', () => {
     }
   })
 
+  it('rejects an oversized screenshot file before reading or base64-copying it', () => {
+    existsSyncMock.mockReturnValue(true)
+    readScreenshotFileMock.mockImplementation(() => {
+      throw new Error(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+    })
+
+    expect(() =>
+      (
+        bridge as unknown as {
+          readScreenshotFromResult: (raw: unknown, format?: string) => unknown
+        }
+      ).readScreenshotFromResult({ path: '/tmp/oversized.png' }, 'png')
+    ).toThrow(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+    expect(readScreenshotFileMock).toHaveBeenCalledWith('/tmp/oversized.png')
+  })
+
   it('captures full-page screenshots directly through CDP using CSS layout bounds', async () => {
     vi.useFakeTimers()
     try {
@@ -1129,6 +1215,88 @@ describe('AgentBrowserBridge', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('reports oversized full-page geometry with a stable browser error code', async () => {
+    vi.useFakeTimers()
+    try {
+      const wc = mockWebContents(100)
+      wc.debugger.sendCommand.mockResolvedValueOnce({
+        cssContentSize: { width: BROWSER_SCREENSHOT_MAX_DIMENSION_PX + 1, height: 1 }
+      })
+      webContentsFromIdMock.mockReturnValue(wc)
+
+      const screenshotPromise = bridge.fullPageScreenshot('png')
+      const rejection = expect(screenshotPromise).rejects.toMatchObject({
+        code: 'browser_screenshot_too_large',
+        message: BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+      })
+      await vi.advanceTimersByTimeAsync(500)
+
+      await rejection
+      expect(wc.debugger.sendCommand).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('rejects a direct PDF before making an oversized base64 copy', async () => {
+    succeedWith(null)
+    const toString = vi.fn()
+    const wc = {
+      ...mockWebContents(100),
+      printToPDF: vi.fn(async () => ({
+        length: CDP_PDF_MAX_RETAINED_BYTES + 1,
+        toString
+      }))
+    }
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await expect(bridge.pdf()).rejects.toThrow(CDP_PDF_MEMORY_LIMIT_ERROR)
+    expect(toString).not.toHaveBeenCalled()
+  })
+
+  it('shares one native PDF print cap across browser sessions', async () => {
+    const tabs = new Map([
+      ['tab-1', 1],
+      ['tab-2', 2],
+      ['tab-3', 3]
+    ])
+    const worktrees = new Map([
+      ['tab-1', 'wt-1'],
+      ['tab-2', 'wt-2'],
+      ['tab-3', 'wt-3']
+    ])
+    const resolvers: ((buffer: Buffer) => void)[] = []
+    const webContentsById = new Map(
+      [1, 2, 3].map((id) => [
+        id,
+        {
+          ...mockWebContents(id),
+          printToPDF: vi.fn(
+            () =>
+              new Promise<Buffer>((resolve) => {
+                resolvers.push(resolve)
+              })
+          )
+        }
+      ])
+    )
+    webContentsFromIdMock.mockImplementation((id: number) => webContentsById.get(id) ?? null)
+    succeedWith(null)
+    const boundedBridge = new AgentBrowserBridge(mockBrowserManager(tabs, worktrees))
+    boundedBridge.setActiveTab(1, 'wt-1')
+    boundedBridge.setActiveTab(2, 'wt-2')
+    boundedBridge.setActiveTab(3, 'wt-3')
+
+    const active = [boundedBridge.pdf('wt-1'), boundedBridge.pdf('wt-2')]
+    await vi.waitFor(() => expect(resolvers).toHaveLength(2))
+    await expect(boundedBridge.pdf('wt-3')).rejects.toMatchObject({ code: 'browser_busy' })
+
+    for (const resolve of resolvers) {
+      resolve(Buffer.from('%PDF-bounded'))
+    }
+    await expect(Promise.all(active)).resolves.toHaveLength(2)
   })
 
   // ── Timeout escalation ──
@@ -2520,6 +2688,19 @@ describe('AgentBrowserBridge', () => {
       (call[1] as string[]).includes('viewport')
     )
     expect(viewportCall).toBeUndefined()
+  })
+
+  it('rejects an oversized viewport before asking Chromium to allocate it', async () => {
+    const wc = mockWebContents(100)
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await expect(
+      bridge.setViewport(BROWSER_SCREENSHOT_MAX_DIMENSION_PX + 1, 1, 1)
+    ).rejects.toMatchObject({
+      code: 'browser_screenshot_too_large',
+      message: BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+    })
+    expect(wc.debugger.sendCommand).not.toHaveBeenCalled()
   })
 
   it('normalizes selector wait state=visible to the default supported semantics', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -1,11 +1,19 @@
 /* eslint-disable max-lines */
 import { execFile, type ChildProcess } from 'node:child_process'
-import { existsSync, accessSync, chmodSync, readFileSync, constants } from 'node:fs'
+import { existsSync, accessSync, chmodSync, constants } from 'node:fs'
 import { join } from 'node:path'
 import { platform, arch } from 'node:os'
 import { app, type WebContents } from 'electron'
 import { CdpWsProxy } from './cdp-ws-proxy'
 import { captureFullPageScreenshot } from './cdp-screenshot'
+import { assertCdpPdfWithinMemoryLimit } from './cdp-print-to-pdf'
+import {
+  assertBrowserScreenshotGeometry,
+  BROWSER_SCREENSHOT_BUSY_ERROR,
+  BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+} from './browser-screenshot-limits'
+import { readBrowserScreenshotFile } from './browser-screenshot-file-reader'
+import { BROWSER_PDF_BUSY_ERROR, startBrowserPdfPrint } from './browser-pdf-admission'
 import { acquireElectronDebugger } from './electron-debugger-lease'
 import type { BrowserManager } from './browser-manager'
 import { BrowserError } from './cdp-bridge'
@@ -59,6 +67,8 @@ const STALE_SESSION_CLOSE_TIMEOUT_MS = 3_000
 const EMBEDDED_NAVIGATION_TIMEOUT_MS = 30_000
 export const AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES = 8 * 1024
 export const AGENT_BROWSER_CLIPBOARD_WRITE_MAX_BYTES = AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
+export const AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION = 64
+const AGENT_BROWSER_MAX_QUEUED_COMMANDS_TOTAL = 512
 
 type SessionState = {
   proxy: CdpWsProxy
@@ -575,6 +585,9 @@ export class AgentBrowserBridge {
   private readonly sessions = new Map<string, SessionState>()
   private readonly commandQueues = new Map<string, QueuedCommand[]>()
   private readonly processingQueues = new Set<string>()
+  private queuedCommandCount = 0
+  private readonly pendingEnqueueCounts = new Map<string, number>()
+  private pendingEnqueueCount = 0
   // Why: screenshot prep mutates shared paintability across tabs; serialize globally so concurrent captures don't blank each other.
   private screenshotTurn: Promise<void> = Promise.resolve()
   private readonly agentBrowserBin: string
@@ -1483,7 +1496,17 @@ export class AgentBrowserBridge {
     if (!existsSync(parsed.path)) {
       throw new BrowserError('browser_error', `Screenshot file not found: ${parsed.path}`)
     }
-    const data = readFileSync(parsed.path).toString('base64')
+    let bytes: Buffer
+    try {
+      bytes = readBrowserScreenshotFile(parsed.path)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to read screenshot file'
+      if (message !== BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR) {
+        throw new BrowserError('browser_error', message)
+      }
+      throw new BrowserError('browser_screenshot_too_large', BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+    }
+    const data = bytes.toString('base64')
     return { data, format: format === 'jpeg' ? 'jpeg' : 'png' } as BrowserScreenshotResult
   }
 
@@ -1529,7 +1552,17 @@ export class AgentBrowserBridge {
         }
         return await captureFullPageScreenshot(wc, format)
       } catch (error) {
-        throw new BrowserError('browser_error', (error as Error).message)
+        if (error instanceof BrowserError) {
+          throw error
+        }
+        const message = error instanceof Error ? error.message : 'Screenshot failed'
+        if (message === BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR) {
+          throw new BrowserError('browser_screenshot_too_large', message)
+        }
+        if (message === BROWSER_SCREENSHOT_BUSY_ERROR) {
+          throw new BrowserError('browser_busy', message)
+        }
+        throw new BrowserError('browser_error', message)
       } finally {
         restore()
       }
@@ -1780,10 +1813,15 @@ export class AgentBrowserBridge {
       if (!wc) {
         throw new BrowserError('browser_no_tab', 'Tab is no longer available')
       }
-      const buffer = await wc.printToPDF({
+      const print = startBrowserPdfPrint(wc, {
         printBackground: true,
         preferCSSPageSize: true
       })
+      if (!print) {
+        throw new BrowserError('browser_busy', BROWSER_PDF_BUSY_ERROR)
+      }
+      const buffer = await print
+      assertCdpPdfWithinMemoryLimit(buffer)
       return { data: buffer.toString('base64') }
     })
   }
@@ -1861,6 +1899,14 @@ export class AgentBrowserBridge {
     worktreeId?: string,
     browserPageId?: string
   ): Promise<BrowserViewportResult> {
+    try {
+      assertBrowserScreenshotGeometry(width, height, scale)
+    } catch (error) {
+      throw new BrowserError(
+        'browser_screenshot_too_large',
+        error instanceof Error ? error.message : BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+      )
+    }
     return this.enqueueTargetedCommand(worktreeId, browserPageId, async (_sessionName, target) => {
       const wc = this.getWebContents(target.webContentsId)
       if (!wc) {
@@ -2069,12 +2115,29 @@ export class AgentBrowserBridge {
     const target = this.resolveCommandTarget(worktreeId, browserPageId, options.requireScopedTarget)
     const sessionName = `orca-tab-${target.browserPageId}`
 
-    if (options.ensureSession !== false) {
-      await this.ensureSession(sessionName, target.browserPageId, target.webContentsId)
+    this.acquirePendingEnqueue(sessionName)
+    try {
+      if (options.ensureSession !== false) {
+        await this.ensureSession(sessionName, target.browserPageId, target.webContentsId)
+      }
+    } finally {
+      this.releasePendingEnqueue(sessionName)
     }
 
     return new Promise<T>((resolve, reject) => {
       let queue = this.commandQueues.get(sessionName)
+      if (
+        (queue?.length ?? 0) >= AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION ||
+        this.queuedCommandCount >= AGENT_BROWSER_MAX_QUEUED_COMMANDS_TOTAL
+      ) {
+        reject(
+          new BrowserError(
+            'browser_busy',
+            'Browser command queue is full; retry after the current commands finish'
+          )
+        )
+        return
+      }
       if (!queue) {
         queue = []
         this.commandQueues.set(sessionName, queue)
@@ -2091,8 +2154,35 @@ export class AgentBrowserBridge {
         resolve: resolve as (value: unknown) => void,
         reject
       })
+      this.queuedCommandCount += 1
       this.processQueue(sessionName)
     })
+  }
+
+  private acquirePendingEnqueue(sessionName: string): void {
+    const pendingForSession = this.pendingEnqueueCounts.get(sessionName) ?? 0
+    const queuedForSession = this.commandQueues.get(sessionName)?.length ?? 0
+    if (
+      pendingForSession + queuedForSession >= AGENT_BROWSER_MAX_QUEUED_COMMANDS_PER_SESSION ||
+      this.pendingEnqueueCount + this.queuedCommandCount >= AGENT_BROWSER_MAX_QUEUED_COMMANDS_TOTAL
+    ) {
+      throw new BrowserError(
+        'browser_busy',
+        'Browser command queue is full; retry after the current commands finish'
+      )
+    }
+    this.pendingEnqueueCounts.set(sessionName, pendingForSession + 1)
+    this.pendingEnqueueCount += 1
+  }
+
+  private releasePendingEnqueue(sessionName: string): void {
+    const remaining = (this.pendingEnqueueCounts.get(sessionName) ?? 1) - 1
+    if (remaining > 0) {
+      this.pendingEnqueueCounts.set(sessionName, remaining)
+    } else {
+      this.pendingEnqueueCounts.delete(sessionName)
+    }
+    this.pendingEnqueueCount = Math.max(0, this.pendingEnqueueCount - 1)
   }
 
   private async executeWithVisibleTarget<T>(
@@ -2159,6 +2249,7 @@ export class AgentBrowserBridge {
     const queue = this.commandQueues.get(sessionName)
     while (queue && queue.length > 0) {
       const cmd = queue.shift()!
+      this.queuedCommandCount = Math.max(0, this.queuedCommandCount - 1)
       try {
         const result = await cmd.execute()
         cmd.resolve(result)
@@ -2456,6 +2547,7 @@ export class AgentBrowserBridge {
     this.commandQueues.delete(sessionName)
     this.processingQueues.delete(sessionName)
     if (queue) {
+      this.queuedCommandCount = Math.max(0, this.queuedCommandCount - queue.length)
       const err = new BrowserError(
         'browser_tab_closed',
         'Tab was closed while commands were queued'

--- a/src/main/browser/browser-cookie-import.comet.test.ts
+++ b/src/main/browser/browser-cookie-import.comet.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as childProcessModule from 'node:child_process'
 import type * as fsModule from 'node:fs'
+import type * as boundedFileReaderModule from '../../shared/node-bounded-file-reader'
 
-const { sessionFromPartitionMock, dialogShowOpenDialogMock } = vi.hoisted(() => ({
-  sessionFromPartitionMock: vi.fn(),
-  dialogShowOpenDialogMock: vi.fn()
-}))
+const { sessionFromPartitionMock, dialogShowOpenDialogMock, boundedLocalStateReadMock } =
+  vi.hoisted(() => ({
+    sessionFromPartitionMock: vi.fn(),
+    dialogShowOpenDialogMock: vi.fn(),
+    boundedLocalStateReadMock: vi.fn<(filePath: string) => string>()
+  }))
 
 vi.mock('electron', () => ({
   BrowserWindow: { fromWebContents: vi.fn() },
@@ -13,10 +16,30 @@ vi.mock('electron', () => ({
   session: { fromPartition: sessionFromPartitionMock }
 }))
 
+vi.mock('../../shared/node-bounded-file-reader', async () => {
+  const actual = await vi.importActual<typeof boundedFileReaderModule>(
+    '../../shared/node-bounded-file-reader'
+  )
+  return {
+    ...actual,
+    readNodeFileSyncWithinLimit: (filePath: string, maxBytes: number) => {
+      const buffer = Buffer.from(boundedLocalStateReadMock(filePath))
+      if (buffer.byteLength > maxBytes) {
+        throw new actual.NodeFileReadTooLargeError(buffer.byteLength, maxBytes)
+      }
+      return { buffer, stats: { size: buffer.byteLength } }
+    }
+  }
+})
+
 import { BROWSER_FAMILY_LABELS } from '../../shared/constants'
 
 function slashPath(pathValue: string): string {
   return pathValue.replaceAll('\\', '/')
+}
+
+function mockLocalState(value: unknown): void {
+  boundedLocalStateReadMock.mockReturnValue(JSON.stringify(value))
 }
 
 describe('detectInstalledBrowsers — Comet', () => {
@@ -32,6 +55,10 @@ describe('detectInstalledBrowsers — Comet', () => {
     vi.resetModules()
     Object.defineProperty(process, 'platform', { value: 'darwin' })
     process.env.HOME = '/Users/test'
+    boundedLocalStateReadMock.mockReset()
+    boundedLocalStateReadMock.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
   })
 
   afterEach(() => {
@@ -41,6 +68,7 @@ describe('detectInstalledBrowsers — Comet', () => {
   })
 
   it('detects Comet when its data directory and Cookies DB exist', async () => {
+    mockLocalState({ profile: { info_cache: { Default: { name: 'Default' } } } })
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof fsModule>('node:fs')
       return {
@@ -88,6 +116,15 @@ describe('detectInstalledBrowsers — Comet', () => {
   })
 
   it('enumerates all Comet profiles from Local State info_cache', async () => {
+    mockLocalState({
+      profile: {
+        info_cache: {
+          Default: { name: 'Personal' },
+          'Profile 1': { name: 'Work' },
+          'Profile 2': { name: 'Research' }
+        }
+      }
+    })
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof fsModule>('node:fs')
       return {
@@ -130,6 +167,13 @@ describe('detectInstalledBrowsers — Comet', () => {
   })
 
   it('ignores Comet profile directories that escape the browser root', async () => {
+    mockLocalState({
+      profile: {
+        info_cache: {
+          '../Outside': { name: 'Outside' }
+        }
+      }
+    })
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof fsModule>('node:fs')
       return {
@@ -195,6 +239,7 @@ describe('detectInstalledBrowsers — Comet', () => {
   })
 
   it('skips Comet when the data directory exists but no Cookies DB is present', async () => {
+    mockLocalState({ profile: { info_cache: { Default: { name: 'Default' } } } })
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof fsModule>('node:fs')
       return {

--- a/src/main/browser/browser-cookie-import.helium.test.ts
+++ b/src/main/browser/browser-cookie-import.helium.test.ts
@@ -1,11 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as childProcessModule from 'node:child_process'
 import type * as fsModule from 'node:fs'
+import type * as boundedFileReaderModule from '../../shared/node-bounded-file-reader'
 
-const { sessionFromPartitionMock, dialogShowOpenDialogMock } = vi.hoisted(() => ({
-  sessionFromPartitionMock: vi.fn(),
-  dialogShowOpenDialogMock: vi.fn()
-}))
+const { sessionFromPartitionMock, dialogShowOpenDialogMock, boundedLocalStateReadMock } =
+  vi.hoisted(() => ({
+    sessionFromPartitionMock: vi.fn(),
+    dialogShowOpenDialogMock: vi.fn(),
+    boundedLocalStateReadMock: vi.fn<(filePath: string) => string>()
+  }))
 
 vi.mock('electron', () => ({
   BrowserWindow: { fromWebContents: vi.fn() },
@@ -13,10 +16,30 @@ vi.mock('electron', () => ({
   session: { fromPartition: sessionFromPartitionMock }
 }))
 
+vi.mock('../../shared/node-bounded-file-reader', async () => {
+  const actual = await vi.importActual<typeof boundedFileReaderModule>(
+    '../../shared/node-bounded-file-reader'
+  )
+  return {
+    ...actual,
+    readNodeFileSyncWithinLimit: (filePath: string, maxBytes: number) => {
+      const buffer = Buffer.from(boundedLocalStateReadMock(filePath))
+      if (buffer.byteLength > maxBytes) {
+        throw new actual.NodeFileReadTooLargeError(buffer.byteLength, maxBytes)
+      }
+      return { buffer, stats: { size: buffer.byteLength } }
+    }
+  }
+})
+
 import { BROWSER_FAMILY_LABELS } from '../../shared/constants'
 
 function slashPath(pathValue: string): string {
   return pathValue.replaceAll('\\', '/')
+}
+
+function mockLocalState(value: unknown): void {
+  boundedLocalStateReadMock.mockReturnValue(JSON.stringify(value))
 }
 
 describe('detectInstalledBrowsers — Helium', () => {
@@ -30,6 +53,10 @@ describe('detectInstalledBrowsers — Helium', () => {
     vi.resetModules()
     Object.defineProperty(process, 'platform', { value: 'darwin' })
     process.env.HOME = '/Users/test'
+    boundedLocalStateReadMock.mockReset()
+    boundedLocalStateReadMock.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
   })
 
   afterEach(() => {
@@ -39,6 +66,7 @@ describe('detectInstalledBrowsers — Helium', () => {
   })
 
   it('detects Helium under its bundle-id data dir via the legacy Cookies path', async () => {
+    mockLocalState({ profile: { info_cache: { Default: { name: 'Default' } } } })
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof fsModule>('node:fs')
       return {
@@ -93,6 +121,14 @@ describe('detectInstalledBrowsers — Helium', () => {
   })
 
   it('enumerates all Helium profiles from Local State info_cache', async () => {
+    mockLocalState({
+      profile: {
+        info_cache: {
+          Default: { name: 'Personal' },
+          'Profile 1': { name: 'Work' }
+        }
+      }
+    })
     vi.doMock('node:fs', async () => {
       const actual = await vi.importActual<typeof fsModule>('node:fs')
       return {

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -36,6 +36,7 @@ vi.mock('electron', () => ({
 
 import {
   buildChromiumCookieInsertParams,
+  CHROMIUM_LOCAL_STATE_MAX_BYTES,
   importCookiesFromFile,
   importCookiesFromBrowser,
   detectInstalledBrowsers,
@@ -47,7 +48,20 @@ import {
   createChromiumCookieTestDatabase,
   encryptMacChromiumCookie
 } from './browser-cookie-import-test-database'
-import { existsSync, writeFileSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { COOKIE_JSON_FILE_MAX_BYTES } from './browser-cookie-json-file-parser'
+import { INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES } from './installed-browser-cookie-store-limits'
+import { SAFARI_COOKIE_STORE_MAX_FILE_BYTES } from './safari-cookie-store-decoder'
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { DatabaseSync } from 'node:sqlite'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -61,6 +75,40 @@ function chromeBrowser(cookiesPath: string): DetectedBrowser {
     profiles: [{ name: 'Default', directory: 'Default' }],
     selectedProfile: 'Default'
   }
+}
+
+function firefoxBrowser(cookiesPath: string): DetectedBrowser {
+  return {
+    family: 'firefox',
+    label: 'Firefox',
+    cookiesPath,
+    profiles: [{ name: 'default', directory: 'default' }],
+    selectedProfile: 'default'
+  }
+}
+
+function createFirefoxCookieTestDatabase(
+  databasePath: string,
+  rows: { name: string; value: string; host: string }[]
+): void {
+  const database = new DatabaseSync(databasePath)
+  database.exec(`
+    CREATE TABLE moz_cookies (
+      name TEXT,
+      value TEXT,
+      host TEXT,
+      path TEXT,
+      expiry INTEGER,
+      isSecure INTEGER,
+      isHttpOnly INTEGER,
+      sameSite INTEGER
+    )
+  `)
+  const insert = database.prepare('INSERT INTO moz_cookies VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
+  for (const row of rows) {
+    insert.run(row.name, row.value, row.host, '/', 2_000_000_000, 0, 0, 0)
+  }
+  database.close()
 }
 
 const LARGE_SAFARI_COOKIE_COUNT = 150_000
@@ -281,6 +329,20 @@ describe('importCookiesFromFile', () => {
     expect(result.reason).toContain('Could not read')
   })
 
+  it('rejects an oversized JSON file before reading its bytes', async () => {
+    const filePath = join(tmpDir, 'oversized.json')
+    writeFileSync(filePath, '')
+    truncateSync(filePath, COOKIE_JSON_FILE_MAX_BYTES + 1)
+
+    const result = await importCookiesFromFile(filePath, 'persist:test')
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'Cookie file is too large to import safely (64 MiB file limit).'
+    })
+    expect(sessionFromPartitionMock).not.toHaveBeenCalled()
+  })
+
   it('normalizes sameSite values', async () => {
     const filePath = writeCookieFile([
       { domain: '.test.com', name: 'a', value: '1', sameSite: 'None' },
@@ -363,6 +425,94 @@ describe('importCookiesFromBrowser Safari', () => {
 
     expect(result).toEqual({ ok: false, reason: 'All Safari cookies are expired.' })
     expect(cookiesSetMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized Safari store before reading its bytes', async () => {
+    const cookiesPath = join(tmpDir, 'Cookies.binarycookies')
+    writeFileSync(cookiesPath, '')
+    truncateSync(cookiesPath, SAFARI_COOKIE_STORE_MAX_FILE_BYTES + 1)
+    const browser: DetectedBrowser = {
+      family: 'safari',
+      label: 'Safari',
+      cookiesPath,
+      profiles: [],
+      selectedProfile: 'Default'
+    }
+
+    const result = await importCookiesFromBrowser(browser, 'persist:test')
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'Safari cookie store is too large to import safely (64 MiB file limit).'
+    })
+    expect(sessionFromPartitionMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('importCookiesFromBrowser Firefox', () => {
+  let tmpDir: string
+  let cookiesSetMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'orca-firefox-cookie-test-'))
+    cookiesSetMock = vi.fn().mockResolvedValue(undefined)
+    sessionFromPartitionMock.mockReset()
+    sessionFromPartitionMock.mockReturnValue({
+      cookies: { set: cookiesSetMock }
+    })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('streams ordinary cookies in source order without changing the summary', async () => {
+    const cookiesPath = join(tmpDir, 'cookies.sqlite')
+    createFirefoxCookieTestDatabase(cookiesPath, [
+      { name: 'first', value: 'one', host: '.first.example.com' },
+      { name: 'second', value: 'two', host: '.second.example.com' }
+    ])
+
+    const result = await importCookiesFromBrowser(firefoxBrowser(cookiesPath), 'persist:test')
+
+    expect(result).toEqual({
+      ok: true,
+      profileId: '',
+      summary: {
+        totalCookies: 2,
+        importedCookies: 2,
+        skippedCookies: 0,
+        domains: ['first.example.com', 'second.example.com']
+      }
+    })
+    expect(cookiesSetMock.mock.calls.map(([cookie]) => cookie.name)).toEqual(['first', 'second'])
+  })
+
+  it('rejects oversized cookie data before iterating or mutating the target session', async () => {
+    const cookiesPath = join(tmpDir, 'cookies.sqlite')
+    const database = new DatabaseSync(cookiesPath)
+    database.exec(`
+      CREATE VIEW moz_cookies AS
+      SELECT
+        'sid' AS name,
+        zeroblob(${INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES + 1}) AS value,
+        '.example.com' AS host,
+        '/' AS path,
+        0 AS expiry,
+        0 AS isSecure,
+        0 AS isHttpOnly,
+        0 AS sameSite
+    `)
+    database.close()
+
+    const result = await importCookiesFromBrowser(firefoxBrowser(cookiesPath), 'persist:test')
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        'Firefox cookie store is too large to import safely (250,000-cookie and 64 MiB cookie-data limits).'
+    })
+    expect(sessionFromPartitionMock).not.toHaveBeenCalled()
   })
 })
 
@@ -530,9 +680,79 @@ describe('importCookiesFromBrowser Chromium', () => {
     expect(result).toEqual({ ok: false, reason: 'Could not create staging cookie database.' })
     expect(readdirSync(join(tmpDir, 'userData', 'cookie-import-staging'))).toEqual([])
   })
+
+  it('rejects oversized source data before decrypting or clearing target cookies', async () => {
+    const sourceCookiesPath = join(tmpDir, 'Chrome', 'Default', 'Network', 'Cookies')
+    const targetCookiesPath = join(tmpDir, 'userData', 'Partitions', 'test', 'Network', 'Cookies')
+    mkdirSync(join(sourceCookiesPath, '..'), { recursive: true })
+    const sourceDatabase = new DatabaseSync(sourceCookiesPath)
+    sourceDatabase.exec(`
+      CREATE VIEW cookies AS
+      SELECT
+        1 AS creation_utc,
+        '.example.com' AS host_key,
+        '' AS top_frame_site_key,
+        'sid' AS name,
+        zeroblob(${INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES + 1}) AS value,
+        X'' AS encrypted_value,
+        '/' AS path,
+        0 AS expires_utc,
+        0 AS is_secure,
+        0 AS is_httponly,
+        0 AS samesite,
+        0 AS source_scheme,
+        -1 AS source_port,
+        0 AS last_update_utc,
+        0 AS has_cross_site_ancestor
+    `)
+    sourceDatabase.close()
+    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
+
+    const result = await importCookiesFromBrowser(chromeBrowser(sourceCookiesPath), 'persist:test')
+
+    expect(result).toEqual({
+      ok: false,
+      reason:
+        'Google Chrome cookie store is too large to import safely (250,000-cookie and 64 MiB cookie-data limits).'
+    })
+    expect(clearStorageDataMock).not.toHaveBeenCalled()
+    expect(cookiesSetMock).not.toHaveBeenCalled()
+    expect(readdirSync(join(tmpDir, 'userData', 'cookie-import-staging'))).toEqual([])
+  })
 })
 
 describe('detectInstalledBrowsers', () => {
+  it('falls back safely when Chromium Local State exceeds its read cap', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-browser-detection-bounds-'))
+    const originalConfigHome = process.env.XDG_CONFIG_HOME
+    const originalPlatform = process.platform
+    try {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      process.env.XDG_CONFIG_HOME = root
+      const browserRoot = join(root, 'google-chrome')
+      mkdirSync(join(browserRoot, 'Default'), { recursive: true })
+      writeFileSync(join(browserRoot, 'Default', 'Cookies'), '')
+      writeFileSync(join(browserRoot, 'Local State'), '')
+      truncateSync(join(browserRoot, 'Local State'), CHROMIUM_LOCAL_STATE_MAX_BYTES + 1)
+
+      const chrome = detectInstalledBrowsers().find((browser) => browser.family === 'chrome')
+
+      expect(chrome?.profiles).toEqual([{ name: 'Default', directory: 'Default' }])
+      expect(chrome?.selectedProfile).toBe('Default')
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+      if (originalConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME
+      } else {
+        process.env.XDG_CONFIG_HOME = originalConfigHome
+      }
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
   it('returns an array of detected browsers', () => {
     const browsers = detectInstalledBrowsers()
     expect(Array.isArray(browsers)).toBe(true)

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -8,12 +8,10 @@ import {
   existsSync,
   mkdtempSync,
   mkdirSync,
-  readFileSync,
-  readdirSync,
+  opendirSync,
   rmSync,
   unlinkSync
 } from 'node:fs'
-import { readFile } from 'node:fs/promises'
 import { DatabaseSync } from 'node:sqlite'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -73,13 +71,42 @@ import type {
   BrowserCookieImportSummary,
   BrowserSessionProfileSource
 } from '../../shared/types'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit,
+  readNodeFileSyncWithinLimit
+} from '../../shared/node-bounded-file-reader'
 import { browserSessionRegistry } from './browser-session-registry'
 import { setupClientHintsOverride } from './browser-session-ua'
+import {
+  COOKIE_JSON_FILE_MAX_BYTES,
+  COOKIE_JSON_FILE_MAX_DEPTH,
+  COOKIE_JSON_FILE_MAX_ENTRIES,
+  COOKIE_JSON_FILE_MAX_RETAINED_BYTES,
+  CookieJsonFileFormatError,
+  CookieJsonFileLimitError,
+  enforceCookieJsonRetainedBytes,
+  visitCookieJsonFileObjects
+} from './browser-cookie-json-file-parser'
 import {
   createChromiumCookieSnapshot,
   type ChromiumCookieSnapshot
 } from './chromium-cookie-snapshot'
 import { resolveChromiumCookiesPath } from './chromium-cookie-path'
+import {
+  assertInstalledBrowserCookieStoreWithinLimits,
+  InstalledBrowserCookieStoreLimitError,
+  installedBrowserCookieStoreLimitReason
+} from './installed-browser-cookie-store-limits'
+import {
+  decodeSafariCookieStore,
+  SAFARI_COOKIE_STORE_MAX_COOKIES,
+  SAFARI_COOKIE_STORE_MAX_FILE_BYTES,
+  SAFARI_COOKIE_STORE_MAX_PAGES,
+  SAFARI_COOKIE_STORE_MAX_PARSED_BYTES,
+  SafariCookieStoreLimitError,
+  removeExpiredSafariCookiesInPlace
+} from './safari-cookie-store-decoder'
 
 // ---------------------------------------------------------------------------
 // Browser detection
@@ -89,6 +116,10 @@ export type BrowserProfile = {
   name: string
   directory: string
 }
+
+export const CHROMIUM_LOCAL_STATE_MAX_BYTES = 16 * 1024 * 1024
+const BROWSER_PROFILE_SCAN_MAX_ENTRIES = 10_000
+const BROWSER_PROFILE_RETAINED_NAME_MAX_BYTES = 4 * 1024 * 1024
 
 export type DetectedBrowser = {
   family: BrowserSessionProfileSource['browserFamily']
@@ -210,19 +241,38 @@ function discoverProfiles(browserRoot: string): BrowserProfile[] {
     if (!existsSync(localStatePath)) {
       return [{ name: 'Default', directory: 'Default' }]
     }
-    const raw = readFileSync(localStatePath, 'utf-8')
-    const localState = JSON.parse(raw)
+    const localState = JSON.parse(
+      readNodeFileSyncWithinLimit(localStatePath, CHROMIUM_LOCAL_STATE_MAX_BYTES).buffer.toString(
+        'utf8'
+      )
+    )
     const infoCache = localState?.profile?.info_cache
     if (!infoCache || typeof infoCache !== 'object') {
       return [{ name: 'Default', directory: 'Default' }]
     }
     const profiles: BrowserProfile[] = []
-    for (const [dir, info] of Object.entries(infoCache)) {
+    let retainedNameBytes = 0
+    let visitedEntries = 0
+    for (const dir in infoCache) {
+      if (!Object.hasOwn(infoCache, dir)) {
+        continue
+      }
+      visitedEntries++
+      if (visitedEntries > BROWSER_PROFILE_SCAN_MAX_ENTRIES) {
+        return [{ name: 'Default', directory: 'Default' }]
+      }
       // Why: Local State is external metadata, but profile dirs become path segments.
       if (!isSafeBrowserProfileDirectory(dir)) {
         continue
       }
-      const profileName = (info as { name?: string })?.name ?? dir
+      const info = (infoCache as Record<string, unknown>)[dir]
+      const configuredName =
+        info && typeof info === 'object' ? (info as { name?: unknown }).name : undefined
+      const profileName = typeof configuredName === 'string' ? configuredName : dir
+      retainedNameBytes += Buffer.byteLength(dir, 'utf8') + Buffer.byteLength(profileName, 'utf8')
+      if (retainedNameBytes > BROWSER_PROFILE_RETAINED_NAME_MAX_BYTES) {
+        return [{ name: 'Default', directory: 'Default' }]
+      }
       profiles.push({ name: profileName, directory: dir })
     }
     return profiles.length > 0 ? profiles : [{ name: 'Default', directory: 'Default' }]
@@ -257,9 +307,30 @@ function discoverFirefoxProfiles(): BrowserProfile[] {
     if (!existsSync(profilesRoot)) {
       return []
     }
-    const entries = readdirSync(profilesRoot, { withFileTypes: true })
-      .filter((e) => e.isDirectory())
-      .map((e) => e.name)
+    const entries: string[] = []
+    let retainedNameBytes = 0
+    const directory = opendirSync(profilesRoot)
+    try {
+      for (let visitedEntries = 0; ; visitedEntries++) {
+        const entry = directory.readSync()
+        if (!entry) {
+          break
+        }
+        if (visitedEntries >= BROWSER_PROFILE_SCAN_MAX_ENTRIES) {
+          return []
+        }
+        if (!entry.isDirectory()) {
+          continue
+        }
+        retainedNameBytes += Buffer.byteLength(entry.name, 'utf8')
+        if (retainedNameBytes > BROWSER_PROFILE_RETAINED_NAME_MAX_BYTES) {
+          return []
+        }
+        entries.push(entry.name)
+      }
+    } finally {
+      directory.closeSync()
+    }
     // Why: Firefox dirs are named <random>.<name>; prefer 'default-release' as the primary profile on most installs.
     const sorted = entries.sort((a, b) => {
       if (a.includes('default-release')) {
@@ -309,8 +380,6 @@ function detectFirefox(): DetectedBrowser | null {
 // ---------------------------------------------------------------------------
 // Safari detection
 // ---------------------------------------------------------------------------
-
-const MAC_EPOCH_DELTA = 978_307_200
 
 function detectSafari(): DetectedBrowser | null {
   if (process.platform !== 'darwin') {
@@ -645,41 +714,62 @@ export async function importCookiesFromFile(
 ): Promise<BrowserCookieImportResult> {
   let rawContent: string
   try {
-    rawContent = await readFile(filePath, 'utf-8')
-  } catch {
+    rawContent = (
+      await readNodeFileWithinLimit(filePath, COOKIE_JSON_FILE_MAX_BYTES)
+    ).buffer.toString('utf8')
+  } catch (err) {
+    if (err instanceof NodeFileReadTooLargeError) {
+      return {
+        ok: false,
+        reason: `Cookie file is too large to import safely (${COOKIE_JSON_FILE_MAX_BYTES / 1024 / 1024} MiB file limit).`
+      }
+    }
     return { ok: false, reason: 'Could not read the selected file.' }
   }
 
-  let parsed: unknown
+  const validated: ValidatedCookie[] = []
+  let totalEntries = 0
+  let retainedBytes = 0
   try {
-    parsed = JSON.parse(rawContent)
-  } catch {
+    totalEntries = visitCookieJsonFileObjects(rawContent, (entry) => {
+      const cookie = validateCookieEntry(entry as RawCookieEntry)
+      if (!cookie) {
+        return
+      }
+      retainedBytes +=
+        Buffer.byteLength(cookie.url) +
+        Buffer.byteLength(cookie.name) +
+        Buffer.byteLength(cookie.value) +
+        Buffer.byteLength(cookie.domain) +
+        Buffer.byteLength(cookie.path)
+      enforceCookieJsonRetainedBytes(retainedBytes)
+      validated.push(cookie)
+    })
+  } catch (err) {
+    if (err instanceof CookieJsonFileFormatError) {
+      return err.kind === 'root'
+        ? { ok: false, reason: 'Expected a JSON array of cookie objects.' }
+        : { ok: false, reason: 'File is not valid JSON.' }
+    }
+    if (err instanceof CookieJsonFileLimitError) {
+      const limit = {
+        depth: `${COOKIE_JSON_FILE_MAX_DEPTH} levels of nesting`,
+        entries: `${COOKIE_JSON_FILE_MAX_ENTRIES.toLocaleString('en-US')} entries`,
+        'retained-bytes': `${COOKIE_JSON_FILE_MAX_RETAINED_BYTES / 1024 / 1024} MiB parsed cookie data`
+      }[err.kind]
+      return {
+        ok: false,
+        reason: `Cookie file is too large to import safely (${limit} limit).`
+      }
+    }
     return { ok: false, reason: 'File is not valid JSON.' }
   }
 
-  if (!Array.isArray(parsed)) {
-    return { ok: false, reason: 'Expected a JSON array of cookie objects.' }
-  }
-
-  if (parsed.length === 0) {
+  if (totalEntries === 0) {
     return { ok: false, reason: 'Cookie file is empty.' }
   }
 
-  const validated: ValidatedCookie[] = []
-  let skipped = 0
-  for (const entry of parsed) {
-    if (typeof entry !== 'object' || entry === null) {
-      skipped++
-      continue
-    }
-    const cookie = validateCookieEntry(entry as RawCookieEntry)
-    if (cookie) {
-      validated.push(cookie)
-    } else {
-      skipped++
-    }
-  }
-
+  const skipped = totalEntries - validated.length
   if (validated.length === 0) {
     return {
       ok: false,
@@ -687,7 +777,7 @@ export async function importCookiesFromFile(
     }
   }
 
-  return importValidatedCookies(validated, parsed.length, targetPartition)
+  return importValidatedCookies(validated, totalEntries, targetPartition)
 }
 
 // ---------------------------------------------------------------------------
@@ -986,8 +1076,11 @@ function getWindowsEncryptionKey(browser: DetectedBrowser): EncryptionKeyResult 
   }
 
   try {
-    const raw = readFileSync(localStatePath, 'utf-8')
-    const localState = JSON.parse(raw)
+    const localState = JSON.parse(
+      readNodeFileSyncWithinLimit(localStatePath, CHROMIUM_LOCAL_STATE_MAX_BYTES).buffer.toString(
+        'utf8'
+      )
+    )
     const encryptedKeyB64 = localState?.os_crypt?.encrypted_key
     if (typeof encryptedKeyB64 !== 'string') {
       return null
@@ -1104,144 +1197,6 @@ function decryptAes256Gcm(payload: Buffer, key: Buffer): Buffer | null {
 }
 
 // ---------------------------------------------------------------------------
-// Safari binary cookie parser
-// ---------------------------------------------------------------------------
-
-function decodeSafariBinaryCookies(buffer: Buffer): ValidatedCookie[] {
-  if (buffer.length < 8) {
-    return []
-  }
-  if (buffer.subarray(0, 4).toString('utf8') !== 'cook') {
-    return []
-  }
-
-  const pageCount = buffer.readUInt32BE(4)
-  let cursor = 8
-  if (cursor + pageCount * 4 > buffer.length) {
-    return []
-  }
-  const pageSizes: number[] = []
-  for (let i = 0; i < pageCount; i++) {
-    pageSizes.push(buffer.readUInt32BE(cursor))
-    cursor += 4
-  }
-
-  const cookies: ValidatedCookie[] = []
-  for (const pageSize of pageSizes) {
-    const page = buffer.subarray(cursor, cursor + pageSize)
-    cursor += pageSize
-    appendSafariCookies(cookies, decodeSafariPage(page))
-  }
-  return cookies
-}
-
-function appendSafariCookies(target: ValidatedCookie[], cookies: readonly ValidatedCookie[]): void {
-  // Why: pages can hold large cookie lists; push per-item to avoid exceeding the spread argument limit.
-  for (const cookie of cookies) {
-    target.push(cookie)
-  }
-}
-
-function decodeSafariPage(page: Buffer): ValidatedCookie[] {
-  if (page.length < 16) {
-    return []
-  }
-  if (page.readUInt32BE(0) !== 0x00000100) {
-    return []
-  }
-
-  const cookieCount = page.readUInt32LE(4)
-  if (8 + cookieCount * 4 > page.length) {
-    return []
-  }
-  const offsets: number[] = []
-  let cursor = 8
-  for (let i = 0; i < cookieCount; i++) {
-    offsets.push(page.readUInt32LE(cursor))
-    cursor += 4
-  }
-
-  const cookies: ValidatedCookie[] = []
-  for (const offset of offsets) {
-    const cookie = decodeSafariCookie(page.subarray(offset))
-    if (cookie) {
-      cookies.push(cookie)
-    }
-  }
-  return cookies
-}
-
-function decodeSafariCookie(buf: Buffer): ValidatedCookie | null {
-  if (buf.length < 48) {
-    return null
-  }
-  // Why: size comes from the file and could be attacker-controlled; clamp so readCString can't escape the subarray.
-  const size = Math.min(buf.readUInt32LE(0), buf.length)
-  if (size < 48) {
-    return null
-  }
-
-  const flags = buf.readUInt32LE(8)
-  const secure = (flags & 1) !== 0
-  const httpOnly = (flags & 4) !== 0
-
-  const urlOffset = buf.readUInt32LE(16)
-  const nameOffset = buf.readUInt32LE(20)
-  const pathOffset = buf.readUInt32LE(24)
-  const valueOffset = buf.readUInt32LE(28)
-
-  // Why: Safari stores dates as Mac absolute time (seconds since 2001-01-01).
-  const expiration = buf.length >= 48 ? buf.readDoubleLE(40) : 0
-
-  const name = readCString(buf, nameOffset, size)
-  if (!name) {
-    return null
-  }
-  const value = readCString(buf, valueOffset, size) ?? ''
-  const path = readCString(buf, pathOffset, size) ?? '/'
-  const rawUrl = readCString(buf, urlOffset, size) ?? ''
-
-  // Why: Safari stores the domain in the URL field, not as a separate domain column.
-  const domain = rawUrl.startsWith('.') ? rawUrl : rawUrl || null
-  if (!domain) {
-    return null
-  }
-
-  const url = deriveUrl(domain, secure)
-  if (!url) {
-    return null
-  }
-
-  const expirationDate = expiration > 0 ? Math.round(expiration + MAC_EPOCH_DELTA) : undefined
-
-  return {
-    url,
-    name,
-    value,
-    domain,
-    path,
-    secure,
-    httpOnly,
-    sameSite: 'unspecified',
-    expirationDate
-  }
-}
-
-function readCString(buf: Buffer, offset: number, end: number): string | null {
-  if (offset < 0 || offset >= end) {
-    return null
-  }
-  let cursor = offset
-  while (cursor < end && buf[cursor] !== 0) {
-    cursor++
-  }
-  if (cursor >= end) {
-    return null
-  }
-  return buf.toString('utf8', offset, cursor)
-}
-
-// ---------------------------------------------------------------------------
 // Firefox import
 // ---------------------------------------------------------------------------
 
@@ -1274,8 +1229,9 @@ async function importCookiesFromFirefox(
     }
   }
 
+  let db: InstanceType<typeof DatabaseSync> | null = null
   try {
-    const db = new DatabaseSync(tmpCookiesPath, { readOnly: true })
+    db = new DatabaseSync(tmpCookiesPath, { readOnly: true })
     type FirefoxRow = {
       name: string
       value: string
@@ -1286,18 +1242,37 @@ async function importCookiesFromFirefox(
       isHttpOnly: number
       sameSite: number
     }
+    const sourceStats = db
+      .prepare(
+        `SELECT
+          COUNT(*) AS cookie_count,
+          COALESCE(SUM(
+            length(CAST(COALESCE(name, '') AS BLOB)) +
+            length(CAST(COALESCE(value, '') AS BLOB)) +
+            length(CAST(COALESCE(host, '') AS BLOB)) +
+            length(CAST(COALESCE(path, '') AS BLOB))
+          ), 0) AS cookie_bytes
+        FROM moz_cookies`
+      )
+      .get() as { cookie_count: number | bigint; cookie_bytes: number | bigint }
+    const totalRows = assertInstalledBrowserCookieStoreWithinLimits(
+      sourceStats.cookie_count,
+      sourceStats.cookie_bytes
+    )
+
+    diag(`  Firefox source has ${totalRows} cookies`)
+    if (totalRows === 0) {
+      db.close()
+      db = null
+      rmSync(tmpDir, { recursive: true, force: true })
+      return { ok: false, reason: 'No cookies found in Firefox.' }
+    }
+
     const rows = db
       .prepare(
         'SELECT name, value, host, path, expiry, isSecure, isHttpOnly, sameSite FROM moz_cookies'
       )
-      .all() as FirefoxRow[]
-    db.close()
-
-    diag(`  Firefox source has ${rows.length} cookies`)
-    if (rows.length === 0) {
-      rmSync(tmpDir, { recursive: true, force: true })
-      return { ok: false, reason: 'No cookies found in Firefox.' }
-    }
+      .iterate() as IterableIterator<FirefoxRow>
 
     const now = Math.floor(Date.now() / 1000)
     const validated: ValidatedCookie[] = []
@@ -1328,6 +1303,8 @@ async function importCookiesFromFirefox(
         expirationDate: row.expiry > 0 ? row.expiry : undefined
       })
     }
+    db.close()
+    db = null
 
     rmSync(tmpDir, { recursive: true, force: true })
 
@@ -1335,10 +1312,18 @@ async function importCookiesFromFirefox(
       return { ok: false, reason: 'No valid cookies found in Firefox.' }
     }
 
-    return importValidatedCookies(validated, rows.length, targetPartition)
+    return importValidatedCookies(validated, totalRows, targetPartition)
   } catch (err) {
+    try {
+      db?.close()
+    } catch {
+      /* best-effort */
+    }
     rmSync(tmpDir, { recursive: true, force: true })
     diag(`  Firefox import failed: ${err}`)
+    if (err instanceof InstalledBrowserCookieStoreLimitError) {
+      return { ok: false, reason: installedBrowserCookieStoreLimitReason(browser.label) }
+    }
     return {
       ok: false,
       reason: 'Could not import cookies from Firefox. Try closing Firefox first.'
@@ -1350,6 +1335,17 @@ async function importCookiesFromFirefox(
 // Safari import
 // ---------------------------------------------------------------------------
 
+function safariCookieStoreLimitReason(error: SafariCookieStoreLimitError): string {
+  switch (error.kind) {
+    case 'pages':
+      return `Safari cookie store is too large to import safely (${SAFARI_COOKIE_STORE_MAX_PAGES.toLocaleString('en-US')}-page limit).`
+    case 'cookies':
+      return `Safari cookie store is too large to import safely (${SAFARI_COOKIE_STORE_MAX_COOKIES.toLocaleString('en-US')}-cookie limit).`
+    case 'parsed-bytes':
+      return `Safari cookie store is too large to import safely (${SAFARI_COOKIE_STORE_MAX_PARSED_BYTES / 1024 / 1024} MiB parsed cookie-data limit).`
+  }
+}
+
 async function importCookiesFromSafari(
   browser: DetectedBrowser,
   targetPartition: string
@@ -1358,9 +1354,18 @@ async function importCookiesFromSafari(
 
   let data: Buffer
   try {
-    data = readFileSync(browser.cookiesPath)
+    data = readNodeFileSyncWithinLimit(
+      browser.cookiesPath,
+      SAFARI_COOKIE_STORE_MAX_FILE_BYTES
+    ).buffer
   } catch (err) {
     diag(`  Safari read failed: ${err}`)
+    if (err instanceof NodeFileReadTooLargeError) {
+      return {
+        ok: false,
+        reason: `Safari cookie store is too large to import safely (${SAFARI_COOKIE_STORE_MAX_FILE_BYTES / 1024 / 1024} MiB file limit).`
+      }
+    }
     // Why: Safari's Cookies.binarycookies is in a sandbox container; reading it needs Full Disk Access.
     const isPermError =
       err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'EPERM'
@@ -1375,23 +1380,25 @@ async function importCookiesFromSafari(
   }
 
   try {
-    const cookies = decodeSafariBinaryCookies(data)
-    diag(`  Safari source has ${cookies.length} cookies`)
+    const decoded = decodeSafariCookieStore(data)
+    diag(`  Safari source has ${decoded.totalCookies} cookies`)
 
-    if (cookies.length === 0) {
+    if (decoded.totalCookies === 0) {
       return { ok: false, reason: 'No cookies found in Safari.' }
     }
 
     const now = Math.floor(Date.now() / 1000)
-    const valid = cookies.filter((c) => !c.expirationDate || c.expirationDate > now)
-
-    if (valid.length === 0) {
+    removeExpiredSafariCookiesInPlace(decoded.cookies, now)
+    if (decoded.cookies.length === 0) {
       return { ok: false, reason: 'All Safari cookies are expired.' }
     }
 
-    return importValidatedCookies(valid, cookies.length, targetPartition)
+    return importValidatedCookies(decoded.cookies, decoded.totalCookies, targetPartition)
   } catch (err) {
     diag(`  Safari import failed: ${err}`)
+    if (err instanceof SafariCookieStoreLimitError) {
+      return { ok: false, reason: safariCookieStoreLimitReason(err) }
+    }
     return { ok: false, reason: 'Could not import cookies from Safari.' }
   }
 }
@@ -1498,16 +1505,30 @@ export async function importCookiesFromBrowser(
 
     stagingDb.exec('DELETE FROM cookies')
 
-    const sourceRows = sourceDb.prepare('SELECT * FROM cookies ORDER BY rowid').all() as Record<
-      string,
-      unknown
-    >[]
-    sourceDb.close()
-    sourceDb = null
+    const sourceStats = sourceDb
+      .prepare(
+        `SELECT
+          COUNT(*) AS cookie_count,
+          COALESCE(SUM(
+            length(CAST(COALESCE(host_key, '') AS BLOB)) +
+            length(CAST(COALESCE(name, '') AS BLOB)) +
+            length(CAST(COALESCE(value, '') AS BLOB)) +
+            length(COALESCE(encrypted_value, X'')) +
+            length(CAST(COALESCE(path, '') AS BLOB))
+          ), 0) AS cookie_bytes
+        FROM cookies`
+      )
+      .get() as { cookie_count: number | bigint; cookie_bytes: number | bigint }
+    const totalSourceRows = assertInstalledBrowserCookieStoreWithinLimits(
+      sourceStats.cookie_count,
+      sourceStats.cookie_bytes
+    )
 
-    diag(`  source has ${sourceRows.length} cookies`)
+    diag(`  source has ${totalSourceRows} cookies`)
 
-    if (sourceRows.length === 0) {
+    if (totalSourceRows === 0) {
+      sourceDb.close()
+      sourceDb = null
       stagingDb.close()
       stagingDb = null
       try {
@@ -1518,14 +1539,16 @@ export async function importCookiesFromBrowser(
       return { ok: false, reason: `No cookies found in ${browser.label}.` }
     }
 
-    const needsSourceKey = sourceRows.some((sourceRow) => {
-      const encRaw = sourceRow.encrypted_value
-      return encRaw instanceof Uint8Array && encRaw.length > 0
-    })
+    const needsSourceKey =
+      sourceDb
+        .prepare('SELECT 1 AS needed FROM cookies WHERE length(encrypted_value) > 0 LIMIT 1')
+        .get() !== undefined
     const sourceKey = needsSourceKey
       ? getEncryptionKey(browser.keychainService!, browser.keychainAccount!, browser)
       : null
     if (needsSourceKey && !sourceKey) {
+      sourceDb.close()
+      sourceDb = null
       stagingDb.close()
       stagingDb = null
       // Why: key denial happens after staging, so clean up the target DB copy or retries pile up.
@@ -1564,7 +1587,6 @@ export async function importCookiesFromBrowser(
     const domainSet = new Set<string>()
 
     type DecryptedCookie = {
-      decryptedValue: Buffer
       value: string
       domain: string
       name: string
@@ -1584,6 +1606,9 @@ export async function importCookiesFromBrowser(
 
     stagingDb.exec('BEGIN TRANSACTION')
 
+    const sourceRows = sourceDb
+      .prepare('SELECT * FROM cookies ORDER BY rowid')
+      .iterate() as IterableIterator<Record<string, unknown>>
     for (const sourceRow of sourceRows) {
       const encRaw = sourceRow.encrypted_value
       // Why: node:sqlite returns BLOBs as Uint8Array; treat any other type as missing, not an empty buffer that would silently blank the cookie value.
@@ -1626,7 +1651,6 @@ export async function importCookiesFromBrowser(
       const value = decryptedValue.toString('latin1')
 
       decryptedCookies.push({
-        decryptedValue,
         value,
         domain,
         name,
@@ -1641,6 +1665,8 @@ export async function importCookiesFromBrowser(
       insertStmt.run(...params)
       imported++
     }
+    sourceDb.close()
+    sourceDb = null
     diag(`  skipped ${integritySkipped} Google integrity cookies (SIDCC/STRP/AEC)`)
 
     stagingDb.exec('COMMIT')
@@ -1706,7 +1732,7 @@ export async function importCookiesFromBrowser(
     }
 
     const summary: BrowserCookieImportSummary = {
-      totalCookies: sourceRows.length,
+      totalCookies: totalSourceRows,
       importedCookies: imported,
       skippedCookies: skipped,
       domains: [...domainSet].sort()
@@ -1731,6 +1757,9 @@ export async function importCookiesFromBrowser(
       /* may not exist yet */
     }
     diag(`  SQLite import failed: ${err}`)
+    if (err instanceof InstalledBrowserCookieStoreLimitError) {
+      return { ok: false, reason: installedBrowserCookieStoreLimitReason(browser.label) }
+    }
     return {
       ok: false,
       reason: reasonWithDiagLog(

--- a/src/main/browser/browser-cookie-json-file-parser.test.ts
+++ b/src/main/browser/browser-cookie-json-file-parser.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  COOKIE_JSON_FILE_MAX_BYTES,
+  COOKIE_JSON_FILE_MAX_DEPTH,
+  COOKIE_JSON_FILE_MAX_ENTRIES,
+  COOKIE_JSON_FILE_MAX_RETAINED_BYTES,
+  CookieJsonFileFormatError,
+  CookieJsonFileLimitError,
+  enforceCookieJsonRetainedBytes,
+  visitCookieJsonFileObjects
+} from './browser-cookie-json-file-parser'
+
+describe('visitCookieJsonFileObjects', () => {
+  it('visits top-level objects in order and counts every entry', () => {
+    const onObject = vi.fn()
+    const total = visitCookieJsonFileObjects(
+      '[{"name":"first"}, 42, ["ignored"], {"name":"last","nested":{"x":1}}]',
+      onObject
+    )
+
+    expect(total).toBe(4)
+    expect(onObject.mock.calls.map(([entry]) => entry)).toEqual([
+      { name: 'first' },
+      { name: 'last' }
+    ])
+  })
+
+  it('accepts the exact entry boundary and rejects one over it', () => {
+    expect(visitCookieJsonFileObjects('[{},{}]', () => undefined, 2)).toBe(2)
+    expect(() => visitCookieJsonFileObjects('[{},{},{}]', () => undefined, 2)).toThrow(
+      expect.objectContaining({
+        name: CookieJsonFileLimitError.name,
+        kind: 'entries',
+        observed: 3,
+        limit: 2
+      })
+    )
+  })
+
+  it('accepts the retained-byte boundary and rejects one byte over it', () => {
+    expect(() => enforceCookieJsonRetainedBytes(COOKIE_JSON_FILE_MAX_RETAINED_BYTES)).not.toThrow()
+    expect(() => enforceCookieJsonRetainedBytes(COOKIE_JSON_FILE_MAX_RETAINED_BYTES + 1)).toThrow(
+      expect.objectContaining({
+        name: CookieJsonFileLimitError.name,
+        kind: 'retained-bytes',
+        observed: COOKIE_JSON_FILE_MAX_RETAINED_BYTES + 1
+      })
+    )
+  })
+
+  it('accepts the nesting boundary and rejects one level over it', () => {
+    expect(
+      visitCookieJsonFileObjects(`${'['.repeat(4)}0${']'.repeat(4)}`, () => undefined, 10, 4)
+    ).toBe(1)
+    expect(() =>
+      visitCookieJsonFileObjects(`${'['.repeat(5)}0${']'.repeat(5)}`, () => undefined, 10, 4)
+    ).toThrow(
+      expect.objectContaining({
+        name: CookieJsonFileLimitError.name,
+        kind: 'depth',
+        observed: 5,
+        limit: 4
+      })
+    )
+  })
+
+  it.each([
+    { raw: '{"name":"not-an-array"}', kind: 'root' },
+    { raw: '[{"name":}]', kind: 'syntax' },
+    { raw: '[{"name":"cookie"},]', kind: 'syntax' },
+    { raw: '[/* comment */ {"name":"cookie"}]', kind: 'syntax' }
+  ])('rejects $kind input without returning partial data', ({ raw, kind }) => {
+    expect(() => visitCookieJsonFileObjects(raw, () => undefined)).toThrow(
+      expect.objectContaining({ name: CookieJsonFileFormatError.name, kind })
+    )
+  })
+
+  it('publishes the production file, entry, and retained-data limits', () => {
+    expect({
+      fileBytes: COOKIE_JSON_FILE_MAX_BYTES,
+      depth: COOKIE_JSON_FILE_MAX_DEPTH,
+      entries: COOKIE_JSON_FILE_MAX_ENTRIES,
+      retainedBytes: COOKIE_JSON_FILE_MAX_RETAINED_BYTES
+    }).toEqual({
+      fileBytes: 64 * 1024 * 1024,
+      depth: 128,
+      entries: 250_000,
+      retainedBytes: 64 * 1024 * 1024
+    })
+  })
+})

--- a/src/main/browser/browser-cookie-json-file-parser.ts
+++ b/src/main/browser/browser-cookie-json-file-parser.ts
@@ -1,0 +1,184 @@
+import { visit, type JSONPath } from 'jsonc-parser'
+
+export const COOKIE_JSON_FILE_MAX_BYTES = 64 * 1024 * 1024
+export const COOKIE_JSON_FILE_MAX_ENTRIES = 250_000
+export const COOKIE_JSON_FILE_MAX_DEPTH = 128
+export const COOKIE_JSON_FILE_MAX_RETAINED_BYTES = 64 * 1024 * 1024
+
+export type CookieJsonFileLimitKind = 'depth' | 'entries' | 'retained-bytes'
+export type CookieJsonFileFormatKind = 'syntax' | 'root'
+
+export class CookieJsonFileLimitError extends Error {
+  constructor(
+    readonly kind: CookieJsonFileLimitKind,
+    readonly observed: number,
+    readonly limit: number
+  ) {
+    super(`Cookie JSON file exceeds the ${kind} limit`)
+    this.name = 'CookieJsonFileLimitError'
+  }
+}
+
+export class CookieJsonFileFormatError extends Error {
+  constructor(readonly kind: CookieJsonFileFormatKind) {
+    super(`Cookie JSON file has invalid ${kind}`)
+    this.name = 'CookieJsonFileFormatError'
+  }
+}
+
+type Container = {
+  kind: 'array' | 'object'
+  topLevelEntry: boolean
+}
+
+const COOKIE_PROPERTY_NAMES = new Set([
+  'domain',
+  'name',
+  'value',
+  'path',
+  'secure',
+  'httpOnly',
+  'sameSite',
+  'expirationDate'
+])
+
+export function visitCookieJsonFileObjects(
+  rawContent: string,
+  onObject: (entry: Record<string, unknown>) => void,
+  maxEntries = COOKIE_JSON_FILE_MAX_ENTRIES,
+  maxDepth = COOKIE_JSON_FILE_MAX_DEPTH
+): number {
+  enforceJsonNestingDepth(rawContent, maxDepth)
+  const containers: Container[] = []
+  let rootKind: 'array' | 'other' | null = null
+  let currentEntry: Record<string, unknown> | null = null
+  let entryCount = 0
+  let syntaxError = false
+
+  const countEntry = (): void => {
+    entryCount += 1
+    if (entryCount > maxEntries) {
+      throw new CookieJsonFileLimitError('entries', entryCount, maxEntries)
+    }
+  }
+  const isTopLevelEntry = (path: JSONPath): boolean => rootKind === 'array' && path.length === 1
+  const setDirectProperty = (path: JSONPath, value: unknown): void => {
+    const property = path[1]
+    if (
+      currentEntry &&
+      path.length === 2 &&
+      typeof property === 'string' &&
+      COOKIE_PROPERTY_NAMES.has(property)
+    ) {
+      currentEntry[property] = value
+    }
+  }
+
+  // Why: retain only fields validation uses instead of materializing the entire external JSON tree.
+  visit(
+    rawContent,
+    {
+      onArrayBegin: (_offset, _length, _line, _character, pathSupplier) => {
+        const path = pathSupplier()
+        if (path.length === 0) {
+          rootKind = 'array'
+        }
+        const topLevelEntry = isTopLevelEntry(path)
+        if (topLevelEntry) {
+          countEntry()
+        } else {
+          setDirectProperty(path, undefined)
+        }
+        containers.push({ kind: 'array', topLevelEntry })
+      },
+      onArrayEnd: () => {
+        containers.pop()
+      },
+      onObjectBegin: (_offset, _length, _line, _character, pathSupplier) => {
+        const path = pathSupplier()
+        if (path.length === 0) {
+          rootKind = 'other'
+        }
+        const topLevelEntry = isTopLevelEntry(path)
+        if (topLevelEntry) {
+          countEntry()
+          currentEntry = {}
+        } else {
+          setDirectProperty(path, undefined)
+        }
+        containers.push({ kind: 'object', topLevelEntry })
+      },
+      onObjectEnd: () => {
+        const container = containers.pop()
+        if (!container || container.kind !== 'object' || !container.topLevelEntry) {
+          return
+        }
+        if (currentEntry) {
+          onObject(currentEntry)
+        }
+        currentEntry = null
+      },
+      onLiteralValue: (value, _offset, _length, _line, _character, pathSupplier) => {
+        const path = pathSupplier()
+        if (path.length === 0) {
+          rootKind = 'other'
+        } else if (isTopLevelEntry(path)) {
+          countEntry()
+        } else {
+          setDirectProperty(path, value)
+        }
+      },
+      onError: () => {
+        syntaxError = true
+      }
+    },
+    { disallowComments: true, allowTrailingComma: false, allowEmptyContent: false }
+  )
+
+  if (syntaxError) {
+    throw new CookieJsonFileFormatError('syntax')
+  }
+  if (rootKind !== 'array') {
+    throw new CookieJsonFileFormatError('root')
+  }
+  return entryCount
+}
+
+function enforceJsonNestingDepth(rawContent: string, maxDepth: number): void {
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let index = 0; index < rawContent.length; index += 1) {
+    const character = rawContent[index]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (character === '\\') {
+        escaped = true
+      } else if (character === '"') {
+        inString = false
+      }
+      continue
+    }
+    if (character === '"') {
+      inString = true
+    } else if (character === '[' || character === '{') {
+      depth += 1
+      if (depth > maxDepth) {
+        throw new CookieJsonFileLimitError('depth', depth, maxDepth)
+      }
+    } else if (character === ']' || character === '}') {
+      depth = Math.max(0, depth - 1)
+    }
+  }
+}
+
+export function enforceCookieJsonRetainedBytes(observed: number): void {
+  if (observed > COOKIE_JSON_FILE_MAX_RETAINED_BYTES) {
+    throw new CookieJsonFileLimitError(
+      'retained-bytes',
+      observed,
+      COOKIE_JSON_FILE_MAX_RETAINED_BYTES
+    )
+  }
+}

--- a/src/main/browser/browser-manager.test.ts
+++ b/src/main/browser/browser-manager.test.ts
@@ -54,7 +54,7 @@ vi.mock('./popup-origin-bar-window', () => ({
   openPopupWithOriginBar: openPopupWithOriginBarMock
 }))
 
-import { browserManager } from './browser-manager'
+import { MAX_ACTIVE_BROWSER_DOWNLOADS, browserManager } from './browser-manager'
 
 describe('browserManager', () => {
   const rendererWebContentsId = 5001
@@ -1925,6 +1925,24 @@ describe('browserManager', () => {
         error: null
       })
     )
+  })
+
+  it('cancels excess concurrent downloads before retaining another item', () => {
+    const item = createDownloadItem()
+    const managerState = browserManager as unknown as { downloadsById: Map<string, unknown> }
+    for (let index = 0; index < MAX_ACTIVE_BROWSER_DOWNLOADS; index += 1) {
+      managerState.downloadsById.set(`active-${index}`, {})
+    }
+
+    try {
+      browserManager.handleGuestWillDownload({ guestWebContentsId: 999, item })
+
+      expect(item.cancel).toHaveBeenCalledTimes(1)
+      expect(item.setSavePath).not.toHaveBeenCalled()
+      expect(managerState.downloadsById.size).toBe(MAX_ACTIVE_BROWSER_DOWNLOADS)
+    } finally {
+      managerState.downloadsById.clear()
+    }
   })
 
   it('flushes started and terminal snapshots for downloads that finish before registration', () => {

--- a/src/main/browser/browser-manager.ts
+++ b/src/main/browser/browser-manager.ts
@@ -198,6 +198,8 @@ type ActiveDownload = {
   cleanup: (() => void) | null
 }
 
+export const MAX_ACTIVE_BROWSER_DOWNLOADS = 64
+
 function safeOrigin(rawUrl: string): string {
   const external = normalizeExternalBrowserUrl(rawUrl)
   const urlToParse = external ?? rawUrl
@@ -1257,6 +1259,14 @@ export class BrowserManager {
 
   handleGuestWillDownload(args: { guestWebContentsId: number; item: Electron.DownloadItem }): void {
     const { guestWebContentsId, item } = args
+    if (this.downloadsById.size >= MAX_ACTIVE_BROWSER_DOWNLOADS) {
+      try {
+        item.cancel()
+      } catch {
+        // Why: rejecting excess admission must remain safe if Chromium already finalized the item.
+      }
+      return
+    }
     const downloadId = randomUUID()
     const requestedFilename = (() => {
       try {

--- a/src/main/browser/browser-pdf-admission.test.ts
+++ b/src/main/browser/browser-pdf-admission.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  acquireBrowserPdfAdmission,
+  BROWSER_PDF_MAX_CONCURRENT_PRINTS,
+  startBrowserPdfPrint
+} from './browser-pdf-admission'
+
+function createWebContents() {
+  return { printToPDF: vi.fn<() => Promise<Buffer>>() }
+}
+
+describe('browser PDF admission', () => {
+  it('caps native prints process-wide and releases only after native settlement', async () => {
+    const resolvers: ((data: Buffer) => void)[] = []
+    const webContents = createWebContents()
+    webContents.printToPDF.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+
+    const active = Array.from({ length: BROWSER_PDF_MAX_CONCURRENT_PRINTS }, () =>
+      startBrowserPdfPrint(webContents as never, {})
+    )
+    expect(active.every(Boolean)).toBe(true)
+    expect(startBrowserPdfPrint(createWebContents() as never, {})).toBeNull()
+
+    resolvers[0]!(Buffer.from('first'))
+    await Promise.resolve()
+    const nextWebContents = createWebContents()
+    nextWebContents.printToPDF.mockResolvedValue(Buffer.from('next'))
+    await expect(startBrowserPdfPrint(nextWebContents as never, {})).resolves.toEqual(
+      Buffer.from('next')
+    )
+
+    resolvers[1]!(Buffer.from('second'))
+    await Promise.all(active)
+  })
+
+  it('lets pre-render work release unused admission', () => {
+    const first = acquireBrowserPdfAdmission()
+    const second = acquireBrowserPdfAdmission()
+    expect(first).not.toBeNull()
+    expect(second).not.toBeNull()
+    expect(acquireBrowserPdfAdmission()).toBeNull()
+
+    first!.releaseIfIdle()
+    const replacement = acquireBrowserPdfAdmission()
+    expect(replacement).not.toBeNull()
+    second!.releaseIfIdle()
+    replacement!.releaseIfIdle()
+  })
+
+  it('releases process-wide print slots after synchronous and asynchronous failures', async () => {
+    const synchronous = createWebContents()
+    synchronous.printToPDF.mockImplementation(() => {
+      throw new Error('sync print failure')
+    })
+    await expect(startBrowserPdfPrint(synchronous as never, {})).rejects.toThrow(
+      'sync print failure'
+    )
+
+    const asynchronous = createWebContents()
+    asynchronous.printToPDF.mockRejectedValue(new Error('async print failure'))
+    await expect(startBrowserPdfPrint(asynchronous as never, {})).rejects.toThrow(
+      'async print failure'
+    )
+
+    const replacement = createWebContents()
+    replacement.printToPDF.mockResolvedValue(Buffer.from('replacement'))
+    await expect(startBrowserPdfPrint(replacement as never, {})).resolves.toEqual(
+      Buffer.from('replacement')
+    )
+  })
+})

--- a/src/main/browser/browser-pdf-admission.ts
+++ b/src/main/browser/browser-pdf-admission.ts
@@ -1,0 +1,59 @@
+import type { PrintToPDFOptions, WebContents } from 'electron'
+
+export const BROWSER_PDF_MAX_CONCURRENT_PRINTS = 2
+export const BROWSER_PDF_BUSY_ERROR = 'Too many PDF print requests are already running'
+
+let activePrints = 0
+
+export type BrowserPdfAdmission = {
+  print(webContents: WebContents, options: PrintToPDFOptions): Promise<Buffer>
+  releaseIfIdle(): void
+}
+
+export function acquireBrowserPdfAdmission(): BrowserPdfAdmission | null {
+  if (activePrints >= BROWSER_PDF_MAX_CONCURRENT_PRINTS) {
+    return null
+  }
+  activePrints += 1
+  let printStarted = false
+  let released = false
+  const release = (): void => {
+    if (released) {
+      return
+    }
+    released = true
+    activePrints = Math.max(0, activePrints - 1)
+  }
+
+  return {
+    print(webContents, options) {
+      if (printStarted) {
+        return Promise.reject(new Error('PDF admission has already started a print'))
+      }
+      printStarted = true
+      let print: Promise<Buffer>
+      try {
+        print = webContents.printToPDF(options)
+      } catch (error) {
+        release()
+        return Promise.reject(error)
+      }
+      // Why: native PDF work cannot be cancelled when its caller times out or disconnects.
+      void print.then(release, release)
+      return print
+    },
+    releaseIfIdle() {
+      if (!printStarted) {
+        release()
+      }
+    }
+  }
+}
+
+export function startBrowserPdfPrint(
+  webContents: WebContents,
+  options: PrintToPDFOptions
+): Promise<Buffer> | null {
+  const admission = acquireBrowserPdfAdmission()
+  return admission?.print(webContents, options) ?? null
+}

--- a/src/main/browser/browser-screencast-stream.test.ts
+++ b/src/main/browser/browser-screencast-stream.test.ts
@@ -3,7 +3,11 @@ import { EventEmitter } from 'node:events'
 import { describe, expect, it, vi } from 'vitest'
 
 import { decodeBrowserScreencastFrame } from '../../shared/browser-screencast-protocol'
-import { startBrowserScreencast } from './browser-screencast-stream'
+import {
+  decodeBrowserScreencastImage,
+  MAX_BROWSER_SCREENCAST_BASE64_CHARACTERS,
+  startBrowserScreencast
+} from './browser-screencast-stream'
 
 function createMockWebContents() {
   let attached = false
@@ -57,6 +61,16 @@ function jpegWithSize(width: number, height: number): Buffer {
 }
 
 describe('startBrowserScreencast', () => {
+  it('rejects oversized CDP image text before base64 decoding', () => {
+    const decode = vi.spyOn(Buffer, 'from')
+
+    expect(
+      decodeBrowserScreencastImage('A'.repeat(MAX_BROWSER_SCREENCAST_BASE64_CHARACTERS + 1))
+    ).toBeNull()
+    expect(decode).not.toHaveBeenCalled()
+    decode.mockRestore()
+  })
+
   it('emits an initial captured frame before CDP produces screencast events', async () => {
     const webContents = createMockWebContents()
     const firstFrame = Buffer.from('first-frame')

--- a/src/main/browser/browser-screencast-stream.ts
+++ b/src/main/browser/browser-screencast-stream.ts
@@ -10,9 +10,12 @@ import {
 import { BrowserError } from './cdp-bridge'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
 import { readBrowserScreencastImageSize } from './browser-screencast-image-size'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES } from '../../shared/remote-runtime-memory-limits'
 
 const DEBUGGER_COMMAND_TIMEOUT_MS = 8_000
 const BACKPRESSURE_RETRY_MS = 50
+export const MAX_BROWSER_SCREENCAST_BASE64_CHARACTERS =
+  Math.ceil(REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES / 3) * 4
 
 export type BrowserScreencastOptions = {
   format: BrowserScreencastFormat
@@ -452,7 +455,10 @@ export async function startBrowserScreencast(
     }
 
     try {
-      const image = new Uint8Array(Buffer.from(data, 'base64'))
+      const image = decodeBrowserScreencastImage(data)
+      if (!image) {
+        throw new Error('Browser screencast frame is too large')
+      }
       // Why: image dimension parsing happens for every live frame; share the
       // result between stale-frame rejection and metadata enrichment.
       const imageSize = readBrowserScreencastImageSize(image, options.format)
@@ -558,7 +564,10 @@ export async function startBrowserScreencast(
         if (!data) {
           return
         }
-        image = new Uint8Array(Buffer.from(data, 'base64'))
+        image = decodeBrowserScreencastImage(data)
+        if (!image) {
+          return
+        }
       }
       if (isSnapshotStale(initialOnly, generation)) {
         return
@@ -631,4 +640,12 @@ export async function startBrowserScreencast(
     },
     done
   }
+}
+
+export function decodeBrowserScreencastImage(data: string): Uint8Array | null {
+  if (data.length > MAX_BROWSER_SCREENCAST_BASE64_CHARACTERS) {
+    return null
+  }
+  const image = new Uint8Array(Buffer.from(data, 'base64'))
+  return image.byteLength <= REMOTE_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES ? image : null
 }

--- a/src/main/browser/browser-screenshot-admission.test.ts
+++ b/src/main/browser/browser-screenshot-admission.test.ts
@@ -1,0 +1,95 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  resetBrowserScreenshotAdmissionForTests,
+  startBrowserFallbackCapture,
+  startBrowserScreenshotCommand
+} from './browser-screenshot-admission'
+import { BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES } from './browser-screenshot-limits'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  reject: (error: Error) => void
+  resolve: (value: T) => void
+} {
+  let reject!: (error: Error) => void
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((accept, fail) => {
+    resolve = accept
+    reject = fail
+  })
+  return { promise, reject, resolve }
+}
+
+function createWebContents() {
+  const events = new EventEmitter()
+  return Object.assign(events, {
+    capturePage: vi.fn(),
+    debugger: { sendCommand: vi.fn() }
+  })
+}
+
+afterEach(() => {
+  resetBrowserScreenshotAdmissionForTests()
+})
+
+describe('browser screenshot admission', () => {
+  it('caps native capture work across different WebContents and releases on settlement', async () => {
+    const operations = Array.from({ length: BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES }, () =>
+      deferred<unknown>()
+    )
+    const contents = operations.map((operation) => {
+      const webContents = createWebContents()
+      webContents.debugger.sendCommand.mockReturnValue(operation.promise)
+      return webContents
+    })
+    const active = contents.map((webContents) =>
+      startBrowserScreenshotCommand(webContents as never, 'Page.captureScreenshot', {})
+    )
+
+    const overflow = createWebContents()
+    overflow.debugger.sendCommand.mockResolvedValue({ data: 'later' })
+    expect(
+      startBrowserScreenshotCommand(overflow as never, 'Page.captureScreenshot', {})
+    ).toBeNull()
+
+    operations[0]!.resolve({ data: 'first' })
+    await expect(active[0]).resolves.toEqual({ data: 'first' })
+    await expect(
+      startBrowserScreenshotCommand(overflow as never, 'Page.captureScreenshot', {})
+    ).resolves.toEqual({ data: 'later' })
+
+    operations[1]!.reject(new Error('capture failed'))
+    await expect(active[1]).rejects.toThrow('capture failed')
+  })
+
+  it('shares admission with fallback capture and releases synchronous failures', async () => {
+    const commandContents = createWebContents()
+    commandContents.debugger.sendCommand.mockImplementation(() => {
+      throw new Error('sync failure')
+    })
+    await expect(
+      startBrowserScreenshotCommand(commandContents as never, 'Page.captureScreenshot', {})
+    ).rejects.toThrow('sync failure')
+
+    const fallbackContents = createWebContents()
+    const image = { isEmpty: () => false }
+    fallbackContents.capturePage.mockResolvedValue(image)
+    await expect(startBrowserFallbackCapture(fallbackContents as never)).resolves.toBe(image)
+  })
+
+  it('releases a hung operation when its WebContents is destroyed', async () => {
+    const hung = createWebContents()
+    hung.debugger.sendCommand.mockImplementation(() => new Promise(() => {}))
+    expect(
+      startBrowserScreenshotCommand(hung as never, 'Page.captureScreenshot', {})
+    ).not.toBeNull()
+    hung.emit('destroyed')
+
+    const replacement = createWebContents()
+    replacement.debugger.sendCommand.mockResolvedValue({ data: 'replacement' })
+    await expect(
+      startBrowserScreenshotCommand(replacement as never, 'Page.captureScreenshot', {})
+    ).resolves.toEqual({ data: 'replacement' })
+  })
+})

--- a/src/main/browser/browser-screenshot-admission.ts
+++ b/src/main/browser/browser-screenshot-admission.ts
@@ -1,0 +1,64 @@
+import type { WebContents } from 'electron'
+import { BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES } from './browser-screenshot-limits'
+
+let activeCaptures = 0
+let admissionEpoch = 0
+
+function startBrowserScreenshotOperation<T>(
+  webContents: WebContents,
+  start: () => Promise<T>
+): Promise<T> | null {
+  if (activeCaptures >= BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES) {
+    return null
+  }
+  activeCaptures += 1
+  const operationEpoch = admissionEpoch
+
+  let released = false
+  const onDestroyed = (): void => release()
+  const release = (): void => {
+    if (released) {
+      return
+    }
+    released = true
+    webContents.removeListener?.('destroyed', onDestroyed)
+    if (operationEpoch === admissionEpoch) {
+      activeCaptures = Math.max(0, activeCaptures - 1)
+    }
+  }
+  // Why: destroying the native target releases its capture resources even if Chromium omits rejection.
+  webContents.once?.('destroyed', onDestroyed)
+
+  let command: Promise<T>
+  try {
+    command = start()
+  } catch (error) {
+    release()
+    return Promise.reject(error)
+  }
+  // Why: a timed-out native command cannot be cancelled, so it owns its slot until it truly settles.
+  void command.then(release, release)
+  return command
+}
+
+export function startBrowserScreenshotCommand<T>(
+  webContents: WebContents,
+  method: 'Page.captureScreenshot' | 'Page.getLayoutMetrics',
+  params: Record<string, unknown>
+): Promise<T> | null {
+  return startBrowserScreenshotOperation(
+    webContents,
+    () => webContents.debugger.sendCommand(method, params) as Promise<T>
+  )
+}
+
+export function startBrowserFallbackCapture(
+  webContents: WebContents
+): Promise<Electron.NativeImage> | null {
+  return startBrowserScreenshotOperation(webContents, () => webContents.capturePage())
+}
+
+export function resetBrowserScreenshotAdmissionForTests(): void {
+  admissionEpoch += 1
+  activeCaptures = 0
+}

--- a/src/main/browser/browser-screenshot-file-reader.test.ts
+++ b/src/main/browser/browser-screenshot-file-reader.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { readBrowserScreenshotFile } from './browser-screenshot-file-reader'
+import { BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR } from './browser-screenshot-limits'
+
+const temporaryDirectories: string[] = []
+
+function createFile(bytes: Buffer): string {
+  const directory = mkdtempSync(join(tmpdir(), 'orca-screenshot-reader-'))
+  temporaryDirectories.push(directory)
+  const path = join(directory, 'screenshot.png')
+  writeFileSync(path, bytes)
+  return path
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('readBrowserScreenshotFile', () => {
+  it('reads a screenshot at the byte boundary', () => {
+    const path = createFile(Buffer.from('1234'))
+
+    expect(readBrowserScreenshotFile(path, 4)).toEqual(Buffer.from('1234'))
+  })
+
+  it('rejects an oversized screenshot before allocating its contents', () => {
+    const path = createFile(Buffer.from('12345'))
+
+    expect(() => readBrowserScreenshotFile(path, 4)).toThrow(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+  })
+})

--- a/src/main/browser/browser-screenshot-file-reader.ts
+++ b/src/main/browser/browser-screenshot-file-reader.ts
@@ -1,0 +1,54 @@
+import { closeSync, fstatSync, openSync, readSync } from 'node:fs'
+import {
+  BROWSER_SCREENSHOT_MAX_ENCODED_BYTES,
+  BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+} from './browser-screenshot-limits'
+
+const MIN_GROWTH_BYTES = 64 * 1024
+
+function throwIfOverLimit(bytes: number, maxBytes: number): void {
+  if (bytes > maxBytes) {
+    throw new Error(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+  }
+}
+
+export function readBrowserScreenshotFile(
+  path: string,
+  maxBytes = BROWSER_SCREENSHOT_MAX_ENCODED_BYTES
+): Buffer {
+  const descriptor = openSync(path, 'r')
+  try {
+    const initialSize = fstatSync(descriptor).size
+    throwIfOverLimit(initialSize, maxBytes)
+    let bytes = Buffer.allocUnsafe(initialSize)
+    let offset = 0
+
+    while (true) {
+      while (offset < bytes.length) {
+        const read = readSync(descriptor, bytes, offset, bytes.length - offset, null)
+        if (read === 0) {
+          return bytes.subarray(0, offset)
+        }
+        offset += read
+      }
+
+      const probe = Buffer.allocUnsafe(1)
+      if (readSync(descriptor, probe, 0, 1, null) === 0) {
+        return bytes.subarray(0, offset)
+      }
+      throwIfOverLimit(offset + 1, maxBytes)
+
+      const nextCapacity = Math.min(
+        maxBytes,
+        Math.max(MIN_GROWTH_BYTES, bytes.length * 2, offset + 1)
+      )
+      const expanded = Buffer.allocUnsafe(nextCapacity)
+      bytes.copy(expanded, 0, 0, offset)
+      expanded[offset] = probe[0]!
+      bytes = expanded
+      offset += 1
+    }
+  } finally {
+    closeSync(descriptor)
+  }
+}

--- a/src/main/browser/browser-screenshot-limits.test.ts
+++ b/src/main/browser/browser-screenshot-limits.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertBrowserScreenshotEncodedBytes,
+  assertBrowserScreenshotGeometry,
+  BROWSER_SCREENSHOT_MAX_EFFECTIVE_PIXELS,
+  BROWSER_SCREENSHOT_MAX_ENCODED_BYTES,
+  BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+} from './browser-screenshot-limits'
+
+describe('browser screenshot memory limits', () => {
+  it('accepts ordinary HiDPI viewport geometry', () => {
+    expect(() => assertBrowserScreenshotGeometry(1_440, 900, 2)).not.toThrow()
+  })
+
+  it('counts device scale in the effective pixel budget', () => {
+    const side = Math.floor(Math.sqrt(BROWSER_SCREENSHOT_MAX_EFFECTIVE_PIXELS))
+
+    expect(() => assertBrowserScreenshotGeometry(side, side, 2)).toThrow(
+      BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+    )
+  })
+
+  it('accepts the encoded-byte boundary and rejects the next byte', () => {
+    expect(() =>
+      assertBrowserScreenshotEncodedBytes(BROWSER_SCREENSHOT_MAX_ENCODED_BYTES)
+    ).not.toThrow()
+    expect(() =>
+      assertBrowserScreenshotEncodedBytes(BROWSER_SCREENSHOT_MAX_ENCODED_BYTES + 1)
+    ).toThrow(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+  })
+})

--- a/src/main/browser/browser-screenshot-limits.ts
+++ b/src/main/browser/browser-screenshot-limits.ts
@@ -1,0 +1,37 @@
+export const BROWSER_SCREENSHOT_MAX_DIMENSION_PX = 32_768
+export const BROWSER_SCREENSHOT_MAX_EFFECTIVE_PIXELS = 32 * 1024 * 1024
+export const BROWSER_SCREENSHOT_MAX_ENCODED_BYTES = 32 * 1024 * 1024
+export const BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES = 2
+export const BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR =
+  'Screenshot exceeds the browser automation memory limit'
+export const BROWSER_SCREENSHOT_BUSY_ERROR = 'Too many screenshot requests are already running'
+
+export function assertBrowserScreenshotGeometry(width: number, height: number, scale = 1): void {
+  const effectiveWidth = width * scale
+  const effectiveHeight = height * scale
+  if (
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    !Number.isFinite(scale) ||
+    width <= 0 ||
+    height <= 0 ||
+    scale <= 0 ||
+    effectiveWidth > BROWSER_SCREENSHOT_MAX_DIMENSION_PX ||
+    effectiveHeight > BROWSER_SCREENSHOT_MAX_DIMENSION_PX ||
+    effectiveWidth * effectiveHeight > BROWSER_SCREENSHOT_MAX_EFFECTIVE_PIXELS
+  ) {
+    throw new Error(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+  }
+}
+
+export function assertBrowserScreenshotEncodedBytes(bytes: number): void {
+  if (!Number.isFinite(bytes) || bytes < 0 || bytes > BROWSER_SCREENSHOT_MAX_ENCODED_BYTES) {
+    throw new Error(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+  }
+}
+
+export function assertBrowserScreenshotBase64(data: string): void {
+  const padding = data.endsWith('==') ? 2 : data.endsWith('=') ? 1 : 0
+  const decodedBytes = Math.max(0, Math.floor((data.length * 3) / 4) - padding)
+  assertBrowserScreenshotEncodedBytes(decodedBytes)
+}

--- a/src/main/browser/browser-session-registry.persistence.test.ts
+++ b/src/main/browser/browser-session-registry.persistence.test.ts
@@ -105,6 +105,19 @@ function installModuleMocks(
       fsState.present.add(key)
     })
   }))
+  vi.doMock('../../shared/node-bounded-file-reader', () => ({
+    readNodeFileSyncWithinLimit: vi.fn((p: string, maxBytes: number) => {
+      const value = fsState.files.get(fsKey(p))
+      if (value === undefined) {
+        throw new Error('ENOENT')
+      }
+      const buffer = Buffer.from(value)
+      if (buffer.byteLength > maxBytes) {
+        throw new Error('File too large')
+      }
+      return { buffer, stats: {} }
+    })
+  }))
 
   vi.doMock('./browser-manager', () => ({
     browserManager: {
@@ -205,6 +218,73 @@ describe('BrowserSessionRegistry persistence', () => {
       partition: profile!.partition,
       label: 'Work Browser'
     })
+  })
+
+  it('ignores oversized browser-session metadata', async () => {
+    const fsState = createFsState()
+    fsState.files.set(META_PATH, ' '.repeat(1024 * 1024 + 1))
+    fsState.present.add(META_PATH)
+
+    installModuleMocks(fsState)
+    const { browserSessionRegistry } = await import('./browser-session-registry')
+    browserSessionRegistry.initializeBrowserSessionsFromPersistedState()
+
+    expect(browserSessionRegistry.listProfiles()).toHaveLength(1)
+    expect(browserSessionRegistry.listProfiles()[0]?.id).toBe('default')
+  })
+
+  it('rejects an oversized profile label without retaining or persisting it', async () => {
+    const fsState = createFsState()
+    installModuleMocks(fsState)
+    const { browserSessionRegistry, MAX_BROWSER_SESSION_LABEL_BYTES } =
+      await import('./browser-session-registry')
+
+    expect(
+      browserSessionRegistry.createProfile(
+        'isolated',
+        'x'.repeat(MAX_BROWSER_SESSION_LABEL_BYTES + 1)
+      )
+    ).toBeNull()
+    expect(browserSessionRegistry.listProfiles()).toHaveLength(1)
+    expect(fsState.files.has(META_PATH)).toBe(false)
+  })
+
+  it('keeps profile creation bounded while preserving the last readable metadata snapshot', async () => {
+    const fsState = createFsState()
+    installModuleMocks(fsState)
+    const { browserSessionRegistry, MAX_BROWSER_SESSION_LABEL_BYTES } =
+      await import('./browser-session-registry')
+    const label = 'x'.repeat(MAX_BROWSER_SESSION_LABEL_BYTES - 8)
+    for (let index = 0; index < 256; index += 1) {
+      browserSessionRegistry.createProfile('isolated', `${index}-${label}`)
+    }
+
+    const durableProfiles = JSON.parse(fsState.files.get(META_PATH) ?? '{}').profiles
+    expect(browserSessionRegistry.listProfiles().length).toBeGreaterThan(durableProfiles.length + 1)
+    expect(Buffer.byteLength(fsState.files.get(META_PATH) ?? '')).toBeLessThanOrEqual(1024 * 1024)
+  })
+
+  it('preserves metadata when a pending import path would exceed the byte limit', async () => {
+    const fsState = createFsState()
+    seedMeta(fsState, {
+      defaultSource: null,
+      userAgent: null,
+      userAgentByPartition: {},
+      pendingCookieDbPath: null,
+      pendingCookieImports: {},
+      profiles: []
+    })
+    const before = fsState.files.get(META_PATH)
+    installModuleMocks(fsState)
+    const { browserSessionRegistry, MAX_BROWSER_SESSION_META_FILE_BYTES } =
+      await import('./browser-session-registry')
+
+    browserSessionRegistry.setPendingCookieImport(
+      'persist:orca-browser',
+      'x'.repeat(MAX_BROWSER_SESSION_META_FILE_BYTES)
+    )
+
+    expect(fsState.files.get(META_PATH)).toBe(before)
   })
 
   it('merges partition-keyed pending entries without clobbering unrelated entries', async () => {

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -2,17 +2,11 @@
 import { app, session } from 'electron'
 import type { Session } from 'electron'
 import { randomUUID } from 'node:crypto'
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  unlinkSync,
-  writeFileSync
-} from 'node:fs'
+import { copyFileSync, existsSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
 import {
   DEFAULT_LOCAL_ORCA_PROFILE_ID,
   getOrcaProfileBrowserDefaultPartition,
@@ -46,6 +40,9 @@ export type BrowserSessionRegistryProfileOptions = {
 }
 
 const BROWSER_SESSION_META_FILE_NAME = 'browser-session-meta.json'
+export const MAX_BROWSER_SESSION_META_FILE_BYTES = 1024 * 1024
+export const MAX_BROWSER_SESSION_PROFILES = 256
+export const MAX_BROWSER_SESSION_LABEL_BYTES = 16 * 1024
 const LEGACY_BROWSER_SESSION_PARTITION_RE =
   /^persist:orca-browser-session-[\da-f-]{8}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{12}$/
 
@@ -103,8 +100,12 @@ class BrowserSessionRegistry {
     try {
       const existing = this.loadPersistedMeta()
       const tmpPath = `${this.metadataPath}.tmp`
+      const serialized = stringifyJsonWithinByteLimit(
+        { ...existing, ...updates },
+        MAX_BROWSER_SESSION_META_FILE_BYTES
+      ).serialized
       mkdirSync(dirname(this.metadataPath), { recursive: true })
-      writeFileSync(tmpPath, JSON.stringify({ ...existing, ...updates }))
+      writeFileSync(tmpPath, serialized)
       renameSync(tmpPath, this.metadataPath)
     } catch {
       // best-effort
@@ -126,7 +127,10 @@ class BrowserSessionRegistry {
 
   private loadPersistedMeta(): BrowserSessionMeta {
     try {
-      const raw = readFileSync(this.metadataPath, 'utf-8')
+      const raw = readNodeFileSyncWithinLimit(
+        this.metadataPath,
+        MAX_BROWSER_SESSION_META_FILE_BYTES
+      ).buffer.toString('utf8')
       const data = JSON.parse(raw)
       const legacyUserAgent = typeof data?.userAgent === 'string' ? data.userAgent : null
       const userAgentByPartition: Record<string, string> =
@@ -340,7 +344,11 @@ class BrowserSessionRegistry {
 
   createProfile(scope: BrowserSessionProfileScope, label: string): BrowserSessionProfile | null {
     // Why: block scope:'default' here — only the constructor makes the default profile; a second one sharing the partition breaks delete.
-    if (scope === 'default') {
+    if (
+      scope === 'default' ||
+      Buffer.byteLength(label, 'utf8') > MAX_BROWSER_SESSION_LABEL_BYTES ||
+      this.profiles.size >= MAX_BROWSER_SESSION_PROFILES
+    ) {
       return null
     }
     const id = randomUUID()

--- a/src/main/browser/cdp-bridge-memory-bounds.test.ts
+++ b/src/main/browser/cdp-bridge-memory-bounds.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { webContentsFromId } = vi.hoisted(() => ({ webContentsFromId: vi.fn() }))
+
+vi.mock('electron', () => ({
+  webContents: { fromId: webContentsFromId }
+}))
+
+import { CdpBridge } from './cdp-bridge'
+import {
+  CDP_MAX_CONSOLE_TEXT_CODE_UNITS,
+  CDP_MAX_IFRAME_SESSIONS,
+  CDP_MAX_PAUSED_REQUESTS
+} from './cdp-event-memory-bounds'
+
+function createHarness() {
+  let attached = false
+  const messageListeners: ((event: unknown, method: string, params: unknown) => void)[] = []
+  const sendCommand = vi.fn(async (_method: string, _params?: unknown) => ({}))
+  const guest = {
+    id: 1,
+    isDestroyed: () => false,
+    getURL: () => 'https://example.com',
+    getTitle: () => 'Example',
+    debugger: {
+      isAttached: () => attached,
+      attach: () => {
+        attached = true
+      },
+      sendCommand,
+      on: (event: string, listener: (event: unknown, method: string, params: unknown) => void) => {
+        if (event === 'message') {
+          messageListeners.push(listener)
+        }
+      },
+      removeListener: vi.fn()
+    }
+  }
+  const browserManager = {
+    webContentsIdByTabId: new Map([['page-1', guest.id]])
+  }
+  const bridge = new CdpBridge(browserManager as never)
+  bridge.setActiveTab(guest.id)
+  return {
+    bridge,
+    guest,
+    sendCommand,
+    emit(method: string, params: unknown) {
+      for (const listener of messageListeners) {
+        listener({}, method, params)
+      }
+    }
+  }
+}
+
+describe('CdpBridge event retention', () => {
+  beforeEach(() => {
+    webContentsFromId.mockReset()
+  })
+
+  it('bounds paused requests, iframe sessions, and console text', async () => {
+    const harness = createHarness()
+    webContentsFromId.mockReturnValue(harness.guest)
+    const internals = harness.bridge as unknown as {
+      ensureDebuggerAttached: (guest: unknown) => Promise<void>
+      tabState: Map<
+        string,
+        {
+          capturing: boolean
+          intercepting: boolean
+          consoleLog: { text: string }[]
+          pausedRequests: Map<string, unknown>
+          iframeSessions: Map<string, string>
+        }
+      >
+    }
+    await internals.ensureDebuggerAttached(harness.guest)
+    const state = internals.tabState.get('page-1')!
+    state.capturing = true
+    state.intercepting = true
+
+    harness.emit('Runtime.consoleAPICalled', {
+      args: [{ value: 'x'.repeat(CDP_MAX_CONSOLE_TEXT_CODE_UNITS * 2) }]
+    })
+    for (let index = 0; index < CDP_MAX_PAUSED_REQUESTS + 10; index++) {
+      harness.emit('Fetch.requestPaused', {
+        requestId: `request-${index}`,
+        request: { url: `https://example.com/${index}`, method: 'GET', headers: {} }
+      })
+    }
+    for (let index = 0; index < CDP_MAX_IFRAME_SESSIONS + 1; index++) {
+      harness.emit('Target.attachedToTarget', {
+        sessionId: `session-${index}`,
+        targetInfo: { type: 'iframe', targetId: `frame-${index}` }
+      })
+    }
+
+    expect(state.consoleLog[0]?.text).toHaveLength(CDP_MAX_CONSOLE_TEXT_CODE_UNITS)
+    expect(state.pausedRequests.size).toBe(CDP_MAX_PAUSED_REQUESTS)
+    expect(state.iframeSessions.size).toBe(CDP_MAX_IFRAME_SESSIONS)
+    expect(
+      harness.sendCommand.mock.calls.filter(([method]) => method === 'Fetch.continueRequest')
+    ).toHaveLength(10)
+    expect(
+      harness.sendCommand.mock.calls.filter(([method]) => method === 'Target.detachFromTarget')
+    ).toHaveLength(1)
+  })
+})

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -48,8 +48,16 @@ import {
 import { insertTextThroughCdp } from './browser-text-insertion'
 import type { BrowserManager } from './browser-manager'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
-
-const CAPTURE_LOG_LIMIT = 1000
+import { CdpCommandQueue } from './cdp-command-queue'
+import {
+  buildBoundedCdpConsoleEntry,
+  buildBoundedCdpInterceptedRequest,
+  buildBoundedCdpNetworkEntry,
+  CDP_CAPTURE_LOG_LIMIT,
+  CDP_MAX_IFRAME_SESSIONS,
+  CDP_MAX_PAUSED_REQUESTS,
+  isBoundedCdpIframeSession
+} from './cdp-event-memory-bounds'
 
 export class BrowserError extends Error {
   constructor(
@@ -79,21 +87,21 @@ type TabState = {
   networkRequestMap: Map<string, BrowserNetworkEntry>
 }
 
-type QueuedCommand = {
-  execute: () => Promise<unknown>
-  resolve: (value: unknown) => void
-  reject: (reason: unknown) => void
-}
-
 export class CdpBridge {
   private activeWebContentsId: number | null = null
   private readonly tabState = new Map<string, TabState>()
-  private readonly commandQueues = new Map<string, QueuedCommand[]>()
-  private readonly processingQueues = new Set<string>()
+  private readonly commandQueue: CdpCommandQueue
   private readonly browserManager: BrowserManager
 
   constructor(browserManager: BrowserManager) {
     this.browserManager = browserManager
+    this.commandQueue = new CdpCommandQueue(
+      () =>
+        new BrowserError(
+          'browser_busy',
+          'Browser command queue is full; retry after the current commands finish'
+        )
+    )
   }
 
   setActiveTab(webContentsId: number): void {
@@ -1010,7 +1018,13 @@ export class CdpBridge {
         this.removeDebuggerListeners(guest, state)
       }
       this.tabState.delete(tabId)
-      this.commandQueues.delete(tabId)
+      this.commandQueue.closeTab(
+        tabId,
+        new BrowserError(
+          'browser_debugger_detached',
+          'Browser tab closed before command execution.'
+        )
+      )
     }
   }
 
@@ -1195,10 +1209,21 @@ export class CdpBridge {
             }
           | undefined
         if (p?.sessionId && p.targetInfo?.type === 'iframe' && p.targetInfo.targetId) {
-          state.iframeSessions.set(p.targetInfo.targetId, p.sessionId)
-          guest.debugger.sendCommand('DOM.enable', {}, p.sessionId).catch(() => {})
-          guest.debugger.sendCommand('Accessibility.enable', {}, p.sessionId).catch(() => {})
-          guest.debugger.sendCommand('Runtime.enable', {}, p.sessionId).catch(() => {})
+          const frameId = p.targetInfo.targetId
+          const canRetainSession =
+            isBoundedCdpIframeSession(frameId, p.sessionId) &&
+            (state.iframeSessions.has(frameId) ||
+              state.iframeSessions.size < CDP_MAX_IFRAME_SESSIONS)
+          if (canRetainSession) {
+            state.iframeSessions.set(frameId, p.sessionId)
+            guest.debugger.sendCommand('DOM.enable', {}, p.sessionId).catch(() => {})
+            guest.debugger.sendCommand('Accessibility.enable', {}, p.sessionId).catch(() => {})
+            guest.debugger.sendCommand('Runtime.enable', {}, p.sessionId).catch(() => {})
+          } else {
+            guest.debugger
+              .sendCommand('Target.detachFromTarget', { sessionId: p.sessionId })
+              .catch(() => {})
+          }
         }
       }
       if (method === 'Target.detachedFromTarget') {
@@ -1224,15 +1249,8 @@ export class CdpBridge {
               }
             | undefined
           if (p) {
-            const text = (p.args ?? []).map((a) => a.value ?? a.description ?? '').join(' ')
-            state.consoleLog.push({
-              level: p.type ?? 'log',
-              text,
-              timestamp: p.timestamp ?? Date.now(),
-              url: p.stackTrace?.callFrames?.[0]?.url,
-              line: p.stackTrace?.callFrames?.[0]?.lineNumber
-            })
-            if (state.consoleLog.length > CAPTURE_LOG_LIMIT) {
+            state.consoleLog.push(buildBoundedCdpConsoleEntry(p))
+            if (state.consoleLog.length > CDP_CAPTURE_LOG_LIMIT) {
               state.consoleLog.shift()
             }
           }
@@ -1252,20 +1270,13 @@ export class CdpBridge {
               }
             | undefined
           if (p?.response) {
-            const entry: BrowserNetworkEntry = {
-              url: p.response.url ?? '',
-              method: '',
-              status: p.response.status ?? 0,
-              mimeType: p.response.mimeType ?? '',
-              size: 0,
-              timestamp: p.timestamp ?? Date.now()
-            }
+            const entry = buildBoundedCdpNetworkEntry(p.response, p.timestamp)
             state.networkLog.push(entry)
             // Why: map requestId→entry so loadingFinished attributes size to the right response, not the latest one.
             if (p.requestId) {
               state.networkRequestMap.set(p.requestId, entry)
             }
-            if (state.networkLog.length > CAPTURE_LOG_LIMIT) {
+            if (state.networkLog.length > CDP_CAPTURE_LOG_LIMIT) {
               const evicted = state.networkLog.shift()
               if (evicted) {
                 for (const [requestId, requestEntry] of state.networkRequestMap) {
@@ -1299,13 +1310,23 @@ export class CdpBridge {
             }
           | undefined
         if (p?.requestId && p.request) {
-          state.pausedRequests.set(p.requestId, {
-            id: p.requestId,
-            url: p.request.url ?? '',
-            method: p.request.method ?? 'GET',
-            headers: (p.request.headers ?? {}) as Record<string, string>,
-            resourceType: p.resourceType ?? 'Other'
+          const boundedRequest = buildBoundedCdpInterceptedRequest({
+            requestId: p.requestId,
+            request: p.request,
+            resourceType: p.resourceType
           })
+          if (
+            boundedRequest &&
+            (state.pausedRequests.has(p.requestId) ||
+              state.pausedRequests.size < CDP_MAX_PAUSED_REQUESTS)
+          ) {
+            state.pausedRequests.set(p.requestId, boundedRequest)
+          } else {
+            state.pausedRequests.delete(p.requestId)
+            guest.debugger
+              .sendCommand('Fetch.continueRequest', { requestId: p.requestId })
+              .catch(() => {})
+          }
         }
       }
     }
@@ -1681,40 +1702,7 @@ export class CdpBridge {
   private async enqueueCommand<T>(execute: () => Promise<T>): Promise<T> {
     const guest = this.getActiveGuest()
     const tabId = this.resolveTabId(guest.id)
-
-    return new Promise<T>((resolve, reject) => {
-      let queue = this.commandQueues.get(tabId)
-      if (!queue) {
-        queue = []
-        this.commandQueues.set(tabId, queue)
-      }
-      queue.push({
-        execute: execute as () => Promise<unknown>,
-        resolve: resolve as (value: unknown) => void,
-        reject
-      })
-      this.processQueue(tabId)
-    })
-  }
-
-  private async processQueue(tabId: string): Promise<void> {
-    if (this.processingQueues.has(tabId)) {
-      return
-    }
-    this.processingQueues.add(tabId)
-
-    const queue = this.commandQueues.get(tabId)
-    while (queue && queue.length > 0) {
-      const cmd = queue.shift()!
-      try {
-        const result = await cmd.execute()
-        cmd.resolve(result)
-      } catch (error) {
-        cmd.reject(error)
-      }
-    }
-
-    this.processingQueues.delete(tabId)
+    return this.commandQueue.enqueue(tabId, execute)
   }
 }
 

--- a/src/main/browser/cdp-command-queue.test.ts
+++ b/src/main/browser/cdp-command-queue.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CdpCommandQueue } from './cdp-command-queue'
+
+function deferred<T = void>(): {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('CdpCommandQueue', () => {
+  it('preserves ordinary per-tab command order', async () => {
+    const first = deferred()
+    const calls: number[] = []
+    const queue = new CdpCommandQueue(() => new Error('full'), 4, 8)
+    const one = queue.enqueue('tab-1', async () => {
+      calls.push(1)
+      await first.promise
+      return 'one'
+    })
+    const two = queue.enqueue('tab-1', async () => {
+      calls.push(2)
+      return 'two'
+    })
+
+    expect(calls).toEqual([1])
+    first.resolve()
+
+    await expect(Promise.all([one, two])).resolves.toEqual(['one', 'two'])
+    expect(calls).toEqual([1, 2])
+  })
+
+  it('rejects commands beyond per-tab and aggregate queue caps', async () => {
+    const first = deferred()
+    const second = deferred()
+    const queue = new CdpCommandQueue(() => new Error('full'), 2, 3)
+    const active = queue.enqueue('tab-1', () => first.promise)
+    const activeTwo = queue.enqueue('tab-2', () => second.promise)
+    const queued = [
+      queue.enqueue('tab-1', async () => 1),
+      queue.enqueue('tab-1', async () => 2),
+      queue.enqueue('tab-2', async () => 3)
+    ]
+
+    await expect(queue.enqueue('tab-1', async () => 4)).rejects.toThrow('full')
+    await expect(queue.enqueue('tab-3', async () => 5)).rejects.toThrow('full')
+
+    first.resolve()
+    second.resolve()
+    await expect(Promise.all([active, activeTwo, ...queued])).resolves.toEqual([
+      undefined,
+      undefined,
+      1,
+      2,
+      3
+    ])
+  })
+
+  it('rejects retained commands when a tab closes and continues a replacement queue', async () => {
+    const first = deferred()
+    const executeAfterClose = vi.fn(async () => 'stale')
+    const queue = new CdpCommandQueue(() => new Error('full'), 4, 8)
+    const active = queue.enqueue('tab-1', () => first.promise)
+    const stale = queue.enqueue('tab-1', executeAfterClose)
+
+    queue.closeTab('tab-1', new Error('closed'))
+    await expect(stale).rejects.toThrow('closed')
+    expect(executeAfterClose).not.toHaveBeenCalled()
+
+    const replacement = queue.enqueue('tab-1', async () => 'fresh')
+    first.resolve()
+    await expect(active).resolves.toBeUndefined()
+    await expect(replacement).resolves.toBe('fresh')
+  })
+})

--- a/src/main/browser/cdp-command-queue.ts
+++ b/src/main/browser/cdp-command-queue.ts
@@ -1,0 +1,80 @@
+export const CDP_MAX_QUEUED_COMMANDS_PER_TAB = 64
+export const CDP_MAX_QUEUED_COMMANDS_TOTAL = 512
+
+type QueuedCdpCommand = {
+  execute: () => Promise<unknown>
+  resolve: (value: unknown) => void
+  reject: (reason: unknown) => void
+}
+
+export class CdpCommandQueue {
+  private readonly queues = new Map<string, QueuedCdpCommand[]>()
+  private readonly processing = new Set<string>()
+  private queuedCount = 0
+
+  constructor(
+    private readonly createOverflowError: () => Error,
+    private readonly maxQueuedPerTab = CDP_MAX_QUEUED_COMMANDS_PER_TAB,
+    private readonly maxQueuedTotal = CDP_MAX_QUEUED_COMMANDS_TOTAL
+  ) {}
+
+  enqueue<T>(tabId: string, execute: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      let queue = this.queues.get(tabId)
+      if ((queue?.length ?? 0) >= this.maxQueuedPerTab || this.queuedCount >= this.maxQueuedTotal) {
+        reject(this.createOverflowError())
+        return
+      }
+      if (!queue) {
+        queue = []
+        this.queues.set(tabId, queue)
+      }
+      queue.push({
+        execute: execute as () => Promise<unknown>,
+        resolve: resolve as (value: unknown) => void,
+        reject
+      })
+      this.queuedCount += 1
+      void this.process(tabId)
+    })
+  }
+
+  closeTab(tabId: string, error: Error): void {
+    const queue = this.queues.get(tabId)
+    if (!queue) {
+      return
+    }
+    this.queues.delete(tabId)
+    for (const command of queue.splice(0)) {
+      this.queuedCount = Math.max(0, this.queuedCount - 1)
+      command.reject(error)
+    }
+  }
+
+  private async process(tabId: string): Promise<void> {
+    if (this.processing.has(tabId)) {
+      return
+    }
+    this.processing.add(tabId)
+    const queue = this.queues.get(tabId)
+    try {
+      while (queue && queue.length > 0) {
+        const command = queue.shift()!
+        this.queuedCount = Math.max(0, this.queuedCount - 1)
+        try {
+          command.resolve(await command.execute())
+        } catch (error) {
+          command.reject(error)
+        }
+      }
+      if (this.queues.get(tabId) === queue) {
+        this.queues.delete(tabId)
+      }
+    } finally {
+      this.processing.delete(tabId)
+      if ((this.queues.get(tabId)?.length ?? 0) > 0) {
+        void this.process(tabId)
+      }
+    }
+  }
+}

--- a/src/main/browser/cdp-event-memory-bounds.test.ts
+++ b/src/main/browser/cdp-event-memory-bounds.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildBoundedCdpConsoleEntry,
+  buildBoundedCdpInterceptedRequest,
+  buildBoundedCdpNetworkEntry,
+  CDP_MAX_CAPTURE_URL_CODE_UNITS,
+  CDP_MAX_CONSOLE_ARGUMENTS,
+  CDP_MAX_CONSOLE_TEXT_CODE_UNITS,
+  CDP_MAX_INTERCEPTED_HEADERS,
+  CDP_MAX_INTERCEPTED_METADATA_CODE_UNITS
+} from './cdp-event-memory-bounds'
+
+describe('CDP event memory bounds', () => {
+  it('preserves ordinary console and network capture fields', () => {
+    expect(
+      buildBoundedCdpConsoleEntry({
+        type: 'warning',
+        args: [{ value: 'hello' }, { value: 42 }],
+        timestamp: 123,
+        stackTrace: { callFrames: [{ url: 'https://example.com/app.js', lineNumber: 7 }] }
+      })
+    ).toEqual({
+      level: 'warning',
+      text: 'hello 42',
+      timestamp: 123,
+      url: 'https://example.com/app.js',
+      line: 7
+    })
+    expect(
+      buildBoundedCdpNetworkEntry(
+        { url: 'https://example.com/data', status: 200, mimeType: 'application/json' },
+        456
+      )
+    ).toEqual({
+      url: 'https://example.com/data',
+      method: '',
+      status: 200,
+      mimeType: 'application/json',
+      size: 0,
+      timestamp: 456
+    })
+  })
+
+  it('bounds console argument count, joined text, and capture URLs', () => {
+    const entry = buildBoundedCdpConsoleEntry({
+      args: Array.from({ length: CDP_MAX_CONSOLE_ARGUMENTS + 100 }, () => ({
+        value: 'x'.repeat(100)
+      })),
+      stackTrace: { callFrames: [{ url: 'u'.repeat(CDP_MAX_CAPTURE_URL_CODE_UNITS + 100) }] }
+    })
+
+    expect(entry.text.length).toBeLessThanOrEqual(CDP_MAX_CONSOLE_TEXT_CODE_UNITS)
+    expect(entry.url).toHaveLength(CDP_MAX_CAPTURE_URL_CODE_UNITS)
+  })
+
+  it('rejects intercepted metadata beyond aggregate and header-count caps', () => {
+    expect(
+      buildBoundedCdpInterceptedRequest({
+        requestId: 'request-1',
+        request: { url: 'https://example.com', headers: { accept: '*/*' } }
+      })
+    ).toEqual({
+      id: 'request-1',
+      url: 'https://example.com',
+      method: 'GET',
+      headers: { accept: '*/*' },
+      resourceType: 'Other'
+    })
+
+    expect(
+      buildBoundedCdpInterceptedRequest({
+        requestId: 'request-2',
+        request: { url: 'u'.repeat(CDP_MAX_INTERCEPTED_METADATA_CODE_UNITS + 1) }
+      })
+    ).toBeNull()
+
+    const headers = Object.fromEntries(
+      Array.from({ length: CDP_MAX_INTERCEPTED_HEADERS + 1 }, (_, index) => [`x-${index}`, 'v'])
+    )
+    expect(
+      buildBoundedCdpInterceptedRequest({ requestId: 'request-3', request: { headers } })
+    ).toBeNull()
+  })
+})

--- a/src/main/browser/cdp-event-memory-bounds.ts
+++ b/src/main/browser/cdp-event-memory-bounds.ts
@@ -1,0 +1,145 @@
+import type {
+  BrowserConsoleEntry,
+  BrowserInterceptedRequest,
+  BrowserNetworkEntry
+} from '../../shared/runtime-types'
+
+export const CDP_CAPTURE_LOG_LIMIT = 1000
+export const CDP_MAX_PAUSED_REQUESTS = 256
+export const CDP_MAX_IFRAME_SESSIONS = 1024
+export const CDP_MAX_CONSOLE_ARGUMENTS = 1024
+export const CDP_MAX_CONSOLE_TEXT_CODE_UNITS = 16 * 1024
+export const CDP_MAX_CAPTURE_URL_CODE_UNITS = 16 * 1024
+export const CDP_MAX_INTERCEPTED_HEADERS = 256
+export const CDP_MAX_INTERCEPTED_METADATA_CODE_UNITS = 64 * 1024
+const CDP_MAX_LEVEL_CODE_UNITS = 32
+const CDP_MAX_MIME_TYPE_CODE_UNITS = 1024
+const CDP_MAX_SESSION_ID_CODE_UNITS = 1024
+
+type ConsoleEvent = {
+  type?: string
+  args?: { value?: unknown; description?: unknown }[]
+  timestamp?: number
+  stackTrace?: { callFrames?: { url?: string; lineNumber?: number }[] }
+}
+
+type InterceptedRequestEvent = {
+  requestId: string
+  request: { url?: string; method?: string; headers?: Record<string, string> }
+  resourceType?: string
+}
+
+export function buildBoundedCdpConsoleEntry(event: ConsoleEvent): BrowserConsoleEntry {
+  const parts: string[] = []
+  let remaining = CDP_MAX_CONSOLE_TEXT_CODE_UNITS
+  const args = event.args ?? []
+  const argumentCount = Math.min(args.length, CDP_MAX_CONSOLE_ARGUMENTS)
+  for (let index = 0; index < argumentCount && remaining > 0; index++) {
+    if (index > 0) {
+      parts.push(' ')
+      remaining -= 1
+      if (remaining <= 0) {
+        break
+      }
+    }
+    const raw = consoleArgumentText(args[index])
+    const value = truncateCdpField(raw, remaining)
+    parts.push(value)
+    remaining -= value.length
+  }
+  return {
+    level: truncateCdpField(event.type ?? 'log', CDP_MAX_LEVEL_CODE_UNITS),
+    text: parts.join(''),
+    timestamp: event.timestamp ?? Date.now(),
+    url: truncateOptionalCdpField(
+      event.stackTrace?.callFrames?.[0]?.url,
+      CDP_MAX_CAPTURE_URL_CODE_UNITS
+    ),
+    line: event.stackTrace?.callFrames?.[0]?.lineNumber
+  }
+}
+
+export function buildBoundedCdpNetworkEntry(
+  response: { url?: string; status?: number; mimeType?: string },
+  timestamp?: number
+): BrowserNetworkEntry {
+  return {
+    url: truncateCdpField(response.url ?? '', CDP_MAX_CAPTURE_URL_CODE_UNITS),
+    method: '',
+    status: response.status ?? 0,
+    mimeType: truncateCdpField(response.mimeType ?? '', CDP_MAX_MIME_TYPE_CODE_UNITS),
+    size: 0,
+    timestamp: timestamp ?? Date.now()
+  }
+}
+
+export function buildBoundedCdpInterceptedRequest(
+  event: InterceptedRequestEvent
+): BrowserInterceptedRequest | null {
+  let remaining = CDP_MAX_INTERCEPTED_METADATA_CODE_UNITS
+  const reserve = (value: string): boolean => {
+    if (value.length > remaining) {
+      return false
+    }
+    remaining -= value.length
+    return true
+  }
+  const url = event.request.url ?? ''
+  const method = event.request.method ?? 'GET'
+  const resourceType = event.resourceType ?? 'Other'
+  if (![event.requestId, url, method, resourceType].every(reserve)) {
+    return null
+  }
+
+  const headers: Record<string, string> = Object.create(null) as Record<string, string>
+  let headerCount = 0
+  for (const name in event.request.headers ?? {}) {
+    if (!Object.hasOwn(event.request.headers ?? {}, name)) {
+      continue
+    }
+    const value = event.request.headers![name]
+    if (
+      headerCount >= CDP_MAX_INTERCEPTED_HEADERS ||
+      typeof value !== 'string' ||
+      !reserve(name) ||
+      !reserve(value)
+    ) {
+      return null
+    }
+    headers[name] = value
+    headerCount += 1
+  }
+  return { id: event.requestId, url, method, headers, resourceType }
+}
+
+export function isBoundedCdpIframeSession(frameId: string, sessionId: string): boolean {
+  return (
+    frameId.length <= CDP_MAX_SESSION_ID_CODE_UNITS &&
+    sessionId.length <= CDP_MAX_SESSION_ID_CODE_UNITS
+  )
+}
+
+function consoleArgumentText(arg: { value?: unknown; description?: unknown } | undefined): string {
+  const value = arg?.value ?? arg?.description ?? ''
+  if (typeof value === 'string') {
+    return value
+  }
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value)
+  }
+  return ''
+}
+
+function truncateOptionalCdpField(
+  value: string | undefined,
+  maxLength: number
+): string | undefined {
+  return value === undefined ? undefined : truncateCdpField(value, maxLength)
+}
+
+function truncateCdpField(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value
+  }
+  return `${value.slice(0, Math.max(0, maxLength - 1))}…`
+}

--- a/src/main/browser/cdp-print-to-pdf.test.ts
+++ b/src/main/browser/cdp-print-to-pdf.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { buildPrintToPdfOptions, CdpPdfStreamStore } from './cdp-print-to-pdf'
+import {
+  buildPrintToPdfOptions,
+  CDP_PDF_MAX_RETAINED_STREAMS,
+  CDP_PDF_MEMORY_LIMIT_ERROR,
+  CdpPdfRetentionBudget,
+  CdpPdfStreamStore
+} from './cdp-print-to-pdf'
+import type { CdpPdfStreamStoreOptions } from './cdp-print-to-pdf'
 
 const DEFAULT_MARGIN_INCHES = 1 / 2.54
 const TTL_MS = 5 * 60 * 1000
+const stores = new Set<CdpPdfStreamStore>()
+
+function createStore(options: CdpPdfStreamStoreOptions = {}): CdpPdfStreamStore {
+  const store = new CdpPdfStreamStore(options)
+  stores.add(store)
+  return store
+}
 
 describe('buildPrintToPdfOptions', () => {
   it('returns empty options for empty params', () => {
@@ -78,11 +92,15 @@ describe('buildPrintToPdfOptions', () => {
 
 describe('CdpPdfStreamStore', () => {
   afterEach(() => {
+    for (const store of stores) {
+      store.clear()
+    }
+    stores.clear()
     vi.useRealTimers()
   })
 
   it('claims only its own handles', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('pdf'))
 
     expect(store.ownsHandle({ handle })).toBe(true)
@@ -93,12 +111,12 @@ describe('CdpPdfStreamStore', () => {
   })
 
   it('mints distinct handles per stream', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     expect(store.create(Buffer.from('a'))).not.toBe(store.create(Buffer.from('b')))
   })
 
   it('reads sequential chunks and reports eof', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('abcdef'))
 
     expect(store.read({ handle, size: 2 })).toEqual({
@@ -112,7 +130,7 @@ describe('CdpPdfStreamStore', () => {
   })
 
   it('honors an explicit read offset', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('abcdef'))
 
     expect(store.read({ handle, offset: 4 })).toEqual({
@@ -122,20 +140,20 @@ describe('CdpPdfStreamStore', () => {
   })
 
   it('returns an empty eof chunk when reading past the end', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('abc'))
 
     expect(store.read({ handle, offset: 99 })).toEqual({ data: '', eof: true })
   })
 
   it('returns null for unknown handles', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     expect(store.read({ handle: 'nope' })).toBeNull()
     expect(store.read({})).toBeNull()
   })
 
   it('drops a stream on close', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('abc'))
 
     store.close({ handle })
@@ -143,7 +161,7 @@ describe('CdpPdfStreamStore', () => {
   })
 
   it('drops all streams on clear', () => {
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('abc'))
 
     store.clear()
@@ -152,7 +170,7 @@ describe('CdpPdfStreamStore', () => {
 
   it('evicts an abandoned stream after the TTL', () => {
     vi.useFakeTimers()
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('abc'))
 
     vi.advanceTimersByTime(TTL_MS + 1)
@@ -161,12 +179,75 @@ describe('CdpPdfStreamStore', () => {
 
   it('refreshes the TTL on each read', () => {
     vi.useFakeTimers()
-    const store = new CdpPdfStreamStore()
+    const store = createStore()
     const handle = store.create(Buffer.from('abcdef'))
 
     vi.advanceTimersByTime(TTL_MS - 1)
     expect(store.read({ handle, size: 1 })).not.toBeNull()
     vi.advanceTimersByTime(TTL_MS - 1)
     expect(store.read({ handle, size: 1 })).not.toBeNull()
+  })
+
+  it('rejects aggregate stream retention past its count or byte budget', () => {
+    const store = createStore({ maxStreams: 2, maxRetainedBytes: 5 })
+    const first = store.create(Buffer.from('ab'))
+    store.create(Buffer.from('cde'))
+
+    expect(() => store.create(Buffer.alloc(0))).toThrow(CDP_PDF_MEMORY_LIMIT_ERROR)
+    store.close({ handle: first })
+    expect(() => store.create(Buffer.from('fg'))).not.toThrow()
+    expect(() => createStore({ maxRetainedBytes: 5 }).create(Buffer.alloc(6))).toThrow(
+      CDP_PDF_MEMORY_LIMIT_ERROR
+    )
+    store.clear()
+  })
+
+  it('clamps oversized IO.read requests to a bounded base64 chunk', () => {
+    const store = createStore({ maxReadChunkBytes: 2 })
+    const handle = store.create(Buffer.from('abcdef'))
+
+    expect(store.read({ handle, size: Number.MAX_SAFE_INTEGER })).toEqual({
+      data: Buffer.from('ab').toString('base64'),
+      eof: false
+    })
+    store.clear()
+  })
+
+  it('shares the default retained-stream cap across independent proxy stores', () => {
+    const admitted = Array.from({ length: CDP_PDF_MAX_RETAINED_STREAMS }, () => {
+      const store = createStore()
+      return { handle: store.create(Buffer.alloc(0)), store }
+    })
+    const overflow = createStore()
+
+    expect(() => overflow.create(Buffer.alloc(0))).toThrow(CDP_PDF_MEMORY_LIMIT_ERROR)
+
+    admitted[0]!.store.close({ handle: admitted[0]!.handle })
+    expect(() => overflow.create(Buffer.alloc(0))).not.toThrow()
+  })
+
+  it('releases a shared byte budget on close, expiry, clear, and failed admission', () => {
+    vi.useFakeTimers()
+    const budget = new CdpPdfRetentionBudget(4, 5)
+    const first = createStore({ maxRetainedBytes: 5, retentionBudget: budget })
+    const second = createStore({ maxRetainedBytes: 5, retentionBudget: budget })
+    const firstHandle = first.create(Buffer.from('abc'))
+    const secondHandle = second.create(Buffer.from('de'))
+
+    expect(budget.inspect()).toEqual({ retainedBytes: 5, retainedStreams: 2 })
+    expect(() => second.create(Buffer.from('f'))).toThrow(CDP_PDF_MEMORY_LIMIT_ERROR)
+    expect(budget.inspect()).toEqual({ retainedBytes: 5, retainedStreams: 2 })
+
+    first.close({ handle: firstHandle })
+    expect(budget.inspect()).toEqual({ retainedBytes: 2, retainedStreams: 1 })
+    second.close({ handle: secondHandle })
+    const expiring = first.create(Buffer.from('xy'))
+    expect(first.read({ handle: expiring })).not.toBeNull()
+    vi.advanceTimersByTime(TTL_MS + 1)
+    expect(budget.inspect()).toEqual({ retainedBytes: 0, retainedStreams: 0 })
+
+    first.create(Buffer.from('z'))
+    first.clear()
+    expect(budget.inspect()).toEqual({ retainedBytes: 0, retainedStreams: 0 })
   })
 })

--- a/src/main/browser/cdp-print-to-pdf.ts
+++ b/src/main/browser/cdp-print-to-pdf.ts
@@ -5,6 +5,9 @@ const PDF_DEFAULT_MARGIN_INCHES = 1 / 2.54
 const PDF_STREAM_CHUNK_BYTES = 1024 * 1024
 const PDF_STREAM_HANDLE_PREFIX = 'orca-pdf-'
 const PDF_STREAM_TTL_MS = 5 * 60 * 1000
+export const CDP_PDF_MAX_RETAINED_STREAMS = 8
+export const CDP_PDF_MAX_RETAINED_BYTES = 64 * 1024 * 1024
+export const CDP_PDF_MEMORY_LIMIT_ERROR = 'PDF exceeds the browser automation memory limit'
 
 function finiteNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
@@ -80,12 +83,64 @@ type PdfStream = {
   data: Buffer
   offset: number
   cleanupTimer: ReturnType<typeof setTimeout>
+  releaseRetention: () => void
 }
 
 export type PdfStreamChunk = {
   data: string
   eof: boolean
 }
+
+export type CdpPdfStreamStoreOptions = {
+  maxStreams?: number
+  maxRetainedBytes?: number
+  maxReadChunkBytes?: number
+  retentionBudget?: CdpPdfRetentionBudget
+}
+
+export function assertCdpPdfWithinMemoryLimit(data: Buffer): void {
+  if (data.length > CDP_PDF_MAX_RETAINED_BYTES) {
+    throw new Error(CDP_PDF_MEMORY_LIMIT_ERROR)
+  }
+}
+
+export class CdpPdfRetentionBudget {
+  private retainedBytes = 0
+  private retainedStreams = 0
+
+  constructor(
+    private readonly maxStreams = CDP_PDF_MAX_RETAINED_STREAMS,
+    private readonly maxRetainedBytes = CDP_PDF_MAX_RETAINED_BYTES
+  ) {}
+
+  retain(bytes: number): (() => void) | null {
+    if (
+      !Number.isSafeInteger(bytes) ||
+      bytes < 0 ||
+      this.retainedStreams >= this.maxStreams ||
+      this.retainedBytes + bytes > this.maxRetainedBytes
+    ) {
+      return null
+    }
+    this.retainedStreams += 1
+    this.retainedBytes += bytes
+    let released = false
+    return () => {
+      if (released) {
+        return
+      }
+      released = true
+      this.retainedStreams = Math.max(0, this.retainedStreams - 1)
+      this.retainedBytes = Math.max(0, this.retainedBytes - bytes)
+    }
+  }
+
+  inspect(): { retainedBytes: number; retainedStreams: number } {
+    return { retainedBytes: this.retainedBytes, retainedStreams: this.retainedStreams }
+  }
+}
+
+const processPdfRetentionBudget = new CdpPdfRetentionBudget()
 
 /**
  * Holds the PDF buffers produced for CDP `transferMode: "ReturnAsStream"` and
@@ -97,7 +152,25 @@ export type PdfStreamChunk = {
 export class CdpPdfStreamStore {
   private readonly streams = new Map<string, PdfStream>()
   private readonly handlePrefix = `${PDF_STREAM_HANDLE_PREFIX}${randomUUID()}-`
+  private readonly maxStreams: number
+  private readonly maxRetainedBytes: number
+  private readonly maxReadChunkBytes: number
+  private readonly retentionBudget: CdpPdfRetentionBudget
   private nextId = 0
+  private retainedBytes = 0
+
+  constructor(options: CdpPdfStreamStoreOptions = {}) {
+    this.maxStreams = Math.max(0, Math.floor(options.maxStreams ?? CDP_PDF_MAX_RETAINED_STREAMS))
+    this.maxRetainedBytes = Math.max(
+      0,
+      Math.floor(options.maxRetainedBytes ?? CDP_PDF_MAX_RETAINED_BYTES)
+    )
+    this.maxReadChunkBytes = Math.max(
+      1,
+      Math.floor(options.maxReadChunkBytes ?? PDF_STREAM_CHUNK_BYTES)
+    )
+    this.retentionBudget = options.retentionBudget ?? processPdfRetentionBudget
+  }
 
   /** True when `params.handle` names one of this store's streams. */
   ownsHandle(params: Record<string, unknown>): boolean {
@@ -105,12 +178,30 @@ export class CdpPdfStreamStore {
   }
 
   create(data: Buffer): string {
+    if (
+      data.length > this.maxRetainedBytes ||
+      this.streams.size >= this.maxStreams ||
+      this.retainedBytes + data.length > this.maxRetainedBytes
+    ) {
+      throw new Error(CDP_PDF_MEMORY_LIMIT_ERROR)
+    }
+    const releaseRetention = this.retentionBudget.retain(data.length)
+    if (!releaseRetention) {
+      throw new Error(CDP_PDF_MEMORY_LIMIT_ERROR)
+    }
     const handle = `${this.handlePrefix}${++this.nextId}`
-    this.streams.set(handle, {
-      data,
-      offset: 0,
-      cleanupTimer: this.scheduleCleanup(handle)
-    })
+    let cleanupTimer: ReturnType<typeof setTimeout> | null = null
+    try {
+      cleanupTimer = this.scheduleCleanup(handle)
+      this.streams.set(handle, { data, offset: 0, cleanupTimer, releaseRetention })
+    } catch (error) {
+      if (cleanupTimer) {
+        clearTimeout(cleanupTimer)
+      }
+      releaseRetention()
+      throw error
+    }
+    this.retainedBytes += data.length
     return handle
   }
 
@@ -130,8 +221,8 @@ export class CdpPdfStreamStore {
     const requestedSize = finiteNumber(params.size)
     const size =
       requestedSize !== null && requestedSize > 0
-        ? Math.floor(requestedSize)
-        : PDF_STREAM_CHUNK_BYTES
+        ? Math.min(Math.floor(requestedSize), this.maxReadChunkBytes)
+        : this.maxReadChunkBytes
     const start = Math.min(stream.offset, stream.data.length)
     const end = Math.min(start + size, stream.data.length)
     const chunk = stream.data.subarray(start, end)
@@ -146,10 +237,9 @@ export class CdpPdfStreamStore {
   }
 
   clear(): void {
-    for (const stream of this.streams.values()) {
-      clearTimeout(stream.cleanupTimer)
+    for (const handle of this.streams.keys()) {
+      this.delete(handle)
     }
-    this.streams.clear()
   }
 
   private scheduleCleanup(handle: string): ReturnType<typeof setTimeout> {
@@ -173,5 +263,7 @@ export class CdpPdfStreamStore {
     }
     clearTimeout(stream.cleanupTimer)
     this.streams.delete(handle)
+    this.retainedBytes = Math.max(0, this.retainedBytes - stream.data.length)
+    stream.releaseRetention()
   }
 }

--- a/src/main/browser/cdp-screenshot.test.ts
+++ b/src/main/browser/cdp-screenshot.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { captureFullPageScreenshot, captureScreenshot } from './cdp-screenshot'
+import { resetBrowserScreenshotAdmissionForTests } from './browser-screenshot-admission'
+import {
+  BROWSER_SCREENSHOT_BUSY_ERROR,
+  BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES,
+  BROWSER_SCREENSHOT_MAX_DIMENSION_PX,
+  BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+} from './browser-screenshot-limits'
 
 function createMockWebContents() {
   return {
+    once: vi.fn(),
+    removeListener: vi.fn(),
     isDestroyed: vi.fn(() => false),
     invalidate: vi.fn(),
     capturePage: vi.fn(),
@@ -16,6 +25,7 @@ function createMockWebContents() {
 
 describe('captureScreenshot', () => {
   afterEach(() => {
+    resetBrowserScreenshotAdmissionForTests()
     vi.useRealTimers()
   })
 
@@ -36,6 +46,102 @@ describe('captureScreenshot', () => {
     expect(onError).not.toHaveBeenCalled()
   })
 
+  it('rejects concurrent capture overload without retaining another native promise', async () => {
+    const webContents = createMockWebContents()
+    const resolvers: ((result: { data: string }) => void)[] = []
+    webContents.debugger.sendCommand.mockImplementation(
+      () =>
+        new Promise<{ data: string }>((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    const results = Array.from({ length: BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES + 1 }, () =>
+      vi.fn()
+    )
+    const errors = results.map(() => vi.fn())
+
+    for (let index = 0; index < results.length; index += 1) {
+      captureScreenshot(webContents as never, { format: 'png' }, results[index]!, errors[index]!)
+    }
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(webContents.debugger.sendCommand).toHaveBeenCalledTimes(
+      BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES
+    )
+    expect(errors.at(-1)).toHaveBeenCalledWith(BROWSER_SCREENSHOT_BUSY_ERROR)
+    for (const resolve of resolvers) {
+      resolve({ data: 'cG5n' })
+    }
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(
+      results
+        .slice(0, BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES)
+        .every((callback) => callback.mock.calls.length === 1)
+    ).toBe(true)
+  })
+
+  it('keeps timed-out native captures admitted until Chromium actually settles', async () => {
+    vi.useFakeTimers()
+    const webContents = createMockWebContents()
+    webContents.debugger.sendCommand.mockImplementation(() => new Promise(() => {}))
+    webContents.capturePage.mockResolvedValue({
+      isEmpty: () => false,
+      getSize: () => ({ width: 800, height: 600 }),
+      toPNG: () => Buffer.from('fallback-png')
+    })
+    const results = Array.from({ length: BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES }, () =>
+      vi.fn()
+    )
+    const errors = results.map(() => vi.fn())
+
+    for (let index = 0; index < results.length; index += 1) {
+      captureScreenshot(webContents as never, { format: 'png' }, results[index]!, errors[index]!)
+    }
+    await vi.advanceTimersByTimeAsync(8000)
+
+    expect(results.every((callback) => callback.mock.calls.length === 0)).toBe(true)
+    expect(
+      errors.every((callback) => callback.mock.calls[0]?.[0] === BROWSER_SCREENSHOT_BUSY_ERROR)
+    ).toBe(true)
+    expect(webContents.capturePage).not.toHaveBeenCalled()
+    const overloadError = vi.fn()
+    captureScreenshot(webContents as never, { format: 'png' }, vi.fn(), overloadError)
+    expect(overloadError).toHaveBeenCalledWith(BROWSER_SCREENSHOT_BUSY_ERROR)
+    expect(webContents.debugger.sendCommand).toHaveBeenCalledTimes(
+      BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES
+    )
+  })
+
+  it('retains admission for a fallback that outlives the failed CDP capture', async () => {
+    vi.useFakeTimers()
+    const webContents = createMockWebContents()
+    const commandRejectors: ((error: Error) => void)[] = []
+    webContents.debugger.sendCommand.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          commandRejectors.push(reject)
+        })
+    )
+    webContents.capturePage.mockImplementation(() => new Promise(() => {}))
+    const firstError = vi.fn()
+
+    captureScreenshot(webContents as never, { format: 'png' }, vi.fn(), firstError)
+    await vi.advanceTimersByTimeAsync(8000)
+    commandRejectors[0]!(new Error('CDP failed after timeout'))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(firstError).toHaveBeenCalledWith('CDP failed after timeout')
+    const secondError = vi.fn()
+    captureScreenshot(webContents as never, { format: 'png' }, vi.fn(), secondError)
+    await vi.advanceTimersByTimeAsync(8000)
+
+    expect(secondError).toHaveBeenCalledWith(BROWSER_SCREENSHOT_BUSY_ERROR)
+    expect(webContents.capturePage).toHaveBeenCalledOnce()
+  })
+
   it('falls back to capturePage when Page.captureScreenshot stalls', async () => {
     vi.useFakeTimers()
 
@@ -43,6 +149,7 @@ describe('captureScreenshot', () => {
     webContents.debugger.sendCommand.mockImplementation(() => new Promise(() => {}))
     webContents.capturePage.mockResolvedValueOnce({
       isEmpty: () => false,
+      getSize: () => ({ width: 800, height: 600 }),
       toPNG: () => Buffer.from('fallback-png')
     })
     const onResult = vi.fn()
@@ -63,6 +170,7 @@ describe('captureScreenshot', () => {
 
     const croppedImage = {
       isEmpty: () => false,
+      getSize: () => ({ width: 60, height: 80 }),
       toPNG: () => Buffer.from('cropped-png')
     }
     const webContents = createMockWebContents()
@@ -125,6 +233,47 @@ describe('captureScreenshot', () => {
     expect(onError).toHaveBeenCalledWith(
       'Screenshot timed out — the browser tab may not be visible or the window may not have focus.'
     )
+  })
+
+  it('rejects an oversized clip before asking Chromium to capture it', () => {
+    const webContents = createMockWebContents()
+    const onResult = vi.fn()
+    const onError = vi.fn()
+
+    captureScreenshot(
+      webContents as never,
+      {
+        format: 'png',
+        clip: { x: 0, y: 0, width: BROWSER_SCREENSHOT_MAX_DIMENSION_PX + 1, height: 1 }
+      },
+      onResult,
+      onError
+    )
+
+    expect(onError).toHaveBeenCalledWith(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+    expect(onResult).not.toHaveBeenCalled()
+    expect(webContents.debugger.sendCommand).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized fallback bitmap before encoding it', async () => {
+    vi.useFakeTimers()
+    const toPNG = vi.fn(() => Buffer.from('unused'))
+    const webContents = createMockWebContents()
+    webContents.debugger.sendCommand.mockImplementation(() => new Promise(() => {}))
+    webContents.capturePage.mockResolvedValueOnce({
+      isEmpty: () => false,
+      getSize: () => ({ width: BROWSER_SCREENSHOT_MAX_DIMENSION_PX + 1, height: 1 }),
+      toPNG
+    })
+    const onResult = vi.fn()
+    const onError = vi.fn()
+
+    captureScreenshot(webContents as never, { format: 'png' }, onResult, onError)
+    await vi.advanceTimersByTimeAsync(8000)
+
+    expect(onError).toHaveBeenCalledWith(BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+    expect(onResult).not.toHaveBeenCalled()
+    expect(toPNG).not.toHaveBeenCalled()
   })
 
   it('ignores the fallback result when CDP settles first after the timeout fires', async () => {
@@ -237,6 +386,11 @@ describe('captureScreenshot', () => {
 })
 
 describe('captureFullPageScreenshot', () => {
+  afterEach(() => {
+    resetBrowserScreenshotAdmissionForTests()
+    vi.useRealTimers()
+  })
+
   it('uses cssContentSize so HiDPI pages are captured at the real page size', async () => {
     const webContents = createMockWebContents()
     webContents.debugger.sendCommand.mockImplementation((method: string) => {
@@ -287,5 +441,44 @@ describe('captureFullPageScreenshot', () => {
       captureBeyondViewport: true,
       clip: { x: 0, y: 0, width: 800, height: 1600, scale: 1 }
     })
+  })
+
+  it('rejects oversized full-page layout bounds before capture allocation', async () => {
+    const webContents = createMockWebContents()
+    webContents.debugger.sendCommand.mockResolvedValueOnce({
+      cssContentSize: { width: BROWSER_SCREENSHOT_MAX_DIMENSION_PX + 1, height: 1 }
+    })
+
+    await expect(captureFullPageScreenshot(webContents as never, 'png')).rejects.toThrow(
+      BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+    )
+    expect(webContents.debugger.sendCommand).toHaveBeenCalledOnce()
+    expect(webContents.debugger.sendCommand).toHaveBeenCalledWith('Page.getLayoutMetrics', {})
+  })
+
+  it('bounds hung full-page metric commands across logical timeouts', async () => {
+    vi.useFakeTimers()
+    const webContents = createMockWebContents()
+    webContents.debugger.sendCommand.mockImplementation(() => new Promise(() => {}))
+    const active = Array.from({ length: BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES }, () =>
+      captureFullPageScreenshot(webContents as never, 'png')
+    )
+    const activeAssertions = active.map((capture) =>
+      expect(capture).rejects.toThrow(
+        'Screenshot timed out — the browser tab may not be visible or the window may not have focus.'
+      )
+    )
+
+    await expect(captureFullPageScreenshot(webContents as never, 'png')).rejects.toThrow(
+      BROWSER_SCREENSHOT_BUSY_ERROR
+    )
+    await vi.advanceTimersByTimeAsync(8000)
+    await Promise.all(activeAssertions)
+    await expect(captureFullPageScreenshot(webContents as never, 'png')).rejects.toThrow(
+      BROWSER_SCREENSHOT_BUSY_ERROR
+    )
+    expect(webContents.debugger.sendCommand).toHaveBeenCalledTimes(
+      BROWSER_SCREENSHOT_MAX_CONCURRENT_CAPTURES
+    )
   })
 })

--- a/src/main/browser/cdp-screenshot.ts
+++ b/src/main/browser/cdp-screenshot.ts
@@ -1,83 +1,20 @@
 import type { WebContents } from 'electron'
+import {
+  assertBrowserScreenshotBase64,
+  assertBrowserScreenshotGeometry,
+  BROWSER_SCREENSHOT_BUSY_ERROR,
+  BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+} from './browser-screenshot-limits'
+import {
+  startBrowserFallbackCapture,
+  startBrowserScreenshotCommand
+} from './browser-screenshot-admission'
+import { encodeNativeImageScreenshot } from './native-image-screenshot-encoder'
 
 const SCREENSHOT_TIMEOUT_MS = 8000
 const FALLBACK_CAPTURE_TIMEOUT_MS = 1000
 const SCREENSHOT_TIMEOUT_MESSAGE =
   'Screenshot timed out — the browser tab may not be visible or the window may not have focus.'
-
-function applyFallbackClip(
-  image: Electron.NativeImage,
-  params: Record<string, unknown> | undefined
-): Electron.NativeImage | null {
-  if (params?.captureBeyondViewport) {
-    // Why: capturePage() can only see the currently painted viewport. If the
-    // caller asked for beyond-viewport pixels, returning a viewport-sized image
-    // would silently lie about what was captured.
-    return null
-  }
-
-  const clip = params?.clip
-  if (!clip || typeof clip !== 'object') {
-    return image
-  }
-  const clipRect = clip as Record<string, unknown>
-
-  const x = typeof clipRect.x === 'number' ? clipRect.x : Number.NaN
-  const y = typeof clipRect.y === 'number' ? clipRect.y : Number.NaN
-  const width = typeof clipRect.width === 'number' ? clipRect.width : Number.NaN
-  const height = typeof clipRect.height === 'number' ? clipRect.height : Number.NaN
-  const scale =
-    typeof clipRect.scale === 'number' && Number.isFinite(clipRect.scale) && clipRect.scale > 0
-      ? clipRect.scale
-      : 1
-
-  if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) {
-    return null
-  }
-
-  const cropRect = {
-    x: Math.round(x * scale),
-    y: Math.round(y * scale),
-    width: Math.round(width * scale),
-    height: Math.round(height * scale)
-  }
-  const imageSize = image.getSize()
-  if (
-    cropRect.x < 0 ||
-    cropRect.y < 0 ||
-    cropRect.width <= 0 ||
-    cropRect.height <= 0 ||
-    cropRect.x + cropRect.width > imageSize.width ||
-    cropRect.y + cropRect.height > imageSize.height
-  ) {
-    return null
-  }
-
-  return image.crop(cropRect)
-}
-
-function encodeNativeImageScreenshot(
-  image: Electron.NativeImage,
-  params: Record<string, unknown> | undefined
-): { data: string } | null {
-  if (image.isEmpty()) {
-    return null
-  }
-
-  const clippedImage = applyFallbackClip(image, params)
-  if (!clippedImage || clippedImage.isEmpty()) {
-    return null
-  }
-
-  const format = params?.format === 'jpeg' ? 'jpeg' : 'png'
-  const quality =
-    typeof params?.quality === 'number' && Number.isFinite(params.quality)
-      ? Math.max(0, Math.min(100, Math.round(params.quality)))
-      : undefined
-  const buffer = format === 'jpeg' ? clippedImage.toJPEG(quality ?? 90) : clippedImage.toPNG()
-  return { data: buffer.toString('base64') }
-}
-
 function getLayoutClip(metrics: {
   cssContentSize?: { width?: number; height?: number }
   contentSize?: { width?: number; height?: number }
@@ -100,25 +37,31 @@ function getLayoutClip(metrics: {
     return null
   }
 
-  return {
+  const clip = {
     x: 0,
     y: 0,
     width: Math.ceil(width),
     height: Math.ceil(height),
     scale: 1
   }
+  assertBrowserScreenshotGeometry(clip.width, clip.height)
+  return clip
 }
 
 async function sendCommandWithTimeout<T>(
   webContents: WebContents,
-  method: string,
+  method: 'Page.captureScreenshot' | 'Page.getLayoutMetrics',
   params: Record<string, unknown> | undefined,
   timeoutMessage: string
 ): Promise<T> {
+  const command = startBrowserScreenshotCommand<T>(webContents, method, params ?? {})
+  if (!command) {
+    throw new Error(BROWSER_SCREENSHOT_BUSY_ERROR)
+  }
   let timer: NodeJS.Timeout | null = null
   try {
     return await Promise.race([
-      webContents.debugger.sendCommand(method, params ?? {}) as Promise<T>,
+      command,
       new Promise<T>((_, reject) => {
         timer = setTimeout(() => reject(new Error(timeoutMessage)), SCREENSHOT_TIMEOUT_MS)
       })
@@ -160,15 +103,25 @@ export async function captureFullPageScreenshot(
   const { data } = await sendCommandWithTimeout<{ data: string }>(
     webContents,
     'Page.captureScreenshot',
-    {
-      format,
-      captureBeyondViewport: true,
-      clip
-    },
+    { format, captureBeyondViewport: true, clip },
     SCREENSHOT_TIMEOUT_MESSAGE
   )
+  assertBrowserScreenshotBase64(data)
 
   return { data, format }
+}
+
+function assertCaptureClipWithinLimit(params: Record<string, unknown> | undefined): void {
+  const clip = params?.clip
+  if (!clip || typeof clip !== 'object') {
+    return
+  }
+  const values = clip as Record<string, unknown>
+  if (typeof values.width !== 'number' || typeof values.height !== 'number') {
+    return
+  }
+  const scale = typeof values.scale === 'number' ? values.scale : 1
+  assertBrowserScreenshotGeometry(values.width, values.height, scale)
 }
 
 // Why: Electron's capturePage() is unreliable on webview guests — the compositor
@@ -192,7 +145,12 @@ export function captureScreenshot(
     onError('Debugger not attached')
     return
   }
-
+  try {
+    assertCaptureClipWithinLimit(params)
+  } catch (error) {
+    onError(error instanceof Error ? error.message : BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
+    return
+  }
   const screenshotParams: Record<string, unknown> = {}
   if (params?.format) {
     screenshotParams.format = params.format
@@ -208,6 +166,15 @@ export function captureScreenshot(
   }
   if (params?.fromSurface != null) {
     screenshotParams.fromSurface = params.fromSurface
+  }
+  const capture = startBrowserScreenshotCommand(
+    webContents,
+    'Page.captureScreenshot',
+    screenshotParams
+  )
+  if (!capture) {
+    onError(BROWSER_SCREENSHOT_BUSY_ERROR)
+    return
   }
 
   let settled = false
@@ -225,6 +192,16 @@ export function captureScreenshot(
   }
   const settleResult = (result: unknown): void => {
     if (settled) {
+      return
+    }
+    const data =
+      result && typeof result === 'object' ? (result as { data?: unknown }).data : undefined
+    try {
+      if (typeof data === 'string') {
+        assertBrowserScreenshotBase64(data)
+      }
+    } catch (error) {
+      settleError(error instanceof Error ? error.message : BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR)
       return
     }
     settled = true
@@ -257,42 +234,48 @@ export function captureScreenshot(
       () => settleError(SCREENSHOT_TIMEOUT_MESSAGE),
       FALLBACK_CAPTURE_TIMEOUT_MS
     )
-    void Promise.resolve()
-      .then(() => webContents.capturePage())
-      .then(
-        (image) => {
-          if (settled) {
-            return
-          }
-          if (fallbackTimer) {
-            clearTimeout(fallbackTimer)
-            fallbackTimer = null
-          }
-          let fallback: { data: string } | null = null
-          try {
-            fallback = encodeNativeImageScreenshot(image, params)
-          } catch {
-            settleError(SCREENSHOT_TIMEOUT_MESSAGE)
-            return
-          }
-          if (fallback) {
-            settleResult(fallback)
-            return
-          }
-          settleError(SCREENSHOT_TIMEOUT_MESSAGE)
-        },
-        () => {
-          if (fallbackTimer) {
-            clearTimeout(fallbackTimer)
-            fallbackTimer = null
-          }
-          settleError(SCREENSHOT_TIMEOUT_MESSAGE)
+    const fallbackCapture = startBrowserFallbackCapture(webContents)
+    if (!fallbackCapture) {
+      settleError(BROWSER_SCREENSHOT_BUSY_ERROR)
+      return
+    }
+    void fallbackCapture.then(
+      (image) => {
+        if (settled) {
+          return
         }
-      )
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer)
+          fallbackTimer = null
+        }
+        let fallback: { data: string } | null = null
+        try {
+          fallback = encodeNativeImageScreenshot(image, params)
+        } catch (error) {
+          settleError(
+            error instanceof Error && error.message === BROWSER_SCREENSHOT_MEMORY_LIMIT_ERROR
+              ? error.message
+              : SCREENSHOT_TIMEOUT_MESSAGE
+          )
+          return
+        }
+        if (fallback) {
+          settleResult(fallback)
+          return
+        }
+        settleError(SCREENSHOT_TIMEOUT_MESSAGE)
+      },
+      () => {
+        if (fallbackTimer) {
+          clearTimeout(fallbackTimer)
+          fallbackTimer = null
+        }
+        settleError(SCREENSHOT_TIMEOUT_MESSAGE)
+      }
+    )
   }, SCREENSHOT_TIMEOUT_MS)
 
-  dbg
-    .sendCommand('Page.captureScreenshot', screenshotParams)
+  void capture
     .then((result) => settleResult(result))
     .catch((err) => settleError((err as Error).message))
 }

--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import WebSocket from 'ws'
-import { CdpWsProxy } from './cdp-ws-proxy'
+import {
+  CDP_PROXY_MAX_MESSAGE_BYTES,
+  CDP_PROXY_MAX_TCP_CONNECTIONS,
+  CdpWsProxy
+} from './cdp-ws-proxy'
 import {
   connect,
   createMockWebContents,
@@ -50,6 +54,16 @@ describe('CdpWsProxy', () => {
     ).httpServer
 
     expect(server.listenerCount('error')).toBeLessThanOrEqual(1)
+  })
+
+  it('caps pre-upgrade sockets and WebSocket message materialization', () => {
+    const internals = proxy as unknown as {
+      httpServer: { maxConnections: number }
+      wss: { options: { maxPayload: number } }
+    }
+
+    expect(internals.httpServer.maxConnections).toBe(CDP_PROXY_MAX_TCP_CONNECTIONS)
+    expect(internals.wss.options.maxPayload).toBe(CDP_PROXY_MAX_MESSAGE_BYTES)
   })
 
   it('attaches debugger on start', () => {
@@ -742,6 +756,37 @@ describe('CdpWsProxy', () => {
 
     expect(createSpy).not.toHaveBeenCalled()
     createSpy.mockRestore()
+  })
+
+  it('rejects PDF print overload instead of retaining unlimited native promises', async () => {
+    const resolvePrints: ((buffer: Buffer<ArrayBuffer>) => void)[] = []
+    mock.webContents.printToPDF.mockImplementation(
+      () =>
+        new Promise<Buffer<ArrayBuffer>>((resolve) => {
+          resolvePrints.push(resolve)
+        })
+    )
+    const client = await connect(endpoint)
+    const responses: Record<string, unknown>[] = []
+    client.on('message', (data) => responses.push(JSON.parse(data.toString())))
+
+    for (let id = 31; id <= 33; id += 1) {
+      client.send(JSON.stringify({ id, method: 'Page.printToPDF' }))
+    }
+
+    await vi.waitFor(() =>
+      expect(responses.find((response) => response.id === 33)).toEqual({
+        id: 33,
+        error: { code: -32000, message: 'Too many PDF print requests are already running' }
+      })
+    )
+    expect(mock.webContents.printToPDF).toHaveBeenCalledTimes(2)
+
+    for (const resolve of resolvePrints) {
+      resolve(Buffer.from('%PDF-bounded'))
+    }
+    await vi.waitFor(() => expect(responses).toHaveLength(3))
+    client.close()
   })
 
   it('forwards non-PDF IO streams to the debugger', async () => {

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -3,11 +3,18 @@ import { WebSocketServer, WebSocket } from 'ws'
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'node:http'
 import type { WebContents } from 'electron'
 import { captureScreenshot } from './cdp-screenshot'
-import { buildPrintToPdfOptions, CdpPdfStreamStore } from './cdp-print-to-pdf'
+import {
+  assertCdpPdfWithinMemoryLimit,
+  buildPrintToPdfOptions,
+  CdpPdfStreamStore
+} from './cdp-print-to-pdf'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
+import { BROWSER_PDF_BUSY_ERROR, startBrowserPdfPrint } from './browser-pdf-admission'
 
 const LIFECYCLE_PRIMING_TIMEOUT_MS = 1_000
+export const CDP_PROXY_MAX_MESSAGE_BYTES = 16 * 1024 * 1024
+export const CDP_PROXY_MAX_TCP_CONNECTIONS = 16
 
 export class CdpWsProxy {
   // Why: holds each session's last DOM.focus params to replay right before the next
@@ -40,7 +47,12 @@ export class CdpWsProxy {
     await this.attachDebugger()
     return new Promise<string>((resolve, reject) => {
       this.httpServer = createServer((req, res) => this.handleHttpRequest(req, res))
-      this.wss = new WebSocketServer({ server: this.httpServer })
+      // Why: raw sockets that never upgrade must not bypass the proxy's single active WebSocket.
+      this.httpServer.maxConnections = CDP_PROXY_MAX_TCP_CONNECTIONS
+      this.wss = new WebSocketServer({
+        server: this.httpServer,
+        maxPayload: CDP_PROXY_MAX_MESSAGE_BYTES
+      })
       const failStart = (error: Error): void => {
         this.httpServer?.removeListener('error', onListenError)
         this.wss?.close()
@@ -635,8 +647,13 @@ export class CdpWsProxy {
       this.sendError(clientId, 'Browser tab is no longer available', client)
       return
     }
+    const print = startBrowserPdfPrint(this.webContents, buildPrintToPdfOptions(params))
+    if (!print) {
+      this.sendError(clientId, BROWSER_PDF_BUSY_ERROR, client)
+      return
+    }
     try {
-      const pdf = await this.webContents.printToPDF(buildPrintToPdfOptions(params))
+      const pdf = await print
       // Why: printToPDF can resolve after the client disconnected (or was
       // replaced). Bail before registering a stream so its buffer isn't
       // orphaned in pdfStreams past the disconnect's clear() until the TTL.
@@ -644,6 +661,7 @@ export class CdpWsProxy {
         return
       }
       const buffer = Buffer.isBuffer(pdf) ? pdf : Buffer.from(pdf)
+      assertCdpPdfWithinMemoryLimit(buffer)
       if (params.transferMode === 'ReturnAsStream') {
         const handle = this.pdfStreams.create(buffer)
         this.sendResult(clientId, { data: '', stream: handle }, client)

--- a/src/main/browser/installed-browser-cookie-store-limits.test.ts
+++ b/src/main/browser/installed-browser-cookie-store-limits.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertInstalledBrowserCookieStoreWithinLimits,
+  INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES,
+  INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES,
+  InstalledBrowserCookieStoreLimitError
+} from './installed-browser-cookie-store-limits'
+
+describe('assertInstalledBrowserCookieStoreWithinLimits', () => {
+  it('accepts the exact cookie-count and byte boundaries', () => {
+    expect(
+      assertInstalledBrowserCookieStoreWithinLimits(
+        BigInt(INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES),
+        BigInt(INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES)
+      )
+    ).toBe(INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES)
+  })
+
+  it.each([
+    {
+      kind: 'cookies',
+      cookies: INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES + 1,
+      bytes: INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES
+    },
+    {
+      kind: 'bytes',
+      cookies: INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES,
+      bytes: INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES + 1
+    }
+  ])('rejects one $kind over its boundary', ({ kind, cookies, bytes }) => {
+    expect(() => assertInstalledBrowserCookieStoreWithinLimits(cookies, bytes)).toThrow(
+      expect.objectContaining({
+        name: InstalledBrowserCookieStoreLimitError.name,
+        kind
+      })
+    )
+  })
+})

--- a/src/main/browser/installed-browser-cookie-store-limits.ts
+++ b/src/main/browser/installed-browser-cookie-store-limits.ts
@@ -1,0 +1,41 @@
+export const INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES = 250_000
+export const INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES = 64 * 1024 * 1024
+
+export type InstalledBrowserCookieStoreLimitKind = 'cookies' | 'bytes'
+
+export class InstalledBrowserCookieStoreLimitError extends Error {
+  constructor(
+    readonly kind: InstalledBrowserCookieStoreLimitKind,
+    readonly observed: number | bigint,
+    readonly limit: number
+  ) {
+    super(`Installed browser cookie store exceeds the ${kind} limit`)
+    this.name = 'InstalledBrowserCookieStoreLimitError'
+  }
+}
+
+export function assertInstalledBrowserCookieStoreWithinLimits(
+  cookieCount: number | bigint,
+  cookieBytes: number | bigint
+): number {
+  enforceLimit('cookies', cookieCount, INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES)
+  enforceLimit('bytes', cookieBytes, INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES)
+  return Number(cookieCount)
+}
+
+export function installedBrowserCookieStoreLimitReason(browserLabel: string): string {
+  return `${browserLabel} cookie store is too large to import safely (${INSTALLED_BROWSER_COOKIE_STORE_MAX_COOKIES.toLocaleString('en-US')}-cookie and ${INSTALLED_BROWSER_COOKIE_STORE_MAX_BYTES / 1024 / 1024} MiB cookie-data limits).`
+}
+
+function enforceLimit(
+  kind: InstalledBrowserCookieStoreLimitKind,
+  observed: number | bigint,
+  limit: number
+): void {
+  if (
+    (typeof observed === 'bigint' && observed > BigInt(limit)) ||
+    (typeof observed === 'number' && (!Number.isSafeInteger(observed) || observed > limit))
+  ) {
+    throw new InstalledBrowserCookieStoreLimitError(kind, observed, limit)
+  }
+}

--- a/src/main/browser/native-image-screenshot-encoder.ts
+++ b/src/main/browser/native-image-screenshot-encoder.ts
@@ -1,0 +1,79 @@
+import {
+  assertBrowserScreenshotEncodedBytes,
+  assertBrowserScreenshotGeometry
+} from './browser-screenshot-limits'
+
+function applyFallbackClip(
+  image: Electron.NativeImage,
+  params: Record<string, unknown> | undefined
+): Electron.NativeImage | null {
+  if (params?.captureBeyondViewport) {
+    // Why: capturePage cannot produce pixels outside the currently painted viewport.
+    return null
+  }
+
+  const clip = params?.clip
+  if (!clip || typeof clip !== 'object') {
+    return image
+  }
+  const clipRect = clip as Record<string, unknown>
+
+  const x = typeof clipRect.x === 'number' ? clipRect.x : Number.NaN
+  const y = typeof clipRect.y === 'number' ? clipRect.y : Number.NaN
+  const width = typeof clipRect.width === 'number' ? clipRect.width : Number.NaN
+  const height = typeof clipRect.height === 'number' ? clipRect.height : Number.NaN
+  const scale =
+    typeof clipRect.scale === 'number' && Number.isFinite(clipRect.scale) && clipRect.scale > 0
+      ? clipRect.scale
+      : 1
+
+  if (![x, y, width, height].every(Number.isFinite) || width <= 0 || height <= 0) {
+    return null
+  }
+
+  const cropRect = {
+    x: Math.round(x * scale),
+    y: Math.round(y * scale),
+    width: Math.round(width * scale),
+    height: Math.round(height * scale)
+  }
+  assertBrowserScreenshotGeometry(cropRect.width, cropRect.height)
+  const imageSize = image.getSize()
+  if (
+    cropRect.x < 0 ||
+    cropRect.y < 0 ||
+    cropRect.width <= 0 ||
+    cropRect.height <= 0 ||
+    cropRect.x + cropRect.width > imageSize.width ||
+    cropRect.y + cropRect.height > imageSize.height
+  ) {
+    return null
+  }
+
+  return image.crop(cropRect)
+}
+
+export function encodeNativeImageScreenshot(
+  image: Electron.NativeImage,
+  params: Record<string, unknown> | undefined
+): { data: string } | null {
+  if (image.isEmpty()) {
+    return null
+  }
+
+  const clippedImage = applyFallbackClip(image, params)
+  if (!clippedImage || clippedImage.isEmpty()) {
+    return null
+  }
+  const clippedSize = clippedImage.getSize()
+  assertBrowserScreenshotGeometry(clippedSize.width, clippedSize.height)
+
+  const format = params?.format === 'jpeg' ? 'jpeg' : 'png'
+  const quality =
+    typeof params?.quality === 'number' && Number.isFinite(params.quality)
+      ? Math.max(0, Math.min(100, Math.round(params.quality)))
+      : undefined
+  const buffer = format === 'jpeg' ? clippedImage.toJPEG(quality ?? 90) : clippedImage.toPNG()
+  assertBrowserScreenshotEncodedBytes(buffer.length)
+  return { data: buffer.toString('base64') }
+}

--- a/src/main/browser/safari-cookie-store-decoder.test.ts
+++ b/src/main/browser/safari-cookie-store-decoder.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+import {
+  decodeSafariCookieStore,
+  SAFARI_COOKIE_STORE_MAX_COOKIES,
+  SAFARI_COOKIE_STORE_MAX_FILE_BYTES,
+  SAFARI_COOKIE_STORE_MAX_PAGES,
+  SAFARI_COOKIE_STORE_MAX_PARSED_BYTES,
+  SafariCookieStoreLimitError,
+  removeExpiredSafariCookiesInPlace,
+  type SafariCookieDecodeLimits
+} from './safari-cookie-store-decoder'
+
+type TestCookie = {
+  domain: string
+  name: string
+  value: string
+  path?: string
+  secure?: boolean
+  httpOnly?: boolean
+  expiration?: number
+}
+
+function buildCookie(input: TestCookie): Buffer {
+  const strings = [input.domain, input.name, input.path ?? '/', input.value]
+  let cursor = 48
+  const offsets = strings.map((text) => {
+    const offset = cursor
+    cursor += Buffer.byteLength(text) + 1
+    return offset
+  })
+  const cookie = Buffer.alloc(cursor)
+  cookie.writeUInt32LE(cookie.length, 0)
+  cookie.writeUInt32LE((input.secure ? 1 : 0) | (input.httpOnly ? 4 : 0), 8)
+  cookie.writeUInt32LE(offsets[0]!, 16)
+  cookie.writeUInt32LE(offsets[1]!, 20)
+  cookie.writeUInt32LE(offsets[2]!, 24)
+  cookie.writeUInt32LE(offsets[3]!, 28)
+  cookie.writeDoubleLE(input.expiration ?? 0, 40)
+  strings.forEach((text, index) => cookie.write(text, offsets[index]!, 'utf8'))
+  return cookie
+}
+
+function buildPage(inputs: TestCookie[]): Buffer {
+  const cookies = inputs.map(buildCookie)
+  const headerBytes = 8 + cookies.length * 4
+  const page = Buffer.alloc(headerBytes + cookies.reduce((sum, cookie) => sum + cookie.length, 0))
+  page.writeUInt32BE(0x00000100, 0)
+  page.writeUInt32LE(cookies.length, 4)
+  let cursor = headerBytes
+  cookies.forEach((cookie, index) => {
+    page.writeUInt32LE(cursor, 8 + index * 4)
+    cookie.copy(page, cursor)
+    cursor += cookie.length
+  })
+  return page
+}
+
+function buildStore(pages: TestCookie[][]): Buffer {
+  const encodedPages = pages.map(buildPage)
+  const headerBytes = 8 + encodedPages.length * 4
+  const store = Buffer.alloc(headerBytes + encodedPages.reduce((sum, page) => sum + page.length, 0))
+  store.write('cook', 0, 'utf8')
+  store.writeUInt32BE(encodedPages.length, 4)
+  let cursor = headerBytes
+  encodedPages.forEach((page, index) => {
+    store.writeUInt32BE(page.length, 8 + index * 4)
+    page.copy(store, cursor)
+    cursor += page.length
+  })
+  return store
+}
+
+function limits(overrides: Partial<SafariCookieDecodeLimits> = {}): SafariCookieDecodeLimits {
+  return {
+    maxPages: 10,
+    maxCookies: 10,
+    maxParsedBytes: 1024,
+    ...overrides
+  }
+}
+
+function retainedBytes(cookie: TestCookie): number {
+  const cleanDomain = cookie.domain.startsWith('.') ? cookie.domain.slice(1) : cookie.domain
+  const url = `${cookie.secure ? 'https' : 'http'}://${cleanDomain}/`
+  return [url, cookie.domain, cookie.name, cookie.value, cookie.path ?? '/'].reduce(
+    (sum, value) => sum + Buffer.byteLength(value),
+    0
+  )
+}
+
+describe('decodeSafariCookieStore', () => {
+  it('preserves page order and removes expired cookies without a second retained list', () => {
+    const first = {
+      domain: '.first.example.com',
+      name: 'first',
+      value: 'one',
+      secure: true,
+      httpOnly: true
+    }
+    const expired = {
+      domain: '.expired.example.com',
+      name: 'expired',
+      value: 'old',
+      expiration: 1
+    }
+    const last = { domain: '.last.example.com', name: 'last', value: 'three' }
+
+    const result = decodeSafariCookieStore(buildStore([[first, expired], [last]]))
+    const originalList = result.cookies
+    removeExpiredSafariCookiesInPlace(result.cookies, 2_000_000_000)
+
+    expect(result.totalCookies).toBe(3)
+    expect(result.cookies).toBe(originalList)
+    expect(result.cookies.map((cookie) => cookie.name)).toEqual(['first', 'last'])
+    expect(result.cookies[0]).toMatchObject({
+      url: 'https://first.example.com/',
+      domain: '.first.example.com',
+      value: 'one',
+      path: '/',
+      secure: true,
+      httpOnly: true,
+      sameSite: 'unspecified'
+    })
+  })
+
+  it('accepts the exact cookie and parsed-byte boundaries', () => {
+    const first = { domain: '.a.example.com', name: 'a', value: 'one' }
+    const second = { domain: '.b.example.com', name: 'b', value: 'two' }
+    const maxParsedBytes = retainedBytes(first) + retainedBytes(second)
+
+    const result = decodeSafariCookieStore(
+      buildStore([[first, second]]),
+      limits({ maxCookies: 2, maxParsedBytes })
+    )
+
+    expect(result.cookies.map((cookie) => cookie.name)).toEqual(['a', 'b'])
+  })
+
+  it('rejects one cookie or parsed byte over the configured boundary', () => {
+    const first = { domain: '.a.example.com', name: 'a', value: 'one' }
+    const second = { domain: '.b.example.com', name: 'b', value: 'two' }
+    const store = buildStore([[first, second]])
+
+    expect(() => decodeSafariCookieStore(store, limits({ maxCookies: 1 }))).toThrow(
+      expect.objectContaining({ kind: 'cookies', observed: 2, limit: 1 })
+    )
+    expect(() =>
+      decodeSafariCookieStore(
+        store,
+        limits({ maxParsedBytes: retainedBytes(first) + retainedBytes(second) - 1 })
+      )
+    ).toThrow(
+      expect.objectContaining({
+        kind: 'parsed-bytes',
+        observed: retainedBytes(first) + retainedBytes(second)
+      })
+    )
+  })
+
+  it('counts malformed declared entries against the parse budget', () => {
+    const malformedPage = Buffer.alloc(20)
+    malformedPage.writeUInt32BE(0x00000100, 0)
+    malformedPage.writeUInt32LE(3, 4)
+    const header = Buffer.alloc(12)
+    header.write('cook', 0, 'utf8')
+    header.writeUInt32BE(1, 4)
+    header.writeUInt32BE(malformedPage.length, 8)
+
+    expect(() =>
+      decodeSafariCookieStore(Buffer.concat([header, malformedPage]), limits({ maxCookies: 2 }))
+    ).toThrow(SafariCookieStoreLimitError)
+  })
+
+  it('publishes generous production limits', () => {
+    expect({
+      fileBytes: SAFARI_COOKIE_STORE_MAX_FILE_BYTES,
+      pages: SAFARI_COOKIE_STORE_MAX_PAGES,
+      cookies: SAFARI_COOKIE_STORE_MAX_COOKIES,
+      parsedBytes: SAFARI_COOKIE_STORE_MAX_PARSED_BYTES
+    }).toEqual({
+      fileBytes: 64 * 1024 * 1024,
+      pages: 65_536,
+      cookies: 250_000,
+      parsedBytes: 64 * 1024 * 1024
+    })
+  })
+})

--- a/src/main/browser/safari-cookie-store-decoder.ts
+++ b/src/main/browser/safari-cookie-store-decoder.ts
@@ -1,0 +1,212 @@
+const MAC_EPOCH_DELTA_SECONDS = 978_307_200
+
+export const SAFARI_COOKIE_STORE_MAX_FILE_BYTES = 64 * 1024 * 1024
+export const SAFARI_COOKIE_STORE_MAX_PAGES = 65_536
+export const SAFARI_COOKIE_STORE_MAX_COOKIES = 250_000
+export const SAFARI_COOKIE_STORE_MAX_PARSED_BYTES = 64 * 1024 * 1024
+
+export type SafariCookieStoreLimitKind = 'pages' | 'cookies' | 'parsed-bytes'
+
+export class SafariCookieStoreLimitError extends Error {
+  constructor(
+    readonly kind: SafariCookieStoreLimitKind,
+    readonly observed: number,
+    readonly limit: number
+  ) {
+    super(`Safari cookie store exceeds the ${kind} limit`)
+    this.name = 'SafariCookieStoreLimitError'
+  }
+}
+
+export type SafariDecodedCookie = {
+  url: string
+  name: string
+  value: string
+  domain: string
+  path: string
+  secure: boolean
+  httpOnly: boolean
+  sameSite: 'unspecified'
+  expirationDate: number | undefined
+}
+
+export type SafariCookieDecodeResult = {
+  cookies: SafariDecodedCookie[]
+  totalCookies: number
+}
+
+export type SafariCookieDecodeLimits = {
+  maxPages: number
+  maxCookies: number
+  maxParsedBytes: number
+}
+
+const DEFAULT_LIMITS: SafariCookieDecodeLimits = {
+  maxPages: SAFARI_COOKIE_STORE_MAX_PAGES,
+  maxCookies: SAFARI_COOKIE_STORE_MAX_COOKIES,
+  maxParsedBytes: SAFARI_COOKIE_STORE_MAX_PARSED_BYTES
+}
+
+type DecodeState = {
+  readonly cookies: SafariDecodedCookie[]
+  readonly limits: SafariCookieDecodeLimits
+  decodedCookies: number
+  inspectedEntries: number
+  parsedBytes: number
+}
+
+export function decodeSafariCookieStore(
+  buffer: Buffer,
+  limits: SafariCookieDecodeLimits = DEFAULT_LIMITS
+): SafariCookieDecodeResult {
+  if (buffer.length < 8 || buffer.subarray(0, 4).toString('utf8') !== 'cook') {
+    return { cookies: [], totalCookies: 0 }
+  }
+
+  const pageCount = buffer.readUInt32BE(4)
+  enforceLimit('pages', pageCount, limits.maxPages)
+  const pagesOffset = 8 + pageCount * 4
+  if (pagesOffset > buffer.length) {
+    return { cookies: [], totalCookies: 0 }
+  }
+
+  const state: DecodeState = {
+    cookies: [],
+    limits,
+    decodedCookies: 0,
+    inspectedEntries: 0,
+    parsedBytes: 0
+  }
+  let pageOffset = pagesOffset
+  for (let pageIndex = 0; pageIndex < pageCount; pageIndex += 1) {
+    const pageSize = buffer.readUInt32BE(8 + pageIndex * 4)
+    const pageEnd = Math.min(buffer.length, pageOffset + pageSize)
+    decodeSafariCookiePage(buffer.subarray(pageOffset, pageEnd), state)
+    pageOffset += pageSize
+  }
+  return { cookies: state.cookies, totalCookies: state.decodedCookies }
+}
+
+function decodeSafariCookiePage(page: Buffer, state: DecodeState): void {
+  if (page.length < 16 || page.readUInt32BE(0) !== 0x00000100) {
+    return
+  }
+
+  const cookieCount = page.readUInt32LE(4)
+  state.inspectedEntries += cookieCount
+  enforceLimit('cookies', state.inspectedEntries, state.limits.maxCookies)
+  if (8 + cookieCount * 4 > page.length) {
+    return
+  }
+
+  for (let index = 0; index < cookieCount; index += 1) {
+    const offset = page.readUInt32LE(8 + index * 4)
+    const cookie = decodeSafariCookie(page.subarray(offset))
+    if (!cookie) {
+      continue
+    }
+    state.decodedCookies += 1
+    state.parsedBytes += cookieRetainedBytes(cookie)
+    enforceLimit('parsed-bytes', state.parsedBytes, state.limits.maxParsedBytes)
+    state.cookies.push(cookie)
+  }
+}
+
+export function removeExpiredSafariCookiesInPlace(
+  cookies: SafariDecodedCookie[],
+  nowSeconds: number
+): void {
+  let retained = 0
+  for (const cookie of cookies) {
+    if (!cookie.expirationDate || cookie.expirationDate > nowSeconds) {
+      cookies[retained] = cookie
+      retained += 1
+    }
+  }
+  cookies.length = retained
+}
+
+function decodeSafariCookie(buffer: Buffer): SafariDecodedCookie | null {
+  if (buffer.length < 48) {
+    return null
+  }
+  // Why: the declared size is external; clamp string scans to bytes present in this page.
+  const size = Math.min(buffer.readUInt32LE(0), buffer.length)
+  if (size < 48) {
+    return null
+  }
+
+  const flags = buffer.readUInt32LE(8)
+  const secure = (flags & 1) !== 0
+  const name = readCString(buffer, buffer.readUInt32LE(20), size)
+  if (!name) {
+    return null
+  }
+  const value = readCString(buffer, buffer.readUInt32LE(28), size) ?? ''
+  const path = readCString(buffer, buffer.readUInt32LE(24), size) ?? '/'
+  const rawUrl = readCString(buffer, buffer.readUInt32LE(16), size) ?? ''
+  const domain = rawUrl.startsWith('.') ? rawUrl : rawUrl || null
+  if (!domain) {
+    return null
+  }
+
+  const url = deriveUrl(domain, secure)
+  if (!url) {
+    return null
+  }
+  // Why: Safari stores expiration seconds relative to 2001-01-01.
+  const expiration = buffer.readDoubleLE(40)
+  const expirationDate =
+    expiration > 0 ? Math.round(expiration + MAC_EPOCH_DELTA_SECONDS) : undefined
+
+  return {
+    url,
+    name,
+    value,
+    domain,
+    path,
+    secure,
+    httpOnly: (flags & 4) !== 0,
+    sameSite: 'unspecified',
+    expirationDate
+  }
+}
+
+function readCString(buffer: Buffer, offset: number, end: number): string | null {
+  if (offset < 0 || offset >= end) {
+    return null
+  }
+  let cursor = offset
+  while (cursor < end && buffer[cursor] !== 0) {
+    cursor += 1
+  }
+  return cursor < end ? buffer.toString('utf8', offset, cursor) : null
+}
+
+function deriveUrl(domain: string, secure: boolean): string | null {
+  const cleanDomain = domain.startsWith('.') ? domain.slice(1) : domain
+  if (!cleanDomain || cleanDomain.includes(' ')) {
+    return null
+  }
+  try {
+    return new URL(`${secure ? 'https' : 'http'}://${cleanDomain}/`).toString()
+  } catch {
+    return null
+  }
+}
+
+function cookieRetainedBytes(cookie: SafariDecodedCookie): number {
+  return (
+    Buffer.byteLength(cookie.url) +
+    Buffer.byteLength(cookie.name) +
+    Buffer.byteLength(cookie.value) +
+    Buffer.byteLength(cookie.domain) +
+    Buffer.byteLength(cookie.path)
+  )
+}
+
+function enforceLimit(kind: SafariCookieStoreLimitKind, observed: number, limit: number): void {
+  if (observed > limit) {
+    throw new SafariCookieStoreLimitError(kind, observed, limit)
+  }
+}

--- a/src/main/browser/snapshot-engine.test.ts
+++ b/src/main/browser/snapshot-engine.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { buildSnapshot, type CdpCommandSender } from './snapshot-engine'
+import {
+  buildSnapshot,
+  SNAPSHOT_MAX_ENTRIES,
+  SNAPSHOT_MAX_NAME_CODE_UNITS,
+  SNAPSHOT_MAX_RETAINED_NAME_CODE_UNITS,
+  type CdpCommandSender
+} from './snapshot-engine'
 
 type AXNode = {
   nodeId: string
@@ -192,5 +198,47 @@ describe('buildSnapshot', () => {
     expect(result.snapshot).toContain('[Main Content]')
     expect(result.snapshot).toContain('[Footer]')
     expect(result.snapshot).toContain('heading "Dashboard"')
+  })
+
+  it('bounds retained entries and page-controlled accessible names', async () => {
+    const childIds = Array.from({ length: SNAPSHOT_MAX_ENTRIES + 100 }, (_, index) =>
+      String(index + 2)
+    )
+    const nodes: AXNode[] = [node('1', 'WebArea', 'page', { childIds })]
+    for (const childId of childIds) {
+      nodes.push(
+        node(
+          childId,
+          'button',
+          `${childId.padStart(8, '0')}-${'x'.repeat(SNAPSHOT_MAX_NAME_CODE_UNITS + 100)}`
+        )
+      )
+    }
+
+    const result = await buildSnapshot(makeSender(nodes))
+
+    expect(result.refs).toHaveLength(
+      Math.min(
+        SNAPSHOT_MAX_ENTRIES,
+        Math.floor(SNAPSHOT_MAX_RETAINED_NAME_CODE_UNITS / SNAPSHOT_MAX_NAME_CODE_UNITS)
+      )
+    )
+    expect(result.refs[0]?.name).toHaveLength(SNAPSHOT_MAX_NAME_CODE_UNITS)
+    expect(result.refs.reduce((total, ref) => total + ref.name.length, 0)).toBeLessThanOrEqual(
+      SNAPSHOT_MAX_RETAINED_NAME_CODE_UNITS
+    )
+  })
+
+  it('walks malformed cyclic trees without recursive growth', async () => {
+    const nodes: AXNode[] = [
+      node('1', 'WebArea', 'page', { childIds: ['2'] }),
+      node('2', 'generic', '', { childIds: ['3'] }),
+      node('3', 'generic', '', { childIds: ['2', '4'] }),
+      node('4', 'button', 'Reachable', { backendDOMNodeId: 4 })
+    ]
+
+    const result = await buildSnapshot(makeSender(nodes))
+
+    expect(result.refs).toEqual([{ ref: '@e1', role: 'button', name: 'Reachable' }])
   })
 })

--- a/src/main/browser/snapshot-engine.ts
+++ b/src/main/browser/snapshot-engine.ts
@@ -75,6 +75,18 @@ const HEADING_PATTERN = /^heading$/
 
 const SKIP_ROLES = new Set(['none', 'presentation', 'generic'])
 
+export const SNAPSHOT_MAX_AX_NODES = 50_000
+export const SNAPSHOT_MAX_ENTRIES = 4096
+export const SNAPSHOT_MAX_NAME_CODE_UNITS = 1024
+export const SNAPSHOT_MAX_RETAINED_NAME_CODE_UNITS = 1024 * 1024
+const SNAPSHOT_MAX_VISUAL_DEPTH = 64
+
+type SnapshotWalkBudget = {
+  remainingNodes: number
+  remainingEntries: number
+  remainingNameCodeUnits: number
+}
+
 export async function buildSnapshot(
   sendCommand: CdpCommandSender,
   iframeSessions?: Map<string, string>,
@@ -84,37 +96,50 @@ export async function buildSnapshot(
   const { nodes } = (await sendCommand('Accessibility.getFullAXTree')) as { nodes: AXNode[] }
 
   const nodeById = new Map<string, AXNode>()
-  for (const node of nodes) {
+  for (const node of nodes.slice(0, SNAPSHOT_MAX_AX_NODES)) {
     nodeById.set(node.nodeId, node)
   }
 
   const entries: SnapshotEntry[] = []
   let refCounter = 1
+  const budget: SnapshotWalkBudget = {
+    remainingNodes: SNAPSHOT_MAX_AX_NODES,
+    remainingEntries: SNAPSHOT_MAX_ENTRIES,
+    remainingNameCodeUnits: SNAPSHOT_MAX_RETAINED_NAME_CODE_UNITS
+  }
 
   const root = nodes[0]
   if (!root) {
     return { snapshot: '', refs: [], refMap: new Map() }
   }
 
-  walkTree(root, nodeById, 0, entries, () => refCounter++)
+  walkTree(root, nodeById, 0, entries, () => refCounter++, budget)
 
   // Why: many modern SPAs use styled <div>s, <span>s, and custom elements as
   // interactive controls without proper ARIA roles. These elements are invisible
   // to the accessibility tree walk above but are clearly interactive (cursor:pointer,
   // onclick, tabindex, contenteditable). This DOM query pass discovers them and
   // promotes them to interactive refs so the agent can interact with them.
-  const cursorInteractiveEntries = await findCursorInteractiveElements(sendCommand, entries)
+  const cursorInteractiveEntries =
+    budget.remainingEntries > 0 ? await findCursorInteractiveElements(sendCommand, entries) : []
   for (const cie of cursorInteractiveEntries) {
+    const name = reserveSnapshotName(cie.name, budget)
+    if (name === null || !reserveSnapshotEntry(budget)) {
+      break
+    }
     cie.ref = `@e${refCounter++}`
-    entries.push(cie)
+    entries.push({ ...cie, name })
   }
 
   // Why: cross-origin iframes have their own AX trees accessible only through
   // their dedicated CDP session. Append their elements after the parent tree
   // so the agent can see and interact with iframe content.
-  const iframeRefSessions: { ref: string; sessionId: string }[] = []
+  const iframeRefSessions = new Map<string, string>()
   if (iframeSessions && makeIframeSender && iframeSessions.size > 0) {
     for (const [_frameId, sessionId] of iframeSessions) {
+      if (budget.remainingEntries <= 0 || budget.remainingNodes <= 0) {
+        break
+      }
       try {
         const iframeSender = makeIframeSender(sessionId)
         await iframeSender('Accessibility.enable')
@@ -125,15 +150,15 @@ export async function buildSnapshot(
           continue
         }
         const iframeNodeById = new Map<string, AXNode>()
-        for (const n of iframeNodes) {
+        for (const n of iframeNodes.slice(0, budget.remainingNodes)) {
           iframeNodeById.set(n.nodeId, n)
         }
         const iframeRoot = iframeNodes[0]
         if (iframeRoot) {
           const startRef = refCounter
-          walkTree(iframeRoot, iframeNodeById, 1, entries, () => refCounter++)
+          walkTree(iframeRoot, iframeNodeById, 1, entries, () => refCounter++, budget)
           for (let i = startRef; i < refCounter; i++) {
-            iframeRefSessions.push({ ref: `@e${i}`, sessionId })
+            iframeRefSessions.set(`@e${i}`, sessionId)
           }
         }
       } catch {
@@ -171,12 +196,11 @@ export async function buildSnapshot(
       }
       lines.push(`${indent}[${entry.ref}] ${entry.role} "${displayName}"`)
       refs.push({ ref: entry.ref, role: entry.role, name: displayName })
-      const iframeSession = iframeRefSessions.find((s) => s.ref === entry.ref)
       refMap.set(entry.ref, {
         backendDOMNodeId: entry.backendDOMNodeId,
         role: entry.role,
         name: entry.name,
-        sessionId: iframeSession?.sessionId,
+        sessionId: iframeRefSessions.get(entry.ref),
         nth: total > 1 ? nth : undefined
       })
     } else {
@@ -188,107 +212,159 @@ export async function buildSnapshot(
 }
 
 function walkTree(
-  node: AXNode,
+  root: AXNode,
   nodeById: Map<string, AXNode>,
   depth: number,
   entries: SnapshotEntry[],
-  nextRef: () => number
+  nextRef: () => number,
+  budget: SnapshotWalkBudget
 ): void {
-  if (node.ignored) {
-    walkChildren(node, nodeById, depth, entries, nextRef)
-    return
-  }
+  const stack: { node: AXNode; depth: number }[] = [{ node: root, depth }]
+  const visited = new Set<string>()
+  while (stack.length > 0 && budget.remainingNodes > 0 && budget.remainingEntries > 0) {
+    const current = stack.pop()!
+    const node = current.node
+    if (visited.has(node.nodeId)) {
+      continue
+    }
+    visited.add(node.nodeId)
+    budget.remainingNodes -= 1
 
-  const role = node.role?.value ?? ''
-  const name = node.name?.value ?? ''
+    const role = node.role?.value ?? ''
+    const rawName = node.name?.value ?? ''
+    const isInteractive = INTERACTIVE_ROLES.has(role)
+    const isHeading = HEADING_PATTERN.test(role)
+    const isLandmark = LANDMARK_ROLES.has(role)
+    const isStaticText = role === 'staticText' || role === 'StaticText'
+    const shouldWalkChildren =
+      node.ignored === true ||
+      SKIP_ROLES.has(role) ||
+      (!isInteractive && !isHeading && !isLandmark && !isStaticText) ||
+      (!rawName && !isLandmark)
 
-  if (SKIP_ROLES.has(role)) {
-    walkChildren(node, nodeById, depth, entries, nextRef)
-    return
-  }
+    if (shouldWalkChildren) {
+      pushSnapshotChildren(stack, node, nodeById, current.depth, budget.remainingNodes)
+      continue
+    }
 
-  const isInteractive = INTERACTIVE_ROLES.has(role)
-  const isHeading = HEADING_PATTERN.test(role)
-  const isLandmark = LANDMARK_ROLES.has(role)
-  const isStaticText = role === 'staticText' || role === 'StaticText'
+    if (isLandmark) {
+      const name = reserveSnapshotName(rawName || role, budget)
+      if (name !== null && reserveSnapshotEntry(budget)) {
+        entries.push({
+          ref: '',
+          role: formatLandmarkRole(role, rawName ? name : ''),
+          name,
+          backendDOMNodeId: node.backendDOMNodeId ?? 0,
+          depth: current.depth
+        })
+      }
+      pushSnapshotChildren(
+        stack,
+        node,
+        nodeById,
+        Math.min(current.depth + 1, SNAPSHOT_MAX_VISUAL_DEPTH),
+        budget.remainingNodes
+      )
+      continue
+    }
 
-  if (!isInteractive && !isHeading && !isLandmark && !isStaticText) {
-    walkChildren(node, nodeById, depth, entries, nextRef)
-    return
-  }
+    if (isHeading) {
+      appendSnapshotEntry(entries, budget, {
+        ref: '',
+        role: 'heading',
+        rawName,
+        backendDOMNodeId: node.backendDOMNodeId ?? 0,
+        depth: current.depth
+      })
+      continue
+    }
 
-  if (!name && !isLandmark) {
-    walkChildren(node, nodeById, depth, entries, nextRef)
-    return
-  }
+    if (isStaticText) {
+      const name = trimSnapshotName(rawName)
+      if (name) {
+        appendSnapshotEntry(entries, budget, {
+          ref: '',
+          role: 'text',
+          rawName: name,
+          backendDOMNodeId: node.backendDOMNodeId ?? 0,
+          depth: current.depth
+        })
+      }
+      continue
+    }
 
-  const hasFocusable = isInteractive && isFocusable(node)
-
-  if (isLandmark) {
-    entries.push({
-      ref: '',
-      role: formatLandmarkRole(role, name),
-      name: name || role,
-      backendDOMNodeId: node.backendDOMNodeId ?? 0,
-      depth
-    })
-    walkChildren(node, nodeById, depth + 1, entries, nextRef)
-    return
-  }
-
-  if (isHeading) {
-    entries.push({
-      ref: '',
-      role: 'heading',
-      name,
-      backendDOMNodeId: node.backendDOMNodeId ?? 0,
-      depth
-    })
-    return
-  }
-
-  if (isStaticText && name.trim().length > 0) {
-    entries.push({
-      ref: '',
-      role: 'text',
-      name: name.trim(),
-      backendDOMNodeId: node.backendDOMNodeId ?? 0,
-      depth
-    })
-    return
-  }
-
-  if (isInteractive && (hasFocusable || node.backendDOMNodeId)) {
-    const ref = `@e${nextRef()}`
-    entries.push({
-      ref,
-      role: formatInteractiveRole(role),
-      name: name || '(unlabeled)',
-      backendDOMNodeId: node.backendDOMNodeId ?? 0,
-      depth
-    })
-    return
-  }
-
-  walkChildren(node, nodeById, depth, entries, nextRef)
-}
-
-function walkChildren(
-  node: AXNode,
-  nodeById: Map<string, AXNode>,
-  depth: number,
-  entries: SnapshotEntry[],
-  nextRef: () => number
-): void {
-  if (!node.childIds) {
-    return
-  }
-  for (const childId of node.childIds) {
-    const child = nodeById.get(childId)
-    if (child) {
-      walkTree(child, nodeById, depth, entries, nextRef)
+    if (isInteractive && (isFocusable(node) || node.backendDOMNodeId)) {
+      appendSnapshotEntry(entries, budget, {
+        ref: `@e${nextRef()}`,
+        role: formatInteractiveRole(role),
+        rawName,
+        backendDOMNodeId: node.backendDOMNodeId ?? 0,
+        depth: current.depth
+      })
     }
   }
+}
+
+function pushSnapshotChildren(
+  stack: { node: AXNode; depth: number }[],
+  node: AXNode,
+  nodeById: Map<string, AXNode>,
+  depth: number,
+  maxChildren: number
+): void {
+  const childCount = Math.min(node.childIds?.length ?? 0, maxChildren)
+  for (let index = childCount - 1; index >= 0; index--) {
+    const child = nodeById.get(node.childIds![index])
+    if (child) {
+      stack.push({ node: child, depth })
+    }
+  }
+}
+
+function appendSnapshotEntry(
+  entries: SnapshotEntry[],
+  budget: SnapshotWalkBudget,
+  entry: Omit<SnapshotEntry, 'name'> & { rawName: string }
+): void {
+  const name = reserveSnapshotName(entry.rawName, budget)
+  if (name === null || !reserveSnapshotEntry(budget)) {
+    return
+  }
+  const { rawName: _rawName, ...rest } = entry
+  entries.push({ ...rest, name })
+}
+
+function reserveSnapshotEntry(budget: SnapshotWalkBudget): boolean {
+  if (budget.remainingEntries <= 0) {
+    return false
+  }
+  budget.remainingEntries -= 1
+  return true
+}
+
+function reserveSnapshotName(rawName: string, budget: SnapshotWalkBudget): string | null {
+  const maxLength = Math.min(SNAPSHOT_MAX_NAME_CODE_UNITS, budget.remainingNameCodeUnits)
+  if (maxLength <= 0) {
+    return null
+  }
+  const name = rawName.slice(0, maxLength)
+  budget.remainingNameCodeUnits -= name.length
+  return name
+}
+
+function trimSnapshotName(rawName: string): string {
+  let start = 0
+  while (start < rawName.length && /\s/.test(rawName[start])) {
+    start += 1
+  }
+  if (start === rawName.length) {
+    return ''
+  }
+  let end = rawName.length
+  while (end > start && /\s/.test(rawName[end - 1])) {
+    end -= 1
+  }
+  return rawName.slice(start, Math.min(end, start + SNAPSHOT_MAX_NAME_CODE_UNITS))
 }
 
 function isFocusable(node: AXNode): boolean {

--- a/src/main/computer/macos-computer-use-permission-status.test.ts
+++ b/src/main/computer/macos-computer-use-permission-status.test.ts
@@ -1,12 +1,17 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
 import { join } from 'node:path'
+import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as nodeBoundedFileReader from '../../shared/node-bounded-file-reader'
 
 const resolveHelperAppPathMock = vi.hoisted(() => vi.fn())
 const resolveHelperExecutablePathMock = vi.hoisted(() => vi.fn())
 const permissionStatusTempDir = '/tmp/orca-computer-use-permissions-test'
 const permissionStatusPath = join(permissionStatusTempDir, 'status.json')
+const { readNodeFileWithinLimitMock } = vi.hoisted(() => ({
+  readNodeFileWithinLimitMock: vi.fn()
+}))
 
 vi.mock('child_process', () => ({
   execFileSync: vi.fn(),
@@ -30,10 +35,14 @@ vi.mock('child_process', () => ({
 
 vi.mock('fs/promises', () => ({
   mkdtemp: vi.fn(),
-  readFile: vi.fn(),
   rm: vi.fn(),
   stat: vi.fn()
 }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof nodeBoundedFileReader>()
+  return { ...actual, readNodeFileWithinLimit: readNodeFileWithinLimitMock }
+})
 
 vi.mock('./macos-native-provider-paths', () => ({
   resolveMacOSComputerUseAppPath: resolveHelperAppPathMock,
@@ -48,7 +57,7 @@ describe('getComputerUsePermissionStatus', () => {
     vi.mocked(spawnSync).mockClear()
     vi.mocked(execFileSync).mockReset()
     vi.mocked(mkdtemp).mockReset()
-    vi.mocked(readFile).mockReset()
+    readNodeFileWithinLimitMock.mockReset()
     vi.mocked(rm).mockReset()
     vi.mocked(stat).mockReset()
     resolveHelperAppPathMock.mockReset()
@@ -162,6 +171,56 @@ describe('getComputerUsePermissionStatus', () => {
     })
   })
 
+  it('kills the helper and rejects oversized launch output', async () => {
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+      stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+    child.kill = vi.fn()
+    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
+
+    const statusPromise = getComputerUsePermissionStatus()
+    await Promise.resolve()
+    child.stdout.emit('data', 'x'.repeat(64 * 1024 + 1))
+
+    await expect(statusPromise).rejects.toMatchObject({
+      name: 'RuntimeClientError',
+      code: 'accessibility_error',
+      message: 'Permission helper returned too much launch output'
+    })
+    expect(child.kill).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves helper diagnostics delivered as 50,000 one-byte fragments', async () => {
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+      stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
+      kill: ReturnType<typeof vi.fn>
+    }
+    child.stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+    child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() })
+    child.kill = vi.fn()
+    vi.mocked(spawn).mockImplementationOnce(() => child as unknown as ReturnType<typeof spawn>)
+    const statusPromise = getComputerUsePermissionStatus()
+    await Promise.resolve()
+
+    for (let index = 0; index < 50_000; index += 1) {
+      child.stderr.emit('data', ' ')
+    }
+    child.stderr.emit('data', 'permission denied')
+    child.emit('close', 1)
+
+    await expect(statusPromise).rejects.toMatchObject({
+      code: 'accessibility_error',
+      message: 'Could not check permissions: permission denied'
+    })
+  })
+
   it('reads permission status through the helper app identity', async () => {
     const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
     mockPermissionStatus('{"accessibility":"granted","screenshots":"not-granted"}')
@@ -187,10 +246,23 @@ describe('getComputerUsePermissionStatus', () => {
       { stdio: ['ignore', 'pipe', 'pipe'] }
     )
     expect(spawnSync).not.toHaveBeenCalled()
-    expect(readFile).toHaveBeenCalledWith(permissionStatusPath, 'utf8')
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith(permissionStatusPath, 64 * 1024)
     expect(rm).toHaveBeenCalledWith(permissionStatusTempDir, {
       recursive: true,
       force: true
+    })
+  })
+
+  it('maps an oversized permission status file to a stable runtime error', async () => {
+    const { getComputerUsePermissionStatus } = await import('./macos-computer-use-permissions')
+    readNodeFileWithinLimitMock.mockRejectedValueOnce(
+      new nodeBoundedFileReader.NodeFileReadTooLargeError(64 * 1024 + 1, 64 * 1024)
+    )
+
+    await expect(getComputerUsePermissionStatus()).rejects.toMatchObject({
+      name: 'RuntimeClientError',
+      code: 'accessibility_error',
+      message: 'Permission helper returned too much status data'
     })
   })
 
@@ -213,7 +285,10 @@ describe('getComputerUsePermissionStatus', () => {
 
 function mockPermissionStatus(json: string): void {
   vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>)
-  vi.mocked(readFile).mockResolvedValue(json)
+  readNodeFileWithinLimitMock.mockResolvedValue({
+    buffer: Buffer.from(json),
+    stats: { size: Buffer.byteLength(json) }
+  })
 }
 
 function setPlatform(platform: NodeJS.Platform): void {

--- a/src/main/computer/macos-computer-use-permission-status.ts
+++ b/src/main/computer/macos-computer-use-permission-status.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { setTimeout as delay } from 'node:timers/promises'
@@ -13,8 +13,14 @@ import {
   resolveMacOSComputerUseExecutablePath
 } from './macos-native-provider-paths'
 import { RuntimeClientError } from './runtime-client-error'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../../shared/node-bounded-file-reader'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 
 const PERMISSION_STATUS_HELPER_LAUNCH_TIMEOUT_MS = 5_000
+export const PERMISSION_STATUS_MAX_BYTES = 64 * 1024
 
 export function getComputerUsePermissionStatus(): Promise<ComputerUsePermissionStatusResult> {
   return getComputerUsePermissionStatusAsync()
@@ -86,10 +92,22 @@ async function readPermissionStatusFromHelperApp(
 
     for (let attempt = 0; attempt < 50; attempt++) {
       if (await fileExists(statusPath)) {
-        const output = await readFile(statusPath, 'utf8')
-        return JSON.parse(output) as Partial<
-          Record<ComputerUsePermissionId, ComputerUsePermissionStatus>
-        >
+        try {
+          const output = (
+            await readNodeFileWithinLimit(statusPath, PERMISSION_STATUS_MAX_BYTES)
+          ).buffer.toString('utf8')
+          return JSON.parse(output) as Partial<
+            Record<ComputerUsePermissionId, ComputerUsePermissionStatus>
+          >
+        } catch (error) {
+          if (error instanceof NodeFileReadTooLargeError) {
+            throw new RuntimeClientError(
+              'accessibility_error',
+              'Permission helper returned too much status data'
+            )
+          }
+          throw error
+        }
       }
       await delay(100)
     }
@@ -108,16 +126,41 @@ function launchPermissionStatusHelper(helperAppPath: string, statusPath: string)
         stdio: ['ignore', 'pipe', 'pipe']
       }
     )
-    let stdout = ''
-    let stderr = ''
+    const stdout = new GrowingByteBuffer()
+    const stderr = new GrowingByteBuffer()
+    let outputBytes = 0
 
     launch.stdout?.setEncoding('utf8')
     launch.stderr?.setEncoding('utf8')
     const onStdoutData = (chunk: string): void => {
-      stdout += chunk
+      const bytes = Buffer.from(chunk)
+      outputBytes += bytes.byteLength
+      if (outputBytes > PERMISSION_STATUS_MAX_BYTES) {
+        launch.kill()
+        settleReject(
+          new RuntimeClientError(
+            'accessibility_error',
+            'Permission helper returned too much launch output'
+          )
+        )
+        return
+      }
+      stdout.append(bytes)
     }
     const onStderrData = (chunk: string): void => {
-      stderr += chunk
+      const bytes = Buffer.from(chunk)
+      outputBytes += bytes.byteLength
+      if (outputBytes > PERMISSION_STATUS_MAX_BYTES) {
+        launch.kill()
+        settleReject(
+          new RuntimeClientError(
+            'accessibility_error',
+            'Permission helper returned too much launch output'
+          )
+        )
+        return
+      }
+      stderr.append(bytes)
     }
     let settled = false
     let launchTimeout: ReturnType<typeof setTimeout> | null = null
@@ -137,6 +180,8 @@ function launchPermissionStatusHelper(helperAppPath: string, statusPath: string)
       }
       settled = true
       removeListeners()
+      stdout.clear()
+      stderr.clear()
       resolve()
     }
     const settleReject = (error: Error): void => {
@@ -145,6 +190,8 @@ function launchPermissionStatusHelper(helperAppPath: string, statusPath: string)
       }
       settled = true
       removeListeners()
+      stdout.clear()
+      stderr.clear()
       reject(error)
     }
     const onError = (): void => {
@@ -160,7 +207,8 @@ function launchPermissionStatusHelper(helperAppPath: string, statusPath: string)
         settleResolve()
         return
       }
-      const detail = stderr.trim() || stdout.trim() || `exit ${status ?? 'unknown'}`
+      const detail =
+        stderr.toString().trim() || stdout.toString().trim() || `exit ${status ?? 'unknown'}`
       settleReject(
         new RuntimeClientError('accessibility_error', `Could not check permissions: ${detail}`)
       )

--- a/src/main/computer/macos-computer-use-permissions.test.ts
+++ b/src/main/computer/macos-computer-use-permissions.test.ts
@@ -1,7 +1,8 @@
 import { execFileSync, spawn, spawnSync } from 'node:child_process'
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as nodeBoundedFileReader from '../../shared/node-bounded-file-reader'
 import {
   openComputerUsePermissions,
   resetComputerUsePermissions
@@ -12,6 +13,9 @@ const resolveHelperExecutablePathMock = vi.hoisted(() => vi.fn())
 const permissionStatusTempDir = '/tmp/orca-computer-use-permissions-test'
 const helperAppPath = '/Applications/Orca Computer Use.app'
 const helperInfoPlistPath = join(helperAppPath, 'Contents', 'Info.plist')
+const { readNodeFileWithinLimitMock } = vi.hoisted(() => ({
+  readNodeFileWithinLimitMock: vi.fn()
+}))
 
 vi.mock('child_process', () => ({
   execFileSync: vi.fn(),
@@ -35,10 +39,14 @@ vi.mock('child_process', () => ({
 
 vi.mock('fs/promises', () => ({
   mkdtemp: vi.fn(),
-  readFile: vi.fn(),
   rm: vi.fn(),
   stat: vi.fn()
 }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof nodeBoundedFileReader>()
+  return { ...actual, readNodeFileWithinLimit: readNodeFileWithinLimitMock }
+})
 
 vi.mock('./macos-native-provider-paths', () => ({
   resolveMacOSComputerUseAppPath: resolveHelperAppPathMock,
@@ -53,7 +61,7 @@ describe('openComputerUsePermissions', () => {
     vi.mocked(spawnSync).mockClear()
     vi.mocked(execFileSync).mockReset()
     vi.mocked(mkdtemp).mockReset()
-    vi.mocked(readFile).mockReset()
+    readNodeFileWithinLimitMock.mockReset()
     vi.mocked(rm).mockReset()
     vi.mocked(stat).mockReset()
     resolveHelperAppPathMock.mockReset()
@@ -210,9 +218,13 @@ describe('openComputerUsePermissions', () => {
 
   it('resets stale macOS TCC grants for the helper bundle id', async () => {
     resolveHelperAppPathMock.mockReturnValue('/Applications/Orca Computer Use.app')
-    vi.mocked(readFile)
-      .mockResolvedValueOnce('{"accessibility":"granted","screenshots":"granted"}')
-      .mockResolvedValueOnce('{"accessibility":"not-granted","screenshots":"not-granted"}')
+    readNodeFileWithinLimitMock
+      .mockResolvedValueOnce(
+        boundedPermissionStatus('{"accessibility":"granted","screenshots":"granted"}')
+      )
+      .mockResolvedValueOnce(
+        boundedPermissionStatus('{"accessibility":"not-granted","screenshots":"not-granted"}')
+      )
     vi.mocked(execFileSync).mockReturnValueOnce('com.example.orca.computer-use\n')
     vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>)
 
@@ -246,7 +258,14 @@ describe('openComputerUsePermissions', () => {
 
 function mockPermissionStatus(json: string): void {
   vi.mocked(spawnSync).mockReturnValue({ status: 0 } as ReturnType<typeof spawnSync>)
-  vi.mocked(readFile).mockResolvedValue(json)
+  readNodeFileWithinLimitMock.mockResolvedValue(boundedPermissionStatus(json))
+}
+
+function boundedPermissionStatus(json: string) {
+  return {
+    buffer: Buffer.from(json),
+    stats: { size: Buffer.byteLength(json) }
+  }
 }
 
 function setPlatform(platform: NodeJS.Platform): void {

--- a/src/main/computer/macos-native-provider-client.ts
+++ b/src/main/computer/macos-native-provider-client.ts
@@ -20,7 +20,7 @@ import {
 import { resolveMacOSComputerUseExecutablePath } from './macos-native-provider-paths'
 import {
   attachMacOSNativeProviderSocketListeners,
-  consumeNativeProviderLines,
+  MacOSNativeProviderLineBuffer,
   startMacOSNativeProviderSocket
 } from './macos-native-provider-transport'
 import { validateComputerProviderActionParams } from './computer-provider-action-validation'
@@ -37,7 +37,7 @@ export class MacOSNativeProviderClient {
   private socketToken: string | null = null
   private nextId = 1
   private pending = new Map<number, PendingNativeRequest>()
-  private socketBuffer = ''
+  private readonly socketBuffer = new MacOSNativeProviderLineBuffer()
   private providerCapabilities: ComputerProviderCapabilities | null = null
   private socketListenerCleanup: (() => void) | null = null
   private socketStartGeneration = 0
@@ -70,20 +70,16 @@ export class MacOSNativeProviderClient {
     this.socketStartPromise = null
     this.socketStartGeneration++
     this.providerCapabilities = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     this.cleanupActiveSocketListeners()
     if (socket && !socket.destroyed) {
       const id = this.nextId++
       socket.write(`${JSON.stringify({ id, method: 'terminate', params: {}, token })}\n`)
       socket.end()
     }
-    for (const [id, pending] of this.pending) {
-      clearTimeout(pending.timer)
-      pending.reject(
-        new RuntimeClientError('accessibility_error', 'native macOS provider shut down')
-      )
-      this.pending.delete(id)
-    }
+    this.rejectPending(
+      new RuntimeClientError('accessibility_error', 'native macOS provider shut down')
+    )
     this.cleanupSocketDirectory()
   }
   private async call(method: NativeMethod, params: unknown): Promise<unknown> {
@@ -199,7 +195,7 @@ export class MacOSNativeProviderClient {
     this.socketToken = started.socketToken
     const socket = started.socket
     socket.setEncoding('utf8')
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     this.socketListenerCleanup = attachMacOSNativeProviderSocketListeners(socket, {
       data: (chunk) => this.handleSocketData(socket, chunk),
       close: () => this.handleSocketClose(socket),
@@ -214,10 +210,11 @@ export class MacOSNativeProviderClient {
     if (this.socket !== socket) {
       return
     }
-    this.socketBuffer += chunk
-    this.socketBuffer = consumeNativeProviderLines(this.socketBuffer, (line) =>
-      this.handleLine(line)
-    )
+    try {
+      this.socketBuffer.feed(chunk, (line) => this.handleLine(line))
+    } catch (error) {
+      this.handleTransportError(socket, error instanceof Error ? error : new Error(String(error)))
+    }
   }
   private handleLine(line: string): void {
     let response: NativeResponse
@@ -245,7 +242,7 @@ export class MacOSNativeProviderClient {
     }
     this.cleanupActiveSocketListeners()
     this.socket = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     this.cleanupSocketDirectory()
     this.rejectPending(
       new RuntimeClientError('accessibility_error', 'native macOS helper app connection closed')
@@ -259,7 +256,7 @@ export class MacOSNativeProviderClient {
     this.cleanupActiveSocketListeners()
     // Why: an active transport error makes the helper socket unreliable for the next request.
     this.socket = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     if (!socket.destroyed) {
       socket.destroy()
     }
@@ -275,7 +272,7 @@ export class MacOSNativeProviderClient {
     }
     this.cleanupActiveSocketListeners()
     this.socket = null
-    this.socketBuffer = ''
+    this.socketBuffer.clear()
     if (!socket.destroyed) {
       socket.destroy()
     }

--- a/src/main/computer/macos-native-provider-transport.test.ts
+++ b/src/main/computer/macos-native-provider-transport.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MacOSNativeProviderLineBuffer,
+  MacOSNativeProviderResponseTooLargeError,
+  consumeNativeProviderLines
+} from './macos-native-provider-transport'
+
+describe('consumeNativeProviderLines', () => {
+  it('preserves complete lines and returns the partial tail', () => {
+    const handleLine = vi.fn()
+
+    const remaining = consumeNativeProviderLines('one\ntwo\npartial', handleLine, 16)
+
+    expect(handleLine.mock.calls.map(([line]) => line)).toEqual(['one', 'two'])
+    expect(remaining).toBe('partial')
+  })
+
+  it('rejects a complete oversized response before dispatching it', () => {
+    const handleLine = vi.fn()
+
+    expect(() => consumeNativeProviderLines('12345\n', handleLine, 4)).toThrow(
+      MacOSNativeProviderResponseTooLargeError
+    )
+    expect(handleLine).not.toHaveBeenCalled()
+  })
+
+  it('rejects a newline-free response once its retained tail crosses the limit', () => {
+    expect(() => consumeNativeProviderLines('12345', vi.fn(), 4)).toThrow(
+      'native macOS provider response exceeded'
+    )
+  })
+})
+
+describe('MacOSNativeProviderLineBuffer', () => {
+  it('parses a response delivered in more than 100,000 one-character fragments', () => {
+    const buffer = new MacOSNativeProviderLineBuffer()
+    const handleLine = vi.fn()
+    const line = JSON.stringify({ id: 1, ok: true, result: 'x'.repeat(100_000) })
+
+    for (const character of line) {
+      buffer.feed(character, handleLine)
+    }
+    buffer.feed('\n', handleLine)
+
+    expect(handleLine).toHaveBeenCalledWith(line)
+  })
+
+  it('clears an oversized fragmented line and accepts a later response', () => {
+    const buffer = new MacOSNativeProviderLineBuffer(4)
+    const handleLine = vi.fn()
+    buffer.feed('12', handleLine)
+    expect(() => buffer.feed('345', handleLine)).toThrow(MacOSNativeProviderResponseTooLargeError)
+
+    buffer.feed('ok\n', handleLine)
+
+    expect(handleLine).toHaveBeenCalledWith('ok')
+  })
+})

--- a/src/main/computer/macos-native-provider-transport.ts
+++ b/src/main/computer/macos-native-provider-transport.ts
@@ -6,14 +6,60 @@ import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { connectMacOSProviderSocket } from './macos-native-provider-socket'
 import { RuntimeClientError } from './runtime-client-error'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 
 const HELPER_CONNECT_TIMEOUT_MS = 10_000
+export const MACOS_NATIVE_PROVIDER_MAX_RESPONSE_LINE_BYTES = 64 * 1024 * 1024
+
+export class MacOSNativeProviderResponseTooLargeError extends Error {
+  constructor(
+    readonly observedBytes: number,
+    readonly maxBytes: number
+  ) {
+    super(`native macOS provider response exceeded ${maxBytes} byte line limit`)
+    this.name = 'MacOSNativeProviderResponseTooLargeError'
+  }
+}
 
 export type StartedMacOSProviderSocket = {
   socket: net.Socket
   socketDirectory: string
   socketPath: string
   socketToken: string
+}
+
+export class MacOSNativeProviderLineBuffer {
+  private readonly pending = new GrowingByteBuffer()
+
+  constructor(private readonly maxLineBytes = MACOS_NATIVE_PROVIDER_MAX_RESPONSE_LINE_BYTES) {}
+
+  feed(chunk: string, handleLine: (line: string) => void): void {
+    let remaining = chunk
+    while (remaining.length > 0) {
+      const newline = remaining.indexOf('\n')
+      const hasNewline = newline >= 0
+      const segment = hasNewline ? remaining.slice(0, newline) : remaining
+      remaining = hasNewline ? remaining.slice(newline + 1) : ''
+      const segmentBytes = Buffer.byteLength(segment)
+      const observedBytes = this.pending.byteLength + segmentBytes
+      if (observedBytes > this.maxLineBytes) {
+        this.pending.clear()
+        throw new MacOSNativeProviderResponseTooLargeError(observedBytes, this.maxLineBytes)
+      }
+      this.pending.append(Buffer.from(segment))
+      if (!hasNewline) {
+        return
+      }
+      const line = this.pending.takeString('utf8')
+      if (line.trim()) {
+        handleLine(line)
+      }
+    }
+  }
+
+  clear(): void {
+    this.pending.clear()
+  }
 }
 
 export function isMacOS14OrNewer(): boolean {
@@ -47,16 +93,25 @@ export function attachMacOSNativeProviderSocketListeners(
 
 export function consumeNativeProviderLines(
   buffer: string,
-  handleLine: (line: string) => void
+  handleLine: (line: string) => void,
+  maxLineBytes = MACOS_NATIVE_PROVIDER_MAX_RESPONSE_LINE_BYTES
 ): string {
   let remaining = buffer
   while (true) {
     const newline = remaining.indexOf('\n')
     if (newline < 0) {
+      const remainingBytes = Buffer.byteLength(remaining)
+      if (remainingBytes > maxLineBytes) {
+        throw new MacOSNativeProviderResponseTooLargeError(remainingBytes, maxLineBytes)
+      }
       return remaining
     }
     const line = remaining.slice(0, newline)
     remaining = remaining.slice(newline + 1)
+    const lineBytes = Buffer.byteLength(line)
+    if (lineBytes > maxLineBytes) {
+      throw new MacOSNativeProviderResponseTooLargeError(lineBytes, maxLineBytes)
+    }
     if (line.trim()) {
       handleLine(line)
     }

--- a/src/main/computer/sidecar-client.test.ts
+++ b/src/main/computer/sidecar-client.test.ts
@@ -8,6 +8,7 @@ import {
 import {
   callComputerSidecarAction,
   callComputerSidecarCapabilities,
+  COMPUTER_SIDECAR_MAX_QUEUED_CALLS,
   resetComputerSidecarForTest
 } from './sidecar-client'
 
@@ -158,6 +159,44 @@ describe('computer sidecar client', () => {
     const secondRequest = child.sent[1]!
 
     child.emit('message', {
+      id: secondRequest.id,
+      ok: true,
+      result: { provider: 'second' }
+    })
+
+    await expect(secondCall).resolves.toEqual({ provider: 'second' })
+  })
+
+  it('fails closed when the serialized call queue reaches its cap', async () => {
+    const admitted = Array.from({ length: COMPUTER_SIDECAR_MAX_QUEUED_CALLS }, () =>
+      callComputerSidecarCapabilities()
+    )
+    const admittedSettlements = Promise.allSettled(admitted)
+    const child = children[0]!
+
+    await expect(callComputerSidecarCapabilities()).rejects.toThrow(
+      'computer sidecar queue limit reached'
+    )
+    expect(child.sent).toHaveLength(1)
+
+    child.emit('error', new Error('stop saturated sidecar'))
+    await admittedSettlements
+  })
+
+  it('releases queue admission after a call settles', async () => {
+    const firstCall = callComputerSidecarCapabilities()
+    const firstChild = children[0]!
+    const firstRequest = firstChild.sent[0]!
+    firstChild.emit('message', {
+      id: firstRequest.id,
+      ok: true,
+      result: { provider: 'first' }
+    })
+    await expect(firstCall).resolves.toEqual({ provider: 'first' })
+
+    const secondCall = callComputerSidecarCapabilities()
+    const secondRequest = firstChild.sent[1]!
+    firstChild.emit('message', {
       id: secondRequest.id,
       ok: true,
       result: { provider: 'second' }

--- a/src/main/computer/sidecar-client.ts
+++ b/src/main/computer/sidecar-client.ts
@@ -43,6 +43,7 @@ type PendingRequest = {
 }
 
 const REQUEST_TIMEOUT_MS = 60_000
+export const COMPUTER_SIDECAR_MAX_QUEUED_CALLS = 16
 let sidecar: ComputerSidecarProcess | null = null
 
 // Why: Node treats unhandled child 'error' events as process exceptions, so
@@ -122,10 +123,20 @@ class ComputerSidecarProcess {
   private pending = new Map<number, PendingRequest>()
   private queueTail: Promise<void> | null = null
   private queueGeneration = 0
+  private queuedCalls = 0
 
   constructor(private readonly entryPath: string) {}
 
   call(method: ComputerSidecarMethod, params: unknown): Promise<unknown> {
+    if (this.queuedCalls >= COMPUTER_SIDECAR_MAX_QUEUED_CALLS) {
+      return Promise.reject(
+        new RuntimeClientError(
+          'accessibility_error',
+          'computer sidecar queue limit reached; retry the computer-use request'
+        )
+      )
+    }
+    this.queuedCalls += 1
     const generation = this.queueGeneration
     const run = () => {
       if (generation !== this.queueGeneration) {
@@ -136,8 +147,17 @@ class ComputerSidecarProcess {
       }
       return this.send(method, params)
     }
-    const result = this.queueTail ? this.queueTail.then(run, run) : run()
-    const tail = result.then(
+    let result: Promise<unknown>
+    try {
+      result = this.queueTail ? this.queueTail.then(run, run) : run()
+    } catch (error) {
+      this.queuedCalls -= 1
+      throw error
+    }
+    const trackedResult = result.finally(() => {
+      this.queuedCalls -= 1
+    })
+    const tail = trackedResult.then(
       () => undefined,
       () => undefined
     )
@@ -147,7 +167,7 @@ class ComputerSidecarProcess {
         this.queueTail = null
       }
     })
-    return result
+    return trackedResult
   }
 
   private send(method: ComputerSidecarMethod, params: unknown): Promise<unknown> {

--- a/src/main/emulator/android/android-device-inventory.test.ts
+++ b/src/main/emulator/android/android-device-inventory.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AndroidCommandResult, AndroidCommandRunner } from './android-command-runner'
 import type { AndroidSdkPaths } from './android-sdk-discovery'
 import {
+  ANDROID_AVD_NAME_LOOKUP_CONCURRENCY,
   findRunningAvdSerial,
   listAndroidDevices,
-  mergeAndroidDevices
+  mergeAndroidDevices,
+  resolveRunningAvdNames
 } from './android-device-inventory'
 import { parseAdbDevices } from './adb-devices'
 
@@ -87,5 +89,42 @@ describe('findRunningAvdSerial', () => {
     const running = parseAdbDevices('List of devices attached\nemulator-5554\tdevice')
     expect(await findRunningAvdSerial(fake, SDK, 'Pixel_7', running)).toBe('emulator-5554')
     expect(await findRunningAvdSerial(fake, SDK, 'Other', running)).toBeNull()
+  })
+
+  it.each([
+    ['at the limit', ANDROID_AVD_NAME_LOOKUP_CONCURRENCY],
+    ['above the limit', ANDROID_AVD_NAME_LOOKUP_CONCURRENCY + 1]
+  ])('bounds AVD name probes %s', async (_, count) => {
+    let active = 0
+    let peak = 0
+    let started = 0
+    const releases: (() => void)[] = []
+    const fake: AndroidCommandRunner = async (_binary, args) => {
+      started++
+      active++
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => releases.push(resolve))
+      active--
+      return ok(`${args[1]}\nOK`)
+    }
+    const running = parseAdbDevices(
+      `List of devices attached\n${Array.from(
+        { length: count },
+        (_, index) => `emulator-${index}\tdevice`
+      ).join('\n')}`
+    )
+
+    const result = resolveRunningAvdNames(fake, SDK, running)
+    await vi.waitFor(() =>
+      expect(started).toBe(Math.min(count, ANDROID_AVD_NAME_LOOKUP_CONCURRENCY))
+    )
+    if (count > ANDROID_AVD_NAME_LOOKUP_CONCURRENCY) {
+      releases.shift()?.()
+      await vi.waitFor(() => expect(started).toBe(count))
+    }
+    releases.splice(0).forEach((release) => release())
+
+    expect((await result).size).toBe(count)
+    expect(peak).toBe(Math.min(count, ANDROID_AVD_NAME_LOOKUP_CONCURRENCY))
   })
 })

--- a/src/main/emulator/android/android-device-inventory.ts
+++ b/src/main/emulator/android/android-device-inventory.ts
@@ -3,6 +3,9 @@ import type { AndroidSdkPaths } from './android-sdk-discovery'
 import { adbDevicesArgs, parseAdbDevices, type AndroidAdbDevice } from './adb-devices'
 import { listAvdsArgs, parseAvdList } from './avd-manager'
 import type { EmulatorDevice } from '../backends/emulator-backend'
+import { mapWithConcurrency } from '../../../shared/map-with-concurrency'
+
+export const ANDROID_AVD_NAME_LOOKUP_CONCURRENCY = 4
 
 // Android device discovery: turns raw `adb`/`emulator` output into the
 // cross-backend EmulatorDevice list and resolves AVD names to running serials.
@@ -23,17 +26,19 @@ export async function resolveRunningAvdNames(
   running: AndroidAdbDevice[]
 ): Promise<Map<string, string>> {
   const names = new Map<string, string>()
-  await Promise.all(
-    running
-      .filter((device) => device.isEmulator)
-      .map(async (device) => {
-        const out = await runner(sdk.adb, ['-s', device.serial, 'emu', 'avd', 'name'])
-        const name = firstNonStatusLine(out.stdout)
-        if (name) {
-          names.set(device.serial, name)
-        }
-      })
+  const resolved = await mapWithConcurrency(
+    running.filter((device) => device.isEmulator),
+    ANDROID_AVD_NAME_LOOKUP_CONCURRENCY,
+    async (device) => {
+      const out = await runner(sdk.adb, ['-s', device.serial, 'emu', 'avd', 'name'])
+      return { serial: device.serial, name: firstNonStatusLine(out.stdout) }
+    }
   )
+  for (const { serial, name } of resolved) {
+    if (name) {
+      names.set(serial, name)
+    }
+  }
   return names
 }
 

--- a/src/main/emulator/android/scrcpy-stream-session.test.ts
+++ b/src/main/emulator/android/scrcpy-stream-session.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import {
+  appendScrcpyServerLogPreview,
+  SCRCPY_SERVER_LOG_PREVIEW_CHARS
+} from './scrcpy-stream-session'
+
+describe('appendScrcpyServerLogPreview', () => {
+  it('preserves the diagnostic prefix while bounding a chatty long-lived server', () => {
+    const prefix = 'startup\n'
+    const first = appendScrcpyServerLogPreview(prefix, Buffer.from('x'.repeat(100_000)))
+    const complete = appendScrcpyServerLogPreview(first, Buffer.from('ignored forever'))
+
+    expect(complete).toBe(first)
+    expect(complete).toHaveLength(SCRCPY_SERVER_LOG_PREVIEW_CHARS)
+    expect(complete.startsWith(prefix)).toBe(true)
+  })
+})

--- a/src/main/emulator/android/scrcpy-stream-session.ts
+++ b/src/main/emulator/android/scrcpy-stream-session.ts
@@ -29,6 +29,7 @@ import { emulatorProbe, emulatorProbeError } from '../emulator-probe'
 const DEVICE_NAME_BYTES = 64
 const DUMMY_BYTE = 1
 const DYNAMIC_FORWARD_PORT = 0
+export const SCRCPY_SERVER_LOG_PREVIEW_CHARS = 1_000
 
 export type ScrcpyStreamCallbacks = {
   onMeta: (meta: ScrcpyVideoMeta) => void
@@ -44,6 +45,14 @@ export type ScrcpyStreamOptions = {
   localJarPath: string
   localPort?: number
   maxSize?: number
+}
+
+export function appendScrcpyServerLogPreview(current: string, chunk: Buffer): string {
+  const remaining = SCRCPY_SERVER_LOG_PREVIEW_CHARS - current.length
+  if (remaining <= 0) {
+    return current
+  }
+  return current + chunk.toString().slice(0, remaining)
 }
 
 function newScid(): string {
@@ -127,13 +136,13 @@ export class ScrcpyStreamSession {
     })
     let serverLog = ''
     const capture = (chunk: Buffer): void => {
-      serverLog += chunk.toString()
+      serverLog = appendScrcpyServerLogPreview(serverLog, chunk)
     }
     this.server.stdout?.on('data', capture)
     this.server.stderr?.on('data', capture)
     this.server.on('error', (error) => this.fail(error.message))
     this.server.on('exit', (code) => {
-      emulatorProbe('scrcpy.server.exit', { code, log: serverLog.slice(0, 1000).trim() })
+      emulatorProbe('scrcpy.server.exit', { code, log: serverLog.trim() })
       if (!this.metaSeen) {
         this.fail('scrcpy server exited before the video stream started')
         return

--- a/src/main/emulator/android/uiautomator-tree.test.ts
+++ b/src/main/emulator/android/uiautomator-tree.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { EmulatorError } from '../emulator-errors'
-import { parseAndroidBounds, parseUiAutomatorXml } from './uiautomator-tree'
+import {
+  ANDROID_UIAUTOMATOR_XML_MAX_ATTRIBUTES_PER_ELEMENT,
+  ANDROID_UIAUTOMATOR_XML_MAX_DEPTH,
+  ANDROID_UIAUTOMATOR_XML_MAX_ELEMENTS,
+  parseAndroidBounds,
+  parseUiAutomatorXml
+} from './uiautomator-tree'
 
 // Realistic `uiautomator dump` output: an XML prolog, a <hierarchy> root, and
 // nested self-describing <node> elements (mix of container + self-closing leaf).
@@ -96,6 +102,23 @@ describe('parseUiAutomatorXml', () => {
     expect(() => parseUiAutomatorXml('not xml at all')).toThrowError(EmulatorError)
     expect(() => parseUiAutomatorXml('')).toThrowError(EmulatorError)
     expect(() => parseUiAutomatorXml('<hierarchy></node>')).toThrowError(EmulatorError)
+  })
+
+  it('rejects element-count, nesting, and per-element attribute amplification', () => {
+    const tooManyElements = `<hierarchy>${'<node />'.repeat(
+      ANDROID_UIAUTOMATOR_XML_MAX_ELEMENTS
+    )}</hierarchy>`
+    const tooDeep = `${'<node>'.repeat(ANDROID_UIAUTOMATOR_XML_MAX_DEPTH + 1)}${'</node>'.repeat(
+      ANDROID_UIAUTOMATOR_XML_MAX_DEPTH + 1
+    )}`
+    const tooManyAttributes = `<node ${Array.from(
+      { length: ANDROID_UIAUTOMATOR_XML_MAX_ATTRIBUTES_PER_ELEMENT + 1 },
+      (_, index) => `a${index}="x"`
+    ).join(' ')} />`
+
+    expect(() => parseUiAutomatorXml(tooManyElements)).toThrow('exceeds 50000 elements')
+    expect(() => parseUiAutomatorXml(tooDeep)).toThrow('exceeds 256 levels')
+    expect(() => parseUiAutomatorXml(tooManyAttributes)).toThrow('exceeds 64 attributes')
   })
 })
 

--- a/src/main/emulator/android/uiautomator-tree.ts
+++ b/src/main/emulator/android/uiautomator-tree.ts
@@ -18,6 +18,11 @@ export type AndroidAxNode = {
 // Raw element produced by the parser before mapping to the typed Android node.
 type RawElement = { tag: string; attributes: Record<string, string>; children: RawElement[] }
 
+export const ANDROID_UIAUTOMATOR_XML_MAX_BYTES = 16 * 1024 * 1024
+export const ANDROID_UIAUTOMATOR_XML_MAX_ELEMENTS = 50_000
+export const ANDROID_UIAUTOMATOR_XML_MAX_DEPTH = 256
+export const ANDROID_UIAUTOMATOR_XML_MAX_ATTRIBUTES_PER_ELEMENT = 64
+
 // Parses an Android bounds string "[left,top][right,bottom]" -> AndroidAxBounds,
 // or null when the format doesn't match. Coordinates may be negative (off-screen).
 export function parseAndroidBounds(value: string): AndroidAxBounds | null {
@@ -39,6 +44,9 @@ export function parseAndroidBounds(value: string): AndroidAxBounds | null {
 export function parseUiAutomatorXml(xml: string): AndroidAxNode {
   if (xml.trim() === '') {
     throw new EmulatorError('emulator_error', 'Cannot parse empty uiautomator XML')
+  }
+  if (Buffer.byteLength(xml) > ANDROID_UIAUTOMATOR_XML_MAX_BYTES) {
+    throw new EmulatorError('emulator_error', 'uiautomator XML exceeds the 16 MiB limit')
   }
   let root: RawElement
   try {
@@ -107,6 +115,7 @@ function setBool(
 function parseDocument(xml: string): RawElement {
   let i = 0
   const n = xml.length
+  let elementCount = 0
 
   const fail = (message: string): never => {
     throw new EmulatorError('emulator_error', `${message} at offset ${i}`)
@@ -156,7 +165,14 @@ function parseDocument(xml: string): RawElement {
     }
   }
 
-  const parseElement = (): RawElement => {
+  const parseElement = (depth: number): RawElement => {
+    if (depth > ANDROID_UIAUTOMATOR_XML_MAX_DEPTH) {
+      fail(`uiautomator XML exceeds ${ANDROID_UIAUTOMATOR_XML_MAX_DEPTH} levels`)
+    }
+    elementCount += 1
+    if (elementCount > ANDROID_UIAUTOMATOR_XML_MAX_ELEMENTS) {
+      fail(`uiautomator XML exceeds ${ANDROID_UIAUTOMATOR_XML_MAX_ELEMENTS} elements`)
+    }
     if (xml[i] !== '<') {
       fail('Expected element start')
     }
@@ -166,6 +182,7 @@ function parseDocument(xml: string): RawElement {
       fail('Expected tag name')
     }
     const attributes: Record<string, string> = {}
+    let attributeCount = 0
     for (;;) {
       skipWs()
       if (i >= n) {
@@ -185,6 +202,12 @@ function parseDocument(xml: string): RawElement {
       const name = readName()
       if (name === '') {
         fail('Expected attribute name')
+      }
+      attributeCount += 1
+      if (attributeCount > ANDROID_UIAUTOMATOR_XML_MAX_ATTRIBUTES_PER_ELEMENT) {
+        fail(
+          `uiautomator XML element exceeds ${ANDROID_UIAUTOMATOR_XML_MAX_ATTRIBUTES_PER_ELEMENT} attributes`
+        )
       }
       skipWs()
       if (xml[i] !== '=') {
@@ -207,10 +230,14 @@ function parseDocument(xml: string): RawElement {
       attributes[name] = decodeEntities(xml.slice(start, i))
       i++
     }
-    return parseChildren(tag, attributes)
+    return parseChildren(tag, attributes, depth)
   }
 
-  const parseChildren = (tag: string, attributes: Record<string, string>): RawElement => {
+  const parseChildren = (
+    tag: string,
+    attributes: Record<string, string>,
+    depth: number
+  ): RawElement => {
     const children: RawElement[] = []
     for (;;) {
       if (i >= n) {
@@ -243,7 +270,7 @@ function parseDocument(xml: string): RawElement {
       } else if (startsWith('<?')) {
         skipDelimited('<?', '?>', 'processing instruction')
       } else {
-        children.push(parseElement())
+        children.push(parseElement(depth + 1))
       }
     }
   }
@@ -252,7 +279,7 @@ function parseDocument(xml: string): RawElement {
   if (i >= n || xml[i] !== '<') {
     fail('No root element found')
   }
-  return parseElement()
+  return parseElement(1)
 }
 
 // Decodes the predefined XML entities plus numeric character references.

--- a/src/main/emulator/mjpeg-frame-stream-reconnect.test.ts
+++ b/src/main/emulator/mjpeg-frame-stream-reconnect.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type FakeResponseLike = {
+  destroy: ReturnType<typeof vi.fn>
+  destroyed: boolean
+  emit: (eventName: string, ...args: unknown[]) => boolean
+}
+
+type FakeRequestLike = {
+  destroy: ReturnType<typeof vi.fn>
+  destroyed: boolean
+  emit: (eventName: string, ...args: unknown[]) => boolean
+  respond: (statusCode: number) => FakeResponseLike
+}
+
+const requestState = vi.hoisted(() => ({
+  requests: [] as FakeRequestLike[]
+}))
+
+vi.mock('node:http', async () => {
+  const { EventEmitter } = await import('node:events')
+
+  class FakeResponse extends EventEmitter implements FakeResponseLike {
+    destroyed = false
+    readonly resume = vi.fn()
+    readonly destroy = vi.fn(() => {
+      this.destroyed = true
+      return this
+    })
+
+    constructor(readonly statusCode: number) {
+      super()
+    }
+  }
+
+  class FakeRequest extends EventEmitter implements FakeRequestLike {
+    destroyed = false
+    private response: FakeResponse | null = null
+    readonly end = vi.fn()
+    readonly destroy = vi.fn((error?: Error) => {
+      if (this.destroyed) {
+        return this
+      }
+      this.destroyed = true
+      this.response?.destroy()
+      if (error) {
+        this.emit('error', error)
+      }
+      return this
+    })
+
+    constructor(private readonly onResponse: (response: FakeResponse) => void) {
+      super()
+    }
+
+    respond(statusCode: number): FakeResponse {
+      const response = new FakeResponse(statusCode)
+      this.response = response
+      this.onResponse(response)
+      return response
+    }
+  }
+
+  return {
+    request: vi.fn(
+      (
+        _url: unknown,
+        _options: unknown,
+        onResponse: (response: FakeResponse) => void
+      ): FakeRequest => {
+        const request = new FakeRequest(onResponse)
+        requestState.requests.push(request)
+        return request
+      }
+    )
+  }
+})
+
+import { MjpegFrameStream } from './mjpeg-frame-stream'
+
+const JPEG = Buffer.from([0xff, 0xd8, 0x01, 0x02, 0xff, 0xd9])
+const streams: MjpegFrameStream[] = []
+
+function makeStream() {
+  const callbacks = {
+    onError: vi.fn(),
+    onFrame: vi.fn()
+  }
+  const stream = new MjpegFrameStream('http://127.0.0.1:3100/stream.mjpeg', callbacks)
+  streams.push(stream)
+  return { callbacks, stream }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  requestState.requests.length = 0
+})
+
+afterEach(() => {
+  for (const stream of streams) {
+    stream.stop()
+  }
+  streams.length = 0
+  vi.useRealTimers()
+})
+
+describe('MjpegFrameStream reconnect ownership', () => {
+  it('closes an endless error response before reconnecting and ignores stale errors', () => {
+    const { callbacks, stream } = makeStream()
+    stream.start()
+    stream.start()
+    expect(requestState.requests).toHaveLength(1)
+
+    const firstRequest = requestState.requests[0]
+    const errorResponse = firstRequest.respond(503)
+    expect(firstRequest.destroyed).toBe(true)
+    expect(errorResponse.destroyed).toBe(true)
+    expect(callbacks.onError).toHaveBeenCalledWith('Simulator stream returned HTTP 503.')
+
+    vi.runOnlyPendingTimers()
+    expect(requestState.requests).toHaveLength(2)
+
+    firstRequest.emit('error', new Error('late failure'))
+    vi.runOnlyPendingTimers()
+    expect(requestState.requests).toHaveLength(2)
+    expect(callbacks.onError).toHaveBeenCalledTimes(1)
+
+    requestState.requests[1].emit('timeout')
+    expect(callbacks.onError).toHaveBeenLastCalledWith('Simulator stream timed out.')
+    stream.stop()
+    vi.runOnlyPendingTimers()
+    expect(requestState.requests).toHaveLength(2)
+  })
+
+  it('delivers a valid response and reconnects once after it ends', () => {
+    const { callbacks, stream } = makeStream()
+    stream.start()
+    const firstRequest = requestState.requests[0]
+    const response = firstRequest.respond(200)
+
+    response.emit('data', JPEG)
+    expect(callbacks.onFrame).toHaveBeenCalledWith(JPEG)
+
+    response.emit('end')
+    expect(firstRequest.destroyed).toBe(true)
+    vi.runOnlyPendingTimers()
+    expect(requestState.requests).toHaveLength(2)
+
+    response.emit('error', new Error('late response error'))
+    vi.runOnlyPendingTimers()
+    expect(requestState.requests).toHaveLength(2)
+    expect(callbacks.onError).not.toHaveBeenCalled()
+  })
+
+  it('destroys a response that arrives after its request is stale', () => {
+    const { callbacks, stream } = makeStream()
+    stream.start()
+    const firstRequest = requestState.requests[0]
+
+    firstRequest.emit('error', new Error('connection reset'))
+    vi.runOnlyPendingTimers()
+    expect(requestState.requests).toHaveLength(2)
+
+    const staleResponse = firstRequest.respond(200)
+    staleResponse.emit('data', JPEG)
+    expect(staleResponse.destroyed).toBe(true)
+    expect(callbacks.onFrame).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/emulator/mjpeg-frame-stream.ts
+++ b/src/main/emulator/mjpeg-frame-stream.ts
@@ -56,6 +56,9 @@ export class MjpegFrameStream {
   }
 
   start(): void {
+    if (this.stopped || this.request || this.reconnectTimer) {
+      return
+    }
     this.openRequest()
   }
 
@@ -70,10 +73,12 @@ export class MjpegFrameStream {
     this.pending = Buffer.alloc(0)
   }
 
-  private scheduleReconnect(): void {
-    if (this.stopped || this.reconnectTimer) {
+  private scheduleReconnect(request: ClientRequest): void {
+    if (this.stopped || this.request !== request || this.reconnectTimer) {
       return
     }
+    this.request = null
+    request.destroy()
     this.reconnectTimer = setTimeout(() => {
       this.reconnectTimer = null
       this.openRequest()
@@ -81,34 +86,45 @@ export class MjpegFrameStream {
   }
 
   private openRequest(): void {
-    if (this.stopped) {
+    if (this.stopped || this.request) {
       return
     }
 
     const req = requestForUrl(this.streamUrl, (res) => {
+      if (this.stopped || this.request !== req) {
+        res.destroy()
+        return
+      }
       if (res.statusCode && res.statusCode >= 400) {
+        this.scheduleReconnect(req)
+        res.destroy()
         this.callbacks.onError(`Simulator stream returned HTTP ${res.statusCode}.`)
-        res.resume()
-        this.scheduleReconnect()
         return
       }
 
-      res.on('data', (chunk: Buffer) => this.handleChunk(chunk))
-      res.on('end', () => this.scheduleReconnect())
+      res.on('data', (chunk: Buffer) => {
+        if (!this.stopped && this.request === req) {
+          this.handleChunk(chunk)
+        }
+      })
+      res.on('end', () => this.scheduleReconnect(req))
       res.on('error', (error) => {
+        if (this.stopped || this.request !== req) {
+          return
+        }
+        this.scheduleReconnect(req)
         this.callbacks.onError(error.message)
-        this.scheduleReconnect()
       })
     })
 
     this.request = req
     req.on('timeout', () => req.destroy(new Error('Simulator stream timed out.')))
     req.on('error', (error) => {
-      if (this.stopped) {
+      if (this.stopped || this.request !== req) {
         return
       }
+      this.scheduleReconnect(req)
       this.callbacks.onError(error.message)
-      this.scheduleReconnect()
     })
     req.end()
   }

--- a/src/main/emulator/scrcpy-video-registry-memory.test.ts
+++ b/src/main/emulator/scrcpy-video-registry-memory.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  SCRCPY_VIDEO_MAX_GOP_FRAMES,
+  SCRCPY_VIDEO_MAX_REGISTRY_ENTRIES,
+  SCRCPY_VIDEO_MAX_REPLAY_BYTES_PER_DEVICE,
+  SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL,
+  SCRCPY_VIDEO_MAX_SUBSCRIBERS,
+  scrcpyVideoRegistry,
+  type ScrcpyVideoFrameMessage
+} from './scrcpy-video-registry'
+
+const MEBIBYTE = 1024 * 1024
+const registeredDevices = new Set<string>()
+
+function registerDevice(deviceId: string, close = vi.fn()): void {
+  scrcpyVideoRegistry.register(deviceId, close)
+  registeredDevices.add(deviceId)
+}
+
+function frame(
+  pts: string,
+  byteLength: number,
+  options: { config?: boolean; keyFrame?: boolean } = {}
+): ScrcpyVideoFrameMessage {
+  return {
+    config: options.config === true,
+    keyFrame: options.keyFrame === true,
+    pts,
+    bytes: { byteLength } as ArrayBuffer
+  }
+}
+
+function replayFrames(deviceId: string): ScrcpyVideoFrameMessage[] {
+  const frames: ScrcpyVideoFrameMessage[] = []
+  const unsubscribe = scrcpyVideoRegistry.subscribe(deviceId, (event) => {
+    if (event.type === 'frame') {
+      frames.push(event.frame)
+    }
+  })
+  unsubscribe()
+  return frames
+}
+
+function replayBytes(deviceId: string): number {
+  return replayFrames(deviceId).reduce((total, replayed) => total + replayed.bytes.byteLength, 0)
+}
+
+afterEach(() => {
+  for (const deviceId of registeredDevices) {
+    scrcpyVideoRegistry.stop(deviceId)
+  }
+  registeredDevices.clear()
+})
+
+describe('scrcpy video replay retention', () => {
+  it('sheds an overloaded GOP until a fresh keyframe arrives', () => {
+    registerDevice('frame-cap')
+    scrcpyVideoRegistry.pushFrame('frame-cap', frame('key', 1, { keyFrame: true }))
+    for (let index = 1; index <= SCRCPY_VIDEO_MAX_GOP_FRAMES + 10; index += 1) {
+      scrcpyVideoRegistry.pushFrame('frame-cap', frame(String(index), 1))
+    }
+
+    expect(replayFrames('frame-cap')).toEqual([])
+
+    scrcpyVideoRegistry.pushFrame('frame-cap', frame('recovery-key', 1, { keyFrame: true }))
+    expect(replayFrames('frame-cap').map((replayed) => replayed.pts)).toEqual(['recovery-key'])
+  })
+
+  it('sheds only cached deltas under per-device byte pressure', () => {
+    registerDevice('device-bytes')
+    const liveFrames: string[] = []
+    const unsubscribe = scrcpyVideoRegistry.subscribe('device-bytes', (event) => {
+      if (event.type === 'frame') {
+        liveFrames.push(event.frame.pts)
+      }
+    })
+
+    scrcpyVideoRegistry.pushFrame('device-bytes', frame('config', MEBIBYTE, { config: true }))
+    scrcpyVideoRegistry.pushFrame('device-bytes', frame('key', 8 * MEBIBYTE, { keyFrame: true }))
+    for (let index = 1; index <= 5; index += 1) {
+      scrcpyVideoRegistry.pushFrame('device-bytes', frame(`delta-${index}`, 8 * MEBIBYTE))
+    }
+    unsubscribe()
+
+    expect(liveFrames).toEqual([
+      'config',
+      'key',
+      'delta-1',
+      'delta-2',
+      'delta-3',
+      'delta-4',
+      'delta-5'
+    ])
+    expect(replayFrames('device-bytes').map((replayed) => replayed.pts)).toEqual(['config'])
+    expect(replayBytes('device-bytes')).toBeLessThanOrEqual(
+      SCRCPY_VIDEO_MAX_REPLAY_BYTES_PER_DEVICE
+    )
+    scrcpyVideoRegistry.pushFrame(
+      'device-bytes',
+      frame('recovery-key', 8 * MEBIBYTE, { keyFrame: true })
+    )
+    expect(replayFrames('device-bytes').map((replayed) => replayed.pts)).toEqual([
+      'config',
+      'recovery-key'
+    ])
+  })
+
+  it('delivers an oversized frame live without retaining invalid replay', () => {
+    registerDevice('oversized')
+    const liveFrames: string[] = []
+    const unsubscribe = scrcpyVideoRegistry.subscribe('oversized', (event) => {
+      if (event.type === 'frame') {
+        liveFrames.push(event.frame.pts)
+      }
+    })
+    scrcpyVideoRegistry.pushFrame('oversized', frame('config', 1, { config: true }))
+    scrcpyVideoRegistry.pushFrame(
+      'oversized',
+      frame('key', SCRCPY_VIDEO_MAX_REPLAY_BYTES_PER_DEVICE, { keyFrame: true })
+    )
+    unsubscribe()
+
+    expect(liveFrames).toEqual(['config', 'key'])
+    expect(replayFrames('oversized').map((replayed) => replayed.pts)).toEqual(['config'])
+  })
+
+  it('bounds replay bytes across devices while protecting the newest device', () => {
+    const perEntryBytes = 16 * MEBIBYTE
+    const deviceCount = Math.floor(SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL / perEntryBytes) + 1
+    const deviceIds = Array.from({ length: deviceCount }, (_, index) => `aggregate-${index}`)
+
+    for (const deviceId of deviceIds) {
+      registerDevice(deviceId)
+      scrcpyVideoRegistry.pushFrame(deviceId, frame('config', MEBIBYTE, { config: true }))
+      scrcpyVideoRegistry.pushFrame(
+        deviceId,
+        frame('key', perEntryBytes - MEBIBYTE, { keyFrame: true })
+      )
+    }
+
+    const totalReplayBytes = deviceIds.reduce((total, deviceId) => total + replayBytes(deviceId), 0)
+    expect(totalReplayBytes).toBeLessThanOrEqual(SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL)
+    expect(replayFrames(deviceIds.at(-1)!).map((replayed) => replayed.pts)).toEqual([
+      'config',
+      'key'
+    ])
+    for (const deviceId of deviceIds) {
+      expect(replayFrames(deviceId).map((replayed) => replayed.pts)).toEqual(
+        expect.arrayContaining(['config'])
+      )
+    }
+  })
+
+  it('cleans accounting before a reentrant close callback', () => {
+    const close = vi.fn(() => scrcpyVideoRegistry.stop('reentrant'))
+    registerDevice('reentrant', close)
+    scrcpyVideoRegistry.pushFrame(
+      'reentrant',
+      frame('key', SCRCPY_VIDEO_MAX_REPLAY_BYTES_PER_DEVICE, { keyFrame: true })
+    )
+
+    scrcpyVideoRegistry.stop('reentrant')
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(scrcpyVideoRegistry.has('reentrant')).toBe(false)
+  })
+
+  it('bounds active registry entries without closing admitted streams', () => {
+    const closes: ReturnType<typeof vi.fn>[] = []
+    for (let index = 0; index < SCRCPY_VIDEO_MAX_REGISTRY_ENTRIES; index += 1) {
+      const close = vi.fn()
+      closes.push(close)
+      registerDevice(`entry-${index}`, close)
+    }
+
+    expect(() => registerDevice('entry-overflow')).toThrow(/active scrcpy video streams/)
+    for (const close of closes) {
+      expect(close).not.toHaveBeenCalled()
+    }
+  })
+
+  it('bounds subscriber callbacks and releases admission on unsubscribe', () => {
+    registerDevice('subscriber-cap')
+    const unsubscribes = Array.from({ length: SCRCPY_VIDEO_MAX_SUBSCRIBERS }, () =>
+      scrcpyVideoRegistry.subscribe('subscriber-cap', () => {})
+    )
+
+    expect(() => scrcpyVideoRegistry.subscribe('subscriber-cap', () => {})).toThrow(
+      /video subscribers/
+    )
+    unsubscribes[0]()
+    expect(() => scrcpyVideoRegistry.subscribe('subscriber-cap', () => {})).not.toThrow()
+  })
+})

--- a/src/main/emulator/scrcpy-video-registry.ts
+++ b/src/main/emulator/scrcpy-video-registry.ts
@@ -8,8 +8,13 @@ import type { ScrcpyVideoMeta } from './android/scrcpy-video-frame-parser'
 
 // scrcpy keyframes ~every 10s; high-motion content can otherwise buffer
 // hundreds of deltas. Cap the replayed GOP so memory stays bounded and a
-// late subscriber isn't flooded — always keep the keyframe at index 0.
-const MAX_GOP_FRAMES = 120
+// late subscriber isn't flooded. An overloaded GOP is shed as a unit because
+// dropping an interior delta would make the retained suffix undecodable.
+export const SCRCPY_VIDEO_MAX_GOP_FRAMES = 120
+export const SCRCPY_VIDEO_MAX_REPLAY_BYTES_PER_DEVICE = 32 * 1024 * 1024
+export const SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL = 128 * 1024 * 1024
+export const SCRCPY_VIDEO_MAX_REGISTRY_ENTRIES = 16
+export const SCRCPY_VIDEO_MAX_SUBSCRIBERS = 8
 
 export type ScrcpyVideoFrameMessage = {
   config: boolean
@@ -30,13 +35,27 @@ type RegistryEntry = {
   gop: ScrcpyVideoFrameMessage[]
   subscribers: Set<ScrcpyVideoSubscriber>
   close: () => void
+  retainedBytes: number
 }
 
 class ScrcpyVideoRegistry {
   private readonly entries = new Map<string, RegistryEntry>()
+  private retainedBytes = 0
+  private subscriberCount = 0
 
   register(deviceId: string, close: () => void): void {
-    this.entries.set(deviceId, { subscribers: new Set(), gop: [], close })
+    if (!this.entries.has(deviceId) && this.entries.size >= SCRCPY_VIDEO_MAX_REGISTRY_ENTRIES) {
+      throw new Error(
+        `Orca can have at most ${SCRCPY_VIDEO_MAX_REGISTRY_ENTRIES} active scrcpy video streams.`
+      )
+    }
+    this.stop(deviceId)
+    this.entries.set(deviceId, {
+      subscribers: new Set(),
+      gop: [],
+      close,
+      retainedBytes: 0
+    })
   }
 
   pushMeta(deviceId: string, meta: ScrcpyVideoMeta): void {
@@ -56,20 +75,21 @@ class ScrcpyVideoRegistry {
       return
     }
     if (frame.config) {
-      entry.config = frame
+      this.replaceConfig(entry, frame)
     } else if (frame.keyFrame) {
       // A keyframe starts a fresh decodeable GOP; buffer it + the following
       // deltas so a late subscriber can decode immediately on replay.
-      entry.gop = [frame]
+      this.clearGop(entry)
+      entry.gop.push(frame)
+      this.adjustRetainedBytes(entry, frame.bytes.byteLength)
     } else if (entry.gop.length > 0) {
       // Only buffer deltas once a keyframe anchors the GOP (a delta alone is
       // undecodable); deltas before the first keyframe are still sent live below.
       entry.gop.push(frame)
-      // Drop the oldest delta (never index 0, the keyframe) so replay stays decodable.
-      if (entry.gop.length > MAX_GOP_FRAMES) {
-        entry.gop.splice(1, 1)
-      }
+      this.adjustRetainedBytes(entry, frame.bytes.byteLength)
     }
+    this.trimEntryReplay(entry)
+    this.trimAggregateReplay(deviceId)
     for (const subscriber of entry.subscribers) {
       subscriber({ type: 'frame', frame })
     }
@@ -82,6 +102,11 @@ class ScrcpyVideoRegistry {
     if (!entry) {
       return () => {}
     }
+    if (this.subscriberCount >= SCRCPY_VIDEO_MAX_SUBSCRIBERS) {
+      throw new Error(
+        `Orca can have at most ${SCRCPY_VIDEO_MAX_SUBSCRIBERS} scrcpy video subscribers.`
+      )
+    }
     if (entry.meta) {
       subscriber({ type: 'meta', meta: entry.meta })
     }
@@ -92,8 +117,16 @@ class ScrcpyVideoRegistry {
     for (const frame of entry.gop) {
       subscriber({ type: 'frame', frame })
     }
+    if (this.entries.get(deviceId) !== entry) {
+      return () => {}
+    }
     entry.subscribers.add(subscriber)
-    return () => entry.subscribers.delete(subscriber)
+    this.subscriberCount += 1
+    return () => {
+      if (entry.subscribers.delete(subscriber)) {
+        this.subscriberCount -= 1
+      }
+    }
   }
 
   stop(deviceId: string): void {
@@ -101,13 +134,89 @@ class ScrcpyVideoRegistry {
     if (!entry) {
       return
     }
-    entry.close()
-    entry.subscribers.clear()
     this.entries.delete(deviceId)
+    this.subscriberCount -= entry.subscribers.size
+    entry.subscribers.clear()
+    this.clearGop(entry)
+    this.clearConfig(entry)
+    entry.close()
   }
 
   has(deviceId: string): boolean {
     return this.entries.has(deviceId)
+  }
+
+  private adjustRetainedBytes(entry: RegistryEntry, delta: number): void {
+    entry.retainedBytes += delta
+    this.retainedBytes += delta
+  }
+
+  private replaceConfig(entry: RegistryEntry, frame: ScrcpyVideoFrameMessage): void {
+    this.clearConfig(entry)
+    entry.config = frame
+    this.adjustRetainedBytes(entry, frame.bytes.byteLength)
+  }
+
+  private clearConfig(entry: RegistryEntry): void {
+    if (!entry.config) {
+      return
+    }
+    this.adjustRetainedBytes(entry, -entry.config.bytes.byteLength)
+    entry.config = undefined
+  }
+
+  private clearGop(entry: RegistryEntry): void {
+    for (const frame of entry.gop) {
+      this.adjustRetainedBytes(entry, -frame.bytes.byteLength)
+    }
+    entry.gop = []
+  }
+
+  private trimEntryReplay(entry: RegistryEntry): void {
+    if (
+      entry.gop.length > SCRCPY_VIDEO_MAX_GOP_FRAMES ||
+      entry.retainedBytes > SCRCPY_VIDEO_MAX_REPLAY_BYTES_PER_DEVICE
+    ) {
+      this.clearGop(entry)
+    }
+    if (entry.retainedBytes > SCRCPY_VIDEO_MAX_REPLAY_BYTES_PER_DEVICE) {
+      this.clearConfig(entry)
+    }
+  }
+
+  private trimAggregateReplay(preferredDeviceId: string): void {
+    if (this.retainedBytes <= SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL) {
+      return
+    }
+    const preferred = this.entries.get(preferredDeviceId)
+
+    for (const [deviceId, entry] of this.entries) {
+      if (deviceId === preferredDeviceId) {
+        continue
+      }
+      if (this.retainedBytes > SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL && entry.gop.length > 0) {
+        this.clearGop(entry)
+      }
+    }
+    if (
+      preferred &&
+      this.retainedBytes > SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL &&
+      preferred.gop.length > 0
+    ) {
+      this.clearGop(preferred)
+    }
+    for (const [deviceId, entry] of this.entries) {
+      if (this.retainedBytes <= SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL) {
+        break
+      }
+      if (deviceId === preferredDeviceId) {
+        continue
+      }
+      this.clearConfig(entry)
+    }
+    if (preferred && this.retainedBytes > SCRCPY_VIDEO_MAX_REPLAY_BYTES_TOTAL) {
+      this.clearConfig(preferred)
+    }
   }
 }
 

--- a/src/main/emulator/serve-sim-accessibility-tree.test.ts
+++ b/src/main/emulator/serve-sim-accessibility-tree.test.ts
@@ -4,7 +4,10 @@ const { netFetchMock } = vi.hoisted(() => ({ netFetchMock: vi.fn() }))
 
 vi.mock('electron', () => ({ net: { fetch: netFetchMock } }))
 
-import { requestServeSimAccessibilityTree } from './serve-sim-accessibility-tree'
+import {
+  MAX_SERVE_SIM_AX_RESPONSE_BYTES,
+  requestServeSimAccessibilityTree
+} from './serve-sim-accessibility-tree'
 
 const AX_URL = 'http://127.0.0.1:3100/ax'
 
@@ -80,6 +83,25 @@ describe('requestServeSimAccessibilityTree', () => {
     })
 
     netFetchMock.mockResolvedValueOnce(new Response('not json', { status: 200 }))
+    await expect(requestServeSimAccessibilityTree(AX_URL)).rejects.toMatchObject({
+      code: 'emulator_error'
+    })
+  })
+
+  it('rejects oversized or excessively nested payloads before parsing', async () => {
+    netFetchMock.mockResolvedValueOnce(
+      new Response('[]', {
+        status: 200,
+        headers: { 'content-length': String(MAX_SERVE_SIM_AX_RESPONSE_BYTES + 1) }
+      })
+    )
+    await expect(requestServeSimAccessibilityTree(AX_URL)).rejects.toMatchObject({
+      code: 'emulator_helper_failed'
+    })
+
+    netFetchMock.mockResolvedValueOnce(
+      new Response(`${'['.repeat(129)}0${']'.repeat(129)}`, { status: 200 })
+    )
     await expect(requestServeSimAccessibilityTree(AX_URL)).rejects.toMatchObject({
       code: 'emulator_error'
     })

--- a/src/main/emulator/serve-sim-accessibility-tree.ts
+++ b/src/main/emulator/serve-sim-accessibility-tree.ts
@@ -1,16 +1,22 @@
 import { net } from 'electron'
 import { EmulatorError } from './emulator-errors'
 import { normalizeServeSimAxTree, type NormalizedAxNode } from './serve-sim-ax-normalization'
+import {
+  API_RESPONSE_JSON_LIMITS,
+  readFetchResponseTextWithinLimit
+} from '../../shared/fetch-response-body'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
 
 const AX_REQUEST_TIMEOUT_MS = 5_000
 const MAX_ERROR_BODY_LENGTH = 512
+export const MAX_SERVE_SIM_AX_RESPONSE_BYTES = 16 * 1024 * 1024
 
 export async function requestServeSimAccessibilityTree(axUrl: string): Promise<NormalizedAxNode[]> {
   try {
     const response = await net.fetch(axUrl, {
       signal: AbortSignal.timeout(AX_REQUEST_TIMEOUT_MS)
     })
-    const body = await response.text()
+    const body = await readFetchResponseTextWithinLimit(response, MAX_SERVE_SIM_AX_RESPONSE_BYTES)
     if (!response.ok) {
       const detail = body.slice(0, MAX_ERROR_BODY_LENGTH) || response.statusText
       const retry = response.status === 503 ? ' Accessibility may still be warming up; retry.' : ''
@@ -22,6 +28,7 @@ export async function requestServeSimAccessibilityTree(axUrl: string): Promise<N
 
     let tree: unknown
     try {
+      assertJsonTextStructureWithinLimits(body, API_RESPONSE_JSON_LIMITS)
       tree = JSON.parse(body)
     } catch {
       throw new EmulatorError('emulator_error', 'serve-sim AX returned invalid JSON.')

--- a/src/main/emulator/serve-sim-detached-session.test.ts
+++ b/src/main/emulator/serve-sim-detached-session.test.ts
@@ -1,8 +1,35 @@
-import { describe, expect, it } from 'vitest'
+import { mkdirSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   deriveAxUrlFromStreamUrl,
+  SERVE_SIM_STATE_FILE_MAX_BYTES,
   parseServeSimDetachedSession
 } from './serve-sim-detached-session'
+
+const stateFiles: string[] = []
+
+function stateFileFor(udid: string): string {
+  const filePath = join(tmpdir(), 'serve-sim', `server-${udid}.json`)
+  mkdirSync(join(tmpdir(), 'serve-sim'), { recursive: true })
+  stateFiles.push(filePath)
+  return filePath
+}
+
+function detachedPayload(udid: string): Record<string, string> {
+  return {
+    device: udid,
+    streamUrl: 'http://127.0.0.1:3100/stream.mjpeg',
+    wsUrl: 'ws://127.0.0.1:3100/ws'
+  }
+}
+
+afterEach(() => {
+  for (const filePath of stateFiles.splice(0)) {
+    rmSync(filePath, { force: true })
+  }
+})
 
 describe('parseServeSimDetachedSession', () => {
   it('uses serve-sim streamUrl when present', () => {
@@ -55,6 +82,27 @@ describe('parseServeSimDetachedSession', () => {
     )
 
     expect(info.streamUrl).toBe('http://127.0.0.1:3100/stream.mjpeg')
+  })
+
+  it('reads a helper PID state file at the exact byte boundary', () => {
+    const udid = `orca-boundary-${process.pid}-${Date.now()}`
+    const statePath = stateFileFor(udid)
+    const state = '{"pid":4321}'
+    writeFileSync(
+      statePath,
+      state + ' '.repeat(SERVE_SIM_STATE_FILE_MAX_BYTES - Buffer.byteLength(state))
+    )
+
+    expect(parseServeSimDetachedSession(detachedPayload(udid), udid).helperPid).toBe(4321)
+  })
+
+  it('ignores a sparse helper PID state file one byte over the boundary', () => {
+    const udid = `orca-oversized-${process.pid}-${Date.now()}`
+    const statePath = stateFileFor(udid)
+    writeFileSync(statePath, '{"pid":4321}')
+    truncateSync(statePath, SERVE_SIM_STATE_FILE_MAX_BYTES + 1)
+
+    expect(parseServeSimDetachedSession(detachedPayload(udid), udid).helperPid).toBeUndefined()
   })
 })
 

--- a/src/main/emulator/serve-sim-detached-session.ts
+++ b/src/main/emulator/serve-sim-detached-session.ts
@@ -1,10 +1,11 @@
-import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 import { EmulatorError } from './emulator-errors'
 import type { EmulatorSessionInfo } from './emulator-types'
 
 const MJPEG_STREAM_SUFFIX = '/stream.mjpeg'
+export const SERVE_SIM_STATE_FILE_MAX_BYTES = 8 * 1024
 
 function streamUrlFromServeSimUrl(url: string): string {
   return url.endsWith(MJPEG_STREAM_SUFFIX) ? url : `${url.replace(/\/$/, '')}${MJPEG_STREAM_SUFFIX}`
@@ -42,11 +43,11 @@ export function parseServeSimDetachedSession(raw: unknown, udid: string): Emulat
   }
   try {
     const statePath = join(tmpdir(), 'serve-sim', `server-${info.deviceUdid}.json`)
-    if (existsSync(statePath)) {
-      const state = JSON.parse(readFileSync(statePath, 'utf8')) as { pid?: unknown }
-      if (typeof state.pid === 'number') {
-        info.helperPid = state.pid
-      }
+    const state = JSON.parse(
+      readNodeFileSyncWithinLimit(statePath, SERVE_SIM_STATE_FILE_MAX_BYTES).buffer.toString('utf8')
+    ) as { pid?: unknown }
+    if (typeof state.pid === 'number') {
+      info.helperPid = state.pid
     }
   } catch {}
   return info

--- a/src/main/emulator/serve-sim-execution.ts
+++ b/src/main/emulator/serve-sim-execution.ts
@@ -1,16 +1,9 @@
 import { execFile } from 'node:child_process'
-import {
-  accessSync,
-  chmodSync,
-  constants,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  writeFileSync
-} from 'node:fs'
+import { accessSync, chmodSync, constants, existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { app } from 'electron'
 import { platform, tmpdir } from 'node:os'
 import { delimiter, dirname, join } from 'node:path'
+import { nodeFileContentsEqualSync } from '../../shared/node-file-content-equality'
 import { EmulatorError } from './emulator-errors'
 import { materializeServeSimRuntime } from './serve-sim-runtime-materializer'
 
@@ -45,8 +38,10 @@ function ensureMacOpenShim(): string | null {
   }
   try {
     mkdirSync(MAC_OPEN_SHIM_DIR, { recursive: true })
-    const current = existsSync(MAC_OPEN_SHIM_PATH) ? readFileSync(MAC_OPEN_SHIM_PATH, 'utf8') : ''
-    if (current !== MAC_OPEN_SHIM) {
+    if (
+      !existsSync(MAC_OPEN_SHIM_PATH) ||
+      !nodeFileContentsEqualSync(MAC_OPEN_SHIM_PATH, MAC_OPEN_SHIM)
+    ) {
       writeFileSync(MAC_OPEN_SHIM_PATH, MAC_OPEN_SHIM, { mode: 0o755 })
     }
     chmodSync(MAC_OPEN_SHIM_PATH, 0o755)

--- a/src/main/emulator/serve-sim-runtime-materializer.ts
+++ b/src/main/emulator/serve-sim-runtime-materializer.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { chmodSync, cpSync, existsSync, mkdirSync, readdirSync, renameSync, rmSync } from 'node:fs'
+import { chmodSync, cpSync, existsSync, mkdirSync, opendirSync, renameSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 
 export type ServeSimRuntimeMaterializerOptions = {
@@ -13,6 +13,7 @@ const EXECUTABLE_RELATIVE_PATHS = [
   join('bin', 'serve-sim-bin'),
   join('dist', 'simcam', 'serve-sim-camera-helper')
 ]
+export const SERVE_SIM_RUNTIME_MAX_PRUNE_ENTRIES = 4_096
 
 function defaultClearQuarantine(dir: string): void {
   if (process.platform !== 'darwin') {
@@ -28,21 +29,44 @@ function defaultClearQuarantine(dir: string): void {
   execFileSync('/usr/bin/xattr', ['-rd', 'com.apple.quarantine', dir], { timeout: 30_000 })
 }
 
-function pruneStaleServeSimRuntimes(targetRootDir: string, keepVersion: string): void {
-  let entries: string[]
+export function pruneStaleServeSimRuntimes(
+  targetRootDir: string,
+  keepVersion: string,
+  requestedMaxEntries = SERVE_SIM_RUNTIME_MAX_PRUNE_ENTRIES
+): void {
+  const maxEntries =
+    Number.isSafeInteger(requestedMaxEntries) && requestedMaxEntries >= 0
+      ? Math.min(requestedMaxEntries, SERVE_SIM_RUNTIME_MAX_PRUNE_ENTRIES)
+      : SERVE_SIM_RUNTIME_MAX_PRUNE_ENTRIES
+  let directory: ReturnType<typeof opendirSync>
   try {
-    entries = readdirSync(targetRootDir)
+    directory = opendirSync(targetRootDir, { bufferSize: 32 })
   } catch {
     return
   }
-  for (const entryName of entries) {
-    if (entryName === keepVersion) {
-      continue
+
+  let scannedEntries = 0
+  try {
+    while (scannedEntries < maxEntries) {
+      const entry = directory.readSync()
+      if (entry === null) {
+        return
+      }
+      scannedEntries += 1
+      if (entry.name === keepVersion) {
+        continue
+      }
+      try {
+        rmSync(join(targetRootDir, entry.name), { recursive: true, force: true })
+      } catch {
+        // Old-version cleanup is best-effort; a locked file must not block materialization.
+      }
     }
+  } finally {
     try {
-      rmSync(join(targetRootDir, entryName), { recursive: true, force: true })
+      directory.closeSync()
     } catch {
-      // Old-version cleanup is best-effort; a locked file must not block materialization.
+      // A failed close cannot make already bounded cleanup unsafe.
     }
   }
 }

--- a/src/main/emulator/serve-sim-runtime-pruning-bounds.test.ts
+++ b/src/main/emulator/serve-sim-runtime-pruning-bounds.test.ts
@@ -1,0 +1,79 @@
+import type * as NodeFs from 'node:fs'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { opendirSyncMock, rmSyncMock } = vi.hoisted(() => ({
+  opendirSyncMock: vi.fn(),
+  rmSyncMock: vi.fn()
+}))
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFs>()),
+  opendirSync: opendirSyncMock,
+  rmSync: rmSyncMock
+}))
+
+import {
+  pruneStaleServeSimRuntimes,
+  SERVE_SIM_RUNTIME_MAX_PRUNE_ENTRIES
+} from './serve-sim-runtime-materializer'
+
+function useEntryNames(names: string[]): {
+  closeSync: ReturnType<typeof vi.fn>
+  readSync: ReturnType<typeof vi.fn>
+} {
+  let index = 0
+  const directory = {
+    closeSync: vi.fn(),
+    readSync: vi.fn(() => {
+      const name = names[index]
+      index += 1
+      return name === undefined ? null : { name }
+    })
+  }
+  opendirSyncMock.mockReturnValue(directory)
+  return directory
+}
+
+describe('serve-sim stale runtime pruning bounds', () => {
+  beforeEach(() => {
+    opendirSyncMock.mockReset()
+    rmSyncMock.mockReset()
+  })
+
+  it('processes the exact requested entry limit in stream order', () => {
+    const directory = useEntryNames(['old-a', 'keep', 'old-b', 'old-c'])
+
+    pruneStaleServeSimRuntimes('/runtime', 'keep', 3)
+
+    expect(rmSyncMock).toHaveBeenCalledTimes(2)
+    expect(rmSyncMock).toHaveBeenNthCalledWith(1, join('/runtime', 'old-a'), {
+      recursive: true,
+      force: true
+    })
+    expect(rmSyncMock).toHaveBeenNthCalledWith(2, join('/runtime', 'old-b'), {
+      recursive: true,
+      force: true
+    })
+    expect(directory.readSync).toHaveBeenCalledTimes(3)
+    expect(directory.closeSync).toHaveBeenCalledOnce()
+  })
+
+  it('stops at the production cap without reading or retaining the next entry', () => {
+    let nextEntry = 0
+    const directory = {
+      closeSync: vi.fn(),
+      readSync: vi.fn(() => {
+        nextEntry += 1
+        return { name: `old-${nextEntry}` }
+      })
+    }
+    opendirSyncMock.mockReturnValue(directory)
+
+    pruneStaleServeSimRuntimes('/runtime', 'keep')
+
+    expect(directory.readSync).toHaveBeenCalledTimes(SERVE_SIM_RUNTIME_MAX_PRUNE_ENTRIES)
+    expect(rmSyncMock).toHaveBeenCalledTimes(SERVE_SIM_RUNTIME_MAX_PRUNE_ENTRIES)
+    expect(directory.closeSync).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/ghostty/index.test.ts
+++ b/src/main/ghostty/index.test.ts
@@ -1,22 +1,36 @@
 import type { Store } from '../persistence'
 import type { GlobalSettings } from '../../shared/types'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
+import type * as GhosttyParser from './parser'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const { statMock, readFileMock } = vi.hoisted(() => ({
+const { statMock, readNodeFileWithinLimitMock, parseGhosttyConfigMock } = vi.hoisted(() => ({
   statMock: vi.fn(),
-  readFileMock: vi.fn()
+  readNodeFileWithinLimitMock: vi.fn(),
+  parseGhosttyConfigMock: vi.fn()
 }))
 
 vi.mock('fs/promises', () => ({
-  stat: statMock,
-  readFile: readFileMock
+  stat: statMock
 }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => ({
+  ...(await importOriginal<typeof BoundedFileReader>()),
+  readNodeFileWithinLimit: readNodeFileWithinLimitMock
+}))
+
+vi.mock('./parser', async (importOriginal) => {
+  const actual = await importOriginal<typeof GhosttyParser>()
+  parseGhosttyConfigMock.mockImplementation(actual.parseGhosttyConfig)
+  return { ...actual, parseGhosttyConfig: parseGhosttyConfigMock }
+})
 
 vi.mock('os', () => ({
   platform: vi.fn(() => 'darwin'),
   homedir: vi.fn(() => '/Users/alice')
 }))
 
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import { previewGhosttyImport } from './index'
 
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
@@ -36,6 +50,13 @@ function createStore(settings: Record<string, unknown> = {}): Store {
   } as Store
 }
 
+function fileRead(content: string, size = Buffer.byteLength(content)) {
+  return {
+    buffer: Buffer.from(content),
+    stats: { isFile: () => true, size }
+  }
+}
+
 describe('previewGhosttyImport', () => {
   it('returns found false when no config exists', async () => {
     statMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
@@ -52,11 +73,13 @@ describe('previewGhosttyImport', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue(`
+    readNodeFileWithinLimitMock.mockResolvedValue(
+      fileRead(`
 font-family = JetBrains Mono
 font-size = 14
 background = #1a1a1a
 `)
+    )
 
     const result = await previewGhosttyImport(
       createStore({
@@ -88,12 +111,12 @@ background = #1a1a1a
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockImplementation(async (p: string) => {
+    readNodeFileWithinLimitMock.mockImplementation(async (p: string) => {
       if (p === '/Users/alice/.config/ghostty/config.ghostty') {
-        return 'font-size = 22\nbackground = #1a1a1a\n'
+        return fileRead('font-size = 22\nbackground = #1a1a1a\n')
       }
       if (p === '/Users/alice/.config/ghostty/config') {
-        return 'font-family = JetBrains Mono\nfont-size = 18\n'
+        return fileRead('font-family = JetBrains Mono\nfont-size = 18\n')
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
@@ -121,7 +144,7 @@ background = #1a1a1a
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('font-family = Menlo\nfont-size = 12\n')
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('font-family = Menlo\nfont-size = 12\n'))
 
     const result = await previewGhosttyImport(
       createStore({
@@ -142,7 +165,9 @@ background = #1a1a1a
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('background = #1a1a1a\nforeground = #e0e0e0\n')
+    readNodeFileWithinLimitMock.mockResolvedValue(
+      fileRead('background = #1a1a1a\nforeground = #e0e0e0\n')
+    )
 
     const result = await previewGhosttyImport(
       createStore({
@@ -162,7 +187,9 @@ background = #1a1a1a
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('background = #1a1a1a\nforeground = #e0e0e0\n')
+    readNodeFileWithinLimitMock.mockResolvedValue(
+      fileRead('background = #1a1a1a\nforeground = #e0e0e0\n')
+    )
 
     const result = await previewGhosttyImport(
       createStore({
@@ -192,7 +219,7 @@ background = #1a1a1a
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('font-family = JetBrains Mono\n')
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('font-family = JetBrains Mono\n'))
 
     // Why: Replace timer globals temporarily to detect any polling setup.
     const originalSetInterval = globalThis.setInterval
@@ -211,5 +238,45 @@ background = #1a1a1a
     expect(watchFileMock).not.toHaveBeenCalled()
     expect(setIntervalMock).not.toHaveBeenCalled()
     expect(setTimeoutMock).not.toHaveBeenCalled()
+  })
+
+  it('accepts a config at the exact byte limit', async () => {
+    const configPath = '/Users/alice/Library/Application Support/com.mitchellh.ghostty/config'
+    statMock.mockImplementation(async (p: string) => {
+      if (p === configPath) {
+        return { isFile: () => true, size: 1_000_000 }
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('font-size = 14\n', 1_000_000))
+
+    const result = await previewGhosttyImport(createStore())
+
+    expect(result.found).toBe(true)
+    expect(result.diff).toEqual({ terminalFontSize: 14 })
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith(configPath, 1_000_000)
+  })
+
+  it('rejects config growth beyond the limit before parsing', async () => {
+    const configPath = '/Users/alice/Library/Application Support/com.mitchellh.ghostty/config'
+    statMock.mockImplementation(async (p: string) => {
+      if (p === configPath) {
+        return { isFile: () => true, size: 128 }
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    readNodeFileWithinLimitMock.mockRejectedValue(
+      new NodeFileReadTooLargeError(1_000_001, 1_000_000)
+    )
+
+    const result = await previewGhosttyImport(createStore())
+
+    expect(result).toMatchObject({
+      found: false,
+      diff: {},
+      unsupportedKeys: [],
+      error: 'Config file is too large to import (1000001 bytes, limit 1000000).'
+    })
+    expect(parseGhosttyConfigMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ghostty/index.ts
+++ b/src/main/ghostty/index.ts
@@ -1,6 +1,9 @@
-import { readFile, stat } from 'node:fs/promises'
 import { platform } from 'node:os'
 import type { GlobalSettings, GhosttyImportPreview } from '../../shared/types'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../../shared/node-bounded-file-reader'
 import type { Store } from '../persistence'
 import { findGhosttyConfigPaths } from './discovery'
 import { parseGhosttyConfig } from './parser'
@@ -110,17 +113,25 @@ export async function previewGhosttyImport(store: Store): Promise<GhosttyImportP
   for (const configPath of configPaths) {
     let content: string
     try {
-      const info = await stat(configPath)
-      if (info.size > MAX_CONFIG_BYTES) {
+      const result = await readNodeFileWithinLimit(configPath, MAX_CONFIG_BYTES)
+      if (!result.stats.isFile()) {
         return {
           found: false,
           diff: {},
           unsupportedKeys: [],
-          error: `Config file is too large to import (${info.size} bytes, limit ${MAX_CONFIG_BYTES}).`
+          error: 'Could not read config: Config path is not a file'
         }
       }
-      content = await readFile(configPath, 'utf-8')
+      content = result.buffer.toString('utf8')
     } catch (err) {
+      if (err instanceof NodeFileReadTooLargeError) {
+        return {
+          found: false,
+          diff: {},
+          unsupportedKeys: [],
+          error: `Config file is too large to import (${err.observedBytes} bytes, limit ${MAX_CONFIG_BYTES}).`
+        }
+      }
       const message = err instanceof Error ? err.message : 'Could not read config file'
       return {
         found: false,

--- a/src/main/ghostty/theme-import.test.ts
+++ b/src/main/ghostty/theme-import.test.ts
@@ -1,15 +1,20 @@
 import type { Store } from '../persistence'
 import type { GlobalSettings } from '../../shared/types'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { statMock, readFileMock } = vi.hoisted(() => ({
+const { statMock, readNodeFileWithinLimitMock } = vi.hoisted(() => ({
   statMock: vi.fn(),
-  readFileMock: vi.fn()
+  readNodeFileWithinLimitMock: vi.fn()
 }))
 
 vi.mock('fs/promises', () => ({
-  stat: statMock,
-  readFile: readFileMock
+  stat: statMock
+}))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => ({
+  ...(await importOriginal<typeof BoundedFileReader>()),
+  readNodeFileWithinLimit: readNodeFileWithinLimitMock
 }))
 
 vi.mock('os', () => ({
@@ -47,6 +52,13 @@ function createStore(settings: Record<string, unknown> = {}): Store {
   } as Store
 }
 
+function fileRead(content: string) {
+  return {
+    buffer: Buffer.from(content),
+    stats: { isFile: () => true, size: Buffer.byteLength(content) }
+  }
+}
+
 describe('previewGhosttyImport theme references', () => {
   it('resolves a theme reference into color overrides', async () => {
     const configPath = '/Users/alice/Library/Application Support/com.mitchellh.ghostty/config'
@@ -57,11 +69,11 @@ describe('previewGhosttyImport theme references', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockImplementation(async (p: string) => {
+    readNodeFileWithinLimitMock.mockImplementation(async (p: string) => {
       if (p === themePath) {
-        return 'palette = 1=#d54e53\nbackground = #000000\nforeground = #eaeaea\n'
+        return fileRead('palette = 1=#d54e53\nbackground = #000000\nforeground = #eaeaea\n')
       }
-      return 'theme = Tomorrow Night Bright\nfont-size = 14\n'
+      return fileRead('theme = Tomorrow Night Bright\nfont-size = 14\n')
     })
 
     const result = await previewGhosttyImport(createStore())
@@ -86,11 +98,11 @@ describe('previewGhosttyImport theme references', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockImplementation(async (p: string) => {
+    readNodeFileWithinLimitMock.mockImplementation(async (p: string) => {
       if (p === themePath) {
-        return 'palette = 1=#d54e53\npalette = 2=#b9ca4a\nbackground = #000000\n'
+        return fileRead('palette = 1=#d54e53\npalette = 2=#b9ca4a\nbackground = #000000\n')
       }
-      return 'theme = night\nbackground = #101010\npalette = 1=#ff0000\n'
+      return fileRead('theme = night\nbackground = #101010\npalette = 1=#ff0000\n')
     })
 
     const result = await previewGhosttyImport(createStore())
@@ -115,11 +127,11 @@ describe('previewGhosttyImport theme references', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockImplementation(async (p: string) => {
+    readNodeFileWithinLimitMock.mockImplementation(async (p: string) => {
       if (p === themePath) {
-        return 'background = #202020\nforeground = #f0f0f0\n'
+        return fileRead('background = #202020\nforeground = #f0f0f0\n')
       }
-      return `theme = ${themePath}\n`
+      return fileRead(`theme = ${themePath}\n`)
     })
 
     const result = await previewGhosttyImport(createStore())
@@ -145,7 +157,7 @@ describe('previewGhosttyImport theme references', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('theme = Missing Theme\n')
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('theme = Missing Theme\n'))
 
     const result = await previewGhosttyImport(createStore())
 
@@ -161,7 +173,9 @@ describe('previewGhosttyImport theme references', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('theme = light:Tomorrow,dark:Tomorrow Night\n')
+    readNodeFileWithinLimitMock.mockResolvedValue(
+      fileRead('theme = light:Tomorrow,dark:Tomorrow Night\n')
+    )
 
     const result = await previewGhosttyImport(createStore())
 

--- a/src/main/ghostty/theme-resolution.test.ts
+++ b/src/main/ghostty/theme-resolution.test.ts
@@ -1,20 +1,34 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
+import type * as GhosttyParser from './parser'
 
-const { statMock, readFileMock } = vi.hoisted(() => ({
+const { statMock, readNodeFileWithinLimitMock, parseGhosttyConfigMock } = vi.hoisted(() => ({
   statMock: vi.fn(),
-  readFileMock: vi.fn()
+  readNodeFileWithinLimitMock: vi.fn(),
+  parseGhosttyConfigMock: vi.fn()
 }))
 
 vi.mock('fs/promises', () => ({
-  stat: statMock,
-  readFile: readFileMock
+  stat: statMock
 }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => ({
+  ...(await importOriginal<typeof BoundedFileReader>()),
+  readNodeFileWithinLimit: readNodeFileWithinLimitMock
+}))
+
+vi.mock('./parser', async (importOriginal) => {
+  const actual = await importOriginal<typeof GhosttyParser>()
+  parseGhosttyConfigMock.mockImplementation(actual.parseGhosttyConfig)
+  return { ...actual, parseGhosttyConfig: parseGhosttyConfigMock }
+})
 
 vi.mock('os', () => ({
   platform: vi.fn(() => 'darwin'),
   homedir: vi.fn(() => '/Users/alice')
 }))
 
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import { getGhosttyThemeSearchDirs, resolveGhosttyThemeColors } from './theme-resolution'
 
 const originalXdgConfigHome = process.env.XDG_CONFIG_HOME
@@ -49,6 +63,13 @@ selection-background = #424242
 selection-foreground = #eaeaea
 `
 
+function fileRead(content: string, size = Buffer.byteLength(content)) {
+  return {
+    buffer: Buffer.from(content),
+    stats: { isFile: () => true, size }
+  }
+}
+
 describe('getGhosttyThemeSearchDirs', () => {
   it('probes XDG, then the Ghostty.app resources dir', () => {
     delete process.env.XDG_CONFIG_HOME
@@ -80,7 +101,7 @@ describe('resolveGhosttyThemeColors', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue(THEME_FILE)
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead(THEME_FILE))
 
     const result = await resolveGhosttyThemeColors('Tomorrow Night Bright')
     expect(result).toEqual({
@@ -100,7 +121,7 @@ describe('resolveGhosttyThemeColors', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('background = #1d1f21')
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('background = #1d1f21'))
 
     const result = await resolveGhosttyThemeColors('Tomorrow')
     expect(result).toEqual({ background: '#1d1f21' })
@@ -113,7 +134,7 @@ describe('resolveGhosttyThemeColors', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('background = #1d1f21')
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('background = #1d1f21'))
 
     const result = await resolveGhosttyThemeColors('/Users/alice/themes/work')
     expect(result).toEqual({ background: '#1d1f21' })
@@ -127,7 +148,7 @@ describe('resolveGhosttyThemeColors', () => {
       }
       throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
     })
-    readFileMock.mockResolvedValue('background = #101010\nfont-size = 20')
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('background = #101010\nfont-size = 20'))
 
     const result = await resolveGhosttyThemeColors('custom')
     expect(result).toEqual({ background: '#101010' })
@@ -149,7 +170,7 @@ describe('resolveGhosttyThemeColors', () => {
   it('rejects oversized theme files', async () => {
     statMock.mockImplementation(async () => ({ isFile: () => true, size: 10_000_000 }))
     expect(await resolveGhosttyThemeColors('huge')).toBeNull()
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(readNodeFileWithinLimitMock).not.toHaveBeenCalled()
     expect(statMock).toHaveBeenCalledTimes(1)
   })
 
@@ -165,7 +186,35 @@ describe('resolveGhosttyThemeColors', () => {
     })
 
     expect(await resolveGhosttyThemeColors('night')).toBeNull()
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(readNodeFileWithinLimitMock).not.toHaveBeenCalled()
     expect(statMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts a theme at the exact byte limit', async () => {
+    const themePath = '/Users/alice/.config/ghostty/themes/boundary'
+    statMock.mockImplementation(async (p: string) => {
+      if (p === themePath) {
+        return { isFile: () => true, size: 262_144 }
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    readNodeFileWithinLimitMock.mockResolvedValue(fileRead('background = #1d1f21', 262_144))
+
+    expect(await resolveGhosttyThemeColors('boundary')).toEqual({ background: '#1d1f21' })
+    expect(readNodeFileWithinLimitMock).toHaveBeenCalledWith(themePath, 262_144)
+  })
+
+  it('rejects theme growth beyond the limit before parsing', async () => {
+    const themePath = '/Users/alice/.config/ghostty/themes/growing'
+    statMock.mockImplementation(async (p: string) => {
+      if (p === themePath) {
+        return { isFile: () => true, size: 128 }
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+    readNodeFileWithinLimitMock.mockRejectedValue(new NodeFileReadTooLargeError(262_145, 262_144))
+
+    expect(await resolveGhosttyThemeColors('growing')).toBeNull()
+    expect(parseGhosttyConfigMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ghostty/theme-resolution.ts
+++ b/src/main/ghostty/theme-resolution.ts
@@ -1,6 +1,7 @@
 import { homedir, platform } from 'node:os'
 import path from 'node:path'
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 import { parseGhosttyConfig } from './parser'
 
 // Why: theme files ship a few dozen short lines; anything larger is not a
@@ -86,7 +87,11 @@ async function readThemeColors(themePath: string): Promise<ThemeReadResult> {
     if (!info.isFile() || info.size > MAX_THEME_BYTES) {
       return { status: 'invalid' }
     }
-    content = await readFile(themePath, 'utf-8')
+    const result = await readNodeFileWithinLimit(themePath, MAX_THEME_BYTES)
+    if (!result.stats.isFile()) {
+      return { status: 'invalid' }
+    }
+    content = result.buffer.toString('utf8')
   } catch (err) {
     return { status: isMissingThemeError(err) ? 'missing' : 'invalid' }
   }


### PR DESCRIPTION
## OOM hardening slice 15/29 — bound browser capture & emulator video replay

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **15/29** (base: `oom/14-b-ai-vault`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Re-introduces OOM ceilings across the browser/computer-use/emulator/ghostty subsystems: bounded CDP command queues, screenshot/PDF/screencast size+concurrency caps, streaming cookie-store parsers with count/byte/depth limits, a budgeted accessibility-snapshot walk, and bounded scrcpy GOP replay and stdout/line buffers. Behavior below the (generous) ceilings is unchanged; overload paths now reject or shed instead of growing unbounded.

### ELI5
Imagine the app's browser helper used to keep saying "yes" to everything — every screenshot, every giant cookie file, every element on a page — and could eat all the computer's memory. This change adds sensible "that's too much, try again later" limits so a huge page or a flood of requests can't crash the app. For everyday browsing and screenshots you won't notice; the limits only kick in on enormous or abusive inputs.

### Proof of OOM fix
- CDP/agent command queues capped at 64/tab(session) and 512 total (cdp-command-queue.ts, agent-browser-bridge.ts); overflow rejects with browser_busy — proven by cdp-command-queue.test.ts ('full'/'closed' assertions) and cdp-bridge-memory-bounds.test.ts
- Screenshot geometry/bytes capped: 32768px/dimension, 32Mi effective pixels, 32MiB encoded, 2 concurrent captures (browser-screenshot-limits.ts, browser-screenshot-admission.ts) — browser-screenshot-limits.test.ts asserts throw at BROWSER_SCREENSHOT_MAX_EFFECTIVE_PIXELS/MAX_ENCODED_BYTES
- PDF bounded: 2 concurrent prints, 64MiB per PDF, 8 retained streams + 64MiB process retention budget (browser-pdf-admission.ts, cdp-print-to-pdf.ts) — cdp-print-to-pdf.test.ts, browser-pdf-admission.test.ts
- CDP event buffers bounded: 1000 console/network entries, 256 paused requests (excess auto-continued), 1024 iframe sessions (excess detached), 16K/64K text/metadata truncation (cdp-event-memory-bounds.ts) — cdp-event-memory-bounds.test.ts
- Cookie import bounded: JSON 64MiB file / 250k entries / depth 128 / 64MiB retained via streaming jsonc visit (browser-cookie-json-file-parser.ts); Safari store 64MiB/65536 pages/250k cookies (safari-cookie-store-decoder.ts); installed Chromium/Firefox stores 250k cookies/64MiB via SQL aggregate + row iteration (installed-browser-cookie-store-limits.ts) — respective .test.ts files
- Accessibility snapshot budget: 50000 AX nodes, 4096 entries, 1024 name code-units, 1MiB retained names, depth 64 (snapshot-engine.ts) — snapshot-engine.test.ts asserts truncation at SNAPSHOT_MAX_ENTRIES
- scrcpy replay bounded: 120 GOP frames, 32MiB/device, 128MiB total, 16 devices, 8 subscribers (scrcpy-video-registry.ts) — scrcpy-video-registry-memory.test.ts asserts whole-GOP shed then keyframe-only recovery
- CDP ws proxy: 16MiB max incoming payload, 16 max TCP connections (cdp-ws-proxy.ts) — cdp-ws-proxy.test.ts
- Bounded file reads / buffers: ghostty config+theme, serve-sim state (8KiB), permission status (64KiB), macOS native provider line buffer (64MiB), screencast frame = outbound binary frame limit; uiautomator XML 16MiB/50000 elems/depth256/64 attrs (uiautomator-tree.ts) — uiautomator-tree.test.ts
- Concurrency/fanout caps: max 64 active browser downloads (browser-manager.ts), 16 queued computer-sidecar calls (sidecar-client.ts), AVD-name lookup concurrency 4 (android-device-inventory.ts), serve-sim prune scan capped at 4096 entries (serve-sim-runtime-materializer.ts) — serve-sim-runtime-pruning-bounds.test.ts

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **medium**: Accessibility snapshot the agent consumes is now capped at 4096 entries and 50000 AX nodes (names truncated to 1024 code units). On very large/complex pages the agent may no longer see all interactive/text elements it previously did, which can change agent browsing outcomes. _(trigger: Agent browses a page with >4096 interactive+heading+landmark+text elements or >50000 AX nodes (large data tables, very long documents). Below that, identical output.)_
- **low**: Concurrent screenshot captures and PDF prints are limited to 2 each via process-global counters shared across all tabs/worktrees; a 3rd simultaneous capture/print returns browser_busy instead of running. _(trigger: Three or more tabs/worktrees screenshot or print-to-PDF at the exact same moment; the UI/agent must handle browser_busy and retry.)_
- **low**: Screenshot capture and PDF printing now use process-global two-slot admission, so unrelated worktrees contend and excess operations fail with browser_busy rather than waiting or running. _(trigger: A third screenshot-related native operation or PDF print overlaps two unsettled operations anywhere in the process.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Agent/CDP browser commands rejected with browser_busy only after 64 are already queued for one tab or 512 across all tabs
- Screenshots rejected browser_screenshot_too_large only above 32768px/dimension, 32M effective pixels, or 32MiB encoded output
- browser_busy on screenshots/PDF only when >2 captures or >2 prints are simultaneously in flight (process-global counters)
- Cookie import aborts only for files >64MiB, >250k entries, >128 nesting levels, or cookie stores exceeding 250k cookies / 64MiB
- Accessibility snapshot truncates only past 50000 AX nodes / 4096 emitted entries — the agent stops seeing further elements on extreme pages
- scrcpy: subscribe() throws only past 8 total subscribers, register() past 16 devices; late subscriber gets no replay (whole GOP shed) only under sustained high-motion until the next ~10s keyframe
- Live screencast frames silently dropped only when a single frame exceeds the outbound binary-frame byte limit
- CDP request interception silently stops pausing (auto-continues) only past 256 concurrent paused requests or requests with >256 headers / >64K metadata
- uiautomator XML parse fails only above 16MiB / 50000 elements / depth 256 / 64 attributes per element
- scrcpy late-subscriber replay changed from a 120-frame sliding window to shedding the entire buffered GOP as a unit when the cap is exceeded, so a viewer that attaches during sustained high-motion sees nothing until the next keyframe (~10s). subscribe()/register() now throw past 8 subscribers / 16 devices. _(only when: Opening an Android device view during heavy on-screen motion, or opening a 9th concurrent stream viewer / 17th device.)_
- Several new BrowserError codes (browser_screenshot_too_large, browser_busy) and cookie-import rejection reasons are surfaced to the UI; if a caller/UI does not map these they may show generic errors. _(only when: Hitting any screenshot/PDF/queue ceiling or importing an oversized cookie file/store.)_
- Accessibility snapshots truncate names at 1,024 code units and stop after a shared budget of 4,096 emitted entries, 50,000 walked AX nodes, or 1 MiB of retained names. On extreme pages the agent can no longer see later controls or text. _(only when: Agent snapshots a very large document, data table, or iframe set that exceeds one of the snapshot budgets.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.

### ⚠️ Inherited edge-case defect(s) — pre-existing in #10179
- ⚠️ [medium] `src/main/browser/browser-session-registry.ts` — adversarial-flagged (overload-path only, unverified): hydrateFromPersisted() bypasses the createProfile() 256-profile / 16 KiB-label ceilings; a shape-valid 1 MiB metadata file can hydrate ~5,400 profiles at startup, each installing an Electron session policy.

> Defects **inherited from the original #10179 code** (not introduced by slicing; not present in today's unbounded `main`). Fixed items were patched in-slice and re-verified (typecheck + affected suites); remaining flagged items are overload-only and noted for a fast-follow.

### Adversarial review
- 3 skeptic lens(es) incl. a frontier-model (GPT) cross-check. Sign-off: **FLAGGED — see above**. Residual risk: **medium**.
- Verified every numeric ceiling in the slice; all are far above ordinary use. Screenshot geometry 32768px/dimension, 32M effective pixels, 32MiB encoded (browser-screenshot-limits.ts) — Chromium's own texture limits already constrain full-page captures below this; a full-page of a very long page could theoretically approach 32M px but that is extreme. Concurrency caps: 2 screenshots + 2 PDF prints (process-global). CDP command queue 64/tab, 512 total (cdp-command-queue.ts) — closeTab/process correctly decrement queuedCount, no leak, FIFO preserved. Cookie import: 64MiB / 250k entries / depth 128 (browser-cookie-json-file-parser.ts), installed store 250k cookies / 64MiB, Chromium Local State 16MiB, profile scan 10k entries — real cookie stores are a few thousand cookies, Local State well under 1MB. uiautomator XML 16MiB / 50k elements / depth 256 / 64 attrs. ghostty config import 1MB (real configs are KB). Screencast per-frame limit 8MiB (decodeBrowserScreencastImage returns null → drops single oversized frame, stream continues); a viewport JPEG is well under 1MB. scrcpy replay per-device 32MiB / total 128MiB. All confirmed overload-only. The ONLY user/agent-visible normal-path change is the accessibility-snapshot 4096-entry / 50k-node cap (snapshot-engine.ts): below it, output is identical, but large content-heavy pages now truncate silently for the agent. That is a deliberate, generous, already-shipped (passed full CI) design tradeoff, not a correctness bug — flag it for human sign-off but it does not block a draft PR. No confirmed normal-path regression or correctness bug; signoff=true.
- Correctness notes: `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/browser/browser-session-registry.ts`: Persisted-state hydration bypasses the new 256-profile ceiling and the 16 KiB label ceiling. createProfile() checks both limits at lines 345-352, but hydrateFromPersisted() at lines 481-490 accepts every shape-valid record from the 1 MiB metadata file. A compact valid file can contain roughly 5,400 profiles, causing startup to retain them and install an Electron session policy for each. This is a concrete migration/tampered-state path and is not covered by the persistence limit tests.

### Files
71 files changed (+5002 / −707).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
