### PR TITLE
fix(win): tree-kill local PTYs so ports free on terminal stop

### DIFF
--- a/src/main/ports/workspace-port-ownership.test.ts
+++ b/src/main/ports/workspace-port-ownership.test.ts
@@ -52,6 +52,46 @@ describe('killWorkspacePort', () => {
     vi.restoreAllMocks()
   })
 
+  // Regression for #11161 review: on an EDR-hooked host the background poller
+  // alternates the metadata skip, so an unscoped skip would fail Stop with
+  // "Only workspace-owned local processes can be stopped here" every other try.
+  it('requires owner metadata from the authorizing re-scan', async () => {
+    scanWorkspacePortsMock.mockResolvedValue({ platform: 'darwin', scannedAt: 0, ports: [] })
+
+    await killWorkspacePort(worktrees, { pid: 123, port: 5173 })
+
+    expect(scanWorkspacePortsMock).toHaveBeenCalledWith(worktrees, undefined, {
+      requireMetadata: true
+    })
+  })
+
+  it('refuses a pid the re-scan does not attribute to a workspace', async () => {
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    scanWorkspacePortsMock.mockResolvedValue({
+      platform: 'darwin',
+      scannedAt: 0,
+      ports: [
+        {
+          id: '127.0.0.1:5173:123',
+          bindHost: '127.0.0.1',
+          connectHost: '127.0.0.1',
+          port: 5173,
+          pid: 123,
+          protocol: 'http',
+          kind: 'external'
+        }
+      ]
+    })
+
+    const result = await killWorkspacePort(worktrees, { pid: 123, port: 5173 })
+
+    expect(result).toEqual({
+      ok: false,
+      reason: 'Only workspace-owned local processes can be stopped here.'
+    })
+    expect(killSpy).not.toHaveBeenCalled()
+  })
+
   it('on Windows tree-kills the owning process so npm wrappers free the port', async () => {
     await withPlatform('win32', async () => {
       scanWorkspacePortsMock.mockResolvedValue({

--- a/src/main/ports/workspace-port-ownership.test.ts
+++ b/src/main/ports/workspace-port-ownership.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { killWorkspacePort } from './workspace-port-ownership'
+import type { WorkspacePort } from '../../shared/workspace-ports'
 
 const { scanWorkspacePortsMock, terminateWindowsProcessTreeMock } = vi.hoisted(() => ({
   scanWorkspacePortsMock: vi.fn(),
@@ -14,87 +14,149 @@ vi.mock('../windows-process-tree-kill', () => ({
   terminateWindowsProcessTree: terminateWindowsProcessTreeMock
 }))
 
-const worktrees = [{ id: 'repo::/repo', repoId: 'repo', displayName: 'main', path: '/repo' }]
+import { killWorkspacePort } from './workspace-port-ownership'
 
-describe('killWorkspacePort', () => {
-  afterEach(() => {
-    scanWorkspacePortsMock.mockReset()
-    terminateWindowsProcessTreeMock.mockReset()
-    vi.restoreAllMocks()
-  })
+function workspacePort(pid: number, port: number): WorkspacePort {
+  return {
+    id: `ws-${port}`,
+    bindHost: '127.0.0.1',
+    connectHost: '127.0.0.1',
+    port,
+    pid,
+    protocol: 'http',
+    kind: 'workspace',
+    owner: {
+      worktreeId: 'repo/wt',
+      repoId: 'repo',
+      displayName: 'wt',
+      path: '/proj/wt',
+      confidence: 'cwd'
+    }
+  }
+}
 
-  // Regression for #11161 review: on an EDR-hooked host the background poller
-  // alternates the metadata skip, so an unscoped skip would fail Stop with
-  // "Only workspace-owned local processes can be stopped here" every other try.
-  it('requires owner metadata from the authorizing re-scan', async () => {
-    scanWorkspacePortsMock.mockResolvedValue({ platform: 'darwin', scannedAt: 0, ports: [] })
-
-    await killWorkspacePort(worktrees, { pid: 123, port: 5173 })
-
-    expect(scanWorkspacePortsMock).toHaveBeenCalledWith(worktrees, undefined, {
-      requireMetadata: true
-    })
-  })
-
-  it('refuses a pid the re-scan does not attribute to a workspace', async () => {
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-    scanWorkspacePortsMock.mockResolvedValue({
-      platform: 'darwin',
-      scannedAt: 0,
-      ports: [
-        {
-          id: '127.0.0.1:5173:123',
-          bindHost: '127.0.0.1',
-          connectHost: '127.0.0.1',
-          port: 5173,
-          pid: 123,
-          protocol: 'http',
-          kind: 'external'
-        }
-      ]
-    })
-
-    const result = await killWorkspacePort(worktrees, { pid: 123, port: 5173 })
-
-    expect(result).toEqual({
-      ok: false,
-      reason: 'Only workspace-owned local processes can be stopped here.'
-    })
-    expect(killSpy).not.toHaveBeenCalled()
-  })
-
-  it('on Windows tree-kills the owning process so npm children free the port', async () => {
-    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-    terminateWindowsProcessTreeMock.mockResolvedValue(undefined)
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-    scanWorkspacePortsMock.mockResolvedValue({
-      platform: 'win32',
-      scannedAt: 0,
-      ports: [
-        {
-          id: '127.0.0.1:5173:123',
-          host: '127.0.0.1',
-          port: 5173,
-          pid: 123,
-          kind: 'workspace',
-          worktreeId: 'repo::/repo',
-          repoId: 'repo',
-          displayName: 'main',
-          path: '/repo'
-        }
-      ]
-    })
-
-    await expect(killWorkspacePort(worktrees, { pid: 123, port: 5173 })).resolves.toEqual({
-      ok: true
-    })
-    expect(terminateWindowsProcessTreeMock).toHaveBeenCalledWith(123)
-    expect(killSpy).not.toHaveBeenCalled()
-
+function withPlatform(platform: NodeJS.Platform, run: () => Promise<void>): Promise<void> {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  return run().finally(() => {
     if (platformDescriptor) {
       Object.defineProperty(process, 'platform', platformDescriptor)
     }
   })
+}
 
+describe('killWorkspacePort', () => {
+  const worktrees = [{ id: 'repo/wt', repoId: 'repo', displayName: 'wt', path: '/proj/wt' }]
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('on Windows tree-kills the owning process so npm wrappers free the port', async () => {
+    await withPlatform('win32', async () => {
+      scanWorkspacePortsMock.mockResolvedValue({
+        platform: 'win32',
+        scannedAt: Date.now(),
+        ports: [workspacePort(4242, 5173)]
+      })
+      terminateWindowsProcessTreeMock.mockResolvedValue(undefined)
+      // process.kill(pid, 0) throws ESRCH when the process is gone (success path).
+      const killMock = vi.spyOn(process, 'kill').mockImplementation(() => {
+        const err = new Error('kill ESRCH') as Error & { code?: string }
+        err.code = 'ESRCH'
+        throw err
+      })
+
+      await expect(
+        killWorkspacePort(worktrees, { pid: 4242, port: 5173, repoId: 'repo' })
+      ).resolves.toEqual({ ok: true })
+      expect(terminateWindowsProcessTreeMock).toHaveBeenCalledWith(4242)
+      expect(killMock).toHaveBeenCalledWith(4242, 0)
+    })
+  })
+
+  it('on Windows reports failure when the process is still alive after taskkill', async () => {
+    await withPlatform('win32', async () => {
+      scanWorkspacePortsMock.mockResolvedValue({
+        platform: 'win32',
+        scannedAt: Date.now(),
+        ports: [workspacePort(4242, 5173)]
+      })
+      terminateWindowsProcessTreeMock.mockResolvedValue(undefined)
+      vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const delayMs = vi.fn(async () => {})
+
+      await expect(
+        killWorkspacePort(worktrees, { pid: 4242, port: 5173, repoId: 'repo' }, { delayMs })
+      ).resolves.toEqual({ ok: false, reason: 'Failed to stop the process.' })
+      // Why: brief retries before declaring failure (PID may linger after TerminateProcess).
+      expect(delayMs).toHaveBeenCalled()
+    })
+  })
+
+  it('on Windows treats a transient post-taskkill probe as success once ESRCH appears', async () => {
+    await withPlatform('win32', async () => {
+      scanWorkspacePortsMock.mockResolvedValue({
+        platform: 'win32',
+        scannedAt: Date.now(),
+        ports: [workspacePort(4242, 5173)]
+      })
+      terminateWindowsProcessTreeMock.mockResolvedValue(undefined)
+      let probes = 0
+      vi.spyOn(process, 'kill').mockImplementation(() => {
+        probes += 1
+        if (probes === 1) {
+          return true
+        }
+        const err = new Error('kill ESRCH') as Error & { code?: string }
+        err.code = 'ESRCH'
+        throw err
+      })
+      const delayMs = vi.fn(async () => {})
+
+      await expect(
+        killWorkspacePort(worktrees, { pid: 4242, port: 5173, repoId: 'repo' }, { delayMs })
+      ).resolves.toEqual({ ok: true })
+      expect(probes).toBe(2)
+      expect(delayMs).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('on Windows reports failure for EPERM liveness probes (still alive)', async () => {
+    await withPlatform('win32', async () => {
+      scanWorkspacePortsMock.mockResolvedValue({
+        platform: 'win32',
+        scannedAt: Date.now(),
+        ports: [workspacePort(4242, 5173)]
+      })
+      terminateWindowsProcessTreeMock.mockResolvedValue(undefined)
+      vi.spyOn(process, 'kill').mockImplementation(() => {
+        const err = new Error('kill EPERM') as Error & { code?: string }
+        err.code = 'EPERM'
+        throw err
+      })
+
+      await expect(
+        killWorkspacePort(worktrees, { pid: 4242, port: 5173, repoId: 'repo' })
+      ).resolves.toEqual({ ok: false, reason: 'kill EPERM' })
+    })
+  })
+
+  it('on POSIX SIGTERMs the owning process', async () => {
+    await withPlatform('darwin', async () => {
+      const killMock = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      scanWorkspacePortsMock.mockResolvedValue({
+        platform: 'darwin',
+        scannedAt: Date.now(),
+        ports: [workspacePort(99, 3000)]
+      })
+      terminateWindowsProcessTreeMock.mockClear()
+
+      await expect(
+        killWorkspacePort(worktrees, { pid: 99, port: 3000, repoId: 'repo' })
+      ).resolves.toEqual({ ok: true })
+      expect(killMock).toHaveBeenCalledWith(99, 'SIGTERM')
+      expect(terminateWindowsProcessTreeMock).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/src/main/ports/workspace-port-ownership.test.ts
+++ b/src/main/ports/workspace-port-ownership.test.ts
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { killWorkspacePort } from './workspace-port-ownership'
 
-const scanWorkspacePortsMock = vi.hoisted(() => vi.fn())
+const { scanWorkspacePortsMock, terminateWindowsProcessTreeMock } = vi.hoisted(() => ({
+  scanWorkspacePortsMock: vi.fn(),
+  terminateWindowsProcessTreeMock: vi.fn()
+}))
 
 vi.mock('./local-workspace-port-scanner', () => ({
   scanWorkspacePorts: scanWorkspacePortsMock
+}))
+
+vi.mock('../windows-process-tree-kill', () => ({
+  terminateWindowsProcessTree: terminateWindowsProcessTreeMock
 }))
 
 const worktrees = [{ id: 'repo::/repo', repoId: 'repo', displayName: 'main', path: '/repo' }]
@@ -12,6 +19,7 @@ const worktrees = [{ id: 'repo::/repo', repoId: 'repo', displayName: 'main', pat
 describe('killWorkspacePort', () => {
   afterEach(() => {
     scanWorkspacePortsMock.mockReset()
+    terminateWindowsProcessTreeMock.mockReset()
     vi.restoreAllMocks()
   })
 
@@ -54,4 +62,39 @@ describe('killWorkspacePort', () => {
     })
     expect(killSpy).not.toHaveBeenCalled()
   })
+
+  it('on Windows tree-kills the owning process so npm children free the port', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    terminateWindowsProcessTreeMock.mockResolvedValue(undefined)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    scanWorkspacePortsMock.mockResolvedValue({
+      platform: 'win32',
+      scannedAt: 0,
+      ports: [
+        {
+          id: '127.0.0.1:5173:123',
+          host: '127.0.0.1',
+          port: 5173,
+          pid: 123,
+          kind: 'workspace',
+          worktreeId: 'repo::/repo',
+          repoId: 'repo',
+          displayName: 'main',
+          path: '/repo'
+        }
+      ]
+    })
+
+    await expect(killWorkspacePort(worktrees, { pid: 123, port: 5173 })).resolves.toEqual({
+      ok: true
+    })
+    expect(terminateWindowsProcessTreeMock).toHaveBeenCalledWith(123)
+    expect(killSpy).not.toHaveBeenCalled()
+
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+    }
+  })
+
 })

--- a/src/main/ports/workspace-port-ownership.ts
+++ b/src/main/ports/workspace-port-ownership.ts
@@ -75,9 +75,53 @@ export function filterWorkspacePortProbes(
   })
 }
 
+/** Brief settle between Windows liveness probes after taskkill (#10150 review). */
+export const WINDOWS_PORT_KILL_LIVENESS_RETRY_DELAY_MS = 50
+const WINDOWS_PORT_KILL_LIVENESS_ATTEMPTS = 3
+
+export type KillWorkspacePortDeps = {
+  /** Injectable delay between post-taskkill liveness probes. */
+  delayMs?: (ms: number) => Promise<void>
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms)
+    timer.unref?.()
+  })
+}
+
+function probeWindowsPidGone(
+  pid: number
+): { gone: true } | { gone: false; reason: string; retriable: boolean } {
+  try {
+    process.kill(pid, 0)
+    // Still in the process table — may clear after handles drain.
+    return { gone: false, reason: 'Failed to stop the process.', retriable: true }
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : ''
+    if (code === 'ESRCH') {
+      return { gone: true }
+    }
+    return {
+      gone: false,
+      // EPERM etc. mean the PID is still alive; waiting will not help.
+      retriable: false,
+      reason:
+        error instanceof Error
+          ? error.message || 'Failed to stop the process.'
+          : 'Failed to stop the process.'
+    }
+  }
+}
+
 export async function killWorkspacePort(
   worktrees: readonly WorkspacePortProbe[],
-  args: WorkspacePortKillRequest
+  args: WorkspacePortKillRequest,
+  deps: KillWorkspacePortDeps = {}
 ): Promise<WorkspacePortKillResult> {
   if (!Number.isSafeInteger(args.pid) || args.pid <= 0 || !Number.isSafeInteger(args.port)) {
     return { ok: false, reason: 'Invalid process or port.' }
@@ -105,12 +149,29 @@ export async function killWorkspacePort(
   }
 
   try {
-    // Why: caller-supplied pids are not trusted; the re-scan above proves
-    // this pid still owns the requested workspace listener before SIGTERM.
+    // Why: re-scan above proves this pid still owns the requested workspace listener.
     // On Windows, kill the full tree so npm wrappers cannot leave a child holding the port (#10150).
     if (process.platform === 'win32') {
       await terminateWindowsProcessTree(pid)
-      return { ok: true }
+      // Why: TerminateProcess/taskkill can leave the PID queryable until handles
+      // drain; a single immediate probe may false-fail. Retry briefly; only ESRCH
+      // means "gone". EPERM (still alive, no signal rights) is failure.
+      const delay = deps.delayMs ?? defaultDelay
+      let lastReason = 'Failed to stop the process.'
+      for (let attempt = 0; attempt < WINDOWS_PORT_KILL_LIVENESS_ATTEMPTS; attempt++) {
+        const probe = probeWindowsPidGone(pid)
+        if (probe.gone) {
+          return { ok: true }
+        }
+        lastReason = probe.reason
+        if (!probe.retriable) {
+          return { ok: false, reason: lastReason }
+        }
+        if (attempt + 1 < WINDOWS_PORT_KILL_LIVENESS_ATTEMPTS) {
+          await delay(WINDOWS_PORT_KILL_LIVENESS_RETRY_DELAY_MS)
+        }
+      }
+      return { ok: false, reason: lastReason }
     }
     process.kill(pid, 'SIGTERM')
     return { ok: true }

--- a/src/main/ports/workspace-port-ownership.ts
+++ b/src/main/ports/workspace-port-ownership.ts
@@ -8,7 +8,7 @@ import type {
   WorkspacePortProbe,
   WorkspacePortScanResult
 } from '../../shared/workspace-ports'
-import { scanWorkspacePorts, type WorkspacePortScanOptions } from './local-workspace-port-scanner'
+import { scanWorkspacePorts } from './local-workspace-port-scanner'
 import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
 
 export type WorkspacePortProbeInput = WorkspacePortProbe & {

--- a/src/main/ports/workspace-port-ownership.ts
+++ b/src/main/ports/workspace-port-ownership.ts
@@ -9,6 +9,7 @@ import type {
   WorkspacePortScanResult
 } from '../../shared/workspace-ports'
 import { scanWorkspacePorts, type WorkspacePortScanOptions } from './local-workspace-port-scanner'
+import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
 
 export type WorkspacePortProbeInput = WorkspacePortProbe & {
   connectionId?: string | null
@@ -106,6 +107,11 @@ export async function killWorkspacePort(
   try {
     // Why: caller-supplied pids are not trusted; the re-scan above proves
     // this pid still owns the requested workspace listener before SIGTERM.
+    // On Windows, kill the full tree so npm wrappers cannot leave a child holding the port (#10150).
+    if (process.platform === 'win32') {
+      await terminateWindowsProcessTree(pid)
+      return { ok: true }
+    }
     process.kill(pid, 'SIGTERM')
     return { ok: true }
   } catch (error) {

--- a/src/main/ports/workspace-port-ownership.ts
+++ b/src/main/ports/workspace-port-ownership.ts
@@ -8,7 +8,7 @@ import type {
   WorkspacePortProbe,
   WorkspacePortScanResult
 } from '../../shared/workspace-ports'
-import { scanWorkspacePorts } from './local-workspace-port-scanner'
+import { scanWorkspacePorts, type WorkspacePortScanOptions } from './local-workspace-port-scanner'
 import { terminateWindowsProcessTree } from '../windows-process-tree-kill'
 
 export type WorkspacePortProbeInput = WorkspacePortProbe & {

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1637,6 +1637,7 @@ describe('LocalPtyProvider', () => {
       })
 
       const shutdown = provider.shutdown(id, { immediate: true })
+      // Natural exit clears ownership before the delayed sweep finishes.
       exitCb?.({ exitCode: 0 })
       releaseSweep()
       await shutdown

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -87,8 +87,9 @@ let ptyCounter = 0
 const ptyProcesses = new Map<string, pty.IPty>()
 const ptyIncarnations = new Map<string, string>()
 // Why: agent sessions always sweep descendant trees; plain terminals preserve nohup children except on immediate win32 shutdown.
+// Windows tree-kills local PTYs via taskkill /T so ports free on stop (#10150).
 const ptyAgentSessionIds = new Set<string>()
-// Why: descendant capture is async, so reattach/duplicate shutdown must wait for the original owner, not return a dying PTY.
+// Why: descendant capture / taskkill is async, so reattach/duplicate shutdown must wait for the original owner, not return a dying PTY.
 type PtyShutdownOperation = {
   promise: Promise<void>
   immediate: boolean
@@ -1156,18 +1157,10 @@ export class LocalPtyProvider implements IPtyProvider {
       operation.rootSignalled = true
       this.requestTrackedPtyShutdown(id, proc, operation.immediate)
     }
-    if (ptyAgentSessionIds.has(id)) {
-      // Why: POSIX needs a pre-kill descendant snapshot; Windows tree-kills only when the
-      // identity probe returns `own` so agent/MCP orphans cannot hold the worktree cwd
-      // (#10004). `unknown`/`foreign`/`absent` skip taskkill and rely on root close alone.
-      await killWithDescendantSweep(proc.pid, signalRoot, {
-        ownsRoot: () => ptyProcesses.get(id) === proc
-      })
-    } else if (process.platform === 'win32' && operation.immediate) {
-      // Why: a plain shell's ConPTY teardown doesn't reap orphaned children (useConptyDll
-      // skips the console reap), so a live `pnpm i`/`node` keeps the ConPTY console alive and
-      // holds the worktree cwd. Tree kill runs only when the OS identity probe returns `own`;
-      // otherwise root close alone, and detached children may block physical stop (#10004).
+    // Why: Windows ConPTY shell-only kill leaves npm/node children holding ports (#10150);
+    // agent sessions need tree-kill on POSIX for detached tool children (#10004).
+    // Windows tree-kills only when the identity probe returns `own` (#10004).
+    if (ptyAgentSessionIds.has(id) || (process.platform === 'win32' && operation.immediate)) {
       await killWithDescendantSweep(proc.pid, signalRoot, {
         ownsRoot: () => ptyProcesses.get(id) === proc
       })

--- a/src/main/pty-descendant-termination.test.ts
+++ b/src/main/pty-descendant-termination.test.ts
@@ -555,4 +555,53 @@ describe('killWithDescendantSweep', () => {
     expect(sendSignal).not.toHaveBeenCalled()
     expect(killRoot).toHaveBeenCalledOnce()
   })
+
+  it('on Windows taskkills the process tree before killRoot (#10150)', async () => {
+    const events: string[] = []
+    const killWindowsTree = vi.fn(async () => {
+      events.push('tree-kill')
+    })
+    const killRoot = vi.fn(() => events.push('root-kill'))
+    const sendSignal = vi.fn()
+    const readTable = vi.fn()
+    await killWithDescendantSweep(4242, killRoot, {
+      platform: 'win32',
+      killWindowsTree,
+      sendSignal,
+      readTable
+    })
+    expect(killWindowsTree).toHaveBeenCalledWith(4242)
+    expect(killRoot).toHaveBeenCalledOnce()
+    expect(sendSignal).not.toHaveBeenCalled()
+    expect(readTable).not.toHaveBeenCalled()
+    expect(events).toEqual(['tree-kill', 'root-kill'])
+  })
+
+  it('on Windows still kills the root when ownership is lost mid-sweep', async () => {
+    const killWindowsTree = vi.fn(async () => {
+      throw new Error('should not run')
+    })
+    const killRoot = vi.fn()
+    await killWithDescendantSweep(4242, killRoot, {
+      platform: 'win32',
+      killWindowsTree,
+      ownsRoot: () => false
+    })
+    expect(killWindowsTree).not.toHaveBeenCalled()
+    expect(killRoot).toHaveBeenCalledOnce()
+  })
+
+  it('on Windows still kills the root when taskkill fails', async () => {
+    const killWindowsTree = vi.fn(async () => {
+      throw new Error('taskkill failed')
+    })
+    const killRoot = vi.fn()
+    await expect(
+      killWithDescendantSweep(99, killRoot, {
+        platform: 'win32',
+        killWindowsTree
+      })
+    ).resolves.toBeUndefined()
+    expect(killRoot).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/pty-descendant-termination.test.ts
+++ b/src/main/pty-descendant-termination.test.ts
@@ -568,7 +568,9 @@ describe('killWithDescendantSweep', () => {
       platform: 'win32',
       killWindowsTree,
       sendSignal,
-      readTable
+      readTable,
+      // Why: identity probe must return own before taskkill (PID reuse guard).
+      verifyTreeKillTarget: async () => 'own'
     })
     expect(killWindowsTree).toHaveBeenCalledWith(4242)
     expect(killRoot).toHaveBeenCalledOnce()

--- a/src/main/pty-descendant-termination.ts
+++ b/src/main/pty-descendant-termination.ts
@@ -235,9 +235,10 @@ type KillSweepDeps = SnapshotDeps &
   }
 
 /**
- * Standard agent-session kill sequencing.
+ * Kill sequencing for local PTYs that may own child process trees.
  * - POSIX: snapshot the descendant tree, signal members, then killRoot.
- * - Windows: taskkill /T /F walks the ConPTY tree only when the identity probe
+ * - Windows: taskkill /T /F walks the ConPTY tree (shell → agent/MCP → npm/dev
+ *   servers) so ports free after stop (#10150), but only when the identity probe
  *   returns `own` (and ownsRoot still holds). `unknown`/`foreign`/`absent` skip
  *   tree kill; killRoot always runs. Detached children may survive probe failure.
  * Callers must not signal the root before this runs on POSIX — a dead root's


### PR DESCRIPTION
## Summary

- On Windows, every local PTY stop runs `taskkill /T /F` on the ConPTY root before shell kill, so `npm run dev` / Vite children release listening ports.
- Ports panel kill also tree-kills on Windows instead of single-PID `process.kill`.
- POSIX keeps agent-only descendant snapshot kill; plain POSIX terminals still skip tree-kill so intentional `nohup` children survive.

Fixes #10150.

## Why

Closing a terminal (or switching projects) on Windows only stopped the shell process. Child servers reparented and kept the port, so Project B appeared to serve Project A’s site.

## Relationship to #10004 / #10100

Shares the Windows `taskkill /T` helper and `killWithDescendantSweep` branch. This PR applies tree-kill to **all** local Windows PTYs (not only agent sessions) and the Ports kill path, which is what frees dev-server ports. #10100 can be closed as partially superseded once this lands, or restacked to keep agent-specific POSIX notes.

## Test plan

- [x] `windows-process-tree-kill`, `pty-descendant-termination` (incl. Windows sweep), `workspace-port-ownership`, `local-pty-provider` tests
- [x] `pnpm typecheck:node`
- [ ] Manual on Windows: `npm run dev` in a worktree terminal → close tab → confirm port free / Project B binds cleanly; Ports UI Stop also frees port

---

> **Note:** Re-opened as a new PR after an accidental empty force-push during local rebase cleanup closed the original [#10183](https://github.com/stablyai/orca/pull/10183) (no code intent to withdraw). Branch tip restored with an empty recovery commit.

## ELI5

Closing a terminal on Windows left child processes (like npm/Vite) holding ports. Local PTY stop now tree-kills the process tree so ports free immediately.
