### PR TITLE
oom(17/29): bound native chat transcript & speech input

### DIFF
--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os'
 import { basename, extname, join } from 'node:path'
 import type { AgentType } from '../../shared/native-chat-types'
 import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
-import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
+import { findFirstSessionFile } from '../ai-vault/session-scanner-discovery'
 import { getOrcaManagedCodexHomePath } from '../codex/codex-home-paths'
 import {
   findGrokChatHistoryBySessionId,
@@ -102,11 +102,10 @@ async function resolveClaudeSessionFile(
   projectsDir: string
 ): Promise<string | null> {
   const targetName = `${sessionId}.jsonl`
-  const files = await walkSessionFiles(projectsDir, 'claude', [], {
+  return findFirstSessionFile(projectsDir, {
     extensions: new Set(['.jsonl']),
     filePredicate: (path) => basename(path) === targetName
   })
-  return files[0] ?? null
 }
 
 async function resolveCodexSessionFile(
@@ -120,15 +119,15 @@ async function resolveCodexSessionFile(
     if (!existsSync(sessionsDir)) {
       continue
     }
-    const files = await walkSessionFiles(sessionsDir, 'codex', [], {
+    const file = await findFirstSessionFile(sessionsDir, {
       extensions: new Set(['.jsonl']),
       filePredicate: (path) => {
         const name = basename(path, extname(path))
         return name === sessionId || name.endsWith(`-${sessionId}`)
       }
     })
-    if (files[0]) {
-      return files[0]
+    if (file) {
+      return file
     }
   }
   return null

--- a/src/main/native-chat/transcript-incremental-reader.test.ts
+++ b/src/main/native-chat/transcript-incremental-reader.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import {
+  APPEND_BATCH_RETAINED_BYTE_LIMIT,
+  createIncrementalTranscriptState,
+  readIncrementalTranscriptMessages
+} from './transcript-incremental-reader'
+import {
+  estimateTranscriptMessageRetainedBytes,
+  MAX_NATIVE_CHAT_TRANSCRIPT_MESSAGES
+} from './transcript-message-retention'
+import { transcriptFallbackId } from './transcript-fallback-id'
+import { MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES } from './transcript-tail-reader'
+
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('readIncrementalTranscriptMessages', () => {
+  it('keeps the newest shared-retention window for an initial snapshot without batching', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-transcript-incremental-'))
+    tempRoots.push(root)
+    const filePath = join(root, 'transcript.jsonl')
+    const extraMessages = 5
+    await writeFile(
+      filePath,
+      Array.from(
+        { length: MAX_NATIVE_CHAT_TRANSCRIPT_MESSAGES + extraMessages },
+        (_unused, index) => `row-${index}\n`
+      ).join('')
+    )
+    const state = createIncrementalTranscriptState()
+
+    const messages = await readIncrementalTranscriptMessages(
+      filePath,
+      state,
+      (line): NativeChatMessage => ({
+        id: line,
+        role: 'user',
+        blocks: [{ type: 'text', text: line }],
+        timestamp: null,
+        source: 'transcript'
+      })
+    )
+
+    expect(messages).toHaveLength(MAX_NATIVE_CHAT_TRANSCRIPT_MESSAGES)
+    expect(messages[0]?.id).toBe(`row-${extraMessages}`)
+    expect(messages.at(-1)?.id).toBe(
+      `row-${MAX_NATIVE_CHAT_TRANSCRIPT_MESSAGES + extraMessages - 1}`
+    )
+  })
+
+  it('flushes append batches by retained bytes before the message-count limit', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-transcript-incremental-batch-bytes-'))
+    tempRoots.push(root)
+    const filePath = join(root, 'transcript.jsonl')
+    const payload = 'x'.repeat(1024 * 1024)
+    const lines = Array.from({ length: 5 }, (_unused, index) => `row-${index}:${payload}`)
+    await writeFile(filePath, `${lines.join('\n')}\n`)
+    const state = createIncrementalTranscriptState()
+    const batches: NativeChatMessage[][] = []
+    const decode = (line: string): NativeChatMessage => ({
+      id: line.slice(0, line.indexOf(':')),
+      role: 'user',
+      blocks: [{ type: 'text', text: line }],
+      timestamp: null,
+      source: 'transcript'
+    })
+
+    const remaining = await readIncrementalTranscriptMessages(filePath, state, decode, (messages) =>
+      batches.push(messages)
+    )
+    const delivered = [...batches.flat(), ...remaining]
+
+    expect(batches.map((batch) => batch.length)).toEqual([3])
+    expect(delivered.map((message) => message.id)).toEqual(
+      Array.from({ length: 5 }, (_unused, index) => `row-${index}`)
+    )
+    for (const batch of [...batches, remaining]) {
+      const retainedBytes = batch.reduce(
+        (total, message) =>
+          total +
+          estimateTranscriptMessageRetainedBytes(
+            lines.find((line) => line.startsWith(`${message.id}:`))!.length
+          ),
+        0
+      )
+      expect(retainedBytes).toBeLessThanOrEqual(APPEND_BATCH_RETAINED_BYTE_LIMIT)
+    }
+  })
+
+  it('pauses an aggregate drain at a record boundary and resumes without gaps', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-transcript-incremental-drain-budget-'))
+    tempRoots.push(root)
+    const filePath = join(root, 'transcript.jsonl')
+    await writeFile(filePath, 'row-0\nrow-1\nrow-2\nrow-3\nrow-4\n')
+    const state = createIncrementalTranscriptState()
+    const decode = (line: string): NativeChatMessage => ({
+      id: line,
+      role: 'user',
+      blocks: [{ type: 'text', text: line }],
+      timestamp: null,
+      source: 'transcript'
+    })
+    const drain = (): Promise<NativeChatMessage[]> =>
+      readIncrementalTranscriptMessages(filePath, state, decode, () => {}, undefined, undefined, {
+        maxDrainRetainedBytes: 600
+      })
+
+    const first = await drain()
+    const firstOffset = state.offset
+    const second = await drain()
+    const third = await drain()
+
+    expect(first.map((message) => message.id)).toEqual(['row-0', 'row-1'])
+    expect(second.map((message) => message.id)).toEqual(['row-2', 'row-3'])
+    expect(third.map((message) => message.id)).toEqual(['row-4'])
+    expect(firstOffset).toBeGreaterThan(0)
+    expect(state.pendingRecord.byteLength).toBe(0)
+  })
+
+  it('advances one bounded record when the drain budget is smaller than that record', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-transcript-incremental-small-budget-'))
+    tempRoots.push(root)
+    const filePath = join(root, 'transcript.jsonl')
+    await writeFile(filePath, 'row-0\nrow-1\n')
+    const state = createIncrementalTranscriptState()
+    const decode = (line: string): NativeChatMessage => ({
+      id: line,
+      role: 'user',
+      blocks: [{ type: 'text', text: line }],
+      timestamp: null,
+      source: 'transcript'
+    })
+    const drain = (): Promise<NativeChatMessage[]> =>
+      readIncrementalTranscriptMessages(filePath, state, decode, () => {}, undefined, undefined, {
+        maxDrainRetainedBytes: 1
+      })
+
+    const first = await drain()
+    const firstOffset = state.offset
+    const second = await drain()
+    const secondOffset = state.offset
+    const exhausted = await drain()
+
+    expect(first.map((message) => message.id)).toEqual(['row-0'])
+    expect(second.map((message) => message.id)).toEqual(['row-1'])
+    expect(exhausted).toEqual([])
+    expect(firstOffset).toBeGreaterThan(0)
+    expect(secondOffset).toBeGreaterThan(firstOffset)
+  })
+
+  it('keeps the exact fallback offset after discarding an oversized record', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-transcript-incremental-oversized-'))
+    tempRoots.push(root)
+    const filePath = join(root, 'transcript.jsonl')
+    const oversized = Buffer.alloc(MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES + 1, 0x78)
+    const valid = Buffer.from('valid\n')
+    await writeFile(filePath, Buffer.concat([oversized, Buffer.from('\n'), valid]))
+    const state = createIncrementalTranscriptState()
+
+    const messages = await readIncrementalTranscriptMessages(
+      filePath,
+      state,
+      (line, fallbackId): NativeChatMessage => ({
+        id: fallbackId,
+        role: 'user',
+        blocks: [{ type: 'text', text: line }],
+        timestamp: null,
+        source: 'transcript'
+      })
+    )
+
+    expect(messages.map((message) => message.id)).toEqual([
+      transcriptFallbackId(filePath, oversized.byteLength + 1)
+    ])
+    expect(state.offset).toBe(oversized.byteLength + 1 + valid.byteLength)
+    expect(state.pendingRecord.byteLength).toBe(0)
+  })
+})

--- a/src/main/native-chat/transcript-incremental-reader.ts
+++ b/src/main/native-chat/transcript-incremental-reader.ts
@@ -1,27 +1,38 @@
 import { open, stat } from 'node:fs/promises'
 import type { NativeChatMessage, NativeChatTurnLifecycle } from '../../shared/native-chat-types'
 import { transcriptFallbackId } from './transcript-fallback-id'
+import { TranscriptRecordBuffer } from './transcript-record-buffer'
 import {
   MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES,
   type NativeChatLineDecoder
 } from './transcript-tail-reader'
+import {
+  estimateTranscriptMessageRetainedBytes,
+  TranscriptMessageRetention
+} from './transcript-message-retention'
 
-const APPEND_BATCH_MESSAGE_LIMIT = 40
+export const APPEND_BATCH_MESSAGE_LIMIT = 40
+export const APPEND_BATCH_RETAINED_BYTE_LIMIT = 8 * 1024 * 1024
+export const INCREMENTAL_DRAIN_RETAINED_BYTE_LIMIT = 32 * 1024 * 1024
 
 export type IncrementalTranscriptState = {
   offset: number
-  pendingChunks: Buffer[]
+  pendingRecord: TranscriptRecordBuffer
   pendingStart: number
-  pendingBytes: number
-  droppingOversizedRecord: boolean
+}
+
+export function createIncrementalTranscriptState(): IncrementalTranscriptState {
+  return {
+    offset: 0,
+    pendingRecord: new TranscriptRecordBuffer(MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES),
+    pendingStart: 0
+  }
 }
 
 export function resetIncrementalTranscriptState(state: IncrementalTranscriptState): void {
   state.offset = 0
-  state.pendingChunks.length = 0
+  state.pendingRecord.clear()
   state.pendingStart = 0
-  state.pendingBytes = 0
-  state.droppingOversizedRecord = false
 }
 
 export async function readIncrementalTranscriptMessages(
@@ -30,27 +41,41 @@ export async function readIncrementalTranscriptMessages(
   decode: NativeChatLineDecoder,
   onBatch?: (messages: NativeChatMessage[]) => void,
   decodeLifecycle?: (line: string, fallbackId: string) => NativeChatTurnLifecycle | null,
-  onLifecycle?: (lifecycle: NativeChatTurnLifecycle) => void
+  onLifecycle?: (lifecycle: NativeChatTurnLifecycle) => void,
+  options: { maxDrainRetainedBytes?: number } = {}
 ): Promise<NativeChatMessage[]> {
   const end = (await stat(filePath)).size
   if (end <= state.offset) {
     return []
   }
   const messages: NativeChatMessage[] = []
+  let messageBatchBytes = 0
+  let drainRetainedBytes = 0
+  const requestedDrainLimit = options.maxDrainRetainedBytes
+  const maxDrainRetainedBytes =
+    Number.isSafeInteger(requestedDrainLimit) && (requestedDrainLimit ?? 0) > 0
+      ? Math.min(INCREMENTAL_DRAIN_RETAINED_BYTE_LIMIT, requestedDrainLimit ?? 0)
+      : INCREMENTAL_DRAIN_RETAINED_BYTE_LIMIT
+  const retainedSnapshot = onBatch ? null : new TranscriptMessageRetention()
   const handle = await open(filePath, 'r')
   try {
     const stream = handle.createReadStream({ start: state.offset, end: end - 1, autoClose: false })
     let absoluteOffset = state.offset
-    for await (const rawChunk of stream) {
+    streamChunks: for await (const rawChunk of stream) {
       const chunk = Buffer.isBuffer(rawChunk) ? rawChunk : Buffer.from(rawChunk)
       let segmentStart = 0
       let newline = chunk.indexOf(0x0a)
       while (newline >= 0) {
         retainPart(chunk.subarray(segmentStart, newline))
-        if (!state.droppingOversizedRecord) {
-          decodeLine()
+        if (!state.pendingRecord.isOversized && !decodeLine()) {
+          const retryOffset = state.pendingStart
+          resetPendingLine(retryOffset)
+          state.offset = retryOffset
+          break streamChunks
         }
-        resetPendingLine(absoluteOffset + newline + 1)
+        const nextOffset = absoluteOffset + newline + 1
+        resetPendingLine(nextOffset)
+        state.offset = nextOffset
         segmentStart = newline + 1
         newline = chunk.indexOf(0x0a, segmentStart)
       }
@@ -60,51 +85,69 @@ export async function readIncrementalTranscriptMessages(
       absoluteOffset += chunk.length
       state.offset = absoluteOffset
     }
-    return messages
+    return retainedSnapshot?.values() ?? messages
   } finally {
     await handle.close()
   }
 
   function retainPart(part: Buffer): void {
-    if (state.droppingOversizedRecord) {
-      return
-    }
-    state.pendingBytes += part.length
-    if (state.pendingBytes > MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES) {
-      state.pendingChunks.length = 0
-      state.droppingOversizedRecord = true
-      return
-    }
-    state.pendingChunks.push(part)
+    state.pendingRecord.append(part)
   }
 
   function resetPendingLine(nextStart: number): void {
-    state.pendingChunks.length = 0
-    state.pendingBytes = 0
-    state.droppingOversizedRecord = false
+    state.pendingRecord.clear()
     state.pendingStart = nextStart
   }
 
-  function decodeLine(): void {
-    let line = Buffer.concat(state.pendingChunks).toString('utf8')
+  function decodeLine(): boolean {
+    let line = state.pendingRecord.toString()
     if (line.endsWith('\r')) {
       line = line.slice(0, -1)
     }
     if (!line) {
-      return
+      return true
     }
     const fallbackId = transcriptFallbackId(filePath, state.pendingStart)
+    const message = decode(line, fallbackId)
+    const estimatedBytes = message
+      ? estimateTranscriptMessageRetainedBytes(state.pendingRecord.byteLength)
+      : 0
+    if (
+      message &&
+      onBatch &&
+      drainRetainedBytes > 0 &&
+      estimatedBytes > maxDrainRetainedBytes - drainRetainedBytes
+    ) {
+      // Why: a budget below one bounded record must still advance instead of
+      // retrying that record forever.
+      return false
+    }
     const lifecycle = decodeLifecycle?.(line, fallbackId)
     if (lifecycle) {
       onLifecycle?.(lifecycle)
     }
-    const message = decode(line, fallbackId)
     if (!message) {
-      return
+      return true
+    }
+    if (retainedSnapshot) {
+      retainedSnapshot.add(message, state.pendingRecord.byteLength)
+      return true
+    }
+    drainRetainedBytes += estimatedBytes
+    if (
+      onBatch &&
+      messages.length > 0 &&
+      estimatedBytes > APPEND_BATCH_RETAINED_BYTE_LIMIT - messageBatchBytes
+    ) {
+      onBatch(messages.splice(0))
+      messageBatchBytes = 0
     }
     messages.push(message)
+    messageBatchBytes += estimatedBytes
     if (onBatch && messages.length >= APPEND_BATCH_MESSAGE_LIMIT) {
       onBatch(messages.splice(0))
+      messageBatchBytes = 0
     }
+    return true
   }
 }

--- a/src/main/native-chat/transcript-message-retention.test.ts
+++ b/src/main/native-chat/transcript-message-retention.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import {
+  MAX_NATIVE_CHAT_TRANSCRIPT_RETAINED_BYTES,
+  TranscriptMessageRetention
+} from './transcript-message-retention'
+
+function message(id: string): NativeChatMessage {
+  return {
+    id,
+    role: 'user',
+    blocks: [{ type: 'text', text: id }],
+    timestamp: null,
+    source: 'transcript'
+  }
+}
+
+describe('TranscriptMessageRetention', () => {
+  it('keeps the newest messages within both count and byte budgets', () => {
+    const retention = new TranscriptMessageRetention(2, 600)
+
+    retention.add(message('one'), 10)
+    retention.add(message('two'), 10)
+    retention.add(message('three'), 10)
+
+    expect(retention.values().map(({ id }) => id)).toEqual(['two', 'three'])
+    expect(retention.size).toBe(2)
+    expect(retention.retainedBytes).toBeLessThanOrEqual(600)
+  })
+
+  it('applies the production 64 MiB policy without retaining older oversized history', () => {
+    const retention = new TranscriptMessageRetention()
+    const sourceBytes = 2 * 1024 * 1024
+
+    for (let index = 0; index < 17; index += 1) {
+      retention.add(message(`message-${index}`), sourceBytes)
+    }
+
+    expect(retention.values().map(({ id }) => id)).toEqual(
+      Array.from({ length: 15 }, (_unused, index) => `message-${index + 2}`)
+    )
+    expect(retention.retainedBytes).toBeLessThanOrEqual(MAX_NATIVE_CHAT_TRANSCRIPT_RETAINED_BYTES)
+  })
+})

--- a/src/main/native-chat/transcript-message-retention.ts
+++ b/src/main/native-chat/transcript-message-retention.ts
@@ -1,0 +1,59 @@
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+
+export const MAX_NATIVE_CHAT_TRANSCRIPT_MESSAGES = 50_000
+export const MAX_NATIVE_CHAT_TRANSCRIPT_RETAINED_BYTES = 64 * 1024 * 1024
+
+type RetainedMessage = {
+  message: NativeChatMessage
+  estimatedBytes: number
+}
+
+export function estimateTranscriptMessageRetainedBytes(sourceBytes: number): number {
+  return sourceBytes * 2 + 256
+}
+
+export class TranscriptMessageRetention {
+  private entries: (RetainedMessage | undefined)[] = []
+  private head = 0
+  private retained = 0
+
+  constructor(
+    private readonly maxMessages = MAX_NATIVE_CHAT_TRANSCRIPT_MESSAGES,
+    private readonly maxBytes = MAX_NATIVE_CHAT_TRANSCRIPT_RETAINED_BYTES
+  ) {}
+
+  add(message: NativeChatMessage, sourceBytes: number): void {
+    const estimatedBytes = estimateTranscriptMessageRetainedBytes(sourceBytes)
+    this.entries.push({ message, estimatedBytes })
+    this.retained += estimatedBytes
+    while (this.size > this.maxMessages || this.retained > this.maxBytes) {
+      const oldest = this.entries[this.head]
+      this.entries[this.head] = undefined
+      this.head += 1
+      this.retained -= oldest?.estimatedBytes ?? 0
+    }
+    if (this.head >= 1_024 && this.head * 2 >= this.entries.length) {
+      this.entries.splice(0, this.head)
+      this.head = 0
+    }
+  }
+
+  values(): NativeChatMessage[] {
+    const messages: NativeChatMessage[] = []
+    for (let index = this.head; index < this.entries.length; index += 1) {
+      const entry = this.entries[index]
+      if (entry) {
+        messages.push(entry.message)
+      }
+    }
+    return messages
+  }
+
+  get size(): number {
+    return this.entries.length - this.head
+  }
+
+  get retainedBytes(): number {
+    return this.retained
+  }
+}

--- a/src/main/native-chat/transcript-read-admission.test.ts
+++ b/src/main/native-chat/transcript-read-admission.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { NativeChatTranscriptReadAdmission } from './transcript-read-admission'
+
+describe('NativeChatTranscriptReadAdmission', () => {
+  it('admits only reads that fit both concurrency and aggregate byte limits', async () => {
+    const admission = new NativeChatTranscriptReadAdmission(10, 2, 4)
+    const releaseSix = await admission.acquire(6)
+    const releaseFour = await admission.acquire(4)
+    let thirdAdmitted = false
+    const third = admission.acquire(1).then((release) => {
+      thirdAdmitted = true
+      return release
+    })
+
+    await Promise.resolve()
+    expect(thirdAdmitted).toBe(false)
+    expect(admission.activeCount).toBe(2)
+    expect(admission.retainedBytes).toBe(10)
+    expect(admission.queuedCount).toBe(1)
+
+    releaseFour()
+    const releaseThird = await third
+    expect(thirdAdmitted).toBe(true)
+    expect(admission.retainedBytes).toBe(7)
+
+    releaseSix()
+    releaseThird()
+    expect(admission.activeCount).toBe(0)
+    expect(admission.retainedBytes).toBe(0)
+  })
+
+  it('removes an aborted queued read and immediately reuses the slot', async () => {
+    const admission = new NativeChatTranscriptReadAdmission(10, 2, 1)
+    const releaseActive = await admission.acquire(10)
+    const controller = new AbortController()
+    const queued = admission.acquire(1, controller.signal)
+
+    expect(admission.queuedCount).toBe(1)
+    controller.abort()
+    await expect(queued).rejects.toMatchObject({ name: 'AbortError' })
+    expect(admission.queuedCount).toBe(0)
+
+    const replacement = admission.acquire(1)
+    expect(admission.queuedCount).toBe(1)
+    releaseActive()
+    const releaseReplacement = await replacement
+    releaseReplacement()
+  })
+
+  it('bounds queued closures and releases reservations idempotently', async () => {
+    const admission = new NativeChatTranscriptReadAdmission(1, 1, 2)
+    const releaseActive = await admission.acquire(1)
+    const first = admission.acquire(1)
+    const second = admission.acquire(1)
+
+    expect(() => admission.acquire(1)).toThrow('Too many queued native chat transcript reads')
+    releaseActive()
+    releaseActive()
+    const releaseFirst = await first
+    releaseFirst()
+    const releaseSecond = await second
+    releaseSecond()
+
+    expect(admission.activeCount).toBe(0)
+    expect(admission.retainedBytes).toBe(0)
+  })
+
+  it('detaches abort listeners after admission', async () => {
+    const admission = new NativeChatTranscriptReadAdmission(1, 1, 1)
+    const controller = new AbortController()
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+
+    const release = await admission.acquire(1, controller.signal)
+
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    controller.abort()
+    expect(admission.activeCount).toBe(1)
+    release()
+  })
+})

--- a/src/main/native-chat/transcript-read-admission.ts
+++ b/src/main/native-chat/transcript-read-admission.ts
@@ -1,0 +1,144 @@
+import { INCREMENTAL_DRAIN_RETAINED_BYTE_LIMIT } from './transcript-incremental-reader'
+import { MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES } from './transcript-tail-reader'
+
+export const MAX_NATIVE_CHAT_TRANSCRIPT_READ_CONCURRENCY = 8
+export const MAX_NATIVE_CHAT_TRANSCRIPT_READ_WAITERS = 256
+export const MAX_NATIVE_CHAT_TRANSCRIPT_PROCESS_RETAINED_BYTES = 128 * 1024 * 1024
+export const NATIVE_CHAT_TRANSCRIPT_PAGE_RESERVATION_BYTES =
+  MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES
+export const NATIVE_CHAT_TRANSCRIPT_WATCH_DRAIN_RESERVATION_BYTES =
+  MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES + INCREMENTAL_DRAIN_RETAINED_BYTE_LIMIT
+
+type AdmissionWaiter = {
+  abort: (() => void) | null
+  bytes: number
+  reject: (error: Error) => void
+  resolve: (release: () => void) => void
+  signal?: AbortSignal
+}
+
+function abortedReadError(): Error {
+  const error = new Error('Native chat transcript read was canceled')
+  error.name = 'AbortError'
+  return error
+}
+
+export class NativeChatTranscriptReadAdmission {
+  private activeBytes = 0
+  private activeReads = 0
+  private readonly waiters: AdmissionWaiter[] = []
+
+  constructor(
+    private readonly maxBytes = MAX_NATIVE_CHAT_TRANSCRIPT_PROCESS_RETAINED_BYTES,
+    private readonly maxActive = MAX_NATIVE_CHAT_TRANSCRIPT_READ_CONCURRENCY,
+    private readonly maxWaiters = MAX_NATIVE_CHAT_TRANSCRIPT_READ_WAITERS
+  ) {
+    if (
+      !Number.isSafeInteger(maxBytes) ||
+      maxBytes < 0 ||
+      !Number.isSafeInteger(maxActive) ||
+      maxActive < 1 ||
+      !Number.isSafeInteger(maxWaiters) ||
+      maxWaiters < 0
+    ) {
+      throw new RangeError('Invalid native chat transcript read admission limits')
+    }
+  }
+
+  acquire(bytes: number, signal?: AbortSignal): Promise<() => void> {
+    if (!Number.isSafeInteger(bytes) || bytes < 0 || bytes > this.maxBytes) {
+      throw new RangeError('Native chat transcript read exceeds the process memory budget')
+    }
+    if (signal?.aborted) {
+      return Promise.reject(abortedReadError())
+    }
+    const canAdmitImmediately =
+      this.waiters.length === 0 &&
+      this.activeReads < this.maxActive &&
+      bytes <= this.maxBytes - this.activeBytes
+    if (!canAdmitImmediately && this.waiters.length >= this.maxWaiters) {
+      throw new Error('Too many queued native chat transcript reads')
+    }
+
+    return new Promise((resolve, reject) => {
+      const waiter: AdmissionWaiter = {
+        abort: null,
+        bytes,
+        reject,
+        resolve,
+        ...(signal ? { signal } : {})
+      }
+      if (signal) {
+        waiter.abort = (): void => {
+          const index = this.waiters.indexOf(waiter)
+          if (index < 0) {
+            return
+          }
+          this.waiters.splice(index, 1)
+          signal.removeEventListener('abort', waiter.abort!)
+          waiter.abort = null
+          reject(abortedReadError())
+          this.admitWaiters()
+        }
+        signal.addEventListener('abort', waiter.abort, { once: true })
+      }
+      this.waiters.push(waiter)
+      this.admitWaiters()
+    })
+  }
+
+  get activeCount(): number {
+    return this.activeReads
+  }
+
+  get queuedCount(): number {
+    return this.waiters.length
+  }
+
+  get retainedBytes(): number {
+    return this.activeBytes
+  }
+
+  private admitWaiters(): void {
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters[0]
+      if (this.activeReads >= this.maxActive || waiter.bytes > this.maxBytes - this.activeBytes) {
+        return
+      }
+      this.waiters.shift()
+      if (waiter.signal && waiter.abort) {
+        waiter.signal.removeEventListener('abort', waiter.abort)
+        waiter.abort = null
+      }
+      this.activeReads += 1
+      this.activeBytes += waiter.bytes
+      let released = false
+      waiter.resolve(() => {
+        if (released) {
+          return
+        }
+        released = true
+        this.activeReads -= 1
+        this.activeBytes -= waiter.bytes
+        this.admitWaiters()
+      })
+    }
+  }
+}
+
+export const nativeChatTranscriptReadAdmission = new NativeChatTranscriptReadAdmission()
+
+export async function withNativeChatTranscriptWatchDrainAdmission<T>(
+  signal: AbortSignal,
+  run: () => Promise<T>
+): Promise<T> {
+  const release = await nativeChatTranscriptReadAdmission.acquire(
+    NATIVE_CHAT_TRANSCRIPT_WATCH_DRAIN_RESERVATION_BYTES,
+    signal
+  )
+  try {
+    return await run()
+  } finally {
+    release()
+  }
+}

--- a/src/main/native-chat/transcript-read-cache.ts
+++ b/src/main/native-chat/transcript-read-cache.ts
@@ -13,9 +13,8 @@ import { readNativeChatTranscript, type ReadTranscriptResult } from './transcrip
 // share one sessionId yet resolve to DIFFERENT files (the same session resumed
 // into a second worktree, which writes a new transcript file), and a
 // sessionId-only key let one worktree's cached parse be served to another when
-// their file mtimes momentarily coincided (#7326). The cache stores ONE
-// canonical, unwindowed parse; windowing and per-surface truncation stay in the
-// callers so the same parse is reused across all `limit` values and every client kind.
+// their file mtimes momentarily coincided (#7326). The cache stores one
+// canonical bounded parse; surface-specific windowing stays in callers.
 
 type CachedTranscript = {
   result: ReadTranscriptResult
@@ -34,7 +33,7 @@ const cache = new Map<string, CachedTranscript>()
 const MAX_CACHE_ENTRIES = 50
 // Why: a heavy Claude/Codex coding session's JSONL is routinely tens of MB (tool
 // results embed whole file contents, command output, and diffs), and each cached
-// entry is the full unwindowed parse. The count cap alone let 50 such entries
+// entry is a large bounded parse. The count cap alone let 50 such entries
 // retain multiple GB in the one process that now serves desktop + every paired
 // web/mobile client. Bound total cached file bytes too; we always keep the most-
 // recent entry (see setCached) so an active transcript is never re-parsed on
@@ -79,9 +78,7 @@ async function fileStat(filePath: string): Promise<{ mtimeMs: number; bytes: num
 }
 
 /**
- * Read the full transcript for an agent + session, returning the cached parse on
- * an mtime hit and re-reading (and re-caching) when the file changed. Returns the
- * canonical, unwindowed result; callers apply their own windowing/truncation.
+ * Read the canonical bounded transcript for a session, refreshing on file changes.
  */
 export async function readNativeChatTranscriptCached(
   agent: AgentType,

--- a/src/main/native-chat/transcript-reader.test.ts
+++ b/src/main/native-chat/transcript-reader.test.ts
@@ -2,8 +2,10 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../shared/native-chat-types'
 import { readNativeChatTranscript } from './transcript-reader'
 import {
+  MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES,
   nativeChatLineDecoderForAgent,
   readNativeChatTranscriptTail,
   readNativeChatTranscriptTailFile
@@ -331,5 +333,42 @@ describe('readNativeChatTranscriptTailFile', () => {
 
     expect(result.messages).toEqual([])
     expect(result.hasMore).toBe(false)
+  })
+
+  it('preserves the newest messages and a correct pagination boundary at the page byte cap', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-native-chat-tail-page-bytes-'))
+    tempRoots.push(root)
+    const filePath = join(root, 'transcript.jsonl')
+    const payload = 'x'.repeat(1024 * 1024)
+    const ids = Array.from({ length: 10 }, (_unused, index) => `message-${index}`)
+    await writeFile(filePath, ids.map((id) => `${id}:${payload}\n`).join(''))
+    const decode = (line: string): NativeChatMessage => {
+      const id = line.slice(0, line.indexOf(':'))
+      return {
+        id,
+        role: 'user',
+        blocks: [{ type: 'text', text: line }],
+        timestamp: null,
+        source: 'transcript'
+      }
+    }
+
+    const newest = await readNativeChatTranscriptTailFile(filePath, 100, decode, true)
+    const older = await readNativeChatTranscriptTailFile(
+      filePath,
+      100,
+      decode,
+      true,
+      newest.beforeOffset
+    )
+
+    expect(newest.hasMore).toBe(true)
+    expect(newest.messages.length).toBeGreaterThan(0)
+    expect(newest.messages.length).toBeLessThan(ids.length)
+    expect(newest.messages.at(-1)?.id).toBe(ids.at(-1))
+    expect([...older.messages, ...newest.messages].map((message) => message.id)).toEqual(ids)
+    expect(newest.messages.length * (payload.length * 2 + 256)).toBeLessThanOrEqual(
+      MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES
+    )
   })
 })

--- a/src/main/native-chat/transcript-reader.ts
+++ b/src/main/native-chat/transcript-reader.ts
@@ -28,13 +28,7 @@ export type ReadTranscriptOptions = ResolveSessionFileOptions & {
   filePath?: string
 }
 
-/**
- * Read the ENTIRE Claude/Codex JSONL transcript for an agent + session id into
- * the NativeChatMessage model. Unlike the AI-Vault preview scan, this applies
- * NO message cap. Unknown record types are skipped rather than throwing, so a
- * single malformed/unrecognized line cannot fail the whole read. The per-line
- * record-to-message mapping is shared with the live tailer.
- */
+/** Reads the newest bounded transcript window; malformed records are skipped. */
 export async function readNativeChatTranscript(
   agent: AgentType,
   sessionId: string,

--- a/src/main/native-chat/transcript-record-buffer.test.ts
+++ b/src/main/native-chat/transcript-record-buffer.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { TranscriptRecordBuffer } from './transcript-record-buffer'
+
+describe('TranscriptRecordBuffer', () => {
+  it('preserves UTF-8 across 100,000 one-byte fragments', () => {
+    const expected = Buffer.from(`${'a'.repeat(99_996)}😀`)
+    const record = new TranscriptRecordBuffer(expected.byteLength)
+
+    for (const byte of expected) {
+      record.append(Uint8Array.of(byte))
+    }
+
+    expect(record.byteLength).toBe(expected.byteLength)
+    expect(record.toString()).toBe(expected.toString())
+    expect(record.isOversized).toBe(false)
+  })
+
+  it('drops retained storage at the byte cap while tracking the full record length', () => {
+    const record = new TranscriptRecordBuffer(4)
+
+    record.append(Buffer.from('1234'))
+    record.append(Buffer.from('56789'))
+    record.append(Buffer.from('abc'))
+
+    expect(record.byteLength).toBe(12)
+    expect(record.toString()).toBe('')
+    expect(record.isOversized).toBe(true)
+
+    record.clear()
+    record.append(Buffer.from('ok'))
+    expect(record.toString()).toBe('ok')
+  })
+})

--- a/src/main/native-chat/transcript-record-buffer.ts
+++ b/src/main/native-chat/transcript-record-buffer.ts
@@ -1,0 +1,44 @@
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
+
+export class TranscriptRecordBuffer {
+  private readonly retained = new GrowingByteBuffer()
+  private observedBytes = 0
+  private oversized = false
+
+  constructor(private readonly maxRetainedBytes: number) {
+    if (!Number.isSafeInteger(maxRetainedBytes) || maxRetainedBytes < 0) {
+      throw new RangeError('Transcript record limit must be a non-negative safe integer')
+    }
+  }
+
+  append(part: Buffer | Uint8Array): void {
+    this.observedBytes += part.byteLength
+    if (this.oversized) {
+      return
+    }
+    if (this.observedBytes > this.maxRetainedBytes) {
+      this.retained.clear()
+      this.oversized = true
+      return
+    }
+    this.retained.append(part)
+  }
+
+  clear(): void {
+    this.retained.clear()
+    this.observedBytes = 0
+    this.oversized = false
+  }
+
+  toString(): string {
+    return this.retained.toString('utf8')
+  }
+
+  get byteLength(): number {
+    return this.observedBytes
+  }
+
+  get isOversized(): boolean {
+    return this.oversized
+  }
+}

--- a/src/main/native-chat/transcript-stream-lines.test.ts
+++ b/src/main/native-chat/transcript-stream-lines.test.ts
@@ -1,6 +1,8 @@
 import { Readable } from 'node:stream'
 import { describe, expect, it } from 'vitest'
+import { transcriptFallbackId } from './transcript-fallback-id'
 import { decodeTranscriptStream } from './transcript-stream-lines'
+import { MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES } from './transcript-tail-reader'
 
 const decode = (line: string, id: string) => ({
   id,
@@ -45,5 +47,53 @@ describe('decodeTranscriptStream', () => {
 
     expect(result.messages).toHaveLength(1)
     expect(result.consumedBytes).toBe(Buffer.byteLength(complete, 'utf8'))
+  })
+
+  it('preserves multibyte UTF-8 split across one-byte stream chunks', async () => {
+    const line = `prefix-😀-suffix`
+    const encoded = Buffer.from(`${line}\n`)
+    const result = await decodeTranscriptStream(
+      Readable.from([...encoded].map((byte) => Uint8Array.of(byte))),
+      '/chat.jsonl',
+      0,
+      decode,
+      false
+    )
+
+    expect(result.messages[0]?.blocks).toEqual([{ type: 'text', text: line }])
+    expect(result.consumedBytes).toBe(encoded.byteLength)
+  })
+
+  it('drops an oversized record without retaining it or losing the next line', async () => {
+    const oversized = 'x'.repeat(MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES + 1)
+    const valid = '{"valid":true}'
+    const result = await decodeTranscriptStream(
+      Readable.from([oversized, `\n${valid}\n`]),
+      '/chat.jsonl',
+      0,
+      decode,
+      true
+    )
+
+    expect(result.messages).toHaveLength(1)
+    expect(result.messages[0]?.blocks).toEqual([{ type: 'text', text: valid }])
+    expect(result.messages[0]?.id).toBe(
+      transcriptFallbackId('/chat.jsonl', Buffer.byteLength(`${oversized}\n`, 'utf8'))
+    )
+    expect(result.consumedBytes).toBe(Buffer.byteLength(`${oversized}\n${valid}\n`, 'utf8'))
+  })
+
+  it('consumes an oversized trailing record when trailing lines are included', async () => {
+    const oversized = 'x'.repeat(MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES + 1)
+    const result = await decodeTranscriptStream(
+      Readable.from([oversized]),
+      '/chat.jsonl',
+      0,
+      decode,
+      true
+    )
+
+    expect(result.messages).toEqual([])
+    expect(result.consumedBytes).toBe(Buffer.byteLength(oversized, 'utf8'))
   })
 })

--- a/src/main/native-chat/transcript-stream-lines.ts
+++ b/src/main/native-chat/transcript-stream-lines.ts
@@ -1,6 +1,9 @@
 import type { Readable } from 'node:stream'
 import type { NativeChatMessage } from '../../shared/native-chat-types'
 import { transcriptFallbackId } from './transcript-fallback-id'
+import { TranscriptRecordBuffer } from './transcript-record-buffer'
+import { MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES } from './transcript-tail-reader'
+import { TranscriptMessageRetention } from './transcript-message-retention'
 
 type TranscriptDecoder = (line: string, fallbackId: string) => NativeChatMessage | null
 
@@ -11,28 +14,42 @@ export async function decodeTranscriptStream(
   decode: TranscriptDecoder,
   includeTrailingLine: boolean
 ): Promise<{ messages: NativeChatMessage[]; consumedBytes: number }> {
-  const messages: NativeChatMessage[] = []
-  let pending = ''
+  const messages = new TranscriptMessageRetention()
+  const pending = new TranscriptRecordBuffer(MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES)
   let consumedBytes = 0
 
   for await (const chunk of stream) {
-    pending += typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
-    let newlineIndex = pending.indexOf('\n')
+    const bytes =
+      typeof chunk === 'string'
+        ? Buffer.from(chunk, 'utf8')
+        : Buffer.isBuffer(chunk)
+          ? chunk
+          : Buffer.from(chunk)
+    let segmentStart = 0
+    let newlineIndex = bytes.indexOf(0x0a)
     while (newlineIndex !== -1) {
-      const segment = pending.slice(0, newlineIndex + 1)
-      decodeLine(segment.slice(0, -1), consumedBytes)
-      consumedBytes += Buffer.byteLength(segment, 'utf8')
-      pending = pending.slice(newlineIndex + 1)
-      newlineIndex = pending.indexOf('\n')
+      pending.append(bytes.subarray(segmentStart, newlineIndex))
+      if (!pending.isOversized) {
+        decodeLine(pending.toString(), consumedBytes)
+      }
+      consumedBytes += pending.byteLength + 1
+      pending.clear()
+      segmentStart = newlineIndex + 1
+      newlineIndex = bytes.indexOf(0x0a, segmentStart)
+    }
+    if (segmentStart < bytes.length) {
+      pending.append(bytes.subarray(segmentStart))
     }
   }
 
-  if (includeTrailingLine && pending.length > 0) {
-    decodeLine(pending, consumedBytes)
-    consumedBytes += Buffer.byteLength(pending, 'utf8')
+  if (includeTrailingLine && pending.byteLength > 0) {
+    if (!pending.isOversized) {
+      decodeLine(pending.toString(), consumedBytes)
+    }
+    consumedBytes += pending.byteLength
   }
 
-  return { messages, consumedBytes }
+  return { messages: messages.values(), consumedBytes }
 
   function decodeLine(rawLine: string, relativeOffset: number): void {
     const line = rawLine.endsWith('\r') ? rawLine.slice(0, -1) : rawLine
@@ -41,7 +58,7 @@ export async function decodeTranscriptStream(
     }
     const message = decode(line, transcriptFallbackId(filePath, start + relativeOffset))
     if (message) {
-      messages.push(message)
+      messages.add(message, Buffer.byteLength(line, 'utf8'))
     }
   }
 }

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -16,8 +16,10 @@ import {
   nativeChatTurnLifecycleDecoderForAgent,
   type NativeChatTurnLifecycleDecoder
 } from './transcript-turn-lifecycle'
+import { estimateTranscriptMessageRetainedBytes } from './transcript-message-retention'
 
 export const MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES = 2 * 1024 * 1024
+export const MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES = 16 * 1024 * 1024
 const TAIL_CHUNK_BYTES = 64 * 1024
 
 export type NativeChatLineDecoder = (line: string, fallbackId: string) => NativeChatMessage | null
@@ -59,6 +61,8 @@ export async function readNativeChatTranscriptTailFile(
   let lineBytes = 0
   let lineOversized = false
   let lifecycle: NativeChatTurnLifecycle | undefined
+  let retainedMessageBytes = 0
+  let pageBudgetReached = false
   try {
     const consumedTo = includeTrailingLine ? end : await findLastCompleteLineEnd(handle, end)
     if (consumedTo === 0) {
@@ -68,12 +72,16 @@ export async function readNativeChatTranscriptTailFile(
     const finalByte = Buffer.allocUnsafe(1)
     await handle.read(finalByte, 0, 1, consumedTo - 1)
     let cursor = consumedTo - (finalByte[0] === 0x0a ? 1 : 0)
-    while (cursor > 0 && newestFirst.length <= limit) {
+    while (cursor > 0 && newestFirst.length <= limit && !pageBudgetReached) {
       const start = Math.max(0, cursor - TAIL_CHUNK_BYTES)
       const buffer = Buffer.allocUnsafe(cursor - start)
       const { bytesRead } = await handle.read(buffer, 0, buffer.length, start)
       let segmentEnd = bytesRead
-      for (let index = bytesRead - 1; index >= 0 && newestFirst.length <= limit; index--) {
+      for (
+        let index = bytesRead - 1;
+        index >= 0 && newestFirst.length <= limit && !pageBudgetReached;
+        index--
+      ) {
         if (buffer[index] !== 0x0a) {
           continue
         }
@@ -89,7 +97,7 @@ export async function readNativeChatTranscriptTailFile(
       }
       cursor = start
     }
-    if (cursor === 0 && lineParts.length > 0 && newestFirst.length <= limit) {
+    if (cursor === 0 && lineParts.length > 0 && newestFirst.length <= limit && !pageBudgetReached) {
       decodeLine(0, newestFirst)
     }
     const chronological = newestFirst.toReversed()
@@ -100,7 +108,7 @@ export async function readNativeChatTranscriptTailFile(
       messages: selected.map((entry) => entry.message),
       ...(lifecycle ? { lifecycle } : {}),
       consumedTo,
-      hasMore: limit > 0 && chronological.length > limit,
+      hasMore: limit > 0 && (chronological.length > limit || pageBudgetReached),
       beforeOffset: selected[0]?.offset ?? end
     }
   } finally {
@@ -144,6 +152,12 @@ export async function readNativeChatTranscriptTailFile(
     lifecycle ??= decodeLifecycle?.(line, fallbackId) ?? undefined
     const message = decode(line, fallbackId)
     if (message) {
+      const estimatedBytes = estimateTranscriptMessageRetainedBytes(lineBytes)
+      if (estimatedBytes > MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES - retainedMessageBytes) {
+        pageBudgetReached = true
+        return
+      }
+      retainedMessageBytes += estimatedBytes
       messages.push({ message, offset: lineOffset })
     }
   }

--- a/src/main/native-chat/transcript-watch-drain-admission.test.ts
+++ b/src/main/native-chat/transcript-watch-drain-admission.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as TranscriptTailReader from './transcript-tail-reader'
+
+const { tailRead } = vi.hoisted(() => ({ tailRead: vi.fn() }))
+
+vi.mock('./transcript-tail-reader', async () => {
+  const actual = await vi.importActual<typeof TranscriptTailReader>('./transcript-tail-reader')
+  return { ...actual, readNativeChatTranscriptTailFile: tailRead }
+})
+
+import { nativeChatTranscriptReadAdmission } from './transcript-read-admission'
+import { getActiveNativeChatWatcherCount, subscribeNativeChatTranscript } from './transcript-watch'
+import type { NativeChatTranscriptSubscription } from './transcript-watch-contract'
+
+let root: string | null = null
+const subscriptions: NativeChatTranscriptSubscription[] = []
+
+afterEach(async () => {
+  for (const subscription of subscriptions.splice(0)) {
+    subscription.unsubscribe()
+  }
+  await vi.waitFor(() => expect(nativeChatTranscriptReadAdmission.activeCount).toBe(0))
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+    root = null
+  }
+})
+
+describe('native chat transcript watcher drain admission', () => {
+  it('removes a queued drain immediately when its watcher unsubscribes', async () => {
+    root = await mkdtemp(join(tmpdir(), 'orca-native-chat-drain-admission-'))
+    const filePath = join(root, 'transcript.jsonl')
+    await writeFile(filePath, '{}\n')
+    let finishReads!: () => void
+    const readGate = new Promise<{
+      messages: never[]
+      consumedTo: number
+      hasMore: boolean
+      beforeOffset: number
+    }>((resolve) => {
+      finishReads = () => resolve({ messages: [], consumedTo: 3, hasMore: false, beforeOffset: 0 })
+    })
+    tailRead.mockReturnValue(readGate)
+    const activeBefore = getActiveNativeChatWatcherCount()
+
+    for (let index = 0; index < 3; index++) {
+      subscriptions.push(
+        await subscribeNativeChatTranscript({
+          agent: 'claude',
+          sessionId: `session-${index}`,
+          filePath,
+          initialLimit: 40,
+          onInitialSnapshot: () => {},
+          onAppend: () => {},
+          debounceMs: 0,
+          reconciliationIntervalMs: 10_000
+        })
+      )
+    }
+    await vi.waitFor(() => {
+      expect(nativeChatTranscriptReadAdmission.activeCount).toBe(2)
+      expect(nativeChatTranscriptReadAdmission.queuedCount).toBe(1)
+    })
+
+    subscriptions.pop()?.unsubscribe()
+
+    await vi.waitFor(() => expect(nativeChatTranscriptReadAdmission.queuedCount).toBe(0))
+    expect(getActiveNativeChatWatcherCount()).toBe(activeBefore + 2)
+
+    finishReads()
+    await vi.waitFor(() => expect(nativeChatTranscriptReadAdmission.activeCount).toBe(0))
+  })
+})

--- a/src/main/native-chat/transcript-watch-engine.ts
+++ b/src/main/native-chat/transcript-watch-engine.ts
@@ -6,11 +6,12 @@ import {
   type TranscriptFileVersion
 } from './transcript-file-version'
 import {
+  createIncrementalTranscriptState,
   readIncrementalTranscriptMessages,
-  resetIncrementalTranscriptState,
-  type IncrementalTranscriptState
+  resetIncrementalTranscriptState
 } from './transcript-incremental-reader'
 import { createTranscriptNativeWatcher } from './transcript-native-watcher'
+import { withNativeChatTranscriptWatchDrainAdmission } from './transcript-read-admission'
 import { readNativeChatTranscriptTailFile } from './transcript-tail-reader'
 import { nativeChatTurnLifecycleDecoderForAgent } from './transcript-turn-lifecycle'
 import type {
@@ -61,13 +62,7 @@ export async function installTranscriptWatcher(
   const { onAppend, onInitialSnapshot, onReplace, initialLimit } = args
   const decodeLifecycle = nativeChatTurnLifecycleDecoderForAgent(args.agent)
 
-  const state: IncrementalTranscriptState = {
-    offset: 0,
-    pendingChunks: [],
-    pendingStart: 0,
-    pendingBytes: 0,
-    droppingOversizedRecord: false
-  }
+  const state = createIncrementalTranscriptState()
   let watchedVersion: TranscriptFileVersion | null = null
   let watchedBoundary = ''
   let initialDrain = true
@@ -78,6 +73,7 @@ export async function installTranscriptWatcher(
   let reading = false
   let pendingReadRequested = false
   let rotationRetryCount = 0
+  const drainController = new AbortController()
 
   function scheduleRotationRetry(): void {
     if (closed) {
@@ -134,7 +130,7 @@ export async function installTranscriptWatcher(
     scheduleRotationRetry()
   }
 
-  async function drainOnce(): Promise<void> {
+  async function drainOnceAdmitted(): Promise<void> {
     const current = await readTranscriptFileVersion(filePath)
     const currentBoundary = await boundaryFingerprint(filePath, state.offset)
     if (closed) {
@@ -239,6 +235,14 @@ export async function installTranscriptWatcher(
     await finishSuccessfulDrain(current)
   }
 
+  async function drainOnce(): Promise<void> {
+    await withNativeChatTranscriptWatchDrainAdmission(drainController.signal, async () => {
+      if (!closed) {
+        await drainOnceAdmitted()
+      }
+    })
+  }
+
   async function drain(): Promise<void> {
     if (closed) {
       return
@@ -317,6 +321,7 @@ export async function installTranscriptWatcher(
         return
       }
       closed = true
+      drainController.abort()
       scheduler.dispose()
       nativeWatcher.dispose()
       activeWatcherCount--

--- a/src/main/speech/model-cache-path-bounds.test.ts
+++ b/src/main/speech/model-cache-path-bounds.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { migrateSpeechModelCacheIfNeeded } from './model-cache-path'
+
+describe('speech model cache migration bounds', () => {
+  const cleanupPaths: string[] = []
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await Promise.all(
+      cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true }))
+    )
+  })
+
+  async function createMigrationDirs(): Promise<{ sourceDir: string; targetDir: string }> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-speech-migration-'))
+    cleanupPaths.push(root)
+    const sourceDir = join(root, 'source')
+    const targetDir = join(root, 'target')
+    await Promise.all([
+      mkdir(sourceDir, { recursive: true }),
+      mkdir(targetDir, { recursive: true })
+    ])
+    return { sourceDir, targetDir }
+  }
+
+  it('copies every entry at the exact count limit', async () => {
+    const { sourceDir, targetDir } = await createMigrationDirs()
+    await Promise.all([
+      writeFile(join(sourceDir, 'encoder.onnx'), 'encoder'),
+      writeFile(join(sourceDir, 'tokens.txt'), 'tokens')
+    ])
+
+    await migrateSpeechModelCacheIfNeeded(sourceDir, targetDir, { maxEntries: 2 })
+
+    expect((await readdir(targetDir)).sort()).toEqual(['encoder.onnx', 'tokens.txt'])
+  })
+
+  it('stops before copying the first entry over the count limit', async () => {
+    const { sourceDir, targetDir } = await createMigrationDirs()
+    await Promise.all([
+      writeFile(join(sourceDir, 'encoder.onnx'), 'encoder'),
+      writeFile(join(sourceDir, 'decoder.onnx'), 'decoder'),
+      writeFile(join(sourceDir, 'tokens.txt'), 'tokens')
+    ])
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await migrateSpeechModelCacheIfNeeded(sourceDir, targetDir, { maxEntries: 2 })
+
+    expect(await readdir(targetDir)).toHaveLength(2)
+    expect(warn).toHaveBeenCalledWith(
+      '[speech] Failed to migrate speech model cache to ASCII path:',
+      expect.objectContaining({ message: expect.stringContaining('exceeded 2 entries') })
+    )
+  })
+
+  it('stops traversal beyond the configured depth', async () => {
+    const { sourceDir, targetDir } = await createMigrationDirs()
+    await mkdir(join(sourceDir, 'model', 'nested'), { recursive: true })
+    await writeFile(join(sourceDir, 'model', 'nested', 'encoder.onnx'), 'encoder')
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await migrateSpeechModelCacheIfNeeded(sourceDir, targetDir, { maxDepth: 2 })
+
+    await expect(readFile(join(targetDir, 'model', 'nested', 'encoder.onnx'))).rejects.toThrow()
+    expect(warn).toHaveBeenCalledWith(
+      '[speech] Failed to migrate speech model cache to ASCII path:',
+      expect.objectContaining({ message: expect.stringContaining('exceeded depth 2') })
+    )
+  })
+
+  it('accepts the exact visited-path byte budget and rejects one byte less', async () => {
+    const exact = await createMigrationDirs()
+    await writeFile(join(exact.sourceDir, 'tokens.txt'), 'tokens')
+    const exactBytes =
+      Buffer.byteLength(join(exact.sourceDir, 'tokens.txt'), 'utf8') +
+      Buffer.byteLength(join(exact.targetDir, 'tokens.txt'), 'utf8')
+
+    await migrateSpeechModelCacheIfNeeded(exact.sourceDir, exact.targetDir, {
+      maxVisitedPathBytes: exactBytes
+    })
+    await expect(readFile(join(exact.targetDir, 'tokens.txt'), 'utf8')).resolves.toBe('tokens')
+
+    const overflow = await createMigrationDirs()
+    await writeFile(join(overflow.sourceDir, 'tokens.txt'), 'tokens')
+    const overflowBytes =
+      Buffer.byteLength(join(overflow.sourceDir, 'tokens.txt'), 'utf8') +
+      Buffer.byteLength(join(overflow.targetDir, 'tokens.txt'), 'utf8')
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await migrateSpeechModelCacheIfNeeded(overflow.sourceDir, overflow.targetDir, {
+      maxVisitedPathBytes: overflowBytes - 1
+    })
+    await expect(readFile(join(overflow.targetDir, 'tokens.txt'))).rejects.toThrow()
+  })
+
+  it('keeps an existing target file unchanged', async () => {
+    const { sourceDir, targetDir } = await createMigrationDirs()
+    await writeFile(join(sourceDir, 'tokens.txt'), 'source')
+    await writeFile(join(targetDir, 'tokens.txt'), 'existing')
+
+    await migrateSpeechModelCacheIfNeeded(sourceDir, targetDir)
+
+    await expect(readFile(join(targetDir, 'tokens.txt'), 'utf8')).resolves.toBe('existing')
+  })
+})

--- a/src/main/speech/model-cache-path.ts
+++ b/src/main/speech/model-cache-path.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { cp, mkdir, readdir, rename, stat } from 'node:fs/promises'
+import { cp, mkdir, opendir, rename, stat } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 
 export type SpeechModelCacheDir = {
@@ -9,6 +9,72 @@ export type SpeechModelCacheDir = {
 }
 
 const WINDOWS_SAFE_CACHE_HASH_LENGTH = 16
+export const SPEECH_MODEL_CACHE_MIGRATION_MAX_ENTRIES = 16_384
+export const SPEECH_MODEL_CACHE_MIGRATION_MAX_DEPTH = 16
+export const SPEECH_MODEL_CACHE_MIGRATION_MAX_VISITED_PATH_BYTES = 16 * 1024 * 1024
+
+export type SpeechModelCacheMigrationLimits = {
+  maxEntries: number
+  maxDepth: number
+  maxVisitedPathBytes: number
+}
+
+class SpeechModelCacheMigrationBudget {
+  private entries = 0
+  private visitedPathBytes = 0
+  private readonly limits: SpeechModelCacheMigrationLimits
+
+  constructor(requested: Partial<SpeechModelCacheMigrationLimits>) {
+    this.limits = {
+      maxEntries: resolveMigrationLimit(
+        requested.maxEntries,
+        SPEECH_MODEL_CACHE_MIGRATION_MAX_ENTRIES,
+        'maxEntries'
+      ),
+      maxDepth: resolveMigrationLimit(
+        requested.maxDepth,
+        SPEECH_MODEL_CACHE_MIGRATION_MAX_DEPTH,
+        'maxDepth'
+      ),
+      maxVisitedPathBytes: resolveMigrationLimit(
+        requested.maxVisitedPathBytes,
+        SPEECH_MODEL_CACHE_MIGRATION_MAX_VISITED_PATH_BYTES,
+        'maxVisitedPathBytes'
+      )
+    }
+  }
+
+  claim(sourcePath: string, targetPath: string, depth: number): void {
+    if (depth > this.limits.maxDepth) {
+      throw new Error(`Speech model cache migration exceeded depth ${this.limits.maxDepth}`)
+    }
+    this.entries += 1
+    if (this.entries > this.limits.maxEntries) {
+      throw new Error(`Speech model cache migration exceeded ${this.limits.maxEntries} entries`)
+    }
+    this.visitedPathBytes +=
+      Buffer.byteLength(sourcePath, 'utf8') + Buffer.byteLength(targetPath, 'utf8')
+    if (this.visitedPathBytes > this.limits.maxVisitedPathBytes) {
+      throw new Error(
+        `Speech model cache migration exceeded ${this.limits.maxVisitedPathBytes} visited path bytes`
+      )
+    }
+  }
+}
+
+function resolveMigrationLimit(
+  requested: number | undefined,
+  maximum: number,
+  name: string
+): number {
+  if (requested === undefined) {
+    return maximum
+  }
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+  return Math.min(requested, maximum)
+}
 
 function hasNonAsciiCharacters(value: string): boolean {
   for (const character of value) {
@@ -65,12 +131,24 @@ export function getSpeechModelCacheDirCandidates(
   return [...candidates, { modelsDir: requestedModelsDir, migrationSourceDir: null }]
 }
 
-async function copyMissingCacheEntry(sourcePath: string, targetPath: string): Promise<void> {
+async function copyMissingCacheEntry(
+  sourcePath: string,
+  targetPath: string,
+  depth: number,
+  budget: SpeechModelCacheMigrationBudget
+): Promise<void> {
+  budget.claim(sourcePath, targetPath, depth)
   const sourceStat = await stat(sourcePath)
   if (sourceStat.isDirectory()) {
     await mkdir(targetPath, { recursive: true })
-    for (const entry of await readdir(sourcePath, { withFileTypes: true })) {
-      await copyMissingCacheEntry(join(sourcePath, entry.name), join(targetPath, entry.name))
+    const directory = await opendir(sourcePath, { bufferSize: 32 })
+    for await (const entry of directory) {
+      await copyMissingCacheEntry(
+        join(sourcePath, entry.name),
+        join(targetPath, entry.name),
+        depth + 1,
+        budget
+      )
     }
     return
   }
@@ -88,15 +166,23 @@ async function copyMissingCacheEntry(sourcePath: string, targetPath: string): Pr
 
 export async function migrateSpeechModelCacheIfNeeded(
   sourceDir: string | null,
-  targetDir: string
+  targetDir: string,
+  limits: Partial<SpeechModelCacheMigrationLimits> = {}
 ): Promise<void> {
   if (!sourceDir || resolve(sourceDir) === resolve(targetDir) || !existsSync(sourceDir)) {
     return
   }
 
   try {
-    for (const entry of await readdir(sourceDir, { withFileTypes: true })) {
-      await copyMissingCacheEntry(join(sourceDir, entry.name), join(targetDir, entry.name))
+    const budget = new SpeechModelCacheMigrationBudget(limits)
+    const directory = await opendir(sourceDir, { bufferSize: 32 })
+    for await (const entry of directory) {
+      await copyMissingCacheEntry(
+        join(sourceDir, entry.name),
+        join(targetDir, entry.name),
+        1,
+        budget
+      )
     }
   } catch (error) {
     console.warn('[speech] Failed to migrate speech model cache to ASCII path:', error)

--- a/src/main/speech/model-manager.test.ts
+++ b/src/main/speech/model-manager.test.ts
@@ -5,6 +5,7 @@ import { dirname, join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SPEECH_MODEL_CATALOG } from './model-catalog'
 import { ModelManager } from './model-manager'
+import { SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES } from './speech-model-extraction-stderr'
 
 const { hasOpenAiSpeechApiKeyMock, netRequestMock, spawnMock } = vi.hoisted(() => ({
   hasOpenAiSpeechApiKeyMock: vi.fn(),
@@ -449,6 +450,61 @@ describe('ModelManager', () => {
       expect(child.kill).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('surfaces bounded prefix and tail evidence when tar stderr is oversized', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-model-manager-'))
+    try {
+      const handlers: Record<string, ((arg?: unknown) => void)[]> = {
+        close: [],
+        error: []
+      }
+      const stderrHandlers: ((chunk: Buffer) => void)[] = []
+      const child = {
+        stderr: {
+          on: vi.fn((_event: string, cb: (chunk: Buffer) => void) => {
+            stderrHandlers.push(cb)
+            return child.stderr
+          }),
+          off: vi.fn((_event: string, cb: (chunk: Buffer) => void) => {
+            const index = stderrHandlers.indexOf(cb)
+            if (index !== -1) {
+              stderrHandlers.splice(index, 1)
+            }
+            return child.stderr
+          })
+        },
+        kill: vi.fn(),
+        on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+          handlers[event]?.push(cb)
+          return child
+        }),
+        off: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+          handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+          return child
+        })
+      }
+      spawnMock.mockReturnValue(child)
+      const manager = new ModelManager(dir) as unknown as ModelManagerInternals
+      const extraction = manager.extractArchive(join(dir, 'model.tar.bz2'), dir, 'm', () => false)
+      stderrHandlers[0](
+        Buffer.concat([
+          Buffer.from('PREFIX'),
+          Buffer.alloc(SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES * 2, 0x78),
+          Buffer.from('TAIL')
+        ])
+      )
+      handlers.close[0](2)
+
+      await expect(extraction).rejects.toThrow(
+        /tar exited with code 2: PREFIX[\s\S]+stderr bytes omitted[\s\S]+TAIL$/
+      )
+      expect(stderrHandlers).toHaveLength(0)
+      expect(handlers.close).toHaveLength(0)
+      expect(handlers.error).toHaveLength(0)
+    } finally {
       rmSync(dir, { recursive: true, force: true })
     }
   })

--- a/src/main/speech/model-manager.ts
+++ b/src/main/speech/model-manager.ts
@@ -9,7 +9,7 @@ import {
   rmSync,
   statSync
 } from 'node:fs'
-import { readdir, rm } from 'node:fs/promises'
+import { rm } from 'node:fs/promises'
 import { createHash } from 'node:crypto'
 import { pipeline } from 'node:stream/promises'
 import { spawn } from 'node:child_process'
@@ -26,6 +26,8 @@ import {
   migrateSpeechModelCacheIfNeeded,
   type SpeechModelCacheDir
 } from './model-cache-path'
+import { findNestedSpeechModelDirectory } from './speech-model-directory-scanner'
+import { SpeechModelExtractionStderr } from './speech-model-extraction-stderr'
 
 type DownloadHandle = {
   abort: () => void
@@ -835,7 +837,7 @@ export class ModelManager {
         }
       )
 
-      let stderr = ''
+      const stderr = new SpeechModelExtractionStderr()
       let settled = false
       let timeout: ReturnType<typeof setTimeout> | null = null
       let abortPoll: ReturnType<typeof setInterval> | null = null
@@ -864,7 +866,7 @@ export class ModelManager {
         reject(error)
       }
       const onStderrData = (chunk: Buffer): void => {
-        stderr += chunk.toString()
+        stderr.append(chunk)
       }
       const onClose = (code: number | null): void => {
         if (settled) {
@@ -875,7 +877,7 @@ export class ModelManager {
         if (code === 0) {
           resolve()
         } else {
-          reject(new Error(`tar exited with code ${code}: ${stderr.slice(0, 500)}`))
+          reject(new Error(`tar exited with code ${code}: ${stderr.errorEvidence()}`))
         }
       }
       const onError = (err: Error): void => {
@@ -902,22 +904,15 @@ export class ModelManager {
     if (!manifest.files) {
       return
     }
-    const entries = await readdir(modelDir, { withFileTypes: true })
-    for (const entry of entries) {
-      if (entry.isDirectory()) {
-        const nestedDir = join(modelDir, entry.name)
-        const nestedFiles = await readdir(nestedDir)
-        const hasExpected = manifest.files.some((f) => nestedFiles.includes(f))
-        if (hasExpected) {
-          const { rename: fsRename } = await import('node:fs/promises')
-          for (const file of nestedFiles) {
-            await fsRename(join(nestedDir, file), join(modelDir, file))
-          }
-          await rm(nestedDir, { recursive: true, force: true })
-          return
-        }
-      }
+    const nested = await findNestedSpeechModelDirectory(modelDir, manifest.files)
+    if (!nested) {
+      return
     }
+    const { rename: fsRename } = await import('node:fs/promises')
+    for (const file of nested.entryNames) {
+      await fsRename(join(nested.directoryPath, file), join(modelDir, file))
+    }
+    await rm(nested.directoryPath, { recursive: true, force: true })
   }
 
   private cleanup(modelId: string, archivePath: string): void {

--- a/src/main/speech/openai-api-key-store.test.ts
+++ b/src/main/speech/openai-api-key-store.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
@@ -83,6 +83,15 @@ describe('OpenAI speech API key store', () => {
 
     expect(store.hasOpenAiSpeechApiKey()).toBe(false)
     expect(existsSync(join(tempHome, '.orca'))).toBe(false)
+    expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized sparse key file before decrypting it', async () => {
+    writeStoredOpenAiKey('x')
+    truncateSync(join(tempHome, '.orca', 'openai-speech-token.enc'), 1024 * 1024 + 1)
+    const store = await loadStoreModule()
+
+    expect(() => store.readOpenAiSpeechApiKey()).toThrow('could not be decrypted')
     expect(safeStorageMock.decryptString).not.toHaveBeenCalled()
   })
 })

--- a/src/main/speech/openai-api-key-store.ts
+++ b/src/main/speech/openai-api-key-store.ts
@@ -1,7 +1,8 @@
 import { safeStorage } from 'electron'
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
+import { readIntegrationCredentialFileSync } from '../integration-credential-file'
 
 type StoredOpenAiKey = {
   encryptedKeyBase64: string
@@ -31,7 +32,9 @@ function readLegacyJsonStoredOpenAiKey(): StoredOpenAiKey | null {
     return null
   }
   try {
-    const parsed = JSON.parse(readFileSync(keyPath, 'utf8')) as Partial<StoredOpenAiKey>
+    const parsed = JSON.parse(
+      readIntegrationCredentialFileSync(keyPath).toString('utf8')
+    ) as Partial<StoredOpenAiKey>
     if (typeof parsed.encryptedKeyBase64 !== 'string' || parsed.encryptedKeyBase64 === '') {
       return null
     }
@@ -76,7 +79,7 @@ export function readOpenAiSpeechApiKey(): string {
     throw new Error('OpenAI API key is not configured')
   }
   try {
-    const raw = readFileSync(keyPath)
+    const raw = readIntegrationCredentialFileSync(keyPath)
     const legacyJson = readLegacyJsonStoredOpenAiKey()
     if (legacyJson) {
       cachedOpenAiSpeechApiKey = safeStorage.decryptString(

--- a/src/main/speech/openai-transcription-client.test.ts
+++ b/src/main/speech/openai-transcription-client.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { sanitizeOpenAiTranscriptionErrorMessage } from './openai-transcription-client'
+import {
+  OpenAiTranscriptionSession,
+  sanitizeOpenAiTranscriptionErrorMessage
+} from './openai-transcription-client'
 
 describe('sanitizeOpenAiTranscriptionErrorMessage', () => {
   it('does not expose the invalid OpenAI API key echoed by the provider', () => {
@@ -16,5 +19,17 @@ describe('sanitizeOpenAiTranscriptionErrorMessage', () => {
         'Request failed for sk-testSecret123 with Authorization: Bearer token-value_123'
       )
     ).toBe('Request failed for [redacted] with Authorization: Bearer [redacted]')
+  })
+
+  it('retains one growable sample buffer for adversarial one-sample feeds', () => {
+    const session = new OpenAiTranscriptionSession('openai-gpt-4o-mini-transcribe', () => 'key')
+    const sample = new Float32Array([0.25])
+
+    for (let index = 0; index < 100_000; index += 1) {
+      session.feedAudio(sample, 16_000)
+    }
+
+    expect(Reflect.get(session, 'sampleCount')).toBe(100_000)
+    expect(Reflect.get(session, 'samples')).toBeInstanceOf(Float32Array)
   })
 })

--- a/src/main/speech/openai-transcription-client.ts
+++ b/src/main/speech/openai-transcription-client.ts
@@ -1,4 +1,5 @@
 import { resampleToRate } from './stt-audio-resample'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 export const OPENAI_TRANSCRIPTION_MODEL_BY_ID: Record<string, string> = {
   'openai-gpt-4o-mini-transcribe': 'gpt-4o-mini-transcribe',
@@ -8,6 +9,7 @@ export const OPENAI_TRANSCRIPTION_MODEL_BY_ID: Record<string, string> = {
 const OPENAI_TRANSCRIPTION_URL = 'https://api.openai.com/v1/audio/transcriptions'
 const CLOUD_TRANSCRIPTION_SAMPLE_RATE = 16000
 const MAX_CLOUD_AUDIO_SECONDS = 10 * 60
+const MAX_CLOUD_AUDIO_SAMPLES = CLOUD_TRANSCRIPTION_SAMPLE_RATE * MAX_CLOUD_AUDIO_SECONDS
 
 type OpenAiTranscriptionResponse = {
   text?: unknown
@@ -29,8 +31,8 @@ export function sanitizeOpenAiTranscriptionErrorMessage(message: string): string
   return sanitized || 'OpenAI transcription request failed'
 }
 
-function encodePcm16Wav(samples: Float32Array, sampleRate: number): Buffer {
-  const dataBytes = samples.length * 2
+function encodePcm16Wav(samples: Float32Array, sampleCount: number, sampleRate: number): Buffer {
+  const dataBytes = sampleCount * 2
   const buffer = Buffer.alloc(44 + dataBytes)
 
   buffer.write('RIFF', 0)
@@ -47,24 +49,13 @@ function encodePcm16Wav(samples: Float32Array, sampleRate: number): Buffer {
   buffer.write('data', 36)
   buffer.writeUInt32LE(dataBytes, 40)
 
-  for (let i = 0; i < samples.length; i += 1) {
+  for (let i = 0; i < sampleCount; i += 1) {
     const clamped = Math.max(-1, Math.min(1, samples[i]))
     const value = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff
     buffer.writeInt16LE(Math.round(value), 44 + i * 2)
   }
 
   return buffer
-}
-
-function combineChunks(chunks: Float32Array[]): Float32Array {
-  const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0)
-  const combined = new Float32Array(totalLength)
-  let offset = 0
-  for (const chunk of chunks) {
-    combined.set(chunk, offset)
-    offset += chunk.length
-  }
-  return combined
 }
 
 function parseOpenAiTranscriptionResponse(data: OpenAiTranscriptionResponse): string {
@@ -78,8 +69,8 @@ function parseOpenAiTranscriptionResponse(data: OpenAiTranscriptionResponse): st
 }
 
 export class OpenAiTranscriptionSession {
-  private chunks: Float32Array[] = []
-  private audioSeconds = 0
+  private samples = new Float32Array(0)
+  private sampleCount = 0
 
   constructor(
     private readonly modelId: string,
@@ -88,15 +79,25 @@ export class OpenAiTranscriptionSession {
 
   feedAudio(samples: Float32Array, sampleRate: number): void {
     const normalized = resampleToRate(samples, sampleRate, CLOUD_TRANSCRIPTION_SAMPLE_RATE)
-    this.audioSeconds += normalized.length / CLOUD_TRANSCRIPTION_SAMPLE_RATE
-    if (this.audioSeconds > MAX_CLOUD_AUDIO_SECONDS) {
+    const nextSampleCount = this.sampleCount + normalized.length
+    if (nextSampleCount > MAX_CLOUD_AUDIO_SAMPLES) {
       throw new Error('Cloud transcription is limited to 10 minutes per dictation')
     }
-    this.chunks.push(new Float32Array(normalized))
+    if (this.samples.length < nextSampleCount) {
+      const nextCapacity = Math.min(
+        MAX_CLOUD_AUDIO_SAMPLES,
+        Math.max(CLOUD_TRANSCRIPTION_SAMPLE_RATE, this.samples.length * 2, nextSampleCount)
+      )
+      const next = new Float32Array(nextCapacity)
+      next.set(this.samples.subarray(0, this.sampleCount))
+      this.samples = next
+    }
+    this.samples.set(normalized, this.sampleCount)
+    this.sampleCount = nextSampleCount
   }
 
   async finish(): Promise<string> {
-    if (this.chunks.length === 0) {
+    if (this.sampleCount === 0) {
       return ''
     }
 
@@ -105,9 +106,9 @@ export class OpenAiTranscriptionSession {
       throw new Error(`Unknown OpenAI transcription model: ${this.modelId}`)
     }
 
-    const audio = combineChunks(this.chunks)
-    this.chunks = []
-    const wav = encodePcm16Wav(audio, CLOUD_TRANSCRIPTION_SAMPLE_RATE)
+    const wav = encodePcm16Wav(this.samples, this.sampleCount, CLOUD_TRANSCRIPTION_SAMPLE_RATE)
+    this.samples = new Float32Array(0)
+    this.sampleCount = 0
     const form = new FormData()
     form.append('model', apiModel)
     form.append('response_format', 'json')
@@ -123,7 +124,9 @@ export class OpenAiTranscriptionSession {
       body: form
     })
 
-    const data = (await response.json().catch(() => ({}))) as OpenAiTranscriptionResponse
+    const data = await readFetchResponseJsonWithinLimit<OpenAiTranscriptionResponse>(
+      response
+    ).catch((): OpenAiTranscriptionResponse => ({}))
     if (!response.ok) {
       const message =
         typeof data.error?.message === 'string'

--- a/src/main/speech/speech-model-directory-scanner.test.ts
+++ b/src/main/speech/speech-model-directory-scanner.test.ts
@@ -1,0 +1,172 @@
+import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { opendirMock, opendirSyncMock } = vi.hoisted(() => ({
+  opendirMock: vi.fn(),
+  opendirSyncMock: vi.fn()
+}))
+
+vi.mock('node:fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFs>()),
+  opendirSync: opendirSyncMock
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFsPromises>()),
+  opendir: opendirMock
+}))
+
+import {
+  findNestedSpeechModelDirectory,
+  findSpeechModelBpeVocabFile,
+  SPEECH_MODEL_VOCAB_SCAN_MAX_ENTRIES,
+  SpeechModelDirectoryCapacityError
+} from './speech-model-directory-scanner'
+import { buildHotwordsConfig } from './stt-worker-model-config'
+
+type FakeEntry = { name: string; directory?: boolean }
+
+function fakeAsyncDirectory(entries: FakeEntry[], onClose?: () => void): object {
+  return {
+    async *[Symbol.asyncIterator]() {
+      try {
+        for (const entry of entries) {
+          yield {
+            name: entry.name,
+            isDirectory: () => entry.directory === true
+          }
+        }
+      } finally {
+        onClose?.()
+      }
+    }
+  }
+}
+
+function useSyncEntries(entries: FakeEntry[]): ReturnType<typeof vi.fn> {
+  let index = 0
+  const closeSync = vi.fn()
+  opendirSyncMock.mockReturnValue({
+    closeSync,
+    readSync: vi.fn(() => {
+      const entry = entries[index]
+      index += 1
+      return entry ? { name: entry.name } : null
+    })
+  })
+  return closeSync
+}
+
+describe('speech model directory scanner', () => {
+  beforeEach(() => {
+    opendirMock.mockReset()
+    opendirSyncMock.mockReset()
+  })
+
+  it('preserves the first matching nested directory and its entry order', async () => {
+    opendirMock.mockImplementation(async (path: string) => {
+      if (path === '/models') {
+        return fakeAsyncDirectory([
+          { name: 'unrelated', directory: true },
+          { name: 'archive', directory: true }
+        ])
+      }
+      if (path === '/models/unrelated') {
+        return fakeAsyncDirectory([{ name: 'README.md' }])
+      }
+      return fakeAsyncDirectory([{ name: 'encoder.onnx' }, { name: 'tokens.txt' }])
+    })
+
+    await expect(findNestedSpeechModelDirectory('/models', ['encoder.onnx'])).resolves.toEqual({
+      directoryPath: '/models/archive',
+      entryNames: ['encoder.onnx', 'tokens.txt']
+    })
+  })
+
+  it('accepts the exact archive entry limit', async () => {
+    opendirMock.mockImplementation(async (path: string) =>
+      path === '/models'
+        ? fakeAsyncDirectory([{ name: 'archive', directory: true }])
+        : fakeAsyncDirectory([{ name: 'encoder.onnx' }, { name: 'tokens.txt' }])
+    )
+
+    await expect(
+      findNestedSpeechModelDirectory('/models', ['encoder.onnx'], {
+        maxEntries: 3
+      })
+    ).resolves.toMatchObject({ entryNames: ['encoder.onnx', 'tokens.txt'] })
+  })
+
+  it('closes both streams and rejects the first entry over the archive limit', async () => {
+    const closed: string[] = []
+    opendirMock.mockImplementation(async (path: string) =>
+      path === '/models'
+        ? fakeAsyncDirectory([{ name: 'archive', directory: true }], () => closed.push('root'))
+        : fakeAsyncDirectory([{ name: 'one' }, { name: 'two' }, { name: 'three' }], () =>
+            closed.push('nested')
+          )
+    )
+
+    await expect(
+      findNestedSpeechModelDirectory('/models', ['missing'], {
+        maxEntries: 3
+      })
+    ).rejects.toBeInstanceOf(SpeechModelDirectoryCapacityError)
+    expect(closed).toEqual(['nested', 'root'])
+  })
+
+  it('rejects a nested listing above its retained-name budget', async () => {
+    opendirMock.mockImplementation(async (path: string) =>
+      path === '/models'
+        ? fakeAsyncDirectory([{ name: 'archive', directory: true }])
+        : fakeAsyncDirectory([{ name: 'x' }])
+    )
+
+    await expect(
+      findNestedSpeechModelDirectory('/models', ['x'], {
+        maxRetainedNameBytes: 65
+      })
+    ).rejects.toThrow('retained name bytes')
+  })
+
+  it('finds a vocab at the exact production scan boundary', () => {
+    const entries = Array.from({ length: SPEECH_MODEL_VOCAB_SCAN_MAX_ENTRIES - 1 }, (_, index) => ({
+      name: `file-${index}`
+    }))
+    entries.push({ name: 'tokens.vocab' })
+    const closeSync = useSyncEntries(entries)
+
+    expect(
+      buildHotwordsConfig({
+        modelDir: '/models',
+        modelType: 'transducer',
+        hotwordsFilePath: '/hotwords.txt',
+        modelingUnit: 'bpe'
+      })
+    ).toMatchObject({
+      decodingMethod: 'modified_beam_search',
+      bpeVocab: '/models/tokens.vocab'
+    })
+    expect(closeSync).toHaveBeenCalledOnce()
+  })
+
+  it('ignores a vocab beyond the production scan boundary and closes the stream', () => {
+    const entries = Array.from({ length: SPEECH_MODEL_VOCAB_SCAN_MAX_ENTRIES }, (_, index) => ({
+      name: `file-${index}`
+    }))
+    entries.push({ name: 'too-late.vocab' })
+    const closeSync = useSyncEntries(entries)
+
+    expect(
+      buildHotwordsConfig({
+        modelDir: '/models',
+        modelType: 'transducer',
+        hotwordsFilePath: '/hotwords.txt',
+        modelingUnit: 'bpe'
+      })
+    ).toEqual({ decodingMethod: 'greedy_search' })
+    expect(findSpeechModelBpeVocabFile('/models', 0)).toBeUndefined()
+    expect(closeSync).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/speech/speech-model-directory-scanner.ts
+++ b/src/main/speech/speech-model-directory-scanner.ts
@@ -1,0 +1,130 @@
+import { opendirSync } from 'node:fs'
+import { opendir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export const SPEECH_MODEL_ARCHIVE_SCAN_MAX_ENTRIES = 32_768
+export const SPEECH_MODEL_ARCHIVE_MAX_RETAINED_NAME_BYTES = 4 * 1024 * 1024
+export const SPEECH_MODEL_VOCAB_SCAN_MAX_ENTRIES = 4_096
+
+export type SpeechModelArchiveScanLimits = {
+  maxEntries: number
+  maxRetainedNameBytes: number
+}
+
+export type NestedSpeechModelDirectory = {
+  directoryPath: string
+  entryNames: string[]
+}
+
+export class SpeechModelDirectoryCapacityError extends Error {
+  constructor(resource: string, limit: number) {
+    super(`Speech model directory exceeded its ${resource} limit (${limit})`)
+    this.name = 'SpeechModelDirectoryCapacityError'
+  }
+}
+
+function resolveLimit(requested: number | undefined, maximum: number, name: string): number {
+  if (requested === undefined) {
+    return maximum
+  }
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+  return Math.min(requested, maximum)
+}
+
+function estimateRetainedNameBytes(name: string): number {
+  return name.length * 2 + 64
+}
+
+export async function findNestedSpeechModelDirectory(
+  modelDir: string,
+  expectedFiles: readonly string[],
+  requestedLimits: Partial<SpeechModelArchiveScanLimits> = {}
+): Promise<NestedSpeechModelDirectory | null> {
+  const maxEntries = resolveLimit(
+    requestedLimits.maxEntries,
+    SPEECH_MODEL_ARCHIVE_SCAN_MAX_ENTRIES,
+    'maxEntries'
+  )
+  const maxRetainedNameBytes = resolveLimit(
+    requestedLimits.maxRetainedNameBytes,
+    SPEECH_MODEL_ARCHIVE_MAX_RETAINED_NAME_BYTES,
+    'maxRetainedNameBytes'
+  )
+  const expectedFileNames = new Set(expectedFiles)
+  let scannedEntries = 0
+
+  const rootDirectory = await opendir(modelDir, { bufferSize: 32 })
+  for await (const entry of rootDirectory) {
+    scannedEntries += 1
+    if (scannedEntries > maxEntries) {
+      throw new SpeechModelDirectoryCapacityError('entry count', maxEntries)
+    }
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const nestedDirectoryPath = join(modelDir, entry.name)
+    const entryNames: string[] = []
+    let retainedNameBytes = 0
+    const nestedDirectory = await opendir(nestedDirectoryPath, { bufferSize: 32 })
+    for await (const nestedEntry of nestedDirectory) {
+      scannedEntries += 1
+      if (scannedEntries > maxEntries) {
+        throw new SpeechModelDirectoryCapacityError('entry count', maxEntries)
+      }
+      retainedNameBytes += estimateRetainedNameBytes(nestedEntry.name)
+      if (retainedNameBytes > maxRetainedNameBytes) {
+        throw new SpeechModelDirectoryCapacityError('retained name bytes', maxRetainedNameBytes)
+      }
+      entryNames.push(nestedEntry.name)
+    }
+    if (entryNames.some((name) => expectedFileNames.has(name))) {
+      return { directoryPath: nestedDirectoryPath, entryNames }
+    }
+  }
+  return null
+}
+
+function closeSpeechModelDirectory(directory: ReturnType<typeof opendirSync>): void {
+  try {
+    directory.closeSync()
+  } catch {
+    // The OS may already have closed a fully consumed directory stream.
+  }
+}
+
+export function findSpeechModelBpeVocabFile(
+  modelDir: string,
+  requestedMaxEntries = SPEECH_MODEL_VOCAB_SCAN_MAX_ENTRIES
+): string | undefined {
+  const maxEntries = resolveLimit(
+    requestedMaxEntries,
+    SPEECH_MODEL_VOCAB_SCAN_MAX_ENTRIES,
+    'maxEntries'
+  )
+  let directory: ReturnType<typeof opendirSync>
+  try {
+    directory = opendirSync(modelDir, { bufferSize: 32 })
+  } catch {
+    return undefined
+  }
+
+  let scannedEntries = 0
+  try {
+    while (scannedEntries < maxEntries) {
+      const entry = directory.readSync()
+      if (entry === null) {
+        return undefined
+      }
+      scannedEntries += 1
+      if (entry.name.endsWith('.vocab')) {
+        return join(modelDir, entry.name)
+      }
+    }
+    return undefined
+  } finally {
+    closeSpeechModelDirectory(directory)
+  }
+}

--- a/src/main/speech/speech-model-extraction-stderr.test.ts
+++ b/src/main/speech/speech-model-extraction-stderr.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES,
+  SpeechModelExtractionStderr
+} from './speech-model-extraction-stderr'
+
+describe('speech model extraction stderr', () => {
+  it('preserves ordinary error evidence exactly', () => {
+    const stderr = new SpeechModelExtractionStderr()
+    stderr.append(Buffer.from('tar: archive is corrupt\n'))
+    stderr.append(Buffer.from('tar: exiting with failure'))
+
+    expect(stderr.errorEvidence()).toBe('tar: archive is corrupt\ntar: exiting with failure')
+    expect(stderr.retainedByteLength()).toBe(49)
+    expect(stderr.wasTruncated()).toBe(false)
+  })
+
+  it('retains the exact byte limit without truncation', () => {
+    const stderr = new SpeechModelExtractionStderr()
+    stderr.append(Buffer.alloc(SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES, 0x61))
+
+    expect(stderr.retainedByteLength()).toBe(SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES)
+    expect(stderr.wasTruncated()).toBe(false)
+    expect(stderr.errorEvidence()).toBe('a'.repeat(500))
+  })
+
+  it('caps one byte over the limit while preserving prefix and tail evidence', () => {
+    const stderr = new SpeechModelExtractionStderr()
+    stderr.append(Buffer.alloc(SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES, 0x61))
+    stderr.append(Buffer.from('Z'))
+
+    expect(stderr.retainedByteLength()).toBe(SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES)
+    expect(stderr.wasTruncated()).toBe(true)
+    expect(stderr.errorEvidence()).toMatch(
+      /^a{500}\n\[\.\.\. 1 stderr bytes omitted \.\.\.\]\na{499}Z$/
+    )
+  })
+
+  it('bounds a single oversized chunk without converting it to an oversized string', () => {
+    const stderr = new SpeechModelExtractionStderr()
+    const chunk = Buffer.concat([
+      Buffer.from('PREFIX'),
+      Buffer.alloc(SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES * 2, 0x78),
+      Buffer.from('TAIL')
+    ])
+
+    stderr.append(chunk)
+
+    expect(stderr.retainedByteLength()).toBe(SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES)
+    expect(stderr.errorEvidence()).toContain('PREFIX')
+    expect(stderr.errorEvidence()).toMatch(/TAIL$/)
+  })
+})

--- a/src/main/speech/speech-model-extraction-stderr.ts
+++ b/src/main/speech/speech-model-extraction-stderr.ts
@@ -1,0 +1,74 @@
+export const SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES = 64 * 1024
+
+const STDERR_PREFIX_BYTES = 4 * 1024
+const STDERR_TAIL_BYTES = SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES - STDERR_PREFIX_BYTES
+const STDERR_EVIDENCE_CHARS_PER_END = 500
+
+export class SpeechModelExtractionStderr {
+  private readonly prefix = Buffer.alloc(STDERR_PREFIX_BYTES)
+  private readonly tail = Buffer.alloc(STDERR_TAIL_BYTES)
+  private prefixLength = 0
+  private tailLength = 0
+  private tailWriteOffset = 0
+  private observedBytes = 0
+
+  append(chunk: Buffer): void {
+    if (chunk.length === 0) {
+      return
+    }
+    if (this.prefixLength < this.prefix.length) {
+      const prefixBytes = Math.min(chunk.length, this.prefix.length - this.prefixLength)
+      chunk.copy(this.prefix, this.prefixLength, 0, prefixBytes)
+      this.prefixLength += prefixBytes
+    }
+    this.appendTail(chunk)
+    this.observedBytes = Math.min(Number.MAX_SAFE_INTEGER, this.observedBytes + chunk.length)
+  }
+
+  retainedByteLength(): number {
+    return Math.min(this.observedBytes, SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES)
+  }
+
+  wasTruncated(): boolean {
+    return this.observedBytes > SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES
+  }
+
+  errorEvidence(): string {
+    const prefix = this.prefix
+      .subarray(0, this.prefixLength)
+      .toString('utf8')
+      .slice(0, STDERR_EVIDENCE_CHARS_PER_END)
+    if (!this.wasTruncated()) {
+      return prefix
+    }
+    const omittedBytes = this.observedBytes - this.retainedByteLength()
+    const tail = this.orderedTail().toString('utf8').slice(-STDERR_EVIDENCE_CHARS_PER_END)
+    return `${prefix}\n[... ${omittedBytes} stderr bytes omitted ...]\n${tail}`
+  }
+
+  private appendTail(chunk: Buffer): void {
+    if (chunk.length >= this.tail.length) {
+      chunk.copy(this.tail, 0, chunk.length - this.tail.length)
+      this.tailLength = this.tail.length
+      this.tailWriteOffset = 0
+      return
+    }
+    const firstBytes = Math.min(chunk.length, this.tail.length - this.tailWriteOffset)
+    chunk.copy(this.tail, this.tailWriteOffset, 0, firstBytes)
+    if (firstBytes < chunk.length) {
+      chunk.copy(this.tail, 0, firstBytes)
+    }
+    this.tailWriteOffset = (this.tailWriteOffset + chunk.length) % this.tail.length
+    this.tailLength = Math.min(this.tail.length, this.tailLength + chunk.length)
+  }
+
+  private orderedTail(): Buffer {
+    if (this.tailLength < this.tail.length || this.tailWriteOffset === 0) {
+      return this.tail.subarray(0, this.tailLength)
+    }
+    return Buffer.concat([
+      this.tail.subarray(this.tailWriteOffset),
+      this.tail.subarray(0, this.tailWriteOffset)
+    ])
+  }
+}

--- a/src/main/speech/stt-offline-audio-chunker.test.ts
+++ b/src/main/speech/stt-offline-audio-chunker.test.ts
@@ -97,4 +97,17 @@ describe('OfflineAudioChunker', () => {
     expect(chunker.push(new Float32Array(0))).toEqual([])
     expect(chunker.flush()).toBeNull()
   })
+
+  it('preserves 100,000 one-sample fragments without retaining one object per push', () => {
+    const chunker = new OfflineAudioChunker(10_000)
+    const expected = new Float32Array(100_000)
+
+    for (let index = 0; index < expected.length; index += 1) {
+      const value = (index % 251) / 251
+      expected[index] = value
+      expect(chunker.push(Float32Array.of(value))).toEqual([])
+    }
+
+    expect(chunker.flush()).toEqual(expected)
+  })
 })

--- a/src/main/speech/stt-offline-audio-chunker.ts
+++ b/src/main/speech/stt-offline-audio-chunker.ts
@@ -13,7 +13,7 @@ const SPLIT_SEARCH_SECONDS = 5
 const SPLIT_ENERGY_WINDOW_SECONDS = 0.1
 
 export class OfflineAudioChunker {
-  private buffered: Float32Array[] = []
+  private buffered = new Float32Array(0)
   private bufferedSamples = 0
   private readonly chunkSampleLimit: number
   private readonly splitSearchSamples: number
@@ -30,18 +30,16 @@ export class OfflineAudioChunker {
     if (samples.length === 0) {
       return []
     }
-    this.buffered.push(samples)
-    this.bufferedSamples += samples.length
+    this.append(samples)
 
     const ready: Float32Array[] = []
     while (this.bufferedSamples >= this.chunkSampleLimit) {
-      const combined = this.combineBuffered()
-      const splitIndex = this.findQuietSplitIndex(combined)
-      ready.push(combined.slice(0, splitIndex))
-      const tail = combined.slice(splitIndex)
-      this.buffered = tail.length > 0 ? [tail] : []
-      this.bufferedSamples = tail.length
+      const splitIndex = this.findQuietSplitIndex(this.buffered.subarray(0, this.bufferedSamples))
+      ready.push(this.buffered.slice(0, splitIndex))
+      this.buffered.copyWithin(0, splitIndex, this.bufferedSamples)
+      this.bufferedSamples -= splitIndex
     }
+    this.releaseOversizedCapacity()
     return ready
   }
 
@@ -50,23 +48,32 @@ export class OfflineAudioChunker {
     if (this.bufferedSamples === 0) {
       return null
     }
-    const combined = this.combineBuffered()
-    this.buffered = []
+    const combined = this.buffered.slice(0, this.bufferedSamples)
+    this.buffered = new Float32Array(0)
     this.bufferedSamples = 0
     return combined
   }
 
-  private combineBuffered(): Float32Array {
-    if (this.buffered.length === 1) {
-      return this.buffered[0]
+  private append(samples: Float32Array): void {
+    const required = this.bufferedSamples + samples.length
+    if (required > this.buffered.length) {
+      const capacity = Math.max(required, Math.max(1_024, this.buffered.length * 2))
+      const next = new Float32Array(capacity)
+      next.set(this.buffered.subarray(0, this.bufferedSamples))
+      this.buffered = next
     }
-    const combined = new Float32Array(this.bufferedSamples)
-    let offset = 0
-    for (const chunk of this.buffered) {
-      combined.set(chunk, offset)
-      offset += chunk.length
+    this.buffered.set(samples, this.bufferedSamples)
+    this.bufferedSamples = required
+  }
+
+  private releaseOversizedCapacity(): void {
+    const retainedCapacity = Math.max(this.chunkSampleLimit, this.bufferedSamples)
+    if (this.buffered.length <= retainedCapacity * 2) {
+      return
     }
-    return combined
+    const compacted = new Float32Array(retainedCapacity)
+    compacted.set(this.buffered.subarray(0, this.bufferedSamples))
+    this.buffered = compacted
   }
 
   private findQuietSplitIndex(samples: Float32Array): number {

--- a/src/main/speech/stt-worker-model-config.ts
+++ b/src/main/speech/stt-worker-model-config.ts
@@ -1,5 +1,5 @@
-import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { findSpeechModelBpeVocabFile } from './speech-model-directory-scanner'
 
 // Why: different models name their ONNX files differently (e.g.
 // encoder.int8.onnx vs tiny-encoder.onnx vs encoder-epoch-99-avg-1.onnx).
@@ -29,16 +29,6 @@ export function resolveTokens(files: string[], modelDir: string): string {
 // Why: BPE models need a vocab file for hotwords token matching. The file
 // ships in the model archive but isn't listed in the manifest. We discover
 // it at runtime to avoid breaking existing downloads.
-function discoverBpeVocab(modelDir: string): string | undefined {
-  try {
-    const entries = readdirSync(modelDir)
-    const vocabFile = entries.find((f) => f.endsWith('.vocab'))
-    return vocabFile ? join(modelDir, vocabFile) : undefined
-  } catch {
-    return undefined
-  }
-}
-
 export type HotwordsConfig = {
   decodingMethod: string
   hotwordsFile?: string
@@ -59,7 +49,7 @@ export function buildHotwordsConfig(opts: {
 
   const unit = opts.modelingUnit
   if (unit?.includes('bpe')) {
-    const bpeVocab = discoverBpeVocab(opts.modelDir)
+    const bpeVocab = findSpeechModelBpeVocabFile(opts.modelDir)
     if (!bpeVocab) {
       return { decodingMethod: 'greedy_search' }
     }


### PR DESCRIPTION
## OOM hardening slice 17/29 — bound native chat transcript & speech input

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **17/29** (base: `oom/16-b-codex`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Re-introduces OOM ceilings across native-chat transcript reading (per-record/page/retention byte caps, message-count cap, and a process-wide concurrency+byte admission gate for transcript reads) and speech (cloud-audio sample cap, credential/response/stderr size caps, and bounded model-cache migration + directory scans). The most significant user-visible shift is that native-chat transcript reads are no longer "entire file, no cap" — they now return the newest bounded window with pagination.

### ELI5
Imagine a chat log that could grow to any size. Before, the app tried to load the whole thing into memory at once, which could crash it on huge logs. Now it loads the newest chunk (still very large) and lets you scroll back for older parts, and it only lets a couple of these big loads happen at the same time so memory stays safe. The speech-to-text side gets similar seatbelts: caps on how much audio, error text, and model-folder scanning it will hold. Ordinary users won't notice; only enormous logs or extreme conditions hit the limits.

### Proof of OOM fix
- Transcript retention: MAX_NATIVE_CHAT_TRANSCRIPT_MESSAGES=50,000 and MAX_NATIVE_CHAT_TRANSCRIPT_RETAINED_BYTES=64 MiB (retained-byte estimate = sourceBytes*2+256) in transcript-message-retention.ts; tested in transcript-message-retention.test.ts.
- Per-record cap: MAX_NATIVE_CHAT_TRANSCRIPT_RECORD_BYTES=2 MiB via TranscriptRecordBuffer; tested in transcript-record-buffer.test.ts and transcript-stream-lines.test.ts (oversized record dropped, next line preserved, UTF-8 split across 1-byte chunks intact).
- Per-page cap: MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES=16 MiB in transcript-tail-reader.ts (sets pageBudgetReached, forces hasMore=true); tested in transcript-reader.test.ts.
- Incremental drain: APPEND_BATCH_RETAINED_BYTE_LIMIT=8 MiB, INCREMENTAL_DRAIN_RETAINED_BYTE_LIMIT=32 MiB in transcript-incremental-reader.ts; tested in transcript-incremental-reader.test.ts (byte-flush before count limit, pause/resume at record boundary without gaps, always advances one record even when budget < record).
- Read admission: MAX_..._READ_CONCURRENCY=8, MAX_..._READ_WAITERS=256, MAX_..._PROCESS_RETAINED_BYTES=128 MiB; each watch drain reserves PAGE(16 MiB)+DRAIN(32 MiB)=48 MiB (transcript-read-admission.ts); tested in transcript-read-admission.test.ts and transcript-watch-drain-admission.test.ts (concurrency+byte budget, aborted/unsubscribed waiter removed and slot reused, idempotent release, listener detach).
- Speech cloud audio: MAX_CLOUD_AUDIO_SAMPLES=16000*600 (10 min) with a single growing Float32Array in openai-transcription-client.ts; tested in openai-transcription-client.test.ts (100k one-sample feeds keep one buffer).
- Speech model-cache migration: 16,384 entries / depth 16 / 16 MiB visited-path bytes in model-cache-path.ts; tested in model-cache-path-bounds.test.ts.
- Speech directory scan: SPEECH_MODEL_ARCHIVE_SCAN_MAX_ENTRIES=32,768, retained-name 4 MiB, SPEECH_MODEL_VOCAB_SCAN_MAX_ENTRIES=4,096 in speech-model-directory-scanner.ts; tested in speech-model-directory-scanner.test.ts.
- tar stderr: SPEECH_MODEL_EXTRACTION_STDERR_MAX_RETAINED_BYTES=64 KiB (4 KiB prefix + ring tail, 500 chars/end evidence) in speech-model-extraction-stderr.ts; tested in speech-model-extraction-stderr.test.ts.
- Credential/response caps: openai-api-key-store.ts uses readIntegrationCredentialFileSync (rejects >1 MiB key file, tested in openai-api-key-store.test.ts); openai-transcription-client.ts uses readFetchResponseJsonWithinLimit for the provider response body.

### Regressions
**Normal-path (ordinary use, below the new limits):** **none** — behavior is unchanged below the ceilings.

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Native-chat transcript reads truncate to the newest 50,000 messages / 64 MiB retained (~32 MB source JSONL); older history reachable only via pagination (beforeOffset).
- A single per-page tail read caps at 16 MiB retained and returns hasMore=true; UI must page for the rest.
- Records >2 MiB are dropped (surfaced as a fallback-id placeholder message).
- Admission throws 'Too many queued native chat transcript reads' only when >256 transcript reads are simultaneously queued process-wide.
- Speech model-cache migration aborts best-effort (logs a warning, leaves a partial copy) only past 16,384 entries / depth 16 / 16 MiB path bytes.
- BPE vocab discovery scans at most 4,096 entries; a .vocab beyond that falls back to greedy_search (loses hotwords).
- Cloud dictation still hard-caps at 10 minutes of audio (unchanged limit, now sample-based).
- tar extraction error messages bounded to 4 KiB prefix + 64 KiB tail with an 'N stderr bytes omitted' marker.
- readNativeChatTranscript changed from 'entire transcript, NO message cap' to a bounded newest-window (50,000 messages / 64 MiB retained). For very heavy sessions, oldest messages are no longer in the canonical parse and are only reachable via pagination (the read-cache doc comment explicitly dropped 'canonical, unwindowed'). Confirm all surfaces page correctly. _(only when: Opening a native-chat (Claude/Codex/Grok) session whose transcript exceeds ~32 MB source JSONL or 50k messages; reachable in ordinary heavy coding sessions, which the code comments describe as 'routinely tens of MB'.)_
- Live transcript watcher drains now pass through a shared 128 MiB / 8-concurrency admission gate, each reserving a fixed 48 MiB, so at most ~2 watch drains run concurrently process-wide (shared with page reads from other call sites). With many native-chat views open, live updates serialize behind each other, adding refresh latency. _(only when: Several native-chat sessions actively updating at once (multiple worktrees / paired web/mobile clients). Correctness preserved (FIFO admit, no loss); only latency increases.)_
- readNativeChatTranscript / the read-cache now return a bounded newest window (50,000 messages / 64 MiB retained, ~32 MB source JSONL) instead of the whole file. Below those ceilings the parse is byte-for-byte identical to BASE; above them the oldest history is dropped from the canonical parse and only reachable via pagination (beforeOffset). This is the intended OOM fix, but it IS user-visible for very heavy sessions and warrants explicit human signoff. _(only when: Opening a native-chat session whose transcript exceeds ~32 MB / 50k messages; the code comments describe heavy Claude/Codex sessions as 'routinely tens of MB'.)_
- A tail page can return hasMore=true with fewer than `limit` messages once the 16 MiB per-page retained-byte budget is hit, requiring the UI to page for the rest. Only reachable when records approach the 2 MiB per-record cap (tens of near-max records); ordinary KB-sized messages keep tens of thousands within 16 MiB. _(only when: Paging a transcript composed of many very large (near-2 MiB) records.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.

### Adversarial review
- 2 skeptic lens(es). Sign-off: **FLAGGED — see above**. Residual risk: **low**.
- Adversarial regression pass on PR #17 (native-chat transcript + speech). I tried hard to refute 'ordinary users see no change' and could not confirm a normal-path regression.\n\nKEY REFUTATION OF THE PRIOR REVIEWER'S MEDIUM FINDING: the claimed 'readNativeChatTranscript went from entire-file to bounded window, older msgs only via pagination' is largely moot. grep -rn shows readNativeChatTranscript / readNativeChatTranscriptCached / decodeTranscriptStream have no wired user-facing caller. All live surfaces use readNativeChatTranscriptTail(File) which ALREADY did newest-first message-count windowing with hasMore/beforeOffset before this PR (src/main/ipc/native-chat.ts default window, MAX 2000; RPC default 40, MAX 2000). The renderer already lazy-pages ('starts at the default window and raises limit to page in older history as it scrolls up'). So the paginated window is pre-existing behavior, not introduced here.\n\nWHAT THIS PR ACTUALLY ADDS on the user path: a per-page byte ceiling (MAX_NATIVE_CHAT_TRANSCRIPT_PAGE_RETAINED_BYTES = 16 MiB retained, ~8 MB source) on the tail reader, and the 48 MiB-reservation admission gate on watch drains. The page cap only makes a heavy page smaller and sets hasMore=true; the existing pagination UI continues loading. transcript-reader.test.ts verifies [...older, ...newest] reconstructs the full ordered list, and that a single record can never single-handedly trip the page budget (records are hard-capped at 2 MiB source => ~4 MiB retained, well under the 16 MiB page budget => >=4 records/page, no starvation).\n\nCEILINGS VERIFIED (all far above ordinary use): retention window 50,000 msgs / 64 MiB retained (estimate = sourceBytes*2+256, ~32 MB source); page cap 16 MiB retained; admission process budget 128 MiB / concurrency 8 / 256 waiters (throws only >256 simultaneous queued reads); cloud dictation 10 min unchanged (now sample-based, MAX_CLOUD_AUDIO_SAMPLES = 16000*600); model-cache migration 16,384 entries / depth 16 / 16 MiB path bytes (a model has a handful of files); BPE vocab scan 4,096 entries; tar stderr 64 KiB (4 KiB prefix + 60 KiB tail); key file 1 MiB.\n\nCORRECTNESS CHECKS (no defect found): incremental drain-budget break resets state.offset to pendingStart and clears pendingRecord so the next drain re-reads that record with no gap; the drainRetainedBytes>0 guard forces one oversized record to advance instead of stalling (both verified by transcript-incremental-reader.test.ts). Admission abort removes queued waiter + detaches listener + re-admits; release is idempotent (transcript-read-admission.test.ts). OfflineAudioChunker findQuietSplitIndex returns Math.max(1, bestIndex) so push() cannot infinite-loop; 100k one-sample test reconstructs exactly. No deadlock in the admission gate since every reservation (16/48 MiB) <= 128 MiB budget.\n\nOnly residual user-visible effect is the low-severity multi-session watch-drain serialization latency noted in confirmedRegressions. Safe to open as a draft PR for human review.

### Files
32 files changed (+1703 / −166).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
