### PR TITLE
oom(27/29): bound renderer components (native-chat, pet, sidebar, automations)

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -6,8 +6,7 @@ import React, {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
-  useSyncExternalStore
+  useState
 } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -90,6 +89,8 @@ import {
 } from '@/components/editor/diff-section-layout'
 import type { DiffSection } from '@/components/editor/diff-section-types'
 import { removeDiffSectionMeasuredHeight } from '@/components/editor/diff-section-height-cache'
+import { createCombinedDiffLoadScheduler } from '@/components/editor/combined-diff-load-scheduler'
+import { retainCombinedDiffSectionText } from '@/components/editor/combined-diff-text-retention'
 import {
   MAX_RENDERED_DIFF_COMBINED_CHARACTERS,
   MAX_RENDERED_DIFF_LINES_PER_SIDE,
@@ -160,10 +161,18 @@ import {
   getCommentBodySubmitState,
   hasBoundedCommentBodyText
 } from '@/lib/comment-body-submit-state'
+import { emitGitHubWorkItemDetailsCacheMutation } from '@/lib/github-work-item-details-cache-events'
 import {
-  emitGitHubWorkItemDetailsCacheMutation,
-  onGitHubWorkItemDetailsCacheMutation
-} from '@/lib/github-work-item-details-cache-events'
+  WORK_ITEM_DETAILS_FRESH_MS,
+  WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE,
+  getWorkItemDetailsCacheEntry,
+  getWorkItemDetailsCacheGeneration,
+  getWorkItemDetailsCacheKey,
+  invalidateWorkItemDetailsCacheByMatch,
+  invalidateWorkItemDetailsCacheForKey,
+  touchWorkItemDetailsCache,
+  useWorkItemDetailsCacheEntry
+} from '@/lib/github-work-item-details-cache'
 import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-source-lookup'
 import {
   canUseGitHubRepoContext,
@@ -1409,102 +1418,12 @@ function isPRFileViewed(file: GitHubPRFile): boolean {
   return file.viewerViewedState === 'VIEWED'
 }
 
-// Why: SWR cache for work-item details so reopening paints instantly instead of paying IPC + `gh` startup; keyed to avoid source/type collisions, LRU-bounded, FRESH_MS refetch on open. See docs/gh-work-item-drawer-cache.md.
-const WORK_ITEM_DETAILS_CACHE_MAX = 50
-const WORK_ITEM_DETAILS_FRESH_MS = 30_000
-const WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE = 'Unable to load details for this GitHub item.'
-type WorkItemDetailsCacheEntry = {
-  details: GitHubWorkItemDetails | null
-  fetchedAt: number
-  pending?: Promise<GitHubWorkItemDetails | null>
-  error?: string
-}
-const workItemDetailsCache = new Map<string, WorkItemDetailsCacheEntry>()
-
-// Why: drawers subscribe via useSyncExternalStore so a cached item paints synchronously; snapshot stability relies on every write replacing entry identity (delete+set).
-const workItemDetailsCacheListeners = new Set<() => void>()
-function subscribeWorkItemDetailsCache(listener: () => void): () => void {
-  workItemDetailsCacheListeners.add(listener)
-  return () => {
-    workItemDetailsCacheListeners.delete(listener)
-  }
-}
-function notifyWorkItemDetailsCache(): void {
-  for (const listener of workItemDetailsCacheListeners) {
-    listener()
-  }
-}
-
-function getWorkItemDetailsCacheKey(args: {
-  repoPath: string
-  repoId: string
-  issueSourcePreference: string | undefined
-  sourceCacheScope?: string | null
-  type: 'issue' | 'pr'
-  number: number
-}): string {
-  // Why: key on every axis that changes which (repo, item) the IPC resolves to; `\0` separator avoids ambiguity with fields containing `:` or `/`.
-  const keyParts = args.sourceCacheScope
-    ? [args.repoId, args.sourceCacheScope, args.issueSourcePreference ?? 'auto', args.type]
-    : [args.repoId, args.issueSourcePreference ?? 'auto', args.type]
-  return [...keyParts, args.number].join('\0')
-}
-
-function touchWorkItemDetailsCache(key: string, entry: WorkItemDetailsCacheEntry): void {
-  // Why: re-insert to move to MRU position; Map insertion order keeps the oldest key first for eviction.
-  workItemDetailsCache.delete(key)
-  workItemDetailsCache.set(key, entry)
-  while (workItemDetailsCache.size > WORK_ITEM_DETAILS_CACHE_MAX) {
-    const oldest = workItemDetailsCache.keys().next().value
-    if (oldest === undefined) {
-      break
-    }
-    workItemDetailsCache.delete(oldest)
-  }
-  notifyWorkItemDetailsCache()
-}
-
-// Why: exposed so mutation handlers can drop a stale entry after a local mutation; cross-window invalidation arrives via the gh:workItemMutated listener below.
-export function invalidateWorkItemDetailsCacheForKey(key: string): void {
-  // Why: bump generation so a fetch launched before this invalidation won't write its stale result back.
-  workItemDetailsCacheGeneration += 1
-  const existed = workItemDetailsCache.delete(key)
-  if (existed) {
-    notifyWorkItemDetailsCache()
-  }
-}
-
-// Why: bumped on every invalidation so an in-flight refetch started before a mutation can detect its result is stale and skip writing it back.
-let workItemDetailsCacheGeneration = 0
-
-// Why: without the exact key (e.g. a cross-window event carries only repoPath+number+type), drop every entry matching that tuple regardless of source preference.
-function invalidateWorkItemDetailsCacheByMatch(args: {
-  repoPath: string
-  repoId?: string
-  type: 'issue' | 'pr'
-  number: number
-}): void {
-  const suffix = `\0${args.type}\0${args.number}`
-  const prefix = `${args.repoId ?? args.repoPath}\0`
-  let removed = false
-  for (const key of Array.from(workItemDetailsCache.keys())) {
-    if (key.startsWith(prefix) && key.endsWith(suffix)) {
-      workItemDetailsCache.delete(key)
-      removed = true
-    }
-  }
-  if (removed) {
-    workItemDetailsCacheGeneration += 1
-    notifyWorkItemDetailsCache()
-  }
-}
-
 function patchCachedPRFileViewedState(
   cacheKey: string,
   path: string,
   viewerViewedState: GitHubPRFileViewedState
 ): GitHubPRFileViewedState | undefined {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   const files = prev?.details?.files
   if (!prev?.details || !files) {
     return undefined
@@ -1529,7 +1448,7 @@ function patchCachedPRFileViewedState(
 }
 
 function patchCachedPRChecks(cacheKey: string, checks: PRCheckDetail[]): void {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   if (!prev?.details) {
     return
   }
@@ -1545,7 +1464,7 @@ function patchCachedPRReviewRequests(
   cacheKey: string,
   reviewRequests: GitHubAssignableUser[]
 ): void {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   if (!prev?.details) {
     return
   }
@@ -1561,7 +1480,7 @@ function patchCachedPRReviewRequests(
 }
 
 function patchCachedWorkItemBody(cacheKey: string, body: string): void {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   if (!prev?.details) {
     return
   }
@@ -1570,29 +1489,6 @@ function patchCachedWorkItemBody(cacheKey: string, body: string): void {
     details: { ...prev.details, body },
     fetchedAt: Date.now(),
     error: undefined
-  })
-}
-
-// Why: install once — all dialogs share the cache; track unsubscribe so Vite HMR doesn't accumulate listeners across dev reloads.
-let workItemMutatedUnsub: (() => void) | undefined
-let workItemDetailsCacheEventUnsub: (() => void) | undefined
-if (typeof window !== 'undefined' && window.api?.gh?.onWorkItemMutated) {
-  workItemMutatedUnsub = window.api.gh.onWorkItemMutated((payload) => {
-    invalidateWorkItemDetailsCacheByMatch({
-      repoPath: payload.repoPath,
-      repoId: payload.repoId,
-      type: payload.type,
-      number: payload.number
-    })
-  })
-  workItemDetailsCacheEventUnsub = onGitHubWorkItemDetailsCacheMutation((payload) => {
-    invalidateWorkItemDetailsCacheByMatch(payload)
-  })
-}
-if (typeof import.meta !== 'undefined' && import.meta.hot) {
-  import.meta.hot.dispose(() => {
-    workItemMutatedUnsub?.()
-    workItemDetailsCacheEventUnsub?.()
   })
 }
 
@@ -2277,13 +2173,47 @@ function PRFilesCombinedDiffViewer({
   const loadedIndicesRef = useRef<Set<number>>(new Set())
   const loadingIndicesRef = useRef<Set<number>>(new Set())
   const sectionsRef = useRef<DiffSection[]>([])
+  const protectedSectionKeysRef = useRef<ReadonlySet<string>>(new Set())
   const generationRef = useRef(0)
   const modifiedEditorsRef = useRef<Map<number, monacoEditor.IStandaloneCodeEditor>>(new Map())
   const handleSectionSaveRef = useRef<(index: number) => Promise<void>>(async () => {})
+  const loadSectionRef = useRef<(index: number) => Promise<void>>(async () => {})
+  const loadSchedulerRef = useRef(
+    createCombinedDiffLoadScheduler({
+      loadSection: (index) => loadSectionRef.current(index),
+      // Why: keep hosted fetch latency responsive without stacking a PR worth of response bodies.
+      maxConcurrent: 2
+    })
+  )
+  const applySectionTextRetention = useCallback(
+    (nextSections: DiffSection[], additionallyProtectedKey?: string): DiffSection[] => {
+      const protectedSectionKeys = new Set(protectedSectionKeysRef.current)
+      if (additionallyProtectedKey) {
+        protectedSectionKeys.add(additionallyProtectedKey)
+      }
+      const retained = retainCombinedDiffSectionText({
+        sections: nextSections,
+        loadedIndices: loadedIndicesRef.current,
+        protectedSectionKeys
+      })
+      for (const index of retained.evictedIndices) {
+        loadedIndicesRef.current.delete(index)
+      }
+      return retained.sections
+    },
+    []
+  )
   sectionsRef.current = sections
 
   useEffect(() => {
+    const scheduler = loadSchedulerRef.current
+    scheduler.reset()
+    return () => scheduler.dispose()
+  }, [])
+
+  useEffect(() => {
     generationRef.current += 1
+    loadSchedulerRef.current.reset()
     loadedIndicesRef.current.clear()
     loadingIndicesRef.current.clear()
     setSectionHeights({})
@@ -2308,10 +2238,10 @@ function PRFilesCombinedDiffViewer({
     )
   }, [entries, entrySignature])
 
-  const loadSection = useCallback(
-    (index: number) => {
+  const loadSectionNow = useCallback(
+    async (index: number) => {
       const section = sectionsRef.current[index]
-      if (!section || section.collapsed) {
+      if (!section || section.collapsed || !protectedSectionKeysRef.current.has(section.key)) {
         return
       }
       if (loadedIndicesRef.current.has(index) || loadingIndicesRef.current.has(index)) {
@@ -2368,74 +2298,86 @@ function PRFilesCombinedDiffViewer({
         return { result: getPRFileDiffResult(contents), resultContents: contents }
       }
 
-      load()
-        .catch((error) => ({
-          result: {
-            kind: 'text',
-            originalContent: '',
-            modifiedContent: '',
-            originalIsBinary: false,
-            modifiedIsBinary: false
-          } as GitDiffResult,
-          resultContents: undefined,
-          error: error instanceof Error ? error.message : 'Failed to load diff.'
-        }))
-        .then(({ result, resultContents, error }) => {
-          loadingIndicesRef.current.delete(index)
-          if (generationRef.current !== generation) {
-            return
-          }
-          const largeDiffRenderLimit =
-            !error && result.kind === 'text' && resultContents
-              ? getPRFileContentsRenderLimit(resultContents)
-              : null
-          const storedContent = getStoredTextDiffContent(result, largeDiffRenderLimit)
-          const storedResult = getStoredTextDiffResult(result, largeDiffRenderLimit)
-          loadedIndicesRef.current.add(index)
-          setSections((prev) =>
-            prev.map((current, currentIndex) =>
-              currentIndex === index
-                ? {
-                    ...current,
-                    diffResult: storedResult,
-                    originalContent: storedContent.originalContent,
-                    modifiedContent: storedContent.modifiedContent,
-                    loading: false,
-                    error,
-                    largeDiffRenderLimit
-                  }
-                : current
-            )
-          )
-        })
-    },
-    [baseSha, fileByPath, headSha, prNumber, prRepo, repoId, repoPath, sourceContext]
-  )
-
-  const retrySection = useCallback(
-    (index: number) => {
-      loadedIndicesRef.current.delete(index)
+      const { result, resultContents, error } = await load().catch((error) => ({
+        result: {
+          kind: 'text',
+          originalContent: '',
+          modifiedContent: '',
+          originalIsBinary: false,
+          modifiedIsBinary: false
+        } as GitDiffResult,
+        resultContents: undefined,
+        error: error instanceof Error ? error.message : 'Failed to load diff.'
+      }))
       loadingIndicesRef.current.delete(index)
-      setSectionHeights((prev) => removeDiffSectionMeasuredHeight(prev, index))
-      setSections((prev) =>
-        prev.map((section, sectionIndex) =>
-          sectionIndex === index
+      if (generationRef.current !== generation) {
+        return
+      }
+      const largeDiffRenderLimit =
+        !error && result.kind === 'text' && resultContents
+          ? getPRFileContentsRenderLimit(resultContents)
+          : null
+      const storedContent = getStoredTextDiffContent(result, largeDiffRenderLimit)
+      const storedResult = getStoredTextDiffResult(result, largeDiffRenderLimit)
+      loadedIndicesRef.current.add(index)
+      setSections((prev) => {
+        const nextSections = prev.map((current, currentIndex) =>
+          currentIndex === index
             ? {
-                ...section,
-                diffResult: null,
-                originalContent: '',
-                modifiedContent: '',
-                loading: true,
-                error: undefined,
-                largeDiffRenderLimit: null
+                ...current,
+                diffResult: storedResult,
+                originalContent: storedContent.originalContent,
+                modifiedContent: storedContent.modifiedContent,
+                loading: false,
+                error,
+                largeDiffRenderLimit
               }
-            : section
+            : current
         )
-      )
-      loadSection(index)
+        return applySectionTextRetention(nextSections, nextSections[index]?.key)
+      })
     },
-    [loadSection]
+    [
+      applySectionTextRetention,
+      baseSha,
+      fileByPath,
+      headSha,
+      prNumber,
+      prRepo,
+      repoId,
+      repoPath,
+      sourceContext
+    ]
   )
+  loadSectionRef.current = loadSectionNow
+
+  const loadSection = useCallback((index: number) => {
+    if (!sectionsRef.current[index]?.collapsed) {
+      loadSchedulerRef.current.request(index)
+    }
+  }, [])
+
+  const retrySection = useCallback((index: number) => {
+    loadedIndicesRef.current.delete(index)
+    loadingIndicesRef.current.delete(index)
+    setSectionHeights((prev) => removeDiffSectionMeasuredHeight(prev, index))
+    setSections((prev) =>
+      prev.map((section, sectionIndex) =>
+        sectionIndex === index
+          ? {
+              ...section,
+              diffResult: null,
+              originalContent: '',
+              modifiedContent: '',
+              loading: true,
+              error: undefined,
+              largeDiffRenderLimit: null
+            }
+          : section
+      )
+    )
+    loadSchedulerRef.current.rerequest(index)
+  }, [])
 
   const toggleSection = useCallback(
     (index: number) => {
@@ -2452,17 +2394,11 @@ function PRFilesCombinedDiffViewer({
     [loadSection]
   )
 
-  const setAllSectionsCollapsed = useCallback(
-    (collapsed: boolean) => {
-      setSections((prev) => prev.map((section) => ({ ...section, collapsed })))
-      if (!collapsed) {
-        window.requestAnimationFrame(() => {
-          sectionsRef.current.forEach((_, index) => loadSection(index))
-        })
-      }
-    },
-    [loadSection]
-  )
+  const setAllSectionsCollapsed = useCallback((collapsed: boolean) => {
+    // Why: expanded virtual rows load on mount; prefetching every offscreen file
+    // can queue an entire large PR's response bodies before retention runs.
+    setSections((prev) => prev.map((section) => ({ ...section, collapsed })))
+  }, [])
 
   const allSectionsCollapsed = sections.length > 0 && sections.every((section) => section.collapsed)
   const sectionIndexByKey = useMemo(() => createCombinedDiffSectionIndexMap(sections), [sections])
@@ -2501,6 +2437,18 @@ function PRFilesCombinedDiffViewer({
         : `${index}:${entrySignature}`
     }
   })
+  const protectedSectionKeys = [
+    ...virtualizer
+      .getVirtualItems()
+      .map((item) => sections[item.index]?.key)
+      .filter((key): key is string => key !== undefined),
+    ...(activeTreeSectionKey ? [activeTreeSectionKey] : [])
+  ]
+  protectedSectionKeysRef.current = new Set(protectedSectionKeys)
+  const protectedSectionSignature = protectedSectionKeys.join('\0')
+  useLayoutEffect(() => {
+    setSections((current) => applySectionTextRetention(current))
+  }, [applySectionTextRetention, protectedSectionSignature, sections])
 
   useLayoutEffect(() => {
     virtualizer.measure()
@@ -6874,14 +6822,8 @@ export default function GitHubItemDialog({
     }
   }, [workItem])
 
-  // Why: subscribe to the module-level cache so reopening a cached item paints synchronously on first render.
-  const cachedEntry = useSyncExternalStore(
-    subscribeWorkItemDetailsCache,
-    useCallback(
-      () => (detailsCacheKey ? workItemDetailsCache.get(detailsCacheKey) : undefined),
-      [detailsCacheKey]
-    )
-  )
+  // Why: rejected oversized results stay local to the mounted drawer without re-entering retention.
+  const cachedEntry = useWorkItemDetailsCacheEntry(detailsCacheKey)
 
   // Why: bumped on cold open (no cached details yet) so the details memo re-runs and surfaces the optimistic comment before the fetch lands.
   const [optimisticTick, setOptimisticTick] = useState(0)
@@ -6948,7 +6890,7 @@ export default function GitHubItemDialog({
     prevItemIdRef.current = workItem.id
     setTab(normalizeItemDialogTab(workItem, initialTab))
 
-    const cached = workItemDetailsCache.get(detailsCacheKey)
+    const cached = getWorkItemDetailsCacheEntry(detailsCacheKey)
     const now = Date.now()
     const hasFreshData = cached?.details && now - cached.fetchedAt <= WORK_ITEM_DETAILS_FRESH_MS
 
@@ -6968,7 +6910,7 @@ export default function GitHubItemDialog({
       })
 
     // Why: snapshot the invalidation generation; if it advances before resolve, a mid-flight mutation invalidated the entry — don't write back.
-    const launchedAtGeneration = workItemDetailsCacheGeneration
+    const launchedAtGeneration = getWorkItemDetailsCacheGeneration()
 
     if (!cached?.pending) {
       touchWorkItemDetailsCache(detailsCacheKey, {
@@ -6981,8 +6923,8 @@ export default function GitHubItemDialog({
 
     inflight
       .then((result) => {
-        const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
-        const prev = workItemDetailsCache.get(detailsCacheKey)
+        const invalidatedMidFlight = getWorkItemDetailsCacheGeneration() !== launchedAtGeneration
+        const prev = getWorkItemDetailsCacheEntry(detailsCacheKey)
         if (invalidatedMidFlight && prev?.pending !== inflight) {
           // Why: entry was deliberately dropped (or later repopulated) — don't recreate or touch it.
           return
@@ -7010,8 +6952,8 @@ export default function GitHubItemDialog({
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : 'Failed to load details'
-        const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
-        const prev = workItemDetailsCache.get(detailsCacheKey)
+        const invalidatedMidFlight = getWorkItemDetailsCacheGeneration() !== launchedAtGeneration
+        const prev = getWorkItemDetailsCacheEntry(detailsCacheKey)
         if (invalidatedMidFlight && prev?.pending !== inflight) {
           return
         }
@@ -7115,7 +7057,7 @@ export default function GitHubItemDialog({
       optimisticCommentsRef.current.push(comment)
       // Why: write through the module cache so concurrent drawers re-render; mark fetchedAt stale (0) so next open refetches server fields.
       if (detailsCacheKey) {
-        const prev = workItemDetailsCache.get(detailsCacheKey)
+        const prev = getWorkItemDetailsCacheEntry(detailsCacheKey)
         if (prev?.details) {
           const ids = new Set(prev.details.comments.map((c) => c.id))
           if (!ids.has(comment.id)) {

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -6,8 +6,7 @@ import React, {
   useLayoutEffect,
   useMemo,
   useRef,
-  useState,
-  useSyncExternalStore
+  useState
 } from 'react'
 import { lazyWithRetry as lazy } from '@/lib/lazy-with-retry'
 import { useVirtualizer } from '@tanstack/react-virtual'
@@ -85,6 +84,12 @@ import {
 } from '@/components/editor/diff-section-layout'
 import type { DiffSection } from '@/components/editor/diff-section-types'
 import { removeDiffSectionMeasuredHeight } from '@/components/editor/diff-section-height-cache'
+import { createCombinedDiffLoadScheduler } from '@/components/editor/combined-diff-load-scheduler'
+import {
+  COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES,
+  retainCombinedDiffSectionText,
+  retainCombinedDiffViewStateText
+} from '@/components/editor/combined-diff-text-retention'
 import {
   MAX_RENDERED_DIFF_COMBINED_CHARACTERS,
   MAX_RENDERED_DIFF_LINES_PER_SIDE,
@@ -163,10 +168,18 @@ import {
   getCommentBodySubmitState,
   hasBoundedCommentBodyText
 } from '@/lib/comment-body-submit-state'
+import { emitGitHubWorkItemDetailsCacheMutation } from '@/lib/github-work-item-details-cache-events'
 import {
-  emitGitHubWorkItemDetailsCacheMutation,
-  onGitHubWorkItemDetailsCacheMutation
-} from '@/lib/github-work-item-details-cache-events'
+  WORK_ITEM_DETAILS_FRESH_MS,
+  WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE,
+  getWorkItemDetailsCacheEntry,
+  getWorkItemDetailsCacheGeneration,
+  getWorkItemDetailsCacheKey,
+  invalidateWorkItemDetailsCacheByMatch,
+  invalidateWorkItemDetailsCacheForKey,
+  touchWorkItemDetailsCache,
+  useWorkItemDetailsCacheEntry
+} from '@/lib/github-work-item-details-cache'
 import { lookupGitHubWorkItemDetailsForSource } from '@/lib/github-work-item-source-lookup'
 import {
   canUseGitHubRepoContext,
@@ -1452,102 +1465,12 @@ function isPRFileViewed(file: GitHubPRFile): boolean {
   return file.viewerViewedState === 'VIEWED'
 }
 
-// SWR cache: reopening a drawer paints cached data instantly while a background refetch reconciles. See docs/gh-work-item-drawer-cache.md.
-const WORK_ITEM_DETAILS_CACHE_MAX = 50
-const WORK_ITEM_DETAILS_FRESH_MS = 30_000
-const WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE = 'Unable to load details for this GitHub item.'
-type WorkItemDetailsCacheEntry = {
-  details: GitHubWorkItemDetails | null
-  fetchedAt: number
-  pending?: Promise<GitHubWorkItemDetails | null>
-  error?: string
-}
-const workItemDetailsCache = new Map<string, WorkItemDetailsCacheEntry>()
-
-// Why: useSyncExternalStore snapshot stability relies on every cache write replacing the entry object identity (delete+set).
-const workItemDetailsCacheListeners = new Set<() => void>()
-function subscribeWorkItemDetailsCache(listener: () => void): () => void {
-  workItemDetailsCacheListeners.add(listener)
-  return () => {
-    workItemDetailsCacheListeners.delete(listener)
-  }
-}
-function notifyWorkItemDetailsCache(): void {
-  for (const listener of workItemDetailsCacheListeners) {
-    listener()
-  }
-}
-
-function getWorkItemDetailsCacheKey(args: {
-  repoPath: string
-  repoId: string
-  issueSourcePreference: string | undefined
-  sourceCacheScope?: string | null
-  type: 'issue' | 'pr'
-  number: number
-}): string {
-  // Why: `\0` separator avoids collisions between key fields that may contain `:` or `/`.
-  const keyParts = args.sourceCacheScope
-    ? [args.repoId, args.sourceCacheScope, args.issueSourcePreference ?? 'auto', args.type]
-    : [args.repoId, args.issueSourcePreference ?? 'auto', args.type]
-  return [...keyParts, args.number].join('\0')
-}
-
-function touchWorkItemDetailsCache(key: string, entry: WorkItemDetailsCacheEntry): void {
-  // Why: re-insert moves the key to MRU; Map insertion order keeps the oldest key first when evicting.
-  workItemDetailsCache.delete(key)
-  workItemDetailsCache.set(key, entry)
-  while (workItemDetailsCache.size > WORK_ITEM_DETAILS_CACHE_MAX) {
-    const oldest = workItemDetailsCache.keys().next().value
-    if (oldest === undefined) {
-      break
-    }
-    workItemDetailsCache.delete(oldest)
-  }
-  notifyWorkItemDetailsCache()
-}
-
-// Exposed so mutation handlers can drop a stale entry after a local mutation (cross-window invalidation arrives via the `gh:workItemMutated` listener below).
-export function invalidateWorkItemDetailsCacheForKey(key: string): void {
-  // Why: bump generation so an in-flight fetch launched before this invalidation won't write its stale result back.
-  workItemDetailsCacheGeneration += 1
-  const existed = workItemDetailsCache.delete(key)
-  if (existed) {
-    notifyWorkItemDetailsCache()
-  }
-}
-
-// Why: monotonic counter so an in-flight refetch that started before a mutation detects its result is stale and skips the write-back.
-let workItemDetailsCacheGeneration = 0
-
-// Why: without the exact key (cross-window events carry only repoPath+number+type), drop every entry matching that tuple regardless of source preference.
-function invalidateWorkItemDetailsCacheByMatch(args: {
-  repoPath: string
-  repoId?: string
-  type: 'issue' | 'pr'
-  number: number
-}): void {
-  const suffix = `\0${args.type}\0${args.number}`
-  const prefix = `${args.repoId ?? args.repoPath}\0`
-  let removed = false
-  for (const key of Array.from(workItemDetailsCache.keys())) {
-    if (key.startsWith(prefix) && key.endsWith(suffix)) {
-      workItemDetailsCache.delete(key)
-      removed = true
-    }
-  }
-  if (removed) {
-    workItemDetailsCacheGeneration += 1
-    notifyWorkItemDetailsCache()
-  }
-}
-
 function patchCachedPRFileViewedState(
   cacheKey: string,
   path: string,
   viewerViewedState: GitHubPRFileViewedState
 ): GitHubPRFileViewedState | undefined {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   const files = prev?.details?.files
   if (!prev?.details || !files) {
     return undefined
@@ -1572,7 +1495,7 @@ function patchCachedPRFileViewedState(
 }
 
 function patchCachedPRChecks(cacheKey: string, checks: PRCheckDetail[]): void {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   if (!prev?.details) {
     return
   }
@@ -1588,7 +1511,7 @@ function patchCachedPRReviewRequests(
   cacheKey: string,
   reviewRequests: GitHubAssignableUser[]
 ): void {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   if (!prev?.details) {
     return
   }
@@ -1604,7 +1527,7 @@ function patchCachedPRReviewRequests(
 }
 
 function patchCachedWorkItemBody(cacheKey: string, body: string): void {
-  const prev = workItemDetailsCache.get(cacheKey)
+  const prev = getWorkItemDetailsCacheEntry(cacheKey)
   if (!prev?.details) {
     return
   }
@@ -1613,29 +1536,6 @@ function patchCachedWorkItemBody(cacheKey: string, body: string): void {
     details: { ...prev.details, body },
     fetchedAt: Date.now(),
     error: undefined
-  })
-}
-
-// Install once at module load (all dialogs share the cache); track the unsubscribe so Vite HMR doesn't accumulate listeners across reloads.
-let workItemMutatedUnsub: (() => void) | undefined
-let workItemDetailsCacheEventUnsub: (() => void) | undefined
-if (typeof window !== 'undefined' && window.api?.gh?.onWorkItemMutated) {
-  workItemMutatedUnsub = window.api.gh.onWorkItemMutated((payload) => {
-    invalidateWorkItemDetailsCacheByMatch({
-      repoPath: payload.repoPath,
-      repoId: payload.repoId,
-      type: payload.type,
-      number: payload.number
-    })
-  })
-  workItemDetailsCacheEventUnsub = onGitHubWorkItemDetailsCacheMutation((payload) => {
-    invalidateWorkItemDetailsCacheByMatch(payload)
-  })
-}
-if (typeof import.meta !== 'undefined' && import.meta.hot) {
-  import.meta.hot.dispose(() => {
-    workItemMutatedUnsub?.()
-    workItemDetailsCacheEventUnsub?.()
   })
 }
 
@@ -2339,14 +2239,48 @@ function PRFilesCombinedDiffViewer({
   const loadedIndicesRef = useRef<Set<number>>(new Set())
   const loadingIndicesRef = useRef<Set<number>>(new Set())
   const sectionsRef = useRef<DiffSection[]>([])
+  const protectedSectionKeysRef = useRef<ReadonlySet<string>>(new Set())
   const generationRef = useRef(0)
   const modifiedEditorsRef = useRef<Map<number, monacoEditor.IStandaloneCodeEditor>>(new Map())
   const handleSectionSaveRef = useRef<(index: number) => Promise<void>>(async () => {})
+  const loadSectionRef = useRef<(index: number) => Promise<void>>(async () => {})
+  const loadSchedulerRef = useRef(
+    createCombinedDiffLoadScheduler({
+      loadSection: (index) => loadSectionRef.current(index),
+      // Why: keep hosted fetch latency responsive without stacking a PR worth of response bodies.
+      maxConcurrent: 2
+    })
+  )
+  const applySectionTextRetention = useCallback(
+    (nextSections: DiffSection[], additionallyProtectedKey?: string): DiffSection[] => {
+      const protectedSectionKeys = new Set(protectedSectionKeysRef.current)
+      if (additionallyProtectedKey) {
+        protectedSectionKeys.add(additionallyProtectedKey)
+      }
+      const retained = retainCombinedDiffSectionText({
+        sections: nextSections,
+        loadedIndices: loadedIndicesRef.current,
+        protectedSectionKeys
+      })
+      for (const index of retained.evictedIndices) {
+        loadedIndicesRef.current.delete(index)
+      }
+      return retained.sections
+    },
+    []
+  )
   sectionsRef.current = sections
+
+  useEffect(() => {
+    const scheduler = loadSchedulerRef.current
+    scheduler.reset()
+    return () => scheduler.dispose()
+  }, [])
 
   useEffect(() => {
     // Why: bump generation so stale async diff loads from the previous view can't patch the restored sections.
     generationRef.current += 1
+    loadSchedulerRef.current.reset()
     const cached = prFilesDiffViewStateCache.get(viewStateKey)
     if (cached && cached.entrySignature === entrySignature) {
       const restoredSections = cached.sections
@@ -2389,10 +2323,10 @@ function PRFilesCombinedDiffViewer({
     )
   }, [entries, entrySignature, viewStateKey])
 
-  const loadSection = useCallback(
-    (index: number) => {
+  const loadSectionNow = useCallback(
+    async (index: number) => {
       const section = sectionsRef.current[index]
-      if (!section || section.collapsed) {
+      if (!section || section.collapsed || !protectedSectionKeysRef.current.has(section.key)) {
         return
       }
       if (loadedIndicesRef.current.has(index) || loadingIndicesRef.current.has(index)) {
@@ -2449,74 +2383,86 @@ function PRFilesCombinedDiffViewer({
         return { result: getPRFileDiffResult(contents), resultContents: contents }
       }
 
-      load()
-        .catch((error) => ({
-          result: {
-            kind: 'text',
-            originalContent: '',
-            modifiedContent: '',
-            originalIsBinary: false,
-            modifiedIsBinary: false
-          } as GitDiffResult,
-          resultContents: undefined,
-          error: error instanceof Error ? error.message : 'Failed to load diff.'
-        }))
-        .then(({ result, resultContents, error }) => {
-          loadingIndicesRef.current.delete(index)
-          if (generationRef.current !== generation) {
-            return
-          }
-          const largeDiffRenderLimit =
-            !error && result.kind === 'text' && resultContents
-              ? getPRFileContentsRenderLimit(resultContents)
-              : null
-          const storedContent = getStoredTextDiffContent(result, largeDiffRenderLimit)
-          const storedResult = getStoredTextDiffResult(result, largeDiffRenderLimit)
-          loadedIndicesRef.current.add(index)
-          setSections((prev) =>
-            prev.map((current, currentIndex) =>
-              currentIndex === index
-                ? {
-                    ...current,
-                    diffResult: storedResult,
-                    originalContent: storedContent.originalContent,
-                    modifiedContent: storedContent.modifiedContent,
-                    loading: false,
-                    error,
-                    largeDiffRenderLimit
-                  }
-                : current
-            )
-          )
-        })
-    },
-    [baseSha, fileByPath, headSha, prNumber, prRepo, repoId, repoPath, sourceContext]
-  )
-
-  const retrySection = useCallback(
-    (index: number) => {
-      loadedIndicesRef.current.delete(index)
+      const { result, resultContents, error } = await load().catch((error) => ({
+        result: {
+          kind: 'text',
+          originalContent: '',
+          modifiedContent: '',
+          originalIsBinary: false,
+          modifiedIsBinary: false
+        } as GitDiffResult,
+        resultContents: undefined,
+        error: error instanceof Error ? error.message : 'Failed to load diff.'
+      }))
       loadingIndicesRef.current.delete(index)
-      setSectionHeights((prev) => removeDiffSectionMeasuredHeight(prev, index))
-      setSections((prev) =>
-        prev.map((section, sectionIndex) =>
-          sectionIndex === index
+      if (generationRef.current !== generation) {
+        return
+      }
+      const largeDiffRenderLimit =
+        !error && result.kind === 'text' && resultContents
+          ? getPRFileContentsRenderLimit(resultContents)
+          : null
+      const storedContent = getStoredTextDiffContent(result, largeDiffRenderLimit)
+      const storedResult = getStoredTextDiffResult(result, largeDiffRenderLimit)
+      loadedIndicesRef.current.add(index)
+      setSections((prev) => {
+        const nextSections = prev.map((current, currentIndex) =>
+          currentIndex === index
             ? {
-                ...section,
-                diffResult: null,
-                originalContent: '',
-                modifiedContent: '',
-                loading: true,
-                error: undefined,
-                largeDiffRenderLimit: null
+                ...current,
+                diffResult: storedResult,
+                originalContent: storedContent.originalContent,
+                modifiedContent: storedContent.modifiedContent,
+                loading: false,
+                error,
+                largeDiffRenderLimit
               }
-            : section
+            : current
         )
-      )
-      loadSection(index)
+        return applySectionTextRetention(nextSections, nextSections[index]?.key)
+      })
     },
-    [loadSection]
+    [
+      applySectionTextRetention,
+      baseSha,
+      fileByPath,
+      headSha,
+      prNumber,
+      prRepo,
+      repoId,
+      repoPath,
+      sourceContext
+    ]
   )
+  loadSectionRef.current = loadSectionNow
+
+  const loadSection = useCallback((index: number) => {
+    if (!sectionsRef.current[index]?.collapsed) {
+      loadSchedulerRef.current.request(index)
+    }
+  }, [])
+
+  const retrySection = useCallback((index: number) => {
+    loadedIndicesRef.current.delete(index)
+    loadingIndicesRef.current.delete(index)
+    setSectionHeights((prev) => removeDiffSectionMeasuredHeight(prev, index))
+    setSections((prev) =>
+      prev.map((section, sectionIndex) =>
+        sectionIndex === index
+          ? {
+              ...section,
+              diffResult: null,
+              originalContent: '',
+              modifiedContent: '',
+              loading: true,
+              error: undefined,
+              largeDiffRenderLimit: null
+            }
+          : section
+      )
+    )
+    loadSchedulerRef.current.rerequest(index)
+  }, [])
 
   const toggleSection = useCallback(
     (index: number) => {
@@ -2533,17 +2479,11 @@ function PRFilesCombinedDiffViewer({
     [loadSection]
   )
 
-  const setAllSectionsCollapsed = useCallback(
-    (collapsed: boolean) => {
-      setSections((prev) => prev.map((section) => ({ ...section, collapsed })))
-      if (!collapsed) {
-        window.requestAnimationFrame(() => {
-          sectionsRef.current.forEach((_, index) => loadSection(index))
-        })
-      }
-    },
-    [loadSection]
-  )
+  const setAllSectionsCollapsed = useCallback((collapsed: boolean) => {
+    // Why: expanded virtual rows load on mount; prefetching every offscreen file
+    // can queue an entire large PR's response bodies before retention runs.
+    setSections((prev) => prev.map((section) => ({ ...section, collapsed })))
+  }, [])
 
   const allSectionsCollapsed = sections.length > 0 && sections.every((section) => section.collapsed)
   const sectionIndexByKey = useMemo(() => createCombinedDiffSectionIndexMap(sections), [sections])
@@ -2582,6 +2522,18 @@ function PRFilesCombinedDiffViewer({
         : `${index}:${entrySignature}`
     }
   })
+  const protectedSectionKeys = [
+    ...virtualizer
+      .getVirtualItems()
+      .map((item) => sections[item.index]?.key)
+      .filter((key): key is string => key !== undefined),
+    ...(activeTreeSectionKey ? [activeTreeSectionKey] : [])
+  ]
+  protectedSectionKeysRef.current = new Set(protectedSectionKeys)
+  const protectedSectionSignature = protectedSectionKeys.join('\0')
+  useLayoutEffect(() => {
+    setSections((current) => applySectionTextRetention(current))
+  }, [applySectionTextRetention, protectedSectionSignature, sections])
 
   useLayoutEffect(() => {
     virtualizer.measure()
@@ -2593,18 +2545,24 @@ function PRFilesCombinedDiffViewer({
     }
     const preservedScrollTop =
       prFilesDiffScrollTopCache.get(viewStateKey) ?? scrollContainerRef.current?.scrollTop ?? 0
-    setWithLRU(prFilesDiffViewStateCache, viewStateKey, {
-      entrySignature,
-      sections,
-      sectionHeights,
-      loadedIndices: Array.from(loadedIndicesRef.current).filter(
-        (index) => !sections[index]?.loading
-      ),
-      scrollTop: preservedScrollTop,
-      sideBySide,
-      fileTreeCollapsed,
-      activeTreeSectionKey
-    })
+    setWithLRU(
+      prFilesDiffViewStateCache,
+      viewStateKey,
+      {
+        entrySignature,
+        sections,
+        sectionHeights,
+        loadedIndices: Array.from(loadedIndicesRef.current).filter(
+          (index) => !sections[index]?.loading
+        ),
+        scrollTop: preservedScrollTop,
+        sideBySide,
+        fileTreeCollapsed,
+        activeTreeSectionKey
+      },
+      COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES
+    )
+    retainCombinedDiffViewStateText(prFilesDiffViewStateCache)
   }, [
     activeTreeSectionKey,
     entries.length,
@@ -6619,14 +6577,8 @@ export default function PullRequestPage({
     }
   }, [workItem])
 
-  // Why: subscribe to the module cache so reopening a cached item paints synchronously; writes replace entry identity (delete+set), so Map.get is a stable snapshot.
-  const cachedEntry = useSyncExternalStore(
-    subscribeWorkItemDetailsCache,
-    useCallback(
-      () => (detailsCacheKey ? workItemDetailsCache.get(detailsCacheKey) : undefined),
-      [detailsCacheKey]
-    )
-  )
+  // Why: rejected oversized results stay local to the mounted page without re-entering retention.
+  const cachedEntry = useWorkItemDetailsCacheEntry(detailsCacheKey)
 
   // Why: bumped on cold open (no cached details) so the details memo re-runs and surfaces the optimistic comment via the loading shell; cache-notify handles the warm case.
   const [optimisticTick, setOptimisticTick] = useState(0)
@@ -6680,7 +6632,7 @@ export default function PullRequestPage({
     }
     prevItemIdRef.current = workItem.id
 
-    const cached = workItemDetailsCache.get(detailsCacheKey)
+    const cached = getWorkItemDetailsCacheEntry(detailsCacheKey)
     const now = Date.now()
     const hasFreshData = cached?.details && now - cached.fetchedAt <= WORK_ITEM_DETAILS_FRESH_MS
 
@@ -6700,7 +6652,7 @@ export default function PullRequestPage({
       })
 
     // Why: snapshot the generation so a mid-flight invalidation (generation advance) blocks writing a stale result back.
-    const launchedAtGeneration = workItemDetailsCacheGeneration
+    const launchedAtGeneration = getWorkItemDetailsCacheGeneration()
 
     if (!cached?.pending) {
       touchWorkItemDetailsCache(detailsCacheKey, {
@@ -6713,8 +6665,8 @@ export default function PullRequestPage({
 
     inflight
       .then((result) => {
-        const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
-        const prev = workItemDetailsCache.get(detailsCacheKey)
+        const invalidatedMidFlight = getWorkItemDetailsCacheGeneration() !== launchedAtGeneration
+        const prev = getWorkItemDetailsCacheEntry(detailsCacheKey)
         if (invalidatedMidFlight && prev?.pending !== inflight) {
           // Why: entry was deliberately dropped (or later repopulated) — don't recreate or clobber it.
           return
@@ -6742,8 +6694,8 @@ export default function PullRequestPage({
       })
       .catch((err) => {
         const message = err instanceof Error ? err.message : 'Failed to load details'
-        const invalidatedMidFlight = workItemDetailsCacheGeneration !== launchedAtGeneration
-        const prev = workItemDetailsCache.get(detailsCacheKey)
+        const invalidatedMidFlight = getWorkItemDetailsCacheGeneration() !== launchedAtGeneration
+        const prev = getWorkItemDetailsCacheEntry(detailsCacheKey)
         if (invalidatedMidFlight && prev?.pending !== inflight) {
           return
         }
@@ -6854,7 +6806,7 @@ export default function PullRequestPage({
       optimisticCommentsRef.current.push(comment)
       // Why: write through the shared cache so subscribers re-render; fetchedAt=0 forces a background refresh next open for server-side fields.
       if (detailsCacheKey) {
-        const prev = workItemDetailsCache.get(detailsCacheKey)
+        const prev = getWorkItemDetailsCacheEntry(detailsCacheKey)
         if (prev?.details) {
           const ids = new Set(prev.details.comments.map((c) => c.id))
           if (!ids.has(comment.id)) {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -124,6 +124,7 @@ import {
   getLinearStatePillStyle
 } from '@/components/linear-state-pill-style'
 import { parseTaskQuery, stripRepoQualifiers, withQualifier } from '../../../shared/task-query'
+import { mapSettledWithConcurrency } from '../../../shared/map-with-concurrency'
 import { githubProjectHost } from '../../../shared/github-project-identity'
 import {
   buildLinearTeamUrl,
@@ -384,6 +385,7 @@ const TASK_SEARCH_DEBOUNCE_MS = 300
 const LINEAR_ITEM_LIMIT = 36
 const JIRA_ITEM_LIMIT = 50
 const PR_CHECKS_EAGER_PREFETCH_LIMIT = 20
+const GITLAB_REPO_FETCH_CONCURRENCY = 8
 
 const GITHUB_TASK_GRID_CLASS =
   'min-w-[790px] grid-cols-[72px_minmax(320px,1fr)_84px_100px_92px_122px]'
@@ -4909,7 +4911,12 @@ export default function TaskPage(): React.JSX.Element {
                 return { repoId: repo.id, items: typed.items, error }
               })
 
-    void Promise.allSettled(eligibleRepos.map(fetchItems))
+    void mapSettledWithConcurrency(eligibleRepos, GITLAB_REPO_FETCH_CONCURRENCY, async (repo) => {
+      if (stale) {
+        return { repoId: repo.id, items: [] as GitLabWorkItem[], error: undefined }
+      }
+      return fetchItems(repo)
+    })
       .then((results) => {
         if (stale) {
           return

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -1926,7 +1926,8 @@ export default function AutomationsPage(): React.JSX.Element {
     async ({ manager, job, page, pageSize }) => {
       const fallbackRunsPage = {
         runs: job.runs.slice(page * pageSize, page * pageSize + pageSize),
-        totalCount: job.runCount
+        totalCount: job.runCount,
+        totalCountSaturated: job.runCountSaturated === true
       }
       const listExternalRuns = (
         window.api.automations as Partial<Pick<typeof window.api.automations, 'listExternalRuns'>>
@@ -1945,7 +1946,8 @@ export default function AutomationsPage(): React.JSX.Element {
         })
         return {
           runs: result.runs,
-          totalCount: result.total
+          totalCount: result.total,
+          totalCountSaturated: result.totalSaturated === true
         }
       } catch (error) {
         if (isMissingExternalRunsApiError(error)) {
@@ -2666,7 +2668,7 @@ export default function AutomationsPage(): React.JSX.Element {
                           <span className="shrink-0">·</span>
                           <span className="truncate">
                             {entry.manager.provider === 'hermes'
-                              ? `${entry.job.runCount} ${entry.job.runCount === 1 ? 'run' : 'runs'}`
+                              ? `${entry.job.runCount}${entry.job.runCountSaturated ? '+' : ''} ${entry.job.runCount === 1 ? 'run' : 'runs'}`
                               : entry.manager.canManage
                                 ? translate(
                                     'auto.components.automations.AutomationsPage.aecdc3681f',

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.test.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.test.tsx
@@ -151,6 +151,13 @@ describe('ExternalAutomationManagers toggle', () => {
     expect(getSwitch().getAttribute('aria-checked')).toBe('false')
   })
 
+  it('marks a capped run count as a lower bound', () => {
+    renderManagers([
+      makeManager({ jobs: [makeJob({ runCount: 10_000, runCountSaturated: true })] })
+    ])
+    expect(container.textContent).toContain('10000+ runs found')
+  })
+
   it('dispatches pause when toggling an enabled job', () => {
     const manager = makeManager({ jobs: [makeJob({ enabled: true })] })
     const { onAction } = renderManagers([manager])

--- a/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationManagers.tsx
@@ -241,7 +241,8 @@ export function ExternalAutomationManagers({
                       </div>
                       {manager.provider === 'hermes' ? (
                         <div className="mt-1 truncate text-xs text-muted-foreground">
-                          {job.runCount}{' '}
+                          {job.runCount}
+                          {job.runCountSaturated ? '+' : ''}{' '}
                           {job.runCount === 1
                             ? translate(
                                 'auto.components.automations.ExternalAutomationManagers.8e9165af08',

--- a/src/renderer/src/components/automations/ExternalAutomationRunTable.tsx
+++ b/src/renderer/src/components/automations/ExternalAutomationRunTable.tsx
@@ -24,6 +24,7 @@ const PAGE_SIZE = 8
 export type ExternalAutomationRunPage = {
   runs: ExternalAutomationRun[]
   totalCount?: number
+  totalCountSaturated?: boolean
 }
 
 export type FetchExternalAutomationRuns = (input: {
@@ -110,7 +111,14 @@ export function ExternalAutomationRunTable({
     // before paint so stale fetched rows/selection never flash for the new job.
     setTableState(resolvedTableState)
   }
-  const { page, selectedRunId, fetchedRuns, fetchedTotalCount, fetchError } = resolvedTableState
+  const {
+    page,
+    selectedRunId,
+    fetchedRuns,
+    fetchedTotalCount,
+    fetchedTotalCountSaturated,
+    fetchError
+  } = resolvedTableState
 
   useEffect(() => {
     if (!onFetchRuns) {
@@ -143,6 +151,7 @@ export function ExternalAutomationRunTable({
             ...resolveExternalAutomationRunTableState(current, jobRef.current),
             fetchedRuns: null,
             fetchedTotalCount: null,
+            fetchedTotalCountSaturated: false,
             fetchError: error instanceof Error ? error.message : 'Failed to load runs.'
           }))
         }
@@ -162,6 +171,11 @@ export function ExternalAutomationRunTable({
     ? (fetchedRuns ?? fallbackRuns.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE))
     : fallbackRuns.slice(page * PAGE_SIZE, page * PAGE_SIZE + PAGE_SIZE)
   const totalCount = onFetchRuns ? (fetchedTotalCount ?? job.runCount) : job.runCount
+  const totalCountSaturated = onFetchRuns
+    ? fetchedTotalCount === null
+      ? job.runCountSaturated === true
+      : fetchedTotalCountSaturated
+    : job.runCountSaturated === true
   const totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE))
   const selectedRun = useMemo(
     () =>
@@ -199,7 +213,8 @@ export function ExternalAutomationRunTable({
           ) : null}
         </div>
         <div className="text-xs text-muted-foreground">
-          {totalCount}{' '}
+          {totalCount}
+          {totalCountSaturated ? '+' : ''}{' '}
           {totalCount === 1
             ? translate('auto.components.automations.ExternalAutomationRunTable.872d032d05', 'run')
             : translate(
@@ -290,6 +305,7 @@ export function ExternalAutomationRunTable({
             {pageStart}-{pageEnd}{' '}
             {translate('auto.components.automations.ExternalAutomationRunTable.7475c0ce96', 'of')}{' '}
             {totalCount}
+            {totalCountSaturated ? '+' : ''}
           </span>
         </div>
         <div className="flex items-center gap-1">

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
@@ -86,6 +86,18 @@ describe('automation run output snapshot buffer', () => {
     expect(snapshot?.truncated).toBe(true)
   })
 
+  it('preserves output delivered as 100,000 one-character chunks', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    for (let index = 0; index < 100_000; index += 1) {
+      buffer.append(String.fromCharCode(97 + (index % 26)))
+    }
+
+    const snapshot = buffer.snapshot()
+    expect(snapshot?.content).toHaveLength(100_000)
+    expect(snapshot?.truncated).toBe(false)
+  })
+
   it('creates a saved snapshot from agent transcript text', () => {
     expect(createAutomationRunOutputSnapshotFromText('\nFinal summary.\n')).toEqual({
       format: 'plain_text',

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-control-regex -- terminal snapshots normalize ANSI/control output. */
 import type { AutomationRunOutputSnapshot } from '../../../../shared/automations-types'
+import { appendCompactedStringChunk } from '../../../../shared/string-chunk-compaction'
 
 const MAX_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
 
@@ -63,7 +64,7 @@ export function createAutomationRunOutputSnapshotBuffer(): AutomationRunOutputSn
       if (!chunk) {
         return
       }
-      chunks.push(chunk)
+      appendCompactedStringChunk(chunks, chunk)
       totalChars += chunk.length
       let overflowChars = totalChars - MAX_OUTPUT_SNAPSHOT_CHARS
       while (overflowChars > 0 && chunks.length > 0) {

--- a/src/renderer/src/components/automations/external-automation-run-table-state.test.ts
+++ b/src/renderer/src/components/automations/external-automation-run-table-state.test.ts
@@ -53,6 +53,7 @@ describe('external automation run table state', () => {
       selectedRunId: 'run-2',
       fetchedRuns: null,
       fetchedTotalCount: null,
+      fetchedTotalCountSaturated: false,
       fetchError: null
     })
   })
@@ -83,12 +84,14 @@ describe('external automation run table state', () => {
     expect(
       resolveExternalAutomationFetchedRuns(current, job('job-1', current.sourceRuns), {
         runs: [run('run-1'), run('run-2')],
-        totalCount: 12
+        totalCount: 12,
+        totalCountSaturated: true
       })
     ).toMatchObject({
       selectedRunId: 'run-2',
       fetchedRuns: [run('run-1'), run('run-2')],
-      fetchedTotalCount: 12
+      fetchedTotalCount: 12,
+      fetchedTotalCountSaturated: true
     })
   })
 

--- a/src/renderer/src/components/automations/external-automation-run-table-state.ts
+++ b/src/renderer/src/components/automations/external-automation-run-table-state.ts
@@ -8,6 +8,7 @@ type ExternalAutomationRunTableJob = {
 type ExternalAutomationRunPageResult = {
   runs: ExternalAutomationRun[]
   totalCount?: number
+  totalCountSaturated?: boolean
 }
 
 export type ExternalAutomationRunTableState = {
@@ -17,6 +18,7 @@ export type ExternalAutomationRunTableState = {
   selectedRunId: string | null
   fetchedRuns: ExternalAutomationRun[] | null
   fetchedTotalCount: number | null
+  fetchedTotalCountSaturated: boolean
   fetchError: string | null
 }
 
@@ -30,6 +32,7 @@ export function createExternalAutomationRunTableState(
     selectedRunId: job.runs[0]?.id ?? null,
     fetchedRuns: null,
     fetchedTotalCount: null,
+    fetchedTotalCountSaturated: false,
     fetchError: null
   }
 }
@@ -70,6 +73,7 @@ export function resolveExternalAutomationFetchedRuns(
     ...resolved,
     fetchedRuns: result.runs,
     fetchedTotalCount: result.totalCount ?? null,
+    fetchedTotalCountSaturated: result.totalCountSaturated === true,
     selectedRunId
   }
 }

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -81,24 +81,25 @@ describe('GitHubItemDialog source host boundaries', () => {
 
   it('uses source-aware details routing and cache identity', () => {
     const source = componentSource('GitHubItemDialog.tsx')
+    const cacheSource = componentSource('../lib/github-work-item-details-cache.ts')
     const cacheKeySection = sourceBetween(
-      source,
-      'function getWorkItemDetailsCacheKey',
-      'function touchWorkItemDetailsCache'
+      cacheSource,
+      'export function getWorkItemDetailsCacheKey',
+      'export function getWorkItemDetailsCacheEntry'
     )
     const matchInvalidationSection = sourceBetween(
-      source,
-      'function invalidateWorkItemDetailsCacheByMatch',
-      'function patchCachedPRFileViewedState'
+      cacheSource,
+      'export function invalidateWorkItemDetailsCacheByMatch',
+      'export function clearWorkItemDetailsCacheForTests'
     )
 
     expect(source).toContain('lookupGitHubWorkItemDetailsForSource({')
     expect(source).toContain('sourceContext,')
     expect(cacheKeySection).toContain('sourceCacheScope')
     expect(source).toContain('getTaskSourceCacheScope(sourceContext)')
-    expect(matchInvalidationSection).toContain(
-      'if (removed) {\n    workItemDetailsCacheGeneration += 1'
-    )
+    expect(source).toContain('useWorkItemDetailsCacheEntry(detailsCacheKey)')
+    expect(source).not.toContain('new Map<string, WorkItemDetailsCacheEntry>')
+    expect(matchInvalidationSection).toContain('cacheGeneration += 1')
   })
 
   it('treats null details as unavailable while preserving empty detail payloads', () => {
@@ -115,6 +116,8 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(resultSection).toContain('} else if (result === null) {')
     expect(resultSection).toContain('error: WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE')
     expect(resultSection).toContain('details: result')
+    expect(resultSection).toContain('getWorkItemDetailsCacheGeneration() !== launchedAtGeneration')
+    expect(resultSection).toContain('prev?.pending !== inflight')
   })
 
   it('routes PR file viewed mutations through the task source context', () => {
@@ -160,6 +163,7 @@ describe('GitHubItemDialog source host boundaries', () => {
 
   it('routes PR file contents and runtime viewed invalidations through the task source context', () => {
     const source = componentSource('GitHubItemDialog.tsx')
+    const cacheSource = componentSource('../lib/github-work-item-details-cache.ts')
     const fileContentsSection = sourceBetween(
       source,
       'function loadPRFileContents',
@@ -170,7 +174,11 @@ describe('GitHubItemDialog source host boundaries', () => {
       'function getPRFileContentCacheKey',
       'function loadPRFileContents'
     )
-    const listenerSection = sourceBetween(source, 'let workItemMutatedUnsub', '// Why: bounded LRU')
+    const listenerSection = sourceBetween(
+      cacheSource,
+      'let workItemMutatedUnsub',
+      "if (typeof import.meta !== 'undefined'"
+    )
 
     expect(fileContentsCacheKeySection).toContain(
       'source:${getTaskSourceCacheScope(args.sourceContext)}'
@@ -182,6 +190,7 @@ describe('GitHubItemDialog source host boundaries', () => {
     expect(fileContentsSection).toContain('sourceContext: args.sourceContext')
     expect(fileContentsSection).toContain('sourceContext,')
     expect(listenerSection).toContain('onGitHubWorkItemDetailsCacheMutation')
+    expect(listenerSection).toContain('invalidateWorkItemDetailsCacheByMatch')
     expect(source).toContain('emitGitHubWorkItemDetailsCacheMutation(args)')
     expect(source).toContain('options.local !== false')
     expect(source).toContain('notifyWorkItemMutated({')

--- a/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.test.ts
@@ -1,35 +1,173 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX,
-  setBoundedScopeCacheEntry
+  createNativeChatScopeCacheController
 } from './native-chat-composer-scope-cache'
 
-describe('setBoundedScopeCacheEntry', () => {
-  it('bounds the cache with LRU eviction, keeping re-set keys', () => {
-    const cache = new Map<string, number>()
-    setBoundedScopeCacheEntry(cache, 'keep', 1)
+function createController(
+  overrides: Partial<Parameters<typeof createNativeChatScopeCacheController>[0]> = {}
+): ReturnType<typeof createNativeChatScopeCacheController> {
+  return createNativeChatScopeCacheController({
+    maxEntriesPerCache: 128,
+    maxAggregateBytes: 100,
+    maxValueBytes: 80,
+    maxKeyBytes: 20,
+    ...overrides
+  })
+}
 
+describe('native-chat scope cache retention', () => {
+  it('retains values and keys exactly at their individual limits', () => {
+    const controller = createController({ maxValueBytes: 4, maxKeyBytes: 4 })
+    const valueCache = new Map<string, string>()
+    const keyCache = new Map<string, string>()
+
+    expect(controller.set(valueCache, 'v', '1234')).toBe(true)
+    expect(controller.set(keyCache, '1234', 'v')).toBe(true)
+    expect(controller.get(valueCache, 'v')).toBe('1234')
+    expect(controller.get(keyCache, '1234')).toBe('v')
+  })
+
+  it('rejects a key or value one byte over its limit', () => {
+    const controller = createController({ maxValueBytes: 4, maxKeyBytes: 4 })
+    const cache = new Map<string, string>()
+
+    expect(controller.set(cache, '12345', 'v')).toBe(false)
+    expect(controller.set(cache, 'v', '12345')).toBe(false)
+    expect(cache.size).toBe(0)
+    expect(controller.getRetainedBytes()).toBe(0)
+  })
+
+  it('measures multibyte scope keys as UTF-8', () => {
+    const controller = createController({ maxKeyBytes: 4 })
+    const cache = new Map<string, string>()
+
+    expect(controller.set(cache, '😀', 'exact')).toBe(true)
+    expect(controller.set(cache, '😀a', 'too large')).toBe(false)
+    expect(cache.has('😀')).toBe(true)
+    expect(cache.has('😀a')).toBe(false)
+  })
+
+  it('retains an entry exactly at the aggregate limit', () => {
+    const controller = createController({
+      maxAggregateBytes: 5,
+      maxValueBytes: 5,
+      maxKeyBytes: 1
+    })
+    const cache = new Map<string, string>()
+
+    expect(controller.set(cache, 'k', '1234')).toBe(true)
+    expect(controller.getRetainedBytes()).toBe(5)
+    expect(controller.get(cache, 'k')).toBe('1234')
+  })
+
+  it('rejects one entry larger than the aggregate limit', () => {
+    const controller = createController({
+      maxAggregateBytes: 5,
+      maxValueBytes: 5,
+      maxKeyBytes: 1
+    })
+    const cache = new Map<string, string>()
+
+    expect(controller.set(cache, 'k', '12345')).toBe(false)
+    expect(cache.size).toBe(0)
+  })
+
+  it('globally evicts the least-recently-used entry across caches', () => {
+    const controller = createController({
+      maxAggregateBytes: 10,
+      maxValueBytes: 4,
+      maxKeyBytes: 1
+    })
+    const first = new Map<string, string>()
+    const second = new Map<string, string>()
+    const third = new Map<string, string>()
+
+    controller.set(first, 'a', '1111')
+    controller.set(second, 'b', '2222')
+    controller.set(third, 'c', '3333')
+
+    expect(first.has('a')).toBe(false)
+    expect(second.get('b')).toBe('2222')
+    expect(third.get('c')).toBe('3333')
+    expect(controller.getRetainedBytes()).toBe(10)
+  })
+
+  it('refreshes global LRU order when an entry is read', () => {
+    const controller = createController({
+      maxAggregateBytes: 10,
+      maxValueBytes: 4,
+      maxKeyBytes: 1
+    })
+    const first = new Map<string, string>()
+    const second = new Map<string, string>()
+    const third = new Map<string, string>()
+
+    controller.set(first, 'a', '1111')
+    controller.set(second, 'b', '2222')
+    expect(controller.get(first, 'a')).toBe('1111')
+    controller.set(third, 'c', '3333')
+
+    expect(first.get('a')).toBe('1111')
+    expect(second.has('b')).toBe(false)
+    expect(third.get('c')).toBe('3333')
+  })
+
+  it('releases retained-byte accounting on delete and clear', () => {
+    const controller = createController()
+    const first = new Map<string, string>()
+    const second = new Map<string, string>()
+
+    controller.set(first, 'a', '111')
+    controller.set(first, 'b', '22')
+    controller.set(second, 'c', '3')
+    expect(controller.getRetainedBytes()).toBe(9)
+
+    controller.delete(first, 'a')
+    expect(controller.getRetainedBytes()).toBe(5)
+    controller.clear(first)
+    expect(controller.getRetainedBytes()).toBe(2)
+    controller.clear(second)
+    expect(controller.getRetainedBytes()).toBe(0)
+  })
+
+  it('removes a stale value when an update is inadmissible', () => {
+    const controller = createController({ maxValueBytes: 4 })
+    const cache = new Map<string, string>()
+
+    controller.set(cache, 'key', 'old')
+    expect(controller.set(cache, 'key', '12345')).toBe(false)
+
+    expect(controller.get(cache, 'key')).toBeUndefined()
+    expect(controller.getRetainedBytes()).toBe(0)
+  })
+
+  it('measures nested values without looping on repeated references', () => {
+    const controller = createController({ maxValueBytes: 64 })
+    const cache = new Map<string, unknown>()
+    const value: { label: string; self?: unknown } = { label: 'cycle' }
+    value.self = value
+
+    expect(controller.set(cache, 'key', value)).toBe(true)
+    expect(controller.get(cache, 'key')).toBe(value)
+  })
+
+  it('preserves the 128-entry per-cache cap', () => {
+    const controller = createNativeChatScopeCacheController()
+    const cache = new Map<string, number>()
+
+    controller.set(cache, 'keep', 1)
     const total = NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX + 20
-    for (let i = 0; i < total; i += 1) {
-      setBoundedScopeCacheEntry(cache, `scope-${i}`, i)
-      if (i % 10 === 0) {
-        setBoundedScopeCacheEntry(cache, 'keep', 1)
+    for (let index = 0; index < total; index += 1) {
+      controller.set(cache, `scope-${index}`, index)
+      if (index % 10 === 0) {
+        controller.set(cache, 'keep', 1)
       }
     }
 
     expect(cache.size).toBe(NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX)
-    expect(cache.has('scope-0')).toBe(false) // oldest untouched entry evicted
-    expect(cache.has('keep')).toBe(true) // periodically re-set → retained
-    expect(cache.has(`scope-${total - 1}`)).toBe(true) // most recent retained
-  })
-
-  it('moves a re-set key to most-recent and updates its value', () => {
-    const cache = new Map<string, number>()
-    setBoundedScopeCacheEntry(cache, 'a', 1)
-    setBoundedScopeCacheEntry(cache, 'b', 2)
-    setBoundedScopeCacheEntry(cache, 'a', 3)
-
-    expect([...cache.keys()]).toEqual(['b', 'a'])
-    expect(cache.get('a')).toBe(3)
+    expect(cache.has('scope-0')).toBe(false)
+    expect(cache.has('keep')).toBe(true)
+    expect(cache.has(`scope-${total - 1}`)).toBe(true)
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-scope-cache.ts
@@ -1,24 +1,322 @@
-// Shared LRU bound for the native-chat composer's per-scope caches (draft text
-// and image attachments), both keyed by stable pane identity. The
-// caches exist so an in-progress message survives the composer unmounting on a
-// TUI/GUI toggle, but a scope key for a permanently-removed pane is never
-// revisited, so without a bound its unsent entry would linger for the renderer's
-// whole session. delete-then-set keeps the actively-edited scope most-recent so
-// eviction only sheds the oldest untouched scopes.
+import { measureUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
+
 export const NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX = 128
+export const NATIVE_CHAT_SCOPE_CACHE_MAX_AGGREGATE_BYTES = 32 * 1024 * 1024
+export const NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES = 16 * 1024 * 1024
+export const NATIVE_CHAT_SCOPE_CACHE_MAX_KEY_BYTES = 4 * 1024
+
+const CONTAINER_BYTES = 8
+const CONTAINER_ENTRY_BYTES = 8
+
+export type NativeChatScopeCacheLimits = {
+  maxEntriesPerCache: number
+  maxAggregateBytes: number
+  maxValueBytes: number
+  maxKeyBytes: number
+}
+
+export type NativeChatScopeCacheController = {
+  set<T>(cache: Map<string, T>, scopeKey: string, value: T): boolean
+  get<T>(cache: Map<string, T>, scopeKey: string): T | undefined
+  delete<T>(cache: Map<string, T>, scopeKey: string): boolean
+  clear<T>(cache: Map<string, T>): void
+  getRetainedBytes(): number
+}
+
+type RetainedEntry = {
+  cacheIdentity: object
+  scopeKey: string
+  retainedBytes: number
+  deleteCachedValue: () => void
+}
+
+type MeasurementFrame =
+  | { kind: 'value'; value: unknown }
+  | { kind: 'array'; value: readonly unknown[]; index: number }
+  | {
+      kind: 'record'
+      value: Record<string, unknown>
+      keys: Generator<string, void, unknown>
+    }
+
+const DEFAULT_LIMITS: NativeChatScopeCacheLimits = {
+  maxEntriesPerCache: NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX,
+  maxAggregateBytes: NATIVE_CHAT_SCOPE_CACHE_MAX_AGGREGATE_BYTES,
+  maxValueBytes: NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES,
+  maxKeyBytes: NATIVE_CHAT_SCOPE_CACHE_MAX_KEY_BYTES
+}
+
+function addMeasuredBytes(
+  currentBytes: number,
+  additionalBytes: number,
+  maxBytes: number
+): { bytes: number; exceeded: boolean } {
+  const bytes = currentBytes + additionalBytes
+  return { bytes, exceeded: bytes > maxBytes }
+}
+
+function measureRetainedString(
+  value: string,
+  currentBytes: number,
+  maxBytes: number
+): { bytes: number; exceeded: boolean } {
+  const remaining = Math.max(0, maxBytes - currentBytes)
+  const measured = measureUtf8ByteLength(value, { stopAfterBytes: remaining })
+  const next = addMeasuredBytes(currentBytes, measured.byteLength, maxBytes)
+  return { bytes: next.bytes, exceeded: measured.exceededLimit || next.exceeded }
+}
+
+function isPlainRecord(value: object): value is Record<string, unknown> {
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function* iterateOwnEnumerableKeys(value: Record<string, unknown>): Generator<string> {
+  for (const key in value) {
+    if (Object.hasOwn(value, key)) {
+      yield key
+    }
+  }
+}
+
+function measureRetainedValue(value: unknown, maxBytes: number): number | null {
+  const seen = new WeakSet<object>()
+  const frames: MeasurementFrame[] = [{ kind: 'value', value }]
+  let bytes = 0
+
+  while (frames.length > 0) {
+    const frame = frames.pop()
+    if (!frame) {
+      break
+    }
+    if (frame.kind === 'array') {
+      if (frame.index >= frame.value.length) {
+        continue
+      }
+      const index = frame.index
+      frame.index += 1
+      frames.push(frame)
+      if (Object.hasOwn(frame.value, index)) {
+        frames.push({ kind: 'value', value: frame.value[index] })
+      }
+      continue
+    }
+    if (frame.kind === 'record') {
+      const nextKey = frame.keys.next()
+      if (nextKey.done) {
+        continue
+      }
+      const entry = addMeasuredBytes(bytes, CONTAINER_ENTRY_BYTES, maxBytes)
+      if (entry.exceeded) {
+        return null
+      }
+      const keyMeasurement = measureRetainedString(nextKey.value, entry.bytes, maxBytes)
+      if (keyMeasurement.exceeded) {
+        return null
+      }
+      bytes = keyMeasurement.bytes
+      frames.push(frame)
+      frames.push({ kind: 'value', value: frame.value[nextKey.value] })
+      continue
+    }
+
+    const current = frame.value
+    if (current === null || current === undefined) {
+      continue
+    }
+    if (typeof current === 'string') {
+      const measured = measureRetainedString(current, bytes, maxBytes)
+      if (measured.exceeded) {
+        return null
+      }
+      bytes = measured.bytes
+      continue
+    }
+    if (typeof current === 'number') {
+      const measured = addMeasuredBytes(bytes, 8, maxBytes)
+      if (measured.exceeded) {
+        return null
+      }
+      bytes = measured.bytes
+      continue
+    }
+    if (typeof current === 'boolean') {
+      const measured = addMeasuredBytes(bytes, 1, maxBytes)
+      if (measured.exceeded) {
+        return null
+      }
+      bytes = measured.bytes
+      continue
+    }
+    if (typeof current !== 'object' || seen.has(current)) {
+      if (typeof current !== 'object') {
+        return null
+      }
+      continue
+    }
+
+    seen.add(current)
+    const container = addMeasuredBytes(bytes, CONTAINER_BYTES, maxBytes)
+    if (container.exceeded) {
+      return null
+    }
+    bytes = container.bytes
+    if (Array.isArray(current)) {
+      const entries = addMeasuredBytes(bytes, current.length * CONTAINER_ENTRY_BYTES, maxBytes)
+      if (entries.exceeded) {
+        return null
+      }
+      bytes = entries.bytes
+      frames.push({ kind: 'array', value: current, index: 0 })
+      continue
+    }
+    if (!isPlainRecord(current)) {
+      return null
+    }
+    frames.push({ kind: 'record', value: current, keys: iterateOwnEnumerableKeys(current) })
+  }
+
+  return bytes
+}
+
+export function createNativeChatScopeCacheController(
+  limitOverrides: Partial<NativeChatScopeCacheLimits> = {}
+): NativeChatScopeCacheController {
+  const limits = { ...DEFAULT_LIMITS, ...limitOverrides }
+  const entriesByCache = new Map<object, Map<string, RetainedEntry>>()
+  const globalLru = new Map<RetainedEntry, true>()
+  let retainedBytes = 0
+
+  const removeEntry = (entry: RetainedEntry, deleteCachedValue: boolean): void => {
+    const cacheEntries = entriesByCache.get(entry.cacheIdentity)
+    cacheEntries?.delete(entry.scopeKey)
+    if (cacheEntries?.size === 0) {
+      entriesByCache.delete(entry.cacheIdentity)
+    }
+    if (globalLru.delete(entry)) {
+      retainedBytes -= entry.retainedBytes
+    }
+    if (deleteCachedValue) {
+      entry.deleteCachedValue()
+    }
+  }
+
+  const evictOldest = (entries: Map<RetainedEntry, true>): void => {
+    const oldest = entries.keys().next().value
+    if (oldest) {
+      removeEntry(oldest, true)
+    }
+  }
+
+  const controller: NativeChatScopeCacheController = {
+    set: <T>(cache: Map<string, T>, scopeKey: string, value: T): boolean => {
+      controller.delete(cache, scopeKey)
+      const keyMeasurement = measureUtf8ByteLength(scopeKey, {
+        stopAfterBytes: limits.maxKeyBytes
+      })
+      if (keyMeasurement.exceededLimit) {
+        return false
+      }
+      const valueBytes = measureRetainedValue(value, limits.maxValueBytes)
+      if (valueBytes === null) {
+        return false
+      }
+      const entryBytes = keyMeasurement.byteLength + valueBytes
+      if (entryBytes > limits.maxAggregateBytes) {
+        return false
+      }
+
+      cache.set(scopeKey, value)
+      const cacheIdentity = cache as object
+      const cacheEntries = entriesByCache.get(cacheIdentity) ?? new Map()
+      entriesByCache.set(cacheIdentity, cacheEntries)
+      const entry: RetainedEntry = {
+        cacheIdentity,
+        scopeKey,
+        retainedBytes: entryBytes,
+        deleteCachedValue: () => {
+          cache.delete(scopeKey)
+        }
+      }
+      cacheEntries.set(scopeKey, entry)
+      globalLru.set(entry, true)
+      retainedBytes += entryBytes
+
+      while (cacheEntries.size > limits.maxEntriesPerCache) {
+        const oldest = cacheEntries.values().next().value
+        if (!oldest) {
+          break
+        }
+        removeEntry(oldest, true)
+      }
+      while (retainedBytes > limits.maxAggregateBytes) {
+        evictOldest(globalLru)
+      }
+      return cacheEntries.get(scopeKey) === entry
+    },
+    get: <T>(cache: Map<string, T>, scopeKey: string): T | undefined => {
+      const cacheEntries = entriesByCache.get(cache as object)
+      const entry = cacheEntries?.get(scopeKey)
+      if (!entry) {
+        return cache.get(scopeKey)
+      }
+      if (!cache.has(scopeKey)) {
+        removeEntry(entry, false)
+        return undefined
+      }
+      const value = cache.get(scopeKey)
+      cache.delete(scopeKey)
+      cache.set(scopeKey, value as T)
+      cacheEntries?.delete(scopeKey)
+      cacheEntries?.set(scopeKey, entry)
+      globalLru.delete(entry)
+      globalLru.set(entry, true)
+      return value
+    },
+    delete: <T>(cache: Map<string, T>, scopeKey: string): boolean => {
+      const entry = entriesByCache.get(cache as object)?.get(scopeKey)
+      if (!entry) {
+        return cache.delete(scopeKey)
+      }
+      const hadValue = cache.has(scopeKey)
+      removeEntry(entry, true)
+      return hadValue
+    },
+    clear: <T>(cache: Map<string, T>): void => {
+      const cacheEntries = entriesByCache.get(cache as object)
+      if (cacheEntries) {
+        for (const entry of cacheEntries.values()) {
+          removeEntry(entry, false)
+        }
+      }
+      cache.clear()
+    },
+    getRetainedBytes: () => retainedBytes
+  }
+  return controller
+}
+
+const sharedController = createNativeChatScopeCacheController()
 
 export function setBoundedScopeCacheEntry<T>(
   cache: Map<string, T>,
   scopeKey: string,
   value: T
-): void {
-  cache.delete(scopeKey)
-  cache.set(scopeKey, value)
-  while (cache.size > NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX) {
-    const oldest = cache.keys().next().value
-    if (oldest === undefined) {
-      break
-    }
-    cache.delete(oldest)
-  }
+): boolean {
+  return sharedController.set(cache, scopeKey, value)
+}
+
+export function getBoundedScopeCacheEntry<T>(
+  cache: Map<string, T>,
+  scopeKey: string
+): T | undefined {
+  return sharedController.get(cache, scopeKey)
+}
+
+export function deleteBoundedScopeCacheEntry<T>(cache: Map<string, T>, scopeKey: string): boolean {
+  return sharedController.delete(cache, scopeKey)
+}
+
+export function clearBoundedScopeCache<T>(cache: Map<string, T>): void {
+  sharedController.clear(cache)
 }

--- a/src/renderer/src/components/native-chat/native-chat-draft-cache.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-draft-cache.test.ts
@@ -4,7 +4,11 @@ import {
   readNativeChatDraftCache,
   writeNativeChatDraftCache
 } from './native-chat-draft-cache'
-import { NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX } from './native-chat-composer-scope-cache'
+import {
+  NATIVE_CHAT_COMPOSER_SCOPE_CACHE_MAX,
+  NATIVE_CHAT_SCOPE_CACHE_MAX_KEY_BYTES,
+  NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES
+} from './native-chat-composer-scope-cache'
 
 afterEach(() => {
   clearNativeChatDraftCacheForTests()
@@ -26,6 +30,28 @@ describe('native-chat draft cache', () => {
     writeNativeChatDraftCache('pty-1', 'hello')
     writeNativeChatDraftCache('pty-1', '')
     expect(readNativeChatDraftCache('pty-1')).toBe('')
+  })
+
+  it('retains a draft exactly at the production value limit', () => {
+    const draft = 'x'.repeat(NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES)
+
+    writeNativeChatDraftCache('pty-1', draft)
+
+    expect(readNativeChatDraftCache('pty-1')).toBe(draft)
+  })
+
+  it('does not retain a draft one byte over the production value limit', () => {
+    writeNativeChatDraftCache('pty-1', 'x'.repeat(NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES + 1))
+
+    expect(readNativeChatDraftCache('pty-1')).toBe('')
+  })
+
+  it('does not retain a draft under an oversized multibyte scope key', () => {
+    const scopeKey = '😀'.repeat(NATIVE_CHAT_SCOPE_CACHE_MAX_KEY_BYTES / 4 + 1)
+
+    writeNativeChatDraftCache(scopeKey, 'still available to the mounted composer')
+
+    expect(readNativeChatDraftCache(scopeKey)).toBe('')
   })
 
   it('bounds the cache so unsent drafts for removed panes cannot accumulate', () => {

--- a/src/renderer/src/components/native-chat/native-chat-draft-cache.ts
+++ b/src/renderer/src/components/native-chat/native-chat-draft-cache.ts
@@ -4,19 +4,24 @@
 // draft would be lost on every TUI/GUI round-trip. Mirrors the attachment cache
 // so both halves of an unsent message survive toggles and reconnects.
 
-import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+import {
+  clearBoundedScopeCache,
+  deleteBoundedScopeCacheEntry,
+  getBoundedScopeCacheEntry,
+  setBoundedScopeCacheEntry
+} from './native-chat-composer-scope-cache'
 
 const draftCache = new Map<string, string>()
 
 export function readNativeChatDraftCache(scopeKey: string): string {
-  return draftCache.get(scopeKey) ?? ''
+  return getBoundedScopeCacheEntry(draftCache, scopeKey) ?? ''
 }
 
 export function writeNativeChatDraftCache(scopeKey: string, draft: string): void {
   // An empty draft carries no state worth retaining; drop the entry so a stale
   // scope key never resurrects cleared text.
   if (draft === '') {
-    draftCache.delete(scopeKey)
+    deleteBoundedScopeCacheEntry(draftCache, scopeKey)
     return
   }
   // LRU-bounded so unsent drafts for permanently-removed panes can't accumulate.
@@ -24,5 +29,5 @@ export function writeNativeChatDraftCache(scopeKey: string, draft: string): void
 }
 
 export function clearNativeChatDraftCacheForTests(): void {
-  draftCache.clear()
+  clearBoundedScopeCache(draftCache)
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -21,6 +21,7 @@ import {
   type NativeChatPendingSend
 } from './native-chat-pending'
 import { stripNoiseMessages } from './native-chat-noise'
+import { NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES } from './native-chat-composer-scope-cache'
 
 function userMessage(id: string, text: string): NativeChatMessage {
   return {
@@ -417,6 +418,36 @@ describe('pending send cache', () => {
 
     expect(readPendingSendCache(scope)).toEqual([])
   })
+
+  it('returns an oversized pending send for the mounted view without retaining it', () => {
+    clearPendingSendCacheForTests()
+    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex' }
+    const entry = pendingOf('p1', 'x'.repeat(NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES))
+
+    const current = writePendingSendCache(scope, [entry])
+
+    expect(current).toEqual([entry])
+    expect(readPendingSendCache(scope)).toEqual([])
+  })
+
+  it('still caps an admissible pending-send list to the latest eight', () => {
+    clearPendingSendCacheForTests()
+    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex' }
+    const pending = Array.from({ length: 10 }, (_, index) =>
+      pendingOf(`p${index}`, `prompt ${index}`)
+    )
+
+    expect(writePendingSendCache(scope, pending).map(({ id }) => id)).toEqual([
+      'p2',
+      'p3',
+      'p4',
+      'p5',
+      'p6',
+      'p7',
+      'p8',
+      'p9'
+    ])
+  })
 })
 
 describe('isPendingMessageId', () => {
@@ -487,6 +518,17 @@ describe('command marker cache', () => {
       '/cmd-8',
       '/cmd-9'
     ])
+  })
+
+  it('returns an oversized marker for the mounted view without retaining it', () => {
+    clearCommandMarkerCacheForTests()
+    const scope = { paneKey: 'tab-a:leaf-a', agent: 'codex', sessionId: 'session-1' }
+    const command = 'x'.repeat(NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES)
+
+    const current = appendCommandMarkerCache(scope, command, 10)
+
+    expect(current).toEqual([{ id: '10-1', command, sentAt: 10 }])
+    expect(readCommandMarkerCache(scope)).toEqual([])
   })
 })
 

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -4,7 +4,12 @@
 // rule (match on normalized user-message content) is unit-testable without React.
 
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
-import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+import {
+  clearBoundedScopeCache,
+  deleteBoundedScopeCacheEntry,
+  getBoundedScopeCacheEntry,
+  setBoundedScopeCacheEntry
+} from './native-chat-composer-scope-cache'
 import type { NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
 import {
   advancedNativeChatUserContentCounts,
@@ -54,7 +59,7 @@ function pendingSendScopeKey(scope: NativeChatPendingSendScope): string {
 }
 
 export function readPendingSendCache(scope: NativeChatPendingSendScope): NativeChatPendingSend[] {
-  return [...(pendingSendCache.get(pendingSendScopeKey(scope)) ?? [])]
+  return [...(getBoundedScopeCacheEntry(pendingSendCache, pendingSendScopeKey(scope)) ?? [])]
 }
 
 export function writePendingSendCache(
@@ -64,7 +69,7 @@ export function writePendingSendCache(
   const next = pending.slice(-PENDING_SEND_LIMIT)
   const key = pendingSendScopeKey(scope)
   if (next.length === 0) {
-    pendingSendCache.delete(key)
+    deleteBoundedScopeCacheEntry(pendingSendCache, key)
   } else {
     // Why: the empty-drain path above clears keys on the normal confirm flow,
     // but a pane closed with an unconfirmed send (agent crash / early close)
@@ -84,7 +89,7 @@ export function appendPendingSendCache(
 }
 
 export function clearPendingSendCacheForTests(): void {
-  pendingSendCache.clear()
+  clearBoundedScopeCache(pendingSendCache)
   pendingSendCounter = 0
 }
 
@@ -304,7 +309,7 @@ function commandMarkerScopeKey(scope: NativeChatCommandMarkerScope): string {
 export function readCommandMarkerCache(
   scope: NativeChatCommandMarkerScope
 ): NativeChatCommandMarker[] {
-  return [...(commandMarkerCache.get(commandMarkerScopeKey(scope)) ?? [])]
+  return [...(getBoundedScopeCacheEntry(commandMarkerCache, commandMarkerScopeKey(scope)) ?? [])]
 }
 
 export function appendCommandMarkerCache(
@@ -317,7 +322,7 @@ export function appendCommandMarkerCache(
   // Why: native/TUI view switches remount the chat surface, but slash commands
   // are not transcript turns, so their local feedback needs a pane-scoped cache.
   const next = [
-    ...(commandMarkerCache.get(key) ?? []),
+    ...(getBoundedScopeCacheEntry(commandMarkerCache, key) ?? []),
     { id: `${sentAt}-${commandMarkerCounter}`, command, sentAt }
   ].slice(-COMMAND_MARKER_LIMIT)
   // Why: the per-key array is capped at 8, but the KEY (paneKey\0agent\0sessionId,
@@ -329,7 +334,7 @@ export function appendCommandMarkerCache(
 }
 
 export function clearCommandMarkerCacheForTests(): void {
-  commandMarkerCache.clear()
+  clearBoundedScopeCache(commandMarkerCache)
   commandMarkerCounter = 0
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -5,6 +5,7 @@ import {
   seedNativeChatAppliedSessionOptions
 } from './native-chat-session-option-cache'
 import { createNativeChatPtySessionOptions } from './native-chat-pty-session-options'
+import { NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES } from './native-chat-composer-scope-cache'
 
 describe('native chat PTY session options', () => {
   beforeEach(() => clearNativeChatSessionOptionCacheForTests())
@@ -46,6 +47,28 @@ describe('native chat PTY session options', () => {
         })
       ])
     )
+  })
+
+  it('keeps oversized reported options live without retaining them for remount', () => {
+    const model = 'x'.repeat(NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES)
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      reportedValues: { model },
+      dispatchCommand: vi.fn()
+    })!
+
+    expect(surface.getSnapshot()[0]?.kind).toMatchObject({ currentValue: model })
+    expect(readNativeChatSessionOptionCache('pty-1')).toBeNull()
+
+    const remounted = createNativeChatPtySessionOptions({
+      agent: 'claude',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn()
+    })!
+    expect(remounted.getSnapshot()[0]?.kind).not.toHaveProperty('currentValue')
   })
 
   it('restores launch-backed values through the tab-to-PTY cache handoff', () => {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-cache.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-cache.ts
@@ -3,7 +3,11 @@ import type {
   SessionOptionValue,
   SessionOptionValueSource
 } from '../../../../shared/native-chat-session-options'
-import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+import {
+  clearBoundedScopeCache,
+  getBoundedScopeCacheEntry,
+  setBoundedScopeCacheEntry
+} from './native-chat-composer-scope-cache'
 
 export type TrackedNativeChatSessionOption = {
   value: SessionOptionValue
@@ -43,7 +47,9 @@ export function readNativeChatSessionOptionCache(
   scopeKey: string,
   fallbackScopeKey?: string
 ): NativeChatSessionOptionRecord | null {
-  const record = sessionOptionCache.get(scopeKey) ?? sessionOptionCache.get(fallbackScopeKey ?? '')
+  const record =
+    getBoundedScopeCacheEntry(sessionOptionCache, scopeKey) ??
+    getBoundedScopeCacheEntry(sessionOptionCache, fallbackScopeKey ?? '')
   return record ? cloneNativeChatSessionOptionRecord(record) : null
 }
 
@@ -80,5 +86,5 @@ export function seedNativeChatAppliedSessionOptions(
 }
 
 export function clearNativeChatSessionOptionCacheForTests(): void {
-  sessionOptionCache.clear()
+  clearBoundedScopeCache(sessionOptionCache)
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -3,12 +3,20 @@ import type { CatalogModel } from '../../../../shared/agent-session-option-catal
 import {
   clearNativeChatModelEnrichmentForTests,
   ensureNativeChatModelEnrichment,
+  NATIVE_CHAT_MODEL_ENRICHMENT_CACHE_MAX,
+  NATIVE_CHAT_MODEL_ENRICHMENT_PENDING_MAX,
   readNativeChatEnrichedModels,
   subscribeNativeChatEnrichedModels
 } from './native-chat-session-option-enrichment'
 
 describe('native chat session option enrichment', () => {
   beforeEach(() => clearNativeChatModelEnrichmentForTests())
+
+  async function flushMicrotasks(): Promise<void> {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve()
+    }
+  }
 
   it('keeps reads synchronous while one host-scoped probe is in flight', async () => {
     let resolveDiscovery: ((models: CatalogModel[]) => void) | undefined
@@ -57,5 +65,62 @@ describe('native chat session option enrichment', () => {
     const discover = vi.fn()
     ensureNativeChatModelEnrichment({ agent: 'claude', hostKey: 'local', discover })
     expect(discover).not.toHaveBeenCalled()
+  })
+
+  it('evicts old host model arrays instead of retaining every host for the renderer lifetime', async () => {
+    for (let index = 0; index <= NATIVE_CHAT_MODEL_ENRICHMENT_CACHE_MAX; index += 1) {
+      ensureNativeChatModelEnrichment({
+        agent: 'cursor',
+        hostKey: `ssh:${index}`,
+        discover: async () => [{ id: `host-model-${index}`, label: `Host ${index}`, options: [] }]
+      })
+      await flushMicrotasks()
+    }
+
+    expect(readNativeChatEnrichedModels('cursor', 'ssh:0')).toBeNull()
+    expect(
+      readNativeChatEnrichedModels('cursor', `ssh:${NATIVE_CHAT_MODEL_ENRICHMENT_CACHE_MAX}`)
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: `host-model-${NATIVE_CHAT_MODEL_ENRICHMENT_CACHE_MAX}` })
+      ])
+    )
+  })
+
+  it('bounds hung host discovery promises without building a hidden probe queue', async () => {
+    const resolvers: ((models: CatalogModel[]) => void)[] = []
+    const discovers = Array.from({ length: NATIVE_CHAT_MODEL_ENRICHMENT_PENDING_MAX + 1 }, () =>
+      vi.fn(
+        () =>
+          new Promise<CatalogModel[]>((resolve) => {
+            resolvers.push(resolve)
+          })
+      )
+    )
+
+    for (const [index, discover] of discovers.entries()) {
+      ensureNativeChatModelEnrichment({ agent: 'cursor', hostKey: `hung:${index}`, discover })
+    }
+    await flushMicrotasks()
+    expect(
+      discovers
+        .slice(0, NATIVE_CHAT_MODEL_ENRICHMENT_PENDING_MAX)
+        .every((probe) => probe.mock.calls.length === 1)
+    ).toBe(true)
+    expect(discovers.at(-1)).not.toHaveBeenCalled()
+
+    resolvers[0]?.([{ id: 'released', label: 'Released', options: [] }])
+    await flushMicrotasks()
+    ensureNativeChatModelEnrichment({
+      agent: 'cursor',
+      hostKey: `hung:${NATIVE_CHAT_MODEL_ENRICHMENT_PENDING_MAX}`,
+      discover: discovers.at(-1)!
+    })
+    await flushMicrotasks()
+    expect(discovers.at(-1)).toHaveBeenCalledOnce()
+    for (const resolve of resolvers) {
+      resolve([])
+    }
+    await flushMicrotasks()
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -12,6 +12,27 @@ type CatalogEnrichmentEntry = {
 }
 
 const enrichmentByAgentHost = new Map<string, CatalogEnrichmentEntry>()
+export const NATIVE_CHAT_MODEL_ENRICHMENT_CACHE_MAX = 128
+export const NATIVE_CHAT_MODEL_ENRICHMENT_PENDING_MAX = 8
+let pendingEnrichmentCount = 0
+
+function rememberEnrichment(key: string, entry: CatalogEnrichmentEntry): void {
+  enrichmentByAgentHost.delete(key)
+  enrichmentByAgentHost.set(key, entry)
+  let inactiveEntries = Array.from(enrichmentByAgentHost.values()).filter(
+    (candidate) => candidate.state === 'settled' && candidate.listeners.size === 0
+  ).length
+  while (inactiveEntries > NATIVE_CHAT_MODEL_ENRICHMENT_CACHE_MAX) {
+    const oldestInactive = Array.from(enrichmentByAgentHost).find(
+      ([, candidate]) => candidate.state === 'settled' && candidate.listeners.size === 0
+    )
+    if (!oldestInactive) {
+      break
+    }
+    enrichmentByAgentHost.delete(oldestInactive[0])
+    inactiveEntries -= 1
+  }
+}
 
 function enrichmentKey(agent: AgentType, hostKey: string): string {
   return JSON.stringify([agent, hostKey])
@@ -21,7 +42,12 @@ export function readNativeChatEnrichedModels(
   agent: AgentType,
   hostKey: string
 ): CatalogModel[] | null {
-  const models = enrichmentByAgentHost.get(enrichmentKey(agent, hostKey))?.models
+  const key = enrichmentKey(agent, hostKey)
+  const entry = enrichmentByAgentHost.get(key)
+  if (entry) {
+    rememberEnrichment(key, entry)
+  }
+  const models = entry?.models
   return models ? [...models] : null
 }
 
@@ -37,8 +63,15 @@ export function subscribeNativeChatEnrichedModels(
     listeners: new Set<(models: CatalogModel[]) => void>()
   }
   entry.listeners.add(listener)
-  enrichmentByAgentHost.set(key, entry)
-  return () => entry.listeners.delete(listener)
+  rememberEnrichment(key, entry)
+  return () => {
+    entry.listeners.delete(listener)
+    if (entry.state === 'idle' && enrichmentByAgentHost.get(key) === entry) {
+      enrichmentByAgentHost.delete(key)
+    } else if (enrichmentByAgentHost.get(key) === entry) {
+      rememberEnrichment(key, entry)
+    }
+  }
 }
 
 export function ensureNativeChatModelEnrichment(args: {
@@ -53,6 +86,10 @@ export function ensureNativeChatModelEnrichment(args: {
   const key = enrichmentKey(args.agent, args.hostKey)
   const existing = enrichmentByAgentHost.get(key)
   if (existing?.state === 'pending' || existing?.state === 'settled') {
+    rememberEnrichment(key, existing)
+    return
+  }
+  if (pendingEnrichmentCount >= NATIVE_CHAT_MODEL_ENRICHMENT_PENDING_MAX) {
     return
   }
   const entry: CatalogEnrichmentEntry = existing ?? {
@@ -61,12 +98,23 @@ export function ensureNativeChatModelEnrichment(args: {
     listeners: new Set()
   }
   entry.state = 'pending'
-  enrichmentByAgentHost.set(key, entry)
+  pendingEnrichmentCount += 1
+  rememberEnrichment(key, entry)
 
   // Why: model discovery must never delay rendering or launching; the seed is
   // immediately usable while this once-per-host probe runs in the background.
-  void args
-    .discover()
+  let discovery: Promise<readonly CatalogModel[] | null>
+  try {
+    discovery = args.discover()
+  } catch {
+    entry.state = 'settled'
+    if (enrichmentByAgentHost.get(key) === entry) {
+      rememberEnrichment(key, entry)
+    }
+    pendingEnrichmentCount = Math.max(0, pendingEnrichmentCount - 1)
+    return
+  }
+  void discovery
     .then((discovered) => {
       entry.state = 'settled'
       if (!discovered || discovered.length === 0) {
@@ -80,8 +128,15 @@ export function ensureNativeChatModelEnrichment(args: {
     .catch(() => {
       entry.state = 'settled'
     })
+    .finally(() => {
+      if (enrichmentByAgentHost.get(key) === entry) {
+        rememberEnrichment(key, entry)
+      }
+      pendingEnrichmentCount = Math.max(0, pendingEnrichmentCount - 1)
+    })
 }
 
 export function clearNativeChatModelEnrichmentForTests(): void {
   enrichmentByAgentHost.clear()
+  pendingEnrichmentCount = 0
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.test.tsx
@@ -9,6 +9,7 @@ import {
   useNativeChatComposerAttachments
 } from './use-native-chat-composer-attachments'
 import type { NativeChatResolvedTarget } from './native-chat-composer-target'
+import { NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES } from './native-chat-composer-scope-cache'
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
@@ -110,6 +111,23 @@ describe('useNativeChatComposerAttachments', () => {
     expect(second.latest().imageAttachments).toMatchObject([
       { path: '/tmp/orca-native-chat-attach-test.png' }
     ])
+    act(() => second.root.unmount())
+  })
+
+  it('keeps an oversized attachment in the mounted view without retaining it', async () => {
+    const first = await renderProbe('pty-1')
+    const path = `${'x'.repeat(NATIVE_CHAT_SCOPE_CACHE_MAX_VALUE_BYTES)}.png`
+
+    await act(async () => {
+      first.latest().attachResolvedPaths([path])
+    })
+
+    expect(first.latest().imageAttachments).toMatchObject([{ path }])
+    expect(readNativeChatAttachmentCache('pty-1')).toEqual([])
+
+    act(() => first.root.unmount())
+    const second = await renderProbe('pty-1')
+    expect(second.latest().imageAttachments).toEqual([])
     act(() => second.root.unmount())
   })
 

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-attachments.ts
@@ -7,7 +7,12 @@ import {
   type NativeChatResolvedTarget
 } from './native-chat-composer-target'
 import type { NativeChatComposerImageAttachment } from './NativeChatComposerField'
-import { setBoundedScopeCacheEntry } from './native-chat-composer-scope-cache'
+import {
+  clearBoundedScopeCache,
+  deleteBoundedScopeCacheEntry,
+  getBoundedScopeCacheEntry,
+  setBoundedScopeCacheEntry
+} from './native-chat-composer-scope-cache'
 
 export type UseNativeChatComposerAttachmentsArgs = {
   attachmentScopeKey: string
@@ -146,7 +151,7 @@ const attachmentCache = new Map<string, NativeChatComposerImageAttachment[]>()
 export function readNativeChatAttachmentCache(
   scopeKey: string
 ): NativeChatComposerImageAttachment[] {
-  return [...(attachmentCache.get(scopeKey) ?? [])]
+  return [...(getBoundedScopeCacheEntry(attachmentCache, scopeKey) ?? [])]
 }
 
 function writeNativeChatAttachmentCache(
@@ -154,7 +159,7 @@ function writeNativeChatAttachmentCache(
   attachments: readonly NativeChatComposerImageAttachment[]
 ): void {
   if (attachments.length === 0) {
-    attachmentCache.delete(scopeKey)
+    deleteBoundedScopeCacheEntry(attachmentCache, scopeKey)
     return
   }
   // LRU-bounded so pending attachments for permanently-removed panes can't accumulate.
@@ -162,5 +167,5 @@ function writeNativeChatAttachmentCache(
 }
 
 export function clearNativeChatAttachmentCacheForTests(): void {
-  attachmentCache.clear()
+  clearBoundedScopeCache(attachmentCache)
 }

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -83,6 +83,7 @@ import {
 } from '../../../../shared/task-source-context'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
 import { githubRepoIdentityKey } from '../../../../shared/github-repository-identity-key'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
 import {
   getGitHubRuntimeRepoId,
@@ -127,6 +128,7 @@ export type SmartWorkspaceNameSelection = {
 
 const SEARCH_DEBOUNCE_MS = 200
 const RESULT_LIMIT = 12
+export const PROJECT_GROUP_LOOKUP_CONCURRENCY = 4
 
 export function canUseGitLabSmartSource({
   localGitlabAvailable,
@@ -670,8 +672,10 @@ export default function SmartWorkspaceNameField({
               type: directLink.type
             }
           : { kind: 'hash-number' as const, number: directNumber }
-      const request = Promise.all(
-        repoBackedSearchTargets.map((target) =>
+      const request = mapWithConcurrency(
+        repoBackedSearchTargets,
+        PROJECT_GROUP_LOOKUP_CONCURRENCY,
+        (target) =>
           lookupSmartGitHubSubmitItem({
             repoPath: target.repo.path,
             repoId: target.repo.id,
@@ -680,7 +684,6 @@ export default function SmartWorkspaceNameField({
             workItem: lookupGitHubWorkItemForSource,
             workItemByOwnerRepo: lookupGitHubWorkItemByOwnerRepoForSource
           }).catch(() => null)
-        )
       ).then((items) =>
         items
           .filter((item): item is GitHubWorkItem => item !== null)
@@ -924,19 +927,17 @@ export default function SmartWorkspaceNameField({
     }
     let stale = false
     setGitlabLoading(true)
-    void Promise.all(
-      repoBackedSearchTargets.map((target) =>
-        lookupGitLabWorkItemByPathForSource({
-          repoPath: target.repo.path,
-          repoId: target.repo.id,
-          sourceContext: target.gitlabSourceContext,
-          // Why: self-hosted GitLab URLs must resolve against their pasted hostname, not gitlab.com.
-          host: parsedGlLink.slug.host,
-          path: parsedGlLink.slug.path,
-          iid: parsedGlLink.number,
-          type: parsedGlLink.type
-        }).catch(() => null)
-      )
+    void mapWithConcurrency(repoBackedSearchTargets, PROJECT_GROUP_LOOKUP_CONCURRENCY, (target) =>
+      lookupGitLabWorkItemByPathForSource({
+        repoPath: target.repo.path,
+        repoId: target.repo.id,
+        sourceContext: target.gitlabSourceContext,
+        // Why: self-hosted GitLab URLs must resolve against their pasted hostname, not gitlab.com.
+        host: parsedGlLink.slug.host,
+        path: parsedGlLink.slug.path,
+        iid: parsedGlLink.number,
+        type: parsedGlLink.type
+      }).catch(() => null)
     )
       .then((items) => {
         if (stale) {
@@ -981,18 +982,16 @@ export default function SmartWorkspaceNameField({
     setGitlabLoading(true)
     // Why: thread the typed query so the GitLab API filters MRs by name/number (shouldQueryGitlab already gates oversized queries).
     const trimmedQuery = debouncedQuery.trim() || undefined
-    void Promise.all(
-      repoBackedSearchTargets.map((target) =>
-        listGitLabMRsForSource({
-          repoPath: target.repo.path,
-          repoId: target.repo.id,
-          sourceContext: target.gitlabSourceContext,
-          state: mrStateFilter,
-          page: 1,
-          perPage: RESULT_LIMIT,
-          query: trimmedQuery
-        }).catch(() => ({ items: [], hasMore: false }))
-      )
+    void mapWithConcurrency(repoBackedSearchTargets, PROJECT_GROUP_LOOKUP_CONCURRENCY, (target) =>
+      listGitLabMRsForSource({
+        repoPath: target.repo.path,
+        repoId: target.repo.id,
+        sourceContext: target.gitlabSourceContext,
+        state: mrStateFilter,
+        page: 1,
+        perPage: RESULT_LIMIT,
+        query: trimmedQuery
+      }).catch(() => ({ items: [], hasMore: false }))
     )
       .then((results) => {
         if (stale) {

--- a/src/renderer/src/components/pet/custom-pet-bundle-processing.ts
+++ b/src/renderer/src/components/pet/custom-pet-bundle-processing.ts
@@ -1,0 +1,129 @@
+import { isCustomPetSheetSizeSafe } from '../../../../shared/custom-pet-media-limits'
+import { detectFramesFromImageData } from './sprite-frame-detection'
+import type { DetectedSpriteCacheEntry } from './custom-pet-media-types'
+
+export type ProcessedCustomPetBundle =
+  | { kind: 'rejected' }
+  | {
+      kind: 'processed'
+      url: string
+      detected: DetectedSpriteCacheEntry | null
+      retainedBytes: number
+    }
+
+function closeDetectedSprite(entry: DetectedSpriteCacheEntry | null): void {
+  for (const bitmap of entry?.bitmaps ?? []) {
+    bitmap.close()
+  }
+}
+
+function estimateDetectedSpriteBytes(entry: DetectedSpriteCacheEntry | null): number {
+  if (!entry) {
+    return 0
+  }
+  return entry.frames.reduce((bytes, frame) => bytes + frame.w * frame.h * 4, 0)
+}
+
+export async function processCustomPetBundleSheet(
+  srcUrl: string,
+  spriteFps?: number,
+  skipDetection?: boolean
+): Promise<ProcessedCustomPetBundle | null> {
+  let detected: DetectedSpriteCacheEntry | null = null
+  try {
+    const img = await loadImage(srcUrl)
+    if (!isCustomPetSheetSizeSafe(img.naturalWidth, img.naturalHeight)) {
+      return { kind: 'rejected' }
+    }
+    const canvas = document.createElement('canvas')
+    canvas.width = img.naturalWidth
+    canvas.height = img.naturalHeight
+    const ctx = canvas.getContext('2d')
+    if (!ctx) {
+      return null
+    }
+    ctx.drawImage(img, 0, 0)
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    keyMagenta(data.data)
+    ctx.putImageData(data, 0, 0)
+    // Why: detection needs keyed transparent gutters; manifest-backed sheets
+    // skip bitmap crops because CSS reads the declared grid directly.
+    const sprite = skipDetection ? null : detectFramesFromImageData(data)
+    if (sprite && sprite.frames.length >= 1) {
+      const results = await Promise.allSettled(
+        sprite.frames.map((frame) => createImageBitmap(canvas, frame.x, frame.y, frame.w, frame.h))
+      )
+      const rejected = results.some((result) => result.status === 'rejected')
+      if (rejected) {
+        // Why: a partial crop failure still permits the keyed static sheet,
+        // but every successful orphan bitmap must be closed first.
+        for (const result of results) {
+          if (result.status === 'fulfilled') {
+            result.value.close()
+          }
+        }
+      } else {
+        const bitmaps = results.map(
+          (result) => (result as PromiseFulfilledResult<ImageBitmap>).value
+        )
+        detected = { frames: sprite.frames, bitmaps, fps: spriteFps ?? 8 }
+      }
+    }
+    const output = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, 'image/png'))
+    if (!output) {
+      closeDetectedSprite(detected)
+      return null
+    }
+    try {
+      return {
+        kind: 'processed',
+        url: URL.createObjectURL(output),
+        detected,
+        retainedBytes: output.size + estimateDetectedSpriteBytes(detected)
+      }
+    } catch {
+      closeDetectedSprite(detected)
+      return null
+    }
+  } catch {
+    closeDetectedSprite(detected)
+    return null
+  }
+}
+
+// Why: compressed magenta keys leave gradient halos, so clear strongly
+// magenta pixels and proportionally fade the antialiased edge family.
+function magentaScore(red: number, green: number, blue: number): number {
+  const minimumRedBlue = Math.min(red, blue)
+  if (green >= minimumRedBlue) {
+    return 0
+  }
+  const dominance = (minimumRedBlue - green) / 255
+  return dominance <= 0.4 ? 0 : Math.max(0, Math.min(1, dominance * 1.4))
+}
+
+function keyMagenta(pixels: Uint8ClampedArray): void {
+  for (let index = 0; index < pixels.length; index += 4) {
+    const score = magentaScore(pixels[index], pixels[index + 1], pixels[index + 2])
+    if (score <= 0) {
+      continue
+    }
+    if (score >= 0.5) {
+      pixels[index] = 0
+      pixels[index + 1] = 0
+      pixels[index + 2] = 0
+      pixels[index + 3] = 0
+      continue
+    }
+    pixels[index + 3] = Math.round(pixels[index + 3] * Math.max(0, 1 - score * 2))
+  }
+}
+
+function loadImage(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('image load failed'))
+    image.src = url
+  })
+}

--- a/src/renderer/src/components/pet/custom-pet-load-queue.test.ts
+++ b/src/renderer/src/components/pet/custom-pet-load-queue.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  CustomPetLoadQueue,
+  MAX_CONCURRENT_CUSTOM_PET_LOADS,
+  MAX_PENDING_CUSTOM_PET_LOADS
+} from './custom-pet-load-queue'
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+describe('CustomPetLoadQueue', () => {
+  it('bounds active and retained pending loads', async () => {
+    const queue = new CustomPetLoadQueue()
+    const loads = Array.from({ length: MAX_PENDING_CUSTOM_PET_LOADS }, deferred)
+    const pending = loads.map((load) => queue.run(() => load.promise))
+
+    expect(queue.inspect()).toEqual({
+      active: MAX_CONCURRENT_CUSTOM_PET_LOADS,
+      pending: MAX_PENDING_CUSTOM_PET_LOADS
+    })
+    await expect(queue.run(() => Promise.resolve())).rejects.toThrow('Too many pending')
+
+    loads.forEach((load) => load.resolve())
+    await Promise.all(pending)
+    expect(queue.inspect()).toEqual({ active: 0, pending: 0 })
+  })
+})

--- a/src/renderer/src/components/pet/custom-pet-load-queue.ts
+++ b/src/renderer/src/components/pet/custom-pet-load-queue.ts
@@ -1,0 +1,53 @@
+type QueuedCustomPetLoad = {
+  run: () => Promise<unknown>
+  resolve: (value: unknown) => void
+  reject: (error: unknown) => void
+}
+
+export const MAX_CONCURRENT_CUSTOM_PET_LOADS = 2
+export const MAX_PENDING_CUSTOM_PET_LOADS = 16
+
+export class CustomPetLoadQueue {
+  private active = 0
+  private pending = 0
+  private readonly queue: QueuedCustomPetLoad[] = []
+
+  run<T>(task: () => Promise<T>): Promise<T> {
+    if (this.pending >= MAX_PENDING_CUSTOM_PET_LOADS) {
+      return Promise.reject(
+        new Error(`Too many pending custom pet loads (max ${MAX_PENDING_CUSTOM_PET_LOADS}).`)
+      )
+    }
+    this.pending += 1
+    const promise = new Promise<unknown>((resolve, reject) => {
+      this.queue.push({ run: task, resolve, reject })
+      this.pump()
+    })
+    return promise as Promise<T>
+  }
+
+  inspect(): { active: number; pending: number } {
+    return { active: this.active, pending: this.pending }
+  }
+
+  private pump(): void {
+    while (this.active < MAX_CONCURRENT_CUSTOM_PET_LOADS) {
+      const next = this.queue.shift()
+      if (!next) {
+        return
+      }
+      this.active += 1
+      let load: Promise<unknown>
+      try {
+        load = next.run()
+      } catch (error) {
+        load = Promise.reject(error)
+      }
+      void load.then(next.resolve, next.reject).finally(() => {
+        this.active -= 1
+        this.pending -= 1
+        this.pump()
+      })
+    }
+  }
+}

--- a/src/renderer/src/components/pet/custom-pet-media-types.ts
+++ b/src/renderer/src/components/pet/custom-pet-media-types.ts
@@ -1,0 +1,9 @@
+import type { DetectedFrame } from './sprite-frame-detection'
+
+export type DetectedSpriteCacheEntry = {
+  frames: DetectedFrame[]
+  /** Per-frame image bitmaps drawn from the keyed canvas. */
+  bitmaps: ImageBitmap[]
+  /** Manifest playback speed; the overlay defaults to 8 fps when absent. */
+  fps: number
+}

--- a/src/renderer/src/components/pet/pet-blob-cache.test.ts
+++ b/src/renderer/src/components/pet/pet-blob-cache.test.ts
@@ -2,11 +2,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   blobUrlCache,
   CUSTOM_PET_BLOB_CACHE_MAX,
+  CUSTOM_PET_MEDIA_CACHE_MAX_BYTES,
   detectedSpriteCache,
+  inspectCustomPetMediaCache,
   loadCustomBlobUrl,
   retainCustomPetBlobCacheEntry,
   revokeCustomPetBlobUrl
 } from './pet-blob-cache'
+import { MAX_CUSTOM_PET_SHEET_PIXELS } from '../../../../shared/custom-pet-media-limits'
 
 const TEST_PET_IDS = ['pet', 'late-pet', 'bundle-pet']
 
@@ -43,7 +46,7 @@ describe('loadCustomBlobUrl', () => {
     expect(blobUrlCache.get('pet')).toBe('blob:pet')
   })
 
-  it('revokes a blob URL created after the custom pet was removed', async () => {
+  it('does not create a blob URL after the custom pet was removed', async () => {
     let resolveRead: (buffer: ArrayBuffer) => void = () => {}
     const read = vi.fn(
       () =>
@@ -53,14 +56,14 @@ describe('loadCustomBlobUrl', () => {
     )
     stubPetRead(read)
     vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:late-pet')
-    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
 
     const load = loadCustomBlobUrl('late-pet', 'pet.png', 'image/png')
     revokeCustomPetBlobUrl('late-pet')
     resolveRead(new Uint8Array([4, 5, 6]).buffer)
 
     await expect(load).resolves.toBeNull()
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:late-pet')
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
     expect(blobUrlCache.has('late-pet')).toBe(false)
   })
 
@@ -108,6 +111,50 @@ describe('loadCustomBlobUrl', () => {
     expect(detectedSpriteCache.has('bundle-pet')).toBe(false)
   })
 
+  it('counts retained detected bitmaps alongside the processed blob', async () => {
+    stubPetRead(vi.fn().mockResolvedValue(new Uint8Array([7, 8, 9]).buffer))
+    vi.spyOn(URL, 'createObjectURL')
+      .mockReturnValueOnce('blob:bundle-input')
+      .mockReturnValueOnce('blob:bundle-output')
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    const bitmap = { close: vi.fn() } as unknown as ImageBitmap
+    vi.stubGlobal('createImageBitmap', vi.fn().mockResolvedValue(bitmap))
+    vi.stubGlobal(
+      'Image',
+      class {
+        naturalWidth = 8
+        naturalHeight = 8
+        onload: (() => void) | null = null
+        set src(_value: string) {
+          queueMicrotask(() => this.onload?.())
+        }
+      }
+    )
+    const pixels = new Uint8ClampedArray(8 * 8 * 4)
+    for (let index = 3; index < pixels.length; index += 4) {
+      pixels[index] = 255
+    }
+    const output = new Blob([new Uint8Array(10)])
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({
+        drawImage: vi.fn(),
+        getImageData: vi.fn(() => ({ data: pixels, width: 8, height: 8 }) as ImageData),
+        putImageData: vi.fn()
+      })),
+      toBlob: vi.fn((callback: BlobCallback) => callback(output))
+    } as unknown as HTMLCanvasElement
+    vi.stubGlobal('document', { createElement: vi.fn(() => canvas) })
+
+    await expect(
+      loadCustomBlobUrl('bundle-counted', 'sheet.png', 'image/png', 'bundle')
+    ).resolves.toBe('blob:bundle-output')
+
+    expect(inspectCustomPetMediaCache().retainedBytes).toBe(output.size + 8 * 8 * 4)
+    expect(detectedSpriteCache.get('bundle-counted')?.bitmaps).toEqual([bitmap])
+  })
+
   it('evicts least-recent custom pet blobs and closes detected sprite bitmaps', async () => {
     const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
     stubPetRead(read)
@@ -139,6 +186,54 @@ describe('loadCustomBlobUrl', () => {
     expect(evictedBitmap.close).toHaveBeenCalledTimes(1)
   })
 
+  it('evicts by aggregate encoded bytes before the entry-count cap', async () => {
+    const entryBytes = Math.floor(CUSTOM_PET_MEDIA_CACHE_MAX_BYTES / 2) + 1
+    class SizedBlob {
+      size = entryBytes
+    }
+    vi.stubGlobal('Blob', SizedBlob)
+    stubPetRead(vi.fn().mockResolvedValue(new Uint8Array([1]).buffer))
+    vi.spyOn(URL, 'createObjectURL')
+      .mockReturnValueOnce('blob:large-0')
+      .mockReturnValueOnce('blob:large-1')
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    await expect(loadCustomBlobUrl('large-0', 'pet.png', 'image/png')).resolves.toBe('blob:large-0')
+    await expect(loadCustomBlobUrl('large-1', 'pet.png', 'image/png')).resolves.toBe('blob:large-1')
+
+    expect(blobUrlCache.has('large-0')).toBe(false)
+    expect(blobUrlCache.get('large-1')).toBe('blob:large-1')
+    expect(inspectCustomPetMediaCache().retainedBytes).toBe(entryBytes)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:large-0')
+  })
+
+  it('rejects an extreme bundle before allocating a canvas', async () => {
+    stubPetRead(vi.fn().mockResolvedValue(new Uint8Array([1]).buffer))
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:oversized-sheet')
+    const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+    vi.stubGlobal(
+      'Image',
+      class {
+        naturalWidth = 2_048
+        naturalHeight = Math.floor(MAX_CUSTOM_PET_SHEET_PIXELS / this.naturalWidth) + 1
+        onload: (() => void) | null = null
+        set src(_value: string) {
+          queueMicrotask(() => this.onload?.())
+        }
+      }
+    )
+    const createElement = vi.fn()
+    vi.stubGlobal('document', { createElement })
+
+    await expect(
+      loadCustomBlobUrl('oversized-sheet', 'sheet.png', 'image/png', 'bundle')
+    ).resolves.toBeNull()
+
+    expect(createElement).not.toHaveBeenCalled()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:oversized-sheet')
+    expect(blobUrlCache.has('oversized-sheet')).toBe(false)
+  })
+
   it('does not let stale load completions evict retained active media', async () => {
     const resolvers = new Map<string, (buffer: ArrayBuffer) => void>()
     const read = vi.fn(
@@ -152,19 +247,30 @@ describe('loadCustomBlobUrl', () => {
     vi.spyOn(URL, 'createObjectURL').mockImplementation(() => `blob:pet-${blobIndex++}`)
     const revokeObjectURL = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
     const releaseActive = retainCustomPetBlobCacheEntry('pet-16')
-    const loads = Array.from({ length: 17 }, (_, index) =>
+    const activeLoad = loadCustomBlobUrl('pet-16', 'pet.png', 'image/png')
+    const staleLoads = Array.from({ length: 15 }, (_, index) =>
       loadCustomBlobUrl(`pet-${index}`, 'pet.png', 'image/png')
     )
+    const resolveLoad = async (
+      id: string,
+      load: Promise<string | null>,
+      value: number
+    ): Promise<string | null> => {
+      while (!resolvers.has(id)) {
+        await Promise.resolve()
+      }
+      resolvers.get(id)!(new Uint8Array([value]).buffer)
+      resolvers.delete(id)
+      return load
+    }
 
     try {
-      resolvers.get('pet-16')!(new Uint8Array([16]).buffer)
-      const activeUrl = await loads[16]
+      const activeUrl = await resolveLoad('pet-16', activeLoad, 16)
       const activeBitmap = { close: vi.fn() } as unknown as ImageBitmap
       detectedSpriteCache.set('pet-16', { bitmaps: [activeBitmap], fps: 8, frames: [] })
 
-      for (let index = 0; index < 16; index += 1) {
-        resolvers.get(`pet-${index}`)!(new Uint8Array([index]).buffer)
-        await loads[index]
+      for (let index = 0; index < staleLoads.length; index += 1) {
+        await resolveLoad(`pet-${index}`, staleLoads[index], index)
       }
 
       expect(blobUrlCache.get('pet-16')).toBe(activeUrl)
@@ -172,10 +278,13 @@ describe('loadCustomBlobUrl', () => {
       expect(activeBitmap.close).not.toHaveBeenCalled()
       expect(blobUrlCache.size).toBe(CUSTOM_PET_BLOB_CACHE_MAX)
 
+      const overflowLoad = loadCustomBlobUrl('pet-17', 'pet.png', 'image/png')
+      await resolveLoad('pet-17', overflowLoad, 17)
+      expect(blobUrlCache.get('pet-16')).toBe(activeUrl)
+
       releaseActive()
-      const nextLoad = loadCustomBlobUrl('pet-17', 'pet.png', 'image/png')
-      resolvers.get('pet-17')!(new Uint8Array([17]).buffer)
-      await nextLoad
+      const nextLoad = loadCustomBlobUrl('pet-18', 'pet.png', 'image/png')
+      await resolveLoad('pet-18', nextLoad, 18)
 
       expect(blobUrlCache.has('pet-16')).toBe(false)
       expect(revokeObjectURL).toHaveBeenCalledWith(activeUrl)
@@ -185,7 +294,7 @@ describe('loadCustomBlobUrl', () => {
     }
   })
 
-  it('shrinks a temporarily retained overflow when a consumer releases', async () => {
+  it('rejects a retained overflow instead of exceeding the hard cache cap', async () => {
     const read = vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer)
     stubPetRead(read)
     let blobIndex = 0
@@ -196,14 +305,18 @@ describe('loadCustomBlobUrl', () => {
     )
 
     try {
-      for (let index = 0; index < 17; index += 1) {
+      for (let index = 0; index < CUSTOM_PET_BLOB_CACHE_MAX; index += 1) {
         await loadCustomBlobUrl(`retained-${index}`, 'pet.png', 'image/png')
       }
-      expect(blobUrlCache.size).toBe(17)
+      await expect(
+        loadCustomBlobUrl(`retained-${CUSTOM_PET_BLOB_CACHE_MAX}`, 'pet.png', 'image/png')
+      ).resolves.toBeNull()
+      expect(blobUrlCache.size).toBe(CUSTOM_PET_BLOB_CACHE_MAX)
 
       releases[0]()
-
-      expect(blobUrlCache.size).toBe(CUSTOM_PET_BLOB_CACHE_MAX)
+      await expect(
+        loadCustomBlobUrl(`retained-${CUSTOM_PET_BLOB_CACHE_MAX}`, 'pet.png', 'image/png')
+      ).resolves.toBe(`blob:retained-${CUSTOM_PET_BLOB_CACHE_MAX + 1}`)
       expect(blobUrlCache.has('retained-0')).toBe(false)
       expect(revokeObjectURL).toHaveBeenCalledWith('blob:retained-0')
     } finally {

--- a/src/renderer/src/components/pet/pet-blob-cache.ts
+++ b/src/renderer/src/components/pet/pet-blob-cache.ts
@@ -2,7 +2,16 @@
 // without importing usePetUrl (which itself imports the store). Keeps
 // the dependency graph acyclic.
 
-import { detectFramesFromImageData, type DetectedFrame } from './sprite-frame-detection'
+import {
+  CustomPetLoadQueue,
+  MAX_CONCURRENT_CUSTOM_PET_LOADS,
+  MAX_PENDING_CUSTOM_PET_LOADS
+} from './custom-pet-load-queue'
+import { processCustomPetBundleSheet } from './custom-pet-bundle-processing'
+import type { DetectedSpriteCacheEntry } from './custom-pet-media-types'
+
+export { MAX_CONCURRENT_CUSTOM_PET_LOADS, MAX_PENDING_CUSTOM_PET_LOADS }
+export type { DetectedSpriteCacheEntry } from './custom-pet-media-types'
 
 // Why: sandbox=true + webSecurity=true block the renderer from reading user
 // files directly. For custom pet images we fetch the bytes over IPC and
@@ -11,22 +20,31 @@ import { detectFramesFromImageData, type DetectedFrame } from './sprite-frame-de
 // doesn't re-fetch from main.
 export const blobUrlCache = new Map<string, string>()
 export const CUSTOM_PET_BLOB_CACHE_MAX = 16
+export const CUSTOM_PET_MEDIA_CACHE_MAX_BYTES = 128 * 1024 * 1024
 
-export type DetectedSpriteCacheEntry = {
-  frames: DetectedFrame[]
-  /** Per-frame image bitmaps drawn from the keyed canvas. The overlay paints
-   *  these onto its own canvas one at a time, so we can crop irregular sheets
-   *  without forcing the manifest to declare a uniform grid. */
-  bitmaps: ImageBitmap[]
-  /** Manifest-declared playback speed; the overlay falls back to 8 fps when
-   *  the bundle didn't declare one. */
-  fps: number
-}
 export const detectedSpriteCache = new Map<string, DetectedSpriteCacheEntry>()
 const customPetBlobUrlLoads = new Map<string, Promise<string | null>>()
 const customPetBlobCacheEpoch = new Map<string, number>()
 const customPetBlobActiveLoadCounts = new Map<string, number>()
 const customPetBlobRetainCounts = new Map<string, number>()
+const customPetMediaBytes = new Map<string, number>()
+const customPetLoadQueue = new CustomPetLoadQueue()
+let retainedCustomPetMediaBytes = 0
+
+export function inspectCustomPetMediaCache(): {
+  activeLoads: number
+  cachedEntries: number
+  pendingLoads: number
+  retainedBytes: number
+} {
+  const loads = customPetLoadQueue.inspect()
+  return {
+    activeLoads: loads.active,
+    cachedEntries: blobUrlCache.size,
+    pendingLoads: loads.pending,
+    retainedBytes: retainedCustomPetMediaBytes
+  }
+}
 
 export function retainCustomPetBlobCacheEntry(id: string): () => void {
   customPetBlobRetainCounts.set(id, (customPetBlobRetainCounts.get(id) ?? 0) + 1)
@@ -76,22 +94,32 @@ export async function loadCustomBlobUrl(
   if (pending) {
     return pending
   }
+  // Why: reject before allocating tracking Maps/promises for overflow IDs;
+  // the queue's own guard remains the race-proof backstop.
+  if (customPetLoadQueue.inspect().pending >= MAX_PENDING_CUSTOM_PET_LOADS) {
+    return null
+  }
   const loadEpoch = customPetBlobCacheEpoch.get(id) ?? 0
   incrementCustomPetBlobActiveLoadCount(id)
-  const load = loadCustomBlobUrlUncached(
-    id,
-    fileName,
-    mimeType,
-    kind,
-    spriteFps,
-    hasManifestSprite,
-    loadEpoch
-  ).finally(() => {
-    if (customPetBlobUrlLoads.get(id) === load) {
-      customPetBlobUrlLoads.delete(id)
-    }
-    decrementCustomPetBlobActiveLoadCount(id)
-  })
+  const load = customPetLoadQueue
+    .run(() =>
+      loadCustomBlobUrlUncached(
+        id,
+        fileName,
+        mimeType,
+        kind,
+        spriteFps,
+        hasManifestSprite,
+        loadEpoch
+      )
+    )
+    .catch(() => null)
+    .finally(() => {
+      if (customPetBlobUrlLoads.get(id) === load) {
+        customPetBlobUrlLoads.delete(id)
+      }
+      decrementCustomPetBlobActiveLoadCount(id)
+    })
   customPetBlobUrlLoads.set(id, load)
   return load
 }
@@ -119,11 +147,14 @@ async function loadCustomBlobUrlUncached(
   hasManifestSprite: boolean | undefined,
   loadEpoch: number
 ): Promise<string | null> {
+  if ((customPetBlobCacheEpoch.get(id) ?? 0) !== loadEpoch) {
+    return null
+  }
   // Why: defensively clear any stale entry so we don't leak a prior blob URL
   // or ImageBitmap[] when re-populating after a cache miss.
   clearCustomPetBlobCacheEntry(id)
   const buffer = await window.api.pet.read(id, fileName, kind)
-  if (!buffer) {
+  if (!buffer || (customPetBlobCacheEpoch.get(id) ?? 0) !== loadEpoch) {
     return null
   }
   // Why: MIME comes from CustomPet.mimeType — required especially for
@@ -132,6 +163,7 @@ async function loadCustomBlobUrlUncached(
   const blob = new Blob([buffer], { type: mimeType })
   let url = URL.createObjectURL(blob)
   let detected: DetectedSpriteCacheEntry | null = null
+  let retainedBytes = blob.size
   // Why: pet bundles often ship spritesheets with a magenta chroma-key as
   // the background instead of true alpha (common in pixel-art tooling).
   // Strip it once at load and replace the cached URL with a transparent PNG
@@ -141,13 +173,16 @@ async function loadCustomBlobUrlUncached(
     // renderer reads the `sprite` branch of usePetUrl and never touches
     // detectedSpriteCache — so skipping detection (and the per-frame
     // ImageBitmap allocations) avoids a per-bundle memory leak.
-    const processed = await processBundleSheet(url, spriteFps, hasManifestSprite === true)
-    if (processed) {
+    const processed = await processCustomPetBundleSheet(url, spriteFps, hasManifestSprite === true)
+    if (processed?.kind === 'rejected') {
+      URL.revokeObjectURL(url)
+      return null
+    }
+    if (processed?.kind === 'processed') {
       URL.revokeObjectURL(url)
       url = processed.url
-      if (processed.detected) {
-        detected = processed.detected
-      }
+      detected = processed.detected
+      retainedBytes = processed.retainedBytes
     }
   }
   if ((customPetBlobCacheEpoch.get(id) ?? 0) !== loadEpoch) {
@@ -155,27 +190,47 @@ async function loadCustomBlobUrlUncached(
     closeDetectedSpriteCacheEntry(detected)
     return null
   }
-  cacheCustomPetBlobUrl(id, url, detected)
+  if (!cacheCustomPetBlobUrl(id, url, detected, retainedBytes)) {
+    URL.revokeObjectURL(url)
+    closeDetectedSpriteCacheEntry(detected)
+    return null
+  }
   return url
 }
 
 function cacheCustomPetBlobUrl(
   id: string,
   url: string,
-  detected: DetectedSpriteCacheEntry | null
-): void {
+  detected: DetectedSpriteCacheEntry | null,
+  retainedBytes: number
+): boolean {
   clearCustomPetBlobCacheEntry(id)
+  if (!Number.isSafeInteger(retainedBytes) || retainedBytes < 0) {
+    return false
+  }
+  evictInactiveCustomPetBlobUrls(retainedBytes, 1)
+  if (
+    blobUrlCache.size >= CUSTOM_PET_BLOB_CACHE_MAX ||
+    retainedCustomPetMediaBytes + retainedBytes > CUSTOM_PET_MEDIA_CACHE_MAX_BYTES
+  ) {
+    return false
+  }
   blobUrlCache.set(id, url)
+  customPetMediaBytes.set(id, retainedBytes)
+  retainedCustomPetMediaBytes += retainedBytes
   if (detected) {
     detectedSpriteCache.set(id, detected)
   }
-  evictInactiveCustomPetBlobUrls()
+  return true
 }
 
-function evictInactiveCustomPetBlobUrls(): void {
+function evictInactiveCustomPetBlobUrls(incomingBytes = 0, incomingEntries = 0): void {
   // Why: users can import many custom pets; inactive blob URLs and sprite
   // bitmaps should not stay resident for the whole renderer session.
-  while (blobUrlCache.size > CUSTOM_PET_BLOB_CACHE_MAX) {
+  while (
+    blobUrlCache.size + incomingEntries > CUSTOM_PET_BLOB_CACHE_MAX ||
+    retainedCustomPetMediaBytes + incomingBytes > CUSTOM_PET_MEDIA_CACHE_MAX_BYTES
+  ) {
     let evicted = false
     for (const id of blobUrlCache.keys()) {
       if (customPetBlobRetainCounts.has(id)) {
@@ -191,117 +246,6 @@ function evictInactiveCustomPetBlobUrls(): void {
   }
 }
 
-async function processBundleSheet(
-  srcUrl: string,
-  spriteFps?: number,
-  skipDetection?: boolean
-): Promise<{ url: string; detected: DetectedSpriteCacheEntry | null } | null> {
-  let detected: DetectedSpriteCacheEntry | null = null
-  try {
-    const img = await loadImage(srcUrl)
-    const canvas = document.createElement('canvas')
-    canvas.width = img.naturalWidth
-    canvas.height = img.naturalHeight
-    const ctx = canvas.getContext('2d')
-    if (!ctx) {
-      return null
-    }
-    ctx.drawImage(img, 0, 0)
-    const data = ctx.getImageData(0, 0, canvas.width, canvas.height)
-    keyMagenta(data.data)
-    ctx.putImageData(data, 0, 0)
-    // Why: detect frames *after* keying so transparent gutters between
-    // sprites are visible to the band/column scanner. Without this the whole
-    // sheet collapses into one giant frame.
-    const sprite = skipDetection ? null : detectFramesFromImageData(data)
-    if (sprite && sprite.frames.length >= 1) {
-      // Why: allSettled so a single failed crop doesn't leak the bitmaps that
-      // did succeed — close fulfilled ones before bailing out.
-      const results = await Promise.allSettled(
-        sprite.frames.map((f) => createImageBitmap(canvas, f.x, f.y, f.w, f.h))
-      )
-      const rejected = results.some((r) => r.status === 'rejected')
-      if (rejected) {
-        // Why: don't discard the keyed canvas when only the per-frame crops
-        // failed — fall through to emit the keyed PNG so the caller still gets
-        // the chroma-keyed sheet instead of falling back to the un-keyed url.
-        for (const r of results) {
-          if (r.status === 'fulfilled') {
-            r.value.close()
-          }
-        }
-      } else {
-        const bitmaps = results.map((r) => (r as PromiseFulfilledResult<ImageBitmap>).value)
-        detected = { frames: sprite.frames, bitmaps, fps: spriteFps ?? 8 }
-      }
-    }
-    const out = await new Promise<Blob | null>((res) => canvas.toBlob(res, 'image/png'))
-    if (!out) {
-      closeDetectedSpriteCacheEntry(detected)
-      return null
-    }
-    try {
-      return { url: URL.createObjectURL(out), detected }
-    } catch {
-      closeDetectedSpriteCacheEntry(detected)
-      return null
-    }
-  } catch {
-    closeDetectedSpriteCacheEntry(detected)
-    return null
-  }
-}
-
-// Why: WebP/JPEG-compressed magenta keys leave wide gradient halos around
-// each sprite, so a tight RGB-distance check leaves ugly fringing. We use a
-// hue-style test instead: the magenta family has R and B much greater than
-// G. Anything matching gets fully cleared; anything close gets proportional
-// alpha so antialiased edges fade smoothly.
-function magentaScore(r: number, g: number, b: number): number {
-  // 0 = not magenta, 1 = pure magenta key. Restricted to near-pure magenta
-  // (saturated R+B, very low G) so legitimate purples and pinks (e.g.
-  // 128,0,128 or 255,128,200) aren't keyed out of imported sprite art.
-  const minRB = Math.min(r, b)
-  if (g >= minRB) {
-    return 0
-  }
-  const dom = (minRB - g) / 255 // how much R and B dominate green
-  // Why: require a strong R+B dominance over G so purples/pinks (e.g.
-  // 128,0,128 or 255,128,200) aren't keyed, while still letting antialiased
-  // edge pixels (e.g. 255,128,255 → dom≈0.5) fade with proportional alpha.
-  if (dom <= 0.4) {
-    return 0
-  }
-  return Math.max(0, Math.min(1, dom * 1.4))
-}
-
-function keyMagenta(px: Uint8ClampedArray): void {
-  for (let i = 0; i < px.length; i += 4) {
-    const score = magentaScore(px[i], px[i + 1], px[i + 2])
-    if (score <= 0) {
-      continue
-    }
-    if (score >= 0.5) {
-      px[i + 3] = 0
-      px[i] = 0
-      px[i + 1] = 0
-      px[i + 2] = 0
-    } else {
-      const keep = 1 - score * 2
-      px[i + 3] = Math.round(px[i + 3] * Math.max(0, keep))
-    }
-  }
-}
-
-function loadImage(url: string): Promise<HTMLImageElement> {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
-    img.onload = () => resolve(img)
-    img.onerror = () => reject(new Error('image load failed'))
-    img.src = url
-  })
-}
-
 // Why: the store invokes this on removeCustomPet so the underlying Blob
 // is released; otherwise the blob: URL keeps it alive for the rest of the
 // session, wasting memory per imported image.
@@ -315,6 +259,9 @@ export function revokeCustomPetBlobUrl(id: string): void {
 }
 
 function clearCustomPetBlobCacheEntry(id: string): void {
+  const retainedBytes = customPetMediaBytes.get(id) ?? 0
+  customPetMediaBytes.delete(id)
+  retainedCustomPetMediaBytes = Math.max(0, retainedCustomPetMediaBytes - retainedBytes)
   const url = blobUrlCache.get(id)
   if (url) {
     URL.revokeObjectURL(url)

--- a/src/renderer/src/components/pet/sprite-frame-detection.test.ts
+++ b/src/renderer/src/components/pet/sprite-frame-detection.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { MAX_CUSTOM_PET_DETECTED_FRAMES } from '../../../../shared/custom-pet-media-limits'
+import { detectFramesFromImageData } from './sprite-frame-detection'
+
+function stripedImage(frameCount: number): ImageData {
+  const frameWidth = 8
+  const width = frameCount * (frameWidth + 1)
+  const height = 8
+  const data = new Uint8ClampedArray(width * height * 4)
+  for (let frame = 0; frame < frameCount; frame += 1) {
+    const startX = frame * (frameWidth + 1)
+    for (let y = 0; y < height; y += 1) {
+      for (let x = startX; x < startX + frameWidth; x += 1) {
+        data[(y * width + x) * 4 + 3] = 255
+      }
+    }
+  }
+  return { data, width, height } as ImageData
+}
+
+describe('detectFramesFromImageData', () => {
+  it('keeps ordinary auto-detected sprite animations unchanged', () => {
+    expect(detectFramesFromImageData(stripedImage(3))?.frames).toHaveLength(3)
+  })
+
+  it('falls back to a static sheet above the bitmap fan-out cap', () => {
+    expect(detectFramesFromImageData(stripedImage(MAX_CUSTOM_PET_DETECTED_FRAMES + 1))).toBeNull()
+  })
+})

--- a/src/renderer/src/components/pet/sprite-frame-detection.ts
+++ b/src/renderer/src/components/pet/sprite-frame-detection.ts
@@ -5,6 +5,8 @@
 // split on empty columns to get one frame per sprite. The result drives the
 // canvas-based animation in the overlay.
 
+import { MAX_CUSTOM_PET_DETECTED_FRAMES } from '../../../../shared/custom-pet-media-limits'
+
 export type DetectedFrame = { x: number; y: number; w: number; h: number }
 export type DetectedSprite = { frames: DetectedFrame[] }
 
@@ -52,7 +54,7 @@ function framesInBand(
   data: Uint8ClampedArray,
   width: number,
   band: { y0: number; y1: number }
-): DetectedFrame[] {
+): DetectedFrame[] | null {
   const colEmpty = new Uint8Array(width)
   for (let x = 0; x < width; x++) {
     let empty = 1
@@ -70,14 +72,23 @@ function framesInBand(
     if (!colEmpty[x] && start < 0) {
       start = x
     } else if (colEmpty[x] && start >= 0) {
-      frames.push({ x: start, y: band.y0, w: x - start, h: band.y1 - band.y0 + 1 })
+      const frame = { x: start, y: band.y0, w: x - start, h: band.y1 - band.y0 + 1 }
+      if (frame.w >= MIN_DIM && frame.h >= MIN_DIM) {
+        frames.push(frame)
+        if (frames.length > MAX_CUSTOM_PET_DETECTED_FRAMES) {
+          return null
+        }
+      }
       start = -1
     }
   }
   if (start >= 0) {
-    frames.push({ x: start, y: band.y0, w: width - start, h: band.y1 - band.y0 + 1 })
+    const frame = { x: start, y: band.y0, w: width - start, h: band.y1 - band.y0 + 1 }
+    if (frame.w >= MIN_DIM && frame.h >= MIN_DIM) {
+      frames.push(frame)
+    }
   }
-  return frames.filter((f) => f.w >= MIN_DIM && f.h >= MIN_DIM)
+  return frames.length <= MAX_CUSTOM_PET_DETECTED_FRAMES ? frames : null
 }
 
 export function detectFramesFromImageData(image: ImageData): DetectedSprite | null {
@@ -93,6 +104,9 @@ export function detectFramesFromImageData(image: ImageData): DetectedSprite | nu
   let best: DetectedFrame[] = []
   for (const band of bands) {
     const candidate = framesInBand(data, width, band)
+    if (!candidate) {
+      return null
+    }
     if (candidate.length > best.length) {
       best = candidate
     }

--- a/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
@@ -12,11 +12,16 @@ import {
 import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 import {
   clearRuntimeCompatibilityCache,
-  markRuntimeEnvironmentCompatible
+  markRuntimeEnvironmentCompatible,
+  type RuntimeClientTarget
 } from '@/runtime/runtime-rpc-client'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 import { useAppStore } from '@/store'
-import { WorkspacePortScanner } from './WorkspacePortScanner'
+import {
+  scanWorkspacePortTargets,
+  WorkspacePortScanner,
+  WORKSPACE_PORT_SCAN_CONCURRENCY
+} from './WorkspacePortScanner'
 
 const localScan = vi.fn()
 const runtimeEnvironmentCall = vi.fn()
@@ -219,6 +224,40 @@ afterEach(() => {
 })
 
 describe('WorkspacePortScanner', () => {
+  it.each([
+    ['at the limit', WORKSPACE_PORT_SCAN_CONCURRENCY],
+    ['above the limit', WORKSPACE_PORT_SCAN_CONCURRENCY + 1]
+  ])('bounds execution-host scans %s', async (_, count) => {
+    const targets: RuntimeClientTarget[] = Array.from({ length: count }, (_, index) => ({
+      kind: 'environment',
+      environmentId: `env-${index}`
+    }))
+    let active = 0
+    let peak = 0
+    const releases: (() => void)[] = []
+    const scanTarget = vi.fn(async () => {
+      active++
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => releases.push(resolve))
+      active--
+      return emptyScan
+    })
+
+    const scans = scanWorkspacePortTargets(targets, scanTarget)
+    expect(scanTarget).toHaveBeenCalledTimes(Math.min(count, WORKSPACE_PORT_SCAN_CONCURRENCY))
+    if (count > WORKSPACE_PORT_SCAN_CONCURRENCY) {
+      releases.shift()?.()
+      for (let turn = 0; turn < 5 && scanTarget.mock.calls.length < count; turn++) {
+        await Promise.resolve()
+      }
+      expect(scanTarget).toHaveBeenCalledTimes(count)
+    }
+    releases.splice(0).forEach((release) => release())
+
+    await expect(scans).resolves.toHaveLength(count)
+    expect(peak).toBe(Math.min(count, WORKSPACE_PORT_SCAN_CONCURRENCY))
+  })
+
   it('turns a missing runtime scan payload into an unavailable result', async () => {
     runtimeEnvironmentCall.mockResolvedValue({ ok: true, result: undefined })
 

--- a/src/renderer/src/components/ports/WorkspacePortScanner.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.tsx
@@ -15,9 +15,11 @@ import {
 } from '@/lib/workspace-port-scan-debounce'
 import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 import { buildExecutionHostRegistry } from '../../../../shared/execution-host-registry'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 
 const WORKSPACE_PORT_SCAN_INTERVAL_MS = 30_000
 const WORKSPACE_PORT_ADVERTISED_URL_SETTLE_MS = 1_000
+export const WORKSPACE_PORT_SCAN_CONCURRENCY = 4
 type WorkspacePortScannerRefreshOptions = {
   force?: boolean
   targets?: readonly RuntimeClientTarget[]
@@ -32,6 +34,21 @@ function makeUnavailableScan(reason: string): WorkspacePortScanResult {
     ports: [],
     unavailableReason: reason
   }
+}
+
+export function scanWorkspacePortTargets(
+  targets: readonly RuntimeClientTarget[],
+  scanTarget = scanWorkspacePortsForTarget
+): Promise<{ key: string; result: WorkspacePortScanResult }[]> {
+  return mapWithConcurrency(targets, WORKSPACE_PORT_SCAN_CONCURRENCY, async (target) => {
+    const key = workspacePortScanKeyForTarget(target)
+    try {
+      return { key, result: await scanTarget(target) }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return { key, result: makeUnavailableScan(message || 'Workspace port scan failed.') }
+    }
+  })
 }
 
 export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }): null {
@@ -107,18 +124,7 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
 
       const generation = generationRef.current
       setWorkspacePortScanRefreshing(true)
-      const promise = Promise.all(
-        targets.map(async (target) => {
-          const key = workspacePortScanKeyForTarget(target)
-          try {
-            const result = await scanWorkspacePortsForTarget(target)
-            return { key, result }
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error)
-            return { key, result: makeUnavailableScan(message || 'Workspace port scan failed.') }
-          }
-        })
-      )
+      const promise = scanWorkspacePortTargets(targets)
         .then((results) => {
           if (generation === generationRef.current) {
             const activeTargetKeys = new Set(

--- a/src/renderer/src/components/pull-request-page-host-boundary.test.ts
+++ b/src/renderer/src/components/pull-request-page-host-boundary.test.ts
@@ -98,20 +98,21 @@ describe('PullRequestPage host boundaries', () => {
 
   it('uses source-aware initial details routing and cache identity', () => {
     const source = componentSource('PullRequestPage.tsx')
+    const cacheSource = componentSource('../lib/github-work-item-details-cache.ts')
     const propsSection = sourceBetween(
       source,
       'type PullRequestPageProps',
       'function formatRelativeTime'
     )
     const cacheKeySection = sourceBetween(
-      source,
-      'function getWorkItemDetailsCacheKey',
-      'function touchWorkItemDetailsCache'
+      cacheSource,
+      'export function getWorkItemDetailsCacheKey',
+      'export function getWorkItemDetailsCacheEntry'
     )
     const matchInvalidationSection = sourceBetween(
-      source,
-      'function invalidateWorkItemDetailsCacheByMatch',
-      'function patchCachedPRFileViewedState'
+      cacheSource,
+      'export function invalidateWorkItemDetailsCacheByMatch',
+      'export function clearWorkItemDetailsCacheForTests'
     )
 
     expect(propsSection).toContain('sourceContext?: TaskSourceContext | null')
@@ -119,9 +120,9 @@ describe('PullRequestPage host boundaries', () => {
     expect(source).toContain('sourceContext,')
     expect(cacheKeySection).toContain('sourceCacheScope')
     expect(source).toContain('getTaskSourceCacheScope(sourceContext)')
-    expect(matchInvalidationSection).toContain(
-      'if (removed) {\n    workItemDetailsCacheGeneration += 1'
-    )
+    expect(source).toContain('useWorkItemDetailsCacheEntry(detailsCacheKey)')
+    expect(source).not.toContain('new Map<string, WorkItemDetailsCacheEntry>')
+    expect(matchInvalidationSection).toContain('cacheGeneration += 1')
   })
 
   it('treats null details as unavailable while preserving empty detail payloads', () => {
@@ -138,6 +139,8 @@ describe('PullRequestPage host boundaries', () => {
     expect(resultSection).toContain('} else if (result === null) {')
     expect(resultSection).toContain('error: WORK_ITEM_DETAILS_UNAVAILABLE_MESSAGE')
     expect(resultSection).toContain('details: result')
+    expect(resultSection).toContain('getWorkItemDetailsCacheGeneration() !== launchedAtGeneration')
+    expect(resultSection).toContain('prev?.pending !== inflight')
   })
 
   it('routes file viewed mutations through the PR source context', () => {
@@ -201,6 +204,7 @@ describe('PullRequestPage host boundaries', () => {
 
   it('routes PR file contents and runtime viewed invalidations through the PR source context', () => {
     const source = componentSource('PullRequestPage.tsx')
+    const cacheSource = componentSource('../lib/github-work-item-details-cache.ts')
     const fileContentsSection = sourceBetween(
       source,
       'function loadPRFileContents',
@@ -211,7 +215,11 @@ describe('PullRequestPage host boundaries', () => {
       'function getPRFileContentCacheKey',
       'function loadPRFileContents'
     )
-    const listenerSection = sourceBetween(source, 'let workItemMutatedUnsub', '// Why: bounded LRU')
+    const listenerSection = sourceBetween(
+      cacheSource,
+      'let workItemMutatedUnsub',
+      "if (typeof import.meta !== 'undefined'"
+    )
     const commentContextSection = sourceBetween(
       source,
       'function CommentCodeContext',
@@ -228,6 +236,7 @@ describe('PullRequestPage host boundaries', () => {
     expect(fileContentsSection).toContain('sourceContext: args.sourceContext')
     expect(fileContentsSection).toContain('sourceContext,')
     expect(listenerSection).toContain('onGitHubWorkItemDetailsCacheMutation')
+    expect(listenerSection).toContain('invalidateWorkItemDetailsCacheByMatch')
     expect(source).toContain('emitGitHubWorkItemDetailsCacheMutation(args)')
     expect(source).toContain('options.local !== false')
     expect(source).toContain('notifyWorkItemMutated({')

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -43,6 +43,7 @@ import { basename, dirname, joinPath } from '@/lib/path'
 import { cn } from '@/lib/utils'
 import { WORKSPACE_FILE_PATH_MIME } from '@/lib/workspace-file-drag'
 import { isFolderRepo } from '../../../../shared/repo-kind'
+import { mapSettledWithConcurrency } from '../../../../shared/map-with-concurrency'
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@/components/ui/tooltip'
 import { Button } from '@/components/ui/button'
 import {
@@ -533,6 +534,7 @@ const SOURCE_CONTROL_TREE_INDENT_PX = 12
 const SOURCE_CONTROL_TREE_DIRECTORY_PADDING_PX = 8
 const SOURCE_CONTROL_TREE_FILE_PADDING_PX = 20
 const CAPPED_STATUS_RETRY_TIMEOUT_MS = 15_000
+const SOURCE_CONTROL_QUIESCE_CONCURRENCY = 8
 const EMPTY_GIT_HISTORY_STATE: GitHistoryPanelState = { status: 'idle' }
 const DEFAULT_COLLAPSED_SECTIONS = ['history'] as const
 const SUBMODULE_WORKTREE_ONLY_LABEL = 'Stage inside submodule'
@@ -5246,16 +5248,23 @@ function SourceControlInner(): React.JSX.Element {
       const runtimeEnvironmentId =
         useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
       // Why: quiesce matching editor autosaves first so a delayed save can't recreate edits after git mutates the files.
-      await Promise.all(
-        filePaths.map((relativePath) =>
+      const quiesces = await mapSettledWithConcurrency(
+        filePaths,
+        SOURCE_CONTROL_QUIESCE_CONCURRENCY,
+        (relativePath) =>
           requestEditorSaveQuiesce({
             worktreeId: activeWorktreeId,
             worktreePath,
             relativePath,
             runtimeEnvironmentId
           })
-        )
       )
+      const failedQuiesce = quiesces.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected'
+      )
+      if (failedQuiesce) {
+        throw failedQuiesce.reason
+      }
       const connectionId = getConnectionId(activeWorktreeId) ?? undefined
       await bulkDiscardRuntimeGitPaths(
         {

--- a/src/renderer/src/components/right-sidebar/checks-panel-review-copy.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel-review-copy.ts
@@ -263,6 +263,17 @@ const SKIPPED_COPY: Partial<
         'Orca could not refresh {{reviewLabel}} status for this remote context. Retry after the host is available.'
     },
     recovery: ['retry']
+  },
+  capacity: {
+    title: {
+      key: 'auto.components.right.sidebar.checks.panel.review.skipped.capacity.title',
+      fallback: 'Refresh queue busy'
+    },
+    body: {
+      key: 'auto.components.right.sidebar.checks.panel.review.skipped.capacity.body',
+      fallback: 'Orca is handling many review updates. Retry this refresh in a moment.'
+    },
+    recovery: ['retry']
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/fileExplorerUndoRedo.test.ts
+++ b/src/renderer/src/components/right-sidebar/fileExplorerUndoRedo.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearFileExplorerUndoHistory,
+  commitFileExplorerOp,
+  FILE_EXPLORER_UNDO_MAX_ENTRY_BYTES,
+  fileExplorerHasUndo,
+  getFileExplorerUndoRetainedBytesForTests,
+  undoFileExplorer
+} from './fileExplorerUndoRedo'
+
+beforeEach(() => {
+  clearFileExplorerUndoHistory()
+})
+
+describe('file explorer undo retention', () => {
+  it('rejects an operation whose captured payload exceeds the per-entry budget', () => {
+    expect(
+      commitFileExplorerOp({
+        retainedBytes: FILE_EXPLORER_UNDO_MAX_ENTRY_BYTES + 1,
+        undo: vi.fn(),
+        redo: vi.fn()
+      })
+    ).toBe(false)
+    expect(fileExplorerHasUndo()).toBe(false)
+  })
+
+  it('evicts the oldest operation to stay within the aggregate budget', async () => {
+    const oldestUndo = vi.fn()
+    const retainedPerOperation = 12 * 1024 * 1024
+    commitFileExplorerOp({
+      retainedBytes: retainedPerOperation,
+      undo: oldestUndo,
+      redo: vi.fn()
+    })
+    for (let index = 0; index < 2; index += 1) {
+      commitFileExplorerOp({
+        retainedBytes: retainedPerOperation,
+        undo: vi.fn(),
+        redo: vi.fn()
+      })
+    }
+
+    expect(getFileExplorerUndoRetainedBytesForTests()).toBe(retainedPerOperation * 2)
+    await undoFileExplorer()
+    await undoFileExplorer()
+    expect(oldestUndo).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/fileExplorerUndoRedo.ts
+++ b/src/renderer/src/components/right-sidebar/fileExplorerUndoRedo.ts
@@ -5,26 +5,45 @@
  * (which is not exposed in a portable way here).
  */
 const MAX_STEPS = 50
+export const FILE_EXPLORER_UNDO_MAX_ENTRY_BYTES = 16 * 1024 * 1024
+export const FILE_EXPLORER_UNDO_MAX_AGGREGATE_BYTES = 32 * 1024 * 1024
 
 type ExplorerOp = {
   undo: () => Promise<void>
   redo: () => Promise<void>
+  retainedBytes?: number
 }
 
 const past: ExplorerOp[] = []
 const future: ExplorerOp[] = []
+let retainedBytes = 0
 
-export function commitFileExplorerOp(op: ExplorerOp): void {
-  past.push(op)
-  if (past.length > MAX_STEPS) {
-    past.shift()
+export function commitFileExplorerOp(op: ExplorerOp): boolean {
+  const opBytes = Math.max(0, op.retainedBytes ?? 0)
+  if (opBytes > FILE_EXPLORER_UNDO_MAX_ENTRY_BYTES) {
+    return false
+  }
+  for (const futureOp of future) {
+    retainedBytes -= Math.max(0, futureOp.retainedBytes ?? 0)
   }
   future.length = 0
+  while (past.length > 0 && retainedBytes + opBytes > FILE_EXPLORER_UNDO_MAX_AGGREGATE_BYTES) {
+    const expired = past.shift()
+    retainedBytes -= Math.max(0, expired?.retainedBytes ?? 0)
+  }
+  past.push(op)
+  retainedBytes += opBytes
+  if (past.length > MAX_STEPS) {
+    const expired = past.shift()
+    retainedBytes -= Math.max(0, expired?.retainedBytes ?? 0)
+  }
+  return true
 }
 
 export function clearFileExplorerUndoHistory(): void {
   past.length = 0
   future.length = 0
+  retainedBytes = 0
 }
 
 export async function undoFileExplorer(): Promise<boolean> {
@@ -53,4 +72,8 @@ export function fileExplorerHasUndo(): boolean {
 
 export function fileExplorerHasRedo(): boolean {
   return future.length > 0
+}
+
+export function getFileExplorerUndoRetainedBytesForTests(): number {
+  return retainedBytes
 }

--- a/src/renderer/src/components/right-sidebar/useFileDeletion.ts
+++ b/src/renderer/src/components/right-sidebar/useFileDeletion.ts
@@ -24,6 +24,7 @@ import {
   writeRuntimeFile
 } from '@/runtime/runtime-file-client'
 import { translate } from '@/i18n/i18n'
+import { measureUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
 
 type UseFileDeletionParams = {
   activeWorktreeId: string | null
@@ -163,6 +164,7 @@ export function useFileDeletion({
 
         if (undoContent !== undefined) {
           commitFileExplorerOp({
+            retainedBytes: measureUtf8ByteLength(undoContent).byteLength,
             undo: async () => {
               const currentRoute = operationGuard.assertCurrent()
               await writeRuntimeFile(

--- a/src/renderer/src/components/right-sidebar/useFileExplorerTree.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerTree.test.ts
@@ -3,7 +3,10 @@ import type { SetStateAction } from 'react'
 import type { DirEntry } from '../../../../shared/types'
 import type { DirCache } from './file-explorer-types'
 import { createFileExplorerDirLoadTracker } from './file-explorer-dir-load-tracker'
-import { refreshFileExplorerExpandedDirs } from './useFileExplorerTree'
+import {
+  FILE_EXPLORER_REFRESH_CONCURRENCY,
+  refreshFileExplorerExpandedDirs
+} from './useFileExplorerTree'
 
 type CacheUpdate = SetStateAction<Record<string, DirCache>>
 
@@ -12,6 +15,46 @@ function entry(name: string, isDirectory = false): DirEntry {
 }
 
 describe('refreshFileExplorerExpandedDirs', () => {
+  it.each([
+    ['at the limit', FILE_EXPLORER_REFRESH_CONCURRENCY],
+    ['above the limit', FILE_EXPLORER_REFRESH_CONCURRENCY + 1]
+  ])('bounds expanded-directory reads %s', async (_, count) => {
+    let cache: Record<string, DirCache> = {}
+    let active = 0
+    let peak = 0
+    let started = 0
+    const releases: (() => void)[] = []
+    const refresh = refreshFileExplorerExpandedDirs({
+      dirs: Array.from({ length: count }, (_, index) => ({
+        dirPath: `/repo/dir-${index}`,
+        depth: 0
+      })),
+      worktreePath: '/repo',
+      dirLoadTracker: createFileExplorerDirLoadTracker(),
+      setDirCache: (update) => {
+        cache = typeof update === 'function' ? update(cache) : update
+      },
+      readDirectory: async () => {
+        started++
+        active++
+        peak = Math.max(peak, active)
+        await new Promise<void>((resolve) => releases.push(resolve))
+        active--
+        return { entries: [], operationOwner: { kind: 'local' as const } }
+      }
+    })
+
+    await vi.waitFor(() => expect(started).toBe(Math.min(count, FILE_EXPLORER_REFRESH_CONCURRENCY)))
+    if (count > FILE_EXPLORER_REFRESH_CONCURRENCY) {
+      releases.shift()?.()
+      await vi.waitFor(() => expect(started).toBe(count))
+    }
+    releases.splice(0).forEach((release) => release())
+
+    await expect(refresh).resolves.toBe(true)
+    expect(peak).toBe(Math.min(count, FILE_EXPLORER_REFRESH_CONCURRENCY))
+  })
+
   it('reloads expanded directories with one loading cache commit and one result cache commit', async () => {
     let cache: Record<string, DirCache> = {
       '/repo': {

--- a/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useRef, useState } from 'react'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 import type { DirCache } from './file-explorer-types'
 import { splitPathSegments } from './path-tree'
 import { statRuntimePath } from '@/runtime/runtime-file-client'
@@ -48,6 +49,8 @@ type RefreshFileExplorerExpandedDirsParams = {
   readDirectory: (dirPath: string) => Promise<FileExplorerDirectoryListing>
 }
 
+export const FILE_EXPLORER_REFRESH_CONCURRENCY = 8
+
 export async function refreshFileExplorerExpandedDirs({
   dirs,
   worktreePath,
@@ -78,8 +81,10 @@ export async function refreshFileExplorerExpandedDirs({
     return next
   })
 
-  const results = await Promise.all(
-    uniqueDirs.map(async ({ dirPath, depth }) => {
+  const results = await mapWithConcurrency(
+    uniqueDirs,
+    FILE_EXPLORER_REFRESH_CONCURRENCY,
+    async ({ dirPath, depth }) => {
       const loadToken = loadTokens.get(dirPath)!
       try {
         const listing = await readDirectory(dirPath)
@@ -111,7 +116,7 @@ export async function refreshFileExplorerExpandedDirs({
           cache: { children: [], loading: false }
         }
       }
-    })
+    }
   )
 
   // Why: the batch commits only after the slowest read, so a dir can be

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -61,9 +61,11 @@ import {
   getRemoteServerManualUpdateHelp,
   RemoteServerUpdateStatus
 } from './RemoteServerUpdateStatus'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 
 const LOCAL_RUNTIME_VALUE = '__local__'
 const NO_RUNTIME_VALUE = '__none__'
+export const RUNTIME_ENVIRONMENT_REFRESH_CONCURRENCY = 5
 
 type RuntimeEnvironmentsPaneProps = {
   settings: GlobalSettings
@@ -333,8 +335,10 @@ export function RuntimeEnvironmentsPane({
           return next
         })
       }
-      await Promise.allSettled(
-        visibleEnvironments.map(async (environment) => {
+      await mapWithConcurrency(
+        visibleEnvironments,
+        RUNTIME_ENVIRONMENT_REFRESH_CONCURRENCY,
+        async (environment) => {
           try {
             const response = await window.api.runtimeEnvironments.getStatus({
               selector: environment.id,
@@ -379,7 +383,7 @@ export function RuntimeEnvironmentsPane({
               }
             }))
           }
-        })
+        }
       )
     } catch (error) {
       if (mountedRef.current) {
@@ -635,7 +639,9 @@ export function RuntimeEnvironmentsPane({
       // Why: Connect is not the Active Server selector anymore, but connected
       // hosts should still contribute their projects/workspaces to the sidebar.
       const repos = await store.fetchRuntimeEnvironmentRepos(environment.id)
-      await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
+      await mapWithConcurrency(repos, RUNTIME_ENVIRONMENT_REFRESH_CONCURRENCY, async (repo) =>
+        useAppStore.getState().fetchWorktrees(repo.id)
+      )
       await useAppStore.getState().fetchWorktreeLineage()
       if (mountedRef.current) {
         toast.success(

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -82,6 +82,7 @@ import {
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
 import { keybindingMatchesAction } from '../../../../shared/keybindings'
+import { forEachWithConcurrency } from '../../../../shared/map-with-concurrency'
 import {
   isWebClientLocation,
   useSettingsNavigationMetadata
@@ -173,6 +174,7 @@ const SETTINGS_NAV_GROUP_BY_ID = new Map<string, SettingsNavGroupDefinition>(
 
 const SHORTCUTS_ESCAPE_CONFIRM_TOAST_ID = 'shortcuts-escape-confirm'
 const SHORTCUTS_ESCAPE_CONFIRM_WINDOW_MS = 2200
+const REPO_HOOK_PROBE_CONCURRENCY = 4
 
 function getSettingsSectionId(
   pane: SettingsNavTarget,
@@ -909,61 +911,62 @@ function Settings(): React.JSX.Element {
     const requestSeq = ++repoHooksRequestSeqRef.current
     const liveRepoHostIdentities = new Set(repos.map(getRepoHostIdentity))
 
-    void Promise.all(
-      neededRepos.map(async (repo) => {
-        const repoHostIdentity = getRepoHostIdentity(repo)
-        if (isFolderRepo(repo)) {
-          setRepoHooksMap((previous) => {
-            if (previous[repoHostIdentity]) {
-              return previous
-            }
-            return {
-              ...previous,
-              [repoHostIdentity]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
-            }
-          })
+    void forEachWithConcurrency(neededRepos, REPO_HOOK_PROBE_CONCURRENCY, async (repo) => {
+      if (stale || requestSeq !== repoHooksRequestSeqRef.current) {
+        return
+      }
+      const repoHostIdentity = getRepoHostIdentity(repo)
+      if (isFolderRepo(repo)) {
+        setRepoHooksMap((previous) => {
+          if (previous[repoHostIdentity]) {
+            return previous
+          }
+          return {
+            ...previous,
+            [repoHostIdentity]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
+          }
+        })
+        return
+      }
+      try {
+        const hostId = getRepoExecutionHostId(repo)
+        const parsedHost = parseExecutionHostId(hostId)
+        const result = await checkRuntimeHooks(
+          {
+            activeRuntimeEnvironmentId:
+              parsedHost?.kind === 'runtime' ? parsedHost.environmentId : null
+          },
+          repo.id,
+          hostId
+        )
+        if (stale || requestSeq !== repoHooksRequestSeqRef.current) {
           return
         }
-        try {
-          const hostId = getRepoExecutionHostId(repo)
-          const parsedHost = parseExecutionHostId(hostId)
-          const result = await checkRuntimeHooks(
-            {
-              activeRuntimeEnvironmentId:
-                parsedHost?.kind === 'runtime' ? parsedHost.environmentId : null
-            },
-            repo.id,
-            hostId
-          )
-          if (stale || requestSeq !== repoHooksRequestSeqRef.current) {
-            return
+        setRepoHooksMap((previous) => {
+          if (!liveRepoHostIdentities.has(repoHostIdentity)) {
+            return previous
           }
-          setRepoHooksMap((previous) => {
-            if (!liveRepoHostIdentities.has(repoHostIdentity)) {
-              return previous
-            }
-            return { ...previous, [repoHostIdentity]: result }
-          })
-        } catch {
-          // Keep last known value on transient failures.
-          if (stale || requestSeq !== repoHooksRequestSeqRef.current) {
-            return
-          }
-          setRepoHooksMap((previous) => {
-            if (!liveRepoHostIdentities.has(repoHostIdentity)) {
-              return previous
-            }
-            if (previous[repoHostIdentity]) {
-              return previous
-            }
-            return {
-              ...previous,
-              [repoHostIdentity]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
-            }
-          })
+          return { ...previous, [repoHostIdentity]: result }
+        })
+      } catch {
+        // Keep last known value on transient failures.
+        if (stale || requestSeq !== repoHooksRequestSeqRef.current) {
+          return
         }
-      })
-    )
+        setRepoHooksMap((previous) => {
+          if (!liveRepoHostIdentities.has(repoHostIdentity)) {
+            return previous
+          }
+          if (previous[repoHostIdentity]) {
+            return previous
+          }
+          return {
+            ...previous,
+            [repoHostIdentity]: { hasHooks: false, hooks: null, mayNeedUpdate: false }
+          }
+        })
+      }
+    })
 
     return () => {
       stale = true

--- a/src/renderer/src/components/settings/mcp-config-inspection.test.ts
+++ b/src/renderer/src/components/settings/mcp-config-inspection.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MCP_CONFIG_INSPECTION_MAX_BYTES } from '../../../../shared/mcp-config-inspection-limits'
+import { loadMcpConfigInspections } from './mcp-config-inspection'
+
+function installFilesystemApi(size: number) {
+  const readFile = vi.fn().mockResolvedValue({
+    content: '{"mcpServers":{"local":{"command":"node"}}}',
+    isBinary: false
+  })
+  vi.stubGlobal('window', {
+    api: {
+      fs: {
+        readDir: vi
+          .fn()
+          .mockResolvedValue([{ name: '.mcp.json', isDirectory: false, isSymlink: false }]),
+        stat: vi.fn().mockResolvedValue({ size, isDirectory: false, mtime: 0 }),
+        readFile
+      }
+    }
+  })
+  return { readFile }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('loadMcpConfigInspections file admission', () => {
+  it('reads a candidate at the exact byte boundary', async () => {
+    const fs = installFilesystemApi(MCP_CONFIG_INSPECTION_MAX_BYTES)
+
+    const inspections = await loadMcpConfigInspections('/repo', undefined)
+
+    expect(inspections[0]).toMatchObject({
+      exists: true,
+      status: 'valid',
+      servers: [{ name: 'local', command: 'node' }]
+    })
+    expect(fs.readFile).toHaveBeenCalledOnce()
+  })
+
+  it('rejects a +1 candidate before renderer IPC materialization', async () => {
+    const fs = installFilesystemApi(MCP_CONFIG_INSPECTION_MAX_BYTES + 1)
+
+    const inspections = await loadMcpConfigInspections('/repo', 'ssh-1')
+
+    expect(inspections[0]).toMatchObject({
+      exists: true,
+      status: 'invalid',
+      error: 'MCP config exceeds the inspection size limit.'
+    })
+    expect(fs.readFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/mcp-config-inspection.ts
+++ b/src/renderer/src/components/settings/mcp-config-inspection.ts
@@ -6,6 +6,7 @@ import {
   selectExistingMcpConfigCandidates,
   type McpConfigDirectoryEntry
 } from '../../../../shared/mcp-config'
+import { MCP_CONFIG_INSPECTION_MAX_BYTES } from '../../../../shared/mcp-config-inspection-limits'
 import { joinPath } from '../../lib/path'
 import { extractIpcErrorMessage } from '../../lib/ipc-error'
 import type { LoadedMcpConfigInspection } from './McpConfigFileRow'
@@ -74,6 +75,23 @@ export async function loadMcpConfigInspections(
       }
 
       try {
+        const fileStat = await window.api.fs.stat({ filePath: absolutePath, connectionId })
+        if (
+          fileStat.isDirectory ||
+          !Number.isSafeInteger(fileStat.size) ||
+          fileStat.size < 0 ||
+          fileStat.size > MCP_CONFIG_INSPECTION_MAX_BYTES
+        ) {
+          return {
+            ...inspectMcpConfigContent(candidate, null),
+            exists: true,
+            status: 'invalid',
+            error: fileStat.isDirectory
+              ? 'MCP config path is a directory.'
+              : 'MCP config exceeds the inspection size limit.',
+            absolutePath
+          }
+        }
         const result = await window.api.fs.readFile({ filePath: absolutePath, connectionId })
         const inspection = inspectMcpConfigContent(candidate, result.isBinary ? '' : result.content)
         return { ...inspection, absolutePath }

--- a/src/renderer/src/components/settings/settings-repo-hook-fanout-boundary.test.ts
+++ b/src/renderer/src/components/settings/settings-repo-hook-fanout-boundary.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const SETTINGS_SOURCE = readFileSync(join(__dirname, 'Settings.tsx'), 'utf8')
+
+function sourceBetween(startPattern: string, endPattern: string): string {
+  const start = SETTINGS_SOURCE.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = SETTINGS_SOURCE.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return SETTINGS_SOURCE.slice(start, end)
+}
+
+describe('settings repository-hook fanout boundary', () => {
+  it('bounds hook probes while retaining request-generation and repository guards', () => {
+    const section = sourceBetween(
+      'const requestSeq = ++repoHooksRequestSeqRef.current',
+      'const scrollTargetId = pendingScrollTargetRef.current'
+    )
+
+    expect(SETTINGS_SOURCE).toContain('const REPO_HOOK_PROBE_CONCURRENCY = 4')
+    expect(section).toContain('forEachWithConcurrency(neededRepos, REPO_HOOK_PROBE_CONCURRENCY')
+    expect(section).not.toMatch(/Promise\.all\(\s*neededRepos\.map/)
+    expect(section).toContain('requestSeq !== repoHooksRequestSeqRef.current')
+    expect(section).toContain('liveRepoHostIdentities.has(repoHostIdentity)')
+  })
+})

--- a/src/renderer/src/components/sidebar/AddRepoSteps.tsx
+++ b/src/renderer/src/components/sidebar/AddRepoSteps.tsx
@@ -5,9 +5,12 @@ import { useMountedRef } from '@/hooks/useMountedRef'
 import type { NestedRepoScanResult } from '../../../../shared/types'
 import type { SshTarget, SshConnectionState } from '../../../../shared/ssh-types'
 import { createNestedRepoTelemetryAttemptId } from '../../../../shared/nested-repo-telemetry'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 import { translate } from '@/i18n/i18n'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { upsertAddedRepoWithProjectHostSetup } from './add-repo-store-upsert'
+
+export const SSH_TARGET_STATE_READ_CONCURRENCY = 8
 
 // ── SSH host project hook ───────────────────────────────────────────
 
@@ -73,13 +76,15 @@ export function useRemoteRepo(
         if (gen !== remoteGenRef.current) {
           return
         }
-        const withState = await Promise.all(
-          targets.map(async (t) => {
+        const withState = await mapWithConcurrency(
+          targets,
+          SSH_TARGET_STATE_READ_CONCURRENCY,
+          async (t) => {
             const state = (await window.api.ssh.getState({
               targetId: t.id
             })) as SshConnectionState | null
             return { ...t, state: state ?? undefined }
-          })
+          }
         )
         if (gen !== remoteGenRef.current) {
           return

--- a/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
@@ -2,6 +2,9 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import CommentMarkdown, { remarkGitHubReferences } from './CommentMarkdown'
 
+const PNG_1X1_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII='
+
 describe('CommentMarkdown', () => {
   it('marks compact headings so a parent can opt into block flow', () => {
     const markup = renderToStaticMarkup(
@@ -81,12 +84,33 @@ describe('CommentMarkdown', () => {
 
   it('renders trusted compact markdown images inline', () => {
     const markup = renderToStaticMarkup(
-      <CommentMarkdown content="See this: ![Image #1](data:image/png;base64,abc123)" />
+      <CommentMarkdown content={`See this: ![Image #1](data:image/png;base64,${PNG_1X1_BASE64})`} />
     )
 
     expect(markup).toContain('<img')
     expect(markup).toContain('alt="Image #1"')
-    expect(markup).toContain('src="data:image/png;base64,abc123"')
+    expect(markup).toContain(`src="data:image/png;base64,${PNG_1X1_BASE64}"`)
+  })
+
+  it('renders malformed compact raster data as alt text instead of decoding it', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown content="See this: ![Image #1](data:image/png;base64,abc123)" />
+    )
+
+    expect(markup).not.toContain('<img')
+    expect(markup).toContain('<span>Image #1</span>')
+  })
+
+  it('renders malformed document raster data as alt text instead of decoding it', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown
+        variant="document"
+        content="See this: ![Image #1](data:image/png;base64,abc123)"
+      />
+    )
+
+    expect(markup).not.toContain('<img')
+    expect(markup).toContain('<span>Image #1</span>')
   })
 
   it('renders bare GitHub user attachment links as document videos', () => {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -36,6 +36,7 @@ import type { AppState } from '@/store/types'
 import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeMap } from '@/store/selectors'
 import { cn } from '@/lib/utils'
 import type { Repo, Worktree } from '../../../../shared/types'
+import { mapSettledWithConcurrency } from '../../../../shared/map-with-concurrency'
 import { runWorktreeBatchDelete, runWorktreeDelete } from './delete-worktree-flow'
 import { runSleepWorktrees } from './sleep-worktree-flow'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
@@ -74,6 +75,16 @@ const WORKTREE_NATIVE_CONTEXT_MENU_ATTR = 'data-worktree-native-context-menu'
 const CONTEXT_MENU_CLICK_SUPPRESSION_MS = 500
 const DELETE_POSITION_RESTORE_MAX_FRAMES = 180
 const DELETE_POSITION_RESTORE_STABLE_FRAMES = 6
+const WORKTREE_META_MUTATION_CONCURRENCY = 8
+
+function rethrowFirstMutationFailure(results: readonly PromiseSettledResult<unknown>[]): void {
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  )
+  if (failure) {
+    throw failure.reason
+  }
+}
 
 // Why: stable empty sentinels let closed menu wrappers subscribe to a referentially
 // stable value instead of the high-churn maps that delete teardown replaces. The
@@ -504,13 +515,14 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const handleAssignWorkspaceStatus = useCallback(
     (status: string) => {
       setMenuOpenState(false)
-      void Promise.all(
-        activeContextWorktrees.map((item) =>
+      void mapSettledWithConcurrency(
+        activeContextWorktrees,
+        WORKTREE_META_MUTATION_CONCURRENCY,
+        (item) =>
           getWorkspaceStatus(item, workspaceStatuses) === status
             ? Promise.resolve()
             : updateWorktreeMeta(item.id, { workspaceStatus: status })
-        )
-      )
+      ).then(rethrowFirstMutationFailure)
     },
     [activeContextWorktrees, setMenuOpenState, updateWorktreeMeta, workspaceStatuses]
   )
@@ -624,9 +636,11 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   )
 
   const handleRemoveParentLink = useCallback(() => {
-    void Promise.all(
-      activeContextWorktrees.map((item) => updateWorktreeLineage(item.id, { noParent: true }))
-    )
+    void mapSettledWithConcurrency(
+      activeContextWorktrees,
+      WORKTREE_META_MUTATION_CONCURRENCY,
+      (item) => updateWorktreeLineage(item.id, { noParent: true })
+    ).then(rethrowFirstMutationFailure)
   }, [activeContextWorktrees, updateWorktreeLineage])
 
   const suppressOpeningPointerEvent = useCallback((event: React.SyntheticEvent) => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -232,6 +232,7 @@ import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
 import { ProjectGroupDeleteDialog } from './ProjectGroupDeleteDialog'
 import { selectProjectGroupRemovalTargets } from '@/store/slices/project-group-removal-targets'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
+import { mapSettledWithConcurrency } from '../../../../shared/map-with-concurrency'
 import {
   effectiveExternalWorktreeVisibility,
   isLegacyRepoForExternalWorktreeVisibility
@@ -337,6 +338,7 @@ const EMPTY_TERMINAL_LAYOUTS_BY_TAB_ID: AppState['terminalLayoutsByTabId'] = {}
 const EMPTY_PTY_IDS_BY_TAB_ID: AppState['ptyIdsByTabId'] = {}
 const EMPTY_RUNTIME_PANE_TITLES_BY_TAB_ID: AppState['runtimePaneTitlesByTabId'] = {}
 const EXPANDING_CARD_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS = 300
+const WORKTREE_LINEAGE_MUTATION_CONCURRENCY = 8
 const NOOP_WORKSPACE_BOARD_DRAG_PREVIEW_CALLBACK = (): void => {}
 const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
   // Why: TanStack Virtual owns scroll correction; native overflow anchoring fights it and causes jumps.
@@ -344,6 +346,15 @@ const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
 }
 
 const recordKeyCountCache = new WeakMap<Record<string, unknown>, number>()
+
+function rethrowFirstLineageFailure(results: readonly PromiseSettledResult<unknown>[]): void {
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected'
+  )
+  if (failure) {
+    throw failure.reason
+  }
+}
 
 export function countRecordKeysByReference(record: Record<string, unknown>): number {
   const cached = recordKeyCountCache.get(record)
@@ -2720,17 +2731,19 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       if (!target.lineageParentId) {
         return false
       }
-      void Promise.all(
-        draggedIds.map((id) => assignWorktreeParent(id, { parentWorktreeId: parentId }))
-      ).catch((err) => {
-        console.error('Failed to nest workspace:', err)
-        toast.error(
-          translate(
-            'auto.components.sidebar.WorktreeList.failedNestWorkspace',
-            'Failed to nest workspace'
+      void mapSettledWithConcurrency(draggedIds, WORKTREE_LINEAGE_MUTATION_CONCURRENCY, (id) =>
+        assignWorktreeParent(id, { parentWorktreeId: parentId })
+      )
+        .then(rethrowFirstLineageFailure)
+        .catch((err) => {
+          console.error('Failed to nest workspace:', err)
+          toast.error(
+            translate(
+              'auto.components.sidebar.WorktreeList.failedNestWorkspace',
+              'Failed to nest workspace'
+            )
           )
-        )
-      })
+        })
       return true
     },
     [assignWorktreeParent, getEligibleLineageDropTarget]
@@ -2753,8 +2766,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         return
       }
       // Why: dropping a nested card on a reorder line is the un-nest escape hatch; clear only the dragged children.
-      void Promise.all(ids.map((id) => updateWorktreeLineage(id, { noParent: true }))).catch(
-        (err) => {
+      void mapSettledWithConcurrency(ids, WORKTREE_LINEAGE_MUTATION_CONCURRENCY, (id) =>
+        updateWorktreeLineage(id, { noParent: true })
+      )
+        .then(rethrowFirstLineageFailure)
+        .catch((err) => {
           console.error('Failed to unnest workspace:', err)
           toast.error(
             translate(
@@ -2762,8 +2778,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
               'Failed to unnest workspace'
             )
           )
-        }
-      )
+        })
     },
     [cyclicLineageIds, updateWorktreeLineage, worktreeDragGroups, worktreeLineageById, worktreeMap]
   )

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -7,6 +7,7 @@ import {
   isGitHubUserAttachmentUrl,
   isGitHubUserAttachmentVideoLink
 } from './comment-markdown-github-attachment-media'
+import { validateRasterImageDataUri } from '../../../../shared/image-data-uri'
 
 export type CommentMarkdownLinkClickHandler = (
   event: React.MouseEvent<HTMLElement>,
@@ -19,7 +20,9 @@ export function isTrustedCompactImageSrc(src: string | undefined): src is string
   }
   const normalized = src.trim().toLowerCase()
   return (
-    normalized.startsWith('blob:') || /^data:image\/(?:png|jpe?g|gif|webp);base64,/.test(normalized)
+    normalized.startsWith('blob:') ||
+    (/^data:image\/(?:png|jpe?g|gif|webp);base64,/.test(normalized) &&
+      validateRasterImageDataUri(src) !== null)
   )
 }
 
@@ -256,6 +259,13 @@ export function createDocumentCommentMarkdownComponents(
       </blockquote>
     ),
     img: ({ alt, src }) => {
+      if (
+        !src ||
+        (src.trim().toLowerCase().startsWith('data:image/') &&
+          validateRasterImageDataUri(src) === null)
+      ) {
+        return alt ? <span>{alt}</span> : null
+      }
       if (isGitHubUserAttachmentUrl(src)) {
         // Why: private-repo attachment images fail as cross-origin loads; a
         // top-level link opens them in a GitHub-authenticated tab, and falls

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -13,6 +13,7 @@ import {
   normalizeRuntimePathForComparison
 } from '../../../../shared/cross-platform-path'
 import type { Worktree } from '../../../../shared/types'
+import { mapWithConcurrency } from '../../../../shared/map-with-concurrency'
 import { translate } from '@/i18n/i18n'
 
 type WorktreeBatchDeleteOptions = {
@@ -26,6 +27,8 @@ type WorktreeDeleteWithToastOptions = {
   // Why: batch deletes suppress the per-delete focus handoff to focus one survivor after the batch (see runWorktreeDeletesInParallel).
   focusSuccessorOnDelete?: boolean
 }
+
+export const CROSS_REPO_DELETE_CONCURRENCY = 4
 
 // Why: a failed delete usually means unresolved changes, so land on the diff panel, not just focus the worktree.
 function viewWorktreeDiff(worktreeId: string): void {
@@ -67,8 +70,10 @@ export async function runWorktreeDeletesInParallel(
     // Why: delete nested children first — else the parent delete is rejected while it still contains a registered worktree.
     group.sort((a, b) => b.path.length - a.path.length)
   }
-  const groupResults = await Promise.all(
-    Array.from(groups.values()).map(async (group) => {
+  const groupResults = await mapWithConcurrency(
+    Array.from(groups.values()),
+    CROSS_REPO_DELETE_CONCURRENCY,
+    async (group) => {
       const deletedInGroup: string[] = []
       const failedInGroup: (typeof group)[number][] = []
       for (const target of group) {
@@ -88,7 +93,7 @@ export async function runWorktreeDeletesInParallel(
         }
       }
       return deletedInGroup
-    })
+    }
   )
   const deletedSet = new Set(groupResults.flat())
   // Why: focus a survivor once after the batch settles — an intermediate focus could spawn a terminal in a to-be-deleted workspace.

--- a/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-parallel-flow.test.ts
@@ -46,7 +46,7 @@ vi.mock('sonner', () => ({
 }))
 
 import { toast } from 'sonner'
-import { runWorktreeDeletesInParallel } from './delete-worktree-flow'
+import { CROSS_REPO_DELETE_CONCURRENCY, runWorktreeDeletesInParallel } from './delete-worktree-flow'
 
 function deferredDeleteResult(): {
   promise: Promise<{ ok: true }>
@@ -67,6 +67,45 @@ describe('runWorktreeDeletesInParallel', () => {
     mocks.state.deleteStateByWorktreeId = {}
     vi.mocked(toast.error).mockClear()
     vi.mocked(toast.info).mockClear()
+  })
+
+  it.each([
+    ['at the limit', CROSS_REPO_DELETE_CONCURRENCY],
+    ['above the limit', CROSS_REPO_DELETE_CONCURRENCY + 1]
+  ])('bounds cross-project deletes %s', async (_, count) => {
+    let active = 0
+    let peak = 0
+    const pending: ReturnType<typeof deferredDeleteResult>[] = []
+    mocks.state.removeWorktree.mockImplementation(() => {
+      const result = deferredDeleteResult()
+      pending.push(result)
+      active++
+      peak = Math.max(peak, active)
+      return result.promise.finally(() => {
+        active--
+      })
+    })
+    const targets = Array.from({ length: count }, (_, index) => ({
+      id: `wt-${index}`,
+      displayName: `workspace ${index}`,
+      repoId: `repo-${index}`,
+      path: `/workspaces/${index}`
+    }))
+
+    const deleted = runWorktreeDeletesInParallel(targets)
+    await vi.waitFor(() =>
+      expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(
+        Math.min(count, CROSS_REPO_DELETE_CONCURRENCY)
+      )
+    )
+    if (count > CROSS_REPO_DELETE_CONCURRENCY) {
+      pending.shift()?.resolve({ ok: true })
+      await vi.waitFor(() => expect(mocks.state.removeWorktree).toHaveBeenCalledTimes(count))
+    }
+    pending.splice(0).forEach((result) => result.resolve({ ok: true }))
+
+    await expect(deleted).resolves.toEqual(targets.map((target) => target.id))
+    expect(peak).toBe(Math.min(count, CROSS_REPO_DELETE_CONCURRENCY))
   })
 
   it('starts every selected delete before waiting for earlier deletes to finish', async () => {

--- a/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   connectRuntimeHostForNavigation,
   isConnectedRuntimeHostState,
+  RUNTIME_HOST_CATALOG_FETCH_CONCURRENCY,
   runtimeStatusForOverall
 } from './SshStatusSegment'
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  return {
+    promise: new Promise<void>((nextResolve) => {
+      resolve = nextResolve
+    }),
+    resolve
+  }
+}
 
 describe('SshStatusSegment host status helpers', () => {
   it('counts connected remote servers as connected hosts', () => {
@@ -55,5 +66,37 @@ describe('connectRuntimeHostForNavigation', () => {
       })
     ).resolves.toBe(false)
     expect(fetchRepos).not.toHaveBeenCalled()
+  })
+
+  it('bounds catalog worktree fetches for large remote hosts', async () => {
+    const count = RUNTIME_HOST_CATALOG_FETCH_CONCURRENCY + 1
+    const releases = Array.from({ length: count }, deferred)
+    let active = 0
+    let peak = 0
+    const fetchWorktrees = vi.fn(async (_repoId: string) => {
+      const release = releases[fetchWorktrees.mock.calls.length - 1]
+      active += 1
+      peak = Math.max(peak, active)
+      await release.promise
+      active -= 1
+    })
+    const loading = connectRuntimeHostForNavigation({
+      environmentId: 'windows-2',
+      refreshStatus: vi.fn().mockResolvedValue(true),
+      fetchRepos: vi
+        .fn()
+        .mockResolvedValue(Array.from({ length: count }, (_, index) => ({ id: `repo-${index}` }))),
+      fetchWorktrees,
+      fetchLineage: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await vi.waitFor(() =>
+      expect(fetchWorktrees).toHaveBeenCalledTimes(RUNTIME_HOST_CATALOG_FETCH_CONCURRENCY)
+    )
+    releases[0].resolve()
+    await vi.waitFor(() => expect(fetchWorktrees).toHaveBeenCalledTimes(count))
+    releases.slice(1).forEach(({ resolve }) => resolve())
+    await expect(loading).resolves.toBe(true)
+    expect(peak).toBe(RUNTIME_HOST_CATALOG_FETCH_CONCURRENCY)
   })
 })

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -20,6 +20,9 @@ import { isUserManagedRuntimeEnvironment } from '../../../../shared/runtime-envi
 import { RuntimeHostStatusRow, type RuntimeHostConnectionState } from './RuntimeHostStatusRow'
 import { SshTargetStatusRow } from './SshTargetStatusRow'
 import type { RemoteRuntimeSharedConnectionDiagnostics } from '../../../../shared/remote-runtime-shared-control-types'
+import { forEachWithConcurrency } from '../../../../shared/map-with-concurrency'
+
+export const RUNTIME_HOST_CATALOG_FETCH_CONCURRENCY = 4
 
 function isConnecting(status: SshConnectionStatus): boolean {
   return ['connecting', 'deploying-relay', 'reconnecting'].includes(status)
@@ -158,7 +161,9 @@ export async function connectRuntimeHostForNavigation(args: {
     return false
   }
   const repos = await args.fetchRepos(args.environmentId)
-  await Promise.all(repos.map((repo) => args.fetchWorktrees(repo.id)))
+  await forEachWithConcurrency(repos, RUNTIME_HOST_CATALOG_FETCH_CONCURRENCY, async (repo) => {
+    await args.fetchWorktrees(repo.id)
+  })
   await args.fetchLineage()
   return true
 }

--- a/src/renderer/src/components/task-page-gitlab-fanout-boundary.test.ts
+++ b/src/renderer/src/components/task-page-gitlab-fanout-boundary.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const TASK_PAGE_SOURCE = readFileSync(join(__dirname, 'TaskPage.tsx'), 'utf8')
+
+function sourceBetween(startPattern: string, endPattern: string): string {
+  const start = TASK_PAGE_SOURCE.indexOf(startPattern)
+  expect(start).toBeGreaterThanOrEqual(0)
+  const end = TASK_PAGE_SOURCE.indexOf(endPattern, start + startPattern.length)
+  expect(end).toBeGreaterThan(start)
+  return TASK_PAGE_SOURCE.slice(start, end)
+}
+
+describe('TaskPage GitLab request fanout', () => {
+  it('bounds per-repository requests without replacing all-settled handling', () => {
+    const section = sourceBetween(
+      '// Why: fetch GitLab Issues and MRs separately',
+      '// Why: Todos fetch has its own effect'
+    )
+
+    expect(TASK_PAGE_SOURCE).toContain('const GITLAB_REPO_FETCH_CONCURRENCY = 8')
+    expect(section).toContain('mapSettledWithConcurrency(')
+    expect(section).toContain('GITLAB_REPO_FETCH_CONCURRENCY')
+    expect(section).toContain('return fetchItems(repo)')
+    expect(section).not.toContain('Promise.allSettled(eligibleRepos.map(fetchItems))')
+    expect(section).toContain("if (r.status !== 'fulfilled')")
+  })
+})


### PR DESCRIPTION
## OOM hardening slice 27/29 — bound renderer components (native-chat, pet, sidebar, automations)

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **27/29** (base: `oom/26-b-renderer-editor-terminal`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
This slice re-lands memory ceilings across renderer components: a byte/entry-bounded native-chat scope cache (drafts, session options, pending sends), bounded custom-pet blob/media caches and load queue, a rolling 256KB automation-run output buffer, bounded file-explorer undo history, model-enrichment caps, and ~12 concurrency caps on repo/host/worktree fan-outs. All changes are whole-file and ship with dedicated bound tests.

### ELI5
The app has lots of little in-memory "scratch pads" — draft chat text, pet images, automation logs, undo history — that previously grew forever and could crash the app by eating all memory. This change puts a size limit on each: once a pad is full it drops the oldest stuff (or refuses new stuff). It also stops the app from firing off hundreds of network/git requests at once by only allowing a handful in parallel. Normal users never notice; only pathological inputs hit the limits.

### Proof of OOM fix
- native-chat-composer-scope-cache.ts: bounded scope cache — 128 entries/cache, 32MB aggregate, 16MB/value, 4KB/key; UTF-8 byte accounting with per-entry release on delete/clear. Tests: native-chat-composer-scope-cache.test.ts (retains at-limit, rejects one byte over, aggregate eviction, byte-accounting release, 128-entry cap).
- native-chat-pending.ts: PENDING_SEND_LIMIT=8 (pending.slice(-8)) and COMMAND_MARKER_LIMIT=8. Test: native-chat-pending.test.ts.
- native-chat-session-option-enrichment.ts: NATIVE_CHAT_MODEL_ENRICHMENT_CACHE_MAX=128 inactive entries evicted FIFO; NATIVE_CHAT_MODEL_ENRICHMENT_PENDING_MAX=8 concurrent probes; pendingEnrichmentCount decremented in finally (no leak). Test: native-chat-session-option-enrichment.test.ts.
- pet/custom-pet-load-queue.ts: MAX_CONCURRENT_CUSTOM_PET_LOADS=2, MAX_PENDING_CUSTOM_PET_LOADS=16 (rejects over cap). Test: custom-pet-load-queue.test.ts.
- pet/pet-blob-cache.ts: CUSTOM_PET_BLOB_CACHE_MAX=16 blob URLs, CUSTOM_PET_MEDIA_CACHE_MAX_BYTES=128MB; evicts only inactive entries, revokes object URLs. Test: pet-blob-cache.test.ts.
- pet/sprite-frame-detection.ts: MAX_CUSTOM_PET_DETECTED_FRAMES cap — returns null rather than allocating unbounded frames. Test: sprite-frame-detection.test.ts.
- automations/automation-run-output-snapshot.ts: MAX_OUTPUT_SNAPSHOT_CHARS=256KB rolling FIFO buffer, sets truncated flag, strips ANSI/OSC control sequences. Test: automation-run-output-snapshot.test.ts.
- right-sidebar/fileExplorerUndoRedo.ts: MAX_STEPS=50, entry cap 16MB, aggregate cap 32MB; drops oldest past ops. Test: fileExplorerUndoRedo.test.ts.
- settings/mcp-config-inspection.ts: skips reading config files over MCP_CONFIG_INSPECTION_MAX_BYTES (constant in shared foundation slice). Test: mcp-config-inspection.test.ts.
- Concurrency (fan-out) caps via mapSettledWithConcurrency: GITLAB_REPO_FETCH_CONCURRENCY=8, PROJECT_GROUP_LOOKUP_CONCURRENCY=4, WORKSPACE_PORT_SCAN_CONCURRENCY=4, SOURCE_CONTROL_QUIESCE_CONCURRENCY=8, FILE_EXPLORER_REFRESH_CONCURRENCY=8, RUNTIME_ENVIRONMENT_REFRESH_CONCURRENCY=5, REPO_HOOK_PROBE_CONCURRENCY=4, SSH_TARGET_STATE_READ_CONCURRENCY=8, WORKTREE_META/LINEAGE_MUTATION_CONCURRENCY=8, CROSS_REPO_DELETE_CONCURRENCY=4, RUNTIME_HOST_CATALOG_FETCH_CONCURRENCY=4. Boundary tests: task-page-gitlab-fanout-boundary.test.ts, settings-repo-hook-fanout-boundary.test.ts, delete-worktree-parallel-flow.test.ts, github-item-dialog-source-boundary.test.ts, pull-request-page-host-boundary.test.ts.
- PullRequestPage.tsx / TaskPage.tsx wiring: COMBINED_DIFF_VIEW_STATE_CACHE_MAX_ENTRIES + retainCombinedDiffSectionText/retainCombinedDiffViewStateText release cached diff text for evicted files (bound constants live in editor foundation slice).

### Regressions
**Normal-path (ordinary use, below the new limits):** **none** — behavior is unchanged below the ceilings.

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Pending native-chat sends beyond 8 per pane/agent are dropped (oldest first) — only reachable if 9+ sends queue unconfirmed simultaneously.
- Model enrichment is silently skipped for new hosts while 8 discovery probes are in flight; retried on next render once a probe settles (count decremented in finally).
- Importing a custom pet is rejected once 16 loads are pending; blob cache refuses a new pet once 16 are actively retained or 128MB media is resident.
- Automation run output over 256KB is truncated to the most recent 256KB with a truncated indicator.
- File-explorer undo history is capped at 50 steps / 32MB aggregate; oldest undo steps expire silently.
- Combined-diff view-state/section text for files beyond the retention cap is released and re-derived when scrolled back into view (very large PRs/tasks only).
- Fan-out operations (repo fetch, port scan, worktree mutation, cross-repo delete, host reads) run at most 4-8 at a time — slower wall-clock only when the underlying set is large.
- Adding a 17th actively-displayed custom pet (or importing while 16 loads are pending) fails to render/import; cacheCustomPetBlobUrl returns false and the load queue rejects with 'Too many pending custom pet loads'. _(only when: User imports/displays more than 16 custom pets simultaneously, or queues >16 concurrent loads — far above ordinary use of a cosmetic feature.)_
- Sprite-frame auto-detection returns null (no frame overlay) for sprite sheets that decompose into more than MAX_CUSTOM_PET_DETECTED_FRAMES frames. _(only when: Pathologically large/noisy sprite sheet in an imported pet bundle.)_
- File-explorer undo cannot reach steps older than 50 (or beyond 32MB aggregate); very old undo entries silently expire. _(only when: More than 50 file-explorer mutations without undoing, or a single op over 16MB.)_

### Build / CI
- Part of the **Renderer** group; this group's cumulative tree is interlinked, so it becomes typecheck-green at its checkpoint **PR #29** (whole-repo interconnection — see stack README). Content is exact production code.
- ⚠️ **Merge-time reconciliation** with recent `main`:
  - `src/renderer/src/components/sidebar/WorktreeContextMenu.tsx`: TRUE CONFLICT with fix(worktree) #10266 (symlinked-create reconcile): keep both the worktree-identity reconcile and the OOM change.

### Adversarial review
- 2 skeptic lens(es). Sign-off: **yes**. Residual risk: **low**.
- Skeptical adversarial pass on PR #27 (B-renderer-components). I could NOT confirm any normal-path visible regression. All new ceilings sit far above ordinary use, and cleanup/release is correct.

Verified numeric ceilings and judged headroom:
- pet-blob-cache.ts: CUSTOM_PET_BLOB_CACHE_MAX=16 pets, CUSTOM_PET_MEDIA_CACHE_MAX_BYTES=128MB; custom-pet-load-queue.ts MAX_PENDING=16, MAX_CONCURRENT=2. Cosmetic feature; 17th simultaneously-displayed pet is far above ordinary use. cacheCustomPetBlobUrl returning false is tolerated by callers (gated on pending>=16). Overload-only.
- sprite-frame-detection.ts: returns null past MAX_CUSTOM_PET_DETECTED_FRAMES (shared limit) — pathological sprite sheets only.
- automation-run-output-snapshot.ts: MAX_OUTPUT_SNAPSHOT_CHARS=256KB rolling buffer with truncated flag. This is a SAVED snapshot artifact, and selectAutomationRunOutputSnapshot prefers the hook transcript (assistantMessage) when present; terminal snapshot is fallback. Keeps most-recent 256KB. Overload-only truncation of saved output.
- fileExplorerUndoRedo.ts: only new bounds are the 16MB/32MB byte caps (see boundsOrCleanupBugs); MAX_STEPS=50 pre-existed at BASE. Edge-only.
- native-chat-session-option-enrichment.ts: PENDING_MAX=8 in-flight per-host discovery probes, CACHE_MAX=128. CONFIRMED the pendingEnrichmentCount is decremented in BOTH the synchronous-throw catch AND the promise .finally, so the cap cannot get permanently stuck. Seed model is immediately usable; only background enrichment is deferred and retried on next render. Overload-only (users have few hosts).
- native-chat-pending.ts: PENDING_SEND_LIMIT=8 unconfirmed sends per pane, drops oldest. 9+ simultaneous unconfirmed sends is not ordinary. Overload-only.
- native-chat-composer-scope-cache.ts: 128 scopes / 32MB aggregate / 16MB value / 4KB key, global-LRU eviction of least-recently-touched scope. A user has a handful of composer scopes, not 128; LRU never fires in normal use. set() returns false only on oversized key/value/aggregate. Verified no active-draft eviction path in ordinary use.
- Concurrency caps are wall-clock-only, not correctness: GITLAB_REPO_FETCH_CONCURRENCY=8, PROJECT_GROUP_LOOKUP_CONCURRENCY=4, WORKSPACE_PORT_SCAN_CONCURRENCY=4, SOURCE_CONTROL_QUIESCE_CONCURRENCY=8, FILE_EXPLORER_REFRESH_CONCURRENCY=8, combined-diff load scheduler maxConcurrent=2 (GitHubItemDialog/PullRequestPage). These only slow wall-clock when the underlying set is large.
- Combined-diff section-text retention (GitHubItemDialog/PullRequestPage/TaskPage) wires retainCombinedDiffSectionText + createCombinedDiffLoadScheduler; the actual retention CAP lives in editor/combined-diff-text-retention.ts (a DIFFERENT slice), so it's out of scope here. Wiring evicts loaded-but-scrolled-away section text and re-derives on scroll-back — only reachable on very large PRs/tasks.

All caps ship with dedicated bound tests (custom-pet-load-queue.test.ts, pet-blob-cache.test.ts, fileExplorerUndoRedo.test.ts, native-chat-*.test.ts, automation-run-output-snapshot.test.ts, WorkspacePortScanner.test.tsx, useFileExplorerTree.test.ts, plus fanout-boundary tests). OOM evidence is real and corroborated. No off-by-one, no missing release on error/abort, no broken FIFO. Safe to open as a draft PR for human review.

### Files
58 files changed (+2300 / −840).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
