### PR TITLE
ci(release-cut): add explicit version override to the cut dispatch

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -346,7 +346,14 @@ jobs:
             # floor for the current ref so the next cut cannot reuse an older
             # stable number just because the public release was nuked.
             if semver_gt "$package_stable" "$latest_stable"; then
-              if [[ "$KIND" != "rc" ]]; then
+              # Skip floor-tag recovery when an explicit version is requested:
+              # recover_unpublished_tag can exit 0, which would recover the
+              # package-floor tag instead of cutting the requested version —
+              # defeating the very rollback scenario the override exists for.
+              # We still raise latest_stable to the floor below so the explicit
+              # version is gated against it; the collision recovery for the
+              # requested tag runs later.
+              if [[ "$KIND" != "rc" && -z "${EXPLICIT_VERSION:-}" ]]; then
                 package_tag="v$package_stable"
                 if git rev-parse "$package_tag" >/dev/null 2>&1; then
                   recover_unpublished_tag "$package_tag" "current ref stable tag is newer than latest published stable" || true

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: string
         default: ''
+      version:
+        description: Exact version to cut (e.g. 1.4.155 or 1.4.155-rc.0), bypassing kind-based computation. Use to leapfrog a deleted/rolled-back stable that regressed the release list. Must be greater than the latest published stable.
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -202,6 +207,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           KIND: ${{ github.event_name == 'schedule' && 'rc' || inputs.kind }}
           VERSION_SUFFIX: ${{ github.event_name == 'schedule' && '' || inputs.version_suffix }}
+          EXPLICIT_VERSION: ${{ github.event_name == 'schedule' && '' || inputs.version }}
         run: |
           set -euo pipefail
 
@@ -352,6 +358,37 @@ jobs:
             fi
           fi
 
+          # Explicit version override (manual dispatch only).
+          #
+          # Why: kind-based math derives the next number from the latest
+          # *published* stable. When a shipped stable is deleted (e.g. a
+          # rolled-back 1.4.154), the release list regresses to the prior
+          # stable, so a kind cut recomputes a number at or below the nuked one
+          # and strands every client that already installed the deleted build.
+          # The package.json floor above only recovers this when the deleted
+          # version's bump commit is on the ref being cut, which a hotfix cut
+          # from an older RC ref does not carry. An explicit version lets a
+          # human assert the exact target (e.g. leapfrog to 1.4.155); the
+          # updater-safety gate and tag-collision recovery below still apply.
+          new=""
+          if [[ -n "${EXPLICIT_VERSION:-}" ]]; then
+            explicit="${EXPLICIT_VERSION#v}"
+            if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+              echo "::error::version must be X.Y.Z or X.Y.Z-rc.N, got: $EXPLICIT_VERSION" >&2
+              exit 1
+            fi
+            # Same updater-safety gate the kind path enforces: stable line must
+            # strictly increase over the latest published stable (prerelease
+            # identifiers ignored for the comparison).
+            if ! semver_gt "$explicit" "$latest_stable"; then
+              echo "::error::Refusing explicit version $explicit: not greater than latest stable $latest_stable." >&2
+              exit 1
+            fi
+            new="$explicit"
+            echo "Explicit version override: $new"
+          fi
+
+          if [[ -z "$new" ]]; then
           case "$KIND" in
             rc)
               # Why: RCs always stabilize the *next* patch after whatever
@@ -429,6 +466,7 @@ jobs:
               exit 1
               ;;
           esac
+          fi
 
           # Orphan-tag recovery.
           #


### PR DESCRIPTION
## Why

`release-cut` computes the next version from the latest **published** stable and refuses a stable that doesn't strictly increase. That math has a blind spot: **when a shipped stable is deleted/rolled back, the release list regresses to the prior stable**, so a `kind` cut recomputes a number *at or below* the deleted one.

Concrete case we just hit: **v1.4.154 was published, installed by users, then deleted.** The release list now shows latest stable = v1.4.152. A normal `patch` cut would compute **1.4.153** — which is *lower* than the 1.4.154 those users are on, so electron-updater (forward-only) would never offer it and they'd stay stranded. The existing `package.json` floor only recovers this when the deleted version's bump commit is on the ref being cut; a hotfix promoted from an older RC ref doesn't carry it.

## What

Adds an optional `version` `workflow_dispatch` input that lets a human assert the exact target version (e.g. leapfrog the deleted 1.4.154 to **1.4.155**), bypassing kind-based computation.

Guardrails preserved:
- **Updater-safety gate** still enforced — the explicit version must strictly exceed the latest published stable (prerelease identifiers ignored), same rule as the `patch|minor|major` path.
- **Tag-collision recovery** below runs unchanged for the explicit version.
- Format-validated (`X.Y.Z` or `X.Y.Z-rc.N`).
- Empty by default and **forced empty for scheduled cuts**, so nightly automation is untouched.

## Immediate use

Promote the tested `v1.4.153-rc.3` commit as stable `1.4.155`:
`release-cut` → `kind=patch`, `version=1.4.155`, `ref=<rc.3 SHA>`.

## Validation

- YAML parses; `bash -n` clean on the edited compute block.
- Unit-checked the new branch: `1.4.155`/`v1.4.155`/`1.4.155-rc.0` accepted → correct `new`; `1.4.152` (not greater) and malformed input rejected.

## Note

The `case` body is guarded by `if [[ -z "$new" ]]` without re-indenting, to keep the diff surgical. Happy to re-indent the block if preferred.