### PR TITLE
oom(18/29): bound agent hooks & automations state

### DIFF
--- a/src/main/agent-hooks/agent-hook-file-bounds.test.ts
+++ b/src/main/agent-hooks/agent-hook-file-bounds.test.ts
@@ -1,0 +1,165 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('os', async () => {
+  const actual = (await vi.importActual('os')) as Record<string, unknown>
+  return { ...actual, homedir: homedirMock }
+})
+
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import { AmpHookService, _internals as ampInternals } from '../amp/hook-service'
+import { DevinHookService } from '../devin/hook-service'
+import { getDevinConfigPath, getDevinManagedScriptPath } from '../devin/hook-settings'
+import { HermesHookService, _internals as hermesInternals } from '../hermes/hook-service'
+import { KimiHookService } from '../kimi/hook-service'
+import {
+  AGENT_HOOK_CONFIG_MAX_BYTES,
+  AGENT_HOOK_CONFIG_MAX_STRUCTURAL_TOKENS,
+  AGENT_HOOK_MANAGED_SCRIPT_MAX_BYTES,
+  AGENT_HOOK_PLUGIN_MAX_BYTES
+} from './agent-hook-file-limits'
+import {
+  readHooksJson,
+  readHooksJsonRawForGenerationCheck,
+  writeHooksJson,
+  writeManagedScript
+} from './installer-utils'
+
+let root: string
+
+function writeSparseFile(path: string, bytes: number): void {
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, '')
+  truncateSync(path, bytes)
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'orca-agent-hook-bounds-'))
+  homedirMock.mockReturnValue(root)
+  vi.stubEnv('HERMES_HOME', join(root, '.hermes'))
+  vi.stubEnv('KIMI_CODE_HOME', join(root, '.kimi-code'))
+  vi.stubEnv('APPDATA', join(root, 'AppData', 'Roaming'))
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.clearAllMocks()
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('agent hook file bounds', () => {
+  it('fails closed when hooks JSON exceeds the comparison and generation limit', () => {
+    const configPath = join(root, 'hooks.json')
+    writeSparseFile(configPath, AGENT_HOOK_CONFIG_MAX_BYTES + 1)
+    const originalSize = statSync(configPath).size
+
+    expect(readHooksJson(configPath)).toBeNull()
+    expect(() => readHooksJsonRawForGenerationCheck(configPath)).toThrow(NodeFileReadTooLargeError)
+    expect(() => writeHooksJson(configPath, { hooks: {} })).toThrow(NodeFileReadTooLargeError)
+    expect(statSync(configPath).size).toBe(originalSize)
+  })
+
+  it('rejects structurally amplified hooks JSON before parsing', () => {
+    const configPath = join(root, 'hooks.json')
+    writeFileSync(configPath, `[${'0,'.repeat(AGENT_HOOK_CONFIG_MAX_STRUCTURAL_TOKENS)}0]`, 'utf8')
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    expect(readHooksJson(configPath)).toBeNull()
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not replace an oversized managed script during its equality check', () => {
+    const scriptPath = join(root, '.orca', 'agent-hooks', 'status-hook.sh')
+    writeSparseFile(scriptPath, AGENT_HOOK_MANAGED_SCRIPT_MAX_BYTES + 1)
+    const originalSize = statSync(scriptPath).size
+
+    expect(() => writeManagedScript(scriptPath, '#!/bin/sh\n')).toThrow(NodeFileReadTooLargeError)
+    expect(statSync(scriptPath).size).toBe(originalSize)
+  })
+
+  it('does not replace an oversized Amp plugin', () => {
+    const pluginPath = ampInternals.getPluginPath()
+    writeSparseFile(pluginPath, AGENT_HOOK_PLUGIN_MAX_BYTES + 1)
+    const originalSize = statSync(pluginPath).size
+
+    const status = new AmpHookService().install()
+
+    expect(status).toMatchObject({ state: 'error', managedHooksPresent: false })
+    expect(status.detail).toContain('File too large')
+    expect(statSync(pluginPath).size).toBe(originalSize)
+  })
+
+  it('does not create Hermes plugin files when config.yaml is oversized', () => {
+    const configPath = join(process.env.HERMES_HOME!, 'config.yaml')
+    writeSparseFile(configPath, AGENT_HOOK_CONFIG_MAX_BYTES + 1)
+    const originalSize = statSync(configPath).size
+
+    const status = new HermesHookService().install()
+
+    expect(status.state).toBe('error')
+    expect(status.detail).toContain('File too large')
+    expect(statSync(configPath).size).toBe(originalSize)
+    expect(
+      existsSync(
+        join(process.env.HERMES_HOME!, 'plugins', hermesInternals.HERMES_PLUGIN_NAME, 'plugin.yaml')
+      )
+    ).toBe(false)
+  })
+
+  it('does not replace an oversized Hermes plugin manifest', () => {
+    const manifestPath = join(
+      process.env.HERMES_HOME!,
+      'plugins',
+      hermesInternals.HERMES_PLUGIN_NAME,
+      'plugin.yaml'
+    )
+    writeSparseFile(manifestPath, AGENT_HOOK_PLUGIN_MAX_BYTES + 1)
+    const originalSize = statSync(manifestPath).size
+
+    const status = new HermesHookService().install()
+
+    expect(status.state).toBe('error')
+    expect(status.detail).toContain('File too large')
+    expect(statSync(manifestPath).size).toBe(originalSize)
+    expect(existsSync(join(process.env.HERMES_HOME!, 'config.yaml'))).toBe(false)
+  })
+
+  it('does not create a Kimi script or replace an oversized config.toml', () => {
+    const configPath = join(process.env.KIMI_CODE_HOME!, 'config.toml')
+    const scriptPath = join(root, '.orca', 'agent-hooks', 'kimi-hook.sh')
+    writeSparseFile(configPath, AGENT_HOOK_CONFIG_MAX_BYTES + 1)
+    const originalSize = statSync(configPath).size
+
+    const status = new KimiHookService().install()
+
+    expect(status.state).toBe('error')
+    expect(statSync(configPath).size).toBe(originalSize)
+    expect(existsSync(scriptPath)).toBe(false)
+  })
+
+  it('does not create a Devin script or replace an oversized config.json', () => {
+    const configPath = getDevinConfigPath()
+    writeSparseFile(configPath, AGENT_HOOK_CONFIG_MAX_BYTES + 1)
+    const originalSize = statSync(configPath).size
+
+    const status = new DevinHookService().install()
+
+    expect(status.state).toBe('error')
+    expect(statSync(configPath).size).toBe(originalSize)
+    expect(existsSync(getDevinManagedScriptPath())).toBe(false)
+  })
+})

--- a/src/main/agent-hooks/agent-hook-file-comparison.ts
+++ b/src/main/agent-hooks/agent-hook-file-comparison.ts
@@ -1,0 +1,15 @@
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileSyncWithinLimit
+} from '../../shared/node-bounded-file-reader'
+
+export function readAgentHookFileForComparison(path: string, maxBytes: number): string | null {
+  try {
+    return readNodeFileSyncWithinLimit(path, maxBytes).buffer.toString('utf8')
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw error
+    }
+    return null
+  }
+}

--- a/src/main/agent-hooks/agent-hook-file-limits.ts
+++ b/src/main/agent-hooks/agent-hook-file-limits.ts
@@ -1,0 +1,6 @@
+// Why: leave room for the supported 30,000-hook cleanup, including longer encoded Windows commands.
+export const AGENT_HOOK_CONFIG_MAX_BYTES = 64 * 1024 * 1024
+export const AGENT_HOOK_CONFIG_MAX_STRUCTURAL_TOKENS = 1_000_000
+export const AGENT_HOOK_CONFIG_MAX_NESTING_DEPTH = 128
+export const AGENT_HOOK_PLUGIN_MAX_BYTES = 1024 * 1024
+export const AGENT_HOOK_MANAGED_SCRIPT_MAX_BYTES = 1024 * 1024

--- a/src/main/agent-hooks/agent-hook-sftp-text-reader.ts
+++ b/src/main/agent-hooks/agent-hook-sftp-text-reader.ts
@@ -1,0 +1,151 @@
+import type { SFTPWrapper } from 'ssh2'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+
+const READ_CHUNK_BYTES = 64 * 1024
+
+type SftpWithBoundedAgentHookRead = SFTPWrapper & {
+  orcaReadFileWithinLimit?: (
+    remotePath: string,
+    maxBytes: number,
+    callback: (error: unknown, data?: string | Buffer) => void
+  ) => void
+}
+
+export async function readAgentHookRemoteTextFile(
+  sftp: SFTPWrapper,
+  remotePath: string,
+  maxBytes: number,
+  timeoutMs: number
+): Promise<string> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new RangeError('Remote file read limit must be a non-negative safe integer')
+  }
+  const boundedSftp = sftp as SftpWithBoundedAgentHookRead
+  if (typeof boundedSftp.orcaReadFileWithinLimit === 'function') {
+    return readWithCallback(remotePath, maxBytes, timeoutMs, (callback) =>
+      boundedSftp.orcaReadFileWithinLimit!(remotePath, maxBytes, callback)
+    )
+  }
+  if (typeof sftp.createReadStream !== 'function') {
+    return readWithCompatibilityFallback(sftp, remotePath, maxBytes, timeoutMs)
+  }
+
+  const stream = sftp.createReadStream(remotePath, {
+    start: 0,
+    end: maxBytes,
+    highWaterMark: READ_CHUNK_BYTES
+  })
+  return new Promise<string>((resolve, reject) => {
+    let settled = false
+    let totalBytes = 0
+    let retained = Buffer.alloc(0)
+    const timer = setTimeout(() => {
+      fail(new Error(`Timed out waiting for SFTP readFile ${remotePath}`))
+    }, timeoutMs)
+    if (typeof timer === 'object' && 'unref' in timer) {
+      timer.unref()
+    }
+
+    function fail(error: unknown): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      stream.destroy()
+      reject(error)
+    }
+
+    stream.on('data', (chunk: string | Buffer | Uint8Array) => {
+      if (settled) {
+        return
+      }
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      totalBytes += bytes.byteLength
+      if (totalBytes > maxBytes) {
+        fail(new NodeFileReadTooLargeError(totalBytes, maxBytes))
+        return
+      }
+      if (retained.length < totalBytes) {
+        const nextCapacity = Math.min(
+          maxBytes,
+          Math.max(READ_CHUNK_BYTES, retained.length * 2, totalBytes)
+        )
+        const next = Buffer.allocUnsafe(nextCapacity)
+        retained.copy(next)
+        retained = next
+      }
+      bytes.copy(retained, totalBytes - bytes.byteLength)
+    })
+    stream.once('error', fail)
+    stream.once('end', () => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(retained.toString('utf8', 0, totalBytes))
+    })
+  })
+}
+
+function readWithCompatibilityFallback(
+  sftp: SFTPWrapper,
+  remotePath: string,
+  maxBytes: number,
+  timeoutMs: number
+): Promise<string> {
+  return readWithCallback(remotePath, maxBytes, timeoutMs, (callback) => {
+    sftp.readFile(remotePath, 'utf8', callback)
+  })
+}
+
+function readWithCallback(
+  remotePath: string,
+  maxBytes: number,
+  timeoutMs: number,
+  start: (callback: (error: unknown, data?: string | Buffer) => void) => void
+): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let settled = false
+    const timer = setTimeout(() => {
+      finish(new Error(`Timed out waiting for SFTP readFile ${remotePath}`))
+    }, timeoutMs)
+    if (typeof timer === 'object' && 'unref' in timer) {
+      timer.unref()
+    }
+
+    function finish(error: unknown, data?: string | Buffer): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      if (error) {
+        reject(error)
+        return
+      }
+      if (typeof data === 'string') {
+        const byteLength = Buffer.byteLength(data, 'utf8')
+        if (byteLength > maxBytes) {
+          reject(new NodeFileReadTooLargeError(byteLength, maxBytes))
+          return
+        }
+        resolve(data)
+        return
+      }
+      const buffer = data ?? Buffer.alloc(0)
+      if (buffer.byteLength > maxBytes) {
+        reject(new NodeFileReadTooLargeError(buffer.byteLength, maxBytes))
+        return
+      }
+      resolve(buffer.toString('utf8'))
+    }
+
+    try {
+      start(finish)
+    } catch (error) {
+      finish(error)
+    }
+  })
+}

--- a/src/main/agent-hooks/branch-rename-failure-output.test.ts
+++ b/src/main/agent-hooks/branch-rename-failure-output.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  BRANCH_RENAME_FAILURE_KEY_MAX_BYTES,
+  BRANCH_RENAME_FAILURE_OUTPUT_MAX_BYTES,
+  __getBranchRenameFailureOutputCountForTests,
   __resetBranchRenameFailureOutputForTests,
   readBranchRenameFailureOutputForDisplay,
   rememberBranchRenameFailureOutput
@@ -47,5 +50,28 @@ describe('branch rename failure output store', () => {
     rememberBranchRenameFailureOutput('wt-new', output('AgentNew'))
     expect(readBranchRenameFailureOutputForDisplay('wt-0')).not.toBeNull()
     expect(readBranchRenameFailureOutputForDisplay('wt-1')).toBeNull()
+  })
+
+  it('admits exact byte boundaries and skips oversized retained text', () => {
+    const exactKey = 'k'.repeat(BRANCH_RENAME_FAILURE_KEY_MAX_BYTES)
+    const oversizedKey = `${exactKey}x`
+    rememberBranchRenameFailureOutput(exactKey, {
+      label: '',
+      exitCode: 1,
+      stdout: 'x'.repeat(BRANCH_RENAME_FAILURE_OUTPUT_MAX_BYTES),
+      stderr: ''
+    })
+    rememberBranchRenameFailureOutput(oversizedKey, output('oversized-key'))
+    rememberBranchRenameFailureOutput('oversized-output', {
+      label: '',
+      exitCode: 1,
+      stdout: 'x'.repeat(BRANCH_RENAME_FAILURE_OUTPUT_MAX_BYTES + 1),
+      stderr: ''
+    })
+
+    expect(__getBranchRenameFailureOutputCountForTests()).toBe(1)
+    expect(readBranchRenameFailureOutputForDisplay(exactKey)).not.toBeNull()
+    expect(readBranchRenameFailureOutputForDisplay(oversizedKey)).toBeNull()
+    expect(readBranchRenameFailureOutputForDisplay('oversized-output')).toBeNull()
   })
 })

--- a/src/main/agent-hooks/branch-rename-failure-output.ts
+++ b/src/main/agent-hooks/branch-rename-failure-output.ts
@@ -2,13 +2,28 @@ import {
   formatAgentGenerationFailureOutputForDisplay,
   type AgentGenerationFailureOutput
 } from '../text-generation/agent-failure-output'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 // Why: the full CLI output is a diagnostic for the local user only. Keeping it
 // in memory (never in worktree metadata) means nothing environment-identifying
 // is persisted or synced to paired clients; a restart just loses the on-demand
 // view while the sanitized excerpt badge survives.
 const MAX_ENTRIES = 32
+export const BRANCH_RENAME_FAILURE_KEY_MAX_BYTES = 4 * 1024
+export const BRANCH_RENAME_FAILURE_OUTPUT_MAX_BYTES = 520 * 1024
 const entriesByWorktreeId = new Map<string, AgentGenerationFailureOutput>()
+
+function fitsByteBudget(values: readonly string[], maxBytes: number): boolean {
+  let remainingBytes = maxBytes
+  for (const value of values) {
+    const measured = measureUtf8ByteLength(value, { stopAfterBytes: remainingBytes })
+    if (measured.exceededLimit) {
+      return false
+    }
+    remainingBytes -= measured.byteLength
+  }
+  return true
+}
 
 export function rememberBranchRenameFailureOutput(
   worktreeId: string,
@@ -18,6 +33,15 @@ export function rememberBranchRenameFailureOutput(
   // stalest worktree first.
   entriesByWorktreeId.delete(worktreeId)
   if (!output) {
+    return
+  }
+  if (
+    !fitsByteBudget([worktreeId], BRANCH_RENAME_FAILURE_KEY_MAX_BYTES) ||
+    !fitsByteBudget(
+      [output.label, output.stdout, output.stderr],
+      BRANCH_RENAME_FAILURE_OUTPUT_MAX_BYTES
+    )
+  ) {
     return
   }
   entriesByWorktreeId.set(worktreeId, output)
@@ -37,4 +61,8 @@ export function readBranchRenameFailureOutputForDisplay(worktreeId: string): str
 
 export function __resetBranchRenameFailureOutputForTests(): void {
   entriesByWorktreeId.clear()
+}
+
+export function __getBranchRenameFailureOutputCountForTests(): number {
+  return entriesByWorktreeId.size
 }

--- a/src/main/agent-hooks/first-work-branch-rename.test.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.test.ts
@@ -44,7 +44,9 @@ vi.mock('../ipc/worktree-logic', () => ({
 }))
 
 import {
+  FIRST_WORK_BRANCH_RENAME_IN_FLIGHT_LIMIT,
   FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT,
+  getFirstWorkBranchRenameStateForTests,
   maybeAutoRenameBranchOnFirstWork,
   resetFirstWorkBranchRenameState,
   type FirstWorkBranchRenameDeps
@@ -295,6 +297,45 @@ describe('maybeAutoRenameBranchOnFirstWork', () => {
     )
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds simultaneous auto-rename attempts and recovers after they settle', async () => {
+    let releaseGit!: () => void
+    const gitGate = new Promise<void>((resolve) => {
+      releaseGit = resolve
+    })
+    gitExecFileAsyncMock.mockImplementation(async () => {
+      await gitGate
+      return { stdout: 'you/custom-branch\n', stderr: '' }
+    })
+    const { deps } = makeDeps()
+    const attempts = Array.from({ length: FIRST_WORK_BRANCH_RENAME_IN_FLIGHT_LIMIT }, (_, index) =>
+      maybeAutoRenameBranchOnFirstWork(
+        workingEvent({
+          tabId: undefined,
+          paneKey: '',
+          worktreeId: `${REPO_ID}${WORKTREE_ID_SEPARATOR}/repo/concurrent-${index}`
+        }),
+        deps
+      )
+    )
+
+    expect(getFirstWorkBranchRenameStateForTests().inFlight).toBe(
+      FIRST_WORK_BRANCH_RENAME_IN_FLIGHT_LIMIT
+    )
+    await maybeAutoRenameBranchOnFirstWork(
+      workingEvent({
+        tabId: undefined,
+        paneKey: '',
+        worktreeId: `${REPO_ID}${WORKTREE_ID_SEPARATOR}/repo/overflow`
+      }),
+      deps
+    )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(FIRST_WORK_BRANCH_RENAME_IN_FLIGHT_LIMIT)
+
+    releaseGit()
+    await Promise.all(attempts)
+    expect(getFirstWorkBranchRenameStateForTests().inFlight).toBe(0)
   })
 
   it('retries on a later event after a transient failure (does not poison the worktree)', async () => {

--- a/src/main/agent-hooks/first-work-branch-rename.ts
+++ b/src/main/agent-hooks/first-work-branch-rename.ts
@@ -1,4 +1,5 @@
 // On first agent work in a fresh workspace, replace the auto-generated creature branch (e.g. `you/Nautilus`) with a short work-derived name.
+import { createHash } from 'node:crypto'
 import type { GlobalSettings, Repo } from '../../shared/types'
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
@@ -71,6 +72,7 @@ export type FirstWorkBranchRenameDeps = {
 const inFlightWorktreeIds = new Set<string>()
 const settledWorktreeIds = new Set<string>()
 export const FIRST_WORK_BRANCH_RENAME_SETTLED_CACHE_LIMIT = 500
+export const FIRST_WORK_BRANCH_RENAME_IN_FLIGHT_LIMIT = 32
 
 /** Test seam: clear the per-process dedupe sets. */
 export function resetFirstWorkBranchRenameState(): void {
@@ -91,6 +93,20 @@ function rememberSettledWorktreeId(worktreeId: string): void {
   }
 }
 
+function worktreeStateKey(worktreeId: string): string {
+  return createHash('sha256').update(worktreeId).digest('base64url')
+}
+
+export function getFirstWorkBranchRenameStateForTests(): {
+  inFlight: number
+  settled: number
+} {
+  return {
+    inFlight: inFlightWorktreeIds.size,
+    settled: settledWorktreeIds.size
+  }
+}
+
 export async function maybeAutoRenameBranchOnFirstWork(
   event: FirstWorkBranchRenameEvent,
   deps: FirstWorkBranchRenameDeps
@@ -108,26 +124,30 @@ export async function maybeAutoRenameBranchOnFirstWork(
   if (!worktreeId) {
     return
   }
+  const stateKey = worktreeStateKey(worktreeId)
   // Short-circuit settled/in-flight worktrees before any logging or work.
-  if (settledWorktreeIds.has(worktreeId) || inFlightWorktreeIds.has(worktreeId)) {
+  if (settledWorktreeIds.has(stateKey) || inFlightWorktreeIds.has(stateKey)) {
     return
   }
   const prompt = event.prompt?.trim()
   if (!prompt) {
     return
   }
-  inFlightWorktreeIds.add(worktreeId)
+  if (inFlightWorktreeIds.size >= FIRST_WORK_BRANCH_RENAME_IN_FLIGHT_LIMIT) {
+    return
+  }
+  inFlightWorktreeIds.add(stateKey)
   try {
     // settled = definitive verdict (renamed/ineligible); false = transient bail to retry later.
     const settled = await runAutoRename(worktreeId, prompt, event.assistantMessage, deps)
     if (settled) {
-      rememberSettledWorktreeId(worktreeId)
+      rememberSettledWorktreeId(stateKey)
     }
   } catch (error) {
     // Why: best-effort convenience; a failure must never disrupt the user's agent, so swallow after logging.
     console.warn('[auto-branch-rename] rename attempt failed:', error)
   } finally {
-    inFlightWorktreeIds.delete(worktreeId)
+    inFlightWorktreeIds.delete(stateKey)
   }
 }
 

--- a/src/main/agent-hooks/hooks-json-read.ts
+++ b/src/main/agent-hooks/hooks-json-read.ts
@@ -1,5 +1,12 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
 import type { HooksConfig } from './installer-utils'
+import {
+  AGENT_HOOK_CONFIG_MAX_BYTES,
+  AGENT_HOOK_CONFIG_MAX_NESTING_DEPTH,
+  AGENT_HOOK_CONFIG_MAX_STRUCTURAL_TOKENS
+} from './agent-hook-file-limits'
 
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -11,6 +18,19 @@ export type HooksJsonSnapshot = {
   config: HooksConfig | null
 }
 
+export function parseHooksJsonText(raw: string): HooksConfig | null {
+  try {
+    assertJsonTextStructureWithinLimits(raw, {
+      structuralTokens: AGENT_HOOK_CONFIG_MAX_STRUCTURAL_TOKENS,
+      nestingDepth: AGENT_HOOK_CONFIG_MAX_NESTING_DEPTH
+    })
+    const parsed = JSON.parse(raw)
+    return isPlainObject(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
 // Why: generation guards abort a mutation when the file no longer matches the
 // bytes it was derived from; the raw snapshot and the parse must come from one
 // read or a concurrent save can slip between them unnoticed.
@@ -20,18 +40,21 @@ export function readHooksJsonWithRaw(configPath: string): HooksJsonSnapshot {
   }
   let raw: string
   try {
-    raw = readFileSync(configPath, 'utf-8')
+    raw = readNodeFileSyncWithinLimit(configPath, AGENT_HOOK_CONFIG_MAX_BYTES).buffer.toString(
+      'utf8'
+    )
   } catch {
     return { raw: null, config: null }
   }
-  try {
-    const parsed = JSON.parse(raw)
-    return { raw, config: isPlainObject(parsed) ? parsed : null }
-  } catch {
-    return { raw, config: null }
-  }
+  return { raw, config: parseHooksJsonText(raw) }
 }
 
 export function readHooksJson(configPath: string): HooksConfig | null {
   return readHooksJsonWithRaw(configPath).config
+}
+
+export function readHooksJsonRawForGenerationCheck(configPath: string): string {
+  return readNodeFileSyncWithinLimit(configPath, AGENT_HOOK_CONFIG_MAX_BYTES).buffer.toString(
+    'utf8'
+  )
 }

--- a/src/main/agent-hooks/installer-utils-remote.test.ts
+++ b/src/main/agent-hooks/installer-utils-remote.test.ts
@@ -1,8 +1,11 @@
+import { Readable } from 'node:stream'
 import { describe, expect, it, vi } from 'vitest'
 import type { SFTPWrapper } from 'ssh2'
 
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import {
   readHooksJsonRemote,
+  readTextFileRemote,
   writeHooksJsonRemote,
   writeManagedScriptRemote,
   writeTextFileRemoteAtomic
@@ -13,6 +16,7 @@ type FakeFs = {
   dirs: Set<string>
   modes: Map<string, number>
   openSshRenameCount: number
+  readdirCount: number
 }
 
 function createFakeSftp(
@@ -30,7 +34,8 @@ function createFakeSftp(
     files: new Map(),
     dirs: new Set(['/']),
     modes: new Map(),
-    openSshRenameCount: 0
+    openSshRenameCount: 0,
+    readdirCount: 0
   }
   const noEntryError = (path: string): { code: number; message: string } => ({
     code: 2,
@@ -96,6 +101,10 @@ function createFakeSftp(
       cb(null)
     },
     stat: (path: string, cb: (err: unknown, stats?: { mode: number }) => void): void => {
+      if (fs.dirs.has(path)) {
+        cb(null, fakeStats(0o040755))
+        return
+      }
       if (!fs.files.has(path)) {
         cb(noEntryError(path))
         return
@@ -103,6 +112,7 @@ function createFakeSftp(
       cb(null, fakeStats(fs.modes.get(path) ?? 0o100644))
     },
     readdir: (path: string, cb: (err: unknown, list?: { filename: string }[]) => void): void => {
+      fs.readdirCount += 1
       if (fs.dirs.has(path)) {
         cb(null, [])
         return
@@ -201,6 +211,14 @@ describe('installer-utils-remote', () => {
     expect(fs.modes.get('/home/u/.claude/settings.json')).toBe(0o600)
   })
 
+  it('probes mkdir ancestors with stat instead of materializing directory listings', async () => {
+    const { sftp, fs } = createFakeSftp()
+
+    await writeHooksJsonRemote(sftp, '/home/u/.claude/settings.json', { hooks: {} })
+
+    expect(fs.readdirCount).toBe(0)
+  })
+
   it('preserves existing config file mode across atomic replacement', async () => {
     const { sftp, fs } = createFakeSftp()
     const path = '/home/u/.codex/config.toml'
@@ -286,5 +304,45 @@ describe('installer-utils-remote', () => {
     // identical file body.
     await writeHooksJsonRemote(sftp, path, { hooks: {} })
     expect(fs.files.get(path)).toBe(beforeKey)
+  })
+
+  it('preserves ordinary UTF-8 contents through the bounded remote stream', async () => {
+    const { sftp } = createFakeSftp()
+    const content = 'stable 🐋 config'
+    sftp.createReadStream = (() => Readable.from([Buffer.from(content)])) as never
+
+    await expect(readTextFileRemote(sftp, '/home/u/config.toml', 1024)).resolves.toBe(content)
+  })
+
+  it('accepts a streamed remote file at the exact byte cap', async () => {
+    const { sftp } = createFakeSftp()
+    sftp.createReadStream = (() => Readable.from([Buffer.alloc(1024, 0x61)])) as never
+
+    await expect(readTextFileRemote(sftp, '/home/u/config.toml', 1024)).resolves.toHaveLength(1024)
+  })
+
+  it('bounds metadata when a remote emits one byte per stream event', async () => {
+    const { sftp } = createFakeSftp()
+    const byte = Buffer.from('x')
+    sftp.createReadStream = (() =>
+      Readable.from(Array.from({ length: 100_000 }, () => byte))) as never
+
+    await expect(readTextFileRemote(sftp, '/home/u/config.toml', 100_000)).resolves.toBe(
+      'x'.repeat(100_000)
+    )
+  })
+
+  it('stops streamed remote reads at the byte cap and leaves the existing file intact', async () => {
+    const { sftp, fs } = createFakeSftp()
+    const path = '/home/u/.config/agent/config.toml'
+    fs.files.set(path, 'original')
+    sftp.createReadStream = (() => Readable.from([Buffer.alloc(1025)])) as never
+
+    await expect(readTextFileRemote(sftp, path, 1024)).rejects.toThrow(NodeFileReadTooLargeError)
+    await expect(writeTextFileRemoteAtomic(sftp, path, 'replacement', 1024)).rejects.toThrow(
+      NodeFileReadTooLargeError
+    )
+    expect(fs.files.get(path)).toBe('original')
+    expect(Array.from(fs.files.keys()).some((key) => key.includes('.tmp'))).toBe(false)
   })
 })

--- a/src/main/agent-hooks/installer-utils-remote.ts
+++ b/src/main/agent-hooks/installer-utils-remote.ts
@@ -12,9 +12,16 @@
 // See docs/design/agent-status-over-ssh.md §8 (commit #8).
 
 import { randomUUID } from 'node:crypto'
-import type { SFTPWrapper, FileEntryWithStats } from 'ssh2'
+import type { SFTPWrapper } from 'ssh2'
 
-import { isPlainObject, type HooksConfig } from './installer-utils'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import {
+  AGENT_HOOK_CONFIG_MAX_BYTES,
+  AGENT_HOOK_MANAGED_SCRIPT_MAX_BYTES
+} from './agent-hook-file-limits'
+import { readAgentHookRemoteTextFile } from './agent-hook-sftp-text-reader'
+import type { HooksConfig } from './installer-utils'
+import { parseHooksJsonText } from './hooks-json-read'
 
 const DEFAULT_REMOTE_CONFIG_MODE = 0o600
 const REMOTE_SFTP_OPERATION_TIMEOUT_MS = 10_000
@@ -31,19 +38,14 @@ export async function readHooksJsonRemote(
 ): Promise<HooksConfig | null> {
   let body: string
   try {
-    body = await readFile(sftp, remotePath)
+    body = await readFile(sftp, remotePath, AGENT_HOOK_CONFIG_MAX_BYTES)
   } catch (err) {
     if (isNoEntryError(err)) {
       return {}
     }
     throw err
   }
-  try {
-    const parsed = JSON.parse(body)
-    return isPlainObject(parsed) ? parsed : null
-  } catch {
-    return null
-  }
+  return parseHooksJsonText(body)
 }
 
 /** Atomically write a JSON config to the remote — write to a tmp path then
@@ -62,11 +64,14 @@ export async function writeHooksJsonRemote(
   // Why: skip the write when on-disk content is identical so repeated
   // install() calls do not bump the file's mtime / inode unnecessarily.
   try {
-    const existing = await readFile(sftp, remotePath)
+    const existing = await readFile(sftp, remotePath, AGENT_HOOK_CONFIG_MAX_BYTES)
     if (existing === serialized) {
       return
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw error
+    }
     // ENOENT or read error — fall through to the write below.
   }
   // Why: tmp + rename so a partial network drop mid-write does not leave a
@@ -98,12 +103,15 @@ export async function writeManagedScriptRemote(
   const dir = dirnamePosix(remotePath)
   await mkdirpRemote(sftp, dir)
   try {
-    const existing = await readFile(sftp, remotePath)
+    const existing = await readFile(sftp, remotePath, AGENT_HOOK_MANAGED_SCRIPT_MAX_BYTES)
     if (existing === content) {
       await chmod(sftp, remotePath, 0o755)
       return
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw error
+    }
     // ENOENT or read error — fall through to the atomic write below.
   }
 
@@ -126,10 +134,11 @@ export async function writeManagedScriptRemote(
 
 export async function readTextFileRemote(
   sftp: SFTPWrapper,
-  remotePath: string
+  remotePath: string,
+  maxBytes = AGENT_HOOK_CONFIG_MAX_BYTES
 ): Promise<string | null> {
   try {
-    return await readFile(sftp, remotePath)
+    return await readFile(sftp, remotePath, maxBytes)
   } catch (err) {
     if (isNoEntryError(err)) {
       return null
@@ -141,16 +150,20 @@ export async function readTextFileRemote(
 export async function writeTextFileRemoteAtomic(
   sftp: SFTPWrapper,
   remotePath: string,
-  content: string
+  content: string,
+  maxExistingBytes = AGENT_HOOK_CONFIG_MAX_BYTES
 ): Promise<void> {
   const dir = dirnamePosix(remotePath)
   await mkdirpRemote(sftp, dir)
   try {
-    const existing = await readFile(sftp, remotePath)
+    const existing = await readFile(sftp, remotePath, maxExistingBytes)
     if (existing === content) {
       return
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw error
+    }
     // ENOENT or read error — fall through to the atomic write below.
   }
 
@@ -211,11 +224,8 @@ function sftpOperation<T>(
   })
 }
 
-async function readFile(sftp: SFTPWrapper, remotePath: string): Promise<string> {
-  const data = await sftpOperation<string | Buffer>(`readFile ${remotePath}`, (callback) => {
-    sftp.readFile(remotePath, 'utf8', callback)
-  })
-  return typeof data === 'string' ? data : data.toString('utf8')
+async function readFile(sftp: SFTPWrapper, remotePath: string, maxBytes: number): Promise<string> {
+  return readAgentHookRemoteTextFile(sftp, remotePath, maxBytes, REMOTE_SFTP_OPERATION_TIMEOUT_MS)
 }
 
 async function writeFile(
@@ -296,12 +306,6 @@ async function chmod(sftp: SFTPWrapper, remotePath: string, mode: number): Promi
   })
 }
 
-async function readdir(sftp: SFTPWrapper, remotePath: string): Promise<FileEntryWithStats[]> {
-  return await sftpOperation<FileEntryWithStats[]>(`readdir ${remotePath}`, (callback) => {
-    sftp.readdir(remotePath, callback)
-  })
-}
-
 async function mkdir(sftp: SFTPWrapper, remotePath: string): Promise<void> {
   await sftpOperation<void>(`mkdir ${remotePath}`, (callback) => {
     sftp.mkdir(remotePath, callback)
@@ -320,7 +324,7 @@ async function mkdirpRemote(sftp: SFTPWrapper, remotePath: string): Promise<void
   for (const seg of segments) {
     current = current === '' ? `/${seg}` : current === '.' ? seg : `${current}/${seg}`
     try {
-      await readdir(sftp, current)
+      await statMode(sftp, current)
     } catch {
       try {
         await mkdir(sftp, current)

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -1,7 +1,6 @@
 import {
   existsSync,
   mkdirSync,
-  readFileSync,
   statSync,
   writeFileSync,
   chmodSync,
@@ -13,6 +12,11 @@ import { dirname, join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import type { AgentHookSource } from '../../shared/agent-hook-relay'
 import { grantDirAcl, isPermissionError } from '../win32-utils'
+import { readAgentHookFileForComparison } from './agent-hook-file-comparison'
+import {
+  AGENT_HOOK_CONFIG_MAX_BYTES,
+  AGENT_HOOK_MANAGED_SCRIPT_MAX_BYTES
+} from './agent-hook-file-limits'
 import { POSIX_HOOK_STDIN_DRAIN_COMMAND } from './hook-stdin-contract'
 import { resolveHooksJsonWritePath } from './hook-config-write-path'
 import { writeRollingFileBackup } from '../rolling-file-backup'
@@ -60,6 +64,7 @@ export function buildManagedCommandDefinition(command: string): HookDefinition {
 export {
   isPlainObject,
   readHooksJson,
+  readHooksJsonRawForGenerationCheck,
   readHooksJsonWithRaw,
   type HooksJsonSnapshot
 } from './hooks-json-read'
@@ -257,15 +262,12 @@ export function writeManagedScript(scriptPath: string, content: string): void {
   mkdirSync(dir, { recursive: true })
 
   if (existsSync(scriptPath)) {
-    try {
-      if (readFileSync(scriptPath, 'utf-8') === content) {
-        if (process.platform !== 'win32') {
-          chmodSync(scriptPath, 0o755)
-        }
-        return
+    const existing = readAgentHookFileForComparison(scriptPath, AGENT_HOOK_MANAGED_SCRIPT_MAX_BYTES)
+    if (existing === content) {
+      if (process.platform !== 'win32') {
+        chmodSync(scriptPath, 0o755)
       }
-    } catch {
-      // Fall through to the atomic write path.
+      return
     }
   }
 
@@ -327,12 +329,9 @@ export function writeHooksJson(
   // file and rolls the backup forward, which can silently destroy the last
   // recoverable copy if install() is called repeatedly (e.g. on app start).
   if (existsSync(writePath)) {
-    try {
-      if (readFileSync(writePath, 'utf-8') === serialized) {
-        return
-      }
-    } catch {
-      // Fall through to the normal write path; a read error isn't worth failing the install for.
+    const existing = readAgentHookFileForComparison(writePath, AGENT_HOOK_CONFIG_MAX_BYTES)
+    if (existing === serialized) {
+      return
     }
   }
 

--- a/src/main/agent-hooks/managed-hook-local-filesystem.test.ts
+++ b/src/main/agent-hooks/managed-hook-local-filesystem.test.ts
@@ -1,7 +1,9 @@
 import { mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import { readAgentHookRemoteTextFile } from './agent-hook-sftp-text-reader'
 import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
 import { createManagedHookLocalFilesystem } from './managed-hook-local-filesystem'
 
@@ -29,6 +31,51 @@ afterEach(async () => {
 })
 
 describe('managed-hook local filesystem', () => {
+  it('uses the bounded local reader instead of the legacy whole-file callback', async () => {
+    const home = await createTempHome()
+    const configPath = join(home, 'oversized-config.json')
+    await writeFile(configPath, '123456789', 'utf8')
+    const filesystem = createManagedHookLocalFilesystem()
+    const legacyRead = vi.spyOn(filesystem, 'readFile')
+
+    await expect(
+      readAgentHookRemoteTextFile(filesystem, configPath, 8, 1_000)
+    ).rejects.toBeInstanceOf(NodeFileReadTooLargeError)
+    expect(legacyRead).not.toHaveBeenCalled()
+  })
+
+  it('probes a directory without reading or retaining any child entries', async () => {
+    let closeCalls = 0
+    let readCalls = 0
+    const filesystem = createManagedHookLocalFilesystem({
+      openDirectory(_path, callback) {
+        callback(null, {
+          close(closeCallback) {
+            closeCalls += 1
+            closeCallback(null)
+          },
+          read() {
+            readCalls += 1
+          }
+        } as never)
+      }
+    })
+
+    const entries = await new Promise<unknown[]>((resolve, reject) => {
+      filesystem.readdir('/directory-with-millions-of-entries', (error, value) => {
+        if (error) {
+          reject(error)
+          return
+        }
+        resolve(value ?? [])
+      })
+    })
+
+    expect(entries).toEqual([])
+    expect(closeCalls).toBe(1)
+    expect(readCalls).toBe(0)
+  })
+
   it('supports cold and warm aggregate installs without SFTP or temp-file residue', async () => {
     const home = await createTempHome()
     const filesystem = createManagedHookLocalFilesystem()

--- a/src/main/agent-hooks/managed-hook-local-filesystem.ts
+++ b/src/main/agent-hooks/managed-hook-local-filesystem.ts
@@ -1,7 +1,22 @@
-import { chmod, mkdir, readFile, readdir, rename, stat, unlink, writeFile } from 'node:fs'
+import { chmod, mkdir, opendir, readFile, rename, stat, unlink, writeFile } from 'node:fs'
 import type { SFTPWrapper } from 'ssh2'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../../shared/node-bounded-file-reader'
 
 type Callback<T = void> = (error: Error | null, value?: T) => void
+
+type DirectoryProbeHandle = {
+  close(callback: (error: NodeJS.ErrnoException | null) => void): void
+}
+
+export type ManagedHookLocalFilesystemOptions = {
+  openDirectory?: (
+    path: string,
+    callback: (error: NodeJS.ErrnoException | null, directory?: DirectoryProbeHandle) => void
+  ) => void
+}
 
 function asSftpError(error: NodeJS.ErrnoException): Error & { code: number } {
   const translated = new Error(error.message, { cause: error }) as Error & { code: number }
@@ -20,10 +35,40 @@ function finish<T>(callback: Callback<T>, error: NodeJS.ErrnoException | null, v
 
 /** The managed installers only need this small callback-style SFTP surface.
  *  On the remote host it turns hundreds of WAN round trips into local fs calls. */
-export function createManagedHookLocalFilesystem(): SFTPWrapper {
+export function createManagedHookLocalFilesystem(
+  options?: ManagedHookLocalFilesystemOptions
+): SFTPWrapper {
+  const openDirectory =
+    options?.openDirectory ??
+    ((
+      path: string,
+      callback: (error: NodeJS.ErrnoException | null, directory?: DirectoryProbeHandle) => void
+    ) => {
+      opendir(path, callback)
+    })
   const adapter = {
     readFile(path: string, _encoding: string, callback: Callback<string | Buffer>): void {
       readFile(path, 'utf8', (error, contents) => finish(callback, error, contents))
+    },
+    orcaReadFileWithinLimit(
+      path: string,
+      maxBytes: number,
+      callback: Callback<string | Buffer>
+    ): void {
+      void readNodeFileWithinLimit(path, maxBytes).then(
+        ({ buffer }) => callback(null, buffer),
+        (error: unknown) => {
+          if (error instanceof NodeFileReadTooLargeError) {
+            callback(error)
+            return
+          }
+          callback(
+            error instanceof Error
+              ? asSftpError(error as NodeJS.ErrnoException)
+              : new Error(String(error))
+          )
+        }
+      )
     },
     writeFile(
       path: string,
@@ -37,9 +82,15 @@ export function createManagedHookLocalFilesystem(): SFTPWrapper {
       stat(path, (error, stats) => finish(callback, error, stats))
     },
     readdir(path: string, callback: Callback<[]>): void {
-      // Why: installers use readdir only as an existence check; names and
-      // attrs would allocate work that no caller consumes.
-      readdir(path, (error) => finish(callback, error, []))
+      // Why: installers only probe directory existence; opening and closing
+      // avoids materializing every child name before returning the unused [].
+      openDirectory(path, (error, directory) => {
+        if (error || !directory) {
+          finish(callback, error ?? new Error('Directory probe returned no handle'))
+          return
+        }
+        directory.close((closeError) => finish(callback, closeError, []))
+      })
     },
     mkdir(path: string, callback: Callback): void {
       mkdir(path, (error) => finish(callback, error))

--- a/src/main/agent-hooks/managed-hook-lock-claims.ts
+++ b/src/main/agent-hooks/managed-hook-lock-claims.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'node:crypto'
-import { readdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { opendir, rename, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import {
   CLAIMED_OWNER_PATTERN,
+  MANAGED_HOOK_LOCK_DIRECTORY_BUFFER_SIZE,
   claimedOwnerFileName,
   claimRecordFileName,
   hasCode,
@@ -10,6 +12,7 @@ import {
   ownerFileName,
   parseClaim,
   parseOwner,
+  readManagedHookLockRecord,
   removeFileIfPresent,
   type ManagedHookLockClaim,
   type ManagedHookLockOwner
@@ -33,13 +36,21 @@ async function findClaimedOwner(
   lockParent: string,
   ownerToken: string
 ): Promise<{ claimToken: string; path: string } | null | undefined> {
-  const matches = (await readdir(lockParent)).flatMap((entry) => {
-    const match = CLAIMED_OWNER_PATTERN.exec(entry)
-    return match?.[1] === ownerToken && match[2]
-      ? [{ claimToken: match[2], path: join(lockParent, entry) }]
-      : []
+  const directory = await opendir(lockParent, {
+    bufferSize: MANAGED_HOOK_LOCK_DIRECTORY_BUFFER_SIZE
   })
-  return matches.length === 1 ? matches[0] : matches.length === 0 ? null : undefined
+  let claimedOwner: { claimToken: string; path: string } | null = null
+  for await (const entry of directory) {
+    const match = CLAIMED_OWNER_PATTERN.exec(entry.name)
+    if (match?.[1] !== ownerToken || !match[2]) {
+      continue
+    }
+    if (claimedOwner) {
+      return undefined
+    }
+    claimedOwner = { claimToken: match[2], path: join(lockParent, entry.name) }
+  }
+  return claimedOwner
 }
 
 async function resolveClaimSource(
@@ -53,10 +64,13 @@ async function resolveClaimSource(
 > {
   const ownerPath = join(lockParent, ownerFileName(owner.token))
   try {
-    return parseOwner(await readFile(ownerPath, 'utf8'), owner.token)
+    return parseOwner(await readManagedHookLockRecord(ownerPath), owner.token)
       ? { kind: 'ready', sourcePath: ownerPath }
       : { kind: 'unverifiable' }
   } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      return { kind: 'unverifiable' }
+    }
     if (!hasCode(error, 'ENOENT')) {
       throw error
     }
@@ -73,12 +87,12 @@ async function resolveClaimSource(
   let priorClaim: ManagedHookLockClaim | null
   try {
     priorClaim = parseClaim(
-      await readFile(priorClaimRecordPath, 'utf8'),
+      await readManagedHookLockRecord(priorClaimRecordPath),
       owner.token,
       claimedOwner.claimToken
     )
   } catch (error) {
-    if (hasCode(error, 'ENOENT')) {
+    if (hasCode(error, 'ENOENT') || error instanceof NodeFileReadTooLargeError) {
       return { kind: 'unverifiable' }
     }
     throw error

--- a/src/main/agent-hooks/managed-hook-lock-cleanup-bounds.test.ts
+++ b/src/main/agent-hooks/managed-hook-lock-cleanup-bounds.test.ts
@@ -1,0 +1,203 @@
+import type { Dir, OpenDirOptions, PathLike, Stats } from 'node:fs'
+import {
+  link,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  stat,
+  truncate,
+  writeFile
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { withManagedHookInstallLock } from './managed-hook-install-lock'
+import {
+  cleanupManagedHookLockFiles,
+  MANAGED_HOOK_LOCK_CLEANUP_CONCURRENCY,
+  MANAGED_HOOK_LOCK_DIRECTORY_BUFFER_SIZE,
+  MANAGED_HOOK_LOCK_RECORD_MAX_BYTES
+} from './managed-hook-lock-records'
+
+const tempHomes: string[] = []
+const ioProbe = vi.hoisted(() => ({
+  active: 0,
+  enabled: false,
+  opendirBufferSizes: [] as number[],
+  peak: 0
+}))
+const identityProbe = vi.hoisted(() => ({
+  processIdentity: null as string | null | undefined
+}))
+
+type ProbedFsPromises = {
+  lstat: (path: PathLike) => Promise<Stats>
+  opendir: (path: PathLike, options?: OpenDirOptions) => Promise<Dir>
+}
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = await importOriginal<ProbedFsPromises>()
+  return {
+    ...original,
+    lstat: async (...args: Parameters<typeof original.lstat>) => {
+      const tracked = ioProbe.enabled && String(args[0]).includes('managed-hook-install.owner-feed')
+      if (!tracked) {
+        return await original.lstat(...args)
+      }
+      ioProbe.active += 1
+      ioProbe.peak = Math.max(ioProbe.peak, ioProbe.active)
+      try {
+        await new Promise<void>((resolve) => setTimeout(resolve, 2))
+        return await original.lstat(...args)
+      } finally {
+        ioProbe.active -= 1
+      }
+    },
+    opendir: async (...args: Parameters<typeof original.opendir>) => {
+      const options = args[1] as { bufferSize?: number } | undefined
+      if (options?.bufferSize !== undefined) {
+        ioProbe.opendirBufferSizes.push(options.bufferSize)
+      }
+      return await original.opendir(...args)
+    }
+  }
+})
+
+vi.mock('./managed-hook-owner-identity', () => ({
+  readManagedHookProcessIdentity: vi.fn(async () => identityProbe.processIdentity)
+}))
+
+function lockToken(prefix: string, index: number): string {
+  return `${prefix}${index.toString(16).padStart(4, '0')}-0000-4000-8000-${index
+    .toString(16)
+    .padStart(12, '0')}`
+}
+
+async function createTempHome(): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), 'orca-managed-hook-cleanup-bounds-'))
+  tempHomes.push(home)
+  return home
+}
+
+async function seedUnrelatedFiles(directory: string, count: number): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await writeFile(join(directory, `unrelated-${index.toString().padStart(4, '0')}.txt`), '')
+  }
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  ioProbe.active = 0
+  ioProbe.enabled = false
+  ioProbe.opendirBufferSizes.length = 0
+  ioProbe.peak = 0
+  identityProbe.processIdentity = null
+  for (const home of tempHomes.splice(0)) {
+    await rm(home, { recursive: true, force: true })
+  }
+})
+
+describe('managed-hook lock cleanup bounds', () => {
+  it('streams a large directory and cleans at most eight lock records concurrently', async () => {
+    const home = await createTempHome()
+    const lockParent = join(home, '.orca')
+    const hostIdentity = 'test-host'
+    const recordCount = 257
+    const unrelatedCount = 320
+    await mkdir(lockParent, { recursive: true })
+    for (let index = 0; index < recordCount; index += 1) {
+      const token = lockToken('feed', index)
+      await writeFile(
+        join(lockParent, `managed-hook-install.owner-${token}.json`),
+        JSON.stringify({
+          token,
+          pid: process.pid,
+          hostIdentity,
+          processIdentity: 'stale-process'
+        })
+      )
+    }
+    await seedUnrelatedFiles(lockParent, unrelatedCount)
+    ioProbe.enabled = true
+
+    await cleanupManagedHookLockFiles(lockParent, hostIdentity)
+
+    const remaining = await readdir(lockParent)
+    expect(remaining).toHaveLength(unrelatedCount)
+    expect(remaining.every((entry) => entry.startsWith('unrelated-'))).toBe(true)
+    expect(ioProbe.peak).toBe(MANAGED_HOOK_LOCK_CLEANUP_CONCURRENCY)
+    expect(ioProbe.opendirBufferSizes).toEqual([MANAGED_HOOK_LOCK_DIRECTORY_BUFFER_SIZE])
+  })
+
+  it('preserves an oversized lock record without allocating its contents', async () => {
+    const home = await createTempHome()
+    const lockParent = join(home, '.orca')
+    const token = lockToken('feed', 1)
+    const recordPath = join(lockParent, `managed-hook-install.owner-${token}.json`)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    await mkdir(lockParent, { recursive: true })
+    await writeFile(recordPath, '')
+    await truncate(recordPath, MANAGED_HOOK_LOCK_RECORD_MAX_BYTES + 1)
+
+    await cleanupManagedHookLockFiles(lockParent, 'test-host')
+
+    expect((await stat(recordPath)).size).toBe(MANAGED_HOOK_LOCK_RECORD_MAX_BYTES + 1)
+    expect(warn).toHaveBeenCalledWith(
+      '[agent-hooks] Failed to clean managed-hook lock file',
+      expect.objectContaining({ name: 'NodeFileReadTooLargeError' })
+    )
+  })
+
+  it('recovers a claimed owner without collecting a large directory into an array', async () => {
+    const home = await createTempHome()
+    const lockParent = join(home, '.orca')
+    const lockPath = join(lockParent, 'managed-hook-install.lock')
+    const ownerToken = lockToken('cafe', 1)
+    const claimToken = lockToken('face', 2)
+    const ownerPath = join(lockParent, `managed-hook-install.owner-${ownerToken}.json`)
+    const claimedOwnerPath = join(
+      lockParent,
+      `managed-hook-install.claimed-${ownerToken}-${claimToken}.json`
+    )
+    const hostIdentity = 'test-host'
+    await mkdir(lockParent, { recursive: true })
+    await writeFile(
+      ownerPath,
+      JSON.stringify({
+        token: ownerToken,
+        pid: process.pid,
+        hostIdentity,
+        processIdentity: 'stale-owner'
+      })
+    )
+    await link(ownerPath, lockPath)
+    await writeFile(
+      join(lockParent, `managed-hook-install.claim-${ownerToken}-${claimToken}.json`),
+      JSON.stringify({
+        ownerToken,
+        claimToken,
+        pid: process.pid,
+        hostIdentity,
+        processIdentity: 'stale-claimant'
+      })
+    )
+    await rename(ownerPath, claimedOwnerPath)
+    await seedUnrelatedFiles(lockParent, 512)
+    identityProbe.processIdentity = 'current-process'
+
+    await expect(
+      withManagedHookInstallLock(home, undefined, async () => 'installed', hostIdentity)
+    ).resolves.toBe('installed')
+
+    expect(await readFile(join(lockParent, 'unrelated-0000.txt'), 'utf8')).toBe('')
+    expect(ioProbe.opendirBufferSizes.length).toBeGreaterThanOrEqual(2)
+    expect(
+      ioProbe.opendirBufferSizes.every(
+        (bufferSize) => bufferSize === MANAGED_HOOK_LOCK_DIRECTORY_BUFFER_SIZE
+      )
+    ).toBe(true)
+  })
+})

--- a/src/main/agent-hooks/managed-hook-lock-records.ts
+++ b/src/main/agent-hooks/managed-hook-lock-records.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'node:crypto'
-import { link, lstat, readdir, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { link, lstat, opendir, rename, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 import { readManagedHookProcessIdentity } from './managed-hook-owner-identity'
+
+export const MANAGED_HOOK_LOCK_DIRECTORY_BUFFER_SIZE = 32
+export const MANAGED_HOOK_LOCK_CLEANUP_CONCURRENCY = 8
+export const MANAGED_HOOK_LOCK_RECORD_MAX_BYTES = 2 * 1024 * 1024
 
 const UUID_PATTERN = '[\\da-f]{8}-[\\da-f]{4}-[1-5][\\da-f]{3}-[89ab][\\da-f]{3}-[\\da-f]{12}'
 const OWNER_FILE_PATTERN = new RegExp(
@@ -127,10 +132,16 @@ export async function removeFileIfPresent(path: string): Promise<boolean> {
   }
 }
 
+export async function readManagedHookLockRecord(path: string): Promise<string> {
+  return (await readNodeFileWithinLimit(path, MANAGED_HOOK_LOCK_RECORD_MAX_BYTES)).buffer.toString(
+    'utf8'
+  )
+}
+
 export async function inspectManagedHookLock(lockPath: string): Promise<ManagedHookLockState> {
   let rawOwner: string
   try {
-    rawOwner = await readFile(lockPath, 'utf8')
+    rawOwner = await readManagedHookLockRecord(lockPath)
   } catch (error) {
     if (hasCode(error, 'ENOENT')) {
       return { kind: 'missing' }
@@ -193,7 +204,7 @@ async function cleanOwnerEntry(path: string, token: string, hostIdentity: string
   if (stats.nlink !== 1) {
     return
   }
-  const owner = parseOwner(await readFile(path, 'utf8'), token)
+  const owner = parseOwner(await readManagedHookLockRecord(path), token)
   if (!owner || owner.hostIdentity !== hostIdentity) {
     return
   }
@@ -229,7 +240,7 @@ async function cleanLockEntry(
   if (!claimMatch?.[1] || !claimMatch[2]) {
     return
   }
-  const claim = parseClaim(await readFile(path, 'utf8'), claimMatch[1], claimMatch[2])
+  const claim = parseClaim(await readManagedHookLockRecord(path), claimMatch[1], claimMatch[2])
   if (!claim || claim.hostIdentity !== hostIdentity) {
     return
   }
@@ -250,25 +261,59 @@ async function cleanLockEntry(
   }
 }
 
+function isManagedHookLockRecord(entry: string): boolean {
+  return (
+    OWNER_FILE_PATTERN.test(entry) ||
+    OWNER_DRAFT_PATTERN.test(entry) ||
+    CLAIMED_OWNER_PATTERN.test(entry) ||
+    CLAIM_RECORD_PATTERN.test(entry)
+  )
+}
+
+async function cleanLockEntrySafely(
+  entry: string,
+  lockParent: string,
+  hostIdentity: string
+): Promise<void> {
+  try {
+    await cleanLockEntry(entry, lockParent, hostIdentity)
+  } catch (error) {
+    if (!hasCode(error, 'ENOENT')) {
+      console.warn('[agent-hooks] Failed to clean managed-hook lock file', error)
+    }
+  }
+}
+
 export async function cleanupManagedHookLockFiles(
   lockParent: string,
   hostIdentity: string
 ): Promise<void> {
-  let entries: string[]
+  let directory: Awaited<ReturnType<typeof opendir>>
   try {
-    entries = await readdir(lockParent)
+    directory = await opendir(lockParent, {
+      bufferSize: MANAGED_HOOK_LOCK_DIRECTORY_BUFFER_SIZE
+    })
   } catch {
     return
   }
-  await Promise.all(
-    entries.map(async (entry) => {
-      try {
-        await cleanLockEntry(entry, lockParent, hostIdentity)
-      } catch (error) {
-        if (!hasCode(error, 'ENOENT')) {
-          console.warn('[agent-hooks] Failed to clean managed-hook lock file', error)
-        }
+
+  const pending: string[] = []
+  try {
+    for await (const entry of directory) {
+      if (!isManagedHookLockRecord(entry.name)) {
+        continue
       }
-    })
-  )
+      pending.push(entry.name)
+      if (pending.length === MANAGED_HOOK_LOCK_CLEANUP_CONCURRENCY) {
+        await Promise.all(
+          pending.splice(0).map((name) => cleanLockEntrySafely(name, lockParent, hostIdentity))
+        )
+      }
+    }
+    await Promise.all(
+      pending.splice(0).map((name) => cleanLockEntrySafely(name, lockParent, hostIdentity))
+    )
+  } catch {
+    // Directory enumeration is best-effort, matching the prior readdir behavior.
+  }
 }

--- a/src/main/agent-hooks/managed-hook-owner-identity.test.ts
+++ b/src/main/agent-hooks/managed-hook-owner-identity.test.ts
@@ -57,14 +57,34 @@ async function loadLinuxIdentity(fixture: LinuxIdentityFixture) {
       uid: process.getuid?.() ?? 0
     }
   })
+  const readNodeFileWithinLimit = vi.fn(async (path: string, maxBytes: number) => {
+    if (String(path).endsWith('host-id') && fixture.hostToken) {
+      if (Buffer.byteLength(fixture.hostToken, 'utf8') > maxBytes) {
+        throw new Error('file too large')
+      }
+      return {
+        buffer: Buffer.from(fixture.hostToken, 'utf8'),
+        stats: { size: Buffer.byteLength(fixture.hostToken, 'utf8') }
+      }
+    }
+    throw Object.assign(new Error(`unavailable path: ${String(path)}`), { code: 'ENOENT' })
+  })
   vi.doMock('node:fs/promises', async (importOriginal) => ({
     ...(await importOriginal<Record<string, unknown>>()),
     lstat,
     mkdir,
     readFile,
-    readlink
+    readlink,
+    writeFile: vi.fn(async () => {
+      throw Object.assign(new Error('host-local storage unavailable'), { code: 'EACCES' })
+    })
   }))
-  return { identity: await import('./managed-hook-owner-identity'), readFile }
+  vi.doMock('../../shared/node-bounded-file-reader', () => ({ readNodeFileWithinLimit }))
+  return {
+    identity: await import('./managed-hook-owner-identity'),
+    readFile,
+    readNodeFileWithinLimit
+  }
 }
 
 afterEach(() => {
@@ -76,10 +96,23 @@ afterEach(() => {
   }
   vi.unstubAllEnvs()
   vi.doUnmock('node:fs/promises')
+  vi.doUnmock('../../shared/node-bounded-file-reader')
   vi.resetModules()
 })
 
 describe('managed hook owner identity', () => {
+  it('rejects an oversized durable host token before materializing it', async () => {
+    const { identity, readNodeFileWithinLimit } = await loadLinuxIdentity({
+      hostToken: 'x'.repeat(1025)
+    })
+
+    await expect(identity.readManagedHookHostIdentity()).resolves.toMatch(/^runtime:/)
+    expect(readNodeFileWithinLimit).toHaveBeenCalledWith(
+      '/var/tmp/orca-managed-hooks-1000/host-id',
+      1024
+    )
+  })
+
   it('uses durable host-local identity without requiring Linux machine identity files', async () => {
     vi.stubEnv('SSH_CONNECTION', '198.51.100.8 53100 10.0.0.7 2222')
     const { identity, readFile } = await loadLinuxIdentity({

--- a/src/main/agent-hooks/managed-hook-owner-identity.ts
+++ b/src/main/agent-hooks/managed-hook-owner-identity.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto'
 import { link, lstat, mkdir, readFile, readlink, unlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 
 const execFileAsync = promisify(execFile)
 const runtimeHostIdentity = `runtime:${randomUUID()}`
@@ -10,6 +11,7 @@ const runtimeProcessIdentity = `runtime:${randomUUID()}`
 let hostIdentityPromise: Promise<string> | undefined
 let bootIdentityPromise: Promise<string | undefined> | undefined
 const HOST_TOKEN_PATTERN = /^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/i
+const HOST_TOKEN_FILE_MAX_BYTES = 1024
 
 function hasCode(error: unknown, code: string): boolean {
   return error instanceof Error && 'code' in error && error.code === code
@@ -43,7 +45,8 @@ async function readPublishedHostToken(path: string, uid: number): Promise<string
     if (!stats.isFile() || stats.uid !== uid || (stats.mode & 0o077) !== 0) {
       return undefined
     }
-    const token = (await readFile(path, 'utf8')).trim()
+    const { buffer } = await readNodeFileWithinLimit(path, HOST_TOKEN_FILE_MAX_BYTES)
+    const token = buffer.toString('utf8').trim()
     return HOST_TOKEN_PATTERN.test(token) ? token : undefined
   } catch {
     return undefined

--- a/src/main/agent-hooks/migration-unsupported-pty-state.test.ts
+++ b/src/main/agent-hooks/migration-unsupported-pty-state.test.ts
@@ -6,6 +6,8 @@ import {
   clearMigrationUnsupportedPtysByTabPrefix,
   clearMigrationUnsupportedPtysForPaneKey,
   getMigrationUnsupportedPtySnapshot,
+  MIGRATION_UNSUPPORTED_PTY_MAX_ENTRY_BYTES,
+  MIGRATION_UNSUPPORTED_PTY_MAX_ENTRIES,
   setMigrationUnsupportedPty,
   setMigrationUnsupportedPtyListener,
   setMigrationUnsupportedPtyPersistenceListener
@@ -80,5 +82,47 @@ describe('migration unsupported PTY state', () => {
     expect(listener).toHaveBeenNthCalledWith(2, { type: 'clear', ptyId: 'pty-2' })
     expect(persist).toHaveBeenCalledTimes(1)
     expect(persist).toHaveBeenCalledWith([sibling, otherTab])
+  })
+
+  it('evicts the oldest unsupported PTY after the retention ceiling', () => {
+    for (let index = 0; index < MIGRATION_UNSUPPORTED_PTY_MAX_ENTRIES; index++) {
+      setMigrationUnsupportedPty(makeEntry(`pty-${index}`, `tab-${index}:leaf-a`))
+    }
+    const listener = vi.fn()
+    const persist = vi.fn()
+    setMigrationUnsupportedPtyListener(listener)
+    setMigrationUnsupportedPtyPersistenceListener(persist)
+    const newest = makeEntry(`pty-${MIGRATION_UNSUPPORTED_PTY_MAX_ENTRIES}`, 'tab-newest:leaf-a')
+
+    setMigrationUnsupportedPty(newest)
+
+    const snapshot = getMigrationUnsupportedPtySnapshot()
+    expect(snapshot).toHaveLength(MIGRATION_UNSUPPORTED_PTY_MAX_ENTRIES)
+    expect(snapshot.some((entry) => entry.ptyId === 'pty-0')).toBe(false)
+    expect(snapshot.at(-1)).toEqual(newest)
+    expect(listener).toHaveBeenNthCalledWith(1, { type: 'clear', ptyId: 'pty-0' })
+    expect(listener).toHaveBeenNthCalledWith(2, { type: 'set', entry: newest })
+    expect(persist).toHaveBeenCalledTimes(1)
+    expect(persist).toHaveBeenCalledWith(snapshot)
+  })
+
+  it('rejects oversized entries and clears a prior value for the same PTY', () => {
+    const listener = vi.fn()
+    const persist = vi.fn()
+    setMigrationUnsupportedPtyListener(listener)
+    setMigrationUnsupportedPtyPersistenceListener(persist)
+    setMigrationUnsupportedPty(makeEntry('pty-1', 'tab-1:leaf-a'))
+    listener.mockClear()
+    persist.mockClear()
+
+    setMigrationUnsupportedPty(
+      makeEntry('pty-1', `tab-1:${'x'.repeat(MIGRATION_UNSUPPORTED_PTY_MAX_ENTRY_BYTES)}`)
+    )
+
+    expect(getMigrationUnsupportedPtySnapshot()).toEqual([])
+    expect(listener).toHaveBeenCalledOnce()
+    expect(listener).toHaveBeenCalledWith({ type: 'clear', ptyId: 'pty-1' })
+    expect(persist).toHaveBeenCalledOnce()
+    expect(persist).toHaveBeenCalledWith([])
   })
 })

--- a/src/main/agent-hooks/migration-unsupported-pty-state.ts
+++ b/src/main/agent-hooks/migration-unsupported-pty-state.ts
@@ -1,10 +1,13 @@
 import type { MigrationUnsupportedPtyEntry } from '../../shared/agent-status-types'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
 
 type MigrationUnsupportedPtyEvent =
   | { type: 'set'; entry: MigrationUnsupportedPtyEntry }
   | { type: 'clear'; ptyId: string }
 
 const entriesByPtyId = new Map<string, MigrationUnsupportedPtyEntry>()
+export const MIGRATION_UNSUPPORTED_PTY_MAX_ENTRIES = 500
+export const MIGRATION_UNSUPPORTED_PTY_MAX_ENTRY_BYTES = 16 * 1024
 let listener: ((event: MigrationUnsupportedPtyEvent) => void) | null = null
 let persistenceListener: ((entries: MigrationUnsupportedPtyEntry[]) => void) | null = null
 
@@ -25,7 +28,21 @@ export function setMigrationUnsupportedPtyPersistenceListener(
 }
 
 export function setMigrationUnsupportedPty(entry: MigrationUnsupportedPtyEntry): void {
+  try {
+    stringifyJsonWithinByteLimit(entry, MIGRATION_UNSUPPORTED_PTY_MAX_ENTRY_BYTES)
+  } catch {
+    clearMigrationUnsupportedPty(entry.ptyId)
+    return
+  }
   entriesByPtyId.set(entry.ptyId, entry)
+  while (entriesByPtyId.size > MIGRATION_UNSUPPORTED_PTY_MAX_ENTRIES) {
+    const oldestPtyId = entriesByPtyId.keys().next().value
+    if (oldestPtyId === undefined) {
+      break
+    }
+    entriesByPtyId.delete(oldestPtyId)
+    listener?.({ type: 'clear', ptyId: oldestPtyId })
+  }
   listener?.({ type: 'set', entry })
   persistenceListener?.(getMigrationUnsupportedPtySnapshot())
 }

--- a/src/main/agent-hooks/server-retained-metadata-bounds.test.ts
+++ b/src/main/agent-hooks/server-retained-metadata-bounds.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AgentHookServer,
+  MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES,
+  MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES
+} from './server'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../telemetry/cohort-classifier', () => ({ getCohortAtEmit: () => ({}) }))
+
+const PANE_KEY = makePaneKey('metadata-bounds-tab', '11111111-1111-4111-8111-111111111111')
+
+describe('AgentHookServer retained metadata bounds', () => {
+  it('preserves every metadata field at its exact UTF-8 byte limit', () => {
+    const server = new AgentHookServer()
+    const exactId = 'é'.repeat(MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES / 2)
+    const exactPath = 'é'.repeat(MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES / 2)
+
+    expect(Buffer.byteLength(exactId, 'utf8')).toBe(MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES)
+    expect(Buffer.byteLength(exactPath, 'utf8')).toBe(MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES)
+
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        tabId: 'metadata-bounds-tab',
+        worktreeId: exactPath,
+        launchToken: exactId,
+        promptInteractionKey: exactId,
+        hookEventName: exactId,
+        toolUseId: exactId,
+        toolAgentId: exactId,
+        toolAgentType: exactId,
+        providerSession: {
+          key: 'session_id',
+          id: 'session-1',
+          transcriptPath: exactPath
+        },
+        payload: { state: 'working', prompt: 'ordinary prompt', agentType: 'claude' }
+      },
+      exactId
+    )
+
+    const retained = server._getStateForTests().lastStatusByPaneKey.get(PANE_KEY)
+    expect(retained).toMatchObject({
+      launchToken: exactId,
+      worktreeId: exactPath,
+      connectionId: exactId,
+      promptInteractionKey: exactId,
+      hookEventName: exactId,
+      toolUseId: exactId,
+      toolAgentId: exactId,
+      toolAgentType: exactId,
+      providerSession: {
+        key: 'session_id',
+        id: 'session-1',
+        transcriptPath: exactPath
+      }
+    })
+  })
+
+  it('omits optional metadata one byte over its limit', () => {
+    const server = new AgentHookServer()
+    const oversizedId = `${'é'.repeat(MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES / 2)}x`
+    const oversizedPath = `${'é'.repeat(MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES / 2)}x`
+
+    expect(Buffer.byteLength(oversizedId, 'utf8')).toBe(MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES + 1)
+    expect(Buffer.byteLength(oversizedPath, 'utf8')).toBe(
+      MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES + 1
+    )
+
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        tabId: 'metadata-bounds-tab',
+        worktreeId: oversizedPath,
+        launchToken: oversizedId,
+        promptInteractionKey: oversizedId,
+        hookEventName: oversizedId,
+        toolUseId: oversizedId,
+        toolAgentId: oversizedId,
+        toolAgentType: oversizedId,
+        providerSession: {
+          key: 'session_id',
+          id: 'session-1',
+          transcriptPath: oversizedPath
+        },
+        payload: { state: 'working', prompt: 'ordinary prompt', agentType: 'claude' }
+      },
+      'connection-1'
+    )
+
+    const retained = server._getStateForTests().lastStatusByPaneKey.get(PANE_KEY)
+    expect(retained).toMatchObject({
+      connectionId: 'connection-1',
+      providerSession: { key: 'session_id', id: 'session-1' }
+    })
+    expect(retained).not.toHaveProperty('providerSession.transcriptPath')
+    for (const field of [
+      'launchToken',
+      'worktreeId',
+      'promptInteractionKey',
+      'hookEventName',
+      'toolUseId',
+      'toolAgentId',
+      'toolAgentType'
+    ]) {
+      expect(retained?.[field as keyof typeof retained]).toBeUndefined()
+    }
+  })
+
+  it('rejects oversized connection authority without retaining a watermark', () => {
+    const server = new AgentHookServer()
+    const listener = vi.fn()
+    const oversizedConnectionId = 'x'.repeat(MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES + 1)
+    server.setPaneStatusClearListener(listener)
+
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        payload: { state: 'working', prompt: 'ordinary prompt', agentType: 'claude' }
+      },
+      oversizedConnectionId
+    )
+    server.clearStatusEntriesForConnection(oversizedConnectionId)
+
+    expect(server.getStatusSnapshot()).toEqual([])
+    expect(
+      (
+        server as unknown as {
+          connectionTimestampWatermarkById: Map<string, number>
+        }
+      ).connectionTimestampWatermarkById
+    ).toHaveLength(0)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('rejects a path-dependent Pi identity when its transcript path is oversized', () => {
+    const server = new AgentHookServer()
+
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        providerSession: {
+          key: 'session_id',
+          id: 'pi-session-1',
+          transcriptPath: 'x'.repeat(MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES + 1)
+        },
+        providerSessionOnly: true,
+        payload: { state: 'done', prompt: '', agentType: 'pi' }
+      },
+      'connection-1'
+    )
+
+    expect(server.getStatusSnapshot()).toEqual([])
+  })
+})

--- a/src/main/agent-hooks/server-status-cache-bound.test.ts
+++ b/src/main/agent-hooks/server-status-cache-bound.test.ts
@@ -1,0 +1,154 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  AgentHookServer,
+  MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS,
+  MAX_AGENT_HOOK_LAST_STATUS_FILE_BYTES
+} from './server'
+import { MAX_AGENT_HOOK_STATUS_CACHE_PANES } from '../../shared/agent-hook-status-cache'
+import type { AgentHookEventPayload } from '../../shared/agent-hook-listener'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../shared/agent-status-types'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+vi.mock('../telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('../telemetry/cohort-classifier', () => ({ getCohortAtEmit: () => ({}) }))
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function paneKey(index: number): string {
+  return makePaneKey(`status-cache-${index}`, LEAF_ID)
+}
+
+function cachedStatus(
+  index: number,
+  state: AgentHookEventPayload['payload']['state'],
+  receivedAt: number
+): AgentHookEventPayload & { receivedAt: number; stateStartedAt: number } {
+  return {
+    paneKey: paneKey(index),
+    connectionId: null,
+    receivedAt,
+    stateStartedAt: receivedAt,
+    payload: { state, prompt: `prompt-${index}`, agentType: 'claude' }
+  }
+}
+
+describe('AgentHookServer status cache bound', () => {
+  it('evicts a completed row before fresh work and clears related state', () => {
+    const server = new AgentHookServer()
+    const listener = server._getStateForTests()
+    const now = Date.now()
+    for (let index = 0; index < MAX_AGENT_HOOK_STATUS_CACHE_PANES; index += 1) {
+      const state = index === MAX_AGENT_HOOK_STATUS_CACHE_PANES - 1 ? 'done' : 'working'
+      listener.lastStatusByPaneKey.set(paneKey(index), cachedStatus(index, state, now))
+    }
+    const completedPaneKey = paneKey(MAX_AGENT_HOOK_STATUS_CACHE_PANES - 1)
+    listener.lastPromptByPaneKey.set(completedPaneKey, 'cached prompt')
+    const onClear = vi.fn()
+    server.setPaneStatusClearListener(onClear)
+
+    const currentPaneKey = paneKey(MAX_AGENT_HOOK_STATUS_CACHE_PANES)
+    server.ingestRemote(
+      {
+        paneKey: currentPaneKey,
+        payload: { state: 'working', prompt: 'current', agentType: 'claude' }
+      },
+      'connection-1'
+    )
+
+    expect(listener.lastStatusByPaneKey.size).toBe(MAX_AGENT_HOOK_STATUS_CACHE_PANES)
+    expect(listener.lastStatusByPaneKey.has(paneKey(0))).toBe(true)
+    expect(listener.lastStatusByPaneKey.has(completedPaneKey)).toBe(false)
+    expect(listener.lastStatusByPaneKey.has(currentPaneKey)).toBe(true)
+    expect(listener.lastPromptByPaneKey.has(completedPaneKey)).toBe(false)
+    expect(onClear).toHaveBeenCalledOnce()
+    expect(onClear).toHaveBeenCalledWith({ paneKey: completedPaneKey })
+  })
+
+  it('evicts a stale hydrated row before older fresh work at capacity', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-agent-status-cache-'))
+    const endpointDir = join(userDataPath, 'agent-hooks')
+    mkdirSync(endpointDir, { recursive: true })
+    const now = Date.now()
+    const entries: Record<string, ReturnType<typeof cachedStatus>> = {}
+    for (let index = 0; index <= MAX_AGENT_HOOK_STATUS_CACHE_PANES; index += 1) {
+      const receivedAt = index === 1 ? now - AGENT_STATUS_STALE_AFTER_MS - 1 : now
+      entries[paneKey(index)] = cachedStatus(index, 'working', receivedAt)
+    }
+    writeFileSync(join(endpointDir, 'last-status.json'), JSON.stringify({ version: 2, entries }))
+    const server = new AgentHookServer()
+
+    try {
+      await server.start({ env: 'production', userDataPath })
+      const listener = server._getStateForTests()
+
+      expect(listener.lastStatusByPaneKey.size).toBe(MAX_AGENT_HOOK_STATUS_CACHE_PANES)
+      expect(listener.lastStatusByPaneKey.has(paneKey(0))).toBe(true)
+      expect(listener.lastStatusByPaneKey.has(paneKey(1))).toBe(false)
+      expect(listener.lastStatusByPaneKey.has(paneKey(MAX_AGENT_HOOK_STATUS_CACHE_PANES))).toBe(
+        true
+      )
+    } finally {
+      server.stop()
+      rmSync(userDataPath, { recursive: true, force: true })
+    }
+  })
+
+  it('bounds connection watermarks and refreshes recency before overflow', () => {
+    const server = new AgentHookServer()
+    const watermarks = (
+      server as unknown as {
+        connectionTimestampWatermarkById: Map<string, number>
+      }
+    ).connectionTimestampWatermarkById
+
+    for (let index = 0; index < MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS; index += 1) {
+      server.clearStatusEntriesForConnection(`connection-${index}`)
+    }
+    expect(watermarks.size).toBe(MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS)
+
+    server.clearStatusEntriesForConnection('connection-0')
+    server.clearStatusEntriesForConnection(
+      `connection-${MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS}`
+    )
+
+    expect(watermarks.size).toBe(MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS)
+    expect(watermarks.has('connection-0')).toBe(true)
+    expect(watermarks.has('connection-1')).toBe(false)
+    expect(watermarks.has(`connection-${MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS}`)).toBe(
+      true
+    )
+  })
+
+  it('persists the newest statuses without exceeding its own hydration ceiling', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-agent-status-file-bound-'))
+    const server = new AgentHookServer()
+
+    try {
+      await server.start({ env: 'production', userDataPath })
+      const listener = server._getStateForTests()
+      const retainedMetadata = 'x'.repeat(64 * 1024)
+      for (let index = 0; index < MAX_AGENT_HOOK_STATUS_CACHE_PANES; index += 1) {
+        listener.lastStatusByPaneKey.set(paneKey(index), {
+          ...cachedStatus(index, 'working', Date.now()),
+          worktreeId: retainedMetadata
+        })
+      }
+
+      server.flushStatusPersistSync()
+
+      const path = join(userDataPath, 'agent-hooks', 'last-status.json')
+      const persisted = JSON.parse(readFileSync(path, 'utf8')) as {
+        entries: Record<string, unknown>
+      }
+      expect(statSync(path).size).toBeLessThanOrEqual(MAX_AGENT_HOOK_LAST_STATUS_FILE_BYTES)
+      expect(Object.keys(persisted.entries).length).toBeLessThan(MAX_AGENT_HOOK_STATUS_CACHE_PANES)
+      expect(persisted.entries[paneKey(MAX_AGENT_HOOK_STATUS_CACHE_PANES - 1)]).toBeDefined()
+    } finally {
+      server.stop()
+      rmSync(userDataPath, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -8,6 +8,7 @@ import {
   readFileSync,
   rmSync,
   statSync,
+  truncateSync,
   utimesSync,
   writeFileSync
 } from 'node:fs'
@@ -17,6 +18,8 @@ import {
   AgentHookServer,
   agentHookServer,
   CLOSED_AGENT_STATUS_TAB_IDS_MAX,
+  MAX_AGENT_HOOK_LAST_STATUS_FILE_BYTES,
+  MAX_AGENT_HOOK_LAST_STATUS_STRUCTURAL_TOKENS,
   _internals
 } from './server'
 import {
@@ -6614,6 +6617,46 @@ describe('Last-status persistence', () => {
     } finally {
       server.stop()
       warnSpy.mockRestore()
+    }
+  })
+
+  it('treats an oversized sparse last-status file as empty hydration', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    writeFileSync(lastStatusPath(), '{"version":2,"entries":{}}', 'utf8')
+    truncateSync(lastStatusPath(), MAX_AGENT_HOOK_LAST_STATUS_FILE_BYTES + 1)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getStatusSnapshot()).toEqual([])
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[agent-hooks] failed to read last-status file:',
+        expect.any(Error)
+      )
+    } finally {
+      server.stop()
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('rejects structurally amplified last-status JSON before parsing', async () => {
+    mkdirSync(join(userDataPath, 'agent-hooks'), { recursive: true })
+    const values = '0,'.repeat(MAX_AGENT_HOOK_LAST_STATUS_STRUCTURAL_TOKENS)
+    writeFileSync(lastStatusPath(), `[${values}0]`, 'utf8')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    const server = new AgentHookServer()
+    await server.start({ env: 'production', userDataPath })
+    try {
+      expect(server.getStatusSnapshot()).toEqual([])
+      expect(parseSpy).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[agent-hooks] last-status file is invalid or too complex; ignoring'
+      )
+    } finally {
+      server.stop()
+      warnSpy.mockRestore()
+      parseSpy.mockRestore()
     }
   })
 

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -2,13 +2,19 @@
 // Why: this main-process adapter keeps listener internals in shared/ (`src/shared/agent-hook-listener.ts`) so the relay can host the same pipeline without Electron. See docs/design/agent-status-over-ssh.md §5.
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
 import { createHash, randomBytes, randomUUID } from 'node:crypto'
-import { chmodSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, renameSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import { AGENT_KIND_VALUES, type AgentKind } from '../../shared/telemetry-events'
 import { ORCA_HOOK_PROTOCOL_VERSION } from '../../shared/agent-hook-types'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../../shared/node-bounded-json-stringify'
 import {
   clearAllListenerCaches,
   clearPaneCacheState,
@@ -35,6 +41,7 @@ import {
   type HookListenerState
 } from '../../shared/agent-hook-listener'
 import type { AgentHookSource } from '../../shared/agent-hook-relay'
+import { upsertBoundedAgentHookStatus } from '../../shared/agent-hook-status-cache'
 import {
   CLAUDE_STATUSLINE_PATHNAME,
   parseClaudeStatusLineBody,
@@ -69,6 +76,7 @@ import {
   type AgentProviderSessionMetadata
 } from '../../shared/agent-session-resume'
 import { isCommandCodeNewTurnWhileWorking } from '../../shared/command-code-turn-boundary'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 export type { AgentHookSource }
 
@@ -96,6 +104,9 @@ type PaneKeyAliasEntry = {
 
 // Why: co-located with the endpoint file in userData/agent-hooks/ so hook-server cross-restart artifacts stay together.
 const LAST_STATUS_FILE_NAME = 'last-status.json'
+export const MAX_AGENT_HOOK_LAST_STATUS_FILE_BYTES = 16 * 1024 * 1024
+export const MAX_AGENT_HOOK_LAST_STATUS_STRUCTURAL_TOKENS = 1_000_000
+export const MAX_AGENT_HOOK_LAST_STATUS_NESTING_DEPTH = 128
 const ASSISTANT_MESSAGE_RETRY_ATTEMPTS = 5
 const ASSISTANT_MESSAGE_RETRY_MS = 50
 const INTERRUPTED_DONE_LATE_WORKING_SUPPRESSION_MS = 15_000
@@ -115,6 +126,9 @@ const HYDRATE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
 export const CLOSED_AGENT_STATUS_TAB_IDS_MAX = 1024
 export const CLOSED_AGENT_STATUS_PANE_KEYS_MAX = 1024
 export const PANE_KEY_ALIASES_MAX = 1024
+export const MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS = 1024
+export const MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES = 1024
+export const MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES = 16 * 1024
 
 type LastStatusFile = {
   version: number
@@ -181,6 +195,100 @@ function isValidPiProviderSessionOnly(
   return Boolean(providerSession && agentType === 'pi' && getAgentResumeArgv('pi', providerSession))
 }
 
+function isRetainedStringWithinByteLimit(value: string, maxBytes: number): boolean {
+  return !measureUtf8ByteLength(value, { stopAfterBytes: maxBytes }).exceededLimit
+}
+
+function retainOptionalStringWithinByteLimit(value: unknown, maxBytes: number): string | undefined {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    !isRetainedStringWithinByteLimit(value, maxBytes)
+  ) {
+    return undefined
+  }
+  return value
+}
+
+function normalizeOptionalRetainedString(value: unknown, maxBytes: number): string | undefined {
+  const retained = retainOptionalStringWithinByteLimit(value, maxBytes)
+  if (!retained) {
+    return undefined
+  }
+  const trimmed = retained.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+function boundProviderSessionTranscriptPath(
+  providerSession: AgentProviderSessionMetadata | undefined
+): AgentProviderSessionMetadata | undefined {
+  if (!providerSession?.transcriptPath) {
+    return providerSession
+  }
+  const transcriptPath = retainOptionalStringWithinByteLimit(
+    providerSession.transcriptPath,
+    MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES
+  )
+  return transcriptPath === providerSession.transcriptPath
+    ? providerSession
+    : { key: providerSession.key, id: providerSession.id }
+}
+
+function boundAgentHookEventMetadata<T extends AgentHookEventPayload>(event: T): T {
+  const launchToken = retainOptionalStringWithinByteLimit(
+    event.launchToken,
+    MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+  )
+  const worktreeId = retainOptionalStringWithinByteLimit(
+    event.worktreeId,
+    MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES
+  )
+  const promptInteractionKey = retainOptionalStringWithinByteLimit(
+    event.promptInteractionKey,
+    MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+  )
+  const hookEventName = retainOptionalStringWithinByteLimit(
+    event.hookEventName,
+    MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+  )
+  const toolUseId = retainOptionalStringWithinByteLimit(
+    event.toolUseId,
+    MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+  )
+  const toolAgentId = retainOptionalStringWithinByteLimit(
+    event.toolAgentId,
+    MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+  )
+  const toolAgentType = retainOptionalStringWithinByteLimit(
+    event.toolAgentType,
+    MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+  )
+  const providerSession = boundProviderSessionTranscriptPath(event.providerSession)
+  if (
+    launchToken === event.launchToken &&
+    worktreeId === event.worktreeId &&
+    promptInteractionKey === event.promptInteractionKey &&
+    hookEventName === event.hookEventName &&
+    toolUseId === event.toolUseId &&
+    toolAgentId === event.toolAgentId &&
+    toolAgentType === event.toolAgentType &&
+    providerSession === event.providerSession
+  ) {
+    return event
+  }
+  return {
+    ...event,
+    launchToken,
+    worktreeId,
+    promptInteractionKey,
+    hookEventName,
+    toolUseId,
+    toolAgentId,
+    toolAgentType,
+    providerSession
+  }
+}
+
 function sanitizeHydratedEntry(
   paneKey: string,
   rawEntry: unknown
@@ -225,7 +333,10 @@ function sanitizeHydratedEntry(
   let connectionId: string | null
   if (connectionIdRaw === null || connectionIdRaw === undefined) {
     connectionId = null
-  } else if (typeof connectionIdRaw === 'string') {
+  } else if (
+    typeof connectionIdRaw === 'string' &&
+    isRetainedStringWithinByteLimit(connectionIdRaw, MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES)
+  ) {
     connectionId = connectionIdRaw
   } else {
     return null
@@ -234,12 +345,14 @@ function sanitizeHydratedEntry(
   if (!payload) {
     return null
   }
-  const providerSession = normalizeAgentProviderSession(record.providerSession) ?? undefined
+  const providerSession = boundProviderSessionTranscriptPath(
+    normalizeAgentProviderSession(record.providerSession) ?? undefined
+  )
   const providerSessionOnly = record.providerSessionOnly === true
   if (providerSessionOnly && !isValidPiProviderSessionOnly(providerSession, payload.agentType)) {
     return null
   }
-  return {
+  return boundAgentHookEventMetadata({
     paneKey,
     launchToken: typeof record.launchToken === 'string' ? record.launchToken : undefined,
     tabId: typeof tabId === 'string' ? tabId : undefined,
@@ -255,7 +368,7 @@ function sanitizeHydratedEntry(
     payload,
     receivedAt,
     stateStartedAt
-  }
+  })
 }
 
 function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentStatusIpcPayload {
@@ -750,6 +863,48 @@ export class AgentHookServer {
     }
   }
 
+  private cacheStatusEntry(entry: EnrichedAgentHookEventPayload, now = entry.receivedAt): number {
+    const boundedEntry = boundAgentHookEventMetadata(entry)
+    const evicted = upsertBoundedAgentHookStatus(this.state, boundedEntry, { now })
+    for (const { paneKey } of evicted) {
+      this.clearAssistantMessageRetry(paneKey)
+      this.runtimeObservedStatusPaneKeys.delete(paneKey)
+      this.promptSentDedupeByPaneKey.delete(paneKey)
+      this.onPaneStatusCleared?.({ paneKey })
+    }
+    return evicted.length
+  }
+
+  private rememberConnectionTimestampWatermark(connectionId: string, timestamp: number): void {
+    this.connectionTimestampWatermarkById.delete(connectionId)
+    this.connectionTimestampWatermarkById.set(connectionId, timestamp)
+    if (
+      this.connectionTimestampWatermarkById.size <= MAX_AGENT_HOOK_CONNECTION_TIMESTAMP_WATERMARKS
+    ) {
+      return
+    }
+    const activeConnectionIds = new Set<string>()
+    for (const entry of this.state.lastStatusByPaneKey.values()) {
+      if (entry.connectionId) {
+        activeConnectionIds.add(entry.connectionId)
+      }
+    }
+    let oldestFallback: string | undefined
+    for (const retainedConnectionId of this.connectionTimestampWatermarkById.keys()) {
+      if (retainedConnectionId === connectionId) {
+        continue
+      }
+      oldestFallback ??= retainedConnectionId
+      if (!activeConnectionIds.has(retainedConnectionId)) {
+        this.connectionTimestampWatermarkById.delete(retainedConnectionId)
+        return
+      }
+    }
+    if (oldestFallback) {
+      this.connectionTimestampWatermarkById.delete(oldestFallback)
+    }
+  }
+
   private hashPromptForTelemetryDedupe(prompt: string): string {
     return createHash('sha256')
       .update(this.promptSentHashSalt)
@@ -819,7 +974,8 @@ export class AgentHookServer {
     }
   }
 
-  private applyNormalizedStatus(payload: AgentHookEventPayload): EnrichedAgentHookEventPayload {
+  private applyNormalizedStatus(rawPayload: AgentHookEventPayload): EnrichedAgentHookEventPayload {
+    const payload = boundAgentHookEventMetadata(rawPayload)
     const previous = this.state.lastStatusByPaneKey.get(payload.paneKey) as
       | EnrichedAgentHookEventPayload
       | undefined
@@ -829,14 +985,14 @@ export class AgentHookServer {
     // Why: Date.now() can repeat across reconnect; a remote replay must sort strictly after its connection's transient clear.
     const now = Math.max(Date.now(), (connectionClearWatermark ?? -1) + 1)
     if (payload.connectionId) {
-      this.connectionTimestampWatermarkById.set(payload.connectionId, now)
+      this.rememberConnectionTimestampWatermark(payload.connectionId, now)
     }
     if (payload.providerSessionOnly) {
       // Why: Pi session_start replaces stale turn state and survives replay, but must not emit prompt telemetry or a fabricated status.
       const enriched = this.attachStatusTiming(payload, now)
       this.clearAssistantMessageRetry(enriched.paneKey)
       this.runtimeObservedStatusPaneKeys.delete(enriched.paneKey)
-      this.state.lastStatusByPaneKey.set(enriched.paneKey, enriched)
+      this.cacheStatusEntry(enriched)
       this.scheduleStatusPersist()
       this.notifyStatusChangeListeners()
       this.onAgentStatus?.(enriched)
@@ -948,7 +1104,7 @@ export class AgentHookServer {
     }
     const enriched = this.attachStatusTiming(effectivePayload, now)
     this.runtimeObservedStatusPaneKeys.add(enriched.paneKey)
-    this.state.lastStatusByPaneKey.set(enriched.paneKey, enriched)
+    this.cacheStatusEntry(enriched)
     this.scheduleStatusPersist()
     this.notifyStatusChangeListeners()
     this.onAgentStatus?.(enriched)
@@ -1320,10 +1476,16 @@ export class AgentHookServer {
     if (this.shouldSuppressClosedTabStatus(paneKey)) {
       return
     }
-    const worktreeId =
-      event.worktreeId !== undefined && event.worktreeId.trim().length > 0
-        ? event.worktreeId.trim()
-        : undefined
+    const worktreeId = normalizeOptionalRetainedString(
+      event.worktreeId,
+      MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES
+    )
+    if (
+      typeof event.connectionId === 'string' &&
+      !isRetainedStringWithinByteLimit(event.connectionId, MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES)
+    ) {
+      return
+    }
     const connectionId =
       typeof event.connectionId === 'string' && event.connectionId.trim().length > 0
         ? event.connectionId.trim()
@@ -1375,6 +1537,9 @@ export class AgentHookServer {
     if (typeof connectionId !== 'string') {
       return
     }
+    if (!isRetainedStringWithinByteLimit(connectionId, MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES)) {
+      return
+    }
     const trimmedConnectionId = connectionId.trim()
     if (trimmedConnectionId.length === 0) {
       return
@@ -1418,32 +1583,33 @@ export class AgentHookServer {
     if (this.shouldSuppressClosedTabStatus(paneKey)) {
       return
     }
-    const worktreeId =
-      envelope.worktreeId !== undefined && envelope.worktreeId.trim().length > 0
-        ? envelope.worktreeId.trim()
-        : undefined
-    const hookEventName =
-      typeof envelope.hookEventName === 'string' && envelope.hookEventName.trim().length > 0
-        ? envelope.hookEventName.trim()
-        : undefined
-    const promptInteractionKey =
-      typeof envelope.promptInteractionKey === 'string' &&
-      envelope.promptInteractionKey.trim().length > 0
-        ? envelope.promptInteractionKey.trim()
-        : undefined
-    const toolUseId =
-      typeof envelope.toolUseId === 'string' && envelope.toolUseId.trim().length > 0
-        ? envelope.toolUseId.trim()
-        : undefined
-    const toolAgentId =
-      typeof envelope.toolAgentId === 'string' && envelope.toolAgentId.trim().length > 0
-        ? envelope.toolAgentId.trim()
-        : undefined
-    const toolAgentType =
-      typeof envelope.toolAgentType === 'string' && envelope.toolAgentType.trim().length > 0
-        ? envelope.toolAgentType.trim()
-        : undefined
-    const providerSession = normalizeAgentProviderSession(envelope.providerSession) ?? undefined
+    const worktreeId = normalizeOptionalRetainedString(
+      envelope.worktreeId,
+      MAX_AGENT_HOOK_RETAINED_PATH_UTF8_BYTES
+    )
+    const hookEventName = normalizeOptionalRetainedString(
+      envelope.hookEventName,
+      MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+    )
+    const promptInteractionKey = normalizeOptionalRetainedString(
+      envelope.promptInteractionKey,
+      MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+    )
+    const toolUseId = normalizeOptionalRetainedString(
+      envelope.toolUseId,
+      MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+    )
+    const toolAgentId = normalizeOptionalRetainedString(
+      envelope.toolAgentId,
+      MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+    )
+    const toolAgentType = normalizeOptionalRetainedString(
+      envelope.toolAgentType,
+      MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+    )
+    const providerSession = boundProviderSessionTranscriptPath(
+      normalizeAgentProviderSession(envelope.providerSession) ?? undefined
+    )
     // Why: relay crosses a trust boundary — re-run the canonical normalizer to enforce caps/invariants (returns null on malformed).
     const normalizedPayload = normalizeAgentStatusPayload(envelope.payload)
     if (!normalizedPayload) {
@@ -1463,7 +1629,10 @@ export class AgentHookServer {
     })
     const event: AgentHookEventPayload = {
       paneKey,
-      launchToken: envelope.launchToken,
+      launchToken: normalizeOptionalRetainedString(
+        envelope.launchToken,
+        MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES
+      ),
       tabId,
       worktreeId,
       connectionId: trimmedConnectionId,
@@ -1548,8 +1717,14 @@ export class AgentHookServer {
         trackEmptyPaneKeyHook(body)
         const aliasedBody = this.normalizeHookBodyPaneKeyAlias(body)
         const normalized = normalizeHookPayload(this.state, source, aliasedBody, this.env)
-        if (normalized && !this.shouldSuppressClosedTabStatus(normalized.paneKey)) {
-          const enriched = this.applyNormalizedStatus(normalized)
+        const retained = normalized ? boundAgentHookEventMetadata(normalized) : null
+        if (
+          retained &&
+          (!retained.providerSessionOnly ||
+            isValidPiProviderSessionOnly(retained.providerSession, retained.payload.agentType)) &&
+          !this.shouldSuppressClosedTabStatus(retained.paneKey)
+        ) {
+          const enriched = this.applyNormalizedStatus(retained)
           this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
         }
 
@@ -1626,6 +1801,9 @@ export class AgentHookServer {
 
   /** Clear statuses proven to belong to one lost SSH transport. */
   clearStatusEntriesForConnection(connectionId: string): void {
+    if (!isRetainedStringWithinByteLimit(connectionId, MAX_AGENT_HOOK_RETAINED_ID_UTF8_BYTES)) {
+      return
+    }
     const normalizedConnectionId = connectionId.trim()
     if (normalizedConnectionId.length === 0) {
       return
@@ -1634,7 +1812,7 @@ export class AgentHookServer {
       Date.now(),
       (this.connectionTimestampWatermarkById.get(normalizedConnectionId) ?? -1) + 1
     )
-    this.connectionTimestampWatermarkById.set(normalizedConnectionId, clearedAt)
+    this.rememberConnectionTimestampWatermark(normalizedConnectionId, clearedAt)
     let statusChanged = false
     for (const [paneKey, rawEntry] of this.state.lastStatusByPaneKey) {
       const entry = rawEntry as EnrichedAgentHookEventPayload
@@ -1829,7 +2007,10 @@ export class AgentHookServer {
     this.state.lastStatusByPaneKey.clear()
     let raw: string
     try {
-      raw = readFileSync(this.lastStatusFilePath, 'utf8')
+      raw = readNodeFileSyncWithinLimit(
+        this.lastStatusFilePath,
+        MAX_AGENT_HOOK_LAST_STATUS_FILE_BYTES
+      ).buffer.toString('utf8')
     } catch (err) {
       // Why: missing file is normal (first launch); other errors degrade to empty hydration + one warn.
       if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -1839,9 +2020,13 @@ export class AgentHookServer {
     }
     let parsed: unknown
     try {
+      assertJsonTextStructureWithinLimits(raw, {
+        structuralTokens: MAX_AGENT_HOOK_LAST_STATUS_STRUCTURAL_TOKENS,
+        nestingDepth: MAX_AGENT_HOOK_LAST_STATUS_NESTING_DEPTH
+      })
       parsed = JSON.parse(raw)
     } catch {
-      console.warn('[agent-hooks] last-status file is not valid JSON; ignoring')
+      console.warn('[agent-hooks] last-status file is invalid or too complex; ignoring')
       return
     }
     if (typeof parsed !== 'object' || parsed === null) {
@@ -1866,7 +2051,8 @@ export class AgentHookServer {
     let dropped = 0
     let prunedLegacyClaudeSubagents = 0
     // Why: drop entries older than HYDRATE_MAX_AGE_MS to bound disk growth (one Date.now() for a consistent cutoff).
-    const ttlCutoff = Date.now() - HYDRATE_MAX_AGE_MS
+    const hydrateNow = Date.now()
+    const ttlCutoff = hydrateNow - HYDRATE_MAX_AGE_MS
     for (const [paneKey, rawEntry] of Object.entries(entries)) {
       const resolvedPaneKey = this.resolvePaneKeyAlias(paneKey)
       const rawResolvedEntry =
@@ -1881,11 +2067,11 @@ export class AgentHookServer {
             (entry.payload.subagents?.length ?? 0) - (hydratedPayload.subagents?.length ?? 0)
           entry.payload = hydratedPayload
         }
-        this.state.lastStatusByPaneKey.set(resolvedPaneKey, entry)
+        dropped += this.cacheStatusEntry(entry, hydrateNow)
         if (entry.connectionId) {
           // Why: a restart can see an earlier wall clock; seed ordering so new events stay after disk state.
           const previousWatermark = this.connectionTimestampWatermarkById.get(entry.connectionId)
-          this.connectionTimestampWatermarkById.set(
+          this.rememberConnectionTimestampWatermark(
             entry.connectionId,
             Math.max(previousWatermark ?? -1, entry.receivedAt)
           )
@@ -1907,7 +2093,7 @@ export class AgentHookServer {
     }
     if (dropped > 0) {
       console.warn(
-        `[agent-hooks] last-status hydrate dropped ${dropped} entries (kept ${hydrated})`
+        `[agent-hooks] last-status hydrate dropped ${dropped} entries (kept ${this.state.lastStatusByPaneKey.size})`
       )
     }
     if (dropped > 0 || prunedLegacyClaudeSubagents > 0) {
@@ -1920,17 +2106,45 @@ export class AgentHookServer {
   }
 
   private serializeStatusFile(): string {
-    const entries: Record<string, EnrichedAgentHookEventPayload> = {}
-    for (const [paneKey, payload] of this.state.lastStatusByPaneKey) {
+    const prefix = `{"version":${LAST_STATUS_FILE_VERSION},"entries":{`
+    const suffix = '}}'
+    let remainingBytes =
+      MAX_AGENT_HOOK_LAST_STATUS_FILE_BYTES -
+      Buffer.byteLength(prefix, 'utf8') -
+      Buffer.byteLength(suffix, 'utf8')
+    const fragments: string[] = []
+    const statuses = Array.from(this.state.lastStatusByPaneKey)
+    for (let index = statuses.length - 1; index >= 0; index -= 1) {
+      const [paneKey, payload] = statuses[index]
       // Why: never persist invalid keys (matches the hydrate-path invariant).
       if (!isValidPaneKey(paneKey)) {
         continue
       }
       const { promptInteractionKey: _promptInteractionKey, ...persistedPayload } = payload
-      entries[paneKey] = persistedPayload as EnrichedAgentHookEventPayload
+      const propertyPrefix = `${JSON.stringify(paneKey)}:`
+      const separatorBytes = fragments.length > 0 ? 1 : 0
+      const payloadBudget =
+        remainingBytes - separatorBytes - Buffer.byteLength(propertyPrefix, 'utf8')
+      if (payloadBudget < 0) {
+        continue
+      }
+      let serializedPayload: string
+      try {
+        serializedPayload = stringifyJsonWithinByteLimit(persistedPayload, payloadBudget).serialized
+      } catch (error) {
+        if (error instanceof JsonStringifyByteLimitError) {
+          continue
+        }
+        throw error
+      }
+      fragments.push(`${propertyPrefix}${serializedPayload}`)
+      remainingBytes -=
+        separatorBytes +
+        Buffer.byteLength(propertyPrefix, 'utf8') +
+        Buffer.byteLength(serializedPayload, 'utf8')
     }
-    const file: LastStatusFile = { version: LAST_STATUS_FILE_VERSION, entries }
-    return JSON.stringify(file)
+    fragments.reverse()
+    return `${prefix}${fragments.join(',')}${suffix}`
   }
 
   private scheduleStatusPersist(): void {

--- a/src/main/agent-hooks/wsl-hook-fs-adapter.ts
+++ b/src/main/agent-hooks/wsl-hook-fs-adapter.ts
@@ -5,10 +5,20 @@
 // `installer-utils-remote.ts` touches are implemented.
 import type { SFTPWrapper } from 'ssh2'
 
+import { assertFilesystemDirectoryWithinLimit } from '../../shared/filesystem-directory-listing-limit'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import type { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
 import { wslCodexRuntimeHomeForGuestHome } from '../pty/codex-home-wsl-env'
-import { WSL_HOOK_FS_METHODS, type WslFsResult } from '../../shared/wsl-hook-relay-contract'
+import {
+  WSL_HOOK_FS_METHODS,
+  WSL_HOOK_FS_MAX_DIRECTORY_ENTRIES,
+  WSL_HOOK_FS_MAX_DIRECTORY_RETAINED_BYTES,
+  WSL_HOOK_FS_MAX_READ_BYTES,
+  type WslFsFailure,
+  type WslFsResult,
+  type WslHookFsDirectoryLimits
+} from '../../shared/wsl-hook-relay-contract'
 
 /** Run the shared remote hook installers against a WSL guest over the relay's
  *  fs bridge. Codex is the one agent whose home Orca redirects for WSL
@@ -44,7 +54,23 @@ const ERRNO_TO_SFTP_CODE: Record<string, number> = {
   EEXIST: 4
 }
 
-function toSftpError(failure: { errno?: string; message?: string }): Error {
+function toSftpError(failure: {
+  errno?: string
+  message?: string
+  fileCapacity?: { observedBytes: number; maxBytes: number }
+}): Error {
+  if (
+    failure.errno === 'EFBIG' &&
+    Number.isSafeInteger(failure.fileCapacity?.observedBytes) &&
+    Number.isSafeInteger(failure.fileCapacity?.maxBytes) &&
+    failure.fileCapacity!.observedBytes >= 0 &&
+    failure.fileCapacity!.maxBytes >= 0
+  ) {
+    return new NodeFileReadTooLargeError(
+      failure.fileCapacity!.observedBytes,
+      failure.fileCapacity!.maxBytes
+    )
+  }
   const err = new Error(failure.message ?? 'wsl fs bridge failure') as Error & { code?: number }
   err.code = ERRNO_TO_SFTP_CODE[failure.errno ?? ''] ?? 5
   return err
@@ -62,7 +88,7 @@ export function createWslHookSftpAdapter(mux: SshChannelMultiplexer): SFTPWrappe
       .then((raw) => {
         const result = raw as WslFsResult<Wire>
         if (!result || typeof result !== 'object' || result.ok !== true) {
-          callback(toSftpError((result ?? {}) as { errno?: string; message?: string }))
+          callback(toSftpError((result ?? {}) as WslFsFailure))
           return
         }
         callback(null, pick(result))
@@ -81,7 +107,15 @@ export function createWslHookSftpAdapter(mux: SshChannelMultiplexer): SFTPWrappe
     readFile(path: string, _encoding: unknown, callback: SftpCallback<string>): void {
       call<{ content: string }, string>(
         WSL_HOOK_FS_METHODS.readFile,
-        { path },
+        { path, maxBytes: WSL_HOOK_FS_MAX_READ_BYTES },
+        callback,
+        (r) => r.content
+      )
+    },
+    orcaReadFileWithinLimit(path: string, maxBytes: number, callback: SftpCallback<string>): void {
+      call<{ content: string }, string>(
+        WSL_HOOK_FS_METHODS.readFile,
+        { path, maxBytes },
         callback,
         (r) => r.content
       )
@@ -122,9 +156,45 @@ export function createWslHookSftpAdapter(mux: SshChannelMultiplexer): SFTPWrappe
     readdir(path: string, callback: SftpCallback<{ filename: string }[]>): void {
       call<{ entries: { filename: string }[] }, { filename: string }[]>(
         WSL_HOOK_FS_METHODS.readdir,
-        { path },
+        {
+          path,
+          maxEntries: WSL_HOOK_FS_MAX_DIRECTORY_ENTRIES,
+          maxRetainedBytes: WSL_HOOK_FS_MAX_DIRECTORY_RETAINED_BYTES
+        },
         callback,
-        (r) => r.entries
+        (r) => {
+          const limits = {
+            maxEntries: WSL_HOOK_FS_MAX_DIRECTORY_ENTRIES,
+            maxRetainedBytes: WSL_HOOK_FS_MAX_DIRECTORY_RETAINED_BYTES
+          }
+          assertFilesystemDirectoryWithinLimit(
+            r.entries.map((entry) => ({ name: entry.filename })),
+            limits
+          )
+          return r.entries
+        }
+      )
+    },
+    orcaReaddirWithinLimit(
+      path: string,
+      limits: WslHookFsDirectoryLimits,
+      callback: SftpCallback<{ filename: string }[]>
+    ): void {
+      call<{ entries: { filename: string }[] }, { filename: string }[]>(
+        WSL_HOOK_FS_METHODS.readdir,
+        {
+          path,
+          maxEntries: limits.maxEntries,
+          maxRetainedBytes: limits.maxRetainedBytes
+        },
+        callback,
+        (r) => {
+          assertFilesystemDirectoryWithinLimit(
+            r.entries.map((entry) => ({ name: entry.filename })),
+            limits
+          )
+          return r.entries
+        }
       )
     },
     mkdir(path: string, callback: SftpCallback): void {

--- a/src/main/agent-hooks/wsl-hook-relay-deps.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-deps.ts
@@ -2,12 +2,12 @@
 // production wiring. Tests construct the manager with fakes for everything
 // that spawns wsl.exe or touches the live agentHookServer.
 import { createHash } from 'node:crypto'
-import { readFileSync } from 'node:fs'
 
 import { agentHookServer } from './server'
 import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
 import {
   isWslDistroRunning,
+  readWslHookRelayBundle,
   resolveWslHookRelayBundle,
   runWslInstallProcess,
   spawnWslRelayProcess
@@ -73,7 +73,7 @@ export const defaultWslHookRelayDeps: WslHookRelayManagerDeps = {
     return source ? createHash('sha256').update(source).digest('hex').slice(0, 12) : null
   },
   resolveBundle: resolveWslHookRelayBundle,
-  readBundle: (jsPath) => readFileSync(jsPath),
+  readBundle: readWslHookRelayBundle,
   listDistros: () => listWslDistrosAsync(),
   isDistroRunning: isWslDistroRunning,
   spawnRelay: spawnWslRelayProcess,

--- a/src/main/agent-hooks/wsl-hook-relay-file-bounds.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-file-bounds.test.ts
@@ -1,0 +1,60 @@
+import { closeSync, ftruncateSync, mkdtempSync, openSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import {
+  readWslHookRelayBundle,
+  readWslHookRelayBundleVersion,
+  WSL_HOOK_RELAY_MAX_BUNDLE_BYTES,
+  WSL_HOOK_RELAY_MAX_VERSION_FILE_BYTES
+} from './wsl-hook-relay-launch'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function tempFile(name: string): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-wsl-relay-bounds-'))
+  roots.push(root)
+  return join(root, name)
+}
+
+function createSparseFile(path: string, bytes: number): void {
+  const descriptor = openSync(path, 'w')
+  try {
+    ftruncateSync(descriptor, bytes)
+  } finally {
+    closeSync(descriptor)
+  }
+}
+
+describe('WSL hook relay local file bounds', () => {
+  it('preserves ordinary version and bundle reads', () => {
+    const versionPath = tempFile('.version')
+    const bundlePath = tempFile('relay.js')
+    writeFileSync(versionPath, '1.2.3\n')
+    writeFileSync(bundlePath, 'console.log("relay")')
+
+    expect(readWslHookRelayBundleVersion(versionPath)).toBe('1.2.3')
+    expect(readWslHookRelayBundle(bundlePath).toString('utf8')).toBe('console.log("relay")')
+  })
+
+  it('rejects an oversized version marker before materializing it', () => {
+    const versionPath = tempFile('.version')
+    createSparseFile(versionPath, WSL_HOOK_RELAY_MAX_VERSION_FILE_BYTES + 1)
+
+    expect(() => readWslHookRelayBundleVersion(versionPath)).toThrow(NodeFileReadTooLargeError)
+  })
+
+  it('rejects an oversized bundle before materializing or base64-expanding it', () => {
+    const bundlePath = tempFile('relay.js')
+    createSparseFile(bundlePath, WSL_HOOK_RELAY_MAX_BUNDLE_BYTES + 1)
+
+    expect(() => readWslHookRelayBundle(bundlePath)).toThrow(NodeFileReadTooLargeError)
+  })
+})

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -4,10 +4,11 @@
 // MultiplexerTransport. Kept separate from the manager so the state machine
 // stays readable. See docs/agent-status-over-wsl.md (STA-1515).
 import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { app } from 'electron'
 
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 import type { MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
 import {
   decodeWslText,
@@ -27,6 +28,8 @@ import {
 } from '../../shared/wsl-hook-relay-contract'
 
 const INSTALL_TIMEOUT_MS = 30_000
+export const WSL_HOOK_RELAY_MAX_VERSION_FILE_BYTES = 4 * 1024
+export const WSL_HOOK_RELAY_MAX_BUNDLE_BYTES = 8 * 1024 * 1024
 
 export type WslHookRelayBundle = { jsPath: string; version: string }
 
@@ -52,7 +55,12 @@ export function resolveWslHookRelayBundle(): WslHookRelayBundle | null {
     const jsPath = join(dir, WSL_HOOK_RELAY_BUNDLE_NAME)
     const versionPath = join(dir, WSL_HOOK_RELAY_VERSION_FILE)
     if (existsSync(jsPath) && existsSync(versionPath)) {
-      const version = readFileSync(versionPath, 'utf8').trim()
+      let version: string
+      try {
+        version = readWslHookRelayBundleVersion(versionPath)
+      } catch {
+        continue
+      }
       // Why: the version lands inside single-quoted guest shell text and in
       // a guest path segment — refuse anything outside the safe alphabet.
       if (/^[A-Za-z0-9+.-]+$/.test(version)) {
@@ -61,6 +69,16 @@ export function resolveWslHookRelayBundle(): WslHookRelayBundle | null {
     }
   }
   return null
+}
+
+export function readWslHookRelayBundleVersion(versionPath: string): string {
+  return readNodeFileSyncWithinLimit(versionPath, WSL_HOOK_RELAY_MAX_VERSION_FILE_BYTES)
+    .buffer.toString('utf8')
+    .trim()
+}
+
+export function readWslHookRelayBundle(jsPath: string): Buffer {
+  return readNodeFileSyncWithinLimit(jsPath, WSL_HOOK_RELAY_MAX_BUNDLE_BYTES).buffer
 }
 
 // Why: the install dir is namespaced by bundle version so concurrent Orca

--- a/src/main/agent-hooks/wsl-hook-relay-live.integration.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-live.integration.test.ts
@@ -43,12 +43,11 @@ describe.skipIf(process.platform === 'win32')(
     let child: ChildProcessWithoutNullStreams | null
 
     beforeAll(() => {
-      if (!existsSync(BUNDLE_JS)) {
-        execFileSync(process.execPath, [join('config', 'scripts', 'build-relay.mjs')], {
-          cwd: process.cwd(),
-          stdio: 'ignore'
-        })
-      }
+      // Why: a prior build can exist while its embedded fs bridge is stale relative to this checkout.
+      execFileSync(process.execPath, [join('config', 'scripts', 'build-relay.mjs')], {
+        cwd: process.cwd(),
+        stdio: 'ignore'
+      })
     }, 120_000)
 
     afterEach(() => {

--- a/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
@@ -2,15 +2,18 @@
 // bridge (including a full run of the unchanged remote hook installers), and
 // the per-distro relay manager state machine with fault injection.
 import { EventEmitter } from 'node:events'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import type { SFTPWrapper } from 'ssh2'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RelayDispatcher } from '../../relay/dispatcher'
 import { registerWslHookFsHandlers } from '../../relay/wsl-hook-fs-bridge'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
 import { SshChannelMultiplexer, type MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
+import { readTextFileRemote } from './installer-utils-remote'
 import { createWslHookSftpAdapter } from './wsl-hook-fs-adapter'
 import { installRemoteManagedAgentHooks } from './remote-managed-hook-installers'
 import { WslHookRelayManager } from './wsl-hook-relay-manager'
@@ -111,6 +114,39 @@ describe.skipIf(process.platform === 'win32')(
         adapter.readFile('/etc/passwd', 'utf8', ((e: Error) => resolve(e)) as never)
       })
       expect(outside).toBeInstanceOf(Error)
+    })
+
+    it('preserves the bounded-read error across the guest bridge and host adapter', async () => {
+      const adapter = createWslHookSftpAdapter(harness.mux)
+      const path = `${home}/oversized.json`
+      writeFileSync(path, 'x'.repeat(1025))
+
+      await expect(readTextFileRemote(adapter, path, 1024)).rejects.toBeInstanceOf(
+        NodeFileReadTooLargeError
+      )
+      expect(readFileSync(path, 'utf8')).toHaveLength(1025)
+    })
+
+    it('threads requested directory limits through the host adapter', async () => {
+      const adapter = createWslHookSftpAdapter(harness.mux) as SFTPWrapper & {
+        orcaReaddirWithinLimit: (
+          path: string,
+          limits: { maxEntries: number; maxRetainedBytes: number },
+          callback: (error: Error | null, entries?: { filename: string }[]) => void
+        ) => void
+      }
+      writeFileSync(`${home}/one`, '')
+      writeFileSync(`${home}/two`, '')
+
+      const error = await new Promise<Error>((resolve, reject) => {
+        adapter.orcaReaddirWithinLimit(
+          home,
+          { maxEntries: 1, maxRetainedBytes: 4096 },
+          (readError) =>
+            readError ? resolve(readError) : reject(new Error('expected limit error'))
+        )
+      })
+      expect(error).toBeInstanceOf(Error)
     })
 
     it('runs the unchanged remote managed hook installers against a WSL guest home', async () => {

--- a/src/main/agent-hooks/wsl-hook-relay-sentinel.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-sentinel.test.ts
@@ -5,7 +5,11 @@ import { EventEmitter } from 'node:events'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { RELAY_SENTINEL, RELAY_SENTINEL_TIMEOUT_MS } from '../ssh/relay-protocol'
+import {
+  MAX_BUFFERED_FRAME_CHUNKS,
+  RELAY_SENTINEL,
+  RELAY_SENTINEL_TIMEOUT_MS
+} from '../ssh/relay-protocol'
 import {
   MAX_STARTUP_BUFFER_BYTES,
   waitForWslRelaySentinel,
@@ -108,6 +112,26 @@ describe('waitForWslRelaySentinel', () => {
     expect(received).toEqual([])
     await Promise.resolve()
     expect(received).toEqual(['DEFER'])
+  })
+
+  it('closes instead of retaining too many post-sentinel fragments before attachment', async () => {
+    const child = fakeChild()
+    const promise = waitForWslRelaySentinel(child)
+    emitStdout(child, RELAY_SENTINEL)
+    for (let index = 0; index <= MAX_BUFFERED_FRAME_CHUNKS; index += 1) {
+      emitStdout(child, Buffer.from('x'))
+    }
+
+    const transport = await promise
+    const onClose = vi.fn()
+    const onData = vi.fn()
+    transport.onClose(onClose)
+    transport.onData(onData)
+    await Promise.resolve()
+
+    expect(child.kill).toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(onData).not.toHaveBeenCalled()
   })
 
   it('kills the child and rejects when startup output exceeds 64 KiB before the sentinel', async () => {

--- a/src/main/agent-hooks/wsl-hook-relay-sentinel.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-sentinel.ts
@@ -4,10 +4,17 @@
 // ChildProcess instead of a ClientChannel.
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 
-import { RELAY_SENTINEL, RELAY_SENTINEL_TIMEOUT_MS } from '../ssh/relay-protocol'
+import {
+  HEADER_LENGTH,
+  MAX_BUFFERED_FRAME_CHUNKS,
+  MAX_MESSAGE_SIZE,
+  RELAY_SENTINEL,
+  RELAY_SENTINEL_TIMEOUT_MS
+} from '../ssh/relay-protocol'
 import type { MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
 
 export const MAX_STARTUP_BUFFER_BYTES = 64 * 1024
+const MAX_PENDING_RELAY_BYTES = (MAX_MESSAGE_SIZE + HEADER_LENGTH) * 2
 
 // Why: without WSL_UTF8, wsl.exe's own messages arrive UTF-16LE; NUL bytes
 // in breadcrumbs and the catastrophic-failure matcher must not depend on the
@@ -45,6 +52,7 @@ export function waitForWslRelaySentinel(
     // decoder never sees chunks out of order. A setImmediate handoff would
     // NOT preserve that: it is a macrotask the next 'data' event can beat.
     const pendingChunks: Buffer[] = []
+    let pendingChunkBytes = 0
     let closedNotified = false
 
     const fail = (failure: WslRelayStartupFailure): void => {
@@ -71,8 +79,22 @@ export function waitForWslRelaySentinel(
     }
 
     const dispatch = (chunk: Buffer): void => {
+      if (closedNotified) {
+        return
+      }
       if (dataCallbacks.length === 0) {
+        if (
+          chunk.length > MAX_PENDING_RELAY_BYTES - pendingChunkBytes ||
+          pendingChunks.length >= MAX_BUFFERED_FRAME_CHUNKS
+        ) {
+          pendingChunks.length = 0
+          pendingChunkBytes = 0
+          notifyClosed()
+          child.kill()
+          return
+        }
         pendingChunks.push(chunk)
+        pendingChunkBytes += chunk.length
         return
       }
       for (const cb of dataCallbacks) {
@@ -104,23 +126,32 @@ export function waitForWslRelaySentinel(
         dispatch(chunk)
         return
       }
-      stdoutBuffer = Buffer.concat([stdoutBuffer, chunk])
-      const idx = stdoutBuffer.indexOf(sentinel)
+      const searchableLength = Math.max(
+        0,
+        MAX_STARTUP_BUFFER_BYTES - stdoutBuffer.length + sentinel.length
+      )
+      const searchableChunk = chunk.subarray(0, searchableLength)
+      const startupOutput =
+        stdoutBuffer.length === 0 ? searchableChunk : Buffer.concat([stdoutBuffer, searchableChunk])
+      const idx = startupOutput.indexOf(sentinel)
       if (idx === -1) {
         // Why: pre-sentinel stdout is untrusted startup noise; cap it so a
         // broken guest cannot grow memory until the timeout fires.
-        if (stdoutBuffer.length > MAX_STARTUP_BUFFER_BYTES) {
+        if (startupOutput.length > MAX_STARTUP_BUFFER_BYTES) {
           child.kill()
           fail({ kind: 'exit', code: null, stderr: 'startup output exceeded 64 KiB' })
+        } else {
+          stdoutBuffer = startupOutput
         }
         return
       }
       sentinelSeen = true
       settled = true
       clearTimeout(timeout)
-      const trailing = stdoutBuffer.subarray(idx + sentinel.length)
+      const trailingOffset = idx + sentinel.length - stdoutBuffer.length
+      const trailing = chunk.subarray(Math.max(0, trailingOffset))
       if (trailing.length > 0) {
-        pendingChunks.push(trailing)
+        dispatch(trailing)
       }
       const transport: MultiplexerTransport = {
         write: (data) => {
@@ -135,6 +166,7 @@ export function waitForWslRelaySentinel(
           if (dataCallbacks.length === 1 && pendingChunks.length > 0) {
             queueMicrotask(() => {
               for (const pending of pendingChunks.splice(0)) {
+                pendingChunkBytes -= pending.length
                 for (const dataCb of dataCallbacks) {
                   dataCb(pending)
                 }
@@ -142,7 +174,13 @@ export function waitForWslRelaySentinel(
             })
           }
         },
-        onClose: (cb) => closeCallbacks.push(cb),
+        onClose: (cb) => {
+          if (closedNotified) {
+            queueMicrotask(cb)
+          } else {
+            closeCallbacks.push(cb)
+          }
+        },
         close: () => child.kill()
       }
       resolve(transport)

--- a/src/main/agent-trust-presets.test.ts
+++ b/src/main/agent-trust-presets.test.ts
@@ -6,11 +6,14 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
+  truncateSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MAX_AGENT_STATE_FILE_BYTES } from './agent-state-file-reader'
 
 const testState = {
   fakeHomeDir: '',
@@ -38,8 +41,12 @@ vi.mock('node:os', async () => {
   }
 })
 
-const { markCodexProjectTrusted, markCopilotFolderTrusted, markCursorWorkspaceTrusted } =
-  await import('./agent-trust-presets')
+const {
+  MAX_AGENT_TRUST_GIT_POINTER_BYTES,
+  markCodexProjectTrusted,
+  markCopilotFolderTrusted,
+  markCursorWorkspaceTrusted
+} = await import('./agent-trust-presets')
 
 beforeEach(() => {
   testState.fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-trust-presets-'))
@@ -134,9 +141,115 @@ describe('markCopilotFolderTrusted', () => {
       rmSync(workspace, { recursive: true, force: true })
     }
   })
+
+  it('does not overwrite a sparse config above the 4 MiB read ceiling', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'orca-copilot-ws-'))
+    const configDir = join(testState.fakeHomeDir, '.copilot')
+    const configPath = join(configDir, 'config.json')
+    try {
+      mkdirSync(configDir, { recursive: true })
+      writeFileSync(configPath, '{"keep":true}')
+      truncateSync(configPath, MAX_AGENT_STATE_FILE_BYTES + 1)
+
+      markCopilotFolderTrusted(workspace)
+
+      expect(statSync(configPath).size).toBe(MAX_AGENT_STATE_FILE_BYTES + 1)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('markCodexProjectTrusted', () => {
+  it('accepts both linked-worktree pointers at the exact 64 KiB boundary', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-codex-exact-git-pointers-'))
+    const repository = join(fixtureRoot, 'repo')
+    const workspace = join(fixtureRoot, 'worktrees', 'feature')
+    const worktreeGitDir = join(repository, '.git', 'worktrees', 'feature')
+    const padPointer = (value: string): string =>
+      value + ' '.repeat(MAX_AGENT_TRUST_GIT_POINTER_BYTES - Buffer.byteLength(value))
+    try {
+      mkdirSync(worktreeGitDir, { recursive: true })
+      mkdirSync(workspace, { recursive: true })
+      const gitPointer = padPointer(`gitdir: ${worktreeGitDir}\n`)
+      const backlink = padPointer(`${join(workspace, '.git')}\n`)
+      expect(Buffer.byteLength(gitPointer)).toBe(MAX_AGENT_TRUST_GIT_POINTER_BYTES)
+      expect(Buffer.byteLength(backlink)).toBe(MAX_AGENT_TRUST_GIT_POINTER_BYTES)
+      writeFileSync(join(workspace, '.git'), gitPointer)
+      writeFileSync(join(worktreeGitDir, 'gitdir'), backlink)
+
+      markCodexProjectTrusted(workspace)
+
+      const written = readFileSync(join(testState.fakeHomeDir, '.codex', 'config.toml'), 'utf8')
+      expect(written).toContain(
+        `[projects."${escapeTomlBasicString(realpathSync.native(repository))}"]`
+      )
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to the workspace when its sparse .git pointer exceeds 64 KiB', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'orca-codex-large-git-pointer-'))
+    try {
+      const gitPointerPath = join(workspace, '.git')
+      writeFileSync(gitPointerPath, '')
+      truncateSync(gitPointerPath, MAX_AGENT_TRUST_GIT_POINTER_BYTES + 1)
+
+      markCodexProjectTrusted(workspace)
+
+      const written = readFileSync(join(testState.fakeHomeDir, '.codex', 'config.toml'), 'utf8')
+      expect(written).toContain(
+        `[projects."${escapeTomlBasicString(realpathSync.native(workspace))}"]`
+      )
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
+  it('falls back to the workspace when the sparse gitdir backlink exceeds 64 KiB', () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-codex-large-gitdir-pointer-'))
+    const repository = join(fixtureRoot, 'repo')
+    const workspace = join(fixtureRoot, 'worktrees', 'feature')
+    const worktreeGitDir = join(repository, '.git', 'worktrees', 'feature')
+    try {
+      mkdirSync(worktreeGitDir, { recursive: true })
+      mkdirSync(workspace, { recursive: true })
+      writeFileSync(join(workspace, '.git'), `gitdir: ${worktreeGitDir}\n`)
+      const backlinkPath = join(worktreeGitDir, 'gitdir')
+      writeFileSync(backlinkPath, '')
+      truncateSync(backlinkPath, MAX_AGENT_TRUST_GIT_POINTER_BYTES + 1)
+
+      markCodexProjectTrusted(workspace)
+
+      const written = readFileSync(join(testState.fakeHomeDir, '.codex', 'config.toml'), 'utf8')
+      expect(written).toContain(
+        `[projects."${escapeTomlBasicString(realpathSync.native(workspace))}"]`
+      )
+      expect(written).not.toContain(
+        `[projects."${escapeTomlBasicString(realpathSync.native(repository))}"]`
+      )
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not overwrite a sparse config above the 4 MiB read ceiling', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'orca-codex-ws-'))
+    const configDir = join(testState.fakeHomeDir, '.codex')
+    const configPath = join(configDir, 'config.toml')
+    try {
+      mkdirSync(configDir, { recursive: true })
+      writeFileSync(configPath, 'model = "keep"\n')
+      truncateSync(configPath, MAX_AGENT_STATE_FILE_BYTES + 1)
+
+      expect(() => markCodexProjectTrusted(workspace)).toThrow('File too large')
+      expect(statSync(configPath).size).toBe(MAX_AGENT_STATE_FILE_BYTES + 1)
+    } finally {
+      rmSync(workspace, { recursive: true, force: true })
+    }
+  })
+
   it('trusts the main repository root for a linked worktree without reading commondir', () => {
     const fixtureRoot = mkdtempSync(join(tmpdir(), 'orca-codex-linked-ws-'))
     const repository = join(fixtureRoot, 'repo')

--- a/src/main/agent-trust-presets.ts
+++ b/src/main/agent-trust-presets.ts
@@ -1,11 +1,14 @@
-import { existsSync, mkdirSync, readFileSync, realpathSync } from 'node:fs'
+import { existsSync, mkdirSync, realpathSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
+import { readAgentStateJsonFileSync } from './agent-state-file-reader'
 import { writeFileAtomically } from './codex-accounts/fs-utils'
 import { getOrcaManagedCodexHomePath } from './codex/codex-home-paths'
 import { upsertProjectTrustLevel } from './codex/config-toml-trust'
 
 export type AgentTrustPreset = 'cursor' | 'copilot' | 'codex'
+export const MAX_AGENT_TRUST_GIT_POINTER_BYTES = 64 * 1024
 
 /**
  * Pre-mark a workspace as trusted for cursor-agent, GitHub Copilot CLI, or
@@ -73,8 +76,7 @@ export function markCopilotFolderTrusted(workspacePath: string): void {
   let config: Record<string, unknown> = {}
   try {
     if (existsSync(configPath)) {
-      const raw = readFileSync(configPath, 'utf-8')
-      const parsed = JSON.parse(raw)
+      const parsed = readAgentStateJsonFileSync(configPath)
       if (parsed && typeof parsed === 'object') {
         config = parsed as Record<string, unknown>
       }
@@ -120,7 +122,7 @@ export function markCodexProjectTrusted(workspacePath: string): void {
 function resolveCodexProjectTrustRoot(workspacePath: string): string {
   const absPath = canonicalize(workspacePath)
   try {
-    const gitDirReference = readFileSync(join(absPath, '.git'), 'utf-8').trim()
+    const gitDirReference = readGitPointerFile(join(absPath, '.git'))
     if (!gitDirReference.startsWith('gitdir:')) {
       return absPath
     }
@@ -134,7 +136,7 @@ function resolveCodexProjectTrustRoot(workspacePath: string): string {
       return absPath
     }
     // Why: workspace-controlled .git metadata must not broaden trust without Git's reciprocal link.
-    const gitDirBacklink = readFileSync(join(gitDir, 'gitdir'), 'utf-8').trim()
+    const gitDirBacklink = readGitPointerFile(join(gitDir, 'gitdir'))
     if (!gitDirBacklink) {
       return absPath
     }
@@ -151,6 +153,12 @@ function resolveCodexProjectTrustRoot(workspacePath: string): string {
   } catch {
     return absPath
   }
+}
+
+function readGitPointerFile(filePath: string): string {
+  return readNodeFileSyncWithinLimit(filePath, MAX_AGENT_TRUST_GIT_POINTER_BYTES)
+    .buffer.toString('utf8')
+    .trim()
 }
 
 function canonicalize(p: string): string {

--- a/src/main/automations/dispatch-tokens.test.ts
+++ b/src/main/automations/dispatch-tokens.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  _getAutomationDispatchTokenCountForTests,
+  _resetAutomationDispatchTokensForTests,
+  beginAutomationDispatchTokenUse,
+  clearAutomationDispatchTokens,
+  createAutomationDispatchToken,
+  DISPATCH_TOKEN_MAX_ENTRIES,
+  finishAutomationDispatchTokenUse,
+  releaseAutomationDispatchTokenUse
+} from './dispatch-tokens'
+
+beforeEach(() => {
+  _resetAutomationDispatchTokensForTests()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('automation dispatch tokens', () => {
+  it('preserves reservation, release, and one-time finish behavior', () => {
+    const token = createAutomationDispatchToken('automation', 'run')
+    const args = { token, automationId: 'automation', runId: 'run', reservationId: 'request-1' }
+
+    expect(beginAutomationDispatchTokenUse(args)).toBe(true)
+    expect(beginAutomationDispatchTokenUse(args)).toBe(false)
+    releaseAutomationDispatchTokenUse({ token, reservationId: 'request-1' })
+    expect(beginAutomationDispatchTokenUse(args)).toBe(true)
+    finishAutomationDispatchTokenUse({ token, reservationId: 'request-1' })
+    expect(beginAutomationDispatchTokenUse(args)).toBe(false)
+  })
+
+  it('keeps delimiter-containing identities distinct', () => {
+    const token = createAutomationDispatchToken('a:b', 'c')
+    expect(
+      beginAutomationDispatchTokenUse({
+        token,
+        automationId: 'a',
+        runId: 'b:c',
+        reservationId: 'request'
+      })
+    ).toBe(false)
+  })
+
+  it('clears only the matching automation run', () => {
+    const removed = createAutomationDispatchToken('automation', 'run-1')
+    const retained = createAutomationDispatchToken('automation', 'run-2')
+    clearAutomationDispatchTokens('automation', 'run-1')
+
+    expect(
+      beginAutomationDispatchTokenUse({
+        token: removed,
+        automationId: 'automation',
+        runId: 'run-1',
+        reservationId: 'request'
+      })
+    ).toBe(false)
+    expect(
+      beginAutomationDispatchTokenUse({
+        token: retained,
+        automationId: 'automation',
+        runId: 'run-2',
+        reservationId: 'request'
+      })
+    ).toBe(true)
+  })
+
+  it('physically prunes expired records', () => {
+    vi.useFakeTimers()
+    const expired = createAutomationDispatchToken('automation', 'old')
+    vi.advanceTimersByTime(30 * 60_000 + 1)
+    createAutomationDispatchToken('automation', 'new')
+
+    expect(_getAutomationDispatchTokenCountForTests()).toBe(1)
+    expect(
+      beginAutomationDispatchTokenUse({
+        token: expired,
+        automationId: 'automation',
+        runId: 'old',
+        reservationId: 'request'
+      })
+    ).toBe(false)
+  })
+
+  it('evicts the oldest unused token at the entry cap', () => {
+    const oldest = createAutomationDispatchToken('automation', 'run-0')
+    for (let index = 1; index <= DISPATCH_TOKEN_MAX_ENTRIES; index += 1) {
+      createAutomationDispatchToken('automation', `run-${index}`)
+    }
+
+    expect(_getAutomationDispatchTokenCountForTests()).toBe(DISPATCH_TOKEN_MAX_ENTRIES)
+    expect(
+      beginAutomationDispatchTokenUse({
+        token: oldest,
+        automationId: 'automation',
+        runId: 'run-0',
+        reservationId: 'request'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/main/automations/dispatch-tokens.ts
+++ b/src/main/automations/dispatch-tokens.ts
@@ -1,10 +1,10 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 
 const DISPATCH_TOKEN_TTL_MS = 30 * 60_000
+export const DISPATCH_TOKEN_MAX_ENTRIES = 1024
 
 type DispatchTokenRecord = {
-  automationId: string
-  runId: string
+  dispatchIdentity: string
   expiresAt: number
   reservedBy?: string
   inFlight: boolean
@@ -20,12 +20,34 @@ function pruneExpiredDispatchTokens(now = Date.now()): void {
   }
 }
 
+function identityDigest(...parts: string[]): string {
+  const digest = createHash('sha256')
+  for (const part of parts) {
+    digest.update(`${part.length}:`)
+    digest.update(part)
+  }
+  return digest.digest('base64url')
+}
+
+function evictOldestUnusedDispatchTokens(): void {
+  while (dispatchTokens.size >= DISPATCH_TOKEN_MAX_ENTRIES) {
+    const oldestUnused = Array.from(dispatchTokens).find(([, record]) => !record.inFlight)
+    if (!oldestUnused) {
+      return
+    }
+    dispatchTokens.delete(oldestUnused[0])
+  }
+}
+
 export function createAutomationDispatchToken(automationId: string, runId: string): string {
   pruneExpiredDispatchTokens()
+  evictOldestUnusedDispatchTokens()
   const token = randomUUID()
+  if (dispatchTokens.size >= DISPATCH_TOKEN_MAX_ENTRIES) {
+    return token
+  }
   dispatchTokens.set(token, {
-    automationId,
-    runId,
+    dispatchIdentity: identityDigest(automationId, runId),
     expiresAt: Date.now() + DISPATCH_TOKEN_TTL_MS,
     inFlight: false
   })
@@ -41,19 +63,19 @@ export function beginAutomationDispatchTokenUse(args: {
   pruneExpiredDispatchTokens()
   const record = dispatchTokens.get(args.token)
   const valid =
-    record?.automationId === args.automationId &&
-    record.runId === args.runId &&
+    record?.dispatchIdentity === identityDigest(args.automationId, args.runId) &&
     record.expiresAt > Date.now()
   if (!valid) {
     return false
   }
-  if (record.reservedBy !== undefined && record.reservedBy !== args.reservationId) {
+  const reservationIdentity = identityDigest(args.reservationId)
+  if (record.reservedBy !== undefined && record.reservedBy !== reservationIdentity) {
     return false
   }
   if (record.inFlight) {
     return false
   }
-  record.reservedBy = args.reservationId
+  record.reservedBy = reservationIdentity
   record.inFlight = true
   return true
 }
@@ -63,7 +85,7 @@ export function releaseAutomationDispatchTokenUse(args: {
   reservationId: string
 }): void {
   const record = dispatchTokens.get(args.token)
-  if (record?.reservedBy === args.reservationId) {
+  if (record?.reservedBy === identityDigest(args.reservationId)) {
     record.inFlight = false
   }
 }
@@ -73,15 +95,24 @@ export function finishAutomationDispatchTokenUse(args: {
   reservationId: string
 }): void {
   const record = dispatchTokens.get(args.token)
-  if (record?.reservedBy === args.reservationId) {
+  if (record?.reservedBy === identityDigest(args.reservationId)) {
     dispatchTokens.delete(args.token)
   }
 }
 
 export function clearAutomationDispatchTokens(automationId: string, runId: string): void {
+  const dispatchIdentity = identityDigest(automationId, runId)
   for (const [token, record] of dispatchTokens) {
-    if (record.automationId === automationId && record.runId === runId) {
+    if (record.dispatchIdentity === dispatchIdentity) {
       dispatchTokens.delete(token)
     }
   }
+}
+
+export function _resetAutomationDispatchTokensForTests(): void {
+  dispatchTokens.clear()
+}
+
+export function _getAutomationDispatchTokenCountForTests(): number {
+  return dispatchTokens.size
 }

--- a/src/main/automations/external-job-mappers.ts
+++ b/src/main/automations/external-job-mappers.ts
@@ -200,6 +200,7 @@ export function mapHermesJobs(managerId: string, rawJobs: unknown): ExternalAuto
       lastError: asString(job.last_error) ?? asString(job.last_delivery_error),
       workdir: asString(job.workdir),
       runCount: asNumber(job.run_count) ?? (Array.isArray(job.runs) ? job.runs.length : 0),
+      ...(job.run_count_saturated === true ? { runCountSaturated: true as const } : {}),
       runs: mapExternalRuns({
         managerId,
         provider: 'hermes',

--- a/src/main/automations/external-manager-remote-fanout.test.ts
+++ b/src/main/automations/external-manager-remote-fanout.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import type { Store } from '../persistence'
+import type { SshTarget } from '../../shared/ssh-types'
+import { getActiveMultiplexer } from '../ipc/ssh'
+import { listExternalAutomationManagers } from './external-manager'
+
+const execFileMock = vi.hoisted(() =>
+  vi.fn(
+    (
+      _command: string,
+      _args: string[],
+      _options: unknown,
+      callback: (error: Error | null) => void
+    ) => {
+      callback(new Error('not installed'))
+      return { kill: vi.fn() }
+    }
+  )
+)
+
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return { ...actual, existsSync: vi.fn(() => false) }
+})
+vi.mock('../ipc/ssh', () => ({ getActiveMultiplexer: vi.fn() }))
+
+beforeEach(() => {
+  vi.mocked(getActiveMultiplexer).mockReset()
+})
+
+describe('remote external automation manager fanout', () => {
+  it('bounds probes for a large target list and preserves provider order', async () => {
+    const targets: SshTarget[] = Array.from({ length: 100 }, (_, index) => ({
+      id: `ssh-${index}`,
+      label: `Target ${index}`,
+      host: `host-${index}`,
+      port: 22,
+      username: 'orca'
+    }))
+    let inFlight = 0
+    let peak = 0
+    const request = vi.fn(async (_method: string, input: { provider: string }) => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await Promise.resolve()
+      inFlight -= 1
+      return {
+        jobs: [],
+        hermesAvailable: input.provider === 'hermes',
+        openclawAvailable: input.provider === 'openclaw'
+      }
+    })
+    vi.mocked(getActiveMultiplexer).mockReturnValue({
+      isDisposed: () => false,
+      request
+    } as never)
+
+    const managers = await listExternalAutomationManagers({
+      getSshTargets: () => targets
+    } as Store)
+
+    expect(peak).toBe(4)
+    expect(request).toHaveBeenCalledTimes(200)
+    expect(managers.map((manager) => manager.id)).toEqual(
+      targets.flatMap((target) => [`hermes:ssh:${target.id}`, `openclaw:ssh:${target.id}`])
+    )
+  })
+})

--- a/src/main/automations/external-manager.test.ts
+++ b/src/main/automations/external-manager.test.ts
@@ -344,6 +344,7 @@ describe('listExternalAutomationRuns', () => {
   it('requests paginated Hermes runs from the remote relay', async () => {
     const request = vi.fn().mockResolvedValue({
       total: 42,
+      totalSaturated: true,
       runs: [
         {
           id: 'job-1:2026-05-15_09-00-00.md',
@@ -375,6 +376,7 @@ describe('listExternalAutomationRuns', () => {
       page: 2,
       pageSize: 10,
       total: 42,
+      totalSaturated: true,
       runs: [
         {
           id: 'job-1:2026-05-15_09-00-00.md',

--- a/src/main/automations/external-manager.ts
+++ b/src/main/automations/external-manager.ts
@@ -2,7 +2,6 @@
  * and lifecycle routing share provider/target validation and remote relay fallbacks. */
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import type {
@@ -15,6 +14,8 @@ import type {
   ExternalAutomationRunsPage,
   ExternalAutomationUpdateInput
 } from '../../shared/automations-types'
+import { readExternalAutomationJobsFile } from '../../shared/external-automation-jobs-file'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import type { SshTarget } from '../../shared/ssh-types'
 import type { Store } from '../persistence'
 import { getActiveMultiplexer } from '../ipc/ssh'
@@ -32,6 +33,8 @@ const OPENCLAW_JOBS_FILE = join(homedir(), '.openclaw', 'cron', 'jobs.json')
 const EXTERNAL_JOB_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]*$/
 const LOCAL_COMMAND_LOOKUP_TIMEOUT_MS = 5_000
 const LOCAL_AUTOMATION_COMMAND_TIMEOUT_MS = 30_000
+const HERMES_JOB_RUN_COUNT_CONCURRENCY = 4
+const REMOTE_AUTOMATION_MANAGER_FETCH_CONCURRENCY = 4
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -130,39 +133,30 @@ async function readLocalHermesJobs(): Promise<unknown[]> {
   if (!existsSync(HERMES_JOBS_FILE)) {
     return []
   }
-  const content = await readFile(HERMES_JOBS_FILE, 'utf-8')
-  const parsed = JSON.parse(content) as unknown
-  const jobs = Array.isArray(parsed)
-    ? parsed
-    : isRecord(parsed) && Array.isArray(parsed.jobs)
-      ? parsed.jobs
-      : []
-  return Promise.all(
-    jobs.map(async (job) => {
-      if (!isRecord(job)) {
-        return job
-      }
-      const jobId = typeof job.id === 'string' ? job.id : null
-      if (!jobId) {
-        return job
-      }
-      const runsPage = await readHermesCronOutputRunsPage(jobId, { page: 1, pageSize: 0 })
-      return {
-        ...job,
-        run_count: runsPage.total,
-        runs: []
-      }
-    })
-  )
+  const jobs = await readExternalAutomationJobsFile(HERMES_JOBS_FILE, { allowRootArray: true })
+  return mapWithConcurrency(jobs, HERMES_JOB_RUN_COUNT_CONCURRENCY, async (job) => {
+    if (!isRecord(job)) {
+      return job
+    }
+    const jobId = typeof job.id === 'string' ? job.id : null
+    if (!jobId) {
+      return job
+    }
+    const runsPage = await readHermesCronOutputRunsPage(jobId, { page: 1, pageSize: 0 })
+    return {
+      ...job,
+      run_count: runsPage.total,
+      ...(runsPage.totalSaturated ? { run_count_saturated: true } : {}),
+      runs: []
+    }
+  })
 }
 
 async function readLocalOpenClawJobs(): Promise<unknown[]> {
   if (!existsSync(OPENCLAW_JOBS_FILE)) {
     return []
   }
-  const content = await readFile(OPENCLAW_JOBS_FILE, 'utf-8')
-  const parsed = JSON.parse(content) as unknown
-  return isRecord(parsed) && Array.isArray(parsed.jobs) ? parsed.jobs : []
+  return readExternalAutomationJobsFile(OPENCLAW_JOBS_FILE, { allowRootArray: false })
 }
 
 async function listLocalHermesManager(): Promise<ExternalAutomationManager | null> {
@@ -300,16 +294,22 @@ async function listRemoteManager(
 export async function listExternalAutomationManagers(
   store: Store
 ): Promise<ExternalAutomationManager[]> {
+  const remoteManagerRequests = store
+    .getSshTargets()
+    // Why: runtime-owned hidden targets are excluded from SSH/run-target surfaces.
+    .filter((target) => !isRuntimeOwnedSshTarget(target))
+    .flatMap((target) => [
+      { provider: 'hermes' as const, target },
+      { provider: 'openclaw' as const, target }
+    ])
   const [localHermes, localOpenClaw, remote] = await Promise.all([
     listLocalHermesManager(),
     listLocalOpenClawManager(),
-    Promise.all(
-      store
-        .getSshTargets()
-        // Why: runtime-owned hidden targets are excluded from SSH/run-target
-        // surfaces; don't probe them for external automations either.
-        .filter((target) => !isRuntimeOwnedSshTarget(target))
-        .flatMap((target) => [listRemoteHermesManager(target), listRemoteOpenClawManager(target)])
+    mapWithConcurrency(
+      remoteManagerRequests,
+      REMOTE_AUTOMATION_MANAGER_FETCH_CONCURRENCY,
+      ({ provider, target }) =>
+        provider === 'hermes' ? listRemoteHermesManager(target) : listRemoteOpenClawManager(target)
     )
   ])
   return [
@@ -351,6 +351,7 @@ export async function listExternalAutomationRuns(
       page,
       pageSize,
       total: result.total,
+      ...(result.totalSaturated ? { totalSaturated: true } : {}),
       runs: mapHermesJobs(input.managerId, [{ id: input.jobId, runs: result.runs }])[0]?.runs ?? []
     }
   }
@@ -363,7 +364,7 @@ export async function listExternalAutomationRuns(
     jobId: input.jobId,
     page,
     pageSize
-  })) as { total?: number; runs?: unknown[] }
+  })) as { total?: number; totalSaturated?: boolean; runs?: unknown[] }
   return {
     managerId: input.managerId,
     provider: input.provider,
@@ -372,6 +373,7 @@ export async function listExternalAutomationRuns(
     page,
     pageSize,
     total: typeof result.total === 'number' && Number.isFinite(result.total) ? result.total : 0,
+    ...(result.totalSaturated === true ? { totalSaturated: true } : {}),
     runs:
       mapHermesJobs(input.managerId, [{ id: input.jobId, runs: result.runs ?? [] }])[0]?.runs ?? []
   }

--- a/src/main/automations/headless-dispatch.ts
+++ b/src/main/automations/headless-dispatch.ts
@@ -4,6 +4,7 @@ import type {
   AutomationRunOutputSnapshot
 } from '../../shared/automations-types'
 import type { AutomationRunTargetResult } from './run-target-resolution'
+import { appendCompactedStringChunk } from '../../shared/string-chunk-compaction'
 
 const MAX_HEADLESS_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
 
@@ -39,7 +40,7 @@ export function createHeadlessAutomationOutputSnapshotBuffer(): {
       if (!chunk) {
         return
       }
-      chunks.push(chunk)
+      appendCompactedStringChunk(chunks, chunk)
       totalChars += chunk.length
       let overflowChars = totalChars - MAX_HEADLESS_OUTPUT_SNAPSHOT_CHARS
       while (overflowChars > 0 && chunks.length > 0) {

--- a/src/main/automations/hermes-cron-output.test.ts
+++ b/src/main/automations/hermes-cron-output.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -11,6 +11,7 @@ const fakeDbRows = vi.hoisted(() => ({
   messages: [] as Record<string, unknown>[]
 }))
 const fakePrepareSqls = vi.hoisted(() => [] as string[])
+const fakeIteratedSqls = vi.hoisted(() => [] as string[])
 const fakeDatabase = vi.hoisted(() =>
   vi.fn(function FakeDatabase() {
     return {
@@ -26,7 +27,14 @@ const fakeDatabase = vi.hoisted(() =>
             sql.includes('FROM sessions')
               ? fakeDbRows.sessions
               : fakeDbRows.messages.filter((message) => message.session_id === param)
-          )
+          ),
+          iterate: vi.fn(function* (param: string) {
+            fakeIteratedSqls.push(sql)
+            const rows = sql.includes('FROM sessions')
+              ? fakeDbRows.sessions
+              : fakeDbRows.messages.filter((message) => message.session_id === param)
+            yield* rows
+          })
         }
       }),
       close: vi.fn()
@@ -53,6 +61,7 @@ beforeEach(() => {
   fakeDbRows.sessions = []
   fakeDbRows.messages = []
   fakePrepareSqls.length = 0
+  fakeIteratedSqls.length = 0
   fakeDatabase.mockClear()
 })
 
@@ -141,6 +150,26 @@ Run summary: monitor automation completed successfully.
     expect((page.runs[0] as { output_content?: string }).output_content).toContain(
       'full command output line'
     )
+    const transcriptSql = fakeIteratedSqls.find((sql) => sql.includes('FROM messages'))
+    expect(transcriptSql).toContain('substr(CAST(content AS BLOB)')
+    expect(transcriptSql).toContain('LIMIT 10001')
+  })
+
+  it('omits an oversized sparse markdown output without reading it wholesale', async () => {
+    const home = await createHermesHome()
+    const outputDir = join(home, 'cron', 'output', 'job-1')
+    const outputPath = join(outputDir, '2026-05-15_09-02-00.md')
+    await mkdir(outputDir, { recursive: true })
+    await writeFile(outputPath, '', 'utf-8')
+    await truncate(outputPath, 64 * 1024 * 1024)
+
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    const page = await readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 25 })
+
+    expect(page.runs[0]).toMatchObject({
+      output_content: null,
+      error: expect.stringContaining('File too large')
+    })
   })
 
   it('builds large response previews without broad regex captures', async () => {
@@ -275,6 +304,47 @@ Run summary: monitor automation completed successfully.
 
     expect(page).toEqual({ total: 1, runs: [] })
     expect(fakePrepareSqls.some((sql) => sql.includes('FROM messages'))).toBe(false)
+  })
+
+  it('caps one hydrated history page at 100 runs', async () => {
+    const home = await createHermesHome()
+    const outputDir = join(home, 'cron', 'output', 'job-1')
+    await mkdir(outputDir, { recursive: true })
+    await Promise.all(
+      Array.from({ length: 101 }, async (_, index) => {
+        const minute = String(Math.floor(index / 60)).padStart(2, '0')
+        const second = String(index % 60).padStart(2, '0')
+        await writeFile(
+          join(outputDir, `2026-05-15_09-${minute}-${second}.md`),
+          `run ${index}`,
+          'utf-8'
+        )
+      })
+    )
+
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    const page = await readHermesCronOutputRunsPage('job-1', {
+      page: 1,
+      pageSize: Number.MAX_SAFE_INTEGER
+    })
+
+    expect(page.total).toBe(101)
+    expect(page.runs).toHaveLength(100)
+  })
+
+  it('bounds session run refs and reports a saturated total', async () => {
+    const home = await createHermesHome()
+    await writeFile(join(home, 'state.db'), '', 'utf-8')
+    fakeDbRows.sessions = Array.from({ length: 10_001 }, (_, index) => ({
+      id: `cron_job-1_20260515_${String(index).padStart(6, '0')}`,
+      started_at: Date.UTC(2026, 4, 15, 9, 0, 0) / 1000 - index
+    }))
+
+    const { readHermesCronOutputRunsPage } = await loadReader()
+    const page = await readHermesCronOutputRunsPage('job-1', { page: 1, pageSize: 0 })
+
+    expect(page).toEqual({ total: 10_000, totalSaturated: true, runs: [] })
+    expect(fakeIteratedSqls.find((sql) => sql.includes('FROM sessions'))).toContain('LIMIT 10001')
   })
 
   it('caches count-only reads until the cache is cleared', async () => {

--- a/src/main/automations/hermes-cron-output.ts
+++ b/src/main/automations/hermes-cron-output.ts
@@ -1,9 +1,25 @@
 /* eslint-disable max-lines -- Why: Hermes run history has to reconcile
  * markdown output files with SQLite session transcripts from separate stores. */
 import { existsSync } from 'node:fs'
-import { open, readdir, readFile, realpath, stat } from 'node:fs/promises'
+import { open, opendir, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
+import {
+  type BoundedHermesRunRefs,
+  HERMES_RUN_REF_MAX_ENTRIES,
+  HERMES_SESSION_RUN_REFS_SELECT_SQL,
+  HermesRunRefRetainer
+} from '../../shared/hermes-run-ref-retention'
+import {
+  formatHermesSessionMessagesWithinLimits,
+  HERMES_PRIMARY_OUTPUT_MAX_BYTES,
+  HERMES_RUN_PAGE_MAX_RUNS,
+  HERMES_SESSION_RUN_SELECT_SQL,
+  HERMES_SESSION_TRANSCRIPT_SELECT_SQL,
+  HERMES_SESSION_TRANSCRIPT_TRUNCATED_ERROR,
+  hydrateHermesRunPageWithinLimits
+} from '../../shared/hermes-run-output-limits'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 import Database from '../sqlite/sync-database'
 
 const HERMES_HOME = process.env.HERMES_HOME?.trim() || join(homedir(), '.hermes')
@@ -22,6 +38,7 @@ const LATEST_LOG_PATH_PATTERN =
 
 export type HermesCronOutputRunsPage = {
   total: number
+  totalSaturated?: true
   runs: unknown[]
 }
 
@@ -362,9 +379,10 @@ async function readReferencedLogFile(content: string): Promise<{
       return null
     }
     if (logStat.size <= MAX_REFERENCED_LOG_BYTES) {
+      const { buffer } = await readNodeFileWithinLimit(logPath, MAX_REFERENCED_LOG_BYTES)
       return {
         path: logPath,
-        content: await readFile(logPath, 'utf-8'),
+        content: buffer.toString('utf-8'),
         truncated: false
       }
     }
@@ -409,31 +427,6 @@ async function appendReferencedLogFile(content: string): Promise<string> {
   ]
     .filter((part) => part !== null)
     .join('\n\n')
-}
-
-function formatSessionMessages(messages: Record<string, unknown>[]): string | null {
-  if (messages.length === 0) {
-    return null
-  }
-  return messages
-    .map((message) => {
-      const role = typeof message.role === 'string' ? message.role : 'message'
-      const content = typeof message.content === 'string' ? message.content.trim() : ''
-      const toolName = typeof message.tool_name === 'string' ? message.tool_name.trim() : ''
-      const reasoning =
-        typeof message.reasoning_content === 'string'
-          ? message.reasoning_content.trim()
-          : typeof message.reasoning === 'string'
-            ? message.reasoning.trim()
-            : ''
-      const parts = [
-        `## ${role}${toolName ? ` / ${toolName}` : ''}`,
-        reasoning ? `### Reasoning\n\n${reasoning}` : null,
-        content || '(empty)'
-      ].filter(Boolean)
-      return parts.join('\n\n')
-    })
-    .join('\n\n---\n\n')
 }
 
 function getRunKey(run: unknown): string | null {
@@ -579,18 +572,20 @@ export async function readHermesCronOutputRuns(jobId: string): Promise<unknown[]
     .runs
 }
 
-async function readHermesCronOutputRunRefs(jobId: string): Promise<HermesMergedRunRef[]> {
+async function readHermesCronOutputRunRefs(
+  jobId: string
+): Promise<BoundedHermesRunRefs<HermesMergedRunRef>> {
   const outputRuns = await readHermesOutputFileRunRefs(jobId)
-  return mergeHermesOutputAndSessionRunRefs(outputRuns, readHermesSessionDbRunRefs(jobId)).sort(
-    (a, b) => {
-      const aTime = getRawRunTime(a)
-      const bTime = getRawRunTime(b)
-      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
-        return bTime - aTime
-      }
-      return getRawRunId(b).localeCompare(getRawRunId(a))
-    }
-  )
+  const sessionRuns = readHermesSessionDbRunRefs(jobId)
+  const mergedRetainer = new HermesRunRefRetainer<HermesMergedRunRef>()
+  for (const ref of mergeHermesOutputAndSessionRunRefs(outputRuns.refs, sessionRuns.refs)) {
+    mergedRetainer.add(ref)
+  }
+  const merged = mergedRetainer.finish()
+  return {
+    refs: merged.refs,
+    saturated: outputRuns.saturated || sessionRuns.saturated || merged.saturated
+  }
 }
 
 // Why: opening the Automations page calls readHermesCronOutputRunsPage with
@@ -600,9 +595,10 @@ async function readHermesCronOutputRunRefs(jobId: string): Promise<HermesMergedR
 const HERMES_RUN_COUNT_CACHE_TTL_MS = 2000
 const HERMES_RUN_COUNT_CACHE_MAX_ENTRIES = 200
 type HermesRunCountCacheEntry = {
-  promise: Promise<number>
+  promise: Promise<HermesRunCount>
   expiresAt: number
 }
+type HermesRunCount = { total: number; totalSaturated?: true }
 const hermesRunCountCache = new Map<string, HermesRunCountCacheEntry>()
 
 export function clearHermesCronOutputRunCountCache(jobId?: string): void {
@@ -628,7 +624,7 @@ function pruneHermesRunCountCache(now: number): void {
   }
 }
 
-async function readHermesCronOutputRunCount(jobId: string): Promise<number> {
+async function readHermesCronOutputRunCount(jobId: string): Promise<HermesRunCount> {
   const now = Date.now()
   const cached = hermesRunCountCache.get(jobId)
   if (cached && cached.expiresAt > now) {
@@ -641,7 +637,10 @@ async function readHermesCronOutputRunCount(jobId: string): Promise<number> {
   // size bound and expired sweep, a long session can pin stale job ids forever.
   pruneHermesRunCountCache(now)
   const entry: HermesRunCountCacheEntry = {
-    promise: readHermesCronOutputRunRefs(jobId).then((refs) => refs.length),
+    promise: readHermesCronOutputRunRefs(jobId).then((result) => ({
+      total: result.refs.length,
+      ...(result.saturated ? { totalSaturated: true as const } : {})
+    })),
     expiresAt: Number.POSITIVE_INFINITY
   }
   hermesRunCountCache.set(jobId, entry)
@@ -685,57 +684,54 @@ export async function readHermesCronOutputRunsPage(
     return { total: 0, runs: [] }
   }
   const safePage = Math.max(1, Math.floor(page))
-  const safePageSize = Math.max(0, Math.floor(pageSize))
+  const safePageSize = Math.min(HERMES_RUN_PAGE_MAX_RUNS, Math.max(0, Math.floor(pageSize)))
   if (safePageSize === 0) {
     // Why: manager listing only needs a badge count; hydrating markdown logs
     // and full session transcripts can make opening Automations very slow.
-    return { total: await readHermesCronOutputRunCount(jobId), runs: [] }
+    return { ...(await readHermesCronOutputRunCount(jobId)), runs: [] }
   }
   const runRefs = await readHermesCronOutputRunRefs(jobId)
   const start = (safePage - 1) * safePageSize
-  const pageRefs = runRefs.slice(start, start + safePageSize)
+  const pageRefs = runRefs.refs.slice(start, start + safePageSize)
   return {
-    total: runRefs.length,
-    runs: await Promise.all(pageRefs.map((ref) => hydrateHermesRunRef(jobId, ref)))
+    total: runRefs.refs.length,
+    ...(runRefs.saturated ? { totalSaturated: true } : {}),
+    runs: await hydrateHermesRunPageWithinLimits(pageRefs, (ref) => hydrateHermesRunRef(jobId, ref))
   }
 }
 
-function getRawRunId(run: unknown): string {
-  if (typeof run === 'object' && run !== null && 'id' in run) {
-    return String((run as { id: unknown }).id)
-  }
-  return ''
-}
-
-function getRawRunTime(run: unknown): number {
-  if (typeof run !== 'object' || run === null || !('run_at' in run)) {
-    return Number.NaN
-  }
-  const runAt = (run as { run_at: unknown }).run_at
-  return typeof runAt === 'string' ? Date.parse(runAt) : Number.NaN
-}
-
-async function readHermesOutputFileRunRefs(jobId: string): Promise<HermesOutputRunRef[]> {
+async function readHermesOutputFileRunRefs(
+  jobId: string
+): Promise<BoundedHermesRunRefs<HermesOutputRunRef>> {
   const outputDir = join(HERMES_OUTPUT_DIR, jobId)
   if (!existsSync(outputDir)) {
-    return []
+    return { refs: [], saturated: false }
   }
-  const entries = await readdir(outputDir, { withFileTypes: true })
-  return entries
-    .filter((entry) => entry.isFile() && HERMES_OUTPUT_FILE_PATTERN.test(entry.name))
-    .map((entry) => ({
+  const retainer = new HermesRunRefRetainer<HermesOutputRunRef>()
+  const directory = await opendir(outputDir)
+  for await (const entry of directory) {
+    if (!entry.isFile() || !HERMES_OUTPUT_FILE_PATTERN.test(entry.name)) {
+      continue
+    }
+    retainer.add({
       kind: 'output' as const,
       id: `${jobId}:${entry.name}`,
       job_id: jobId,
       run_at: runAtFromHermesOutputFile(entry.name),
       run_key: runKeyFromHermesOutputFile(entry.name),
       output_path: join(outputDir, entry.name)
-    }))
+    })
+  }
+  return retainer.finish()
 }
 
 async function readHermesOutputFileRun(ref: HermesOutputRunRef): Promise<unknown> {
   try {
-    const content = await readFile(ref.output_path, 'utf-8')
+    const { buffer } = await readNodeFileWithinLimit(
+      ref.output_path,
+      HERMES_PRIMARY_OUTPUT_MAX_BYTES
+    )
+    const content = buffer.toString('utf-8')
     const parsed = parseHermesOutput(content)
     const outputContent = await appendReferencedLogFile(parsed.outputContent)
     return {
@@ -764,37 +760,41 @@ async function readHermesOutputFileRun(ref: HermesOutputRunRef): Promise<unknown
   }
 }
 
-function readHermesSessionDbRunRefs(jobId: string): HermesSessionRunRef[] {
+function readHermesSessionDbRunRefs(jobId: string): BoundedHermesRunRefs<HermesSessionRunRef> {
   if (!existsSync(HERMES_STATE_DB)) {
-    return []
+    return { refs: [], saturated: false }
   }
   try {
     const db = new Database(HERMES_STATE_DB, { readonly: true, fileMustExist: true })
     try {
       const pattern = `cron\\_${escapeSqlLike(jobId)}\\_%`
-      const rows = db
-        .prepare(
-          `SELECT id, started_at
-             FROM sessions
-            WHERE id LIKE ? ESCAPE '\\'
-            ORDER BY started_at DESC`
-        )
-        .all(pattern) as Record<string, unknown>[]
-      return rows.map((row) => {
+      const statement = db.prepare(HERMES_SESSION_RUN_REFS_SELECT_SQL)
+      const rows =
+        typeof statement.iterate === 'function'
+          ? (statement.iterate(pattern) as Iterable<Record<string, unknown>>)
+          : (statement.all(pattern) as Record<string, unknown>[])
+      const retainer = new HermesRunRefRetainer<HermesSessionRunRef>()
+      let read = 0
+      for (const row of rows) {
+        if (read >= HERMES_RUN_REF_MAX_ENTRIES + 1) {
+          break
+        }
+        read += 1
         const runId = typeof row.id === 'string' ? row.id : `${jobId}:${String(row.started_at)}`
-        return {
+        retainer.add({
           kind: 'session',
           id: runId,
           job_id: jobId,
           run_at: runAtFromUnixSeconds(row.started_at),
           run_key: runId.split(`${jobId}_`).at(-1) ?? null
-        }
-      })
+        })
+      }
+      return retainer.finish()
     } finally {
       db.close()
     }
   } catch {
-    return []
+    return { refs: [], saturated: false }
   }
 }
 
@@ -805,25 +805,18 @@ function readHermesSessionDbRunById(jobId: string, runId: string): unknown | nul
   try {
     const db = new Database(HERMES_STATE_DB, { readonly: true, fileMustExist: true })
     try {
-      const row = db
-        .prepare(
-          `SELECT id, title, started_at, ended_at, end_reason, model, message_count,
-                  input_tokens, output_tokens, estimated_cost_usd
-             FROM sessions
-            WHERE id = ?`
-        )
-        .get(runId) as Record<string, unknown> | undefined
+      const row = db.prepare(HERMES_SESSION_RUN_SELECT_SQL).get(runId) as
+        | Record<string, unknown>
+        | undefined
       if (!row) {
         return null
       }
-      const messages = db
-        .prepare(
-          `SELECT role, content, tool_name, reasoning, reasoning_content
-               FROM messages
-              WHERE session_id = ?
-              ORDER BY timestamp, id`
-        )
-        .all(runId) as Record<string, unknown>[]
+      const messageStatement = db.prepare(HERMES_SESSION_TRANSCRIPT_SELECT_SQL)
+      const messages =
+        typeof messageStatement.iterate === 'function'
+          ? (messageStatement.iterate(runId) as Iterable<Record<string, unknown>>)
+          : (messageStatement.all(runId) as Record<string, unknown>[])
+      const formattedMessages = formatHermesSessionMessagesWithinLimits(messages)
       const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : null
       const model = typeof row.model === 'string' && row.model.trim() ? row.model.trim() : null
       const messageCount = typeof row.message_count === 'number' ? row.message_count : null
@@ -843,8 +836,8 @@ function readHermesSessionDbRunById(jobId: string, runId: string): unknown | nul
         run_key: runId.split(`${jobId}_`).at(-1) ?? null,
         status: typeof row.ended_at === 'number' ? 'completed' : 'unknown',
         output_preview: summaryParts.join(' · ') || null,
-        output_content: formatSessionMessages(messages),
-        error: null,
+        output_content: formattedMessages.content,
+        error: formattedMessages.truncated ? HERMES_SESSION_TRANSCRIPT_TRUNCATED_ERROR : null,
         output_path: HERMES_STATE_DB
       }
     } finally {

--- a/src/main/hooks-file-bounds.test.ts
+++ b/src/main/hooks-file-bounds.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  truncateSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  loadHooks,
+  MAX_HOOK_GITIGNORE_BYTES,
+  MAX_ISSUE_COMMAND_BYTES,
+  MAX_ORCA_YAML_BYTES,
+  readIssueCommand,
+  writeIssueCommand
+} from './hooks'
+
+describe('hook configuration file bounds', () => {
+  const roots: string[] = []
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    for (const root of roots.splice(0)) {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  function makeRepo(): string {
+    const root = mkdtempSync(join(tmpdir(), 'orca-hook-file-bounds-'))
+    roots.push(root)
+    return root
+  }
+
+  function writeOversizedSparseFile(path: string, limit: number): void {
+    writeFileSync(path, 'x')
+    truncateSync(path, limit + 1)
+  }
+
+  it('fails closed on an oversized sparse orca.yaml', () => {
+    const repoPath = makeRepo()
+    writeOversizedSparseFile(join(repoPath, 'orca.yaml'), MAX_ORCA_YAML_BYTES)
+
+    expect(loadHooks(repoPath)).toBeNull()
+  })
+
+  it('ignores an oversized local issue command while retaining the shared command', () => {
+    const repoPath = makeRepo()
+    mkdirSync(join(repoPath, '.orca'))
+    writeOversizedSparseFile(join(repoPath, '.orca', 'issue-command'), MAX_ISSUE_COMMAND_BYTES)
+    writeFileSync(join(repoPath, 'orca.yaml'), 'issueCommand: shared command\n')
+
+    expect(readIssueCommand(repoPath)).toMatchObject({
+      localContent: null,
+      sharedContent: 'shared command',
+      effectiveContent: 'shared command',
+      source: 'shared'
+    })
+  })
+
+  it('does not rewrite an oversized .gitignore when saving a local command', () => {
+    const repoPath = makeRepo()
+    const gitignorePath = join(repoPath, '.gitignore')
+    writeOversizedSparseFile(gitignorePath, MAX_HOOK_GITIGNORE_BYTES)
+    const originalSize = statSync(gitignorePath).size
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    writeIssueCommand(repoPath, 'local command')
+
+    expect(statSync(gitignorePath).size).toBe(originalSize)
+    expect(readFileSync(join(repoPath, '.orca', 'issue-command'), 'utf8')).toBe('local command\n')
+  })
+})

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -16,6 +16,20 @@ vi.mock('fs', () => ({
   chmodSync: vi.fn()
 }))
 
+vi.mock('../shared/node-bounded-file-reader', async () => {
+  const fs = await import('node:fs')
+  return {
+    readNodeFileSyncWithinLimit: (path: string, maxBytes: number) => {
+      const value = fs.readFileSync(path)
+      const buffer = Buffer.isBuffer(value) ? value : Buffer.from(value)
+      if (buffer.length > maxBytes) {
+        throw new Error('File too large')
+      }
+      return { buffer, stats: { size: buffer.length } }
+    }
+  }
+})
+
 const { execMock, execFileMock, gitExecFileSyncMock } = vi.hoisted(() => ({
   execMock: vi.fn(),
   execFileMock: vi.fn(),

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Why: hook parsing, layered issue-command resolution, and cross-platform runner setup share one execution surface, so keeping them together avoids subtle drift across create/read/write paths. */
-import { readFileSync, existsSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, writeFileSync, chmodSync, rmSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { exec, execFile } from 'node:child_process'
 import { getDefaultRepoHookSettings } from '../shared/constants'
@@ -21,8 +21,17 @@ import type {
   WorktreeSetupLaunch
 } from '../shared/types'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
+import { MAX_ORCA_YAML_BYTES } from '../shared/orca-yaml-file-limit'
 
 const HOOK_TIMEOUT = 120_000 // 2 minutes
+export { MAX_ORCA_YAML_BYTES }
+export const MAX_ISSUE_COMMAND_BYTES = 1024 * 1024
+export const MAX_HOOK_GITIGNORE_BYTES = 4 * 1024 * 1024
+
+function readHookFile(path: string, maxBytes: number): string {
+  return readNodeFileSyncWithinLimit(path, maxBytes).buffer.toString('utf8')
+}
 
 export type HookRuntimeTarget = {
   wslDistro?: string | null
@@ -48,7 +57,7 @@ export function loadHooks(repoPath: string): OrcaHooks | null {
   }
 
   try {
-    const content = readFileSync(yamlPath, 'utf-8')
+    const content = readHookFile(yamlPath, MAX_ORCA_YAML_BYTES)
     return parseOrcaYaml(content)
   } catch {
     return null
@@ -73,7 +82,7 @@ const RECOGNIZED_ORCA_YAML_KEYS = new Set([
 /** True when `orca.yaml` has a top-level key this version of Orca does not handle. */
 export function hasUnrecognizedOrcaYamlKeys(repoPath: string): boolean {
   try {
-    const content = readFileSync(join(repoPath, 'orca.yaml'), 'utf-8')
+    const content = readHookFile(join(repoPath, 'orca.yaml'), MAX_ORCA_YAML_BYTES)
     for (const line of iterateLfScriptLines(content)) {
       // Why: match bare `key:` at end-of-line too, since a mapping with a block value on the next line is valid YAML.
       const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*):(\s|$)/)
@@ -118,7 +127,7 @@ export function readIssueCommand(repoPath: string): ResolvedIssueCommand {
 
   if (existsSync(filePath)) {
     try {
-      const content = readFileSync(filePath, 'utf-8').trim()
+      const content = readHookFile(filePath, MAX_ISSUE_COMMAND_BYTES).trim()
       localContent = content || null
     } catch {
       localContent = null
@@ -169,7 +178,7 @@ function ensureOrcaDirIgnored(repoPath: string): void {
   const gitignorePath = join(repoPath, '.gitignore')
   try {
     if (existsSync(gitignorePath)) {
-      const content = readFileSync(gitignorePath, 'utf-8')
+      const content = readHookFile(gitignorePath, MAX_HOOK_GITIGNORE_BYTES)
       if (/^\.orca\/?$/m.test(content)) {
         return
       }

--- a/src/main/remote-agent-trust-presets.test.ts
+++ b/src/main/remote-agent-trust-presets.test.ts
@@ -14,6 +14,7 @@ vi.mock('./providers/ssh-filesystem-dispatch', () => ({
 }))
 
 const { markRemoteAgentWorkspaceTrusted } = await import('./remote-agent-trust-presets')
+const { MAX_AGENT_STATE_FILE_BYTES } = await import('./agent-state-file-reader')
 
 function makeFsProvider(overrides: Record<string, unknown> = {}) {
   return {
@@ -142,6 +143,27 @@ describe('markRemoteAgentWorkspaceTrusted', () => {
       firstLaunchAt: '2026-01-01',
       trustedFolders: ['/old', '/real/repo/worktree']
     })
+  })
+
+  it('rejects oversized remote config without overwriting it', async () => {
+    const fsProvider = makeFsProvider({
+      readFile: vi.fn(async () => ({
+        content: 'x'.repeat(MAX_AGENT_STATE_FILE_BYTES + 1),
+        isBinary: false
+      }))
+    })
+    mocks.getSshFilesystemProvider.mockReturnValue(fsProvider)
+
+    await expect(
+      markRemoteAgentWorkspaceTrusted({
+        preset: 'codex',
+        connectionId: 'ssh-1',
+        workspacePath: '/repo/worktree'
+      })
+    ).rejects.toThrow('Remote agent state exceeds')
+
+    expect(fsProvider.createDir).not.toHaveBeenCalled()
+    expect(fsProvider.writeFile).not.toHaveBeenCalled()
   })
 
   it('does nothing when the SSH home cannot be resolved safely', async () => {

--- a/src/main/remote-agent-trust-presets.ts
+++ b/src/main/remote-agent-trust-presets.ts
@@ -7,6 +7,14 @@ import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathSeparators
 } from '../shared/cross-platform-path'
+import { MAX_AGENT_STATE_FILE_BYTES } from './agent-state-file-reader'
+
+class RemoteAgentStateFileTooLargeError extends Error {
+  constructor() {
+    super(`Remote agent state exceeds ${MAX_AGENT_STATE_FILE_BYTES} bytes`)
+    this.name = 'RemoteAgentStateFileTooLargeError'
+  }
+}
 
 export async function markRemoteAgentWorkspaceTrusted(args: {
   preset: AgentTrustPreset
@@ -69,9 +77,24 @@ async function readRemoteTextFile(
 ): Promise<string> {
   try {
     const result = await fsProvider.readFile(filePath)
-    return result.isBinary ? '' : result.content
-  } catch {
+    if (result.isBinary) {
+      return ''
+    }
+    if (Buffer.byteLength(result.content, 'utf8') > MAX_AGENT_STATE_FILE_BYTES) {
+      throw new RemoteAgentStateFileTooLargeError()
+    }
+    return result.content
+  } catch (error) {
+    if (error instanceof RemoteAgentStateFileTooLargeError) {
+      throw error
+    }
     return ''
+  }
+}
+
+function assertRemoteAgentStateWithinLimit(content: string): void {
+  if (Buffer.byteLength(content, 'utf8') > MAX_AGENT_STATE_FILE_BYTES) {
+    throw new RemoteAgentStateFileTooLargeError()
   }
 }
 
@@ -91,6 +114,7 @@ async function markRemoteCodexProjectTrusted(
   if (updated === existing) {
     return
   }
+  assertRemoteAgentStateWithinLimit(updated)
   await fsProvider.createDir(codexDir)
   await fsProvider.writeFile(configPath, updated)
 }
@@ -113,10 +137,9 @@ async function markRemoteCursorWorkspaceTrusted(
     // Missing marker: write the same shape the local trust preset writes.
   }
   await fsProvider.createDir(trustDir)
-  await fsProvider.writeFile(
-    trustFile,
-    `${JSON.stringify({ trustedAt: new Date().toISOString(), workspacePath }, null, 2)}\n`
-  )
+  const content = `${JSON.stringify({ trustedAt: new Date().toISOString(), workspacePath }, null, 2)}\n`
+  assertRemoteAgentStateWithinLimit(content)
+  await fsProvider.writeFile(trustFile, content)
 }
 
 async function markRemoteCopilotFolderTrusted(
@@ -143,6 +166,8 @@ async function markRemoteCopilotFolderTrusted(
     return
   }
   config.trustedFolders = [...existing.filter((entry) => typeof entry === 'string'), workspacePath]
+  const content = `${JSON.stringify(config, null, 2)}\n`
+  assertRemoteAgentStateWithinLimit(content)
   await fsProvider.createDir(configDir)
-  await fsProvider.writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`)
+  await fsProvider.writeFile(configPath, content)
 }

--- a/src/main/skills/claude-plugin-skill-sources-wsl.test.ts
+++ b/src/main/skills/claude-plugin-skill-sources-wsl.test.ts
@@ -35,4 +35,8 @@ describe('WSL Claude plugin metadata', () => {
       'invalid response'
     )
   })
+
+  it('parses delimiter-heavy output without materializing a field array', () => {
+    expect(parseWslClaudePluginMetadataOutput('\0'.repeat(1_000_000), 2)).toEqual([null, null])
+  })
 })

--- a/src/main/skills/claude-plugin-skill-sources-wsl.ts
+++ b/src/main/skills/claude-plugin-skill-sources-wsl.ts
@@ -7,6 +7,10 @@ import {
   type ClaudePluginMetadata
 } from './claude-plugin-skill-sources'
 import type { SkillScanRoot } from './skill-discovery-sources'
+import {
+  readWslSkillProtocolField,
+  type WslSkillProtocolFieldCursor
+} from './wsl-skill-protocol-fields'
 
 const MAX_PLUGIN_METADATA_BYTES = 4 * 1024 * 1024
 const WSL_METADATA_TIMEOUT_MS = 5_000
@@ -39,17 +43,26 @@ export function parseWslClaudePluginMetadataOutput(
   fileCount: number
 ): (string | null)[] {
   const contents = Array<string | null>(fileCount).fill(null)
-  const fields = output.split('\0')
-  let index = 0
-  while (index < fields.length && fields[index]) {
-    const kind = fields[index++]
-    const fileIndex = Number.parseInt(fields[index++] ?? '', 10)
-    const exists = fields[index++] === '1'
-    const encoded = fields[index++]
+  const cursor: WslSkillProtocolFieldCursor = { offset: 0 }
+  const readField = (): string =>
+    readWslSkillProtocolField(
+      output,
+      cursor,
+      'WSL Claude plugin metadata returned an incomplete response.'
+    )
+  while (cursor.offset < output.length) {
+    // Why: cursor reads keep delimiter-heavy subprocess output from amplifying into a huge array.
+    const kind = readField()
+    if (!kind) {
+      break
+    }
+    const fileIndex = Number.parseInt(readField(), 10)
+    const exists = readField() === '1'
+    const encoded = readField()
     if (kind !== 'F' || !Number.isInteger(fileIndex) || fileIndex < 0 || fileIndex >= fileCount) {
       throw new Error('WSL Claude plugin metadata returned an invalid response.')
     }
-    if (exists && encoded !== undefined) {
+    if (exists) {
       contents[fileIndex] = Buffer.from(encoded, 'base64').toString('utf8')
     }
   }

--- a/src/main/skills/discovery.test.ts
+++ b/src/main/skills/discovery.test.ts
@@ -328,4 +328,25 @@ describe('skill discovery', () => {
 
     expect(result.skills.map((skill) => skill.name)).not.toContain('Too Deep')
   })
+
+  it('rejects pathological retained skill metadata instead of growing the result unboundedly', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skills-'))
+    const home = join(root, 'home')
+    const skillsRoot = join(home, '.agents', 'skills')
+    const description = 'x'.repeat(150_000)
+    await Promise.all(
+      Array.from({ length: 16 }, async (_, index) => {
+        const skillDir = join(skillsRoot, `large-${index}`)
+        await mkdir(skillDir, { recursive: true })
+        await writeFile(
+          join(skillDir, 'SKILL.md'),
+          `---\nname: large-${index}\ndescription: ${description}\n---\n`
+        )
+      })
+    )
+
+    await expect(
+      discoverSkills({ homeDir: home, cwd: join(root, 'missing-cwd'), repos: [] })
+    ).rejects.toThrow(/result is too large/)
+  })
 })

--- a/src/main/skills/discovery.ts
+++ b/src/main/skills/discovery.ts
@@ -1,5 +1,4 @@
-import type { Dirent } from 'node:fs'
-import { open, readdir, realpath, stat } from 'node:fs/promises'
+import { open, opendir, realpath, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, isAbsolute, join, relative, sep } from 'node:path'
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
@@ -18,6 +17,15 @@ import {
   type SkillScanRoot
 } from './skill-discovery-sources'
 import { discoverClaudePluginSkillSources } from './claude-plugin-skill-sources'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
+import {
+  MAX_CONCURRENT_SKILL_DISCOVERY_CANDIDATES,
+  MAX_CONCURRENT_SKILL_DISCOVERY_ROOTS,
+  MAX_SKILL_PACKAGE_DIRECTORIES,
+  MAX_SKILL_PACKAGE_ENTRIES,
+  SkillDiscoveryBudget,
+  SkillDiscoveryLimitError
+} from './skill-discovery-limits'
 
 export { buildSkillDiscoverySources } from './skill-discovery-sources'
 
@@ -46,13 +54,18 @@ function isWithinDepth(rootPath: string, childPath: string, maxDepth: number): b
   return rel.split(sep).length <= maxDepth
 }
 
-async function findSkillFiles(rootPath: string, maxDepth: number): Promise<string[]> {
+async function findSkillFiles(
+  rootPath: string,
+  maxDepth: number,
+  budget: SkillDiscoveryBudget
+): Promise<string[]> {
   const out: string[] = []
   const visitedDirectoryPaths = new Set<string>()
   async function visit(dirPath: string): Promise<void> {
     if (!isWithinDepth(rootPath, dirPath, maxDepth)) {
       return
     }
+    budget.visitDirectory()
     let resolvedDirPath: string
     try {
       resolvedDirPath = await realpath(dirPath)
@@ -64,44 +77,45 @@ async function findSkillFiles(rootPath: string, maxDepth: number): Promise<strin
     }
     visitedDirectoryPaths.add(resolvedDirPath)
 
-    let entries: Dirent[]
-    try {
-      entries = await readdir(dirPath, { withFileTypes: true })
-    } catch {
+    const directory = await opendir(dirPath).catch(() => null)
+    if (!directory) {
       return
     }
-    for (const entry of entries) {
-      const entryPath = join(dirPath, entry.name)
-      if (entry.name === SKILL_FILE_NAME) {
-        if (entry.isFile()) {
-          out.push(entryPath)
+    try {
+      for await (const entry of directory) {
+        budget.visitEntry()
+        const entryPath = join(dirPath, entry.name)
+        if (entry.name === SKILL_FILE_NAME) {
+          if (entry.isFile()) {
+            budget.admitCandidate()
+            out.push(entryPath)
+            continue
+          }
+          if (entry.isSymbolicLink()) {
+            const linkedStat = await stat(entryPath).catch(() => null)
+            if (linkedStat?.isFile()) {
+              budget.admitCandidate()
+              out.push(entryPath)
+            }
+          }
+          continue
+        }
+        if (entry.isDirectory()) {
+          await visit(entryPath)
           continue
         }
         if (entry.isSymbolicLink()) {
-          try {
-            if ((await stat(entryPath)).isFile()) {
-              out.push(entryPath)
-            }
-          } catch {
-            // Broken links are not valid skill files.
-          }
-        }
-        continue
-      }
-      if (entry.isDirectory()) {
-        await visit(entryPath)
-        continue
-      }
-      if (entry.isSymbolicLink()) {
-        // Why: users commonly symlink agent skill dirs across providers; follow
-        // directory links but guard by realpath so recursive links cannot loop.
-        try {
-          if ((await stat(entryPath)).isDirectory()) {
+          // Why: users commonly symlink agent skill dirs across providers; follow
+          // directory links but guard by realpath so recursive links cannot loop.
+          const linkedStat = await stat(entryPath).catch(() => null)
+          if (linkedStat?.isDirectory()) {
             await visit(entryPath)
           }
-        } catch {
-          // Broken links are not valid skill directories.
         }
+      }
+    } catch (error) {
+      if (error instanceof SkillDiscoveryLimitError) {
+        throw error
       }
     }
   }
@@ -111,9 +125,16 @@ async function findSkillFiles(rootPath: string, maxDepth: number): Promise<strin
 
 async function countFiles(dirPath: string): Promise<number> {
   let count = 0
+  let entriesVisited = 0
+  let stoppedEarly = false
   const visitedDirectoryPaths = new Set<string>()
   async function visit(currentPath: string): Promise<void> {
-    if (count >= MAX_SKILL_FILES) {
+    if (
+      stoppedEarly ||
+      count >= MAX_SKILL_FILES ||
+      visitedDirectoryPaths.size >= MAX_SKILL_PACKAGE_DIRECTORIES
+    ) {
+      stoppedEarly = true
       return
     }
     let resolvedPath: string
@@ -127,30 +148,34 @@ async function countFiles(dirPath: string): Promise<number> {
     }
     visitedDirectoryPaths.add(resolvedPath)
 
-    let entries: Dirent[]
-    try {
-      entries = await readdir(currentPath, { withFileTypes: true })
-    } catch {
+    const directory = await opendir(currentPath).catch(() => null)
+    if (!directory) {
       return
     }
-    for (const entry of entries) {
-      if (count >= MAX_SKILL_FILES) {
-        return
-      }
-      const entryPath = join(currentPath, entry.name)
-      if (entry.isFile()) {
-        count += 1
-      } else if (entry.isDirectory()) {
-        await visit(entryPath)
-      } else if (entry.isSymbolicLink()) {
-        try {
-          if ((await stat(entryPath)).isFile()) {
-            count += 1
+    try {
+      for await (const entry of directory) {
+        entriesVisited += 1
+        if (count >= MAX_SKILL_FILES || entriesVisited > MAX_SKILL_PACKAGE_ENTRIES) {
+          stoppedEarly = true
+          return
+        }
+        const entryPath = join(currentPath, entry.name)
+        if (entry.isFile()) {
+          count += 1
+        } else if (entry.isDirectory()) {
+          await visit(entryPath)
+        } else if (entry.isSymbolicLink()) {
+          try {
+            if ((await stat(entryPath)).isFile()) {
+              count += 1
+            }
+          } catch {
+            // Broken links do not contribute to the skill package file count.
           }
-        } catch {
-          // Broken links do not contribute to the skill package file count.
         }
       }
+    } catch {
+      // Preserve the partial count when a directory changes during enumeration.
     }
   }
   await visit(dirPath)
@@ -184,11 +209,16 @@ async function readSkillSummary(skillFilePath: string): Promise<{
 
 type ScannedSkill = DiscoveredSkill & { canonicalSkillFilePath: string }
 
-async function scanRoot(root: SkillScanRoot): Promise<ScannedSkill[]> {
+async function scanRoot(
+  root: SkillScanRoot,
+  budget: SkillDiscoveryBudget
+): Promise<ScannedSkill[]> {
   const maxDepth = root.sourceKind === 'plugin' ? 9 : 4
-  const skillFiles = await findSkillFiles(root.path, maxDepth)
-  const skills = await Promise.all(
-    skillFiles.map(async (skillFilePath): Promise<ScannedSkill | null> => {
+  const skillFiles = await findSkillFiles(root.path, maxDepth, budget)
+  const skills = await mapWithConcurrency(
+    skillFiles,
+    MAX_CONCURRENT_SKILL_DISCOVERY_CANDIDATES,
+    async (skillFilePath): Promise<ScannedSkill | null> => {
       // Why: path identity belongs to the scanning host; canonicalizing before
       // returning prevents symlinked roots from becoming duplicate picker rows.
       const canonicalSkillFilePath = await realpath(skillFilePath).catch(() => skillFilePath)
@@ -198,7 +228,7 @@ async function scanRoot(root: SkillScanRoot): Promise<ScannedSkill[]> {
         return null
       }
       const sourceKind = sourceKindForSkill(root, skillFilePath, { relative, sep })
-      return {
+      const skill = {
         id: stablePathId(canonicalSkillFilePath),
         name: summary.name ?? basename(directoryPath),
         description: summary.description,
@@ -215,7 +245,9 @@ async function scanRoot(root: SkillScanRoot): Promise<ScannedSkill[]> {
         updatedAt: summary.updatedAt,
         canonicalSkillFilePath
       } satisfies ScannedSkill
-    })
+      budget.retainSkill(skill)
+      return skill
+    }
   )
   return skills.filter((skill): skill is ScannedSkill => skill !== null)
 }
@@ -235,54 +267,58 @@ export async function discoverSkills(args: {
       ? await discoverClaudePluginSkillSources({ homeDir, cwd: args.cwd })
       : [])
   ]
-  const sources: SkillDiscoverySource[] = []
-  const skillGroups = await Promise.all(
-    roots.map(async (root) => {
+  const budget = new SkillDiscoveryBudget(roots)
+  const scannedRoots = await mapWithConcurrency(
+    roots,
+    MAX_CONCURRENT_SKILL_DISCOVERY_ROOTS,
+    async (root) => {
       const exists = await pathExists(root.path)
-      sources.push({
+      const source: SkillDiscoverySource = {
         ...root,
         providers: [...root.providers],
         exists,
         skippedReason: exists ? undefined : 'missing'
-      })
-      if (!exists) {
-        return []
       }
-      return scanRoot(root)
-    })
+      if (!exists) {
+        return { source, skills: [] }
+      }
+      return { source, skills: await scanRoot(root, budget) }
+    }
   )
   const seen = new Map<string, DiscoveredSkill>()
-  for (const skill of skillGroups.flat()) {
-    // Why: overlapping repo/cwd roots and symlinked provider homes can reach
-    // the same file. Keep the first source's higher-level scope identity, but
-    // record every contributing root so per-agent visibility survives dedup.
-    const existing = seen.get(skill.canonicalSkillFilePath)
-    if (existing) {
-      if (existing.rootPaths && !existing.rootPaths.includes(skill.rootPath)) {
-        existing.rootPaths.push(skill.rootPath)
-      }
-      // Why: providers is per-agent visibility just like rootPaths; keeping only
-      // the first root's tags makes a shared/symlinked skill under-report which
-      // agents can see it on the Settings provider badges/filter. Reassign a
-      // fresh array — `providers` aliases the scan root's array, so pushing in
-      // place would mutate the root and every sibling skill/source sharing it.
-      const mergedProviders = [...existing.providers]
-      for (const provider of skill.providers) {
-        if (!mergedProviders.includes(provider)) {
-          mergedProviders.push(provider)
+  for (const group of scannedRoots) {
+    for (const skill of group.skills) {
+      // Why: overlapping repo/cwd roots and symlinked provider homes can reach
+      // the same file. Keep the first source's higher-level scope identity, but
+      // record every contributing root so per-agent visibility survives dedup.
+      const existing = seen.get(skill.canonicalSkillFilePath)
+      if (existing) {
+        if (existing.rootPaths && !existing.rootPaths.includes(skill.rootPath)) {
+          existing.rootPaths.push(skill.rootPath)
         }
+        // Why: providers is per-agent visibility just like rootPaths; keeping only
+        // the first root's tags makes a shared/symlinked skill under-report which
+        // agents can see it on the Settings provider badges/filter. Reassign a
+        // fresh array — `providers` aliases the scan root's array, so pushing in
+        // place would mutate the root and every sibling skill/source sharing it.
+        const mergedProviders = [...existing.providers]
+        for (const provider of skill.providers) {
+          if (!mergedProviders.includes(provider)) {
+            mergedProviders.push(provider)
+          }
+        }
+        existing.providers = mergedProviders
+        continue
       }
-      existing.providers = mergedProviders
-      continue
+      const { canonicalSkillFilePath, ...publicSkill } = skill
+      seen.set(canonicalSkillFilePath, { ...publicSkill, rootPaths: [skill.rootPath] })
     }
-    const { canonicalSkillFilePath, ...publicSkill } = skill
-    seen.set(canonicalSkillFilePath, { ...publicSkill, rootPaths: [skill.rootPath] })
   }
   return {
     skills: Array.from(seen.values()).sort(compareSkills),
-    sources: sources.sort((a, b) =>
-      a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })
-    ),
+    sources: scannedRoots
+      .map(({ source }) => source)
+      .sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' })),
     scannedAt: Date.now()
   }
 }

--- a/src/main/skills/skill-bundle-artifacts.test.ts
+++ b/src/main/skills/skill-bundle-artifacts.test.ts
@@ -1,8 +1,15 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
-import { loadSkillBundleArtifacts } from './skill-bundle-artifacts'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import {
+  loadSkillBundleArtifacts,
+  readSkillBundleArtifactJson,
+  SKILL_BUNDLE_CURRENT_MANIFEST_MAX_BYTES,
+  SKILL_BUNDLE_JSON_MAX_STRUCTURAL_TOKENS,
+  SKILL_BUNDLE_SNAPSHOT_REGISTRY_MAX_BYTES
+} from './skill-bundle-artifacts'
 
 const temporaryDirectories: string[] = []
 
@@ -75,5 +82,46 @@ describe('skill bundle artifacts', () => {
     await expect(loadSkillBundleArtifacts(resourceRoot)).rejects.toThrow(
       'Invalid skill release mapping'
     )
+  })
+
+  it('rejects a sparse oversized artifact without poisoning a later bounded load', async () => {
+    const resourceRoot = await mkdtemp(join(tmpdir(), 'orca-skill-artifacts-'))
+    temporaryDirectories.push(resourceRoot)
+    const target = join(resourceRoot, 'skills')
+    const source = resolve('resources', 'skills')
+    await mkdir(target, { recursive: true })
+    const [manifest, registry, releaseMapping] = await Promise.all(
+      ['current-manifest.json', 'snapshot-registry.json', 'release-mapping.json'].map((name) =>
+        readFile(join(source, name), 'utf8')
+      )
+    )
+    const manifestPath = join(target, 'current-manifest.json')
+    await Promise.all([
+      writeFile(manifestPath, ''),
+      writeFile(join(target, 'snapshot-registry.json'), registry),
+      writeFile(join(target, 'release-mapping.json'), releaseMapping)
+    ])
+    await truncate(manifestPath, SKILL_BUNDLE_CURRENT_MANIFEST_MAX_BYTES + 1)
+
+    await expect(loadSkillBundleArtifacts(resourceRoot)).rejects.toThrow(NodeFileReadTooLargeError)
+
+    await writeFile(manifestPath, manifest)
+    await expect(loadSkillBundleArtifacts(resourceRoot)).resolves.toMatchObject({
+      manifest: { schemaVersion: 2 }
+    })
+  })
+
+  it('rejects structural amplification before parsing a bounded artifact', async () => {
+    const resourceRoot = await mkdtemp(join(tmpdir(), 'orca-skill-artifacts-'))
+    temporaryDirectories.push(resourceRoot)
+    const path = join(resourceRoot, 'amplified.json')
+    await writeFile(path, `[${'0,'.repeat(SKILL_BUNDLE_JSON_MAX_STRUCTURAL_TOKENS)}0]`)
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    await expect(
+      readSkillBundleArtifactJson(path, SKILL_BUNDLE_SNAPSHOT_REGISTRY_MAX_BYTES)
+    ).rejects.toThrow('JSON structure exceeds')
+    expect(parseSpy).not.toHaveBeenCalled()
+    parseSpy.mockRestore()
   })
 })

--- a/src/main/skills/skill-bundle-artifacts.ts
+++ b/src/main/skills/skill-bundle-artifacts.ts
@@ -1,13 +1,20 @@
 import { app } from 'electron'
-import { readFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import { z, type ZodType } from 'zod'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 import type {
   SkillBundleManifest,
   SkillKnownSnapshot,
   SkillReleaseMapping,
   SkillSnapshotRegistry
 } from '../../shared/skill-freshness'
+
+export const SKILL_BUNDLE_CURRENT_MANIFEST_MAX_BYTES = 2 * 1024 * 1024
+export const SKILL_BUNDLE_SNAPSHOT_REGISTRY_MAX_BYTES = 16 * 1024 * 1024
+export const SKILL_BUNDLE_RELEASE_MAPPING_MAX_BYTES = 2 * 1024 * 1024
+export const SKILL_BUNDLE_JSON_MAX_STRUCTURAL_TOKENS = 1_000_000
+export const SKILL_BUNDLE_JSON_MAX_NESTING_DEPTH = 128
 
 export type SkillBundleArtifacts = {
   manifest: SkillBundleManifest
@@ -103,9 +110,18 @@ export function loadSkillBundleArtifacts(
 async function readSkillBundleArtifacts(resourceRoot: string): Promise<SkillBundleArtifacts> {
   const bundleRoot = join(resourceRoot, 'skills')
   const [manifestValue, registryValue, releaseMappingValue] = await Promise.all([
-    readFile(join(bundleRoot, 'current-manifest.json'), 'utf8').then(JSON.parse),
-    readFile(join(bundleRoot, 'snapshot-registry.json'), 'utf8').then(JSON.parse),
-    readFile(join(bundleRoot, 'release-mapping.json'), 'utf8').then(JSON.parse)
+    readSkillBundleArtifactJson(
+      join(bundleRoot, 'current-manifest.json'),
+      SKILL_BUNDLE_CURRENT_MANIFEST_MAX_BYTES
+    ),
+    readSkillBundleArtifactJson(
+      join(bundleRoot, 'snapshot-registry.json'),
+      SKILL_BUNDLE_SNAPSHOT_REGISTRY_MAX_BYTES
+    ),
+    readSkillBundleArtifactJson(
+      join(bundleRoot, 'release-mapping.json'),
+      SKILL_BUNDLE_RELEASE_MAPPING_MAX_BYTES
+    )
   ])
   const manifest: SkillBundleManifest = parseArtifact(
     manifestSchema,
@@ -156,4 +172,17 @@ async function readSkillBundleArtifacts(resourceRoot: string): Promise<SkillBund
     knownSnapshots: registry.skills,
     releasedAppVersions
   }
+}
+
+export async function readSkillBundleArtifactJson(
+  path: string,
+  maxBytes: number
+): Promise<unknown> {
+  const { buffer } = await readNodeFileWithinLimit(path, maxBytes)
+  const content = buffer.toString('utf8')
+  assertJsonTextStructureWithinLimits(content, {
+    structuralTokens: SKILL_BUNDLE_JSON_MAX_STRUCTURAL_TOKENS,
+    nestingDepth: SKILL_BUNDLE_JSON_MAX_NESTING_DEPTH
+  })
+  return JSON.parse(content) as unknown
 }

--- a/src/main/skills/skill-discovery-limits.test.ts
+++ b/src/main/skills/skill-discovery-limits.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import type { DiscoveredSkill } from '../../shared/skills'
+import type { SkillScanRoot } from './skill-discovery-sources'
+import {
+  MAX_SKILL_DISCOVERY_CANDIDATES,
+  MAX_SKILL_DISCOVERY_RESULT_BYTES,
+  MAX_SKILL_DISCOVERY_ROOTS,
+  SkillDiscoveryBudget,
+  WSL_SKILL_DISCOVERY_MAX_OUTPUT_BYTES,
+  assertSkillDiscoveryOutputWithinLimit
+} from './skill-discovery-limits'
+
+function root(index: number): SkillScanRoot {
+  return {
+    id: `root-${index}`,
+    label: `Root ${index}`,
+    path: `/skills/${index}`,
+    sourceKind: 'home',
+    providers: ['agent-skills'],
+    owner: null
+  }
+}
+
+function skill(description: string): DiscoveredSkill {
+  return {
+    id: 'skill-id',
+    name: 'Skill',
+    description,
+    providers: ['agent-skills'],
+    sourceKind: 'home',
+    sourceLabel: 'Agent skills home',
+    rootPath: '/skills',
+    directoryPath: '/skills/example',
+    skillFilePath: '/skills/example/SKILL.md',
+    installed: true,
+    fileCount: 1,
+    updatedAt: null
+  }
+}
+
+describe('installed-skill discovery limits', () => {
+  it('rejects root and candidate counts beyond their fixed budgets', () => {
+    expect(
+      () =>
+        new SkillDiscoveryBudget(
+          Array.from({ length: MAX_SKILL_DISCOVERY_ROOTS + 1 }, (_, index) => root(index))
+        )
+    ).toThrow(/too many roots/)
+
+    const budget = new SkillDiscoveryBudget([root(0)])
+    for (let index = 0; index < MAX_SKILL_DISCOVERY_CANDIDATES; index += 1) {
+      budget.admitCandidate()
+    }
+    expect(() => budget.admitCandidate()).toThrow(/too many skills/)
+  })
+
+  it('rejects retained result text and WSL output beyond their byte budgets', () => {
+    const budget = new SkillDiscoveryBudget([root(0)])
+    expect(() =>
+      budget.retainSkill(skill('x'.repeat(Math.floor(MAX_SKILL_DISCOVERY_RESULT_BYTES / 2))))
+    ).toThrow(/result is too large/)
+
+    expect(() =>
+      assertSkillDiscoveryOutputWithinLimit('x'.repeat(WSL_SKILL_DISCOVERY_MAX_OUTPUT_BYTES + 1))
+    ).toThrow(/output is too large/)
+  })
+})

--- a/src/main/skills/skill-discovery-limits.ts
+++ b/src/main/skills/skill-discovery-limits.ts
@@ -1,0 +1,119 @@
+import type { DiscoveredSkill } from '../../shared/skills'
+import type { SkillScanRoot } from './skill-discovery-sources'
+
+export const MAX_SKILL_DISCOVERY_ROOTS = 512
+export const MAX_SKILL_DISCOVERY_CANDIDATES = 1_024
+export const MAX_SKILL_DISCOVERY_TRAVERSED_DIRECTORIES = 20_000
+export const MAX_SKILL_DISCOVERY_TRAVERSED_ENTRIES = 100_000
+export const MAX_SKILL_DISCOVERY_RESULT_BYTES = 4 * 1024 * 1024
+export const MAX_CONCURRENT_SKILL_DISCOVERY_ROOTS = 4
+export const MAX_CONCURRENT_SKILL_DISCOVERY_CANDIDATES = 4
+export const MAX_SKILL_PACKAGE_DIRECTORIES = 512
+export const MAX_SKILL_PACKAGE_ENTRIES = 10_000
+export const WSL_SKILL_DISCOVERY_MAX_OUTPUT_BYTES = 8 * 1024 * 1024
+
+export class SkillDiscoveryLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SkillDiscoveryLimitError'
+  }
+}
+
+export function assertSkillDiscoveryRootsWithinLimit(roots: readonly SkillScanRoot[]): void {
+  if (roots.length > MAX_SKILL_DISCOVERY_ROOTS) {
+    throw new SkillDiscoveryLimitError(
+      `Installed-skill discovery has too many roots (${roots.length}; max ${MAX_SKILL_DISCOVERY_ROOTS}).`
+    )
+  }
+}
+
+function stringBytes(value: string | null | undefined): number {
+  return (value?.length ?? 0) * 2
+}
+
+export function estimateDiscoveredSkillBytes(skill: DiscoveredSkill): number {
+  return (
+    256 +
+    stringBytes(skill.id) +
+    stringBytes(skill.name) +
+    stringBytes(skill.description) +
+    stringBytes(skill.sourceLabel) +
+    stringBytes(skill.rootPath) +
+    stringBytes(skill.directoryPath) +
+    stringBytes(skill.skillFilePath) +
+    skill.providers.reduce((bytes, provider) => bytes + stringBytes(provider), 0) +
+    (skill.rootPaths ?? []).reduce((bytes, rootPath) => bytes + stringBytes(rootPath), 0)
+  )
+}
+
+function estimateSkillSourceBytes(source: SkillScanRoot): number {
+  return (
+    192 +
+    stringBytes(source.id) +
+    stringBytes(source.label) +
+    stringBytes(source.path) +
+    source.providers.reduce((bytes, provider) => bytes + stringBytes(provider), 0)
+  )
+}
+
+export class SkillDiscoveryBudget {
+  private candidates = 0
+  private directories = 0
+  private entries = 0
+  private retainedBytes = 0
+
+  constructor(roots: readonly SkillScanRoot[]) {
+    assertSkillDiscoveryRootsWithinLimit(roots)
+    for (const root of roots) {
+      this.retainBytes(estimateSkillSourceBytes(root))
+    }
+  }
+
+  visitDirectory(): void {
+    this.directories += 1
+    if (this.directories > MAX_SKILL_DISCOVERY_TRAVERSED_DIRECTORIES) {
+      throw new SkillDiscoveryLimitError(
+        `Installed-skill discovery visited too many directories (max ${MAX_SKILL_DISCOVERY_TRAVERSED_DIRECTORIES}).`
+      )
+    }
+  }
+
+  visitEntry(): void {
+    this.entries += 1
+    if (this.entries > MAX_SKILL_DISCOVERY_TRAVERSED_ENTRIES) {
+      throw new SkillDiscoveryLimitError(
+        `Installed-skill discovery visited too many entries (max ${MAX_SKILL_DISCOVERY_TRAVERSED_ENTRIES}).`
+      )
+    }
+  }
+
+  admitCandidate(): void {
+    this.candidates += 1
+    if (this.candidates > MAX_SKILL_DISCOVERY_CANDIDATES) {
+      throw new SkillDiscoveryLimitError(
+        `Installed-skill discovery found too many skills (max ${MAX_SKILL_DISCOVERY_CANDIDATES}).`
+      )
+    }
+  }
+
+  retainSkill(skill: DiscoveredSkill): void {
+    this.retainBytes(estimateDiscoveredSkillBytes(skill))
+  }
+
+  private retainBytes(bytes: number): void {
+    this.retainedBytes += bytes
+    if (this.retainedBytes > MAX_SKILL_DISCOVERY_RESULT_BYTES) {
+      throw new SkillDiscoveryLimitError(
+        `Installed-skill discovery result is too large (max ${MAX_SKILL_DISCOVERY_RESULT_BYTES} bytes).`
+      )
+    }
+  }
+}
+
+export function assertSkillDiscoveryOutputWithinLimit(output: string): void {
+  if (Buffer.byteLength(output, 'utf8') > WSL_SKILL_DISCOVERY_MAX_OUTPUT_BYTES) {
+    throw new SkillDiscoveryLimitError(
+      `WSL installed-skill discovery output is too large (max ${WSL_SKILL_DISCOVERY_MAX_OUTPUT_BYTES} bytes).`
+    )
+  }
+}

--- a/src/main/skills/skill-discovery-wsl.test.ts
+++ b/src/main/skills/skill-discovery-wsl.test.ts
@@ -85,12 +85,29 @@ describe('WSL skill discovery', () => {
     expect(script).toContain('find -L "$root_path"')
     expect(script).toContain('realpath -- "$skill_file"')
     expect(script).toContain('head -c 262144 -- "$skill_file"')
+    expect(script).toContain('skill_count=$((skill_count + 1))')
+    expect(script).toContain("printf '%s\\0%s\\0' E skill-limit")
     expect(script).toContain(`'/work/alice'\\''s project/.agents/skills'`)
+  })
+
+  it('rejects an explicit distro-side candidate-limit marker', () => {
+    expect(() => parseWslSkillDiscoveryOutput(record('E', 'skill-limit'), [homeRoot])).toThrow(
+      /too many skills/
+    )
   })
 
   it('rejects malformed host responses instead of reporting an empty scan', () => {
     expect(() => parseWslSkillDiscoveryOutput(record('S', '9'), [homeRoot])).toThrow(
       'unknown source'
     )
+  })
+
+  it('parses delimiter-heavy output without materializing a field array', () => {
+    const result = parseWslSkillDiscoveryOutput('\0'.repeat(1_000_000), [homeRoot], 42)
+
+    expect(result.skills).toEqual([])
+    expect(result.sources).toEqual([
+      expect.objectContaining({ id: 'home-codex', exists: false, skippedReason: 'missing' })
+    ])
   })
 })

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -16,16 +16,29 @@ import {
   type SkillScanRoot
 } from './skill-discovery-sources'
 import { discoverClaudePluginSkillSourcesInWsl } from './claude-plugin-skill-sources-wsl'
+import {
+  MAX_SKILL_DISCOVERY_CANDIDATES,
+  SkillDiscoveryBudget,
+  SkillDiscoveryLimitError,
+  WSL_SKILL_DISCOVERY_MAX_OUTPUT_BYTES,
+  assertSkillDiscoveryOutputWithinLimit,
+  assertSkillDiscoveryRootsWithinLimit
+} from './skill-discovery-limits'
+import {
+  readWslSkillProtocolField,
+  type WslSkillProtocolFieldCursor
+} from './wsl-skill-protocol-fields'
 
 const MAX_MARKDOWN_BYTES = 256 * 1024
 const MAX_PACKAGE_FILES = 200
 const WSL_SCAN_TIMEOUT_MS = 10_000
-const WSL_SCAN_MAX_BUFFER_BYTES = 128 * 1024 * 1024
 
 export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): string {
+  assertSkillDiscoveryRootsWithinLimit(roots)
   const lines = [
     'set -u',
     'set -o pipefail',
+    'skill_count=0',
     'scan_root() {',
     '  root_index=$1',
     '  root_path=$2',
@@ -40,6 +53,11 @@ export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): 
     `    directory_path=\${skill_file%/*}`,
     `    updated_at=$(stat -c '%Y' -- "$skill_file" 2>/dev/null || true)`,
     `    encoded_markdown=$(head -c ${MAX_MARKDOWN_BYTES} -- "$skill_file" 2>/dev/null | base64 | tr -d '\\n') || continue`,
+    '    skill_count=$((skill_count + 1))',
+    `    if [ "$skill_count" -gt ${MAX_SKILL_DISCOVERY_CANDIDATES} ]; then`,
+    `      printf '%s\\0%s\\0' E skill-limit`,
+    '      exit 0',
+    '    fi',
     '    file_count=0',
     `    while IFS= read -r -d '' package_file; do`,
     '      file_count=$((file_count + 1))',
@@ -65,7 +83,7 @@ function executeWslSkillDiscovery(distro: string, command: string): Promise<stri
       ['-d', distro, '--', 'bash', '-c', command],
       {
         encoding: 'utf8',
-        maxBuffer: WSL_SCAN_MAX_BUFFER_BYTES,
+        maxBuffer: WSL_SKILL_DISCOVERY_MAX_OUTPUT_BYTES,
         timeout: WSL_SCAN_TIMEOUT_MS,
         windowsHide: true
       },
@@ -80,12 +98,12 @@ function executeWslSkillDiscovery(distro: string, command: string): Promise<stri
   })
 }
 
-function readProtocolField(fields: string[], index: number): string {
-  const value = fields[index]
-  if (value === undefined) {
-    throw new Error('WSL skill discovery returned an incomplete response.')
-  }
-  return value
+function readProtocolField(output: string, cursor: WslSkillProtocolFieldCursor): string {
+  return readWslSkillProtocolField(
+    output,
+    cursor,
+    'WSL skill discovery returned an incomplete response.'
+  )
 }
 
 export function parseWslSkillDiscoveryOutput(
@@ -93,30 +111,44 @@ export function parseWslSkillDiscoveryOutput(
   roots: readonly SkillScanRoot[],
   scannedAt = Date.now()
 ): SkillDiscoveryResult {
-  const fields = output.split('\0')
+  assertSkillDiscoveryOutputWithinLimit(output)
+  const budget = new SkillDiscoveryBudget(roots)
   const rootExists = new Map<number, boolean>()
   const skillsByCanonicalPath = new Map<string, DiscoveredSkill>()
-  let index = 0
-  while (index < fields.length && fields[index]) {
-    const recordKind = fields[index++]
-    const rootIndex = Number.parseInt(readProtocolField(fields, index++), 10)
+  const cursor: WslSkillProtocolFieldCursor = { offset: 0 }
+  while (cursor.offset < output.length) {
+    // Why: cursor reads avoid turning delimiter-heavy bounded output into millions of string slots.
+    const recordKind = readProtocolField(output, cursor)
+    if (!recordKind) {
+      break
+    }
+    if (recordKind === 'E') {
+      const reason = readProtocolField(output, cursor)
+      throw new SkillDiscoveryLimitError(
+        reason === 'skill-limit'
+          ? `WSL installed-skill discovery found too many skills (max ${MAX_SKILL_DISCOVERY_CANDIDATES}).`
+          : 'WSL installed-skill discovery exceeded a safety limit.'
+      )
+    }
+    const rootIndex = Number.parseInt(readProtocolField(output, cursor), 10)
     const root = roots[rootIndex]
     if (!root) {
       throw new Error('WSL skill discovery returned an unknown source.')
     }
     if (recordKind === 'R') {
-      rootExists.set(rootIndex, readProtocolField(fields, index++) === '1')
+      rootExists.set(rootIndex, readProtocolField(output, cursor) === '1')
       continue
     }
     if (recordKind !== 'S') {
       throw new Error('WSL skill discovery returned an invalid response.')
     }
+    budget.admitCandidate()
 
-    const skillFilePath = readProtocolField(fields, index++)
-    const canonicalSkillFilePath = readProtocolField(fields, index++)
-    const updatedAtSeconds = Number.parseInt(readProtocolField(fields, index++), 10)
-    const fileCount = Number.parseInt(readProtocolField(fields, index++), 10)
-    const markdown = Buffer.from(readProtocolField(fields, index++), 'base64').toString('utf8')
+    const skillFilePath = readProtocolField(output, cursor)
+    const canonicalSkillFilePath = readProtocolField(output, cursor)
+    const updatedAtSeconds = Number.parseInt(readProtocolField(output, cursor), 10)
+    const fileCount = Number.parseInt(readProtocolField(output, cursor), 10)
+    const markdown = Buffer.from(readProtocolField(output, cursor), 'base64').toString('utf8')
     const existing = skillsByCanonicalPath.get(canonicalSkillFilePath)
     if (existing) {
       // Why: dedup keeps one row, but every contributing root must survive so
@@ -139,7 +171,7 @@ export function parseWslSkillDiscoveryOutput(
     const directoryPath = pathPosix.dirname(skillFilePath)
     const summary = summarizeSkillMarkdown(markdown)
     const sourceKind = sourceKindForSkill(root, skillFilePath, pathPosix)
-    skillsByCanonicalPath.set(canonicalSkillFilePath, {
+    const skill: DiscoveredSkill = {
       id: stablePathId(canonicalSkillFilePath),
       name: summary.name ?? pathPosix.basename(directoryPath),
       description: summary.description,
@@ -155,7 +187,9 @@ export function parseWslSkillDiscoveryOutput(
       installed: true,
       fileCount: Number.isFinite(fileCount) ? fileCount : 0,
       updatedAt: Number.isFinite(updatedAtSeconds) ? updatedAtSeconds * 1000 : null
-    })
+    }
+    budget.retainSkill(skill)
+    skillsByCanonicalPath.set(canonicalSkillFilePath, skill)
   }
 
   const sources: SkillDiscoverySource[] = roots.map((root, rootIndex) => {

--- a/src/main/skills/wsl-skill-protocol-fields.ts
+++ b/src/main/skills/wsl-skill-protocol-fields.ts
@@ -1,0 +1,20 @@
+export type WslSkillProtocolFieldCursor = { offset: number }
+
+export function readWslSkillProtocolField(
+  output: string,
+  cursor: WslSkillProtocolFieldCursor,
+  incompleteMessage: string
+): string {
+  if (cursor.offset >= output.length) {
+    throw new Error(incompleteMessage)
+  }
+  const end = output.indexOf('\0', cursor.offset)
+  if (end === -1) {
+    const value = output.slice(cursor.offset)
+    cursor.offset = output.length
+    return value
+  }
+  const value = output.slice(cursor.offset, end)
+  cursor.offset = end + 1
+  return value
+}


### PR DESCRIPTION
## OOM hardening slice 18/29 — bound agent hooks & automations state

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **18/29** (base: `oom/17-b-native-chat-speech`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Slice #18 re-introduces OOM ceilings across agent-hooks, automations, and skills: bounded file reads (config/script/plugin/bundle/status), streaming directory/lock cleanup, retained-metadata byte caps on the agent-hook status server, bounded skill-discovery traversal, and concurrency caps on remote fan-outs. Almost all changes are overload-only fail-closed guards; a few introduce user-visible ceilings (skill discovery now throws on overload; Hermes run pages clamp to 100; WSL skill-scan buffer shrinks 128MiB→8MiB).

### ELI5
Imagine the app used to read whole files and folders no matter how huge, and kept lists that could grow forever until it ran out of memory and crashed. This change adds size limits everywhere: "don't read a file bigger than X", "don't keep more than N items", "don't do more than 4 of these at once". If something is absurdly big it's skipped or an error is shown instead of crashing. For normal users nothing changes; only people with truly gigantic files or thousands of items hit the new walls.

### Proof of OOM fix
- agent-hook-file-limits.ts: config 64MiB / 1M structural tokens / depth 128, plugin 1MiB, managed script 1MiB — tests: agent-hook-file-bounds.test.ts, hooks-file-bounds.test.ts
- server.ts: last-status file 16MiB + 1M structural tokens + depth 128; connection watermarks cap 1024; retained id ≤1024B, path ≤16KiB; serializeStatusFile drops oldest entries to stay under 16MiB — tests: server.test.ts, server-status-cache-bound.test.ts, server-retained-metadata-bounds.test.ts
- managed-hook-lock-records.ts: opendir bufferSize 32, cleanup concurrency 8, lock record ≤2MiB (streams dir instead of readdir array) — test: managed-hook-lock-cleanup-bounds.test.ts
- managed-hook-owner-identity.ts: host-token file ≤1024B — test: managed-hook-owner-identity.test.ts
- migration-unsupported-pty-state.ts: MAX_ENTRIES 500, per-entry ≤16KiB (FIFO evict) — test: migration-unsupported-pty-state.test.ts
- branch-rename-failure-output.ts: key ≤4KiB, output ≤520KiB, MAX_ENTRIES 32 — test: branch-rename-failure-output.test.ts
- first-work-branch-rename.ts: in-flight cap 32, settled cache 500 (keys sha256-hashed) — test: first-work-branch-rename.test.ts
- dispatch-tokens.ts: MAX_ENTRIES 1024 with oldest-unused eviction + TTL prune — test: dispatch-tokens.test.ts
- hermes-cron-output.ts: page ≤100 runs, run-refs ≤10000 (totalSaturated), primary output 5MiB, referenced-log bounded, SQLite iterate+substr caps — test: hermes-cron-output.test.ts
- external-manager.ts: run-count concurrency 4, remote-manager fan-out concurrency 4 — test: external-manager-remote-fanout.test.ts
- skill-discovery-limits.ts: roots 512, candidates 1024, dirs 20000, entries 100000, result 4MiB, WSL output 8MiB, per-package dirs 512/entries 10000 — tests: skill-discovery-limits.test.ts, discovery.test.ts, skill-discovery-wsl.test.ts
- skill-bundle-artifacts.ts: manifest 2MiB, registry 16MiB, release-mapping 2MiB + 1M structural tokens/depth 128 — test: skill-bundle-artifacts.test.ts
- wsl-hook-relay-launch.ts: version file 4KiB, bundle 8MiB — test: wsl-hook-relay-file-bounds.test.ts
- wsl-hook-relay-sentinel.ts: pending bytes (MAX_MESSAGE_SIZE+HEADER)*2 and MAX_BUFFERED_FRAME_CHUNKS before kill — test: wsl-hook-relay-sentinel.test.ts
- agent-trust-presets.ts / remote-agent-trust-presets.ts: git-pointer ≤64KiB, agent-state config ≤4MiB (MAX_AGENT_STATE_FILE_BYTES) — tests: agent-trust-presets.test.ts, remote-agent-trust-presets.test.ts
- agent-hook-sftp-text-reader.ts / installer-utils-remote.ts: SFTP reads stream-bounded to maxBytes with 10s timeout; mkdirp probes via stat instead of readdir — test: installer-utils-remote.test.ts

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **low**: Under 1024 concurrent in-flight automation dispatch tokens, createAutomationDispatchToken returns an untracked token (eviction can't reclaim in-flight entries), so that dispatch's begin/finish reservation no-ops. _(trigger: Only at 1024 simultaneously in-flight automation dispatches — practically unreachable.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Skill discovery throws SkillDiscoveryLimitError (rejecting the whole scan) only past 512 roots / 1024 skills / 100k entries / 20k dirs / 4MiB retained result — far above any real install.
- Agent-hook status server drops retained metadata fields (launchToken/toolUseId/worktreeId/transcriptPath) or rejects an event only when a single id >1KiB or path >16KiB, and drops oldest persisted rows only past a 16MiB last-status file.
- Hermes run-count badge saturates at 10000 (reports totalSaturated) only for jobs with >10k runs.
- Managed-hook lock cleanup skips an oversized (>2MiB) lock record and streams the directory in 8-wide batches only when the lock dir is pathologically large.
- migration-unsupported-pty and dispatch-token maps FIFO-evict only past 500 / 1024 live entries; oversized (>16KiB) PTY entries are rejected.
- WSL relay sentinel kills the child only if post-sentinel data floods before the transport attaches (chunk count / byte cap exceeded).
- Codex/Copilot trust presets skip rewriting a config only when it exceeds the 4MiB read ceiling, or fall back to workspace root when a .git pointer exceeds 64KiB.
- discoverSkills() now REJECTS (throws SkillDiscoveryLimitError) instead of returning a partial list when traversal/result budgets are exceeded, so an extreme skills tree fails the entire picker rather than degrading. Fail-closed and intentional, but a hard failure a human should acknowledge. _(only when: >512 roots, >1024 SKILL.md candidates, >100k dir entries, >20k directories, or >4MiB of retained skill metadata; not reachable in ordinary installs.)_
- WSL skill-discovery subprocess maxBuffer dropped from 128MiB to 8MiB; a large WSL skill collection whose base64 output lands between 8–128MiB now fails the scan (ENOBUFS) where it previously succeeded. _(only when: Many/large SKILL.md files under WSL producing >8MiB of encoded scan output.)_
- Hermes run pages are clamped to 100 runs per page (safePageSize=min(100,...)); a caller requesting a larger page silently receives at most 100 rows, and the run count badge saturates at 10000. _(only when: A UI/API path requesting >100 Hermes runs per page or a job with >10k runs.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.

### Adversarial review
- 2 skeptic lens(es). Sign-off: **yes**. Residual risk: **low**.
- Adversarial regression pass on slice #18 (agent-hooks/automations/skills). Verified the prior reviewer's claims against actual numeric ceilings via git show/diff (working tree is at BASE aab112933e; all TARGET analysis done from the diff, which is authoritative).

REFUTED the one claim that looked like a user-visible regression: Hermes run pages clamping to 100 (safePageSize=min(HERMES_RUN_PAGE_MAX_RUNS=100,...) at hermes-cron-output.ts:687). The caller external-manager.ts:330 ALREADY clamps pageSize to Math.min(100, ...) in BASE (pre-existing), so the internal cap is pure defense-in-depth and no UI/API path ever requested >100. Not a regression.

Confirmed all other ceilings are far above ordinary use:
- Skill discovery (skill-discovery-limits.ts): 512 roots / 1024 skills / 20k dirs / 100k entries / 4MiB retained. discoverSkills() propagates SkillDiscoveryLimitError (does NOT catch/degrade — confirmed in discovery.ts:270-286 mapWithConcurrency), so an extreme skills tree rejects the whole picker. Ordinary installs have <50 skills; unreachable normally.
- Agent-hook config read cap 64MiB (comment sized for the supported 30,000-hook cleanup); plugin/script caps 1MiB.
- Status server retained-metadata: id 1KiB / path 16KiB / last-status file 16MiB — normal panes have tiny payloads.
- Closed-tab/pane-alias dedup maps FIFO-evict at 1024.

serializeStatusFile manual serializer (server.ts:2106) is the highest-risk change: builds JSON by hand, iterates entries in reverse to keep newest within the 16MiB budget, then fragments.reverse() to restore order. Separator/prefix byte accounting is consistent with the final ','-join; keys re-quoted via JSON.stringify; values via stringifyJsonWithinByteLimit. Covered by server-status-cache-bound.test.ts. No ordering/correctness defect found; 16MiB is unreachable in normal use (handful of small entries). Byte estimator uses length*2 (over-counts UTF-8 for ASCII) so the 4MiB skill budget trips conservatively early — still far above normal.

dispatch-tokens identityDigest(sha256) rewrite is functionally equivalent for match/reserve/release/clear. first-work-branch-rename sha256 dedupe with in-flight cap 32 correctly retries dropped attempts (no worktree poisoning). No normal-path regression and no correctness bug confirmed. Safe to open as a draft PR for human review; the two low items are behavior-change acknowledgements, not bugs.

### Files
60 files changed (+3225 / −472).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
