### PR TITLE
fix(terminal): reroute misrouted local spawns to the owning SSH host

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -889,6 +889,111 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  describe('fresh-clone SSH spawn reroute', () => {
+    const connectionId = 'ssh-1'
+    const worktreeId = 'repo-fresh::/home/user/proj'
+
+    function buildRerouteHarness(repos: { id: string; connectionId?: string }[]): {
+      sshSpawn: ReturnType<typeof vi.fn>
+      localSpawn: ReturnType<typeof vi.fn>
+    } {
+      const sshSpawn = vi.fn(async () => ({ id: 'ssh-pty' }))
+      const localSpawn = vi.fn(async () => ({ id: 'local-pty' }))
+      setLocalPtyProvider(createAgentClaimProvider({ spawn: localSpawn }) as never)
+      registerSshPtyProvider(connectionId, createAgentClaimProvider({ spawn: sshSpawn }) as never)
+      const store = {
+        getRepos: vi.fn(() => repos),
+        persistPtyBinding: vi.fn(),
+        upsertSshRemotePtyLease: vi.fn(),
+        removeSshRemotePtyLease: vi.fn(),
+        markSshRemotePtyLease: vi.fn()
+      }
+      handlers.clear()
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        store as never
+      )
+      return { sshSpawn, localSpawn }
+    }
+
+    it('reroutes a local spawn to the owning SSH connection for a freshly-cloned repo', async () => {
+      const { sshSpawn, localSpawn } = buildRerouteHarness([{ id: 'repo-fresh', connectionId }])
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/home/user/proj',
+        connectionId: undefined,
+        worktreeId
+      })
+      expect(sshSpawn).toHaveBeenCalledTimes(1)
+      expect(localSpawn).not.toHaveBeenCalled()
+    })
+
+    it('leaves a genuine local spawn on the local provider', async () => {
+      const { sshSpawn, localSpawn } = buildRerouteHarness([
+        { id: 'repo-fresh', connectionId: undefined }
+      ])
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/home/user/proj',
+        connectionId: undefined,
+        worktreeId
+      })
+      expect(localSpawn).toHaveBeenCalledTimes(1)
+      expect(sshSpawn).not.toHaveBeenCalled()
+    })
+
+    it('does not reroute when the repo id is ambiguous across hosts', async () => {
+      const { sshSpawn, localSpawn } = buildRerouteHarness([
+        { id: 'repo-fresh', connectionId: undefined },
+        { id: 'repo-fresh', connectionId }
+      ])
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/home/user/proj',
+        connectionId: undefined,
+        worktreeId
+      })
+      expect(localSpawn).toHaveBeenCalledTimes(1)
+      expect(sshSpawn).not.toHaveBeenCalled()
+    })
+
+    it('does not reroute when the SSH provider is not registered', async () => {
+      const localSpawn = vi.fn(async () => ({ id: 'local-pty' }))
+      setLocalPtyProvider(createAgentClaimProvider({ spawn: localSpawn }) as never)
+      const store = {
+        getRepos: vi.fn(() => [{ id: 'repo-fresh', connectionId }]),
+        persistPtyBinding: vi.fn(),
+        upsertSshRemotePtyLease: vi.fn(),
+        removeSshRemotePtyLease: vi.fn(),
+        markSshRemotePtyLease: vi.fn()
+      }
+      handlers.clear()
+      registerPtyHandlers(
+        mainWindow as never,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        store as never
+      )
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        cwd: '/home/user/proj',
+        connectionId: undefined,
+        worktreeId
+      })
+      expect(localSpawn).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('rejects renderer persistence when a local PTY exits before spawn settles', async () => {
     const ptyId = 'pty-renderer-early-exit'
     const incarnationId = 'incarnation-renderer-early-exit'

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -122,7 +122,7 @@ import {
   type TerminalStartupCwdMissingDirFallback
 } from '../../shared/terminal-startup-cwd'
 import { isWslUncPath } from '../../shared/wsl-paths'
-import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
+import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import type { AgentSessionOwnerBinding } from '../../shared/agent-session-host-authority'
 import {
   agentSessionOwnerBindingsEqual,
@@ -476,6 +476,32 @@ function getProvider(connectionId: string | null | undefined): IPtyProvider {
     throw new Error(`No PTY provider for connection "${connectionId}"`)
   }
   return provider
+}
+
+// Why: right after a fresh remote clone the renderer can briefly resolve the new
+// worktree to the local host (empty connectionId) before its SSH ownership
+// settles, so a spawn would run on localProvider with a remote cwd and fail with
+// "Working directory does not exist" until restart. Main owns the authoritative
+// repo catalog, so correct the route here — but only when it's unambiguous and
+// the SSH provider is live, never guessing.
+function resolveMisroutedSshConnectionId(
+  store: Store | undefined,
+  connectionId: string | null | undefined,
+  worktreeId: string | undefined
+): string | null {
+  if (connectionId || !worktreeId || !store) {
+    return null
+  }
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  const owners = store.getRepos().filter((repo) => repo.id === repoId)
+  if (owners.length !== 1) {
+    return null
+  }
+  const ownerConnectionId = owners[0].connectionId?.trim()
+  if (!ownerConnectionId || !sshProviders.has(ownerConnectionId)) {
+    return null
+  }
+  return ownerConnectionId
 }
 
 function getProviderForPty(ptyId: string): IPtyProvider {
@@ -4012,6 +4038,21 @@ export function registerPtyHandlers(
       }
     ) => {
       const spawnTiming = createPtySpawnTiming()
+      // Why: recover a fresh-clone spawn the renderer misrouted to local before
+      // the new worktree's SSH ownership settled; otherwise it spawns on
+      // localProvider with a remote cwd and fails "Working directory does not
+      // exist" until restart. Rewrite first so the whole handler treats it as SSH.
+      const misroutedSshConnectionId = resolveMisroutedSshConnectionId(
+        store,
+        args.connectionId,
+        args.worktreeId
+      )
+      if (misroutedSshConnectionId) {
+        console.warn(
+          `[pty:spawn] rerouting local spawn for worktree "${args.worktreeId}" to SSH connection "${misroutedSshConnectionId}"`
+        )
+        args.connectionId = misroutedSshConnectionId
+      }
       const startupPromise = getLocalPtyStartupPromise(args.connectionId)
       if (startupPromise) {
         await startupPromise


### PR DESCRIPTION
## Summary

Fixes a bug where, after cloning a Git repo onto an **already-connected remote SSH server**, the first attempt to open a Terminal in the new project failed with **"Working directory … does not exist"** (文件路径不存在) and only started working after restarting the client.

Root cause: right after a fresh clone, the renderer can briefly resolve the new worktree to the **local** host (empty `connectionId`) before its SSH ownership settles. `pty:spawn` then runs on the **local** PTY provider with a **remote** cwd; the local machine has no such path, so `validateWorkingDirectory` throws ([`src/main/providers/local-pty-utils.ts`](https://github.com/stablyai/orca/blob/main/src/main/providers/local-pty-utils.ts)). This stayed broken until a restart re-loaded the SSH repo and routing resolved to SSH again.

Fix: the main process owns the authoritative repo catalog, so correct the route there. In the `pty:spawn` handler, when `connectionId` is empty but the worktree's repo is **unambiguously** owned by a **connected** SSH host, reroute the spawn to that SSH provider. Guarded to act only when exactly one repo owns the worktree id, it has a `connectionId`, and its SSH PTY provider is registered — otherwise behavior is unchanged.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added a focused regression suite in `src/main/ipc/pty.test.ts` ("fresh-clone SSH spawn reroute") covering: reroute to the owning SSH connection, no reroute for a genuine local spawn, no reroute when the repo id is ambiguous across hosts, and no reroute when the SSH provider is not registered.

> Note: the lint/typecheck/test/build commands were **not run in the authoring environment** (no `node_modules`/`pnpm` available in this worktree). Please run the checklist in CI / an installed checkout. Targeted run: `pnpm vitest run src/main/ipc/pty.test.ts`.

Manual verification: connect a remote SSH host, clone a repo into it, and open a Terminal in the new project **without restarting** — it should attach to the remote shell in the cloned directory instead of erroring "Working directory does not exist".

## AI Review Report

Reviewed the change for correctness and blast radius:
- **Correctness:** the guard only rewrites `connectionId` when a single repo owns the worktree id, that repo has a non-empty `connectionId`, and the corresponding SSH PTY provider is currently registered. A local repo (no `connectionId`) is never rerouted; an ambiguous id (local + SSH sharing the id) is left untouched; an unregistered provider falls through to the existing "No PTY provider"/reconnect flow rather than a wrong local spawn.
- **Cross-platform (macOS/Linux/Windows):** the guard is platform-agnostic — pure string/route logic (`getRepoIdFromWorktreeId`, repo lookup, `sshProviders.has`). No shortcuts, labels, paths, shell behavior, or Electron platform APIs are touched. The rewrite happens before cwd-fallback and provider selection so all downstream platform handling is unchanged.
- Verified `resolveMisroutedSshConnectionId` runs before `getLocalPtyStartupPromise`, so a rerouted SSH spawn no longer waits on the local-daemon startup barrier.

## Security Audit

IPC input handling for `pty:spawn`: the guard only **narrows** routing to an SSH provider that is already registered and owned by a repo already present in the store — it never broadens filesystem or host access, and cannot route to an arbitrary/attacker-specified connection (the connection is derived from the stored repo, not from renderer input). No new command execution, path handling, auth, secret, or dependency surface is introduced.

## Notes

Scoped to the desktop renderer `pty:spawn` handler where the bug occurs; the runtime-owned controller spawn path (which receives an explicit resolved `connectionId`) is intentionally left unchanged.

## ELI5

Right after cloning a repo onto an already-connected SSH host, the first terminal could fail saying the path does not exist until restart. Local spawns that belong to SSH are re-routed to the owning host once ownership settles.
