### PR TITLE
docs: refresh product docs content against current Orca

### DIFF
--- a/packages/docs/content/docs/agents/supported.mdx
+++ b/packages/docs/content/docs/agents/supported.mdx
@@ -15,12 +15,14 @@ To restore prompts for one agent only, edit that agent's default arguments or en
 
 | Agent | Notes | Docs |
 | --- | --- | --- |
-| Claude Code | Deep integration: usage, hot-swap, hooks | [Anthropic](https://docs.anthropic.com/claude/docs/claude-code) |
+| Claude | Deep integration: usage, hot-swap, hooks (Claude Code CLI) | [Anthropic](https://docs.anthropic.com/claude/docs/claude-code) |
 | Claude Agent Teams | Disabled by default — enable under Settings → Agents to launch via `orca claude-teams` with native panes for each teammate | [Anthropic](https://code.claude.com/docs/agent-teams) |
+| OpenClaude | Auto-setup | [OpenClaude](https://openclaude.gitlawb.com/) |
 | Codex | Deep integration: usage, hot-swap | [OpenAI](https://github.com/openai/codex) |
 | Grok | Auto-setup | [xAI](https://x.ai/cli) |
-| GitHub Copilot CLI | Auto-setup | [GitHub](https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli) |
+| GitHub Copilot | Auto-setup | [GitHub](https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli) |
 | OpenCode | Auto-setup, status | [OpenCode](https://opencode.ai/docs/cli/) |
+| MiMo Code | Auto-setup | [MiMo Code](https://mimo.xiaomi.com/coder) |
 | Pi | Auto-setup, hooks, status | [Pi](https://pi.dev) |
 | OMP | Auto-setup, hooks, status | [OMP](https://omp.sh) |
 | Gemini | Auto-setup | [Google](https://github.com/google-gemini/gemini-cli) |
@@ -31,22 +33,23 @@ To restore prompts for one agent only, edit that agent's default arguments or en
 | Amp | Auto-setup | [Amp](https://ampcode.com/manual#install) |
 | Kilocode | Auto-setup | [Kilo](https://kilo.ai/docs/cli) |
 | Kiro | Auto-setup | [Kiro](https://kiro.dev/docs/cli/) |
-| Charm Crush | Auto-setup | [Charm](https://github.com/charmbracelet/crush) |
+| Charm (Crush) | Auto-setup | [Charm](https://github.com/charmbracelet/crush) |
 | Auggie | Auto-setup | [Augment](https://docs.augmentcode.com/cli/overview) |
-| Autohand | Auto-setup | [Autohand](https://github.com/autohandai/code-cli) |
+| Autohand Code | Auto-setup | [Autohand](https://github.com/autohandai/code-cli) |
 | Cline | Auto-setup | [Cline](https://docs.cline.bot/cline-cli/overview) |
 | Codebuff | Auto-setup | [Codebuff](https://www.codebuff.com/docs/help/quick-start) |
 | Command Code | Auto-setup, status | [Command Code](https://commandcode.ai/docs/quickstart) |
 | Continue | Auto-setup | [Continue](https://docs.continue.dev/guides/cli) |
-| Cursor CLI | Deep integration | [Cursor](https://cursor.com/cli) |
+| Cursor | Deep integration | [Cursor](https://cursor.com/cli) |
 | Devin | Auto-setup | [Devin](https://devin.ai/cli) |
 | Droid (Factory) | Auto-setup, hooks, status | [Factory](https://docs.factory.ai/cli/getting-started/quickstart) |
 | Kimi | Auto-setup | [Moonshot](https://www.kimi.com/code/docs/en/kimi-code-cli/getting-started.html) |
 | Mistral Vibe | Auto-setup | [Mistral](https://github.com/mistralai/mistral-vibe) |
-| MiniMax | Auto-setup, usage tracking, rate-limit tracking | [MiniMax](https://www.minimax.chat) |
 | Qwen Code | Auto-setup via the installed `qwen` executable | [Qwen](https://github.com/QwenLM/qwen-code) |
 | Rovo Dev | Auto-setup | [Atlassian](https://support.atlassian.com/rovo/docs/install-and-run-rovo-dev-cli-on-your-device/) |
 | Hermes | Auto-setup | [Nous](https://hermes-agent.nousresearch.com/docs/) |
 | OpenClaw | Auto-setup | [OpenClaw](https://github.com/openclaw/openclaw) |
+
+MiniMax CLI usage/rate-limit tracking is configured under [Settings → Integrations](/docs/settings) (session cookie), not as a separate picker agent.
 
 See [Add a custom CLI agent](/docs/agents/custom-cli) for anything not on this list.

--- a/packages/docs/content/docs/cli/overview.mdx
+++ b/packages/docs/content/docs/cli/overview.mdx
@@ -14,9 +14,15 @@ import { Callout, ImagePlaceholder } from '@/components/docs/prose';
 
 The Orca CLI is the `orca` command-line interface for scripting a running Orca editor from any shell. Use it to create and inspect worktrees, drive agent terminals, open files and diffs, automate the built-in browser, run scheduled automations, and control Orca-native tools from scripts or AI agents.
 
-It ships with the desktop app; register it under [Settings → Experimental → CLI](/docs/settings).
+It ships with the desktop app; register it under [Settings → General → Orca CLI](/docs/settings). On some Linux installs the registered command is `orca-ide` (plain `orca` may be the GNOME screen reader) — use whichever command Orca registered on your machine.
 
-Agents can install the matching Orca CLI skill with:
+Agents should load the version-matched CLI guide from a running Orca binary:
+
+```bash
+orca skills get orca-cli
+```
+
+Or install the skill package into an agent’s skill directory:
 
 ```bash
 npx skills add https://github.com/stablyai/orca --skill orca-cli

--- a/packages/docs/content/docs/cli/reference.mdx
+++ b/packages/docs/content/docs/cli/reference.mdx
@@ -9,7 +9,7 @@ The `orca` CLI talks to a running Orca runtime. Use it when a shell script or ag
 
 ## Verify the runtime
 
-Register the CLI under [Settings -> Experimental -> CLI](/docs/settings), then check that it can reach Orca:
+Register the CLI under [Settings → General → Orca CLI](/docs/settings), then check that it can reach Orca:
 
 ```bash
 command -v orca

--- a/packages/docs/content/docs/cli/skills.mdx
+++ b/packages/docs/content/docs/cli/skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Orca skills registry & MCP
-description: Install Orca agent skills with npx skills add, including orca-cli, orchestration, computer-use, orca-linear, and orca-emulator.
+description: Install Orca agent skills with npx skills add, including orca-cli, orchestration, computer-use, orca-linear, orca-emulator, and more.
 keywords:
   - Orca skills
   - npx skills add
@@ -9,13 +9,14 @@ keywords:
   - computer-use skill
   - orca-linear skill
   - orca-emulator skill
+  - orca-per-workspace-env skill
 ---
 
-Orca CLI commands are distributed as **skills** — versioned packages an agent can install into its own skill directory.
+Orca CLI commands are distributed as **skills** — versioned packages an agent can install into its own skill directory. Prefer `orca skills get <name>` from a running Orca binary so the guide matches that install.
 
 ## Installable Orca skills
 
-Use `npx skills add` with the public Orca repo and the skill name. The default agent setup uses `orca-cli`, `computer-use`, and `orchestration`; install `orca-linear` when agents need Linear ticket context and `orca-emulator` when they need to drive a local iOS Simulator from Orca.
+Use `npx skills add` with the public Orca repo and the skill name. The default agent setup uses `orca-cli`, `computer-use`, and `orchestration`; install the others when agents need Linear context, simulators, Android emulators, or per-workspace environments.
 
 | Skill | Install | Use it for |
 | --- | --- | --- |
@@ -24,6 +25,8 @@ Use `npx skills add` with the public Orca repo and the skill name. The default a
 | [`computer-use`](#computer-use) | `npx skills add https://github.com/stablyai/orca --skill computer-use` | Desktop app control through accessibility trees, screenshots, clicks, typing, and safe UI actions. |
 | [`orca-linear`](#orca-linear) | `npx skills add https://github.com/stablyai/orca --skill orca-linear` | Linear ticket context for agents working from linked Linear issues. |
 | [`orca-emulator`](#orca-emulator) | `npx skills add https://github.com/stablyai/orca --skill orca-emulator` | iOS Simulator control from Orca with taps, gestures, typing, permissions, camera injection, and accessibility. |
+| [`orca-emulator-android`](#orca-emulator-android) | `npx skills add https://github.com/stablyai/orca --skill orca-emulator-android` | Android emulator control from Orca. |
+| [`orca-per-workspace-env`](#orca-per-workspace-env) | `npx skills add https://github.com/stablyai/orca --skill orca-per-workspace-env` | Per-workspace environments (ephemeral VMs / sandboxes) via Orca. |
 
 ## orca-cli
 
@@ -76,6 +79,22 @@ npx skills add https://github.com/stablyai/orca --skill orca-emulator
 ```
 
 Use this when an agent should control an iOS Simulator from inside Orca through `orca emulator` commands.
+
+## orca-emulator-android
+
+```
+npx skills add https://github.com/stablyai/orca --skill orca-emulator-android
+```
+
+Use this when an agent should drive an Android emulator from Orca.
+
+## orca-per-workspace-env
+
+```
+npx skills add https://github.com/stablyai/orca --skill orca-per-workspace-env
+```
+
+Use this when agents should create or manage [per-workspace environments](/docs/ways-to-run#4-per-workspace-environments-ephemeral-vms) (cloud sandboxes, VMs, or local Docker) through Orca.
 
 ## Add your own skills
 

--- a/packages/docs/content/docs/index.mdx
+++ b/packages/docs/content/docs/index.mdx
@@ -5,7 +5,7 @@ description: "A 60-second pitch: who Orca is for and when to reach for it."
 
 import { Callout, ImagePlaceholder } from '@/components/docs/prose';
 
-Orca is a desktop IDE for running multiple AI coding agents side by side. Every task gets its own git worktree, its own agent terminal, and its own browser tab — so you can fan out work across Claude Code, Codex, Cursor CLI, and friends without stashing, branch-juggling, or losing flow.
+Orca is a desktop IDE for running multiple AI coding agents side by side. Every task gets its own git worktree, its own agent terminal, and its own browser tab — so you can fan out work across Claude Code, Codex, OpenCode, Pi, Cursor, and friends without stashing, branch-juggling, or losing flow.
 
 <ImagePlaceholder src="/docs/orca-split-screen.gif" caption="Orca main window: sidebar of worktrees, split panes with agent terminals and a diff view" />
 
@@ -13,7 +13,7 @@ Orca is a desktop IDE for running multiple AI coding agents side by side. Every 
 
 - You want three agents trying the same bug in parallel and to pick the winner.
 - You want to review AI-generated diffs seriously before you ship them.
-- You already pay for Claude Code, Codex, or Cursor CLI and want one place to orchestrate them.
+- You already pay for Claude Code, Codex, OpenCode, Pi, or Cursor and want one place to orchestrate them.
 - You want agents to run remotely — over SSH, on a self-hosted Orca server, or in an on-demand VM — without giving up your IDE.
 
 ## Who it's for

--- a/packages/docs/content/docs/mobile.mdx
+++ b/packages/docs/content/docs/mobile.mdx
@@ -10,7 +10,7 @@ The Orca mobile companion is an iOS/Android app that pairs with your desktop Orc
 <ImagePlaceholder src="/whats-new/orca-mobile.gif" caption="Orca Mobile — agent status, scrollback, and quick replies from your phone." />
 
 <Callout title="Beta">
-The mobile companion is in beta. Install iOS from the [App Store](https://apps.apple.com/us/app/orca-ide/id6766130217), join the [TestFlight preview channel](https://testflight.apple.com/join/YjeGMQBA), or install Android from the [current APK 0.0.31](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.31/app-release.apk).
+The mobile companion is in beta. Install iOS from the [App Store](https://apps.apple.com/us/app/orca-ide/id6766130217), join the [TestFlight preview channel](https://testflight.apple.com/join/YjeGMQBA), or install Android from the [current APK 0.0.32](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.32/app-release.apk).
 </Callout>
 
 ## What you can do from mobile

--- a/packages/docs/content/docs/troubleshooting.mdx
+++ b/packages/docs/content/docs/troubleshooting.mdx
@@ -20,7 +20,7 @@ title: Troubleshooting & FAQ
 
 ## Orca CLI says "command not found"
 
-Register the CLI under [Settings → Experimental → CLI](/docs/settings). On macOS it installs a shim into `~/.local/bin`; make sure that's on your shell's `PATH`.
+Register the CLI under [Settings → General → Orca CLI](/docs/settings). On macOS it installs a shim into `~/.local/bin`; make sure that's on your shell's `PATH`. On some Linux installs the command is `orca-ide` instead of `orca`.
 
 ## Browser says `browser_no_tab`
 


### PR DESCRIPTION
## Summary
Stacked on #10355 (`docs/open-source-migrate`). Content-only updates to the open-source docs package:

- **Mobile:** Android APK link `0.0.31` → `0.0.32` (matches README / latest mobile release)
- **CLI install path:** Settings → **General → Orca CLI** (was Experimental); Linux `orca-ide` note
- **Supported agents:** align picker with `TUI_AGENT_DISPLAY_NAMES` / agent catalog (OpenClaude, MiMo Code, label fixes); MiniMax clarified as Integrations usage tracking
- **Skills registry:** document `orca-emulator-android` and `orca-per-workspace-env`; prefer `orca skills get`
- **Index:** agent list matches current product pitch (OpenCode, Pi, Cursor)

## Stack
1. #10355 — migrate `packages/docs` + CI
2. **This PR** — content refresh (base = #10355 branch)

## Test plan
- [x] `pnpm test` / `pnpm build` in `packages/docs`
- [ ] Spot-check rendered pages after #10355 is available