### PR TITLE
fix(win): taskkill plain-shell PTY trees on immediate teardown

### DIFF
--- a/src/main/daemon/terminal-host-session-reaping-leak.test.ts
+++ b/src/main/daemon/terminal-host-session-reaping-leak.test.ts
@@ -15,6 +15,11 @@ import { TerminalHost } from './terminal-host'
 import type { SubprocessHandle } from './session'
 import { HeadlessEmulator } from './headless-emulator'
 
+const killWithDescendantSweepMock = vi.hoisted(() => vi.fn())
+vi.mock('../pty-descendant-termination', () => ({
+  killWithDescendantSweep: killWithDescendantSweepMock
+}))
+
 function createMockSubprocess(): SubprocessHandle & {
   _onExitCb: ((code: number) => void) | null
 } {
@@ -50,8 +55,14 @@ describe('TerminalHost dead-session reaping (leak regression)', () => {
   let host: TerminalHost
   let lastSubprocess: ReturnType<typeof createMockSubprocess>
   let emulatorDispose: ReturnType<typeof vi.spyOn>
+  let platformDescriptor: PropertyDescriptor | undefined
 
   beforeEach(() => {
+    // Pin POSIX so immediate force-kill teardown is deterministic across host OSes; the
+    // Windows taskkill tree-kill path is covered in terminal-session-teardown.test.ts.
+    platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+    killWithDescendantSweepMock.mockReset()
     emulatorDispose = vi.spyOn(HeadlessEmulator.prototype, 'dispose')
     const spawnFn = vi.fn(() => {
       lastSubprocess = createMockSubprocess()
@@ -63,6 +74,9 @@ describe('TerminalHost dead-session reaping (leak regression)', () => {
   afterEach(async () => {
     await host.dispose()
     emulatorDispose.mockRestore()
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+    }
   })
 
   function streamClient() {
@@ -117,6 +131,11 @@ describe('TerminalHost dead-session reaping (leak regression)', () => {
 
     const killed = host.kill('session-1', { immediate: true })
 
+    // Immediate teardown skips the graceful kill and force-kills the child directly. On POSIX
+    // that reaches the child pgroup, so no Windows taskkill /T /F descendant sweep is needed.
+    expect(lastSubprocess.kill).not.toHaveBeenCalled()
+    expect(lastSubprocess.forceKill).toHaveBeenCalled()
+    expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
     expect(emulatorDispose).not.toHaveBeenCalled()
     expect(host.listSessions()).toHaveLength(1)
     lastSubprocess._onExitCb?.(137)
@@ -125,6 +144,7 @@ describe('TerminalHost dead-session reaping (leak regression)', () => {
     // Emulator freed and session dropped from the map (no lingering dead entry).
     expect(emulatorDispose).toHaveBeenCalledTimes(1)
     expect(host.listSessions()).toHaveLength(0)
+    expect(host.isKilled('session-1')).toBe(true)
   })
 
   it('retains a graceful-timeout session until the forced child physically exits', async () => {

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -66,8 +66,13 @@ describe('TerminalHost', () => {
     _onDataCb: ((data: string) => void) | null
     _onExitCb: ((code: number) => void) | null
   }
+  let platformDescriptor: PropertyDescriptor | undefined
 
   beforeEach(() => {
+    // Pin POSIX so plain-shell teardown is deterministic across host OSes (matches linux CI);
+    // the Windows taskkill /T /F tree-kill path is covered in terminal-session-teardown.test.ts.
+    platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
     killWithDescendantSweepMock.mockReset()
     spawnFn = vi.fn(() => {
       const sub = createMockSubprocess() as ReturnType<typeof createMockSubprocess> & {
@@ -82,6 +87,9 @@ describe('TerminalHost', () => {
 
   afterEach(async () => {
     await host.dispose()
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+    }
   })
 
   it('rejects missing strict inspection', () =>
@@ -415,30 +423,8 @@ describe('TerminalHost', () => {
       ).resolves.toMatchObject({ isNew: false })
     })
 
-    it('force-kills immediately when requested', async () => {
-      await host.createOrAttach({
-        sessionId: 'session-1',
-        cols: 80,
-        rows: 24,
-        streamClient: { onData: vi.fn(), onExit: vi.fn() }
-      })
-      lastSubprocess.forceKill = vi.fn()
-
-      const killed = host.kill('session-1', { immediate: true })
-
-      expect(lastSubprocess.kill).not.toHaveBeenCalled()
-      expect(lastSubprocess.forceKill).toHaveBeenCalled()
-      expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
-      expect(lastSubprocess.dispose).not.toHaveBeenCalled()
-      expect(host.listSessions()).toHaveLength(1)
-
-      lastSubprocess._onExitCb?.(137)
-      await killed
-
-      expect(lastSubprocess.dispose).toHaveBeenCalled()
-      expect(host.listSessions()).toHaveLength(0)
-      expect(host.isKilled('session-1')).toBe(true)
-    })
+    // Plain-shell immediate force-kill (POSIX no-sweep + Windows taskkill tree) is covered in
+    // terminal-host-session-reaping-leak.test.ts and terminal-session-teardown.test.ts.
 
     it('escalates an already-graceful termination and joins its physical exit', async () => {
       await host.createOrAttach({

--- a/src/main/daemon/terminal-session-teardown.test.ts
+++ b/src/main/daemon/terminal-session-teardown.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TerminalSessionTeardown } from './terminal-session-teardown'
+import type { Session } from './session'
+
+const killWithDescendantSweepMock = vi.hoisted(() => vi.fn())
+vi.mock('../pty-descendant-termination', () => ({
+  killWithDescendantSweep: killWithDescendantSweepMock
+}))
+
+function createPlainShellSession(overrides: Partial<Session> = {}): Session {
+  return {
+    launchAgent: undefined,
+    pid: 4242,
+    isAlive: true,
+    forceKillAndWaitForExit: vi.fn(async () => {}),
+    kill: vi.fn(),
+    ...overrides
+  } as unknown as Session
+}
+
+describe('TerminalSessionTeardown plain-shell teardown', () => {
+  let platformDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    killWithDescendantSweepMock.mockReset()
+    killWithDescendantSweepMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+    }
+  })
+
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { configurable: true, value })
+  }
+
+  it('win32 immediate kill taskkills the descendant tree before force-kill', async () => {
+    // Why: a live pnpm/node child otherwise survives the ConPTY close, keeps the console
+    // non-empty, and holds the worktree cwd — failing destructive removal (#10004/#10100).
+    setPlatform('win32')
+    const session = createPlainShellSession()
+    const teardown = new TerminalSessionTeardown(new Map([['s1', session]]))
+
+    await teardown.killSession('s1', session, true)
+
+    expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+      4242,
+      expect.any(Function),
+      expect.objectContaining({ ownsRoot: expect.any(Function) })
+    )
+    expect(session.forceKillAndWaitForExit).toHaveBeenCalled()
+    // The sweep owns the taskkill; the killRoot callback is a no-op so force-kill drives exit.
+    const killRoot = killWithDescendantSweepMock.mock.calls[0][1] as () => void
+    expect(() => killRoot()).not.toThrow()
+  })
+
+  it('win32 sweep ownsRoot guard requires the live session to still own the id', async () => {
+    setPlatform('win32')
+    const session = createPlainShellSession()
+    const sessions = new Map([['s1', session]])
+    const teardown = new TerminalSessionTeardown(sessions)
+
+    await teardown.killSession('s1', session, true)
+    const ownsRoot = (killWithDescendantSweepMock.mock.calls[0][2] as { ownsRoot: () => boolean })
+      .ownsRoot
+    expect(ownsRoot()).toBe(true)
+
+    // A natural exit or reap must stop us from taskkilling a recycled PID.
+    ;(session as unknown as { isAlive: boolean }).isAlive = false
+    expect(ownsRoot()).toBe(false)
+    sessions.delete('s1')
+    ;(session as unknown as { isAlive: boolean }).isAlive = true
+    expect(ownsRoot()).toBe(false)
+  })
+
+  it('non-win32 immediate kill skips the tree kill (pgroup force-kill suffices)', async () => {
+    setPlatform('linux')
+    const session = createPlainShellSession()
+    const teardown = new TerminalSessionTeardown(new Map([['s1', session]]))
+
+    await teardown.killSession('s1', session, true)
+
+    expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
+    expect(session.forceKillAndWaitForExit).toHaveBeenCalled()
+  })
+
+  it('non-immediate (graceful) kill uses the plain kill path without a sweep', async () => {
+    setPlatform('win32')
+    const session = createPlainShellSession()
+    const teardown = new TerminalSessionTeardown(new Map([['s1', session]]))
+
+    await teardown.killSession('s1', session, false)
+
+    expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
+    expect(session.forceKillAndWaitForExit).not.toHaveBeenCalled()
+    expect(session.kill).toHaveBeenCalled()
+  })
+})

--- a/src/main/daemon/terminal-session-teardown.test.ts
+++ b/src/main/daemon/terminal-session-teardown.test.ts
@@ -13,6 +13,7 @@ function createPlainShellSession(overrides: Partial<Session> = {}): Session {
     pid: 4242,
     isAlive: true,
     forceKillAndWaitForExit: vi.fn(async () => {}),
+    beginTermination: vi.fn(() => true),
     kill: vi.fn(),
     ...overrides
   } as unknown as Session
@@ -55,6 +56,23 @@ describe('TerminalSessionTeardown plain-shell teardown', () => {
     // The sweep owns the taskkill; the killRoot callback is a no-op so force-kill drives exit.
     const killRoot = killWithDescendantSweepMock.mock.calls[0][1] as () => void
     expect(() => killRoot()).not.toThrow()
+  })
+
+  it('win32 immediate kill claims termination before awaiting the sweep', async () => {
+    // Why: createOrAttach rejects a doomed plain shell only via isTerminating, so the claim
+    // must land before the taskkill await or an attach can bind a pane to a dying session.
+    setPlatform('win32')
+    const session = createPlainShellSession()
+    const beginTermination = session.beginTermination as unknown as ReturnType<typeof vi.fn>
+    let claimedBeforeSweep = false
+    killWithDescendantSweepMock.mockImplementation(async () => {
+      claimedBeforeSweep = beginTermination.mock.calls.length === 1
+    })
+    const teardown = new TerminalSessionTeardown(new Map([['s1', session]]))
+
+    await teardown.killSession('s1', session, true)
+
+    expect(claimedBeforeSweep).toBe(true)
   })
 
   it('win32 sweep ownsRoot guard requires the live session to still own the id', async () => {

--- a/src/main/daemon/terminal-session-teardown.ts
+++ b/src/main/daemon/terminal-session-teardown.ts
@@ -55,6 +55,9 @@ export class TerminalSessionTeardown {
    */
   private async forceKillPlainShellSession(sessionId: string, session: Session): Promise<void> {
     if (process.platform === 'win32') {
+      // Why: forceKillAndWaitForExit claims termination synchronously; awaiting the sweep
+      // ahead of it would leave attach open on a doomed session for the taskkill's duration.
+      session.beginTermination()
       await killWithDescendantSweep(session.pid, () => {}, {
         // Why: the descendant tree is only ours while this Session still owns the live root PID.
         ownsRoot: () => this.sessions.get(sessionId) === session && session.isAlive

--- a/src/main/daemon/terminal-session-teardown.ts
+++ b/src/main/daemon/terminal-session-teardown.ts
@@ -38,10 +38,29 @@ export class TerminalSessionTeardown {
       return this.killAgentSession(sessionId, session, immediate)
     }
     if (immediate) {
-      return session.forceKillAndWaitForExit()
+      return this.forceKillPlainShellSession(sessionId, session)
     } else {
       session.kill()
     }
+  }
+
+  /**
+   * Immediate teardown of a non-agent shell. On Windows, closing the ConPTY does not
+   * reap orphaned children (node-pty `useConptyDll` skips the console-process reap), so a
+   * live `pnpm i`/`node` survives shell exit, keeps the ConPTY console non-empty, and holds
+   * the worktree cwd — failing destructive worktree removal with "Failed to physically stop
+   * every PTY". taskkill /T /F the tree first so physical exit becomes verifiable. Mirrors
+   * the agent path (#10004/#10100). POSIX shells already reach their child pgroup on
+   * forceKill, so they stay on the plain force-kill path.
+   */
+  private async forceKillPlainShellSession(sessionId: string, session: Session): Promise<void> {
+    if (process.platform === 'win32') {
+      await killWithDescendantSweep(session.pid, () => {}, {
+        // Why: the descendant tree is only ours while this Session still owns the live root PID.
+        ownsRoot: () => this.sessions.get(sessionId) === session && session.isAlive
+      })
+    }
+    await session.forceKillAndWaitForExit()
   }
 
   private killAgentSession(

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1510,6 +1510,39 @@ describe('LocalPtyProvider', () => {
 
       expect(terminateDescendants).not.toHaveBeenCalled()
     })
+
+    it('win32 immediate shutdown of a plain shell taskkills the descendant tree', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      await provider.shutdown(id, { immediate: true })
+
+      // Why: an orphaned pnpm/node child otherwise keeps the ConPTY console alive and holds
+      // the worktree cwd; the sweep taskkill /T /F clears the tree so removal can proceed.
+      expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+        mockProc.pid,
+        expect.any(Function),
+        expect.objectContaining({ ownsRoot: expect.any(Function) })
+      )
+    })
+
+    it('win32 graceful shutdown of a plain shell does not taskkill the tree', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      await provider.shutdown(id, { immediate: false })
+
+      expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
+    })
+
+    it('non-win32 immediate shutdown of a plain shell skips the tree kill', async () => {
+      // beforeEach pins platform to linux; POSIX force-kill already reaches the child pgroup.
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+
+      await provider.shutdown(id, { immediate: true })
+
+      expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('hasChildProcesses', () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1128,6 +1128,14 @@ export class LocalPtyProvider implements IPtyProvider {
       await killWithDescendantSweep(proc.pid, signalRoot, {
         ownsRoot: () => ptyProcesses.get(id) === proc
       })
+    } else if (process.platform === 'win32' && operation.immediate) {
+      // Why: a plain shell's ConPTY teardown doesn't reap orphaned children (useConptyDll
+      // skips the console reap), so a live `pnpm i`/`node` keeps the ConPTY console alive and
+      // holds the worktree cwd, failing destructive removal. taskkill /T /F clears the tree so
+      // physical stop is verifiable. POSIX shells reach their child pgroup on forceKill (#10004).
+      await killWithDescendantSweep(proc.pid, signalRoot, {
+        ownsRoot: () => ptyProcesses.get(id) === proc
+      })
     } else {
       signalRoot()
     }


### PR DESCRIPTION
## Problem

On Windows, deleting a worktree that still has a **live process running in a terminal tab** (a `pnpm i`, or any command that spawns a child tree) fails after the full ~10s teardown deadline with:

> Failed to physically stop every PTY for worktree: …

## Root cause

Closing a plain shell's ConPTY on Windows does **not** reap its orphaned children — node-pty's `useConptyDll` skips the console-process reap. So a live `pnpm i`/`node` child:

1. survives the shell root's exit,
2. keeps the ConPTY console non-empty (the daemon therefore still reports the PTY session **alive**), and
3. holds the worktree cwd handle.

The destructive-removal *physical-stop verification* (`killAllProcessesForWorktree` with `requirePhysicalStop`) then can't prove the PTY exited and fails closed.

[#10100](https://github.com/stablyai/orca/pull/10100) added a `taskkill /T /F` descendant tree-kill (`killWithDescendantSweep`) for **agent** sessions, but **plain shells were never swept** — so a terminal tab running an install still blocked deletion. This is a long-standing gap, not a regression in the current RC.

## Fix

Extend the Windows `taskkill /T /F` descendant tree-kill to **non-agent shells on the immediate/destructive teardown path**, in both surfaces:

- `TerminalSessionTeardown.forceKillPlainShellSession` (daemon — default on Windows)
- `LocalPtyProvider.shutdownTrackedPty` (non-daemon / fallback config)

Gated to **win32 + immediate**, reusing `killWithDescendantSweep` so it inherits the same `ownsRoot` guard (never signals a naturally-exited / recycled PID) and the bounded, `windowsHide` taskkill. POSIX shells already reach their child pgroup on `forceKill` and are left unchanged.

## Reproduced & verified (Electron dev build)

- **Before:** worktree with a live `node` child → force-delete fails after **10.0s** with `Failed to physically stop every PTY`; the child survives as an orphan holding the cwd.
- **After:** the child tree is taskkilled, the directory is removed, and the delete **succeeds in ~1.8s**; no orphaned process remains.

## Tests

- `terminal-session-teardown.test.ts` (new): win32 immediate → sweep before force-kill; `ownsRoot` guard (dead / reassigned session → `false`); non-win32 immediate → no sweep; graceful → plain kill path.
- `local-pty-provider.test.ts`: win32 immediate → tree kill; win32 graceful → no tree kill; non-win32 immediate → no tree kill.
- `terminal-host-session-reaping-leak.test.ts` / `terminal-host.test.ts`: pinned to a POSIX platform for deterministic plain-shell teardown assertions across host OSes.

Typecheck + lint clean; affected suites green.

## Behavior note

Because worktree **sleep** also stops PTYs via `immediate: true` (`keepHistory` preserves scrollback, not the process), Windows sleep now tree-kills descendants too. Previously a `pnpm dev` orphaned by a slept worktree kept running with no attached terminal while pinning the worktree cwd — that orphan *is* the reported bug. POSIX already killed the child pgroup here, so this aligns Windows with existing POSIX behavior rather than introducing a new policy. Sleep is user-initiated, so a Windows user who sleeps a worktree with a dev server running will now see it stop.

## Review follow-up

Fixed an attach race introduced by the first commit: `forceKillAndWaitForExit` claims termination synchronously, so awaiting the sweep ahead of it left `createOrAttach`'s doomed-session guard (`terminal-host-session-create.ts:38`) open for the taskkill's duration — a concurrent attach could bind a pane to a session about to be tree-killed. Plain shells never register in the teardown `operations` map, so `isTerminating` is the only fence. Now claims `session.beginTermination()` before the sweep, mirroring the agent path; covered by a regression test that fails without the claim.
