### PR TITLE
fix(source-control): allow http web scheme for ssh remotes

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.test.ts
+++ b/src/main/codex-accounts/runtime-home-service.test.ts
@@ -158,6 +158,7 @@ function createSettings(overrides: TestSettingsOverrides = {}): GlobalSettings {
     agentCmdOverrides: {},
     keepComputerAwakeWhileAgentsRun: false,
     confirmClosePinnedTab: true,
+    gitHostWebSchemes: {},
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,
     terminalJISYenToBackslash: false,

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -163,6 +163,7 @@ function createSettings(overrides: TestSettingsOverrides = {}): GlobalSettings {
     agentCmdOverrides: {},
     keepComputerAwakeWhileAgentsRun: false,
     confirmClosePinnedTab: true,
+    gitHostWebSchemes: {},
     terminalMacOptionAsAlt: 'false',
     terminalMacOptionAsAltMigrated: true,
     terminalJISYenToBackslash: false,

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -1500,7 +1500,8 @@ function SourceControlInner(): React.JSX.Element {
         repoRemoteName: activeRepo?.gitRemoteIdentity?.remoteName ?? null,
         repoRemoteUrl: activeRepo?.gitRemoteIdentity?.remoteUrl ?? null,
         pushTarget: activeWorktree?.pushTarget ?? null,
-        upstreamName: remoteStatus?.upstreamName ?? null
+        upstreamName: remoteStatus?.upstreamName ?? null,
+        webSchemeByHost: settings?.gitHostWebSchemes ?? null
       }),
     [
       activeRepo?.gitRemoteIdentity?.remoteName,
@@ -1516,7 +1517,8 @@ function SourceControlInner(): React.JSX.Element {
       linkedGitHubPR,
       linkedGitLabMR,
       linkedGiteaPR,
-      remoteStatus?.upstreamName
+      remoteStatus?.upstreamName,
+      settings?.gitHostWebSchemes
     ]
   )
   const shouldResolveHostedReviewCreation =

--- a/src/renderer/src/components/right-sidebar/source-control-manual-review-url.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-review-url.test.ts
@@ -157,6 +157,23 @@ describe('buildSourceControlManualReviewUrl', () => {
     )
   })
 
+  it('builds an http GitLab merge request URL when the host web scheme is overridden', () => {
+    // Why: ssh remotes carry no web scheme; http-only self-hosted GitLab needs an explicit override.
+    expect(
+      buildSourceControlManualReviewUrl({
+        baseRef: 'refs/remotes/origin/release/next',
+        branchName: 'feature/gitlab',
+        repoRemoteName: 'origin',
+        repoRemoteUrl: 'ssh://git@gitlab.company.test:2222/group/sub/orca.git',
+        provider: 'gitlab',
+        upstreamName: 'origin/feature/gitlab',
+        webSchemeByHost: { 'gitlab.company.test': 'http' }
+      })
+    ).toBe(
+      'http://gitlab.company.test/group/sub/orca/-/merge_requests/new?merge_request%5Bsource_branch%5D=feature%2Fgitlab&merge_request%5Btarget_branch%5D=release%2Fnext'
+    )
+  })
+
   it('builds a Bitbucket manual pull request URL', () => {
     expect(
       buildSourceControlManualReviewUrl({

--- a/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-manual-review-url.ts
@@ -5,6 +5,7 @@ import {
   normalizeProvider,
   parseRemoteRepo,
   parseUpstream,
+  type GitHostWebSchemes,
   type RemoteRepoRef
 } from './source-control-remote-repo'
 
@@ -17,6 +18,8 @@ type ManualReviewUrlInput = {
   pushTarget?: GitPushTarget | null
   /** Tracking upstream in `<remote>/<branch>` form (git `branch.upstream`). */
   upstreamName?: string | null
+  /** Hostname → web UI scheme for ssh remotes (self-hosted http-only forges). */
+  webSchemeByHost?: GitHostWebSchemes | null
 }
 
 export type SourceControlManualReviewContext = ManualReviewUrlInput & {
@@ -138,8 +141,9 @@ export function buildSourceControlManualReviewUrl(input: ManualReviewUrlInput): 
     return null
   }
 
-  const baseRepo = parseRemoteRepo(baseRemoteUrl, input.provider)
-  const headRepo = parseRemoteRepo(headRemoteUrl, input.provider)
+  const parseOptions = { webSchemeByHost: input.webSchemeByHost ?? null }
+  const baseRepo = parseRemoteRepo(baseRemoteUrl, input.provider, parseOptions)
+  const headRepo = parseRemoteRepo(headRemoteUrl, input.provider, parseOptions)
   if (!baseRepo || !headRepo) {
     return null
   }

--- a/src/renderer/src/components/right-sidebar/source-control-remote-repo.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-remote-repo.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildWebOrigin,
+  parseRemoteRepo,
+  resolveGitHostWebScheme
+} from './source-control-remote-repo'
+
+describe('resolveGitHostWebScheme', () => {
+  it('defaults to https', () => {
+    expect(resolveGitHostWebScheme('gitlab.company.test')).toBe('https')
+    expect(resolveGitHostWebScheme('gitlab.company.test', {})).toBe('https')
+  })
+
+  it('honors an explicit host override', () => {
+    expect(resolveGitHostWebScheme('gitlab.company.test', { 'gitlab.company.test': 'http' })).toBe(
+      'http'
+    )
+  })
+
+  it('matches bare hostname when the remote host includes a transport port', () => {
+    expect(
+      resolveGitHostWebScheme('gitlab.company.test:2222', { 'gitlab.company.test': 'http' })
+    ).toBe('http')
+  })
+})
+
+describe('buildWebOrigin', () => {
+  it('keeps http(s) remote schemes and ports', () => {
+    expect(buildWebOrigin('http:', 'gitlab.company.test:8080', 'gitlab.company.test')).toBe(
+      'http://gitlab.company.test:8080'
+    )
+    expect(buildWebOrigin('https:', 'gitlab.com', 'gitlab.com')).toBe('https://gitlab.com')
+  })
+
+  it('defaults ssh remotes to https', () => {
+    expect(buildWebOrigin('ssh:', 'git@host:2222', 'gitlab.company.test')).toBe(
+      'https://gitlab.company.test'
+    )
+  })
+
+  it('uses http for ssh remotes when the host is overridden', () => {
+    expect(
+      buildWebOrigin('ssh:', 'git@host:2222', 'gitlab.company.test', {
+        'gitlab.company.test': 'http'
+      })
+    ).toBe('http://gitlab.company.test')
+  })
+})
+
+describe('parseRemoteRepo web scheme', () => {
+  it('builds https web URLs for ssh remotes by default', () => {
+    expect(
+      parseRemoteRepo('ssh://git@gitlab.company.test:2222/group/sub/orca.git', 'gitlab')
+    ).toMatchObject({
+      webBaseUrl: 'https://gitlab.company.test/group/sub/orca',
+      provider: 'gitlab'
+    })
+  })
+
+  it('builds http web URLs for ssh remotes when the host override is http', () => {
+    expect(
+      parseRemoteRepo('ssh://git@gitlab.company.test:2222/group/sub/orca.git', 'gitlab', {
+        webSchemeByHost: { 'gitlab.company.test': 'http' }
+      })
+    ).toMatchObject({
+      webBaseUrl: 'http://gitlab.company.test/group/sub/orca',
+      provider: 'gitlab'
+    })
+  })
+
+  it('applies the override to scp-style remotes', () => {
+    expect(
+      parseRemoteRepo('git@gitlab.company.test:group/sub/orca.git', 'gitlab', {
+        webSchemeByHost: { 'gitlab.company.test': 'http' }
+      })
+    ).toMatchObject({
+      webBaseUrl: 'http://gitlab.company.test/group/sub/orca'
+    })
+  })
+
+  it('still prefers the remote scheme for http remotes even when an override exists', () => {
+    expect(
+      parseRemoteRepo('http://gitlab.company.test:8080/group/sub/orca.git', 'gitlab', {
+        webSchemeByHost: { 'gitlab.company.test': 'https' }
+      })
+    ).toMatchObject({
+      webBaseUrl: 'http://gitlab.company.test:8080/group/sub/orca'
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-remote-repo.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-remote-repo.ts
@@ -2,6 +2,14 @@ import type { HostedReviewProvider } from '../../../../shared/hosted-review'
 
 export type ManualReviewProvider = Exclude<HostedReviewProvider, 'unsupported'>
 
+/** Prefer `http` for self-hosted web UIs when the git remote is ssh/git. Keyed by hostname. */
+export type GitHostWebScheme = 'http' | 'https'
+export type GitHostWebSchemes = Readonly<Record<string, GitHostWebScheme>>
+
+export type ParseRemoteRepoOptions = {
+  webSchemeByHost?: GitHostWebSchemes | null
+}
+
 export type RemoteRepoRef = {
   provider: ManualReviewProvider | null
   webBaseUrl: string
@@ -73,13 +81,47 @@ export function normalizeProvider(
   return provider && provider !== 'unsupported' ? provider : null
 }
 
-function buildWebOrigin(protocol: string, host: string, hostname: string): string {
-  return protocol === 'http:' || protocol === 'https:'
-    ? `${protocol}//${host}`
-    : `https://${hostname}`
+/** Resolve web UI scheme for an ssh/git remote host. Defaults to https. */
+export function resolveGitHostWebScheme(
+  hostname: string,
+  schemes?: GitHostWebSchemes | null
+): GitHostWebScheme {
+  const key = hostname.trim().toLowerCase()
+  if (!key) {
+    return 'https'
+  }
+  const direct = schemes?.[key]
+  if (direct === 'http' || direct === 'https') {
+    return direct
+  }
+  // Why: ssh remotes often use a transport port (e.g. :2222); overrides are keyed by bare hostname.
+  const bare = key.replace(/:\d+$/, '')
+  if (bare !== key) {
+    const bareScheme = schemes?.[bare]
+    if (bareScheme === 'http' || bareScheme === 'https') {
+      return bareScheme
+    }
+  }
+  return 'https'
 }
 
-function parseAzureDevOpsRemote(trimmed: string): RemoteRepoRef | null {
+export function buildWebOrigin(
+  protocol: string,
+  host: string,
+  hostname: string,
+  schemes?: GitHostWebSchemes | null
+): string {
+  // Why: http(s) remotes already carry the web scheme (and port); ssh/git do not.
+  if (protocol === 'http:' || protocol === 'https:') {
+    return `${protocol}//${host}`
+  }
+  return `${resolveGitHostWebScheme(hostname, schemes)}://${hostname}`
+}
+
+function parseAzureDevOpsRemote(
+  trimmed: string,
+  schemes?: GitHostWebSchemes | null
+): RemoteRepoRef | null {
   const scpLike = trimmed.match(/^(?:[^@/:]+@)?([^:\s/]+):([^\s]+?)(?:\.git)?$/)
   if (scpLike && scpLike[1].toLowerCase() === 'ssh.dev.azure.com') {
     const parts = cleanPath(scpLike[2])?.split('/') ?? []
@@ -128,7 +170,7 @@ function parseAzureDevOpsRemote(trimmed: string): RemoteRepoRef | null {
     return {
       provider: 'azure-devops',
       path: webPath.join('/'),
-      webBaseUrl: `${buildWebOrigin(protocol, url.host, url.hostname).replace(/\/+$/, '')}/${encodePath(webPath.join('/'))}`
+      webBaseUrl: `${buildWebOrigin(protocol, url.host, url.hostname, schemes).replace(/\/+$/, '')}/${encodePath(webPath.join('/'))}`
     }
   } catch {
     return null
@@ -137,14 +179,16 @@ function parseAzureDevOpsRemote(trimmed: string): RemoteRepoRef | null {
 
 export function parseRemoteRepo(
   remoteUrl: string,
-  providerHint?: HostedReviewProvider | null
+  providerHint?: HostedReviewProvider | null,
+  options?: ParseRemoteRepoOptions
 ): RemoteRepoRef | null {
   const trimmed = remoteUrl.trim().replace(/^git\+/, '')
   if (!trimmed || /^[A-Za-z]:[\\/]/.test(trimmed) || trimmed.startsWith('/')) {
     return null
   }
+  const schemes = options?.webSchemeByHost ?? null
 
-  const azure = parseAzureDevOpsRemote(trimmed)
+  const azure = parseAzureDevOpsRemote(trimmed, schemes)
   if (azure && (providerHint == null || providerHint === 'azure-devops')) {
     return azure
   }
@@ -159,10 +203,11 @@ export function parseRemoteRepo(
       return null
     }
     const hintedProvider = normalizeProvider(providerHint)
+    const scheme = resolveGitHostWebScheme(host, schemes)
     return {
       provider: hintedProvider ?? providerForHost(host) ?? null,
       path,
-      webBaseUrl: `https://${host}/${encodePath(path)}`
+      webBaseUrl: `${scheme}://${host}/${encodePath(path)}`
     }
   }
 
@@ -183,7 +228,7 @@ export function parseRemoteRepo(
     const webOrigin =
       host === 'ssh.github.com'
         ? 'https://github.com'
-        : buildWebOrigin(protocol, url.host, url.hostname).replace(/\/+$/, '')
+        : buildWebOrigin(protocol, url.host, url.hostname, schemes).replace(/\/+$/, '')
     return {
       provider,
       path,

--- a/src/renderer/src/components/right-sidebar/source-control-remote-repo.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-remote-repo.ts
@@ -127,10 +127,11 @@ function parseAzureDevOpsRemote(
     const parts = cleanPath(scpLike[2])?.split('/') ?? []
     if (parts.length >= 4 && parts[0].toLowerCase() === 'v3') {
       const [, organization, project, repository] = parts
+      const azureScheme = resolveGitHostWebScheme('dev.azure.com', schemes)
       return {
         provider: 'azure-devops',
         path: `${organization}/${project}/_git/${repository}`,
-        webBaseUrl: `https://dev.azure.com/${encodePath(organization)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repository)}`
+        webBaseUrl: `${azureScheme}://dev.azure.com/${encodePath(organization)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repository)}`
       }
     }
   }
@@ -145,10 +146,11 @@ function parseAzureDevOpsRemote(
     const parts = cleanPath(url.pathname)?.split('/') ?? []
     if (host === 'ssh.dev.azure.com' && parts.length >= 4 && parts[0].toLowerCase() === 'v3') {
       const [, organization, project, repository] = parts
+      const azureScheme = resolveGitHostWebScheme('dev.azure.com', schemes)
       return {
         provider: 'azure-devops',
         path: `${organization}/${project}/_git/${repository}`,
-        webBaseUrl: `https://dev.azure.com/${encodePath(organization)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repository)}`
+        webBaseUrl: `${azureScheme}://dev.azure.com/${encodePath(organization)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repository)}`
       }
     }
 

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from 'react'
 import { ExternalLink, Github, Gitlab, Terminal } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
 import { useAppStore } from '@/store'
 import { IntegrationCardDetails, IntegrationCardShell } from './integration-card-shell'
 import {
@@ -9,6 +11,10 @@ import {
 import { getProviderAccountScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { usePreflightCardStatuses } from './source-control-preflight-card-status'
+import {
+  formatGitHostWebSchemesText,
+  parseGitHostWebSchemesText
+} from './git-host-web-schemes-text'
 import { translate } from '@/i18n/i18n'
 
 function ProviderAccountScopeDetails({
@@ -164,6 +170,44 @@ export function GitHubIntegrationCard(): React.JSX.Element {
   )
 }
 
+function GitHostWebSchemesField(): React.JSX.Element {
+  const schemes = useAppStore((s) => s.settings?.gitHostWebSchemes)
+  const updateSettings = useAppStore((s) => s.updateSettings)
+  const [draft, setDraft] = useState(() => formatGitHostWebSchemesText(schemes))
+
+  useEffect(() => {
+    setDraft(formatGitHostWebSchemesText(schemes))
+  }, [schemes])
+
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-xs font-medium">
+        {translate(
+          'auto.components.settings.cli.source.control.integration.cards.git_host_web_schemes_label',
+          'Self-hosted web URL schemes'
+        )}
+      </Label>
+      <p className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.cli.source.control.integration.cards.git_host_web_schemes_help',
+          'When git remotes use SSH but the forge web UI is HTTP-only, list one host per line as host=http (or host=https). Review/Open MR links use this scheme.'
+        )}
+      </p>
+      <textarea
+        value={draft}
+        rows={3}
+        spellCheck={false}
+        className="w-full resize-y rounded-md border border-border bg-background px-2.5 py-2 font-mono text-xs text-foreground outline-none placeholder:text-muted-foreground/70 focus-visible:ring-1 focus-visible:ring-ring"
+        placeholder="gitlab.company.test=http"
+        onChange={(event) => setDraft(event.target.value)}
+        onBlur={() => {
+          void updateSettings({ gitHostWebSchemes: parseGitHostWebSchemesText(draft) })
+        }}
+      />
+    </div>
+  )
+}
+
 export function GitLabIntegrationCard(): React.JSX.Element {
   const { statuses, unavailable, refresh } = usePreflightCardStatuses('glab')
   const status = unavailable ? 'unavailable' : statuses.glabStatus
@@ -205,6 +249,7 @@ export function GitLabIntegrationCard(): React.JSX.Element {
       }
     >
       <ProviderAccountScopeDetails>
+        <GitHostWebSchemesField />
         {status !== 'checking' && !connected ? (
           status === 'unavailable' ? (
             <>

--- a/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
+++ b/src/renderer/src/components/settings/cli-source-control-integration-cards.tsx
@@ -181,7 +181,7 @@ function GitHostWebSchemesField(): React.JSX.Element {
 
   return (
     <div className="space-y-1.5">
-      <Label className="text-xs font-medium">
+      <Label htmlFor="git-host-web-schemes" className="text-xs font-medium">
         {translate(
           'auto.components.settings.cli.source.control.integration.cards.git_host_web_schemes_label',
           'Self-hosted web URL schemes'
@@ -194,6 +194,7 @@ function GitHostWebSchemesField(): React.JSX.Element {
         )}
       </p>
       <textarea
+        id="git-host-web-schemes"
         value={draft}
         rows={3}
         spellCheck={false}

--- a/src/renderer/src/components/settings/git-host-web-schemes-text.test.ts
+++ b/src/renderer/src/components/settings/git-host-web-schemes-text.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatGitHostWebSchemesText,
+  parseGitHostWebSchemesText
+} from './git-host-web-schemes-text'
+
+describe('git-host-web-schemes-text', () => {
+  it('round-trips host=scheme lines', () => {
+    const text = formatGitHostWebSchemesText({
+      'git.internal': 'http',
+      'gitlab.company.test': 'http'
+    })
+    expect(text).toBe('git.internal=http\ngitlab.company.test=http')
+    expect(parseGitHostWebSchemesText(text)).toEqual({
+      'git.internal': 'http',
+      'gitlab.company.test': 'http'
+    })
+  })
+
+  it('skips blank, comment, and invalid rows', () => {
+    expect(
+      parseGitHostWebSchemesText(`
+# comment
+gitlab.company.test=http
+broken
+=http
+host=ftp
+`)
+    ).toEqual({ 'gitlab.company.test': 'http' })
+  })
+})

--- a/src/renderer/src/components/settings/git-host-web-schemes-text.ts
+++ b/src/renderer/src/components/settings/git-host-web-schemes-text.ts
@@ -1,0 +1,37 @@
+import type { GlobalSettings } from '../../../../shared/types'
+
+export type GitHostWebSchemes = GlobalSettings['gitHostWebSchemes']
+
+/** Serialize hostname → scheme map as `host=http` lines for the settings field. */
+export function formatGitHostWebSchemesText(schemes: GitHostWebSchemes | null | undefined): string {
+  return Object.entries(schemes ?? {})
+    .filter(([, scheme]) => scheme === 'http' || scheme === 'https')
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([host, scheme]) => `${host}=${scheme}`)
+    .join('\n')
+}
+
+/** Parse `host=http` lines; invalid rows are skipped. */
+export function parseGitHostWebSchemesText(text: string): GitHostWebSchemes {
+  const next: Record<string, 'http' | 'https'> = {}
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    const eq = line.indexOf('=')
+    if (eq <= 0) {
+      continue
+    }
+    const host = line.slice(0, eq).trim().toLowerCase()
+    const scheme = line
+      .slice(eq + 1)
+      .trim()
+      .toLowerCase()
+    if (!host || (scheme !== 'http' && scheme !== 'https')) {
+      continue
+    }
+    next[host] = scheme
+  }
+  return next
+}

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -56,6 +56,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').confirmClosePinnedTab).toBe(true)
   })
 
+  it('defaults git host web schemes empty so ssh remotes keep https until overridden', () => {
+    expect(getDefaultSettings('/tmp').gitHostWebSchemes).toEqual({})
+  })
+
   it('keeps file-editor word wrapping enabled by default', () => {
     expect(getDefaultSettings('/tmp').editorWordWrap).toBe(true)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -322,6 +322,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     agentStatusHooksEnabled: true,
     tabAutoGenerateTitle: false,
     confirmClosePinnedTab: true,
+    // Why: ssh remotes default to https web links; self-hosted http-only forges set hostname → http here.
+    gitHostWebSchemes: {},
     keepComputerAwakeWhileAgentsRun: false,
     // Why: 'auto' probes keyboard layout so non-US users can type Option chars like @/€/[ out of the box (issue #903). See src/renderer/src/lib/keyboard-layout/*.
     terminalMacOptionAsAlt: 'auto',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2877,6 +2877,12 @@ export type GlobalSettings = {
   tabAutoGenerateTitle: boolean
   /** Why: pinned tabs can still be closed via keyboard/native-menu; this gates that behind a confirmation. Defaults on. */
   confirmClosePinnedTab: boolean
+  /**
+   * Prefer `http` or `https` for forge web UI links when the git remote uses ssh/git.
+   * Keyed by hostname (lowercase; port optional). Empty = default https.
+   * Why: ssh remotes carry no web-scheme; http-only self-hosted GitLab/Gitea need an override.
+   */
+  gitHostWebSchemes: Record<string, 'http' | 'https'>
   /** When true, Orca requests local awake assertions while hook-reported agents are working. */
   keepComputerAwakeWhileAgentsRun: boolean
   /** macOS Option key: compose layout chars (@ German, € French) vs act as Meta/Esc for readline.


### PR DESCRIPTION
## Summary

- SSH/scp-style remotes always produced `https://` forge web links (`buildWebOrigin` / `parseRemoteRepo`), so **Open review page** / New MR URLs broke on **http-only self-hosted GitLab**.
- Git transport protocol is not the web UI scheme. Add `gitHostWebSchemes` (hostname → `http`|`https`), thread it into remote parsing and the manual review URL builder, and keep default **https**.
- Settings → Integrations → GitLab: multiline `host=http` editor for self-hosted overrides.

Fixes #10154

## Usage

Settings → Integrations → GitLab → **Self-hosted web URL schemes**:

```text
gitlab.company.test=http
```

Then Open review / New MR links for `ssh://git@gitlab.company.test:2222/...` remotes open `http://gitlab.company.test/...`.

## Test plan

- [x] Unit: `resolveGitHostWebScheme` / `buildWebOrigin` / `parseRemoteRepo` (ssh default, override, scp, http remote preserves scheme)
- [x] Unit: manual review URL builds `http://…/-/merge_requests/new` with override
- [x] Unit: settings text format/parse round-trip
- [ ] Manual: set `host=http`, open a branch with ssh origin, Open review page → browser hits http not https
- [ ] Manual: without override, GitHub/ssh still uses https

---

> **Note:** Re-opened as a new PR after an accidental empty force-push during local rebase cleanup closed the original [#10171](https://github.com/stablyai/orca/pull/10171) (no code intent to withdraw). Branch tip restored with an empty recovery commit.

## ELI5

SSH remotes always got https:// web links, which broke Open review on http-only self-hosted GitLab. You can map hostnames to http or https so forge links use the right scheme.
