### PR TITLE
fix(codex): trust extended-length resume paths

### DIFF
--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -45,6 +45,55 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
     ).toBe('c:\\users\\example\\.codex')
   })
 
+  it('accepts an extended-length Windows rollout and preserves its original path', async () => {
+    const homePath = 'C:\\Users\\Example\\.codex'
+    const transcriptPath =
+      '\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-session.jsonl'
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId: 'session-a',
+        transcriptPath,
+        trustedCodexHomes: [homePath],
+        fileIsRegular: (filePath) => filePath === transcriptPath
+      })
+    ).resolves.toEqual({ homePath, transcriptPath })
+  })
+
+  it('rejects unsafe or unrelated Windows namespace paths before probing files', () => {
+    const fileIsRegular = vi.fn((): boolean => true)
+    const trustedCodexHomes = ['C:\\Users\\Example\\.codex']
+    const rejectedPaths = [
+      '\\\\?\\D:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-a.jsonl',
+      '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1\\sessions\\2026\\07\\20\\rollout-a.jsonl',
+      '\\\\?\\Volume{00000000-0000-0000-0000-000000000000}\\sessions\\2026\\07\\20\\rollout-a.jsonl',
+      '\\\\.\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-a.jsonl',
+      '\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\..\\rollout-a.jsonl'
+    ]
+
+    for (const transcriptPath of rejectedPaths) {
+      expect(
+        resolveTrustedCodexSessionResumeHome({
+          transcriptPath,
+          trustedCodexHomes,
+          fileIsRegular
+        })
+      ).toBeNull()
+    }
+    expect(fileIsRegular).not.toHaveBeenCalled()
+  })
+
+  it('rejects a missing or non-regular extended-length rollout', () => {
+    expect(
+      resolveTrustedCodexSessionResumeHome({
+        transcriptPath:
+          '\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-a.jsonl',
+        trustedCodexHomes: ['C:\\Users\\Example\\.codex'],
+        fileIsRegular: () => false
+      })
+    ).toBeNull()
+  })
+
   it('rejects paths outside trusted homes or outside the rollout layout', () => {
     const fileIsRegular = vi.fn((): boolean => true)
     expect(
@@ -219,6 +268,24 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         trustedCodexHomes: ['/managed/origin/home', '/managed/other/home'],
         ...withoutHomeRanking,
         fileIsRegular: () => false,
+        listSessionFiles
+      })
+    ).resolves.toBeNull()
+    expect(listSessionFiles).not.toHaveBeenCalled()
+  })
+
+  it('does not scan another home after rejecting extended-length provenance', async () => {
+    const listSessionFiles = vi.fn((): AsyncIterable<string> => {
+      throw new Error('must not scan')
+    })
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId: '019f81b9-19a9-7651-a8d1-352d9420bd11',
+        transcriptPath:
+          '\\\\?\\D:\\Other\\.codex\\sessions\\2026\\07\\20\\rollout-019f81b9-19a9-7651-a8d1-352d9420bd11.jsonl',
+        trustedCodexHomes: ['C:\\Users\\Example\\.codex'],
+        fileIsRegular: () => true,
         listSessionFiles
       })
     ).resolves.toBeNull()

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -94,8 +94,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
     ).toBeNull()
   })
 
-  // Why: the extended spelling can appear on the trusted-home side too, so both
-  // sides of the containment comparison must fold, not just the rollout path.
+  // Why: the sessions root is folded too, so the home side must accept the extended spelling.
   it('accepts a normal-form rollout under an extended-length trusted home', () => {
     const homePath = '\\\\?\\C:\\Users\\Example\\.codex'
     expect(
@@ -125,8 +124,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
     ).resolves.toEqual({ homePath, transcriptPath: compressedPath })
   })
 
-  // Why: the legacy id scan runs the same namespace check per directory entry,
-  // so extended-length entries must resolve and device namespaces must not.
+  // Why: the id scan is a second call site of the same check, once per directory entry.
   it('accepts extended-length scan entries but not device-namespace entries', async () => {
     const sessionId = '019f81b9-19a9-7651-a8d1-352d9420bd11'
     const homePath = 'C:\\Users\\Example\\.codex'

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -94,6 +94,69 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
     ).toBeNull()
   })
 
+  // Why: the extended spelling can appear on the trusted-home side too, so both
+  // sides of the containment comparison must fold, not just the rollout path.
+  it('accepts a normal-form rollout under an extended-length trusted home', () => {
+    const homePath = '\\\\?\\C:\\Users\\Example\\.codex'
+    expect(
+      resolveTrustedCodexSessionResumeHome({
+        transcriptPath: 'C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-a.jsonl',
+        trustedCodexHomes: [homePath],
+        fileIsRegular: () => true
+      })
+    ).toBe(homePath)
+  })
+
+  // Why: the .zst sibling is derived from the persisted path, so a folded
+  // comparison copy must never leak into the probed or returned path.
+  it('follows a compressed extended-length rollout without losing the extended spelling', async () => {
+    const homePath = 'C:\\Users\\Example\\.codex'
+    const plainPath =
+      '\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-session.jsonl'
+    const compressedPath = `${plainPath}.zst`
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId: 'session-a',
+        transcriptPath: plainPath,
+        trustedCodexHomes: [homePath],
+        fileIsRegular: (filePath) => filePath === compressedPath
+      })
+    ).resolves.toEqual({ homePath, transcriptPath: compressedPath })
+  })
+
+  // Why: the legacy id scan runs the same namespace check per directory entry,
+  // so extended-length entries must resolve and device namespaces must not.
+  it('accepts extended-length scan entries but not device-namespace entries', async () => {
+    const sessionId = '019f81b9-19a9-7651-a8d1-352d9420bd11'
+    const homePath = 'C:\\Users\\Example\\.codex'
+    const extendedEntry = `\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-${sessionId}.jsonl`
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: undefined,
+        trustedCodexHomes: [homePath],
+        fileIsRegular: () => true,
+        listSessionFiles: async function* (): AsyncIterable<string> {
+          yield extendedEntry
+        }
+      })
+    ).resolves.toEqual({ homePath, transcriptPath: extendedEntry })
+
+    await expect(
+      findTrustedCodexSessionResume({
+        sessionId,
+        transcriptPath: undefined,
+        trustedCodexHomes: [homePath],
+        fileIsRegular: () => true,
+        listSessionFiles: async function* (): AsyncIterable<string> {
+          yield `\\\\.\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-${sessionId}.jsonl`
+        }
+      })
+    ).resolves.toBeNull()
+  })
+
   it('rejects paths outside trusted homes or outside the rollout layout', () => {
     const fileIsRegular = vi.fn((): boolean => true)
     expect(

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -55,6 +55,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId: 'session-a',
         transcriptPath,
         trustedCodexHomes: [homePath],
+        ...withoutHomeRanking,
         fileIsRegular: (filePath) => filePath === transcriptPath
       })
     ).resolves.toEqual({ homePath, transcriptPath })
@@ -120,6 +121,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId: 'session-a',
         transcriptPath: plainPath,
         trustedCodexHomes: [homePath],
+        ...withoutHomeRanking,
         fileIsRegular: (filePath) => filePath === compressedPath
       })
     ).resolves.toEqual({ homePath, transcriptPath: compressedPath })
@@ -136,6 +138,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId,
         transcriptPath: undefined,
         trustedCodexHomes: [homePath],
+        ...withoutHomeRanking,
         fileIsRegular: () => true,
         listSessionFiles: async function* (): AsyncIterable<string> {
           yield extendedEntry
@@ -148,6 +151,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         sessionId,
         transcriptPath: undefined,
         trustedCodexHomes: [homePath],
+        ...withoutHomeRanking,
         fileIsRegular: () => true,
         listSessionFiles: async function* (): AsyncIterable<string> {
           yield `\\\\.\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-${sessionId}.jsonl`
@@ -347,6 +351,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         transcriptPath:
           '\\\\?\\D:\\Other\\.codex\\sessions\\2026\\07\\20\\rollout-019f81b9-19a9-7651-a8d1-352d9420bd11.jsonl',
         trustedCodexHomes: ['C:\\Users\\Example\\.codex'],
+        ...withoutHomeRanking,
         fileIsRegular: () => true,
         listSessionFiles
       })
@@ -572,6 +577,14 @@ describe('claimsCodexRolloutLayout', () => {
   it('is true for a rollout under a home Orca no longer trusts, so resume cannot silently fall through to the selected account', () => {
     expect(
       claimsCodexRolloutLayout('/removed/account/home/sessions/2026/07/20/rollout-a.jsonl')
+    ).toBe(true)
+  })
+
+  it('is true for an ADS-shaped rollout that provenance trust rejects', () => {
+    expect(
+      claimsCodexRolloutLayout(
+        'C:\\Users\\example\\.codex\\sessions\\2026\\07\\20\\rollout-a:stream.jsonl'
+      )
     ).toBe(true)
   })
 

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -68,6 +68,7 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
       '\\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1\\sessions\\2026\\07\\20\\rollout-a.jsonl',
       '\\\\?\\Volume{00000000-0000-0000-0000-000000000000}\\sessions\\2026\\07\\20\\rollout-a.jsonl',
       '\\\\.\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-a.jsonl',
+      '\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-a:stream.jsonl',
       '\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\..\\rollout-a.jsonl'
     ]
 

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -8,7 +8,7 @@ import {
 import { listCodexSessionRolloutFilesIncrementally } from './codex-session-file-listing'
 
 // Why: only Codex's dated rollout layout may establish account-home provenance; nested/misplaced JSONL must not select credentials.
-const DATED_ROLLOUT_TAIL = String.raw`\d{4}/\d{2}/\d{2}/rollout-[^/]+\.jsonl(?:\.zst)?`
+const DATED_ROLLOUT_TAIL = String.raw`\d{4}/\d{2}/\d{2}/rollout-[^/:]+\.jsonl(?:\.zst)?`
 const ROLLOUT_RELATIVE_PATH = new RegExp(`^${DATED_ROLLOUT_TAIL}$`)
 // Why: case-insensitive because trusted-home matching folds Windows path case too.
 const CODEX_ROLLOUT_LAYOUT_PATH = new RegExp(`(?:^|/)sessions/${DATED_ROLLOUT_TAIL}$`, 'i')

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -22,7 +22,8 @@ export type CodexSessionResumePreparation =
   | { outcome: 'resume'; codexHomePath: string }
   | { outcome: 'fresh'; claimedCodexProvenance: boolean }
 
-// Why: provenance may fold Win32's extended drive spelling, never arbitrary device namespaces.
+// Why: fold only Win32's extended drive spelling; \\.\ device namespaces and every other \\?\ form
+// (including \\?\UNC\, which is a network share rather than a device) stay unfolded here.
 function toCodexTrustedPathComparisonCopy(filePath: string): string | null {
   if (filePath.startsWith('\\\\.\\')) {
     return null

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -22,8 +22,24 @@ export type CodexSessionResumePreparation =
   | { outcome: 'resume'; codexHomePath: string }
   | { outcome: 'fresh'; claimedCodexProvenance: boolean }
 
+// Why: provenance may fold Win32's extended drive spelling, never arbitrary device namespaces.
+function toCodexTrustedPathComparisonCopy(filePath: string): string | null {
+  if (filePath.startsWith('\\\\.\\')) {
+    return null
+  }
+  if (!filePath.startsWith('\\\\?\\')) {
+    return filePath
+  }
+  return filePath.match(/^\\\\\?\\([A-Za-z]:[\\/][\s\S]*)$/)?.[1] ?? null
+}
+
 function isCodexRolloutInsideSessionsRoot(sessionsRoot: string, filePath: string): boolean {
-  const relativePath = relativePathInsideRoot(sessionsRoot, filePath)
+  const comparisonSessionsRoot = toCodexTrustedPathComparisonCopy(sessionsRoot)
+  const comparisonFilePath = toCodexTrustedPathComparisonCopy(filePath)
+  if (!comparisonSessionsRoot || !comparisonFilePath) {
+    return false
+  }
+  const relativePath = relativePathInsideRoot(comparisonSessionsRoot, comparisonFilePath)
   return Boolean(relativePath && ROLLOUT_RELATIVE_PATH.test(relativePath.replace(/\\/g, '/')))
 }
 

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -8,10 +8,11 @@ import {
 import { listCodexSessionRolloutFilesIncrementally } from './codex-session-file-listing'
 
 // Why: only Codex's dated rollout layout may establish account-home provenance; nested/misplaced JSONL must not select credentials.
-const DATED_ROLLOUT_TAIL = String.raw`\d{4}/\d{2}/\d{2}/rollout-[^/:]+\.jsonl(?:\.zst)?`
-const ROLLOUT_RELATIVE_PATH = new RegExp(`^${DATED_ROLLOUT_TAIL}$`)
+const CLAIMED_CODEX_ROLLOUT_TAIL = String.raw`\d{4}/\d{2}/\d{2}/rollout-[^/]+\.jsonl(?:\.zst)?`
+const TRUSTED_CODEX_ROLLOUT_TAIL = String.raw`\d{4}/\d{2}/\d{2}/rollout-[^/:]+\.jsonl(?:\.zst)?`
+const ROLLOUT_RELATIVE_PATH = new RegExp(`^${TRUSTED_CODEX_ROLLOUT_TAIL}$`)
 // Why: case-insensitive because trusted-home matching folds Windows path case too.
-const CODEX_ROLLOUT_LAYOUT_PATH = new RegExp(`(?:^|/)sessions/${DATED_ROLLOUT_TAIL}$`, 'i')
+const CODEX_ROLLOUT_LAYOUT_PATH = new RegExp(`(?:^|/)sessions/${CLAIMED_CODEX_ROLLOUT_TAIL}$`, 'i')
 
 /** `resume` pins CODEX_HOME to the account that owns the rollout. `fresh` means
  *  provenance could not be verified, so the caller drops the resume argv — an

--- a/src/main/codex/codex-session-resume-windows.test.ts
+++ b/src/main/codex/codex-session-resume-windows.test.ts
@@ -1,0 +1,46 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, toNamespacedPath } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { prepareCodexSessionResume } from './codex-session-resume-preparation'
+
+const windowsIt = process.platform === 'win32' ? it : it.skip
+const cleanupPaths: string[] = []
+
+afterEach(() => {
+  for (const cleanupPath of cleanupPaths.splice(0)) {
+    rmSync(cleanupPath, { recursive: true, force: true })
+  }
+})
+
+describe('Codex session resume on native Windows', () => {
+  windowsIt('resumes an extended-length rollout from its ordinary trusted home', async () => {
+    const homePath = mkdtempSync(join(tmpdir(), 'orca-codex-resume-'))
+    cleanupPaths.push(homePath)
+    const rolloutPath = join(
+      homePath,
+      'sessions',
+      '2026',
+      '07',
+      '20',
+      'rollout-019f81b9-19a9-7651-a8d1-352d9420bd11.jsonl'
+    )
+    mkdirSync(dirname(rolloutPath), { recursive: true })
+    writeFileSync(rolloutPath, '{"type":"session_meta"}\n')
+    const transcriptPath = toNamespacedPath(rolloutPath)
+    const resolveVerifiedResumeHome = vi.fn(async () => homePath)
+
+    await expect(
+      prepareCodexSessionResume({
+        sessionId: '019f81b9-19a9-7651-a8d1-352d9420bd11',
+        transcriptPath,
+        trustedCodexHomes: [homePath],
+        getSelectedAccountCodexHome: () => null,
+        systemCodexHomePath: homePath,
+        sharedRuntimeCodexHomePath: null,
+        resolveVerifiedResumeHome
+      })
+    ).resolves.toEqual({ outcome: 'resume', codexHomePath: homePath })
+    expect(resolveVerifiedResumeHome).toHaveBeenCalledWith({ homePath, transcriptPath })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -9609,6 +9609,8 @@ describe('connectPanePty', () => {
     })
     transportFactoryQueue.push(transport)
     const paneKey = makePaneKey('tab-1', LEAF_1)
+    const transcriptPath =
+      '\\\\?\\C:\\Users\\Example\\.codex\\sessions\\2026\\07\\20\\rollout-codex-session-1.jsonl'
     // Why: after restart agentStatusByPaneKey is empty — the persisted sleeping record is the only provider session id source (#5232).
     mockStoreState = {
       ...mockStoreState,
@@ -9626,7 +9628,11 @@ describe('connectPanePty', () => {
           tabId: 'tab-1',
           worktreeId: 'wt-1',
           agent: 'codex',
-          providerSession: { key: 'session_id', id: 'codex-session-1' },
+          providerSession: {
+            key: 'session_id',
+            id: 'codex-session-1',
+            transcriptPath
+          },
           prompt: 'finish the task',
           state: 'working',
           capturedAt: 1,
@@ -9660,6 +9666,11 @@ describe('connectPanePty', () => {
       expect.objectContaining({
         sessionId: 'lost-pty',
         command: "codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'",
+        resumeProviderSession: {
+          key: 'session_id',
+          id: 'codex-session-1',
+          transcriptPath
+        },
         env: expect.objectContaining({
           ORCA_PANE_KEY: paneKey,
           ORCA_TAB_ID: 'tab-1',


### PR DESCRIPTION
## Summary

Fix Codex cold resume on Windows when a persisted rollout uses the extended-length spelling `\\?\C:\...` but its trusted Codex home uses the equivalent `C:\...` spelling.

The provenance check now creates a comparison-only copy for strict extended drive paths. File probing and the returned transcript path still use the original path. Other Win32 device namespaces remain rejected.

The final factory stack also preserves the newer fail-closed provenance guard: broad Codex-layout recognition remains separate from the stricter trusted-rollout grammar, so ADS-shaped rollout paths are reported as rejected Codex provenance but cannot become trusted resume sources.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (full-repository lint not run; changed-file oxlint and max-lines passed)
- [ ] `pnpm typecheck` (full multi-target typecheck not run; node typecheck passed)
- [ ] `pnpm test` (full suite not run; decisive focused suites and headed E2E passed)
- [ ] `pnpm build` (production build not run; both headed lanes rebuilt in E2E mode)
- [x] `pnpm typecheck:node`
- [x] Changed-file `oxfmt --check` and `oxlint`
- [x] `node config/scripts/check-max-lines-ratchet.mjs`
- [x] `git diff --check`
- [x] Native Windows extended-path/security resolver matrix: 9 passed
- [x] Resume argv-drop suite: 10 passed
- [x] IPC unstrippable/drop-resume security cases: 4 passed
- [x] Renderer cold-restore/fresh-banner cases: 2 passed
- [x] Headed Electron cold-resume factory lane: `\\?\C:\...` rollout resumed after daemon death/restart and the provider session ID was visible in the terminal
- [x] Identical headed disabled oracle: the same rollout started fresh and the user-visible unavailable-resume banner appeared
- [x] Current-main baseline and disabled oracle both reproduce the fresh-session outcome; the factory changes it to resume

The broader resolver/preparation run still has 11 native-Windows failures from inherited POSIX-path fixtures; the same failures reproduce unchanged on pristine `main`. All decisive extended-path, ADS/device rejection, real-file, argv-drop, IPC fail-closed, and renderer resume cases pass.

## AI Review Report

Reviewed the complete four-file diff for ownership, security, performance, cleanup, native Windows behavior, SSH and folder-workspace neutrality, provider scope, and Git 2.25 compatibility. The Codex provenance resolver is the authoritative owner: the comparison fold belongs at the trust boundary, not in global path normalization or renderer/session transport.

The change adds no scanning, commands, IPC, network access, dependencies, or production file mutation. Non-namespace paths are returned unchanged, so macOS/Linux, SSH, remote runtimes, folder workspaces, and Git worktrees keep their existing behavior. No Git command or provider-review behavior changes.

## Security Audit

Only strict `\\?\<drive>:\...` paths can lose the prefix for containment comparison. `\\.\...`, `\\?\GLOBALROOT\...`, UNC/volume/device namespaces, different roots, traversal, invalid rollout layouts, ADS-shaped filenames, and missing/non-regular files remain rejected. Rejected originating provenance cannot fall back to scanning another home, and the original transcript path is retained for the regular-file check and resume result.

No workflow, action, package manifest, lockfile, dependency, download, credential, or permission surface changed.

## Notes

Windows-specific fix; no behavior change is intended on macOS or Linux. `\\?\UNC\...` remains intentionally unsupported at this boundary. The headed test uses a hermetic command stub rather than an authenticated Codex CLI, while exercising the real Electron persistence, daemon termination, restart, trust, and user-visible terminal path.

X (Twitter) handle: N/A

## ELI5

Windows can spell the same local file as both `C:\...` and `\\?\C:\...`. Orca now compares those spellings as the same trusted Codex rollout without weakening the checks that reject device paths, network namespaces, or alternate data streams.
