### PR TITLE
oom(21/29): bound remote-runtime RPC, transport & waiters

### DIFF
--- a/src/main/runtime/agent-session-claim-identity.test.ts
+++ b/src/main/runtime/agent-session-claim-identity.test.ts
@@ -1,7 +1,11 @@
+import { closeSync, ftruncateSync, mkdtempSync, openSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   canonicalizeAgentSessionIdentity,
-  createEphemeralAgentSessionClaimSigner
+  createEphemeralAgentSessionClaimSigner,
+  loadAgentSessionClaimSigner
 } from './agent-session-claim-identity'
 
 describe('agent session claim identity', () => {
@@ -39,5 +43,18 @@ describe('agent session claim identity', () => {
     expect(() =>
       canonicalizeAgentSessionIdentity('blank', { key: 'session_id', id: 'session-1' })
     ).toThrow('agent_session_identity_required')
+  })
+
+  it('rejects an oversized persisted coordination key before reading it', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'orca-claim-key-'))
+    try {
+      const descriptor = openSync(join(directory, 'agent-session-authority.key'), 'w')
+      ftruncateSync(descriptor, 1024 * 1024 * 1024)
+      closeSync(descriptor)
+
+      expect(() => loadAgentSessionClaimSigner(directory, 'profile-1')).toThrow()
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/runtime/agent-session-claim-identity.ts
+++ b/src/main/runtime/agent-session-claim-identity.ts
@@ -1,13 +1,5 @@
 import { createHash, createHmac, randomBytes } from 'node:crypto'
-import {
-  closeSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  realpathSync,
-  statSync,
-  writeFileSync
-} from 'node:fs'
+import { closeSync, mkdirSync, openSync, realpathSync, statSync, writeFileSync } from 'node:fs'
 import { dirname, isAbsolute, join, normalize } from 'node:path'
 import {
   AGENT_SESSION_CLAIM_DIGEST_VERSION,
@@ -20,6 +12,7 @@ import {
   type AgentProviderSessionMetadata,
   type ResumableTuiAgent
 } from '../../shared/agent-session-resume'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
 
 const COORDINATION_KEY_BYTES = 32
 const COORDINATION_KEY_FILE = 'agent-session-authority.key'
@@ -146,7 +139,7 @@ export function loadAgentSessionClaimSigner(
   mkdirSync(dirname(keyPath), { recursive: true })
   let key: Buffer
   try {
-    key = readFileSync(keyPath)
+    key = readNodeFileSyncWithinLimit(keyPath, COORDINATION_KEY_BYTES).buffer
   } catch {
     const candidate = randomBytes(COORDINATION_KEY_BYTES)
     let fd: number | null = null
@@ -155,7 +148,7 @@ export function loadAgentSessionClaimSigner(
       writeFileSync(fd, candidate)
       key = candidate
     } catch {
-      key = readFileSync(keyPath)
+      key = readNodeFileSyncWithinLimit(keyPath, COORDINATION_KEY_BYTES).buffer
     } finally {
       if (fd !== null) {
         closeSync(fd)

--- a/src/main/runtime/claude-agent-teams-shim-env.test.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, stat, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -23,6 +23,19 @@ describe('claude agent teams shim env', () => {
     await ensureClaudeAgentTeamsShimDir(root)
 
     await expect(readFile(join(root, 'tmux'), 'utf8')).resolves.toContain('agent-teams-tmux "$@"')
+  })
+
+  it('replaces a large sparse shim without reading its payload', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-agent-teams-large-shim-'))
+    roots.push(root)
+    await ensureClaudeAgentTeamsShimDir(root)
+    const shimPath = join(root, 'tmux')
+    await truncate(shimPath, 256 * 1024 * 1024)
+
+    await ensureClaudeAgentTeamsShimDir(root)
+
+    expect((await stat(shimPath)).size).toBeLessThan(64 * 1024)
+    await expect(readFile(shimPath, 'utf8')).resolves.toContain('agent-teams-tmux "$@"')
   })
 
   it('builds native shim env only for direct Claude commands', async () => {

--- a/src/main/runtime/claude-agent-teams-shim-env.ts
+++ b/src/main/runtime/claude-agent-teams-shim-env.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, rename, rm, writeFile } from 'node:fs/promises'
 import { accessSync, constants, existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, join } from 'node:path'
@@ -8,6 +8,7 @@ import {
   isDirectClaudeCommand,
   type ClaudeAgentTeamsMode
 } from '../../shared/claude-agent-teams-tmux-compat'
+import { nodeFileContentsEqual } from '../../shared/node-file-content-equality'
 import { getOrcaCliCommandNameForPlatform } from '../../shared/orca-cli-command-name'
 
 export type ClaudeAgentTeamsLaunchPlan = {
@@ -136,7 +137,7 @@ function windowsShimScript(): string {
 
 async function writeIfChanged(path: string, content: string): Promise<void> {
   try {
-    if ((await readFile(path, 'utf8')) === content) {
+    if (await nodeFileContentsEqual(path, content)) {
       return
     }
   } catch {

--- a/src/main/runtime/client-session-tab-selection-bounds.test.ts
+++ b/src/main/runtime/client-session-tab-selection-bounds.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../shared/runtime-types'
+import type { PersistedMobileClientTabSelection } from '../../shared/types'
+import { ClientSessionTabSelectionStore } from './client-session-tab-selection'
+import {
+  isMobileTabSelectionIdRetainable,
+  MOBILE_TAB_SELECTION_ID_MAX_BYTES,
+  MOBILE_TAB_SELECTION_MAX_BYTES_PER_CLIENT,
+  MOBILE_TAB_SELECTION_MAX_CLIENTS,
+  MOBILE_TAB_SELECTION_MAX_GROUPS_PER_WORKTREE,
+  MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT,
+  mobileTabSelectionRetainedBytes,
+  normalizePersistedMobileClientTabSelections
+} from './client-session-tab-selection-persistence'
+
+function selection(
+  activeTabIdByGroupId: Readonly<Record<string, string>> = {}
+): PersistedMobileClientTabSelection {
+  return { activeTabId: 'browser-1', activeGroupId: 'group-1', activeTabIdByGroupId }
+}
+
+function snapshot(worktree: string): RuntimeMobileSessionTabsResult {
+  return {
+    worktree,
+    publicationEpoch: 'renderer:1',
+    snapshotVersion: 1,
+    activeGroupId: 'group-1',
+    activeTabId: 'browser-1',
+    activeTabType: 'browser',
+    tabGroups: [{ id: 'group-1', activeTabId: 'browser-1', tabOrder: ['browser-1'] }],
+    tabs: [
+      {
+        type: 'browser',
+        id: 'browser-1',
+        browserWorkspaceId: 'browser-workspace',
+        browserPageId: 'page-1',
+        title: 'Browser',
+        url: 'about:blank',
+        loading: false,
+        canGoBack: false,
+        canGoForward: false,
+        isActive: true
+      }
+    ]
+  }
+}
+
+describe('client session-tab selection retention bounds', () => {
+  it('keeps the newest persisted clients without changing accepted selections', () => {
+    const clients = Object.fromEntries(
+      Array.from({ length: MOBILE_TAB_SELECTION_MAX_CLIENTS + 2 }, (_, index) => [
+        `device-${index}`,
+        { 'wt-1': selection() }
+      ])
+    )
+
+    const normalized = normalizePersistedMobileClientTabSelections(clients)
+
+    expect(Object.keys(normalized)).toHaveLength(MOBILE_TAB_SELECTION_MAX_CLIENTS)
+    expect(Object.keys(normalized).at(0)).toBe('device-2')
+    expect(normalized[`device-${MOBILE_TAB_SELECTION_MAX_CLIENTS + 1}`]?.['wt-1']).toEqual(
+      selection()
+    )
+  })
+
+  it('keeps the newest worktrees and group selections within each client', () => {
+    const groups = Object.fromEntries(
+      Array.from({ length: MOBILE_TAB_SELECTION_MAX_GROUPS_PER_WORKTREE + 2 }, (_, index) => [
+        `group-${index}`,
+        `tab-${index}`
+      ])
+    )
+    const worktrees = Object.fromEntries(
+      Array.from({ length: MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT + 2 }, (_, index) => [
+        `wt-${index}`,
+        selection(index === MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT + 1 ? groups : {})
+      ])
+    )
+
+    const normalized = normalizePersistedMobileClientTabSelections({ 'device-1': worktrees })
+    const retainedWorktrees = normalized['device-1']!
+    const retainedGroups =
+      retainedWorktrees[`wt-${MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT + 1}`]!
+        .activeTabIdByGroupId
+
+    expect(Object.keys(retainedWorktrees)).toHaveLength(
+      MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT
+    )
+    expect(Object.keys(retainedWorktrees).at(0)).toBe('wt-2')
+    expect(Object.keys(retainedGroups)).toHaveLength(MOBILE_TAB_SELECTION_MAX_GROUPS_PER_WORKTREE)
+    expect(Object.keys(retainedGroups).at(0)).toBe('group-2')
+  })
+
+  it('bounds clients and worktrees created during the current runtime', () => {
+    const clientStore = new ClientSessionTabSelectionStore()
+    for (let index = 0; index <= MOBILE_TAB_SELECTION_MAX_CLIENTS; index++) {
+      clientStore.activate(snapshot('wt-1'), `device-${index}`, 'browser-1')
+    }
+    const retainedClients = clientStore.serialize()
+
+    expect(Object.keys(retainedClients)).toHaveLength(MOBILE_TAB_SELECTION_MAX_CLIENTS)
+    expect(retainedClients['device-0']).toBeUndefined()
+    expect(retainedClients[`device-${MOBILE_TAB_SELECTION_MAX_CLIENTS}`]).toBeDefined()
+
+    const worktreeStore = new ClientSessionTabSelectionStore()
+    for (let index = 0; index <= MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT; index++) {
+      worktreeStore.activate(snapshot(`wt-${index}`), 'device-1', 'browser-1')
+    }
+    const retainedWorktrees = worktreeStore.serialize()['device-1']!
+
+    expect(Object.keys(retainedWorktrees)).toHaveLength(
+      MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT
+    )
+    expect(retainedWorktrees['wt-0']).toBeUndefined()
+    expect(retainedWorktrees[`wt-${MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT}`]).toBeDefined()
+  })
+
+  it('rejects relay-sized client and worktree ids instead of retaining them', () => {
+    const oversizedId = 'x'.repeat(MOBILE_TAB_SELECTION_ID_MAX_BYTES + 1)
+    expect(isMobileTabSelectionIdRetainable(oversizedId)).toBe(false)
+    expect(
+      normalizePersistedMobileClientTabSelections({
+        [oversizedId]: { 'wt-1': selection() },
+        'device-1': { [oversizedId]: selection() }
+      })
+    ).toEqual({})
+
+    const store = new ClientSessionTabSelectionStore()
+    const ordinarySnapshot = snapshot('wt-1')
+    expect(store.activate(ordinarySnapshot, oversizedId, 'browser-1')).toBe(ordinarySnapshot)
+    const oversizedWorktreeSnapshot = snapshot(oversizedId)
+    expect(store.activate(oversizedWorktreeSnapshot, 'device-1', 'browser-1')).toBe(
+      oversizedWorktreeSnapshot
+    )
+    expect(store.serialize()).toEqual({})
+  })
+
+  it('retains newest worktree selections within the per-client byte budget', () => {
+    const fixedSizeId = (prefix: string, index: number): string => {
+      const label = `${prefix}-${index}-`
+      return `${label}${'x'.repeat(MOBILE_TAB_SELECTION_ID_MAX_BYTES - label.length)}`
+    }
+    const groups = Object.fromEntries(
+      Array.from({ length: MOBILE_TAB_SELECTION_MAX_GROUPS_PER_WORKTREE }, (_, index) => [
+        fixedSizeId('group', index),
+        fixedSizeId('tab', index)
+      ])
+    )
+    const normalized = normalizePersistedMobileClientTabSelections({
+      'device-1': Object.fromEntries(
+        Array.from({ length: 10 }, (_, index) => [`wt-${index}`, selection(groups)])
+      )
+    })
+    const retained = normalized['device-1']!
+    const retainedBytes = Object.entries(retained).reduce(
+      (total, [worktreeId, value]) => total + mobileTabSelectionRetainedBytes(worktreeId, value),
+      0
+    )
+
+    expect(retainedBytes).toBeLessThanOrEqual(MOBILE_TAB_SELECTION_MAX_BYTES_PER_CLIENT)
+    expect(retained['wt-0']).toBeUndefined()
+    expect(retained['wt-9']).toBeDefined()
+  })
+})

--- a/src/main/runtime/client-session-tab-selection-persistence.ts
+++ b/src/main/runtime/client-session-tab-selection-persistence.ts
@@ -2,6 +2,105 @@ import type {
   PersistedMobileClientTabSelection,
   PersistedMobileClientTabSelections
 } from '../../shared/types'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export const MOBILE_TAB_SELECTION_MAX_CLIENTS = 64
+export const MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT = 512
+export const MOBILE_TAB_SELECTION_MAX_GROUPS_PER_WORKTREE = 128
+export const MOBILE_TAB_SELECTION_ID_MAX_BYTES = 4 * 1024
+export const MOBILE_TAB_SELECTION_MAX_BYTES_PER_SELECTION = 64 * 1024
+export const MOBILE_TAB_SELECTION_MAX_BYTES_PER_CLIENT = 256 * 1024
+
+export function isMobileTabSelectionIdRetainable(value: string): boolean {
+  return !measureUtf8ByteLength(value, {
+    stopAfterBytes: MOBILE_TAB_SELECTION_ID_MAX_BYTES
+  }).exceededLimit
+}
+
+function mobileTabSelectionStringBytes(value: string | null): number {
+  return value ? measureUtf8ByteLength(value).byteLength : 0
+}
+
+export function mobileTabSelectionRetainedBytes(
+  worktreeId: string,
+  selection: PersistedMobileClientTabSelection
+): number {
+  let bytes =
+    mobileTabSelectionStringBytes(worktreeId) +
+    mobileTabSelectionStringBytes(selection.activeTabId) +
+    mobileTabSelectionStringBytes(selection.activeGroupId)
+  for (const [groupId, tabId] of Object.entries(selection.activeTabIdByGroupId)) {
+    bytes += mobileTabSelectionStringBytes(groupId) + mobileTabSelectionStringBytes(tabId)
+  }
+  return bytes
+}
+
+function newestOwnEntries(
+  record: Record<string, unknown>,
+  maxEntries: number,
+  acceptKey: (key: string) => boolean = () => true
+): [string, unknown][] {
+  const entries: [string, unknown][] = []
+  let nextReplacementIndex = 0
+  for (const key in record) {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) {
+      continue
+    }
+    if (!acceptKey(key)) {
+      continue
+    }
+    const entry: [string, unknown] = [key, record[key]]
+    if (entries.length < maxEntries) {
+      entries.push(entry)
+    } else {
+      entries[nextReplacementIndex] = entry
+      nextReplacementIndex = (nextReplacementIndex + 1) % maxEntries
+    }
+  }
+  return nextReplacementIndex === 0
+    ? entries
+    : [...entries.slice(nextReplacementIndex), ...entries.slice(0, nextReplacementIndex)]
+}
+
+export function boundMobileClientTabSelectionGroups(
+  selection: PersistedMobileClientTabSelection
+): PersistedMobileClientTabSelection {
+  const activeTabId =
+    selection.activeTabId && isMobileTabSelectionIdRetainable(selection.activeTabId)
+      ? selection.activeTabId
+      : null
+  const activeGroupId =
+    selection.activeGroupId && isMobileTabSelectionIdRetainable(selection.activeGroupId)
+      ? selection.activeGroupId
+      : null
+  let retainedBytes =
+    mobileTabSelectionStringBytes(activeTabId) + mobileTabSelectionStringBytes(activeGroupId)
+  const retainedGroups: [string, string][] = []
+  const candidates = newestOwnEntries(
+    selection.activeTabIdByGroupId,
+    MOBILE_TAB_SELECTION_MAX_GROUPS_PER_WORKTREE,
+    isMobileTabSelectionIdRetainable
+  ).filter(
+    (entry): entry is [string, string] =>
+      typeof entry[1] === 'string' && isMobileTabSelectionIdRetainable(entry[1])
+  )
+  for (let index = candidates.length - 1; index >= 0; index--) {
+    const entry = candidates[index]!
+    const entryBytes =
+      mobileTabSelectionStringBytes(entry[0]) + mobileTabSelectionStringBytes(entry[1])
+    if (retainedBytes + entryBytes > MOBILE_TAB_SELECTION_MAX_BYTES_PER_SELECTION) {
+      break
+    }
+    retainedBytes += entryBytes
+    retainedGroups.push(entry)
+  }
+  return {
+    ...selection,
+    activeTabId,
+    activeGroupId,
+    activeTabIdByGroupId: Object.fromEntries(retainedGroups.toReversed())
+  }
+}
 
 function normalizeClientSessionTabSelection(
   raw: unknown
@@ -10,16 +109,28 @@ function normalizeClientSessionTabSelection(
     return null
   }
   const candidate = raw as Partial<PersistedMobileClientTabSelection>
-  const activeTabId = typeof candidate.activeTabId === 'string' ? candidate.activeTabId : null
-  const activeGroupId = typeof candidate.activeGroupId === 'string' ? candidate.activeGroupId : null
+  const activeTabId =
+    typeof candidate.activeTabId === 'string' &&
+    isMobileTabSelectionIdRetainable(candidate.activeTabId)
+      ? candidate.activeTabId
+      : null
+  const activeGroupId =
+    typeof candidate.activeGroupId === 'string' &&
+    isMobileTabSelectionIdRetainable(candidate.activeGroupId)
+      ? candidate.activeGroupId
+      : null
   const activeTabIdByGroupId: Record<string, string> = {}
   if (
     typeof candidate.activeTabIdByGroupId === 'object' &&
     candidate.activeTabIdByGroupId &&
     !Array.isArray(candidate.activeTabIdByGroupId)
   ) {
-    for (const [groupId, tabId] of Object.entries(candidate.activeTabIdByGroupId)) {
-      if (typeof tabId === 'string') {
+    for (const [groupId, tabId] of newestOwnEntries(
+      candidate.activeTabIdByGroupId as Record<string, unknown>,
+      MOBILE_TAB_SELECTION_MAX_GROUPS_PER_WORKTREE,
+      isMobileTabSelectionIdRetainable
+    )) {
+      if (typeof tabId === 'string' && isMobileTabSelectionIdRetainable(tabId)) {
         activeTabIdByGroupId[groupId] = tabId
       }
     }
@@ -27,7 +138,7 @@ function normalizeClientSessionTabSelection(
   if (!activeTabId && !activeGroupId && Object.keys(activeTabIdByGroupId).length === 0) {
     return null
   }
-  return { activeTabId, activeGroupId, activeTabIdByGroupId }
+  return boundMobileClientTabSelectionGroups({ activeTabId, activeGroupId, activeTabIdByGroupId })
 }
 
 // Why: this state comes off disk (and, for remote runtimes, another machine); a bad payload must degrade to "no selection", not throw.
@@ -38,7 +149,11 @@ export function normalizePersistedMobileClientTabSelections(
   if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
     return normalized
   }
-  for (const [clientNavigationId, selectionsByWorktree] of Object.entries(raw)) {
+  for (const [clientNavigationId, selectionsByWorktree] of newestOwnEntries(
+    raw as Record<string, unknown>,
+    MOBILE_TAB_SELECTION_MAX_CLIENTS,
+    isMobileTabSelectionIdRetainable
+  )) {
     if (
       typeof selectionsByWorktree !== 'object' ||
       selectionsByWorktree === null ||
@@ -46,15 +161,29 @@ export function normalizePersistedMobileClientTabSelections(
     ) {
       continue
     }
-    const entries: Record<string, PersistedMobileClientTabSelection> = {}
-    for (const [worktreeId, selection] of Object.entries(selectionsByWorktree)) {
+    const entries = new Map<string, PersistedMobileClientTabSelection>()
+    let retainedBytes = 0
+    for (const [worktreeId, selection] of newestOwnEntries(
+      selectionsByWorktree as Record<string, unknown>,
+      MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT,
+      isMobileTabSelectionIdRetainable
+    )) {
       const normalizedSelection = normalizeClientSessionTabSelection(selection)
       if (normalizedSelection) {
-        entries[worktreeId] = normalizedSelection
+        entries.set(worktreeId, normalizedSelection)
+        retainedBytes += mobileTabSelectionRetainedBytes(worktreeId, normalizedSelection)
+        while (retainedBytes > MOBILE_TAB_SELECTION_MAX_BYTES_PER_CLIENT) {
+          const oldest = entries.entries().next()
+          if (oldest.done) {
+            break
+          }
+          entries.delete(oldest.value[0])
+          retainedBytes -= mobileTabSelectionRetainedBytes(oldest.value[0], oldest.value[1])
+        }
       }
     }
-    if (Object.keys(entries).length > 0) {
-      normalized[clientNavigationId] = entries
+    if (entries.size > 0) {
+      normalized[clientNavigationId] = Object.fromEntries(entries)
     }
   }
   return normalized

--- a/src/main/runtime/client-session-tab-selection-retention.ts
+++ b/src/main/runtime/client-session-tab-selection-retention.ts
@@ -1,0 +1,64 @@
+import type { ClientSessionTabSelection } from './client-session-tab-selection'
+import {
+  isMobileTabSelectionIdRetainable,
+  MOBILE_TAB_SELECTION_MAX_BYTES_PER_CLIENT,
+  MOBILE_TAB_SELECTION_MAX_CLIENTS,
+  MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT,
+  mobileTabSelectionRetainedBytes
+} from './client-session-tab-selection-persistence'
+
+export type StoredClientSessionTabSelection = {
+  selection: ClientSessionTabSelection
+  revision: number
+  shouldPersist: boolean
+}
+
+export function getOrCreateClientTabSelectionWorktrees(
+  statesByClient: Map<string, Map<string, StoredClientSessionTabSelection>>,
+  clientNavigationId: string
+): Map<string, StoredClientSessionTabSelection> {
+  let statesByWorktree = statesByClient.get(clientNavigationId)
+  if (!statesByWorktree) {
+    if (statesByClient.size >= MOBILE_TAB_SELECTION_MAX_CLIENTS) {
+      const oldestClientId = statesByClient.keys().next().value
+      if (oldestClientId !== undefined) {
+        statesByClient.delete(oldestClientId)
+      }
+    }
+    statesByWorktree = new Map()
+    statesByClient.set(clientNavigationId, statesByWorktree)
+  }
+  return statesByWorktree
+}
+
+export function rememberClientTabSelectionWorktree(
+  statesByWorktree: Map<string, StoredClientSessionTabSelection>,
+  worktreeId: string,
+  state: StoredClientSessionTabSelection
+): void {
+  if (!isMobileTabSelectionIdRetainable(worktreeId)) {
+    return
+  }
+  if (
+    !statesByWorktree.has(worktreeId) &&
+    statesByWorktree.size >= MOBILE_TAB_SELECTION_MAX_WORKTREES_PER_CLIENT
+  ) {
+    const oldestWorktreeId = statesByWorktree.keys().next().value
+    if (oldestWorktreeId !== undefined) {
+      statesByWorktree.delete(oldestWorktreeId)
+    }
+  }
+  statesByWorktree.set(worktreeId, state)
+  let retainedBytes = 0
+  for (const [retainedWorktreeId, retainedState] of statesByWorktree) {
+    retainedBytes += mobileTabSelectionRetainedBytes(retainedWorktreeId, retainedState.selection)
+  }
+  while (retainedBytes > MOBILE_TAB_SELECTION_MAX_BYTES_PER_CLIENT) {
+    const oldest = statesByWorktree.entries().next()
+    if (oldest.done) {
+      break
+    }
+    statesByWorktree.delete(oldest.value[0])
+    retainedBytes -= mobileTabSelectionRetainedBytes(oldest.value[0], oldest.value[1].selection)
+  }
+}

--- a/src/main/runtime/client-session-tab-selection.ts
+++ b/src/main/runtime/client-session-tab-selection.ts
@@ -3,19 +3,21 @@ import type {
   RuntimeMobileSessionTabsResult
 } from '../../shared/runtime-types'
 import type { PersistedMobileClientTabSelections } from '../../shared/types'
-import { normalizePersistedMobileClientTabSelections } from './client-session-tab-selection-persistence'
+import {
+  boundMobileClientTabSelectionGroups,
+  isMobileTabSelectionIdRetainable,
+  normalizePersistedMobileClientTabSelections
+} from './client-session-tab-selection-persistence'
+import {
+  getOrCreateClientTabSelectionWorktrees,
+  rememberClientTabSelectionWorktree,
+  type StoredClientSessionTabSelection
+} from './client-session-tab-selection-retention'
 
 export type ClientSessionTabSelection = {
   activeTabId: string | null
   activeGroupId: string | null
   activeTabIdByGroupId: Readonly<Record<string, string>>
-}
-
-type StoredClientSessionTabSelection = {
-  selection: ClientSessionTabSelection
-  revision: number
-  // Why: listAll projects every worktree; only hydrated or user-activated selections belong on disk.
-  shouldPersist: boolean
 }
 
 function emptyClientSessionTabSelection(): ClientSessionTabSelection {
@@ -42,7 +44,7 @@ function findTabByTopLevelId(
 export function deriveClientSessionTabSelection(
   snapshot: RuntimeMobileSessionTabsResult
 ): ClientSessionTabSelection {
-  return {
+  return boundMobileClientTabSelectionGroups({
     activeTabId: snapshot.activeTabId,
     activeGroupId: snapshot.activeGroupId,
     activeTabIdByGroupId: Object.fromEntries(
@@ -50,7 +52,7 @@ export function deriveClientSessionTabSelection(
         group.activeTabId ? [[group.id, group.activeTabId] as const] : []
       ) ?? []
     )
-  }
+  })
 }
 
 export function activateClientSessionTabSelection(
@@ -66,13 +68,13 @@ export function activateClientSessionTabSelection(
   const activeGroup = snapshot.tabGroups?.find((group) =>
     group.tabOrder.includes(activeTopLevelTabId)
   )
-  return {
+  return boundMobileClientTabSelectionGroups({
     activeTabId,
     activeGroupId: activeGroup?.id ?? selection.activeGroupId,
     activeTabIdByGroupId: activeGroup
       ? { ...selection.activeTabIdByGroupId, [activeGroup.id]: activeTopLevelTabId }
       : selection.activeTabIdByGroupId
-  }
+  })
 }
 
 export function projectClientSessionTabSelection(
@@ -110,11 +112,11 @@ export function projectClientSessionTabSelection(
       : null) ??
     tabGroups?.[0]?.id ??
     null
-  const nextSelection: ClientSessionTabSelection = {
+  const nextSelection: ClientSessionTabSelection = boundMobileClientTabSelectionGroups({
     activeTabId: activeTab?.id ?? null,
     activeGroupId,
     activeTabIdByGroupId
-  }
+  })
   return {
     selection: nextSelection,
     snapshot: {
@@ -137,9 +139,16 @@ export class ClientSessionTabSelectionStore {
     for (const [clientNavigationId, selectionsByWorktree] of Object.entries(
       normalizePersistedMobileClientTabSelections(persisted)
     )) {
-      const statesByWorktree = this.getStatesByWorktree(clientNavigationId)
+      const statesByWorktree = getOrCreateClientTabSelectionWorktrees(
+        this.statesByClient,
+        clientNavigationId
+      )
       for (const [worktreeId, selection] of Object.entries(selectionsByWorktree)) {
-        statesByWorktree.set(worktreeId, { selection, revision: 0, shouldPersist: true })
+        rememberClientTabSelectionWorktree(statesByWorktree, worktreeId, {
+          selection,
+          revision: 0,
+          shouldPersist: true
+        })
       }
     }
   }
@@ -168,25 +177,21 @@ export class ClientSessionTabSelectionStore {
     this.persistListener?.(this.serialize())
   }
 
-  private getStatesByWorktree(
-    clientNavigationId: string
-  ): Map<string, StoredClientSessionTabSelection> {
-    let statesByWorktree = this.statesByClient.get(clientNavigationId)
-    if (!statesByWorktree) {
-      statesByWorktree = new Map()
-      this.statesByClient.set(clientNavigationId, statesByWorktree)
-    }
-    return statesByWorktree
-  }
-
   project(
     snapshot: RuntimeMobileSessionTabsResult,
     clientNavigationId?: string
   ): RuntimeMobileSessionTabsResult {
-    if (!clientNavigationId) {
+    if (
+      !clientNavigationId ||
+      !isMobileTabSelectionIdRetainable(clientNavigationId) ||
+      !isMobileTabSelectionIdRetainable(snapshot.worktree)
+    ) {
       return snapshot
     }
-    const statesByWorktree = this.getStatesByWorktree(clientNavigationId)
+    const statesByWorktree = getOrCreateClientTabSelectionWorktrees(
+      this.statesByClient,
+      clientNavigationId
+    )
     const state = statesByWorktree.get(snapshot.worktree) ?? {
       // Why: host focus is private navigation; a new paired device starts from deterministic topology instead of inheriting it.
       selection: emptyClientSessionTabSelection(),
@@ -202,7 +207,7 @@ export class ClientSessionTabSelectionStore {
       }
     }
     const projected = projectClientSessionTabSelection(snapshot, state.selection)
-    statesByWorktree.set(snapshot.worktree, {
+    rememberClientTabSelectionWorktree(statesByWorktree, snapshot.worktree, {
       selection: projected.selection,
       revision: state.revision,
       shouldPersist: state.shouldPersist
@@ -219,14 +224,23 @@ export class ClientSessionTabSelectionStore {
     clientNavigationId: string,
     activeTabId: string
   ): RuntimeMobileSessionTabsResult {
-    const statesByWorktree = this.getStatesByWorktree(clientNavigationId)
+    if (
+      !isMobileTabSelectionIdRetainable(clientNavigationId) ||
+      !isMobileTabSelectionIdRetainable(snapshot.worktree)
+    ) {
+      return snapshot
+    }
+    const statesByWorktree = getOrCreateClientTabSelectionWorktrees(
+      this.statesByClient,
+      clientNavigationId
+    )
     const state = statesByWorktree.get(snapshot.worktree) ?? {
       selection: emptyClientSessionTabSelection(),
       revision: 0,
       shouldPersist: false
     }
     const nextSelection = activateClientSessionTabSelection(snapshot, state.selection, activeTabId)
-    statesByWorktree.set(snapshot.worktree, {
+    rememberClientTabSelectionWorktree(statesByWorktree, snapshot.worktree, {
       selection: nextSelection,
       revision: state.revision + 1,
       shouldPersist: true
@@ -255,8 +269,8 @@ export class ClientSessionTabSelectionStore {
       if (!state) {
         continue
       }
-      statesByWorktree.set(newWorktreeId, state)
       statesByWorktree.delete(oldWorktreeId)
+      rememberClientTabSelectionWorktree(statesByWorktree, newWorktreeId, state)
       changed = state.shouldPersist || changed
     }
     if (changed) {

--- a/src/main/runtime/device-registry.ts
+++ b/src/main/runtime/device-registry.ts
@@ -3,15 +3,28 @@
 // compromising one device doesn't expose others. The registry is a simple
 // JSON file with hardened permissions matching the runtime metadata pattern.
 import { randomBytes, randomUUID } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { hardenExistingSecureFile, writeSecureJsonFile } from '../../shared/secure-file'
+import { JsonStringifyByteLimitError } from '../../shared/node-bounded-json-stringify'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { writeSecureJsonFileWithinLimit } from '../../shared/bounded-secure-json-file'
+import { hardenExistingSecureFile } from '../../shared/secure-file'
 import type { DeviceScope } from '../../shared/runtime-types'
 import { DEVICE_REGISTRY_FILENAME } from './mobile-pairing-files'
 import type { RelayDeviceBinding } from './relay/relay-revoke-outbox'
 import type { MobilePairingConnectionMode } from '../../shared/mobile-pairing-connection-mode'
 
 export type { DeviceScope }
+
+export const MAX_DEVICE_REGISTRY_FILE_BYTES = 1024 * 1024
+export const MAX_DEVICE_REGISTRY_ENTRIES = 4096
+
+export class DeviceRegistryCapacityError extends Error {
+  constructor() {
+    super('Device registry exceeds its durable capacity')
+    this.name = 'DeviceRegistryCapacityError'
+  }
+}
 
 export type DeviceEntry = {
   deviceId: string
@@ -61,6 +74,9 @@ export class DeviceRegistry {
     name: string,
     scope: DeviceScope
   ): DeviceEntry {
+    if (existingDevices.length >= MAX_DEVICE_REGISTRY_ENTRIES) {
+      throw new DeviceRegistryCapacityError()
+    }
     const entry: DeviceEntry = {
       deviceId: randomUUID(),
       name,
@@ -102,13 +118,13 @@ export class DeviceRegistry {
   }
 
   removeDevice(deviceId: string): boolean {
-    const before = this.devices.length
-    this.devices = this.devices.filter((d) => d.deviceId !== deviceId)
-    if (this.devices.length < before) {
-      this.save()
-      return true
+    const nextDevices = this.devices.filter((device) => device.deviceId !== deviceId)
+    if (nextDevices.length === this.devices.length) {
+      return false
     }
-    return false
+    this.save(nextDevices)
+    this.devices = nextDevices
+    return true
   }
 
   getDevice(deviceId: string): DeviceEntry | null {
@@ -124,8 +140,12 @@ export class DeviceRegistry {
     if (!device || binding.relayDeviceId !== deviceId) {
       return false
     }
+    this.save(
+      this.devices.map((candidate) =>
+        candidate === device ? { ...candidate, relayBinding: binding } : candidate
+      )
+    )
     device.relayBinding = binding
-    this.save()
     return true
   }
 
@@ -134,8 +154,12 @@ export class DeviceRegistry {
     if (!device || device.scope !== 'mobile') {
       return false
     }
+    this.save(
+      this.devices.map((candidate) =>
+        candidate === device ? { ...candidate, mobilePairingConnectionMode: mode } : candidate
+      )
+    )
     device.mobilePairingConnectionMode = mode
-    this.save()
     return true
   }
 
@@ -160,8 +184,13 @@ export class DeviceRegistry {
   updateLastSeen(deviceId: string): void {
     const device = this.devices.find((d) => d.deviceId === deviceId)
     if (device) {
-      device.lastSeenAt = Date.now()
-      this.save()
+      const lastSeenAt = Date.now()
+      this.save(
+        this.devices.map((candidate) =>
+          candidate === device ? { ...candidate, lastSeenAt } : candidate
+        )
+      )
+      device.lastSeenAt = lastSeenAt
     }
   }
 
@@ -172,8 +201,16 @@ export class DeviceRegistry {
     }
     try {
       hardenExistingSecureFile(this.registryPath)
-      const parsed = JSON.parse(readFileSync(this.registryPath, 'utf-8')) as DeviceEntry[]
-      this.devices = parsed.map((device) => ({
+      const parsed: unknown = JSON.parse(
+        readNodeFileSyncWithinLimit(
+          this.registryPath,
+          MAX_DEVICE_REGISTRY_FILE_BYTES
+        ).buffer.toString('utf8')
+      )
+      if (!Array.isArray(parsed) || parsed.length > MAX_DEVICE_REGISTRY_ENTRIES) {
+        throw new DeviceRegistryCapacityError()
+      }
+      this.devices = (parsed as DeviceEntry[]).map((device) => ({
         ...device,
         // Why: older registries only existed for phone pairing. Treat missing
         // scope as mobile so legacy device tokens do not gain new CLI powers.
@@ -188,6 +225,13 @@ export class DeviceRegistry {
   }
 
   private save(devices: DeviceEntry[] = this.devices): void {
-    writeSecureJsonFile(this.registryPath, devices)
+    try {
+      writeSecureJsonFileWithinLimit(this.registryPath, devices, MAX_DEVICE_REGISTRY_FILE_BYTES)
+    } catch (error) {
+      if (error instanceof JsonStringifyByteLimitError) {
+        throw new DeviceRegistryCapacityError()
+      }
+      throw error
+    }
   }
 }

--- a/src/main/runtime/e2ee-keypair.ts
+++ b/src/main/runtime/e2ee-keypair.ts
@@ -1,15 +1,19 @@
 // Why: the E2EE keypair enables application-layer encryption between mobile
 // and desktop over plain ws://. The public key is embedded in the QR pairing
 // offer so the mobile client can derive a shared secret via ECDH.
-import { existsSync, readFileSync, statSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import nacl from 'tweetnacl'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
 import { hardenExistingSecureFile, writeSecureJsonFile } from '../../shared/secure-file'
 import { E2EE_KEYPAIR_FILENAME } from './mobile-pairing-files'
 
 const KEYPAIR_FILENAME = E2EE_KEYPAIR_FILENAME
 const KEYPAIR_VERSION = 1
-const MAX_KEYPAIR_FILE_BYTES = 8 * 1024
+export const MAX_KEYPAIR_FILE_BYTES = 8 * 1024
+export const MAX_KEYPAIR_JSON_STRUCTURAL_TOKENS = 2048
+export const MAX_KEYPAIR_JSON_NESTING_DEPTH = 8
 
 type KeypairFile = {
   v: number
@@ -29,12 +33,15 @@ export function loadOrCreateE2EEKeypair(userDataPath: string): E2EEKeypair {
   if (existsSync(filePath)) {
     try {
       hardenExistingSecureFile(filePath)
-      // Why: this startup path reads synchronously; valid keypair files are
-      // tiny, so oversized/corrupt files should be replaced without loading.
-      if (statSync(filePath).size > MAX_KEYPAIR_FILE_BYTES) {
-        throw new Error('E2EE keypair file is too large')
-      }
-      const raw: KeypairFile = JSON.parse(readFileSync(filePath, 'utf-8'))
+      const serialized = readNodeFileSyncWithinLimit(
+        filePath,
+        MAX_KEYPAIR_FILE_BYTES
+      ).buffer.toString('utf8')
+      assertJsonTextStructureWithinLimits(serialized, {
+        structuralTokens: MAX_KEYPAIR_JSON_STRUCTURAL_TOKENS,
+        nestingDepth: MAX_KEYPAIR_JSON_NESTING_DEPTH
+      })
+      const raw = JSON.parse(serialized) as KeypairFile
       if (raw.v === KEYPAIR_VERSION && raw.publicKeyB64 && raw.secretKeyB64) {
         const publicKey = Uint8Array.from(Buffer.from(raw.publicKeyB64, 'base64'))
         const secretKey = Uint8Array.from(Buffer.from(raw.secretKeyB64, 'base64'))

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -14,6 +14,7 @@ import type * as GitRunner from '../git/runner'
 const {
   lstatMock,
   openMock,
+  opendirMock,
   readdirMock,
   renameMock,
   resolveAuthorizedPathMock,
@@ -29,6 +30,7 @@ const {
   getLocalGitOptionsForRegisteredWorktreeMock: vi.fn(),
   lstatMock: vi.fn(),
   openMock: vi.fn(),
+  opendirMock: vi.fn(),
   readdirMock: vi.fn(),
   renameMock: vi.fn(),
   resolveAuthorizedPathMock: vi.fn(),
@@ -55,6 +57,10 @@ vi.mock('fs/promises', async () => {
     open: (...args: Parameters<typeof actual.open>) => {
       const impl = openMock.getMockImplementation()
       return impl ? openMock(...args) : actual.open(...args)
+    },
+    opendir: (...args: Parameters<typeof actual.opendir>) => {
+      const impl = opendirMock.getMockImplementation()
+      return impl ? opendirMock(...args) : actual.opendir(...args)
     },
     readdir: readdirMock,
     rename: renameMock,
@@ -97,13 +103,27 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
     'Remote connection dropped. Click Reconnect on the SSH target before retrying.'
 }))
 
-import { awaitRuntimeFileWatcherUnsubscribes, RuntimeFileCommands } from './orca-runtime-files'
+import {
+  awaitRuntimeFileWatcherUnsubscribes,
+  classifyRuntimeMobileDirectoryEntries,
+  RuntimeFileCommands
+} from './orca-runtime-files'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   resetSshConnectionGenerations,
   setSshConnectionGeneration
 } from '../ssh/ssh-connection-generation'
 import { SEARCH_TIMEOUT_MS } from '../../shared/text-search'
+
+function pngHeader(width = 1, height = 1): Buffer {
+  const bytes = Buffer.alloc(24)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
+  bytes.writeUInt32BE(13, 8)
+  bytes.write('IHDR', 12, 'ascii')
+  bytes.writeUInt32BE(width, 16)
+  bytes.writeUInt32BE(height, 20)
+  return bytes
+}
 
 type MockRuntimeSearchChild = EventEmitter & {
   stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
@@ -202,6 +222,7 @@ describe('RuntimeFileCommands', () => {
     vi.useFakeTimers()
     lstatMock.mockReset()
     openMock.mockReset()
+    opendirMock.mockReset()
     readdirMock.mockReset()
     renameMock.mockReset()
     resolveAuthorizedPathMock.mockReset()
@@ -212,6 +233,7 @@ describe('RuntimeFileCommands', () => {
     checkRgAvailableMock.mockReset()
     vi.mocked(getSshFilesystemProvider).mockReset()
     resetSshConnectionGenerations()
+    setSshConnectionGeneration('ssh-1', 0)
     getLocalGitOptionsForRegisteredWorktreeMock.mockReset()
     wslAwareSpawnMock.mockReset()
     getLocalGitOptionsForRegisteredWorktreeMock.mockReturnValue({})
@@ -298,6 +320,46 @@ describe('RuntimeFileCommands', () => {
     })
   })
 
+  it('validates local file explorer raster dimensions before returning base64', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'orca-runtime-image-preview-'))
+    const filePath = join(dir, 'image.png')
+    const content = pngHeader(640, 480)
+    await writeFile(filePath, content)
+    const { commands } = createRuntimeFileCommands({ path: dir })
+    resolveAuthorizedPathMock.mockImplementation(async (value: string) => value)
+    statMock.mockResolvedValue({ size: content.length })
+
+    try {
+      await expect(commands.readFileExplorerPreview('id:wt-1', 'image.png')).resolves.toEqual({
+        content: content.toString('base64'),
+        isBinary: true,
+        isImage: true,
+        mimeType: 'image/png',
+        imageDimensions: { width: 640, height: 480 }
+      })
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a local file explorer raster dimension bomb', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'orca-runtime-image-bomb-'))
+    const filePath = join(dir, 'bomb.png')
+    const content = pngHeader(32_769, 1)
+    await writeFile(filePath, content)
+    const { commands } = createRuntimeFileCommands({ path: dir })
+    resolveAuthorizedPathMock.mockImplementation(async (value: string) => value)
+    statMock.mockResolvedValue({ size: content.length })
+
+    try {
+      await expect(commands.readFileExplorerPreview('id:wt-1', 'bomb.png')).rejects.toThrow(
+        'Image dimensions exceed the preview safety limit'
+      )
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   it('leaves non-previewable binaries unavailable on mobile', async () => {
     const openFile = vi.fn()
     const { commands } = createRuntimeFileCommands({ openFile })
@@ -354,10 +416,12 @@ describe('RuntimeFileCommands', () => {
   it('does not follow symlinks when reading runtime-local file explorer dirs', async () => {
     const { commands } = createRuntimeFileCommands()
     resolveAuthorizedPathMock.mockResolvedValue('/repo')
-    readdirMock.mockResolvedValue([
-      dirEntry({ name: 'README.md' }),
-      dirEntry({ name: 'linked-docs', directory: true, symlink: true })
-    ])
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield dirEntry({ name: 'README.md' })
+        yield dirEntry({ name: 'linked-docs', directory: true, symlink: true })
+      }
+    })
 
     const result = await commands.readFileExplorerDir('id:wt-1', '')
 
@@ -366,6 +430,46 @@ describe('RuntimeFileCommands', () => {
       { name: 'README.md', isDirectory: false, isSymlink: false }
     ])
     expect(statMock).not.toHaveBeenCalledWith('/repo/linked-docs')
+  })
+
+  it('stops runtime-local directory enumeration at the mobile entry limit', async () => {
+    const { commands } = createRuntimeFileCommands()
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    let enumerated = 0
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        while (enumerated < 20_000) {
+          enumerated += 1
+          yield dirEntry({ name: 'entry' })
+        }
+      }
+    })
+
+    await expect(commands.readFileExplorerDir('id:wt-1', '')).rejects.toThrow(
+      'This folder is too large to show safely on mobile'
+    )
+    expect(enumerated).toBe(10_001)
+  })
+
+  it('bounds runtime-local directory classification while preserving entry order', async () => {
+    let active = 0
+    let maxActive = 0
+    const classify = vi.fn(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await Promise.resolve()
+      active -= 1
+      return true
+    })
+    const entries = Array.from({ length: 100 }, (_, index) =>
+      dirEntry({ name: `entry-${index}`, symlink: true })
+    )
+
+    const result = await classifyRuntimeMobileDirectoryEntries('/repo', entries, classify)
+
+    expect(maxActive).toBe(32)
+    expect(result.map((entry) => entry.name)).toEqual(entries.map((entry) => entry.name))
+    expect(result.every((entry) => entry.isDirectory && entry.isSymlink)).toBe(true)
   })
 
   it('renames a runtime-local file when destination does not exist', async () => {
@@ -799,7 +903,7 @@ describe('RuntimeFileCommands', () => {
       tempDirs = []
     })
 
-    async function tempFile(name: string, content: string): Promise<string> {
+    async function tempFile(name: string, content: string | Uint8Array): Promise<string> {
       const dir = await mkdtemp(join(tmpdir(), 'orca-terminal-artifact-'))
       tempDirs.push(dir)
       const filePath = join(dir, name)
@@ -1764,6 +1868,49 @@ describe('RuntimeFileCommands', () => {
           'client-a'
         )
       ).rejects.toThrow('terminal_file_grant_stale')
+    })
+
+    it('validates local terminal artifact raster dimensions before returning base64', async () => {
+      const content = pngHeader(320, 240)
+      const artifactPath = await tempFile('result.png', content)
+      const { commands } = createRuntimeFileCommands({ path: '/repo' })
+      resolveAuthorizedPathMock.mockImplementation(async (value: string) => value)
+
+      const result = await resolveTerminalArtifactPath(commands, artifactPath)
+      const target = absoluteFileTarget(result)
+
+      await expect(
+        commands.readTerminalArtifactPreview(
+          'id:wt-1',
+          target.grantId,
+          target.absolutePath,
+          'client-a'
+        )
+      ).resolves.toEqual({
+        content: content.toString('base64'),
+        isBinary: true,
+        isImage: true,
+        mimeType: 'image/png',
+        imageDimensions: { width: 320, height: 240 }
+      })
+    })
+
+    it('rejects a local terminal artifact raster dimension bomb', async () => {
+      const artifactPath = await tempFile('result.png', pngHeader(32_769, 1))
+      const { commands } = createRuntimeFileCommands({ path: '/repo' })
+      resolveAuthorizedPathMock.mockImplementation(async (value: string) => value)
+
+      const result = await resolveTerminalArtifactPath(commands, artifactPath)
+      const target = absoluteFileTarget(result)
+
+      await expect(
+        commands.readTerminalArtifactPreview(
+          'id:wt-1',
+          target.grantId,
+          target.absolutePath,
+          'client-a'
+        )
+      ).rejects.toThrow('Image dimensions exceed the preview safety limit')
     })
 
     it('rejects binary-extension terminal artifacts from the editable text path', async () => {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: filesystem, editor-file, and search commands share the same local/SSH path authorization rules. Keeping that IO adapter together prevents separate command paths from drifting on safety checks. */
 import type { ChildProcess } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
-import { watch as watchFs } from 'node:fs'
+import { watch as watchFs, type Dirent } from 'node:fs'
 import type { FileHandle } from 'node:fs/promises'
 import {
   chmod,
@@ -10,8 +10,7 @@ import {
   lstat,
   mkdir,
   open,
-  readFile,
-  readdir,
+  opendir,
   rename,
   realpath,
   rm,
@@ -38,6 +37,13 @@ import {
   resolveRuntimePath
 } from '../../shared/cross-platform-path'
 import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
+import {
+  assertMobileFileDirectoryWithinLimit,
+  createMobileFileDirectoryLimitState,
+  MOBILE_FILE_DIRECTORY_MAX_ENTRIES,
+  MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES,
+  trackMobileFileDirectoryEntry
+} from '../../shared/mobile-file-directory-limit'
 import type {
   RuntimeFileListResult,
   RuntimeFileOpenResult,
@@ -80,6 +86,10 @@ import {
   WatcherProcessFailure
 } from '../ipc/parcel-watcher-process-failure'
 import { assertNoClobberRenameDestinationAvailable } from '../../shared/filesystem-rename-collision'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../../shared/node-bounded-file-reader'
 import { joinWorktreeRelativePath, normalizeRuntimeRelativePath } from './runtime-relative-paths'
 import {
   rankRuntimeMobileFilePaths,
@@ -88,12 +98,18 @@ import {
 import { beginWatcherInstall } from '../ipc/watcher-removal-gate'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
 import { toSshExecutionHostId } from '../../shared/execution-host'
+import { assertRasterImagePreviewWithinLimits } from '../../shared/raster-image-preview-limits'
+import { SearchSubprocessLineAccumulator } from '../../shared/search-subprocess-lines'
+import { retainRuntimeTerminalFileGrant } from './runtime-terminal-file-grant-retention'
+import { assertRuntimeTextSearchAdmission } from './runtime-text-search-admission'
+import { RuntimeFileWatcherAdmission } from './runtime-file-watcher-admission'
 
 const MOBILE_FILE_LIST_LIMIT = 5000
 const MOBILE_FILE_PATH_SEARCH_CACHE_LIMIT = 20_000
 const MOBILE_FILE_PATH_SEARCH_CACHE_ENTRIES = 8
 const MOBILE_FILE_PATH_SEARCH_CACHE_TTL_MS = 30_000
 const MOBILE_FILE_READ_MAX_BYTES = 512 * 1024
+const RUNTIME_MOBILE_DIRECTORY_CLASSIFICATION_CONCURRENCY = 32
 const RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES = 10 * 1024 * 1024
 const WINDOWS_RUNTIME_FILE_WATCH_DEBOUNCE_MS = 150
 export const WINDOWS_RUNTIME_FILE_WATCH_CLOSE_DEADLINE_MS = 10_000
@@ -126,6 +142,7 @@ type RuntimeFileWatcherLease = {
   forget(): void
 }
 const runtimeFileWatcherLeasesByOwnerAndRoot = new Map<string, Set<RuntimeFileWatcherLease>>()
+const runtimeFileWatcherAdmission = new RuntimeFileWatcherAdmission()
 const MOBILE_BINARY_EXTENSIONS = new Set([
   '.avif',
   '.bmp',
@@ -231,7 +248,8 @@ function registerRuntimeFileWatcherRelease(
   rootPaths: string[],
   unsubscribe: () => Promise<void>,
   restart: () => Promise<() => Promise<void>>,
-  onRestoreError: (error: Error) => void
+  onRestoreError: (error: Error) => void,
+  releaseAdmission: () => void
 ): () => Promise<void> {
   const keys = Array.from(
     new Set(
@@ -252,6 +270,7 @@ function registerRuntimeFileWatcherRelease(
         runtimeFileWatcherLeasesByOwnerAndRoot.delete(key)
       }
     }
+    releaseAdmission()
   }
   const suspend = (): Promise<void> => {
     if (releasePromise) {
@@ -830,7 +849,10 @@ export class RuntimeFileCommands {
       expiresAt: Date.now() + TERMINAL_FILE_GRANT_TTL_MS,
       statIdentity: terminalFileStatIdentity(args.stats)
     }
-    this.terminalFileGrants.set(grant.id, grant)
+    this.pruneExpiredTerminalFileGrants()
+    retainRuntimeTerminalFileGrant(this.terminalFileGrants, grant, (id, retained) =>
+      this.releaseTerminalFileGrant(id, retained)
+    )
     this.scheduleTerminalFileGrantExpiry(grant)
     return grant
   }
@@ -1162,21 +1184,23 @@ export class RuntimeFileCommands {
       if (!provider) {
         throw new Error(SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      return provider.readDir(target.path)
+      const entries = await provider.readDir(target.path, {
+        maxEntries: MOBILE_FILE_DIRECTORY_MAX_ENTRIES,
+        maxRetainedBytes: MOBILE_FILE_DIRECTORY_MAX_RETAINED_BYTES
+      })
+      assertMobileFileDirectoryWithinLimit(entries)
+      return entries
     }
 
     const dirPath = await resolveAuthorizedPath(target.path, this.host.requireStore())
-    const entries = await readdir(dirPath, { withFileTypes: true })
-    const mapped = await Promise.all(
-      entries.map(async (entry) => {
-        const entryPath = join(dirPath, entry.name)
-        return {
-          name: entry.name,
-          isDirectory: await isRuntimeDirectoryEntry(entry, entryPath),
-          isSymlink: entry.isSymbolicLink()
-        }
-      })
-    )
+    const limit = createMobileFileDirectoryLimitState()
+    const directory = await opendir(dirPath)
+    const entries: Dirent[] = []
+    for await (const entry of directory) {
+      trackMobileFileDirectoryEntry(limit, entry)
+      entries.push(entry)
+    }
+    const mapped = await classifyRuntimeMobileDirectoryEntries(dirPath, entries)
     return mapped.sort((a, b) => {
       if (a.isDirectory !== b.isDirectory) {
         return a.isDirectory ? -1 : 1
@@ -1192,6 +1216,11 @@ export class RuntimeFileCommands {
     signal?: AbortSignal
   ): Promise<() => void> {
     const target = await this.resolveFileExplorerPath(worktreeSelector, '')
+    const releaseAdmission = runtimeFileWatcherAdmission.claim(
+      this.host.getRuntimeId(),
+      target.connectionId,
+      target.path
+    )
     const open = async (): Promise<{
       unsubscribe: () => Promise<void>
       rootPaths: string[]
@@ -1229,15 +1258,30 @@ export class RuntimeFileCommands {
         finishInstall()
       }
     }
-    const initial = await open()
-    return registerRuntimeFileWatcherRelease(
-      this.host.getRuntimeId(),
-      target.connectionId,
-      initial.rootPaths,
-      initial.unsubscribe,
-      async () => (await open()).unsubscribe,
-      onTerminalError
-    )
+    let initial: Awaited<ReturnType<typeof open>>
+    try {
+      initial = await open()
+    } catch (error) {
+      releaseAdmission()
+      throw error
+    }
+    try {
+      return registerRuntimeFileWatcherRelease(
+        this.host.getRuntimeId(),
+        target.connectionId,
+        initial.rootPaths,
+        initial.unsubscribe,
+        async () => (await open()).unsubscribe,
+        onTerminalError,
+        releaseAdmission
+      )
+    } catch (error) {
+      releaseAdmission()
+      await trackRuntimeFileWatcherUnsubscribe(initial.rootPaths[0], initial.unsubscribe).catch(
+        () => undefined
+      )
+      throw error
+    }
   }
 
   async closeFileExplorerWatchersForPath(rootPath: string, connectionId?: string): Promise<void> {
@@ -1295,23 +1339,30 @@ export class RuntimeFileCommands {
     const filePath = await resolveAuthorizedPath(target.path, this.host.requireStore())
     const fileStats = await stat(filePath)
     const mimeType = RUNTIME_PREVIEWABLE_BINARY_MIME_TYPES[extname(filePath).toLowerCase()]
-    if (mimeType) {
-      if (fileStats.size > RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES) {
+    const sizeLimit = mimeType ? RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES : MOBILE_FILE_READ_MAX_BYTES
+    if (fileStats.size > sizeLimit) {
+      throw new Error('file_too_large')
+    }
+    let buffer: Buffer
+    try {
+      buffer = (await readNodeFileWithinLimit(filePath, sizeLimit)).buffer
+    } catch (error) {
+      if (error instanceof NodeFileReadTooLargeError) {
         throw new Error('file_too_large')
       }
-      const buffer = await readFile(filePath)
+      throw error
+    }
+    if (mimeType) {
+      const imageDimensions = assertRasterImagePreviewWithinLimits(buffer, mimeType)
       return {
         content: buffer.toString('base64'),
         isBinary: true,
         isImage: true,
-        mimeType
+        mimeType,
+        ...(imageDimensions ? { imageDimensions } : {})
       }
     }
 
-    if (fileStats.size > MOBILE_FILE_READ_MAX_BYTES) {
-      throw new Error('file_too_large')
-    }
-    const buffer = await readFile(filePath)
     if (isBinaryBuffer(buffer)) {
       return { content: '', isBinary: true }
     }
@@ -1738,7 +1789,12 @@ export class RuntimeFileCommands {
       if (!provider) {
         throw new Error(SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      const relativePaths = await provider.listFiles(target.worktree.path)
+      if (!provider.listMarkdownDocuments) {
+        throw new Error(
+          'Remote Markdown link discovery is unavailable. Reconnect the SSH target and retry.'
+        )
+      }
+      const relativePaths = await provider.listMarkdownDocuments(target.worktree.path)
       return markdownDocumentsFromRelativePaths(target.worktree.path, relativePaths)
     }
     return listMarkdownDocuments(target.worktree.path)
@@ -1788,11 +1844,12 @@ export class RuntimeFileCommands {
 
     return new Promise((resolvePromise) => {
       const searchKey = `${this.host.getRuntimeId()}:${authorizedRootPath}`
+      assertRuntimeTextSearchAdmission(this.activeRuntimeTextSearches, searchKey)
       const rgArgs = buildRgArgs(options.query, authorizedRootPath, options)
       this.activeRuntimeTextSearches.get(searchKey)?.kill()
 
       const acc = createAccumulator()
-      let stdoutBuffer = ''
+      const stdoutLines = new SearchSubprocessLineAccumulator()
       let resolved = false
       let child: ChildProcess | null = null
       const wslInfo = parseWslPath(authorizedRootPath)
@@ -1845,13 +1902,11 @@ export class RuntimeFileCommands {
       child = nextChild
       this.activeRuntimeTextSearches.set(searchKey, nextChild)
 
-      nextChild.stdout!.setEncoding('utf-8')
-      const onStdoutData = (chunk: string): void => {
-        stdoutBuffer += chunk
-        const lines = stdoutBuffer.split('\n')
-        stdoutBuffer = lines.pop() ?? ''
-        for (const line of lines) {
-          processLine(line)
+      const onStdoutData = (chunk: Buffer): void => {
+        if (!stdoutLines.push(chunk, processLine)) {
+          acc.truncated = true
+          child?.kill()
+          resolveOnce()
         }
       }
       const onStderrData = (): void => {
@@ -1859,8 +1914,9 @@ export class RuntimeFileCommands {
       }
       const onError = (): void => resolveOnce()
       const onClose = (): void => {
-        if (stdoutBuffer) {
-          processLine(stdoutBuffer)
+        const trailingLine = stdoutLines.finish()
+        if (trailingLine !== null) {
+          processLine(trailingLine)
         }
         resolveOnce()
       }
@@ -2059,6 +2115,45 @@ async function isRuntimeDirectoryEntry(
   return false
 }
 
+type RuntimeDirectorySourceEntry = {
+  name: string
+  isDirectory(): boolean
+  isSymbolicLink(): boolean
+}
+
+type RuntimeDirectoryClassifier = (
+  entry: RuntimeDirectorySourceEntry,
+  entryPath: string
+) => Promise<boolean>
+
+export async function classifyRuntimeMobileDirectoryEntries(
+  dirPath: string,
+  entries: readonly RuntimeDirectorySourceEntry[],
+  classify: RuntimeDirectoryClassifier = isRuntimeDirectoryEntry
+): Promise<DirEntry[]> {
+  const mapped: DirEntry[] = []
+  for (
+    let offset = 0;
+    offset < entries.length;
+    offset += RUNTIME_MOBILE_DIRECTORY_CLASSIFICATION_CONCURRENCY
+  ) {
+    const batch = entries.slice(
+      offset,
+      offset + RUNTIME_MOBILE_DIRECTORY_CLASSIFICATION_CONCURRENCY
+    )
+    mapped.push(
+      ...(await Promise.all(
+        batch.map(async (entry) => ({
+          name: entry.name,
+          isDirectory: await classify(entry, join(dirPath, entry.name)),
+          isSymlink: entry.isSymbolicLink()
+        }))
+      ))
+    )
+  }
+  return mapped
+}
+
 function isBinaryBuffer(buffer: Buffer): boolean {
   const len = Math.min(buffer.length, 8192)
   for (let i = 0; i < len; i += 1) {
@@ -2148,11 +2243,13 @@ async function readLocalTerminalArtifactPreviewFromHandle(
       handle,
       RUNTIME_PREVIEWABLE_BINARY_MAX_BYTES + 1
     )
+    const imageDimensions = assertRasterImagePreviewWithinLimits(buffer, mimeType)
     return {
       content: buffer.toString('base64'),
       isBinary: true,
       isImage: true,
-      mimeType
+      mimeType,
+      ...(imageDimensions ? { imageDimensions } : {})
     }
   }
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -114,6 +114,7 @@ import {
 
 const ORIGINAL_PLATFORM = process.platform
 const ORIGINAL_PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, 'platform')
+const TEST_MAX_HOOK_GITIGNORE_BYTES = 4 * 1024 * 1024
 const removeWorktreeLinkedPathsMock = vi.hoisted(() => vi.fn())
 const findExistingWorktreeSymlinkPathsMock = vi.hoisted(() => vi.fn())
 const resolveLocalGitUsernameMock = vi.hoisted(() => vi.fn(async () => ''))
@@ -439,6 +440,8 @@ vi.mock('../hooks', () => ({
     ORCA_ROOT_PATH: '/remote/repo',
     ORCA_WORKTREE_PATH: worktreePath
   }),
+  MAX_HOOK_GITIGNORE_BYTES: 4 * 1024 * 1024,
+  MAX_ISSUE_COMMAND_BYTES: 1024 * 1024,
   loadHooks: vi.fn().mockReturnValue(null),
   runHook: vi.fn().mockResolvedValue({ success: true, output: '' }),
   shouldRunSetupForCreate: vi
@@ -3278,7 +3281,10 @@ describe('OrcaRuntimeService', () => {
 
     expect(listWorktrees).not.toHaveBeenCalled()
     expect(gitProvider.listWorktrees).toHaveBeenCalledWith('//Server/Share/Repo')
-    expect(fsProvider.readDir).toHaveBeenCalledWith('\\\\Server\\Share\\Repo\\src')
+    expect(fsProvider.readDir).toHaveBeenCalledWith('\\\\Server\\Share\\Repo\\src', {
+      maxEntries: 10_000,
+      maxRetainedBytes: 4 * 1024 * 1024
+    })
     expect(gitProvider.getStatus).toHaveBeenCalledWith('//Server/Share/Repo')
   })
 
@@ -3345,7 +3351,10 @@ describe('OrcaRuntimeService', () => {
     }
 
     expect(fsProvider.stat).toHaveBeenCalledWith(folderPath)
-    expect(fsProvider.readDir).toHaveBeenCalledWith('/srv/platform/src')
+    expect(fsProvider.readDir).toHaveBeenCalledWith('/srv/platform/src', {
+      maxEntries: 10_000,
+      maxRetainedBytes: 4 * 1024 * 1024
+    })
     expect(fsProvider.stat).toHaveBeenCalledWith('/srv/platform/src/app.ts')
     expect(fsProvider.readFile).toHaveBeenCalledWith('/srv/platform/src/app.ts')
   })
@@ -5217,6 +5226,12 @@ describe('OrcaRuntimeService', () => {
       listWorktrees: vi.fn().mockResolvedValue([created])
     }
     const fsProvider = {
+      stat: vi.fn(async (filePath: string) => {
+        if (filePath.endsWith('orca.yaml')) {
+          return { size: 7, type: 'file', mtime: 0 }
+        }
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      }),
       readFile: vi.fn().mockResolvedValue({ isBinary: false, content: 'hooks:\n' }),
       createDir: vi.fn().mockResolvedValue(undefined),
       writeFile: vi.fn().mockResolvedValue(undefined)
@@ -5374,6 +5389,12 @@ describe('OrcaRuntimeService', () => {
       listWorktrees: vi.fn().mockResolvedValue([created])
     }
     const fsProvider = {
+      stat: vi.fn(async (filePath: string) => {
+        if (filePath.endsWith('orca.yaml')) {
+          return { size: 7, type: 'file', mtime: 0 }
+        }
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      }),
       readFile: vi.fn().mockResolvedValue({ isBinary: false, content: 'hooks:\n' }),
       createDir: vi.fn().mockResolvedValue(undefined),
       writeFile: vi.fn().mockResolvedValue(undefined)
@@ -5586,6 +5607,7 @@ describe('OrcaRuntimeService', () => {
       ]
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 32, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  setup: pnpm install\n',
         isBinary: false
@@ -5662,6 +5684,7 @@ describe('OrcaRuntimeService', () => {
       ]
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 32, type: 'file', mtime: 0 }),
       readFile: vi.fn(async (filePath: string) => ({
         content: filePath.endsWith('orca.yaml')
           ? 'scripts:\n  setup: pnpm install\n'
@@ -5707,6 +5730,49 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('does not materialize an oversized SSH .gitignore while writing an issue command', async () => {
+    const remoteStore = {
+      ...store,
+      getRepos: () => [
+        {
+          id: TEST_REPO_ID,
+          path: '/remote/repo',
+          displayName: 'repo',
+          badgeColor: 'blue',
+          addedAt: 1,
+          connectionId: 'ssh-1'
+        }
+      ]
+    }
+    const fsProvider = {
+      stat: vi.fn().mockResolvedValue({
+        size: TEST_MAX_HOOK_GITIGNORE_BYTES + 1,
+        type: 'file',
+        mtime: 0
+      }),
+      readFile: vi.fn(),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      createDir: vi.fn().mockResolvedValue(undefined)
+    }
+    registerSshFilesystemProvider('ssh-1', fsProvider as never)
+    const runtime = new OrcaRuntimeService(remoteStore as never)
+
+    try {
+      await expect(runtime.writeRepoIssueCommand('id:repo-1', 'Ship it')).resolves.toEqual({
+        ok: true
+      })
+    } finally {
+      unregisterSshFilesystemProvider('ssh-1')
+    }
+
+    expect(fsProvider.readFile).not.toHaveBeenCalled()
+    expect(fsProvider.writeFile).toHaveBeenCalledOnce()
+    expect(fsProvider.writeFile).toHaveBeenCalledWith(
+      '/remote/repo/.orca/issue-command',
+      'Ship it\n'
+    )
+  })
+
   it('resolves SSH issue commands from shared orca.yaml and deletes empty overrides', async () => {
     const remoteStore = {
       ...store,
@@ -5726,6 +5792,7 @@ describe('OrcaRuntimeService', () => {
       issueCommand: 'claude -p "Fix #{{issue}}"'
     })
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 48, type: 'file', mtime: 0 }),
       readFile: vi.fn(async (filePath: string) => {
         if (filePath.endsWith('.orca/issue-command')) {
           throw Object.assign(new Error('missing'), { code: 'ENOENT' })
@@ -30699,6 +30766,42 @@ describe('OrcaRuntimeService', () => {
       repos.map((repo) => `${repo.path}/main`)
     )
     expect(listWorktrees).toHaveBeenCalledTimes(15)
+  })
+
+  it('bounds resolved worktree scanning to a fixed repo worker pool', async () => {
+    vi.mocked(listWorktrees).mockReset()
+    const repos = Array.from({ length: 40 }, (_, index) => ({
+      id: `repo-${index}`,
+      path: `/tmp/repo-${index}`,
+      displayName: `repo-${index}`,
+      badgeColor: 'blue' as const,
+      addedAt: 1
+    }))
+    const gate = deferred<void>()
+    let inFlight = 0
+    let peak = 0
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => {
+      inFlight += 1
+      peak = Math.max(peak, inFlight)
+      await gate.promise
+      inFlight -= 1
+      return [makeWorktreeInfo(repoPath)]
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((candidate) => candidate.id === id),
+      getAllWorktreeMeta: () => ({}),
+      getWorktreeMeta: () => undefined
+    } as never)
+
+    const listing = runtime.listManagedWorktrees()
+    await vi.waitFor(() => expect(listWorktrees).toHaveBeenCalledTimes(8))
+    expect(peak).toBe(8)
+    gate.resolve()
+    await expect(listing).resolves.toMatchObject({ totalCount: repos.length })
+    expect(listWorktrees).toHaveBeenCalledTimes(repos.length)
+    expect(peak).toBe(8)
   })
 
   it('worktree scan cache: shares one in-flight repo scan across concurrent consumers', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -91,11 +91,12 @@ import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fe
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
-import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
+import { mkdir, opendir, rm, stat } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
 import { OrchestrationDb } from './orchestration/db'
 import { formatMessagesForInjection } from './orchestration/formatter'
+import { OrchestrationMessageWaiterRegistry } from './orchestration-message-waiter-registry'
 import type {
   Automation,
   AutomationCreateInput,
@@ -189,6 +190,11 @@ import {
 } from '../../shared/runtime-navigation'
 import type { SshConnectionState } from '../../shared/ssh-types'
 import { getPublicSshState } from './public-ssh-state'
+import {
+  RuntimeSshRelayRecoveryGenerations,
+  type RuntimeSshRelayRecoveryGenerationLease
+} from './runtime-ssh-relay-recovery-generations'
+import { RuntimeOperationGenerations } from './runtime-operation-generations'
 import { closeTerminalTabInWorkspaceSession } from '../../shared/workspace-session-terminal-tab-close'
 import type {
   LinearCurrentIssueContextHints,
@@ -241,6 +247,7 @@ import {
 import { parsePtySessionId } from '../../shared/pty-session-id-format'
 import { clampLinearIssueListLimit } from '../../shared/linear-issue-read-limits'
 import { isFolderRepo } from '../../shared/repo-kind'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import {
   buildSetupRunnerCommand,
@@ -559,6 +566,14 @@ import type {
   PRRefreshOutcome
 } from '../../shared/types'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
+import {
+  readSetupScriptImportFile,
+  SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES,
+  SETUP_SCRIPT_IMPORT_MAX_CODE_UNITS
+} from '../setup-script-import-file'
+import { MAX_ORCA_YAML_BYTES, MAX_ORCA_YAML_CODE_UNITS } from '../../shared/orca-yaml-file-limit'
+import { readFilesystemProviderBoundedText } from '../filesystem-provider-bounded-text'
+import { readLocalFilesystemDirectory } from '../ipc/filesystem-directory-reader'
 import type {
   CreateHostedReviewInput,
   CreateHostedReviewResult,
@@ -761,6 +776,8 @@ import {
   hasUnrecognizedOrcaYamlKeys,
   hasHooksFile,
   loadHooks,
+  MAX_HOOK_GITIGNORE_BYTES,
+  MAX_ISSUE_COMMAND_BYTES,
   parseOrcaYaml,
   readIssueCommand,
   runHook,
@@ -1658,14 +1675,6 @@ type TerminalWaiter = {
   abortCleanup: (() => void) | null
 }
 
-type MessageWaiter = {
-  handle: string
-  typeFilter: string[] | undefined
-  resolve: (result: void) => void
-  timeout: NodeJS.Timeout | null
-  abortCleanup: (() => void) | null
-}
-
 function omitUndefinedProperties<T extends Record<string, unknown>>(value: T): Partial<T> {
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => entry !== undefined)
@@ -2490,7 +2499,7 @@ export class OrcaRuntimeService {
   private resolvedWorktreeCache: ResolvedWorktreeCache | null = null
   private resolvedWorktreeInFlight: ResolvedWorktreeInFlight | null = null
   private resolvedWorktreeGeneration = 0
-  private worktreeScanGenerations = new Map<string, number>()
+  private readonly worktreeScanGenerations = new RuntimeOperationGenerations()
   private worktreeScanCache = new Map<string, RuntimeWorktreeScanCache>()
   private worktreeScanInFlight = new Map<string, RuntimeWorktreeScanInFlight>()
   private cloneInFlightByPath = new Map<string, Promise<void>>()
@@ -2498,7 +2507,7 @@ export class OrcaRuntimeService {
   private ptyForegroundAgentRefreshes = new Map<string, PtyForegroundAgentRefresh>()
   private ptyDelayedForegroundSnapshotTitleObservations = new Map<string, number>()
   private _orchestrationDb: OrchestrationDb | null = null
-  private messageWaitersByHandle = new Map<string, Set<MessageWaiter>>()
+  private readonly messageWaiters = new OrchestrationMessageWaiterRegistry()
   // Why: mobile clients subscribe to terminal output via terminal.subscribe.
   // These listeners fire on every onPtyData call, enabling real-time streaming
   // without polling. Keyed by ptyId for O(1) lookup per data event.
@@ -2569,8 +2578,7 @@ export class OrcaRuntimeService {
   private providerVisibleStateByPtyId = new Map<string, RuntimeVisibleTerminalState>()
   private providerVisibleRetryAtByPtyId = new Map<string, number>()
   private providerSnapshotsWithLiveModeTransition = new WeakSet<PtyProviderBufferSnapshot>()
-  private ptyLifecycleGenerationById = new Map<string, number>()
-  private nextPtyLifecycleGeneration = 1
+  private readonly ptyLifecycleGenerations = new RuntimeOperationGenerations()
   private recentPtyPathCandidatesById = new Map<string, string[]>()
   // Why: candidates only feed mobile file-tap provenance; desktop-only
   // sessions skip the 3-regex extraction on every PTY chunk until a
@@ -2870,7 +2878,7 @@ export class OrcaRuntimeService {
     | null
   private readonly agentSessionClaimSigner: AgentSessionClaimSigner
   private readonly agentSessionCreateOperations = new Map<string, AgentSessionCreateOperation>()
-  private sshRelayRecoveryGenerationByTargetId = new Map<string, number>()
+  private readonly sshRelayRecoveryGenerations = new RuntimeSshRelayRecoveryGenerations()
   private accountServices: RuntimeAccountServices | null = null
   private commitMessageAgentEnv: CommitMessageAgentEnvironmentResolvers | null = null
   private automationService: AutomationService | null = null
@@ -3567,33 +3575,32 @@ export class OrcaRuntimeService {
   // Why: SSH state changes originate in main's ssh handlers, not in runtime
   // methods, so they need a public entry point onto the client-event stream.
   notifySshStateChanged(targetId: string, state: SshConnectionState): void {
-    this.bumpSshRelayRecoveryGeneration(targetId)
+    this.sshRelayRecoveryGenerations.invalidate(targetId)
     this.invalidateSshWorktreeScanCache(targetId)
     this.emitClientEvent({ type: 'sshStateChanged', targetId, state: getPublicSshState(state)! })
   }
 
   notifySshRelayReady(targetId: string): void {
-    const generation = this.bumpSshRelayRecoveryGeneration(targetId)
-    void this.publishRecoveredSshMobileSessionTabs(targetId, generation).catch((error) => {
-      if (this.sshRelayRecoveryGenerationByTargetId.get(targetId) !== generation) {
-        return
-      }
-      console.warn('[runtime] failed to publish recovered SSH session tabs', {
-        targetId,
-        error
+    const generationLease = this.sshRelayRecoveryGenerations.begin(targetId)
+    if (!generationLease) {
+      return
+    }
+    void this.publishRecoveredSshMobileSessionTabs(targetId, generationLease)
+      .catch((error) => {
+        if (!generationLease.isCurrent()) {
+          return
+        }
+        console.warn('[runtime] failed to publish recovered SSH session tabs', {
+          targetId,
+          error
+        })
       })
-    })
-  }
-
-  private bumpSshRelayRecoveryGeneration(targetId: string): number {
-    const generation = (this.sshRelayRecoveryGenerationByTargetId.get(targetId) ?? 0) + 1
-    this.sshRelayRecoveryGenerationByTargetId.set(targetId, generation)
-    return generation
+      .finally(() => generationLease.release())
   }
 
   private async publishRecoveredSshMobileSessionTabs(
     targetId: string,
-    generation: number
+    generationLease: RuntimeSshRelayRecoveryGenerationLease
   ): Promise<void> {
     const repoIds = new Set(
       (this.store?.getRepos() ?? [])
@@ -3625,7 +3632,7 @@ export class OrcaRuntimeService {
       })
     }
     await this.refreshMobileSessionPtyRecords()
-    if (this.sshRelayRecoveryGenerationByTargetId.get(targetId) !== generation) {
+    if (!generationLease.isCurrent()) {
       return
     }
     for (const worktreeId of worktreeIds) {
@@ -8401,17 +8408,15 @@ export class OrcaRuntimeService {
   }
 
   private getPtyLifecycleGeneration(ptyId: string): number {
-    const existing = this.ptyLifecycleGenerationById.get(ptyId)
-    if (existing !== undefined) {
-      return existing
-    }
-    const generation = this.nextPtyLifecycleGeneration++
-    this.ptyLifecycleGenerationById.set(ptyId, generation)
-    return generation
+    return this.ptyLifecycleGenerations.current(ptyId)
+  }
+
+  private isPtyLifecycleGenerationCurrent(ptyId: string, generation: number): boolean {
+    return this.ptyLifecycleGenerations.isCurrent(ptyId, generation)
   }
 
   private advancePtyLifecycleGeneration(ptyId: string): void {
-    this.ptyLifecycleGenerationById.set(ptyId, this.nextPtyLifecycleGeneration++)
+    this.ptyLifecycleGenerations.advance(ptyId)
     // Why: a provider response belongs to the process generation that issued
     // it; a respawn must neither reuse its frame nor join its in-flight call.
     this.providerBufferAcquisitionsByPtyId.delete(ptyId)
@@ -9263,7 +9268,7 @@ export class OrcaRuntimeService {
       // Why: daemon PTYs survive an app relaunch before any renderer mounts.
       // Mobile still needs their retained history without navigating desktop.
       const snapshot = await this.ptyController?.serializeProviderBuffer?.(ptyId, opts)
-      if (!snapshot || this.getPtyLifecycleGeneration(ptyId) !== generation) {
+      if (!snapshot || !this.isPtyLifecycleGenerationCurrent(ptyId, generation)) {
         return null
       }
       const snapshotModeTracker = new TerminalKittyKeyboardModeTracker()
@@ -9401,7 +9406,7 @@ export class OrcaRuntimeService {
       { scrollbackRows: 0 },
       { timeoutMs: VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS }
     )
-    if (!snapshot || this.getPtyLifecycleGeneration(ptyId) !== generation) {
+    if (!snapshot || !this.isPtyLifecycleGenerationCurrent(ptyId, generation)) {
       this.providerVisibleRetryAtByPtyId.set(ptyId, Date.now() + VISIBLE_TERMINAL_SNAPSHOT_RETRY_MS)
       return null
     }
@@ -9415,7 +9420,7 @@ export class OrcaRuntimeService {
       }
     }
     const lines = await this.parseVisibleSnapshotLines(snapshot)
-    if (this.getPtyLifecycleGeneration(ptyId) !== generation) {
+    if (!this.isPtyLifecycleGenerationCurrent(ptyId, generation)) {
       return null
     }
     const visibleState: RuntimeVisibleTerminalState = {
@@ -9441,7 +9446,7 @@ export class OrcaRuntimeService {
     await state.writeChain
     if (
       this.headlessTerminals.get(ptyId) !== state ||
-      this.getPtyLifecycleGeneration(ptyId) !== generation
+      !this.isPtyLifecycleGenerationCurrent(ptyId, generation)
     ) {
       return null
     }
@@ -9676,16 +9681,15 @@ export class OrcaRuntimeService {
     // before the first-ever connect no longer yields candidates.
     for (const [ptyId, buffer] of this.recentPtyOutputById) {
       let candidates = this.recentPtyPathCandidatesById.get(ptyId)
-      const { chunks, headChunkIsPartial } = buffer.retainedChunks()
-      for (let index = 0; index < chunks.length; index += 1) {
+      buffer.forEachRetainedChunk((chunk, index, headChunkIsPartial) => {
         if (index === 0 && headChunkIsPartial) {
           // A pre-sliced over-window chunk was already extracted eagerly at
           // append time (while its original text was intact); replaying its
           // truncated remainder would mint or drop candidates spuriously.
-          continue
+          return
         }
-        candidates = appendRecentPtyPathCandidates(candidates, chunks[index]!)
-      }
+        candidates = appendRecentPtyPathCandidates(candidates, chunk)
+      })
       if (candidates) {
         this.recentPtyPathCandidatesById.set(ptyId, candidates)
       }
@@ -15095,21 +15099,7 @@ export class OrcaRuntimeService {
     if (!dirStat.isDirectory()) {
       throw new Error(`${dirPath} is not a directory`)
     }
-    const entries = await readdir(dirPath, { withFileTypes: true })
-    const mapped = entries
-      .filter((entry) => entry.name !== '.' && entry.name !== '..')
-      .map((entry) => ({
-        name: entry.name,
-        isDirectory: entry.isDirectory(),
-        isSymlink: entry.isSymbolicLink()
-      }))
-    mapped.sort((a, b) => {
-      if (a.isDirectory !== b.isDirectory) {
-        return a.isDirectory ? -1 : 1
-      }
-      return a.name.localeCompare(b.name)
-    })
-    return { resolvedPath: dirPath, entries: mapped }
+    return { resolvedPath: dirPath, entries: await readLocalFilesystemDirectory(dirPath) }
   }
 
   async isGitAvailable(): Promise<boolean> {
@@ -15382,9 +15372,13 @@ export class OrcaRuntimeService {
         if (!existingStat.isDirectory()) {
           return { error: `"${trimmedName}" already exists at this location and is not a folder.` }
         }
-        const entries = await readdir(targetPath)
-        if (entries.length > 0) {
-          return { error: `"${trimmedName}" already exists at this location and is not empty.` }
+        const directory = await opendir(targetPath)
+        try {
+          if ((await directory.read()) !== null) {
+            return { error: `"${trimmedName}" already exists at this location and is not empty.` }
+          }
+        } finally {
+          await directory.close().catch(() => {})
         }
       } else {
         await mkdir(targetPath, { recursive: false })
@@ -15715,12 +15709,22 @@ export class OrcaRuntimeService {
     }
     const repo = await this.resolveRepoSelector(repoSelector)
     this.store.removeProject(repo.id)
-    this.terminalTopologyRevisionByRepoId.delete(repo.id)
-    this.invalidateResolvedWorktreeCache()
-    this.invalidateWorktreeScanCacheForRepo(repo.id)
+    this.notifyRepoStoreChanged(repo.id)
     invalidateAuthorizedRootsCache()
-    this.notifyReposChanged()
     return { removed: true }
+  }
+
+  notifyRepoStoreChanged(repoId: string): void {
+    const removed = !this.store?.getRepo(repoId)
+    if (removed) {
+      this.terminalTopologyRevisionByRepoId.delete(repoId)
+    }
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repoId)
+    if (removed) {
+      this.worktreeScanGenerations.forget(repoId)
+    }
+    this.notifyReposChanged()
   }
 
   async inspectTerminalProcess(
@@ -17108,8 +17112,12 @@ export class OrcaRuntimeService {
         }
       }
       try {
-        const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, 'orca.yaml'))
-        const hooks = result.isBinary ? null : parseOrcaYaml(result.content)
+        const result = await readFilesystemProviderBoundedText(
+          fsProvider,
+          joinWorktreeRelativePath(repo.path, 'orca.yaml'),
+          { maxBytes: MAX_ORCA_YAML_BYTES, maxCodeUnits: MAX_ORCA_YAML_CODE_UNITS }
+        )
+        const hooks = result.kind === 'text' ? parseOrcaYaml(result.content) : null
         return {
           hasHooksFile: Boolean(hooks),
           hooks,
@@ -17157,11 +17165,19 @@ export class OrcaRuntimeService {
         return { hasHooks: false, hooks: null, mayNeedUpdate: false }
       }
       try {
-        const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, 'orca.yaml'))
-        if (result.isBinary) {
+        const result = await readFilesystemProviderBoundedText(
+          fsProvider,
+          joinWorktreeRelativePath(repo.path, 'orca.yaml'),
+          { maxBytes: MAX_ORCA_YAML_BYTES, maxCodeUnits: MAX_ORCA_YAML_CODE_UNITS }
+        )
+        if (result.kind === 'binary') {
           return { hasHooks: false, hooks: null, mayNeedUpdate: false }
         }
-        return { hasHooks: true, hooks: parseOrcaYaml(result.content), mayNeedUpdate: false }
+        return {
+          hasHooks: true,
+          hooks: result.kind === 'text' ? parseOrcaYaml(result.content) : null,
+          mayNeedUpdate: false
+        }
       } catch {
         return { hasHooks: false, hooks: null, mayNeedUpdate: false }
       }
@@ -17190,15 +17206,18 @@ export class OrcaRuntimeService {
           return null
         }
         try {
-          const result = await fsProvider.readFile(filePath)
-          return result.isBinary ? null : result.content
+          const result = await readFilesystemProviderBoundedText(fsProvider, filePath, {
+            maxBytes: SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES,
+            maxCodeUnits: SETUP_SCRIPT_IMPORT_MAX_CODE_UNITS
+          })
+          return result.kind === 'text' ? result.content : null
         } catch {
           return null
         }
       }
 
       try {
-        return await readFile(filePath, 'utf-8')
+        return await readSetupScriptImportFile(filePath)
       } catch (error) {
         if (!isENOENT(error)) {
           console.warn('[runtime] Failed to inspect setup script import candidate:', error)
@@ -17256,11 +17275,11 @@ export class OrcaRuntimeService {
     issueCommandPath: string
   ): Promise<string | null> {
     try {
-      const result = await fsProvider.readFile(issueCommandPath)
-      if (result.isBinary) {
-        return null
-      }
-      return result.content.trim() || null
+      const result = await readFilesystemProviderBoundedText(fsProvider, issueCommandPath, {
+        maxBytes: MAX_ISSUE_COMMAND_BYTES,
+        maxCodeUnits: MAX_ISSUE_COMMAND_BYTES
+      })
+      return result.kind === 'text' ? result.content.trim() || null : null
     } catch {
       return null
     }
@@ -17271,8 +17290,12 @@ export class OrcaRuntimeService {
     repoPath: string
   ): Promise<string | null> {
     try {
-      const result = await fsProvider.readFile(joinWorktreeRelativePath(repoPath, 'orca.yaml'))
-      if (result.isBinary) {
+      const result = await readFilesystemProviderBoundedText(
+        fsProvider,
+        joinWorktreeRelativePath(repoPath, 'orca.yaml'),
+        { maxBytes: MAX_ORCA_YAML_BYTES, maxCodeUnits: MAX_ORCA_YAML_CODE_UNITS }
+      )
+      if (result.kind !== 'text') {
         return null
       }
       return parseOrcaYaml(result.content)?.issueCommand?.trim() || null
@@ -17318,9 +17341,12 @@ export class OrcaRuntimeService {
     options: { required?: boolean } = {}
   ): Promise<void> {
     const gitignorePath = joinWorktreeRelativePath(repoPath, '.gitignore')
-    let result: Awaited<ReturnType<IFilesystemProvider['readFile']>>
+    let result: Awaited<ReturnType<typeof readFilesystemProviderBoundedText>>
     try {
-      result = await fsProvider.readFile(gitignorePath)
+      result = await readFilesystemProviderBoundedText(fsProvider, gitignorePath, {
+        maxBytes: MAX_HOOK_GITIGNORE_BYTES,
+        maxCodeUnits: MAX_HOOK_GITIGNORE_BYTES
+      })
     } catch (error) {
       if (!isENOENT(error)) {
         if (options.required) {
@@ -17339,9 +17365,13 @@ export class OrcaRuntimeService {
       }
       return
     }
-    if (result.isBinary) {
+    if (result.kind !== 'text') {
       if (options.required) {
-        throw new Error('Remote .gitignore is binary; cannot verify .orca is ignored')
+        throw new Error(
+          result.kind === 'binary'
+            ? 'Remote .gitignore is binary; cannot verify .orca is ignored'
+            : 'Remote .gitignore exceeds the supported size limit'
+        )
       }
       return
     }
@@ -24596,8 +24626,10 @@ export class OrcaRuntimeService {
         getAgentLaunchPlatformForRepo(repo, projectRuntimeByRepoId.get(repo.id))
       ])
     )
-    const perRepoWorktrees = await Promise.all(
-      repos.map(async (repo) => {
+    const perRepoWorktrees = await mapWithConcurrency(
+      repos,
+      RESOLVED_WORKTREE_REPO_CONCURRENCY,
+      async (repo) => {
         if (isFolderRepo(repo)) {
           return listRuntimeFolderWorkspaces(this.requireStore(), repo).map((worktree) => ({
             ...worktree,
@@ -24654,7 +24686,7 @@ export class OrcaRuntimeService {
             comment: merged.comment
           }
         })
-      })
+      }
     )
     const worktrees = projectResolvedWorktreeLineage(
       perRepoWorktrees.flat(),
@@ -24718,7 +24750,7 @@ export class OrcaRuntimeService {
     projectRuntimeByRepoId?: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
   ): Promise<RuntimeWorktreeScanResult> {
     const now = Date.now()
-    const generation = this.worktreeScanGenerations.get(repo.id) ?? 0
+    const generation = this.worktreeScanGenerations.current(repo.id)
     const projectRuntime = projectRuntimeByRepoId
       ? projectRuntimeByRepoId.get(repo.id)
       : !repo.connectionId
@@ -24749,7 +24781,7 @@ export class OrcaRuntimeService {
       const result = await promise
       if (
         result.ok &&
-        generation === (this.worktreeScanGenerations.get(repo.id) ?? 0) &&
+        this.worktreeScanGenerations.isCurrent(repo.id, generation) &&
         this.worktreeScanInFlight.get(repo.id)?.promise === promise
       ) {
         this.worktreeScanCache.set(repo.id, {
@@ -24829,7 +24861,7 @@ export class OrcaRuntimeService {
   }
 
   private invalidateWorktreeScanCacheForRepo(repoId: string): void {
-    this.worktreeScanGenerations.set(repoId, (this.worktreeScanGenerations.get(repoId) ?? 0) + 1)
+    this.worktreeScanGenerations.advance(repoId)
     this.worktreeScanCache.delete(repoId)
     this.worktreeScanInFlight.delete(repoId)
   }
@@ -24840,7 +24872,7 @@ export class OrcaRuntimeService {
       repos.filter((repo) => repo.connectionId === targetId).map((repo) => repo.id)
     )
     for (const repoId of affectedRepoIds) {
-      this.worktreeScanGenerations.set(repoId, (this.worktreeScanGenerations.get(repoId) ?? 0) + 1)
+      this.worktreeScanGenerations.advance(repoId)
       this.worktreeScanCache.delete(repoId)
       this.worktreeScanInFlight.delete(repoId)
     }
@@ -25318,6 +25350,7 @@ export class OrcaRuntimeService {
     this.terminalFileUriHostnameByPtyId.delete(ptyId)
     this.wslDistroByPtyId.delete(ptyId)
     this.clearAgentRowSnapshotsForPty(ptyId)
+    this.ptyLifecycleGenerations.forget(ptyId)
     const handle = this.handleByPtyId.get(ptyId)
     if (handle) {
       // Why: pruning can remove a PTY without onPtyExit firing; release this leader's agent team so it doesn't leak.
@@ -26660,84 +26693,14 @@ export class OrcaRuntimeService {
 
   // Why: wake blocking orchestration.check --wait calls on this handle so they return the new message immediately instead of polling.
   notifyMessageArrived(handle: string, messageType?: string): void {
-    const waiters = this.messageWaitersByHandle.get(handle)
-    if (!waiters || waiters.size === 0) {
-      return
-    }
-    for (const waiter of [...waiters]) {
-      // Why: don't wake a coordinator waiting for worker_done/escalation on heartbeat noise it would misread as idleness.
-      if (messageType && waiter.typeFilter && !waiter.typeFilter.includes(messageType)) {
-        continue
-      }
-      this.resolveMessageWaiter(waiter)
-    }
+    this.messageWaiters.notify(handle, messageType)
   }
 
   waitForMessage(
     handle: string,
     options?: { typeFilter?: string[]; timeoutMs?: number; signal?: AbortSignal }
   ): Promise<void> {
-    return new Promise((resolve) => {
-      const timeoutMs = options?.timeoutMs ?? MESSAGE_WAIT_DEFAULT_TIMEOUT_MS
-
-      const waiter: MessageWaiter = {
-        handle,
-        typeFilter: options?.typeFilter,
-        resolve,
-        timeout: null,
-        abortCleanup: null
-      }
-
-      // Why: on caller abort (RPC socket closed — design doc §3.1), resolve now to release the long-poll slot instead of waiting out timeoutMs.
-      const signal = options?.signal
-      const onAbort = (): void => {
-        this.removeMessageWaiter(waiter)
-        resolve()
-      }
-      if (signal) {
-        if (signal.aborted) {
-          resolve()
-          return
-        }
-        waiter.abortCleanup = () => signal.removeEventListener('abort', onAbort)
-        signal.addEventListener('abort', onAbort, { once: true })
-      }
-
-      waiter.timeout = setTimeout(() => {
-        this.removeMessageWaiter(waiter)
-        resolve()
-      }, timeoutMs)
-
-      let waiters = this.messageWaitersByHandle.get(handle)
-      if (!waiters) {
-        waiters = new Set()
-        this.messageWaitersByHandle.set(handle, waiters)
-      }
-      waiters.add(waiter)
-    })
-  }
-
-  private resolveMessageWaiter(waiter: MessageWaiter): void {
-    this.removeMessageWaiter(waiter)
-    waiter.resolve()
-  }
-
-  private removeMessageWaiter(waiter: MessageWaiter): void {
-    if (waiter.timeout) {
-      clearTimeout(waiter.timeout)
-      waiter.timeout = null
-    }
-    if (waiter.abortCleanup) {
-      waiter.abortCleanup()
-      waiter.abortCleanup = null
-    }
-    const waiters = this.messageWaitersByHandle.get(waiter.handle)
-    if (waiters) {
-      waiters.delete(waiter)
-      if (waiters.size === 0) {
-        this.messageWaitersByHandle.delete(waiter.handle)
-      }
-    }
+    return this.messageWaiters.wait(handle, options)
   }
 
   private buildPtyTerminalSummary(
@@ -30250,6 +30213,7 @@ const WORKTREE_SCAN_CACHE_TTL_MS = 30_000
 // these (crash-cluster diagnostics, 2026-07).
 const WORKTREE_SCAN_AGENT_SCRATCH_TTL_MS = 5 * 60_000
 const RESOLVED_WORKTREE_REPO_TIMEOUT_MS = 5000
+const RESOLVED_WORKTREE_REPO_CONCURRENCY = 8
 
 export function resolveWorktreeScanCacheTtlMs(repo: Pick<Repo, 'path' | 'connectionId'>): number {
   return !repo.connectionId && isAgentScratchRepoRootPath(repo.path)
@@ -31696,7 +31660,6 @@ async function assertTerminalInputWithinLimitWithYield(text: string | undefined)
 const TUI_IDLE_DEFAULT_TIMEOUT_MS = 5 * 60 * 1000
 const TUI_IDLE_POLL_INTERVAL_MS = 2000
 const TUI_IDLE_QUIESCENCE_MS = 3000
-const MESSAGE_WAIT_DEFAULT_TIMEOUT_MS = 2 * 60 * 1000
 const EXPLICIT_IDLE_TITLE_RE = /(^|\s)(ready|idle|done)(\s|$|[.!?])/i
 const CLAUDE_IDLE_PREFIX = '\u2733'
 const GEMINI_IDLE_PREFIX = '\u25c7'

--- a/src/main/runtime/orchestration-message-waiter-registry.test.ts
+++ b/src/main/runtime/orchestration-message-waiter-registry.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_ORCHESTRATION_MESSAGE_WAITERS,
+  MAX_ORCHESTRATION_MESSAGE_WAITERS_PER_HANDLE,
+  MAX_ORCHESTRATION_MESSAGE_WAITER_HANDLE_BYTES,
+  MAX_ORCHESTRATION_MESSAGE_WAITER_RETAINED_HANDLE_BYTES,
+  OrchestrationMessageWaiterLimitError,
+  OrchestrationMessageWaiterRegistry
+} from './orchestration-message-waiter-registry'
+
+const BOUNDS = {
+  maxWaiters: 3,
+  maxWaitersPerHandle: 2,
+  maxHandleBytes: 8,
+  maxRetainedHandleBytes: 10
+}
+
+describe('OrchestrationMessageWaiterRegistry', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('caps global waiters and admits again after settlement', async () => {
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    const first = registry.wait('a')
+    const second = registry.wait('b')
+    const third = registry.wait('c')
+
+    expect(() => registry.wait('d')).toThrowError(expect.objectContaining({ reason: 'global' }))
+    registry.notify('a')
+    await first
+    const replacement = registry.wait('d')
+    expect(registry.evidence()).toEqual({
+      waiters: 3,
+      handles: 3,
+      retainedHandleBytes: 3
+    })
+
+    registry.close()
+    await Promise.all([second, third, replacement])
+  })
+
+  it('caps waiters per handle without blocking another handle', async () => {
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    const first = registry.wait('same')
+    const second = registry.wait('same')
+
+    expect(() => registry.wait('same')).toThrowError(
+      expect.objectContaining({ reason: 'per-handle' })
+    )
+    const other = registry.wait('other')
+    expect(registry.evidence()).toEqual({
+      waiters: 3,
+      handles: 2,
+      retainedHandleBytes: 9
+    })
+
+    registry.close()
+    await Promise.all([first, second, other])
+  })
+
+  it('rejects oversized handles without retaining them', async () => {
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+
+    expect(() => registry.wait('🌊🌊🌊')).toThrow(OrchestrationMessageWaiterLimitError)
+    expect(() => registry.wait('🌊🌊🌊')).toThrowError(
+      expect.objectContaining({ reason: 'handle-bytes' })
+    )
+    expect(registry.evidence()).toEqual({
+      waiters: 0,
+      handles: 0,
+      retainedHandleBytes: 0
+    })
+
+    const controller = new AbortController()
+    controller.abort()
+    await expect(registry.wait('🌊🌊🌊', { signal: controller.signal })).resolves.toBeUndefined()
+  })
+
+  it('accounts for each unique handle key once and caps aggregate key bytes', async () => {
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    const first = registry.wait('123456')
+    const sameHandle = registry.wait('123456')
+    const second = registry.wait('abcd')
+
+    expect(registry.evidence()).toEqual({
+      waiters: 3,
+      handles: 2,
+      retainedHandleBytes: 10
+    })
+    registry.notify('abcd')
+    await second
+    expect(() => registry.wait('abcde')).toThrowError(
+      expect.objectContaining({ reason: 'retained-handle-bytes' })
+    )
+
+    registry.close()
+    await Promise.all([first, sameHandle])
+  })
+
+  it('releases all key accounting under unique-handle churn', async () => {
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+
+    for (let index = 0; index < 10_000; index += 1) {
+      const handle = String(index)
+      const wait = registry.wait(handle)
+      registry.notify(handle)
+      await wait
+    }
+
+    expect(registry.evidence()).toEqual({
+      waiters: 0,
+      handles: 0,
+      retainedHandleBytes: 0
+    })
+  })
+
+  it('preserves type-filter wake behavior and deduplicates filters', async () => {
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    let statusResolved = false
+    let workerResolved = false
+    const status = registry.wait('same', {
+      typeFilter: ['status', 'status']
+    })
+    const worker = registry.wait('same', {
+      typeFilter: ['worker_done']
+    })
+    void status.then(() => {
+      statusResolved = true
+    })
+    void worker.then(() => {
+      workerResolved = true
+    })
+
+    expect(registry.notify('same', 'status')).toBe(1)
+    await status
+    expect(statusResolved).toBe(true)
+    expect(workerResolved).toBe(false)
+    expect(registry.evidence()).toEqual({
+      waiters: 1,
+      handles: 1,
+      retainedHandleBytes: 4
+    })
+
+    expect(registry.notify('same')).toBe(1)
+    await worker
+  })
+
+  it('removes timeout and abort state after notification', async () => {
+    vi.useFakeTimers()
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    const controller = new AbortController()
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+    const wait = registry.wait('a', { signal: controller.signal, timeoutMs: 100 })
+
+    registry.notify('a')
+    await wait
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    expect(vi.getTimerCount()).toBe(0)
+    expect(registry.evidence()).toEqual({
+      waiters: 0,
+      handles: 0,
+      retainedHandleBytes: 0
+    })
+  })
+
+  it('cleans up exactly on timeout', async () => {
+    vi.useFakeTimers()
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    const controller = new AbortController()
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+    const wait = registry.wait('abc', { signal: controller.signal, timeoutMs: 100 })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await wait
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    expect(registry.evidence()).toEqual({
+      waiters: 0,
+      handles: 0,
+      retainedHandleBytes: 0
+    })
+  })
+
+  it('cleans up exactly on abort and does not register an already-aborted signal', async () => {
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    const controller = new AbortController()
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+    const wait = registry.wait('abc', { signal: controller.signal })
+
+    controller.abort()
+    await wait
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    expect(registry.evidence()).toEqual({
+      waiters: 0,
+      handles: 0,
+      retainedHandleBytes: 0
+    })
+
+    const alreadyAborted = new AbortController()
+    alreadyAborted.abort()
+    const addListener = vi.spyOn(alreadyAborted.signal, 'addEventListener')
+    await registry.wait('abc', { signal: alreadyAborted.signal })
+    expect(addListener).not.toHaveBeenCalled()
+    expect(registry.evidence().waiters).toBe(0)
+  })
+
+  it('settles every waiter and releases all accounting on close', async () => {
+    vi.useFakeTimers()
+    const registry = new OrchestrationMessageWaiterRegistry(BOUNDS)
+    const controller = new AbortController()
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+    const first = registry.wait('first')
+    const sameHandle = registry.wait('first', { signal: controller.signal })
+    const second = registry.wait('other')
+
+    registry.close()
+    await Promise.all([first, sameHandle, second])
+    expect(removeListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    expect(vi.getTimerCount()).toBe(0)
+    expect(registry.evidence()).toEqual({
+      waiters: 0,
+      handles: 0,
+      retainedHandleBytes: 0
+    })
+    await expect(registry.wait('later')).resolves.toBeUndefined()
+    expect(registry.evidence().waiters).toBe(0)
+  })
+
+  it('publishes explicit production bounds', () => {
+    expect(MAX_ORCHESTRATION_MESSAGE_WAITERS).toBe(1_024)
+    expect(MAX_ORCHESTRATION_MESSAGE_WAITERS_PER_HANDLE).toBe(64)
+    expect(MAX_ORCHESTRATION_MESSAGE_WAITER_HANDLE_BYTES).toBe(64 * 1024)
+    expect(MAX_ORCHESTRATION_MESSAGE_WAITER_RETAINED_HANDLE_BYTES).toBe(1024 * 1024)
+  })
+})

--- a/src/main/runtime/orchestration-message-waiter-registry.ts
+++ b/src/main/runtime/orchestration-message-waiter-registry.ts
@@ -1,0 +1,235 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export const MAX_ORCHESTRATION_MESSAGE_WAITERS = 1_024
+export const MAX_ORCHESTRATION_MESSAGE_WAITERS_PER_HANDLE = 64
+export const MAX_ORCHESTRATION_MESSAGE_WAITER_HANDLE_BYTES = 64 * 1024
+export const MAX_ORCHESTRATION_MESSAGE_WAITER_RETAINED_HANDLE_BYTES = 1024 * 1024
+
+const DEFAULT_MESSAGE_WAIT_TIMEOUT_MS = 2 * 60 * 1000
+
+export type OrchestrationMessageWaiterBounds = {
+  maxWaiters: number
+  maxWaitersPerHandle: number
+  maxHandleBytes: number
+  maxRetainedHandleBytes: number
+}
+
+type MessageWaiterBucket = {
+  handle: string
+  handleBytes: number
+  waiters: Set<MessageWaiter>
+}
+
+type MessageWaiter = {
+  bucket: MessageWaiterBucket
+  typeFilter: Set<string> | undefined
+  resolve: () => void
+  timeout: ReturnType<typeof setTimeout> | null
+  signal: AbortSignal | undefined
+  onAbort: () => void
+  active: boolean
+}
+
+const DEFAULT_BOUNDS: OrchestrationMessageWaiterBounds = {
+  maxWaiters: MAX_ORCHESTRATION_MESSAGE_WAITERS,
+  maxWaitersPerHandle: MAX_ORCHESTRATION_MESSAGE_WAITERS_PER_HANDLE,
+  maxHandleBytes: MAX_ORCHESTRATION_MESSAGE_WAITER_HANDLE_BYTES,
+  maxRetainedHandleBytes: MAX_ORCHESTRATION_MESSAGE_WAITER_RETAINED_HANDLE_BYTES
+}
+
+export type OrchestrationMessageWaiterLimitReason =
+  | 'global'
+  | 'per-handle'
+  | 'handle-bytes'
+  | 'retained-handle-bytes'
+
+export class OrchestrationMessageWaiterLimitError extends Error {
+  constructor(
+    readonly reason: OrchestrationMessageWaiterLimitReason,
+    readonly limit: number
+  ) {
+    super(getLimitErrorMessage(reason, limit))
+    this.name = 'OrchestrationMessageWaiterLimitError'
+  }
+}
+
+export class OrchestrationMessageWaiterRegistry {
+  private readonly waitersByHandle = new Map<string, MessageWaiterBucket>()
+  private waiterCount = 0
+  private retainedHandleBytes = 0
+  private closed = false
+
+  constructor(
+    private readonly bounds: OrchestrationMessageWaiterBounds = DEFAULT_BOUNDS,
+    private readonly defaultTimeoutMs = DEFAULT_MESSAGE_WAIT_TIMEOUT_MS
+  ) {
+    if (
+      !Number.isSafeInteger(bounds.maxWaiters) ||
+      bounds.maxWaiters < 1 ||
+      !Number.isSafeInteger(bounds.maxWaitersPerHandle) ||
+      bounds.maxWaitersPerHandle < 1 ||
+      !Number.isSafeInteger(bounds.maxHandleBytes) ||
+      bounds.maxHandleBytes < 1 ||
+      !Number.isSafeInteger(bounds.maxRetainedHandleBytes) ||
+      bounds.maxRetainedHandleBytes < 1
+    ) {
+      throw new RangeError('Orchestration message waiter bounds must be positive integers')
+    }
+  }
+
+  wait(
+    handle: string,
+    options: { typeFilter?: string[]; timeoutMs?: number; signal?: AbortSignal } = {}
+  ): Promise<void> {
+    if (options.signal?.aborted || this.closed) {
+      return Promise.resolve()
+    }
+
+    const bucket = this.admit(handle)
+    const typeFilter = options.typeFilter ? new Set(options.typeFilter) : undefined
+
+    return new Promise((resolve) => {
+      let waiter!: MessageWaiter
+      const onAbort = (): void => this.settle(waiter)
+      waiter = {
+        bucket,
+        typeFilter,
+        resolve,
+        timeout: null,
+        signal: options.signal,
+        onAbort,
+        active: true
+      }
+      this.retain(waiter)
+      options.signal?.addEventListener('abort', onAbort, { once: true })
+      if (options.signal?.aborted) {
+        this.settle(waiter)
+        return
+      }
+      waiter.timeout = setTimeout(
+        () => this.settle(waiter),
+        options.timeoutMs ?? this.defaultTimeoutMs
+      )
+    })
+  }
+
+  notify(handle: string, messageType?: string): number {
+    const bucket = this.waitersByHandle.get(handle)
+    if (!bucket) {
+      return 0
+    }
+
+    let notified = 0
+    for (const waiter of Array.from(bucket.waiters)) {
+      if (messageType && waiter.typeFilter && !waiter.typeFilter.has(messageType)) {
+        continue
+      }
+      this.settle(waiter)
+      notified += 1
+    }
+    return notified
+  }
+
+  close(): void {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    for (const bucket of this.waitersByHandle.values()) {
+      for (const waiter of bucket.waiters) {
+        this.settle(waiter)
+      }
+    }
+  }
+
+  evidence(): { waiters: number; handles: number; retainedHandleBytes: number } {
+    return {
+      waiters: this.waiterCount,
+      handles: this.waitersByHandle.size,
+      retainedHandleBytes: this.retainedHandleBytes
+    }
+  }
+
+  private admit(handle: string): MessageWaiterBucket {
+    const existing = this.waitersByHandle.get(handle)
+    if (existing) {
+      if (this.waiterCount >= this.bounds.maxWaiters) {
+        throw new OrchestrationMessageWaiterLimitError('global', this.bounds.maxWaiters)
+      }
+      if (existing.waiters.size >= this.bounds.maxWaitersPerHandle) {
+        throw new OrchestrationMessageWaiterLimitError(
+          'per-handle',
+          this.bounds.maxWaitersPerHandle
+        )
+      }
+      return existing
+    }
+
+    const measurement = measureUtf8ByteLength(handle, {
+      stopAfterBytes: this.bounds.maxHandleBytes
+    })
+    if (measurement.exceededLimit) {
+      throw new OrchestrationMessageWaiterLimitError('handle-bytes', this.bounds.maxHandleBytes)
+    }
+    if (this.waiterCount >= this.bounds.maxWaiters) {
+      throw new OrchestrationMessageWaiterLimitError('global', this.bounds.maxWaiters)
+    }
+    if (measurement.byteLength > this.bounds.maxRetainedHandleBytes - this.retainedHandleBytes) {
+      throw new OrchestrationMessageWaiterLimitError(
+        'retained-handle-bytes',
+        this.bounds.maxRetainedHandleBytes
+      )
+    }
+    return {
+      handle,
+      handleBytes: measurement.byteLength,
+      waiters: new Set()
+    }
+  }
+
+  private retain(waiter: MessageWaiter): void {
+    const { bucket } = waiter
+    if (bucket.waiters.size === 0) {
+      this.waitersByHandle.set(bucket.handle, bucket)
+      this.retainedHandleBytes += bucket.handleBytes
+    }
+    bucket.waiters.add(waiter)
+    this.waiterCount += 1
+  }
+
+  private settle(waiter: MessageWaiter): void {
+    if (!waiter.active) {
+      return
+    }
+    waiter.active = false
+    if (waiter.timeout !== null) {
+      clearTimeout(waiter.timeout)
+      waiter.timeout = null
+    }
+    waiter.signal?.removeEventListener('abort', waiter.onAbort)
+    const { bucket } = waiter
+    if (bucket.waiters.delete(waiter)) {
+      this.waiterCount -= 1
+    }
+    if (bucket.waiters.size === 0 && this.waitersByHandle.delete(bucket.handle)) {
+      this.retainedHandleBytes -= bucket.handleBytes
+    }
+    waiter.resolve()
+  }
+}
+
+function getLimitErrorMessage(
+  reason: OrchestrationMessageWaiterLimitReason,
+  limit: number
+): string {
+  if (reason === 'handle-bytes') {
+    return `Orchestration message wait handle exceeds ${limit} UTF-8 bytes.`
+  }
+  if (reason === 'per-handle') {
+    return `Orchestration message wait capacity reached for this terminal (${limit}); retry shortly.`
+  }
+  if (reason === 'retained-handle-bytes') {
+    return `Orchestration message wait handle capacity reached (${limit} UTF-8 bytes); retry shortly.`
+  }
+  return `Orchestration message wait capacity reached (${limit}); retry shortly.`
+}

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -3,6 +3,12 @@ import type { OrchestrationDb } from './db'
 import type { MessageRow, TaskRow, CoordinatorStatus } from './types'
 import { buildDispatchPreamble } from './preamble'
 import { reconcileLifecycleMessage } from './lifecycle-reconciliation'
+import {
+  orchestrationRowRetainedUtf8Bytes,
+  ORCHESTRATION_QUERY_MAX_RETAINED_UTF8_BYTES,
+  ORCHESTRATION_QUERY_MAX_ROWS,
+  parseOrchestrationJson
+} from './query-retention'
 
 export type CoordinatorRuntime = {
   sendTerminalAgentPrompt(handle: string, prompt: string): Promise<unknown>
@@ -66,6 +72,7 @@ type CoordinatorState = {
   completedTasks: string[]
   failedTasks: string[]
   escalations: MessageRow[]
+  escalationRetainedBytes: number
 }
 
 const DEFAULT_POLL_MS = 2000
@@ -73,6 +80,23 @@ const MAX_CONCURRENT_DEFAULT = 4
 
 // Why: 10 min = documented heartbeat cadence (5 min) × 2, so one missed heartbeat is the earliest a dispatch can look stale.
 const HUNG_THRESHOLD_MS = 10 * 60 * 1000
+
+function mergeCoordinatorTaskIds(...sources: string[][]): string[] {
+  const retained: string[] = []
+  const seen = new Set<string>()
+  for (const source of sources) {
+    for (const id of source) {
+      if (!seen.has(id)) {
+        seen.add(id)
+        retained.push(id)
+        if (retained.length >= ORCHESTRATION_QUERY_MAX_ROWS) {
+          return retained
+        }
+      }
+    }
+  }
+  return retained
+}
 
 export class Coordinator {
   private db: OrchestrationDb
@@ -100,7 +124,8 @@ export class Coordinator {
       phase: 'decomposing',
       completedTasks: [],
       failedTasks: [],
-      escalations: []
+      escalations: [],
+      escalationRetainedBytes: 0
     }
   }
 
@@ -152,14 +177,12 @@ export class Coordinator {
       }
 
       // Why: an early stop leaves tasks incomplete, so the run counts as failed.
-      const tasks = this.db.listTasks()
-      const allDone = tasks.every((t) => t.status === 'completed' || t.status === 'failed')
-      const failedTasks = [
-        ...new Set([
-          ...this.state.failedTasks,
-          ...tasks.filter((task) => task.status === 'failed').map((task) => task.id)
-        ])
-      ]
+      const counts = this.db.getTaskStatusCounts()
+      const allDone = counts.total === counts.completed + counts.failed
+      const failedTasks = mergeCoordinatorTaskIds(
+        this.state.failedTasks,
+        this.db.listTaskIdsByStatus('failed')
+      )
       const finalStatus =
         this.stopped || failedTasks.length > 0 || !allDone ? 'failed' : 'completed'
       this.db.updateCoordinatorRun(runId, finalStatus)
@@ -185,13 +208,13 @@ export class Coordinator {
   // Why: decomposition isn't implemented yet — tasks must be pre-created before run(); AI-driven decomposition is a future phase.
   private async decompose(): Promise<void> {
     this.state.phase = 'decomposing'
-    const existing = this.db.listTasks()
-    if (existing.length === 0) {
+    const taskCount = this.db.getTaskStatusCounts().total
+    if (taskCount === 0) {
       throw new Error(
         'No tasks found. Create tasks with orchestration.taskCreate before running the coordinator.'
       )
     }
-    this.opts.onLog(`Found ${existing.length} tasks in DAG`)
+    this.opts.onLog(`Found ${taskCount} tasks in DAG`)
     this.state.phase = 'dispatching'
   }
 
@@ -207,13 +230,12 @@ export class Coordinator {
   // Why: warn only, never auto-fail — a false positive (slow but correct worker) costs more than a false negative (hung worker holding a slot); see R6 of DESIGN_DOC_PREAMBLE_FIX.md.
   private warnStaleDispatches(): void {
     const thresholdIso = new Date(Date.now() - HUNG_THRESHOLD_MS).toISOString()
-    const stale = this.db.getStaleDispatches(thresholdIso)
-    for (const ctx of stale) {
+    this.db.forEachStaleDispatch(thresholdIso, (ctx) => {
       const minutes = Math.round(HUNG_THRESHOLD_MS / 60000)
       this.opts.onLog(
         `Warning: worker ${ctx.assignee_handle ?? '<unknown>'} on task ${ctx.task_id} has not sent a heartbeat in ~${minutes} min (dispatch ${ctx.id})`
       )
-    }
+    })
   }
 
   private processMessages(): void {
@@ -252,7 +274,10 @@ export class Coordinator {
   private handleLifecycleMessage(msg: MessageRow): void {
     const result = reconcileLifecycleMessage(this.db, msg, this.opts.onLog)
     if (result.action === 'completed') {
-      if (!this.state.completedTasks.includes(result.taskId)) {
+      if (
+        this.state.completedTasks.length < ORCHESTRATION_QUERY_MAX_ROWS &&
+        !this.state.completedTasks.includes(result.taskId)
+      ) {
         this.state.completedTasks.push(result.taskId)
       }
     }
@@ -260,13 +285,24 @@ export class Coordinator {
 
   private handleEscalation(msg: MessageRow): void {
     this.opts.onLog(`Escalation from ${msg.from_handle}: ${msg.subject}`)
-    this.state.escalations.push(msg)
+    const messageBytes = orchestrationRowRetainedUtf8Bytes(msg)
+    if (
+      this.state.escalations.length < ORCHESTRATION_QUERY_MAX_ROWS &&
+      this.state.escalationRetainedBytes + messageBytes <=
+        ORCHESTRATION_QUERY_MAX_RETAINED_UTF8_BYTES
+    ) {
+      this.state.escalations.push(msg)
+      this.state.escalationRetainedBytes += messageBytes
+    }
 
     let taskId: string | undefined
     if (msg.payload) {
       try {
-        const payload = JSON.parse(msg.payload)
-        taskId = payload.taskId
+        const payload = parseOrchestrationJson(msg.payload)
+        if (payload && typeof payload === 'object') {
+          const rawTaskId = (payload as { taskId?: unknown }).taskId
+          taskId = typeof rawTaskId === 'string' ? rawTaskId : undefined
+        }
       } catch {
         // Escalation without structured payload — log subject as context
       }
@@ -291,7 +327,12 @@ export class Coordinator {
     if (updated?.status === 'circuit_broken') {
       this.opts.onLog(`Task ${taskId} circuit broken after repeated failures`)
       this.db.updateTaskStatus(taskId, 'failed', `Circuit broken: ${msg.subject}`)
-      this.state.failedTasks.push(taskId)
+      if (
+        this.state.failedTasks.length < ORCHESTRATION_QUERY_MAX_ROWS &&
+        !this.state.failedTasks.includes(taskId)
+      ) {
+        this.state.failedTasks.push(taskId)
+      }
     } else {
       this.opts.onLog(`Task ${taskId} will be retried (failure ${updated?.failure_count ?? 0}/3)`)
     }
@@ -303,7 +344,10 @@ export class Coordinator {
     let payload: { taskId?: string; question?: string; options?: string[] } = {}
     if (msg.payload) {
       try {
-        payload = JSON.parse(msg.payload)
+        const parsed = parseOrchestrationJson(msg.payload)
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          payload = parsed as typeof payload
+        }
       } catch {
         return
       }
@@ -329,14 +373,7 @@ export class Coordinator {
 
   private processDecisionGates(): void {
     // Why: the coordinator never auto-resolves gates (humans do, via orchestration.gateResolve) — that would defeat them as approval checkpoints.
-    const pendingGates = this.db.listGates({ status: 'pending' })
-    for (const gate of pendingGates) {
-      const task = this.db.getTask(gate.task_id)
-      if (task && task.status !== 'blocked') {
-        // Why: gate exists but task isn't blocked — re-block to restore the invariant.
-        this.db.updateTaskStatus(gate.task_id, 'blocked')
-      }
-    }
+    this.db.restorePendingGateTaskStatuses()
   }
 
   private async dispatchReadyTasks(): Promise<void> {
@@ -346,8 +383,8 @@ export class Coordinator {
       return
     }
 
-    const dispatched = this.db.listTasks({ status: 'dispatched' })
-    let slotsAvailable = this.opts.maxConcurrent - dispatched.length
+    const dispatchedCount = this.db.getTaskStatusCounts().dispatched
+    let slotsAvailable = this.opts.maxConcurrent - dispatchedCount
     if (slotsAvailable <= 0) {
       return
     }
@@ -437,10 +474,9 @@ export class Coordinator {
     })
 
     // Why: surface a since-resolved decision gate's outcome to the worker via the preamble.
-    const gates = this.db.listGates({ taskId: task.id, status: 'resolved' })
     let gateContext = ''
-    if (gates.length > 0) {
-      const latest = gates.at(-1)!
+    const latest = this.db.getLatestGate({ taskId: task.id, status: 'resolved' })
+    if (latest) {
       gateContext = `\n\n--- DECISION GATE RESOLVED ---\nQuestion: ${latest.question}\nResolution: ${latest.resolution}\n---\n`
     }
 
@@ -452,7 +488,12 @@ export class Coordinator {
         err instanceof Error ? err.message : String(err)
       )
       if (updated?.status === 'circuit_broken') {
-        this.state.failedTasks.push(task.id)
+        if (
+          this.state.failedTasks.length < ORCHESTRATION_QUERY_MAX_ROWS &&
+          !this.state.failedTasks.includes(task.id)
+        ) {
+          this.state.failedTasks.push(task.id)
+        }
       }
       throw err
     }
@@ -464,13 +505,11 @@ export class Coordinator {
   private async getAvailableTerminals(): Promise<string[]> {
     try {
       const result = await this.runtime.listTerminals(this.opts.worktree)
-      const dispatched = this.db.listTasks({ status: 'dispatched' })
       const busyHandles = new Set<string>()
 
-      for (const task of dispatched) {
-        const ctx = this.db.getDispatchContext(task.id)
-        if (ctx?.assignee_handle) {
-          busyHandles.add(ctx.assignee_handle)
+      for (const terminal of result.terminals) {
+        if (this.db.getActiveDispatchForTerminal(terminal.handle)) {
+          busyHandles.add(terminal.handle)
         }
       }
 
@@ -490,25 +529,22 @@ export class Coordinator {
   }
 
   private checkConvergence(): boolean {
-    const tasks = this.db.listTasks()
-    if (tasks.length === 0) {
+    const counts = this.db.getTaskStatusCounts()
+    if (counts.total === 0) {
       return true
     }
 
-    const allDone = tasks.every((t) => t.status === 'completed' || t.status === 'failed')
+    const allDone = counts.total === counts.completed + counts.failed
     if (allDone) {
       this.state.phase = 'done'
       return true
     }
 
     // Why: no active tasks but some blocked → dependencies can never be satisfied (stuck).
-    const active = tasks.filter(
-      (t) => t.status === 'ready' || t.status === 'dispatched' || t.status === 'pending'
-    )
-    const blocked = tasks.filter((t) => t.status === 'blocked')
-    if (active.length === 0 && blocked.length > 0) {
+    const activeCount = counts.ready + counts.dispatched + counts.pending
+    if (activeCount === 0 && counts.blocked > 0) {
       this.opts.onLog(
-        `Stuck: ${blocked.length} tasks blocked with no active tasks. Resolve decision gates to continue.`
+        `Stuck: ${counts.blocked} tasks blocked with no active tasks. Resolve decision gates to continue.`
       )
     }
 

--- a/src/main/runtime/orchestration/db-query-retention.test.ts
+++ b/src/main/runtime/orchestration/db-query-retention.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type Database from '../../sqlite/sync-database'
+import { OrchestrationDb } from './db'
+import {
+  orchestrationRowRetainedUtf8Bytes,
+  ORCHESTRATION_JSON_STRUCTURE_LIMITS,
+  ORCHESTRATION_QUERY_MAX_RETAINED_UTF8_BYTES,
+  ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES,
+  ORCHESTRATION_QUERY_MAX_ROWS,
+  ORCHESTRATION_WRITE_MAX_ITEMS,
+  ORCHESTRATION_WRITE_MAX_UTF8_BYTES,
+  parseOrchestrationJson
+} from './query-retention'
+
+function sqliteFor(db: OrchestrationDb): Database.Database {
+  return (db as unknown as { db: Database.Database }).db
+}
+
+function paneKey(index: number, tab = `tab_${index}`): string {
+  return `${tab}:00000000-0000-4000-8000-${index.toString(16).padStart(12, '0')}`
+}
+
+describe('OrchestrationDb query retention', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  function createDb(): OrchestrationDb {
+    db = new OrchestrationDb(':memory:')
+    return db
+  }
+
+  it('returns unread rows in stable bounded pages that can be drained successively', () => {
+    const d = createDb()
+    const inserted = Array.from({ length: ORCHESTRATION_QUERY_MAX_ROWS + 2 }, (_, index) =>
+      d.insertMessage({ from: 'sender', to: 'worker', subject: `message-${index}` })
+    )
+
+    const first = d.getUnreadMessages('worker')
+    expect(first.map((row) => row.id)).toEqual(
+      inserted.slice(0, ORCHESTRATION_QUERY_MAX_ROWS).map((row) => row.id)
+    )
+
+    d.markAsRead(first.map((row) => row.id))
+    expect(d.getUnreadMessages('worker').map((row) => row.id)).toEqual(
+      inserted.slice(ORCHESTRATION_QUERY_MAX_ROWS).map((row) => row.id)
+    )
+  })
+
+  it('drains undelivered rows successively without replaying the first page', () => {
+    const d = createDb()
+    const inserted = Array.from({ length: ORCHESTRATION_QUERY_MAX_ROWS + 1 }, (_, index) =>
+      d.insertMessage({ from: 'sender', to: 'worker', subject: `delivery-${index}` })
+    )
+
+    const first = d.getUndeliveredUnreadMessages('worker')
+    d.markAsDelivered(first.map((row) => row.id))
+
+    expect(d.getUndeliveredUnreadMessages('worker').map((row) => row.id)).toEqual([
+      inserted.at(-1)!.id
+    ])
+  })
+
+  it('caps aggregate retained bytes and resumes at the first omitted message', () => {
+    const d = createDb()
+    const body = 'x'.repeat(500 * 1024)
+    const inserted = Array.from({ length: 20 }, (_, index) =>
+      d.insertMessage({ from: 'sender', to: 'worker', subject: `large-${index}`, body })
+    )
+
+    const first = d.getUnreadMessages('worker')
+    const retainedBytes = first.reduce(
+      (total, row) => total + orchestrationRowRetainedUtf8Bytes(row),
+      0
+    )
+    expect(first.length).toBeGreaterThan(0)
+    expect(first.length).toBeLessThan(inserted.length)
+    expect(retainedBytes).toBeLessThanOrEqual(ORCHESTRATION_QUERY_MAX_RETAINED_UTF8_BYTES)
+
+    d.markAsRead(first.map((row) => row.id))
+    expect(d.getUnreadMessages('worker')[0]?.id).toBe(inserted[first.length].id)
+  })
+
+  it('rejects new oversized rows and skips oversized legacy rows without starving later rows', () => {
+    const d = createDb()
+    const exactSubject = 'x'.repeat(ORCHESTRATION_WRITE_MAX_UTF8_BYTES - 2)
+    expect(d.insertMessage({ from: 'a', to: 'b', subject: exactSubject }).subject).toBe(
+      exactSubject
+    )
+    expect(() => d.insertMessage({ from: 'a', to: 'b', subject: `${exactSubject}x` })).toThrow(
+      /orchestration limit/
+    )
+
+    sqliteFor(d)
+      .prepare(
+        `INSERT INTO messages (id, from_handle, to_handle, subject, body)
+         VALUES (?, 'a', 'legacy', 'oversized', ?)`
+      )
+      .run('msg_oversized', 'z'.repeat(ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES + 1))
+    const later = d.insertMessage({ from: 'a', to: 'legacy', subject: 'later-valid-row' })
+
+    expect(d.getMessageById('msg_oversized')).toBeUndefined()
+    expect(d.getUnreadMessages('legacy').map((row) => row.id)).toEqual([later.id])
+  })
+
+  it('keeps exact task counts and promotes dependencies beyond the returned page', () => {
+    const d = createDb()
+    const parent = d.createTask({ spec: 'parent' })
+    const children = Array.from({ length: ORCHESTRATION_QUERY_MAX_ROWS + 1 }, (_, index) =>
+      d.createTask({ spec: `child-${index}`, deps: [parent.id] })
+    )
+
+    expect(d.listTasks()).toHaveLength(ORCHESTRATION_QUERY_MAX_ROWS)
+    expect(d.getTaskStatusCounts()).toMatchObject({
+      total: ORCHESTRATION_QUERY_MAX_ROWS + 2,
+      pending: ORCHESTRATION_QUERY_MAX_ROWS + 1,
+      ready: 1
+    })
+
+    d.updateTaskStatus(parent.id, 'completed')
+
+    expect(d.getTask(children.at(-1)!.id)?.status).toBe('ready')
+    expect(d.getTaskStatusCounts()).toMatchObject({
+      total: ORCHESTRATION_QUERY_MAX_ROWS + 2,
+      completed: 1,
+      ready: ORCHESTRATION_QUERY_MAX_ROWS + 1
+    })
+  })
+
+  it('rejects dependency amplification and promotes valid rows after oversized legacy DAG data', () => {
+    const d = createDb()
+    const parent = d.createTask({ spec: 'parent' })
+    expect(() =>
+      d.createTask({
+        spec: 'too many deps',
+        deps: Array.from({ length: ORCHESTRATION_WRITE_MAX_ITEMS + 1 }, () => parent.id)
+      })
+    ).toThrow(/item orchestration limit/)
+
+    sqliteFor(d)
+      .prepare(
+        `INSERT INTO tasks (id, spec, status, deps)
+         VALUES ('task_legacy_amplified', 'legacy', 'pending', ?)`
+      )
+      .run(
+        JSON.stringify(Array.from({ length: ORCHESTRATION_WRITE_MAX_ITEMS + 1 }, () => parent.id))
+      )
+    const valid = d.createTask({ spec: 'valid', deps: [parent.id] })
+
+    d.updateTaskStatus(parent.id, 'completed')
+
+    expect(d.getTask('task_legacy_amplified')?.status).toBe('pending')
+    expect(d.getTask(valid.id)?.status).toBe('ready')
+  })
+
+  it('streams active pane and stale-dispatch scans beyond the returned page', () => {
+    const d = createDb()
+    const contexts = Array.from({ length: ORCHESTRATION_QUERY_MAX_ROWS + 1 }, (_, index) => {
+      const task = d.createTask({ spec: `task-${index}` })
+      return d.createDispatchContext(task.id, `worker-${index}`, paneKey(index))
+    })
+    const duplicateTask = d.createTask({ spec: 'duplicate pane' })
+
+    expect(() =>
+      d.createDispatchContext(
+        duplicateTask.id,
+        'reminted-worker',
+        paneKey(ORCHESTRATION_QUERY_MAX_ROWS, 'reminted-tab')
+      )
+    ).toThrow(/already has an active dispatch/)
+
+    sqliteFor(d)
+      .prepare(
+        "UPDATE dispatch_contexts SET dispatched_at = '2020-01-01 00:00:00', last_heartbeat_at = NULL"
+      )
+      .run()
+    const threshold = '2021-01-01T00:00:00.000Z'
+    expect(d.getStaleDispatches(threshold)).toHaveLength(ORCHESTRATION_QUERY_MAX_ROWS)
+
+    const visited: string[] = []
+    d.forEachStaleDispatch(threshold, (row) => {
+      visited.push(row.id)
+    })
+    expect(visited).toEqual(contexts.map((row) => row.id))
+  })
+
+  it('repairs every pending-gate task even when the gate list is capped', () => {
+    const d = createDb()
+    const rejectedTask = d.createTask({ spec: 'reject amplified options' })
+    expect(() =>
+      d.createGate({
+        taskId: rejectedTask.id,
+        question: 'too many',
+        options: Array.from({ length: ORCHESTRATION_WRITE_MAX_ITEMS + 1 }, () => '')
+      })
+    ).toThrow(/item orchestration limit/)
+    const tasks = Array.from({ length: ORCHESTRATION_QUERY_MAX_ROWS + 1 }, (_, index) => {
+      const task = d.createTask({ spec: `gated-${index}` })
+      d.createGate({ taskId: task.id, question: `question-${index}` })
+      return task
+    })
+
+    expect(d.listGates({ status: 'pending' })).toHaveLength(ORCHESTRATION_QUERY_MAX_ROWS)
+    sqliteFor(d).prepare("UPDATE tasks SET status = 'ready'").run()
+
+    d.restorePendingGateTaskStatuses()
+
+    expect(d.getTask(tasks.at(-1)!.id)?.status).toBe('blocked')
+    expect(d.getTaskStatusCounts()).toMatchObject({
+      blocked: ORCHESTRATION_QUERY_MAX_ROWS + 1,
+      ready: 1
+    })
+  })
+})
+
+describe('orchestration JSON structure admission', () => {
+  it('admits the exact structural-token limit and rejects limit +1', () => {
+    const exactValues = ORCHESTRATION_JSON_STRUCTURE_LIMITS.structuralTokens - 1
+    const exact = `[${Array.from({ length: exactValues }, () => '0').join(',')}]`
+    const over = `${exact.slice(0, -1)},0]`
+
+    expect(parseOrchestrationJson(exact)).toHaveLength(exactValues)
+    expect(() => parseOrchestrationJson(over)).toThrow(/JSON structure exceeds/)
+  })
+
+  it('admits the exact nesting limit and rejects limit +1', () => {
+    const depth = ORCHESTRATION_JSON_STRUCTURE_LIMITS.nestingDepth
+    const exact = `${'['.repeat(depth)}0${']'.repeat(depth)}`
+    const over = `[${exact}]`
+
+    expect(parseOrchestrationJson(exact)).toBeDefined()
+    expect(() => parseOrchestrationJson(over)).toThrow(/JSON nesting exceeds/)
+  })
+})

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -16,6 +16,80 @@ import type {
 } from './types'
 import { buildOrchestrationTaskDisplayMetadata } from '../../../shared/orchestration-task-display'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
+import {
+  assertOrchestrationStringListFits,
+  assertOrchestrationWriteFits,
+  clampOrchestrationQueryLimit,
+  ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES,
+  ORCHESTRATION_QUERY_MAX_ROWS,
+  ORCHESTRATION_WRITE_MAX_ITEMS,
+  parseOrchestrationJson,
+  retainOrchestrationQueryRows,
+  truncateOrchestrationDiagnostic
+} from './query-retention'
+
+function retainedTextBytesSql(columns: string[]): string {
+  return columns.map((column) => `length(CAST(COALESCE(${column}, '') AS BLOB))`).join(' + ')
+}
+
+const MESSAGE_ROW_BYTES_SQL = retainedTextBytesSql([
+  'messages.id',
+  'messages.from_handle',
+  'messages.to_handle',
+  'messages.subject',
+  'messages.body',
+  'messages.type',
+  'messages.priority',
+  'messages.thread_id',
+  'messages.payload',
+  'messages.created_at',
+  'messages.delivered_at',
+  'messages.sender_pane_key'
+])
+const TASK_ROW_BYTES_SQL = retainedTextBytesSql([
+  'tasks.id',
+  'tasks.parent_id',
+  'tasks.created_by_terminal_handle',
+  'tasks.task_title',
+  'tasks.display_name',
+  'tasks.spec',
+  'tasks.status',
+  'tasks.deps',
+  'tasks.result',
+  'tasks.created_at',
+  'tasks.completed_at'
+])
+const DISPATCH_ROW_BYTES_SQL = retainedTextBytesSql([
+  'dispatch_contexts.id',
+  'dispatch_contexts.task_id',
+  'dispatch_contexts.assignee_handle',
+  'dispatch_contexts.assignee_pane_key',
+  'dispatch_contexts.status',
+  'dispatch_contexts.last_failure',
+  'dispatch_contexts.dispatched_at',
+  'dispatch_contexts.completed_at',
+  'dispatch_contexts.created_at',
+  'dispatch_contexts.last_heartbeat_at'
+])
+const GATE_ROW_BYTES_SQL = retainedTextBytesSql([
+  'decision_gates.id',
+  'decision_gates.task_id',
+  'decision_gates.question',
+  'decision_gates.options',
+  'decision_gates.status',
+  'decision_gates.resolution',
+  'decision_gates.created_at',
+  'decision_gates.resolved_at'
+])
+const COORDINATOR_RUN_ROW_BYTES_SQL = retainedTextBytesSql([
+  'coordinator_runs.id',
+  'coordinator_runs.spec',
+  'coordinator_runs.status',
+  'coordinator_runs.coordinator_handle',
+  'coordinator_runs.created_at',
+  'coordinator_runs.completed_at'
+])
+const INTERNAL_SCAN_BATCH_ROWS = 64
 
 // Why: leaf UUID is the remint-stable pane identity (tab half changes on break-out); exact match covers legacy/unparseable keys.
 function isEquivalentPaneKey(a: string, b: string): boolean {
@@ -41,14 +115,29 @@ export type {
   CoordinatorRun
 }
 
+export type TaskStatusCounts = Record<TaskStatus, number> & { total: number }
+
 function generateId(prefix: string): string {
   return `${prefix}_${randomBytes(6).toString('hex')}`
+}
+
+function uniqueMessageTypes(types: MessageType[] | undefined): MessageType[] {
+  const unique: MessageType[] = []
+  for (const type of types ?? []) {
+    if (!unique.includes(type)) {
+      unique.push(type)
+      if (unique.length === 8) {
+        break
+      }
+    }
+  }
+  return unique
 }
 
 function addLifecycleRejectionMarker(payload: string | null, reason: string): string {
   let parsed: Record<string, unknown> = {}
   try {
-    const value: unknown = payload ? JSON.parse(payload) : {}
+    const value: unknown = payload ? parseOrchestrationJson(payload) : {}
     if (value && typeof value === 'object' && !Array.isArray(value)) {
       parsed = value as Record<string, unknown>
     }
@@ -104,6 +193,24 @@ export class OrchestrationDb {
     this.db.pragma('busy_timeout = 5000')
     this.createTables()
     this.migrate()
+  }
+
+  private readRows<T extends object>(
+    sql: string,
+    params: Database.BindValue[] = [],
+    requestedLimit?: number
+  ): T[] {
+    const limit = clampOrchestrationQueryLimit(requestedLimit)
+    if (limit === 0) {
+      return []
+    }
+    const rows = this.db.prepare(`${sql} LIMIT ?`).iterate(...params, limit) as Iterable<T>
+    return retainOrchestrationQueryRows(rows, limit)
+  }
+
+  private countRows(sql: string, params: Database.BindValue[] = []): number {
+    const row = this.db.prepare(sql).get(...params) as { count: number }
+    return row.count
   }
 
   private createTables(): void {
@@ -333,6 +440,17 @@ export class OrchestrationDb {
     payload?: string
     senderPaneKey?: string
   }): MessageRow {
+    assertOrchestrationWriteFits('Message', [
+      msg.from,
+      msg.to,
+      msg.subject,
+      msg.body,
+      msg.type,
+      msg.priority,
+      msg.threadId,
+      msg.payload,
+      msg.senderPaneKey
+    ])
     const id = generateId('msg')
     const stmt = this.db.prepare(`
       INSERT INTO messages (id, from_handle, to_handle, subject, body, type, priority, thread_id, payload, sender_pane_key)
@@ -350,26 +468,37 @@ export class OrchestrationDb {
       msg.payload ?? null,
       msg.senderPaneKey ?? null
     )
-    return exposeMessageTimestamps(
-      this.db.prepare('SELECT * FROM messages WHERE id = ?').get(id) as MessageRow
-    )
+    return this.getMessageById(id)!
   }
 
   getUnreadMessages(toHandle: string, types?: MessageType[]): MessageRow[] {
-    if (types && types.length > 0) {
-      const placeholders = types.map(() => '?').join(',')
-      return exposeMessageListTimestamps(
-        this.db
-          .prepare(
-            `SELECT * FROM messages WHERE to_handle = ? AND read = 0 AND type IN (${placeholders}) ORDER BY sequence`
-          )
-          .all(toHandle, ...types) as MessageRow[]
-      )
+    const params: Database.BindValue[] = [toHandle]
+    let typeFilter = ''
+    const retainedTypes = uniqueMessageTypes(types)
+    if (retainedTypes.length > 0) {
+      const placeholders = retainedTypes.map(() => '?').join(',')
+      typeFilter = ` AND type IN (${placeholders})`
+      params.push(...retainedTypes)
     }
     return exposeMessageListTimestamps(
-      this.db
-        .prepare('SELECT * FROM messages WHERE to_handle = ? AND read = 0 ORDER BY sequence')
-        .all(toHandle) as MessageRow[]
+      this.readRows<MessageRow>(
+        `SELECT * FROM messages
+         WHERE to_handle = ? AND read = 0${typeFilter}
+           AND (${MESSAGE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY sequence`,
+        params
+      )
+    )
+  }
+
+  countUnreadMessages(toHandle: string, types?: MessageType[]): number {
+    const retainedTypes = uniqueMessageTypes(types)
+    const placeholders = retainedTypes.map(() => '?').join(',')
+    const typeFilter = retainedTypes.length > 0 ? ` AND type IN (${placeholders})` : ''
+    return this.countRows(
+      `SELECT COUNT(*) AS count FROM messages
+       WHERE to_handle = ? AND read = 0${typeFilter}`,
+      [toHandle, ...retainedTypes]
     )
   }
 
@@ -380,8 +509,11 @@ export class OrchestrationDb {
     }
 
     const originalBody = message.body ? `\n\nOriginal body:\n${message.body}` : ''
-    const body = `Orca rejected this ${message.type}: ${reason}${originalBody}`
-    const payload = addLifecycleRejectionMarker(message.payload, reason)
+    const boundedReason = truncateOrchestrationDiagnostic(reason)
+    const body = truncateOrchestrationDiagnostic(
+      `Orca rejected this ${message.type}: ${boundedReason}${originalBody}`
+    )
+    const payload = addLifecycleRejectionMarker(message.payload, boundedReason)
     // Why: rejected lifecycle signals stay auditable but must not reach read paths as actionable completion/liveness events.
     this.db
       .prepare(
@@ -395,116 +527,133 @@ export class OrchestrationDb {
 
   // Why: delivered_at IS NULL filter — push-on-idle delivers each row at most once; read (set only by check) wouldn't prevent replay.
   getUndeliveredUnreadMessages(toHandle: string, types?: MessageType[]): MessageRow[] {
-    if (types && types.length > 0) {
-      const placeholders = types.map(() => '?').join(',')
-      return exposeMessageListTimestamps(
-        this.db
-          .prepare(
-            `SELECT * FROM messages WHERE to_handle = ? AND read = 0 AND delivered_at IS NULL AND type IN (${placeholders}) ORDER BY sequence`
-          )
-          .all(toHandle, ...types) as MessageRow[]
-      )
+    const params: Database.BindValue[] = [toHandle]
+    let typeFilter = ''
+    const retainedTypes = uniqueMessageTypes(types)
+    if (retainedTypes.length > 0) {
+      const placeholders = retainedTypes.map(() => '?').join(',')
+      typeFilter = ` AND type IN (${placeholders})`
+      params.push(...retainedTypes)
     }
     return exposeMessageListTimestamps(
-      this.db
-        .prepare(
-          'SELECT * FROM messages WHERE to_handle = ? AND read = 0 AND delivered_at IS NULL ORDER BY sequence'
-        )
-        .all(toHandle) as MessageRow[]
+      this.readRows<MessageRow>(
+        `SELECT * FROM messages
+         WHERE to_handle = ? AND read = 0 AND delivered_at IS NULL${typeFilter}
+           AND (${MESSAGE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY sequence`,
+        params
+      )
     )
   }
 
   getAllMessages(toHandle: string, limit = 20): MessageRow[] {
     return exposeMessageListTimestamps(
-      this.db
-        .prepare('SELECT * FROM messages WHERE to_handle = ? ORDER BY sequence DESC LIMIT ?')
-        .all(toHandle, limit) as MessageRow[]
+      this.readRows<MessageRow>(
+        `SELECT * FROM messages
+         WHERE to_handle = ?
+           AND (${MESSAGE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY sequence DESC`,
+        [toHandle],
+        limit
+      )
     )
   }
 
   getMessageById(id: string): MessageRow | undefined {
-    const message = this.db.prepare('SELECT * FROM messages WHERE id = ?').get(id) as
-      | MessageRow
-      | undefined
+    const message = this.db
+      .prepare(
+        `SELECT * FROM messages
+         WHERE id = ? AND (${MESSAGE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}`
+      )
+      .get(id) as MessageRow | undefined
     return message ? exposeMessageTimestamps(message) : undefined
   }
 
   markAsRead(ids: string[]): void {
-    if (ids.length === 0) {
-      return
-    }
-    const placeholders = ids.map(() => '?').join(',')
-    this.db.prepare(`UPDATE messages SET read = 1 WHERE id IN (${placeholders})`).run(...ids)
+    this.updateMessageIds(ids, 'read = 1')
   }
 
   // Why: use datetime('now') so delivered_at matches the space-format UTC shape of the table's other timestamps for correct ordering (§3.2).
   markAsDelivered(ids: string[]): void {
-    if (ids.length === 0) {
-      return
-    }
-    const placeholders = ids.map(() => '?').join(',')
-    this.db
-      .prepare(`UPDATE messages SET delivered_at = datetime('now') WHERE id IN (${placeholders})`)
-      .run(...ids)
+    this.updateMessageIds(ids, "delivered_at = datetime('now')")
   }
 
   markAsReadAndDelivered(ids: string[]): void {
-    if (ids.length === 0) {
-      return
-    }
-    const placeholders = ids.map(() => '?').join(',')
     // Why: superseded lifecycle messages stay in history but must not be consumed or injected after their dispatch finished.
-    this.db
-      .prepare(
-        `UPDATE messages SET read = 1, delivered_at = COALESCE(delivered_at, datetime('now')) WHERE id IN (${placeholders})`
-      )
-      .run(...ids)
+    this.updateMessageIds(ids, "read = 1, delivered_at = COALESCE(delivered_at, datetime('now'))")
+  }
+
+  private updateMessageIds(ids: string[], assignments: string): void {
+    for (let start = 0; start < ids.length; start += ORCHESTRATION_QUERY_MAX_ROWS) {
+      const batch = ids.slice(start, start + ORCHESTRATION_QUERY_MAX_ROWS)
+      const placeholders = batch.map(() => '?').join(',')
+      this.db
+        .prepare(`UPDATE messages SET ${assignments} WHERE id IN (${placeholders})`)
+        .run(...batch)
+    }
   }
 
   getInbox(limit = 20): MessageRow[] {
     return exposeMessageListTimestamps(
-      this.db
-        .prepare('SELECT * FROM messages ORDER BY sequence DESC LIMIT ?')
-        .all(limit) as MessageRow[]
+      this.readRows<MessageRow>(
+        `SELECT * FROM messages
+         WHERE (${MESSAGE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY sequence DESC`,
+        [],
+        limit
+      )
     )
+  }
+
+  countInbox(): number {
+    return this.countRows('SELECT COUNT(*) AS count FROM messages')
   }
 
   // Why: read-only history for a handle — returns every message regardless of read/delivered state, never flips the read bit (§3.3).
   getAllMessagesForHandle(toHandle: string, limit = 100, types?: MessageType[]): MessageRow[] {
-    if (types && types.length > 0) {
-      const placeholders = types.map(() => '?').join(',')
-      return exposeMessageListTimestamps(
-        this.db
-          .prepare(
-            `SELECT * FROM messages WHERE to_handle = ? AND type IN (${placeholders}) ORDER BY sequence DESC LIMIT ?`
-          )
-          .all(toHandle, ...types, limit) as MessageRow[]
-      )
+    const params: Database.BindValue[] = [toHandle]
+    let typeFilter = ''
+    const retainedTypes = uniqueMessageTypes(types)
+    if (retainedTypes.length > 0) {
+      const placeholders = retainedTypes.map(() => '?').join(',')
+      typeFilter = ` AND type IN (${placeholders})`
+      params.push(...retainedTypes)
     }
     return exposeMessageListTimestamps(
-      this.db
-        .prepare('SELECT * FROM messages WHERE to_handle = ? ORDER BY sequence DESC LIMIT ?')
-        .all(toHandle, limit) as MessageRow[]
+      this.readRows<MessageRow>(
+        `SELECT * FROM messages
+         WHERE to_handle = ?${typeFilter}
+           AND (${MESSAGE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY sequence DESC`,
+        params,
+        limit
+      )
+    )
+  }
+
+  countAllMessagesForHandle(toHandle: string, types?: MessageType[]): number {
+    const retainedTypes = uniqueMessageTypes(types)
+    const placeholders = retainedTypes.map(() => '?').join(',')
+    const typeFilter = retainedTypes.length > 0 ? ` AND type IN (${placeholders})` : ''
+    return this.countRows(
+      `SELECT COUNT(*) AS count FROM messages WHERE to_handle = ?${typeFilter}`,
+      [toHandle, ...retainedTypes]
     )
   }
 
   // Why: ask wait-loop read — to_handle filter shows only replies to the worker; afterSequence resumes past its own outbound ask.
   getThreadMessagesFor(threadId: string, toHandle: string, afterSequence?: number): MessageRow[] {
-    if (afterSequence !== undefined) {
-      return exposeMessageListTimestamps(
-        this.db
-          .prepare(
-            'SELECT * FROM messages WHERE thread_id = ? AND to_handle = ? AND sequence > ? ORDER BY sequence ASC'
-          )
-          .all(threadId, toHandle, afterSequence) as MessageRow[]
-      )
-    }
+    const sequenceFilter = afterSequence === undefined ? '' : ' AND sequence > ?'
+    const params: Database.BindValue[] =
+      afterSequence === undefined ? [threadId, toHandle] : [threadId, toHandle, afterSequence]
     return exposeMessageListTimestamps(
-      this.db
-        .prepare(
-          'SELECT * FROM messages WHERE thread_id = ? AND to_handle = ? ORDER BY sequence ASC'
-        )
-        .all(threadId, toHandle) as MessageRow[]
+      this.readRows<MessageRow>(
+        `SELECT * FROM messages
+         WHERE thread_id = ? AND to_handle = ?${sequenceFilter}
+           AND (${MESSAGE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY sequence ASC`,
+        params
+      )
     )
   }
 
@@ -519,14 +668,32 @@ export class OrchestrationDb {
     createdByTerminalHandle?: string
   }): TaskRow {
     const id = generateId('task')
-    const depsJson = JSON.stringify(task.deps ?? [])
-    const hasDeps = (task.deps ?? []).length > 0
+    const deps = task.deps ?? []
+    assertOrchestrationStringListFits('Task dependencies', deps)
+    assertOrchestrationWriteFits('Task', [
+      task.spec,
+      task.taskTitle,
+      task.displayName,
+      task.parentId,
+      task.createdByTerminalHandle,
+      ...deps
+    ])
+    const depsJson = JSON.stringify(deps)
+    const hasDeps = deps.length > 0
     const status: TaskStatus = hasDeps ? 'pending' : 'ready'
     const display = buildOrchestrationTaskDisplayMetadata({
       spec: task.spec,
       taskTitle: task.taskTitle,
       displayName: task.displayName
     })
+    assertOrchestrationWriteFits('Task', [
+      task.spec,
+      display.taskTitle,
+      display.displayName,
+      depsJson,
+      task.parentId,
+      task.createdByTerminalHandle
+    ])
     this.db
       .prepare(
         'INSERT INTO tasks (id, parent_id, created_by_terminal_handle, task_title, display_name, spec, status, deps) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
@@ -541,25 +708,35 @@ export class OrchestrationDb {
         status,
         depsJson
       )
-    return this.db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow
+    return this.getTask(id)!
   }
 
   getTask(id: string): TaskRow | undefined {
-    return this.db.prepare('SELECT * FROM tasks WHERE id = ?').get(id) as TaskRow | undefined
+    return this.db
+      .prepare(
+        `SELECT * FROM tasks
+         WHERE id = ? AND (${TASK_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}`
+      )
+      .get(id) as TaskRow | undefined
   }
 
   listTasks(filter?: { status?: TaskStatus; ready?: boolean }): TaskRow[] {
-    if (filter?.ready) {
-      return this.db
-        .prepare("SELECT * FROM tasks WHERE status = 'ready' ORDER BY created_at")
-        .all() as TaskRow[]
-    }
-    if (filter?.status) {
-      return this.db
-        .prepare('SELECT * FROM tasks WHERE status = ? ORDER BY created_at')
-        .all(filter.status) as TaskRow[]
-    }
-    return this.db.prepare('SELECT * FROM tasks ORDER BY created_at').all() as TaskRow[]
+    const status = filter?.ready ? 'ready' : filter?.status
+    const statusFilter = status ? 'status = ? AND ' : ''
+    return this.readRows<TaskRow>(
+      `SELECT * FROM tasks
+       WHERE ${statusFilter}(${TASK_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+       ORDER BY created_at, rowid`,
+      status ? [status] : []
+    )
+  }
+
+  countTasks(filter?: { status?: TaskStatus; ready?: boolean }): number {
+    const status = filter?.ready ? 'ready' : filter?.status
+    return this.countRows(
+      `SELECT COUNT(*) AS count FROM tasks${status ? ' WHERE status = ?' : ''}`,
+      status ? [status] : []
+    )
   }
 
   // Why: LEFT JOIN keeps non-dispatched tasks (NULL assignee); the MAX(rowid) subquery matches getDispatchContext's most-recent-active-dispatch semantics.
@@ -570,20 +747,25 @@ export class OrchestrationDb {
     const whereClauses: string[] = []
     const params: Database.BindValue[] = []
     if (filter?.ready) {
-      whereClauses.push("t.status = 'ready'")
+      whereClauses.push("tasks.status = 'ready'")
     } else if (filter?.status) {
-      whereClauses.push('t.status = ?')
+      whereClauses.push('tasks.status = ?')
       params.push(filter.status)
     }
+    whereClauses.push(
+      `(${TASK_ROW_BYTES_SQL}
+        + length(CAST(COALESCE(d.assignee_handle, '') AS BLOB))
+        + length(CAST(COALESCE(d.id, '') AS BLOB))) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}`
+    )
     const where = whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : ''
     const sql = `
       SELECT
-        t.*,
+        tasks.*,
         d.assignee_handle AS assignee_handle,
         d.id              AS dispatch_id
-      FROM tasks t
+      FROM tasks
       LEFT JOIN (
-        SELECT dc.*
+        SELECT dc.id, dc.task_id, dc.assignee_handle
         FROM dispatch_contexts dc
         INNER JOIN (
           SELECT task_id, MAX(rowid) AS max_rowid
@@ -591,17 +773,23 @@ export class OrchestrationDb {
           WHERE status IN ('pending', 'dispatched')
           GROUP BY task_id
         ) latest ON latest.task_id = dc.task_id AND latest.max_rowid = dc.rowid
-      ) d ON d.task_id = t.id
+      ) d ON d.task_id = tasks.id
       ${where}
-      ORDER BY t.created_at
+      ORDER BY tasks.created_at, tasks.rowid
     `
-    return this.db.prepare(sql).all(...params) as (TaskRow & {
+    return this.readRows<
+      TaskRow & {
+        assignee_handle: string | null
+        dispatch_id: string | null
+      }
+    >(sql, params) as (TaskRow & {
       assignee_handle: string | null
       dispatch_id: string | null
     })[]
   }
 
   updateTaskStatus(id: string, status: TaskStatus, result?: string): TaskRow | undefined {
+    assertOrchestrationWriteFits('Task result', [result])
     const completedAt =
       status === 'completed' || status === 'failed' ? new Date().toISOString() : null
     this.db
@@ -620,24 +808,79 @@ export class OrchestrationDb {
 
   // Why: runs in the status-update transaction, so a completed task never leaves its ready children unpromoted.
   private promoteReadyTasks(completedTaskId: string): void {
-    const candidates = this.db
-      .prepare("SELECT * FROM tasks WHERE status = 'pending'")
-      .all() as TaskRow[]
-
-    for (const task of candidates) {
-      const deps: string[] = JSON.parse(task.deps)
-      if (!deps.includes(completedTaskId)) {
-        continue
+    let afterRowId = 0
+    while (true) {
+      const candidates = this.readRows<{ rowid: number; id: string; deps: string }>(
+        `SELECT rowid, id, deps FROM tasks
+         WHERE status = 'pending' AND rowid > ?
+           AND (${retainedTextBytesSql(['tasks.id', 'tasks.deps'])})
+             <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+           AND CASE WHEN json_valid(deps)
+             THEN json_type(deps) = 'array'
+               AND json_array_length(deps) <= ${ORCHESTRATION_WRITE_MAX_ITEMS}
+             ELSE 0
+           END
+         ORDER BY rowid`,
+        [afterRowId],
+        INTERNAL_SCAN_BATCH_ROWS
+      )
+      if (candidates.length === 0) {
+        return
       }
+      afterRowId = candidates.at(-1)!.rowid
 
-      const allDepsCompleted = deps.every((depId) => {
-        const dep = this.getTask(depId)
-        return dep?.status === 'completed'
-      })
-      if (allDepsCompleted) {
-        this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(task.id)
+      for (const task of candidates) {
+        let parsedDeps: unknown
+        try {
+          parsedDeps = parseOrchestrationJson(task.deps)
+        } catch {
+          continue
+        }
+        if (
+          !Array.isArray(parsedDeps) ||
+          parsedDeps.length > ORCHESTRATION_WRITE_MAX_ITEMS ||
+          !parsedDeps.every((dependency) => typeof dependency === 'string')
+        ) {
+          continue
+        }
+        const deps = parsedDeps
+        if (!deps.includes(completedTaskId)) {
+          continue
+        }
+        const allDepsCompleted = deps.every((depId) => this.getTask(depId)?.status === 'completed')
+        if (allDepsCompleted) {
+          this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(task.id)
+        }
       }
     }
+  }
+
+  getTaskStatusCounts(): TaskStatusCounts {
+    const row = this.db
+      .prepare(
+        `SELECT
+           COUNT(*) AS total,
+           COALESCE(SUM(status = 'pending'), 0) AS pending,
+           COALESCE(SUM(status = 'ready'), 0) AS ready,
+           COALESCE(SUM(status = 'dispatched'), 0) AS dispatched,
+           COALESCE(SUM(status = 'completed'), 0) AS completed,
+           COALESCE(SUM(status = 'failed'), 0) AS failed,
+           COALESCE(SUM(status = 'blocked'), 0) AS blocked
+         FROM tasks`
+      )
+      .get() as TaskStatusCounts
+    return row
+  }
+
+  listTaskIdsByStatus(status: TaskStatus): string[] {
+    const rows = this.readRows<{ id: string }>(
+      `SELECT id FROM tasks
+       WHERE status = ?
+         AND length(CAST(id AS BLOB)) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+       ORDER BY created_at, rowid`,
+      [status]
+    )
+    return rows.map((row) => row.id)
   }
 
   // ── Dispatch Contexts ──
@@ -648,6 +891,7 @@ export class OrchestrationDb {
     // Why: pane key is the remint-stable identity behind the handle — lets worker_done ownership survive handle reissue.
     assigneePaneKey?: string
   ): DispatchContextRow {
+    assertOrchestrationWriteFits('Dispatch context', [taskId, assigneeHandle, assigneePaneKey])
     const task = this.getTask(taskId)
     if (!task) {
       throw new Error(`Task not found: ${taskId}`)
@@ -682,21 +926,28 @@ export class OrchestrationDb {
 
     this.db.prepare("UPDATE tasks SET status = 'dispatched' WHERE id = ?").run(taskId)
 
-    return this.db
-      .prepare('SELECT * FROM dispatch_contexts WHERE id = ?')
-      .get(id) as DispatchContextRow
+    return this.getDispatchContextById(id)!
   }
 
   getDispatchContext(taskId: string): DispatchContextRow | undefined {
     return this.db
-      .prepare('SELECT * FROM dispatch_contexts WHERE task_id = ? ORDER BY rowid DESC LIMIT 1')
+      .prepare(
+        `SELECT * FROM dispatch_contexts
+         WHERE task_id = ?
+           AND (${DISPATCH_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY rowid DESC LIMIT 1`
+      )
       .get(taskId) as DispatchContextRow | undefined
   }
 
   getDispatchContextById(dispatchId: string): DispatchContextRow | undefined {
-    return this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(dispatchId) as
-      | DispatchContextRow
-      | undefined
+    return this.db
+      .prepare(
+        `SELECT * FROM dispatch_contexts
+         WHERE id = ?
+           AND (${DISPATCH_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}`
+      )
+      .get(dispatchId) as DispatchContextRow | undefined
   }
 
   getActiveDispatchForTerminal(handle: string): DispatchContextRow | undefined {
@@ -723,7 +974,10 @@ export class OrchestrationDb {
   ): DispatchContextRow | undefined {
     const byHandle = this.db
       .prepare(
-        "SELECT * FROM dispatch_contexts WHERE assignee_handle = ? AND status IN ('pending', 'dispatched') LIMIT 1"
+        `SELECT * FROM dispatch_contexts
+         WHERE assignee_handle = ? AND status IN ('pending', 'dispatched')
+           AND (${DISPATCH_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         LIMIT 1`
       )
       .get(assigneeHandle) as DispatchContextRow | undefined
     if (byHandle) {
@@ -736,22 +990,33 @@ export class OrchestrationDb {
 
     const actives = this.db
       .prepare(
-        "SELECT * FROM dispatch_contexts WHERE assignee_pane_key IS NOT NULL AND status IN ('pending', 'dispatched')"
+        `SELECT id, assignee_pane_key FROM dispatch_contexts
+         WHERE assignee_pane_key IS NOT NULL AND status IN ('pending', 'dispatched')
+           AND (${retainedTextBytesSql([
+             'dispatch_contexts.id',
+             'dispatch_contexts.assignee_pane_key'
+           ])}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY rowid`
       )
-      .all() as DispatchContextRow[]
+      .iterate() as Iterable<{ id: string; assignee_pane_key: string }>
 
+    let matchingId: string | undefined
     for (const row of actives) {
-      if (row.assignee_pane_key && isEquivalentPaneKey(row.assignee_pane_key, assigneePaneKey)) {
-        return row
+      if (isEquivalentPaneKey(row.assignee_pane_key, assigneePaneKey)) {
+        matchingId = row.id
+        break
       }
     }
-    return undefined
+    return matchingId ? this.getDispatchContextById(matchingId) : undefined
   }
 
   getLatestDispatchForTerminal(handle: string): DispatchContextRow | undefined {
     return this.db
       .prepare(
-        'SELECT * FROM dispatch_contexts WHERE assignee_handle = ? ORDER BY rowid DESC LIMIT 1'
+        `SELECT * FROM dispatch_contexts
+         WHERE assignee_handle = ?
+           AND (${DISPATCH_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY rowid DESC LIMIT 1`
       )
       .get(handle) as DispatchContextRow | undefined
   }
@@ -767,9 +1032,9 @@ export class OrchestrationDb {
   completeActiveDispatchForTask(taskId: string): void {
     const active = this.db
       .prepare(
-        "SELECT * FROM dispatch_contexts WHERE task_id = ? AND status IN ('pending', 'dispatched') ORDER BY rowid DESC LIMIT 1"
+        "SELECT id FROM dispatch_contexts WHERE task_id = ? AND status IN ('pending', 'dispatched') ORDER BY rowid DESC LIMIT 1"
       )
-      .get(taskId) as DispatchContextRow | undefined
+      .get(taskId) as { id: string } | undefined
     if (active) {
       this.completeDispatch(active.id)
     }
@@ -778,14 +1043,15 @@ export class OrchestrationDb {
   failActiveDispatchForTask(taskId: string, error: string): DispatchContextRow | undefined {
     const active = this.db
       .prepare(
-        "SELECT * FROM dispatch_contexts WHERE task_id = ? AND status IN ('pending', 'dispatched') ORDER BY rowid DESC LIMIT 1"
+        "SELECT id FROM dispatch_contexts WHERE task_id = ? AND status IN ('pending', 'dispatched') ORDER BY rowid DESC LIMIT 1"
       )
-      .get(taskId) as DispatchContextRow | undefined
+      .get(taskId) as { id: string } | undefined
     return active ? this.failDispatch(active.id, error) : undefined
   }
 
   // Why: only bump status='dispatched' — a zombie heartbeat from a finished dispatch would mask a hung retry from the stale detector (§5.3.4).
   recordHeartbeat(dispatchId: string, at: string): void {
+    assertOrchestrationWriteFits('Dispatch heartbeat', [dispatchId, at])
     this.db
       .prepare(
         "UPDATE dispatch_contexts SET last_heartbeat_at = ? WHERE id = ? AND status = 'dispatched'"
@@ -795,21 +1061,37 @@ export class OrchestrationDb {
 
   // Why: dispatched_at grace skips workers still within their first heartbeat interval; julianday() vs raw-TEXT compare avoids misflagging space-format timestamps as stale (#8452).
   getStaleDispatches(thresholdIso: string): DispatchContextRow[] {
-    return this.db
+    return this.readRows<DispatchContextRow>(
+      `SELECT * FROM dispatch_contexts
+       WHERE status = 'dispatched'
+         AND dispatched_at IS NOT NULL
+         AND julianday(dispatched_at) < julianday(?)
+         AND (last_heartbeat_at IS NULL OR julianday(last_heartbeat_at) < julianday(?))
+         AND (${DISPATCH_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+       ORDER BY rowid`,
+      [thresholdIso, thresholdIso]
+    )
+  }
+
+  forEachStaleDispatch(thresholdIso: string, visit: (row: DispatchContextRow) => void): void {
+    const rows = this.db
       .prepare(
         `SELECT * FROM dispatch_contexts
          WHERE status = 'dispatched'
            AND dispatched_at IS NOT NULL
            AND julianday(dispatched_at) < julianday(?)
-           AND (last_heartbeat_at IS NULL OR julianday(last_heartbeat_at) < julianday(?))`
+           AND (last_heartbeat_at IS NULL OR julianday(last_heartbeat_at) < julianday(?))
+           AND (${DISPATCH_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY rowid`
       )
-      .all(thresholdIso, thresholdIso) as DispatchContextRow[]
+      .iterate(thresholdIso, thresholdIso) as Iterable<DispatchContextRow>
+    for (const row of rows) {
+      visit(row)
+    }
   }
 
   failDispatch(ctxId: string, error: string): DispatchContextRow | undefined {
-    const ctx = this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(ctxId) as
-      | DispatchContextRow
-      | undefined
+    const ctx = this.getDispatchContextById(ctxId)
     if (!ctx) {
       return undefined
     }
@@ -821,22 +1103,24 @@ export class OrchestrationDb {
       .prepare(
         'UPDATE dispatch_contexts SET status = ?, failure_count = ?, last_failure = ? WHERE id = ?'
       )
-      .run(newStatus, newFailureCount, error, ctxId)
+      .run(newStatus, newFailureCount, truncateOrchestrationDiagnostic(error), ctxId)
 
     // Why: back to 'ready' not 'pending' — 'pending' would strand it since promoteReadyTasks only runs when a dep completes.
     const taskStatus: TaskStatus = newStatus === 'circuit_broken' ? 'failed' : 'ready'
     this.db.prepare('UPDATE tasks SET status = ? WHERE id = ?').run(taskStatus, ctx.task_id)
 
-    return this.db.prepare('SELECT * FROM dispatch_contexts WHERE id = ?').get(ctxId) as
-      | DispatchContextRow
-      | undefined
+    return this.getDispatchContextById(ctxId)
   }
 
   // ── Decision Gates ──
 
   createGate(gate: { taskId: string; question: string; options?: string[] }): DecisionGateRow {
     const id = generateId('gate')
-    const optionsJson = JSON.stringify(gate.options ?? [])
+    const options = gate.options ?? []
+    assertOrchestrationStringListFits('Decision gate options', options)
+    assertOrchestrationWriteFits('Decision gate', [gate.taskId, gate.question, ...options])
+    const optionsJson = JSON.stringify(options)
+    assertOrchestrationWriteFits('Decision gate', [gate.taskId, gate.question, optionsJson])
     this.db
       .prepare('INSERT INTO decision_gates (id, task_id, question, options) VALUES (?, ?, ?, ?)')
       .run(id, gate.taskId, gate.question, optionsJson)
@@ -844,13 +1128,12 @@ export class OrchestrationDb {
     this.completeActiveDispatchForTask(gate.taskId)
     this.db.prepare("UPDATE tasks SET status = 'blocked' WHERE id = ?").run(gate.taskId)
 
-    return this.db.prepare('SELECT * FROM decision_gates WHERE id = ?').get(id) as DecisionGateRow
+    return this.getGate(id)!
   }
 
   resolveGate(gateId: string, resolution: string): DecisionGateRow | undefined {
-    const gate = this.db.prepare('SELECT * FROM decision_gates WHERE id = ?').get(gateId) as
-      | DecisionGateRow
-      | undefined
+    assertOrchestrationWriteFits('Decision gate resolution', [gateId, resolution])
+    const gate = this.getGate(gateId)
     if (!gate) {
       return undefined
     }
@@ -864,9 +1147,7 @@ export class OrchestrationDb {
     // Why: set to 'ready' (not the previous status) so the coordinator re-dispatches the worker with the resolution context.
     this.db.prepare("UPDATE tasks SET status = 'ready' WHERE id = ?").run(gate.task_id)
 
-    return this.db.prepare('SELECT * FROM decision_gates WHERE id = ?').get(gateId) as
-      | DecisionGateRow
-      | undefined
+    return this.getGate(gateId)
   }
 
   timeoutGate(gateId: string): DecisionGateRow | undefined {
@@ -875,38 +1156,81 @@ export class OrchestrationDb {
         "UPDATE decision_gates SET status = 'timeout', resolved_at = datetime('now') WHERE id = ?"
       )
       .run(gateId)
-    return this.db.prepare('SELECT * FROM decision_gates WHERE id = ?').get(gateId) as
-      | DecisionGateRow
-      | undefined
+    return this.getGate(gateId)
   }
 
   listGates(filter?: { taskId?: string; status?: GateStatus }): DecisionGateRow[] {
+    const clauses = [`(${GATE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}`]
+    const params: Database.BindValue[] = []
     if (filter?.taskId && filter?.status) {
-      return this.db
-        .prepare(
-          'SELECT * FROM decision_gates WHERE task_id = ? AND status = ? ORDER BY created_at'
-        )
-        .all(filter.taskId, filter.status) as DecisionGateRow[]
+      clauses.push('task_id = ?', 'status = ?')
+      params.push(filter.taskId, filter.status)
+    } else if (filter?.taskId) {
+      clauses.push('task_id = ?')
+      params.push(filter.taskId)
+    } else if (filter?.status) {
+      clauses.push('status = ?')
+      params.push(filter.status)
     }
+    return this.readRows<DecisionGateRow>(
+      `SELECT * FROM decision_gates
+       WHERE ${clauses.join(' AND ')}
+       ORDER BY created_at, rowid`,
+      params
+    )
+  }
+
+  countGates(filter?: { taskId?: string; status?: GateStatus }): number {
+    const clauses: string[] = []
+    const params: Database.BindValue[] = []
     if (filter?.taskId) {
-      return this.db
-        .prepare('SELECT * FROM decision_gates WHERE task_id = ? ORDER BY created_at')
-        .all(filter.taskId) as DecisionGateRow[]
+      clauses.push('task_id = ?')
+      params.push(filter.taskId)
     }
     if (filter?.status) {
-      return this.db
-        .prepare('SELECT * FROM decision_gates WHERE status = ? ORDER BY created_at')
-        .all(filter.status) as DecisionGateRow[]
+      clauses.push('status = ?')
+      params.push(filter.status)
     }
-    return this.db
-      .prepare('SELECT * FROM decision_gates ORDER BY created_at')
-      .all() as DecisionGateRow[]
+    return this.countRows(
+      `SELECT COUNT(*) AS count FROM decision_gates${
+        clauses.length > 0 ? ` WHERE ${clauses.join(' AND ')}` : ''
+      }`,
+      params
+    )
   }
 
   getGate(id: string): DecisionGateRow | undefined {
-    return this.db.prepare('SELECT * FROM decision_gates WHERE id = ?').get(id) as
-      | DecisionGateRow
-      | undefined
+    return this.db
+      .prepare(
+        `SELECT * FROM decision_gates
+         WHERE id = ? AND (${GATE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}`
+      )
+      .get(id) as DecisionGateRow | undefined
+  }
+
+  getLatestGate(filter: { taskId: string; status: GateStatus }): DecisionGateRow | undefined {
+    return this.db
+      .prepare(
+        `SELECT * FROM decision_gates
+         WHERE task_id = ? AND status = ?
+           AND (${GATE_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY created_at DESC, rowid DESC LIMIT 1`
+      )
+      .get(filter.taskId, filter.status) as DecisionGateRow | undefined
+  }
+
+  restorePendingGateTaskStatuses(): void {
+    this.db
+      .prepare(
+        `UPDATE tasks SET status = 'blocked'
+         WHERE status <> 'blocked'
+           AND EXISTS (
+             SELECT 1 FROM decision_gates
+             WHERE decision_gates.task_id = tasks.id
+               AND decision_gates.status = 'pending'
+           )`
+      )
+      .run()
   }
 
   // ── Coordinator Runs ──
@@ -916,19 +1240,24 @@ export class OrchestrationDb {
     coordinatorHandle: string
     pollIntervalMs?: number
   }): CoordinatorRun {
+    assertOrchestrationWriteFits('Coordinator run', [run.spec, run.coordinatorHandle])
     const id = generateId('run')
     this.db
       .prepare(
         "INSERT INTO coordinator_runs (id, spec, status, coordinator_handle, poll_interval_ms) VALUES (?, ?, 'running', ?, ?)"
       )
       .run(id, run.spec, run.coordinatorHandle, run.pollIntervalMs ?? 2000)
-    return this.db.prepare('SELECT * FROM coordinator_runs WHERE id = ?').get(id) as CoordinatorRun
+    return this.getCoordinatorRun(id)!
   }
 
   getCoordinatorRun(id: string): CoordinatorRun | undefined {
-    return this.db.prepare('SELECT * FROM coordinator_runs WHERE id = ?').get(id) as
-      | CoordinatorRun
-      | undefined
+    return this.db
+      .prepare(
+        `SELECT * FROM coordinator_runs
+         WHERE id = ?
+           AND (${COORDINATOR_RUN_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}`
+      )
+      .get(id) as CoordinatorRun | undefined
   }
 
   updateCoordinatorRun(id: string, status: CoordinatorStatus): CoordinatorRun | undefined {
@@ -945,7 +1274,10 @@ export class OrchestrationDb {
   getActiveCoordinatorRun(): CoordinatorRun | undefined {
     return this.db
       .prepare(
-        "SELECT * FROM coordinator_runs WHERE status = 'running' ORDER BY created_at DESC LIMIT 1"
+        `SELECT * FROM coordinator_runs
+         WHERE status = 'running'
+           AND (${COORDINATOR_RUN_ROW_BYTES_SQL}) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+         ORDER BY created_at DESC, rowid DESC LIMIT 1`
       )
       .get() as CoordinatorRun | undefined
   }
@@ -953,22 +1285,31 @@ export class OrchestrationDb {
   // ── Queries for Coordinator ──
 
   getIdleTerminals(excludeHandles: string[] = []): string[] {
-    const active = this.db
+    const rows = this.db
       .prepare(
-        "SELECT DISTINCT assignee_handle FROM dispatch_contexts WHERE status IN ('pending', 'dispatched')"
+        `WITH handles(handle) AS (
+           SELECT to_handle FROM messages
+           UNION
+           SELECT from_handle FROM messages
+         )
+         SELECT handle FROM handles
+         WHERE length(CAST(handle AS BLOB)) <= ${ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES}
+           AND NOT EXISTS (
+             SELECT 1 FROM dispatch_contexts
+             WHERE dispatch_contexts.assignee_handle = handles.handle
+               AND dispatch_contexts.status IN ('pending', 'dispatched')
+           )
+         ORDER BY handle`
       )
-      .all() as { assignee_handle: string }[]
-    const busyHandles = new Set(active.map((r) => r.assignee_handle))
-    for (const h of excludeHandles) {
-      busyHandles.add(h)
-    }
-    // Return handles from message history that aren't busy
-    const allHandles = this.db
-      .prepare(
-        'SELECT DISTINCT to_handle FROM messages UNION SELECT DISTINCT from_handle FROM messages'
-      )
-      .all() as { to_handle: string }[]
-    return [...new Set(allHandles.map((r) => r.to_handle))].filter((h) => !busyHandles.has(h))
+      .iterate() as Iterable<{ handle: string }>
+    const filtered = (function* (): Iterable<{ handle: string }> {
+      for (const row of rows) {
+        if (!excludeHandles.includes(row.handle)) {
+          yield row
+        }
+      }
+    })()
+    return retainOrchestrationQueryRows(filtered).map((row) => row.handle)
   }
 
   // ── Lifecycle ──

--- a/src/main/runtime/orchestration/lifecycle-reconciliation.ts
+++ b/src/main/runtime/orchestration/lifecycle-reconciliation.ts
@@ -1,6 +1,7 @@
 import type { OrchestrationDb } from './db'
 import type { MessageRow } from './types'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
+import { parseOrchestrationJson } from './query-retention'
 
 // Why: the tab half can change on pane break-out, while opaque legacy keys
 // have no safe equivalence beyond exact equality.
@@ -53,8 +54,10 @@ function parseObjectPayload(msg: MessageRow, onInvalidJson: () => void): Record<
   }
 
   try {
-    const parsed: unknown = JSON.parse(msg.payload)
-    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : {}
+    const parsed = parseOrchestrationJson(msg.payload)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {}
   } catch {
     onInvalidJson()
     return {}

--- a/src/main/runtime/orchestration/query-retention.ts
+++ b/src/main/runtime/orchestration/query-retention.ts
@@ -1,0 +1,124 @@
+import {
+  assertJsonTextStructureWithinLimits,
+  type JsonTextStructureLimits
+} from '../../../shared/json-text-structure-limit'
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
+
+export const ORCHESTRATION_QUERY_MAX_ROWS = 256
+export const ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES = 2 * 1024 * 1024
+export const ORCHESTRATION_QUERY_MAX_RETAINED_UTF8_BYTES = 8 * 1024 * 1024
+export const ORCHESTRATION_WRITE_MAX_UTF8_BYTES = 512 * 1024
+export const ORCHESTRATION_WRITE_MAX_ITEMS = 4096
+export const ORCHESTRATION_WAIT_TYPE_FILTER_MAX_UTF8_BYTES = 1024
+export const ORCHESTRATION_JSON_STRUCTURE_LIMITS: JsonTextStructureLimits = {
+  structuralTokens: 64 * 1024,
+  nestingDepth: 64
+}
+
+export function parseOrchestrationJson(content: string): unknown {
+  assertJsonTextStructureWithinLimits(content, ORCHESTRATION_JSON_STRUCTURE_LIMITS)
+  return JSON.parse(content) as unknown
+}
+
+export function clampOrchestrationQueryLimit(
+  requested: number | undefined,
+  fallback = ORCHESTRATION_QUERY_MAX_ROWS
+): number {
+  if (requested === undefined || !Number.isFinite(requested)) {
+    return Math.min(fallback, ORCHESTRATION_QUERY_MAX_ROWS)
+  }
+  return Math.min(ORCHESTRATION_QUERY_MAX_ROWS, Math.max(0, Math.floor(requested)))
+}
+
+export function orchestrationRowRetainedUtf8Bytes(row: object): number {
+  let bytes = 0
+  for (const value of Object.values(row)) {
+    if (typeof value === 'string') {
+      bytes += Buffer.byteLength(value, 'utf8')
+    }
+  }
+  return bytes
+}
+
+export function retainOrchestrationQueryRows<T extends object>(
+  rows: Iterable<T>,
+  requestedLimit?: number
+): T[] {
+  const limit = clampOrchestrationQueryLimit(requestedLimit)
+  if (limit === 0) {
+    return []
+  }
+  const retained: T[] = []
+  let retainedBytes = 0
+
+  for (const row of rows) {
+    const rowBytes = orchestrationRowRetainedUtf8Bytes(row)
+    if (rowBytes > ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES) {
+      continue
+    }
+    if (retainedBytes + rowBytes > ORCHESTRATION_QUERY_MAX_RETAINED_UTF8_BYTES) {
+      break
+    }
+    retained.push(row)
+    retainedBytes += rowBytes
+    if (retained.length >= limit) {
+      break
+    }
+  }
+  return retained
+}
+
+export function assertOrchestrationWriteFits(label: string, values: unknown[]): void {
+  let retainedBytes = 0
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      continue
+    }
+    retainedBytes += Buffer.byteLength(value, 'utf8')
+    if (retainedBytes > ORCHESTRATION_WRITE_MAX_UTF8_BYTES) {
+      throw new Error(
+        `${label} exceeds the ${ORCHESTRATION_WRITE_MAX_UTF8_BYTES}-byte orchestration limit`
+      )
+    }
+  }
+}
+
+export function assertOrchestrationWaitTypeFilterFits(value: string | undefined): void {
+  if (
+    value &&
+    measureUtf8ByteLength(value, {
+      stopAfterBytes: ORCHESTRATION_WAIT_TYPE_FILTER_MAX_UTF8_BYTES
+    }).exceededLimit
+  ) {
+    throw new Error(
+      `Message type filter exceeds the ${ORCHESTRATION_WAIT_TYPE_FILTER_MAX_UTF8_BYTES}-byte orchestration wait limit`
+    )
+  }
+}
+
+export function assertOrchestrationStringListFits(label: string, values: string[]): void {
+  if (values.length > ORCHESTRATION_WRITE_MAX_ITEMS) {
+    throw new Error(
+      `${label} exceeds the ${ORCHESTRATION_WRITE_MAX_ITEMS}-item orchestration limit`
+    )
+  }
+  assertOrchestrationWriteFits(label, values)
+}
+
+export function truncateOrchestrationDiagnostic(value: string): string {
+  if (Buffer.byteLength(value, 'utf8') <= ORCHESTRATION_WRITE_MAX_UTF8_BYTES) {
+    return value
+  }
+
+  let bytes = 0
+  let end = 0
+  for (const codePoint of value) {
+    const codePointBytes = Buffer.byteLength(codePoint, 'utf8')
+    if (bytes + codePointBytes > ORCHESTRATION_WRITE_MAX_UTF8_BYTES) {
+      break
+    }
+    bytes += codePointBytes
+    end += codePoint.length
+  }
+  return value.slice(0, end)
+}

--- a/src/main/runtime/recent-pty-output-buffer.test.ts
+++ b/src/main/runtime/recent-pty-output-buffer.test.ts
@@ -93,6 +93,34 @@ describe('RecentPtyOutputBuffer', () => {
     expectEquivalent(chunks)
   })
 
+  it('retains 100,000 tiny writes in compact payload storage and typed boundary metadata', () => {
+    const buffer = new RecentPtyOutputBuffer()
+    let reference: string | undefined
+    for (let index = 0; index < 100_000; index += 1) {
+      const chunk = String.fromCharCode(97 + (index % 26))
+      buffer.append(chunk)
+      reference = referenceAppend(reference, chunk)
+    }
+
+    const internals = buffer as unknown as {
+      chunks: string[]
+      originalChunkLengths: { length: number; capacity: number }
+    }
+    expect(internals.chunks.length).toBeLessThanOrEqual(1024)
+    expect(internals.originalChunkLengths.length).toBe(RECENT_PTY_OUTPUT_LIMIT)
+    expect(internals.originalChunkLengths.capacity).toBe(RECENT_PTY_OUTPUT_LIMIT)
+    expect(buffer.read()).toBe(reference)
+
+    let streamedLength = 0
+    let streamedChunks = 0
+    buffer.forEachRetainedChunk((chunk) => {
+      streamedLength += chunk.length
+      streamedChunks += 1
+    })
+    expect(streamedLength).toBe(RECENT_PTY_OUTPUT_LIMIT)
+    expect(streamedChunks).toBe(RECENT_PTY_OUTPUT_LIMIT)
+  })
+
   it('matches the old UTF-16 slice behavior for multi-byte content at the boundary', () => {
     // JS string .slice counts UTF-16 code units, so trimming can split a
     // surrogate pair; the buffer must reproduce that split exactly.

--- a/src/main/runtime/recent-pty-output-buffer.ts
+++ b/src/main/runtime/recent-pty-output-buffer.ts
@@ -1,31 +1,69 @@
 export const RECENT_PTY_OUTPUT_LIMIT = 64 * 1024
 
-// Compact the backing array once this many fully-dropped head slots accumulate,
-// so the array itself stays bounded under long chunk floods.
-const DROPPED_HEAD_COMPACT_THRESHOLD = 1024
+const RETAINED_CONTENT_CHUNK_LIMIT = 1024
+const DROPPED_CONTENT_CHUNK_LIMIT = 1024
+const INITIAL_BOUNDARY_CAPACITY = 16
 
-/**
- * Bounded deque of raw PTY output chunks retaining exactly the last
- * RECENT_PTY_OUTPUT_LIMIT UTF-16 code units.
- *
- * Why: eagerly rebuilding a rolling 64KB string per PTY chunk flattened a
- * ~128KB rope on every write; keep chunks and defer the join to rare readers.
- */
+class RetainedChunkLengthQueue {
+  private values = new Uint32Array(INITIAL_BOUNDARY_CAPACITY)
+  private head = 0
+  private count = 0
+
+  get length(): number {
+    return this.count
+  }
+
+  get capacity(): number {
+    return this.values.length
+  }
+
+  push(value: number): void {
+    if (this.count === this.values.length) {
+      const grown = new Uint32Array(this.values.length * 2)
+      for (let index = 0; index < this.count; index += 1) {
+        grown[index] = this.at(index)
+      }
+      this.values = grown
+      this.head = 0
+    }
+    this.values[(this.head + this.count) % this.values.length] = value
+    this.count += 1
+  }
+
+  shift(): number {
+    if (this.count === 0) {
+      return 0
+    }
+    const value = this.values[this.head]!
+    this.head = (this.head + 1) % this.values.length
+    this.count -= 1
+    if (this.count === 0) {
+      this.head = 0
+    }
+    return value
+  }
+
+  at(index: number): number {
+    return this.values[(this.head + index) % this.values.length]!
+  }
+
+  reset(): void {
+    this.values = new Uint32Array(INITIAL_BOUNDARY_CAPACITY)
+    this.head = 0
+    this.count = 0
+  }
+}
+
+/** Bounded raw PTY tail that temporarily preserves source chunk boundaries for path backfill. */
 export class RecentPtyOutputBuffer {
   private chunks: string[] = []
-  private headIndex = 0
-  // Code units already trimmed off the front of the head chunk. Deferred so
-  // repeated small trims never allocate a substring per append, and so the
-  // head chunk's original text stays available for candidate backfill.
-  private headOffset = 0
+  private contentHeadIndex = 0
+  private contentHeadOffset = 0
   private totalLen = 0
-  // True when the stored head chunk is not the full original PTY chunk (a
-  // single over-limit append is stored pre-sliced), so backfill replay knows
-  // the original line context of its leading text is gone.
+  private headOffset = 0
   private headChunkIsPartial = false
-  // Original chunk boundaries are owed only to the one-time path-candidate
-  // backfill; compact() ends that obligation and lets read() collapse.
   private preserveChunkBoundaries: boolean
+  private readonly originalChunkLengths = new RetainedChunkLengthQueue()
 
   constructor(options?: { preserveChunkBoundaries?: boolean }) {
     this.preserveChunkBoundaries = options?.preserveChunkBoundaries ?? true
@@ -36,88 +74,145 @@ export class RecentPtyOutputBuffer {
       return
     }
     if (data.length >= RECENT_PTY_OUTPUT_LIMIT) {
-      this.chunks = [data.slice(-RECENT_PTY_OUTPUT_LIMIT)]
-      this.headIndex = 0
-      this.headOffset = 0
+      this.replaceContent(data.slice(-RECENT_PTY_OUTPUT_LIMIT))
       this.totalLen = RECENT_PTY_OUTPUT_LIMIT
+      this.headOffset = 0
       this.headChunkIsPartial = data.length > RECENT_PTY_OUTPUT_LIMIT
+      this.originalChunkLengths.reset()
+      if (this.preserveChunkBoundaries) {
+        this.originalChunkLengths.push(RECENT_PTY_OUTPUT_LIMIT)
+      }
       return
     }
-    this.chunks.push(data)
+
+    this.appendContent(data)
     this.totalLen += data.length
+    if (this.preserveChunkBoundaries) {
+      this.trimPreservingBoundaries()
+      this.originalChunkLengths.push(data.length)
+    } else {
+      this.trimContentToWindow()
+    }
+  }
+
+  read(): string {
+    const stored = this.storedContent()
+    const value = this.headOffset > 0 ? stored.slice(this.headOffset) : stored
+    if (!this.preserveChunkBoundaries) {
+      this.replaceContent(value)
+    }
+    return value
+  }
+
+  /** Original PTY chunks retained for the one-time path-candidate backfill. */
+  retainedChunks(): { chunks: string[]; headChunkIsPartial: boolean } {
+    const chunks: string[] = []
+    const state = this.forEachRetainedChunk((chunk) => chunks.push(chunk))
+    return { chunks, headChunkIsPartial: state.headChunkIsPartial }
+  }
+
+  /** Streams boundaries so activation does not allocate one string object per tiny write. */
+  forEachRetainedChunk(
+    visit: (chunk: string, index: number, headChunkIsPartial: boolean) => void
+  ): {
+    headChunkIsPartial: boolean
+  } {
+    if (!this.preserveChunkBoundaries) {
+      const value = this.read()
+      if (value) {
+        visit(value, 0, false)
+      }
+      return { headChunkIsPartial: false }
+    }
+    const stored = this.storedContent()
+    let offset = 0
+    for (let index = 0; index < this.originalChunkLengths.length; index += 1) {
+      const length = this.originalChunkLengths.at(index)
+      visit(stored.slice(offset, offset + length), index, this.headChunkIsPartial)
+      offset += length
+    }
+    return { headChunkIsPartial: this.headChunkIsPartial }
+  }
+
+  /** Ends the boundary obligation and returns to compact steady-state storage. */
+  compact(): void {
+    const value = this.read()
+    this.preserveChunkBoundaries = false
+    this.replaceContent(value)
+    this.headOffset = 0
+    this.headChunkIsPartial = false
+    this.originalChunkLengths.reset()
+  }
+
+  private appendContent(data: string): void {
+    this.chunks.push(data)
+    if (this.chunks.length - this.contentHeadIndex > RETAINED_CONTENT_CHUNK_LIMIT) {
+      this.replaceContent(this.storedContent())
+    }
+  }
+
+  private trimPreservingBoundaries(): void {
     while (this.totalLen > RECENT_PTY_OUTPUT_LIMIT) {
-      const headRemaining = this.chunks[this.headIndex].length - this.headOffset
+      const originalHeadLength = this.originalChunkLengths.at(0)
+      const headRemaining = originalHeadLength - this.headOffset
       const excess = this.totalLen - RECENT_PTY_OUTPUT_LIMIT
       if (headRemaining <= excess) {
-        // Release the dropped chunk's reference; the slot is reclaimed on compaction.
-        this.chunks[this.headIndex] = ''
-        this.headIndex += 1
+        this.totalLen -= headRemaining
         this.headOffset = 0
         this.headChunkIsPartial = false
-        this.totalLen -= headRemaining
+        this.originalChunkLengths.shift()
+        this.dropContentPrefix(originalHeadLength)
       } else {
         this.headOffset += excess
         this.totalLen -= excess
       }
     }
-    if (this.headIndex >= DROPPED_HEAD_COMPACT_THRESHOLD) {
-      this.chunks = this.chunks.slice(this.headIndex)
-      this.headIndex = 0
-    }
   }
 
-  read(): string {
-    if (this.preserveChunkBoundaries) {
-      // Join without mutating: boundaries and the original head chunk are
-      // still owed to retainedChunks(); reads are rare before compact().
-      if (this.chunks.length - this.headIndex > 1) {
-        const retained = this.chunks.slice(this.headIndex)
-        if (this.headOffset > 0) {
-          retained[0] = retained[0].slice(this.headOffset)
-        }
-        return retained.join('')
+  private trimContentToWindow(): void {
+    const excess = this.totalLen - RECENT_PTY_OUTPUT_LIMIT
+    if (excess <= 0) {
+      return
+    }
+    this.dropContentPrefix(excess)
+    this.totalLen -= excess
+  }
+
+  private dropContentPrefix(length: number): void {
+    let remaining = length
+    while (remaining > 0) {
+      const chunk = this.chunks[this.contentHeadIndex] ?? ''
+      const available = chunk.length - this.contentHeadOffset
+      if (available <= remaining) {
+        this.chunks[this.contentHeadIndex] = ''
+        this.contentHeadIndex += 1
+        this.contentHeadOffset = 0
+        remaining -= available
+      } else {
+        this.contentHeadOffset += remaining
+        remaining = 0
       }
-      const head = this.chunks[this.headIndex] ?? ''
-      return this.headOffset > 0 ? head.slice(this.headOffset) : head
     }
-    if (this.chunks.length - this.headIndex > 1) {
-      // Collapse to the joined tail so repeated reads stay O(1).
-      const retained = this.chunks.slice(this.headIndex)
-      if (this.headOffset > 0) {
-        retained[0] = retained[0].slice(this.headOffset)
-        this.headOffset = 0
-      }
-      this.chunks = [retained.join('')]
-      this.headIndex = 0
-    } else if (this.headOffset > 0) {
-      // Single retained chunk: apply the deferred head trim once, here.
-      this.chunks[this.headIndex] = this.chunks[this.headIndex].slice(this.headOffset)
-      this.headOffset = 0
-    }
-    return this.chunks[this.headIndex] ?? ''
-  }
-
-  /**
-   * Retained chunks with original PTY boundaries. The head chunk is its full
-   * original text (any window-trimmed prefix included) unless
-   * headChunkIsPartial. Why: path-candidate backfill must replay the eager
-   * per-chunk extraction exactly — trimming or joining chunks changes the
-   * candidate set. Only meaningful before compact().
-   */
-  retainedChunks(): { chunks: string[]; headChunkIsPartial: boolean } {
-    return {
-      chunks: this.chunks.slice(this.headIndex),
-      headChunkIsPartial: this.headChunkIsPartial
+    if (this.contentHeadIndex >= DROPPED_CONTENT_CHUNK_LIMIT) {
+      this.chunks = this.chunks.slice(this.contentHeadIndex)
+      this.contentHeadIndex = 0
     }
   }
 
-  /**
-   * Ends the chunk-boundary obligation after the one-time backfill and
-   * collapses immediately, so the append/read hot path returns to the
-   * compact single-chunk steady state.
-   */
-  compact(): void {
-    this.preserveChunkBoundaries = false
-    this.read()
+  private storedContent(): string {
+    const retained = this.chunks.slice(this.contentHeadIndex)
+    if (retained.length === 0) {
+      return ''
+    }
+    if (this.contentHeadOffset > 0) {
+      retained[0] = retained[0]!.slice(this.contentHeadOffset)
+    }
+    return retained.length === 1 ? retained[0]! : retained.join('')
+  }
+
+  private replaceContent(value: string): void {
+    this.chunks = value ? [value] : []
+    this.contentHeadIndex = 0
+    this.contentHeadOffset = 0
   }
 }

--- a/src/main/runtime/relay/relay-control-client.test.ts
+++ b/src/main/runtime/relay/relay-control-client.test.ts
@@ -2,8 +2,13 @@ import { createHash, createHmac, randomBytes } from 'node:crypto'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
 import { WebSocketServer, type WebSocket } from 'ws'
+import { JsonStringifyByteLimitError } from '../../../shared/node-bounded-json-stringify'
 import type { E2EEKeypair } from '../e2ee-keypair'
-import { RelayControlClient } from './relay-control-client'
+import {
+  RELAY_CONTROL_MAX_MESSAGE_BYTES,
+  RelayControlClient,
+  serializeRelayControlMessage
+} from './relay-control-client'
 
 const encoder = new TextEncoder()
 const HOST_PROOF_DOMAIN = 'orca-relay-host-proof/v1'
@@ -79,6 +84,21 @@ function nextJson(ws: WebSocket): Promise<Record<string, unknown>> {
 describe('RelayControlClient', () => {
   const servers: WebSocketServer[] = []
   const clients: RelayControlClient[] = []
+
+  it('preserves ordinary control message serialization byte-for-byte', () => {
+    const payload = { type: 'auth-refresh', relayJwt: 'token-😀' }
+
+    expect(serializeRelayControlMessage(payload)).toBe(JSON.stringify(payload))
+  })
+
+  it('rejects an oversized control message during bounded serialization', () => {
+    expect(() =>
+      serializeRelayControlMessage({
+        type: 'auth-refresh',
+        relayJwt: 'x'.repeat(RELAY_CONTROL_MAX_MESSAGE_BYTES)
+      })
+    ).toThrow(JsonStringifyByteLimitError)
+  })
 
   afterEach(async () => {
     for (const client of clients.splice(0)) {

--- a/src/main/runtime/relay/relay-control-client.ts
+++ b/src/main/runtime/relay/relay-control-client.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import WebSocket, { type RawData } from 'ws'
 import { MOBILE_RELAY_CLOSE_CODE } from '../../../shared/mobile-relay-close-codes'
+import { stringifyJsonWithinByteLimit } from '../../../shared/node-bounded-json-stringify'
 import type { E2EEKeypair } from '../e2ee-keypair'
 import {
   RelayConnectionOpenMessageSchema,
@@ -19,6 +20,7 @@ import type { DeviceCredentialInstallAuthorization } from './relay-control-reque
 import { answerRelayHostChallenge } from './relay-host-proof'
 
 type RelayControlState = 'idle' | 'opening' | 'proving' | 'active' | 'draining' | 'closed'
+export const RELAY_CONTROL_MAX_MESSAGE_BYTES = 64 * 1024
 
 type RelayControlClientOptions = {
   cellUrl: string
@@ -74,7 +76,7 @@ export class RelayControlClient {
         new WebSocket(url, {
           headers: { authorization: `Bearer ${token}` },
           perMessageDeflate: false,
-          maxPayload: 64 * 1024
+          maxPayload: RELAY_CONTROL_MAX_MESSAGE_BYTES
         }))
   }
 
@@ -165,7 +167,7 @@ export class RelayControlClient {
     }
     this.state = 'proving'
     this.socket.send(
-      JSON.stringify({
+      serializeRelayControlMessage({
         type: 'host-hello',
         v: 1,
         relayHostId: this.options.relayHostId,
@@ -197,7 +199,7 @@ export class RelayControlClient {
       return
     }
     if (RelayPingMessageSchema.safeParse(message).success) {
-      this.socket?.send(JSON.stringify({ type: 'pong', t: message.t }))
+      this.socket?.send(serializeRelayControlMessage({ type: 'pong', t: message.t }))
       return
     }
     const connection = RelayConnectionOpenMessageSchema.safeParse(message)
@@ -235,7 +237,7 @@ export class RelayControlClient {
         return
       }
       this.socket?.send(
-        JSON.stringify({
+        serializeRelayControlMessage({
           type: 'host-challenge-ack',
           challengeId: challenge.data.challengeId,
           proofB64
@@ -257,7 +259,7 @@ export class RelayControlClient {
     if (!this.socket || (this.state !== 'active' && this.state !== 'draining')) {
       throw new Error('relay_control_not_active')
     }
-    this.socket.send(JSON.stringify(payload))
+    this.socket.send(serializeRelayControlMessage(payload))
   }
 
   private failProtocol(reason: string): void {
@@ -281,4 +283,8 @@ export class RelayControlClient {
     this.connectResolve = null
     this.connectReject = null
   }
+}
+
+export function serializeRelayControlMessage(payload: unknown): string {
+  return stringifyJsonWithinByteLimit(payload, RELAY_CONTROL_MAX_MESSAGE_BYTES).serialized
 }

--- a/src/main/runtime/relay/relay-control-requests.test.ts
+++ b/src/main/runtime/relay/relay-control-requests.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  RELAY_CONTROL_MAX_PENDING_REQUESTS,
+  RELAY_CONTROL_REQUEST_ID_MAX_UTF8_BYTES,
+  RelayControlRequests
+} from './relay-control-requests'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('RelayControlRequests admission', () => {
+  it('fails closed at the pending request cap', async () => {
+    vi.useFakeTimers()
+    const requests = new RelayControlRequests()
+    const send = vi.fn()
+    const admitted = Array.from({ length: RELAY_CONTROL_MAX_PENDING_REQUESTS }, (_, index) =>
+      requests.createInvite(`request-${index}`, 'device-a', send)
+    )
+    const settlements = Promise.allSettled(admitted)
+
+    await expect(requests.createInvite('request-overflow', 'device-a', send)).rejects.toThrow(
+      'relay_control_request_limit'
+    )
+    expect(requests.size).toBe(RELAY_CONTROL_MAX_PENDING_REQUESTS)
+    expect(send).toHaveBeenCalledTimes(RELAY_CONTROL_MAX_PENDING_REQUESTS)
+
+    requests.rejectAll(new Error('closed'))
+    await settlements
+    expect(requests.size).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('rejects an oversized request id before sending or retaining it', async () => {
+    const requests = new RelayControlRequests()
+    const send = vi.fn()
+
+    await expect(
+      requests.createInvite('🙂'.repeat(RELAY_CONTROL_REQUEST_ID_MAX_UTF8_BYTES), 'device-a', send)
+    ).rejects.toThrow('relay_control_request_limit')
+
+    expect(requests.size).toBe(0)
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('releases admission when send throws', async () => {
+    vi.useFakeTimers()
+    const requests = new RelayControlRequests()
+
+    await expect(
+      requests.createInvite('request-a', 'device-a', () => {
+        throw new Error('send failed')
+      })
+    ).rejects.toThrow('send failed')
+
+    expect(requests.size).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('releases admission when a request times out', async () => {
+    vi.useFakeTimers()
+    const requests = new RelayControlRequests()
+    const result = requests.createInvite('request-a', 'device-a', () => {})
+    const rejection = expect(result).rejects.toThrow('relay_control_request_timeout')
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    await rejection
+    expect(requests.size).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/src/main/runtime/relay/relay-control-requests.ts
+++ b/src/main/runtime/relay/relay-control-requests.ts
@@ -16,7 +16,13 @@ type PendingRequest = {
   resolve: (value: unknown) => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
+  reqIdBytes: number
 }
+
+export const RELAY_CONTROL_MAX_PENDING_REQUESTS = 256
+export const RELAY_CONTROL_REQUEST_ID_MAX_UTF8_BYTES = 512
+export const RELAY_CONTROL_RETAINED_REQUEST_ID_MAX_UTF8_BYTES =
+  RELAY_CONTROL_MAX_PENDING_REQUESTS * RELAY_CONTROL_REQUEST_ID_MAX_UTF8_BYTES
 
 export type DeviceCredentialInstallAuthorization =
   | { mode: 'relay-basis'; basisConnId: string }
@@ -24,6 +30,7 @@ export type DeviceCredentialInstallAuthorization =
 
 export class RelayControlRequests {
   private readonly pending = new Map<string, PendingRequest>()
+  private retainedRequestIdBytes = 0
 
   get size(): number {
     return this.pending.size
@@ -160,12 +167,22 @@ export class RelayControlRequests {
     if (this.pending.has(reqId)) {
       return Promise.reject(new Error('duplicate_relay_request_id'))
     }
+    const reqIdBytes = Buffer.byteLength(reqId, 'utf8')
+    if (
+      reqId.length === 0 ||
+      reqIdBytes > RELAY_CONTROL_REQUEST_ID_MAX_UTF8_BYTES ||
+      this.pending.size >= RELAY_CONTROL_MAX_PENDING_REQUESTS ||
+      reqIdBytes > RELAY_CONTROL_RETAINED_REQUEST_ID_MAX_UTF8_BYTES - this.retainedRequestIdBytes
+    ) {
+      return Promise.reject(new Error('relay_control_request_limit'))
+    }
     return new Promise((resolve, reject) => {
       const timer = setTimeout(() => {
-        this.pending.delete(reqId)
+        this.finish(reqId)
         reject(new Error('relay_control_request_timeout'))
       }, 10_000)
-      this.pending.set(reqId, { kind, resolve, reject, timer })
+      this.pending.set(reqId, { kind, resolve, reject, timer, reqIdBytes })
+      this.retainedRequestIdBytes += reqIdBytes
       try {
         send(payload)
       } catch (error) {
@@ -180,6 +197,7 @@ export class RelayControlRequests {
     if (pending) {
       clearTimeout(pending.timer)
       this.pending.delete(reqId)
+      this.retainedRequestIdBytes -= pending.reqIdBytes
     }
   }
 }

--- a/src/main/runtime/relay/relay-host-proof-bounds.test.ts
+++ b/src/main/runtime/relay/relay-host-proof-bounds.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import nacl from 'tweetnacl'
+import {
+  answerRelayHostChallenge,
+  RELAY_HOST_CHALLENGE_MAX_CIPHERTEXT_BASE64_CHARACTERS
+} from './relay-host-proof'
+
+describe('relay host proof base64 admission', () => {
+  it('rejects oversized fixed-width fields before decoding', () => {
+    const decode = vi.spyOn(Buffer, 'from')
+
+    expect(
+      answerRelayHostChallenge(
+        {
+          challengeId: 'challenge',
+          relayEphemeralPublicKeyB64: 'A'.repeat(45),
+          nonceB64: 'A'.repeat(33),
+          ciphertextB64: 'AAAA',
+          expiresAt: Date.now() + 1_000
+        },
+        context()
+      )
+    ).toBeNull()
+    expect(decode).not.toHaveBeenCalled()
+    decode.mockRestore()
+  })
+
+  it('rejects oversized ciphertext before decoding that field', () => {
+    const relayKey = Buffer.from(new Uint8Array(32)).toString('base64')
+    const nonce = Buffer.from(new Uint8Array(24)).toString('base64')
+    const decode = vi.spyOn(Buffer, 'from')
+
+    expect(
+      answerRelayHostChallenge(
+        {
+          challengeId: 'challenge',
+          relayEphemeralPublicKeyB64: relayKey,
+          nonceB64: nonce,
+          ciphertextB64: 'A'.repeat(RELAY_HOST_CHALLENGE_MAX_CIPHERTEXT_BASE64_CHARACTERS + 1),
+          expiresAt: Date.now() + 1_000
+        },
+        context()
+      )
+    ).toBeNull()
+    expect(decode).toHaveBeenCalledTimes(2)
+    decode.mockRestore()
+  })
+})
+
+function context() {
+  const host = nacl.box.keyPair()
+  return {
+    relayOrigin: 'https://relay.example',
+    userId: 'user',
+    profileId: 'profile',
+    organizationId: 'organization',
+    relayHostId: 'host',
+    hostPublicKey: host.publicKey,
+    hostSecretKey: host.secretKey,
+    assignmentEpoch: 1,
+    resumeRequested: false
+  }
+}

--- a/src/main/runtime/relay/relay-host-proof.ts
+++ b/src/main/runtime/relay/relay-host-proof.ts
@@ -5,6 +5,7 @@ const HOST_PROOF_TRANSCRIPT_DOMAIN = 'orca-relay-host-proof/v1'
 const HOST_CHALLENGE_PLAINTEXT_DOMAIN = 'orca-relay-host-challenge/v1'
 const textEncoder = new TextEncoder()
 const textDecoder = new TextDecoder()
+export const RELAY_HOST_CHALLENGE_MAX_CIPHERTEXT_BASE64_CHARACTERS = 16 * 1024
 
 export type RelayHostChallenge = {
   challengeId: string
@@ -29,7 +30,10 @@ export type RelayHostProofContext = {
 }
 
 function decodeCanonicalBase64(value: string, expectedBytes: number): Uint8Array | null {
-  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+  if (
+    value.length !== Math.ceil(expectedBytes / 3) * 4 ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
+  ) {
     return null
   }
   const decoded = Buffer.from(value, 'base64')
@@ -129,8 +133,18 @@ export function answerRelayHostChallenge(
 ): string | null {
   const relayKey = decodeCanonicalBase64(challenge.relayEphemeralPublicKeyB64, 32)
   const nonce = decodeCanonicalBase64(challenge.nonceB64, 24)
+  if (
+    !relayKey ||
+    !nonce ||
+    challenge.ciphertextB64.length > RELAY_HOST_CHALLENGE_MAX_CIPHERTEXT_BASE64_CHARACTERS ||
+    !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+      challenge.ciphertextB64
+    )
+  ) {
+    return null
+  }
   const ciphertext = Buffer.from(challenge.ciphertextB64, 'base64')
-  if (!relayKey || !nonce || ciphertext.toString('base64') !== challenge.ciphertextB64) {
+  if (ciphertext.toString('base64') !== challenge.ciphertextB64) {
     return null
   }
   const plaintext = nacl.box.open(ciphertext, nonce, relayKey, context.hostSecretKey)

--- a/src/main/runtime/relay/relay-http-client.test.ts
+++ b/src/main/runtime/relay/relay-http-client.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
+import {
+  API_RESPONSE_MAX_BYTES,
+  FetchResponseBodyTooLargeError
+} from '../../lib/fetch-response-body'
 import { cancelTrackingResponse } from '../../lib/unread-response-body.test-fixtures'
 import { exchangeRelayAuthorization, requestRelayAssignment } from './relay-http-client'
 
@@ -103,5 +107,31 @@ describe('relay HTTP client', () => {
       })
     ).rejects.toThrow()
     expect(cancelledBodies).toBe(2)
+  })
+
+  it('rejects oversized successful responses from injected standard fetch clients', async () => {
+    let cancelled = false
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([123]))
+        },
+        cancel() {
+          cancelled = true
+        }
+      }),
+      { headers: { 'content-length': String(API_RESPONSE_MAX_BYTES + 1) } }
+    )
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => response)
+
+    await expect(
+      requestRelayAssignment({
+        directorUrl: 'https://relay.example',
+        relayToken: 'scoped-token',
+        relayHostId: 'AbCdEf0123_-xyZ9',
+        fetch
+      })
+    ).rejects.toBeInstanceOf(FetchResponseBodyTooLargeError)
+    expect(cancelled).toBe(true)
   })
 })

--- a/src/main/runtime/relay/relay-http-client.ts
+++ b/src/main/runtime/relay/relay-http-client.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import type { E2EEKeypair } from '../e2ee-keypair'
 import { cancelUnreadResponseBody } from '../../lib/unread-response-body'
+import { readFetchResponseJsonWithinLimit } from '../../lib/fetch-response-body'
 
 const RelayTokenResponseSchema = z
   .object({
@@ -85,7 +86,9 @@ export async function exchangeRelayAuthorization(input: {
     await cancelUnreadResponseBody(response)
     throw new RelayHttpError('token-exchange', response.status)
   }
-  const parsed = RelayTokenResponseSchema.safeParse(await response.json())
+  const parsed = RelayTokenResponseSchema.safeParse(
+    await readFetchResponseJsonWithinLimit<unknown>(response)
+  )
   if (!parsed.success) {
     throw new RelayHttpError('token-exchange', 502)
   }
@@ -113,7 +116,9 @@ export async function requestRelayAssignment(input: {
     await cancelUnreadResponseBody(response)
     throw new RelayHttpError('assignment', response.status)
   }
-  const parsed = AssignmentResponseSchema.safeParse(await response.json())
+  const parsed = AssignmentResponseSchema.safeParse(
+    await readFetchResponseJsonWithinLimit<unknown>(response)
+  )
   if (!parsed.success || !isAllowedRelayOrigin(parsed.data.cellUrl)) {
     throw new RelayHttpError('assignment', 502)
   }

--- a/src/main/runtime/relay/relay-revoke-outbox.test.ts
+++ b/src/main/runtime/relay/relay-revoke-outbox.test.ts
@@ -1,8 +1,14 @@
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { RelayRevokeOutbox } from './relay-revoke-outbox'
+import {
+  MAX_RELAY_REVOKE_OUTBOX_FILE_BYTES,
+  MAX_RELAY_REVOKE_OUTBOX_ITEMS,
+  RelayRevokeOutbox,
+  RelayRevokeOutboxCapacityError,
+  type RelayRevokeOutboxItem
+} from './relay-revoke-outbox'
 
 describe('RelayRevokeOutbox', () => {
   const paths: string[] = []
@@ -28,5 +34,71 @@ describe('RelayRevokeOutbox', () => {
     expect(
       new RelayRevokeOutbox(path).pendingFor(binding.ownerIdentityKey, binding.relayHostId)
     ).toEqual([])
+  })
+
+  it('treats an oversized sparse outbox file as unavailable', () => {
+    const path = mkdtempSync(join(tmpdir(), 'orca-relay-revoke-bound-'))
+    paths.push(path)
+    const outboxPath = join(path, 'mobile-relay-revoke-outbox.json')
+    writeFileSync(outboxPath, '[]')
+    truncateSync(outboxPath, MAX_RELAY_REVOKE_OUTBOX_FILE_BYTES + 1)
+
+    expect(new RelayRevokeOutbox(path).pendingFor('owner', 'host')).toEqual([])
+  })
+
+  it('fails closed instead of dropping revocations beyond the retained-item bound', () => {
+    const path = mkdtempSync(join(tmpdir(), 'orca-relay-revoke-count-'))
+    paths.push(path)
+    const items: RelayRevokeOutboxItem[] = Array.from(
+      { length: MAX_RELAY_REVOKE_OUTBOX_ITEMS + 1 },
+      (_, index) => ({
+        reqId: `request-${index}`,
+        relayHostId: 'host',
+        relayDeviceId: `device-${index}`,
+        ownerIdentityKey: 'owner',
+        createdAt: index
+      })
+    )
+    writeFileSync(join(path, 'mobile-relay-revoke-outbox.json'), JSON.stringify(items))
+
+    expect(() => new RelayRevokeOutbox(path)).toThrow(RelayRevokeOutboxCapacityError)
+  })
+
+  it('keeps idempotent revokes usable at capacity and rejects only a new revoke', () => {
+    const path = mkdtempSync(join(tmpdir(), 'orca-relay-revoke-capacity-'))
+    paths.push(path)
+    const items: RelayRevokeOutboxItem[] = Array.from(
+      { length: MAX_RELAY_REVOKE_OUTBOX_ITEMS },
+      (_, index) => ({
+        reqId: `request-${index}`,
+        relayHostId: 'host',
+        relayDeviceId: `device-${index}`,
+        ownerIdentityKey: 'owner',
+        createdAt: index
+      })
+    )
+    writeFileSync(join(path, 'mobile-relay-revoke-outbox.json'), JSON.stringify(items))
+    const outbox = new RelayRevokeOutbox(path)
+
+    expect(outbox.enqueue(items[0]!).reqId).toBe(items[0]!.reqId)
+    expect(() =>
+      outbox.enqueue({ relayHostId: 'host', relayDeviceId: 'new', ownerIdentityKey: 'owner' })
+    ).toThrow(RelayRevokeOutboxCapacityError)
+  })
+
+  it('rejects a byte-oversized revoke without publishing partial in-memory state', () => {
+    const path = mkdtempSync(join(tmpdir(), 'orca-relay-revoke-byte-capacity-'))
+    paths.push(path)
+    const outbox = new RelayRevokeOutbox(path)
+
+    expect(() =>
+      outbox.enqueue({
+        relayHostId: 'host',
+        relayDeviceId: 'device',
+        ownerIdentityKey: 'x'.repeat(MAX_RELAY_REVOKE_OUTBOX_FILE_BYTES)
+      })
+    ).toThrow(RelayRevokeOutboxCapacityError)
+    expect(outbox.pendingFor('owner', 'host')).toEqual([])
+    expect(new RelayRevokeOutbox(path).pendingFor('owner', 'host')).toEqual([])
   })
 })

--- a/src/main/runtime/relay/relay-revoke-outbox.ts
+++ b/src/main/runtime/relay/relay-revoke-outbox.ts
@@ -1,7 +1,10 @@
 import { randomUUID } from 'node:crypto'
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
-import { hardenExistingSecureFile, writeSecureJsonFile } from '../../../shared/secure-file'
+import { readNodeFileSyncWithinLimit } from '../../../shared/node-bounded-file-reader'
+import { JsonStringifyByteLimitError } from '../../../shared/node-bounded-json-stringify'
+import { writeSecureJsonFileWithinLimit } from '../../../shared/bounded-secure-json-file'
+import { hardenExistingSecureFile } from '../../../shared/secure-file'
 
 export type RelayDeviceBinding = {
   relayHostId: string
@@ -16,6 +19,15 @@ export type RelayRevokeOutboxItem = RelayDeviceBinding & {
 }
 
 const OUTBOX_FILENAME = 'mobile-relay-revoke-outbox.json'
+export const MAX_RELAY_REVOKE_OUTBOX_FILE_BYTES = 1024 * 1024
+export const MAX_RELAY_REVOKE_OUTBOX_ITEMS = 4096
+
+export class RelayRevokeOutboxCapacityError extends Error {
+  constructor() {
+    super(`Relay revoke outbox exceeds ${MAX_RELAY_REVOKE_OUTBOX_ITEMS} items`)
+    this.name = 'RelayRevokeOutboxCapacityError'
+  }
+}
 
 function isItem(value: unknown): value is RelayRevokeOutboxItem {
   if (!value || typeof value !== 'object') {
@@ -53,9 +65,13 @@ export class RelayRevokeOutbox {
     if (existing) {
       return existing
     }
+    if (this.items.length >= MAX_RELAY_REVOKE_OUTBOX_ITEMS) {
+      throw new RelayRevokeOutboxCapacityError()
+    }
     const item = { ...binding, reqId: randomUUID(), createdAt: Date.now() }
-    this.items.push(item)
-    this.save()
+    const next = [...this.items, item]
+    this.save(next)
+    this.items = next
     return item
   }
 
@@ -70,24 +86,44 @@ export class RelayRevokeOutbox {
     if (next.length === this.items.length) {
       return
     }
+    this.save(next)
     this.items = next
-    this.save()
   }
 
   private load(): RelayRevokeOutboxItem[] {
     if (!existsSync(this.path)) {
       return []
     }
+    let parsed: unknown
     try {
       hardenExistingSecureFile(this.path)
-      const parsed: unknown = JSON.parse(readFileSync(this.path, 'utf-8'))
-      return Array.isArray(parsed) ? parsed.filter(isItem) : []
+      parsed = JSON.parse(
+        readNodeFileSyncWithinLimit(this.path, MAX_RELAY_REVOKE_OUTBOX_FILE_BYTES).buffer.toString(
+          'utf8'
+        )
+      )
     } catch {
       return []
     }
+    if (!Array.isArray(parsed)) {
+      return []
+    }
+    const items = parsed.filter(isItem)
+    if (items.length > MAX_RELAY_REVOKE_OUTBOX_ITEMS) {
+      // Why: silently dropping durable revocations could leave remote credentials active.
+      throw new RelayRevokeOutboxCapacityError()
+    }
+    return items
   }
 
-  private save(): void {
-    writeSecureJsonFile(this.path, this.items)
+  private save(items: RelayRevokeOutboxItem[]): void {
+    try {
+      writeSecureJsonFileWithinLimit(this.path, items, MAX_RELAY_REVOKE_OUTBOX_FILE_BYTES)
+    } catch (error) {
+      if (error instanceof JsonStringifyByteLimitError) {
+        throw new RelayRevokeOutboxCapacityError()
+      }
+      throw error
+    }
   }
 }

--- a/src/main/runtime/rpc/dispatcher-output-bounds.test.ts
+++ b/src/main/runtime/rpc/dispatcher-output-bounds.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES } from '../../../shared/remote-runtime-memory-limits'
+import type { OrcaRuntimeService } from '../orca-runtime'
+import { defineMethod, defineStreamingMethod, type RpcRequest } from './core'
+import { RpcDispatcher } from './dispatcher'
+
+const request = (method: string): RpcRequest => ({
+  id: 'request-1',
+  authToken: 'unused',
+  method
+})
+
+function runtime(): OrcaRuntimeService {
+  return {
+    getRuntimeId: () => 'runtime-1',
+    recordFeatureInteraction: vi.fn()
+  } as unknown as OrcaRuntimeService
+}
+
+describe('RpcDispatcher outbound response bounds', () => {
+  it('preserves ordinary streaming response serialization byte-for-byte', async () => {
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime(),
+      methods: [
+        defineMethod({
+          name: 'test.normal',
+          params: null,
+          handler: () => ({ text: 'hello 😀' })
+        })
+      ]
+    })
+    const reply = vi.fn()
+
+    await dispatcher.dispatchStreaming(request('test.normal'), reply)
+
+    expect(reply).toHaveBeenCalledWith(
+      JSON.stringify({
+        id: 'request-1',
+        ok: true,
+        result: { text: 'hello 😀' },
+        _meta: { runtimeId: 'runtime-1' }
+      })
+    )
+  })
+
+  it('replaces an oversized one-shot result with a small correlated error', async () => {
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime(),
+      methods: [
+        defineMethod({
+          name: 'test.oversized',
+          params: null,
+          handler: () => ({ text: 'x'.repeat(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) })
+        })
+      ]
+    })
+
+    const response = await dispatcher.dispatch(request('test.oversized'))
+
+    expect(response).toMatchObject({
+      id: 'request-1',
+      ok: false,
+      error: { code: 'response_too_large' },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    expect(Buffer.byteLength(JSON.stringify(response), 'utf8')).toBeLessThan(
+      REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+    )
+  })
+
+  it('bounds an oversized streaming emission before calling the reply transport', async () => {
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime(),
+      methods: [
+        defineStreamingMethod({
+          name: 'test.stream-oversized',
+          params: null,
+          handler: async (_params, _context, emit) => {
+            emit({ text: 'x'.repeat(REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) })
+          }
+        })
+      ]
+    })
+    const reply = vi.fn()
+
+    await dispatcher.dispatchStreaming(request('test.stream-oversized'), reply)
+
+    expect(reply).toHaveBeenCalledOnce()
+    const response = JSON.parse(reply.mock.calls[0]![0] as string) as {
+      id: string
+      ok: boolean
+      error: { code: string }
+    }
+    expect(response).toMatchObject({
+      id: 'request-1',
+      ok: false,
+      error: { code: 'response_too_large' }
+    })
+  })
+})

--- a/src/main/runtime/rpc/dispatcher.ts
+++ b/src/main/runtime/rpc/dispatcher.ts
@@ -29,6 +29,10 @@ import {
 import { ALL_RPC_METHODS } from './methods'
 import { emulatorProbe, emulatorProbeError } from '../../emulator/emulator-probe'
 import type { OrcaRuntimeService } from '../orca-runtime'
+import {
+  boundRuntimeRpcResponse,
+  serializeRuntimeRpcResponse
+} from './runtime-rpc-response-serialization'
 
 export type DispatcherOptions = {
   runtime: OrcaRuntimeService
@@ -48,28 +52,27 @@ export class RpcDispatcher {
     const meta = this.meta()
     const method = this.registry.get(request.method)
     if (!method) {
-      return errorResponse(
-        request.id,
-        meta,
-        'method_not_found',
-        `Unknown method: ${request.method}`
+      return boundRuntimeRpcResponse(
+        errorResponse(request.id, meta, 'method_not_found', `Unknown method: ${request.method}`)
       )
     }
 
     const parsedParams = this.parseParams(request, method, meta)
     if (parsedParams.error) {
-      return parsedParams.error
+      return boundRuntimeRpcResponse(parsedParams.error)
     }
 
     // Why: streaming methods are not supported over one-shot transports like
     // Unix sockets. They require a reply function that can be called multiple
     // times, which is only available via dispatchStreaming.
     if (isStreamingMethod(method)) {
-      return errorResponse(
-        request.id,
-        meta,
-        'method_not_supported',
-        `Method ${request.method} requires a streaming transport`
+      return boundRuntimeRpcResponse(
+        errorResponse(
+          request.id,
+          meta,
+          'method_not_supported',
+          `Method ${request.method} requires a streaming transport`
+        )
       )
     }
 
@@ -83,12 +86,12 @@ export class RpcDispatcher {
         signal: options?.signal
       })
       this.recordRuntimeFeatureInteraction(request.method, result, undefined, request.params)
-      return successResponse(request.id, meta, result)
+      return boundRuntimeRpcResponse(successResponse(request.id, meta, result))
     } catch (error) {
       if (isEmulator) {
         emulatorProbeError(`rpc ${request.method}`, error, { params: request.params })
       }
-      return this.mapError(request, meta, error)
+      return boundRuntimeRpcResponse(this.mapError(request, meta, error))
     }
   }
 
@@ -116,7 +119,7 @@ export class RpcDispatcher {
     const method = this.registry.get(request.method)
     if (!method) {
       reply(
-        JSON.stringify(
+        serializeRuntimeRpcResponse(
           errorResponse(request.id, meta, 'method_not_found', `Unknown method: ${request.method}`)
         )
       )
@@ -125,7 +128,7 @@ export class RpcDispatcher {
 
     const parsedParams = this.parseParams(request, method, meta)
     if (parsedParams.error) {
-      reply(JSON.stringify(parsedParams.error))
+      reply(serializeRuntimeRpcResponse(parsedParams.error))
       return
     }
 
@@ -144,9 +147,9 @@ export class RpcDispatcher {
           registerBinaryStreamHandler: options?.registerBinaryStreamHandler
         })
         this.recordRuntimeFeatureInteraction(request.method, result, undefined, request.params)
-        reply(JSON.stringify(successResponse(request.id, meta, result)))
+        reply(serializeRuntimeRpcResponse(successResponse(request.id, meta, result)))
       } catch (error) {
-        reply(JSON.stringify(this.mapError(request, meta, error)))
+        reply(serializeRuntimeRpcResponse(this.mapError(request, meta, error)))
       }
       return
     }
@@ -161,7 +164,7 @@ export class RpcDispatcher {
       )
       const response = successResponse(request.id, meta, result)
       response.streaming = true
-      reply(JSON.stringify(response))
+      reply(serializeRuntimeRpcResponse(response))
     }
 
     try {
@@ -188,7 +191,7 @@ export class RpcDispatcher {
         request.params
       )
     } catch (error) {
-      reply(JSON.stringify(this.mapError(request, meta, error)))
+      reply(serializeRuntimeRpcResponse(this.mapError(request, meta, error)))
     }
   }
 

--- a/src/main/runtime/rpc/errors.test.ts
+++ b/src/main/runtime/rpc/errors.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import {
+  MARKDOWN_DOCUMENT_LISTING_ERROR_CODE,
+  MarkdownDocumentListingCapacityError
+} from '../../../shared/markdown-document-listing-limits'
 import { mapRuntimeError } from './errors'
 
 class LineageError extends Error {
@@ -143,6 +147,21 @@ describe('mapRuntimeError', () => {
         }
       },
       _meta: { runtimeId: 'runtime-1' }
+    })
+  })
+
+  it('preserves the Markdown listing capacity code across runtime RPC', () => {
+    expect(
+      mapRuntimeError(
+        'req_1',
+        { runtimeId: 'runtime-1' },
+        new MarkdownDocumentListingCapacityError()
+      )
+    ).toMatchObject({
+      ok: false,
+      error: {
+        code: MARKDOWN_DOCUMENT_LISTING_ERROR_CODE
+      }
     })
   })
 })

--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -7,6 +7,7 @@ import { computerUseErrorRecoveryData } from '../../../shared/computer-use-error
 import { COMPUTER_ERROR_CODES } from '../../../shared/runtime-types'
 import { LINEAR_ERROR_CODES } from '../../../shared/linear-agent-access'
 import { AGENT_SESSION_RPC_ERROR_CODES } from '../../../shared/agent-session-host-authority'
+import { MARKDOWN_DOCUMENT_LISTING_ERROR_CODE } from '../../../shared/markdown-document-listing-limits'
 
 export function successResponse(id: string, meta: RpcEnvelopeMeta, result: unknown): RpcSuccess {
   return {
@@ -60,7 +61,8 @@ const RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
 const COMPUTER_PASSTHROUGH_CODES: ReadonlySet<string> = new Set(Object.values(COMPUTER_ERROR_CODES))
 const LINEAR_PASSTHROUGH_CODES: ReadonlySet<string> = new Set(LINEAR_ERROR_CODES)
 const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
-  'worktree_id_requires_full_path'
+  'worktree_id_requires_full_path',
+  MARKDOWN_DOCUMENT_LISTING_ERROR_CODE
 ])
 
 export function mapRuntimeError(id: string, meta: RpcEnvelopeMeta, error: unknown): RpcFailure {

--- a/src/main/runtime/rpc/methods/ai-vault.test.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.test.ts
@@ -4,6 +4,7 @@ import type { RpcRequest } from '../core'
 import { OrcaRuntimeService } from '../../orca-runtime'
 import type { AiVaultListResult, AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { AiVaultScanOptions } from '../../../ai-vault/session-scanner-types'
+import { AI_VAULT_SESSION_ID_MAX_UTF8_BYTES } from '../../../ai-vault/session-list-retention'
 
 const { scanAiVaultSessions } = vi.hoisted(() => ({
   scanAiVaultSessions: vi.fn()
@@ -178,6 +179,24 @@ describe('aiVault.listSessions handler + shared cache', () => {
     await listAiVaultSessions({ limit: 500 })
     // Second call via the RPC method with the same cache key.
     await dispatcher.dispatch(makeRequest('aiVault.listSessions', { limit: 500 }))
+    expect(scanAiVaultSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('bounds a pathological result before retaining it in the shared cache', async () => {
+    const oversized = makeSession()
+    oversized.sessionId = 'x'.repeat(AI_VAULT_SESSION_ID_MAX_UTF8_BYTES + 1)
+    scanAiVaultSessions.mockResolvedValue({
+      sessions: [oversized],
+      issues: [],
+      scannedAt: SCANNED_AT
+    })
+
+    const first = await listAiVaultSessions({ limit: 500 })
+    const second = await listAiVaultSessions({ limit: 500 })
+
+    expect(first.sessions).toEqual([])
+    expect(first.issues.at(-1)?.message).toContain('AI Vault omitted')
+    expect(second).toBe(first)
     expect(scanAiVaultSessions).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/runtime/rpc/methods/clipboard-image-upload-buffer.ts
+++ b/src/main/runtime/rpc/methods/clipboard-image-upload-buffer.ts
@@ -1,0 +1,121 @@
+const BASE64_PADDING_BYTE = '='.charCodeAt(0)
+
+function isBase64DataByte(byte: number): boolean {
+  return (
+    (byte >= 65 && byte <= 90) ||
+    (byte >= 97 && byte <= 122) ||
+    (byte >= 48 && byte <= 57) ||
+    byte === 43 ||
+    byte === 47
+  )
+}
+
+export class ClipboardImageUploadBuffer {
+  private readonly segments: Buffer[] = []
+  private retainedLength = 0
+
+  constructor(
+    private readonly expectedLength: number,
+    private readonly segmentLength: number
+  ) {}
+
+  get length(): number {
+    return this.retainedLength
+  }
+
+  append(contentBase64: string): void {
+    if (contentBase64.length > this.expectedLength - this.retainedLength) {
+      throw new Error('Clipboard image upload exceeded expected size')
+    }
+    const source = Buffer.from(contentBase64, 'ascii')
+    const originalLength = this.retainedLength
+    const originalSegmentCount = this.segments.length
+    let sourceOffset = 0
+    try {
+      while (sourceOffset < source.length) {
+        const segmentIndex = Math.floor(this.retainedLength / this.segmentLength)
+        const segmentOffset = this.retainedLength % this.segmentLength
+        let segment = this.segments[segmentIndex]
+        if (!segment) {
+          const segmentStart = segmentIndex * this.segmentLength
+          segment = Buffer.allocUnsafe(
+            Math.min(this.segmentLength, this.expectedLength - segmentStart)
+          )
+          this.segments.push(segment)
+        }
+        const copyLength = Math.min(source.length - sourceOffset, segment.length - segmentOffset)
+        source.copy(segment, segmentOffset, sourceOffset, sourceOffset + copyLength)
+        sourceOffset += copyLength
+        this.retainedLength += copyLength
+      }
+    } catch (error) {
+      this.retainedLength = originalLength
+      this.segments.length = originalSegmentCount
+      throw error
+    }
+  }
+
+  clear(): void {
+    this.retainedLength = 0
+    this.segments.length = 0
+  }
+
+  decode(): Buffer {
+    const dataLength = this.validateAndGetDataLength()
+    const decoded = Buffer.allocUnsafe(Math.floor((dataLength * 3) / 4))
+    let carry = ''
+    let remainingData = dataLength
+    let written = 0
+    for (const segment of this.segments) {
+      if (remainingData === 0) {
+        break
+      }
+      const segmentDataLength = Math.min(segment.length, remainingData)
+      const data = segment.subarray(0, segmentDataLength).toString('ascii')
+      const combined = carry.length > 0 ? carry + data : data
+      const completeLength = combined.length - (combined.length % 4)
+      if (completeLength > 0) {
+        const complete =
+          completeLength === combined.length ? combined : combined.slice(0, completeLength)
+        written += decoded.write(complete, written, 'base64')
+      }
+      carry = completeLength === combined.length ? '' : combined.slice(completeLength)
+      remainingData -= segmentDataLength
+    }
+    if (carry.length > 0) {
+      written += decoded.write(carry, written, 'base64')
+    }
+    if (written !== decoded.length) {
+      throw new Error('Clipboard image content must be base64')
+    }
+    return decoded
+  }
+
+  private validateAndGetDataLength(): number {
+    if (this.retainedLength % 4 === 1) {
+      throw new Error('Clipboard image content must be base64')
+    }
+    let dataLength = 0
+    let paddingLength = 0
+    let remaining = this.retainedLength
+    for (const segment of this.segments) {
+      const usedLength = Math.min(segment.length, remaining)
+      for (let index = 0; index < usedLength; index++) {
+        const byte = segment[index]
+        if (byte === BASE64_PADDING_BYTE) {
+          paddingLength += 1
+          continue
+        }
+        if (paddingLength > 0 || !isBase64DataByte(byte)) {
+          throw new Error('Clipboard image content must be base64')
+        }
+        dataLength += 1
+      }
+      remaining -= usedLength
+    }
+    if (paddingLength > 2) {
+      throw new Error('Clipboard image content must be base64')
+    }
+    return dataLength
+  }
+}

--- a/src/main/runtime/rpc/methods/clipboard.test.ts
+++ b/src/main/runtime/rpc/methods/clipboard.test.ts
@@ -4,6 +4,7 @@ import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import {
   CLIPBOARD_IMAGE_MAX_BASE64_CHARS,
+  CLIPBOARD_IMAGE_MAX_SOURCE_BYTES,
   CLIPBOARD_IMAGE_TOO_LARGE_ERROR
 } from '../../../../shared/clipboard-image'
 
@@ -18,7 +19,9 @@ vi.mock('../../../window/clipboard-image-temp-file', () => ({
 import {
   CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS,
   CLIPBOARD_IMAGE_UPLOAD_MAX_CONCURRENT,
+  CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS,
   CLIPBOARD_METHODS,
+  getRetainedClipboardImageUploadBase64CharsForTest,
   resetClipboardImageUploadsForTest
 } from './clipboard'
 
@@ -100,7 +103,7 @@ describe('clipboard RPC methods', () => {
   it('accepts chunked uploads and forwards the recorded connectionId on commit', async () => {
     saveClipboardImageBufferAsTempFile.mockResolvedValue('/tmp/orca-paste-image.png')
     const dispatcher = makeDispatcher()
-    const contentBase64 = Buffer.from('png-bytes').toString('base64')
+    const contentBase64 = Buffer.from('png-byte').toString('base64')
 
     const start = await dispatcher.dispatch(
       makeRequest('clipboard.startImageUpload', {
@@ -111,8 +114,8 @@ describe('clipboard RPC methods', () => {
     expect(start.ok).toBe(true)
     const uploadId = (start.ok ? start.result : null) as { uploadId: string }
 
-    const firstChunk = contentBase64.slice(0, 4)
-    const secondChunk = contentBase64.slice(4)
+    const firstChunk = contentBase64.slice(0, 2)
+    const secondChunk = contentBase64.slice(2)
     await expect(
       dispatcher.dispatch(
         makeRequest('clipboard.appendImageUploadChunk', {
@@ -121,7 +124,7 @@ describe('clipboard RPC methods', () => {
           contentBase64: firstChunk
         })
       )
-    ).resolves.toMatchObject({ ok: true, result: { receivedBase64Length: 4 } })
+    ).resolves.toMatchObject({ ok: true, result: { receivedBase64Length: 2 } })
     await expect(
       dispatcher.dispatch(
         makeRequest('clipboard.appendImageUploadChunk', {
@@ -131,13 +134,15 @@ describe('clipboard RPC methods', () => {
         })
       )
     ).resolves.toMatchObject({ ok: true, result: { receivedBase64Length: contentBase64.length } })
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(contentBase64.length)
 
     await expect(
       dispatcher.dispatch(
         makeRequest('clipboard.commitImageUpload', { uploadId: uploadId.uploadId })
       )
     ).resolves.toMatchObject({ ok: true, result: '/tmp/orca-paste-image.png' })
-    expect(saveClipboardImageBufferAsTempFile).toHaveBeenCalledWith(Buffer.from('png-bytes'), {
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
+    expect(saveClipboardImageBufferAsTempFile).toHaveBeenCalledWith(Buffer.from('png-byte'), {
       connectionId: 'ssh-1'
     })
   })
@@ -161,6 +166,7 @@ describe('clipboard RPC methods', () => {
     )
 
     expect(response.ok).toBe(false)
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
     expect(saveClipboardImageBufferAsTempFile).not.toHaveBeenCalled()
   })
 
@@ -183,6 +189,7 @@ describe('clipboard RPC methods', () => {
         })
       )
     ).resolves.toMatchObject({ ok: false })
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
     await expect(
       dispatcher.dispatch(
         makeRequest('clipboard.appendImageUploadChunk', {
@@ -258,6 +265,7 @@ describe('clipboard RPC methods', () => {
     )
 
     expect(response.ok).toBe(false)
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
     expect(saveClipboardImageBufferAsTempFile).not.toHaveBeenCalled()
   })
 
@@ -290,6 +298,7 @@ describe('clipboard RPC methods', () => {
     )
 
     expect(response.ok).toBe(false)
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
     expect(saveClipboardImageBufferAsTempFile).not.toHaveBeenCalled()
   })
 
@@ -302,12 +311,21 @@ describe('clipboard RPC methods', () => {
       })
     )
     const uploadId = (start.ok ? start.result : null) as { uploadId: string }
+    await dispatcher.dispatch(
+      makeRequest('clipboard.appendImageUploadChunk', {
+        uploadId: uploadId.uploadId,
+        offset: 0,
+        contentBase64: 'AAAA'
+      })
+    )
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(4)
 
     await expect(
       dispatcher.dispatch(
         makeRequest('clipboard.abortImageUpload', { uploadId: uploadId.uploadId })
       )
     ).resolves.toMatchObject({ ok: true, result: { aborted: true } })
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
     await expect(
       dispatcher.dispatch(
         makeRequest('clipboard.abortImageUpload', { uploadId: uploadId.uploadId })
@@ -349,22 +367,137 @@ describe('clipboard RPC methods', () => {
         makeRequest('clipboard.commitImageUpload', { uploadId: uploadId.uploadId })
       )
     ).resolves.toMatchObject({ ok: false })
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
     expect(saveClipboardImageBufferAsTempFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('caps retained chunks process-wide and keeps commit memory charged until save completes', async () => {
+    let releaseSave!: () => void
+    const saveGate = new Promise<void>((resolve) => {
+      releaseSave = resolve
+    })
+    saveClipboardImageBufferAsTempFile.mockImplementation(async (content: Buffer) => {
+      expect(content).toHaveLength(CLIPBOARD_IMAGE_MAX_SOURCE_BYTES)
+      await saveGate
+      return '/tmp/orca-paste-image.png'
+    })
+    const dispatcher = makeDispatcher()
+    const firstStart = await dispatcher.dispatch(
+      makeRequest('clipboard.startImageUpload', {
+        expectedBase64Length: CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS,
+        connectionId: 'ssh-1'
+      })
+    )
+    const secondStart = await dispatcher.dispatch(
+      makeRequest('clipboard.startImageUpload', {
+        expectedBase64Length: 4,
+        connectionId: 'ssh-2'
+      })
+    )
+    const firstUpload = (firstStart.ok ? firstStart.result : null) as { uploadId: string }
+    const secondUpload = (secondStart.ok ? secondStart.result : null) as { uploadId: string }
+    const fullChunk = 'A'.repeat(CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS)
+
+    for (
+      let offset = 0;
+      offset < CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS;
+      offset += fullChunk.length
+    ) {
+      await expect(
+        dispatcher.dispatch(
+          makeRequest('clipboard.appendImageUploadChunk', {
+            uploadId: firstUpload.uploadId,
+            offset,
+            contentBase64: fullChunk
+          })
+        )
+      ).resolves.toMatchObject({ ok: true })
+    }
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(
+      CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS
+    )
+
+    await expect(
+      dispatcher.dispatch(
+        makeRequest('clipboard.appendImageUploadChunk', {
+          uploadId: secondUpload.uploadId,
+          offset: 0,
+          contentBase64: 'AAAA'
+        })
+      )
+    ).resolves.toMatchObject({ ok: false })
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(
+      CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS
+    )
+
+    const commit = dispatcher.dispatch(
+      makeRequest('clipboard.commitImageUpload', { uploadId: firstUpload.uploadId })
+    )
+    await vi.waitFor(() => expect(saveClipboardImageBufferAsTempFile).toHaveBeenCalledTimes(1))
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(
+      CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS
+    )
+    releaseSave()
+    await expect(commit).resolves.toMatchObject({ ok: true })
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
+
+    await expect(
+      dispatcher.dispatch(
+        makeRequest('clipboard.appendImageUploadChunk', {
+          uploadId: secondUpload.uploadId,
+          offset: 0,
+          contentBase64: 'AAAA'
+        })
+      )
+    ).resolves.toMatchObject({ ok: true, result: { receivedBase64Length: 4 } })
+  })
+
+  it('releases retained chunks when test state is reset', async () => {
+    const dispatcher = makeDispatcher()
+    const start = await dispatcher.dispatch(
+      makeRequest('clipboard.startImageUpload', {
+        expectedBase64Length: 4,
+        connectionId: null
+      })
+    )
+    const uploadId = (start.ok ? start.result : null) as { uploadId: string }
+    await dispatcher.dispatch(
+      makeRequest('clipboard.appendImageUploadChunk', {
+        uploadId: uploadId.uploadId,
+        offset: 0,
+        contentBase64: 'AAAA'
+      })
+    )
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(4)
+
+    resetClipboardImageUploadsForTest()
+
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
   })
 
   it('bounds concurrent uploads and releases slots through TTL cleanup', async () => {
     vi.useFakeTimers()
     const dispatcher = makeDispatcher()
     for (let index = 0; index < CLIPBOARD_IMAGE_UPLOAD_MAX_CONCURRENT; index++) {
-      await expect(
-        dispatcher.dispatch(
-          makeRequest('clipboard.startImageUpload', {
-            expectedBase64Length: 4,
-            connectionId: null
-          })
-        )
-      ).resolves.toMatchObject({ ok: true })
+      const start = await dispatcher.dispatch(
+        makeRequest('clipboard.startImageUpload', {
+          expectedBase64Length: 4,
+          connectionId: null
+        })
+      )
+      expect(start).toMatchObject({ ok: true })
+      const uploadId = (start.ok ? start.result : null) as { uploadId: string }
+      await dispatcher.dispatch(
+        makeRequest('clipboard.appendImageUploadChunk', {
+          uploadId: uploadId.uploadId,
+          offset: 0,
+          contentBase64: 'AAAA'
+        })
+      )
     }
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(
+      CLIPBOARD_IMAGE_UPLOAD_MAX_CONCURRENT * 4
+    )
     await expect(
       dispatcher.dispatch(
         makeRequest('clipboard.startImageUpload', {
@@ -375,6 +508,7 @@ describe('clipboard RPC methods', () => {
     ).resolves.toMatchObject({ ok: false })
 
     vi.advanceTimersByTime(5 * 60 * 1000 + 1)
+    expect(getRetainedClipboardImageUploadBase64CharsForTest()).toBe(0)
 
     await expect(
       dispatcher.dispatch(

--- a/src/main/runtime/rpc/methods/clipboard.ts
+++ b/src/main/runtime/rpc/methods/clipboard.ts
@@ -6,23 +6,28 @@ import {
   CLIPBOARD_IMAGE_MAX_BASE64_CHARS,
   CLIPBOARD_IMAGE_TOO_LARGE_ERROR
 } from '../../../../shared/clipboard-image'
+import { ClipboardImageUploadBuffer } from './clipboard-image-upload-buffer'
 
 const MAX_CLIPBOARD_IMAGE_BASE64_CHARS = CLIPBOARD_IMAGE_MAX_BASE64_CHARS
 export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
 export const CLIPBOARD_IMAGE_UPLOAD_MAX_CONCURRENT = 8
+export const CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS = CLIPBOARD_IMAGE_MAX_BASE64_CHARS
 const CLIPBOARD_IMAGE_UPLOAD_TTL_MS = 5 * 60 * 1000
+const CLIPBOARD_IMAGE_UPLOAD_MEMORY_ERROR = 'Too much clipboard image upload data is in progress'
 const BASE64_PATTERN = /^[A-Za-z0-9+/]*={0,2}$/
 
 type ClipboardImageUpload = {
   expectedBase64Length: number
   connectionId?: string | null
-  chunks: string[]
-  receivedBase64Length: number
+  content: ClipboardImageUploadBuffer
+  reservedBase64Length: number
   expiresAt: number
   ttlTimer: ReturnType<typeof setTimeout>
+  committing: boolean
 }
 
 const clipboardImageUploads = new Map<string, ClipboardImageUpload>()
+let retainedClipboardImageUploadBase64Chars = 0
 
 function isValidBase64(value: string): boolean {
   return value.length % 4 !== 1 && BASE64_PATTERN.test(value)
@@ -38,7 +43,7 @@ function pruneExpiredUploads(now = Date.now()): void {
 
 function scheduleUploadExpiry(uploadId: string): ReturnType<typeof setTimeout> {
   const timer = setTimeout(() => {
-    clipboardImageUploads.delete(uploadId)
+    deleteUpload(uploadId)
   }, CLIPBOARD_IMAGE_UPLOAD_TTL_MS)
   if (typeof timer === 'object' && 'unref' in timer) {
     timer.unref()
@@ -52,12 +57,26 @@ function refreshUploadExpiry(uploadId: string, upload: ClipboardImageUpload): vo
   upload.ttlTimer = scheduleUploadExpiry(uploadId)
 }
 
+function releaseUploadRetention(upload: ClipboardImageUpload): void {
+  retainedClipboardImageUploadBase64Chars -= upload.reservedBase64Length
+  upload.reservedBase64Length = 0
+  upload.content.clear()
+}
+
+function finishUpload(uploadId: string, upload: ClipboardImageUpload): void {
+  clearTimeout(upload.ttlTimer)
+  if (clipboardImageUploads.get(uploadId) === upload) {
+    clipboardImageUploads.delete(uploadId)
+  }
+  releaseUploadRetention(upload)
+}
+
 function deleteUpload(uploadId: string): void {
   const upload = clipboardImageUploads.get(uploadId)
-  if (upload) {
-    clearTimeout(upload.ttlTimer)
+  if (!upload || upload.committing) {
+    return
   }
-  clipboardImageUploads.delete(uploadId)
+  finishUpload(uploadId, upload)
 }
 
 function getUpload(uploadId: string): ClipboardImageUpload {
@@ -66,13 +85,21 @@ function getUpload(uploadId: string): ClipboardImageUpload {
   if (!upload) {
     throw new Error('Clipboard image upload was not found')
   }
+  if (upload.committing) {
+    throw new Error('Clipboard image upload is already committing')
+  }
   return upload
 }
 
-function assertValidBase64Content(value: string): void {
-  if (!isValidBase64(value)) {
-    throw new Error('Clipboard image content must be base64')
+function reserveUploadBase64(chars: number): boolean {
+  if (
+    chars >
+    CLIPBOARD_IMAGE_UPLOAD_MAX_RETAINED_BASE64_CHARS - retainedClipboardImageUploadBase64Chars
+  ) {
+    return false
   }
+  retainedClipboardImageUploadBase64Chars += chars
+  return true
 }
 
 function clipboardImageBase64Payload(maxChars: number, tooLargeMessage: string) {
@@ -148,10 +175,14 @@ export const CLIPBOARD_METHODS: RpcMethod[] = [
       clipboardImageUploads.set(uploadId, {
         expectedBase64Length: params.expectedBase64Length,
         connectionId: params.connectionId,
-        chunks: [],
-        receivedBase64Length: 0,
+        content: new ClipboardImageUploadBuffer(
+          params.expectedBase64Length,
+          CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS
+        ),
+        reservedBase64Length: 0,
         expiresAt: Date.now() + CLIPBOARD_IMAGE_UPLOAD_TTL_MS,
-        ttlTimer: scheduleUploadExpiry(uploadId)
+        ttlTimer: scheduleUploadExpiry(uploadId),
+        committing: false
       })
       return { uploadId }
     }
@@ -161,17 +192,25 @@ export const CLIPBOARD_METHODS: RpcMethod[] = [
     params: AppendImageUploadChunk,
     handler: (params) => {
       const upload = getUpload(params.uploadId)
-      if (params.offset !== upload.receivedBase64Length) {
+      if (params.offset !== upload.content.length) {
         throw new Error('Clipboard image chunk offset is out of order')
       }
-      const nextLength = upload.receivedBase64Length + params.contentBase64.length
+      const nextLength = upload.content.length + params.contentBase64.length
       if (nextLength > upload.expectedBase64Length) {
         throw new Error('Clipboard image upload exceeded expected size')
       }
-      upload.chunks.push(params.contentBase64)
-      upload.receivedBase64Length = nextLength
+      if (!reserveUploadBase64(params.contentBase64.length)) {
+        throw new Error(CLIPBOARD_IMAGE_UPLOAD_MEMORY_ERROR)
+      }
+      try {
+        upload.content.append(params.contentBase64)
+      } catch (error) {
+        retainedClipboardImageUploadBase64Chars -= params.contentBase64.length
+        throw error
+      }
+      upload.reservedBase64Length += params.contentBase64.length
       refreshUploadExpiry(params.uploadId, upload)
-      return { receivedBase64Length: upload.receivedBase64Length }
+      return { receivedBase64Length: upload.content.length }
     }
   }),
   defineMethod({
@@ -179,19 +218,19 @@ export const CLIPBOARD_METHODS: RpcMethod[] = [
     params: CommitImageUpload,
     handler: async (params) => {
       const upload = getUpload(params.uploadId)
+      upload.committing = true
+      clearTimeout(upload.ttlTimer)
       try {
-        if (upload.receivedBase64Length !== upload.expectedBase64Length) {
+        if (upload.content.length !== upload.expectedBase64Length) {
           throw new Error('Clipboard image upload is incomplete')
         }
-        const contentBase64 = upload.chunks.join('')
-        assertValidBase64Content(contentBase64)
-        return await saveClipboardImageBufferAsTempFile(Buffer.from(contentBase64, 'base64'), {
+        const content = upload.content.decode()
+        upload.content.clear()
+        return await saveClipboardImageBufferAsTempFile(content, {
           connectionId: upload.connectionId
         })
       } finally {
-        // Why: failed SSH or filesystem commits must not leave bounded upload
-        // memory pinned until TTL cleanup.
-        deleteUpload(params.uploadId)
+        finishUpload(params.uploadId, upload)
       }
     }
   }),
@@ -206,7 +245,12 @@ export const CLIPBOARD_METHODS: RpcMethod[] = [
 ]
 
 export function resetClipboardImageUploadsForTest(): void {
-  for (const uploadId of clipboardImageUploads.keys()) {
-    deleteUpload(uploadId)
+  for (const [uploadId, upload] of clipboardImageUploads) {
+    finishUpload(uploadId, upload)
   }
+  retainedClipboardImageUploadBase64Chars = 0
+}
+
+export function getRetainedClipboardImageUploadBase64CharsForTest(): number {
+  return retainedClipboardImageUploadBase64Chars
 }

--- a/src/main/runtime/rpc/methods/orchestration-gates.ts
+++ b/src/main/runtime/rpc/methods/orchestration-gates.ts
@@ -3,6 +3,10 @@ import { defineMethod, type RpcMethod } from '../core'
 import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
 import type { GateStatus } from '../../orchestration/db'
 import { Coordinator } from '../../orchestration/coordinator'
+import {
+  assertOrchestrationStringListFits,
+  assertOrchestrationWriteFits
+} from '../../orchestration/query-retention'
 
 // Why: the coordinator instance is stored at module scope so orchestration.runStop
 // can signal it to halt. Only one coordinator can run at a time (enforced by
@@ -108,10 +112,12 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
       let options: string[] | undefined
       if (params.options) {
         try {
+          assertOrchestrationWriteFits('Decision gate options', [params.options])
           const parsed = JSON.parse(params.options)
           if (!Array.isArray(parsed) || !parsed.every((option) => typeof option === 'string')) {
             throw new Error('not an array of strings')
           }
+          assertOrchestrationStringListFits('Decision gate options', parsed)
           options = parsed
         } catch {
           throw new Error('Invalid --options: must be a JSON array of strings')
@@ -144,11 +150,17 @@ export const ORCHESTRATION_GATE_METHODS: RpcMethod[] = [
     params: GateListParams,
     handler: (params, { runtime }) => {
       const db = runtime.getOrchestrationDb()
-      const gates = db.listGates({
+      const filter = {
         taskId: params.task,
         status: params.status as GateStatus
-      })
-      return { gates, count: gates.length }
+      }
+      const gates = db.listGates(filter)
+      const total = db.countGates(filter)
+      return {
+        gates,
+        count: gates.length,
+        ...(total > gates.length ? { total, truncated: true as const } : {})
+      }
     }
   })
 ]

--- a/src/main/runtime/rpc/methods/orchestration-query-retention.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-query-retention.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type Database from '../../../sqlite/sync-database'
+import { OrchestrationDb } from '../../orchestration/db'
+import {
+  ORCHESTRATION_QUERY_MAX_ROWS,
+  ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES,
+  ORCHESTRATION_WAIT_TYPE_FILTER_MAX_UTF8_BYTES
+} from '../../orchestration/query-retention'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcContext } from '../core'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+function sqliteFor(db: OrchestrationDb): Database.Database {
+  return (db as unknown as { db: Database.Database }).db
+}
+
+describe('orchestration RPC query retention', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  async function call(name: string, params: Record<string, unknown>): Promise<unknown> {
+    db ??= new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    return callWithRuntime(runtime, name, params)
+  }
+
+  async function callWithRuntime(
+    runtime: OrcaRuntimeService,
+    name: string,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const ctx: RpcContext = { runtime }
+    const method = ORCHESTRATION_METHODS.find((candidate) => candidate.name === name)
+    if (!method) {
+      throw new Error(`Method not found: ${name}`)
+    }
+    const parsed = method.params ? method.params.parse(params) : undefined
+    return method.handler(parsed, ctx)
+  }
+
+  function createDb(): OrchestrationDb {
+    db = new OrchestrationDb(':memory:')
+    return db
+  }
+
+  it('reports remaining unread messages while successive checks drain the queue', async () => {
+    const d = createDb()
+    for (let index = 0; index < ORCHESTRATION_QUERY_MAX_ROWS + 1; index += 1) {
+      d.insertMessage({ from: 'sender', to: 'worker', subject: `message-${index}` })
+    }
+
+    const first = (await call('orchestration.check', { terminal: 'worker' })) as {
+      count: number
+      truncated?: boolean
+      remaining?: number
+    }
+    expect(first).toMatchObject({
+      count: ORCHESTRATION_QUERY_MAX_ROWS,
+      truncated: true,
+      remaining: 1
+    })
+
+    const second = (await call('orchestration.check', { terminal: 'worker' })) as {
+      count: number
+      truncated?: boolean
+    }
+    expect(second).toMatchObject({ count: 1 })
+    expect(second.truncated).toBeUndefined()
+  })
+
+  it('returns truncation instead of waiting forever on an oversized legacy row', async () => {
+    const d = createDb()
+    sqliteFor(d)
+      .prepare(
+        `INSERT INTO messages (id, from_handle, to_handle, subject, body)
+         VALUES ('msg_oversized', 'sender', 'worker', 'oversized', ?)`
+      )
+      .run('x'.repeat(ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES + 1))
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(d)
+    const waitForMessage = vi.spyOn(runtime, 'waitForMessage')
+
+    const result = await callWithRuntime(runtime, 'orchestration.check', {
+      terminal: 'worker',
+      wait: true,
+      timeoutMs: 60_000
+    })
+
+    expect(result).toMatchObject({
+      count: 0,
+      truncated: true,
+      remaining: 1
+    })
+    expect(waitForMessage).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized waiting type filters before retaining the request', async () => {
+    const d = createDb()
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(d)
+    const waitForMessage = vi.spyOn(runtime, 'waitForMessage')
+    const types = 'status,'.repeat(
+      Math.ceil(ORCHESTRATION_WAIT_TYPE_FILTER_MAX_UTF8_BYTES / 'status,'.length) + 1
+    )
+
+    await expect(
+      callWithRuntime(runtime, 'orchestration.check', {
+        terminal: 'worker',
+        wait: true,
+        types
+      })
+    ).rejects.toThrow(
+      `${ORCHESTRATION_WAIT_TYPE_FILTER_MAX_UTF8_BYTES}-byte orchestration wait limit`
+    )
+    expect(waitForMessage).not.toHaveBeenCalled()
+  })
+
+  it('preserves normal waiting type filters while removing duplicate retention', async () => {
+    const d = createDb()
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(d)
+    const waitForMessage = vi.spyOn(runtime, 'waitForMessage').mockResolvedValue()
+
+    await expect(
+      callWithRuntime(runtime, 'orchestration.check', {
+        terminal: 'worker',
+        wait: true,
+        timeoutMs: 100,
+        types: 'status,status,worker_done,escalation,decision_gate'
+      })
+    ).resolves.toMatchObject({ count: 0, messages: [] })
+    expect(waitForMessage).toHaveBeenCalledWith('worker', {
+      typeFilter: ['status', 'worker_done', 'escalation', 'decision_gate'],
+      timeoutMs: 100,
+      signal: undefined
+    })
+  })
+
+  it('reports exact totals when task and gate lists are capped', async () => {
+    const d = createDb()
+    const task = d.createTask({ spec: 'gated' })
+    for (let index = 0; index < ORCHESTRATION_QUERY_MAX_ROWS + 1; index += 1) {
+      d.createTask({ spec: `task-${index}` })
+      d.createGate({ taskId: task.id, question: `question-${index}` })
+    }
+
+    const tasks = (await call('orchestration.taskList', {})) as {
+      count: number
+      total?: number
+      truncated?: boolean
+    }
+    expect(tasks).toMatchObject({
+      count: ORCHESTRATION_QUERY_MAX_ROWS,
+      total: ORCHESTRATION_QUERY_MAX_ROWS + 2,
+      truncated: true
+    })
+
+    const gates = (await call('orchestration.gateList', {})) as {
+      count: number
+      total?: number
+      truncated?: boolean
+    }
+    expect(gates).toMatchObject({
+      count: ORCHESTRATION_QUERY_MAX_ROWS,
+      total: ORCHESTRATION_QUERY_MAX_ROWS + 1,
+      truncated: true
+    })
+  })
+
+  it('reports the exact inbox total when a requested page omits rows', async () => {
+    const d = createDb()
+    d.insertMessage({ from: 'a', to: 'b', subject: 'one' })
+    d.insertMessage({ from: 'a', to: 'b', subject: 'two' })
+
+    await expect(call('orchestration.inbox', { limit: 1 })).resolves.toMatchObject({
+      count: 1,
+      total: 2,
+      truncated: true
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -7,6 +7,11 @@ import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { formatMessageBanner } from '../../orchestration/formatter'
 import { isGroupAddress, resolveGroupAddress } from '../../orchestration/groups'
 import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import {
+  assertOrchestrationStringListFits,
+  assertOrchestrationWaitTypeFilterFits,
+  assertOrchestrationWriteFits
+} from '../../orchestration/query-retention'
 import { abbreviateOrchestrationTasks } from '../../../../shared/orchestration-task-summary'
 import { ORCHESTRATION_GATE_METHODS } from './orchestration-gates'
 
@@ -20,6 +25,21 @@ const MESSAGE_TYPES: MessageType[] = [
   'decision_gate',
   'heartbeat'
 ]
+
+function parseMessageTypeFilter(types: string | undefined): MessageType[] | undefined {
+  if (!types) {
+    return undefined
+  }
+  const parsed = types
+    .split(',')
+    .map((type) => type.trim())
+    .filter(Boolean) as MessageType[]
+  const invalidTypes = parsed.filter((type) => !MESSAGE_TYPES.includes(type))
+  if (invalidTypes.length > 0) {
+    throw new Error(`Invalid --types: ${invalidTypes.join(',')}`)
+  }
+  return Array.from(new Set(parsed))
+}
 
 const TASK_STATUSES: TaskStatus[] = [
   'pending',
@@ -272,22 +292,20 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     handler: async (params, { runtime, signal }) => {
       const db = runtime.getOrchestrationDb()
       const handle = params.terminal ?? 'unknown'
-      const typeFilter = params.types
-        ? (params.types
-            .split(',')
-            .map((t) => t.trim())
-            .filter(Boolean) as MessageType[])
-        : undefined
-      const invalidTypes = typeFilter?.filter((t) => !MESSAGE_TYPES.includes(t))
-      if (invalidTypes && invalidTypes.length > 0) {
-        throw new Error(`Invalid --types: ${invalidTypes.join(',')}`)
+      if (params.wait) {
+        assertOrchestrationWaitTypeFilterFits(params.types)
       }
+      assertOrchestrationWriteFits('Message type filter', [params.types])
+      const typeFilter = parseMessageTypeFilter(params.types)
 
       // Why: unread:false is honored for one release as a compat shim so in-flight callers don't break (design doc §5).
       const showAll = params.all === true || (params.unread === false && params.peek !== true)
       const consumeUnread = !showAll && params.peek !== true
 
       const readAndReturn = () => {
+        const totalBeforeRead = showAll
+          ? db.countAllMessagesForHandle(handle, typeFilter)
+          : db.countUnreadMessages(handle, typeFilter)
         const messages = showAll
           ? db.getAllMessagesForHandle(handle, undefined, typeFilter)
           : db.getUnreadMessages(handle, typeFilter)
@@ -304,19 +322,28 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           db.markAsRead(messages.map((m) => m.id))
         }
 
+        const remaining = consumeUnread
+          ? db.countUnreadMessages(handle, typeFilter)
+          : Math.max(0, totalBeforeRead - messages.length)
+        const saturation = remaining > 0 ? { truncated: true as const, remaining } : {}
         if (params.inject) {
           const formatted = visibleMessages.map(formatMessageBanner).join('\n\n')
-          return { messages: visibleMessages, formatted, count: visibleMessages.length }
+          return {
+            messages: visibleMessages,
+            formatted,
+            count: visibleMessages.length,
+            ...saturation
+          }
         }
 
-        return { messages: visibleMessages, count: visibleMessages.length }
+        return { messages: visibleMessages, count: visibleMessages.length, ...saturation }
       }
 
       if (signal?.aborted) {
         return { messages: [], count: 0 }
       }
       const result = readAndReturn()
-      if (result.count > 0 || !params.wait) {
+      if (result.count > 0 || result.truncated || !params.wait) {
         return result
       }
 
@@ -367,7 +394,14 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       const messages = params.terminal
         ? db.getAllMessagesForHandle(params.terminal, params.limit)
         : db.getInbox(params.limit)
-      return { messages, count: messages.length }
+      const total = params.terminal
+        ? db.countAllMessagesForHandle(params.terminal)
+        : db.countInbox()
+      return {
+        messages,
+        count: messages.length,
+        ...(total > messages.length ? { total, truncated: true as const } : {})
+      }
     }
   }),
 
@@ -379,10 +413,12 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       let deps: string[] | undefined
       if (params.deps) {
         try {
+          assertOrchestrationWriteFits('Task dependencies', [params.deps])
           const parsed = JSON.parse(params.deps)
           if (!Array.isArray(parsed) || !parsed.every((d) => typeof d === 'string')) {
             throw new Error('not an array of strings')
           }
+          assertOrchestrationStringListFits('Task dependencies', parsed)
           deps = parsed
         } catch {
           throw new Error('Invalid --deps: must be a JSON array of task IDs')
@@ -405,11 +441,12 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
     params: TaskListParams,
     handler: (params, { runtime }) => {
       const db = runtime.getOrchestrationDb()
-      // Why: listTasksWithDispatch adds assignee_handle + dispatch_id (NULL for non-dispatched), so legacy-shape consumers are unaffected.
-      const joined = db.listTasksWithDispatch({
+      const filter = {
         status: params.status as TaskStatus,
         ready: params.ready
-      })
+      }
+      // Why: listTasksWithDispatch adds assignee_handle + dispatch_id (NULL for non-dispatched), so legacy-shape consumers are unaffected.
+      const joined = db.listTasksWithDispatch(filter)
       const tasks = joined.map((row) => {
         const { assignee_handle, dispatch_id, ...base } = row
         if (base.status === 'dispatched') {
@@ -417,9 +454,11 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         }
         return base
       })
+      const total = db.countTasks(filter)
       return {
         tasks: params.brief ? abbreviateOrchestrationTasks(tasks) : tasks,
-        count: tasks.length
+        count: tasks.length,
+        ...(total > tasks.length ? { total, truncated: true as const } : {})
       }
     }
   }),
@@ -568,11 +607,13 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       const db = runtime.getOrchestrationDb()
       const from = params.from ?? 'unknown'
       const timeoutMs = params.timeoutMs ?? 600_000
+      assertOrchestrationWriteFits('Decision gate options', [params.options])
       const options =
         params.options
           ?.split(',')
           .map((s) => s.trim())
           .filter(Boolean) ?? []
+      assertOrchestrationStringListFits('Decision gate options', options)
 
       const payload = JSON.stringify({ question: params.question, options })
       const outbound = db.insertMessage({

--- a/src/main/runtime/rpc/methods/terminal.ts
+++ b/src/main/runtime/rpc/methods/terminal.ts
@@ -53,6 +53,7 @@ import {
   TERMINAL_STREAM_CHUNK_BYTES
 } from '../../../../shared/terminal-multiplex-flow-control'
 import { drainTerminalMultiplexRoundRobin } from '../terminal-multiplex-round-robin'
+import { appendCompactedStringChunk } from '../../../../shared/string-chunk-compaction'
 
 const REQUESTED_SNAPSHOT_BYTE_BUDGET = 2 * 1024 * 1024
 const TERMINAL_OUTPUT_FLUSH_MS = 5
@@ -208,7 +209,7 @@ function createTerminalOutputBatcher(onFlush: (data: string, meta?: TerminalOutp
         flush()
         pendingCwd = meta.cwd
       }
-      chunks.push(data)
+      appendCompactedStringChunk(chunks, data)
       pendingRawLength += rawLength
       const remainingBudget = Math.max(1, TERMINAL_OUTPUT_BATCH_MAX_BYTES - bytes)
       const measurement = measureTerminalStreamByteLength(data, {

--- a/src/main/runtime/rpc/runtime-rpc-response-serialization.ts
+++ b/src/main/runtime/rpc/runtime-rpc-response-serialization.ts
@@ -1,0 +1,45 @@
+import {
+  JsonStringifyByteLimitError,
+  stringifyJsonWithinByteLimit
+} from '../../../shared/node-bounded-json-stringify'
+import { REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES } from '../../../shared/remote-runtime-memory-limits'
+import type { RpcResponse } from './core'
+import { errorResponse } from './errors'
+
+const RESPONSE_TOO_LARGE_MESSAGE = `RPC response exceeds ${REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES} bytes`
+
+export function boundRuntimeRpcResponse(response: RpcResponse): RpcResponse {
+  try {
+    serializeWithinLimit(response)
+    return response
+  } catch (error) {
+    if (error instanceof JsonStringifyByteLimitError) {
+      return responseTooLargeError(response)
+    }
+    throw error
+  }
+}
+
+export function serializeRuntimeRpcResponse(response: RpcResponse): string {
+  try {
+    return serializeWithinLimit(response)
+  } catch (error) {
+    if (error instanceof JsonStringifyByteLimitError) {
+      return serializeWithinLimit(responseTooLargeError(response))
+    }
+    throw error
+  }
+}
+
+function serializeWithinLimit(response: RpcResponse): string {
+  return stringifyJsonWithinByteLimit(response, REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES).serialized
+}
+
+function responseTooLargeError(response: RpcResponse): RpcResponse {
+  return errorResponse(
+    response.id,
+    response._meta,
+    'response_too_large',
+    RESPONSE_TOO_LARGE_MESSAGE
+  )
+}

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -63,7 +63,7 @@ describe('UnixSocketTransport', () => {
     ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
       socket as unknown as Socket
     )
-    socket.emit('data', '{"id":"pending","method":"wait"}\n')
+    socket.emit('data', Buffer.from('{"id":"pending","method":"wait"}\n'))
 
     vi.advanceTimersByTime(100)
     expect(socket.writes).toHaveLength(1)
@@ -73,5 +73,27 @@ describe('UnixSocketTransport', () => {
 
     vi.advanceTimersByTime(500)
     expect(socket.writes).toHaveLength(1)
+  })
+
+  it('parses a request delivered as 100,000 one-byte fragments', () => {
+    const transport = new UnixSocketTransport({
+      endpoint: '/tmp/orca-runtime-rpc-test.sock',
+      kind: 'unix'
+    })
+    const socket = new FakeSocket()
+    let received = ''
+    transport.onMessage((message) => {
+      received = message
+    })
+    ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
+      socket as unknown as Socket
+    )
+
+    const request = Buffer.from(`${' '.repeat(99_960)}{"id":"tiny","method":"status"}\n`)
+    for (let index = 0; index < request.byteLength; index += 1) {
+      socket.emit('data', request.subarray(index, index + 1))
+    }
+
+    expect(received).toBe('{"id":"tiny","method":"status"}')
   })
 })

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -6,6 +6,7 @@
 // away. See design doc §3.1.
 import { createServer, type Server, type Socket } from 'node:net'
 import { chmodSync, existsSync, rmSync } from 'node:fs'
+import { GrowingByteBuffer } from '../../../shared/growing-byte-buffer'
 import type { RpcMessageContext, RpcTransport } from './transport'
 
 const MAX_RUNTIME_RPC_MESSAGE_BYTES = 1024 * 1024
@@ -104,7 +105,7 @@ export class UnixSocketTransport implements RpcTransport {
 
   private handleConnection(socket: Socket): void {
     this.activeSockets.add(socket)
-    let buffer = ''
+    const buffer = new GrowingByteBuffer()
     let oversized = false
     // Why: each in-flight dispatch registers its own AbortController here so
     // `socket.on('close')` can abort them all at once. Keeping the set scoped
@@ -114,7 +115,6 @@ export class UnixSocketTransport implements RpcTransport {
     // multiplexes sequential requests.
     const inflight = new Set<() => void>()
 
-    socket.setEncoding('utf8')
     socket.setNoDelay(true)
     socket.setTimeout(RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS, () => {
       socket.destroy()
@@ -129,30 +129,31 @@ export class UnixSocketTransport implements RpcTransport {
       inflight.clear()
       this.activeSockets.delete(socket)
     })
-    socket.on('data', (chunk: string) => {
+    socket.on('data', (chunk: Buffer) => {
       if (oversized) {
         return
       }
-      buffer += chunk
+      buffer.append(chunk)
       // Why: the Orca runtime lives in Electron main, so it must reject
       // oversized local RPC frames instead of letting a local client grow an
       // unbounded buffer and stall the app.
-      if (Buffer.byteLength(buffer, 'utf8') > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
+      if (buffer.byteLength > MAX_RUNTIME_RPC_MESSAGE_BYTES) {
         oversized = true
+        buffer.clear()
         this.messageHandler?.('', (response) => {
           socket.write(`${response}\n`)
           socket.end()
         })
         return
       }
-      let newlineIndex = buffer.indexOf('\n')
+      let newlineIndex = buffer.indexOfByte(0x0a)
       while (newlineIndex !== -1) {
-        const rawMessage = buffer.slice(0, newlineIndex).trim()
-        buffer = buffer.slice(newlineIndex + 1)
+        const rawMessage = buffer.takePrefixString(newlineIndex).trim()
+        buffer.discardPrefix(1)
         if (rawMessage) {
           this.dispatchMessage(socket, rawMessage, inflight)
         }
-        newlineIndex = buffer.indexOf('\n')
+        newlineIndex = buffer.indexOfByte(0x0a)
       }
     })
   }

--- a/src/main/runtime/rpc/ws-fallback-port-store.test.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.test.ts
@@ -1,8 +1,12 @@
-import { mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { readWsFallbackPort, writeWsFallbackPort } from './ws-fallback-port-store'
+import {
+  MAX_FALLBACK_PORT_FILE_BYTES,
+  readWsFallbackPort,
+  writeWsFallbackPort
+} from './ws-fallback-port-store'
 
 function makeUserDataPath(): string {
   return mkdtempSync(join(tmpdir(), 'ws-fallback-port-test-'))
@@ -30,6 +34,15 @@ describe('ws-fallback-port-store', () => {
     const userDataPath = makeUserDataPath()
     writeWsFallbackPort(userDataPath, 0)
     writeWsFallbackPort(userDataPath, 70000)
+    expect(readWsFallbackPort(userDataPath)).toBeUndefined()
+  })
+
+  it('ignores an oversized sparse fallback-port file', () => {
+    const userDataPath = makeUserDataPath()
+    const path = join(userDataPath, 'mobile-ws-fallback-port.json')
+    writeFileSync(path, '{"port":54321}', 'utf8')
+    truncateSync(path, MAX_FALLBACK_PORT_FILE_BYTES + 1)
+
     expect(readWsFallbackPort(userDataPath)).toBeUndefined()
   })
 })

--- a/src/main/runtime/rpc/ws-fallback-port-store.ts
+++ b/src/main/runtime/rpc/ws-fallback-port-store.ts
@@ -1,5 +1,6 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import { writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { readNodeFileSyncWithinLimit } from '../../../shared/node-bounded-file-reader'
 
 // Why: when the preferred WS port is taken (second Orca instance), the OS
 // assigns a random port. Paired mobile devices store ws://ip:port endpoints,
@@ -10,6 +11,7 @@ import { join } from 'node:path'
 // again.
 
 const FALLBACK_PORT_FILE = 'mobile-ws-fallback-port.json'
+export const MAX_FALLBACK_PORT_FILE_BYTES = 1024
 
 function isValidPort(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= 65535
@@ -17,7 +19,10 @@ function isValidPort(value: unknown): value is number {
 
 export function readWsFallbackPort(userDataPath: string): number | undefined {
   try {
-    const raw = readFileSync(join(userDataPath, FALLBACK_PORT_FILE), 'utf8')
+    const raw = readNodeFileSyncWithinLimit(
+      join(userDataPath, FALLBACK_PORT_FILE),
+      MAX_FALLBACK_PORT_FILE_BYTES
+    ).buffer.toString('utf8')
     const parsed: unknown = JSON.parse(raw)
     if (
       typeof parsed === 'object' &&

--- a/src/main/runtime/runtime-control-file-bounds.test.ts
+++ b/src/main/runtime/runtime-control-file-bounds.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NodeFileReadTooLargeError } from '../../shared/node-bounded-file-reader'
+import {
+  getRuntimeMetadataPath,
+  MAX_RUNTIME_METADATA_FILE_BYTES,
+  MAX_RUNTIME_METADATA_JSON_STRUCTURAL_TOKENS
+} from '../../shared/runtime-bootstrap'
+import {
+  DeviceRegistry,
+  DeviceRegistryCapacityError,
+  MAX_DEVICE_REGISTRY_FILE_BYTES
+} from './device-registry'
+import {
+  loadOrCreateE2EEKeypair,
+  MAX_KEYPAIR_FILE_BYTES,
+  MAX_KEYPAIR_JSON_STRUCTURAL_TOKENS
+} from './e2ee-keypair'
+import { readRuntimeMetadata, writeRuntimeMetadata } from './runtime-metadata'
+
+describe('runtime control-file bounds', () => {
+  const paths: string[] = []
+
+  afterEach(() => {
+    for (const path of paths.splice(0)) {
+      rmSync(path, { recursive: true, force: true })
+    }
+  })
+
+  function makeUserDataPath(prefix: string): string {
+    const path = mkdtempSync(join(tmpdir(), prefix))
+    paths.push(path)
+    return path
+  }
+
+  it('rejects oversized runtime metadata before parsing it', () => {
+    const userDataPath = makeUserDataPath('orca-runtime-metadata-bound-')
+    const metadataPath = getRuntimeMetadataPath(userDataPath)
+    writeFileSync(metadataPath, '{"runtimeId":"runtime-1"}')
+    truncateSync(metadataPath, MAX_RUNTIME_METADATA_FILE_BYTES + 1)
+
+    expect(() => readRuntimeMetadata(userDataPath)).toThrow(NodeFileReadTooLargeError)
+  })
+
+  it('rejects structurally amplified runtime metadata before parsing it', () => {
+    const userDataPath = makeUserDataPath('orca-runtime-metadata-structure-')
+    const metadataPath = getRuntimeMetadataPath(userDataPath)
+    writeFileSync(
+      metadataPath,
+      `{"transports":[${'0,'.repeat(MAX_RUNTIME_METADATA_JSON_STRUCTURAL_TOKENS)}0]}`
+    )
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    expect(() => readRuntimeMetadata(userDataPath)).toThrow('JSON structure exceeds')
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves prior runtime metadata when serialization exceeds its read ceiling', () => {
+    const userDataPath = makeUserDataPath('orca-runtime-metadata-write-')
+    const metadataPath = getRuntimeMetadataPath(userDataPath)
+    const initial = {
+      runtimeId: 'runtime-1',
+      pid: 42,
+      transports: [],
+      authToken: 'token',
+      startedAt: 1
+    }
+    writeRuntimeMetadata(userDataPath, initial)
+    const before = readFileSync(metadataPath, 'utf8')
+
+    expect(() =>
+      writeRuntimeMetadata(userDataPath, {
+        ...initial,
+        transports: [{ kind: 'unix', endpoint: 'x'.repeat(MAX_RUNTIME_METADATA_FILE_BYTES) }]
+      })
+    ).toThrow('JSON output exceeds')
+    expect(readFileSync(metadataPath, 'utf8')).toBe(before)
+  })
+
+  it('treats an oversized device registry as unavailable', () => {
+    const userDataPath = makeUserDataPath('orca-device-registry-bound-')
+    const registryPath = join(userDataPath, 'orca-devices.json')
+    writeFileSync(registryPath, '[]')
+    truncateSync(registryPath, MAX_DEVICE_REGISTRY_FILE_BYTES + 1)
+
+    expect(new DeviceRegistry(userDataPath).listDevices()).toEqual([])
+  })
+
+  it('rejects a byte-oversized device without publishing a partial credential', () => {
+    const userDataPath = makeUserDataPath('orca-device-registry-write-bound-')
+    const registry = new DeviceRegistry(userDataPath)
+
+    expect(() => registry.addDevice('x'.repeat(MAX_DEVICE_REGISTRY_FILE_BYTES), 'mobile')).toThrow(
+      DeviceRegistryCapacityError
+    )
+    expect(registry.listDevices()).toEqual([])
+    expect(new DeviceRegistry(userDataPath).listDevices()).toEqual([])
+  })
+
+  it('regenerates an oversized E2EE keypair without loading it', () => {
+    const userDataPath = makeUserDataPath('orca-keypair-bound-')
+    const keypairPath = join(userDataPath, 'orca-e2ee-keypair.json')
+    writeFileSync(keypairPath, '{"v":1}')
+    truncateSync(keypairPath, MAX_KEYPAIR_FILE_BYTES + 1)
+
+    expect(loadOrCreateE2EEKeypair(userDataPath).publicKey).toHaveLength(32)
+    expect(statSync(keypairPath).size).toBeLessThan(MAX_KEYPAIR_FILE_BYTES)
+  })
+
+  it('regenerates a structurally amplified E2EE keypair before parsing it', () => {
+    const userDataPath = makeUserDataPath('orca-keypair-structure-')
+    const keypairPath = join(userDataPath, 'orca-e2ee-keypair.json')
+    writeFileSync(keypairPath, `{"padding":[${'0,'.repeat(MAX_KEYPAIR_JSON_STRUCTURAL_TOKENS)}0]}`)
+    const parseSpy = vi.spyOn(JSON, 'parse')
+
+    expect(loadOrCreateE2EEKeypair(userDataPath).publicKey).toHaveLength(32)
+    expect(parseSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/runtime-file-watcher-admission.test.ts
+++ b/src/main/runtime/runtime-file-watcher-admission.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RUNTIME_FILE_WATCHER_MAX_LEASES,
+  RUNTIME_FILE_WATCHER_MAX_PATH_BYTES,
+  RuntimeFileWatcherAdmission
+} from './runtime-file-watcher-admission'
+
+describe('runtime file watcher admission', () => {
+  it('caps pending and active leases, then recovers after release', () => {
+    const admission = new RuntimeFileWatcherAdmission()
+    const releases = Array.from({ length: RUNTIME_FILE_WATCHER_MAX_LEASES }, (_, index) =>
+      admission.claim('runtime-a', index % 2 === 0 ? 'ssh-a' : undefined, `/repo-${index}`)
+    )
+
+    expect(admission.evidence().leases).toBe(RUNTIME_FILE_WATCHER_MAX_LEASES)
+    expect(() => admission.claim('runtime-a', undefined, '/overflow')).toThrow('capacity reached')
+
+    releases[0]?.()
+    releases[0]?.()
+    expect(() => admission.claim('runtime-a', undefined, '/recovered')).not.toThrow()
+  })
+
+  it('bounds multibyte roots before retaining a lease', () => {
+    const admission = new RuntimeFileWatcherAdmission()
+    const exact = 'é'.repeat(RUNTIME_FILE_WATCHER_MAX_PATH_BYTES / 2)
+
+    expect(() => admission.claim('runtime-a', 'ssh-a', exact)).not.toThrow()
+    expect(() => admission.claim('runtime-a', 'ssh-a', `${exact}x`)).toThrow(
+      `exceeds ${RUNTIME_FILE_WATCHER_MAX_PATH_BYTES} UTF-8 bytes`
+    )
+    expect(admission.evidence().leases).toBe(1)
+  })
+})

--- a/src/main/runtime/runtime-file-watcher-admission.ts
+++ b/src/main/runtime/runtime-file-watcher-admission.ts
@@ -1,0 +1,53 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export const RUNTIME_FILE_WATCHER_MAX_LEASES = 256
+export const RUNTIME_FILE_WATCHER_MAX_RETAINED_IDENTITY_BYTES = 16 * 1024 * 1024
+export const RUNTIME_FILE_WATCHER_MAX_PATH_BYTES = 64 * 1024
+const RUNTIME_FILE_WATCHER_MAX_OWNER_ID_BYTES = 8 * 1024
+
+export class RuntimeFileWatcherAdmission {
+  private leases = 0
+  private retainedBytes = 0
+
+  claim(runtimeId: string, connectionId: string | undefined, rootPath: string): () => void {
+    const identityBytes =
+      boundedIdentityBytes(runtimeId, RUNTIME_FILE_WATCHER_MAX_OWNER_ID_BYTES, 'runtime id') +
+      boundedIdentityBytes(rootPath, RUNTIME_FILE_WATCHER_MAX_PATH_BYTES, 'root path') +
+      (connectionId
+        ? boundedIdentityBytes(
+            connectionId,
+            RUNTIME_FILE_WATCHER_MAX_OWNER_ID_BYTES,
+            'connection id'
+          )
+        : 0)
+    if (
+      this.leases >= RUNTIME_FILE_WATCHER_MAX_LEASES ||
+      this.retainedBytes + identityBytes > RUNTIME_FILE_WATCHER_MAX_RETAINED_IDENTITY_BYTES
+    ) {
+      throw new Error('Runtime file watcher capacity reached; close an existing watch and retry.')
+    }
+    this.leases += 1
+    this.retainedBytes += identityBytes
+    let claimed = true
+    return () => {
+      if (!claimed) {
+        return
+      }
+      claimed = false
+      this.leases -= 1
+      this.retainedBytes -= identityBytes
+    }
+  }
+
+  evidence(): { leases: number; retainedBytes: number } {
+    return { leases: this.leases, retainedBytes: this.retainedBytes }
+  }
+}
+
+function boundedIdentityBytes(value: string, limit: number, field: string): number {
+  const measured = measureUtf8ByteLength(value, { stopAfterBytes: limit })
+  if (measured.exceededLimit) {
+    throw new Error(`Runtime file watcher ${field} exceeds ${limit} UTF-8 bytes.`)
+  }
+  return measured.byteLength
+}

--- a/src/main/runtime/runtime-metadata.ts
+++ b/src/main/runtime/runtime-metadata.ts
@@ -1,6 +1,13 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs'
-import { getRuntimeMetadataPath, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
-import { writeSecureJsonFile } from '../../shared/secure-file'
+import { existsSync, rmSync } from 'node:fs'
+import { readNodeFileSyncWithinLimit } from '../../shared/node-bounded-file-reader'
+import {
+  getRuntimeMetadataPath,
+  MAX_RUNTIME_METADATA_FILE_BYTES,
+  parseRuntimeMetadataJson,
+  type RuntimeMetadata
+} from '../../shared/runtime-bootstrap'
+import { stringifyJsonWithinByteLimit } from '../../shared/node-bounded-json-stringify'
+import { writeSecureFile } from '../../shared/secure-file'
 
 export function writeRuntimeMetadata(userDataPath: string, metadata: RuntimeMetadata): void {
   const metadataPath = getRuntimeMetadataPath(userDataPath)
@@ -12,7 +19,11 @@ export function readRuntimeMetadata(userDataPath: string): RuntimeMetadata | nul
   if (!existsSync(metadataPath)) {
     return null
   }
-  return JSON.parse(readFileSync(metadataPath, 'utf-8')) as RuntimeMetadata
+  return parseRuntimeMetadataJson(
+    readNodeFileSyncWithinLimit(metadataPath, MAX_RUNTIME_METADATA_FILE_BYTES).buffer.toString(
+      'utf8'
+    )
+  )
 }
 
 export function clearRuntimeMetadata(userDataPath: string): void {
@@ -52,5 +63,6 @@ export function clearRuntimeMetadataIfOwned(
 }
 
 function writeMetadataFile(path: string, metadata: RuntimeMetadata): void {
-  writeSecureJsonFile(path, metadata)
+  const { serialized } = stringifyJsonWithinByteLimit(metadata, MAX_RUNTIME_METADATA_FILE_BYTES, 2)
+  writeSecureFile(path, serialized)
 }

--- a/src/main/runtime/runtime-mobile-file-path-search.test.ts
+++ b/src/main/runtime/runtime-mobile-file-path-search.test.ts
@@ -95,4 +95,21 @@ describe('RuntimeMobileFilePathSearchCache', () => {
       vi.useRealTimers()
     }
   })
+
+  it('rejects distinct scans beyond the in-flight cache bound', async () => {
+    const cache = new RuntimeMobileFilePathSearchCache(2, 100)
+    const loads: ((value: RuntimeMobileFilePathInventory) => void)[] = []
+    const load = () =>
+      new Promise<RuntimeMobileFilePathInventory>((resolve) => {
+        loads.push(resolve)
+      })
+    const first = cache.get('a', load)
+    const second = cache.get('b', load)
+
+    await expect(cache.get('c', load)).rejects.toThrow('search is busy')
+
+    const inventory = { paths: [], totalCount: 0, truncated: false }
+    loads.forEach((resolve) => resolve(inventory))
+    await expect(Promise.all([first, second])).resolves.toEqual([inventory, inventory])
+  })
 })

--- a/src/main/runtime/runtime-mobile-file-path-search.ts
+++ b/src/main/runtime/runtime-mobile-file-path-search.ts
@@ -34,6 +34,9 @@ export class RuntimeMobileFilePathSearchCache {
     if (pending) {
       return pending
     }
+    if (this.inFlight.size >= this.maxEntries) {
+      throw new Error('Mobile file path search is busy; retry after current searches finish.')
+    }
     const next = load()
       .then((loaded) => {
         // Why: a slow SSH scan should receive a full TTL after it becomes usable,

--- a/src/main/runtime/runtime-operation-generations.test.ts
+++ b/src/main/runtime/runtime-operation-generations.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_RUNTIME_OPERATION_GENERATIONS,
+  MAX_RUNTIME_OPERATION_GENERATION_KEY_BYTES,
+  MAX_RUNTIME_OPERATION_GENERATION_RETAINED_KEY_BYTES,
+  RuntimeOperationGenerations
+} from './runtime-operation-generations'
+
+const BOUNDS = {
+  maxEntries: 2,
+  maxKeyBytes: 4,
+  maxRetainedKeyBytes: 6
+}
+
+describe('RuntimeOperationGenerations', () => {
+  it('keeps a stable generation until the operation advances', () => {
+    const generations = new RuntimeOperationGenerations(BOUNDS)
+    const initial = generations.current('a')
+
+    expect(generations.current('a')).toBe(initial)
+    expect(generations.advance('a')).not.toBe(initial)
+    expect(generations.isCurrent('a', initial)).toBe(false)
+  })
+
+  it('evicts least-recently-used keys and fails closed for stale captures', () => {
+    const generations = new RuntimeOperationGenerations(BOUNDS)
+    const first = generations.current('a')
+    const evicted = generations.current('b')
+    generations.current('a')
+    const latest = generations.current('cc')
+
+    expect(generations.isCurrent('a', first)).toBe(true)
+    expect(generations.isCurrent('b', evicted)).toBe(false)
+    expect(generations.isCurrent('cc', latest)).toBe(true)
+    expect(generations.evidence()).toEqual({ entries: 2, retainedKeyBytes: 3 })
+  })
+
+  it('bounds aggregate retained key bytes', () => {
+    const generations = new RuntimeOperationGenerations({
+      maxEntries: 3,
+      maxKeyBytes: 4,
+      maxRetainedKeyBytes: 3
+    })
+    const evicted = generations.current('aa')
+    generations.current('b')
+    generations.current('cc')
+
+    expect(generations.isCurrent('aa', evicted)).toBe(false)
+    expect(generations.evidence()).toEqual({ entries: 2, retainedKeyBytes: 3 })
+  })
+
+  it('does not retain oversized keys', () => {
+    const generations = new RuntimeOperationGenerations(BOUNDS)
+    const generation = generations.current('oversized')
+
+    expect(generations.isCurrent('oversized', generation)).toBe(false)
+    expect(generations.evidence()).toEqual({ entries: 0, retainedKeyBytes: 0 })
+  })
+
+  it('invalidates forgotten owners without retaining tombstones', () => {
+    const generations = new RuntimeOperationGenerations(BOUNDS)
+    const stale = generations.current('a')
+    generations.forget('a')
+
+    expect(generations.isCurrent('a', stale)).toBe(false)
+    expect(generations.current('a')).not.toBe(stale)
+    expect(generations.evidence()).toEqual({ entries: 1, retainedKeyBytes: 1 })
+  })
+
+  it('publishes explicit production bounds', () => {
+    expect(MAX_RUNTIME_OPERATION_GENERATIONS).toBe(8_192)
+    expect(MAX_RUNTIME_OPERATION_GENERATION_KEY_BYTES).toBe(64 * 1024)
+    expect(MAX_RUNTIME_OPERATION_GENERATION_RETAINED_KEY_BYTES).toBe(4 * 1024 * 1024)
+  })
+})

--- a/src/main/runtime/runtime-operation-generations.ts
+++ b/src/main/runtime/runtime-operation-generations.ts
@@ -1,0 +1,122 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export const MAX_RUNTIME_OPERATION_GENERATIONS = 8_192
+export const MAX_RUNTIME_OPERATION_GENERATION_KEY_BYTES = 64 * 1024
+export const MAX_RUNTIME_OPERATION_GENERATION_RETAINED_KEY_BYTES = 4 * 1024 * 1024
+
+export type RuntimeOperationGenerationBounds = {
+  maxEntries: number
+  maxKeyBytes: number
+  maxRetainedKeyBytes: number
+}
+
+const DEFAULT_BOUNDS: RuntimeOperationGenerationBounds = {
+  maxEntries: MAX_RUNTIME_OPERATION_GENERATIONS,
+  maxKeyBytes: MAX_RUNTIME_OPERATION_GENERATION_KEY_BYTES,
+  maxRetainedKeyBytes: MAX_RUNTIME_OPERATION_GENERATION_RETAINED_KEY_BYTES
+}
+
+type RetainedGeneration = {
+  generation: number
+  keyBytes: number
+}
+
+export class RuntimeOperationGenerations {
+  private readonly generations = new Map<string, RetainedGeneration>()
+  private nextGeneration = 1
+  private retainedKeyBytes = 0
+
+  constructor(private readonly bounds: RuntimeOperationGenerationBounds = DEFAULT_BOUNDS) {
+    if (
+      !Number.isSafeInteger(bounds.maxEntries) ||
+      bounds.maxEntries < 1 ||
+      !Number.isSafeInteger(bounds.maxKeyBytes) ||
+      bounds.maxKeyBytes < 1 ||
+      !Number.isSafeInteger(bounds.maxRetainedKeyBytes) ||
+      bounds.maxRetainedKeyBytes < 1
+    ) {
+      throw new RangeError('Runtime operation generation bounds must be positive integers')
+    }
+  }
+
+  current(key: string): number {
+    const retained = this.generations.get(key)
+    if (!retained) {
+      // Why: a missing key may have been evicted, so it must never reuse a stale token.
+      return this.replace(key)
+    }
+    this.generations.delete(key)
+    this.generations.set(key, retained)
+    return retained.generation
+  }
+
+  advance(key: string): number {
+    return this.replace(key)
+  }
+
+  isCurrent(key: string, generation: number): boolean {
+    const retained = this.generations.get(key)
+    if (retained?.generation !== generation) {
+      return false
+    }
+    this.generations.delete(key)
+    this.generations.set(key, retained)
+    return true
+  }
+
+  forget(key: string): void {
+    this.delete(key)
+  }
+
+  evidence(): { entries: number; retainedKeyBytes: number } {
+    return {
+      entries: this.generations.size,
+      retainedKeyBytes: this.retainedKeyBytes
+    }
+  }
+
+  private replace(key: string): number {
+    this.delete(key)
+    const generation = this.takeGeneration()
+    const measurement = measureUtf8ByteLength(key, {
+      stopAfterBytes: this.bounds.maxKeyBytes
+    })
+    if (measurement.exceededLimit || measurement.byteLength > this.bounds.maxRetainedKeyBytes) {
+      return generation
+    }
+    while (
+      this.generations.size >= this.bounds.maxEntries ||
+      this.retainedKeyBytes + measurement.byteLength > this.bounds.maxRetainedKeyBytes
+    ) {
+      const oldest = this.generations.keys().next().value
+      if (oldest === undefined) {
+        return generation
+      }
+      this.delete(oldest)
+    }
+    this.generations.set(key, {
+      generation,
+      keyBytes: measurement.byteLength
+    })
+    this.retainedKeyBytes += measurement.byteLength
+    return generation
+  }
+
+  private takeGeneration(): number {
+    if (!Number.isSafeInteger(this.nextGeneration)) {
+      throw new Error('Runtime operation generation exhausted')
+    }
+    const generation = this.nextGeneration
+    this.nextGeneration += 1
+    return generation
+  }
+
+  private delete(key: string): void {
+    const retained = this.generations.get(key)
+    if (!retained) {
+      return
+    }
+    this.generations.delete(key)
+    this.retainedKeyBytes -= retained.keyBytes
+  }
+}

--- a/src/main/runtime/runtime-rpc-request-admission.test.ts
+++ b/src/main/runtime/runtime-rpc-request-admission.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import type { WebSocket } from 'ws'
+import { REMOTE_RUNTIME_JSON_STRUCTURE_LIMITS } from '../../shared/remote-runtime-request-frames'
+import { DeviceRegistry } from './device-registry'
+import type { OrcaRuntimeService } from './orca-runtime'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+import type { RpcResponse } from './rpc/core'
+
+function createServer(shortRequestCap = 64): OrcaRuntimeRpcServer {
+  const runtime = { getRuntimeId: () => 'runtime-test' } as OrcaRuntimeService
+  return new OrcaRuntimeRpcServer({
+    runtime,
+    userDataPath: mkdtempSync(join(tmpdir(), 'orca-runtime-admission-')),
+    shortRequestCap
+  })
+}
+
+function localRequest(server: OrcaRuntimeRpcServer, id: string): string {
+  return JSON.stringify({
+    id,
+    authToken: server['authToken'],
+    method: 'status.get'
+  })
+}
+
+describe('runtime RPC request admission', () => {
+  it('rejects structural amplification before JSON.parse', async () => {
+    const server = createServer()
+    const amplified = `{"id":"amplified","authToken":"${server['authToken']}","method":"status.get","params":[${'0,'.repeat(REMOTE_RUNTIME_JSON_STRUCTURE_LIMITS.structuralTokens)}0]}`
+    const parse = vi.spyOn(JSON, 'parse')
+
+    const response = await server['handleMessage'](amplified)
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { code: 'bad_request' }
+    })
+    expect(parse).not.toHaveBeenCalled()
+    parse.mockRestore()
+  })
+
+  it('caps concurrent short local requests and releases capacity on settle', async () => {
+    const server = createServer(1)
+    let releaseFirst: ((response: RpcResponse) => void) | undefined
+    const firstResponse = new Promise<RpcResponse>((resolve) => {
+      releaseFirst = resolve
+    })
+    const dispatch = vi
+      .spyOn(server['dispatcher'], 'dispatch')
+      .mockImplementationOnce(() => firstResponse)
+      .mockResolvedValue({
+        id: 'after',
+        ok: true,
+        result: null,
+        _meta: { runtimeId: 'runtime-test' }
+      })
+
+    const first = server['handleMessage'](localRequest(server, 'first'))
+    await vi.waitFor(() => expect(server['activeShortRequests']).toBe(1))
+
+    await expect(server['handleMessage'](localRequest(server, 'overflow'))).resolves.toMatchObject({
+      id: 'overflow',
+      ok: false,
+      error: { code: 'runtime_busy' }
+    })
+    expect(dispatch).toHaveBeenCalledTimes(1)
+
+    releaseFirst?.({
+      id: 'first',
+      ok: true,
+      result: null,
+      _meta: { runtimeId: 'runtime-test' }
+    })
+    await first
+    expect(server['activeShortRequests']).toBe(0)
+    await server['handleMessage'](localRequest(server, 'after'))
+    expect(dispatch).toHaveBeenCalledTimes(2)
+  })
+
+  it('applies the same short-request cap to WebSocket dispatch', async () => {
+    const server = createServer(1)
+    const registry = new DeviceRegistry(mkdtempSync(join(tmpdir(), 'orca-runtime-device-')))
+    const device = registry.addDevice('runtime-test', 'runtime')
+    server['deviceRegistry'] = registry
+    server['activeShortRequests'] = 1
+    const replies: RpcResponse[] = []
+
+    await server['handleWebSocketMessage'](
+      JSON.stringify({ id: 'overflow', method: 'status.get', deviceToken: device.token }),
+      (response) => replies.push(JSON.parse(response) as RpcResponse),
+      () => {},
+      undefined,
+      undefined as WebSocket | undefined
+    )
+
+    expect(replies).toEqual([
+      expect.objectContaining({
+        id: 'overflow',
+        ok: false,
+        error: expect.objectContaining({ code: 'runtime_busy' })
+      })
+    ])
+  })
+})

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: this file is the single security boundary for the bundled CLI — transport setup, auth-token enforcement, admission control, keepalive framing, and orphan-socket sweeping all co-locate deliberately so a reviewer can audit the boundary in one sitting. Splitting this across files would scatter the invariants without reducing complexity. */
 // Why: the single security boundary for the bundled CLI — auth-token enforcement, metadata publication, transport orchestration.
 import { randomBytes } from 'node:crypto'
-import { readdirSync, rmSync } from 'node:fs'
+import { opendirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 import type { RuntimeMetadata, RuntimeTransportMetadata } from '../../shared/runtime-bootstrap'
 import type { OrcaRuntimeService } from './orca-runtime'
@@ -41,6 +41,7 @@ import {
   decodeTerminalStreamFrame,
   type TerminalStreamFrame
 } from '../../shared/terminal-stream-protocol'
+import { parseRemoteRuntimeJsonText } from '../../shared/remote-runtime-request-frames'
 
 const DEFAULT_WS_PORT = 6768
 
@@ -54,9 +55,11 @@ type OrcaRuntimeRpcServerOptions = {
   // Why: true when the caller pinned a port (`orca serve --port`) so bind order prefers it over a stale STA-1511 fallback (#8535).
   preferPinnedWsPort?: boolean
   webClientRoot?: string
-  // Why: test-only overrides for the two constants below; production must not pass these (defaults set by §3.1).
+  // Why: test-only overrides for the admission constants below; production uses the defaults.
   keepaliveIntervalMs?: number
   longPollCap?: number
+  shortRequestCap?: number
+  streamSubscriptionCap?: number
 }
 
 export type PairingOfferUnavailableReason =
@@ -114,6 +117,12 @@ const KEEPALIVE_INTERVAL_MS = 10_000
 
 // Why: cap long-polls at half the 32-slot connection budget so they can't starve short RPCs; overflow → runtime_busy. See §7 risk #2.
 const LONG_POLL_CAP = 16
+// Why: multiplexed sockets otherwise let one peer retain an unbounded number of active request graphs.
+const SHORT_REQUEST_CAP = 64
+// Why: subscription dispatches block until unsubscribe/stream-close; a separate, larger budget keeps them
+// from consuming the short-request slots that unsubscribe and other short RPCs need (else 64 subscriptions
+// permanently starve the socket, including the unsubscribe that would free them). See §7 risk #2.
+const STREAM_SUBSCRIPTION_CAP = 256
 
 function createWebClientUrl(endpoint: string, pairingUrl: string): string {
   const url = new URL(endpoint)
@@ -404,6 +413,13 @@ function isLongPollRequest(request: RpcRequest): boolean {
   return false
 }
 
+// Why: subscription dispatches await stream-close, holding their dispatch slot for the whole
+// subscription lifetime; they draw from a dedicated budget so a full set of subscriptions can never
+// starve the short-request budget that unsubscribe (itself a short RPC) needs to free them.
+function isStreamingSubscription(request: RpcRequest): boolean {
+  return request.method.endsWith('.subscribe') || request.method.endsWith('.subscribeAll')
+}
+
 // Why: status.get has no per-connection context in the dispatcher, so stamp the scope here at the transport boundary.
 function injectDeviceScope(response: string, scope: DeviceScope): string {
   try {
@@ -431,6 +447,8 @@ export class OrcaRuntimeRpcServer {
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
   private readonly longPollCap: number
+  private readonly shortRequestCap: number
+  private readonly streamSubscriptionCap: number
   private readonly relayRevokeOutbox: RelayRevokeOutbox
   private deviceRegistry: DeviceRegistry | null = null
   private e2eeKeypair: E2EEKeypair | null = null
@@ -452,6 +470,8 @@ export class OrcaRuntimeRpcServer {
   >()
   // Why: separate from server.maxConnections — count only long-running dispatches, not short RPCs. See §3.1 + §7 risk #2.
   private activeLongPolls = 0
+  private activeShortRequests = 0
+  private activeStreamSubscriptions = 0
 
   constructor({
     runtime,
@@ -463,7 +483,9 @@ export class OrcaRuntimeRpcServer {
     preferPinnedWsPort = false,
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
-    longPollCap = LONG_POLL_CAP
+    longPollCap = LONG_POLL_CAP,
+    shortRequestCap = SHORT_REQUEST_CAP,
+    streamSubscriptionCap = STREAM_SUBSCRIPTION_CAP
   }: OrcaRuntimeRpcServerOptions) {
     this.runtime = runtime
     this.dispatcher = new RpcDispatcher({ runtime })
@@ -476,6 +498,8 @@ export class OrcaRuntimeRpcServer {
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
     this.longPollCap = longPollCap
+    this.shortRequestCap = shortRequestCap
+    this.streamSubscriptionCap = streamSubscriptionCap
     this.relayRevokeOutbox = new RelayRevokeOutbox(userDataPath)
   }
 
@@ -862,7 +886,7 @@ export class OrcaRuntimeRpcServer {
           // Why: best-effort id recovery so the client can correlate the error frame to its pending request.
           let id = 'unknown'
           try {
-            const parsed = JSON.parse(msg) as { id?: unknown }
+            const parsed = parseRemoteRuntimeJsonText(msg) as { id?: unknown }
             if (typeof parsed.id === 'string' && parsed.id.length > 0) {
               id = parsed.id
             }
@@ -1009,7 +1033,7 @@ export class OrcaRuntimeRpcServer {
     }
     const request = parsed.request
 
-    // Why: long-poll admission fence; short RPCs bypass the counter. See §7 risk #2.
+    // Why: long-polls and short work have separate budgets so waits cannot starve ordinary RPCs.
     const longPoll = isLongPollRequest(request)
     if (longPoll && this.activeLongPolls >= this.longPollCap) {
       return this.buildError(
@@ -1018,10 +1042,19 @@ export class OrcaRuntimeRpcServer {
         'long-poll capacity reached; retry with backoff'
       )
     }
+    if (!longPoll && this.activeShortRequests >= this.shortRequestCap) {
+      return this.buildError(
+        request.id,
+        'runtime_busy',
+        'short-request capacity reached; retry with backoff'
+      )
+    }
     if (longPoll) {
       this.activeLongPolls += 1
       // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
       context?.startKeepalive()
+    } else {
+      this.activeShortRequests += 1
     }
 
     try {
@@ -1031,6 +1064,8 @@ export class OrcaRuntimeRpcServer {
     } finally {
       if (longPoll) {
         this.activeLongPolls = Math.max(0, this.activeLongPolls - 1)
+      } else {
+        this.activeShortRequests = Math.max(0, this.activeShortRequests - 1)
       }
     }
   }
@@ -1038,7 +1073,7 @@ export class OrcaRuntimeRpcServer {
   private parseAndAuth(rawMessage: string): { request: RpcRequest } | { error: RpcResponse } {
     let request: RpcRequest
     try {
-      request = JSON.parse(rawMessage) as RpcRequest
+      request = parseRemoteRuntimeJsonText(rawMessage) as RpcRequest
     } catch {
       return { error: this.buildError('unknown', 'bad_request', 'Invalid JSON request') }
     }
@@ -1071,7 +1106,7 @@ export class OrcaRuntimeRpcServer {
   ): Promise<void> {
     let request: RpcRequest
     try {
-      request = JSON.parse(rawMessage) as RpcRequest
+      request = parseRemoteRuntimeJsonText(rawMessage) as RpcRequest
     } catch {
       reply(JSON.stringify(this.buildError('unknown', 'bad_request', 'Invalid JSON request')))
       return
@@ -1124,6 +1159,7 @@ export class OrcaRuntimeRpcServer {
     }
 
     const longPoll = isLongPollRequest(request)
+    const streaming = !longPoll && isStreamingSubscription(request)
     if (longPoll && this.activeLongPolls >= this.longPollCap) {
       reply(
         JSON.stringify(
@@ -1136,10 +1172,38 @@ export class OrcaRuntimeRpcServer {
       )
       return
     }
+    if (streaming && this.activeStreamSubscriptions >= this.streamSubscriptionCap) {
+      reply(
+        JSON.stringify(
+          this.buildError(
+            request.id,
+            'runtime_busy',
+            'subscription capacity reached; retry with backoff'
+          )
+        )
+      )
+      return
+    }
+    if (!longPoll && !streaming && this.activeShortRequests >= this.shortRequestCap) {
+      reply(
+        JSON.stringify(
+          this.buildError(
+            request.id,
+            'runtime_busy',
+            'short-request capacity reached; retry with backoff'
+          )
+        )
+      )
+      return
+    }
 
     const abortRegistration = ws ? this.registerWebSocketDispatchAbort(ws) : null
     if (longPoll) {
       this.activeLongPolls += 1
+    } else if (streaming) {
+      this.activeStreamSubscriptions += 1
+    } else {
+      this.activeShortRequests += 1
     }
 
     // Why: older pairings may lack scope metadata, so stamp the authenticated scope onto status.get.
@@ -1190,6 +1254,10 @@ export class OrcaRuntimeRpcServer {
       abortRegistration?.dispose()
       if (longPoll) {
         this.activeLongPolls = Math.max(0, this.activeLongPolls - 1)
+      } else if (streaming) {
+        this.activeStreamSubscriptions = Math.max(0, this.activeStreamSubscriptions - 1)
+      } else {
+        this.activeShortRequests = Math.max(0, this.activeShortRequests - 1)
       }
     }
   }
@@ -1214,37 +1282,49 @@ export class OrcaRuntimeRpcServer {
 export const RUNTIME_SOCKET_NAME_REGEX = /^o-(\d+)-[A-Za-z0-9_-]+\.sock$/
 
 export function sweepOrphanedRuntimeSockets(userDataPath: string, ownPid: number): void {
-  let entries: string[]
+  let directory: ReturnType<typeof opendirSync>
   try {
-    entries = readdirSync(userDataPath)
+    directory = opendirSync(userDataPath)
   } catch {
     // Why: first-launch userData may not exist yet; nothing to sweep.
     return
   }
-  for (const entry of entries) {
-    const match = RUNTIME_SOCKET_NAME_REGEX.exec(entry)
-    if (!match) {
-      continue
-    }
-    const pid = Number(match[1])
-    if (!Number.isFinite(pid)) {
-      continue
-    }
-    // Why: never delete our own socket — a bug here would rmSync one we're about to bind.
-    if (pid === ownPid) {
-      continue
-    }
-    try {
-      // Why: signal 0 is the POSIX liveness probe (sends nothing); ESRCH = dead pid, EPERM = foreign owner (left alone).
-      process.kill(pid, 0)
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
-        try {
-          rmSync(join(userDataPath, entry), { force: true })
-        } catch {
-          // Why: best-effort sweep; a later start() or OS reboot cleans any socket we can't unlink.
+  try {
+    while (true) {
+      const entry = directory.readSync()
+      if (!entry) {
+        break
+      }
+      const match = RUNTIME_SOCKET_NAME_REGEX.exec(entry.name)
+      if (!match) {
+        continue
+      }
+      const pid = Number(match[1])
+      if (!Number.isFinite(pid)) {
+        continue
+      }
+      // Why: never delete our own socket — a bug here would rmSync one we're about to bind.
+      if (pid === ownPid) {
+        continue
+      }
+      try {
+        // Why: signal 0 is the POSIX liveness probe (sends nothing); ESRCH = dead pid, EPERM = foreign owner (left alone).
+        process.kill(pid, 0)
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+          try {
+            rmSync(join(userDataPath, entry.name), { force: true })
+          } catch {
+            // Why: best-effort sweep; a later start() or OS reboot cleans any socket we can't unlink.
+          }
         }
       }
+    }
+  } finally {
+    try {
+      directory.closeSync()
+    } catch {
+      // Best-effort sweep cleanup.
     }
   }
 }

--- a/src/main/runtime/runtime-ssh-relay-recovery-generations.test.ts
+++ b/src/main/runtime/runtime-ssh-relay-recovery-generations.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_RUNTIME_SSH_RELAY_RECOVERIES,
+  MAX_RUNTIME_SSH_RELAY_RECOVERY_RETAINED_TARGET_ID_BYTES,
+  MAX_RUNTIME_SSH_RELAY_RECOVERY_TARGET_ID_BYTES,
+  RuntimeSshRelayRecoveryGenerations
+} from './runtime-ssh-relay-recovery-generations'
+
+describe('RuntimeSshRelayRecoveryGenerations', () => {
+  it('releases completed recoveries under sequential unique-target churn', () => {
+    const generations = new RuntimeSshRelayRecoveryGenerations()
+
+    for (let index = 0; index < 10_000; index += 1) {
+      const targetId = `ssh-${index}`
+      const lease = generations.begin(targetId)
+      expect(lease).not.toBeNull()
+      lease?.release()
+    }
+
+    expect(generations.evidence()).toEqual({ recoveries: 0, retainedTargetIdBytes: 0 })
+  })
+
+  it('keeps a replacement current when an older recovery finishes late', () => {
+    const generations = new RuntimeSshRelayRecoveryGenerations()
+    const stale = generations.begin('ssh-1')!
+    const replacement = generations.begin('ssh-1')!
+
+    stale.release()
+
+    expect(stale.isCurrent()).toBe(false)
+    expect(replacement.isCurrent()).toBe(true)
+    expect(generations.evidence()).toEqual({
+      recoveries: 1,
+      retainedTargetIdBytes: 5
+    })
+  })
+
+  it('caps same-target hung replacements by outstanding lease count', () => {
+    const generations = new RuntimeSshRelayRecoveryGenerations()
+    const leases = Array.from({ length: 10_000 }, () => generations.begin('ssh-1')).filter(
+      (lease) => lease !== null
+    )
+
+    expect(leases).toHaveLength(MAX_RUNTIME_SSH_RELAY_RECOVERIES)
+    expect(leases.slice(0, -1).every((lease) => !lease.isCurrent())).toBe(true)
+    expect(leases.at(-1)?.isCurrent()).toBe(true)
+    expect(generations.evidence()).toEqual({
+      recoveries: MAX_RUNTIME_SSH_RELAY_RECOVERIES,
+      retainedTargetIdBytes: MAX_RUNTIME_SSH_RELAY_RECOVERIES * 5
+    })
+
+    for (const lease of leases) {
+      lease.release()
+    }
+    expect(generations.evidence()).toEqual({ recoveries: 0, retainedTargetIdBytes: 0 })
+  })
+
+  it('keeps invalidated attempts admitted until their work releases', () => {
+    const generations = new RuntimeSshRelayRecoveryGenerations({
+      maxRecoveries: 1,
+      maxTargetIdBytes: 8,
+      maxRetainedTargetIdBytes: 8
+    })
+    const stale = generations.begin('ssh-1')!
+
+    generations.invalidate('ssh-1')
+
+    expect(stale.isCurrent()).toBe(false)
+    expect(generations.begin('ssh-2')).toBeNull()
+    stale.release()
+    expect(generations.begin('ssh-2')?.isCurrent()).toBe(true)
+  })
+
+  it('rejects unique hung recoveries at the concurrent-entry cap and admits after release', () => {
+    const generations = new RuntimeSshRelayRecoveryGenerations()
+    const leases = Array.from({ length: MAX_RUNTIME_SSH_RELAY_RECOVERIES }, (_, index) =>
+      generations.begin(`ssh-${index}`)
+    )
+
+    expect(leases.every(Boolean)).toBe(true)
+    expect(generations.begin('ssh-overflow')).toBeNull()
+    leases[0]?.release()
+
+    const replacement = generations.begin('ssh-overflow')
+    expect(replacement?.isCurrent()).toBe(true)
+    for (const lease of leases) {
+      lease?.release()
+    }
+    replacement?.release()
+    expect(generations.evidence()).toEqual({ recoveries: 0, retainedTargetIdBytes: 0 })
+  })
+
+  it('bounds individual and aggregate retained target-id bytes', () => {
+    const generations = new RuntimeSshRelayRecoveryGenerations({
+      maxRecoveries: 3,
+      maxTargetIdBytes: 8,
+      maxRetainedTargetIdBytes: 10
+    })
+    const first = generations.begin('123456')
+    const second = generations.begin('abcd')
+
+    expect(first?.isCurrent()).toBe(true)
+    expect(second?.isCurrent()).toBe(true)
+    expect(generations.begin('x')).toBeNull()
+    expect(generations.begin('🌊🌊🌊')).toBeNull()
+    expect(generations.evidence()).toEqual({ recoveries: 2, retainedTargetIdBytes: 10 })
+  })
+
+  it('publishes explicit production bounds', () => {
+    expect(MAX_RUNTIME_SSH_RELAY_RECOVERIES).toBe(256)
+    expect(MAX_RUNTIME_SSH_RELAY_RECOVERY_TARGET_ID_BYTES).toBe(64 * 1024)
+    expect(MAX_RUNTIME_SSH_RELAY_RECOVERY_RETAINED_TARGET_ID_BYTES).toBe(4 * 1024 * 1024)
+  })
+})

--- a/src/main/runtime/runtime-ssh-relay-recovery-generations.ts
+++ b/src/main/runtime/runtime-ssh-relay-recovery-generations.ts
@@ -1,0 +1,108 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export const MAX_RUNTIME_SSH_RELAY_RECOVERIES = 256
+export const MAX_RUNTIME_SSH_RELAY_RECOVERY_TARGET_ID_BYTES = 64 * 1024
+export const MAX_RUNTIME_SSH_RELAY_RECOVERY_RETAINED_TARGET_ID_BYTES = 4 * 1024 * 1024
+
+export type RuntimeSshRelayRecoveryGenerationBounds = {
+  maxRecoveries: number
+  maxTargetIdBytes: number
+  maxRetainedTargetIdBytes: number
+}
+
+export type RuntimeSshRelayRecoveryGenerationLease = {
+  isCurrent: () => boolean
+  release: () => void
+}
+
+const DEFAULT_BOUNDS: RuntimeSshRelayRecoveryGenerationBounds = {
+  maxRecoveries: MAX_RUNTIME_SSH_RELAY_RECOVERIES,
+  maxTargetIdBytes: MAX_RUNTIME_SSH_RELAY_RECOVERY_TARGET_ID_BYTES,
+  maxRetainedTargetIdBytes: MAX_RUNTIME_SSH_RELAY_RECOVERY_RETAINED_TARGET_ID_BYTES
+}
+
+type RetainedRecovery = {
+  generation: number
+  targetIdBytes: number
+}
+
+export class RuntimeSshRelayRecoveryGenerations {
+  private readonly generationByTargetId = new Map<string, RetainedRecovery>()
+  private activeRecoveries = 0
+  private retainedTargetIdBytes = 0
+  private nextGeneration = 1
+
+  constructor(private readonly bounds: RuntimeSshRelayRecoveryGenerationBounds = DEFAULT_BOUNDS) {
+    if (
+      !Number.isSafeInteger(bounds.maxRecoveries) ||
+      bounds.maxRecoveries < 1 ||
+      !Number.isSafeInteger(bounds.maxTargetIdBytes) ||
+      bounds.maxTargetIdBytes < 1 ||
+      !Number.isSafeInteger(bounds.maxRetainedTargetIdBytes) ||
+      bounds.maxRetainedTargetIdBytes < 1
+    ) {
+      throw new RangeError('SSH relay recovery generation bounds must be positive integers')
+    }
+  }
+
+  begin(targetId: string): RuntimeSshRelayRecoveryGenerationLease | null {
+    const targetIdMeasurement = measureUtf8ByteLength(targetId, {
+      stopAfterBytes: this.bounds.maxTargetIdBytes
+    })
+    if (targetIdMeasurement.exceededLimit) {
+      return null
+    }
+    if (
+      this.activeRecoveries >= this.bounds.maxRecoveries ||
+      this.retainedTargetIdBytes + targetIdMeasurement.byteLength >
+        this.bounds.maxRetainedTargetIdBytes
+    ) {
+      return null
+    }
+    if (!Number.isSafeInteger(this.nextGeneration)) {
+      throw new Error('SSH relay recovery generation exhausted')
+    }
+    const generation = this.nextGeneration
+    this.nextGeneration += 1
+    const retained = {
+      generation,
+      targetIdBytes: targetIdMeasurement.byteLength
+    }
+    this.generationByTargetId.set(targetId, retained)
+    this.activeRecoveries += 1
+    this.retainedTargetIdBytes += retained.targetIdBytes
+    let active = true
+    return {
+      isCurrent: () =>
+        active &&
+        this.generationByTargetId.get(targetId) === retained &&
+        retained.generation === generation,
+      release: () => {
+        if (!active) {
+          return
+        }
+        active = false
+        this.releaseLease(targetId, retained)
+      }
+    }
+  }
+
+  invalidate(targetId: string): void {
+    this.generationByTargetId.delete(targetId)
+  }
+
+  evidence(): { recoveries: number; retainedTargetIdBytes: number } {
+    return {
+      recoveries: this.activeRecoveries,
+      retainedTargetIdBytes: this.retainedTargetIdBytes
+    }
+  }
+
+  private releaseLease(targetId: string, retained: RetainedRecovery): void {
+    this.activeRecoveries -= 1
+    this.retainedTargetIdBytes -= retained.targetIdBytes
+    if (this.generationByTargetId.get(targetId) === retained) {
+      this.generationByTargetId.delete(targetId)
+    }
+  }
+}

--- a/src/main/runtime/runtime-terminal-file-grant-retention.test.ts
+++ b/src/main/runtime/runtime-terminal-file-grant-retention.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest'
+import { retainRuntimeTerminalFileGrant } from './runtime-terminal-file-grant-retention'
+
+describe('retainRuntimeTerminalFileGrant', () => {
+  it('preserves grants below the cap and evicts the oldest at admission', () => {
+    const grants = new Map<string, { id: string }>()
+    const release = vi.fn((id: string) => grants.delete(id))
+
+    retainRuntimeTerminalFileGrant(grants, { id: 'a' }, release, 2)
+    retainRuntimeTerminalFileGrant(grants, { id: 'b' }, release, 2)
+    expect([...grants.keys()]).toEqual(['a', 'b'])
+    expect(release).not.toHaveBeenCalled()
+
+    retainRuntimeTerminalFileGrant(grants, { id: 'c' }, release, 2)
+    expect([...grants.keys()]).toEqual(['b', 'c'])
+    expect(release).toHaveBeenCalledWith('a', { id: 'a' })
+  })
+})

--- a/src/main/runtime/runtime-terminal-file-grant-retention.ts
+++ b/src/main/runtime/runtime-terminal-file-grant-retention.ts
@@ -1,0 +1,22 @@
+export const RUNTIME_TERMINAL_FILE_GRANT_MAX_ENTRIES = 1024
+
+export function retainRuntimeTerminalFileGrant<T extends { id: string }>(
+  grants: Map<string, T>,
+  grant: T,
+  release: (id: string, retained: T) => void,
+  maxEntries = RUNTIME_TERMINAL_FILE_GRANT_MAX_ENTRIES
+): void {
+  while (grants.size >= Math.max(1, maxEntries)) {
+    const oldestId = grants.keys().next().value as string | undefined
+    if (oldestId === undefined) {
+      break
+    }
+    const oldest = grants.get(oldestId)
+    if (oldest) {
+      release(oldestId, oldest)
+    } else {
+      grants.delete(oldestId)
+    }
+  }
+  grants.set(grant.id, grant)
+}

--- a/src/main/runtime/runtime-text-search-admission.test.ts
+++ b/src/main/runtime/runtime-text-search-admission.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { assertRuntimeTextSearchAdmission } from './runtime-text-search-admission'
+
+describe('assertRuntimeTextSearchAdmission', () => {
+  it('allows ordinary and replacement searches but rejects excess distinct roots', () => {
+    const active = new Map<string, unknown>([
+      ['repo-a', {}],
+      ['repo-b', {}]
+    ])
+
+    expect(() => assertRuntimeTextSearchAdmission(active, 'repo-a', 2)).not.toThrow()
+    expect(() => assertRuntimeTextSearchAdmission(active, 'repo-c', 2)).toThrow('search is busy')
+  })
+})

--- a/src/main/runtime/runtime-text-search-admission.ts
+++ b/src/main/runtime/runtime-text-search-admission.ts
@@ -1,0 +1,11 @@
+export const RUNTIME_TEXT_SEARCH_MAX_ACTIVE = 16
+
+export function assertRuntimeTextSearchAdmission(
+  activeSearchKeys: ReadonlyMap<string, unknown>,
+  requestedKey: string,
+  maxActive = RUNTIME_TEXT_SEARCH_MAX_ACTIVE
+): void {
+  if (!activeSearchKeys.has(requestedKey) && activeSearchKeys.size >= maxActive) {
+    throw new Error('Runtime text search is busy; retry after current searches finish.')
+  }
+}

--- a/src/main/runtime/tls-certificate-bounds.test.ts
+++ b/src/main/runtime/tls-certificate-bounds.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { closeSync, ftruncateSync, mkdtempSync, openSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const execFileSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:child_process', () => ({ execFileSync: execFileSyncMock }))
+
+import { loadOrCreateTlsCertificate } from './tls-certificate'
+
+const CERTIFICATE = '-----BEGIN CERTIFICATE-----\nYQ==\n-----END CERTIFICATE-----\n'
+const PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nYg==\n-----END PRIVATE KEY-----\n'
+const roots: string[] = []
+
+beforeEach(() => {
+  execFileSyncMock.mockImplementation((_command: string, args: string[]) => {
+    const keyIndex = args.indexOf('-keyout')
+    const certIndex = args.indexOf('-out')
+    writeFileSync(args[keyIndex + 1], PRIVATE_KEY)
+    writeFileSync(args[certIndex + 1], CERTIFICATE)
+  })
+})
+
+afterEach(() => {
+  execFileSyncMock.mockReset()
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function makeUserDataPath(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-tls-bounds-'))
+  roots.push(root)
+  return root
+}
+
+describe('TLS certificate file bounds', () => {
+  it('preserves existing ordinary certificate material', () => {
+    const userDataPath = makeUserDataPath()
+    writeFileSync(join(userDataPath, 'orca-tls-cert.pem'), CERTIFICATE)
+    writeFileSync(join(userDataPath, 'orca-tls-key.pem'), PRIVATE_KEY)
+
+    expect(loadOrCreateTlsCertificate(userDataPath)).toMatchObject({
+      cert: CERTIFICATE,
+      key: PRIVATE_KEY
+    })
+    expect(execFileSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('regenerates instead of retaining an oversized sparse PEM file', () => {
+    const userDataPath = makeUserDataPath()
+    const certPath = join(userDataPath, 'orca-tls-cert.pem')
+    const descriptor = openSync(certPath, 'w')
+    ftruncateSync(descriptor, 1024 * 1024 + 1)
+    closeSync(descriptor)
+    writeFileSync(join(userDataPath, 'orca-tls-key.pem'), PRIVATE_KEY)
+
+    expect(loadOrCreateTlsCertificate(userDataPath)).toMatchObject({
+      cert: CERTIFICATE,
+      key: PRIVATE_KEY
+    })
+    expect(execFileSyncMock).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/runtime/tls-certificate.ts
+++ b/src/main/runtime/tls-certificate.ts
@@ -4,11 +4,16 @@
 // app pins the certificate fingerprint received during QR pairing.
 import { createHash } from 'node:crypto'
 import { execFileSync } from 'node:child_process'
-import { existsSync, readFileSync, chmodSync } from 'node:fs'
+import { existsSync, chmodSync } from 'node:fs'
 import { join } from 'node:path'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileSyncWithinLimit
+} from '../../shared/node-bounded-file-reader'
 
 const TLS_CERT_FILENAME = 'orca-tls-cert.pem'
 const TLS_KEY_FILENAME = 'orca-tls-key.pem'
+const MAX_TLS_PEM_FILE_BYTES = 1024 * 1024
 
 export type TlsCertificate = {
   cert: string
@@ -21,11 +26,17 @@ export function loadOrCreateTlsCertificate(userDataPath: string): TlsCertificate
   const keyPath = join(userDataPath, TLS_KEY_FILENAME)
 
   if (existsSync(certPath) && existsSync(keyPath)) {
-    const cert = readFileSync(certPath, 'utf-8')
-    const key = readFileSync(keyPath, 'utf-8')
-    const fingerprint = computeFingerprint(cert)
-    if (fingerprint) {
-      return { cert, key, fingerprint }
+    try {
+      const cert = readTlsPemFile(certPath)
+      const key = readTlsPemFile(keyPath)
+      const fingerprint = computeFingerprint(cert)
+      if (fingerprint) {
+        return { cert, key, fingerprint }
+      }
+    } catch (error) {
+      if (!(error instanceof NodeFileReadTooLargeError)) {
+        throw error
+      }
     }
     // Why: if the existing cert is malformed (e.g., from a buggy earlier
     // generation), regenerate rather than failing the WebSocket transport.
@@ -66,9 +77,13 @@ export function loadOrCreateTlsCertificate(userDataPath: string): TlsCertificate
   chmodSync(keyPath_, 0o600)
   chmodSync(certPath_, 0o600)
 
-  const cert = readFileSync(certPath_, 'utf-8')
-  const key = readFileSync(keyPath_, 'utf-8')
+  const cert = readTlsPemFile(certPath_)
+  const key = readTlsPemFile(keyPath_)
   return { cert, key, fingerprint: computeFingerprint(cert)! }
+}
+
+function readTlsPemFile(filePath: string): string {
+  return readNodeFileSyncWithinLimit(filePath, MAX_TLS_PEM_FILE_BYTES).buffer.toString('utf-8')
 }
 
 function resolveOpenSslExecutable(): string {


### PR DESCRIPTION
## OOM hardening slice 21/29 — bound remote-runtime RPC, transport & waiters

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **21/29** (base: `oom/20-b-relay`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Re-lands the "B-runtime" slice of the OOM ceilings: bounds the orchestration SQLite query/write layer, the mobile tab-selection store, mobile file-directory listing + image previews, runtime RPC response/admission control, relay control/revoke/host-proof paths, and a family of bounded control-file readers and LRU generation/registry maps. Whole-file changes with matching regression tests; behavior below the ceilings is preserved.

### ELI5
Imagine the app has lots of buckets it fills with data (messages, tasks, open files, network requests). Before, some buckets had no lid, so a flood of junk could fill all the memory and crash the app. This change puts a lid on every bucket with a clearly labeled max size, and adds tests that pour in too much to prove the lid holds. Normal usage stays the same; only extreme or abusive amounts get turned away. A few lids sit low enough that a real person could occasionally bump them — previewing a very high-resolution photo, opening a folder with more than 10,000 files, or running an orchestration with more than 256 tasks — so a human should confirm those thresholds are acceptable.

### Proof of OOM fix
- Orchestration DB: ORCHESTRATION_QUERY_MAX_ROWS=256, ORCHESTRATION_QUERY_MAX_ROW_UTF8_BYTES=2MB, ORCHESTRATION_QUERY_MAX_RETAINED_UTF8_BYTES=8MB, ORCHESTRATION_WRITE_MAX_UTF8_BYTES=512KB, ORCHESTRATION_WRITE_MAX_ITEMS=4096, JSON 64K tokens/depth 64 (query-retention.ts; tests db-query-retention.test.ts, orchestration-query-retention.test.ts)
- OrchestrationMessageWaiterRegistry: 1024 global / 64 per-handle / 64KB handle / 1MB retained-handle-bytes (orchestration-message-waiter-registry.ts + .test.ts)
- Mobile tab selection: 64 clients, 512 worktrees/client, 128 groups/worktree, 4KB id, 64KB/selection, 256KB/client (client-session-tab-selection-persistence.ts; client-session-tab-selection-bounds.test.ts)
- Mobile directory listing: MOBILE_FILE_DIRECTORY_MAX_ENTRIES=10,000 / 4MB retained, classification concurrency 32 (orca-runtime-files.ts; orca-runtime-files.test.ts stops at 10,001)
- Raster preview: MAX_RASTER_IMAGE_PREVIEW_DIMENSION_PX=32,768, MAX_RASTER_IMAGE_PREVIEW_PIXELS=32M (assertRasterImagePreviewWithinLimits; tests reject 32,769-wide bomb)
- Runtime RPC outbound: REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES=4MB → response_too_large (runtime-rpc-response-serialization.ts, dispatcher.ts; dispatcher-output-bounds.test.ts)
- Runtime RPC admission: SHORT_REQUEST_CAP=64 + LONG_POLL_CAP=16 → runtime_busy; structural JSON pre-parse guard (runtime-rpc.ts; runtime-rpc-request-admission.test.ts)
- RuntimeOperationGenerations LRU 8,192 / 64KB key / 4MB retained (pty-lifecycle + worktree-scan gens; runtime-operation-generations.test.ts)
- RuntimeSshRelayRecoveryGenerations 256 / 64KB / 4MB (runtime-ssh-relay-recovery-generations.test.ts)
- Relay: RELAY_CONTROL_MAX_PENDING_REQUESTS=256 / 512B id; RELAY_CONTROL_MAX_MESSAGE_BYTES=64KB; MAX_RELAY_REVOKE_OUTBOX_ITEMS=4096 / 1MB (fails closed on overflow); host-proof exact-base64-length + 16KB ciphertext cap
- Control-file readers: device registry 4096 entries/1MB, E2EE keypair 8KB, TLS PEM 1MB, ws-fallback-port 1KB, runtime metadata bounded read+structure, agent-session key 32B (runtime-control-file-bounds.test.ts, tls-certificate-bounds.test.ts, ws-fallback-port-store.test.ts, relay-revoke-outbox.test.ts)
- Misc runtime maps: terminal file grants 1024, RUNTIME_TEXT_SEARCH_MAX_ACTIVE=16, mobile-file-path-search in-flight cap, RuntimeFileWatcherAdmission 256 leases/16MB/64KB path, resolved-worktree repo concurrency 8, clipboard upload retained cap = CLIPBOARD_IMAGE_MAX_BASE64_CHARS/8 concurrent, recent-pty-output-buffer 64KB window + 1024-chunk cap, Unix socket 1MB frame via GrowingByteBuffer

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **low**: Resolved-worktree scanning is throttled to 8 concurrent repo scans (was unbounded Promise.all), adding latency for users with many (>8) repos while a scan is cold. _(trigger: Listing managed worktrees across dozens of repos with a cold scan cache.)_
- **high**: A process with 64 active long-lived WebSocket subscriptions can starve all normal short RPCs because subscriptions are charged to SHORT_REQUEST_CAP and keep the slots until stream teardown. _(trigger: Keep 64 non-terminal.wait/non-orchestration.check streaming RPCs active across one or more connected clients, then issue any ordinary RPC.)_
- **low**: Orchestration inbox, task, and gate list RPCs now return at most 256 rows and expose total/truncated/remaining metadata. Consumers that previously received the complete list now see only the first page; no pagination path was added in this slice. _(trigger: Use an orchestration run with more than 256 matching messages, tasks, or gates.)_
- **low**: Resolved-worktree scanning is limited to eight repositories at once, preserving order and results but increasing cold-scan latency for installations with many repositories. _(trigger: Cold-list managed worktrees across substantially more than eight repositories.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Orchestration message-waiter, relay control/revoke, device-registry, file-watcher, text-search, mobile-path-search, and generation-map caps all sit far above ordinary single-user/single-device use and fail closed with retry-style errors (runtime_busy / *_limit / capacity errors)
- Oversized (>2MB) legacy orchestration rows are silently skipped from query results and orchestration.check reports {truncated,remaining} instead of hanging; unreachable via normal insert because the 512KB aggregate write cap is below the 2MB read cap
- Poison-message containment: a >2MB body message is undeliverable forever, but can only be created via direct SQL, not the RPC write path
- Coordinator state arrays (completedTasks/failedTasks/escalations) stop growing at 256, but convergence uses exact getTaskStatusCounts() so run outcome stays correct
- RuntimeOperationGenerations LRU eviction only drops an in-flight pty/worktree snapshot when >8,192 distinct owners churn during one operation (returns null, fails safe)
- Clipboard second concurrent upload is refused only when a prior upload already reserves the whole process-wide base64 budget
- Oversized/structurally-amplified control files (metadata, keypair, TLS, registry, outbox) are regenerated or rejected only when corrupt or sparse-inflated
- Mobile/artifact image preview of high-resolution rasters now fails with 'Image dimensions exceed the preview safety limit' when a dimension exceeds 32,768px OR total pixels exceed 32M (~32 megapixels). Modern 48MP phone photos (e.g. 8000x6000 = 48M px) exceed this and can no longer be previewed. _(only when: Previewing a >32MP image via mobile file explorer or terminal-artifact preview; reachable in ordinary use with high-MP camera photos.)_
- Runtime RPC responses larger than 4MB (REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) are replaced with a small 'response_too_large' error. The previewable-binary path allows up to a 10MB file, whose base64 (~13MB) far exceeds 4MB, and even a ~3MB photo's base64 can cross 4MB — so mobile image/file preview of multi-MB files can now return an error instead of the content. _(only when: Mobile client requesting a file/artifact preview whose base64-encoded JSON response exceeds 4MB; reachable with ordinary multi-MB images.)_
- Mobile file explorer directory listing of a folder with more than 10,000 entries now errors ('This folder is too large to show safely on mobile') instead of listing; also caps at 4MB of retained entry bytes. _(only when: Browsing a very large directory (e.g. node_modules) from a paired mobile device.)_
- Orchestration list/inbox/gate/task RPCs now return at most 256 rows and add {total,truncated,remaining} fields; runs with >256 tasks/messages show a truncated page in the UI (coordinator itself still processes all rows via exact counts and streaming scans). _(only when: Orchestration run/DAG or inbox exceeding 256 tasks or messages.)_
- Inline IMAGE preview of a 3-10MB image on an SSH/remote worktree now returns 'response_too_large' where BASE succeeded. This slice adds boundRuntimeRpcResponse/serializeRuntimeRpcResponse to RpcDispatcher, newly enforcing REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES (4MB) on the dispatcher/unix-socket path (BASE used raw JSON.stringify, uncapped). The image file-size gate is 10MB but base64 of a ~3MB image already exceeds the 4MB JSON cap, so images the user perceives as previewable (under the 10MB gate) fail to render inline. Local (non-SSH) desktop previews are UNAFFECTED (direct window.api.fs.readFile IPC, confirmed in runtime-file-client.ts). Remote downloads are UNAFFECTED (chunked files.readChunk). Fails closed with a clear error. _(only when: Previewing a 3-10MB image file (photo/design asset) inside an SSH-connected remote worktree over the unix-socket runtime transport.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.
- Touches 7 file(s) also changed on `main` since the revert; git auto-merges them (no conflict): `orca-runtime.test.ts`, `orca-runtime.ts`, `relay-control-client.test.ts`, `relay-control-client.ts`, `relay-http-client.test.ts`, `relay-http-client.ts`, `terminal.ts`.

### ✅ Inherited defect FIXED in this slice
- ✅ **FIXED** [high, overload-path only] `src/main/runtime/runtime-rpc.ts` — Only terminal.wait & orchestration.check(wait) are long-poll-exempt; terminal.subscribe holds a short-request slot for its lifetime, so 64 subscriptions permanently starve all short RPCs (incl. unsubscribe) with runtime_busy.
  - **Fix applied:** Added a separate STREAM_SUBSCRIPTION_CAP=256 budget: isStreamingSubscription() classifies *.subscribe/*.subscribeAll dispatches, which now draw from activeStreamSubscriptions instead of the 64-slot short budget — so open subscriptions can never starve unsubscribe/short RPCs. Verified: typecheck clean + runtime-rpc tests pass.
- ⚠️ [medium] `src/main/runtime/runtime-rpc.ts` — adversarial-flagged (overload-path only, unverified): status.get device-scope injector JSON.stringify runs AFTER the 4 MiB outbound ceiling check, so a near-limit response can exceed REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES on the wire.

> Defects **inherited from the original #10179 code** (not introduced by slicing; not present in today's unbounded `main`). Fixed items were patched in-slice and re-verified (typecheck + affected suites); remaining flagged items are overload-only and noted for a fast-follow.

### Adversarial review
- 3 skeptic lens(es) incl. a frontier-model (GPT) cross-check. Sign-off: **FLAGGED — see above**. Residual risk: **high**.
- Skeptical pass on PR #21 (B-runtime). Verified numeric ceilings and refuted the prior reviewer's strongest claim.\n\nREFUTED prior claim #2 (medium: '4MB RPC regresses mobile image/file preview'): The 4MB cap (REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES) and its enforcement on the mobile/remote transport (serializeRemoteRuntimePayload, mobile-e2ee-outbound-admission) already exist at BASE — src/shared/remote-runtime-memory-limits.ts and both mobile-e2ee files are byte-identical between BASE and TARGET. So mobile previews >4MB already failed at BASE; this slice does NOT regress the mobile path. The dispatcher change actually improves it by returning a correlated 'response_too_large' error instead of a transport-level throw.\n\nThe ONE genuine new regression this slice introduces: the dispatcher change extends the same 4MB ceiling to the previously-uncapped unix-socket / SSH-tunnel dispatch path (BASE used raw JSON.stringify). Effect is confined to inline IMAGE preview of 3-10MB images on SSH-remote worktrees (local previews bypass runtime RPC via IPC; remote downloads use chunking via files.readChunk). Fails closed with a clear error. Narrow reachability (multi-MB images uncommon in code repos) — low severity, but a below-the-10MB-gate visible change, so normalPathRegressionFound=true.\n\nOther new limits verified as overload-ish / power-user, all far above ordinary use and fail closed:\n- Raster preview cap 32,768px/side & ~33.5M px: 8K (33.2MP) passes; only 48MP+ photos/45MP+ camera exports bite. Header-parse failure also fails a preview, but parser covers standard PNG/JPEG/GIF/WebP/BMP/ICO variants; failure on ordinary images is low-likelihood.\n- Mobile directory listing 10,000 entries / 4MB retained: ordinary repo dirs far below; large asset/dataset/build dirs could hit.\n- Orchestration query cap 256 rows: UI page truncation only. Confirmed coordinator convergence uses exact getTaskStatusCounts() (coordinator.ts:180,211), not the capped state arrays, so run outcomes stay correct — {total,truncated,remaining} added.\n- Resolved-worktree scan concurrency 8: latency only.\n\nNo correctness bugs (watcher-admission release handled on all error paths; classifyRuntimeMobileDirectoryEntries batching preserves order and is re-sorted; db.ts non-null assertions safe via write<read cap invariant).\n\nSignoff=true: safe to open as a draft PR for human review. The single confirmed regression is narrow, fails safe, extends a ceiling the primary remote-preview client (mobile) already enforced at BASE, and matches the exact production code that passed full CI. Human should decide whether the 4MB response cap sitting below the 10MB image-preview file gate warrants raising the cap or lowering the gate on the SSH path.
- Correctness notes: `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/runtime/runtime-rpc.ts`: Confirmed starvation bug: only terminal.wait and orchestration.check(wait=true) are classified as long polls, while every other WebSocket dispatch consumes the 64-slot short-request budget until dispatchStreaming returns. Long-lived methods such as terminal.subscribe await stream closure, so 64 active subscriptions permanently reject all subsequent short RPCs, including unsubscribe-style cleanup RPCs, with runtime_busy; recovery may require closing sockets or terminals rather than normal RPC cleanup.; `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/runtime/runtime-rpc.ts`: The status.get device-scope injector runs after the dispatcher has enforced the 4 MiB response ceiling: it parses the already-bounded JSON, adds deviceScope, and calls unbounded JSON.stringify. A response within the added field's size of 4 MiB therefore exceeds REMOTE_RUNTIME_MAX_OUTBOUND_JSON_BYTES on the wire, violating the advertised hard ceiling.

### Files
68 files changed (+4978 / −796).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**
