### PR TITLE
oom(29/29): bound web-renderer variants

### DIFF
--- a/src/renderer/src/web/web-e2ee.test.ts
+++ b/src/renderer/src/web/web-e2ee.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS } from '../../../shared/e2ee-crypto'
+import { decrypt, publicKeyFromBase64, WEB_E2EE_PUBLIC_KEY_MAX_BASE64_CHARACTERS } from './web-e2ee'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('web E2EE decode admission', () => {
+  it('rejects an oversized public key before base64 decoding', () => {
+    const atob = vi.fn(() => '')
+    vi.stubGlobal('window', { atob })
+
+    expect(() =>
+      publicKeyFromBase64('A'.repeat(WEB_E2EE_PUBLIC_KEY_MAX_BASE64_CHARACTERS + 1))
+    ).toThrow('encoded value is too large')
+    expect(atob).not.toHaveBeenCalled()
+  })
+
+  it('admits encrypted text at the boundary and rejects one extra character before decoding', () => {
+    const atob = vi.fn(() => '')
+    vi.stubGlobal('window', { atob })
+    const sharedKey = new Uint8Array(32)
+
+    expect(decrypt('A'.repeat(MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS), sharedKey)).toBeNull()
+    expect(atob).toHaveBeenCalledOnce()
+    atob.mockClear()
+
+    expect(decrypt('A'.repeat(MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS + 1), sharedKey)).toBeNull()
+    expect(atob).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/web/web-e2ee.ts
+++ b/src/renderer/src/web/web-e2ee.ts
@@ -1,4 +1,7 @@
 import nacl from 'tweetnacl'
+import { MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS } from '../../../shared/e2ee-crypto'
+
+export const WEB_E2EE_PUBLIC_KEY_MAX_BASE64_CHARACTERS = 44
 
 if (globalThis.crypto?.getRandomValues) {
   nacl.setPRNG((bytes, count) => {
@@ -15,6 +18,9 @@ export function deriveSharedKey(ourSecretKey: Uint8Array, peerPublicKey: Uint8Ar
 }
 
 export function publicKeyFromBase64(b64: string): Uint8Array {
+  if (b64.length > WEB_E2EE_PUBLIC_KEY_MAX_BASE64_CHARACTERS) {
+    throw new Error('Invalid public key: encoded value is too large')
+  }
   const key = base64ToBytes(b64)
   if (key.length !== 32) {
     throw new Error(`Invalid public key: expected 32 bytes, got ${key.length}`)
@@ -31,6 +37,9 @@ export function encrypt(plaintext: string, sharedKey: Uint8Array): string {
 }
 
 export function decrypt(encrypted: string, sharedKey: Uint8Array): string | null {
+  if (encrypted.length > MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS) {
+    return null
+  }
   const plaintext = decryptBytes(base64ToBytes(encrypted), sharedKey)
   return plaintext ? new TextDecoder().decode(plaintext) : null
 }

--- a/src/renderer/src/web/web-local-storage-json.test.ts
+++ b/src/renderer/src/web/web-local-storage-json.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  parseWebLocalStorageJson,
+  stringifyWebLocalStorageJson,
+  WEB_LOCAL_STORAGE_JSON_LIMITS,
+  type WebLocalStorageJsonLimits
+} from './web-local-storage-json'
+
+describe('browser-local JSON memory admission', () => {
+  it('preserves ordinary JSON serialization and parsing', () => {
+    const value = {
+      escaped: '\u0000\n',
+      nested: [1, true, null, { emoji: '🐋' }],
+      omitted: undefined
+    }
+    const serialized = JSON.stringify(value)
+
+    expect(stringifyWebLocalStorageJson(value)).toBe(serialized)
+    expect(parseWebLocalStorageJson(serialized)).toEqual(JSON.parse(serialized))
+  })
+
+  it('accepts exact UTF-8 bytes and rejects the next byte', () => {
+    const limits = createLimits({ maxBytes: 6 })
+
+    expect(parseWebLocalStorageJson('"🐋"', limits)).toBe('🐋')
+    expect(stringifyWebLocalStorageJson('🐋', limits)).toBe('"🐋"')
+    expect(() => parseWebLocalStorageJson('"🐋x"', limits)).toThrow(
+      'Browser-local JSON exceeds 6 bytes'
+    )
+    expect(() => stringifyWebLocalStorageJson('🐋x', limits)).toThrow(
+      'Browser-local JSON exceeds 6 bytes'
+    )
+  })
+
+  it('admits exact structure and depth while rejecting the next token or level', () => {
+    const structuralLimits = createLimits({ structuralTokens: 4 })
+    const depthLimits = createLimits({ nestingDepth: 3 })
+
+    expect(parseWebLocalStorageJson('[0,0,0]', structuralLimits)).toEqual([0, 0, 0])
+    expect(stringifyWebLocalStorageJson([0, 0, 0], structuralLimits)).toBe('[0,0,0]')
+    expect(() => parseWebLocalStorageJson('[0,0,0,0]', structuralLimits)).toThrow(
+      'JSON structure exceeds 4 tokens'
+    )
+    expect(() => stringifyWebLocalStorageJson([0, 0, 0, 0], structuralLimits)).toThrow(
+      'JSON structure exceeds 4 tokens'
+    )
+    expect(parseWebLocalStorageJson('[[[]]]', depthLimits)).toEqual([[[]]])
+    expect(() => parseWebLocalStorageJson('[[[[]]]]', depthLimits)).toThrow(
+      'JSON nesting exceeds 3 levels'
+    )
+  })
+
+  it('rejects amplified input before invoking JSON.parse', () => {
+    const parse = vi.spyOn(JSON, 'parse')
+
+    expect(() =>
+      parseWebLocalStorageJson('[0,0,0,0]', createLimits({ structuralTokens: 4 }))
+    ).toThrow('JSON structure exceeds 4 tokens')
+    expect(parse).not.toHaveBeenCalled()
+  })
+
+  it('stops output traversal once the byte limit is exceeded', () => {
+    const readAfter = vi.fn(() => 'late')
+    const value = {
+      payload: 'x'.repeat(100),
+      get after() {
+        return readAfter()
+      }
+    }
+
+    expect(() => stringifyWebLocalStorageJson(value, createLimits({ maxBytes: 32 }))).toThrow(
+      'Browser-local JSON exceeds 32 bytes'
+    )
+    expect(readAfter).not.toHaveBeenCalled()
+  })
+
+  it('keeps a finite default persistence envelope', () => {
+    expect(WEB_LOCAL_STORAGE_JSON_LIMITS).toEqual({
+      maxBytes: 8 * 1024 * 1024,
+      structuralTokens: 1_000_000,
+      nestingDepth: 128
+    })
+  })
+})
+
+function createLimits(overrides: Partial<WebLocalStorageJsonLimits>): WebLocalStorageJsonLimits {
+  return {
+    maxBytes: 1_000,
+    structuralTokens: 100,
+    nestingDepth: 10,
+    ...overrides
+  }
+}

--- a/src/renderer/src/web/web-local-storage-json.ts
+++ b/src/renderer/src/web/web-local-storage-json.ts
@@ -1,0 +1,64 @@
+import {
+  assertJsonTextStructureWithinLimits,
+  type JsonTextStructureLimits
+} from '../../../shared/json-text-structure-limit'
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
+import {
+  stringifyWebRuntimeOutboundJson,
+  WebRuntimeOutboundJsonLimitError
+} from './web-runtime-outbound-json'
+
+export type WebLocalStorageJsonLimits = JsonTextStructureLimits & {
+  maxBytes: number
+}
+
+export const WEB_LOCAL_STORAGE_JSON_LIMITS: WebLocalStorageJsonLimits = {
+  maxBytes: 8 * 1024 * 1024,
+  structuralTokens: 1_000_000,
+  nestingDepth: 128
+}
+
+export class WebLocalStorageJsonByteCapacityError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Browser-local JSON exceeds ${maxBytes} bytes`)
+    this.name = 'WebLocalStorageJsonByteCapacityError'
+  }
+}
+
+export function parseWebLocalStorageJson<T = unknown>(
+  content: string,
+  limits: WebLocalStorageJsonLimits = WEB_LOCAL_STORAGE_JSON_LIMITS
+): T {
+  assertWebLocalStorageJsonBytes(content, limits.maxBytes)
+  assertJsonTextStructureWithinLimits(content, limits)
+  return JSON.parse(content) as T
+}
+
+export function stringifyWebLocalStorageJson(
+  value: unknown,
+  limits: WebLocalStorageJsonLimits = WEB_LOCAL_STORAGE_JSON_LIMITS
+): string {
+  let serialized: string | undefined
+  try {
+    serialized = stringifyWebRuntimeOutboundJson(value, limits.maxBytes).serialized
+  } catch (error) {
+    if (error instanceof WebRuntimeOutboundJsonLimitError) {
+      throw new WebLocalStorageJsonByteCapacityError(limits.maxBytes)
+    }
+    throw error
+  }
+  if (serialized === undefined) {
+    throw new TypeError('Browser-local JSON value is not serializable')
+  }
+  assertJsonTextStructureWithinLimits(serialized, limits)
+  return serialized
+}
+
+function assertWebLocalStorageJsonBytes(content: string, maxBytes: number): void {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new RangeError('Browser-local JSON byte limit must be a positive safe integer')
+  }
+  if (measureUtf8ByteLength(content, { stopAfterBytes: maxBytes }).exceededLimit) {
+    throw new WebLocalStorageJsonByteCapacityError(maxBytes)
+  }
+}

--- a/src/renderer/src/web/web-pairing.test.ts
+++ b/src/renderer/src/web/web-pairing.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  PAIRING_CODE_MAX_CHARACTERS,
+  PAIRING_DEVICE_TOKEN_MAX_CHARACTERS,
+  PAIRING_ENDPOINT_MAX_CHARACTERS,
+  PAIRING_INPUT_MAX_CHARACTERS,
+  PAIRING_PUBLIC_KEY_MAX_CHARACTERS
+} from '../../../shared/mobile-relay-pairing-offer'
 import { decideWebPairingStartup, parseWebPairingInput, type WebPairingOffer } from './web-pairing'
 
 describe('web pairing input', () => {
@@ -49,6 +56,23 @@ describe('web pairing input', () => {
   it('rejects orca URLs outside the exact pairing route', () => {
     expect(parseWebPairingInput(`orca://pairing?code=${encodeOffer()}`)).toBeNull()
     expect(parseWebPairingInput(`orca://pair-extra?code=${encodeOffer()}`)).toBeNull()
+  })
+
+  it('rejects oversized input before base64 decoding', () => {
+    const atob = vi.spyOn(globalThis, 'atob')
+
+    expect(parseWebPairingInput('A'.repeat(PAIRING_INPUT_MAX_CHARACTERS + 1))).toBeNull()
+    expect(parseWebPairingInput('A'.repeat(PAIRING_CODE_MAX_CHARACTERS + 1))).toBeNull()
+    expect(atob).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ['endpoint', PAIRING_ENDPOINT_MAX_CHARACTERS],
+    ['deviceToken', PAIRING_DEVICE_TOKEN_MAX_CHARACTERS],
+    ['publicKeyB64', PAIRING_PUBLIC_KEY_MAX_CHARACTERS]
+  ] as const)('accepts %s at its limit and rejects one extra character', (field, limit) => {
+    expect(parseWebPairingInput(encodeOffer({ [field]: 'x'.repeat(limit) }))).not.toBeNull()
+    expect(parseWebPairingInput(encodeOffer({ [field]: 'x'.repeat(limit + 1) }))).toBeNull()
   })
 
   it('auto-saves scoped runtime offers during web startup', () => {

--- a/src/renderer/src/web/web-pairing.ts
+++ b/src/renderer/src/web/web-pairing.ts
@@ -1,4 +1,11 @@
 import type { DeviceScope } from '../../../shared/runtime-types'
+import {
+  PAIRING_CODE_MAX_CHARACTERS,
+  PAIRING_DEVICE_TOKEN_MAX_CHARACTERS,
+  PAIRING_ENDPOINT_MAX_CHARACTERS,
+  PAIRING_INPUT_MAX_CHARACTERS,
+  PAIRING_PUBLIC_KEY_MAX_CHARACTERS
+} from '../../../shared/mobile-relay-pairing-offer'
 
 const PAIRING_OFFER_VERSION = 2
 
@@ -16,6 +23,9 @@ export type WebPairingStartupDecision =
   | { kind: 'use-stored-environment' }
 
 export function parseWebPairingInput(input: string): WebPairingOffer | null {
+  if (input.length > PAIRING_INPUT_MAX_CHARACTERS) {
+    return null
+  }
   const trimmed = input.trim()
   if (!trimmed) {
     return null
@@ -33,6 +43,9 @@ export function parseWebPairingInput(input: string): WebPairingOffer | null {
 }
 
 export function readPairingInputFromLocation(location: Location): string | null {
+  if (location.search.length + location.hash.length > PAIRING_INPUT_MAX_CHARACTERS) {
+    return null
+  }
   const search = new URLSearchParams(location.search)
   for (const key of ['pairing', 'pair', 'code', 'token']) {
     const value = search.get(key)
@@ -85,16 +98,26 @@ export function clearPairingInputFromAddressBar(): void {
 }
 
 function decodePairingPayload(base64url: string): WebPairingOffer | null {
+  if (
+    base64url.length === 0 ||
+    base64url.length > PAIRING_CODE_MAX_CHARACTERS ||
+    !/^[A-Za-z0-9+/_-]+={0,2}$/.test(base64url)
+  ) {
+    return null
+  }
   const json = new TextDecoder().decode(base64UrlToBytes(base64url))
   const parsed = JSON.parse(json) as Partial<WebPairingOffer>
   if (
     parsed.v !== PAIRING_OFFER_VERSION ||
     typeof parsed.endpoint !== 'string' ||
     parsed.endpoint.length === 0 ||
+    parsed.endpoint.length > PAIRING_ENDPOINT_MAX_CHARACTERS ||
     typeof parsed.deviceToken !== 'string' ||
     parsed.deviceToken.length === 0 ||
+    parsed.deviceToken.length > PAIRING_DEVICE_TOKEN_MAX_CHARACTERS ||
     typeof parsed.publicKeyB64 !== 'string' ||
-    parsed.publicKeyB64.length === 0
+    parsed.publicKeyB64.length === 0 ||
+    parsed.publicKeyB64.length > PAIRING_PUBLIC_KEY_MAX_CHARACTERS
   ) {
     return null
   }

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -439,6 +439,21 @@ describe('web keybindings preload API', () => {
 
     unsubscribe()
   })
+
+  it('caps keybinding listeners and releases their storage handlers on reinstall', async () => {
+    const { api, window } = await installApi('Linux')
+    const { installWebPreloadApi, WEB_PRELOAD_MAX_KEYBINDING_LISTENERS } =
+      await import('./web-preload-api')
+    for (let index = 0; index < WEB_PRELOAD_MAX_KEYBINDING_LISTENERS; index += 1) {
+      api.keybindings.onChanged(vi.fn())
+    }
+
+    expect(() => api.keybindings.onChanged(vi.fn())).toThrow('listener capacity reached')
+    installWebPreloadApi()
+
+    expect(window.removeEventListener).toHaveBeenCalledTimes(WEB_PRELOAD_MAX_KEYBINDING_LISTENERS)
+    expect(() => window.api.keybindings.onChanged(vi.fn())).not.toThrow()
+  })
 })
 
 describe('web settings preload API', () => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -108,7 +108,9 @@ import {
 } from './web-runtime-environment'
 import { parseWebPairingInput } from './web-pairing'
 import { WebRuntimeClient } from './web-runtime-client'
+import { parseWebLocalStorageJson, stringifyWebLocalStorageJson } from './web-local-storage-json'
 import { RuntimeRpcCallQueuePool } from '../../../shared/runtime-rpc-call-queue'
+import { mapWithConcurrency } from '../../../shared/map-with-concurrency'
 import {
   assertClipboardTextWriteWithinLimitWithYield,
   assertClipboardTextWithinLimitWithYield,
@@ -123,6 +125,7 @@ import {
   assertClipboardImageDimensionsWithinLimit
 } from '../../../shared/clipboard-image'
 import { sanitizeWebRuntimeWorkspaceSession } from './web-workspace-session'
+import { WebPreloadRequestOwners } from './web-preload-request-owners'
 import {
   normalizeFeatureInteractions,
   type FeatureInteractionId,
@@ -145,12 +148,14 @@ const GITHUB_CACHE_STORAGE_KEY = 'orca.web.githubCache.v1'
 const KEYBINDINGS_STORAGE_KEY = 'orca.web.keybindings.v1'
 // Why: paired clients need parity for large dev sessions; the runtime default stays capped for lower-level RPC callers.
 const WEB_RUNTIME_WORKTREE_LIST_LIMIT = 10_000
+export const WEB_RUNTIME_REPO_DISCOVERY_CONCURRENCY = 8
 const MAX_CLIPBOARD_IMAGE_BASE64_CHARS = CLIPBOARD_IMAGE_MAX_BASE64_CHARS
 export const MAX_CLIPBOARD_IMAGE_SOURCE_BYTES = CLIPBOARD_IMAGE_MAX_SOURCE_BYTES
 export const MAX_CLIPBOARD_IMAGE_PIXELS = CLIPBOARD_IMAGE_MAX_PIXELS
 export const CLIPBOARD_IMAGE_UPLOAD_CHUNK_BASE64_CHARS = 512 * 1024
 export const CLIPBOARD_IMAGE_SINGLE_FRAME_FALLBACK_BASE64_CHARS = 256 * 1024
 const CLIPBOARD_IMAGE_SAVE_TIMEOUT_MS = 30_000
+export const WEB_PRELOAD_MAX_KEYBINDING_LISTENERS = 64
 
 let activeEnvironment: StoredWebRuntimeEnvironment | null = readStoredWebRuntimeEnvironment()
 let activeClient: WebRuntimeClient | null = null
@@ -474,9 +479,17 @@ export const GITLAB_WEB_RPC_METHODS = {
 } as const satisfies Record<WebGitLabRouteKey, WebGitLabRuntimeMethod>
 
 const WEB_KEYBINDING_PLATFORMS: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
-const webKeybindingListeners = new Set<(snapshot: KeybindingFileSnapshot) => void>()
+type WebKeybindingSubscription = {
+  target: Window
+  onStorage: (event: StorageEvent) => void
+}
+const webKeybindingSubscriptions = new Map<
+  (snapshot: KeybindingFileSnapshot) => void,
+  WebKeybindingSubscription
+>()
 
 export function installWebPreloadApi(): void {
+  disposeWebPreloadOwnedState()
   activeEnvironment = readStoredWebRuntimeEnvironment()
   const webWindow = window as unknown as { __ORCA_WEB_CLIENT__?: boolean }
   webWindow.__ORCA_WEB_CLIENT__ = true
@@ -1101,7 +1114,7 @@ function writeWebKeybindingAction(
 }
 
 function notifyWebKeybindingListeners(snapshot: KeybindingFileSnapshot): void {
-  for (const listener of webKeybindingListeners) {
+  for (const listener of webKeybindingSubscriptions.keys()) {
     listener(snapshot)
   }
 }
@@ -1119,18 +1132,41 @@ function createWebKeybindingsApi(): WebKeybindingsApi {
     openFile: () => Promise.resolve(getWebKeybindingSnapshot()),
     revealFile: () => Promise.resolve(getWebKeybindingSnapshot()),
     onChanged: (callback) => {
-      webKeybindingListeners.add(callback)
+      const existing = webKeybindingSubscriptions.get(callback)
+      if (existing) {
+        return () => releaseWebKeybindingSubscription(callback, existing)
+      }
+      if (webKeybindingSubscriptions.size >= WEB_PRELOAD_MAX_KEYBINDING_LISTENERS) {
+        throw new Error('Web keybinding listener capacity reached; remove a listener and retry.')
+      }
+      const target = window
       const onStorage = (event: StorageEvent): void => {
         if (event.key === KEYBINDINGS_STORAGE_KEY) {
           callback(getWebKeybindingSnapshot())
         }
       }
-      window.addEventListener('storage', onStorage)
-      return () => {
-        webKeybindingListeners.delete(callback)
-        window.removeEventListener('storage', onStorage)
-      }
+      const subscription = { target, onStorage }
+      webKeybindingSubscriptions.set(callback, subscription)
+      target.addEventListener('storage', onStorage)
+      return () => releaseWebKeybindingSubscription(callback, subscription)
     }
+  }
+}
+
+function releaseWebKeybindingSubscription(
+  callback: (snapshot: KeybindingFileSnapshot) => void,
+  expected: WebKeybindingSubscription
+): void {
+  if (webKeybindingSubscriptions.get(callback) !== expected) {
+    return
+  }
+  webKeybindingSubscriptions.delete(callback)
+  expected.target.removeEventListener('storage', expected.onStorage)
+}
+
+function disposeWebKeybindingSubscriptions(): void {
+  for (const [callback, subscription] of webKeybindingSubscriptions) {
+    releaseWebKeybindingSubscription(callback, subscription)
   }
 }
 
@@ -1763,16 +1799,14 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
 }
 
 // Why: track the in-flight abortable status request per token so cancelStatus can abort it and close its remote context.
-const webGitStatusAbortControllers = new Map<string, AbortController>()
+const webGitStatusRequestOwners = new WebPreloadRequestOwners()
 
 async function callAbortableRuntimeStatus<TResult>(
   requestToken: string,
   params: unknown
 ): Promise<TResult> {
   const environment = requireActiveEnvironment()
-  webGitStatusAbortControllers.get(requestToken)?.abort()
-  const controller = new AbortController()
-  webGitStatusAbortControllers.set(requestToken, controller)
+  const controller = webGitStatusRequestOwners.replace(requestToken)
   try {
     const response = await callAbortableRuntimeEnvironment(
       environment.id,
@@ -1787,9 +1821,7 @@ async function callAbortableRuntimeStatus<TResult>(
     }
     return response.result as TResult
   } finally {
-    if (webGitStatusAbortControllers.get(requestToken) === controller) {
-      webGitStatusAbortControllers.delete(requestToken)
-    }
+    webGitStatusRequestOwners.release(requestToken, controller)
   }
 }
 
@@ -1816,7 +1848,7 @@ function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
       return callAbortableRuntimeStatus(requestToken, params)
     },
     cancelStatus: async ({ requestToken }) => {
-      webGitStatusAbortControllers.get(requestToken)?.abort()
+      webGitStatusRequestOwners.abort(requestToken)
     },
     submoduleStatus: async ({ worktreePath, submodulePath, area }) => {
       const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
@@ -3275,10 +3307,16 @@ function getClientForEnvironment(environment: StoredWebRuntimeEnvironment): WebR
 }
 
 function closeActiveRuntimeClients(): void {
+  webGitStatusRequestOwners.abortAll()
   activeClient?.close()
   activeClient = null
   activeClientEnvironmentId = null
   invalidateRuntimeWorktreeCaches()
+}
+
+function disposeWebPreloadOwnedState(): void {
+  disposeWebKeybindingSubscriptions()
+  closeActiveRuntimeClients()
 }
 
 function disconnectActiveRuntimeEnvironment(): void {
@@ -3331,8 +3369,8 @@ function updateEnvironmentFromResponse(
 function getStoredSettings(): GlobalSettings {
   activeEnvironment = activeEnvironment ?? readStoredWebRuntimeEnvironment()
   const defaults = getDefaultSettings('~')
-  const rawStoredSettings = window.localStorage.getItem(SETTINGS_STORAGE_KEY)
-  const stored = readJson<Partial<GlobalSettings>>(SETTINGS_STORAGE_KEY, {})
+  const storedResult = readJsonWithMetadata<Partial<GlobalSettings>>(SETTINGS_STORAGE_KEY, {})
+  const stored = storedResult.value
   const migratedStored = {
     ...stored,
     ...normalizeAutoRenameBranchFromWorkDefaultOn(stored),
@@ -3341,7 +3379,7 @@ function getStoredSettings(): GlobalSettings {
     uiLanguage: normalizeUiLanguage(stored.uiLanguage)
   }
   if (
-    rawStoredSettings &&
+    storedResult.parsedPlainObject &&
     (stored.autoRenameBranchFromWork !== migratedStored.autoRenameBranchFromWork ||
       stored.autoRenameBranchFromWorkDefaultedOn !==
         migratedStored.autoRenameBranchFromWorkDefaultedOn ||
@@ -3351,14 +3389,7 @@ function getStoredSettings(): GlobalSettings {
       stored.terminalCustomThemes !== migratedStored.terminalCustomThemes ||
       stored.uiLanguage !== migratedStored.uiLanguage)
   ) {
-    try {
-      const parsed = JSON.parse(rawStoredSettings) as unknown
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        writeJson(SETTINGS_STORAGE_KEY, migratedStored)
-      }
-    } catch {
-      // Keep readJson's invalid-JSON fallback non-destructive.
-    }
+    writeJson(SETTINGS_STORAGE_KEY, migratedStored)
   }
   return mergeSettings(
     {
@@ -3725,10 +3756,10 @@ async function listAllRuntimeDetectedWorktrees(
 
   assertActiveEnvironment(expectedEnvironmentId)
   const repos = (await callResult<{ repos: Repo[] }>('repo.list')).repos
-  const detectedLists = await Promise.all(
-    repos.map((repo) =>
-      callRuntimeDetectedWorktrees(repo.id, expectedEnvironmentId, callResult, callEnvelope)
-    )
+  const detectedLists = await mapWithConcurrency(
+    repos,
+    WEB_RUNTIME_REPO_DISCOVERY_CONCURRENCY,
+    (repo) => callRuntimeDetectedWorktrees(repo.id, expectedEnvironmentId, callResult, callEnvelope)
   )
   const worktrees = detectedLists.flatMap((result) => result.worktrees)
   assertActiveEnvironment(expectedEnvironmentId)
@@ -3927,23 +3958,34 @@ function getBrowserPlatform(): NodeJS.Platform {
 }
 
 function readJson<T>(key: string, fallback: T): T {
+  return readJsonWithMetadata(key, fallback).value
+}
+
+function readJsonWithMetadata<T>(
+  key: string,
+  fallback: T
+): { value: T; parsedPlainObject: boolean } {
   const raw = window.localStorage.getItem(key)
   if (!raw) {
-    return cloneJson(fallback)
+    return { value: cloneJson(fallback), parsedPlainObject: false }
   }
   try {
-    return { ...cloneJson(fallback), ...JSON.parse(raw) } as T
+    const parsed = parseWebLocalStorageJson(raw)
+    return {
+      value: { ...cloneJson(fallback), ...(parsed as object) } as T,
+      parsedPlainObject: parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+    }
   } catch {
-    return cloneJson(fallback)
+    return { value: cloneJson(fallback), parsedPlainObject: false }
   }
 }
 
 function writeJson<T>(key: string, value: T): void {
-  window.localStorage.setItem(key, JSON.stringify(value))
+  window.localStorage.setItem(key, stringifyWebLocalStorageJson(value))
 }
 
 function cloneJson<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T
+  return parseWebLocalStorageJson<T>(stringifyWebLocalStorageJson(value))
 }
 
 function withFallback<T extends object>(target: T, path: string[]): T {

--- a/src/renderer/src/web/web-preload-request-owners.test.ts
+++ b/src/renderer/src/web/web-preload-request-owners.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WEB_PRELOAD_MAX_ABORTABLE_REQUESTS,
+  WEB_PRELOAD_MAX_REQUEST_TOKEN_BYTES,
+  WebPreloadRequestOwners
+} from './web-preload-request-owners'
+
+describe('web preload request owners', () => {
+  it('caps unique request tokens and recovers after release', () => {
+    const owners = new WebPreloadRequestOwners()
+    const first = owners.replace('request-0')
+    for (let index = 1; index < WEB_PRELOAD_MAX_ABORTABLE_REQUESTS; index += 1) {
+      owners.replace(`request-${index}`)
+    }
+
+    expect(() => owners.replace('overflow')).toThrow('capacity reached')
+    owners.release('request-0', first)
+    expect(() => owners.replace('recovered')).not.toThrow()
+  })
+
+  it('replaces same-token ownership without growing or letting stale cleanup win', () => {
+    const owners = new WebPreloadRequestOwners()
+    const first = owners.replace('stable')
+    const replacement = owners.replace('stable')
+
+    expect(first.signal.aborted).toBe(true)
+    expect(owners.size()).toBe(1)
+    owners.release('stable', first)
+    expect(owners.size()).toBe(1)
+    owners.release('stable', replacement)
+    expect(owners.size()).toBe(0)
+  })
+
+  it('bounds multibyte request tokens before retaining them', () => {
+    const owners = new WebPreloadRequestOwners()
+    const exact = 'é'.repeat(WEB_PRELOAD_MAX_REQUEST_TOKEN_BYTES / 2)
+
+    expect(() => owners.replace(exact)).not.toThrow()
+    expect(() => owners.replace(`${exact}x`)).toThrow(
+      `between 1 and ${WEB_PRELOAD_MAX_REQUEST_TOKEN_BYTES} UTF-8 bytes`
+    )
+  })
+
+  it('aborts and releases every owner on teardown', () => {
+    const owners = new WebPreloadRequestOwners()
+    const first = owners.replace('first')
+    const second = owners.replace('second')
+
+    owners.abortAll()
+
+    expect(first.signal.aborted).toBe(true)
+    expect(second.signal.aborted).toBe(true)
+    expect(owners.size()).toBe(0)
+  })
+})

--- a/src/renderer/src/web/web-preload-request-owners.ts
+++ b/src/renderer/src/web/web-preload-request-owners.ts
@@ -1,0 +1,49 @@
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
+
+export const WEB_PRELOAD_MAX_ABORTABLE_REQUESTS = 256
+export const WEB_PRELOAD_MAX_REQUEST_TOKEN_BYTES = 4 * 1024
+
+export class WebPreloadRequestOwners {
+  private readonly controllers = new Map<string, AbortController>()
+
+  replace(requestToken: string): AbortController {
+    const measured = measureUtf8ByteLength(requestToken, {
+      stopAfterBytes: WEB_PRELOAD_MAX_REQUEST_TOKEN_BYTES
+    })
+    if (requestToken.length === 0 || measured.exceededLimit) {
+      throw new Error(
+        `Web request token must be between 1 and ${WEB_PRELOAD_MAX_REQUEST_TOKEN_BYTES} UTF-8 bytes.`
+      )
+    }
+    const existing = this.controllers.get(requestToken)
+    if (!existing && this.controllers.size >= WEB_PRELOAD_MAX_ABORTABLE_REQUESTS) {
+      throw new Error('Web request capacity reached; wait for an active request to finish.')
+    }
+    existing?.abort()
+    const controller = new AbortController()
+    this.controllers.set(requestToken, controller)
+    return controller
+  }
+
+  abort(requestToken: string): void {
+    this.controllers.get(requestToken)?.abort()
+  }
+
+  release(requestToken: string, expected: AbortController): void {
+    if (this.controllers.get(requestToken) === expected) {
+      this.controllers.delete(requestToken)
+    }
+  }
+
+  abortAll(): void {
+    const controllers = [...this.controllers.values()]
+    this.controllers.clear()
+    for (const controller of controllers) {
+      controller.abort()
+    }
+  }
+
+  size(): number {
+    return this.controllers.size
+  }
+}

--- a/src/renderer/src/web/web-preload-runtime-discovery-concurrency.test.ts
+++ b/src/renderer/src/web/web-preload-runtime-discovery-concurrency.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>()
+
+  get length(): number {
+    return this.values.size
+  }
+
+  clear(): void {
+    this.values.clear()
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key)
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+}
+
+function installBrowserGlobals(): MemoryStorage {
+  const storage = new MemoryStorage()
+  vi.stubGlobal('window', {
+    localStorage: storage,
+    location: { protocol: 'http:', reload: vi.fn() },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  })
+  vi.stubGlobal('navigator', { userAgent: 'Linux', hardwareConcurrency: 8 })
+  return storage
+}
+
+function writeStoredRuntimeEnvironment(storage: Storage): void {
+  storage.setItem(
+    'orca.web.runtimeEnvironment.v1',
+    JSON.stringify({
+      id: 'web-env-1',
+      name: 'Test runtime',
+      createdAt: 1,
+      updatedAt: 1,
+      lastUsedAt: null,
+      runtimeId: null,
+      preferredEndpointId: 'ws-web-env-1',
+      endpoints: [
+        {
+          id: 'ws-web-env-1',
+          kind: 'websocket',
+          label: 'WebSocket',
+          endpoint: 'ws://127.0.0.1:1234',
+          deviceToken: 'token',
+          publicKeyB64: 'public-key'
+        }
+      ]
+    })
+  )
+}
+
+describe('web runtime repository discovery concurrency', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+    vi.doUnmock('./web-runtime-client')
+  })
+
+  it('resolves a 300-repository catalog without overflowing the shared RPC queue', async () => {
+    const repoCount = 300
+    let activeDetectedCalls = 0
+    let peakDetectedCalls = 0
+    let detectedCallCount = 0
+
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          if (method === 'repo.list') {
+            return Promise.resolve({
+              id: 'repo-list',
+              ok: true,
+              result: {
+                repos: Array.from({ length: repoCount }, (_, index) => ({
+                  id: `repo-${index}`
+                }))
+              },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          if (method === 'worktree.detectedList') {
+            const repoId = (params as { repo: string }).repo
+            const index = Number(repoId.slice('repo-'.length))
+            activeDetectedCalls += 1
+            detectedCallCount += 1
+            peakDetectedCalls = Math.max(peakDetectedCalls, activeDetectedCalls)
+            return Promise.resolve({
+              id: `detected-${index}`,
+              ok: true as const,
+              result: {
+                repoId,
+                authoritative: true,
+                worktrees: [
+                  {
+                    id: `worktree-${index}`,
+                    repoId,
+                    path: `/workspace/repo-${index}`
+                  }
+                ]
+              },
+              _meta: { runtimeId: 'runtime-1' }
+            }).finally(() => {
+              activeDetectedCalls -= 1
+            })
+          }
+          if (method === 'files.stat') {
+            return Promise.resolve({
+              id: 'file-stat',
+              ok: true,
+              result: { size: 1 },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          throw new Error(`Unexpected method: ${method}`)
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const storage = installBrowserGlobals()
+    writeStoredRuntimeEnvironment(storage)
+    const { installWebPreloadApi, WEB_RUNTIME_REPO_DISCOVERY_CONCURRENCY } =
+      await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(
+      window.api.fs.pathExists({ filePath: '/workspace/repo-299/file.txt' })
+    ).resolves.toBe(true)
+    expect(detectedCallCount).toBe(repoCount)
+    expect(peakDetectedCalls).toBe(WEB_RUNTIME_REPO_DISCOVERY_CONCURRENCY)
+  })
+})

--- a/src/renderer/src/web/web-runtime-client-memory-bounds.test.ts
+++ b/src/renderer/src/web/web-runtime-client-memory-bounds.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  WEB_RUNTIME_MAX_BINARY_FRAME_BYTES,
+  WEB_RUNTIME_MAX_CHILD_CLIENTS,
+  WEB_RUNTIME_MAX_CONNECTION_WAITERS,
+  WEB_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES,
+  WEB_RUNTIME_MAX_PENDING_REQUESTS,
+  WEB_RUNTIME_MAX_RPC_METHOD_BYTES,
+  WEB_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES,
+  WEB_RUNTIME_MAX_SUBSCRIPTIONS,
+  WebRuntimeClient
+} from './web-runtime-client'
+import { createWebRuntimeOutboundMemoryBudget } from './web-runtime-outbound-memory-budget'
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  readyState = FakeWebSocket.CONNECTING
+  bufferedAmount = 0
+  binaryType = 'arraybuffer'
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn()
+  send = vi.fn()
+}
+
+function createClient(): WebRuntimeClient {
+  return new WebRuntimeClient({
+    v: 2,
+    endpoint: 'ws://127.0.0.1:6768',
+    deviceToken: 'token',
+    publicKeyB64: Buffer.alloc(32).toString('base64')
+  })
+}
+
+function acceptedOutboundSend(): { accepted: true; queued: false; cancel: () => false } {
+  return { accepted: true, queued: false, cancel: () => false }
+}
+
+describe('WebRuntimeClient memory admission', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      atob: (value: string) => Buffer.from(value, 'base64').toString('binary'),
+      btoa: (value: string) => Buffer.from(value, 'binary').toString('base64')
+    })
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects connection fan-out after the waiter cap', async () => {
+    const client = createClient()
+    const waiting = Array.from({ length: WEB_RUNTIME_MAX_CONNECTION_WAITERS }, () =>
+      client.call('status.get').catch((error: unknown) => error)
+    )
+
+    await expect(client.call('status.get')).rejects.toThrow('client is busy')
+
+    client.close()
+    await Promise.all(waiting)
+  })
+
+  it('rejects request fan-out after the connected pending cap', async () => {
+    const client = createClient()
+    const internals = client as unknown as {
+      state: string
+      sendEncryptedSerialized: (serialized: string) => ReturnType<typeof acceptedOutboundSend>
+      pending: Map<string, unknown>
+    }
+    internals.state = 'connected'
+    vi.spyOn(internals, 'sendEncryptedSerialized').mockReturnValue(acceptedOutboundSend())
+    const pending = Array.from({ length: WEB_RUNTIME_MAX_PENDING_REQUESTS }, () =>
+      client.call('status.get').catch((error: unknown) => error)
+    )
+    await vi.waitFor(() => expect(internals.pending.size).toBe(WEB_RUNTIME_MAX_PENDING_REQUESTS))
+
+    await expect(client.call('status.get')).rejects.toThrow('client is busy')
+
+    client.close()
+    await Promise.all(pending)
+  })
+
+  it('caps active subscription records and child sockets', async () => {
+    const client = createClient()
+    const internals = client as unknown as {
+      state: string
+      subscriptions: Map<string, unknown>
+      childClients: Set<{ close: () => void }>
+      subscribeOnCurrentConnection: (
+        method: string,
+        params: unknown,
+        callbacks: { onResponse: () => void }
+      ) => Promise<unknown>
+    }
+    internals.state = 'connected'
+    for (let index = 0; index < WEB_RUNTIME_MAX_SUBSCRIPTIONS; index++) {
+      internals.subscriptions.set(`subscription-${index}`, {})
+    }
+
+    await expect(
+      internals.subscribeOnCurrentConnection('files.watch', {}, { onResponse: vi.fn() })
+    ).rejects.toThrow('client is busy')
+
+    internals.subscriptions.clear()
+    for (let index = 0; index < WEB_RUNTIME_MAX_CHILD_CLIENTS; index++) {
+      internals.childClients.add({ close: vi.fn() })
+    }
+    await expect(
+      client.subscribe('terminal.multiplex', {}, { onResponse: vi.fn() })
+    ).rejects.toThrow('client is busy')
+
+    client.close()
+  })
+
+  it('rejects an oversized Blob before copying it into an ArrayBuffer', async () => {
+    const client = createClient()
+    const onBinary = vi.fn()
+    const arrayBuffer = vi.fn()
+    const oversizedBlob = Object.create(Blob.prototype) as Blob
+    Object.defineProperties(oversizedBlob, {
+      size: { value: WEB_RUNTIME_MAX_BINARY_FRAME_BYTES + 1 },
+      arrayBuffer: { value: arrayBuffer }
+    })
+    const internals = client as unknown as {
+      state: string
+      sharedKey: Uint8Array
+      subscriptions: Map<string, { callbacks: { onBinary: typeof onBinary } }>
+      handleSocketMessage: (rawData: unknown) => Promise<void>
+    }
+    internals.state = 'connected'
+    internals.sharedKey = new Uint8Array(32)
+    internals.subscriptions.set('stream-1', { callbacks: { onBinary } })
+
+    await internals.handleSocketMessage(oversizedBlob)
+
+    expect(arrayBuffer).not.toHaveBeenCalled()
+    expect(onBinary).not.toHaveBeenCalled()
+    client.close()
+  })
+
+  it('bounds RPC method keys before they enter connection waiters', async () => {
+    const client = createClient()
+    const internals = client as unknown as { waiters: unknown[] }
+
+    await expect(client.call('x'.repeat(WEB_RUNTIME_MAX_RPC_METHOD_BYTES + 1))).rejects.toThrow(
+      'RPC method exceeds'
+    )
+    expect(internals.waiters).toHaveLength(0)
+    client.close()
+  })
+
+  it('accepts exact subscription parameters and releases their retained bytes', async () => {
+    const client = createClient()
+    const internals = client as unknown as {
+      state: string
+      sendEncryptedSerialized: (serialized: string) => ReturnType<typeof acceptedOutboundSend>
+      subscriptions: Map<string, unknown>
+      subscribeOnCurrentConnection: (
+        method: string,
+        params: unknown,
+        callbacks: { onResponse: () => void }
+      ) => Promise<{ unsubscribe: () => void }>
+    }
+    internals.state = 'connected'
+    vi.spyOn(internals, 'sendEncryptedSerialized').mockReturnValue(acceptedOutboundSend())
+    const handle = await internals.subscribeOnCurrentConnection(
+      'files.watch',
+      'x'.repeat(WEB_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES - 2),
+      { onResponse: vi.fn() }
+    )
+
+    expect(internals.subscriptions.size).toBe(1)
+    handle.unsubscribe()
+    expect(internals.subscriptions.size).toBe(0)
+    await expect(
+      internals.subscribeOnCurrentConnection(
+        'files.watch',
+        'x'.repeat(WEB_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES - 1),
+        { onResponse: vi.fn() }
+      )
+    ).rejects.toThrow('JSON payload exceeds')
+    expect(internals.subscriptions.size).toBe(0)
+    client.close()
+  })
+
+  it('does not retain a subscription when parameter serialization throws', async () => {
+    const client = createClient()
+    const cyclic: { self?: unknown } = {}
+    cyclic.self = cyclic
+    const internals = client as unknown as {
+      subscriptions: Map<string, unknown>
+      subscribeOnCurrentConnection: (
+        method: string,
+        params: unknown,
+        callbacks: { onResponse: () => void }
+      ) => Promise<unknown>
+    }
+
+    await expect(
+      internals.subscribeOnCurrentConnection('files.watch', cyclic, { onResponse: vi.fn() })
+    ).rejects.toThrow('circular')
+    expect(internals.subscriptions.size).toBe(0)
+    client.close()
+  })
+
+  it('releases a subscription when encryption fails after admission', async () => {
+    const client = createClient()
+    const internals = client as unknown as {
+      state: string
+      sharedKey: Uint8Array
+      ws: FakeWebSocket
+      subscriptions: Map<string, unknown>
+      subscribeOnCurrentConnection: (
+        method: string,
+        params: unknown,
+        callbacks: { onResponse: () => void }
+      ) => Promise<unknown>
+    }
+    internals.state = 'connected'
+    internals.sharedKey = new Uint8Array(32)
+    internals.ws.readyState = FakeWebSocket.OPEN
+    const runtimeWindow = window as unknown as { btoa: (value: string) => string }
+    runtimeWindow.btoa = () => {
+      throw new Error('encryption allocation failed')
+    }
+
+    await expect(
+      internals.subscribeOnCurrentConnection('files.watch', {}, { onResponse: vi.fn() })
+    ).rejects.toThrow('could not send the subscription')
+    expect(internals.subscriptions.size).toBe(0)
+    client.close()
+  })
+
+  it('closes an overloaded socket after the aggregate queued-frame cap', () => {
+    const budget = createWebRuntimeOutboundMemoryBudget({
+      maxBufferedBytes: 1,
+      maxQueuedBytes: 1_024,
+      maxQueuedFrames: 2
+    })
+    const client = new WebRuntimeClient(
+      {
+        v: 2,
+        endpoint: 'ws://127.0.0.1:6768',
+        deviceToken: 'token',
+        publicKeyB64: Buffer.alloc(32).toString('base64')
+      },
+      budget
+    )
+    const internals = client as unknown as {
+      state: string
+      sharedKey: Uint8Array
+      ws: FakeWebSocket
+      sendEncrypted: (message: unknown) => boolean
+    }
+    internals.state = 'connected'
+    internals.sharedKey = new Uint8Array(32)
+    internals.ws.readyState = FakeWebSocket.OPEN
+    internals.ws.bufferedAmount = 1
+
+    expect(internals.sendEncrypted({ value: 1 })).toBe(true)
+    expect(internals.sendEncrypted({ value: 2 })).toBe(true)
+    expect(internals.sendEncrypted({ value: 3 })).toBe(false)
+    expect(internals.ws).toBeNull()
+  })
+
+  it('closes before encrypting an oversized outbound binary frame', () => {
+    const client = createClient()
+    const internals = client as unknown as {
+      ws: FakeWebSocket | null
+      sendEncryptedBinary: (bytes: Uint8Array) => boolean
+    }
+    const socket = internals.ws!
+    socket.readyState = FakeWebSocket.OPEN
+    const oversized = {
+      byteLength: WEB_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES + 1
+    } as Uint8Array
+
+    expect(internals.sendEncryptedBinary(oversized)).toBe(false)
+    expect(socket.close).toHaveBeenCalledTimes(1)
+    expect(internals.ws).toBeNull()
+  })
+})

--- a/src/renderer/src/web/web-runtime-client.test.ts
+++ b/src/renderer/src/web/web-runtime-client.test.ts
@@ -12,6 +12,18 @@ import {
 } from '../../../shared/e2ee-crypto'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 
+type TestSubscriptionCallbacks = {
+  onResponse: (response: RuntimeRpcResponse<unknown>) => void
+}
+
+type SubscribePreparedForTest = (
+  method: string,
+  preparedInput: unknown,
+  releaseRetainedBytes: () => void,
+  callbacks: TestSubscriptionCallbacks,
+  options?: unknown
+) => Promise<{ unsubscribe: () => void; sendBinary: (bytes: Uint8Array) => void }>
+
 const fakeSockets: FakeWebSocket[] = []
 
 class FakeWebSocket {
@@ -89,6 +101,31 @@ describe('WebRuntimeClient', () => {
     client.close({ notifySubscriptions: false })
 
     expect(child.close).toHaveBeenCalledWith({ notifySubscriptions: false })
+  })
+
+  it('closes the socket when handshake JSON exceeds the nesting cap', async () => {
+    const client = new WebRuntimeClient({
+      v: 2,
+      endpoint: 'ws://127.0.0.1:6768',
+      deviceToken: 'token',
+      publicKeyB64: Buffer.alloc(32).toString('base64')
+    })
+    const socket = fakeSockets[0]!
+    const internals = client as unknown as {
+      state: 'handshaking'
+      sharedKey: Uint8Array
+      handleSocketMessage: (rawData: unknown, sourceWs?: WebSocket) => Promise<void>
+    }
+    internals.state = 'handshaking'
+    internals.sharedKey = new Uint8Array(32)
+
+    await internals.handleSocketMessage(
+      `${'['.repeat(129)}0${']'.repeat(129)}`,
+      socket as unknown as WebSocket
+    )
+
+    expect(socket.close).toHaveBeenCalledOnce()
+    client.close()
   })
 
   it('does not report locally closed subscriptions as remote closes', () => {
@@ -258,23 +295,24 @@ describe('WebRuntimeClient', () => {
     const handle = { unsubscribe: vi.fn(), sendBinary: vi.fn() }
     const internals = client as unknown as {
       childClients: Set<WebRuntimeClient>
-      subscribeOnCurrentConnection: WebRuntimeClient['subscribe']
+      subscribePreparedOnCurrentConnection: SubscribePreparedForTest
     }
-    const subscribeOnCurrentConnection = vi
-      .spyOn(internals, 'subscribeOnCurrentConnection')
+    const subscribePrepared = vi
+      .spyOn(internals, 'subscribePreparedOnCurrentConnection')
       .mockResolvedValue(handle)
     const onResponse = vi.fn()
 
     const subscription = await client.subscribe('files.watch', { worktree: 'wt-1' }, { onResponse })
 
-    expect(subscribeOnCurrentConnection).toHaveBeenCalledWith(
+    expect(subscribePrepared).toHaveBeenCalledWith(
       'files.watch',
-      { worktree: 'wt-1' },
+      expect.objectContaining({ paramsByteLength: 19, worktree: 'wt-1' }),
+      expect.any(Function),
       expect.objectContaining({ onResponse: expect.any(Function) }),
       undefined
     )
     expect(internals.childClients.size).toBe(0)
-    subscribeOnCurrentConnection.mock.calls[0]?.[2].onResponse({
+    subscribePrepared.mock.calls[0]?.[3].onResponse({
       id: 'watch',
       ok: true,
       streaming: true,
@@ -297,10 +335,10 @@ describe('WebRuntimeClient', () => {
     })
     const localHandle = { unsubscribe: vi.fn(), sendBinary: vi.fn() }
     const internals = client as unknown as {
-      subscribeOnCurrentConnection: WebRuntimeClient['subscribe']
+      subscribePreparedOnCurrentConnection: SubscribePreparedForTest
     }
-    const subscribeOnCurrentConnection = vi
-      .spyOn(internals, 'subscribeOnCurrentConnection')
+    const subscribePrepared = vi
+      .spyOn(internals, 'subscribePreparedOnCurrentConnection')
       .mockResolvedValue(localHandle)
     const unwatch = vi.spyOn(client, 'call').mockImplementation(() => {
       expect(localHandle.unsubscribe).not.toHaveBeenCalled()
@@ -314,7 +352,7 @@ describe('WebRuntimeClient', () => {
     const onResponse = vi.fn()
 
     const subscription = await client.subscribe('files.watch', { worktree: 'wt-1' }, { onResponse })
-    const wrappedCallbacks = subscribeOnCurrentConnection.mock.calls[0]?.[2]
+    const wrappedCallbacks = subscribePrepared.mock.calls[0]?.[3]
     wrappedCallbacks?.onResponse({
       id: 'watch',
       ok: true,
@@ -344,10 +382,10 @@ describe('WebRuntimeClient', () => {
     })
     const localHandle = { unsubscribe: vi.fn(), sendBinary: vi.fn() }
     const internals = client as unknown as {
-      subscribeOnCurrentConnection: WebRuntimeClient['subscribe']
+      subscribePreparedOnCurrentConnection: SubscribePreparedForTest
     }
-    const subscribeOnCurrentConnection = vi
-      .spyOn(internals, 'subscribeOnCurrentConnection')
+    const subscribePrepared = vi
+      .spyOn(internals, 'subscribePreparedOnCurrentConnection')
       .mockResolvedValue(localHandle)
     const unwatch = vi
       .spyOn(client, 'call')
@@ -370,7 +408,7 @@ describe('WebRuntimeClient', () => {
         { worktree: 'wt-1' },
         { onResponse: vi.fn() }
       )
-      const wrappedCallbacks = subscribeOnCurrentConnection.mock.calls[0]?.[2]
+      const wrappedCallbacks = subscribePrepared.mock.calls[0]?.[3]
       wrappedCallbacks?.onResponse({
         id: 'watch',
         ok: true,
@@ -396,7 +434,7 @@ describe('WebRuntimeClient', () => {
       await client.subscribe('files.watch', { worktree: 'wt-1' }, { onResponse: vi.fn() })
       expect(unwatch).toHaveBeenCalledTimes(2)
       expect(localHandle.unsubscribe).toHaveBeenCalledTimes(1)
-      expect(subscribeOnCurrentConnection).toHaveBeenCalledTimes(2)
+      expect(subscribePrepared).toHaveBeenCalledTimes(2)
     } finally {
       client.close()
       warn.mockRestore()
@@ -415,10 +453,10 @@ describe('WebRuntimeClient', () => {
       sendBinary: vi.fn()
     }))
     const internals = client as unknown as {
-      subscribeOnCurrentConnection: WebRuntimeClient['subscribe']
+      subscribePreparedOnCurrentConnection: SubscribePreparedForTest
     }
-    const subscribeOnCurrentConnection = vi
-      .spyOn(internals, 'subscribeOnCurrentConnection')
+    const subscribePrepared = vi
+      .spyOn(internals, 'subscribePreparedOnCurrentConnection')
       .mockResolvedValueOnce(handles[0])
       .mockResolvedValueOnce(handles[1])
       .mockResolvedValueOnce(handles[2])
@@ -445,7 +483,7 @@ describe('WebRuntimeClient', () => {
         { onResponse: vi.fn() }
       )
       for (const [index, subscriptionId] of ['watch-a', 'watch-b'].entries()) {
-        subscribeOnCurrentConnection.mock.calls[index]?.[2].onResponse({
+        subscribePrepared.mock.calls[index]?.[3].onResponse({
           id: subscriptionId,
           ok: true,
           streaming: true,
@@ -462,7 +500,7 @@ describe('WebRuntimeClient', () => {
       expect(unwatch).toHaveBeenCalledTimes(4)
       expect(handles[0].unsubscribe).toHaveBeenCalledTimes(1)
       expect(handles[1].unsubscribe).toHaveBeenCalledTimes(1)
-      expect(subscribeOnCurrentConnection).toHaveBeenCalledTimes(3)
+      expect(subscribePrepared).toHaveBeenCalledTimes(3)
     } finally {
       client.close()
       warn.mockRestore()
@@ -478,10 +516,10 @@ describe('WebRuntimeClient', () => {
     })
     const localHandle = { unsubscribe: vi.fn(), sendBinary: vi.fn() }
     const internals = client as unknown as {
-      subscribeOnCurrentConnection: WebRuntimeClient['subscribe']
+      subscribePreparedOnCurrentConnection: SubscribePreparedForTest
     }
-    const subscribeOnCurrentConnection = vi
-      .spyOn(internals, 'subscribeOnCurrentConnection')
+    const subscribePrepared = vi
+      .spyOn(internals, 'subscribePreparedOnCurrentConnection')
       .mockResolvedValue(localHandle)
     const unwatch = vi.spyOn(client, 'call').mockResolvedValue({
       id: 'unwatch',
@@ -492,7 +530,7 @@ describe('WebRuntimeClient', () => {
     const onResponse = vi.fn()
 
     const subscription = await client.subscribe('files.watch', { worktree: 'wt-1' }, { onResponse })
-    const wrappedCallbacks = subscribeOnCurrentConnection.mock.calls[0]?.[2]
+    const wrappedCallbacks = subscribePrepared.mock.calls[0]?.[3]
 
     subscription.unsubscribe()
     expect(unwatch).not.toHaveBeenCalled()
@@ -532,10 +570,10 @@ describe('WebRuntimeClient', () => {
     })
     const localHandle = { unsubscribe: vi.fn(), sendBinary: vi.fn() }
     const internals = client as unknown as {
-      subscribeOnCurrentConnection: WebRuntimeClient['subscribe']
+      subscribePreparedOnCurrentConnection: SubscribePreparedForTest
     }
-    const subscribeOnCurrentConnection = vi
-      .spyOn(internals, 'subscribeOnCurrentConnection')
+    const subscribePrepared = vi
+      .spyOn(internals, 'subscribePreparedOnCurrentConnection')
       .mockResolvedValue(localHandle)
     const unwatch = vi.spyOn(client, 'call').mockResolvedValue({
       id: 'unwatch',
@@ -558,7 +596,7 @@ describe('WebRuntimeClient', () => {
       await vi.advanceTimersByTimeAsync(300_000)
       expect(localHandle.unsubscribe).not.toHaveBeenCalled()
 
-      const wrappedCallbacks = subscribeOnCurrentConnection.mock.calls[0]?.[2]
+      const wrappedCallbacks = subscribePrepared.mock.calls[0]?.[3]
       wrappedCallbacks?.onResponse({
         id: 'watch',
         ok: true,
@@ -693,6 +731,11 @@ describe('WebRuntimeClient', () => {
     const internals = client as unknown as {
       waitForConnected: (timeoutMs?: number) => Promise<void>
       sendEncrypted: (message: unknown) => boolean
+      sendEncryptedSerialized: (serialized: string) => {
+        accepted: boolean
+        queued: boolean
+        cancel: () => boolean
+      }
       subscribeOnCurrentConnection: (
         method: string,
         params: unknown,
@@ -701,6 +744,11 @@ describe('WebRuntimeClient', () => {
       ) => Promise<{ unsubscribe: () => void }>
     }
     vi.spyOn(internals, 'waitForConnected').mockResolvedValue(undefined)
+    vi.spyOn(internals, 'sendEncryptedSerialized').mockReturnValue({
+      accepted: true,
+      queued: false,
+      cancel: () => false
+    })
     const sent: unknown[] = []
     vi.spyOn(internals, 'sendEncrypted').mockImplementation((message) => {
       sent.push(message)

--- a/src/renderer/src/web/web-runtime-client.ts
+++ b/src/renderer/src/web/web-runtime-client.ts
@@ -1,6 +1,13 @@
 /* eslint-disable max-lines -- Why: one transport boundary — E2EE WebSocket state machine, JSON-RPC routing, streaming, binary frame forwarding. */
 import type { RuntimeRpcResponse, RuntimeRpcSuccess } from '../../../shared/runtime-rpc-envelope'
 import { isKeepaliveFrame } from '../../../shared/runtime-rpc-envelope'
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
+import { MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS } from '../../../shared/e2ee-crypto'
+import {
+  createWsOutboundBackpressureQueue,
+  type WsOutboundEnqueueResult,
+  type WsOutboundBackpressureQueue
+} from '../../../shared/ws-outbound-backpressure-queue'
 import type { WebPairingOffer } from './web-pairing'
 import { installWindowVisibilityInterval } from '../lib/window-visibility-interval'
 import { withRemoteRuntimeTailscaleHint } from '../../../shared/remote-runtime-tailscale-hint'
@@ -14,6 +21,21 @@ import {
   publicKeyFromBase64,
   publicKeyToBase64
 } from './web-e2ee'
+import {
+  createWebRuntimeOutboundMemoryBudget,
+  WEB_RUNTIME_OUTBOUND_MAX_QUEUED_BYTES,
+  WEB_RUNTIME_OUTBOUND_MAX_QUEUED_FRAMES,
+  type WebRuntimeOutboundMemoryBudget,
+  type WebRuntimeOutboundSocketMemory
+} from './web-runtime-outbound-memory-budget'
+import {
+  stringifyWebRuntimeOutboundJson,
+  WebRuntimeOutboundJsonLimitError
+} from './web-runtime-outbound-json'
+import {
+  isWebRuntimeJsonStructureCapacityError,
+  parseWebRuntimeInboundJson
+} from './web-runtime-inbound-json'
 
 type WebRuntimeConnectionState =
   | 'disconnected'
@@ -23,6 +45,7 @@ type WebRuntimeConnectionState =
   | 'auth-failed'
 
 type PendingRequest = {
+  cancelQueuedFrame: () => boolean
   method: string
   resolve: (response: RuntimeRpcResponse<unknown>) => void
   reject: (error: Error) => void
@@ -41,9 +64,25 @@ type SubscriptionCallbacks = {
 type RuntimeSubscription = {
   id: string
   method: string
-  params: unknown
+  paramsJson: string | undefined
+  paramsByteLength: number
   callbacks: SubscriptionCallbacks
   needsReplay: boolean
+  releaseRetainedBytes: () => void
+  cancelQueuedFrame: () => boolean
+}
+
+type PreparedSubscriptionInput = {
+  paramsJson: string | undefined
+  paramsByteLength: number
+  retainedBytes: number
+  teardownKey: string
+  worktree: string
+}
+
+type WebRuntimeOutboundFrame = {
+  bytes: number
+  payload: string | Uint8Array<ArrayBuffer>
 }
 
 export type WebRuntimeSubscriptionHandle = {
@@ -66,6 +105,29 @@ const SHARED_CONNECTION_SUBSCRIPTION_METHODS = new Set(['files.watch'])
 const HEARTBEAT_INTERVAL_MS = 10_000
 const HEARTBEAT_IDLE_MS = 25_000
 const HEARTBEAT_PROBE_GRACE_MS = 20_000
+export const WEB_RUNTIME_MAX_CONNECTION_WAITERS = 256
+export const WEB_RUNTIME_MAX_PENDING_REQUESTS = 256
+export const WEB_RUNTIME_MAX_SUBSCRIPTIONS = 256
+export const WEB_RUNTIME_MAX_CHILD_CLIENTS = 64
+export const WEB_RUNTIME_MAX_BINARY_FRAME_BYTES = 64 * 1024 * 1024
+export const WEB_RUNTIME_MAX_ENCRYPTED_TEXT_FRAME_BYTES = MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS
+export const WEB_RUNTIME_MAX_OUTBOUND_JSON_BYTES = 4 * 1024 * 1024
+export const WEB_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES = 1024 * 1024
+export const WEB_RUNTIME_MAX_RPC_METHOD_BYTES = 8 * 1024
+export const WEB_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES = 8 * 1024 * 1024
+
+const WEB_RUNTIME_OUTBOUND_SOCKET_SOFT_CAP_BYTES = 8 * 1024 * 1024
+const WEB_RUNTIME_MAX_OUTBOUND_WIRE_FRAME_BYTES = WEB_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES + 64
+
+const WEB_RUNTIME_BUSY_MESSAGE = 'Remote Orca runtime client is busy; retry after requests finish.'
+const RPC_PARAMS_MEMBER_PREFIX = ',"params":'
+const cancelNothing = (): boolean => false
+const releaseNothing = (): void => undefined
+const REJECTED_OUTBOUND_ENQUEUE: WsOutboundEnqueueResult = {
+  accepted: false,
+  queued: false,
+  cancel: cancelNothing
+}
 
 export class WebRuntimeClient {
   private ws: WebSocket | null = null
@@ -89,8 +151,15 @@ export class WebRuntimeClient {
   private readonly childClients = new Set<WebRuntimeClient>()
   private readonly waiters: { resolve: () => void; reject: (error: Error) => void }[] = []
   private readonly serverPublicKey: Uint8Array
+  private outboundQueue: WsOutboundBackpressureQueue<WebRuntimeOutboundFrame> | null = null
+  private outboundSocketMemory: WebRuntimeOutboundSocketMemory | null = null
+  private activeCallAdmissions = 0
+  private pendingSubscriptionAdmissions = 0
 
-  constructor(private readonly pairing: WebPairingOffer) {
+  constructor(
+    private readonly pairing: WebPairingOffer,
+    private readonly outboundMemoryBudget: WebRuntimeOutboundMemoryBudget = createWebRuntimeOutboundMemoryBudget()
+  ) {
     this.serverPublicKey = publicKeyFromBase64(pairing.publicKeyB64)
     this.openConnection()
   }
@@ -100,21 +169,66 @@ export class WebRuntimeClient {
     params?: unknown,
     options?: { timeoutMs?: number }
   ): Promise<RuntimeRpcResponse<unknown>> {
-    await this.waitForConnected(options?.timeoutMs)
-    return new Promise((resolve, reject) => {
+    assertRpcMethodWithinLimit(method)
+    const releaseCallAdmission = this.claimCallAdmission()
+    let releasePreparedBytes: (() => void) | null = null
+    let serialized: string | undefined
+    try {
       const id = this.nextId()
-      const timeoutMs = options?.timeoutMs ?? REQUEST_TIMEOUT_MS
-      const timeout = window.setTimeout(() => {
-        this.pending.delete(id)
-        reject(new Error(`Request timed out: ${method}`))
-      }, timeoutMs)
-      this.pending.set(id, { method, resolve, reject, timeout })
-      if (!this.sendEncrypted({ id, deviceToken: this.pairing.deviceToken, method, params })) {
+      serialized = stringifyWebRuntimeOutboundJson(
+        { id, deviceToken: this.pairing.deviceToken, method, params },
+        WEB_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+      ).serialized
+      params = undefined
+      releasePreparedBytes = this.outboundMemoryBudget.claimPreparedRpcBytes(
+        retainedPreparedFrameBytes(serialized, method)
+      )
+      if (!releasePreparedBytes) {
+        throw new Error(WEB_RUNTIME_BUSY_MESSAGE)
+      }
+      await this.waitForConnected(options?.timeoutMs)
+      return await new Promise((resolve, reject) => {
+        if (this.pending.size >= WEB_RUNTIME_MAX_PENDING_REQUESTS) {
+          reject(new Error(WEB_RUNTIME_BUSY_MESSAGE))
+          return
+        }
+        const timeoutMs = options?.timeoutMs ?? REQUEST_TIMEOUT_MS
+        const pending: PendingRequest = {
+          cancelQueuedFrame: cancelNothing,
+          method,
+          resolve,
+          reject,
+          timeout: 0
+        }
+        const timeout = window.setTimeout(() => {
+          if (this.pending.get(id) !== pending) {
+            return
+          }
+          pending.cancelQueuedFrame()
+          this.pending.delete(id)
+          reject(new Error(`Request timed out: ${method}`))
+        }, timeoutMs)
+        pending.timeout = timeout
+        this.pending.set(id, pending)
+        const sent = serialized
+          ? this.sendEncryptedSerialized(serialized)
+          : REJECTED_OUTBOUND_ENQUEUE
+        serialized = undefined
+        pending.cancelQueuedFrame = sent.cancel
+        releasePreparedBytes?.()
+        releasePreparedBytes = null
+        if (sent.accepted) {
+          return
+        }
         this.pending.delete(id)
         window.clearTimeout(timeout)
-        reject(new Error('Remote Orca runtime is not connected.'))
-      }
-    })
+        reject(new Error('Remote Orca runtime could not send the request.'))
+      })
+    } finally {
+      serialized = undefined
+      releasePreparedBytes?.()
+      releaseCallAdmission()
+    }
   }
 
   async subscribe(
@@ -123,56 +237,97 @@ export class WebRuntimeClient {
     callbacks: SubscriptionCallbacks,
     options?: SubscribeOptions
   ): Promise<WebRuntimeSubscriptionHandle> {
-    if (SHARED_CONNECTION_SUBSCRIPTION_METHODS.has(method)) {
-      // Why: sharing the main socket for file watches avoids exhausting the server's WebSocket connection cap.
-      return this.subscribeSharedFileWatch(params, callbacks, options)
+    assertRpcMethodWithinLimit(method)
+    const sharedConnection = SHARED_CONNECTION_SUBSCRIPTION_METHODS.has(method)
+    if (!sharedConnection && this.childClients.size >= WEB_RUNTIME_MAX_CHILD_CLIENTS) {
+      throw new Error(WEB_RUNTIME_BUSY_MESSAGE)
     }
-    const client = new WebRuntimeClient(this.pairing)
-    this.childClients.add(client)
-    const closeChild = (notifySubscriptions = false): void => {
-      this.childClients.delete(client)
-      client.close({ notifySubscriptions })
-    }
+    const releaseAdmission = this.claimSubscriptionAdmission()
+    let releaseRetainedBytes: (() => void) | null = null
+    let ownershipTransferred = false
     try {
+      const preparedInput = prepareSubscriptionInput(method, params)
+      params = undefined
+      releaseRetainedBytes = this.outboundMemoryBudget.claimSubscriptionBytes(
+        preparedInput.retainedBytes
+      )
+      if (!releaseRetainedBytes) {
+        throw new Error(WEB_RUNTIME_BUSY_MESSAGE)
+      }
+      if (sharedConnection) {
+        // Why: sharing the main socket for file watches avoids exhausting the server's WebSocket connection cap.
+        const handle = await this.subscribeSharedFileWatch(
+          preparedInput,
+          releaseRetainedBytes,
+          callbacks,
+          options
+        )
+        ownershipTransferred = true
+        return handle
+      }
+      const client = new WebRuntimeClient(this.pairing, this.outboundMemoryBudget)
+      this.childClients.add(client)
+      const closeChild = (notifySubscriptions = false): void => {
+        this.childClients.delete(client)
+        client.close({ notifySubscriptions })
+      }
       const wrappedCallbacks: SubscriptionCallbacks = {
         ...callbacks,
         onError: (error) => {
-          callbacks.onError?.(error)
           closeChild()
+          invokeConsumerCallback(() => callbacks.onError?.(error))
         },
         onClose: () => {
-          callbacks.onClose?.()
           closeChild()
+          invokeConsumerCallback(() => callbacks.onClose?.())
         }
       }
-      const handle = await client.subscribeOnCurrentConnection(
-        method,
-        params,
-        wrappedCallbacks,
-        options
-      )
+      let handle: WebRuntimeSubscriptionHandle
+      try {
+        handle = await client.subscribePreparedOnCurrentConnection(
+          method,
+          preparedInput,
+          releaseRetainedBytes,
+          wrappedCallbacks,
+          options
+        )
+      } catch (error) {
+        closeChild()
+        throw error
+      }
+      ownershipTransferred = true
+      preparedInput.paramsJson = undefined
+      preparedInput.teardownKey = ''
       return {
         unsubscribe: () => {
           // Why: emit the teardown RPC before closing the child socket so the server reaps the fs-watcher on view-toggle.
-          handle.unsubscribe()
-          closeChild()
+          try {
+            handle.unsubscribe()
+          } finally {
+            closeChild()
+          }
         },
         sendBinary: (bytes) => handle.sendBinary(bytes)
       }
-    } catch (error) {
-      closeChild()
-      throw error
+    } finally {
+      if (!ownershipTransferred) {
+        releaseRetainedBytes?.()
+      }
+      releaseAdmission()
     }
   }
 
   private async subscribeSharedFileWatch(
-    params: unknown,
+    preparedInput: PreparedSubscriptionInput,
+    releaseRetainedBytes: () => void,
     callbacks: SubscriptionCallbacks,
     options?: { timeoutMs?: number }
   ): Promise<WebRuntimeSubscriptionHandle> {
-    const teardownKey = JSON.stringify(params) ?? String(params)
+    const initialTeardownKey = preparedInput.teardownKey
+    let teardownKey: string | null = initialTeardownKey
+    const worktree = preparedInput.worktree
     await Promise.all(
-      Array.from(this.fileWatchTeardownRetries.get(teardownKey) ?? [], (retry) => retry())
+      Array.from(this.fileWatchTeardownRetries.get(initialTeardownKey) ?? [], (retry) => retry())
     )
     let stopped = false
     let remoteSubscriptionId: string | null = null
@@ -198,12 +353,14 @@ export class WebRuntimeClient {
           if (response.ok === false) {
             throw new Error(`${response.error.code}: ${response.error.message}`)
           }
-          const retries = this.fileWatchTeardownRetries.get(teardownKey)
+          const key = teardownKey
+          const retries = key ? this.fileWatchTeardownRetries.get(key) : undefined
           retries?.delete(retryRemoteUnwatch)
           if (retries?.size === 0) {
-            this.fileWatchTeardownRetries.delete(teardownKey)
+            this.fileWatchTeardownRetries.delete(key!)
           }
           dropLocalSubscription()
+          teardownKey = null
         })
         .catch((error: unknown) => {
           console.warn('Failed to unwatch remote file subscription:', error)
@@ -225,9 +382,14 @@ export class WebRuntimeClient {
         return
       }
       // Why: retain the callback and retry until the server acks physical teardown; a new watch joins this barrier.
-      const retries = this.fileWatchTeardownRetries.get(teardownKey) ?? new Set()
+      const key = teardownKey
+      if (!key) {
+        dropLocalSubscription()
+        return
+      }
+      const retries = this.fileWatchTeardownRetries.get(key) ?? new Set()
       retries.add(retryRemoteUnwatch)
-      this.fileWatchTeardownRetries.set(teardownKey, retries)
+      this.fileWatchTeardownRetries.set(key, retries)
       void retryRemoteUnwatch().catch(() => {})
     }
     const wrappedCallbacks: SubscriptionCallbacks = {
@@ -247,11 +409,13 @@ export class WebRuntimeClient {
           return
         }
         if (!stopped) {
-          callbacks.onResponse(response)
+          invokeConsumerCallback(() => callbacks.onResponse(response))
           if (pendingReplayResync && nextSubscriptionId && response.ok) {
             pendingReplayResync = false
             // Why: a replayed watch only reports events after its own setup, so consumers must re-scan the reconnect gap.
-            callbacks.onResponse(createFileWatchReplayOverflowResponse(response, params))
+            invokeConsumerCallback(() =>
+              callbacks.onResponse(createFileWatchReplayOverflowResponse(response, worktree))
+            )
           }
         } else if (response.ok === false) {
           dropLocalSubscription()
@@ -259,12 +423,12 @@ export class WebRuntimeClient {
       },
       onError: (error) => {
         if (!stopped) {
-          callbacks.onError?.(error)
+          invokeConsumerCallback(() => callbacks.onError?.(error))
         }
       },
       onClose: () => {
         if (!stopped) {
-          callbacks.onClose?.()
+          invokeConsumerCallback(() => callbacks.onClose?.())
         }
       },
       onTransportInterrupted: () => {
@@ -273,25 +437,30 @@ export class WebRuntimeClient {
         if (!stopped) {
           return
         }
-        const retries = this.fileWatchTeardownRetries.get(teardownKey)
+        const key = teardownKey
+        const retries = key ? this.fileWatchTeardownRetries.get(key) : undefined
         retries?.delete(retryRemoteUnwatch)
         if (retries?.size === 0) {
-          this.fileWatchTeardownRetries.delete(teardownKey)
+          this.fileWatchTeardownRetries.delete(key!)
         }
         // Why: socket close physically releases the server subscription — a stopped watch must not replay on the replacement.
         dropLocalSubscription()
+        teardownKey = null
       },
       onTransportReplayed: () => {
         transportInterrupted = false
         pendingReplayResync = true
       }
     }
-    handle = await this.subscribeOnCurrentConnection(
+    handle = await this.subscribePreparedOnCurrentConnection(
       'files.watch',
-      params,
+      preparedInput,
+      releaseRetainedBytes,
       wrappedCallbacks,
       options
     )
+    preparedInput.paramsJson = undefined
+    preparedInput.teardownKey = ''
 
     return {
       unsubscribe: () => {
@@ -311,25 +480,88 @@ export class WebRuntimeClient {
     }
   }
 
-  private async subscribeOnCurrentConnection(
+  protected async subscribeOnCurrentConnection(
     method: string,
     params: unknown,
     callbacks: SubscriptionCallbacks,
     options?: SubscribeOptions
   ): Promise<WebRuntimeSubscriptionHandle> {
+    assertRpcMethodWithinLimit(method)
+    const releaseAdmission = this.claimSubscriptionAdmission()
+    let releaseRetainedBytes: (() => void) | null = null
+    let ownershipTransferred = false
+    try {
+      const preparedInput = prepareSubscriptionInput(method, params)
+      params = undefined
+      releaseRetainedBytes = this.outboundMemoryBudget.claimSubscriptionBytes(
+        preparedInput.retainedBytes
+      )
+      if (!releaseRetainedBytes) {
+        throw new Error(WEB_RUNTIME_BUSY_MESSAGE)
+      }
+      const handle = await this.subscribePreparedOnCurrentConnection(
+        method,
+        preparedInput,
+        releaseRetainedBytes,
+        callbacks,
+        options
+      )
+      ownershipTransferred = true
+      preparedInput.paramsJson = undefined
+      preparedInput.teardownKey = ''
+      return handle
+    } finally {
+      if (!ownershipTransferred) {
+        releaseRetainedBytes?.()
+      }
+      releaseAdmission()
+    }
+  }
+
+  private async subscribePreparedOnCurrentConnection(
+    method: string,
+    preparedInput: PreparedSubscriptionInput,
+    releaseRetainedBytes: () => void,
+    callbacks: SubscriptionCallbacks,
+    options?: SubscribeOptions
+  ): Promise<WebRuntimeSubscriptionHandle> {
     await this.waitForConnected(options?.timeoutMs)
+    if (this.subscriptions.size >= WEB_RUNTIME_MAX_SUBSCRIPTIONS) {
+      throw new Error(WEB_RUNTIME_BUSY_MESSAGE)
+    }
     const id = this.nextId()
-    const subscription: RuntimeSubscription = { id, method, params, callbacks, needsReplay: false }
+    const serialized = serializePreparedRpcFrame({
+      id,
+      deviceToken: this.pairing.deviceToken,
+      method,
+      paramsJson: preparedInput.paramsJson,
+      paramsByteLength: preparedInput.paramsByteLength
+    })
+    const subscription: RuntimeSubscription = {
+      id,
+      method,
+      paramsJson: preparedInput.paramsJson,
+      paramsByteLength: preparedInput.paramsByteLength,
+      callbacks,
+      needsReplay: false,
+      releaseRetainedBytes,
+      cancelQueuedFrame: cancelNothing
+    }
     this.subscriptions.set(id, subscription)
-    if (!this.sendEncrypted({ id, deviceToken: this.pairing.deviceToken, method, params })) {
-      this.subscriptions.delete(id)
-      throw new Error('Remote Orca runtime is not connected.')
+    const sent = this.sendEncryptedSerialized(serialized)
+    subscription.cancelQueuedFrame = sent.cancel
+    if (!sent.accepted) {
+      this.removeSubscription(id, subscription)
+      throw new Error('Remote Orca runtime could not send the subscription.')
     }
     return {
       unsubscribe: () => {
-        this.subscriptions.delete(subscription.id)
+        const paramsJson = subscription.paramsJson
+        if (!this.removeSubscription(subscription.id, subscription)) {
+          return
+        }
         // Tell the server to reap its keyed cleanup before the socket closes; best-effort (a closed socket already reaps).
-        const teardown = options?.buildUnsubscribe?.(params)
+        const teardown = options?.buildUnsubscribe?.(parseSerializedParams(paramsJson))
         if (teardown) {
           this.sendEncrypted({
             id: this.nextId(),
@@ -348,25 +580,36 @@ export class WebRuntimeClient {
   close(options: { notifySubscriptions?: boolean } = {}): void {
     const shouldNotifySubscriptions = options.notifySubscriptions ?? true
     this.intentionallyClosed = true
-    for (const child of Array.from(this.childClients)) {
-      child.close({ notifySubscriptions: shouldNotifySubscriptions })
-    }
+    const children = Array.from(this.childClients)
     this.childClients.clear()
     this.fileWatchTeardownRetries.clear()
     this.clearTimers()
+    const ws = this.ws
+    this.ws = null
+    this.sharedKey = null
+    this.disposeOutboundTransport()
+    if (ws) {
+      try {
+        ws.close()
+      } catch {
+        // The client is already detached; a browser close failure must not retain transport state.
+      }
+    }
     this.rejectAllPending('Remote Orca runtime connection closed.')
     this.rejectAllWaiters(new Error('Remote Orca runtime connection closed.'))
+    this.setState('disconnected')
+    for (const child of children) {
+      try {
+        child.close({ notifySubscriptions: shouldNotifySubscriptions })
+      } catch {
+        // Continue closing sibling transports even if one child cleanup fails.
+      }
+    }
     if (shouldNotifySubscriptions) {
       this.notifySubscriptionsClosed()
     } else {
-      this.subscriptions.clear()
+      this.clearSubscriptions()
     }
-    if (this.ws) {
-      this.ws.close()
-      this.ws = null
-    }
-    this.sharedKey = null
-    this.setState('disconnected')
   }
 
   private openConnection(): void {
@@ -378,6 +621,15 @@ export class WebRuntimeClient {
       ws = new WebSocket(this.pairing.endpoint)
     } catch (error) {
       this.rejectAllPending(error instanceof Error ? error.message : String(error))
+      this.scheduleReconnect()
+      return
+    }
+    try {
+      this.outboundSocketMemory = this.outboundMemoryBudget.registerBufferedAmount(
+        () => ws.bufferedAmount
+      )
+    } catch {
+      ws.close()
       this.scheduleReconnect()
       return
     }
@@ -402,6 +654,7 @@ export class WebRuntimeClient {
       this.setState('handshaking')
       const keyPair = generateKeyPair()
       this.sharedKey = deriveSharedKey(keyPair.secretKey, this.serverPublicKey)
+      this.ensureOutboundQueue(ws)
       ws.send(
         JSON.stringify({
           type: 'e2ee_hello',
@@ -443,17 +696,28 @@ export class WebRuntimeClient {
 
   private async handleSocketMessage(rawData: unknown, sourceWs?: WebSocket): Promise<void> {
     const raw = typeof rawData === 'string' ? rawData : null
+    if (raw !== null && raw.length > WEB_RUNTIME_MAX_ENCRYPTED_TEXT_FRAME_BYTES) {
+      const offendingSocket = sourceWs ?? this.ws
+      if (offendingSocket) {
+        this.failOutboundSocket(offendingSocket)
+      }
+      return
+    }
     if (this.state === 'handshaking') {
       if (raw === null || !this.sharedKey) {
         return
       }
       try {
-        const control = JSON.parse(raw) as { type?: unknown }
+        const control = parseWebRuntimeInboundJson<{ type?: unknown }>(raw)
         if (control.type === 'e2ee_ready') {
           this.sendEncrypted({ type: 'e2ee_auth', deviceToken: this.pairing.deviceToken })
           return
         }
-      } catch {
+      } catch (error) {
+        if (isWebRuntimeJsonStructureCapacityError(error)) {
+          this.failInboundJsonCapacity(sourceWs)
+          return
+        }
         // The authenticated control frame is encrypted, so non-JSON is normal here.
       }
 
@@ -462,22 +726,22 @@ export class WebRuntimeClient {
         return
       }
       try {
-        const control = JSON.parse(plaintext) as {
+        const control = parseWebRuntimeInboundJson<{
           type?: unknown
           error?: { code?: string; message?: string }
-        }
+        }>(plaintext)
         if (control.type === 'e2ee_authenticated') {
           this.clearHandshakeTimer()
           this.reconnectAttempt = 0
           this.setState('connected')
         } else if (control.type === 'e2ee_error' || control.error?.code === 'unauthorized') {
-          this.intentionallyClosed = true
-          this.setState('auth-failed')
-          this.rejectAllPending('Unauthorized. Pair this web client again.')
-          this.notifySubscriptionsError('unauthorized', 'Unauthorized. Pair this web client again.')
-          this.ws?.close()
+          this.handleAuthenticationFailure()
         }
-      } catch {
+      } catch (error) {
+        if (isWebRuntimeJsonStructureCapacityError(error)) {
+          this.failInboundJsonCapacity(sourceWs)
+          return
+        }
         // Ignore malformed handshake payloads; the server will close on timeout.
       }
       return
@@ -499,8 +763,8 @@ export class WebRuntimeClient {
       if (!plaintext) {
         return
       }
-      for (const subscription of this.subscriptions.values()) {
-        subscription.callbacks.onBinary?.(plaintext)
+      for (const subscription of Array.from(this.subscriptions.values())) {
+        invokeConsumerCallback(() => subscription.callbacks.onBinary?.(plaintext))
       }
       return
     }
@@ -512,8 +776,13 @@ export class WebRuntimeClient {
 
     let response: RuntimeRpcResponse<unknown> | Record<string, unknown>
     try {
-      response = JSON.parse(plaintext) as RuntimeRpcResponse<unknown> | Record<string, unknown>
-    } catch {
+      response = parseWebRuntimeInboundJson<RuntimeRpcResponse<unknown> | Record<string, unknown>>(
+        plaintext
+      )
+    } catch (error) {
+      if (isWebRuntimeJsonStructureCapacityError(error)) {
+        this.failInboundJsonCapacity(sourceWs)
+      }
       return
     }
     if (isKeepaliveFrame(response)) {
@@ -523,26 +792,23 @@ export class WebRuntimeClient {
       return
     }
     if (isRuntimeFailureResponse(response) && response.error.code === 'unauthorized') {
-      this.intentionallyClosed = true
-      this.setState('auth-failed')
-      this.rejectAllPending('Unauthorized. Pair this web client again.')
-      this.notifySubscriptionsError('unauthorized', 'Unauthorized. Pair this web client again.')
-      this.ws?.close()
+      this.handleAuthenticationFailure()
       return
     }
 
     const subscription = this.subscriptions.get(response.id)
     if (subscription) {
       const subscriptionResponse = response as RuntimeRpcResponse<unknown>
-      // Why: setup failures must be evicted before callbacks so reconnect cannot replay them.
-      if (subscriptionResponse.ok === false) {
-        this.subscriptions.delete(response.id)
+      subscription.cancelQueuedFrame = cancelNothing
+      const ended = subscriptionResponse.ok && isEndResult(subscriptionResponse.result)
+      // Why: terminal subscriptions must release replay payloads before consumer code can throw or reconnect.
+      if (subscriptionResponse.ok === false || ended) {
+        this.removeSubscription(response.id, subscription)
       }
       // Why: subscription-backed unary RPCs can return ordinary success frames.
-      subscription.callbacks.onResponse(subscriptionResponse)
-      if (subscriptionResponse.ok && isEndResult(subscriptionResponse.result)) {
-        this.subscriptions.delete(response.id)
-        subscription.callbacks.onClose?.()
+      invokeConsumerCallback(() => subscription.callbacks.onResponse(subscriptionResponse))
+      if (ended) {
+        invokeConsumerCallback(() => subscription.callbacks.onClose?.())
       }
       return
     }
@@ -551,27 +817,61 @@ export class WebRuntimeClient {
     if (!pending) {
       return
     }
+    pending.cancelQueuedFrame()
+    pending.cancelQueuedFrame = cancelNothing
     this.pending.delete(response.id)
     window.clearTimeout(pending.timeout)
     pending.resolve(response as RuntimeRpcResponse<unknown>)
   }
 
   private sendEncrypted(message: unknown): boolean {
-    const ws = this.ws
-    if (!ws || ws.readyState !== WebSocket.OPEN || !this.sharedKey) {
+    try {
+      const { serialized } = stringifyWebRuntimeOutboundJson(
+        message,
+        WEB_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+      )
+      return serialized !== undefined && this.sendEncryptedSerialized(serialized).accepted
+    } catch {
       return false
     }
-    ws.send(encrypt(JSON.stringify(message), this.sharedKey))
-    return true
+  }
+
+  private sendEncryptedSerialized(serialized: string): WsOutboundEnqueueResult {
+    const ws = this.ws
+    if (!ws || ws.readyState !== WebSocket.OPEN || !this.sharedKey) {
+      return REJECTED_OUTBOUND_ENQUEUE
+    }
+    const queue = this.ensureOutboundQueue(ws)
+    if (!queue) {
+      return REJECTED_OUTBOUND_ENQUEUE
+    }
+    try {
+      const payload = encrypt(serialized, this.sharedKey)
+      return queue.enqueueCancelable({ payload, bytes: payload.length })
+    } catch {
+      return REJECTED_OUTBOUND_ENQUEUE
+    }
   }
 
   private sendEncryptedBinary(bytes: Uint8Array<ArrayBufferLike>): boolean {
     const ws = this.ws
+    if (ws && bytes.byteLength > WEB_RUNTIME_MAX_OUTBOUND_BINARY_FRAME_BYTES) {
+      this.failOutboundSocket(ws)
+      return false
+    }
     if (!ws || ws.readyState !== WebSocket.OPEN || !this.sharedKey) {
       return false
     }
-    ws.send(encryptBytes(bytes, this.sharedKey))
-    return true
+    const queue = this.ensureOutboundQueue(ws)
+    if (!queue) {
+      return false
+    }
+    try {
+      const payload = encryptBytes(bytes, this.sharedKey)
+      return queue.enqueue({ payload, bytes: payload.byteLength })
+    } catch {
+      return false
+    }
   }
 
   private waitForConnected(timeoutMs = REQUEST_TIMEOUT_MS): Promise<void> {
@@ -583,6 +883,9 @@ export class WebRuntimeClient {
     }
     if (this.intentionallyClosed) {
       return Promise.reject(new Error('Remote Orca runtime connection closed.'))
+    }
+    if (this.waiters.length >= WEB_RUNTIME_MAX_CONNECTION_WAITERS) {
+      return Promise.reject(new Error(WEB_RUNTIME_BUSY_MESSAGE))
     }
     return new Promise((resolve, reject) => {
       const timeout = window.setTimeout(() => {
@@ -612,10 +915,50 @@ export class WebRuntimeClient {
     })
   }
 
+  private claimCallAdmission(): () => void {
+    if (this.activeCallAdmissions >= WEB_RUNTIME_MAX_PENDING_REQUESTS) {
+      throw new Error(WEB_RUNTIME_BUSY_MESSAGE)
+    }
+    this.activeCallAdmissions += 1
+    return releaseOnce(() => {
+      this.activeCallAdmissions -= 1
+    })
+  }
+
+  private claimSubscriptionAdmission(): () => void {
+    if (this.pendingSubscriptionAdmissions >= WEB_RUNTIME_MAX_SUBSCRIPTIONS) {
+      throw new Error(WEB_RUNTIME_BUSY_MESSAGE)
+    }
+    this.pendingSubscriptionAdmissions += 1
+    return releaseOnce(() => {
+      this.pendingSubscriptionAdmissions -= 1
+    })
+  }
+
+  private handleAuthenticationFailure(): void {
+    this.intentionallyClosed = true
+    this.clearTimers()
+    this.setState('auth-failed')
+    const ws = this.ws
+    this.ws = null
+    this.sharedKey = null
+    this.disposeOutboundTransport()
+    if (ws) {
+      try {
+        ws.close()
+      } catch {
+        // Authentication failure already detached the socket and released its memory claims.
+      }
+    }
+    this.rejectAllPending('Unauthorized. Pair this web client again.')
+    this.notifySubscriptionsError('unauthorized', 'Unauthorized. Pair this web client again.')
+  }
+
   private handleSocketClosed(closedWs: WebSocket): void {
     if (this.ws !== closedWs) {
       return
     }
+    this.disposeOutboundTransport()
     this.ws = null
     this.sharedKey = null
     this.clearConnectTimer()
@@ -629,6 +972,69 @@ export class WebRuntimeClient {
     }
     this.setState('disconnected')
     this.scheduleReconnect()
+  }
+
+  private ensureOutboundQueue(
+    ws: WebSocket
+  ): WsOutboundBackpressureQueue<WebRuntimeOutboundFrame> | null {
+    if (this.outboundQueue) {
+      return this.outboundQueue
+    }
+    if (!this.outboundSocketMemory) {
+      try {
+        this.outboundSocketMemory = this.outboundMemoryBudget.registerBufferedAmount(
+          () => ws.bufferedAmount
+        )
+      } catch {
+        return null
+      }
+    }
+    const socketMemory = this.outboundSocketMemory
+    this.outboundQueue = createWsOutboundBackpressureQueue<WebRuntimeOutboundFrame>({
+      send: (frame) => {
+        try {
+          ws.send(frame.payload)
+        } catch {
+          this.failOutboundSocket(ws)
+        }
+      },
+      byteLengthOf: (frame) => frame.bytes,
+      getBufferedAmount: () => ws.bufferedAmount,
+      isWritable: () => this.ws === ws && ws.readyState === WebSocket.OPEN && !!this.sharedKey,
+      canSend: (bytes) => socketMemory.canSend(bytes),
+      claimQueuedBytes: (bytes) => this.outboundMemoryBudget.claimQueuedBytes(bytes),
+      softCapBytes: WEB_RUNTIME_OUTBOUND_SOCKET_SOFT_CAP_BYTES,
+      maxQueuedBytes: WEB_RUNTIME_OUTBOUND_MAX_QUEUED_BYTES,
+      maxQueuedFrames: WEB_RUNTIME_OUTBOUND_MAX_QUEUED_FRAMES,
+      maxFrameBytes: WEB_RUNTIME_MAX_OUTBOUND_WIRE_FRAME_BYTES,
+      onOverflow: () => this.failOutboundSocket(ws)
+    })
+    return this.outboundQueue
+  }
+
+  private failOutboundSocket(ws: WebSocket): void {
+    if (this.ws !== ws) {
+      return
+    }
+    try {
+      ws.close()
+    } finally {
+      this.handleSocketClosed(ws)
+    }
+  }
+
+  private failInboundJsonCapacity(sourceWs?: WebSocket): void {
+    const ws = sourceWs ?? this.ws
+    if (ws) {
+      this.failOutboundSocket(ws)
+    }
+  }
+
+  private disposeOutboundTransport(): void {
+    this.outboundQueue?.dispose()
+    this.outboundQueue = null
+    this.outboundSocketMemory?.release()
+    this.outboundSocketMemory = null
   }
 
   private scheduleReconnect(): void {
@@ -667,6 +1073,8 @@ export class WebRuntimeClient {
     for (const [id, pending] of this.pending) {
       this.pending.delete(id)
       window.clearTimeout(pending.timeout)
+      pending.cancelQueuedFrame()
+      pending.cancelQueuedFrame = cancelNothing
       pending.reject(error)
     }
   }
@@ -677,22 +1085,44 @@ export class WebRuntimeClient {
     }
   }
 
+  private removeSubscription(id: string, expected?: RuntimeSubscription): boolean {
+    const subscription = this.subscriptions.get(id)
+    if (!subscription || (expected && subscription !== expected)) {
+      return false
+    }
+    this.subscriptions.delete(id)
+    subscription.cancelQueuedFrame?.()
+    subscription.cancelQueuedFrame = cancelNothing
+    subscription.paramsJson = undefined
+    subscription.paramsByteLength = 0
+    subscription.releaseRetainedBytes?.()
+    subscription.releaseRetainedBytes = releaseNothing
+    return true
+  }
+
+  private clearSubscriptions(): void {
+    for (const [id, subscription] of Array.from(this.subscriptions)) {
+      this.removeSubscription(id, subscription)
+    }
+  }
+
   private notifySubscriptionsClosed(): void {
     const subscriptions = Array.from(this.subscriptions.values())
-    this.subscriptions.clear()
+    this.clearSubscriptions()
     for (const subscription of subscriptions) {
-      subscription.callbacks.onClose?.()
+      invokeConsumerCallback(() => subscription.callbacks.onClose?.())
     }
   }
 
   private handleInterruptedSubscriptions(): void {
     for (const [id, subscription] of Array.from(this.subscriptions)) {
       if (!SHARED_CONNECTION_SUBSCRIPTION_METHODS.has(subscription.method)) {
-        this.subscriptions.delete(id)
-        subscription.callbacks.onClose?.()
+        this.removeSubscription(id, subscription)
+        invokeConsumerCallback(() => subscription.callbacks.onClose?.())
         continue
       }
-      subscription.callbacks.onTransportInterrupted?.()
+      subscription.cancelQueuedFrame = cancelNothing
+      invokeConsumerCallback(() => subscription.callbacks.onTransportInterrupted?.())
       if (this.subscriptions.get(subscription.id) === subscription) {
         subscription.needsReplay = true
       }
@@ -708,15 +1138,22 @@ export class WebRuntimeClient {
       subscription.id = this.nextId()
       subscription.needsReplay = false
       this.subscriptions.set(subscription.id, subscription)
-      if (
-        this.sendEncrypted({
+      let sent = REJECTED_OUTBOUND_ENQUEUE
+      try {
+        const serialized = serializePreparedRpcFrame({
           id: subscription.id,
           deviceToken: this.pairing.deviceToken,
           method: subscription.method,
-          params: subscription.params
+          paramsJson: subscription.paramsJson,
+          paramsByteLength: subscription.paramsByteLength
         })
-      ) {
-        subscription.callbacks.onTransportReplayed?.()
+        sent = this.sendEncryptedSerialized(serialized)
+      } catch {
+        // A previously admitted subscription stays replayable if a replacement frame cannot be prepared.
+      }
+      subscription.cancelQueuedFrame = sent.cancel
+      if (sent.accepted) {
+        invokeConsumerCallback(() => subscription.callbacks.onTransportReplayed?.())
       } else {
         subscription.needsReplay = true
       }
@@ -725,9 +1162,9 @@ export class WebRuntimeClient {
 
   private notifySubscriptionsError(code: string, message: string): void {
     const subscriptions = Array.from(this.subscriptions.values())
-    this.subscriptions.clear()
+    this.clearSubscriptions()
     for (const subscription of subscriptions) {
-      subscription.callbacks.onError?.({ code, message })
+      invokeConsumerCallback(() => subscription.callbacks.onError?.({ code, message }))
     }
   }
 
@@ -836,6 +1273,81 @@ export class WebRuntimeClient {
   }
 }
 
+function assertRpcMethodWithinLimit(method: string): void {
+  if (
+    measureUtf8ByteLength(method, { stopAfterBytes: WEB_RUNTIME_MAX_RPC_METHOD_BYTES })
+      .exceededLimit
+  ) {
+    throw new Error(`Remote runtime RPC method exceeds ${WEB_RUNTIME_MAX_RPC_METHOD_BYTES} bytes`)
+  }
+}
+
+function prepareSubscriptionInput(method: string, params: unknown): PreparedSubscriptionInput {
+  const prepared = stringifyWebRuntimeOutboundJson(params, WEB_RUNTIME_MAX_SUBSCRIPTION_PARAM_BYTES)
+  const canonicalParams = parseSerializedParams(prepared.serialized)
+  const worktree = (canonicalParams as { worktree?: unknown } | null)?.worktree
+  const normalizedWorktree = typeof worktree === 'string' ? worktree : ''
+  return {
+    paramsJson: prepared.serialized,
+    paramsByteLength: prepared.byteLength,
+    retainedBytes:
+      retainedPreparedFrameBytes(prepared.serialized, method) + normalizedWorktree.length * 2,
+    teardownKey: prepared.serialized ?? String(canonicalParams),
+    worktree: normalizedWorktree
+  }
+}
+
+function serializePreparedRpcFrame(input: {
+  id: string
+  deviceToken: string
+  method: string
+  paramsJson: string | undefined
+  paramsByteLength: number
+}): string {
+  const header = stringifyWebRuntimeOutboundJson(
+    { id: input.id, deviceToken: input.deviceToken, method: input.method },
+    WEB_RUNTIME_MAX_OUTBOUND_JSON_BYTES
+  )
+  if (header.serialized === undefined) {
+    throw new WebRuntimeOutboundJsonLimitError(WEB_RUNTIME_MAX_OUTBOUND_JSON_BYTES)
+  }
+  if (input.paramsJson === undefined) {
+    return header.serialized
+  }
+  const totalBytes = header.byteLength + RPC_PARAMS_MEMBER_PREFIX.length + input.paramsByteLength
+  if (totalBytes > WEB_RUNTIME_MAX_OUTBOUND_JSON_BYTES) {
+    throw new WebRuntimeOutboundJsonLimitError(WEB_RUNTIME_MAX_OUTBOUND_JSON_BYTES)
+  }
+  return `${header.serialized.slice(0, -1)}${RPC_PARAMS_MEMBER_PREFIX}${input.paramsJson}}`
+}
+
+function parseSerializedParams(serialized: string | undefined): unknown {
+  return serialized === undefined ? undefined : JSON.parse(serialized)
+}
+
+function retainedPreparedFrameBytes(serialized: string | undefined, method: string): number {
+  return (serialized?.length ?? 0) * 2 + method.length * 2 + 256
+}
+
+function releaseOnce(release: () => void): () => void {
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    release()
+  }
+}
+
+function invokeConsumerCallback(callback: () => void): void {
+  try {
+    callback()
+  } catch {
+    // One consumer must not block transport cleanup, replay, or sibling notifications.
+  }
+}
+
 function isRuntimeFailureResponse(
   response: RuntimeRpcResponse<unknown> | Record<string, unknown>
 ): response is RuntimeRpcResponse<unknown> & { ok: false } {
@@ -863,19 +1375,18 @@ function getFileWatchSubscriptionId(response: RuntimeRpcResponse<unknown>): stri
 
 function createFileWatchReplayOverflowResponse(
   readyResponse: RuntimeRpcSuccess<unknown>,
-  params: unknown
+  worktree: string
 ): RuntimeRpcSuccess<{
   type: 'changed'
   worktree: string
   events: { kind: 'overflow'; absolutePath: string }[]
 }> {
-  const worktree = (params as { worktree?: unknown } | null)?.worktree
   return {
     id: readyResponse.id,
     ok: true,
     result: {
       type: 'changed',
-      worktree: typeof worktree === 'string' ? worktree : '',
+      worktree,
       // Why: overflow consumers re-scan the whole root and ignore the path (client lacks the server-side root here).
       events: [{ kind: 'overflow', absolutePath: '' }]
     },
@@ -902,12 +1413,15 @@ async function websocketPayloadToUint8(
   value: unknown
 ): Promise<Uint8Array<ArrayBufferLike> | null> {
   if (value instanceof Uint8Array) {
-    return value
+    return value.byteLength <= WEB_RUNTIME_MAX_BINARY_FRAME_BYTES ? value : null
   }
   if (value instanceof ArrayBuffer) {
-    return new Uint8Array(value)
+    return value.byteLength <= WEB_RUNTIME_MAX_BINARY_FRAME_BYTES ? new Uint8Array(value) : null
   }
   if (value instanceof Blob) {
+    if (value.size > WEB_RUNTIME_MAX_BINARY_FRAME_BYTES) {
+      return null
+    }
     return new Uint8Array(await value.arrayBuffer())
   }
   return null

--- a/src/renderer/src/web/web-runtime-environment.ts
+++ b/src/renderer/src/web/web-runtime-environment.ts
@@ -2,6 +2,7 @@ import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-envi
 import type { WebPairingOffer } from './web-pairing'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { translate } from '@/i18n/i18n'
+import { parseWebLocalStorageJson, stringifyWebLocalStorageJson } from './web-local-storage-json'
 
 export type StoredWebRuntimeEnvironment = Omit<PublicKnownRuntimeEnvironment, 'endpoints'> & {
   compatibleEnvironmentIds?: string[]
@@ -23,7 +24,7 @@ export function readStoredWebRuntimeEnvironment(): StoredWebRuntimeEnvironment |
     return null
   }
   try {
-    const parsed = JSON.parse(raw) as StoredWebRuntimeEnvironment
+    const parsed = parseWebLocalStorageJson<StoredWebRuntimeEnvironment>(raw)
     if (
       !parsed.id ||
       !parsed.name ||
@@ -48,7 +49,7 @@ export function readStoredWebRuntimeEnvironment(): StoredWebRuntimeEnvironment |
 }
 
 export function saveStoredWebRuntimeEnvironment(environment: StoredWebRuntimeEnvironment): void {
-  window.localStorage.setItem(ENVIRONMENT_STORAGE_KEY, JSON.stringify(environment))
+  window.localStorage.setItem(ENVIRONMENT_STORAGE_KEY, stringifyWebLocalStorageJson(environment))
 }
 
 export function clearStoredWebRuntimeEnvironment(): void {

--- a/src/renderer/src/web/web-runtime-inbound-json.test.ts
+++ b/src/renderer/src/web/web-runtime-inbound-json.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  isWebRuntimeJsonStructureCapacityError,
+  parseWebRuntimeInboundJson
+} from './web-runtime-inbound-json'
+
+describe('web runtime inbound JSON admission', () => {
+  it('accepts the exact structural-token limit and rejects one more', () => {
+    const limits = { structuralTokens: 4, nestingDepth: 2 }
+
+    expect(parseWebRuntimeInboundJson('[0,0,0]', limits)).toEqual([0, 0, 0])
+    expect(() => parseWebRuntimeInboundJson('[0,0,0,0]', limits)).toThrow(
+      'JSON structure exceeds 4 tokens'
+    )
+  })
+
+  it('accepts the exact nesting limit and rejects one more', () => {
+    const limits = { structuralTokens: 20, nestingDepth: 3 }
+
+    expect(parseWebRuntimeInboundJson('[[[]]]', limits)).toEqual([[[]]])
+    expect(() => parseWebRuntimeInboundJson('[[[[]]]]', limits)).toThrow(
+      'JSON nesting exceeds 3 levels'
+    )
+  })
+
+  it('identifies capacity failures separately from malformed JSON', () => {
+    const capacityError = captureError(() =>
+      parseWebRuntimeInboundJson('[0,0]', {
+        structuralTokens: 2,
+        nestingDepth: 2
+      })
+    )
+    const syntaxError = captureError(() =>
+      parseWebRuntimeInboundJson('[', {
+        structuralTokens: 2,
+        nestingDepth: 2
+      })
+    )
+
+    expect(isWebRuntimeJsonStructureCapacityError(capacityError)).toBe(true)
+    expect(isWebRuntimeJsonStructureCapacityError(syntaxError)).toBe(false)
+  })
+})
+
+function captureError(run: () => void): unknown {
+  try {
+    run()
+    return null
+  } catch (error) {
+    return error
+  }
+}

--- a/src/renderer/src/web/web-runtime-inbound-json.ts
+++ b/src/renderer/src/web/web-runtime-inbound-json.ts
@@ -1,0 +1,24 @@
+import {
+  assertJsonTextStructureWithinLimits,
+  JsonTextStructureCapacityError,
+  type JsonTextStructureLimits
+} from '../../../shared/json-text-structure-limit'
+
+export const WEB_RUNTIME_INBOUND_JSON_STRUCTURE_LIMITS: JsonTextStructureLimits = {
+  structuralTokens: 1_000_000,
+  nestingDepth: 128
+}
+
+export function parseWebRuntimeInboundJson<T = unknown>(
+  content: string,
+  limits: JsonTextStructureLimits = WEB_RUNTIME_INBOUND_JSON_STRUCTURE_LIMITS
+): T {
+  assertJsonTextStructureWithinLimits(content, limits)
+  return JSON.parse(content) as T
+}
+
+export function isWebRuntimeJsonStructureCapacityError(
+  error: unknown
+): error is JsonTextStructureCapacityError {
+  return error instanceof JsonTextStructureCapacityError
+}

--- a/src/renderer/src/web/web-runtime-outbound-json.test.ts
+++ b/src/renderer/src/web/web-runtime-outbound-json.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  stringifyWebRuntimeOutboundJson,
+  WebRuntimeOutboundJsonLimitError
+} from './web-runtime-outbound-json'
+
+describe('bounded web runtime JSON serialization', () => {
+  it('preserves ordinary JSON values and exact byte accounting', () => {
+    const value = { text: 'hello', escaped: '\u0000\n', items: [1, true, null] }
+    const serialized = JSON.stringify(value)
+
+    expect(stringifyWebRuntimeOutboundJson(value, 1_000)).toEqual({
+      serialized,
+      byteLength: new TextEncoder().encode(serialized).byteLength
+    })
+  })
+
+  it('accepts the exact limit and rejects one byte over it', () => {
+    expect(stringifyWebRuntimeOutboundJson('🐋', 6)).toEqual({
+      serialized: '"🐋"',
+      byteLength: 6
+    })
+    expect(() => stringifyWebRuntimeOutboundJson('🐋x', 6)).toThrow(
+      WebRuntimeOutboundJsonLimitError
+    )
+  })
+
+  it('stops traversal immediately after an oversized member', () => {
+    const readAfter = vi.fn(() => 'late')
+    const value = {
+      payload: 'x'.repeat(100),
+      get after() {
+        return readAfter()
+      }
+    }
+
+    expect(() => stringifyWebRuntimeOutboundJson(value, 32)).toThrow(
+      'Remote runtime JSON payload exceeds 32 bytes'
+    )
+    expect(readAfter).not.toHaveBeenCalled()
+  })
+
+  it('matches JSON omission, array null, escaping, and boxed primitive behavior', () => {
+    const omitted = { ignored: undefined, kept: 1 }
+    const array = [undefined, () => 'ignored', Symbol('ignored')]
+
+    expect(stringifyWebRuntimeOutboundJson(omitted, 10).serialized).toBe('{"kept":1}')
+    expect(stringifyWebRuntimeOutboundJson(array, 16).serialized).toBe('[null,null,null]')
+    expect(stringifyWebRuntimeOutboundJson(new String('\u0000'), 8).serialized).toBe('"\\u0000"')
+  })
+
+  it('accepts shared containers at the exact serialized limit', () => {
+    const sharedObject = { value: 1 }
+    const sharedArray = [1, 2]
+    for (const value of [
+      [sharedObject, sharedObject],
+      [sharedArray, sharedArray]
+    ]) {
+      const serialized = JSON.stringify(value)
+      const byteLength = new TextEncoder().encode(serialized).byteLength
+      expect(stringifyWebRuntimeOutboundJson(value, byteLength)).toEqual({
+        serialized,
+        byteLength
+      })
+    }
+  })
+
+  it('rejects oversized raw JSON before visiting later members', () => {
+    const json = JSON as typeof JSON & { rawJSON?: (value: string) => unknown }
+    if (!json.rawJSON) {
+      return
+    }
+    const readAfter = vi.fn(() => 1)
+    const value = {
+      raw: json.rawJSON(`"${'x'.repeat(100)}"`),
+      get after() {
+        return readAfter()
+      }
+    }
+
+    expect(() => stringifyWebRuntimeOutboundJson(value, 32)).toThrow(
+      WebRuntimeOutboundJsonLimitError
+    )
+    expect(readAfter).not.toHaveBeenCalled()
+  })
+
+  it('reports root values omitted by JSON.stringify without retaining output', () => {
+    expect(stringifyWebRuntimeOutboundJson(undefined, 1)).toEqual({
+      serialized: undefined,
+      byteLength: 0
+    })
+  })
+})

--- a/src/renderer/src/web/web-runtime-outbound-json.ts
+++ b/src/renderer/src/web/web-runtime-outbound-json.ts
@@ -1,0 +1,161 @@
+import { measureUtf8ByteLength } from '../../../shared/utf8-byte-limits'
+
+export class WebRuntimeOutboundJsonLimitError extends Error {
+  constructor(readonly maxBytes: number) {
+    super(`Remote runtime JSON payload exceeds ${maxBytes} bytes`)
+    this.name = 'WebRuntimeOutboundJsonLimitError'
+  }
+}
+
+export type WebRuntimeOutboundJson = {
+  byteLength: number
+  serialized: string | undefined
+}
+
+export function stringifyWebRuntimeOutboundJson(
+  value: unknown,
+  maxBytes: number
+): WebRuntimeOutboundJson {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error('Remote runtime JSON limit must be a positive safe integer')
+  }
+  let estimatedBytes = 0
+  let root = true
+  const emittedMembers = new WeakMap<object, number>()
+  const serialized = JSON.stringify(value, function (key, item: unknown) {
+    const isRoot = root
+    root = false
+    const parent = this as object
+    const inArray = Array.isArray(parent)
+    if (isRoot && isOmittedObjectValue(item)) {
+      return item
+    }
+    if (!isRoot && !inArray && isOmittedObjectValue(item)) {
+      return item
+    }
+    if (!isRoot) {
+      const emitted = emittedMembers.get(parent) ?? 0
+      estimatedBytes += emitted > 0 ? 1 : 0
+      if (!inArray) {
+        estimatedBytes += escapedJsonStringBytes(key) + 1
+      }
+      emittedMembers.set(parent, emitted + 1)
+    }
+    estimatedBytes +=
+      inArray && isOmittedObjectValue(item)
+        ? 4
+        : jsonValueBytes(item, Math.max(0, maxBytes - estimatedBytes))
+    if (estimatedBytes > maxBytes) {
+      throw new WebRuntimeOutboundJsonLimitError(maxBytes)
+    }
+    if (typeof item === 'object' && item !== null) {
+      // Why: the same container can appear twice, and each traversal starts with no emitted members.
+      emittedMembers.set(item, 0)
+    }
+    return item
+  })
+  if (serialized === undefined) {
+    return { serialized, byteLength: 0 }
+  }
+  const measured = measureUtf8ByteLength(serialized, { stopAfterBytes: maxBytes })
+  if (measured.exceededLimit) {
+    throw new WebRuntimeOutboundJsonLimitError(maxBytes)
+  }
+  return { serialized, byteLength: measured.byteLength }
+}
+
+function isOmittedObjectValue(value: unknown): boolean {
+  return value === undefined || typeof value === 'function' || typeof value === 'symbol'
+}
+
+function jsonValueBytes(value: unknown, stopAfterBytes: number): number {
+  if (value === null) {
+    return 4
+  }
+  if (typeof value === 'string') {
+    return escapedJsonStringBytes(value)
+  }
+  if (typeof value === 'boolean') {
+    return value ? 4 : 5
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value).length : 4
+  }
+  if (typeof value === 'object' && value !== null) {
+    return rawJsonBytes(value, stopAfterBytes) ?? boxedPrimitiveJsonBytes(value) ?? 2
+  }
+  return 4
+}
+
+function rawJsonBytes(value: object, stopAfterBytes: number): number | null {
+  const json = JSON as typeof JSON & { isRawJSON?: (candidate: unknown) => boolean }
+  if (json.isRawJSON?.(value) !== true) {
+    return null
+  }
+  const rawJson = (value as { rawJSON?: unknown }).rawJSON
+  if (typeof rawJson !== 'string') {
+    return stopAfterBytes + 1
+  }
+  return measureUtf8ByteLength(rawJson, { stopAfterBytes }).byteLength
+}
+
+function boxedPrimitiveJsonBytes(value: object): number | null {
+  try {
+    return escapedJsonStringBytes(String.prototype.valueOf.call(value))
+  } catch {}
+  try {
+    const number = Number.prototype.valueOf.call(value)
+    return Number.isFinite(number) ? String(number).length : 4
+  } catch {}
+  try {
+    return Boolean.prototype.valueOf.call(value) ? 4 : 5
+  } catch {
+    return null
+  }
+}
+
+function escapedJsonStringBytes(value: string): number {
+  let bytes = 2
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (
+      code === 0x22 ||
+      code === 0x5c ||
+      code === 0x08 ||
+      code === 0x09 ||
+      code === 0x0a ||
+      code === 0x0c ||
+      code === 0x0d
+    ) {
+      bytes += 2
+    } else if (
+      code <= 0x1f ||
+      (code >= 0xd800 && code <= 0xdfff && !isSurrogatePair(value, index))
+    ) {
+      bytes += 6
+    } else if (code <= 0x7f) {
+      bytes += 1
+    } else if (code <= 0x7ff) {
+      bytes += 2
+    } else if (code >= 0xd800 && code <= 0xdbff) {
+      bytes += 4
+      index += 1
+    } else {
+      bytes += 3
+    }
+  }
+  return bytes
+}
+
+function isSurrogatePair(value: string, index: number): boolean {
+  const code = value.charCodeAt(index)
+  if (code >= 0xd800 && code <= 0xdbff) {
+    const next = value.charCodeAt(index + 1)
+    return next >= 0xdc00 && next <= 0xdfff
+  }
+  if (code >= 0xdc00 && code <= 0xdfff) {
+    const previous = value.charCodeAt(index - 1)
+    return previous >= 0xd800 && previous <= 0xdbff
+  }
+  return false
+}

--- a/src/renderer/src/web/web-runtime-outbound-memory-budget.test.ts
+++ b/src/renderer/src/web/web-runtime-outbound-memory-budget.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { createWebRuntimeOutboundMemoryBudget } from './web-runtime-outbound-memory-budget'
+
+describe('web runtime outbound memory budget', () => {
+  it('bounds aggregate queued bytes and frames with capacity recovery', () => {
+    const budget = createWebRuntimeOutboundMemoryBudget({
+      maxQueuedBytes: 10,
+      maxQueuedFrames: 2
+    })
+    const first = budget.claimQueuedBytes(5)
+    const second = budget.claimQueuedBytes(5)
+
+    expect(first).not.toBeNull()
+    expect(second).not.toBeNull()
+    expect(budget.claimQueuedBytes(0)).toBeNull()
+    first?.()
+    expect(budget.claimQueuedBytes(5)).not.toBeNull()
+  })
+
+  it('accepts exact retained subscription bytes and releases them', () => {
+    const budget = createWebRuntimeOutboundMemoryBudget({ maxSubscriptionBytes: 10 })
+    const release = budget.claimSubscriptionBytes(10)
+
+    expect(release).not.toBeNull()
+    expect(budget.claimSubscriptionBytes(1)).toBeNull()
+    release?.()
+    expect(budget.claimSubscriptionBytes(10)).not.toBeNull()
+  })
+
+  it('bounds prepared RPC bytes across connection waiters and releases them', () => {
+    const budget = createWebRuntimeOutboundMemoryBudget({ maxPreparedRpcBytes: 10 })
+    const release = budget.claimPreparedRpcBytes(10)
+
+    expect(release).not.toBeNull()
+    expect(budget.claimPreparedRpcBytes(1)).toBeNull()
+    release?.()
+    expect(budget.claimPreparedRpcBytes(10)).not.toBeNull()
+  })
+
+  it('accounts native buffered amounts across registered child sockets', () => {
+    const budget = createWebRuntimeOutboundMemoryBudget({
+      maxBufferedBytes: 10,
+      maxSocketSources: 2
+    })
+    let firstBytes = 6
+    let secondBytes = 3
+    const first = budget.registerBufferedAmount(() => firstBytes)
+    const second = budget.registerBufferedAmount(() => secondBytes)
+
+    expect(first.canSend(1)).toBe(true)
+    expect(first.canSend(2)).toBe(false)
+    secondBytes = 0
+    expect(first.canSend(4)).toBe(true)
+    firstBytes = 0
+    second.release()
+    expect(first.canSend(10)).toBe(true)
+  })
+
+  it('caps tracked sockets and recovers when a socket closes', () => {
+    const budget = createWebRuntimeOutboundMemoryBudget({ maxSocketSources: 1 })
+    const socket = budget.registerBufferedAmount(() => 0)
+
+    expect(() => budget.registerBufferedAmount(() => 0)).toThrow('socket tracking limit')
+    socket.release()
+    expect(() => budget.registerBufferedAmount(() => 0)).not.toThrow()
+  })
+})

--- a/src/renderer/src/web/web-runtime-outbound-memory-budget.ts
+++ b/src/renderer/src/web/web-runtime-outbound-memory-budget.ts
@@ -1,0 +1,125 @@
+export const WEB_RUNTIME_OUTBOUND_MAX_BUFFERED_BYTES = 16 * 1024 * 1024
+export const WEB_RUNTIME_OUTBOUND_MAX_QUEUED_BYTES = 32 * 1024 * 1024
+export const WEB_RUNTIME_OUTBOUND_MAX_QUEUED_FRAMES = 4_096
+export const WEB_RUNTIME_OUTBOUND_MAX_SOCKET_SOURCES = 65
+export const WEB_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES = 16 * 1024 * 1024
+export const WEB_RUNTIME_MAX_PREPARED_RPC_BYTES = 32 * 1024 * 1024
+
+export type WebRuntimeOutboundSocketMemory = {
+  canSend: (bytes: number) => boolean
+  release: () => void
+}
+
+export type WebRuntimeOutboundMemoryBudget = {
+  claimQueuedBytes: (bytes: number) => (() => void) | null
+  claimPreparedRpcBytes: (bytes: number) => (() => void) | null
+  claimSubscriptionBytes: (bytes: number) => (() => void) | null
+  registerBufferedAmount: (readBufferedAmount: () => number) => WebRuntimeOutboundSocketMemory
+}
+
+export function createWebRuntimeOutboundMemoryBudget(options?: {
+  maxBufferedBytes?: number
+  maxQueuedBytes?: number
+  maxQueuedFrames?: number
+  maxPreparedRpcBytes?: number
+  maxSocketSources?: number
+  maxSubscriptionBytes?: number
+}): WebRuntimeOutboundMemoryBudget {
+  const maxBufferedBytes = options?.maxBufferedBytes ?? WEB_RUNTIME_OUTBOUND_MAX_BUFFERED_BYTES
+  const maxQueuedBytes = options?.maxQueuedBytes ?? WEB_RUNTIME_OUTBOUND_MAX_QUEUED_BYTES
+  const maxQueuedFrames = options?.maxQueuedFrames ?? WEB_RUNTIME_OUTBOUND_MAX_QUEUED_FRAMES
+  const maxPreparedRpcBytes = options?.maxPreparedRpcBytes ?? WEB_RUNTIME_MAX_PREPARED_RPC_BYTES
+  const maxSocketSources = options?.maxSocketSources ?? WEB_RUNTIME_OUTBOUND_MAX_SOCKET_SOURCES
+  const maxSubscriptionBytes =
+    options?.maxSubscriptionBytes ?? WEB_RUNTIME_MAX_RETAINED_SUBSCRIPTION_BYTES
+  const bufferedSources = new Set<() => number>()
+  let queuedBytes = 0
+  let queuedFrames = 0
+  let preparedRpcBytes = 0
+  let subscriptionBytes = 0
+
+  const bufferedBytes = (): number => {
+    let total = 0
+    for (const read of bufferedSources) {
+      try {
+        const value = read()
+        if (Number.isFinite(value) && value > 0) {
+          total += value
+        }
+      } catch {
+        // Closed browser sockets can reject late reads before their close callback releases the source.
+      }
+    }
+    return total
+  }
+
+  return {
+    claimQueuedBytes(bytes): (() => void) | null {
+      if (
+        !Number.isFinite(bytes) ||
+        bytes < 0 ||
+        queuedFrames >= maxQueuedFrames ||
+        queuedBytes + bytes > maxQueuedBytes
+      ) {
+        return null
+      }
+      queuedBytes += bytes
+      queuedFrames += 1
+      return createRelease(() => {
+        queuedBytes -= bytes
+        queuedFrames -= 1
+      })
+    },
+    claimPreparedRpcBytes(bytes): (() => void) | null {
+      if (!Number.isFinite(bytes) || bytes < 0 || preparedRpcBytes + bytes > maxPreparedRpcBytes) {
+        return null
+      }
+      preparedRpcBytes += bytes
+      return createRelease(() => {
+        preparedRpcBytes -= bytes
+      })
+    },
+    claimSubscriptionBytes(bytes): (() => void) | null {
+      if (
+        !Number.isFinite(bytes) ||
+        bytes < 0 ||
+        subscriptionBytes + bytes > maxSubscriptionBytes
+      ) {
+        return null
+      }
+      subscriptionBytes += bytes
+      return createRelease(() => {
+        subscriptionBytes -= bytes
+      })
+    },
+    registerBufferedAmount(readBufferedAmount) {
+      if (bufferedSources.size >= maxSocketSources) {
+        throw new Error('Remote runtime outbound socket tracking limit exceeded')
+      }
+      bufferedSources.add(readBufferedAmount)
+      let registered = true
+      return {
+        canSend: (bytes): boolean =>
+          registered &&
+          Number.isFinite(bytes) &&
+          bytes >= 0 &&
+          bytes <= maxBufferedBytes - bufferedBytes(),
+        release: createRelease(() => {
+          registered = false
+          bufferedSources.delete(readBufferedAmount)
+        })
+      }
+    }
+  }
+}
+
+function createRelease(release: () => void): () => void {
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    release()
+  }
+}


### PR DESCRIPTION
## OOM hardening slice 29/29 — bound web-renderer variants

> **Part of a 29-PR stack re-landing #10179** ("bound OOM-prone accumulators across Orca"), which was reverted in #10255 for being too large (~1,600 files). This is slice **29/29** (base: `oom/28-b-renderer-state`). **Merge in numeric order.** The full stack's end-state is byte-for-byte the commit that passed #10179's complete CI matrix (36k+ tests, multi-OS).

### Summary
Re-introduces OOM ceilings on the renderer web/SSH remote-runtime path: pre-decode admission caps for E2EE keys/pairing input, bounded browser-local JSON persistence, capped RPC/subscription/waiter/child-client counts, and an outbound WebSocket backpressure budget that closes+reconnects overloaded sockets instead of growing memory.

### ELI5
When Orca runs in a browser or over SSH, it talks to your machine's runtime over an encrypted connection. This change adds seatbelts: it refuses absurdly large messages, keys, and saved-settings blobs before doing expensive work, limits how many requests/subscriptions can pile up, and if the outgoing pipe gets clogged it hangs up and reconnects rather than eating unlimited memory. All the limits are far above what normal use ever reaches.

### Proof of OOM fix
- web-e2ee.ts: public key <=44 base64 chars, encrypted text <= MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS (~4MiB plaintext); test web-e2ee.test.ts asserts atob not called past the cap
- web-pairing.ts: PAIRING input 129KiB / code 128KiB / endpoint 16KiB / deviceToken 64KiB / publicKey 4KiB (shared/mobile-relay-pairing-offer); test web-pairing.test.ts boundary accept+reject
- web-local-storage-json.ts: WEB_LOCAL_STORAGE_JSON_LIMITS = 8MiB bytes / 1_000_000 structural tokens / depth 128; test web-local-storage-json.test.ts asserts JSON.parse not reached on amplified input
- web-preload-request-owners.ts: WEB_PRELOAD_MAX_ABORTABLE_REQUESTS=256, WEB_PRELOAD_MAX_REQUEST_TOKEN_BYTES=4KiB; test web-preload-request-owners.test.ts
- web-preload-api.ts: WEB_PRELOAD_MAX_KEYBINDING_LISTENERS=64, WEB_RUNTIME_REPO_DISCOVERY_CONCURRENCY=8; test web-preload-runtime-discovery-concurrency.test.ts resolves 300 repos with peak concurrency==8
- web-runtime-client.ts: 256 waiters/pending/subscriptions, 64 child clients, 64MiB inbound binary, 8MiB outbound binary, 4MiB outbound JSON, 1MiB subscription params, 8KiB RPC method; tests web-runtime-client-memory-bounds.test.ts + web-runtime-client.test.ts
- web-runtime-outbound-memory-budget.ts: 16MiB buffered / 32MiB queued / 4096 frames / 16MiB retained-subscription / 32MiB prepared-RPC / 65 socket sources (=64 children+1 parent), shared across parent+child clients; test web-runtime-outbound-memory-budget.test.ts

### Regressions
**Normal-path (ordinary use, below the new limits):** ⚠️ **needs sign-off:**
- **low**: Runtime worktree discovery fan-out changed from unbounded Promise.all to mapWithConcurrency(8), so detected-worktree discovery for users with many repos is now processed 8 repos at a time (slightly higher latency, no functional change). _(trigger: Web/SSH runtime user with a large repo catalog (test exercises 300 repos).)_

**Overload-only (extreme input / sustained backpressure) — intended, documented degradations:**
- Outbound WebSocket queue overflow (sustained backpressure beyond 32MiB / 4096 frames / 16MiB buffered) closes the socket and schedules a reconnect (failOutboundSocket) rather than buffering unbounded
- Inbound encrypted text frame over ~4MiB or JSON exceeding 1M tokens / depth 128 closes the remote-runtime socket (failInboundJsonCapacity)
- Exceeding 256 pending requests / 256 connection waiters / 256 subscriptions / 64 child clients rejects new calls with 'client is busy'
- Browser-local JSON over 8MiB or too-deeply-nested throws; readJson swallows it and returns defaults, writeJson throws
- Oversized outbound binary frame (>8MiB) closes the socket before encrypting
- keybindings.onChanged now throws 'listener capacity reached' after 64 concurrently registered listeners instead of growing an unbounded Set. _(only when: Only if >64 keybinding change listeners are registered without unsubscribing; far above ordinary use.)_

### Build / CI
- ✅ Cumulative typecheck is **green** at this stack position.

### Adversarial review
- 1 skeptic lens(es). Sign-off: **yes**. Residual risk: **low**.
- Skeptic pass on PR #29 (B-renderer-web) found NO confirmed normal-path regression. All new ceilings sit far above ordinary use and several interact coherently.\n\nKey verifications:\n- Inbound encrypted text-frame cap (~4MiB, WEB_RUNTIME_MAX_ENCRYPTED_TEXT_FRAME_BYTES = MAX_E2EE_ENCRYPTED_BASE64_CHARACTERS): the 4MiB MAX_E2EE_TEXT_PLAINTEXT_BYTES threshold ALREADY exists in BASE (src/shared/e2ee-crypto.ts at aab112933e), where oversized frames were silently dropped by decrypt() returning null. This slice only changes the reaction to close+reconnect (failInboundJsonCapacity/failOutboundSocket). No new normal-path frame is rejected; server is designed to stay under 4MiB (chunks large data via 64MiB binary frames). Overload-only.\n- mapWithConcurrency(8) repo discovery (web-preload-api.ts:3756): users with <=8 repos see no change; also necessary to stay under the new 256 pending-request cap that unbounded Promise.all would otherwise trip for 257+ repos. Negligible latency for many-repo users.\n- Keybinding listener cap 64 (web-preload-api.ts:404): effect-cleanup usage keeps live count tiny; the new Map also fixes a pre-existing duplicate storage-listener leak in the old Set path.\n- Pairing ceilings (128KiB/64KiB/16KiB/4KiB) dwarf real offers (tens of chars). Overload-only.\n- Socket-source cap 65 = parent(1)+64 children exactly; no off-by-one lockout. terminal.multiplex muxes terminals so heavy users do not fan out to 64 sockets.\n- Outbound backpressure (32MiB/4096 frames/16MiB buffered) only trips under sustained server non-drain.\n\nAgree with prior reviewer that the getStoredSettings writeJson try/catch removal is overload-only; verified it is in fact effectively unreachable due to the parsedPlainObject gate. Slice is whole-file lossless production code that passed full CI. Safe to open as a draft PR for human review; recommend a one-line human note on the localStorage silent-reset-above-limits behavior.

### Files
21 files changed (+2114 / −184).

---
🤖 Decomposed, reviewed & assembled by Claude Code from the reverted #10179. **Draft — do not merge out of order.**

Made with [Orca](https://github.com/stablyai/orca) 🐋
