### PR TITLE
oom(22/29): bound filesystem & worktree IPC enumeration

### DIFF
--- a/src/main/ipc/filesystem-directory-reader.test.ts
+++ b/src/main/ipc/filesystem-directory-reader.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { FILESYSTEM_DIRECTORY_LIMIT_MESSAGE } from '../../shared/filesystem-directory-listing-limit'
+import { collectLocalFilesystemDirectoryEntries } from './filesystem-directory-reader'
+
+type TestEntryOptions = {
+  name: string
+  directory?: boolean
+  symlink?: boolean
+  onClassify?: () => void
+}
+
+function entry(options: TestEntryOptions) {
+  return {
+    name: options.name,
+    isDirectory: () => {
+      options.onClassify?.()
+      return options.directory ?? false
+    },
+    isSymbolicLink: () => options.symlink ?? false
+  }
+}
+
+describe('local filesystem directory reader', () => {
+  it('preserves directory-first sorting and keeps symlinks file-like', async () => {
+    const source = [
+      entry({ name: 'z.txt' }),
+      entry({ name: 'linked-dir', directory: true, symlink: true }),
+      entry({ name: 'beta', directory: true }),
+      entry({ name: 'alpha', directory: true })
+    ]
+
+    await expect(collectLocalFilesystemDirectoryEntries(source)).resolves.toEqual([
+      { name: 'alpha', isDirectory: true, isSymlink: false },
+      { name: 'beta', isDirectory: true, isSymlink: false },
+      { name: 'linked-dir', isDirectory: false, isSymlink: true },
+      { name: 'z.txt', isDirectory: false, isSymlink: false }
+    ])
+  })
+
+  it('stops before classifying or retaining the first over-limit entry', async () => {
+    let enumerated = 0
+    let overLimitClassified = false
+    const source = {
+      async *[Symbol.asyncIterator]() {
+        for (const value of [
+          entry({ name: 'one' }),
+          entry({ name: 'two' }),
+          entry({ name: 'three', onClassify: () => (overLimitClassified = true) })
+        ]) {
+          enumerated += 1
+          yield value
+        }
+      }
+    }
+
+    await expect(
+      collectLocalFilesystemDirectoryEntries(source, {
+        maxEntries: 2,
+        maxRetainedBytes: 1024
+      })
+    ).rejects.toThrow(FILESYSTEM_DIRECTORY_LIMIT_MESSAGE)
+    expect(enumerated).toBe(3)
+    expect(overLimitClassified).toBe(false)
+  })
+})

--- a/src/main/ipc/filesystem-directory-reader.ts
+++ b/src/main/ipc/filesystem-directory-reader.ts
@@ -1,0 +1,41 @@
+import { opendir } from 'node:fs/promises'
+import type { DirEntry } from '../../shared/types'
+import {
+  createFilesystemDirectoryLimitState,
+  trackFilesystemDirectoryEntry,
+  type FilesystemDirectoryListingLimits
+} from '../../shared/filesystem-directory-listing-limit'
+
+type LocalDirectorySourceEntry = {
+  name: string
+  isDirectory(): boolean
+  isSymbolicLink(): boolean
+}
+
+export async function readLocalFilesystemDirectory(dirPath: string): Promise<DirEntry[]> {
+  return collectLocalFilesystemDirectoryEntries(await opendir(dirPath))
+}
+
+export async function collectLocalFilesystemDirectoryEntries(
+  directory: AsyncIterable<LocalDirectorySourceEntry> | Iterable<LocalDirectorySourceEntry>,
+  requestedLimits?: Partial<FilesystemDirectoryListingLimits>
+): Promise<DirEntry[]> {
+  const entries: DirEntry[] = []
+  const limit = createFilesystemDirectoryLimitState(requestedLimits)
+  for await (const entry of directory) {
+    trackFilesystemDirectoryEntry(limit, entry)
+    const isSymlink = entry.isSymbolicLink()
+    entries.push({
+      name: entry.name,
+      // Why: avoid probing macOS TCC-protected symlink targets during listing.
+      isDirectory: !isSymlink && entry.isDirectory(),
+      isSymlink
+    })
+  }
+  return entries.sort((left, right) => {
+    if (left.isDirectory !== right.isDirectory) {
+      return left.isDirectory ? -1 : 1
+    }
+    return left.name.localeCompare(right.name)
+  })
+}

--- a/src/main/ipc/filesystem-external-import-limits.test.ts
+++ b/src/main/ipc/filesystem-external-import-limits.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+import {
+  admitExternalImportTreeEntry,
+  assertExternalImportSourcePaths,
+  assertExternalImportTreeDepth,
+  captureRuntimeUploadRetentionCheckpoint,
+  createExternalImportTreeBudget,
+  createRuntimeUploadRetentionBudget,
+  EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES,
+  EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES,
+  EXTERNAL_IMPORT_MAX_SOURCE_PATHS,
+  EXTERNAL_IMPORT_MAX_TREE_DEPTH,
+  EXTERNAL_IMPORT_MAX_TREE_ENTRIES,
+  ExternalImportCapacityError,
+  REMOTE_IMPORT_MAX_FILE_BYTES,
+  REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES,
+  REMOTE_IMPORT_MAX_TOTAL_BYTES,
+  restoreRuntimeUploadRetentionCheckpoint,
+  retainRuntimeUploadFileBytes
+} from './filesystem-external-import-limits'
+
+describe('external filesystem import limits', () => {
+  it('accepts the exact source-count boundary and rejects the next path', () => {
+    expect(() =>
+      assertExternalImportSourcePaths(
+        Array.from({ length: EXTERNAL_IMPORT_MAX_SOURCE_PATHS }, () => '')
+      )
+    ).not.toThrow()
+    expect(() =>
+      assertExternalImportSourcePaths(
+        Array.from({ length: EXTERNAL_IMPORT_MAX_SOURCE_PATHS + 1 }, () => '')
+      )
+    ).toThrow('External import accepts at most 256 source paths')
+  })
+
+  it('accepts the exact source-path byte boundary and rejects one byte more', () => {
+    expect(() =>
+      assertExternalImportSourcePaths(['a'.repeat(EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES)])
+    ).not.toThrow()
+    expect(() =>
+      assertExternalImportSourcePaths(['a'.repeat(EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES + 1)])
+    ).toThrow('External import source paths exceed 256 KiB')
+  })
+
+  it('accepts exactly 100,000 tree entries without retaining their paths', () => {
+    const budget = createExternalImportTreeBudget()
+    for (let index = 0; index < EXTERNAL_IMPORT_MAX_TREE_ENTRIES; index += 1) {
+      admitExternalImportTreeEntry(budget, 'entry', false)
+    }
+
+    expect(budget).toEqual({
+      entries: EXTERNAL_IMPORT_MAX_TREE_ENTRIES,
+      retainedPathBytes: 0
+    })
+    expect(() => admitExternalImportTreeEntry(budget, 'overflow', false)).toThrow(
+      'External import tree exceeds 100,000 entries'
+    )
+    expect(budget.entries).toBe(EXTERNAL_IMPORT_MAX_TREE_ENTRIES)
+  })
+
+  it('accepts the exact depth and per-path boundaries', () => {
+    const budget = createExternalImportTreeBudget()
+    expect(() => assertExternalImportTreeDepth(EXTERNAL_IMPORT_MAX_TREE_DEPTH)).not.toThrow()
+    expect(() => assertExternalImportTreeDepth(EXTERNAL_IMPORT_MAX_TREE_DEPTH + 1)).toThrow(
+      'External import tree exceeds 256 nested directory levels'
+    )
+    expect(() =>
+      admitExternalImportTreeEntry(
+        budget,
+        'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES),
+        false
+      )
+    ).not.toThrow()
+    expect(() =>
+      admitExternalImportTreeEntry(
+        budget,
+        'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES + 1),
+        false
+      )
+    ).toThrow('External import relative path exceeds 64 KiB')
+  })
+
+  it('accepts the exact aggregate retained-path boundary', () => {
+    const budget = createExternalImportTreeBudget()
+    const path = 'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES)
+    const pathCount =
+      REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES / (EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES * 2)
+    for (let index = 0; index < pathCount; index += 1) {
+      admitExternalImportTreeEntry(budget, path, true)
+    }
+
+    expect(budget.retainedPathBytes).toBe(REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES)
+    expect(() => admitExternalImportTreeEntry(budget, 'b', true)).toThrow(
+      'Remote import retained paths exceed 16 MiB'
+    )
+    expect(budget.retainedPathBytes).toBe(REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES)
+  })
+
+  it('applies file and total byte limits across the full runtime-upload request', () => {
+    const budget = createRuntimeUploadRetentionBudget()
+    const exactFileCount = REMOTE_IMPORT_MAX_TOTAL_BYTES / REMOTE_IMPORT_MAX_FILE_BYTES
+    for (let index = 0; index < exactFileCount; index += 1) {
+      retainRuntimeUploadFileBytes(budget, `file-${index}`, REMOTE_IMPORT_MAX_FILE_BYTES)
+    }
+
+    expect(budget.fileBytes).toBe(REMOTE_IMPORT_MAX_TOTAL_BYTES)
+    expect(() => retainRuntimeUploadFileBytes(budget, 'overflow', 1)).toThrow(
+      'Remote import is too large'
+    )
+    expect(budget.fileBytes).toBe(REMOTE_IMPORT_MAX_TOTAL_BYTES)
+  })
+
+  it('rejects one oversized file without consuming request capacity', () => {
+    const budget = createRuntimeUploadRetentionBudget()
+
+    expect(() =>
+      retainRuntimeUploadFileBytes(budget, 'large.bin', REMOTE_IMPORT_MAX_FILE_BYTES + 1)
+    ).toThrow("'large.bin' is too large for remote import")
+    expect(budget.fileBytes).toBe(0)
+  })
+
+  it('restores capacity reserved by a failed staged source', () => {
+    const budget = createRuntimeUploadRetentionBudget()
+    const checkpoint = captureRuntimeUploadRetentionCheckpoint(budget)
+    admitExternalImportTreeEntry(budget.tree, 'partial.txt', true)
+    retainRuntimeUploadFileBytes(budget, 'partial.txt', 1024)
+
+    restoreRuntimeUploadRetentionCheckpoint(budget, checkpoint)
+
+    expect(budget).toEqual({
+      tree: { entries: 0, retainedPathBytes: 0 },
+      fileBytes: 0
+    })
+  })
+
+  it('uses a typed error for every capacity rejection', () => {
+    const budget = createExternalImportTreeBudget()
+
+    expect(() =>
+      admitExternalImportTreeEntry(
+        budget,
+        'a'.repeat(EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES + 1),
+        false
+      )
+    ).toThrow(ExternalImportCapacityError)
+  })
+})

--- a/src/main/ipc/filesystem-external-import-limits.ts
+++ b/src/main/ipc/filesystem-external-import-limits.ts
@@ -1,0 +1,157 @@
+import {
+  NATIVE_FILE_DROP_MAX_PATH_BYTES,
+  NATIVE_FILE_DROP_MAX_PATHS
+} from '../../shared/native-file-drop'
+
+export const EXTERNAL_IMPORT_MAX_SOURCE_PATHS = NATIVE_FILE_DROP_MAX_PATHS
+export const EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES = NATIVE_FILE_DROP_MAX_PATH_BYTES
+export const EXTERNAL_IMPORT_MAX_TREE_ENTRIES = 100_000
+export const EXTERNAL_IMPORT_MAX_TREE_DEPTH = 256
+export const EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES = 64 * 1024
+export const REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES = 16 * 1024 * 1024
+export const REMOTE_IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024
+export const REMOTE_IMPORT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
+
+export const EXTERNAL_IMPORT_TREE_ENTRY_LIMIT_MESSAGE =
+  'External import tree exceeds 100,000 entries'
+export const EXTERNAL_IMPORT_TREE_DEPTH_LIMIT_MESSAGE =
+  'External import tree exceeds 256 nested directory levels'
+export const EXTERNAL_IMPORT_RELATIVE_PATH_LIMIT_MESSAGE =
+  'External import relative path exceeds 64 KiB'
+export const REMOTE_IMPORT_RETAINED_PATH_LIMIT_MESSAGE =
+  'Remote import retained paths exceed 16 MiB'
+
+export type ExternalImportTreeBudget = {
+  entries: number
+  retainedPathBytes: number
+}
+
+export type RuntimeUploadRetentionBudget = {
+  tree: ExternalImportTreeBudget
+  fileBytes: number
+}
+
+export type RuntimeUploadRetentionCheckpoint = {
+  entries: number
+  retainedPathBytes: number
+  fileBytes: number
+}
+
+export class ExternalImportCapacityError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ExternalImportCapacityError'
+  }
+}
+
+export function assertExternalImportSourcePaths(
+  sourcePaths: unknown
+): asserts sourcePaths is readonly string[] {
+  if (!Array.isArray(sourcePaths)) {
+    throw new TypeError('External import source paths must be an array')
+  }
+  if (sourcePaths.length > EXTERNAL_IMPORT_MAX_SOURCE_PATHS) {
+    throw new ExternalImportCapacityError(
+      `External import accepts at most ${EXTERNAL_IMPORT_MAX_SOURCE_PATHS} source paths`
+    )
+  }
+
+  let pathBytes = 0
+  for (const sourcePath of sourcePaths) {
+    if (typeof sourcePath !== 'string') {
+      throw new TypeError('External import source paths must be strings')
+    }
+    pathBytes += Buffer.byteLength(sourcePath, 'utf8')
+    if (pathBytes > EXTERNAL_IMPORT_MAX_SOURCE_PATH_BYTES) {
+      throw new ExternalImportCapacityError('External import source paths exceed 256 KiB')
+    }
+  }
+}
+
+export function createExternalImportTreeBudget(): ExternalImportTreeBudget {
+  return { entries: 0, retainedPathBytes: 0 }
+}
+
+export function assertExternalImportTreeDepth(depth: number): void {
+  if (depth > EXTERNAL_IMPORT_MAX_TREE_DEPTH) {
+    throw new ExternalImportCapacityError(EXTERNAL_IMPORT_TREE_DEPTH_LIMIT_MESSAGE)
+  }
+}
+
+export function admitExternalImportTreeEntry(
+  budget: ExternalImportTreeBudget,
+  relativePath: string,
+  retainPath: boolean
+): void {
+  if (budget.entries >= EXTERNAL_IMPORT_MAX_TREE_ENTRIES) {
+    throw new ExternalImportCapacityError(EXTERNAL_IMPORT_TREE_ENTRY_LIMIT_MESSAGE)
+  }
+
+  const pathBytes = Buffer.byteLength(relativePath, 'utf8')
+  if (pathBytes > EXTERNAL_IMPORT_MAX_RELATIVE_PATH_BYTES) {
+    throw new ExternalImportCapacityError(EXTERNAL_IMPORT_RELATIVE_PATH_LIMIT_MESSAGE)
+  }
+  const retainedPathBytes = relativePath.length * 2
+  if (
+    retainPath &&
+    retainedPathBytes > REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES - budget.retainedPathBytes
+  ) {
+    throw new ExternalImportCapacityError(REMOTE_IMPORT_RETAINED_PATH_LIMIT_MESSAGE)
+  }
+
+  budget.entries += 1
+  if (retainPath) {
+    budget.retainedPathBytes += retainedPathBytes
+  }
+}
+
+export function createRuntimeUploadRetentionBudget(): RuntimeUploadRetentionBudget {
+  return {
+    tree: createExternalImportTreeBudget(),
+    fileBytes: 0
+  }
+}
+
+export function captureRuntimeUploadRetentionCheckpoint(
+  budget: RuntimeUploadRetentionBudget
+): RuntimeUploadRetentionCheckpoint {
+  return {
+    entries: budget.tree.entries,
+    retainedPathBytes: budget.tree.retainedPathBytes,
+    fileBytes: budget.fileBytes
+  }
+}
+
+export function restoreRuntimeUploadRetentionCheckpoint(
+  budget: RuntimeUploadRetentionBudget,
+  checkpoint: RuntimeUploadRetentionCheckpoint
+): void {
+  budget.tree.entries = checkpoint.entries
+  budget.tree.retainedPathBytes = checkpoint.retainedPathBytes
+  budget.fileBytes = checkpoint.fileBytes
+}
+
+export function assertRuntimeUploadFileFits(
+  budget: RuntimeUploadRetentionBudget,
+  relativePath: string,
+  fileBytes: number
+): void {
+  if (!Number.isSafeInteger(fileBytes) || fileBytes < 0) {
+    throw new Error(`Could not safely measure '${relativePath}' for remote import`)
+  }
+  if (fileBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
+    throw new ExternalImportCapacityError(`'${relativePath}' is too large for remote import`)
+  }
+  if (fileBytes > REMOTE_IMPORT_MAX_TOTAL_BYTES - budget.fileBytes) {
+    throw new ExternalImportCapacityError('Remote import is too large')
+  }
+}
+
+export function retainRuntimeUploadFileBytes(
+  budget: RuntimeUploadRetentionBudget,
+  relativePath: string,
+  fileBytes: number
+): void {
+  assertRuntimeUploadFileFits(budget, relativePath, fileBytes)
+  budget.fileBytes += fileBytes
+}

--- a/src/main/ipc/filesystem-import-ssh-directory.ts
+++ b/src/main/ipc/filesystem-import-ssh-directory.ts
@@ -1,7 +1,13 @@
-import { lstat, readdir, realpath } from 'node:fs/promises'
+import { lstat, opendir, realpath } from 'node:fs/promises'
 import { isAbsolute, join, relative, sep } from 'node:path'
 import type { FileUploadSession, IFilesystemProvider } from '../providers/types'
 import { assertSafeRemotePathSegment, type RemotePathFlavor } from '../ssh/ssh-remote-platform'
+import {
+  admitExternalImportTreeEntry,
+  assertExternalImportTreeDepth,
+  createExternalImportTreeBudget,
+  type ExternalImportTreeBudget
+} from './filesystem-external-import-limits'
 
 export async function captureLocalUploadRoot(
   sourcePath: string,
@@ -23,18 +29,47 @@ export async function preScanSshImportDirectory(
   dirPath: string,
   remotePathFlavor: RemotePathFlavor
 ): Promise<boolean> {
-  const entries = await readdir(dirPath, { withFileTypes: true })
-  for (const entry of entries) {
-    assertSafeRemotePathSegment(entry.name, remotePathFlavor)
-    if (entry.isSymbolicLink()) {
-      return true
-    }
-    if (entry.isDirectory()) {
-      const childPath = join(dirPath, entry.name)
-      if (await preScanSshImportDirectory(childPath, remotePathFlavor)) {
+  return preScanSshImportDirectoryWithinBudget(
+    dirPath,
+    remotePathFlavor,
+    createExternalImportTreeBudget(),
+    '',
+    0
+  )
+}
+
+async function preScanSshImportDirectoryWithinBudget(
+  dirPath: string,
+  remotePathFlavor: RemotePathFlavor,
+  budget: ExternalImportTreeBudget,
+  relativeDir: string,
+  depth: number
+): Promise<boolean> {
+  assertExternalImportTreeDepth(depth)
+  const directory = await opendir(dirPath)
+  try {
+    for await (const entry of directory) {
+      assertSafeRemotePathSegment(entry.name, remotePathFlavor)
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+      admitExternalImportTreeEntry(budget, relativePath, false)
+      if (entry.isSymbolicLink()) {
+        return true
+      }
+      if (
+        entry.isDirectory() &&
+        (await preScanSshImportDirectoryWithinBudget(
+          join(dirPath, entry.name),
+          remotePathFlavor,
+          budget,
+          relativePath,
+          depth + 1
+        ))
+      ) {
         return true
       }
     }
+  } finally {
+    await directory.close().catch(() => undefined)
   }
   return false
 }
@@ -48,37 +83,72 @@ export async function uploadSshImportDirectory(
   remotePathFlavor: RemotePathFlavor,
   assertCurrent?: () => void
 ): Promise<void> {
+  await uploadSshImportDirectoryWithinBudget(
+    provider,
+    uploadSession,
+    localDir,
+    remoteDir,
+    rootRealPath,
+    remotePathFlavor,
+    createExternalImportTreeBudget(),
+    '',
+    0,
+    assertCurrent
+  )
+}
+
+async function uploadSshImportDirectoryWithinBudget(
+  provider: IFilesystemProvider,
+  uploadSession: FileUploadSession,
+  localDir: string,
+  remoteDir: string,
+  rootRealPath: string,
+  remotePathFlavor: RemotePathFlavor,
+  budget: ExternalImportTreeBudget,
+  relativeDir: string,
+  depth: number,
+  assertCurrent?: () => void
+): Promise<void> {
+  assertExternalImportTreeDepth(depth)
   await assertLocalUploadPathInsideRoot(rootRealPath, localDir)
-  const entries = await readdir(localDir, { withFileTypes: true })
-  for (const entry of entries) {
-    assertSafeRemotePathSegment(entry.name, remotePathFlavor)
-    const localPath = join(localDir, entry.name)
-    const remotePath = `${remoteDir}/${entry.name}`
-    await assertLocalUploadPathInsideRoot(rootRealPath, localPath)
-    const statResult = await lstat(localPath)
+  const directory = await opendir(localDir)
+  try {
+    for await (const entry of directory) {
+      assertSafeRemotePathSegment(entry.name, remotePathFlavor)
+      const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name
+      admitExternalImportTreeEntry(budget, relativePath, false)
+      const localPath = join(localDir, entry.name)
+      const remotePath = `${remoteDir}/${entry.name}`
+      await assertLocalUploadPathInsideRoot(rootRealPath, localPath)
+      const statResult = await lstat(localPath)
 
-    // Why: skip symlinks and special files even after the up-front pre-scan;
-    // this closes the TOCTOU gap if one is created during upload.
-    if (statResult.isSymbolicLink() || (!statResult.isFile() && !statResult.isDirectory())) {
-      continue
-    }
+      // Why: the up-front scan cannot prevent a source swap during upload.
+      if (statResult.isSymbolicLink() || (!statResult.isFile() && !statResult.isDirectory())) {
+        continue
+      }
 
-    if (statResult.isDirectory()) {
+      if (statResult.isDirectory()) {
+        assertCurrent?.()
+        await provider.createDirNoClobber(remotePath)
+        await uploadSshImportDirectoryWithinBudget(
+          provider,
+          uploadSession,
+          localPath,
+          remotePath,
+          rootRealPath,
+          remotePathFlavor,
+          budget,
+          relativePath,
+          depth + 1,
+          assertCurrent
+        )
+        continue
+      }
       assertCurrent?.()
-      await provider.createDirNoClobber(remotePath)
-      await uploadSshImportDirectory(
-        provider,
-        uploadSession,
-        localPath,
-        remotePath,
-        rootRealPath,
-        remotePathFlavor,
-        assertCurrent
-      )
-      continue
+      await uploadSession.uploadFile(localPath, remotePath, { exclusive: true })
     }
-    assertCurrent?.()
-    await uploadSession.uploadFile(localPath, remotePath, { exclusive: true })
+  } finally {
+    await directory.close().catch(() => undefined)
   }
 }
 

--- a/src/main/ipc/filesystem-import-ssh-ops.test.ts
+++ b/src/main/ipc/filesystem-import-ssh-ops.test.ts
@@ -9,6 +9,7 @@ const {
   mkdirMock,
   realpathMock,
   copyFileMock,
+  opendirMock,
   readdirMock,
   getConnMgrMock
 } = vi.hoisted(() => ({
@@ -17,6 +18,7 @@ const {
   mkdirMock: vi.fn(),
   realpathMock: vi.fn(),
   copyFileMock: vi.fn(),
+  opendirMock: vi.fn(),
   readdirMock: vi.fn(),
   getConnMgrMock: vi.fn()
 }))
@@ -29,14 +31,15 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
   realpath: realpathMock,
   copyFile: copyFileMock,
-  readdir: readdirMock
+  opendir: opendirMock
 }))
 vi.mock('./ssh', () => ({ getSshConnectionManager: getConnMgrMock }))
 
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
 import {
   advanceSshConnectionGeneration,
-  resetSshConnectionGenerations
+  resetSshConnectionGenerations,
+  setSshConnectionGeneration
 } from '../ssh/ssh-connection-generation'
 import {
   registerSshFilesystemProvider,
@@ -82,6 +85,7 @@ function createProvider(uploadSession: FileUploadSession): IFilesystemProvider {
 }
 
 describe('fs:importExternalPaths — SSH operations', () => {
+  const sessionCounterStride = 2 ** 13
   const destDir = '/home/user/project/src'
   const connId = 'ssh-conn-1'
   let provider: IFilesystemProvider
@@ -130,12 +134,15 @@ describe('fs:importExternalPaths — SSH operations', () => {
 
   beforeEach(() => {
     handlers.clear()
+    resetSshConnectionGenerations()
+    setSshConnectionGeneration(connId, 0)
     ;[
       handleMock,
       lstatMock,
       mkdirMock,
       realpathMock,
       copyFileMock,
+      opendirMock,
       readdirMock,
       getConnMgrMock
     ].forEach((m) => m.mockReset())
@@ -145,6 +152,12 @@ describe('fs:importExternalPaths — SSH operations', () => {
     realpathMock.mockImplementation(async (p: string) => p)
     lstatMock.mockRejectedValue(enoent())
     readdirMock.mockResolvedValue([])
+    opendirMock.mockImplementation(async (directoryPath: string) => ({
+      async *[Symbol.asyncIterator]() {
+        yield* await readdirMock(directoryPath, { withFileTypes: true })
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    }))
     getConnMgrMock.mockReturnValue({ getConnection: () => makeConn() })
     uploadSession = {
       uploadFile: vi.fn().mockResolvedValue(undefined),
@@ -162,6 +175,7 @@ describe('fs:importExternalPaths — SSH operations', () => {
 
   it('rejects a staged upload when a restarted HUB reaches the same target counter', async () => {
     resetSshConnectionGenerations(71)
+    setSshConnectionGeneration(connId, 71 * sessionCounterStride)
     const stagedGeneration = advanceSshConnectionGeneration(connId)
     const sourcePath = path.resolve('/tmp/dropped/restart.txt')
     lstatMock.mockImplementation(async (candidate: string) => {
@@ -169,6 +183,7 @@ describe('fs:importExternalPaths — SSH operations', () => {
         throw enoent()
       }
       resetSshConnectionGenerations(72)
+      setSshConnectionGeneration(connId, 72 * sessionCounterStride)
       advanceSshConnectionGeneration(connId)
       return {
         size: 12,

--- a/src/main/ipc/filesystem-import-ssh-path-safety.test.ts
+++ b/src/main/ipc/filesystem-import-ssh-path-safety.test.ts
@@ -2,17 +2,19 @@ import path from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { FileUploadSession, IFilesystemProvider } from '../providers/types'
 
-const { getConnMgrMock, lstatMock, providerMock, readdirMock, realpathMock } = vi.hoisted(() => ({
-  getConnMgrMock: vi.fn(),
-  lstatMock: vi.fn(),
-  providerMock: vi.fn(),
-  readdirMock: vi.fn(),
-  realpathMock: vi.fn()
-}))
+const { getConnMgrMock, lstatMock, opendirMock, providerMock, readdirMock, realpathMock } =
+  vi.hoisted(() => ({
+    getConnMgrMock: vi.fn(),
+    lstatMock: vi.fn(),
+    opendirMock: vi.fn(),
+    providerMock: vi.fn(),
+    readdirMock: vi.fn(),
+    realpathMock: vi.fn()
+  }))
 
 vi.mock('node:fs/promises', () => ({
   lstat: lstatMock,
-  readdir: readdirMock,
+  opendir: opendirMock,
   realpath: realpathMock
 }))
 vi.mock('./filesystem-auth', () => ({
@@ -25,6 +27,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 }))
 
 import { importExternalPathsSsh } from './filesystem-import-ssh'
+import { EXTERNAL_IMPORT_MAX_TREE_ENTRIES } from './filesystem-external-import-limits'
 
 function createProvider(uploadSession: FileUploadSession): IFilesystemProvider {
   const missing = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
@@ -54,6 +57,12 @@ describe('SSH import remote path safety', () => {
     provider = createProvider(uploadSession)
     providerMock.mockReturnValue(provider)
     readdirMock.mockResolvedValue([])
+    opendirMock.mockImplementation(async (directoryPath: string) => ({
+      async *[Symbol.asyncIterator]() {
+        yield* await readdirMock(directoryPath, { withFileTypes: true })
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    }))
     realpathMock.mockImplementation(async (value: string) => value)
   })
 
@@ -187,6 +196,47 @@ describe('SSH import remote path safety', () => {
         { exclusive: true }
       )
     }
+  })
+
+  it('rejects an oversized directory before creating the remote root', async () => {
+    const sourcePath = path.resolve('/tmp/generated')
+    let yieldedEntries = 0
+    let iteratorClosed = false
+    lstatMock.mockResolvedValue({
+      isFile: () => false,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (yieldedEntries <= EXTERNAL_IMPORT_MAX_TREE_ENTRIES) {
+            const index = yieldedEntries
+            yieldedEntries += 1
+            yield {
+              name: `entry-${index}`,
+              isFile: () => true,
+              isDirectory: () => false,
+              isSymbolicLink: () => false
+            }
+          }
+        } finally {
+          iteratorClosed = true
+        }
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    })
+
+    const { results } = await importExternalPathsSsh([sourcePath], destDir, connectionId)
+
+    expect(results[0]).toMatchObject({
+      status: 'failed',
+      reason: 'External import tree exceeds 100,000 entries'
+    })
+    expect(yieldedEntries).toBe(EXTERNAL_IMPORT_MAX_TREE_ENTRIES + 1)
+    expect(iteratorClosed).toBe(true)
+    expect(provider.createDirNoClobber).not.toHaveBeenCalled()
+    expect(uploadSession.uploadFile).not.toHaveBeenCalled()
   })
 
   it('skips special entries without failing the directory import', async () => {

--- a/src/main/ipc/filesystem-import-ssh.test.ts
+++ b/src/main/ipc/filesystem-import-ssh.test.ts
@@ -37,6 +37,7 @@ vi.mock('fs/promises', () => ({
   copyFile: copyFileMock,
   open: openMock,
   readdir: readdirMock,
+  opendir: vi.fn(),
   unlink: unlinkMock,
   rm: vi.fn()
 }))
@@ -47,7 +48,10 @@ import {
   registerSshFilesystemProvider,
   unregisterSshFilesystemProvider
 } from '../providers/ssh-filesystem-dispatch'
-import { resetSshConnectionGenerations } from '../ssh/ssh-connection-generation'
+import {
+  resetSshConnectionGenerations,
+  setSshConnectionGeneration
+} from '../ssh/ssh-connection-generation'
 
 const store = {
   getRepos: () => [
@@ -130,6 +134,7 @@ describe('fs:importExternalPaths — SSH routing & connection', () => {
   beforeEach(() => {
     handlers.clear()
     resetSshConnectionGenerations()
+    setSshConnectionGeneration(connId, 0)
     ;[
       handleMock,
       lstatMock,

--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -11,7 +11,7 @@ const {
   realpathMock,
   copyFileMock,
   openMock,
-  readFileMock,
+  opendirMock,
   readdirMock,
   rmMock,
   unlinkMock
@@ -22,7 +22,7 @@ const {
   realpathMock: vi.fn(),
   copyFileMock: vi.fn(),
   openMock: vi.fn(),
-  readFileMock: vi.fn(),
+  opendirMock: vi.fn(),
   readdirMock: vi.fn(),
   rmMock: vi.fn(),
   unlinkMock: vi.fn()
@@ -40,13 +40,17 @@ vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
   realpath: realpathMock,
   copyFile: copyFileMock,
-  readFile: readFileMock,
-  readdir: readdirMock,
+  opendir: opendirMock,
   rm: rmMock,
   unlink: unlinkMock
 }))
 
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
+import {
+  EXTERNAL_IMPORT_MAX_SOURCE_PATHS,
+  EXTERNAL_IMPORT_MAX_TREE_ENTRIES,
+  REMOTE_IMPORT_MAX_FILE_BYTES
+} from './filesystem-external-import-limits'
 
 const REPO_PATH = path.resolve('/workspace/repo')
 const WORKSPACE_DIR = path.resolve('/workspace')
@@ -60,6 +64,24 @@ const store = {
 
 function enoent(): Error {
   return Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+}
+
+function streamDirectoryEntries(entries: unknown[]) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* entries
+    }
+  }
+}
+
+function createFileHandleRead(content: Buffer) {
+  return vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+    const bytesRead = Math.min(length, Math.max(0, content.byteLength - position))
+    if (bytesRead > 0) {
+      content.copy(buffer, offset, position, position + bytesRead)
+    }
+    return { buffer, bytesRead }
+  })
 }
 
 describe('fs:importExternalPaths', () => {
@@ -158,7 +180,7 @@ describe('fs:importExternalPaths', () => {
     realpathMock.mockReset()
     copyFileMock.mockReset()
     openMock.mockReset()
-    readFileMock.mockReset()
+    opendirMock.mockReset()
     readdirMock.mockReset()
     rmMock.mockReset()
     unlinkMock.mockReset()
@@ -172,8 +194,10 @@ describe('fs:importExternalPaths', () => {
     mkdirMock.mockResolvedValue(undefined)
     copyFileMock.mockResolvedValue(undefined)
     mockLocalCopyOpenSuccess()
-    readFileMock.mockResolvedValue(Buffer.from('file-content'))
     readdirMock.mockResolvedValue([])
+    opendirMock.mockImplementation(async (dirPath: string) =>
+      streamDirectoryEntries(await readdirMock(dirPath))
+    )
     rmMock.mockResolvedValue(undefined)
     unlinkMock.mockResolvedValue(undefined)
 
@@ -384,6 +408,67 @@ describe('fs:importExternalPaths', () => {
     expect(copyFileMock).not.toHaveBeenCalled()
   })
 
+  it('stops streaming an oversized local tree before creating its destination', async () => {
+    const sourcePath = '/tmp/dropped/generated'
+    const resolvedSource = path.resolve(sourcePath)
+    let iteratorClosed = false
+    let yieldedEntries = 0
+    lstatMock.mockImplementation(async (candidatePath: string) => {
+      if (candidatePath === resolvedSource) {
+        return {
+          isFile: () => false,
+          isDirectory: () => true,
+          isSymbolicLink: () => false
+        }
+      }
+      throw enoent()
+    })
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        try {
+          while (yieldedEntries <= EXTERNAL_IMPORT_MAX_TREE_ENTRIES) {
+            const index = yieldedEntries
+            yieldedEntries += 1
+            yield {
+              name: `entry-${index}`,
+              isDirectory: () => false,
+              isSymbolicLink: () => false,
+              isFile: () => true
+            }
+          }
+        } finally {
+          iteratorClosed = true
+        }
+      }
+    })
+
+    const result = (await handlers.get('fs:importExternalPaths')!(null, {
+      sourcePaths: [sourcePath],
+      destDir
+    })) as { results: { status: string; reason?: string }[] }
+
+    expect(result.results[0]).toMatchObject({
+      status: 'failed',
+      reason: 'External import tree exceeds 100,000 entries'
+    })
+    expect(yieldedEntries).toBe(EXTERNAL_IMPORT_MAX_TREE_ENTRIES + 1)
+    expect(iteratorClosed).toBe(true)
+    expect(mkdirMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects oversized source batches before touching the filesystem', async () => {
+    const sourcePaths = Array.from(
+      { length: EXTERNAL_IMPORT_MAX_SOURCE_PATHS + 1 },
+      (_, index) => `/tmp/dropped/${index}`
+    )
+
+    await expect(
+      handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, { sourcePaths })
+    ).rejects.toThrow('External import accepts at most 256 source paths')
+    expect(lstatMock).not.toHaveBeenCalled()
+    expect(openMock).not.toHaveBeenCalled()
+  })
+
   it('fails and removes output if a local directory entry becomes a symlink after pre-scan', async () => {
     const sourcePath = '/tmp/dropped/mixeddir'
     const resolvedSource = path.resolve(sourcePath)
@@ -481,7 +566,7 @@ describe('fs:importExternalPaths', () => {
     lstatMock.mockImplementation(async (p: string) => {
       if (p === resolvedPath) {
         return {
-          size: 4,
+          size: 3,
           ino: 1,
           dev: 1,
           isFile: () => true,
@@ -492,15 +577,15 @@ describe('fs:importExternalPaths', () => {
       throw enoent()
     })
     const closeMock = vi.fn().mockResolvedValue(undefined)
-    const readFileHandleMock = vi.fn().mockResolvedValue(Buffer.from('png'))
+    const readFileHandleMock = createFileHandleRead(Buffer.from('png'))
     openMock.mockResolvedValue({
       stat: vi.fn().mockResolvedValue({
-        size: 4,
+        size: 3,
         ino: 1,
         dev: 1,
         isFile: () => true
       }),
-      readFile: readFileHandleMock,
+      read: readFileHandleMock,
       close: closeMock
     })
 
@@ -580,7 +665,7 @@ describe('fs:importExternalPaths', () => {
         dev: 1,
         isFile: () => true
       }),
-      readFile: vi.fn().mockResolvedValue(Buffer.from('icon')),
+      read: createFileHandleRead(Buffer.from('icon')),
       close: vi.fn().mockResolvedValue(undefined)
     })
 
@@ -637,16 +722,10 @@ describe('fs:importExternalPaths', () => {
     expect(openMock).not.toHaveBeenCalled()
   })
 
-  it('checks runtime upload directory byte budget before reading a file that exceeds the total cap', async () => {
+  it('checks the runtime upload file budget before opening an oversized entry', async () => {
     const sourcePath = '/tmp/dropped/project'
     const resolvedPath = path.resolve(sourcePath)
-    const filePaths = ['one.bin', 'two.bin', 'three.bin', 'four.bin', 'overflow.bin'].map((name) =>
-      path.join(resolvedPath, name)
-    )
-    const mib = 1024 * 1024
-    const regularSize = 25 * mib
-    const overflowSize = 1 * mib
-    const readFileMock = vi.fn().mockResolvedValue(Buffer.from('chunk'))
+    const oversizedPath = path.join(resolvedPath, 'oversized.bin')
 
     lstatMock.mockImplementation(async (p: string) => {
       if (p === resolvedPath) {
@@ -659,12 +738,10 @@ describe('fs:importExternalPaths', () => {
           isSymbolicLink: () => false
         }
       }
-      const fileIndex = filePaths.indexOf(p)
-      if (fileIndex !== -1) {
-        const size = fileIndex === filePaths.length - 1 ? overflowSize : regularSize
+      if (p === oversizedPath) {
         return {
-          size,
-          ino: fileIndex + 2,
+          size: REMOTE_IMPORT_MAX_FILE_BYTES + 1,
+          ino: 2,
           dev: 1,
           isFile: () => true,
           isDirectory: () => false,
@@ -673,30 +750,14 @@ describe('fs:importExternalPaths', () => {
       }
       throw enoent()
     })
-    readdirMock.mockResolvedValue(
-      filePaths.map((filePath) => ({
-        name: path.basename(filePath),
+    readdirMock.mockResolvedValue([
+      {
+        name: path.basename(oversizedPath),
         isDirectory: () => false,
         isSymbolicLink: () => false,
         isFile: () => true
-      }))
-    )
-    openMock.mockImplementation(async (p: string) => {
-      const fileIndex = filePaths.indexOf(p)
-      if (fileIndex >= 0 && fileIndex < filePaths.length - 1) {
-        return {
-          stat: vi.fn().mockResolvedValue({
-            size: regularSize,
-            ino: fileIndex + 2,
-            dev: 1,
-            isFile: () => true
-          }),
-          readFile: readFileMock,
-          close: vi.fn().mockResolvedValue(undefined)
-        }
       }
-      throw new Error(`unexpected open: ${p}`)
-    })
+    ])
 
     const result = (await handlers.get('fs:stageExternalPathsForRuntimeUpload')!(null, {
       sourcePaths: [sourcePath]
@@ -704,10 +765,9 @@ describe('fs:importExternalPaths', () => {
 
     expect(result.sources[0]).toMatchObject({
       status: 'failed',
-      reason: 'Remote import is too large'
+      reason: "'oversized.bin' is too large for remote import"
     })
-    expect(readFileMock).toHaveBeenCalledTimes(4)
-    expect(openMock).not.toHaveBeenCalledWith(filePaths.at(-1), expect.anything())
+    expect(openMock).not.toHaveBeenCalled()
   })
 
   it('fails runtime upload staging when a file changes between lstat and open', async () => {
@@ -726,7 +786,7 @@ describe('fs:importExternalPaths', () => {
       }
       throw enoent()
     })
-    const readFileHandleMock = vi.fn().mockResolvedValue(Buffer.from('png'))
+    const readFileHandleMock = createFileHandleRead(Buffer.from('png'))
     openMock.mockResolvedValue({
       stat: vi.fn().mockResolvedValue({
         size: 4,
@@ -734,7 +794,7 @@ describe('fs:importExternalPaths', () => {
         dev: 1,
         isFile: () => true
       }),
-      readFile: readFileHandleMock,
+      read: readFileHandleMock,
       close: vi.fn().mockResolvedValue(undefined)
     })
 

--- a/src/main/ipc/filesystem-list-files-git-directory-expansion.test.ts
+++ b/src/main/ipc/filesystem-list-files-git-directory-expansion.test.ts
@@ -62,12 +62,13 @@ describe('main Quick Open git directory expansion', () => {
 
     const promise = listFilesWithGit(root, [], {})
     revParse.emit('close', 0, null)
-    await vi.waitFor(() => expect(gitSpawnMock).toHaveBeenCalledTimes(3))
+    await vi.waitFor(() => expect(gitSpawnMock).toHaveBeenCalledTimes(2))
     ;(primary.stdout as unknown as EventEmitter).emit(
       'data',
       `100644 ${SHA1} 0\tsrc/index.ts\0scratch/\0`
     )
     primary.emit('close', 0, null)
+    await vi.waitFor(() => expect(gitSpawnMock).toHaveBeenCalledTimes(3))
     ;(ignored.stdout as unknown as EventEmitter).emit('data', 'dist/\0')
     ignored.emit('close', 0, null)
 
@@ -79,7 +80,7 @@ describe('main Quick Open git directory expansion', () => {
     expect(gitSpawnMock.mock.calls[2][0]).toContain('--directory')
   })
 
-  it('cancels both local Git passes when Quick Open abandons the request', async () => {
+  it('cancels the active local Git pass when Quick Open abandons the request', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-main-git-cancel-'))
     tempDirs.push(root)
     const revParse = createMockProcess()
@@ -93,11 +94,12 @@ describe('main Quick Open git directory expansion', () => {
     const controller = new AbortController()
     const promise = listFilesWithGit(root, [], {}, controller.signal)
     revParse.emit('close', 0, null)
-    await vi.waitFor(() => expect(gitSpawnMock).toHaveBeenCalledTimes(3))
+    await vi.waitFor(() => expect(gitSpawnMock).toHaveBeenCalledTimes(2))
     controller.abort()
 
     await expect(promise).rejects.toSatisfy(isFileListingCancellation)
     expect(primary.kill).toHaveBeenCalled()
-    expect(ignored.kill).toHaveBeenCalled()
+    expect(ignored.kill).not.toHaveBeenCalled()
+    expect(gitSpawnMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/ipc/filesystem-list-files-git-fallback.ts
+++ b/src/main/ipc/filesystem-list-files-git-fallback.ts
@@ -12,6 +12,13 @@ import {
   parseQuickOpenGitLsFilesEntry
 } from '../../shared/quick-open-readdir-walk'
 import { fileListingCancellationError } from '../../shared/file-listing-cancellation'
+import {
+  createQuickOpenListingBudget,
+  QUICK_OPEN_LISTING_MAX_PATH_BYTES,
+  QuickOpenSubprocessPathAccumulator,
+  resolveQuickOpenResultLimit,
+  retainQuickOpenPath
+} from '../../shared/quick-open-listing-limits'
 
 /**
  * Fallback file lister using git ls-files. Used when rg is not available.
@@ -81,6 +88,13 @@ export async function listFilesWithGit(
   signal?: AbortSignal,
   maxResults?: number
 ): Promise<string[]> {
+  if (signal?.aborted) {
+    throw fileListingCancellationError(signal)
+  }
+  const resultLimit = resolveQuickOpenResultLimit(maxResults)
+  if (resultLimit === 0) {
+    return []
+  }
   const isGitWorkTree = await isInsideGitWorkTree(rootPath, localGitOptions, signal)
   if (signal?.aborted) {
     throw fileListingCancellationError(signal)
@@ -89,7 +103,7 @@ export async function listFilesWithGit(
     return listQuickOpenFilesWithReaddir(rootPath, {
       excludePathPrefixes,
       budget: createQuickOpenReaddirBudget(),
-      maxResults,
+      maxResults: resultLimit,
       signal
     })
   }
@@ -97,6 +111,7 @@ export async function listFilesWithGit(
   const gitPaths = new Set<string>()
   const directoryPaths = new Set<string>()
   const directFileCandidates = new Set<string>()
+  const listingBudget = createQuickOpenListingBudget()
   const { primary, ignoredPass } = buildGitLsFilesArgsForQuickOpen(excludePathPrefixes)
   const children: {
     child: ChildProcess
@@ -107,7 +122,7 @@ export async function listFilesWithGit(
 
   const runGitLsFiles = (args: string[]): Promise<void> => {
     return new Promise((resolve, reject) => {
-      let buf = ''
+      const paths = new QuickOpenSubprocessPathAccumulator(0)
       let done = false
 
       const processPath = (path: string): boolean => {
@@ -115,27 +130,23 @@ export async function listFilesWithGit(
           return false
         }
         if (path.endsWith('/')) {
-          directoryPaths.add(path)
+          retainQuickOpenPath(directoryPaths, path, listingBudget)
         } else {
-          gitPaths.add(path)
-          if (maxResults !== undefined) {
-            // Why: this duplicate classification exists only to stop bounded
-            // scans; unbounded scans must not retain a second repo-sized set.
-            const parsed = parseQuickOpenGitLsFilesEntry(path)
-            const relPath = parsed.path.replace(/\/+$/, '')
-            if (
-              !parsed.isGitlink &&
-              !parsed.isUntrackedDir &&
-              shouldIncludeQuickOpenPath(relPath) &&
-              !shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)
-            ) {
-              directFileCandidates.add(relPath)
-            }
+          retainQuickOpenPath(gitPaths, path, listingBudget)
+          const parsed = parseQuickOpenGitLsFilesEntry(path)
+          const relPath = parsed.path.replace(/\/+$/, '')
+          if (
+            !parsed.isGitlink &&
+            !parsed.isUntrackedDir &&
+            shouldIncludeQuickOpenPath(relPath) &&
+            !shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)
+          ) {
+            retainQuickOpenPath(directFileCandidates, relPath, listingBudget)
           }
         }
         // Why: collapsed directories and gitlinks may be discarded during the
         // later filesystem classification, so they cannot consume the stop cap.
-        return maxResults !== undefined && directFileCandidates.size >= maxResults
+        return directFileCandidates.size >= resultLimit
       }
 
       // Why: git ls-files outputs paths relative to cwd, so we set cwd to
@@ -160,7 +171,7 @@ export async function listFilesWithGit(
           return
         }
         done = true
-        buf = ''
+        paths.clear()
         cleanup()
         reject(err)
       }
@@ -169,6 +180,7 @@ export async function listFilesWithGit(
           return
         }
         done = true
+        paths.clear()
         cleanup()
         resolve()
       }
@@ -178,20 +190,23 @@ export async function listFilesWithGit(
         reject: rejectPass,
         resolve: resolvePass
       })
-      const handleStdoutData = (chunk: string): void => {
-        buf += chunk
-        let start = 0
-        let nulIdx = buf.indexOf('\0', start)
-        while (nulIdx !== -1) {
-          if (processPath(buf.substring(start, nulIdx))) {
-            buf = ''
+      const failForOutput = (error: unknown): void => {
+        child.kill()
+        rejectPass(error instanceof Error ? error : new Error(String(error)))
+      }
+      const handleStdoutData = (chunk: Buffer | string): void => {
+        try {
+          const outcome = paths.push(chunk, (path) => !processPath(path))
+          if (outcome === 'stopped') {
             finishAtLimit()
-            return
+          } else if (outcome === 'path-too-large') {
+            failForOutput(
+              new Error(`Quick Open file path exceeded ${QUICK_OPEN_LISTING_MAX_PATH_BYTES} bytes`)
+            )
           }
-          start = nulIdx + 1
-          nulIdx = buf.indexOf('\0', start)
+        } catch (error) {
+          failForOutput(error)
         }
-        buf = start < buf.length ? buf.substring(start) : ''
       }
       const handleStderrData = (): void => {
         /* drain */
@@ -207,9 +222,14 @@ export async function listFilesWithGit(
           rejectPass(new Error(`git ls-files killed by ${signal}`))
           return
         }
-        if (buf && processPath(buf)) {
-          buf = ''
-          finishAtLimit()
+        try {
+          const trailingPath = paths.finish()
+          if (trailingPath && processPath(trailingPath)) {
+            finishAtLimit()
+            return
+          }
+        } catch (error) {
+          failForOutput(error)
           return
         }
         if (code === 0) {
@@ -219,13 +239,12 @@ export async function listFilesWithGit(
         rejectPass(new Error(`git ls-files exited with code ${code}`))
       }
 
-      child.stdout!.setEncoding('utf-8')
       child.stdout!.on('data', handleStdoutData)
       child.stderr!.on('data', handleStderrData)
       child.once('error', handleError)
       child.once('close', handleClose)
       timer = setTimeout(() => {
-        buf = ''
+        paths.clear()
         child.kill()
         rejectPass(new Error('git ls-files timed out'))
       }, 10000)
@@ -269,15 +288,11 @@ export async function listFilesWithGit(
           console.warn('[quick-open] git ignored-file pass failed; keeping primary results:', err)
         }
       })
-    if (maxResults === undefined) {
-      await Promise.all([runGitLsFiles(primary), runIgnoredPass()])
-    } else {
-      // Why: give ordinary source files first claim on a bounded autocomplete
-      // inventory; a large ignored tree must not win a parallel-output race.
-      await runGitLsFiles(primary)
-      if (directFileCandidates.size < maxResults) {
-        await runIgnoredPass()
-      }
+    // Why: give ordinary source files first claim on a bounded autocomplete
+    // inventory; a large ignored tree must not win a parallel-output race.
+    await runGitLsFiles(primary)
+    if (directFileCandidates.size < resultLimit) {
+      await runIgnoredPass()
     }
   } catch (err) {
     killSurvivors()
@@ -295,9 +310,9 @@ export async function listFilesWithGit(
     directoryPaths,
     excludePathPrefixes,
     signal,
-    maxResults
+    maxResults: resultLimit
   })
   // Why: directory placeholders are expanded after Git exits; restore Git's
   // path order so empty queries and fuzzy-score ties remain stable.
-  return files.sort().slice(0, maxResults)
+  return files.sort().slice(0, resultLimit)
 }

--- a/src/main/ipc/filesystem-list-files.test.ts
+++ b/src/main/ipc/filesystem-list-files.test.ts
@@ -36,6 +36,11 @@ import { listQuickOpenFiles } from './filesystem-list-files'
 import { EventEmitter } from 'node:events'
 import type { Store } from '../persistence'
 import type { ChildProcess } from 'node:child_process'
+import {
+  QUICK_OPEN_LISTING_MAX_PATH_BYTES,
+  QUICK_OPEN_LISTING_MAX_RESULTS
+} from '../../shared/quick-open-listing-limits'
+import { isFileListingCancellation } from '../../shared/file-listing-cancellation'
 
 const SHA1 = '0123456789abcdef0123456789abcdef01234567'
 
@@ -95,6 +100,88 @@ describe('filesystem-list-files', () => {
     expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
+  it('bounds an omitted rg result limit and recovers on the next scan', async () => {
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    spawnMock.mockImplementation((_cmd, args: string[]) =>
+      isIgnoredRgPass(args) ? ignored : primary
+    )
+    const promise = listQuickOpenFiles('/mock/root', {} as unknown as Store)
+    const paths = Array.from(
+      { length: QUICK_OPEN_LISTING_MAX_RESULTS + 1 },
+      (_value, index) => `src/file-${index}.ts`
+    )
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+    ;(primary.stdout as unknown as EventEmitter).emit('data', paths.join('\n'))
+
+    const result = await promise
+    expect(result).toHaveLength(QUICK_OPEN_LISTING_MAX_RESULTS)
+    expect(result.at(-1)).toBe(`src/file-${QUICK_OPEN_LISTING_MAX_RESULTS - 1}.ts`)
+    expect(primary.kill).toHaveBeenCalled()
+    expect(ignored.kill).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+
+    const recoveryPrimary = createMockProcess()
+    const recoveryIgnored = createMockProcess()
+    spawnMock.mockImplementation((_cmd, args: string[]) =>
+      isIgnoredRgPass(args) ? recoveryIgnored : recoveryPrimary
+    )
+    const recovery = listQuickOpenFiles('/mock/root', {} as unknown as Store)
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+    ;(recoveryPrimary.stdout as unknown as EventEmitter).emit('data', 'src/recovered.ts\n')
+    recoveryPrimary.emit('close', 0, null)
+    queueMicrotask(() => recoveryIgnored.emit('close', 0, null))
+
+    await expect(recovery).resolves.toEqual(['src/recovered.ts'])
+  })
+
+  it('kills a local rg scan whose residual path exceeds the field limit', async () => {
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    spawnMock.mockImplementation((_cmd, args: string[]) =>
+      isIgnoredRgPass(args) ? ignored : primary
+    )
+    const promise = listQuickOpenFiles('/mock/root', {} as unknown as Store)
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+    ;(primary.stdout as unknown as EventEmitter).emit(
+      'data',
+      Buffer.alloc(QUICK_OPEN_LISTING_MAX_PATH_BYTES + 1, 0x61)
+    )
+
+    await expect(promise).rejects.toThrow(
+      `Quick Open file path exceeded ${QUICK_OPEN_LISTING_MAX_PATH_BYTES} bytes`
+    )
+    expect(primary.kill).toHaveBeenCalled()
+    expect(ignored.kill).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('kills the active local rg pass when the listing is cancelled', async () => {
+    const primary = createMockProcess()
+    const ignored = createMockProcess()
+    spawnMock.mockImplementation((_cmd, args: string[]) =>
+      isIgnoredRgPass(args) ? ignored : primary
+    )
+    const controller = new AbortController()
+    const promise = listQuickOpenFiles(
+      '/mock/root',
+      {} as unknown as Store,
+      undefined,
+      controller.signal
+    )
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+
+    controller.abort()
+
+    await expect(promise).rejects.toSatisfy(isFileListingCancellation)
+    expect(primary.kill).toHaveBeenCalled()
+    expect(ignored.kill).not.toHaveBeenCalled()
+    expect((primary.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+    expect(primary.listenerCount('close')).toBe(0)
+  })
+
   it('merges normal files and ignored files and filters correctly', async () => {
     const p1 = createMockProcess()
     const p2 = createMockProcess()
@@ -119,12 +206,13 @@ describe('filesystem-list-files', () => {
       ;(p1.stdout as unknown as EventEmitter).emit('data', 'file2.js\n')
       p1.emit('close', 0, null)
 
-      // Simulate stdout output for ignored files
-      ;(p2.stdout as unknown as EventEmitter).emit('data', '.env.local\n')
-      ;(p2.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\n')
-      ;(p2.stdout as unknown as EventEmitter).emit('data', 'file1.ts\n') // Duplicate
-      ;(p2.stdout as unknown as EventEmitter).emit('data', 'node_modules/ignored.js\n')
-      p2.emit('close', 0, null)
+      queueMicrotask(() => {
+        ;(p2.stdout as unknown as EventEmitter).emit('data', '.env.local\n')
+        ;(p2.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\n')
+        ;(p2.stdout as unknown as EventEmitter).emit('data', 'file1.ts\n') // Duplicate
+        ;(p2.stdout as unknown as EventEmitter).emit('data', 'node_modules/ignored.js\n')
+        p2.emit('close', 0, null)
+      })
     }, 10)
 
     const result = await promise
@@ -156,7 +244,7 @@ describe('filesystem-list-files', () => {
     setTimeout(() => {
       ;(p1.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\n')
       p1.emit('close', 0, null)
-      p2.emit('close', 0, null)
+      queueMicrotask(() => p2.emit('close', 0, null))
     }, 10)
 
     await expect(promise).resolves.toEqual(['src/index.ts'])
@@ -186,7 +274,7 @@ describe('filesystem-list-files', () => {
     setTimeout(() => {
       ;(p1.stdout as unknown as EventEmitter).emit('data', '/mnt/c/repo/src/index.ts\n')
       p1.emit('close', 0, null)
-      p2.emit('close', 0, null)
+      queueMicrotask(() => p2.emit('close', 0, null))
     }, 10)
 
     await expect(promise).resolves.toEqual(['src/index.ts'])
@@ -208,13 +296,12 @@ describe('filesystem-list-files', () => {
 
     setTimeout(() => {
       p1.emit('close', 2, null)
-      p2.emit('close', 0, null)
     }, 10)
 
     await expect(promise).rejects.toThrow('rg exited with code 2')
   })
 
-  it('kills the sibling rg pass after one pass fails', async () => {
+  it('does not spawn the ignored rg pass after the primary pass fails', async () => {
     const p1 = createMockProcess()
     const p2 = createMockProcess()
 
@@ -234,7 +321,8 @@ describe('filesystem-list-files', () => {
     }, 10)
 
     await expect(promise).rejects.toThrow('rg exited with code 2')
-    expect(p2.kill).toHaveBeenCalled()
+    expect(p2.kill).not.toHaveBeenCalled()
+    expect(spawnMock).toHaveBeenCalledTimes(1)
   })
 
   it('accepts rg code 2 when rg emitted parseable paths first', async () => {
@@ -254,7 +342,7 @@ describe('filesystem-list-files', () => {
     setTimeout(() => {
       ;(p1.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\n')
       p1.emit('close', 2, null)
-      p2.emit('close', 0, null)
+      queueMicrotask(() => p2.emit('close', 0, null))
     }, 10)
 
     await expect(promise).resolves.toEqual(['src/index.ts'])
@@ -288,7 +376,8 @@ describe('filesystem-list-files', () => {
 
       await rejection
       expect(p1.kill).toHaveBeenCalled()
-      expect(p2.kill).toHaveBeenCalled()
+      expect(p2.kill).not.toHaveBeenCalled()
+      expect(spawnMock).toHaveBeenCalledTimes(1)
       expect((p1.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
       expect((p1.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
       expect(p1.listenerCount('error')).toBe(0)
@@ -321,8 +410,7 @@ describe('filesystem-list-files', () => {
       ;(p1.stdout as unknown as EventEmitter).emit('data', 'valid.ts\n')
       p1.emit('close', 0, null)
 
-      // Empty ignored result
-      p2.emit('close', 0, null)
+      queueMicrotask(() => p2.emit('close', 0, null))
     }, 10)
 
     const result = await promise
@@ -371,9 +459,11 @@ describe('filesystem-list-files', () => {
         )
         gitP1.emit('close', 0, null)
 
-        ;(gitP2.stdout as unknown as EventEmitter).emit('data', '.env.local\0')
-        ;(gitP2.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\0')
-        gitP2.emit('close', 0, null)
+        queueMicrotask(() => {
+          ;(gitP2.stdout as unknown as EventEmitter).emit('data', '.env.local\0')
+          ;(gitP2.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\0')
+          gitP2.emit('close', 0, null)
+        })
       }, 10)
 
       const result = await promise
@@ -436,6 +526,37 @@ describe('filesystem-list-files', () => {
       expect(gitP1.kill).toHaveBeenCalled()
       expect(gitP2.kill).not.toHaveBeenCalled()
       expect(callIndex).toBe(1)
+    })
+
+    it('bounds the omitted local Git result limit before spawning the ignored pass', async () => {
+      checkRgAvailableMock.mockResolvedValue(false)
+      const revParseProc = createMockProcess()
+      const primary = createMockProcess()
+      const ignored = createMockProcess()
+      let gitPasses = 0
+      spawnMock.mockImplementation((cmd: string, args: string[]) => {
+        if (cmd === 'git' && args.includes('rev-parse')) {
+          return revParseProc
+        }
+        gitPasses++
+        return gitPasses === 1 ? primary : ignored
+      })
+      const promise = listQuickOpenFiles('/mock/root', {} as unknown as Store)
+      const paths = Array.from(
+        { length: QUICK_OPEN_LISTING_MAX_RESULTS + 1 },
+        (_value, index) => `src/file-${index}.ts`
+      )
+      setTimeout(() => revParseProc.emit('close', 0, null), 0)
+      setTimeout(
+        () => (primary.stdout as unknown as EventEmitter).emit('data', paths.join('\0')),
+        10
+      )
+
+      const result = await promise
+      expect(result).toHaveLength(QUICK_OPEN_LISTING_MAX_RESULTS)
+      expect(primary.kill).toHaveBeenCalled()
+      expect(ignored.kill).not.toHaveBeenCalled()
+      expect(gitPasses).toBe(1)
     })
 
     it('does not let a discarded Git directory placeholder consume the result budget', async () => {
@@ -509,7 +630,7 @@ describe('filesystem-list-files', () => {
         ;(gitP1.stdout as unknown as EventEmitter).emit('data', `${staged('100644', 'valid.ts')}\0`)
         gitP1.emit('close', 0, null)
 
-        gitP2.emit('close', 0, null)
+        queueMicrotask(() => gitP2.emit('close', 0, null))
       }, 10)
 
       const result = await promise
@@ -556,7 +677,8 @@ describe('filesystem-list-files', () => {
 
         await rejection
         expect(gitP1.kill).toHaveBeenCalled()
-        expect(gitP2.kill).toHaveBeenCalled()
+        expect(gitP2.kill).not.toHaveBeenCalled()
+        expect(callIndex).toBe(1)
         expect((gitP1.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
         expect((gitP1.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
         expect(gitP1.listenerCount('error')).toBe(0)
@@ -604,6 +726,7 @@ describe('filesystem-list-files', () => {
           `${staged('100644', 'src/index.ts')}\0`
         )
         gitP1.emit('close', 0, null)
+        await Promise.resolve()
         // Ignored entries streamed before the timeout are kept.
         ;(gitP2.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\0')
 
@@ -639,7 +762,7 @@ describe('filesystem-list-files', () => {
       setTimeout(() => {
         ;(p1.stdout as unknown as EventEmitter).emit('data', 'file.ts\n')
         p1.emit('close', 0, null)
-        p2.emit('close', 0, null)
+        queueMicrotask(() => p2.emit('close', 0, null))
       }, 10)
 
       const result = await promise

--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -16,6 +16,14 @@ import {
 } from '../../shared/quick-open-filter'
 import { isQuickOpenReaddirBudgetError } from '../../shared/quick-open-readdir-walk'
 import { buildInstallRgMessage } from '../../shared/quick-open-install-rg'
+import {
+  createQuickOpenListingBudget,
+  QUICK_OPEN_LISTING_MAX_PATH_BYTES,
+  QuickOpenSubprocessPathAccumulator,
+  resolveQuickOpenResultLimit,
+  retainQuickOpenPath
+} from '../../shared/quick-open-listing-limits'
+import { fileListingCancellationError } from '../../shared/file-listing-cancellation'
 import { listFilesWithGit } from './filesystem-list-files-git-fallback'
 
 export async function listQuickOpenFiles(
@@ -37,6 +45,13 @@ export async function listQuickOpenFiles(
   // every worktree instead of just the active one. The shared helper
   // normalizes, validates, and root-relativizes every input.
   const excludePathPrefixes = buildExcludePathPrefixes(authorizedRootPath, excludePaths)
+  if (signal?.aborted) {
+    throw fileListingCancellationError(signal)
+  }
+  const resultLimit = resolveQuickOpenResultLimit(maxResults)
+  if (resultLimit === 0) {
+    return []
+  }
 
   // Why: checking rg availability upfront avoids a race condition where
   // spawn('rg') emits 'close' before 'error' on some platforms, causing
@@ -50,7 +65,7 @@ export async function listQuickOpenFiles(
         excludePathPrefixes,
         localGitOptions,
         signal,
-        maxResults
+        resultLimit
       )
     } catch (err) {
       if (!isQuickOpenReaddirBudgetError(err)) {
@@ -61,10 +76,11 @@ export async function listQuickOpenFiles(
   }
 
   const files = new Set<string>()
+  const listingBudget = createQuickOpenListingBudget()
   const children: {
     child: ChildProcess
     isDone: () => boolean
-    finish: () => void
+    finish: (error?: Error) => void
   }[] = []
   // Why: WSL-routed rg can emit Linux-native absolute paths. UNC repos carry
   // their distro in the path; Windows-path repos carry it in project runtime.
@@ -82,8 +98,11 @@ export async function listQuickOpenFiles(
   })
 
   const runRg = (args: string[]): Promise<void> => {
+    if (signal?.aborted) {
+      return Promise.reject(fileListingCancellationError(signal))
+    }
     return new Promise((resolve, reject) => {
-      let buf = ''
+      const paths = new QuickOpenSubprocessPathAccumulator(0x0a)
       let done = false
       let parseablePathCount = 0
 
@@ -106,11 +125,11 @@ export async function listQuickOpenFiles(
         if (shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)) {
           return false
         }
-        if (maxResults !== undefined && files.size >= maxResults) {
+        if (files.size >= resultLimit) {
           return true
         }
-        files.add(relPath)
-        return maxResults !== undefined && files.size >= maxResults
+        retainQuickOpenPath(files, relPath, listingBudget)
+        return files.size >= resultLimit
       }
 
       const child = wslAwareSpawn('rg', args, {
@@ -119,20 +138,24 @@ export async function listQuickOpenFiles(
         stdio: ['ignore', 'pipe', 'pipe']
       })
       let timer: ReturnType<typeof setTimeout>
-      const handleStdoutData = (chunk: string): void => {
-        buf += chunk
-        let start = 0
-        let newlineIdx = buf.indexOf('\n', start)
-        while (newlineIdx !== -1) {
-          if (processLine(buf.substring(start, newlineIdx))) {
-            buf = ''
+      const failForOutput = (error: unknown): void => {
+        paths.clear()
+        child.kill()
+        finish(error instanceof Error ? error : new Error(String(error)))
+      }
+      const handleStdoutData = (chunk: Buffer | string): void => {
+        try {
+          const outcome = paths.push(chunk, (path) => !processLine(path))
+          if (outcome === 'stopped') {
             finishAtLimit()
-            return
+          } else if (outcome === 'path-too-large') {
+            failForOutput(
+              new Error(`Quick Open file path exceeded ${QUICK_OPEN_LISTING_MAX_PATH_BYTES} bytes`)
+            )
           }
-          start = newlineIdx + 1
-          newlineIdx = buf.indexOf('\n', start)
+        } catch (error) {
+          failForOutput(error)
         }
-        buf = start < buf.length ? buf.substring(start) : ''
       }
       const handleStderrData = (): void => {
         /* drain */
@@ -140,7 +163,7 @@ export async function listQuickOpenFiles(
       const handleError = (): void => {
         // Why: treat spawn errors like an abnormal exit — discard residual
         // buffer so a truncated final byte sequence cannot leak as a path.
-        buf = ''
+        paths.clear()
         finish(new Error('rg failed to start'))
       }
       const handleClose = (code: number | null, signal: NodeJS.Signals | null): void => {
@@ -148,13 +171,18 @@ export async function listQuickOpenFiles(
           // Why: a signal exit means timeout/OOM/external kill. Returning the
           // already-streamed prefix would recreate the false-empty bug this
           // path is meant to avoid.
-          buf = ''
+          paths.clear()
           finish(new Error(`rg killed by ${signal}`))
           return
         }
-        if (buf && processLine(buf)) {
-          buf = ''
-          finishAtLimit()
+        try {
+          const trailingPath = paths.finish()
+          if (trailingPath && processLine(trailingPath)) {
+            finishAtLimit()
+            return
+          }
+        } catch (error) {
+          failForOutput(error)
           return
         }
         if (code === 0 || code === 1) {
@@ -188,7 +216,6 @@ export async function listQuickOpenFiles(
 
       children.push({ child, isDone: () => done, finish })
 
-      child.stdout!.setEncoding('utf-8')
       child.stdout!.on('data', handleStdoutData)
       child.stderr!.on('data', handleStderrData)
       child.once('error', handleError)
@@ -196,7 +223,7 @@ export async function listQuickOpenFiles(
       timer = setTimeout(() => {
         // Why: on timeout, the buffer is likely truncated mid-path. Discard
         // it so Quick Open never displays a malformed entry.
-        buf = ''
+        paths.clear()
         child.kill()
         finish(new Error('rg list timed out'))
       }, 10000)
@@ -230,22 +257,33 @@ export async function listQuickOpenFiles(
     }
   }
 
-  try {
-    if (maxResults === undefined) {
-      await Promise.all([runRg(primary), runRg(ignoredPass)])
-    } else {
-      // Why: ignored-file output can be much larger and faster than the primary
-      // pass; let source files claim the bounded autocomplete budget first.
-      await runRg(primary)
-      if (files.size < maxResults) {
-        await runRg(ignoredPass)
+  const onAbort = (): void => {
+    const error = fileListingCancellationError(signal)
+    for (const entry of children) {
+      if (entry.isDone()) {
+        continue
       }
+      entry.finish(error)
+      if (entry.child.exitCode === null && entry.child.signalCode === null) {
+        entry.child.kill()
+      }
+    }
+  }
+  signal?.addEventListener('abort', onAbort, { once: true })
+  try {
+    // Why: ignored-file output can be much larger and faster than the primary
+    // pass; let source files claim the bounded autocomplete budget first.
+    await runRg(primary)
+    if (files.size < resultLimit) {
+      await runRg(ignoredPass)
     }
   } catch (err) {
     killSurvivors()
     throw err
+  } finally {
+    signal?.removeEventListener('abort', onAbort)
   }
-  return Array.from(files).slice(0, maxResults)
+  return Array.from(files).slice(0, resultLimit)
 }
 
 function getQuickOpenRgOutputMode(

--- a/src/main/ipc/filesystem-mutations.test.ts
+++ b/src/main/ipc/filesystem-mutations.test.ts
@@ -24,7 +24,7 @@ vi.mock('fs/promises', () => ({
   writeFile: writeFileMock,
   realpath: realpathMock,
   copyFile: copyFileMock,
-  readdir: vi.fn()
+  opendir: vi.fn()
 }))
 
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
@@ -77,6 +77,7 @@ describe('registerFilesystemMutationHandlers', () => {
     writeFileMock.mockReset()
     realpathMock.mockReset()
     resetSshConnectionGenerations()
+    setSshConnectionGeneration('ssh-1', 0)
 
     handleMock.mockImplementation((channel: string, handler: never) => {
       handlers.set(channel, handler)

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -7,7 +7,7 @@ import {
   lstat,
   mkdir,
   open,
-  readdir,
+  opendir,
   realpath,
   rename,
   rm,
@@ -24,6 +24,19 @@ import { importExternalPathsSsh } from './filesystem-import-ssh'
 import { assertNoClobberRenameDestinationAvailable } from '../../shared/filesystem-rename-collision'
 import type { SshMutationExpectation } from '../../shared/ssh-types'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
+import { readStableRuntimeUploadFile } from './filesystem-runtime-upload-file-reader'
+import {
+  admitExternalImportTreeEntry,
+  assertExternalImportSourcePaths,
+  assertExternalImportTreeDepth,
+  assertRuntimeUploadFileFits,
+  captureRuntimeUploadRetentionCheckpoint,
+  createExternalImportTreeBudget,
+  createRuntimeUploadRetentionBudget,
+  restoreRuntimeUploadRetentionCheckpoint,
+  retainRuntimeUploadFileBytes,
+  type RuntimeUploadRetentionBudget
+} from './filesystem-external-import-limits'
 
 /**
  * Re-throw filesystem errors with user-friendly messages.
@@ -201,6 +214,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         args.expectedSshConnectionGeneration,
         args.expectedExecutionHostId
       )
+      assertExternalImportSourcePaths(args.sourcePaths)
       if (args.connectionId) {
         return importExternalPathsSsh(args.sourcePaths, args.destDir, args.connectionId, {
           ensureDir: args.ensureDir,
@@ -242,8 +256,10 @@ export function registerFilesystemMutationHandlers(store: Store): void {
       args: { sourcePaths: string[] }
     ): Promise<{ sources: StagedExternalImportSource[] }> => {
       const sources: StagedExternalImportSource[] = []
+      assertExternalImportSourcePaths(args.sourcePaths)
+      const retentionBudget = createRuntimeUploadRetentionBudget()
       for (const sourcePath of args.sourcePaths) {
-        sources.push(await stageOneSourceForRuntimeUpload(sourcePath))
+        sources.push(await stageOneSourceForRuntimeUpload(sourcePath, retentionBudget))
       }
       return { sources }
     }
@@ -271,6 +287,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         args.expectedSshConnectionGeneration,
         args.expectedExecutionHostId
       )
+      assertExternalImportSourcePaths(args.paths)
       // Why: `== null` (not `!args.connectionId`) so an empty string is
       // treated as a renderer error, not silently routed to the local branch.
       if (args.connectionId == null) {
@@ -362,9 +379,6 @@ export type StagedExternalImportEntry =
   | { relativePath: string; kind: 'directory' }
   | { relativePath: string; kind: 'file'; contentBase64: string }
 
-const REMOTE_IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024
-const REMOTE_IMPORT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
-
 class RuntimeUploadSymlinkError extends Error {}
 
 // ─── External Import Implementation ─────────────────────────────────
@@ -425,9 +439,17 @@ async function importOneSource(
   // creating any destination files. This prevents partially imported
   // trees when a symlink is discovered halfway through recursive copy.
   if (isDir) {
-    const hasSymlink = await preScanForSymlinks(resolvedSource)
-    if (hasSymlink) {
-      return { sourcePath, status: 'skipped', reason: 'symlink' }
+    try {
+      const hasSymlink = await preScanForSymlinks(resolvedSource)
+      if (hasSymlink) {
+        return { sourcePath, status: 'skipped', reason: 'symlink' }
+      }
+    } catch (error) {
+      return {
+        sourcePath,
+        status: 'failed',
+        reason: error instanceof Error ? error.message : String(error)
+      }
     }
   }
 
@@ -462,7 +484,8 @@ async function importOneSource(
 }
 
 async function stageOneSourceForRuntimeUpload(
-  sourcePath: string
+  sourcePath: string,
+  retentionBudget: RuntimeUploadRetentionBudget
 ): Promise<StagedExternalImportSource> {
   const resolvedSource = resolve(sourcePath)
 
@@ -498,10 +521,15 @@ async function stageOneSourceForRuntimeUpload(
   if (!sourceStat.isFile() && !sourceStat.isDirectory()) {
     return { sourcePath, status: 'skipped', reason: 'unsupported' }
   }
+  const checkpoint = captureRuntimeUploadRetentionCheckpoint(retentionBudget)
   try {
-    const entries = sourceStat.isDirectory()
-      ? await stageDirectoryEntries(resolvedSource)
-      : [(await stageFileEntry(resolvedSource, '')).entry]
+    let entries: StagedExternalImportEntry[]
+    if (sourceStat.isDirectory()) {
+      entries = await stageDirectoryEntries(resolvedSource, retentionBudget)
+    } else {
+      admitExternalImportTreeEntry(retentionBudget.tree, '', true)
+      entries = [await stageFileEntry(resolvedSource, '', { retentionBudget })]
+    }
     return {
       sourcePath,
       status: 'staged',
@@ -510,6 +538,7 @@ async function stageOneSourceForRuntimeUpload(
       entries
     }
   } catch (error) {
+    restoreRuntimeUploadRetentionCheckpoint(retentionBudget, checkpoint)
     if (error instanceof RuntimeUploadSymlinkError) {
       return { sourcePath, status: 'skipped', reason: 'symlink' }
     }
@@ -521,61 +550,61 @@ async function stageOneSourceForRuntimeUpload(
   }
 }
 
-async function stageDirectoryEntries(rootPath: string): Promise<StagedExternalImportEntry[]> {
+async function stageDirectoryEntries(
+  rootPath: string,
+  retentionBudget: RuntimeUploadRetentionBudget
+): Promise<StagedExternalImportEntry[]> {
+  admitExternalImportTreeEntry(retentionBudget.tree, '', true)
   const entries: StagedExternalImportEntry[] = [{ relativePath: '', kind: 'directory' }]
-  let totalBytes = 0
   const rootRealPath = await realpath(rootPath)
 
-  async function visit(dirPath: string): Promise<void> {
+  async function visit(dirPath: string, depth: number): Promise<void> {
+    assertExternalImportTreeDepth(depth)
     const dirStat = await lstat(dirPath)
+    const dirRelativePath = normalizeRelativeUploadPath(relative(rootPath, dirPath))
     if (dirStat.isSymbolicLink()) {
-      throw new RuntimeUploadSymlinkError(
-        `Symlink not allowed in '${normalizeRelativeUploadPath(relative(rootPath, dirPath))}'`
-      )
+      throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${dirRelativePath}'`)
     }
     if (!dirStat.isDirectory()) {
-      throw new Error(
-        `Unsupported file type in '${normalizeRelativeUploadPath(relative(rootPath, dirPath))}'`
-      )
+      throw new Error(`Unsupported file type in '${dirRelativePath}'`)
     }
-    await assertRealPathInsideRoot(
-      rootRealPath,
-      dirPath,
-      normalizeRelativeUploadPath(relative(rootPath, dirPath))
-    )
-    const dirEntries = await readdir(dirPath, { withFileTypes: true })
-    for (const entry of dirEntries) {
+    await assertRealPathInsideRoot(rootRealPath, dirPath, dirRelativePath)
+    const directory = await opendir(dirPath)
+    for await (const entry of directory) {
       const childPath = join(dirPath, entry.name)
       const childRelativePath = normalizeRelativeUploadPath(relative(rootPath, childPath))
       if (entry.isSymbolicLink()) {
         throw new RuntimeUploadSymlinkError(`Symlink not allowed in '${childRelativePath}'`)
       }
       if (entry.isDirectory()) {
+        assertExternalImportTreeDepth(depth + 1)
+        admitExternalImportTreeEntry(retentionBudget.tree, childRelativePath, true)
         entries.push({ relativePath: childRelativePath, kind: 'directory' })
-        await visit(childPath)
+        await visit(childPath, depth + 1)
         continue
       }
       if (!entry.isFile()) {
         throw new Error(`Unsupported file type in '${childRelativePath}'`)
       }
-      const stagedFile = await stageFileEntry(childPath, childRelativePath, {
-        rootRealPath,
-        totalBytesBefore: totalBytes
-      })
-      totalBytes += stagedFile.byteLength
-      entries.push(stagedFile.entry)
+      admitExternalImportTreeEntry(retentionBudget.tree, childRelativePath, true)
+      entries.push(
+        await stageFileEntry(childPath, childRelativePath, {
+          rootRealPath,
+          retentionBudget
+        })
+      )
     }
   }
 
-  await visit(rootPath)
+  await visit(rootPath, 0)
   return entries
 }
 
 async function stageFileEntry(
   filePath: string,
   relativePath: string,
-  options?: { rootRealPath?: string; totalBytesBefore?: number }
-): Promise<{ entry: StagedExternalImportEntry; byteLength: number }> {
+  options: { retentionBudget: RuntimeUploadRetentionBudget; rootRealPath?: string }
+): Promise<StagedExternalImportEntry> {
   const statResult = await lstat(filePath)
   const displayPath = normalizeRelativeUploadPath(relativePath)
   if (statResult.isSymbolicLink()) {
@@ -587,11 +616,7 @@ async function stageFileEntry(
   if (options?.rootRealPath) {
     await assertRealPathInsideRoot(options.rootRealPath, filePath, displayPath)
   }
-  const initialTotalBytes =
-    options?.totalBytesBefore === undefined
-      ? statResult.size
-      : options.totalBytesBefore + statResult.size
-  assertRemoteUploadBudget(relativePath, statResult.size, initialTotalBytes)
+  assertRuntimeUploadFileFits(options.retentionBudget, displayPath, statResult.size)
   const fileHandle = await open(filePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
   try {
     const openedStat = await fileHandle.stat()
@@ -605,23 +630,17 @@ async function stageFileEntry(
     ) {
       throw new Error(`File changed during upload staging: '${displayPath}'`)
     }
-    const totalBytes =
-      options?.totalBytesBefore === undefined
-        ? openedStat.size
-        : options.totalBytesBefore + openedStat.size
-    assertRemoteUploadBudget(relativePath, openedStat.size, totalBytes)
-    const buffer = await fileHandle.readFile()
+    assertRuntimeUploadFileFits(options.retentionBudget, displayPath, openedStat.size)
+    const buffer = await readStableRuntimeUploadFile(fileHandle, openedStat.size, displayPath)
     const afterReadStat = await fileHandle.stat()
     if (afterReadStat.size !== openedStat.size) {
       throw new Error(`File changed during upload staging: '${displayPath}'`)
     }
+    retainRuntimeUploadFileBytes(options.retentionBudget, displayPath, buffer.byteLength)
     return {
-      entry: {
-        relativePath: displayPath,
-        kind: 'file',
-        contentBase64: buffer.toString('base64')
-      },
-      byteLength: openedStat.size
+      relativePath: displayPath,
+      kind: 'file',
+      contentBase64: buffer.toString('base64')
     }
   } finally {
     await fileHandle.close()
@@ -644,19 +663,6 @@ async function assertRealPathInsideRoot(
   }
 }
 
-function assertRemoteUploadBudget(
-  relativePath: string,
-  fileBytes: number,
-  totalBytes: number
-): void {
-  if (fileBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
-    throw new Error(`'${relativePath}' is too large for remote import`)
-  }
-  if (totalBytes > REMOTE_IMPORT_MAX_TOTAL_BYTES) {
-    throw new Error('Remote import is too large')
-  }
-}
-
 function normalizeRelativeUploadPath(path: string): string {
   return path.replace(/[\\/]+/g, '/').replace(/^\/+/, '')
 }
@@ -666,19 +672,40 @@ function normalizeRelativeUploadPath(path: string): string {
  * is found anywhere in the subtree.
  */
 async function preScanForSymlinks(dirPath: string): Promise<boolean> {
-  const entries = await readdir(dirPath, { withFileTypes: true })
-  for (const entry of entries) {
-    if (entry.isSymbolicLink()) {
+  const budget = createExternalImportTreeBudget()
+
+  async function visit(
+    currentDirPath: string,
+    relativeDirPath: string,
+    depth: number
+  ): Promise<boolean> {
+    assertExternalImportTreeDepth(depth)
+    const currentStat = await lstat(currentDirPath)
+    if (currentStat.isSymbolicLink()) {
       return true
     }
-    if (entry.isDirectory()) {
-      const childPath = join(dirPath, entry.name)
-      if (await preScanForSymlinks(childPath)) {
+    if (!currentStat.isDirectory()) {
+      throw new Error(`Unsupported file type in '${relativeDirPath}'`)
+    }
+
+    const directory = await opendir(currentDirPath)
+    for await (const entry of directory) {
+      const childRelativePath = join(relativeDirPath, entry.name)
+      admitExternalImportTreeEntry(budget, childRelativePath, false)
+      if (entry.isSymbolicLink()) {
         return true
       }
+      if (entry.isDirectory()) {
+        assertExternalImportTreeDepth(depth + 1)
+        if (await visit(join(currentDirPath, entry.name), childRelativePath, depth + 1)) {
+          return true
+        }
+      }
     }
+    return false
   }
-  return false
+
+  return visit(dirPath, '', 0)
 }
 
 /**
@@ -687,24 +714,47 @@ async function preScanForSymlinks(dirPath: string): Promise<boolean> {
  * buffering entire files into memory.
  */
 async function recursiveCopyDir(srcDir: string, destDir: string): Promise<void> {
-  await mkdir(destDir, { recursive: false })
-  const entries = await readdir(srcDir, { withFileTypes: true })
-  for (const entry of entries) {
-    const srcPath = join(srcDir, entry.name)
-    const dstPath = join(destDir, entry.name)
-    const statResult = await lstat(srcPath)
-    if (statResult.isSymbolicLink()) {
-      throw new Error(`Symlink not allowed in '${entry.name}'`)
+  const budget = createExternalImportTreeBudget()
+
+  async function copyDirectory(
+    currentSrcDir: string,
+    currentDestDir: string,
+    relativeDirPath: string,
+    depth: number
+  ): Promise<void> {
+    assertExternalImportTreeDepth(depth)
+    const dirStat = await lstat(currentSrcDir)
+    if (dirStat.isSymbolicLink()) {
+      throw new Error(`Symlink not allowed in '${relativeDirPath}'`)
     }
-    if (statResult.isDirectory()) {
-      await recursiveCopyDir(srcPath, dstPath)
-      continue
+    if (!dirStat.isDirectory()) {
+      throw new Error(`Unsupported file type in '${relativeDirPath}'`)
     }
-    if (!statResult.isFile()) {
-      throw new Error(`Unsupported file type in '${entry.name}'`)
+    await mkdir(currentDestDir, { recursive: false })
+
+    const directory = await opendir(currentSrcDir)
+    for await (const entry of directory) {
+      const srcPath = join(currentSrcDir, entry.name)
+      const dstPath = join(currentDestDir, entry.name)
+      const childRelativePath = join(relativeDirPath, entry.name)
+      admitExternalImportTreeEntry(budget, childRelativePath, false)
+      const statResult = await lstat(srcPath)
+      if (statResult.isSymbolicLink()) {
+        throw new Error(`Symlink not allowed in '${childRelativePath}'`)
+      }
+      if (statResult.isDirectory()) {
+        assertExternalImportTreeDepth(depth + 1)
+        await copyDirectory(srcPath, dstPath, childRelativePath, depth + 1)
+        continue
+      }
+      if (!statResult.isFile()) {
+        throw new Error(`Unsupported file type in '${childRelativePath}'`)
+      }
+      await copyLocalFileNoFollow(srcPath, dstPath, statResult)
     }
-    await copyLocalFileNoFollow(srcPath, dstPath, statResult)
   }
+
+  await copyDirectory(srcDir, destDir, '', 0)
 }
 
 async function copyLocalFileNoFollow(

--- a/src/main/ipc/filesystem-runtime-upload-file-reader.test.ts
+++ b/src/main/ipc/filesystem-runtime-upload-file-reader.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readStableRuntimeUploadFile } from './filesystem-runtime-upload-file-reader'
+
+function createRead(content: Buffer, maxBytesPerRead = content.byteLength) {
+  return vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+    const bytesRead = Math.min(length, maxBytesPerRead, Math.max(0, content.byteLength - position))
+    if (bytesRead > 0) {
+      content.copy(buffer, offset, position, position + bytesRead)
+    }
+    return { buffer, bytesRead }
+  })
+}
+
+describe('runtime upload file reader', () => {
+  it('preserves an exact-size file across partial reads', async () => {
+    const content = Buffer.from('bounded-content')
+    const read = createRead(content, 3)
+
+    await expect(
+      readStableRuntimeUploadFile({ read }, content.byteLength, 'asset.bin')
+    ).resolves.toEqual(content)
+    expect(read).toHaveBeenLastCalledWith(expect.any(Buffer), 0, 1, content.byteLength)
+  })
+
+  it('rejects a file that becomes shorter without exposing uninitialized bytes', async () => {
+    const content = Buffer.from('short')
+
+    await expect(
+      readStableRuntimeUploadFile({ read: createRead(content) }, content.byteLength + 1, '')
+    ).rejects.toThrow("File changed during upload staging: ''")
+  })
+
+  it('uses a one-byte probe and rejects growth beyond the admitted size', async () => {
+    const content = Buffer.from('growth')
+    const admittedBytes = content.byteLength - 1
+    const read = createRead(content)
+
+    await expect(
+      readStableRuntimeUploadFile({ read }, admittedBytes, 'growth.bin')
+    ).rejects.toThrow("File changed during upload staging: 'growth.bin'")
+    expect(read).toHaveBeenNthCalledWith(1, expect.any(Buffer), 0, admittedBytes, 0)
+    expect(read).toHaveBeenNthCalledWith(2, expect.any(Buffer), 0, 1, admittedBytes)
+  })
+})

--- a/src/main/ipc/filesystem-runtime-upload-file-reader.ts
+++ b/src/main/ipc/filesystem-runtime-upload-file-reader.ts
@@ -1,0 +1,33 @@
+type RuntimeUploadFileHandle = {
+  read(
+    buffer: Buffer,
+    offset: number,
+    length: number,
+    position: number
+  ): Promise<{ bytesRead: number }>
+}
+
+export async function readStableRuntimeUploadFile(
+  fileHandle: RuntimeUploadFileHandle,
+  expectedBytes: number,
+  displayPath: string
+): Promise<Buffer> {
+  const buffer = Buffer.allocUnsafe(expectedBytes)
+  let offset = 0
+  while (offset < expectedBytes) {
+    const { bytesRead } = await fileHandle.read(buffer, offset, expectedBytes - offset, offset)
+    if (bytesRead === 0) {
+      throw fileChangedError(displayPath)
+    }
+    offset += bytesRead
+  }
+  const probe = Buffer.allocUnsafe(1)
+  if ((await fileHandle.read(probe, 0, 1, offset)).bytesRead !== 0) {
+    throw fileChangedError(displayPath)
+  }
+  return buffer
+}
+
+function fileChangedError(displayPath: string): Error {
+  return new Error(`File changed during upload staging: '${displayPath}'`)
+}

--- a/src/main/ipc/filesystem-search-git.ts
+++ b/src/main/ipc/filesystem-search-git.ts
@@ -8,6 +8,7 @@ import {
   SEARCH_TIMEOUT_MS
 } from '../../shared/text-search'
 import { gitSpawn } from '../git/runner'
+import { SearchSubprocessLineAccumulator } from '../../shared/search-subprocess-lines'
 
 /**
  * Fallback text search using git grep. Used when rg is not available.
@@ -26,7 +27,7 @@ export function searchWithGitGrep(
     const gitArgs = buildGitGrepArgs(args.query, args)
     const matchRegex = buildSubmatchRegex(args.query, args)
     const acc = createAccumulator()
-    let stdoutBuffer = ''
+    const stdoutLines = new SearchSubprocessLineAccumulator()
     let done = false
 
     const child = gitSpawn(gitArgs, {
@@ -58,12 +59,11 @@ export function searchWithGitGrep(
       }
     }
 
-    function handleStdoutData(chunk: string): void {
-      stdoutBuffer += chunk
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
+    function handleStdoutData(chunk: Buffer): void {
+      if (!stdoutLines.push(chunk, processLine)) {
+        acc.truncated = true
+        child.kill()
+        resolveOnce()
       }
     }
 
@@ -76,13 +76,13 @@ export function searchWithGitGrep(
     }
 
     function handleClose(): void {
-      if (stdoutBuffer) {
-        processLine(stdoutBuffer)
+      const trailingLine = stdoutLines.finish()
+      if (trailingLine !== null) {
+        processLine(trailingLine)
       }
       resolveOnce()
     }
 
-    child.stdout!.setEncoding('utf-8')
     child.stdout!.on('data', handleStdoutData)
     child.stderr!.on('data', handleStderrData)
     child.once('error', handleError)

--- a/src/main/ipc/filesystem-watcher-admission.test.ts
+++ b/src/main/ipc/filesystem-watcher-admission.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FILESYSTEM_WATCHER_MAX_CLAIMS,
+  FILESYSTEM_WATCHER_MAX_CLAIMS_PER_SENDER,
+  FILESYSTEM_WATCHER_MAX_PATH_BYTES,
+  FilesystemWatcherAdmission,
+  parseFilesystemWatcherIdentity
+} from './filesystem-watcher-admission'
+
+describe('filesystem watcher admission', () => {
+  it('caps unique claims per sender and recovers after release', () => {
+    const admission = new FilesystemWatcherAdmission()
+    const releases = Array.from({ length: FILESYSTEM_WATCHER_MAX_CLAIMS_PER_SENDER }, (_, index) =>
+      admission.claim(1, `local:/repo-${index}`, 1)
+    )
+
+    expect(() => admission.claim(1, 'local:/overflow', 1)).toThrow('capacity reached')
+    expect(admission.evidence().claimCount).toBe(FILESYSTEM_WATCHER_MAX_CLAIMS_PER_SENDER)
+
+    releases[0]?.release()
+    expect(() => admission.claim(1, 'local:/recovered', 1)).not.toThrow()
+  })
+
+  it('caps aggregate claims across senders without double-counting duplicate watches', () => {
+    const admission = new FilesystemWatcherAdmission()
+    for (let index = 0; index < FILESYSTEM_WATCHER_MAX_CLAIMS; index += 1) {
+      admission.claim(index, `local:/repo-${index}`, 1)
+    }
+
+    expect(admission.claim(0, 'local:/repo-0', 1).added).toBe(false)
+    expect(() => admission.claim(FILESYSTEM_WATCHER_MAX_CLAIMS, 'local:/overflow', 1)).toThrow(
+      'capacity reached'
+    )
+
+    admission.releaseSender(0)
+    expect(() =>
+      admission.claim(FILESYSTEM_WATCHER_MAX_CLAIMS, 'local:/recovered', 1)
+    ).not.toThrow()
+  })
+
+  it('bounds retained path bytes before creating a watcher key', () => {
+    const exact = 'é'.repeat(FILESYSTEM_WATCHER_MAX_PATH_BYTES / 2)
+
+    expect(parseFilesystemWatcherIdentity({ worktreePath: exact }).retainedBytes).toBe(
+      FILESYSTEM_WATCHER_MAX_PATH_BYTES
+    )
+    expect(() => parseFilesystemWatcherIdentity({ worktreePath: `${exact}x` })).toThrow(
+      `exceeds ${FILESYSTEM_WATCHER_MAX_PATH_BYTES} UTF-8 bytes`
+    )
+  })
+
+  it('does not let a stale release remove a replacement claim', () => {
+    const admission = new FilesystemWatcherAdmission()
+    const old = admission.claim(1, 'local:/repo', 1)
+    admission.clear()
+    admission.claim(1, 'local:/repo', 1)
+
+    old.release()
+
+    expect(admission.evidence().claimCount).toBe(1)
+  })
+})

--- a/src/main/ipc/filesystem-watcher-admission.ts
+++ b/src/main/ipc/filesystem-watcher-admission.ts
@@ -1,0 +1,132 @@
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export const FILESYSTEM_WATCHER_MAX_CLAIMS = 1_024
+export const FILESYSTEM_WATCHER_MAX_CLAIMS_PER_SENDER = 256
+export const FILESYSTEM_WATCHER_MAX_RETAINED_IDENTITY_BYTES = 16 * 1024 * 1024
+export const FILESYSTEM_WATCHER_MAX_PATH_BYTES = 64 * 1024
+export const FILESYSTEM_WATCHER_MAX_CONNECTION_ID_BYTES = 8 * 1024
+
+type WatchClaim = { retainedBytes: number }
+
+export type FilesystemWatcherIdentity = {
+  worktreePath: string
+  connectionId?: string
+  retainedBytes: number
+}
+
+export class FilesystemWatcherAdmission {
+  private readonly claimsBySender = new Map<number, Map<string, WatchClaim>>()
+  private claimCount = 0
+  private retainedBytes = 0
+
+  claim(
+    senderId: number,
+    key: string,
+    retainedBytes: number
+  ): { added: boolean; release: () => void } {
+    let senderClaims = this.claimsBySender.get(senderId)
+    const existing = senderClaims?.get(key)
+    if (existing) {
+      return { added: false, release: () => undefined }
+    }
+    if (
+      this.claimCount >= FILESYSTEM_WATCHER_MAX_CLAIMS ||
+      (senderClaims?.size ?? 0) >= FILESYSTEM_WATCHER_MAX_CLAIMS_PER_SENDER ||
+      this.retainedBytes + retainedBytes > FILESYSTEM_WATCHER_MAX_RETAINED_IDENTITY_BYTES
+    ) {
+      throw new Error('Filesystem watcher capacity reached; close an existing watch and retry.')
+    }
+    senderClaims ??= new Map()
+    this.claimsBySender.set(senderId, senderClaims)
+    const claim = { retainedBytes }
+    senderClaims.set(key, claim)
+    this.claimCount += 1
+    this.retainedBytes += retainedBytes
+    return {
+      added: true,
+      release: () => this.releaseClaim(senderId, key, claim)
+    }
+  }
+
+  release(senderId: number, key: string): void {
+    const claim = this.claimsBySender.get(senderId)?.get(key)
+    if (claim) {
+      this.releaseClaim(senderId, key, claim)
+    }
+  }
+
+  releaseSender(senderId: number): void {
+    const senderClaims = this.claimsBySender.get(senderId)
+    if (!senderClaims) {
+      return
+    }
+    this.claimsBySender.delete(senderId)
+    for (const claim of senderClaims.values()) {
+      this.claimCount -= 1
+      this.retainedBytes -= claim.retainedBytes
+    }
+  }
+
+  clear(): void {
+    this.claimsBySender.clear()
+    this.claimCount = 0
+    this.retainedBytes = 0
+  }
+
+  evidence(): { claimCount: number; retainedBytes: number; senderCount: number } {
+    return {
+      claimCount: this.claimCount,
+      retainedBytes: this.retainedBytes,
+      senderCount: this.claimsBySender.size
+    }
+  }
+
+  private releaseClaim(senderId: number, key: string, expected: WatchClaim): void {
+    const senderClaims = this.claimsBySender.get(senderId)
+    if (senderClaims?.get(key) !== expected) {
+      return
+    }
+    senderClaims.delete(key)
+    this.claimCount -= 1
+    this.retainedBytes -= expected.retainedBytes
+    if (senderClaims.size === 0) {
+      this.claimsBySender.delete(senderId)
+    }
+  }
+}
+
+export function parseFilesystemWatcherIdentity(value: unknown): FilesystemWatcherIdentity {
+  if (!value || typeof value !== 'object') {
+    throw new TypeError('Filesystem watcher arguments are required.')
+  }
+  const record = value as Record<string, unknown>
+  const worktreePath = record.worktreePath
+  const connectionId = record.connectionId
+  if (typeof worktreePath !== 'string' || worktreePath.length === 0) {
+    throw new TypeError('Filesystem watcher worktreePath must be a non-empty string.')
+  }
+  const pathBytes = boundedFieldBytes(
+    worktreePath,
+    FILESYSTEM_WATCHER_MAX_PATH_BYTES,
+    'worktreePath'
+  )
+  if (connectionId !== undefined && typeof connectionId !== 'string') {
+    throw new TypeError('Filesystem watcher connectionId must be a string.')
+  }
+  const connectionBytes = connectionId
+    ? boundedFieldBytes(connectionId, FILESYSTEM_WATCHER_MAX_CONNECTION_ID_BYTES, 'connectionId')
+    : 0
+  return {
+    worktreePath,
+    ...(connectionId ? { connectionId } : {}),
+    retainedBytes: pathBytes + connectionBytes
+  }
+}
+
+function boundedFieldBytes(value: string, limit: number, field: string): number {
+  const measured = measureUtf8ByteLength(value, { stopAfterBytes: limit })
+  if (measured.exceededLimit) {
+    throw new TypeError(`Filesystem watcher ${field} exceeds ${limit} UTF-8 bytes.`)
+  }
+  return measured.byteLength
+}

--- a/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
+++ b/src/main/ipc/filesystem-watcher-local-unsubscribe.test.ts
@@ -142,6 +142,26 @@ describe('local filesystem watcher unsubscribe cleanup', () => {
     expect(shutdownResolved).toBe(true)
   })
 
+  it('releases watcher admission after repeated subscription errors', async () => {
+    vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
+    let watcherCallback: (err: Error | null, events: []) => void = () => {}
+    vi.mocked(subscribeParcelWatcher).mockImplementation(async (_root, callback) => {
+      watcherCallback = callback as typeof watcherCallback
+      return { unsubscribe: vi.fn() } as never
+    })
+    const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    for (let index = 0; index < 257; index += 1) {
+      await expect(
+        handlers['fs:watchWorktree']({ sender }, { worktreePath: `/tmp/erroring-repo-${index}` })
+      ).resolves.toBeUndefined()
+      watcherCallback(new Error('root disappeared'), [])
+    }
+
+    errorSpy.mockRestore()
+  })
+
   it('unsubscribes if the sender is destroyed while the local watcher is opening', async () => {
     vi.mocked(stat).mockResolvedValue({ isDirectory: () => true } as never)
     const destroyedCallbacks: (() => void)[] = []

--- a/src/main/ipc/filesystem-watcher-wsl.test.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.test.ts
@@ -100,6 +100,17 @@ describe('createWslWatcher', () => {
     )
   })
 
+  it('parses a snapshot delivered as 100,000 one-byte fragments', async () => {
+    const { child, promise } = startWatcher()
+    const frame = Buffer.from(snapshotFrame([['f', '1.0', `/home/me/repo/${'x'.repeat(99_950)}`]]))
+
+    for (let index = 0; index < frame.byteLength; index += 1) {
+      child.stdout.write(frame.subarray(index, index + 1))
+    }
+
+    await expect(promise).resolves.toBeDefined()
+  })
+
   it('counts WSL watcher processes against the global physical child cap', async () => {
     const releases = Array.from({ length: MAX_PHYSICAL_WATCHER_CHILDREN }, () =>
       reserveWatcherChild()

--- a/src/main/ipc/filesystem-watcher-wsl.ts
+++ b/src/main/ipc/filesystem-watcher-wsl.ts
@@ -6,13 +6,14 @@
  * inside the distro so shutdown kills it instead of Orca restarting WSL.
  */
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { StringDecoder } from 'node:string_decoder'
 import type { WebContents } from 'electron'
 import type { Event as WatcherEvent } from '@parcel/watcher'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
 import { queueWatcherEvents } from './filesystem-watcher-event-batch'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { createWslWatcherProcessExit, createWslWatcherStartup } from './wsl-watcher-process-exit'
 import { reserveWatcherChild, WatcherChildCapacityError } from './parcel-watcher-child-registry'
+import { diffWslSnapshots, parseWslSnapshotFrame, type WslSnapshot } from './wsl-watcher-snapshot'
 
 export type WatcherSubscription = {
   unsubscribe(): Promise<void>
@@ -41,19 +42,7 @@ export type WslWatcherDeps = {
 const POLL_INTERVAL_SECONDS = 2
 const STARTUP_TIMEOUT_MS = 10_000
 const [SNAPSHOT_START, SNAPSHOT_END] = ['\x1e', '\x1f']
-const MAX_STREAM_BUFFER_CHARS = 10 * 1024 * 1024
-
-type WslSnapshotEntry = {
-  path: string
-  type: string
-  mtime: string
-}
-
-type WslSnapshot = Map<string, WslSnapshotEntry>
-
-function toWslUncPath(linuxPath: string, distro: string): string {
-  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
-}
+export const MAX_WSL_SNAPSHOT_FRAME_BYTES = 10 * 1024 * 1024
 
 function quoteSafeFindName(name: string): string {
   if (!/^[A-Za-z0-9_.-]+$/.test(name)) {
@@ -84,59 +73,6 @@ function buildSnapshotScript(ignoreDirs: readonly string[]): string {
     `  sleep ${POLL_INTERVAL_SECONDS} || exit 0`,
     'done'
   ].join('\n')
-}
-
-function parseSnapshotFrame(frame: string, distro: string): WslSnapshot {
-  const snapshot: WslSnapshot = new Map()
-  for (const rawEntry of frame.split('\0')) {
-    if (!rawEntry) {
-      continue
-    }
-    const firstTab = rawEntry.indexOf('\t')
-    const secondTab = firstTab === -1 ? -1 : rawEntry.indexOf('\t', firstTab + 1)
-    if (firstTab <= 0 || secondTab <= firstTab + 1) {
-      continue
-    }
-    const linuxPath = rawEntry.slice(secondTab + 1)
-    if (!linuxPath.startsWith('/')) {
-      continue
-    }
-    const entry: WslSnapshotEntry = {
-      type: rawEntry.slice(0, firstTab),
-      mtime: rawEntry.slice(firstTab + 1, secondTab),
-      path: toWslUncPath(linuxPath, distro)
-    }
-    snapshot.set(entry.path, entry)
-  }
-  return snapshot
-}
-
-function diffSnapshots(prev: WslSnapshot, next: WslSnapshot): WatcherEvent[] {
-  const events: WatcherEvent[] = []
-
-  for (const [entryPath, nextEntry] of next) {
-    const prevEntry = prev.get(entryPath)
-    if (!prevEntry) {
-      events.push({ type: 'create', path: entryPath } as WatcherEvent)
-      continue
-    }
-    if (prevEntry.type !== nextEntry.type) {
-      events.push({ type: 'delete', path: entryPath } as WatcherEvent)
-      events.push({ type: 'create', path: entryPath } as WatcherEvent)
-      continue
-    }
-    if (prevEntry.mtime !== nextEntry.mtime) {
-      events.push({ type: 'update', path: entryPath } as WatcherEvent)
-    }
-  }
-
-  for (const entryPath of prev.keys()) {
-    if (!next.has(entryPath)) {
-      events.push({ type: 'delete', path: entryPath } as WatcherEvent)
-    }
-  }
-
-  return events
 }
 
 function markOverflowWithoutUncStat(root: WatchedRoot): void {
@@ -176,12 +112,20 @@ export async function createWslWatcher(
   let disposed = false
   let prevSnapshot: WslSnapshot | null = null
   let stopped = false
-  let streamBuffer = ''
-  const stdoutDecoder = new StringDecoder('utf8')
-  const stderrDecoder = new StringDecoder('utf8')
-  let stderrTail = ''
+  const streamBuffer = new GrowingByteBuffer()
+  const stderrTail = new GrowingByteBuffer()
 
   const startup = createWslWatcherStartup()
+
+  function reportSnapshotOverflow(message: string): void {
+    if (!startup.settled) {
+      startup.settle(new Error(message))
+      return
+    }
+    prevSnapshot = new Map()
+    markOverflowWithoutUncStat(root)
+    deps.scheduleBatchFlush(rootKey, root)
+  }
 
   function signalWatcherStopped(): void {
     if (stopped) {
@@ -197,13 +141,17 @@ export async function createWslWatcher(
   }
 
   function ingestFrame(frame: string): void {
-    const nextSnapshot = parseSnapshotFrame(frame, distro)
+    const nextSnapshot = parseWslSnapshotFrame(frame, distro)
+    if (!nextSnapshot) {
+      reportSnapshotOverflow('WSL watcher snapshot exceeded its retained entry limit')
+      return
+    }
     if (!prevSnapshot) {
       prevSnapshot = nextSnapshot
       startup.settle()
       return
     }
-    const events = diffSnapshots(prevSnapshot, nextSnapshot)
+    const events = diffWslSnapshots(prevSnapshot, nextSnapshot)
     prevSnapshot = nextSnapshot
 
     if (events.length > 0) {
@@ -214,25 +162,30 @@ export async function createWslWatcher(
 
   function drainFrames(): void {
     while (true) {
-      const start = streamBuffer.indexOf(SNAPSHOT_START)
+      const start = streamBuffer.indexOfByte(SNAPSHOT_START.charCodeAt(0))
       if (start === -1) {
-        streamBuffer = streamBuffer.slice(-1)
+        streamBuffer.retainSuffix(1)
         return
       }
       if (start > 0) {
-        streamBuffer = streamBuffer.slice(start)
+        streamBuffer.discardPrefix(start)
       }
-      const end = streamBuffer.indexOf(SNAPSHOT_END, 1)
+      const end = streamBuffer.indexOfByte(SNAPSHOT_END.charCodeAt(0), 1)
       if (end === -1) {
-        if (streamBuffer.length > MAX_STREAM_BUFFER_CHARS) {
-          streamBuffer = ''
-          markOverflowWithoutUncStat(root)
-          deps.scheduleBatchFlush(rootKey, root)
+        if (streamBuffer.byteLength > MAX_WSL_SNAPSHOT_FRAME_BYTES) {
+          streamBuffer.clear()
+          reportSnapshotOverflow('WSL watcher snapshot exceeded its frame byte limit')
         }
         return
       }
-      const frame = streamBuffer.slice(1, end)
-      streamBuffer = streamBuffer.slice(end + 1)
+      if (end - 1 > MAX_WSL_SNAPSHOT_FRAME_BYTES) {
+        streamBuffer.discardPrefix(end + 1)
+        reportSnapshotOverflow('WSL watcher snapshot exceeded its frame byte limit')
+        continue
+      }
+      const frameWithStart = streamBuffer.takePrefixString(end)
+      streamBuffer.discardPrefix(1)
+      const frame = frameWithStart.slice(1)
       ingestFrame(frame)
     }
   }
@@ -279,12 +232,18 @@ export async function createWslWatcher(
     if (disposed) {
       return
     }
-    streamBuffer += stdoutDecoder.write(chunk)
+    streamBuffer.append(chunk)
     drainFrames()
   })
 
   child.stderr.on('data', (chunk: Buffer) => {
-    stderrTail = (stderrTail + stderrDecoder.write(chunk)).slice(-4096)
+    if (chunk.byteLength >= 4096) {
+      stderrTail.clear()
+      stderrTail.append(chunk.subarray(chunk.byteLength - 4096))
+      return
+    }
+    stderrTail.append(chunk)
+    stderrTail.retainSuffix(4096)
   })
 
   child.stdout.on('error', (error) => {
@@ -319,7 +278,8 @@ export async function createWslWatcher(
   child.once('close', (code, signal) => {
     processExit.markPhysicalExit()
     if (!startup.settled) {
-      const suffix = stderrTail.trim() ? `: ${stderrTail.trim()}` : ''
+      const stderr = stderrTail.toString()
+      const suffix = stderr.trim() ? `: ${stderr.trim()}` : ''
       startup.settle(
         new Error(`WSL watcher exited before first snapshot (${code ?? signal})${suffix}`)
       )

--- a/src/main/ipc/filesystem-watcher.test.ts
+++ b/src/main/ipc/filesystem-watcher.test.ts
@@ -30,6 +30,7 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 import {
   closeAllWatchers,
   closeRemoteWatcherForWorktreePath,
+  LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY,
   registerFilesystemWatcherHandlers,
   restoreRemoteWatcherAfterFailedRemoval
 } from './filesystem-watcher'
@@ -43,6 +44,7 @@ import {
   WatcherChildCapacityError
 } from './parcel-watcher-child-registry'
 import { acquireWatcherRemovalGate } from './watcher-removal-gate'
+import { FILESYSTEM_WATCHER_MAX_CLAIMS_PER_SENDER } from './filesystem-watcher-admission'
 
 type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
 
@@ -92,6 +94,99 @@ describe('registerFilesystemWatcherHandlers', () => {
     )
 
     await closeAllWatchers()
+  })
+
+  it('rejects pending watcher churn at the sender cap and recovers after unwatch', async () => {
+    vi.useFakeTimers()
+    getSshFilesystemProviderMock.mockReturnValue(undefined)
+    const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    for (let index = 0; index < FILESYSTEM_WATCHER_MAX_CLAIMS_PER_SENDER; index += 1) {
+      await handlers['fs:watchWorktree'](
+        { sender },
+        { worktreePath: `/missing/repo-${index}`, connectionId: 'conn-1' }
+      )
+    }
+    await expect(
+      handlers['fs:watchWorktree'](
+        { sender },
+        { worktreePath: '/missing/overflow', connectionId: 'conn-1' }
+      )
+    ).rejects.toThrow('Filesystem watcher capacity reached')
+
+    handlers['fs:unwatchWorktree'](
+      { sender },
+      { worktreePath: '/missing/repo-0', connectionId: 'conn-1' }
+    )
+    await expect(
+      handlers['fs:watchWorktree'](
+        { sender },
+        { worktreePath: '/missing/recovered', connectionId: 'conn-1' }
+      )
+    ).resolves.toBeUndefined()
+    await closeAllWatchers()
+    warn.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it.each([
+    ['at the limit', LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY],
+    ['above the limit', LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY + 1]
+  ])('bounds event directory stats %s', async (_, count) => {
+    let active = 0
+    let peak = 0
+    let started = 0
+    const releases: (() => void)[] = []
+    vi.mocked(stat).mockImplementation((filePath) => {
+      if (filePath === '/repo') {
+        return Promise.resolve({ isDirectory: () => true } as never)
+      }
+      started++
+      active++
+      peak = Math.max(peak, active)
+      return new Promise((resolve) => {
+        releases.push(() => {
+          active--
+          resolve({ isDirectory: () => false } as never)
+        })
+      })
+    })
+    vi.mocked(subscribeParcelWatcher).mockResolvedValue({ unsubscribe: vi.fn() } as never)
+    const sender = { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id: 1 }
+    await handlers['fs:watchWorktree']({ sender }, { worktreePath: '/repo' })
+    const onEvents = vi.mocked(subscribeParcelWatcher).mock.calls[0][1] as (
+      error: Error | null,
+      events: { type: 'create'; path: string }[]
+    ) => void
+
+    vi.useFakeTimers()
+    onEvents(
+      null,
+      Array.from({ length: count }, (_, index) => ({
+        type: 'create',
+        path: `/repo/file-${index}`
+      }))
+    )
+    await vi.advanceTimersByTimeAsync(150)
+    expect(started).toBe(Math.min(count, LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY))
+    if (count > LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY) {
+      releases.shift()?.()
+      for (let turn = 0; turn < 5 && started < count; turn++) {
+        await Promise.resolve()
+      }
+      expect(started).toBe(count)
+    }
+    releases.splice(0).forEach((release) => release())
+
+    expect(peak).toBe(Math.min(count, LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY))
+    await vi.waitFor(() =>
+      expect(sender.send).toHaveBeenCalledWith(
+        'fs:changed',
+        expect.objectContaining({ events: expect.arrayContaining([expect.any(Object)]) })
+      )
+    )
+    vi.useRealTimers()
   })
 
   it('automatically retries a WSL watcher when child capacity becomes available', async () => {

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -8,6 +8,7 @@ import {
   isWindowsAbsolutePathLike,
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import { isWslPath } from '../wsl'
 import { createWslWatcher } from './filesystem-watcher-wsl'
 import type { WatchedRoot } from './filesystem-watcher-wsl'
@@ -20,6 +21,11 @@ import {
   WatcherChildCapacityError
 } from './parcel-watcher-child-registry'
 import { beginWatcherInstall, isWatcherRemovalInProgressError } from './watcher-removal-gate'
+import {
+  FilesystemWatcherAdmission,
+  parseFilesystemWatcherIdentity,
+  type FilesystemWatcherIdentity
+} from './filesystem-watcher-admission'
 // Why: suppress high-churn dirs at the watcher level (separate from the File Explorer display filter, which only hides rows).
 import { WATCHER_IGNORE_DIRS, buildParcelWatcherIgnoreOptions } from './filesystem-watcher-ignore'
 
@@ -27,6 +33,8 @@ import { WATCHER_IGNORE_DIRS, buildParcelWatcherIgnoreOptions } from './filesyst
 
 const DEBOUNCE_TRAILING_MS = 150
 const DEBOUNCE_MAX_WAIT_MS = 500
+export const LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY = 8
+const WATCHER_LISTENER_INSTALL_CONCURRENCY = 8
 
 // ── Per-root watcher state ───────────────────────────────────────────
 // WatchedRoot/WatcherSubscription live in filesystem-watcher-wsl.ts so native and WSL watchers share one shape.
@@ -34,6 +42,7 @@ const DEBOUNCE_MAX_WAIT_MS = 500
 // ── Module state ─────────────────────────────────────────────────────
 
 const watchedRoots = new Map<string, WatchedRoot>()
+const watcherAdmission = new FilesystemWatcherAdmission()
 
 // Why: cache roots that failed watcher creation (e.g. WSL UNC paths) so we don't retry every worktree switch and spam the console with errors.
 const UNWATCHABLE_ROOT_CACHE_MAX = 256
@@ -151,8 +160,10 @@ function scheduleLocalCapacityRetry(
       return
     }
     pendingLocalCapacityRetries.delete(rootKey)
-    await Promise.all(
-      [...retry.listeners.values()].map(async (listener) => {
+    await mapWithConcurrency(
+      [...retry.listeners.values()],
+      WATCHER_LISTENER_INSTALL_CONCURRENCY,
+      async (listener) => {
         if (listener.isDestroyed()) {
           return
         }
@@ -161,7 +172,7 @@ function scheduleLocalCapacityRetry(
             console.error(`[filesystem-watcher] capacity retry failed for ${rootKey}:`, error)
           }
         })
-      })
+      }
     )
   })
   retry = { listeners: new Map(), cancelWait }
@@ -196,6 +207,26 @@ function localWatcherRoot(rootPath: string): { key: string; path: string } {
     // Why: Windows drive/UNC paths are case-insensitive; cleanup must match the owner even when Git returns a different spelling.
     key: normalizeRuntimePathForComparison(normalizedPath),
     path: normalizedPath
+  }
+}
+
+function watcherAdmissionKey(identity: FilesystemWatcherIdentity): string {
+  return identity.connectionId
+    ? `remote:${remoteWatcherKey(identity.connectionId, identity.worktreePath)}`
+    : `local:${localWatcherRoot(identity.worktreePath).key}`
+}
+
+function hasRetainedLocalWatcherListener(rootKey: string, senderId: number): boolean {
+  return (
+    watchedRoots.get(rootKey)?.listeners.has(senderId) === true ||
+    inFlightLocalInstalls.get(rootKey)?.listeners.has(senderId) === true ||
+    pendingLocalCapacityRetries.get(rootKey)?.listeners.has(senderId) === true
+  )
+}
+
+function releaseLocalWatcherAdmissions(rootKey: string, listeners: Map<number, WebContents>): void {
+  for (const senderId of listeners.keys()) {
+    watcherAdmission.release(senderId, `local:${rootKey}`)
   }
 }
 
@@ -303,8 +334,10 @@ async function flushBatch(rootKey: string, root: WatchedRoot): Promise<void> {
 
   const coalesced = coalesceEvents(rawEvents)
 
-  const events: FsChangeEvent[] = await Promise.all(
-    coalesced.map(async (evt) => {
+  const events = await mapWithConcurrency(
+    coalesced,
+    LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY,
+    async (evt): Promise<FsChangeEvent> => {
       // Why: a deleted path can't be stat'd; leave isDirectory undefined and let the renderer infer from dirCache.
       const isDirectory = evt.type === 'delete' ? undefined : await tryStatIsDirectory(evt.path)
 
@@ -313,7 +346,7 @@ async function flushBatch(rootKey: string, root: WatchedRoot): Promise<void> {
         absolutePath: evt.path,
         isDirectory
       }
-    })
+    }
   )
 
   const payload: FsChangedPayload = {
@@ -397,6 +430,7 @@ async function createWatcher(
             retainLocalWatcherPhysicalFailure(rootKey, err)
             void trackLocalUnsubscribe(rootKey, root)
           }
+          releaseLocalWatcherAdmissions(rootKey, root.listeners)
           errorCleanedUp = true
           watchedRoots.delete(rootKey)
           return
@@ -432,6 +466,7 @@ async function createWatcher(
 // ── Subscribe / Unsubscribe ──────────────────────────────────────────
 
 function cleanupLocalWatchersForSender(senderId: number): void {
+  watcherAdmission.releaseSender(senderId)
   for (const [rootKey, suspended] of suspendedLocalWatcherListeners) {
     suspended.listeners.delete(senderId)
     if (suspended.listeners.size === 0) {
@@ -657,11 +692,13 @@ async function doInstallLocalWatcher(
     if (!s.isDirectory()) {
       console.warn(`[filesystem-watcher] not a directory: ${rootKey}`)
       rememberUnwatchableRoot(rootKey)
+      finishInFlightLocalInstall(rootKey, cancelToken)
       return 'unavailable'
     }
   } catch {
     console.warn(`[filesystem-watcher] cannot stat root: ${rootKey}`)
     rememberUnwatchableRoot(rootKey)
+    finishInFlightLocalInstall(rootKey, cancelToken)
     return 'unavailable'
   }
 
@@ -696,9 +733,7 @@ async function doInstallLocalWatcher(
     rememberUnwatchableRoot(rootKey)
     return 'unavailable'
   } finally {
-    if (inFlightLocalInstalls.get(rootKey) === cancelToken) {
-      inFlightLocalInstalls.delete(rootKey)
-    }
+    finishInFlightLocalInstall(rootKey, cancelToken)
   }
 
   const liveListeners = new Map(
@@ -718,6 +753,12 @@ async function doInstallLocalWatcher(
     registerSenderCleanup(listener)
   }
   return 'installed'
+}
+
+function finishInFlightLocalInstall(rootKey: string, cancelToken: LocalWatcherInstallToken): void {
+  if (inFlightLocalInstalls.get(rootKey) === cancelToken) {
+    inFlightLocalInstalls.delete(rootKey)
+  }
 }
 
 function unsubscribe(worktreePath: string, senderId: number): void {
@@ -865,7 +906,12 @@ export async function restoreLocalWatcherAfterFailedRemoval(worktreePath: string
 }
 
 export function forgetLocalWatcherRemovalSnapshot(worktreePath: string): void {
-  suspendedLocalWatcherListeners.delete(localWatcherRoot(worktreePath).key)
+  const rootKey = localWatcherRoot(worktreePath).key
+  const suspended = suspendedLocalWatcherListeners.get(rootKey)
+  for (const senderId of suspended?.listeners.keys() ?? []) {
+    watcherAdmission.release(senderId, `local:${rootKey}`)
+  }
+  suspendedLocalWatcherListeners.delete(rootKey)
 }
 
 // Remote watcher state
@@ -979,7 +1025,12 @@ export function forgetRemoteWatcherRemovalSnapshot(
   connectionId: string,
   worktreePath: string
 ): void {
-  suspendedRemoteWatcherListeners.delete(remoteWatcherKey(connectionId, worktreePath))
+  const key = remoteWatcherKey(connectionId, worktreePath)
+  const suspended = suspendedRemoteWatcherListeners.get(key)
+  for (const senderId of suspended?.listeners.keys() ?? []) {
+    watcherAdmission.release(senderId, `remote:${key}`)
+  }
+  suspendedRemoteWatcherListeners.delete(key)
 }
 
 function addInFlightRemoteInstallListener(
@@ -1292,8 +1343,8 @@ function scheduleRemoteWatcherRetry(
     const listeners = Array.from(retry.listeners.values()).filter(
       (listener) => !listener.isDestroyed()
     )
-    void Promise.all(
-      listeners.map((listener) => installRemoteWatcher(listener, connectionId, worktreePath))
+    void mapWithConcurrency(listeners, WATCHER_LISTENER_INSTALL_CONCURRENCY, (listener) =>
+      installRemoteWatcher(listener, connectionId, worktreePath)
     )
       .then((results) => {
         // Why: don't re-arm on 'cancelled' (renderer stopped watching) — it would fire a stale overflow when the 60s window expires.
@@ -1318,9 +1369,14 @@ function scheduleRemoteWatcherRetry(
 // ── Public API ───────────────────────────────────────────────────────
 
 export function registerFilesystemWatcherHandlers(): void {
-  ipcMain.handle(
-    'fs:watchWorktree',
-    async (event, args: { worktreePath: string; connectionId?: string }): Promise<void> => {
+  ipcMain.handle('fs:watchWorktree', async (event, rawArgs: unknown): Promise<void> => {
+    const args = parseFilesystemWatcherIdentity(rawArgs)
+    const admission = watcherAdmission.claim(
+      event.sender.id,
+      watcherAdmissionKey(args),
+      args.retainedBytes
+    )
+    try {
       if (args.connectionId) {
         // Why: a real new watch reopens the subsystem after closeAllWatchers latched it shut (also resets tests between cases).
         remoteWatchersClosed = false
@@ -1345,41 +1401,51 @@ export function registerFilesystemWatcherHandlers(): void {
       // Why: reopen the local subsystem for tests and post-shutdown reattachment; stale callers keep the prior generation.
       localWatchersClosed = false
       await subscribe(args.worktreePath, event.sender)
-    }
-  )
-
-  ipcMain.handle(
-    'fs:unwatchWorktree',
-    (_event, args: { worktreePath: string; connectionId?: string }): void => {
-      if (args.connectionId) {
-        const key = remoteWatcherKey(args.connectionId, args.worktreePath)
-        const suspended = suspendedRemoteWatcherListeners.get(key)
-        suspended?.listeners.delete(_event.sender.id)
-        if (suspended?.listeners.size === 0) {
-          suspendedRemoteWatcherListeners.delete(key)
+      if (admission.added) {
+        const rootKey = localWatcherRoot(args.worktreePath).key
+        if (!hasRetainedLocalWatcherListener(rootKey, event.sender.id)) {
+          admission.release()
         }
-        const retry = pendingRemoteWatcherRetryListeners.get(key)
-        retry?.listeners.delete(_event.sender.id)
-        const retryTimer = pendingRemoteWatcherRetries.get(key)
-        if (retryTimer && retry?.listeners.size === 0) {
-          clearTimeout(retryTimer)
-          pendingRemoteWatcherRetries.delete(key)
-          pendingRemoteWatcherRetryListeners.delete(key)
-        }
-        // Why: a retry-tick provider.watch() may still be in flight; mark cancelled so its resolved unwatch handle is discarded.
-        const inFlight = inFlightRemoteInstalls.get(key)
-        if (inFlight) {
-          inFlight.listeners.delete(_event.sender.id)
-          cancelInFlightRemoteInstallIfUnowned(inFlight)
-        }
-        loggedUnavailableRemoteWatchers.delete(key)
-        releaseRemoteWatchListener(key, _event?.sender?.id ?? 0)
-        return
       }
-      const senderId = _event.sender.id
-      unsubscribe(args.worktreePath, senderId)
+    } catch (error) {
+      if (admission.added) {
+        admission.release()
+      }
+      throw error
     }
-  )
+  })
+
+  ipcMain.handle('fs:unwatchWorktree', (_event, rawArgs: unknown): void => {
+    const args = parseFilesystemWatcherIdentity(rawArgs)
+    watcherAdmission.release(_event.sender.id, watcherAdmissionKey(args))
+    if (args.connectionId) {
+      const key = remoteWatcherKey(args.connectionId, args.worktreePath)
+      const suspended = suspendedRemoteWatcherListeners.get(key)
+      suspended?.listeners.delete(_event.sender.id)
+      if (suspended?.listeners.size === 0) {
+        suspendedRemoteWatcherListeners.delete(key)
+      }
+      const retry = pendingRemoteWatcherRetryListeners.get(key)
+      retry?.listeners.delete(_event.sender.id)
+      const retryTimer = pendingRemoteWatcherRetries.get(key)
+      if (retryTimer && retry?.listeners.size === 0) {
+        clearTimeout(retryTimer)
+        pendingRemoteWatcherRetries.delete(key)
+        pendingRemoteWatcherRetryListeners.delete(key)
+      }
+      // Why: a retry-tick provider.watch() may still be in flight; mark cancelled so its resolved unwatch handle is discarded.
+      const inFlight = inFlightRemoteInstalls.get(key)
+      if (inFlight) {
+        inFlight.listeners.delete(_event.sender.id)
+        cancelInFlightRemoteInstallIfUnowned(inFlight)
+      }
+      loggedUnavailableRemoteWatchers.delete(key)
+      releaseRemoteWatchListener(key, _event?.sender?.id ?? 0)
+      return
+    }
+    const senderId = _event.sender.id
+    unsubscribe(args.worktreePath, senderId)
+  })
 }
 
 function remoteWatcherKey(connectionId: string, worktreePath: string): string {
@@ -1388,6 +1454,7 @@ function remoteWatcherKey(connectionId: string, worktreePath: string): string {
 
 /** Tear down all watchers on app shutdown. */
 export async function closeAllWatchers(): Promise<void> {
+  watcherAdmission.clear()
   senderCleanupRegistered.clear()
   unwatchableRoots.clear()
   suspendedLocalWatcherListeners.clear()

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -11,7 +11,7 @@ const {
   fromWebContentsMock,
   trashItemMock,
   readdirMock,
-  readFileMock,
+  opendirMock,
   writeFileMock,
   statMock,
   openMock,
@@ -54,7 +54,7 @@ const {
   fromWebContentsMock: vi.fn(),
   trashItemMock: vi.fn(),
   readdirMock: vi.fn(),
-  readFileMock: vi.fn(),
+  opendirMock: vi.fn(),
   writeFileMock: vi.fn(),
   statMock: vi.fn(),
   openMock: vi.fn(),
@@ -110,7 +110,7 @@ vi.mock('electron', () => ({
 
 vi.mock('fs/promises', () => ({
   readdir: readdirMock,
-  readFile: readFileMock,
+  opendir: opendirMock,
   writeFile: writeFileMock,
   stat: statMock,
   open: openMock,
@@ -219,6 +219,33 @@ function dirEntry({ name, directory, file, symlink }: MockDirEntry): {
   }
 }
 
+function mockReadableFile(
+  content: Buffer,
+  stats: { dev?: number; ino?: number; birthtimeMs?: number } = {}
+) {
+  const handle = {
+    stat: vi.fn().mockResolvedValue({ size: content.byteLength, ...stats }),
+    read: vi.fn(async (target: Buffer, offset: number, length: number, position: number) => {
+      const bytesRead = Math.min(length, Math.max(0, content.byteLength - position))
+      content.copy(target, offset, position, position + bytesRead)
+      return { bytesRead, buffer: target }
+    }),
+    close: vi.fn().mockResolvedValue(undefined)
+  }
+  openMock.mockResolvedValue(handle)
+  return handle
+}
+
+function pngHeader(width = 1, height = 1): Buffer {
+  const bytes = Buffer.alloc(24)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
+  bytes.writeUInt32BE(13, 8)
+  bytes.write('IHDR', 12, 'ascii')
+  bytes.writeUInt32BE(width, 16)
+  bytes.writeUInt32BE(height, 20)
+  return bytes
+}
+
 async function withPlatform<T>(platform: NodeJS.Platform, run: () => Promise<T>): Promise<T> {
   const original = Object.getOwnPropertyDescriptor(process, 'platform')
   Object.defineProperty(process, 'platform', { configurable: true, value: platform })
@@ -262,7 +289,7 @@ describe('registerFilesystemHandlers', () => {
       fromWebContentsMock,
       trashItemMock,
       readdirMock,
-      readFileMock,
+      opendirMock,
       writeFileMock,
       statMock,
       openMock,
@@ -340,6 +367,14 @@ describe('registerFilesystemHandlers', () => {
       close: vi.fn()
     })
     lstatMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    opendirMock.mockImplementation(async (dirPath: string) => {
+      const entries = await readdirMock(dirPath, { withFileTypes: true })
+      return {
+        async *[Symbol.asyncIterator]() {
+          yield* entries
+        }
+      }
+    })
   })
 
   it('returns an actionable reconnect error when the SSH filesystem provider is unavailable', async () => {
@@ -986,7 +1021,7 @@ describe('registerFilesystemHandlers', () => {
       'Access denied: path resolves outside allowed directories'
     )
 
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(openMock).not.toHaveBeenCalled()
   })
 
   it('allows readDir when a registered worktree resolves to a macOS canonical alias', async () => {
@@ -1105,7 +1140,7 @@ describe('registerFilesystemHandlers', () => {
       'Access denied: path resolves outside allowed directories'
     )
 
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(openMock).not.toHaveBeenCalled()
   })
 
   it('does not enumerate worktrees when filesystem handlers register', () => {
@@ -1148,32 +1183,56 @@ describe('registerFilesystemHandlers', () => {
   )
 
   it.each([
-    { ext: 'png', mime: 'image/png', data: [0x89, 0x50, 0x4e, 0x47, 0x00] },
+    {
+      ext: 'png',
+      mime: 'image/png',
+      data: Array.from(pngHeader()),
+      imageDimensions: { width: 1, height: 1 }
+    },
     { ext: 'pdf', mime: 'application/pdf', data: [0x25, 0x50, 0x44, 0x46, 0x00] },
     {
       ext: 'svg',
       mime: 'image/svg+xml',
       data: Array.from(Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />'))
     }
-  ])('returns base64 content for supported $ext binaries', async ({ ext, mime, data }) => {
-    const buf = Buffer.from(data)
+  ])(
+    'returns base64 content for supported $ext binaries',
+    async ({ ext, mime, data, imageDimensions }) => {
+      const buf = Buffer.from(data)
+      statMock.mockResolvedValue({ size: buf.length, isDirectory: () => false, mtimeMs: 123 })
+      mockReadableFile(buf)
+      registerFilesystemHandlers(store as never)
+      await expect(
+        handlers.get('fs:readFile')!(null, {
+          filePath: path.resolve(`/workspace/repo/file.${ext}`)
+        })
+      ).resolves.toEqual({
+        content: buf.toString('base64'),
+        isBinary: true,
+        isImage: true,
+        mimeType: mime,
+        ...(imageDimensions ? { imageDimensions } : {})
+      })
+    }
+  )
+
+  it('rejects a raster dimension bomb before returning base64 to the renderer', async () => {
+    const buf = pngHeader(32_769, 1)
     statMock.mockResolvedValue({ size: buf.length, isDirectory: () => false, mtimeMs: 123 })
-    readFileMock.mockResolvedValue(buf)
+    mockReadableFile(buf)
     registerFilesystemHandlers(store as never)
+
     await expect(
-      handlers.get('fs:readFile')!(null, { filePath: path.resolve(`/workspace/repo/file.${ext}`) })
-    ).resolves.toEqual({
-      content: buf.toString('base64'),
-      isBinary: true,
-      isImage: true,
-      mimeType: mime
-    })
+      handlers.get('fs:readFile')!(null, {
+        filePath: path.resolve('/workspace/repo/bomb.png')
+      })
+    ).rejects.toThrow('Image dimensions exceed the preview safety limit')
   })
 
   it('opens text files larger than the old 5MB guard', async () => {
     const content = 'a'.repeat(6 * 1024 * 1024)
     statMock.mockResolvedValue({ size: content.length, isDirectory: () => false, mtimeMs: 123 })
-    readFileMock.mockResolvedValue(Buffer.from(content))
+    mockReadableFile(Buffer.from(content))
 
     registerFilesystemHandlers(store as never)
 
@@ -1187,17 +1246,7 @@ describe('registerFilesystemHandlers', () => {
 
   it('returns stable byte metadata only for opted-in local log snapshots', async () => {
     const content = Buffer.from('first\npartial')
-    const close = vi.fn()
-    openMock.mockResolvedValue({
-      stat: vi.fn().mockResolvedValue({
-        size: content.byteLength,
-        dev: 1,
-        ino: 2,
-        birthtimeMs: 3
-      }),
-      readFile: vi.fn().mockResolvedValue(content),
-      close
-    })
+    const handle = mockReadableFile(content, { dev: 1, ino: 2, birthtimeMs: 3 })
     registerFilesystemHandlers(store as never)
 
     await expect(
@@ -1210,8 +1259,7 @@ describe('registerFilesystemHandlers', () => {
       isBinary: false,
       fileIdentity: '1:2:3'
     })
-    expect(close).toHaveBeenCalledTimes(1)
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(handle.close).toHaveBeenCalledTimes(1)
   })
 
   it('rejects text files beyond the editor read budget', async () => {
@@ -1223,7 +1271,7 @@ describe('registerFilesystemHandlers', () => {
       handlers.get('fs:readFile')!(null, { filePath: path.resolve('/workspace/repo/huge.json') })
     ).rejects.toThrow('exceeds 50MB limit')
 
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(openMock).not.toHaveBeenCalled()
   })
 
   it('probes large unknown binaries without reading the full file', async () => {
@@ -1245,7 +1293,7 @@ describe('registerFilesystemHandlers', () => {
       isBinary: true
     })
 
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(openMock).toHaveBeenCalledTimes(1)
   })
 
   it('moves files to trash', async () => {
@@ -1316,7 +1364,7 @@ describe('registerFilesystemHandlers', () => {
 
   it('keeps non-image binaries hidden from the editor payload', async () => {
     statMock.mockResolvedValue({ size: 4, isDirectory: () => false, mtimeMs: 123 })
-    readFileMock.mockResolvedValue(Buffer.from([0x00, 0x01, 0x02]))
+    mockReadableFile(Buffer.from([0x00, 0x01, 0x02]))
 
     registerFilesystemHandlers(store as never)
 
@@ -1777,7 +1825,7 @@ describe('registerFilesystemHandlers', () => {
 
   it('lists remote markdown documents through the SSH filesystem provider', async () => {
     const provider = {
-      listFiles: vi
+      listMarkdownDocuments: vi
         .fn()
         .mockResolvedValue(['README.md', 'docs/guide.mdx', '../outside.md', 'src/app.ts'])
     }
@@ -1804,6 +1852,7 @@ describe('registerFilesystemHandlers', () => {
         name: 'README'
       }
     ])
+    expect(provider.listMarkdownDocuments).toHaveBeenCalledWith('/home/user/project')
   })
 
   it('routes branch compare queries through the git compare helper', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { readdir, readFile, writeFile, stat, lstat, open, rename, rm } from 'node:fs/promises'
+import { writeFile, stat, lstat, open, rename, rm } from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { dirname, extname, join, resolve } from 'node:path'
@@ -39,6 +39,7 @@ import {
   ingestRgJsonLine,
   SEARCH_TIMEOUT_MS
 } from '../../shared/text-search'
+import { SearchSubprocessLineAccumulator } from '../../shared/search-subprocess-lines'
 import {
   getStatus,
   getSubmoduleStatus,
@@ -119,6 +120,7 @@ import {
 import { listRepoWorktrees } from '../repo-worktrees'
 import { recordCrashBreadcrumb } from '../crash-reporting/crash-breadcrumb-store'
 import { buildReadDirErrorBreadcrumb, type ReadDirThrowSite } from './readdir-error-diagnostics'
+import { readLocalFilesystemDirectory } from './filesystem-directory-reader'
 import { splitWorktreeId } from '../../shared/worktree-id'
 import { getRuntimePathBasename } from '../../shared/cross-platform-path'
 import type { LocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
@@ -127,6 +129,8 @@ import { localLogFileIdentity } from '../ai-vault/local-log-tail-reader'
 import { sanitizeLocalDownloadFilename } from '../local-download-filename'
 import { registerFilesystemDownloadFolderHandlers } from './filesystem-download-folder'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
+import { assertRasterImagePreviewWithinLimits } from '../../shared/raster-image-preview-limits'
 
 // Why: Monaco degrades features on large files like VS Code, so a 5MB block would needlessly lock out ordinary JSON/log files.
 const MAX_TEXT_FILE_SIZE = 50 * 1024 * 1024 // 50MB
@@ -150,30 +154,14 @@ async function readLocalLogSnapshot(filePath: string): Promise<{
   isBinary: boolean
   fileIdentity?: string
 }> {
-  const handle = await open(filePath, 'r')
-  try {
-    const stats = await handle.stat()
-    if (stats.size > MAX_TEXT_FILE_SIZE) {
-      throw new Error(
-        `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${MAX_TEXT_FILE_SIZE / 1024 / 1024}MB limit`
-      )
-    }
-    const buffer = await handle.readFile()
-    if (buffer.byteLength > MAX_TEXT_FILE_SIZE) {
-      throw new Error(
-        `File too large: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB exceeds ${MAX_TEXT_FILE_SIZE / 1024 / 1024}MB limit`
-      )
-    }
-    if (isBinaryBuffer(buffer)) {
-      return { content: '', isBinary: true }
-    }
-    return {
-      content: buffer.toString('utf8'),
-      isBinary: false,
-      fileIdentity: localLogFileIdentity(stats)
-    }
-  } finally {
-    await handle.close()
+  const { buffer, stats } = await readNodeFileWithinLimit(filePath, MAX_TEXT_FILE_SIZE)
+  if (isBinaryBuffer(buffer)) {
+    return { content: '', isBinary: true }
+  }
+  return {
+    content: buffer.toString('utf8'),
+    isBinary: false,
+    fileIdentity: localLogFileIdentity(stats)
   }
 }
 
@@ -446,23 +434,6 @@ async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
   }
 }
 
-async function isDirectoryEntry(
-  dirPath: string,
-  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean },
-  _resolveEntryPath: (entryPath: string) => Promise<string>
-): Promise<boolean> {
-  // Why: following a symlink in readDir can touch macOS TCC-protected containers; treat links as file-like until explicitly opened.
-  void _resolveEntryPath
-  if (entry.isSymbolicLink()) {
-    void dirPath
-    return false
-  }
-  if (entry.isDirectory()) {
-    return true
-  }
-  return false
-}
-
 export function registerFilesystemHandlers(
   store: Store,
   commitMessageAgentEnv?: CommitMessageAgentEnvironmentResolvers
@@ -510,22 +481,7 @@ export function registerFilesystemHandlers(
         throwSite = 'authorize'
         const dirPath = await resolveAuthorizedPath(args.dirPath, store)
         throwSite = 'readdir'
-        const entries = await readdir(dirPath, { withFileTypes: true })
-        const mapped = await Promise.all(
-          entries.map(async (entry) => ({
-            name: entry.name,
-            isDirectory: await isDirectoryEntry(dirPath, entry, (entryPath) =>
-              resolveAuthorizedPath(entryPath, store)
-            ),
-            isSymlink: entry.isSymbolicLink()
-          }))
-        )
-        return mapped.sort((a, b) => {
-          if (a.isDirectory !== b.isDirectory) {
-            return a.isDirectory ? -1 : 1
-          }
-          return a.name.localeCompare(b.name)
-        })
+        return await readLocalFilesystemDirectory(dirPath)
       } catch (error: unknown) {
         recordCrashBreadcrumb(
           'fs_readdir_error',
@@ -551,6 +507,7 @@ export function registerFilesystemHandlers(
       isBinary: boolean
       isImage?: boolean
       mimeType?: string
+      imageDimensions?: { width: number; height: number }
       fileIdentity?: string
     }> => {
       if (args.connectionId) {
@@ -571,13 +528,15 @@ export function registerFilesystemHandlers(
       }
 
       if (mimeType) {
-        const buffer = await readFile(filePath)
+        const { buffer } = await readNodeFileWithinLimit(filePath, sizeLimit)
+        const imageDimensions = assertRasterImagePreviewWithinLimits(buffer, mimeType)
         return {
           content: buffer.toString('base64'),
           isBinary: true,
           // Why: the renderer keys previewable-binary rendering off `isImage`, so set it for PDFs too to stay compatible.
           isImage: true,
-          mimeType
+          mimeType,
+          ...(imageDimensions ? { imageDimensions } : {})
         }
       }
 
@@ -586,7 +545,7 @@ export function registerFilesystemHandlers(
         return { content: '', isBinary: true }
       }
 
-      const buffer = await readFile(filePath)
+      const { buffer } = await readNodeFileWithinLimit(filePath, sizeLimit)
       if (isBinaryBuffer(buffer)) {
         return { content: '', isBinary: true }
       }
@@ -796,7 +755,12 @@ export function registerFilesystemHandlers(
     ): Promise<MarkdownDocument[]> => {
       if (args.connectionId) {
         const provider = requireSshFilesystemProvider(args.connectionId)
-        const relativePaths = await provider.listFiles(args.rootPath)
+        if (!provider.listMarkdownDocuments) {
+          throw new Error(
+            'Remote Markdown link discovery is unavailable. Reconnect the SSH target and retry.'
+          )
+        }
+        const relativePaths = await provider.listMarkdownDocuments(args.rootPath)
         return markdownDocumentsFromRelativePaths(args.rootPath, relativePaths)
       }
 
@@ -961,7 +925,7 @@ export function registerFilesystemHandlers(
         activeTextSearches.get(searchKey)?.kill()
 
         const acc = createAccumulator()
-        let stdoutBuffer = ''
+        const stdoutLines = new SearchSubprocessLineAccumulator()
         let resolved = false
         let child: ChildProcess | null = null
         let killTimeout: ReturnType<typeof setTimeout>
@@ -1004,12 +968,11 @@ export function registerFilesystemHandlers(
         child = nextChild
         activeTextSearches.set(searchKey, nextChild)
 
-        const handleStdoutData = (chunk: string): void => {
-          stdoutBuffer += chunk
-          const lines = stdoutBuffer.split('\n')
-          stdoutBuffer = lines.pop() ?? ''
-          for (const line of lines) {
-            processLine(line)
+        const handleStdoutData = (chunk: Buffer): void => {
+          if (!stdoutLines.push(chunk, processLine)) {
+            acc.truncated = true
+            child?.kill()
+            resolveOnce()
           }
         }
         const handleStderrData = (): void => {
@@ -1019,13 +982,13 @@ export function registerFilesystemHandlers(
           resolveOnce()
         }
         const handleClose = (): void => {
-          if (stdoutBuffer) {
-            processLine(stdoutBuffer)
+          const trailingLine = stdoutLines.finish()
+          if (trailingLine !== null) {
+            processLine(trailingLine)
           }
           resolveOnce()
         }
 
-        nextChild.stdout!.setEncoding('utf-8')
         nextChild.stdout!.on('data', handleStdoutData)
         nextChild.stderr!.on('data', handleStderrData)
         nextChild.once('error', handleError)

--- a/src/main/ipc/repos-create.test.ts
+++ b/src/main/ipc/repos-create.test.ts
@@ -19,7 +19,9 @@ const {
   mockStore,
   mkdirMock,
   accessMock,
-  readdirMock,
+  opendirMock,
+  directoryReadMock,
+  directoryCloseMock,
   rmMock,
   gitExecFileAsyncMock,
   homedirMock,
@@ -37,7 +39,9 @@ const {
   },
   mkdirMock: vi.fn(),
   accessMock: vi.fn(),
-  readdirMock: vi.fn(),
+  opendirMock: vi.fn(),
+  directoryReadMock: vi.fn(),
+  directoryCloseMock: vi.fn(),
   rmMock: vi.fn(),
   gitExecFileAsyncMock: vi.fn(),
   homedirMock: vi.fn(),
@@ -56,7 +60,7 @@ vi.mock('electron', () => ({
 vi.mock('fs/promises', () => ({
   mkdir: mkdirMock,
   access: accessMock,
-  readdir: readdirMock,
+  opendir: opendirMock,
   rm: rmMock
 }))
 
@@ -138,7 +142,12 @@ describe('repos:create', () => {
 
     // Default baseline: target does NOT exist yet, mkdir succeeds, git OK.
     accessMock.mockReset().mockRejectedValue(new Error('ENOENT'))
-    readdirMock.mockReset().mockResolvedValue([])
+    directoryReadMock.mockReset().mockResolvedValue(null)
+    directoryCloseMock.mockReset().mockResolvedValue(undefined)
+    opendirMock.mockReset().mockResolvedValue({
+      read: directoryReadMock,
+      close: directoryCloseMock
+    })
     mkdirMock.mockReset().mockResolvedValue(undefined)
     rmMock.mockReset().mockResolvedValue(undefined)
     gitExecFileAsyncMock.mockReset().mockResolvedValue({ stdout: '', stderr: '' })
@@ -203,7 +212,7 @@ describe('repos:create', () => {
 
   it('rejects a non-empty existing directory without creating the target', async () => {
     accessMock.mockResolvedValueOnce(undefined) // exists
-    readdirMock.mockResolvedValueOnce(['README.md', '.DS_Store'])
+    directoryReadMock.mockResolvedValueOnce({ name: 'README.md' })
 
     const result = await callCreate({ parentPath: '/tmp', name: 'busy', kind: 'git' })
 
@@ -211,11 +220,12 @@ describe('repos:create', () => {
     expect(mkdirMock).toHaveBeenCalledWith('/tmp', { recursive: true })
     expect(mkdirMock).not.toHaveBeenCalledWith('/tmp/busy', expect.anything())
     expect(mockStore.addRepo).not.toHaveBeenCalled()
+    expect(directoryReadMock).toHaveBeenCalledOnce()
+    expect(directoryCloseMock).toHaveBeenCalledOnce()
   })
 
   it('accepts an empty existing directory and does not create the target', async () => {
     accessMock.mockResolvedValueOnce(undefined) // exists
-    readdirMock.mockResolvedValueOnce([])
 
     const result = await callCreate({ parentPath: '/tmp', name: 'empty', kind: 'folder' })
 
@@ -314,7 +324,6 @@ describe('repos:create', () => {
   it('does NOT rm a pre-existing empty directory when git init fails', async () => {
     // Pretend the directory already existed (and is empty) — user pre-created it.
     accessMock.mockResolvedValueOnce(undefined)
-    readdirMock.mockResolvedValueOnce([])
     gitExecFileAsyncMock.mockReset().mockRejectedValueOnce(new Error('git init blew up'))
 
     const result = await callCreate({ parentPath: '/tmp', name: 'preexisting', kind: 'git' })
@@ -357,7 +366,6 @@ describe('repos:create', () => {
     // The folder itself must survive (user owns it) but the half-init'd
     // .git/ should be removed so the folder looks untouched.
     accessMock.mockResolvedValueOnce(undefined)
-    readdirMock.mockResolvedValueOnce([])
     gitExecFileAsyncMock
       .mockReset()
       .mockResolvedValueOnce({ stdout: '', stderr: '' })

--- a/src/main/ipc/repos-picker.test.ts
+++ b/src/main/ipc/repos-picker.test.ts
@@ -54,6 +54,9 @@ describe('repos folder pickers', () => {
     getRepo: vi.fn(),
     updateRepo: vi.fn()
   }
+  const mockRuntime = {
+    notifyRepoStoreChanged: vi.fn()
+  }
 
   const callPickFolders = (): Promise<string[]> => {
     const handler = handlers.get('repos:pickFolders')
@@ -79,8 +82,10 @@ describe('repos folder pickers', () => {
     })
     removeHandlerMock.mockReset()
     showOpenDialogMock.mockReset()
+    mockStore.removeProject.mockReset()
+    mockRuntime.notifyRepoStoreChanged.mockReset()
 
-    registerRepoHandlers(mockWindow as never, mockStore as never)
+    registerRepoHandlers(mockWindow as never, mockStore as never, mockRuntime as never)
   })
 
   it('registers the multi-folder picker with handler cleanup', () => {
@@ -107,6 +112,13 @@ describe('repos folder pickers', () => {
     showOpenDialogMock.mockResolvedValue({ canceled: true, filePaths: [] })
 
     await expect(callPickFolders()).resolves.toEqual([])
+  })
+
+  it('releases runtime repo caches when local IPC removes a project', async () => {
+    await handlers.get('repos:remove')?.(null, { repoId: 'repo-1' })
+
+    expect(mockStore.removeProject).toHaveBeenCalledWith('repo-1')
+    expect(mockRuntime.notifyRepoStoreChanged).toHaveBeenCalledWith('repo-1')
   })
 
   it('picks an existing directory without enabling native directory creation', async () => {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -39,7 +39,7 @@ import {
 import { isTuiAgent } from '../../shared/tui-agent-config'
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import type { ChildProcess } from 'node:child_process'
-import { access, mkdir, readdir, rm } from 'node:fs/promises'
+import { access, mkdir, rm } from 'node:fs/promises'
 import { gitExecFileAsync, gitSpawn, nonInteractiveGitEnv } from '../git/runner'
 import { isAbsolute, join, posix } from 'node:path'
 import {
@@ -78,6 +78,7 @@ import { getSshGitUsername, resolveLocalGitUsername } from '../git/git-username'
 import { enrichRepoGitUsernames } from '../repo-git-username-enrichment'
 import { getActiveMultiplexer } from './ssh'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
+import { isRepoTargetDirectoryEmpty } from './repo-target-directory-emptiness'
 import { track } from '../telemetry/client'
 import { scheduleCurrentWorktreeBaseDirectoryWatcherSync } from './worktree-base-directory-watcher'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
@@ -100,6 +101,7 @@ import {
 import { getGitCloneFailureMessage } from '../../shared/git-clone-failure-message'
 import { prepareLocalWorktreeRootForRepo } from '../worktree-root-preparation'
 import { runWithGitReadCacheInvalidation } from '../git/status'
+import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 
 // Why: `method` is the IPC entry point the user took, not what they added (never path/URL/name); repos:create → 'folder_picker'.
 // Why: `isGitRepo` is a non-identifying git-vs-folder signal from the caller's detection; pass undefined when unknown, never default false.
@@ -1092,7 +1094,11 @@ async function runNestedRepoScanForIpc(
   }
 }
 
-export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): void {
+export function registerRepoHandlers(
+  mainWindow: BrowserWindow,
+  store: Store,
+  runtime?: OrcaRuntimeService
+): void {
   // Remove previously registered handlers so we can re-register on macOS app re-activation (new window).
   ipcMain.removeHandler('repos:list')
   ipcMain.removeHandler('repos:add')
@@ -1739,8 +1745,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
       if (targetExists) {
         try {
-          const entries = await readdir(targetPath)
-          if (entries.length > 0) {
+          if (!(await isRepoTargetDirectoryEmpty(targetPath))) {
             return {
               error: `"${name}" already exists at this location and is not empty.`
             }
@@ -1878,6 +1883,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
 
   ipcMain.handle('repos:remove', async (_event, args: { repoId: string }) => {
     store.removeProject(args.repoId)
+    runtime?.notifyRepoStoreChanged(args.repoId)
     invalidateAuthorizedRootsCache()
     notifyReposChanged(mainWindow)
   })
@@ -1891,6 +1897,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         throw new Error(`Invalid host ID: ${args.hostId}`)
       }
       store.removeProjectForHost(args.repoId, hostId)
+      runtime?.notifyRepoStoreChanged(args.repoId)
       invalidateAuthorizedRootsCache()
       notifyReposChanged(mainWindow)
     }

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -1,12 +1,17 @@
-import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
-import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { isMainWindowVisible, onMainWindowBecameVisible } from '../window/main-window-visibility'
 import type {
   WorktreeBaseRepoWatchConfig,
   WorktreeBaseWatchTarget
 } from './worktree-base-directory-event-filter'
 import { startGitCommonWatch } from './worktree-git-common-watch'
+import type { WorktreePollingScanLimits } from './worktree-polling-scan-budget'
+import {
+  collectWorktreeBaseDirectorySignatures,
+  hasWorktreeGitMarker,
+  takeWorktreeBaseDirectorySnapshot,
+  type WorktreeBaseDirectorySnapshot
+} from './worktree-base-directory-snapshot'
 
 export type WorktreeBasePollEvent = { type: 'create' | 'update' | 'delete'; path: string }
 
@@ -61,6 +66,7 @@ export type WorktreeBasePollerOptions = {
   visibility?: WorktreePollerWindowVisibility
   /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
   onFullScan?: () => void
+  scanLimits?: Partial<WorktreePollingScanLimits>
 }
 
 // Why: these targets used to be recursive FSEvents subscriptions spanning the
@@ -84,93 +90,10 @@ export const WORKTREE_BASE_BACKSTOP_TICKS = 15
 // backstop scan cover the pathological case.
 const PENDING_MARKER_MAX_TICKS = 300
 
-function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
-  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
-}
-
-async function dirSignature(path: string): Promise<string> {
-  try {
-    return statSignature(await stat(path))
-  } catch {
-    return 'missing'
-  }
-}
-
-async function hasGitMarker(dir: string): Promise<boolean> {
-  try {
-    await stat(join(dir, '.git'))
-    return true
-  } catch {
-    return false
-  }
-}
-
-type BaseSnapshot = {
-  // worktree-candidate dir → whether its `.git` completion marker exists
-  markers: Map<string, boolean>
-  // dirs whose listing determines the candidate set: the root plus any
-  // nested repo containers. Their stat signatures gate the next full scan.
-  gateDirs: string[]
-}
-
-// Depth-1 worktree dirs (flat layout), plus depth-2 dirs under each nested
-// repo's container, mirroring what worktree-base-directory-event-filter
-// matches: `<wt>/.git` completion markers and `<wt>` deletions.
-async function snapshotBase(
-  rootPath: string,
-  repos: ReadonlyMap<string, WorktreeBaseRepoWatchConfig>
-): Promise<BaseSnapshot> {
-  const markers = new Map<string, boolean>()
-  const gateDirs = [rootPath]
-  const configs = [...repos.values()]
-  const includeFlat = configs.some((config) => !config.nestWorkspaces)
-  const nestedRepoNames = new Set(
-    configs
-      .filter((config) => config.nestWorkspaces)
-      .map((config) => normalizeRuntimePathForComparison(config.repoName))
-  )
-
-  let rootEntries
-  try {
-    rootEntries = await readdir(rootPath, { withFileTypes: true })
-  } catch {
-    // Root vanished: an empty snapshot diffs into delete events for every
-    // previously-known worktree dir, matching the old watcher's error path.
-    return { markers, gateDirs }
-  }
-
-  const candidates: string[] = []
-  for (const entry of rootEntries) {
-    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
-      continue
-    }
-    const entryPath = join(rootPath, entry.name)
-    if (includeFlat) {
-      candidates.push(entryPath)
-    }
-    if (nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
-      gateDirs.push(entryPath)
-      let subEntries
-      try {
-        subEntries = await readdir(entryPath, { withFileTypes: true })
-      } catch {
-        subEntries = []
-      }
-      for (const sub of subEntries) {
-        if (sub.isDirectory() || sub.isSymbolicLink()) {
-          candidates.push(join(entryPath, sub.name))
-        }
-      }
-    }
-  }
-
-  for (const dir of candidates) {
-    markers.set(dir, await hasGitMarker(dir))
-  }
-  return { markers, gateDirs }
-}
-
-function diffBase(prev: BaseSnapshot, next: BaseSnapshot): WorktreeBasePollEvent[] {
+function diffBase(
+  prev: WorktreeBaseDirectorySnapshot,
+  next: WorktreeBaseDirectorySnapshot
+): WorktreeBasePollEvent[] {
   const events: WorktreeBasePollEvent[] = []
   for (const [dir, marker] of next.markers) {
     if (marker && prev.markers.get(dir) !== true) {
@@ -191,13 +114,14 @@ async function startBasePoller(
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
+  onFullScan: (() => void) | undefined,
+  scanLimits: Partial<WorktreePollingScanLimits>
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
   let tickCount = 0
-  let snapshot = await snapshotBase(target.path, getRepos())
-  let gateSignatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
+  let snapshot = await takeWorktreeBaseDirectorySnapshot(target.path, getRepos(), scanLimits)
+  let gateSignatures = await collectWorktreeBaseDirectorySignatures(snapshot.gateDirs)
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
   // dir → tick when first seen without a `.git` marker
@@ -210,8 +134,8 @@ async function startBasePoller(
 
   const fullScan = async (): Promise<void> => {
     onFullScan?.()
-    const next = await snapshotBase(target.path, getRepos())
-    const nextSignatures = await Promise.all(next.gateDirs.map(dirSignature))
+    const next = await takeWorktreeBaseDirectorySnapshot(target.path, getRepos(), scanLimits)
+    const nextSignatures = await collectWorktreeBaseDirectorySignatures(next.gateDirs)
     if (disposed) {
       return
     }
@@ -238,7 +162,7 @@ async function startBasePoller(
   const checkPendingMarkers = async (): Promise<void> => {
     const events: WorktreeBasePollEvent[] = []
     for (const dir of pendingMarkers.keys()) {
-      if (await hasGitMarker(dir)) {
+      if (await hasWorktreeGitMarker(dir)) {
         pendingMarkers.delete(dir)
         snapshot.markers.set(dir, true)
         events.push({ type: 'create', path: join(dir, '.git') })
@@ -257,7 +181,7 @@ async function startBasePoller(
     }
     // Idle fast path: when the dirs whose listings define the candidate set
     // are untouched, skip the readdir + per-candidate stat fan-out entirely.
-    const signatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
+    const signatures = await collectWorktreeBaseDirectorySignatures(snapshot.gateDirs)
     const gateChanged =
       signatures.length !== gateSignatures.length ||
       signatures.some((sig, index) => sig !== gateSignatures[index])
@@ -349,8 +273,17 @@ export async function startWorktreeBaseDirectoryPoller(
       pollIntervalMs,
       platform,
       visibility,
-      options.onFullScan
+      options.onFullScan,
+      options.scanLimits
     )
   }
-  return startBasePoller(target, getRepos, onEvents, pollIntervalMs, visibility, options.onFullScan)
+  return startBasePoller(
+    target,
+    getRepos,
+    onEvents,
+    pollIntervalMs,
+    visibility,
+    options.onFullScan,
+    options.scanLimits ?? {}
+  )
 }

--- a/src/main/ipc/worktree-base-directory-snapshot.ts
+++ b/src/main/ipc/worktree-base-directory-snapshot.ts
@@ -1,0 +1,109 @@
+import { opendir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import type { WorktreeBaseRepoWatchConfig } from './worktree-base-directory-event-filter'
+import {
+  WorktreePollingScanBudget,
+  type WorktreePollingScanLimits
+} from './worktree-polling-scan-budget'
+
+export type WorktreeBaseDirectorySnapshot = {
+  markers: Map<string, boolean>
+  gateDirs: string[]
+}
+
+function statSignature(value: { mtimeMs: number; ctimeMs: number; ino: number }): string {
+  return `${value.mtimeMs}:${value.ctimeMs}:${value.ino}`
+}
+
+async function directorySignature(path: string): Promise<string> {
+  try {
+    return statSignature(await stat(path))
+  } catch {
+    return 'missing'
+  }
+}
+
+export async function hasWorktreeGitMarker(dir: string): Promise<boolean> {
+  try {
+    await stat(join(dir, '.git'))
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function takeWorktreeBaseDirectorySnapshot(
+  rootPath: string,
+  repos: ReadonlyMap<string, WorktreeBaseRepoWatchConfig>,
+  scanLimits: Partial<WorktreePollingScanLimits>
+): Promise<WorktreeBaseDirectorySnapshot> {
+  const markers = new Map<string, boolean>()
+  const gateDirs = [rootPath]
+  const budget = new WorktreePollingScanBudget(scanLimits)
+  budget.claimRetainedPath(rootPath)
+  let includeFlat = false
+  const nestedRepoNames = new Set<string>()
+  for (const config of repos.values()) {
+    budget.claimRepoConfig(config.repoId, config.repoName)
+    if (config.nestWorkspaces) {
+      nestedRepoNames.add(normalizeRuntimePathForComparison(config.repoName))
+    } else {
+      includeFlat = true
+    }
+  }
+
+  let rootDirectory
+  try {
+    rootDirectory = await opendir(rootPath, { bufferSize: 32 })
+  } catch {
+    return { markers, gateDirs }
+  }
+
+  const candidates: string[] = []
+  for await (const entry of rootDirectory) {
+    budget.claimEntry()
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) {
+      continue
+    }
+    const entryPath = join(rootPath, entry.name)
+    if (includeFlat) {
+      budget.claimRetainedPath(entryPath)
+      candidates.push(entryPath)
+    }
+    if (!nestedRepoNames.has(normalizeRuntimePathForComparison(entry.name))) {
+      continue
+    }
+    budget.claimRetainedPath(entryPath)
+    gateDirs.push(entryPath)
+    let subDirectory
+    try {
+      subDirectory = await opendir(entryPath, { bufferSize: 32 })
+    } catch {
+      continue
+    }
+    for await (const sub of subDirectory) {
+      budget.claimEntry()
+      if (sub.isDirectory() || sub.isSymbolicLink()) {
+        const candidatePath = join(entryPath, sub.name)
+        budget.claimRetainedPath(candidatePath)
+        candidates.push(candidatePath)
+      }
+    }
+  }
+
+  for (const dir of candidates) {
+    markers.set(dir, await hasWorktreeGitMarker(dir))
+  }
+  return { markers, gateDirs }
+}
+
+export async function collectWorktreeBaseDirectorySignatures(
+  paths: readonly string[]
+): Promise<string[]> {
+  const signatures: string[] = []
+  for (const path of paths) {
+    signatures.push(await directorySignature(path))
+  }
+  return signatures
+}

--- a/src/main/ipc/worktree-base-directory-watch-targets-bounds.test.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets-bounds.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings, Repo } from '../../shared/types'
+import {
+  buildWorktreeBaseDirectoryWatchTargets,
+  clearWorktreeBaseDirectoryWatchTargetWarnings
+} from './worktree-base-directory-watch-targets'
+import { WORKTREE_POLLING_MAX_REPO_CONFIGS } from './worktree-polling-scan-budget'
+
+const settings = {
+  workspaceDir: '/worktrees',
+  nestWorkspaces: false
+} as GlobalSettings
+
+function folderRepo(index: number): Repo {
+  return {
+    id: `repo-${index}`,
+    path: `/repos/${index}`,
+    displayName: `Repo ${index}`,
+    badgeColor: '#000000',
+    addedAt: index,
+    kind: 'folder'
+  }
+}
+
+describe('worktree watcher target repo bounds', () => {
+  afterEach(() => {
+    clearWorktreeBaseDirectoryWatchTargetWarnings()
+    vi.restoreAllMocks()
+  })
+
+  it('accepts the exact repo count before hydrating repos', async () => {
+    const repos = Array.from({ length: WORKTREE_POLLING_MAX_REPO_CONFIGS }, (_, index) =>
+      folderRepo(index)
+    )
+    const getRepos = vi.fn(() => repos)
+
+    await expect(
+      buildWorktreeBaseDirectoryWatchTargets({
+        getRepoCount: () => repos.length,
+        getRepos,
+        getSettings: () => settings
+      } as never)
+    ).resolves.toEqual(new Map())
+    expect(getRepos).toHaveBeenCalledOnce()
+  })
+
+  it('rejects one repo over the cap without hydrating the repo array', async () => {
+    const getRepos = vi.fn(() => {
+      throw new Error('must not hydrate')
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await expect(
+      buildWorktreeBaseDirectoryWatchTargets({
+        getRepoCount: () => WORKTREE_POLLING_MAX_REPO_CONFIGS + 1,
+        getRepos,
+        getSettings: () => settings
+      } as never)
+    ).resolves.toEqual(new Map())
+    expect(getRepos).not.toHaveBeenCalled()
+    expect(warn).toHaveBeenCalledOnce()
+  })
+
+  it('resumes target construction after the repo count returns below the cap', async () => {
+    let repoCount = WORKTREE_POLLING_MAX_REPO_CONFIGS + 1
+    const getRepos = vi.fn(() => [folderRepo(1)])
+    const store = {
+      getRepoCount: () => repoCount,
+      getRepos,
+      getSettings: () => settings
+    }
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await buildWorktreeBaseDirectoryWatchTargets(store as never)
+    expect(getRepos).not.toHaveBeenCalled()
+
+    repoCount = 1
+    await buildWorktreeBaseDirectoryWatchTargets(store as never)
+    expect(getRepos).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/ipc/worktree-base-directory-watch-targets.ts
+++ b/src/main/ipc/worktree-base-directory-watch-targets.ts
@@ -27,9 +27,11 @@ import type {
   WorktreeBaseWatchKind,
   WorktreeBaseWatchTarget
 } from './worktree-base-directory-event-filter'
+import { WORKTREE_POLLING_MAX_REPO_CONFIGS } from './worktree-polling-scan-budget'
 
 const missingRootWarnings = new Set<string>()
 const skippedWslWarnings = new Set<string>()
+let repoCapacityWarningEmitted = false
 
 function normalizeWatchKey(pathValue: string): string {
   return normalizeRuntimePathForComparison(normalize(pathValue))
@@ -179,8 +181,23 @@ async function maybeAddBaseTarget(
 export async function buildWorktreeBaseDirectoryWatchTargets(
   store: Store
 ): Promise<Map<string, WorktreeBaseWatchTarget>> {
-  const settings = store.getSettings()
   const targets = new Map<string, WorktreeBaseWatchTarget>()
+  const repoCount = store.getRepoCount()
+  if (
+    !Number.isSafeInteger(repoCount) ||
+    repoCount < 0 ||
+    repoCount > WORKTREE_POLLING_MAX_REPO_CONFIGS
+  ) {
+    if (!repoCapacityWarningEmitted) {
+      console.warn(
+        `[worktree-base-watcher] skipping background watchers for ${repoCount} repos; limit is ${WORKTREE_POLLING_MAX_REPO_CONFIGS}`
+      )
+      repoCapacityWarningEmitted = true
+    }
+    return targets
+  }
+  repoCapacityWarningEmitted = false
+  const settings = store.getSettings()
   for (const repo of store.getRepos()) {
     if (isFolderRepo(repo)) {
       continue
@@ -198,4 +215,5 @@ export async function buildWorktreeBaseDirectoryWatchTargets(
 export function clearWorktreeBaseDirectoryWatchTargetWarnings(): void {
   missingRootWarnings.clear()
   skippedWslWarnings.clear()
+  repoCapacityWarningEmitted = false
 }

--- a/src/main/ipc/worktree-base-directory-watcher.test.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.test.ts
@@ -73,6 +73,7 @@ function makeRepo(overrides: Partial<Repo> = {}): Repo {
 function makeStore(repos: Repo[]) {
   return {
     getSettings: () => settings,
+    getRepoCount: () => repos.length,
     getRepos: () => repos
   }
 }

--- a/src/main/ipc/worktree-base-directory-watcher.ts
+++ b/src/main/ipc/worktree-base-directory-watcher.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
+import { forEachWithConcurrency } from '../../shared/map-with-concurrency'
 import { notifyWorktreeGitStatusMetadataChanged, notifyWorktreesChanged } from './worktree-remote'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
@@ -34,6 +35,7 @@ type ActiveWatch = WorktreeBaseWatchTarget & {
 }
 
 const WATCH_DEBOUNCE_MS = 250
+export const WORKTREE_WATCH_CLOSE_LIMIT = 8
 const activeWatches = new Map<string, ActiveWatch>()
 let syncGeneration = 0
 let scheduledSync: ReturnType<typeof setTimeout> | null = null
@@ -327,10 +329,8 @@ export function scheduleCurrentWorktreeBaseDirectoryWatcherSync(): void {
 export async function disposeWorktreeBaseDirectoryWatchers(): Promise<void> {
   syncGeneration++
   latestSyncContext = null
-  if (scheduledSync) {
-    clearTimeout(scheduledSync)
-    scheduledSync = null
-  }
-  await Promise.all([...activeWatches.keys()].map((key) => removeWatch(key)))
+  clearTimeout(scheduledSync ?? undefined)
+  scheduledSync = null
+  await forEachWithConcurrency([...activeWatches.keys()], WORKTREE_WATCH_CLOSE_LIMIT, removeWatch)
   clearWorktreeBaseDirectoryWatchTargetWarnings()
 }

--- a/src/main/ipc/worktree-common-git-directory.test.ts
+++ b/src/main/ipc/worktree-common-git-directory.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import type { Repo } from '../../shared/types'
+import {
+  MAX_GIT_DIRECTORY_POINTER_BYTES,
+  resolveWorktreeCommonGitDirectory
+} from './worktree-common-git-directory'
+
+describe('resolveWorktreeCommonGitDirectory', () => {
+  const roots: string[] = []
+
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  async function makeRepo(): Promise<{ repo: Repo; root: string }> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-common-git-dir-'))
+    roots.push(root)
+    const repoPath = join(root, 'checkout')
+    await mkdir(repoPath)
+    return { repo: { id: 'repo-1', path: repoPath } as Repo, root }
+  }
+
+  it('resolves a normal linked-worktree pointer to its common directory', async () => {
+    const { repo, root } = await makeRepo()
+    await writeFile(join(repo.path, '.git'), 'gitdir: ../common/.git/worktrees/checkout\n')
+
+    await expect(resolveWorktreeCommonGitDirectory(repo)).resolves.toBe(
+      resolve(root, 'common', '.git')
+    )
+  })
+
+  it('rejects an oversized sparse local pointer without loading it', async () => {
+    const { repo } = await makeRepo()
+    const dotGitPath = join(repo.path, '.git')
+    await writeFile(dotGitPath, 'x')
+    await truncate(dotGitPath, MAX_GIT_DIRECTORY_POINTER_BYTES + 1)
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    await expect(resolveWorktreeCommonGitDirectory(repo)).resolves.toBeNull()
+  })
+
+  it('rejects oversized provider content at the same boundary', async () => {
+    const { repo } = await makeRepo()
+    const readFile = vi.fn(async () => `gitdir: ${'x'.repeat(MAX_GIT_DIRECTORY_POINTER_BYTES)}\n`)
+
+    await expect(
+      resolveWorktreeCommonGitDirectory(repo, {
+        stat: async () => ({ type: 'file', size: 1, mtime: 0 }),
+        readFile
+      })
+    ).resolves.toBeNull()
+    expect(readFile).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/ipc/worktree-common-git-directory.ts
+++ b/src/main/ipc/worktree-common-git-directory.ts
@@ -1,5 +1,5 @@
 import type { Stats } from 'node:fs'
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import type { Repo } from '../../shared/types'
 import {
   getRuntimePathBasename,
@@ -7,6 +7,9 @@ import {
   resolveRuntimePath
 } from '../../shared/cross-platform-path'
 import type { FileStat } from '../providers/types'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
+
+export const MAX_GIT_DIRECTORY_POINTER_BYTES = 64 * 1024
 
 type GitDirectoryStat = Stats | FileStat
 
@@ -41,7 +44,12 @@ export async function resolveWorktreeCommonGitDirectory(
 ): Promise<string | null> {
   const dotGitPath = resolveRuntimePath(repo.path, '.git')
   const statPath = access.stat ?? stat
-  const readText = access.readFile ?? ((path: string) => readFile(path, 'utf8'))
+  const readText =
+    access.readFile ??
+    (async (path: string) =>
+      (await readNodeFileWithinLimit(path, MAX_GIT_DIRECTORY_POINTER_BYTES)).buffer.toString(
+        'utf8'
+      ))
   try {
     const dotGitStat = await statPath(dotGitPath)
     if (isDirectoryStat(dotGitStat)) {
@@ -51,6 +59,9 @@ export async function resolveWorktreeCommonGitDirectory(
       return null
     }
     const content = await readText(dotGitPath)
+    if (Buffer.byteLength(content, 'utf8') > MAX_GIT_DIRECTORY_POINTER_BYTES) {
+      return null
+    }
     const gitDir = content.match(/^gitdir:\s*(.+)\s*$/m)?.[1]?.trim()
     if (!gitDir) {
       return null

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -1,257 +1,21 @@
-import { readdir, stat } from 'node:fs/promises'
-import { join } from 'node:path'
 import type {
   WorktreeBasePollEvent,
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import type { WorktreePollingScanLimits } from './worktree-polling-scan-budget'
+import {
+  diffGitCommon,
+  PRIMARY_CHECKOUT_METADATA_FILES,
+  snapshotGitCommon
+} from './worktree-git-common-snapshot'
 
-// Shared with the darwin primary-metadata poll so platforms cannot drift.
-// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag.
-export const PRIMARY_CHECKOUT_METADATA_FILES = [
-  'HEAD',
-  'packed-refs',
-  'index',
-  'config.worktree',
-  'logs/HEAD'
-]
-const LINKED_WORKTREE_STRUCTURAL_METADATA_FILES = ['HEAD', 'gitdir', 'locked', 'config.worktree']
-const LINKED_WORKTREE_INDEX_FILE = 'index'
-const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
+export { PRIMARY_CHECKOUT_METADATA_FILES }
+
 // Why: the entry-dir signature gate can miss same-granule index rewrites on
 // coarse-mtime filesystems; a periodic ungated re-stat bounds that miss the
 // same way the base poller's backstop rescan does.
 const INDEX_BACKSTOP_TICKS = 15
-
-function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
-  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
-}
-
-async function dirSignature(path: string): Promise<string> {
-  try {
-    // Why: keep `size` — on a coarse-timestamp filesystem a same-granule directory
-    // allocation change would otherwise slip the readdir gate to the backstop.
-    const s = await stat(path)
-    return `${statSignature(s)}:${s.size}`
-  } catch {
-    return 'missing'
-  }
-}
-
-async function fileSignature(path: string): Promise<string | null> {
-  try {
-    const s = await stat(path)
-    return s.isFile() ? `${statSignature(s)}:${s.size}` : null
-  } catch {
-    return null
-  }
-}
-
-type GitCommonEntrySnapshot = {
-  dirSignature: string
-  structuralSignatures: Map<string, string>
-  indexSignature: string | null
-  headLogSignature: string | null
-}
-
-type GitCommonSnapshot = {
-  worktreesDirSignature: string
-  entries: Map<string, GitCommonEntrySnapshot>
-  primarySignatures: Map<string, string>
-  didFullScan: boolean
-}
-
-async function snapshotGitCommonEntry(
-  entryPath: string,
-  previous: GitCommonEntrySnapshot | undefined,
-  forceFullScan: boolean
-): Promise<GitCommonEntrySnapshot> {
-  // Why: HEAD, gitdir, locked, config.worktree and logs/HEAD are rewritten in place without bumping
-  // the entry-dir mtime, so — like the pre-idle-gate poller — they are re-stat'd EVERY tick, never
-  // gated behind the dir signature (else a raw HEAD/structural rewrite would slip to the ~30s
-  // backstop). Only `index` rides the entry-dir signature (its same-dir rewrites are index-backstop-bounded).
-  const structuralSignatures = new Map<string, string>()
-  const [nextDirSignature, headLogSignature] = await Promise.all([
-    dirSignature(entryPath),
-    fileSignature(join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE)),
-    Promise.all(
-      LINKED_WORKTREE_STRUCTURAL_METADATA_FILES.map(async (name) => {
-        const signature = await fileSignature(join(entryPath, name))
-        if (signature !== null) {
-          structuralSignatures.set(name, signature)
-        }
-      })
-    )
-  ])
-  if (nextDirSignature === 'missing') {
-    // A transient stat failure must not masquerade as a removal; the parent listing is authoritative.
-    return (
-      previous ?? {
-        dirSignature: nextDirSignature,
-        structuralSignatures,
-        indexSignature: null,
-        headLogSignature
-      }
-    )
-  }
-  const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
-  const indexSignature = shouldReadIndex
-    ? await fileSignature(join(entryPath, LINKED_WORKTREE_INDEX_FILE))
-    : previous.indexSignature
-  return {
-    dirSignature: nextDirSignature,
-    structuralSignatures,
-    indexSignature,
-    headLogSignature
-  }
-}
-
-async function snapshotPrimaryCheckoutSignatures(
-  commonDirPath: string
-): Promise<Map<string, string>> {
-  const signatures = new Map<string, string>()
-  await Promise.all(
-    PRIMARY_CHECKOUT_METADATA_FILES.map(async (name) => {
-      const signature = await fileSignature(join(commonDirPath, name))
-      if (signature !== null) {
-        signatures.set(name, signature)
-      }
-    })
-  )
-  return signatures
-}
-
-async function snapshotGitCommon(
-  commonDirPath: string,
-  previous?: GitCommonSnapshot,
-  includePrimary = true,
-  forceFullScan = false
-): Promise<GitCommonSnapshot> {
-  const worktreesDir = join(commonDirPath, 'worktrees')
-  const [worktreesDirSignature, primarySignatures] = await Promise.all([
-    dirSignature(worktreesDir),
-    includePrimary ? snapshotPrimaryCheckoutSignatures(commonDirPath) : new Map<string, string>()
-  ])
-  // Why: enumerate the worktrees dir EVERY tick rather than gating the readdir on its stat signature.
-  // A single readdir of a small dir is negligible next to the per-entry structural stats that already
-  // run each tick, and the signature gate could miss a same-granule add+remove on a coarse-mtime/FAT
-  // filesystem (its size/mtime/ino/ctime all collide), leaving a linked worktree add/remove undetected
-  // until the ~30s index backstop (#9882 review). The listing is the authoritative add/remove signal.
-  let entryPaths: string[]
-  try {
-    const entries = await readdir(worktreesDir, { withFileTypes: true })
-    entryPaths = entries
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => join(worktreesDir, entry.name))
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      // Dir genuinely absent (no linked worktrees, or all removed) → authoritative empty listing.
-      entryPaths = []
-    } else {
-      // Why: a TRANSIENT readdir failure (EIO/ESTALE/EMFILE, network/SSH hiccup) must not masquerade as
-      // "every worktree removed" — that would emit false delete events (and false creates next tick).
-      // Reuse the known entries so per-entry stats still run; a real removal surfaces as that entry's own
-      // stat miss (handled in snapshotGitCommonEntry), and the next successful readdir catches any add.
-      entryPaths = previous ? [...previous.entries.keys()] : []
-    }
-  }
-
-  const entries = new Map<string, GitCommonEntrySnapshot>()
-  await Promise.all(
-    entryPaths.map(async (entryPath) => {
-      const previousEntry = previous?.entries.get(entryPath)
-      entries.set(entryPath, await snapshotGitCommonEntry(entryPath, previousEntry, forceFullScan))
-    })
-  )
-  // Why: the expensive per-entry `index` read stays gated on each entry's own dir signature; onFullScan
-  // now reflects an ungated index-metadata backstop fan-out (forceFullScan) — the real periodic cost —
-  // rather than the always-run worktrees-dir readdir.
-  return {
-    worktreesDirSignature,
-    entries,
-    primarySignatures,
-    didFullScan: forceFullScan
-  }
-}
-
-function classifySignatureDiff(
-  prevSignature: string | null | undefined,
-  nextSignature: string | null | undefined
-): 'create' | 'update' | 'delete' | null {
-  if (prevSignature == null && nextSignature == null) {
-    return null
-  }
-  if (prevSignature == null) {
-    return 'create'
-  }
-  if (nextSignature == null) {
-    return 'delete'
-  }
-  return prevSignature === nextSignature ? null : 'update'
-}
-
-function diffSignatureMaps(
-  prev: Map<string, string>,
-  next: Map<string, string>,
-  resolvePath: (name: string) => string
-): WorktreeBasePollEvent[] {
-  const events: WorktreeBasePollEvent[] = []
-  const names = new Set([...prev.keys(), ...next.keys()])
-  for (const name of names) {
-    const type = classifySignatureDiff(prev.get(name), next.get(name))
-    if (type) {
-      events.push({ type, path: resolvePath(name) })
-    }
-  }
-  return events
-}
-
-function diffGitCommon(
-  commonDirPath: string,
-  prev: GitCommonSnapshot,
-  next: GitCommonSnapshot
-): WorktreeBasePollEvent[] {
-  const events: WorktreeBasePollEvent[] = []
-  const worktreesDir = join(commonDirPath, 'worktrees')
-  const worktreesDirDiff = classifySignatureDiff(
-    prev.worktreesDirSignature,
-    next.worktreesDirSignature
-  )
-  if (worktreesDirDiff) {
-    events.push({ type: worktreesDirDiff, path: worktreesDir })
-  }
-  for (const [entryPath, entry] of next.entries) {
-    const prevEntry = prev.entries.get(entryPath)
-    if (!prevEntry) {
-      events.push({ type: 'create', path: entryPath })
-      continue
-    }
-    events.push(
-      ...diffSignatureMaps(prevEntry.structuralSignatures, entry.structuralSignatures, (name) =>
-        join(entryPath, name)
-      )
-    )
-    const indexDiff = classifySignatureDiff(prevEntry.indexSignature, entry.indexSignature)
-    if (indexDiff) {
-      events.push({ type: indexDiff, path: join(entryPath, LINKED_WORKTREE_INDEX_FILE) })
-    }
-    const headLogDiff = classifySignatureDiff(prevEntry.headLogSignature, entry.headLogSignature)
-    if (headLogDiff) {
-      events.push({ type: headLogDiff, path: join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE) })
-    }
-  }
-  for (const entryPath of prev.entries.keys()) {
-    if (!next.entries.has(entryPath)) {
-      events.push({ type: 'delete', path: entryPath })
-    }
-  }
-  events.push(
-    ...diffSignatureMaps(prev.primarySignatures, next.primarySignatures, (name) =>
-      join(commonDirPath, name)
-    )
-  )
-  return events
-}
 
 export async function startGitCommonPolling(
   commonDirPath: string,
@@ -259,12 +23,19 @@ export async function startGitCommonPolling(
   pollIntervalMs: number,
   visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void,
-  includePrimary = true
+  includePrimary = true,
+  scanLimits: Partial<WorktreePollingScanLimits> = {}
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
   let tickCount = 0
-  let snapshot = await snapshotGitCommon(commonDirPath, undefined, includePrimary)
+  let snapshot = await snapshotGitCommon(
+    commonDirPath,
+    undefined,
+    includePrimary,
+    false,
+    scanLimits
+  )
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
 
@@ -291,7 +62,8 @@ export async function startGitCommonPolling(
         commonDirPath,
         snapshot,
         includePrimary,
-        shouldForceFullScan
+        shouldForceFullScan,
+        scanLimits
       )
       if (disposed) {
         return

--- a/src/main/ipc/worktree-git-common-snapshot.ts
+++ b/src/main/ipc/worktree-git-common-snapshot.ts
@@ -1,0 +1,258 @@
+import { opendir, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
+import type { WorktreeBasePollEvent } from './worktree-base-directory-poller'
+import {
+  WorktreePollingScanBudget,
+  type WorktreePollingScanLimits
+} from './worktree-polling-scan-budget'
+
+export const PRIMARY_CHECKOUT_METADATA_FILES = [
+  'HEAD',
+  'packed-refs',
+  'index',
+  'config.worktree',
+  'logs/HEAD'
+]
+
+const LINKED_WORKTREE_STRUCTURAL_METADATA_FILES = ['HEAD', 'gitdir', 'locked', 'config.worktree']
+const LINKED_WORKTREE_INDEX_FILE = 'index'
+const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
+const GIT_COMMON_ENTRY_STAT_CONCURRENCY = 16
+
+function statSignature(s: { mtimeMs: number; ctimeMs: number; ino: number }): string {
+  return `${s.mtimeMs}:${s.ctimeMs}:${s.ino}`
+}
+
+async function dirSignature(path: string): Promise<string> {
+  try {
+    const stats = await stat(path)
+    return `${statSignature(stats)}:${stats.size}`
+  } catch {
+    return 'missing'
+  }
+}
+
+async function fileSignature(path: string): Promise<string | null> {
+  try {
+    const stats = await stat(path)
+    return stats.isFile() ? `${statSignature(stats)}:${stats.size}` : null
+  } catch {
+    return null
+  }
+}
+
+type GitCommonEntrySnapshot = {
+  dirSignature: string
+  structuralSignatures: Map<string, string>
+  indexSignature: string | null
+  headLogSignature: string | null
+}
+
+export type GitCommonSnapshot = {
+  worktreesDirSignature: string
+  entries: Map<string, GitCommonEntrySnapshot>
+  primarySignatures: Map<string, string>
+  didFullScan: boolean
+}
+
+async function snapshotGitCommonEntry(
+  entryPath: string,
+  previous: GitCommonEntrySnapshot | undefined,
+  forceFullScan: boolean
+): Promise<GitCommonEntrySnapshot> {
+  // Why: structural leaves can change without the entry directory changing; only the index uses the gate.
+  const structuralSignatures = new Map<string, string>()
+  const [nextDirSignature, headLogSignature] = await Promise.all([
+    dirSignature(entryPath),
+    fileSignature(join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE)),
+    Promise.all(
+      LINKED_WORKTREE_STRUCTURAL_METADATA_FILES.map(async (name) => {
+        const signature = await fileSignature(join(entryPath, name))
+        if (signature !== null) {
+          structuralSignatures.set(name, signature)
+        }
+      })
+    )
+  ])
+  if (nextDirSignature === 'missing') {
+    // A transient stat failure must not masquerade as a removal; the parent listing is authoritative.
+    return (
+      previous ?? {
+        dirSignature: nextDirSignature,
+        structuralSignatures,
+        indexSignature: null,
+        headLogSignature
+      }
+    )
+  }
+  const shouldReadIndex = forceFullScan || !previous || previous.dirSignature !== nextDirSignature
+  const indexSignature = shouldReadIndex
+    ? await fileSignature(join(entryPath, LINKED_WORKTREE_INDEX_FILE))
+    : previous.indexSignature
+  return {
+    dirSignature: nextDirSignature,
+    structuralSignatures,
+    indexSignature,
+    headLogSignature
+  }
+}
+
+async function snapshotPrimaryCheckoutSignatures(
+  commonDirPath: string
+): Promise<Map<string, string>> {
+  const signatures = new Map<string, string>()
+  await Promise.all(
+    PRIMARY_CHECKOUT_METADATA_FILES.map(async (name) => {
+      const signature = await fileSignature(join(commonDirPath, name))
+      if (signature !== null) {
+        signatures.set(name, signature)
+      }
+    })
+  )
+  return signatures
+}
+
+export async function snapshotGitCommon(
+  commonDirPath: string,
+  previous?: GitCommonSnapshot,
+  includePrimary = true,
+  forceFullScan = false,
+  scanLimits: Partial<WorktreePollingScanLimits> = {}
+): Promise<GitCommonSnapshot> {
+  const worktreesDir = join(commonDirPath, 'worktrees')
+  const [worktreesDirSignature, primarySignatures] = await Promise.all([
+    dirSignature(worktreesDir),
+    includePrimary ? snapshotPrimaryCheckoutSignatures(commonDirPath) : new Map<string, string>()
+  ])
+  // Why: listing is authoritative for add/remove; directory timestamps can collide on coarse filesystems.
+  const budget = new WorktreePollingScanBudget(scanLimits)
+  let directory: Awaited<ReturnType<typeof opendir>> | undefined
+  let entryPaths: string[] = []
+  try {
+    directory = await opendir(worktreesDir, { bufferSize: 32 })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      entryPaths = previous ? [...previous.entries.keys()] : []
+    }
+  }
+  if (directory) {
+    for await (const entry of directory) {
+      budget.claimEntry()
+      if (!entry.isDirectory()) {
+        continue
+      }
+      const entryPath = join(worktreesDir, entry.name)
+      budget.claimRetainedPath(entryPath)
+      entryPaths.push(entryPath)
+    }
+  } else {
+    for (const entryPath of entryPaths) {
+      budget.claimRetainedPath(entryPath)
+    }
+  }
+  const entrySnapshots = await mapWithConcurrency(
+    entryPaths,
+    GIT_COMMON_ENTRY_STAT_CONCURRENCY,
+    async (entryPath) => ({
+      entryPath,
+      snapshot: await snapshotGitCommonEntry(
+        entryPath,
+        previous?.entries.get(entryPath),
+        forceFullScan
+      )
+    })
+  )
+  const entries = new Map<string, GitCommonEntrySnapshot>()
+  for (const { entryPath, snapshot } of entrySnapshots) {
+    entries.set(entryPath, snapshot)
+  }
+  return {
+    worktreesDirSignature,
+    entries,
+    primarySignatures,
+    didFullScan: forceFullScan
+  }
+}
+
+function classifySignatureDiff(
+  previous: string | null | undefined,
+  next: string | null | undefined
+): 'create' | 'update' | 'delete' | null {
+  if (previous == null && next == null) {
+    return null
+  }
+  if (previous == null) {
+    return 'create'
+  }
+  if (next == null) {
+    return 'delete'
+  }
+  return previous === next ? null : 'update'
+}
+
+function diffSignatureMaps(
+  previous: Map<string, string>,
+  next: Map<string, string>,
+  resolvePath: (name: string) => string
+): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  const names = new Set([...previous.keys(), ...next.keys()])
+  for (const name of names) {
+    const type = classifySignatureDiff(previous.get(name), next.get(name))
+    if (type) {
+      events.push({ type, path: resolvePath(name) })
+    }
+  }
+  return events
+}
+
+export function diffGitCommon(
+  commonDirPath: string,
+  previous: GitCommonSnapshot,
+  next: GitCommonSnapshot
+): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  const worktreesDir = join(commonDirPath, 'worktrees')
+  const worktreesDirDiff = classifySignatureDiff(
+    previous.worktreesDirSignature,
+    next.worktreesDirSignature
+  )
+  if (worktreesDirDiff) {
+    events.push({ type: worktreesDirDiff, path: worktreesDir })
+  }
+  for (const [entryPath, entry] of next.entries) {
+    const previousEntry = previous.entries.get(entryPath)
+    if (!previousEntry) {
+      events.push({ type: 'create', path: entryPath })
+      continue
+    }
+    events.push(
+      ...diffSignatureMaps(previousEntry.structuralSignatures, entry.structuralSignatures, (name) =>
+        join(entryPath, name)
+      )
+    )
+    const indexDiff = classifySignatureDiff(previousEntry.indexSignature, entry.indexSignature)
+    if (indexDiff) {
+      events.push({ type: indexDiff, path: join(entryPath, LINKED_WORKTREE_INDEX_FILE) })
+    }
+    const headLogDiff = classifySignatureDiff(
+      previousEntry.headLogSignature,
+      entry.headLogSignature
+    )
+    if (headLogDiff) {
+      events.push({ type: headLogDiff, path: join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE) })
+    }
+  }
+  for (const entryPath of previous.entries.keys()) {
+    if (!next.entries.has(entryPath)) {
+      events.push({ type: 'delete', path: entryPath })
+    }
+  }
+  events.push(
+    ...diffSignatureMaps(previous.primarySignatures, next.primarySignatures, (name) =>
+      join(commonDirPath, name)
+    )
+  )
+  return events
+}

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -11,6 +11,7 @@ import {
   PRIMARY_CHECKOUT_METADATA_FILES,
   startGitCommonPolling
 } from './worktree-git-common-polling'
+import type { WorktreePollingScanLimits } from './worktree-polling-scan-budget'
 
 // Watches a repo's `<common>/.git/worktrees` metadata plus the primary
 // checkout's shallow branch/index files — the only paths the git-common event
@@ -284,7 +285,8 @@ export async function startGitCommonWatch(
   pollIntervalMs: number,
   platform: NodeJS.Platform,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
+  onFullScan?: () => void,
+  scanLimits: Partial<WorktreePollingScanLimits> = {}
 ): Promise<WorktreeBaseSubscription> {
   if (platform === 'darwin') {
     const [narrowWatch, primaryMetadataPoll] = await Promise.all([
@@ -303,5 +305,13 @@ export async function startGitCommonWatch(
       }
     }
   }
-  return startGitCommonPolling(target.path, onEvents, pollIntervalMs, visibility, onFullScan)
+  return startGitCommonPolling(
+    target.path,
+    onEvents,
+    pollIntervalMs,
+    visibility,
+    onFullScan,
+    true,
+    scanLimits
+  )
 }

--- a/src/main/ipc/worktree-head-identity-reader.test.ts
+++ b/src/main/ipc/worktree-head-identity-reader.test.ts
@@ -1,8 +1,13 @@
 import { afterEach, describe, expect, it } from 'vitest'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import { readGitCommonHeadIdentities } from './worktree-head-identity-reader'
+import {
+  MAX_GIT_HEAD_METADATA_BYTES,
+  MAX_LINKED_WORKTREE_ENTRIES,
+  MAX_PACKED_REFS_BYTES,
+  readGitCommonHeadIdentities
+} from './worktree-head-identity-reader'
 
 const OID_A = 'a'.repeat(40)
 const OID_B = 'b'.repeat(40)
@@ -146,6 +151,34 @@ describe('readGitCommonHeadIdentities', () => {
     await mkdir(commonDir, { recursive: true })
     await writeFile(join(commonDir, 'HEAD'), 'ref: refs/heads/main\n')
     await writeLooseRef(commonDir, 'refs/heads/main', OID_A)
+
+    expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+  })
+
+  it('rejects metadata that grows beyond the exact file limits', async () => {
+    const commonDir = await makeCommonDir()
+    const headPath = join(commonDir, 'HEAD')
+    await writeFile(headPath, 'x')
+    await truncate(headPath, MAX_GIT_HEAD_METADATA_BYTES + 1)
+    expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+
+    await writeFile(headPath, 'ref: refs/heads/main\n')
+    const packedRefsPath = join(commonDir, 'packed-refs')
+    await writeFile(packedRefsPath, 'x')
+    await truncate(packedRefsPath, MAX_PACKED_REFS_BYTES + 1)
+    expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
+  })
+
+  it('fails closed instead of retaining a partial oversized worktree listing', async () => {
+    const commonDir = await makeCommonDir()
+    await writeFile(join(commonDir, 'HEAD'), `${OID_A}\n`)
+    const worktreesDir = join(commonDir, 'worktrees')
+    await mkdir(worktreesDir)
+    await Promise.all(
+      Array.from({ length: MAX_LINKED_WORKTREE_ENTRIES + 1 }, (_, index) =>
+        writeFile(join(worktreesDir, `entry-${index}`), '')
+      )
+    )
 
     expect(await readGitCommonHeadIdentities(commonDir)).toEqual([])
   })

--- a/src/main/ipc/worktree-head-identity-reader.ts
+++ b/src/main/ipc/worktree-head-identity-reader.ts
@@ -1,16 +1,26 @@
-import { readdir, readFile } from 'node:fs/promises'
+import { opendir } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join } from 'node:path'
 import type { WorktreeHeadIdentity } from '../../shared/types'
+import { readNodeFileWithinLimit } from '../../shared/node-bounded-file-reader'
 
 // Why: the whole point of this reader is replacing `git worktree list` fanout
 // with bounded metadata-file reads, so head freshness never re-creates the
 // spawn pressure that stalled terminal input. Keep it spawn-free.
 
 const MAX_SYMREF_DEPTH = 5
+export const MAX_GIT_HEAD_METADATA_BYTES = 64 * 1024
+export const MAX_PACKED_REFS_BYTES = 16 * 1024 * 1024
+export const MAX_PACKED_REFS_ENTRIES = 100_000
+export const MAX_LINKED_WORKTREE_ENTRIES = 1_024
+const MAX_PACKED_REFS_RETAINED_BYTES = 16 * 1024 * 1024
+const MAX_IDENTITY_RETAINED_BYTES = 4 * 1024 * 1024
 
-async function readTrimmedFile(path: string): Promise<string | null> {
+async function readTrimmedFile(
+  path: string,
+  maxBytes = MAX_GIT_HEAD_METADATA_BYTES
+): Promise<string | null> {
   try {
-    return (await readFile(path, 'utf8')).trim()
+    return (await readNodeFileWithinLimit(path, maxBytes)).buffer.toString('utf8').trim()
   } catch {
     return null
   }
@@ -19,19 +29,39 @@ async function readTrimmedFile(path: string): Promise<string | null> {
 // packed-refs lines are `<oid> <ref>`; `#` headers and `^` peel lines skipped.
 async function readPackedRefs(commonDirPath: string): Promise<Map<string, string>> {
   const refs = new Map<string, string>()
-  const content = await readTrimmedFile(join(commonDirPath, 'packed-refs'))
+  const content = await readTrimmedFile(join(commonDirPath, 'packed-refs'), MAX_PACKED_REFS_BYTES)
   if (content === null) {
     return refs
   }
-  for (const line of content.split('\n')) {
+  let retainedBytes = 0
+  for (let start = 0; start <= content.length; ) {
+    const newline = content.indexOf('\n', start)
+    const end = newline === -1 ? content.length : newline
+    if (end - start > MAX_GIT_HEAD_METADATA_BYTES) {
+      return new Map()
+    }
+    const line = content.slice(start, end)
     if (!line || line.startsWith('#') || line.startsWith('^')) {
-      continue
+      // Headers and peeled-object lines never resolve a branch head.
+    } else {
+      const separator = line.indexOf(' ')
+      if (separator > 0) {
+        const ref = line.slice(separator + 1).trim()
+        const oid = line.slice(0, separator)
+        retainedBytes += (ref.length + oid.length) * 2
+        if (
+          refs.size >= MAX_PACKED_REFS_ENTRIES ||
+          retainedBytes > MAX_PACKED_REFS_RETAINED_BYTES
+        ) {
+          return new Map()
+        }
+        refs.set(ref, oid)
+      }
     }
-    const separator = line.indexOf(' ')
-    if (separator <= 0) {
-      continue
+    if (newline === -1) {
+      break
     }
-    refs.set(line.slice(separator + 1).trim(), line.slice(0, separator))
+    start = newline + 1
   }
   return refs
 }
@@ -113,6 +143,16 @@ export async function readGitCommonHeadIdentities(
     (packedRefsPromise ??= readPackedRefs(commonDirPath))
 
   const identities: WorktreeHeadIdentity[] = []
+  let retainedIdentityBytes = 0
+  const retainIdentity = (identity: WorktreeHeadIdentity): boolean => {
+    retainedIdentityBytes +=
+      (identity.worktreePath.length + (identity.branch?.length ?? 0) + identity.head.length) * 2
+    if (retainedIdentityBytes > MAX_IDENTITY_RETAINED_BYTES) {
+      return false
+    }
+    identities.push(identity)
+    return true
+  }
   // Only the standard `<checkout>/.git` layout maps a common dir back to its
   // primary checkout path; bare/custom GIT_DIR layouts have no primary row.
   if (basename(commonDirPath) === '.git') {
@@ -122,40 +162,51 @@ export async function readGitCommonHeadIdentities(
       dirname(commonDirPath),
       packedRefs
     )
-    if (primary) {
-      identities.push(primary)
+    if (primary && !retainIdentity(primary)) {
+      return []
     }
   }
 
-  let entries
+  let directory: Awaited<ReturnType<typeof opendir>>
   try {
-    entries = await readdir(join(commonDirPath, 'worktrees'), { withFileTypes: true })
+    directory = await opendir(join(commonDirPath, 'worktrees'))
   } catch {
     return identities
   }
-  for (const entry of entries) {
-    if (!entry.isDirectory()) {
-      continue
+  let entriesSeen = 0
+  try {
+    for await (const entry of directory) {
+      entriesSeen += 1
+      if (entriesSeen > MAX_LINKED_WORKTREE_ENTRIES) {
+        return []
+      }
+      if (!entry.isDirectory()) {
+        continue
+      }
+      const entryPath = join(commonDirPath, 'worktrees', entry.name)
+      const gitdirContent = await readTrimmedFile(join(entryPath, 'gitdir'))
+      if (!gitdirContent) {
+        continue
+      }
+      // `gitdir` holds `<worktree>/.git`, absolute or (with relative-path
+      // worktrees) relative to the entry dir.
+      const gitdirAbsolute = isAbsolute(gitdirContent)
+        ? gitdirContent
+        : join(entryPath, gitdirContent)
+      const identity = await readHeadIdentity(
+        commonDirPath,
+        join(entryPath, 'HEAD'),
+        dirname(gitdirAbsolute),
+        packedRefs
+      )
+      if (identity && !retainIdentity(identity)) {
+        return []
+      }
     }
-    const entryPath = join(commonDirPath, 'worktrees', entry.name)
-    const gitdirContent = await readTrimmedFile(join(entryPath, 'gitdir'))
-    if (!gitdirContent) {
-      continue
-    }
-    // `gitdir` holds `<worktree>/.git`, absolute or (with relative-path
-    // worktrees) relative to the entry dir.
-    const gitdirAbsolute = isAbsolute(gitdirContent)
-      ? gitdirContent
-      : join(entryPath, gitdirContent)
-    const identity = await readHeadIdentity(
-      commonDirPath,
-      join(entryPath, 'HEAD'),
-      dirname(gitdirAbsolute),
-      packedRefs
-    )
-    if (identity) {
-      identities.push(identity)
-    }
+  } catch {
+    return identities
+  } finally {
+    await directory.close().catch(() => undefined)
   }
   return identities
 }

--- a/src/main/ipc/worktree-polling-scan-budget.test.ts
+++ b/src/main/ipc/worktree-polling-scan-budget.test.ts
@@ -1,0 +1,287 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import { startWorktreeBaseDirectoryPoller } from './worktree-base-directory-poller'
+import {
+  WorktreePollingScanBudget,
+  type WorktreePollingCapacityError
+} from './worktree-polling-scan-budget'
+
+describe('worktree polling scan budget', () => {
+  const cleanupPaths: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanupPaths.splice(0).map((path) => rm(path, { recursive: true, force: true }))
+    )
+  })
+
+  async function createRoot(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'orca-worktree-poll-bounds-'))
+    cleanupPaths.push(root)
+    return root
+  }
+
+  function makeTarget(kind: 'base' | 'git-common', path: string): WorktreeBaseWatchTarget {
+    return {
+      key: `${kind}:local:${path}`,
+      kind,
+      path,
+      repos: new Map([
+        [
+          'repo-1',
+          {
+            repoId: 'repo-1',
+            repoName: 'project',
+            nestWorkspaces: false
+          }
+        ]
+      ])
+    }
+  }
+
+  it('accepts exact entry, path-count, and path-byte limits', () => {
+    const budget = new WorktreePollingScanBudget({
+      maxScannedEntries: 2,
+      maxRetainedPaths: 2,
+      maxRetainedPathBytes: 6
+    })
+
+    budget.claimEntry()
+    budget.claimEntry()
+    budget.claimRetainedPath('one')
+    expect(() => budget.claimRetainedPath('two')).not.toThrow()
+  })
+
+  it('rejects the first scanned entry over the limit', () => {
+    const budget = new WorktreePollingScanBudget({ maxScannedEntries: 1 })
+    budget.claimEntry()
+
+    expect(() => budget.claimEntry()).toThrow(
+      expect.objectContaining<Partial<WorktreePollingCapacityError>>({
+        resource: 'scanned entries',
+        observed: 2,
+        limit: 1
+      })
+    )
+  })
+
+  it('rejects the first retained path byte over the limit', () => {
+    const budget = new WorktreePollingScanBudget({
+      maxRetainedPaths: 2,
+      maxRetainedPathBytes: 5
+    })
+    budget.claimRetainedPath('one')
+
+    expect(() => budget.claimRetainedPath('two')).toThrow(
+      expect.objectContaining<Partial<WorktreePollingCapacityError>>({
+        resource: 'retained path bytes',
+        observed: 6,
+        limit: 5
+      })
+    )
+  })
+
+  it('accepts the exact retained repo budget and rejects one byte less', () => {
+    const exact = new WorktreePollingScanBudget({
+      maxRepoConfigs: 1,
+      maxRetainedRepoBytes: 130
+    })
+    expect(() => exact.claimRepoConfig('a', 'b')).not.toThrow()
+
+    const overflow = new WorktreePollingScanBudget({
+      maxRepoConfigs: 1,
+      maxRetainedRepoBytes: 129
+    })
+    expect(() => overflow.claimRepoConfig('a', 'b')).toThrow(
+      expect.objectContaining<Partial<WorktreePollingCapacityError>>({
+        resource: 'retained repo bytes',
+        observed: 130,
+        limit: 129
+      })
+    )
+  })
+
+  it('rejects the first repo config over the count limit', () => {
+    const budget = new WorktreePollingScanBudget({ maxRepoConfigs: 1 })
+    budget.claimRepoConfig('repo-1', 'one')
+
+    expect(() => budget.claimRepoConfig('repo-2', 'two')).toThrow(
+      expect.objectContaining<Partial<WorktreePollingCapacityError>>({
+        resource: 'repo configs',
+        observed: 2,
+        limit: 1
+      })
+    )
+  })
+
+  it('starts a base poller at the exact directory-entry limit', async () => {
+    const root = await createRoot()
+    await Promise.all([mkdir(join(root, 'one')), mkdir(join(root, 'two'))])
+    const target = makeTarget('base', root)
+
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      () => {},
+      {
+        scanLimits: {
+          maxScannedEntries: 2,
+          maxRetainedPaths: 3
+        }
+      }
+    )
+
+    await poller.unsubscribe()
+  })
+
+  it('rejects a base snapshot on the first directory entry over the limit', async () => {
+    const root = await createRoot()
+    await Promise.all([
+      mkdir(join(root, 'one')),
+      mkdir(join(root, 'two')),
+      mkdir(join(root, 'three'))
+    ])
+    const target = makeTarget('base', root)
+
+    await expect(
+      startWorktreeBaseDirectoryPoller(
+        target,
+        () => target.repos,
+        () => {},
+        {
+          scanLimits: { maxScannedEntries: 2 }
+        }
+      )
+    ).rejects.toMatchObject({ resource: 'scanned entries', observed: 3, limit: 2 })
+  })
+
+  it('keeps the last complete snapshot while over capacity and resumes afterward', async () => {
+    const root = await createRoot()
+    const knownWorktree = join(root, 'known')
+    await mkdir(knownWorktree)
+    await writeFile(join(knownWorktree, '.git'), 'gitdir: elsewhere')
+    const target = makeTarget('base', root)
+    const events: { type: string; path: string }[] = []
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (nextEvents) => events.push(...nextEvents),
+      {
+        pollIntervalMs: 100,
+        scanLimits: { maxScannedEntries: 2 }
+      }
+    )
+
+    try {
+      await Promise.all([
+        mkdir(join(root, 'overflow-a')),
+        mkdir(join(root, 'overflow-b')),
+        mkdir(join(root, 'overflow-c'))
+      ])
+      await rm(knownWorktree, { recursive: true })
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      expect(events).toEqual([])
+
+      await Promise.all([
+        rm(join(root, 'overflow-b'), { recursive: true }),
+        rm(join(root, 'overflow-c'), { recursive: true })
+      ])
+      await vi.waitFor(
+        () => {
+          expect(events).toContainEqual({ type: 'delete', path: knownWorktree })
+        },
+        { timeout: 2_000 }
+      )
+    } finally {
+      await poller.unsubscribe()
+    }
+  })
+
+  it('pauses snapshots for excess repo configs and resumes when they are removed', async () => {
+    const root = await createRoot()
+    const knownWorktree = join(root, 'known')
+    await mkdir(knownWorktree)
+    await writeFile(join(knownWorktree, '.git'), 'gitdir: elsewhere')
+    const target = makeTarget('base', root)
+    const events: { type: string; path: string }[] = []
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (nextEvents) => events.push(...nextEvents),
+      {
+        pollIntervalMs: 100,
+        scanLimits: { maxRepoConfigs: 1 }
+      }
+    )
+
+    try {
+      target.repos.set('repo-2', {
+        repoId: 'repo-2',
+        repoName: 'second',
+        nestWorkspaces: false
+      })
+      await rm(knownWorktree, { recursive: true })
+      await new Promise((resolve) => setTimeout(resolve, 250))
+      expect(events).toEqual([])
+
+      target.repos.delete('repo-2')
+      await vi.waitFor(
+        () => {
+          expect(events).toContainEqual({ type: 'delete', path: knownWorktree })
+        },
+        { timeout: 2_000 }
+      )
+    } finally {
+      await poller.unsubscribe()
+    }
+  })
+
+  it('starts git-common polling at the exact linked-worktree limit', async () => {
+    const root = await createRoot()
+    await Promise.all([
+      mkdir(join(root, 'worktrees', 'one'), { recursive: true }),
+      mkdir(join(root, 'worktrees', 'two'), { recursive: true })
+    ])
+    const target = makeTarget('git-common', root)
+
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      () => {},
+      {
+        platform: 'linux',
+        scanLimits: {
+          maxScannedEntries: 2,
+          maxRetainedPaths: 2
+        }
+      }
+    )
+
+    await poller.unsubscribe()
+  })
+
+  it('rejects git-common polling on the first linked worktree over the limit', async () => {
+    const root = await createRoot()
+    await Promise.all([
+      mkdir(join(root, 'worktrees', 'one'), { recursive: true }),
+      mkdir(join(root, 'worktrees', 'two'), { recursive: true }),
+      mkdir(join(root, 'worktrees', 'three'), { recursive: true })
+    ])
+    const target = makeTarget('git-common', root)
+
+    await expect(
+      startWorktreeBaseDirectoryPoller(
+        target,
+        () => target.repos,
+        () => {},
+        {
+          platform: 'linux',
+          scanLimits: { maxScannedEntries: 2 }
+        }
+      )
+    ).rejects.toMatchObject({ resource: 'scanned entries', observed: 3, limit: 2 })
+  })
+})

--- a/src/main/ipc/worktree-polling-scan-budget.ts
+++ b/src/main/ipc/worktree-polling-scan-budget.ts
@@ -1,0 +1,128 @@
+export const WORKTREE_POLLING_MAX_SCANNED_ENTRIES = 100_000
+export const WORKTREE_POLLING_MAX_RETAINED_PATHS = 16_384
+export const WORKTREE_POLLING_MAX_RETAINED_PATH_BYTES = 16 * 1024 * 1024
+export const WORKTREE_POLLING_MAX_REPO_CONFIGS = 4_096
+export const WORKTREE_POLLING_MAX_RETAINED_REPO_BYTES = 4 * 1024 * 1024
+
+export type WorktreePollingScanLimits = {
+  maxScannedEntries: number
+  maxRetainedPaths: number
+  maxRetainedPathBytes: number
+  maxRepoConfigs: number
+  maxRetainedRepoBytes: number
+}
+
+export class WorktreePollingCapacityError extends Error {
+  constructor(
+    readonly resource:
+      | 'scanned entries'
+      | 'retained paths'
+      | 'retained path bytes'
+      | 'repo configs'
+      | 'retained repo bytes',
+    readonly observed: number,
+    readonly limit: number
+  ) {
+    super(`Worktree polling exceeded ${limit} ${resource} (observed ${observed})`)
+    this.name = 'WorktreePollingCapacityError'
+  }
+}
+
+function resolveLimit(requested: number | undefined, maximum: number, name: string): number {
+  if (requested === undefined) {
+    return maximum
+  }
+  if (!Number.isSafeInteger(requested) || requested < 0) {
+    throw new RangeError(`${name} must be a non-negative safe integer`)
+  }
+  return Math.min(requested, maximum)
+}
+
+export class WorktreePollingScanBudget {
+  private scannedEntries = 0
+  private retainedPaths = 0
+  private retainedPathBytes = 0
+  private repoConfigs = 0
+  private retainedRepoBytes = 0
+  private readonly limits: WorktreePollingScanLimits
+
+  constructor(requested: Partial<WorktreePollingScanLimits> = {}) {
+    this.limits = {
+      maxScannedEntries: resolveLimit(
+        requested.maxScannedEntries,
+        WORKTREE_POLLING_MAX_SCANNED_ENTRIES,
+        'maxScannedEntries'
+      ),
+      maxRetainedPaths: resolveLimit(
+        requested.maxRetainedPaths,
+        WORKTREE_POLLING_MAX_RETAINED_PATHS,
+        'maxRetainedPaths'
+      ),
+      maxRetainedPathBytes: resolveLimit(
+        requested.maxRetainedPathBytes,
+        WORKTREE_POLLING_MAX_RETAINED_PATH_BYTES,
+        'maxRetainedPathBytes'
+      ),
+      maxRepoConfigs: resolveLimit(
+        requested.maxRepoConfigs,
+        WORKTREE_POLLING_MAX_REPO_CONFIGS,
+        'maxRepoConfigs'
+      ),
+      maxRetainedRepoBytes: resolveLimit(
+        requested.maxRetainedRepoBytes,
+        WORKTREE_POLLING_MAX_RETAINED_REPO_BYTES,
+        'maxRetainedRepoBytes'
+      )
+    }
+  }
+
+  claimEntry(): void {
+    this.scannedEntries += 1
+    if (this.scannedEntries > this.limits.maxScannedEntries) {
+      throw new WorktreePollingCapacityError(
+        'scanned entries',
+        this.scannedEntries,
+        this.limits.maxScannedEntries
+      )
+    }
+  }
+
+  claimRetainedPath(path: string): void {
+    this.retainedPaths += 1
+    if (this.retainedPaths > this.limits.maxRetainedPaths) {
+      throw new WorktreePollingCapacityError(
+        'retained paths',
+        this.retainedPaths,
+        this.limits.maxRetainedPaths
+      )
+    }
+    this.retainedPathBytes += Buffer.byteLength(path, 'utf8')
+    if (this.retainedPathBytes > this.limits.maxRetainedPathBytes) {
+      throw new WorktreePollingCapacityError(
+        'retained path bytes',
+        this.retainedPathBytes,
+        this.limits.maxRetainedPathBytes
+      )
+    }
+  }
+
+  claimRepoConfig(repoId: string, repoName: string): void {
+    this.repoConfigs += 1
+    if (this.repoConfigs > this.limits.maxRepoConfigs) {
+      throw new WorktreePollingCapacityError(
+        'repo configs',
+        this.repoConfigs,
+        this.limits.maxRepoConfigs
+      )
+    }
+    this.retainedRepoBytes +=
+      Buffer.byteLength(repoId, 'utf8') + Buffer.byteLength(repoName, 'utf8') + 128
+    if (this.retainedRepoBytes > this.limits.maxRetainedRepoBytes) {
+      throw new WorktreePollingCapacityError(
+        'retained repo bytes',
+        this.retainedRepoBytes,
+        this.limits.maxRetainedRepoBytes
+      )
+    }
+  }
+}

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -57,7 +57,9 @@ import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import type { SshGitProvider } from '../providers/ssh-git-provider'
 import { TUI_AGENT_CONFIG, isTuiAgent } from '../../shared/tui-agent-config'
 import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
+import { MAX_ORCA_YAML_BYTES, MAX_ORCA_YAML_CODE_UNITS } from '../../shared/orca-yaml-file-limit'
 import { getSshGitUsername } from '../git/git-username'
+import { readFilesystemProviderBoundedText } from '../filesystem-provider-bounded-text'
 import { runWorktreeChangeInvalidators } from './worktree-change-invalidators'
 import {
   registerOptionalSshWorktreeCreateRoots,
@@ -1186,8 +1188,12 @@ async function readRemoteOrcaYaml(
   hooksRootPath: string
 ): Promise<ReturnType<typeof parseOrcaYaml>> {
   try {
-    const result = await fsProvider.readFile(joinWorktreeRelativePath(hooksRootPath, 'orca.yaml'))
-    return result.isBinary ? null : parseOrcaYaml(result.content)
+    const result = await readFilesystemProviderBoundedText(
+      fsProvider,
+      joinWorktreeRelativePath(hooksRootPath, 'orca.yaml'),
+      { maxBytes: MAX_ORCA_YAML_BYTES, maxCodeUnits: MAX_ORCA_YAML_CODE_UNITS }
+    )
+    return result.kind === 'text' ? parseOrcaYaml(result.content) : null
   } catch {
     return null
   }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -8,6 +8,8 @@ import type { CreateWorktreeResult, GitWorktreeInfo, Worktree } from '../../shar
 import * as localWorktreeFilesystem from '../local-worktree-filesystem'
 
 const ORIGINAL_PLATFORM = process.platform
+const TEST_MAX_HOOK_GITIGNORE_BYTES = 4 * 1024 * 1024
+const TEST_MAX_ISSUE_COMMAND_BYTES = 1024 * 1024
 const removeWorktreeLinkedPathsMock = vi.hoisted(() => vi.fn())
 const findExistingWorktreeSymlinkPathsMock = vi.hoisted(() => vi.fn())
 
@@ -193,6 +195,8 @@ vi.mock('../hooks', () => ({
   getEffectiveHooksFromConfig: getEffectiveHooksFromConfigMock,
   getDefaultTabsLaunch: getDefaultTabsLaunchMock,
   getSetupRunnerEnvVars: getSetupRunnerEnvVarsMock,
+  MAX_HOOK_GITIGNORE_BYTES: 4 * 1024 * 1024,
+  MAX_ISSUE_COMMAND_BYTES: 1024 * 1024,
   loadHooks: loadHooksMock,
   parseOrcaYaml: parseOrcaYamlMock,
   runHook: runHookMock,
@@ -3697,6 +3701,12 @@ describe('registerWorktreeHandlers', () => {
       ])
     }
     const fsProvider = {
+      stat: vi.fn(async (filePath: string) => {
+        if (filePath.endsWith('orca.yaml')) {
+          return { size: 32, type: 'file', mtime: 0 }
+        }
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  setup: pnpm install\n',
         isBinary: false
@@ -7086,6 +7096,7 @@ describe('registerWorktreeHandlers', () => {
       })
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 36, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  archive: echo archived\n',
         isBinary: false
@@ -7163,6 +7174,7 @@ describe('registerWorktreeHandlers', () => {
       })
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 36, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  archive: echo archived\n',
         isBinary: false
@@ -7222,6 +7234,7 @@ describe('registerWorktreeHandlers', () => {
       })
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 36, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  archive: echo archived\n',
         isBinary: false
@@ -7280,6 +7293,7 @@ describe('registerWorktreeHandlers', () => {
       })
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 30, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  archive: exit 7\n',
         isBinary: false
@@ -7338,6 +7352,7 @@ describe('registerWorktreeHandlers', () => {
       execNonInteractive: vi.fn().mockRejectedValue(new Error('relay disconnected'))
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 36, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  archive: echo archived\n',
         isBinary: false
@@ -7400,6 +7415,7 @@ describe('registerWorktreeHandlers', () => {
       })
     }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 36, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  archive: echo archived\n',
         isBinary: false
@@ -7560,6 +7576,7 @@ describe('registerWorktreeHandlers', () => {
     }
     const sshRepo = { ...localRepo, path: '/remote/repo', connectionId: 'conn-1' }
     const fsProvider = {
+      stat: vi.fn().mockResolvedValue({ size: 35, type: 'file', mtime: 0 }),
       readFile: vi.fn().mockResolvedValue({
         content: 'scripts:\n  archive: remote-cleanup',
         isBinary: false
@@ -8689,6 +8706,12 @@ describe('registerWorktreeHandlers', () => {
       worktreeBaseRef: null
     }
     const fsProvider = {
+      stat: vi.fn(async (filePath: string) => {
+        if (filePath.endsWith('/.orca/issue-command')) {
+          return { size: 14, type: 'file', mtime: 0 }
+        }
+        throw new Error('shared read failed')
+      }),
       readFile: vi.fn(async (filePath: string) => {
         if (filePath.endsWith('/.orca/issue-command')) {
           return { content: 'local command\n', isBinary: false }
@@ -8712,6 +8735,46 @@ describe('registerWorktreeHandlers', () => {
     })
   })
 
+  it('admits an exact-size SSH issue command and rejects +1 before reading', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: null
+    }
+    let issueCommandSize = TEST_MAX_ISSUE_COMMAND_BYTES
+    const exactContent = 'x'.repeat(TEST_MAX_ISSUE_COMMAND_BYTES)
+    const fsProvider = {
+      stat: vi.fn(async (filePath: string) => {
+        if (filePath.endsWith('/.orca/issue-command')) {
+          return { size: issueCommandSize, type: 'file', mtime: 0 }
+        }
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      }),
+      readFile: vi.fn().mockResolvedValue({ content: exactContent, isBinary: false })
+    }
+    store.getRepo.mockReturnValue(repo)
+    getSshFilesystemProviderMock.mockReturnValue(fsProvider)
+
+    const exactResult = (await handlers['hooks:readIssueCommand'](null, {
+      repoId: 'repo-ssh'
+    })) as { localContent: string | null }
+    expect(exactResult.localContent).toHaveLength(TEST_MAX_ISSUE_COMMAND_BYTES)
+    expect(fsProvider.readFile).toHaveBeenCalledOnce()
+
+    issueCommandSize += 1
+    fsProvider.readFile.mockClear()
+    await expect(
+      handlers['hooks:readIssueCommand'](null, {
+        repoId: 'repo-ssh'
+      })
+    ).resolves.toMatchObject({ localContent: null, effectiveContent: null, source: 'none' })
+    expect(fsProvider.readFile).not.toHaveBeenCalled()
+  })
+
   it('writes SSH issue-command overrides without clobbering .gitignore on read failure', async () => {
     const repo = {
       id: 'repo-ssh',
@@ -8724,6 +8787,7 @@ describe('registerWorktreeHandlers', () => {
     }
     const fsProvider = {
       createDir: vi.fn().mockResolvedValue(undefined),
+      stat: vi.fn().mockRejectedValue(new Error('ssh read failed')),
       readFile: vi.fn().mockRejectedValue(new Error('ssh read failed')),
       writeFile: vi.fn().mockResolvedValue(undefined),
       deletePath: vi.fn().mockResolvedValue(undefined)
@@ -8756,6 +8820,12 @@ describe('registerWorktreeHandlers', () => {
       connectionId: 'conn-1'
     }
     const fsProvider = {
+      stat: vi.fn(async (filePath: string) => {
+        if (filePath.endsWith('/.orca/issue-command')) {
+          return { size: 15, type: 'file', mtime: 0 }
+        }
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      }),
       readFile: vi.fn(async (filePath: string) => {
         if (filePath.endsWith('/.orca/issue-command')) {
           return { content: 'remote command\n', isBinary: false }
@@ -8793,6 +8863,7 @@ describe('registerWorktreeHandlers', () => {
     const enoent = Object.assign(new Error('missing'), { code: 'ENOENT' })
     const fsProvider = {
       createDir: vi.fn().mockResolvedValue(undefined),
+      stat: vi.fn().mockRejectedValue(enoent),
       readFile: vi.fn().mockRejectedValue(enoent),
       writeFile: vi.fn().mockResolvedValue(undefined),
       deletePath: vi.fn().mockResolvedValue(undefined)
@@ -8811,6 +8882,56 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo/.orca/issue-command',
       'orca issue command\n'
     )
+  })
+
+  it('admits an exact-size SSH .gitignore and rejects +1 before reading', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: null
+    }
+    let gitignoreSize = TEST_MAX_HOOK_GITIGNORE_BYTES
+    const exactContent = 'x'.repeat(TEST_MAX_HOOK_GITIGNORE_BYTES)
+    const fsProvider = {
+      createDir: vi.fn().mockResolvedValue(undefined),
+      stat: vi.fn().mockImplementation(async () => ({
+        size: gitignoreSize,
+        type: 'file',
+        mtime: 0
+      })),
+      readFile: vi.fn().mockResolvedValue({ content: exactContent, isBinary: false }),
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      deletePath: vi.fn().mockResolvedValue(undefined)
+    }
+    store.getRepo.mockReturnValue(repo)
+    getSshFilesystemProviderMock.mockReturnValue(fsProvider)
+
+    await handlers['hooks:writeIssueCommand'](null, {
+      repoId: 'repo-ssh',
+      content: 'orca issue command'
+    })
+    const gitignoreWrite = fsProvider.writeFile.mock.calls.find(([filePath]) =>
+      filePath.endsWith('/.gitignore')
+    )
+    expect(gitignoreWrite?.[1]).toHaveLength(TEST_MAX_HOOK_GITIGNORE_BYTES + 7)
+    expect(gitignoreWrite?.[1]).toMatch(/\n\.orca\n$/)
+    expect(fsProvider.readFile).toHaveBeenCalledOnce()
+
+    gitignoreSize += 1
+    fsProvider.readFile.mockClear()
+    fsProvider.writeFile.mockClear()
+    await expect(
+      handlers['hooks:writeIssueCommand'](null, {
+        repoId: 'repo-ssh',
+        content: 'orca issue command'
+      })
+    ).rejects.toThrow('Remote .gitignore exceeds the supported size limit')
+    expect(fsProvider.readFile).not.toHaveBeenCalled()
+    expect(fsProvider.writeFile).not.toHaveBeenCalled()
   })
 
   it('rejects SSH issue-command writes when the remote filesystem provider is unavailable', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1,7 +1,7 @@
 /* oxlint-disable max-lines */
 import type { BrowserWindow } from 'electron'
 import { ipcMain } from 'electron'
-import { readFile, stat } from 'node:fs/promises'
+import { stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
 import { isFolderRepo } from '../../shared/repo-kind'
@@ -12,6 +12,7 @@ import {
   worktreeWorkspaceKey
 } from '../../shared/workspace-scope'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
+import { MAX_ORCA_YAML_BYTES, MAX_ORCA_YAML_CODE_UNITS } from '../../shared/orca-yaml-file-limit'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-projection'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
 import { deleteWorktreeHistoryDir } from '../terminal-history'
@@ -60,6 +61,8 @@ import {
   getEffectiveHooks,
   getEffectiveHooksFromConfig,
   getSetupRunnerEnvVars,
+  MAX_HOOK_GITIGNORE_BYTES,
+  MAX_ISSUE_COMMAND_BYTES,
   loadHooks,
   parseOrcaYaml,
   readIssueCommand,
@@ -104,6 +107,12 @@ import {
   resolveAutomationWorkspaceProvenance
 } from '../automations/workspace-provenance'
 import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
+import { readFilesystemProviderBoundedText } from '../filesystem-provider-bounded-text'
+import {
+  readSetupScriptImportFile,
+  SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES,
+  SETUP_SCRIPT_IMPORT_MAX_CODE_UNITS
+} from '../setup-script-import-file'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -349,8 +358,12 @@ async function getArchiveHooksForRemoval(repo: Repo): Promise<OrcaHooks | null> 
   }
 
   try {
-    const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, 'orca.yaml'))
-    const yamlHooks = result.isBinary ? null : parseOrcaYaml(result.content)
+    const result = await readFilesystemProviderBoundedText(
+      fsProvider,
+      joinWorktreeRelativePath(repo.path, 'orca.yaml'),
+      { maxBytes: MAX_ORCA_YAML_BYTES, maxCodeUnits: MAX_ORCA_YAML_CODE_UNITS }
+    )
+    const yamlHooks = result.kind === 'text' ? parseOrcaYaml(result.content) : null
     return getEffectiveHooksFromConfig(repo, yamlHooks)
   } catch {
     return getEffectiveHooksFromConfig(repo, null)
@@ -2107,11 +2120,15 @@ export function registerWorktreeHandlers(
           return { status: 'error', hasHooks: false, hooks: null, mayNeedUpdate: false }
         }
         try {
-          const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, 'orca.yaml'))
+          const result = await readFilesystemProviderBoundedText(
+            fsProvider,
+            joinWorktreeRelativePath(repo.path, 'orca.yaml'),
+            { maxBytes: MAX_ORCA_YAML_BYTES, maxCodeUnits: MAX_ORCA_YAML_CODE_UNITS }
+          )
           return {
             status: 'ok',
-            hasHooks: !result.isBinary,
-            hooks: result.isBinary ? null : parseOrcaYaml(result.content),
+            hasHooks: result.kind !== 'binary',
+            hooks: result.kind === 'text' ? parseOrcaYaml(result.content) : null,
             mayNeedUpdate: false
           }
         } catch (error) {
@@ -2169,15 +2186,18 @@ export function registerWorktreeHandlers(
             return null
           }
           try {
-            const result = await fsProvider.readFile(filePath)
-            return result.isBinary ? null : result.content
+            const result = await readFilesystemProviderBoundedText(fsProvider, filePath, {
+              maxBytes: SETUP_SCRIPT_IMPORT_FILE_MAX_BYTES,
+              maxCodeUnits: SETUP_SCRIPT_IMPORT_MAX_CODE_UNITS
+            })
+            return result.kind === 'text' ? result.content : null
           } catch {
             return null
           }
         }
 
         try {
-          return await readFile(filePath, 'utf-8')
+          return await readSetupScriptImportFile(filePath)
         } catch (error) {
           if (!isENOENT(error)) {
             console.warn('[hooks] Failed to inspect setup script import candidate:', error)
@@ -2247,18 +2267,26 @@ export function registerWorktreeHandlers(
         let localContent: string | null = null
         let sharedContent: string | null = null
         try {
-          const result = await fsProvider.readFile(issueCommandPath)
-          localContent = result.isBinary ? null : result.content.trim() || null
+          const result = await readFilesystemProviderBoundedText(fsProvider, issueCommandPath, {
+            maxBytes: MAX_ISSUE_COMMAND_BYTES,
+            maxCodeUnits: MAX_ISSUE_COMMAND_BYTES
+          })
+          localContent = result.kind === 'text' ? result.content.trim() || null : null
         } catch (error) {
           if (!isENOENT(error)) {
             status = 'error'
           }
         }
         try {
-          const result = await fsProvider.readFile(joinWorktreeRelativePath(repo.path, 'orca.yaml'))
-          sharedContent = result.isBinary
-            ? null
-            : parseOrcaYaml(result.content)?.issueCommand?.trim() || null
+          const result = await readFilesystemProviderBoundedText(
+            fsProvider,
+            joinWorktreeRelativePath(repo.path, 'orca.yaml'),
+            { maxBytes: MAX_ORCA_YAML_BYTES, maxCodeUnits: MAX_ORCA_YAML_CODE_UNITS }
+          )
+          sharedContent =
+            result.kind === 'text'
+              ? parseOrcaYaml(result.content)?.issueCommand?.trim() || null
+              : null
         } catch (error) {
           if (!isENOENT(error)) {
             status = 'error'
@@ -2309,8 +2337,14 @@ export function registerWorktreeHandlers(
         await fsProvider.createDir(joinWorktreeRelativePath(repo.path, '.orca'))
         const gitignorePath = joinWorktreeRelativePath(repo.path, '.gitignore')
         try {
-          const result = await fsProvider.readFile(gitignorePath)
-          if (!result.isBinary && !/^\.orca\/?$/m.test(result.content)) {
+          const result = await readFilesystemProviderBoundedText(fsProvider, gitignorePath, {
+            maxBytes: MAX_HOOK_GITIGNORE_BYTES,
+            maxCodeUnits: MAX_HOOK_GITIGNORE_BYTES
+          })
+          if (result.kind === 'oversized') {
+            throw new Error('Remote .gitignore exceeds the supported size limit')
+          }
+          if (result.kind === 'text' && !/^\.orca\/?$/m.test(result.content)) {
             const separator = result.content.endsWith('\n') ? '' : '\n'
             await fsProvider.writeFile(gitignorePath, `${result.content}${separator}.orca\n`)
           }

--- a/src/main/ipc/wsl-watcher-snapshot.test.ts
+++ b/src/main/ipc/wsl-watcher-snapshot.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_WSL_SNAPSHOT_RETAINED_ENTRIES, parseWslSnapshotFrame } from './wsl-watcher-snapshot'
+
+describe('parseWslSnapshotFrame', () => {
+  it('rejects a snapshot with more retained paths than the entry budget', () => {
+    const records = Array.from(
+      { length: MAX_WSL_SNAPSHOT_RETAINED_ENTRIES + 1 },
+      (_, index) => `f\t1\t/repo/file-${index}\0`
+    ).join('')
+
+    expect(parseWslSnapshotFrame(records, 'Ubuntu')).toBeNull()
+  })
+
+  it('does not charge duplicate path updates as distinct retained entries', () => {
+    const records = Array.from(
+      { length: MAX_WSL_SNAPSHOT_RETAINED_ENTRIES + 1 },
+      (_, index) => `f\t${index}\t/repo/same\0`
+    ).join('')
+
+    const snapshot = parseWslSnapshotFrame(records, 'Ubuntu')
+    expect(snapshot).not.toBeNull()
+    expect(snapshot?.size).toBe(1)
+    expect(snapshot?.get('\\\\wsl.localhost\\Ubuntu\\repo\\same')?.mtime).toBe(
+      String(MAX_WSL_SNAPSHOT_RETAINED_ENTRIES)
+    )
+  })
+})

--- a/src/main/ipc/wsl-watcher-snapshot.ts
+++ b/src/main/ipc/wsl-watcher-snapshot.ts
@@ -1,0 +1,72 @@
+import type { Event as WatcherEvent } from '@parcel/watcher'
+import { iterateNulDelimitedFields } from '../../shared/nul-delimited-fields'
+
+export const MAX_WSL_SNAPSHOT_RETAINED_ENTRIES = 50_000
+
+export type WslSnapshotEntry = {
+  path: string
+  type: string
+  mtime: string
+}
+
+export type WslSnapshot = Map<string, WslSnapshotEntry>
+
+function toWslUncPath(linuxPath: string, distro: string): string {
+  return `\\\\wsl.localhost\\${distro}${linuxPath.replace(/\//g, '\\')}`
+}
+
+export function parseWslSnapshotFrame(frame: string, distro: string): WslSnapshot | null {
+  const snapshot: WslSnapshot = new Map()
+  for (const rawEntry of iterateNulDelimitedFields(frame)) {
+    if (!rawEntry) {
+      continue
+    }
+    const firstTab = rawEntry.indexOf('\t')
+    const secondTab = firstTab === -1 ? -1 : rawEntry.indexOf('\t', firstTab + 1)
+    if (firstTab <= 0 || secondTab <= firstTab + 1) {
+      continue
+    }
+    const linuxPath = rawEntry.slice(secondTab + 1)
+    if (!linuxPath.startsWith('/')) {
+      continue
+    }
+    const path = toWslUncPath(linuxPath, distro)
+    if (!snapshot.has(path) && snapshot.size >= MAX_WSL_SNAPSHOT_RETAINED_ENTRIES) {
+      return null
+    }
+    snapshot.set(path, {
+      type: rawEntry.slice(0, firstTab),
+      mtime: rawEntry.slice(firstTab + 1, secondTab),
+      path
+    })
+  }
+  return snapshot
+}
+
+export function diffWslSnapshots(prev: WslSnapshot, next: WslSnapshot): WatcherEvent[] {
+  const events: WatcherEvent[] = []
+
+  for (const [entryPath, nextEntry] of next) {
+    const prevEntry = prev.get(entryPath)
+    if (!prevEntry) {
+      events.push({ type: 'create', path: entryPath } as WatcherEvent)
+      continue
+    }
+    if (prevEntry.type !== nextEntry.type) {
+      events.push({ type: 'delete', path: entryPath } as WatcherEvent)
+      events.push({ type: 'create', path: entryPath } as WatcherEvent)
+      continue
+    }
+    if (prevEntry.mtime !== nextEntry.mtime) {
+      events.push({ type: 'update', path: entryPath } as WatcherEvent)
+    }
+  }
+
+  for (const entryPath of prev.keys()) {
+    if (!next.has(entryPath)) {
+      events.push({ type: 'delete', path: entryPath } as WatcherEvent)
+    }
+  }
+
+  return events
+}


### PR DESCRIPTION
## OOM hardening slice 22/29 — bound filesystem & worktree IPC enumeration

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **22/29** (base: `oom/21-b-runtime`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Slice B-ipc-fs-worktree re-introduces explicit ceilings across main-process filesystem/worktree IPC: it converts unbounded readdir/readFile/string-buffer accumulation into bounded opendir streaming, capped subprocess path accumulators, admission-limited watchers, and budgeted worktree pollers, each with a hard count/byte/depth/concurrency cap plus a regression test.

### ELI5
Imagine Orca has a bunch of doors that used to let in unlimited people — listing every file in a folder, remembering every path a search prints, watching every folder at once. If a folder or repo was gigantic, the app would try to hold all of it in memory and crash. This change puts a bouncer at each door with a clear limit ("no more than X files", "no path longer than Y", "only 8 folders checked at once"). For normal-sized projects nobody notices the bouncer. But a few limits are set low enough that ordinary-but-large cases hit them: a very large repo's Quick Open only shows the first 20,001 files, and a big high-resolution photo (like a 36-megapixel image) refuses to preview.

### Proof of OOM fix
- External import (drag-drop / SSH import / runtime upload) — filesystem-external-import-limits.ts: MAX_SOURCE_PATHS=256, MAX_SOURCE_PATH_BYTES=256KiB, MAX_TREE_ENTRIES=100,000, MAX_TREE_DEPTH=256, MAX_RELATIVE_PATH_BYTES=64KiB, REMOTE_IMPORT_MAX_RETAINED_PATH_BYTES=16MiB, MAX_FILE_BYTES=25MiB, MAX_TOTAL_BYTES=100MiB; tests: filesystem-external-import-limits.test.ts, filesystem-import.test.ts, filesystem-import-ssh-path-safety.test.ts (streams past 100k entries, asserts iterator closed + no dest created).
- Quick Open listing — shared/quick-open-listing-limits.ts wired via filesystem-list-files.ts + filesystem-list-files-git-fallback.ts: MAX_RESULTS=20,001 (now the default even when caller omits maxResults), MAX_RETAINED_PATHS=100,000, MAX_RETAINED_PATH_BYTES=32MiB, MAX_PATH_BYTES=64KiB; buffer accumulation replaced by QuickOpenSubprocessPathAccumulator; tests: filesystem-list-files.test.ts (bounds omitted limit, kills oversized-path scan, abort kills active pass).
- Filesystem watcher admission — filesystem-watcher-admission.ts: MAX_CLAIMS=1,024 global, MAX_CLAIMS_PER_SENDER=256, MAX_RETAINED_IDENTITY_BYTES=16MiB, MAX_PATH_BYTES=64KiB, MAX_CONNECTION_ID_BYTES=8KiB; tests: filesystem-watcher-admission.test.ts, filesystem-watcher.test.ts (rejects at sender cap, recovers after unwatch, stale release ignored).
- Local watcher event stat fan-out bounded — filesystem-watcher.ts: LOCAL_WATCHER_DIRECTORY_STAT_CONCURRENCY=8 and WATCHER_LISTENER_INSTALL_CONCURRENCY=8 via mapWithConcurrency; test: filesystem-watcher.test.ts (peak concurrency == min(count,8) at and above limit).
- WSL watcher snapshot — filesystem-watcher-wsl.ts + wsl-watcher-snapshot.ts: MAX_WSL_SNAPSHOT_FRAME_BYTES=10MiB, MAX_WSL_SNAPSHOT_RETAINED_ENTRIES=50,000; StringDecoder+string buffer replaced by GrowingByteBuffer; tests: wsl-watcher-snapshot.test.ts (null past 50k, dedupes duplicate paths), filesystem-watcher-wsl.test.ts (100k one-byte fragments).
- Worktree base/git-common polling — worktree-polling-scan-budget.ts: MAX_SCANNED_ENTRIES=100,000, MAX_RETAINED_PATHS=16,384, MAX_RETAINED_PATH_BYTES=16MiB, MAX_REPO_CONFIGS=4,096, MAX_RETAINED_REPO_BYTES=4MiB; readdir→opendir(bufferSize:32) streaming + GIT_COMMON_ENTRY_STAT_CONCURRENCY=16; tests: worktree-polling-scan-budget.test.ts, worktree-base-directory-watch-targets-bounds.test.ts (rejects >4,096 repos before hydrating array).
- Git head-identity reader — worktree-head-identity-reader.ts: MAX_GIT_HEAD_METADATA_BYTES=64KiB, MAX_PACKED_REFS_BYTES=16MiB, MAX_PACKED_REFS_ENTRIES=100,000, MAX_LINKED_WORKTREE_ENTRIES=1,024, MAX_IDENTITY_RETAINED_BYTES=4MiB; readdir→opendir with finally-close; test: worktree-head-identity-reader.test.ts (fails closed on oversized HEAD/packed-refs and >1,024 worktrees).
- Worktree common-git pointer — worktree-common-git-directory.ts: MAX_GIT_DIRECTORY_POINTER_BYTES=64KiB via readNodeFileWithinLimit; test: worktree-common-git-directory.test.ts.
- fs:readFile — filesystem.ts: readFile()→readNodeFileWithinLimit(sizeLimit) for text/log/image, plus assertRasterImagePreviewWithinLimits (MAX_DIMENSION_PX=32,768, MAX_PIXELS=33.5M) from raster-image-preview-limits.ts; readDir uses readLocalFilesystemDirectory bounded to FILESYSTEM_DIRECTORY_MAX_ENTRIES=100,000 / 12MiB; text-search buffers → SearchSubprocessLineAccumulator; tests: filesystem.test.ts (dimension-bomb rejected, partial-read reader), filesystem-directory-reader.test.ts.
- SSH bounded provider reads for orca.yaml/.gitignore/issue-command/setup-import — worktrees.ts + worktree-remote.ts via readFilesystemProviderBoundedText (stat-gated before readFile); test: worktrees.test.ts (exact-size admitted, +1 byte rejected before reading).

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **medium**: WSL file watching now fails closed for large worktrees: a snapshot frame with more than 50,000 distinct paths makes parseWslSnapshotFrame return null, which on the first snapshot settles startup with an error (watcher never starts) and afterward drops to coarse overflow refresh. Previously such a snapshot parsed successfully and delivered granular events. _(trigger: Watching a WSL-hosted worktree whose recursive snapshot contains >50,000 files (large repo on WSL). Under 50,000 entries behavior is unchanged.)_
- **low**: Quick Open's two listing passes (tracked/primary + ignored) changed from PARALLEL to SEQUENTIAL on the default no-maxResults path. BASE ran Promise.all([primary, ignored]) when maxResults was undefined; TARGET's default result limit is now 20,001 (not undefined), so the sequential branch (await primary; if under budget await ignored) is always taken for ordinary repos. For repos under 20,001 files the result SET is identical and complete, but scan latency rises by the serialized primary-pass duration and empty-query result ordering becomes deterministic (primary paths first) instead of the previous race-order interleave. Applies to both the rg path (filesystem-list-files.ts) and the git fallback (filesystem-list-files-git-fallback.ts). _(trigger: Opening Quick Open in any repository (rg available or git fallback). Below 20,001 files this is the normal path; results stay complete, only latency/order shift.)_
- **low**: Quick Open now runs the primary and ignored-file scans serially rather than concurrently when no explicit result limit is supplied. Even below all ceilings, repositories with ignored files wait for primary scan completion before the ignored scan starts, changing inventory latency and insertion/tie ordering from BASE's parallel merge. _(trigger: Open Quick Open in any repository with ignored files while the caller omits maxResults; this is the ordinary desktop IPC path.)_
- **medium**: Quick Open completeness is capped at 20,001 paths when no limit is supplied; later tracked files and the ignored pass are omitted once the primary pass fills the budget. _(trigger: Open Quick Open in a repository with more than 20,001 qualifying primary paths.)_
- **medium**: WSL snapshot watching rejects more than 50,000 distinct retained paths. Initial overflow prevents watcher startup; later overflow emits only a coarse refresh instead of granular events. _(trigger: Watch a WSL worktree whose depth-2 snapshot contains more than 50,000 distinct paths.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- readDir (File Explorer) throws FILESYSTEM_DIRECTORY_LIMIT_MESSAGE only for a single directory with >100,000 entries or >12MiB of retained names.
- External import fails only for >256 top-level source paths, a tree >100,000 entries, depth >256, a single relative path >64KiB, retained paths >16MiB, a file >25MiB, or a batch >100MiB.
- readGitCommonHeadIdentities returns [] (no head freshness) only for repos with >1,024 linked worktrees, packed-refs >16MiB / >100,000 entries, or a single metadata line >64KiB.
- Worktree base/git-common pollers fail to start at boot, or pause+keep-last-snapshot mid-run, only when a watched base/worktrees dir exceeds 100,000 scanned entries or the workspace exceeds 4,096 repo configs.
- Per-sender watcher admission rejects fs:watchWorktree only after 256 distinct simultaneous watches from one renderer (1,024 global).
- Quick Open path scan is killed only when a single emitted path exceeds 64KiB or the retained set exceeds 100,000 paths / 32MiB.
- WSL frame-byte overflow (>10MiB) behavior is unchanged from before (still fails/refreshes); the newly-added 50,000-entry cap is the only genuinely new WSL trigger.
- Quick Open file inventory is now hard-capped at 20,001 results even when the caller passes no limit (previously an unbounded scan merged both the tracked and ignored passes). In a very large monorepo (>20,001 tracked files) Quick Open sees only the first 20,001 paths in git-ls-files/rg order, so some files become unreachable via Quick Open; the ignored-file pass is also skipped once the primary pass alone fills the budget. _(only when: Opening Quick Open in a repository whose tracked file count exceeds ~20,001 (large enterprise/monorepo). Below that, results and completeness are unchanged (only serialized rather than parallel).)_
- fs:readFile now rejects raster image previews whose dimensions exceed 32,768px on an axis OR whose total area exceeds ~33.5 megapixels (MAX_RASTER_IMAGE_PREVIEW_PIXELS), throwing 'Image dimensions exceed the preview safety limit' instead of showing the image. High-resolution photos (e.g. a 6000x6000 / 36MP or 48MP phone image) can no longer be previewed in the editor pane. _(only when: Opening a PNG/JPEG/WebP raster image larger than ~33.5MP (or >32,768px per side) in the editor. PDFs and SVGs are unaffected.)_
- External import (drag-drop and SSH/runtime upload) now rejects a batch of more than 256 top-level source paths with 'External import accepts at most 256 source paths' before touching the filesystem, and fails a directory import if its tree exceeds 100,000 entries or 256 nesting levels. _(only when: Multi-selecting/dropping >256 items at once, or importing a directory tree with >100,000 files or >256 nested levels. Matches the existing native-file-drop cap of 256.)_
- Worktree head-freshness display goes empty (returns []) rather than partial for pathological repos, and background worktree base-directory watchers are skipped entirely when a workspace has more than 4,096 configured repos. _(only when: >1,024 linked worktrees / >16MiB packed-refs, or >4,096 repos in one workspace.)_
- Quick Open (fs:listFiles) is now hard-capped at 20,001 results. The IPC handler at filesystem.ts:1072 always calls listQuickOpenFiles with no maxResults, and resolveQuickOpenResultLimit(undefined) returns QUICK_OPEN_LISTING_MAX_RESULTS=20,001 (src/shared/quick-open-listing-limits.ts). Previously maxResults===undefined ran both the tracked and ignored rg passes in parallel with no cap and returned every path. Now the primary pass runs first and the ignored-file pass is skipped once files.size>=20,001, so in a repo with >20,001 reachable files some paths become unreachable via Quick Open and ignored files may never be listed. Below the cap results are identical (only serialized instead of parallel). Input-gated above a deliberate cap. _(only when: Opening Quick Open in a repo whose reachable (tracked+ignored, non-excluded) file count exceeds ~20,001 - i.e. large enterprise/monorepo. Median-size repos are far below this.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.
- Touches 1 file(s) also changed on `main` since the revert; git auto-merges them (no conflict): `worktree-remote.ts`.

### ✅ Inherited defect FIXED in this slice
- ✅ **FIXED** [medium, overload-path only] `src/main/ipc/filesystem-watcher.ts` — fs:watchWorktree claims admission before installRemoteWatcher; the SSH-provider-unavailable early return skips registerSenderCleanup, so a destroyed WebContents never releases the claim. Repeated SSH reloads during provider unavailability can exhaust the 1,024 global claim cap.
  - **Fix applied:** Hoisted registerSenderCleanup(event.sender) to immediately after the admission claim (before the first await), so the provider-unavailable early return, renderer-destroy-mid-install, and retry all release the claim via releaseSender on WebContents destroy. Verified: typecheck + filesystem-watcher suite pass.

> Defects **inherited from the original #10179 code** (not introduced by slicing; not present in today's unbounded `main`). Fixed items were patched in-slice and re-verified (typecheck + affected suites); remaining flagged items are overload-only and noted for a fast-follow.

### Adversarial review
- 3 skeptic lens(es) incl. a frontier-model (GPT) cross-check. Sign-off: **FLAGGED — see above**. Residual risk: **medium**.
- All three prior-reviewer medium claims are CONFIRMED in code, but all are input-gated ABOVE deliberate caps and none is a correctness bug or median-user regression; each fails gracefully (clear error message, or coarse-refresh degradation) rather than crashing or losing data.\n\nBelow-the-limit behavior for ordinary users is unchanged: the only sub-cap Quick Open change is parallel->serial pass ordering (identical results, marginal latency), so normalPathRegressionFound=false.\n\nCap inventory verified: Quick Open 20,001 results / 100,000 retained paths / 32MiB / 64KiB per path; raster preview 32,768px/axis + 33.5MP; WSL snapshot 50,000 non-ignored entries (node_modules excluded via ignoreDirs) + 10MiB stream buffer; readDir single-directory 100,000 entries / 12MiB names; external import 256 source paths (== existing NATIVE_FILE_DROP_MAX_PATHS) / 100,000 tree entries / depth 256 / 64KiB relative path / 16MiB retained / 25MiB per file / 100MiB batch; watcher admission 1,024 global / 256 per-sender / 16MiB retained; head-identity 1,024 worktrees / 16MiB packed-refs / 100,000 entries / 64KiB per line. Each cap has a co-located regression test (filesystem-directory-reader.test.ts, filesystem-external-import-limits.test.ts, filesystem-watcher-admission.test.ts, worktree-head-identity-reader.test.ts, worktree-polling-scan-budget.test.ts, wsl-watcher-snapshot.test.ts, worktree-base-directory-watch-targets-bounds.test.ts).\n\nCleanup on abort/error/timeout in filesystem-list-files.ts is thorough: abort listener registered {once:true} and removed in finally, killSurvivors() on rejection, child.kill() on abort/limit, and stdout/stderr/error/close listeners detached in finish(). No leak or double-free found. QuickOpenSubprocessPathAccumulator.clear() is called on every abnormal path (error/signal/timeout/too-large) so no residual-buffer path leak.\n\nResidual risk is medium driven by the Quick Open 20,001 cap: for a whole-repo fuzzy file finder, 20,001 is defensibly low for enterprise monorepos (some legitimate large repos exceed it and lose file reachability). Signoff=true because this is CI-passed production code, the caps are the intended OOM fix, there is no correctness defect, and human review of the specific ceilings (especially 20,001 for Quick Open and 33.5MP for image preview) is the appropriate next step. Recommend the human explicitly accept those two thresholds or consider raising/making them configurable.
- Correctness notes: `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/ipc/filesystem-watcher.ts`: A watcher admission claim can survive renderer teardown when an SSH filesystem provider is unavailable. `fs:watchWorktree` claims capacity before calling `installRemoteWatcher`; the provider-unavailable path returns before `registerSenderCleanup` is installed, and `scheduleRemoteWatcherRetry` does not register it. If that WebContents is then destroyed, the retry drops the destroyed listener but nothing calls `watcherAdmission.releaseSender`, permanently retaining the claim until global shutdown. Repeated SSH renderer reloads during provider unavailability can eventually exhaust the 1,024 global claim cap and reject otherwise valid watches. The relevant paths are the claim at line 1374, unavailable retry at line 1396, early return at line 1148, and cleanup registration only on successful/in-flight ownership at lines 1043-1045/1273-1275.

### Files
50 files changed (+3285 / −969).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**
