### PR TITLE
oom(16/29): bound Codex session/transport/account memory

### DIFF
--- a/src/main/codex-accounts/codex-wsl-runtime-home-retention.test.ts
+++ b/src/main/codex-accounts/codex-wsl-runtime-home-retention.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { CodexWslRuntimeHomeRetention } from './codex-wsl-runtime-home-retention'
+
+const BOUNDS = {
+  maxEntries: 2,
+  maxKeyBytes: 8,
+  maxValueBytes: 8,
+  maxTotalBytes: 18
+}
+
+describe('CodexWslRuntimeHomeRetention', () => {
+  it('retains the coordinated state and distinguishes an explicit system account', () => {
+    const retention = new CodexWslRuntimeHomeRetention(BOUNDS)
+    retention.setRuntimeHomePath('a', '/home')
+    retention.setLastWrittenAuthJson('a', 'auth')
+    retention.setLastSyncedAccountId('a', null)
+
+    expect(retention.getRuntimeHomePath('a')).toBe('/home')
+    expect(retention.getLastWrittenAuthJson('a')).toBe('auth')
+    expect(retention.hasLastSyncedAccountId('a')).toBe(true)
+    expect(retention.getLastSyncedAccountId('a')).toBeNull()
+  })
+
+  it('evicts the least-recently-used distro at the entry bound', () => {
+    const retention = new CodexWslRuntimeHomeRetention(BOUNDS)
+    retention.setRuntimeHomePath('a', 'one')
+    retention.setRuntimeHomePath('b', 'two')
+    retention.getRuntimeHomePath('a')
+    retention.setRuntimeHomePath('c', 'three')
+
+    expect(retention.getRuntimeHomePath('a')).toBe('one')
+    expect(retention.getRuntimeHomePath('b')).toBeUndefined()
+    expect(retention.getRuntimeHomePath('c')).toBe('three')
+    expect(retention.evidence().entries).toBe(2)
+  })
+
+  it('bounds aggregate retained bytes and fails closed for oversized fields', () => {
+    const retention = new CodexWslRuntimeHomeRetention(BOUNDS)
+    retention.setRuntimeHomePath('a', '12345678')
+    retention.setRuntimeHomePath('b', '12345678')
+
+    expect(retention.evidence()).toEqual({ entries: 2, retainedBytes: 18 })
+
+    retention.setLastWrittenAuthJson('b', '123456789')
+
+    expect(retention.getRuntimeHomePath('b')).toBeUndefined()
+    expect(retention.evidence()).toEqual({ entries: 1, retainedBytes: 9 })
+  })
+})

--- a/src/main/codex-accounts/codex-wsl-runtime-home-retention.ts
+++ b/src/main/codex-accounts/codex-wsl-runtime-home-retention.ts
@@ -1,0 +1,140 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export type CodexWslRuntimeHomeRetentionBounds = {
+  maxEntries: number
+  maxKeyBytes: number
+  maxValueBytes: number
+  maxTotalBytes: number
+}
+
+export const DEFAULT_CODEX_WSL_RUNTIME_HOME_RETENTION_BOUNDS: CodexWslRuntimeHomeRetentionBounds = {
+  maxEntries: 64,
+  maxKeyBytes: 1024,
+  maxValueBytes: 4 * 1024 * 1024,
+  maxTotalBytes: 8 * 1024 * 1024
+}
+
+type CodexWslRuntimeHomeEntry = {
+  runtimeHomePath?: string
+  lastWrittenAuthJson?: string | null
+  lastSyncedAccountId?: string | null
+  retainedBytes: number
+}
+
+export class CodexWslRuntimeHomeRetention {
+  private readonly entries = new Map<string, CodexWslRuntimeHomeEntry>()
+  private retainedBytes = 0
+
+  constructor(
+    private readonly bounds: CodexWslRuntimeHomeRetentionBounds = DEFAULT_CODEX_WSL_RUNTIME_HOME_RETENTION_BOUNDS
+  ) {
+    for (const value of Object.values(bounds)) {
+      if (!Number.isSafeInteger(value) || value < 1) {
+        throw new RangeError('Codex WSL runtime-home retention bounds must be positive integers')
+      }
+    }
+  }
+
+  getRuntimeHomePath(distro: string): string | undefined {
+    return this.get(distro)?.runtimeHomePath
+  }
+
+  hasLastSyncedAccountId(distro: string): boolean {
+    return this.get(distro)?.lastSyncedAccountId !== undefined
+  }
+
+  getLastSyncedAccountId(distro: string): string | null | undefined {
+    return this.get(distro)?.lastSyncedAccountId
+  }
+
+  getLastWrittenAuthJson(distro: string): string | null | undefined {
+    return this.get(distro)?.lastWrittenAuthJson
+  }
+
+  setRuntimeHomePath(distro: string, runtimeHomePath: string): void {
+    this.update(distro, { runtimeHomePath })
+  }
+
+  setLastSyncedAccountId(distro: string, accountId: string | null): void {
+    this.update(distro, { lastSyncedAccountId: accountId })
+  }
+
+  setLastWrittenAuthJson(distro: string, authJson: string | null): void {
+    this.update(distro, { lastWrittenAuthJson: authJson })
+  }
+
+  evidence(): { entries: number; retainedBytes: number } {
+    return { entries: this.entries.size, retainedBytes: this.retainedBytes }
+  }
+
+  private get(distro: string): CodexWslRuntimeHomeEntry | undefined {
+    const entry = this.entries.get(distro)
+    if (entry) {
+      this.entries.delete(distro)
+      this.entries.set(distro, entry)
+    }
+    return entry
+  }
+
+  private update(
+    distro: string,
+    patch: Omit<Partial<CodexWslRuntimeHomeEntry>, 'retainedBytes'>
+  ): void {
+    const previous = this.entries.get(distro)
+    const next = { ...previous, ...patch, retainedBytes: 0 }
+    const retainedBytes = this.measureEntry(distro, next)
+    this.delete(distro)
+    if (retainedBytes === null || retainedBytes > this.bounds.maxTotalBytes) {
+      return
+    }
+    while (
+      this.entries.size >= this.bounds.maxEntries ||
+      this.retainedBytes + retainedBytes > this.bounds.maxTotalBytes
+    ) {
+      const oldest = this.entries.keys().next().value
+      if (oldest === undefined) {
+        return
+      }
+      this.delete(oldest)
+    }
+    next.retainedBytes = retainedBytes
+    this.entries.set(distro, next)
+    this.retainedBytes += retainedBytes
+  }
+
+  private measureEntry(distro: string, entry: CodexWslRuntimeHomeEntry): number | null {
+    const keyBytes = measureUtf8ByteLength(distro, {
+      stopAfterBytes: this.bounds.maxKeyBytes
+    })
+    if (keyBytes.exceededLimit) {
+      return null
+    }
+    let retainedBytes = keyBytes.byteLength
+    for (const value of [
+      entry.runtimeHomePath,
+      entry.lastWrittenAuthJson,
+      entry.lastSyncedAccountId
+    ]) {
+      if (typeof value !== 'string') {
+        continue
+      }
+      const valueBytes = measureUtf8ByteLength(value, {
+        stopAfterBytes: this.bounds.maxValueBytes
+      })
+      if (valueBytes.exceededLimit) {
+        return null
+      }
+      retainedBytes += valueBytes.byteLength
+    }
+    return retainedBytes
+  }
+
+  private delete(distro: string): void {
+    const entry = this.entries.get(distro)
+    if (!entry) {
+      return
+    }
+    this.entries.delete(distro)
+    this.retainedBytes -= entry.retainedBytes
+  }
+}

--- a/src/main/codex-accounts/host-codex-managed-home-ownership.ts
+++ b/src/main/codex-accounts/host-codex-managed-home-ownership.ts
@@ -1,5 +1,6 @@
-import { existsSync, lstatSync, readFileSync, realpathSync } from 'node:fs'
+import { existsSync, lstatSync, realpathSync } from 'node:fs'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
 
 type HostCodexManagedHomeOwnershipOptions = {
   candidatePath: string
@@ -87,7 +88,7 @@ export function assertOwnedHostCodexManagedHomePath({
   if (!markerIsRegularFile) {
     throw new Error('Managed Codex home ownership marker is not a regular file.')
   }
-  const markerContents = readFileSync(markerPath, 'utf-8')
+  const markerContents = readAgentStateFileSync(markerPath)
   if (expectedAccountId !== undefined && markerContents.trim() !== expectedAccountId) {
     throw new Error('Managed Codex home ownership marker does not match its account ID.')
   }

--- a/src/main/codex-accounts/legacy-history-migration.test.ts
+++ b/src/main/codex-accounts/legacy-history-migration.test.ts
@@ -1,0 +1,109 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  CODEX_LEGACY_HISTORY_READ_CHUNK_BYTES,
+  mergeCodexLegacyHistorySync
+} from './legacy-history-migration'
+
+describe('Codex legacy history migration', () => {
+  let root = ''
+  let legacyHistoryPath = ''
+  let runtimeHistoryPath = ''
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-codex-legacy-history-'))
+    legacyHistoryPath = join(root, 'legacy-history.jsonl')
+    runtimeHistoryPath = join(root, 'runtime-history.jsonl')
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('preserves the legacy merge order and exact normalized output in limit', () => {
+    const longLegacyLine = `🦀${'x'.repeat(CODEX_LEGACY_HISTORY_READ_CHUNK_BYTES + 8)}`
+    writeFileSync(runtimeHistoryPath, 'first\n\nsecond\r\nlast')
+    writeFileSync(legacyHistoryPath, `second\r\nthird\nfirst\n\nthird\n${longLegacyLine}`)
+
+    const result = mergeCodexLegacyHistorySync({ legacyHistoryPath, runtimeHistoryPath })
+
+    expect(result).toMatchObject({ kind: 'merged', addedLineCount: 2, outputLineCount: 5 })
+    expect(readFileSync(runtimeHistoryPath, 'utf8')).toBe(
+      `first\nsecond\r\nlast\nthird\n${longLegacyLine}\n`
+    )
+  })
+
+  it('leaves the runtime file byte-for-byte unchanged when output exceeds its limit', () => {
+    const originalRuntime = 'runtime\n'
+    writeFileSync(runtimeHistoryPath, originalRuntime)
+    writeFileSync(legacyHistoryPath, 'new-value\n')
+
+    const result = mergeCodexLegacyHistorySync({
+      legacyHistoryPath,
+      runtimeHistoryPath,
+      limits: { maxOutputBytes: Buffer.byteLength(originalRuntime) }
+    })
+
+    expect(result).toEqual({
+      kind: 'skipped',
+      reason: 'output-bytes',
+      observed: Buffer.byteLength(originalRuntime) + Buffer.byteLength('new-value\n'),
+      limit: Buffer.byteLength(originalRuntime)
+    })
+    expect(readFileSync(runtimeHistoryPath, 'utf8')).toBe(originalRuntime)
+  })
+
+  it('does not create partial output for an oversized source file or line', () => {
+    writeFileSync(legacyHistoryPath, '')
+    truncateSync(legacyHistoryPath, 4096)
+
+    const fileResult = mergeCodexLegacyHistorySync({
+      legacyHistoryPath,
+      runtimeHistoryPath,
+      limits: { maxFileBytes: 1024 }
+    })
+
+    expect(fileResult).toMatchObject({ kind: 'skipped', reason: 'file-bytes', limit: 1024 })
+    expect(existsSync(runtimeHistoryPath)).toBe(false)
+
+    writeFileSync(legacyHistoryPath, 'oversized\n')
+    const lineResult = mergeCodexLegacyHistorySync({
+      legacyHistoryPath,
+      runtimeHistoryPath,
+      limits: { maxLineBytes: 4 }
+    })
+
+    expect(lineResult).toMatchObject({ kind: 'skipped', reason: 'line-bytes', limit: 4 })
+    expect(existsSync(runtimeHistoryPath)).toBe(false)
+  })
+
+  it('bounds input records even when every record is empty or duplicated', () => {
+    writeFileSync(legacyHistoryPath, 'same\nsame\n\nsame\n')
+
+    const result = mergeCodexLegacyHistorySync({
+      legacyHistoryPath,
+      runtimeHistoryPath,
+      limits: { maxInputLines: 3 }
+    })
+
+    expect(result).toMatchObject({
+      kind: 'skipped',
+      reason: 'input-lines',
+      observed: 4,
+      limit: 3
+    })
+    expect(existsSync(runtimeHistoryPath)).toBe(false)
+  })
+
+  it('leaves an existing empty-only runtime file untouched when no record survives', () => {
+    writeFileSync(runtimeHistoryPath, '\n\n')
+    writeFileSync(legacyHistoryPath, '\n')
+
+    expect(mergeCodexLegacyHistorySync({ legacyHistoryPath, runtimeHistoryPath })).toEqual({
+      kind: 'empty'
+    })
+    expect(readFileSync(runtimeHistoryPath, 'utf8')).toBe('\n\n')
+  })
+})

--- a/src/main/codex-accounts/legacy-history-migration.ts
+++ b/src/main/codex-accounts/legacy-history-migration.ts
@@ -1,0 +1,230 @@
+import { randomUUID } from 'node:crypto'
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  rmSync,
+  writeSync
+} from 'node:fs'
+import { dirname } from 'node:path'
+import { renameFileWithWindowsRetry } from './fs-utils'
+
+export const CODEX_LEGACY_HISTORY_FILE_MAX_BYTES = 32 * 1024 * 1024
+export const CODEX_LEGACY_HISTORY_LINE_MAX_BYTES = 1024 * 1024
+export const CODEX_LEGACY_HISTORY_INPUT_MAX_LINES = 200_000
+export const CODEX_LEGACY_HISTORY_OUTPUT_MAX_BYTES = 32 * 1024 * 1024
+export const CODEX_LEGACY_HISTORY_READ_CHUNK_BYTES = 64 * 1024
+
+export type CodexLegacyHistoryMigrationLimits = {
+  maxFileBytes: number
+  maxLineBytes: number
+  maxInputLines: number
+  maxOutputBytes: number
+}
+
+export const DEFAULT_CODEX_LEGACY_HISTORY_MIGRATION_LIMITS: CodexLegacyHistoryMigrationLimits = {
+  maxFileBytes: CODEX_LEGACY_HISTORY_FILE_MAX_BYTES,
+  maxLineBytes: CODEX_LEGACY_HISTORY_LINE_MAX_BYTES,
+  maxInputLines: CODEX_LEGACY_HISTORY_INPUT_MAX_LINES,
+  maxOutputBytes: CODEX_LEGACY_HISTORY_OUTPUT_MAX_BYTES
+}
+
+export type CodexLegacyHistorySkipReason =
+  | 'file-bytes'
+  | 'line-bytes'
+  | 'input-lines'
+  | 'output-bytes'
+
+export type CodexLegacyHistoryMigrationResult =
+  | {
+      kind: 'merged'
+      addedLineCount: number
+      outputBytes: number
+      outputLineCount: number
+    }
+  | { kind: 'empty' }
+  | {
+      kind: 'skipped'
+      reason: CodexLegacyHistorySkipReason
+      observed: number
+      limit: number
+    }
+
+class CodexLegacyHistoryCapacityError extends Error {
+  constructor(
+    readonly reason: CodexLegacyHistorySkipReason,
+    readonly observed: number,
+    readonly limit: number
+  ) {
+    super(`Codex legacy history exceeded ${reason} limit (${observed} > ${limit})`)
+    this.name = 'CodexLegacyHistoryCapacityError'
+  }
+}
+
+export function mergeCodexLegacyHistorySync(options: {
+  legacyHistoryPath: string
+  runtimeHistoryPath: string
+  limits?: Partial<CodexLegacyHistoryMigrationLimits>
+}): CodexLegacyHistoryMigrationResult {
+  const limits = resolveLimits(options.limits)
+  const temporaryPath = `${options.runtimeHistoryPath}.${process.pid}.${randomUUID()}.migration.tmp`
+  let outputDescriptor: number | null = null
+
+  try {
+    mkdirSync(dirname(options.runtimeHistoryPath), { recursive: true })
+    outputDescriptor = openSync(temporaryPath, 'wx')
+    const seenLines = new Set<string>()
+    let inputLineCount = 0
+    let outputBytes = 0
+    let addedLineCount = 0
+
+    const retainLine = (line: string, fromLegacy: boolean): void => {
+      inputLineCount += 1
+      assertWithinCapacity('input-lines', inputLineCount, limits.maxInputLines)
+      if (!line || seenLines.has(line)) {
+        return
+      }
+
+      const encodedLine = Buffer.from(`${line}\n`, 'utf8')
+      assertWithinCapacity('output-bytes', outputBytes + encodedLine.length, limits.maxOutputBytes)
+      seenLines.add(line)
+      writeAll(outputDescriptor!, encodedLine)
+      outputBytes += encodedLine.length
+      if (fromLegacy) {
+        addedLineCount += 1
+      }
+    }
+
+    if (existsSync(options.runtimeHistoryPath)) {
+      readHistoryLinesSync(options.runtimeHistoryPath, limits, (line) => retainLine(line, false))
+    }
+    readHistoryLinesSync(options.legacyHistoryPath, limits, (line) => retainLine(line, true))
+
+    closeSync(outputDescriptor)
+    outputDescriptor = null
+    if (seenLines.size === 0) {
+      rmSync(temporaryPath, { force: true })
+      return { kind: 'empty' }
+    }
+
+    renameFileWithWindowsRetry(temporaryPath, options.runtimeHistoryPath)
+    return {
+      kind: 'merged',
+      addedLineCount,
+      outputBytes,
+      outputLineCount: seenLines.size
+    }
+  } catch (error) {
+    closeIgnoringErrors(outputDescriptor)
+    rmSync(temporaryPath, { force: true })
+    if (error instanceof CodexLegacyHistoryCapacityError) {
+      return {
+        kind: 'skipped',
+        reason: error.reason,
+        observed: error.observed,
+        limit: error.limit
+      }
+    }
+    throw error
+  }
+}
+
+function readHistoryLinesSync(
+  filePath: string,
+  limits: CodexLegacyHistoryMigrationLimits,
+  onLine: (line: string) => void
+): void {
+  const descriptor = openSync(filePath, 'r')
+  try {
+    const initialBytes = fstatSync(descriptor).size
+    assertWithinCapacity('file-bytes', initialBytes, limits.maxFileBytes)
+    const readBuffer = Buffer.allocUnsafe(CODEX_LEGACY_HISTORY_READ_CHUNK_BYTES)
+    let sourceBytes = 0
+    let fragments: Buffer[] = []
+    let fragmentBytes = 0
+
+    while (true) {
+      const bytesRead = readSync(descriptor, readBuffer, 0, readBuffer.length, null)
+      if (bytesRead === 0) {
+        break
+      }
+      sourceBytes += bytesRead
+      assertWithinCapacity('file-bytes', sourceBytes, limits.maxFileBytes)
+
+      let offset = 0
+      while (offset < bytesRead) {
+        const newlineIndex = readBuffer.indexOf(0x0a, offset)
+        const end = newlineIndex === -1 || newlineIndex >= bytesRead ? bytesRead : newlineIndex
+        const nextFragmentBytes = end - offset
+        assertWithinCapacity('line-bytes', fragmentBytes + nextFragmentBytes, limits.maxLineBytes)
+        if (nextFragmentBytes > 0) {
+          fragments.push(Buffer.from(readBuffer.subarray(offset, end)))
+          fragmentBytes += nextFragmentBytes
+        }
+        if (newlineIndex === -1 || newlineIndex >= bytesRead) {
+          break
+        }
+        onLine(decodeLine(fragments, fragmentBytes))
+        fragments = []
+        fragmentBytes = 0
+        offset = newlineIndex + 1
+      }
+    }
+
+    if (fragmentBytes > 0) {
+      onLine(decodeLine(fragments, fragmentBytes))
+    }
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+function decodeLine(fragments: Buffer[], bytes: number): string {
+  if (fragments.length === 1) {
+    return fragments[0]!.toString('utf8')
+  }
+  return Buffer.concat(fragments, bytes).toString('utf8')
+}
+
+function writeAll(descriptor: number, buffer: Buffer): void {
+  let offset = 0
+  while (offset < buffer.length) {
+    offset += writeSync(descriptor, buffer, offset, buffer.length - offset)
+  }
+}
+
+function assertWithinCapacity(
+  reason: CodexLegacyHistorySkipReason,
+  observed: number,
+  limit: number
+): void {
+  if (observed > limit) {
+    throw new CodexLegacyHistoryCapacityError(reason, observed, limit)
+  }
+}
+
+function resolveLimits(
+  overrides: Partial<CodexLegacyHistoryMigrationLimits> | undefined
+): CodexLegacyHistoryMigrationLimits {
+  const limits = { ...DEFAULT_CODEX_LEGACY_HISTORY_MIGRATION_LIMITS, ...overrides }
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`${name} must be a non-negative safe integer`)
+    }
+  }
+  return limits
+}
+
+function closeIgnoringErrors(descriptor: number | null): void {
+  if (descriptor === null) {
+    return
+  }
+  try {
+    closeSync(descriptor)
+  } catch {
+    // The original migration error is more actionable than cleanup failure.
+  }
+}

--- a/src/main/codex-accounts/legacy-managed-state-migration.test.ts
+++ b/src/main/codex-accounts/legacy-managed-state-migration.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { migrateLegacyManagedCodexStateSync } from './legacy-managed-state-migration'
+
+describe('Codex legacy managed-state migration', () => {
+  let root = ''
+  let managedAccountsRoot = ''
+  let metadataDir = ''
+  let runtimeHomePath = ''
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-codex-managed-state-'))
+    managedAccountsRoot = join(root, 'codex-accounts')
+    metadataDir = join(root, 'metadata')
+    runtimeHomePath = join(root, 'runtime')
+    mkdirSync(managedAccountsRoot)
+    mkdirSync(metadataDir)
+    mkdirSync(runtimeHomePath)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  function createManagedHome(accountId: string): string {
+    const homePath = join(managedAccountsRoot, accountId, 'home')
+    mkdirSync(homePath, { recursive: true })
+    writeFileSync(join(homePath, '.orca-managed-home'), '')
+    return homePath
+  }
+
+  function migrate(
+    limits?: Parameters<typeof migrateLegacyManagedCodexStateSync>[0]['limits']
+  ): ReturnType<typeof migrateLegacyManagedCodexStateSync> {
+    return migrateLegacyManagedCodexStateSync({
+      managedAccountsRoot,
+      metadataDir,
+      runtimeHomePath,
+      limits
+    })
+  }
+
+  it('preserves ordinary history, session, diagnostic, and one-shot marker behavior', () => {
+    const homePath = createManagedHome('account-1')
+    writeFileSync(join(runtimeHomePath, 'history.jsonl'), '{"id":"shared"}\n')
+    writeFileSync(join(homePath, 'history.jsonl'), '{"id":"shared"}\n{"id":"managed"}\n')
+    mkdirSync(join(homePath, 'sessions'))
+    mkdirSync(join(runtimeHomePath, 'sessions'))
+    writeFileSync(join(homePath, 'sessions', 'conflict.jsonl'), 'legacy\n')
+    writeFileSync(join(runtimeHomePath, 'sessions', 'conflict.jsonl'), 'runtime\n')
+
+    const summary = migrate()
+
+    expect(summary).toMatchObject({
+      diagnosticRecordsOmitted: 0,
+      diagnosticRecordsWritten: 1,
+      historySkippedHomeCount: 0,
+      managedHomeDiscoverySkipped: false,
+      migratedHomeCount: 1,
+      sessionSkippedHomeCount: 0
+    })
+    expect(readFileSync(join(runtimeHomePath, 'history.jsonl'), 'utf8')).toBe(
+      '{"id":"shared"}\n{"id":"managed"}\n'
+    )
+    expect(
+      readFileSync(
+        join(runtimeHomePath, 'sessions', 'conflict.orca-legacy-account-1.jsonl'),
+        'utf8'
+      )
+    ).toBe('legacy\n')
+    const diagnostic = readFileSync(join(metadataDir, 'migration-diagnostics.jsonl'), 'utf8')
+    expect(diagnostic).toContain('"type":"session-conflict"')
+
+    const marker = JSON.parse(readFileSync(join(metadataDir, 'migration-v1.json'), 'utf8'))
+    expect(Object.keys(marker).sort()).toEqual(['completedAt', 'migratedHomeCount'])
+    expect(marker.migratedHomeCount).toBe(1)
+    expect(migrate()).toBeNull()
+  })
+
+  it('skips all homes deterministically when managed-home discovery exceeds its cap', () => {
+    const firstHome = createManagedHome('account-1')
+    createManagedHome('account-2')
+    writeFileSync(join(firstHome, 'history.jsonl'), '{"id":"must-not-import"}\n')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const summary = migrate({ maxAccountEntries: 1 })
+
+    expect(summary).toMatchObject({
+      managedHomeDiscoverySkipped: true,
+      migratedHomeCount: 0
+    })
+    expect(existsSync(join(runtimeHomePath, 'history.jsonl'))).toBe(false)
+    const marker = JSON.parse(readFileSync(join(metadataDir, 'migration-v1.json'), 'utf8'))
+    expect(marker).toMatchObject({
+      managedHomeDiscoverySkipped: true,
+      migratedHomeCount: 0
+    })
+    expect(readFileSync(join(metadataDir, 'migration-diagnostics.jsonl'), 'utf8')).toContain(
+      '"type":"managed-home-discovery-skipped"'
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('records history and session capacity skips without partial output', () => {
+    const homePath = createManagedHome('account-1')
+    writeFileSync(join(homePath, 'history.jsonl'), 'oversized\n')
+    mkdirSync(join(homePath, 'sessions'))
+    writeFileSync(join(homePath, 'sessions', 'a.jsonl'), 'a')
+    writeFileSync(join(homePath, 'sessions', 'b.jsonl'), 'b')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const summary = migrate({
+      history: { maxFileBytes: 4 },
+      sessions: { maxEntries: 1 }
+    })
+
+    expect(summary).toMatchObject({
+      historySkippedHomeCount: 1,
+      sessionSkippedHomeCount: 1
+    })
+    expect(existsSync(join(runtimeHomePath, 'history.jsonl'))).toBe(false)
+    expect(existsSync(join(runtimeHomePath, 'sessions'))).toBe(false)
+    const marker = JSON.parse(readFileSync(join(metadataDir, 'migration-v1.json'), 'utf8'))
+    expect(marker).toMatchObject({
+      historySkippedHomeCount: 1,
+      sessionSkippedHomeCount: 1
+    })
+    const diagnostics = readFileSync(join(metadataDir, 'migration-diagnostics.jsonl'), 'utf8')
+    expect(diagnostics).toContain('"type":"history-skipped"')
+    expect(diagnostics).toContain('"type":"sessions-skipped"')
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps diagnostic output while still preserving every conflicting session', () => {
+    const homePath = createManagedHome('account-1')
+    mkdirSync(join(homePath, 'sessions'))
+    mkdirSync(join(runtimeHomePath, 'sessions'))
+    for (const name of ['a.jsonl', 'b.jsonl']) {
+      writeFileSync(join(homePath, 'sessions', name), `legacy-${name}`)
+      writeFileSync(join(runtimeHomePath, 'sessions', name), `runtime-${name}`)
+    }
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const summary = migrate({ maxDiagnosticRecords: 1 })
+
+    expect(summary).toMatchObject({
+      diagnosticRecordsOmitted: 1,
+      diagnosticRecordsWritten: 1
+    })
+    expect(existsSync(join(runtimeHomePath, 'sessions', 'a.orca-legacy-account-1.jsonl'))).toBe(
+      true
+    )
+    expect(existsSync(join(runtimeHomePath, 'sessions', 'b.orca-legacy-account-1.jsonl'))).toBe(
+      true
+    )
+    const marker = JSON.parse(readFileSync(join(metadataDir, 'migration-v1.json'), 'utf8'))
+    expect(marker.diagnosticRecordsOmitted).toBe(1)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/codex-accounts/legacy-managed-state-migration.ts
+++ b/src/main/codex-accounts/legacy-managed-state-migration.ts
@@ -1,0 +1,317 @@
+import { appendFileSync, existsSync, opendirSync } from 'node:fs'
+import { join } from 'node:path'
+import { writeFileAtomically } from './fs-utils'
+import {
+  mergeCodexLegacyHistorySync,
+  type CodexLegacyHistoryMigrationLimits
+} from './legacy-history-migration'
+import {
+  migrateCodexLegacySessionsSync,
+  type CodexLegacySessionMigrationLimits
+} from './legacy-session-migration'
+
+export const CODEX_LEGACY_MANAGED_ACCOUNT_MAX_ENTRIES = 4096
+export const CODEX_LEGACY_MANAGED_HOME_MAX_COUNT = 256
+export const CODEX_LEGACY_MIGRATION_DIAGNOSTIC_MAX_RECORDS = 2048
+export const CODEX_LEGACY_MIGRATION_DIAGNOSTIC_MAX_BYTES = 1024 * 1024
+
+type LegacyManagedHome = {
+  accountId: string
+  homePath: string
+}
+
+type ManagedHomeDiscoveryResult =
+  | { kind: 'complete'; homes: LegacyManagedHome[] }
+  | {
+      kind: 'skipped'
+      reason: 'account-entries' | 'managed-homes'
+      observed: number
+      limit: number
+    }
+
+type MigrationDiagnostic = Record<string, boolean | number | string>
+
+export type CodexLegacyManagedStateMigrationLimits = {
+  maxAccountEntries: number
+  maxManagedHomes: number
+  maxDiagnosticRecords: number
+  maxDiagnosticBytes: number
+  history?: Partial<CodexLegacyHistoryMigrationLimits>
+  sessions?: Partial<CodexLegacySessionMigrationLimits>
+}
+
+export type CodexLegacyManagedStateMigrationSummary = {
+  diagnosticRecordsOmitted: number
+  diagnosticRecordsWritten: number
+  historySkippedHomeCount: number
+  managedHomeDiscoverySkipped: boolean
+  migratedHomeCount: number
+  sessionSkippedHomeCount: number
+}
+
+const DEFAULT_LIMITS: CodexLegacyManagedStateMigrationLimits = {
+  maxAccountEntries: CODEX_LEGACY_MANAGED_ACCOUNT_MAX_ENTRIES,
+  maxManagedHomes: CODEX_LEGACY_MANAGED_HOME_MAX_COUNT,
+  maxDiagnosticRecords: CODEX_LEGACY_MIGRATION_DIAGNOSTIC_MAX_RECORDS,
+  maxDiagnosticBytes: CODEX_LEGACY_MIGRATION_DIAGNOSTIC_MAX_BYTES
+}
+
+export function migrateLegacyManagedCodexStateSync(options: {
+  managedAccountsRoot: string
+  metadataDir: string
+  runtimeHomePath: string
+  limits?: Partial<CodexLegacyManagedStateMigrationLimits>
+}): CodexLegacyManagedStateMigrationSummary | null {
+  const markerPath = join(options.metadataDir, 'migration-v1.json')
+  if (existsSync(markerPath)) {
+    return null
+  }
+
+  const limits = resolveLimits(options.limits)
+  const diagnostics = new MigrationDiagnosticWriter(
+    join(options.metadataDir, 'migration-diagnostics.jsonl'),
+    limits.maxDiagnosticRecords,
+    limits.maxDiagnosticBytes
+  )
+  const discovery = discoverLegacyManagedHomesSync(options.managedAccountsRoot, limits)
+  let historySkippedHomeCount = 0
+  let sessionSkippedHomeCount = 0
+
+  if (discovery.kind === 'skipped') {
+    diagnostics.append({
+      type: 'managed-home-discovery-skipped',
+      reason: discovery.reason,
+      observed: discovery.observed,
+      limit: discovery.limit
+    })
+  } else {
+    for (const home of discovery.homes) {
+      const legacyHistoryPath = join(home.homePath, 'history.jsonl')
+      if (existsSync(legacyHistoryPath)) {
+        const historyResult = mergeCodexLegacyHistorySync({
+          legacyHistoryPath,
+          runtimeHistoryPath: join(options.runtimeHomePath, 'history.jsonl'),
+          limits: limits.history
+        })
+        if (historyResult.kind === 'skipped') {
+          historySkippedHomeCount += 1
+          diagnostics.append({
+            type: 'history-skipped',
+            accountId: home.accountId,
+            legacyHistoryPath,
+            reason: historyResult.reason,
+            observed: historyResult.observed,
+            limit: historyResult.limit
+          })
+        }
+      }
+
+      const legacySessionsRoot = join(home.homePath, 'sessions')
+      if (!existsSync(legacySessionsRoot)) {
+        continue
+      }
+      const sessionResult = migrateCodexLegacySessionsSync({
+        accountId: home.accountId,
+        legacySessionsRoot,
+        runtimeSessionsRoot: join(options.runtimeHomePath, 'sessions'),
+        limits: limits.sessions,
+        onConflict: ({ runtimeFilePath, preservedPath }) => {
+          diagnostics.append({
+            type: 'session-conflict',
+            accountId: home.accountId,
+            runtimeFilePath,
+            preservedPath
+          })
+        }
+      })
+      if (sessionResult.kind === 'skipped') {
+        sessionSkippedHomeCount += 1
+        diagnostics.append({
+          type: 'sessions-skipped',
+          accountId: home.accountId,
+          legacySessionsRoot,
+          reason: sessionResult.reason,
+          observed: sessionResult.observed,
+          limit: sessionResult.limit
+        })
+      }
+    }
+  }
+
+  const summary: CodexLegacyManagedStateMigrationSummary = {
+    diagnosticRecordsOmitted: diagnostics.omittedCount,
+    diagnosticRecordsWritten: diagnostics.writtenCount,
+    historySkippedHomeCount,
+    managedHomeDiscoverySkipped: discovery.kind === 'skipped',
+    migratedHomeCount: discovery.kind === 'complete' ? discovery.homes.length : 0,
+    sessionSkippedHomeCount
+  }
+  writeMigrationMarker(markerPath, summary)
+  warnAboutCapacitySkips(summary, markerPath)
+  return summary
+}
+
+function discoverLegacyManagedHomesSync(
+  managedAccountsRoot: string,
+  limits: CodexLegacyManagedStateMigrationLimits
+): ManagedHomeDiscoveryResult {
+  if (!existsSync(managedAccountsRoot)) {
+    return { kind: 'complete', homes: [] }
+  }
+
+  const homes: LegacyManagedHome[] = []
+  let entryCount = 0
+  const directory = opendirSync(managedAccountsRoot)
+  try {
+    while (true) {
+      const entry = directory.readSync()
+      if (entry === null) {
+        break
+      }
+      entryCount += 1
+      if (entryCount > limits.maxAccountEntries) {
+        return {
+          kind: 'skipped',
+          reason: 'account-entries',
+          observed: entryCount,
+          limit: limits.maxAccountEntries
+        }
+      }
+      if (!entry.isDirectory()) {
+        continue
+      }
+      const homePath = join(managedAccountsRoot, entry.name, 'home')
+      if (!existsSync(join(homePath, '.orca-managed-home'))) {
+        continue
+      }
+      homes.push({ accountId: entry.name, homePath })
+      if (homes.length > limits.maxManagedHomes) {
+        return {
+          kind: 'skipped',
+          reason: 'managed-homes',
+          observed: homes.length,
+          limit: limits.maxManagedHomes
+        }
+      }
+    }
+  } finally {
+    closeDirectoryIgnoringAlreadyClosed(directory)
+  }
+  return {
+    kind: 'complete',
+    homes: homes.sort(compareManagedHomePaths)
+  }
+}
+
+function compareManagedHomePaths(left: LegacyManagedHome, right: LegacyManagedHome): number {
+  if (left.homePath < right.homePath) {
+    return -1
+  }
+  return left.homePath > right.homePath ? 1 : 0
+}
+
+function writeMigrationMarker(
+  markerPath: string,
+  summary: CodexLegacyManagedStateMigrationSummary
+): void {
+  const capacityDetails = {
+    ...(summary.managedHomeDiscoverySkipped ? { managedHomeDiscoverySkipped: true } : {}),
+    ...(summary.historySkippedHomeCount > 0
+      ? { historySkippedHomeCount: summary.historySkippedHomeCount }
+      : {}),
+    ...(summary.sessionSkippedHomeCount > 0
+      ? { sessionSkippedHomeCount: summary.sessionSkippedHomeCount }
+      : {}),
+    ...(summary.diagnosticRecordsOmitted > 0
+      ? { diagnosticRecordsOmitted: summary.diagnosticRecordsOmitted }
+      : {})
+  }
+  writeFileAtomically(
+    markerPath,
+    `${JSON.stringify({
+      completedAt: Date.now(),
+      migratedHomeCount: summary.migratedHomeCount,
+      ...capacityDetails
+    })}\n`
+  )
+}
+
+function warnAboutCapacitySkips(
+  summary: CodexLegacyManagedStateMigrationSummary,
+  markerPath: string
+): void {
+  const skippedCount =
+    Number(summary.managedHomeDiscoverySkipped) +
+    summary.historySkippedHomeCount +
+    summary.sessionSkippedHomeCount
+  if (skippedCount === 0 && summary.diagnosticRecordsOmitted === 0) {
+    return
+  }
+  console.warn('[codex-runtime-home] Legacy state migration completed with bounded skips:', {
+    skippedCount,
+    diagnosticRecordsOmitted: summary.diagnosticRecordsOmitted,
+    markerPath
+  })
+}
+
+class MigrationDiagnosticWriter {
+  private bytesWritten = 0
+  private failed = false
+  omittedCount = 0
+  writtenCount = 0
+
+  constructor(
+    private readonly path: string,
+    private readonly maxRecords: number,
+    private readonly maxBytes: number
+  ) {}
+
+  append(record: MigrationDiagnostic): void {
+    const line = `${JSON.stringify(record)}\n`
+    const lineBytes = Buffer.byteLength(line)
+    if (
+      this.failed ||
+      this.writtenCount >= this.maxRecords ||
+      lineBytes > this.maxBytes - this.bytesWritten
+    ) {
+      this.omittedCount += 1
+      return
+    }
+    try {
+      appendFileSync(this.path, line, { encoding: 'utf8' })
+      this.writtenCount += 1
+      this.bytesWritten += lineBytes
+    } catch (error) {
+      this.failed = true
+      this.omittedCount += 1
+      console.warn('[codex-runtime-home] Failed to append migration diagnostic:', error)
+    }
+  }
+}
+
+function resolveLimits(
+  overrides: Partial<CodexLegacyManagedStateMigrationLimits> | undefined
+): CodexLegacyManagedStateMigrationLimits {
+  const limits = { ...DEFAULT_LIMITS, ...overrides }
+  for (const [name, value] of Object.entries({
+    maxAccountEntries: limits.maxAccountEntries,
+    maxManagedHomes: limits.maxManagedHomes,
+    maxDiagnosticRecords: limits.maxDiagnosticRecords,
+    maxDiagnosticBytes: limits.maxDiagnosticBytes
+  })) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`${name} must be a non-negative safe integer`)
+    }
+  }
+  return limits
+}
+
+function closeDirectoryIgnoringAlreadyClosed(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ERR_DIR_CLOSED') {
+      throw error
+    }
+  }
+}

--- a/src/main/codex-accounts/legacy-session-migration.test.ts
+++ b/src/main/codex-accounts/legacy-session-migration.test.ts
@@ -1,0 +1,174 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  CODEX_LEGACY_SESSION_COMPARE_CHUNK_BYTES,
+  codexLegacySessionFilesEqualSync,
+  migrateCodexLegacySessionsSync
+} from './legacy-session-migration'
+
+describe('Codex legacy session migration', () => {
+  let root = ''
+  let legacySessionsRoot = ''
+  let runtimeSessionsRoot = ''
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-codex-legacy-sessions-'))
+    legacySessionsRoot = join(root, 'legacy')
+    runtimeSessionsRoot = join(root, 'runtime')
+    mkdirSync(legacySessionsRoot)
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('preserves creation of the runtime sessions directory for an empty legacy tree', () => {
+    const result = migrateCodexLegacySessionsSync({
+      accountId: 'account-1',
+      legacySessionsRoot,
+      runtimeSessionsRoot
+    })
+
+    expect(result).toMatchObject({
+      kind: 'migrated',
+      copiedFileCount: 0,
+      discoveredEntryCount: 0,
+      discoveredFileCount: 0
+    })
+    expect(existsSync(runtimeSessionsRoot)).toBe(true)
+  })
+
+  it('copies and conflict-preserves ordinary files in the historical sorted order', () => {
+    mkdirSync(join(legacySessionsRoot, 'nested'))
+    mkdirSync(join(runtimeSessionsRoot, 'nested'), { recursive: true })
+    writeFileSync(join(legacySessionsRoot, 'z-copy.jsonl'), 'copy\n')
+    writeFileSync(join(legacySessionsRoot, 'a-conflict.jsonl'), 'legacy\n')
+    writeFileSync(join(runtimeSessionsRoot, 'a-conflict.jsonl'), 'runtime\n')
+    writeFileSync(join(legacySessionsRoot, 'nested', 'same.jsonl'), 'same\n')
+    writeFileSync(join(runtimeSessionsRoot, 'nested', 'same.jsonl'), 'same\n')
+    const conflicts: string[] = []
+
+    const result = migrateCodexLegacySessionsSync({
+      accountId: 'account-1',
+      legacySessionsRoot,
+      runtimeSessionsRoot,
+      onConflict: ({ runtimeFilePath }) => conflicts.push(runtimeFilePath)
+    })
+
+    expect(result).toMatchObject({
+      kind: 'migrated',
+      conflictCount: 1,
+      copiedFileCount: 2,
+      discoveredEntryCount: 4,
+      discoveredFileCount: 3
+    })
+    expect(conflicts).toEqual([join(runtimeSessionsRoot, 'a-conflict.jsonl')])
+    expect(readFileSync(join(runtimeSessionsRoot, 'z-copy.jsonl'), 'utf8')).toBe('copy\n')
+    expect(
+      readFileSync(join(runtimeSessionsRoot, 'a-conflict.orca-legacy-account-1.jsonl'), 'utf8')
+    ).toBe('legacy\n')
+    expect(readFileSync(join(runtimeSessionsRoot, 'a-conflict.jsonl'), 'utf8')).toBe('runtime\n')
+  })
+
+  it('compares sparse multi-megabyte collisions with fixed-size buffers', () => {
+    mkdirSync(runtimeSessionsRoot)
+    const legacyPath = join(legacySessionsRoot, 'large.jsonl')
+    const runtimePath = join(runtimeSessionsRoot, 'large.jsonl')
+    const sparseBytes = CODEX_LEGACY_SESSION_COMPARE_CHUNK_BYTES * 128
+    for (const path of [legacyPath, runtimePath]) {
+      writeFileSync(path, 'same-prefix')
+      truncateSync(path, sparseBytes)
+    }
+
+    expect(codexLegacySessionFilesEqualSync(legacyPath, runtimePath)).toBe(true)
+    const result = migrateCodexLegacySessionsSync({
+      accountId: 'account-1',
+      legacySessionsRoot,
+      runtimeSessionsRoot
+    })
+
+    expect(result).toMatchObject({ kind: 'migrated', conflictCount: 0, copiedFileCount: 0 })
+    expect(existsSync(join(runtimeSessionsRoot, 'large.orca-legacy-account-1.jsonl'))).toBe(false)
+  })
+
+  it('preflights the entry cap before copying any file', () => {
+    writeFileSync(join(legacySessionsRoot, 'a.jsonl'), 'a')
+    writeFileSync(join(legacySessionsRoot, 'b.jsonl'), 'b')
+
+    const result = migrateCodexLegacySessionsSync({
+      accountId: 'account-1',
+      legacySessionsRoot,
+      runtimeSessionsRoot,
+      limits: { maxEntries: 1 }
+    })
+
+    expect(result).toMatchObject({
+      kind: 'skipped',
+      reason: 'entries',
+      observed: 2,
+      limit: 1
+    })
+    expect(existsSync(runtimeSessionsRoot)).toBe(false)
+  })
+
+  it('preflights depth and aggregate file bytes before copying', () => {
+    mkdirSync(join(legacySessionsRoot, 'one', 'two'), { recursive: true })
+    writeFileSync(join(legacySessionsRoot, 'one', 'two', 'deep.jsonl'), 'deep')
+
+    const depthResult = migrateCodexLegacySessionsSync({
+      accountId: 'account-1',
+      legacySessionsRoot,
+      runtimeSessionsRoot,
+      limits: { maxDepth: 1 }
+    })
+
+    expect(depthResult).toMatchObject({ kind: 'skipped', reason: 'depth', observed: 2, limit: 1 })
+    expect(existsSync(runtimeSessionsRoot)).toBe(false)
+
+    rmSync(join(legacySessionsRoot, 'one'), { recursive: true })
+    writeFileSync(join(legacySessionsRoot, 'a.jsonl'), '1234')
+    writeFileSync(join(legacySessionsRoot, 'b.jsonl'), '5678')
+    const byteResult = migrateCodexLegacySessionsSync({
+      accountId: 'account-1',
+      legacySessionsRoot,
+      runtimeSessionsRoot,
+      limits: { maxTotalFileBytes: 7 }
+    })
+
+    expect(byteResult).toMatchObject({
+      kind: 'skipped',
+      reason: 'total-file-bytes',
+      observed: 8,
+      limit: 7
+    })
+    expect(existsSync(runtimeSessionsRoot)).toBe(false)
+  })
+
+  it('bounds retained path text independently of entry count', () => {
+    writeFileSync(join(legacySessionsRoot, 'long-name.jsonl'), 'content')
+
+    const result = migrateCodexLegacySessionsSync({
+      accountId: 'account-1',
+      legacySessionsRoot,
+      runtimeSessionsRoot,
+      limits: { maxPathCodeUnits: legacySessionsRoot.length }
+    })
+
+    expect(result).toMatchObject({
+      kind: 'skipped',
+      reason: 'path-code-units',
+      limit: legacySessionsRoot.length
+    })
+    expect(existsSync(runtimeSessionsRoot)).toBe(false)
+  })
+})

--- a/src/main/codex-accounts/legacy-session-migration.ts
+++ b/src/main/codex-accounts/legacy-session-migration.ts
@@ -1,0 +1,305 @@
+import { randomUUID } from 'node:crypto'
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  opendirSync,
+  readSync,
+  rmSync,
+  statSync
+} from 'node:fs'
+import { dirname, extname, join, relative } from 'node:path'
+import { copyFileWithWindowsRetry, renameFileWithWindowsRetry } from './fs-utils'
+
+export const CODEX_LEGACY_SESSION_MAX_DEPTH = 32
+export const CODEX_LEGACY_SESSION_MAX_ENTRIES = 50_000
+export const CODEX_LEGACY_SESSION_MAX_TOTAL_FILE_BYTES = 4 * 1024 * 1024 * 1024
+export const CODEX_LEGACY_SESSION_MAX_PATH_CODE_UNITS = 4 * 1024 * 1024
+export const CODEX_LEGACY_SESSION_COMPARE_CHUNK_BYTES = 64 * 1024
+
+export type CodexLegacySessionMigrationLimits = {
+  maxDepth: number
+  maxEntries: number
+  maxTotalFileBytes: number
+  maxPathCodeUnits: number
+}
+
+export const DEFAULT_CODEX_LEGACY_SESSION_MIGRATION_LIMITS: CodexLegacySessionMigrationLimits = {
+  maxDepth: CODEX_LEGACY_SESSION_MAX_DEPTH,
+  maxEntries: CODEX_LEGACY_SESSION_MAX_ENTRIES,
+  maxTotalFileBytes: CODEX_LEGACY_SESSION_MAX_TOTAL_FILE_BYTES,
+  maxPathCodeUnits: CODEX_LEGACY_SESSION_MAX_PATH_CODE_UNITS
+}
+
+export type CodexLegacySessionSkipReason =
+  | 'depth'
+  | 'entries'
+  | 'total-file-bytes'
+  | 'path-code-units'
+
+export type CodexLegacySessionMigrationResult =
+  | {
+      kind: 'migrated'
+      conflictCount: number
+      copiedFileCount: number
+      discoveredEntryCount: number
+      discoveredFileBytes: number
+      discoveredFileCount: number
+    }
+  | {
+      kind: 'skipped'
+      reason: CodexLegacySessionSkipReason
+      observed: number
+      limit: number
+      visitedEntryCount: number
+    }
+
+type TraversalResult =
+  | {
+      kind: 'complete'
+      entryCount: number
+      fileBytes: number
+      filePaths: string[]
+    }
+  | {
+      kind: 'skipped'
+      reason: CodexLegacySessionSkipReason
+      observed: number
+      limit: number
+      visitedEntryCount: number
+    }
+
+class CodexLegacySessionCapacityError extends Error {
+  constructor(
+    readonly reason: CodexLegacySessionSkipReason,
+    readonly observed: number,
+    readonly limit: number,
+    readonly visitedEntryCount: number
+  ) {
+    super(`Codex legacy sessions exceeded ${reason} limit (${observed} > ${limit})`)
+    this.name = 'CodexLegacySessionCapacityError'
+  }
+}
+
+export function migrateCodexLegacySessionsSync(options: {
+  accountId: string
+  legacySessionsRoot: string
+  runtimeSessionsRoot: string
+  limits?: Partial<CodexLegacySessionMigrationLimits>
+  onConflict?: (conflict: { runtimeFilePath: string; preservedPath: string }) => void
+}): CodexLegacySessionMigrationResult {
+  const limits = resolveLimits(options.limits)
+  const traversal = collectLegacySessionFilesSync(options.legacySessionsRoot, limits)
+  if (traversal.kind === 'skipped') {
+    return traversal
+  }
+
+  mkdirSync(options.runtimeSessionsRoot, { recursive: true })
+  let conflictCount = 0
+  let copiedFileCount = 0
+  for (const legacyFilePath of traversal.filePaths) {
+    const relativePath = relative(options.legacySessionsRoot, legacyFilePath)
+    const runtimeFilePath = join(options.runtimeSessionsRoot, relativePath)
+    mkdirSync(dirname(runtimeFilePath), { recursive: true })
+    if (!existsSync(runtimeFilePath)) {
+      copyFileAtomicallySync(legacyFilePath, runtimeFilePath)
+      copiedFileCount += 1
+      continue
+    }
+    if (codexLegacySessionFilesEqualSync(legacyFilePath, runtimeFilePath)) {
+      continue
+    }
+
+    const preservedPath = getPreservedLegacySessionPath(runtimeFilePath, options.accountId)
+    copyFileAtomicallySync(legacyFilePath, preservedPath)
+    conflictCount += 1
+    copiedFileCount += 1
+    options.onConflict?.({ runtimeFilePath, preservedPath })
+  }
+
+  return {
+    kind: 'migrated',
+    conflictCount,
+    copiedFileCount,
+    discoveredEntryCount: traversal.entryCount,
+    discoveredFileBytes: traversal.fileBytes,
+    discoveredFileCount: traversal.filePaths.length
+  }
+}
+
+function collectLegacySessionFilesSync(
+  rootPath: string,
+  limits: CodexLegacySessionMigrationLimits
+): TraversalResult {
+  let entryCount = 0
+  let fileBytes = 0
+  let pathCodeUnits = rootPath.length
+  const filePaths: string[] = []
+  const rootStats = statSync(rootPath)
+  if (rootStats.isFile()) {
+    assertWithinCapacity('total-file-bytes', rootStats.size, limits.maxTotalFileBytes, 0)
+    assertWithinCapacity('path-code-units', pathCodeUnits, limits.maxPathCodeUnits, 0)
+    return { kind: 'complete', entryCount: 0, fileBytes: rootStats.size, filePaths: [rootPath] }
+  }
+
+  const pendingDirectories = [{ depth: 0, path: rootPath }]
+  try {
+    while (pendingDirectories.length > 0) {
+      const current = pendingDirectories.pop()!
+      const directory = opendirSync(current.path)
+      try {
+        while (true) {
+          const entry = directory.readSync()
+          if (entry === null) {
+            break
+          }
+          entryCount += 1
+          assertWithinCapacity('entries', entryCount, limits.maxEntries, entryCount)
+          const childPath = join(current.path, entry.name)
+          pathCodeUnits += childPath.length
+          assertWithinCapacity(
+            'path-code-units',
+            pathCodeUnits,
+            limits.maxPathCodeUnits,
+            entryCount
+          )
+
+          if (entry.isDirectory()) {
+            const childDepth = current.depth + 1
+            assertWithinCapacity('depth', childDepth, limits.maxDepth, entryCount)
+            pendingDirectories.push({ depth: childDepth, path: childPath })
+            continue
+          }
+          if (!entry.isFile()) {
+            continue
+          }
+
+          const size = statSync(childPath).size
+          fileBytes += size
+          assertWithinCapacity('total-file-bytes', fileBytes, limits.maxTotalFileBytes, entryCount)
+          filePaths.push(childPath)
+        }
+      } finally {
+        closeDirectoryIgnoringAlreadyClosed(directory)
+      }
+    }
+  } catch (error) {
+    if (error instanceof CodexLegacySessionCapacityError) {
+      return {
+        kind: 'skipped',
+        reason: error.reason,
+        observed: error.observed,
+        limit: error.limit,
+        visitedEntryCount: error.visitedEntryCount
+      }
+    }
+    throw error
+  }
+
+  return { kind: 'complete', entryCount, fileBytes, filePaths: filePaths.sort() }
+}
+
+export function codexLegacySessionFilesEqualSync(leftPath: string, rightPath: string): boolean {
+  let leftDescriptor: number | null = null
+  let rightDescriptor: number | null = null
+  try {
+    leftDescriptor = openSync(leftPath, 'r')
+    rightDescriptor = openSync(rightPath, 'r')
+    if (fstatSync(leftDescriptor).size !== fstatSync(rightDescriptor).size) {
+      return false
+    }
+
+    const leftBuffer = Buffer.allocUnsafe(CODEX_LEGACY_SESSION_COMPARE_CHUNK_BYTES)
+    const rightBuffer = Buffer.allocUnsafe(CODEX_LEGACY_SESSION_COMPARE_CHUNK_BYTES)
+    while (true) {
+      const leftBytes = readFullChunkSync(leftDescriptor, leftBuffer)
+      const rightBytes = readFullChunkSync(rightDescriptor, rightBuffer)
+      if (leftBytes !== rightBytes) {
+        return false
+      }
+      if (leftBytes === 0) {
+        return true
+      }
+      if (!leftBuffer.subarray(0, leftBytes).equals(rightBuffer.subarray(0, rightBytes))) {
+        return false
+      }
+    }
+  } finally {
+    closeIgnoringErrors(leftDescriptor)
+    closeIgnoringErrors(rightDescriptor)
+  }
+}
+
+function readFullChunkSync(descriptor: number, buffer: Buffer): number {
+  let offset = 0
+  while (offset < buffer.length) {
+    const bytesRead = readSync(descriptor, buffer, offset, buffer.length - offset, null)
+    if (bytesRead === 0) {
+      break
+    }
+    offset += bytesRead
+  }
+  return offset
+}
+
+function copyFileAtomicallySync(sourcePath: string, targetPath: string): void {
+  const temporaryPath = `${targetPath}.${process.pid}.${randomUUID()}.migration.tmp`
+  try {
+    copyFileWithWindowsRetry(sourcePath, temporaryPath)
+    renameFileWithWindowsRetry(temporaryPath, targetPath)
+  } finally {
+    rmSync(temporaryPath, { force: true })
+  }
+}
+
+function getPreservedLegacySessionPath(runtimeFilePath: string, accountId: string): string {
+  const extension = extname(runtimeFilePath)
+  const basename = runtimeFilePath.slice(0, runtimeFilePath.length - extension.length)
+  return `${basename}.orca-legacy-${accountId}${extension}`
+}
+
+function assertWithinCapacity(
+  reason: CodexLegacySessionSkipReason,
+  observed: number,
+  limit: number,
+  visitedEntryCount: number
+): void {
+  if (!Number.isSafeInteger(observed) || observed > limit) {
+    throw new CodexLegacySessionCapacityError(reason, observed, limit, visitedEntryCount)
+  }
+}
+
+function resolveLimits(
+  overrides: Partial<CodexLegacySessionMigrationLimits> | undefined
+): CodexLegacySessionMigrationLimits {
+  const limits = { ...DEFAULT_CODEX_LEGACY_SESSION_MIGRATION_LIMITS, ...overrides }
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`${name} must be a non-negative safe integer`)
+    }
+  }
+  return limits
+}
+
+function closeIgnoringErrors(descriptor: number | null): void {
+  if (descriptor === null) {
+    return
+  }
+  try {
+    closeSync(descriptor)
+  } catch {
+    // Preserve the comparison result or original read error.
+  }
+}
+
+function closeDirectoryIgnoringAlreadyClosed(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ERR_DIR_CLOSED') {
+      throw error
+    }
+  }
+}

--- a/src/main/codex-accounts/legacy-shared-auth-migration.ts
+++ b/src/main/codex-accounts/legacy-shared-auth-migration.ts
@@ -1,6 +1,7 @@
-import { lstatSync, readFileSync } from 'node:fs'
+import { lstatSync } from 'node:fs'
 import { join } from 'node:path'
 import type { CodexManagedAccount } from '../../shared/types'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
 import { writeFileAtomically } from './fs-utils'
 import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-ownership'
 import { codexAuthMatchesManagedAccount, compareCodexAuthFreshness } from './codex-auth-identity'
@@ -174,7 +175,7 @@ function migrateSharedMcpCredentials(
 
 function readRegularFile(filePath: string): string | null {
   const state = regularFileState(filePath)
-  return state === 'missing' ? null : readFileSync(filePath, 'utf-8')
+  return state === 'missing' ? null : readAgentStateFileSync(filePath)
 }
 
 function regularFileState(filePath: string): 'missing' | 'present' {

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -1,35 +1,22 @@
 /* eslint-disable max-lines -- Why: keeps Codex's whole runtime-home contract in one place so account-switch semantics don't drift across launch/login/quota paths. */
 import {
-  appendFileSync,
-  copyFileSync,
   existsSync,
   chmodSync,
   lstatSync,
   mkdirSync,
   readlinkSync,
-  readdirSync,
-  readFileSync,
   renameSync,
   rmdirSync,
   rmSync,
-  statSync,
   symlinkSync,
   unlinkSync
 } from 'node:fs'
 import { execFileSync } from 'node:child_process'
-import {
-  dirname,
-  extname,
-  isAbsolute,
-  join,
-  parse,
-  relative,
-  resolve,
-  win32 as pathWin32
-} from 'node:path'
+import { dirname, isAbsolute, join, resolve, win32 as pathWin32 } from 'node:path'
 import { app } from 'electron'
 import type { CodexManagedAccount } from '../../shared/types'
 import type { Store } from '../persistence'
+import { readAgentStateFileSync, readAgentStateJsonFileSync } from '../agent-state-file-reader'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
 import { writeFileAtomically } from './fs-utils'
 import {
@@ -69,6 +56,9 @@ import {
   codexAuthMatchesSystemDefaultIdentity
 } from './codex-auth-identity'
 import { migrateLegacySharedAuthToPerAccountHome } from './legacy-shared-auth-migration'
+import { migrateLegacyManagedCodexStateSync } from './legacy-managed-state-migration'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import { CodexWslRuntimeHomeRetention } from './codex-wsl-runtime-home-retention'
 
 type CodexSystemDefaultSnapshot = {
   authJson: string | null
@@ -114,9 +104,7 @@ export class CodexRuntimeHomeService {
   // Last auth.json Orca wrote to the runtime home; a later diff signals an out-of-band change (Codex token refresh, or external login to adopt).
   private lastWrittenAuthJson: string | null = null
   // Why: WSL terminals have per-distro runtime homes; sharing the host baseline can make stale WSL auth look newer than managed storage.
-  private readonly lastWrittenWslAuthJsonByDistro = new Map<string, string | null>()
-  private readonly lastSyncedWslAccountIdByDistro = new Map<string, string | null>()
-  private readonly wslRuntimeHomePathByDistro = new Map<string, string>()
+  private readonly wslRuntimeHomeRetention = new CodexWslRuntimeHomeRetention()
   private skipNextReadBackForAccountId: string | null = null
   // Why: a flag-ON host account refreshes auth in its own home. Remember that
   // provenance so a later deselect/rollback never adopts stale shared bytes.
@@ -640,7 +628,7 @@ export class CodexRuntimeHomeService {
       this.skipNextReadBackForAccountId = null
     }
     this.lastSyncedAccountId = activeAccount.id
-    this.writeRuntimeAuth(readFileSync(activeAuthPath, 'utf-8'))
+    this.writeRuntimeAuth(readAgentStateFileSync(activeAuthPath))
   }
 
   // Why: re-auth/add-account write fresh managed tokens, so skip the next read-back to avoid clobbering them with stale runtime tokens.
@@ -691,7 +679,7 @@ export class CodexRuntimeHomeService {
         options.lastWrittenAuthJson === undefined
           ? this.lastWrittenAuthJson
           : options.lastWrittenAuthJson
-      const runtimeContents = readFileSync(runtimeAuthPath, 'utf-8')
+      const runtimeContents = readAgentStateFileSync(runtimeAuthPath)
       if (lastWrittenAuthJson !== null && runtimeContents === lastWrittenAuthJson) {
         return 'unchanged'
       }
@@ -746,7 +734,7 @@ export class CodexRuntimeHomeService {
       if (!existsSync(runtimeAuthPath) || this.lastWrittenAuthJson === null) {
         return 'rejected'
       }
-      const runtimeContents = readFileSync(runtimeAuthPath, 'utf-8')
+      const runtimeContents = readAgentStateFileSync(runtimeAuthPath)
       if (runtimeContents === this.lastWrittenAuthJson) {
         return 'unchanged'
       }
@@ -803,11 +791,11 @@ export class CodexRuntimeHomeService {
         // Why: the system-default account changes outside Orca, so read its real home directly to avoid a stale cached runtime copy.
         return this.getWslSystemCodexHomePath(target)
       }
-      const cachedRuntimeHomePath = this.wslRuntimeHomePathByDistro.get(distro)
+      const cachedRuntimeHomePath = this.wslRuntimeHomeRetention.getRuntimeHomePath(distro)
       if (
         cachedRuntimeHomePath &&
-        this.lastSyncedWslAccountIdByDistro.has(distro) &&
-        this.lastSyncedWslAccountIdByDistro.get(distro) === selectedAccountId
+        this.wslRuntimeHomeRetention.hasLastSyncedAccountId(distro) &&
+        this.wslRuntimeHomeRetention.getLastSyncedAccountId(distro) === selectedAccountId
       ) {
         // Why: RateLimitService resolves provenance twice per poll; stay path-only so it doesn't block main on UNC reads and a wsl.exe probe.
         return cachedRuntimeHomePath
@@ -836,14 +824,14 @@ export class CodexRuntimeHomeService {
     if (!runtimeHomePath) {
       return null
     }
-    this.wslRuntimeHomePathByDistro.set(distro, runtimeHomePath)
+    this.wslRuntimeHomeRetention.setRuntimeHomePath(distro, runtimeHomePath)
 
     mkdirSync(runtimeHomePath, { recursive: true })
     this.safeMigrateLegacyWslActiveHomePointer(distro, runtimeHomePath)
     this.seedWslRuntimeHome(runtimeHomePath, activeAccount, distro)
 
     const runtimeAuthPath = join(runtimeHomePath, 'auth.json')
-    const previousWslAccountId = this.lastSyncedWslAccountIdByDistro.get(distro) ?? null
+    const previousWslAccountId = this.wslRuntimeHomeRetention.getLastSyncedAccountId(distro) ?? null
     if (previousWslAccountId) {
       if (this.skipNextReadBackForAccountId === previousWslAccountId) {
         this.skipNextReadBackForAccountId = null
@@ -855,9 +843,10 @@ export class CodexRuntimeHomeService {
         if (previousWslAccount) {
           this.readBackRefreshedTokensFromPath(runtimeAuthPath, {
             updateLastWrittenAuthJson: true,
-            lastWrittenAuthJson: this.lastWrittenWslAuthJsonByDistro.get(distro) ?? null,
+            lastWrittenAuthJson:
+              this.wslRuntimeHomeRetention.getLastWrittenAuthJson(distro) ?? null,
             setLastWrittenAuthJson: (contents) => {
-              this.lastWrittenWslAuthJsonByDistro.set(distro, contents)
+              this.wslRuntimeHomeRetention.setLastWrittenAuthJson(distro, contents)
             },
             expectedAccountId: previousWslAccount.id
           })
@@ -867,10 +856,10 @@ export class CodexRuntimeHomeService {
 
     const activeAuthPath = activeAccount ? join(activeAccount.managedHomePath, 'auth.json') : null
     if (activeAccount && activeAuthPath && existsSync(activeAuthPath)) {
-      const activeAuth = readFileSync(activeAuthPath, 'utf-8')
+      const activeAuth = readAgentStateFileSync(activeAuthPath)
       this.writeRuntimeAuthAtPath(runtimeAuthPath, activeAuth)
-      this.lastWrittenWslAuthJsonByDistro.set(distro, activeAuth)
-      this.lastSyncedWslAccountIdByDistro.set(distro, activeAccount.id)
+      this.wslRuntimeHomeRetention.setLastWrittenAuthJson(distro, activeAuth)
+      this.wslRuntimeHomeRetention.setLastSyncedAccountId(distro, activeAccount.id)
       return runtimeHomePath
     }
     if (activeAccount && activeAuthPath) {
@@ -889,10 +878,11 @@ export class CodexRuntimeHomeService {
 
     const systemAuthPath = this.getWslSystemCodexAuthPath({ runtime: 'wsl', wslDistro: distro })
     if (systemAuthPath && existsSync(systemAuthPath)) {
-      const systemAuth = readFileSync(systemAuthPath, 'utf-8')
-      const mirroredSystemDefaultAuth = this.lastWrittenWslAuthJsonByDistro.get(distro) ?? null
+      const systemAuth = readAgentStateFileSync(systemAuthPath)
+      const mirroredSystemDefaultAuth =
+        this.wslRuntimeHomeRetention.getLastWrittenAuthJson(distro) ?? null
       const runtimeAuth = existsSync(runtimeAuthPath)
-        ? readFileSync(runtimeAuthPath, 'utf-8')
+        ? readAgentStateFileSync(runtimeAuthPath)
         : null
       if (
         runtimeAuth !== null &&
@@ -904,19 +894,19 @@ export class CodexRuntimeHomeService {
       ) {
         // Why: WSL baselines are lost on restart, so a same-identity fresher runtime auth is a token refresh; copy it back before mirroring ~/.codex.
         this.writeRuntimeAuthAtPath(systemAuthPath, runtimeAuth)
-        this.lastWrittenWslAuthJsonByDistro.set(distro, runtimeAuth)
-        this.lastSyncedWslAccountIdByDistro.set(distro, null)
+        this.wslRuntimeHomeRetention.setLastWrittenAuthJson(distro, runtimeAuth)
+        this.wslRuntimeHomeRetention.setLastSyncedAccountId(distro, null)
         return runtimeHomePath
       }
       this.writeRuntimeAuthAtPath(runtimeAuthPath, systemAuth)
-      this.lastWrittenWslAuthJsonByDistro.set(distro, systemAuth)
-      this.lastSyncedWslAccountIdByDistro.set(distro, null)
+      this.wslRuntimeHomeRetention.setLastWrittenAuthJson(distro, systemAuth)
+      this.wslRuntimeHomeRetention.setLastSyncedAccountId(distro, null)
       return runtimeHomePath
     }
 
     rmSync(runtimeAuthPath, { force: true })
-    this.lastWrittenWslAuthJsonByDistro.set(distro, null)
-    this.lastSyncedWslAccountIdByDistro.set(distro, null)
+    this.wslRuntimeHomeRetention.setLastWrittenAuthJson(distro, null)
+    this.wslRuntimeHomeRetention.setLastSyncedAccountId(distro, null)
     return runtimeHomePath
   }
 
@@ -948,16 +938,16 @@ export class CodexRuntimeHomeService {
       return
     }
 
-    const runtimeHomePath = this.wslRuntimeHomePathByDistro.get(distro)
+    const runtimeHomePath = this.wslRuntimeHomeRetention.getRuntimeHomePath(distro)
     if (!runtimeHomePath) {
       return
     }
 
     this.readBackRefreshedTokensFromPath(join(runtimeHomePath, 'auth.json'), {
       updateLastWrittenAuthJson: true,
-      lastWrittenAuthJson: this.lastWrittenWslAuthJsonByDistro.get(distro) ?? null,
+      lastWrittenAuthJson: this.wslRuntimeHomeRetention.getLastWrittenAuthJson(distro) ?? null,
       setLastWrittenAuthJson: (contents) => {
-        this.lastWrittenWslAuthJsonByDistro.set(distro, contents)
+        this.wslRuntimeHomeRetention.setLastWrittenAuthJson(distro, contents)
       },
       expectedAccountId: account.id
     })
@@ -1056,7 +1046,7 @@ export class CodexRuntimeHomeService {
       if (existsSync(configPath)) {
         writeFileAtomically(
           runtimeConfigPath,
-          prepareWslRuntimeSeedConfig(readFileSync(configPath, 'utf-8'), homePath)
+          prepareWslRuntimeSeedConfig(readAgentStateFileSync(configPath), homePath)
         )
         return
       }
@@ -1080,7 +1070,7 @@ export class CodexRuntimeHomeService {
       if (!existsSync(managedAuthPath)) {
         continue
       }
-      const managedAuthContents = readFileSync(managedAuthPath, 'utf-8')
+      const managedAuthContents = readAgentStateFileSync(managedAuthPath)
       if (codexAuthMatchesManagedAccount(runtimeAuthContents, account, managedAuthContents)) {
         matches.push({ account, managedAuthPath, managedAuthContents })
       }
@@ -1170,14 +1160,6 @@ export class CodexRuntimeHomeService {
 
   private getLegacyHostActiveHomePath(): string {
     return join(this.getRuntimeMetadataDir(), 'active', 'host', 'home')
-  }
-
-  private getMigrationMarkerPath(): string {
-    return join(this.getRuntimeMetadataDir(), 'migration-v1.json')
-  }
-
-  private getMigrationDiagnosticsPath(): string {
-    return join(this.getRuntimeMetadataDir(), 'migration-diagnostics.jsonl')
   }
 
   private getManagedAccountsRoot(): string {
@@ -1284,150 +1266,11 @@ export class CodexRuntimeHomeService {
   }
 
   private migrateLegacyManagedStateIfNeeded(): void {
-    if (existsSync(this.getMigrationMarkerPath())) {
-      return
-    }
-
-    const managedHomes = this.getLegacyManagedHomes()
-    for (const managedHomePath of managedHomes) {
-      const accountId = parse(relative(this.getManagedAccountsRoot(), managedHomePath)).dir.split(
-        /[\\/]/
-      )[0]
-      if (!accountId) {
-        continue
-      }
-      this.migrateLegacyHistory(managedHomePath)
-      this.migrateLegacySessions(managedHomePath, accountId)
-    }
-
-    // Why: migration is one-shot; re-importing every startup would replay stale managed-home state into the shared runtime.
-    writeFileAtomically(
-      this.getMigrationMarkerPath(),
-      `${JSON.stringify({ completedAt: Date.now(), migratedHomeCount: managedHomes.length })}\n`
-    )
-  }
-
-  private getLegacyManagedHomes(): string[] {
-    const managedAccountsRoot = this.getManagedAccountsRoot()
-    if (!existsSync(managedAccountsRoot)) {
-      return []
-    }
-
-    const accountEntries = readdirSync(managedAccountsRoot, { withFileTypes: true })
-    const managedHomes: string[] = []
-    for (const entry of accountEntries) {
-      if (!entry.isDirectory()) {
-        continue
-      }
-      const managedHomePath = join(managedAccountsRoot, entry.name, 'home')
-      if (existsSync(join(managedHomePath, '.orca-managed-home'))) {
-        managedHomes.push(managedHomePath)
-      }
-    }
-    return managedHomes.sort()
-  }
-
-  private migrateLegacyHistory(managedHomePath: string): void {
-    const legacyHistoryPath = join(managedHomePath, 'history.jsonl')
-    if (!existsSync(legacyHistoryPath)) {
-      return
-    }
-
-    const runtimeHistoryPath = join(this.getRuntimeHomePath(), 'history.jsonl')
-    const existingLines = existsSync(runtimeHistoryPath)
-      ? readFileSync(runtimeHistoryPath, 'utf-8').split('\n').filter(Boolean)
-      : []
-    const mergedLines = [...existingLines]
-    const seenLines = new Set(existingLines)
-    for (const line of readFileSync(legacyHistoryPath, 'utf-8').split('\n')) {
-      if (!line || seenLines.has(line)) {
-        continue
-      }
-      seenLines.add(line)
-      mergedLines.push(line)
-    }
-
-    if (mergedLines.length === 0) {
-      return
-    }
-    writeFileAtomically(runtimeHistoryPath, `${mergedLines.join('\n')}\n`)
-  }
-
-  private migrateLegacySessions(managedHomePath: string, accountId: string): void {
-    const legacySessionsRoot = join(managedHomePath, 'sessions')
-    if (!existsSync(legacySessionsRoot)) {
-      return
-    }
-
-    const runtimeSessionsRoot = join(this.getRuntimeHomePath(), 'sessions')
-    mkdirSync(runtimeSessionsRoot, { recursive: true })
-    for (const legacyFilePath of this.listFilesRecursively(legacySessionsRoot)) {
-      const relativePath = relative(legacySessionsRoot, legacyFilePath)
-      const runtimeFilePath = join(runtimeSessionsRoot, relativePath)
-      mkdirSync(dirname(runtimeFilePath), { recursive: true })
-      if (!existsSync(runtimeFilePath)) {
-        copyFileSync(legacyFilePath, runtimeFilePath)
-        continue
-      }
-
-      const legacyContents = readFileSync(legacyFilePath)
-      const runtimeContents = readFileSync(runtimeFilePath)
-      if (runtimeContents.equals(legacyContents)) {
-        continue
-      }
-
-      const preservedPath = this.getPreservedLegacySessionPath(runtimeFilePath, accountId)
-      copyFileSync(legacyFilePath, preservedPath)
-      this.appendMigrationDiagnostic({
-        type: 'session-conflict',
-        accountId,
-        runtimeFilePath,
-        preservedPath
-      })
-    }
-  }
-
-  private listFilesRecursively(rootPath: string): string[] {
-    const stat = statSync(rootPath)
-    if (!stat.isDirectory()) {
-      return [rootPath]
-    }
-
-    const files: string[] = []
-    for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
-      const childPath = join(rootPath, entry.name)
-      if (entry.isDirectory()) {
-        this.appendListedFiles(files, this.listFilesRecursively(childPath))
-        continue
-      }
-      if (entry.isFile()) {
-        files.push(childPath)
-      }
-    }
-    return files.sort()
-  }
-
-  private appendListedFiles(target: string[], source: readonly string[]): void {
-    // Why: tolerate directories larger than V8's argument limit for spread calls.
-    for (const filePath of source) {
-      target.push(filePath)
-    }
-  }
-
-  private getPreservedLegacySessionPath(runtimeFilePath: string, accountId: string): string {
-    const extension = extname(runtimeFilePath)
-    const basename = runtimeFilePath.slice(0, runtimeFilePath.length - extension.length)
-    return `${basename}.orca-legacy-${accountId}${extension}`
-  }
-
-  private appendMigrationDiagnostic(record: Record<string, string>): void {
-    const diagnosticsPath = this.getMigrationDiagnosticsPath()
-    try {
-      appendFileSync(diagnosticsPath, `${JSON.stringify(record)}\n`, { encoding: 'utf-8' })
-    } catch (error) {
-      // Why: diagnostics must not fail the one-shot migration after the session file is already preserved.
-      console.warn('[codex-runtime-home] Failed to append migration diagnostic:', error)
-    }
+    migrateLegacyManagedCodexStateSync({
+      managedAccountsRoot: this.getManagedAccountsRoot(),
+      metadataDir: this.getRuntimeMetadataDir(),
+      runtimeHomePath: this.getRuntimeHomePath()
+    })
   }
 
   private captureSystemDefaultSnapshot(options: { force: boolean }): void {
@@ -1438,7 +1281,7 @@ export class CodexRuntimeHomeService {
 
     const runtimeAuthPath = join(getSystemCodexHomePath(), 'auth.json')
     const snapshot: CodexSystemDefaultSnapshot = {
-      authJson: existsSync(runtimeAuthPath) ? readFileSync(runtimeAuthPath, 'utf-8') : null
+      authJson: existsSync(runtimeAuthPath) ? readAgentStateFileSync(runtimeAuthPath) : null
     }
     writeFileAtomically(snapshotPath, `${JSON.stringify(snapshot, null, 2)}\n`, { mode: 0o600 })
   }
@@ -1451,7 +1294,7 @@ export class CodexRuntimeHomeService {
     }
 
     try {
-      const runtimeAuth = readFileSync(runtimeAuthPath, 'utf-8')
+      const runtimeAuth = readAgentStateFileSync(runtimeAuthPath)
       if (!existsSync(systemDefaultAuthPath)) {
         const snapshot = this.readSystemDefaultSnapshot(this.getSystemDefaultSnapshotPath())
         const mirroredSystemDefaultAuth = this.lastWrittenAuthJson ?? snapshot?.authJson ?? null
@@ -1467,7 +1310,7 @@ export class CodexRuntimeHomeService {
         }
         return
       }
-      const systemDefaultAuth = readFileSync(systemDefaultAuthPath, 'utf-8')
+      const systemDefaultAuth = readAgentStateFileSync(systemDefaultAuthPath)
       if (runtimeAuth !== systemDefaultAuth) {
         const snapshot = this.readSystemDefaultSnapshot(this.getSystemDefaultSnapshotPath())
         const mirroredSystemDefaultAuth = this.lastWrittenAuthJson ?? snapshot?.authJson ?? null
@@ -1496,7 +1339,7 @@ export class CodexRuntimeHomeService {
     const runtimeAuthPath = this.getRuntimeAuthPath()
     const systemDefaultAuthPath = join(getSystemCodexHomePath(), 'auth.json')
     if (existsSync(systemDefaultAuthPath)) {
-      const systemDefaultAuth = readFileSync(systemDefaultAuthPath, 'utf-8')
+      const systemDefaultAuth = readAgentStateFileSync(systemDefaultAuthPath)
       this.captureSystemDefaultSnapshot({ force: true })
       this.writeRuntimeAuth(systemDefaultAuth)
       return
@@ -1566,7 +1409,7 @@ export class CodexRuntimeHomeService {
 
   private readSystemDefaultAuth(): string | null {
     const systemDefaultAuthPath = join(getSystemCodexHomePath(), 'auth.json')
-    return existsSync(systemDefaultAuthPath) ? readFileSync(systemDefaultAuthPath, 'utf-8') : null
+    return existsSync(systemDefaultAuthPath) ? readAgentStateFileSync(systemDefaultAuthPath) : null
   }
 
   private writeRuntimeAuth(contents: string): void {
@@ -1592,8 +1435,11 @@ export class CodexRuntimeHomeService {
 
   private fileContentsEqual(targetPath: string, contents: string): boolean {
     try {
-      return existsSync(targetPath) && readFileSync(targetPath, 'utf-8') === contents
-    } catch {
+      return existsSync(targetPath) && readAgentStateFileSync(targetPath) === contents
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
+        throw error
+      }
       return false
     }
   }
@@ -1635,7 +1481,7 @@ export class CodexRuntimeHomeService {
   private readRuntimeLogoutMarker(): CodexRuntimeLogoutMarker | null {
     let parsed: unknown
     try {
-      parsed = JSON.parse(readFileSync(this.getRuntimeLogoutMarkerPath(), 'utf-8')) as unknown
+      parsed = readAgentStateJsonFileSync(this.getRuntimeLogoutMarkerPath())
     } catch {
       return null
     }
@@ -1665,7 +1511,7 @@ export class CodexRuntimeHomeService {
   private readSystemDefaultSnapshot(snapshotPath: string): CodexSystemDefaultSnapshot | null {
     let rawContents: string
     try {
-      rawContents = readFileSync(snapshotPath, 'utf-8')
+      rawContents = readAgentStateFileSync(snapshotPath)
     } catch {
       return null
     }

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: keeps Codex account lifecycle, path safety, login, and identity parsing in one audited main-process module. */
 import { randomUUID } from 'node:crypto'
 import { execFileSync, spawn, type ChildProcess } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname, join, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
 import { app } from 'electron'
@@ -44,6 +44,8 @@ import {
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-ownership'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 
 const LOGIN_TIMEOUT_MS = 120_000
 const MAX_LOGIN_OUTPUT_CHARS = 4_000
@@ -133,7 +135,7 @@ function killLoginProcessTree(child: ChildProcess): void {
 
 function readLoginAuthSnapshot(authJsonPath: string): string | null | undefined {
   try {
-    return readFileSync(authJsonPath, 'utf-8')
+    return readAgentStateFileSync(authJsonPath)
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
     if (code === 'ENOENT' || code === 'ENOTDIR') {
@@ -426,7 +428,7 @@ export class CodexAccountService {
     try {
       // Why: a single read avoids an exists/read race and halves filesystem
       // probes whenever an accounts snapshot resolves this live identity.
-      contents = readFileSync(authFilePath, 'utf-8')
+      contents = readAgentStateFileSync(authFilePath)
     } catch (error) {
       const code = (error as NodeJS.ErrnoException | null)?.code
       if (code === 'ENOENT' || code === 'ENOTDIR') {
@@ -722,7 +724,7 @@ export class CodexAccountService {
 
     try {
       return {
-        contents: readFileSync(primaryConfigPath, 'utf-8'),
+        contents: readAgentStateFileSync(primaryConfigPath),
         sourceHomePath,
         sourceHooksPath: join(sourceHomePath, 'hooks.json')
       }
@@ -753,7 +755,7 @@ export class CodexAccountService {
       // Why: the config is read over UNC but consumed by Codex inside WSL, so
       // path rewrites must anchor to the Linux-side ~/.codex, not the UNC path.
       return {
-        contents: readFileSync(configPath, 'utf-8'),
+        contents: readAgentStateFileSync(configPath),
         sourceHomePath: `${wslHome}/.codex`,
         sourceHooksPath: `${wslHome}/.codex/hooks.json`
       }
@@ -781,10 +783,13 @@ export class CodexAccountService {
   private writeManagedConfig(managedHomePath: string, contents: string): void {
     const configPath = join(managedHomePath, 'config.toml')
     try {
-      if (existsSync(configPath) && readFileSync(configPath, 'utf-8') === contents) {
+      if (existsSync(configPath) && readAgentStateFileSync(configPath) === contents) {
         return
       }
-    } catch {
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
+        throw error
+      }
       // Why: a read error must not make a stale config look current; atomic write owns ACL repair and error surfacing.
     }
     writeFileAtomically(configPath, contents)
@@ -953,7 +958,7 @@ export class CodexAccountService {
       }
       if (
         expectedAccountId !== undefined &&
-        readFileSync(join(candidatePath, '.orca-managed-home'), 'utf-8').trim() !==
+        readAgentStateFileSync(join(candidatePath, '.orca-managed-home')).trim() !==
           expectedAccountId
       ) {
         throw new Error('Managed WSL Codex home ownership marker does not match its account ID.')
@@ -1261,7 +1266,7 @@ export class CodexAccountService {
       this.assertManagedHomePath(managedHomePath, expectedAccountId),
       'auth.json'
     )
-    const authFileContents = readFileSync(authFilePath, 'utf-8')
+    const authFileContents = readAgentStateFileSync(authFilePath)
     let parsed: Record<string, unknown>
     try {
       parsed = JSON.parse(authFileContents) as Record<string, unknown>

--- a/src/main/codex-cli/command.ts
+++ b/src/main/codex-cli/command.ts
@@ -1,6 +1,7 @@
-import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:fs'
+import { accessSync, constants, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, join } from 'node:path'
+import { discoverNvmVersionBinDirectories } from './nvm-version-directory-discovery'
 
 type ResolveCommandOptions = {
   pathEnv?: string | null
@@ -25,29 +26,6 @@ function splitPath(pathEnv: string | null | undefined): string[] {
     .split(delimiter)
     .map((entry) => entry.trim())
     .filter(Boolean)
-}
-
-function parseVersionSegment(raw: string): number[] {
-  return raw
-    .replace(/^v/i, '')
-    .split('.')
-    .map((segment) => Number.parseInt(segment, 10))
-    .map((segment) => (Number.isFinite(segment) ? segment : 0))
-}
-
-function compareVersionDesc(left: string, right: string): number {
-  const leftParts = parseVersionSegment(left)
-  const rightParts = parseVersionSegment(right)
-  const length = Math.max(leftParts.length, rightParts.length)
-
-  for (let index = 0; index < length; index += 1) {
-    const delta = (rightParts[index] ?? 0) - (leftParts[index] ?? 0)
-    if (delta !== 0) {
-      return delta
-    }
-  }
-
-  return right.localeCompare(left)
 }
 
 function findFirstExecutable(
@@ -123,19 +101,6 @@ function getBaseVersionManagerDirectories(platform: NodeJS.Platform, homePath: s
   return directories
 }
 
-function getNvmVersionDirectories(homePath: string): string[] {
-  const nvmVersionsDir = join(homePath, '.nvm', 'versions', 'node')
-  if (!existsSync(nvmVersionsDir)) {
-    return []
-  }
-
-  return readdirSync(nvmVersionsDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .sort(compareVersionDesc)
-    .map((entry) => join(nvmVersionsDir, entry, 'bin'))
-}
-
 function getVersionManagerDirectories(
   platform: NodeJS.Platform,
   homePath: string,
@@ -147,7 +112,7 @@ function getVersionManagerDirectories(
   // command resolution probes the newest installed Node versions explicitly.
   const firstNvmMatch = findFirstExecutable(
     platform,
-    getNvmVersionDirectories(homePath),
+    discoverNvmVersionBinDirectories(homePath),
     executableNames
   )
   if (firstNvmMatch) {
@@ -189,7 +154,7 @@ export function resolveCliCommands(
   // Why: agent detection probes many CLIs at once; compute expensive install
   // directories, especially nvm versions, once per detection pass.
   const installDirectories = [
-    ...getNvmVersionDirectories(homePath),
+    ...discoverNvmVersionBinDirectories(homePath),
     ...getBaseVersionManagerDirectories(platform, homePath)
   ]
   const resolved = new Map<string, string>()

--- a/src/main/codex-cli/nvm-version-directory-discovery.test.ts
+++ b/src/main/codex-cli/nvm-version-directory-discovery.test.ts
@@ -1,0 +1,93 @@
+import { join } from 'node:path'
+import type * as NodeFs from 'node:fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const opendirSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFs>()),
+  opendirSync: opendirSyncMock
+}))
+
+import { discoverNvmVersionBinDirectories } from './nvm-version-directory-discovery'
+
+type FakeEntry = { name: string; directory?: boolean }
+
+function useEntries(entries: FakeEntry[]): { closeSync: ReturnType<typeof vi.fn> } {
+  let index = 0
+  const closeSync = vi.fn()
+  opendirSyncMock.mockReturnValue({
+    closeSync,
+    readSync: vi.fn(() => {
+      const entry = entries[index]
+      index += 1
+      return entry
+        ? {
+            name: entry.name,
+            isDirectory: () => entry.directory !== false
+          }
+        : null
+    })
+  })
+  return { closeSync }
+}
+
+describe('nvm version directory discovery', () => {
+  beforeEach(() => {
+    opendirSyncMock.mockReset()
+  })
+
+  it('preserves newest-version ordering for an ordinary listing', () => {
+    useEntries([
+      { name: 'v20.18.0' },
+      { name: 'README', directory: false },
+      { name: 'v24.2.0' },
+      { name: 'v22.14.0' }
+    ])
+
+    expect(discoverNvmVersionBinDirectories('/home/alice')).toEqual([
+      join('/home/alice', '.nvm', 'versions', 'node', 'v24.2.0', 'bin'),
+      join('/home/alice', '.nvm', 'versions', 'node', 'v22.14.0', 'bin'),
+      join('/home/alice', '.nvm', 'versions', 'node', 'v20.18.0', 'bin')
+    ])
+  })
+
+  it('accepts the exact entry and retained-name limits', () => {
+    const { closeSync } = useEntries([{ name: 'v20' }, { name: 'v22' }])
+
+    expect(
+      discoverNvmVersionBinDirectories('/home/alice', {
+        maxEntries: 2,
+        maxRetainedNameBytes: 6
+      })
+    ).toHaveLength(2)
+    expect(closeSync).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed and closes the stream on the first entry over the count limit', () => {
+    const { closeSync } = useEntries([
+      { name: 'v20' },
+      { name: 'v22' },
+      { name: 'v24' },
+      { name: 'v26' }
+    ])
+
+    expect(
+      discoverNvmVersionBinDirectories('/home/alice', {
+        maxEntries: 2
+      })
+    ).toEqual([])
+    expect(closeSync).toHaveBeenCalledOnce()
+  })
+
+  it('fails closed when retained directory names exceed the byte limit', () => {
+    const { closeSync } = useEntries([{ name: 'v20' }, { name: 'v22' }])
+
+    expect(
+      discoverNvmVersionBinDirectories('/home/alice', {
+        maxRetainedNameBytes: 5
+      })
+    ).toEqual([])
+    expect(closeSync).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/codex-cli/nvm-version-directory-discovery.ts
+++ b/src/main/codex-cli/nvm-version-directory-discovery.ts
@@ -1,0 +1,100 @@
+import { opendirSync } from 'node:fs'
+import { join } from 'node:path'
+
+export const NVM_VERSION_DISCOVERY_MAX_ENTRIES = 4_096
+export const NVM_VERSION_DISCOVERY_MAX_RETAINED_NAME_BYTES = 1024 * 1024
+
+export type NvmVersionDiscoveryLimits = {
+  maxEntries: number
+  maxRetainedNameBytes: number
+}
+
+function parseVersionSegment(raw: string): number[] {
+  return raw
+    .replace(/^v/i, '')
+    .split('.')
+    .map((segment) => Number.parseInt(segment, 10))
+    .map((segment) => (Number.isFinite(segment) ? segment : 0))
+}
+
+function compareVersionDesc(left: string, right: string): number {
+  const leftParts = parseVersionSegment(left)
+  const rightParts = parseVersionSegment(right)
+  const length = Math.max(leftParts.length, rightParts.length)
+
+  for (let index = 0; index < length; index += 1) {
+    const delta = (rightParts[index] ?? 0) - (leftParts[index] ?? 0)
+    if (delta !== 0) {
+      return delta
+    }
+  }
+
+  return right.localeCompare(left)
+}
+
+function resolveLimit(requested: number | undefined, maximum: number, name: string): number {
+  if (requested === undefined) {
+    return maximum
+  }
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+  return Math.min(requested, maximum)
+}
+
+function closeNvmVersionsDirectory(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch {
+    // The OS may already have closed a fully consumed directory stream.
+  }
+}
+
+export function discoverNvmVersionBinDirectories(
+  homePath: string,
+  requestedLimits: Partial<NvmVersionDiscoveryLimits> = {}
+): string[] {
+  const maxEntries = resolveLimit(
+    requestedLimits.maxEntries,
+    NVM_VERSION_DISCOVERY_MAX_ENTRIES,
+    'maxEntries'
+  )
+  const maxRetainedNameBytes = resolveLimit(
+    requestedLimits.maxRetainedNameBytes,
+    NVM_VERSION_DISCOVERY_MAX_RETAINED_NAME_BYTES,
+    'maxRetainedNameBytes'
+  )
+  const versionsDir = join(homePath, '.nvm', 'versions', 'node')
+  let directory: ReturnType<typeof opendirSync>
+  try {
+    directory = opendirSync(versionsDir, { bufferSize: 32 })
+  } catch {
+    return []
+  }
+
+  const versionNames: string[] = []
+  let scannedEntries = 0
+  let retainedNameBytes = 0
+  try {
+    for (let entry = directory.readSync(); entry !== null; entry = directory.readSync()) {
+      scannedEntries += 1
+      if (scannedEntries > maxEntries) {
+        return []
+      }
+      if (!entry.isDirectory()) {
+        continue
+      }
+      retainedNameBytes += Buffer.byteLength(entry.name, 'utf8')
+      if (retainedNameBytes > maxRetainedNameBytes) {
+        return []
+      }
+      versionNames.push(entry.name)
+    }
+  } finally {
+    closeNvmVersionsDirectory(directory)
+  }
+
+  return versionNames
+    .sort(compareVersionDesc)
+    .map((versionName) => join(versionsDir, versionName, 'bin'))
+}

--- a/src/main/codex-usage/scanner-large-directory.test.ts
+++ b/src/main/codex-usage/scanner-large-directory.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Dirent, Stats } from 'node:fs'
+import type { Dir, Dirent, Stats } from 'node:fs'
 import type * as FsPromises from 'node:fs/promises'
 import { join } from 'node:path'
 
-const { getLegacyCopiedCodexSessionBridgeScanPreferenceMock, readdirMock, statMock } = vi.hoisted(
+const { getLegacyCopiedCodexSessionBridgeScanPreferenceMock, opendirMock, statMock } = vi.hoisted(
   () => ({
     getLegacyCopiedCodexSessionBridgeScanPreferenceMock: vi.fn(),
-    readdirMock: vi.fn<(dirPath: string) => Promise<Dirent[]>>(),
+    opendirMock: vi.fn<(dirPath: string) => Promise<Dir>>(),
     statMock: vi.fn<(filePath: string) => Promise<Stats>>()
   })
 )
@@ -15,7 +15,7 @@ vi.mock('fs/promises', async () => {
   const actual = await vi.importActual<typeof FsPromises>('fs/promises')
   return {
     ...actual,
-    readdir: readdirMock,
+    opendir: opendirMock,
     stat: statMock
   }
 })
@@ -49,26 +49,44 @@ const largeSessionEntries = Array.from({ length: FILE_COUNT }, (_, index) =>
   dirent(`session-${index}.jsonl`, 'file')
 )
 
+function directory(entries: Dirent[]): Dir {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* entries
+    }
+  } as Dir
+}
+
+function generatedFileDirectory(count: number): Dir {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (let index = 0; index < count; index++) {
+        yield dirent(`session-${index}.jsonl`, 'file')
+      }
+    }
+  } as Dir
+}
+
 describe('listCodexSessionFiles large directories', () => {
   beforeEach(() => {
     getLegacyCopiedCodexSessionBridgeScanPreferenceMock.mockReset()
     getLegacyCopiedCodexSessionBridgeScanPreferenceMock.mockReturnValue(null)
-    readdirMock.mockReset()
+    opendirMock.mockReset()
     statMock.mockReset()
   })
 
   it('keeps nested session scans past the JavaScript spread-argument limit', async () => {
-    readdirMock.mockImplementation(async (dirPath) => {
+    opendirMock.mockImplementation(async (dirPath) => {
       if (dirPath === RUNTIME_SESSIONS_ROOT) {
-        return [dirent('bulk', 'directory')]
+        return directory([dirent('bulk', 'directory')])
       }
       if (dirPath === RUNTIME_BULK_DIR) {
-        return largeSessionEntries
+        return directory(largeSessionEntries)
       }
       if (dirPath === SYSTEM_SESSIONS_ROOT) {
-        return []
+        return directory([])
       }
-      throw new Error(`Unexpected readdir path: ${dirPath}`)
+      throw new Error(`Unexpected opendir path: ${dirPath}`)
     })
     statMock.mockImplementation(async (filePath) => {
       const match = /session-(\d+)\.jsonl$/.exec(filePath.replaceAll('\\', '/'))
@@ -82,5 +100,25 @@ describe('listCodexSessionFiles large directories', () => {
 
     await expect(listCodexSessionFiles()).resolves.toHaveLength(FILE_COUNT)
     expect(getLegacyCopiedCodexSessionBridgeScanPreferenceMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed instead of silently omitting a rollout past capacity', async () => {
+    opendirMock.mockImplementation(async (dirPath) => {
+      if (dirPath === RUNTIME_SESSIONS_ROOT) {
+        return generatedFileDirectory(200_001)
+      }
+      if (dirPath === SYSTEM_SESSIONS_ROOT) {
+        return directory([])
+      }
+      throw new Error(`Unexpected opendir path: ${dirPath}`)
+    })
+
+    const { listCodexSessionFiles } = await import('./scanner')
+
+    await expect(listCodexSessionFiles()).rejects.toMatchObject({
+      name: 'UsageHistoryScanCapacityError',
+      resource: 'files',
+      limit: 200_000
+    })
   })
 })

--- a/src/main/codex-usage/scanner.test.ts
+++ b/src/main/codex-usage/scanner.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 const { getPathMock } = vi.hoisted(() => ({
   getPathMock: vi.fn<(name: string) => string>()
@@ -10,7 +13,8 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { attributeCodexUsageEvent, parseCodexUsageRecord } from './scanner'
+import { attributeCodexUsageEvent, parseCodexUsageFile, parseCodexUsageRecord } from './scanner'
+import { UsageHistoryScanBudget } from '../usage-history-scan-budget'
 
 describe('parseCodexUsageRecord', () => {
   it('uses token totals only as a duplicate baseline', () => {
@@ -319,5 +323,39 @@ describe('attributeCodexUsageEvent', () => {
 
     expect(attributed?.projectKey).toBe('cwd:d:/other/repo')
     expect(attributed?.worktreeId).toBeNull()
+  })
+})
+
+describe('parseCodexUsageFile capacity', () => {
+  it('fails the whole parse when retained usage events exceed capacity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-codex-capacity-'))
+    const filePath = join(root, 'rollout.jsonl')
+    const event = (timestamp: string, total: number) =>
+      JSON.stringify({
+        timestamp,
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: { input_tokens: total, total_tokens: total },
+            last_token_usage: { input_tokens: 1, total_tokens: 1 }
+          }
+        }
+      })
+    try {
+      await writeFile(
+        filePath,
+        [event('2026-04-09T10:00:00.000Z', 1), event('2026-04-09T10:00:01.000Z', 2)].join('\n')
+      )
+      const budget = new UsageHistoryScanBudget({ records: 1 })
+
+      await expect(parseCodexUsageFile(filePath, [], { budget })).rejects.toMatchObject({
+        name: 'UsageHistoryScanCapacityError',
+        resource: 'records',
+        limit: 1
+      })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/codex-usage/scanner.ts
+++ b/src/main/codex-usage/scanner.ts
@@ -1,14 +1,21 @@
 /* eslint-disable max-lines -- Why: Codex discovery, incremental parsing, attribution, and aggregation all depend on the same event-normalization rules. Keeping them together makes the duplicate-snapshot logic easier to audit when usage totals look wrong. */
 import { basename, join, win32, posix } from 'node:path'
-import { createReadStream, existsSync } from 'node:fs'
-import { realpath, readdir, stat } from 'node:fs/promises'
-import { createInterface } from 'node:readline'
+import { existsSync } from 'node:fs'
+import { realpath, stat } from 'node:fs/promises'
 import type { Repo } from '../../shared/types'
 import { areWorktreePathsEqual } from '../ipc/worktree-logic'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { getCodexAccountHomeSessionDirectories } from '../codex/codex-account-home-discovery'
 import { getLegacyCopiedCodexSessionBridgeScanPreference } from '../codex/codex-session-bridge'
 import { canonicalizeUsageWorktreePaths } from '../usage-worktree-canonicalizer'
+import { walkUsageHistoryJsonlFiles } from '../usage-history-file-discovery'
+import { readUsageHistoryJsonlLines } from '../usage-history-jsonl-reader'
+import {
+  MAX_USAGE_HISTORY_FILES,
+  UsageHistoryScanBudget,
+  UsageHistoryScanCapacityError,
+  getUsageHistoryRetainedBytes
+} from '../usage-history-scan-budget'
 import type {
   CodexUsageAttributedEvent,
   CodexUsageDailyAggregate,
@@ -93,39 +100,6 @@ async function yieldToEventLoop(): Promise<void> {
   await new Promise((resolve) => setImmediate(resolve))
 }
 
-async function walkJsonlFiles(
-  dirPath: string,
-  progress: { entriesVisited: number } = { entriesVisited: 0 }
-): Promise<string[]> {
-  const entries = await readdir(dirPath, { withFileTypes: true })
-  const files: string[] = []
-
-  for (const entry of entries) {
-    progress.entriesVisited += 1
-    if (progress.entriesVisited % YIELD_EVERY_DISCOVERY_ENTRIES === 0) {
-      await yieldToEventLoop()
-    }
-    const fullPath = join(dirPath, entry.name)
-    if (entry.isDirectory()) {
-      appendDiscoveredFiles(files, await walkJsonlFiles(fullPath, progress))
-      continue
-    }
-    if (entry.isFile() && entry.name.endsWith('.jsonl')) {
-      files.push(fullPath)
-    }
-  }
-
-  return files
-}
-
-function appendDiscoveredFiles(target: string[], source: readonly string[]): void {
-  // Why: large session directories can exceed V8's argument limit if child
-  // file arrays are spread into push().
-  for (const filePath of source) {
-    target.push(filePath)
-  }
-}
-
 export function getCodexSessionsDirectory(): string {
   // Why: Orca-launched Codex processes receive an Orca-owned CODEX_HOME, so
   // callers that need the primary runtime path should not consult ambient
@@ -148,12 +122,19 @@ function hasLegacyCopiedSessionBridgeMarkers(): boolean {
   return existsSync(join(getOrcaManagedCodexHomePath(), '.orca-session-copies'))
 }
 
-export async function listCodexSessionFiles(): Promise<string[]> {
+export async function listCodexSessionFiles(
+  budget = new UsageHistoryScanBudget()
+): Promise<string[]> {
   const files: string[] = []
   for (const dirPath of getCodexSessionDirectories()) {
     try {
-      appendDiscoveredFiles(files, await walkJsonlFiles(dirPath))
-    } catch {
+      for (const filePath of await walkUsageHistoryJsonlFiles(dirPath, budget)) {
+        files.push(filePath)
+      }
+    } catch (error) {
+      if (error instanceof UsageHistoryScanCapacityError) {
+        throw error
+      }
       // Missing or unreadable history in one home should not hide the other.
     }
   }
@@ -894,6 +875,62 @@ function mergeDailyAggregates(
   }
 }
 
+function claimCodexUsageProjection(
+  budget: UsageHistoryScanBudget,
+  sessions: readonly CodexUsageSession[],
+  dailyAggregates: readonly CodexUsageDailyAggregate[]
+): void {
+  for (const session of sessions) {
+    budget.claimProjection(
+      getUsageHistoryRetainedBytes([
+        session.sessionId,
+        session.firstTimestamp,
+        session.lastTimestamp,
+        session.primaryModel,
+        session.primaryProjectLabel,
+        session.primaryWorktreeId,
+        session.primaryRepoId
+      ])
+    )
+    for (const location of session.locationBreakdown) {
+      budget.claimProjection(
+        getUsageHistoryRetainedBytes([
+          location.locationKey,
+          location.projectLabel,
+          location.repoId,
+          location.worktreeId
+        ])
+      )
+    }
+    for (const model of session.modelBreakdown) {
+      budget.claimProjection(getUsageHistoryRetainedBytes([model.modelKey, model.modelLabel]))
+    }
+    for (const locationModel of session.locationModelBreakdown) {
+      budget.claimProjection(
+        getUsageHistoryRetainedBytes([
+          locationModel.locationKey,
+          locationModel.modelKey,
+          locationModel.modelLabel,
+          locationModel.repoId,
+          locationModel.worktreeId
+        ])
+      )
+    }
+  }
+  for (const daily of dailyAggregates) {
+    budget.claimProjection(
+      getUsageHistoryRetainedBytes([
+        daily.day,
+        daily.model,
+        daily.projectKey,
+        daily.projectLabel,
+        daily.repoId,
+        daily.worktreeId
+      ])
+    )
+  }
+}
+
 export function parseCodexUsageRecord(
   line: string,
   context: CodexUsageParseContext
@@ -997,16 +1034,14 @@ export function parseCodexUsageRecord(
 export async function parseCodexUsageFile(
   filePath: string,
   worktrees: (CodexUsageWorktreeRef & { canonicalPath: string })[],
-  options: { skipInitialBytes?: number; claimEventKey?: (eventKey: string) => boolean } = {}
+  options: {
+    skipInitialBytes?: number
+    claimEventKey?: (eventKey: string) => boolean
+    budget?: UsageHistoryScanBudget
+  } = {}
 ): Promise<CodexUsagePersistedFile> {
+  const budget = options.budget ?? new UsageHistoryScanBudget()
   const processedFile = await getProcessedFileInfo(filePath)
-  const lines = createInterface({
-    input: createReadStream(filePath, {
-      encoding: 'utf-8',
-      start: options.skipInitialBytes ?? 0
-    }),
-    crlfDelay: Infinity
-  })
   const events: CodexUsageAttributedEvent[] = []
   const context: CodexUsageParseContext = {
     sessionId: basename(filePath, '.jsonl'),
@@ -1021,7 +1056,9 @@ export async function parseCodexUsageFile(
 
   const ownedEventKeys = new Set<string>()
   let hasDeferredClaims = false
-  for await (const line of lines) {
+  for await (const line of readUsageHistoryJsonlLines(filePath, {
+    start: options.skipInitialBytes ?? 0
+  })) {
     const parsed = parseCodexUsageRecord(line, context)
     if (!parsed) {
       continue
@@ -1033,6 +1070,18 @@ export async function parseCodexUsageFile(
       hasDeferredClaims = true
       continue
     }
+    budget.claimRecord(
+      getUsageHistoryRetainedBytes([
+        parsed.sessionId,
+        parsed.timestamp,
+        parsed.eventKey,
+        parsed.cwd,
+        parsed.model
+      ])
+    )
+    if (!ownedEventKeys.has(parsed.eventKey)) {
+      budget.claimOwnershipKey(parsed.eventKey)
+    }
     ownedEventKeys.add(parsed.eventKey)
     const attributed = await attributeCodexUsageEvent(parsed, worktrees)
     if (attributed) {
@@ -1040,9 +1089,11 @@ export async function parseCodexUsageFile(
     }
   }
 
+  const aggregates = aggregateCodexUsage(events)
+  claimCodexUsageProjection(budget, aggregates.sessions, aggregates.dailyAggregates)
   return {
     ...processedFile,
-    ...aggregateCodexUsage(events),
+    ...aggregates,
     ownedEventKeys: [...ownedEventKeys],
     hasDeferredClaims
   }
@@ -1056,7 +1107,14 @@ export async function scanCodexUsageFiles(
   sessions: CodexUsageSession[]
   dailyAggregates: CodexUsageDailyAggregate[]
 }> {
-  const files = await listCodexSessionFiles()
+  if (previousProcessedFiles.length > MAX_USAGE_HISTORY_FILES) {
+    throw new UsageHistoryScanCapacityError('files', MAX_USAGE_HISTORY_FILES)
+  }
+  const budget = new UsageHistoryScanBudget()
+  const files = await listCodexSessionFiles(budget)
+  for (const previous of previousProcessedFiles) {
+    budget.claimPath(previous.path)
+  }
   const previousByPath = new Map(previousProcessedFiles.map((file) => [file.path, file]))
   const worktreesWithCanonicalPaths = await buildWorktreesWithCanonicalPaths(worktrees)
   const legacySourceSkipBytesByPath = getLegacySourceSkipBytesByPath(files)
@@ -1107,7 +1165,12 @@ export async function scanCodexUsageFiles(
   // deterministic.
   const eventOwnerByKey = new Map<string, string>()
   for (const [filePath, previous] of reusedByPath) {
+    for (const session of previous.sessions) {
+      budget.claimRecords(session.eventCount)
+    }
+    claimCodexUsageProjection(budget, previous.sessions, previous.dailyAggregates)
     for (const eventKey of previous.ownedEventKeys) {
+      budget.claimOwnershipKey(eventKey)
       // First cached claim wins so conflicting projections stay deterministic.
       if (!eventOwnerByKey.has(eventKey)) {
         eventOwnerByKey.set(eventKey, filePath)
@@ -1119,6 +1182,7 @@ export async function scanCodexUsageFiles(
   for (const [index, filePath] of pathsToParse.entries()) {
     const processed = await parseCodexUsageFile(filePath, worktreesWithCanonicalPaths, {
       skipInitialBytes: legacySourceSkipBytesByPath.get(filePath) ?? 0,
+      budget,
       claimEventKey: (eventKey) => {
         const owner = eventOwnerByKey.get(eventKey)
         if (owner !== undefined && owner !== filePath) {
@@ -1151,14 +1215,17 @@ export async function scanCodexUsageFiles(
     mergeDailyAggregates(dailyByKey, processed.dailyAggregates)
   }
 
+  const sessions = finalizeSessions(sessionsById)
+  const dailyAggregates = [...dailyByKey.values()].sort((left, right) =>
+    left.day === right.day
+      ? left.projectLabel.localeCompare(right.projectLabel)
+      : left.day.localeCompare(right.day)
+  )
+  claimCodexUsageProjection(budget, sessions, dailyAggregates)
   return {
     processedFiles,
-    sessions: finalizeSessions(sessionsById),
-    dailyAggregates: [...dailyByKey.values()].sort((left, right) =>
-      left.day === right.day
-        ? left.projectLabel.localeCompare(right.projectLabel)
-        : left.day.localeCompare(right.day)
-    )
+    sessions,
+    dailyAggregates
   }
 }
 

--- a/src/main/codex-usage/store.ts
+++ b/src/main/codex-usage/store.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines -- Why: this store owns Codex analytics persistence, scan policy, and renderer query semantics. Keeping them together prevents the Codex range/scope rules from drifting away from the scanner’s event model. */
 import { app } from 'electron'
-import { dirname, join } from 'node:path'
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import type {
   CodexUsageBreakdownKind,
   CodexUsageBreakdownRow,
@@ -15,6 +14,10 @@ import type {
 } from '../../shared/codex-usage-types'
 import type { AutomationRunUsage } from '../../shared/automations-types'
 import type { Store } from '../persistence'
+import {
+  readUsageProjectionStateFile,
+  writeUsageProjectionStateFileWithRecovery
+} from '../usage-projection-state-file'
 import { loadKnownUsageWorktreesByRepo, type UsageWorktreeRef } from '../usage-worktree-metadata'
 import type { CodexUsagePersistedState } from './types'
 import { createWorktreeRefs, scanCodexUsageFiles } from './scanner'
@@ -336,10 +339,11 @@ export class CodexUsageStore {
   private load(): CodexUsagePersistedState {
     try {
       const usageFile = getCodexUsageFile()
-      if (!existsSync(usageFile)) {
+      const raw = readUsageProjectionStateFile(usageFile)
+      if (raw === null) {
         return getDefaultState()
       }
-      const parsed = JSON.parse(readFileSync(usageFile, 'utf-8')) as CodexUsagePersistedState
+      const parsed = JSON.parse(raw) as CodexUsagePersistedState
       return normalizePersistedState({
         ...getDefaultState(),
         ...parsed,
@@ -356,13 +360,12 @@ export class CodexUsageStore {
 
   private writeToDisk(): void {
     const usageFile = getCodexUsageFile()
-    const dir = dirname(usageFile)
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
-    }
-    const tmpFile = `${usageFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-    writeFileSync(tmpFile, JSON.stringify(this.state), 'utf-8')
-    renameSync(tmpFile, usageFile)
+    this.state = writeUsageProjectionStateFileWithRecovery(usageFile, this.state, (error) => {
+      const reset = getDefaultState()
+      reset.scanState.enabled = this.state.scanState.enabled
+      reset.scanState.lastScanError = error.message
+      return reset
+    })
   }
 
   async setEnabled(enabled: boolean): Promise<CodexUsageScanState> {

--- a/src/main/codex/codex-account-home-discovery.test.ts
+++ b/src/main/codex/codex-account-home-discovery.test.ts
@@ -1,0 +1,96 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { pathState, ownershipMock } = vi.hoisted(() => ({
+  pathState: { userData: '' },
+  ownershipMock: vi.fn()
+}))
+
+vi.mock('./codex-home-paths', () => ({
+  getOrcaUserDataPath: () => pathState.userData,
+  getSystemCodexHomePath: () => join(pathState.userData, 'system-codex')
+}))
+
+vi.mock('../codex-accounts/host-codex-managed-home-ownership', () => ({
+  assertOwnedHostCodexManagedHomePath: ownershipMock
+}))
+
+import { getCodexAccountHomeSessionDirectories } from './codex-account-home-discovery'
+
+let root = ''
+let accountsRoot = ''
+
+async function createAccount(accountId: string): Promise<string> {
+  const sessionsPath = join(accountsRoot, accountId, 'home', 'sessions')
+  await mkdir(sessionsPath, { recursive: true })
+  return sessionsPath
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orca-codex-account-discovery-'))
+  pathState.userData = root
+  accountsRoot = join(root, 'codex-accounts')
+  await mkdir(accountsRoot)
+  ownershipMock.mockReset()
+})
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('Codex account-home discovery limits', () => {
+  it('preserves sorted valid account homes below every limit', async () => {
+    const later = await createAccount('z-account')
+    const earlier = await createAccount('a-account')
+    await writeFile(join(accountsRoot, 'not-an-account'), 'x')
+
+    expect(getCodexAccountHomeSessionDirectories()).toEqual([earlier, later])
+  })
+
+  it('accepts the exact entry limit and fails closed on the next entry', async () => {
+    const sessionsPath = await createAccount('account-1')
+    await writeFile(join(accountsRoot, 'ignored'), 'x')
+
+    expect(getCodexAccountHomeSessionDirectories({ maxEntries: 2 })).toEqual([sessionsPath])
+    await writeFile(join(accountsRoot, 'overflow'), 'x')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(getCodexAccountHomeSessionDirectories({ maxEntries: 2 })).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[codex-usage] Account-home discovery exceeded 2 entries; skipping homes'
+    )
+  })
+
+  it('accepts the exact home limit and fails closed on the next valid home', async () => {
+    await createAccount('account-1')
+    await createAccount('account-2')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(getCodexAccountHomeSessionDirectories({ maxHomes: 2 })).toHaveLength(2)
+    expect(getCodexAccountHomeSessionDirectories({ maxHomes: 1 })).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[codex-usage] Account-home discovery exceeded 1 homes; skipping homes'
+    )
+  })
+
+  it('bounds retained account and session path strings at the exact code-unit limit', async () => {
+    const accountId = 'account-1'
+    const sessionsPath = await createAccount(accountId)
+    const accountHome = join(accountsRoot, accountId, 'home')
+    const exactPathCodeUnits = accountId.length + accountHome.length + sessionsPath.length
+
+    expect(getCodexAccountHomeSessionDirectories({ maxPathCodeUnits: exactPathCodeUnits })).toEqual(
+      [sessionsPath]
+    )
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    expect(
+      getCodexAccountHomeSessionDirectories({ maxPathCodeUnits: exactPathCodeUnits - 1 })
+    ).toEqual([])
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[codex-usage] Account-home discovery exceeded ${exactPathCodeUnits - 1} path code units; skipping homes`
+    )
+  })
+})

--- a/src/main/codex/codex-account-home-discovery.ts
+++ b/src/main/codex/codex-account-home-discovery.ts
@@ -1,34 +1,102 @@
-import { lstatSync, readdirSync } from 'node:fs'
+import { lstatSync, opendirSync } from 'node:fs'
 import { join } from 'node:path'
 import { getOrcaUserDataPath, getSystemCodexHomePath } from './codex-home-paths'
 import { assertOwnedHostCodexManagedHomePath } from '../codex-accounts/host-codex-managed-home-ownership'
+
+export const CODEX_ACCOUNT_HOME_DISCOVERY_MAX_ENTRIES = 4096
+export const CODEX_ACCOUNT_HOME_DISCOVERY_MAX_HOMES = 256
+export const CODEX_ACCOUNT_HOME_DISCOVERY_MAX_PATH_CODE_UNITS = 1024 * 1024
+
+export type CodexAccountHomeDiscoveryLimits = {
+  maxEntries: number
+  maxHomes: number
+  maxPathCodeUnits: number
+}
 
 /** Session roots of per-account self-contained host Codex homes present on disk.
  *  Why disk-enumerated, not settings-driven: rollouts retained after an account
  *  change must still be counted, and CLI callers have no settings store. WSL
  *  account homes live inside their distro and are scanned by their own lane. */
-export function getCodexAccountHomeSessionDirectories(): string[] {
+export function getCodexAccountHomeSessionDirectories(
+  limitOverrides: Partial<CodexAccountHomeDiscoveryLimits> = {}
+): string[] {
+  const limits: CodexAccountHomeDiscoveryLimits = {
+    maxEntries: CODEX_ACCOUNT_HOME_DISCOVERY_MAX_ENTRIES,
+    maxHomes: CODEX_ACCOUNT_HOME_DISCOVERY_MAX_HOMES,
+    maxPathCodeUnits: CODEX_ACCOUNT_HOME_DISCOVERY_MAX_PATH_CODE_UNITS,
+    ...limitOverrides
+  }
+  for (const [name, value] of Object.entries(limits)) {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`${name} must be a non-negative safe integer`)
+    }
+  }
+
   const accountsRoot = join(getOrcaUserDataPath(), 'codex-accounts')
   try {
-    return readdirSync(accountsRoot, { withFileTypes: true })
-      .filter((entry) => entry.isDirectory())
-      .flatMap((entry) => {
-        const accountHome = join(accountsRoot, entry.name, 'home')
-        try {
-          assertOwnedHostCodexManagedHomePath({
-            candidatePath: accountHome,
-            managedAccountsRoot: accountsRoot,
-            systemCodexHomePath: getSystemCodexHomePath(),
-            expectedAccountId: entry.name
-          })
-          const sessionsPath = join(accountHome, 'sessions')
-          // Why: a redirected sessions root could make usage scan unrelated, unbounded trees.
-          return lstatSync(sessionsPath).isDirectory() ? [sessionsPath] : []
-        } catch {
-          return []
+    const accountIds: string[] = []
+    let entryCount = 0
+    let pathCodeUnits = 0
+    const directory = opendirSync(accountsRoot)
+    try {
+      for (let entry = directory.readSync(); entry !== null; entry = directory.readSync()) {
+        entryCount += 1
+        if (entryCount > limits.maxEntries) {
+          return failCodexAccountHomeDiscovery('entries', limits.maxEntries)
         }
-      })
+        pathCodeUnits += entry.name.length
+        if (pathCodeUnits > limits.maxPathCodeUnits) {
+          return failCodexAccountHomeDiscovery('path code units', limits.maxPathCodeUnits)
+        }
+        if (entry.isDirectory()) {
+          accountIds.push(entry.name)
+        }
+      }
+    } finally {
+      closeCodexAccountDirectory(directory)
+    }
+
+    const sessionDirectories: string[] = []
+    for (const accountId of accountIds.sort()) {
+      const accountHome = join(accountsRoot, accountId, 'home')
+      const sessionsPath = join(accountHome, 'sessions')
+      pathCodeUnits += accountHome.length + sessionsPath.length
+      if (pathCodeUnits > limits.maxPathCodeUnits) {
+        return failCodexAccountHomeDiscovery('path code units', limits.maxPathCodeUnits)
+      }
+      try {
+        assertOwnedHostCodexManagedHomePath({
+          candidatePath: accountHome,
+          managedAccountsRoot: accountsRoot,
+          systemCodexHomePath: getSystemCodexHomePath(),
+          expectedAccountId: accountId
+        })
+        // Why: a redirected sessions root could make usage scan unrelated, unbounded trees.
+        if (lstatSync(sessionsPath).isDirectory()) {
+          sessionDirectories.push(sessionsPath)
+          if (sessionDirectories.length > limits.maxHomes) {
+            return failCodexAccountHomeDiscovery('homes', limits.maxHomes)
+          }
+        }
+      } catch {
+        // A missing, redirected, or invalid account home is not a usage source.
+      }
+    }
+    return sessionDirectories
   } catch {
     return []
   }
+}
+
+function closeCodexAccountDirectory(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch {
+    // The OS may have already closed a failed directory stream.
+  }
+}
+
+function failCodexAccountHomeDiscovery(resource: string, limit: number): [] {
+  console.warn(`[codex-usage] Account-home discovery exceeded ${limit} ${resource}; skipping homes`)
+  return []
 }

--- a/src/main/codex/codex-app-server-capability-cache.test.ts
+++ b/src/main/codex/codex-app-server-capability-cache.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   CODEX_APP_SERVER_CAPABILITY_RETRY_INTERVAL_MS,
   CodexAppServerCapabilityCache,
-  getCodexAppServerHostKey
+  getCodexAppServerHostKey,
+  MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS,
+  MAX_CODEX_APP_SERVER_HOST_KEY_CODE_UNITS,
+  type CodexAppServerHostKey
 } from './codex-app-server-capability-cache'
 
 const unsupportedError = new Error('unsupported')
@@ -113,5 +116,49 @@ describe('CodexAppServerCapabilityCache', () => {
     expect(getCodexAppServerHostKey({ kind: 'native' })).toBe('native')
     expect(getCodexAppServerHostKey({ kind: 'wsl', distro: 'Ubuntu' })).toBe('wsl:Ubuntu')
     expect(getCodexAppServerHostKey({ kind: 'wsl', distro: 'Debian' })).toBe('wsl:Debian')
+  })
+
+  it('retains exactly the host limit and LRU-evicts on the next host', () => {
+    const cache = new CodexAppServerCapabilityCache()
+    const hostKeys = Array.from(
+      { length: MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS },
+      (_, index): CodexAppServerHostKey => `wsl:distro-${index}`
+    )
+    hostKeys.forEach((hostKey) => cache.rememberUnsupported(hostKey, 0))
+
+    expect(cache.shouldTry(hostKeys[0], 1)).toBe(false)
+    cache.rememberUnsupported('wsl:overflow', 0)
+
+    expect(cache.shouldTry(hostKeys[0], 1)).toBe(false)
+    expect(cache.shouldTry(hostKeys[1], 1)).toBe(true)
+    expect(cache.shouldTry('wsl:overflow', 1)).toBe(false)
+  })
+
+  it('bounds oversized generated and direct host keys', () => {
+    const exactDistro = 'x'.repeat(MAX_CODEX_APP_SERVER_HOST_KEY_CODE_UNITS - 'wsl:'.length)
+    const oversizedDistro = `${exactDistro}x`
+
+    expect(getCodexAppServerHostKey({ kind: 'wsl', distro: exactDistro })).toBe(
+      `wsl:${exactDistro}`
+    )
+    const firstDigest = getCodexAppServerHostKey({ kind: 'wsl', distro: oversizedDistro })
+    expect(firstDigest).toMatch(/^wsl:sha256:[a-f0-9]{64}$/)
+    expect(getCodexAppServerHostKey({ kind: 'wsl', distro: oversizedDistro })).toBe(firstDigest)
+
+    const directOversized = `wsl:${oversizedDistro}` as CodexAppServerHostKey
+    const cache = new CodexAppServerCapabilityCache()
+    cache.rememberUnsupported(directOversized, 0)
+    expect(cache.shouldTry(directOversized, 1)).toBe(false)
+  })
+
+  it('clear forgets supported and unsupported host state', () => {
+    const cache = new CodexAppServerCapabilityCache()
+    cache.rememberSupported('native')
+    cache.rememberUnsupported('wsl:Ubuntu', 0)
+
+    cache.clear()
+
+    expect(cache.isKnownSupported('native')).toBe(false)
+    expect(cache.shouldTry('wsl:Ubuntu', 1)).toBe(true)
   })
 })

--- a/src/main/codex/codex-app-server-capability-cache.ts
+++ b/src/main/codex/codex-app-server-capability-cache.ts
@@ -1,17 +1,35 @@
+import { createHash } from 'node:crypto'
+
 // Why: suppress a known-missing RPC surface without pinning it forever — an
 // in-place codex upgrade during a long Orca session self-heals after the
 // interval, mirroring GitCapabilityCache's rationale.
 export const CODEX_APP_SERVER_CAPABILITY_RETRY_INTERVAL_MS = 30 * 60_000
+export const MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS = 64
+export const MAX_CODEX_APP_SERVER_HOST_KEY_CODE_UNITS = 4 * 1024
 
 /** Execution host that runs the codex binary. WSL distros are isolated from
  *  the native host and from each other — each can carry a different codex. */
 export type CodexAppServerHostKey = 'native' | `wsl:${string}`
 
+function boundHostKey(hostKey: CodexAppServerHostKey): CodexAppServerHostKey {
+  if (hostKey.length <= MAX_CODEX_APP_SERVER_HOST_KEY_CODE_UNITS) {
+    return hostKey
+  }
+  return `wsl:sha256:${createHash('sha256').update(hostKey.slice('wsl:'.length)).digest('hex')}`
+}
+
 export function getCodexAppServerHostKey(
   host: { kind: 'native' } | { kind: 'wsl'; distro: string }
 ): CodexAppServerHostKey {
-  return host.kind === 'wsl' ? `wsl:${host.distro}` : 'native'
+  if (host.kind === 'native') {
+    return 'native'
+  }
+  return boundHostKey(`wsl:${host.distro}`)
 }
+
+type CodexAppServerCapabilityState =
+  | { kind: 'supported' }
+  | { kind: 'unsupported'; retryAfterMs: number }
 
 /**
  * Capability cache for the codex app-server trust-grant RPC pair, modeled on
@@ -20,33 +38,56 @@ export function getCodexAppServerHostKey(
  * unsupported mark alone is what keeps later installs off the dead probe.
  */
 export class CodexAppServerCapabilityCache {
-  private readonly retryAfterByHost = new Map<CodexAppServerHostKey, number>()
-  private readonly supportedHosts = new Set<CodexAppServerHostKey>()
+  private readonly stateByHost = new Map<CodexAppServerHostKey, CodexAppServerCapabilityState>()
+
+  private getState(hostKey: CodexAppServerHostKey): CodexAppServerCapabilityState | undefined {
+    const retainedHostKey = boundHostKey(hostKey)
+    const state = this.stateByHost.get(retainedHostKey)
+    if (state) {
+      this.stateByHost.delete(retainedHostKey)
+      this.stateByHost.set(retainedHostKey, state)
+    }
+    return state
+  }
+
+  private remember(hostKey: CodexAppServerHostKey, state: CodexAppServerCapabilityState): void {
+    const retainedHostKey = boundHostKey(hostKey)
+    this.stateByHost.delete(retainedHostKey)
+    this.stateByHost.set(retainedHostKey, state)
+    while (this.stateByHost.size > MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS) {
+      const oldestHost = this.stateByHost.keys().next().value
+      if (oldestHost === undefined) {
+        return
+      }
+      this.stateByHost.delete(oldestHost)
+    }
+  }
 
   shouldTry(hostKey: CodexAppServerHostKey, nowMs = Date.now()): boolean {
-    const retryAfterMs = this.retryAfterByHost.get(hostKey)
-    if (retryAfterMs === undefined) {
+    const state = this.getState(hostKey)
+    if (!state || state.kind === 'supported') {
       return true
     }
-    if (nowMs < retryAfterMs) {
+    if (nowMs < state.retryAfterMs) {
       return false
     }
-    this.retryAfterByHost.delete(hostKey)
+    this.stateByHost.delete(boundHostKey(hostKey))
     return true
   }
 
   isKnownSupported(hostKey: CodexAppServerHostKey): boolean {
-    return this.supportedHosts.has(hostKey)
+    return this.getState(hostKey)?.kind === 'supported'
   }
 
   rememberUnsupported(hostKey: CodexAppServerHostKey, nowMs = Date.now()): void {
-    this.supportedHosts.delete(hostKey)
-    this.retryAfterByHost.set(hostKey, nowMs + CODEX_APP_SERVER_CAPABILITY_RETRY_INTERVAL_MS)
+    this.remember(hostKey, {
+      kind: 'unsupported',
+      retryAfterMs: nowMs + CODEX_APP_SERVER_CAPABILITY_RETRY_INTERVAL_MS
+    })
   }
 
   rememberSupported(hostKey: CodexAppServerHostKey): void {
-    this.retryAfterByHost.delete(hostKey)
-    this.supportedHosts.add(hostKey)
+    this.remember(hostKey, { kind: 'supported' })
   }
 
   runWithFallbackSync<T>(
@@ -56,7 +97,7 @@ export class CodexAppServerCapabilityCache {
     isUnsupportedError: (error: unknown) => boolean,
     nowMs = Date.now()
   ): T {
-    if (!this.supportedHosts.has(hostKey) && !this.shouldTry(hostKey, nowMs)) {
+    if (!this.shouldTry(hostKey, nowMs)) {
       return runFallback()
     }
     try {
@@ -76,8 +117,7 @@ export class CodexAppServerCapabilityCache {
   }
 
   clear(): void {
-    this.retryAfterByHost.clear()
-    this.supportedHosts.clear()
+    this.stateByHost.clear()
   }
 }
 

--- a/src/main/codex/codex-app-server-fragment-memory.test.ts
+++ b/src/main/codex/codex-app-server-fragment-memory.test.ts
@@ -1,0 +1,45 @@
+import type { ChildProcess, ChildProcessWithoutNullStreams, spawn } from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import { runCodexAppServerSession } from './codex-app-server-session'
+
+describe('runCodexAppServerSession fragmented output', () => {
+  it('parses a response delivered as 100,000 one-byte fragments', async () => {
+    const child = new EventEmitter() as ChildProcessWithoutNullStreams
+    child.stdin = new PassThrough()
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = vi.fn(() => true) as ChildProcess['kill']
+    child.stdin.on('data', (bytes: Buffer) => {
+      const request = JSON.parse(bytes.toString()) as { id?: number; method: string }
+      if (request.id === undefined) {
+        return
+      }
+      const response = Buffer.from(
+        `${request.method === 'fragment/get' ? ' '.repeat(99_950) : ''}${JSON.stringify({
+          id: request.id,
+          result: request.method === 'fragment/get' ? { value: 'complete' } : {}
+        })}\n`
+      )
+      for (let index = 0; index < response.byteLength; index += 1) {
+        child.stdout.emit('data', response.subarray(index, index + 1))
+      }
+    })
+    child.stdin.once('finish', () => {
+      queueMicrotask(() => {
+        child.emit('exit', 0, null)
+        child.emit('close', 0, null)
+      })
+    })
+    const spawnImpl = vi.fn(() => child) as unknown as typeof spawn
+
+    const result = await runCodexAppServerSession(
+      { command: 'codex', args: ['app-server'], timeoutMs: 5_000 },
+      ({ request }) => request('fragment/get'),
+      spawnImpl
+    )
+
+    expect(result).toEqual({ value: 'complete' })
+  })
+})

--- a/src/main/codex/codex-app-server-grant-bridge.ts
+++ b/src/main/codex/codex-app-server-grant-bridge.ts
@@ -16,6 +16,10 @@ import type {
   CodexUserHookTrustRebaseRequest,
   CodexUserHookTrustRebaseResult
 } from './codex-user-hook-trust-rebase-client'
+import {
+  findLastNonEmptyCodexAppServerGrantLine,
+  parseCodexAppServerGrantJson
+} from './codex-app-server-grant-json'
 
 // Why: hook install/refresh is synchronous launch prep — a Codex pane must
 // not start before its trust is settled — but a stdio JSON-RPC session needs
@@ -114,12 +118,11 @@ function runCodexAppServerEntrySync(
       `codex trust-grant entry killed by ${spawned.signal} after ${request.invocation.timeoutMs}ms deadline`
     )
   }
-  const lines = (spawned.stdout ?? '').split('\n').filter((line) => line.trim().length > 0)
-  const lastLine = lines.at(-1)
+  const lastLine = findLastNonEmptyCodexAppServerGrantLine(spawned.stdout ?? '')
   let envelope: GrantEntryEnvelope | null = null
   if (lastLine) {
     try {
-      envelope = JSON.parse(lastLine) as GrantEntryEnvelope
+      envelope = parseCodexAppServerGrantJson<GrantEntryEnvelope>(lastLine)
     } catch {
       envelope = null
     }

--- a/src/main/codex/codex-app-server-grant-entry.ts
+++ b/src/main/codex/codex-app-server-grant-entry.ts
@@ -11,22 +11,21 @@ import {
 import { writeSync } from 'node:fs'
 import { runCodexHookTrustGrantSession } from './codex-app-server-client'
 import { runCodexUserHookTrustRebaseSession } from './codex-user-hook-trust-rebase-client'
+import { readNodeReadableTextWithinLimit } from '../../shared/node-readable-text'
+import { parseCodexAppServerGrantJson } from './codex-app-server-grant-json'
 
 const HARD_EXIT_MARGIN_MS = 2_000
+const GRANT_ENTRY_MAX_INPUT_BYTES = 16 * 1024 * 1024
 
 async function readStdin(): Promise<string> {
-  const chunks: Buffer[] = []
-  for await (const chunk of process.stdin) {
-    chunks.push(chunk as Buffer)
-  }
-  return Buffer.concat(chunks).toString('utf8')
+  return await readNodeReadableTextWithinLimit(process.stdin, GRANT_ENTRY_MAX_INPUT_BYTES)
 }
 
 async function main(): Promise<void> {
   const raw = await readStdin()
   let request: CodexAppServerEntryRequest
   try {
-    request = JSON.parse(raw) as CodexAppServerEntryRequest
+    request = parseCodexAppServerGrantJson<CodexAppServerEntryRequest>(raw)
   } catch (error) {
     process.stdout.write(
       `${JSON.stringify({

--- a/src/main/codex/codex-app-server-grant-json.test.ts
+++ b/src/main/codex/codex-app-server-grant-json.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  CODEX_APP_SERVER_GRANT_JSON_MAX_STRUCTURAL_TOKENS,
+  findLastNonEmptyCodexAppServerGrantLine,
+  parseCodexAppServerGrantJson
+} from './codex-app-server-grant-json'
+
+describe('Codex app-server grant JSON admission', () => {
+  it('preserves the last non-empty output line without splitting all output', () => {
+    expect(findLastNonEmptyCodexAppServerGrantLine('diagnostic\n\n{"ok":true}\n \t\r')).toBe(
+      '{"ok":true}'
+    )
+    expect(findLastNonEmptyCodexAppServerGrantLine('\n \t\r')).toBeNull()
+  })
+
+  it('rejects structurally amplified grant JSON before parsing', () => {
+    const text = `{"values":[${'0,'.repeat(CODEX_APP_SERVER_GRANT_JSON_MAX_STRUCTURAL_TOKENS)}0]}`
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    try {
+      expect(() => parseCodexAppServerGrantJson(text)).toThrow(/JSON structure exceeds/)
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
+  })
+})

--- a/src/main/codex/codex-app-server-grant-json.ts
+++ b/src/main/codex/codex-app-server-grant-json.ts
@@ -1,0 +1,51 @@
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
+
+export const CODEX_APP_SERVER_GRANT_JSON_MAX_STRUCTURAL_TOKENS = 1_000_000
+export const CODEX_APP_SERVER_GRANT_JSON_MAX_NESTING_DEPTH = 128
+
+export function parseCodexAppServerGrantJson<T>(text: string): T {
+  assertJsonTextStructureWithinLimits(text, {
+    structuralTokens: CODEX_APP_SERVER_GRANT_JSON_MAX_STRUCTURAL_TOKENS,
+    nestingDepth: CODEX_APP_SERVER_GRANT_JSON_MAX_NESTING_DEPTH
+  })
+  return JSON.parse(text) as T
+}
+
+export function findLastNonEmptyCodexAppServerGrantLine(output: string): string | null {
+  let end = output.length
+  while (end > 0) {
+    const newline = output.lastIndexOf('\n', end - 1)
+    const start = newline + 1
+    const line = output.slice(start, end)
+    if (hasNonWhitespace(line)) {
+      return line
+    }
+    end = newline === -1 ? 0 : newline
+  }
+  return null
+}
+
+function hasNonWhitespace(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    if (!isEcmaWhitespace(value.charCodeAt(index))) {
+      return true
+    }
+  }
+  return false
+}
+
+function isEcmaWhitespace(code: number): boolean {
+  return (
+    code === 0x20 ||
+    (code >= 0x09 && code <= 0x0d) ||
+    code === 0xa0 ||
+    code === 0x1680 ||
+    (code >= 0x2000 && code <= 0x200a) ||
+    code === 0x2028 ||
+    code === 0x2029 ||
+    code === 0x202f ||
+    code === 0x205f ||
+    code === 0x3000 ||
+    code === 0xfeff
+  )
+}

--- a/src/main/codex/codex-app-server-session.ts
+++ b/src/main/codex/codex-app-server-session.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 import { waitForProcessExitUntil } from './codex-process-exit-deadline'
 import { stderrIndicatesMissingAppServer } from './codex-app-server-capability-signal'
 
@@ -117,7 +118,7 @@ export async function runCodexAppServerSession<T>(
     windowsHide: true
   }) as ChildProcessWithoutNullStreams
 
-  let stderrTail = ''
+  const stderrTail = new GrowingByteBuffer()
   let exited = false
   let nextRequestId = 1
   let timedOut = false
@@ -145,10 +146,15 @@ export async function runCodexAppServerSession<T>(
   child.on('close', () => {
     failPending(buildEarlyExitError())
   })
-  // Why: JSONL can contain non-ASCII hook paths. Stream decoding must retain a
-  // multibyte character split across pipe chunks or the response becomes invalid JSON.
-  child.stderr.setEncoding('utf8').on('data', (chunk: string) => {
-    stderrTail = (stderrTail + chunk).slice(-STDERR_TAIL_MAX_BYTES)
+  // Why: retain raw bytes so split UTF-8 code points decode only after a full line arrives.
+  child.stderr.on('data', (chunk: Buffer) => {
+    if (chunk.byteLength >= STDERR_TAIL_MAX_BYTES) {
+      stderrTail.clear()
+      stderrTail.append(chunk.subarray(chunk.byteLength - STDERR_TAIL_MAX_BYTES))
+      return
+    }
+    stderrTail.append(chunk)
+    stderrTail.retainSuffix(STDERR_TAIL_MAX_BYTES)
   })
   // Why: a child can exit between the liveness check and stdin.write(); an
   // EPIPE must reject the RPC instead of becoming an unhandled stream error.
@@ -156,21 +162,25 @@ export async function runCodexAppServerSession<T>(
     failPending(error)
   })
 
-  let stdoutBuffer = ''
-  child.stdout.setEncoding('utf8').on('data', (chunk: string) => {
-    stdoutBuffer += chunk
-    if (Buffer.byteLength(stdoutBuffer) > STDOUT_LINE_MAX_BYTES) {
+  const stdoutBuffer = new GrowingByteBuffer()
+  child.stdout.on('data', (chunk: Buffer) => {
+    stdoutBuffer.append(chunk)
+    if (stdoutBuffer.byteLength > STDOUT_LINE_MAX_BYTES) {
       // Why: Windows process-tree termination is asynchronous; stop buffered
       // chunks from spawning another taskkill for the same oversized response.
       child.stdout.destroy()
+      stdoutBuffer.clear()
       killCodexAppServerProcessTree(child)
       failPending(new Error('codex app-server emitted an oversized JSONL response'))
       return
     }
-    let newlineIndex
-    while ((newlineIndex = stdoutBuffer.indexOf('\n')) !== -1) {
-      const line = stdoutBuffer.slice(0, newlineIndex).trim()
-      stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1)
+    while (true) {
+      const newlineIndex = stdoutBuffer.indexOfByte(0x0a)
+      if (newlineIndex === -1) {
+        break
+      }
+      const line = stdoutBuffer.takePrefixString(newlineIndex).trim()
+      stdoutBuffer.discardPrefix(1)
       if (!line) {
         continue
       }
@@ -263,13 +273,14 @@ export async function runCodexAppServerSession<T>(
   }
 
   function buildEarlyExitError(): Error {
-    if (stderrIndicatesMissingAppServer(stderrTail)) {
+    const stderr = stderrTail.toString()
+    if (stderrIndicatesMissingAppServer(stderr)) {
       return new CodexAppServerUnsupportedError(
-        `codex CLI does not support the app-server subcommand: ${stderrTail.trim().slice(0, 400)}`
+        `codex CLI does not support the app-server subcommand: ${stderr.trim().slice(0, 400)}`
       )
     }
     return new Error(
-      `codex app-server exited before completing the session${stderrTail ? `: ${stderrTail.trim().slice(0, 400)}` : ''}`
+      `codex app-server exited before completing the session${stderr ? `: ${stderr.trim().slice(0, 400)}` : ''}`
     )
   }
 
@@ -289,10 +300,11 @@ export async function runCodexAppServerSession<T>(
       error instanceof Error &&
       !(error instanceof CodexAppServerUnsupportedError) &&
       !(error instanceof CodexAppServerTimeoutError) &&
-      stderrIndicatesMissingAppServer(stderrTail)
+      stderrIndicatesMissingAppServer(stderrTail.toString())
     ) {
+      const stderr = stderrTail.toString()
       throw new CodexAppServerUnsupportedError(
-        `codex CLI does not support the app-server subcommand: ${stderrTail.trim().slice(0, 400)}`
+        `codex CLI does not support the app-server subcommand: ${stderr.trim().slice(0, 400)}`
       )
     }
     throw error
@@ -312,5 +324,7 @@ export async function runCodexAppServerSession<T>(
       }
     }
     clearTimeout(deadline)
+    stdoutBuffer.clear()
+    stderrTail.clear()
   }
 }

--- a/src/main/codex/codex-home-paths.ts
+++ b/src/main/codex/codex-home-paths.ts
@@ -3,7 +3,6 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readlinkSync,
   rmdirSync,
   rmSync,
@@ -14,8 +13,11 @@ import {
 } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { nodeSourceAndCopyContentsEqualSync } from '../../shared/node-source-copy-content-equality'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 
 const CODEX_GLOBAL_INSTRUCTIONS_ENTRY = 'AGENTS.md'
+const CODEX_RESOURCE_COPY_MARKER_MAX_BYTES = 64 * 1024
 
 const CODEX_SYSTEM_RESOURCE_ENTRIES = [
   'skills',
@@ -124,7 +126,7 @@ function linkSystemCodexResource(
     // rewriting an unchanged file across the UNC boundary on every launch.
     if (
       entryName === CODEX_GLOBAL_INSTRUCTIONS_ENTRY &&
-      copiedFileContentsMatch(sourcePath, targetPath)
+      nodeSourceAndCopyContentsEqualSync(sourcePath, targetPath)
     ) {
       return
     }
@@ -213,19 +215,6 @@ function pathEntryExists(entryPath: string): boolean {
   }
 }
 
-function copiedFileContentsMatch(sourcePath: string, targetPath: string): boolean {
-  try {
-    // Why: reading a FIFO or device synchronously can block Codex launch.
-    // Follow source symlinks, but only compare two regular files.
-    if (!statSync(sourcePath).isFile() || !lstatSync(targetPath).isFile()) {
-      return false
-    }
-    return readFileSync(sourcePath).equals(readFileSync(targetPath))
-  } catch {
-    return false
-  }
-}
-
 function targetAlreadyPointsToSource(targetPath: string, sourcePath: string): boolean {
   try {
     return (
@@ -264,7 +253,10 @@ function markCopiedResource(managedHomePath: string, entryName: string, sourcePa
 function readCopiedResourceSourcePath(managedHomePath: string, entryName: string): string | null {
   try {
     const parsed: unknown = JSON.parse(
-      readFileSync(getResourceCopyMarkerPath(managedHomePath, entryName), 'utf-8')
+      readNodeFileSyncWithinLimit(
+        getResourceCopyMarkerPath(managedHomePath, entryName),
+        CODEX_RESOURCE_COPY_MARKER_MAX_BYTES
+      ).buffer.toString('utf8')
     )
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return null

--- a/src/main/codex/codex-hook-trust-grant.ts
+++ b/src/main/codex/codex-hook-trust-grant.ts
@@ -15,6 +15,7 @@ import {
   codexAppServerCapabilityCache,
   getCodexAppServerHostKey
 } from './codex-app-server-capability-cache'
+import { CodexHostRetryDeadlines } from './codex-host-retry-deadlines'
 import {
   writeCodexTrustGrantLedgerHome,
   type CodexTrustGrantBinaryStamp,
@@ -72,7 +73,7 @@ const diagnostics = {
   lastFallbackReason: null as CodexTrustGrantFallbackReason | null
 }
 export type CodexTrustGrantDiagnostics = typeof diagnostics
-const transientRetryAfterByHost = new Map<string, number>()
+const transientRetryAfterByHost = new CodexHostRetryDeadlines()
 
 export function getCodexTrustGrantDiagnostics(): CodexTrustGrantDiagnostics {
   return { ...diagnostics }

--- a/src/main/codex/codex-host-retry-deadlines.test.ts
+++ b/src/main/codex/codex-host-retry-deadlines.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS,
+  type CodexAppServerHostKey
+} from './codex-app-server-capability-cache'
+import { CodexHostRetryDeadlines } from './codex-host-retry-deadlines'
+
+function host(index: number): CodexAppServerHostKey {
+  return `wsl:distro-${index}`
+}
+
+describe('CodexHostRetryDeadlines', () => {
+  it('preserves every deadline through the exact host limit', () => {
+    const deadlines = new CodexHostRetryDeadlines()
+    for (let index = 0; index < MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS; index += 1) {
+      deadlines.set(host(index), index + 1)
+    }
+
+    expect(deadlines.sizeForTest()).toBe(MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS)
+    for (let index = 0; index < MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS; index += 1) {
+      expect(deadlines.get(host(index))).toBe(index + 1)
+    }
+  })
+
+  it('evicts the least recently used host above the limit', () => {
+    const deadlines = new CodexHostRetryDeadlines()
+    for (let index = 0; index < MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS; index += 1) {
+      deadlines.set(host(index), index + 1)
+    }
+    expect(deadlines.get(host(0))).toBe(1)
+
+    deadlines.set(host(MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS), 999)
+
+    expect(deadlines.sizeForTest()).toBe(MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS)
+    expect(deadlines.get(host(0))).toBe(1)
+    expect(deadlines.get(host(1))).toBeUndefined()
+    expect(deadlines.get(host(MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS))).toBe(999)
+  })
+})

--- a/src/main/codex/codex-host-retry-deadlines.ts
+++ b/src/main/codex/codex-host-retry-deadlines.ts
@@ -1,0 +1,41 @@
+import {
+  MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS,
+  type CodexAppServerHostKey
+} from './codex-app-server-capability-cache'
+
+export class CodexHostRetryDeadlines {
+  private readonly deadlineByHost = new Map<CodexAppServerHostKey, number>()
+
+  get(hostKey: CodexAppServerHostKey): number | undefined {
+    const deadline = this.deadlineByHost.get(hostKey)
+    if (deadline !== undefined) {
+      this.deadlineByHost.delete(hostKey)
+      this.deadlineByHost.set(hostKey, deadline)
+    }
+    return deadline
+  }
+
+  set(hostKey: CodexAppServerHostKey, deadline: number): void {
+    this.deadlineByHost.delete(hostKey)
+    this.deadlineByHost.set(hostKey, deadline)
+    while (this.deadlineByHost.size > MAX_CODEX_APP_SERVER_CAPABILITY_HOSTS) {
+      const oldestHost = this.deadlineByHost.keys().next().value
+      if (oldestHost === undefined) {
+        return
+      }
+      this.deadlineByHost.delete(oldestHost)
+    }
+  }
+
+  delete(hostKey: CodexAppServerHostKey): void {
+    this.deadlineByHost.delete(hostKey)
+  }
+
+  clear(): void {
+    this.deadlineByHost.clear()
+  }
+
+  sizeForTest(): number {
+    return this.deadlineByHost.size
+  }
+}

--- a/src/main/codex/codex-real-home-hook-install.ts
+++ b/src/main/codex/codex-real-home-hook-install.ts
@@ -1,10 +1,11 @@
-import { existsSync, mkdirSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { existsSync, mkdirSync, statSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
   MANAGED_HOOK_TIMEOUT_SECONDS,
+  readHooksJsonRawForGenerationCheck,
   readHooksJsonWithRaw,
   removeManagedCommands,
   writeHooksJson,
@@ -74,7 +75,9 @@ function assertHooksJsonGeneration(
   hooksWritePath: string,
   expectedRaw: string | null
 ): void {
-  const currentRaw = existsSync(hooksJsonPath) ? readFileSync(hooksJsonPath, 'utf-8') : null
+  const currentRaw = existsSync(hooksJsonPath)
+    ? readHooksJsonRawForGenerationCheck(hooksJsonPath)
+    : null
   if (currentRaw !== expectedRaw || resolveHooksJsonWritePath(hooksJsonPath) !== hooksWritePath) {
     // Why: the pre-mutation RPC can overlap a user's editor save. Abort rather
     // than atomically replacing a newer file with the stale parsed snapshot.

--- a/src/main/codex/codex-session-backfill-marker.ts
+++ b/src/main/codex/codex-session-backfill-marker.ts
@@ -1,5 +1,6 @@
-import { mkdirSync, readFileSync, rmSync } from 'node:fs'
+import { mkdirSync, rmSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { readAgentStateJsonFileSync } from '../agent-state-file-reader'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import type { CodexSessionBackfillSummary } from './codex-session-backfill-types'
 
@@ -12,7 +13,7 @@ export function hasCompletedCodexSessionBackfillMarker(
   systemSessionsRoot: string
 ): boolean {
   try {
-    const parsed: unknown = JSON.parse(readFileSync(markerPath, 'utf-8'))
+    const parsed = readAgentStateJsonFileSync(markerPath)
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return false
     }

--- a/src/main/codex/codex-session-bridge.ts
+++ b/src/main/codex/codex-session-bridge.ts
@@ -3,13 +3,13 @@ import {
   linkSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   readlinkSync,
   renameSync,
   rmSync,
   symlinkSync
 } from 'node:fs'
 import { dirname, isAbsolute, join, relative, sep } from 'node:path'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
 import {
   listCodexSessionJsonlFiles,
@@ -334,7 +334,7 @@ function getLegacySessionCopyMarkerPath(relativePath: string): string {
 function readLegacyCopiedSessionMarker(relativePath: string): LegacyCopiedSessionMarker | null {
   try {
     const parsed: unknown = JSON.parse(
-      readFileSync(getLegacySessionCopyMarkerPath(relativePath), 'utf-8')
+      readAgentStateFileSync(getLegacySessionCopyMarkerPath(relativePath))
     )
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return null

--- a/src/main/codex/codex-session-file-listing.test.ts
+++ b/src/main/codex/codex-session-file-listing.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  CodexSessionListingCapacityError,
+  listCodexSessionJsonlFilesIncrementally,
+  listCodexSessionJsonlFilesWithinLimits
+} from './codex-session-file-listing'
+
+const tempRoots: string[] = []
+
+async function makeRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-codex-session-listing-'))
+  tempRoots.push(root)
+  return root
+}
+
+async function collect(files: AsyncIterable<string>): Promise<string[]> {
+  const collected: string[] = []
+  for await (const file of files) {
+    collected.push(file)
+  }
+  return collected
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('Codex session file-listing limits', () => {
+  it('preserves sorted JSONL discovery below every limit', async () => {
+    const root = await makeRoot()
+    await mkdir(join(root, '2026', '01', '02'), { recursive: true })
+    const later = join(root, '2026', '01', '02', 'z.jsonl')
+    const earlier = join(root, '2026', '01', '02', 'a.jsonl')
+    await writeFile(later, '{}')
+    await writeFile(earlier, '{}')
+    await writeFile(join(root, '2026', '01', '02', 'ignored.txt'), 'x')
+
+    expect(listCodexSessionJsonlFilesWithinLimits(root)).toEqual([earlier, later])
+  })
+
+  it('accepts exact entry and file limits, then rejects the next file', async () => {
+    const root = await makeRoot()
+    await writeFile(join(root, 'a.jsonl'), '{}')
+    await writeFile(join(root, 'b.jsonl'), '{}')
+
+    expect(
+      listCodexSessionJsonlFilesWithinLimits(root, { maxEntries: 2, maxFiles: 2 })
+    ).toHaveLength(2)
+    await writeFile(join(root, 'c.jsonl'), '{}')
+    expect(() =>
+      listCodexSessionJsonlFilesWithinLimits(root, { maxEntries: 3, maxFiles: 2 })
+    ).toThrow('Codex session listing exceeded 2 files')
+  })
+
+  it('bounds a zero-file directory tree by entries and depth', async () => {
+    const root = await makeRoot()
+    await mkdir(join(root, 'a', 'b'), { recursive: true })
+
+    expect(listCodexSessionJsonlFilesWithinLimits(root, { maxEntries: 2, maxDepth: 2 })).toEqual([])
+    expect(() =>
+      listCodexSessionJsonlFilesWithinLimits(root, { maxEntries: 1, maxDepth: 2 })
+    ).toThrow('Codex session listing exceeded 1 entries')
+    expect(() =>
+      listCodexSessionJsonlFilesWithinLimits(root, { maxEntries: 2, maxDepth: 1 })
+    ).toThrow('Codex session listing exceeded 1 depth')
+  })
+
+  it('accepts the exact aggregate path limit and rejects one code unit less', async () => {
+    const root = await makeRoot()
+    const filePath = join(root, 'a.jsonl')
+    await writeFile(filePath, '{}')
+    const exactPathCodeUnits = root.length + filePath.length
+
+    expect(
+      listCodexSessionJsonlFilesWithinLimits(root, {
+        maxPathCodeUnits: exactPathCodeUnits
+      })
+    ).toEqual([filePath])
+    expect(() =>
+      listCodexSessionJsonlFilesWithinLimits(root, {
+        maxPathCodeUnits: exactPathCodeUnits - 1
+      })
+    ).toThrow(`Codex session listing exceeded ${exactPathCodeUnits - 1} path code units`)
+  })
+
+  it('stops an incremental scan at capacity and reports it as a failed directory', async () => {
+    const root = await makeRoot()
+    await writeFile(join(root, 'a.jsonl'), '{}')
+    await writeFile(join(root, 'b.jsonl'), '{}')
+    const onDirectoryError = vi.fn()
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const files = await collect(
+      listCodexSessionJsonlFilesIncrementally(
+        root,
+        { batchSize: 1, limits: { maxFiles: 1 }, yieldMs: 0 },
+        onDirectoryError
+      )
+    )
+
+    expect(files).toHaveLength(1)
+    expect(onDirectoryError).toHaveBeenCalledWith(
+      root,
+      expect.any(CodexSessionListingCapacityError)
+    )
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/codex/codex-session-file-listing.ts
+++ b/src/main/codex/codex-session-file-listing.ts
@@ -1,10 +1,25 @@
-import { readdirSync } from 'node:fs'
+import { opendirSync } from 'node:fs'
 import { opendir } from 'node:fs/promises'
 import { join } from 'node:path'
+import {
+  CodexSessionListingBudget,
+  CodexSessionListingCapacityError,
+  type CodexSessionListingLimits
+} from './codex-session-listing-budget'
+
+export {
+  CODEX_SESSION_LISTING_MAX_DEPTH,
+  CODEX_SESSION_LISTING_MAX_ENTRIES,
+  CODEX_SESSION_LISTING_MAX_FILES,
+  CODEX_SESSION_LISTING_MAX_PATH_CODE_UNITS,
+  CodexSessionListingCapacityError
+} from './codex-session-listing-budget'
 
 export type CodexSessionBridgeIncrementalOptions = {
   /** Directory entries to process before yielding back to the event loop. */
   batchSize?: number
+  /** Optional lower limits for tests or constrained callers. */
+  limits?: Partial<CodexSessionListingLimits>
   /** Delay after each processed batch; zero still yields on a timer turn. */
   yieldMs?: number
 }
@@ -19,32 +34,59 @@ const INCREMENTAL_BRIDGE_YIELD_MS = 10
  * that run outside the CLI launch path.
  */
 export function listCodexSessionJsonlFiles(rootPath: string): string[] {
+  return listCodexSessionJsonlFilesWithinLimits(rootPath)
+}
+
+export function listCodexSessionJsonlFilesWithinLimits(
+  rootPath: string,
+  limits: Partial<CodexSessionListingLimits> = {}
+): string[] {
+  const budget = new CodexSessionListingBudget(limits)
+  budget.claimDepth(0)
+  budget.claimPath(rootPath)
   const files: string[] = []
-  try {
-    for (const entry of readdirSync(rootPath, { withFileTypes: true })) {
-      const childPath = join(rootPath, entry.name)
-      if (entry.isDirectory()) {
-        appendSessionFilePaths(files, listCodexSessionJsonlFiles(childPath))
-        continue
-      }
-      if (entry.isFile() && entry.name.endsWith('.jsonl')) {
-        files.push(childPath)
-      }
+  const pendingDirectories = [{ depth: 0, path: rootPath }]
+
+  while (pendingDirectories.length > 0) {
+    const current = pendingDirectories.pop()!
+    let directory: ReturnType<typeof opendirSync>
+    try {
+      directory = opendirSync(current.path)
+    } catch (error) {
+      warnAboutCodexSessionListingError(error)
+      continue
     }
-  } catch (error) {
-    console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
+    try {
+      for (let entry = directory.readSync(); entry !== null; entry = directory.readSync()) {
+        budget.claimEntry()
+        const childPath = join(current.path, entry.name)
+        budget.claimPath(childPath)
+        if (entry.isDirectory()) {
+          const depth = current.depth + 1
+          budget.claimDepth(depth)
+          pendingDirectories.push({ depth, path: childPath })
+        } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+          budget.claimFile()
+          files.push(childPath)
+        }
+      }
+    } catch (error) {
+      if (error instanceof CodexSessionListingCapacityError) {
+        throw error
+      }
+      warnAboutCodexSessionListingError(error)
+    } finally {
+      closeCodexSessionDirectory(directory)
+    }
   }
   return files.sort()
 }
 
-/**
- * Appends session paths without spreading large arrays into a single call.
- */
-function appendSessionFilePaths(target: string[], source: readonly string[]): void {
-  // Why: existing Codex homes can accumulate enough nested sessions to exceed
-  // V8's argument limit if child arrays are spread into push().
-  for (const filePath of source) {
-    target.push(filePath)
+function closeCodexSessionDirectory(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch {
+    // The OS may have already closed a failed directory stream.
   }
 }
 
@@ -89,21 +131,26 @@ async function* listCodexSessionFilesIncrementally(
 ): AsyncGenerator<string> {
   const batchSize = Math.max(1, options.batchSize ?? INCREMENTAL_BRIDGE_BATCH_SIZE)
   const yieldMs = Math.max(0, options.yieldMs ?? INCREMENTAL_BRIDGE_YIELD_MS)
-  const pendingDirectories = [rootPath]
+  const budget = new CodexSessionListingBudget(options.limits)
+  budget.claimDepth(0)
+  budget.claimPath(rootPath)
+  const pendingDirectories = [{ depth: 0, path: rootPath }]
   let entriesSinceYield = 0
 
   while (pendingDirectories.length > 0) {
-    const currentDirectory = pendingDirectories.pop()
-    if (!currentDirectory) {
-      continue
-    }
+    const currentDirectory = pendingDirectories.pop()!
     try {
-      const directory = await opendir(currentDirectory)
+      const directory = await opendir(currentDirectory.path)
       for await (const entry of directory) {
-        const childPath = join(currentDirectory, entry.name)
+        budget.claimEntry()
+        const childPath = join(currentDirectory.path, entry.name)
+        budget.claimPath(childPath)
         if (entry.isDirectory()) {
-          pendingDirectories.push(childPath)
+          const depth = currentDirectory.depth + 1
+          budget.claimDepth(depth)
+          pendingDirectories.push({ depth, path: childPath })
         } else if (entry.isFile() && isSessionFile(entry.name)) {
+          budget.claimFile()
           yield childPath
         }
         entriesSinceYield += 1
@@ -113,10 +160,17 @@ async function* listCodexSessionFilesIncrementally(
         }
       }
     } catch (error) {
-      await onDirectoryError?.(currentDirectory, error)
-      console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
+      await onDirectoryError?.(currentDirectory.path, error)
+      warnAboutCodexSessionListingError(error)
+      if (error instanceof CodexSessionListingCapacityError) {
+        return
+      }
     }
   }
+}
+
+function warnAboutCodexSessionListingError(error: unknown): void {
+  console.warn('[codex-session-bridge] Failed to list system Codex sessions:', error)
 }
 
 /**

--- a/src/main/codex/codex-session-index-heal-jsonl.test.ts
+++ b/src/main/codex/codex-session-index-heal-jsonl.test.ts
@@ -1,0 +1,45 @@
+import { appendFileSync, mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_CODEX_SESSION_INDEX_HEAL_JSONL_LINE_BYTES,
+  readCodexSessionIndexHealJsonlRecords
+} from './codex-session-index-heal-jsonl'
+
+describe('Codex session index heal JSONL reader', () => {
+  const roots: string[] = []
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  function makePath(): string {
+    const root = mkdtempSync(join(tmpdir(), 'orca-heal-jsonl-'))
+    roots.push(root)
+    return join(root, 'ledger.jsonl')
+  }
+
+  it('accepts a valid record exactly at the per-line byte limit', () => {
+    const path = makePath()
+    const prefix = '{"padding":"'
+    const suffix = '"}'
+    const padding = 'x'.repeat(
+      MAX_CODEX_SESSION_INDEX_HEAL_JSONL_LINE_BYTES - prefix.length - suffix.length
+    )
+    writeFileSync(path, `${prefix}${padding}${suffix}\n`)
+
+    expect([...readCodexSessionIndexHealJsonlRecords(path)]).toEqual([{ padding }])
+  })
+
+  it('skips an oversized sparse line and resumes at the next record', () => {
+    const path = makePath()
+    writeFileSync(path, '{"ignored":"')
+    truncateSync(path, MAX_CODEX_SESSION_INDEX_HEAL_JSONL_LINE_BYTES + 8 * 1024 * 1024)
+    appendFileSync(path, '\n{"kept":true}\n')
+
+    expect([...readCodexSessionIndexHealJsonlRecords(path)]).toEqual([{ kept: true }])
+  })
+})

--- a/src/main/codex/codex-session-index-heal-jsonl.ts
+++ b/src/main/codex/codex-session-index-heal-jsonl.ts
@@ -1,0 +1,102 @@
+import { closeSync, openSync, readSync } from 'node:fs'
+
+export const MAX_CODEX_SESSION_INDEX_HEAL_JSONL_LINE_BYTES = 1024 * 1024
+const HEAL_JSONL_READ_CHUNK_BYTES = 64 * 1024
+
+function isNotFoundError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+}
+
+function parseJsonlRecord(raw: string): Record<string, unknown> | null {
+  if (!raw.trim()) {
+    return null
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function* readCodexSessionIndexHealJsonlRecords(
+  filePath: string
+): Generator<Record<string, unknown>> {
+  let descriptor: number
+  try {
+    descriptor = openSync(filePath, 'r')
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return
+    }
+    throw error
+  }
+
+  const readBuffer = Buffer.allocUnsafe(HEAL_JSONL_READ_CHUNK_BYTES)
+  let lineParts: Buffer[] = []
+  let lineBytes = 0
+  let skippingOversizedLine = false
+
+  const resetLine = (): void => {
+    lineParts = []
+    lineBytes = 0
+    skippingOversizedLine = false
+  }
+  const appendSegment = (start: number, end: number): void => {
+    if (skippingOversizedLine || start === end) {
+      return
+    }
+    const nextBytes = lineBytes + end - start
+    if (nextBytes > MAX_CODEX_SESSION_INDEX_HEAL_JSONL_LINE_BYTES) {
+      // Why: a corrupt line may span an arbitrarily large sparse file; discard until its newline.
+      lineParts = []
+      lineBytes = 0
+      skippingOversizedLine = true
+      return
+    }
+    lineParts.push(Buffer.from(readBuffer.subarray(start, end)))
+    lineBytes = nextBytes
+  }
+  const takeRecord = (): Record<string, unknown> | null => {
+    const raw =
+      lineParts.length === 1
+        ? lineParts[0].toString('utf8')
+        : Buffer.concat(lineParts, lineBytes).toString('utf8')
+    return parseJsonlRecord(raw)
+  }
+
+  try {
+    while (true) {
+      const bytesRead = readSync(descriptor, readBuffer, 0, readBuffer.length, null)
+      if (bytesRead === 0) {
+        break
+      }
+      let start = 0
+      for (let index = 0; index < bytesRead; index += 1) {
+        if (readBuffer[index] !== 0x0a) {
+          continue
+        }
+        appendSegment(start, index)
+        if (!skippingOversizedLine) {
+          const record = takeRecord()
+          if (record) {
+            yield record
+          }
+        }
+        resetLine()
+        start = index + 1
+      }
+      appendSegment(start, bytesRead)
+    }
+    if (!skippingOversizedLine && lineBytes > 0) {
+      const record = takeRecord()
+      if (record) {
+        yield record
+      }
+    }
+  } finally {
+    closeSync(descriptor)
+  }
+}

--- a/src/main/codex/codex-session-index-heal-state-memory.test.ts
+++ b/src/main/codex/codex-session-index-heal-state-memory.test.ts
@@ -1,0 +1,81 @@
+import {
+  closeSync,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+  writeSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  CODEX_SESSION_INDEX_HEAL_VERSION,
+  CodexSessionIndexHealCapacityError,
+  collectPendingHealThreads,
+  isHealMarkerCurrent,
+  MAX_CODEX_SESSION_INDEX_HEAL_MARKER_FILE_BYTES,
+  MAX_CODEX_SESSION_INDEX_HEAL_TRACKED_THREADS,
+  type CodexSessionIndexHealPaths
+} from './codex-session-index-heal-state'
+
+describe('Codex session index heal state memory bounds', () => {
+  const roots: string[] = []
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  function makePaths(): CodexSessionIndexHealPaths {
+    const root = mkdtempSync(join(tmpdir(), 'orca-heal-state-memory-'))
+    roots.push(root)
+    return {
+      auditLogPath: join(root, 'audit.jsonl'),
+      systemSessionsRoot: '/sessions',
+      healLedgerPath: join(root, 'heal.jsonl'),
+      healMarkerPath: join(root, 'marker.json')
+    }
+  }
+
+  it('fails closed when processed state exceeds the retained-thread ceiling', () => {
+    const paths = makePaths()
+    const descriptor = openSync(paths.healLedgerPath, 'w')
+    try {
+      for (let start = 0; start <= MAX_CODEX_SESSION_INDEX_HEAL_TRACKED_THREADS; start += 1000) {
+        const count = Math.min(1000, MAX_CODEX_SESSION_INDEX_HEAL_TRACKED_THREADS + 1 - start)
+        const lines = Array.from({ length: count }, (_, offset) => {
+          const suffix = (start + offset).toString(16).padStart(12, '0')
+          return JSON.stringify({
+            v: CODEX_SESSION_INDEX_HEAL_VERSION,
+            systemSessionsRoot: paths.systemSessionsRoot,
+            threadId: `00000000-0000-0000-0000-${suffix}`,
+            outcome: 'healed'
+          })
+        })
+        writeSync(descriptor, `${lines.join('\n')}\n`)
+      }
+    } finally {
+      closeSync(descriptor)
+    }
+
+    expect(() => collectPendingHealThreads(paths)).toThrow(CodexSessionIndexHealCapacityError)
+  })
+
+  it('rejects an oversized sparse completion marker', () => {
+    const paths = makePaths()
+    writeFileSync(
+      paths.healMarkerPath,
+      JSON.stringify({
+        version: CODEX_SESSION_INDEX_HEAL_VERSION,
+        systemSessionsRoot: paths.systemSessionsRoot,
+        auditBytes: 0
+      })
+    )
+    truncateSync(paths.healMarkerPath, MAX_CODEX_SESSION_INDEX_HEAL_MARKER_FILE_BYTES + 1)
+
+    expect(isHealMarkerCurrent(paths, 0)).toBe(false)
+  })
+})

--- a/src/main/codex/codex-session-index-heal-state.ts
+++ b/src/main/codex/codex-session-index-heal-state.ts
@@ -1,10 +1,17 @@
-import { appendFileSync, mkdirSync, readFileSync, statSync } from 'node:fs'
+import { appendFileSync, mkdirSync, statSync } from 'node:fs'
 import { dirname } from 'node:path'
 import {
   isPathInsideOrEqual,
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import {
+  MAX_CODEX_SESSION_INDEX_HEAL_JSONL_LINE_BYTES,
+  readCodexSessionIndexHealJsonlRecords
+} from './codex-session-index-heal-jsonl'
+
+export { MAX_CODEX_SESSION_INDEX_HEAL_JSONL_LINE_BYTES }
 
 // State files for the session index heal: which backfilled rollouts exist
 // (the backfill audit ledger), which thread ids this pass already processed
@@ -14,6 +21,22 @@ import { writeFileAtomically } from '../codex-accounts/fs-utils'
 // Bump to re-drive the heal for every host after a semantics change; already
 // processed thread ids are re-read because ledger lines are version-scoped.
 export const CODEX_SESSION_INDEX_HEAL_VERSION = 3
+export const MAX_CODEX_SESSION_INDEX_HEAL_TRACKED_THREADS = 100_000
+export const MAX_CODEX_SESSION_INDEX_HEAL_MARKER_FILE_BYTES = 64 * 1024
+
+const MAX_AUDIT_TARGET_LENGTH = 64 * 1024
+const MAX_AUDIT_RECORD_ID_LENGTH = 128
+const MAX_ROLLOUT_STAMP_LENGTH = 512
+const CODEX_THREAD_ID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export class CodexSessionIndexHealCapacityError extends Error {
+  constructor(kind: 'pending' | 'processed') {
+    super(
+      `Codex session index heal ${kind} state exceeds ${MAX_CODEX_SESSION_INDEX_HEAL_TRACKED_THREADS} entries`
+    )
+    this.name = 'CodexSessionIndexHealCapacityError'
+  }
+}
 
 // Why: an unsupported CLI stays unsupported until upgraded; re-probing once a
 // day is enough to notice an upgrade without a per-startup spawn.
@@ -53,11 +76,11 @@ export type HealMarkerSummary = {
 export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): PendingHealThread[] {
   const processed = readProcessedHealThreads(paths)
   const pendingByThreadId = new Map<string, PendingHealThread>()
-  for (const line of readJsonlLines(paths.auditLogPath, true)) {
+  for (const line of readCodexSessionIndexHealJsonlRecords(paths.auditLogPath)) {
     if (line.action !== 'hardlink' && line.action !== 'copy' && line.action !== 'existing') {
       continue
     }
-    if (typeof line.target !== 'string') {
+    if (typeof line.target !== 'string' || line.target.length > MAX_AUDIT_TARGET_LENGTH) {
       continue
     }
     // Why: the append-only audit can contain runs for several custom Codex
@@ -66,10 +89,13 @@ export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): Pe
       continue
     }
     const match = CODEX_ROLLOUT_THREAD_ID_PATTERN.exec(lastPathSegment(line.target))
-    if (!match) {
+    if (!match || match[1].length > MAX_ROLLOUT_STAMP_LENGTH) {
       continue
     }
     const threadId = match[2].toLowerCase()
+    if (typeof line.recordId === 'string' && line.recordId.length > MAX_AUDIT_RECORD_ID_LENGTH) {
+      continue
+    }
     const auditRecordId = typeof line.recordId === 'string' ? line.recordId : null
     if (
       processed.healedThreadIds.has(threadId) ||
@@ -81,6 +107,12 @@ export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): Pe
       // processed event must displace an older pending event from this scan.
       pendingByThreadId.delete(threadId)
       continue
+    }
+    if (
+      !pendingByThreadId.has(threadId) &&
+      pendingByThreadId.size >= MAX_CODEX_SESSION_INDEX_HEAL_TRACKED_THREADS
+    ) {
+      throw new CodexSessionIndexHealCapacityError('pending')
     }
     pendingByThreadId.set(threadId, { threadId, rolloutStamp: match[1], auditRecordId })
   }
@@ -102,22 +134,48 @@ function readProcessedHealThreads(paths: CodexSessionIndexHealPaths): {
   const missingAuditRecords = new Set<string>()
   const legacyMissingThreadIds = new Set<string>()
   const expectedRoot = normalizeRuntimePathForComparison(paths.systemSessionsRoot)
-  for (const line of readJsonlLines(paths.healLedgerPath)) {
-    if (
-      line.v === CODEX_SESSION_INDEX_HEAL_VERSION &&
-      typeof line.threadId === 'string' &&
-      typeof line.systemSessionsRoot === 'string' &&
-      (line.outcome === 'healed' || line.outcome === 'missing') &&
-      normalizeRuntimePathForComparison(line.systemSessionsRoot) === expectedRoot
-    ) {
-      const threadId = line.threadId.toLowerCase()
-      if (line.outcome === 'healed') {
-        healedThreadIds.add(threadId)
-      } else if (typeof line.auditRecordId === 'string') {
-        missingAuditRecords.add(`${threadId}\0${line.auditRecordId}`)
-      } else {
-        legacyMissingThreadIds.add(threadId)
+  let trackedEntries = 0
+  const addTrackedEntry = (entries: Set<string>, key: string): void => {
+    if (entries.has(key)) {
+      return
+    }
+    if (trackedEntries >= MAX_CODEX_SESSION_INDEX_HEAL_TRACKED_THREADS) {
+      throw new CodexSessionIndexHealCapacityError('processed')
+    }
+    entries.add(key)
+    trackedEntries += 1
+  }
+  try {
+    for (const line of readCodexSessionIndexHealJsonlRecords(paths.healLedgerPath)) {
+      if (
+        line.v === CODEX_SESSION_INDEX_HEAL_VERSION &&
+        typeof line.threadId === 'string' &&
+        CODEX_THREAD_ID_PATTERN.test(line.threadId) &&
+        typeof line.systemSessionsRoot === 'string' &&
+        (line.outcome === 'healed' || line.outcome === 'missing') &&
+        normalizeRuntimePathForComparison(line.systemSessionsRoot) === expectedRoot
+      ) {
+        const threadId = line.threadId.toLowerCase()
+        if (line.outcome === 'healed') {
+          addTrackedEntry(healedThreadIds, threadId)
+        } else if (
+          typeof line.auditRecordId === 'string' &&
+          line.auditRecordId.length <= MAX_AUDIT_RECORD_ID_LENGTH
+        ) {
+          addTrackedEntry(missingAuditRecords, `${threadId}\0${line.auditRecordId}`)
+        } else if (line.auditRecordId === undefined) {
+          addTrackedEntry(legacyMissingThreadIds, threadId)
+        }
       }
+    }
+  } catch (error) {
+    if (error instanceof CodexSessionIndexHealCapacityError) {
+      throw error
+    }
+    return {
+      healedThreadIds: new Set(),
+      missingAuditRecords: new Set(),
+      legacyMissingThreadIds: new Set()
     }
   }
   return { healedThreadIds, missingAuditRecords, legacyMissingThreadIds }
@@ -153,35 +211,6 @@ export function appendHealLedgerRecord(
   }
 }
 
-function readJsonlLines(filePath: string, throwOnReadFailure = false): Record<string, unknown>[] {
-  let contents: string
-  try {
-    contents = readFileSync(filePath, 'utf-8')
-  } catch (error) {
-    if (throwOnReadFailure && !isNotFoundError(error)) {
-      // Why: the audit is the heal work queue. Treating EACCES/EIO as empty
-      // would write a completion marker that permanently skips every session.
-      throw error
-    }
-    return []
-  }
-  const lines: Record<string, unknown>[] = []
-  for (const raw of contents.split('\n')) {
-    if (!raw.trim()) {
-      continue
-    }
-    try {
-      const parsed: unknown = JSON.parse(raw)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        lines.push(parsed as Record<string, unknown>)
-      }
-    } catch {
-      // Skip torn/corrupt lines; both ledgers are append-only diagnostics.
-    }
-  }
-  return lines
-}
-
 export function readAuditLogSize(auditLogPath: string): number {
   try {
     return statSync(auditLogPath).size
@@ -202,7 +231,12 @@ export function isHealMarkerCurrent(
   auditBytes: number
 ): boolean {
   try {
-    const parsed: unknown = JSON.parse(readFileSync(paths.healMarkerPath, 'utf-8'))
+    const parsed: unknown = JSON.parse(
+      readNodeFileSyncWithinLimit(
+        paths.healMarkerPath,
+        MAX_CODEX_SESSION_INDEX_HEAL_MARKER_FILE_BYTES
+      ).buffer.toString('utf8')
+    )
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return false
     }

--- a/src/main/codex/codex-session-listing-budget.ts
+++ b/src/main/codex/codex-session-listing-budget.ts
@@ -1,0 +1,81 @@
+export const CODEX_SESSION_LISTING_MAX_DEPTH = 32
+export const CODEX_SESSION_LISTING_MAX_ENTRIES = 200_000
+export const CODEX_SESSION_LISTING_MAX_FILES = 100_000
+export const CODEX_SESSION_LISTING_MAX_PATH_CODE_UNITS = 32 * 1024 * 1024
+
+export type CodexSessionListingLimits = {
+  maxDepth: number
+  maxEntries: number
+  maxFiles: number
+  maxPathCodeUnits: number
+}
+
+const DEFAULT_LIMITS: CodexSessionListingLimits = {
+  maxDepth: CODEX_SESSION_LISTING_MAX_DEPTH,
+  maxEntries: CODEX_SESSION_LISTING_MAX_ENTRIES,
+  maxFiles: CODEX_SESSION_LISTING_MAX_FILES,
+  maxPathCodeUnits: CODEX_SESSION_LISTING_MAX_PATH_CODE_UNITS
+}
+
+export type CodexSessionListingCapacityResource = 'depth' | 'entries' | 'files' | 'path code units'
+
+export class CodexSessionListingCapacityError extends Error {
+  constructor(
+    readonly resource: CodexSessionListingCapacityResource,
+    readonly observed: number,
+    readonly limit: number
+  ) {
+    super(`Codex session listing exceeded ${limit} ${resource}`)
+    this.name = 'CodexSessionListingCapacityError'
+  }
+}
+
+export class CodexSessionListingBudget {
+  readonly limits: CodexSessionListingLimits
+  private entries = 0
+  private files = 0
+  private pathCodeUnits = 0
+
+  constructor(limits: Partial<CodexSessionListingLimits> = {}) {
+    this.limits = { ...DEFAULT_LIMITS, ...limits }
+    for (const [name, value] of Object.entries(this.limits)) {
+      if (!Number.isSafeInteger(value) || value < 0) {
+        throw new RangeError(`${name} must be a non-negative safe integer`)
+      }
+    }
+  }
+
+  claimDepth(depth: number): void {
+    if (depth > this.limits.maxDepth) {
+      throw new CodexSessionListingCapacityError('depth', depth, this.limits.maxDepth)
+    }
+  }
+
+  claimEntry(): void {
+    this.entries += 1
+    if (this.entries > this.limits.maxEntries) {
+      throw new CodexSessionListingCapacityError('entries', this.entries, this.limits.maxEntries)
+    }
+  }
+
+  claimFile(): void {
+    this.files += 1
+    if (this.files > this.limits.maxFiles) {
+      throw new CodexSessionListingCapacityError('files', this.files, this.limits.maxFiles)
+    }
+  }
+
+  claimPath(path: string): void {
+    this.pathCodeUnits += path.length
+    if (
+      !Number.isSafeInteger(this.pathCodeUnits) ||
+      this.pathCodeUnits > this.limits.maxPathCodeUnits
+    ) {
+      throw new CodexSessionListingCapacityError(
+        'path code units',
+        this.pathCodeUnits,
+        this.limits.maxPathCodeUnits
+      )
+    }
+  }
+}

--- a/src/main/codex/codex-trust-config-rollback.test.ts
+++ b/src/main/codex/codex-trust-config-rollback.test.ts
@@ -8,10 +8,13 @@ import {
   rmSync,
   statSync,
   symlinkSync,
+  truncateSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import { MAX_AGENT_STATE_FILE_BYTES } from '../agent-state-file-reader'
 import { captureCodexTrustConfig, restoreCodexTrustConfig } from './codex-trust-config-rollback'
 
 const roots: string[] = []
@@ -29,6 +32,15 @@ function tempConfigPath(): string {
 }
 
 describe('Codex trust config rollback', () => {
+  it('rejects a sparse config above 4 MiB without changing it', () => {
+    const configPath = tempConfigPath()
+    writeFileSync(configPath, '')
+    truncateSync(configPath, MAX_AGENT_STATE_FILE_BYTES + 1)
+
+    expect(() => captureCodexTrustConfig(configPath)).toThrow(NodeFileReadTooLargeError)
+    expect(statSync(configPath).size).toBe(MAX_AGENT_STATE_FILE_BYTES + 1)
+  })
+
   it('treats a missing config as absent and tolerates it remaining absent', () => {
     const configPath = tempConfigPath()
     const snapshot = captureCodexTrustConfig(configPath)

--- a/src/main/codex/codex-trust-config-rollback.ts
+++ b/src/main/codex/codex-trust-config-rollback.ts
@@ -1,10 +1,6 @@
 import {
   chmodSync,
-  closeSync,
-  fstatSync,
   lstatSync,
-  openSync,
-  readFileSync,
   readlinkSync,
   realpathSync,
   unlinkSync,
@@ -12,6 +8,8 @@ import {
 } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { dirname, resolve } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { MAX_AGENT_STATE_FILE_BYTES } from '../agent-state-file-reader'
 import { renameFileWithWindowsRetry } from '../codex-accounts/fs-utils'
 
 export type CodexTrustConfigSnapshot =
@@ -43,26 +41,21 @@ function resolveConfigRestorePath(tomlPath: string): string {
 
 export function captureCodexTrustConfig(tomlPath: string): CodexTrustConfigSnapshot {
   const restorePath = resolveConfigRestorePath(tomlPath)
-  let descriptor: number
   try {
-    descriptor = openSync(restorePath, 'r')
+    // Why: contents and mode come from one descriptor, so a path replacement
+    // cannot pair one file's bytes with another file's permissions.
+    const { buffer, stats } = readNodeFileSyncWithinLimit(restorePath, MAX_AGENT_STATE_FILE_BYTES)
+    return {
+      existed: true,
+      contents: buffer,
+      mode: stats.mode,
+      restorePath
+    }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return restorePath === tomlPath ? { existed: false } : { existed: false, restorePath }
     }
     throw error
-  }
-  try {
-    // Why: read and stat the same open file so replacement between two path
-    // lookups cannot pair one file's contents with another file's mode.
-    return {
-      existed: true,
-      contents: readFileSync(descriptor),
-      mode: fstatSync(descriptor).mode,
-      restorePath
-    }
-  } finally {
-    closeSync(descriptor)
   }
 }
 
@@ -82,7 +75,11 @@ export function restoreCodexTrustConfig(
   }
   const { restorePath } = snapshot
   try {
-    if (readFileSync(restorePath).equals(snapshot.contents)) {
+    if (
+      readNodeFileSyncWithinLimit(restorePath, MAX_AGENT_STATE_FILE_BYTES).buffer.equals(
+        snapshot.contents
+      )
+    ) {
       // Why: the RPC may change permissions without changing bytes; rollback
       // restores the complete captured file state, not only its contents.
       chmodSync(restorePath, snapshot.mode)

--- a/src/main/codex/codex-trust-grant-ledger.test.ts
+++ b/src/main/codex/codex-trust-grant-ledger.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -9,6 +9,7 @@ import {
   removeCodexTrustGrantLedgerHome,
   writeCodexTrustGrantLedgerHome
 } from './codex-trust-grant-ledger'
+import { MAX_AGENT_STATE_FILE_BYTES } from '../agent-state-file-reader'
 
 let userDataDir: string
 let previousUserDataPath: string | undefined
@@ -79,6 +80,26 @@ describe('codex trust grant ledger', () => {
     // Why: a corrupt file must not block recording the next verified grant.
     writeCodexTrustGrantLedgerHome(home, { binary: null, entries: {} })
     expect(readCodexTrustGrantLedgerHome(home)).not.toBeNull()
+  })
+
+  it('preserves the prior ledger when a grant exceeds its read ceiling', () => {
+    const home = join(userDataDir, 'codex-runtime-home', 'home')
+    const ledgerPath = getCodexTrustGrantLedgerPath()
+    writeCodexTrustGrantLedgerHome(home, { binary: null, entries: {} })
+    const before = readFileSync(ledgerPath, 'utf8')
+
+    expect(() =>
+      writeCodexTrustGrantLedgerHome(home, {
+        binary: null,
+        entries: {
+          oversized: {
+            signature: 'x'.repeat(MAX_AGENT_STATE_FILE_BYTES),
+            trustedHash: 'sha256:test'
+          }
+        }
+      })
+    ).toThrow('JSON output exceeds')
+    expect(readFileSync(ledgerPath, 'utf8')).toBe(before)
   })
 
   it('matches binary stamps only on identical identity', () => {

--- a/src/main/codex/codex-trust-grant-ledger.ts
+++ b/src/main/codex/codex-trust-grant-ledger.ts
@@ -1,5 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
+import { MAX_AGENT_STATE_FILE_BYTES, readAgentStateJsonFileSync } from '../agent-state-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
 import { getOrcaManagedCodexHomePath } from './codex-home-paths'
 import { normalizeCodexProjectPathForLookup } from './config-toml-trust'
 
@@ -46,7 +48,7 @@ function readLedgerFile(ledgerPath: string): CodexTrustGrantLedgerFile {
     return empty
   }
   try {
-    const parsed: unknown = JSON.parse(readFileSync(ledgerPath, 'utf-8'))
+    const parsed = readAgentStateJsonFileSync(ledgerPath)
     if (
       !parsed ||
       typeof parsed !== 'object' ||
@@ -69,7 +71,8 @@ function readLedgerFile(ledgerPath: string): CodexTrustGrantLedgerFile {
 
 function persistLedgerFile(ledgerPath: string, file: CodexTrustGrantLedgerFile): void {
   mkdirSync(dirname(ledgerPath), { recursive: true, mode: 0o700 })
-  writeFileSync(ledgerPath, `${JSON.stringify(file, null, 2)}\n`, {
+  const { serialized } = stringifyJsonWithinByteLimit(file, MAX_AGENT_STATE_FILE_BYTES - 1, 2)
+  writeFileSync(ledgerPath, `${serialized}\n`, {
     encoding: 'utf-8',
     mode: 0o600
   })

--- a/src/main/codex/codex-user-hook-trust-rebase.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase.ts
@@ -7,6 +7,7 @@ import {
 import { runCodexUserHookTrustRebaseSessionSync } from './codex-app-server-grant-bridge'
 import { isCodexAppServerUnsupportedError } from './codex-app-server-session'
 import { CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS } from './codex-hook-trust-grant'
+import { CodexHostRetryDeadlines } from './codex-host-retry-deadlines'
 import { createCodexHookTrustEntry } from './codex-hook-identity'
 import { resolveCodexTrustGrantHost } from './codex-trust-grant-host'
 import {
@@ -32,7 +33,7 @@ let runSessionSync: RebaseSessionRunnerSync = runCodexUserHookTrustRebaseSession
 // Why: launch prep re-runs the callers on every pane spawn. A host stuck
 // without a usable rebase lane (old CLI, unmatched keys) must not pay a codex
 // session each time — bound retries like the grant lane does.
-const rebaseRetryAfterByHost = new Map<CodexAppServerHostKey, number>()
+const rebaseRetryAfterByHost = new CodexHostRetryDeadlines()
 
 function rememberRebaseSessionFailure(hostKey: CodexAppServerHostKey, error: unknown): void {
   if (isCodexAppServerUnsupportedError(error)) {

--- a/src/main/codex/codex-wsl-hook-install-plan.test.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.test.ts
@@ -6,7 +6,12 @@ vi.mock('node:child_process', () => ({
   execFile: execFileMock
 }))
 
-import { _internals, createCodexWslRuntimeHookInstallPlan } from './codex-wsl-hook-install-plan'
+import {
+  _internals,
+  createCodexWslRuntimeHookInstallPlan,
+  WSL_CANONICAL_PATH_CACHE_MAX_ENTRIES,
+  WSL_CANONICAL_PATH_CACHE_MAX_UTF8_BYTES
+} from './codex-wsl-hook-install-plan'
 
 const originalPlatform = process.platform
 
@@ -125,6 +130,17 @@ describe('canonicalizeWslLinuxPath', () => {
     expect(execFileMock).toHaveBeenCalledTimes(2)
   })
 
+  it('clears in-flight ownership when spawning wsl.exe throws synchronously', () => {
+    setPlatform('win32')
+    execFileMock.mockImplementationOnce(() => {
+      throw new Error('invalid WSL argv')
+    })
+
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+  })
+
   it('keeps the last known-good cache when revalidation later fails', () => {
     setPlatform('win32')
     _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')
@@ -207,5 +223,49 @@ describe('canonicalizeWslLinuxPath', () => {
     callback(null, 'readlink: missing operand\n')
 
     expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/alias')).toBeNull()
+  })
+
+  it('LRU-evicts canonical identities beyond the entry cap', () => {
+    setPlatform('win32')
+    for (let index = 0; index <= WSL_CANONICAL_PATH_CACHE_MAX_ENTRIES; index += 1) {
+      const logicalPath = `/home/runtime-${index}`
+      _internals.canonicalizeWslLinuxPath('Ubuntu', logicalPath)
+      const callback = execFileMock.mock.calls[index][3] as (
+        error: Error | null,
+        stdout: string
+      ) => void
+      callback(null, `/canonical/runtime-${index}\n`)
+    }
+
+    expect(_internals.getWslCanonicalPathCacheSize()).toBe(WSL_CANONICAL_PATH_CACHE_MAX_ENTRIES)
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/runtime-0')).toBeNull()
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/runtime-1')).toBe(
+      '/canonical/runtime-1'
+    )
+  })
+
+  it('does not retain a canonical identity larger than the aggregate byte budget', () => {
+    setPlatform('win32')
+    _internals.canonicalizeWslLinuxPath('Ubuntu', '/home/oversized')
+    const callback = execFileMock.mock.calls[0][3] as (error: Error | null, stdout: string) => void
+    callback(null, `/${'x'.repeat(WSL_CANONICAL_PATH_CACHE_MAX_UTF8_BYTES)}\n`)
+
+    expect(_internals.getWslCanonicalPathCacheSize()).toBe(0)
+    expect(_internals.getWslCanonicalPathCacheBytes()).toBe(0)
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', '/home/oversized')).toBeNull()
+  })
+
+  it('retains a canonical identity at the exact aggregate byte budget', () => {
+    setPlatform('win32')
+    const logicalPath = '/home/exact-limit'
+    const keyBytes = Buffer.byteLength(`Ubuntu\0${logicalPath}`, 'utf8')
+    const canonicalPath = `/${'x'.repeat(WSL_CANONICAL_PATH_CACHE_MAX_UTF8_BYTES - keyBytes - 1)}`
+    _internals.canonicalizeWslLinuxPath('Ubuntu', logicalPath)
+    const callback = execFileMock.mock.calls[0][3] as (error: Error | null, stdout: string) => void
+    callback(null, canonicalPath)
+
+    expect(_internals.getWslCanonicalPathCacheSize()).toBe(1)
+    expect(_internals.getWslCanonicalPathCacheBytes()).toBe(WSL_CANONICAL_PATH_CACHE_MAX_UTF8_BYTES)
+    expect(_internals.canonicalizeWslLinuxPath('Ubuntu', logicalPath)).toBe(canonicalPath)
   })
 })

--- a/src/main/codex/codex-wsl-hook-install-plan.ts
+++ b/src/main/codex/codex-wsl-hook-install-plan.ts
@@ -48,15 +48,79 @@ function toDefaultWslLinuxPath(windowsPath: string): string {
 
 const WSL_CANONICALIZE_TIMEOUT_MS = 5000
 const WSL_PATH_MISSING_OUTPUT = '__ORCA_WSL_PATH_MISSING__'
+export const WSL_CANONICAL_PATH_CACHE_MAX_ENTRIES = 256
+export const WSL_CANONICAL_PATH_CACHE_MAX_UTF8_BYTES = 2 * 1024 * 1024
 
 // Why: `readlink -f` over wsl.exe stalls up to the timeout on a cold or wedged
 // distro. Running it synchronously on the Electron main process froze the UI on
 // every Codex WSL launch, so resolve it off-thread and cache the latest result.
-const canonicalWslPathCache = new Map<string, string>()
+const canonicalWslPathCache = new Map<string, { canonicalPath: string; retainedBytes: number }>()
+let canonicalWslPathCacheBytes = 0
 const inFlightWslCanonicalizations = new Map<string, Set<WslCanonicalPathSettled>>()
 
 function wslCanonicalizeCacheKey(distro: string, linuxPath: string): string {
   return `${distro}\x00${linuxPath}`
+}
+
+function getCachedWslCanonicalPath(key: string): string | null {
+  const cached = canonicalWslPathCache.get(key)
+  if (!cached) {
+    return null
+  }
+  canonicalWslPathCache.delete(key)
+  canonicalWslPathCache.set(key, cached)
+  return cached.canonicalPath
+}
+
+function deleteCachedWslCanonicalPath(key: string): void {
+  const cached = canonicalWslPathCache.get(key)
+  if (!cached) {
+    return
+  }
+  canonicalWslPathCache.delete(key)
+  canonicalWslPathCacheBytes -= cached.retainedBytes
+}
+
+function cacheWslCanonicalPath(key: string, canonicalPath: string): void {
+  deleteCachedWslCanonicalPath(key)
+  const retainedBytes = Buffer.byteLength(key, 'utf8') + Buffer.byteLength(canonicalPath, 'utf8')
+  if (retainedBytes > WSL_CANONICAL_PATH_CACHE_MAX_UTF8_BYTES) {
+    return
+  }
+  while (
+    canonicalWslPathCache.size >= WSL_CANONICAL_PATH_CACHE_MAX_ENTRIES ||
+    canonicalWslPathCacheBytes + retainedBytes > WSL_CANONICAL_PATH_CACHE_MAX_UTF8_BYTES
+  ) {
+    const oldestKey = canonicalWslPathCache.keys().next().value as string | undefined
+    if (oldestKey === undefined) {
+      break
+    }
+    deleteCachedWslCanonicalPath(oldestKey)
+  }
+  canonicalWslPathCache.set(key, { canonicalPath, retainedBytes })
+  canonicalWslPathCacheBytes += retainedBytes
+}
+
+function settleWslCanonicalization(key: string, settlement: WslCanonicalPathSettlement): void {
+  if (settlement.status === 'resolved') {
+    cacheWslCanonicalPath(key, settlement.canonicalPath)
+  } else if (settlement.status === 'missing') {
+    // Why: a successful directory probe is stronger than a transport error;
+    // clear the identity so stale trust can be revoked and later rediscovered.
+    deleteCachedWslCanonicalPath(key)
+  }
+  // Why: keep the last known-good cache on timeout/transient WSL failures.
+  // Dropping it forces the next launch onto the logical `/mnt/...` guess,
+  // which is wrong under custom automount roots and rewrites trust keys.
+  const settledListeners = inFlightWslCanonicalizations.get(key) ?? new Set()
+  inFlightWslCanonicalizations.delete(key)
+  for (const listener of settledListeners) {
+    try {
+      listener(settlement)
+    } catch (listenerError) {
+      console.warn('[codex-wsl-hook-path] failed to reconcile canonical path', listenerError)
+    }
+  }
 }
 
 function scheduleWslLinuxPathCanonicalization(
@@ -102,40 +166,28 @@ function scheduleWslLinuxPathCanonicalization(
         'sh',
         linuxPath
       ]
-  execFile(
-    'wsl.exe',
-    args,
-    { encoding: 'utf-8', timeout: WSL_CANONICALIZE_TIMEOUT_MS, windowsHide: true },
-    (error, stdout) => {
-      const canonicalPath = stdout.trim()
-      const resolvedPath = !error && canonicalPath.startsWith('/') ? canonicalPath : null
-      const pathMissing = !error && canonicalPath === WSL_PATH_MISSING_OUTPUT
-      const settlement: WslCanonicalPathSettlement = resolvedPath
-        ? { status: 'resolved', canonicalPath: resolvedPath }
-        : pathMissing
-          ? { status: 'missing' }
-          : { status: 'unavailable' }
-      if (settlement.status === 'resolved') {
-        canonicalWslPathCache.set(key, canonicalPath)
-      } else if (settlement.status === 'missing') {
-        // Why: a successful directory probe is stronger than a transport error;
-        // clear the identity so stale trust can be revoked and later rediscovered.
-        canonicalWslPathCache.delete(key)
+  try {
+    execFile(
+      'wsl.exe',
+      args,
+      { encoding: 'utf-8', timeout: WSL_CANONICALIZE_TIMEOUT_MS, windowsHide: true },
+      (error, stdout) => {
+        const canonicalPath = stdout.trim()
+        const resolvedPath = !error && canonicalPath.startsWith('/') ? canonicalPath : null
+        const pathMissing = !error && canonicalPath === WSL_PATH_MISSING_OUTPUT
+        settleWslCanonicalization(
+          key,
+          resolvedPath
+            ? { status: 'resolved', canonicalPath: resolvedPath }
+            : pathMissing
+              ? { status: 'missing' }
+              : { status: 'unavailable' }
+        )
       }
-      // Why: keep the last known-good cache on timeout/transient WSL failures.
-      // Dropping it forces the next launch onto the logical `/mnt/...` guess,
-      // which is wrong under custom automount roots and rewrites trust keys.
-      const settledListeners = inFlightWslCanonicalizations.get(key) ?? new Set()
-      inFlightWslCanonicalizations.delete(key)
-      for (const listener of settledListeners) {
-        try {
-          listener(settlement)
-        } catch (listenerError) {
-          console.warn('[codex-wsl-hook-path] failed to reconcile canonical path', listenerError)
-        }
-      }
-    }
-  )
+    )
+  } catch {
+    settleWslCanonicalization(key, { status: 'unavailable' })
+  }
 }
 
 function canonicalizeWslLinuxPath(
@@ -147,7 +199,7 @@ function canonicalizeWslLinuxPath(
   if (process.platform !== 'win32') {
     return linuxPath
   }
-  const cached = canonicalWslPathCache.get(wslCanonicalizeCacheKey(distro, linuxPath))
+  const cached = getCachedWslCanonicalPath(wslCanonicalizeCacheKey(distro, linuxPath))
   // Why: every launch revalidates asynchronously. Returning the cache keeps
   // launch prep synchronous while settlement repairs or revokes trust in-place.
   scheduleWslLinuxPathCanonicalization(distro, linuxPath, windowsPath, onSettled)
@@ -199,6 +251,13 @@ export const _internals = {
   canonicalizeWslLinuxPath,
   resetWslCanonicalPathCache(): void {
     canonicalWslPathCache.clear()
+    canonicalWslPathCacheBytes = 0
     inFlightWslCanonicalizations.clear()
+  },
+  getWslCanonicalPathCacheSize(): number {
+    return canonicalWslPathCache.size
+  },
+  getWslCanonicalPathCacheBytes(): number {
+    return canonicalWslPathCacheBytes
   }
 }

--- a/src/main/codex/codex-wsl-reconciliation-generations.test.ts
+++ b/src/main/codex/codex-wsl-reconciliation-generations.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { CodexWslReconciliationGenerations } from './codex-wsl-reconciliation-generations'
+
+const BOUNDS = {
+  maxEntries: 2,
+  maxKeyBytes: 4,
+  maxTotalKeyBytes: 6
+}
+
+describe('CodexWslReconciliationGenerations', () => {
+  it('invalidates an older reconciliation for the same runtime home', () => {
+    const generations = new CodexWslReconciliationGenerations(BOUNDS)
+    const stale = generations.advance('a')
+    const current = generations.advance('a')
+
+    expect(generations.isCurrent('a', stale)).toBe(false)
+    expect(generations.isCurrent('a', current)).toBe(true)
+  })
+
+  it('bounds retained homes and fails closed for an evicted callback', () => {
+    const generations = new CodexWslReconciliationGenerations(BOUNDS)
+    const evicted = generations.advance('a')
+    generations.advance('bb')
+    generations.advance('ccc')
+
+    expect(generations.isCurrent('a', evicted)).toBe(false)
+    expect(generations.evidence()).toEqual({ entries: 2, keyBytes: 5 })
+  })
+
+  it('does not retain an oversized home key', () => {
+    const generations = new CodexWslReconciliationGenerations(BOUNDS)
+    const generation = generations.advance('oversized')
+
+    expect(generations.isCurrent('oversized', generation)).toBe(false)
+    expect(generations.evidence()).toEqual({ entries: 0, keyBytes: 0 })
+  })
+})

--- a/src/main/codex/codex-wsl-reconciliation-generations.ts
+++ b/src/main/codex/codex-wsl-reconciliation-generations.ts
@@ -1,0 +1,76 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export type CodexWslReconciliationGenerationBounds = {
+  maxEntries: number
+  maxKeyBytes: number
+  maxTotalKeyBytes: number
+}
+
+export const DEFAULT_CODEX_WSL_RECONCILIATION_GENERATION_BOUNDS: CodexWslReconciliationGenerationBounds =
+  {
+    maxEntries: 256,
+    maxKeyBytes: 64 * 1024,
+    maxTotalKeyBytes: 1024 * 1024
+  }
+
+type RetainedGeneration = {
+  generation: number
+  keyBytes: number
+}
+
+export class CodexWslReconciliationGenerations {
+  private readonly generations = new Map<string, RetainedGeneration>()
+  private nextGeneration = 0
+  private retainedKeyBytes = 0
+
+  constructor(
+    private readonly bounds: CodexWslReconciliationGenerationBounds = DEFAULT_CODEX_WSL_RECONCILIATION_GENERATION_BOUNDS
+  ) {
+    for (const value of Object.values(bounds)) {
+      if (!Number.isSafeInteger(value) || value < 1) {
+        throw new RangeError('Codex WSL reconciliation bounds must be positive integers')
+      }
+    }
+  }
+
+  advance(key: string): number {
+    const generation = ++this.nextGeneration
+    const keyBytes = measureUtf8ByteLength(key, {
+      stopAfterBytes: this.bounds.maxKeyBytes
+    })
+    this.delete(key)
+    if (keyBytes.exceededLimit || keyBytes.byteLength > this.bounds.maxTotalKeyBytes) {
+      return generation
+    }
+    while (
+      this.generations.size >= this.bounds.maxEntries ||
+      this.retainedKeyBytes + keyBytes.byteLength > this.bounds.maxTotalKeyBytes
+    ) {
+      const oldest = this.generations.keys().next().value
+      if (oldest === undefined) {
+        return generation
+      }
+      this.delete(oldest)
+    }
+    this.generations.set(key, { generation, keyBytes: keyBytes.byteLength })
+    this.retainedKeyBytes += keyBytes.byteLength
+    return generation
+  }
+
+  isCurrent(key: string, generation: number): boolean {
+    return this.generations.get(key)?.generation === generation
+  }
+
+  evidence(): { entries: number; keyBytes: number } {
+    return { entries: this.generations.size, keyBytes: this.retainedKeyBytes }
+  }
+
+  private delete(key: string): void {
+    const retained = this.generations.get(key)
+    if (!retained) {
+      return
+    }
+    this.generations.delete(key)
+    this.retainedKeyBytes -= retained.keyBytes
+  }
+}

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -3,7 +3,6 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
-  readFileSync,
   realpathSync,
   statSync,
   unlinkSync,
@@ -12,6 +11,7 @@ import {
 import { basename, dirname, join, posix as pathPosix, win32 as pathWin32 } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 import { renameFileWithWindowsRetry } from '../codex-accounts/fs-utils'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
 import { foldWslUncPathCaseInsensitiveParts } from '../../shared/wsl-paths'
 import { writeRollingFileBackup } from '../rolling-file-backup'
 import {
@@ -327,7 +327,7 @@ function isCodexEventLabel(value: string): value is CodexEventLabel {
 
 // Why: strip a leading BOM (some Windows editors write one) so header regexes anchored at `^[ \t]*\[` still match.
 function readTomlFile(configPath: string): string {
-  const raw = readFileSync(configPath, 'utf-8')
+  const raw = readAgentStateFileSync(configPath)
   return raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw
 }
 

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1,8 +1,9 @@
 /* eslint-disable max-lines -- Why: getStatus + install + remove all share the managed-command and trust-key derivation. Splitting would hide that the three operations must agree on group index, event label, and command bytes. */
-import { existsSync, readFileSync, statSync, unlinkSync } from 'node:fs'
+import { existsSync, statSync, unlinkSync } from 'node:fs'
 import { join, win32 as pathWin32 } from 'node:path'
 import type { SFTPWrapper } from 'ssh2'
 import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared/agent-hook-types'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
 import {
   buildManagedCommandHook,
   createManagedCommandMatcher,
@@ -11,6 +12,7 @@ import {
   hookDefinitionHasManagedCommand,
   MANAGED_HOOK_TIMEOUT_SECONDS,
   readHooksJson,
+  readHooksJsonRawForGenerationCheck,
   readHooksJsonWithRaw,
   removeManagedCommands,
   wrapPosixHookCommand,
@@ -81,6 +83,7 @@ import {
 } from './codex-managed-trust-reconciliation'
 import type { CodexTrustGrantLedgerHome } from './codex-trust-grant-ledger'
 import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
+import { CodexWslReconciliationGenerations } from './codex-wsl-reconciliation-generations'
 
 // Why: Pre/PostToolUse feed the live in-flight-tool readout; PermissionRequest exits with no decision so Codex still shows its approval UI while Orca flips the pane to waiting.
 const CODEX_EVENTS = [
@@ -541,7 +544,7 @@ function applyMirroredRuntimeUserHookTrustStates(
     return
   }
 
-  const existing = readFileSync(tomlPath, 'utf-8')
+  const existing = readAgentStateFileSync(tomlPath)
   let updated = existing
   for (const { entry, enabled } of entries) {
     const headerKeyPattern = buildHookTrustHeaderKeyPattern(computeTrustKey(entry))
@@ -645,7 +648,7 @@ function cleanupLegacySystemManagedHooks(): void {
       afterHooks: nextHooks,
       writeHooks: () => {
         if (
-          readFileSync(legacyConfigPath, 'utf-8') !== previousRaw ||
+          readHooksJsonRawForGenerationCheck(legacyConfigPath) !== previousRaw ||
           resolveHooksJsonWritePath(legacyConfigPath) !== hooksWritePath
         ) {
           // Why: the pre-mutation RPC may overlap a user save; downgrade must
@@ -691,7 +694,7 @@ function cleanupLegacyCodexProfileHooks(): void {
     return
   }
 
-  const existing = readFileSync(profilePath, 'utf-8')
+  const existing = readAgentStateFileSync(profilePath)
   const next = stripLegacyManagedProfileBlock(existing)
   if (next === existing) {
     return
@@ -1021,16 +1024,14 @@ function getWslReconciliationKey(runtimeHomePath: string): string {
 }
 
 export class CodexHookService {
-  private readonly wslReconciliationGeneration = new Map<string, number>()
+  private readonly wslReconciliationGenerations = new CodexWslReconciliationGenerations()
 
   private supersedeWslReconciliation(runtimeHomePath: string | null | undefined): number {
     if (!runtimeHomePath) {
       return 0
     }
     const key = getWslReconciliationKey(runtimeHomePath)
-    const generation = (this.wslReconciliationGeneration.get(key) ?? 0) + 1
-    this.wslReconciliationGeneration.set(key, generation)
-    return generation
+    return this.wslReconciliationGenerations.advance(key)
   }
 
   installForRuntimeHome(
@@ -1058,7 +1059,7 @@ export class CodexHookService {
           : null
       const action = getWslHookReconciliationAction({
         settlement,
-        isCurrentGeneration: this.wslReconciliationGeneration.get(key) === generation,
+        isCurrentGeneration: this.wslReconciliationGenerations.isCurrent(key, generation),
         installedTrustConfigPath,
         resolvedTrustConfigPath: resolvedPlan?.trustConfigPath ?? null,
         installSucceeded

--- a/src/main/codex/hook-trust-promotion.ts
+++ b/src/main/codex/hook-trust-promotion.ts
@@ -1,5 +1,7 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { MAX_AGENT_STATE_FILE_BYTES, readAgentStateJsonFileSync } from '../agent-state-file-reader'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
 import {
   createManagedCommandMatcher,
   readHooksJson,
@@ -51,7 +53,7 @@ function readHookTrustProvenance(
     return null
   }
   try {
-    const parsed: unknown = JSON.parse(readFileSync(provenancePath, 'utf-8'))
+    const parsed = readAgentStateJsonFileSync(provenancePath)
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
       return null
     }
@@ -97,7 +99,8 @@ export function snapshotCodexRuntimeHookTrustProvenance(
       }
     }
     const file: HookTrustProvenanceFile = { version: 1, entries }
-    writeFileSync(getProvenancePath(runtimeHomePath), `${JSON.stringify(file, null, 2)}\n`, {
+    const { serialized } = stringifyJsonWithinByteLimit(file, MAX_AGENT_STATE_FILE_BYTES - 1, 2)
+    writeFileSync(getProvenancePath(runtimeHomePath), `${serialized}\n`, {
       encoding: 'utf-8',
       mode: 0o600
     })

--- a/src/main/opencode-usage/scanner.ts
+++ b/src/main/opencode-usage/scanner.ts
@@ -1,13 +1,15 @@
 /* eslint-disable max-lines -- Why: OpenCode usage analytics need to normalize multiple local DB schema generations, attribute worktrees, and build persisted projections in one auditable pipeline. */
 import { existsSync } from 'node:fs'
-import { readdir, realpath, stat } from 'node:fs/promises'
+import { realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, isAbsolute, join, posix, win32 } from 'node:path'
 import type { Repo } from '../../shared/types'
 import { areWorktreePathsEqual } from '../ipc/worktree-logic'
 import Database from '../sqlite/sync-database'
-import { columnExists, tableExists } from './schema-helpers'
+import { listOpenCodeDatabaseFiles } from '../opencode/opencode-database-files'
 import { canonicalizeUsageWorktreePaths } from '../usage-worktree-canonicalizer'
+import { getUsageHistoryRetainedBytes, UsageHistoryScanBudget } from '../usage-history-scan-budget'
+import { iterateOpenCodeUsageRows, type OpenCodeUsageRow } from './sqlite-usage-row-stream'
 import type {
   OpenCodeUsageAttributedEvent,
   OpenCodeUsageDailyAggregate,
@@ -25,34 +27,6 @@ export type OpenCodeUsageWorktreeRef = {
   worktreeId: string
   path: string
   displayName: string
-}
-
-type OpenCodeUsageRow = {
-  id: string
-  session_id: string
-  time_created: number
-  time_updated: number | null
-  data: string
-  directory: string | null
-  title: string | null
-  worktree: string | null
-  session_model: string | null
-}
-
-type OpenCodeSessionUsageRow = {
-  id: string
-  session_id: string
-  time_created: number
-  time_updated: number | null
-  directory: string | null
-  title: string | null
-  worktree: string | null
-  session_model: string | null
-  cost: number
-  tokens_input: number
-  tokens_output: number
-  tokens_reasoning: number
-  tokens_cache_read: number
 }
 
 const YIELD_EVERY_DATABASES = 2
@@ -111,11 +85,7 @@ export async function listOpenCodeDatabases(): Promise<string[]> {
   }
 
   try {
-    const entries = await readdir(getOpenCodeDataDirectory(), { withFileTypes: true })
-    return entries
-      .filter((entry) => entry.isFile() && /^opencode(?:-[A-Za-z0-9_.-]+)?\.db$/.test(entry.name))
-      .map((entry) => join(getOpenCodeDataDirectory(), entry.name))
-      .sort()
+    return (await listOpenCodeDatabaseFiles(getOpenCodeDataDirectory())).paths
   } catch {
     return []
   }
@@ -146,140 +116,6 @@ export async function getProcessedDatabaseInfo(
 
 async function yieldToEventLoop(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0))
-}
-
-function getProjectJoin(db: Database.Database): string {
-  return tableExists(db, 'project') && columnExists(db, 'session', 'project_id')
-    ? 'LEFT JOIN project p ON p.id = s.project_id'
-    : 'LEFT JOIN (SELECT NULL AS id, NULL AS worktree) p ON 1 = 0'
-}
-
-function getSessionModelSelect(db: Database.Database): string {
-  return columnExists(db, 'session', 'model') ? 's.model AS session_model' : 'NULL AS session_model'
-}
-
-function getAssistantSessionMessageCount(db: Database.Database): number {
-  if (!tableExists(db, 'session_message')) {
-    return 0
-  }
-  const assistantPredicate = columnExists(db, 'session_message', 'type')
-    ? "type = 'assistant' AND json_extract(data, '$.tokens.input') IS NOT NULL"
-    : "json_extract(data, '$.tokens.input') IS NOT NULL"
-  const row = db
-    .prepare(`SELECT COUNT(*) AS count FROM session_message WHERE ${assistantPredicate}`)
-    .get() as { count?: number } | undefined
-  return row?.count ?? 0
-}
-
-function canReadSessionUsageRows(db: Database.Database): boolean {
-  if (!tableExists(db, 'session')) {
-    return false
-  }
-  return ['cost', 'tokens_input', 'tokens_output', 'tokens_reasoning', 'tokens_cache_read'].every(
-    (columnName) => columnExists(db, 'session', columnName)
-  )
-}
-
-function getSessionUsageRowCount(db: Database.Database): number {
-  if (!canReadSessionUsageRows(db)) {
-    return 0
-  }
-  const row = db
-    .prepare(
-      `SELECT COUNT(*) AS count
-       FROM session
-       WHERE tokens_input + tokens_output + tokens_reasoning + tokens_cache_read > 0`
-    )
-    .get() as { count?: number } | undefined
-  return row?.count ?? 0
-}
-
-function selectSessionUsageRows(db: Database.Database): OpenCodeUsageRow[] {
-  const projectJoin = getProjectJoin(db)
-  const sessionModelSelect = getSessionModelSelect(db)
-  const rows = db
-    .prepare(
-      `SELECT s.id, s.id AS session_id, s.time_created, s.time_updated,
-              s.directory, s.title, p.worktree, ${sessionModelSelect},
-              s.cost, s.tokens_input, s.tokens_output, s.tokens_reasoning, s.tokens_cache_read
-       FROM session s
-       ${projectJoin}
-       WHERE s.tokens_input + s.tokens_output + s.tokens_reasoning + s.tokens_cache_read > 0
-       ORDER BY s.time_created, s.id`
-    )
-    .all() as OpenCodeSessionUsageRow[]
-
-  return rows.map((row) => ({
-    id: row.id,
-    session_id: row.session_id,
-    time_created: row.time_created,
-    time_updated: row.time_updated,
-    directory: row.directory,
-    title: row.title,
-    worktree: row.worktree,
-    session_model: row.session_model,
-    data: JSON.stringify({
-      cost: row.cost,
-      tokens: {
-        input: row.tokens_input,
-        output: row.tokens_output,
-        reasoning: row.tokens_reasoning,
-        total: row.tokens_input + row.tokens_output + row.tokens_reasoning,
-        cache: {
-          read: row.tokens_cache_read,
-          write: 0
-        }
-      }
-    })
-  }))
-}
-
-function selectUsageRows(db: Database.Database): OpenCodeUsageRow[] {
-  if (!tableExists(db, 'session')) {
-    return []
-  }
-
-  // Why: newer OpenCode DBs maintain session-level token/cost totals. Reading
-  // one aggregate row per session is faster than parsing every message blob.
-  if (getSessionUsageRowCount(db) > 0) {
-    return selectSessionUsageRows(db)
-  }
-
-  const projectJoin = getProjectJoin(db)
-  const sessionModelSelect = getSessionModelSelect(db)
-
-  if (getAssistantSessionMessageCount(db) > 0) {
-    const assistantPredicate = columnExists(db, 'session_message', 'type')
-      ? "sm.type = 'assistant'"
-      : "json_extract(sm.data, '$.tokens.input') IS NOT NULL"
-    return db
-      .prepare(
-        `SELECT sm.id, sm.session_id, sm.time_created, sm.time_updated, sm.data,
-                s.directory, s.title, p.worktree, ${sessionModelSelect}
-         FROM session_message sm
-         JOIN session s ON s.id = sm.session_id
-         ${projectJoin}
-         WHERE ${assistantPredicate}
-         ORDER BY sm.time_created, sm.id`
-      )
-      .all() as OpenCodeUsageRow[]
-  }
-
-  if (!tableExists(db, 'message')) {
-    return []
-  }
-
-  return db
-    .prepare(
-      `SELECT m.id, m.session_id, m.time_created, m.time_updated, m.data,
-              s.directory, s.title, p.worktree, ${sessionModelSelect}
-       FROM message m
-       JOIN session s ON s.id = m.session_id
-       ${projectJoin}
-       WHERE json_extract(m.data, '$.role') = 'assistant'
-       ORDER BY m.time_created, m.id`
-    )
-    .all() as OpenCodeUsageRow[]
 }
 
 function parseJsonObject(value: unknown): Record<string, unknown> | null {
@@ -841,11 +677,71 @@ function mergeDailyAggregates(
   }
 }
 
+function claimOpenCodeUsageProjection(
+  budget: UsageHistoryScanBudget,
+  sessions: readonly OpenCodeUsageSession[],
+  dailyAggregates: readonly OpenCodeUsageDailyAggregate[]
+): void {
+  for (const session of sessions) {
+    budget.claimProjection(
+      getUsageHistoryRetainedBytes([
+        session.sessionId,
+        session.firstTimestamp,
+        session.lastTimestamp,
+        session.primaryModel,
+        session.primaryProjectLabel,
+        session.primaryWorktreeId,
+        session.primaryRepoId
+      ])
+    )
+    for (const location of session.locationBreakdown) {
+      budget.claimProjection(
+        getUsageHistoryRetainedBytes([
+          location.locationKey,
+          location.projectLabel,
+          location.repoId,
+          location.worktreeId
+        ])
+      )
+    }
+    for (const model of session.modelBreakdown) {
+      budget.claimProjection(getUsageHistoryRetainedBytes([model.modelKey, model.modelLabel]))
+    }
+    for (const locationModel of session.locationModelBreakdown) {
+      budget.claimProjection(
+        getUsageHistoryRetainedBytes([
+          locationModel.locationKey,
+          locationModel.modelKey,
+          locationModel.modelLabel,
+          locationModel.repoId,
+          locationModel.worktreeId
+        ])
+      )
+    }
+  }
+  for (const daily of dailyAggregates) {
+    budget.claimProjection(
+      getUsageHistoryRetainedBytes([
+        daily.day,
+        daily.model,
+        daily.projectKey,
+        daily.projectLabel,
+        daily.repoId,
+        daily.worktreeId
+      ])
+    )
+  }
+}
+
 export async function parseOpenCodeUsageDatabase(
   dbPath: string,
   worktrees: (OpenCodeUsageWorktreeRef & { canonicalPath: string })[],
-  options: { claimSession?: (sessionId: string) => boolean } = {}
+  options: {
+    claimSession?: (sessionId: string) => boolean
+    budget?: UsageHistoryScanBudget
+  } = {}
 ): Promise<OpenCodeUsagePersistedDatabase> {
+  const budget = options.budget ?? new UsageHistoryScanBudget()
   const processedDatabase = await getProcessedDatabaseInfo(dbPath)
   const db = new Database(dbPath, { readonly: true, fileMustExist: true })
   try {
@@ -853,7 +749,7 @@ export async function parseOpenCodeUsageDatabase(
     const events: OpenCodeUsageAttributedEvent[] = []
     const claimedBySessionId = new Map<string, boolean>()
     let hasDeferredClaims = false
-    for (const row of selectUsageRows(db)) {
+    for (const row of iterateOpenCodeUsageRows(db)) {
       const parsed = parseOpenCodeUsageRow(row)
       if (!parsed) {
         continue
@@ -862,6 +758,7 @@ export async function parseOpenCodeUsageDatabase(
       // each session must be counted from exactly one database (#8006).
       let owned = claimedBySessionId.get(parsed.sessionId)
       if (owned === undefined) {
+        budget.claimOwnershipKey(parsed.sessionId)
         owned = options.claimSession ? options.claimSession(parsed.sessionId) : true
         claimedBySessionId.set(parsed.sessionId, owned)
       }
@@ -871,12 +768,27 @@ export async function parseOpenCodeUsageDatabase(
       }
       const attributed = await attributeOpenCodeUsageEvent(parsed, worktrees)
       if (attributed) {
+        budget.claimRecord(
+          getUsageHistoryRetainedBytes([
+            attributed.sessionId,
+            attributed.timestamp,
+            attributed.cwd,
+            attributed.model,
+            attributed.day,
+            attributed.projectKey,
+            attributed.projectLabel,
+            attributed.repoId,
+            attributed.worktreeId
+          ])
+        )
         events.push(attributed)
       }
     }
+    const aggregates = aggregateOpenCodeUsage(events)
+    claimOpenCodeUsageProjection(budget, aggregates.sessions, aggregates.dailyAggregates)
     return {
       ...processedDatabase,
-      ...aggregateOpenCodeUsage(events),
+      ...aggregates,
       ownedSessionIds: [...claimedBySessionId.entries()]
         .filter(([, owned]) => owned)
         .map(([sessionId]) => sessionId),
@@ -889,12 +801,14 @@ export async function parseOpenCodeUsageDatabase(
 
 export async function scanOpenCodeUsageDatabases(
   worktrees: OpenCodeUsageWorktreeRef[],
-  previousProcessedDatabases: OpenCodeUsagePersistedDatabase[]
+  previousProcessedDatabases: OpenCodeUsagePersistedDatabase[],
+  options: { budget?: UsageHistoryScanBudget } = {}
 ): Promise<{
   processedDatabases: OpenCodeUsagePersistedDatabase[]
   sessions: OpenCodeUsageSession[]
   dailyAggregates: OpenCodeUsageDailyAggregate[]
 }> {
+  const budget = options.budget ?? new UsageHistoryScanBudget()
   const dbPaths = await listOpenCodeDatabases()
   const previousByPath = new Map(
     previousProcessedDatabases.map((database) => [database.path, database])
@@ -965,7 +879,12 @@ export async function scanOpenCodeUsageDatabases(
   const sessionOwnerById = new Map<string, string>()
   for (const dbPath of [...reusedByPath.keys()].sort(compareOpenCodeClaimPriority)) {
     const previous = reusedByPath.get(dbPath)
+    for (const session of previous?.sessions ?? []) {
+      budget.claimRecords(session.eventCount)
+    }
+    claimOpenCodeUsageProjection(budget, previous?.sessions ?? [], previous?.dailyAggregates ?? [])
     for (const sessionId of previous?.ownedSessionIds ?? []) {
+      budget.claimOwnershipKey(sessionId)
       if (!sessionOwnerById.has(sessionId)) {
         sessionOwnerById.set(sessionId, dbPath)
       }
@@ -976,6 +895,7 @@ export async function scanOpenCodeUsageDatabases(
   const orderedPathsToParse = [...pathsToParse].sort(compareOpenCodeClaimPriority)
   for (const [index, dbPath] of orderedPathsToParse.entries()) {
     const processed = await parseOpenCodeUsageDatabase(dbPath, worktreesWithCanonicalPaths, {
+      budget,
       claimSession: (sessionId) => {
         const owner = sessionOwnerById.get(sessionId)
         if (owner !== undefined && owner !== dbPath) {

--- a/src/main/opencode-usage/sqlite-usage-row-stream.test.ts
+++ b/src/main/opencode-usage/sqlite-usage-row-stream.test.ts
@@ -1,0 +1,118 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import Database from '../sqlite/sync-database'
+import { UsageHistoryScanBudget, UsageHistoryScanCapacityError } from '../usage-history-scan-budget'
+import { parseOpenCodeUsageDatabase } from './scanner'
+import {
+  iterateOpenCodeUsageRows,
+  OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES
+} from './sqlite-usage-row-stream'
+
+const tempDirs: string[] = []
+
+function createDatabase(): { db: Database.Database; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-retention-'))
+  tempDirs.push(dir)
+  const path = join(dir, 'opencode.db')
+  const db = new Database(path)
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      directory TEXT,
+      title TEXT,
+      cost REAL,
+      tokens_input INTEGER,
+      tokens_output INTEGER,
+      tokens_reasoning INTEGER,
+      tokens_cache_read INTEGER,
+      time_created INTEGER,
+      time_updated INTEGER
+    );
+  `)
+  return { db, path }
+}
+
+function insertSession(db: Database.Database, id: string, title = '', inputTokens = 1): void {
+  db.prepare(
+    `INSERT INTO session (
+      id, directory, title, cost,
+      tokens_input, tokens_output, tokens_reasoning, tokens_cache_read,
+      time_created, time_updated
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  ).run(id, null, title, 0, inputTokens, 0, 0, 0, 1_777_777_700_000, 1_777_777_800_000)
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('OpenCode SQLite usage row retention', () => {
+  it('preserves an exact-boundary row', () => {
+    const { db } = createDatabase()
+    const title = 't'.repeat(OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES - 2)
+    insertSession(db, 's', title)
+
+    const rows = [...iterateOpenCodeUsageRows(db)]
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.id).toBe('s')
+    expect(rows[0]?.title).toBe(title)
+    db.close()
+  })
+
+  it('rejects a row one byte above the retained-text limit', () => {
+    const { db } = createDatabase()
+    insertSession(db, 's', 't'.repeat(OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES - 1))
+
+    expect(() => [...iterateOpenCodeUsageRows(db)]).toThrowError(
+      new UsageHistoryScanCapacityError('retainedBytes', OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES)
+    )
+    db.close()
+  })
+
+  it('rejects oversized legacy JSON before asking SQLite to parse it', () => {
+    const { db } = createDatabase()
+    insertSession(db, 's', '', 0)
+    db.exec(`
+      CREATE TABLE message (
+        id TEXT PRIMARY KEY,
+        session_id TEXT,
+        time_created INTEGER,
+        time_updated INTEGER,
+        data TEXT
+      );
+    `)
+    const data = `{"role":"assistant","padding":"${'x'.repeat(
+      OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES
+    )}"}`
+    db.prepare(
+      'INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)'
+    ).run('m', 's', 1, 1, data)
+
+    expect(() => [...iterateOpenCodeUsageRows(db)]).toThrowError(
+      new UsageHistoryScanCapacityError('retainedBytes', OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES)
+    )
+    db.close()
+  })
+
+  it('shares the history record budget across streamed rows', async () => {
+    const { db, path } = createDatabase()
+    insertSession(db, 'session-1')
+    insertSession(db, 'session-2')
+    db.close()
+    const budget = new UsageHistoryScanBudget({
+      records: 1,
+      ownershipKeys: 4,
+      retainedBytes: 16 * 1024 * 1024
+    })
+
+    await expect(parseOpenCodeUsageDatabase(path, [], { budget })).rejects.toMatchObject({
+      resource: 'records',
+      limit: 1
+    })
+  })
+})

--- a/src/main/opencode-usage/sqlite-usage-row-stream.ts
+++ b/src/main/opencode-usage/sqlite-usage-row-stream.ts
@@ -1,0 +1,238 @@
+import type Database from '../sqlite/sync-database'
+import { UsageHistoryScanCapacityError } from '../usage-history-scan-budget'
+import { columnExists, tableExists } from './schema-helpers'
+
+export const OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES = 4 * 1024 * 1024
+
+export type OpenCodeUsageRow = {
+  id: string
+  session_id: string
+  time_created: number
+  time_updated: number | null
+  data: string
+  directory: string | null
+  title: string | null
+  worktree: string | null
+  session_model: string | null
+}
+
+type OpenCodeSessionUsageRow = Omit<OpenCodeUsageRow, 'data'> & {
+  cost: number
+  tokens_input: number
+  tokens_output: number
+  tokens_reasoning: number
+  tokens_cache_read: number
+}
+
+function retainedTextBytesSql(expressions: readonly string[]): string {
+  return expressions
+    .map((expression) => `length(CAST(COALESCE(${expression}, '') AS BLOB))`)
+    .join(' + ')
+}
+
+function assertNoOversizedRows(
+  db: Database.Database,
+  fromSql: string,
+  whereSql: string,
+  rowBytesSql: string
+): void {
+  const oversized = db
+    .prepare(
+      `SELECT 1
+       ${fromSql}
+       WHERE ${whereSql}
+         AND (${rowBytesSql}) > ${OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES}
+       LIMIT 1`
+    )
+    .get()
+  if (oversized) {
+    throw new UsageHistoryScanCapacityError('retainedBytes', OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES)
+  }
+}
+
+function assertNoOversizedJsonCandidates(
+  db: Database.Database,
+  table: 'message' | 'session_message',
+  candidateWhereSql: string
+): void {
+  const oversized = db
+    .prepare(
+      `SELECT 1
+       FROM ${table}
+       WHERE ${candidateWhereSql}
+         AND length(CAST(COALESCE(data, '') AS BLOB)) > ${OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES}
+       LIMIT 1`
+    )
+    .get()
+  if (oversized) {
+    throw new UsageHistoryScanCapacityError('retainedBytes', OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES)
+  }
+}
+
+function boundedJsonPredicate(dataExpression: string, predicate: string): string {
+  return `CASE
+    WHEN length(CAST(COALESCE(${dataExpression}, '') AS BLOB)) <= ${OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES}
+    THEN (${predicate})
+    ELSE 0
+  END`
+}
+
+function getProjectJoin(db: Database.Database): string {
+  return tableExists(db, 'project') && columnExists(db, 'session', 'project_id')
+    ? 'LEFT JOIN project p ON p.id = s.project_id'
+    : 'LEFT JOIN (SELECT NULL AS id, NULL AS worktree) p ON 1 = 0'
+}
+
+function getSessionModelSelect(db: Database.Database): string {
+  return columnExists(db, 'session', 'model') ? 's.model AS session_model' : 'NULL AS session_model'
+}
+
+function getAssistantSessionMessageCount(db: Database.Database): number {
+  if (!tableExists(db, 'session_message')) {
+    return 0
+  }
+  const hasType = columnExists(db, 'session_message', 'type')
+  assertNoOversizedJsonCandidates(db, 'session_message', hasType ? "type = 'assistant'" : '1 = 1')
+  const jsonPredicate = boundedJsonPredicate(
+    'data',
+    "json_extract(data, '$.tokens.input') IS NOT NULL"
+  )
+  const assistantPredicate = hasType ? `type = 'assistant' AND ${jsonPredicate}` : jsonPredicate
+  const row = db
+    .prepare(`SELECT COUNT(*) AS count FROM session_message WHERE ${assistantPredicate}`)
+    .get() as { count?: number } | undefined
+  return row?.count ?? 0
+}
+
+function canReadSessionUsageRows(db: Database.Database): boolean {
+  if (!tableExists(db, 'session')) {
+    return false
+  }
+  return ['cost', 'tokens_input', 'tokens_output', 'tokens_reasoning', 'tokens_cache_read'].every(
+    (columnName) => columnExists(db, 'session', columnName)
+  )
+}
+
+function getSessionUsageRowCount(db: Database.Database): number {
+  if (!canReadSessionUsageRows(db)) {
+    return 0
+  }
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) AS count
+       FROM session
+       WHERE tokens_input + tokens_output + tokens_reasoning + tokens_cache_read > 0`
+    )
+    .get() as { count?: number } | undefined
+  return row?.count ?? 0
+}
+
+function* iterateSessionUsageRows(db: Database.Database): Iterable<OpenCodeUsageRow> {
+  const projectJoin = getProjectJoin(db)
+  const sessionModelSelect = getSessionModelSelect(db)
+  const fromSql = `FROM session s ${projectJoin}`
+  const whereSql = 's.tokens_input + s.tokens_output + s.tokens_reasoning + s.tokens_cache_read > 0'
+  const rowBytesSql = retainedTextBytesSql([
+    's.id',
+    's.id',
+    's.directory',
+    's.title',
+    'p.worktree',
+    columnExists(db, 'session', 'model') ? 's.model' : "''"
+  ])
+  assertNoOversizedRows(db, fromSql, whereSql, rowBytesSql)
+
+  const rows = db
+    .prepare(
+      `SELECT s.id, s.id AS session_id, s.time_created, s.time_updated,
+              s.directory, s.title, p.worktree, ${sessionModelSelect},
+              s.cost, s.tokens_input, s.tokens_output, s.tokens_reasoning, s.tokens_cache_read
+       ${fromSql}
+       WHERE ${whereSql}
+         AND (${rowBytesSql}) <= ${OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES}
+       ORDER BY s.time_created, s.id`
+    )
+    .iterate() as Iterable<OpenCodeSessionUsageRow>
+
+  for (const row of rows) {
+    yield {
+      id: row.id,
+      session_id: row.session_id,
+      time_created: row.time_created,
+      time_updated: row.time_updated,
+      directory: row.directory,
+      title: row.title,
+      worktree: row.worktree,
+      session_model: row.session_model,
+      data: JSON.stringify({
+        cost: row.cost,
+        tokens: {
+          input: row.tokens_input,
+          output: row.tokens_output,
+          reasoning: row.tokens_reasoning,
+          total: row.tokens_input + row.tokens_output + row.tokens_reasoning,
+          cache: { read: row.tokens_cache_read, write: 0 }
+        }
+      })
+    }
+  }
+}
+
+function iterateMessageUsageRows(
+  db: Database.Database,
+  table: 'message' | 'session_message',
+  assistantPredicate: string
+): Iterable<OpenCodeUsageRow> {
+  const alias = table === 'message' ? 'm' : 'sm'
+  const projectJoin = getProjectJoin(db)
+  const sessionModelSelect = getSessionModelSelect(db)
+  const fromSql = `FROM ${table} ${alias} JOIN session s ON s.id = ${alias}.session_id ${projectJoin}`
+  const rowBytesSql = retainedTextBytesSql([
+    `${alias}.id`,
+    `${alias}.session_id`,
+    `${alias}.data`,
+    's.directory',
+    's.title',
+    'p.worktree',
+    columnExists(db, 'session', 'model') ? 's.model' : "''"
+  ])
+  assertNoOversizedRows(db, fromSql, assistantPredicate, rowBytesSql)
+
+  return db
+    .prepare(
+      `SELECT ${alias}.id, ${alias}.session_id, ${alias}.time_created,
+              ${alias}.time_updated, ${alias}.data,
+              s.directory, s.title, p.worktree, ${sessionModelSelect}
+       ${fromSql}
+       WHERE ${assistantPredicate}
+         AND (${rowBytesSql}) <= ${OPENCODE_USAGE_SQLITE_ROW_MAX_BYTES}
+       ORDER BY ${alias}.time_created, ${alias}.id`
+    )
+    .iterate() as Iterable<OpenCodeUsageRow>
+}
+
+export function iterateOpenCodeUsageRows(db: Database.Database): Iterable<OpenCodeUsageRow> {
+  if (!tableExists(db, 'session')) {
+    return []
+  }
+  if (getSessionUsageRowCount(db) > 0) {
+    return iterateSessionUsageRows(db)
+  }
+
+  if (getAssistantSessionMessageCount(db) > 0) {
+    const assistantPredicate = columnExists(db, 'session_message', 'type')
+      ? "sm.type = 'assistant'"
+      : boundedJsonPredicate('sm.data', "json_extract(sm.data, '$.tokens.input') IS NOT NULL")
+    return iterateMessageUsageRows(db, 'session_message', assistantPredicate)
+  }
+
+  if (!tableExists(db, 'message')) {
+    return []
+  }
+  assertNoOversizedJsonCandidates(db, 'message', '1 = 1')
+  return iterateMessageUsageRows(
+    db,
+    'message',
+    boundedJsonPredicate('m.data', "json_extract(m.data, '$.role') = 'assistant'")
+  )
+}

--- a/src/main/opencode-usage/store.ts
+++ b/src/main/opencode-usage/store.ts
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines -- Why: this store owns OpenCode analytics persistence, scan policy, and renderer query semantics. Keeping range/scope queries next to scan persistence prevents UI totals from drifting from the SQLite projection. */
 import { app } from 'electron'
-import { dirname, join } from 'node:path'
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import type {
   OpenCodeUsageBreakdownKind,
   OpenCodeUsageBreakdownRow,
@@ -14,6 +13,10 @@ import type {
   OpenCodeUsageSummary
 } from '../../shared/opencode-usage-types'
 import type { Store } from '../persistence'
+import {
+  readUsageProjectionStateFile,
+  writeUsageProjectionStateFileWithRecovery
+} from '../usage-projection-state-file'
 import { loadKnownUsageWorktreesByRepo, type UsageWorktreeRef } from '../usage-worktree-metadata'
 import type { OpenCodeUsageDailyAggregate, OpenCodeUsagePersistedState } from './types'
 import { createWorktreeRefs, scanOpenCodeUsageDatabases } from './scanner'
@@ -161,10 +164,11 @@ export class OpenCodeUsageStore {
   private load(): OpenCodeUsagePersistedState {
     try {
       const usageFile = getOpenCodeUsageFile()
-      if (!existsSync(usageFile)) {
+      const raw = readUsageProjectionStateFile(usageFile)
+      if (raw === null) {
         return getDefaultState()
       }
-      const parsed = JSON.parse(readFileSync(usageFile, 'utf-8')) as OpenCodeUsagePersistedState
+      const parsed = JSON.parse(raw) as OpenCodeUsagePersistedState
       return normalizePersistedState({
         ...getDefaultState(),
         ...parsed,
@@ -181,13 +185,12 @@ export class OpenCodeUsageStore {
 
   private writeToDisk(): void {
     const usageFile = getOpenCodeUsageFile()
-    const dir = dirname(usageFile)
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true })
-    }
-    const tmpFile = `${usageFile}.${process.pid}.${Date.now()}.${Math.random().toString(16).slice(2)}.tmp`
-    writeFileSync(tmpFile, JSON.stringify(this.state, null, 2), 'utf-8')
-    renameSync(tmpFile, usageFile)
+    this.state = writeUsageProjectionStateFileWithRecovery(usageFile, this.state, (error) => {
+      const reset = getDefaultState()
+      reset.scanState.enabled = this.state.scanState.enabled
+      reset.scanState.lastScanError = error.message
+      return reset
+    })
   }
 
   async setEnabled(enabled: boolean): Promise<OpenCodeUsageScanState> {

--- a/src/main/opencode/config-overlay-manifest.test.ts
+++ b/src/main/opencode/config-overlay-manifest.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES,
+  CONFIG_OVERLAY_MAX_SOURCE_ENTRIES,
+  ConfigOverlayCapacityError
+} from '../pty/config-overlay-mirroring'
+import { _configOverlayManifestInternals } from './config-overlay-manifest'
+
+const { parseOverlayManifest } = _configOverlayManifestInternals
+
+describe('OpenCode overlay manifest bounds', () => {
+  it('accepts the exact entry limit and rejects one more retained entry', () => {
+    const exact = parseOverlayManifest(
+      JSON.stringify({
+        topLevelEntries: Array.from({ length: CONFIG_OVERLAY_MAX_SOURCE_ENTRIES }, () => 'same'),
+        pluginEntries: []
+      })
+    )
+    expect(exact.topLevelEntries).toHaveLength(CONFIG_OVERLAY_MAX_SOURCE_ENTRIES)
+
+    expect(() =>
+      parseOverlayManifest(
+        JSON.stringify({
+          topLevelEntries: Array.from(
+            { length: CONFIG_OVERLAY_MAX_SOURCE_ENTRIES + 1 },
+            () => 'same'
+          ),
+          pluginEntries: []
+        })
+      )
+    ).toThrowError(
+      new ConfigOverlayCapacityError(
+        'entries',
+        CONFIG_OVERLAY_MAX_SOURCE_ENTRIES + 1,
+        CONFIG_OVERLAY_MAX_SOURCE_ENTRIES
+      )
+    )
+  })
+
+  it('accepts the exact encoded-name budget and rejects the next name', () => {
+    const name = 'a'.repeat(4_094)
+    const names = Array.from({ length: CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES / 4_096 }, () => name)
+    expect(
+      parseOverlayManifest(JSON.stringify({ topLevelEntries: names })).topLevelEntries
+    ).toHaveLength(names.length)
+
+    expect(() =>
+      parseOverlayManifest(JSON.stringify({ topLevelEntries: [...names, 'a'] }))
+    ).toThrowError(
+      new ConfigOverlayCapacityError(
+        'retained-name-bytes',
+        CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES + 3,
+        CONFIG_OVERLAY_MAX_RETAINED_NAME_BYTES
+      )
+    )
+  })
+
+  it('never authorizes cleanup of reserved overlay-owned paths', () => {
+    expect(
+      parseOverlayManifest(
+        JSON.stringify({
+          topLevelEntries: ['plugins', '.orca-opencode-overlay-manifest.json', 'auth.json'],
+          pluginEntries: ['orca-opencode-status.js', 'user-plugin.js']
+        })
+      )
+    ).toEqual({
+      topLevelEntries: ['auth.json'],
+      pluginEntries: ['user-plugin.js']
+    })
+  })
+})

--- a/src/main/opencode/config-overlay-manifest.ts
+++ b/src/main/opencode/config-overlay-manifest.ts
@@ -1,0 +1,164 @@
+import { unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileSyncWithinLimit
+} from '../../shared/node-bounded-file-reader'
+import {
+  CONFIG_OVERLAY_MAX_SOURCE_ENTRIES,
+  ConfigOverlayCapacityError,
+  ConfigOverlayEntryBudget,
+  applyConfigOverlayPlan,
+  createConfigOverlayPlan,
+  type AppliedConfigOverlayEntries
+} from '../pty/config-overlay-mirroring'
+import { safeRemoveTree } from '../pty/overlay-mirror'
+
+export const ORCA_OPENCODE_PLUGIN_FILE = 'orca-opencode-status.js'
+export const OPENCODE_OVERLAY_MANIFEST_FILE = '.orca-opencode-overlay-manifest.json'
+export const OPENCODE_OVERLAY_MANIFEST_MAX_BYTES = 2 * 1_024 * 1_024
+
+type OpenCodeOverlayManifest = {
+  topLevelEntries: string[]
+  pluginEntries: string[]
+}
+
+const RESERVED_TOP_LEVEL_ENTRIES = new Set([OPENCODE_OVERLAY_MANIFEST_FILE])
+
+function emptyManifest(): OpenCodeOverlayManifest {
+  return { topLevelEntries: [], pluginEntries: [] }
+}
+
+function parseManifestEntryNames(
+  value: unknown,
+  kind: 'top-level' | 'plugin',
+  budget: ConfigOverlayEntryBudget
+): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const names: string[] = []
+  for (const candidate of value) {
+    if (typeof candidate !== 'string') {
+      continue
+    }
+    budget.reserve(candidate)
+    if (
+      (kind === 'top-level' &&
+        (candidate === 'plugins' || candidate === OPENCODE_OVERLAY_MANIFEST_FILE)) ||
+      (kind === 'plugin' && candidate === ORCA_OPENCODE_PLUGIN_FILE)
+    ) {
+      continue
+    }
+    names.push(candidate)
+  }
+  return names
+}
+
+function parseOverlayManifest(contents: string): OpenCodeOverlayManifest {
+  const parsed = JSON.parse(contents) as Partial<OpenCodeOverlayManifest>
+  const topLevelCount = Array.isArray(parsed.topLevelEntries) ? parsed.topLevelEntries.length : 0
+  const pluginCount = Array.isArray(parsed.pluginEntries) ? parsed.pluginEntries.length : 0
+  if (topLevelCount + pluginCount > CONFIG_OVERLAY_MAX_SOURCE_ENTRIES) {
+    throw new ConfigOverlayCapacityError(
+      'entries',
+      topLevelCount + pluginCount,
+      CONFIG_OVERLAY_MAX_SOURCE_ENTRIES
+    )
+  }
+
+  const budget = new ConfigOverlayEntryBudget()
+  return {
+    topLevelEntries: parseManifestEntryNames(parsed.topLevelEntries, 'top-level', budget),
+    pluginEntries: parseManifestEntryNames(parsed.pluginEntries, 'plugin', budget)
+  }
+}
+
+function readOverlayManifest(overlayDir: string): OpenCodeOverlayManifest {
+  try {
+    const contents = readNodeFileSyncWithinLimit(
+      join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE),
+      OPENCODE_OVERLAY_MANIFEST_MAX_BYTES
+    ).buffer.toString('utf8')
+    return parseOverlayManifest(contents)
+  } catch (error) {
+    if (error instanceof ConfigOverlayCapacityError || error instanceof NodeFileReadTooLargeError) {
+      throw error
+    }
+    return emptyManifest()
+  }
+}
+
+function removePathBeforeWrite(path: string): void {
+  try {
+    unlinkSync(path)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
+
+function writeOverlayManifest(overlayDir: string, manifest: OpenCodeOverlayManifest): void {
+  const manifestPath = join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE)
+  const { serialized } = stringifyJsonWithinByteLimit(
+    manifest,
+    OPENCODE_OVERLAY_MANIFEST_MAX_BYTES - 1
+  )
+  removePathBeforeWrite(manifestPath)
+  writeFileSync(manifestPath, `${serialized}\n`)
+}
+
+function clearManifestEntries(overlayDir: string, manifest: OpenCodeOverlayManifest): void {
+  for (const entryName of manifest.topLevelEntries) {
+    if (!safeRemoveTree(join(overlayDir, entryName))) {
+      throw new Error('Unable to clear an OpenCode config overlay entry')
+    }
+  }
+
+  const overlayPluginsDir = join(overlayDir, 'plugins')
+  for (const entryName of manifest.pluginEntries) {
+    if (!safeRemoveTree(join(overlayPluginsDir, entryName))) {
+      throw new Error('Unable to clear an OpenCode plugin overlay entry')
+    }
+  }
+}
+
+function toManifest(applied: AppliedConfigOverlayEntries): OpenCodeOverlayManifest {
+  return {
+    topLevelEntries: applied.topLevelEntryNames,
+    pluginEntries: applied.pluginEntryNames
+  }
+}
+
+export function mirrorOpenCodeConfigWithManifest(sourceDir: string, overlayDir: string): void {
+  const plan = createConfigOverlayPlan(sourceDir, {
+    reservedPluginFile: ORCA_OPENCODE_PLUGIN_FILE,
+    reservedTopLevelEntryNames: RESERVED_TOP_LEVEL_ENTRIES
+  })
+  const previousManifest = readOverlayManifest(overlayDir)
+  clearManifestEntries(overlayDir, previousManifest)
+
+  const applied: AppliedConfigOverlayEntries = {
+    topLevelEntryNames: [],
+    pluginEntryNames: []
+  }
+  try {
+    applyConfigOverlayPlan(plan, overlayDir, applied)
+    writeOverlayManifest(overlayDir, toManifest(applied))
+  } catch (error) {
+    try {
+      clearManifestEntries(overlayDir, toManifest(applied))
+    } catch {
+      // Preserve the original mirror/write failure; a later spawn can retry cleanup.
+    }
+    throw error
+  }
+}
+
+export const _configOverlayManifestInternals = {
+  parseOverlayManifest,
+  writeOverlayManifest
+}

--- a/src/main/opencode/hook-service.test.ts
+++ b/src/main/opencode/hook-service.test.ts
@@ -8,10 +8,12 @@ import {
   readdirSync,
   rmSync,
   symlinkSync,
+  truncateSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { GENERATED_NODE_MANAGED_FILE_MAX_BYTES } from '../generated-node-bounded-file-reader'
 
 const { getPathMock } = vi.hoisted(() => ({
   getPathMock: vi.fn<(name: string) => string>()
@@ -24,6 +26,10 @@ vi.mock('electron', () => ({
 }))
 
 import { OpenCodeHookService, _internals } from './hook-service'
+import {
+  OPENCODE_OVERLAY_MANIFEST_FILE,
+  OPENCODE_OVERLAY_MANIFEST_MAX_BYTES
+} from './config-overlay-manifest'
 
 const { isUsableId, toSafeDirName } = _internals
 
@@ -65,6 +71,11 @@ describe('OpenCode hook plugin source', () => {
     expect(source).toContain('const coords = resolveHookCoords();')
     expect(source).toContain('`http://127.0.0.1:${coords.port}/hook/opencode`')
     expect(source).toContain('"X-Orca-Agent-Hook-Token": coords.token')
+    expect(source).toContain(
+      `function readOrcaManagedFileWithinLimit(fs, path, maxBytes = ${GENERATED_NODE_MANAGED_FILE_MAX_BYTES})`
+    )
+    expect(source).toContain('readOrcaManagedFileWithinLimit(fs, path)')
+    expect(source).not.toContain('fs.readFileSync')
   })
 
   it('caches the parsed endpoint file on mtime+size+inode to skip re-reads per post', () => {
@@ -354,6 +365,81 @@ describe('OpenCodeHookService overlay mode (user OPENCODE_CONFIG_DIR set)', () =
     expect(overlayPlugin).not.toBe(userOrcaSentinel)
     expectUserConfigIntact()
   })
+
+  it('does not mirror or overwrite a user file named like the internal manifest', () => {
+    const userManifest = join(userConfigDir, OPENCODE_OVERLAY_MANIFEST_FILE)
+    writeFileSync(userManifest, 'USER MANIFEST SENTINEL')
+
+    const env = new OpenCodeHookService().buildPtyEnv(ptyId, userConfigDir)
+    const overlayManifest = join(env.OPENCODE_CONFIG_DIR!, OPENCODE_OVERLAY_MANIFEST_FILE)
+
+    expect(readFileSync(userManifest, 'utf8')).toBe('USER MANIFEST SENTINEL')
+    expect(lstatSync(overlayManifest).isSymbolicLink()).toBe(false)
+    expect(JSON.parse(readFileSync(overlayManifest, 'utf8'))).toMatchObject({
+      topLevelEntries: expect.arrayContaining(['auth.json', 'opencode.json'])
+    })
+  })
+
+  it('falls back before mutation when a retained manifest exceeds its byte limit', () => {
+    const service = new OpenCodeHookService()
+    const first = service.buildPtyEnv(ptyId, userConfigDir)
+    const overlayDir = first.OPENCODE_CONFIG_DIR!
+    const overlayManifest = join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE)
+    truncateSync(overlayManifest, OPENCODE_OVERLAY_MANIFEST_MAX_BYTES + 1)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    expect(service.buildPtyEnv(ptyId, userConfigDir)).toEqual({
+      OPENCODE_CONFIG_DIR: userConfigDir
+    })
+    expect(readFileSync(join(overlayDir, 'auth.json'), 'utf8')).toBe('user-auth-token')
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[opencode-hooks] config overlay exceeded its memory limit; using the original OPENCODE_CONFIG_DIR without Orca status integration'
+    )
+    expectUserConfigIntact()
+  })
+
+  it('ignores forged manifest traversal entries during cleanup', () => {
+    const overlayDir = join(
+      userDataDir,
+      'opencode-config-overlays',
+      toSafeDirName(`source:${userConfigDir}`)
+    )
+    mkdirSync(overlayDir, { recursive: true })
+    const outsideMarker = join(userDataDir, 'outside-manifest-marker')
+    writeFileSync(outsideMarker, 'keep')
+    writeFileSync(
+      join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE),
+      JSON.stringify({ topLevelEntries: ['../outside-manifest-marker'] })
+    )
+
+    const env = new OpenCodeHookService().buildPtyEnv(ptyId, userConfigDir)
+
+    expect(env.OPENCODE_CONFIG_DIR).toBe(overlayDir)
+    expect(readFileSync(outsideMarker, 'utf8')).toBe('keep')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'replaces a stale manifest symlink without writing through to the user file',
+    () => {
+      const userManifest = join(userConfigDir, OPENCODE_OVERLAY_MANIFEST_FILE)
+      writeFileSync(userManifest, 'USER MANIFEST SENTINEL')
+      const overlayDir = join(
+        userDataDir,
+        'opencode-config-overlays',
+        toSafeDirName(`source:${userConfigDir}`)
+      )
+      mkdirSync(overlayDir, { recursive: true })
+      symlinkSync(userManifest, join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE), 'file')
+
+      const env = new OpenCodeHookService().buildPtyEnv(ptyId, userConfigDir)
+
+      expect(env.OPENCODE_CONFIG_DIR).toBe(overlayDir)
+      expect(readFileSync(userManifest, 'utf8')).toBe('USER MANIFEST SENTINEL')
+      expect(lstatSync(join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE)).isSymbolicLink()).toBe(
+        false
+      )
+    }
+  )
 
   it.skipIf(process.platform === 'win32')(
     'does not write through a symlinked plugins/ directory into the user filesystem',

--- a/src/main/opencode/hook-service.ts
+++ b/src/main/opencode/hook-service.ts
@@ -1,29 +1,19 @@
 /* eslint-disable max-lines -- Why: holds an inline JS plugin source emitted as one file; splitting across TS modules would scatter tightly coupled string-template logic. */
 import { app } from 'electron'
 import { join } from 'node:path'
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  realpathSync,
-  statSync,
-  unlinkSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
-import { mirrorEntry, safeRemoveTree } from '../pty/overlay-mirror'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import { getGeneratedNodeBoundedFileReaderSourceLines } from '../generated-node-bounded-file-reader'
+import { ConfigOverlayCapacityError } from '../pty/config-overlay-mirroring'
+import {
+  ORCA_OPENCODE_PLUGIN_FILE,
+  mirrorOpenCodeConfigWithManifest
+} from './config-overlay-manifest'
 
-const ORCA_OPENCODE_PLUGIN_FILE = 'orca-opencode-status.js'
 const OPENCODE_LEGACY_HOOKS_DIR = 'opencode-hooks'
 const OPENCODE_OVERLAY_DIR = 'opencode-config-overlays'
 const OPENCODE_SHARED_CONFIG_DIR = 'shared'
-const OPENCODE_OVERLAY_MANIFEST_FILE = '.orca-opencode-overlay-manifest.json'
-
-type OpenCodeOverlayManifest = {
-  topLevelEntries: string[]
-  pluginEntries: string[]
-}
 
 // Why: bounds-check only — the id is a daemon sessionId with path separators, hashed downstream to a filesystem-safe name (an old regex rejecting "/"/":" broke every such id, #1148); 1024 just caps pathological hash input.
 function isUsableId(id: string): boolean {
@@ -48,12 +38,13 @@ export function getOpenCodeFamilyPluginSource(hookPathname: string): string {
     "// OpenCode's Node process (not Orca's) and has no access to server.ts's",
     '// equivalent warnedVersions / warnedEnvs Sets.',
     'let warnedBadEndpoint = false;',
+    ...getGeneratedNodeBoundedFileReaderSourceLines(),
     '',
     '// Why: message.part.updated can fire many times per second during a',
     '// streaming assistant reply, and each post() calls resolveHookCoords()',
     '// which reads the endpoint file. The file only changes on Orca restart',
     '// (rare), so a stat+mtime check is substantially cheaper than a full',
-    '// readFileSync+parse on every streamed part. On stat error we fall',
+    '// bounded read+parse on every streamed part. On stat error we fall',
     '// through to parse so the fail-open behavior is preserved.',
     'let cachedEndpointKey = "";',
     'let cachedEndpointValues = null;',
@@ -74,7 +65,7 @@ export function getOpenCodeFamilyPluginSource(hookPathname: string): string {
     '      if (cacheKey === cachedEndpointKey && cachedEndpointValues) {',
     '        return cachedEndpointValues;',
     '      }',
-    '      const contents = fs.readFileSync(path, "utf8");',
+    '      const contents = readOrcaManagedFileWithinLimit(fs, path);',
     '      const out = {};',
     '      for (const line of contents.split(/\\r?\\n/)) {',
     '        // Why: Windows endpoint.cmd uses `set KEY=VALUE`; Unix endpoint.env',
@@ -91,7 +82,7 @@ export function getOpenCodeFamilyPluginSource(hookPathname: string): string {
     '      return out;',
     '    } catch (ioErr) {',
     '      // Why: any stat or read failure (file yanked mid-read, permission',
-    '      // race, unlink between stat and readFileSync) must invalidate the',
+    '      // race, unlink between stat and bounded read) must invalidate the',
     '      // cache so a transient failure does not lock in a stale parse for',
     '      // the remaining process lifetime; rethrow to the outer catch.',
     '      cachedEndpointKey = "";',
@@ -377,6 +368,8 @@ export function getOpenCodeFamilyPluginSource(hookPathname: string): string {
 
 // Why: installs the plugin into OPENCODE_CONFIG_DIR so it POSTs to the shared agent-hooks server, unifying OpenCode status with Claude/Codex/Gemini (the old loopback-IPC path never reached agentStatusByPaneKey).
 export class OpenCodeHookService {
+  private warnedOverlayCapacity = false
+
   clearPty(_ptyId: string): void {
     // Why: no-op — config dirs are app/source-scoped now, and recursive delete on the main-process hot path could freeze on Windows.
   }
@@ -407,7 +400,16 @@ export class OpenCodeHookService {
       mkdirSync(overlayDir, { recursive: true })
       this.mirrorUserConfig(existingConfigDir, overlayDir)
       this.writePluginIntoOverlay(overlayDir)
-    } catch {
+    } catch (error) {
+      if (
+        !this.warnedOverlayCapacity &&
+        (error instanceof ConfigOverlayCapacityError || error instanceof NodeFileReadTooLargeError)
+      ) {
+        this.warnedOverlayCapacity = true
+        console.warn(
+          '[opencode-hooks] config overlay exceeded its memory limit; using the original OPENCODE_CONFIG_DIR without Orca status integration'
+        )
+      }
       // Why: best-effort — symlink creation needs Windows developer mode (else EPERM) and userData may be read-only; preserve the user's config over dropping their auth/models/keymap.
       return { OPENCODE_CONFIG_DIR: existingConfigDir }
     }
@@ -427,90 +429,8 @@ export class OpenCodeHookService {
     return join(app.getPath('userData'), OPENCODE_LEGACY_HOOKS_DIR, OPENCODE_SHARED_CONFIG_DIR)
   }
 
-  private readOverlayManifest(overlayDir: string): OpenCodeOverlayManifest {
-    try {
-      const parsed = JSON.parse(
-        readFileSync(join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE), 'utf8')
-      ) as Partial<OpenCodeOverlayManifest>
-      return {
-        topLevelEntries: Array.isArray(parsed.topLevelEntries) ? parsed.topLevelEntries : [],
-        pluginEntries: Array.isArray(parsed.pluginEntries) ? parsed.pluginEntries : []
-      }
-    } catch {
-      return { topLevelEntries: [], pluginEntries: [] }
-    }
-  }
-
-  private writeOverlayManifest(overlayDir: string, manifest: OpenCodeOverlayManifest): void {
-    writeFileSync(
-      join(overlayDir, OPENCODE_OVERLAY_MANIFEST_FILE),
-      `${JSON.stringify(manifest, null, 2)}\n`
-    )
-  }
-
-  private clearManifestEntries(overlayDir: string, manifest: OpenCodeOverlayManifest): void {
-    for (const entryName of manifest.topLevelEntries) {
-      safeRemoveTree(join(overlayDir, entryName))
-    }
-
-    const overlayPluginsDir = join(overlayDir, 'plugins')
-    for (const entryName of manifest.pluginEntries) {
-      if (entryName === ORCA_OPENCODE_PLUGIN_FILE) {
-        continue
-      }
-      safeRemoveTree(join(overlayPluginsDir, entryName))
-    }
-  }
-
-  // Why: mirror user config entries as symlinks so edits propagate live; only plugins/ becomes a real overlay dir so Orca can drop a sibling plugin file.
   private mirrorUserConfig(sourceDir: string, overlayDir: string): void {
-    const previousManifest = this.readOverlayManifest(overlayDir)
-    // Why: overlays persist across terminals; remove only Orca-mirrored paths so stale user config clears but OpenCode runtime dirs (node_modules) survive.
-    this.clearManifestEntries(overlayDir, previousManifest)
-
-    const nextManifest: OpenCodeOverlayManifest = { topLevelEntries: [], pluginEntries: [] }
-
-    for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
-      const sourcePath = join(sourceDir, entry.name)
-
-      if (entry.name === 'plugins') {
-        // Why: check isSymbolicLink before isDirectory — a Windows junction reports both, and the symlink branch must win.
-        const isSymlink = entry.isSymbolicLink()
-        let isLinkPointingToDir = false
-        if (isSymlink) {
-          try {
-            isLinkPointingToDir = statSync(sourcePath).isDirectory()
-          } catch {
-            // Why: broken/inaccessible symlink — mirror the dangling link verbatim instead of resolving through it.
-            isLinkPointingToDir = false
-          }
-        }
-
-        if ((!isSymlink && entry.isDirectory()) || isLinkPointingToDir) {
-          // Why: resolve a symlinked plugins/ to its real target so <overlay>/plugins stays a real dir and writePluginIntoOverlay can't write through the user's link.
-          const resolvedSource = isLinkPointingToDir ? realpathSync(sourcePath) : sourcePath
-          const overlayPluginsDir = join(overlayDir, 'plugins')
-          mkdirSync(overlayPluginsDir, { recursive: true })
-          for (const pluginEntry of readdirSync(resolvedSource, { withFileTypes: true })) {
-            // Why: skip a user plugin sharing Orca's filename; mirroring it would let writePluginIntoOverlay clobber the user's file.
-            if (pluginEntry.name === ORCA_OPENCODE_PLUGIN_FILE) {
-              continue
-            }
-            mirrorEntry(
-              join(resolvedSource, pluginEntry.name),
-              join(overlayPluginsDir, pluginEntry.name)
-            )
-            nextManifest.pluginEntries.push(pluginEntry.name)
-          }
-          continue
-        }
-      }
-
-      mirrorEntry(sourcePath, join(overlayDir, entry.name))
-      nextManifest.topLevelEntries.push(entry.name)
-    }
-
-    this.writeOverlayManifest(overlayDir, nextManifest)
+    mirrorOpenCodeConfigWithManifest(sourceDir, overlayDir)
   }
 
   // Why: pre-write unlink guards against POSIX writeFileSync writing through a mirrored symlink and clobbering a same-named user plugin.
@@ -520,8 +440,10 @@ export class OpenCodeHookService {
     const pluginPath = join(pluginsDir, ORCA_OPENCODE_PLUGIN_FILE)
     try {
       unlinkSync(pluginPath)
-    } catch {
-      // File may not exist on a fresh overlay; a real failure surfaces on writeFileSync below.
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
     }
     writeFileSync(pluginPath, getOpenCodePluginSource())
   }
@@ -531,7 +453,7 @@ export class OpenCodeHookService {
     const pluginsDir = join(configDir, 'plugins')
     try {
       mkdirSync(pluginsDir, { recursive: true })
-      writeFileSync(join(pluginsDir, ORCA_OPENCODE_PLUGIN_FILE), getOpenCodePluginSource())
+      this.writePluginIntoOverlay(configDir)
     } catch {
       // Why: userData can be locked on Windows (EPERM/EBUSY); plugin is non-critical, so spawn without it.
       return null

--- a/src/main/opencode/opencode-database-files.test.ts
+++ b/src/main/opencode/opencode-database-files.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { collectOpenCodeDatabaseFiles } from './opencode-database-files'
+
+function entry(name: string, file = true): { name: string; isFile(): boolean } {
+  return { name, isFile: () => file }
+}
+
+describe('OpenCode database file discovery', () => {
+  it('preserves and sorts every matching file within the limit', async () => {
+    const result = await collectOpenCodeDatabaseFiles(
+      '/data',
+      (async function* () {
+        yield entry('opencode-z.db')
+        yield entry('notes.txt')
+        yield entry('opencode.db')
+        yield entry('opencode-directory.db', false)
+      })(),
+      2
+    )
+
+    expect(result).toEqual({
+      paths: ['/data/opencode-z.db', '/data/opencode.db'].sort(),
+      truncated: false
+    })
+  })
+
+  it('stops retaining names immediately after the database count limit', async () => {
+    let enumerated = 0
+    const result = await collectOpenCodeDatabaseFiles(
+      '/data',
+      (async function* () {
+        for (const name of ['opencode-a.db', 'opencode-b.db', 'opencode-c.db', 'opencode-d.db']) {
+          enumerated += 1
+          yield entry(name)
+        }
+      })(),
+      2
+    )
+
+    expect(result).toEqual({
+      paths: ['/data/opencode-a.db', '/data/opencode-b.db'],
+      truncated: true
+    })
+    expect(enumerated).toBe(3)
+  })
+})

--- a/src/main/opencode/opencode-database-files.ts
+++ b/src/main/opencode/opencode-database-files.ts
@@ -1,0 +1,40 @@
+import { opendir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const OPENCODE_DATABASE_FILE_LIMIT = 256
+
+type OpenCodeDatabaseDirectoryEntry = {
+  name: string
+  isFile(): boolean
+}
+
+export type OpenCodeDatabaseFiles = {
+  paths: string[]
+  truncated: boolean
+}
+
+export async function listOpenCodeDatabaseFiles(dataDir: string): Promise<OpenCodeDatabaseFiles> {
+  try {
+    return collectOpenCodeDatabaseFiles(dataDir, await opendir(dataDir))
+  } catch {
+    return { paths: [], truncated: false }
+  }
+}
+
+export async function collectOpenCodeDatabaseFiles(
+  dataDir: string,
+  directory: AsyncIterable<OpenCodeDatabaseDirectoryEntry>,
+  maxFiles = OPENCODE_DATABASE_FILE_LIMIT
+): Promise<OpenCodeDatabaseFiles> {
+  const paths: string[] = []
+  for await (const entry of directory) {
+    if (!entry.isFile() || !/^opencode(?:-[A-Za-z0-9_.-]+)?\.db$/.test(entry.name)) {
+      continue
+    }
+    if (paths.length >= maxFiles) {
+      return { paths: paths.sort(), truncated: true }
+    }
+    paths.push(join(dataDir, entry.name))
+  }
+  return { paths: paths.sort(), truncated: false }
+}


### PR DESCRIPTION
## OOM hardening slice 16/29 — bound Codex session/transport/account memory

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **16/29** (base: `oom/15-b-browser-emulator`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
This slice re-introduces explicit count/byte/depth/LRU ceilings across Codex and OpenCode account-management, migration, session-listing, capability-cache, and usage-scan code, plus a 4 MiB per-file read cap (readAgentStateFileSync / node-bounded-file-reader) on agent state files. All bounds are whole-file with dedicated boundary tests; every over-limit path fails closed or LRU-evicts.

### ELI5
Orca reads and imports a lot of files that Codex/OpenCode write on disk (login tokens, session logs, config, usage history). Before, some of that reading had no size limit, so a giant or corrupt file could balloon memory and crash the app. This change puts a fixed "you can only hold this much" cap on each of those spots. In everyday use nobody hits the caps. If something is absurdly large (a 4 MB auth file, 200k session files, 100k history threads), Orca now skips or trims that piece instead of trying to swallow it all — occasionally meaning one feature (like usage analytics or OpenCode status integration) quietly steps aside until the oversized data is gone.

### Proof of OOM fix
- Per-file read cap MAX_AGENT_STATE_FILE_BYTES = 4 MiB via readAgentStateFileSync/readNodeFileSyncWithinLimit, applied to auth.json/config.toml/hooks.json/markers across runtime-home-service.ts, service.ts, config-toml-trust.ts, codex-trust-config-rollback.ts (test: codex-trust-config-rollback.test.ts rejects sparse >4MiB config)
- Codex legacy history migration caps: file 32 MiB, line 1 MiB, input 200k lines, output 32 MiB, 64 KiB streaming chunks (legacy-history-migration.ts; test legacy-history-migration.test.ts asserts each skip reason with no partial output)
- Codex legacy session migration caps: depth 32, entries 50k, total 4 GiB, path 4 MiB code units, 64 KiB compare chunks (legacy-session-migration.ts; test legacy-session-migration.test.ts preflights each cap before any copy)
- Legacy managed-state migration caps: 4096 account entries, 256 managed homes, 2048 diagnostic records, 1 MiB diagnostic bytes (legacy-managed-state-migration.ts; test asserts discovery-skip / history-skip / session-skip markers)
- Codex session listing budget: depth 32, entries 200k, files 100k, path 32 MiB code units (codex-session-listing-budget.ts; tests codex-session-file-listing.test.ts hit each exact boundary)
- Codex account-home discovery: 4096 entries, 256 homes, 1 MiB path code units, fails closed to [] (codex-account-home-discovery.ts + .test.ts)
- Codex session index heal: 100k tracked threads, 64 KiB marker file, 1 MiB JSONL line, 64 KiB audit target, 128 recordId, 512 rollout stamp (codex-session-index-heal-state.ts + heal-jsonl.ts; memory + jsonl tests)
- Codex app-server capability cache + retry deadlines: 64-host LRU, 4 KiB host-key cap (sha256-digested beyond) (codex-app-server-capability-cache.ts, codex-host-retry-deadlines.ts + tests)
- WSL runtime-home retention & reconciliation generations: 64/256-entry LRU with byte budgets (8 MiB / 1 MiB) (codex-wsl-runtime-home-retention.ts, codex-wsl-reconciliation-generations.ts + tests)
- WSL canonical-path cache: 256-entry LRU + 2 MiB aggregate byte budget (codex-wsl-hook-install-plan.ts; LRU + byte-budget tests)
- OpenCode SQLite usage row cap 4 MiB retained text, rejected in-SQL before parse (sqlite-usage-row-stream.ts + .test.ts); OpenCode DB file limit 256 (opencode-database-files.ts + .test.ts); overlay manifest 2 MiB + entry/name budgets (config-overlay-manifest.ts + .test.ts)
- Grant JSON admission: 1,000,000 structural tokens / depth 128 before JSON.parse; grant-entry stdin cap 16 MiB; app-server stdout/stderr GrowingByteBuffer tail bounded by STDOUT_LINE_MAX_BYTES/STDERR_TAIL_MAX_BYTES (codex-app-server-grant-json.ts, codex-app-server-grant-entry.ts, codex-app-server-session.ts + tests)
- nvm version discovery: 4096 entries, 1 MiB retained-name bytes, fails closed to [] (nvm-version-directory-discovery.ts + .test.ts)

### Regressions
**Normal-path (ordinary use, below the new limits):** **none** — behavior is unchanged below the ceilings.

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Usage scan aborts wholesale: parseCodexUsageFile/scanCodexUsageFiles and parseOpenCodeUsageDatabase now share a UsageHistoryScanBudget and throw UsageHistoryScanCapacityError (records/ownershipKeys/retainedBytes) which propagates up and resets the usage store to defaults with lastScanError — only when the shared budget or MAX_USAGE_HISTORY_FILES(200k)/previous-file count is exceeded
- Codex account-home discovery and nvm version discovery fail closed to [] (drop ALL homes / ALL nvm bin dirs) only past 4096 entries / 256 homes / 1 MiB path text / 1 MiB names
- Legacy history/session migration permanently skips import (still writes one-shot marker) only when a legacy file exceeds 32 MiB / 200k lines / 4 GiB / depth 32
- OpenCode config overlay is abandoned (falls back to user OPENCODE_CONFIG_DIR without Orca status integration) only when the overlay manifest exceeds 2 MiB or an entry budget is hit
- WSL runtime-home retention drops a whole distro's cached auth/home when any single field exceeds 4 MiB (forces a re-read, not data loss on disk)
- 4 MiB agent-state read cap throws NodeFileReadTooLargeError on auth.json/config.toml/ledger only if those files somehow exceed 4 MiB (kilobyte-sized in practice)
- OpenCode DB discovery silently truncates past 256 .db files (listOpenCodeDatabases ignores the returned truncated flag)
- A single oversized/corrupt usage record or projection now aborts the ENTIRE Codex/OpenCode usage scan (shared budget throws), resetting the usage store to defaults instead of degrading per-file as the old code did (which swallowed per-home errors). Default budget limits live in usage-history-scan-budget.ts, which is NOT in this slice — the reviewer cannot confirm the ceilings are far above ordinary use from this diff alone. _(only when: Usage-history budget (records/ownershipKeys/retainedBytes) or MAX_USAGE_HISTORY_FILES=200k exceeded; must verify default budget in the dependency slice is generous.)_
- One-shot legacy Codex managed-state migration now permanently skips importing history/sessions that exceed the new caps and still writes the completion marker, so an oversized legacy home is never re-imported (diagnostics + console.warn record the skip). _(only when: Legacy managed home with history >32 MiB / >200k lines, or sessions tree >50k entries / >4 GiB / depth >32 — one-time upgrade path only.)_
- OpenCode usage analytics silently ignore .db files beyond 256 (truncated flag computed but dropped by listOpenCodeDatabases), and account-home/nvm discovery drop all results on overflow. _(only when: >256 OpenCode db files, or >4096 dir entries / >256 account homes during discovery — far above normal.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.

### Adversarial review
- 2 skeptic lens(es). Sign-off: **yes**. Residual risk: **medium**.
- Verified every numeric ceiling in the slice against TARGET; all sit far above ordinary use, so I could not confirm a normal-path regression for ordinary users.

Confirmed ceilings:
- Session listing (codex-session-listing-budget.ts): depth 32, 200k entries, 100k files, 32 MiB path text. Codex sessions are date-partitioned (shallow); overload-only.
- Usage scan (usage-history-scan-budget.ts, dep slice, read at TARGET): records 100k, ownershipKeys 100k, retainedBytes 256 MiB, files 200k, discoveryEntries 1M.
- Account-home discovery (codex-account-home-discovery.ts): 4096 entries / 256 homes / 1 MiB paths, fails closed to [] with console.warn.
- nvm discovery: 4096 entries / 1 MiB names, fails closed to [].
- Legacy migration (legacy-history-migration.ts): 32 MiB file / 1 MiB line / 200k lines / 32 MiB output — one-shot, still writes completion marker.
- config-overlay-manifest.ts: 2 MiB + entry budget.
- agent-state read cap (agent-state-file-reader.ts, dep slice): 4 MiB on auth.json/config.toml/ledger (KB-sized in practice).
- WSL runtime-home retention: 4 MiB per field.

Refuting/qualifying the prior reviewer:
- The claim "a SINGLE oversized/corrupt usage record aborts the entire scan" is inaccurate. budget.claimRecord adds only 1024 pipeline bytes + getUsageHistoryRetainedBytes([sessionId,timestamp,eventKey,cwd,model]) (a few hundred bytes) per record; one record cannot trip the 256 MiB / 100k-record ceiling. The abort is strictly cumulative across the whole scan.
- STDOUT_LINE_MAX_BYTES (1 MiB) and STDERR_TAIL_MAX_BYTES (8 KiB) in codex-app-server-session.ts are PRE-EXISTING (visible on the '-' side of the diff). The change only refactors string concatenation to GrowingByteBuffer with raw bytes, which is more correct for split multibyte UTF-8. No new cap, no normal-path change.
- Sync listCodexSessionJsonlFiles rethrows CodexSessionListingCapacityError, but the only production caller (syncSystemCodexSessionsIntoManagedHome) is not on the launch path; the launch path uses the incremental variant which catches the error and returns gracefully. No unhandled-throw crash on normal startup.

Residual risk (medium, NOT ordinary-path): the cumulative per-scan usage budget makes a heavy multi-year Codex user (~100k+ lifetime token_count records) permanently lose the usage panel (sticky scan_failed) where base degraded gracefully. This is above ordinary use but worth a human sign-off note, and the actual defaults live in a dependency slice (usage-history-scan-budget.ts) so they must land together.

### Files
65 files changed (+4362 / −865).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
