### PR TITLE
oom(26/29): bound renderer editor & terminal-pane buffers

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/constants/terminal'
 import { useAppStore } from '../store'
 import { folderWorkspaceKey } from '../../../shared/workspace-scope'
+import { mapWithConcurrency } from '../../../shared/map-with-concurrency'
 import { useAllWorktrees } from '../store/selectors'
 import { getConnectionId } from '../lib/connection-context'
 import { basename } from '../lib/path'
@@ -141,6 +142,7 @@ const EditorPanel = lazy(() => import('./editor/EditorPanel'))
 
 // Why: gate handler runs after a dialog advances so a stray carry-over click can't act on the next dialog; ~200ms absorbs a physical double-click while staying responsive.
 const CLOSE_DIALOG_DEBOUNCE_MS = 200
+const CHILD_PROCESS_CHECK_CONCURRENCY = 8
 const EDITOR_TAB_CONTENT_TYPES = new Set<TabContentType>([
   'editor',
   'diff',
@@ -447,15 +449,15 @@ function Terminal(): React.JSX.Element | null {
           }
         )
         if (localPtyIds.length > 0) {
-          void Promise.all(localPtyIds.map((id) => window.api.pty.hasChildProcesses(id))).then(
-            (results) => {
-              if (results.some(Boolean)) {
-                setWindowCloseDialogOpen(true)
-              } else {
-                confirmNativeWindowClose()
-              }
+          void mapWithConcurrency(localPtyIds, CHILD_PROCESS_CHECK_CONCURRENCY, (id) =>
+            window.api.pty.hasChildProcesses(id)
+          ).then((results) => {
+            if (results.some(Boolean)) {
+              setWindowCloseDialogOpen(true)
+            } else {
+              confirmNativeWindowClose()
             }
-          )
+          })
           return
         }
       }

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -76,6 +76,12 @@ import { removeDiffSectionMeasuredHeight } from './diff-section-height-cache'
 import { createCombinedDiffLoadScheduler } from './combined-diff-load-scheduler'
 import { combinedDiffSectionsMatchEntryMetadata } from './combined-diff-section-cache-match'
 import {
+  COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES,
+  getCombinedDiffViewedSectionKeys,
+  retainCombinedDiffSectionText,
+  retainCombinedDiffViewStateText
+} from './combined-diff-text-retention'
+import {
   beginCombinedDiffScrollbarDrag,
   type CombinedDiffScrollbarDragCleanup
 } from './combined-diff-scrollbar-drag'
@@ -294,9 +300,28 @@ export default function CombinedDiffViewer({
   const loadedIndicesRef = useRef<Set<number>>(new Set())
   const loadingIndicesRef = useRef<Set<number>>(new Set())
   const sectionsRef = useRef<DiffSection[]>([])
+  const protectedSectionKeysRef = useRef<ReadonlySet<string>>(new Set())
   const generationRef = useRef(0)
   const loadSectionRef = useRef<(index: number) => Promise<void>>(async () => {})
   const retrySectionRef = useRef<(index: number) => void>(() => {})
+  const applySectionTextRetention = useCallback(
+    (nextSections: DiffSection[], additionallyProtectedKey?: string): DiffSection[] => {
+      const protectedSectionKeys = new Set(protectedSectionKeysRef.current)
+      if (additionallyProtectedKey) {
+        protectedSectionKeys.add(additionallyProtectedKey)
+      }
+      const retained = retainCombinedDiffSectionText({
+        sections: nextSections,
+        loadedIndices: loadedIndicesRef.current,
+        protectedSectionKeys
+      })
+      for (const index of retained.evictedIndices) {
+        loadedIndicesRef.current.delete(index)
+      }
+      return retained.sections
+    },
+    []
+  )
   const updateCombinedDiffScrollbar = useCallback(() => {
     const container = scrollContainerRef.current
     if (!container || container.scrollHeight <= container.clientHeight + 1) {
@@ -689,7 +714,7 @@ export default function CombinedDiffViewer({
       const storedResult = getStoredTextDiffResult(result, largeDiffRenderLimit)
       loadedIndicesRef.current.add(index)
       setSections((prev) => {
-        return prev.map((s, i) =>
+        const nextSections = prev.map((s, i) =>
           i === index
             ? {
                 ...s,
@@ -702,6 +727,7 @@ export default function CombinedDiffViewer({
               }
             : s
         )
+        return applySectionTextRetention(nextSections, nextSections[index]?.key)
       })
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -719,7 +745,8 @@ export default function CombinedDiffViewer({
       isBranchMode,
       isCommitMode,
       renderableBranchEntries,
-      uncommittedEntries
+      uncommittedEntries,
+      applySectionTextRetention
     ]
   )
   loadSectionRef.current = loadSectionNow
@@ -987,8 +1014,20 @@ export default function CombinedDiffViewer({
     // Why: the tree highlight belongs to one entry set; reset now so it can't flash on another before an Effect would.
     setActiveTreeSectionState({ entrySignature, key: null })
   }
+  const protectedSectionKeys = [
+    ...virtualizer
+      .getVirtualItems()
+      .map((item) => sections[item.index]?.key)
+      .filter((key): key is string => key !== undefined),
+    ...(activeTreeSectionKey ? [activeTreeSectionKey] : [])
+  ]
+  protectedSectionKeysRef.current = new Set(protectedSectionKeys)
+  const protectedSectionSignature = protectedSectionKeys.join('\0')
+  useLayoutEffect(() => {
+    setSections((current) => applySectionTextRetention(current))
+  }, [applySectionTextRetention, protectedSectionSignature, sections])
   const viewedSectionKeys = React.useMemo(
-    () => new Set(sections.filter((section) => !section.loading).map((section) => section.key)),
+    () => getCombinedDiffViewedSectionKeys(sections),
     [sections]
   )
   const handleTreeNavigate = useCallback(
@@ -1203,8 +1242,8 @@ export default function CombinedDiffViewer({
           content
         )
         setSectionHeights((prev) => removeDiffSectionMeasuredHeight(prev, index))
-        setSections((prev) =>
-          prev.map((s, i) => {
+        setSections((prev) => {
+          const nextSections = prev.map((s, i) => {
             if (i !== index) {
               return s
             }
@@ -1234,12 +1273,20 @@ export default function CombinedDiffViewer({
               largeDiffRenderLimit: nextLargeDiffRenderLimit
             }
           })
-        )
+          return applySectionTextRetention(nextSections, nextSections[index]?.key)
+        })
       } catch (err) {
         console.error('Save failed:', err)
       }
     },
-    [file.filePath, file.operationProvenance, file.runtimeEnvironmentId, file.worktreeId, sections]
+    [
+      applySectionTextRetention,
+      file.filePath,
+      file.operationProvenance,
+      file.runtimeEnvironmentId,
+      file.worktreeId,
+      sections
+    ]
   )
 
   const handleSectionSaveRef = useRef(handleSectionSave)
@@ -1251,17 +1298,23 @@ export default function CombinedDiffViewer({
     }
     const preservedScrollTop =
       combinedDiffScrollTopCache.get(viewStateKey) ?? scrollContainerRef.current?.scrollTop ?? 0
-    setWithLRU(combinedDiffViewStateCache, viewStateKey, {
-      entrySignature,
-      gitStatusSignature: combinedGitStatusSignature,
-      sections,
-      sectionHeights,
-      loadedIndices: Array.from(loadedIndicesRef.current).filter(
-        (index) => !sections[index]?.loading
-      ),
-      scrollTop: preservedScrollTop,
-      sideBySide
-    })
+    setWithLRU(
+      combinedDiffViewStateCache,
+      viewStateKey,
+      {
+        entrySignature,
+        gitStatusSignature: combinedGitStatusSignature,
+        sections,
+        sectionHeights,
+        loadedIndices: Array.from(loadedIndicesRef.current).filter(
+          (index) => !sections[index]?.loading
+        ),
+        scrollTop: preservedScrollTop,
+        sideBySide
+      },
+      COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES
+    )
+    retainCombinedDiffViewStateText(combinedDiffViewStateCache)
   }, [
     combinedGitStatusSignature,
     entries.length,

--- a/src/renderer/src/components/editor/CsvViewer.tsx
+++ b/src/renderer/src/components/editor/CsvViewer.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useRef } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { detectCsvDelimiter, parseCsv } from './csv-parse'
+import { CSV_PARSE_LIMITS, detectCsvDelimiter, parseCsv } from './csv-parse'
 import { translate } from '@/i18n/i18n'
 
 type CsvViewerProps = {
@@ -14,6 +14,40 @@ const MIN_COL_PX = 80
 const MAX_COL_PX = 320
 const ROW_NUMBER_COL_PX = 48
 const CHAR_PX = 7
+const numberFormatter = new Intl.NumberFormat()
+
+function CsvLimitFallback({ filePath }: { filePath: string }): React.JSX.Element {
+  return (
+    <div className="flex h-full items-center justify-center px-4 text-muted-foreground">
+      <div className="max-w-xl space-y-3 text-center">
+        <div className="text-sm font-medium text-foreground">
+          {translate(
+            'auto.components.editor.CsvViewer.2b65aa2913',
+            'This CSV is too large to display safely.'
+          )}
+        </div>
+        <div className="break-all text-xs">{filePath}</div>
+        <div className="text-xs">
+          {translate(
+            'auto.components.editor.CsvViewer.d5e8a2b453',
+            'Table view is limited to {{rows}} rows, {{columns}} columns, and {{cells}} cells.',
+            {
+              rows: numberFormatter.format(CSV_PARSE_LIMITS.rows),
+              columns: numberFormatter.format(CSV_PARSE_LIMITS.columnsPerRow),
+              cells: numberFormatter.format(CSV_PARSE_LIMITS.cells)
+            }
+          )}
+        </div>
+        <div className="text-[11px]">
+          {translate(
+            'auto.components.editor.CsvViewer.59cfb175a2',
+            'Switch to source mode to inspect the raw text.'
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
 
 // Why: CsvViewer is the table counterpart to source-mode Monaco for .csv/.tsv
 // files. Row virtualization via @tanstack/react-virtual keeps large files
@@ -88,6 +122,10 @@ export default function CsvViewer({ content, filePath }: CsvViewerProps): React.
     overscan: OVERSCAN,
     getItemKey: (index) => index
   })
+
+  if (parsed.limitExceeded) {
+    return <CsvLimitFallback filePath={filePath} />
+  }
 
   if (parsed.rows.length === 0) {
     return (

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -316,6 +316,7 @@ export function EditorContent({
       onContentChange={activeFile.readOnly === true ? noopEditorContentChange : handleContentChange}
       onSave={activeFile.readOnly === true ? noopEditorSave : isMarkdown ? md.mdSave : handleSave}
       worktreeId={activeFile.worktreeId}
+      runtimeEnvironmentId={activeFile.runtimeEnvironmentId}
       markdownAnnotationsEnabled={markdownAnnotationsEnabled && isMarkdown}
       conflictDecorationsEnabled={activeFile.conflict?.conflictStatus === 'unresolved'}
       revealLine={

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -75,6 +75,7 @@ import {
   type IpynbOutputItem
 } from './ipynb-parse'
 import { translate } from '@/i18n/i18n'
+import { buildImageDataUri } from '../../../../shared/image-data-uri'
 
 type IpynbViewerProps = {
   content: string
@@ -149,7 +150,7 @@ function dataUriForImage(item: IpynbOutputItem): string | null {
   if (item.mime === 'image/svg+xml') {
     return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(valueToText(item.value))}`
   }
-  return `data:${item.mime};base64,${value}`
+  return buildImageDataUri(item.mime, value)
 }
 
 function NotebookCellHeader({

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -81,6 +81,7 @@ type MonacoEditorProps = {
   revealMatchLength?: number
   markdownDocuments?: MarkdownDocument[]
   worktreeId?: string
+  runtimeEnvironmentId?: string | null
   markdownAnnotationsEnabled?: boolean
   conflictDecorationsEnabled?: boolean
   readOnly?: boolean
@@ -106,6 +107,7 @@ export default function MonacoEditor({
   revealMatchLength,
   markdownDocuments,
   worktreeId,
+  runtimeEnvironmentId,
   markdownAnnotationsEnabled = false,
   conflictDecorationsEnabled = false,
   readOnly = false,
@@ -204,11 +206,15 @@ export default function MonacoEditor({
       return
     }
     if (language === 'markdown' && markdownDocuments) {
-      setMarkdownDocCompletionDocuments(modelKey, markdownDocuments)
+      setMarkdownDocCompletionDocuments(
+        modelKey,
+        JSON.stringify([runtimeEnvironmentId ?? '', worktreeId ?? modelKey]),
+        markdownDocuments
+      )
     } else {
       clearMarkdownDocCompletionDocuments(modelKey)
     }
-  }, [language, markdownDocuments])
+  }, [language, markdownDocuments, runtimeEnvironmentId, worktreeId])
 
   const shouldShowMarkdownAnnotations =
     markdownAnnotationsEnabled && language === 'markdown' && Boolean(worktreeId)

--- a/src/renderer/src/components/editor/base64-byte-decoder.test.ts
+++ b/src/renderer/src/components/editor/base64-byte-decoder.test.ts
@@ -1,0 +1,13 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from 'vitest'
+import { decodeBase64Bytes } from './base64-byte-decoder'
+
+describe('decodeBase64Bytes', () => {
+  it('decodes large and whitespace-delimited input without changing bytes', () => {
+    const expected = new Uint8Array(40_000).map((_, index) => index % 251)
+    const encoded = btoa(String.fromCharCode(...expected)).replace(/.{100}/g, '$&\n')
+
+    expect(decodeBase64Bytes(encoded)).toEqual(expected)
+  })
+})

--- a/src/renderer/src/components/editor/base64-byte-decoder.ts
+++ b/src/renderer/src/components/editor/base64-byte-decoder.ts
@@ -1,0 +1,18 @@
+const BASE64_DECODE_CHUNK_CHARS = 32 * 1024
+
+export function decodeBase64Bytes(base64: string): Uint8Array<ArrayBuffer> {
+  const normalized = /\s/.test(base64) ? base64.replace(/\s/g, '') : base64
+  const padding = normalized.endsWith('==') ? 2 : normalized.endsWith('=') ? 1 : 0
+  const bytes = new Uint8Array(Math.floor((normalized.length * 3) / 4) - padding)
+  let targetOffset = 0
+  for (let sourceOffset = 0; sourceOffset < normalized.length; ) {
+    const sourceEnd = Math.min(sourceOffset + BASE64_DECODE_CHUNK_CHARS, normalized.length)
+    const binary = atob(normalized.slice(sourceOffset, sourceEnd))
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[targetOffset] = binary.charCodeAt(index)
+      targetOffset += 1
+    }
+    sourceOffset = sourceEnd
+  }
+  return bytes
+}

--- a/src/renderer/src/components/editor/combined-diff-load-scheduler.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-load-scheduler.test.ts
@@ -183,6 +183,70 @@ describe('combined diff load scheduler', () => {
     expect(started).toEqual([1, 3])
   })
 
+  it('counts stale in-flight loads against concurrency across repeated resets', async () => {
+    const blockers = new Map([1, 2, 3, 5].map((index) => [index, deferred()]))
+    const started: number[] = []
+    let active = 0
+    let maxActive = 0
+    const scheduler = createCombinedDiffLoadScheduler({
+      maxConcurrent: 2,
+      schedule: (callback) => callback(),
+      loadSection: async (index) => {
+        started.push(index)
+        active += 1
+        maxActive = Math.max(maxActive, active)
+        await blockers.get(index)!.promise
+        active -= 1
+      }
+    })
+
+    scheduler.request(1)
+    scheduler.request(2)
+    scheduler.reset()
+    scheduler.request(3)
+    scheduler.request(4)
+    expect(started).toEqual([1, 2])
+
+    blockers.get(1)!.resolve()
+    await flushMicrotasks()
+    expect(started).toEqual([1, 2, 3])
+
+    scheduler.reset()
+    scheduler.request(5)
+    blockers.get(2)!.resolve()
+    await flushMicrotasks()
+    expect(started).toEqual([1, 2, 3, 5])
+    expect(maxActive).toBe(2)
+
+    blockers.get(3)!.resolve()
+    blockers.get(5)!.resolve()
+    await flushMicrotasks()
+  })
+
+  it('keeps a rerequest deduped while the previous load settles', async () => {
+    const first = deferred()
+    const second = deferred()
+    const started: number[] = []
+    const scheduler = createCombinedDiffLoadScheduler({
+      schedule: (callback) => callback(),
+      loadSection: async (index) => {
+        started.push(index)
+        await (started.length === 1 ? first.promise : second.promise)
+      }
+    })
+
+    scheduler.request(4)
+    scheduler.rerequest(4)
+    scheduler.request(4)
+    first.resolve()
+    await flushMicrotasks()
+    scheduler.request(4)
+
+    expect(started).toEqual([4, 4])
+    second.resolve()
+    await flushMicrotasks()
+  })
+
   it('revives after dispose when reset for a StrictMode remount', async () => {
     const started: number[] = []
     const scheduler = createCombinedDiffLoadScheduler({

--- a/src/renderer/src/components/editor/combined-diff-load-scheduler.ts
+++ b/src/renderer/src/components/editor/combined-diff-load-scheduler.ts
@@ -5,6 +5,11 @@ export type CombinedDiffLoadScheduler = {
   dispose: () => void
 }
 
+type PendingLoad = {
+  index: number
+  requestId: number
+}
+
 export function createCombinedDiffLoadScheduler({
   loadSection,
   schedule = (callback) => queueMicrotask(callback),
@@ -16,11 +21,12 @@ export function createCombinedDiffLoadScheduler({
   schedule?: (callback: () => void) => void
   maxConcurrent?: number
 }): CombinedDiffLoadScheduler {
-  const pending: number[] = []
-  const queued = new Set<number>()
+  const pending: PendingLoad[] = []
+  const queuedRequestByIndex = new Map<number, number>()
   let active = 0
   let disposed = false
   let version = 0
+  let nextRequestId = 0
 
   const drain = (drainVersion: number): void => {
     if (disposed || drainVersion !== version) {
@@ -28,29 +34,33 @@ export function createCombinedDiffLoadScheduler({
     }
 
     while (active < maxConcurrent) {
-      const nextIndex = pending.shift()
-      if (nextIndex === undefined) {
+      const next = pending.shift()
+      if (!next) {
         return
       }
 
       active += 1
-      void loadSection(nextIndex).finally(() => {
-        queued.delete(nextIndex)
-        if (disposed || drainVersion !== version) {
+      void loadSection(next.index).finally(() => {
+        active = Math.max(0, active - 1)
+        if (queuedRequestByIndex.get(next.index) === next.requestId) {
+          queuedRequestByIndex.delete(next.index)
+        }
+        if (disposed) {
           return
         }
-        active = Math.max(0, active - 1)
-        schedule(() => drain(drainVersion))
+        const currentVersion = version
+        schedule(() => drain(currentVersion))
       })
     }
   }
 
   const enqueue = (index: number): void => {
-    if (disposed || queued.has(index)) {
+    if (disposed || queuedRequestByIndex.has(index)) {
       return
     }
-    queued.add(index)
-    pending.push(index)
+    const requestId = ++nextRequestId
+    queuedRequestByIndex.set(index, requestId)
+    pending.push({ index, requestId })
     const requestVersion = version
     schedule(() => drain(requestVersion))
   }
@@ -63,8 +73,9 @@ export function createCombinedDiffLoadScheduler({
       if (disposed) {
         return
       }
-      queued.delete(index)
-      const pendingIndex = pending.indexOf(index)
+      const requestId = queuedRequestByIndex.get(index)
+      queuedRequestByIndex.delete(index)
+      const pendingIndex = pending.findIndex((load) => load.requestId === requestId)
       if (pendingIndex !== -1) {
         pending.splice(pendingIndex, 1)
       }
@@ -73,14 +84,14 @@ export function createCombinedDiffLoadScheduler({
     reset() {
       disposed = false
       version += 1
+      // Why: don't reset `active`; stale loads still consume memory and I/O until they settle.
       pending.length = 0
-      queued.clear()
-      active = 0
+      queuedRequestByIndex.clear()
     },
     dispose() {
       disposed = true
       pending.length = 0
-      queued.clear()
+      queuedRequestByIndex.clear()
     }
   }
 }

--- a/src/renderer/src/components/editor/combined-diff-text-retention.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-text-retention.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_RENDERED_DIFF_COMBINED_CHARACTERS } from '../../../../shared/large-diff-render-limit'
+import type { DiffSection } from './diff-section-types'
+import {
+  COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES,
+  MAX_RETAINED_COMBINED_DIFF_TEXT_BYTES,
+  MAX_RETAINED_COMBINED_DIFF_TEXT_CHARACTERS,
+  getCombinedDiffViewedSectionKeys,
+  inspectCombinedDiffTextRetention,
+  retainCombinedDiffSectionText,
+  retainCombinedDiffViewStateText
+} from './combined-diff-text-retention'
+
+function textSection(key: string, content: string): DiffSection {
+  return {
+    key,
+    path: `${key}.ts`,
+    status: 'modified',
+    originalContent: content,
+    modifiedContent: '',
+    collapsed: false,
+    loading: false,
+    dirty: false,
+    diffResult: {
+      kind: 'text',
+      originalContent: content,
+      modifiedContent: '',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    },
+    largeDiffRenderLimit: null
+  }
+}
+
+describe('combined diff text retention', () => {
+  it('bounds many individually renderable files by evicting the oldest offscreen bodies', () => {
+    const justUnderPerFileLimit = 'x'.repeat(MAX_RENDERED_DIFF_COMBINED_CHARACTERS - 1)
+    const sections = Array.from({ length: 10 }, (_, index) =>
+      textSection(`section-${index}`, justUnderPerFileLimit)
+    )
+    const loadedIndices = sections.map((_, index) => index)
+
+    const result = retainCombinedDiffSectionText({
+      sections,
+      loadedIndices,
+      protectedSectionKeys: new Set(['section-9'])
+    })
+
+    const inspection = inspectCombinedDiffTextRetention(result.sections)
+    expect(inspection.characters).toBeLessThanOrEqual(MAX_RETAINED_COMBINED_DIFF_TEXT_CHARACTERS)
+    expect(inspection.approximateBytes).toBeLessThanOrEqual(MAX_RETAINED_COMBINED_DIFF_TEXT_BYTES)
+    expect(result.evictedIndices[0]).toBe(0)
+    expect(result.sections[9].originalContent).toBe(justUnderPerFileLimit)
+    expect(result.loadedIndices).not.toContain(result.evictedIndices[0])
+    for (const index of result.evictedIndices) {
+      expect(result.sections[index]).toMatchObject({
+        originalContent: '',
+        modifiedContent: '',
+        loading: true,
+        diffResult: null
+      })
+    }
+  })
+
+  it('makes an evicted section reloadable and retains its refetched body when revisited', () => {
+    const firstPass = retainCombinedDiffSectionText({
+      sections: [textSection('old', '12345678'), textSection('active', 'abcdefgh')],
+      loadedIndices: [0, 1],
+      protectedSectionKeys: new Set(['active']),
+      maxCharacters: 10
+    })
+
+    expect(firstPass.evictedIndices).toEqual([0])
+    expect(firstPass.loadedIndices).toEqual([1])
+    expect(getCombinedDiffViewedSectionKeys(firstPass.sections)).toEqual(new Set(['old', 'active']))
+
+    const refetched = firstPass.sections.map((section, index) =>
+      index === 0 ? textSection('old', 'refetched') : section
+    )
+    const secondPass = retainCombinedDiffSectionText({
+      sections: refetched,
+      loadedIndices: [...firstPass.loadedIndices, 0],
+      protectedSectionKeys: new Set(['old']),
+      maxCharacters: 10
+    })
+
+    expect(secondPass.sections[0].originalContent).toBe('refetched')
+    expect(secondPass.loadedIndices).toContain(0)
+    expect(secondPass.evictedIndices).toEqual([1])
+  })
+
+  it('keeps the full view-state LRU within one aggregate text budget', () => {
+    const body = 'x'.repeat(Math.floor(MAX_RETAINED_COMBINED_DIFF_TEXT_CHARACTERS / 2))
+    const viewStates = new Map(
+      Array.from({ length: COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES }, (_, index) => [
+        `view-${index}`,
+        { sections: [textSection(`section-${index}`, body)], loadedIndices: [0] }
+      ])
+    )
+
+    const inspection = retainCombinedDiffViewStateText(viewStates)
+
+    expect(inspection.characters).toBeLessThanOrEqual(MAX_RETAINED_COMBINED_DIFF_TEXT_CHARACTERS)
+    expect(viewStates.get('view-0')?.sections[0].originalContent).toBe('')
+    expect(viewStates.get('view-19')?.sections[0].originalContent).toBe(body)
+  })
+
+  it('never evicts active, loading, or unsaved section text', () => {
+    const dirty = { ...textSection('dirty', 'dirty text'), dirty: true }
+    const loading = { ...textSection('loading', 'loading text'), loading: true }
+    const result = retainCombinedDiffSectionText({
+      sections: [
+        textSection('old', 'old text'),
+        dirty,
+        loading,
+        textSection('active', 'active text')
+      ],
+      loadedIndices: [0, 1, 2, 3],
+      protectedSectionKeys: new Set(['active']),
+      maxCharacters: 0
+    })
+
+    expect(result.evictedIndices).toEqual([0])
+    expect(result.sections[1].originalContent).toBe('dirty text')
+    expect(result.sections[2].originalContent).toBe('loading text')
+    expect(result.sections[3].originalContent).toBe('active text')
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-text-retention.ts
+++ b/src/renderer/src/components/editor/combined-diff-text-retention.ts
@@ -1,0 +1,205 @@
+import type { DiffSection } from './diff-section-types'
+
+export const COMBINED_DIFF_TEXT_BYTES_PER_CHARACTER = 2
+// Why: bound raw UTF-16 text before Monaco creates its own models; inactive
+// snapshots split the same budget and may refetch an oversized file on revisit.
+export const MAX_RETAINED_COMBINED_DIFF_TEXT_BYTES = 24 * 1024 * 1024
+export const MAX_RETAINED_COMBINED_DIFF_TEXT_CHARACTERS = Math.floor(
+  MAX_RETAINED_COMBINED_DIFF_TEXT_BYTES / COMBINED_DIFF_TEXT_BYTES_PER_CHARACTER
+)
+export const COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES = 20
+
+export type CombinedDiffTextRetentionInspection = {
+  characters: number
+  approximateBytes: number
+  sectionsWithText: number
+}
+
+export type CombinedDiffTextRetentionResult = CombinedDiffTextRetentionInspection & {
+  sections: DiffSection[]
+  loadedIndices: number[]
+  evictedIndices: number[]
+}
+
+type CombinedDiffTextViewState = {
+  sections: DiffSection[]
+  loadedIndices: number[]
+}
+
+function getSectionTextCharacters(section: DiffSection): number {
+  if (section.diffResult?.kind !== 'text') {
+    return 0
+  }
+  return section.originalContent.length + section.modifiedContent.length
+}
+
+export function inspectCombinedDiffTextRetention(
+  sections: readonly DiffSection[]
+): CombinedDiffTextRetentionInspection {
+  let characters = 0
+  let sectionsWithText = 0
+  for (const section of sections) {
+    const sectionCharacters = getSectionTextCharacters(section)
+    if (sectionCharacters === 0) {
+      continue
+    }
+    characters += sectionCharacters
+    sectionsWithText += 1
+  }
+  return {
+    characters,
+    approximateBytes: characters * COMBINED_DIFF_TEXT_BYTES_PER_CHARACTER,
+    sectionsWithText
+  }
+}
+
+function isReloadableSection(
+  section: DiffSection,
+  protectedSectionKeys: ReadonlySet<string>
+): boolean {
+  return (
+    getSectionTextCharacters(section) > 0 &&
+    !section.loading &&
+    !section.dirty &&
+    !section.error &&
+    !protectedSectionKeys.has(section.key)
+  )
+}
+
+function releaseSectionText(section: DiffSection): DiffSection {
+  return {
+    ...section,
+    originalContent: '',
+    modifiedContent: '',
+    diffResult: null,
+    loading: true,
+    contentGeneration: (section.contentGeneration ?? 0) + 1,
+    textEvictedForRetention: true
+  }
+}
+
+export function getCombinedDiffViewedSectionKeys(
+  sections: readonly DiffSection[]
+): ReadonlySet<string> {
+  return new Set(
+    sections
+      .filter((section) => !section.loading || section.textEvictedForRetention === true)
+      .map((section) => section.key)
+  )
+}
+
+export function retainCombinedDiffSectionText({
+  sections,
+  loadedIndices,
+  protectedSectionKeys = new Set<string>(),
+  maxCharacters = MAX_RETAINED_COMBINED_DIFF_TEXT_CHARACTERS
+}: {
+  sections: DiffSection[]
+  loadedIndices: Iterable<number>
+  protectedSectionKeys?: ReadonlySet<string>
+  maxCharacters?: number
+}): CombinedDiffTextRetentionResult {
+  const inspection = inspectCombinedDiffTextRetention(sections)
+  const loadedIndexOrder = Array.from(loadedIndices)
+  if (inspection.characters <= maxCharacters) {
+    return {
+      ...inspection,
+      sections,
+      loadedIndices: loadedIndexOrder,
+      evictedIndices: []
+    }
+  }
+
+  // Why: loaded indices preserve load order; a refetched section rejoins at the tail.
+  const orderedCandidates = loadedIndexOrder.filter((index) => {
+    const section = sections[index]
+    return section !== undefined && isReloadableSection(section, protectedSectionKeys)
+  })
+  const orderedCandidateSet = new Set(orderedCandidates)
+  for (let index = 0; index < sections.length; index += 1) {
+    const section = sections[index]
+    if (
+      !orderedCandidateSet.has(index) &&
+      section !== undefined &&
+      isReloadableSection(section, protectedSectionKeys)
+    ) {
+      orderedCandidates.push(index)
+    }
+  }
+
+  let retainedCharacters = inspection.characters
+  let retainedSections = sections
+  const evictedIndices: number[] = []
+  for (const index of orderedCandidates) {
+    if (retainedCharacters <= maxCharacters) {
+      break
+    }
+    const section = retainedSections[index]
+    const sectionCharacters = getSectionTextCharacters(section)
+    if (sectionCharacters === 0) {
+      continue
+    }
+    if (retainedSections === sections) {
+      retainedSections = [...sections]
+    }
+    retainedSections[index] = releaseSectionText(section)
+    retainedCharacters -= sectionCharacters
+    evictedIndices.push(index)
+  }
+
+  const evictedIndexSet = new Set(evictedIndices)
+  return {
+    characters: retainedCharacters,
+    approximateBytes: retainedCharacters * COMBINED_DIFF_TEXT_BYTES_PER_CHARACTER,
+    sectionsWithText: inspection.sectionsWithText - evictedIndices.length,
+    sections: retainedSections,
+    loadedIndices: loadedIndexOrder.filter((index) => !evictedIndexSet.has(index)),
+    evictedIndices
+  }
+}
+
+export function inspectCombinedDiffViewStateTextRetention(
+  viewStates: Iterable<CombinedDiffTextViewState>
+): CombinedDiffTextRetentionInspection {
+  let characters = 0
+  let sectionsWithText = 0
+  for (const viewState of viewStates) {
+    const inspection = inspectCombinedDiffTextRetention(viewState.sections)
+    characters += inspection.characters
+    sectionsWithText += inspection.sectionsWithText
+  }
+  return {
+    characters,
+    approximateBytes: characters * COMBINED_DIFF_TEXT_BYTES_PER_CHARACTER,
+    sectionsWithText
+  }
+}
+
+export function retainCombinedDiffViewStateText<T extends CombinedDiffTextViewState>(
+  viewStates: Map<string, T>,
+  maxCharacters = MAX_RETAINED_COMBINED_DIFF_TEXT_CHARACTERS
+): CombinedDiffTextRetentionInspection {
+  let retainedCharacters = inspectCombinedDiffViewStateTextRetention(viewStates.values()).characters
+  // Why: view-state Maps are LRUs, so iteration releases the oldest inactive view first.
+  for (const [key, viewState] of viewStates) {
+    if (retainedCharacters <= maxCharacters) {
+      break
+    }
+    const viewStateCharacters = inspectCombinedDiffTextRetention(viewState.sections).characters
+    const retained = retainCombinedDiffSectionText({
+      sections: viewState.sections,
+      loadedIndices: viewState.loadedIndices,
+      maxCharacters: Math.max(0, viewStateCharacters - (retainedCharacters - maxCharacters))
+    })
+    if (retained.evictedIndices.length === 0) {
+      continue
+    }
+    viewStates.set(key, {
+      ...viewState,
+      sections: retained.sections,
+      loadedIndices: retained.loadedIndices
+    })
+    retainedCharacters -= viewStateCharacters - retained.characters
+  }
+  return inspectCombinedDiffViewStateTextRetention(viewStates.values())
+}

--- a/src/renderer/src/components/editor/csv-parse.test.ts
+++ b/src/renderer/src/components/editor/csv-parse.test.ts
@@ -1,5 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { CSV_DELIMITER_SNIFF_SCAN_CODE_UNITS, detectCsvDelimiter, parseCsv } from './csv-parse'
+import {
+  CSV_DELIMITER_SNIFF_SCAN_CODE_UNITS,
+  CSV_PARSE_LIMITS,
+  type CsvParseLimits,
+  detectCsvDelimiter,
+  parseCsv
+} from './csv-parse'
+
+function parseLimits(overrides: Partial<CsvParseLimits>): CsvParseLimits {
+  return { ...CSV_PARSE_LIMITS, ...overrides }
+}
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -68,7 +78,81 @@ describe('parseCsv', () => {
     const { rows } = parseCsv('""')
     expect(rows).toEqual([['']])
   })
+
+  it.each([
+    {
+      name: 'source code units',
+      source: 'a,b\n',
+      limits: parseLimits({ sourceCodeUnits: 3 }),
+      reason: 'source-code-units'
+    },
+    {
+      name: 'rows',
+      source: 'a\nb\nc',
+      limits: parseLimits({ rows: 2 }),
+      reason: 'rows'
+    },
+    {
+      name: 'columns per row',
+      source: 'a,b,c',
+      limits: parseLimits({ columnsPerRow: 2 }),
+      reason: 'columns-per-row'
+    },
+    {
+      name: 'total cells',
+      source: 'a,b\nc,d,e',
+      limits: parseLimits({ cells: 4 }),
+      reason: 'cells'
+    },
+    {
+      name: 'retained cell text',
+      source: 'a,bcd',
+      limits: parseLimits({ retainedCellCodeUnits: 3 }),
+      reason: 'retained-cell-code-units'
+    }
+  ])('fails closed when $name exceeds its memory limit', ({ source, limits, reason }) => {
+    expect(parseCsv(source, ',', limits)).toEqual({
+      rows: [],
+      maxColumns: 0,
+      limitExceeded: { reason, limit: limits[reasonToLimitKey(reason)] }
+    })
+  })
+
+  it('preserves exact output at every parser boundary', () => {
+    const source = 'a,b\nc,d'
+    const limits = parseLimits({
+      sourceCodeUnits: source.length,
+      rows: 2,
+      columnsPerRow: 2,
+      cells: 4,
+      retainedCellCodeUnits: 4
+    })
+
+    expect(parseCsv(source, ',', limits)).toEqual({
+      rows: [
+        ['a', 'b'],
+        ['c', 'd']
+      ],
+      maxColumns: 2,
+      limitExceeded: null
+    })
+  })
 })
+
+function reasonToLimitKey(reason: string): keyof CsvParseLimits {
+  switch (reason) {
+    case 'source-code-units':
+      return 'sourceCodeUnits'
+    case 'rows':
+      return 'rows'
+    case 'columns-per-row':
+      return 'columnsPerRow'
+    case 'cells':
+      return 'cells'
+    default:
+      return 'retainedCellCodeUnits'
+  }
+}
 
 describe('detectCsvDelimiter', () => {
   it('uses tab for .tsv files regardless of content', () => {

--- a/src/renderer/src/components/editor/csv-parse.ts
+++ b/src/renderer/src/components/editor/csv-parse.ts
@@ -1,9 +1,37 @@
 export type CsvParseResult = {
   rows: string[][]
   maxColumns: number
+  limitExceeded: CsvParseLimitExceeded | null
 }
 
 export const CSV_DELIMITER_SNIFF_SCAN_CODE_UNITS = 64 * 1024
+export const CSV_PARSE_LIMITS = {
+  sourceCodeUnits: 50 * 1024 * 1024,
+  rows: 250_000,
+  columnsPerRow: 1024,
+  cells: 1_000_000,
+  retainedCellCodeUnits: 50 * 1024 * 1024
+} as const
+
+export type CsvParseLimitReason =
+  | 'source-code-units'
+  | 'rows'
+  | 'columns-per-row'
+  | 'cells'
+  | 'retained-cell-code-units'
+
+export type CsvParseLimitExceeded = {
+  reason: CsvParseLimitReason
+  limit: number
+}
+
+export type CsvParseLimits = Readonly<{
+  sourceCodeUnits: number
+  rows: number
+  columnsPerRow: number
+  cells: number
+  retainedCellCodeUnits: number
+}>
 
 const LINE_FEED_CODE_UNIT = 10
 const CARRIAGE_RETURN_CODE_UNIT = 13
@@ -12,7 +40,21 @@ const CARRIAGE_RETURN_CODE_UNIT = 13
 // A hand-rolled parser avoids pulling a new dependency (papaparse) for what is
 // a small, well-specified grammar. Inline state machine keeps the hot path
 // allocation-light for large files.
-export function parseCsv(source: string, delimiter: string = ','): CsvParseResult {
+export function parseCsv(
+  source: string,
+  delimiter: string = ',',
+  limits: CsvParseLimits = CSV_PARSE_LIMITS
+): CsvParseResult {
+  const limited = (reason: CsvParseLimitReason, limit: number): CsvParseResult => ({
+    rows: [],
+    maxColumns: 0,
+    limitExceeded: { reason, limit }
+  })
+
+  if (source.length > limits.sourceCodeUnits) {
+    return limited('source-code-units', limits.sourceCodeUnits)
+  }
+
   // Why: strip a leading UTF-8 BOM (U+FEFF). Excel and other spreadsheet tools
   // prepend a BOM to exported CSVs; without this, the BOM contaminates the
   // first header cell and breaks column-name lookups for downstream consumers.
@@ -25,6 +67,8 @@ export function parseCsv(source: string, delimiter: string = ','): CsvParseResul
   let field = ''
   let inQuotes = false
   let maxColumns = 0
+  let cellCount = 0
+  let retainedCellCodeUnits = 0
   // Why: track whether the current record has produced any content — including
   // a quoted-but-empty field like `""`. Without this flag, the EOF flush
   // condition `field.length > 0 || row.length > 0` would drop a record whose
@@ -32,18 +76,41 @@ export function parseCsv(source: string, delimiter: string = ','): CsvParseResul
   // delimiter/newline ever pushed it onto the row.
   let recordHasContent = false
 
-  const pushField = (): void => {
+  const pushField = (): CsvParseResult | null => {
+    if (row.length >= limits.columnsPerRow) {
+      return limited('columns-per-row', limits.columnsPerRow)
+    }
+    if (cellCount >= limits.cells) {
+      return limited('cells', limits.cells)
+    }
     row.push(field)
+    cellCount += 1
     field = ''
+    return null
   }
-  const pushRow = (): void => {
-    pushField()
+  const pushRow = (): CsvParseResult | null => {
+    if (rows.length >= limits.rows) {
+      return limited('rows', limits.rows)
+    }
+    const fieldLimit = pushField()
+    if (fieldLimit) {
+      return fieldLimit
+    }
     if (row.length > maxColumns) {
       maxColumns = row.length
     }
     rows.push(row)
     row = []
     recordHasContent = false
+    return null
+  }
+  const appendToField = (value: string): CsvParseResult | null => {
+    if (retainedCellCodeUnits + value.length > limits.retainedCellCodeUnits) {
+      return limited('retained-cell-code-units', limits.retainedCellCodeUnits)
+    }
+    field += value
+    retainedCellCodeUnits += value.length
+    return null
   }
 
   for (let i = 0; i < source.length; i += 1) {
@@ -52,13 +119,19 @@ export function parseCsv(source: string, delimiter: string = ','): CsvParseResul
     if (inQuotes) {
       if (ch === '"') {
         if (source[i + 1] === '"') {
-          field += '"'
+          const retainedLimit = appendToField('"')
+          if (retainedLimit) {
+            return retainedLimit
+          }
           i += 1
         } else {
           inQuotes = false
         }
       } else {
-        field += ch
+        const retainedLimit = appendToField(ch)
+        if (retainedLimit) {
+          return retainedLimit
+        }
       }
       continue
     }
@@ -71,7 +144,10 @@ export function parseCsv(source: string, delimiter: string = ','): CsvParseResul
       continue
     }
     if (ch === delimiter) {
-      pushField()
+      const fieldLimit = pushField()
+      if (fieldLimit) {
+        return fieldLimit
+      }
       recordHasContent = true
       continue
     }
@@ -79,14 +155,23 @@ export function parseCsv(source: string, delimiter: string = ','): CsvParseResul
       if (source[i + 1] === '\n') {
         i += 1
       }
-      pushRow()
+      const rowLimit = pushRow()
+      if (rowLimit) {
+        return rowLimit
+      }
       continue
     }
     if (ch === '\n') {
-      pushRow()
+      const rowLimit = pushRow()
+      if (rowLimit) {
+        return rowLimit
+      }
       continue
     }
-    field += ch
+    const retainedLimit = appendToField(ch)
+    if (retainedLimit) {
+      return retainedLimit
+    }
     recordHasContent = true
   }
 
@@ -97,10 +182,13 @@ export function parseCsv(source: string, delimiter: string = ','): CsvParseResul
   // empty and nothing has been pushed to `row`, but the record is real and
   // must not be dropped.
   if (field.length > 0 || row.length > 0 || recordHasContent) {
-    pushRow()
+    const rowLimit = pushRow()
+    if (rowLimit) {
+      return rowLimit
+    }
   }
 
-  return { rows, maxColumns }
+  return { rows, maxColumns, limitExceeded: null }
 }
 
 export function detectCsvDelimiter(filePath: string, content: string): string {

--- a/src/renderer/src/components/editor/diff-section-types.ts
+++ b/src/renderer/src/components/editor/diff-section-types.ts
@@ -20,4 +20,6 @@ export type DiffSection = {
   // Why: combined sections keep Monaco models by path; bump on reload so
   // refetched git content does not replay through keepCurrent* model reuse.
   contentGeneration?: number
+  // Why: releasing a reviewed body must not make its file-tree entry appear unviewed.
+  textEvictedForRetention?: boolean
 }

--- a/src/renderer/src/components/editor/editor-autosave-controller.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.test.ts
@@ -7,7 +7,10 @@ import {
   ORCA_EDITOR_SAVE_DIRTY_FILES_EVENT
 } from '../../../../shared/editor-save-events'
 import { requestEditorFileSave, requestEditorSaveQuiesce } from './editor-autosave'
-import { attachEditorAutosaveController } from './editor-autosave-controller'
+import {
+  attachEditorAutosaveController,
+  EDITOR_BULK_SAVE_CONCURRENCY
+} from './editor-autosave-controller'
 import { registerPendingEditorFlush } from './editor-pending-flush'
 import { __clearSelfWriteRegistryForTests, hasRecentSelfWrite } from './editor-self-write-registry'
 import {
@@ -193,6 +196,70 @@ describe('attachEditorAutosaveController', () => {
       })
       expect(store.getState().openFiles[0]?.isDirty).toBe(false)
       expect(store.getState().editorDrafts).toEqual({})
+    } finally {
+      cleanup()
+    }
+  })
+
+  it.each([
+    ['at the limit', EDITOR_BULK_SAVE_CONCURRENCY],
+    ['above the limit', EDITOR_BULK_SAVE_CONCURRENCY + 1]
+  ])('bounds dirty-file writes %s', async (_, count) => {
+    let active = 0
+    let peak = 0
+    const releases: (() => void)[] = []
+    const writeFile = vi.fn(async () => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => releases.push(resolve))
+      active--
+    })
+    const eventTarget = new EventTarget()
+    vi.stubGlobal('window', {
+      addEventListener: eventTarget.addEventListener.bind(eventTarget),
+      removeEventListener: eventTarget.removeEventListener.bind(eventTarget),
+      dispatchEvent: eventTarget.dispatchEvent.bind(eventTarget),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      api: { fs: { writeFile } }
+    } satisfies WindowStub)
+    const store = createEditorStore()
+    store.setState({
+      settings: { editorAutoSave: false, editorAutoSaveDelayMs: 1000 } as never
+    })
+    for (let index = 0; index < count; index++) {
+      const filePath = `/repo/file-${index}.ts`
+      store.getState().openFile({
+        filePath,
+        relativePath: `file-${index}.ts`,
+        worktreeId: 'wt-1',
+        language: 'typescript',
+        mode: 'edit'
+      })
+      store.getState().setEditorDraft(filePath, `draft ${index}`)
+      store.getState().markFileDirty(filePath, true)
+    }
+
+    const cleanup = attachEditorAutosaveController(store)
+    try {
+      const save = requestDirtyFileSave()
+      for (
+        let turn = 0;
+        turn < 10 && writeFile.mock.calls.length < Math.min(count, EDITOR_BULK_SAVE_CONCURRENCY);
+        turn++
+      ) {
+        await Promise.resolve()
+      }
+      expect(writeFile).toHaveBeenCalledTimes(Math.min(count, EDITOR_BULK_SAVE_CONCURRENCY))
+      if (count > EDITOR_BULK_SAVE_CONCURRENCY) {
+        releases.shift()?.()
+        await vi.waitFor(() => expect(writeFile).toHaveBeenCalledTimes(count))
+      }
+      releases.splice(0).forEach((release) => release())
+      await save
+
+      expect(peak).toBe(Math.min(count, EDITOR_BULK_SAVE_CONCURRENCY))
+      expect(store.getState().openFiles.filter((file) => file.isDirty)).toEqual([])
     } finally {
       cleanup()
     }

--- a/src/renderer/src/components/editor/editor-autosave-controller.ts
+++ b/src/renderer/src/components/editor/editor-autosave-controller.ts
@@ -43,8 +43,22 @@ import {
   type EditorPrepareHotExitDetail,
   type EditorSaveDirtyFilesDetail
 } from '../../../../shared/editor-save-events'
+import {
+  mapSettledWithConcurrency,
+  mapWithConcurrency
+} from '../../../../shared/map-with-concurrency'
 
 type AppStoreApi = Pick<StoreApi<AppState>, 'getState' | 'subscribe'>
+export const EDITOR_BULK_SAVE_CONCURRENCY = 4
+
+function throwFirstRejected(results: readonly PromiseSettledResult<unknown>[]): void {
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  )
+  if (failure) {
+    throw failure.reason
+  }
+}
 
 export function attachEditorAutosaveController(store: AppStoreApi): () => void {
   const autoSaveTimers = new Map<string, number>()
@@ -253,15 +267,18 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
         return
       }
 
-      await Promise.all(
-        dirtyFiles.map(async (file) => {
+      const saves = await mapSettledWithConcurrency(
+        dirtyFiles,
+        EDITOR_BULK_SAVE_CONCURRENCY,
+        async (file) => {
           const content = getLatestWritableContent(file)
           if (content === null) {
             throw new Error(`Missing editor buffer for ${file.relativePath}`)
           }
           await queueSave(file, content)
-        })
+        }
       )
+      throwFirstRejected(saves)
       detail.resolve()
     } catch (error) {
       detail.reject(String((error as Error)?.message ?? error))
@@ -278,7 +295,9 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
       detail.claim()
 
       const initiallyDirtyFiles = store.getState().openFiles.filter((file) => file.isDirty)
-      await Promise.all(initiallyDirtyFiles.map((file) => quiesceFileSave(file.id)))
+      await mapWithConcurrency(initiallyDirtyFiles, EDITOR_BULK_SAVE_CONCURRENCY, (file) =>
+        quiesceFileSave(file.id)
+      )
 
       const state = store.getState()
       const dirtyFiles = state.openFiles.filter((file) => file.isDirty)
@@ -369,7 +388,9 @@ export function attachEditorAutosaveController(store: AppStoreApi): () => void {
         ? store.getState().openFiles.filter((file) => file.id === detail.fileId)
         : getOpenFilesForExternalFileChange(store.getState().openFiles, detail)
 
-    await Promise.all(matchingFiles.map((file) => quiesceFileSave(file.id)))
+    await mapWithConcurrency(matchingFiles, EDITOR_BULK_SAVE_CONCURRENCY, (file) =>
+      quiesceFileSave(file.id)
+    )
     detail.resolve()
   }
 

--- a/src/renderer/src/components/editor/editor-pending-flush.test.ts
+++ b/src/renderer/src/components/editor/editor-pending-flush.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest'
+import { flushPendingEditorChange, registerPendingEditorFlush } from './editor-pending-flush'
+
+describe('editor pending flush registry', () => {
+  it('releases a registered callback through its lifecycle disposer', () => {
+    const flush = vi.fn()
+    const unregister = registerPendingEditorFlush('/repo/file.md', flush)
+
+    flushPendingEditorChange('/repo/file.md')
+    unregister()
+    flushPendingEditorChange('/repo/file.md')
+
+    expect(flush).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not let an older disposer remove a replacement callback', () => {
+    const olderFlush = vi.fn()
+    const newerFlush = vi.fn()
+    const unregisterOlder = registerPendingEditorFlush('/repo/file.md', olderFlush)
+    const unregisterNewer = registerPendingEditorFlush('/repo/file.md', newerFlush)
+
+    unregisterOlder()
+    flushPendingEditorChange('/repo/file.md')
+    unregisterNewer()
+    flushPendingEditorChange('/repo/file.md')
+
+    expect(olderFlush).not.toHaveBeenCalled()
+    expect(newerFlush).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/ipynb-json-admission.test.ts
+++ b/src/renderer/src/components/editor/ipynb-json-admission.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertIpynbJsonWithinMemoryLimits,
+  assertIpynbShapeWithinMemoryLimits,
+  IPYNB_MEMORY_LIMITS,
+  type IpynbMemoryLimits
+} from './ipynb-json-admission'
+
+function limits(overrides: Partial<IpynbMemoryLimits>): IpynbMemoryLimits {
+  return { ...IPYNB_MEMORY_LIMITS, ...overrides }
+}
+
+describe('notebook memory admission', () => {
+  it('preserves JSON at exact source, structure, and nesting boundaries', () => {
+    const content = '{"cells":[]}'
+    expect(() =>
+      assertIpynbJsonWithinMemoryLimits(
+        content,
+        limits({ sourceCodeUnits: content.length, structuralTokens: 5, nestingDepth: 2 })
+      )
+    ).not.toThrow()
+  })
+
+  it.each([
+    ['source size', '{"cells":[]}', { sourceCodeUnits: 11 }, 'source size'],
+    ['JSON structure', '{"cells":[]}', { structuralTokens: 4 }, 'JSON structure'],
+    ['JSON nesting', '{"cells":[]}', { nestingDepth: 1 }, 'JSON nesting']
+  ] as const)('rejects %s one step past its limit', (_name, content, override, message) => {
+    expect(() => assertIpynbJsonWithinMemoryLimits(content, limits(override))).toThrow(message)
+  })
+
+  it('ignores structural characters inside strings', () => {
+    const content = '{"cells":[{"source":"[{,:}]"}]}'
+    expect(() =>
+      assertIpynbJsonWithinMemoryLimits(content, limits({ structuralTokens: 9 }))
+    ).not.toThrow()
+  })
+
+  it.each([
+    ['cells', [{}, {}], { cells: 1 }, 'cell'],
+    ['outputs', [{ outputs: [{}, {}] }], { outputs: 1 }, 'output'],
+    [
+      'display items',
+      [{ outputs: [{ data: { one: 1, two: 2 } }] }],
+      { displayItems: 1 },
+      'display item'
+    ],
+    ['multiline parts', [{ source: ['one', 'two'] }], { multilineParts: 1 }, 'fragment']
+  ] as const)('rejects too many %s before render projection', (_name, cells, override, message) => {
+    expect(() => assertIpynbShapeWithinMemoryLimits(cells, limits(override))).toThrow(message)
+  })
+})

--- a/src/renderer/src/components/editor/ipynb-json-admission.ts
+++ b/src/renderer/src/components/editor/ipynb-json-admission.ts
@@ -1,0 +1,94 @@
+import { assertJsonTextStructureWithinLimits } from '../../../../shared/json-text-structure-limit'
+
+export const IPYNB_MEMORY_LIMITS = {
+  sourceCodeUnits: 50 * 1024 * 1024,
+  structuralTokens: 500_000,
+  nestingDepth: 256,
+  cells: 1000,
+  outputs: 10_000,
+  displayItems: 20_000,
+  multilineParts: 100_000
+} as const
+
+export type IpynbMemoryLimits = Readonly<{
+  sourceCodeUnits: number
+  structuralTokens: number
+  nestingDepth: number
+  cells: number
+  outputs: number
+  displayItems: number
+  multilineParts: number
+}>
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function assertIpynbJsonWithinMemoryLimits(
+  content: string,
+  limits: IpynbMemoryLimits = IPYNB_MEMORY_LIMITS
+): void {
+  if (content.length > limits.sourceCodeUnits) {
+    throw new Error('Notebook exceeds the safe source size limit')
+  }
+
+  assertJsonTextStructureWithinLimits(content, {
+    structuralTokens: limits.structuralTokens,
+    nestingDepth: limits.nestingDepth
+  })
+}
+
+export function assertIpynbShapeWithinMemoryLimits(
+  cells: readonly unknown[],
+  limits: IpynbMemoryLimits = IPYNB_MEMORY_LIMITS
+): void {
+  if (cells.length > limits.cells) {
+    throw new Error('Notebook exceeds the safe cell limit')
+  }
+
+  let outputCount = 0
+  let displayItemCount = 0
+  let multilinePartCount = 0
+  const claimMultilineParts = (value: unknown): void => {
+    if (!Array.isArray(value)) {
+      return
+    }
+    multilinePartCount += value.length
+    if (multilinePartCount > limits.multilineParts) {
+      throw new Error('Notebook exceeds the safe multiline fragment limit')
+    }
+  }
+
+  for (const cell of cells) {
+    if (!isRecord(cell)) {
+      continue
+    }
+    claimMultilineParts(cell.source)
+    if (!Array.isArray(cell.outputs)) {
+      continue
+    }
+    outputCount += cell.outputs.length
+    if (outputCount > limits.outputs) {
+      throw new Error('Notebook exceeds the safe output limit')
+    }
+    for (const output of cell.outputs) {
+      if (!isRecord(output)) {
+        continue
+      }
+      claimMultilineParts(output.text)
+      claimMultilineParts(output.traceback)
+      if (!isRecord(output.data)) {
+        continue
+      }
+      for (const key in output.data) {
+        if (!Object.prototype.hasOwnProperty.call(output.data, key)) {
+          continue
+        }
+        displayItemCount += 1
+        if (displayItemCount > limits.displayItems) {
+          throw new Error('Notebook exceeds the safe display item limit')
+        }
+      }
+    }
+  }
+}

--- a/src/renderer/src/components/editor/ipynb-parse.test.ts
+++ b/src/renderer/src/components/editor/ipynb-parse.test.ts
@@ -11,6 +11,7 @@ import {
   updateIpynbCellSource,
   updateIpynbCellSources
 } from './ipynb-parse'
+import { IPYNB_MEMORY_LIMITS } from './ipynb-json-admission'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -87,6 +88,18 @@ describe('ipynb parsing', () => {
   it('rejects invalid notebook roots', () => {
     expect(() => parseIpynb('[]')).toThrow('Notebook root must be a JSON object')
     expect(() => parseIpynb('{}')).toThrow('Notebook is missing a cells array')
+  })
+
+  it('rejects renderer-amplifying cell counts before projecting cells', () => {
+    const content = JSON.stringify({
+      cells: Array.from({ length: IPYNB_MEMORY_LIMITS.cells + 1 }, () => ({
+        cell_type: 'raw',
+        metadata: {},
+        source: []
+      }))
+    })
+
+    expect(() => parseIpynb(content)).toThrow('safe cell limit')
   })
 
   it('serializes cell source edits while preserving notebook metadata', () => {

--- a/src/renderer/src/components/editor/ipynb-parse.ts
+++ b/src/renderer/src/components/editor/ipynb-parse.ts
@@ -2,6 +2,11 @@
 in one module makes nbformat preservation easier to audit while the notebook
 editor model is still small. */
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import {
+  assertIpynbJsonWithinMemoryLimits,
+  assertIpynbShapeWithinMemoryLimits,
+  IPYNB_MEMORY_LIMITS
+} from './ipynb-json-admission'
 
 export type IpynbCellKind = 'code' | 'markdown' | 'raw'
 
@@ -65,12 +70,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export function concatIpynbMultilineString(value: unknown): string {
   if (Array.isArray(value)) {
-    let result = ''
+    const parts: string[] = []
     for (let i = 0; i < value.length; i += 1) {
       const item = String(value[i] ?? '')
-      result += i < value.length - 1 && !item.endsWith('\n') ? `${item}\n` : item
+      parts.push(i < value.length - 1 && !item.endsWith('\n') ? `${item}\n` : item)
     }
-    return result.replace(/\r\n/g, '\n')
+    return parts.join('').replace(/\r\n/g, '\n')
   }
   return String(value ?? '').replace(/\r\n/g, '\n')
 }
@@ -183,16 +188,10 @@ function parseCell(rawCell: unknown, fallbackLanguage: string): IpynbCell | null
 }
 
 export function parseIpynb(content: string): ParsedIpynb {
-  const parsed = JSON.parse(content) as unknown
-  if (!isRecord(parsed)) {
-    throw new Error('Notebook root must be a JSON object')
-  }
-  if (!Array.isArray(parsed.cells)) {
-    throw new Error('Notebook is missing a cells array')
-  }
+  const parsed = parseNotebookRoot(content)
 
   const language = getPreferredLanguage(parsed)
-  const cells = parsed.cells
+  const cells = (parsed.cells as unknown[])
     .map((cell) => parseCell(cell, language))
     .filter((cell): cell is IpynbCell => cell !== null)
 
@@ -208,6 +207,9 @@ export function parseIpynb(content: string): ParsedIpynb {
 }
 
 function splitIpynbSource(source: string): string[] {
+  if (source.length > IPYNB_MEMORY_LIMITS.sourceCodeUnits) {
+    throw new Error('Notebook cell source exceeds the safe size limit')
+  }
   if (!source) {
     return []
   }
@@ -218,15 +220,22 @@ function splitIpynbSource(source: string): string[] {
       continue
     }
     lines.push(source.slice(lineStart, index + 1))
+    if (lines.length > IPYNB_MEMORY_LIMITS.multilineParts) {
+      throw new Error('Notebook cell source exceeds the safe line limit')
+    }
     lineStart = index + 1
   }
   if (lineStart < source.length) {
     lines.push(source.slice(lineStart))
+    if (lines.length > IPYNB_MEMORY_LIMITS.multilineParts) {
+      throw new Error('Notebook cell source exceeds the safe line limit')
+    }
   }
   return lines
 }
 
 function parseNotebookRoot(content: string): Record<string, unknown> {
+  assertIpynbJsonWithinMemoryLimits(content)
   const parsed = JSON.parse(content) as unknown
   if (!isRecord(parsed)) {
     throw new Error('Notebook root must be a JSON object')
@@ -234,6 +243,7 @@ function parseNotebookRoot(content: string): Record<string, unknown> {
   if (!Array.isArray(parsed.cells)) {
     throw new Error('Notebook is missing a cells array')
   }
+  assertIpynbShapeWithinMemoryLimits(parsed.cells)
   return parsed
 }
 
@@ -246,7 +256,9 @@ function ensureCell(root: Record<string, unknown>, index: number): Record<string
 }
 
 function serializeNotebook(root: Record<string, unknown>): string {
-  return `${JSON.stringify(root, null, 1)}\n`
+  const serialized = `${JSON.stringify(root, null, 1)}\n`
+  assertIpynbJsonWithinMemoryLimits(serialized)
+  return serialized
 }
 
 export function updateIpynbCellSource(content: string, index: number, source: string): string {
@@ -300,6 +312,9 @@ export function insertIpynbCell(
 ): string {
   const root = parseNotebookRoot(content)
   const cells = root.cells as unknown[]
+  if (cells.length >= IPYNB_MEMORY_LIMITS.cells) {
+    throw new Error('Notebook exceeds the safe cell limit')
+  }
   const nextCell: Record<string, unknown> = {
     cell_type: kind,
     id: createBrowserUuid(),

--- a/src/renderer/src/components/editor/local-image-blob-retention.test.ts
+++ b/src/renderer/src/components/editor/local-image-blob-retention.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest'
+import { LocalImageBlobRetention, MAX_LOCAL_IMAGE_BLOB_BYTES } from './local-image-blob-retention'
+
+describe('LocalImageBlobRetention', () => {
+  it('evicts oldest blobs until aggregate retained bytes are bounded', () => {
+    const revoke = vi.fn()
+    const retention = new LocalImageBlobRetention(revoke)
+
+    retention.set('first', { url: 'blob:first', bytes: MAX_LOCAL_IMAGE_BLOB_BYTES - 1 })
+    retention.set('second', { url: 'blob:second', bytes: 2 })
+
+    expect(retention.has('first')).toBe(false)
+    expect(retention.get('second')).toBe('blob:second')
+    expect(retention.retainedBytes).toBe(2)
+    expect(revoke).toHaveBeenCalledWith('blob:first')
+  })
+})

--- a/src/renderer/src/components/editor/local-image-blob-retention.ts
+++ b/src/renderer/src/components/editor/local-image-blob-retention.ts
@@ -1,0 +1,61 @@
+export const MAX_LOCAL_IMAGE_BLOB_ENTRIES = 100
+export const MAX_LOCAL_IMAGE_BLOB_BYTES = 128 * 1024 * 1024
+
+export type RetainedLocalImageBlob = {
+  url: string
+  bytes: number
+}
+
+export class LocalImageBlobRetention {
+  private readonly entries = new Map<string, RetainedLocalImageBlob>()
+  private retained = 0
+
+  constructor(private readonly revoke: (url: string) => void) {}
+
+  get(key: string): string | undefined {
+    return this.entries.get(key)?.url
+  }
+
+  has(key: string): boolean {
+    return this.entries.has(key)
+  }
+
+  set(key: string, entry: RetainedLocalImageBlob): void {
+    const previous = this.entries.get(key)
+    if (previous) {
+      this.entries.delete(key)
+      this.retained -= previous.bytes
+      if (previous.url !== entry.url) {
+        this.revoke(previous.url)
+      }
+    }
+    this.entries.set(key, entry)
+    this.retained += entry.bytes
+    while (
+      this.entries.size > MAX_LOCAL_IMAGE_BLOB_ENTRIES ||
+      this.retained > MAX_LOCAL_IMAGE_BLOB_BYTES
+    ) {
+      const oldestKey = this.entries.keys().next().value
+      if (oldestKey === undefined) {
+        break
+      }
+      const oldest = this.entries.get(oldestKey)
+      this.entries.delete(oldestKey)
+      this.retained -= oldest?.bytes ?? 0
+      if (oldest) {
+        this.revoke(oldest.url)
+      }
+    }
+  }
+
+  clear(): RetainedLocalImageBlob[] {
+    const stale = Array.from(this.entries.values())
+    this.entries.clear()
+    this.retained = 0
+    return stale
+  }
+
+  get retainedBytes(): number {
+    return this.retained
+  }
+}

--- a/src/renderer/src/components/editor/local-image-load-admission.test.ts
+++ b/src/renderer/src/components/editor/local-image-load-admission.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  LocalImageLoadAdmission,
+  MAX_ACTIVE_LOCAL_IMAGE_LOADS,
+  MAX_ADMITTED_LOCAL_IMAGE_LOADS
+} from './local-image-load-admission'
+
+async function flushMicrotasks(): Promise<void> {
+  for (let index = 0; index < 6; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('LocalImageLoadAdmission', () => {
+  it('starts only the bounded number of image reads concurrently', async () => {
+    const admission = new LocalImageLoadAdmission()
+    const releases: (() => void)[] = []
+    const task = vi.fn(
+      () =>
+        new Promise<number>((resolve) => {
+          releases.push(() => resolve(releases.length))
+        })
+    )
+
+    const loads = Array.from({ length: MAX_ACTIVE_LOCAL_IMAGE_LOADS + 1 }, () =>
+      admission.admit(task)
+    )
+    await flushMicrotasks()
+    expect(task).toHaveBeenCalledTimes(MAX_ACTIVE_LOCAL_IMAGE_LOADS)
+
+    releases[0]?.()
+    await flushMicrotasks()
+    expect(task).toHaveBeenCalledTimes(MAX_ACTIVE_LOCAL_IMAGE_LOADS + 1)
+
+    for (const release of releases) {
+      release()
+    }
+    await Promise.all(loads)
+  })
+
+  it('rejects excess admission and can release every queued load', async () => {
+    const admission = new LocalImageLoadAdmission()
+    const releases: (() => void)[] = []
+    const admitted = Array.from({ length: MAX_ADMITTED_LOCAL_IMAGE_LOADS }, () =>
+      admission.admit(
+        () =>
+          new Promise<void>((resolve) => {
+            releases.push(resolve)
+          })
+      )
+    )
+
+    await flushMicrotasks()
+    expect(admission.admit(() => Promise.resolve())).toBeNull()
+    admission.clearPending()
+    for (const release of releases) {
+      release()
+    }
+    await Promise.all(admitted)
+  })
+})

--- a/src/renderer/src/components/editor/local-image-load-admission.ts
+++ b/src/renderer/src/components/editor/local-image-load-admission.ts
@@ -1,0 +1,62 @@
+export const MAX_ACTIVE_LOCAL_IMAGE_LOADS = 2
+export const MAX_ADMITTED_LOCAL_IMAGE_LOADS = 100
+
+type PendingLoad = {
+  start: () => void
+  cancel: () => void
+}
+
+export class LocalImageLoadAdmission {
+  private active = 0
+  private readonly pending: PendingLoad[] = []
+
+  admit<T>(task: () => Promise<T>): Promise<T | null> | null {
+    if (this.active + this.pending.length >= MAX_ADMITTED_LOCAL_IMAGE_LOADS) {
+      return null
+    }
+    let resolveResult!: (value: T | null) => void
+    let rejectResult!: (error: unknown) => void
+    const result = new Promise<T | null>((resolve, reject) => {
+      resolveResult = resolve
+      rejectResult = reject
+    })
+    const pendingLoad = {
+      start: () => {
+        this.active += 1
+        let operation: Promise<T>
+        try {
+          operation = task()
+        } catch (error) {
+          this.active -= 1
+          rejectResult(error)
+          this.drain()
+          return
+        }
+        void operation.then(resolveResult, rejectResult).finally(() => {
+          this.active -= 1
+          this.drain()
+        })
+      },
+      cancel: () => resolveResult(null)
+    }
+    this.pending.push(pendingLoad)
+    this.drain()
+    return result
+  }
+
+  clearPending(): void {
+    for (const load of this.pending.splice(0)) {
+      load.cancel()
+    }
+  }
+
+  private drain(): void {
+    while (this.active < MAX_ACTIVE_LOCAL_IMAGE_LOADS) {
+      const next = this.pending.shift()
+      if (!next) {
+        return
+      }
+      next.start()
+    }
+  }
+}

--- a/src/renderer/src/components/editor/markdown-doc-links.test.ts
+++ b/src/renderer/src/components/editor/markdown-doc-links.test.ts
@@ -71,6 +71,10 @@ describe('splitMarkdownDocLinkText', () => {
 })
 
 describe('resolveMarkdownDocLink', () => {
+  it('shares one immutable index for consumers of the same document snapshot', () => {
+    expect(createMarkdownDocumentIndex(documents)).toBe(createMarkdownDocumentIndex(documents))
+  })
+
   it('resolves basename links', () => {
     const result = resolveMarkdownDocLink('setup-guide', createMarkdownDocumentIndex(documents))
     expect(result.status).toBe('resolved')

--- a/src/renderer/src/components/editor/markdown-doc-links.ts
+++ b/src/renderer/src/components/editor/markdown-doc-links.ts
@@ -101,7 +101,13 @@ function resolveMatches(matches: MarkdownDocument[] | undefined): MarkdownDocLin
     : { status: 'ambiguous', matches }
 }
 
+const markdownDocumentIndexes = new WeakMap<MarkdownDocument[], MarkdownDocumentIndex>()
+
 export function createMarkdownDocumentIndex(documents: MarkdownDocument[]): MarkdownDocumentIndex {
+  const cached = markdownDocumentIndexes.get(documents)
+  if (cached) {
+    return cached
+  }
   const byName = new Map<string, MarkdownDocument[]>()
   const byRelativePath = new Map<string, MarkdownDocument[]>()
   const byRelativePathWithoutExtension = new Map<string, MarkdownDocument[]>()
@@ -116,7 +122,9 @@ export function createMarkdownDocumentIndex(documents: MarkdownDocument[]): Mark
     )
   }
 
-  return { byName, byRelativePath, byRelativePathWithoutExtension }
+  const index = { byName, byRelativePath, byRelativePathWithoutExtension }
+  markdownDocumentIndexes.set(documents, index)
+  return index
 }
 
 export function resolveMarkdownDocLink(

--- a/src/renderer/src/components/editor/markdown-document-list-request.test.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.test.ts
@@ -3,8 +3,10 @@ import type { MarkdownDocument } from '../../../../shared/types'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
 import {
   getMarkdownDocumentListRequestKey,
+  MARKDOWN_DOCUMENT_LIST_MAX_IN_FLIGHT,
   requestSharedMarkdownDocumentList
 } from './markdown-document-list-request'
+import { MarkdownDocumentListingCapacityError } from '../../../../shared/markdown-document-listing-limits'
 
 function context(overrides: Partial<RuntimeFileOperationArgs> = {}): RuntimeFileOperationArgs {
   return {
@@ -172,5 +174,30 @@ describe('shared Markdown document list requests', () => {
       []
     )
     expect(load).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects the first distinct scan beyond the global in-flight cap', async () => {
+    const pending = Array.from({ length: MARKDOWN_DOCUMENT_LIST_MAX_IN_FLIGHT }, () =>
+      deferred<MarkdownDocument[]>()
+    )
+    const load = vi.fn((_context: RuntimeFileOperationArgs, rootPath: string) => {
+      const index = Number(rootPath.slice('/route-'.length))
+      return pending[index].promise
+    })
+    const requests = pending.map((_entry, index) =>
+      requestSharedMarkdownDocumentList(context(), `/route-${index}`, {}, load)
+    )
+
+    await expect(
+      requestSharedMarkdownDocumentList(context(), '/one-too-many', {}, load)
+    ).rejects.toBeInstanceOf(MarkdownDocumentListingCapacityError)
+    expect(load).toHaveBeenCalledTimes(MARKDOWN_DOCUMENT_LIST_MAX_IN_FLIGHT)
+
+    for (const entry of pending) {
+      entry.resolve([])
+    }
+    await expect(Promise.all(requests)).resolves.toEqual(
+      Array.from({ length: MARKDOWN_DOCUMENT_LIST_MAX_IN_FLIGHT }, () => [])
+    )
   })
 })

--- a/src/renderer/src/components/editor/markdown-document-list-request.ts
+++ b/src/renderer/src/components/editor/markdown-document-list-request.ts
@@ -3,6 +3,7 @@ import {
   listRuntimeMarkdownDocuments,
   type RuntimeFileOperationArgs
 } from '@/runtime/runtime-file-client'
+import { MarkdownDocumentListingCapacityError } from '../../../../shared/markdown-document-listing-limits'
 
 type MarkdownDocumentListLoader = (
   context: RuntimeFileOperationArgs,
@@ -19,7 +20,9 @@ type InFlightMarkdownDocumentList = {
 }
 
 const MARKDOWN_DOCUMENT_LIST_JOIN_WINDOW_MS = 30_000
+export const MARKDOWN_DOCUMENT_LIST_MAX_IN_FLIGHT = 16
 const inFlightMarkdownDocumentLists = new Map<string, InFlightMarkdownDocumentList>()
+let activeMarkdownDocumentListLoads = 0
 
 export function getMarkdownDocumentListRequestKey(
   context: RuntimeFileOperationArgs,
@@ -54,10 +57,22 @@ export function requestSharedMarkdownDocumentList(
   if (existing && !options.requireFresh) {
     return existing.request
   }
+  if (activeMarkdownDocumentListLoads >= MARKDOWN_DOCUMENT_LIST_MAX_IN_FLIGHT) {
+    return Promise.reject(new MarkdownDocumentListingCapacityError())
+  }
 
   // Why: split Markdown panes mount together and otherwise launch identical
   // whole-worktree local/SSH scans; mutation refreshes bypass older snapshots.
-  const request = load(context, rootPath).finally(() => {
+  activeMarkdownDocumentListLoads += 1
+  let loaded: Promise<MarkdownDocument[]>
+  try {
+    loaded = load(context, rootPath)
+  } catch (error) {
+    activeMarkdownDocumentListLoads -= 1
+    return Promise.reject(error)
+  }
+  const request = loaded.finally(() => {
+    activeMarkdownDocumentListLoads -= 1
     if (inFlightMarkdownDocumentLists.get(key)?.request === request) {
       inFlightMarkdownDocumentLists.delete(key)
     }

--- a/src/renderer/src/components/editor/markdown-document-worktree-retention.test.ts
+++ b/src/renderer/src/components/editor/markdown-document-worktree-retention.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { MarkdownDocument } from '../../../../shared/types'
+import {
+  retainMarkdownDocumentWorktreeSnapshot,
+  type MarkdownDocumentWorktreeSnapshot
+} from './markdown-document-worktree-retention'
+
+function documents(name: string): MarkdownDocument[] {
+  return [
+    {
+      filePath: `/repo/${name}.md`,
+      relativePath: `${name}.md`,
+      basename: `${name}.md`,
+      name
+    }
+  ]
+}
+
+describe('Markdown document worktree retention', () => {
+  it('preserves recent under-limit worktrees and refreshes their LRU position', () => {
+    let snapshots = new Map<string, MarkdownDocumentWorktreeSnapshot>()
+    snapshots = retainMarkdownDocumentWorktreeSnapshot(snapshots, 'a', documents('a'), {
+      maxSnapshots: 2,
+      maxRetainedBytes: 10_000
+    })
+    snapshots = retainMarkdownDocumentWorktreeSnapshot(snapshots, 'b', documents('b'), {
+      maxSnapshots: 2,
+      maxRetainedBytes: 10_000
+    })
+    snapshots = retainMarkdownDocumentWorktreeSnapshot(snapshots, 'a', documents('a-new'), {
+      maxSnapshots: 2,
+      maxRetainedBytes: 10_000
+    })
+    snapshots = retainMarkdownDocumentWorktreeSnapshot(snapshots, 'c', documents('c'), {
+      maxSnapshots: 2,
+      maxRetainedBytes: 10_000
+    })
+
+    expect(Array.from(snapshots.keys())).toEqual(['a', 'c'])
+    expect(snapshots.get('a')?.documents[0]?.name).toBe('a-new')
+  })
+
+  it('evicts oldest snapshots when their aggregate byte budget is exceeded', () => {
+    let snapshots = new Map<string, MarkdownDocumentWorktreeSnapshot>()
+    snapshots = retainMarkdownDocumentWorktreeSnapshot(snapshots, 'a', documents('a'), {
+      maxSnapshots: 10,
+      maxRetainedBytes: 10_000
+    })
+    const oneSnapshotBytes = snapshots.get('a')?.retainedBytes ?? 0
+    snapshots = retainMarkdownDocumentWorktreeSnapshot(snapshots, 'b', documents('b'), {
+      maxSnapshots: 10,
+      maxRetainedBytes: oneSnapshotBytes
+    })
+
+    expect(Array.from(snapshots.keys())).toEqual(['b'])
+  })
+})

--- a/src/renderer/src/components/editor/markdown-document-worktree-retention.ts
+++ b/src/renderer/src/components/editor/markdown-document-worktree-retention.ts
@@ -1,0 +1,41 @@
+import type { MarkdownDocument } from '../../../../shared/types'
+import { assertMarkdownDocumentsWithinLimit } from '../../../../shared/markdown-document-listing-limits'
+
+export const MARKDOWN_DOCUMENT_WORKTREE_MAX_SNAPSHOTS = 8
+export const MARKDOWN_DOCUMENT_WORKTREE_MAX_RETAINED_BYTES = 32 * 1024 * 1024
+
+export type MarkdownDocumentWorktreeSnapshot = {
+  documents: MarkdownDocument[]
+  retainedBytes: number
+}
+
+export function retainMarkdownDocumentWorktreeSnapshot(
+  previous: ReadonlyMap<string, MarkdownDocumentWorktreeSnapshot>,
+  worktreeId: string,
+  documents: MarkdownDocument[],
+  limits: { maxSnapshots: number; maxRetainedBytes: number } = {
+    maxSnapshots: MARKDOWN_DOCUMENT_WORKTREE_MAX_SNAPSHOTS,
+    maxRetainedBytes: MARKDOWN_DOCUMENT_WORKTREE_MAX_RETAINED_BYTES
+  }
+): Map<string, MarkdownDocumentWorktreeSnapshot> {
+  const next = new Map(previous)
+  next.delete(worktreeId)
+  next.set(worktreeId, {
+    documents,
+    retainedBytes: assertMarkdownDocumentsWithinLimit(documents)
+  })
+
+  let retainedBytes = 0
+  for (const snapshot of next.values()) {
+    retainedBytes += snapshot.retainedBytes
+  }
+  while (next.size > limits.maxSnapshots || retainedBytes > limits.maxRetainedBytes) {
+    const oldestKey = next.keys().next().value
+    if (typeof oldestKey !== 'string') {
+      break
+    }
+    retainedBytes -= next.get(oldestKey)?.retainedBytes ?? 0
+    next.delete(oldestKey)
+  }
+  return next
+}

--- a/src/renderer/src/components/editor/markdown-export-extract.test.ts
+++ b/src/renderer/src/components/editor/markdown-export-extract.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { getActiveMarkdownExportPayload } from './markdown-export-extract'
+import { getActiveMarkdownExportPayload, inlineBlobImageSources } from './markdown-export-extract'
 
 vi.mock('@/store', () => ({
   useAppStore: {
@@ -14,10 +14,11 @@ describe('getActiveMarkdownExportPayload', () => {
     vi.clearAllMocks()
     vi.stubGlobal(
       'fetch',
-      vi.fn().mockResolvedValue({
-        ok: true,
-        blob: async () => new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })
-      })
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(new Uint8Array([1, 2, 3]), { headers: { 'content-type': 'image/png' } })
+        )
     )
     const { useAppStore } = await import('@/store')
     vi.mocked(useAppStore.getState).mockReturnValue({
@@ -65,5 +66,31 @@ describe('getActiveMarkdownExportPayload', () => {
         root
       })
     ).rejects.toThrow('Failed to inline image for PDF export')
+  })
+
+  it('rejects streamed image bytes before the rendered fragment can exceed its cap', async () => {
+    let cancelled = false
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new Uint8Array(12))
+            controller.enqueue(new Uint8Array(12))
+          },
+          cancel() {
+            cancelled = true
+          }
+        }),
+        { headers: { 'content-type': 'image/png' } }
+      )
+    )
+    const root = document.createElement('div')
+    root.innerHTML = '<img src="blob:large">'
+    const prefixOnly = '<img src="data:image/png;base64,">'.length
+
+    await expect(inlineBlobImageSources(root, prefixOnly + 16)).rejects.toThrow(
+      'HTML export exceeds the PDF memory limit'
+    )
+    expect(cancelled).toBe(true)
   })
 })

--- a/src/renderer/src/components/editor/markdown-export-extract.ts
+++ b/src/renderer/src/components/editor/markdown-export-extract.ts
@@ -1,5 +1,15 @@
 import { useAppStore } from '@/store'
 import { detectLanguage } from '@/lib/language-detect'
+import {
+  assertHtmlToPdfInputWithinMemoryLimit,
+  HTML_TO_PDF_MAX_INPUT_BYTES,
+  HTML_TO_PDF_MEMORY_LIMIT_ERROR
+} from '../../../../shared/html-to-pdf-memory-limit'
+import {
+  FetchResponseBodyTooLargeError,
+  readFetchResponseBytesWithinLimit
+} from '../../../../shared/fetch-response-body'
+import { measureUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
 import { buildMarkdownExportHtml } from './markdown-export-html'
 
 export type MarkdownExportPayload = {
@@ -65,6 +75,15 @@ export async function getActiveMarkdownExportPayload({
     return null
   }
 
+  const title = basenameWithoutExt(activeFile.relativePath || activeFile.filePath)
+  const wrapper = buildMarkdownExportHtml({ title, renderedHtml: '' })
+  const wrapperBytes = measureUtf8ByteLength(wrapper, {
+    stopAfterBytes: HTML_TO_PDF_MAX_INPUT_BYTES
+  })
+  if (wrapperBytes.exceededLimit) {
+    throw new Error(HTML_TO_PDF_MEMORY_LIMIT_ERROR)
+  }
+
   const clone = subtree.cloneNode(true) as Element
   for (const selector of UI_ONLY_SELECTORS) {
     for (const node of clone.querySelectorAll(selector)) {
@@ -73,51 +92,77 @@ export async function getActiveMarkdownExportPayload({
   }
   // Why: local-image previews use renderer-scoped blob URLs; the hidden PDF
   // window cannot dereference them, so embed the bytes before export.
-  await inlineBlobImageSources(clone)
+  await inlineBlobImageSources(clone, HTML_TO_PDF_MAX_INPUT_BYTES - wrapperBytes.byteLength)
 
   const renderedHtml = clone.innerHTML.trim()
   if (!renderedHtml) {
     return null
   }
 
-  const title = basenameWithoutExt(activeFile.relativePath || activeFile.filePath)
   const html = buildMarkdownExportHtml({ title, renderedHtml })
+  assertHtmlToPdfInputWithinMemoryLimit(html)
   return { title, html }
 }
 
-async function inlineBlobImageSources(root: Element): Promise<void> {
-  const images = Array.from(root.querySelectorAll<HTMLImageElement>('img[src^="blob:"]'))
-  await Promise.all(
-    images.map(async (image) => {
-      const src = image.getAttribute('src')
-      if (!src) {
-        return
-      }
-      image.setAttribute('src', await readBlobImageAsDataUrl(src))
-    })
-  )
+export async function inlineBlobImageSources(
+  root: Element,
+  maxFragmentBytes: number
+): Promise<void> {
+  for (const image of root.querySelectorAll<HTMLImageElement>('img[src^="blob:"]')) {
+    const src = image.getAttribute('src')
+    if (!src) {
+      continue
+    }
+    await inlineBlobImageSource(root, image, src, maxFragmentBytes)
+  }
 }
 
-async function readBlobImageAsDataUrl(src: string): Promise<string> {
+async function inlineBlobImageSource(
+  root: Element,
+  image: HTMLImageElement,
+  src: string,
+  maxFragmentBytes: number
+): Promise<void> {
   try {
     const response = await fetch(src)
     if (!response.ok) {
       throw new Error('Unable to fetch blob image')
     }
-    const blob = await response.blob()
-    const bytes = new Uint8Array(await blob.arrayBuffer())
-    return `data:${blob.type || 'application/octet-stream'};base64,${bytesToBase64(bytes)}`
+    const mediaType = normalizedMediaType(response.headers.get('content-type'))
+    const prefix = `data:${mediaType};base64,`
+    image.setAttribute('src', prefix)
+    const prefixMeasurement = measureUtf8ByteLength(root.innerHTML, {
+      stopAfterBytes: maxFragmentBytes
+    })
+    if (prefixMeasurement.exceededLimit) {
+      throw new Error(HTML_TO_PDF_MEMORY_LIMIT_ERROR)
+    }
+    const availableBase64Characters = maxFragmentBytes - prefixMeasurement.byteLength
+    const maxImageBytes = Math.floor(availableBase64Characters / 4) * 3
+    const bytes = await readFetchResponseBytesWithinLimit(response, maxImageBytes)
+    image.setAttribute('src', `${prefix}${bytesToBase64(bytes)}`)
   } catch (error) {
+    if (
+      error instanceof FetchResponseBodyTooLargeError ||
+      (error instanceof Error && error.message === HTML_TO_PDF_MEMORY_LIMIT_ERROR)
+    ) {
+      throw new Error(HTML_TO_PDF_MEMORY_LIMIT_ERROR)
+    }
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Failed to inline image for PDF export: ${message}`)
   }
 }
 
+function normalizedMediaType(value: string | null): string {
+  return new Blob([], { type: value ?? '' }).type || 'application/octet-stream'
+}
+
 function bytesToBase64(bytes: Uint8Array): string {
-  let binary = ''
-  const chunkSize = 0x8000
+  const chunks: string[] = []
+  const chunkSize = 3 * 8192
   for (let index = 0; index < bytes.length; index += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize))
+    const binary = String.fromCharCode(...bytes.subarray(index, index + chunkSize))
+    chunks.push(btoa(binary))
   }
-  return btoa(binary)
+  return chunks.join('')
 }

--- a/src/renderer/src/components/editor/monaco-markdown-doc-completions.test.ts
+++ b/src/renderer/src/components/editor/monaco-markdown-doc-completions.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { MarkdownDocument } from '../../../../shared/types'
+import { assertMarkdownDocumentsWithinLimit } from '../../../../shared/markdown-document-listing-limits'
+import {
+  clearMarkdownDocCompletionDocuments,
+  getMarkdownCompletionRetentionForTests,
+  MARKDOWN_COMPLETION_MAX_MODELS,
+  MARKDOWN_COMPLETION_MAX_SCOPES,
+  resetMarkdownCompletionRetentionForTests,
+  setMarkdownDocCompletionDocuments
+} from './monaco-markdown-doc-completions'
+
+function documents(scope: string): MarkdownDocument[] {
+  return [
+    {
+      filePath: `/repo/${scope}.md`,
+      relativePath: `${scope}.md`,
+      basename: `${scope}.md`,
+      name: scope
+    }
+  ]
+}
+
+afterEach(() => {
+  resetMarkdownCompletionRetentionForTests()
+})
+
+describe('Monaco Markdown completion retention', () => {
+  it('stores one document snapshot for every mounted model in the same worktree scope', () => {
+    setMarkdownDocCompletionDocuments('model-a', 'worktree-a', documents('old'))
+    const freshDocuments = documents('fresh')
+    setMarkdownDocCompletionDocuments('model-b', 'worktree-a', freshDocuments)
+
+    expect(getMarkdownCompletionRetentionForTests()).toEqual({
+      models: 2,
+      scopes: 1,
+      retainedBytes: assertMarkdownDocumentsWithinLimit(freshDocuments)
+    })
+
+    clearMarkdownDocCompletionDocuments('model-a')
+    expect(getMarkdownCompletionRetentionForTests()).toMatchObject({ models: 1, scopes: 1 })
+    clearMarkdownDocCompletionDocuments('model-b')
+    expect(getMarkdownCompletionRetentionForTests()).toEqual({
+      models: 0,
+      scopes: 0,
+      retainedBytes: 0
+    })
+  })
+
+  it('evicts oldest scopes and model associations at their exact caps', () => {
+    for (let index = 0; index <= MARKDOWN_COMPLETION_MAX_SCOPES; index += 1) {
+      setMarkdownDocCompletionDocuments(`model-${index}`, `scope-${index}`, documents(`${index}`))
+    }
+    expect(getMarkdownCompletionRetentionForTests()).toMatchObject({
+      models: MARKDOWN_COMPLETION_MAX_SCOPES,
+      scopes: MARKDOWN_COMPLETION_MAX_SCOPES
+    })
+
+    resetMarkdownCompletionRetentionForTests()
+    for (let index = 0; index <= MARKDOWN_COMPLETION_MAX_MODELS; index += 1) {
+      setMarkdownDocCompletionDocuments(`model-${index}`, 'shared-scope', documents('shared'))
+    }
+    expect(getMarkdownCompletionRetentionForTests()).toMatchObject({
+      models: MARKDOWN_COMPLETION_MAX_MODELS,
+      scopes: 1
+    })
+  })
+})

--- a/src/renderer/src/components/editor/monaco-markdown-doc-completions.ts
+++ b/src/renderer/src/components/editor/monaco-markdown-doc-completions.ts
@@ -5,12 +5,72 @@ import {
   getMarkdownDocCompletionContext,
   getMarkdownDocCompletionDocuments
 } from './markdown-doc-completions'
+import { assertMarkdownDocumentsWithinLimit } from '../../../../shared/markdown-document-listing-limits'
 
 type MonacoApi = Parameters<OnMount>[1]
 
+type CompletionScope = {
+  documents: MarkdownDocument[]
+  modelKeys: Set<string>
+  retainedBytes: number
+}
+
+export const MARKDOWN_COMPLETION_MAX_MODELS = 256
+export const MARKDOWN_COMPLETION_MAX_SCOPES = 32
+export const MARKDOWN_COMPLETION_MAX_RETAINED_BYTES = 64 * 1024 * 1024
+
 let provider: IDisposable | null = null
 let providerMonaco: MonacoApi | null = null
-const documentsByModel = new Map<string, MarkdownDocument[]>()
+const scopeKeyByModel = new Map<string, string>()
+const completionScopes = new Map<string, CompletionScope>()
+let retainedBytes = 0
+
+function deleteCompletionScope(scopeKey: string, scope: CompletionScope): void {
+  completionScopes.delete(scopeKey)
+  retainedBytes -= scope.retainedBytes
+  for (const modelKey of scope.modelKeys) {
+    scopeKeyByModel.delete(modelKey)
+  }
+}
+
+function removeModel(modelKey: string): void {
+  const scopeKey = scopeKeyByModel.get(modelKey)
+  if (!scopeKey) {
+    return
+  }
+  scopeKeyByModel.delete(modelKey)
+  const scope = completionScopes.get(scopeKey)
+  scope?.modelKeys.delete(modelKey)
+  if (scope && scope.modelKeys.size === 0) {
+    deleteCompletionScope(scopeKey, scope)
+  }
+}
+
+function enforceCompletionRetentionLimits(): void {
+  while (scopeKeyByModel.size > MARKDOWN_COMPLETION_MAX_MODELS) {
+    const oldestModelKey = scopeKeyByModel.keys().next().value
+    if (typeof oldestModelKey !== 'string') {
+      break
+    }
+    removeModel(oldestModelKey)
+  }
+  while (
+    completionScopes.size > MARKDOWN_COMPLETION_MAX_SCOPES ||
+    retainedBytes > MARKDOWN_COMPLETION_MAX_RETAINED_BYTES
+  ) {
+    const oldest = completionScopes.entries().next().value
+    if (!oldest) {
+      break
+    }
+    deleteCompletionScope(oldest[0], oldest[1])
+  }
+}
+
+function clearCompletionRetention(): void {
+  scopeKeyByModel.clear()
+  completionScopes.clear()
+  retainedBytes = 0
+}
 
 export function ensureMarkdownDocCompletionProvider(monaco: MonacoApi): void {
   // Why: if Monaco was torn down and re-created (e.g. window reload), the old
@@ -21,7 +81,7 @@ export function ensureMarkdownDocCompletionProvider(monaco: MonacoApi): void {
   }
   if (provider) {
     provider.dispose()
-    documentsByModel.clear()
+    clearCompletionRetention()
   }
   providerMonaco = monaco
 
@@ -34,7 +94,8 @@ export function ensureMarkdownDocCompletionProvider(monaco: MonacoApi): void {
         return { suggestions: [] }
       }
 
-      const documents = documentsByModel.get(model.uri.toString()) ?? []
+      const scopeKey = scopeKeyByModel.get(model.uri.toString())
+      const documents = scopeKey ? (completionScopes.get(scopeKey)?.documents ?? []) : []
       const suffix = line.slice(position.column - 1)
       const range = {
         startLineNumber: position.lineNumber,
@@ -60,11 +121,49 @@ export function ensureMarkdownDocCompletionProvider(monaco: MonacoApi): void {
 
 export function setMarkdownDocCompletionDocuments(
   modelKey: string,
+  scopeKey: string,
   documents: MarkdownDocument[]
 ): void {
-  documentsByModel.set(modelKey, documents)
+  removeModel(modelKey)
+  let nextRetainedBytes: number
+  try {
+    nextRetainedBytes = assertMarkdownDocumentsWithinLimit(documents)
+  } catch {
+    return
+  }
+
+  let scope = completionScopes.get(scopeKey)
+  if (scope) {
+    completionScopes.delete(scopeKey)
+    retainedBytes -= scope.retainedBytes
+    scope.documents = documents
+    scope.retainedBytes = nextRetainedBytes
+  } else {
+    scope = { documents, modelKeys: new Set(), retainedBytes: nextRetainedBytes }
+  }
+  scope.modelKeys.add(modelKey)
+  completionScopes.set(scopeKey, scope)
+  scopeKeyByModel.set(modelKey, scopeKey)
+  retainedBytes += nextRetainedBytes
+  enforceCompletionRetentionLimits()
 }
 
 export function clearMarkdownDocCompletionDocuments(modelKey: string): void {
-  documentsByModel.delete(modelKey)
+  removeModel(modelKey)
+}
+
+export function getMarkdownCompletionRetentionForTests(): {
+  models: number
+  scopes: number
+  retainedBytes: number
+} {
+  return {
+    models: scopeKeyByModel.size,
+    scopes: completionScopes.size,
+    retainedBytes
+  }
+}
+
+export function resetMarkdownCompletionRetentionForTests(): void {
+  clearCompletionRetention()
 }

--- a/src/renderer/src/components/editor/rich-markdown-local-image.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-local-image.test.ts
@@ -22,7 +22,7 @@ describe('rich markdown local images', () => {
       ...globalThis.window.api,
       fs: {
         readFile: vi.fn().mockResolvedValue({
-          content: 'AA==',
+          content: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB',
           isBinary: true,
           mimeType: 'image/png'
         })

--- a/src/renderer/src/components/editor/useLocalImageSrc.test.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.test.ts
@@ -31,7 +31,17 @@ function deferred<T>(): {
   return { promise, reject, resolve }
 }
 
-function binaryPreview(content = 'AA=='): PreviewResult {
+function pngBase64(width = 1, height = 1): string {
+  const bytes = Buffer.alloc(24)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
+  bytes.writeUInt32BE(13, 8)
+  bytes.write('IHDR', 12, 'ascii')
+  bytes.writeUInt32BE(width, 16)
+  bytes.writeUInt32BE(height, 20)
+  return bytes.toString('base64')
+}
+
+function binaryPreview(content = pngBase64()): PreviewResult {
   return { content, isBinary: true, mimeType: 'image/png' }
 }
 
@@ -151,6 +161,13 @@ describe('loadLocalImageSrc', () => {
     ).resolves.toBeNull()
   })
 
+  it('rejects an inline raster dimension bomb before assigning it to an image', async () => {
+    const src = `data:image/png;base64,${pngBase64(32_769, 1)}`
+
+    await expect(loadLocalImageSrc(src, '/repo/docs/readme.md')).resolves.toBeNull()
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
+  })
+
   it('suppresses a stale pending completion after cache invalidation', async () => {
     const firstRead = deferred<PreviewResult>()
     const readFile = vi
@@ -186,15 +203,23 @@ describe('loadLocalImageSrc', () => {
     invalidateLocalImageSrcCacheForTests()
     const newerLoad = loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')
 
-    secondRead.resolve(binaryPreview('AQ=='))
+    secondRead.resolve(binaryPreview(pngBase64(2, 1)))
     await expect(newerLoad).resolves.toBe('blob:newer')
-    firstRead.resolve(binaryPreview('Ag=='))
+    firstRead.resolve(binaryPreview(pngBase64(3, 1)))
     await expect(staleLoad).resolves.toBeNull()
     await expect(loadLocalImageSrc('diagram.png', '/repo/docs/readme.md')).resolves.toBe(
       'blob:newer'
     )
     expect(readFile).toHaveBeenCalledTimes(2)
     expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('blob:newer')
+  })
+
+  it('rejects an oversized raster header before creating a blob URL', async () => {
+    const readFile = vi.fn().mockResolvedValue(binaryPreview(pngBase64(32_769, 1)))
+    setReadFile(readFile)
+
+    await expect(loadLocalImageSrc('bomb.png', '/repo/docs/readme.md')).resolves.toBeNull()
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
   })
 
   it('keeps runtime owners in separate image cache entries', async () => {

--- a/src/renderer/src/components/editor/useLocalImageSrc.ts
+++ b/src/renderer/src/components/editor/useLocalImageSrc.ts
@@ -2,15 +2,24 @@ import { useEffect, useState } from 'react'
 import { resolveImageAbsolutePath } from './markdown-preview-links'
 import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
 import { readRuntimeFilePreview } from '@/runtime/runtime-file-client'
+import {
+  LocalImageBlobRetention,
+  MAX_LOCAL_IMAGE_BLOB_BYTES,
+  type RetainedLocalImageBlob
+} from './local-image-blob-retention'
+import { LocalImageLoadAdmission } from './local-image-load-admission'
+import { decodeBase64Bytes } from './base64-byte-decoder'
+import { assertRasterImagePreviewWithinLimits } from '../../../../shared/raster-image-preview-limits'
+import { validateRasterImageDataUri } from '../../../../shared/image-data-uri'
 
 // Why: the renderer is served from http://localhost in dev mode, so file://
 // URLs in <img> tags are blocked by cross-origin restrictions. Loading images
 // via the existing fs.readFile IPC and converting to blob URLs bypasses this
 // limitation and works identically in both dev and production modes.
 
-const BLOB_URL_CACHE_MAX_SIZE = 100
-const blobUrlCache = new Map<string, string>()
+const blobUrlCache = new LocalImageBlobRetention((url) => URL.revokeObjectURL(url))
 const inFlightBlobUrlLoads = new Map<string, Promise<string | null>>()
+const imageLoadAdmission = new LocalImageLoadAdmission()
 
 export function getLocalImageCacheKey(
   absolutePath: string,
@@ -31,53 +40,45 @@ export function getLocalImageCacheKey(
 // the cache grows without bound and leaks memory. We evict the oldest entry
 // (Map iteration order is insertion order) and revoke its blob URL so the
 // browser can free the underlying data.
-function cacheBlobUrl(key: string, url: string): void {
-  const previousUrl = blobUrlCache.get(key)
-  if (previousUrl !== undefined) {
-    blobUrlCache.delete(key)
-    if (previousUrl !== url) {
-      // Why: cache replacements must release the superseded Blob even when
-      // they come from rare stale state or future loader changes.
-      URL.revokeObjectURL(previousUrl)
-    }
-  }
-  blobUrlCache.set(key, url)
-  if (blobUrlCache.size > BLOB_URL_CACHE_MAX_SIZE) {
-    const oldest = blobUrlCache.keys().next().value
-    if (oldest !== undefined) {
-      const oldUrl = blobUrlCache.get(oldest)
-      blobUrlCache.delete(oldest)
-      if (oldUrl) {
-        URL.revokeObjectURL(oldUrl)
-      }
-    }
-  }
+function cacheBlobUrl(key: string, entry: RetainedLocalImageBlob): void {
+  blobUrlCache.set(key, entry)
 }
 const cacheListeners = new Set<() => void>()
 let cacheGeneration = 0
-const pendingBlobUrlRevocations = new Set<string>()
+const pendingBlobUrlRevocations = new Map<string, number>()
+let pendingBlobUrlRevocationBytes = 0
 let pendingBlobUrlRevocationTimer: ReturnType<typeof setTimeout> | null = null
 
-function base64ToBlobUrl(base64: string, mimeType: string): string {
-  const binary = atob(base64.replace(/\s/g, ''))
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i += 1) {
-    bytes[i] = binary.charCodeAt(i)
-  }
-  return URL.createObjectURL(new Blob([bytes], { type: mimeType }))
+function base64ToBlobUrl(base64: string, mimeType: string): RetainedLocalImageBlob {
+  const bytes = decodeBase64Bytes(base64)
+  assertRasterImagePreviewWithinLimits(bytes, mimeType)
+  return { url: URL.createObjectURL(new Blob([bytes], { type: mimeType })), bytes: bytes.length }
 }
 
 function revokePendingBlobUrls(): void {
   pendingBlobUrlRevocationTimer = null
-  for (const url of pendingBlobUrlRevocations) {
+  for (const url of pendingBlobUrlRevocations.keys()) {
     URL.revokeObjectURL(url)
   }
   pendingBlobUrlRevocations.clear()
+  pendingBlobUrlRevocationBytes = 0
 }
 
-function scheduleBlobUrlRevocation(urls: string[]): void {
-  for (const url of urls) {
-    pendingBlobUrlRevocations.add(url)
+function scheduleBlobUrlRevocation(entries: RetainedLocalImageBlob[]): void {
+  for (const { url, bytes } of entries) {
+    const previousBytes = pendingBlobUrlRevocations.get(url) ?? 0
+    pendingBlobUrlRevocations.set(url, bytes)
+    pendingBlobUrlRevocationBytes += bytes - previousBytes
+  }
+  while (pendingBlobUrlRevocationBytes > MAX_LOCAL_IMAGE_BLOB_BYTES) {
+    const oldest = pendingBlobUrlRevocations.entries().next().value
+    if (!oldest) {
+      break
+    }
+    const [url, bytes] = oldest
+    pendingBlobUrlRevocations.delete(url)
+    pendingBlobUrlRevocationBytes -= bytes
+    URL.revokeObjectURL(url)
   }
   if (pendingBlobUrlRevocationTimer !== null || pendingBlobUrlRevocations.size === 0) {
     return
@@ -92,9 +93,9 @@ function scheduleBlobUrlRevocation(urls: string[]): void {
 // display the old data while the fresh IPC load completes, avoiding a visible
 // flash. The 30-second window is generous enough for even slow IPC reads.
 function invalidateImageCache(): void {
-  const staleUrls = Array.from(blobUrlCache.values())
-  blobUrlCache.clear()
+  const staleUrls = blobUrlCache.clear()
   inFlightBlobUrlLoads.clear()
+  imageLoadAdmission.clearPending()
   cacheGeneration += 1
   for (const listener of cacheListeners) {
     listener()
@@ -109,6 +110,7 @@ function invalidateImageCache(): void {
 }
 
 function disposeImageCacheModuleState(): void {
+  cacheGeneration += 1
   if (typeof window !== 'undefined') {
     window.removeEventListener('focus', invalidateImageCache)
   }
@@ -117,10 +119,10 @@ function disposeImageCacheModuleState(): void {
     pendingBlobUrlRevocationTimer = null
   }
   revokePendingBlobUrls()
-  for (const url of blobUrlCache.values()) {
+  for (const { url } of blobUrlCache.clear()) {
     URL.revokeObjectURL(url)
   }
-  blobUrlCache.clear()
+  imageLoadAdmission.clearPending()
   inFlightBlobUrlLoads.clear()
   cacheListeners.clear()
 }
@@ -146,13 +148,13 @@ export function onImageCacheInvalidated(listener: () => void): () => void {
   }
 }
 
-function isExternalUrl(src: string): boolean {
-  return (
-    src.startsWith('http://') ||
-    src.startsWith('https://') ||
-    src.startsWith('data:') ||
-    src.startsWith('blob:')
-  )
+function resolveExternalImageUrl(src: string): string | null {
+  if (src.startsWith('data:')) {
+    return validateRasterImageDataUri(src)
+  }
+  return src.startsWith('http://') || src.startsWith('https://') || src.startsWith('blob:')
+    ? src
+    : null
 }
 
 /**
@@ -177,8 +179,9 @@ export function useLocalImageSrc(
     if (!rawSrc) {
       return undefined
     }
-    if (isExternalUrl(rawSrc)) {
-      return rawSrc
+    const externalSrc = resolveExternalImageUrl(rawSrc)
+    if (externalSrc) {
+      return externalSrc
     }
     const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
     if (absolutePath) {
@@ -196,8 +199,9 @@ export function useLocalImageSrc(
       return
     }
 
-    if (isExternalUrl(rawSrc)) {
-      setDisplaySrc(rawSrc)
+    const externalSrc = resolveExternalImageUrl(rawSrc)
+    if (externalSrc) {
+      setDisplaySrc(externalSrc)
       return
     }
 
@@ -247,13 +251,9 @@ export async function loadLocalImageSrc(
   connectionId?: string | null,
   runtimeContext?: Omit<RuntimeFileOperationArgs, 'connectionId'> & { connectionId?: string | null }
 ): Promise<string | null> {
-  if (
-    rawSrc.startsWith('http://') ||
-    rawSrc.startsWith('https://') ||
-    rawSrc.startsWith('data:') ||
-    rawSrc.startsWith('blob:')
-  ) {
-    return rawSrc
+  const externalSrc = resolveExternalImageUrl(rawSrc)
+  if (externalSrc) {
+    return externalSrc
   }
 
   const absolutePath = resolveImageAbsolutePath(rawSrc, filePath)
@@ -287,20 +287,26 @@ export function loadLocalImageAbsolutePath(
   }
 
   const readGeneration = cacheGeneration
-  const loadPromise = readImagePreview(absolutePath, connectionId, runtimeContext)
+  const admitted = imageLoadAdmission.admit(() =>
+    readImagePreview(absolutePath, connectionId, runtimeContext)
+  )
+  if (!admitted) {
+    return Promise.resolve(null)
+  }
+  const loadPromise = admitted
     .then((result) => {
-      if (!result.isBinary || !result.content || cacheGeneration !== readGeneration) {
+      if (!result?.isBinary || !result.content || cacheGeneration !== readGeneration) {
         // Why: local image paths must stay behind IPC/runtime authorization;
         // handing raw file: or relative paths back to Chromium can escape it.
         return null
       }
-      const url = base64ToBlobUrl(result.content, result.mimeType ?? 'image/png')
+      const entry = base64ToBlobUrl(result.content, result.mimeType ?? 'image/png')
       if (cacheGeneration !== readGeneration) {
-        URL.revokeObjectURL(url)
+        URL.revokeObjectURL(entry.url)
         return null
       }
-      cacheBlobUrl(cacheKey, url)
-      return url
+      cacheBlobUrl(cacheKey, entry)
+      return entry.url
     })
     .catch(() => null)
     .finally(() => {
@@ -318,13 +324,14 @@ export function resetLocalImageSrcStateForTests(): void {
     pendingBlobUrlRevocationTimer = null
   }
   revokePendingBlobUrls()
-  for (const url of blobUrlCache.values()) {
+  for (const { url } of blobUrlCache.clear()) {
     URL.revokeObjectURL(url)
   }
-  blobUrlCache.clear()
+  imageLoadAdmission.clearPending()
   inFlightBlobUrlLoads.clear()
-  cacheGeneration = 0
+  cacheGeneration += 1
   pendingBlobUrlRevocations.clear()
+  pendingBlobUrlRevocationBytes = 0
   cacheListeners.clear()
 }
 

--- a/src/renderer/src/components/editor/useMarkdownDocuments.test.tsx
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { MarkdownDocument } from '../../../../shared/types'
+import { MarkdownDocumentListingCapacityError } from '../../../../shared/markdown-document-listing-limits'
+import type { OpenFile } from '@/store/slices/editor'
+import { useMarkdownDocuments } from './useMarkdownDocuments'
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  openFile: vi.fn(),
+  openMarkdownPreview: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
+vi.mock('@/lib/connection-context', () => ({ getConnectionId: () => null }))
+vi.mock('@/runtime/runtime-file-client', () => ({ statRuntimePath: vi.fn() }))
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  settingsForRuntimeOwner: () => ({ activeRuntimeEnvironmentId: null })
+}))
+vi.mock('./markdown-document-list-request', () => ({
+  requestSharedMarkdownDocumentList: mocks.list
+}))
+vi.mock('./markdown-document-worktree-path-selector', () => ({
+  selectMarkdownDocumentWorktreePath: (_state: unknown, worktreeId: string) => `/repo/${worktreeId}`
+}))
+vi.mock('@/store', () => {
+  const state = {
+    settings: {},
+    openFile: mocks.openFile,
+    openMarkdownPreview: mocks.openMarkdownPreview
+  }
+  const useAppStore = Object.assign(
+    (selector: (value: typeof state) => unknown) => selector(state),
+    { getState: () => state }
+  )
+  return { useAppStore }
+})
+
+function file(worktreeId: string): OpenFile {
+  return {
+    id: `/repo/${worktreeId}/README.md`,
+    filePath: `/repo/${worktreeId}/README.md`,
+    relativePath: 'README.md',
+    worktreeId,
+    language: 'markdown',
+    isDirty: false,
+    mode: 'edit'
+  }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  reject: (error: Error) => void
+  resolve: (value: T) => void
+} {
+  let reject!: (error: Error) => void
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+})
+
+describe('useMarkdownDocuments', () => {
+  it('does not toast when a superseded worktree scan later exceeds capacity', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const first = deferred<MarkdownDocument[]>()
+    const second = deferred<MarkdownDocument[]>()
+    mocks.list.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    const hook = renderHook(
+      ({ activeFile }) => useMarkdownDocuments(activeFile, true, 'source', vi.fn()),
+      { initialProps: { activeFile: file('first') } }
+    )
+    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(1))
+
+    hook.rerender({ activeFile: file('second') })
+    await waitFor(() => expect(mocks.list).toHaveBeenCalledTimes(2))
+
+    await act(async () => {
+      first.reject(new MarkdownDocumentListingCapacityError())
+      second.resolve([])
+      await Promise.allSettled([first.promise, second.promise])
+    })
+
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/useMarkdownDocuments.ts
+++ b/src/renderer/src/components/editor/useMarkdownDocuments.ts
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import type { MarkdownDocument } from '../../../../shared/types'
+import {
+  isMarkdownDocumentListingCapacityError,
+  MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE
+} from '../../../../shared/markdown-document-listing-limits'
 import { useAppStore } from '@/store'
 import { getConnectionId } from '@/lib/connection-context'
 import { statRuntimePath } from '@/runtime/runtime-file-client'
@@ -12,6 +17,10 @@ import {
 } from './markdown-doc-links'
 import { selectMarkdownDocumentWorktreePath } from './markdown-document-worktree-path-selector'
 import { requestSharedMarkdownDocumentList } from './markdown-document-list-request'
+import {
+  retainMarkdownDocumentWorktreeSnapshot,
+  type MarkdownDocumentWorktreeSnapshot
+} from './markdown-document-worktree-retention'
 
 type OpenMarkdownDocumentOptions = {
   anchor?: string | null
@@ -60,8 +69,8 @@ export function useMarkdownDocuments(
   const openFile = useAppStore((s) => s.openFile)
   const openMarkdownPreview = useAppStore((s) => s.openMarkdownPreview)
   const [markdownDocumentsByWorktree, setMarkdownDocumentsByWorktree] = useState<
-    Record<string, MarkdownDocument[]>
-  >({})
+    Map<string, MarkdownDocumentWorktreeSnapshot>
+  >(() => new Map())
   const requestRef = useRef(0)
 
   const connectionId = getConnectionId(worktreeId)
@@ -91,17 +100,20 @@ export function useMarkdownDocuments(
         if (requestRef.current !== requestId) {
           return
         }
-        setMarkdownDocumentsByWorktree((prev) => ({
-          ...prev,
-          [worktreeId]: documents
-        }))
+        setMarkdownDocumentsByWorktree((prev) =>
+          retainMarkdownDocumentWorktreeSnapshot(prev, worktreeId, documents)
+        )
       } catch (err) {
         console.error('Failed to list markdown documents:', err)
         if (requestRef.current === requestId) {
-          setMarkdownDocumentsByWorktree((prev) => ({
-            ...prev,
-            [worktreeId]: []
-          }))
+          if (isMarkdownDocumentListingCapacityError(err)) {
+            toast.error(MARKDOWN_DOCUMENT_LISTING_ERROR_MESSAGE, {
+              id: `markdown-document-listing-capacity:${worktreeId}`
+            })
+          }
+          setMarkdownDocumentsByWorktree((prev) =>
+            retainMarkdownDocumentWorktreeSnapshot(prev, worktreeId, [])
+          )
         }
       }
     },
@@ -182,7 +194,7 @@ export function useMarkdownDocuments(
   }, [activeFile.id, isMarkdown, viewMode, refreshMarkdownDocuments])
 
   const markdownDocuments = useMemo(
-    () => (worktreeId ? (markdownDocumentsByWorktree[worktreeId] ?? []) : []),
+    () => (worktreeId ? (markdownDocumentsByWorktree.get(worktreeId)?.documents ?? []) : []),
     [worktreeId, markdownDocumentsByWorktree]
   )
 

--- a/src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts
@@ -7,6 +7,7 @@ import {
   TERMINAL_INPUT_CHUNK_MAX_BYTES,
   TERMINAL_INPUT_MAX_BYTES
 } from '../../../../shared/terminal-input'
+import { CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS } from '../../../../shared/clipboard-text'
 
 const WHEEL_UP_REPORT = '\x1b[<64;60;20M'
 
@@ -153,5 +154,42 @@ describe('pty input write queue', () => {
 
     expect(writes.length).toBe(1)
     expect(writes.map((write) => write.data).join('')).not.toContain('tail')
+  })
+
+  it('rejects producer backlog beyond the retained item and text budgets', async () => {
+    const writes: WriteRecord[] = []
+    const pendingYields: (() => void)[] = []
+    const large = 'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+    const queue = createPtyInputWriteQueue({
+      isWritable: () => true,
+      write: (id, data) => writes.push({ id, data }),
+      yieldBetweenWrites: () =>
+        new Promise<void>((resolve) => {
+          pendingYields.push(resolve)
+        }),
+      maxPendingItems: 2,
+      maxPendingCodeUnits: large.length + 4
+    })
+
+    expect(queue.enqueue('pty-1', large)).toBe(true)
+    expect(queue.enqueue('pty-1', 'tail')).toBe(true)
+    expect(queue.enqueue('pty-1', '!')).toBe(false)
+
+    queue.clear()
+    pendingYields.shift()?.()
+    await queue.waitForDrain()
+
+    expect(writes).toEqual([{ id: 'pty-1', data: large.slice(0, TERMINAL_INPUT_CHUNK_MAX_BYTES) }])
+  })
+
+  it('does not write deferred input after clear', async () => {
+    const { writes, queue } = createRecordingQueue()
+    const deferred = 'x'.repeat(CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS + 1)
+
+    expect(queue.enqueue('pty-1', deferred)).toBe(true)
+    queue.clear()
+    await queue.waitForDrain()
+
+    expect(writes).toEqual([])
   })
 })

--- a/src/renderer/src/components/terminal-pane/pty-input-write-queue.ts
+++ b/src/renderer/src/components/terminal-pane/pty-input-write-queue.ts
@@ -1,4 +1,5 @@
 import {
+  TERMINAL_INPUT_MAX_BYTES,
   isTerminalInputTooLargeWithDeferredMeasurement,
   iterateTerminalInputChunks
 } from '../../../../shared/terminal-input'
@@ -7,6 +8,7 @@ import {
 // 16KB TERMINAL_INPUT_CHUNK_MAX_BYTES cap without paying byte measurement on
 // the hot input path.
 export const TERMINAL_INPUT_COALESCE_MAX_CODE_UNITS = 4096
+export const PTY_INPUT_WRITE_QUEUE_MAX_PENDING_ITEMS = 4_096
 
 type PendingPtyInputWrite = {
   id: string
@@ -26,6 +28,8 @@ export type PtyInputWriteQueueDeps = {
   isWritable: (id: string) => boolean
   write: (id: string, data: string) => void
   yieldBetweenWrites?: () => Promise<void>
+  maxPendingItems?: number
+  maxPendingCodeUnits?: number
 }
 
 function defaultYieldBetweenWrites(): Promise<void> {
@@ -38,28 +42,47 @@ function isCoalescibleText(text: string): boolean {
 
 export function createPtyInputWriteQueue(deps: PtyInputWriteQueueDeps): PtyInputWriteQueue {
   const yieldBetweenWrites = deps.yieldBetweenWrites ?? defaultYieldBetweenWrites
+  const maxPendingItems = positiveLimit(
+    deps.maxPendingItems,
+    PTY_INPUT_WRITE_QUEUE_MAX_PENDING_ITEMS
+  )
+  const maxPendingCodeUnits = positiveLimit(deps.maxPendingCodeUnits, TERMINAL_INPUT_MAX_BYTES)
   let pending: PendingPtyInputWrite[] = []
+  let pendingCodeUnits = 0
   let drainPromise: Promise<void> | null = null
+  let clearVersion = 0
+
+  function shiftPending(): PendingPtyInputWrite | undefined {
+    const shifted = pending.shift()
+    if (shifted) {
+      pendingCodeUnits -= shifted.text.length
+    }
+    return shifted
+  }
 
   async function drain(): Promise<void> {
     while (pending.length > 0) {
       const next = pending[0]
       if (!next) {
-        pending.shift()
+        shiftPending()
         continue
       }
       if (!deps.isWritable(next.id)) {
-        pending.shift()
+        shiftPending()
         continue
       }
       if (next.tooLarge !== false) {
+        const validationVersion = clearVersion
         next.tooLarge = await Promise.resolve(next.tooLarge).catch(() => true)
+        if (validationVersion !== clearVersion) {
+          continue
+        }
         if (next.tooLarge) {
-          pending.shift()
+          shiftPending()
           continue
         }
         if (!deps.isWritable(next.id)) {
-          pending.shift()
+          shiftPending()
           continue
         }
       }
@@ -72,7 +95,7 @@ export function createPtyInputWriteQueue(deps: PtyInputWriteQueueDeps): PtyInput
       // the PTY byte stream identical while draining the backlog in one turn.
       if (next.chunks === undefined && isCoalescibleText(next.text)) {
         let payload = next.text
-        pending.shift()
+        shiftPending()
         while (pending.length > 0) {
           const peek = pending[0]
           if (
@@ -86,7 +109,7 @@ export function createPtyInputWriteQueue(deps: PtyInputWriteQueueDeps): PtyInput
             break
           }
           payload += peek.text
-          pending.shift()
+          shiftPending()
         }
         deps.write(next.id, payload)
         if (pending.length > 0) {
@@ -99,13 +122,13 @@ export function createPtyInputWriteQueue(deps: PtyInputWriteQueueDeps): PtyInput
         next.nextChunk === undefined ? next.chunks.next() : { done: false, value: next.nextChunk }
       next.nextChunk = undefined
       if (chunk.done) {
-        pending.shift()
+        shiftPending()
         continue
       }
       deps.write(next.id, chunk.value)
       const following = next.chunks.next()
       if (following.done) {
-        pending.shift()
+        shiftPending()
       } else {
         next.nextChunk = following.value
       }
@@ -134,7 +157,14 @@ export function createPtyInputWriteQueue(deps: PtyInputWriteQueueDeps): PtyInput
         if (tooLarge === true) {
           return false
         }
+        if (
+          pending.length >= maxPendingItems ||
+          pendingCodeUnits + data.length > maxPendingCodeUnits
+        ) {
+          return false
+        }
         pending.push({ id, text: data, tooLarge })
+        pendingCodeUnits += data.length
         scheduleDrain()
         return true
       } catch {
@@ -150,6 +180,12 @@ export function createPtyInputWriteQueue(deps: PtyInputWriteQueueDeps): PtyInput
 
     clear(): void {
       pending = []
+      pendingCodeUnits = 0
+      clearVersion += 1
     }
   }
+}
+
+function positiveLimit(value: number | undefined, fallback: number): number {
+  return Number.isFinite(value) && (value ?? 0) > 0 ? Math.floor(value ?? fallback) : fallback
 }

--- a/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.test.ts
@@ -5,6 +5,7 @@ import {
   drainRolledBackPtyShutdownData,
   ptyDataHandlers,
   ptyReplayHandlers,
+  PTY_SHUTDOWN_OUTPUT_MAX_EVENTS,
   ptyShutdownLifecycleHandlers,
   ptyTeardownHandlers,
   unregisterPtyDataHandlers
@@ -73,4 +74,21 @@ it('retains ordered rollback output across detach and another pending shutdown',
   ptyReplayHandlers.delete(ptyId)
   ptyTeardownHandlers.delete(ptyId)
   ptyShutdownLifecycleHandlers.delete(ptyId)
+})
+
+it('bounds zero-byte shutdown events independently of buffered text', () => {
+  const ptyId = 'pty-shutdown-empty-event-flood'
+  const delivered = vi.fn()
+  ptyDataHandlers.set(ptyId, delivered)
+  ptyReplayHandlers.set(ptyId, vi.fn())
+
+  const [snapshot] = unregisterPtyDataHandlers([ptyId])
+  for (let index = 0; index < PTY_SHUTDOWN_OUTPUT_MAX_EVENTS + 10; index += 1) {
+    expect(bufferPtyShutdownData(ptyId, '')).toBe(true)
+  }
+  snapshot.rollback()
+
+  expect(delivered).toHaveBeenCalledTimes(PTY_SHUTDOWN_OUTPUT_MAX_EVENTS)
+  ptyDataHandlers.delete(ptyId)
+  ptyReplayHandlers.delete(ptyId)
 })

--- a/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
@@ -40,6 +40,7 @@ type PtyShutdownOutputEvent =
 
 const rolledBackShutdownEvents = new Map<string, PtyShutdownOutputEvent[]>()
 const ROLLED_BACK_SHUTDOWN_REPLAY_MAX_PTYS = 64
+export const PTY_SHUTDOWN_OUTPUT_MAX_EVENTS = 4_096
 const shutdownBufferTextEncoder = new TextEncoder()
 
 /** Suspend delivery until every overlapping shutdown owner commits or rolls back. */
@@ -117,7 +118,8 @@ function bufferPtyShutdownOutput(ptyId: string, event: PtyShutdownOutputEvent): 
   pending.events.push({ ...event, data: clamped.data })
   pending.bufferedBytes += clamped.bytes
   while (
-    pending.bufferedBytes > TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT &&
+    (pending.bufferedBytes > TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT ||
+      pending.events.length > PTY_SHUTDOWN_OUTPUT_MAX_EVENTS) &&
     pending.events.length > 1
   ) {
     pending.bufferedBytes -= shutdownBufferTextEncoder.encode(

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.test.ts
@@ -119,6 +119,54 @@ describe('createRemoteRuntimePtyTextBatcher', () => {
     }
   })
 
+  it('bounds strings retained behind deferred validation without changing accepted order', async () => {
+    vi.useFakeTimers()
+    try {
+      const text = 'x'.repeat(CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS + 1)
+      const batcher = createRemoteRuntimePtyTextBatcher(1_000, () => {}, {
+        maxPendingBytes: text.length + 10,
+        maxValidationQueuedCodeUnits: text.length + 4,
+        maxValidationQueuedEntries: 3
+      })
+
+      expect(batcher.push(text)).toBe(true)
+      expect(batcher.push('tail')).toBe(true)
+      expect(batcher.push('!')).toBe(false)
+
+      const drained = batcher.drain()
+      await vi.advanceTimersByTimeAsync(0)
+      await drained
+
+      expect(batcher.takePending()).toBe(`${text}tail`)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('bounds tiny entries retained behind deferred validation', async () => {
+    vi.useFakeTimers()
+    try {
+      const text = 'x'.repeat(CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS + 1)
+      const batcher = createRemoteRuntimePtyTextBatcher(1_000, () => {}, {
+        maxPendingBytes: text.length + 10,
+        maxValidationQueuedCodeUnits: text.length + 10,
+        maxValidationQueuedEntries: 2
+      })
+
+      expect(batcher.push(text)).toBe(true)
+      expect(batcher.push('a')).toBe(true)
+      expect(batcher.push('b')).toBe(false)
+
+      const drained = batcher.drain()
+      await vi.advanceTimersByTimeAsync(0)
+      await drained
+
+      expect(batcher.takePending()).toBe(`${text}a`)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('drops asynchronously oversized input without flushing clipboard content', async () => {
     vi.useFakeTimers()
     try {

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.ts
@@ -24,7 +24,11 @@ export type RemoteRuntimeViewportBatcher = {
 export type RemoteRuntimePtyTextBatcherOptions = {
   maxPendingBytes?: number
   maxBytes?: number
+  maxValidationQueuedCodeUnits?: number
+  maxValidationQueuedEntries?: number
 }
+
+export const REMOTE_RUNTIME_PTY_VALIDATION_QUEUE_MAX_ENTRIES = 4_096
 
 export function createRemoteRuntimePtyTextBatcher(
   delayMs: number,
@@ -36,11 +40,21 @@ export function createRemoteRuntimePtyTextBatcher(
     TERMINAL_INPUT_CHUNK_MAX_BYTES
   )
   const maxBytes = getPositiveByteLimit(options.maxBytes, TERMINAL_INPUT_MAX_BYTES)
+  const maxValidationQueuedCodeUnits = getPositiveByteLimit(
+    options.maxValidationQueuedCodeUnits,
+    maxBytes
+  )
+  const maxValidationQueuedEntries = getPositiveByteLimit(
+    options.maxValidationQueuedEntries,
+    REMOTE_RUNTIME_PTY_VALIDATION_QUEUE_MAX_ENTRIES
+  )
   let pending = ''
   let pendingBytes = 0
   let timer: ReturnType<typeof setTimeout> | null = null
   let validationTail: Promise<void> | null = null
   let validationVersion = 0
+  let validationQueuedCodeUnits = 0
+  let validationQueuedEntries = 0
 
   const clearTimer = (): void => {
     if (timer) {
@@ -55,6 +69,8 @@ export function createRemoteRuntimePtyTextBatcher(
     pendingBytes = 0
     validationVersion += 1
     validationTail = null
+    validationQueuedCodeUnits = 0
+    validationQueuedEntries = 0
   }
 
   const flush = (): void => {
@@ -96,8 +112,16 @@ export function createRemoteRuntimePtyTextBatcher(
     }
   }
 
-  const enqueueValidatedInput = (data: string, tooLarge: false | Promise<boolean>): void => {
+  const enqueueValidatedInput = (data: string, tooLarge: false | Promise<boolean>): boolean => {
+    if (
+      validationQueuedEntries >= maxValidationQueuedEntries ||
+      validationQueuedCodeUnits + data.length > maxValidationQueuedCodeUnits
+    ) {
+      return false
+    }
     const queuedVersion = validationVersion
+    validationQueuedEntries += 1
+    validationQueuedCodeUnits += data.length
     const previousTail = validationTail ?? Promise.resolve()
     const guardedTail = previousTail.then(async () => {
       if (validationVersion !== queuedVersion) {
@@ -113,11 +137,16 @@ export function createRemoteRuntimePtyTextBatcher(
     const nextTail = guardedTail
       .catch(() => {})
       .finally(() => {
+        if (validationVersion === queuedVersion) {
+          validationQueuedEntries -= 1
+          validationQueuedCodeUnits -= data.length
+        }
         if (validationTail === nextTail) {
           validationTail = null
         }
       })
     validationTail = nextTail
+    return true
   }
 
   const drain = async (): Promise<void> => {
@@ -143,8 +172,7 @@ export function createRemoteRuntimePtyTextBatcher(
         return true
       }
 
-      enqueueValidatedInput(data, tooLarge)
-      return true
+      return enqueueValidatedInput(data, tooLarge)
     },
     // Why: earlier input can be mid async byte-length validation and not yet in
     // `pending`. `takePending()` cannot see it, so callers that must preserve

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -49,6 +49,7 @@ import {
   createRemoteRuntimePtyTextBatcher,
   createRemoteRuntimeViewportBatcher
 } from './remote-runtime-pty-batching'
+import { createRemoteRuntimeViewportClaimInput } from './remote-runtime-viewport-claim-input'
 import {
   REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS,
   RemoteRuntimePtyRecoveryState
@@ -173,7 +174,7 @@ export function createRemoteRuntimePtyTransport(
   })
   let lastRecoveryStateKey = ''
   let pendingViewportClaim = false
-  let pendingClaimInput = ''
+  const pendingClaimInput = createRemoteRuntimeViewportClaimInput()
   let terminalCreateRetryWait: {
     timer: ReturnType<typeof setTimeout>
     resolve: (continueRetrying: boolean) => void
@@ -196,7 +197,7 @@ export function createRemoteRuntimePtyTransport(
   const viewportClaimReadyWaiters = new Set<(ready: boolean) => void>()
   const clearPendingViewportClaim = (): void => {
     pendingViewportClaim = false
-    pendingClaimInput = ''
+    pendingClaimInput.clear()
     for (const resolve of viewportClaimReadyWaiters) {
       resolve(false)
     }
@@ -975,7 +976,7 @@ export function createRemoteRuntimePtyTransport(
     }
     if (pendingViewportClaim) {
       // Why: a claim during subscribe/reconnect has no stream record yet; hold its input so the stream emits claim+input in one order.
-      pendingClaimInput += text
+      pendingClaimInput.append(text)
       return
     }
     void callRuntime('terminal.send', {
@@ -1456,8 +1457,7 @@ export function createRemoteRuntimePtyTransport(
     if (pendingViewportClaim && desiredViewport) {
       nextStream.claimViewport(desiredViewport.cols, desiredViewport.rows)
       pendingViewportClaim = false
-      const queuedInput = pendingClaimInput
-      pendingClaimInput = ''
+      const queuedInput = pendingClaimInput.take()
       if (queuedInput) {
         nextStream.sendInput(queuedInput)
       }
@@ -1862,8 +1862,7 @@ export function createRemoteRuntimePtyTransport(
         return true
       }
       if (pendingViewportClaim) {
-        pendingClaimInput += text
-        return true
+        return pendingClaimInput.append(text)
       }
       void callRuntime('terminal.send', {
         terminal: targetHandle,

--- a/src/renderer/src/components/terminal-pane/remote-runtime-viewport-claim-input.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-viewport-claim-input.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { createRemoteRuntimeViewportClaimInput } from './remote-runtime-viewport-claim-input'
+
+describe('remote runtime viewport-claim input', () => {
+  it('preserves accepted input order and resets its byte charge on take', () => {
+    const input = createRemoteRuntimeViewportClaimInput(4)
+
+    expect(input.append('ab')).toBe(true)
+    expect(input.append('cd')).toBe(true)
+    expect(input.take()).toBe('abcd')
+    expect(input.append('next')).toBe(true)
+  })
+
+  it('rejects producer backlog before concatenating beyond the byte budget', () => {
+    const input = createRemoteRuntimeViewportClaimInput(4)
+
+    expect(input.append('é')).toBe(true)
+    expect(input.append('ab')).toBe(true)
+    expect(input.append('!')).toBe(false)
+    expect(input.take()).toBe('éab')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/remote-runtime-viewport-claim-input.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-viewport-claim-input.ts
@@ -1,0 +1,31 @@
+import {
+  getTerminalInputByteLength,
+  TERMINAL_INPUT_MAX_BYTES
+} from '../../../../shared/terminal-input'
+
+export function createRemoteRuntimeViewportClaimInput(maxBytes = TERMINAL_INPUT_MAX_BYTES) {
+  let text = ''
+  let bytes = 0
+
+  return {
+    append(value: string): boolean {
+      const valueBytes = getTerminalInputByteLength(value)
+      if (bytes + valueBytes > maxBytes) {
+        return false
+      }
+      text += value
+      bytes += valueBytes
+      return true
+    },
+    clear(): void {
+      text = ''
+      bytes = 0
+    },
+    take(): string {
+      const value = text
+      text = ''
+      bytes = 0
+      return value
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-layout-leaf-ids.ts
@@ -217,6 +217,32 @@ export function collectLeafIdsInOrder(node: TerminalPaneLayoutNode | null | unde
   return [...collectLeafIdsInOrder(node.first), ...collectLeafIdsInOrder(node.second)]
 }
 
+export function collectTerminalLayoutLeafIds(
+  snapshot: TerminalLayoutSnapshot | null | undefined
+): string[] {
+  if (!snapshot) {
+    return []
+  }
+  const ids = new Set(collectLeafIdsInOrder(snapshot.root))
+  if (snapshot.activeLeafId) {
+    ids.add(snapshot.activeLeafId)
+  }
+  if (snapshot.expandedLeafId) {
+    ids.add(snapshot.expandedLeafId)
+  }
+  for (const record of [
+    snapshot.ptyIdsByLeafId,
+    snapshot.buffersByLeafId,
+    snapshot.scrollbackRefsByLeafId,
+    snapshot.titlesByLeafId
+  ]) {
+    for (const leafId of Object.keys(record ?? {})) {
+      ids.add(leafId)
+    }
+  }
+  return [...ids]
+}
+
 export function resolvePtyBoundActiveLeafId(args: {
   root: TerminalPaneLayoutNode | null | undefined
   activeLeafId: string | null | undefined

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.test.ts
@@ -11,7 +11,8 @@ import {
   installFilePathLinkClickFallback,
   isTerminalLinkActivation,
   openFilePathLinkAtBufferPosition,
-  openDetectedFilePath
+  openDetectedFilePath,
+  TERMINAL_FILE_LINK_PROBE_CONCURRENCY
 } from './terminal-link-handlers'
 import { TERMINAL_PATH_EXISTS_CACHE_MAX_ENTRIES } from './terminal-path-exists-cache'
 import { handleOscLink } from './terminal-osc-link-routing'
@@ -1230,6 +1231,43 @@ describe('createFilePathLinkProvider range bounds', () => {
 
     expect(links).toEqual([])
     expect(shellPathExists).toHaveBeenCalled()
+  })
+
+  it.each([
+    ['at the limit', TERMINAL_FILE_LINK_PROBE_CONCURRENCY],
+    ['above the limit', TERMINAL_FILE_LINK_PROBE_CONCURRENCY + 1]
+  ])('bounds path-existence probes %s', async (_, count) => {
+    let active = 0
+    let peak = 0
+    const releases: (() => void)[] = []
+    const shellPathExists = vi.mocked(window.api.shell.pathExists)
+    shellPathExists.mockImplementation(async () => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => releases.push(resolve))
+      active--
+      return true
+    })
+    const text = Array.from({ length: count }, (_, index) => `file-${index}.ts`).join(' ')
+    const { provider } = createProviderSetup([makeBufferLine(text)], new Map())
+    const links = new Promise<ILink[]>((resolve) => {
+      provider.provideLinks(1, (provided) => resolve(provided ?? []))
+    })
+
+    expect(shellPathExists).toHaveBeenCalledTimes(
+      Math.min(count, TERMINAL_FILE_LINK_PROBE_CONCURRENCY)
+    )
+    if (count > TERMINAL_FILE_LINK_PROBE_CONCURRENCY) {
+      releases.shift()?.()
+      for (let turn = 0; turn < 5 && shellPathExists.mock.calls.length < count; turn++) {
+        await Promise.resolve()
+      }
+      expect(shellPathExists).toHaveBeenCalledTimes(count)
+    }
+    releases.splice(0).forEach((release) => release())
+
+    await expect(links).resolves.toHaveLength(count)
+    expect(peak).toBe(Math.min(count, TERMINAL_FILE_LINK_PROBE_CONCURRENCY))
   })
 
   it('does not invoke the xterm callback twice when the callback throws', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-handlers.ts
@@ -1,4 +1,5 @@
 import type { IDisposable, ILink, ILinkProvider, Terminal } from '@xterm/xterm'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 import {
   extractTerminalFileLinkCandidates,
   extractTerminalFileLinks,
@@ -56,10 +57,9 @@ export type LinkHandlerDeps = {
   getRuntimeEnvironmentIdForPane?: (paneId: number) => string | null
 }
 
-type ProvidedFileLink = {
-  link: ILink
-  logicalLine: WrappedLogicalLine
-}
+type ProvidedFileLink = { link: ILink; logicalLine: WrappedLogicalLine }
+
+export const TERMINAL_FILE_LINK_PROBE_CONCURRENCY = 8
 
 function rangesOverlap(left: ILink['range'], right: ILink['range']): boolean {
   const leftStartsAfterRightEnds =
@@ -121,99 +121,99 @@ export function createFilePathLinkProvider(
         return
       }
 
-      void Promise.all(
-        logicalLines.flatMap((logicalLine) =>
-          extractTerminalFileLinkCandidates(logicalLine.text).map(
-            async (parsed): Promise<ProvidedFileLink | null> => {
-              const paneLinkCwd = deps.getPaneLinkCwd?.(paneId) ?? startupCwd
-              const resolved = paneLinkCwd
-                ? resolveTerminalFileLink(parsed, paneLinkCwd, deps.terminalHomePath)
-                : null
-              if (!resolved) {
-                return null
-              }
-              const range = rangeForParsedFileLink(logicalLine, parsed.startIndex, parsed.endIndex)
-              if (!range) {
-                return null
-              }
+      const candidates = logicalLines.flatMap((logicalLine) =>
+        extractTerminalFileLinkCandidates(logicalLine.text).map((parsed) => ({
+          logicalLine,
+          parsed
+        }))
+      )
+      void mapWithConcurrency(
+        candidates,
+        TERMINAL_FILE_LINK_PROBE_CONCURRENCY,
+        async ({ logicalLine, parsed }): Promise<ProvidedFileLink | null> => {
+          const paneLinkCwd = deps.getPaneLinkCwd?.(paneId) ?? startupCwd
+          const resolved = paneLinkCwd
+            ? resolveTerminalFileLink(parsed, paneLinkCwd, deps.terminalHomePath)
+            : null
+          if (!resolved) {
+            return null
+          }
+          const range = rangeForParsedFileLink(logicalLine, parsed.startIndex, parsed.endIndex)
+          if (!range) {
+            return null
+          }
 
-              const runtimeEnvironmentId =
-                deps.getRuntimeEnvironmentIdForPane?.(paneId) ?? deps.runtimeEnvironmentId ?? null
-              const fileContext = getTerminalFileContext(
-                worktreeId,
-                worktreePath,
-                runtimeEnvironmentId
-              )
-              const isRemoteRuntimePath = isRemoteRuntimeFileOperation(
-                fileContext,
-                resolved.absolutePath
-              )
-              const cacheKey = getTerminalPathExistsCacheKey({
-                absolutePath: resolved.absolutePath,
-                connectionId: fileContext.connectionId,
-                isRemoteRuntimePath,
-                runtimeEnvironmentId
-              })
-              const worktreeRootLink = resolveKnownWorktreeRootPathLink(resolved.absolutePath)
-              if (/[\\/]$/.test(parsed.pathText) && !worktreeRootLink) {
-                return null
-              }
-              // Why: exact known workspace roots must stay clickable for SSH or
-              // stale local paths even when filesystem probing says "missing".
-              if (!worktreeRootLink) {
-                const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
-                const exists =
-                  cachedExists ??
-                  (fileContext.connectionId || isRemoteRuntimePath
-                    ? await runtimePathExists(fileContext, resolved.absolutePath)
-                    : await window.api.shell.pathExists(resolved.absolutePath))
-                writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
-                if (!exists) {
-                  return null
-                }
-              }
+          const runtimeEnvironmentId =
+            deps.getRuntimeEnvironmentIdForPane?.(paneId) ?? deps.runtimeEnvironmentId ?? null
+          const fileContext = getTerminalFileContext(worktreeId, worktreePath, runtimeEnvironmentId)
+          const isRemoteRuntimePath = isRemoteRuntimeFileOperation(
+            fileContext,
+            resolved.absolutePath
+          )
+          const cacheKey = getTerminalPathExistsCacheKey({
+            absolutePath: resolved.absolutePath,
+            connectionId: fileContext.connectionId,
+            isRemoteRuntimePath,
+            runtimeEnvironmentId
+          })
+          const worktreeRootLink = resolveKnownWorktreeRootPathLink(resolved.absolutePath)
+          if (/[\\/]$/.test(parsed.pathText) && !worktreeRootLink) {
+            return null
+          }
+          // Why: exact known workspace roots must stay clickable for SSH or
+          // stale local paths even when filesystem probing says "missing".
+          if (!worktreeRootLink) {
+            const cachedExists = readTerminalPathExistsCache(pathExistsCache, cacheKey)
+            const exists =
+              cachedExists ??
+              (fileContext.connectionId || isRemoteRuntimePath
+                ? await runtimePathExists(fileContext, resolved.absolutePath)
+                : await window.api.shell.pathExists(resolved.absolutePath))
+            writeTerminalPathExistsCache(pathExistsCache, cacheKey, exists)
+            if (!exists) {
+              return null
+            }
+          }
 
-              return {
-                logicalLine,
-                link: {
-                  range,
-                  text: parsed.displayText,
-                  activate: (event) => {
-                    if (!isTerminalLinkActivation(event)) {
-                      return
-                    }
-                    openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, {
-                      worktreeId,
-                      worktreePath,
-                      runtimeEnvironmentId,
-                      openWithSystemDefault: Boolean(event.shiftKey)
-                    })
-                  },
-                  hover: () => {
-                    // Why: only local paths can offer the Shift+modifier system
-                    // default escape hatch; remote paths may not exist locally.
-                    const canOpenWithSystemDefault = shouldOpenTerminalFileWithSystemDefault(
-                      fileContext,
-                      resolved.absolutePath
-                    )
-                    const hint = worktreeRootLink
-                      ? getTerminalWorktreePathOpenHint(canOpenWithSystemDefault)
-                      : canOpenWithSystemDefault
-                        ? isHtmlFilePath(resolved.absolutePath)
-                          ? getTerminalHtmlFileOpenHint()
-                          : openLinkHint
-                        : getTerminalOrcaFileOpenHint()
-                    linkTooltip.textContent = `${resolved.absolutePath} (${hint})`
-                    linkTooltip.style.display = ''
-                  },
-                  leave: () => {
-                    linkTooltip.style.display = 'none'
-                  }
+          return {
+            logicalLine,
+            link: {
+              range,
+              text: parsed.displayText,
+              activate: (event) => {
+                if (!isTerminalLinkActivation(event)) {
+                  return
                 }
+                openDetectedFilePath(resolved.absolutePath, resolved.line, resolved.column, {
+                  worktreeId,
+                  worktreePath,
+                  runtimeEnvironmentId,
+                  openWithSystemDefault: Boolean(event.shiftKey)
+                })
+              },
+              hover: () => {
+                // Why: only local paths can offer the Shift+modifier system
+                // default escape hatch; remote paths may not exist locally.
+                const canOpenWithSystemDefault = shouldOpenTerminalFileWithSystemDefault(
+                  fileContext,
+                  resolved.absolutePath
+                )
+                const hint = worktreeRootLink
+                  ? getTerminalWorktreePathOpenHint(canOpenWithSystemDefault)
+                  : canOpenWithSystemDefault
+                    ? isHtmlFilePath(resolved.absolutePath)
+                      ? getTerminalHtmlFileOpenHint()
+                      : openLinkHint
+                    : getTerminalOrcaFileOpenHint()
+                linkTooltip.textContent = `${resolved.absolutePath} (${hint})`
+                linkTooltip.style.display = ''
+              },
+              leave: () => {
+                linkTooltip.style.display = 'none'
               }
             }
-          )
-        )
+          }
+        }
       )
         .then(
           (resolvedLinks) => {

--- a/src/renderer/src/components/terminal-pane/terminal-pane-recovery-retirement.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-recovery-retirement.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  forgetRetiredTerminalPaneRecovery,
+  registerTerminalPaneRecoveryRetirementHandler
+} from './terminal-pane-recovery-retirement'
+
+describe('terminal pane recovery retirement bridge', () => {
+  let unregister: (() => void) | undefined
+
+  afterEach(() => unregister?.())
+
+  it('routes authoritative retirement without coupling the store to recovery state', () => {
+    const handler = vi.fn()
+    unregister = registerTerminalPaneRecoveryRetirementHandler(handler)
+
+    forgetRetiredTerminalPaneRecovery('tab-1')
+
+    expect(handler).toHaveBeenCalledWith('tab-1')
+  })
+
+  it('does not retain a retired module handler', () => {
+    const handler = vi.fn()
+    unregister = registerTerminalPaneRecoveryRetirementHandler(handler)
+    unregister()
+    unregister = undefined
+
+    forgetRetiredTerminalPaneRecovery('tab-1')
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-recovery-retirement.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-recovery-retirement.ts
@@ -1,0 +1,18 @@
+type TerminalPaneRecoveryRetirementHandler = (tabId: string) => void
+
+let retirementHandler: TerminalPaneRecoveryRetirementHandler | null = null
+
+export function registerTerminalPaneRecoveryRetirementHandler(
+  handler: TerminalPaneRecoveryRetirementHandler
+): () => void {
+  retirementHandler = handler
+  return () => {
+    if (retirementHandler === handler) {
+      retirementHandler = null
+    }
+  }
+}
+
+export function forgetRetiredTerminalPaneRecovery(tabId: string): void {
+  retirementHandler?.(tabId)
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-recovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   _resetTerminalPaneRecoveryForTests,
   captureTerminalPaneRecoveryGeneration,
+  forgetTerminalPaneRecovery,
   registerTerminalPaneRecoveryInstance,
   requestTerminalPaneRecovery
 } from './terminal-pane-recovery'
@@ -270,6 +271,36 @@ describe('requestTerminalPaneRecovery', () => {
 
     expect(mocks.remountTerminalTabForRecovery).toHaveBeenCalledTimes(1)
     healthySuccessor.unregister()
+  })
+
+  it('forgets recovery history and pending work only after authoritative tab retirement', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+    const instance = registerTerminalPaneRecoveryInstance('tab-1')
+    await requestTerminalPaneRecovery({
+      tabId: 'tab-1',
+      ptyId: 'pty-1',
+      reason: 'write-stalled',
+      terminalRecoveryGeneration: captureTerminalPaneRecoveryGeneration('tab-1'),
+      terminalRecoveryInstanceId: instance.id
+    })
+    const recoveredGeneration = captureTerminalPaneRecoveryGeneration('tab-1')
+    await requestTerminalPaneRecovery({
+      tabId: 'tab-1',
+      ptyId: 'pty-1',
+      reason: 'replay-wedged',
+      terminalRecoveryGeneration: recoveredGeneration,
+      terminalRecoveryInstanceId: instance.id
+    })
+
+    expect(recoveredGeneration).toBe(1)
+    expect(vi.getTimerCount()).toBe(1)
+    forgetTerminalPaneRecovery('tab-1')
+    expect(captureTerminalPaneRecoveryGeneration('tab-1')).toBe(0)
+    expect(vi.getTimerCount()).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(600_000)
+    expect(mocks.remountTerminalTabForRecovery).toHaveBeenCalledTimes(1)
   })
 
   it('keeps a sibling pane retry when the first requesting split is disposed', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-pane-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-recovery.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '@/store'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+import { registerTerminalPaneRecoveryRetirementHandler } from './terminal-pane-recovery-retirement'
 
 // Why this module exists: a terminal pane can die renderer-side while its PTY
 // stays alive — a wedged xterm WriteBuffer (issue #2836), a disposed xterm
@@ -50,6 +51,7 @@ const RECOVERY_COOLDOWN_MS = 15_000
 const recoveryTimestampsByTabId = new Map<string, number[]>()
 const recoveryGenerationByTabId = new Map<string, number>()
 const activeTerminalRecoveryInstanceIds = new Set<number>()
+const terminalRecoveryTabIdByInstanceId = new Map<number, string>()
 const pendingRetryByTabId = new Map<
   string,
   {
@@ -98,10 +100,12 @@ export function registerTerminalPaneRecoveryInstance(tabId: string): {
 } {
   const id = ++nextTerminalRecoveryInstanceId
   activeTerminalRecoveryInstanceIds.add(id)
+  terminalRecoveryTabIdByInstanceId.set(id, tabId)
   return {
     id,
     unregister: () => {
       activeTerminalRecoveryInstanceIds.delete(id)
+      terminalRecoveryTabIdByInstanceId.delete(id)
       const pendingRetry = pendingRetryByTabId.get(tabId)
       pendingRetry?.requestsByInstanceId.delete(id)
       if (pendingRetry?.requestsByInstanceId.size === 0) {
@@ -271,10 +275,30 @@ export async function requestTerminalPaneRecovery(request: RecoveryRequest): Pro
   return true
 }
 
+export function forgetTerminalPaneRecovery(tabId: string): void {
+  recoveryTimestampsByTabId.delete(tabId)
+  recoveryGenerationByTabId.delete(tabId)
+  cancelPendingRecoveryRetry(tabId)
+  for (const [instanceId, instanceTabId] of terminalRecoveryTabIdByInstanceId) {
+    if (instanceTabId === tabId) {
+      terminalRecoveryTabIdByInstanceId.delete(instanceId)
+      activeTerminalRecoveryInstanceIds.delete(instanceId)
+    }
+  }
+}
+
+const unregisterTerminalPaneRecoveryRetirement = registerTerminalPaneRecoveryRetirementHandler(
+  forgetTerminalPaneRecovery
+)
+if (import.meta.hot) {
+  import.meta.hot.dispose(unregisterTerminalPaneRecoveryRetirement)
+}
+
 export function _resetTerminalPaneRecoveryForTests(): void {
   recoveryTimestampsByTabId.clear()
   recoveryGenerationByTabId.clear()
   activeTerminalRecoveryInstanceIds.clear()
+  terminalRecoveryTabIdByInstanceId.clear()
   nextTerminalRecoveryInstanceId = 0
   for (const pendingRetry of pendingRetryByTabId.values()) {
     clearTimeout(pendingRetry.timer)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -110,7 +110,10 @@ import { getConnectionId } from '@/lib/connection-context'
 import { getExecutionHostIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { isPaneReplaying, type ReplayingPanesRef } from './replay-guard'
 import { fitAndFocusPanes, fitPanes } from './pane-helpers'
-import { markTerminalPinnedViewport } from '@/lib/pane-manager/terminal-scroll-intent'
+import {
+  markTerminalPinnedViewport,
+  releaseTerminalScrollIntentKeys
+} from '@/lib/pane-manager/terminal-scroll-intent'
 import { syncTerminalScrollIntentSoon } from '@/lib/pane-manager/terminal-scroll-intent-settle'
 import { registerRuntimeTerminalTab, scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { captureParkedTerminalPaneCandidates } from './terminal-parked-tab-watchers'
@@ -1222,6 +1225,7 @@ export function useTerminalPaneLifecycle({
         }
         const leafId = closedPane?.leafId
         if (leafId && !isDetachedToTab) {
+          releaseTerminalScrollIntentKeys([leafId])
           // Why: revoke only this pane's authority; an exact tombstone blocks queued hooks without suppressing siblings.
           const paneKey = makePaneKey(tabId, leafId)
           useAppStore.getState().retireAgentPaneAuthority(paneKey)


### PR DESCRIPTION
## OOM hardening slice 26/29 — bound renderer editor & terminal-pane buffers

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **26/29** (base: `oom/25-b-cli`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Bounds renderer editor + terminal-pane accumulators against OOM with concrete numeric caps and extensive tests. Combined-diff text retention (24MB/12M-char budget, evict+refetch offscreen bodies, view-state LRU=20), CSV parse limits (50MB/250k rows/1024 cols/1M cells) with graceful fallback, notebook admission limits, local-image blob LRU (128MB/100) + load admission (2 active/100 admitted) + raster dimension validation, markdown completion/worktree/scan caps, and terminal input/shutdown/validation queue caps. Replaces unbounded Promise.all(map) with order-preserving mapWithConcurrency (child-checks 8, bulk-save 4, link-probes 8). Bundles two correctness fixes: load-scheduler reset keeps `active` so stale loads still count against concurrency, and pty-input-queue clearVersion prevents post-clear writes. SVG and valid rasters pass through unchanged; only decode bombs rejected. Slice compiles standalone; tab-retirement cleanup wiring lives in store slices (another bucket).

### ELI5
When files, diffs, images, notebooks, or terminal streams get huge, Orca used to keep everything in memory at once and could crash. This adds size limits everywhere: oversized CSVs/notebooks show a friendly 'too large' message, giant diffs quietly drop offscreen text and refetch it when you scroll back, image bombs are refused before they can blow up memory, and typing/paste backlogs and background checks are capped and run a few at a time. Normal files behave exactly as before.

### Proof of OOM fix
- combined-diff-text-retention.ts: MAX_RETAINED_COMBINED_DIFF_TEXT_BYTES=24MB (12M chars); offscreen non-active/non-dirty/non-loading sections evicted+reloadable; view-state cache COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES=20 + aggregate budget
- csv-parse.ts CSV_PARSE_LIMITS: 50MB source / 250k rows / 1024 cols / 1M cells / 50MB retained cell text -> CsvLimitFallback
- ipynb-json-admission.ts IPYNB_MEMORY_LIMITS: 50MB source, 500k structural tokens, depth 256, 1000 cells, 10k outputs, 20k display items, 100k multiline parts
- useLocalImageSrc.ts: LocalImageBlobRetention 128MB/100 entries, LocalImageLoadAdmission 2 active/100 admitted, chunked base64 decode, assertRasterImagePreviewWithinLimits (32768px/side, 32M px)
- monaco-markdown-doc-completions.ts: 256 models / 32 scopes / 64MB; markdown-document-worktree-retention.ts: 8 snapshots / 32MB; markdown-document-list-request.ts: global in-flight cap 16
- markdown-export-extract.ts: HTML_TO_PDF_MAX_INPUT_BYTES fragment cap with sequential blob-image inlining and streamed-body limit
- pty-input-write-queue.ts (4096 items + byte budget), pty-shutdown-data-suspension.ts (PTY_SHUTDOWN_OUTPUT_MAX_EVENTS=4096), remote-runtime-pty-batching.ts (validation-queue 4096), remote-runtime-viewport-claim-input.ts (<=TERMINAL_INPUT_MAX_BYTES)
- concurrency caps: CHILD_PROCESS_CHECK_CONCURRENCY=8, EDITOR_BULK_SAVE_CONCURRENCY=4, TERMINAL_FILE_LINK_PROBE_CONCURRENCY=8 via order-preserving mapWithConcurrency

### Regressions
**Normal-path (ordinary use, below the new limits):** **none** — behavior is unchanged below the ceilings.

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- CSV beyond 50MB/250k rows/1024 cols/1M cells shows 'too large' fallback with source-mode escape
- Combined diff over 24MB retained text evicts offscreen section bodies and refetches on revisit (transparent)
- Notebook exceeding shape/source limits throws a safe-limit error instead of projecting
- Raster image exceeding 32768px/side or 32M px, or a decode bomb, shows failure instead of loading (ImageViewer/IpynbViewer/local preview)
- Markdown completions unavailable for a listing that exceeds the per-listing byte limit; 17th+ concurrent distinct worktree scan rejected with a toast
- PDF export of oversized markdown/images rejected with 'HTML export exceeds the PDF memory limit'
- Terminal input/paste, shutdown events, and remote validation queues reject producer backlog beyond their item/byte budgets

### Build / CI
- Part of the **Renderer** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #29** (whole-repo interconnection — see stack README). Content is exact production code.
- Touches 1 file(s) also changed on `main` since the revert; git auto-merges them (no conflict): `remote-runtime-pty-transport.ts`.

### Adversarial review
- 1 skeptic lens(es). Sign-off: **yes**. Residual risk: **low**.
- Verified no infinite render loop in CombinedDiffViewer: retainCombinedDiffSectionText returns the same array reference when under budget, so setSections bails via Object.is; eviction stabilizes in one pass. load-scheduler no longer zeroing `active` is an intentional bound fix (always decrements in finally; loads always settle, no hang). useLocalImageSrc not-admitted path returns before inFlightBlobUrlLoads.set, so no stuck in-flight key. SVG/valid raster data URIs preserved (validateRasterImageDataUri returns undefined for non-raster). Borderline normal-path edges (CSV >1024 columns; >100 concurrent local images; valid-but-unparseable raster showing an error) are rare and non-fatal with graceful fallbacks. Cleanup exports (forgetTerminalPaneRecovery bridge, collectTerminalLayoutLeafIds, releaseTerminalScrollIntentKeys) are additive; retirement wiring lives in store slices in another bucket, so full map-cleanup activates only once that bucket lands, but this slice does not break without it.

### Files
60 files changed (+2459 / −308).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
