### PR TITLE
feat(automations): host selector for remote environment automations

### DIFF
--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -238,6 +238,7 @@ export default function AutomationsPage(): React.JSX.Element {
   } | null>(null)
   const [dontAskDeleteAgain, setDontAskDeleteAgain] = useState(false)
   const editRequestRef = useRef(0)
+  const refreshGenerationRef = useRef(0)
   const deleteConfirmButtonRef = useRef<HTMLButtonElement>(null)
   // Why: both dialogs stay mounted, so a shared ref would let one dialog's
   // unmount clear the focus target the other still needs.
@@ -794,6 +795,7 @@ export default function AutomationsPage(): React.JSX.Element {
   }, [activeWorktreeId, repoMap, repos, worktreeMap, worktreesByRepo])
 
   const refresh = useCallback(async () => {
+    const generation = ++refreshGenerationRef.current
     setIsLoading(true)
     const pendingNavigation = useAppStore.getState().pendingAutomationRunNavigation
     // Why: keep an explicit page host selection so remote automations stay
@@ -809,6 +811,9 @@ export default function AutomationsPage(): React.JSX.Element {
         listAutomationRunsForTarget(automationHostTarget),
         window.api.automations.listExternalManagers()
       ])
+      if (generation !== refreshGenerationRef.current) {
+        return
+      }
       const currentSelectedId = useAppStore.getState().selectedAutomationId
       const hasCurrentSelection = nextAutomations.some(
         (automation) => automation.id === currentSelectedId
@@ -824,6 +829,9 @@ export default function AutomationsPage(): React.JSX.Element {
       const nextSelectedRuns = nextSelectedId
         ? await listAutomationRunsForTarget(automationHostTarget, nextSelectedId)
         : []
+      if (generation !== refreshGenerationRef.current) {
+        return
+      }
       setAutomations(nextAutomations)
       setRuns(nextRuns)
       // Why: pending navigation only temporarily targets a host for the deep-link
@@ -840,7 +848,9 @@ export default function AutomationsPage(): React.JSX.Element {
         selectAutomationId(nextAutomations[0]?.id ?? null)
       }
     } finally {
-      setIsLoading(false)
+      if (generation === refreshGenerationRef.current) {
+        setIsLoading(false)
+      }
     }
   }, [selectAutomationId, settings, validatedAutomationHostTargetKey])
 
@@ -849,6 +859,11 @@ export default function AutomationsPage(): React.JSX.Element {
       if (nextKey === automationHostTargetKey) {
         return
       }
+      refreshGenerationRef.current += 1
+      setAutomations([])
+      setRuns([])
+      setSelectedAutomationRuns({ automationId: null, runs: [] })
+      setIsLoading(true)
       setAutomationHostTargetKey(nextKey)
       selectAutomationId(null)
       setSelectedAutomationRunPageId(null)

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -79,6 +79,7 @@ import {
   isSshConnectionBusy
 } from './external-automation-source-availability'
 import {
+  buildAutomationListHostOptions,
   createAutomationForTarget,
   deleteAutomationForTarget,
   getAutomationHostTargetFromKey,
@@ -88,9 +89,17 @@ import {
   getAutomationTargetFromHostId,
   listAutomationRunsForTarget,
   listAutomationsForTarget,
+  resolveAutomationListHostTarget,
   runAutomationNowForTarget,
   updateAutomationForTarget
 } from './automation-host-client'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/components/ui/select'
 import type { FetchExternalAutomationRuns } from './ExternalAutomationRunTable'
 import {
   AUTOMATION_DEFAULT_TIME,
@@ -760,12 +769,28 @@ export default function AutomationsPage(): React.JSX.Element {
     }
   }, [activeWorktreeId, repoMap, repos, worktreeMap, worktreesByRepo])
 
+  const automationListHostOptions = useMemo(
+    () =>
+      buildAutomationListHostOptions({
+        localLabel: getLocalExecutionHostLabel(),
+        environments: runtimeEnvironments.map((environment) => ({
+          id: environment.id,
+          name: environment.name
+        }))
+      }),
+    [runtimeEnvironments]
+  )
+
   const refresh = useCallback(async () => {
     setIsLoading(true)
     const pendingNavigation = useAppStore.getState().pendingAutomationRunNavigation
-    const automationHostTarget = pendingNavigation
-      ? getAutomationTargetFromHostId(pendingNavigation.hostId)
-      : getAutomationListTarget(settings)
+    // Why: keep an explicit page host selection so remote automations stay
+    // visible without flipping the global active runtime (#9964).
+    const automationHostTarget = resolveAutomationListHostTarget({
+      pendingHostId: pendingNavigation?.hostId,
+      selectedKey: automationHostTargetKey,
+      settings
+    })
     try {
       const [nextAutomations, nextRuns, nextExternalManagers] = await Promise.all([
         listAutomationsForTarget(automationHostTarget),
@@ -789,7 +814,11 @@ export default function AutomationsPage(): React.JSX.Element {
         : []
       setAutomations(nextAutomations)
       setRuns(nextRuns)
-      setAutomationHostTargetKey(getAutomationHostTargetKey(automationHostTarget))
+      // Why: pending navigation only temporarily targets a host for the deep-link
+      // refresh — do not overwrite the user's explicit selector choice (#10347).
+      if (!pendingNavigation) {
+        setAutomationHostTargetKey(getAutomationHostTargetKey(automationHostTarget))
+      }
       setSelectedAutomationRuns({
         automationId: nextSelectedId,
         runs: nextSelectedRuns
@@ -801,7 +830,19 @@ export default function AutomationsPage(): React.JSX.Element {
     } finally {
       setIsLoading(false)
     }
-  }, [selectAutomationId, settings])
+  }, [automationHostTargetKey, selectAutomationId, settings])
+
+  const handleAutomationHostTargetChange = useCallback(
+    (nextKey: string) => {
+      if (nextKey === automationHostTargetKey) {
+        return
+      }
+      setAutomationHostTargetKey(nextKey)
+      selectAutomationId(null)
+      setSelectedAutomationRunPageId(null)
+    },
+    [automationHostTargetKey, selectAutomationId]
+  )
 
   useEffect(() => {
     if (!pendingAutomationRunNavigation || isLoading) {
@@ -1956,6 +1997,30 @@ export default function AutomationsPage(): React.JSX.Element {
           </Tooltip>
         </div>
         <div className="flex items-center gap-2">
+          {automationListHostOptions.length > 1 ? (
+            <Select
+              value={automationHostTargetKey ?? 'local'}
+              onValueChange={handleAutomationHostTargetChange}
+            >
+              <SelectTrigger
+                size="sm"
+                className="h-8 min-w-[9rem] max-w-[14rem] border-border/50 bg-transparent text-xs"
+                aria-label={translate(
+                  'auto.components.automations.AutomationsPage.environmentSelector',
+                  'Automation host'
+                )}
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent align="end">
+                {automationListHostOptions.map((option) => (
+                  <SelectItem key={option.key} value={option.key} className="text-xs">
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          ) : null}
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -1965,7 +2030,7 @@ export default function AutomationsPage(): React.JSX.Element {
                   'auto.components.automations.AutomationsPage.19a6e30eae',
                   'Refresh automations'
                 )}
-                onClick={refresh}
+                onClick={() => void refresh()}
                 disabled={isLoading}
                 className="border border-border/50 bg-transparent hover:bg-muted/50"
               >

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -87,6 +87,7 @@ import {
   getAutomationListTarget,
   getAutomationOwnerTarget,
   getAutomationTargetFromHostId,
+  getValidatedAutomationHostTargetKey,
   listAutomationRunsForTarget,
   listAutomationsForTarget,
   resolveAutomationListHostTarget,
@@ -420,10 +421,33 @@ export default function AutomationsPage(): React.JSX.Element {
     () => worktreesByRepo[draft.projectId] ?? [],
     [draft.projectId, worktreesByRepo]
   )
-  const automationHostTarget = useMemo(
-    () => getAutomationHostTargetFromKey(automationHostTargetKey),
-    [automationHostTargetKey]
+  const automationListHostOptions = useMemo(
+    () =>
+      buildAutomationListHostOptions({
+        localLabel: getLocalExecutionHostLabel(),
+        environments: runtimeEnvironments.map((environment) => ({
+          id: environment.id,
+          name: environment.name
+        }))
+      }),
+    [runtimeEnvironments]
   )
+  const validatedAutomationHostTargetKey = useMemo(
+    () => getValidatedAutomationHostTargetKey(automationHostTargetKey, automationListHostOptions),
+    [automationHostTargetKey, automationListHostOptions]
+  )
+  const automationHostTarget = useMemo(
+    () => getAutomationHostTargetFromKey(validatedAutomationHostTargetKey),
+    [validatedAutomationHostTargetKey]
+  )
+
+  useEffect(() => {
+    if (automationHostTargetKey && !validatedAutomationHostTargetKey) {
+      setAutomationHostTargetKey(null)
+      selectAutomationId(null)
+      setSelectedAutomationRunPageId(null)
+    }
+  }, [automationHostTargetKey, selectAutomationId, validatedAutomationHostTargetKey])
 
   useEffect(() => {
     for (const [workspaceId, worktree] of worktreeMap) {
@@ -769,18 +793,6 @@ export default function AutomationsPage(): React.JSX.Element {
     }
   }, [activeWorktreeId, repoMap, repos, worktreeMap, worktreesByRepo])
 
-  const automationListHostOptions = useMemo(
-    () =>
-      buildAutomationListHostOptions({
-        localLabel: getLocalExecutionHostLabel(),
-        environments: runtimeEnvironments.map((environment) => ({
-          id: environment.id,
-          name: environment.name
-        }))
-      }),
-    [runtimeEnvironments]
-  )
-
   const refresh = useCallback(async () => {
     setIsLoading(true)
     const pendingNavigation = useAppStore.getState().pendingAutomationRunNavigation
@@ -788,7 +800,7 @@ export default function AutomationsPage(): React.JSX.Element {
     // visible without flipping the global active runtime (#9964).
     const automationHostTarget = resolveAutomationListHostTarget({
       pendingHostId: pendingNavigation?.hostId,
-      selectedKey: automationHostTargetKey,
+      selectedKey: validatedAutomationHostTargetKey,
       settings
     })
     try {
@@ -830,7 +842,7 @@ export default function AutomationsPage(): React.JSX.Element {
     } finally {
       setIsLoading(false)
     }
-  }, [automationHostTargetKey, selectAutomationId, settings])
+  }, [selectAutomationId, settings, validatedAutomationHostTargetKey])
 
   const handleAutomationHostTargetChange = useCallback(
     (nextKey: string) => {

--- a/src/renderer/src/components/automations/automation-host-client.test.ts
+++ b/src/renderer/src/components/automations/automation-host-client.test.ts
@@ -96,6 +96,16 @@ describe('automation host client', () => {
     ).toEqual({ kind: 'environment', environmentId: 'server-01' })
   })
 
+  it('rejects empty environment keys so global fallback still applies', () => {
+    expect(
+      resolveAutomationListHostTarget({
+        pendingHostId: null,
+        selectedKey: 'environment:',
+        settings: { activeRuntimeEnvironmentId: 'gpu' }
+      })
+    ).toEqual({ kind: 'environment', environmentId: 'gpu' })
+  })
+
   it('prefers pending navigation host over page selection', () => {
     expect(
       resolveAutomationListHostTarget({

--- a/src/renderer/src/components/automations/automation-host-client.test.ts
+++ b/src/renderer/src/components/automations/automation-host-client.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import type { Automation, AutomationCreateInput } from '../../../../shared/automations-types'
 import {
+  buildAutomationListHostOptions,
   createAutomationForTarget,
   getAutomationListTarget,
   listAutomationsForTarget,
+  resolveAutomationListHostTarget,
   runAutomationNowForTarget,
   updateAutomationForTarget
 } from './automation-host-client'
@@ -82,6 +84,50 @@ describe('automation host client', () => {
       undefined,
       { timeoutMs: 15_000 }
     )
+  })
+
+  it('prefers explicit page host selection over global active runtime (#9964)', () => {
+    expect(
+      resolveAutomationListHostTarget({
+        pendingHostId: null,
+        selectedKey: 'environment:server-01',
+        settings: { activeRuntimeEnvironmentId: null }
+      })
+    ).toEqual({ kind: 'environment', environmentId: 'server-01' })
+  })
+
+  it('prefers pending navigation host over page selection', () => {
+    expect(
+      resolveAutomationListHostTarget({
+        pendingHostId: 'runtime:gpu',
+        selectedKey: 'local',
+        settings: { activeRuntimeEnvironmentId: null }
+      })
+    ).toEqual({ kind: 'environment', environmentId: 'gpu' })
+  })
+
+  it('builds local + connected environment options for the host selector', () => {
+    expect(
+      buildAutomationListHostOptions({
+        localLabel: 'This Mac',
+        environments: [
+          { id: 'server-01', name: 'server-01' },
+          { id: 'gpu', name: 'GPU box' }
+        ]
+      })
+    ).toEqual([
+      { key: 'local', label: 'This Mac', target: { kind: 'local' } },
+      {
+        key: 'environment:server-01',
+        label: 'server-01',
+        target: { kind: 'environment', environmentId: 'server-01' }
+      },
+      {
+        key: 'environment:gpu',
+        label: 'GPU box',
+        target: { kind: 'environment', environmentId: 'gpu' }
+      }
+    ])
   })
 
   it('creates and manually runs runtime-host automations through that server', async () => {

--- a/src/renderer/src/components/automations/automation-host-client.test.ts
+++ b/src/renderer/src/components/automations/automation-host-client.test.ts
@@ -4,6 +4,7 @@ import {
   buildAutomationListHostOptions,
   createAutomationForTarget,
   getAutomationListTarget,
+  getValidatedAutomationHostTargetKey,
   listAutomationsForTarget,
   resolveAutomationListHostTarget,
   runAutomationNowForTarget,
@@ -138,6 +139,35 @@ describe('automation host client', () => {
         target: { kind: 'environment', environmentId: 'gpu' }
       }
     ])
+  })
+
+  it('normalizes environment ids and omits empty host options', () => {
+    expect(
+      buildAutomationListHostOptions({
+        localLabel: 'This Mac',
+        environments: [
+          { id: '  gpu  ', name: '' },
+          { id: ' \t', name: 'Invalid' }
+        ]
+      })
+    ).toEqual([
+      { key: 'local', label: 'This Mac', target: { kind: 'local' } },
+      {
+        key: 'environment:gpu',
+        label: 'gpu',
+        target: { kind: 'environment', environmentId: 'gpu' }
+      }
+    ])
+  })
+
+  it('clears a selected host key when its environment disappears', () => {
+    const options = buildAutomationListHostOptions({
+      localLabel: 'This Mac',
+      environments: [{ id: 'gpu', name: 'GPU box' }]
+    })
+
+    expect(getValidatedAutomationHostTargetKey('environment:gpu', options)).toBe('environment:gpu')
+    expect(getValidatedAutomationHostTargetKey('environment:retired', options)).toBeNull()
   })
 
   it('creates and manually runs runtime-host automations through that server', async () => {

--- a/src/renderer/src/components/automations/automation-host-client.ts
+++ b/src/renderer/src/components/automations/automation-host-client.ts
@@ -26,20 +26,6 @@ export type AutomationHostTarget =
   | { kind: 'local' }
   | { kind: 'environment'; environmentId: string }
 
-export function getAutomationHostTargetKey(target: AutomationHostTarget): string {
-  return target.kind === 'environment' ? `environment:${target.environmentId}` : 'local'
-}
-
-export function getAutomationHostTargetFromKey(key: string | null): AutomationHostTarget | null {
-  if (!key) {
-    return null
-  }
-  if (key.startsWith('environment:')) {
-    return { kind: 'environment', environmentId: key.slice('environment:'.length) }
-  }
-  return { kind: 'local' }
-}
-
 export function getAutomationTargetFromHostId(
   hostId: string | null | undefined
 ): AutomationHostTarget {
@@ -54,6 +40,64 @@ export function getAutomationListTarget(
 ): AutomationHostTarget {
   const environmentId = settings?.activeRuntimeEnvironmentId?.trim()
   return environmentId ? { kind: 'environment', environmentId } : { kind: 'local' }
+}
+
+export function getAutomationHostTargetKey(target: AutomationHostTarget): string {
+  return target.kind === 'environment' ? `environment:${target.environmentId}` : 'local'
+}
+
+export function getAutomationHostTargetFromKey(key: string | null): AutomationHostTarget | null {
+  if (!key) {
+    return null
+  }
+  if (key.startsWith('environment:')) {
+    const environmentId = key.slice('environment:'.length).trim()
+    // Why: bare "environment:" must not override the global list fallback (#10187 review).
+    if (!environmentId) {
+      return null
+    }
+    return { kind: 'environment', environmentId }
+  }
+  if (key === 'local') {
+    return { kind: 'local' }
+  }
+  return null
+}
+
+/**
+ * Resolve which host the Automations page should list against.
+ * Pending navigation wins, then an explicit page selection, then the global
+ * active runtime focus (legacy default).
+ */
+export function resolveAutomationListHostTarget(args: {
+  pendingHostId?: string | null
+  selectedKey: string | null
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+}): AutomationHostTarget {
+  if (args.pendingHostId) {
+    return getAutomationTargetFromHostId(args.pendingHostId)
+  }
+  return getAutomationHostTargetFromKey(args.selectedKey) ?? getAutomationListTarget(args.settings)
+}
+
+export type AutomationListHostOption = {
+  key: string
+  label: string
+  target: AutomationHostTarget
+}
+
+export function buildAutomationListHostOptions(args: {
+  localLabel: string
+  environments: readonly { id: string; name: string }[]
+}): AutomationListHostOption[] {
+  return [
+    { key: 'local', label: args.localLabel, target: { kind: 'local' } },
+    ...args.environments.map((environment) => ({
+      key: getAutomationHostTargetKey({ kind: 'environment', environmentId: environment.id }),
+      label: environment.name || environment.id,
+      target: { kind: 'environment' as const, environmentId: environment.id }
+    }))
+  ]
 }
 
 export function getAutomationOwnerTarget(

--- a/src/renderer/src/components/automations/automation-host-client.ts
+++ b/src/renderer/src/components/automations/automation-host-client.ts
@@ -42,8 +42,17 @@ export function getAutomationListTarget(
   return environmentId ? { kind: 'environment', environmentId } : { kind: 'local' }
 }
 
-export function getAutomationHostTargetKey(target: AutomationHostTarget): string {
-  return target.kind === 'environment' ? `environment:${target.environmentId}` : 'local'
+function normalizeAutomationEnvironmentId(environmentId: string): string | null {
+  const normalized = environmentId.trim()
+  return normalized || null
+}
+
+export function getAutomationHostTargetKey(target: AutomationHostTarget): string | null {
+  if (target.kind === 'local') {
+    return 'local'
+  }
+  const environmentId = normalizeAutomationEnvironmentId(target.environmentId)
+  return environmentId ? `environment:${environmentId}` : null
 }
 
 export function getAutomationHostTargetFromKey(key: string | null): AutomationHostTarget | null {
@@ -86,17 +95,36 @@ export type AutomationListHostOption = {
   target: AutomationHostTarget
 }
 
+export function getValidatedAutomationHostTargetKey(
+  selectedKey: string | null,
+  options: readonly AutomationListHostOption[]
+): string | null {
+  return selectedKey && options.some((option) => option.key === selectedKey) ? selectedKey : null
+}
+
 export function buildAutomationListHostOptions(args: {
   localLabel: string
   environments: readonly { id: string; name: string }[]
 }): AutomationListHostOption[] {
   return [
     { key: 'local', label: args.localLabel, target: { kind: 'local' } },
-    ...args.environments.map((environment) => ({
-      key: getAutomationHostTargetKey({ kind: 'environment', environmentId: environment.id }),
-      label: environment.name || environment.id,
-      target: { kind: 'environment' as const, environmentId: environment.id }
-    }))
+    ...args.environments.flatMap((environment) => {
+      const environmentId = normalizeAutomationEnvironmentId(environment.id)
+      if (!environmentId) {
+        return []
+      }
+      const key = getAutomationHostTargetKey({ kind: 'environment', environmentId })
+      if (!key) {
+        return []
+      }
+      return [
+        {
+          key,
+          label: environment.name || environmentId,
+          target: { kind: 'environment' as const, environmentId }
+        }
+      ]
+    })
   ]
 }
 


### PR DESCRIPTION
## Summary

- Add a **host selector** on the Automations page (Local + each connected runtime environment).
- Prefer the page’s explicit host when listing automations/runs, so remote automations are visible without changing the global active runtime.
- Pending run navigation still overrides the selection temporarily.

Fixes #9964.

## Why

CLI `orca automations list --environment server-01` already works, but the UI always listed via `activeRuntimeEnvironmentId` (or local). Projects from a connected remote could show in the sidebar while the Automations page stayed empty.

## Test plan

- [x] `automation-host-client` unit tests (resolve host target + option list)
- [ ] Manual: connect a remote environment with automations → open Automations → switch host selector to that environment → list populates; Local still shows local automations

---

> **Note:** Re-opened as a new PR after an accidental empty force-push during local rebase cleanup closed the original [#10187](https://github.com/stablyai/orca/pull/10187) (no code intent to withdraw). Branch tip restored with an empty recovery commit.

## ELI5

Automations UI always used the globally active runtime, so remote automations were hard to see. A host selector lets you pick Local or each connected environment without changing global focus.
