### PR TITLE
docs: fix stale /stargazers link in French README (follow-up to #8756)

### DIFF
--- a/docs/readme/README.fr.md
+++ b/docs/readme/README.fr.md
@@ -3,7 +3,7 @@
 </h1>
 
 <p align="center">
-  <a href="https://github.com/stablyai/orca/stargazers"><img src="https://badgen.net/github/stars/stablyai/orca?label=%E2%98%85" alt="Étoiles GitHub" /></a>
+  <a href="https://github.com/stablyai/orca"><img src="https://badgen.net/github/stars/stablyai/orca?label=%E2%98%85" alt="Étoiles GitHub" /></a>
   <a href="https://github.com/stablyai/orca/releases"><img src="../assets/readme-downloads.svg" alt="Téléchargements totaux sur toutes les versions" /></a>
   <img src="https://badgen.net/github/license/stablyai/orca" alt="Licence" />
   <a href="https://discord.gg/fzjDKHxv8Q"><img src="https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white" alt="Rejoindre le Discord Orca" /></a>


### PR DESCRIPTION
Follow-up to #8756 (merged), which fixed the app links but missed one README. The French README star badge (`docs/readme/README.fr.md`) still deep-linked to `/stargazers`, which 404s for users without repo write access. Points it at the repo root like every other README.

Verified: all other READMEs already use the root URL; this is the only remaining doc occurrence.

Made with [Orca](https://github.com/stablyai/orca) 🐋
