### PR TITLE
oom(23/29): bound PTY/runtime/remote IPC delivery

### DIFF
--- a/src/main/ipc/pty-external-renderer-delivery.test.ts
+++ b/src/main/ipc/pty-external-renderer-delivery.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, onMock, removeHandlerMock, removeAllListenersMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  onMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  removeAllListenersMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getPath: () => '/tmp/orca-pty-external-delivery-test',
+    getVersion: () => '0.0.0-test'
+  },
+  powerMonitor: { on: vi.fn() },
+  nativeTheme: { shouldUseDarkColors: true },
+  ipcMain: {
+    handle: handleMock,
+    on: onMock,
+    removeHandler: removeHandlerMock,
+    removeAllListeners: removeAllListenersMock
+  }
+}))
+
+vi.mock('node-pty', () => ({ spawn: vi.fn() }))
+vi.mock('../pwsh', () => ({ isPwshAvailable: vi.fn(() => false) }))
+
+import { LocalPtyProvider } from '../providers/local-pty-provider'
+import { registerPtyHandlers, setLocalPtyProvider } from './pty'
+import {
+  routeExternalPtyData,
+  routeExternalPtyExit,
+  routeExternalPtyReplay
+} from './pty-renderer-delivery-router'
+
+describe('external PTY renderer delivery', () => {
+  const mainWindow = {
+    isDestroyed: () => false,
+    isFocused: () => true,
+    isVisible: () => true,
+    isMinimized: () => false,
+    webContents: {
+      on: vi.fn(),
+      send: vi.fn(),
+      removeListener: vi.fn(),
+      isLoadingMainFrame: vi.fn(() => true)
+    }
+  }
+  const mainWindowEvent = { sender: mainWindow.webContents }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    onMock.mockImplementation((channel: string, listener: (...args: unknown[]) => void) => {
+      if (channel === 'pty:rendererDispatcherReady') {
+        listener(mainWindowEvent)
+        vi.advanceTimersByTime(0)
+      }
+    })
+  })
+
+  afterEach(() => {
+    setLocalPtyProvider(new LocalPtyProvider())
+    vi.useRealTimers()
+  })
+
+  function findIpcListener(channel: string): (...args: never[]) => void {
+    const call = onMock.mock.calls.findLast(([registered]) => registered === channel)
+    if (!call) {
+      throw new Error(`Missing ${channel} listener`)
+    }
+    return call[1] as (...args: never[]) => void
+  }
+
+  function makeRuntime(sequence = 17) {
+    return {
+      setPtyController: vi.fn(),
+      onPtyData: vi.fn(() => sequence),
+      getPtyOutputSequence: vi.fn(() => sequence),
+      hasRawTerminalViewSubscriber: vi.fn(() => false)
+    }
+  }
+
+  it('returns captured SSH credit only after the renderer acknowledges parsing', () => {
+    const runtime = makeRuntime()
+    const upstreamCredit = { charCount: 9, acknowledge: vi.fn() }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    mainWindow.webContents.send.mockClear()
+
+    routeExternalPtyData({
+      id: 'ssh:target@@pty-1',
+      data: '',
+      sequenceChars: 9,
+      transformed: true,
+      upstreamCredit
+    })
+    vi.advanceTimersByTime(2)
+
+    expect(runtime.onPtyData).toHaveBeenCalledWith(
+      'ssh:target@@pty-1',
+      '',
+      expect.any(Number),
+      9,
+      true
+    )
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:data', {
+      id: 'ssh:target@@pty-1',
+      data: '',
+      seq: 17,
+      rawLength: 9,
+      transformed: true
+    })
+    expect(upstreamCredit.acknowledge).not.toHaveBeenCalled()
+
+    findIpcListener('pty:ackData')(
+      mainWindowEvent as never,
+      {
+        id: 'ssh:target@@pty-1',
+        processedChars: 9
+      } as never
+    )
+
+    expect(upstreamCredit.acknowledge).toHaveBeenCalledOnce()
+    expect(upstreamCredit.acknowledge).toHaveBeenCalledWith(9)
+  })
+
+  it('returns credit immediately when hidden output is intentionally dropped', () => {
+    const runtime = makeRuntime(42)
+    const upstreamCredit = { charCount: 13, acknowledge: vi.fn() }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    findIpcListener('pty:setHiddenRendererPty')(
+      null as never,
+      {
+        id: 'ssh:target@@pty-hidden',
+        hidden: true
+      } as never
+    )
+    mainWindow.webContents.send.mockClear()
+
+    routeExternalPtyData({
+      id: 'ssh:target@@pty-hidden',
+      data: 'hidden output',
+      upstreamCredit
+    })
+
+    expect(runtime.onPtyData).toHaveBeenCalledOnce()
+    expect(upstreamCredit.acknowledge).toHaveBeenCalledWith(13)
+    expect(mainWindow.webContents.send).toHaveBeenCalledOnce()
+    expect(mainWindow.webContents.send).toHaveBeenCalledWith('pty:modelRestoreNeeded', {
+      id: 'ssh:target@@pty-hidden',
+      reason: 'hidden-drop',
+      markerSeq: 42
+    })
+  })
+
+  it('settles queued live credit when a reconnect replay supersedes it', () => {
+    const runtime = makeRuntime()
+    const upstreamCredit = { charCount: 11, acknowledge: vi.fn() }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    mainWindow.webContents.send.mockClear()
+
+    routeExternalPtyData({
+      id: 'ssh:target@@pty-replay',
+      data: 'queued live',
+      upstreamCredit
+    })
+    routeExternalPtyReplay({ id: 'ssh:target@@pty-replay', data: 'full snapshot' })
+    vi.advanceTimersByTime(10)
+
+    expect(upstreamCredit.acknowledge).toHaveBeenCalledWith(11)
+    expect(mainWindow.webContents.send.mock.calls).toEqual([
+      ['pty:replay', { id: 'ssh:target@@pty-replay', data: 'full snapshot' }]
+    ])
+  })
+
+  it('writes off captured in-flight credit when the renderer lifecycle ends', () => {
+    const runtime = makeRuntime()
+    const upstreamCredit = { charCount: 7, acknowledge: vi.fn() }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    routeExternalPtyData({
+      id: 'ssh:target@@pty-reload',
+      data: 'inflight',
+      upstreamCredit
+    })
+    vi.advanceTimersByTime(2)
+    expect(upstreamCredit.acknowledge).not.toHaveBeenCalled()
+
+    const lifecycleCall = mainWindow.webContents.on.mock.calls.findLast(
+      ([event]) => event === 'did-start-loading'
+    )
+    const handleLifecycleReset = lifecycleCall?.[1] as (() => void) | undefined
+    expect(handleLifecycleReset).toBeTypeOf('function')
+    handleLifecycleReset?.()
+
+    expect(upstreamCredit.acknowledge).toHaveBeenCalledWith(7)
+  })
+
+  it('settles queued final-tail credit when exit flushes before the batch timer', () => {
+    const runtime = makeRuntime()
+    const upstreamCredit = { charCount: 10, acknowledge: vi.fn() }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+    mainWindow.webContents.send.mockClear()
+
+    routeExternalPtyData({
+      id: 'ssh:target@@pty-final-tail',
+      data: 'final tail',
+      upstreamCredit
+    })
+    routeExternalPtyExit({ id: 'ssh:target@@pty-final-tail', code: 0 })
+
+    expect(upstreamCredit.acknowledge).toHaveBeenCalledWith(10)
+    expect(mainWindow.webContents.send.mock.calls).toEqual([
+      [
+        'pty:data',
+        {
+          id: 'ssh:target@@pty-final-tail',
+          data: 'final tail',
+          seq: 17,
+          rawLength: 10
+        }
+      ],
+      ['pty:exit', { id: 'ssh:target@@pty-final-tail', code: 0 }]
+    ])
+  })
+
+  it('settles already-sent credit when exit arrives before renderer ACK', () => {
+    const runtime = makeRuntime()
+    const upstreamCredit = { charCount: 8, acknowledge: vi.fn() }
+    registerPtyHandlers(mainWindow as never, runtime as never)
+
+    routeExternalPtyData({
+      id: 'ssh:target@@pty-inflight-exit',
+      data: 'inflight',
+      upstreamCredit
+    })
+    vi.advanceTimersByTime(2)
+    expect(upstreamCredit.acknowledge).not.toHaveBeenCalled()
+
+    routeExternalPtyExit({ id: 'ssh:target@@pty-inflight-exit', code: 0 })
+
+    expect(upstreamCredit.acknowledge).toHaveBeenCalledWith(8)
+  })
+})

--- a/src/main/ipc/pty-renderer-delivery-credit.test.ts
+++ b/src/main/ipc/pty-renderer-delivery-credit.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  appendPtyDeliveryCredit,
+  MAX_PENDING_PTY_DELIVERY_CREDIT_SPANS,
+  MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS,
+  MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS_PER_PTY,
+  MAX_RENDERER_PTY_DELIVERY_CREDIT_STATE_ID_BYTES,
+  MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES,
+  PtyRendererDeliveryCreditLedger,
+  settlePtyDeliveryCredit,
+  takePtyDeliveryCredit
+} from './pty-renderer-delivery-credit'
+
+function makeCredit(charCount: number) {
+  return { charCount, acknowledge: vi.fn() }
+}
+
+describe('PTY renderer delivery credit', () => {
+  it('splits queued provider credit without settling bytes left for a later renderer chunk', () => {
+    const first = makeCredit(5)
+    const second = makeCredit(7)
+    const spans = appendPtyDeliveryCredit(appendPtyDeliveryCredit(undefined, first), second)
+
+    const taken = takePtyDeliveryCredit(spans, 8)
+    settlePtyDeliveryCredit(taken)
+
+    expect(first.acknowledge).toHaveBeenCalledWith(5)
+    expect(second.acknowledge).toHaveBeenCalledWith(3)
+    expect(spans).toEqual([{ credit: second, chars: 4 }])
+  })
+
+  it('settles explicit provider owners and legacy fallback spans in renderer order', () => {
+    const first = makeCredit(5)
+    const second = makeCredit(4)
+    const acknowledgeFallback = vi.fn()
+    const ledger = new PtyRendererDeliveryCreditLedger()
+
+    ledger.recordSent('pty-1', 5, [{ credit: first, chars: 5 }], acknowledgeFallback)
+    ledger.recordSent('pty-1', 3, undefined, acknowledgeFallback)
+    ledger.recordSent('pty-1', 4, [{ credit: second, chars: 4 }], acknowledgeFallback)
+    ledger.acknowledge('pty-1', 7, acknowledgeFallback)
+    ledger.acknowledge('pty-1', 2, acknowledgeFallback)
+    ledger.acknowledge('pty-1', 3, acknowledgeFallback)
+
+    expect(first.acknowledge).toHaveBeenCalledWith(5)
+    expect(second.acknowledge.mock.calls).toEqual([[1], [3]])
+    expect(acknowledgeFallback.mock.calls).toEqual([[2], [1]])
+  })
+
+  it('writes off every captured owner while keeping PTY fallback routing separate', () => {
+    const first = makeCredit(4)
+    const second = makeCredit(6)
+    const acknowledgeFallback = vi.fn()
+    const ledger = new PtyRendererDeliveryCreditLedger()
+
+    ledger.recordSent('pty-1', 4, [{ credit: first, chars: 4 }], acknowledgeFallback)
+    ledger.recordSent('pty-2', 2, undefined, acknowledgeFallback)
+    ledger.recordSent('pty-3', 6, [{ credit: second, chars: 6 }], acknowledgeFallback)
+    ledger.writeOffAll(acknowledgeFallback)
+
+    expect(first.acknowledge).toHaveBeenCalledWith(4)
+    expect(second.acknowledge).toHaveBeenCalledWith(6)
+    expect(acknowledgeFallback).toHaveBeenCalledOnce()
+    expect(acknowledgeFallback).toHaveBeenCalledWith('pty-2', 2)
+  })
+
+  it('abandons an exited PTY without crediting a replacement owner', () => {
+    const exited = makeCredit(4)
+    const acknowledgeFallback = vi.fn()
+    const ledger = new PtyRendererDeliveryCreditLedger()
+    ledger.recordSent('reused-id', 4, [{ credit: exited, chars: 4 }], acknowledgeFallback)
+
+    ledger.abandon('reused-id')
+    ledger.acknowledge('reused-id', 4, acknowledgeFallback)
+
+    expect(exited.acknowledge).not.toHaveBeenCalled()
+    expect(acknowledgeFallback).not.toHaveBeenCalled()
+  })
+
+  it('collapses one-byte pending credit floods into already-settled metadata', () => {
+    const total = MAX_PENDING_PTY_DELIVERY_CREDIT_SPANS + 100
+    const credits = Array.from({ length: total }, () => makeCredit(1))
+    let spans
+    for (const credit of credits) {
+      spans = appendPtyDeliveryCredit(spans, credit)
+    }
+
+    expect(spans).toEqual([{ chars: total, settled: true }])
+    expect(credits.every((credit) => credit.acknowledge.mock.calls.length === 1)).toBe(true)
+
+    const ledger = new PtyRendererDeliveryCreditLedger()
+    const acknowledgeFallback = vi.fn()
+    const sent = takePtyDeliveryCredit(spans, total)
+    ledger.recordSent('pty-tiny', total, sent, acknowledgeFallback)
+    ledger.acknowledge('pty-tiny', total, acknowledgeFallback)
+
+    expect(acknowledgeFallback).not.toHaveBeenCalled()
+    expect(credits.every((credit) => credit.acknowledge.mock.calls.length === 1)).toBe(true)
+  })
+
+  it('bounds per-PTY in-flight credit closures and settles each exactly once', () => {
+    const total = MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS_PER_PTY + 100
+    const credits = Array.from({ length: total }, () => makeCredit(1))
+    const acknowledgeFallback = vi.fn()
+    const ledger = new PtyRendererDeliveryCreditLedger()
+
+    for (const credit of credits) {
+      ledger.recordSent('pty-tiny', 1, [{ credit, chars: 1 }], acknowledgeFallback)
+    }
+
+    const state = (Reflect.get(ledger, 'inFlightByPty') as Map<string, { spans: unknown[] }>).get(
+      'pty-tiny'
+    )
+    expect(state?.spans.length).toBeLessThanOrEqual(MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS_PER_PTY)
+    ledger.acknowledge('pty-tiny', total, acknowledgeFallback)
+
+    expect(acknowledgeFallback).not.toHaveBeenCalled()
+    expect(credits.every((credit) => credit.acknowledge.mock.calls.length === 1)).toBe(true)
+  })
+
+  it('bounds aggregate in-flight credit spans across PTYs', () => {
+    let acknowledged = 0
+    const acknowledgeFallback = vi.fn()
+    const ledger = new PtyRendererDeliveryCreditLedger()
+    const total = MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS + 100
+
+    for (let index = 0; index < total; index += 1) {
+      const credit = {
+        charCount: 1,
+        acknowledge: (chars: number) => {
+          acknowledged += chars
+        }
+      }
+      ledger.recordSent(`pty-${index % 8}`, 1, [{ credit, chars: 1 }], acknowledgeFallback)
+    }
+
+    expect(Reflect.get(ledger, 'retainedSpanCount')).toBeLessThanOrEqual(
+      MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS
+    )
+    ledger.writeOffAll(acknowledgeFallback)
+    expect(acknowledged).toBe(total)
+    expect(acknowledgeFallback).not.toHaveBeenCalled()
+  })
+
+  it('bounds unique in-flight IDs and settles evicted credit exactly once', () => {
+    const credits = Array.from({ length: MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES + 50 }, () =>
+      makeCredit(1)
+    )
+    const acknowledgeFallback = vi.fn()
+    const ledger = new PtyRendererDeliveryCreditLedger()
+
+    for (const [index, credit] of credits.entries()) {
+      ledger.recordSent(`pty-${index}`, 1, [{ credit, chars: 1 }], acknowledgeFallback)
+    }
+
+    const states = Reflect.get(ledger, 'inFlightByPty') as Map<string, unknown>
+    expect(states.size).toBe(MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES)
+    expect(states.has('pty-0')).toBe(false)
+    ledger.writeOffAll(acknowledgeFallback)
+    expect(credits.every((credit) => credit.acknowledge.mock.calls.length === 1)).toBe(true)
+    expect(acknowledgeFallback).not.toHaveBeenCalled()
+  })
+
+  it('bounds aggregate in-flight ID bytes and settles fallback before eviction', () => {
+    const id = 'x'.repeat(MAX_RENDERER_PTY_DELIVERY_CREDIT_STATE_ID_BYTES)
+    const settleFallback = vi.fn()
+    const ledger = new PtyRendererDeliveryCreditLedger()
+
+    ledger.recordSent(id, 3, undefined, settleFallback)
+    ledger.recordSent('extra', 2, undefined, settleFallback)
+
+    const states = Reflect.get(ledger, 'inFlightByPty') as Map<string, unknown>
+    expect(states.size).toBe(1)
+    expect(states.has(id)).toBe(false)
+    expect(settleFallback).toHaveBeenCalledOnce()
+    expect(settleFallback).toHaveBeenCalledWith(3)
+    ledger.acknowledge(id, 3, settleFallback)
+    expect(settleFallback).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/ipc/pty-renderer-delivery-credit.ts
+++ b/src/main/ipc/pty-renderer-delivery-credit.ts
@@ -1,0 +1,297 @@
+import type { PtyDataUpstreamCredit } from '../providers/pty-provider-events'
+
+export const MAX_PENDING_PTY_DELIVERY_CREDIT_SPANS = 4096
+export const MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS_PER_PTY = 4096
+export const MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS = 16_384
+export const MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES = 4096
+export const MAX_RENDERER_PTY_DELIVERY_CREDIT_STATE_ID_BYTES = 8 * 1024 * 1024
+
+export type PtyDeliveryCreditSpan =
+  | {
+      credit: PtyDataUpstreamCredit
+      chars: number
+      settled?: never
+    }
+  | {
+      chars: number
+      settled: true
+      credit?: never
+    }
+
+type InFlightCreditSpan = {
+  chars: number
+  credit?: PtyDataUpstreamCredit
+  settled?: true
+}
+
+type InFlightCreditState = {
+  idBytes: number
+  spans: InFlightCreditSpan[]
+  settledPrefixChars: number
+  settleFallback: (chars: number) => void
+}
+
+export function appendPtyDeliveryCredit(
+  spans: PtyDeliveryCreditSpan[] | undefined,
+  credit: PtyDataUpstreamCredit | undefined
+): PtyDeliveryCreditSpan[] | undefined {
+  if (!credit || !Number.isFinite(credit.charCount) || credit.charCount <= 0) {
+    return spans
+  }
+  const chars = Math.floor(credit.charCount)
+  const next = spans ?? []
+  const tail = next.at(-1)
+  if (tail?.settled === true) {
+    credit.acknowledge(chars)
+    tail.chars += chars
+    return next
+  }
+  if (next.length >= MAX_PENDING_PTY_DELIVERY_CREDIT_SPANS) {
+    let settledChars = chars
+    for (const span of next) {
+      settledChars += span.chars
+      span.credit?.acknowledge(span.chars)
+    }
+    credit.acknowledge(chars)
+    next.splice(0, next.length, { chars: settledChars, settled: true })
+    return next
+  }
+  next.push({ credit, chars })
+  return next
+}
+
+export function takePtyDeliveryCredit(
+  spans: PtyDeliveryCreditSpan[] | undefined,
+  requestedChars: number
+): PtyDeliveryCreditSpan[] | undefined {
+  if (!spans || spans.length === 0 || requestedChars <= 0) {
+    return undefined
+  }
+  const taken: PtyDeliveryCreditSpan[] = []
+  let remaining = requestedChars
+  while (remaining > 0 && spans.length > 0) {
+    const span = spans[0]
+    const chars = Math.min(remaining, span.chars)
+    taken.push(span.settled === true ? { chars, settled: true } : { credit: span.credit, chars })
+    span.chars -= chars
+    remaining -= chars
+    if (span.chars === 0) {
+      spans.shift()
+    }
+  }
+  return taken
+}
+
+export function settlePtyDeliveryCredit(spans: PtyDeliveryCreditSpan[] | undefined): void {
+  if (!spans) {
+    return
+  }
+  for (const span of spans.splice(0)) {
+    span.credit?.acknowledge(span.chars)
+  }
+}
+
+export class PtyRendererDeliveryCreditLedger {
+  private readonly inFlightByPty = new Map<string, InFlightCreditState>()
+  private retainedSpanCount = 0
+  private retainedStateIdBytes = 0
+
+  recordSent(
+    id: string,
+    charCount: number,
+    explicitCredit: PtyDeliveryCreditSpan[] | undefined,
+    settleFallback: (chars: number) => void
+  ): void {
+    if (!Number.isFinite(charCount) || charCount <= 0) {
+      return
+    }
+    const admittedCharCount = Math.floor(charCount)
+    const state = this.inFlightByPty.get(id) ?? {
+      idBytes: Buffer.byteLength(id, 'utf8'),
+      spans: [],
+      settledPrefixChars: 0,
+      settleFallback
+    }
+    const isNewState = !this.inFlightByPty.has(id)
+    state.settleFallback = settleFallback
+    let recorded = 0
+    for (const span of explicitCredit ?? []) {
+      if (recorded >= admittedCharCount || !Number.isFinite(span.chars) || span.chars <= 0) {
+        break
+      }
+      const chars = Math.min(Math.floor(span.chars), admittedCharCount - recorded)
+      this.appendSpan(
+        state,
+        span.settled === true ? { chars, settled: true } : { chars, credit: span.credit }
+      )
+      recorded += chars
+    }
+    if (recorded < admittedCharCount) {
+      this.appendSpan(state, { chars: admittedCharCount - recorded })
+    }
+    this.inFlightByPty.delete(id)
+    this.inFlightByPty.set(id, state)
+    if (isNewState) {
+      this.retainedStateIdBytes += state.idBytes
+    }
+    this.capStates()
+  }
+
+  acknowledge(id: string, charCount: number, acknowledgeFallback: (chars: number) => void): void {
+    const state = this.inFlightByPty.get(id)
+    if (!state || !Number.isFinite(charCount) || charCount <= 0) {
+      return
+    }
+    let remaining = Math.floor(charCount)
+    const settledPrefix = Math.min(remaining, state.settledPrefixChars)
+    state.settledPrefixChars -= settledPrefix
+    remaining -= settledPrefix
+    let fallbackChars = 0
+    while (remaining > 0 && state.spans.length > 0) {
+      const span = state.spans[0]
+      const chars = Math.min(remaining, span.chars)
+      if (span.credit) {
+        span.credit.acknowledge(chars)
+      } else if (span.settled !== true) {
+        fallbackChars += chars
+      }
+      span.chars -= chars
+      remaining -= chars
+      if (span.chars === 0) {
+        state.spans.shift()
+        this.retainedSpanCount--
+      }
+    }
+    if (state.spans.length === 0 && state.settledPrefixChars === 0) {
+      this.deleteState(id, state)
+    }
+    if (fallbackChars > 0) {
+      acknowledgeFallback(fallbackChars)
+    }
+  }
+
+  writeOff(id: string, acknowledgeFallback: (chars: number) => void): void {
+    const state = this.inFlightByPty.get(id)
+    if (!state) {
+      return
+    }
+    this.acknowledge(
+      id,
+      state.settledPrefixChars + state.spans.reduce((total, span) => total + span.chars, 0),
+      acknowledgeFallback
+    )
+  }
+
+  writeOffAll(acknowledgeFallback: (id: string, chars: number) => void): void {
+    for (const id of Array.from(this.inFlightByPty.keys())) {
+      this.writeOff(id, (chars) => acknowledgeFallback(id, chars))
+    }
+  }
+
+  abandon(id: string): void {
+    const state = this.inFlightByPty.get(id)
+    if (!state) {
+      return
+    }
+    this.retainedSpanCount -= state.spans.length
+    this.deleteState(id, state)
+  }
+
+  private appendSpan(state: InFlightCreditState, span: InFlightCreditSpan): void {
+    if (span.chars <= 0) {
+      return
+    }
+    let tail = state.spans.at(-1)
+    if (tail && this.canMergeSpans(tail, span)) {
+      tail.chars += span.chars
+      return
+    }
+    this.ensureSpanCapacity(state)
+    tail = state.spans.at(-1)
+    if (tail && this.canMergeSpans(tail, span)) {
+      tail.chars += span.chars
+      return
+    }
+    state.spans.push(span)
+    this.retainedSpanCount++
+  }
+
+  private capStates(): void {
+    while (
+      this.inFlightByPty.size > MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES ||
+      this.retainedStateIdBytes > MAX_RENDERER_PTY_DELIVERY_CREDIT_STATE_ID_BYTES
+    ) {
+      const oldest = this.inFlightByPty.entries().next().value as
+        | [string, InFlightCreditState]
+        | undefined
+      if (!oldest) {
+        return
+      }
+      this.collapseState(oldest[1])
+      this.deleteState(oldest[0], oldest[1])
+    }
+  }
+
+  private ensureSpanCapacity(state: InFlightCreditState): void {
+    if (
+      state.spans.length >= MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS_PER_PTY ||
+      this.retainedSpanCount >= MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS
+    ) {
+      this.collapseState(state)
+    }
+    while (this.retainedSpanCount >= MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS) {
+      const candidate = Array.from(this.inFlightByPty.values()).find(
+        (entry) => entry.spans.length > 0
+      )
+      if (!candidate) {
+        break
+      }
+      this.collapseState(candidate)
+    }
+  }
+
+  private collapseState(state: InFlightCreditState): void {
+    if (state.spans.length === 0) {
+      return
+    }
+    let settledChars = 0
+    let fallbackChars = 0
+    for (const span of state.spans) {
+      settledChars += span.chars
+      try {
+        if (span.credit) {
+          span.credit.acknowledge(span.chars)
+        } else if (span.settled !== true) {
+          fallbackChars += span.chars
+        }
+      } catch {
+        // Why: overload shedding must still release local metadata if an upstream is gone.
+      }
+    }
+    if (fallbackChars > 0) {
+      try {
+        state.settleFallback(fallbackChars)
+      } catch {
+        // Why: overload shedding must still release local metadata if an upstream is gone.
+      }
+    }
+    state.settledPrefixChars += settledChars
+    this.retainedSpanCount -= state.spans.length
+    state.spans.length = 0
+  }
+
+  private deleteState(id: string, state: InFlightCreditState): void {
+    if (this.inFlightByPty.get(id) !== state) {
+      return
+    }
+    this.inFlightByPty.delete(id)
+    this.retainedStateIdBytes -= state.idBytes
+  }
+
+  private canMergeSpans(left: InFlightCreditSpan, right: InFlightCreditSpan): boolean {
+    if (left.credit || right.credit) {
+      return left.credit !== undefined && left.credit === right.credit
+    }
+    return left.settled === right.settled
+  }
+}

--- a/src/main/ipc/pty-renderer-delivery-retention.test.ts
+++ b/src/main/ipc/pty-renderer-delivery-retention.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MAX_PENDING_PTY_DATA_CHARS,
+  MAX_PENDING_PTY_DATA_CREDIT_SPANS,
+  MAX_PENDING_PTY_DATA_ID_BYTES,
+  MAX_PENDING_PTY_DATA_STATES,
+  MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_ID_BYTES,
+  MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES,
+  PendingPtyDataMap,
+  PtyRendererDeliveryAccountingMap,
+  PtyRendererDeliveryIdSet,
+  settleRejectedPtyRendererDelivery
+} from './pty-renderer-delivery-retention'
+
+type Pending = {
+  data: string
+  creditSpans: number
+}
+
+function pendingMap(onRejected = vi.fn()) {
+  return {
+    map: new PendingPtyDataMap<Pending>(
+      (pending) => ({ chars: pending.data.length, creditSpans: pending.creditSpans }),
+      onRejected
+    ),
+    onRejected
+  }
+}
+
+describe('PTY renderer delivery retention', () => {
+  it('preserves ordinary pending updates and exact map bookkeeping', () => {
+    const { map, onRejected } = pendingMap()
+
+    expect(map.admit('pty-1', { data: 'one', creditSpans: 1 })).toBe(true)
+    expect(map.admit('pty-1', { data: 'updated', creditSpans: 2 })).toBe(true)
+    expect(map.delete('pty-1')).toBe(true)
+
+    expect(map.size).toBe(0)
+    expect(onRejected).not.toHaveBeenCalled()
+  })
+
+  it('rejects unique pending-ID floods after the bounded state count', () => {
+    const { map, onRejected } = pendingMap()
+    for (let index = 0; index < MAX_PENDING_PTY_DATA_STATES + 50; index += 1) {
+      map.set(`pty-${index}`, { data: 'x', creditSpans: 1 })
+    }
+
+    expect(map.size).toBe(MAX_PENDING_PTY_DATA_STATES)
+    expect(map.has('pty-0')).toBe(true)
+    expect(map.has(`pty-${MAX_PENDING_PTY_DATA_STATES}`)).toBe(false)
+    expect(onRejected).toHaveBeenCalledTimes(50)
+  })
+
+  it('bounds pending ID bytes, characters, and credit records independently', () => {
+    const idPressure = pendingMap()
+    const id = 'x'.repeat(MAX_PENDING_PTY_DATA_ID_BYTES)
+    idPressure.map.set(id, { data: 'x', creditSpans: 0 })
+    idPressure.map.set('extra', { data: 'x', creditSpans: 0 })
+    expect(idPressure.map.size).toBe(1)
+    expect(idPressure.onRejected).toHaveBeenCalledWith('extra', {
+      data: 'x',
+      creditSpans: 0
+    })
+
+    const charPressure = pendingMap()
+    charPressure.map.set('full', {
+      data: 'x'.repeat(MAX_PENDING_PTY_DATA_CHARS),
+      creditSpans: 0
+    })
+    charPressure.map.set('extra', { data: 'x', creditSpans: 0 })
+    expect(charPressure.map.size).toBe(1)
+    expect(charPressure.onRejected).toHaveBeenCalledOnce()
+
+    const creditPressure = pendingMap()
+    creditPressure.map.set('full', { data: 'x', creditSpans: MAX_PENDING_PTY_DATA_CREDIT_SPANS })
+    creditPressure.map.set('extra', { data: 'x', creditSpans: 1 })
+    expect(creditPressure.map.size).toBe(1)
+    expect(creditPressure.onRejected).toHaveBeenCalledOnce()
+  })
+
+  it('bounds accounting and warning IDs without evicting admitted live state', () => {
+    const accounting = new PtyRendererDeliveryAccountingMap<number>()
+    const warned = new PtyRendererDeliveryIdSet()
+    for (let index = 0; index < MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES + 50; index += 1) {
+      accounting.set(`pty-${index}`, index)
+      warned.add(`pty-${index}`)
+    }
+
+    expect(accounting.size).toBe(MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES)
+    expect(warned.size).toBe(MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES)
+    expect(accounting.has('pty-0')).toBe(true)
+    expect(accounting.has(`pty-${MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES}`)).toBe(false)
+    expect(warned.has(`pty-${MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES}`)).toBe(false)
+
+    const byteBounded = new PtyRendererDeliveryAccountingMap<number>()
+    byteBounded.set('x'.repeat(MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_ID_BYTES), 1)
+    expect(byteBounded.admit('extra', 2)).toBe(false)
+    expect(byteBounded.size).toBe(1)
+  })
+
+  it('settles rejected explicit, already-settled, and fallback credit exactly once', () => {
+    const explicit = vi.fn()
+    const fallback = vi.fn()
+
+    settleRejectedPtyRendererDelivery(
+      7,
+      [
+        { chars: 2, settled: true },
+        { chars: 3, credit: { charCount: 3, acknowledge: explicit } }
+      ],
+      fallback
+    )
+
+    expect(explicit).toHaveBeenCalledOnce()
+    expect(explicit).toHaveBeenCalledWith(3)
+    expect(fallback).toHaveBeenCalledOnce()
+    expect(fallback).toHaveBeenCalledWith(2)
+  })
+})

--- a/src/main/ipc/pty-renderer-delivery-retention.ts
+++ b/src/main/ipc/pty-renderer-delivery-retention.ts
@@ -1,0 +1,188 @@
+import {
+  MAX_RENDERER_PTY_DELIVERY_CREDIT_STATE_ID_BYTES,
+  MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES,
+  type PtyDeliveryCreditSpan
+} from './pty-renderer-delivery-credit'
+
+export const MAX_PENDING_PTY_DATA_STATES = MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES
+export const MAX_PENDING_PTY_DATA_ID_BYTES = MAX_RENDERER_PTY_DELIVERY_CREDIT_STATE_ID_BYTES
+export const MAX_PENDING_PTY_DATA_CHARS = 32 * 1024 * 1024
+export const MAX_PENDING_PTY_DATA_CREDIT_SPANS = 16_384
+export const MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES = MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES
+export const MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_ID_BYTES =
+  MAX_RENDERER_PTY_DELIVERY_CREDIT_STATE_ID_BYTES
+
+type PendingPtyDataMeasurement = {
+  chars: number
+  creditSpans: number
+}
+
+export class PendingPtyDataMap<T> extends Map<string, T> {
+  private readonly measurements = new Map<string, PendingPtyDataMeasurement>()
+  private retainedChars = 0
+  private retainedCreditSpans = 0
+  private retainedIdBytes = 0
+
+  constructor(
+    private readonly measure: (value: T) => PendingPtyDataMeasurement,
+    private readonly onRejected: (id: string, value: T) => void
+  ) {
+    super()
+  }
+
+  admit(id: string, value: T): boolean {
+    const hadPrevious = super.has(id)
+    const previousMeasurement = this.measurements.get(id) ?? { chars: 0, creditSpans: 0 }
+    const measurement = this.measure(value)
+    const idBytes = Buffer.byteLength(id, 'utf8')
+    const nextSize = this.size + (hadPrevious ? 0 : 1)
+    const nextIdBytes = this.retainedIdBytes + (hadPrevious ? 0 : idBytes)
+    const nextChars = this.retainedChars - previousMeasurement.chars + measurement.chars
+    const nextCreditSpans =
+      this.retainedCreditSpans - previousMeasurement.creditSpans + measurement.creditSpans
+
+    if (
+      nextSize > MAX_PENDING_PTY_DATA_STATES ||
+      nextIdBytes > MAX_PENDING_PTY_DATA_ID_BYTES ||
+      nextChars > MAX_PENDING_PTY_DATA_CHARS ||
+      nextCreditSpans > MAX_PENDING_PTY_DATA_CREDIT_SPANS
+    ) {
+      if (hadPrevious) {
+        this.delete(id)
+      }
+      this.onRejected(id, value)
+      return false
+    }
+
+    super.set(id, value)
+    this.measurements.set(id, measurement)
+    this.retainedChars = nextChars
+    this.retainedCreditSpans = nextCreditSpans
+    this.retainedIdBytes = nextIdBytes
+    return true
+  }
+
+  override set(id: string, value: T): this {
+    this.admit(id, value)
+    return this
+  }
+
+  override delete(id: string): boolean {
+    const measurement = this.measurements.get(id) ?? { chars: 0, creditSpans: 0 }
+    if (!super.delete(id)) {
+      return false
+    }
+    this.measurements.delete(id)
+    this.retainedChars -= measurement.chars
+    this.retainedCreditSpans -= measurement.creditSpans
+    this.retainedIdBytes -= Buffer.byteLength(id, 'utf8')
+    return true
+  }
+
+  override clear(): void {
+    super.clear()
+    this.measurements.clear()
+    this.retainedChars = 0
+    this.retainedCreditSpans = 0
+    this.retainedIdBytes = 0
+  }
+}
+
+export class PtyRendererDeliveryAccountingMap<T> extends Map<string, T> {
+  private retainedIdBytes = 0
+
+  admit(id: string, value: T): boolean {
+    if (super.has(id)) {
+      super.set(id, value)
+      return true
+    }
+    const idBytes = Buffer.byteLength(id, 'utf8')
+    if (
+      this.size >= MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES ||
+      this.retainedIdBytes + idBytes > MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_ID_BYTES
+    ) {
+      return false
+    }
+    super.set(id, value)
+    this.retainedIdBytes += idBytes
+    return true
+  }
+
+  override set(id: string, value: T): this {
+    this.admit(id, value)
+    return this
+  }
+
+  override delete(id: string): boolean {
+    if (!super.delete(id)) {
+      return false
+    }
+    this.retainedIdBytes -= Buffer.byteLength(id, 'utf8')
+    return true
+  }
+
+  override clear(): void {
+    super.clear()
+    this.retainedIdBytes = 0
+  }
+}
+
+export class PtyRendererDeliveryIdSet extends Set<string> {
+  private retainedIdBytes = 0
+
+  remember(id: string): boolean {
+    if (super.has(id)) {
+      return false
+    }
+    const idBytes = Buffer.byteLength(id, 'utf8')
+    if (
+      this.size >= MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES ||
+      this.retainedIdBytes + idBytes > MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_ID_BYTES
+    ) {
+      return false
+    }
+    super.add(id)
+    this.retainedIdBytes += idBytes
+    return true
+  }
+
+  override add(id: string): this {
+    this.remember(id)
+    return this
+  }
+
+  override delete(id: string): boolean {
+    if (!super.delete(id)) {
+      return false
+    }
+    this.retainedIdBytes -= Buffer.byteLength(id, 'utf8')
+    return true
+  }
+
+  override clear(): void {
+    super.clear()
+    this.retainedIdBytes = 0
+  }
+}
+
+export function settleRejectedPtyRendererDelivery(
+  charCount: number,
+  creditSpans: PtyDeliveryCreditSpan[] | undefined,
+  settleFallback: (chars: number) => void
+): void {
+  if (!Number.isFinite(charCount) || charCount <= 0) {
+    return
+  }
+  let remaining = Math.floor(charCount)
+  for (const span of creditSpans ?? []) {
+    if (remaining <= 0 || !Number.isFinite(span.chars) || span.chars <= 0) {
+      continue
+    }
+    const chars = Math.min(remaining, Math.floor(span.chars))
+    remaining -= chars
+    span.credit?.acknowledge(chars)
+  }
+  if (remaining > 0) {
+    settleFallback(remaining)
+  }
+}

--- a/src/main/ipc/pty-renderer-delivery-router.ts
+++ b/src/main/ipc/pty-renderer-delivery-router.ts
@@ -1,0 +1,35 @@
+import type { PtyDataEvent } from '../providers/pty-provider-events'
+
+export type ExternalPtyRendererDeliveryRouter = {
+  data(payload: PtyDataEvent): void
+  replay(payload: { id: string; data: string }): void
+  exit(payload: { id: string; code: number }): void
+}
+
+function returnUnroutedCredit(payload: PtyDataEvent): void {
+  payload.upstreamCredit?.acknowledge(payload.upstreamCredit.charCount)
+}
+
+let router: ExternalPtyRendererDeliveryRouter = {
+  data: returnUnroutedCredit,
+  replay: () => {},
+  exit: () => {}
+}
+
+export function installExternalPtyRendererDeliveryRouter(
+  nextRouter: ExternalPtyRendererDeliveryRouter
+): void {
+  router = nextRouter
+}
+
+export function routeExternalPtyData(payload: PtyDataEvent): void {
+  router.data(payload)
+}
+
+export function routeExternalPtyReplay(payload: { id: string; data: string }): void {
+  router.replay(payload)
+}
+
+export function routeExternalPtyExit(payload: { id: string; code: number }): void {
+  router.exit(payload)
+}

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -11,6 +11,8 @@ import { redactPtyIdForDiagnostics } from '../../shared/pty-delivery-diagnostics
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
 import type { TuiAgent } from '../../shared/types'
 import type { AgentSessionOwnerBinding } from '../../shared/agent-session-host-authority'
+import { MAX_CLAIMED_AGENT_PTY_OWNER_ENTRIES } from '../../shared/claimed-agent-pty-owner'
+import type * as NodeBoundedFileReader from '../../shared/node-bounded-file-reader'
 
 const isWindowsHost = process.platform === 'win32'
 const posixOnlyIt = isWindowsHost ? it.skip : it
@@ -123,6 +125,21 @@ vi.mock('fs', () => ({
   chmodSync: chmodSyncMock,
   constants: {
     X_OK: 1
+  }
+}))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeBoundedFileReader>()),
+  readNodeFileSyncWithinLimit: (path: string, maxBytes: number) => {
+    const content = readFileSyncMock(path)
+    if (typeof content !== 'string' && !Buffer.isBuffer(content)) {
+      throw new Error('File unavailable')
+    }
+    const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content)
+    if (buffer.byteLength > maxBytes) {
+      throw new Error('File too large')
+    }
+    return { buffer, stats: { size: buffer.byteLength } }
   }
 }))
 
@@ -1017,6 +1034,52 @@ describe('registerPtyHandlers', () => {
     expect(isCurrentPtyExit({ id: owner.ptyId, incarnationId: 'incarnation-recovered' })).toBe(true)
     expect(provider.spawn).not.toHaveBeenCalled()
     clearProviderPtyState(owner.ptyId)
+  })
+
+  it('fails claimed ensure closed before aggregate owner listings amplify memory', async () => {
+    const ownersPerSession = 256
+    const sessionCount = Math.floor(MAX_CLAIMED_AGENT_PTY_OWNER_ENTRIES / ownersPerSession) + 1
+    const sessions = Array.from({ length: sessionCount }, (_, sessionIndex) => {
+      const id = `pty-owner-cap-${sessionIndex}`
+      return {
+        id,
+        incarnationId: 'incarnation-owner-cap',
+        cwd: '/tmp/recovered-worktree',
+        title: 'Codex',
+        agentSessionOwners: Array.from({ length: ownersPerSession }, (_, ownerIndex) => {
+          const index = sessionIndex * ownersPerSession + ownerIndex
+          return {
+            claim: {
+              ...recoveredAgentClaim,
+              identityDigest: index.toString(36).padStart(43, 'a')
+            },
+            generation: `generation-owner-cap-${index}`,
+            phase: 'live' as const,
+            ptyId: id,
+            surface: recoveredAgentSurface
+          }
+        })
+      }
+    })
+    const provider = createAgentClaimProvider({ sessions })
+    setLocalPtyProvider(provider as never)
+    const controller = registerAgentClaimController()
+
+    await expect(
+      controller.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp/recovered-worktree',
+        agentSessionEnsure: {
+          claim: {
+            ...recoveredAgentClaim,
+            identityDigest: '7777777777777777777777777777777777777777777'
+          },
+          surface: recoveredAgentSurface
+        }
+      })
+    ).rejects.toThrow('execution_owner_unavailable')
+    expect(provider.spawn).not.toHaveBeenCalled()
   })
 
   it('releases an adopted-owner fence when that owner exits during admission', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -57,12 +57,18 @@ import { piTitlebarExtensionService } from '../pi/titlebar-extension-service'
 import { detectPiAgentKindFromCommand, type PiAgentKind } from '../../shared/pi-agent-kind'
 import { isPwshAvailable } from '../pwsh'
 import { LocalPtyProvider } from '../providers/local-pty-provider'
-import type { IPtyProvider, PtySpawnOptions, PtySpawnResult } from '../providers/types'
+import type {
+  IPtyProvider,
+  PtyProcessInfo,
+  PtySpawnOptions,
+  PtySpawnResult
+} from '../providers/types'
 import { inspectPtyProviderProcess } from '../providers/pty-process-inspection'
 import {
   PtyProcessListAdmission,
   visitPtyProcessListingsInBatches
 } from '../providers/pty-process-list-admission'
+import type { PtyDataEvent } from '../providers/pty-provider-events'
 import type { StartupCommandDelivery } from '../../shared/codex-startup-delivery'
 import {
   SSH_SESSION_EXPIRED_ERROR,
@@ -173,6 +179,20 @@ import {
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
 import { isPtyIncarnationId } from '../../shared/pty-incarnation'
+import {
+  appendPtyDeliveryCredit,
+  PtyRendererDeliveryCreditLedger,
+  settlePtyDeliveryCredit,
+  takePtyDeliveryCredit,
+  type PtyDeliveryCreditSpan
+} from './pty-renderer-delivery-credit'
+import {
+  PendingPtyDataMap,
+  PtyRendererDeliveryAccountingMap,
+  PtyRendererDeliveryIdSet,
+  settleRejectedPtyRendererDelivery
+} from './pty-renderer-delivery-retention'
+import { installExternalPtyRendererDeliveryRouter } from './pty-renderer-delivery-router'
 
 // ─── Provider Registry ──────────────────────────────────────────────
 // Routes PTY operations by connectionId (null = local provider).
@@ -182,19 +202,7 @@ type FreshLocalFallbackProvider = IPtyProvider & {
   routesFreshSpawnsToLocalProvider?: true
 }
 const sshProviders = new Map<string, IPtyProvider>()
-
-type RegisteredPtyProvider = {
-  provider: IPtyProvider
-  connectionId: string | null
-}
-
-function registeredPtyProviders(): RegisteredPtyProvider[] {
-  return [
-    { provider: localProvider, connectionId: null },
-    ...Array.from(sshProviders, ([connectionId, provider]) => ({ provider, connectionId }))
-  ]
-}
-
+export const MAX_REGISTERED_SSH_PTY_PROVIDERS = 256
 const SYNTHETIC_KILL_EXIT_DUPLICATE_WINDOW_MS = 30_000
 // Why: kill switch — flip to disable producer flow control (pause/resume) without untangling the wiring.
 const PRODUCER_FLOW_CONTROL_ENABLED = true
@@ -266,6 +274,18 @@ const paneSpawnReservationsByPaneKey = new Map<string, PaneSpawnReservation>()
 const agentSessionOwners = new ClaimedAgentPtyOwnerRegistry()
 let agentSessionOwnerReconciliation: Promise<void> | null = null
 
+type RegisteredPtyProvider = {
+  provider: IPtyProvider
+  connectionId: string | null
+}
+
+function registeredPtyProviders(): RegisteredPtyProvider[] {
+  return [
+    { provider: localProvider, connectionId: null },
+    ...Array.from(sshProviders, ([connectionId, provider]) => ({ provider, connectionId }))
+  ]
+}
+
 function assertSpawnReplyWasLive(result: PtySpawnResult): void {
   if (!result.exitedBeforeSpawnReply) {
     return
@@ -281,39 +301,35 @@ async function reconcileAgentSessionOwnerListings(): Promise<void> {
     return await agentSessionOwnerReconciliation
   }
   const reconciliation = (async () => {
-    const providers: { provider: IPtyProvider; connectionId: string | null }[] = [
-      { provider: localProvider, connectionId: null },
-      ...Array.from(sshProviders, ([connectionId, provider]) => ({ provider, connectionId }))
-    ]
-    const listings = await Promise.all(
-      providers.map(async ({ provider, connectionId }) => ({
-        connectionId,
-        sessions: await provider.listProcesses()
-      }))
-    )
+    const admission = new PtyProcessListAdmission('execution_owner_unavailable')
     const advertisedOwners: AgentSessionOwnerBinding[] = []
     const advertisedOwnerSessions: {
       id: string
       connectionId: string | null
       incarnationId: string
     }[] = []
-    for (const { connectionId, sessions } of listings) {
-      for (const session of sessions) {
-        const incarnationId = session.incarnationId
-        let hasAdvertisedOwner = false
-        for (const owner of session.agentSessionOwners ?? []) {
-          if (owner.ptyId !== session.id || !isPtyIncarnationId(incarnationId)) {
-            // Why: a recovered claim without process-incarnation proof cannot safely reject a delayed exit.
-            throw new Error('agent_session_ownership_unknown')
+    await visitPtyProcessListingsInBatches(
+      registeredPtyProviders(),
+      ({ provider }) => provider.listProcesses(),
+      ({ connectionId }, sessions) => {
+        for (const rawSession of sessions) {
+          const session = admission.admit(rawSession)
+          const incarnationId = session.incarnationId
+          let hasAdvertisedOwner = false
+          for (const owner of session.agentSessionOwners ?? []) {
+            if (owner.ptyId !== session.id || !isPtyIncarnationId(incarnationId)) {
+              // Why: a recovered claim without process-incarnation proof cannot safely reject a delayed exit.
+              throw new Error('agent_session_ownership_unknown')
+            }
+            advertisedOwners.push(owner)
+            hasAdvertisedOwner = true
           }
-          advertisedOwners.push(owner)
-          hasAdvertisedOwner = true
-        }
-        if (hasAdvertisedOwner && isPtyIncarnationId(incarnationId)) {
-          advertisedOwnerSessions.push({ id: session.id, connectionId, incarnationId })
+          if (hasAdvertisedOwner && isPtyIncarnationId(incarnationId)) {
+            advertisedOwnerSessions.push({ id: session.id, connectionId, incarnationId })
+          }
         }
       }
-    }
+    )
     agentSessionOwners.reconcileAuthoritative(advertisedOwners, {
       // Why: an unregistered relay can still own a live PTY during reconnect;
       // only providers that serialize claims may make listing absence authoritative.
@@ -1210,6 +1226,9 @@ function beginPtySpawnForWorktree(
 
 /** Register an SSH PTY provider for a connection. */
 export function registerSshPtyProvider(connectionId: string, provider: IPtyProvider): void {
+  if (!sshProviders.has(connectionId) && sshProviders.size >= MAX_REGISTERED_SSH_PTY_PROVIDERS) {
+    throw new Error('ssh_pty_provider_capacity')
+  }
   sshProviders.set(connectionId, provider)
 }
 
@@ -1711,6 +1730,7 @@ export function registerPtyHandlers(
     containsBackgroundOutput?: boolean
     // Why droppedOutput (not main's droppedBacklog trim): this branch's drop-to-sentinel + snapshot-restore supersedes #7630's 2MB-tail trim; both would race two cap policies over one buffer.
     droppedOutput?: true
+    upstreamCreditSpans?: PtyDeliveryCreditSpan[]
   }
 
   type PtyDataPayload = {
@@ -1723,9 +1743,15 @@ export function registerPtyHandlers(
     droppedOutput?: boolean
   }
 
-  const pendingData = new Map<string, PendingPtyData>()
+  const pendingData = new PendingPtyDataMap<PendingPtyData>(
+    (pending) => ({
+      chars: pending.data.length,
+      creditSpans: pending.upstreamCreditSpans?.length ?? 0
+    }),
+    rejectPendingPtyDataForRetentionPressure
+  )
   // Why: one restore marker per overflow episode — cleared on full drain so a later overflow re-marks exactly once.
-  const pendingOverflowMarkedPtys = new Set<string>()
+  const pendingOverflowMarkedPtys = new PtyRendererDeliveryIdSet()
   // Why: TCP-style cumulative accounting — monotonic sent/acked totals self-heal on any later ACK, where relative in-flight counters would make each lost ACK a permanent debt.
   type RendererPtyDeliveryAccounting = {
     sentChars: number
@@ -1733,7 +1759,9 @@ export function registerPtyHandlers(
     lastSendAtMs: number
     lastAckAtMs: number | null
   }
-  const rendererDeliveryAccountingByPty = new Map<string, RendererPtyDeliveryAccounting>()
+  const rendererDeliveryAccountingByPty =
+    new PtyRendererDeliveryAccountingMap<RendererPtyDeliveryAccounting>()
+  const rendererDeliveryCredit = new PtyRendererDeliveryCreditLedger()
   const trustedTerminalHandleEnv = new Set<string>()
   let flushTimer: ReturnType<typeof setTimeout> | null = null
   let rendererInFlightTotalChars = 0
@@ -2004,12 +2032,17 @@ export function registerPtyHandlers(
     rendererLifecycleResetCount += 1
     // Why release before clearing: pending bytes and credits belonged to the dead page; releasing producer pauses first keeps no shell wedged.
     producerFlowControl.releaseAll()
+    settleAllPendingUpstreamCredit()
+    rendererDeliveryCredit.writeOffAll((id, chars) => {
+      tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+    })
     clearDeliveryResyncProbe()
     deliveryResyncUnansweredWarnLogged = false
     rendererDeliveryAccountingByPty.clear()
     rendererInFlightTotalChars = 0
     pendingData.clear()
     pendingOverflowMarkedPtys.clear()
+    pendingDataDropWarnedPtys.clear()
     // Why hold sends: the reloading page's pty:data listener is gone until it re-registers/handshakes, so bytes would drop into a listener-less page and re-pin the gate.
     rendererPtyDispatcherReady = false
     // Why: arm the self-heal watchdog so a never-arriving handshake can't hold the gate forever; the real handshake cancels it.
@@ -2100,6 +2133,9 @@ export function registerPtyHandlers(
     accounting.ackedChars = nextAckedChars
     if (acknowledged > 0) {
       accounting.lastAckAtMs = Date.now()
+      rendererDeliveryCredit.acknowledge(id, acknowledged, (chars) => {
+        tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+      })
     }
     rendererInFlightTotalChars = Math.max(0, rendererInFlightTotalChars - acknowledged)
     return acknowledged
@@ -2160,11 +2196,11 @@ export function registerPtyHandlers(
       if (acknowledged <= 0) {
         continue
       }
-      tryGetProviderForPty(id)?.acknowledgeDataEvent(id, acknowledged)
       // Why drop pending: everything at/before markerSeq comes from the snapshot, so flushing pre-marker bytes would double-paint the restore.
       const pending = pendingData.get(id)
       if (pending) {
         pendingDroppedChars += pending.data.length
+        settlePendingPtyDataDelivery(id, pending)
         pendingData.delete(id)
         pendingOverflowMarkedPtys.delete(id)
         updateProducerFlowControl(id)
@@ -2193,20 +2229,30 @@ export function registerPtyHandlers(
     return writtenOff
   }
 
-  function sendPtyDataToRenderer(id: string, payload: PtyDataPayload): void {
+  function sendPtyDataToRenderer(
+    id: string,
+    payload: PtyDataPayload,
+    upstreamCredit?: PtyDeliveryCreditSpan[]
+  ): void {
     const charCount = getPtyPayloadCharCount(payload)
-    const accounting = rendererDeliveryAccountingByPty.get(id)
-    if (accounting) {
-      accounting.sentChars += charCount
-      accounting.lastSendAtMs = Date.now()
-    } else {
-      rendererDeliveryAccountingByPty.set(id, {
-        sentChars: charCount,
+    let accounting = rendererDeliveryAccountingByPty.get(id)
+    if (!accounting) {
+      accounting = {
+        sentChars: 0,
         ackedChars: 0,
         lastSendAtMs: Date.now(),
         lastAckAtMs: null
-      })
+      }
+      if (!rendererDeliveryAccountingByPty.admit(id, accounting)) {
+        rejectSentPtyDataForRetentionPressure(id, payload, upstreamCredit)
+        return
+      }
     }
+    rendererDeliveryCredit.recordSent(id, charCount, upstreamCredit, (chars) => {
+      tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+    })
+    accounting.sentChars += charCount
+    accounting.lastSendAtMs = Date.now()
     rendererInFlightTotalChars += charCount
     recordPtyRendererDeliveryPressure()
     mainWindow.webContents.send('pty:data', payload)
@@ -2269,7 +2315,47 @@ export function registerPtyHandlers(
     return [...active, ...background]
   }
 
-  const pendingDataDropWarnedPtys = new Set<string>()
+  const pendingDataDropWarnedPtys = new PtyRendererDeliveryIdSet()
+
+  function markPtyRendererDeliveryDropped(id: string, droppedChars: number, detail: string): void {
+    pendingDroppedChars += droppedChars
+    if (pendingOverflowMarkedPtys.remember(id)) {
+      sendModelRestoreNeededMarker(id, 'pending-cap', runtime?.getPtyOutputSequence(id))
+    }
+    if (!pendingDataDropWarnedPtys.remember(id)) {
+      return
+    }
+    console.error(`[pty] dropped ${droppedChars} buffered chars: ${detail}`)
+    recordCrashBreadcrumb('terminal_pending_output_dropped', {
+      droppedChars,
+      capChars: pendingDataCapChars()
+    })
+  }
+
+  function rejectPendingPtyDataForRetentionPressure(id: string, pending: PendingPtyData): void {
+    settlePendingPtyDataDelivery(id, pending)
+    producerFlowControl.release(id)
+    markPtyRendererDeliveryDropped(
+      id,
+      pending.data.length,
+      'aggregate renderer pending-output retention limit exceeded; pane will restore from the main-owned snapshot'
+    )
+  }
+
+  function rejectSentPtyDataForRetentionPressure(
+    id: string,
+    payload: PtyDataPayload,
+    upstreamCredit: PtyDeliveryCreditSpan[] | undefined
+  ): void {
+    settleRejectedPtyRendererDelivery(getPtyPayloadCharCount(payload), upstreamCredit, (chars) =>
+      tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+    )
+    markPtyRendererDeliveryDropped(
+      id,
+      payload.data.length,
+      'aggregate renderer delivery-accounting limit exceeded; pane will restore from the main-owned snapshot'
+    )
+  }
 
   // Why capped: keeps O(1) memory per PTY; salvaged query bytes are tiny, so past the cap a pathological stream can degrade to the plain sentinel.
   const DROPPED_QUERY_SALVAGE_MAX_CHARS = 4096
@@ -2288,8 +2374,7 @@ export function registerPtyHandlers(
     if (pending.droppedOutput === true || pending.data.length <= capChars) {
       return pending
     }
-    if (!pendingDataDropWarnedPtys.has(id)) {
-      pendingDataDropWarnedPtys.add(id)
+    if (pendingDataDropWarnedPtys.remember(id)) {
       console.error(
         `[pty] dropped ${pending.data.length} buffered chars for ${id}: renderer not receiving and per-PTY pending cap exceeded; pane will restore from the main-owned snapshot`
       )
@@ -2300,11 +2385,11 @@ export function registerPtyHandlers(
       })
     }
     // Why the marker: the snapshot can recover the dropped middle; emit it once per overflow episode so a fresh or reloaded view latches restore too.
-    if (isHiddenPtyDeliveryGateEnabled(getSettings?.()) && !pendingOverflowMarkedPtys.has(id)) {
-      pendingOverflowMarkedPtys.add(id)
+    if (isHiddenPtyDeliveryGateEnabled(getSettings?.()) && pendingOverflowMarkedPtys.remember(id)) {
       sendModelRestoreNeededMarker(id, 'pending-cap', runtime?.getPtyOutputSequence(id))
     }
     pendingDroppedChars += pending.data.length
+    settlePendingPtyDataDelivery(id, pending)
     // Why no trimmed content tail: a mid-stream gap would corrupt the pane; the droppedOutput sentinel repaints from the snapshot and realigns by sequence (only query bytes ride along).
     return {
       data: extractDroppedPtyQueryBytes(pending.data).slice(0, DROPPED_QUERY_SALVAGE_MAX_CHARS),
@@ -2320,10 +2405,16 @@ export function registerPtyHandlers(
     preservesSeq: boolean,
     containsBackgroundOutput: boolean,
     rawLength = data.length,
-    transformed = false
+    transformed = false,
+    upstreamCredit?: PtyDataEvent['upstreamCredit']
   ): PendingPtyData {
     // Why stay dropped at O(1): once over the cap the restore sentinel supersedes interim bytes; queries still get carved out (bounded) so replies survive the whole episode.
     if (existing?.droppedOutput === true) {
+      settleRejectedPtyRendererDelivery(
+        rawLength,
+        appendPtyDeliveryCredit(undefined, upstreamCredit),
+        (chars) => tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+      )
       if (existing.data.length >= DROPPED_QUERY_SALVAGE_MAX_CHARS) {
         return existing
       }
@@ -2338,16 +2429,24 @@ export function registerPtyHandlers(
         ...(typeof startSeq === 'number' ? { startSeq } : {}),
         ...(rawLength !== data.length ? { rawLength } : {}),
         ...(transformed ? { transformed: true } : {}),
-        ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {})
+        ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {}),
+        ...(upstreamCredit
+          ? { upstreamCreditSpans: appendPtyDeliveryCredit(undefined, upstreamCredit) }
+          : {})
       })
     }
     const existingRawLength = existing.rawLength ?? existing.data.length
+    const upstreamCreditSpans = appendPtyDeliveryCredit(
+      existing.upstreamCreditSpans,
+      upstreamCredit
+    )
     const next: PendingPtyData = {
       data: existing.data + data,
       ...(!preservesSeq || existing.transformed || transformed
         ? { rawLength: existingRawLength + rawLength, transformed: true as const }
         : {}),
-      ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {})
+      ...(nextContainsBackgroundOutput ? { containsBackgroundOutput: true } : {}),
+      ...(upstreamCreditSpans ? { upstreamCreditSpans } : {})
     }
     if (typeof existing.startSeq === 'number') {
       next.startSeq = existing.startSeq
@@ -2392,9 +2491,14 @@ export function registerPtyHandlers(
     if (mainWindow.isDestroyed()) {
       // Why release now: bookkeeping is being wiped, so no future drain can resume these producers — local shells would wedge.
       producerFlowControl.releaseAll()
+      settleAllPendingUpstreamCredit()
+      rendererDeliveryCredit.writeOffAll((id, chars) => {
+        tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+      })
       clearDeliveryResyncProbe()
       pendingData.clear()
       pendingOverflowMarkedPtys.clear()
+      pendingDataDropWarnedPtys.clear()
       rendererDeliveryAccountingByPty.clear()
       rendererInFlightTotalChars = 0
       clearDispatcherReadyWatchdog()
@@ -2414,6 +2518,7 @@ export function registerPtyHandlers(
       // Why drop, never re-queue: the model already ingested hidden-gated bytes; reveal restores from the snapshot+seq machinery.
       if (shouldDropHiddenRendererPtyData(id, settings)) {
         pendingData.delete(id)
+        settlePendingPtyDataDelivery(id, pending)
         pendingOverflowMarkedPtys.delete(id)
         updateProducerFlowControl(id)
         const drop = recordHiddenRendererPtyDataDrop(id, pending.data.length)
@@ -2438,6 +2543,8 @@ export function registerPtyHandlers(
       const indivisible = pending.transformed === true
       const chunk = indivisible ? data : data.slice(0, PTY_BATCH_FLUSH_CHUNK_CHARS)
       const remaining = indivisible ? '' : data.slice(PTY_BATCH_FLUSH_CHUNK_CHARS)
+      const chunkRawLength = indivisible ? (pending.rawLength ?? chunk.length) : chunk.length
+      const upstreamCredit = takePtyDeliveryCredit(pending.upstreamCreditSpans, chunkRawLength)
       if (remaining) {
         const nextPending: PendingPtyData = { data: remaining }
         if (typeof pending.startSeq === 'number') {
@@ -2445,6 +2552,9 @@ export function registerPtyHandlers(
         }
         if (pending.containsBackgroundOutput === true) {
           nextPending.containsBackgroundOutput = true
+        }
+        if (pending.upstreamCreditSpans?.length) {
+          nextPending.upstreamCreditSpans = pending.upstreamCreditSpans
         }
         pendingData.set(id, nextPending)
       } else {
@@ -2460,7 +2570,8 @@ export function registerPtyHandlers(
           pending.containsBackgroundOutput,
           pending.rawLength,
           pending.transformed
-        )
+        ),
+        upstreamCredit
       )
       writes++
     }
@@ -2480,6 +2591,24 @@ export function registerPtyHandlers(
     }
     clearTimeout(flushTimer)
     flushTimer = null
+  }
+
+  function settleAllPendingUpstreamCredit(): void {
+    for (const [id, pending] of pendingData) {
+      settlePendingPtyDataDelivery(id, pending)
+    }
+  }
+
+  function settlePendingPtyDataDelivery(id: string, pending: PendingPtyData): void {
+    if (pending.droppedOutput === true) {
+      settlePtyDeliveryCredit(pending.upstreamCreditSpans)
+      return
+    }
+    settleRejectedPtyRendererDelivery(
+      pending.rawLength ?? pending.data.length,
+      pending.upstreamCreditSpans,
+      (chars) => tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+    )
   }
 
   const syntheticKillExitPtyIds = new Map<string, NodeJS.Timeout>()
@@ -2510,12 +2639,27 @@ export function registerPtyHandlers(
 
   function sendPtyExitToRenderer(payload: { id: string; code: number }): void {
     if (mainWindow.isDestroyed()) {
+      const pending = pendingData.get(payload.id)
+      if (pending) {
+        settlePendingPtyDataDelivery(payload.id, pending)
+      }
+      pendingData.delete(payload.id)
+      pendingDataDropWarnedPtys.delete(payload.id)
+      rendererDeliveryCredit.writeOff(payload.id, (chars) => {
+        tryGetProviderForPty(payload.id)?.acknowledgeDataEvent(payload.id, chars)
+      })
+      rendererInFlightTotalChars = Math.max(
+        0,
+        rendererInFlightTotalChars - getRendererInFlightCharsForPty(payload.id)
+      )
+      rendererDeliveryAccountingByPty.delete(payload.id)
       return
     }
     // Why flush before exit: the renderer tears down the terminal on pty:exit, so any batched output not yet flushed would be silently lost.
     const remaining = pendingData.get(payload.id)
     if (remaining) {
       if (remaining.droppedOutput === true) {
+        settlePendingPtyDataDelivery(payload.id, remaining)
         // Sentinel entry: only salvaged query bytes remain; keep the flag so the renderer knows the span was dropped.
         sendPtyDataToRenderer(payload.id, {
           id: payload.id,
@@ -2523,6 +2667,11 @@ export function registerPtyHandlers(
           droppedOutput: true
         })
       } else {
+        const upstreamCredit = takePtyDeliveryCredit(
+          remaining.upstreamCreditSpans,
+          remaining.rawLength ?? remaining.data.length
+        )
+        settlePtyDeliveryCredit(remaining.upstreamCreditSpans)
         sendPtyDataToRenderer(
           payload.id,
           makePtyDataPayload(
@@ -2532,7 +2681,8 @@ export function registerPtyHandlers(
             remaining.containsBackgroundOutput,
             remaining.rawLength,
             remaining.transformed
-          )
+          ),
+          upstreamCredit
         )
       }
       pendingData.delete(payload.id)
@@ -2540,6 +2690,7 @@ export function registerPtyHandlers(
     // Why resume a dead PTY (no-op): avoid leaving a stale paused mark behind for a reused id.
     producerFlowControl.release(payload.id)
     pendingOverflowMarkedPtys.delete(payload.id)
+    pendingDataDropWarnedPtys.delete(payload.id)
     lastInputAtByPty.delete(payload.id)
     interactiveOutputCharsByPty.delete(payload.id)
     rendererInFlightTotalChars = Math.max(
@@ -2548,6 +2699,9 @@ export function registerPtyHandlers(
     )
     // Why: the renderer also drops its cumulative total on pty:exit, so a reused id restarts aligned at zero on both sides.
     rendererDeliveryAccountingByPty.delete(payload.id)
+    rendererDeliveryCredit.writeOff(payload.id, (chars) => {
+      tryGetProviderForPty(payload.id)?.acknowledgeDataEvent(payload.id, chars)
+    })
     recordPtyRendererDeliveryPressure()
     mainWindow.webContents.send('pty:exit', {
       ...payload,
@@ -2558,6 +2712,20 @@ export function registerPtyHandlers(
   function sendPtySpawnedToRenderer(id: string): void {
     if (!mainWindow.isDestroyed()) {
       mainWindow.webContents.send('pty:spawned', { id })
+    }
+  }
+
+  function sendPtyReplayToRenderer(payload: { id: string; data: string }): void {
+    const pending = pendingData.get(payload.id)
+    if (pending) {
+      settlePendingPtyDataDelivery(payload.id, pending)
+      pendingData.delete(payload.id)
+      pendingOverflowMarkedPtys.delete(payload.id)
+      updateProducerFlowControl(payload.id)
+      clearFlushTimerIfIdle()
+    }
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('pty:replay', payload)
     }
   }
 
@@ -2583,6 +2751,144 @@ export function registerPtyHandlers(
     }
     return providerExitObserved
   }
+
+  function routeProviderData(payload: PtyDataEvent, runtimeAlreadyIngested: boolean): void {
+    const rawLength = payload.sequenceChars ?? payload.data.length
+    const outputSeq = runtimeAlreadyIngested
+      ? runtime?.getPtyOutputSequence(payload.id)
+      : runtime?.onPtyData(payload.id, payload.data, Date.now(), rawLength, payload.transformed)
+    const rendererData = payload.data
+    const preservesSeq = !payload.transformed && rawLength === payload.data.length
+    const startSeq = typeof outputSeq === 'number' ? Math.max(0, outputSeq - rawLength) : undefined
+    if (mainWindow.isDestroyed()) {
+      // Why clear the flush timer: macOS app re-activation otherwise leaks orphaned timers from the previous window's registration.
+      if (flushTimer) {
+        clearTimeout(flushTimer)
+        flushTimer = null
+      }
+      producerFlowControl.releaseAll()
+      settleRejectedPtyRendererDelivery(
+        rawLength,
+        appendPtyDeliveryCredit(undefined, payload.upstreamCredit),
+        (chars) => tryGetProviderForPty(payload.id)?.acknowledgeDataEvent(payload.id, chars)
+      )
+      settleAllPendingUpstreamCredit()
+      rendererDeliveryCredit.writeOffAll((id, chars) => {
+        tryGetProviderForPty(id)?.acknowledgeDataEvent(id, chars)
+      })
+      clearDeliveryResyncProbe()
+      pendingData.clear()
+      pendingOverflowMarkedPtys.clear()
+      pendingDataDropWarnedPtys.clear()
+      rendererDeliveryAccountingByPty.clear()
+      rendererInFlightTotalChars = 0
+      clearDispatcherReadyWatchdog()
+      recordPtyRendererDeliveryPressure()
+      return
+    }
+    const settings = getSettings?.()
+    // Why drop before the interactive bypass: runtime already ingested the chunk, so gated PTYs skip both renderer paths and reveal restores from the snapshot.
+    if (shouldDropHiddenRendererPtyData(payload.id, settings)) {
+      settleRejectedPtyRendererDelivery(
+        rawLength,
+        appendPtyDeliveryCredit(undefined, payload.upstreamCredit),
+        (chars) => tryGetProviderForPty(payload.id)?.acknowledgeDataEvent(payload.id, chars)
+      )
+      const drop = recordHiddenRendererPtyDataDrop(payload.id, payload.data.length)
+      warnIfDroppingHiddenBytesForVisiblePty(payload.id, payload.data.length)
+      if (drop.shouldEmitRestoreMarker) {
+        sendModelRestoreNeededMarker(payload.id, 'hidden-drop', outputSeq)
+      }
+      return
+    }
+    if (rendererData.length === 0 && !payload.transformed) {
+      settleRejectedPtyRendererDelivery(
+        rawLength,
+        appendPtyDeliveryCredit(undefined, payload.upstreamCredit),
+        (chars) => tryGetProviderForPty(payload.id)?.acknowledgeDataEvent(payload.id, chars)
+      )
+      return
+    }
+    const containsBackgroundOutput =
+      rendererPtyIsKnownHidden(payload.id) || ptyHasHiddenRendererResizeOutput(payload.id)
+    if (containsBackgroundOutput) {
+      markHiddenRendererResizeOutputDelivered(payload.id)
+    }
+    const existing = pendingData.get(payload.id)
+    const pending = appendPendingPtyData(
+      payload.id,
+      existing,
+      rendererData,
+      startSeq,
+      preservesSeq,
+      containsBackgroundOutput,
+      rawLength,
+      payload.transformed === true,
+      payload.upstreamCredit
+    )
+    const nextData = pending.data
+    const isInteractiveOutput = shouldSendInteractiveOutputNow(
+      payload.id,
+      nextData,
+      performance.now()
+    )
+    // Why gate the fast path on the handshake too: else boot-window keystroke echo is sent into a listener-less page and pins the gate.
+    if (isInteractiveOutput && rendererPtyDispatcherReady) {
+      // Why the reserve: keep input echo from being pinned behind unrelated bulk output; it's bounded and the per-PTY cap still prevents an active TUI runaway.
+      if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
+        requestDeliveryResyncForGatedPty()
+        pendingData.set(payload.id, pending)
+        updateProducerFlowControl(payload.id)
+        recordPtyRendererDeliveryPressure()
+        return
+      }
+      pendingData.delete(payload.id)
+      updateProducerFlowControl(payload.id)
+      pendingOverflowMarkedPtys.delete(payload.id)
+      clearFlushTimerIfIdle()
+      const upstreamCredit = takePtyDeliveryCredit(
+        pending.upstreamCreditSpans,
+        pending.rawLength ?? nextData.length
+      )
+      // Why immediate: agent TUIs redraw small prompt regions per keystroke; the throughput batch timer would add visible input latency.
+      sendPtyDataToRenderer(
+        payload.id,
+        {
+          id: payload.id,
+          data: nextData,
+          ...(typeof pending.startSeq === 'number'
+            ? {
+                seq: pending.startSeq + (pending.rawLength ?? nextData.length),
+                rawLength: pending.rawLength ?? nextData.length
+              }
+            : {}),
+          ...(pending.transformed ? { transformed: true } : {}),
+          ...(pending.containsBackgroundOutput === true ? { background: true } : {}),
+          ...(pending.droppedOutput === true ? { droppedOutput: true } : {})
+        },
+        upstreamCredit
+      )
+      return
+    }
+    pendingData.set(payload.id, pending)
+    updateProducerFlowControl(payload.id)
+    recordPtyRendererDeliveryPressure()
+    // Why probe on data arrival (not flush skips): new output for a fully gated PTY is the moment stuck delivery becomes observable.
+    if (
+      !canSendPtyDataToRenderer(payload.id, { interactive: activeRendererPtys.has(payload.id) })
+    ) {
+      requestDeliveryResyncForGatedPty()
+    }
+    if (!flushTimer) {
+      schedulePendingDataFlush(PTY_BATCH_INTERVAL_MS)
+    }
+  }
+
+  installExternalPtyRendererDeliveryRouter({
+    data: (payload) => routeProviderData(payload, false),
+    replay: sendPtyReplayToRenderer,
+    exit: sendPtyExitToRenderer
+  })
 
   // Why extracted: the "Restart daemon" flow rebinds against the fresh adapter after replaceDaemonProvider, sharing this code path with startup registration.
   const bindProviderListeners = (): void => {
@@ -2617,109 +2923,7 @@ export function registerPtyHandlers(
     // Why: daemon providers lack configure().onData, so feed the runtime here or their tail buffer (terminal.read, agent-detection, mobile stream) stays empty.
     const isLocalProvider = localProvider instanceof LocalPtyProvider
 
-    localDataUnsub = localProvider.onData((payload) => {
-      const rawLength = payload.sequenceChars ?? payload.data.length
-      const outputSeq = isLocalProvider
-        ? runtime?.getPtyOutputSequence(payload.id)
-        : runtime?.onPtyData(payload.id, payload.data, Date.now(), rawLength, payload.transformed)
-      const rendererData = payload.data
-      const preservesSeq = !payload.transformed && rawLength === payload.data.length
-      const startSeq =
-        typeof outputSeq === 'number' ? Math.max(0, outputSeq - rawLength) : undefined
-      if (mainWindow.isDestroyed()) {
-        // Why clear the flush timer: macOS app re-activation otherwise leaks orphaned timers from the previous window's registration.
-        if (flushTimer) {
-          clearTimeout(flushTimer)
-          flushTimer = null
-        }
-        producerFlowControl.releaseAll()
-        clearDeliveryResyncProbe()
-        pendingData.clear()
-        pendingOverflowMarkedPtys.clear()
-        rendererDeliveryAccountingByPty.clear()
-        rendererInFlightTotalChars = 0
-        clearDispatcherReadyWatchdog()
-        recordPtyRendererDeliveryPressure()
-        return
-      }
-      const settings = getSettings?.()
-      // Why drop before the interactive bypass: runtime already ingested the chunk, so gated PTYs skip both renderer paths and reveal restores from the snapshot.
-      if (shouldDropHiddenRendererPtyData(payload.id, settings)) {
-        const drop = recordHiddenRendererPtyDataDrop(payload.id, payload.data.length)
-        warnIfDroppingHiddenBytesForVisiblePty(payload.id, payload.data.length)
-        if (drop.shouldEmitRestoreMarker) {
-          sendModelRestoreNeededMarker(payload.id, 'hidden-drop', outputSeq)
-        }
-        return
-      }
-      if (rendererData.length === 0 && !payload.transformed) {
-        return
-      }
-      const containsBackgroundOutput =
-        rendererPtyIsKnownHidden(payload.id) || ptyHasHiddenRendererResizeOutput(payload.id)
-      if (containsBackgroundOutput) {
-        markHiddenRendererResizeOutputDelivered(payload.id)
-      }
-      const existing = pendingData.get(payload.id)
-      const pending = appendPendingPtyData(
-        payload.id,
-        existing,
-        rendererData,
-        startSeq,
-        preservesSeq,
-        containsBackgroundOutput,
-        rawLength,
-        payload.transformed === true
-      )
-      const nextData = pending.data
-      const isInteractiveOutput = shouldSendInteractiveOutputNow(
-        payload.id,
-        nextData,
-        performance.now()
-      )
-      // Why gate the fast path on the handshake too: else boot-window keystroke echo is sent into a listener-less page and pins the gate.
-      if (isInteractiveOutput && rendererPtyDispatcherReady) {
-        // Why the reserve: keep input echo from being pinned behind unrelated bulk output; it's bounded and the per-PTY cap still prevents an active TUI runaway.
-        if (!canSendPtyDataToRenderer(payload.id, { interactive: true })) {
-          requestDeliveryResyncForGatedPty()
-          pendingData.set(payload.id, pending)
-          updateProducerFlowControl(payload.id)
-          recordPtyRendererDeliveryPressure()
-          return
-        }
-        pendingData.delete(payload.id)
-        updateProducerFlowControl(payload.id)
-        pendingOverflowMarkedPtys.delete(payload.id)
-        clearFlushTimerIfIdle()
-        // Why immediate: agent TUIs redraw small prompt regions per keystroke; the throughput batch timer would add visible input latency.
-        sendPtyDataToRenderer(payload.id, {
-          id: payload.id,
-          data: nextData,
-          ...(typeof pending.startSeq === 'number'
-            ? {
-                seq: pending.startSeq + (pending.rawLength ?? nextData.length),
-                rawLength: pending.rawLength ?? nextData.length
-              }
-            : {}),
-          ...(pending.transformed ? { transformed: true } : {}),
-          ...(pending.containsBackgroundOutput === true ? { background: true } : {}),
-          ...(pending.droppedOutput === true ? { droppedOutput: true } : {})
-        })
-        return
-      }
-      pendingData.set(payload.id, pending)
-      updateProducerFlowControl(payload.id)
-      recordPtyRendererDeliveryPressure()
-      // Why probe on data arrival (not flush skips): new output for a fully gated PTY is the moment stuck delivery becomes observable.
-      if (
-        !canSendPtyDataToRenderer(payload.id, { interactive: activeRendererPtys.has(payload.id) })
-      ) {
-        requestDeliveryResyncForGatedPty()
-      }
-      if (!flushTimer) {
-        schedulePendingDataFlush(PTY_BATCH_INTERVAL_MS)
-      }
-    })
+    localDataUnsub = localProvider.onData((payload) => routeProviderData(payload, isLocalProvider))
     localExitUnsub = localProvider.onExit((payload) => {
       if (!isCurrentPtyExit(payload)) {
         return
@@ -3821,11 +4025,18 @@ export function registerPtyHandlers(
       }
     },
     listProcesses: async () => {
-      const providerSessions = await Promise.all([
-        localProvider.listProcesses(),
-        ...Array.from(sshProviders.values(), (provider) => provider.listProcesses())
-      ])
-      return providerSessions.flat()
+      const processes: PtyProcessInfo[] = []
+      const admission = new PtyProcessListAdmission()
+      await visitPtyProcessListingsInBatches(
+        registeredPtyProviders(),
+        ({ provider }) => provider.listProcesses(),
+        (_source, listing) => {
+          for (const process of listing) {
+            processes.push(admission.admit(process))
+          }
+        }
+      )
+      return processes
     },
     serializeBuffer: (ptyId, opts) => {
       // Why: mobile xterm must start from the desktop's exact screen state/dimensions before live TUI chunks render correctly.
@@ -5023,9 +5234,14 @@ export function registerPtyHandlers(
         // Why: tolerate legacy per-chunk delta payloads — dev hot-reload can pair an old renderer with a new main.
         const accounting = rendererDeliveryAccountingByPty.get(args.id)
         const delta = Number.isFinite(args.charCount) ? Math.max(0, args.charCount ?? 0) : 0
-        acknowledged = accounting ? applyCumulativeAck(args.id, accounting.ackedChars + delta) : 0
+        if (accounting) {
+          acknowledged = applyCumulativeAck(args.id, accounting.ackedChars + delta)
+        }
       }
-      tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, acknowledged)
+      // Why preserve the zero callback: legacy providers observe every renderer ACK, while captured token owners still receive only their exact positive credit above.
+      if (acknowledged === 0) {
+        tryGetProviderForPty(args.id)?.acknowledgeDataEvent(args.id, 0)
+      }
       recordPtyRendererDeliveryPressure()
       if (pendingData.size > 0 && !flushTimer) {
         schedulePendingDataFlush(0)
@@ -5049,10 +5265,7 @@ export function registerPtyHandlers(
         if (typeof processedChars !== 'number' || !Number.isFinite(processedChars)) {
           continue
         }
-        const acknowledged = applyCumulativeAck(id, Math.max(0, processedChars))
-        if (acknowledged > 0) {
-          tryGetProviderForPty(id)?.acknowledgeDataEvent(id, acknowledged)
-        }
+        applyCumulativeAck(id, Math.max(0, processedChars))
       }
       recordPtyRendererDeliveryPressure()
       if (pendingData.size > 0 && !flushTimer) {
@@ -5070,10 +5283,7 @@ export function registerPtyHandlers(
         if (typeof processedChars !== 'number' || !Number.isFinite(processedChars)) {
           continue
         }
-        const acknowledged = applyCumulativeAck(id, Math.max(0, processedChars))
-        if (acknowledged > 0) {
-          tryGetProviderForPty(id)?.acknowledgeDataEvent(id, acknowledged)
-        }
+        applyCumulativeAck(id, Math.max(0, processedChars))
       }
       let writtenOff: PtyDeliveryWriteOff[] = []
       // Why the main-side ACK-silence check: requiring main to have also seen no ACK stops a buggy/foreign caller from writing off live delivery.
@@ -5168,6 +5378,7 @@ export function registerPtyHandlers(
       const pending = pendingData.get(args.id)
       if (pending && shouldDropHiddenRendererPtyData(args.id, getSettings?.())) {
         pendingData.delete(args.id)
+        settlePendingPtyDataDelivery(args.id, pending)
         updateProducerFlowControl(args.id)
         pendingOverflowMarkedPtys.delete(args.id)
         const drop = recordHiddenRendererPtyDataDrop(args.id, pending.data.length)

--- a/src/main/ipc/remote-workspace.test.ts
+++ b/src/main/ipc/remote-workspace.test.ts
@@ -36,6 +36,7 @@ vi.mock('./remote-workspace-events', () => ({
 
 import {
   _resetRemoteWorkspaceCachesForTests,
+  REMOTE_WORKSPACE_PATCH_CONCURRENCY,
   registerRemoteWorkspaceHandlers,
   remoteWorkspaceSessionMatchesSnapshot
 } from './remote-workspace'
@@ -262,6 +263,66 @@ describe('remoteWorkspace:setForConnectedTargets', () => {
       })
     )
     expect(requestByTargetId.get('target-2')).toBeUndefined()
+  })
+
+  it.each([
+    ['at the limit', REMOTE_WORKSPACE_PATCH_CONCURRENCY],
+    ['above the limit', REMOTE_WORKSPACE_PATCH_CONCURRENCY + 1]
+  ])('bounds per-target workspace patches %s', async (_, count) => {
+    const manyTargets: SshTarget[] = Array.from({ length: count }, (_, index) => ({
+      id: `target-${index}`,
+      label: `Target ${index}`,
+      host: `${index}.example.com`,
+      port: 22,
+      username: 'alice'
+    }))
+    getSshConnectionStoreMock.mockReturnValue({ listTargets: () => manyTargets })
+    let active = 0
+    let peak = 0
+    let started = 0
+    const releases: (() => void)[] = []
+    getActiveMultiplexerMock.mockImplementation(() => ({
+      request: async (method: string) => {
+        if (method === 'workspace.get') {
+          started++
+          active++
+          peak = Math.max(peak, active)
+          await new Promise<void>((resolve) => releases.push(resolve))
+          active--
+          return snapshot({
+            activeWorktreePath: '/previous',
+            activeTabId: null,
+            tabsByWorktreePath: {},
+            terminalLayoutsByTabId: {}
+          })
+        }
+        return {
+          ok: true,
+          snapshot: snapshot({
+            activeWorktreePath: null,
+            activeTabId: null,
+            tabsByWorktreePath: {},
+            terminalLayoutsByTabId: {}
+          })
+        }
+      }
+    }))
+
+    const patches = callSetForConnectedTargets({
+      session: baseSession,
+      hydratedTargetIds: manyTargets.map((target) => target.id)
+    })
+    await vi.waitFor(() =>
+      expect(started).toBe(Math.min(count, REMOTE_WORKSPACE_PATCH_CONCURRENCY))
+    )
+    if (count > REMOTE_WORKSPACE_PATCH_CONCURRENCY) {
+      releases.shift()?.()
+      await vi.waitFor(() => expect(started).toBe(count))
+    }
+    releases.splice(0).forEach((release) => release())
+
+    await expect(patches).resolves.toHaveLength(count)
+    expect(peak).toBe(Math.min(count, REMOTE_WORKSPACE_PATCH_CONCURRENCY))
   })
 
   it('can export from the persisted store session when no session argument is provided', async () => {

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -16,6 +16,7 @@ import type {
 import type { SshTarget } from '../../shared/ssh-types'
 import type { WorkspaceSessionState } from '../../shared/types'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
+import { mapWithConcurrency } from '../../shared/map-with-concurrency'
 import { getRemoteWorkspaceNamespace } from './remote-workspace-namespace'
 import { registerRemoteWorkspaceNotificationHandler } from './remote-workspace-events'
 
@@ -23,6 +24,7 @@ const CLIENT_ID = randomUUID()
 const CLIENT_NAME = hostname() || 'This device'
 const SNAPSHOT_SCHEMA_VERSION = 1
 export const REMOTE_WORKSPACE_SNAPSHOT_CACHE_MAX_ENTRIES = 64
+export const REMOTE_WORKSPACE_PATCH_CONCURRENCY = 4
 
 let mainWindowGetter: (() => BrowserWindow | null) | null = null
 const latestSnapshotByTargetId = new Map<string, RemoteWorkspaceSnapshot>()
@@ -420,8 +422,10 @@ export function registerRemoteWorkspaceHandlers(
           ) ?? []
 
       const workspaceSession = args.session ?? store.getWorkspaceSession()
-      const results = await Promise.all(
-        targets.map(async (target) => {
+      const results = await mapWithConcurrency(
+        targets,
+        REMOTE_WORKSPACE_PATCH_CONCURRENCY,
+        async (target) => {
           // Why: each target has its own revision stream. Keep same-target
           // writes queued, but do not let one slow relay block others.
           const session = exportSessionForTarget(store, target.id, workspaceSession)
@@ -429,7 +433,7 @@ export function registerRemoteWorkspaceHandlers(
             patchRemoteWorkspaceSession(target, session)
           )
           return result ? { targetId: target.id, result } : null
-        })
+        }
       )
       return results.filter(
         (entry): entry is { targetId: string; result: RemoteWorkspacePatchResult } => entry !== null

--- a/src/main/ipc/runtime-environment-call-queue.ts
+++ b/src/main/ipc/runtime-environment-call-queue.ts
@@ -5,7 +5,8 @@ const runtimeCallQueuePool = new RuntimeRpcCallQueuePool()
 export function enqueueRuntimeCall<T>(
   selector: string,
   method: string,
-  run: () => Promise<T>
+  run: () => Promise<T>,
+  retainedBytes = 0
 ): Promise<T> {
-  return runtimeCallQueuePool.enqueue(selector, method, run)
+  return runtimeCallQueuePool.enqueue(selector, method, run, retainedBytes)
 }

--- a/src/main/ipc/runtime-environment-shared-control-support.ts
+++ b/src/main/ipc/runtime-environment-shared-control-support.ts
@@ -1,0 +1,81 @@
+import { REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY } from '../../shared/protocol-version'
+import { sendRemoteRuntimeRequest } from '../../shared/remote-runtime-client'
+import { markEnvironmentUsed } from '../../shared/runtime-environment-store'
+import type {
+  getPreferredPairingOffer,
+  KnownRuntimeEnvironment
+} from '../../shared/runtime-environments'
+import type { RuntimeStatus } from '../../shared/runtime-types'
+
+const sharedControlSupport = new Map<string, { cacheKey: string; check: Promise<boolean> }>()
+
+export function resetSharedControlSupport(): void {
+  sharedControlSupport.clear()
+}
+
+export function clearSharedControlSupport(environmentId: string): void {
+  sharedControlSupport.delete(environmentId)
+}
+
+export async function supportsSharedControl(
+  userDataPath: string,
+  environment: KnownRuntimeEnvironment,
+  pairing: ReturnType<typeof getPreferredPairingOffer>,
+  timeoutMs: number
+): Promise<boolean> {
+  const cacheKey = getSharedControlSupportCacheKey(environment, pairing)
+  const cached = sharedControlSupport.get(environment.id)
+  if (cached?.cacheKey === cacheKey) {
+    return cached.check
+  }
+  let resolvedCacheKey = cacheKey
+  const check = (async () => {
+    const response = await sendRemoteRuntimeRequest<RuntimeStatus>(
+      pairing,
+      'status.get',
+      undefined,
+      timeoutMs
+    )
+    if (response.ok === true) {
+      markEnvironmentUsed(userDataPath, environment.id, { runtimeId: response._meta.runtimeId })
+      resolvedCacheKey = getSharedControlSupportCacheKey(
+        environment,
+        pairing,
+        response._meta.runtimeId
+      )
+      return (
+        response.result.capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY) === true
+      )
+    }
+    return false
+  })()
+  // Why: the same saved host can be re-paired or point at a different runtime
+  // binary over time; capability support belongs to that pairing/runtime identity.
+  sharedControlSupport.set(environment.id, { cacheKey, check })
+  try {
+    const supported = await check
+    const cachedAfterCheck = sharedControlSupport.get(environment.id)
+    if (cachedAfterCheck?.check === check && cachedAfterCheck.cacheKey !== resolvedCacheKey) {
+      sharedControlSupport.set(environment.id, { cacheKey: resolvedCacheKey, check })
+    }
+    return supported
+  } catch (error) {
+    if (sharedControlSupport.get(environment.id)?.check === check) {
+      sharedControlSupport.delete(environment.id)
+    }
+    throw error
+  }
+}
+
+function getSharedControlSupportCacheKey(
+  environment: KnownRuntimeEnvironment,
+  pairing: ReturnType<typeof getPreferredPairingOffer>,
+  runtimeId = environment.runtimeId
+): string {
+  return [
+    runtimeId ?? 'unknown-runtime',
+    pairing.endpoint,
+    pairing.deviceToken,
+    pairing.publicKeyB64
+  ].join('\0')
+}

--- a/src/main/ipc/runtime-environment-subscription-admission.test.ts
+++ b/src/main/ipc/runtime-environment-subscription-admission.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES,
+  REMOTE_RUNTIME_MAX_SUBSCRIPTION_ID_BYTES,
+  REMOTE_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES,
+  REMOTE_RUNTIME_MAX_SUBSCRIPTIONS
+} from '../../shared/remote-runtime-memory-limits'
+import { createRuntimeEnvironmentSubscriptionAdmission } from './runtime-environment-subscription-admission'
+
+describe('runtime environment subscription admission', () => {
+  it('caps pending and active subscriptions, then recovers after release', () => {
+    const admission = createRuntimeEnvironmentSubscriptionAdmission()
+    const releases = Array.from({ length: REMOTE_RUNTIME_MAX_SUBSCRIPTIONS }, (_value, index) =>
+      admission.claim(`subscription-${index}`, undefined)
+    )
+
+    expect(admission.evidence()).toEqual({
+      retainedBytes: 0,
+      subscriptionCount: REMOTE_RUNTIME_MAX_SUBSCRIPTIONS
+    })
+    expect(() => admission.claim('overflow', undefined)).toThrow('subscription limit reached')
+
+    releases[0]?.()
+    expect(() => admission.claim('recovered', undefined)).not.toThrow()
+  })
+
+  it('caps aggregate retained params and releases the claim exactly once', () => {
+    const admission = createRuntimeEnvironmentSubscriptionAdmission()
+    const exactParams = 'x'.repeat(REMOTE_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES - 2)
+    const claimCount =
+      REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES / REMOTE_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES
+    const releases = Array.from({ length: claimCount }, (_value, index) =>
+      admission.claim(`large-${index}`, exactParams)
+    )
+
+    expect(admission.evidence()).toEqual({
+      retainedBytes: REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES,
+      subscriptionCount: claimCount
+    })
+    expect(() => admission.claim('aggregate-overflow', null)).toThrow(
+      'subscription memory limit reached'
+    )
+
+    releases[0]?.()
+    releases[0]?.()
+    const recovered = admission.claim('aggregate-recovered', exactParams)
+    expect(admission.evidence().retainedBytes).toBe(REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES)
+    recovered()
+  })
+
+  it('bounds caller-supplied ids by UTF-8 bytes and reserves duplicates', () => {
+    const admission = createRuntimeEnvironmentSubscriptionAdmission()
+    const exactId = 'é'.repeat(REMOTE_RUNTIME_MAX_SUBSCRIPTION_ID_BYTES / 2)
+    const release = admission.claim(exactId, undefined)
+
+    expect(() => admission.claim(exactId, undefined)).toThrow('already exists')
+    expect(() => admission.claim(`${exactId}x`, undefined)).toThrow(
+      `between 1 and ${REMOTE_RUNTIME_MAX_SUBSCRIPTION_ID_BYTES} bytes`
+    )
+
+    release()
+    expect(() => admission.claim(exactId, undefined)).not.toThrow()
+  })
+})

--- a/src/main/ipc/runtime-environment-subscription-admission.ts
+++ b/src/main/ipc/runtime-environment-subscription-admission.ts
@@ -1,0 +1,69 @@
+import { RemoteRuntimeClientError } from '../../shared/remote-runtime-client-error'
+import {
+  measureRemoteRuntimeSubscriptionParams,
+  REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES,
+  REMOTE_RUNTIME_MAX_SUBSCRIPTION_ID_BYTES,
+  REMOTE_RUNTIME_MAX_SUBSCRIPTIONS
+} from '../../shared/remote-runtime-memory-limits'
+import { measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
+
+export type RuntimeEnvironmentSubscriptionAdmission = {
+  claim: (subscriptionId: string, params: unknown) => () => void
+  evidence: () => { retainedBytes: number; subscriptionCount: number }
+}
+
+export function createRuntimeEnvironmentSubscriptionAdmission(): RuntimeEnvironmentSubscriptionAdmission {
+  const subscriptionIds = new Set<string>()
+  let retainedBytes = 0
+
+  return {
+    claim(subscriptionId, params): () => void {
+      assertSubscriptionId(subscriptionId)
+      if (subscriptionIds.has(subscriptionId)) {
+        throw new RemoteRuntimeClientError(
+          'invalid_argument',
+          'Runtime environment subscription id already exists.'
+        )
+      }
+      if (subscriptionIds.size >= REMOTE_RUNTIME_MAX_SUBSCRIPTIONS) {
+        throw new RemoteRuntimeClientError(
+          'remote_runtime_busy',
+          'Remote runtime subscription limit reached; close a subscription and retry.'
+        )
+      }
+      const paramsBytes = measureRemoteRuntimeSubscriptionParams(params)
+      if (retainedBytes + paramsBytes > REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES) {
+        throw new RemoteRuntimeClientError(
+          'remote_runtime_busy',
+          'Remote runtime subscription memory limit reached; close a subscription and retry.'
+        )
+      }
+      subscriptionIds.add(subscriptionId)
+      retainedBytes += paramsBytes
+      let claimed = true
+      return () => {
+        if (!claimed) {
+          return
+        }
+        claimed = false
+        subscriptionIds.delete(subscriptionId)
+        retainedBytes -= paramsBytes
+      }
+    },
+    evidence: () => ({ retainedBytes, subscriptionCount: subscriptionIds.size })
+  }
+}
+
+function assertSubscriptionId(subscriptionId: string): void {
+  if (
+    subscriptionId.length === 0 ||
+    measureUtf8ByteLength(subscriptionId, {
+      stopAfterBytes: REMOTE_RUNTIME_MAX_SUBSCRIPTION_ID_BYTES
+    }).exceededLimit
+  ) {
+    throw new RemoteRuntimeClientError(
+      'invalid_argument',
+      `Runtime environment subscription id must be between 1 and ${REMOTE_RUNTIME_MAX_SUBSCRIPTION_ID_BYTES} bytes.`
+    )
+  }
+}

--- a/src/main/ipc/runtime-environment-subscription-handlers.ts
+++ b/src/main/ipc/runtime-environment-subscription-handlers.ts
@@ -1,0 +1,238 @@
+import { ipcMain } from 'electron'
+import { randomUUID } from 'node:crypto'
+import type { RemoteRuntimeSubscription } from '../../shared/remote-runtime-client'
+import { isRemoteRuntimeBinaryFrameWithinLimit } from '../../shared/remote-runtime-memory-limits'
+import { resolveEnvironment } from '../../shared/runtime-environment-store'
+import { createRuntimeEnvironmentSubscriptionAdmission } from './runtime-environment-subscription-admission'
+import {
+  retainRuntimeEnvironmentTransportGeneration,
+  type RuntimeEnvironmentTransportGenerationLease
+} from './runtime-environment-transport-generation'
+import { subscribeRuntimeEnvironment } from './runtime-environment-transport-routing'
+
+type RetainedRemoteRuntimeSubscription = RemoteRuntimeSubscription & {
+  environmentId: string
+  ownerWebContentsId: number
+  removeDestroyedListener: () => void
+  releaseOwnership: () => void
+}
+
+const remoteRuntimeSubscriptions = new Map<string, RetainedRemoteRuntimeSubscription>()
+
+export function closeAllRuntimeEnvironmentSubscriptions(): void {
+  for (const [subscriptionId, subscription] of Array.from(remoteRuntimeSubscriptions)) {
+    remoteRuntimeSubscriptions.delete(subscriptionId)
+    subscription.close()
+  }
+}
+
+export function closeRuntimeEnvironmentSubscriptionsForEnvironment(environmentId: string): void {
+  for (const [subscriptionId, subscription] of remoteRuntimeSubscriptions) {
+    if (subscription.environmentId !== environmentId) {
+      continue
+    }
+    remoteRuntimeSubscriptions.delete(subscriptionId)
+    subscription.close()
+  }
+}
+
+export function registerRuntimeEnvironmentSubscriptionHandlers(
+  getUserDataPath: () => string
+): void {
+  const subscriptionAdmission = createRuntimeEnvironmentSubscriptionAdmission()
+  ipcMain.handle(
+    'runtimeEnvironments:subscribe',
+    async (
+      event,
+      args: {
+        selector: string
+        method: string
+        params?: unknown
+        timeoutMs?: number
+        subscriptionId?: string
+        expectedEnvironmentPairingRevision?: number
+      }
+    ): Promise<{ subscriptionId: string; requestId: string }> => {
+      const subscriptionId =
+        typeof args.subscriptionId === 'string' && args.subscriptionId.length > 0
+          ? args.subscriptionId
+          : randomUUID()
+      const releaseAdmission = subscriptionAdmission.claim(subscriptionId, args.params)
+      let transportLease: RuntimeEnvironmentTransportGenerationLease | null = null
+      let transportLeaseReleased = false
+      let transportWasCurrentAtRelease = true
+      const transportSetupIsCurrent = (): boolean =>
+        transportLeaseReleased
+          ? transportWasCurrentAtRelease
+          : (transportLease?.isCurrent() ?? true)
+      const transportIsCurrent = (): boolean =>
+        !transportLeaseReleased && (transportLease?.isCurrent() ?? true)
+      const releaseTransportLease = (): void => {
+        if (!transportLease || transportLeaseReleased) {
+          return
+        }
+        transportWasCurrentAtRelease = transportLease.isCurrent()
+        transportLeaseReleased = true
+        transportLease.release()
+      }
+      const releaseOwnership = (): void => {
+        releaseAdmission()
+        releaseTransportLease()
+      }
+      let ownershipTransferred = false
+      try {
+        if (remoteRuntimeSubscriptions.has(subscriptionId)) {
+          throw new Error('Runtime environment subscription id already exists')
+        }
+        const environment = resolveEnvironment(getUserDataPath(), args.selector)
+        const pairingRevision = environment.pairingRevision ?? environment.createdAt
+        if (
+          args.expectedEnvironmentPairingRevision !== undefined &&
+          pairingRevision !== args.expectedEnvironmentPairingRevision
+        ) {
+          throw new Error('Runtime environment pairing changed; refresh and try again')
+        }
+        transportLease = retainRuntimeEnvironmentTransportGeneration(environment.id)
+        const sender = event.sender
+        const ownerWebContentsId = sender.id
+        let senderDestroyed = sender.isDestroyed()
+        let transportClosed = false
+        let subscription: RemoteRuntimeSubscription | null = null
+        let destroyedListenerAttached = false
+        const removeDestroyedListener = (): void => {
+          if (!destroyedListenerAttached) {
+            return
+          }
+          destroyedListenerAttached = false
+          sender.removeListener('destroyed', closeSubscription)
+        }
+        const closeSubscription = (): void => {
+          senderDestroyed = true
+          const retained = remoteRuntimeSubscriptions.get(subscriptionId) ?? null
+          remoteRuntimeSubscriptions.delete(subscriptionId)
+          if (retained) {
+            retained.close()
+            return
+          }
+          removeDestroyedListener()
+          subscription?.close()
+          releaseOwnership()
+        }
+        sender.once('destroyed', closeSubscription)
+        destroyedListenerAttached = true
+        try {
+          subscription = await subscribeRuntimeEnvironment(
+            getUserDataPath(),
+            environment.id,
+            args.method,
+            args.params,
+            args.timeoutMs,
+            {
+              onEvent: (payload) => {
+                if (transportIsCurrent() && !sender.isDestroyed()) {
+                  sender.send('runtimeEnvironments:subscriptionEvent', {
+                    subscriptionId,
+                    ...payload
+                  })
+                }
+              },
+              onClose: () => {
+                transportClosed = true
+                const retained = remoteRuntimeSubscriptions.get(subscriptionId) ?? null
+                remoteRuntimeSubscriptions.delete(subscriptionId)
+                if (retained) {
+                  retained.removeDestroyedListener()
+                  retained.releaseOwnership()
+                  return
+                }
+                removeDestroyedListener()
+                releaseOwnership()
+              }
+            }
+          )
+        } catch (error) {
+          removeDestroyedListener()
+          throw error
+        }
+        let pairingIsCurrent = false
+        try {
+          const currentEnvironment = resolveEnvironment(getUserDataPath(), environment.id)
+          pairingIsCurrent =
+            (currentEnvironment.pairingRevision ?? currentEnvironment.createdAt) === pairingRevision
+        } catch {
+          pairingIsCurrent = false
+        }
+        if (!transportSetupIsCurrent() || !pairingIsCurrent) {
+          removeDestroyedListener()
+          subscription.close()
+          throw new Error('Runtime environment pairing changed; refresh and try again')
+        }
+        if (senderDestroyed || transportClosed || sender.isDestroyed()) {
+          removeDestroyedListener()
+          subscription.close()
+          return { subscriptionId, requestId: subscription.requestId }
+        }
+        remoteRuntimeSubscriptions.set(subscriptionId, {
+          requestId: subscription.requestId,
+          environmentId: environment.id,
+          ownerWebContentsId,
+          removeDestroyedListener,
+          releaseOwnership,
+          sendBinary: (bytes) => subscription?.sendBinary(bytes) ?? false,
+          close: () => {
+            removeDestroyedListener()
+            releaseOwnership()
+            subscription?.close()
+          }
+        })
+        ownershipTransferred = true
+        return { subscriptionId, requestId: subscription.requestId }
+      } finally {
+        if (!ownershipTransferred) {
+          releaseOwnership()
+        }
+      }
+    }
+  )
+  ipcMain.handle(
+    'runtimeEnvironments:unsubscribe',
+    (event, args: { subscriptionId: string }): { unsubscribed: boolean } => {
+      const subscription = remoteRuntimeSubscriptions.get(args.subscriptionId)
+      if (!subscription || subscription.ownerWebContentsId !== event.sender.id) {
+        return { unsubscribed: false }
+      }
+      remoteRuntimeSubscriptions.delete(args.subscriptionId)
+      subscription.close()
+      return { unsubscribed: true }
+    }
+  )
+  ipcMain.on(
+    'runtimeEnvironments:subscriptionBinary',
+    (event, args: { subscriptionId?: unknown; bytes?: unknown }) => {
+      if (typeof args.subscriptionId !== 'string') {
+        return
+      }
+      const bytes = toBinaryPayload(args.bytes)
+      if (!bytes || !isRemoteRuntimeBinaryFrameWithinLimit(bytes)) {
+        return
+      }
+      const subscription = remoteRuntimeSubscriptions.get(args.subscriptionId)
+      if (subscription?.ownerWebContentsId === event.sender.id) {
+        subscription.sendBinary(bytes)
+      }
+    }
+  )
+}
+
+function toBinaryPayload(value: unknown): Uint8Array<ArrayBufferLike> | null {
+  if (value instanceof Uint8Array) {
+    return value
+  }
+  if (value instanceof ArrayBuffer) {
+    return new Uint8Array(value)
+  }
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+  }
+  return null
+}

--- a/src/main/ipc/runtime-environment-transport-generation.test.ts
+++ b/src/main/ipc/runtime-environment-transport-generation.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  _internals,
+  advanceRuntimeEnvironmentTransportGeneration,
+  retainRuntimeEnvironmentTransportGeneration
+} from './runtime-environment-transport-generation'
+
+afterEach(() => {
+  _internals.resetForTest()
+})
+
+describe('runtime environment transport generations', () => {
+  it('invalidates retained transports and releases their environment entry', () => {
+    const lease = retainRuntimeEnvironmentTransportGeneration('environment-1')
+
+    expect(lease.isCurrent()).toBe(true)
+    advanceRuntimeEnvironmentTransportGeneration('environment-1')
+    expect(lease.isCurrent()).toBe(false)
+
+    lease.release()
+    expect(_internals.trackedEnvironmentCountForTest()).toBe(0)
+  })
+
+  it('retains a shared environment entry until its final lease closes', () => {
+    const first = retainRuntimeEnvironmentTransportGeneration('environment-1')
+    const second = retainRuntimeEnvironmentTransportGeneration('environment-1')
+
+    first.release()
+    expect(second.isCurrent()).toBe(true)
+    expect(_internals.trackedEnvironmentCountForTest()).toBe(1)
+
+    second.release()
+    expect(_internals.trackedEnvironmentCountForTest()).toBe(0)
+  })
+
+  it('does not accumulate tombstones under sequential unique-environment churn', () => {
+    for (let index = 0; index < 10_000; index += 1) {
+      const environmentId = `environment-${index}`
+      const lease = retainRuntimeEnvironmentTransportGeneration(environmentId)
+      advanceRuntimeEnvironmentTransportGeneration(environmentId)
+      lease.release()
+    }
+
+    expect(_internals.trackedEnvironmentCountForTest()).toBe(0)
+  })
+
+  it('does not allocate tombstones when invalidating environments without transports', () => {
+    for (let index = 0; index < 10_000; index += 1) {
+      advanceRuntimeEnvironmentTransportGeneration(`environment-${index}`)
+    }
+
+    expect(_internals.trackedEnvironmentCountForTest()).toBe(0)
+  })
+})

--- a/src/main/ipc/runtime-environment-transport-generation.ts
+++ b/src/main/ipc/runtime-environment-transport-generation.ts
@@ -1,12 +1,71 @@
-const generationByEnvironment = new Map<string, number>()
+type RuntimeEnvironmentTransportGenerationEntry = {
+  token: number
+  leaseCount: number
+}
 
-export function getRuntimeEnvironmentTransportGeneration(environmentId: string): number {
-  return generationByEnvironment.get(environmentId) ?? 0
+export type RuntimeEnvironmentTransportGenerationLease = {
+  isCurrent: () => boolean
+  release: () => void
+}
+
+const generationByEnvironment = new Map<string, RuntimeEnvironmentTransportGenerationEntry>()
+let nextGenerationToken = 1
+
+function allocateGenerationToken(): number {
+  if (!Number.isSafeInteger(nextGenerationToken)) {
+    throw new Error('Runtime environment transport generation exhausted')
+  }
+  const token = nextGenerationToken
+  nextGenerationToken += 1
+  return token
+}
+
+export function retainRuntimeEnvironmentTransportGeneration(
+  environmentId: string
+): RuntimeEnvironmentTransportGenerationLease {
+  let entry = generationByEnvironment.get(environmentId)
+  if (!entry) {
+    entry = { token: allocateGenerationToken(), leaseCount: 0 }
+    generationByEnvironment.set(environmentId, entry)
+  }
+  entry.leaseCount += 1
+  const retainedEntry = entry
+  const retainedToken = entry.token
+  let retained = true
+  return {
+    isCurrent: () =>
+      retained &&
+      generationByEnvironment.get(environmentId) === retainedEntry &&
+      retainedEntry.token === retainedToken,
+    release: () => {
+      if (!retained) {
+        return
+      }
+      retained = false
+      retainedEntry.leaseCount -= 1
+      if (
+        retainedEntry.leaseCount === 0 &&
+        generationByEnvironment.get(environmentId) === retainedEntry
+      ) {
+        generationByEnvironment.delete(environmentId)
+      }
+    }
+  }
 }
 
 export function advanceRuntimeEnvironmentTransportGeneration(environmentId: string): void {
-  generationByEnvironment.set(
-    environmentId,
-    getRuntimeEnvironmentTransportGeneration(environmentId) + 1
-  )
+  const entry = generationByEnvironment.get(environmentId)
+  if (entry) {
+    entry.token = allocateGenerationToken()
+  }
+}
+
+export const _internals = {
+  trackedEnvironmentCountForTest(): number {
+    return generationByEnvironment.size
+  },
+  resetForTest(): void {
+    generationByEnvironment.clear()
+    nextGenerationToken = 1
+  }
 }

--- a/src/main/ipc/runtime-environment-transport-routing.ts
+++ b/src/main/ipc/runtime-environment-transport-routing.ts
@@ -1,11 +1,8 @@
-import {
-  getPreferredPairingOffer,
-  type KnownRuntimeEnvironment
-} from '../../shared/runtime-environments'
+import { getPreferredPairingOffer } from '../../shared/runtime-environments'
 import { resolveEnvironment, markEnvironmentUsed } from '../../shared/runtime-environment-store'
 import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
+import { serializeRemoteRuntimeRpcRequest } from '../../shared/remote-runtime-memory-limits'
 import type { RuntimeStatus } from '../../shared/runtime-types'
-import { REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY } from '../../shared/protocol-version'
 import {
   sendRemoteRuntimeRequest,
   subscribeRemoteRuntimeRequest,
@@ -22,14 +19,14 @@ import {
 import { attachRemoteControlDiagnostics } from './runtime-environment-status-diagnostics'
 import { runtimeEnvironmentRevisionFailure } from './runtime-environment-revision-guard'
 import { withTailscaleHintForResponse } from './runtime-environment-tailscale-response'
+import { supportsSharedControl } from './runtime-environment-shared-control-support'
+
+export {
+  clearSharedControlSupport,
+  resetSharedControlSupport
+} from './runtime-environment-shared-control-support'
 
 const DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS = 15_000
-const sharedControlSupport = new Map<string, { cacheKey: string; check: Promise<boolean> }>()
-
-export const resetSharedControlSupport = (): void => sharedControlSupport.clear()
-
-export const clearSharedControlSupport = (environmentId: string): void =>
-  void sharedControlSupport.delete(environmentId)
 
 export async function getRuntimeEnvironmentStatus(
   userDataPath: string,
@@ -84,58 +81,78 @@ export async function callRuntimeEnvironment(
   expectedEnvironmentPairingRevision?: number
 ): Promise<RuntimeRpcResponse<unknown>> {
   const environment = resolveEnvironment(userDataPath, selector)
+  const initialPairing = getPreferredPairingOffer(environment)
+  const retainedBytes = Buffer.byteLength(
+    serializeRemoteRuntimeRpcRequest({
+      requestId: '00000000-0000-4000-8000-000000000000',
+      deviceToken: initialPairing.deviceToken,
+      method,
+      params
+    }),
+    'utf8'
+  )
   // Why: connection failures reject (they don't resolve as ok:false), so the
   // Tailscale hint is applied to the thrown error here — wrapping the resolved
   // value would miss the in-use connect/timeout case the toast surfaces.
   // Track the endpoint the queued closure actually used: it re-resolves the
   // environment, so a re-pair between enqueue and dispatch can change it.
-  let endpoint = getPreferredPairingOffer(environment).endpoint
+  let endpoint = initialPairing.endpoint
   try {
-    return await enqueueRuntimeCall(environment.id, method, async () => {
-      const currentEnvironment = resolveEnvironment(userDataPath, environment.id)
-      const revisionFailure = runtimeEnvironmentRevisionFailure(
-        currentEnvironment,
-        expectedEnvironmentPairingRevision,
-        method
-      )
-      if (revisionFailure) {
-        return revisionFailure
-      }
-      const pairing = getPreferredPairingOffer(currentEnvironment)
-      endpoint = pairing.endpoint
-      const effectiveTimeoutMs = timeoutMs ?? DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS
-      if (shouldUseCachedRequestConnection(method)) {
-        const response = await sendRemoteRuntimeConnectionRequest(
-          currentEnvironment.id,
-          pairing,
-          method,
-          params,
-          effectiveTimeoutMs
+    return await enqueueRuntimeCall(
+      environment.id,
+      method,
+      async () => {
+        const currentEnvironment = resolveEnvironment(userDataPath, environment.id)
+        const revisionFailure = runtimeEnvironmentRevisionFailure(
+          currentEnvironment,
+          expectedEnvironmentPairingRevision,
+          method
         )
+        if (revisionFailure) {
+          return revisionFailure
+        }
+        const pairing = getPreferredPairingOffer(currentEnvironment)
+        endpoint = pairing.endpoint
+        const effectiveTimeoutMs = timeoutMs ?? DEFAULT_REMOTE_RUNTIME_TIMEOUT_MS
+        if (shouldUseCachedRequestConnection(method)) {
+          const response = await sendRemoteRuntimeConnectionRequest(
+            currentEnvironment.id,
+            pairing,
+            method,
+            params,
+            effectiveTimeoutMs
+          )
+          markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
+          return response
+        }
+        if (
+          method !== 'status.get' &&
+          !shouldUseOneShotRequest(method) &&
+          (await supportsSharedControl(
+            userDataPath,
+            currentEnvironment,
+            pairing,
+            effectiveTimeoutMs
+          ))
+        ) {
+          const response = await sendRemoteRuntimeSharedControlRequest(
+            currentEnvironment.id,
+            pairing,
+            method,
+            params,
+            effectiveTimeoutMs
+          )
+          markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
+          return response
+        }
+        // Why: startup/control-plane RPCs use the proven one-shot path so repo
+        // hydration cannot be coupled to a stale terminal-control connection.
+        const response = await sendRemoteRuntimeRequest(pairing, method, params, effectiveTimeoutMs)
         markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
         return response
-      }
-      if (
-        method !== 'status.get' &&
-        !shouldUseOneShotRequest(method) &&
-        (await supportsSharedControl(userDataPath, currentEnvironment, pairing, effectiveTimeoutMs))
-      ) {
-        const response = await sendRemoteRuntimeSharedControlRequest(
-          currentEnvironment.id,
-          pairing,
-          method,
-          params,
-          effectiveTimeoutMs
-        )
-        markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
-        return response
-      }
-      // Why: startup/control-plane RPCs use the proven one-shot path so repo
-      // hydration cannot be coupled to a stale terminal-control connection.
-      const response = await sendRemoteRuntimeRequest(pairing, method, params, effectiveTimeoutMs)
-      markEnvironmentUsedFromResponse(userDataPath, currentEnvironment.id, response)
-      return response
-    })
+      },
+      retainedBytes
+    )
   } catch (error) {
     if (error instanceof Error) {
       error.message = withRemoteRuntimeTailscaleHint(error.message, endpoint)
@@ -256,67 +273,4 @@ function shouldUseSharedControlSubscription(method: string): boolean {
     method === 'notifications.subscribe' ||
     method === 'files.watch'
   )
-}
-
-async function supportsSharedControl(
-  userDataPath: string,
-  environment: KnownRuntimeEnvironment,
-  pairing: ReturnType<typeof getPreferredPairingOffer>,
-  timeoutMs: number
-): Promise<boolean> {
-  const cacheKey = getSharedControlSupportCacheKey(environment, pairing)
-  const cached = sharedControlSupport.get(environment.id)
-  if (cached?.cacheKey === cacheKey) {
-    return cached.check
-  }
-  let resolvedCacheKey = cacheKey
-  const check = (async () => {
-    const response = await sendRemoteRuntimeRequest<RuntimeStatus>(
-      pairing,
-      'status.get',
-      undefined,
-      timeoutMs
-    )
-    if (response.ok === true) {
-      markEnvironmentUsed(userDataPath, environment.id, { runtimeId: response._meta.runtimeId })
-      resolvedCacheKey = getSharedControlSupportCacheKey(
-        environment,
-        pairing,
-        response._meta.runtimeId
-      )
-      return (
-        response.result.capabilities?.includes(REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY) === true
-      )
-    }
-    return false
-  })()
-  // Why: the same saved host can be re-paired or point at a different runtime
-  // binary over time; capability support belongs to that pairing/runtime identity.
-  sharedControlSupport.set(environment.id, { cacheKey, check })
-  try {
-    const supported = await check
-    const cachedAfterCheck = sharedControlSupport.get(environment.id)
-    if (cachedAfterCheck?.check === check && cachedAfterCheck.cacheKey !== resolvedCacheKey) {
-      sharedControlSupport.set(environment.id, { cacheKey: resolvedCacheKey, check })
-    }
-    return supported
-  } catch (error) {
-    if (sharedControlSupport.get(environment.id)?.check === check) {
-      sharedControlSupport.delete(environment.id)
-    }
-    throw error
-  }
-}
-
-function getSharedControlSupportCacheKey(
-  environment: KnownRuntimeEnvironment,
-  pairing: ReturnType<typeof getPreferredPairingOffer>,
-  runtimeId = environment.runtimeId
-): string {
-  return [
-    runtimeId ?? 'unknown-runtime',
-    pairing.endpoint,
-    pairing.deviceToken,
-    pairing.publicKeyB64
-  ].join('\0')
 }

--- a/src/main/ipc/runtime-environments.test.ts
+++ b/src/main/ipc/runtime-environments.test.ts
@@ -1381,6 +1381,56 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     markUsedSpy.mockRestore()
   })
 
+  it('drops a queued old-peer frame after unsubscribe and transport invalidation', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    const close = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockResolvedValue({
+      requestId: 'queued-old-peer',
+      close,
+      sendBinary: vi.fn()
+    })
+
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    const added = await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const senderSend = vi.fn()
+    const subscribe = handler<
+      { selector: string; method: string; subscriptionId: string },
+      { subscriptionId: string; requestId: string }
+    >('runtimeEnvironments:subscribe')
+    const result = await subscribe(
+      {
+        sender: {
+          id: 1,
+          isDestroyed: () => false,
+          send: senderSend,
+          once: vi.fn(),
+          removeListener: vi.fn()
+        }
+      },
+      {
+        selector: added.environment.id,
+        method: 'terminal.subscribe',
+        subscriptionId: 'queued-old-peer'
+      }
+    )
+    const callbacks = subscribeRemoteRuntimeRequestMock.mock.calls[0]![4] as {
+      onBinary: (bytes: Uint8Array<ArrayBufferLike>) => void
+    }
+    const unsubscribe = handler<{ subscriptionId: string }, { unsubscribed: boolean }>(
+      'runtimeEnvironments:unsubscribe'
+    )
+
+    expect(await unsubscribe({ sender: { id: 1 } }, result)).toEqual({ unsubscribed: true })
+    invalidateRuntimeEnvironmentTransport(added.environment.id)
+    callbacks.onBinary(new Uint8Array([1, 2, 3]))
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(senderSend).not.toHaveBeenCalled()
+  })
+
   it('closes streaming subscriptions when their saved runtime is removed', async () => {
     registerRuntimeEnvironmentHandlers(store as never)
     const close = vi.fn()

--- a/src/main/ipc/runtime-environments.ts
+++ b/src/main/ipc/runtime-environments.ts
@@ -1,5 +1,4 @@
 import { app, ipcMain } from 'electron'
-import { randomUUID } from 'node:crypto'
 import {
   addEnvironmentFromPairingCode,
   listEnvironments,
@@ -12,20 +11,20 @@ import {
 } from '../../shared/runtime-environments'
 import type { RuntimeStatus } from '../../shared/runtime-types'
 import type { RuntimeRpcResponse } from '../../shared/runtime-rpc-envelope'
-import type { RemoteRuntimeSubscription } from '../../shared/remote-runtime-client'
 import type { Store } from '../persistence'
 import { closeRemoteRuntimeRequestConnection } from './runtime-environment-request-connections'
-import {
-  advanceRuntimeEnvironmentTransportGeneration,
-  getRuntimeEnvironmentTransportGeneration
-} from './runtime-environment-transport-generation'
+import { advanceRuntimeEnvironmentTransportGeneration } from './runtime-environment-transport-generation'
 import {
   callRuntimeEnvironment,
   clearSharedControlSupport,
   getRuntimeEnvironmentStatus,
-  resetSharedControlSupport,
-  subscribeRuntimeEnvironment
+  resetSharedControlSupport
 } from './runtime-environment-transport-routing'
+import {
+  closeAllRuntimeEnvironmentSubscriptions,
+  closeRuntimeEnvironmentSubscriptionsForEnvironment,
+  registerRuntimeEnvironmentSubscriptionHandlers
+} from './runtime-environment-subscription-handlers'
 
 const RUNTIME_ENVIRONMENT_HANDLER_CHANNELS = [
   'runtimeEnvironments:list',
@@ -39,30 +38,14 @@ const RUNTIME_ENVIRONMENT_HANDLER_CHANNELS = [
   'runtimeEnvironments:unsubscribe'
 ] as const
 
-type RetainedRemoteRuntimeSubscription = RemoteRuntimeSubscription & {
-  environmentId: string
-  ownerWebContentsId: number
-  removeDestroyedListener: () => void
-}
-const remoteRuntimeSubscriptions = new Map<string, RetainedRemoteRuntimeSubscription>()
 const getUserDataPath = (): string => app.getPath('userData')
 
-function closeSubscriptionsForEnvironment(environmentId: string): void {
-  // Why: removed runtimes must not retain terminal/browser WebSockets until renderer teardown.
-  for (const [subscriptionId, subscription] of remoteRuntimeSubscriptions) {
-    if (subscription.environmentId !== environmentId) {
-      continue
-    }
-    remoteRuntimeSubscriptions.delete(subscriptionId)
-    subscription.close()
-  }
-}
 export function invalidateRuntimeEnvironmentTransport(environmentId: string): void {
   // Why: a same-id re-pair must retire every transport that still authenticates as the old peer.
   advanceRuntimeEnvironmentTransportGeneration(environmentId)
   closeRemoteRuntimeRequestConnection(environmentId)
   clearSharedControlSupport(environmentId)
-  closeSubscriptionsForEnvironment(environmentId)
+  closeRuntimeEnvironmentSubscriptionsForEnvironment(environmentId)
 }
 
 function listPublicRuntimeEnvironments(): PublicKnownRuntimeEnvironment[] {
@@ -74,6 +57,7 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
   // Why: keep direct re-registration safe even though register-core-handlers
   // normally guards this path; otherwise the binary send listener can stack.
   resetSharedControlSupport()
+  closeAllRuntimeEnvironmentSubscriptions()
   for (const channel of RUNTIME_ENVIRONMENT_HANDLER_CHANNELS) {
     ipcMain.removeHandler(channel)
   }
@@ -153,160 +137,5 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
       )
     }
   )
-  ipcMain.handle(
-    'runtimeEnvironments:subscribe',
-    async (
-      event,
-      args: {
-        selector: string
-        method: string
-        params?: unknown
-        timeoutMs?: number
-        subscriptionId?: string
-        expectedEnvironmentPairingRevision?: number
-      }
-    ): Promise<{ subscriptionId: string; requestId: string }> => {
-      const subscriptionId =
-        typeof args.subscriptionId === 'string' && args.subscriptionId.length > 0
-          ? args.subscriptionId
-          : randomUUID()
-      if (remoteRuntimeSubscriptions.has(subscriptionId)) {
-        throw new Error('Runtime environment subscription id already exists')
-      }
-      const environment = resolveEnvironment(getUserDataPath(), args.selector)
-      const pairingRevision = environment.pairingRevision ?? environment.createdAt
-      if (
-        args.expectedEnvironmentPairingRevision !== undefined &&
-        pairingRevision !== args.expectedEnvironmentPairingRevision
-      ) {
-        throw new Error('Runtime environment pairing changed; refresh and try again')
-      }
-      const transportGeneration = getRuntimeEnvironmentTransportGeneration(environment.id)
-      const transportIsCurrent = (): boolean =>
-        getRuntimeEnvironmentTransportGeneration(environment.id) === transportGeneration
-      const sender = event.sender
-      const ownerWebContentsId = sender.id
-      let senderDestroyed = sender.isDestroyed()
-      let subscription: RemoteRuntimeSubscription | null = null
-      let destroyedListenerAttached = false
-      const removeDestroyedListener = (): void => {
-        if (!destroyedListenerAttached) {
-          return
-        }
-        destroyedListenerAttached = false
-        sender.removeListener('destroyed', closeSubscription)
-      }
-      const closeSubscription = (): void => {
-        senderDestroyed = true
-        const retained = remoteRuntimeSubscriptions.get(subscriptionId) ?? null
-        remoteRuntimeSubscriptions.delete(subscriptionId)
-        if (retained) {
-          retained.close()
-          return
-        }
-        removeDestroyedListener()
-        subscription?.close()
-      }
-      sender.once('destroyed', closeSubscription)
-      destroyedListenerAttached = true
-      try {
-        subscription = await subscribeRuntimeEnvironment(
-          getUserDataPath(),
-          environment.id,
-          args.method,
-          args.params,
-          args.timeoutMs,
-          {
-            onEvent: (payload) => {
-              if (transportIsCurrent() && !sender.isDestroyed()) {
-                sender.send('runtimeEnvironments:subscriptionEvent', {
-                  subscriptionId,
-                  ...payload
-                })
-              }
-            },
-            onClose: () => {
-              const retained = remoteRuntimeSubscriptions.get(subscriptionId) ?? null
-              retained?.removeDestroyedListener()
-              remoteRuntimeSubscriptions.delete(subscriptionId)
-            }
-          }
-        )
-      } catch (error) {
-        removeDestroyedListener()
-        throw error
-      }
-      let pairingIsCurrent = false
-      try {
-        const currentEnvironment = resolveEnvironment(getUserDataPath(), environment.id)
-        pairingIsCurrent =
-          (currentEnvironment.pairingRevision ?? currentEnvironment.createdAt) === pairingRevision
-      } catch {
-        pairingIsCurrent = false
-      }
-      if (!transportIsCurrent() || !pairingIsCurrent) {
-        removeDestroyedListener()
-        subscription.close()
-        throw new Error('Runtime environment pairing changed; refresh and try again')
-      }
-      if (senderDestroyed || sender.isDestroyed()) {
-        removeDestroyedListener()
-        subscription.close()
-        return { subscriptionId, requestId: subscription.requestId }
-      }
-      remoteRuntimeSubscriptions.set(subscriptionId, {
-        requestId: subscription.requestId,
-        environmentId: environment.id,
-        ownerWebContentsId,
-        removeDestroyedListener,
-        sendBinary: (bytes) => subscription?.sendBinary(bytes) ?? false,
-        close: () => {
-          removeDestroyedListener()
-          subscription?.close()
-        }
-      })
-      return { subscriptionId, requestId: subscription.requestId }
-    }
-  )
-  ipcMain.handle(
-    'runtimeEnvironments:unsubscribe',
-    (event, args: { subscriptionId: string }): { unsubscribed: boolean } => {
-      const subscription = remoteRuntimeSubscriptions.get(args.subscriptionId)
-      if (!subscription || subscription.ownerWebContentsId !== event.sender.id) {
-        return { unsubscribed: false }
-      }
-      remoteRuntimeSubscriptions.delete(args.subscriptionId)
-      subscription.close()
-      return { unsubscribed: true }
-    }
-  )
-  ipcMain.on(
-    'runtimeEnvironments:subscriptionBinary',
-    (event, args: { subscriptionId?: unknown; bytes?: unknown }) => {
-      if (typeof args.subscriptionId !== 'string') {
-        return
-      }
-      const bytes = toBinaryPayload(args.bytes)
-      if (!bytes) {
-        return
-      }
-      const subscription = remoteRuntimeSubscriptions.get(args.subscriptionId)
-      if (subscription?.ownerWebContentsId === event.sender.id) {
-        subscription.sendBinary(bytes)
-      }
-    }
-  )
-}
-
-function toBinaryPayload(value: unknown): Uint8Array<ArrayBufferLike> | null {
-  if (value instanceof Uint8Array) {
-    return value
-  }
-  if (value instanceof ArrayBuffer) {
-    return new Uint8Array(value)
-  }
-  if (ArrayBuffer.isView(value)) {
-    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
-  }
-  return null
+  registerRuntimeEnvironmentSubscriptionHandlers(getUserDataPath)
 }

--- a/src/main/ipc/shell-repo-icon-picker.ts
+++ b/src/main/ipc/shell-repo-icon-picker.ts
@@ -1,0 +1,52 @@
+import { dialog } from 'electron'
+import { stat } from 'node:fs/promises'
+import { basename, extname } from 'node:path'
+import {
+  NodeFileReadTooLargeError,
+  readNodeFileWithinLimit
+} from '../../shared/node-bounded-file-reader'
+import { assertRasterImagePreviewWithinLimits } from '../../shared/raster-image-preview-limits'
+import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
+
+const REPO_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png'
+}
+
+export async function pickRepoIconImage(): Promise<{
+  dataUrl: string
+  fileName: string
+} | null> {
+  const result = await dialog.showOpenDialog({
+    properties: ['openFile'],
+    filters: [{ name: 'Repo icon images', extensions: ['png'] }]
+  })
+  if (result.canceled || result.filePaths.length === 0) {
+    return null
+  }
+
+  const filePath = result.filePaths[0]
+  const mimeType = REPO_ICON_IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
+  if (!mimeType) {
+    throw new Error('Repo icons must be PNG files.')
+  }
+
+  const stats = await stat(filePath)
+  if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
+    throw new Error('Repo icon image must be 256KB or smaller.')
+  }
+
+  let buffer: Buffer
+  try {
+    buffer = (await readNodeFileWithinLimit(filePath, MAX_REPO_ICON_UPLOAD_BYTES)).buffer
+  } catch (error) {
+    if (error instanceof NodeFileReadTooLargeError) {
+      throw new Error('Repo icon image must be 256KB or smaller.')
+    }
+    throw error
+  }
+  assertRasterImagePreviewWithinLimits(buffer, mimeType)
+  return {
+    dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
+    fileName: basename(filePath)
+  }
+}

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { normalize, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import * as NodeBoundedFileReader from '../../shared/node-bounded-file-reader'
 
 const {
   getSpawnArgsForWindowsMock,
   handleMock,
   openPathMock,
+  readNodeFileWithinLimitMock,
   resolveCliCommandMock,
+  readFileMock,
   showItemInFolderMock,
   showOpenDialogMock,
   spawnMock,
@@ -15,7 +18,9 @@ const {
   getSpawnArgsForWindowsMock: vi.fn(),
   handleMock: vi.fn(),
   openPathMock: vi.fn(),
+  readNodeFileWithinLimitMock: vi.fn(),
   resolveCliCommandMock: vi.fn(),
+  readFileMock: vi.fn(),
   showItemInFolderMock: vi.fn(),
   showOpenDialogMock: vi.fn(),
   spawnMock: vi.fn(),
@@ -41,6 +46,11 @@ vi.mock('node:fs/promises', () => ({
   copyFile: vi.fn(),
   stat: statMock
 }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeBoundedFileReader>()
+  return { ...actual, readNodeFileWithinLimit: readNodeFileWithinLimitMock }
+})
 
 vi.mock('node:child_process', () => ({
   spawn: spawnMock
@@ -105,6 +115,11 @@ describe('registerShellHandlers', () => {
     getSpawnArgsForWindowsMock.mockReset()
     openPathMock.mockReset()
     resolveCliCommandMock.mockReset()
+    readFileMock.mockReset()
+    readNodeFileWithinLimitMock.mockReset()
+    readNodeFileWithinLimitMock.mockImplementation(async (path: string) => ({
+      buffer: await readFileMock(path)
+    }))
     showItemInFolderMock.mockReset()
     showOpenDialogMock.mockReset()
     spawnMock.mockReset()
@@ -152,6 +167,32 @@ describe('registerShellHandlers', () => {
 
     const handler = getHandler('shell:pickAudio')
     await expect(handler({})).resolves.toBeNull()
+  })
+
+  it('rejects a repo icon raster dimension bomb before returning a data URL', async () => {
+    const bytes = Buffer.alloc(24)
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
+    bytes.writeUInt32BE(13, 8)
+    bytes.write('IHDR', 12, 'ascii')
+    bytes.writeUInt32BE(32_769, 16)
+    bytes.writeUInt32BE(1, 20)
+    showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: ['/tmp/bomb.png'] })
+    statMock.mockResolvedValue({ size: bytes.length })
+    readFileMock.mockResolvedValue(bytes)
+
+    const handler = getHandler('shell:pickRepoIconImage')
+    await expect(handler({})).rejects.toThrow('Image dimensions exceed the preview safety limit')
+  })
+
+  it('rejects a repo icon that grows past the byte cap after its size check', async () => {
+    showOpenDialogMock.mockResolvedValue({ canceled: false, filePaths: ['/tmp/growing.png'] })
+    statMock.mockResolvedValue({ size: 1 })
+    readNodeFileWithinLimitMock.mockRejectedValue(
+      new NodeBoundedFileReader.NodeFileReadTooLargeError(256 * 1024 + 1, 256 * 1024)
+    )
+
+    const handler = getHandler('shell:pickRepoIconImage')
+    await expect(handler({})).rejects.toThrow('Repo icon image must be 256KB or smaller.')
   })
 
   it('picks an existing directory without enabling native directory creation', async () => {

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -1,14 +1,13 @@
 import { ipcMain, shell, dialog } from 'electron'
 import { spawn } from 'node:child_process'
-import { constants, copyFile, readFile, stat } from 'node:fs/promises'
-import { basename, extname, isAbsolute, normalize, posix, win32 } from 'node:path'
+import { constants, copyFile, stat } from 'node:fs/promises'
+import { isAbsolute, normalize, posix, win32 } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type {
   ShellOpenExternalEditorRequest,
   ShellOpenExternalEditorResult,
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
-import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
 import type { Store } from '../persistence'
 import { getSpawnArgsForWindows } from '../win32-utils'
 import {
@@ -18,12 +17,9 @@ import {
   type ExternalEditorLaunchSpec
 } from '../external-editor-launch'
 import { resolveVsCodeSshAuthority } from '../ssh/vscode-ssh-authority'
+import { pickRepoIconImage } from './shell-repo-icon-picker'
 
 export { EXTERNAL_EDITOR_CLI_COMMAND }
-
-const REPO_ICON_IMAGE_MIME_TYPES: Record<string, string> = {
-  '.png': 'image/png'
-}
 
 async function pathExists(pathValue: string): Promise<boolean> {
   try {
@@ -296,36 +292,7 @@ export function registerShellHandlers(store: Store): void {
     return result.filePaths[0]
   })
 
-  ipcMain.handle(
-    'shell:pickRepoIconImage',
-    async (): Promise<{ dataUrl: string; fileName: string } | null> => {
-      const result = await dialog.showOpenDialog({
-        properties: ['openFile'],
-        filters: [{ name: 'Repo icon images', extensions: ['png'] }]
-      })
-      if (result.canceled || result.filePaths.length === 0) {
-        return null
-      }
-
-      const filePath = result.filePaths[0]
-      const extension = extname(filePath).toLowerCase()
-      const mimeType = REPO_ICON_IMAGE_MIME_TYPES[extension]
-      if (!mimeType) {
-        throw new Error('Repo icons must be PNG files.')
-      }
-
-      const stats = await stat(filePath)
-      if (stats.size > MAX_REPO_ICON_UPLOAD_BYTES) {
-        throw new Error('Repo icon image must be 256KB or smaller.')
-      }
-
-      const buffer = await readFile(filePath)
-      return {
-        dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
-        fileName: basename(filePath)
-      }
-    }
-  )
+  ipcMain.handle('shell:pickRepoIconImage', pickRepoIconImage)
 
   ipcMain.handle('shell:pickAudio', async (): Promise<string | null> => {
     const result = await dialog.showOpenDialog({

--- a/src/main/ipc/ssh-browse.test.ts
+++ b/src/main/ipc/ssh-browse.test.ts
@@ -1,6 +1,10 @@
 import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { registerSshBrowseHandler } from './ssh-browse'
+import { registerSshBrowseHandler, type RemoteDirEntry } from './ssh-browse'
+import {
+  FILESYSTEM_DIRECTORY_LIMIT_MESSAGE,
+  FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES
+} from '../../shared/filesystem-directory-listing-limit'
 
 const { handleMock, removeHandlerMock } = vi.hoisted(() => ({
   handleMock: vi.fn(),
@@ -75,6 +79,68 @@ describe('registerSshBrowseHandler', () => {
     expect(channel.listenerCount('error')).toBe(0)
     expect(channel.stderr.listenerCount('data')).toBe(0)
     expect(channel.stderr.listenerCount('error')).toBe(0)
+  })
+
+  it('closes and rejects a remote listing that exceeds the shared byte limit', async () => {
+    const channel = Object.assign(createMockChannel(), { close: vi.fn() })
+    const exec = vi.fn().mockResolvedValue(channel)
+    const getConnectionManager = () => ({ getConnection: () => ({ exec }) })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '~' })
+    await Promise.resolve()
+    channel.emit('data', Buffer.alloc(FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES + 1, 0x78))
+
+    await expect(resultPromise).rejects.toThrow(FILESYSTEM_DIRECTORY_LIMIT_MESSAGE)
+    expect(channel.close).toHaveBeenCalledOnce()
+    expect(channel.listenerCount('data')).toBe(0)
+    expect(channel.stderr.listenerCount('data')).toBe(0)
+  })
+
+  it('retains tens of thousands of tiny stdout chunks without quadratic copying', async () => {
+    const channel = createMockChannel()
+    const exec = vi.fn().mockResolvedValue(channel)
+    const getConnectionManager = () => ({ getConnection: () => ({ exec }) })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '~' })
+    await Promise.resolve()
+    channel.emit('data', Buffer.from('/home/user\n'))
+    for (let index = 0; index < 65_000; index += 1) {
+      channel.emit('data', Buffer.from(`f${String(index).padStart(5, '0')}\n`))
+    }
+    channel.emit('exit', 0)
+    channel.emit('close')
+
+    const result = (await resultPromise) as {
+      resolvedPath: string
+      entries: RemoteDirEntry[]
+    }
+    expect(result.resolvedPath).toBe('/home/user')
+    expect(result.entries).toHaveLength(65_000)
+    expect(result.entries[0]).toEqual({ name: 'f00000', isDirectory: false })
+    expect(result.entries.at(-1)).toEqual({ name: 'f64999', isDirectory: false })
+  })
+
+  it('decodes a filename whose UTF-8 bytes span stdout chunks', async () => {
+    const channel = createMockChannel()
+    const exec = vi.fn().mockResolvedValue(channel)
+    const getConnectionManager = () => ({ getConnection: () => ({ exec }) })
+    registerSshBrowseHandler(getConnectionManager as never)
+
+    const resultPromise = handler(null, { targetId: 'ssh-1', dirPath: '~' })
+    await Promise.resolve()
+    const output = Buffer.from('/home/user\nemoji-🙂.txt\n')
+    const emojiOffset = output.indexOf(Buffer.from('🙂'))
+    channel.emit('data', output.subarray(0, emojiOffset + 1))
+    channel.emit('data', output.subarray(emojiOffset + 1))
+    channel.emit('exit', 0)
+    channel.emit('close')
+
+    await expect(resultPromise).resolves.toEqual({
+      resolvedPath: '/home/user',
+      entries: [{ name: 'emoji-🙂.txt', isDirectory: false }]
+    })
   })
 
   it('escapes remote browse paths before invoking command ls', async () => {

--- a/src/main/ipc/ssh-browse.ts
+++ b/src/main/ipc/ssh-browse.ts
@@ -2,6 +2,14 @@ import { ipcMain } from 'electron'
 import type { SshConnectionManager } from '../ssh/ssh-connection'
 import type { SshExecOptions } from '../ssh/ssh-connection-utils'
 import { powerShellCommand, powerShellLiteral } from '../ssh/ssh-remote-powershell'
+import {
+  createFilesystemDirectoryLimitState,
+  FILESYSTEM_DIRECTORY_LIMIT_MESSAGE,
+  FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES,
+  trackFilesystemDirectoryEntry
+} from '../../shared/filesystem-directory-listing-limit'
+import { GrowingByteBuffer } from '../../shared/growing-byte-buffer'
+import { SystemSshOutputTail } from '../ssh/system-ssh-output-tail'
 
 export type RemoteDirEntry = {
   name: string
@@ -102,8 +110,8 @@ async function runBrowseCommand(
   const channel = options ? await conn.exec(command, options) : await conn.exec(command)
 
   return new Promise((resolve, reject) => {
-    let stdout = ''
-    let stderr = ''
+    const stdout = new GrowingByteBuffer()
+    const stderr = new SystemSshOutputTail()
     let exitCode: number | null = null
     let settled = false
     let timeout: ReturnType<typeof setTimeout> | null = null
@@ -155,10 +163,16 @@ async function runBrowseCommand(
     }
 
     const onStdoutData = (data: Buffer): void => {
-      stdout += data.toString()
+      if (data.byteLength > FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES - stdout.byteLength) {
+        stdout.clear()
+        rejectOnce(new Error(FILESYSTEM_DIRECTORY_LIMIT_MESSAGE))
+        closeChannel()
+        return
+      }
+      stdout.append(data)
     }
     const onStderrData = (data: Buffer): void => {
-      stderr += data.toString()
+      stderr.push(data)
     }
     // `exit` fires before `close`; capture the code to tell a failed `ls` (that still printed `pwd`) from an empty listing.
     const onExit = (code: number | null): void => {
@@ -170,21 +184,24 @@ async function runBrowseCommand(
     const onClose = (): void => {
       // Why: a null exitCode (channel closed without exit status) isn't success; don't treat empty stdout as an empty dir.
       if (exitCode !== 0) {
+        const stderrText = stderr.toString()
         const msg =
-          stderr.trim() ||
+          stderrText.trim() ||
           (exitCode === null
             ? 'Remote listing failed (channel closed without exit status)'
             : `Remote listing failed (exit ${exitCode})`)
         rejectOnce(new RemoteBrowseError(msg, exitCode))
         return
       }
-      if (stderr.trim() && !stdout.trim()) {
-        rejectOnce(new Error(stderr.trim()))
+      const stderrText = stderr.toString()
+      const stdoutText = stdout.toString('utf8')
+      if (stderrText.trim() && !stdoutText.trim()) {
+        rejectOnce(new Error(stderrText.trim()))
         return
       }
 
       // Why: Windows OpenSSH exec emits CRLF; split on \r?\n so a trailing \r doesn't defeat the endsWith('/') dir check or leave a stray CR in names.
-      const lines = stdout.trim().split(/\r?\n/)
+      const lines = stdoutText.trim().split(/\r?\n/)
       if (lines.length === 0) {
         rejectOnce(new Error('Empty response from remote'))
         return
@@ -192,16 +209,24 @@ async function runBrowseCommand(
 
       const resolvedPath = lines[0]
       const entries: RemoteDirEntry[] = []
+      const listingLimit = createFilesystemDirectoryLimitState()
 
       for (let i = 1; i < lines.length; i++) {
         const line = lines[i]
         if (!line || line === './' || line === '../') {
           continue
         }
+        const name = line.endsWith('/') ? line.slice(0, -1) : line
+        try {
+          trackFilesystemDirectoryEntry(listingLimit, { name })
+        } catch (error) {
+          rejectOnce(error instanceof Error ? error : new Error(String(error)))
+          return
+        }
         if (line.endsWith('/')) {
-          entries.push({ name: line.slice(0, -1), isDirectory: true })
+          entries.push({ name, isDirectory: true })
         } else {
-          entries.push({ name: line, isDirectory: false })
+          entries.push({ name, isDirectory: false })
         }
       }
 

--- a/src/main/ipc/ssh-passphrase.test.ts
+++ b/src/main/ipc/ssh-passphrase.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getUtf8ByteLength } from '../../shared/utf8-byte-limits'
+import {
+  SSH_CREDENTIAL_DETAIL_MAX_UTF8_BYTES,
+  SSH_RETAINED_IDENTIFIER_MAX_UTF8_BYTES
+} from '../../shared/ssh-retained-payload-admission'
+
+const electronMocks = vi.hoisted(() => {
+  const handlers = new Map<string, (event: unknown, args: unknown) => unknown>()
+  return {
+    handlers,
+    ipcMain: {
+      removeHandler: vi.fn((channel: string) => handlers.delete(channel)),
+      handle: vi.fn((channel: string, handler: (event: unknown, args: unknown) => unknown) => {
+        handlers.set(channel, handler)
+      })
+    }
+  }
+})
+
+vi.mock('electron', () => ({ ipcMain: electronMocks.ipcMain }))
+
+import {
+  getPendingCredentialRequestCountForTests,
+  registerCredentialHandler,
+  requestCredential,
+  resetPendingCredentialRequestsForTests,
+  SSH_CREDENTIAL_VALUE_MAX_UTF8_BYTES,
+  SSH_MAX_PENDING_CREDENTIAL_REQUESTS
+} from './ssh-passphrase'
+
+function createWindow() {
+  return {
+    isDestroyed: vi.fn(() => false),
+    webContents: { send: vi.fn() }
+  }
+}
+
+describe('SSH credential request admission', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    electronMocks.handlers.clear()
+    resetPendingCredentialRequestsForTests()
+  })
+
+  afterEach(() => {
+    resetPendingCredentialRequestsForTests()
+    vi.useRealTimers()
+  })
+
+  it('forwards ordinary metadata and resolves the submitted credential', async () => {
+    const win = createWindow()
+    registerCredentialHandler(() => win as never)
+    const result = requestCredential(() => win as never, 'ssh-a', 'password', 'example.test')
+    const request = win.webContents.send.mock.calls[0][1] as { requestId: string }
+
+    electronMocks.handlers.get('ssh:submitCredential')?.(
+      {},
+      {
+        requestId: request.requestId,
+        value: 'secret'
+      }
+    )
+
+    await expect(result).resolves.toBe('secret')
+    expect(win.webContents.send).toHaveBeenNthCalledWith(1, 'ssh:credential-request', {
+      requestId: request.requestId,
+      targetId: 'ssh-a',
+      kind: 'password',
+      detail: 'example.test'
+    })
+    expect(win.webContents.send).toHaveBeenNthCalledWith(2, 'ssh:credential-resolved', {
+      requestId: request.requestId
+    })
+  })
+
+  it('caps detail before sending it to the renderer', () => {
+    const win = createWindow()
+
+    void requestCredential(
+      () => win as never,
+      'ssh-a',
+      'passphrase',
+      '🙂'.repeat(SSH_CREDENTIAL_DETAIL_MAX_UTF8_BYTES)
+    )
+
+    const sent = win.webContents.send.mock.calls[0][1] as { detail: string }
+    expect(getUtf8ByteLength(sent.detail)).toBeLessThanOrEqual(SSH_CREDENTIAL_DETAIL_MAX_UTF8_BYTES)
+  })
+
+  it('rejects an oversized submitted credential without retaining the request', async () => {
+    const win = createWindow()
+    registerCredentialHandler(() => win as never)
+    const result = requestCredential(() => win as never, 'ssh-a', 'password', 'example.test')
+    const request = win.webContents.send.mock.calls[0][1] as { requestId: string }
+
+    electronMocks.handlers.get('ssh:submitCredential')?.(
+      {},
+      {
+        requestId: request.requestId,
+        value: '🙂'.repeat(SSH_CREDENTIAL_VALUE_MAX_UTF8_BYTES)
+      }
+    )
+
+    await expect(result).resolves.toBeNull()
+    expect(getPendingCredentialRequestCountForTests()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('settles a submitted credential when its resolution notification throws', async () => {
+    const win = createWindow()
+    registerCredentialHandler(() => win as never)
+    const result = requestCredential(() => win as never, 'ssh-a', 'password', 'example.test')
+    const request = win.webContents.send.mock.calls[0][1] as { requestId: string }
+    win.webContents.send.mockImplementation(() => {
+      throw new Error('renderer gone')
+    })
+
+    electronMocks.handlers.get('ssh:submitCredential')?.(
+      {},
+      {
+        requestId: request.requestId,
+        value: 'secret'
+      }
+    )
+
+    await expect(result).resolves.toBe('secret')
+    expect(getPendingCredentialRequestCountForTests()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('settles a timed-out credential when its resolution notification throws', async () => {
+    const win = createWindow()
+    const result = requestCredential(() => win as never, 'ssh-a', 'password', 'example.test')
+    win.webContents.send.mockImplementation(() => {
+      throw new Error('renderer gone')
+    })
+
+    await vi.runAllTimersAsync()
+
+    await expect(result).resolves.toBeNull()
+    expect(getPendingCredentialRequestCountForTests()).toBe(0)
+  })
+
+  it('rejects an oversized target without allocating request state', async () => {
+    const win = createWindow()
+    const result = requestCredential(
+      () => win as never,
+      'x'.repeat(SSH_RETAINED_IDENTIFIER_MAX_UTF8_BYTES + 1),
+      'password',
+      'host'
+    )
+
+    await expect(result).resolves.toBeNull()
+    expect(getPendingCredentialRequestCountForTests()).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(win.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('fails closed at the pending-request cap without adding a timer or map row', async () => {
+    const win = createWindow()
+    const pending = Array.from({ length: SSH_MAX_PENDING_CREDENTIAL_REQUESTS }, (_, index) =>
+      requestCredential(() => win as never, `ssh-${index}`, 'password', 'host')
+    )
+    expect(getPendingCredentialRequestCountForTests()).toBe(SSH_MAX_PENDING_CREDENTIAL_REQUESTS)
+    expect(vi.getTimerCount()).toBe(SSH_MAX_PENDING_CREDENTIAL_REQUESTS)
+
+    const overflow = requestCredential(() => win as never, 'ssh-overflow', 'password', 'host')
+
+    await expect(overflow).resolves.toBeNull()
+    expect(getPendingCredentialRequestCountForTests()).toBe(SSH_MAX_PENDING_CREDENTIAL_REQUESTS)
+    expect(vi.getTimerCount()).toBe(SSH_MAX_PENDING_CREDENTIAL_REQUESTS)
+    expect(win.webContents.send).toHaveBeenCalledTimes(SSH_MAX_PENDING_CREDENTIAL_REQUESTS)
+    resetPendingCredentialRequestsForTests()
+    await expect(Promise.all(pending)).resolves.toEqual(
+      Array.from({ length: SSH_MAX_PENDING_CREDENTIAL_REQUESTS }, () => null)
+    )
+  })
+})

--- a/src/main/ipc/ssh-passphrase.ts
+++ b/src/main/ipc/ssh-passphrase.ts
@@ -1,8 +1,15 @@
 import { ipcMain, type BrowserWindow } from 'electron'
 import { randomUUID } from 'node:crypto'
 import type { SshCredentialKind } from '../ssh/ssh-connection-utils'
+import {
+  isSshRetainedIdentifier,
+  SSH_CREDENTIAL_DETAIL_MAX_UTF8_BYTES
+} from '../../shared/ssh-retained-payload-admission'
+import { clampUtf8TextPrefix, measureUtf8ByteLength } from '../../shared/utf8-byte-limits'
 
 const CREDENTIAL_TIMEOUT_MS = 120_000
+export const SSH_MAX_PENDING_CREDENTIAL_REQUESTS = 64
+export const SSH_CREDENTIAL_VALUE_MAX_UTF8_BYTES = 64 * 1024
 const pendingRequests = new Map<string, { resolve: (value: string | null) => void }>()
 
 function notifyCredentialResolved(
@@ -11,7 +18,11 @@ function notifyCredentialResolved(
 ): void {
   const win = getMainWindow()
   if (win && !win.isDestroyed()) {
-    win.webContents.send('ssh:credential-resolved', { requestId })
+    try {
+      win.webContents.send('ssh:credential-resolved', { requestId })
+    } catch {
+      // The SSH caller must still settle if its renderer disappears between checks.
+    }
   }
 }
 
@@ -21,6 +32,16 @@ export function requestCredential(
   kind: SshCredentialKind,
   detail: string
 ): Promise<string | null> {
+  const win = getMainWindow()
+  if (
+    !isSshRetainedIdentifier(targetId) ||
+    pendingRequests.size >= SSH_MAX_PENDING_CREDENTIAL_REQUESTS ||
+    !win ||
+    win.isDestroyed()
+  ) {
+    return Promise.resolve(null)
+  }
+  const retainedDetail = clampUtf8TextPrefix(detail, SSH_CREDENTIAL_DETAIL_MAX_UTF8_BYTES)
   const requestId = randomUUID()
   return new Promise((resolve) => {
     const timer = setTimeout(() => {
@@ -37,13 +58,16 @@ export function requestCredential(
       }
     })
 
-    const win = getMainWindow()
-    if (win && !win.isDestroyed()) {
-      win.webContents.send('ssh:credential-request', { requestId, targetId, kind, detail })
-    } else {
+    try {
+      win.webContents.send('ssh:credential-request', {
+        requestId,
+        targetId,
+        kind,
+        detail: retainedDetail
+      })
+    } catch {
       pendingRequests.delete(requestId)
       clearTimeout(timer)
-      notifyCredentialResolved(getMainWindow, requestId)
       resolve(null)
     }
   })
@@ -53,13 +77,36 @@ export function registerCredentialHandler(getMainWindow: () => BrowserWindow | n
   ipcMain.removeHandler('ssh:submitCredential')
   ipcMain.handle(
     'ssh:submitCredential',
-    (_event, args: { requestId: string; value: string | null }) => {
+    (_event, args: { requestId?: unknown; value?: unknown }) => {
+      if (!args || typeof args !== 'object' || typeof args.requestId !== 'string') {
+        return
+      }
       const pending = pendingRequests.get(args.requestId)
       if (pending) {
         pendingRequests.delete(args.requestId)
         notifyCredentialResolved(getMainWindow, args.requestId)
-        pending.resolve(args.value)
+        const value =
+          args.value === null ||
+          (typeof args.value === 'string' &&
+            !measureUtf8ByteLength(args.value, {
+              stopAfterBytes: SSH_CREDENTIAL_VALUE_MAX_UTF8_BYTES
+            }).exceededLimit)
+            ? args.value
+            : null
+        pending.resolve(value)
       }
     }
   )
+}
+
+export function resetPendingCredentialRequestsForTests(): void {
+  const pending = Array.from(pendingRequests.values())
+  pendingRequests.clear()
+  for (const request of pending) {
+    request.resolve(null)
+  }
+}
+
+export function getPendingCredentialRequestCountForTests(): number {
+  return pendingRequests.size
 }

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -18,7 +18,10 @@ const {
   mockPortForwardManager,
   mockPortScannerCallbacks,
   mockNextConnectionManagers,
-  mockNextPortForwardManagers
+  mockNextPortForwardManagers,
+  routeExternalPtyDataMock,
+  routeExternalPtyReplayMock,
+  routeExternalPtyExitMock
 } = vi.hoisted(() => ({
   handleMock: vi.fn(),
   powerMonitorOffMock: vi.fn(),
@@ -81,7 +84,10 @@ const {
   },
   mockPortScannerCallbacks: new Map<string, unknown>(),
   mockNextConnectionManagers: [] as unknown[],
-  mockNextPortForwardManagers: [] as unknown[]
+  mockNextPortForwardManagers: [] as unknown[],
+  routeExternalPtyDataMock: vi.fn(),
+  routeExternalPtyReplayMock: vi.fn(),
+  routeExternalPtyExitMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -167,6 +173,12 @@ vi.mock('./pty', () => ({
   isRendererPtyOutputPaused: vi.fn().mockReturnValue(false)
 }))
 
+vi.mock('./pty-renderer-delivery-router', () => ({
+  routeExternalPtyData: routeExternalPtyDataMock,
+  routeExternalPtyReplay: routeExternalPtyReplayMock,
+  routeExternalPtyExit: routeExternalPtyExitMock
+}))
+
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
   registerSshFilesystemProvider: vi.fn(),
   unregisterSshFilesystemProvider: vi.fn(),
@@ -225,7 +237,11 @@ import {
   getSshPtyProvider,
   getPtyIdsForConnection
 } from './pty'
-import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
+import {
+  MAX_TRACKED_SSH_CONNECTION_GENERATIONS,
+  assertSshMutationExpectation,
+  retainSshConnectionGeneration
+} from '../ssh/ssh-connection-generation'
 
 describe('SSH IPC handlers', () => {
   const handlers = new Map<string, (_event: unknown, args: unknown) => unknown>()
@@ -334,6 +350,9 @@ describe('SSH IPC handlers', () => {
     mockPtyProvider.onReplay.mockReset()
     mockPtyProvider.attachForReconnect.mockReset().mockResolvedValue({})
     mockPtyProvider.shutdown.mockReset()
+    routeExternalPtyDataMock.mockReset()
+    routeExternalPtyReplayMock.mockReset()
+    routeExternalPtyExitMock.mockReset()
     mockPortForwardManager.addForward.mockReset()
     mockPortForwardManager.updateForward.mockReset()
     mockPortForwardManager.removeForward.mockReset()
@@ -479,6 +498,32 @@ describe('SSH IPC handlers', () => {
     await expect(handlers.get('ssh:connect')!(null, { targetId: 'unknown' })).rejects.toThrow(
       'SSH target "unknown" not found'
     )
+  })
+
+  it('rejects the 4,097th retained SSH target before starting connection work', async () => {
+    const target: SshTarget = {
+      id: 'ssh-overflow',
+      label: 'Overflow',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    const leases = Array.from({ length: MAX_TRACKED_SSH_CONNECTION_GENERATIONS }, (_, index) =>
+      retainSshConnectionGeneration(`ssh-cap-${index}`)
+    )
+    mockSshStore.getTarget.mockReturnValue(target)
+
+    try {
+      await expect(handlers.get('ssh:connect')!(null, { targetId: target.id })).rejects.toThrow(
+        'SSH connection generation target capacity exhausted'
+      )
+      expect(mockConnectionManager.connect).not.toHaveBeenCalled()
+      expect(mockDeployAndLaunchRelay).not.toHaveBeenCalled()
+    } finally {
+      for (const lease of leases) {
+        lease.release()
+      }
+    }
   })
 
   it('ssh:connect calls connection manager', async () => {
@@ -848,7 +893,7 @@ describe('SSH IPC handlers', () => {
     }
   })
 
-  it('forwards remote PTY events into the runtime', async () => {
+  it('forwards remote PTY events through shared renderer delivery', async () => {
     const runtime = {
       onPtyData: vi.fn(),
       onPtyExit: vi.fn()
@@ -881,13 +926,12 @@ describe('SSH IPC handlers', () => {
     onData?.({ id: 'remote-pty', data: 'hello' })
     onExit?.({ id: 'remote-pty', code: 7 })
 
-    expect(runtime.onPtyData).toHaveBeenCalledWith(
-      'remote-pty',
-      'hello',
-      expect.any(Number),
-      'hello'.length,
-      undefined
-    )
+    expect(routeExternalPtyDataMock).toHaveBeenCalledWith({
+      id: 'remote-pty',
+      data: 'hello'
+    })
+    expect(routeExternalPtyExitMock).toHaveBeenCalledWith({ id: 'remote-pty', code: 7 })
+    expect(runtime.onPtyData).not.toHaveBeenCalled()
     expect(runtime.onPtyExit).toHaveBeenCalledWith('remote-pty', 7, undefined)
   })
 
@@ -1250,11 +1294,11 @@ describe('SSH IPC handlers', () => {
         connectionGeneration: 1
       }
     })
-    expect(secondWindow.webContents.send).toHaveBeenCalledWith(
-      'pty:data',
-      expect.objectContaining({ id: 'remote-pty', data: 'hello' })
-    )
-    expect(secondWindow.webContents.send).toHaveBeenCalledWith('pty:exit', {
+    expect(routeExternalPtyDataMock).toHaveBeenCalledWith({
+      id: 'remote-pty',
+      data: 'hello'
+    })
+    expect(routeExternalPtyExitMock).toHaveBeenCalledWith({
       id: 'remote-pty',
       code: 9
     })
@@ -1262,13 +1306,7 @@ describe('SSH IPC handlers', () => {
       targetId: 'ssh-1',
       ports: expect.arrayContaining([expect.objectContaining({ port: 3000 })])
     })
-    expect(secondRuntime.onPtyData).toHaveBeenCalledWith(
-      'remote-pty',
-      'hello',
-      expect.any(Number),
-      'hello'.length,
-      undefined
-    )
+    expect(secondRuntime.onPtyData).not.toHaveBeenCalled()
     expect(secondRuntime.onPtyExit).toHaveBeenCalledWith('remote-pty', 9, undefined)
     expect(firstRuntime.onPtyData).not.toHaveBeenCalled()
     expect(firstRuntime.onPtyExit).not.toHaveBeenCalled()

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -18,6 +18,7 @@ import type {
 } from '../../shared/ssh-types'
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../shared/constants'
 import { isRuntimeOwnedSshTargetId } from '../../shared/execution-host'
+import { clampSshConnectionError } from '../../shared/ssh-retained-payload-admission'
 import { isAuthError } from '../ssh/ssh-connection-utils'
 import { forceStopRelayForTarget } from '../ssh/ssh-relay-reset'
 import { isSshPtyNotFoundError } from '../providers/ssh-pty-errors'
@@ -42,7 +43,9 @@ import {
   advanceSshConnectionGeneration,
   getSshConnectionGeneration,
   initializeSshConnectionGenerationSession,
-  resetSshConnectionGenerations
+  resetSshConnectionGenerations,
+  retainSshConnectionGeneration,
+  type SshConnectionGenerationLease
 } from '../ssh/ssh-connection-generation'
 
 let sshStore: SshConnectionStore | null = null
@@ -135,6 +138,24 @@ export async function removeRegisteredSshTarget(targetId: string): Promise<void>
 
 // One session per SSH target owns the whole relay lifecycle (mux, providers, abort controller, state machine).
 const activeSessions = new Map<string, SshRelaySession>()
+const activeSessionGenerationLeases = new Map<string, SshConnectionGenerationLease>()
+
+function retainActiveSessionGeneration(targetId: string): boolean {
+  if (activeSessionGenerationLeases.has(targetId)) {
+    return false
+  }
+  activeSessionGenerationLeases.set(targetId, retainSshConnectionGeneration(targetId))
+  return true
+}
+
+function releaseActiveSessionGeneration(targetId: string): void {
+  const lease = activeSessionGenerationLeases.get(targetId)
+  if (!lease) {
+    return
+  }
+  activeSessionGenerationLeases.delete(targetId)
+  lease.release()
+}
 
 export function getActiveSshAiVaultHostInfo(targetId: string): SshRelayAiVaultHostInfo | null {
   if (isRuntimeOwnedSshTargetId(targetId)) {
@@ -173,6 +194,7 @@ async function teardownActiveSshSession(
   await portForwardManager?.removeAllForwards(targetId)
   teardown(session)
   activeSessions.delete(targetId)
+  releaseActiveSessionGeneration(targetId)
   clearRelayLostBackoff(targetId)
   clearRelayStateOverride(targetId)
 }
@@ -184,7 +206,6 @@ function relayGracePeriodForTarget(target: SshTarget | null | undefined): number
 // Why: tabs must share one connect, while a disconnect must invalidate that
 // attempt so its late continuation cannot clobber a replacement.
 type ConnectAttempt = {
-  generation: number
   promise: Promise<SshConnectionState>
 }
 
@@ -263,6 +284,7 @@ function withSshRemotePlatform(targetId: string, state: SshConnectionState): Ssh
   const remotePlatform = activeSessions.get(targetId)?.getHostPlatform()?.os
   return {
     ...state,
+    error: clampSshConnectionError(state.error),
     connectionGeneration: currentConnectGeneration(targetId),
     ...(remotePlatform ? { remotePlatform } : {})
   }
@@ -804,31 +826,41 @@ export function registerSshHandlers(
       appendFileSync(e2eProbePath, `${JSON.stringify(targetId)}\n`)
       throw new Error('e2e_forbidden_local_ssh_connect')
     }
-    const observedGeneration = currentConnectGeneration(targetId)
-    const reset = resetRelayInFlight.get(targetId)
-    if (reset) {
-      await reset
+    const target = sshStore!.getTarget(targetId)
+    if (!target) {
+      throw new Error(`SSH target "${targetId}" not found`)
     }
-
-    // Why: serialize concurrent ssh:connect for the same target; interleaved connects otherwise leak the first session.
-    const existing = connectInFlight.get(targetId)
-    if (existing) {
-      return existing.promise
-    }
-    if (currentConnectGeneration(targetId) !== observedGeneration) {
-      throw connectCancelledError()
-    }
-
-    pendingTransportReconnects.delete(targetId)
-    const promise = doConnect(targetId)
-    const attempt = { generation: currentConnectGeneration(targetId), promise }
-    connectInFlight.set(targetId, attempt)
+    const generationLease = retainSshConnectionGeneration(targetId)
+    let observedGeneration = currentConnectGeneration(targetId)
     try {
-      return await promise
-    } finally {
-      if (connectInFlight.get(targetId) === attempt) {
-        connectInFlight.delete(targetId)
+      const reset = resetRelayInFlight.get(targetId)
+      if (reset) {
+        await reset
+        observedGeneration = currentConnectGeneration(targetId)
       }
+
+      // Why: serialize concurrent ssh:connect for the same target; interleaved connects otherwise leak the first session.
+      const existing = connectInFlight.get(targetId)
+      if (existing) {
+        return existing.promise
+      }
+      if (currentConnectGeneration(targetId) !== observedGeneration) {
+        throw connectCancelledError()
+      }
+
+      pendingTransportReconnects.delete(targetId)
+      const promise = doConnect(targetId)
+      const attempt = { promise }
+      connectInFlight.set(targetId, attempt)
+      try {
+        return await promise
+      } finally {
+        if (connectInFlight.get(targetId) === attempt) {
+          connectInFlight.delete(targetId)
+        }
+      }
+    } finally {
+      generationLease.release()
     }
   }
 
@@ -862,7 +894,14 @@ export function registerSshHandlers(
       return getPublicSshState(targetId)!
     }
 
-    const generation = advanceSshConnectionGeneration(targetId)
+    const createdGenerationOwnership = retainActiveSessionGeneration(targetId)
+    const generation = createdGenerationOwnership
+      ? currentConnectGeneration(targetId)
+      : advanceSshConnectionGeneration(targetId)
+    if (generation === null) {
+      releaseActiveSessionGeneration(targetId)
+      throw connectCancelledError()
+    }
     clearRelayStateOverride(targetId)
     let conn
     // Why: tear down any existing session first to avoid leaking its multiplexer, providers, and timers (double-connect / reconnect-after-error).
@@ -907,6 +946,7 @@ export function registerSshHandlers(
       // Why: clear this failed connect's flag so a later non-prompting connect isn't deferred.
       credentialRequestedForTarget.delete(targetId)
       activeSessions.delete(targetId)
+      releaseActiveSessionGeneration(targetId)
       clearRelayLostBackoff(targetId)
       clearRelayStateOverride(targetId)
       broadcastSshState(getCurrentMainWindow, targetId, {
@@ -945,6 +985,7 @@ export function registerSshHandlers(
         throw connectCancelledError()
       }
       activeSessions.delete(targetId)
+      releaseActiveSessionGeneration(targetId)
       clearRelayLostBackoff(targetId)
       await connectionManager!.disconnect(targetId)
       throw err
@@ -1020,6 +1061,7 @@ export function registerSshHandlers(
       await portForwardManager!.removeAllForwards(args.targetId)
       session.dispose()
       activeSessions.delete(args.targetId)
+      releaseActiveSessionGeneration(args.targetId)
       clearRelayLostBackoff(args.targetId)
       clearRelayStateOverride(args.targetId)
     }
@@ -1027,46 +1069,53 @@ export function registerSshHandlers(
   })
 
   async function doResetRelay(targetId: string, target: SshTarget): Promise<void> {
-    const inFlightConnect = connectInFlight.get(targetId)
-    if (inFlightConnect) {
-      try {
-        // Why: resetting activeSessions mid-deploy would dispose the session doConnect will use.
-        await inFlightConnect.promise
-      } catch {
-        // The reset can still recover a stale remote relay after a failed connect.
-      }
-    }
-
-    const session = activeSessions.get(targetId)
-    if (session) {
-      await portForwardManager!.removeAllForwards(targetId)
-      // Why: detach() not dispose() — reset has its own stale-lease semantics below that dispose()'s clean-termination recording would hide.
-      session.detach()
-      activeSessions.delete(targetId)
-      clearRelayLostBackoff(targetId)
-    }
-
-    const existingConn = connectionManager!.getConnection(targetId)
-    const conn = existingConn ?? (await connectionManager!.connect(target))
+    const generationLease = retainSshConnectionGeneration(targetId)
     try {
-      await forceStopRelayForTarget(conn, targetId)
-    } finally {
-      const ptyIds = new Set(getPtyIdsForConnection(targetId))
-      for (const lease of persistedStore!.getSshRemotePtyLeases(targetId)) {
-        if (lease.state !== 'terminated' && lease.state !== 'expired') {
-          ptyIds.add(lease.ptyId)
-          persistedStore!.markSshRemotePtyLease(targetId, lease.ptyId, 'expired')
+      const inFlightConnect = connectInFlight.get(targetId)
+      if (inFlightConnect) {
+        try {
+          // Why: resetting activeSessions mid-deploy would dispose the session doConnect will use.
+          await inFlightConnect.promise
+        } catch {
+          // The reset can still recover a stale remote relay after a failed connect.
         }
       }
-      // Why: reset force-kills the remote relay, so every local PTY handle it owned is stale even if the reset command failed after SIGTERM.
-      for (const ptyId of ptyIds) {
-        const appPtyId = toAppSshPtyId(targetId, ptyId)
-        clearProviderPtyState(appPtyId)
-        deletePtyOwnership(appPtyId)
+      advanceSshConnectionGeneration(targetId)
+
+      const session = activeSessions.get(targetId)
+      if (session) {
+        await portForwardManager!.removeAllForwards(targetId)
+        // Why: detach() not dispose() — reset has its own stale-lease semantics below that dispose()'s clean-termination recording would hide.
+        session.detach()
+        activeSessions.delete(targetId)
+        releaseActiveSessionGeneration(targetId)
+        clearRelayLostBackoff(targetId)
       }
-      // Why: reset's connect() may trip onCredentialRequest; clear so a later non-prompting doConnect doesn't persist lastRequiredPassphrase=true.
-      credentialRequestedForTarget.delete(targetId)
-      await connectionManager!.disconnect(targetId)
+
+      const existingConn = connectionManager!.getConnection(targetId)
+      const conn = existingConn ?? (await connectionManager!.connect(target))
+      try {
+        await forceStopRelayForTarget(conn, targetId)
+      } finally {
+        const ptyIds = new Set(getPtyIdsForConnection(targetId))
+        for (const lease of persistedStore!.getSshRemotePtyLeases(targetId)) {
+          if (lease.state !== 'terminated' && lease.state !== 'expired') {
+            ptyIds.add(lease.ptyId)
+            persistedStore!.markSshRemotePtyLease(targetId, lease.ptyId, 'expired')
+          }
+        }
+        // Why: reset force-kills the remote relay, so every local PTY handle it owned is stale even if the reset command failed after SIGTERM.
+        for (const ptyId of ptyIds) {
+          const appPtyId = toAppSshPtyId(targetId, ptyId)
+          clearProviderPtyState(appPtyId)
+          deletePtyOwnership(appPtyId)
+        }
+        // Why: reset's connect() may trip onCredentialRequest; clear so a later non-prompting doConnect doesn't persist lastRequiredPassphrase=true.
+        credentialRequestedForTarget.delete(targetId)
+        await connectionManager!.disconnect(targetId)
+      }
+    } finally {
+      generationLease.release()
     }
   }
 
@@ -1139,7 +1188,9 @@ export function registerSshHandlers(
     }
 
     testingTargets.add(args.targetId)
+    let generationLease: SshConnectionGenerationLease | null = null
     try {
+      generationLease = retainSshConnectionGeneration(args.targetId)
       const conn = await connectionManager!.connect(target)
       const state = conn.getState()
       await connectionManager!.disconnect(args.targetId)
@@ -1150,6 +1201,7 @@ export function registerSshHandlers(
         error: err instanceof Error ? err.message : String(err)
       }
     } finally {
+      generationLease?.release()
       testingTargets.delete(args.targetId)
       // Why: clear so a test's credential prompt doesn't leave lastRequiredPassphrase=true and defer this target at startup.
       credentialRequestedForTarget.delete(args.targetId)
@@ -1271,6 +1323,10 @@ export async function resetSshHandlerStateForTests(): Promise<void> {
     session.dispose()
   }
   activeSessions.clear()
+  for (const lease of activeSessionGenerationLeases.values()) {
+    lease.release()
+  }
+  activeSessionGenerationLeases.clear()
   for (const targetId of relayLostBackoff.keys()) {
     clearRelayLostBackoff(targetId)
   }

--- a/src/main/ipc/terminal-preview-admission.test.ts
+++ b/src/main/ipc/terminal-preview-admission.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handlers, ipcMainMock } = vi.hoisted(() => {
+  const map = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    handlers: map,
+    ipcMainMock: {
+      removeHandler: vi.fn(),
+      handle: (channel: string, fn: (...args: unknown[]) => unknown) => map.set(channel, fn)
+    }
+  }
+})
+
+vi.mock('electron', () => ({ ipcMain: ipcMainMock }))
+vi.mock('../window/dashboard-popout-window', () => ({
+  isDashboardPopoutRenderer: () => true
+}))
+
+import {
+  registerTerminalPreviewHandlers,
+  TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS,
+  TERMINAL_PREVIEW_MAX_ENTRIES_TOTAL
+} from './terminal-preview'
+
+function makeRuntime() {
+  return {
+    serializeTerminalBuffer: vi.fn(async () => ({ data: '', cols: 80, rows: 24, seq: 0 })),
+    subscribeToTerminalData: vi.fn(() => vi.fn()),
+    subscribeToTerminalResize: vi.fn(() => vi.fn()),
+    registerRawTerminalViewSubscriber: vi.fn(() => vi.fn()),
+    writeTerminalPreviewInput: vi.fn(async () => true),
+    updateRemoteDesktopViewer: vi.fn(async () => true),
+    unregisterRemoteDesktopViewer: vi.fn(async () => true),
+    getTerminalSize: vi.fn(() => ({ cols: 80, rows: 24 }))
+  }
+}
+
+function makeSender(id: number) {
+  return {
+    id,
+    isDestroyed: () => false,
+    send: vi.fn(),
+    once: vi.fn()
+  }
+}
+
+function eventFor(sender: ReturnType<typeof makeSender>) {
+  return { sender } as never
+}
+
+describe('terminal preview aggregate admission', () => {
+  beforeEach(() => handlers.clear())
+
+  it('bounds output streams per renderer without affecting replacements', async () => {
+    const runtime = makeRuntime()
+    registerTerminalPreviewHandlers(runtime as never)
+    const sender = makeSender(1)
+    const connect = handlers.get('terminalPreview:connect')!
+
+    for (let index = 0; index < TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS; index += 1) {
+      await connect(eventFor(sender), { ptyId: `pty-${index}` })
+    }
+    await expect(connect(eventFor(sender), { ptyId: 'overflow' })).resolves.toEqual({
+      snapshot: null,
+      replay: []
+    })
+    await expect(connect(eventFor(sender), { ptyId: 'pty-0' })).resolves.toMatchObject({
+      snapshot: { cols: 80, rows: 24 }
+    })
+    expect(runtime.subscribeToTerminalData).toHaveBeenCalledTimes(
+      TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS + 1
+    )
+  })
+
+  it('bounds output streams across renderers', async () => {
+    const runtime = makeRuntime()
+    registerTerminalPreviewHandlers(runtime as never)
+    const connect = handlers.get('terminalPreview:connect')!
+
+    for (let index = 0; index < TERMINAL_PREVIEW_MAX_ENTRIES_TOTAL; index += 1) {
+      const sender = makeSender(Math.floor(index / TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS) + 1)
+      await connect(eventFor(sender), { ptyId: `pty-${index}` })
+    }
+    await expect(connect(eventFor(makeSender(99)), { ptyId: 'overflow' })).resolves.toEqual({
+      snapshot: null,
+      replay: []
+    })
+    expect(runtime.subscribeToTerminalData).toHaveBeenCalledTimes(
+      TERMINAL_PREVIEW_MAX_ENTRIES_TOTAL
+    )
+  })
+
+  it('bounds independent fit claims per renderer', async () => {
+    const runtime = makeRuntime()
+    registerTerminalPreviewHandlers(runtime as never)
+    const sender = makeSender(1)
+    const fit = handlers.get('terminalPreview:fit')!
+
+    for (let index = 0; index < TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS; index += 1) {
+      await fit(eventFor(sender), { ptyId: `pty-${index}`, cols: 80, rows: 24 })
+    }
+    await expect(
+      fit(eventFor(sender), { ptyId: 'overflow', cols: 80, rows: 24 })
+    ).resolves.toBeNull()
+    expect(runtime.updateRemoteDesktopViewer).toHaveBeenCalledTimes(
+      TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS
+    )
+  })
+})

--- a/src/main/ipc/terminal-preview-output-stream-memory.test.ts
+++ b/src/main/ipc/terminal-preview-output-stream-memory.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RETAINED_STRING_CHUNK_LIMIT } from '../../shared/string-chunk-compaction'
+import {
+  TERMINAL_PREVIEW_OUTPUT_BATCH_MAX_BYTES,
+  TERMINAL_PREVIEW_PENDING_MAX_RECORDS,
+  TerminalPreviewOutputStream
+} from './terminal-preview-output-stream'
+
+function makeStream() {
+  const contents = {
+    isDestroyed: () => false,
+    send: vi.fn()
+  }
+  const stream = new TerminalPreviewOutputStream(contents as never, 'pty-1', vi.fn(), vi.fn())
+  return { contents, stream }
+}
+
+describe('TerminalPreviewOutputStream memory bounds', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('ignores empty snapshot records and resyncs when tiny records reach the count cap', () => {
+    const { stream } = makeStream()
+
+    for (let index = 0; index < 100_000; index += 1) {
+      stream.append('', { seq: index, rawLength: 0 })
+    }
+    expect(stream.consumeInitialOverflow()).toBe(false)
+
+    for (let index = 0; index <= TERMINAL_PREVIEW_PENDING_MAX_RECORDS; index += 1) {
+      stream.append('x', { seq: index + 1, rawLength: 1 })
+    }
+    expect(stream.consumeInitialOverflow()).toBe(true)
+  })
+
+  it('compacts 50,000 live fragments without changing the emitted output', () => {
+    vi.useFakeTimers()
+    const { contents, stream } = makeStream()
+    stream.completeSnapshot()
+
+    for (let index = 0; index < 50_000; index += 1) {
+      stream.append(String.fromCharCode(97 + (index % 26)))
+    }
+    const retained = stream as unknown as { batchChunks: string[] }
+    expect(retained.batchChunks.length).toBeLessThanOrEqual(RETAINED_STRING_CHUNK_LIMIT)
+
+    vi.advanceTimersByTime(5)
+    expect(contents.send).toHaveBeenCalledWith(
+      'terminalPreview:data',
+      expect.objectContaining({ data: expect.stringMatching(/^[a-z]{50000}$/), bytes: 50_000 })
+    )
+  })
+
+  it('resyncs when a stalled renderer accumulates too many tiny pending batches', () => {
+    vi.useFakeTimers()
+    const { contents, stream } = makeStream()
+    stream.completeSnapshot()
+    const fullBatch = 'x'.repeat(TERMINAL_PREVIEW_OUTPUT_BATCH_MAX_BYTES)
+
+    for (let index = 0; index < 8; index += 1) {
+      stream.append(fullBatch)
+    }
+    for (let index = 0; index <= TERMINAL_PREVIEW_PENDING_MAX_RECORDS; index += 1) {
+      stream.append('x')
+      vi.advanceTimersByTime(5)
+    }
+
+    stream.acknowledge(8 * TERMINAL_PREVIEW_OUTPUT_BATCH_MAX_BYTES)
+    expect(contents.send).toHaveBeenLastCalledWith('terminalPreview:data', {
+      type: 'resync',
+      ptyId: 'pty-1'
+    })
+  })
+})

--- a/src/main/ipc/terminal-preview-output-stream.ts
+++ b/src/main/ipc/terminal-preview-output-stream.ts
@@ -1,4 +1,5 @@
 import type { WebContents } from 'electron'
+import { appendCompactedStringChunk } from '../../shared/string-chunk-compaction'
 import { iterateTerminalInputChunks } from '../../shared/terminal-input'
 import type { TerminalPreviewDataPayload } from '../../shared/terminal-preview'
 
@@ -7,6 +8,7 @@ export const TERMINAL_PREVIEW_OUTPUT_BATCH_MAX_BYTES = 64 * 1024
 const OUTPUT_IN_FLIGHT_MAX_BYTES = 512 * 1024
 const OUTPUT_PENDING_MAX_BYTES = 256 * 1024
 const INITIAL_PENDING_MAX_BYTES = 256 * 1024
+export const TERMINAL_PREVIEW_PENDING_MAX_RECORDS = 4_096
 
 export type TerminalPreviewOutputMeta = {
   seq?: number
@@ -81,7 +83,7 @@ export class TerminalPreviewOutputStream {
   }
 
   append(data: string, meta?: TerminalPreviewOutputMeta): void {
-    if (this.isDisposed || this.awaitingReconnect || this.resyncPending) {
+    if (data.length === 0 || this.isDisposed || this.awaitingReconnect || this.resyncPending) {
       return
     }
     if (this.bufferingSnapshot) {
@@ -205,7 +207,10 @@ export class TerminalPreviewOutputStream {
     }
     this.pendingBatches.push({ data, bytes })
     this.pendingBatchBytes += bytes
-    if (this.pendingBatchBytes > OUTPUT_PENDING_MAX_BYTES) {
+    if (
+      this.pendingBatchBytes > OUTPUT_PENDING_MAX_BYTES ||
+      this.pendingBatches.length > TERMINAL_PREVIEW_PENDING_MAX_RECORDS
+    ) {
       // Why: a stuck renderer heals from a fresh authoritative snapshot instead of retaining output without bound.
       this.pendingBatches = []
       this.pendingBatchBytes = 0
@@ -237,7 +242,7 @@ export class TerminalPreviewOutputStream {
       ) {
         this.flushBatch()
       }
-      this.batchChunks.push(chunk)
+      appendCompactedStringChunk(this.batchChunks, chunk)
       this.batchBytes += bytes
       if (this.batchBytes >= TERMINAL_PREVIEW_OUTPUT_BATCH_MAX_BYTES) {
         this.flushBatch()
@@ -249,11 +254,18 @@ export class TerminalPreviewOutputStream {
   }
 
   private appendInitial(data: string, meta?: TerminalPreviewOutputMeta): void {
+    if (this.initialPendingOverflowed) {
+      return
+    }
     const bytes = Buffer.byteLength(data, 'utf8')
     this.initialPending.push({ data, bytes, meta })
     this.initialPendingBytes += bytes
-    while (this.initialPendingBytes > INITIAL_PENDING_MAX_BYTES && this.initialPending.length > 0) {
-      this.initialPendingBytes -= this.initialPending.shift()!.bytes
+    if (
+      this.initialPendingBytes > INITIAL_PENDING_MAX_BYTES ||
+      this.initialPending.length > TERMINAL_PREVIEW_PENDING_MAX_RECORDS
+    ) {
+      this.initialPending = []
+      this.initialPendingBytes = 0
       this.initialPendingOverflowed = true
     }
   }

--- a/src/main/ipc/terminal-preview.ts
+++ b/src/main/ipc/terminal-preview.ts
@@ -11,9 +11,30 @@ import {
 } from './terminal-preview-output-stream'
 
 const PREVIEW_ID_MAX_LENGTH = 4096
+export const TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS = 64
+export const TERMINAL_PREVIEW_MAX_ENTRIES_TOTAL = 256
 
 function isValidPtyId(value: unknown): value is string {
   return typeof value === 'string' && value.length > 0 && value.length <= PREVIEW_ID_MAX_LENGTH
+}
+
+function canRetainPreviewEntry<T>(
+  registry: Map<number, Map<string, T>>,
+  contentsId: number,
+  ptyId: string
+): boolean {
+  const retained = registry.get(contentsId)
+  if (retained?.has(ptyId)) {
+    return true
+  }
+  if ((retained?.size ?? 0) >= TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS) {
+    return false
+  }
+  let total = 0
+  for (const perContents of registry.values()) {
+    total += perContents.size
+  }
+  return total < TERMINAL_PREVIEW_MAX_ENTRIES_TOTAL
 }
 
 /** Pop-out terminal transport with an atomic snapshot/live boundary. */
@@ -88,6 +109,9 @@ export function registerTerminalPreviewHandlers(runtime: OrcaRuntimeService): vo
       }
       const ptyId = args.ptyId
       const perPty = subscriptionsFor(event.sender)
+      if (!canRetainPreviewEntry(subscriptionsByContents, event.sender.id, ptyId)) {
+        return { snapshot: null, replay: [] }
+      }
       perPty.get(ptyId)?.dispose()
 
       const subscription = new TerminalPreviewOutputStream(
@@ -210,6 +234,9 @@ export function registerTerminalPreviewHandlers(runtime: OrcaRuntimeService): vo
       // Why: guarantees the destroyed hook exists even if this claim outlives
       // the current output stream across a resync reconnect.
       subscriptionsFor(event.sender)
+      if (!canRetainPreviewEntry(fitClaimsByContents, event.sender.id, ptyId)) {
+        return null
+      }
       let claimed = fitClaimsByContents.get(event.sender.id)
       if (!claimed) {
         claimed = new Map()

--- a/src/main/ipc/terminal-render-desync-evidence.ts
+++ b/src/main/ipc/terminal-render-desync-evidence.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, opendir, rm, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { app, ipcMain } from 'electron'
 import type {
@@ -79,29 +79,23 @@ export async function writeTerminalRenderDesyncEvidence(
 }
 
 async function pruneRenderDesyncEvidence(root: string, currentDirectory: string): Promise<void> {
-  const entries = await readdir(root, { withFileTypes: true })
-  const captures = await Promise.all(
-    entries
-      .filter((entry) => entry.isDirectory())
-      .map(async (entry) => {
-        const directory = path.join(root, entry.name)
-        const [directoryStat, files] = await Promise.all([
-          stat(directory),
-          readdir(directory, { withFileTypes: true })
-        ])
-        const sizes = await Promise.all(
-          files.filter((file) => file.isFile()).map((file) => stat(path.join(directory, file.name)))
-        )
-        return {
-          directory,
-          bytes: sizes.reduce((total, file) => total + file.size, 0),
-          modifiedAt: directoryStat.mtimeMs
-        }
-      })
-  )
+  const captures: EvidenceCapture[] = []
+  const entries = await opendir(root)
+  for await (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+    captures.push(await inspectEvidenceCapture(path.join(root, entry.name)))
+    captures.sort((a, b) => a.modifiedAt - b.modifiedAt)
+    if (captures.length > MAX_CAPTURE_DIRECTORIES) {
+      const removableIndex = captures.findIndex((capture) => capture.directory !== currentDirectory)
+      const [capture] = captures.splice(Math.max(removableIndex, 0), 1)
+      await rm(capture.directory, { recursive: true, force: true })
+    }
+  }
   captures.sort((a, b) => a.modifiedAt - b.modifiedAt)
   let totalBytes = captures.reduce((total, capture) => total + capture.bytes, 0)
-  while (captures.length > MAX_CAPTURE_DIRECTORIES || totalBytes > MAX_EVIDENCE_BYTES) {
+  while (totalBytes > MAX_EVIDENCE_BYTES) {
     const removableIndex = captures.findIndex((capture) => capture.directory !== currentDirectory)
     const index = Math.max(removableIndex, 0)
     const [capture] = captures.splice(index, 1)
@@ -111,4 +105,24 @@ async function pruneRenderDesyncEvidence(root: string, currentDirectory: string)
       throw new Error('Render-desync evidence exceeds the aggregate storage budget')
     }
   }
+}
+
+type EvidenceCapture = {
+  directory: string
+  bytes: number
+  modifiedAt: number
+}
+
+async function inspectEvidenceCapture(directory: string): Promise<EvidenceCapture> {
+  const directoryStat = await stat(directory)
+  const files = await opendir(directory)
+  let bytes = 0
+  for await (const file of files) {
+    if (!file.isFile()) {
+      continue
+    }
+    const fileStat = await stat(path.join(directory, file.name))
+    bytes = Math.min(MAX_EVIDENCE_BYTES + 1, bytes + fileStat.size)
+  }
+  return { directory, bytes, modifiedAt: directoryStat.mtimeMs }
 }


### PR DESCRIPTION
## OOM hardening slice 23/29 — bound PTY/runtime/remote IPC delivery

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **23/29** (base: `oom/22-b-ipc-fs-worktree`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
This slice re-lands the OOM ceilings for the IPC PTY-delivery, remote-runtime, SSH, and terminal-preview surfaces: it bounds the PTY renderer-delivery credit ledger and pending-output maps, caps registered SSH providers/subscriptions/credential prompts/preview streams, and (structurally) reroutes SSH/remote PTY output through the same bounded batched renderer-delivery pipeline used for local PTYs.

### ELI5
Imagine the app is a mailroom that forwards terminal output to the screen. Before, if a firehose of text came in (from a remote machine, a giant folder listing, or a runaway program) the mailroom kept stacking mail forever until it ran out of room and crashed. This change puts labeled shelves with hard size limits everywhere, and when a shelf fills it throws away the extra and just re-photographs the whole screen instead of remembering every scrap. It also makes remote (SSH) terminals use the exact same shelves the local ones already use, so both are protected the same way.

### Proof of OOM fix
- PTY renderer-delivery credit ledger caps (src/main/ipc/pty-renderer-delivery-credit.ts): MAX_PENDING_PTY_DELIVERY_CREDIT_SPANS=4096, MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS_PER_PTY=4096, MAX_RENDERER_PTY_DELIVERY_CREDIT_SPANS=16384, MAX_RENDERER_PTY_DELIVERY_CREDIT_STATES=4096, MAX_...STATE_ID_BYTES=8MB. Overflow collapses spans into settled metadata and acknowledges upstream credit so no flow-control stall. Tests: pty-renderer-delivery-credit.test.ts (flood-collapse, per-PTY cap, aggregate cap, state-count cap, id-byte cap, each settled exactly once).
- Pending PTY-data retention caps (src/main/ipc/pty-renderer-delivery-retention.ts): MAX_PENDING_PTY_DATA_STATES=4096, MAX_PENDING_PTY_DATA_ID_BYTES=8MB, MAX_PENDING_PTY_DATA_CHARS=32MB, MAX_PENDING_PTY_DATA_CREDIT_SPANS=16384, MAX_RENDERER_PTY_DELIVERY_ACCOUNTING_STATES=4096. Rejection settles credit + emits pending-cap restore marker (pane repaints from snapshot). Tests: pty-renderer-delivery-retention.test.ts.
- MAX_REGISTERED_SSH_PTY_PROVIDERS=256 in src/main/ipc/pty.ts; registerSshPtyProvider throws 'ssh_pty_provider_capacity'. listProcesses/reconcile now stream via PtyProcessListAdmission + visitPtyProcessListingsInBatches. Test: pty.test.ts ('fails claimed ensure closed before aggregate owner listings amplify memory').
- Remote-runtime subscription admission (src/main/ipc/runtime-environment-subscription-admission.ts): REMOTE_RUNTIME_MAX_SUBSCRIPTIONS=256, REMOTE_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES=16MB, REMOTE_RUNTIME_MAX_SUBSCRIPTION_ID_BYTES=4KB, per-param 1MB. Claim/release refcount, settled once. Tests: runtime-environment-subscription-admission.test.ts.
- Runtime transport-generation refactored to leased entries (src/main/ipc/runtime-environment-transport-generation.ts) — no tombstone accumulation under unique-environment churn. Tests: runtime-environment-transport-generation.test.ts (10k churn -> 0 tracked).
- SSH credential prompts (src/main/ipc/ssh-passphrase.ts): SSH_MAX_PENDING_CREDENTIAL_REQUESTS=64, SSH_CREDENTIAL_VALUE_MAX_UTF8_BYTES=64KB, detail clamped to SSH_CREDENTIAL_DETAIL_MAX_UTF8_BYTES; oversized targetId rejected without allocating state. Tests: ssh-passphrase.test.ts.
- SSH remote directory browse (src/main/ipc/ssh-browse.ts): FILESYSTEM_DIRECTORY_MAX_RETAINED_BYTES=12MB and FILESYSTEM_DIRECTORY_MAX_ENTRIES=100000; stdout accumulated via GrowingByteBuffer (no quadratic string concat), stderr via bounded tail. Tests: ssh-browse.test.ts (byte-limit reject+channel close, 65k tiny chunks, split-UTF8 filename).
- SSH connection generations (src/main/ipc/ssh.ts): MAX_TRACKED_SSH_CONNECTION_GENERATIONS=4096 via lease; ssh:connect rejects (cap+1)th target with 'SSH connection generation target capacity exhausted'; state.error clamped via clampSshConnectionError. Tests: ssh.test.ts.
- Terminal preview aggregate caps (src/main/ipc/terminal-preview.ts): TERMINAL_PREVIEW_MAX_ENTRIES_PER_CONTENTS=64, TERMINAL_PREVIEW_MAX_ENTRIES_TOTAL=256 for both output streams and fit claims. Tests: terminal-preview-admission.test.ts.
- Terminal preview output stream (src/main/ipc/terminal-preview-output-stream.ts): TERMINAL_PREVIEW_PENDING_MAX_RECORDS=4096 record cap in addition to byte caps; batch chunks compacted via appendCompactedStringChunk (RETAINED_STRING_CHUNK_LIMIT). Tests: terminal-preview-output-stream-memory.test.ts.
- Repo icon picker (src/main/ipc/shell-repo-icon-picker.ts): readNodeFileWithinLimit(MAX_REPO_ICON_UPLOAD_BYTES=256KB) with post-stat re-check, plus assertRasterImagePreviewWithinLimits (max 32768px dimension / 32M pixels). Tests: shell.test.ts.
- Render-desync evidence pruning (src/main/ipc/terminal-render-desync-evidence.ts): streamed via opendir with incremental capture eviction and per-capture byte accounting clamped to MAX_EVIDENCE_BYTES+1 (bounds pruning-time memory).

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **low**: Remote workspace session patches are now applied at most 4 targets concurrently (REMOTE_WORKSPACE_PATCH_CONCURRENCY) instead of all-at-once via Promise.all. With many connected SSH targets, propagation of a workspace change is slightly more serialized. Correctness is unchanged (all targets still patched). _(trigger: More than 4 connected remote targets receiving a workspace patch.)_
- **high**: At credit-ledger state pressure, ACK ordering can release a newly sent remote/local PTY credit span before the renderer has processed it. _(trigger: More than 4,096 distinct PTYs retain in-flight delivery credit, an evicted PTY ID sends again, and the renderer then ACKs bytes from that ID's older delivery generation.)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Registered SSH PTY provider #257 throws ssh_pty_provider_capacity (ordinary use is 1-3 SSH connections).
- 257th concurrent remote-runtime subscription, or >16MB aggregate retained params, rejected as remote_runtime_busy.
- 65th concurrent pending SSH credential prompt returns null (auth fails); a submitted passphrase >64KB is rejected as null.
- 4097th distinct tracked SSH connection-generation target rejects ssh:connect (leases normally release on teardown, so this only trips under thousands of live/leaked targets).
- 65th terminal preview stream per pop-out window (or 257th total) silently returns {snapshot:null, replay:[]}; 65th fit claim returns null.
- Per-PTY pending output above 32MB (or 16384 credit spans / 4096 states / 8MB of ids) is dropped to a restore-sentinel; pane repaints from the main-owned snapshot instead of OOMing.
- A stalled terminal-preview renderer accumulating >4096 pending batches (or >256KB) is force-resynced from a fresh snapshot.
- SSH/remote PTY output is now routed through the same shared, batched, flow-controlled renderer-delivery pipeline as local PTYs (ssh.ts now calls routeExternalPtyData/Exit/Replay -> pty.ts routeProviderData) instead of the old direct runtime.onPtyData + webContents.send path. This changes remote terminal delivery timing/batching and subjects remote output to the pending-data caps and producer flow-control credit. It is exercised on every SSH terminal, not just under overload, so it warrants explicit sign-off even though CI passed. _(only when: Any SSH/remote-runtime terminal session (ordinary use).)_
- Browsing a remote SSH directory that emits more than 100,000 entries or >12MB of listing bytes now rejects with FILESYSTEM_DIRECTORY_LIMIT_MESSAGE (and closes the channel) instead of loading; previously the listing was unbounded. Users on servers with very large directories (e.g. huge maildirs, /nix/store) see an error toast rather than a partial/complete listing. _(only when: SSH file browser opening a directory with >100k entries or >12MB of names.)_
- Empty terminal-preview data records (append('')) are now dropped early, and repo-icon PNGs are additionally rejected if their raster dimensions exceed 32768px / 32M pixels even when under the 256KB byte cap. Both are edge cases unlikely to affect real content. _(only when: Empty preview chunks; or a >32768px-dimension icon PNG under 256KB.)_
- Repo icon uploads are now hard-capped at 256KB (MAX_REPO_ICON_UPLOAD_BYTES in src/shared/repo-icon.ts) and 400KB data-URL length. A user who picks a large image (e.g. a phone photo) as a custom repo/worktree icon now gets 'Repo icon image must be 256KB or smaller.' instead of the previously-unbounded load. Clear error, not silent; icons are meant to be small, so this is a benign edge. _(only when: Choosing an image >256KB as a custom repo icon via shell-repo-icon-picker.)_
- SSH file-browser listings for a single directory with >100,000 entries or >12MB of names now reject with FILESYSTEM_DIRECTORY_LIMIT_MESSAGE and close the channel (ssh-browse.ts, limits from src/shared/filesystem-directory-listing-limit.ts). Real servers with huge single directories (e.g. browsing /nix/store or a giant maildir) would see an error toast instead of a listing; ordinary directories are orders of magnitude below. _(only when: SSH browser opening a directory with >100k entries or >12MB of names.)_

### Build / CI
- Part of the **Main services + CLI** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #25** (whole-repo interconnection — see stack README). Content is exact production code.
- ⚠️ **Merge-time reconciliation** with recent `main`:
  - `src/main/ipc/pty.ts`: TRUE CONFLICT with perf(pty) #10113 (constant-time delivery-pressure): combine the `pendingDataTotalChars`/`deletePendingPtyData`/`setPendingPtyData` constant-time accounting with the OOM `PendingPtyDataMap` retention bound — keep both.

### ⚠️ Inherited edge-case defect(s) — pre-existing in #10179
- ~~[high] `src/main/ipc/pty-renderer-delivery-credit.ts`~~ — **refuted** (not a real bug): [REFUTED false-positive] Claimed evicted-PTY ACK misapplication is unreachable: recordSent is gated behind the accounting map admit() which rejects the 4097th PTY before the ledger eviction path can fire (ledger keys ⊆ accounting keys). Latent-fragility only if the two 4096 caps ever diverge.
- ⚠️ [medium] `src/main/ipc/pty.ts` — adversarial-flagged (overload-path only, unverified): After pending PTY output becomes a dropped-output sentinel, a newly salvaged query string is appended without truncating to the 4,096-char remaining allowance; one provider event retained ~4,000,000 chars in a repro.

> Defects **inherited from the original #10179 code** (not introduced by slicing; not present in today's unbounded `main`). Fixed items were patched in-slice and re-verified (typecheck + affected suites); remaining flagged items are overload-only and noted for a fast-follow.

### Adversarial review
- 3 skeptic lens(es) incl. a frontier-model (GPT) cross-check. Sign-off: **FLAGGED — see above**. Residual risk: **high**.
- Skeptic pass on PR #23 (ipc-pty-runtime-remote). Verified every numeric ceiling against source; all sit far above ordinary use: SSH dir listing 100k entries/12MB (src/shared/filesystem-directory-listing-limit.ts); MAX_REGISTERED_SSH_PTY_PROVIDERS=256; MAX_TRACKED_SSH_CONNECTION_GENERATIONS=4096 / 8192 leases; SSH_MAX_PENDING_CREDENTIAL_REQUESTS=64, credential value 64KB, detail 16KB; REMOTE_WORKSPACE_PATCH_CONCURRENCY=4 (mapWithConcurrency, all targets still patched — correctness intact); TERMINAL_PREVIEW 64/window & 256 total; MAX_PENDING_PTY_DATA_CHARS=32MB, 16384 credit spans, 4096 states, 8MB id bytes; repo icon 256KB.

Correction to prior reviewer's MEDIUM claim: it states 'ssh.ts now calls routeExternalPtyData/Exit/Replay'. Inaccurate — git grep at TARGET shows the actual caller of routeExternalPty* is src/main/ssh/ssh-relay-session.ts, which is NOT in this slice's filelist. Within THIS slice, pty.ts only adds the receiving side (routeProviderData, PtyRendererDeliveryCreditLedger, PendingPtyDataMap retention bounds) and installExternalPtyRendererDeliveryRouter; it does not itself reroute remote output. The local PTY batched-delivery pipeline (pendingData Map + flush + sendPtyDataToRenderer flow control) already exists in BASE, so local terminal timing is unchanged below the new 32MB cap. Net: the remote-delivery timing/batching change flagged medium is not triggerable from this slice alone, so I do not treat it as a confirmed normal-path regression here.

Cleanup/lifecycle: ssh.ts adds symmetric releaseActiveSessionGeneration() at every teardown/connect-error/disconnect/reset path plus a per-connect finally lease release; the credit ledger writeOff on exit/drop/reload is exercised by pty-external-renderer-delivery/credit/retention tests. No missing-release path found. ssh-passphrase requestCredential returns null up-front on missing window / bad targetId / over-cap but proceeds normally when a window is present — behaviorally equivalent to BASE on the normal path (isSshRetainedIdentifier only rejects empty or >1024-byte ids; ordinary UUID targetIds pass).

Two low, user-visible-but-clear-error edges (repo icon 256KB cap; SSH huge-directory listing) are the only ordinary-adjacent changes; both surface an explicit message rather than corrupting or silently dropping. No off-by-one, FIFO break, or missing-cleanup defect confirmed. OOM evidence (caps + regression tests) is solid. Recommend opening as a draft PR for human sign-off on the two low edges and on the cross-slice remote-delivery reroute (whose caller lands in the ssh-relay-session slice).
- Correctness notes: `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/ipc/pty-renderer-delivery-credit.ts:132`: Confirmed cap/ordering bug: when the 4,097th in-flight PTY causes an old credit-ledger state to be collapsed and deleted, the corresponding cumulative-delivery accounting row remains. If that evicted PTY ID sends again before the renderer's ACK for its older byte arrives, recordSent creates a fresh ledger state; applyCumulativeAck then applies the old byte's ACK to the fresh span. A standalone reproduction against TARGET printed {"oldAck":1,"newAck":1} after acknowledging only one processed byte; newAck must still be 0. This prematurely returns producer credit for data the renderer has not parsed and defeats flow control under the state-cap overload path. The unique-ID test only checks one-shot eviction and never reuses the evicted ID.; `/Users/nwparker/orca/workspaces/orca/oom-followup/src/main/ipc/pty.ts:2422`: Confirmed ceiling bypass: once pending PTY output is a dropped-output sentinel, the code checks whether existing.data is already at 4,096 chars but appends the entire newly salvaged query string without truncating it to the remaining allowance. A standalone reproduction using TARGET's query extractor retained 4,000,000 chars from one repeated DSR-query chunk despite the declared 4,096-char cap. Subsequent calls stop growth, but one provider event can retain far above the intended O(1) sentinel bound. The regression test covers only two tiny queries and misses a large post-sentinel append.

### Files
34 files changed (+3161 / −654).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
