### PR TITLE
oom(19/29): bound integration pagination & fan-out (GitHub/GitLab/Linear)

### DIFF
--- a/src/main/azure-devops/azure-devops-api-request.ts
+++ b/src/main/azure-devops/azure-devops-api-request.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'node:buffer'
 import type { AzureDevOpsRepoRef } from './repository-ref'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 const REQUEST_TIMEOUT_MS = 5000
 
@@ -95,7 +96,7 @@ export async function requestAzureDevOpsJsonAtBase<T>(
       }
       return null
     }
-    return (await response.json()) as T
+    return await readFetchResponseJsonWithinLimit<T>(response)
   } catch (error) {
     if (throwOnFailure) {
       throw error

--- a/src/main/azure-devops/repository-ref.ts
+++ b/src/main/azure-devops/repository-ref.ts
@@ -1,5 +1,9 @@
 import { gitExecFileAsync } from '../git/runner'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import {
+  buildRepositoryRefCacheKey,
+  RepositoryRefCache
+} from '../source-control/repository-ref-cache'
 
 export type AzureDevOpsRepoRef = {
   host: string
@@ -14,8 +18,7 @@ type LocalGitExecOptions = {
   wslDistro?: string
 }
 
-const REPO_REF_CACHE_MAX_ENTRIES = 512
-const repoRefCache = new Map<string, AzureDevOpsRepoRef | null>()
+const repoRefCache = new RepositoryRefCache<AzureDevOpsRepoRef>()
 
 /** @internal - exposed for tests only */
 export function _resetAzureDevOpsRepoRefCache(): void {
@@ -25,17 +28,6 @@ export function _resetAzureDevOpsRepoRefCache(): void {
 /** @internal - exposed for tests only */
 export function _getAzureDevOpsRepoRefCacheSize(): number {
   return repoRefCache.size
-}
-
-function rememberRepoRefCacheEntry(cacheKey: string, value: AzureDevOpsRepoRef | null): void {
-  repoRefCache.set(cacheKey, value)
-  while (repoRefCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
-    const oldestKey = repoRefCache.keys().next().value
-    if (oldestKey === undefined) {
-      return
-    }
-    repoRefCache.delete(oldestKey)
-  }
 }
 
 function decodeSegment(value: string): string {
@@ -212,9 +204,10 @@ export async function getAzureDevOpsRepoRefForRemote(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<AzureDevOpsRepoRef | null> {
   const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
-  const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}`
-  if (repoRefCache.has(cacheKey)) {
-    return repoRefCache.get(cacheKey)!
+  const cacheKey = buildRepositoryRefCacheKey([runtimeKey, repoPath, remoteName])
+  const cached = repoRefCache.get(cacheKey)
+  if (cached.found) {
+    return cached.value
   }
   try {
     const sshGitProvider = connectionId ? getSshGitProvider(connectionId) : null
@@ -228,7 +221,20 @@ export async function getAzureDevOpsRepoRefForRemote(
           ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
         })
     const result = parseAzureDevOpsRepoRef(stdout)
-    rememberRepoRefCacheEntry(cacheKey, result)
+    repoRefCache.remember(
+      cacheKey,
+      result,
+      result
+        ? [
+            result.host,
+            result.project,
+            result.repository,
+            result.apiBaseUrl,
+            result.webBaseUrl,
+            result.organization ?? ''
+          ]
+        : []
+    )
     return result
   } catch {
     if (connectionId) {
@@ -236,7 +242,7 @@ export async function getAzureDevOpsRepoRefForRemote(
       // caching them as "not Azure DevOps" would poison the repo for the session.
       return null
     }
-    rememberRepoRefCacheEntry(cacheKey, null)
+    repoRefCache.remember(cacheKey, null, [])
     return null
   }
 }

--- a/src/main/bitbucket/client.ts
+++ b/src/main/bitbucket/client.ts
@@ -15,6 +15,7 @@ import {
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 const DEFAULT_API_BASE_URL = 'https://api.bitbucket.org/2.0'
 const REQUEST_TIMEOUT_MS = 5000
@@ -113,7 +114,7 @@ async function requestJson<T>(
       }
       return null
     }
-    return (await response.json()) as T
+    return await readFetchResponseJsonWithinLimit<T>(response)
   } catch (error) {
     if (throwOnFailure) {
       throw error

--- a/src/main/bitbucket/repository-ref.ts
+++ b/src/main/bitbucket/repository-ref.ts
@@ -1,5 +1,9 @@
 import { gitExecFileAsync } from '../git/runner'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import {
+  buildRepositoryRefCacheKey,
+  RepositoryRefCache
+} from '../source-control/repository-ref-cache'
 
 export type BitbucketRepoRef = {
   workspace: string
@@ -10,8 +14,7 @@ type LocalGitExecOptions = {
   wslDistro?: string
 }
 
-const REPO_REF_CACHE_MAX_ENTRIES = 512
-const repoRefCache = new Map<string, BitbucketRepoRef | null>()
+const repoRefCache = new RepositoryRefCache<BitbucketRepoRef>()
 
 /** @internal - exposed for tests only */
 export function _resetBitbucketRepoRefCache(): void {
@@ -21,17 +24,6 @@ export function _resetBitbucketRepoRefCache(): void {
 /** @internal - exposed for tests only */
 export function _getBitbucketRepoRefCacheSize(): number {
   return repoRefCache.size
-}
-
-function rememberRepoRefCacheEntry(cacheKey: string, value: BitbucketRepoRef | null): void {
-  repoRefCache.set(cacheKey, value)
-  while (repoRefCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
-    const oldestKey = repoRefCache.keys().next().value
-    if (oldestKey === undefined) {
-      return
-    }
-    repoRefCache.delete(oldestKey)
-  }
 }
 
 function decodeSegment(value: string): string {
@@ -87,9 +79,10 @@ export async function getBitbucketRepoRefForRemote(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<BitbucketRepoRef | null> {
   const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
-  const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}`
-  if (repoRefCache.has(cacheKey)) {
-    return repoRefCache.get(cacheKey)!
+  const cacheKey = buildRepositoryRefCacheKey([runtimeKey, repoPath, remoteName])
+  const cached = repoRefCache.get(cacheKey)
+  if (cached.found) {
+    return cached.value
   }
   try {
     const sshGitProvider = connectionId ? getSshGitProvider(connectionId) : null
@@ -103,7 +96,7 @@ export async function getBitbucketRepoRefForRemote(
           ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
         })
     const result = parseBitbucketRepoRef(stdout)
-    rememberRepoRefCacheEntry(cacheKey, result)
+    repoRefCache.remember(cacheKey, result, result ? [result.workspace, result.repoSlug] : [])
     return result
   } catch {
     if (connectionId) {
@@ -111,7 +104,7 @@ export async function getBitbucketRepoRefForRemote(
       // caching them as "not Bitbucket" would poison the repo for the session.
       return null
     }
-    rememberRepoRefCacheEntry(cacheKey, null)
+    repoRefCache.remember(cacheKey, null, [])
     return null
   }
 }

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -17,7 +17,11 @@ import {
 } from './client'
 import { _resetGiteaRepoRefCache } from './repository-ref'
 import {
+  GITEA_SCAN_CACHE_ENTRY_MAX_BYTES,
+  GITEA_SCAN_MAX_IN_FLIGHT,
+  GITEA_SCAN_REPO_KEY_MAX_BYTES,
   _getGiteaPullRequestScanCacheSize,
+  _getGiteaPullRequestScanState,
   _resetGiteaPullRequestScanCache,
   scanGiteaPullRequests
 } from './pull-request-scan-cache'
@@ -297,6 +301,62 @@ describe('Gitea client', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('skips retained state for oversized scan keys and payloads', async () => {
+    const exactKey = 'k'.repeat(GITEA_SCAN_REPO_KEY_MAX_BYTES)
+    const oversizedKey = `${exactKey}x`
+    await scanGiteaPullRequests(exactKey, async () => [], 50, 5)
+    await scanGiteaPullRequests(oversizedKey, async () => [], 50, 5)
+    const oversizedListing = [giteaPr(1, 'x'.repeat(GITEA_SCAN_CACHE_ENTRY_MAX_BYTES))]
+    await expect(
+      scanGiteaPullRequests('oversized-payload', async () => oversizedListing, 50, 5)
+    ).resolves.toEqual(oversizedListing)
+
+    expect(_getGiteaPullRequestScanCacheSize()).toBe(1)
+  })
+
+  it('caps distinct in-flight scans and recovers tracked capacity', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const scans = Array.from({ length: GITEA_SCAN_MAX_IN_FLIGHT }, (_, index) =>
+      scanGiteaPullRequests(
+        `in-flight-${index}`,
+        async () => {
+          await gate
+          return []
+        },
+        50,
+        5
+      )
+    )
+    let overflowCalls = 0
+    await scanGiteaPullRequests(
+      'overflow',
+      async () => {
+        overflowCalls += 1
+        return []
+      },
+      50,
+      5
+    )
+    await scanGiteaPullRequests(
+      'overflow',
+      async () => {
+        overflowCalls += 1
+        return []
+      },
+      50,
+      5
+    )
+
+    expect(_getGiteaPullRequestScanState().inFlight).toBe(GITEA_SCAN_MAX_IN_FLIGHT)
+    expect(overflowCalls).toBe(2)
+    release()
+    await Promise.all(scans)
+    expect(_getGiteaPullRequestScanState().inFlight).toBe(0)
   })
 
   it('does not let an in-flight scan re-cache results from before an invalidation', async () => {

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -14,6 +14,7 @@ import {
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
 import { cancelUnreadResponseBody } from '../lib/unread-response-body'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
 
 const REQUEST_TIMEOUT_MS = 5000
 // Why: self-hosted Forgejo can take ~5s to serve one /pulls page (it loads
@@ -102,7 +103,7 @@ async function requestJsonAtBase<T>(
       }
       return null
     }
-    return (await response.json()) as T
+    return await readFetchResponseJsonWithinLimit<T>(response)
   } catch (error) {
     if (throwOnFailure) {
       throw error

--- a/src/main/gitea/pull-request-scan-cache.ts
+++ b/src/main/gitea/pull-request-scan-cache.ts
@@ -1,4 +1,5 @@
 import type { RawGiteaPullRequest } from './pull-request-mappers'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 export type GiteaPullRequestPageFetcher = (page: number) => Promise<RawGiteaPullRequest[] | null>
 
@@ -16,7 +17,11 @@ const SCAN_TTL_MS = 30_000
 const FAILED_SCAN_RETRY_MS = 3_000
 // Why: each entry can retain hundreds of full PR payloads, so TTL alone is not
 // enough protection when many repositories are opened during one app session.
-const MAX_SCAN_CACHE_ENTRIES = 32
+export const GITEA_SCAN_CACHE_MAX_ENTRIES = 32
+export const GITEA_SCAN_MAX_IN_FLIGHT = 32
+export const GITEA_SCAN_REPO_KEY_MAX_BYTES = 4 * 1024
+export const GITEA_SCAN_CACHE_ENTRY_MAX_PULL_REQUESTS = 250
+export const GITEA_SCAN_CACHE_ENTRY_MAX_BYTES = 512 * 1024
 
 const scanCache = new Map<string, GiteaPullRequestScanEntry>()
 const inFlightScans = new Map<string, Promise<RawGiteaPullRequest[]>>()
@@ -41,6 +46,9 @@ function rememberScanCacheEntry(
   ttlMs: number
 ): void {
   removeScanCacheEntry(repoKey)
+  if (!isRetainablePullRequestListing(pullRequests)) {
+    return
+  }
   let entry!: GiteaPullRequestScanEntry
   const expirationTimer = setTimeout(() => removeScanCacheEntry(repoKey, entry), ttlMs)
   expirationTimer.unref()
@@ -50,13 +58,72 @@ function rememberScanCacheEntry(
     pullRequests
   }
   scanCache.set(repoKey, entry)
-  while (scanCache.size > MAX_SCAN_CACHE_ENTRIES) {
+  while (scanCache.size > GITEA_SCAN_CACHE_MAX_ENTRIES) {
     const oldestKey = scanCache.keys().next().value
     if (oldestKey === undefined) {
       break
     }
     removeScanCacheEntry(oldestKey)
   }
+}
+
+function isRetainableRepoKey(repoKey: string): boolean {
+  return !measureUtf8ByteLength(repoKey, {
+    stopAfterBytes: GITEA_SCAN_REPO_KEY_MAX_BYTES
+  }).exceededLimit
+}
+
+function isRetainablePullRequestListing(pullRequests: RawGiteaPullRequest[]): boolean {
+  if (pullRequests.length > GITEA_SCAN_CACHE_ENTRY_MAX_PULL_REQUESTS) {
+    return false
+  }
+  let remainingBytes = GITEA_SCAN_CACHE_ENTRY_MAX_BYTES - pullRequests.length * 128
+  if (remainingBytes < 0) {
+    return false
+  }
+  for (const pullRequest of pullRequests) {
+    const values = [
+      pullRequest.title,
+      pullRequest.state,
+      pullRequest.html_url,
+      pullRequest.updated_at,
+      pullRequest.head?.ref,
+      pullRequest.head?.label,
+      pullRequest.head?.sha
+    ]
+    for (const value of values) {
+      if (typeof value !== 'string') {
+        continue
+      }
+      const measured = measureUtf8ByteLength(value, { stopAfterBytes: remainingBytes })
+      if (measured.exceededLimit) {
+        return false
+      }
+      remainingBytes -= measured.byteLength
+    }
+  }
+  return true
+}
+
+async function collectPullRequests(
+  fetchPage: GiteaPullRequestPageFetcher,
+  pageLimit: number,
+  maxPages: number
+): Promise<{ completed: boolean; pullRequests: RawGiteaPullRequest[] }> {
+  const pullRequests: RawGiteaPullRequest[] = []
+  let completed = true
+  for (let page = 1; page <= maxPages; page++) {
+    const list = await fetchPage(page)
+    if (!list) {
+      completed = false
+      break
+    }
+    pullRequests.push(...list)
+    if (list.length < pageLimit) {
+      break
+    }
+  }
+  return { completed, pullRequests }
 }
 
 function reusableScanCacheEntry(repoKey: string): GiteaPullRequestScanEntry | null {
@@ -89,6 +156,9 @@ export async function scanGiteaPullRequests(
   pageLimit: number,
   maxPages: number
 ): Promise<RawGiteaPullRequest[]> {
+  if (!isRetainableRepoKey(repoKey)) {
+    return (await collectPullRequests(fetchPage, pageLimit, maxPages)).pullRequests
+  }
   const cached = reusableScanCacheEntry(repoKey)
   if (cached) {
     return cached.pullRequests
@@ -97,22 +167,13 @@ export async function scanGiteaPullRequests(
   if (running) {
     return running
   }
+  if (inFlightScans.size >= GITEA_SCAN_MAX_IN_FLIGHT) {
+    return (await collectPullRequests(fetchPage, pageLimit, maxPages)).pullRequests
+  }
   const generation = scanGenerations.get(repoKey) ?? 0
   activeScanCounts.set(repoKey, (activeScanCounts.get(repoKey) ?? 0) + 1)
   const scan = (async () => {
-    const pullRequests: RawGiteaPullRequest[] = []
-    let completed = true
-    for (let page = 1; page <= maxPages; page++) {
-      const list = await fetchPage(page)
-      if (!list) {
-        completed = false
-        break
-      }
-      pullRequests.push(...list)
-      if (list.length < pageLimit) {
-        break
-      }
-    }
+    const { completed, pullRequests } = await collectPullRequests(fetchPage, pageLimit, maxPages)
     if ((scanGenerations.get(repoKey) ?? 0) === generation) {
       rememberScanCacheEntry(repoKey, pullRequests, completed ? SCAN_TTL_MS : FAILED_SCAN_RETRY_MS)
     }
@@ -158,4 +219,18 @@ export function _resetGiteaPullRequestScanCache(): void {
 
 export function _getGiteaPullRequestScanCacheSize(): number {
   return scanCache.size
+}
+
+export function _getGiteaPullRequestScanState(): {
+  cached: number
+  inFlight: number
+  active: number
+  generations: number
+} {
+  return {
+    cached: scanCache.size,
+    inFlight: inFlightScans.size,
+    active: activeScanCounts.size,
+    generations: scanGenerations.size
+  }
 }

--- a/src/main/gitea/repository-ref.ts
+++ b/src/main/gitea/repository-ref.ts
@@ -1,5 +1,9 @@
 import { gitExecFileAsync } from '../git/runner'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+import {
+  buildRepositoryRefCacheKey,
+  RepositoryRefCache
+} from '../source-control/repository-ref-cache'
 
 export type GiteaRepoRef = {
   host: string
@@ -20,8 +24,7 @@ const KNOWN_NON_GITEA_HOSTS = new Set([
   'dev.azure.com',
   'ssh.dev.azure.com'
 ])
-const REPO_REF_CACHE_MAX_ENTRIES = 512
-const repoRefCache = new Map<string, GiteaRepoRef | null>()
+const repoRefCache = new RepositoryRefCache<GiteaRepoRef>()
 
 /** @internal - exposed for tests only */
 export function _resetGiteaRepoRefCache(): void {
@@ -31,17 +34,6 @@ export function _resetGiteaRepoRefCache(): void {
 /** @internal - exposed for tests only */
 export function _getGiteaRepoRefCacheSize(): number {
   return repoRefCache.size
-}
-
-function rememberRepoRefCacheEntry(cacheKey: string, value: GiteaRepoRef | null): void {
-  repoRefCache.set(cacheKey, value)
-  while (repoRefCache.size > REPO_REF_CACHE_MAX_ENTRIES) {
-    const oldestKey = repoRefCache.keys().next().value
-    if (oldestKey === undefined) {
-      return
-    }
-    repoRefCache.delete(oldestKey)
-  }
 }
 
 function decodeSegment(value: string): string {
@@ -148,9 +140,10 @@ export async function getGiteaRepoRefForRemote(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<GiteaRepoRef | null> {
   const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
-  const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}`
-  if (repoRefCache.has(cacheKey)) {
-    return repoRefCache.get(cacheKey)!
+  const cacheKey = buildRepositoryRefCacheKey([runtimeKey, repoPath, remoteName])
+  const cached = repoRefCache.get(cacheKey)
+  if (cached.found) {
+    return cached.value
   }
   try {
     const sshGitProvider = connectionId ? getSshGitProvider(connectionId) : null
@@ -164,7 +157,11 @@ export async function getGiteaRepoRefForRemote(
           ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
         })
     const result = parseGiteaRepoRef(stdout)
-    rememberRepoRefCacheEntry(cacheKey, result)
+    repoRefCache.remember(
+      cacheKey,
+      result,
+      result ? [result.host, result.owner, result.repo, result.apiBaseUrl, result.webBaseUrl] : []
+    )
     return result
   } catch {
     if (connectionId) {
@@ -172,7 +169,7 @@ export async function getGiteaRepoRefForRemote(
       // caching them as "not Gitea" would poison the repo for the session.
       return null
     }
-    rememberRepoRefCacheEntry(cacheKey, null)
+    repoRefCache.remember(cacheKey, null, [])
     return null
   }
 }

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -34,7 +34,7 @@ import {
   GITHUB_WORK_ITEMS_SSH_REMOTE_REQUIRED_MESSAGE,
   sortWorkItemsByNumber
 } from '../../shared/work-items'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { sliceCheckLogTail } from './check-job-log-tail-slice'
@@ -43,8 +43,6 @@ import {
   safePRRefreshErrorMessage
 } from './pr-refresh-error-classification'
 import { getPRConflictSummary } from './conflict-summary'
-import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
-import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import { splitRemoteBranchName } from '../../shared/git-effective-upstream'
 import {
   execFileAsync,
@@ -74,6 +72,9 @@ import {
 } from '../source-control/hosted-review-git-options'
 import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
 import { readLocalGitConfigSignature } from './local-git-config-signature'
+import { readHostedReviewTemplate } from '../source-control/pull-request-template'
+import { cacheIdentityDigest } from '../cache-identity-digest'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 import {
   getGitHubApiRepositoryForRemote,
   getIssueGitHubApiRepository,
@@ -1773,41 +1774,6 @@ async function findOpenPRByHeadBase(args: {
   return { number: list[0].number, url: list[0].url }
 }
 
-async function readPullRequestTemplate(
-  repoPath: string,
-  connectionId?: string | null
-): Promise<string> {
-  const relativeCandidates = [
-    '.github/pull_request_template.md',
-    '.github/PULL_REQUEST_TEMPLATE.md',
-    'pull_request_template.md',
-    'PULL_REQUEST_TEMPLATE.md',
-    'docs/pull_request_template.md',
-    'docs/PULL_REQUEST_TEMPLATE.md'
-  ]
-  const remoteProvider = connectionId ? getSshFilesystemProvider(connectionId) : undefined
-  if (connectionId && !remoteProvider) {
-    return ''
-  }
-  for (const relativeCandidate of relativeCandidates) {
-    try {
-      if (remoteProvider) {
-        const result = await remoteProvider.readFile(
-          joinWorktreeRelativePath(repoPath, relativeCandidate)
-        )
-        if (result.isBinary) {
-          continue
-        }
-        return result.content
-      }
-      return await readFile(join(repoPath, relativeCandidate), 'utf8')
-    } catch {
-      // Try the next conventional PR template path.
-    }
-  }
-  return ''
-}
-
 export async function createGitHubPullRequest(
   repoPath: string,
   input: CreateHostedReviewInput,
@@ -1862,7 +1828,7 @@ export async function createGitHubPullRequest(
   try {
     const body =
       input.useTemplate && !input.body?.trim()
-        ? await readPullRequestTemplate(repoPath, connectionId)
+        ? await readHostedReviewTemplate(repoPath, connectionId, 'github')
         : (input.body ?? '')
     await writeFile(bodyPath, body, 'utf8')
     const createArgs = [
@@ -2216,7 +2182,7 @@ async function detectRepositoryMergeMetadata(
   branchName: string | undefined,
   ghOptions: GhExecOptions
 ): Promise<GitHubRepositoryMergeMetadata> {
-  const cacheKey = `${githubRepoIdentityKey(ownerRepo)}:${branchName ?? '__repo__'}`
+  const cacheKey = cacheIdentityDigest([githubRepoIdentityKey(ownerRepo), branchName ?? '__repo__'])
   pruneRepositoryMergeMetadataCache()
   const cached = repositoryMergeMetadataCache.get(cacheKey)
   if (cached) {
@@ -2390,11 +2356,16 @@ type TrackedUpstreamBranch = {
 
 const TRACKED_UPSTREAM_SNAPSHOT_CACHE_TTL_MS = 30_000
 const TRACKED_UPSTREAM_SNAPSHOT_CACHE_MAX_ENTRIES = 512
+export const TRACKED_UPSTREAM_SNAPSHOT_MAX_IN_FLIGHT = 32
+export const TRACKED_UPSTREAM_SNAPSHOT_MAX_BRANCHES = 4096
+export const TRACKED_UPSTREAM_SNAPSHOT_MAX_BYTES = 2 * 1024 * 1024
+export const TRACKED_UPSTREAM_SNAPSHOT_CACHE_MAX_BYTES = 32 * 1024 * 1024
 
 type TrackedUpstreamSnapshotCacheEntry = {
   expiresAt: number
   gitConfigSignature?: string
   upstreamsByBranchName: Map<string, TrackedUpstreamBranch | null>
+  retainedBytes: number
 }
 
 type TrackedUpstreamSnapshotProbeResult = {
@@ -2402,6 +2373,7 @@ type TrackedUpstreamSnapshotProbeResult = {
   gitConfigSignature?: string
   probeFailed: boolean
   upstreamsByBranchName: Map<string, TrackedUpstreamBranch | null>
+  retainedBytes: number
 }
 
 const trackedUpstreamSnapshotCache = new Map<string, TrackedUpstreamSnapshotCacheEntry>()
@@ -2410,6 +2382,16 @@ const trackedUpstreamSnapshotInFlight = new Map<
   Promise<TrackedUpstreamSnapshotProbeResult>
 >()
 const trackedUpstreamSnapshotGenerations = new Map<string, symbol>()
+let trackedUpstreamSnapshotCacheBytes = 0
+
+function deleteTrackedUpstreamSnapshot(cacheKey: string): void {
+  const cached = trackedUpstreamSnapshotCache.get(cacheKey)
+  if (!cached) {
+    return
+  }
+  trackedUpstreamSnapshotCacheBytes -= cached.retainedBytes
+  trackedUpstreamSnapshotCache.delete(cacheKey)
+}
 
 function beginTrackedUpstreamSnapshotProbe(cacheKey: string): symbol {
   const generation = Symbol()
@@ -2427,16 +2409,19 @@ function finishTrackedUpstreamSnapshotProbe(cacheKey: string, generation: symbol
 function pruneTrackedUpstreamSnapshotCache(now: number): void {
   for (const [cacheKey, cached] of trackedUpstreamSnapshotCache) {
     if (cached.expiresAt <= now) {
-      trackedUpstreamSnapshotCache.delete(cacheKey)
+      deleteTrackedUpstreamSnapshot(cacheKey)
     }
   }
   // Why: workspace/runtime churn can create unbounded unique keys within one TTL window, so expiry sweeping alone isn't a memory bound.
-  while (trackedUpstreamSnapshotCache.size > TRACKED_UPSTREAM_SNAPSHOT_CACHE_MAX_ENTRIES) {
+  while (
+    trackedUpstreamSnapshotCache.size > TRACKED_UPSTREAM_SNAPSHOT_CACHE_MAX_ENTRIES ||
+    trackedUpstreamSnapshotCacheBytes > TRACKED_UPSTREAM_SNAPSHOT_CACHE_MAX_BYTES
+  ) {
     const oldestKey = trackedUpstreamSnapshotCache.keys().next().value
     if (oldestKey === undefined) {
       break
     }
-    trackedUpstreamSnapshotCache.delete(oldestKey)
+    deleteTrackedUpstreamSnapshot(oldestKey)
   }
 }
 
@@ -2456,6 +2441,7 @@ export function __resetTrackedUpstreamBranchCacheForTests(): void {
   trackedUpstreamSnapshotCache.clear()
   trackedUpstreamSnapshotInFlight.clear()
   trackedUpstreamSnapshotGenerations.clear()
+  trackedUpstreamSnapshotCacheBytes = 0
 }
 
 function parseTrackedUpstreamBranch(upstreamRef: string): TrackedUpstreamBranch | null {
@@ -2463,7 +2449,10 @@ function parseTrackedUpstreamBranch(upstreamRef: string): TrackedUpstreamBranch 
   if (!parsed) {
     return null
   }
-  return parsed
+  return {
+    remoteName: parsed.remoteName.replace(/$/u, ''),
+    branchName: parsed.branchName.replace(/$/u, '')
+  }
 }
 
 function shouldRetryTrackedUpstreamBranch(
@@ -2504,10 +2493,10 @@ async function getTrackedUpstreamBranch(
     ) {
       return cached.upstreamsByBranchName.get(branchName) ?? null
     }
-    trackedUpstreamSnapshotCache.delete(cacheKey)
+    deleteTrackedUpstreamSnapshot(cacheKey)
   }
   if (cached) {
-    trackedUpstreamSnapshotCache.delete(cacheKey)
+    deleteTrackedUpstreamSnapshot(cacheKey)
   }
 
   const inFlight = trackedUpstreamSnapshotInFlight.get(cacheKey)
@@ -2524,18 +2513,31 @@ async function getTrackedUpstreamBranch(
     }
   }
 
+  if (trackedUpstreamSnapshotInFlight.size >= TRACKED_UPSTREAM_SNAPSHOT_MAX_IN_FLIGHT) {
+    const result = await probeTrackedUpstreamSnapshot(
+      repoPath,
+      connectionId,
+      localGitOptions,
+      branchName
+    )
+    return result.upstreamsByBranchName.get(branchName) ?? null
+  }
+
   // Why: PR polling asks about hundreds of branches at once; read all upstreams in one git process per repo/runtime, not one probe per branch.
   const probeGeneration = beginTrackedUpstreamSnapshotProbe(cacheKey)
-  const probe = probeTrackedUpstreamSnapshot(repoPath, connectionId, localGitOptions)
+  const probe = probeTrackedUpstreamSnapshot(repoPath, connectionId, localGitOptions, branchName)
   trackedUpstreamSnapshotInFlight.set(cacheKey, probe)
   try {
     const result = await probe
     if (result.cacheable && trackedUpstreamSnapshotGenerations.get(cacheKey) === probeGeneration) {
+      deleteTrackedUpstreamSnapshot(cacheKey)
       trackedUpstreamSnapshotCache.set(cacheKey, {
         ...(result.gitConfigSignature ? { gitConfigSignature: result.gitConfigSignature } : {}),
         upstreamsByBranchName: getCacheableTrackedUpstreamSnapshot(result.upstreamsByBranchName),
+        retainedBytes: result.retainedBytes,
         expiresAt: Date.now() + TRACKED_UPSTREAM_SNAPSHOT_CACHE_TTL_MS
       })
+      trackedUpstreamSnapshotCacheBytes += result.retainedBytes
       pruneTrackedUpstreamSnapshotCache(Date.now())
     }
     if (trackedUpstreamSnapshotGenerations.get(cacheKey) !== probeGeneration) {
@@ -2556,7 +2558,8 @@ async function getTrackedUpstreamBranch(
 async function probeTrackedUpstreamSnapshot(
   repoPath: string,
   connectionId?: string | null,
-  localGitOptions: { wslDistro?: string } = {}
+  localGitOptions: { wslDistro?: string } = {},
+  requestedBranchName?: string
 ): Promise<TrackedUpstreamSnapshotProbeResult> {
   const startingGitConfigSignature = await readLocalGitConfigSignature({
     repoPath,
@@ -2566,8 +2569,10 @@ async function probeTrackedUpstreamSnapshot(
   const { probeFailed, upstreamsByBranchName } = await probeTrackedUpstreamBranches(
     repoPath,
     connectionId,
-    localGitOptions
+    localGitOptions,
+    requestedBranchName
   )
+  const retainedBytes = measureTrackedUpstreamSnapshotBytes(upstreamsByBranchName)
   const endingGitConfigSignature = await readLocalGitConfigSignature({
     repoPath,
     connectionId: connectionId ?? null,
@@ -2583,7 +2588,8 @@ async function probeTrackedUpstreamSnapshot(
     cacheable: !configSignatureChanged && !probeFailed,
     probeFailed,
     ...(gitConfigSignature ? { gitConfigSignature } : {}),
-    upstreamsByBranchName
+    upstreamsByBranchName,
+    retainedBytes
   }
 }
 
@@ -2626,13 +2632,14 @@ function getTrackedUpstreamBranchCacheKey(
   const runtimeKey = connectionId
     ? `ssh:${connectionId}`
     : `local:${localGitOptions.wslDistro ?? 'host'}`
-  return [runtimeKey, repoPath].join('\0')
+  return cacheIdentityDigest([runtimeKey, repoPath])
 }
 
 async function probeTrackedUpstreamBranches(
   repoPath: string,
   connectionId?: string | null,
-  localGitOptions: { wslDistro?: string } = {}
+  localGitOptions: { wslDistro?: string } = {},
+  requestedBranchName?: string
 ): Promise<{
   probeFailed: boolean
   upstreamsByBranchName: Map<string, TrackedUpstreamBranch | null>
@@ -2648,27 +2655,104 @@ async function probeTrackedUpstreamBranches(
         })
     return {
       probeFailed: false,
-      upstreamsByBranchName: parseTrackedUpstreamBranches(result.stdout)
+      upstreamsByBranchName: parseTrackedUpstreamBranches(result.stdout, requestedBranchName)
     }
   } catch {
     return { probeFailed: true, upstreamsByBranchName: new Map() }
   }
 }
 
-function parseTrackedUpstreamBranches(stdout: string): Map<string, TrackedUpstreamBranch | null> {
+function parseTrackedUpstreamBranches(
+  stdout: string,
+  requestedBranchName?: string
+): Map<string, TrackedUpstreamBranch | null> {
   const upstreamsByBranchName = new Map<string, TrackedUpstreamBranch | null>()
-  for (const line of stdout.split(/\r?\n/)) {
+  let retainedBytes = 0
+  let lineStart = 0
+  while (lineStart <= stdout.length) {
+    const newline = stdout.indexOf('\n', lineStart)
+    const lineEnd = newline === -1 ? stdout.length : newline
+    const line = stdout.slice(
+      lineStart,
+      lineEnd > lineStart && stdout[lineEnd - 1] === '\r' ? lineEnd - 1 : lineEnd
+    )
+    lineStart = newline === -1 ? stdout.length + 1 : newline + 1
     if (!line) {
       continue
     }
-    const [branchName, upstreamRef] = line.split('\0')
-    const localBranchName = branchName?.replace(/^refs\/heads\//, '')
+    const separator = line.indexOf('\0')
+    const branchName = separator === -1 ? line : line.slice(0, separator)
+    const upstreamRef = separator === -1 ? '' : line.slice(separator + 1)
+    const localBranchName = branchName.startsWith('refs/heads/')
+      ? branchName.slice('refs/heads/'.length)
+      : branchName
     if (!localBranchName) {
       continue
     }
-    upstreamsByBranchName.set(localBranchName, parseTrackedUpstreamRef(upstreamRef ?? ''))
+    const parsedUpstream = parseTrackedUpstreamRef(upstreamRef)
+    const entryBytes = measureTrackedUpstreamEntryBytes(localBranchName, parsedUpstream)
+    if (entryBytes === null) {
+      continue
+    }
+    const isRequested = localBranchName === requestedBranchName
+    while (
+      isRequested &&
+      upstreamsByBranchName.size > 0 &&
+      (upstreamsByBranchName.size >= TRACKED_UPSTREAM_SNAPSHOT_MAX_BRANCHES ||
+        retainedBytes + entryBytes > TRACKED_UPSTREAM_SNAPSHOT_MAX_BYTES)
+    ) {
+      const oldest = upstreamsByBranchName.keys().next().value
+      if (oldest === undefined) {
+        break
+      }
+      retainedBytes -=
+        measureTrackedUpstreamEntryBytes(oldest, upstreamsByBranchName.get(oldest) ?? null) ?? 0
+      upstreamsByBranchName.delete(oldest)
+    }
+    if (
+      upstreamsByBranchName.size >= TRACKED_UPSTREAM_SNAPSHOT_MAX_BRANCHES ||
+      retainedBytes + entryBytes > TRACKED_UPSTREAM_SNAPSHOT_MAX_BYTES
+    ) {
+      continue
+    }
+    upstreamsByBranchName.set(localBranchName.replace(/$/u, ''), parsedUpstream)
+    retainedBytes += entryBytes
   }
   return upstreamsByBranchName
+}
+
+export function _parseTrackedUpstreamBranchesForTests(
+  stdout: string,
+  requestedBranchName?: string
+): Map<string, TrackedUpstreamBranch | null> {
+  return parseTrackedUpstreamBranches(stdout, requestedBranchName)
+}
+
+function measureTrackedUpstreamEntryBytes(
+  branchName: string,
+  upstream: TrackedUpstreamBranch | null
+): number | null {
+  let remainingBytes = TRACKED_UPSTREAM_SNAPSHOT_MAX_BYTES - 64
+  let bytes = 64
+  for (const value of [branchName, upstream?.remoteName ?? '', upstream?.branchName ?? '']) {
+    const measured = measureUtf8ByteLength(value, { stopAfterBytes: remainingBytes })
+    if (measured.exceededLimit) {
+      return null
+    }
+    remainingBytes -= measured.byteLength
+    bytes += measured.byteLength
+  }
+  return bytes <= TRACKED_UPSTREAM_SNAPSHOT_MAX_BYTES ? bytes : null
+}
+
+function measureTrackedUpstreamSnapshotBytes(
+  upstreamsByBranchName: Map<string, TrackedUpstreamBranch | null>
+): number {
+  let bytes = 0
+  for (const [branchName, upstream] of upstreamsByBranchName) {
+    bytes += measureTrackedUpstreamEntryBytes(branchName, upstream) ?? 0
+  }
+  return bytes
 }
 
 function parseTrackedUpstreamRef(upstreamRef: string): TrackedUpstreamBranch | null {
@@ -3787,7 +3871,9 @@ async function attachFailedJobLogTails(
   // Why: cap log fetches so failed-job details stay a bounded follow-up, not a burst of hosted log downloads.
   for (const job of failedJobs) {
     const jobCacheKey = getCheckJobLogTailCacheKey(job)
-    const cacheKey = jobCacheKey ? `${githubRepoIdentityKey(ownerRepo)}:${jobCacheKey}` : null
+    const cacheKey = jobCacheKey
+      ? cacheIdentityDigest([githubRepoIdentityKey(ownerRepo), jobCacheKey])
+      : null
     if (!cacheKey) {
       continue
     }

--- a/src/main/github/conflict-summary-bounds.test.ts
+++ b/src/main/github/conflict-summary-bounds.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parseMergeTreeNameOnlyOutput,
+  PR_CONFLICT_FILES_MAX_BYTES,
+  PR_CONFLICT_FILES_MAX_ENTRIES
+} from './conflict-summary'
+
+describe('PR conflict summary retention bounds', () => {
+  it('caps retained conflict file count', () => {
+    const stdout = [
+      'tree-oid',
+      ...Array.from({ length: PR_CONFLICT_FILES_MAX_ENTRIES + 1 }, (_, index) => `file-${index}`)
+    ].join('\0')
+    const files = parseMergeTreeNameOnlyOutput(stdout)
+    expect(files).toHaveLength(PR_CONFLICT_FILES_MAX_ENTRIES)
+    expect(files.at(-1)).toBe(`file-${PR_CONFLICT_FILES_MAX_ENTRIES - 1}`)
+  })
+
+  it('stops before retaining an oversized path', () => {
+    const files = parseMergeTreeNameOnlyOutput(
+      `tree-oid\0${'x'.repeat(PR_CONFLICT_FILES_MAX_BYTES + 1)}\0later`
+    )
+    expect(files).toEqual([])
+  })
+})

--- a/src/main/github/conflict-summary-cache.ts
+++ b/src/main/github/conflict-summary-cache.ts
@@ -1,4 +1,5 @@
 import type { PRConflictSummary } from '../../shared/types'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 // Why 60s: the hottest coordinator cadences that re-derive a CONFLICTING PR
 // (10s mergeability-pending, 2.5s manual-pending) previously each ran a
@@ -13,6 +14,7 @@ export const CONFLICT_SUMMARY_BASE_FETCH_WINDOW_MS = 60_000
 // that stop refreshing can't accumulate entries forever.
 const BASE_OID_CACHE_MAX = 64
 const SUMMARY_CACHE_MAX = 128
+const CONFLICT_SUMMARY_MAX_IN_FLIGHT = 32
 
 export type FreshBaseTipResolution =
   | { kind: 'resolved'; oid: string }
@@ -42,11 +44,10 @@ export function getConflictSummaryGitRuntimeKey(wslDistro: string | undefined): 
   return wslDistro ? `wsl:${wslDistro}` : 'local:host'
 }
 
-// Why JSON: repo paths and git ref names may contain any printable joiner
-// character (git allows `|` in branch names), so a delimiter-joined key could
-// alias distinct identities onto one cache entry.
+// Why digest: keys include arbitrary repo paths and refs; a length-framed
+// digest prevents delimiter aliases without retaining those strings.
 export function buildConflictSummaryCacheKey(...parts: string[]): string {
-  return JSON.stringify(parts)
+  return cacheIdentityDigest(parts)
 }
 
 export function readFreshBaseTipResolution(baseKey: string): FreshBaseTipResolution | null {
@@ -121,8 +122,14 @@ function dedupeInFlight<T>(
   if (existing) {
     return existing
   }
-  const promise = factory().finally(() => {
-    map.delete(key)
+  if (map.size >= CONFLICT_SUMMARY_MAX_IN_FLIGHT) {
+    return factory()
+  }
+  let promise!: Promise<T>
+  promise = factory().finally(() => {
+    if (map.get(key) === promise) {
+      map.delete(key)
+    }
   })
   map.set(key, promise)
   return promise

--- a/src/main/github/conflict-summary.ts
+++ b/src/main/github/conflict-summary.ts
@@ -4,6 +4,7 @@ import {
   isUnsupportedMergeTreeWriteTreeError
 } from '../../shared/git-merge-tree-capability'
 import { gitExecFileAsync } from '../git/runner'
+import { iterateNulDelimitedFields } from '../../shared/nul-delimited-fields'
 import {
   clearGitCapabilityStateForTests,
   getLocalGitCapabilityCache
@@ -20,10 +21,14 @@ import {
   storeResolvedBaseTip,
   storeCachedSummary
 } from './conflict-summary-cache'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 type LocalGitExecOptions = {
   wslDistro?: string
 }
+
+export const PR_CONFLICT_FILES_MAX_ENTRIES = 512
+export const PR_CONFLICT_FILES_MAX_BYTES = 256 * 1024
 
 export function __resetPRConflictSummaryCachesForTests(): void {
   clearGitCapabilityStateForTests()
@@ -301,13 +306,27 @@ async function loadConflictingFilesWithLegacyMergeTree(
   }
 }
 
-function parseMergeTreeNameOnlyOutput(stdout: string): string[] {
-  const entries = stdout.split('\0').filter(Boolean)
-  if (entries.length === 0) {
-    return []
+export function parseMergeTreeNameOnlyOutput(stdout: string): string[] {
+  const files: string[] = []
+  let skippedTreeId = false
+  let retainedBytes = 0
+  for (const entry of iterateNulDelimitedFields(stdout)) {
+    if (!entry) {
+      continue
+    }
+    if (!skippedTreeId) {
+      skippedTreeId = true
+      continue
+    }
+    const measured = measureUtf8ByteLength(entry, {
+      stopAfterBytes: PR_CONFLICT_FILES_MAX_BYTES - retainedBytes
+    })
+    if (measured.exceededLimit || files.length >= PR_CONFLICT_FILES_MAX_ENTRIES) {
+      break
+    }
+    files.push(entry.replace(/$/u, ''))
+    retainedBytes += measured.byteLength
   }
-
-  const [, ...files] = entries
   return files
 }
 

--- a/src/main/github/gh-utils.test.ts
+++ b/src/main/github/gh-utils.test.ts
@@ -678,6 +678,35 @@ describe('github owner/repo resolution', () => {
       await rm(repoPath, { recursive: true, force: true })
     }
   })
+
+  it('parses exact-limit config files and safely skips oversized include graphs', async () => {
+    const repoPath = await mkdtemp(join(tmpdir(), 'orca-gh-utils-'))
+    const gitDir = join(repoPath, '.git')
+    const includedConfigPath = join(repoPath, 'included.gitconfig')
+    const configPath = join(gitDir, 'config')
+    const maxConfigBytes = 4 * 1024 * 1024
+    await mkdir(gitDir)
+    await writeFile(includedConfigPath, '[user]\n\tname = first\n')
+    const includePrefix = `[include]\n\tpath = "${includedConfigPath}"\n#`
+    await writeFile(configPath, includePrefix + 'x'.repeat(maxConfigBytes - includePrefix.length))
+    try {
+      const exactFirst = await readLocalGitConfigSignature({ repoPath, connectionId: null })
+      await writeFile(includedConfigPath, '[user]\n\tname = exact-limit-change\n')
+      const exactSecond = await readLocalGitConfigSignature({ repoPath, connectionId: null })
+      expect(exactSecond).not.toEqual(exactFirst)
+
+      await writeFile(
+        configPath,
+        includePrefix + 'x'.repeat(maxConfigBytes + 1 - includePrefix.length)
+      )
+      const oversizedFirst = await readLocalGitConfigSignature({ repoPath, connectionId: null })
+      await writeFile(includedConfigPath, '[user]\n\tname = ignored-oversized-change\n')
+      const oversizedSecond = await readLocalGitConfigSignature({ repoPath, connectionId: null })
+      expect(oversizedSecond).toEqual(oversizedFirst)
+    } finally {
+      await rm(repoPath, { recursive: true, force: true })
+    }
+  })
 })
 
 describe('resolveIssueSource', () => {

--- a/src/main/github/gh-utils.ts
+++ b/src/main/github/gh-utils.ts
@@ -4,6 +4,7 @@ import { gitExecFileAsync, ghExecFileAsync } from '../git/runner'
 // Pure error-parsing helpers come from the lightweight module (not `runner`) so
 // tests that mock `../git/runner` still resolve the real implementations.
 import { extractExecError, parseRetryAfterMs } from '../git/exec-error'
+import { IntegrationApiConcurrencyGate } from '../integration-api-concurrency'
 
 // Why: legacy generic execFile wrapper - only used by callers that don't need
 // WSL-aware routing. Repo-scoped callers should use the runner exports below.
@@ -34,26 +35,12 @@ export type {
 } from './github-repository-identity'
 
 const MAX_CONCURRENT = 4
-let running = 0
-const queue: (() => void)[] = []
+const concurrencyGate = new IntegrationApiConcurrencyGate(MAX_CONCURRENT)
 
 export function acquire(): Promise<void> {
-  if (running < MAX_CONCURRENT) {
-    running += 1
-    return Promise.resolve()
-  }
-  return new Promise((resolve) =>
-    queue.push(() => {
-      running += 1
-      resolve()
-    })
-  )
+  return concurrencyGate.acquire()
 }
 
 export function release(): void {
-  running -= 1
-  const next = queue.shift()
-  if (next) {
-    next()
-  }
+  concurrencyGate.release()
 }

--- a/src/main/github/github-api-repository-validation.ts
+++ b/src/main/github/github-api-repository-validation.ts
@@ -1,0 +1,14 @@
+import type { GitHubOwnerRepo } from '../../shared/types'
+
+const GITHUB_OWNER_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/
+const GITHUB_REPO_SLUG_RE = /^[A-Za-z0-9._-]+$/
+
+// Why: renderer/RPC overrides are interpolated into authenticated REST paths.
+export function isValidGitHubApiRepository(repository: GitHubOwnerRepo): boolean {
+  return (
+    GITHUB_OWNER_SLUG_RE.test(repository.owner) &&
+    GITHUB_REPO_SLUG_RE.test(repository.repo) &&
+    repository.repo !== '.' &&
+    repository.repo !== '..'
+  )
+}

--- a/src/main/github/github-api-repository.ts
+++ b/src/main/github/github-api-repository.ts
@@ -14,6 +14,8 @@ import {
   getEnterpriseGitHubRepoSlugForRemote,
   isGitHubHostAuthenticated
 } from './github-enterprise-repository'
+import { isValidGitHubApiRepository } from './github-api-repository-validation'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 export type GitHubApiRepository = GitHubOwnerRepo
 export type GitHubRepoExecOptions = ReturnType<typeof ghRepoExecOptions> & { host?: string }
@@ -28,25 +30,12 @@ type GitHubApiRepositoryResolution =
   | undefined
   | (() => Promise<GitHubApiRepository | null>)
 
-// Why: renderer/RPC repository overrides are interpolated into REST paths.
-// Reject path syntax before an authenticated gh process can target it.
-const GITHUB_OWNER_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/
-const GITHUB_REPO_SLUG_RE = /^[A-Za-z0-9._-]+$/
-
-function isValidGitHubApiRepository(repository: GitHubApiRepository): boolean {
-  return (
-    GITHUB_OWNER_SLUG_RE.test(repository.owner) &&
-    GITHUB_REPO_SLUG_RE.test(repository.repo) &&
-    repository.repo !== '.' &&
-    repository.repo !== '..'
-  )
-}
-
 // Why: the enterprise branch spawns an uncached `git remote get-url` (an SSH
 // round trip on connection-backed repos) — hot paths like per-file contents
 // and viewed-state toggles resolve per call, so cache like ownerRepoCache does.
 const ORIGIN_REPO_CACHE_TTL_MS = 30_000
 const ORIGIN_REPO_CACHE_MAX_ENTRIES = 512
+const ORIGIN_REPO_MAX_IN_FLIGHT = 32
 const originRepoCache = new Map<string, { value: GitHubApiRepository | null; expiresAt: number }>()
 const originRepoInFlight = new Map<string, Promise<GitHubApiRepository | null>>()
 
@@ -56,7 +45,12 @@ function originRepoCacheKey(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): string {
-  return `${connectionId ?? 'local'}\0${localGitOptions.wslDistro ?? ''}\0${repoPath}\0${remoteName}`
+  return cacheIdentityDigest([
+    connectionId ?? 'local',
+    localGitOptions.wslDistro ?? '',
+    repoPath,
+    remoteName
+  ])
 }
 
 /** @internal - exposed for tests only */
@@ -136,6 +130,9 @@ export async function getGitHubApiRepositoryForRemote(
     }
     return slug ?? null
   })()
+  if (originRepoInFlight.size >= ORIGIN_REPO_MAX_IN_FLIGHT) {
+    return probe
+  }
   originRepoInFlight.set(cacheKey, probe)
   try {
     return await probe

--- a/src/main/github/github-enterprise-repository.ts
+++ b/src/main/github/github-enterprise-repository.ts
@@ -13,6 +13,7 @@ import {
   type LocalGitExecOptions
 } from './github-repository-identity'
 import { parseWslPath } from '../wsl'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 export type GitHubEnterpriseRepoSlug = GitHubOwnerRepo & { host: string }
 
@@ -22,6 +23,8 @@ export type GitHubEnterpriseRepoSlug = GitHubOwnerRepo & { host: string }
 // GHES remote is not left to fall through to Gitea (#8312).
 const HOST_AUTH_TTL_MS = 60_000
 const HOST_AUTH_CACHE_MAX_ENTRIES = 512
+const HOST_AUTH_MAX_IN_FLIGHT = 16
+const GITHUB_HOST_MAX_CHARS = 1024
 
 type HostAuthCacheEntry = {
   authenticatedHost: string | null
@@ -82,6 +85,9 @@ type NormalizedGitHubHost = {
 }
 
 function normalizeGitHubHost(host: string): NormalizedGitHubHost | null {
+  if (host.length > GITHUB_HOST_MAX_CHARS) {
+    return null
+  }
   const match = host
     .trim()
     .toLowerCase()
@@ -128,8 +134,14 @@ async function resolveAuthenticatedGitHubHost(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<string | null | undefined> {
-  const normalizedHost = normalizeGitHubHost(host)?.authority ?? host.trim().toLowerCase()
-  const cacheKey = `${runtimeCacheKey(repoPath, localGitOptions.wslDistro)}\0${normalizedHost}`
+  const normalizedHost = normalizeGitHubHost(host)?.authority
+  if (!normalizedHost) {
+    return null
+  }
+  const cacheKey = cacheIdentityDigest([
+    runtimeCacheKey(repoPath, localGitOptions.wslDistro),
+    normalizedHost
+  ])
   const now = Date.now()
   pruneHostAuthCache(now)
   const cached = hostAuthCache.get(cacheKey)
@@ -168,6 +180,9 @@ async function resolveAuthenticatedGitHubHost(
     pruneHostAuthCache(Date.now())
     return authenticatedHost
   })()
+  if (hostAuthInFlight.size >= HOST_AUTH_MAX_IN_FLIGHT) {
+    return probe
+  }
   hostAuthInFlight.set(cacheKey, probe)
   try {
     return await probe

--- a/src/main/github/github-remote-identity-parsing.test.ts
+++ b/src/main/github/github-remote-identity-parsing.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseGitHubOwnerRepo, parseGitHubRemoteIdentity } from './github-remote-identity-parsing'
+import {
+  GITHUB_REMOTE_REPO_MAX_BYTES,
+  GITHUB_REMOTE_URL_MAX_BYTES,
+  parseGitHubOwnerRepo,
+  parseGitHubRemoteIdentity
+} from './github-remote-identity-parsing'
 
 describe('parseGitHubRemoteIdentity', () => {
+  it('rejects oversized remote URLs and identity fields before retention', () => {
+    expect(parseGitHubRemoteIdentity('x'.repeat(GITHUB_REMOTE_URL_MAX_BYTES + 1))).toBeNull()
+    expect(
+      parseGitHubRemoteIdentity(
+        `git@github.com:owner/${'r'.repeat(GITHUB_REMOTE_REPO_MAX_BYTES + 1)}.git`
+      )
+    ).toBeNull()
+  })
+
   it('parses a plain github.com https remote', () => {
     expect(parseGitHubRemoteIdentity('https://github.com/team/orca.git')).toEqual({
       host: 'github.com',

--- a/src/main/github/github-remote-identity-parsing.ts
+++ b/src/main/github/github-remote-identity-parsing.ts
@@ -1,6 +1,15 @@
 import type { GitHubOwnerRepo } from '../../shared/types'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 export type GitHubRemoteIdentity = GitHubOwnerRepo & { host: string }
+export const GITHUB_REMOTE_URL_MAX_BYTES = 64 * 1024
+export const GITHUB_REMOTE_HOST_MAX_BYTES = 1024
+export const GITHUB_REMOTE_OWNER_MAX_BYTES = 256
+export const GITHUB_REMOTE_REPO_MAX_BYTES = 1024
+
+function fitsRemoteField(value: string, maxBytes: number): boolean {
+  return !measureUtf8ByteLength(value, { stopAfterBytes: maxBytes }).exceededLimit
+}
 
 function normalizeGitHubRemoteHost(host: string): string {
   const normalizedHost = host.toLowerCase()
@@ -22,16 +31,31 @@ function parseGitHubRemotePath(path: string): Pick<GitHubRemoteIdentity, 'owner'
   }
   const [owner, repoWithSuffix] = parts
   const repo = repoWithSuffix.replace(/\.git$/i, '')
-  if (!owner || !repo) {
+  if (
+    !owner ||
+    !repo ||
+    !fitsRemoteField(owner, GITHUB_REMOTE_OWNER_MAX_BYTES) ||
+    !fitsRemoteField(repo, GITHUB_REMOTE_REPO_MAX_BYTES)
+  ) {
     return null
   }
   return { owner, repo }
 }
 
 export function parseGitHubRemoteIdentity(remoteUrl: string): GitHubRemoteIdentity | null {
+  if (!fitsRemoteField(remoteUrl, GITHUB_REMOTE_URL_MAX_BYTES)) {
+    return null
+  }
   const trimmed = remoteUrl.trim()
   const sshMatch = trimmed.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/i)
   if (sshMatch) {
+    if (
+      !fitsRemoteField(sshMatch[1], GITHUB_REMOTE_HOST_MAX_BYTES) ||
+      !fitsRemoteField(sshMatch[2], GITHUB_REMOTE_OWNER_MAX_BYTES) ||
+      !fitsRemoteField(sshMatch[3], GITHUB_REMOTE_REPO_MAX_BYTES)
+    ) {
+      return null
+    }
     return { host: normalizeGitHubRemoteHost(sshMatch[1]), owner: sshMatch[2], repo: sshMatch[3] }
   }
 
@@ -41,7 +65,8 @@ export function parseGitHubRemoteIdentity(remoteUrl: string): GitHubRemoteIdenti
       return null
     }
     const path = parseGitHubRemotePath(url.pathname)
-    return path ? { host: normalizeGitHubRemoteHost(hostFromRemoteUrl(url)), ...path } : null
+    const host = normalizeGitHubRemoteHost(hostFromRemoteUrl(url))
+    return path && fitsRemoteField(host, GITHUB_REMOTE_HOST_MAX_BYTES) ? { host, ...path } : null
   } catch {
     return null
   }

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -9,6 +9,7 @@ import {
 } from './github-remote-identity-parsing'
 import { isStableMissingGitRemoteError } from './stable-missing-git-remote-error'
 import { githubRepoIdentityKey } from '../../shared/github-repository-identity-key'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 export type OwnerRepo = GitHubOwnerRepo
 
@@ -53,6 +54,7 @@ export function ghRepoExecOptions(context: GitHubRepoContext): {
 const OWNER_REPO_POSITIVE_CACHE_TTL_MS = 30_000
 const OWNER_REPO_NEGATIVE_CACHE_TTL_MS = 5 * 60_000
 const OWNER_REPO_CACHE_MAX_ENTRIES = 512
+const OWNER_REPO_MAX_IN_FLIGHT = 32
 
 type OwnerRepoCacheEntry = {
   value: OwnerRepo | null
@@ -123,7 +125,7 @@ export async function getOwnerRepoForRemote(
 ): Promise<OwnerRepo | null> {
   const context = githubRepoContext(repoPath, connectionId, localGitOptions)
   const runtimeKey = context.connectionId ?? `local:${context.wslDistro ?? 'host'}`
-  const cacheKey = `${runtimeKey}\0${context.repoPath}\0${remoteName}`
+  const cacheKey = cacheIdentityDigest([runtimeKey, context.repoPath, remoteName])
   const now = Date.now()
   pruneOwnerRepoCache(now)
   const cached = ownerRepoCache.get(cacheKey)
@@ -158,6 +160,9 @@ export async function getOwnerRepoForRemote(
   // Why: startup can resolve issue sources, PR candidates, and repo metadata
   // for the same repo concurrently. Coalesce missing-remote probes.
   const probe = resolveOwnerRepoForRemote(context, remoteName, cacheKey, nextConfigSignature)
+  if (ownerRepoInFlight.size >= OWNER_REPO_MAX_IN_FLIGHT) {
+    return probe
+  }
   ownerRepoInFlight.set(cacheKey, probe)
   try {
     return await probe

--- a/src/main/github/local-git-config-signature.ts
+++ b/src/main/github/local-git-config-signature.ts
@@ -1,7 +1,11 @@
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
 import { homedir } from 'node:os'
 import { dirname, isAbsolute, join, resolve } from 'node:path'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 import type { GitHubRepoContext } from './github-repository-identity'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 type LocalGitConfigPaths = {
   commonConfigPath: string
@@ -9,6 +13,18 @@ type LocalGitConfigPaths = {
 }
 
 const localGitConfigSignatureInFlight = new Map<string, Promise<string | undefined>>()
+const LOCAL_GIT_CONFIG_SIGNATURE_MAX_IN_FLIGHT = 32
+const MAX_GIT_CONFIG_BYTES = 4 * 1024 * 1024
+const MAX_GIT_POINTER_FILE_BYTES = 64 * 1024
+const MAX_INCLUDED_CONFIG_FILES = 256
+const MAX_INCLUDED_CONFIG_DEPTH = 8
+const MAX_INCLUDED_CONFIG_PATH_BYTES = 16 * 1024
+const MAX_INCLUDED_CONFIG_AGGREGATE_PATH_BYTES = 2 * 1024 * 1024
+
+type ConfigSignatureBudget = {
+  admittedFiles: number
+  pathBytes: number
+}
 
 export async function readLocalGitConfigSignature(
   context: GitHubRepoContext
@@ -18,13 +34,16 @@ export async function readLocalGitConfigSignature(
     // runtimes are already separated by cache key and probed through git.
     return undefined
   }
-  const cacheKey = context.repoPath
+  const cacheKey = cacheIdentityDigest([context.repoPath])
   const inFlight = localGitConfigSignatureInFlight.get(cacheKey)
   if (inFlight) {
     return inFlight
   }
 
   const read = readUncachedLocalGitConfigSignature(context.repoPath)
+  if (localGitConfigSignatureInFlight.size >= LOCAL_GIT_CONFIG_SIGNATURE_MAX_IN_FLIGHT) {
+    return read
+  }
   localGitConfigSignatureInFlight.set(cacheKey, read)
   try {
     return await read
@@ -48,31 +67,54 @@ async function readUncachedLocalGitConfigSignature(repoPath: string): Promise<st
     readConfigPathSignatures(configPaths.commonConfigPath),
     readConfigPathSignatures(configPaths.worktreeConfigPath)
   ])
-  return signatures.flat().join('\0')
+  const digest = createHash('sha256')
+  for (const signature of signatures.flat()) {
+    digest.update(`${signature.length}:`)
+    digest.update(signature)
+  }
+  return digest.digest('base64url')
 }
 
 async function readConfigPathSignatures(
   configPath: string,
-  visited = new Set<string>()
+  visited = new Set<string>(),
+  budget: ConfigSignatureBudget = { admittedFiles: 0, pathBytes: 0 },
+  depth = 0
 ): Promise<string[]> {
   if (visited.has(configPath)) {
     return []
   }
+  const measuredPath = measureUtf8ByteLength(configPath, {
+    stopAfterBytes: MAX_INCLUDED_CONFIG_PATH_BYTES
+  })
+  if (
+    measuredPath.exceededLimit ||
+    depth > MAX_INCLUDED_CONFIG_DEPTH ||
+    budget.admittedFiles >= MAX_INCLUDED_CONFIG_FILES ||
+    budget.pathBytes + measuredPath.byteLength > MAX_INCLUDED_CONFIG_AGGREGATE_PATH_BYTES
+  ) {
+    return []
+  }
   visited.add(configPath)
+  budget.admittedFiles += 1
+  budget.pathBytes += measuredPath.byteLength
 
   const ownSignature = await readConfigPathSignature(configPath)
   let configText: string
   try {
-    configText = await readFile(configPath, 'utf8')
+    configText = (await readNodeFileWithinLimit(configPath, MAX_GIT_CONFIG_BYTES)).buffer.toString(
+      'utf8'
+    )
   } catch {
     return [ownSignature]
   }
 
   const includedPaths = parseIncludedConfigPaths(configText, dirname(configPath))
-  const includedSignatures = await Promise.all(
-    includedPaths.map((includedPath) => readConfigPathSignatures(includedPath, visited))
-  )
-  return [ownSignature, ...includedSignatures.flat()]
+  const signatures = [ownSignature]
+  for (const includedPath of includedPaths) {
+    signatures.push(...(await readConfigPathSignatures(includedPath, visited, budget, depth + 1)))
+  }
+  return signatures
 }
 
 async function readConfigPathSignature(configPath: string): Promise<string> {
@@ -103,6 +145,9 @@ function parseIncludedConfigPaths(configText: string, baseDir: string): string[]
     const includePath = parseIncludedConfigPath(line)
     if (includePath) {
       includedPaths.push(resolveIncludedConfigPath(includePath, baseDir))
+      if (includedPaths.length >= MAX_INCLUDED_CONFIG_FILES) {
+        break
+      }
     }
   }
   return includedPaths
@@ -214,7 +259,9 @@ async function resolveLocalGitConfigPaths(repoPath: string): Promise<LocalGitCon
   }
 
   try {
-    const gitFile = await readFile(dotGitPath, 'utf8')
+    const gitFile = (
+      await readNodeFileWithinLimit(dotGitPath, MAX_GIT_POINTER_FILE_BYTES)
+    ).buffer.toString('utf8')
     const match = gitFile.match(/^gitdir:\s*(.+?)\s*$/im)
     if (!match) {
       return null
@@ -222,7 +269,11 @@ async function resolveLocalGitConfigPaths(repoPath: string): Promise<LocalGitCon
     const gitDir = resolve(dirname(dotGitPath), match[1])
     let commonGitDir = gitDir
     try {
-      const commonDir = (await readFile(join(gitDir, 'commondir'), 'utf8')).trim()
+      const commonDir = (
+        await readNodeFileWithinLimit(join(gitDir, 'commondir'), MAX_GIT_POINTER_FILE_BYTES)
+      ).buffer
+        .toString('utf8')
+        .trim()
       if (commonDir) {
         commonGitDir = resolve(gitDir, commonDir)
       }

--- a/src/main/github/merged-pr-commit-membership.ts
+++ b/src/main/github/merged-pr-commit-membership.ts
@@ -3,6 +3,7 @@ import { noteRepositoryRateLimitSpend, repositoryRateLimitGuard } from './rate-l
 import { githubHostExecOptions } from './github-api-repository'
 import { githubRepoIdentityKey } from '../../shared/github-repository-identity-key'
 import type { OwnerRepo } from './github-repository-identity'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 type GhExecOptions = Parameters<typeof ghExecFileAsync>[1]
 
@@ -61,7 +62,11 @@ export async function isCommitPartOfMergedPR(args: {
   }
   const owner = args.ownerRepo.owner
   const repo = args.ownerRepo.repo
-  const cacheKey = `${githubRepoIdentityKey(args.ownerRepo)}#${args.prNumber}@${oid}`
+  const cacheKey = cacheIdentityDigest([
+    githubRepoIdentityKey(args.ownerRepo),
+    String(args.prNumber),
+    oid
+  ])
   const ghOptions = { ...args.ghOptions, ...githubHostExecOptions(args.ownerRepo) }
   const now = Date.now()
   pruneMergedPRCommitMembershipCache(now)

--- a/src/main/github/pr-refresh-coordinator-memory.test.ts
+++ b/src/main/github/pr-refresh-coordinator-memory.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GitHubPRRefreshCandidate } from '../../shared/types'
+import {
+  PR_REFRESH_ALIAS_LIMIT,
+  PR_REFRESH_QUEUE_ENTRY_LIMIT
+} from '../../shared/pr-refresh-memory-limits'
+
+const { sendToTrustedUIRendererMock } = vi.hoisted(() => ({
+  sendToTrustedUIRendererMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  webContents: { getAllWebContents: () => [] }
+}))
+vi.mock('./client', () => ({ getPRForBranchOutcome: vi.fn() }))
+vi.mock('./github-api-repository', () => ({ getOriginGitHubApiRepository: vi.fn() }))
+vi.mock('./rate-limit', () => ({
+  getRateLimit: vi.fn(),
+  noteRepositoryRateLimitSpend: vi.fn(),
+  repositoryRateLimitGuard: vi.fn(() => ({ blocked: false })),
+  spendsSharedGitHubComQuota: vi.fn(() => false)
+}))
+vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
+  recordCoalescedCrashBreadcrumb: vi.fn()
+}))
+vi.mock('../ipc/ui', () => ({ sendToTrustedUIRenderer: sendToTrustedUIRendererMock }))
+
+function candidate(index: number, linkedPRNumber?: number): GitHubPRRefreshCandidate {
+  return {
+    cacheKey: `/repo-${index}::feature-${index}`,
+    repoPath: linkedPRNumber === undefined ? `/repo-${index}` : '/repo',
+    branch: `feature-${index}`,
+    repoKind: 'git',
+    repoId: `repo-${index}`,
+    worktreeId: `worktree-${index}`,
+    cachedFetchedAt: Date.now(),
+    linkedPRNumber
+  }
+}
+
+describe('PR refresh coordinator memory admission', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    sendToTrustedUIRendererMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('caps distinct queued refreshes while GitHub work is delayed', async () => {
+    const { enqueuePRRefresh, _getPRRefreshQueueSizeForTests } =
+      await import('./pr-refresh-coordinator')
+
+    for (let index = 0; index <= PR_REFRESH_QUEUE_ENTRY_LIMIT; index += 1) {
+      enqueuePRRefresh(candidate(index), 'visible', 40, 1)
+    }
+
+    expect(_getPRRefreshQueueSizeForTests()).toBe(PR_REFRESH_QUEUE_ENTRY_LIMIT)
+    expect(sendToTrustedUIRendererMock).toHaveBeenLastCalledWith(
+      'gh:prRefreshEvent',
+      expect.objectContaining({ status: 'skipped', skippedReason: 'capacity' })
+    )
+  })
+
+  it('caps aliases coalesced behind one linked review', async () => {
+    const { enqueuePRRefresh, _getPRRefreshAliasCountForTests } =
+      await import('./pr-refresh-coordinator')
+
+    for (let index = 0; index <= PR_REFRESH_ALIAS_LIMIT; index += 1) {
+      enqueuePRRefresh(candidate(index, 42), 'visible', 40, 1)
+    }
+
+    expect(_getPRRefreshAliasCountForTests('local::runtime:host::/repo::pr::42')).toBe(
+      PR_REFRESH_ALIAS_LIMIT
+    )
+    expect(sendToTrustedUIRendererMock).toHaveBeenCalledWith(
+      'gh:prRefreshEvent',
+      expect.objectContaining({ status: 'skipped', skippedReason: 'capacity' })
+    )
+  })
+})

--- a/src/main/github/pr-refresh-coordinator.ts
+++ b/src/main/github/pr-refresh-coordinator.ts
@@ -12,6 +12,14 @@ import { getPRForBranchOutcome, type GitHubPRBranchLookupOptions } from './clien
 import { getOriginGitHubApiRepository } from './github-api-repository'
 import { ghRepoExecOptions, githubRepoContext } from './gh-utils'
 import {
+  boundedVisiblePRRefreshCandidates,
+  PR_REFRESH_ACTIVE_SCOPE_LIMIT,
+  PR_REFRESH_QUEUE_ENTRY_LIMIT,
+  PR_REFRESH_RETRY_STATE_LIMIT,
+  retainPRRefreshAlias,
+  retainPRRefreshState
+} from './pr-refresh-memory-bounds'
+import {
   getRateLimit,
   noteRepositoryRateLimitSpend,
   repositoryRateLimitGuard,
@@ -97,8 +105,19 @@ let lastBackgroundStartAt = 0
  * Only a rate-limit outcome carrying `retryDisabledUntil` sets a gate; any other settled outcome clears it.
  */
 function noteManualRetryGate(key: string, outcome: PRRefreshOutcome): void {
+  const now = Date.now()
+  for (const [gateKey, retryAt] of manualRetryGates) {
+    if (retryAt <= now) {
+      manualRetryGates.delete(gateKey)
+    }
+  }
   if (outcome.kind === 'upstream-error' && outcome.retryDisabledUntil !== undefined) {
-    manualRetryGates.set(key, outcome.retryDisabledUntil)
+    retainPRRefreshState(
+      manualRetryGates,
+      key,
+      outcome.retryDisabledUntil,
+      PR_REFRESH_RETRY_STATE_LIMIT
+    )
   } else {
     manualRetryGates.delete(key)
   }
@@ -116,6 +135,14 @@ const diagnosticsCounters = {
   coalesced: 0,
   skipped: 0,
   backgroundPauses: 0
+}
+
+function setBoundedQueueEntry(entry: QueueEntry): boolean {
+  if (!queue.has(entry.key) && queue.size >= PR_REFRESH_QUEUE_ENTRY_LIMIT) {
+    return false
+  }
+  queue.set(entry.key, entry)
+  return true
 }
 
 export function setPRRefreshOutcomeObserver(observer: PRRefreshOutcomeObserver | null): void {
@@ -156,6 +183,26 @@ function recordPRRefreshQueueDiagnostic(
       backgroundPauses: diagnosticsCounters.backgroundPauses
     }
   })
+}
+
+function broadcastCapacitySkip(
+  aliases: GitHubPRRefreshAlias[],
+  reason: GitHubPRRefreshReason
+): void {
+  diagnosticsCounters.skipped += 1
+  recordPRRefreshQueueDiagnostic('skipped', reason, 'capacity')
+  broadcast({ aliases, reason, status: 'skipped', skippedReason: 'capacity' })
+}
+
+function addBoundedQueueAlias(
+  entry: QueueEntry,
+  alias: GitHubPRRefreshAlias,
+  reason: GitHubPRRefreshReason
+): void {
+  const evicted = retainPRRefreshAlias(entry.aliases, alias, entry.candidate.cacheKey)
+  if (evicted) {
+    broadcastCapacitySkip([evicted], reason)
+  }
 }
 
 function clearActiveBurstWindow(windowId: number): void {
@@ -364,15 +411,18 @@ function visibleCandidateAfterOutcome(
   }
 }
 
-function setVisibleFollowUp(entry: QueueEntry): void {
+function setVisibleFollowUp(entry: QueueEntry): boolean {
   const existing = queue.get(entry.key)
   if (!existing) {
-    queue.set(entry.key, entry)
-    return
+    if (!setBoundedQueueEntry(entry)) {
+      broadcastCapacitySkip(Array.from(entry.aliases.values()), entry.reason)
+      return false
+    }
+    return true
   }
 
   for (const alias of entry.aliases.values()) {
-    existing.aliases.set(alias.cacheKey, alias)
+    addBoundedQueueAlias(existing, alias, entry.reason)
   }
 
   // Why: a user activation can arrive while a background refresh awaits gh; the follow-up must not overwrite that pending active/manual work.
@@ -381,13 +431,14 @@ function setVisibleFollowUp(entry: QueueEntry): void {
     existing.priority > entry.priority ||
     existing.dueAt <= entry.dueAt
   ) {
-    return
+    return true
   }
 
-  queue.set(entry.key, {
+  setBoundedQueueEntry({
     ...entry,
     aliases: existing.aliases
   })
+  return true
 }
 
 function removeQueuedAliasForInvalidCandidate(key: string, alias: GitHubPRRefreshAlias): void {
@@ -426,7 +477,7 @@ function nextVisibleErrorRetryAt(key: string): number {
   const failures = (errorBackoff.get(key)?.failures ?? 0) + 1
   const retryAt =
     Date.now() + Math.min(BACKOFF_MAX_MS, BACKOFF_BASE_MS * 2 ** Math.min(failures - 1, 4))
-  errorBackoff.set(key, { failures, retryAt })
+  retainPRRefreshState(errorBackoff, key, { failures, retryAt }, PR_REFRESH_RETRY_STATE_LIMIT)
   return retryAt
 }
 
@@ -463,7 +514,7 @@ function scheduleVisibleFollowUp(
   if (outcome.kind === 'upstream-error') {
     // Why: reuse the retry time already computed for the broadcast so the same failure isn't counted twice against the backoff.
     const retryAt = options?.plannedRetryAt ?? nextVisibleErrorRetryAt(key)
-    setVisibleFollowUp({
+    const retained = setVisibleFollowUp({
       key,
       candidate,
       aliases: new Map(aliases.map((alias) => [alias.cacheKey, alias])),
@@ -473,6 +524,10 @@ function scheduleVisibleFollowUp(
       queuedAt: nextQueueOrder(),
       windowId
     })
+    if (!retained) {
+      resetKeyRetryState(key)
+      return
+    }
     // Why: this is a delayed retry, not active work; a spinner would make visible worktrees look stuck until backoff expires.
     scheduleDrain(retryAt - Date.now())
     return
@@ -489,7 +544,7 @@ function scheduleVisibleFollowUp(
       ? regularDueAt
       : Math.min(regularDueAt, pendingMergeabilityDueAt)
   // Why: a coalesced linked-PR refresh may represent several branches; preserve every alias so all cache entries keep getting updates.
-  setVisibleFollowUp({
+  const retained = setVisibleFollowUp({
     key,
     candidate: followUpCandidate,
     aliases: new Map(aliases.map((alias) => [alias.cacheKey, alias])),
@@ -501,6 +556,10 @@ function scheduleVisibleFollowUp(
     bypassBackgroundBudget: pendingMergeabilityDueAt !== null,
     windowId
   })
+  if (!retained) {
+    resetKeyRetryState(key)
+    return
+  }
   scheduleDrain(Math.max(0, dueAt - Date.now()))
 }
 
@@ -595,6 +654,12 @@ function pruneActiveStarts(scope: string, now: number): number[] {
   return activeStarts
 }
 
+function pruneExpiredActiveScopes(now: number): void {
+  for (const scope of Array.from(activeStartsByScope.keys())) {
+    pruneActiveStarts(scope, now)
+  }
+}
+
 function nextActiveBurstDelay(entry: QueueEntry): number {
   const now = Date.now()
   const activeStarts = pruneActiveStarts(activeBurstScope(entry), now)
@@ -607,9 +672,10 @@ function nextActiveBurstDelay(entry: QueueEntry): number {
 function noteActiveStart(entry: QueueEntry): void {
   const now = Date.now()
   const scope = activeBurstScope(entry)
+  pruneExpiredActiveScopes(now)
   const activeStarts = pruneActiveStarts(scope, now)
   activeStarts.push(now)
-  activeStartsByScope.set(scope, activeStarts)
+  retainPRRefreshState(activeStartsByScope, scope, activeStarts, PR_REFRESH_ACTIVE_SCOPE_LIMIT)
 }
 
 function activeOrder(a: QueueEntry, b: QueueEntry): number {
@@ -758,7 +824,12 @@ async function drainQueue(): Promise<void> {
           .find((guard) => guard.blocked)
         if (blockedGuard?.blocked) {
           const retryAt = blockedGuard.resetAt * 1000
-          queue.set(next.key, { ...next, dueAt: retryAt })
+          const retained = setBoundedQueueEntry({ ...next, dueAt: retryAt })
+          if (!retained) {
+            resetKeyRetryState(next.key)
+            broadcastCapacitySkip(aliases, next.reason)
+            continue
+          }
           broadcast({
             aliases,
             reason: next.reason,
@@ -845,7 +916,7 @@ export function enqueuePRRefresh(
   const freshDueAt = shouldSkipFresh(candidate, reason) ? freshRetryAt(candidate) : null
   const dueAt = freshDueAt ?? Date.now() + (reason === 'post-push' ? POST_PUSH_DELAY_MS : 0)
   if (existing) {
-    existing.aliases.set(alias.cacheKey, alias)
+    addBoundedQueueAlias(existing, alias, reason)
     diagnosticsCounters.coalesced += 1
     recordPRRefreshQueueDiagnostic('coalesced', reason)
     const shouldPromoteExisting =
@@ -871,9 +942,13 @@ export function enqueuePRRefresh(
       }
     }
   } else {
+    if (queue.size >= PR_REFRESH_QUEUE_ENTRY_LIMIT) {
+      broadcastCapacitySkip([alias], reason)
+      return
+    }
     diagnosticsCounters.enqueued += 1
     recordPRRefreshQueueDiagnostic('enqueued', reason)
-    queue.set(key, {
+    setBoundedQueueEntry({
       key,
       candidate,
       aliases: new Map([[alias.cacheKey, alias]]),
@@ -900,9 +975,13 @@ export function reportVisiblePRRefreshCandidates(
   if (existingVisible && generation < existingVisible.generation) {
     return
   }
-  visibleByWindow.set(windowId, { generation, keys: new Set(candidates.map(refreshKey)) })
+  const retainedCandidates = boundedVisiblePRRefreshCandidates(candidates)
+  visibleByWindow.set(windowId, {
+    generation,
+    keys: new Set(retainedCandidates.map(refreshKey))
+  })
   removeInvisibleVisibleRefreshes()
-  for (const candidate of candidates) {
+  for (const candidate of retainedCandidates) {
     enqueuePRRefresh(candidate, 'visible', 40, windowId)
   }
 }
@@ -928,7 +1007,14 @@ export async function refreshPRNow(candidate: GitHubPRRefreshCandidate): Promise
   const key = refreshKey(candidate)
   const existing = queue.get(key)
   const aliasMap = new Map(existing ? existing.aliases : [])
-  aliasMap.set(alias.cacheKey, alias)
+  const evictedAlias = retainPRRefreshAlias(
+    aliasMap,
+    alias,
+    existing?.candidate.cacheKey ?? alias.cacheKey
+  )
+  if (evictedAlias) {
+    broadcastCapacitySkip([evictedAlias], 'manual')
+  }
   const aliases = Array.from(aliasMap.values())
   const skippedReason = validateCandidate(candidate)
   if (skippedReason) {
@@ -963,7 +1049,7 @@ export async function refreshPRNow(candidate: GitHubPRRefreshCandidate): Promise
   if (gateUntil > Date.now()) {
     const retryAt = gateUntil
     // Why: paused maps `pausedUntil` into the renderer's auto-retry, so requeue at reset (finding 12) — don't advertise an unscheduled retry.
-    queue.set(key, {
+    const retained = setBoundedQueueEntry({
       key,
       candidate,
       aliases: aliasMap,
@@ -972,6 +1058,16 @@ export async function refreshPRNow(candidate: GitHubPRRefreshCandidate): Promise
       dueAt: retryAt,
       queuedAt: nextQueueOrder()
     })
+    if (!retained) {
+      broadcastCapacitySkip(aliases, 'manual')
+      return {
+        kind: 'upstream-error',
+        errorType: 'rate_limited',
+        message: 'GitHub is temporarily limiting requests. Try again after the limit resets.',
+        fetchedAt: Date.now(),
+        retryDisabledUntil: retryAt
+      }
+    }
     broadcast({
       aliases,
       reason: 'manual',

--- a/src/main/github/pr-refresh-memory-bounds.test.ts
+++ b/src/main/github/pr-refresh-memory-bounds.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubPRRefreshAlias, GitHubPRRefreshCandidate } from '../../shared/types'
+import {
+  boundedVisiblePRRefreshCandidates,
+  PR_REFRESH_ALIAS_LIMIT,
+  PR_REFRESH_RETRY_STATE_LIMIT,
+  retainPRRefreshAlias,
+  retainPRRefreshState
+} from './pr-refresh-memory-bounds'
+import { PR_REFRESH_VISIBLE_CANDIDATE_LIMIT } from '../../shared/pr-refresh-memory-limits'
+
+function alias(index: number): GitHubPRRefreshAlias {
+  return {
+    cacheKey: `cache-${index}`,
+    repoId: 'repo-1',
+    repoPath: '/repo',
+    branch: `feature-${index}`,
+    worktreeId: `worktree-${index}`,
+    connectionId: null,
+    currentHeadOid: null,
+    linkedPRNumber: 42,
+    fallbackPRNumber: null,
+    fallbackPRSource: null
+  }
+}
+
+function candidate(index: number): GitHubPRRefreshCandidate {
+  return {
+    cacheKey: `cache-${index}`,
+    repoId: 'repo-1',
+    repoPath: '/repo',
+    branch: `feature-${index}`,
+    worktreeId: `worktree-${index}`,
+    connectionId: null,
+    currentHeadOid: null,
+    linkedPRNumber: 42,
+    fallbackPRNumber: null,
+    fallbackPRSource: null,
+    repoKind: 'git',
+    cachedFetchedAt: null
+  }
+}
+
+describe('PR refresh memory bounds', () => {
+  it('retains ordinary aliases without changing their identity or order', () => {
+    const aliases = new Map<string, GitHubPRRefreshAlias>()
+
+    expect(retainPRRefreshAlias(aliases, alias(0), 'cache-0')).toBeNull()
+    expect(retainPRRefreshAlias(aliases, alias(1), 'cache-0')).toBeNull()
+
+    expect(Array.from(aliases.keys())).toEqual(['cache-0', 'cache-1'])
+  })
+
+  it('caps aliases while preserving the representative candidate', () => {
+    const aliases = new Map<string, GitHubPRRefreshAlias>()
+    for (let index = 0; index < PR_REFRESH_ALIAS_LIMIT; index += 1) {
+      retainPRRefreshAlias(aliases, alias(index), 'cache-0')
+    }
+
+    const evicted = retainPRRefreshAlias(aliases, alias(PR_REFRESH_ALIAS_LIMIT), 'cache-0')
+
+    expect(aliases).toHaveLength(PR_REFRESH_ALIAS_LIMIT)
+    expect(aliases.has('cache-0')).toBe(true)
+    expect(aliases.has(`cache-${PR_REFRESH_ALIAS_LIMIT}`)).toBe(true)
+    expect(evicted?.cacheKey).toBe('cache-1')
+  })
+
+  it('caps retry state and refreshes existing keys without growing', () => {
+    const states = new Map<number, number>()
+    for (let index = 0; index < PR_REFRESH_RETRY_STATE_LIMIT; index += 1) {
+      retainPRRefreshState(states, index, index, PR_REFRESH_RETRY_STATE_LIMIT)
+    }
+
+    expect(retainPRRefreshState(states, 1, 99, PR_REFRESH_RETRY_STATE_LIMIT)).toBeNull()
+    expect(
+      retainPRRefreshState(states, PR_REFRESH_RETRY_STATE_LIMIT, 1, PR_REFRESH_RETRY_STATE_LIMIT)
+    ).toBe(0)
+    expect(states).toHaveLength(PR_REFRESH_RETRY_STATE_LIMIT)
+    expect(states.get(1)).toBe(99)
+  })
+
+  it('passes ordinary visible candidates through and truncates adversarial batches', () => {
+    const ordinary = [candidate(0), candidate(1)]
+    expect(boundedVisiblePRRefreshCandidates(ordinary)).toBe(ordinary)
+
+    const oversized = Array.from({ length: PR_REFRESH_VISIBLE_CANDIDATE_LIMIT + 1 }, (_, index) =>
+      candidate(index)
+    )
+    expect(boundedVisiblePRRefreshCandidates(oversized)).toHaveLength(
+      PR_REFRESH_VISIBLE_CANDIDATE_LIMIT
+    )
+  })
+})

--- a/src/main/github/pr-refresh-memory-bounds.ts
+++ b/src/main/github/pr-refresh-memory-bounds.ts
@@ -1,0 +1,75 @@
+import type { GitHubPRRefreshAlias, GitHubPRRefreshCandidate } from '../../shared/types'
+import {
+  PR_REFRESH_ALIAS_LIMIT,
+  PR_REFRESH_VISIBLE_CANDIDATE_LIMIT
+} from '../../shared/pr-refresh-memory-limits'
+
+export {
+  PR_REFRESH_ACTIVE_SCOPE_LIMIT,
+  PR_REFRESH_ALIAS_LIMIT,
+  PR_REFRESH_QUEUE_ENTRY_LIMIT,
+  PR_REFRESH_RETRY_STATE_LIMIT,
+  PR_REFRESH_VISIBLE_CANDIDATE_LIMIT
+} from '../../shared/pr-refresh-memory-limits'
+
+export function retainPRRefreshAlias(
+  aliases: Map<string, GitHubPRRefreshAlias>,
+  alias: GitHubPRRefreshAlias,
+  protectedCacheKey: string
+): GitHubPRRefreshAlias | null {
+  if (aliases.has(alias.cacheKey)) {
+    aliases.delete(alias.cacheKey)
+    aliases.set(alias.cacheKey, alias)
+    return null
+  }
+  if (aliases.size < PR_REFRESH_ALIAS_LIMIT) {
+    aliases.set(alias.cacheKey, alias)
+    return null
+  }
+
+  let evictionKey: string | undefined
+  for (const cacheKey of aliases.keys()) {
+    if (cacheKey !== protectedCacheKey) {
+      evictionKey = cacheKey
+      break
+    }
+  }
+  if (evictionKey === undefined) {
+    return alias
+  }
+  const evicted = aliases.get(evictionKey) ?? null
+  aliases.delete(evictionKey)
+  aliases.set(alias.cacheKey, alias)
+  return evicted
+}
+
+export function retainPRRefreshState<K, V>(
+  entries: Map<K, V>,
+  key: K,
+  value: V,
+  limit: number
+): K | null {
+  if (entries.has(key)) {
+    entries.delete(key)
+    entries.set(key, value)
+    return null
+  }
+  let evictedKey: K | null = null
+  if (entries.size >= limit) {
+    const oldest = entries.keys().next()
+    if (!oldest.done) {
+      evictedKey = oldest.value
+      entries.delete(oldest.value)
+    }
+  }
+  entries.set(key, value)
+  return evictedKey
+}
+
+export function boundedVisiblePRRefreshCandidates(
+  candidates: GitHubPRRefreshCandidate[]
+): GitHubPRRefreshCandidate[] {
+  return candidates.length <= PR_REFRESH_VISIBLE_CANDIDATE_LIMIT
+    ? candidates
+    : candidates.slice(0, PR_REFRESH_VISIBLE_CANDIDATE_LIMIT)
+}

--- a/src/main/github/pr-refresh-validation-backoff.ts
+++ b/src/main/github/pr-refresh-validation-backoff.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import { resolve } from 'node:path'
 import { recordCoalescedCrashBreadcrumb } from '../crash-reporting/crash-breadcrumb-store'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 const VALIDATION_BACKOFF_TTL_MS = 5 * 60_000
 const MAX_VALIDATION_BACKOFF_ENTRIES = 256
@@ -35,7 +36,7 @@ const counters: ValidationBackoffCounters = {
 }
 
 function validationIdentityKey(identity: ValidationBackoffIdentity): string {
-  return [identity.repoId ?? '', resolve(identity.repoPath), identity.reason].join('\0')
+  return cacheIdentityDigest([identity.repoId ?? '', resolve(identity.repoPath), identity.reason])
 }
 
 function validationIdentityToken(key: string): string {

--- a/src/main/github/project-view.ts
+++ b/src/main/github/project-view.ts
@@ -52,6 +52,7 @@ import {
   isGitHubProjectRefInputTooLarge
 } from '../../shared/github-project-ref-input'
 import { githubProjectHost } from '../../shared/github-project-identity'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 // Re-export the public API so existing `./project-view` call sites keep working; the split is internal-only.
 export { isValidOwnerSlug, isValidRepoSlug, isValidSlug } from './project-view/internals'
@@ -129,12 +130,11 @@ const parentFieldProbeInFlight = new Map<string, Promise<void>>()
 // host's probe result can't leak into another. Normalize github.com so
 // host-less callers share the same probe state as explicitly pinned calls.
 function ownerScopeKey(owner: string, ownerType: GitHubProjectOwnerType, host?: string): string {
-  const base = `${owner}\u0000${ownerType}`
-  return `${base}\u0000${githubProjectHost(host)}`
+  return cacheIdentityDigest([owner, ownerType, githubProjectHost(host)])
 }
 
 function ownerTypeCacheKey(owner: string, host?: string): string {
-  return `${owner}\u0000${githubProjectHost(host)}`
+  return cacheIdentityDigest([owner, githubProjectHost(host)])
 }
 
 function rememberOwnerType(

--- a/src/main/github/project-view/internals.ts
+++ b/src/main/github/project-view/internals.ts
@@ -68,15 +68,23 @@ export async function projectHostAuthenticationError(
 const OWNER_SLUG_RE = /^[A-Za-z0-9][A-Za-z0-9-]*$/
 const REPO_SLUG_RE = /^[A-Za-z0-9._-]+$/
 const REPO_SLUG_RESERVED = new Set(['.', '..'])
+const OWNER_SLUG_MAX_CHARS = 256
+const REPO_SLUG_MAX_CHARS = 1024
 
 export function isValidOwnerSlug(value: unknown): value is string {
-  return typeof value === 'string' && value.length > 0 && OWNER_SLUG_RE.test(value)
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= OWNER_SLUG_MAX_CHARS &&
+    OWNER_SLUG_RE.test(value)
+  )
 }
 
 export function isValidRepoSlug(value: unknown): value is string {
   return (
     typeof value === 'string' &&
     value.length > 0 &&
+    value.length <= REPO_SLUG_MAX_CHARS &&
     REPO_SLUG_RE.test(value) &&
     !REPO_SLUG_RESERVED.has(value)
   )

--- a/src/main/github/rate-limit.ts
+++ b/src/main/github/rate-limit.ts
@@ -22,6 +22,7 @@ import {
   registerGhRateLimitResetProbe,
   type GhRateLimitBucket
 } from '../git/gh-rate-limit-breaker'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 // Why: GET /rate_limit is exempt from limits, so caching only avoids a gh subprocess per render; 30s stays live while absorbing 1/s polling.
 const RATE_LIMIT_CACHE_TTL_MS = 30_000
@@ -196,15 +197,21 @@ const DEFAULT_BREAKER_SCOPE = ghRateLimitScopeKey('native', 'github.com')
 const scopeRefinementInFlight = new Map<string, Promise<void>>()
 const scopeProbeFailureAtMs = new Map<string, number>()
 const SCOPE_PROBE_FAILURE_MAX_ENTRIES = 512
+const SCOPE_REFINEMENT_MAX_IN_FLIGHT = 16
+
+function scopeRetentionKey(scope: string): string {
+  return cacheIdentityDigest([scope])
+}
 
 function rememberScopeProbeFailure(scope: string, failedAt: number): void {
+  const retentionKey = scopeRetentionKey(scope)
   for (const [key, at] of scopeProbeFailureAtMs) {
     if (failedAt - at >= RATE_LIMIT_CACHE_TTL_MS) {
       scopeProbeFailureAtMs.delete(key)
     }
   }
-  scopeProbeFailureAtMs.delete(scope)
-  scopeProbeFailureAtMs.set(scope, failedAt)
+  scopeProbeFailureAtMs.delete(retentionKey)
+  scopeProbeFailureAtMs.set(retentionKey, failedAt)
   while (scopeProbeFailureAtMs.size > SCOPE_PROBE_FAILURE_MAX_ENTRIES) {
     const oldestKey = scopeProbeFailureAtMs.keys().next().value
     if (oldestKey === undefined) {
@@ -221,14 +228,18 @@ function refineBreakerForScope(scope: string): void {
     return
   }
   const parts = parseGhRateLimitScopeKey(scope)
-  if (!parts || scopeRefinementInFlight.has(scope)) {
+  const retentionKey = scopeRetentionKey(scope)
+  if (!parts || scopeRefinementInFlight.has(retentionKey)) {
     return
   }
   // Why: GHES with rate limiting disabled 404s every probe. Fail open (the
   // fallback block stands) and don't re-probe in a tight loop while the
   // breaker keeps tripping.
-  const failedAt = scopeProbeFailureAtMs.get(scope)
+  const failedAt = scopeProbeFailureAtMs.get(retentionKey)
   if (failedAt !== undefined && Date.now() - failedAt < RATE_LIMIT_CACHE_TTL_MS) {
+    return
+  }
+  if (scopeRefinementInFlight.size >= SCOPE_REFINEMENT_MAX_IN_FLIGHT) {
     return
   }
   const probe = (async () => {
@@ -243,7 +254,7 @@ function refineBreakerForScope(scope: string): void {
           ...(parts.runtime === 'wsl' ? { wslDistro: parts.wslDistro } : {})
         })
         const parsed = JSON.parse(stdout) as GhRateLimitPayload
-        scopeProbeFailureAtMs.delete(scope)
+        scopeProbeFailureAtMs.delete(retentionKey)
         // Why: mirrors the default-scope refinement, but records into the
         // per-scope breaker only — the shared snapshot must keep describing
         // native github.com exclusively.
@@ -263,10 +274,10 @@ function refineBreakerForScope(scope: string): void {
       // negative cache so repeated failing hosts cannot accumulate forever.
       rememberScopeProbeFailure(scope, Date.now())
     } finally {
-      scopeRefinementInFlight.delete(scope)
+      scopeRefinementInFlight.delete(retentionKey)
     }
   })()
-  scopeRefinementInFlight.set(scope, probe)
+  scopeRefinementInFlight.set(retentionKey, probe)
 }
 
 registerGhRateLimitResetProbe((_bucket, scope) => refineBreakerForScope(scope))

--- a/src/main/github/tracked-upstream-snapshot-bounds.test.ts
+++ b/src/main/github/tracked-upstream-snapshot-bounds.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  _parseTrackedUpstreamBranchesForTests,
+  TRACKED_UPSTREAM_SNAPSHOT_MAX_BRANCHES,
+  TRACKED_UPSTREAM_SNAPSHOT_MAX_BYTES
+} from './client'
+
+describe('tracked upstream snapshot bounds', () => {
+  it('caps branch count while preserving the currently requested branch', () => {
+    const requested = `branch-${TRACKED_UPSTREAM_SNAPSHOT_MAX_BRANCHES}`
+    const stdout = Array.from(
+      { length: TRACKED_UPSTREAM_SNAPSHOT_MAX_BRANCHES + 1 },
+      (_, index) => `refs/heads/branch-${index}\0refs/remotes/origin/branch-${index}\n`
+    ).join('')
+
+    const parsed = _parseTrackedUpstreamBranchesForTests(stdout, requested)
+    expect(parsed.size).toBe(TRACKED_UPSTREAM_SNAPSHOT_MAX_BRANCHES)
+    expect(parsed.get(requested)).toEqual({
+      remoteName: 'origin',
+      branchName: requested
+    })
+    expect(parsed.has('branch-0')).toBe(false)
+  })
+
+  it('skips an individual branch that cannot fit the byte budget', () => {
+    const oversized = 'x'.repeat(TRACKED_UPSTREAM_SNAPSHOT_MAX_BYTES + 1)
+    const parsed = _parseTrackedUpstreamBranchesForTests(
+      `refs/heads/${oversized}\0refs/remotes/origin/main\n`,
+      oversized
+    )
+    expect(parsed.size).toBe(0)
+  })
+})

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -55,6 +55,7 @@ import {
   closeMR,
   diagnoseAuth,
   getRateLimit,
+  GITLAB_RATE_LIMIT_CACHE_HOST_MAX_BYTES,
   listMergeRequests,
   listWorkItems,
   mergeMR,
@@ -338,6 +339,15 @@ describe('gitlab client — MR operations', () => {
       }
 
       expect(_getGitLabRateLimitCacheSize()).toBe(64)
+    })
+
+    it('does not retain an oversized host snapshot', async () => {
+      glabApiWithHeadersMock.mockResolvedValue({ body: '{}', headers: {} })
+      await getRateLimit({
+        host: 'h'.repeat(GITLAB_RATE_LIMIT_CACHE_HOST_MAX_BYTES + 1),
+        force: true
+      })
+      expect(_getGitLabRateLimitCacheSize()).toBe(0)
     })
   })
 

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -46,6 +46,8 @@ import {
   type HostedReviewExecutionOptions
 } from '../source-control/hosted-review-git-options'
 import { shouldHideNonOpenReviewOnDefaultBranch } from '../source-control/repo-default-branch'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import { cacheIdentityDigest } from '../cache-identity-digest'
 
 // Why: glab REST addresses projects by URL-encoded path; escapes slashes for nested groups.
 function encodedProject(projectPath: string): string {
@@ -54,6 +56,7 @@ function encodedProject(projectPath: string): string {
 
 const GITLAB_RATE_LIMIT_CACHE_TTL_MS = 30_000
 const GITLAB_RATE_LIMIT_CACHE_MAX_ENTRIES = 64
+export const GITLAB_RATE_LIMIT_CACHE_HOST_MAX_BYTES = 1024
 const gitLabRateLimitCache = new Map<string, GitLabRateLimitSnapshot>()
 
 type HostedReviewLocalGitOptions = ReturnType<typeof getHostedReviewLocalGitOptions>
@@ -210,9 +213,14 @@ export async function getRateLimit(options?: {
   host?: string | null
 }): Promise<GetGitLabRateLimitResult> {
   const host = options?.host?.trim() || null
-  const cacheKey = host ?? 'default'
+  const retainableHost =
+    host === null ||
+    !measureUtf8ByteLength(host, {
+      stopAfterBytes: GITLAB_RATE_LIMIT_CACHE_HOST_MAX_BYTES
+    }).exceededLimit
+  const cacheKey = cacheIdentityDigest([host ?? 'default'])
   pruneGitLabRateLimitCache()
-  const cached = gitLabRateLimitCache.get(cacheKey)
+  const cached = retainableHost ? gitLabRateLimitCache.get(cacheKey) : undefined
   if (!options?.force && cached && Date.now() - cached.fetchedAt < GITLAB_RATE_LIMIT_CACHE_TTL_MS) {
     return { ok: true, snapshot: cached }
   }
@@ -223,7 +231,9 @@ export async function getRateLimit(options?: {
     const args = host ? ['--hostname', host, 'user'] : ['user']
     const { headers } = await glabApiWithHeaders(args)
     const snapshot = parseGitLabRateLimitSnapshot(headers, host)
-    rememberGitLabRateLimitSnapshot(cacheKey, snapshot)
+    if (retainableHost) {
+      rememberGitLabRateLimitSnapshot(cacheKey, snapshot)
+    }
     return { ok: true, snapshot }
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)

--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -7,24 +7,160 @@ export type LocalGitExecOptions = {
 }
 
 const GLAB_KNOWN_HOSTS_TIMEOUT_MS = 10_000
-const knownHostsCacheByExecutionContext = new Map<string, readonly string[]>()
+export const GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES = 1024 * 1024
+export const GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES = 64
+export const GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES = 4 * 1024
+export const GLAB_KNOWN_HOSTS_CONTEXT_KEYS_MAX_BYTES = 128 * 1024
+export const GLAB_KNOWN_HOSTS_MAX_ENTRIES = 64
+export const GLAB_KNOWN_HOST_MAX_BYTES = 1024
+export const GLAB_KNOWN_HOSTS_MAX_BYTES = 32 * 1024
+export const GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT = 16
+
+type KnownHostsCacheEntry = {
+  hosts: readonly string[]
+  keyBytes: number
+}
+
+type KnownHostRetention = {
+  hosts: string[]
+  retainedBytes: number
+  protectedEntries: number
+}
+
+const knownHostsCacheByExecutionContext = new Map<string, KnownHostsCacheEntry>()
 const knownHostsInFlightByExecutionContext = new Map<string, Promise<readonly string[]>>()
+let knownHostsCachedContextKeyBytes = 0
+
+function utf8Bytes(value: string): number {
+  return Buffer.byteLength(value, 'utf8')
+}
 
 function knownHostsExecutionKey(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
-): string {
+): string | null {
+  let key: string
   if (connectionId) {
+    if (utf8Bytes(connectionId) > GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES) {
+      return null
+    }
     // Why: reconnecting can replace the SSH/relay execution host under the same id.
-    return `connection:${connectionId}:${getSshGitProviderGeneration(connectionId)}`
+    key = `connection:${connectionId}:${getSshGitProviderGeneration(connectionId)}`
+  } else if (localGitOptions.wslDistro) {
+    if (utf8Bytes(localGitOptions.wslDistro) > GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES) {
+      return null
+    }
+    key = `wsl:${localGitOptions.wslDistro}`
+  } else {
+    key = 'native'
   }
-  return localGitOptions.wslDistro ? `wsl:${localGitOptions.wslDistro}` : 'native'
+  return utf8Bytes(key) <= GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES ? key : null
+}
+
+function deleteCachedContext(key: string): void {
+  const cached = knownHostsCacheByExecutionContext.get(key)
+  if (!cached) {
+    return
+  }
+  knownHostsCachedContextKeyBytes -= cached.keyBytes
+  knownHostsCacheByExecutionContext.delete(key)
+}
+
+function getCachedHosts(key: string): readonly string[] | undefined {
+  const cached = knownHostsCacheByExecutionContext.get(key)
+  if (!cached) {
+    return undefined
+  }
+  knownHostsCacheByExecutionContext.delete(key)
+  knownHostsCacheByExecutionContext.set(key, cached)
+  return cached.hosts
+}
+
+function createKnownHostRetention(includeDefaults: boolean): KnownHostRetention {
+  const hosts = includeDefaults ? [...DEFAULT_GITLAB_HOSTS] : []
+  return {
+    hosts,
+    retainedBytes: hosts.reduce((total, host) => total + utf8Bytes(host), 0),
+    protectedEntries: hosts.length
+  }
+}
+
+function retainKnownHost(retention: KnownHostRetention, host: string): void {
+  if (utf8Bytes(host) > GLAB_KNOWN_HOST_MAX_BYTES) {
+    return
+  }
+  const normalized = normalizeGitLabHost(host)
+  const hostBytes = utf8Bytes(normalized)
+  if (
+    hostBytes === 0 ||
+    hostBytes > GLAB_KNOWN_HOST_MAX_BYTES ||
+    retention.hosts.includes(normalized)
+  ) {
+    return
+  }
+  while (
+    retention.hosts.length > retention.protectedEntries &&
+    (retention.hosts.length >= GLAB_KNOWN_HOSTS_MAX_ENTRIES ||
+      retention.retainedBytes + hostBytes > GLAB_KNOWN_HOSTS_MAX_BYTES)
+  ) {
+    const removed = retention.hosts.splice(retention.protectedEntries, 1)[0]
+    retention.retainedBytes -= utf8Bytes(removed)
+  }
+  if (
+    retention.hosts.length >= GLAB_KNOWN_HOSTS_MAX_ENTRIES ||
+    retention.retainedBytes + hostBytes > GLAB_KNOWN_HOSTS_MAX_BYTES
+  ) {
+    return
+  }
+  retention.hosts.push(normalized)
+  retention.retainedBytes += hostBytes
+}
+
+function retainKnownHosts(hosts: Iterable<string>): readonly string[] {
+  const retention = createKnownHostRetention(true)
+  for (const host of hosts) {
+    retainKnownHost(retention, host)
+  }
+  return retention.hosts
+}
+
+function cacheKnownHosts(key: string, hosts: Iterable<string>): readonly string[] {
+  const retained = retainKnownHosts(hosts)
+  const keyBytes = utf8Bytes(key)
+  deleteCachedContext(key)
+  while (
+    knownHostsCacheByExecutionContext.size >= GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES ||
+    knownHostsCachedContextKeyBytes + keyBytes > GLAB_KNOWN_HOSTS_CONTEXT_KEYS_MAX_BYTES
+  ) {
+    const oldestKey = knownHostsCacheByExecutionContext.keys().next().value
+    if (oldestKey === undefined) {
+      break
+    }
+    deleteCachedContext(oldestKey)
+  }
+  knownHostsCacheByExecutionContext.set(key, { hosts: retained, keyBytes })
+  knownHostsCachedContextKeyBytes += keyBytes
+  return retained
 }
 
 /** @internal - exposed for tests only */
 export function _resetKnownHostsCache(): void {
   knownHostsCacheByExecutionContext.clear()
   knownHostsInFlightByExecutionContext.clear()
+  knownHostsCachedContextKeyBytes = 0
+}
+
+/** @internal - exposed for tests only */
+export function _getKnownHostsCacheState(): {
+  cachedContexts: number
+  cachedContextKeyBytes: number
+  inFlightContexts: number
+} {
+  return {
+    cachedContexts: knownHostsCacheByExecutionContext.size,
+    cachedContextKeyBytes: knownHostsCachedContextKeyBytes,
+    inFlightContexts: knownHostsInFlightByExecutionContext.size
+  }
 }
 
 export function rememberGlabKnownHost(
@@ -32,13 +168,19 @@ export function rememberGlabKnownHost(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): void {
-  const normalizedHost = normalizeGitLabHost(host)
   const key = knownHostsExecutionKey(connectionId, localGitOptions)
-  const cached = knownHostsCacheByExecutionContext.get(key)
-  if (!cached || cached.map(normalizeGitLabHost).includes(normalizedHost)) {
+  if (!key || utf8Bytes(host) > GLAB_KNOWN_HOST_MAX_BYTES) {
     return
   }
-  knownHostsCacheByExecutionContext.set(key, [...cached, normalizedHost])
+  const normalizedHost = normalizeGitLabHost(host)
+  if (utf8Bytes(normalizedHost) > GLAB_KNOWN_HOST_MAX_BYTES) {
+    return
+  }
+  const cached = getCachedHosts(key)
+  if (!cached || cached.includes(normalizedHost)) {
+    return
+  }
+  cacheKnownHosts(key, [...cached, normalizedHost])
 }
 
 export async function getGlabKnownHosts(
@@ -46,13 +188,19 @@ export async function getGlabKnownHosts(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<readonly string[]> {
   const key = knownHostsExecutionKey(connectionId, localGitOptions)
-  const cached = knownHostsCacheByExecutionContext.get(key)
+  if (!key) {
+    return [...DEFAULT_GITLAB_HOSTS]
+  }
+  const cached = getCachedHosts(key)
   if (cached) {
     return cached
   }
   const inFlight = knownHostsInFlightByExecutionContext.get(key)
   if (inFlight) {
     return inFlight
+  }
+  if (knownHostsInFlightByExecutionContext.size >= GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT) {
+    return [...DEFAULT_GITLAB_HOSTS]
   }
   const probe = probeGlabKnownHosts(key, connectionId, localGitOptions)
   knownHostsInFlightByExecutionContext.set(key, probe)
@@ -75,14 +223,13 @@ async function probeGlabKnownHosts(
     // or reconnected SSH/relay results, and bound an otherwise global probe.
     const { stdout, stderr } = await glabExecFileAsync(['auth', 'status'], {
       timeout: GLAB_KNOWN_HOSTS_TIMEOUT_MS,
+      maxBuffer: GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES,
       ...(!connectionId && localGitOptions.wslDistro
         ? { wslDistro: localGitOptions.wslDistro }
         : {})
     })
     const hosts = parseGlabAuthStatusHosts(`${stdout}\n${stderr}`)
-    const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...hosts]))
-    knownHostsCacheByExecutionContext.set(key, merged)
-    return merged
+    return cacheKnownHosts(key, hosts)
   } catch {
     // Keep failures uncached so auth or tunnel recovery is discovered later.
     return [...DEFAULT_GITLAB_HOSTS]
@@ -90,11 +237,11 @@ async function probeGlabKnownHosts(
 }
 
 export function parseGlabAuthStatusHosts(output: string): string[] {
-  const hosts = new Set<string>()
+  const retention = createKnownHostRetention(false)
   // Why: self-hosted GitLab can run on a non-default port; preserve it so
   // services on the same hostname remain distinct downstream.
   for (const match of output.matchAll(/logged in to ([a-zA-Z0-9.-]+(?::\d+)?)/gi)) {
-    hosts.add(match[1].toLowerCase())
+    retainKnownHost(retention, match[1].toLowerCase())
   }
   for (const line of output.split('\n')) {
     const bareLine = line.trim()
@@ -103,8 +250,8 @@ export function parseGlabAuthStatusHosts(output: string): string[] {
       line === bareLine &&
       /^[a-zA-Z0-9](?:[a-zA-Z0-9.-]*[a-zA-Z0-9])?(?::\d+)?$/.test(hostLine)
     ) {
-      hosts.add(hostLine.toLowerCase())
+      retainKnownHost(retention, hostLine.toLowerCase())
     }
   }
-  return Array.from(hosts)
+  return retention.hosts
 }

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -3,6 +3,10 @@ import type { IssueSourcePreference } from '../../shared/types'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import { clearProjectRefInFlight, runProjectRefProbeOnce } from './project-ref-inflight'
 import {
+  buildRepositoryRefCacheKey,
+  RepositoryRefCache
+} from '../source-control/repository-ref-cache'
+import {
   parseGlabAuthStatusHosts,
   rememberGlabKnownHost,
   type LocalGitExecOptions
@@ -18,14 +22,23 @@ import {
 export { DEFAULT_GITLAB_HOSTS, parseGitLabProjectRef }
 export type { ProjectRef }
 export {
+  GLAB_KNOWN_HOST_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_KEYS_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES,
+  GLAB_KNOWN_HOSTS_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_MAX_ENTRIES,
+  GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT,
+  GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES,
+  _getKnownHostsCacheState,
   _resetKnownHostsCache,
   getGlabKnownHosts,
-  parseGlabAuthStatusHosts
+  parseGlabAuthStatusHosts,
+  rememberGlabKnownHost
 } from './gitlab-known-host-probe'
 export type { LocalGitExecOptions } from './gitlab-known-host-probe'
 
-const PROJECT_REF_CACHE_MAX_ENTRIES = 512
-const projectRefCache = new Map<string, ProjectRef | null>()
+const projectRefCache = new RepositoryRefCache<ProjectRef>()
 
 /** @internal - exposed for tests only */
 export function _resetProjectRefCache(): void {
@@ -38,17 +51,6 @@ export function _getProjectRefCacheSize(): number {
   return projectRefCache.size
 }
 
-function rememberProjectRefCacheEntry(cacheKey: string, value: ProjectRef | null): void {
-  projectRefCache.set(cacheKey, value)
-  while (projectRefCache.size > PROJECT_REF_CACHE_MAX_ENTRIES) {
-    const oldestKey = projectRefCache.keys().next().value
-    if (oldestKey === undefined) {
-      return
-    }
-    projectRefCache.delete(oldestKey)
-  }
-}
-
 export async function getProjectRefForRemote(
   repoPath: string,
   remoteName: string,
@@ -57,12 +59,13 @@ export async function getProjectRefForRemote(
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<ProjectRef | null> {
   const runtimeKey = connectionId ?? `local:${localGitOptions.wslDistro ?? 'host'}`
-  const cacheKey = `${runtimeKey}\0${repoPath}\0${remoteName}\0${knownHosts.join(',')}`
-  if (projectRefCache.has(cacheKey)) {
-    return projectRefCache.get(cacheKey)!
+  const cacheKey = buildRepositoryRefCacheKey([runtimeKey, repoPath, remoteName, ...knownHosts])
+  const cached = projectRefCache.get(cacheKey)
+  if (cached.found) {
+    return cached.value
   }
 
-  return runProjectRefProbeOnce(cacheKey, () =>
+  const probe = () =>
     resolveProjectRefForRemote(
       repoPath,
       remoteName,
@@ -71,7 +74,7 @@ export async function getProjectRefForRemote(
       cacheKey,
       localGitOptions
     )
-  )
+  return cacheKey === null ? probe() : runProjectRefProbeOnce(cacheKey, probe)
 }
 
 async function resolveProjectRefForRemote(
@@ -79,7 +82,7 @@ async function resolveProjectRefForRemote(
   remoteName: string,
   knownHosts: readonly string[],
   connectionId: string | null | undefined,
-  cacheKey: string,
+  cacheKey: string | null,
   localGitOptions: LocalGitExecOptions
 ): Promise<ProjectRef | null> {
   try {
@@ -95,7 +98,7 @@ async function resolveProjectRefForRemote(
         })
     const result = parseGitLabProjectRef(stdout, knownHosts)
     if (result) {
-      rememberProjectRefCacheEntry(cacheKey, result)
+      projectRefCache.remember(cacheKey, result, [result.host, result.path])
       return result
     }
     const remoteCandidate = parseRemoteProjectRefCandidate(stdout)
@@ -109,7 +112,10 @@ async function resolveProjectRefForRemote(
       ))
     ) {
       rememberGlabKnownHost(remoteCandidate.host, connectionId, localGitOptions)
-      rememberProjectRefCacheEntry(cacheKey, remoteCandidate)
+      projectRefCache.remember(cacheKey, remoteCandidate, [
+        remoteCandidate.host,
+        remoteCandidate.path
+      ])
       return remoteCandidate
     }
   } catch {
@@ -117,7 +123,7 @@ async function resolveProjectRefForRemote(
       return null
     }
   }
-  rememberProjectRefCacheEntry(cacheKey, null)
+  projectRefCache.remember(cacheKey, null, [])
   return null
 }
 

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -12,6 +12,15 @@ vi.mock('../git/runner', () => ({
 }))
 
 import {
+  GLAB_KNOWN_HOST_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_KEYS_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES,
+  GLAB_KNOWN_HOSTS_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_MAX_ENTRIES,
+  GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT,
+  GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES,
+  _getKnownHostsCacheState,
   _getProjectRefCacheSize,
   _resetKnownHostsCache,
   _resetProjectRefCache,
@@ -23,6 +32,7 @@ import {
   getProjectRefForRemote,
   parseGlabApiResponse,
   parseGlabAuthStatusHosts,
+  rememberGlabKnownHost,
   resolveIssueSource
 } from './gl-utils'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
@@ -434,7 +444,10 @@ describe('getGlabKnownHosts', () => {
     })
 
     await expect(getGlabKnownHosts()).resolves.toEqual(['gitlab.com', 'gitlab.example.com'])
-    expect(glabExecFileAsyncMock).toHaveBeenCalledWith(['auth', 'status'], { timeout: 10_000 })
+    expect(glabExecFileAsyncMock).toHaveBeenCalledWith(['auth', 'status'], {
+      timeout: 10_000,
+      maxBuffer: GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES
+    })
   })
 
   it('falls back to default when glab auth status fails', async () => {
@@ -495,10 +508,12 @@ describe('getGlabKnownHosts', () => {
     expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(4)
     expect(glabExecFileAsyncMock).toHaveBeenNthCalledWith(1, ['auth', 'status'], {
       timeout: 10_000,
+      maxBuffer: GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES,
       wslDistro: 'Ubuntu'
     })
     expect(glabExecFileAsyncMock).toHaveBeenNthCalledWith(2, ['auth', 'status'], {
       timeout: 10_000,
+      maxBuffer: GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES,
       wslDistro: 'Debian'
     })
   })
@@ -596,5 +611,145 @@ describe('getGlabKnownHosts', () => {
     ])
     expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(2)
     unregisterSshGitProvider(connectionId)
+  })
+
+  it('keeps the most recently used execution contexts at the cache limit', async () => {
+    glabExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+
+    for (let index = 0; index < GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES; index += 1) {
+      await getGlabKnownHosts(undefined, { wslDistro: `Distro-${index}` })
+    }
+    expect(_getKnownHostsCacheState().cachedContexts).toBe(GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES)
+
+    await getGlabKnownHosts(undefined, { wslDistro: 'Distro-0' })
+    await getGlabKnownHosts(undefined, { wslDistro: 'Distro-overflow' })
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES + 1)
+
+    await getGlabKnownHosts(undefined, { wslDistro: 'Distro-1' })
+    await getGlabKnownHosts(undefined, { wslDistro: 'Distro-0' })
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES + 2)
+  })
+
+  it('accepts an exact-limit execution key and skips an oversized context', async () => {
+    glabExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    const prefixBytes = Buffer.byteLength('wsl:', 'utf8')
+    const exactDistro = 'x'.repeat(GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES - prefixBytes)
+
+    await expect(getGlabKnownHosts(undefined, { wslDistro: exactDistro })).resolves.toEqual([
+      'gitlab.com'
+    ])
+    expect(_getKnownHostsCacheState().cachedContextKeyBytes).toBe(
+      GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES
+    )
+
+    await expect(getGlabKnownHosts(undefined, { wslDistro: `${exactDistro}x` })).resolves.toEqual([
+      'gitlab.com'
+    ])
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('evicts old large context keys at the aggregate byte limit', async () => {
+    glabExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    const prefixBytes = Buffer.byteLength('wsl:', 'utf8')
+    const retainedContexts =
+      GLAB_KNOWN_HOSTS_CONTEXT_KEYS_MAX_BYTES / GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES
+    const distroAt = (index: number): string => {
+      const suffix = String(index).padStart(3, '0')
+      return `${'x'.repeat(GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES - prefixBytes - suffix.length)}${suffix}`
+    }
+
+    for (let index = 0; index <= retainedContexts; index += 1) {
+      await getGlabKnownHosts(undefined, { wslDistro: distroAt(index) })
+    }
+    expect(_getKnownHostsCacheState()).toMatchObject({
+      cachedContexts: retainedContexts,
+      cachedContextKeyBytes: GLAB_KNOWN_HOSTS_CONTEXT_KEYS_MAX_BYTES
+    })
+
+    await getGlabKnownHosts(undefined, { wslDistro: distroAt(0) })
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(retainedContexts + 2)
+  })
+
+  it('bounds parsed hosts while retaining the newest values', () => {
+    const hosts = Array.from(
+      { length: GLAB_KNOWN_HOSTS_MAX_ENTRIES + 6 },
+      (_, index) => `gitlab-${index}.example.com`
+    )
+
+    expect(parseGlabAuthStatusHosts(hosts.join('\n'))).toEqual(
+      hosts.slice(-GLAB_KNOWN_HOSTS_MAX_ENTRIES)
+    )
+  })
+
+  it('preserves gitlab.com and the newest remembered hosts at the count limit', async () => {
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await getGlabKnownHosts()
+    const customHosts = Array.from(
+      { length: GLAB_KNOWN_HOSTS_MAX_ENTRIES + 6 },
+      (_, index) => `gitlab-${index}.example.com`
+    )
+    for (const host of customHosts) {
+      rememberGlabKnownHost(host)
+    }
+
+    await expect(getGlabKnownHosts()).resolves.toEqual([
+      'gitlab.com',
+      ...customHosts.slice(-(GLAB_KNOWN_HOSTS_MAX_ENTRIES - 1))
+    ])
+  })
+
+  it('accepts an exact-limit host and ignores an oversized host', async () => {
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await getGlabKnownHosts()
+    const exactHost = `${'x'.repeat(GLAB_KNOWN_HOST_MAX_BYTES - 5)}.test`
+    const oversizedHost = `${exactHost}x`
+
+    rememberGlabKnownHost(exactHost)
+    rememberGlabKnownHost(oversizedHost)
+
+    await expect(getGlabKnownHosts()).resolves.toEqual(['gitlab.com', exactHost])
+  })
+
+  it('bounds aggregate retained host bytes and keeps newest values', async () => {
+    glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '', stderr: '' })
+    await getGlabKnownHosts()
+    const customHosts = Array.from({ length: 40 }, (_, index) => {
+      const prefix = String(index).padStart(2, '0')
+      return `${prefix}${'x'.repeat(GLAB_KNOWN_HOST_MAX_BYTES - prefix.length)}`
+    })
+    for (const host of customHosts) {
+      rememberGlabKnownHost(host)
+    }
+
+    const retained = await getGlabKnownHosts()
+    expect(retained).toEqual(['gitlab.com', ...customHosts.slice(-31)])
+    expect(
+      retained.reduce((total, host) => total + Buffer.byteLength(host), 0)
+    ).toBeLessThanOrEqual(GLAB_KNOWN_HOSTS_MAX_BYTES)
+  })
+
+  it('caps distinct in-flight probes and recovers capacity after settlement', async () => {
+    const resolvers: ((value: { stdout: string; stderr: string }) => void)[] = []
+    glabExecFileAsyncMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve)
+        })
+    )
+    const probes = Array.from({ length: GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT }, (_, index) =>
+      getGlabKnownHosts(undefined, { wslDistro: `Distro-${index}` })
+    )
+
+    expect(_getKnownHostsCacheState().inFlightContexts).toBe(GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT)
+    await expect(getGlabKnownHosts(undefined, { wslDistro: 'Distro-overflow' })).resolves.toEqual([
+      'gitlab.com'
+    ])
+    expect(glabExecFileAsyncMock).toHaveBeenCalledTimes(GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT)
+
+    for (const resolve of resolvers) {
+      resolve({ stdout: '', stderr: '' })
+    }
+    await Promise.all(probes)
+    expect(_getKnownHostsCacheState().inFlightContexts).toBe(0)
   })
 })

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { gitExecFileAsync, glabExecFileAsync } from '../git/runner'
 import { parseGlabApiResponse, type GlabApiResponse } from './glab-api-response'
+import { IntegrationApiConcurrencyGate } from '../integration-api-concurrency'
 
 // Why: legacy generic execFile wrapper - only used by callers that don't need
 // WSL-aware routing. Repo-scoped callers should use the runner exports below.
@@ -10,6 +11,15 @@ export { glabExecFileAsync, gitExecFileAsync }
 export { classifyGlabError, classifyListIssuesError } from './glab-error-classification'
 export {
   DEFAULT_GITLAB_HOSTS,
+  GLAB_KNOWN_HOST_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_KEYS_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_KEY_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_CONTEXT_MAX_ENTRIES,
+  GLAB_KNOWN_HOSTS_MAX_BYTES,
+  GLAB_KNOWN_HOSTS_MAX_ENTRIES,
+  GLAB_KNOWN_HOSTS_MAX_IN_FLIGHT,
+  GLAB_KNOWN_HOSTS_OUTPUT_MAX_BYTES,
+  _getKnownHostsCacheState,
   _getProjectRefCacheSize,
   _resetKnownHostsCache,
   _resetProjectRefCache,
@@ -21,6 +31,7 @@ export {
   glabRepoExecOptions,
   parseGlabAuthStatusHosts,
   parseGitLabProjectRef,
+  rememberGlabKnownHost,
   resolveIssueSource
 } from './gitlab-project-ref-resolution'
 export type {
@@ -31,28 +42,14 @@ export type {
 export { parseGlabApiResponse, type GlabApiResponse } from './glab-api-response'
 
 const MAX_CONCURRENT = 4
-let running = 0
-const queue: (() => void)[] = []
+const concurrencyGate = new IntegrationApiConcurrencyGate(MAX_CONCURRENT)
 
 export function acquire(): Promise<void> {
-  if (running < MAX_CONCURRENT) {
-    running += 1
-    return Promise.resolve()
-  }
-  return new Promise((resolve) =>
-    queue.push(() => {
-      running += 1
-      resolve()
-    })
-  )
+  return concurrencyGate.acquire()
 }
 
 export function release(): void {
-  running -= 1
-  const next = queue.shift()
-  if (next) {
-    next()
-  }
+  concurrencyGate.release()
 }
 
 export async function glabApiWithHeaders(

--- a/src/main/gitlab/merge-request-creation.ts
+++ b/src/main/gitlab/merge-request-creation.ts
@@ -1,12 +1,8 @@
-import { readFile } from 'node:fs/promises'
-import { join } from 'node:path'
 import type { CreateHostedReviewInput, CreateHostedReviewResult } from '../../shared/hosted-review'
 import {
   normalizeHostedReviewBaseRef,
   normalizeHostedReviewHeadRef
 } from '../../shared/hosted-review-refs'
-import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
-import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
 import {
   getHostedReviewLocalGitOptions,
   hasHostedReviewLocalGitOptions,
@@ -21,6 +17,7 @@ import {
   release
 } from './gl-utils'
 import { findOpenMRByHeadBase, parseMergeRequestPayload } from './merge-request-creation-lookup'
+import { readGitLabMergeRequestTemplate } from '../source-control/pull-request-template'
 
 function execErrorMessage(error: unknown): string {
   if (error instanceof Error) {
@@ -88,39 +85,6 @@ function hostedReviewExecutionOptionArgs(
   return hasHostedReviewLocalGitOptions(options) ? [options] : []
 }
 
-async function readMergeRequestTemplate(
-  repoPath: string,
-  connectionId?: string | null
-): Promise<string> {
-  const relativeCandidates = [
-    '.gitlab/merge_request_templates/Default.md',
-    '.gitlab/merge_request_templates/default.md',
-    '.gitlab/merge_request_template.md',
-    '.gitlab/MERGE_REQUEST_TEMPLATE.md'
-  ]
-  const remoteProvider = connectionId ? getSshFilesystemProvider(connectionId) : undefined
-  if (connectionId && !remoteProvider) {
-    return ''
-  }
-  for (const relativeCandidate of relativeCandidates) {
-    try {
-      if (remoteProvider) {
-        const result = await remoteProvider.readFile(
-          joinWorktreeRelativePath(repoPath, relativeCandidate)
-        )
-        if (result.isBinary) {
-          continue
-        }
-        return result.content
-      }
-      return await readFile(join(repoPath, relativeCandidate), 'utf8')
-    } catch {
-      // Try the next conventional GitLab merge-request template path.
-    }
-  }
-  return ''
-}
-
 export async function createGitLabMergeRequest(
   repoPath: string,
   input: CreateHostedReviewInput,
@@ -170,7 +134,7 @@ export async function createGitLabMergeRequest(
   try {
     const body =
       input.useTemplate && !input.body?.trim()
-        ? await readMergeRequestTemplate(repoPath, connectionId)
+        ? await readGitLabMergeRequestTemplate(repoPath, connectionId)
         : (input.body ?? '')
     const createArgs = [
       'mr',

--- a/src/main/gitlab/project-ref-inflight.test.ts
+++ b/src/main/gitlab/project-ref-inflight.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearProjectRefInFlight,
+  PROJECT_REF_MAX_IN_FLIGHT,
+  runProjectRefProbeOnce
+} from './project-ref-inflight'
+
+describe('GitLab project-ref in-flight probes', () => {
+  it('caps retained probes and recovers coalescing after settlement', async () => {
+    clearProjectRefInFlight()
+    const releases: (() => void)[] = []
+    const probes = Array.from({ length: PROJECT_REF_MAX_IN_FLIGHT }, (_, index) =>
+      runProjectRefProbeOnce(
+        `key-${index}`,
+        () =>
+          new Promise((resolve) => {
+            releases.push(() => resolve(null))
+          })
+      )
+    )
+    let overflowCalls = 0
+    await expect(
+      runProjectRefProbeOnce('overflow', async () => {
+        overflowCalls += 1
+        return null
+      })
+    ).resolves.toBeNull()
+    await expect(
+      runProjectRefProbeOnce('overflow', async () => {
+        overflowCalls += 1
+        return null
+      })
+    ).resolves.toBeNull()
+    expect(overflowCalls).toBe(2)
+
+    releases.forEach((release) => release())
+    await Promise.all(probes)
+
+    let retainedCalls = 0
+    const first = runProjectRefProbeOnce('recovered', async () => {
+      retainedCalls += 1
+      return null
+    })
+    const second = runProjectRefProbeOnce('recovered', async () => {
+      retainedCalls += 1
+      return null
+    })
+    await Promise.all([first, second])
+    expect(retainedCalls).toBe(1)
+  })
+})

--- a/src/main/gitlab/project-ref-inflight.ts
+++ b/src/main/gitlab/project-ref-inflight.ts
@@ -1,6 +1,7 @@
 import type { ProjectRef } from './gl-utils'
 
 const projectRefInFlight = new Map<string, Promise<ProjectRef | null>>()
+export const PROJECT_REF_MAX_IN_FLIGHT = 32
 
 export function clearProjectRefInFlight(): void {
   projectRefInFlight.clear()
@@ -13,6 +14,9 @@ export async function runProjectRefProbeOnce(
   const inFlight = projectRefInFlight.get(cacheKey)
   if (inFlight) {
     return inFlight
+  }
+  if (projectRefInFlight.size >= PROJECT_REF_MAX_IN_FLIGHT) {
+    return createProbe()
   }
   const probe = createProbe()
   projectRefInFlight.set(cacheKey, probe)

--- a/src/main/integration-account-persistence-limits.test.ts
+++ b/src/main/integration-account-persistence-limits.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertIntegrationAccountCount,
+  assertIntegrationCredentialBytes,
+  assertIntegrationStringBytes,
+  MAX_INTEGRATION_ACCOUNT_FILE_BYTES,
+  MAX_INTEGRATION_ACCOUNTS,
+  MAX_INTEGRATION_CREDENTIAL_BYTES,
+  serializeIntegrationAccountFile
+} from './integration-account-persistence-limits'
+
+describe('integration account persistence limits', () => {
+  it('admits the exact account boundary and rejects one more', () => {
+    expect(() => assertIntegrationAccountCount('Test', MAX_INTEGRATION_ACCOUNTS)).not.toThrow()
+    expect(() => assertIntegrationAccountCount('Test', MAX_INTEGRATION_ACCOUNTS + 1)).toThrow(
+      `at most ${MAX_INTEGRATION_ACCOUNTS}`
+    )
+  })
+
+  it('measures credential and metadata fields as UTF-8 bytes', () => {
+    const exactCredential = 'é'.repeat(MAX_INTEGRATION_CREDENTIAL_BYTES / 2)
+    expect(() => assertIntegrationCredentialBytes('Test', exactCredential)).not.toThrow()
+    expect(() => assertIntegrationCredentialBytes('Test', `${exactCredential}a`)).toThrow(
+      `${MAX_INTEGRATION_CREDENTIAL_BYTES} UTF-8 bytes`
+    )
+
+    expect(() => assertIntegrationStringBytes('Test', 'field', 'éé', 4)).not.toThrow()
+    expect(() => assertIntegrationStringBytes('Test', 'field', 'ééa', 4)).toThrow('4 UTF-8 bytes')
+  })
+
+  it('serializes ordinary JSON identically through the bounded writer', () => {
+    const value = { version: 1, accounts: [{ id: 'alpha', name: 'Ada' }] }
+    expect(serializeIntegrationAccountFile(value)).toBe(JSON.stringify(value, null, 2))
+  })
+
+  it('admits an exact-size metadata file and rejects one extra byte', () => {
+    const base = JSON.stringify({ value: '' }, null, 2)
+    const exact = { value: 'a'.repeat(MAX_INTEGRATION_ACCOUNT_FILE_BYTES - base.length) }
+    expect(Buffer.byteLength(JSON.stringify(exact, null, 2))).toBe(
+      MAX_INTEGRATION_ACCOUNT_FILE_BYTES
+    )
+    expect(serializeIntegrationAccountFile(exact)).toBe(JSON.stringify(exact, null, 2))
+    expect(() => serializeIntegrationAccountFile({ value: `${exact.value}a` })).toThrow(
+      `${MAX_INTEGRATION_ACCOUNT_FILE_BYTES} bytes`
+    )
+  })
+})

--- a/src/main/integration-account-persistence-limits.ts
+++ b/src/main/integration-account-persistence-limits.ts
@@ -1,0 +1,53 @@
+import { stringifyJsonWithinByteLimit } from '../shared/node-bounded-json-stringify'
+import { MAX_INTEGRATION_CREDENTIAL_FILE_BYTES } from './integration-credential-file'
+
+export const MAX_INTEGRATION_ACCOUNTS = 256
+export const MAX_INTEGRATION_ACCOUNT_ID_BYTES = 128
+export const MAX_INTEGRATION_ACCOUNT_URL_BYTES = 16 * 1024
+export const MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES = 4 * 1024
+export const MAX_INTEGRATION_ACCOUNT_LABEL_BYTES = 16 * 1024
+export const MAX_INTEGRATION_CREDENTIAL_BYTES = 64 * 1024
+export const MAX_INTEGRATION_ACCOUNT_FILE_BYTES = MAX_INTEGRATION_CREDENTIAL_FILE_BYTES
+
+export class IntegrationAccountPersistenceLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'IntegrationAccountPersistenceLimitError'
+  }
+}
+
+export function assertIntegrationAccountCount(service: string, count: number): void {
+  if (count > MAX_INTEGRATION_ACCOUNTS) {
+    throw new IntegrationAccountPersistenceLimitError(
+      `${service} supports at most ${MAX_INTEGRATION_ACCOUNTS} saved accounts.`
+    )
+  }
+}
+
+export function assertIntegrationStringBytes(
+  service: string,
+  field: string,
+  value: string,
+  maxBytes: number
+): void {
+  if (Buffer.byteLength(value, 'utf8') > maxBytes) {
+    throw new IntegrationAccountPersistenceLimitError(
+      `${service} ${field} exceeds ${maxBytes} UTF-8 bytes.`
+    )
+  }
+}
+
+export function assertIntegrationCredentialBytes(service: string, value: string): void {
+  assertIntegrationStringBytes(service, 'credential', value, MAX_INTEGRATION_CREDENTIAL_BYTES)
+}
+
+export function serializeIntegrationAccountFile(value: unknown): string {
+  return stringifyJsonWithinByteLimit(value, MAX_INTEGRATION_ACCOUNT_FILE_BYTES, 2).serialized
+}
+
+export function unreadableIntegrationAccountFileError(service: string): Error {
+  return new Error(
+    `Saved ${service} account metadata is unreadable or exceeds supported limits; ` +
+      'the existing file was left unchanged.'
+  )
+}

--- a/src/main/integration-api-concurrency.test.ts
+++ b/src/main/integration-api-concurrency.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import { IntegrationApiConcurrencyGate } from './integration-api-concurrency'
+
+describe('IntegrationApiConcurrencyGate', () => {
+  it('preserves FIFO admission within the ordinary concurrency limit', async () => {
+    const gate = new IntegrationApiConcurrencyGate(1, 2)
+    const first = gate.acquire()
+    const secondResolved = vi.fn()
+    const second = gate.acquire().then(secondResolved)
+
+    await first
+    expect(secondResolved).not.toHaveBeenCalled()
+    gate.release()
+    await second
+
+    expect(secondResolved).toHaveBeenCalledTimes(1)
+    gate.release()
+  })
+
+  it('rejects fan-out beyond the retained waiter cap', async () => {
+    const gate = new IntegrationApiConcurrencyGate(1, 2)
+    await gate.acquire()
+    const queued = [gate.acquire(), gate.acquire()]
+
+    await expect(gate.acquire()).rejects.toThrow('queue is full')
+
+    gate.release()
+    await queued[0]
+    gate.release()
+    await queued[1]
+    gate.release()
+  })
+})

--- a/src/main/integration-api-concurrency.ts
+++ b/src/main/integration-api-concurrency.ts
@@ -1,0 +1,34 @@
+export const INTEGRATION_API_MAX_WAITERS = 1024
+
+export class IntegrationApiConcurrencyGate {
+  private running = 0
+  private readonly waiters: (() => void)[] = []
+
+  constructor(
+    private readonly maxConcurrent: number,
+    private readonly maxWaiters = INTEGRATION_API_MAX_WAITERS
+  ) {}
+
+  acquire(): Promise<void> {
+    if (this.running < this.maxConcurrent) {
+      this.running += 1
+      return Promise.resolve()
+    }
+    if (this.waiters.length >= this.maxWaiters) {
+      return Promise.reject(
+        new Error('Integration API request queue is full; retry after current requests finish.')
+      )
+    }
+    return new Promise((resolve) => {
+      this.waiters.push(() => {
+        this.running += 1
+        resolve()
+      })
+    })
+  }
+
+  release(): void {
+    this.running = Math.max(0, this.running - 1)
+    this.waiters.shift()?.()
+  }
+}

--- a/src/main/integration-credential-file.test.ts
+++ b/src/main/integration-credential-file.test.ts
@@ -1,0 +1,46 @@
+import { closeSync, ftruncateSync, mkdtempSync, openSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  MAX_INTEGRATION_CREDENTIAL_FILE_BYTES,
+  readIntegrationCredentialFileSync,
+  readIntegrationCredentialFileText
+} from './integration-credential-file'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function createPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-integration-credential-'))
+  roots.push(root)
+  return join(root, 'credential')
+}
+
+describe('integration credential file bounds', () => {
+  it('accepts exact-cap credential bytes in sync and async readers', async () => {
+    const filePath = createPath()
+    writeFileSync(filePath, Buffer.alloc(MAX_INTEGRATION_CREDENTIAL_FILE_BYTES, 0x61))
+
+    expect(readIntegrationCredentialFileSync(filePath)).toHaveLength(
+      MAX_INTEGRATION_CREDENTIAL_FILE_BYTES
+    )
+    await expect(readIntegrationCredentialFileText(filePath)).resolves.toHaveLength(
+      MAX_INTEGRATION_CREDENTIAL_FILE_BYTES
+    )
+  })
+
+  it('rejects a sparse credential file beyond the cap', () => {
+    const filePath = createPath()
+    const file = openSync(filePath, 'w')
+    ftruncateSync(file, MAX_INTEGRATION_CREDENTIAL_FILE_BYTES + 1)
+    closeSync(file)
+
+    expect(() => readIntegrationCredentialFileSync(filePath)).toThrow('exceeds')
+  })
+})

--- a/src/main/integration-credential-file.ts
+++ b/src/main/integration-credential-file.ts
@@ -1,9 +1,29 @@
 import { statSync } from 'node:fs'
 import { safeStorage } from 'electron'
 import {
+  readNodeFileSyncWithinLimit,
+  readNodeFileWithinLimit
+} from '../shared/node-bounded-file-reader'
+import {
   credentialDecryptionMessage,
   type IntegrationCredentialService
 } from '../shared/integration-credential-errors'
+
+export const MAX_INTEGRATION_CREDENTIAL_FILE_BYTES = 1024 * 1024
+
+export function readIntegrationCredentialFileSync(filePath: string): Buffer {
+  return readNodeFileSyncWithinLimit(filePath, MAX_INTEGRATION_CREDENTIAL_FILE_BYTES).buffer
+}
+
+export function readIntegrationCredentialFileSyncText(filePath: string): string {
+  return readIntegrationCredentialFileSync(filePath).toString('utf8')
+}
+
+export async function readIntegrationCredentialFileText(filePath: string): Promise<string> {
+  return (
+    await readNodeFileWithinLimit(filePath, MAX_INTEGRATION_CREDENTIAL_FILE_BYTES)
+  ).buffer.toString('utf8')
+}
 
 // Why: connection status treats a token file as a saved credential; empty
 // files read as "missing", so counting them would split-brain getStatus.

--- a/src/main/integration-error-message.test.ts
+++ b/src/main/integration-error-message.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  boundedIntegrationErrorLog,
+  boundedIntegrationErrorMessage,
+  MAX_INTEGRATION_ERROR_MESSAGE_CHARS
+} from './integration-error-message'
+
+describe('boundedIntegrationErrorMessage', () => {
+  it('preserves the exact character boundary and truncates character +1', () => {
+    const exact = 'a'.repeat(MAX_INTEGRATION_ERROR_MESSAGE_CHARS)
+    expect(boundedIntegrationErrorMessage(new Error(exact))).toBe(exact)
+
+    const truncated = boundedIntegrationErrorMessage(`${exact}b`)
+    expect(truncated).toHaveLength(MAX_INTEGRATION_ERROR_MESSAGE_CHARS)
+    expect(truncated.endsWith('…')).toBe(true)
+  })
+
+  it('bounds retained stack text used by provider logs', () => {
+    const error = new Error('failed')
+    error.stack = 's'.repeat(MAX_INTEGRATION_ERROR_MESSAGE_CHARS + 1)
+
+    expect(boundedIntegrationErrorLog(error)).toHaveLength(MAX_INTEGRATION_ERROR_MESSAGE_CHARS)
+  })
+})

--- a/src/main/integration-error-message.ts
+++ b/src/main/integration-error-message.ts
@@ -1,0 +1,13 @@
+export const MAX_INTEGRATION_ERROR_MESSAGE_CHARS = 16 * 1024
+
+export function boundedIntegrationErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error)
+  if (message.length <= MAX_INTEGRATION_ERROR_MESSAGE_CHARS) {
+    return message
+  }
+  return `${message.slice(0, MAX_INTEGRATION_ERROR_MESSAGE_CHARS - 1)}…`
+}
+
+export function boundedIntegrationErrorLog(error: unknown): string {
+  return boundedIntegrationErrorMessage(error instanceof Error && error.stack ? error.stack : error)
+}

--- a/src/main/integration-fanout.test.ts
+++ b/src/main/integration-fanout.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  runBoundedIntegrationFanout,
+  runBoundedIntegrationSettledFanout
+} from './integration-fanout'
+
+describe('runBoundedIntegrationFanout', () => {
+  it('bounds concurrency and preserves input order across out-of-order completions', async () => {
+    let active = 0
+    let peak = 0
+    const result = await runBoundedIntegrationFanout(
+      [0, 1, 2, 3, 4],
+      async (entry) => {
+        active += 1
+        peak = Math.max(peak, active)
+        await new Promise((resolve) => setTimeout(resolve, (4 - entry) % 3))
+        active -= 1
+        return [entry]
+      },
+      (items) => items,
+      {
+        maxConcurrent: 2,
+        limits: { maxPages: 5, maxItems: 5, maxRetainedBytes: 100 }
+      }
+    )
+
+    expect(peak).toBe(2)
+    expect(result).toEqual({
+      results: [[0], [1], [2], [3], [4]],
+      truncated: false,
+      attemptedCount: 5
+    })
+  })
+
+  it('admits the exact aggregate item boundary and stops scheduling after item +1', async () => {
+    const visited: number[] = []
+    const result = await runBoundedIntegrationFanout(
+      [0, 1, 2, 3],
+      async (entry) => {
+        visited.push(entry)
+        return [entry]
+      },
+      (items) => items,
+      {
+        maxConcurrent: 2,
+        limits: { maxPages: 4, maxItems: 2, maxRetainedBytes: 100 }
+      }
+    )
+
+    expect(result).toEqual({
+      results: [[0], [1]],
+      truncated: true,
+      attemptedCount: 2
+    })
+    expect(visited).toEqual([0, 1])
+  })
+
+  it('does not retain or schedule later batches after byte +1', async () => {
+    const visited: number[] = []
+    const result = await runBoundedIntegrationFanout(
+      [0, 1, 2],
+      async (entry) => {
+        visited.push(entry)
+        return entry === 0 ? ['a'] : ['aa']
+      },
+      (items) => items,
+      {
+        maxConcurrent: 1,
+        limits: { maxPages: 3, maxItems: 3, maxRetainedBytes: 10 }
+      }
+    )
+
+    expect(result).toEqual({
+      results: [['a']],
+      truncated: true,
+      attemptedCount: 2
+    })
+    expect(visited).toEqual([0, 1])
+  })
+
+  it('preserves settled success and failure order without rejecting the fan-out', async () => {
+    const result = await runBoundedIntegrationSettledFanout(
+      ['ok', 'bad', 'later'],
+      async (entry) => {
+        if (entry === 'bad') {
+          throw new Error('failed')
+        }
+        return [entry]
+      },
+      (items) => items
+    )
+
+    expect(result.results).toMatchObject([
+      { status: 'fulfilled', value: ['ok'] },
+      { status: 'rejected', reason: { message: 'failed' } },
+      { status: 'fulfilled', value: ['later'] }
+    ])
+  })
+})

--- a/src/main/integration-fanout.ts
+++ b/src/main/integration-fanout.ts
@@ -1,0 +1,82 @@
+import { MAX_INTEGRATION_ACCOUNTS } from './integration-account-persistence-limits'
+import {
+  INTEGRATION_PAGINATION_MAX_ITEMS,
+  INTEGRATION_PAGINATION_MAX_RETAINED_BYTES,
+  IntegrationPaginationBudget,
+  type IntegrationPaginationLimits
+} from './integration-pagination-budget'
+
+export const INTEGRATION_FANOUT_MAX_CONCURRENT = 4
+
+const DEFAULT_FANOUT_LIMITS: IntegrationPaginationLimits = {
+  maxPages: MAX_INTEGRATION_ACCOUNTS,
+  maxItems: INTEGRATION_PAGINATION_MAX_ITEMS,
+  maxRetainedBytes: INTEGRATION_PAGINATION_MAX_RETAINED_BYTES
+}
+
+export function createIntegrationFanoutBudget(): IntegrationPaginationBudget {
+  return new IntegrationPaginationBudget(DEFAULT_FANOUT_LIMITS)
+}
+
+export async function runBoundedIntegrationFanout<TEntry, TResult>(
+  entries: readonly TEntry[],
+  load: (entry: TEntry, index: number) => Promise<TResult>,
+  retainedValues: (result: TResult) => readonly unknown[],
+  options: {
+    budget?: IntegrationPaginationBudget
+    maxConcurrent?: number
+    limits?: IntegrationPaginationLimits
+  } = {}
+): Promise<{ results: TResult[]; truncated: boolean; attemptedCount: number }> {
+  const maxConcurrent = options.maxConcurrent ?? INTEGRATION_FANOUT_MAX_CONCURRENT
+  if (!Number.isSafeInteger(maxConcurrent) || maxConcurrent <= 0) {
+    throw new RangeError('Integration fan-out concurrency must be a positive safe integer')
+  }
+
+  const budget =
+    options.budget ?? new IntegrationPaginationBudget(options.limits ?? DEFAULT_FANOUT_LIMITS)
+  const results: TResult[] = []
+  let attemptedCount = 0
+  for (let offset = 0; offset < entries.length; offset += maxConcurrent) {
+    const batch = entries.slice(offset, offset + maxConcurrent)
+    attemptedCount += batch.length
+    const loaded = await Promise.all(
+      batch.map((entry, batchIndex) => load(entry, offset + batchIndex))
+    )
+    for (const result of loaded) {
+      if (!budget.admitPage(retainedValues(result))) {
+        return { results, truncated: true, attemptedCount }
+      }
+      results.push(result)
+    }
+    if (!budget.canRequestPage && offset + batch.length < entries.length) {
+      return { results, truncated: true, attemptedCount }
+    }
+  }
+  return { results, truncated: false, attemptedCount }
+}
+
+export function runBoundedIntegrationSettledFanout<TEntry, TResult>(
+  entries: readonly TEntry[],
+  load: (entry: TEntry, index: number) => Promise<TResult>,
+  retainedValues: (result: TResult) => readonly unknown[]
+): Promise<{
+  results: PromiseSettledResult<TResult>[]
+  truncated: boolean
+  attemptedCount: number
+}> {
+  return runBoundedIntegrationFanout(
+    entries,
+    async (entry, index): Promise<PromiseSettledResult<TResult>> => {
+      try {
+        return { status: 'fulfilled', value: await load(entry, index) }
+      } catch (reason) {
+        return { status: 'rejected', reason }
+      }
+    },
+    (result) =>
+      result.status === 'fulfilled'
+        ? retainedValues(result.value)
+        : [result.reason instanceof Error ? result.reason.message : String(result.reason)]
+  )
+}

--- a/src/main/integration-pagination-budget.test.ts
+++ b/src/main/integration-pagination-budget.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  IntegrationPaginationBudget,
+  IntegrationPaginationLimitError
+} from './integration-pagination-budget'
+
+describe('IntegrationPaginationBudget', () => {
+  it('admits exact page and item boundaries and rejects page +1', () => {
+    const budget = new IntegrationPaginationBudget({
+      maxPages: 1,
+      maxItems: 2,
+      maxRetainedBytes: 100
+    })
+
+    expect(budget.admitPage(['a', 'b'])).toBe(true)
+    expect(budget.canRequestPage).toBe(false)
+    expect(budget.admitPage([])).toBe(false)
+  })
+
+  it('admits the exact retained-byte boundary and rejects byte +1', () => {
+    const exact = new IntegrationPaginationBudget({
+      maxPages: 2,
+      maxItems: 2,
+      maxRetainedBytes: 5
+    })
+    const over = new IntegrationPaginationBudget({
+      maxPages: 2,
+      maxItems: 2,
+      maxRetainedBytes: 5
+    })
+
+    expect(exact.admitPage(['a'])).toBe(true)
+    expect(over.admitPage(['aa'])).toBe(false)
+  })
+
+  it('does not consume capacity when a page is rejected', () => {
+    const budget = new IntegrationPaginationBudget({
+      maxPages: 1,
+      maxItems: 1,
+      maxRetainedBytes: 5
+    })
+
+    expect(budget.admitPage(['aa'])).toBe(false)
+    expect(budget.admitPage(['a'])).toBe(true)
+  })
+
+  it('bounds SDK-style cumulative pages at exact and +1 byte sizes', () => {
+    const exact = new IntegrationPaginationBudget({
+      maxPages: 2,
+      maxItems: 2,
+      maxRetainedBytes: 5
+    })
+    const over = new IntegrationPaginationBudget({
+      maxPages: 2,
+      maxItems: 2,
+      maxRetainedBytes: 5
+    })
+
+    expect(() => exact.assertCumulativePage(['a'])).not.toThrow()
+    expect(() => over.assertCumulativePage(['aa'])).toThrow(IntegrationPaginationLimitError)
+  })
+})

--- a/src/main/integration-pagination-budget.ts
+++ b/src/main/integration-pagination-budget.ts
@@ -1,0 +1,96 @@
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../shared/node-bounded-json-stringify'
+
+export const INTEGRATION_PAGINATION_MAX_PAGES = 100
+export const INTEGRATION_PAGINATION_MAX_ITEMS = 10_000
+export const INTEGRATION_PAGINATION_MAX_RETAINED_BYTES = 32 * 1024 * 1024
+
+export type IntegrationPaginationLimits = {
+  maxPages: number
+  maxItems: number
+  maxRetainedBytes: number
+}
+
+const DEFAULT_LIMITS: IntegrationPaginationLimits = {
+  maxPages: INTEGRATION_PAGINATION_MAX_PAGES,
+  maxItems: INTEGRATION_PAGINATION_MAX_ITEMS,
+  maxRetainedBytes: INTEGRATION_PAGINATION_MAX_RETAINED_BYTES
+}
+
+export class IntegrationPaginationLimitError extends Error {
+  constructor() {
+    super('Integration pagination exceeded its retained result budget.')
+    this.name = 'IntegrationPaginationLimitError'
+  }
+}
+
+export class IntegrationPaginationBudget {
+  private pages = 0
+  private items = 0
+  private retainedBytes = 0
+
+  constructor(private readonly limits: IntegrationPaginationLimits = DEFAULT_LIMITS) {}
+
+  admitPage(pageItems: readonly unknown[]): boolean {
+    if (
+      this.pages >= this.limits.maxPages ||
+      pageItems.length > this.limits.maxItems - this.items
+    ) {
+      return false
+    }
+    const pageBytes = this.measureWithinRemainingBudget(pageItems)
+    if (pageBytes === null) {
+      return false
+    }
+    this.pages += 1
+    this.items += pageItems.length
+    this.retainedBytes += pageBytes
+    return true
+  }
+
+  assertCumulativePage(items: readonly unknown[]): void {
+    if (this.pages >= this.limits.maxPages || items.length > this.limits.maxItems) {
+      throw new IntegrationPaginationLimitError()
+    }
+    const measuredBytes = this.measureWithinTotalBudget(items)
+    if (measuredBytes === null) {
+      throw new IntegrationPaginationLimitError()
+    }
+    this.pages += 1
+    this.items = items.length
+    this.retainedBytes = measuredBytes
+  }
+
+  get canRequestPage(): boolean {
+    return (
+      this.pages < this.limits.maxPages &&
+      this.items < this.limits.maxItems &&
+      this.retainedBytes <= this.limits.maxRetainedBytes - 2
+    )
+  }
+
+  private measureWithinRemainingBudget(value: unknown): number | null {
+    const remaining = this.limits.maxRetainedBytes - this.retainedBytes
+    try {
+      return stringifyJsonWithinByteLimit(value, remaining).byteLength
+    } catch (error) {
+      if (error instanceof JsonStringifyByteLimitError) {
+        return null
+      }
+      throw error
+    }
+  }
+
+  private measureWithinTotalBudget(value: unknown): number | null {
+    try {
+      return stringifyJsonWithinByteLimit(value, this.limits.maxRetainedBytes).byteLength
+    } catch (error) {
+      if (error instanceof JsonStringifyByteLimitError) {
+        return null
+      }
+      throw error
+    }
+  }
+}

--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -3,6 +3,10 @@ import { tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_INTEGRATION_ACCOUNTS,
+  MAX_INTEGRATION_CREDENTIAL_BYTES
+} from '../integration-account-persistence-limits'
 
 const OLD_FETCH = globalThis.fetch
 const { closeAllConnectionsMock, netFetchMock, resolveProxyMock, setProxyMock } = vi.hoisted(
@@ -649,5 +653,74 @@ describe('Jira client credential storage', () => {
     const headers = netFetchMock.mock.calls[0]?.[1]?.headers as Headers
     expect(headers.get('User-Agent')).toBe('Orca')
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('admits the exact saved-site boundary without changing order', async () => {
+    const sites = Array.from({ length: MAX_INTEGRATION_ACCOUNTS }, (_, index) => ({
+      id: `site-${index}`,
+      token: `token-${index}`
+    }))
+    writeMultiSiteFiles(sites, 'all')
+    const jira = await loadClientModule()
+
+    const status = jira.getStatus()
+    expect(status.sites).toHaveLength(MAX_INTEGRATION_ACCOUNTS)
+    expect(status.sites?.map((site) => site.id)).toEqual(sites.map((site) => site.id))
+  })
+
+  it('preserves an over-limit saved-site file and refuses to overwrite it', async () => {
+    const sites = Array.from({ length: MAX_INTEGRATION_ACCOUNTS + 1 }, (_, index) => ({
+      id: `site-${index}`,
+      token: `token-${index}`
+    }))
+    writeMultiSiteFiles(sites, 'all')
+    const path = join(tempHome, '.orca', 'jira-sites.json')
+    const before = readFileSync(path, 'utf8')
+    const jira = await loadClientModule()
+
+    expect(jira.getStatus()).toMatchObject({ connected: false, sites: [] })
+    await expect(
+      jira.connect({
+        siteUrl: 'example.atlassian.net',
+        email: 'ada@example.com',
+        apiToken: 'token-alpha'
+      })
+    ).resolves.toMatchObject({ ok: false, error: expect.stringContaining('left unchanged') })
+    expect(netFetchMock).not.toHaveBeenCalled()
+    expect(readFileSync(path, 'utf8')).toBe(before)
+  })
+
+  it('admits an exact-size Jira credential and rejects credential byte +1 before fetch', async () => {
+    const exactToken = 't'.repeat(MAX_INTEGRATION_CREDENTIAL_BYTES)
+    netFetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          accountId: 'account-alpha',
+          displayName: 'Ada',
+          emailAddress: 'ada@example.com'
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    )
+    const jira = await loadClientModule()
+
+    await expect(
+      jira.connect({
+        siteUrl: 'example.atlassian.net',
+        email: 'ada@example.com',
+        apiToken: exactToken
+      })
+    ).resolves.toMatchObject({ ok: true })
+    await expect(
+      jira.connect({
+        siteUrl: 'another.atlassian.net',
+        email: 'ada@example.com',
+        apiToken: `${exactToken}t`
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining(`${MAX_INTEGRATION_CREDENTIAL_BYTES} UTF-8 bytes`)
+    })
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/jira/client.ts
+++ b/src/main/jira/client.ts
@@ -2,17 +2,36 @@
 request plumbing share one boundary so encrypted token lifecycle and
 multi-site selection cannot drift between task operations. */
 import { createHash } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { net, safeStorage, session } from 'electron'
 import {
   CredentialDecryptionError,
   credentialFileHasContent,
+  readIntegrationCredentialFileSync,
+  readIntegrationCredentialFileSyncText,
   readStoredCredentialToken
 } from '../integration-credential-file'
 import { ensureElectronProxyFromEnvironment } from '../network/proxy-settings'
 import { withSpan } from '../observability/tracer'
+import { readFetchResponseJsonWithinLimit } from '../lib/fetch-response-body'
+import { IntegrationApiConcurrencyGate } from '../integration-api-concurrency'
+import {
+  assertIntegrationAccountCount,
+  assertIntegrationCredentialBytes,
+  assertIntegrationStringBytes,
+  IntegrationAccountPersistenceLimitError,
+  MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES,
+  MAX_INTEGRATION_ACCOUNT_FILE_BYTES,
+  MAX_INTEGRATION_ACCOUNT_ID_BYTES,
+  MAX_INTEGRATION_ACCOUNT_LABEL_BYTES,
+  MAX_INTEGRATION_ACCOUNTS,
+  MAX_INTEGRATION_ACCOUNT_URL_BYTES,
+  serializeIntegrationAccountFile,
+  unreadableIntegrationAccountFileError
+} from '../integration-account-persistence-limits'
+import { boundedIntegrationErrorMessage } from '../integration-error-message'
 import type {
   JiraAuthType,
   JiraConnectArgs,
@@ -30,28 +49,14 @@ import type {
 const JIRA_API_USER_AGENT = 'Orca'
 
 const MAX_CONCURRENT = 4
-let running = 0
-const queue: (() => void)[] = []
+const concurrencyGate = new IntegrationApiConcurrencyGate(MAX_CONCURRENT)
 
 export function acquire(): Promise<void> {
-  if (running < MAX_CONCURRENT) {
-    running += 1
-    return Promise.resolve()
-  }
-  return new Promise((resolve) =>
-    queue.push(() => {
-      running += 1
-      resolve()
-    })
-  )
+  return concurrencyGate.acquire()
 }
 
 export function release(): void {
-  running -= 1
-  const next = queue.shift()
-  if (next) {
-    next()
-  }
+  concurrencyGate.release()
 }
 
 type JiraSiteFile = {
@@ -77,17 +82,28 @@ export class JiraApiError extends Error {
   status: number | null
 
   constructor(message: string, status: number | null = null) {
-    super(message)
+    super(boundedIntegrationErrorMessage(message))
     this.status = status
   }
 }
 
 let cachedSiteFile: JiraSiteFile | null = null
 let siteFileLoaded = false
+let siteFileReadError: Error | null = null
 const cachedTokens = new Map<string, string>()
 // Why: decrypt failures are recorded per site so getStatus can explain
 // failing reads without re-touching the keychain on every status poll.
 const credentialErrors = new Map<string, string>()
+
+function cacheToken(siteId: string, token: string): void {
+  if (!cachedTokens.has(siteId) && cachedTokens.size >= MAX_INTEGRATION_ACCOUNTS) {
+    const oldestSiteId = cachedTokens.keys().next().value
+    if (oldestSiteId !== undefined) {
+      cachedTokens.delete(oldestSiteId)
+    }
+  }
+  cachedTokens.set(siteId, token)
+}
 
 function getOrcaDir(): string {
   return join(homedir(), '.orca')
@@ -102,6 +118,7 @@ function getTokenDir(): string {
 }
 
 function getTokenPath(siteId: string): string {
+  assertIntegrationStringBytes('Jira', 'site ID', siteId, MAX_INTEGRATION_ACCOUNT_ID_BYTES)
   return join(getTokenDir(), `${Buffer.from(siteId).toString('base64url')}.enc`)
 }
 
@@ -157,19 +174,95 @@ function normalizeSite(input: unknown): JiraSite | null {
   }
 }
 
+function assertSiteBounds(site: JiraSite): void {
+  assertIntegrationStringBytes('Jira', 'site ID', site.id, MAX_INTEGRATION_ACCOUNT_ID_BYTES)
+  assertIntegrationStringBytes('Jira', 'site URL', site.siteUrl, MAX_INTEGRATION_ACCOUNT_URL_BYTES)
+  assertIntegrationStringBytes('Jira', 'email', site.email, MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES)
+  assertIntegrationStringBytes(
+    'Jira',
+    'display name',
+    site.displayName,
+    MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+  )
+  assertIntegrationStringBytes(
+    'Jira',
+    'account ID',
+    site.accountId,
+    MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+  )
+}
+
+function assertStoredSiteBounds(input: unknown): void {
+  if (!input || typeof input !== 'object') {
+    return
+  }
+  const record = input as Record<string, unknown>
+  const fields = [
+    ['site ID', record.id, MAX_INTEGRATION_ACCOUNT_ID_BYTES],
+    ['site URL', record.siteUrl, MAX_INTEGRATION_ACCOUNT_URL_BYTES],
+    ['email', record.email, MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES],
+    ['display name', record.displayName, MAX_INTEGRATION_ACCOUNT_LABEL_BYTES],
+    ['account ID', record.accountId, MAX_INTEGRATION_ACCOUNT_LABEL_BYTES]
+  ] as const
+  for (const [field, value, maxBytes] of fields) {
+    if (typeof value === 'string') {
+      assertIntegrationStringBytes('Jira', field, value, maxBytes)
+    }
+  }
+}
+
+function assertSiteFileBounds(file: JiraSiteFile): void {
+  assertIntegrationAccountCount('Jira', file.sites.length)
+  for (const site of file.sites) {
+    assertSiteBounds(site)
+  }
+}
+
 function readSiteFileFromDisk(): JiraSiteFile {
   const path = getSiteFilePath()
   if (!existsSync(path)) {
+    siteFileReadError = null
     return emptySiteFile()
   }
   try {
-    const parsed = JSON.parse(readFileSync(path, { encoding: 'utf-8' })) as Partial<JiraSiteFile>
-    const sites = Array.isArray(parsed.sites)
-      ? parsed.sites
-          .map((site) => normalizeSite(site))
-          .filter((site): site is JiraSite => site !== null)
-          .filter((site) => hasStoredToken(site.id))
-      : []
+    const parsed = JSON.parse(readIntegrationCredentialFileSyncText(path)) as Partial<JiraSiteFile>
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed) ||
+      parsed.version !== 1 ||
+      !Array.isArray(parsed.sites)
+    ) {
+      throw unreadableIntegrationAccountFileError('Jira')
+    }
+    if (typeof parsed.activeSiteId === 'string') {
+      assertIntegrationStringBytes(
+        'Jira',
+        'active site ID',
+        parsed.activeSiteId,
+        MAX_INTEGRATION_ACCOUNT_ID_BYTES
+      )
+    }
+    if (typeof parsed.selectedSiteId === 'string' && parsed.selectedSiteId !== 'all') {
+      assertIntegrationStringBytes(
+        'Jira',
+        'selected site ID',
+        parsed.selectedSiteId,
+        MAX_INTEGRATION_ACCOUNT_ID_BYTES
+      )
+    }
+    const sites: JiraSite[] = []
+    assertIntegrationAccountCount('Jira', parsed.sites.length)
+    for (const input of parsed.sites) {
+      assertStoredSiteBounds(input)
+      const site = normalizeSite(input)
+      if (!site) {
+        throw unreadableIntegrationAccountFileError('Jira')
+      }
+      if (hasStoredToken(site.id)) {
+        sites.push(site)
+      }
+    }
     const activeSiteId =
       typeof parsed.activeSiteId === 'string' &&
       sites.some((site) => site.id === parsed.activeSiteId)
@@ -181,8 +274,10 @@ function readSiteFileFromDisk(): JiraSiteFile {
         sites.some((site) => site.id === parsed.selectedSiteId))
         ? parsed.selectedSiteId
         : activeSiteId
+    siteFileReadError = null
     return { version: 1, activeSiteId, selectedSiteId, sites }
   } catch {
+    siteFileReadError = unreadableIntegrationAccountFileError('Jira')
     return emptySiteFile()
   }
 }
@@ -196,6 +291,10 @@ function getSiteFile(): JiraSiteFile {
 }
 
 function writeSiteFile(file: JiraSiteFile): void {
+  if (siteFileReadError) {
+    throw siteFileReadError
+  }
+  assertSiteFileBounds(file)
   ensureOrcaDir()
   const sites = file.sites.filter((site) => hasStoredToken(site.id))
   const activeSiteId =
@@ -209,22 +308,31 @@ function writeSiteFile(file: JiraSiteFile): void {
         ? file.selectedSiteId
         : activeSiteId
 
-  cachedSiteFile = {
+  const nextFile: JiraSiteFile = {
     version: 1,
     activeSiteId,
     selectedSiteId,
     sites
   }
-  siteFileLoaded = true
-  writeFileSync(getSiteFilePath(), JSON.stringify(cachedSiteFile, null, 2), {
+  const serialized = serializeIntegrationAccountFile(nextFile)
+  writeFileSync(getSiteFilePath(), serialized, {
     encoding: 'utf-8',
     mode: 0o600
   })
+  cachedSiteFile = nextFile
+  siteFileLoaded = true
 }
 
 function writeEncryptedToken(path: string, apiToken: string): void {
+  assertIntegrationCredentialBytes('Jira', apiToken)
   if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(path, safeStorage.encryptString(apiToken), { mode: 0o600 })
+    const encrypted = safeStorage.encryptString(apiToken)
+    if (encrypted.length > MAX_INTEGRATION_ACCOUNT_FILE_BYTES) {
+      throw new IntegrationAccountPersistenceLimitError(
+        `Jira encrypted credential exceeds ${MAX_INTEGRATION_ACCOUNT_FILE_BYTES} bytes.`
+      )
+    }
+    writeFileSync(path, encrypted, { mode: 0o600 })
     return
   }
   console.warn('[jira] safeStorage encryption unavailable — storing token in plaintext')
@@ -241,15 +349,19 @@ function readToken(siteId: string): string | null {
     return null
   }
   try {
-    const raw = readFileSync(path)
+    const raw = readIntegrationCredentialFileSync(path)
     const token = readStoredCredentialToken('Jira', raw)
     if (token) {
-      cachedTokens.set(siteId, token)
+      assertIntegrationCredentialBytes('Jira', token)
+      cacheToken(siteId, token)
     }
     credentialErrors.delete(siteId)
     return token
   } catch (error) {
-    if (error instanceof CredentialDecryptionError) {
+    if (
+      error instanceof CredentialDecryptionError ||
+      error instanceof IntegrationAccountPersistenceLimitError
+    ) {
       credentialErrors.set(siteId, error.message)
       throw error
     }
@@ -261,7 +373,7 @@ function saveToken(siteId: string, apiToken: string): void {
   ensureOrcaDir()
   ensureTokenDir()
   writeEncryptedToken(getTokenPath(siteId), apiToken)
-  cachedTokens.set(siteId, apiToken)
+  cacheToken(siteId, apiToken)
   credentialErrors.delete(siteId)
 }
 
@@ -344,9 +456,9 @@ function describeErrorCause(error: unknown): string | undefined {
   }
   const cause = (error as { cause?: unknown }).cause
   if (cause instanceof Error) {
-    return `${cause.name}: ${cause.message}`
+    return boundedIntegrationErrorMessage(`${cause.name}: ${cause.message}`)
   }
-  return cause === undefined ? undefined : String(cause)
+  return cause === undefined ? undefined : boundedIntegrationErrorMessage(cause)
 }
 
 async function jiraFetch(url: string, init: RequestInit): Promise<Response> {
@@ -360,7 +472,7 @@ async function jiraFetch(url: string, init: RequestInit): Promise<Response> {
       }).catch((error) => {
         span.addEvent('jira.proxySetupFailed', {
           errorName: error instanceof Error ? error.name : typeof error,
-          errorMessage: error instanceof Error ? error.message : String(error)
+          errorMessage: boundedIntegrationErrorMessage(error)
         })
       })
       try {
@@ -372,10 +484,7 @@ async function jiraFetch(url: string, init: RequestInit): Promise<Response> {
           'jira.transportErrorName',
           error instanceof Error ? error.name : typeof error
         )
-        span.setAttribute(
-          'jira.transportErrorMessage',
-          error instanceof Error ? error.message : String(error)
-        )
+        span.setAttribute('jira.transportErrorMessage', boundedIntegrationErrorMessage(error))
         const cause = describeErrorCause(error)
         if (cause) {
           span.setAttribute('jira.transportErrorCause', cause)
@@ -410,16 +519,16 @@ async function requestWithCredentials(
   if (response.status === 204) {
     return null
   }
-  return response.json()
+  return readFetchResponseJsonWithinLimit<unknown>(response)
 }
 
 async function readJiraError(response: Response): Promise<string> {
   try {
-    const data = (await response.json()) as {
+    const data = await readFetchResponseJsonWithinLimit<{
       errorMessages?: string[]
       errors?: Record<string, string>
       message?: string
-    }
+    }>(response)
     const messages = [
       ...(Array.isArray(data.errorMessages) ? data.errorMessages : []),
       ...Object.values(data.errors ?? {}),
@@ -454,7 +563,7 @@ export async function jiraRequest<T>(
   if (response.status === 204) {
     return null as T
   }
-  return (await response.json()) as T
+  return await readFetchResponseJsonWithinLimit<T>(response)
 }
 
 export function getClients(selection?: JiraSiteSelection | null): JiraClientForSite[] {
@@ -475,7 +584,11 @@ export function getClients(selection?: JiraSiteSelection | null): JiraClientForS
       // credentialError for getStatus to surface, so skip this site like a
       // missing token. A specific-site selection still rethrows so the renderer
       // can surface the decrypt banner promptly.
-      if (isAllSelection && error instanceof CredentialDecryptionError) {
+      if (
+        isAllSelection &&
+        (error instanceof CredentialDecryptionError ||
+          error instanceof IntegrationAccountPersistenceLimitError)
+      ) {
         return []
       }
       throw error
@@ -504,9 +617,25 @@ export function getStatus(): JiraConnectionStatus {
 export async function connect(
   args: JiraConnectArgs
 ): Promise<{ ok: true; viewer: JiraViewer } | { ok: false; error: string }> {
+  try {
+    assertIntegrationStringBytes(
+      'Jira',
+      'site URL',
+      args.siteUrl,
+      MAX_INTEGRATION_ACCOUNT_URL_BYTES
+    )
+    assertIntegrationStringBytes('Jira', 'email', args.email, MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES)
+    assertIntegrationCredentialBytes('Jira', args.apiToken)
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? boundedIntegrationErrorMessage(error) : 'Connection failed.'
+    }
+  }
   let siteUrl: string
   try {
     siteUrl = normalizeJiraSiteUrl(args.siteUrl)
+    assertIntegrationStringBytes('Jira', 'site URL', siteUrl, MAX_INTEGRATION_ACCOUNT_URL_BYTES)
   } catch {
     return { ok: false, error: 'Enter a valid Jira site URL.' }
   }
@@ -527,6 +656,10 @@ export async function connect(
     return { ok: false, error: 'Email and API token are required.' }
   }
 
+  getSiteFile()
+  if (siteFileReadError) {
+    return { ok: false, error: siteFileReadError.message }
+  }
   await acquire()
   try {
     const myselfPath = authType === 'server' ? '/rest/api/2/myself' : '/rest/api/3/myself'
@@ -554,17 +687,23 @@ export async function connect(
       accountId: viewer.accountId,
       authType
     }
-    saveToken(id, apiToken)
     const file = getSiteFile()
-    writeSiteFile({
+    const nextFile: JiraSiteFile = {
       version: 1,
       activeSiteId: id,
       selectedSiteId: id,
       sites: [site, ...file.sites.filter((entry) => entry.id !== id)]
-    })
+    }
+    assertSiteFileBounds(nextFile)
+    serializeIntegrationAccountFile(nextFile)
+    saveToken(id, apiToken)
+    writeSiteFile(nextFile)
     return { ok: true, viewer }
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : 'Connection failed.' }
+    return {
+      ok: false,
+      error: error instanceof Error ? boundedIntegrationErrorMessage(error) : 'Connection failed.'
+    }
   } finally {
     release()
   }
@@ -572,6 +711,9 @@ export async function connect(
 
 export function disconnect(siteId?: string): void {
   const file = getSiteFile()
+  if (siteFileReadError) {
+    throw siteFileReadError
+  }
   const ids = siteId ? [siteId] : file.sites.map((site) => site.id)
   for (const id of ids) {
     deleteToken(id)
@@ -604,7 +746,10 @@ export async function testConnection(
   try {
     client = getClients(siteId)[0]
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : 'Connection failed.' }
+    return {
+      ok: false,
+      error: error instanceof Error ? boundedIntegrationErrorMessage(error) : 'Connection failed.'
+    }
   }
   if (!client) {
     return { ok: false, error: 'Not connected to Jira.' }
@@ -617,15 +762,21 @@ export async function testConnection(
     )
     return { ok: true, viewer }
   } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : 'Connection failed.' }
+    return {
+      ok: false,
+      error: error instanceof Error ? boundedIntegrationErrorMessage(error) : 'Connection failed.'
+    }
   } finally {
     release()
   }
 }
 
 export function clearToken(siteId: string): void {
-  deleteToken(siteId)
   const file = getSiteFile()
+  if (siteFileReadError) {
+    throw siteFileReadError
+  }
+  deleteToken(siteId)
   writeSiteFile({ ...file, sites: file.sites.filter((site) => site.id !== siteId) })
 }
 

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -22,6 +22,16 @@ import type {
   JiraUser
 } from '../../shared/types'
 import {
+  boundedIntegrationErrorLog,
+  boundedIntegrationErrorMessage
+} from '../integration-error-message'
+import {
+  INTEGRATION_PAGINATION_MAX_ITEMS,
+  IntegrationPaginationBudget,
+  INTEGRATION_PAGINATION_MAX_PAGES
+} from '../integration-pagination-budget'
+import { runBoundedIntegrationFanout } from '../integration-fanout'
+import {
   acquire,
   apiBasePath,
   clearToken,
@@ -83,16 +93,13 @@ function getErrorStatus(error: unknown): number | null {
   return typeof status === 'number' && Number.isFinite(status) ? status : null
 }
 
-function toIssueSearchFailureError(error: unknown): unknown {
+function toIssueSearchFailureError(error: unknown): Error {
   const status = getErrorStatus(error)
-  if (
-    status === null ||
-    !(error instanceof Error) ||
-    error.message.startsWith(`Error ${status}:`)
-  ) {
-    return error
+  const message = boundedIntegrationErrorMessage(error)
+  if (status === null || message.startsWith(`Error ${status}:`)) {
+    return new Error(message)
   }
-  return new Error(`Error ${status}: ${error.message}`)
+  return new Error(boundedIntegrationErrorMessage(`Error ${status}: ${message}`))
 }
 
 function shouldSurfaceSiteFailure(
@@ -164,15 +171,26 @@ async function fetchPagedRecords(
   maxResults = 100
 ): Promise<JiraRecord[]> {
   const records: JiraRecord[] = []
+  const budget = new IntegrationPaginationBudget()
   let startAt = 0
-  for (let guard = 0; guard < 100; guard += 1) {
+  for (let guard = 0; guard < INTEGRATION_PAGINATION_MAX_PAGES; guard += 1) {
     const response = await jiraRequest<JiraPagedResponse<JiraRecord>>(
       entry,
       pathForPage(startAt, maxResults)
     )
     const items = getPageItems(response, key)
-    records.push(...items)
+    if (!budget.admitPage(items)) {
+      console.warn('[jira] Paginated result exceeded its retained result budget; truncating.')
+      break
+    }
+    for (const item of items) {
+      records.push(item)
+    }
     if (!shouldFetchNextPage(response, startAt, items, maxResults)) {
+      break
+    }
+    if (!budget.canRequestPage) {
+      console.warn('[jira] Paginated result reached its retained result budget; truncating.')
       break
     }
     startAt += asFiniteNumber(response.maxResults) ?? maxResults
@@ -374,7 +392,7 @@ async function searchIssuesForClient(
       fields: ISSUE_FIELDS
     })
   })
-  return (result.issues ?? []).map((issue) => mapJiraIssue(entry.site, issue))
+  return (result.issues ?? []).slice(0, limit).map((issue) => mapJiraIssue(entry.site, issue))
 }
 
 export async function listIssues(
@@ -397,8 +415,9 @@ export async function searchIssues(
   const safeLimit = clampLimit(limit)
   const failures: (JiraIssueSearchFailure | undefined)[] = Array.from({ length: entries.length })
   const surfaceSiteFailure = shouldSurfaceSiteFailure(siteId, entries.length)
-  const results = await Promise.all(
-    entries.map(async (entry, index) => {
+  const fanout = await runBoundedIntegrationFanout(
+    entries,
+    async (entry, index) => {
       await acquire()
       try {
         return await searchIssuesForClient(entry, jql.trim(), safeLimit)
@@ -410,13 +429,14 @@ export async function searchIssues(
         if (surfaceSiteFailure) {
           throw toIssueSearchFailureError(error)
         }
-        console.warn('[jira] searchIssues failed:', error)
+        console.warn('[jira] searchIssues failed:', boundedIntegrationErrorLog(error))
         failures[index] = { error: toIssueSearchFailureError(error), auth: authFailure }
         return [] as JiraIssue[]
       } finally {
         release()
       }
-    })
+    },
+    (issues) => issues
   )
   // 'all' fan-out: only surface an error when every connected site failed, so a
   // partial success (or a genuinely empty result) is not reported as an error.
@@ -426,9 +446,11 @@ export async function searchIssues(
   if (recordedFailures.length === entries.length) {
     throw (recordedFailures.find((failure) => !failure.auth) ?? recordedFailures[0]).error
   }
-  return entries.length === 1
-    ? results.flat().slice(0, safeLimit)
-    : sortAndLimitIssues(results.flat(), safeLimit)
+  if (fanout.truncated) {
+    console.warn('[jira] Cross-site search exceeded its aggregate result budget; truncating.')
+  }
+  const results = fanout.results.flat()
+  return entries.length === 1 ? results.slice(0, safeLimit) : sortAndLimitIssues(results, safeLimit)
 }
 
 export async function getIssue(
@@ -453,7 +475,7 @@ export async function getIssue(
           throw error
         }
       } else {
-        console.warn('[jira] getIssue failed:', error)
+        console.warn('[jira] getIssue failed:', boundedIntegrationErrorLog(error))
       }
     } finally {
       release()
@@ -631,7 +653,7 @@ export async function getIssueComments(
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] getIssueComments failed:', error)
+    console.warn('[jira] getIssueComments failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -643,8 +665,9 @@ export async function listProjects(siteId?: JiraSiteSelection | null): Promise<J
   if (entries.length === 0) {
     return []
   }
-  const results = await Promise.all(
-    entries.map(async (entry) => {
+  const fanout = await runBoundedIntegrationFanout(
+    entries,
+    async (entry) => {
       await acquire()
       try {
         // Server/DC has no /project/search resource; /project returns the
@@ -659,7 +682,11 @@ export async function listProjects(siteId?: JiraSiteSelection | null): Promise<J
                 })
                 return `/rest/api/3/project/search?${params.toString()}`
               })
-        return projects.map((project) => mapProject(project, entry.site))
+        const retainedProjects = projects.slice(0, INTEGRATION_PAGINATION_MAX_ITEMS)
+        if (projects.length > retainedProjects.length) {
+          console.warn('[jira] Projects returned more rows than supported; truncating.')
+        }
+        return retainedProjects.map((project) => mapProject(project, entry.site))
       } catch (error) {
         if (isAuthError(error)) {
           clearToken(entry.site.id)
@@ -667,15 +694,19 @@ export async function listProjects(siteId?: JiraSiteSelection | null): Promise<J
             throw error
           }
         } else {
-          console.warn('[jira] listProjects failed:', error)
+          console.warn('[jira] listProjects failed:', boundedIntegrationErrorLog(error))
         }
         return []
       } finally {
         release()
       }
-    })
+    },
+    (projects) => projects
   )
-  return results.flat().sort((a, b) => a.name.localeCompare(b.name))
+  if (fanout.truncated) {
+    console.warn('[jira] Cross-site projects exceeded their aggregate result budget; truncating.')
+  }
+  return fanout.results.flat().sort((a, b) => a.name.localeCompare(b.name))
 }
 
 export async function listIssueTypes(
@@ -704,7 +735,7 @@ export async function listIssueTypes(
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] listIssueTypes failed:', error)
+    console.warn('[jira] listIssueTypes failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -723,9 +754,10 @@ export async function listCreateFields(
   await acquire()
   try {
     const fields: JiraCreateField[] = []
+    const budget = new IntegrationPaginationBudget()
     let startAt = 0
     const maxResults = 100
-    for (let guard = 0; guard < 100; guard += 1) {
+    for (let guard = 0; guard < INTEGRATION_PAGINATION_MAX_PAGES; guard += 1) {
       const params = new URLSearchParams({
         maxResults: String(maxResults),
         startAt: String(startAt)
@@ -737,12 +769,21 @@ export async function listCreateFields(
         )}/issuetypes/${encodeURIComponent(issueTypeId)}?${params.toString()}`
       )
       const records = getCreateFieldRecords(response)
-      fields.push(
-        ...records
-          .map((record) => mapCreateField(record))
-          .filter((field): field is JiraCreateField => field !== null)
-      )
+      if (!budget.admitPage(records)) {
+        console.warn('[jira] Create fields exceeded their retained result budget; truncating.')
+        break
+      }
+      for (const record of records) {
+        const field = mapCreateField(record)
+        if (field) {
+          fields.push(field)
+        }
+      }
       if (!shouldFetchNextPage(response, startAt, records, maxResults)) {
+        break
+      }
+      if (!budget.canRequestPage) {
+        console.warn('[jira] Create fields reached their retained result budget; truncating.')
         break
       }
       startAt += asFiniteNumber(response.maxResults) ?? maxResults
@@ -753,7 +794,7 @@ export async function listCreateFields(
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] listCreateFields failed:', error)
+    console.warn('[jira] listCreateFields failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -768,13 +809,16 @@ export async function listPriorities(siteId?: string | null): Promise<JiraPriori
   await acquire()
   try {
     const response = await jiraRequest<JiraRecord[]>(entry, `${apiBasePath(entry.site)}/priority`)
-    return response.map(mapPriority).filter((priority): priority is JiraPriority => !!priority)
+    return response
+      .slice(0, INTEGRATION_PAGINATION_MAX_ITEMS)
+      .map(mapPriority)
+      .filter((priority): priority is JiraPriority => !!priority)
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] listPriorities failed:', error)
+    console.warn('[jira] listPriorities failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -802,13 +846,16 @@ export async function listAssignableUsers(
       entry,
       `${apiBasePath(entry.site)}/user/assignable/search?${params.toString()}`
     )
-    return response.map(mapUser).filter((user): user is JiraUser => !!user)
+    return response
+      .slice(0, 50)
+      .map(mapUser)
+      .filter((user): user is JiraUser => !!user)
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] listAssignableUsers failed:', error)
+    console.warn('[jira] listAssignableUsers failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -829,17 +876,19 @@ export async function listTransitions(
       entry,
       `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}/transitions`
     )
-    return (response.transitions ?? []).map((transition) => ({
-      id: asString(transition.id),
-      name: asString(transition.name),
-      to: mapStatus(transition.to)
-    }))
+    return (response.transitions ?? [])
+      .slice(0, INTEGRATION_PAGINATION_MAX_ITEMS)
+      .map((transition) => ({
+        id: asString(transition.id),
+        name: asString(transition.name),
+        to: mapStatus(transition.to)
+      }))
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] listTransitions failed:', error)
+    console.warn('[jira] listTransitions failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -891,12 +940,18 @@ export async function getProjectStatusOrder(
     const seenStatusIds = new Set<string>()
     const statusIdsByColumn: string[][] = []
     for (const column of columns) {
+      if (seenStatusIds.size >= INTEGRATION_PAGINATION_MAX_ITEMS) {
+        break
+      }
       const statuses = asRecord(column).statuses
       if (!Array.isArray(statuses)) {
         continue
       }
       const columnStatusIds: string[] = []
       for (const status of statuses) {
+        if (seenStatusIds.size >= INTEGRATION_PAGINATION_MAX_ITEMS) {
+          break
+        }
         const statusId = asIdentifier(asRecord(status).id)
         if (statusId && !seenStatusIds.has(statusId)) {
           seenStatusIds.add(statusId)
@@ -913,7 +968,7 @@ export async function getProjectStatusOrder(
       clearToken(entry.site.id)
       throw error
     }
-    console.warn('[jira] getProjectStatusOrder failed:', error)
+    console.warn('[jira] getProjectStatusOrder failed:', boundedIntegrationErrorLog(error))
     return { statusIdsByColumn: [] }
   } finally {
     release()

--- a/src/main/linear/client.test.ts
+++ b/src/main/linear/client.test.ts
@@ -3,6 +3,10 @@ import { tmpdir } from 'node:os'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_INTEGRATION_ACCOUNTS,
+  MAX_INTEGRATION_CREDENTIAL_BYTES
+} from '../integration-account-persistence-limits'
 
 type ViewerFixture = {
   displayName: string
@@ -388,5 +392,58 @@ describe('Linear client workspace storage', () => {
     })
 
     expect(() => linear.getClients('bad')).toThrow('Could not decrypt')
+  })
+
+  it('admits the exact saved-workspace boundary without changing order', async () => {
+    const workspaces = Array.from({ length: MAX_INTEGRATION_ACCOUNTS }, (_, index) => ({
+      id: `workspace-${index}`,
+      token: `token-${index}`
+    }))
+    writeMultiWorkspaceFiles(workspaces, 'all')
+    const linear = await loadClientModule()
+
+    const status = linear.getStatus()
+    expect(status.workspaces).toHaveLength(MAX_INTEGRATION_ACCOUNTS)
+    expect(status.workspaces?.map((workspace) => workspace.id)).toEqual(
+      workspaces.map((workspace) => workspace.id)
+    )
+  })
+
+  it('preserves an over-limit saved-workspace file and refuses to overwrite it', async () => {
+    const workspaces = Array.from({ length: MAX_INTEGRATION_ACCOUNTS + 1 }, (_, index) => ({
+      id: `workspace-${index}`,
+      token: `token-${index}`
+    }))
+    writeMultiWorkspaceFiles(workspaces, 'all')
+    const path = join(tempHome, '.orca', 'linear-workspaces.json')
+    const before = readFileSync(path, 'utf8')
+    const linear = await loadClientModule()
+
+    expect(linear.getStatus()).toMatchObject({ connected: false, workspaces: [] })
+    await expect(linear.connect('token-alpha')).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('left unchanged')
+    })
+    expect(linearClientMock).not.toHaveBeenCalled()
+    expect(readFileSync(path, 'utf8')).toBe(before)
+  })
+
+  it('admits an exact-size Linear credential and rejects credential byte +1 before SDK use', async () => {
+    const exactToken = 't'.repeat(MAX_INTEGRATION_CREDENTIAL_BYTES)
+    fixtures.set(exactToken, {
+      displayName: 'Ada',
+      email: 'ada@example.com',
+      organizationId: 'org-exact',
+      organizationName: 'Exact',
+      organizationUrlKey: 'exact'
+    })
+    const linear = await loadClientModule()
+
+    await expect(linear.connect(exactToken)).resolves.toMatchObject({ ok: true })
+    await expect(linear.connect(`${exactToken}t`)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining(`${MAX_INTEGRATION_CREDENTIAL_BYTES} UTF-8 bytes`)
+    })
+    expect(linearClientMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/linear/client.ts
+++ b/src/main/linear/client.ts
@@ -3,13 +3,15 @@
    stay in one consistency boundary. */
 import { safeStorage } from 'electron'
 import type { LinearClient } from '@linear/sdk'
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { loadLinearSdk } from './linear-sdk'
 import {
   CredentialDecryptionError,
   credentialFileHasContent,
+  readIntegrationCredentialFileSync,
+  readIntegrationCredentialFileSyncText,
   readStoredCredentialToken
 } from '../integration-credential-file'
 import type {
@@ -18,31 +20,32 @@ import type {
   LinearWorkspace,
   LinearWorkspaceSelection
 } from '../../shared/types'
+import { IntegrationApiConcurrencyGate } from '../integration-api-concurrency'
+import {
+  assertIntegrationAccountCount,
+  assertIntegrationCredentialBytes,
+  assertIntegrationStringBytes,
+  IntegrationAccountPersistenceLimitError,
+  MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES,
+  MAX_INTEGRATION_ACCOUNT_FILE_BYTES,
+  MAX_INTEGRATION_ACCOUNT_ID_BYTES,
+  MAX_INTEGRATION_ACCOUNT_LABEL_BYTES,
+  MAX_INTEGRATION_ACCOUNTS,
+  serializeIntegrationAccountFile,
+  unreadableIntegrationAccountFileError
+} from '../integration-account-persistence-limits'
+import { boundedIntegrationErrorMessage } from '../integration-error-message'
 
 // ── Concurrency limiter — max 4 parallel Linear API calls ────────────
 const MAX_CONCURRENT = 4
-let running = 0
-const queue: (() => void)[] = []
+const concurrencyGate = new IntegrationApiConcurrencyGate(MAX_CONCURRENT)
 
 export function acquire(): Promise<void> {
-  if (running < MAX_CONCURRENT) {
-    running++
-    return Promise.resolve()
-  }
-  return new Promise((resolve) =>
-    queue.push(() => {
-      running++
-      resolve()
-    })
-  )
+  return concurrencyGate.acquire()
 }
 
 export function release(): void {
-  running--
-  const next = queue.shift()
-  if (next) {
-    next()
-  }
+  concurrencyGate.release()
 }
 
 // ── Token + workspace storage ────────────────────────────────────────
@@ -74,6 +77,17 @@ let cachedLegacyViewer: LinearViewer | null = null
 let legacyViewerLoadedFromDisk = false
 let cachedWorkspaceFile: LinearWorkspaceFile | null = null
 let workspaceFileLoadedFromDisk = false
+let workspaceFileReadError: Error | null = null
+
+function cacheToken(workspaceId: string, token: string): void {
+  if (!cachedTokens.has(workspaceId) && cachedTokens.size >= MAX_INTEGRATION_ACCOUNTS) {
+    const oldestWorkspaceId = cachedTokens.keys().next().value
+    if (oldestWorkspaceId !== undefined) {
+      cachedTokens.delete(oldestWorkspaceId)
+    }
+  }
+  cachedTokens.set(workspaceId, token)
+}
 
 function getOrcaDir(): string {
   return join(homedir(), '.orca')
@@ -99,6 +113,12 @@ function getWorkspaceTokenPath(workspaceId: string): string {
   if (workspaceId === LEGACY_WORKSPACE_ID) {
     return getLegacyTokenPath()
   }
+  assertIntegrationStringBytes(
+    'Linear',
+    'workspace ID',
+    workspaceId,
+    MAX_INTEGRATION_ACCOUNT_ID_BYTES
+  )
   return join(getWorkspaceTokenDir(), `${Buffer.from(workspaceId).toString('base64url')}.enc`)
 }
 
@@ -122,10 +142,46 @@ function readLegacyViewerFromDisk(): LinearViewer | null {
     return null
   }
   try {
-    const raw = readFileSync(path, { encoding: 'utf-8' })
+    const raw = readIntegrationCredentialFileSyncText(path)
     const parsed = JSON.parse(raw) as Partial<LinearViewer>
     if (typeof parsed?.displayName !== 'string' || typeof parsed?.organizationName !== 'string') {
       return null
+    }
+    assertIntegrationStringBytes(
+      'Linear',
+      'legacy display name',
+      parsed.displayName,
+      MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+    )
+    assertIntegrationStringBytes(
+      'Linear',
+      'legacy organization name',
+      parsed.organizationName,
+      MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+    )
+    if (typeof parsed.email === 'string') {
+      assertIntegrationStringBytes(
+        'Linear',
+        'legacy email',
+        parsed.email,
+        MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES
+      )
+    }
+    if (typeof parsed.organizationId === 'string') {
+      assertIntegrationStringBytes(
+        'Linear',
+        'legacy organization ID',
+        parsed.organizationId,
+        MAX_INTEGRATION_ACCOUNT_ID_BYTES
+      )
+    }
+    if (typeof parsed.organizationUrlKey === 'string') {
+      assertIntegrationStringBytes(
+        'Linear',
+        'legacy organization URL key',
+        parsed.organizationUrlKey,
+        MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+      )
     }
     return {
       displayName: parsed.displayName,
@@ -180,6 +236,76 @@ function normalizeWorkspace(input: unknown): LinearWorkspace | null {
   }
 }
 
+function assertWorkspaceBounds(workspace: LinearWorkspace): void {
+  assertIntegrationStringBytes(
+    'Linear',
+    'workspace ID',
+    workspace.id,
+    MAX_INTEGRATION_ACCOUNT_ID_BYTES
+  )
+  assertIntegrationStringBytes(
+    'Linear',
+    'organization ID',
+    workspace.organizationId,
+    MAX_INTEGRATION_ACCOUNT_ID_BYTES
+  )
+  assertIntegrationStringBytes(
+    'Linear',
+    'organization name',
+    workspace.organizationName,
+    MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+  )
+  if (workspace.organizationUrlKey !== undefined) {
+    assertIntegrationStringBytes(
+      'Linear',
+      'organization URL key',
+      workspace.organizationUrlKey,
+      MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+    )
+  }
+  assertIntegrationStringBytes(
+    'Linear',
+    'display name',
+    workspace.displayName,
+    MAX_INTEGRATION_ACCOUNT_LABEL_BYTES
+  )
+  if (workspace.email !== null) {
+    assertIntegrationStringBytes(
+      'Linear',
+      'email',
+      workspace.email,
+      MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES
+    )
+  }
+}
+
+function assertStoredWorkspaceBounds(input: unknown): void {
+  if (!input || typeof input !== 'object') {
+    return
+  }
+  const record = input as Record<string, unknown>
+  const fields = [
+    ['workspace ID', record.id, MAX_INTEGRATION_ACCOUNT_ID_BYTES],
+    ['organization ID', record.organizationId, MAX_INTEGRATION_ACCOUNT_ID_BYTES],
+    ['organization name', record.organizationName, MAX_INTEGRATION_ACCOUNT_LABEL_BYTES],
+    ['organization URL key', record.organizationUrlKey, MAX_INTEGRATION_ACCOUNT_LABEL_BYTES],
+    ['display name', record.displayName, MAX_INTEGRATION_ACCOUNT_LABEL_BYTES],
+    ['email', record.email, MAX_INTEGRATION_ACCOUNT_EMAIL_BYTES]
+  ] as const
+  for (const [field, value, maxBytes] of fields) {
+    if (typeof value === 'string') {
+      assertIntegrationStringBytes('Linear', field, value, maxBytes)
+    }
+  }
+}
+
+function assertWorkspaceFileBounds(file: LinearWorkspaceFile): void {
+  assertIntegrationAccountCount('Linear', file.workspaces.length)
+  for (const workspace of file.workspaces) {
+    assertWorkspaceBounds(workspace)
+  }
+}
+
 function emptyWorkspaceFile(): LinearWorkspaceFile {
   return {
     version: 1,
@@ -192,17 +318,49 @@ function emptyWorkspaceFile(): LinearWorkspaceFile {
 function readWorkspaceFileFromDisk(): LinearWorkspaceFile {
   const path = getWorkspaceFilePath()
   if (!existsSync(path)) {
+    workspaceFileReadError = null
     return emptyWorkspaceFile()
   }
   try {
-    const raw = readFileSync(path, { encoding: 'utf-8' })
+    const raw = readIntegrationCredentialFileSyncText(path)
     const parsed = JSON.parse(raw) as Partial<LinearWorkspaceFile>
-    const workspaces = Array.isArray(parsed.workspaces)
-      ? parsed.workspaces
-          .map((workspace) => normalizeWorkspace(workspace))
-          .filter((workspace): workspace is LinearWorkspace => workspace !== null)
-          .filter((workspace) => hasStoredToken(workspace.id))
-      : []
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      Array.isArray(parsed) ||
+      parsed.version !== 1 ||
+      !Array.isArray(parsed.workspaces)
+    ) {
+      throw unreadableIntegrationAccountFileError('Linear')
+    }
+    if (typeof parsed.activeWorkspaceId === 'string') {
+      assertIntegrationStringBytes(
+        'Linear',
+        'active workspace ID',
+        parsed.activeWorkspaceId,
+        MAX_INTEGRATION_ACCOUNT_ID_BYTES
+      )
+    }
+    if (typeof parsed.selectedWorkspaceId === 'string' && parsed.selectedWorkspaceId !== 'all') {
+      assertIntegrationStringBytes(
+        'Linear',
+        'selected workspace ID',
+        parsed.selectedWorkspaceId,
+        MAX_INTEGRATION_ACCOUNT_ID_BYTES
+      )
+    }
+    const workspaces: LinearWorkspace[] = []
+    assertIntegrationAccountCount('Linear', parsed.workspaces.length)
+    for (const input of parsed.workspaces) {
+      assertStoredWorkspaceBounds(input)
+      const workspace = normalizeWorkspace(input)
+      if (!workspace) {
+        throw unreadableIntegrationAccountFileError('Linear')
+      }
+      if (hasStoredToken(workspace.id)) {
+        workspaces.push(workspace)
+      }
+    }
     const activeWorkspaceId =
       typeof parsed.activeWorkspaceId === 'string' &&
       workspaces.some((workspace) => workspace.id === parsed.activeWorkspaceId)
@@ -215,6 +373,7 @@ function readWorkspaceFileFromDisk(): LinearWorkspaceFile {
         ? parsed.selectedWorkspaceId
         : activeWorkspaceId
 
+    workspaceFileReadError = null
     return {
       version: 1,
       activeWorkspaceId,
@@ -222,6 +381,7 @@ function readWorkspaceFileFromDisk(): LinearWorkspaceFile {
       workspaces
     }
   } catch {
+    workspaceFileReadError = unreadableIntegrationAccountFileError('Linear')
     return emptyWorkspaceFile()
   }
 }
@@ -235,6 +395,10 @@ function getWorkspaceFile(): LinearWorkspaceFile {
 }
 
 function writeWorkspaceFile(file: LinearWorkspaceFile): void {
+  if (workspaceFileReadError) {
+    throw workspaceFileReadError
+  }
+  assertWorkspaceFileBounds(file)
   ensureOrcaDir()
   const persistedWorkspaces = file.workspaces.filter(
     (workspace) => workspace.id !== LEGACY_WORKSPACE_ID
@@ -255,17 +419,19 @@ function writeWorkspaceFile(file: LinearWorkspaceFile): void {
         ? file.selectedWorkspaceId
         : activeWorkspaceId
 
-  cachedWorkspaceFile = {
+  const nextFile: LinearWorkspaceFile = {
     version: 1,
     activeWorkspaceId,
     selectedWorkspaceId,
     workspaces: persistedWorkspaces
   }
-  workspaceFileLoadedFromDisk = true
-  writeFileSync(getWorkspaceFilePath(), JSON.stringify(cachedWorkspaceFile, null, 2), {
+  const serialized = serializeIntegrationAccountFile(nextFile)
+  writeFileSync(getWorkspaceFilePath(), serialized, {
     encoding: 'utf-8',
     mode: 0o600
   })
+  cachedWorkspaceFile = nextFile
+  workspaceFileLoadedFromDisk = true
 }
 
 function getLegacyWorkspace(): LinearWorkspace | null {
@@ -321,8 +487,14 @@ function clearLegacyViewerOnDisk(): void {
 }
 
 function writeEncryptedToken(path: string, apiKey: string): void {
+  assertIntegrationCredentialBytes('Linear', apiKey)
   if (safeStorage.isEncryptionAvailable()) {
     const encrypted = safeStorage.encryptString(apiKey)
+    if (encrypted.length > MAX_INTEGRATION_ACCOUNT_FILE_BYTES) {
+      throw new IntegrationAccountPersistenceLimitError(
+        `Linear encrypted credential exceeds ${MAX_INTEGRATION_ACCOUNT_FILE_BYTES} bytes.`
+      )
+    }
     writeFileSync(path, encrypted, { mode: 0o600 })
     return
   }
@@ -338,7 +510,7 @@ function saveWorkspaceToken(workspaceId: string, apiKey: string): void {
   }
   const tokenPath = getWorkspaceTokenPath(workspaceId)
   writeEncryptedToken(tokenPath, apiKey)
-  cachedTokens.set(workspaceId, apiKey)
+  cacheToken(workspaceId, apiKey)
   credentialErrors.delete(workspaceId)
 }
 
@@ -350,6 +522,12 @@ export function saveToken(apiKey: string): void {
 export function loadToken(options: { force?: boolean; workspaceId?: string } = {}): string | null {
   const workspaceId = options.workspaceId ?? resolveWorkspaceId()
   if (!workspaceId) {
+    return null
+  }
+  if (
+    workspaceId !== LEGACY_WORKSPACE_ID &&
+    !getWorkspaceState().workspaces.some((workspace) => workspace.id === workspaceId)
+  ) {
     return null
   }
   const cached = cachedTokens.get(workspaceId)
@@ -364,15 +542,19 @@ export function loadToken(options: { force?: boolean; workspaceId?: string } = {
     return null
   }
   try {
-    const raw = readFileSync(tokenPath)
+    const raw = readIntegrationCredentialFileSync(tokenPath)
     const token = readStoredCredentialToken('Linear', raw)
     if (token) {
-      cachedTokens.set(workspaceId, token)
+      assertIntegrationCredentialBytes('Linear', token)
+      cacheToken(workspaceId, token)
     }
     credentialErrors.delete(workspaceId)
     return token
   } catch (error) {
-    if (error instanceof CredentialDecryptionError) {
+    if (
+      error instanceof CredentialDecryptionError ||
+      error instanceof IntegrationAccountPersistenceLimitError
+    ) {
       credentialErrors.set(workspaceId, error.message)
       throw error
     }
@@ -401,6 +583,10 @@ function clearTokenFile(workspaceId: string): void {
 }
 
 export function clearToken(workspaceId?: string): void {
+  getWorkspaceFile()
+  if (workspaceFileReadError) {
+    throw workspaceFileReadError
+  }
   if (!workspaceId) {
     const state = getWorkspaceState()
     for (const workspace of state.workspaces) {
@@ -417,6 +603,9 @@ export function clearToken(workspaceId?: string): void {
     return
   }
 
+  if (!getWorkspaceState().workspaces.some((workspace) => workspace.id === workspaceId)) {
+    return
+  }
   clearTokenFile(workspaceId)
   if (workspaceId === LEGACY_WORKSPACE_ID) {
     cachedLegacyViewer = null
@@ -453,7 +642,10 @@ function workspaceFromLinearData(
   }
 }
 
-function upsertWorkspace(workspace: LinearWorkspace, options: { select?: boolean } = {}): void {
+function workspaceFileWithUpsert(
+  workspace: LinearWorkspace,
+  options: { select?: boolean } = {}
+): LinearWorkspaceFile {
   const file = getWorkspaceFile()
   const current = file.workspaces.find((entry) => entry.id === workspace.id)
   const credentialRevision = (current?.credentialRevision ?? 0) + 1
@@ -467,12 +659,16 @@ function upsertWorkspace(workspace: LinearWorkspace, options: { select?: boolean
     : file.selectedWorkspaceId && file.selectedWorkspaceId !== LEGACY_WORKSPACE_ID
       ? file.selectedWorkspaceId
       : workspace.id
-  writeWorkspaceFile({
+  return {
     version: 1,
     activeWorkspaceId: workspace.id,
     selectedWorkspaceId,
     workspaces
-  })
+  }
+}
+
+function upsertWorkspace(workspace: LinearWorkspace, options: { select?: boolean } = {}): void {
+  writeWorkspaceFile(workspaceFileWithUpsert(workspace, options))
 }
 
 function replaceLegacyWorkspace(workspace: LinearWorkspace, token: string): void {
@@ -486,7 +682,8 @@ function replaceLegacyWorkspace(workspace: LinearWorkspace, token: string): void
 
 function resolveWorkspaceId(workspaceId?: string | null): string | null {
   if (workspaceId && workspaceId !== 'all') {
-    return workspaceId
+    const state = getWorkspaceState()
+    return state.workspaces.some((workspace) => workspace.id === workspaceId) ? workspaceId : null
   }
   const state = getWorkspaceState()
   if (
@@ -539,7 +736,11 @@ export function getClients(
       // per-workspace credentialError for getStatus to surface, so skip this
       // workspace like a missing token. A specific-workspace selection still
       // rethrows so the renderer can surface the decrypt banner promptly.
-      if (isAllSelection && error instanceof CredentialDecryptionError) {
+      if (
+        isAllSelection &&
+        (error instanceof CredentialDecryptionError ||
+          error instanceof IntegrationAccountPersistenceLimitError)
+      ) {
         continue
       }
       throw error
@@ -580,13 +781,22 @@ export async function connect(
   { ok: true; viewer: LinearViewer; workspace: LinearWorkspace } | { ok: false; error: string }
 > {
   try {
+    assertIntegrationCredentialBytes('Linear', apiKey)
+    getWorkspaceFile()
+    if (workspaceFileReadError) {
+      throw workspaceFileReadError
+    }
     const client = new (loadLinearSdk().LinearClient)({ apiKey })
     const me = await client.viewer
     const org = await me.organization
     const workspace = workspaceFromLinearData(me, org)
 
-    saveWorkspaceToken(workspace.id, apiKey)
+    assertWorkspaceBounds(workspace)
     const legacyWorkspace = getLegacyWorkspace()
+    const candidateFile = workspaceFileWithUpsert(workspace, { select: true })
+    assertWorkspaceFileBounds(candidateFile)
+    serializeIntegrationAccountFile(candidateFile)
+    saveWorkspaceToken(workspace.id, apiKey)
     if (
       legacyWorkspace &&
       legacyWorkspace.organizationName === workspace.organizationName &&
@@ -600,7 +810,8 @@ export async function connect(
     upsertWorkspace(workspace, { select: true })
     return { ok: true, viewer: workspace, workspace }
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Failed to validate API key'
+    const message =
+      error instanceof Error ? boundedIntegrationErrorMessage(error) : 'Failed to validate API key'
     return { ok: false, error: message }
   }
 }
@@ -659,6 +870,10 @@ export async function testConnection(
 ): Promise<
   { ok: true; viewer: LinearViewer; workspace: LinearWorkspace } | { ok: false; error: string }
 > {
+  getWorkspaceFile()
+  if (workspaceFileReadError) {
+    return { ok: false, error: workspaceFileReadError.message }
+  }
   const resolvedWorkspaceId = resolveWorkspaceId(workspaceId)
   if (!resolvedWorkspaceId) {
     return { ok: false, error: 'No API key stored.' }
@@ -667,7 +882,7 @@ export async function testConnection(
   try {
     token = loadToken({ force: true, workspaceId: resolvedWorkspaceId })
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Test failed'
+    const message = error instanceof Error ? boundedIntegrationErrorMessage(error) : 'Test failed'
     return { ok: false, error: message }
   }
   if (!token) {
@@ -679,6 +894,10 @@ export async function testConnection(
     const me = await client.viewer
     const org = await me.organization
     const workspace = workspaceFromLinearData(me, org)
+    assertWorkspaceBounds(workspace)
+    const candidateFile = workspaceFileWithUpsert(workspace, { select: true })
+    assertWorkspaceFileBounds(candidateFile)
+    serializeIntegrationAccountFile(candidateFile)
     if (resolvedWorkspaceId === LEGACY_WORKSPACE_ID) {
       replaceLegacyWorkspace(workspace, token)
     } else {
@@ -690,7 +909,7 @@ export async function testConnection(
     if (isAuthError(error)) {
       clearToken(resolvedWorkspaceId)
     }
-    const message = error instanceof Error ? error.message : 'Test failed'
+    const message = error instanceof Error ? boundedIntegrationErrorMessage(error) : 'Test failed'
     return { ok: false, error: message }
   }
 }

--- a/src/main/linear/issue-context-client.test.ts
+++ b/src/main/linear/issue-context-client.test.ts
@@ -78,7 +78,7 @@ describe('Linear agent issue context client', () => {
     })
     expect(console.warn).toHaveBeenCalledWith(
       '[linear] agent issue read failed:',
-      expect.any(Error)
+      expect.stringContaining('fetch failed')
     )
   })
 

--- a/src/main/linear/issue-context-client.ts
+++ b/src/main/linear/issue-context-client.ts
@@ -24,11 +24,11 @@ import {
   linearError,
   linearMessage
 } from './issue-context-errors'
+import { getFanoutClientEntries, type WorkspaceReadFailure } from './issue-context-fanout'
 import {
-  getFanoutClientEntries,
-  workspaceFailure,
-  type WorkspaceReadFailure
-} from './issue-context-fanout'
+  readLinearIssueWorkspaceFanout,
+  readLinearSearchWorkspaceFanout
+} from './issue-context-fanout-reads'
 import {
   ambiguousWorkspace,
   resolveWorkspaceSelector,
@@ -59,11 +59,10 @@ export async function searchLinearIssuesForAgents(args: {
     })
   }
 
-  const perWorkspace = await readSearchWorkspaces(
+  const perWorkspace = await readLinearSearchWorkspaceFanout(
     entries,
-    args.query,
-    limit + 1,
     workspaceId,
+    (entry) => readSearchWorkspace(entry, args.query, limit + 1, workspaceId),
     entryFailures
   )
   const merged = perWorkspace.results
@@ -77,8 +76,8 @@ export async function searchLinearIssuesForAgents(args: {
       workspaceId,
       limit,
       returned: limited.length,
-      limitReached: merged.length > limit,
-      partial: perWorkspace.failures.length > 0,
+      limitReached: perWorkspace.truncated || merged.length > limit,
+      partial: perWorkspace.truncated || perWorkspace.failures.length > 0,
       workspaceErrors: perWorkspace.failures.map(({ workspace, code, message }) => ({
         workspace,
         code,
@@ -106,9 +105,21 @@ export async function resolveIssue(
     })
   }
 
-  const results = await readIssueWorkspaces(entries, identifier, selection, entryFailures)
+  const issueFanout = await readLinearIssueWorkspaceFanout(
+    entries,
+    selection,
+    (entry) => readIssueWorkspace(entry, identifier),
+    entryFailures
+  )
+  const results = issueFanout.results
 
   if (results.length === 0) {
+    if (issueFanout.truncated) {
+      throw linearError(
+        'linear_partial',
+        'Linear issue lookup exceeded its aggregate result budget.'
+      )
+    }
     throw linearError('linear_issue_not_found', `Linear issue ${identifier} was not found.`)
   }
   if (results.length > 1) {
@@ -203,42 +214,6 @@ async function readIssueWorkspace(
   return response ? { issue: mapIssue(response), workspace: entry.workspace } : null
 }
 
-async function readIssueWorkspaces(
-  entries: LinearClientForWorkspace[],
-  identifier: string,
-  selection: string | 'all',
-  initialFailures: WorkspaceReadFailure[] = []
-): Promise<ResolvedIssue[]> {
-  if (selection !== 'all') {
-    const selected = await readIssueWorkspace(entries[0], identifier)
-    return selected ? [selected] : []
-  }
-
-  const settled = await Promise.allSettled(
-    entries.map((entry) => readIssueWorkspace(entry, identifier))
-  )
-  const results: ResolvedIssue[] = []
-  const failures: LinearAgentAccessError[] = initialFailures.map((failure) => failure.error)
-
-  for (const result of settled) {
-    if (result.status === 'fulfilled') {
-      if (result.value) {
-        results.push(result.value)
-      }
-      continue
-    }
-    if (result.reason instanceof LinearAgentAccessError) {
-      failures.push(result.reason)
-    }
-    console.warn('[linear] agent issue read failed:', result.reason)
-  }
-
-  if (results.length === 0 && failures[0]) {
-    throw failures[0]
-  }
-  return results
-}
-
 async function readSearchWorkspace(
   entry: LinearClientForWorkspace,
   query: string,
@@ -252,7 +227,7 @@ async function readSearchWorkspace(
         SEARCH_QUERY,
         { term: query, first: limit }
       )
-      return raw.data?.searchIssues?.nodes ?? []
+      return (raw.data?.searchIssues?.nodes ?? []).slice(0, limit)
     },
     workspaceId
   )
@@ -263,42 +238,4 @@ async function readSearchWorkspace(
       name: entry.workspace.organizationName
     }
   }))
-}
-
-async function readSearchWorkspaces(
-  entries: LinearClientForWorkspace[],
-  query: string,
-  limit: number,
-  workspaceId?: string | 'all',
-  initialFailures: WorkspaceReadFailure[] = []
-): Promise<{ results: LinearSearchIssueSummary[][]; failures: WorkspaceReadFailure[] }> {
-  if (workspaceId && workspaceId !== 'all') {
-    return {
-      results: [await readSearchWorkspace(entries[0], query, limit, workspaceId)],
-      failures: []
-    }
-  }
-
-  const settled = await Promise.allSettled(
-    entries.map(async (entry) => readSearchWorkspace(entry, query, limit, workspaceId))
-  )
-  const attemptedWorkspaceCount = entries.length + initialFailures.length
-  const results: LinearSearchIssueSummary[][] = []
-  const failures: WorkspaceReadFailure[] = [...initialFailures]
-  for (let index = 0; index < settled.length; index += 1) {
-    const result = settled[index]
-    if (result.status === 'fulfilled') {
-      results.push(result.value)
-      continue
-    }
-    if (result.reason instanceof LinearAgentAccessError) {
-      failures.push(workspaceFailure(entries[index].workspace, result.reason))
-    }
-    console.warn('[linear] agent search failed:', result.reason)
-  }
-
-  if (results.length === 0 && failures.length === attemptedWorkspaceCount && failures[0]) {
-    throw failures[0].error
-  }
-  return { results, failures }
 }

--- a/src/main/linear/issue-context-errors.ts
+++ b/src/main/linear/issue-context-errors.ts
@@ -1,11 +1,12 @@
 import type { LinearErrorCode, LinearIncludeErrorCode } from '../../shared/linear-agent-access'
+import { boundedIntegrationErrorMessage } from '../integration-error-message'
 
 export class LinearAgentAccessError extends Error {
   readonly code: LinearErrorCode
   readonly data?: unknown
 
   constructor(code: LinearErrorCode, message: string, data?: unknown) {
-    super(message)
+    super(boundedIntegrationErrorMessage(message))
     this.name = 'LinearAgentAccessError'
     this.code = code
     this.data = data
@@ -58,13 +59,12 @@ export function classifyLinearError(error: unknown): LinearErrorCode {
 }
 
 export function linearMessage(error: unknown): string {
-  const message = error instanceof Error ? error.message : String(error)
-  return sanitizeLinearErrorMessage(message)
+  return sanitizeLinearErrorMessage(boundedIntegrationErrorMessage(error))
 }
 
 export function sanitizeLinearErrorMessage(message: string): string {
   // Why: provider text is useful in CLI errors, but raw SDK failures can embed secrets or user payloads.
-  return stripLinearStackTrace(message)
+  return stripLinearStackTrace(boundedIntegrationErrorMessage(message))
     .replace(
       /(headers?\s*[:=]\s*)\{[^{}]*(?:authorization|token|api[-_]?key)[^{}]*\}/gi,
       '$1[REDACTED]'

--- a/src/main/linear/issue-context-fanout-reads.ts
+++ b/src/main/linear/issue-context-fanout-reads.ts
@@ -1,0 +1,96 @@
+import { runBoundedIntegrationSettledFanout } from '../integration-fanout'
+import { boundedIntegrationErrorLog } from '../integration-error-message'
+import type { LinearClientForWorkspace } from './client'
+import { LinearAgentAccessError } from './issue-context-errors'
+import { workspaceFailure, type WorkspaceReadFailure } from './issue-context-fanout'
+
+export async function readLinearIssueWorkspaceFanout<TResult>(
+  entries: LinearClientForWorkspace[],
+  selection: string | 'all',
+  readWorkspace: (entry: LinearClientForWorkspace) => Promise<TResult | null>,
+  initialFailures: WorkspaceReadFailure[] = []
+): Promise<{ results: TResult[]; truncated: boolean }> {
+  if (selection !== 'all') {
+    const selected = await readWorkspace(entries[0])
+    return { results: selected ? [selected] : [], truncated: false }
+  }
+
+  const fanout = await runBoundedIntegrationSettledFanout(entries, readWorkspace, (result) =>
+    result ? [result] : []
+  )
+  const results: TResult[] = []
+  const failures: LinearAgentAccessError[] = initialFailures.map((failure) => failure.error)
+
+  for (const result of fanout.results) {
+    if (result.status === 'fulfilled') {
+      if (result.value) {
+        results.push(result.value)
+      }
+      continue
+    }
+    if (result.reason instanceof LinearAgentAccessError) {
+      failures.push(result.reason)
+    }
+    console.warn('[linear] agent issue read failed:', boundedIntegrationErrorLog(result.reason))
+  }
+
+  if (fanout.truncated) {
+    console.warn('[linear] Agent issue fan-out exceeded its aggregate result budget; truncating.')
+  }
+  if (results.length === 0 && failures[0] && !fanout.truncated) {
+    throw failures[0]
+  }
+  return { results, truncated: fanout.truncated }
+}
+
+export async function readLinearSearchWorkspaceFanout<TResult>(
+  entries: LinearClientForWorkspace[],
+  workspaceId: string | 'all' | undefined,
+  readWorkspace: (entry: LinearClientForWorkspace) => Promise<TResult[]>,
+  initialFailures: WorkspaceReadFailure[] = []
+): Promise<{
+  results: TResult[][]
+  failures: WorkspaceReadFailure[]
+  truncated: boolean
+}> {
+  if (workspaceId && workspaceId !== 'all') {
+    return {
+      results: [await readWorkspace(entries[0])],
+      failures: [],
+      truncated: false
+    }
+  }
+
+  const fanout = await runBoundedIntegrationSettledFanout(
+    entries,
+    readWorkspace,
+    (results) => results
+  )
+  const attemptedWorkspaceCount = fanout.attemptedCount + initialFailures.length
+  const results: TResult[][] = []
+  const failures: WorkspaceReadFailure[] = [...initialFailures]
+  for (let index = 0; index < fanout.results.length; index += 1) {
+    const result = fanout.results[index]
+    if (result.status === 'fulfilled') {
+      results.push(result.value)
+      continue
+    }
+    if (result.reason instanceof LinearAgentAccessError) {
+      failures.push(workspaceFailure(entries[index].workspace, result.reason))
+    }
+    console.warn('[linear] agent search failed:', boundedIntegrationErrorLog(result.reason))
+  }
+
+  if (fanout.truncated) {
+    console.warn('[linear] Agent search fan-out exceeded its aggregate result budget; truncating.')
+  }
+  if (
+    results.length === 0 &&
+    failures.length === attemptedWorkspaceCount &&
+    failures[0] &&
+    !fanout.truncated
+  ) {
+    throw failures[0].error
+  }
+  return { results, failures, truncated: fanout.truncated }
+}

--- a/src/main/linear/issue-context-fanout.ts
+++ b/src/main/linear/issue-context-fanout.ts
@@ -1,5 +1,6 @@
 import type { LinearErrorCode, LinearWorkspaceCandidate } from '../../shared/linear-agent-access'
 import type { LinearWorkspace } from '../../shared/types'
+import { boundedIntegrationErrorLog } from '../integration-error-message'
 import { getClients, getStatus, type LinearClientForWorkspace } from './client'
 import {
   LinearAgentAccessError,
@@ -35,7 +36,10 @@ export function getFanoutClientEntries(): {
     } catch (error) {
       const failure = workspaceFailure(workspace, toLinearAccessError(error))
       failures.push(failure)
-      console.warn('[linear] agent workspace credential read failed:', error)
+      console.warn(
+        '[linear] agent workspace credential read failed:',
+        boundedIntegrationErrorLog(error)
+      )
     }
   }
   return { entries, failures }

--- a/src/main/linear/issue-context-includes.ts
+++ b/src/main/linear/issue-context-includes.ts
@@ -17,6 +17,8 @@ import {
   clampLinearIssueDepth
 } from '../../shared/linear-agent-access'
 import { extractLinearInlineMedia } from '../../shared/linear-inline-media'
+import { boundedIntegrationErrorMessage } from '../integration-error-message'
+import { IntegrationPaginationBudget } from '../integration-pagination-budget'
 import type { ResolvedIssue } from './issue-context-client'
 import { getRequiredEntry, withLinearRead } from './issue-context-client'
 import { getPublicFileUrlClient } from './client'
@@ -69,7 +71,7 @@ export async function readOptionalIncludes(
       includeErrors.push({
         include,
         code: includeErrorCode(error),
-        message: error instanceof Error ? error.message : String(error)
+        message: boundedIntegrationErrorMessage(error)
       })
     }
   }
@@ -175,6 +177,7 @@ async function readChildren(
   let returned = 0
   let capReached = false
   let depthReached = false
+  const budget = new IntegrationPaginationBudget()
 
   const readLevel = async (issueId: string, level: number): Promise<LinearIssueChildNode[]> => {
     if (level > depth || returned >= LINEAR_CHILDREN_NODE_CAP) {
@@ -182,16 +185,20 @@ async function readChildren(
       return []
     }
     const remaining = LINEAR_CHILDREN_NODE_CAP - returned
-    const response = await readConnectionPages(remaining, async (page) => {
-      return await withLinearRead(entry, async () => {
-        const client = getPublicFileUrlClient(entry)
-        const raw = await client.client.rawRequest<RawChildrenResponse, Record<string, unknown>>(
-          CHILDREN_QUERY,
-          { id: issueId, ...page }
-        )
-        return raw.data?.issue?.children ?? null
-      })
-    })
+    const response = await readConnectionPages(
+      remaining,
+      async (page) => {
+        return await withLinearRead(entry, async () => {
+          const client = getPublicFileUrlClient(entry)
+          const raw = await client.client.rawRequest<RawChildrenResponse, Record<string, unknown>>(
+            CHILDREN_QUERY,
+            { id: issueId, ...page }
+          )
+          return raw.data?.issue?.children ?? null
+        })
+      },
+      budget
+    )
     const nodes = response.nodes
     if (response.hasMore || nodes.length > remaining) {
       capReached = true

--- a/src/main/linear/issue-context-pagination.test.ts
+++ b/src/main/linear/issue-context-pagination.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { IntegrationPaginationBudget } from '../integration-pagination-budget'
+import { readConnectionPages } from './issue-context-pagination'
+
+describe('Linear issue context pagination', () => {
+  it('stops before retaining a page that exceeds the aggregate byte budget', async () => {
+    const loadConnection = vi
+      .fn()
+      .mockResolvedValueOnce({
+        nodes: [{ id: 'first', body: 'small' }],
+        pageInfo: { hasNextPage: true, endCursor: 'next' }
+      })
+      .mockResolvedValueOnce({
+        nodes: [{ id: 'second', body: 'x'.repeat(100) }],
+        pageInfo: { hasNextPage: false, endCursor: null }
+      })
+    const budget = new IntegrationPaginationBudget({
+      maxPages: 10,
+      maxItems: 10,
+      maxRetainedBytes: 64
+    })
+
+    await expect(readConnectionPages(10, loadConnection, budget)).resolves.toEqual({
+      nodes: [{ id: 'first', body: 'small' }],
+      hasMore: true
+    })
+    expect(loadConnection).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports truncation when a backend over-delivers the requested page', async () => {
+    await expect(
+      readConnectionPages(1, async () => ({
+        nodes: [{ id: 'first' }, { id: 'omitted' }],
+        pageInfo: { hasNextPage: false, endCursor: null }
+      }))
+    ).resolves.toEqual({
+      nodes: [{ id: 'first' }],
+      hasMore: true
+    })
+  })
+})

--- a/src/main/linear/issue-context-pagination.ts
+++ b/src/main/linear/issue-context-pagination.ts
@@ -1,4 +1,5 @@
 import { LINEAR_ISSUE_API_PAGE_SIZE_MAX } from '../../shared/linear-issue-read-limits'
+import { IntegrationPaginationBudget } from '../integration-pagination-budget'
 
 export type LinearPageVariables = { first: number; after?: string }
 
@@ -12,7 +13,8 @@ export type LinearConnection<T> = {
 
 export async function readConnectionPages<T>(
   limit: number,
-  loadConnection: (page: LinearPageVariables) => Promise<LinearConnection<T>>
+  loadConnection: (page: LinearPageVariables) => Promise<LinearConnection<T>>,
+  budget = new IntegrationPaginationBudget()
 ): Promise<{ nodes: T[]; hasMore: boolean }> {
   const nodes: T[] = []
   let after: string | undefined
@@ -24,12 +26,20 @@ export async function readConnectionPages<T>(
     const first = Math.min(LINEAR_ISSUE_API_PAGE_SIZE_MAX, limit - nodes.length)
     const connection = await loadConnection(after ? { first, after } : { first })
     const pageNodes = connection?.nodes ?? []
-    nodes.push(...pageNodes.slice(0, limit - nodes.length))
-    hasMore = Boolean(connection?.pageInfo?.hasNextPage)
+    const retainedPageNodes = pageNodes.slice(0, limit - nodes.length)
+    hasMore =
+      pageNodes.length > retainedPageNodes.length || Boolean(connection?.pageInfo?.hasNextPage)
+    if (!budget.admitPage(retainedPageNodes)) {
+      return { nodes, hasMore: true }
+    }
+    nodes.push(...retainedPageNodes)
 
     const nextCursor = connection?.pageInfo?.endCursor ?? undefined
     if (!hasMore || !nextCursor || nextCursor === after || pageNodes.length === 0) {
       break
+    }
+    if (!budget.canRequestPage) {
+      return { nodes, hasMore: true }
     }
     after = nextCursor
   }

--- a/src/main/linear/issue-context-raw.ts
+++ b/src/main/linear/issue-context-raw.ts
@@ -231,7 +231,7 @@ export function mapIssue(issue: RawIssue): LinearIssueSummary {
     project: issue.project ?? null,
     cycle: issue.cycle ?? null,
     assignee: issue.assignee ?? null,
-    labels: issue.labels?.nodes ?? [],
+    labels: (issue.labels?.nodes ?? []).slice(0, 50),
     priority: issue.priority,
     estimate: issue.estimate,
     dueDate: issue.dueDate,

--- a/src/main/linear/issue-context-relations.ts
+++ b/src/main/linear/issue-context-relations.ts
@@ -1,5 +1,6 @@
 import type { LinearCollectionMeta, LinearIssueRelation } from '../../shared/linear-agent-access'
 import { LINEAR_RELATIONS_CAP } from '../../shared/linear-agent-access'
+import { IntegrationPaginationBudget } from '../integration-pagination-budget'
 import type { ResolvedIssue } from './issue-context-client'
 import { getRequiredEntry, withLinearRead } from './issue-context-client'
 import { readConnectionPages } from './issue-context-pagination'
@@ -16,15 +17,20 @@ export async function readIssueRelations(
   resolved: ResolvedIssue
 ): Promise<{ items: LinearIssueRelation[]; meta: LinearCollectionMeta }> {
   const entry = getRequiredEntry(resolved.workspace.id)
-  const response = await readConnectionPages(LINEAR_RELATIONS_CAP, async (page) => {
-    return await withLinearRead(entry, async () => {
-      const raw = await entry.client.client.rawRequest<
-        RawRelationsResponse,
-        Record<string, unknown>
-      >(RELATIONS_QUERY, { id: resolved.issue.id, ...page })
-      return raw.data?.issue?.relations ?? null
-    })
-  })
+  const budget = new IntegrationPaginationBudget()
+  const response = await readConnectionPages(
+    LINEAR_RELATIONS_CAP,
+    async (page) => {
+      return await withLinearRead(entry, async () => {
+        const raw = await entry.client.client.rawRequest<
+          RawRelationsResponse,
+          Record<string, unknown>
+        >(RELATIONS_QUERY, { id: resolved.issue.id, ...page })
+        return raw.data?.issue?.relations ?? null
+      })
+    },
+    budget
+  )
   const outbound = response.nodes
     .slice(0, LINEAR_RELATIONS_CAP)
     .map((node) => mapRelation(node, 'outbound', node.relatedIssue))
@@ -32,15 +38,19 @@ export async function readIssueRelations(
   // Why: when outbound relations exactly fill the cap, probe inverse relations so
   // the response cannot claim completeness while silently omitting inbound ones.
   const inverseReadLimit = Math.max(1, remaining)
-  const inverse = await readConnectionPages(inverseReadLimit, async (page) => {
-    return await withLinearRead(entry, async () => {
-      const raw = await entry.client.client.rawRequest<
-        RawRelationsResponse,
-        Record<string, unknown>
-      >(INVERSE_RELATIONS_QUERY, { id: resolved.issue.id, ...page })
-      return raw.data?.issue?.inverseRelations ?? null
-    })
-  })
+  const inverse = await readConnectionPages(
+    inverseReadLimit,
+    async (page) => {
+      return await withLinearRead(entry, async () => {
+        const raw = await entry.client.client.rawRequest<
+          RawRelationsResponse,
+          Record<string, unknown>
+        >(INVERSE_RELATIONS_QUERY, { id: resolved.issue.id, ...page })
+        return raw.data?.issue?.inverseRelations ?? null
+      })
+    },
+    budget
+  )
   const inbound = inverse.nodes
     .slice(0, remaining)
     .map((node) => mapRelation(node, 'inbound', node.issue))

--- a/src/main/linear/issues-retention-bounds.test.ts
+++ b/src/main/linear/issues-retention-bounds.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LinearClientForWorkspace } from './client'
+import { MAX_INTEGRATION_ACCOUNTS } from '../integration-account-persistence-limits'
+import { LINEAR_SEARCH_MAX_LIMIT } from '../../shared/linear-agent-access'
+
+const getClients = vi.fn()
+
+vi.mock('./client', () => ({
+  acquire: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+  getClients: (...args: unknown[]) => getClients(...args),
+  isAuthError: vi.fn().mockReturnValue(false),
+  clearToken: vi.fn()
+}))
+
+function issue(id: string) {
+  return {
+    id,
+    identifier: id,
+    title: id,
+    description: '',
+    url: `https://linear.app/${id}`,
+    estimate: null,
+    priority: 0,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    labelIds: [],
+    labels: { nodes: [] }
+  }
+}
+
+function entry(id: string, rawRequest: ReturnType<typeof vi.fn>): LinearClientForWorkspace {
+  return {
+    workspace: {
+      id,
+      organizationId: id,
+      organizationName: id,
+      displayName: 'Ada',
+      email: null
+    },
+    client: { client: { rawRequest } }
+  } as unknown as LinearClientForWorkspace
+}
+
+describe('Linear issue retention bounds', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('retains only the requested list page when a provider returns extra rows', async () => {
+    const rawRequest = vi.fn().mockResolvedValue({
+      data: {
+        issues: {
+          nodes: [issue('LIN-1'), issue('LIN-2')],
+          pageInfo: { hasNextPage: false }
+        }
+      }
+    })
+    getClients.mockReturnValue([entry('workspace-1', rawRequest)])
+    const { listIssues } = await import('./issues')
+
+    await expect(listIssues('all', 1, 'workspace-1')).resolves.toMatchObject({
+      items: [{ id: 'LIN-1' }],
+      hasMore: true
+    })
+    expect(rawRequest.mock.calls[0]?.[1]).toMatchObject({ first: 1 })
+  })
+
+  it('clamps direct search callers and maps no more than the requested rows', async () => {
+    const rawRequest = vi.fn().mockResolvedValue({
+      data: {
+        searchIssues: {
+          nodes: Array.from({ length: LINEAR_SEARCH_MAX_LIMIT + 1 }, (_, index) =>
+            issue(`LIN-${index + 1}`)
+          )
+        }
+      }
+    })
+    getClients.mockReturnValue([entry('workspace-1', rawRequest)])
+    const { searchIssues } = await import('./issues')
+
+    await expect(searchIssues('bug', Number.MAX_SAFE_INTEGER, 'workspace-1')).resolves.toHaveLength(
+      LINEAR_SEARCH_MAX_LIMIT
+    )
+    expect(rawRequest.mock.calls[0]?.[1]).toMatchObject({ first: LINEAR_SEARCH_MAX_LIMIT })
+  })
+
+  it('stops all-workspace scheduling at the aggregate account boundary', async () => {
+    const requests = Array.from({ length: MAX_INTEGRATION_ACCOUNTS + 1 }, (_, index) =>
+      vi.fn().mockResolvedValue({
+        data: {
+          issues: {
+            nodes: [issue(`LIN-${index + 1}`)],
+            pageInfo: { hasNextPage: false }
+          }
+        }
+      })
+    )
+    getClients.mockReturnValue(
+      requests.map((request, index) => entry(`workspace-${index}`, request))
+    )
+    const { listIssues } = await import('./issues')
+
+    await expect(listIssues('all', 1, 'all')).resolves.toMatchObject({
+      items: [{ id: 'LIN-1' }],
+      hasMore: true
+    })
+    expect(requests[MAX_INTEGRATION_ACCOUNTS - 1]).toHaveBeenCalledTimes(1)
+    expect(requests[MAX_INTEGRATION_ACCOUNTS]).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/linear/issues.ts
+++ b/src/main/linear/issues.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../shared/types'
 import type { LinearClient } from '@linear/sdk'
 import { loadLinearSdk } from './linear-sdk'
+import { clampLinearSearchLimit } from '../../shared/linear-agent-access'
 import {
   LINEAR_ISSUE_API_PAGE_SIZE_MAX,
   clampLinearIssueListLimit
@@ -19,6 +20,15 @@ import {
   isEmptyLinearIssueAttributeFilter,
   type LinearIssueAttributeFilter
 } from '../../shared/linear-issue-attribute-filter'
+import {
+  boundedIntegrationErrorLog,
+  boundedIntegrationErrorMessage
+} from '../integration-error-message'
+import { createIntegrationFanoutBudget, runBoundedIntegrationFanout } from '../integration-fanout'
+import {
+  INTEGRATION_PAGINATION_MAX_ITEMS,
+  IntegrationPaginationBudget
+} from '../integration-pagination-budget'
 import {
   acquire,
   release,
@@ -397,7 +407,7 @@ function mapRawIssueForWorkspace(
   entry: LinearClientForWorkspace,
   issue: LinearIssueNode
 ): LinearIssue {
-  const labelNodes = issue.labels?.nodes ?? []
+  const labelNodes = (issue.labels?.nodes ?? []).slice(0, LINEAR_ISSUE_API_PAGE_SIZE_MAX)
   return {
     id: issue.id,
     identifier: issue.identifier,
@@ -418,7 +428,9 @@ function mapRawIssueForWorkspace(
     labels: labelNodes.map((label) => label.name),
     // Why: labelIds drives full-replace updates. Keep Linear's complete id
     // list even when display label nodes are paginated.
-    labelIds: issue.labelIds ?? labelNodes.map((label) => label.id),
+    labelIds:
+      issue.labelIds?.slice(0, INTEGRATION_PAGINATION_MAX_ITEMS) ??
+      labelNodes.map((label) => label.id),
     assignee: issue.assignee
       ? {
           id: issue.assignee.id,
@@ -441,6 +453,7 @@ async function readIssueConnectionPages(
   loadConnection: LinearIssueConnectionLoader
 ): Promise<{ items: LinearIssue[]; hasMore: boolean }> {
   const items: LinearIssue[] = []
+  const budget = new IntegrationPaginationBudget()
   let after: string | undefined
   let hasMore = false
 
@@ -449,12 +462,22 @@ async function readIssueConnectionPages(
     // cursors instead of asking for the whole expanded limit in one request.
     const first = Math.min(LINEAR_ISSUE_API_PAGE_SIZE_MAX, limit - items.length)
     const connection = await loadConnection(after ? { first, after } : { first })
-    const nodes = connection?.nodes ?? []
-    items.push(...nodes.map((issue) => mapRawIssueForWorkspace(entry, issue)))
-    hasMore = Boolean(connection?.pageInfo?.hasNextPage)
+    const pageNodes = connection?.nodes ?? []
+    const nodes = pageNodes.slice(0, first)
+    const pageItems = nodes.map((issue) => mapRawIssueForWorkspace(entry, issue))
+    hasMore = pageNodes.length > nodes.length || Boolean(connection?.pageInfo?.hasNextPage)
+    if (!budget.admitPage(pageItems)) {
+      console.warn('[linear] Issue list exceeded its retained result budget; truncating.')
+      return { items, hasMore: true }
+    }
+    items.push(...pageItems)
 
     const nextCursor = connection?.pageInfo?.endCursor ?? undefined
-    if (!hasMore || !nextCursor || nextCursor === after || nodes.length === 0) {
+    if (!hasMore || !nextCursor || nextCursor === after || pageNodes.length === 0) {
+      break
+    }
+    if (!budget.canRequestPage) {
+      console.warn('[linear] Issue list reached its retained result budget; truncating.')
       break
     }
     after = nextCursor
@@ -539,7 +562,7 @@ function shouldThrowAuthError(selection: LinearWorkspaceSelection | null | undef
 }
 
 function linearWriteMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+  return boundedIntegrationErrorMessage(error)
 }
 
 function isDuplicateIdError(error: unknown): boolean {
@@ -643,7 +666,7 @@ async function runLinearLookup<T>(
 }
 
 function isLinearLookupMiss(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error)
+  const message = boundedIntegrationErrorMessage(error)
   // Why: Linear throws for direct entity lookups that miss; write-id probes
   // need the same null shape as GraphQL nullable data, not a failed write.
   return message.includes('Entity not found:') && message.includes('Could not find referenced')
@@ -703,7 +726,10 @@ function mapRawIssueWriteRecord(
 ): LinearIssueWriteRecord {
   return {
     ...issue,
-    labels: issue.labels?.nodes ?? []
+    ...(issue.labelIds
+      ? { labelIds: issue.labelIds.slice(0, INTEGRATION_PAGINATION_MAX_ITEMS) }
+      : {}),
+    labels: (issue.labels?.nodes ?? []).slice(0, LINEAR_ISSUE_API_PAGE_SIZE_MAX)
   }
 }
 
@@ -731,7 +757,7 @@ export async function getIssue(
           throw error
         }
       } else {
-        console.warn('[linear] getIssue failed:', error)
+        console.warn('[linear] getIssue failed:', boundedIntegrationErrorLog(error))
       }
     } finally {
       release()
@@ -814,20 +840,22 @@ export async function searchIssues(
   limit = 20,
   workspaceId?: LinearWorkspaceSelection | null
 ): Promise<LinearIssue[]> {
+  const effectiveLimit = clampLinearSearchLimit(limit)
   const entries = getClients(workspaceId)
   if (entries.length === 0) {
     return []
   }
 
-  const results = await Promise.all(
-    entries.map(async (entry) => {
+  const fanout = await runBoundedIntegrationFanout(
+    entries,
+    async (entry) => {
       await acquire()
       try {
         const result = await entry.client.client.rawRequest<
           LinearIssueConnectionResponse,
           LinearRawVariables
-        >(SEARCH_ISSUES_QUERY, { term: query, first: limit })
-        const nodes = result.data?.searchIssues?.nodes ?? []
+        >(SEARCH_ISSUES_QUERY, { term: query, first: effectiveLimit })
+        const nodes = (result.data?.searchIssues?.nodes ?? []).slice(0, effectiveLimit)
         return nodes.map((issue) => mapRawIssueForWorkspace(entry, issue))
       } catch (error) {
         if (isAuthError(error)) {
@@ -836,21 +864,28 @@ export async function searchIssues(
             throw error
           }
         } else {
-          console.warn('[linear] searchIssues failed:', error)
+          console.warn('[linear] searchIssues failed:', boundedIntegrationErrorLog(error))
         }
         return []
       } finally {
         release()
       }
-    })
+    },
+    (issues) => issues
   )
   // Why: searchIssues returns Linear's relevance ranking. Re-sorting by
   // updatedAt would discard relevance order for single-workspace results,
   // diverging from Linear's web UI and pre-PR behavior.
-  if (entries.length === 1) {
-    return results.flat().slice(0, limit)
+  if (fanout.truncated) {
+    console.warn(
+      '[linear] Cross-workspace search exceeded its aggregate result budget; truncating.'
+    )
   }
-  return sortAndLimitIssues(results.flat(), limit)
+  const results = fanout.results.flat()
+  if (entries.length === 1) {
+    return results.slice(0, effectiveLimit)
+  }
+  return sortAndLimitIssues(results, effectiveLimit)
 }
 
 export type LinearListFilter = 'assigned' | 'created' | 'all' | 'completed' | 'open'
@@ -875,7 +910,7 @@ function linearWorkspaceError(
   entry: LinearClientForWorkspace,
   error: unknown
 ): LinearWorkspaceError {
-  const message = error instanceof Error ? error.message : String(error)
+  const message = boundedIntegrationErrorMessage(error)
   const lower = message.toLocaleLowerCase()
   const type: LinearWorkspaceError['type'] = isAuthError(error)
     ? 'auth'
@@ -917,7 +952,7 @@ async function readListIssuesForWorkspace(
         throw error
       }
     } else {
-      console.warn('[linear] listIssues failed:', error)
+      console.warn('[linear] listIssues failed:', boundedIntegrationErrorLog(error))
     }
     return { items: [], hasMore: false, errors: [linearWorkspaceError(entry, error)] }
   } finally {
@@ -931,10 +966,11 @@ async function readIssueConnectionPage(
   page: LinearIssuePageRequest
 ): Promise<LinearIssuePageResult> {
   const connection = await loadConnection(page)
-  const nodes = connection?.nodes ?? []
+  const pageNodes = connection?.nodes ?? []
+  const nodes = pageNodes.slice(0, page.first)
   return {
     items: nodes.map((issue) => mapRawIssueForWorkspace(entry, issue)),
-    hasMore: Boolean(connection?.pageInfo?.hasNextPage),
+    hasMore: pageNodes.length > nodes.length || Boolean(connection?.pageInfo?.hasNextPage),
     endCursor: connection?.pageInfo?.endCursor ?? undefined
   }
 }
@@ -942,8 +978,9 @@ async function readIssueConnectionPage(
 async function readListIssuesPageForState(
   state: LinearIssueWorkspacePageState,
   first: number,
-  workspaceId: LinearWorkspaceSelection | null | undefined
-): Promise<void> {
+  workspaceId: LinearWorkspaceSelection | null | undefined,
+  budget?: IntegrationPaginationBudget
+): Promise<boolean> {
   const previousCursor = state.after
   await acquire()
   try {
@@ -952,25 +989,38 @@ async function readListIssuesPageForState(
       state.loadConnection,
       previousCursor ? { first, after: previousCursor } : { first }
     )
+    if (budget && !budget.admitPage(page.items)) {
+      state.hasMore = true
+      state.canPage = false
+      return false
+    }
     state.items.push(...page.items)
     state.hasMore = page.hasMore
     state.after = page.endCursor
     state.canPage = Boolean(
       page.hasMore && page.endCursor && page.endCursor !== previousCursor && page.items.length > 0
     )
+    return true
   } catch (error) {
     state.items = []
     state.hasMore = false
     state.canPage = false
-    state.error = linearWorkspaceError(state.entry, error)
+    const workspaceError = linearWorkspaceError(state.entry, error)
+    state.error = workspaceError
     if (isAuthError(error)) {
       clearToken(state.entry.workspace.id)
       if (shouldThrowAuthError(workspaceId)) {
         throw error
       }
     } else {
-      console.warn('[linear] listIssues failed:', error)
+      console.warn('[linear] listIssues failed:', boundedIntegrationErrorLog(error))
     }
+    if (budget && !budget.admitPage([workspaceError])) {
+      state.error = undefined
+      state.hasMore = true
+      return false
+    }
+    return true
   } finally {
     release()
   }
@@ -1023,15 +1073,38 @@ async function readListIssuesAcrossWorkspaces(
     canPage: false
   }))
   const first = Math.min(LINEAR_ISSUE_API_PAGE_SIZE_MAX, limit)
+  const aggregateBudget = createIntegrationFanoutBudget()
 
   // Why: "all workspaces" is a global sorted list. Pull one bounded page per
   // workspace first, then spend additional API calls only where unseen issues
   // can still change the global updatedAt cutoff.
-  await Promise.all(states.map((state) => readListIssuesPageForState(state, first, workspaceId)))
+  const initialFanout = await runBoundedIntegrationFanout(
+    states,
+    async (state) => {
+      await readListIssuesPageForState(state, first, workspaceId)
+      return state
+    },
+    (state) => [...state.items, ...(state.error ? [state.error] : [])],
+    { budget: aggregateBudget }
+  )
+  const acceptedStates = new Set(initialFanout.results)
+  for (const state of states) {
+    if (!acceptedStates.has(state)) {
+      state.items = []
+      state.error = undefined
+      state.hasMore = true
+      state.canPage = false
+    }
+  }
+  let aggregateTruncated = initialFanout.truncated
 
   for (;;) {
     const nextState = findWorkspaceToPageForLimit(states, limit)
     if (!nextState) {
+      break
+    }
+    if (!aggregateBudget.canRequestPage) {
+      aggregateTruncated = true
       break
     }
     const itemCount = states.reduce((count, state) => count + state.items.length, 0)
@@ -1042,7 +1115,10 @@ async function readListIssuesAcrossWorkspaces(
             LINEAR_ISSUE_API_PAGE_SIZE_MAX,
             Math.max(1, countSelectedIssuesOlderThanWorkspaceBoundary(states, nextState, limit))
           )
-    await readListIssuesPageForState(nextState, pageSize, workspaceId)
+    if (!(await readListIssuesPageForState(nextState, pageSize, workspaceId, aggregateBudget))) {
+      aggregateTruncated = true
+      break
+    }
   }
 
   const limited = sortLimitAndDescribeIssues(
@@ -1051,7 +1127,7 @@ async function readListIssuesAcrossWorkspaces(
   )
   return {
     items: limited.items,
-    hasMore: states.some((state) => state.hasMore) || limited.clipped,
+    hasMore: aggregateTruncated || states.some((state) => state.hasMore) || limited.clipped,
     errors: states.flatMap((state) => (state.error ? [state.error] : []))
   }
 }
@@ -1148,7 +1224,7 @@ export async function createIssue(
       clearToken(entry.workspace.id)
       throw error
     }
-    const message = error instanceof Error ? error.message : String(error)
+    const message = boundedIntegrationErrorMessage(error)
     return { ok: false, error: message }
   } finally {
     release()
@@ -1284,7 +1360,7 @@ export async function updateIssue(
       clearToken(entry.workspace.id)
       throw error
     }
-    const message = error instanceof Error ? error.message : String(error)
+    const message = boundedIntegrationErrorMessage(error)
     return { ok: false, error: message }
   } finally {
     release()
@@ -1381,7 +1457,7 @@ export async function addIssueComment(
       clearToken(entry.workspace.id)
       throw error
     }
-    const message = error instanceof Error ? error.message : String(error)
+    const message = boundedIntegrationErrorMessage(error)
     return { ok: false, error: message }
   } finally {
     release()
@@ -1511,7 +1587,7 @@ export async function getIssueComments(
       LinearRawVariables
     >(ISSUE_COMMENTS_QUERY, { id: issueId })
     const nodes = result.data?.issue?.comments?.nodes ?? []
-    return nodes.map((node) => ({
+    return nodes.slice(0, LINEAR_ISSUE_API_PAGE_SIZE_MAX).map((node) => ({
       id: node.id,
       body: node.body ?? '',
       // Why: rawRequest returns createdAt as an ISO string already; do not
@@ -1529,7 +1605,7 @@ export async function getIssueComments(
       clearToken(entry.workspace.id)
       throw error
     }
-    console.warn('[linear] getIssueComments failed:', error)
+    console.warn('[linear] getIssueComments failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()

--- a/src/main/linear/linear-project-request-coalescer.test.ts
+++ b/src/main/linear/linear-project-request-coalescer.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  LINEAR_PROJECT_MAX_INFLIGHT_KEYS,
+  LINEAR_PROJECT_MAX_INFLIGHT_KEY_BYTES,
+  LinearProjectRequestCoalescer
+} from './linear-project-request-coalescer'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('LinearProjectRequestCoalescer', () => {
+  it('preserves ordinary same-key coalescing and cleans up after settlement', async () => {
+    const coalescer = new LinearProjectRequestCoalescer()
+    const request = deferred<string>()
+    const load = vi.fn(() => request.promise)
+
+    const first = coalescer.coalesce('projects:alpha', load)
+    const second = coalescer.coalesce('projects:alpha', load)
+    expect(first).toBe(second)
+    expect(load).toHaveBeenCalledTimes(1)
+    expect(coalescer.trackedRequestCount).toBe(1)
+
+    request.resolve('done')
+    await expect(first).resolves.toBe('done')
+    expect(coalescer.trackedRequestCount).toBe(0)
+  })
+
+  it('tracks the exact key-count boundary and executes key +1 untracked', async () => {
+    const coalescer = new LinearProjectRequestCoalescer()
+    const requests = Array.from({ length: LINEAR_PROJECT_MAX_INFLIGHT_KEYS + 1 }, () =>
+      deferred<number>()
+    )
+    const promises = requests.map((request, index) =>
+      coalescer.coalesce(`key-${index}`, () => request.promise)
+    )
+
+    expect(coalescer.trackedRequestCount).toBe(LINEAR_PROJECT_MAX_INFLIGHT_KEYS)
+    requests.forEach((request, index) => request.resolve(index))
+    await expect(Promise.all(promises)).resolves.toHaveLength(requests.length)
+    expect(coalescer.trackedRequestCount).toBe(0)
+  })
+
+  it('tracks an exact-size key and executes key byte +1 untracked', async () => {
+    const coalescer = new LinearProjectRequestCoalescer()
+    const exactRequest = deferred<string>()
+    const exact = coalescer.coalesce(
+      'a'.repeat(LINEAR_PROJECT_MAX_INFLIGHT_KEY_BYTES),
+      () => exactRequest.promise
+    )
+    const over = coalescer.coalesce(
+      'a'.repeat(LINEAR_PROJECT_MAX_INFLIGHT_KEY_BYTES + 1),
+      async () => 'over'
+    )
+
+    expect(coalescer.trackedRequestCount).toBe(1)
+    await expect(over).resolves.toBe('over')
+    expect(coalescer.trackedRequestCount).toBe(1)
+    exactRequest.resolve('exact')
+    await expect(exact).resolves.toBe('exact')
+    expect(coalescer.trackedRequestCount).toBe(0)
+  })
+
+  it('keeps a forced replacement tracked when the older request settles', async () => {
+    const coalescer = new LinearProjectRequestCoalescer()
+    const staleRequest = deferred<string>()
+    const freshRequest = deferred<string>()
+
+    const stale = coalescer.coalesce('same', () => staleRequest.promise)
+    const fresh = coalescer.coalesce('same', () => freshRequest.promise, true)
+    staleRequest.resolve('stale')
+    await expect(stale).resolves.toBe('stale')
+    expect(coalescer.trackedRequestCount).toBe(1)
+
+    freshRequest.resolve('fresh')
+    await expect(fresh).resolves.toBe('fresh')
+    expect(coalescer.trackedRequestCount).toBe(0)
+  })
+})

--- a/src/main/linear/linear-project-request-coalescer.ts
+++ b/src/main/linear/linear-project-request-coalescer.ts
@@ -1,0 +1,33 @@
+export const LINEAR_PROJECT_MAX_INFLIGHT_KEYS = 256
+export const LINEAR_PROJECT_MAX_INFLIGHT_KEY_BYTES = 16 * 1024
+
+export class LinearProjectRequestCoalescer {
+  private readonly inFlight = new Map<string, Promise<unknown>>()
+
+  coalesce<T>(key: string, load: () => Promise<T>, force = false): Promise<T> {
+    const existing = this.inFlight.get(key) as Promise<T> | undefined
+    if (existing && !force) {
+      return existing
+    }
+
+    const loaded = load()
+    const mayTrack =
+      Buffer.byteLength(key, 'utf8') <= LINEAR_PROJECT_MAX_INFLIGHT_KEY_BYTES &&
+      (this.inFlight.has(key) || this.inFlight.size < LINEAR_PROJECT_MAX_INFLIGHT_KEYS)
+    if (!mayTrack) {
+      return loaded
+    }
+
+    const tracked = loaded.finally(() => {
+      if (this.inFlight.get(key) === tracked) {
+        this.inFlight.delete(key)
+      }
+    })
+    this.inFlight.set(key, tracked)
+    return tracked
+  }
+
+  get trackedRequestCount(): number {
+    return this.inFlight.size
+  }
+}

--- a/src/main/linear/linear-team-pages.test.ts
+++ b/src/main/linear/linear-team-pages.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  INTEGRATION_PAGINATION_MAX_ITEMS,
+  INTEGRATION_PAGINATION_MAX_PAGES,
+  IntegrationPaginationLimitError
+} from '../integration-pagination-budget'
+import { fetchAllTeamLabels } from './linear-team-pages'
+
+function label(index: number) {
+  return { id: `label-${index}`, name: `Label ${index}`, color: '#888888' }
+}
+
+function cumulativeLabelPage(totalPages: number, advertisesOneMore = false) {
+  let pageNumber = 1
+  const page = {
+    nodes: [label(1)],
+    pageInfo: { hasNextPage: totalPages > 1 || advertisesOneMore },
+    fetchNext: vi.fn(async () => {
+      pageNumber += 1
+      page.nodes.push(label(pageNumber))
+      page.pageInfo.hasNextPage = pageNumber < totalPages || advertisesOneMore
+      return page
+    })
+  }
+  return page
+}
+
+describe('bounded Linear team metadata pagination', () => {
+  it('preserves cumulative node order through the exact page boundary', async () => {
+    const page = cumulativeLabelPage(INTEGRATION_PAGINATION_MAX_PAGES)
+
+    const labels = await fetchAllTeamLabels({ labels: async () => page })
+    expect(labels).toHaveLength(INTEGRATION_PAGINATION_MAX_PAGES)
+    expect(labels[0]).toMatchObject({ id: 'label-1' })
+    expect(labels.at(-1)).toMatchObject({ id: `label-${INTEGRATION_PAGINATION_MAX_PAGES}` })
+    expect(page.fetchNext).toHaveBeenCalledTimes(INTEGRATION_PAGINATION_MAX_PAGES - 1)
+  })
+
+  it('rejects page +1 before asking the SDK to materialize it', async () => {
+    const page = cumulativeLabelPage(INTEGRATION_PAGINATION_MAX_PAGES, true)
+
+    await expect(fetchAllTeamLabels({ labels: async () => page })).rejects.toThrow(
+      IntegrationPaginationLimitError
+    )
+    expect(page.fetchNext).toHaveBeenCalledTimes(INTEGRATION_PAGINATION_MAX_PAGES - 1)
+  })
+
+  it('admits the exact item boundary and rejects item +1', async () => {
+    const exact = {
+      nodes: Array.from({ length: INTEGRATION_PAGINATION_MAX_ITEMS }, (_, index) => label(index)),
+      pageInfo: { hasNextPage: false },
+      fetchNext: vi.fn()
+    }
+    const over = {
+      ...exact,
+      nodes: [...exact.nodes, label(INTEGRATION_PAGINATION_MAX_ITEMS)]
+    }
+
+    await expect(fetchAllTeamLabels({ labels: async () => exact })).resolves.toHaveLength(
+      INTEGRATION_PAGINATION_MAX_ITEMS
+    )
+    await expect(fetchAllTeamLabels({ labels: async () => over })).rejects.toThrow(
+      IntegrationPaginationLimitError
+    )
+  })
+})

--- a/src/main/linear/linear-team-pages.ts
+++ b/src/main/linear/linear-team-pages.ts
@@ -1,5 +1,9 @@
 import type { LinearLabel, LinearMember, LinearTeam, LinearWorkflowState } from '../../shared/types'
 import { buildLinearTeamUrl } from '../../shared/linear-links'
+import {
+  IntegrationPaginationBudget,
+  IntegrationPaginationLimitError
+} from '../integration-pagination-budget'
 import type { LinearClientForWorkspace } from './client'
 
 const TEAM_PAGE_SIZE = 100
@@ -32,13 +36,26 @@ type TeamStateNode = {
   position: number
 }
 
+async function fetchBoundedConnection<TNode>(
+  page: LinearConnectionPage<TNode>
+): Promise<LinearConnectionPage<TNode>> {
+  const budget = new IntegrationPaginationBudget()
+  while (true) {
+    budget.assertCumulativePage(page.nodes)
+    if (!page.pageInfo.hasNextPage) {
+      return page
+    }
+    if (!budget.canRequestPage) {
+      throw new IntegrationPaginationLimitError()
+    }
+    await page.fetchNext()
+  }
+}
+
 export async function fetchAllTeamsForWorkspace(
   entry: LinearClientForWorkspace
 ): Promise<LinearTeam[]> {
-  let page = await entry.client.teams({ first: TEAM_PAGE_SIZE })
-  while (page.pageInfo.hasNextPage) {
-    await page.fetchNext()
-  }
+  const page = await fetchBoundedConnection(await entry.client.teams({ first: TEAM_PAGE_SIZE }))
   return page.nodes.map((t) => ({
     id: t.id,
     workspaceId: entry.workspace.id,
@@ -56,10 +73,7 @@ export async function fetchAllTeamsForWorkspace(
 export async function fetchAllTeamStates(team: {
   states: (variables?: { first?: number }) => Promise<LinearConnectionPage<TeamStateNode>>
 }): Promise<LinearWorkflowState[]> {
-  const states = await team.states({ first: TEAM_PAGE_SIZE })
-  while (states.pageInfo.hasNextPage) {
-    await states.fetchNext()
-  }
+  const states = await fetchBoundedConnection(await team.states({ first: TEAM_PAGE_SIZE }))
   return states.nodes
     .map((s) => ({
       id: s.id,
@@ -74,20 +88,14 @@ export async function fetchAllTeamStates(team: {
 export async function fetchAllTeamLabels(team: {
   labels: (variables?: { first?: number }) => Promise<LinearConnectionPage<TeamLabelNode>>
 }): Promise<LinearLabel[]> {
-  const labels = await team.labels({ first: TEAM_PAGE_SIZE })
-  while (labels.pageInfo.hasNextPage) {
-    await labels.fetchNext()
-  }
+  const labels = await fetchBoundedConnection(await team.labels({ first: TEAM_PAGE_SIZE }))
   return labels.nodes.map((l) => ({ id: l.id, name: l.name, color: l.color }))
 }
 
 export async function fetchAllTeamMembers(team: {
   members: (variables?: { first?: number }) => Promise<LinearConnectionPage<TeamMemberNode>>
 }): Promise<LinearMember[]> {
-  const members = await team.members({ first: TEAM_PAGE_SIZE })
-  while (members.pageInfo.hasNextPage) {
-    await members.fetchNext()
-  }
+  const members = await fetchBoundedConnection(await team.members({ first: TEAM_PAGE_SIZE }))
   return members.nodes.map((m) => ({
     id: m.id,
     displayName: m.displayName,

--- a/src/main/linear/mappers.test.ts
+++ b/src/main/linear/mappers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { mapLinearIssue } from './mappers'
 
 describe('mapLinearIssue', () => {
@@ -46,5 +46,45 @@ describe('mapLinearIssue', () => {
       assignee: undefined,
       project: undefined
     })
+  })
+
+  it('retains only requested lazy-relation rows when the SDK returns extra nodes', async () => {
+    const labels = vi.fn().mockResolvedValue({
+      nodes: Array.from({ length: 51 }, (_, index) => ({
+        id: `label-${index}`,
+        name: `Label ${index}`
+      }))
+    })
+    const children = vi.fn().mockResolvedValue({
+      nodes: Array.from({ length: 26 }, (_, index) => ({
+        id: `child-${index}`,
+        identifier: `LIN-${index}`,
+        title: `Child ${index}`,
+        url: `https://linear.app/child-${index}`
+      }))
+    })
+    const issue = {
+      id: 'issue-1',
+      identifier: 'LIN-1',
+      title: 'Bound relations',
+      description: null,
+      url: 'https://linear.app/LIN-1',
+      estimate: null,
+      priority: 0,
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      state: null,
+      team: null,
+      assignee: null,
+      labels,
+      children
+    }
+
+    const mapped = await mapLinearIssue(issue as never, { includeChildren: true })
+
+    expect(mapped.labels).toHaveLength(50)
+    expect(mapped.labelIds).toHaveLength(50)
+    expect(mapped.subIssues).toHaveLength(25)
+    expect(labels).toHaveBeenCalledWith({ first: 50 })
+    expect(children).toHaveBeenCalledWith({ first: 25 })
   })
 })

--- a/src/main/linear/mappers.ts
+++ b/src/main/linear/mappers.ts
@@ -1,5 +1,7 @@
 import type { Issue, IssueSearchResult } from '@linear/sdk'
 import type { LinearIssue, LinearIssueChildSummary } from '../../shared/types'
+import { LINEAR_ISSUE_API_PAGE_SIZE_MAX } from '../../shared/linear-issue-read-limits'
+import { INTEGRATION_PAGINATION_MAX_ITEMS } from '../integration-pagination-budget'
 
 type IssueWithChildren = Issue & {
   children: Issue['children']
@@ -51,21 +53,24 @@ export async function mapLinearIssue(
   let labelIds: string[] = []
   if ('labels' in issue && typeof issue.labels === 'function') {
     try {
-      const labelsConnection = await (issue as Issue).labels()
-      labelNames = labelsConnection.nodes.map((l) => l.name)
-      labelIds = labelsConnection.nodes.map((l) => l.id)
+      const labelsConnection = await (issue as Issue).labels({
+        first: LINEAR_ISSUE_API_PAGE_SIZE_MAX
+      })
+      const labels = labelsConnection.nodes.slice(0, LINEAR_ISSUE_API_PAGE_SIZE_MAX)
+      labelNames = labels.map((label) => label.name)
+      labelIds = labels.map((label) => label.id)
     } catch {
       // Swallow — labels are non-critical display data.
     }
   } else if ('labelIds' in issue && Array.isArray(issue.labelIds)) {
-    labelIds = issue.labelIds as string[]
+    labelIds = issue.labelIds.slice(0, INTEGRATION_PAGINATION_MAX_ITEMS) as string[]
   }
 
   let subIssues: LinearIssueChildSummary[] | undefined
   if (options.includeChildren && 'children' in issue && typeof issue.children === 'function') {
     try {
       const childrenConnection = await (issue as IssueWithChildren).children({ first: 25 })
-      subIssues = childrenConnection.nodes.map(mapLinearIssueChild)
+      subIssues = childrenConnection.nodes.slice(0, 25).map(mapLinearIssueChild)
     } catch {
       // Swallow — child issues are secondary display data and creation still works without them.
     }

--- a/src/main/linear/mcp-issue-list.ts
+++ b/src/main/linear/mcp-issue-list.ts
@@ -2,6 +2,7 @@ import type {
   LinearMcpIssueListRequest,
   LinearMcpIssueListResult
 } from '../../shared/linear-agent-access'
+import { runBoundedIntegrationSettledFanout } from '../integration-fanout'
 import { getClients, getStatus, type LinearClientForWorkspace } from './client'
 import { withLinearRead } from './issue-context-client'
 import { linearError } from './issue-context-errors'
@@ -70,7 +71,7 @@ export async function listMcpIssues(
       nextSteps: ['Connect Linear from Orca settings, then retry the issue list.']
     })
   }
-  const { pages, failures } = await readIssueListWorkspaces(
+  const { pages, failures, truncated } = await readIssueListWorkspaces(
     entries,
     request,
     limit,
@@ -78,7 +79,7 @@ export async function listMcpIssues(
     entryFailures
   )
   const issues = pages.flatMap((page) => page.issues)
-  let hasMore = pages.some((page) => page.hasMore)
+  let hasMore = truncated || pages.some((page) => page.hasMore)
 
   issues.sort((left, right) => compareIssues(left, right, orderBy))
   if (issues.length > limit) {
@@ -96,7 +97,7 @@ export async function listMcpIssues(
         : {}),
       orderBy,
       workspaceId: request.workspaceId === 'all' ? 'all' : entries[0].workspace.id,
-      partial: failures.length > 0,
+      partial: truncated || failures.length > 0,
       workspaceErrors: failures.map(({ workspace, code, message }) => ({
         workspace,
         code,
@@ -125,31 +126,45 @@ async function readIssueListWorkspaces(
   limit: number,
   orderBy: 'createdAt' | 'updatedAt',
   initialFailures: WorkspaceReadFailure[]
-): Promise<{ pages: WorkspaceIssuePage[]; failures: WorkspaceReadFailure[] }> {
+): Promise<{
+  pages: WorkspaceIssuePage[]
+  failures: WorkspaceReadFailure[]
+  truncated: boolean
+}> {
   if (request.workspaceId !== 'all') {
     return {
       pages: [await readIssueListWorkspace(entries[0], request, limit, orderBy)],
-      failures: []
+      failures: [],
+      truncated: false
     }
   }
 
-  const settled = await Promise.allSettled(
-    entries.map((entry) => readIssueListWorkspace(entry, request, limit, orderBy))
+  const fanout = await runBoundedIntegrationSettledFanout(
+    entries,
+    (entry) => readIssueListWorkspace(entry, request, limit, orderBy),
+    (page) => page.issues
   )
   const pages: WorkspaceIssuePage[] = []
   const failures = [...initialFailures]
-  for (let index = 0; index < settled.length; index += 1) {
-    const result = settled[index]
+  for (let index = 0; index < fanout.results.length; index += 1) {
+    const result = fanout.results[index]
     if (result.status === 'fulfilled') {
       pages.push(result.value)
       continue
     }
     failures.push(workspaceFailure(entries[index].workspace, result.reason))
   }
-  if (pages.length === 0 && failures.length === entries.length + initialFailures.length) {
+  if (
+    pages.length === 0 &&
+    failures.length === fanout.attemptedCount + initialFailures.length &&
+    !fanout.truncated
+  ) {
     throw failures[0].error
   }
-  return { pages, failures }
+  if (fanout.truncated) {
+    console.warn('[linear] MCP issue list exceeded its aggregate result budget; truncating.')
+  }
+  return { pages, failures, truncated: fanout.truncated }
 }
 
 async function readIssueListWorkspace(
@@ -170,12 +185,14 @@ async function readIssueListWorkspace(
       includeArchived: request.includeArchived ?? false
     })
     const connection = raw.data?.issues
+    const rawIssues = connection?.nodes ?? []
+    const issues = rawIssues.slice(0, limit)
     return {
-      issues: (connection?.nodes ?? []).map((issue) => ({
+      issues: issues.map((issue) => ({
         ...mapIssue(issue),
         workspace: { id: entry.workspace.id, name: entry.workspace.organizationName }
       })),
-      hasMore: connection?.pageInfo?.hasNextPage === true,
+      hasMore: rawIssues.length > issues.length || connection?.pageInfo?.hasNextPage === true,
       nextCursor: connection?.pageInfo?.endCursor ?? undefined
     }
   })

--- a/src/main/linear/projects.ts
+++ b/src/main/linear/projects.ts
@@ -17,6 +17,15 @@ import {
   clampLinearIssueListLimit
 } from '../../shared/linear-issue-read-limits'
 import {
+  boundedIntegrationErrorLog,
+  boundedIntegrationErrorMessage
+} from '../integration-error-message'
+import { runBoundedIntegrationFanout } from '../integration-fanout'
+import {
+  INTEGRATION_PAGINATION_MAX_ITEMS,
+  IntegrationPaginationBudget
+} from '../integration-pagination-budget'
+import {
   acquire,
   clearToken,
   getClients,
@@ -24,6 +33,7 @@ import {
   release,
   type LinearClientForWorkspace
 } from './client'
+import { LinearProjectRequestCoalescer } from './linear-project-request-coalescer'
 
 type LinearRawVariables = Record<string, unknown>
 
@@ -508,7 +518,7 @@ const CUSTOM_VIEW_PROJECTS_QUERY = `
   }
 `
 
-const inFlight = new Map<string, Promise<unknown>>()
+const requestCoalescer = new LinearProjectRequestCoalescer()
 const LINEAR_PROJECT_API_PAGE_SIZE_MAX = 50
 
 function clampLimit(limit = 20): number {
@@ -516,17 +526,7 @@ function clampLimit(limit = 20): number {
 }
 
 function coalesce<T>(key: string, load: () => Promise<T>, force = false): Promise<T> {
-  const existing = inFlight.get(key) as Promise<T> | undefined
-  if (existing && !force) {
-    return existing
-  }
-  const promise = load().finally(() => {
-    if (inFlight.get(key) === promise) {
-      inFlight.delete(key)
-    }
-  })
-  inFlight.set(key, promise)
-  return promise
+  return requestCoalescer.coalesce(key, load, force)
 }
 
 function normalizeConcreteWorkspaceId(workspaceId: unknown): LinearConcreteWorkspaceId {
@@ -547,7 +547,7 @@ function workspaceError(entry: LinearClientForWorkspace, error: unknown): Linear
   }
 
   const record = error as { name?: string; message?: string; status?: number; response?: unknown }
-  const message = record.message || 'Linear request failed.'
+  const message = boundedIntegrationErrorMessage(record.message || 'Linear request failed.')
   const status =
     typeof record.status === 'number'
       ? record.status
@@ -629,14 +629,15 @@ function mapProjectForWorkspace(
     priorityLabel: project.priorityLabel ?? null,
     lead: mapUser(project.lead),
     members: project.members?.nodes
+      ?.slice(0, 10)
       ?.map(mapUser)
       .filter((user): user is LinearProjectMemberSummary => !!user),
-    teams: project.teams?.nodes?.map((team) => ({
+    teams: project.teams?.nodes?.slice(0, 10).map((team) => ({
       id: team.id,
       name: team.name ?? '',
       key: team.key ?? undefined
     })),
-    labels: project.labels?.nodes?.map((label) => ({
+    labels: project.labels?.nodes?.slice(0, 20).map((label) => ({
       id: label.id,
       name: label.name ?? '',
       color: label.color ?? undefined
@@ -661,7 +662,7 @@ function mapProjectDetailForWorkspace(
 ): LinearProjectDetail {
   return {
     ...mapProjectForWorkspace(entry, project),
-    milestones: project.projectMilestones?.nodes?.map((milestone) => ({
+    milestones: project.projectMilestones?.nodes?.slice(0, 20).map((milestone) => ({
       id: milestone.id,
       name: milestone.name ?? '',
       status: milestone.status ?? undefined,
@@ -669,6 +670,7 @@ function mapProjectDetailForWorkspace(
       progress: milestone.progress ?? null
     })),
     resources: project.externalLinks?.nodes
+      ?.slice(0, 20)
       ?.filter((link) => link.url)
       .map((link) => ({
         id: link.id,
@@ -694,7 +696,7 @@ function mapIssueForWorkspace(
   entry: LinearClientForWorkspace,
   issue: LinearIssueNode
 ): LinearIssue {
-  const labelNodes = issue.labels?.nodes ?? []
+  const labelNodes = (issue.labels?.nodes ?? []).slice(0, LINEAR_ISSUE_API_PAGE_SIZE_MAX)
   return {
     id: issue.id,
     identifier: issue.identifier,
@@ -712,7 +714,9 @@ function mapIssueForWorkspace(
       key: issue.team?.key ?? ''
     },
     labels: labelNodes.map((label) => label.name),
-    labelIds: issue.labelIds ?? labelNodes.map((label) => label.id),
+    labelIds:
+      issue.labelIds?.slice(0, INTEGRATION_PAGINATION_MAX_ITEMS) ??
+      labelNodes.map((label) => label.id),
     assignee: mapUser(issue.assignee),
     estimate: issue.estimate ?? null,
     priority: issue.priority,
@@ -777,6 +781,7 @@ async function readIssueConnectionPages(
   }) => Promise<LinearConnection<LinearIssueNode> | null | undefined>
 ): Promise<LinearCollectionResult<LinearIssue>> {
   const items: LinearIssue[] = []
+  const budget = new IntegrationPaginationBudget()
   let after: string | undefined
   let hasMore = false
 
@@ -785,12 +790,22 @@ async function readIssueConnectionPages(
     // Orca reads must follow cursors to show more than one backend page.
     const first = Math.min(LINEAR_ISSUE_API_PAGE_SIZE_MAX, limit - items.length)
     const connection = await loadConnection(after ? { first, after } : { first })
-    const nodes = connection?.nodes ?? []
-    items.push(...nodes.map((issue) => mapIssueForWorkspace(entry, issue)))
-    hasMore = Boolean(connection?.pageInfo?.hasNextPage)
+    const pageNodes = connection?.nodes ?? []
+    const nodes = pageNodes.slice(0, first)
+    const pageItems = nodes.map((issue) => mapIssueForWorkspace(entry, issue))
+    hasMore = pageNodes.length > nodes.length || Boolean(connection?.pageInfo?.hasNextPage)
+    if (!budget.admitPage(pageItems)) {
+      console.warn('[linear] Project issue list exceeded its retained result budget; truncating.')
+      return { items, hasMore: true }
+    }
+    items.push(...pageItems)
 
     const nextCursor = connection?.pageInfo?.endCursor ?? undefined
-    if (!hasMore || !nextCursor || nextCursor === after || nodes.length === 0) {
+    if (!hasMore || !nextCursor || nextCursor === after || pageNodes.length === 0) {
+      break
+    }
+    if (!budget.canRequestPage) {
+      console.warn('[linear] Project issue list reached its retained result budget; truncating.')
       break
     }
     after = nextCursor
@@ -813,8 +828,9 @@ async function readCollection<T>(
         return { items: [] }
       }
 
-      const results = await Promise.all(
-        entries.map(async (entry) => {
+      const fanout = await runBoundedIntegrationFanout(
+        entries,
+        async (entry) => {
           await acquire()
           try {
             return await load(entry)
@@ -822,7 +838,7 @@ async function readCollection<T>(
             if (isAuthError(error)) {
               clearToken(entry.workspace.id)
             } else {
-              console.warn('[linear] project/view read failed:', error)
+              console.warn('[linear] project/view read failed:', boundedIntegrationErrorLog(error))
             }
             if (shouldFailWholeRequest(workspaceId)) {
               throw error
@@ -831,15 +847,22 @@ async function readCollection<T>(
           } finally {
             release()
           }
-        })
+        },
+        (result) => [...result.items, ...(result.errors ?? [])]
       )
+      if (fanout.truncated) {
+        console.warn(
+          '[linear] Cross-workspace project metadata exceeded its aggregate result budget; truncating.'
+        )
+      }
+      const results = fanout.results
 
       return {
         items: results.flatMap((result) => result.items),
         errors: results.flatMap((result) => result.errors ?? []).length
           ? results.flatMap((result) => result.errors ?? [])
           : undefined,
-        hasMore: results.some((result) => result.hasMore)
+        hasMore: fanout.truncated || results.some((result) => result.hasMore)
       }
     },
     force
@@ -875,9 +898,11 @@ export async function listProjects(
         LinearRawVariables
       >(trimmed ? SEARCH_PROJECTS_QUERY : PROJECTS_QUERY, variables)
       const connection = trimmed ? result.data?.searchProjects : result.data?.projects
+      const rawProjects = connection?.nodes ?? []
+      const projects = rawProjects.slice(0, first)
       return {
-        items: (connection?.nodes ?? []).map((project) => mapProjectForWorkspace(entry, project)),
-        hasMore: !!connection?.pageInfo?.hasNextPage
+        items: projects.map((project) => mapProjectForWorkspace(entry, project)),
+        hasMore: rawProjects.length > projects.length || !!connection?.pageInfo?.hasNextPage
       }
     },
     force
@@ -907,6 +932,7 @@ export async function listProjectsByExactName(
       await acquire()
       try {
         const matches: LinearProjectSummary[] = []
+        const budget = new IntegrationPaginationBudget()
         let after: string | undefined
         while (true) {
           const result = await entry.client.client.rawRequest<
@@ -918,17 +944,31 @@ export async function listProjectsByExactName(
             ...(after ? { after } : {})
           })
           const connection = result.data?.searchProjects
-          for (const project of connection?.nodes ?? []) {
+          const rawNodes = connection?.nodes ?? []
+          const nodes = rawNodes.slice(0, LINEAR_PROJECT_API_PAGE_SIZE_MAX)
+          if (!budget.admitPage(nodes)) {
+            console.warn('[linear] Project search exceeded its retained result budget; truncating.')
+            break
+          }
+          for (const project of nodes) {
             if (project.name.trim().toLowerCase() === normalized) {
               matches.push(mapProjectForWorkspace(entry, project))
             }
           }
+          if (rawNodes.length > nodes.length) {
+            console.warn('[linear] Project search returned more rows than requested; truncating.')
+            break
+          }
           const nextCursor = connection?.pageInfo?.endCursor ?? undefined
+          if (connection?.pageInfo?.hasNextPage === true && !budget.canRequestPage) {
+            console.warn('[linear] Project search reached its retained result budget; truncating.')
+            break
+          }
           if (
             connection?.pageInfo?.hasNextPage !== true ||
             !nextCursor ||
             nextCursor === after ||
-            (connection.nodes ?? []).length === 0
+            nodes.length === 0
           ) {
             break
           }
@@ -1015,7 +1055,7 @@ export async function createProject(
       clearToken(entry.workspace.id)
       throw error
     }
-    const message = error instanceof Error ? error.message : String(error)
+    const message = boundedIntegrationErrorMessage(error)
     return { ok: false, error: message }
   } finally {
     release()
@@ -1073,6 +1113,7 @@ export async function listProjectTeams(
         return []
       }
       const teams: NonNullable<LinearProjectSummary['teams']> = []
+      const budget = new IntegrationPaginationBudget()
       let after: string | undefined
       await acquire()
       try {
@@ -1090,15 +1131,30 @@ export async function listProjectTeams(
             throw new Error('Project was not found')
           }
           const connection = project.teams
-          const nodes = connection?.nodes ?? []
-          teams.push(
-            ...nodes.map((team) => ({
+          const rawNodes = connection?.nodes ?? []
+          const nodes = rawNodes.slice(0, LINEAR_PROJECT_API_PAGE_SIZE_MAX)
+          if (!budget.admitPage(nodes)) {
+            console.warn(
+              '[linear] Project teams exceeded their retained result budget; truncating.'
+            )
+            break
+          }
+          for (const team of nodes) {
+            teams.push({
               id: team.id,
               name: team.name ?? '',
               key: team.key ?? undefined
-            }))
-          )
+            })
+          }
+          if (rawNodes.length > nodes.length) {
+            console.warn('[linear] Project teams returned more rows than requested; truncating.')
+            break
+          }
           const nextCursor = connection?.pageInfo?.endCursor ?? undefined
+          if (connection?.pageInfo?.hasNextPage === true && !budget.canRequestPage) {
+            console.warn('[linear] Project teams reached their retained result budget; truncating.')
+            break
+          }
           if (
             !connection?.pageInfo?.hasNextPage ||
             !nextCursor ||
@@ -1141,11 +1197,13 @@ export async function listCustomViews(
         LinearRawVariables
       >(CUSTOM_VIEWS_QUERY, { first, filter, orderBy: 'updatedAt' })
       const connection = result.data?.customViews
+      const rawViews = connection?.nodes ?? []
+      const views = rawViews.slice(0, first)
       return {
-        items: (connection?.nodes ?? [])
+        items: views
           .map((view) => mapCustomViewForWorkspace(entry, view))
           .filter((view): view is LinearCustomViewSummary => !!view && view.model === model),
-        hasMore: !!connection?.pageInfo?.hasNextPage
+        hasMore: rawViews.length > views.length || !!connection?.pageInfo?.hasNextPage
       }
     },
     force
@@ -1251,9 +1309,11 @@ export async function listCustomViewProjects(
         throw new Error('Custom view does not contain projects')
       }
       const connection = view?.projects
+      const rawProjects = connection?.nodes ?? []
+      const projects = rawProjects.slice(0, first)
       return {
-        items: (connection?.nodes ?? []).map((project) => mapProjectForWorkspace(entry, project)),
-        hasMore: !!connection?.pageInfo?.hasNextPage
+        items: projects.map((project) => mapProjectForWorkspace(entry, project)),
+        hasMore: rawProjects.length > projects.length || !!connection?.pageInfo?.hasNextPage
       }
     },
     force

--- a/src/main/linear/teams.ts
+++ b/src/main/linear/teams.ts
@@ -6,6 +6,11 @@ import type {
   LinearWorkspaceError,
   LinearWorkspaceSelection
 } from '../../shared/types'
+import {
+  boundedIntegrationErrorLog,
+  boundedIntegrationErrorMessage
+} from '../integration-error-message'
+import { runBoundedIntegrationFanout } from '../integration-fanout'
 import { acquire, release, getClients, isAuthError, clearToken } from './client'
 import {
   fetchAllTeamLabels,
@@ -22,11 +27,12 @@ export async function listTeams(
     return []
   }
 
-  const results = await Promise.all(
-    entries.map(async (entry) => {
+  const fanout = await runBoundedIntegrationFanout(
+    entries,
+    async (entry) => {
       await acquire()
       try {
-        return fetchAllTeamsForWorkspace(entry)
+        return await fetchAllTeamsForWorkspace(entry)
       } catch (error) {
         if (isAuthError(error)) {
           clearToken(entry.workspace.id)
@@ -34,15 +40,21 @@ export async function listTeams(
             throw error
           }
         } else {
-          console.warn('[linear] listTeams failed:', error)
+          console.warn('[linear] listTeams failed:', boundedIntegrationErrorLog(error))
         }
         return []
       } finally {
         release()
       }
-    })
+    },
+    (teams) => teams
   )
-  return results.flat().sort((a, b) => a.name.localeCompare(b.name))
+  if (fanout.truncated) {
+    console.warn(
+      '[linear] Cross-workspace teams exceeded their aggregate result budget; truncating.'
+    )
+  }
+  return fanout.results.flat().sort((a, b) => a.name.localeCompare(b.name))
 }
 
 export async function listTeamsOrThrow(
@@ -53,8 +65,9 @@ export async function listTeamsOrThrow(
     return []
   }
 
-  const results = await Promise.all(
-    entries.map(async (entry) => {
+  const fanout = await runBoundedIntegrationFanout(
+    entries,
+    async (entry) => {
       await acquire()
       try {
         return await fetchAllTeamsForWorkspace(entry)
@@ -66,9 +79,15 @@ export async function listTeamsOrThrow(
       } finally {
         release()
       }
-    })
+    },
+    (teams) => teams
   )
-  return results.flat().sort((a, b) => a.name.localeCompare(b.name))
+  if (fanout.truncated) {
+    console.warn(
+      '[linear] Cross-workspace teams exceeded their aggregate result budget; truncating.'
+    )
+  }
+  return fanout.results.flat().sort((a, b) => a.name.localeCompare(b.name))
 }
 
 export async function listTeamsForAgent(
@@ -79,8 +98,9 @@ export async function listTeamsForAgent(
     return { teams: [], errors: [] }
   }
 
-  const results = await Promise.all(
-    entries.map(async (entry) => {
+  const fanout = await runBoundedIntegrationFanout(
+    entries,
+    async (entry) => {
       await acquire()
       try {
         return { teams: await fetchAllTeamsForWorkspace(entry), error: null }
@@ -94,17 +114,23 @@ export async function listTeamsForAgent(
             workspaceId: entry.workspace.id,
             workspaceName: entry.workspace.organizationName,
             type: isAuthError(error) ? 'auth' : 'unknown',
-            message: error instanceof Error ? error.message : String(error)
+            message: boundedIntegrationErrorMessage(error)
           } satisfies LinearWorkspaceError
         }
       } finally {
         release()
       }
-    })
+    },
+    (result) => [...result.teams, ...(result.error ? [result.error] : [])]
   )
+  if (fanout.truncated) {
+    console.warn('[linear] Agent team list exceeded its aggregate result budget; truncating.')
+  }
   return {
-    teams: results.flatMap((result) => result.teams).sort((a, b) => a.name.localeCompare(b.name)),
-    errors: results.flatMap((result) => (result.error ? [result.error] : []))
+    teams: fanout.results
+      .flatMap((result) => result.teams)
+      .sort((a, b) => a.name.localeCompare(b.name)),
+    errors: fanout.results.flatMap((result) => (result.error ? [result.error] : []))
   }
 }
 
@@ -126,7 +152,7 @@ export async function getTeamStates(
       clearToken(entry.workspace.id)
       throw error
     }
-    console.warn('[linear] getTeamStates failed:', error)
+    console.warn('[linear] getTeamStates failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -174,7 +200,7 @@ export async function getTeamLabels(
       clearToken(entry.workspace.id)
       throw error
     }
-    console.warn('[linear] getTeamLabels failed:', error)
+    console.warn('[linear] getTeamLabels failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()
@@ -222,7 +248,7 @@ export async function getTeamMembers(
       clearToken(entry.workspace.id)
       throw error
     }
-    console.warn('[linear] getTeamMembers failed:', error)
+    console.warn('[linear] getTeamMembers failed:', boundedIntegrationErrorLog(error))
     return []
   } finally {
     release()

--- a/src/main/project-groups/nested-repo-discovery.test.ts
+++ b/src/main/project-groups/nested-repo-discovery.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises'
+import { mkdtemp, mkdir, writeFile, rm, symlink, truncate } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { scanNestedRepos } from './nested-repo-discovery'
+import { NESTED_REPO_GITIGNORE_MAX_BYTES, scanNestedRepos } from './nested-repo-discovery'
 
 let tempDirs: string[] = []
 
@@ -302,6 +302,34 @@ describe('scanNestedRepos', () => {
     expect(result.repos.map((repo) => repo.path)).toEqual(['/workspace/active/repo'])
   })
 
+  it('ignores an oversized gitignore payload instead of retaining its rules', async () => {
+    const directories = new Map([
+      ['/workspace', ['.gitignore', 'repo']],
+      ['/workspace/repo', []]
+    ])
+    const files = new Map([['/workspace/.gitignore', `repo\n${'x'.repeat(1024 * 1024)}`]])
+    const gitRepos = new Set(['/workspace/repo'])
+
+    const result = await scanNestedRepos({
+      path: '/workspace',
+      filesystem: posixTestFilesystem({ directories, gitRepos, files })
+    })
+
+    expect(result.repos.map((repo) => repo.path)).toEqual(['/workspace/repo'])
+  })
+
+  it('skips a sparse oversized local gitignore before reading its payload', async () => {
+    const root = await tempRoot()
+    const ignorePath = join(root, '.gitignore')
+    await writeFile(ignorePath, '')
+    await truncate(ignorePath, NESTED_REPO_GITIGNORE_MAX_BYTES + 1)
+    await makeGitRepo(join(root, 'repo'))
+
+    const result = await scanNestedRepos({ path: root })
+
+    expect(result.repos.map((repo) => repo.displayName)).toEqual(['repo'])
+  })
+
   it('keeps root-anchored gitignore rules scoped to their base directory', async () => {
     const directories = new Map([
       ['/workspace', ['.gitignore', 'active', 'ignored']],
@@ -352,6 +380,49 @@ describe('scanNestedRepos', () => {
 
     expect(result.repos.map((repo) => repo.path)).toEqual(['/workspace/repo'])
     expect(selectedPathChecks).toEqual(['/workspace'])
+  })
+
+  it('accepts the exact aggregate entry capacity without truncation', async () => {
+    const directories = new Map([['/workspace', ['api', 'web']]])
+    const gitRepos = new Set(['/workspace/api', '/workspace/web'])
+
+    const result = await scanNestedRepos({
+      path: '/workspace',
+      filesystem: posixTestFilesystem({ directories, gitRepos }),
+      limits: { maxEntries: 2 }
+    })
+
+    expect(result.repos.map((repo) => repo.path)).toEqual(['/workspace/api', '/workspace/web'])
+    expect(result.truncated).toBe(false)
+  })
+
+  it('returns bounded partial results and closes the iterator on entry overflow', async () => {
+    let iteratorClosed = false
+    const filesystem = {
+      ...posixTestFilesystem({
+        directories: new Map(),
+        gitRepos: new Set(['/workspace/api', '/workspace/web', '/workspace/worker'])
+      }),
+      readDirectory: async function* () {
+        try {
+          yield { name: 'api', isDirectory: true }
+          yield { name: 'web', isDirectory: true }
+          yield { name: 'worker', isDirectory: true }
+        } finally {
+          iteratorClosed = true
+        }
+      }
+    }
+
+    const result = await scanNestedRepos({
+      path: '/workspace',
+      filesystem,
+      limits: { maxEntries: 2 }
+    })
+
+    expect(result.repos.map((repo) => repo.path)).toEqual(['/workspace/api', '/workspace/web'])
+    expect(result.truncated).toBe(true)
+    expect(iteratorClosed).toBe(true)
   })
 
   it('skips heavy directories and respects result caps', async () => {

--- a/src/main/project-groups/nested-repo-discovery.ts
+++ b/src/main/project-groups/nested-repo-discovery.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: scanner traversal, ignore matching, and filesystem
 abstraction stay together so local, SSH, and runtime scans cannot drift. */
-import { readFile, readdir, stat } from 'node:fs/promises'
+import { opendir, stat } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import type {
   NestedRepoCandidate,
@@ -8,6 +8,8 @@ import type {
   NestedRepoScanResult
 } from '../../shared/types'
 import { isGitRepo } from '../git/repo'
+import { NestedRepoScanBudget, type NestedRepoScanLimits } from './nested-repo-scan-budget'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 
 type NestedRepoDirectoryEntry = {
   name: string
@@ -16,7 +18,12 @@ type NestedRepoDirectoryEntry = {
 }
 
 type NestedRepoScanFilesystem = {
-  readDirectory: (dirPath: string) => Promise<NestedRepoDirectoryEntry[]>
+  readDirectory: (
+    dirPath: string
+  ) =>
+    | AsyncIterable<NestedRepoDirectoryEntry>
+    | Iterable<NestedRepoDirectoryEntry>
+    | Promise<AsyncIterable<NestedRepoDirectoryEntry> | Iterable<NestedRepoDirectoryEntry>>
   readTextFile?: (filePath: string) => Promise<string>
   joinPath: (parentPath: string, childName: string) => string
   basename: (path: string) => string
@@ -46,6 +53,7 @@ type NormalizedNestedRepoScanOptions = {
 
 const DEFAULT_MAX_DEPTH = 3
 const DEFAULT_MAX_REPOS = 100
+export const NESTED_REPO_GITIGNORE_MAX_BYTES = 1024 * 1024
 
 const SKIPPED_DIRS = new Set([
   'node_modules',
@@ -121,24 +129,35 @@ function pathSegmentsMatch(patternSegments: string[], candidateSegments: string[
   return matchFrom(0, 0)
 }
 
-function parseGitignoreRules(content: string, baseSegments: string[]): IgnoreRule[] {
-  return content
-    .split(/\r?\n/)
-    .map((rawLine) => rawLine.trim())
-    .filter((line) => line.length > 0 && !line.startsWith('#'))
-    .map((line) => {
-      const negate = line.startsWith('!')
-      const unprefixed = negate ? line.slice(1) : line
-      const anchored = unprefixed.startsWith('/')
-      const pattern = unprefixed.replace(/^\/+/, '').replace(/\/+$/, '')
-      return {
-        pattern,
-        negate,
-        basenameOnly: !anchored && !pattern.includes('/'),
-        baseSegments
-      }
+function parseGitignoreRules(
+  content: string,
+  baseSegments: string[],
+  budget: NestedRepoScanBudget
+): IgnoreRule[] {
+  const rules: IgnoreRule[] = []
+  for (const match of content.matchAll(/[^\r\n]+/g)) {
+    const line = match[0].trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    const negate = line.startsWith('!')
+    const unprefixed = negate ? line.slice(1) : line
+    const anchored = unprefixed.startsWith('/')
+    const pattern = unprefixed.replace(/^\/+/, '').replace(/\/+$/, '')
+    if (!pattern) {
+      continue
+    }
+    if (!budget.tryRetainIgnoreRule(pattern)) {
+      break
+    }
+    rules.push({
+      pattern,
+      negate,
+      basenameOnly: !anchored && !pattern.includes('/'),
+      baseSegments
     })
-    .filter((rule) => rule.pattern.length > 0)
+  }
+  return rules
 }
 
 function isIgnoredByRules(name: string, segments: string[], rules: IgnoreRule[]): boolean {
@@ -164,6 +183,7 @@ async function readGitignoreRules(args: {
   entries: NestedRepoDirectoryEntry[]
   filesystem: NestedRepoScanFilesystem
   baseSegments: string[]
+  budget: NestedRepoScanBudget
 }): Promise<IgnoreRule[]> {
   if (!args.filesystem.readTextFile || !args.entries.some((entry) => entry.name === '.gitignore')) {
     return []
@@ -172,7 +192,10 @@ async function readGitignoreRules(args: {
     const content = await args.filesystem.readTextFile(
       args.filesystem.joinPath(args.folderPath, '.gitignore')
     )
-    return parseGitignoreRules(content, args.baseSegments)
+    if (Buffer.byteLength(content, 'utf8') > NESTED_REPO_GITIGNORE_MAX_BYTES) {
+      return []
+    }
+    return parseGitignoreRules(content, args.baseSegments, args.budget)
   } catch {
     return []
   }
@@ -195,15 +218,15 @@ async function hasGitMarker(dirPath: string): Promise<boolean> {
   return head?.isFile() === true && objects?.isDirectory() === true && refs?.isDirectory() === true
 }
 
-async function readLocalDirectory(dirPath: string): Promise<NestedRepoDirectoryEntry[]> {
-  // Why: Dirent data avoids one stat per child and keeps symlinked directories
-  // from expanding the scan outside the selected folder.
-  const entries = await readdir(dirPath, { withFileTypes: true })
-  return entries.map((entry) => ({
-    name: entry.name,
-    isDirectory: entry.isDirectory(),
-    isSymlink: entry.isSymbolicLink()
-  }))
+async function* readLocalDirectory(dirPath: string): AsyncGenerator<NestedRepoDirectoryEntry> {
+  const directory = await opendir(dirPath)
+  for await (const entry of directory) {
+    yield {
+      name: entry.name,
+      isDirectory: entry.isDirectory(),
+      isSymlink: entry.isSymbolicLink()
+    }
+  }
 }
 
 export async function scanNestedRepos(args: {
@@ -212,6 +235,7 @@ export async function scanNestedRepos(args: {
   filesystem?: NestedRepoScanFilesystem
   signal?: AbortSignal
   onProgress?: (scan: NestedRepoScanResult) => void
+  limits?: Partial<NestedRepoScanLimits>
 }): Promise<NestedRepoScanResult> {
   const startedAt = Date.now()
   const options = normalizeScanOptions(args.options)
@@ -219,9 +243,13 @@ export async function scanNestedRepos(args: {
   let truncated = false
   let timedOut = false
   let stopped = false
+  const scanBudget = new NestedRepoScanBudget(args.limits)
   const filesystem = args.filesystem ?? {
     readDirectory: readLocalDirectory,
-    readTextFile: (path: string) => readFile(path, 'utf8'),
+    readTextFile: async (path: string) =>
+      (await readNodeFileWithinLimit(path, NESTED_REPO_GITIGNORE_MAX_BYTES)).buffer.toString(
+        'utf8'
+      ),
     joinPath: join,
     basename,
     hasGitMarker,
@@ -281,7 +309,12 @@ export async function scanNestedRepos(args: {
 
     let entries: NestedRepoDirectoryEntry[]
     try {
-      entries = await filesystem.readDirectory(currentFolder.path)
+      entries = await collectNestedRepoDirectoryEntries(
+        await filesystem.readDirectory(currentFolder.path),
+        currentFolder.path,
+        filesystem,
+        scanBudget
+      )
     } catch {
       continue
     }
@@ -294,7 +327,8 @@ export async function scanNestedRepos(args: {
         folderPath: currentFolder.path,
         entries,
         filesystem,
-        baseSegments: currentFolder.segments
+        baseSegments: currentFolder.segments,
+        budget: scanBudget
       }))
     ]
 
@@ -347,7 +381,28 @@ export async function scanNestedRepos(args: {
         })
       }
     }
+    if (scanBudget.capacityReached) {
+      truncated = true
+      break
+    }
   }
 
   return buildResult('non_git_folder')
+}
+
+async function collectNestedRepoDirectoryEntries(
+  source: AsyncIterable<NestedRepoDirectoryEntry> | Iterable<NestedRepoDirectoryEntry>,
+  directoryPath: string,
+  filesystem: NestedRepoScanFilesystem,
+  budget: NestedRepoScanBudget
+): Promise<NestedRepoDirectoryEntry[]> {
+  const entries: NestedRepoDirectoryEntry[] = []
+  for await (const entry of source) {
+    const entryPath = filesystem.joinPath(directoryPath, entry.name)
+    if (!budget.tryVisitEntry(entryPath)) {
+      break
+    }
+    entries.push(entry)
+  }
+  return entries
 }

--- a/src/main/project-groups/nested-repo-scan-budget.test.ts
+++ b/src/main/project-groups/nested-repo-scan-budget.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { NestedRepoScanBudget } from './nested-repo-scan-budget'
+
+describe('NestedRepoScanBudget', () => {
+  it('accepts the exact path-memory capacity and rejects the next entry', () => {
+    const budget = new NestedRepoScanBudget({ maxPathBytes: 258 })
+
+    expect(budget.tryVisitEntry('a')).toBe(true)
+    expect(budget.tryVisitEntry('b')).toBe(false)
+    expect(budget.capacityReached).toBe(true)
+  })
+
+  it('accepts the exact ignore-rule capacity and rejects the next rule', () => {
+    const budget = new NestedRepoScanBudget({ maxIgnoreBytes: 130 })
+
+    expect(budget.tryRetainIgnoreRule('a')).toBe(true)
+    expect(budget.tryRetainIgnoreRule('b')).toBe(false)
+    expect(budget.capacityReached).toBe(true)
+  })
+})

--- a/src/main/project-groups/nested-repo-scan-budget.ts
+++ b/src/main/project-groups/nested-repo-scan-budget.ts
@@ -1,0 +1,61 @@
+export const NESTED_REPO_SCAN_MAX_ENTRIES = 100_000
+export const NESTED_REPO_SCAN_MAX_PATH_BYTES = 32 * 1024 * 1024
+export const NESTED_REPO_SCAN_MAX_IGNORE_RULES = 100_000
+export const NESTED_REPO_SCAN_MAX_IGNORE_BYTES = 8 * 1024 * 1024
+
+const NESTED_REPO_ENTRY_OVERHEAD_BYTES = 256
+const NESTED_REPO_IGNORE_RULE_OVERHEAD_BYTES = 128
+
+export type NestedRepoScanLimits = {
+  maxEntries: number
+  maxIgnoreBytes: number
+  maxIgnoreRules: number
+  maxPathBytes: number
+}
+
+export class NestedRepoScanBudget {
+  private entries = 0
+  private ignoreBytes = 0
+  private ignoreRules = 0
+  private pathBytes = 0
+  readonly limits: NestedRepoScanLimits
+  capacityReached = false
+
+  constructor(requested?: Partial<NestedRepoScanLimits>) {
+    this.limits = {
+      maxEntries: clampLimit(requested?.maxEntries, NESTED_REPO_SCAN_MAX_ENTRIES),
+      maxIgnoreBytes: clampLimit(requested?.maxIgnoreBytes, NESTED_REPO_SCAN_MAX_IGNORE_BYTES),
+      maxIgnoreRules: clampLimit(requested?.maxIgnoreRules, NESTED_REPO_SCAN_MAX_IGNORE_RULES),
+      maxPathBytes: clampLimit(requested?.maxPathBytes, NESTED_REPO_SCAN_MAX_PATH_BYTES)
+    }
+  }
+
+  tryVisitEntry(path: string): boolean {
+    const nextPathBytes = this.pathBytes + path.length * 2 + NESTED_REPO_ENTRY_OVERHEAD_BYTES
+    if (this.entries >= this.limits.maxEntries || nextPathBytes > this.limits.maxPathBytes) {
+      this.capacityReached = true
+      return false
+    }
+    this.entries += 1
+    this.pathBytes = nextPathBytes
+    return true
+  }
+
+  tryRetainIgnoreRule(pattern: string): boolean {
+    const nextBytes = this.ignoreBytes + pattern.length * 2 + NESTED_REPO_IGNORE_RULE_OVERHEAD_BYTES
+    if (this.ignoreRules >= this.limits.maxIgnoreRules || nextBytes > this.limits.maxIgnoreBytes) {
+      this.capacityReached = true
+      return false
+    }
+    this.ignoreRules += 1
+    this.ignoreBytes = nextBytes
+    return true
+  }
+}
+
+function clampLimit(value: number | undefined, maximum: number): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+    return maximum
+  }
+  return Math.min(value, maximum)
+}

--- a/src/main/source-control/hosted-review-api-request.ts
+++ b/src/main/source-control/hosted-review-api-request.ts
@@ -1,3 +1,8 @@
+import {
+  readFetchResponseJsonWithinLimit,
+  readFetchResponseTextWithinLimit
+} from '../lib/fetch-response-body'
+
 export class HostedReviewApiRequestError extends Error {
   readonly status: number | null
   readonly timedOut: boolean
@@ -12,7 +17,7 @@ export class HostedReviewApiRequestError extends Error {
 
 async function readResponseText(response: Response): Promise<string> {
   try {
-    return await response.text()
+    return await readFetchResponseTextWithinLimit(response)
   } catch {
     return ''
   }
@@ -31,7 +36,7 @@ export async function requestHostedReviewJson<T>(
         status: response.status
       })
     }
-    return (await response.json()) as T
+    return await readFetchResponseJsonWithinLimit<T>(response)
   } catch (error) {
     if (error instanceof HostedReviewApiRequestError) {
       throw error

--- a/src/main/source-control/pull-request-template.test.ts
+++ b/src/main/source-control/pull-request-template.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { MAX_HOSTED_REVIEW_TEMPLATE_BYTES, readHostedReviewTemplate } from './pull-request-template'
+
+describe('readHostedReviewTemplate', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  async function makeRepo(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-review-template-'))
+    roots.push(root)
+    await mkdir(join(root, '.github'), { recursive: true })
+    return root
+  }
+
+  it('preserves the first conventional template under the limit', async () => {
+    const repoPath = await makeRepo()
+    await writeFile(join(repoPath, '.github', 'pull_request_template.md'), 'normal template\n')
+    await writeFile(join(repoPath, 'PULL_REQUEST_TEMPLATE.md'), 'fallback\n')
+
+    await expect(readHostedReviewTemplate(repoPath)).resolves.toBe('normal template\n')
+  })
+
+  it('skips an oversized sparse template and reads the next candidate', async () => {
+    const repoPath = await makeRepo()
+    const oversizedPath = join(repoPath, '.github', 'pull_request_template.md')
+    await writeFile(oversizedPath, 'x')
+    await truncate(oversizedPath, MAX_HOSTED_REVIEW_TEMPLATE_BYTES + 1)
+    await writeFile(join(repoPath, '.github', 'PULL_REQUEST_TEMPLATE.md'), 'bounded fallback\n')
+
+    await expect(readHostedReviewTemplate(repoPath)).resolves.toBe('bounded fallback\n')
+  })
+
+  it('accepts a template exactly at the byte limit', async () => {
+    const repoPath = await makeRepo()
+    const body = 'a'.repeat(MAX_HOSTED_REVIEW_TEMPLATE_BYTES)
+    await writeFile(join(repoPath, '.github', 'pull_request_template.md'), body)
+
+    await expect(readHostedReviewTemplate(repoPath)).resolves.toHaveLength(
+      MAX_HOSTED_REVIEW_TEMPLATE_BYTES
+    )
+  })
+})

--- a/src/main/source-control/pull-request-template.ts
+++ b/src/main/source-control/pull-request-template.ts
@@ -1,8 +1,10 @@
-import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { HostedReviewProvider } from '../../shared/hosted-review'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
+
+export const MAX_HOSTED_REVIEW_TEMPLATE_BYTES = 1024 * 1024
 
 const PULL_REQUEST_TEMPLATE_CANDIDATES = [
   '.github/pull_request_template.md',
@@ -28,6 +30,11 @@ function getTemplateCandidates(provider?: HostedReviewProvider | null): string[]
   if (provider === 'gitlab') {
     return [...MERGE_REQUEST_TEMPLATE_CANDIDATES, ...PULL_REQUEST_TEMPLATE_CANDIDATES]
   }
+  if (provider === 'github') {
+    return PULL_REQUEST_TEMPLATE_CANDIDATES.filter(
+      (candidate) => !candidate.startsWith('.azuredevops/') && !candidate.startsWith('.gitea/')
+    )
+  }
   return PULL_REQUEST_TEMPLATE_CANDIDATES
 }
 
@@ -38,27 +45,54 @@ export async function readHostedPullRequestTemplate(
   return readHostedReviewTemplate(repoPath, connectionId)
 }
 
+export async function readGitLabMergeRequestTemplate(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<string> {
+  return readHostedReviewTemplateCandidates(
+    repoPath,
+    connectionId,
+    MERGE_REQUEST_TEMPLATE_CANDIDATES
+  )
+}
+
 export async function readHostedReviewTemplate(
   repoPath: string,
   connectionId?: string | null,
   provider?: HostedReviewProvider | null
 ): Promise<string> {
+  return readHostedReviewTemplateCandidates(repoPath, connectionId, getTemplateCandidates(provider))
+}
+
+async function readHostedReviewTemplateCandidates(
+  repoPath: string,
+  connectionId: string | null | undefined,
+  candidates: readonly string[]
+): Promise<string> {
   const remoteProvider = connectionId ? getSshFilesystemProvider(connectionId) : undefined
   if (connectionId && !remoteProvider) {
     return ''
   }
-  for (const relativeCandidate of getTemplateCandidates(provider)) {
+  for (const relativeCandidate of candidates) {
     try {
       if (remoteProvider) {
         const result = await remoteProvider.readFile(
           joinWorktreeRelativePath(repoPath, relativeCandidate)
         )
-        if (result.isBinary) {
+        if (
+          result.isBinary ||
+          Buffer.byteLength(result.content, 'utf8') > MAX_HOSTED_REVIEW_TEMPLATE_BYTES
+        ) {
           continue
         }
         return result.content
       }
-      return await readFile(join(repoPath, relativeCandidate), 'utf8')
+      return (
+        await readNodeFileWithinLimit(
+          join(repoPath, relativeCandidate),
+          MAX_HOSTED_REVIEW_TEMPLATE_BYTES
+        )
+      ).buffer.toString('utf8')
     } catch {
       // Try the next conventional hosted-review template path.
     }

--- a/src/main/source-control/repository-ref-cache.test.ts
+++ b/src/main/source-control/repository-ref-cache.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildRepositoryRefCacheKey,
+  REPOSITORY_REF_CACHE_KEY_MAX_BYTES,
+  REPOSITORY_REF_CACHE_MAX_ENTRIES,
+  REPOSITORY_REF_CACHE_VALUE_MAX_BYTES,
+  RepositoryRefCache
+} from './repository-ref-cache'
+
+describe('repository ref cache bounds', () => {
+  it('admits an exact-boundary UTF-8 key and rejects one byte over', () => {
+    expect(
+      buildRepositoryRefCacheKey(['a'.repeat(REPOSITORY_REF_CACHE_KEY_MAX_BYTES - 1), ''])
+    ).not.toBeNull()
+    expect(
+      buildRepositoryRefCacheKey(['a'.repeat(REPOSITORY_REF_CACHE_KEY_MAX_BYTES), ''])
+    ).toBeNull()
+  })
+
+  it('measures multibyte keys by bytes', () => {
+    expect(
+      buildRepositoryRefCacheKey(['😀'.repeat(REPOSITORY_REF_CACHE_KEY_MAX_BYTES / 4)])
+    ).not.toBeNull()
+    expect(
+      buildRepositoryRefCacheKey(['😀'.repeat(REPOSITORY_REF_CACHE_KEY_MAX_BYTES / 4 + 1)])
+    ).toBeNull()
+  })
+
+  it('retains exact-boundary values and skips oversized values', () => {
+    const cache = new RepositoryRefCache<{ value: string }>()
+    const exactKey = buildRepositoryRefCacheKey(['exact'])
+    const oversizedKey = buildRepositoryRefCacheKey(['oversized'])
+    const exact = 'a'.repeat(REPOSITORY_REF_CACHE_VALUE_MAX_BYTES)
+    const oversized = 'a'.repeat(REPOSITORY_REF_CACHE_VALUE_MAX_BYTES + 1)
+
+    cache.remember(exactKey, { value: exact }, [exact])
+    cache.remember(oversizedKey, { value: oversized }, [oversized])
+
+    expect(cache.get(exactKey)).toEqual({ found: true, value: { value: exact } })
+    expect(cache.get(oversizedKey)).toEqual({ found: false })
+  })
+
+  it('bounds entry count and refreshes hits before LRU eviction', () => {
+    const cache = new RepositoryRefCache<{ value: number }>()
+    for (let index = 0; index < REPOSITORY_REF_CACHE_MAX_ENTRIES; index += 1) {
+      cache.remember(`key-${index}`, { value: index }, [])
+    }
+    expect(cache.get('key-0')).toEqual({ found: true, value: { value: 0 } })
+    cache.remember('new-key', { value: -1 }, [])
+
+    expect(cache.size).toBe(REPOSITORY_REF_CACHE_MAX_ENTRIES)
+    expect(cache.get('key-0').found).toBe(true)
+    expect(cache.get('key-1')).toEqual({ found: false })
+  })
+
+  it('never retains an inadmissible key', () => {
+    const cache = new RepositoryRefCache<{ value: number }>()
+    cache.remember(null, { value: 1 }, [])
+    expect(cache.size).toBe(0)
+  })
+})

--- a/src/main/source-control/repository-ref-cache.ts
+++ b/src/main/source-control/repository-ref-cache.ts
@@ -1,0 +1,71 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export const REPOSITORY_REF_CACHE_MAX_ENTRIES = 512
+export const REPOSITORY_REF_CACHE_KEY_MAX_BYTES = 4 * 1024
+export const REPOSITORY_REF_CACHE_VALUE_MAX_BYTES = 16 * 1024
+
+export type RepositoryRefCacheLookup<T> = { found: true; value: T | null } | { found: false }
+
+export function buildRepositoryRefCacheKey(parts: readonly string[]): string | null {
+  let remainingBytes = REPOSITORY_REF_CACHE_KEY_MAX_BYTES - Math.max(0, parts.length - 1)
+  if (remainingBytes < 0) {
+    return null
+  }
+  for (const part of parts) {
+    const measured = measureUtf8ByteLength(part, { stopAfterBytes: remainingBytes })
+    if (measured.exceededLimit) {
+      return null
+    }
+    remainingBytes -= measured.byteLength
+  }
+  return parts.join('\0')
+}
+
+export class RepositoryRefCache<T> {
+  private readonly entries = new Map<string, T | null>()
+
+  clear(): void {
+    this.entries.clear()
+  }
+
+  get size(): number {
+    return this.entries.size
+  }
+
+  get(cacheKey: string | null): RepositoryRefCacheLookup<T> {
+    if (cacheKey === null || !this.entries.has(cacheKey)) {
+      return { found: false }
+    }
+    const value = this.entries.get(cacheKey) ?? null
+    this.entries.delete(cacheKey)
+    this.entries.set(cacheKey, value)
+    return { found: true, value }
+  }
+
+  remember(cacheKey: string | null, value: T | null, retainedStrings: readonly string[]): void {
+    if (cacheKey === null || !fitsValueBudget(retainedStrings)) {
+      return
+    }
+    this.entries.delete(cacheKey)
+    this.entries.set(cacheKey, value)
+    while (this.entries.size > REPOSITORY_REF_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.entries.keys().next().value
+      if (oldestKey === undefined) {
+        return
+      }
+      this.entries.delete(oldestKey)
+    }
+  }
+}
+
+function fitsValueBudget(values: readonly string[]): boolean {
+  let remainingBytes = REPOSITORY_REF_CACHE_VALUE_MAX_BYTES
+  for (const value of values) {
+    const measured = measureUtf8ByteLength(value, { stopAfterBytes: remainingBytes })
+    if (measured.exceededLimit) {
+      return false
+    }
+    remainingBytes -= measured.byteLength
+  }
+  return true
+}


### PR DESCRIPTION
## OOM hardening slice 19/29 — bound integration pagination & fan-out (GitHub/GitLab/Linear)

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **19/29** (base: `oom/18-b-agent-hooks-automations`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
This slice re-introduces count/byte/depth/concurrency/retention ceilings across every SCM and issue-tracker integration (GitHub, GitLab, Gitea, Bitbucket, Azure DevOps, Jira, Linear) plus shared helpers (RepositoryRefCache, IntegrationApiConcurrencyGate, IntegrationPaginationBudget, integration fanout, bounded fetch/file readers). Almost all ceilings are overload-only, but a handful of Linear/Jira display .slice caps and a "refuse to overwrite an unreadable/over-limit account file" policy are visible in ordinary use and warrant sign-off.

### ELI5
Imagine every place the app talks to GitHub, GitLab, Jira, Linear, etc. used to accept unlimited data into memory — huge API responses, unlimited cached repos, unbounded queues of pending requests. This change puts a fence around each one: caches hold at most N entries and M bytes, queues reject once absurdly full, pagination stops after so many pages/items, and giant files or responses are skipped. The fences are set very high, so normal users never touch them; they only kick in under abusive or runaway inputs. Two small things a person should confirm: (1) some Linear/Jira lists are now trimmed for display (e.g. a project shows at most 10 members, an assignee picker at most 50 people), and (2) if your saved Jira/Linear accounts file is corrupt or has more than 256 accounts, the app now refuses to touch it and shows you as disconnected until it's fixed, rather than silently overwriting it.

### Proof of OOM fix
- RepositoryRefCache (src/main/source-control/repository-ref-cache.ts): 512 entries, 4KB key, 16KB retained-value bytes, LRU-on-hit; now backs Azure/Bitbucket/Gitea/GitLab repo-ref caches. Tested by repository-ref-cache.test.ts (exact-boundary key/value, LRU eviction, null-key no-op).
- Gitea PR scan cache (gitea/pull-request-scan-cache.ts): GITEA_SCAN_CACHE_MAX_ENTRIES=32, GITEA_SCAN_MAX_IN_FLIGHT=32, key 4KB, 250 PRs, 512KB per entry; overflow runs uncached. Tested by gitea/client.test.ts.
- Tracked upstream snapshot (github/client.ts): MAX_IN_FLIGHT=32, MAX_BRANCHES=4096, 2MB/snapshot, 32MB cache; parser keeps the requested branch while evicting oldest. Tested by tracked-upstream-snapshot-bounds.test.ts.
- PR conflict summary (github/conflict-summary.ts): PR_CONFLICT_FILES_MAX_ENTRIES=512, PR_CONFLICT_FILES_MAX_BYTES=256KB; conflict-summary-cache adds 32 in-flight cap. Tested by conflict-summary-bounds.test.ts.
- IntegrationApiConcurrencyGate (integration-api-concurrency.ts): 4 concurrent, INTEGRATION_API_MAX_WAITERS=1024 then acquire() rejects. Tested by integration-api-concurrency.test.ts (FIFO + queue-full rejection).
- Integration account persistence (integration-account-persistence-limits.ts): MAX_INTEGRATION_ACCOUNTS=256, 64KB credential, 1MB file, per-field byte caps. Tested by integration-account-persistence-limits.test.ts + jira/linear client.test.ts.
- IntegrationPaginationBudget (integration-pagination-budget.ts): 100 pages, 10,000 items, 32MB retained. Tested by integration-pagination-budget.test.ts, linear-team-pages.test.ts, issue-context-pagination.test.ts, issues-retention-bounds.test.ts.
- GLAB known-hosts (gitlab/gitlab-known-host-probe.ts): 64 hosts, 1KB/host, 32KB aggregate, 64 contexts, 128KB context-key bytes, 16 in-flight, 1MB subprocess output cap. Tested by gl-utils.test.ts.
- Nested repo scan (project-groups/nested-repo-scan-budget.ts): 100k entries, 32MB paths, 100k ignore rules, 8MB ignore bytes, 1MB gitignore; readdir->streaming opendir. Tested by nested-repo-scan-budget.test.ts + nested-repo-discovery.test.ts.
- PR refresh coordinator (github/pr-refresh-memory-bounds.ts): queue/alias/retry-state/active-scope/visible-candidate limits, capacity-skip broadcast. Tested by pr-refresh-memory-bounds.test.ts + pr-refresh-coordinator-memory.test.ts.
- GitHub remote identity parsing: 64KB URL, 1KB host, 256B owner, 1KB repo. Tested by github-remote-identity-parsing.test.ts. GitLab rate-limit cache: 64 entries, 1KB host (client-mr.test.ts). Local git-config signature: 4MB config, 64KB pointer, 256 includes, depth 8 (gh-utils.test.ts).
- Bounded fetch bodies (readFetchResponseJsonWithinLimit/Text) applied to Azure/Bitbucket/Gitea/Jira/hosted-review requests; bounded file readers for credential files (1MB, integration-credential-file.test.ts) and PR templates (1MB, pull-request-template.test.ts). Linear project request coalescer: 256 keys, 16KB key (linear-project-request-coalescer.test.ts).

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **low**: Linear project-detail lists are silently hard-capped for display: members slice(0,10), teams slice(0,10), labels slice(0,20), milestones slice(0,20), external resources slice(0,20), and issue sub-issues slice(0,25) (src/main/linear/projects.ts:632-673, src/main/linear/mappers.ts:73). The member/team cap of 10 is low enough that ordinary teams larger than ~10 people will see a truncated list with no 'more' indicator. Display-only: no data loss, no crash. _(trigger: Viewing a Linear project with more than 10 members/teams or 20 labels/milestones in normal use.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- IntegrationApiConcurrencyGate.acquire() rejects with 'queue is full' only past 1024 simultaneously-queued integration API calls; ordinary use has <=4 running.
- Gitea scan / GitHub origin-repo / owner-repo / host-auth / GitLab project-ref / config-signature in-flight caps (16-32) fall back to an uncached probe only when that many distinct probes are concurrently outstanding.
- Tracked-upstream parser drops branches only beyond 4096 branches or 2MB/snapshot per repo, always keeping the currently requested branch.
- PR conflict summary truncates only past 512 conflicting files or 256KB of paths.
- IntegrationPaginationBudget truncates Jira/Linear list/search/team results only past 100 pages, 10k items, or 32MB; cross-account fanout stops scheduling past 256 accounts.
- GLAB known-hosts retains newest 64 hosts; users with >64 GitLab hosts lose oldest entries.
- Nested-repo scan returns truncated:true only past 100k directory entries / 32MB of paths; gitignore files >1MB are ignored.
- Saved-account files are treated as unreadable only if corrupt, version!=1, >256 accounts, or a field exceeds its byte cap.
- PR-refresh queue/alias capacity-skips broadcast 'capacity' only past the (large) queue/alias limits under sustained gh backpressure.
- Bounded fetch/file readers skip only responses/files exceeding their (MB-scale) caps.
- If a user's ~/.orca/jira-sites.json or linear-workspaces.json is corrupt, has version!=1, contains >256 accounts, or has any field over its byte cap, the integration now reports connected:false with an empty account list, and connect/disconnect/clearToken throw 'left unchanged' / unreadable errors instead of overwriting the file. This blocks all account operations until the file is fixed or removed. _(only when: Pre-existing over-limit or malformed saved-account file (e.g. >256 sites, or hand-edited/corrupt JSON). Not reachable for ordinary valid files.)_
- Linear project detail lists are hard-capped for display: members slice(0,10), teams slice(0,10), labels slice(0,20), milestones slice(0,20), external resources slice(0,20). Projects exceeding these show a truncated list with no explicit 'more' indicator. _(only when: Viewing a Linear project with more than 10 members/teams or 20 labels/milestones/resources — reachable for large teams in ordinary use.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.

### Adversarial review
- 2 skeptic lens(es). Sign-off: **FLAGGED — see above**. Residual risk: **low**.
- Adversarial regression pass on slice #19 (B-integrations-scm). Refuted the prior reviewer's two 'low' user-facing flags: (1) Linear project detail slice caps (members/teams 10, labels/milestones/resources 20) are defensive no-ops — BASE projects.ts GraphQL already fetched members(first:10)/teams(first:10)/labels(first:20)/projectMilestones(first:20)/externalLinks(first:20), so the slice mirrors existing query limits and changes nothing user-visible. (2) Jira listAssignableUsers slice(0,50) mirrors BASE's already-present maxResults:'50' request. Linear mappers labels(first:50) likewise matches the SDK single-page default. No normal-path truncation is introduced.

Medium account-file concern is real but corrupt/hand-edited/>256-account-only: BASE already stamped version:1 so no upgrade migration breaks ordinary users, and valid files roundtrip fine. Ceilings all verified far above ordinary use: 256 accounts, ID 128B/URL 16KB/email 4KB/credential 64KB, concurrency gate 1024 queued, tracked-upstream 4096 branches (test proves requested branch always kept), GLAB 64 hosts, nested-repo 100k entries/32MB, pagination 100pg/10k items/32MB. Correctness edge cases (GHES normalize-null, linear resolveWorkspaceId null, config-signature staleness) are malformed/pathological-input only and passed full CI. No confirmed normal-path regression or correctness bug; safe to open as draft PR for human sign-off on the corrupt-account-file policy.

### Files
87 files changed (+4131 / −754).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
