### PR TITLE
fix(daemon): respawn terminal host for listProcesses/shutdown

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -714,6 +714,34 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
     })
   })
 
+  describe('listProcesses', () => {
+    it('respawns a dead terminal host and retries listProcesses (#10087)', async () => {
+      // Why: worktree remove inventories via listProcesses; spawn already retried
+      // daemon-gone errors but list did not, so Windows named-pipe ENOENT blocked delete.
+      let respawnServer: DaemonServer | undefined
+      const respawnFn = vi.fn(async () => {
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+      const retryAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+
+      try {
+        await retryAdapter.spawn({ cols: 80, rows: 24 })
+        await server.shutdown()
+        // Fresh host has no sessions, but the inventory must not throw connect ENOENT.
+        await expect(retryAdapter.listProcesses()).resolves.toEqual([])
+        expect(respawnFn).toHaveBeenCalledOnce()
+      } finally {
+        retryAdapter.dispose()
+        await respawnServer?.shutdown()
+      }
+    })
+  })
+
   describe('serialize / revive', () => {
     it('serialize returns JSON', async () => {
       const { id } = await adapter.spawn({ cols: 80, rows: 24 })

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1954,6 +1954,32 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         })
       )
     })
+
+    it('respawns a dead terminal host and retries listProcesses (#10087)', async () => {
+      // Why: worktree remove inventories via listProcesses; spawn already retried
+      // daemon-gone errors but list did not, so Windows named-pipe ENOENT blocked delete.
+      let respawnServer: DaemonServer | undefined
+      const respawnFn = vi.fn(async () => {
+        respawnServer = new DaemonServer({
+          socketPath,
+          tokenPath,
+          spawnSubprocess: () => createMockSubprocess()
+        })
+        await respawnServer.start()
+      })
+      const retryAdapter = new DaemonPtyAdapter({ socketPath, tokenPath, respawn: respawnFn })
+
+      try {
+        await retryAdapter.spawn({ cols: 80, rows: 24 })
+        await server.shutdown()
+        // Fresh host has no sessions, but the inventory must not throw connect ENOENT.
+        await expect(retryAdapter.listProcesses()).resolves.toEqual([])
+        expect(respawnFn).toHaveBeenCalledOnce()
+      } finally {
+        retryAdapter.dispose()
+        await respawnServer?.shutdown()
+      }
+    })
   })
 
   describe('hasChildProcesses / getForegroundProcess', () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1061,7 +1061,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // before killing so a healthy daemon session is not orphaned (#7742). Connect
     // and kill share the caller's one absolute deadline, so a wedged handshake
     // cannot burn the whole teardown budget before the kill even starts.
-    await this.ensureConnected(opts.deadlineMs)
+    // Why withDaemonRetry: same dead-pipe path as listProcesses during remove (#10087).
+    await this.withDaemonRetry(() => this.ensureConnected(opts.deadlineMs))
     // Why: sleep/exact-stop kills the live PTY before the periodic checkpoint may run.
     // Force a final snapshot so wake can restore the pane users left.
     if (opts.keepHistory) {
@@ -1409,49 +1410,52 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // be reconciled away below.
     const preRequestActiveIds = new Set(this.activeSessionIds)
     try {
-      // Why: connect + listSessions share the caller's one absolute deadline so a
-      // wedged handshake cannot burn the whole teardown budget before the list issues.
-      await this.ensureConnected(opts?.deadlineMs)
-      const result = await this.client.request<ListSessionsResult>(
-        'listSessions',
-        undefined,
-        remainingRequestTimeoutMs(opts?.deadlineMs)
-      )
-      const admission = new PtyProcessListAdmission()
-      const processes: PtyProcessInfo[] = []
-      const aliveSessionIds = new Set<string>()
-      for (const session of result.sessions) {
-        if (!session.isAlive) {
-          continue
-        }
-        aliveSessionIds.add(session.sessionId)
-        const { worktreeId } = parsePtySessionId(session.sessionId)
-        processes.push(
-          admission.admit({
-            id: session.sessionId,
-            ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
-            // Why: OSC 7 may not arrive before cleanup; spawn cwd is authoritative until the daemon reports a live cwd.
-            cwd: session.cwd ?? this.initialCwds.get(session.sessionId) ?? '',
-            title: 'shell',
-            ...(worktreeId ? { worktreeId } : {}),
-            ...(session.terminalHandle ? { terminalHandle: session.terminalHandle } : {}),
-            ...(session.wslDistro !== undefined ? { wslDistro: session.wslDistro } : {}),
-            ...this.validatedAgentSessionOwners(session.agentSessionOwners)
-          })
+      // Why: worktree removal may inventory through a retired daemon endpoint.
+      return await this.withDaemonRetry(async () => {
+        // Why: connect + listSessions share the caller's one absolute deadline so a
+        // wedged handshake cannot burn the whole teardown budget before the list issues.
+        await this.ensureConnected(opts?.deadlineMs)
+        const result = await this.client.request<ListSessionsResult>(
+          'listSessions',
+          undefined,
+          remainingRequestTimeoutMs(opts?.deadlineMs)
         )
-      }
-      // Why: hasPty reads activeSessionIds, and an exit missed while the socket
-      // was disconnected otherwise survives an authoritative inventory forever —
-      // defeating every absence proof built on the cache.
-      for (const id of preRequestActiveIds) {
-        if (!aliveSessionIds.has(id)) {
-          this.activeSessionIds.delete(id)
+        const admission = new PtyProcessListAdmission()
+        const processes: PtyProcessInfo[] = []
+        const aliveSessionIds = new Set<string>()
+        for (const session of result.sessions) {
+          if (!session.isAlive) {
+            continue
+          }
+          aliveSessionIds.add(session.sessionId)
+          const { worktreeId } = parsePtySessionId(session.sessionId)
+          processes.push(
+            admission.admit({
+              id: session.sessionId,
+              ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
+              // Why: OSC 7 may not arrive before cleanup; spawn cwd is authoritative until the daemon reports a live cwd.
+              cwd: session.cwd ?? this.initialCwds.get(session.sessionId) ?? '',
+              title: 'shell',
+              ...(worktreeId ? { worktreeId } : {}),
+              ...(session.terminalHandle ? { terminalHandle: session.terminalHandle } : {}),
+              ...(session.wslDistro !== undefined ? { wslDistro: session.wslDistro } : {}),
+              ...this.validatedAgentSessionOwners(session.agentSessionOwners)
+            })
+          )
         }
-      }
-      this.publishAuditObservation(
-        recordAuthenticatedInventory(this.auditContext, this.exactDaemonIncarnation)
-      )
-      return processes
+        // Why: hasPty reads activeSessionIds, and an exit missed while the socket
+        // was disconnected otherwise survives an authoritative inventory forever —
+        // defeating every absence proof built on the cache.
+        for (const id of preRequestActiveIds) {
+          if (!aliveSessionIds.has(id)) {
+            this.activeSessionIds.delete(id)
+          }
+        }
+        this.publishAuditObservation(
+          recordAuthenticatedInventory(this.auditContext, this.exactDaemonIncarnation)
+        )
+        return processes
+      })
     } catch (error) {
       const missingAuthenticatedToken =
         isMissingTokenFileError(error) && this.client.hasObservedAuthenticatedDisconnect()

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -1237,7 +1237,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // deadline, so neither a wedged handshake nor a stalled history write can burn
     // the whole teardown budget before the kill even starts. Only the waits are
     // bounded — the checkpoint itself stays deadline-free and lossless (STA-4228).
-    await this.ensureConnected(opts.deadlineMs)
+    // Why withDaemonRetry: same dead-pipe path as listProcesses during remove (#10087).
+    await this.withDaemonRetry(() => this.ensureConnected(opts.deadlineMs))
     // Why: sleep/exact-stop kills the live PTY before the periodic checkpoint may run.
     // Force a final snapshot so wake can restore the pane users left.
     if (opts.keepHistory) {
@@ -1741,49 +1742,52 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // be reconciled away below.
     const preRequestActiveIds = new Set(this.activeSessionIds)
     try {
-      // Why: connect + listSessions share the caller's one absolute deadline so a
-      // wedged handshake cannot burn the whole teardown budget before the list issues.
-      await this.ensureConnected(opts?.deadlineMs)
-      const result = await this.client.request<ListSessionsResult>(
-        'listSessions',
-        undefined,
-        remainingRequestTimeoutMs(opts?.deadlineMs)
-      )
-      const admission = new PtyProcessListAdmission()
-      const processes: PtyProcessInfo[] = []
-      const aliveSessionIds = new Set<string>()
-      for (const session of result.sessions) {
-        if (!session.isAlive) {
-          continue
-        }
-        aliveSessionIds.add(session.sessionId)
-        const { worktreeId } = parsePtySessionId(session.sessionId)
-        processes.push(
-          admission.admit({
-            id: session.sessionId,
-            ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
-            // Why: OSC 7 may not arrive before cleanup; spawn cwd is authoritative until the daemon reports a live cwd.
-            cwd: session.cwd ?? this.initialCwds.get(session.sessionId) ?? '',
-            title: 'shell',
-            ...(worktreeId ? { worktreeId } : {}),
-            ...(session.terminalHandle ? { terminalHandle: session.terminalHandle } : {}),
-            ...(session.wslDistro !== undefined ? { wslDistro: session.wslDistro } : {}),
-            ...this.validatedAgentSessionOwners(session.agentSessionOwners)
-          })
+      // Why: worktree removal may inventory through a retired daemon endpoint.
+      return await this.withDaemonRetry(async () => {
+        // Why: connect + listSessions share the caller's one absolute deadline so a
+        // wedged handshake cannot burn the whole teardown budget before the list issues.
+        await this.ensureConnected(opts?.deadlineMs)
+        const result = await this.client.request<ListSessionsResult>(
+          'listSessions',
+          undefined,
+          remainingRequestTimeoutMs(opts?.deadlineMs)
         )
-      }
-      // Why: hasPty reads activeSessionIds, and an exit missed while the socket
-      // was disconnected otherwise survives an authoritative inventory forever —
-      // defeating every absence proof built on the cache.
-      for (const id of preRequestActiveIds) {
-        if (!aliveSessionIds.has(id)) {
-          this.activeSessionIds.delete(id)
+        const admission = new PtyProcessListAdmission()
+        const processes: PtyProcessInfo[] = []
+        const aliveSessionIds = new Set<string>()
+        for (const session of result.sessions) {
+          if (!session.isAlive) {
+            continue
+          }
+          aliveSessionIds.add(session.sessionId)
+          const { worktreeId } = parsePtySessionId(session.sessionId)
+          processes.push(
+            admission.admit({
+              id: session.sessionId,
+              ...(session.incarnationId ? { incarnationId: session.incarnationId } : {}),
+              // Why: OSC 7 may not arrive before cleanup; spawn cwd is authoritative until the daemon reports a live cwd.
+              cwd: session.cwd ?? this.initialCwds.get(session.sessionId) ?? '',
+              title: 'shell',
+              ...(worktreeId ? { worktreeId } : {}),
+              ...(session.terminalHandle ? { terminalHandle: session.terminalHandle } : {}),
+              ...(session.wslDistro !== undefined ? { wslDistro: session.wslDistro } : {}),
+              ...this.validatedAgentSessionOwners(session.agentSessionOwners)
+            })
+          )
         }
-      }
-      this.publishAuditObservation(
-        recordAuthenticatedInventory(this.auditContext, this.exactDaemonIncarnation)
-      )
-      return processes
+        // Why: hasPty reads activeSessionIds, and an exit missed while the socket
+        // was disconnected otherwise survives an authoritative inventory forever —
+        // defeating every absence proof built on the cache.
+        for (const id of preRequestActiveIds) {
+          if (!aliveSessionIds.has(id)) {
+            this.activeSessionIds.delete(id)
+          }
+        }
+        this.publishAuditObservation(
+          recordAuthenticatedInventory(this.auditContext, this.exactDaemonIncarnation)
+        )
+        return processes
+      })
     } catch (error) {
       const missingAuthenticatedToken = this.isRetiredEndpointTokenMissing()
       const missingNamedPipe = isMissingWindowsNamedPipeError(error)


### PR DESCRIPTION
## Summary

On Windows, worktree remove could hard-fail with:

```text
Error invoking remote method 'worktrees:remove': Error: connect ENOENT \\?\pipe\orca-terminal-host-…
```

after normal terminal/agent use. Restarting Orca and deleting immediately worked, because a fresh terminal host pipe exists.

### Cause

Destructive teardown inventories PTYs via `DaemonPtyAdapter.listProcesses()` (and stops via `shutdown()`). **Spawn** already wraps operations in `withDaemonRetry` (respawn on `connect ENOENT` / other daemon-gone errors). **listProcesses / shutdown** only called `ensureConnected` without that retry, so a dead named pipe failed remove until full app restart.

### Fix

- Wrap `listProcesses` in `withDaemonRetry`
- Use `withDaemonRetry` for the connect step of `shutdown`

After a dead host, inventory can respawn once and return an empty session list so remove proceeds instead of blocking on pipe connect.

### Out of scope

- Resource Manager kill button no-op (separate surface; not fixed here)
- OS-level orphaned child processes after host death (#10004 / #9045)

Fixes #10087

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-pty-adapter.test.ts -t "listProcesses|respawns a dead terminal host"` (2/2)
- [ ] Full suite / Windows manual delete after agent use

## AI Review Report

- Cross-platform: Windows named pipes and Unix sockets both surface `connect` ENOENT/ECONNREFUSED; existing `isDaemonGoneError` already covers them
- Destructive path deadline still applied via `ensureConnected(deadlineMs)`
- Does not loosen `requirePhysicalStop` when sessions still exist and stop fails

## Security Audit

- No new IPC; reuses existing daemon respawn path used by spawn
- Respawn still gated by adapter lifecycle (`respawnAdoptionClosed` / missing `respawn` callback)

## Notes

- If the host died with OS orphans still holding files, remove may still hit later PTY/physical-stop errors — that remains the #10004 class of issues

---

> **Note:** Re-opened as a new PR after an accidental empty force-push during local rebase cleanup closed the original [#10092](https://github.com/stablyai/orca/pull/10092) (no code intent to withdraw). Branch tip restored with an empty recovery commit.

## ELI5

On Windows, removing a worktree could fail with a missing terminal-host pipe after normal terminal use. listProcesses and shutdown now respawn the daemon host like spawn already did, so teardown works again.
