### PR TITLE
fix(skills): decouple skill-manifest verify from local git tags

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,9 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          # Why: the freshness registry is derived from immutable release tags,
-          # so shallow PR checkouts cannot verify historical official identities.
-          fetch-depth: 0
+          # Why: verify:skill-bundle-manifest now checks working-tree bytes
+          # against the committed skill ledger (advanced only at release cut) and
+          # no longer walks release tags, so a shallow checkout is sufficient.
           persist-credentials: false
 
       - name: Install native build tools

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -476,7 +476,14 @@ jobs:
           # message and tag name explicitly (avoids npm's `v1.2.3` prefix
           # assumptions and any lifecycle scripts that would run on bump).
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-          git add package.json
+          # Why: release cut is the single authoritative point where the released
+          # skill ledger advances — this version's working-tree bytes become an
+          # immutable released revision so future builds recognize them as an
+          # official snapshot. It is the only place skill artifacts regenerate;
+          # ordinary lint verifies working-tree bytes against the committed ledger
+          # and never walks tags. Uses only Node built-ins, so no install needed.
+          node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"
+          git add package.json resources/skills
           commit_message="release: v$VERSION"
           if [[ "$EVENT_NAME" == "schedule" ]]; then
             commit_message="$commit_message [rc-slot:$SLOT]"

--- a/config/scripts/generate-skill-bundle-manifest.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.mjs
@@ -370,14 +370,64 @@ function buildReleasedHistory() {
   return { registry, mapping }
 }
 
-// Why: the artifacts must be pure functions of skills/ bytes and release-tag
-// history. Stamping the app version made every release cut invalidate the
-// committed output on all open branches and drag skill CI onto unrelated PRs.
-async function buildArtifacts() {
+// Why: released history is authoritative committed data, advanced only at
+// release cut. Seeding generation from the committed registry + mapping makes
+// ordinary verify/regeneration a pure function of working-tree bytes, so it
+// never walks git tags — the root cause of recurring lint drift when a clone
+// holds stray, deleted, or fork tags the committed artifacts predate.
+function releasedHistoryFromCommitted(committedRegistry, committedMapping) {
+  const registry = { schemaVersion: SNAPSHOT_REGISTRY_SCHEMA_VERSION, skills: {} }
+  const releasedSnapshotCounts = {}
+  const mapping =
+    committedMapping && committedMapping.schemaVersion === RELEASE_MAPPING_SCHEMA_VERSION
+      ? structuredClone(committedMapping)
+      : { schemaVersion: RELEASE_MAPPING_SCHEMA_VERSION, releases: [] }
+  if (committedRegistry && committedRegistry.schemaVersion === SNAPSHOT_REGISTRY_SCHEMA_VERSION) {
+    const mappedCounts = releasedSnapshotCountsFromMapping(mapping)
+    for (const [name, snapshots] of Object.entries(committedRegistry.skills ?? {})) {
+      // The committed registry carries at most one unreleased tail beyond the
+      // revisions named by the mapping; drop it and recompute it from bytes.
+      const releasedCount = mappedCounts?.[name] ?? Math.max(0, snapshots.length - 1)
+      registry.skills[name] = snapshots.slice(0, releasedCount)
+      releasedSnapshotCounts[name] = releasedCount
+    }
+  }
+  return { registry, mapping, releasedSnapshotCounts }
+}
+
+// Why: disaster recovery only. Reconstruct released history from the immutable
+// release tags when the committed ledger must be rebuilt from scratch. Kept off
+// the verify/regenerate path — walking tags there is what coupled lint to the
+// executing clone's tag state and broke it on version bumps, new tags, and
+// stray/deleted local tags.
+function releasedHistoryFromTags() {
   const { registry, mapping } = buildReleasedHistory()
   const releasedSnapshotCounts = Object.fromEntries(
     Object.entries(registry.skills).map(([name, snapshots]) => [name, snapshots.length])
   )
+  return { registry, mapping, releasedSnapshotCounts }
+}
+
+// Why: release cut is the single authoritative point where working-tree bytes
+// become an immutable released revision. Append one mapping row for the version,
+// mirroring the historical dedupe where consecutive identical skill trees share
+// the earliest release's row.
+function appendReleaseRow(artifacts, version) {
+  const appVersion = version.startsWith('v') ? version.slice(1) : version
+  const currentRevisions = {}
+  for (const skill of artifacts.currentManifest.skills) {
+    currentRevisions[skill.name] = skill.releaseRevision
+  }
+  const releases = artifacts.releaseMapping.releases
+  const last = releases.at(-1)
+  if (last && isDeepStrictEqual(last.skills, currentRevisions)) {
+    return
+  }
+  releases.push({ appVersion, skills: currentRevisions })
+}
+
+async function buildArtifacts(releasedHistory) {
+  const { registry, mapping, releasedSnapshotCounts } = releasedHistory
   const skillDirectories = (await readdir(SKILLS_ROOT, { withFileTypes: true }))
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
@@ -557,13 +607,32 @@ async function verifyArtifacts(artifacts) {
 }
 
 async function main() {
-  const artifacts = await buildArtifacts()
-  assertReleasedHistoryPreserved(
-    await readCommittedRegistry(),
-    artifacts,
-    await readCommittedReleaseMapping()
-  )
-  await (process.argv.includes('--write') ? writeArtifacts : verifyArtifacts)(artifacts)
+  const argv = process.argv.slice(2)
+  const rebuildFromTags = argv.includes('--rebuild-from-tags')
+  const releaseIndex = argv.indexOf('--release')
+  const releaseVersion = releaseIndex >= 0 ? argv[releaseIndex + 1] : null
+  if (releaseIndex >= 0 && !releaseVersion) {
+    throw new Error('--release requires a version argument, e.g. --release 1.4.160')
+  }
+
+  const committedRegistry = await readCommittedRegistry()
+  const committedMapping = await readCommittedReleaseMapping()
+  const releasedHistory = rebuildFromTags
+    ? releasedHistoryFromTags()
+    : releasedHistoryFromCommitted(committedRegistry, committedMapping)
+  const artifacts = await buildArtifacts(releasedHistory)
+
+  if (releaseVersion) {
+    appendReleaseRow(artifacts, releaseVersion)
+  }
+
+  // Why: released snapshots are append-only. The committed registry/mapping are
+  // read fresh here so the artifacts (which may have appended a release row) can
+  // never alias what we validate against.
+  assertReleasedHistoryPreserved(committedRegistry, artifacts, committedMapping)
+
+  const shouldWrite = releaseVersion !== null || argv.includes('--write')
+  await (shouldWrite ? writeArtifacts : verifyArtifacts)(artifacts)
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === import.meta.filename) {
@@ -574,6 +643,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === import.meta.filename) {
 }
 
 export {
+  appendReleaseRow,
   assertReleasedHistoryPreserved,
   buildArtifacts,
   buildReleasedHistory,
@@ -584,6 +654,7 @@ export {
   isToleratedReleaseMappingPrefix,
   normalizeText,
   packageDigest,
+  releasedHistoryFromCommitted,
   sortManifestFiles,
   verifyArtifacts,
   writeArtifacts

--- a/config/scripts/generate-skill-bundle-manifest.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.mjs
@@ -423,6 +423,19 @@ function appendReleaseRow(artifacts, version) {
   if (last && isDeepStrictEqual(last.skills, currentRevisions)) {
     return
   }
+  // Why: a cut that pushed the version bump to main but died before pushing the
+  // tag is re-cut at the same version. If skills changed in between, appending
+  // would leave two rows claiming this version and the stale one would name
+  // revisions that tag never ships — overwrite, since the tag ships these bytes.
+  if (last?.appVersion === appVersion) {
+    releases[releases.length - 1] = { appVersion, skills: currentRevisions }
+    return
+  }
+  // Why: an earlier row means re-cutting an already-shipped version, which the
+  // cut workflow refuses upstream. Fail rather than corrupt shipped provenance.
+  if (releases.some((release) => release.appVersion === appVersion)) {
+    throw new Error(`Release mapping already has a row for ${appVersion}.`)
+  }
   releases.push({ appVersion, skills: currentRevisions })
 }
 

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -278,6 +278,43 @@ describe('skill bundle manifest generator', () => {
     expect(artifacts.releaseMapping.releases).toHaveLength(2)
   })
 
+  it('overwrites the trailing row when a failed cut is re-cut at the same version', () => {
+    const artifacts = {
+      currentManifest: { skills: [{ name: 'orca-cli', releaseRevision: 37 }] },
+      releaseMapping: {
+        schemaVersion: 1,
+        releases: [
+          { appVersion: '1.4.151', skills: { 'orca-cli': 35 } },
+          // The failed cut already pushed this row to main at revision 36.
+          { appVersion: '1.4.160', skills: { 'orca-cli': 36 } }
+        ]
+      }
+    }
+
+    appendReleaseRow(artifacts, '1.4.160')
+
+    // One row per version: the tag ships revision 37, so 36 must not linger.
+    expect(artifacts.releaseMapping.releases).toEqual([
+      { appVersion: '1.4.151', skills: { 'orca-cli': 35 } },
+      { appVersion: '1.4.160', skills: { 'orca-cli': 37 } }
+    ])
+  })
+
+  it('refuses to rewrite an already-shipped version behind the trailing row', () => {
+    const artifacts = {
+      currentManifest: { skills: [{ name: 'orca-cli', releaseRevision: 37 }] },
+      releaseMapping: {
+        schemaVersion: 1,
+        releases: [
+          { appVersion: '1.4.151', skills: { 'orca-cli': 35 } },
+          { appVersion: '1.4.160', skills: { 'orca-cli': 36 } }
+        ]
+      }
+    }
+
+    expect(() => appendReleaseRow(artifacts, '1.4.151')).toThrow(/already has a row for 1\.4\.151/)
+  })
+
   it.runIf(process.platform !== 'win32')(
     'rejects executable files in shipped skill packages',
     async () => {

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  appendReleaseRow,
   assertReleasedHistoryPreserved,
   classifyFile,
   collectPackageFiles,
@@ -12,6 +13,7 @@ import {
   isToleratedReleaseMappingPrefix,
   normalizeText,
   packageDigest,
+  releasedHistoryFromCommitted,
   sortManifestFiles
 } from './generate-skill-bundle-manifest.mjs'
 
@@ -215,6 +217,65 @@ describe('skill bundle manifest generator', () => {
     ).toBe(false)
     expect(isToleratedReleaseMappingPrefix('not json', artifacts)).toBe(false)
     expect(isToleratedReleaseMappingPrefix(serialized({ schemaVersion: 1 }), artifacts)).toBe(false)
+  })
+
+  it('seeds released history from the committed ledger and drops the floating tail', () => {
+    const snapshot = (releaseRevision, packageDigest) => ({ releaseRevision, packageDigest })
+    const committedRegistry = {
+      schemaVersion: 1,
+      skills: {
+        // released revs 1..2 named by the mapping, plus an unreleased tail at 3
+        'orca-cli': [snapshot(1, 'aaa'), snapshot(2, 'bbb'), snapshot(3, 'unreleased')],
+        // no mapping row -> fall back to all-but-tail
+        'orca-linear': [snapshot(1, 'ccc'), snapshot(2, 'tail')]
+      }
+    }
+    const committedMapping = {
+      schemaVersion: 1,
+      releases: [{ appVersion: '1.0.0', skills: { 'orca-cli': 2 } }]
+    }
+
+    const seeded = releasedHistoryFromCommitted(committedRegistry, committedMapping)
+
+    // The unreleased tail is dropped; only mapping-named revisions survive.
+    expect(seeded.registry.skills['orca-cli']).toEqual([snapshot(1, 'aaa'), snapshot(2, 'bbb')])
+    expect(seeded.registry.skills['orca-linear']).toEqual([snapshot(1, 'ccc')])
+    expect(seeded.releasedSnapshotCounts).toEqual({ 'orca-cli': 2, 'orca-linear': 1 })
+    // The seed clones the mapping so a later release append cannot alias committed state.
+    expect(seeded.mapping).toEqual(committedMapping)
+    expect(seeded.mapping).not.toBe(committedMapping)
+  })
+
+  it('returns an empty ledger when no committed artifacts exist', () => {
+    const seeded = releasedHistoryFromCommitted(null, null)
+    expect(seeded.registry.skills).toEqual({})
+    expect(seeded.releasedSnapshotCounts).toEqual({})
+    expect(seeded.mapping.releases).toEqual([])
+  })
+
+  it('appends one release row, stripping the v-prefix and deduping identical tails', () => {
+    const artifacts = {
+      currentManifest: {
+        skills: [
+          { name: 'orca-cli', releaseRevision: 36 },
+          { name: 'orca-linear', releaseRevision: 8 }
+        ]
+      },
+      releaseMapping: {
+        schemaVersion: 1,
+        releases: [{ appVersion: '1.4.151', skills: { 'orca-cli': 35, 'orca-linear': 8 } }]
+      }
+    }
+
+    appendReleaseRow(artifacts, 'v1.4.160')
+    expect(artifacts.releaseMapping.releases.at(-1)).toEqual({
+      appVersion: '1.4.160',
+      skills: { 'orca-cli': 36, 'orca-linear': 8 }
+    })
+
+    // A second release over identical revisions adds no row.
+    appendReleaseRow(artifacts, '1.4.161')
+    expect(artifacts.releaseMapping.releases).toHaveLength(2)
   })
 
   it.runIf(process.platform !== 'win32')(


### PR DESCRIPTION
## What

`verify:skill-bundle-manifest` (part of `pnpm lint`) rebuilt the **entire** released-skill history by walking every local `refs/tags/v*` on each run and demanded byte-equality with the committed artifacts. Its output was a function of `skill bytes × local tag set × release timing`, so any clone holding **stray, deleted, or fork tags** the committed artifacts predate rebuilt a divergent registry and failed lint — while CI passed (its fresh checkout only has origin's current tags).

This makes generation a **pure function of working-tree bytes**, sourcing released history from the committed ledger instead of tags.

## Why

This was the **4th instance of one failure class**, each previously patched with a new tolerance rather than removing the tag coupling:

| PR | Broke on | Patch |
|----|----------|-------|
| #8637 | (introduced tag-walk generation) | — |
| #9119 | every RC/stable **version bump** broke lint on every open branch | mapping-prefix tolerance |
| #9778 | a **new tag** claiming the next revision failed every PR | derive protected boundary from mapping |
| _this_ | **stray/deleted/fork local tags** the artifacts predate | **remove the tag walk from the hot path** |

The committed `snapshot-registry.json` + `release-mapping.json` already *are* the released history. Trusting them removes the environmental coupling at the root instead of tolerating one more symptom.

## Changes

- **`generate-skill-bundle-manifest.mjs`**
  - `releasedHistoryFromCommitted()` seeds generation from the committed ledger, dropping the floating unreleased tail (entries beyond what the mapping names). `verify` and `--write` now touch **zero git tags**.
  - Tag walk kept only behind `--rebuild-from-tags` (disaster recovery), off the everyday path.
  - `--release <version>` + `appendReleaseRow()` do the **O(1)** append of one mapping row (dedupes vs the last row, strips the `v` prefix).
- **`release-cut.yml`** — runs `generate --release "$VERSION"` before the release commit and `git add resources/skills`. The single authoritative point where the ledger advances. (Generator uses only Node built-ins — no install step.)
- **`pr.yml`** — drops `fetch-depth: 0` from the lint job; verify no longer needs tag history.

## Recognition & update behavior — unchanged

The runtime uses `knownSnapshots = registry.skills` (all entries, including the working-tree tail committed at **PR-merge** time), and the release mapping is provenance-only. So a missing mapping row (off-main release, or a cut that doesn't push main) only loses a **version label** — never recognition or the update nudge. Legacy fat installs and future stub updates keep working exactly as before.

## Trade-off

Lint no longer cross-checks committed **historical** snapshots against tags (that cross-check was the flaky thing). A hand-edit to an old released entry is still caught by the runtime `manifest ↔ registry` consistency check when the current manifest points at it, and can be audited anytime with `--rebuild-from-tags`.

## Verification

- `verify` passes committed-sourced; `--write` is **zero-diff** (byte parity with committed).
- A planted stray `v99.99.99` tag (the exact failure class) **no longer changes output**.
- edit-stub → `--write` → `--release` appends the correct single mapping row; double `--release` is **idempotent**.
- `--rebuild-from-tags` reproduces the committed artifacts.
- Generator tests **14 pass / 1 skip**; runtime `skill-bundle-artifacts` + `skill-freshness-inventory` **14 pass**; `verify:bundled-skill-guides` passes; oxlint + oxfmt clean.

No runtime code changed; committed `resources/skills/*.json` are untouched, so the transition is seamless (no regeneration commit needed at land).