### PR TITLE
oom(20/29): bound relay transport, listings & log rotation

### DIFF
--- a/src/relay/agent-exec-handler.test.ts
+++ b/src/relay/agent-exec-handler.test.ts
@@ -2,6 +2,7 @@ import { execFile, spawn } from 'node:child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ChildProcess from 'node:child_process'
 import { createFakeChild, createHandlers, requestContext } from './agent-exec-handler-test-harness'
+import { MAX_CONCURRENT_AGENT_EXECS } from './agent-exec-handler'
 import { TERMINAL_GIT_CREDENTIAL_GUARD_POLICY_ENV } from '../shared/terminal-git-credential-guard'
 
 vi.mock('child_process', async (importOriginal) => {
@@ -16,7 +17,7 @@ vi.mock('child_process', async (importOriginal) => {
 const spawnMock = vi.mocked(spawn)
 const execFileMock = vi.mocked(execFile)
 
-type AgentExecResult = { exitCode: number | null; timedOut: boolean }
+type AgentExecResult = { stdout: string; exitCode: number | null; timedOut: boolean }
 
 describe('AgentExecHandler', () => {
   beforeEach(() => {
@@ -62,6 +63,68 @@ describe('AgentExecHandler', () => {
       windowsHide: true
     })
     expect(child.stdin.end).toHaveBeenCalledWith('PROMPT')
+  })
+
+  it('preserves output delivered as 100,000 one-byte fragments', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandlers()
+    const pending = handlers.get('agent.execNonInteractive')!(
+      { binary: 'agent', cwd: '/repo', timeoutMs: 5_000 },
+      requestContext()
+    ) as Promise<AgentExecResult>
+
+    for (let index = 0; index < 100_000; index += 1) {
+      child.stdout.emit('data', Buffer.from(index % 2 === 0 ? 'a' : 'b'))
+    }
+    child.emit('close', 0)
+
+    const result = await pending
+    expect(result.stdout).toHaveLength(100_000)
+    expect(result.stdout.slice(0, 4)).toBe('abab')
+    expect(result.stdout.slice(-4)).toBe('abab')
+  })
+
+  it('caps physical agent children until close confirms release', async () => {
+    const children = Array.from({ length: MAX_CONCURRENT_AGENT_EXECS + 1 }, (_, index) => {
+      const child = createFakeChild()
+      child.pid += index
+      return child
+    })
+    let spawnIndex = 0
+    spawnMock.mockImplementation(() => children[spawnIndex++] as never)
+    const handlers = createHandlers()
+    const active = children
+      .slice(0, MAX_CONCURRENT_AGENT_EXECS)
+      .map((_, index) =>
+        handlers.get('agent.execNonInteractive')!(
+          { binary: 'agent', cwd: `/repo-${index}`, timeoutMs: 5_000 },
+          requestContext()
+        )
+      )
+
+    await expect(
+      handlers.get('agent.execNonInteractive')!(
+        { binary: 'agent', cwd: '/overflow', timeoutMs: 5_000 },
+        requestContext()
+      )
+    ).resolves.toMatchObject({ spawnError: 'Remote agent execution capacity reached' })
+    expect(spawnMock).toHaveBeenCalledTimes(MAX_CONCURRENT_AGENT_EXECS)
+
+    children[0]!.emit('close', 0)
+    await active[0]
+    const retry = handlers.get('agent.execNonInteractive')!(
+      { binary: 'agent', cwd: '/retry', timeoutMs: 5_000 },
+      requestContext()
+    )
+    expect(spawnMock).toHaveBeenCalledTimes(MAX_CONCURRENT_AGENT_EXECS + 1)
+
+    for (const child of children.slice(1)) {
+      child.emit('close', 0)
+    }
+    await expect(Promise.all([...active.slice(1), retry])).resolves.toHaveLength(
+      MAX_CONCURRENT_AGENT_EXECS
+    )
   })
 
   it('merges caller-supplied provider environment into the spawned command environment', async () => {
@@ -450,6 +513,8 @@ describe('AgentExecHandler', () => {
       expect(child.stdout.listenerCount('data')).toBe(0)
       expect(child.stderr.listenerCount('data')).toBe(0)
       expect(child.listenerCount('error')).toBe(0)
+      expect(child.listenerCount('close')).toBe(1)
+      child.emit('close', null)
       expect(child.listenerCount('close')).toBe(0)
     } finally {
       vi.useRealTimers()

--- a/src/relay/agent-exec-handler.ts
+++ b/src/relay/agent-exec-handler.ts
@@ -3,12 +3,14 @@ import { existsSync } from 'node:fs'
 import { delimiter, join } from 'node:path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import { applyTerminalGitCredentialPromptGuard } from '../shared/terminal-git-credential-guard'
+import { GrowingByteBuffer } from '../shared/growing-byte-buffer'
 import { mergeGitConfigEnvProtocol } from '../shared/git-credential-prompt-env'
 import { terminateRelaySubprocessTree } from './subprocess-tree-termination'
 
 const DEFAULT_TIMEOUT_MS = 60_000
 const MAX_TIMEOUT_MS = 5 * 60 * 1000
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+export const MAX_CONCURRENT_AGENT_EXECS = 8
 const WINDOWS_BATCH_UNSAFE_ARGUMENTS_ERROR = 'UNSAFE_WINDOWS_BATCH_ARGUMENTS'
 
 function getCmdExePath(): string {
@@ -111,6 +113,7 @@ export class AgentExecHandler {
   // Why: commit-message and PR-field generation can run together for one cwd;
   // operation lanes let cancel target only the user-visible job that stopped.
   private inFlightByLane = new Map<string, InFlightExec>()
+  private activeChildren = new Set<ChildProcess>()
 
   private laneKey(cwd: string, operation: unknown): string {
     return laneKeyFor(cwd, operation)
@@ -159,6 +162,16 @@ export class AgentExecHandler {
       platform: process.platform
     })
 
+    if (this.activeChildren.size >= MAX_CONCURRENT_AGENT_EXECS) {
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: null,
+        timedOut: false,
+        spawnError: 'Remote agent execution capacity reached'
+      }
+    }
+
     return new Promise<ExecResult>((resolve) => {
       let child
       try {
@@ -179,11 +192,13 @@ export class AgentExecHandler {
         })
         return
       }
+      this.activeChildren.add(child)
+      child.once('close', () => {
+        this.activeChildren.delete(child)
+      })
 
-      let stdout = ''
-      let stderr = ''
-      let stdoutBytes = 0
-      let stderrBytes = 0
+      const stdout = new GrowingByteBuffer()
+      const stderr = new GrowingByteBuffer()
       let timedOut = false
       let canceled = false
       let settled = false
@@ -206,6 +221,8 @@ export class AgentExecHandler {
         if (laneKey && entry && this.inFlightByLane.get(laneKey) === entry) {
           this.inFlightByLane.delete(laneKey)
         }
+        stdout.clear()
+        stderr.clear()
         resolve(result)
       }
       const cancelCurrent = (): void => {
@@ -231,36 +248,46 @@ export class AgentExecHandler {
         // also Windows wraps `.cmd` shims in cmd.exe, so the immediate child
         // is not the real node.exe process.
         terminateRelaySubprocessTree(child)
-        finish({ stdout, stderr, exitCode: null, timedOut, canceled })
+        finish({
+          stdout: stdout.toString(),
+          stderr: stderr.toString(),
+          exitCode: null,
+          timedOut,
+          canceled
+        })
       }, timeoutMs)
 
       const onStdoutData = (chunk: Buffer): void => {
-        stdoutBytes += chunk.byteLength
-        if (stdoutBytes > MAX_OUTPUT_BYTES) {
+        if (stdout.byteLength + chunk.byteLength > MAX_OUTPUT_BYTES) {
           terminateRelaySubprocessTree(child)
           return
         }
-        stdout += chunk.toString('utf-8')
+        stdout.append(chunk)
       }
       const onStderrData = (chunk: Buffer): void => {
-        stderrBytes += chunk.byteLength
-        if (stderrBytes > MAX_OUTPUT_BYTES) {
+        if (stderr.byteLength + chunk.byteLength > MAX_OUTPUT_BYTES) {
           terminateRelaySubprocessTree(child)
           return
         }
-        stderr += chunk.toString('utf-8')
+        stderr.append(chunk)
       }
       const onError = (error: Error): void => {
         finish({
-          stdout,
-          stderr,
+          stdout: stdout.toString(),
+          stderr: stderr.toString(),
           exitCode: null,
           timedOut,
           spawnError: error.message
         })
       }
       const onClose = (code: number | null): void => {
-        finish({ stdout, stderr, exitCode: code, timedOut, canceled })
+        finish({
+          stdout: stdout.toString(),
+          stderr: stderr.toString(),
+          exitCode: code,
+          timedOut,
+          canceled
+        })
       }
       child.stdout?.on('data', onStdoutData)
       child.stderr?.on('data', onStderrData)

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -2,7 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
+import {
+  endpointDirForRelaySocket,
+  MAX_RELAY_AGENT_HOOK_STATUS_CACHE_PANES,
+  RelayAgentHookServer
+} from './agent-hook-server'
 import type { AgentHookRelayEnvelope } from '../shared/agent-hook-relay'
 import { makePaneKey } from '../shared/stable-pane-id'
 import * as agentHookListener from '../shared/agent-hook-listener'
@@ -391,10 +395,8 @@ describe('RelayAgentHookServer', () => {
     }
   })
 
-  it('caps the replay cache at 256 panes, evicting the least-recently-updated', async () => {
-    // Mirrors the server's private MAX_CACHED_PANES. The WSL relay never gets a
-    // per-pane teardown signal, so the cache is recency-capped instead.
-    const CAP = 256
+  it('caps the replay cache, evicting the least-recently-updated', async () => {
+    const CAP = MAX_RELAY_AGENT_HOOK_STATUS_CACHE_PANES
     const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
     const server = new RelayAgentHookServer({ endpointDir: dir, forward })
     await server.start()

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -29,6 +29,7 @@ import {
   type AgentHookRelayEnvelope,
   type AgentHookSource
 } from '../shared/agent-hook-relay'
+import { upsertBoundedAgentHookStatus } from '../shared/agent-hook-status-cache'
 
 export type RelayHookForward = (envelope: AgentHookRelayEnvelope) => void
 
@@ -40,9 +41,8 @@ const ASSISTANT_MESSAGE_RETRY_MS = 50
 
 // Why: cap env/version at 64 chars so a misbehaving agent CLI can't grow the meta cache unboundedly; canonical values are short.
 const MAX_HOOK_META_LEN = 64
-
-// Why: WSL relay has no per-pane teardown (PTYs live on the Windows host), so the replay cache would grow forever without a recency cap.
-const MAX_CACHED_PANES = 256
+// Why: preserve the relay's existing replay-memory ceiling while main uses the renderer-aligned 500-pane cap.
+export const MAX_RELAY_AGENT_HOOK_STATUS_CACHE_PANES = 256
 
 function defaultEndpointDir(): string {
   return join(homedir(), RELAY_HOOKS_DIR_NAME, RELAY_HOOKS_SUBDIR)
@@ -326,17 +326,14 @@ export class RelayAgentHookServer {
     if (event.payload.state !== 'done' || event.payload.lastAssistantMessage) {
       this.clearAssistantMessageRetry(event.paneKey)
     }
-    // Why: delete-then-set makes Map insertion order = recency, so the cap below evicts the longest-idle pane.
-    this.state.lastStatusByPaneKey.delete(event.paneKey)
-    this.state.lastStatusByPaneKey.set(event.paneKey, event)
+    const evicted = upsertBoundedAgentHookStatus(this.state, event, {
+      maxPanes: MAX_RELAY_AGENT_HOOK_STATUS_CACHE_PANES
+    })
     this.lastEnvelopeMetaByPaneKey.delete(event.paneKey)
     this.lastEnvelopeMetaByPaneKey.set(event.paneKey, { source, env, version })
-    while (this.state.lastStatusByPaneKey.size > MAX_CACHED_PANES) {
-      const oldest = this.state.lastStatusByPaneKey.keys().next().value
-      if (oldest === undefined) {
-        break
-      }
-      this.clearPaneState(oldest)
+    for (const { paneKey } of evicted) {
+      this.clearAssistantMessageRetry(paneKey)
+      this.lastEnvelopeMetaByPaneKey.delete(paneKey)
     }
     this.forwardEvent(event, source, env, version)
   }

--- a/src/relay/client-request-aborts.test.ts
+++ b/src/relay/client-request-aborts.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import {
+  ClientRequestAborts,
+  MAX_ACTIVE_RELAY_REQUEST_BYTES,
+  MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT,
+  MAX_ACTIVE_RELAY_REQUESTS,
+  MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT
+} from './client-request-aborts'
+
+describe('ClientRequestAborts', () => {
+  it('accepts the per-client request boundary, rejects overflow, and recovers', () => {
+    const requests = new ClientRequestAborts()
+    const registrations = Array.from(
+      { length: MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT },
+      (_, requestId) => requests.create(1, requestId)
+    )
+
+    expect(() => requests.create(1, MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT)).toThrow(
+      `Relay client active request limit of ${MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT} reached`
+    )
+
+    requests.delete(registrations[0].key)
+    expect(() => requests.create(1, MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT)).not.toThrow()
+  })
+
+  it('accepts the aggregate request boundary without evicting active clients', () => {
+    const requests = new ClientRequestAborts()
+    for (let index = 0; index < MAX_ACTIVE_RELAY_REQUESTS; index += 1) {
+      const clientId = Math.floor(index / MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT) + 1
+      requests.create(clientId, index)
+    }
+
+    expect(() => requests.create(99, MAX_ACTIVE_RELAY_REQUESTS)).toThrow(
+      `Relay active request limit of ${MAX_ACTIVE_RELAY_REQUESTS} reached`
+    )
+    expect(requests.get(1, 0)?.signal.aborted).toBe(false)
+
+    requests.delete({ clientId: 1, requestId: 0 })
+    expect(() => requests.create(99, MAX_ACTIVE_RELAY_REQUESTS)).not.toThrow()
+  })
+
+  it('bounds retained payload bytes per client and releases the budget on delete', () => {
+    const requests = new ClientRequestAborts()
+    const halfBudget = MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT / 2
+    const first = requests.create(1, 1, halfBudget)
+    requests.create(1, 2, halfBudget)
+
+    expect(() => requests.create(1, 3, 1)).toThrow(
+      `Relay client active request payload limit of ${MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT} bytes exceeded`
+    )
+
+    requests.delete(first.key)
+    expect(() => requests.create(1, 3, 1)).not.toThrow()
+  })
+
+  it('bounds aggregate retained payload bytes and recovers after client abort', () => {
+    const requests = new ClientRequestAborts()
+    requests.create(1, 1, MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT)
+    requests.create(
+      2,
+      2,
+      MAX_ACTIVE_RELAY_REQUEST_BYTES - MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT
+    )
+
+    expect(() => requests.create(3, 3, 1)).toThrow(
+      `Relay active request payload limit of ${MAX_ACTIVE_RELAY_REQUEST_BYTES} bytes exceeded`
+    )
+
+    requests.abortClient(1)
+    expect(() => requests.create(3, 3, 1)).not.toThrow()
+  })
+
+  it('rejects duplicate ids and releases only the requested owners', () => {
+    const requests = new ClientRequestAborts()
+    const first = requests.create(1, 7)
+    const second = requests.create(2, 7)
+
+    expect(() => requests.create(1, 7)).toThrow('Duplicate active relay request id 7')
+    expect(requests.get(1, 7)).toBe(first.controller)
+
+    requests.abortClient(1)
+    expect(first.controller.signal.aborted).toBe(true)
+    expect(second.controller.signal.aborted).toBe(false)
+    expect(requests.get(1, 7)).toBeUndefined()
+    expect(requests.get(2, 7)).toBe(second.controller)
+
+    requests.abortAll()
+    expect(second.controller.signal.aborted).toBe(true)
+    expect(requests.get(2, 7)).toBeUndefined()
+  })
+})

--- a/src/relay/client-request-aborts.ts
+++ b/src/relay/client-request-aborts.ts
@@ -1,40 +1,118 @@
-export class ClientRequestAborts {
-  private readonly controllers = new Map<string, AbortController>()
+export const MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT = 256
+export const MAX_ACTIVE_RELAY_REQUESTS = 1024
+// Why: handlers retain parsed params until settlement, so cardinality alone
+// cannot bound a burst of near-maximum relay frames.
+export const MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT = 32 * 1024 * 1024
+export const MAX_ACTIVE_RELAY_REQUEST_BYTES = 64 * 1024 * 1024
 
-  create(clientId: number, requestId: number): { key: string; controller: AbortController } {
-    const key = this.key(clientId, requestId)
+type ClientRequestAbortEntry = {
+  controller: AbortController
+  retainedBytes: number
+}
+
+export type ClientRequestAbortKey = {
+  clientId: number
+  requestId: number
+}
+
+export class RelayRequestAdmissionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RelayRequestAdmissionError'
+  }
+}
+
+export class ClientRequestAborts {
+  private readonly entriesByClient = new Map<number, Map<number, ClientRequestAbortEntry>>()
+  private activeRequestCount = 0
+  private activeRequestBytes = 0
+
+  create(
+    clientId: number,
+    requestId: number,
+    retainedBytes = 0
+  ): { key: ClientRequestAbortKey; controller: AbortController } {
+    const clientEntries = this.entriesByClient.get(clientId)
+    if (clientEntries?.has(requestId)) {
+      throw new RelayRequestAdmissionError(`Duplicate active relay request id ${requestId}`)
+    }
+    if ((clientEntries?.size ?? 0) >= MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT) {
+      throw new RelayRequestAdmissionError(
+        `Relay client active request limit of ${MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT} reached`
+      )
+    }
+    if (this.activeRequestCount >= MAX_ACTIVE_RELAY_REQUESTS) {
+      throw new RelayRequestAdmissionError(
+        `Relay active request limit of ${MAX_ACTIVE_RELAY_REQUESTS} reached`
+      )
+    }
+    const normalizedBytes = Math.max(0, retainedBytes)
+    const clientBytes = sumRetainedBytes(clientEntries?.values())
+    if (clientBytes + normalizedBytes > MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT) {
+      throw new RelayRequestAdmissionError(
+        `Relay client active request payload limit of ${MAX_ACTIVE_RELAY_REQUEST_BYTES_PER_CLIENT} bytes exceeded`
+      )
+    }
+    if (this.activeRequestBytes + normalizedBytes > MAX_ACTIVE_RELAY_REQUEST_BYTES) {
+      throw new RelayRequestAdmissionError(
+        `Relay active request payload limit of ${MAX_ACTIVE_RELAY_REQUEST_BYTES} bytes exceeded`
+      )
+    }
+
     const controller = new AbortController()
-    this.controllers.set(key, controller)
-    return { key, controller }
+    const entries = clientEntries ?? new Map<number, ClientRequestAbortEntry>()
+    entries.set(requestId, { controller, retainedBytes: normalizedBytes })
+    this.entriesByClient.set(clientId, entries)
+    this.activeRequestCount += 1
+    this.activeRequestBytes += normalizedBytes
+    return { key: { clientId, requestId }, controller }
   }
 
   get(clientId: number, requestId: number): AbortController | undefined {
-    return this.controllers.get(this.key(clientId, requestId))
+    return this.entriesByClient.get(clientId)?.get(requestId)?.controller
   }
 
-  delete(key: string): void {
-    this.controllers.delete(key)
+  delete(key: ClientRequestAbortKey): void {
+    const clientEntries = this.entriesByClient.get(key.clientId)
+    const entry = clientEntries?.get(key.requestId)
+    if (!clientEntries || !entry) {
+      return
+    }
+    clientEntries.delete(key.requestId)
+    this.activeRequestCount -= 1
+    this.activeRequestBytes -= entry.retainedBytes
+    if (clientEntries.size === 0) {
+      this.entriesByClient.delete(key.clientId)
+    }
   }
 
   abortClient(clientId: number): void {
-    const prefix = `${clientId}:`
-    for (const [key, controller] of this.controllers) {
-      if (!key.startsWith(prefix)) {
-        continue
-      }
-      controller.abort()
-      this.controllers.delete(key)
+    const clientEntries = this.entriesByClient.get(clientId)
+    if (!clientEntries) {
+      return
+    }
+    for (const [requestId, entry] of clientEntries) {
+      entry.controller.abort()
+      this.delete({ clientId, requestId })
     }
   }
 
   abortAll(): void {
-    for (const [, controller] of this.controllers) {
-      controller.abort()
+    for (const clientEntries of this.entriesByClient.values()) {
+      for (const entry of clientEntries.values()) {
+        entry.controller.abort()
+      }
     }
-    this.controllers.clear()
+    this.entriesByClient.clear()
+    this.activeRequestCount = 0
+    this.activeRequestBytes = 0
   }
+}
 
-  private key(clientId: number, requestId: number): string {
-    return `${clientId}:${requestId}`
+function sumRetainedBytes(entries?: Iterable<ClientRequestAbortEntry>): number {
+  let total = 0
+  for (const entry of entries ?? []) {
+    total += entry.retainedBytes
   }
+  return total
 }

--- a/src/relay/dispatcher.test.ts
+++ b/src/relay/dispatcher.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { RelayDispatcher } from './dispatcher'
+import {
+  MAX_PENDING_RELAY_REQUESTS,
+  MAX_RELAY_DISPATCHER_CLIENTS,
+  RelayDispatcher
+} from './dispatcher'
+import { MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT } from './client-request-aborts'
 import {
   encodeJsonRpcFrame,
   encodeKeepAliveFrame,
   MessageType,
   type JsonRpcRequest,
-  type JsonRpcNotification
+  type JsonRpcNotification,
+  type JsonRpcResponse
 } from './protocol'
 
 function decodeFirstFrame(buf: Buffer): { type: number; id: number; ack: number; payload: Buffer } {
@@ -118,6 +124,48 @@ describe('RelayDispatcher', () => {
     expect(resp.id).toBe(5)
   })
 
+  it('rejects incoming request overflow without evicting active work', async () => {
+    const resolutions: ((value: unknown) => void)[] = []
+    const handler = vi.fn(
+      (_params, context) =>
+        new Promise((resolve) => {
+          resolutions.push(resolve)
+          context.signal?.addEventListener('abort', () => resolve(null), { once: true })
+        })
+    )
+    dispatcher.onRequest('slow.method', handler)
+
+    for (let id = 1; id <= MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT + 1; id += 1) {
+      dispatcher.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id, method: 'slow.method' }, id, 0))
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(handler).toHaveBeenCalledTimes(MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT)
+    const overflowId = MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT + 1
+    const overflow = written
+      .map(decodeFirstFrame)
+      .filter((frame) => frame.type === MessageType.Regular)
+      .map((frame) => JSON.parse(frame.payload.toString('utf-8')) as JsonRpcResponse)
+      .find((response) => response.id === overflowId)
+    expect(overflow?.error?.message).toBe(
+      `Relay client active request limit of ${MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT} reached`
+    )
+    expect(resolutions).toHaveLength(MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT)
+
+    resolutions[0]('done')
+    await vi.advanceTimersByTimeAsync(0)
+    dispatcher.feed(
+      encodeJsonRpcFrame(
+        { jsonrpc: '2.0', id: overflowId + 1, method: 'slow.method' },
+        overflowId + 1,
+        0
+      )
+    )
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(handler).toHaveBeenCalledTimes(MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT + 1)
+  })
+
   it('sends method-not-found for unknown methods', async () => {
     const req: JsonRpcRequest = {
       jsonrpc: '2.0',
@@ -201,6 +249,21 @@ describe('RelayDispatcher', () => {
     expect(socketWritten).toHaveLength(1)
   })
 
+  it('accepts the exact client cap, rejects aggregate overflow, and recovers after detach', () => {
+    const attachedIds = Array.from({ length: MAX_RELAY_DISPATCHER_CLIENTS - 1 }, () =>
+      dispatcher.attachClient(() => undefined)
+    )
+
+    expect(dispatcher.connectedClientIds()).toHaveLength(MAX_RELAY_DISPATCHER_CLIENTS)
+    expect(() => dispatcher.attachClient(() => undefined)).toThrow(
+      `Relay client limit of ${MAX_RELAY_DISPATCHER_CLIENTS} reached`
+    )
+
+    dispatcher.detachClient(attachedIds[0])
+    expect(() => dispatcher.attachClient(() => undefined)).not.toThrow()
+    expect(dispatcher.connectedClientIds()).toHaveLength(MAX_RELAY_DISPATCHER_CLIENTS)
+  })
+
   it('targets terminal ownership notifications to one attached client', () => {
     const firstWritten: Buffer[] = []
     const secondWritten: Buffer[] = []
@@ -216,6 +279,76 @@ describe('RelayDispatcher', () => {
     expect(written).toHaveLength(0)
     expect(firstWritten).toHaveLength(1)
     expect(secondWritten).toHaveLength(0)
+  })
+
+  it('reports targeted sink saturation and waits for its drain signal', async () => {
+    const ownerWritten: Buffer[] = []
+    let signalDrain: (() => void) | undefined
+    const ownerId = dispatcher.attachClient(
+      (data) => {
+        ownerWritten.push(Buffer.from(data))
+        return false
+      },
+      {
+        waitWriteDrain: (callback) => {
+          signalDrain = callback
+        }
+      }
+    )
+    const otherWritten: Buffer[] = []
+    dispatcher.attachClient((data) => {
+      otherWritten.push(Buffer.from(data))
+    })
+
+    const result = dispatcher.notifyClientWithBackpressure(ownerId, 'pty.data', {
+      id: 'pty-1',
+      data: 'output'
+    })
+
+    expect(result.delivered).toBe(true)
+    expect(result.saturated).toBe(true)
+    expect(ownerWritten).toHaveLength(1)
+    expect(written).toHaveLength(0)
+    expect(otherWritten).toHaveLength(0)
+    let drained = false
+    void result.drained.then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+
+    signalDrain?.()
+    await expect(result.drained).resolves.toBeUndefined()
+    expect(drained).toBe(true)
+  })
+
+  it('reports a detached targeted client without writing', async () => {
+    const ownerId = dispatcher.attachClient(() => true)
+    dispatcher.detachClient(ownerId)
+
+    const result = dispatcher.notifyClientWithBackpressure(ownerId, 'pty.data', {
+      id: 'pty-1',
+      data: 'output'
+    })
+
+    expect(result).toMatchObject({ delivered: false, saturated: false })
+    await expect(result.drained).resolves.toBeUndefined()
+    expect(written).toHaveLength(0)
+  })
+
+  it('allows a targeted drain waiter to be canceled during owner cleanup', async () => {
+    const ownerId = dispatcher.attachClient(() => false, {
+      waitWriteDrain: () => {}
+    })
+    const result = dispatcher.notifyClientWithBackpressure(ownerId, 'pty.data', {
+      id: 'pty-1',
+      data: 'output'
+    })
+
+    expect(result.saturated).toBe(true)
+    result.cancelDrain?.()
+
+    await expect(result.drained).resolves.toBeUndefined()
   })
 
   it('forwards relay-originated requests to an owning socket client instead of the caller', async () => {
@@ -271,6 +404,48 @@ describe('RelayDispatcher', () => {
     )
 
     await expect(pending).resolves.toEqual({ exitCode: 0 })
+  })
+
+  it('bounds relay-originated pending requests and recovers after a response', async () => {
+    const pending = Array.from({ length: MAX_PENDING_RELAY_REQUESTS }, (_, index) => {
+      const request = dispatcher.requestPrimary('orca.cli', { index })
+      void request.catch(() => undefined)
+      return request
+    })
+
+    expect(written).toHaveLength(MAX_PENDING_RELAY_REQUESTS)
+    await expect(dispatcher.requestPrimary('orca.cli', { overflow: true })).rejects.toThrow(
+      `Relay pending request limit of ${MAX_PENDING_RELAY_REQUESTS} reached`
+    )
+    expect(written).toHaveLength(MAX_PENDING_RELAY_REQUESTS)
+
+    const firstRequest = JSON.parse(
+      decodeFirstFrame(written[0]).payload.toString('utf-8')
+    ) as JsonRpcRequest
+    dispatcher.feed(
+      encodeJsonRpcFrame({ jsonrpc: '2.0', id: firstRequest.id, result: 'done' }, 1, 0)
+    )
+    await expect(pending[0]).resolves.toBe('done')
+
+    const recovered = dispatcher.requestPrimary('orca.cli', { recovered: true })
+    expect(written).toHaveLength(MAX_PENDING_RELAY_REQUESTS + 1)
+    const recoveredRequest = JSON.parse(
+      decodeFirstFrame(written.at(-1)!).payload.toString('utf-8')
+    ) as JsonRpcRequest
+    dispatcher.feed(
+      encodeJsonRpcFrame({ jsonrpc: '2.0', id: recoveredRequest.id, result: 'recovered' }, 2, 0)
+    )
+    await expect(recovered).resolves.toBe('recovered')
+  })
+
+  it('rejects relay-originated requests when their owning client detaches', async () => {
+    const ownerId = dispatcher.attachClient(() => undefined)
+    dispatcher.invalidateClient()
+    const pending = dispatcher.requestAnyClient('orca.cli')
+
+    dispatcher.detachClient(ownerId)
+
+    await expect(pending).rejects.toThrow('Relay client disconnected')
   })
 
   it('isolates failed socket-client writes from other clients', () => {

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -11,7 +11,7 @@ import {
   type JsonRpcNotification,
   type JsonRpcResponse
 } from './protocol'
-import { ClientRequestAborts } from './client-request-aborts'
+import { ClientRequestAborts, RelayRequestAdmissionError } from './client-request-aborts'
 
 export type RequestContext = {
   clientId: number
@@ -32,6 +32,15 @@ export type RelayClientWrite = (data: Buffer) => boolean | void
 export type RelayClientSinkOptions = {
   /** One-shot: invoke `cb` when the sink can accept more data (drain) or is permanently dead, so waiters never hang. */
   waitWriteDrain?: (cb: () => void) => void
+  /** Close only this transport when bounded per-client delivery can no longer retain its backlog. */
+  disconnect?: () => void
+}
+
+export type RelayNotificationWriteResult = {
+  delivered: boolean
+  saturated: boolean
+  drained: Promise<void>
+  cancelDrain?: () => void
 }
 
 type RelayClient = {
@@ -39,6 +48,7 @@ type RelayClient = {
   decoder: FrameDecoder
   write: RelayClientWrite
   waitWriteDrain?: (cb: () => void) => void
+  disconnect?: () => void
   /** Resolvers for bulk sends stalled on sink saturation; flushed so no pump hangs. */
   drainWaiters: Set<() => void>
   /** Serializes bulk-lane sends so only one bulk frame is admitted past the sink high-water mark at a time. */
@@ -50,12 +60,16 @@ type RelayClient = {
 }
 
 type PendingRelayRequest = {
+  clientId: number
   resolve: (result: unknown) => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
 }
 
 const RELAY_TO_CLIENT_REQUEST_TIMEOUT_MS = 30_000
+export const MAX_RELAY_DISPATCHER_CLIENTS = 16
+export const MAX_RELAY_SOCKET_CONNECTIONS = MAX_RELAY_DISPATCHER_CLIENTS - 1
+export const MAX_PENDING_RELAY_REQUESTS = 256
 
 export class RelayDispatcher {
   private readonly primaryClient: RelayClient
@@ -80,8 +94,10 @@ export class RelayDispatcher {
   // Why: the new client's multiplexer restarts at seq=1, so reset seq/decoder state or acks stall and fire a false connection-dead signal.
   setWrite(write: RelayClientWrite, sinkOptions?: RelayClientSinkOptions): void {
     this.requestAborts.abortClient(this.primaryClient.id)
+    this.rejectPendingRequestsForClient(this.primaryClient.id, 'Relay client reconnected')
     this.primaryClient.write = write
     this.primaryClient.waitWriteDrain = sinkOptions?.waitWriteDrain
+    this.primaryClient.disconnect = sinkOptions?.disconnect
     this.primaryClient.closed = false
     // Why: the old sink is gone; wake stalled bulk senders to re-evaluate against the new one.
     this.flushDrainWaiters(this.primaryClient)
@@ -91,6 +107,7 @@ export class RelayDispatcher {
   // Why: mark in-flight requests stale on disconnect so a late pty.spawn/fs.watch can't create unowned remote state.
   invalidateClient(): void {
     this.requestAborts.abortClient(this.primaryClient.id)
+    this.rejectPendingRequestsForClient(this.primaryClient.id, 'Relay client disconnected')
     this.primaryClient.generation++
     this.primaryClient.closed = true
     this.flushDrainWaiters(this.primaryClient)
@@ -99,6 +116,12 @@ export class RelayDispatcher {
 
   // Why: seq numbers and request ids are per SSH channel, so each attached client needs independent protocol state.
   attachClient(write: RelayClientWrite, sinkOptions?: RelayClientSinkOptions): number {
+    if (this.disposed) {
+      throw new Error('Relay dispatcher is disposed')
+    }
+    if (this.clients.size >= MAX_RELAY_DISPATCHER_CLIENTS) {
+      throw new Error(`Relay client limit of ${MAX_RELAY_DISPATCHER_CLIENTS} reached`)
+    }
     const client = this.createClient(write, sinkOptions)
     this.clients.set(client.id, client)
     return client.id
@@ -110,11 +133,39 @@ export class RelayDispatcher {
       return
     }
     this.requestAborts.abortClient(clientId)
+    this.rejectPendingRequestsForClient(clientId, 'Relay client disconnected')
     client.generation++
     client.closed = true
     this.flushDrainWaiters(client)
     this.clients.delete(clientId)
     this.notifyClientDetached(clientId)
+  }
+
+  connectedClientIds(): number[] {
+    if (this.disposed) {
+      return []
+    }
+    return Array.from(this.clients.values(), (client) => client)
+      .filter((client) => !client.closed)
+      .map((client) => client.id)
+  }
+
+  evictClient(clientId: number): void {
+    const client = this.clients.get(clientId)
+    if (!client || client.closed) {
+      return
+    }
+    const disconnect = client.disconnect
+    if (client === this.primaryClient) {
+      this.invalidateClient()
+    } else {
+      this.detachClient(clientId)
+    }
+    try {
+      disconnect?.()
+    } catch {
+      // Why: disconnect failures cannot restore an already-detached dispatcher.
+    }
   }
 
   feedClient(clientId: number, data: Buffer): void {
@@ -184,6 +235,35 @@ export class RelayDispatcher {
     })
   }
 
+  notifyClientWithBackpressure(
+    clientId: number,
+    method: string,
+    params?: Record<string, unknown>
+  ): RelayNotificationWriteResult {
+    const client = this.clients.get(clientId)
+    if (this.disposed || !client || client.closed) {
+      return { delivered: false, saturated: false, drained: Promise.resolve() }
+    }
+    const accepted = this.sendFrame(client, {
+      jsonrpc: '2.0',
+      method,
+      ...(params !== undefined ? { params } : {})
+    })
+    if (client.closed || !this.clients.has(clientId)) {
+      return { delivered: false, saturated: false, drained: Promise.resolve() }
+    }
+    if (accepted !== false) {
+      return { delivered: true, saturated: false, drained: Promise.resolve() }
+    }
+    const drain = this.waitForClientDrainCancelable(client)
+    return {
+      delivered: true,
+      saturated: true,
+      drained: drain.drained,
+      cancelDrain: drain.cancel
+    }
+  }
+
   /**
    * Bulk-lane notification: sends are serialized per client and the promise
    * resolves only after the sink accepted the frame (backpressure), so bulk
@@ -233,10 +313,18 @@ export class RelayDispatcher {
   }
 
   private waitForClientDrain(client: RelayClient): Promise<void> {
+    return this.waitForClientDrainCancelable(client).drained
+  }
+
+  private waitForClientDrainCancelable(client: RelayClient): {
+    drained: Promise<void>
+    cancel: () => void
+  } {
     if (this.disposed || client.closed || !client.waitWriteDrain) {
-      return Promise.resolve()
+      return { drained: Promise.resolve(), cancel: () => {} }
     }
-    return new Promise<void>((resolve) => {
+    let cancel = (): void => {}
+    const drained = new Promise<void>((resolve) => {
       let settled = false
       const finish = (): void => {
         if (settled) {
@@ -246,6 +334,7 @@ export class RelayDispatcher {
         client.drainWaiters.delete(finish)
         resolve()
       }
+      cancel = finish
       client.drainWaiters.add(finish)
       try {
         client.waitWriteDrain!(finish)
@@ -253,6 +342,7 @@ export class RelayDispatcher {
         finish()
       }
     })
+    return { drained, cancel }
   }
 
   private flushDrainWaiters(client: RelayClient): void {
@@ -295,6 +385,11 @@ export class RelayDispatcher {
     if (this.disposed || !client || client.closed) {
       return Promise.reject(new Error('Relay client is not connected'))
     }
+    if (this.pendingRelayRequests.size >= MAX_PENDING_RELAY_REQUESTS) {
+      return Promise.reject(
+        new Error(`Relay pending request limit of ${MAX_PENDING_RELAY_REQUESTS} reached`)
+      )
+    }
     const id = this.nextRequestId++
     const msg: JsonRpcRequest = {
       jsonrpc: '2.0',
@@ -308,9 +403,25 @@ export class RelayDispatcher {
         this.pendingRelayRequests.delete(id)
         reject(new Error(`Request "${method}" timed out after ${timeoutMs}ms`))
       }, timeoutMs)
-      this.pendingRelayRequests.set(id, { resolve, reject, timer })
+      this.pendingRelayRequests.set(id, { clientId, resolve, reject, timer })
       this.sendFrame(client, msg)
+      if (client.closed) {
+        clearTimeout(timer)
+        this.pendingRelayRequests.delete(id)
+        reject(new Error('Relay client disconnected'))
+      }
     })
+  }
+
+  private rejectPendingRequestsForClient(clientId: number, message: string): void {
+    for (const [id, pending] of this.pendingRelayRequests) {
+      if (pending.clientId !== clientId) {
+        continue
+      }
+      clearTimeout(pending.timer)
+      this.pendingRelayRequests.delete(id)
+      pending.reject(new Error(message))
+    }
   }
 
   dispose(): void {
@@ -341,6 +452,7 @@ export class RelayDispatcher {
       decoder: new FrameDecoder((frame) => this.handleFrame(client, frame)),
       write,
       waitWriteDrain: sinkOptions?.waitWriteDrain,
+      disconnect: sinkOptions?.disconnect,
       drainWaiters: new Set(),
       bulkChain: Promise.resolve(),
       nextOutgoingSeq: 1,
@@ -371,7 +483,7 @@ export class RelayDispatcher {
     if (frame.type === MessageType.Regular) {
       try {
         const msg = parseJsonRpcMessage(frame.payload)
-        this.handleMessage(client, msg)
+        this.handleMessage(client, msg, frame.payload.byteLength)
       } catch (err) {
         process.stderr.write(
           `[relay] Parse error: ${err instanceof Error ? err.message : String(err)}\n`
@@ -382,10 +494,11 @@ export class RelayDispatcher {
 
   private handleMessage(
     client: RelayClient,
-    msg: JsonRpcRequest | JsonRpcNotification | JsonRpcResponse
+    msg: JsonRpcRequest | JsonRpcNotification | JsonRpcResponse,
+    retainedBytes: number
   ): void {
     if ('id' in msg && 'method' in msg) {
-      void this.handleRequest(client, msg as JsonRpcRequest)
+      void this.handleRequest(client, msg as JsonRpcRequest, retainedBytes)
     } else if ('id' in msg && ('result' in msg || 'error' in msg)) {
       this.handleResponse(msg as JsonRpcResponse)
     } else if ('method' in msg && !('id' in msg)) {
@@ -410,7 +523,11 @@ export class RelayDispatcher {
     pending.resolve(msg.result)
   }
 
-  private async handleRequest(client: RelayClient, req: JsonRpcRequest): Promise<void> {
+  private async handleRequest(
+    client: RelayClient,
+    req: JsonRpcRequest,
+    retainedBytes: number
+  ): Promise<void> {
     const handler = this.requestHandlers.get(req.method)
     if (!handler) {
       this.sendResponse(client, req.id, undefined, {
@@ -422,10 +539,17 @@ export class RelayDispatcher {
 
     // Why: snapshot generation before the await to detect if the client disconnected mid-flight.
     const gen = client.generation
-    const { key: abortKey, controller: abortController } = this.requestAborts.create(
-      client.id,
-      req.id
-    )
+    let registration: ReturnType<ClientRequestAborts['create']>
+    try {
+      registration = this.requestAborts.create(client.id, req.id, retainedBytes)
+    } catch (error) {
+      if (error instanceof RelayRequestAdmissionError) {
+        this.sendResponse(client, req.id, undefined, { code: -32000, message: error.message })
+        return
+      }
+      throw error
+    }
+    const { key: abortKey, controller: abortController } = registration
     const context: RequestContext = {
       clientId: client.id,
       isStale: () =>
@@ -518,6 +642,7 @@ export class RelayDispatcher {
       client.closed = true
       client.generation++
       this.requestAborts.abortClient(client.id)
+      this.rejectPendingRequestsForClient(client.id, 'Relay client disconnected')
       this.flushDrainWaiters(client)
       // Why: frames have no retransmit buffer; detach now so reconnect/PTY-reattach runs instead of waiting the ~20s keepalive timeout.
       if (client !== this.primaryClient) {

--- a/src/relay/external-automations-handler.test.ts
+++ b/src/relay/external-automations-handler.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import type { RelayDispatcher } from './dispatcher'
 
@@ -15,6 +18,7 @@ const execFileMock = vi.hoisted(() =>
 vi.mock('child_process', () => ({ execFile: execFileMock }))
 
 type CapturedHandler = (params?: Record<string, unknown>) => Promise<unknown>
+const tempDirs: string[] = []
 
 function createHandlerHarness(): {
   handler: ExternalAutomationsHandler
@@ -32,6 +36,10 @@ function createHandlerHarness(): {
 
 beforeEach(() => {
   execFileMock.mockClear()
+})
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
 describe('ExternalAutomationsHandler', () => {
@@ -55,26 +63,32 @@ describe('ExternalAutomationsHandler', () => {
   it('paginates remote Hermes run history after ref lookup', async () => {
     const { handler, requestHandlers } = createHandlerHarness()
     const handlerInternals = handler as unknown as {
-      readHermesRunRefs: (jobId: string) => Promise<{ id: string; run_at: string }[]>
+      readHermesRunRefs: (jobId: string) => Promise<{
+        refs: { id: string; run_at: string }[]
+        saturated: boolean
+      }>
       hydrateHermesRunRef: (
         jobId: string,
         ref: { id: string; run_at: string }
       ) => Promise<{ id: string; run_at: string }>
     }
-    handlerInternals.readHermesRunRefs = vi.fn().mockResolvedValue([
-      {
-        id: 'cron_job-1_20260516_090000',
-        run_at: '2026-05-16T09:00:00'
-      },
-      {
-        id: 'job-1:2026-05-15_09-00-00.md',
-        run_at: '2026-05-15T09:00:00'
-      },
-      {
-        id: 'job-1:2026-05-14_09-00-00.md',
-        run_at: '2026-05-14T09:00:00'
-      }
-    ])
+    handlerInternals.readHermesRunRefs = vi.fn().mockResolvedValue({
+      refs: [
+        {
+          id: 'cron_job-1_20260516_090000',
+          run_at: '2026-05-16T09:00:00'
+        },
+        {
+          id: 'job-1:2026-05-15_09-00-00.md',
+          run_at: '2026-05-15T09:00:00'
+        },
+        {
+          id: 'job-1:2026-05-14_09-00-00.md',
+          run_at: '2026-05-14T09:00:00'
+        }
+      ],
+      saturated: false
+    })
     handlerInternals.hydrateHermesRunRef = vi.fn(async (_jobId, ref) => ref)
 
     const result = (await requestHandlers.get('externalAutomations.runs')?.({
@@ -91,12 +105,80 @@ describe('ExternalAutomationsHandler', () => {
     ])
   })
 
+  it('bounds remote hydration concurrency and omits page-wide output overflow', async () => {
+    const { handler, requestHandlers } = createHandlerHarness()
+    const refs = Array.from({ length: 3 }, (_, index) => ({
+      id: `run-${index}`,
+      run_at: `2026-05-15T09:00:0${index}`
+    }))
+    let active = 0
+    let maxActive = 0
+    const handlerInternals = handler as unknown as {
+      readHermesRunRefs: () => Promise<{ refs: typeof refs; saturated: boolean }>
+      hydrateHermesRunRef: (
+        jobId: string,
+        ref: (typeof refs)[number]
+      ) => Promise<{ id: string; output_content: string }>
+    }
+    handlerInternals.readHermesRunRefs = vi.fn().mockResolvedValue({ refs, saturated: false })
+    handlerInternals.hydrateHermesRunRef = vi.fn(async (_jobId, ref) => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise<void>((resolve) => setTimeout(resolve, 1))
+      active -= 1
+      return { id: ref.id, output_content: 'x'.repeat(16 * 1024 * 1024 + 1) }
+    })
+
+    const result = (await requestHandlers.get('externalAutomations.runs')?.({
+      provider: 'hermes',
+      jobId: 'job-1',
+      page: 1,
+      pageSize: 3
+    })) as {
+      runs: { id: string; output_content: string | null; error?: string }[]
+    }
+
+    expect(maxActive).toBe(2)
+    expect(result.runs.map((run) => run.id)).toEqual(refs.map((ref) => ref.id))
+    expect(result.runs[0]?.output_content).toHaveLength(16 * 1024 * 1024 + 1)
+    expect(result.runs.slice(1)).toEqual([
+      expect.objectContaining({ output_content: null, error: expect.stringContaining('omitted') }),
+      expect.objectContaining({ output_content: null, error: expect.stringContaining('omitted') })
+    ])
+  })
+
+  it('omits an oversized sparse remote markdown output without reading it wholesale', async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), 'orca-relay-hermes-output-'))
+    tempDirs.push(tempDir)
+    const outputPath = join(tempDir, '2026-05-15_09-00-00.md')
+    await writeFile(outputPath, '', 'utf-8')
+    await truncate(outputPath, 64 * 1024 * 1024)
+    const { handler } = createHandlerHarness()
+    const handlerInternals = handler as unknown as {
+      readHermesOutputFileRun: (ref: Record<string, unknown>) => Promise<unknown>
+    }
+
+    const run = await handlerInternals.readHermesOutputFileRun({
+      kind: 'output',
+      id: 'job-1:2026-05-15_09-00-00.md',
+      job_id: 'job-1',
+      run_at: '2026-05-15T09:00:00',
+      run_key: '20260515_090000',
+      output_path: outputPath
+    })
+
+    expect(run).toMatchObject({
+      output_content: null,
+      error: expect.stringContaining('File too large')
+    })
+  })
+
   it('uses a count-only path for remote Hermes manager listing run counts', async () => {
     const { handler, requestHandlers } = createHandlerHarness()
     const handlerInternals = handler as unknown as {
-      readHermesRunCount: (jobId: string) => Promise<number>
+      readHermesRunCount: (jobId: string) => Promise<{ total: number }>
     }
-    handlerInternals.readHermesRunCount = vi.fn().mockResolvedValue(42)
+    handlerInternals.readHermesRunCount = vi.fn().mockResolvedValue({ total: 42 })
 
     const result = (await requestHandlers.get('externalAutomations.runs')?.({
       provider: 'hermes',
@@ -108,12 +190,34 @@ describe('ExternalAutomationsHandler', () => {
     expect(result).toEqual({ total: 42, runs: [] })
   })
 
+  it('reports when the remote run total is saturated', async () => {
+    const { handler, requestHandlers } = createHandlerHarness()
+    const handlerInternals = handler as unknown as {
+      readHermesRunCount: () => Promise<{ total: number; totalSaturated: true }>
+    }
+    handlerInternals.readHermesRunCount = vi
+      .fn()
+      .mockResolvedValue({ total: 10_000, totalSaturated: true })
+
+    await expect(
+      requestHandlers.get('externalAutomations.runs')?.({
+        provider: 'hermes',
+        jobId: 'job-1',
+        page: 1,
+        pageSize: 0
+      })
+    ).resolves.toEqual({ total: 10_000, totalSaturated: true, runs: [] })
+  })
+
   it('deduplicates concurrent remote Hermes count reads', async () => {
     const { handler, requestHandlers } = createHandlerHarness()
-    let resolveRefs: (refs: { id: string; run_at: string }[]) => void = () => {}
+    let resolveRefs: (result: {
+      refs: { id: string; run_at: string }[]
+      saturated: boolean
+    }) => void = () => {}
     const readHermesRunRefs = vi.fn(
       () =>
-        new Promise<{ id: string; run_at: string }[]>((resolve) => {
+        new Promise<{ refs: { id: string; run_at: string }[]; saturated: boolean }>((resolve) => {
           resolveRefs = resolve
         })
     )
@@ -136,10 +240,13 @@ describe('ExternalAutomationsHandler', () => {
     })
 
     expect(readHermesRunRefs).toHaveBeenCalledTimes(1)
-    resolveRefs([
-      { id: 'job-1:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' },
-      { id: 'job-1:2026-05-16_09-00-00.md', run_at: '2026-05-16T09:00:00' }
-    ])
+    resolveRefs({
+      refs: [
+        { id: 'job-1:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' },
+        { id: 'job-1:2026-05-16_09-00-00.md', run_at: '2026-05-16T09:00:00' }
+      ],
+      saturated: false
+    })
 
     await expect(Promise.all([first, second])).resolves.toEqual([
       { total: 2, runs: [] },
@@ -151,13 +258,17 @@ describe('ExternalAutomationsHandler', () => {
     const { handler, requestHandlers } = createHandlerHarness()
     const readHermesRunRefs = vi
       .fn()
-      .mockResolvedValueOnce([
-        { id: 'job-1:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' }
-      ])
-      .mockResolvedValueOnce([
-        { id: 'job-1:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' },
-        { id: 'job-1:2026-05-16_09-00-00.md', run_at: '2026-05-16T09:00:00' }
-      ])
+      .mockResolvedValueOnce({
+        refs: [{ id: 'job-1:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' }],
+        saturated: false
+      })
+      .mockResolvedValueOnce({
+        refs: [
+          { id: 'job-1:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' },
+          { id: 'job-1:2026-05-16_09-00-00.md', run_at: '2026-05-16T09:00:00' }
+        ],
+        saturated: false
+      })
     const handlerInternals = handler as unknown as {
       readHermesRunRefs: typeof readHermesRunRefs
     }
@@ -200,8 +311,11 @@ describe('ExternalAutomationsHandler', () => {
     const { handler, requestHandlers } = createHandlerHarness()
     const readHermesRunRefs = vi.fn(async (jobId: string) =>
       jobId === 'job-0'
-        ? [{ id: 'job-0:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' }]
-        : []
+        ? {
+            refs: [{ id: 'job-0:2026-05-15_09-00-00.md', run_at: '2026-05-15T09:00:00' }],
+            saturated: false
+          }
+        : { refs: [], saturated: false }
     )
     const handlerInternals = handler as unknown as {
       readHermesRunRefs: typeof readHermesRunRefs

--- a/src/relay/external-automations-handler.ts
+++ b/src/relay/external-automations-handler.ts
@@ -2,11 +2,28 @@
  * run history, and actions must stay co-located behind one relay request handler. */
 import { execFile } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { open, readdir, readFile, realpath, stat } from 'node:fs/promises'
+import { open, opendir, realpath, stat } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { homedir } from 'node:os'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { promisify } from 'node:util'
+import { readExternalAutomationJobsFile } from '../shared/external-automation-jobs-file'
+import {
+  type BoundedHermesRunRefs,
+  HERMES_RUN_REF_MAX_ENTRIES,
+  HERMES_SESSION_RUN_REFS_SELECT_SQL,
+  HermesRunRefRetainer
+} from '../shared/hermes-run-ref-retention'
+import {
+  formatHermesSessionMessagesWithinLimits,
+  HERMES_PRIMARY_OUTPUT_MAX_BYTES,
+  HERMES_RUN_PAGE_MAX_RUNS,
+  HERMES_SESSION_TRANSCRIPT_SELECT_SQL,
+  HERMES_SESSION_TRANSCRIPT_TRUNCATED_ERROR,
+  hydrateHermesRunPageWithinLimits
+} from '../shared/hermes-run-output-limits'
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
+import { mapWithConcurrency } from '../shared/map-with-concurrency'
 import type { RelayDispatcher } from './dispatcher'
 
 const execFileAsync = promisify(execFile)
@@ -23,6 +40,7 @@ const HERMES_RUN_KEY_PATTERN = /^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$/
 const MAX_SESSION_OUTPUT_GAP_MS = 24 * 60 * 60 * 1000
 const MAX_REFERENCED_LOG_BYTES = 5 * 1024 * 1024
 const HERMES_RUN_COUNT_CACHE_MAX_ENTRIES = 200
+const HERMES_JOB_RUN_COUNT_CONCURRENCY = 4
 const FULL_SESSION_LOG_HEADING = '## Full session log'
 const REFERENCED_LOG_HEADING = '## Latest log file'
 const LATEST_LOG_PATH_PATTERN =
@@ -30,6 +48,7 @@ const LATEST_LOG_PATH_PATTERN =
 type SqliteStatement = {
   get: (...args: unknown[]) => Record<string, unknown> | undefined
   all: (...args: unknown[]) => Record<string, unknown>[]
+  iterate?: (...args: unknown[]) => Iterable<Record<string, unknown>>
 }
 type SqliteDatabase = {
   prepare: (sql: string) => SqliteStatement
@@ -71,9 +90,10 @@ type HermesMergedRunRef = {
   session: HermesSessionRunRef | null
 }
 type HermesRunCountCacheEntry = {
-  promise: Promise<number>
+  promise: Promise<HermesRunCount>
   expiresAt: number
 }
+type HermesRunCount = { total: number; totalSaturated?: true }
 
 const HERMES_RUN_COUNT_CACHE_TTL_MS = 2000
 
@@ -106,37 +126,27 @@ export class ExternalAutomationsHandler {
     if (!existsSync(jobsFile)) {
       return []
     }
-    const content = await readFile(jobsFile, 'utf-8')
-    const parsed = JSON.parse(content) as unknown
-    const jobs = Array.isArray(parsed)
-      ? parsed
-      : typeof parsed === 'object' &&
-          parsed !== null &&
-          !Array.isArray(parsed) &&
-          Array.isArray((parsed as { jobs?: unknown }).jobs)
-        ? (parsed as { jobs: unknown[] }).jobs
-        : []
+    const jobs = await readExternalAutomationJobsFile(jobsFile, { allowRootArray: true })
     if (provider !== 'hermes') {
       return jobs
     }
-    return Promise.all(
-      jobs.map(async (job) => {
-        if (!this.isRecord(job) || typeof job.id !== 'string') {
-          return job
-        }
-        const runsPage = await this.listRuns({
-          provider: 'hermes',
-          jobId: job.id,
-          page: 1,
-          pageSize: 0
-        })
-        return {
-          ...job,
-          run_count: runsPage.total,
-          runs: runsPage.runs
-        }
+    return mapWithConcurrency(jobs, HERMES_JOB_RUN_COUNT_CONCURRENCY, async (job) => {
+      if (!this.isRecord(job) || typeof job.id !== 'string') {
+        return job
+      }
+      const runsPage = await this.listRuns({
+        provider: 'hermes',
+        jobId: job.id,
+        page: 1,
+        pageSize: 0
       })
-    )
+      return {
+        ...job,
+        run_count: runsPage.total,
+        ...(runsPage.totalSaturated ? { run_count_saturated: true } : {}),
+        runs: runsPage.runs
+      }
+    })
   }
 
   private isRecord(value: unknown): value is Record<string, unknown> {
@@ -259,9 +269,10 @@ export class ExternalAutomationsHandler {
         return null
       }
       if (logStat.size <= MAX_REFERENCED_LOG_BYTES) {
+        const { buffer } = await readNodeFileWithinLimit(logPath, MAX_REFERENCED_LOG_BYTES)
         return {
           path: logPath,
-          content: await readFile(logPath, 'utf-8'),
+          content: buffer.toString('utf-8'),
           truncated: false
         }
       }
@@ -311,31 +322,6 @@ export class ExternalAutomationsHandler {
     ]
       .filter((part) => part !== null)
       .join('\n\n')
-  }
-
-  private formatSessionMessages(messages: Record<string, unknown>[]): string | null {
-    if (messages.length === 0) {
-      return null
-    }
-    return messages
-      .map((message) => {
-        const role = typeof message.role === 'string' ? message.role : 'message'
-        const content = typeof message.content === 'string' ? message.content.trim() : ''
-        const toolName = typeof message.tool_name === 'string' ? message.tool_name.trim() : ''
-        const reasoning =
-          typeof message.reasoning_content === 'string'
-            ? message.reasoning_content.trim()
-            : typeof message.reasoning === 'string'
-              ? message.reasoning.trim()
-              : ''
-        const parts = [
-          `## ${role}${toolName ? ` / ${toolName}` : ''}`,
-          reasoning ? `### Reasoning\n\n${reasoning}` : null,
-          content || '(empty)'
-        ].filter(Boolean)
-        return parts.join('\n\n')
-      })
-      .join('\n\n---\n\n')
   }
 
   private getRunKey(run: unknown): string | null {
@@ -535,19 +521,20 @@ export class ExternalAutomationsHandler {
     return databaseConstructor
   }
 
-  private async readHermesRunRefs(jobId: string): Promise<HermesMergedRunRef[]> {
+  private async readHermesRunRefs(
+    jobId: string
+  ): Promise<BoundedHermesRunRefs<HermesMergedRunRef>> {
     const outputRuns = await this.readHermesOutputFileRunRefs(jobId)
-    return this.mergeHermesOutputAndSessionRunRefs(
-      outputRuns,
-      this.readHermesSessionDbRunRefs(jobId)
-    ).sort((a, b) => {
-      const aTime = this.getRawRunTime(a)
-      const bTime = this.getRawRunTime(b)
-      if (Number.isFinite(aTime) && Number.isFinite(bTime)) {
-        return bTime - aTime
-      }
-      return this.getRawRunId(b).localeCompare(this.getRawRunId(a))
-    })
+    const sessionRuns = this.readHermesSessionDbRunRefs(jobId)
+    const mergedRetainer = new HermesRunRefRetainer<HermesMergedRunRef>()
+    for (const ref of this.mergeHermesOutputAndSessionRunRefs(outputRuns.refs, sessionRuns.refs)) {
+      mergedRetainer.add(ref)
+    }
+    const merged = mergedRetainer.finish()
+    return {
+      refs: merged.refs,
+      saturated: outputRuns.saturated || sessionRuns.saturated || merged.saturated
+    }
   }
 
   private async hydrateHermesRunRef(jobId: string, ref: HermesMergedRunRef): Promise<unknown> {
@@ -564,9 +551,9 @@ export class ExternalAutomationsHandler {
     )
   }
 
-  private async readHermesRunCount(jobId: string): Promise<number> {
+  private async readHermesRunCount(jobId: string): Promise<HermesRunCount> {
     if (!EXTERNAL_JOB_ID_PATTERN.test(jobId)) {
-      return 0
+      return { total: 0 }
     }
     const now = Date.now()
     const cached = this.hermesRunCountCache.get(jobId)
@@ -580,7 +567,10 @@ export class ExternalAutomationsHandler {
     // processes are long-lived, so stale job ids need both TTL and a hard cap.
     this.pruneHermesRunCountCache(now)
     const entry: HermesRunCountCacheEntry = {
-      promise: this.readHermesRunRefs(jobId).then((refs) => refs.length),
+      promise: this.readHermesRunRefs(jobId).then((result) => ({
+        total: result.refs.length,
+        ...(result.saturated ? { totalSaturated: true as const } : {})
+      })),
       expiresAt: Number.POSITIVE_INFINITY
     }
     this.hermesRunCountCache.set(jobId, entry)
@@ -621,6 +611,7 @@ export class ExternalAutomationsHandler {
 
   private async listRuns(params: Record<string, unknown> = {}): Promise<{
     total: number
+    totalSaturated?: true
     runs: unknown[]
   }> {
     const provider = params.provider === 'openclaw' ? 'openclaw' : 'hermes'
@@ -631,7 +622,7 @@ export class ExternalAutomationsHandler {
         : 1
     const pageSize =
       typeof params.pageSize === 'number' && Number.isFinite(params.pageSize)
-        ? Math.min(100, Math.max(0, Math.floor(params.pageSize)))
+        ? Math.min(HERMES_RUN_PAGE_MAX_RUNS, Math.max(0, Math.floor(params.pageSize)))
         : 25
     if (provider !== 'hermes') {
       return { total: 0, runs: [] }
@@ -642,53 +633,52 @@ export class ExternalAutomationsHandler {
     if (pageSize === 0) {
       // Why: manager listing only needs a badge count; hydrating markdown logs
       // and full session transcripts can make opening Automations very slow.
-      return { total: await this.readHermesRunCount(jobId), runs: [] }
+      return { ...(await this.readHermesRunCount(jobId)), runs: [] }
     }
     const runRefs = await this.readHermesRunRefs(jobId)
     const start = (page - 1) * pageSize
     return {
-      total: runRefs.length,
-      runs: await Promise.all(
-        runRefs.slice(start, start + pageSize).map((ref) => this.hydrateHermesRunRef(jobId, ref))
+      total: runRefs.refs.length,
+      ...(runRefs.saturated ? { totalSaturated: true } : {}),
+      runs: await hydrateHermesRunPageWithinLimits(
+        runRefs.refs.slice(start, start + pageSize),
+        (ref) => this.hydrateHermesRunRef(jobId, ref)
       )
     }
   }
 
-  private getRawRunId(run: unknown): string {
-    if (this.isRecord(run) && 'id' in run) {
-      return String(run.id)
-    }
-    return ''
-  }
-
-  private getRawRunTime(run: unknown): number {
-    if (!this.isRecord(run) || !('run_at' in run)) {
-      return Number.NaN
-    }
-    return typeof run.run_at === 'string' ? Date.parse(run.run_at) : Number.NaN
-  }
-
-  private async readHermesOutputFileRunRefs(jobId: string): Promise<HermesOutputRunRef[]> {
+  private async readHermesOutputFileRunRefs(
+    jobId: string
+  ): Promise<BoundedHermesRunRefs<HermesOutputRunRef>> {
     const outputDir = join(HERMES_OUTPUT_DIR, jobId)
     if (!existsSync(outputDir)) {
-      return []
+      return { refs: [], saturated: false }
     }
-    const entries = await readdir(outputDir, { withFileTypes: true })
-    return entries
-      .filter((entry) => entry.isFile() && HERMES_OUTPUT_FILE_PATTERN.test(entry.name))
-      .map((entry) => ({
+    const retainer = new HermesRunRefRetainer<HermesOutputRunRef>()
+    const directory = await opendir(outputDir)
+    for await (const entry of directory) {
+      if (!entry.isFile() || !HERMES_OUTPUT_FILE_PATTERN.test(entry.name)) {
+        continue
+      }
+      retainer.add({
         kind: 'output' as const,
         id: `${jobId}:${entry.name}`,
         job_id: jobId,
         run_at: this.runAtFromHermesOutputFile(entry.name),
         run_key: this.runKeyFromHermesOutputFile(entry.name),
         output_path: join(outputDir, entry.name)
-      }))
+      })
+    }
+    return retainer.finish()
   }
 
   private async readHermesOutputFileRun(ref: HermesOutputRunRef): Promise<unknown> {
     try {
-      const content = await readFile(ref.output_path, 'utf-8')
+      const { buffer } = await readNodeFileWithinLimit(
+        ref.output_path,
+        HERMES_PRIMARY_OUTPUT_MAX_BYTES
+      )
+      const content = buffer.toString('utf-8')
       const parsed = this.parseHermesOutput(content)
       const outputContent = await this.appendReferencedLogFile(parsed.outputContent)
       return {
@@ -717,41 +707,45 @@ export class ExternalAutomationsHandler {
     }
   }
 
-  private readHermesSessionDbRunRefs(jobId: string): HermesSessionRunRef[] {
+  private readHermesSessionDbRunRefs(jobId: string): BoundedHermesRunRefs<HermesSessionRunRef> {
     if (!existsSync(HERMES_STATE_DB)) {
-      return []
+      return { refs: [], saturated: false }
     }
     const Database = this.getDatabaseConstructor()
     if (!Database) {
-      return []
+      return { refs: [], saturated: false }
     }
     try {
       const db = new Database(HERMES_STATE_DB, { readonly: true, fileMustExist: true })
       try {
         const pattern = `cron\\_${this.escapeSqlLike(jobId)}\\_%`
-        const rows = db
-          .prepare(
-            `SELECT id, started_at
-               FROM sessions
-              WHERE id LIKE ? ESCAPE '\\'
-              ORDER BY started_at DESC`
-          )
-          .all(pattern) as Record<string, unknown>[]
-        return rows.map((row) => {
+        const statement = db.prepare(HERMES_SESSION_RUN_REFS_SELECT_SQL)
+        const rows =
+          typeof statement.iterate === 'function'
+            ? statement.iterate(pattern)
+            : statement.all(pattern)
+        const retainer = new HermesRunRefRetainer<HermesSessionRunRef>()
+        let read = 0
+        for (const row of rows) {
+          if (read >= HERMES_RUN_REF_MAX_ENTRIES + 1) {
+            break
+          }
+          read += 1
           const runId = typeof row.id === 'string' ? row.id : `${jobId}:${String(row.started_at)}`
-          return {
+          retainer.add({
             kind: 'session',
             id: runId,
             job_id: jobId,
             run_at: this.runAtFromUnixSeconds(row.started_at),
             run_key: runId.split(`${jobId}_`).at(-1) ?? null
-          }
-        })
+          })
+        }
+        return retainer.finish()
       } finally {
         db.close()
       }
     } catch {
-      return []
+      return { refs: [], saturated: false }
     }
   }
 
@@ -777,14 +771,12 @@ export class ExternalAutomationsHandler {
         if (!row) {
           return null
         }
-        const messages = db
-          .prepare(
-            `SELECT role, content, tool_name, reasoning, reasoning_content
-                 FROM messages
-                WHERE session_id = ?
-                ORDER BY timestamp, id`
-          )
-          .all(runId) as Record<string, unknown>[]
+        const messageStatement = db.prepare(HERMES_SESSION_TRANSCRIPT_SELECT_SQL)
+        const messages =
+          typeof messageStatement.iterate === 'function'
+            ? messageStatement.iterate(runId)
+            : messageStatement.all(runId)
+        const formattedMessages = formatHermesSessionMessagesWithinLimits(messages)
         const title = typeof row.title === 'string' && row.title.trim() ? row.title.trim() : null
         const model = typeof row.model === 'string' && row.model.trim() ? row.model.trim() : null
         const messageCount = typeof row.message_count === 'number' ? row.message_count : null
@@ -804,8 +796,8 @@ export class ExternalAutomationsHandler {
           run_key: runId.split(`${jobId}_`).at(-1) ?? null,
           status: typeof row.ended_at === 'number' ? 'completed' : 'unknown',
           output_preview: summaryParts.join(' · ') || null,
-          output_content: this.formatSessionMessages(messages),
-          error: null,
+          output_content: formattedMessages.content,
+          error: formattedMessages.truncated ? HERMES_SESSION_TRANSCRIPT_TRUNCATED_ERROR : null,
           output_path: HERMES_STATE_DB
         }
       } finally {

--- a/src/relay/filesystem-directory-reader.test.ts
+++ b/src/relay/filesystem-directory-reader.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FILESYSTEM_DIRECTORY_LIMIT_MESSAGE } from '../shared/filesystem-directory-listing-limit'
+import { collectRelayFilesystemDirectoryEntries } from './filesystem-directory-reader'
+
+function entry(name: string, options?: { directory?: boolean; symlink?: boolean }) {
+  return {
+    name,
+    isDirectory: () => options?.directory ?? false,
+    isSymbolicLink: () => options?.symlink ?? false
+  }
+}
+
+describe('relay filesystem directory reader', () => {
+  it('preserves directory-first ordering and symlink-directory classification', async () => {
+    const classify = vi.fn(async (_dirPath, source) =>
+      source.isSymbolicLink() ? true : source.isDirectory()
+    )
+
+    await expect(
+      collectRelayFilesystemDirectoryEntries(
+        '/repo',
+        [
+          entry('z.txt'),
+          entry('linked', { symlink: true }),
+          entry('beta', { directory: true }),
+          entry('alpha', { directory: true })
+        ],
+        undefined,
+        classify
+      )
+    ).resolves.toEqual([
+      { name: 'alpha', isDirectory: true, isSymlink: false },
+      { name: 'beta', isDirectory: true, isSymlink: false },
+      { name: 'linked', isDirectory: true, isSymlink: true },
+      { name: 'z.txt', isDirectory: false, isSymlink: false }
+    ])
+    expect(classify).toHaveBeenCalledTimes(4)
+  })
+
+  it('stops before classifying or retaining the first over-limit entry', async () => {
+    let enumerated = 0
+    const classify = vi.fn(async () => false)
+    const source = {
+      async *[Symbol.asyncIterator]() {
+        while (enumerated < 100) {
+          enumerated += 1
+          yield entry(`entry-${enumerated}`)
+        }
+      }
+    }
+
+    await expect(
+      collectRelayFilesystemDirectoryEntries(
+        '/repo',
+        source,
+        { maxEntries: 3, maxRetainedBytes: 1024 },
+        classify
+      )
+    ).rejects.toThrow(FILESYSTEM_DIRECTORY_LIMIT_MESSAGE)
+    expect(enumerated).toBe(4)
+    expect(classify).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/relay/filesystem-directory-reader.ts
+++ b/src/relay/filesystem-directory-reader.ts
@@ -1,0 +1,70 @@
+import { opendir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  createFilesystemDirectoryLimitState,
+  trackFilesystemDirectoryEntry,
+  type FilesystemDirectoryListingLimits
+} from '../shared/filesystem-directory-listing-limit'
+
+type RelayDirectorySourceEntry = {
+  name: string
+  isDirectory(): boolean
+  isSymbolicLink(): boolean
+}
+
+export type RelayFilesystemDirectoryEntry = {
+  name: string
+  isDirectory: boolean
+  isSymlink: boolean
+}
+
+type DirectoryClassifier = (dirPath: string, entry: RelayDirectorySourceEntry) => Promise<boolean>
+
+async function isRelayFilesystemDirectoryEntry(
+  dirPath: string,
+  entry: RelayDirectorySourceEntry
+): Promise<boolean> {
+  if (entry.isDirectory()) {
+    return true
+  }
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  try {
+    // Why: linked directories must remain expandable remotely.
+    return (await stat(join(dirPath, entry.name))).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export async function readRelayFilesystemDirectory(
+  dirPath: string,
+  requestedLimits?: Partial<FilesystemDirectoryListingLimits>
+): Promise<RelayFilesystemDirectoryEntry[]> {
+  return collectRelayFilesystemDirectoryEntries(dirPath, await opendir(dirPath), requestedLimits)
+}
+
+export async function collectRelayFilesystemDirectoryEntries(
+  dirPath: string,
+  directory: AsyncIterable<RelayDirectorySourceEntry> | Iterable<RelayDirectorySourceEntry>,
+  requestedLimits?: Partial<FilesystemDirectoryListingLimits>,
+  classifyDirectory: DirectoryClassifier = isRelayFilesystemDirectoryEntry
+): Promise<RelayFilesystemDirectoryEntry[]> {
+  const entries: RelayFilesystemDirectoryEntry[] = []
+  const limit = createFilesystemDirectoryLimitState(requestedLimits)
+  for await (const entry of directory) {
+    trackFilesystemDirectoryEntry(limit, entry)
+    entries.push({
+      name: entry.name,
+      isDirectory: await classifyDirectory(dirPath, entry),
+      isSymlink: entry.isSymbolicLink()
+    })
+  }
+  return entries.sort((left, right) => {
+    if (left.isDirectory !== right.isDirectory) {
+      return left.isDirectory ? -1 : 1
+    }
+    return left.name.localeCompare(right.name)
+  })
+}

--- a/src/relay/fs-handler-file-read.ts
+++ b/src/relay/fs-handler-file-read.ts
@@ -1,5 +1,12 @@
-import { open, readFile, stat } from 'node:fs/promises'
+import { open, stat } from 'node:fs/promises'
 import { extname } from 'node:path'
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
+import {
+  assertRasterImagePreviewWithinLimits,
+  isKnownRasterImageMimeType,
+  RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES
+} from '../shared/raster-image-preview-limits'
+import type { RasterImageDimensions } from '../shared/raster-image-dimensions'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import { STREAM_ACK_WINDOW_CHUNKS, STREAM_CHUNK_SIZE, RelayErrorCode } from './protocol'
 import type { RelayStreamRegistry, TooManyStreamsError } from './fs-stream-registry'
@@ -23,15 +30,22 @@ export async function readRelayFileContent(filePath: string) {
   }
 
   if (mimeType) {
-    const buffer = await readFile(filePath)
-    return { content: buffer.toString('base64'), isBinary: true, isImage: true, mimeType }
+    const { buffer } = await readNodeFileWithinLimit(filePath, sizeLimit)
+    const imageDimensions = assertRasterImagePreviewWithinLimits(buffer, mimeType)
+    return {
+      content: buffer.toString('base64'),
+      isBinary: true,
+      isImage: true,
+      mimeType,
+      ...(imageDimensions ? { imageDimensions } : {})
+    }
   }
 
   if (stats.size > BINARY_PROBE_BYTES && (await isBinaryFilePrefix(filePath))) {
     return { content: '', isBinary: true }
   }
 
-  const buffer = await readFile(filePath)
+  const { buffer } = await readNodeFileWithinLimit(filePath, sizeLimit)
   if (isBinaryBuffer(buffer)) {
     return { content: '', isBinary: true }
   }
@@ -44,6 +58,7 @@ export type StreamMetadata = {
   isBinary: boolean
   isImage?: boolean
   mimeType?: string
+  imageDimensions?: RasterImageDimensions
   /** On-the-wire encoding of each chunk's `data` field. Always 'base64'. */
   chunkEncoding?: 'base64'
   /** Encoding of the assembled FileReadResult.content. */
@@ -105,30 +120,37 @@ export async function readRelayFileStreamMetadata(
   const handle = await open(filePath, 'r')
   let streamId: number
   try {
-    streamId = registry.register(handle)
+    let imageDimensions: RasterImageDimensions | undefined
+    if (isKnownRasterImageMimeType(mimeType)) {
+      const header = Buffer.alloc(Math.min(stats.size, RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES))
+      const headerBytesRead = await readFullStreamChunk(handle, header, header.length, 0)
+      imageDimensions = assertRasterImagePreviewWithinLimits(
+        header.subarray(0, headerBytesRead),
+        mimeType
+      )
+    }
+    streamId = registry.register(handle, context.clientId)
+    process.stderr.write(`[relay] stream start id=${streamId} size=${stats.size}\n`)
+
+    // Why: start after metadata returns so the subscribed client cannot miss the first chunk.
+    const resolvedPumpOptions = pumpOptions ?? { paceWithAcks: false }
+    setImmediate(() => {
+      void pumpChunks(streamId, stats.size, dispatcher, registry, context, resolvedPumpOptions)
+    })
+
+    return {
+      streamId,
+      totalSize: stats.size,
+      isBinary: !!mimeType,
+      isImage: mimeType ? true : undefined,
+      mimeType,
+      ...(imageDimensions ? { imageDimensions } : {}),
+      chunkEncoding: 'base64',
+      resultEncoding: mimeType ? 'base64' : 'utf-8'
+    }
   } catch (err) {
     await handle.close()
     throw err
-  }
-
-  process.stderr.write(`[relay] stream start id=${streamId} size=${stats.size}\n`)
-
-  // Why: pumpChunks owns its own try/finally for handle release; the outer
-  // setImmediate kicks the pump off the metadata-response task so the client
-  // sees the response before the first chunk frame.
-  const resolvedPumpOptions = pumpOptions ?? { paceWithAcks: false }
-  setImmediate(() => {
-    void pumpChunks(streamId, stats.size, dispatcher, registry, context, resolvedPumpOptions)
-  })
-
-  return {
-    streamId,
-    totalSize: stats.size,
-    isBinary: !!mimeType,
-    isImage: mimeType ? true : undefined,
-    mimeType,
-    chunkEncoding: 'base64',
-    resultEncoding: mimeType ? 'base64' : 'utf-8'
   }
 }
 
@@ -203,6 +225,7 @@ async function pumpChunks(
         // Why: the bulk lane waits out sink saturation, so a flood of chunk
         // frames cannot pile up in the outbound pipe ahead of interactive
         // pty.data frames written via plain notify().
+        registry.recordSent(streamId, seq)
         await dispatcher.notifyBulk(
           'fs.streamChunk',
           { streamId, seq, data },
@@ -227,14 +250,23 @@ async function pumpChunks(
 
     try {
       if (endReason === 'end') {
-        dispatcher.notify('fs.streamEnd', { streamId })
+        if (pumpOptions.clientId !== undefined) {
+          dispatcher.notifyClient(pumpOptions.clientId, 'fs.streamEnd', { streamId })
+        } else {
+          dispatcher.notify('fs.streamEnd', { streamId })
+        }
         process.stderr.write(`[relay] stream end id=${streamId}\n`)
       } else if (endReason === 'error') {
-        dispatcher.notify('fs.streamError', {
+        const params = {
           streamId,
           code: errorCode ?? 'ESTREAMERROR',
           message: errorMessage ?? 'stream error'
-        })
+        }
+        if (pumpOptions.clientId !== undefined) {
+          dispatcher.notifyClient(pumpOptions.clientId, 'fs.streamError', params)
+        } else {
+          dispatcher.notify('fs.streamError', params)
+        }
         process.stderr.write(`[relay] stream error id=${streamId} code=${errorCode}\n`)
       } else if (endReason === 'aborted') {
         process.stderr.write(`[relay] stream cancel id=${streamId}\n`)

--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -27,6 +27,14 @@ import {
   SEARCH_TIMEOUT_MS
 } from '../shared/text-search'
 import { buildRelayGitEnv } from './relay-command-env'
+import { SearchSubprocessLineAccumulator } from '../shared/search-subprocess-lines'
+import {
+  createQuickOpenListingBudget,
+  QUICK_OPEN_LISTING_MAX_PATH_BYTES,
+  QuickOpenSubprocessPathAccumulator,
+  resolveQuickOpenResultLimit,
+  retainQuickOpenPath
+} from '../shared/quick-open-listing-limits'
 
 /**
  * List files using `git ls-files`. Fallback when rg is not installed.
@@ -46,9 +54,14 @@ export function listFilesWithGit(
   if (signal?.aborted) {
     return Promise.reject(fileListingCancellationError(signal))
   }
+  const resultLimit = resolveQuickOpenResultLimit(maxResults)
+  if (resultLimit === 0) {
+    return Promise.resolve([])
+  }
   const gitPaths = new Set<string>()
   const directoryPaths = new Set<string>()
   const directFileCandidates = new Set<string>()
+  const listingBudget = createQuickOpenListingBudget()
   const { primary, ignoredPass } = buildGitLsFilesArgsForQuickOpen(excludePathPrefixes)
   const children: {
     child: ReturnType<typeof spawn>
@@ -59,7 +72,7 @@ export function listFilesWithGit(
 
   const runGitLsFiles = (args: string[]): Promise<void> => {
     return new Promise((resolve, reject) => {
-      let buf = ''
+      const paths = new QuickOpenSubprocessPathAccumulator(0)
       let done = false
 
       const processPath = (path: string): boolean => {
@@ -67,27 +80,23 @@ export function listFilesWithGit(
           return false
         }
         if (path.endsWith('/')) {
-          directoryPaths.add(path)
+          retainQuickOpenPath(directoryPaths, path, listingBudget)
         } else {
-          gitPaths.add(path)
-          if (maxResults !== undefined) {
-            // Why: this duplicate classification exists only to stop bounded
-            // scans; unbounded SSH scans must not retain another full listing.
-            const parsed = parseQuickOpenGitLsFilesEntry(path)
-            const relPath = parsed.path.replace(/\/+$/, '')
-            if (
-              !parsed.isGitlink &&
-              !parsed.isUntrackedDir &&
-              shouldIncludeQuickOpenPath(relPath) &&
-              !shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)
-            ) {
-              directFileCandidates.add(relPath)
-            }
+          retainQuickOpenPath(gitPaths, path, listingBudget)
+          const parsed = parseQuickOpenGitLsFilesEntry(path)
+          const relPath = parsed.path.replace(/\/+$/, '')
+          if (
+            !parsed.isGitlink &&
+            !parsed.isUntrackedDir &&
+            shouldIncludeQuickOpenPath(relPath) &&
+            !shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)
+          ) {
+            retainQuickOpenPath(directFileCandidates, relPath, listingBudget)
           }
         }
         // Why: placeholders need IO classification and can disappear; only
         // guaranteed final files are allowed to stop the remote Git processes.
-        return maxResults !== undefined && directFileCandidates.size >= maxResults
+        return directFileCandidates.size >= resultLimit
       }
 
       const child = spawn('git', ['ls-files', ...args], {
@@ -111,7 +120,7 @@ export function listFilesWithGit(
           return
         }
         done = true
-        buf = ''
+        paths.clear()
         cleanup()
         reject(error)
       }
@@ -120,6 +129,7 @@ export function listFilesWithGit(
           return
         }
         done = true
+        paths.clear()
         cleanup()
         resolve()
       }
@@ -130,20 +140,23 @@ export function listFilesWithGit(
         resolve: resolvePass
       })
 
-      function handleStdoutData(chunk: string): void {
-        buf += chunk
-        let start = 0
-        let idx = buf.indexOf('\0', start)
-        while (idx !== -1) {
-          if (processPath(buf.substring(start, idx))) {
-            buf = ''
+      function failForOutput(error: unknown): void {
+        child.kill()
+        rejectPass(error instanceof Error ? error : new Error(String(error)))
+      }
+      function handleStdoutData(chunk: Buffer | string): void {
+        try {
+          const outcome = paths.push(chunk, (path) => !processPath(path))
+          if (outcome === 'stopped') {
             finishAtLimit()
-            return
+          } else if (outcome === 'path-too-large') {
+            failForOutput(
+              new Error(`Quick Open file path exceeded ${QUICK_OPEN_LISTING_MAX_PATH_BYTES} bytes`)
+            )
           }
-          start = idx + 1
-          idx = buf.indexOf('\0', start)
+        } catch (error) {
+          failForOutput(error)
         }
-        buf = start < buf.length ? buf.substring(start) : ''
       }
       function handleStderrData(): void {
         /* drain */
@@ -162,9 +175,14 @@ export function listFilesWithGit(
           rejectPass(new Error(`git ls-files killed by ${signal}`))
           return
         }
-        if (buf && processPath(buf)) {
-          buf = ''
-          finishAtLimit()
+        try {
+          const trailingPath = paths.finish()
+          if (trailingPath && processPath(trailingPath)) {
+            finishAtLimit()
+            return
+          }
+        } catch (error) {
+          failForOutput(error)
           return
         }
         if (code === 0) {
@@ -177,7 +195,6 @@ export function listFilesWithGit(
         rejectPass(new Error(`git ls-files exited with code ${code}`))
       }
 
-      child.stdout!.setEncoding('utf-8')
       child.stdout!.on('data', handleStdoutData)
       child.stderr!.on('data', handleStderrData)
       child.once('error', handleError)
@@ -232,12 +249,9 @@ export function listFilesWithGit(
         )
       }
     })
-  const passes =
-    maxResults === undefined
-      ? Promise.all([runGitLsFiles(primary), runIgnoredPass()])
-      : runGitLsFiles(primary).then(() =>
-          directFileCandidates.size < maxResults ? runIgnoredPass() : Promise.resolve()
-        )
+  const passes = runGitLsFiles(primary).then(() =>
+    directFileCandidates.size < resultLimit ? runIgnoredPass() : Promise.resolve()
+  )
 
   return passes
     .then(async () => {
@@ -247,11 +261,11 @@ export function listFilesWithGit(
         directoryPaths,
         excludePathPrefixes,
         signal,
-        maxResults
+        maxResults: resultLimit
       })
       // Why: directory placeholders are expanded after Git exits; restore
       // Git's path order for empty queries and fuzzy-score ties over SSH.
-      return files.sort().slice(0, maxResults)
+      return files.sort().slice(0, resultLimit)
     })
     .catch((err) => {
       killSurvivors('git ls-files canceled after sibling failure')
@@ -277,7 +291,7 @@ export function searchWithGitGrep(
     const gitArgs = buildGitGrepArgs(query, opts)
     const matchRegex = buildSubmatchRegex(query, opts)
     const acc = createAccumulator()
-    let stdoutBuffer = ''
+    const stdoutLines = new SearchSubprocessLineAccumulator()
     let done = false
 
     const child = spawn('git', gitArgs, {
@@ -309,12 +323,11 @@ export function searchWithGitGrep(
       }
     }
 
-    function handleStdoutData(chunk: string): void {
-      stdoutBuffer += chunk
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
+    function handleStdoutData(chunk: Buffer): void {
+      if (!stdoutLines.push(chunk, processLine)) {
+        acc.truncated = true
+        child.kill()
+        resolveOnce()
       }
     }
 
@@ -327,13 +340,13 @@ export function searchWithGitGrep(
     }
 
     function handleClose(): void {
-      if (stdoutBuffer) {
-        processLine(stdoutBuffer)
+      const trailingLine = stdoutLines.finish()
+      if (trailingLine !== null) {
+        processLine(trailingLine)
       }
       resolveOnce()
     }
 
-    child.stdout!.setEncoding('utf-8')
     child.stdout!.on('data', handleStdoutData)
     child.stderr!.on('data', handleStderrData)
     child.once('error', handleError)

--- a/src/relay/fs-handler-list-files-cancel.test.ts
+++ b/src/relay/fs-handler-list-files-cancel.test.ts
@@ -43,7 +43,7 @@ describe('relay list-files cancellation', () => {
     vi.useRealTimers()
   })
 
-  it('listFilesWithRg kills both rg passes and rejects when aborted mid-flight', async () => {
+  it('listFilesWithRg kills the active rg pass and rejects when aborted mid-flight', async () => {
     const primaryProc = createMockProcess()
     const ignoredProc = createMockProcess()
     spawnMock.mockImplementation((_cmd: string, args: string[]) =>
@@ -59,7 +59,8 @@ describe('relay list-files cancellation', () => {
 
     await expect(promise).rejects.toSatisfy(isFileListingCancellation)
     expect(primaryProc.kill).toHaveBeenCalled()
-    expect(ignoredProc.kill).toHaveBeenCalled()
+    expect(ignoredProc.kill).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
 
     // Late close events after cancellation must not fire anything.
     primaryProc.emit('close', null, 'SIGTERM')
@@ -89,14 +90,16 @@ describe('relay list-files cancellation', () => {
     setTimeout(() => {
       ;(primaryProc.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\n')
       primaryProc.emit('close', 0, null)
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/out.js\n')
-      ignoredProc.emit('close', 0, null)
+      queueMicrotask(() => {
+        ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/out.js\n')
+        ignoredProc.emit('close', 0, null)
+      })
     }, 5)
 
     await expect(promise).resolves.toEqual(['src/index.ts', 'dist/out.js'])
   })
 
-  it('listFilesWithGit kills both git passes and rejects when aborted mid-flight', async () => {
+  it('listFilesWithGit kills the active git pass and rejects when aborted mid-flight', async () => {
     const procs: ChildProcess[] = []
     spawnMock.mockImplementation(() => {
       const proc = createMockProcess()
@@ -107,12 +110,11 @@ describe('relay list-files cancellation', () => {
     const controller = new AbortController()
     const promise = listFilesWithGit('/remote/root', [], { signal: controller.signal })
 
-    expect(procs).toHaveLength(2)
+    expect(procs).toHaveLength(1)
     controller.abort()
 
     await expect(promise).rejects.toSatisfy(isFileListingCancellation)
     expect(procs[0].kill).toHaveBeenCalled()
-    expect(procs[1].kill).toHaveBeenCalled()
   })
 
   it('listFilesWithGit rejects without spawning when the signal is already aborted', async () => {

--- a/src/relay/fs-handler-list-files-ignored.test.ts
+++ b/src/relay/fs-handler-list-files-ignored.test.ts
@@ -16,6 +16,10 @@ import { tmpdir } from 'node:os'
 import { listFilesWithGit } from './fs-handler-git-fallback'
 import { listFilesWithRg } from './fs-handler-list-files'
 import { searchWithRg } from './fs-handler-utils'
+import {
+  QUICK_OPEN_LISTING_MAX_PATH_BYTES,
+  QUICK_OPEN_LISTING_MAX_RESULTS
+} from '../shared/quick-open-listing-limits'
 
 const tempDirs: string[] = []
 const SHA1 = '0123456789abcdef0123456789abcdef01234567'
@@ -77,10 +81,12 @@ describe('relay quick open ignored file listing', () => {
       ;(primaryProc.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\n')
       primaryProc.emit('close', 0, null)
 
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\n')
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'node_modules/pkg/index.js\n')
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'packages/other/src/x.ts\n')
-      ignoredProc.emit('close', 0, null)
+      queueMicrotask(() => {
+        ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\n')
+        ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'node_modules/pkg/index.js\n')
+        ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'packages/other/src/x.ts\n')
+        ignoredProc.emit('close', 0, null)
+      })
     }, 10)
 
     await expect(promise).resolves.toEqual(['src/index.ts', 'dist/generated.js'])
@@ -115,6 +121,46 @@ describe('relay quick open ignored file listing', () => {
     expect(callIndex).toBe(1)
   })
 
+  it('bounds an omitted relay rg result limit without spawning the ignored pass', async () => {
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    let callIndex = 0
+    spawnMock.mockImplementation(() => (++callIndex === 1 ? primary : ignored))
+    const promise = listFilesWithRg('/remote/root')
+    const paths = Array.from(
+      { length: QUICK_OPEN_LISTING_MAX_RESULTS + 1 },
+      (_value, index) => `src/file-${index}.ts`
+    )
+
+    ;(primary.stdout as unknown as EventEmitter).emit('data', paths.join('\n'))
+
+    const result = await promise
+    expect(result).toHaveLength(QUICK_OPEN_LISTING_MAX_RESULTS)
+    expect(primary.kill).toHaveBeenCalled()
+    expect(ignored.kill).not.toHaveBeenCalled()
+    expect(callIndex).toBe(1)
+  })
+
+  it('kills a relay rg scan whose residual path exceeds the field limit', async () => {
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    let callIndex = 0
+    spawnMock.mockImplementation(() => (++callIndex === 1 ? primary : ignored))
+    const promise = listFilesWithRg('/remote/root')
+
+    ;(primary.stdout as unknown as EventEmitter).emit(
+      'data',
+      Buffer.alloc(QUICK_OPEN_LISTING_MAX_PATH_BYTES + 1, 0x61)
+    )
+
+    await expect(promise).rejects.toThrow(
+      `Quick Open file path exceeded ${QUICK_OPEN_LISTING_MAX_PATH_BYTES} bytes`
+    )
+    expect(primary.kill).toHaveBeenCalled()
+    expect(ignored.kill).not.toHaveBeenCalled()
+    expect(callIndex).toBe(1)
+  })
+
   it('git fallback ignored pass includes ignored non-env files', async () => {
     const root = await makeTempRoot()
     await writeRel(root, 'dist/generated.js')
@@ -140,9 +186,11 @@ describe('relay quick open ignored file listing', () => {
       )
       primaryProc.emit('close', 0, null)
 
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/\0')
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'packages/other/src/x.ts\0')
-      ignoredProc.emit('close', 0, null)
+      queueMicrotask(() => {
+        ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/\0')
+        ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'packages/other/src/x.ts\0')
+        ignoredProc.emit('close', 0, null)
+      })
     }, 10)
 
     await expect(promise).resolves.toEqual(['dist/generated.js', 'src/index.ts', 'tab\tfile.txt'])
@@ -176,6 +224,26 @@ describe('relay quick open ignored file listing', () => {
     await expect(promise).resolves.toEqual(['src/one.ts', 'src/two.ts'])
     expect(primaryProc.kill).toHaveBeenCalled()
     expect(ignoredProc.kill).not.toHaveBeenCalled()
+    expect(callIndex).toBe(1)
+  })
+
+  it('bounds an omitted relay Git result limit before spawning the ignored pass', async () => {
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    let callIndex = 0
+    spawnMock.mockImplementation(() => (++callIndex === 1 ? primary : ignored))
+    const promise = listFilesWithGit('/remote/root')
+    const paths = Array.from(
+      { length: QUICK_OPEN_LISTING_MAX_RESULTS + 1 },
+      (_value, index) => `src/file-${index}.ts`
+    )
+
+    ;(primary.stdout as unknown as EventEmitter).emit('data', paths.join('\0'))
+
+    const result = await promise
+    expect(result).toHaveLength(QUICK_OPEN_LISTING_MAX_RESULTS)
+    expect(primary.kill).toHaveBeenCalled()
+    expect(ignored.kill).not.toHaveBeenCalled()
     expect(callIndex).toBe(1)
   })
 
@@ -219,7 +287,7 @@ describe('relay quick open ignored file listing', () => {
         `${staged('100644', 'README.md')}\0${staged('160000', 'packages/app')}\0packages/lib/\0`
       )
       primaryProc.emit('close', 0, null)
-      ignoredProc.emit('close', 0, null)
+      queueMicrotask(() => ignoredProc.emit('close', 0, null))
     }, 10)
 
     await expect(promise).resolves.toEqual([
@@ -247,9 +315,11 @@ describe('relay quick open ignored file listing', () => {
         ;(primaryProc.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\0')
         primaryProc.emit('close', 0, null)
 
-        // Entries streamed before the kill are kept alongside the primary pass.
-        ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\0')
-        ignoredProc.emit('close', null, 'SIGTERM')
+        queueMicrotask(() => {
+          // Entries streamed before the kill are kept alongside the primary pass.
+          ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\0')
+          ignoredProc.emit('close', null, 'SIGTERM')
+        })
       }, 10)
 
       await expect(promise).resolves.toEqual(['dist/generated.js', 'src/index.ts'])
@@ -277,7 +347,7 @@ describe('relay quick open ignored file listing', () => {
         ;(primaryProc.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\0')
         primaryProc.emit('close', 0, null)
 
-        ignoredProc.emit('close', 128, null)
+        queueMicrotask(() => ignoredProc.emit('close', 128, null))
       }, 10)
 
       await expect(promise).resolves.toEqual(['src/index.ts'])
@@ -302,12 +372,10 @@ describe('relay quick open ignored file listing', () => {
     setTimeout(() => {
       ;(primaryProc.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\0')
       primaryProc.emit('close', null, 'SIGTERM')
-
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\0')
-      ignoredProc.emit('close', 0, null)
     }, 10)
 
     await expect(promise).rejects.toThrow('git ls-files killed by SIGTERM')
+    expect(callIndex).toBe(1)
   })
 
   it('git fallback rejects when the primary pass exits non-zero', async () => {
@@ -324,12 +392,10 @@ describe('relay quick open ignored file listing', () => {
 
     setTimeout(() => {
       primaryProc.emit('close', 128, null)
-
-      ;(ignoredProc.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\0')
-      ignoredProc.emit('close', 0, null)
     }, 10)
 
     await expect(promise).rejects.toThrow('git ls-files exited with code 128')
+    expect(callIndex).toBe(1)
   })
 
   it('git fallback rejects when a timed-out child does not emit close', async () => {
@@ -355,15 +421,12 @@ describe('relay quick open ignored file listing', () => {
 
       expect(outcome).toContain('git ls-files timed out')
       expect(primaryProc.kill).toHaveBeenCalled()
-      expect(ignoredProc.kill).toHaveBeenCalled()
+      expect(ignoredProc.kill).not.toHaveBeenCalled()
+      expect(callIndex).toBe(1)
       expect((primaryProc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
       expect((primaryProc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
       expect(primaryProc.listenerCount('error')).toBe(0)
       expect(primaryProc.listenerCount('close')).toBe(0)
-      expect((ignoredProc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
-      expect((ignoredProc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
-      expect(ignoredProc.listenerCount('error')).toBe(0)
-      expect(ignoredProc.listenerCount('close')).toBe(0)
     } finally {
       vi.useRealTimers()
     }
@@ -392,15 +455,12 @@ describe('relay quick open ignored file listing', () => {
 
       expect(outcome).toBe('rejected:rg list timed out')
       expect(primaryProc.kill).toHaveBeenCalled()
-      expect(ignoredProc.kill).toHaveBeenCalled()
+      expect(ignoredProc.kill).not.toHaveBeenCalled()
+      expect(callIndex).toBe(1)
       expect((primaryProc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
       expect((primaryProc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
       expect(primaryProc.listenerCount('error')).toBe(0)
       expect(primaryProc.listenerCount('close')).toBe(0)
-      expect((ignoredProc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
-      expect((ignoredProc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
-      expect(ignoredProc.listenerCount('error')).toBe(0)
-      expect(ignoredProc.listenerCount('close')).toBe(0)
     } finally {
       vi.useRealTimers()
     }

--- a/src/relay/fs-handler-list-files.ts
+++ b/src/relay/fs-handler-list-files.ts
@@ -23,6 +23,13 @@ import {
   shouldExcludeQuickOpenRelPath,
   shouldIncludeQuickOpenPath
 } from '../shared/quick-open-filter'
+import {
+  createQuickOpenListingBudget,
+  QUICK_OPEN_LISTING_MAX_PATH_BYTES,
+  QuickOpenSubprocessPathAccumulator,
+  resolveQuickOpenResultLimit,
+  retainQuickOpenPath
+} from '../shared/quick-open-listing-limits'
 
 export const LIST_FILES_TIMEOUT_MS = 25_000
 
@@ -35,8 +42,13 @@ export function listFilesWithRg(
   if (signal?.aborted) {
     return Promise.reject(fileListingCancellationError(signal))
   }
+  const resultLimit = resolveQuickOpenResultLimit(maxResults)
+  if (resultLimit === 0) {
+    return Promise.resolve([])
+  }
   return new Promise((resolve, reject) => {
     const files = new Set<string>()
+    const listingBudget = createQuickOpenListingBudget()
     let done = false
     const children: {
       child: ChildProcess
@@ -66,16 +78,15 @@ export function listFilesWithRg(
       if (shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)) {
         return true
       }
-      files.add(relPath)
-      if (maxResults !== undefined && files.size >= maxResults) {
-        finishAtLimit()
+      if (files.size < resultLimit) {
+        retainQuickOpenPath(files, relPath, listingBudget)
       }
       return true
     }
 
     const runPass = (args: string[]): Promise<void> =>
       new Promise((passResolve, passReject) => {
-        let passBuf = ''
+        const paths = new QuickOpenSubprocessPathAccumulator(0x0a)
         let passDone = false
         let passFileCount = 0
         // --no-messages: permission-denied noise on the remote (e.g. .ssh,
@@ -104,7 +115,7 @@ export function listFilesWithRg(
             return
           }
           passDone = true
-          passBuf = ''
+          paths.clear()
           cleanup()
           passReject(error)
         }
@@ -113,6 +124,7 @@ export function listFilesWithRg(
             return
           }
           passDone = true
+          paths.clear()
           cleanup()
           passResolve()
         }
@@ -129,21 +141,30 @@ export function listFilesWithRg(
           rejectPass(new Error('rg list timed out'))
         }, LIST_FILES_TIMEOUT_MS)
 
-        function handleStdoutData(chunk: string): void {
-          passBuf += chunk
-          let start = 0
-          let idx = passBuf.indexOf('\n', start)
-          while (idx !== -1) {
-            if (processLine(passBuf.substring(start, idx))) {
-              passFileCount++
+        function failForOutput(error: unknown): void {
+          child.kill()
+          rejectPass(error instanceof Error ? error : new Error(String(error)))
+        }
+        function handleStdoutData(chunk: Buffer | string): void {
+          try {
+            const outcome = paths.push(chunk, (path) => {
+              if (processLine(path)) {
+                passFileCount++
+              }
+              return files.size < resultLimit
+            })
+            if (outcome === 'stopped') {
+              finishAtLimit()
+            } else if (outcome === 'path-too-large') {
+              failForOutput(
+                new Error(
+                  `Quick Open file path exceeded ${QUICK_OPEN_LISTING_MAX_PATH_BYTES} bytes`
+                )
+              )
             }
-            if (done) {
-              return
-            }
-            start = idx + 1
-            idx = passBuf.indexOf('\n', start)
+          } catch (error) {
+            failForOutput(error)
           }
-          passBuf = start < passBuf.length ? passBuf.substring(start) : ''
         }
         function handleStderrData(): void {
           /* drain to prevent backpressure stalls */
@@ -163,10 +184,18 @@ export function listFilesWithRg(
             return
           }
           // Flush residual line only on clean exit.
-          if (passBuf) {
-            if (processLine(passBuf)) {
+          try {
+            const trailingPath = paths.finish()
+            if (trailingPath && processLine(trailingPath)) {
               passFileCount++
             }
+            if (files.size >= resultLimit) {
+              finishAtLimit()
+              return
+            }
+          } catch (error) {
+            failForOutput(error)
+            return
           }
           // exit 0 = matches found, 1 = no files (still success for --files).
           // exit 2 is documented as "a subdirectory could not be searched"
@@ -182,7 +211,6 @@ export function listFilesWithRg(
           }
         }
 
-        child.stdout!.setEncoding('utf-8')
         child.stdout!.on('data', handleStdoutData)
         child.stderr!.on('data', handleStderrData)
         child.once('error', handleError)
@@ -212,7 +240,7 @@ export function listFilesWithRg(
       done = true
       signal?.removeEventListener('abort', onAbort)
       killSurvivors('rg list reached bounded result limit')
-      resolve(Array.from(files).slice(0, maxResults))
+      resolve(Array.from(files).slice(0, resultLimit))
     }
 
     // Why: a cancelled scan (workspace switch, superseded request) must stop
@@ -228,14 +256,11 @@ export function listFilesWithRg(
     }
     signal?.addEventListener('abort', onAbort, { once: true })
 
-    const passes =
-      maxResults === undefined
-        ? Promise.all([runPass(primary), runPass(ignoredPass)])
-        : // Why: deterministic primary-first budgeting prevents a large ignored
-          // tree from starving ordinary source paths on a remote host.
-          runPass(primary).then(() =>
-            files.size < maxResults ? runPass(ignoredPass) : Promise.resolve()
-          )
+    // Why: deterministic primary-first budgeting prevents a large ignored
+    // tree from starving ordinary source paths on a remote host.
+    const passes = runPass(primary).then(() =>
+      files.size < resultLimit ? runPass(ignoredPass) : Promise.resolve()
+    )
 
     passes
       .then(() => {
@@ -244,7 +269,7 @@ export function listFilesWithRg(
         }
         done = true
         signal?.removeEventListener('abort', onAbort)
-        resolve(Array.from(files))
+        resolve(Array.from(files).slice(0, resultLimit))
       })
       .catch((err) => {
         if (done) {

--- a/src/relay/fs-handler-stream.test.ts
+++ b/src/relay/fs-handler-stream.test.ts
@@ -5,19 +5,25 @@ import type { RelayDispatcher } from './dispatcher'
 import { STREAM_CHUNK_SIZE } from './protocol'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 
 vi.mock('@parcel/watcher', () => ({ subscribe: vi.fn() }))
 
-type Notification = { method: string; params?: Record<string, unknown> }
+type Notification = { method: string; params?: Record<string, unknown>; clientId?: number }
 
 function createMockDispatcher() {
   const requestHandlers = new Map<
     string,
-    (params: Record<string, unknown>, context?: { isStale: () => boolean }) => Promise<unknown>
+    (
+      params: Record<string, unknown>,
+      context?: { clientId: number; isStale: () => boolean }
+    ) => Promise<unknown>
   >()
-  const notificationHandlers = new Map<string, (params: Record<string, unknown>) => void>()
+  const notificationHandlers = new Map<
+    string,
+    (params: Record<string, unknown>, context: { clientId: number; isStale: () => boolean }) => void
+  >()
   const notifications: Notification[] = []
   return {
     onRequest: vi.fn(
@@ -28,33 +34,55 @@ function createMockDispatcher() {
         requestHandlers.set(method, handler as never)
       }
     ),
-    onNotification: vi.fn((method: string, handler: (params: Record<string, unknown>) => void) => {
-      notificationHandlers.set(method, handler)
-    }),
+    onNotification: vi.fn(
+      (
+        method: string,
+        handler: (
+          params: Record<string, unknown>,
+          context: { clientId: number; isStale: () => boolean }
+        ) => void
+      ) => {
+        notificationHandlers.set(method, handler)
+      }
+    ),
     notify: vi.fn((method: string, params?: Record<string, unknown>) => {
       notifications.push({ method, params })
     }),
-    notifyBulk: vi.fn(async (method: string, params?: Record<string, unknown>): Promise<void> => {
-      notifications.push({ method, params })
-    }),
+    notifyClient: vi.fn(
+      (clientId: number, method: string, params?: Record<string, unknown>): void => {
+        notifications.push({ method, params, clientId })
+      }
+    ),
+    notifyBulk: vi.fn(
+      async (
+        method: string,
+        params?: Record<string, unknown>,
+        options?: { clientId?: number }
+      ): Promise<void> => {
+        notifications.push({ method, params, clientId: options?.clientId })
+      }
+    ),
     _notifications: notifications,
     callRequest(
       method: string,
       params: Record<string, unknown> = {},
-      context?: { isStale: () => boolean }
+      context?: { clientId?: number; isStale: () => boolean }
     ) {
       const handler = requestHandlers.get(method)
       if (!handler) {
         throw new Error(`No handler for ${method}`)
       }
-      return handler(params, context)
+      return handler(
+        params,
+        context ? { clientId: context.clientId ?? 1, isStale: context.isStale } : undefined
+      )
     },
-    callNotification(method: string, params: Record<string, unknown> = {}) {
+    callNotification(method: string, params: Record<string, unknown> = {}, clientId = 1) {
       const handler = notificationHandlers.get(method)
       if (!handler) {
         throw new Error(`No handler for ${method}`)
       }
-      handler(params)
+      handler(params, { clientId, isStale: () => false })
     }
   }
 }
@@ -100,6 +128,16 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void
   }
 }
 
+function pngContent(size: number, width = 1, height = 1): Buffer {
+  const content = Buffer.alloc(size, 0x42)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(content)
+  content.writeUInt32BE(13, 8)
+  content.write('IHDR', 12, 'ascii')
+  content.writeUInt32BE(width, 16)
+  content.writeUInt32BE(height, 20)
+  return content
+}
+
 describe('FsHandler readFileStream', () => {
   let dispatcher: ReturnType<typeof createMockDispatcher>
   let handler: FsHandler
@@ -116,19 +154,39 @@ describe('FsHandler readFileStream', () => {
     await fs.rm(tmpDir, { recursive: true, force: true })
   })
 
+  it('rejects a terminal-artifact raster dimension bomb', async () => {
+    const filePath = path.join(tmpDir, 'artifact-bomb.png')
+    writeFileSync(filePath, pngContent(24, 32_769, 1))
+
+    await expect(
+      dispatcher.callRequest('fs.readTerminalArtifact', {
+        filePath,
+        expectedRealPath: await fs.realpath(filePath),
+        maxBytes: 512 * 1024
+      })
+    ).rejects.toThrow('Image dimensions exceed the preview safety limit')
+  })
+
   it('streams a binary file in chunked notifications', async () => {
     const filePath = path.join(tmpDir, 'image.png')
-    const content = Buffer.alloc(300 * 1024, 0x42)
+    const content = pngContent(300 * 1024)
+    const ownerClientId = 7
     writeFileSync(filePath, content)
 
     const meta = (await dispatcher.callRequest(
       'fs.readFileStream',
       { filePath },
-      { isStale: () => false }
-    )) as { streamId: number; totalSize: number; resultEncoding: string }
+      { clientId: ownerClientId, isStale: () => false }
+    )) as {
+      streamId: number
+      totalSize: number
+      resultEncoding: string
+      imageDimensions: { width: number; height: number }
+    }
     expect(meta.streamId).toBeDefined()
     expect(meta.totalSize).toBe(content.length)
     expect(meta.resultEncoding).toBe('base64')
+    expect(meta.imageDimensions).toEqual({ width: 1, height: 1 })
 
     await waitFor(() => collectStream(dispatcher).end !== null)
     const { chunks, end, err } = collectStream(dispatcher)
@@ -136,11 +194,48 @@ describe('FsHandler readFileStream', () => {
     expect(end).toEqual({ streamId: meta.streamId })
     const reassembled = Buffer.concat(chunks.map((c) => Buffer.from(c.data, 'base64')))
     expect(reassembled.equals(content)).toBe(true)
+    expect(
+      dispatcher._notifications.filter((notification) => notification.method === 'fs.streamEnd')
+    ).toEqual([
+      {
+        method: 'fs.streamEnd',
+        params: { streamId: meta.streamId },
+        clientId: ownerClientId
+      }
+    ])
+  })
+
+  it('sends a stream error only to the requesting relay client', async () => {
+    const filePath = path.join(tmpDir, 'truncated.png')
+    const ownerClientId = 9
+    writeFileSync(filePath, pngContent(STREAM_CHUNK_SIZE))
+
+    const meta = (await dispatcher.callRequest(
+      'fs.readFileStream',
+      { filePath },
+      { clientId: ownerClientId, isStale: () => false }
+    )) as { streamId: number }
+    truncateSync(filePath, 0)
+
+    await waitFor(() => collectStream(dispatcher).err !== null)
+    expect(
+      dispatcher._notifications.filter((notification) => notification.method === 'fs.streamError')
+    ).toEqual([
+      {
+        method: 'fs.streamError',
+        params: {
+          streamId: meta.streamId,
+          code: 'ESTREAMTRUNCATED',
+          message: `File truncated mid-stream: expected ${STREAM_CHUNK_SIZE}, got 0`
+        },
+        clientId: ownerClientId
+      }
+    ])
   })
 
   it('fills protocol chunks when fs.read returns short before EOF', async () => {
     const filePath = path.join(tmpDir, 'short-read.png')
-    const content = Buffer.alloc(STREAM_CHUNK_SIZE + 17, 0x42)
+    const content = pngContent(STREAM_CHUNK_SIZE + 17)
     writeFileSync(filePath, content)
 
     const sampleHandle = await fs.open(filePath, 'r')
@@ -242,7 +337,7 @@ describe('FsHandler readFileStream', () => {
 
   it('exits the pump and emits no further chunks when isStale flips', async () => {
     const filePath = path.join(tmpDir, 'big.png')
-    const content = Buffer.alloc(800 * 1024, 0x42)
+    const content = pngContent(800 * 1024)
     writeFileSync(filePath, content)
 
     let stale = false
@@ -264,7 +359,7 @@ describe('FsHandler readFileStream', () => {
 
   it('honors fs.cancelStream by stopping the pump and emitting no end frame', async () => {
     const filePath = path.join(tmpDir, 'cancel.png')
-    writeFileSync(filePath, Buffer.alloc(2 * 1024 * 1024, 0x42))
+    writeFileSync(filePath, pngContent(2 * 1024 * 1024))
 
     const meta = (await dispatcher.callRequest(
       'fs.readFileStream',
@@ -283,7 +378,7 @@ describe('FsHandler readFileStream', () => {
 
   it('parks the pump at the ack credit window and resumes on fs.streamAck', async () => {
     const filePath = path.join(tmpDir, 'paced.png')
-    const content = Buffer.alloc(1536 * 1024, 0x42) // 6 chunks
+    const content = pngContent(1536 * 1024) // 6 chunks
     writeFileSync(filePath, content)
 
     const meta = (await dispatcher.callRequest(
@@ -297,6 +392,11 @@ describe('FsHandler readFileStream', () => {
     await flush(10)
     expect(collectStream(dispatcher).chunks.length).toBe(4)
     expect(collectStream(dispatcher).end).toBeNull()
+
+    // A future ACK must not mint credit for chunks the relay has not sent.
+    dispatcher.callNotification('fs.streamAck', { streamId: meta.streamId, seq: 10_000 })
+    await flush(10)
+    expect(collectStream(dispatcher).chunks.length).toBe(4)
 
     // Ack one chunk → exactly one more is admitted.
     dispatcher.callNotification('fs.streamAck', { streamId: meta.streamId, seq: 0 })
@@ -315,9 +415,38 @@ describe('FsHandler readFileStream', () => {
     expect(reassembled.equals(content)).toBe(true)
   })
 
+  it('ignores stream credit and cancellation from a different relay client', async () => {
+    const filePath = path.join(tmpDir, 'owned-paced.png')
+    writeFileSync(filePath, pngContent(4 * 1024 * 1024))
+    const ownerClientId = 7
+    const meta = (await dispatcher.callRequest(
+      'fs.readFileStream',
+      { filePath, flowControl: 'ack' },
+      { clientId: ownerClientId, isStale: () => false }
+    )) as { streamId: number }
+
+    await waitFor(() => collectStream(dispatcher).chunks.length === 4)
+    dispatcher.callNotification('fs.streamAck', { streamId: meta.streamId, seq: 10_000 }, 8)
+    dispatcher.callNotification('fs.cancelStream', { streamId: meta.streamId }, 8)
+    await flush(10)
+    expect(collectStream(dispatcher).chunks).toHaveLength(4)
+
+    dispatcher.callNotification('fs.streamAck', { streamId: meta.streamId, seq: 0 }, ownerClientId)
+    await waitFor(() => collectStream(dispatcher).chunks.length === 5)
+    dispatcher.callNotification('fs.cancelStream', { streamId: meta.streamId }, ownerClientId)
+
+    const registry = (handler as unknown as { streamRegistry: { size(): number } }).streamRegistry
+    await waitFor(() => registry.size() === 0)
+    expect(
+      dispatcher._notifications
+        .filter((notification) => notification.method.startsWith('fs.stream'))
+        .every((notification) => notification.clientId === ownerClientId)
+    ).toBe(true)
+  })
+
   it('releases a pump parked on the ack window when the stream is cancelled', async () => {
     const filePath = path.join(tmpDir, 'parked-cancel.png')
-    writeFileSync(filePath, Buffer.alloc(4 * 1024 * 1024, 0x42)) // 16 chunks
+    writeFileSync(filePath, pngContent(4 * 1024 * 1024)) // 16 chunks
 
     const meta = (await dispatcher.callRequest(
       'fs.readFileStream',
@@ -340,7 +469,7 @@ describe('FsHandler readFileStream', () => {
     const paths: string[] = []
     for (let i = 0; i < 17; i++) {
       const p = path.join(tmpDir, `s${i}.png`)
-      writeFileSync(p, Buffer.alloc(8 * 1024 * 1024, 0x42))
+      writeFileSync(p, pngContent(8 * 1024 * 1024))
       paths.push(p)
     }
 
@@ -370,4 +499,15 @@ describe('FsHandler readFileStream', () => {
     }
     await flush(50)
   }, 20_000)
+
+  it('rejects an oversized raster before registering or pumping a stream', async () => {
+    const filePath = path.join(tmpDir, 'bomb.png')
+    writeFileSync(filePath, pngContent(24, 32_769, 1))
+
+    await expect(
+      dispatcher.callRequest('fs.readFileStream', { filePath }, { isStale: () => false })
+    ).rejects.toThrow('Image dimensions exceed the preview safety limit')
+    await flush()
+    expect(collectStream(dispatcher).chunks).toHaveLength(0)
+  })
 })

--- a/src/relay/fs-handler-terminal-artifact.ts
+++ b/src/relay/fs-handler-terminal-artifact.ts
@@ -10,6 +10,7 @@ import {
   MAX_PREVIEWABLE_BINARY_SIZE,
   MAX_TEXT_FILE_SIZE
 } from './fs-handler-utils'
+import { assertRasterImagePreviewWithinLimits } from '../shared/raster-image-preview-limits'
 
 type TerminalArtifactStat = {
   size: number
@@ -43,7 +44,14 @@ export async function readVerifiedTerminalArtifact(params: Record<string, unknow
     )
     const buffer = await readBoundedFileFromHandle(handle, sizeLimit)
     if (mimeType) {
-      return { content: buffer.toString('base64'), isBinary: true, isImage: true, mimeType }
+      const imageDimensions = assertRasterImagePreviewWithinLimits(buffer, mimeType)
+      return {
+        content: buffer.toString('base64'),
+        isBinary: true,
+        isImage: true,
+        mimeType,
+        ...(imageDimensions ? { imageDimensions } : {})
+      }
     }
     if (isBinaryBuffer(buffer)) {
       return { content: '', isBinary: true }

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -16,6 +16,7 @@ import {
 } from '../shared/text-search'
 import { IMAGE_FILE_MIME_TYPES } from '../shared/image-file-extensions'
 import type { SearchResult as SharedSearchResult } from '../shared/types'
+import { SearchSubprocessLineAccumulator } from '../shared/search-subprocess-lines'
 
 // ─── Constants ───────────────────────────────────────────────────────
 
@@ -92,7 +93,7 @@ export function searchWithRg(
   return new Promise((resolve) => {
     const rgArgs = buildRgArgs(query, rootPath, opts)
     const acc = createAccumulator()
-    let buffer = ''
+    const stdoutLines = new SearchSubprocessLineAccumulator()
     let resolved = false
 
     // Why: spawn can throw synchronously on invalid options (e.g. bad cwd),
@@ -134,12 +135,11 @@ export function searchWithRg(
       }
     }
 
-    function handleStdoutData(chunk: string): void {
-      buffer += chunk
-      const lines = buffer.split('\n')
-      buffer = lines.pop() ?? ''
-      for (const line of lines) {
-        processLine(line)
+    function handleStdoutData(chunk: Buffer): void {
+      if (!stdoutLines.push(chunk, processLine)) {
+        acc.truncated = true
+        child.kill()
+        resolveOnce()
       }
     }
 
@@ -152,13 +152,13 @@ export function searchWithRg(
     }
 
     function handleClose(): void {
-      if (buffer) {
-        processLine(buffer)
+      const trailingLine = stdoutLines.finish()
+      if (trailingLine !== null) {
+        processLine(trailingLine)
       }
       resolveOnce()
     }
 
-    child.stdout!.setEncoding('utf-8')
     child.stdout!.on('data', handleStdoutData)
     child.stderr!.on('data', handleStderrData)
     child.once('error', handleError)

--- a/src/relay/fs-handler.test.ts
+++ b/src/relay/fs-handler.test.ts
@@ -17,6 +17,8 @@ vi.mock('@parcel/watcher', () => ({
   subscribe: mockSubscribe
 }))
 
+const PNG_1X1 = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB', 'base64')
+
 function createMockDispatcher() {
   const requestHandlers = new Map<
     string,
@@ -138,6 +140,7 @@ describe('FsHandler', () => {
   it('registers all expected handlers', () => {
     const methods = Array.from(dispatcher._requestHandlers.keys())
     expect(methods).toContain('fs.readDir')
+    expect(methods).toContain('fs.readDirBounded')
     expect(methods).toContain('fs.readFile')
     expect(methods).toContain('fs.tempDir')
     expect(methods).toContain('fs.writeFile')
@@ -152,6 +155,7 @@ describe('FsHandler', () => {
     expect(methods).toContain('fs.realpath')
     expect(methods).toContain('fs.search')
     expect(methods).toContain('fs.listFiles')
+    expect(methods).toContain('fs.listMarkdownDocuments')
     expect(methods).toContain('fs.workspaceSpaceScan')
     expect(methods).toContain('fs.watch')
     expect(methods).toContain('fs.unwatchAndWait')
@@ -164,12 +168,12 @@ describe('FsHandler', () => {
     await expect(dispatcher.callRequest('fs.tempDir')).resolves.toBe(tmpdir())
   })
 
-  it('readDir returns sorted entries with directories first', async () => {
+  it('bounded readDir returns sorted entries with directories first', async () => {
     mkdirSync(path.join(tmpDir, 'subdir'))
     writeFileSync(path.join(tmpDir, 'file.txt'), 'hello')
     writeFileSync(path.join(tmpDir, 'aaa.txt'), 'world')
 
-    const result = (await dispatcher.callRequest('fs.readDir', { dirPath: tmpDir })) as {
+    const result = (await dispatcher.callRequest('fs.readDirBounded', { dirPath: tmpDir })) as {
       name: string
       isDirectory: boolean
     }[]
@@ -239,17 +243,19 @@ describe('FsHandler', () => {
 
   it('readFile returns base64 for image files', async () => {
     const filePath = path.join(tmpDir, 'test.png')
-    writeFileSync(filePath, Buffer.from([0x89, 0x50, 0x4e, 0x47]))
+    writeFileSync(filePath, PNG_1X1)
 
     const result = (await dispatcher.callRequest('fs.readFile', { filePath })) as {
       content: string
       isBinary: boolean
       isImage: boolean
       mimeType: string
+      imageDimensions: { width: number; height: number }
     }
     expect(result.isBinary).toBe(true)
     expect(result.isImage).toBe(true)
     expect(result.mimeType).toBe('image/png')
+    expect(result.imageDimensions).toEqual({ width: 1, height: 1 })
     expect(result.content).toBeTruthy()
   })
 

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -1,9 +1,8 @@
 /* eslint-disable max-lines -- Why: relay filesystem request handling shares
    path expansion, file IO, search, streaming reads, and Space scans. */
-import { readdir, writeFile, stat, lstat, mkdir, rename, cp, rm, realpath } from 'node:fs/promises'
+import { writeFile, stat, lstat, mkdir, rename, cp, rm, realpath } from 'node:fs/promises'
 import { execFile } from 'node:child_process'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import type { RelayContext } from './context'
 // Why: RelayContext is accepted in the constructor for protocol back-compat
@@ -36,24 +35,27 @@ import { buildRelayCommandEnv } from './relay-command-env'
 import { assertNoClobberRenameDestinationAvailable } from '../shared/filesystem-rename-collision'
 import { RelayFilesystemWatchRegistry } from './relay-filesystem-watch-registry'
 import type { RelayWatcherProcessPool } from './relay-watcher-process-pool'
+import {
+  MOBILE_FILE_DIRECTORY_MAX_ENTRIES,
+  MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES
+} from '../shared/mobile-file-directory-limit'
+import { readMobileRelayDirectory } from './mobile-file-directory-reader'
+import { readRelayFilesystemDirectory } from './filesystem-directory-reader'
+import type { FilesystemDirectoryListingLimits } from '../shared/filesystem-directory-listing-limit'
+import { listRelayMarkdownDocumentPaths } from './markdown-document-listing'
+import { resolveQuickOpenResultLimit } from '../shared/quick-open-listing-limits'
 
-async function isDirectoryEntry(
-  dirPath: string,
-  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }
-): Promise<boolean> {
-  if (entry.isDirectory()) {
-    return true
+function readDirectoryLimitsFromParams(
+  params: Record<string, unknown>
+): Partial<FilesystemDirectoryListingLimits> {
+  const limits: Partial<FilesystemDirectoryListingLimits> = {}
+  if (typeof params.maxEntries === 'number') {
+    limits.maxEntries = params.maxEntries
   }
-  if (!entry.isSymbolicLink()) {
-    return false
+  if (typeof params.maxRetainedBytes === 'number') {
+    limits.maxRetainedBytes = params.maxRetainedBytes
   }
-  try {
-    // Why: the file explorer needs target type for symlinked directories so a
-    // workspace link to an external folder expands instead of opening as a file.
-    return (await stat(join(dirPath, entry.name))).isDirectory()
-  } catch {
-    return false
-  }
+  return limits
 }
 
 function fileStatFromLstat(stats: Awaited<ReturnType<typeof lstat>>) {
@@ -102,6 +104,7 @@ export class FsHandler {
 
   private registerHandlers(): void {
     this.dispatcher.onRequest('fs.readDir', (p) => this.readDir(p))
+    this.dispatcher.onRequest('fs.readDirBounded', (p) => this.readDir(p))
     this.dispatcher.onRequest('fs.readFile', (p) => this.readFile(p))
     this.dispatcher.onRequest('fs.readFileStream', (p, c) => this.readFileStream(p, c))
     this.dispatcher.onRequest('fs.readTerminalArtifact', (p) => this.readTerminalArtifact(p))
@@ -120,6 +123,9 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.realpath', (p) => this.realpath(p))
     this.dispatcher.onRequest('fs.search', (p) => this.search(p))
     this.dispatcher.onRequest('fs.listFiles', (p, c) => this.listFiles(p, c))
+    this.dispatcher.onRequest('fs.listMarkdownDocuments', (p, c) =>
+      listRelayMarkdownDocumentPaths(expandTilde(p.rootPath as string), c.signal)
+    )
     this.dispatcher.onRequest('fs.workspaceSpaceScan', (p, c) => this.workspaceSpaceScan(p, c))
     this.dispatcher.onRequest('fs.watch', (p, context) =>
       this.watchRegistry.watch(
@@ -134,21 +140,25 @@ export class FsHandler {
     this.dispatcher.onNotification('fs.unwatch', (p, context) =>
       this.watchRegistry.unwatch(expandTilde(p.rootPath as string), context)
     )
-    this.dispatcher.onNotification('fs.cancelStream', (p) => this.cancelStream(p))
-    this.dispatcher.onNotification('fs.streamAck', (p) => this.streamAck(p))
+    this.dispatcher.onNotification('fs.cancelStream', (p, context) => this.cancelStream(p, context))
+    this.dispatcher.onNotification('fs.streamAck', (p, context) => this.streamAck(p, context))
   }
 
   private async readDir(params: Record<string, unknown>) {
     const dirPath = expandTilde(params.dirPath as string)
-    const entries = await readdir(dirPath, { withFileTypes: true })
-    const mapped = await Promise.all(
-      entries.map(async (entry) => ({
-        name: entry.name,
-        isDirectory: await isDirectoryEntry(dirPath, entry),
-        isSymlink: entry.isSymbolicLink()
-      }))
-    )
-    return mapped.sort((a, b) => {
+    if (
+      params.maxEntries === MOBILE_FILE_DIRECTORY_MAX_ENTRIES &&
+      params.maxRetainedBytes === MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES
+    ) {
+      return this.sortDirectoryEntries(await readMobileRelayDirectory(dirPath))
+    }
+    return readRelayFilesystemDirectory(dirPath, readDirectoryLimitsFromParams(params))
+  }
+
+  private sortDirectoryEntries<T extends { name: string; isDirectory: boolean }>(
+    entries: T[]
+  ): T[] {
+    return entries.sort((a, b) => {
       if (a.isDirectory !== b.isDirectory) {
         return a.isDirectory ? -1 : 1
       }
@@ -184,18 +194,18 @@ export class FsHandler {
     return tmpdir()
   }
 
-  private cancelStream(params: Record<string, unknown>): void {
+  private cancelStream(params: Record<string, unknown>, context: RequestContext): void {
     const streamId = params.streamId as number | undefined
     if (typeof streamId === 'number') {
-      this.streamRegistry.abort(streamId)
+      this.streamRegistry.abort(streamId, context.clientId)
     }
   }
 
-  private streamAck(params: Record<string, unknown>): void {
+  private streamAck(params: Record<string, unknown>, context: RequestContext): void {
     const streamId = params.streamId as number | undefined
     const seq = params.seq as number | undefined
     if (typeof streamId === 'number' && typeof seq === 'number') {
-      this.streamRegistry.recordAck(streamId, seq)
+      this.streamRegistry.recordAck(streamId, seq, context.clientId)
     }
   }
 
@@ -356,12 +366,13 @@ export class FsHandler {
 
   private listFiles(params: Record<string, unknown>, context?: RequestContext): Promise<string[]> {
     const rootPath = expandTilde(params.rootPath as string)
-    const maxResults =
+    const requestedMaxResults =
       typeof params.maxResults === 'number' &&
       Number.isInteger(params.maxResults) &&
       params.maxResults > 0
-        ? Math.min(params.maxResults, 20_001)
+        ? params.maxResults
         : undefined
+    const maxResults = resolveQuickOpenResultLimit(requestedMaxResults)
     // Why: the main-to-relay RPC adds excludePaths so nested linked worktrees
     // don't get double-scanned. The shared helper validates the shape and
     // normalizes into root-relative prefixes; malformed input yields [] so
@@ -382,7 +393,7 @@ export class FsHandler {
     rootPath: string,
     excludePathPrefixes: string[],
     signal: AbortSignal,
-    maxResults?: number
+    maxResults: number
   ): Promise<string[]> {
     const rgAvailable = await checkRgAvailable()
     throwIfFileListingCancelled(signal)

--- a/src/relay/fs-list-files-cancel.integration.test.ts
+++ b/src/relay/fs-list-files-cancel.integration.test.ts
@@ -27,7 +27,7 @@ const { fakeListFiles } = vi.hoisted(() => {
       (
         rootPath: string,
         _excludes: readonly string[] = [],
-        options: { signal?: AbortSignal } = {}
+        options: { signal?: AbortSignal; maxResults?: number } = {}
       ) =>
         new Promise<string[]>((resolve, reject) => {
           scans.push({ rootPath, signal: options.signal, resolve })
@@ -67,6 +67,7 @@ import { RelayDispatcher } from './dispatcher'
 import { RelayContext } from './context'
 import { FsHandler } from './fs-handler'
 import { LIST_FILES_SUPERSEDED_MESSAGE } from './fs-list-files-scan-coordinator'
+import { QUICK_OPEN_LISTING_MAX_RESULTS } from '../shared/quick-open-listing-limits'
 
 async function flushPipe(): Promise<void> {
   // The in-memory pipe defers each hop with setImmediate; a few macrotask
@@ -123,6 +124,7 @@ describe('Integration: cancellable fs.listFiles (#7721)', () => {
     const scanPromise = mux.request('fs.listFiles', { rootPath: '/big/workspace' })
     await flushPipe()
     expect(fakeListFiles.scans).toHaveLength(1)
+    expect(fakeListFiles.mock.calls[0][2]?.maxResults).toBe(QUICK_OPEN_LISTING_MAX_RESULTS)
 
     // The interactive request must complete while the scan is still pending.
     const entries = (await mux.request('fs.readDir', { dirPath: tmpDir })) as { name: string }[]

--- a/src/relay/fs-stream-pty-echo-backpressure.integration.test.ts
+++ b/src/relay/fs-stream-pty-echo-backpressure.integration.test.ts
@@ -37,6 +37,16 @@ const FRAMED_CHUNK_BYTES = Math.ceil((STREAM_CHUNK_SIZE * 4) / 3) + 512
 // Node pipe/socket sinks report saturation via write() === false past the HWM.
 const SINK_HIGH_WATER_MARK = 64 * 1024
 
+function randomPngBytes(size: number): Buffer {
+  const content = randomBytes(size)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(content)
+  content.writeUInt32BE(13, 8)
+  content.write('IHDR', 12, 'ascii')
+  content.writeUInt32BE(1, 16)
+  content.writeUInt32BE(1, 20)
+  return content
+}
+
 async function waitUntil(
   predicate: () => boolean,
   what: string,
@@ -182,7 +192,7 @@ describe('fs.readFileStream vs pty.data echo head-of-line blocking', () => {
     const harness = createHarness({ congested: true })
     try {
       const filePath = path.join(tmpDir, 'big.png')
-      const original = randomBytes(3 * 1024 * 1024) // 12 chunks
+      const original = randomPngBytes(3 * 1024 * 1024) // 12 chunks
       writeFileSync(filePath, original)
 
       // Relay-side fake PTY: echoes input back immediately, mirroring
@@ -222,11 +232,17 @@ describe('fs.readFileStream vs pty.data echo head-of-line blocking', () => {
     const harness = createHarness({ congested: false })
     try {
       const filePath = path.join(tmpDir, 'big.png')
-      writeFileSync(filePath, randomBytes(3 * 1024 * 1024)) // 12 chunks
+      writeFileSync(filePath, randomPngBytes(3 * 1024 * 1024)) // 12 chunks
 
       const receivedSeqs: number[] = []
+      let acknowledgeChunks = false
+      let streamId: number | null = null
       harness.mux.onNotificationByMethod('fs.streamChunk', (params) => {
-        receivedSeqs.push(params.seq as number)
+        const seq = params.seq as number
+        receivedSeqs.push(seq)
+        if (acknowledgeChunks && streamId !== null) {
+          harness.mux.notify('fs.streamAck', { streamId, seq })
+        }
       })
       let streamEnded = false
       harness.mux.onNotificationByMethod('fs.streamEnd', () => {
@@ -240,6 +256,7 @@ describe('fs.readFileStream vs pty.data echo head-of-line blocking', () => {
         filePath,
         flowControl: 'ack'
       })) as { streamId: number }
+      streamId = metadata.streamId
 
       await waitUntil(() => receivedSeqs.length > 0, 'first chunk received')
       await waitUntilSettled(() => receivedSeqs.length)
@@ -250,8 +267,9 @@ describe('fs.readFileStream vs pty.data echo head-of-line blocking', () => {
       expect(streamEnded).toBe(false)
 
       // Acking releases the window and the stream completes.
+      acknowledgeChunks = true
       const totalChunks = 12
-      for (let seq = 0; seq < totalChunks; seq += 1) {
+      for (const seq of receivedSeqs) {
         harness.mux.notify('fs.streamAck', { streamId: metadata.streamId, seq })
       }
       await waitUntil(() => streamEnded, 'stream completed after acks')
@@ -265,7 +283,7 @@ describe('fs.readFileStream vs pty.data echo head-of-line blocking', () => {
     const harness = createHarness({ congested: false })
     try {
       const filePath = path.join(tmpDir, 'legacy.png')
-      const original = randomBytes(1024 * 1024 + 12345)
+      const original = randomPngBytes(1024 * 1024 + 12345)
       writeFileSync(filePath, original)
 
       const chunks = new Map<number, Buffer>()

--- a/src/relay/fs-stream-registry.ts
+++ b/src/relay/fs-stream-registry.ts
@@ -3,7 +3,10 @@ import { MAX_CONCURRENT_STREAMS, RelayErrorCode, STREAM_ACK_STALL_RECHECK_MS } f
 
 type StreamEntry = {
   handle: FileHandle
+  ownerClientId: number
   aborted: boolean
+  /** Highest chunk seq admitted to the outbound bulk lane. */
+  sentThroughSeq: number
   /** Highest chunk seq the client acknowledged (in-order; -1 = none yet). */
   ackedThroughSeq: number
   /** Pumps parked on the ack credit window. Woken by acks, abort, release,
@@ -22,23 +25,25 @@ export class RelayStreamRegistry {
   private streams = new Map<number, StreamEntry>()
   private nextId = 1
 
-  register(handle: FileHandle): number {
+  register(handle: FileHandle, ownerClientId: number): number {
     if (this.streams.size >= MAX_CONCURRENT_STREAMS) {
       throw new TooManyStreamsError()
     }
     const streamId = this.nextId++
     this.streams.set(streamId, {
       handle,
+      ownerClientId,
       aborted: false,
+      sentThroughSeq: -1,
       ackedThroughSeq: -1,
       ackWaiters: new Set()
     })
     return streamId
   }
 
-  abort(streamId: number): void {
+  abort(streamId: number, clientId: number): void {
     const entry = this.streams.get(streamId)
-    if (entry) {
+    if (entry?.ownerClientId === clientId) {
       entry.aborted = true
       this.wakeAckWaiters(entry)
     }
@@ -52,9 +57,22 @@ export class RelayStreamRegistry {
     return this.streams.get(streamId)
   }
 
-  recordAck(streamId: number, seq: number): void {
+  recordSent(streamId: number, seq: number): void {
     const entry = this.streams.get(streamId)
-    if (!entry || typeof seq !== 'number' || !Number.isFinite(seq)) {
+    if (entry && Number.isSafeInteger(seq) && seq === entry.sentThroughSeq + 1) {
+      entry.sentThroughSeq = seq
+    }
+  }
+
+  recordAck(streamId: number, seq: number, clientId: number): void {
+    const entry = this.streams.get(streamId)
+    if (
+      !entry ||
+      entry.ownerClientId !== clientId ||
+      !Number.isSafeInteger(seq) ||
+      seq < 0 ||
+      seq > entry.sentThroughSeq
+    ) {
       return
     }
     if (seq > entry.ackedThroughSeq) {
@@ -129,7 +147,11 @@ export class RelayStreamRegistry {
     // cleanly on the next iteration boundary instead of seeing EBADF when
     // release closes the handle out from under an in-flight read.
     for (const id of this.streams.keys()) {
-      this.abort(id)
+      const entry = this.streams.get(id)
+      if (entry) {
+        entry.aborted = true
+        this.wakeAckWaiters(entry)
+      }
     }
     const ids = Array.from(this.streams.keys())
     await Promise.all(ids.map((id) => this.release(id)))

--- a/src/relay/git-handler-status-ops-bounds.test.ts
+++ b/src/relay/git-handler-status-ops-bounds.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { resolveGitDir } from './git-handler-status-ops'
+
+describe('relay resolveGitDir metadata bounds', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  async function makeWorktree(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-relay-resolve-git-dir-'))
+    roots.push(root)
+    const worktreePath = join(root, 'checkout')
+    await mkdir(worktreePath)
+    return worktreePath
+  }
+
+  it('preserves a normal linked-worktree pointer', async () => {
+    const worktreePath = await makeWorktree()
+    await writeFile(join(worktreePath, '.git'), 'gitdir: ../common/.git/worktrees/checkout\n')
+
+    await expect(resolveGitDir(worktreePath)).resolves.toBe(
+      join(worktreePath, '..', 'common', '.git', 'worktrees', 'checkout')
+    )
+  })
+
+  it('falls back to the .git path for an oversized sparse pointer', async () => {
+    const worktreePath = await makeWorktree()
+    const dotGitPath = join(worktreePath, '.git')
+    await writeFile(dotGitPath, 'x')
+    await truncate(dotGitPath, 64 * 1024 + 1)
+
+    await expect(resolveGitDir(worktreePath)).resolves.toBe(dotGitPath)
+  })
+})

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -4,7 +4,6 @@
  */
 import * as path from 'node:path'
 import { existsSync } from 'node:fs'
-import { readFile } from 'node:fs/promises'
 import { parseUnmergedEntry } from './git-handler-utils'
 import type { GitExec } from './git-handler-ops'
 import type { RelayGitStreamExec } from './git-stdout-stream'
@@ -24,11 +23,16 @@ import {
   clearGitStatusLineStatsCacheKey,
   reuseOrRecomputeGitStatusLineStats
 } from '../shared/git-status-line-stats-cache'
+import { readNodeFileWithinLimit } from '../shared/node-bounded-file-reader'
+
+const MAX_GIT_POINTER_FILE_BYTES = 64 * 1024
 
 export async function resolveGitDir(worktreePath: string): Promise<string> {
   const dotGitPath = path.join(worktreePath, '.git')
   try {
-    const contents = await readFile(dotGitPath, 'utf-8')
+    const contents = (
+      await readNodeFileWithinLimit(dotGitPath, MAX_GIT_POINTER_FILE_BYTES)
+    ).buffer.toString('utf-8')
     const match = contents.match(/^gitdir:\s*(.+)\s*$/m)
     if (match) {
       return path.resolve(worktreePath, match[1])

--- a/src/relay/git-handler-stream-serialization-memory.test.ts
+++ b/src/relay/git-handler-stream-serialization-memory.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RelayContext } from './context'
+import { RelayDispatcher, type RequestContext } from './dispatcher'
+import { GitHandler } from './git-handler'
+import { GIT_RESPONSE_STREAM_THRESHOLD, type GitResponseStreamMarker } from './protocol'
+
+type StreamableGitHandler = {
+  maybeStreamResponse(
+    result: unknown,
+    params: Record<string, unknown>,
+    context: RequestContext
+  ): GitResponseStreamMarker
+}
+
+describe('GitHandler streamed response serialization', () => {
+  it('registers a large serialized string without allocating a full payload Buffer', () => {
+    const dispatcher = new RelayDispatcher(() => true)
+    const handler = new GitHandler(dispatcher, new RelayContext())
+    const streamable = handler as unknown as StreamableGitHandler
+    const result = { text: 'x'.repeat(GIT_RESPONSE_STREAM_THRESHOLD + 1) }
+    const fromSpy = vi.spyOn(Buffer, 'from')
+
+    try {
+      const marker = streamable.maybeStreamResponse(
+        result,
+        { __streamResponse: true },
+        { clientId: 1, isStale: () => false }
+      )
+
+      expect(marker.__orcaGitResponseStream.totalBytes).toBe(
+        Buffer.byteLength(JSON.stringify(result), 'utf8')
+      )
+      expect(fromSpy).not.toHaveBeenCalled()
+    } finally {
+      handler.dispose()
+      dispatcher.dispose()
+      fromSpy.mockRestore()
+    }
+  })
+})

--- a/src/relay/git-handler-submodule-ops.test.ts
+++ b/src/relay/git-handler-submodule-ops.test.ts
@@ -2,11 +2,19 @@ import { describe, expect, it } from 'vitest'
 import * as path from 'node:path'
 import type { GitExec } from './git-handler-ops'
 import {
+  MAX_SUBMODULE_PATH_CODE_UNITS,
+  MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS,
   MAX_SUBMODULE_PATHS_CACHE_ENTRIES,
+  MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES,
+  MAX_SUBMODULE_PATHS_OUTPUT_BYTES,
+  MAX_SUBMODULE_PATHS_PER_REPO,
+  MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS,
   SUBMODULE_PATHS_CACHE_TTL_MS,
   clearSubmodulePathsCache,
   createSubmodulePathsCache,
+  getSubmodulePathsCacheCodeUnits,
   getSubmodulePathsCacheCount,
+  listSubmodulePaths,
   listSubmodulePathsCached,
   resolveSubmoduleWorktreePath
 } from './git-handler-submodule-ops'
@@ -26,6 +34,19 @@ function gitmodulesExec(paths: string[]): { git: GitExec; calls: () => number } 
   return { git, calls: () => calls }
 }
 
+function pathsUsingCodeUnits(codeUnits: number): string[] {
+  const fullPath = 'x'.repeat(MAX_SUBMODULE_PATH_CODE_UNITS)
+  const paths = Array.from(
+    { length: Math.floor(codeUnits / MAX_SUBMODULE_PATH_CODE_UNITS) },
+    () => fullPath
+  )
+  const remainder = codeUnits % MAX_SUBMODULE_PATH_CODE_UNITS
+  if (remainder > 0) {
+    paths.push('x'.repeat(remainder))
+  }
+  return paths
+}
+
 describe('listSubmodulePathsCached', () => {
   it('reads .gitmodules once for repeated diffs on the same worktree within TTL', async () => {
     const { git, calls } = gitmodulesExec(['vendor/lib'])
@@ -37,6 +58,19 @@ describe('listSubmodulePathsCached', () => {
     expect(first).toEqual(['vendor/lib'])
     expect(second).toEqual(['vendor/lib'])
     expect(calls()).toBe(1)
+  })
+
+  it('keeps the existing 10 MiB command-output ceiling explicit', async () => {
+    let receivedOptions: Parameters<GitExec>[2]
+    const git: GitExec = async (_args, _cwd, options) => {
+      receivedOptions = options
+      return { stdout: 'submodule.lib.path vendor/lib\n', stderr: '' }
+    }
+
+    await listSubmodulePaths(git, '/repo')
+
+    expect(receivedOptions).toEqual({ maxBuffer: MAX_SUBMODULE_PATHS_OUTPUT_BYTES })
+    expect(MAX_SUBMODULE_PATHS_OUTPUT_BYTES).toBe(10 * 1024 * 1024)
   })
 
   it('re-reads after the TTL expires', async () => {
@@ -69,6 +103,7 @@ describe('listSubmodulePathsCached', () => {
 
     await listSubmodulePathsCached(git, '/repo-c', cache, SUBMODULE_PATHS_CACHE_TTL_MS + 1)
     expect(getSubmodulePathsCacheCount(cache)).toBe(1)
+    expect(getSubmodulePathsCacheCodeUnits(cache)).toBe('/repo-c'.length + 'vendor/lib'.length)
   })
 
   it('caches an empty result so a submodule-free repo is not re-read', async () => {
@@ -121,6 +156,69 @@ describe('listSubmodulePathsCached', () => {
     expect(calls()).toBe(callsBeforeReads + 1)
   })
 
+  it('does not retain worktree keys above the UTF-8 byte ceiling', async () => {
+    const exact = gitmodulesExec(['vendor/lib'])
+    const exactCache = createSubmodulePathsCache()
+    const exactKey = 'r'.repeat(MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES)
+
+    await listSubmodulePathsCached(exact.git, exactKey, exactCache, 1_000)
+    await listSubmodulePathsCached(exact.git, exactKey, exactCache, 1_001)
+
+    expect(exact.calls()).toBe(1)
+    expect(getSubmodulePathsCacheCount(exactCache)).toBe(1)
+
+    const overflow = gitmodulesExec(['vendor/lib'])
+    const overflowCache = createSubmodulePathsCache()
+    const overflowKey = '界'.repeat(Math.floor(MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES / 3) + 1)
+    expect(Buffer.byteLength(overflowKey, 'utf8')).toBeGreaterThan(
+      MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES
+    )
+
+    await listSubmodulePathsCached(overflow.git, overflowKey, overflowCache, 1_000)
+    await listSubmodulePathsCached(overflow.git, overflowKey, overflowCache, 1_001)
+
+    expect(overflow.calls()).toBe(2)
+    expect(getSubmodulePathsCacheCount(overflowCache)).toBe(0)
+    expect(getSubmodulePathsCacheCodeUnits(overflowCache)).toBe(0)
+  })
+
+  it('evicts LRU payloads above the global retained-code-unit ceiling and recovers', async () => {
+    const calls = new Map<string, number>()
+    const git: GitExec = async (_args, cwd) => {
+      calls.set(cwd, (calls.get(cwd) ?? 0) + 1)
+      const paths =
+        cwd === '/overflow'
+          ? ['vendor/lib']
+          : pathsUsingCodeUnits(MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS - cwd.length)
+      return {
+        stdout: paths
+          .map((submodulePath, i) => `submodule.sub${i}.path ${submodulePath}`)
+          .join('\n'),
+        stderr: ''
+      }
+    }
+    const cache = createSubmodulePathsCache()
+
+    for (let i = 0; i < 4; i += 1) {
+      await listSubmodulePathsCached(git, `/repo-${i}`, cache, 1_000)
+    }
+    expect(getSubmodulePathsCacheCodeUnits(cache)).toBe(MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS)
+
+    await listSubmodulePathsCached(git, '/overflow', cache, 1_000)
+
+    expect(getSubmodulePathsCacheCount(cache)).toBe(4)
+    expect(getSubmodulePathsCacheCodeUnits(cache)).toBeLessThan(
+      MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS
+    )
+    await listSubmodulePathsCached(git, '/repo-1', cache, 1_001)
+    expect(calls.get('/repo-1')).toBe(1)
+    await listSubmodulePathsCached(git, '/repo-0', cache, 1_001)
+    expect(calls.get('/repo-0')).toBe(2)
+    expect(getSubmodulePathsCacheCodeUnits(cache)).toBeLessThanOrEqual(
+      MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS
+    )
+  })
+
   it('does not let a pre-mutation SSH read repopulate the cache', async () => {
     let resolveOldRead: ((value: { stdout: string; stderr: string }) => void) | undefined
     let calls = 0
@@ -138,6 +236,7 @@ describe('listSubmodulePathsCached', () => {
     const oldRead = listSubmodulePathsCached(git, '/repo', cache, 1_000)
     expect(resolveOldRead).toBeTypeOf('function')
     clearSubmodulePathsCache(cache)
+    expect(getSubmodulePathsCacheCodeUnits(cache)).toBe(0)
     resolveOldRead?.({ stdout: 'submodule.lib.path old-lib\n', stderr: '' })
 
     await expect(oldRead).resolves.toEqual(['old-lib'])
@@ -146,6 +245,46 @@ describe('listSubmodulePathsCached', () => {
       'fresh-lib'
     ])
     expect(calls).toBe(2)
+  })
+})
+
+describe('listSubmodulePaths', () => {
+  it('preserves the exact path-count boundary and rejects one more', async () => {
+    const exactPaths = Array.from(
+      { length: MAX_SUBMODULE_PATHS_PER_REPO },
+      (_, index) => `vendor/lib-${index}`
+    )
+    const exact = await listSubmodulePaths(gitmodulesExec(exactPaths).git, '/repo')
+    const overflow = await listSubmodulePaths(
+      gitmodulesExec([...exactPaths, 'vendor/overflow']).git,
+      '/repo'
+    )
+
+    expect(exact).toHaveLength(MAX_SUBMODULE_PATHS_PER_REPO)
+    expect(exact.at(-1)).toBe(`vendor/lib-${MAX_SUBMODULE_PATHS_PER_REPO - 1}`)
+    expect(overflow).toEqual([])
+  })
+
+  it('preserves the exact per-path boundary and rejects one more code unit', async () => {
+    const exactPath = 'x'.repeat(MAX_SUBMODULE_PATH_CODE_UNITS)
+
+    await expect(listSubmodulePaths(gitmodulesExec([exactPath]).git, '/repo')).resolves.toEqual([
+      exactPath
+    ])
+    await expect(
+      listSubmodulePaths(gitmodulesExec([`${exactPath}x`]).git, '/repo')
+    ).resolves.toEqual([])
+  })
+
+  it('preserves the exact per-repo payload boundary and rejects one more code unit', async () => {
+    const exactPaths = pathsUsingCodeUnits(MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS)
+    const exact = await listSubmodulePaths(gitmodulesExec(exactPaths).git, '/repo')
+    const overflow = await listSubmodulePaths(gitmodulesExec([...exactPaths, 'x']).git, '/repo')
+
+    expect(exact.reduce((total, submodulePath) => total + submodulePath.length, 0)).toBe(
+      MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS
+    )
+    expect(overflow).toEqual([])
   })
 })
 

--- a/src/relay/git-handler-submodule-ops.ts
+++ b/src/relay/git-handler-submodule-ops.ts
@@ -11,6 +11,7 @@ import * as path from 'node:path'
 import { buildDiffResult } from './git-diff-result'
 import { parseBranchDiff } from './git-handler-utils'
 import { parseNumstat } from '../shared/git-uncommitted-line-stats'
+import { iterateProcessOutputLines } from '../shared/process-output-field-scanner'
 import { readBlobAtOid, type GitBufferExec, type GitExec } from './git-handler-ops'
 
 /**
@@ -20,18 +21,26 @@ import { readBlobAtOid, type GitBufferExec, type GitExec } from './git-handler-o
  */
 export const SUBMODULE_PATHS_CACHE_TTL_MS = 5_000
 export const MAX_SUBMODULE_PATHS_CACHE_ENTRIES = 512
-type SubmodulePathsCacheEntry = { paths: string[]; expiresAt: number }
+export const MAX_SUBMODULE_PATHS_OUTPUT_BYTES = 10 * 1024 * 1024
+export const MAX_SUBMODULE_PATHS_PER_REPO = 10_000
+export const MAX_SUBMODULE_PATH_CODE_UNITS = 64 * 1024
+export const MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS = 4 * 1024 * 1024
+export const MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS = 16 * 1024 * 1024
+export const MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES = 64 * 1024
+type SubmodulePathsCacheEntry = { paths: string[]; expiresAt: number; retainedCodeUnits: number }
 export type SubmodulePathsCache = {
   entries: Map<string, SubmodulePathsCacheEntry>
   generation: number
+  retainedCodeUnits: number
 }
 
 export function createSubmodulePathsCache(): SubmodulePathsCache {
-  return { entries: new Map(), generation: 0 }
+  return { entries: new Map(), generation: 0, retainedCodeUnits: 0 }
 }
 
 export function clearSubmodulePathsCache(cache: SubmodulePathsCache): void {
   cache.entries.clear()
+  cache.retainedCodeUnits = 0
   // Why: a pre-mutation SSH read must not restore stale .gitmodules paths
   // after the mutation invalidated them.
   cache.generation += 1
@@ -39,6 +48,19 @@ export function clearSubmodulePathsCache(cache: SubmodulePathsCache): void {
 
 export function getSubmodulePathsCacheCount(cache: SubmodulePathsCache): number {
   return cache.entries.size
+}
+
+export function getSubmodulePathsCacheCodeUnits(cache: SubmodulePathsCache): number {
+  return cache.retainedCodeUnits
+}
+
+function deleteSubmodulePathsCacheEntry(cache: SubmodulePathsCache, worktreePath: string): void {
+  const entry = cache.entries.get(worktreePath)
+  if (!entry) {
+    return
+  }
+  cache.entries.delete(worktreePath)
+  cache.retainedCodeUnits -= entry.retainedCodeUnits
 }
 
 function getCachedSubmodulePaths(
@@ -51,7 +73,7 @@ function getCachedSubmodulePaths(
     return null
   }
   if (cached.expiresAt <= now) {
-    cache.entries.delete(worktreePath)
+    deleteSubmodulePathsCacheEntry(cache, worktreePath)
     return null
   }
   cache.entries.delete(worktreePath)
@@ -62,7 +84,7 @@ function getCachedSubmodulePaths(
 function pruneExpiredSubmodulePaths(cache: SubmodulePathsCache, now: number): void {
   for (const [worktreePath, entry] of cache.entries) {
     if (entry.expiresAt <= now) {
-      cache.entries.delete(worktreePath)
+      deleteSubmodulePathsCacheEntry(cache, worktreePath)
     }
   }
 }
@@ -73,14 +95,31 @@ function rememberSubmodulePaths(
   paths: string[],
   now: number
 ): void {
-  cache.entries.delete(worktreePath)
-  cache.entries.set(worktreePath, { paths, expiresAt: now + SUBMODULE_PATHS_CACHE_TTL_MS })
-  while (cache.entries.size > MAX_SUBMODULE_PATHS_CACHE_ENTRIES) {
+  deleteSubmodulePathsCacheEntry(cache, worktreePath)
+  if (Buffer.byteLength(worktreePath, 'utf8') > MAX_SUBMODULE_PATHS_CACHE_KEY_BYTES) {
+    return
+  }
+  // Why: JS strings retain UTF-16 code units, so byte counts understate non-ASCII heap use.
+  const retainedCodeUnits =
+    worktreePath.length + paths.reduce((total, submodulePath) => total + submodulePath.length, 0)
+  if (retainedCodeUnits > MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS) {
+    return
+  }
+  cache.entries.set(worktreePath, {
+    paths,
+    expiresAt: now + SUBMODULE_PATHS_CACHE_TTL_MS,
+    retainedCodeUnits
+  })
+  cache.retainedCodeUnits += retainedCodeUnits
+  while (
+    cache.entries.size > MAX_SUBMODULE_PATHS_CACHE_ENTRIES ||
+    cache.retainedCodeUnits > MAX_SUBMODULE_PATHS_CACHE_CODE_UNITS
+  ) {
     const oldestPath = cache.entries.keys().next().value
     if (oldestPath === undefined) {
       break
     }
-    cache.entries.delete(oldestPath)
+    deleteSubmodulePathsCacheEntry(cache, oldestPath)
   }
 }
 
@@ -119,20 +158,37 @@ export async function listSubmodulePaths(git: GitExec, worktreePath: string): Pr
   try {
     const { stdout } = await git(
       ['config', '--file', '.gitmodules', '--get-regexp', '^submodule\\..*\\.path$'],
-      worktreePath
+      worktreePath,
+      { maxBuffer: MAX_SUBMODULE_PATHS_OUTPUT_BYTES }
     )
-    return stdout
-      .split(/\r?\n/)
-      .map((line) => {
-        const spaceIndex = line.indexOf(' ')
-        return spaceIndex === -1
+    const paths: string[] = []
+    let retainedCodeUnits = 0
+    for (const line of iterateProcessOutputLines(stdout)) {
+      if (line.length > MAX_SUBMODULE_PATH_CODE_UNITS + 4_096) {
+        return []
+      }
+      const spaceIndex = line.indexOf(' ')
+      const submodulePath =
+        spaceIndex === -1
           ? ''
           : line
               .slice(spaceIndex + 1)
               .trim()
               .replace(/\/+$/, '')
-      })
-      .filter((value) => value.length > 0)
+      if (!submodulePath) {
+        continue
+      }
+      if (
+        paths.length >= MAX_SUBMODULE_PATHS_PER_REPO ||
+        submodulePath.length > MAX_SUBMODULE_PATH_CODE_UNITS ||
+        submodulePath.length > MAX_SUBMODULE_PATHS_PER_REPO_CODE_UNITS - retainedCodeUnits
+      ) {
+        return []
+      }
+      paths.push(submodulePath)
+      retainedCodeUnits += submodulePath.length
+    }
+    return paths
   } catch {
     return []
   }

--- a/src/relay/git-handler-utils.ts
+++ b/src/relay/git-handler-utils.ts
@@ -10,6 +10,7 @@ import * as path from 'node:path'
 import { decodeGitCQuotedPath } from '../shared/git-cquoted-path'
 import { isBinaryBuffer } from '../shared/binary-buffer'
 import type { GitLineStats } from '../shared/git-uncommitted-line-stats'
+import { iterateNulDelimitedFields } from '../shared/nul-delimited-fields'
 export { isUnsupportedWorktreeListZError } from '../shared/git-worktree-command-capabilities'
 
 export function parseBranchStatusChar(char: string): string {
@@ -209,7 +210,7 @@ function splitNulWorktreeList(output: string): string[][] {
   const blocks: string[][] = []
   let currentBlock: string[] = []
 
-  for (const field of output.split('\0')) {
+  for (const field of iterateNulDelimitedFields(output)) {
     if (field) {
       currentBlock.push(field)
       continue

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -11,6 +11,7 @@ import {
   parseWorktreeList
 } from './git-handler-utils'
 import { parseNumstat } from '../shared/git-uncommitted-line-stats'
+import { iterateNulDelimitedFields } from '../shared/nul-delimited-fields'
 import {
   computeDiff,
   branchCompare as branchCompareOp,
@@ -77,7 +78,15 @@ import {
   isUnsupportedRevParsePathFormatError
 } from '../shared/git-worktree-command-capabilities'
 import { GitResponseStreamRegistry } from './git-response-stream'
-import { GIT_RESPONSE_STREAM_THRESHOLD } from './protocol'
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../shared/node-bounded-json-stringify'
+import {
+  GIT_RESPONSE_STREAM_THRESHOLD,
+  MAX_GIT_RESPONSE_STREAM_BYTES,
+  RelayErrorCode
+} from './protocol'
 import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-cache'
 import { streamRelayGitStdout } from './git-stdout-stream'
@@ -269,11 +278,26 @@ export class GitHandler {
     if (params.__streamResponse !== true || !context) {
       return result
     }
-    const payload = Buffer.from(JSON.stringify(result ?? null), 'utf-8')
-    if (payload.length <= GIT_RESPONSE_STREAM_THRESHOLD) {
+    let serialized: string
+    let payloadBytes: number
+    try {
+      const bounded = stringifyJsonWithinByteLimit(result ?? null, MAX_GIT_RESPONSE_STREAM_BYTES)
+      serialized = bounded.serialized
+      payloadBytes = bounded.byteLength
+    } catch (error) {
+      if (!(error instanceof JsonStringifyByteLimitError)) {
+        throw error
+      }
+      const oversized = new Error(
+        `Git response is too large to transfer safely (more than ${MAX_GIT_RESPONSE_STREAM_BYTES} bytes)`
+      ) as Error & { code: number }
+      oversized.code = RelayErrorCode.StreamProtocolError
+      throw oversized
+    }
+    if (payloadBytes <= GIT_RESPONSE_STREAM_THRESHOLD) {
       return result
     }
-    return this.responseStreams.startStream(payload, this.dispatcher, context)
+    return this.responseStreams.startStream(serialized, this.dispatcher, context)
   }
 
   private clearGitMutationReadCaches(): void {
@@ -691,7 +715,7 @@ export class GitHandler {
           worktreePath
         )
         // Why: a selected tracked directory can make `ls-files -z` return enough descendants for push(...split) to exceed the argument limit.
-        for (const trackedPathSpec of stdout.split('\0')) {
+        for (const trackedPathSpec of iterateNulDelimitedFields(stdout)) {
           if (trackedPathSpec) {
             trackedPathSpecs.push(trackedPathSpec)
           }

--- a/src/relay/git-response-stream-ownership.test.ts
+++ b/src/relay/git-response-stream-ownership.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
-import { GitResponseStreamRegistry } from './git-response-stream'
+import {
+  GitResponseStreamRegistry,
+  MAX_CONCURRENT_GIT_RESPONSE_STREAMS
+} from './git-response-stream'
 import { GIT_RESPONSE_CHUNK_SIZE, STREAM_ACK_WINDOW_CHUNKS } from './protocol'
 
 async function flushPump(): Promise<void> {
@@ -37,7 +40,17 @@ describe('GitResponseStreamRegistry client ownership', () => {
     await flushPump()
     expect(notifyBulk).toHaveBeenCalledTimes(STREAM_ACK_WINDOW_CHUNKS)
 
+    registry.recordAck(streamId, 10_000, ownerClientId)
+    await flushPump()
+    expect(notifyBulk).toHaveBeenCalledTimes(STREAM_ACK_WINDOW_CHUNKS)
+
     registry.recordAck(streamId, 10_000, ownerClientId + 1)
+    await flushPump()
+    expect(notifyBulk).toHaveBeenCalledTimes(STREAM_ACK_WINDOW_CHUNKS)
+
+    for (const invalidSeq of [-1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
+      registry.recordAck(streamId, invalidSeq, ownerClientId)
+    }
     await flushPump()
     expect(notifyBulk).toHaveBeenCalledTimes(STREAM_ACK_WINDOW_CHUNKS)
 
@@ -64,5 +77,116 @@ describe('GitResponseStreamRegistry client ownership', () => {
     expect(notifyBulk).toHaveBeenCalledTimes(2)
     expect(notifyBulk.mock.calls[0]?.[0]).toBe('git.responseChunk')
     expect(notifyBulk.mock.calls[1]?.[0]).toBe('git.responseError')
+  })
+
+  it('caps parked streams and defers base64 expansion until the pump runs', () => {
+    const dispatcher = {
+      notifyBulk: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    } as unknown as RelayDispatcher
+    const registry = new GitResponseStreamRegistry()
+    registries.push(registry)
+    const payload = Buffer.from('payload')
+    const toStringSpy = vi.spyOn(Buffer.prototype, 'toString')
+
+    try {
+      for (let index = 0; index < MAX_CONCURRENT_GIT_RESPONSE_STREAMS; index += 1) {
+        registry.startStream(payload, dispatcher, {
+          clientId: 7,
+          isStale: () => false
+        })
+      }
+
+      expect(toStringSpy.mock.calls.some(([encoding]) => encoding === 'base64')).toBe(false)
+      expect(() =>
+        registry.startStream(payload, dispatcher, {
+          clientId: 7,
+          isStale: () => false
+        })
+      ).toThrow(`Too many concurrent git response streams`)
+    } finally {
+      toStringSpy.mockRestore()
+    }
+  })
+
+  it('caps aggregate bytes retained by concurrent parked responses', () => {
+    const dispatcher = {
+      notifyBulk: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    } as unknown as RelayDispatcher
+    const registry = new GitResponseStreamRegistry(10)
+    registries.push(registry)
+    const context = { clientId: 7, isStale: () => false }
+
+    registry.startStream(Buffer.alloc(6), dispatcher, context)
+    registry.startStream(Buffer.alloc(4), dispatcher, context)
+
+    expect(() => registry.startStream(Buffer.alloc(1), dispatcher, context)).toThrow(
+      'Concurrent git responses exceed retained-byte limit (10 bytes)'
+    )
+  })
+
+  it('rejects a serialized string before allocating any encoded chunk', () => {
+    const dispatcher = {
+      notifyBulk: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    } as unknown as RelayDispatcher
+    const registry = new GitResponseStreamRegistry(0)
+    registries.push(registry)
+    const fromSpy = vi.spyOn(Buffer, 'from')
+
+    try {
+      expect(() =>
+        registry.startStream('serialized response', dispatcher, {
+          clientId: 7,
+          isStale: () => false
+        })
+      ).toThrow('Concurrent git responses exceed retained-byte limit (0 bytes)')
+      expect(fromSpy).not.toHaveBeenCalled()
+    } finally {
+      fromSpy.mockRestore()
+    }
+  })
+
+  it('streams a serialized string without changing its UTF-8 bytes', async () => {
+    const chunks: Buffer[] = []
+    const notifyBulk = vi.fn().mockImplementation((method, params) => {
+      if (method === 'git.responseChunk') {
+        chunks.push(Buffer.from(params.data, 'base64'))
+      }
+      return Promise.resolve()
+    })
+    const dispatcher = { notifyBulk, notify: vi.fn() } as unknown as RelayDispatcher
+    const registry = new GitResponseStreamRegistry()
+    registries.push(registry)
+    const serialized = JSON.stringify({ text: `boundary-${'🐋'.repeat(40_000)}` })
+
+    const marker = registry.startStream(serialized, dispatcher, {
+      clientId: 7,
+      isStale: () => false
+    })
+    await flushPump()
+    await flushPump()
+
+    expect(Buffer.concat(chunks)).toEqual(Buffer.from(serialized, 'utf8'))
+    expect(chunks).toHaveLength(marker.__orcaGitResponseStream.chunkCount)
+    expect(marker.__orcaGitResponseStream.totalBytes).toBe(Buffer.byteLength(serialized, 'utf8'))
+  })
+
+  it('releases aggregate bytes after completion and disposal', async () => {
+    const dispatcher = {
+      notifyBulk: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    } as unknown as RelayDispatcher
+    const registry = new GitResponseStreamRegistry(10)
+    registries.push(registry)
+    const context = { clientId: 7, isStale: () => false }
+
+    registry.startStream(Buffer.alloc(10), dispatcher, context)
+    await flushPump()
+    expect(() => registry.startStream(Buffer.alloc(10), dispatcher, context)).not.toThrow()
+
+    registry.disposeAll()
+    expect(() => registry.startStream(Buffer.alloc(10), dispatcher, context)).not.toThrow()
   })
 })

--- a/src/relay/git-response-stream.ts
+++ b/src/relay/git-response-stream.ts
@@ -6,42 +6,95 @@
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import {
   GIT_RESPONSE_CHUNK_SIZE,
+  MAX_GIT_RESPONSE_STREAM_BYTES,
+  MAX_GIT_RESPONSE_STREAM_CHUNKS,
+  MAX_CONCURRENT_STREAMS,
+  RelayErrorCode,
   STREAM_ACK_WINDOW_CHUNKS,
   STREAM_ACK_STALL_RECHECK_MS,
   type GitResponseStreamMarker
 } from './protocol'
+import {
+  encodeUtf8StringChunk,
+  planUtf8StringChunks,
+  type Utf8StringChunk
+} from './git-response-utf8-chunks'
 
 type GitResponseStreamEntry = {
   ownerClientId: number
+  retainedBytes: number
   aborted: boolean
+  /** Highest chunk seq admitted to the outbound bulk lane. */
+  sentThroughSeq: number
   /** Highest chunk seq the client acknowledged (in-order; -1 = none yet). */
   ackedThroughSeq: number
   ackWaiters: Set<() => void>
 }
 
-/** Serialized git responses are chunked as base64 so multi-byte UTF-8
- * sequences never split across a chunk boundary (the client concatenates the
- * decoded bytes and parses once). */
-function encodeChunks(payload: Buffer): string[] {
-  const chunks: string[] = []
-  for (let offset = 0; offset < payload.length; offset += GIT_RESPONSE_CHUNK_SIZE) {
-    chunks.push(payload.subarray(offset, offset + GIT_RESPONSE_CHUNK_SIZE).toString('base64'))
-  }
-  return chunks
-}
+type PreparedGitResponse =
+  | { kind: 'buffer'; value: Buffer; byteLength: number; chunkCount: number }
+  | {
+      kind: 'string'
+      value: string
+      byteLength: number
+      chunks: Utf8StringChunk[]
+      chunkCount: number
+    }
+
+export const MAX_CONCURRENT_GIT_RESPONSE_STREAMS = MAX_CONCURRENT_STREAMS
+export const MAX_ACTIVE_GIT_RESPONSE_STREAM_BYTES = 128 * 1024 * 1024
 
 export class GitResponseStreamRegistry {
   private streams = new Map<number, GitResponseStreamEntry>()
   private nextId = 1
+  private retainedBytes = 0
 
-  private register(ownerClientId: number): number {
+  constructor(private readonly maxRetainedBytes: number = MAX_ACTIVE_GIT_RESPONSE_STREAM_BYTES) {}
+
+  private preparePayload(payload: Buffer | string): PreparedGitResponse {
+    if (Buffer.isBuffer(payload)) {
+      return {
+        kind: 'buffer',
+        value: payload,
+        byteLength: payload.length,
+        chunkCount: Math.ceil(payload.length / GIT_RESPONSE_CHUNK_SIZE)
+      }
+    }
+    const chunks = planUtf8StringChunks(payload, GIT_RESPONSE_CHUNK_SIZE)
+    return {
+      kind: 'string',
+      value: payload,
+      byteLength: Buffer.byteLength(payload, 'utf8'),
+      chunks,
+      chunkCount: chunks.length
+    }
+  }
+
+  private register(ownerClientId: number, retainedBytes: number): number {
+    if (this.streams.size >= MAX_CONCURRENT_GIT_RESPONSE_STREAMS) {
+      const error = new Error(
+        `Too many concurrent git response streams (max ${MAX_CONCURRENT_GIT_RESPONSE_STREAMS})`
+      ) as Error & { code: number }
+      error.code = RelayErrorCode.TooManyStreams
+      throw error
+    }
+    if (retainedBytes > this.maxRetainedBytes - this.retainedBytes) {
+      const error = new Error(
+        `Concurrent git responses exceed retained-byte limit (${this.maxRetainedBytes} bytes)`
+      ) as Error & { code: number }
+      error.code = RelayErrorCode.TooManyStreams
+      throw error
+    }
     const streamId = this.nextId++
     this.streams.set(streamId, {
       ownerClientId,
+      retainedBytes,
       aborted: false,
+      sentThroughSeq: -1,
       ackedThroughSeq: -1,
       ackWaiters: new Set()
     })
+    this.retainedBytes += retainedBytes
     return streamId
   }
 
@@ -50,8 +103,9 @@ export class GitResponseStreamRegistry {
     if (
       !entry ||
       entry.ownerClientId !== clientId ||
-      typeof seq !== 'number' ||
-      !Number.isFinite(seq)
+      !Number.isSafeInteger(seq) ||
+      seq < 0 ||
+      seq > entry.sentThroughSeq
     ) {
       return
     }
@@ -111,25 +165,39 @@ export class GitResponseStreamRegistry {
    * sentinel marker to send as the RPC result.
    */
   startStream(
-    payload: Buffer,
+    payload: Buffer | string,
     dispatcher: RelayDispatcher,
     context: RequestContext
   ): GitResponseStreamMarker {
-    const streamId = this.register(context.clientId)
-    const chunks = encodeChunks(payload)
+    const prepared = this.preparePayload(payload)
+    if (
+      prepared.byteLength > MAX_GIT_RESPONSE_STREAM_BYTES ||
+      prepared.chunkCount > MAX_GIT_RESPONSE_STREAM_CHUNKS
+    ) {
+      const error = new Error(
+        `Git response exceeds stream limit (${prepared.byteLength} bytes, ${prepared.chunkCount} chunks)`
+      ) as Error & { code: number }
+      error.code = RelayErrorCode.StreamProtocolError
+      throw error
+    }
+    const streamId = this.register(context.clientId, prepared.byteLength)
     // Why: kick the pump off the response task so the client sees the sentinel
     // (and can subscribe/reassemble) before the first chunk frame arrives.
     setImmediate(() => {
-      void this.pump(streamId, chunks, dispatcher, context)
+      void this.pump(streamId, prepared, dispatcher, context)
     })
     return {
-      __orcaGitResponseStream: { streamId, totalBytes: payload.length, chunkCount: chunks.length }
+      __orcaGitResponseStream: {
+        streamId,
+        totalBytes: prepared.byteLength,
+        chunkCount: prepared.chunkCount
+      }
     }
   }
 
   private async pump(
     streamId: number,
-    chunks: string[],
+    payload: PreparedGitResponse,
     dispatcher: RelayDispatcher,
     context: RequestContext
   ): Promise<void> {
@@ -141,7 +209,7 @@ export class GitResponseStreamRegistry {
     let seq = 0
     let endReason: 'end' | 'aborted' | 'stale' = 'end'
     try {
-      for (seq = 0; seq < chunks.length; seq += 1) {
+      for (seq = 0; seq < payload.chunkCount; seq += 1) {
         if (context.isStale()) {
           endReason = 'stale'
           break
@@ -167,11 +235,20 @@ export class GitResponseStreamRegistry {
           endReason = 'aborted'
           break
         }
-        // Why: notifyBulk waits out sink saturation so chunk frames never pile
-        // up in the outbound pipe ahead of interactive pty.data frames.
+        const chunk =
+          payload.kind === 'buffer'
+            ? payload.value.subarray(
+                seq * GIT_RESPONSE_CHUNK_SIZE,
+                (seq + 1) * GIT_RESPONSE_CHUNK_SIZE
+              )
+            : encodeUtf8StringChunk(payload.value, payload.chunks[seq])
+        // Why: encode only the current chunk; eager base64 retained a second,
+        // 4/3-expanded copy of every parked response until its final ACK.
+        const data = chunk.toString('base64')
+        entry.sentThroughSeq = seq
         await dispatcher.notifyBulk(
           'git.responseChunk',
-          { streamId, seq, data: chunks[seq] },
+          { streamId, seq, data },
           {
             clientId
           }
@@ -197,8 +274,17 @@ export class GitResponseStreamRegistry {
         }
       }
     } finally {
-      this.streams.delete(streamId)
+      this.deleteStream(streamId)
     }
+  }
+
+  private deleteStream(streamId: number): void {
+    const entry = this.streams.get(streamId)
+    if (!entry) {
+      return
+    }
+    this.streams.delete(streamId)
+    this.retainedBytes -= entry.retainedBytes
   }
 
   disposeAll(): void {
@@ -207,5 +293,6 @@ export class GitResponseStreamRegistry {
       this.wake(entry)
     }
     this.streams.clear()
+    this.retainedBytes = 0
   }
 }

--- a/src/relay/git-response-utf8-chunks.test.ts
+++ b/src/relay/git-response-utf8-chunks.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { encodeUtf8StringChunk, planUtf8StringChunks } from './git-response-utf8-chunks'
+
+describe('Git response UTF-8 chunk planning', () => {
+  it('round-trips mixed-width text without splitting code points', () => {
+    const value = 'ascii-é-€-🐋-end'.repeat(20)
+    const plan = planUtf8StringChunks(value, 17)
+    const encoded = plan.map((chunk) => encodeUtf8StringChunk(value, chunk))
+
+    expect(Buffer.concat(encoded)).toEqual(Buffer.from(value, 'utf8'))
+    expect(plan.every((chunk) => chunk.byteLength <= 17)).toBe(true)
+    expect(plan.reduce((total, chunk) => total + chunk.byteLength, 0)).toBe(
+      Buffer.byteLength(value, 'utf8')
+    )
+  })
+
+  it('matches Node replacement encoding for unmatched surrogate code units', () => {
+    const value = 'before-\ud800-after-\udc00'
+    const plan = planUtf8StringChunks(value, 8)
+
+    expect(Buffer.concat(plan.map((chunk) => encodeUtf8StringChunk(value, chunk)))).toEqual(
+      Buffer.from(value, 'utf8')
+    )
+  })
+
+  it('returns no chunks for empty text and rejects unsafe chunk sizes', () => {
+    expect(planUtf8StringChunks('', 4)).toEqual([])
+    expect(() => planUtf8StringChunks('value', 3)).toThrow(RangeError)
+  })
+})

--- a/src/relay/git-response-utf8-chunks.ts
+++ b/src/relay/git-response-utf8-chunks.ts
@@ -1,0 +1,55 @@
+export type Utf8StringChunk = {
+  start: number
+  end: number
+  byteLength: number
+}
+
+function encodedCodePointSize(value: string, index: number): { bytes: number; codeUnits: number } {
+  const code = value.charCodeAt(index)
+  if (code <= 0x7f) {
+    return { bytes: 1, codeUnits: 1 }
+  }
+  if (code <= 0x7ff) {
+    return { bytes: 2, codeUnits: 1 }
+  }
+  if (code >= 0xd800 && code <= 0xdbff) {
+    const next = value.charCodeAt(index + 1)
+    if (next >= 0xdc00 && next <= 0xdfff) {
+      return { bytes: 4, codeUnits: 2 }
+    }
+  }
+  return { bytes: 3, codeUnits: 1 }
+}
+
+export function planUtf8StringChunks(value: string, maxChunkBytes: number): Utf8StringChunk[] {
+  if (!Number.isSafeInteger(maxChunkBytes) || maxChunkBytes < 4) {
+    throw new RangeError('UTF-8 chunk limit must be a safe integer of at least 4 bytes')
+  }
+
+  const chunks: Utf8StringChunk[] = []
+  let chunkStart = 0
+  let chunkBytes = 0
+  let index = 0
+  while (index < value.length) {
+    const encoded = encodedCodePointSize(value, index)
+    if (chunkBytes > 0 && chunkBytes + encoded.bytes > maxChunkBytes) {
+      chunks.push({ start: chunkStart, end: index, byteLength: chunkBytes })
+      chunkStart = index
+      chunkBytes = 0
+    }
+    chunkBytes += encoded.bytes
+    index += encoded.codeUnits
+  }
+  if (chunkBytes > 0) {
+    chunks.push({ start: chunkStart, end: value.length, byteLength: chunkBytes })
+  }
+  return chunks
+}
+
+export function encodeUtf8StringChunk(value: string, chunk: Utf8StringChunk): Buffer {
+  const encoded = Buffer.from(value.slice(chunk.start, chunk.end), 'utf8')
+  if (encoded.length !== chunk.byteLength) {
+    throw new Error('UTF-8 chunk plan did not match encoded byte length')
+  }
+  return encoded
+}

--- a/src/relay/git-status-upstream-negative-cache.test.ts
+++ b/src/relay/git-status-upstream-negative-cache.test.ts
@@ -4,6 +4,7 @@ import {
   clearNoEffectiveUpstreamStatusCacheEntry,
   getNoEffectiveUpstreamStatusCacheCountForTests,
   getNoEffectiveUpstreamStatusGenerationCountForTests,
+  MAX_NO_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES,
   readOrProbeNoEffectiveUpstreamStatus
 } from './git-status-upstream-negative-cache'
 
@@ -325,6 +326,59 @@ describe('relay upstream negative cache', () => {
 
     expect(getNoEffectiveUpstreamStatusCacheCountForTests()).toBe(0)
     expect(getNoEffectiveUpstreamStatusGenerationCountForTests()).toBe(512)
+  })
+
+  it('retains the exact key-byte boundary but not oversized identities', async () => {
+    const worktreePath = '/r'
+    const keyOverheadBytes = Buffer.byteLength(`${worktreePath}\0\0`, 'utf8')
+    const exactBranch = 'x'.repeat(MAX_NO_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES - keyOverheadBytes)
+    const oversizedBranch = `${exactBranch}x`
+    const createRunner = (branchName: string) =>
+      vi.fn(async (args: string[]): Promise<{ stdout: string }> => {
+        if (args[0] === 'symbolic-ref') {
+          return { stdout: `${branchName}\n` }
+        }
+        if (args[0] === 'rev-parse' && args.includes('HEAD@{u}')) {
+          throw new Error(`fatal: no upstream configured for branch ${branchName}`)
+        }
+        if (isConfigListSnapshotCommand(args)) {
+          return emptyGitConfigSnapshot()
+        }
+        if (args[0] === 'rev-parse') {
+          throw new Error('missing remote branch')
+        }
+        throw new Error(`No upstream fixture for git ${args.join(' ')}`)
+      })
+    const exactRunner = createRunner(exactBranch)
+    const oversizedRunner = createRunner(oversizedBranch)
+
+    await readOrProbeNoEffectiveUpstreamStatus(
+      { worktreePath, branchName: exactBranch },
+      exactRunner
+    )
+    await readOrProbeNoEffectiveUpstreamStatus(
+      { worktreePath, branchName: exactBranch },
+      exactRunner
+    )
+    await readOrProbeNoEffectiveUpstreamStatus(
+      { worktreePath, branchName: oversizedBranch },
+      oversizedRunner
+    )
+    await readOrProbeNoEffectiveUpstreamStatus(
+      { worktreePath, branchName: oversizedBranch },
+      oversizedRunner
+    )
+    clearNoEffectiveUpstreamStatusCacheEntry({
+      worktreePath,
+      branchName: oversizedBranch
+    })
+
+    expect(exactRunner.mock.calls.filter(([args]) => args[0] === 'symbolic-ref')).toHaveLength(1)
+    expect(oversizedRunner.mock.calls.filter(([args]) => args[0] === 'symbolic-ref')).toHaveLength(
+      2
+    )
+    expect(getNoEffectiveUpstreamStatusCacheCountForTests()).toBe(1)
+    expect(getNoEffectiveUpstreamStatusGenerationCountForTests()).toBe(0)
   })
 
   it('coalesces no-upstream config reads into one snapshot subprocess', async () => {

--- a/src/relay/git-status-upstream-negative-cache.ts
+++ b/src/relay/git-status-upstream-negative-cache.ts
@@ -5,6 +5,7 @@ import type { GitUpstreamStatus } from '../shared/types'
 
 const NO_EFFECTIVE_UPSTREAM_CACHE_TTL_MS = 5 * 60_000
 const MAX_NO_EFFECTIVE_UPSTREAM_CACHE_ENTRIES = 512
+export const MAX_NO_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES = 64 * 1024
 
 type NoEffectiveUpstreamCacheIdentity = {
   worktreePath: string
@@ -24,6 +25,10 @@ const noEffectiveUpstreamWriteGeneration = new Map<string, number>()
 
 function noEffectiveUpstreamCacheKey(identity: NoEffectiveUpstreamCacheIdentity): string {
   return [identity.worktreePath, identity.branchName, identity.upstreamName ?? ''].join('\0')
+}
+
+function canRetainNoEffectiveUpstreamCacheKey(cacheKey: string): boolean {
+  return Buffer.byteLength(cacheKey, 'utf8') <= MAX_NO_EFFECTIVE_UPSTREAM_CACHE_KEY_BYTES
 }
 
 function readCachedNoEffectiveUpstreamStatus(
@@ -66,6 +71,11 @@ function cacheNoEffectiveUpstreamStatus(
   writeGeneration: number,
   nowMs = Date.now()
 ): void {
+  if (!canRetainNoEffectiveUpstreamCacheKey(cacheKey)) {
+    noEffectiveUpstreamByIdentity.delete(cacheKey)
+    noEffectiveUpstreamWriteGeneration.delete(cacheKey)
+    return
+  }
   // Why: hasConfiguredPushTarget controls publish behavior; keep that signal
   // fresh rather than serving a stale positive from status polling.
   if (status.hasUpstream || status.hasConfiguredPushTarget) {
@@ -154,6 +164,10 @@ export function clearNoEffectiveUpstreamStatusCacheEntry(
   retireNoEffectiveUpstreamProbe(cacheKey)
   noEffectiveUpstreamByIdentity.delete(cacheKey)
   noEffectiveUpstreamInFlight.delete(cacheKey)
+  if (!canRetainNoEffectiveUpstreamCacheKey(cacheKey)) {
+    noEffectiveUpstreamWriteGeneration.delete(cacheKey)
+    return
+  }
   noEffectiveUpstreamWriteGeneration.set(
     cacheKey,
     (noEffectiveUpstreamWriteGeneration.get(cacheKey) ?? 0) + 1

--- a/src/relay/git-working-file-read.test.ts
+++ b/src/relay/git-working-file-read.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -29,7 +29,8 @@ describe('readWorkingDiffFile', () => {
   it('marks oversized working-tree files as binary before diffing', async () => {
     tmpDir = await mkdtemp(path.join(tmpdir(), 'relay-working-file-'))
     const filePath = path.join(tmpDir, 'large.log')
-    await writeFile(filePath, Buffer.alloc(10 * 1024 * 1024 + 1, 'a'))
+    await writeFile(filePath, 'a')
+    await truncate(filePath, 10 * 1024 * 1024 + 1)
 
     await expect(readWorkingDiffFile(filePath)).resolves.toEqual({
       content: '',

--- a/src/relay/git-working-file-read.ts
+++ b/src/relay/git-working-file-read.ts
@@ -1,5 +1,9 @@
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import { bufferToBlob } from './git-handler-utils'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../shared/node-bounded-file-reader'
 
 const MAX_RELAY_DIFF_WORKING_FILE_BYTES = 10 * 1024 * 1024
 
@@ -19,16 +23,16 @@ export async function readWorkingDiffFile(
   if (!fileStat.isFile()) {
     return { content: '', isBinary: false, missing: true }
   }
-  if (fileStat.size > MAX_RELAY_DIFF_WORKING_FILE_BYTES) {
-    // Why: mirror local git diff reads, which cap blob transfer at 10MB.
-    return { content: '', isBinary: true, missing: false }
-  }
   try {
-    const buffer = await readFile(absPath)
+    const { buffer } = await readNodeFileWithinLimit(absPath, MAX_RELAY_DIFF_WORKING_FILE_BYTES)
     // Why: bufferToBlob needs the path's extension to know an image is
     // previewable; omitting it made every relay-side binary diff empty.
     return { ...bufferToBlob(buffer, absPath), missing: false }
-  } catch {
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      // Why: mirror local git diff reads, which classify blobs over 10MB as binary.
+      return { content: '', isBinary: true, missing: false }
+    }
     // Why: the file exists but could not be read — a read failure, not a deletion.
     return { content: '', isBinary: false, missing: false }
   }

--- a/src/relay/integration.test.ts
+++ b/src/relay/integration.test.ts
@@ -23,6 +23,7 @@ import { RelayDispatcher } from './dispatcher'
 import { RelayContext } from './context'
 import { FsHandler } from './fs-handler'
 import { GitHandler } from './git-handler'
+import { SshFilesystemProvider } from '../main/providers/ssh-filesystem-provider'
 
 function gitInit(dir: string): void {
   execFileSync('git', ['init'], { cwd: dir, stdio: 'pipe' })
@@ -108,6 +109,17 @@ describe('Integration: Client Mux ↔ Relay Dispatcher', () => {
       expect(names).toEqual(['hello.txt', 'readme.md'])
     })
 
+    it('routes SSH provider directory reads through the bounded relay handler', async () => {
+      writeFileSync(path.join(tmpDir, 'hello.txt'), 'world')
+      const provider = new SshFilesystemProvider('test-connection', mux)
+
+      await expect(provider.readDir(tmpDir)).resolves.toEqual([
+        { name: 'hello.txt', isDirectory: false, isSymlink: false }
+      ])
+
+      provider.dispose()
+    })
+
     it('readFile returns text content', async () => {
       writeFileSync(path.join(tmpDir, 'data.txt'), 'some content')
 
@@ -122,6 +134,11 @@ describe('Integration: Client Mux ↔ Relay Dispatcher', () => {
     it('readFileStream round-trip preserves a 12 MB binary file', async () => {
       const filePath = path.join(tmpDir, 'big.png')
       const original = randomBytes(12 * 1024 * 1024)
+      Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(original)
+      original.writeUInt32BE(13, 8)
+      original.write('IHDR', 12, 'ascii')
+      original.writeUInt32BE(1, 16)
+      original.writeUInt32BE(1, 20)
       writeFileSync(filePath, original)
       const { readFileViaStream } = await import('../main/ssh/ssh-filesystem-stream-reader')
       const { content } = await readFileViaStream(mux, filePath)

--- a/src/relay/markdown-document-listing.test.ts
+++ b/src/relay/markdown-document-listing.test.ts
@@ -1,0 +1,93 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MARKDOWN_DOCUMENT_LISTING_MAX_DOCUMENTS,
+  MARKDOWN_DOCUMENT_LISTING_MAX_PATH_BYTES,
+  MarkdownDocumentListingCapacityError
+} from '../shared/markdown-document-listing-limits'
+import {
+  listMarkdownPathsWithRg,
+  listRelayMarkdownDocumentPaths
+} from './markdown-document-listing'
+
+function successfulChild(output: Buffer): ChildProcess {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null,
+    signalCode: null,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: vi.fn(() => true)
+  }) as unknown as ChildProcess
+  queueMicrotask(() => {
+    child.stdout!.emit('data', output)
+    child.emit('close', 0, null)
+  })
+  return child
+}
+
+describe('relay Markdown document producer', () => {
+  it('returns only Markdown paths from a real under-limit workspace', async () => {
+    const rootPath = await mkdtemp(join(tmpdir(), 'orca-markdown-listing-'))
+    try {
+      await mkdir(join(rootPath, 'docs'))
+      await writeFile(join(rootPath, 'README.md'), 'readme')
+      await writeFile(join(rootPath, 'docs', 'Guide.MDX'), 'guide')
+      await writeFile(join(rootPath, 'docs', 'app.ts'), 'code')
+
+      const result = await listRelayMarkdownDocumentPaths(rootPath)
+      expect(result.sort()).toEqual(['README.md', 'docs/Guide.MDX'])
+    } finally {
+      await rm(rootPath, { recursive: true, force: true })
+    }
+  })
+
+  it('filters a large non-Markdown repository before applying document retention limits', async () => {
+    const nonMarkdown = Array.from({ length: 100_001 }, (_value, index) => `src/${index}.ts\0`)
+    const output = Buffer.from(`${nonMarkdown.join('')}README.md\0docs/GUIDE.MDX\0`)
+    const spawnProcess = vi.fn((_args: string[]) => successfulChild(output))
+
+    await expect(listMarkdownPathsWithRg('/repo', undefined, spawnProcess)).resolves.toEqual([
+      'README.md',
+      'docs/GUIDE.MDX'
+    ])
+    expect(spawnProcess).toHaveBeenCalledTimes(2)
+    expect(spawnProcess.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining(['--iglob', '*.md', '--null'])
+    )
+  })
+
+  it('rejects rather than truncating the first document beyond the count limit', async () => {
+    const output = Buffer.from(
+      Array.from(
+        { length: MARKDOWN_DOCUMENT_LISTING_MAX_DOCUMENTS + 1 },
+        (_value, index) => `${index}.md\0`
+      ).join('')
+    )
+    const children: ChildProcess[] = []
+    const spawnProcess = vi.fn(() => {
+      const child = successfulChild(output)
+      children.push(child)
+      return child
+    })
+
+    await expect(listMarkdownPathsWithRg('/repo', undefined, spawnProcess)).rejects.toBeInstanceOf(
+      MarkdownDocumentListingCapacityError
+    )
+    expect(children[0]?.kill).toHaveBeenCalled()
+    expect(spawnProcess).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds an unterminated subprocess path before decoding or retaining it', async () => {
+    const child = successfulChild(Buffer.alloc(MARKDOWN_DOCUMENT_LISTING_MAX_PATH_BYTES + 1, 0x61))
+
+    await expect(listMarkdownPathsWithRg('/repo', undefined, () => child)).rejects.toBeInstanceOf(
+      MarkdownDocumentListingCapacityError
+    )
+    expect(child.kill).toHaveBeenCalled()
+  })
+})

--- a/src/relay/markdown-document-listing.ts
+++ b/src/relay/markdown-document-listing.ts
@@ -1,0 +1,238 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { checkRgAvailable } from './fs-handler-utils'
+import {
+  buildRgArgsForQuickOpen,
+  normalizeQuickOpenRgLine,
+  shouldIncludeQuickOpenPath
+} from '../shared/quick-open-filter'
+import {
+  assertMarkdownDocumentPathWithinLimit,
+  createMarkdownDocumentListingBudget,
+  isMarkdownDocumentListingCapacityError,
+  MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE,
+  MARKDOWN_DOCUMENT_LISTING_MAX_PATH_BYTES,
+  MarkdownDocumentListingCapacityError,
+  retainMarkdownRelativePath,
+  visitMarkdownDocumentListingEntry
+} from '../shared/markdown-document-listing-limits'
+import {
+  discoverMarkdownRelativePaths,
+  isMarkdownDocumentPath
+} from '../shared/node-markdown-document-discovery'
+import { fileListingCancellationError } from '../shared/file-listing-cancellation'
+import { RelayErrorCode } from './protocol'
+import { GrowingByteBuffer } from '../shared/growing-byte-buffer'
+
+const MARKDOWN_LISTING_TIMEOUT_MS = 25_000
+const MARKDOWN_GLOBS = ['*.md', '*.mdx', '*.markdown']
+
+class MarkdownPathFieldAccumulator {
+  private readonly field = new GrowingByteBuffer()
+
+  push(chunk: Buffer, onPath: (path: string) => void): boolean {
+    let cursor = 0
+    while (cursor < chunk.length) {
+      const delimiter = chunk.indexOf(0, cursor)
+      const end = delimiter === -1 ? chunk.length : delimiter
+      const segmentBytes = end - cursor
+      if (this.field.byteLength + segmentBytes > MARKDOWN_DOCUMENT_LISTING_MAX_PATH_BYTES) {
+        this.clear()
+        return false
+      }
+      if (delimiter !== -1 && this.field.byteLength === 0) {
+        onPath(chunk.toString('utf8', cursor, end))
+      } else if (segmentBytes > 0) {
+        this.field.append(chunk.subarray(cursor, end))
+        if (delimiter !== -1) {
+          onPath(this.take())
+        }
+      } else if (delimiter !== -1) {
+        onPath(this.take())
+      }
+      if (delimiter === -1) {
+        return true
+      }
+      cursor = delimiter + 1
+    }
+    return true
+  }
+
+  finish(): string | null {
+    return this.field.byteLength > 0 ? this.take() : null
+  }
+
+  private take(): string {
+    return this.field.takeString()
+  }
+
+  private clear(): void {
+    this.field.clear()
+  }
+}
+
+function markdownRgArgs(args: string[]): string[] {
+  const target = args.at(-1)
+  if (!target) {
+    throw new Error('Markdown rg scan is missing its search root')
+  }
+  const result = [...args.slice(0, -1), '--null']
+  for (const glob of MARKDOWN_GLOBS) {
+    result.push('--iglob', glob)
+  }
+  result.push(target)
+  return result
+}
+
+function relativePathDepth(path: string): number {
+  let depth = 0
+  for (let index = 0; index < path.length; index += 1) {
+    if (path[index] === '/') {
+      depth += 1
+    }
+  }
+  return depth
+}
+
+export async function listMarkdownPathsWithRg(
+  rootPath: string,
+  signal?: AbortSignal,
+  spawnProcess: (args: string[]) => ChildProcess = (args) =>
+    spawn('rg', args, { cwd: rootPath, stdio: ['ignore', 'pipe', 'pipe'] })
+): Promise<string[]> {
+  const paths = new Set<string>()
+  const budget = createMarkdownDocumentListingBudget()
+  assertMarkdownDocumentPathWithinLimit(rootPath, budget.limits.maxPathBytes)
+  const passes = buildRgArgsForQuickOpen({
+    searchRoot: '.',
+    excludePathPrefixes: [],
+    forceSlashSeparator: true
+  })
+
+  const runPass = (args: string[]): Promise<void> =>
+    new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(fileListingCancellationError(signal))
+        return
+      }
+      const child = spawnProcess(markdownRgArgs(args))
+      const fields = new MarkdownPathFieldAccumulator()
+      let done = false
+      let parseablePathCount = 0
+      let timer: ReturnType<typeof setTimeout> | null = null
+
+      const cleanup = (): void => {
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        child.stdout?.off('data', onStdout)
+        child.stderr?.off('data', onStderr)
+        child.off('error', onError)
+        child.off('close', onClose)
+        signal?.removeEventListener('abort', onAbort)
+      }
+      const finish = (error?: Error, kill = false): void => {
+        if (done) {
+          return
+        }
+        done = true
+        cleanup()
+        if (kill && child.exitCode === null && child.signalCode === null) {
+          child.kill()
+        }
+        if (error) {
+          reject(error)
+        } else {
+          resolve()
+        }
+      }
+      const processPath = (rawPath: string): void => {
+        const relativePath = normalizeQuickOpenRgLine(rawPath, { kind: 'cwd-relative' })
+        if (relativePath === null) {
+          return
+        }
+        parseablePathCount += 1
+        if (
+          paths.has(relativePath) ||
+          !shouldIncludeQuickOpenPath(relativePath) ||
+          !isMarkdownDocumentPath(relativePath)
+        ) {
+          return
+        }
+        visitMarkdownDocumentListingEntry(budget, relativePath, relativePathDepth(relativePath))
+        retainMarkdownRelativePath(budget, rootPath, relativePath)
+        paths.add(relativePath)
+      }
+      const onStdout = (chunk: Buffer): void => {
+        try {
+          if (!fields.push(chunk, processPath)) {
+            finish(new MarkdownDocumentListingCapacityError(), true)
+          }
+        } catch (error) {
+          finish(error instanceof Error ? error : new Error(String(error)), true)
+        }
+      }
+      const onStderr = (): void => {}
+      const onError = (error: Error): void => finish(error)
+      const onClose = (code: number | null, exitSignal: NodeJS.Signals | null): void => {
+        if (exitSignal) {
+          finish(new Error(`rg killed by ${exitSignal}`))
+          return
+        }
+        try {
+          const trailingPath = fields.finish()
+          if (trailingPath !== null) {
+            processPath(trailingPath)
+          }
+        } catch (error) {
+          finish(error instanceof Error ? error : new Error(String(error)))
+          return
+        }
+        if (code === 0 || code === 1 || (code === 2 && parseablePathCount > 0)) {
+          finish()
+        } else {
+          finish(new Error(`rg exited with code ${code}`))
+        }
+      }
+      const onAbort = (): void => finish(fileListingCancellationError(signal), true)
+
+      child.stdout?.on('data', onStdout)
+      child.stderr?.on('data', onStderr)
+      child.once('error', onError)
+      child.once('close', onClose)
+      signal?.addEventListener('abort', onAbort, { once: true })
+      timer = setTimeout(
+        () => finish(new Error('Markdown document listing timed out'), true),
+        MARKDOWN_LISTING_TIMEOUT_MS
+      )
+    })
+
+  await runPass(passes.primary)
+  await runPass(passes.ignoredPass)
+  return Array.from(paths)
+}
+
+export async function listRelayMarkdownDocumentPaths(
+  rootPath: string,
+  signal?: AbortSignal
+): Promise<string[]> {
+  try {
+    if (await checkRgAvailable()) {
+      return await listMarkdownPathsWithRg(rootPath, signal)
+    }
+    return await discoverMarkdownRelativePaths(rootPath, {
+      ignoreNestedDirectoryErrors: true,
+      shouldDescend: (relativePath) => shouldIncludeQuickOpenPath(relativePath),
+      signal
+    })
+  } catch (error) {
+    if (!isMarkdownDocumentListingCapacityError(error)) {
+      throw error
+    }
+    const relayError = new Error(MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE) as Error & {
+      code: number
+    }
+    relayError.code = RelayErrorCode.MarkdownDocumentListingCapacity
+    throw relayError
+  }
+}

--- a/src/relay/mobile-file-directory-reader.test.ts
+++ b/src/relay/mobile-file-directory-reader.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { statMock } = vi.hoisted(() => ({ statMock: vi.fn() }))
+
+vi.mock('node:fs/promises', () => ({ opendir: vi.fn(), stat: statMock }))
+
+import { collectMobileRelayDirectoryEntries } from './mobile-file-directory-reader'
+
+describe('mobile relay directory reader', () => {
+  it('stops enumeration at the mobile entry limit', async () => {
+    let enumerated = 0
+    const directory = {
+      async *[Symbol.asyncIterator]() {
+        while (enumerated < 20_000) {
+          enumerated += 1
+          yield {
+            name: 'entry',
+            isDirectory: () => false,
+            isSymbolicLink: () => false
+          }
+        }
+      }
+    }
+
+    await expect(collectMobileRelayDirectoryEntries('/repo', directory)).rejects.toThrow(
+      'This folder is too large to show safely on mobile'
+    )
+    expect(enumerated).toBe(10_001)
+  })
+
+  it('bounds concurrent symlink stat work while preserving entry order', async () => {
+    let active = 0
+    let maxActive = 0
+    statMock.mockImplementation(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      active -= 1
+      return { isDirectory: () => true }
+    })
+    const directory = {
+      async *[Symbol.asyncIterator]() {
+        for (let index = 0; index < 100; index += 1) {
+          yield {
+            name: `link-${index}`,
+            isDirectory: () => false,
+            isSymbolicLink: () => true
+          }
+        }
+      }
+    }
+
+    const entries = await collectMobileRelayDirectoryEntries('/repo', directory)
+
+    expect(maxActive).toBe(32)
+    expect(entries.map((entry) => entry.name)).toEqual(
+      Array.from({ length: 100 }, (_, index) => `link-${index}`)
+    )
+    expect(entries.every((entry) => entry.isDirectory && entry.isSymlink)).toBe(true)
+  })
+})

--- a/src/relay/mobile-file-directory-reader.ts
+++ b/src/relay/mobile-file-directory-reader.ts
@@ -1,0 +1,76 @@
+import { opendir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  createMobileFileDirectoryLimitState,
+  trackMobileFileDirectoryEntry
+} from '../shared/mobile-file-directory-limit'
+
+type RelayDirectorySourceEntry = {
+  name: string
+  isDirectory(): boolean
+  isSymbolicLink(): boolean
+}
+
+export type RelayDirectoryEntry = {
+  name: string
+  isDirectory: boolean
+  isSymlink: boolean
+}
+
+const MOBILE_DIRECTORY_STAT_CONCURRENCY = 32
+
+export async function isRelayDirectoryEntry(
+  dirPath: string,
+  entry: RelayDirectorySourceEntry
+): Promise<boolean> {
+  if (entry.isDirectory()) {
+    return true
+  }
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  try {
+    // Why: linked workspace directories must remain expandable in the file explorer.
+    return (await stat(join(dirPath, entry.name))).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+export async function readMobileRelayDirectory(dirPath: string): Promise<RelayDirectoryEntry[]> {
+  return collectMobileRelayDirectoryEntries(dirPath, await opendir(dirPath))
+}
+
+export async function collectMobileRelayDirectoryEntries(
+  dirPath: string,
+  directory: AsyncIterable<RelayDirectorySourceEntry>
+): Promise<RelayDirectoryEntry[]> {
+  const entries: RelayDirectoryEntry[] = []
+  let batch: RelayDirectorySourceEntry[] = []
+  const limit = createMobileFileDirectoryLimitState()
+
+  const flushBatch = async (): Promise<void> => {
+    entries.push(
+      ...(await Promise.all(
+        batch.map(async (entry) => ({
+          name: entry.name,
+          isDirectory: await isRelayDirectoryEntry(dirPath, entry),
+          isSymlink: entry.isSymbolicLink()
+        }))
+      ))
+    )
+    batch = []
+  }
+
+  for await (const entry of directory) {
+    trackMobileFileDirectoryEntry(limit, entry)
+    batch.push(entry)
+    if (batch.length === MOBILE_DIRECTORY_STAT_CONCURRENCY) {
+      await flushBatch()
+    }
+  }
+  if (batch.length > 0) {
+    await flushBatch()
+  }
+  return entries
+}

--- a/src/relay/plugin-overlay.test.ts
+++ b/src/relay/plugin-overlay.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,
   mkdirSync,
@@ -11,6 +11,7 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
+import * as configOverlayMirroring from '../main/pty/config-overlay-mirroring'
 import { PluginOverlayManager } from './plugin-overlay'
 import { resolvePiSourceAgentDir } from './plugin-overlay-env'
 
@@ -68,6 +69,30 @@ describe('PluginOverlayManager', () => {
     manager.setSources({ opencodePluginSource: 'orca plugin' })
 
     expect(manager.materializeOpenCode('tab-missing:0', join(homeDir, 'missing'))).toBeNull()
+  })
+
+  it('rejects an over-capacity remote config before replacing the last good overlay', () => {
+    manager.setSources({ opencodePluginSource: 'first plugin' })
+    const overlayDir = manager.materializeOpenCode('tab-capacity:0')!
+    const pluginPath = join(overlayDir, 'plugins', 'orca-opencode-status.js')
+    const userConfigDir = join(homeDir, 'large-opencode-config')
+    mkdirSync(userConfigDir)
+    const planSpy = vi
+      .spyOn(configOverlayMirroring, 'createConfigOverlayPlan')
+      .mockImplementation(() => {
+        throw new configOverlayMirroring.ConfigOverlayCapacityError('entries', 4_097, 4_096)
+      })
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+    try {
+      expect(manager.materializeOpenCode('tab-capacity:0', userConfigDir)).toBeNull()
+      expect(readFileSync(pluginPath, 'utf8')).toBe('first plugin')
+      expect(stderrSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Agent config overlay entries exceeded its 4096 limit')
+      )
+    } finally {
+      planSpy.mockRestore()
+      stderrSpy.mockRestore()
+    }
   })
 
   it('installs Pi extension into the real agent extensions dir', () => {

--- a/src/relay/plugin-overlay.ts
+++ b/src/relay/plugin-overlay.ts
@@ -17,19 +17,19 @@
 // Pi/OMP homes for those agents.
 
 import { createHash } from 'node:crypto'
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  realpathSync,
-  statSync,
-  unlinkSync,
-  writeFileSync
-} from 'node:fs'
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { mirrorEntry, safeRemoveOverlay } from '../main/pty/overlay-mirror'
+import {
+  applyConfigOverlayPlan,
+  createConfigOverlayPlan,
+  type ConfigOverlayPlan
+} from '../main/pty/config-overlay-mirroring'
+import { safeRemoveOverlay } from '../main/pty/overlay-mirror'
+import {
+  isManagedPiExtensionFile,
+  withOrcaManagedPiExtensionMarker
+} from '../main/pi/managed-extension-ownership'
 import type { PiAgentKind } from '../shared/pi-agent-kind'
 
 const RELAY_HOOKS_DIR = '.orca-relay'
@@ -41,13 +41,6 @@ const PI_OVERLAY_SUBDIR_BY_KIND: Record<PiAgentKind, string> = {
 const OPENCODE_PLUGIN_FILE = 'orca-opencode-status.js'
 const PI_EXTENSION_FILE = 'orca-agent-status.ts'
 const PI_AGENT_SUBDIR = 'agent'
-const ORCA_MANAGED_EXTENSION_MARKER = '@orca-managed-pi-extension'
-
-function withOrcaManagedPiExtensionMarker(source: string): string {
-  return source.includes(ORCA_MANAGED_EXTENSION_MARKER)
-    ? source
-    : `// ${ORCA_MANAGED_EXTENSION_MARKER}\n${source}`
-}
 // Why: source-dir resolution is keyed off the launching agent (Pi or OMP).
 // Both consume `PI_CODING_AGENT_DIR` but default to different `~/.<kind>/agent`
 // paths on the remote disk. The renderer-chosen launch command flows in via
@@ -137,50 +130,16 @@ export class PluginOverlayManager {
     return this.piExtensionSources[kind] ?? this.piExtensionSources.pi
   }
 
-  private mirrorOpenCodeConfig(sourceDir: string, overlayDir: string): void {
-    for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
-      const sourcePath = join(sourceDir, entry.name)
-
-      if (entry.name === 'plugins') {
-        const isSymlink = entry.isSymbolicLink()
-        let isLinkPointingToDir = false
-        if (isSymlink) {
-          try {
-            isLinkPointingToDir = statSync(sourcePath).isDirectory()
-          } catch {
-            isLinkPointingToDir = false
-          }
-        }
-
-        if ((!isSymlink && entry.isDirectory()) || isLinkPointingToDir) {
-          const resolvedSource = isLinkPointingToDir ? realpathSync(sourcePath) : sourcePath
-          const overlayPluginsDir = join(overlayDir, 'plugins')
-          mkdirSync(overlayPluginsDir, { recursive: true })
-          for (const pluginEntry of readdirSync(resolvedSource, { withFileTypes: true })) {
-            if (pluginEntry.name === OPENCODE_PLUGIN_FILE) {
-              continue
-            }
-            mirrorEntry(
-              join(resolvedSource, pluginEntry.name),
-              join(overlayPluginsDir, pluginEntry.name)
-            )
-          }
-          continue
-        }
-      }
-
-      mirrorEntry(sourcePath, join(overlayDir, entry.name))
-    }
-  }
-
   private writeOpenCodePlugin(overlayDir: string): void {
     const pluginsDir = join(overlayDir, 'plugins')
     mkdirSync(pluginsDir, { recursive: true })
     const pluginPath = join(pluginsDir, OPENCODE_PLUGIN_FILE)
     try {
       unlinkSync(pluginPath)
-    } catch {
-      // Fresh overlay or no same-named stale symlink.
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error
+      }
     }
     writeFileSync(pluginPath, this.opencodePluginSource!)
   }
@@ -197,8 +156,7 @@ export class PluginOverlayManager {
     }
     const dir = join(this.opencodeRoot, safeDirName(id))
     try {
-      safeRemoveOverlay(dir, this.opencodeRoot)
-      mkdirSync(dir, { recursive: true })
+      let plan: ConfigOverlayPlan | null = null
       if (existingConfigDir) {
         if (!existsSync(existingConfigDir)) {
           return null
@@ -206,7 +164,16 @@ export class PluginOverlayManager {
         // Why: OPENCODE_CONFIG_DIR is a single config root. Mirror the user's
         // remote root into the overlay before adding Orca's plugin so status
         // reporting does not hide their auth, models, keybinds, or plugins.
-        this.mirrorOpenCodeConfig(existingConfigDir, dir)
+        plan = createConfigOverlayPlan(existingConfigDir, {
+          reservedPluginFile: OPENCODE_PLUGIN_FILE
+        })
+      }
+      if (!safeRemoveOverlay(dir, this.opencodeRoot)) {
+        throw new Error('OpenCode overlay cleanup exceeded its safety limits')
+      }
+      mkdirSync(dir, { recursive: true })
+      if (plan) {
+        applyConfigOverlayPlan(plan, dir)
       }
       this.writeOpenCodePlugin(dir)
       return dir
@@ -220,14 +187,6 @@ export class PluginOverlayManager {
 
   private getDefaultPiAgentDir(kind: PiAgentKind): string {
     return join(this.homeDir, PI_AGENT_HOME_DIR_NAME[kind], PI_AGENT_SUBDIR)
-  }
-
-  private canOverwritePiExtension(path: string): boolean {
-    try {
-      return readFileSync(path, 'utf8').includes(ORCA_MANAGED_EXTENSION_MARKER)
-    } catch {
-      return true
-    }
   }
 
   /** Install the Pi/OMP status extension into the remote real agent dir and
@@ -246,7 +205,7 @@ export class PluginOverlayManager {
       const extensionsDir = join(sourceAgentDir, 'extensions')
       mkdirSync(extensionsDir, { recursive: true })
       const extensionPath = join(extensionsDir, PI_EXTENSION_FILE)
-      if (!this.canOverwritePiExtension(extensionPath)) {
+      if (existsSync(extensionPath) && !isManagedPiExtensionFile(extensionPath)) {
         return null
       }
       writeFileSync(extensionPath, extensionSource)
@@ -259,10 +218,8 @@ export class PluginOverlayManager {
     }
   }
 
-  /** Drop a paneKey's overlay dirs on PTY exit. Best-effort; cleanup over a
-   *  recursive tree may fail on exotic filesystems but the worst-case
-   *  outcome is unbounded growth on a long-lived relay, which the per-pane
-   *  caches alone do not bound. */
+  /** Drop a paneKey's overlay dirs on PTY exit. Best-effort and bounded; an
+   *  exotic or pathological tree is logged and left for a later cleanup. */
   clearOverlay(id: string): void {
     if (!isUsableId(id)) {
       return
@@ -273,7 +230,11 @@ export class PluginOverlayManager {
     // safeRemoveOverlay keeps each call bounded to its own tree.
     for (const root of [this.opencodeRoot, ...Object.values(this.piRoots)]) {
       try {
-        safeRemoveOverlay(join(root, safe), root)
+        if (!safeRemoveOverlay(join(root, safe), root)) {
+          process.stderr.write(
+            `[plugin-overlay] overlay cleanup stopped at its safety limit: ${join(root, safe)}\n`
+          )
+        }
       } catch (err) {
         // Why: log the failed cleanup so a permission/IO error is observable.
         // The leak is the failure mode the per-pane cache eviction exists to

--- a/src/relay/port-scan-handler.test.ts
+++ b/src/relay/port-scan-handler.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
-import { parseHexAddress } from './port-scan-handler'
+import { LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES } from '../shared/linux-proc-port-scan-limits'
+import { parseHexAddress, parseLinuxProcListeningSockets } from './port-scan-handler'
 import { parseWindowsNetstatOutput, parseWindowsPowerShellPortRows } from './windows-port-scan'
 
 describe('parseHexAddress', () => {
@@ -65,6 +66,20 @@ describe('parseHexAddress', () => {
   it('parses port 3306 (mysql)', () => {
     const result = parseHexAddress('00000000:0CEA')
     expect(result).toEqual({ host: '0.0.0.0', port: 3306 })
+  })
+})
+
+describe('parseLinuxProcListeningSockets', () => {
+  it('caps retained listeners before inode and process scans', () => {
+    const rows = Array.from(
+      { length: LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES + 5 },
+      (_, index) =>
+        ` ${index}: 0100007F:${(index + 1).toString(16).padStart(4, '0')} 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 ${index + 1}`
+    )
+
+    expect(parseLinuxProcListeningSockets(['header', ...rows].join('\n'))).toHaveLength(
+      LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES
+    )
   })
 })
 

--- a/src/relay/port-scan-handler.ts
+++ b/src/relay/port-scan-handler.ts
@@ -1,5 +1,12 @@
-import { readFile, readdir, readlink } from 'node:fs/promises'
 import { getProcessOutputFields } from '../shared/process-output-field-scanner'
+import { mapLinuxSocketInodesToPids } from '../shared/linux-proc-socket-owner-scanner'
+import {
+  createLinuxProcTextReadBudget,
+  LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES,
+  readLinuxProcNetworkTable,
+  readLinuxProcTextWithinBudget,
+  type LinuxProcTextReadBudget
+} from '../shared/linux-proc-port-scan-limits'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import { scanWindowsListeningPorts } from './windows-port-scan'
 
@@ -43,16 +50,17 @@ export class PortScanHandler {
       this.readProcNet('/proc/net/tcp6')
     ])
 
-    const listeningSockets = [...tcp4, ...tcp6]
+    const listeningSockets = [...tcp4, ...tcp6].slice(0, LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES)
     if (listeningSockets.length === 0) {
       return []
     }
 
     const inodeSet = new Set(listeningSockets.map((s) => s.inode))
-    const inodeToPid = await this.mapInodesToPids(inodeSet)
+    const inodeToPid = await mapLinuxSocketInodesToPids(inodeSet)
 
     const seen = new Set<string>()
     const results: DetectedPort[] = []
+    const metadataBudget = createLinuxProcTextReadBudget()
     const relayPid = process.pid
     const relayParentPid = process.ppid
 
@@ -72,7 +80,7 @@ export class PortScanHandler {
         continue
       }
 
-      const processName = pid != null ? await this.getProcessName(pid) : undefined
+      const processName = pid != null ? await this.getProcessName(pid, metadataBudget) : undefined
 
       if (processName === 'sshd') {
         continue
@@ -95,109 +103,47 @@ export class PortScanHandler {
   private async readProcNet(
     path: string
   ): Promise<{ port: number; host: string; inode: number }[]> {
-    let content: string
-    try {
-      content = await readFile(path, 'utf-8')
-    } catch {
-      return []
-    }
-
-    const lines = content.split('\n')
-    const results: { port: number; host: string; inode: number }[] = []
-
-    for (let i = 1; i < lines.length; i++) {
-      const fields = getProcessOutputFields(lines[i], 10)
-      if (fields.length < 10) {
-        continue
-      }
-
-      // State field (index 3): 0A = TCP_LISTEN
-      if (fields[3] !== '0A') {
-        continue
-      }
-
-      const localAddress = fields[1]
-      const parsed = parseHexAddress(localAddress)
-      if (!parsed) {
-        continue
-      }
-
-      const inode = Number.parseInt(fields[9], 10)
-      if (Number.isNaN(inode) || inode === 0) {
-        continue
-      }
-
-      results.push({ port: parsed.port, host: parsed.host, inode })
-    }
-
-    return results
+    const content = await readLinuxProcNetworkTable(path)
+    return content === null ? [] : parseLinuxProcListeningSockets(content)
   }
 
-  private async mapInodesToPids(inodes: Set<number>): Promise<Map<number, number>> {
-    const result = new Map<number, number>()
-    if (inodes.size === 0) {
-      return result
-    }
-
-    let pids: string[]
-    try {
-      pids = (await readdir('/proc')).filter((name) => /^\d+$/.test(name))
-    } catch {
-      return result
-    }
-
-    for (const pidStr of pids) {
-      const fdDir = `/proc/${pidStr}/fd`
-      let fds: string[]
-      try {
-        fds = await readdir(fdDir)
-      } catch {
-        continue
-      }
-
-      const pid = Number.parseInt(pidStr, 10)
-
-      for (const fd of fds) {
-        let link: string
-        try {
-          link = await readlink(`${fdDir}/${fd}`)
-        } catch {
-          continue
-        }
-
-        const match = link.match(/^socket:\[(\d+)\]$/)
-        if (!match) {
-          continue
-        }
-
-        const inode = Number.parseInt(match[1], 10)
-        if (inodes.has(inode)) {
-          result.set(inode, pid)
-        }
-      }
-    }
-
-    return result
-  }
-
-  private async getProcessName(pid: number): Promise<string | undefined> {
-    try {
-      const cmdline = await readFile(`/proc/${pid}/cmdline`, 'utf-8')
-      if (!cmdline) {
-        return undefined
-      }
-
-      const exe = cmdline.split('\0')[0]
-      if (!exe) {
-        return undefined
-      }
-
-      const parts = exe.split('/')
-      return parts.at(-1)
-    } catch {
+  private async getProcessName(
+    pid: number,
+    budget: LinuxProcTextReadBudget
+  ): Promise<string | undefined> {
+    const cmdline = await readLinuxProcTextWithinBudget(`/proc/${pid}/cmdline`, budget)
+    if (!cmdline) {
       return undefined
     }
+
+    const exe = cmdline.split('\0')[0]
+    return exe ? exe.split('/').at(-1) : undefined
   }
+}
+
+export function parseLinuxProcListeningSockets(
+  content: string
+): { port: number; host: string; inode: number }[] {
+  const lines = content.split('\n')
+  const results: { port: number; host: string; inode: number }[] = []
+
+  for (let i = 1; i < lines.length; i++) {
+    const fields = getProcessOutputFields(lines[i], 10)
+    if (fields.length < 10 || fields[3] !== '0A') {
+      continue
+    }
+    const parsed = parseHexAddress(fields[1])
+    const inode = Number.parseInt(fields[9], 10)
+    if (!parsed || !Number.isFinite(inode) || inode === 0) {
+      continue
+    }
+    results.push({ port: parsed.port, host: parsed.host, inode })
+    if (results.length >= LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES) {
+      break
+    }
+  }
+
+  return results
 }
 
 // Why: /proc/net/tcp encodes addresses as hex pairs in host-byte-order.

--- a/src/relay/preflight-handler.test.ts
+++ b/src/relay/preflight-handler.test.ts
@@ -32,7 +32,8 @@ import {
   buildCommandLookupSpecs,
   hasAbsoluteCommandPath,
   isCommandOnPathForRelay,
-  PreflightHandler
+  PreflightHandler,
+  RELAY_AGENT_PATH_PROBE_CONCURRENCY
 } from './preflight-handler'
 
 function lookupArgs(command: string, mode: '-lc' | '-ilc' = '-lc'): string[] {
@@ -233,6 +234,54 @@ describe('hasAbsoluteCommandPath', () => {
 })
 
 describe('PreflightHandler', () => {
+  it.each([
+    ['at the limit', RELAY_AGENT_PATH_PROBE_CONCURRENCY],
+    ['above the limit', RELAY_AGENT_PATH_PROBE_CONCURRENCY + 1]
+  ])('bounds relay-supplied command probes %s', async (_, count) => {
+    let active = 0
+    let peak = 0
+    const releases: (() => void)[] = []
+    execFileAsyncMock.mockImplementation(async (_file, args) => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => releases.push(resolve))
+      active--
+      const command = String(args[1]).match(/command -v '([^']+)'/)?.[1] ?? 'agent'
+      return { stdout: `__ORCA_AGENT_PATH__/relay/path/${command}\n` }
+    })
+    const requestHandlers = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+    const dispatcher = {
+      onRequest: vi.fn(
+        (method: string, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+          requestHandlers.set(method, handler)
+        }
+      )
+    }
+    new PreflightHandler(dispatcher as never)
+
+    const detection = requestHandlers.get('preflight.detectAgents')!({
+      commands: Array.from({ length: count }, (_, index) => ({
+        id: `agent-${index}`,
+        cmd: `agent-${index}`
+      }))
+    })
+    await vi.waitFor(() =>
+      expect(execFileAsyncMock).toHaveBeenCalledTimes(
+        Math.min(count, RELAY_AGENT_PATH_PROBE_CONCURRENCY)
+      )
+    )
+    if (count > RELAY_AGENT_PATH_PROBE_CONCURRENCY) {
+      releases.shift()?.()
+      await vi.waitFor(() => expect(execFileAsyncMock).toHaveBeenCalledTimes(count))
+    }
+    releases.splice(0).forEach((release) => release())
+
+    await expect(detection).resolves.toMatchObject({
+      agents: expect.arrayContaining(Array.from({ length: count }, (_, index) => `agent-${index}`))
+    })
+    expect(peak).toBe(Math.min(count, RELAY_AGENT_PATH_PROBE_CONCURRENCY))
+  })
+
   it('honors required commands when reporting detected agents', async () => {
     execFileAsyncMock.mockImplementation(async (_file, args) => {
       const script = String(args[1])

--- a/src/relay/preflight-handler.ts
+++ b/src/relay/preflight-handler.ts
@@ -8,6 +8,7 @@ import { isPwshAvailable } from '../main/pwsh'
 import { isWslAvailable, listWslDistros } from '../main/wsl'
 import { isGitBashAvailable } from '../main/git-bash'
 import { buildPosixCommandPathLookupScript } from '../shared/posix-command-path-lookup'
+import { mapWithConcurrency } from '../shared/map-with-concurrency'
 
 const execFileAsync = promisify(execFile)
 
@@ -35,6 +36,7 @@ type AgentDetectionCommand = {
 const SUPPORTED_POSIX_SHELLS = new Set(['sh', 'dash', 'bash', 'zsh', 'fish'])
 const CONSERVATIVE_SYSTEM_SHELL_DIRS = new Set(['/bin', '/usr/bin'])
 const AGENT_PATH_PREFIX = '__ORCA_AGENT_PATH__'
+export const RELAY_AGENT_PATH_PROBE_CONCURRENCY = 8
 
 export class PreflightHandler {
   private dispatcher: RelayDispatcher
@@ -67,11 +69,13 @@ export class PreflightHandler {
       )
     ]
 
-    const results = await Promise.all(
-      probeCommands.map(async (cmd) => ({
+    const results = await mapWithConcurrency(
+      probeCommands,
+      RELAY_AGENT_PATH_PROBE_CONCURRENCY,
+      async (cmd) => ({
         cmd,
         installed: await this.isCommandOnPath(cmd)
-      }))
+      })
     )
     const foundCommands = new Set(
       results.filter((result) => result.installed).map(({ cmd }) => cmd)

--- a/src/relay/protocol-handshake.test.ts
+++ b/src/relay/protocol-handshake.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   MessageType,
   HEADER_LENGTH,
+  MAX_BUFFERED_FRAME_CHUNKS,
   FrameDecoder,
   encodeHandshakeFrame,
   parseHandshakeMessage,
@@ -9,6 +10,45 @@ import {
 } from './protocol'
 
 describe('handshake framing', () => {
+  it('bounds retained chunk wrappers for a byte-fragmented frame', () => {
+    const frames: DecodedFrame[] = []
+    const decoder = new FrameDecoder((frame) => frames.push(frame))
+    const payloadLength = MAX_BUFFERED_FRAME_CHUNKS + 512
+    const header = Buffer.alloc(HEADER_LENGTH)
+    header[0] = MessageType.Regular
+    header.writeUInt32BE(payloadLength, 9)
+    decoder.feed(header)
+
+    const byte = Buffer.from('x')
+    const state = decoder as unknown as { chunks: Buffer[] }
+    for (let index = 0; index < payloadLength; index += 1) {
+      decoder.feed(byte)
+      expect(state.chunks.length).toBeLessThanOrEqual(MAX_BUFFERED_FRAME_CHUNKS)
+    }
+
+    expect(frames).toHaveLength(1)
+    expect(frames[0].payload.equals(Buffer.alloc(payloadLength, 0x78))).toBe(true)
+  })
+
+  it('does not coalesce ordinary transport chunks while a frame is incomplete', () => {
+    const decoder = new FrameDecoder(() => {})
+    const header = Buffer.alloc(HEADER_LENGTH)
+    header[0] = MessageType.Regular
+    header.writeUInt32BE(1024 * 1024, 9)
+    decoder.feed(header)
+    const ordinaryChunks = Array.from({ length: 16 }, () => Buffer.alloc(32 * 1024))
+
+    for (const chunk of ordinaryChunks) {
+      decoder.feed(chunk)
+    }
+
+    const state = decoder as unknown as { chunks: Buffer[] }
+    expect(state.chunks).toHaveLength(ordinaryChunks.length + 1)
+    for (const [index, chunk] of ordinaryChunks.entries()) {
+      expect(state.chunks[index + 1]).toBe(chunk)
+    }
+  })
+
   it('round-trips an orca-relay-handshake envelope through the existing framing', () => {
     const sent = encodeHandshakeFrame({
       type: 'orca-relay-handshake',
@@ -64,5 +104,32 @@ describe('handshake framing', () => {
   it('handshake frames use a distinct MessageType from Regular and KeepAlive', () => {
     expect(MessageType.Handshake).not.toBe(MessageType.Regular)
     expect(MessageType.Handshake).not.toBe(MessageType.KeepAlive)
+  })
+
+  it('stream-discards an oversized payload instead of buffering toward its advertised size', () => {
+    const errors: Error[] = []
+    const decoder = new FrameDecoder(
+      () => {},
+      (error) => errors.push(error)
+    )
+    const header = Buffer.alloc(HEADER_LENGTH)
+    header[0] = MessageType.Regular
+    header.writeUInt32BE(0xffffffff, 9)
+
+    decoder.feed(header)
+    const state = decoder as unknown as {
+      bufferedLength: number
+      oversizedPayloadBytesRemaining: number
+    }
+    expect(errors).toHaveLength(1)
+    expect(state.bufferedLength).toBe(0)
+
+    const payloadChunk = Buffer.alloc(64 * 1024)
+    for (let index = 0; index < 128; index += 1) {
+      decoder.feed(payloadChunk)
+      expect(state.bufferedLength).toBe(0)
+    }
+    expect(state.oversizedPayloadBytesRemaining).toBe(0xffffffff - 128 * payloadChunk.length)
+    expect(errors).toHaveLength(1)
   })
 })

--- a/src/relay/protocol-json-encoding-memory.test.ts
+++ b/src/relay/protocol-json-encoding-memory.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  encodeJsonRpcFrame,
+  HEADER_LENGTH,
+  MAX_MESSAGE_SIZE,
+  parseJsonRpcMessage
+} from './protocol'
+import { RELAY_JSON_MAX_STRUCTURAL_TOKENS } from '../shared/relay-json-admission'
+
+describe('relay JSON frame encoding memory', () => {
+  it('preserves accepted JSON bytes', () => {
+    const message = {
+      jsonrpc: '2.0' as const,
+      id: 1,
+      result: { escaped: 'line\n🐋', omitted: undefined }
+    }
+
+    const frame = encodeJsonRpcFrame(message, 7, 3)
+
+    expect(frame.subarray(HEADER_LENGTH).toString('utf8')).toBe(JSON.stringify(message))
+  })
+
+  it('rejects an oversized message before allocating its payload Buffer', () => {
+    const message = {
+      jsonrpc: '2.0' as const,
+      id: 1,
+      result: '\n'.repeat(MAX_MESSAGE_SIZE)
+    }
+    const fromSpy = vi.spyOn(Buffer, 'from')
+
+    try {
+      expect(() => encodeJsonRpcFrame(message, 1, 0)).toThrow('Message too large')
+      expect(fromSpy).not.toHaveBeenCalled()
+    } finally {
+      fromSpy.mockRestore()
+    }
+  })
+
+  it('rejects structurally amplified inbound JSON before parsing', () => {
+    const payload = Buffer.from(
+      `{"jsonrpc":"2.0","id":1,"method":"x","params":{"values":[${'0,'.repeat(
+        RELAY_JSON_MAX_STRUCTURAL_TOKENS
+      )}0]}}`
+    )
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    try {
+      expect(() => parseJsonRpcMessage(payload)).toThrow(/JSON structure exceeds/)
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
+  })
+})

--- a/src/relay/protocol.ts
+++ b/src/relay/protocol.ts
@@ -1,11 +1,19 @@
 // Self-contained relay protocol — mirrors src/main/ssh/relay-protocol.ts
 // but has no Electron dependencies. Deployed standalone to remote hosts.
 
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../shared/node-bounded-json-stringify'
+import { parseRelayJsonText } from '../shared/relay-json-admission'
+
 export const RELAY_VERSION = '0.1.0'
 export const RELAY_SENTINEL = `ORCA-RELAY v${RELAY_VERSION} READY\n`
 
 export const HEADER_LENGTH = 13
 export const MAX_MESSAGE_SIZE = 16 * 1024 * 1024
+export const MAX_BUFFERED_FRAME_CHUNKS = 4_096
+const MAX_COALESCED_TINY_FRAME_CHUNK_BYTES = 8 * 1024
 
 export const MessageType = {
   Regular: 1,
@@ -28,7 +36,7 @@ export function encodeHandshakeFrame(msg: HandshakeMessage): Buffer {
 }
 
 export function parseHandshakeMessage(payload: Buffer): HandshakeMessage {
-  const msg = JSON.parse(payload.toString('utf-8')) as HandshakeMessage
+  const msg = parseRelayJsonText<HandshakeMessage>(payload.toString('utf-8'))
   const t = (msg as { type?: string }).type
   if (
     t !== 'orca-relay-handshake' &&
@@ -73,6 +81,11 @@ export const GIT_RESPONSE_STREAM_THRESHOLD = 256 * 1024
  * the client reassembles by concatenation (it does not depend on chunk size). */
 export const GIT_RESPONSE_CHUNK_SIZE = 128 * 1024
 
+/** Bounds retained serialized Git results while preserving responses far above
+ * the per-file render limit and git.exec's output ceiling. */
+export const MAX_GIT_RESPONSE_STREAM_BYTES = 64 * 1024 * 1024
+export const MAX_GIT_RESPONSE_STREAM_CHUNKS = 4_096
+
 /** Sentinel result returned in place of a large git response: the real payload
  * follows as git.responseChunk frames on the bulk lane. Old relays never emit
  * this, so a new client falls back to the plain result they return. */
@@ -82,7 +95,8 @@ export type GitResponseStreamMarker = {
 
 export const RelayErrorCode = {
   TooManyStreams: -33006,
-  StreamProtocolError: -33007
+  StreamProtocolError: -33007,
+  MarkdownDocumentListingCapacity: -33008
 } as const
 
 export type JsonRpcRequest = {
@@ -129,10 +143,16 @@ export function encodeFrame(
 }
 
 export function encodeJsonRpcFrame(msg: JsonRpcMessage, id: number, ack: number): Buffer {
-  const payload = Buffer.from(JSON.stringify(msg), 'utf-8')
-  if (payload.length > MAX_MESSAGE_SIZE) {
-    throw new Error(`Message too large: ${payload.length} bytes`)
+  let serialized: string
+  try {
+    serialized = stringifyJsonWithinByteLimit(msg, MAX_MESSAGE_SIZE).serialized
+  } catch (error) {
+    if (error instanceof JsonStringifyByteLimitError) {
+      throw new Error(`Message too large: more than ${MAX_MESSAGE_SIZE} bytes`)
+    }
+    throw error
   }
+  const payload = Buffer.from(serialized, 'utf-8')
   return encodeFrame(MessageType.Regular, id, ack, payload)
 }
 
@@ -147,6 +167,7 @@ export class FrameDecoder {
   // frame exactly once instead.
   private chunks: Buffer[] = []
   private bufferedLength = 0
+  private oversizedPayloadBytesRemaining = 0
   private onFrame: (frame: DecodedFrame) => void
   private onError: ((err: Error) => void) | null
 
@@ -156,12 +177,18 @@ export class FrameDecoder {
   }
 
   feed(chunk: Buffer | Uint8Array): void {
-    const buf = Buffer.isBuffer(chunk)
+    let buf = Buffer.isBuffer(chunk)
       ? chunk
       : Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+    if (this.oversizedPayloadBytesRemaining > 0 && buf.length > 0) {
+      const discarded = Math.min(this.oversizedPayloadBytesRemaining, buf.length)
+      this.oversizedPayloadBytesRemaining -= discarded
+      buf = buf.subarray(discarded)
+    }
     if (buf.length > 0) {
       this.chunks.push(buf)
       this.bufferedLength += buf.length
+      this.coalesceBufferedChunks()
     }
 
     while (this.bufferedLength >= HEADER_LENGTH) {
@@ -169,26 +196,26 @@ export class FrameDecoder {
       const length = header.readUInt32BE(9)
       const totalLength = HEADER_LENGTH + length
 
-      if (this.bufferedLength < totalLength) {
-        // Not fully received yet (also holds oversized frames until they can
-        // be skipped whole, keeping the decoder synchronized).
-        break
-      }
-
       if (length > MAX_MESSAGE_SIZE) {
-        // Why: Throwing here would leave the buffer in a partially consumed
-        // state — subsequent feed() calls would try to parse the leftover
-        // payload bytes as a new header, corrupting every future frame.
-        // Instead we skip the entire oversized frame so the decoder stays
-        // synchronized with the stream.
-        this.discardBytes(totalLength)
+        // Why: retain only the header, then stream-discard the advertised
+        // payload so a 13-byte malicious header cannot pin up to 4 GiB.
+        this.discardBytes(HEADER_LENGTH)
+        this.oversizedPayloadBytesRemaining = length
+        this.discardBufferedOversizedPayload()
         const err = new Error(`Frame payload too large: ${length} bytes — discarded`)
         if (this.onError) {
           this.onError(err)
         } else {
           process.stderr.write(`[relay] ${err.message}\n`)
         }
+        if (this.oversizedPayloadBytesRemaining > 0) {
+          break
+        }
         continue
+      }
+
+      if (this.bufferedLength < totalLength) {
+        break
       }
 
       const framed = this.takeBytes(totalLength)
@@ -205,6 +232,7 @@ export class FrameDecoder {
   reset(): void {
     this.chunks = []
     this.bufferedLength = 0
+    this.oversizedPayloadBytesRemaining = 0
   }
 
   // Why: at the handshake → dispatcher transition, the next consumer must
@@ -280,11 +308,37 @@ export class FrameDecoder {
     }
     this.bufferedLength -= count
   }
+
+  private discardBufferedOversizedPayload(): void {
+    const discarded = Math.min(this.oversizedPayloadBytesRemaining, this.bufferedLength)
+    if (discarded === 0) {
+      return
+    }
+    this.discardBytes(discarded)
+    this.oversizedPayloadBytesRemaining -= discarded
+  }
+
+  private coalesceBufferedChunks(): void {
+    // Why: merge adversarial tiny fragments without copying ordinary transport chunks.
+    while (this.chunks.length >= 2) {
+      const right = this.chunks.at(-1)!
+      const left = this.chunks.at(-2)!
+      if (
+        left.length > right.length ||
+        left.length + right.length > MAX_COALESCED_TINY_FRAME_CHUNK_BYTES
+      ) {
+        break
+      }
+      this.chunks.splice(-2, 2, Buffer.concat([left, right], left.length + right.length))
+    }
+    if (this.chunks.length > MAX_BUFFERED_FRAME_CHUNKS) {
+      this.chunks = [Buffer.concat(this.chunks, this.bufferedLength)]
+    }
+  }
 }
 
 export function parseJsonRpcMessage(payload: Buffer): JsonRpcMessage {
-  const text = payload.toString('utf-8')
-  const msg = JSON.parse(text) as JsonRpcMessage
+  const msg = parseRelayJsonText<JsonRpcMessage>(payload.toString('utf-8'))
   if (msg.jsonrpc !== '2.0') {
     throw new Error(`Invalid JSON-RPC version: ${(msg as Record<string, unknown>).jsonrpc}`)
   }

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -11,6 +11,7 @@ import {
   SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV
 } from '../shared/setup-agent-sequencing'
 import { PTY_STARTUP_INGRESS_VERSION } from '../shared/pty-startup-ingress'
+import { MAX_TERMINAL_COLS } from '../shared/terminal-size-limits'
 
 const { mockPtySpawn, mockPtyInstance } = vi.hoisted(() => ({
   mockPtySpawn: vi.fn(),
@@ -24,7 +25,9 @@ const { mockPtySpawn, mockPtyInstance } = vi.hoisted(() => ({
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(),
-    clear: vi.fn()
+    clear: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn()
   }
 }))
 
@@ -38,9 +41,11 @@ import {
   PtyHandler,
   attachIdentityMismatches
 } from './pty-handler'
-import type { RelayDispatcher } from './dispatcher'
+import { MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES } from './pty-persistence-envelope'
+import type { RelayDispatcher, RelayNotificationWriteResult } from './dispatcher'
 
 type TestRequestContext = {
+  clientId?: number
   isStale: () => boolean
   signal?: AbortSignal
 }
@@ -50,8 +55,18 @@ function createMockDispatcher() {
     string,
     (params: Record<string, unknown>, context?: TestRequestContext) => Promise<unknown>
   >()
-  const notificationHandlers = new Map<string, (params: Record<string, unknown>) => void>()
+  const notificationHandlers = new Map<
+    string,
+    (params: Record<string, unknown>, context: TestRequestContext) => void
+  >()
   const notifications: { method: string; params?: Record<string, unknown> }[] = []
+  const targetedNotifications: {
+    clientId: number
+    method: string
+    params?: Record<string, unknown>
+  }[] = []
+  const clientDetachListeners = new Set<(clientId: number) => void>()
+  const connectedClientIds = new Set([1])
 
   const dispatcher = {
     onRequest: vi.fn(
@@ -62,33 +77,75 @@ function createMockDispatcher() {
         requestHandlers.set(method, handler)
       }
     ),
-    onNotification: vi.fn((method: string, handler: (params: Record<string, unknown>) => void) => {
-      notificationHandlers.set(method, handler)
+    onNotification: vi.fn(
+      (
+        method: string,
+        handler: (params: Record<string, unknown>, context: TestRequestContext) => void
+      ) => {
+        notificationHandlers.set(method, handler)
+      }
+    ),
+    onClientDetached: vi.fn((listener: (clientId: number) => void) => {
+      clientDetachListeners.add(listener)
+      return () => clientDetachListeners.delete(listener)
+    }),
+    connectedClientIds: vi.fn(() => Array.from(connectedClientIds)),
+    evictClient: vi.fn((clientId: number) => {
+      connectedClientIds.delete(clientId)
+      for (const listener of clientDetachListeners) {
+        listener(clientId)
+      }
     }),
     notify: vi.fn((method: string, params?: Record<string, unknown>) => {
       notifications.push({ method, params })
     }),
+    notifyClientWithBackpressure: vi.fn(
+      (
+        clientId: number,
+        method: string,
+        params?: Record<string, unknown>
+      ): RelayNotificationWriteResult => {
+        targetedNotifications.push({ clientId, method, params })
+        const { deliveryToken: _deliveryToken, ...legacyParams } = params ?? {}
+        dispatcher.notify(method, legacyParams)
+        return { delivered: true, saturated: false, drained: Promise.resolve() }
+      }
+    ),
     // Helpers for tests
     _requestHandlers: requestHandlers,
     _notificationHandlers: notificationHandlers,
     _notifications: notifications,
+    _targetedNotifications: targetedNotifications,
     async callRequest(
       method: string,
       params: Record<string, unknown> = {},
-      context?: TestRequestContext
+      context: TestRequestContext = { clientId: 1, isStale: () => false }
     ) {
       const handler = requestHandlers.get(method)
       if (!handler) {
         throw new Error(`No handler for ${method}`)
       }
+      if (typeof context?.clientId === 'number') {
+        connectedClientIds.add(context.clientId)
+      }
       return handler(params, context)
     },
-    callNotification(method: string, params: Record<string, unknown> = {}) {
+    callNotification(
+      method: string,
+      params: Record<string, unknown> = {},
+      context: TestRequestContext = { clientId: 1, isStale: () => false }
+    ) {
       const handler = notificationHandlers.get(method)
       if (!handler) {
         throw new Error(`No handler for ${method}`)
       }
-      handler(params)
+      handler(params, context)
+    },
+    emitClientDetached(clientId: number) {
+      connectedClientIds.delete(clientId)
+      for (const listener of clientDetachListeners) {
+        listener(clientId)
+      }
     }
   }
 
@@ -126,6 +183,8 @@ describe('PtyHandler', () => {
     mockPtyInstance.resize.mockReset()
     mockPtyInstance.kill.mockReset()
     mockPtyInstance.clear.mockReset()
+    mockPtyInstance.pause.mockReset()
+    mockPtyInstance.resume.mockReset()
 
     mockPtySpawn.mockReturnValue({ ...mockPtyInstance })
 
@@ -207,6 +266,13 @@ describe('PtyHandler', () => {
     expect(result).toEqual({ id: 'pty-1', incarnationId: expect.any(String) })
     expect(mockPtySpawn).toHaveBeenCalled()
     expect(handler.activePtyCount).toBe(1)
+  })
+
+  it('rejects oversized spawn dimensions before native allocation', async () => {
+    await expect(
+      dispatcher.callRequest('pty.spawn', { cols: MAX_TERMINAL_COLS + 1, rows: 24 })
+    ).rejects.toThrow(`1 through ${MAX_TERMINAL_COLS}`)
+    expect(mockPtySpawn).not.toHaveBeenCalled()
   })
 
   it("does not forward Orca's own NODE_ENV into the spawned shell", async () => {
@@ -412,6 +478,25 @@ describe('PtyHandler', () => {
     })
     expect(mockPtySpawn).toHaveBeenCalledTimes(MAX_RELAY_PTY_SESSIONS)
     expect(handler.activePtyCount).toBe(MAX_RELAY_PTY_SESSIONS)
+  })
+
+  it('rejects oversized retained spawn fields before creating a native PTY', async () => {
+    await expect(
+      dispatcher.callRequest('pty.spawn', {
+        cwd: 'x'.repeat(MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES + 1)
+      })
+    ).rejects.toThrow(`exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`)
+
+    expect(mockPtySpawn).not.toHaveBeenCalled()
+    expect(handler.activePtyCount).toBe(0)
+  })
+
+  it('bounds the requested PTY serialization id list', async () => {
+    await expect(
+      dispatcher.callRequest('pty.serialize', {
+        ids: Array.from({ length: MAX_RELAY_PTY_SESSIONS + 1 }, (_, index) => `pty-${index}`)
+      })
+    ).rejects.toThrow(`PTY persistence request exceeds ${MAX_RELAY_PTY_SESSIONS} entries`)
   })
 
   it('spawns a PTY without post-Node-18 array copy methods', async () => {
@@ -2338,7 +2423,7 @@ describe('PtyHandler', () => {
     expect(mockPtySpawn).not.toHaveBeenCalled()
   })
 
-  it('applies the physical PTY cap to untrusted revive state', async () => {
+  it('rejects untrusted revive state above the physical PTY cap transactionally', async () => {
     const state = JSON.stringify(
       Array.from({ length: MAX_RELAY_PTY_SESSIONS + 1 }, (_, index) => ({
         id: `pty-${index + 1}`,
@@ -2349,17 +2434,11 @@ describe('PtyHandler', () => {
         worktreeId: 'repo-id::/repo'
       }))
     )
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-    try {
-      await expect(dispatcher.callRequest('pty.revive', { state })).rejects.toThrow(
-        'Maximum number of PTY sessions reached (50)'
-      )
-    } finally {
-      killSpy.mockRestore()
-    }
-
-    expect(mockPtySpawn).toHaveBeenCalledTimes(MAX_RELAY_PTY_SESSIONS)
-    expect(handler.activePtyCount).toBe(MAX_RELAY_PTY_SESSIONS)
+    await expect(dispatcher.callRequest('pty.revive', { state })).rejects.toThrow(
+      `PTY persistence state exceeds ${MAX_RELAY_PTY_SESSIONS} entries`
+    )
+    expect(mockPtySpawn).not.toHaveBeenCalled()
+    expect(handler.activePtyCount).toBe(0)
   })
 
   it('deduplicates concurrent revive requests for the same physical PTY id', async () => {
@@ -2879,6 +2958,40 @@ describe('PtyHandler', () => {
     await dispose
     expect(handler.activePtyCount).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps output delivery registered when relay disposal cannot kill a live PTY', async () => {
+    let onDataCb: ((data: string) => void) | undefined
+    let rejectKill = true
+    const mockKill = vi.fn(() => {
+      if (rejectKill) {
+        throw new Error('persistent dispose kill failure')
+      }
+    })
+    mockPtySpawn.mockReturnValue({
+      ...mockPtyInstance,
+      kill: mockKill,
+      onData: vi.fn((cb: (data: string) => void) => {
+        onDataCb = cb
+      })
+    })
+
+    await dispatcher.callRequest('pty.spawn', {})
+    const dispose = handler.dispose({ waitForPhysicalExit: false })
+    const rejected = expect(dispose).rejects.toThrow('persistent dispose kill failure')
+    await vi.advanceTimersByTimeAsync(250)
+    await rejected
+
+    onDataCb?.('still alive')
+    await vi.advanceTimersByTimeAsync(8)
+    expect(dispatcher._notifications).toContainEqual({
+      method: 'pty.data',
+      params: { id: 'pty-1', data: 'still alive' }
+    })
+
+    rejectKill = false
+    await handler.dispose({ waitForPhysicalExit: false })
+    expect(handler.activePtyCount).toBe(0)
   })
 
   it('takes ownership when dispose overlaps a queued graceful force-kill retry', async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -59,6 +59,25 @@ import {
   isAgentSessionSurfaceBinding,
   type AgentSessionOwnerBinding
 } from '../shared/agent-session-host-authority'
+import { PtyOutputBroadcast } from './pty-output-broadcast'
+import {
+  assertRelayPtyPersistenceFieldWithinLimit,
+  assertRelayPtyRetainedFieldsWithinLimits,
+  parseRelayPtyPersistenceEnvelope,
+  parseRelayPtyPersistenceIds,
+  sanitizeRelayPtyEnvToDelete,
+  serializeRelayPtyPersistenceEnvelope,
+  type RelayPtyIdentity,
+  type RelayPtyPersistenceEntry
+} from './pty-persistence-envelope'
+import {
+  MAX_TERMINAL_COLS,
+  MAX_TERMINAL_ROWS,
+  normalizeTerminalSize,
+  terminalSizeAdmissionError
+} from '../shared/terminal-size-limits'
+
+export { PTY_OUTPUT_HIGH_WATER_CHARS, PTY_OUTPUT_LOW_WATER_CHARS } from './pty-output-broadcast'
 
 function isMissingNodePtyNativeBinding(error: unknown): boolean {
   return (
@@ -109,13 +128,6 @@ type RelayAgentSessionCreateResult = {
 const AGENT_SESSION_CREATE_OPERATION_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/
 const AGENT_SESSION_CREATE_OPERATION_RETENTION_MS = 24 * 60 * 60 * 1000
 const AGENT_SESSION_CREATE_OPERATION_LIMIT = 4_096
-
-type PendingPtyOutput = {
-  data: string
-  rawLength?: number
-  transformed?: boolean
-  seq?: number
-}
 
 type ManagedStartupCommand = {
   command: string
@@ -173,13 +185,9 @@ const DEFAULT_GRACE_TIME_MS = DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000
 export const IMMEDIATE_PTY_EXIT_TIMEOUT_MS = 8_000
 export const MAX_RELAY_PTY_SESSIONS = 50
 export const REPLAY_BUFFER_MAX = 100 * 1024
-const PTY_OUTPUT_BATCH_INTERVAL_MS = 8
-const PTY_OUTPUT_DRAIN_CONTINUE_MS = 1
-const PTY_OUTPUT_FLUSH_CHUNK_CHARS = 16 * 1024
-const PTY_OUTPUT_FLUSH_MAX_WRITES = 2
 const INTERACTIVE_OUTPUT_WINDOW_MS = 100
 const INTERACTIVE_OUTPUT_MAX_CHARS = 1024
-const INTERACTIVE_REDRAW_MAX_CHARS = PTY_OUTPUT_FLUSH_CHUNK_CHARS
+const INTERACTIVE_REDRAW_MAX_CHARS = 16 * 1024
 const INTERACTIVE_OUTPUT_BUDGET_CHARS = 32 * 1024
 const STARTUP_COMMAND_WRITE_DELAY_MS = 50
 const STARTUP_COMMAND_SHELL_READY_FALLBACK_MS = 1500
@@ -233,35 +241,9 @@ type PtyProcessSummary = {
   agentSessionOwners?: AgentSessionOwnerBinding[]
 }
 
-type SerializedPtyEntry = {
-  id: string
-  pid: number
-  cols: number
-  rows: number
-  cwd: string
-  paneKey?: string
-  tabId?: string
-  attachIdentity?: PtyIdentity
-  worktreeId?: string
-  terminalHandle?: string
-  explicitTerm?: string
-  envToDelete?: string[]
-  /** Optional for state serialized by relays predating the credential guard. */
-  gitCredentialPromptGuarded?: boolean
-  agentSessionOwners?: AgentSessionOwnerBinding[]
-}
-
-function sanitizeEnvToDelete(value: unknown): string[] {
-  return Array.isArray(value)
-    ? value
-        .filter((key): key is string => typeof key === 'string' && key.length > 0)
-        .slice(0, 1_024)
-    : []
-}
-
 export type PtyExitListener = (event: { id: string; paneKey?: string }) => void
 
-type PtyIdentity = { paneKey?: string; tabId?: string }
+type PtyIdentity = RelayPtyIdentity
 
 /**
  * True when a reattach's expected pane identity contradicts the target PTY's own.
@@ -292,10 +274,9 @@ export class PtyHandler {
   private ptys = new Map<string, ManagedPty>()
   private nextId = 1
   private dispatcher: RelayDispatcher
+  private readonly outputBroadcast: PtyOutputBroadcast
   private graceTimeMs: number
   private graceTimer: ReturnType<typeof setTimeout> | null = null
-  private outputFlushTimer: ReturnType<typeof setTimeout> | null = null
-  private pendingOutputByPty = new Map<string, PendingPtyOutput>()
   private lastInputAtByPty = new Map<string, number>()
   private interactiveOutputCharsByPty = new Map<string, number>()
   private pendingSpawnCount = 0
@@ -319,6 +300,7 @@ export class PtyHandler {
 
   constructor(dispatcher: RelayDispatcher, graceTimeMs = DEFAULT_GRACE_TIME_MS) {
     this.dispatcher = dispatcher
+    this.outputBroadcast = new PtyOutputBroadcast(dispatcher)
     this.graceTimeMs = graceTimeMs
     this.registerHandlers()
   }
@@ -523,6 +505,7 @@ export class PtyHandler {
   private wireAndStore(managed: ManagedPty): void {
     managed.physicalExit = new PhysicalExitTracker()
     this.ptys.set(managed.id, managed)
+    this.outputBroadcast.register(managed.id, managed.pty)
     const emitIngressData = (emission: PtyIngressEmission): void => {
       const rawLength = emission.rawEndSeq - emission.rawStartSeq
       this.appendReplayBuffer(managed, emission.data)
@@ -567,7 +550,7 @@ export class PtyHandler {
       }
       this.clearStartupCommandTimer(managed)
       this.releaseRelayIngress(managed)
-      this.flushPtyOutput(managed.id)
+      this.outputBroadcast.flushForExit(managed.id)
       this.dispatcher.notify('pty.exit', {
         id: managed.id,
         code: exitCode,
@@ -612,7 +595,7 @@ export class PtyHandler {
 
   private registerHandlers(): void {
     this.dispatcher.onRequest('pty.spawn', (p, context) => this.spawn(p, context))
-    this.dispatcher.onRequest('pty.attach', (p) => this.attach(p))
+    this.dispatcher.onRequest('pty.attach', (p, context) => this.attach(p, context))
     this.dispatcher.onRequest('pty.shutdown', (p) => this.shutdown(p))
     this.dispatcher.onRequest('pty.sendSignal', (p) => this.sendSignal(p))
     this.dispatcher.onRequest('pty.getCwd', (p) => this.getCwd(p))
@@ -638,9 +621,9 @@ export class PtyHandler {
 
     this.dispatcher.onNotification('pty.data', (p) => this.writeData(p))
     this.dispatcher.onNotification('pty.resize', (p) => this.resize(p))
-    this.dispatcher.onNotification('pty.ackData', (_p) => {
-      /* flow control ack -- not yet enforced */
-    })
+    this.dispatcher.onNotification('pty.ackData', (p, context) =>
+      this.outputBroadcast.acknowledge(p, context)
+    )
   }
 
   private isLikelyInteractiveRedraw(data: string): boolean {
@@ -686,105 +669,21 @@ export class PtyHandler {
     data: string,
     meta: { rawLength?: number; transformed?: boolean; seq?: number } = {}
   ): void {
-    const existing = this.pendingOutputByPty.get(id)
-    if (meta.transformed === true) {
-      // Why: transformed spans lack a raw-to-clean slice mapping, so they can't be folded into the output batch.
-      if (existing) {
-        this.flushPtyOutput(id)
-      }
-      this.dispatcher.notify('pty.data', { id, data, ...meta })
+    const managed = this.ptys.get(id)
+    if (!managed || managed.disposed) {
       return
     }
-    const pending: PendingPtyOutput = { data: (existing?.data ?? '') + data }
-    if (existing?.rawLength !== undefined || meta.rawLength !== undefined) {
-      pending.rawLength =
-        (existing?.rawLength ?? existing?.data.length ?? 0) + (meta.rawLength ?? data.length)
-    }
-    if (meta.seq !== undefined) {
-      pending.seq = meta.seq
-    }
-    if (this.shouldSendInteractiveOutputNow(id, pending.data)) {
-      this.pendingOutputByPty.delete(id)
-      this.clearOutputFlushTimerIfIdle()
-      // Why: send interactive echo immediately — batching must not add visible input delay for TUIs.
-      this.dispatcher.notify('pty.data', { id, ...pending })
-      return
-    }
-    this.pendingOutputByPty.set(id, pending)
-    this.scheduleOutputFlush(PTY_OUTPUT_BATCH_INTERVAL_MS)
-  }
-
-  private scheduleOutputFlush(delayMs: number): void {
-    if (this.outputFlushTimer !== null) {
-      return
-    }
-    this.outputFlushTimer = setTimeout(() => this.flushPendingOutput(), delayMs)
-  }
-
-  private flushPendingOutput(): void {
-    this.outputFlushTimer = null
-    let writes = 0
-    for (const [id, pending] of Array.from(this.pendingOutputByPty.entries())) {
-      if (writes >= PTY_OUTPUT_FLUSH_MAX_WRITES) {
-        break
-      }
-      this.pendingOutputByPty.delete(id)
-      const chunk = pending.transformed
-        ? pending.data
-        : pending.data.slice(0, PTY_OUTPUT_FLUSH_CHUNK_CHARS)
-      const remaining = pending.transformed ? '' : pending.data.slice(PTY_OUTPUT_FLUSH_CHUNK_CHARS)
-      if (remaining) {
-        this.pendingOutputByPty.set(id, {
-          data: remaining,
-          ...(pending.rawLength === undefined ? {} : { rawLength: remaining.length }),
-          seq: pending.seq
-        })
-      }
-      const chunkRawLength = pending.transformed
-        ? pending.rawLength
-        : pending.rawLength === undefined
-          ? undefined
-          : chunk.length
-      const chunkSeq =
-        pending.seq === undefined ? undefined : pending.seq - (pending.data.length - chunk.length)
-      this.dispatcher.notify('pty.data', {
-        id,
-        data: chunk,
-        ...(chunkSeq === undefined ? {} : { seq: chunkSeq }),
-        ...(chunkRawLength === undefined ? {} : { rawLength: chunkRawLength }),
-        ...(pending.transformed ? { transformed: true } : {})
-      })
-      writes++
-    }
-    if (this.pendingOutputByPty.size > 0 && writes > 0) {
-      // Why: yield between slices of a large chunk so client input and control frames can interleave.
-      this.scheduleOutputFlush(PTY_OUTPUT_DRAIN_CONTINUE_MS)
-    }
-  }
-
-  private flushPtyOutput(id: string): void {
-    const pending = this.pendingOutputByPty.get(id)
-    if (!pending) {
-      return
-    }
-    this.pendingOutputByPty.delete(id)
-    this.dispatcher.notify('pty.data', { id, ...pending })
-    this.clearOutputFlushTimerIfIdle()
-  }
-
-  private clearOutputFlushTimerIfIdle(): void {
-    if (this.pendingOutputByPty.size > 0 || this.outputFlushTimer === null) {
-      return
-    }
-    clearTimeout(this.outputFlushTimer)
-    this.outputFlushTimer = null
+    this.outputBroadcast.enqueue(
+      id,
+      { data, ...meta },
+      meta.transformed === true || this.shouldSendInteractiveOutputNow(id, data)
+    )
   }
 
   private clearPtyFlowState(id: string): void {
-    this.pendingOutputByPty.delete(id)
+    this.outputBroadcast.unregister(id)
     this.lastInputAtByPty.delete(id)
     this.interactiveOutputCharsByPty.delete(id)
-    this.clearOutputFlushTimerIfIdle()
   }
 
   private beginPtyCreation(operationPaths: readonly (string | undefined)[]): () => void {
@@ -901,9 +800,13 @@ export class PtyHandler {
     context?: RequestContext
   ): Promise<RelayAgentSessionCreateResult> {
     const env = params.env as Record<string, string> | undefined
-    const worktreeId = env?.ORCA_WORKTREE_ID
+    const worktreeId = typeof env?.ORCA_WORKTREE_ID === 'string' ? env.ORCA_WORKTREE_ID : undefined
+    if (worktreeId !== undefined) {
+      assertRelayPtyPersistenceFieldWithinLimit('worktreeId', worktreeId)
+    }
     const worktreePath = worktreeId ? splitWorktreeId(worktreeId)?.worktreePath : undefined
     const cwd = typeof params.cwd === 'string' ? params.cwd : resolveDefaultCwd()
+    assertRelayPtyPersistenceFieldWithinLimit('cwd', cwd)
     const finishCreation = this.beginPtyCreation([worktreePath, cwd])
     let physicalSpawnCommitted = false
     const markPhysicalSpawnCommitted = (): void => {
@@ -989,16 +892,21 @@ export class PtyHandler {
     context?: RequestContext,
     onPhysicalSpawnCommitted?: () => void
   ): Promise<{ id: string; incarnationId: string }> {
+    const sizeError = terminalSizeAdmissionError(params.cols, params.rows, 'pty.spawn', {
+      allowMissing: true
+    })
+    if (sizeError) {
+      throw new Error(sizeError)
+    }
     const pty = await this.loadPty()
     if (!pty) {
       throw new Error('node-pty is not available on this remote host')
     }
 
-    const cols = (params.cols as number) || 80
-    const rows = (params.rows as number) || 24
+    const { cols, rows } = normalizeTerminalSize(params.cols, params.rows)
     const cwd = (params.cwd as string) || resolveDefaultCwd()
     const env = params.env as Record<string, string> | undefined
-    const envToDelete = sanitizeEnvToDelete(params.envToDelete)
+    const envToDelete = sanitizeRelayPtyEnvToDelete(params.envToDelete)
     const explicitTerm =
       !envToDelete.includes('TERM') &&
       env &&
@@ -1021,6 +929,23 @@ export class PtyHandler {
     // Why: kept so a restarted runtime can re-adopt this PTY under its original handle (survives revive).
     const terminalHandle =
       typeof env?.ORCA_TERMINAL_HANDLE === 'string' ? env.ORCA_TERMINAL_HANDLE : undefined
+    const tabId = typeof env?.ORCA_TAB_ID === 'string' ? env.ORCA_TAB_ID : undefined
+    const attachIdentity = {
+      paneKey: typeof params.paneKey === 'string' ? params.paneKey : paneKey,
+      tabId: typeof params.tabId === 'string' ? params.tabId : tabId
+    }
+    const worktreeId = typeof env?.ORCA_WORKTREE_ID === 'string' ? env.ORCA_WORKTREE_ID : undefined
+    assertRelayPtyRetainedFieldsWithinLimits({
+      id,
+      cwd,
+      paneKey,
+      tabId,
+      attachIdentity,
+      worktreeId,
+      terminalHandle,
+      explicitTerm,
+      envToDelete
+    })
     const command = typeof params.command === 'string' ? params.command : undefined
     const terminalWindowsWslDistro =
       typeof params.terminalWindowsWslDistro === 'string' ? params.terminalWindowsWslDistro : null
@@ -1079,12 +1004,6 @@ export class PtyHandler {
     onPhysicalSpawnCommitted?.()
 
     // Why: capture paneKey so the exit listener can evict per-pane caches without a separate ptyId→paneKey map.
-    const tabId = typeof env?.ORCA_TAB_ID === 'string' ? env.ORCA_TAB_ID : undefined
-    const attachIdentity = {
-      paneKey: typeof params.paneKey === 'string' ? params.paneKey : paneKey,
-      tabId: typeof params.tabId === 'string' ? params.tabId : tabId
-    }
-    const worktreeId = typeof env?.ORCA_WORKTREE_ID === 'string' ? env.ORCA_WORKTREE_ID : undefined
     const startupIngressIntent =
       params.startupIngressVersion === PTY_STARTUP_INGRESS_VERSION
         ? parsePtyStartupIngressIntent(params.startupIngress)
@@ -1143,7 +1062,8 @@ export class PtyHandler {
   }
 
   private async attach(
-    params: Record<string, unknown>
+    params: Record<string, unknown>,
+    context?: RequestContext
   ): Promise<{ incarnationId: string; replay?: string }> {
     const id = params.id as string
     const managed = this.ptys.get(id)
@@ -1156,7 +1076,7 @@ export class PtyHandler {
     if (managed.pty.pid && !isProcessAlive(managed.pty.pid)) {
       managed.physicalExit?.markExited()
       this.releaseRelayIngress(managed)
-      this.flushPtyOutput(id)
+      this.outputBroadcast.flushForExit(id)
       this.notifyExitListener(managed)
       this.agentSessionOwners.release(managed.id)
       disposeManagedPty(managed)
@@ -1177,14 +1097,14 @@ export class PtyHandler {
       throw new Error(`PTY "${id}" not found (identity mismatch)`)
     }
 
+    if (typeof context?.clientId === 'number') {
+      this.outputBroadcast.resetClient(id, context.clientId)
+    }
     managed.startupIngress?.snapshotBarrier()
 
     // Why: renderer hasn't registered replay handlers yet during spawn, so return to the caller instead of notifying too early.
     // Why: buffer intentionally NOT cleared after replay (client clears xterm first) so later restarts still replay full history.
     if (managed.buffered) {
-      // Why: drop pending batched bytes already in the replay buffer so attach doesn't render them twice.
-      this.pendingOutputByPty.delete(id)
-      this.clearOutputFlushTimerIfIdle()
       if (params.suppressReplayNotification) {
         return { incarnationId: managed.incarnationId, replay: managed.buffered }
       }
@@ -1209,8 +1129,8 @@ export class PtyHandler {
 
   private resize(params: Record<string, unknown>): void {
     const id = params.id as string
-    const cols = Math.max(1, Math.min(500, Math.floor(Number(params.cols) || 80)))
-    const rows = Math.max(1, Math.min(500, Math.floor(Number(params.rows) || 24)))
+    const cols = Math.max(1, Math.min(MAX_TERMINAL_COLS, Math.floor(Number(params.cols) || 80)))
+    const rows = Math.max(1, Math.min(MAX_TERMINAL_ROWS, Math.floor(Number(params.rows) || 24)))
     const managed = this.ptys.get(id)
     if (managed && !managed.disposed) {
       managed.pty.resize(cols, rows)
@@ -1237,7 +1157,6 @@ export class PtyHandler {
 
     if (immediate) {
       this.releaseStartupCommand(managed)
-      this.flushPtyOutput(id)
       this.requestForceKill(managed)
       // Why: remote Git deletion must not race the child's native handles; on timeout keep the map entry so onExit/retry still owns it.
       await this.waitForPhysicalExit(managed, IMMEDIATE_PTY_EXIT_TIMEOUT_MS)
@@ -1279,6 +1198,7 @@ export class PtyHandler {
     if (managed.gracefulKillSent) {
       return
     }
+    this.outputBroadcast.flushForExit(managed.id)
     managed.gracefulKillSent = true
     if (process.platform === 'win32') {
       // Why: ConPTY's bare kill is already force-final; block any later close of the handle.
@@ -1333,6 +1253,7 @@ export class PtyHandler {
     if (managed.forceKillSent || (process.platform === 'win32' && managed.gracefulKillSent)) {
       return
     }
+    this.outputBroadcast.flushForExit(managed.id)
     managed.forceKillSent = true
     try {
       killPtyProcess(managed.pty, 'SIGKILL')
@@ -1427,8 +1348,8 @@ export class PtyHandler {
   }
 
   private async serialize(params: Record<string, unknown>): Promise<string> {
-    const ids = params.ids as string[]
-    const entries: SerializedPtyEntry[] = []
+    const ids = parseRelayPtyPersistenceIds(params.ids, MAX_RELAY_PTY_SESSIONS)
+    const entries: RelayPtyPersistenceEntry[] = []
     for (const id of ids) {
       const managed = this.ptys.get(id)
       if (!managed) {
@@ -1451,12 +1372,11 @@ export class PtyHandler {
         ...(managed.terminalHandle ? { terminalHandle: managed.terminalHandle } : {})
       })
     }
-    return JSON.stringify(entries)
+    return serializeRelayPtyPersistenceEnvelope(entries, MAX_RELAY_PTY_SESSIONS)
   }
 
   private async revive(params: Record<string, unknown>): Promise<void> {
-    const state = params.state as string
-    const entries = JSON.parse(state) as SerializedPtyEntry[]
+    const entries = parseRelayPtyPersistenceEnvelope(params.state, MAX_RELAY_PTY_SESSIONS)
 
     for (const entry of entries) {
       if (this.ptys.has(entry.id) || this.pendingReviveIds.has(entry.id)) {
@@ -1482,7 +1402,7 @@ export class PtyHandler {
     }
   }
 
-  private async reviveEntry(entry: SerializedPtyEntry): Promise<void> {
+  private async reviveEntry(entry: RelayPtyPersistenceEntry): Promise<void> {
     const ptyMod = await this.loadPty()
     if (!ptyMod) {
       return
@@ -1509,7 +1429,7 @@ export class PtyHandler {
       revivedEnv.TERM = explicitTerm
     }
     // Why: serialized state may come from an older/untrusted client; reapply fresh-spawn bounds.
-    const envToDelete = sanitizeEnvToDelete(entry.envToDelete)
+    const envToDelete = sanitizeRelayPtyEnvToDelete(entry.envToDelete)
     const shell = resolveDefaultShell()
     const spawnEnv = this.buildSpawnEnv(
       revivedEnv,
@@ -1596,16 +1516,8 @@ export class PtyHandler {
     this.cancelGraceTimer()
     await this.waitForPendingPtyCreations()
     for (const managed of this.ptys.values()) {
-      this.releaseRelayIngress(managed)
-      this.flushPtyOutput(managed.id)
+      this.outputBroadcast.flushForExit(managed.id)
     }
-    if (this.outputFlushTimer !== null) {
-      clearTimeout(this.outputFlushTimer)
-      this.outputFlushTimer = null
-    }
-    this.pendingOutputByPty.clear()
-    this.lastInputAtByPty.clear()
-    this.interactiveOutputCharsByPty.clear()
     const results = await Promise.allSettled(
       [...this.ptys.values()].map((managed) =>
         this.disposePtyForRelayShutdown(managed, waitForPhysicalExit)
@@ -1617,6 +1529,9 @@ export class PtyHandler {
     if (rejected) {
       throw rejected.reason
     }
+    this.outputBroadcast.dispose()
+    this.lastInputAtByPty.clear()
+    this.interactiveOutputCharsByPty.clear()
   }
 
   private async disposePtyForRelayShutdown(
@@ -1628,9 +1543,9 @@ export class PtyHandler {
       managed.killTimer = undefined
     }
     this.clearStartupCommandTimer(managed)
-    this.releaseRelayIngress(managed)
     // Why: retain the native owner until SIGKILL is accepted (one bounded retry) or onExit proves it gone.
     await this.requestForceKillForRelayShutdown(managed)
+    this.releaseRelayIngress(managed)
     if (waitForPhysicalExit && this.ptys.get(managed.id) === managed && !managed.disposed) {
       try {
         await this.waitForPhysicalExit(managed, IMMEDIATE_PTY_EXIT_TIMEOUT_MS)

--- a/src/relay/pty-output-broadcast.test.ts
+++ b/src/relay/pty-output-broadcast.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RelayDispatcher, RelayNotificationWriteResult } from './dispatcher'
+import { PTY_OUTPUT_HIGH_WATER_CHARS, PtyOutputBroadcast } from './pty-output-broadcast'
+
+type Delivery = {
+  clientId: number
+  data: string
+  deliveryToken: string
+}
+
+function createDispatcher(clientIds: number[]) {
+  const connected = new Set(clientIds)
+  const detachListeners = new Set<(clientId: number) => void>()
+  const deliveries: Delivery[] = []
+  const evicted: number[] = []
+  const writers = new Map<
+    number,
+    (delivery: Delivery) => RelayNotificationWriteResult | undefined
+  >()
+  const dispatcher = {
+    connectedClientIds: () => Array.from(connected),
+    onClientDetached: (listener: (clientId: number) => void) => {
+      detachListeners.add(listener)
+      return () => detachListeners.delete(listener)
+    },
+    notifyClientWithBackpressure: (
+      clientId: number,
+      _method: string,
+      params: Record<string, unknown> = {}
+    ): RelayNotificationWriteResult => {
+      const delivery = {
+        clientId,
+        data: String(params.data ?? ''),
+        deliveryToken: String(params.deliveryToken ?? '')
+      }
+      deliveries.push(delivery)
+      return (
+        writers.get(clientId)?.(delivery) ?? {
+          delivered: true,
+          saturated: false,
+          drained: Promise.resolve()
+        }
+      )
+    },
+    evictClient: (clientId: number) => {
+      if (!connected.delete(clientId)) {
+        return
+      }
+      evicted.push(clientId)
+      for (const listener of detachListeners) {
+        listener(clientId)
+      }
+    }
+  } as unknown as RelayDispatcher
+  return { dispatcher, deliveries, evicted, writers }
+}
+
+function deliveryData(deliveries: Delivery[], clientId: number): string {
+  return deliveries
+    .filter((delivery) => delivery.clientId === clientId)
+    .map((delivery) => delivery.data)
+    .join('')
+}
+
+describe('PtyOutputBroadcast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('broadcasts identical ordered output to every healthy client', async () => {
+    const { dispatcher, deliveries } = createDispatcher([1, 2])
+    const output = new PtyOutputBroadcast(dispatcher)
+    output.register('pty-1', { pause: vi.fn(), resume: vi.fn() })
+
+    output.enqueue('pty-1', { data: 'hello ' })
+    output.enqueue('pty-1', { data: 'world' })
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(deliveryData(deliveries, 1)).toBe('hello world')
+    expect(deliveryData(deliveries, 2)).toBe('hello world')
+  })
+
+  it('lets a transiently saturated client drain its exact backlog without stalling peers', async () => {
+    const { dispatcher, deliveries, writers } = createDispatcher([1, 2])
+    let signalDrain!: () => void
+    let firstWrite = true
+    writers.set(1, () => {
+      if (!firstWrite) {
+        return undefined
+      }
+      firstWrite = false
+      return {
+        delivered: true,
+        saturated: true,
+        drained: new Promise<void>((resolve) => {
+          signalDrain = resolve
+        })
+      }
+    })
+    const output = new PtyOutputBroadcast(dispatcher)
+    output.register('pty-1', { pause: vi.fn(), resume: vi.fn() })
+
+    output.enqueue('pty-1', { data: 'first' })
+    await vi.advanceTimersByTimeAsync(8)
+    output.enqueue('pty-1', { data: ' second' })
+    await vi.advanceTimersByTimeAsync(8)
+
+    expect(deliveryData(deliveries, 1)).toBe('first')
+    expect(deliveryData(deliveries, 2)).toBe('first second')
+
+    signalDrain()
+    await Promise.resolve()
+
+    expect(deliveryData(deliveries, 1)).toBe('first second')
+    expect(deliveryData(deliveries, 2)).toBe('first second')
+  })
+
+  it('evicts only a permanently slow observer at the shared backlog bound', async () => {
+    const { dispatcher, deliveries, evicted, writers } = createDispatcher([1, 2])
+    writers.set(1, () => ({
+      delivered: true,
+      saturated: true,
+      drained: new Promise<void>(() => {})
+    }))
+    const pause = vi.fn()
+    const output = new PtyOutputBroadcast(dispatcher)
+    output.register('pty-1', { pause, resume: vi.fn() })
+    const chunk = 'x'.repeat(16 * 1024)
+
+    for (let index = 0; index <= PTY_OUTPUT_HIGH_WATER_CHARS / chunk.length; index++) {
+      output.enqueue('pty-1', { data: chunk })
+      await vi.advanceTimersByTimeAsync(8)
+      const healthyDelivery = deliveries.findLast((delivery) => delivery.clientId === 2)
+      output.acknowledge(
+        {
+          id: 'pty-1',
+          charCount: chunk.length,
+          deliveryToken: healthyDelivery?.deliveryToken
+        },
+        { clientId: 2, isStale: () => false }
+      )
+    }
+
+    expect(evicted).toEqual([1])
+    expect(deliveryData(deliveries, 2)).toHaveLength(PTY_OUTPUT_HIGH_WATER_CHARS + chunk.length)
+    expect(pause).not.toHaveBeenCalled()
+
+    output.enqueue('pty-1', { data: 'tail' })
+    await vi.advanceTimersByTimeAsync(20)
+    expect(deliveryData(deliveries, 2).endsWith('tail')).toBe(true)
+  })
+
+  it('pauses all-blocked producers and rejects cross-client or stale credit', async () => {
+    const { dispatcher, deliveries } = createDispatcher([7])
+    const pause = vi.fn()
+    const resume = vi.fn()
+    const output = new PtyOutputBroadcast(dispatcher)
+    output.register('pty-1', { pause, resume })
+
+    output.enqueue('pty-1', { data: 'x'.repeat(PTY_OUTPUT_HIGH_WATER_CHARS) })
+    const deliveryToken = deliveries[0]?.deliveryToken
+
+    expect(pause).toHaveBeenCalledOnce()
+    output.acknowledge(
+      { id: 'pty-1', charCount: PTY_OUTPUT_HIGH_WATER_CHARS, deliveryToken },
+      { clientId: 8, isStale: () => false }
+    )
+    output.acknowledge(
+      { id: 'pty-1', charCount: PTY_OUTPUT_HIGH_WATER_CHARS, deliveryToken: 'stale' },
+      { clientId: 7, isStale: () => false }
+    )
+    expect(resume).not.toHaveBeenCalled()
+
+    output.acknowledge(
+      { id: 'pty-1', charCount: PTY_OUTPUT_HIGH_WATER_CHARS, deliveryToken },
+      { clientId: 7, isStale: () => false }
+    )
+    expect(resume).toHaveBeenCalledOnce()
+  })
+
+  it('rotates only the reattaching client token and preserves other observers', async () => {
+    const { dispatcher, deliveries } = createDispatcher([1, 2])
+    const output = new PtyOutputBroadcast(dispatcher)
+    output.register('pty-1', { pause: vi.fn(), resume: vi.fn() })
+
+    output.enqueue('pty-1', { data: 'before' })
+    await vi.advanceTimersByTimeAsync(20)
+    const oldOne = deliveries.find((delivery) => delivery.clientId === 1)?.deliveryToken
+    const oldTwo = deliveries.find((delivery) => delivery.clientId === 2)?.deliveryToken
+
+    output.resetClient('pty-1', 1)
+    output.enqueue('pty-1', { data: 'after' })
+    await vi.advanceTimersByTimeAsync(20)
+    const latestOne = deliveries.findLast((delivery) => delivery.clientId === 1)?.deliveryToken
+    const latestTwo = deliveries.findLast((delivery) => delivery.clientId === 2)?.deliveryToken
+
+    expect(latestOne).not.toBe(oldOne)
+    expect(latestTwo).toBe(oldTwo)
+    expect(deliveryData(deliveries, 2)).toBe('beforeafter')
+  })
+
+  it('cancels drain waiters and releases a paused producer on cleanup', async () => {
+    const { dispatcher, writers } = createDispatcher([1])
+    const cancelDrain = vi.fn()
+    writers.set(1, () => ({
+      delivered: true,
+      saturated: true,
+      drained: new Promise<void>(() => {}),
+      cancelDrain
+    }))
+    const pause = vi.fn()
+    const resume = vi.fn()
+    const output = new PtyOutputBroadcast(dispatcher)
+    output.register('pty-1', { pause, resume })
+
+    output.enqueue('pty-1', { data: 'blocked' })
+    await vi.advanceTimersByTimeAsync(8)
+    expect(pause).toHaveBeenCalledOnce()
+
+    output.unregister('pty-1')
+
+    expect(resume).toHaveBeenCalledOnce()
+    expect(cancelDrain).toHaveBeenCalledOnce()
+  })
+
+  it('queues the bounded final tail before exit even when normal credit is exhausted', () => {
+    const { dispatcher, deliveries } = createDispatcher([1, 2])
+    const output = new PtyOutputBroadcast(dispatcher)
+    output.register('pty-1', { pause: vi.fn(), resume: vi.fn() })
+    const data = `${'x'.repeat(PTY_OUTPUT_HIGH_WATER_CHARS)}final tail`
+
+    output.enqueue('pty-1', { data })
+    expect(deliveryData(deliveries, 1)).toHaveLength(PTY_OUTPUT_HIGH_WATER_CHARS)
+    expect(deliveryData(deliveries, 2)).toHaveLength(PTY_OUTPUT_HIGH_WATER_CHARS)
+
+    output.flushForExit('pty-1')
+
+    expect(deliveryData(deliveries, 1)).toBe(data)
+    expect(deliveryData(deliveries, 2)).toBe(data)
+  })
+})

--- a/src/relay/pty-output-broadcast.ts
+++ b/src/relay/pty-output-broadcast.ts
@@ -1,0 +1,300 @@
+import type { IPty } from 'node-pty'
+import type { RelayDispatcher, RequestContext } from './dispatcher'
+import {
+  appendPtyOutput,
+  cancelPtyOutputDrains,
+  canSendPtyOutput,
+  createPtyOutputState,
+  ensurePtyOutputClient,
+  evictablePtyOutputClientIds,
+  hasSendablePtyOutput,
+  pendingPtyOutputCharCount,
+  PTY_OUTPUT_HIGH_WATER_CHARS,
+  relayPtyOutputCharCount,
+  removePtyOutputClient,
+  resumePtyOutputProducer,
+  updatePtyOutputProducer,
+  type PtyOutputClientFlow,
+  type PtyOutputState,
+  type RelayPtyOutput
+} from './pty-output-flow-state'
+
+export {
+  PTY_OUTPUT_HIGH_WATER_CHARS,
+  PTY_OUTPUT_LOW_WATER_CHARS,
+  type RelayPtyOutput
+} from './pty-output-flow-state'
+
+const PTY_OUTPUT_BATCH_INTERVAL_MS = 8
+const PTY_OUTPUT_DRAIN_CONTINUE_MS = 1
+const PTY_OUTPUT_FLUSH_MAX_WRITES = 2
+
+export class PtyOutputBroadcast {
+  private readonly states = new Map<string, PtyOutputState>()
+  private flushTimer: ReturnType<typeof setTimeout> | null = null
+  private unsubscribeClientDetach: (() => void) | null
+
+  constructor(private readonly dispatcher: RelayDispatcher) {
+    this.unsubscribeClientDetach = dispatcher.onClientDetached((clientId) => {
+      this.detachClient(clientId)
+    })
+  }
+
+  register(id: string, producer: Pick<IPty, 'pause' | 'resume'>): void {
+    this.unregister(id)
+    this.states.set(id, createPtyOutputState(id, producer))
+  }
+
+  enqueue(id: string, output: RelayPtyOutput, immediate = false): void {
+    const state = this.states.get(id)
+    if (!state || (output.data.length === 0 && relayPtyOutputCharCount(output) === 0)) {
+      return
+    }
+    const clientIds = this.dispatcher.connectedClientIds()
+    if (clientIds.length === 0) {
+      return
+    }
+    for (const clientId of clientIds) {
+      ensurePtyOutputClient(state, clientId)
+    }
+    appendPtyOutput(state, output, new Set(clientIds))
+    if (pendingPtyOutputCharCount(state) >= PTY_OUTPUT_HIGH_WATER_CHARS) {
+      this.enforceBacklogBound(state)
+    } else {
+      updatePtyOutputProducer(state)
+    }
+    if (immediate || output.transformed === true) {
+      this.flushState(state, PTY_OUTPUT_FLUSH_MAX_WRITES)
+      this.scheduleContinuationIfNeeded()
+      return
+    }
+    this.scheduleFlush(PTY_OUTPUT_BATCH_INTERVAL_MS)
+  }
+
+  acknowledge(params: Record<string, unknown>, context: RequestContext): void {
+    const id = params.id
+    const charCount = params.charCount
+    const deliveryToken = params.deliveryToken
+    if (
+      typeof id !== 'string' ||
+      typeof charCount !== 'number' ||
+      !Number.isFinite(charCount) ||
+      charCount <= 0 ||
+      typeof deliveryToken !== 'string'
+    ) {
+      return
+    }
+    const state = this.states.get(id)
+    const flow = state?.clients.get(context.clientId)
+    if (!state || !flow || flow.deliveryToken !== deliveryToken) {
+      return
+    }
+    flow.unackedChars = Math.max(0, flow.unackedChars - Math.floor(charCount))
+    this.flushState(state, PTY_OUTPUT_FLUSH_MAX_WRITES)
+    this.scheduleContinuationIfNeeded()
+  }
+
+  resetClient(id: string, clientId: number): void {
+    const state = this.states.get(id)
+    if (!state) {
+      return
+    }
+    removePtyOutputClient(state, clientId)
+    if (this.dispatcher.connectedClientIds().includes(clientId)) {
+      ensurePtyOutputClient(state, clientId)
+    }
+    updatePtyOutputProducer(state)
+    this.clearFlushTimerIfIdle()
+  }
+
+  flushForExit(id: string): void {
+    const state = this.states.get(id)
+    if (!state) {
+      return
+    }
+    // Why bypass normal credit: the bounded final tail must be queued before pty.exit tears down the client-side terminal.
+    this.flushState(state, Number.POSITIVE_INFINITY, true)
+  }
+
+  unregister(id: string): void {
+    const state = this.states.get(id)
+    if (!state) {
+      return
+    }
+    resumePtyOutputProducer(state)
+    for (const flow of state.clients.values()) {
+      cancelPtyOutputDrains(flow)
+    }
+    state.clients.clear()
+    state.pending.length = 0
+    this.states.delete(id)
+    this.clearFlushTimerIfIdle()
+  }
+
+  dispose(): void {
+    this.unsubscribeClientDetach?.()
+    this.unsubscribeClientDetach = null
+    for (const id of Array.from(this.states.keys())) {
+      this.unregister(id)
+    }
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = null
+    }
+  }
+
+  private flushPending(): void {
+    this.flushTimer = null
+    let writesRemaining = PTY_OUTPUT_FLUSH_MAX_WRITES
+    for (const state of this.states.values()) {
+      if (writesRemaining <= 0) {
+        break
+      }
+      writesRemaining -= this.flushState(state, 1)
+    }
+    if (this.hasSendablePendingOutput()) {
+      this.scheduleFlush(PTY_OUTPUT_DRAIN_CONTINUE_MS)
+    }
+  }
+
+  private flushState(state: PtyOutputState, maxWrites: number, force = false): number {
+    let writes = 0
+    const blockedClientIds = new Set<number>()
+    for (let entryIndex = 0; entryIndex < state.pending.length; ) {
+      if (writes >= maxWrites) {
+        break
+      }
+      const pending = state.pending[entryIndex]
+      for (const clientId of Array.from(pending.pendingClientIds)) {
+        if (writes >= maxWrites) {
+          break
+        }
+        if (blockedClientIds.has(clientId)) {
+          continue
+        }
+        const flow = state.clients.get(clientId)
+        if (!flow) {
+          pending.pendingClientIds.delete(clientId)
+          continue
+        }
+        if (!force && !canSendPtyOutput(flow)) {
+          blockedClientIds.add(clientId)
+          continue
+        }
+        pending.pendingClientIds.delete(clientId)
+        this.sendToClient(state, flow, pending)
+        writes++
+        if (state.pending[entryIndex] !== pending) {
+          break
+        }
+        if (!force && !canSendPtyOutput(flow)) {
+          blockedClientIds.add(clientId)
+        }
+      }
+      if (state.pending[entryIndex] !== pending) {
+        continue
+      }
+      if (pending.pendingClientIds.size === 0) {
+        state.pending.splice(entryIndex, 1)
+      } else {
+        entryIndex++
+      }
+    }
+    if (pendingPtyOutputCharCount(state) >= PTY_OUTPUT_HIGH_WATER_CHARS) {
+      this.evictLaggingClientsWhenHealthy(state)
+    }
+    updatePtyOutputProducer(state)
+    this.clearFlushTimerIfIdle()
+    return writes
+  }
+
+  private sendToClient(
+    state: PtyOutputState,
+    flow: PtyOutputClientFlow,
+    output: RelayPtyOutput
+  ): void {
+    const result = this.dispatcher.notifyClientWithBackpressure(flow.clientId, 'pty.data', {
+      id: state.id,
+      data: output.data,
+      ...(output.rawLength === undefined ? {} : { rawLength: output.rawLength }),
+      ...(output.transformed ? { transformed: true } : {}),
+      ...(output.seq === undefined ? {} : { seq: output.seq }),
+      deliveryToken: flow.deliveryToken
+    })
+    if (!result.delivered || state.clients.get(flow.clientId) !== flow) {
+      removePtyOutputClient(state, flow.clientId)
+      return
+    }
+    flow.unackedChars += relayPtyOutputCharCount(output)
+    if (!result.saturated) {
+      return
+    }
+    flow.sinkBackpressured = true
+    if (result.cancelDrain) {
+      flow.drainCancellations.add(result.cancelDrain)
+    }
+    void result.drained.then(() => {
+      if (result.cancelDrain) {
+        flow.drainCancellations.delete(result.cancelDrain)
+      }
+      if (state.clients.get(flow.clientId) !== flow) {
+        return
+      }
+      flow.sinkBackpressured = false
+      this.flushState(state, PTY_OUTPUT_FLUSH_MAX_WRITES)
+      this.scheduleContinuationIfNeeded()
+    })
+  }
+
+  private detachClient(clientId: number): void {
+    for (const state of this.states.values()) {
+      removePtyOutputClient(state, clientId)
+      updatePtyOutputProducer(state)
+    }
+    this.clearFlushTimerIfIdle()
+  }
+
+  private enforceBacklogBound(state: PtyOutputState): void {
+    this.flushState(state, Number.POSITIVE_INFINITY)
+    if (pendingPtyOutputCharCount(state) < PTY_OUTPUT_HIGH_WATER_CHARS) {
+      return
+    }
+    this.evictLaggingClientsWhenHealthy(state)
+    updatePtyOutputProducer(state)
+  }
+
+  private evictLaggingClientsWhenHealthy(state: PtyOutputState): void {
+    for (const clientId of evictablePtyOutputClientIds(state)) {
+      this.dispatcher.evictClient(clientId)
+      this.detachClient(clientId)
+    }
+  }
+
+  private hasSendablePendingOutput(): boolean {
+    return hasSendablePtyOutput(this.states.values())
+  }
+
+  private scheduleFlush(delayMs: number): void {
+    if (this.flushTimer) {
+      return
+    }
+    this.flushTimer = setTimeout(() => this.flushPending(), delayMs)
+  }
+
+  private scheduleContinuationIfNeeded(): void {
+    if (this.hasSendablePendingOutput()) {
+      this.scheduleFlush(PTY_OUTPUT_DRAIN_CONTINUE_MS)
+    }
+  }
+
+  private clearFlushTimerIfIdle(): void {
+    if (
+      this.flushTimer === null ||
+      Array.from(this.states.values()).some((s) => s.pending.length)
+    ) {
+      return
+    }
+    clearTimeout(this.flushTimer)
+    this.flushTimer = null
+  }
+}

--- a/src/relay/pty-output-flow-state.ts
+++ b/src/relay/pty-output-flow-state.ts
@@ -1,0 +1,240 @@
+import { randomUUID } from 'node:crypto'
+import type { IPty } from 'node-pty'
+
+export const PTY_OUTPUT_HIGH_WATER_CHARS = 256 * 1024
+export const PTY_OUTPUT_LOW_WATER_CHARS = 32 * 1024
+
+const PTY_OUTPUT_FLUSH_CHUNK_CHARS = 16 * 1024
+
+export type RelayPtyOutput = {
+  data: string
+  rawLength?: number
+  transformed?: boolean
+  seq?: number
+}
+
+export type PtyOutputClientFlow = {
+  clientId: number
+  deliveryToken: string
+  unackedChars: number
+  sinkBackpressured: boolean
+  drainCancellations: Set<() => void>
+}
+
+export type PendingPtyOutput = RelayPtyOutput & {
+  pendingClientIds: Set<number>
+}
+
+export type PtyOutputState = {
+  id: string
+  producer: Pick<IPty, 'pause' | 'resume'>
+  clients: Map<number, PtyOutputClientFlow>
+  pending: PendingPtyOutput[]
+  producerPaused: boolean
+}
+
+export function createPtyOutputState(
+  id: string,
+  producer: Pick<IPty, 'pause' | 'resume'>
+): PtyOutputState {
+  return { id, producer, clients: new Map(), pending: [], producerPaused: false }
+}
+
+export function relayPtyOutputCharCount(output: RelayPtyOutput): number {
+  return typeof output.rawLength === 'number' && Number.isFinite(output.rawLength)
+    ? Math.max(0, Math.floor(output.rawLength))
+    : output.data.length
+}
+
+function setsEqual(left: ReadonlySet<number>, right: ReadonlySet<number>): boolean {
+  if (left.size !== right.size) {
+    return false
+  }
+  for (const value of left) {
+    if (!right.has(value)) {
+      return false
+    }
+  }
+  return true
+}
+
+function appendChunk(
+  state: PtyOutputState,
+  output: RelayPtyOutput,
+  pendingClientIds: Set<number>
+): void {
+  const tail = state.pending.at(-1)
+  const tailChars = tail ? relayPtyOutputCharCount(tail) : 0
+  const addedChars = relayPtyOutputCharCount(output)
+  if (
+    tail &&
+    tail.transformed === output.transformed &&
+    setsEqual(tail.pendingClientIds, pendingClientIds) &&
+    tailChars + addedChars <= PTY_OUTPUT_FLUSH_CHUNK_CHARS
+  ) {
+    const previousLength = tail.data.length
+    tail.data += output.data
+    if (tail.rawLength !== undefined || output.rawLength !== undefined) {
+      tail.rawLength = (tail.rawLength ?? previousLength) + addedChars
+    }
+    if (output.seq !== undefined) {
+      tail.seq = output.seq
+    }
+    return
+  }
+  state.pending.push({ ...output, pendingClientIds })
+}
+
+export function appendPtyOutput(
+  state: PtyOutputState,
+  output: RelayPtyOutput,
+  pendingClientIds: Set<number>
+): void {
+  if (output.transformed || output.data.length <= PTY_OUTPUT_FLUSH_CHUNK_CHARS) {
+    appendChunk(state, output, pendingClientIds)
+    return
+  }
+  for (let offset = 0; offset < output.data.length; offset += PTY_OUTPUT_FLUSH_CHUNK_CHARS) {
+    const data = output.data.slice(offset, offset + PTY_OUTPUT_FLUSH_CHUNK_CHARS)
+    const remainingChars = output.data.length - offset - data.length
+    appendChunk(
+      state,
+      {
+        data,
+        ...(output.rawLength === undefined ? {} : { rawLength: data.length }),
+        ...(output.seq === undefined ? {} : { seq: output.seq - remainingChars })
+      },
+      new Set(pendingClientIds)
+    )
+  }
+}
+
+export function ensurePtyOutputClient(
+  state: PtyOutputState,
+  clientId: number
+): PtyOutputClientFlow {
+  const existing = state.clients.get(clientId)
+  if (existing) {
+    return existing
+  }
+  const flow: PtyOutputClientFlow = {
+    clientId,
+    deliveryToken: randomUUID(),
+    unackedChars: 0,
+    sinkBackpressured: false,
+    drainCancellations: new Set()
+  }
+  state.clients.set(clientId, flow)
+  return flow
+}
+
+export function cancelPtyOutputDrains(flow: PtyOutputClientFlow): void {
+  for (const cancel of flow.drainCancellations) {
+    cancel()
+  }
+  flow.drainCancellations.clear()
+}
+
+export function removePtyOutputClient(state: PtyOutputState, clientId: number): void {
+  const flow = state.clients.get(clientId)
+  if (flow) {
+    cancelPtyOutputDrains(flow)
+    state.clients.delete(clientId)
+  }
+  for (let index = state.pending.length - 1; index >= 0; index--) {
+    const pending = state.pending[index]
+    pending.pendingClientIds.delete(clientId)
+    if (pending.pendingClientIds.size === 0) {
+      state.pending.splice(index, 1)
+    }
+  }
+}
+
+export function canSendPtyOutput(flow: PtyOutputClientFlow): boolean {
+  return !flow.sinkBackpressured && flow.unackedChars < PTY_OUTPUT_HIGH_WATER_CHARS
+}
+
+export function pendingPtyOutputCharCount(state: PtyOutputState, clientId?: number): number {
+  return state.pending.reduce(
+    (total, pending) =>
+      total +
+      (clientId === undefined || pending.pendingClientIds.has(clientId)
+        ? relayPtyOutputCharCount(pending)
+        : 0),
+    0
+  )
+}
+
+export function resumePtyOutputProducer(state: PtyOutputState): void {
+  if (!state.producerPaused) {
+    return
+  }
+  try {
+    state.producer.resume()
+  } catch {
+    /* PTY already destroyed */
+  }
+  state.producerPaused = false
+}
+
+export function updatePtyOutputProducer(state: PtyOutputState): void {
+  const flows = Array.from(state.clients.values())
+  if (flows.length === 0) {
+    resumePtyOutputProducer(state)
+    return
+  }
+  if (flows.every((flow) => !canSendPtyOutput(flow))) {
+    if (!state.producerPaused) {
+      try {
+        state.producer.pause()
+        state.producerPaused = true
+      } catch {
+        /* PTY already destroyed */
+      }
+    }
+    return
+  }
+  if (
+    state.producerPaused &&
+    flows.some(
+      (flow) =>
+        !flow.sinkBackpressured &&
+        flow.unackedChars + pendingPtyOutputCharCount(state, flow.clientId) <=
+          PTY_OUTPUT_LOW_WATER_CHARS
+    )
+  ) {
+    resumePtyOutputProducer(state)
+  }
+}
+
+export function hasSendablePtyOutput(states: Iterable<PtyOutputState>): boolean {
+  for (const state of states) {
+    for (const pending of state.pending) {
+      for (const clientId of pending.pendingClientIds) {
+        const flow = state.clients.get(clientId)
+        if (flow && canSendPtyOutput(flow)) {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+export function evictablePtyOutputClientIds(state: PtyOutputState): number[] {
+  const laggingClientIds = new Set<number>()
+  for (const pending of state.pending) {
+    for (const clientId of pending.pendingClientIds) {
+      laggingClientIds.add(clientId)
+    }
+  }
+  if (
+    laggingClientIds.size === 0 ||
+    !Array.from(state.clients.values()).some(
+      (flow) => !laggingClientIds.has(flow.clientId) && canSendPtyOutput(flow)
+    )
+  ) {
+    return []
+  }
+  return Array.from(laggingClientIds)
+}

--- a/src/relay/pty-persistence-envelope.test.ts
+++ b/src/relay/pty-persistence-envelope.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES,
+  MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES,
+  MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES,
+  parseRelayPtyPersistenceEnvelope,
+  serializeRelayPtyPersistenceEnvelope,
+  type RelayPtyPersistenceEntry
+} from './pty-persistence-envelope'
+import { MAX_TERMINAL_COLS } from '../shared/terminal-size-limits'
+
+function entry(index: number, overrides: Partial<RelayPtyPersistenceEntry> = {}) {
+  return {
+    id: `pty-${index}`,
+    pid: 100 + index,
+    cols: 80,
+    rows: 24,
+    cwd: '/repo',
+    envToDelete: [],
+    gitCredentialPromptGuarded: false,
+    ...overrides
+  }
+}
+
+describe('relay PTY persistence envelope', () => {
+  it('round-trips normal state without changing retained fields', () => {
+    const entries = [
+      entry(1, {
+        paneKey: 'tab-1:leaf-1',
+        attachIdentity: { paneKey: 'tab-1:leaf-1', tabId: 'tab-1' },
+        worktreeId: 'repo::/repo',
+        terminalHandle: 'terminal-1',
+        explicitTerm: 'screen-256color',
+        envToDelete: ['ORCA_ATTRIBUTION_SHIM_DIR'],
+        gitCredentialPromptGuarded: true
+      })
+    ]
+
+    const serialized = serializeRelayPtyPersistenceEnvelope(entries, 50)
+
+    expect(parseRelayPtyPersistenceEnvelope(serialized, 50)).toEqual(entries)
+  })
+
+  it('accepts the field limit and rejects limit plus one', () => {
+    expect(() =>
+      serializeRelayPtyPersistenceEnvelope(
+        [entry(1, { cwd: 'x'.repeat(MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES) })],
+        50
+      )
+    ).not.toThrow()
+    expect(() =>
+      serializeRelayPtyPersistenceEnvelope(
+        [entry(1, { cwd: 'x'.repeat(MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES + 1) })],
+        50
+      )
+    ).toThrow(`exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`)
+  })
+
+  it('rejects aggregate retained fields before serialization allocates the output', () => {
+    const field = 'x'.repeat(63 * 1024)
+    const entries = Array.from({ length: 49 }, (_, index) =>
+      entry(index, { cwd: field, paneKey: field })
+    )
+
+    expect(() => serializeRelayPtyPersistenceEnvelope(entries, 50)).toThrow(
+      `exceeds ${MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES} retained bytes`
+    )
+  })
+
+  it('rejects oversized and deeply nested input before JSON.parse', () => {
+    expect(() =>
+      parseRelayPtyPersistenceEnvelope(' '.repeat(MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES + 1), 50)
+    ).toThrow(`exceeds ${MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES} bytes`)
+
+    const deeplyNested = JSON.stringify([
+      {
+        ...entry(1),
+        ignored: [[[[[[[[]]]]]]]]
+      }
+    ])
+    expect(() => parseRelayPtyPersistenceEnvelope(deeplyNested, 50)).toThrow(
+      'JSON nesting exceeds 8 levels'
+    )
+  })
+
+  it('rejects entry-count overflow transactionally', () => {
+    const serialized = JSON.stringify([entry(1), entry(2)])
+    expect(() => parseRelayPtyPersistenceEnvelope(serialized, 1)).toThrow(
+      'PTY persistence state exceeds 1 entries'
+    )
+  })
+
+  it('rejects oversized terminal dimensions on writes and reads', () => {
+    const oversized = entry(1, { cols: MAX_TERMINAL_COLS + 1 })
+    expect(() => serializeRelayPtyPersistenceEnvelope([oversized], 50)).toThrow(
+      `1 through ${MAX_TERMINAL_COLS}`
+    )
+    expect(() => parseRelayPtyPersistenceEnvelope(JSON.stringify([oversized]), 50)).toThrow(
+      `1 through ${MAX_TERMINAL_COLS}`
+    )
+  })
+})

--- a/src/relay/pty-persistence-envelope.ts
+++ b/src/relay/pty-persistence-envelope.ts
@@ -1,0 +1,243 @@
+import { assertJsonTextStructureWithinLimits } from '../shared/json-text-structure-limit'
+import { stringifyJsonWithinByteLimit } from '../shared/node-bounded-json-stringify'
+import { terminalSizeAdmissionError } from '../shared/terminal-size-limits'
+
+export const MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES = 8 * 1024 * 1024
+export const MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES = 64 * 1024
+export const MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES = 128 * 1024
+export const MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES = 6 * 1024 * 1024
+export const MAX_RELAY_PTY_ENV_DELETE_KEYS = 1_024
+
+const PTY_PERSISTENCE_JSON_STRUCTURE_LIMITS = {
+  structuralTokens: 131_072,
+  nestingDepth: 8
+} as const
+
+export type RelayPtyIdentity = {
+  paneKey?: string
+  tabId?: string
+}
+
+export type RelayPtyPersistenceEntry = {
+  id: string
+  pid: number
+  cols: number
+  rows: number
+  cwd: string
+  paneKey?: string
+  tabId?: string
+  attachIdentity?: RelayPtyIdentity
+  worktreeId?: string
+  terminalHandle?: string
+  explicitTerm?: string
+  envToDelete?: string[]
+  gitCredentialPromptGuarded?: boolean
+}
+
+export type RelayPtyRetainedFields = Pick<
+  RelayPtyPersistenceEntry,
+  | 'id'
+  | 'cwd'
+  | 'paneKey'
+  | 'tabId'
+  | 'attachIdentity'
+  | 'worktreeId'
+  | 'terminalHandle'
+  | 'explicitTerm'
+  | 'envToDelete'
+>
+
+export function sanitizeRelayPtyEnvToDelete(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value
+        .filter((key): key is string => typeof key === 'string' && key.length > 0)
+        .slice(0, MAX_RELAY_PTY_ENV_DELETE_KEYS)
+    : []
+}
+
+export function assertRelayPtyRetainedFieldsWithinLimits(fields: RelayPtyRetainedFields): number {
+  let retainedBytes = 0
+  const add = (field: string, value: string | undefined): void => {
+    if (value === undefined) {
+      return
+    }
+    const bytes = Buffer.byteLength(value, 'utf8')
+    if (bytes > MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES) {
+      throw new Error(
+        `PTY persistence field "${field}" exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`
+      )
+    }
+    retainedBytes += bytes
+  }
+
+  add('id', fields.id)
+  add('cwd', fields.cwd)
+  add('paneKey', fields.paneKey)
+  add('tabId', fields.tabId)
+  add('attachIdentity.paneKey', fields.attachIdentity?.paneKey)
+  add('attachIdentity.tabId', fields.attachIdentity?.tabId)
+  add('worktreeId', fields.worktreeId)
+  add('terminalHandle', fields.terminalHandle)
+  add('explicitTerm', fields.explicitTerm)
+  for (const key of fields.envToDelete ?? []) {
+    add('envToDelete', key)
+  }
+  if (retainedBytes > MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES) {
+    throw new Error(
+      `PTY persistence entry exceeds ${MAX_RELAY_PTY_PERSISTENCE_ENTRY_BYTES} retained bytes`
+    )
+  }
+  return retainedBytes
+}
+
+export function serializeRelayPtyPersistenceEnvelope(
+  entries: readonly RelayPtyPersistenceEntry[],
+  maxEntries: number
+): string {
+  assertEnvelopeEntryCount(entries, maxEntries)
+  assertEnvelopeRetainedBytes(entries)
+  return stringifyJsonWithinByteLimit(entries, MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES).serialized
+}
+
+export function parseRelayPtyPersistenceEnvelope(
+  state: unknown,
+  maxEntries: number
+): RelayPtyPersistenceEntry[] {
+  if (typeof state !== 'string') {
+    throw new Error('PTY persistence state must be JSON text')
+  }
+  if (Buffer.byteLength(state, 'utf8') > MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES) {
+    throw new Error(`PTY persistence state exceeds ${MAX_RELAY_PTY_PERSISTENCE_STATE_BYTES} bytes`)
+  }
+  assertJsonTextStructureWithinLimits(state, PTY_PERSISTENCE_JSON_STRUCTURE_LIMITS)
+  return normalizeEnvelope(JSON.parse(state) as unknown, maxEntries)
+}
+
+export function parseRelayPtyPersistenceIds(value: unknown, maxEntries: number): string[] {
+  if (!Array.isArray(value) || value.length > maxEntries) {
+    throw new Error(`PTY persistence request exceeds ${maxEntries} entries`)
+  }
+  return value.map((id) => requiredString(id, 'id'))
+}
+
+function normalizeEnvelope(value: unknown, maxEntries: number): RelayPtyPersistenceEntry[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`PTY persistence state exceeds ${maxEntries} entries`)
+  }
+  assertEnvelopeEntryCount(value, maxEntries)
+
+  const entries = value.map((entry, index) => normalizeEntry(entry, index))
+  assertEnvelopeRetainedBytes(entries)
+  return entries
+}
+
+function assertEnvelopeEntryCount(value: readonly unknown[], maxEntries: number): void {
+  if (!Number.isSafeInteger(maxEntries) || maxEntries < 0) {
+    throw new RangeError('PTY persistence entry limit must be a non-negative safe integer')
+  }
+  if (value.length > maxEntries) {
+    throw new Error(`PTY persistence state exceeds ${maxEntries} entries`)
+  }
+}
+
+function assertEnvelopeRetainedBytes(entries: readonly RelayPtyRetainedFields[]): void {
+  let retainedBytes = 0
+  for (const entry of entries) {
+    const dimensions = entry as Partial<RelayPtyPersistenceEntry>
+    const sizeError = terminalSizeAdmissionError(
+      dimensions.cols,
+      dimensions.rows,
+      'PTY persistence entry',
+      { allowMissing: true }
+    )
+    if (sizeError) {
+      throw new Error(sizeError)
+    }
+    retainedBytes += assertRelayPtyRetainedFieldsWithinLimits(entry)
+    if (retainedBytes > MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES) {
+      throw new Error(
+        `PTY persistence state exceeds ${MAX_RELAY_PTY_PERSISTENCE_RETAINED_BYTES} retained bytes`
+      )
+    }
+  }
+}
+
+function normalizeEntry(value: unknown, index: number): RelayPtyPersistenceEntry {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`PTY persistence entry ${index} must be an object`)
+  }
+  const entry = value as Record<string, unknown>
+  const attachIdentity = normalizeIdentity(entry.attachIdentity)
+  const paneKey = optionalString(entry.paneKey, 'paneKey')
+  const tabId = optionalString(entry.tabId, 'tabId')
+  const worktreeId = optionalString(entry.worktreeId, 'worktreeId')
+  const terminalHandle = optionalString(entry.terminalHandle, 'terminalHandle')
+  const explicitTerm = optionalString(entry.explicitTerm, 'explicitTerm')
+  const envToDelete = sanitizeRelayPtyEnvToDelete(entry.envToDelete)
+  const cols = positiveSafeIntegerOrDefault(entry.cols, 'cols', 80)
+  const rows = positiveSafeIntegerOrDefault(entry.rows, 'rows', 24)
+  const sizeError = terminalSizeAdmissionError(cols, rows, 'PTY persistence entry')
+  if (sizeError) {
+    throw new Error(sizeError)
+  }
+
+  return {
+    id: requiredString(entry.id, 'id'),
+    pid: positiveSafeInteger(entry.pid, 'pid'),
+    cols,
+    rows,
+    cwd: requiredString(entry.cwd, 'cwd'),
+    ...(paneKey === undefined ? {} : { paneKey }),
+    ...(tabId === undefined ? {} : { tabId }),
+    ...(attachIdentity === undefined ? {} : { attachIdentity }),
+    ...(worktreeId === undefined ? {} : { worktreeId }),
+    ...(terminalHandle === undefined ? {} : { terminalHandle }),
+    ...(explicitTerm === undefined ? {} : { explicitTerm }),
+    ...(Array.isArray(entry.envToDelete) ? { envToDelete } : {}),
+    gitCredentialPromptGuarded: entry.gitCredentialPromptGuarded === true
+  }
+}
+
+function normalizeIdentity(value: unknown): RelayPtyIdentity | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const identity = value as Record<string, unknown>
+  const paneKey = optionalString(identity.paneKey, 'attachIdentity.paneKey')
+  const tabId = optionalString(identity.tabId, 'attachIdentity.tabId')
+  return paneKey === undefined && tabId === undefined ? undefined : { paneKey, tabId }
+}
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`PTY persistence field "${field}" must be a string`)
+  }
+  assertRelayPtyPersistenceFieldWithinLimit(field, value)
+  return value
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+  return requiredString(value, field)
+}
+
+export function assertRelayPtyPersistenceFieldWithinLimit(field: string, value: string): void {
+  if (Buffer.byteLength(value, 'utf8') > MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES) {
+    throw new Error(
+      `PTY persistence field "${field}" exceeds ${MAX_RELAY_PTY_PERSISTENCE_FIELD_BYTES} bytes`
+    )
+  }
+}
+
+function positiveSafeInteger(value: unknown, field: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throw new Error(`PTY persistence field "${field}" must be a positive safe integer`)
+  }
+  return value as number
+}
+
+function positiveSafeIntegerOrDefault(value: unknown, field: string, fallback: number): number {
+  return value === undefined ? fallback : positiveSafeInteger(value, field)
+}

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -136,6 +136,24 @@ describe('getRelayShellLaunchConfig', () => {
       'export ORCA_USER_ZDOTDIR="${ZDOTDIR:-${ORCA_ORIG_ZDOTDIR:-$HOME}}"'
     )
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'replaces a sparse oversized wrapper without reading its payload',
+    () => {
+      const zshRoot = join(homeDir, '.orca-relay', 'shell-ready', 'zsh')
+      const wrapperPath = join(zshRoot, '.zshenv')
+      mkdirSync(zshRoot, { recursive: true })
+      writeFileSync(wrapperPath, '')
+      truncateSync(wrapperPath, 1024 * 1024 * 1024)
+
+      getRelayShellLaunchConfig('/bin/zsh', {
+        HOME: homeDir,
+        ORCA_OPENCODE_CONFIG_DIR: '/tmp/orca-opencode-overlay'
+      })
+
+      expect(readFileSync(wrapperPath, 'utf8')).toContain('export ORCA_USER_ZDOTDIR=')
+    }
+  )
 
   it.skipIf(process.platform === 'win32')(
     'wraps zsh when MiMo home must survive shell startup',

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { getPosixOmpShellWrapper } from '../main/pty/omp-shell-wrapper'
@@ -7,6 +7,7 @@ import {
   getZshShellReadyMarkerRegistrationBlock,
   getZshStartupFileSourceBlock
 } from '../main/shell-templates'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
 
 const RELAY_SHELL_READY_DIR = '.orca-relay/shell-ready'
 const POSIX_LOGIN_ARGS = ['-l']
@@ -246,7 +247,10 @@ trap '__orca_osc133_preexec' DEBUG
     mkdirSync(dirname(path), { recursive: true })
     let existing: string | null = null
     try {
-      existing = readFileSync(path, 'utf8')
+      existing = readNodeFileSyncWithinLimit(
+        path,
+        Buffer.byteLength(content, 'utf8')
+      ).buffer.toString('utf8')
     } catch {
       existing = null
     }

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -1,8 +1,9 @@
 import { execFile as execFileCb } from 'node:child_process'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { win32 as pathWin32 } from 'node:path'
 import { promisify } from 'node:util'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
 import {
   isAgentForegroundWrapperProcess,
   isExpectedAgentProcess,
@@ -22,6 +23,7 @@ import {
 } from '../main/providers/windows-agent-foreground-process'
 
 const execFile = promisify(execFileCb)
+const MAX_ETC_SHELLS_BYTES = 64 * 1024
 
 export function resolveWindowsDefaultShell(
   env: NodeJS.ProcessEnv = process.env,
@@ -311,7 +313,10 @@ export function listShellProfiles(): { name: string; path: string }[] {
   const seen = new Set<string>()
 
   try {
-    const content = readFileSync('/etc/shells', 'utf-8')
+    const content = readNodeFileSyncWithinLimit(
+      '/etc/shells',
+      MAX_ETC_SHELLS_BYTES
+    ).buffer.toString('utf8')
     for (const line of content.split('\n')) {
       const trimmed = line.trim()
       if (!trimmed || trimmed.startsWith('#')) {

--- a/src/relay/relay-filesystem-watch-registry.test.ts
+++ b/src/relay/relay-filesystem-watch-registry.test.ts
@@ -11,6 +11,7 @@ import type {
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import { RelayFilesystemWatchRegistry } from './relay-filesystem-watch-registry'
 import { createRelayWatcherProcessPool } from './relay-watcher-process-pool'
+import { MAX_RELAY_WATCH_ROOT_KEY_BYTES } from './relay-watcher-root-capacity'
 
 type InstalledWatch = {
   rootPath: string
@@ -84,6 +85,21 @@ describe('RelayFilesystemWatchRegistry', () => {
     dispatcher = createDispatcher()
     pool = new FakeWatcherPool()
     registry = new RelayFilesystemWatchRegistry(dispatcher as unknown as RelayDispatcher, pool)
+  })
+
+  it('rejects an oversized raw root before retaining a pending setup', async () => {
+    await expect(
+      registry.watch('/'.repeat(MAX_RELAY_WATCH_ROOT_KEY_BYTES + 1), context(1))
+    ).rejects.toThrow('File watcher root path is too long')
+
+    expect(pool.installed).toHaveLength(0)
+    expect(
+      (
+        registry as unknown as {
+          pendingSetups: Map<string, unknown>
+        }
+      ).pendingSetups.size
+    ).toBe(0)
   })
 
   it('emits overflow around child replacement and resumes ordered event delivery', async () => {

--- a/src/relay/relay-filesystem-watch-registry.ts
+++ b/src/relay/relay-filesystem-watch-registry.ts
@@ -16,7 +16,10 @@ import {
   type RelayWatcherTeardownState
 } from './relay-watcher-teardown-tracker'
 import { emitRelayWatcherTerminalFailure } from './relay-watcher-terminal-notifier'
-import { assertRelayWatcherRootCapacity } from './relay-watcher-root-capacity'
+import {
+  assertRelayWatcherRootCapacity,
+  assertRelayWatcherRootKeyCapacity
+} from './relay-watcher-root-capacity'
 import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
 import {
   trackRelayWatcherSetup,
@@ -85,6 +88,7 @@ export class RelayFilesystemWatchRegistry {
     context?: RequestContext,
     watchId?: number
   ): Promise<void> {
+    assertRelayWatcherRootKeyCapacity(rootKey, rootPath)
     const staleTeardown = releaseStaleRelayWatches(this.watches.values(), (state) =>
       this.closeWatch(state)
     )

--- a/src/relay/relay-handshake.ts
+++ b/src/relay/relay-handshake.ts
@@ -1,8 +1,9 @@
 // Wire-level handshake helpers for the Orca relay.
 
 import { dirname, join } from 'node:path'
-import { existsSync, readFileSync, realpathSync } from 'node:fs'
+import { existsSync, realpathSync } from 'node:fs'
 import type { Socket } from 'node:net'
+import { readRelayVersionMarkerSync } from '../shared/relay-version-marker'
 import {
   RELAY_VERSION,
   MessageType,
@@ -34,7 +35,7 @@ export function readLaunchVersion(): string {
     }
     const versionFile = join(dir, '.version')
     if (existsSync(versionFile)) {
-      const v = readFileSync(versionFile, 'utf-8').trim()
+      const v = readRelayVersionMarkerSync(versionFile)
       if (v) {
         return v
       }

--- a/src/relay/relay-watcher-removal-fence.ts
+++ b/src/relay/relay-watcher-removal-fence.ts
@@ -6,6 +6,9 @@ import type { RelayDispatcher } from './dispatcher'
 import { emitRelayWatcherTerminalFailure } from './relay-watcher-terminal-notifier'
 import { isPathInsideOrEqual } from '../shared/cross-platform-path'
 import type { RelayWatcherPendingSetup } from './relay-watcher-setup-tracking'
+import { forEachWithConcurrency, mapSettledWithConcurrency } from '../shared/map-with-concurrency'
+
+const RELAY_WATCH_CLOSE_CONCURRENCY = 8
 
 export class RelayWatcherRemovalFence {
   private readonly roots = new Set<string>()
@@ -102,7 +105,9 @@ export class RelayWatcherRemovalFence {
     const pending = [...this.pendingSetups.entries()].filter(([setupRoot]) =>
       isPathInsideOrEqual(rootKey, setupRoot)
     )
-    await Promise.all(pending.map(([, setup]) => setup.promise.catch(() => undefined)))
+    await forEachWithConcurrency(pending, RELAY_WATCH_CLOSE_CONCURRENCY, async ([, setup]) => {
+      await setup.promise.catch(() => undefined)
+    })
     const states = [...this.watches.entries()]
       .filter(([watchRoot]) => isPathInsideOrEqual(rootKey, watchRoot))
       .map(([, state]) => state)
@@ -111,7 +116,15 @@ export class RelayWatcherRemovalFence {
       state.clients.clear()
       state.clientWatchIds.clear()
     }
-    await Promise.all(states.map((state) => this.closeWatch(state)))
+    const closes = await mapSettledWithConcurrency(states, RELAY_WATCH_CLOSE_CONCURRENCY, (state) =>
+      this.closeWatch(state)
+    )
+    const failedClose = closes.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+    if (failedClose) {
+      throw failedClose.reason
+    }
     const trackedRoots = this.teardownTracker
       .rootPaths()
       .filter((trackedRoot) => isPathInsideOrEqual(rootKey, trackedRoot))

--- a/src/relay/relay-watcher-root-capacity.test.ts
+++ b/src/relay/relay-watcher-root-capacity.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_RELAY_WATCH_ROOT_KEY_BYTES,
+  MAX_RELAY_WATCH_ROOT_KEYS_BYTES,
+  MAX_RELAY_WATCH_ROOTS,
+  assertRelayWatcherRootCapacity
+} from './relay-watcher-root-capacity'
+
+function keyWithBytes(label: string, bytes: number): string {
+  return `${label}${'x'.repeat(bytes - Buffer.byteLength(label))}`
+}
+
+describe('relay watcher root capacity', () => {
+  it('accepts a root key at the exact UTF-8 byte boundary', () => {
+    const root = keyWithBytes('/', MAX_RELAY_WATCH_ROOT_KEY_BYTES)
+
+    expect(() => assertRelayWatcherRootCapacity([], [], [], root)).not.toThrow()
+  })
+
+  it('rejects a root key one byte over the boundary', () => {
+    const root = keyWithBytes('/', MAX_RELAY_WATCH_ROOT_KEY_BYTES + 1)
+
+    expect(() => assertRelayWatcherRootCapacity([], [], [], root)).toThrow(
+      'File watcher root path is too long'
+    )
+  })
+
+  it('rejects an oversized raw path even when normalization made its key small', () => {
+    const rawPath = '/'.repeat(MAX_RELAY_WATCH_ROOT_KEY_BYTES + 1)
+
+    expect(() => assertRelayWatcherRootCapacity([], [], [], '/', rawPath)).toThrow(
+      'File watcher root path is too long'
+    )
+  })
+
+  it('caps aggregate keys retained across active, pending, and failed teardowns', () => {
+    const retained = Array.from({ length: 4 }, (_, index) =>
+      keyWithBytes(`/${index}/`, MAX_RELAY_WATCH_ROOT_KEY_BYTES - 1)
+    )
+    const exactProspective = keyWithBytes('/p', 4)
+    expect(
+      retained.reduce((total, root) => total + Buffer.byteLength(root), 0) +
+        Buffer.byteLength(exactProspective)
+    ).toBe(MAX_RELAY_WATCH_ROOT_KEYS_BYTES)
+
+    expect(() =>
+      assertRelayWatcherRootCapacity(
+        [retained[0]!],
+        [retained[1]!],
+        [retained[2]!, retained[3]!],
+        exactProspective
+      )
+    ).not.toThrow()
+    expect(() =>
+      assertRelayWatcherRootCapacity(
+        [retained[0]!],
+        [retained[1]!],
+        [retained[2]!, retained[3]!],
+        `${exactProspective}x`
+      )
+    ).toThrow('Maximum file watcher root path memory reached')
+  })
+
+  it('keeps the existing physical watcher count boundary', () => {
+    const retained = Array.from({ length: MAX_RELAY_WATCH_ROOTS }, (_, index) => `/${index}`)
+
+    expect(() => assertRelayWatcherRootCapacity(retained, [], [], retained[0]!)).not.toThrow()
+    expect(() => assertRelayWatcherRootCapacity(retained, [], [], '/overflow')).toThrow(
+      'Maximum number of file watchers reached'
+    )
+  })
+})

--- a/src/relay/relay-watcher-root-capacity.ts
+++ b/src/relay/relay-watcher-root-capacity.ts
@@ -1,13 +1,37 @@
-const MAX_RELAY_WATCH_ROOTS = 20
+export const MAX_RELAY_WATCH_ROOTS = 20
+export const MAX_RELAY_WATCH_ROOT_KEY_BYTES = 64 * 1024
+export const MAX_RELAY_WATCH_ROOT_KEYS_BYTES = 256 * 1024
+
+export function assertRelayWatcherRootKeyCapacity(rootKey: string, rootPath = rootKey): void {
+  if (
+    Buffer.byteLength(rootKey, 'utf8') > MAX_RELAY_WATCH_ROOT_KEY_BYTES ||
+    Buffer.byteLength(rootPath, 'utf8') > MAX_RELAY_WATCH_ROOT_KEY_BYTES
+  ) {
+    throw new Error('File watcher root path is too long')
+  }
+}
 
 export function assertRelayWatcherRootCapacity(
   activeRoots: Iterable<string>,
   pendingRoots: Iterable<string>,
   teardownRoots: Iterable<string>,
-  prospectiveRoot: string
+  prospectiveRoot: string,
+  prospectiveRootPath = prospectiveRoot
 ): void {
+  assertRelayWatcherRootKeyCapacity(prospectiveRoot, prospectiveRootPath)
   const physicalRoots = new Set([...activeRoots, ...pendingRoots, ...teardownRoots])
   physicalRoots.add(prospectiveRoot)
+  let retainedKeyBytes = 0
+  for (const root of physicalRoots) {
+    const keyBytes = Buffer.byteLength(root, 'utf8')
+    if (keyBytes > MAX_RELAY_WATCH_ROOT_KEY_BYTES) {
+      throw new Error('File watcher root path is too long')
+    }
+    retainedKeyBytes += keyBytes
+    if (retainedKeyBytes > MAX_RELAY_WATCH_ROOT_KEYS_BYTES) {
+      throw new Error('Maximum file watcher root path memory reached')
+    }
+  }
   if (physicalRoots.size > MAX_RELAY_WATCH_ROOTS) {
     throw new Error('Maximum number of file watchers reached')
   }

--- a/src/relay/relay-watcher-teardown-tracker.ts
+++ b/src/relay/relay-watcher-teardown-tracker.ts
@@ -15,6 +15,7 @@ export type RelayWatcherTeardownState = {
 }
 
 export class RelayWatcherTeardownTracker {
+  // Why: these entries own native handles and cannot be evicted; watcher admission bounds their count and aggregate root-key bytes.
   private readonly pending = new Map<string, Promise<void>>()
   private readonly failed = new Map<string, { state: RelayWatcherTeardownState; error: unknown }>()
 

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -14,6 +14,7 @@ import { resolve, join } from 'node:path'
 import { unlinkSync, existsSync, statSync } from 'node:fs'
 import {
   RELAY_SENTINEL,
+  MAX_MESSAGE_SIZE,
   FrameDecoder,
   MessageType,
   encodeJsonRpcFrame,
@@ -22,7 +23,7 @@ import {
   type JsonRpcResponse
 } from './protocol'
 import { readLaunchVersion, runConnectHandshake, setupDaemonHandshake } from './relay-handshake'
-import { RelayDispatcher } from './dispatcher'
+import { MAX_RELAY_SOCKET_CONNECTIONS, RelayDispatcher } from './dispatcher'
 import { RelayContext } from './context'
 import { PtyHandler } from './pty-handler'
 import { FsHandler } from './fs-handler'
@@ -53,6 +54,10 @@ import { relayLogLine } from './relay-diagnostic-log'
 import { remoteCliRequestTimeoutMs } from './remote-cli-timeout'
 import { shouldReadRemoteCliStdin } from './remote-cli-stdin'
 import { registerManagedHookInstaller } from './managed-hook-installer'
+import {
+  NodeReadableTextTooLargeError,
+  readNodeReadableTextWithinLimit
+} from '../shared/node-readable-text'
 
 const DEFAULT_GRACE_MS = DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS * 1000
 const SOCK_NAME = 'relay.sock'
@@ -283,11 +288,14 @@ async function readOrcaCliStdin(): Promise<string | undefined> {
   if (process.stdin.isTTY) {
     return undefined
   }
-  const chunks: Buffer[] = []
-  for await (const chunk of process.stdin) {
-    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk)))
+  try {
+    return await readNodeReadableTextWithinLimit(process.stdin, MAX_MESSAGE_SIZE)
+  } catch (error) {
+    if (error instanceof NodeReadableTextTooLargeError) {
+      throw new Error(`Remote CLI stdin exceeds ${MAX_MESSAGE_SIZE} byte relay frame limit`)
+    }
+    throw error
   }
-  return Buffer.concat(chunks).toString('utf8')
 }
 
 // ── Normal mode ──────────────────────────────────────────────────────
@@ -377,6 +385,12 @@ async function main(): Promise<void> {
           return
         }
         stdoutDrainWaiters.add(cb)
+      },
+      disconnect: () => {
+        stdoutAlive = false
+        flushStdoutDrainWaiters()
+        process.stdin.destroy()
+        process.stdout.destroy()
       }
     }
   )
@@ -612,17 +626,6 @@ async function main(): Promise<void> {
   }
 
   function attachAcceptedSocket(sock: Socket, leftover: Buffer): void {
-    // Why: remove the initial stdin data listener once a socket client is accepted, so stale SSH-channel bytes can't interleave.
-    process.stdin.pause()
-    process.stdin.removeAllListeners('data')
-
-    hasAcceptedSocketClient = true
-    acceptedSocketConnections++
-    relayLogLine(
-      `[relay] Socket client accepted (clients=${socketClients.size + 1}, accepted=${acceptedSocketConnections})`
-    )
-    cancelGrace('socket client accepted')
-
     // Why: same backpressure surface as stdout — bulk frames wait for socket drain so they can't bury interactive PTY frames.
     const sockDrainWaiters = new Set<() => void>()
     const flushSockDrainWaiters = (): void => {
@@ -634,23 +637,44 @@ async function main(): Promise<void> {
     sock.on('drain', flushSockDrainWaiters)
     sock.on('close', flushSockDrainWaiters)
     sock.on('error', flushSockDrainWaiters)
-    const clientId = dispatcher.attachClient(
-      (data) => {
-        if (!sock.destroyed) {
-          return sock.write(data)
-        }
-        return undefined
-      },
-      {
-        waitWriteDrain: (cb) => {
+    let clientId: number
+    try {
+      clientId = dispatcher.attachClient(
+        (data) => {
           if (sock.destroyed) {
-            cb()
-            return
+            return undefined
           }
-          sockDrainWaiters.add(cb)
+          return sock.write(data)
+        },
+        {
+          waitWriteDrain: (cb) => {
+            if (sock.destroyed) {
+              cb()
+              return
+            }
+            sockDrainWaiters.add(cb)
+          },
+          disconnect: () => sock.destroy()
         }
-      }
+      )
+    } catch (error) {
+      relayLogLine(
+        `[relay] Socket client rejected: ${error instanceof Error ? error.message : String(error)}`
+      )
+      sock.destroy()
+      return
+    }
+
+    // Why: remove the initial stdin data listener once a socket client is accepted, so stale SSH-channel bytes can't interleave.
+    process.stdin.pause()
+    process.stdin.removeAllListeners('data')
+
+    hasAcceptedSocketClient = true
+    acceptedSocketConnections++
+    relayLogLine(
+      `[relay] Socket client accepted (clients=${socketClients.size + 1}, accepted=${acceptedSocketConnections})`
     )
+    cancelGrace('socket client accepted')
     socketClients.set(sock, clientId)
 
     // Why: feed handshake-buffered leftover bytes before wiring sock.on('data') so frame ordering is preserved.
@@ -692,6 +716,7 @@ async function main(): Promise<void> {
         }
       })
     })
+    server.maxConnections = MAX_RELAY_SOCKET_CONNECTIONS
 
     // Why: umask 0o177 before listen makes the socket 0o600 atomically, closing the chmod-after-listen TOCTOU window.
     const shouldSetSocketUmask = !isWindowsNamedPipePath(sockPath)
@@ -861,6 +886,7 @@ async function main(): Promise<void> {
   if (detached) {
     // Why: detached stdin is /dev/null, so listening would EOF → grace → shutdown before --connect arrives; use the socket instead.
     stdoutAlive = false
+    dispatcher.invalidateClient()
     startGrace('detached startup')
   } else {
     process.stdin.on('data', (chunk: Buffer) => {

--- a/src/relay/workspace-session-handler.test.ts
+++ b/src/relay/workspace-session-handler.test.ts
@@ -1,9 +1,15 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { closeSync, ftruncateSync, mkdtempSync, openSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RelayDispatcher } from './dispatcher'
-import { WorkspaceSessionHandler } from './workspace-session-handler'
+import {
+  MAX_PRESENCE_CLIENTS_PER_NAMESPACE,
+  MAX_PRESENCE_NAMESPACES,
+  MAX_WORKSPACE_SESSION_SNAPSHOT_BYTES,
+  MAX_WORKSPACE_SESSION_SNAPSHOT_STRUCTURAL_TOKENS,
+  WorkspaceSessionHandler
+} from './workspace-session-handler'
 import { encodeJsonRpcFrame, MessageType, type JsonRpcRequest } from './protocol'
 
 function decodeJsonFrames(written: Buffer[]): unknown[] {
@@ -34,6 +40,7 @@ async function sendRequest(
 describe('WorkspaceSessionHandler', () => {
   let baseDir: string
   let dispatcher: RelayDispatcher
+  let handler: WorkspaceSessionHandler
   let written: Buffer[]
 
   beforeEach(() => {
@@ -42,11 +49,12 @@ describe('WorkspaceSessionHandler', () => {
     dispatcher = new RelayDispatcher((data) => {
       written.push(Buffer.from(data))
     })
-    new WorkspaceSessionHandler(dispatcher, baseDir)
+    handler = new WorkspaceSessionHandler(dispatcher, baseDir)
   })
 
   afterEach(() => {
     dispatcher.dispose()
+    vi.useRealTimers()
     rmSync(baseDir, { recursive: true, force: true })
   })
 
@@ -104,6 +112,40 @@ describe('WorkspaceSessionHandler', () => {
     expect(staleResponse.result.snapshot.revision).toBe(1)
   })
 
+  it('starts fresh when a persisted snapshot exceeds the file cap', async () => {
+    const snapshotPath = join(baseDir, 'oversized.json')
+    const file = openSync(snapshotPath, 'w')
+    ftruncateSync(file, MAX_WORKSPACE_SESSION_SNAPSHOT_BYTES + 1)
+    closeSync(file)
+
+    await sendRequest(dispatcher, 'workspace.get', { namespace: 'oversized' }, 1)
+
+    const response = decodeJsonFrames(written).find(
+      (frame) => (frame as { id?: number }).id === 1
+    ) as { result: { revision: number; session: { activeRepoId: unknown } } }
+    expect(response.result.revision).toBe(0)
+    expect(response.result.session.activeRepoId).toBeNull()
+  })
+
+  it('starts fresh when a bounded snapshot amplifies structure before parsing', () => {
+    writeFileSync(
+      join(baseDir, 'amplified.json'),
+      `[${'0,'.repeat(MAX_WORKSPACE_SESSION_SNAPSHOT_STRUCTURAL_TOKENS)}0]`
+    )
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    const snapshot = (
+      handler as unknown as {
+        read(namespace: string): { revision: number; session: { activeRepoId: unknown } }
+      }
+    ).read('amplified')
+
+    expect(snapshot.revision).toBe(0)
+    expect(snapshot.session.activeRepoId).toBeNull()
+    expect(parseSpy).not.toHaveBeenCalled()
+    parseSpy.mockRestore()
+  })
+
   it('tracks presence per namespace', async () => {
     await sendRequest(
       dispatcher,
@@ -139,4 +181,83 @@ describe('WorkspaceSessionHandler', () => {
       'Laptop A'
     )
   })
+
+  it('does not retain namespaces for presence queries without a client id', async () => {
+    for (let index = 0; index < MAX_PRESENCE_NAMESPACES + 10; index += 1) {
+      await sendRequest(
+        dispatcher,
+        'workspace.presence',
+        { namespace: `query-${index}` },
+        index + 1
+      )
+    }
+
+    const namespaces = (handler as unknown as { clientsByNamespace: Map<string, unknown> })
+      .clientsByNamespace
+    expect(namespaces.size).toBe(0)
+  })
+
+  it('sweeps expired clients from every namespace on any heartbeat', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    await sendRequest(dispatcher, 'workspace.presence', { namespace: 'a', clientId: 'a' }, 1)
+    await sendRequest(dispatcher, 'workspace.presence', { namespace: 'b', clientId: 'b' }, 2)
+
+    vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+    await sendRequest(dispatcher, 'workspace.presence', { namespace: 'c', clientId: 'c' }, 3)
+
+    const namespaces = (handler as unknown as { clientsByNamespace: Map<string, unknown> })
+      .clientsByNamespace
+    expect(Array.from(namespaces.keys())).toEqual(['c'])
+  })
+
+  it('bounds clients per namespace by evicting the oldest heartbeat', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    for (let index = 0; index <= MAX_PRESENCE_CLIENTS_PER_NAMESPACE; index += 1) {
+      vi.setSystemTime(Date.now() + 1)
+      await sendRequest(
+        dispatcher,
+        'workspace.presence',
+        { namespace: 'team', clientId: `client-${String(index).padStart(3, '0')}` },
+        index + 1
+      )
+    }
+
+    const clients = (
+      handler as unknown as {
+        clientsByNamespace: Map<string, Map<string, ConnectedClientForTest>>
+      }
+    ).clientsByNamespace.get('team')
+    expect(clients?.size).toBe(MAX_PRESENCE_CLIENTS_PER_NAMESPACE)
+    expect(clients?.has('client-000')).toBe(false)
+    expect(
+      clients?.has(`client-${String(MAX_PRESENCE_CLIENTS_PER_NAMESPACE).padStart(3, '0')}`)
+    ).toBe(true)
+  })
+
+  it('bounds namespaces by evicting the least recently active one', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+    for (let index = 0; index <= MAX_PRESENCE_NAMESPACES; index += 1) {
+      vi.setSystemTime(Date.now() + 1)
+      await sendRequest(
+        dispatcher,
+        'workspace.presence',
+        {
+          namespace: `space-${String(index).padStart(3, '0')}`,
+          clientId: `client-${index}`
+        },
+        index + 1
+      )
+    }
+
+    const namespaces = (handler as unknown as { clientsByNamespace: Map<string, unknown> })
+      .clientsByNamespace
+    expect(namespaces.size).toBe(MAX_PRESENCE_NAMESPACES)
+    expect(namespaces.has('space-000')).toBe(false)
+    expect(namespaces.has(`space-${MAX_PRESENCE_NAMESPACES}`)).toBe(true)
+  })
 })
+
+type ConnectedClientForTest = { clientId: string; name: string; lastSeenAt: number }

--- a/src/relay/workspace-session-handler.ts
+++ b/src/relay/workspace-session-handler.ts
@@ -1,6 +1,9 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, renameSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname, join } from 'node:path'
+import { assertJsonTextStructureWithinLimits } from '../shared/json-text-structure-limit'
+import { readNodeFileSyncWithinLimit } from '../shared/node-bounded-file-reader'
+import { stringifyJsonWithinByteLimit } from '../shared/node-bounded-json-stringify'
 import type { RelayDispatcher } from './dispatcher'
 
 type RemoteWorkspaceSnapshot = {
@@ -28,6 +31,11 @@ type PatchResult =
 
 const SNAPSHOT_SCHEMA_VERSION = 1
 const PRESENCE_TTL_MS = 45_000
+export const MAX_PRESENCE_NAMESPACES = 256
+export const MAX_PRESENCE_CLIENTS_PER_NAMESPACE = 64
+export const MAX_WORKSPACE_SESSION_SNAPSHOT_BYTES = 16 * 1024 * 1024
+export const MAX_WORKSPACE_SESSION_SNAPSHOT_STRUCTURAL_TOKENS = 1_000_000
+export const MAX_WORKSPACE_SESSION_SNAPSHOT_NESTING_DEPTH = 128
 
 function emptySession(): Record<string, unknown> {
   return {
@@ -81,7 +89,15 @@ export class WorkspaceSessionHandler {
     }
 
     try {
-      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Partial<RemoteWorkspaceSnapshot>
+      const content = readNodeFileSyncWithinLimit(
+        path,
+        MAX_WORKSPACE_SESSION_SNAPSHOT_BYTES
+      ).buffer.toString('utf8')
+      assertJsonTextStructureWithinLimits(content, {
+        structuralTokens: MAX_WORKSPACE_SESSION_SNAPSHOT_STRUCTURAL_TOKENS,
+        nestingDepth: MAX_WORKSPACE_SESSION_SNAPSHOT_NESTING_DEPTH
+      })
+      const parsed = JSON.parse(content) as Partial<RemoteWorkspaceSnapshot>
       return {
         namespace,
         revision:
@@ -116,7 +132,11 @@ export class WorkspaceSessionHandler {
     const path = this.snapshotPath(snapshot.namespace)
     mkdirSync(dirname(path), { recursive: true, mode: 0o700 })
     const tmpPath = `${path}.tmp`
-    writeFileSync(tmpPath, JSON.stringify(snapshot, null, 2), { mode: 0o600 })
+    const serialized = stringifyJsonWithinByteLimit(
+      snapshot,
+      MAX_WORKSPACE_SESSION_SNAPSHOT_BYTES
+    ).serialized
+    writeFileSync(tmpPath, serialized, { mode: 0o600 })
     renameSync(tmpPath, path)
   }
 
@@ -163,25 +183,72 @@ export class WorkspaceSessionHandler {
     const namespace = sanitizeNamespace(params.namespace)
     const clientId = typeof params.clientId === 'string' ? sanitizeClientId(params.clientId) : ''
     const name = typeof params.clientName === 'string' ? sanitizeClientName(params.clientName) : ''
-    const clients = this.clientsByNamespace.get(namespace) ?? new Map<string, ConnectedClient>()
-    this.clientsByNamespace.set(namespace, clients)
-
     const now = Date.now()
-    for (const [id, client] of clients) {
-      if (now - client.lastSeenAt > PRESENCE_TTL_MS) {
-        clients.delete(id)
+    this.sweepPresence(now)
+
+    let clients = this.clientsByNamespace.get(namespace)
+    if (!clientId) {
+      return { clients: this.sortedClients(clients) }
+    }
+    if (!clients) {
+      if (this.clientsByNamespace.size >= MAX_PRESENCE_NAMESPACES) {
+        this.evictOldestNamespace()
+      }
+      clients = new Map<string, ConnectedClient>()
+      this.clientsByNamespace.set(namespace, clients)
+    }
+    if (!clients.has(clientId) && clients.size >= MAX_PRESENCE_CLIENTS_PER_NAMESPACE) {
+      this.evictOldestClient(clients)
+    }
+    clients.set(clientId, {
+      clientId,
+      name: name || 'Unknown device',
+      lastSeenAt: now
+    })
+
+    return { clients: this.sortedClients(clients) }
+  }
+
+  private sweepPresence(now: number): void {
+    for (const [namespace, clients] of this.clientsByNamespace) {
+      for (const [id, client] of clients) {
+        if (now - client.lastSeenAt > PRESENCE_TTL_MS) {
+          clients.delete(id)
+        }
+      }
+      if (clients.size === 0) {
+        this.clientsByNamespace.delete(namespace)
       }
     }
-    if (clientId) {
-      clients.set(clientId, {
-        clientId,
-        name: name || 'Unknown device',
-        lastSeenAt: now
-      })
-    }
+  }
 
-    return {
-      clients: Array.from(clients.values()).sort((a, b) => b.lastSeenAt - a.lastSeenAt)
+  private evictOldestNamespace(): void {
+    let oldest: { namespace: string; lastSeenAt: number } | undefined
+    for (const [namespace, clients] of this.clientsByNamespace) {
+      const lastSeenAt = Math.max(...Array.from(clients.values(), (client) => client.lastSeenAt))
+      if (
+        !oldest ||
+        lastSeenAt < oldest.lastSeenAt ||
+        (lastSeenAt === oldest.lastSeenAt && namespace < oldest.namespace)
+      ) {
+        oldest = { namespace, lastSeenAt }
+      }
     }
+    if (oldest) {
+      this.clientsByNamespace.delete(oldest.namespace)
+    }
+  }
+
+  private evictOldestClient(clients: Map<string, ConnectedClient>): void {
+    const oldest = Array.from(clients.values()).sort(
+      (a, b) => a.lastSeenAt - b.lastSeenAt || a.clientId.localeCompare(b.clientId)
+    )[0]
+    if (oldest) {
+      clients.delete(oldest.clientId)
+    }
+  }
+
+  private sortedClients(clients: Map<string, ConnectedClient> | undefined): ConnectedClient[] {
+    return Array.from(clients?.values() ?? []).sort((a, b) => b.lastSeenAt - a.lastSeenAt)
   }
 }

--- a/src/relay/workspace-space-scan.ts
+++ b/src/relay/workspace-space-scan.ts
@@ -2,16 +2,25 @@
    cancellation, symlink, and top-level compaction semantics in one scanner. */
 import { execFile } from 'node:child_process'
 import type { Dirent } from 'node:fs'
-import { lstat, readdir } from 'node:fs/promises'
+import { lstat, opendir } from 'node:fs/promises'
 import { basename, join } from 'node:path'
 import { platform } from 'node:process'
 import { promisify } from 'node:util'
 import type {
   WorkspaceSpaceDirectoryScanResult,
-  WorkspaceSpaceItem,
-  WorkspaceSpaceItemKind
+  WorkspaceSpaceItem
 } from '../shared/workspace-space-types'
 import { compactWorkspaceSpaceItems } from '../shared/workspace-space-compaction'
+import { mapWithConcurrency } from '../shared/map-with-concurrency'
+import {
+  scanWorkspaceSpaceEntryTree,
+  type WorkspaceSpaceEntryScan
+} from '../shared/workspace-space-entry-traversal'
+import {
+  collectWorkspaceSpaceDirectoryEntries,
+  createWorkspaceSpaceScanBudget,
+  WorkspaceSpaceScanCapacityError
+} from '../shared/workspace-space-scan-budget'
 import type { RequestContext } from './dispatcher'
 
 const RELAY_FS_CONCURRENCY = 48
@@ -19,15 +28,7 @@ const DU_TIMEOUT_MS = 120_000
 const DU_MAX_BUFFER_BYTES = 16 * 1024 * 1024
 const execFileAsync = promisify(execFile)
 
-type AsyncLimiter = <T>(task: () => Promise<T>) => Promise<T>
-
-type ScanStats = {
-  name: string
-  path: string
-  kind: WorkspaceSpaceItemKind
-  sizeBytes: number
-  skippedEntryCount: number
-}
+type ScanStats = WorkspaceSpaceEntryScan
 
 class RelayWorkspaceSpaceScanCancelledError extends Error {
   constructor() {
@@ -39,57 +40,6 @@ class RelayWorkspaceSpaceScanCancelledError extends Error {
 function throwIfCancelled(context: RequestContext): void {
   if (context.isStale() || context.signal?.aborted) {
     throw new RelayWorkspaceSpaceScanCancelledError()
-  }
-}
-
-function createAsyncLimiter(maxConcurrent: number, context: RequestContext): AsyncLimiter {
-  let active = 0
-  const queue: { resolve: () => void }[] = []
-
-  const acquire = async (): Promise<void> => {
-    throwIfCancelled(context)
-    if (active < maxConcurrent) {
-      active += 1
-      return
-    }
-    await new Promise<void>((resolve, reject) => {
-      let onAbort: (() => void) | null = null
-      const waiter = {
-        resolve: () => {
-          if (onAbort) {
-            context.signal?.removeEventListener('abort', onAbort)
-          }
-          resolve()
-        }
-      }
-      onAbort = () => {
-        const index = queue.indexOf(waiter)
-        if (index !== -1) {
-          queue.splice(index, 1)
-        }
-        reject(new RelayWorkspaceSpaceScanCancelledError())
-      }
-      queue.push(waiter)
-      if (context.signal) {
-        context.signal.addEventListener('abort', onAbort, { once: true })
-        if (context.signal.aborted) {
-          onAbort()
-        }
-      }
-    })
-    throwIfCancelled(context)
-    active += 1
-  }
-
-  return async <T>(task: () => Promise<T>): Promise<T> => {
-    await acquire()
-    try {
-      return await task()
-    } finally {
-      active -= 1
-      const next = queue.shift()
-      next?.resolve()
-    }
   }
 }
 
@@ -142,11 +92,10 @@ async function scanTopLevelEntryWithDu(
   entryPath: string,
   name: string,
   duSizes: Map<string, number>,
-  limit: AsyncLimiter,
   context: RequestContext
 ): Promise<ScanStats> {
   throwIfCancelled(context)
-  const stats = await limit(() => lstat(entryPath))
+  const stats = await lstat(entryPath)
   throwIfCancelled(context)
 
   if (stats.isSymbolicLink()) {
@@ -181,77 +130,30 @@ async function scanTopLevelEntryWithDu(
 async function scanEntryAggregate(
   entryPath: string,
   name: string,
-  limit: AsyncLimiter,
   context: RequestContext
 ): Promise<ScanStats> {
-  throwIfCancelled(context)
-  const stats = await limit(() => lstat(entryPath))
-  throwIfCancelled(context)
-
-  if (stats.isSymbolicLink()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'symlink',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  if (!stats.isDirectory()) {
-    return {
-      name,
-      path: entryPath,
-      kind: 'file',
-      sizeBytes: stats.size,
-      skippedEntryCount: 0
-    }
-  }
-
-  let entries: Dirent[]
-  try {
-    entries = await limit(() => readdir(entryPath, { withFileTypes: true }))
-  } catch {
-    return {
-      name,
-      path: entryPath,
-      kind: 'directory',
-      sizeBytes: stats.size,
-      skippedEntryCount: 1
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanEntryAggregate(join(entryPath, entry.name), entry.name, limit, context)
-      } catch (error) {
-        if (error instanceof RelayWorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
+  return scanWorkspaceSpaceEntryTree<Dirent>({
+    rootPath: entryPath,
+    rootName: name,
+    concurrency: RELAY_FS_CONCURRENCY,
+    signal: context.signal,
+    entryName: (entry) => entry.name,
+    joinPath: join,
+    classifyEntry: async (path) => {
+      const stats = await lstat(path)
+      throwIfCancelled(context)
+      if (stats.isSymbolicLink()) {
+        return { kind: 'symlink', sizeBytes: stats.size }
       }
-    })
-  )
-
-  let sizeBytes = stats.size
-  let skippedEntryCount = 0
-  for (const child of childStats) {
-    if (!child) {
-      skippedEntryCount += 1
-      continue
-    }
-    sizeBytes += child.sizeBytes
-    skippedEntryCount += child.skippedEntryCount
-  }
-
-  return {
-    name,
-    path: entryPath,
-    kind: 'directory',
-    sizeBytes,
-    skippedEntryCount
-  }
+      return stats.isDirectory()
+        ? { kind: 'directory', sizeBytes: stats.size }
+        : { kind: 'file', sizeBytes: stats.size }
+    },
+    readDirectory: (path) => opendir(path),
+    checkCancelled: () => throwIfCancelled(context),
+    createCancellationError: () => new RelayWorkspaceSpaceScanCancelledError(),
+    isCancellationError: (error) => error instanceof RelayWorkspaceSpaceScanCancelledError
+  })
 }
 
 async function scanDirectoryWithDu(
@@ -266,19 +168,27 @@ async function scanDirectoryWithDu(
   }
 
   const [entries, duSizes] = await Promise.all([
-    readdir(rootPath, { withFileTypes: true }),
+    opendir(rootPath).then((directory) =>
+      collectWorkspaceSpaceDirectoryEntries(
+        directory,
+        rootPath,
+        (entry) => entry.name,
+        createWorkspaceSpaceScanBudget(),
+        () => throwIfCancelled(context)
+      )
+    ),
     readDuDepthOne(rootPath, context)
   ])
   throwIfCancelled(context)
-  const limit = createAsyncLimiter(RELAY_FS_CONCURRENCY, context)
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
+  const childStats = await mapWithConcurrency(
+    entries,
+    RELAY_FS_CONCURRENCY,
+    async (entry): Promise<ScanStats | null> => {
       try {
         return await scanTopLevelEntryWithDu(
           join(rootPath, entry.name),
           entry.name,
           duSizes,
-          limit,
           context
         )
       } catch (error) {
@@ -287,7 +197,7 @@ async function scanDirectoryWithDu(
         }
         return null
       }
-    })
+    }
   )
   const children = childStats.filter((child): child is ScanStats => child !== null)
   const compact = compactWorkspaceSpaceItems(children.map(toWorkspaceSpaceItem))
@@ -305,55 +215,13 @@ async function scanDirectoryWithNode(
   rootPath: string,
   context: RequestContext
 ): Promise<WorkspaceSpaceDirectoryScanResult> {
-  throwIfCancelled(context)
-  const limit = createAsyncLimiter(RELAY_FS_CONCURRENCY, context)
-  const rootStats = await lstat(rootPath)
-  throwIfCancelled(context)
-  if (!rootStats.isDirectory() || rootStats.isSymbolicLink()) {
-    const root = await scanEntryAggregate(rootPath, basename(rootPath), limit, context)
-    return {
-      sizeBytes: root.sizeBytes,
-      skippedEntryCount: root.skippedEntryCount,
-      topLevelItems: [],
-      omittedTopLevelItemCount: 0,
-      omittedTopLevelSizeBytes: 0
-    }
-  }
-
-  let entries: Dirent[]
-  try {
-    entries = await readdir(rootPath, { withFileTypes: true })
-  } catch {
-    return {
-      sizeBytes: rootStats.size,
-      skippedEntryCount: 1,
-      topLevelItems: [],
-      omittedTopLevelItemCount: 0,
-      omittedTopLevelSizeBytes: 0
-    }
-  }
-
-  const childStats = await Promise.all(
-    entries.map(async (entry): Promise<ScanStats | null> => {
-      try {
-        return await scanEntryAggregate(join(rootPath, entry.name), entry.name, limit, context)
-      } catch (error) {
-        if (error instanceof RelayWorkspaceSpaceScanCancelledError) {
-          throw error
-        }
-        return null
-      }
-    })
-  )
-  const children = childStats.filter((child): child is ScanStats => child !== null)
+  const root = await scanEntryAggregate(rootPath, basename(rootPath), context)
+  const children = root.children ?? []
   const compact = compactWorkspaceSpaceItems(children.map(toWorkspaceSpaceItem))
 
   return {
-    sizeBytes: rootStats.size + children.reduce((sum, child) => sum + child.sizeBytes, 0),
-    skippedEntryCount:
-      children.reduce((sum, child) => sum + child.skippedEntryCount, 0) +
-      childStats.length -
-      children.length,
+    sizeBytes: root.sizeBytes,
+    skippedEntryCount: root.skippedEntryCount,
     ...compact
   }
 }
@@ -366,7 +234,10 @@ export async function scanWorkspaceSpaceDirectory(
     try {
       return await scanDirectoryWithDu(rootPath, context)
     } catch (error) {
-      if (error instanceof RelayWorkspaceSpaceScanCancelledError) {
+      if (
+        error instanceof RelayWorkspaceSpaceScanCancelledError ||
+        error instanceof WorkspaceSpaceScanCapacityError
+      ) {
         throw error
       }
     }

--- a/src/relay/wsl-hook-fs-bridge.test.ts
+++ b/src/relay/wsl-hook-fs-bridge.test.ts
@@ -2,13 +2,14 @@
 // `posix.resolve` against a POSIX guest home. On win32 `posix.resolve` of a
 // Windows tmpdir yields an invalid path, so the whole suite is skipped there
 // (the bridge only ever runs inside a Linux WSL guest).
-import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import { posix } from 'node:path'
 import { tmpdir } from 'node:os'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { registerWslHookFsHandlers } from './wsl-hook-fs-bridge'
 import type { MethodHandler, RelayDispatcher, RequestContext } from './dispatcher'
+import { estimateFilesystemDirectoryEntryBytes } from '../shared/filesystem-directory-listing-limit'
 import { WSL_HOOK_FS_METHODS, type WslFsResult } from '../shared/wsl-hook-relay-contract'
 
 describe.skipIf(process.platform === 'win32')('registerWslHookFsHandlers (WSL fs bridge)', () => {
@@ -57,6 +58,22 @@ describe.skipIf(process.platform === 'win32')('registerWslHookFsHandlers (WSL fs
     expect(read).toEqual({ ok: true, content: 'hello guest' })
   })
 
+  it('accepts an exact byte-limit read and rejects an oversized file before materializing it', async () => {
+    const path = posix.join(home, 'bounded.txt')
+    writeFileSync(path, '🐋')
+
+    await expect(
+      call<{ content: string }>(WSL_HOOK_FS_METHODS.readFile, { path, maxBytes: 4 })
+    ).resolves.toEqual({ ok: true, content: '🐋' })
+    await expect(
+      call<{ content: string }>(WSL_HOOK_FS_METHODS.readFile, { path, maxBytes: 3 })
+    ).resolves.toMatchObject({
+      ok: false,
+      errno: 'EFBIG',
+      fileCapacity: { observedBytes: 4, maxBytes: 3 }
+    })
+  })
+
   it('refuses writeFile to an absolute path outside home', async () => {
     const result = await call(WSL_HOOK_FS_METHODS.writeFile, {
       path: '/etc/orca-evil.txt',
@@ -98,6 +115,48 @@ describe.skipIf(process.platform === 'win32')('registerWslHookFsHandlers (WSL fs
       path: '/'
     })
     expect(root.ok).toBe(true)
+  })
+
+  it('streams directory entries through requested entry and retained-byte limits', async () => {
+    const directory = posix.join(home, 'bounded-dir')
+    mkdirSync(directory)
+    writeFileSync(posix.join(directory, 'alpha'), '')
+    writeFileSync(posix.join(directory, 'beta'), '')
+
+    const exactEntries = await call<{ entries: { filename: string }[] }>(
+      WSL_HOOK_FS_METHODS.readdir,
+      { path: directory, maxEntries: 2, maxRetainedBytes: 4096 }
+    )
+    expect(exactEntries).toMatchObject({ ok: true })
+    if (exactEntries.ok) {
+      expect(exactEntries.entries).toHaveLength(2)
+    }
+    await expect(
+      call(WSL_HOOK_FS_METHODS.readdir, {
+        path: directory,
+        maxEntries: 1,
+        maxRetainedBytes: 4096
+      })
+    ).resolves.toMatchObject({ ok: false })
+
+    const single = posix.join(home, 'single-entry-dir')
+    mkdirSync(single)
+    writeFileSync(posix.join(single, 'one'), '')
+    const exactRetainedBytes = estimateFilesystemDirectoryEntryBytes({ name: 'one' })
+    await expect(
+      call(WSL_HOOK_FS_METHODS.readdir, {
+        path: single,
+        maxEntries: 1,
+        maxRetainedBytes: exactRetainedBytes
+      })
+    ).resolves.toMatchObject({ ok: true })
+    await expect(
+      call(WSL_HOOK_FS_METHODS.readdir, {
+        path: single,
+        maxEntries: 1,
+        maxRetainedBytes: exactRetainedBytes - 1
+      })
+    ).resolves.toMatchObject({ ok: false })
   })
 
   it('refuses readdir on a non-ancestor dir outside home', async () => {

--- a/src/relay/wsl-hook-fs-bridge.ts
+++ b/src/relay/wsl-hook-fs-bridge.ts
@@ -8,14 +8,51 @@ import { posix } from 'node:path'
 
 import type { RelayDispatcher } from './dispatcher'
 import {
+  createFilesystemDirectoryLimitState,
+  trackFilesystemDirectoryEntry
+} from '../shared/filesystem-directory-listing-limit'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../shared/node-bounded-file-reader'
+import {
   WSL_HOOK_FS_METHODS,
+  WSL_HOOK_FS_MAX_DIRECTORY_ENTRIES,
+  WSL_HOOK_FS_MAX_DIRECTORY_RETAINED_BYTES,
+  WSL_HOOK_FS_MAX_READ_BYTES,
   type WslFsFailure,
   type WslFsResult
 } from '../shared/wsl-hook-relay-contract'
 
 function failure(err: unknown): WslFsFailure {
+  if (err instanceof NodeFileReadTooLargeError) {
+    return {
+      ok: false,
+      errno: 'EFBIG',
+      message: err.message,
+      fileCapacity: { observedBytes: err.observedBytes, maxBytes: err.maxBytes }
+    }
+  }
   const e = err as NodeJS.ErrnoException
   return { ok: false, errno: e?.code ?? 'EUNKNOWN', message: e?.message ?? String(err) }
+}
+
+function requestedLimit(value: unknown, maximum: number): number {
+  if (value === undefined) {
+    return maximum
+  }
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw Object.assign(new Error('invalid capacity limit'), { code: 'EINVAL' })
+  }
+  return Math.min(value, maximum)
+}
+
+function requestedDirectoryLimit(value: unknown, maximum: number): number {
+  const limit = requestedLimit(value, maximum)
+  if (limit === 0) {
+    throw Object.assign(new Error('directory capacity limit must be positive'), { code: 'EINVAL' })
+  }
+  return limit
 }
 
 export function registerWslHookFsHandlers(
@@ -46,7 +83,7 @@ export function registerWslHookFsHandlers(
     return resolved
   }
   // Why: the installers' mkdir-p walks top-down from `/`, probing every
-  // ancestor of home with readdir before it ever creates a dir. Allow
+  // ancestor of home before it ever creates a dir. Allow
   // read-only existence probes on those ancestors; everything else stays
   // home-scoped.
   const scopedProbe = (rawPath: unknown): string => {
@@ -68,7 +105,10 @@ export function registerWslHookFsHandlers(
     WSL_HOOK_FS_METHODS.readFile,
     async (params): Promise<WslFsResult<{ content: string }>> => {
       try {
-        const content = await fs.readFile(scoped(params.path), 'utf8')
+        const maxBytes = requestedLimit(params.maxBytes, WSL_HOOK_FS_MAX_READ_BYTES)
+        const content = (
+          await readNodeFileWithinLimit(scoped(params.path), maxBytes)
+        ).buffer.toString('utf8')
         return { ok: true, content }
       } catch (err) {
         return failure(err)
@@ -93,7 +133,7 @@ export function registerWslHookFsHandlers(
     WSL_HOOK_FS_METHODS.stat,
     async (params): Promise<WslFsResult<{ mode: number }>> => {
       try {
-        const stats = await fs.stat(scoped(params.path))
+        const stats = await fs.stat(scopedProbe(params.path))
         return { ok: true, mode: stats.mode }
       } catch (err) {
         return failure(err)
@@ -133,11 +173,39 @@ export function registerWslHookFsHandlers(
   dispatcher.onRequest(
     WSL_HOOK_FS_METHODS.readdir,
     async (params): Promise<WslFsResult<{ entries: { filename: string }[] }>> => {
+      let directory: Awaited<ReturnType<typeof fs.opendir>> | undefined
       try {
-        const names = await fs.readdir(scopedProbe(params.path))
-        return { ok: true, entries: names.map((filename) => ({ filename })) }
+        const limits = {
+          maxEntries: requestedDirectoryLimit(params.maxEntries, WSL_HOOK_FS_MAX_DIRECTORY_ENTRIES),
+          maxRetainedBytes: requestedDirectoryLimit(
+            params.maxRetainedBytes,
+            WSL_HOOK_FS_MAX_DIRECTORY_RETAINED_BYTES
+          )
+        }
+        const limit = createFilesystemDirectoryLimitState(limits)
+        const entries: { filename: string }[] = []
+        const directoryPath = scopedProbe(params.path)
+        directory = await fs.opendir(directoryPath, { bufferSize: 32 })
+        // Ancestors outside home are authorized only as existence probes.
+        if (
+          directoryPath !== homeRoot &&
+          (directoryPath === '/' || homeRoot.startsWith(`${directoryPath}/`))
+        ) {
+          return { ok: true, entries }
+        }
+        for (;;) {
+          const entry = await directory.read()
+          if (entry === null) {
+            break
+          }
+          trackFilesystemDirectoryEntry(limit, { name: entry.name })
+          entries.push({ filename: entry.name })
+        }
+        return { ok: true, entries }
       } catch (err) {
         return failure(err)
+      } finally {
+        await directory?.close().catch(() => undefined)
       }
     }
   )


### PR DESCRIPTION
## OOM hardening slice 20/29 — bound relay transport, listings & log rotation

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **20/29** (base: `oom/19-b-integrations-scm`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Re-lands the OOM ceilings across the entire relay (remote SSH/WSL host) surface: bounds request/stream/client cardinality and retained bytes, converts subprocess and file reads to bounded accumulators, and replaces the fire-and-forget PTY output batcher with a per-client, ack-credited, backpressure-aware broadcaster that pauses the PTY and can evict lagging clients.

### ELI5
Imagine a helper program running on a remote computer that pipes your terminal, files, and git info back to your laptop. Before, if something sent a giant flood of data (or a malicious message), the helper would try to hold all of it in memory and could crash. This change adds "you can only hold this many, and this many bytes" fences everywhere, and teaches the terminal pipe to slow down and wait for your laptop to say "got it" before sending more. The one thing to watch: the terminal now expects your laptop to send those "got it" receipts, so the matching laptop-side change has to ship at the same time or terminals could freeze after a big burst.

### Proof of OOM fix
- client-request-aborts.ts: MAX_ACTIVE_RELAY_REQUESTS_PER_CLIENT=256, MAX_ACTIVE_RELAY_REQUESTS=1024, per-client bytes 32MB, global 64MB; over-limit rejects with RelayRequestAdmissionError. Tested in client-request-aborts.test.ts.
- dispatcher.ts: MAX_RELAY_DISPATCHER_CLIENTS=16, MAX_RELAY_SOCKET_CONNECTIONS=15, MAX_PENDING_RELAY_REQUESTS=256; pending requests rejected on client disconnect/reconnect. Tested in dispatcher.test.ts.
- pty-output-flow-state.ts: PTY_OUTPUT_HIGH_WATER_CHARS=256KB, PTY_OUTPUT_LOW_WATER_CHARS=32KB; producer paused when all clients backpressured, resumed under low-water. Tested in pty-output-broadcast.test.ts.
- pty-persistence-envelope.ts: state<=8MB, field<=64KB, entry<=128KB, retained<=6MB, envToDelete<=1024 keys; JSON structure limits 131072 tokens/depth 8. Tested in pty-persistence-envelope.test.ts.
- git-response-stream.ts: MAX_CONCURRENT_GIT_RESPONSE_STREAMS=MAX_CONCURRENT_STREAMS, MAX_ACTIVE_GIT_RESPONSE_STREAM_BYTES=128MB, MAX_GIT_RESPONSE_STREAM_BYTES=64MB/4096 chunks; UTF-8-safe string chunking avoids a second base64 copy. Tested in git-response-stream-ownership.test.ts, git-response-utf8-chunks.test.ts.
- protocol.ts: MAX_MESSAGE_SIZE=16MB, MAX_BUFFERED_FRAME_CHUNKS=4096; FrameDecoder now stream-discards oversized payloads (13-byte header can no longer pin ~4GiB) and coalesces adversarial tiny chunks. Tested in protocol-handshake.test.ts, protocol-json-encoding-memory.test.ts.
- agent-exec-handler.ts: MAX_CONCURRENT_AGENT_EXECS=8, MAX_OUTPUT_BYTES=4MB via GrowingByteBuffer. Tested in agent-exec-handler.test.ts.
- git-handler-submodule-ops.ts: maxBuffer 10MB, MAX_SUBMODULE_PATHS_PER_REPO=10000, path 64KB/repo 4MB/cache 16MB code-unit caps. Tested in git-handler-submodule-ops.test.ts.
- workspace-session-handler.ts: MAX_PRESENCE_NAMESPACES=256, MAX_PRESENCE_CLIENTS_PER_NAMESPACE=64, snapshot 16MB/1M tokens/depth 128 with oldest eviction. Tested in workspace-session-handler.test.ts.
- relay-watcher-root-capacity.ts: MAX_RELAY_WATCH_ROOTS=20, root-key 64KB, aggregate root-keys 256KB. Tested in relay-watcher-root-capacity.test.ts.
- port-scan-handler.ts: LINUX_PROC_LISTENING_SOCKET_MAX_ENTRIES=2048, proc-net table 8MB, per-file cmdline 64KB (shared linux-proc-port-scan-limits). Tested in port-scan-handler.test.ts.
- fs/quick-open bounds (shared quick-open-listing-limits): QUICK_OPEN_LISTING_MAX_RESULTS=20001, retained paths 100000/32MB, path 64KB; agent-hook status cache 256 panes; git pointer file 64KB; upstream negative-cache key 64KB.

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **low**: fs.listFiles with no maxResults is now always capped at QUICK_OPEN_LISTING_MAX_RESULTS (20001) and runs the primary then ignored pass sequentially instead of an unbounded parallel Promise.all; previously an unbounded request returned every file. _(trigger: Quick Open / file listing over SSH in a repo with >20001 matching files.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Relay rejects the 17th client / 16th socket connection and the 257th per-client (or 1025th global) in-flight request; requires an abusive fan-out of SSH channels far beyond ordinary use.
- git.exec responses over 64MB serialized (or >4096 chunks, or 128MB concurrent retained) are refused with a StreamProtocolError instead of transferred — only reachable by pathological git output.
- Repos with >10000 submodules or >4MB of submodule-path text return an empty submodule list; >2048 listening sockets on a host truncate the port scan; both are far above realistic values.
- PTY producer is paused (terminal output throttled) only when every attached client is at the 256KB unacked high-water and sink-saturated; normal single-fast-client terminals never pause.
- Lagging-client eviction (disconnecting a slow client) only fires with MULTIPLE clients attached to the same PTY when total pending backlog crosses 256KB and another client is caught up; a single client is never evicted.
- Oversized relay frame handling, tiny-chunk coalescing, and stdin/file byte caps only engage on adversarial or 16MB+ inputs.
- PTY output delivery is rewritten to require ack credit: relay now stamps each pty.data with a deliveryToken and only advances a client once it sends pty.ackData{charCount,deliveryToken}. At BASE the SSH client sends pty.ackData with only {id,charCount} and no token, which the new relay rejects (acknowledge() returns early when deliveryToken mismatches). If this relay slice ships without its paired src/main/providers/ssh-pty-output-delivery-credit.ts change, a client that never supplies a valid token accrues unackedChars up to 256KB, the producer is paused, and terminal output freezes. _(only when: SSH/WSL terminal producing >256KB of output when the relay is deployed without the matching main-side delivery-credit slice (landing-order/co-deploy dependency).)_
- When several clients share one PTY (multi-device attach), a client whose backlog keeps total pending output above 256KB while another client is caught up is evicted (disconnected) via dispatcher.evictClient, rather than merely being throttled. Intended anti-HOL-blocking behavior but a visible disconnect for the slow device. _(only when: Two or more clients attached to the same terminal where one falls persistently >256KB behind.)_
- fs.listFiles over the relay (and the paired local path, for parity) now caps a no-maxResults request at QUICK_OPEN_LISTING_MAX_RESULTS (20001). At BASE, callers like OrcaRuntimeFiles.listRuntimeFiles (provider.listFiles(worktree.path,{excludePaths})) and the fs:listFiles IPC passed no maxResults and received the ENTIRE file tree; TARGET truncates to 20001 files in rg traversal order. For a large-but-normal monorepo over SSH (>20k source files after excludes), files beyond 20001 are no longer returned to Quick Open / file listing, so they become unfindable. Genuinely visible below any abusive threshold, but 20001 is far above typical repo source-file counts and the change is deliberate, applied product-wide (local + remote), and passed full CI. A sign-off item, not a defect. _(only when: Quick Open / runtime file listing over SSH (or locally) in a repo with more than 20001 non-excluded files.)_
- PTY output delivery is rewritten from fire-and-forget dispatcher.notify('pty.data') to a per-client ack-credited broadcaster: each pty.data carries a per-client deliveryToken (randomUUID) and PtyOutputBroadcast.acknowledge() ignores any pty.ackData whose deliveryToken does not match (BASE's ackData handler was a no-op). A client accrues unackedChars up to PTY_OUTPUT_HIGH_WATER_CHARS (256KB); once every attached flow is at/over that high-water, updatePtyOutputProducer pauses the PTY and terminal output freezes. Correct and invisible in fully-landed TARGET, but the token-emitting client side lives in a DIFFERENT slice (src/main/providers/ssh-pty-output-delivery-credit.ts, not in this bucket). If the relay slice is deployed ahead of that main-side slice, any SSH/WSL terminal producing >256KB freezes. Relay and main ship as one versioned unit in production, so this is a landing-order/co-deploy caveat, not a fully-integrated regression. _(only when: This relay slice landed/deployed WITHOUT the paired src/main ssh-pty-output-delivery-credit slice, then an SSH/WSL terminal emits >256KB of output.)_
- Multi-device attach: when two+ clients share one PTY and one falls >256KB behind while another is caught up, the lagging client is DISCONNECTED (dispatcher.evictClient via evictLaggingClientsWhenHealthy in pty-output-broadcast.ts), not merely throttled. At BASE an attached client on a slow sink was never disconnected for lag. evictablePtyOutputClientIds treats any client with pending output as lagging, so a briefly-slow second device can be dropped alongside a genuinely stuck one. Guarded so a single client is never evicted. _(only when: Two+ devices attached to the same terminal, one on a slow/saturated sink, while the producer emits >256KB before the slow client drains (e.g. a build flood plus a second device on weak wifi).)_
- This relay slice is protocol-incompatible with the BASE SSH client. `/Users/nwparker/orca/workspaces/orca/oom-followup/src/relay/pty-output-broadcast.ts:74-94` requires a matching `deliveryToken` before returning PTY credit, while BASE `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/providers/ssh-pty-provider.ts:270-272` emits `pty.ackData` with only `{id,charCount}`. Without the paired target-side `ssh-pty-output-delivery-credit.ts`, an otherwise healthy SSH/WSL terminal reaches 256 KiB unacknowledged output and the relay pauses the PTY indefinitely. This is a confirmed landing/co-deployment dependency, not a speculative concern. _(only when: Land/deploy this relay slice without the paired main-side delivery-credit slice, then produce at least 256 KiB of terminal output.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.

### Adversarial review
- 3 skeptic lens(es) incl. a frontier-model (GPT) cross-check. Sign-off: **FLAGGED — see above**. Residual risk: **high**.
- Verified actual numeric ceilings; almost all are far above ordinary use (overload-only): MAX_RELAY_DISPATCHER_CLIENTS=16 / SOCKET_CONNECTIONS=15, MAX_ACTIVE_RELAY_REQUESTS=1024 (256/client), request bytes 64MB (32MB/client), MAX_CONCURRENT_AGENT_EXECS=8 (short-lived commit/PR-gen execs; hard-fails 'Remote agent execution capacity reached', no queue, but 9+ concurrent on one host is atypical), agent exec MAX_OUTPUT_BYTES=4MB (same truncation semantics as BASE), git response stream 64MB / 128MB concurrent / 4096 chunks, MAX_SUBMODULE_PATHS_PER_REPO=10000, PTY persistence field=64KB/entry=128KB/state=8MB/retained=6MB (metadata only: cwd/paneKey/tabId/env keys, NOT scrollback), MAX_RELAY_PTY_ENV_DELETE_KEYS=1024, presence 64 clients/namespace and 256 namespaces, port scan 2048 sockets, MAX_RELAY_WATCH_ROOTS=20 (count limit is PRE-EXISTING at BASE — only new byte key caps 64KB/256KB were added, path-length overload only). PTY producer pause + lagging-client eviction: verified evictablePtyOutputClientIds returns [] unless (a) backlog >=256KB AND (b) at least one OTHER caught-up sendable client exists, so a single-client terminal is NEVER evicted and never pauses under prompt acking; eviction is strictly a multi-device-attach anti-HOL-blocking behavior. FIFO/ordering preserved (pending[] iterated from index 0, per-client blocked set). Cleanup verified: onClientDetached, removePtyOutputClient, unregister/dispose all resume the producer and cancel drain callbacks. The two normal-path items above (Quick Open 20001 cap; ack-credit co-deploy dependency) are deliberate, CI-passed, and either high-above-typical or manifest only under out-of-order slice landing — worth explicit human sign-off but not blocking a draft PR. No off-by-one, missing-release, or broken-ordering defect found.

### Files
77 files changed (+5152 / −1155).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
