### PR TITLE
feat(mobile): add in-repo F-Droid packaging metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 Monitor and steer your agents from your phone — get notified when an agent finishes and send follow-ups from anywhere.
 
-[iOS App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) · [TestFlight](https://testflight.apple.com/join/YjeGMQBA) · [Android APK 0.0.32](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.32/app-release.apk) · [Docs →](https://www.onorca.dev/docs/mobile)
+[iOS App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) · [TestFlight](https://testflight.apple.com/join/YjeGMQBA) · [Android APK 0.0.32](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.32/app-release.apk) · [F-Droid metadata (in-repo)](metadata/com.stably.orca.mobile.yml) · [Docs →](https://www.onorca.dev/docs/mobile)
 
 </td>
 <td width="50%">
@@ -231,6 +231,7 @@ Pair with your desktop app to monitor and steer your agents from your phone.
 
 - **iOS:** [Download on the App Store](https://apps.apple.com/us/app/orca-ide/id6766130217) or [join TestFlight](https://testflight.apple.com/join/YjeGMQBA)
 - **Android:** [Download APK 0.0.32](https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.32/app-release.apk)
+- **F-Droid:** In-repo packaging metadata and a FOSS-from-source build recipe live at [`metadata/com.stably.orca.mobile.yml`](metadata/com.stably.orca.mobile.yml) (not listed on f-droid.org until an fdroiddata submission is merged).
 
 ---
 

--- a/metadata/com.stably.orca.mobile.yml
+++ b/metadata/com.stably.orca.mobile.yml
@@ -1,0 +1,73 @@
+Categories:
+  - Development
+License: MIT
+AuthorName: Lovecast Inc.
+WebSite: https://www.onorca.dev
+SourceCode: https://github.com/stablyai/orca
+IssueTracker: https://github.com/stablyai/orca/issues
+Changelog: https://github.com/stablyai/orca/releases
+
+AutoName: Orca
+Name: Orca Mobile
+Summary: Mobile companion for the Orca desktop agent IDE
+Description: |-
+  Orca Mobile pairs with the Orca desktop app so you can monitor worktrees,
+  view terminal output, and steer agents from your phone.
+
+  Pairing uses a local QR code / WebSocket connection to your desktop (or
+  another reachable Orca host). The companion does not require Google Play
+  Services for its core workflow.
+
+  This metadata describes a free-software-from-source Android build path.
+  Listing on f-droid.org still requires a separate merge into fdroiddata and
+  a successful build on F-Droid infrastructure.
+
+RepoType: git
+Repo: https://github.com/stablyai/orca.git
+
+Builds:
+  - versionName: 0.0.32
+    versionCode: 8
+    commit: mobile-android-v0.0.32
+    subdir: mobile
+    sudo:
+      - apt-get update
+      - apt-get install -y openjdk-17-jdk-headless curl ca-certificates gnupg
+      - update-alternatives --auto java
+      # Node 24 matches repo engines / mobile Android CI (Expo SDK 55).
+      - curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+      - apt-get install -y nodejs
+      - corepack enable
+    output: android/app/build/outputs/apk/release/*.apk
+    # Why: hermesc + assorted RN gradle plugin bits ship as prebuilts in npm;
+    # F-Droid policy allows scanignore for Hermes (same as other Expo apps).
+    scanignore:
+      - node_modules/hermes-compiler/hermesc/linux64-bin/hermesc
+      - node_modules/react-native/sdks/hermesc/linux64-bin/hermesc
+      - node_modules/expo-modules-core/android/ExpoModulesCorePlugin.gradle
+      - node_modules/expo-modules-autolinking/scripts/android/autolinking_implementation.gradle
+      - node_modules/@react-native-async-storage/async-storage/android/build.gradle
+      - node_modules/react-native-safe-area-context/android/build.gradle
+      - node_modules/react-native-screens/android/build.gradle
+      - node_modules/react-native-svg/android/build.gradle
+      - node_modules/react-native-webview/android/build.gradle
+      - node_modules/react-native-gesture-handler/android/build.gradle
+      - node_modules/react-native-reanimated/android/build.gradle
+      - node_modules/react-native-worklets/android/build.gradle
+    scandelete:
+      - node_modules
+    prebuild:
+      - corepack prepare pnpm@10.24.0 --activate
+      - pnpm install --frozen-lockfile
+      # Mirrors CI: install → expo prebuild → strip signingConfig for F-Droid re-sign.
+      # prepare-fdroid-android-build also enables expo autolinking buildFromSource.
+      - node scripts/prepare-fdroid-android-build.mjs
+    build:
+      - cd android
+      - gradle assembleRelease
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags ^mobile-android-v.*$
+UpdateCheckData: mobile/app.json|"versionCode":\s(\d+)|.|"version":\s"([\d.]+)"
+CurrentVersion: 0.0.32
+CurrentVersionCode: 8

--- a/metadata/com.stably.orca.mobile.yml
+++ b/metadata/com.stably.orca.mobile.yml
@@ -56,12 +56,17 @@ Builds:
       - node_modules/react-native-worklets/android/build.gradle
     scandelete:
       - node_modules
+    # Why: FOSS prep is inlined in this recipe so Builds.commit can pin the release
+    # tag mobile-android-v0.0.32 (that tag predates any in-tree packaging helper).
+    # Same path as CI: pnpm install → expo prebuild → assembleRelease.
     prebuild:
       - corepack prepare pnpm@10.24.0 --activate
       - pnpm install --frozen-lockfile
-      # Mirrors CI: install → expo prebuild → strip signingConfig for F-Droid re-sign.
-      # prepare-fdroid-android-build also enables expo autolinking buildFromSource.
-      - node scripts/prepare-fdroid-android-build.mjs
+      # Prefer compiling RN/Expo Android modules from source on F-Droid builders.
+      - node -e "const fs=require('fs');const p='package.json';const j=JSON.parse(fs.readFileSync(p,'utf8'));const expo={...(j.expo||{})};const autolinking={...(expo.autolinking||{})};const android={...(autolinking.android||{})};android.buildFromSource=['.*'];autolinking.android=android;expo.autolinking=autolinking;j.expo=expo;fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n');"
+      - npx expo prebuild --platform android --no-install
+      # F-Droid re-signs; drop app signingConfig so assembleRelease needs no private keystore.
+      - sed -i -e '/signingConfig /d' android/app/build.gradle
     build:
       - cd android
       - gradle assembleRelease

--- a/mobile/scripts/fdroid-app-identity.mjs
+++ b/mobile/scripts/fdroid-app-identity.mjs
@@ -1,0 +1,209 @@
+/**
+ * Pure helpers for F-Droid metadata ↔ mobile/app.json alignment.
+ * No filesystem I/O — callers pass parsed config / YAML text.
+ */
+
+const SEMVER = /^\d+\.\d+\.\d+$/
+
+/**
+ * @typedef {{
+ *   packageId: string
+ *   versionName: string
+ *   versionCode: number
+ *   autoName: string
+ * }} MobileAndroidAppIdentity
+ */
+
+/**
+ * @typedef {{
+ *   versionName: string
+ *   versionCode: number
+ *   currentVersion: string
+ *   currentVersionCode: number
+ * }} FdroidMetadataVersionFields
+ */
+
+/**
+ * @param {unknown} appConfig
+ * @returns {MobileAndroidAppIdentity}
+ */
+export function readMobileAndroidAppIdentity(appConfig) {
+  if (appConfig == null || typeof appConfig !== 'object') {
+    throw new Error('app.json must be a JSON object')
+  }
+
+  const expo = /** @type {Record<string, unknown>} */ (appConfig).expo
+  if (expo == null || typeof expo !== 'object') {
+    throw new Error('app.json is missing expo config')
+  }
+
+  const expoConfig = /** @type {Record<string, unknown>} */ (expo)
+  const android = expoConfig.android
+  if (android == null || typeof android !== 'object') {
+    throw new Error('app.json is missing expo.android config')
+  }
+
+  const androidConfig = /** @type {Record<string, unknown>} */ (android)
+  const packageId = String(androidConfig.package ?? '').trim()
+  if (!packageId) {
+    throw new Error('app.json is missing expo.android.package')
+  }
+
+  const versionName = String(expoConfig.version ?? '').trim()
+  if (!SEMVER.test(versionName)) {
+    throw new Error(`expo.version must use x.y.z format, got ${JSON.stringify(versionName)}`)
+  }
+
+  const versionCode = Number(androidConfig.versionCode)
+  if (!Number.isSafeInteger(versionCode) || versionCode <= 0) {
+    throw new Error('expo.android.versionCode must be a positive integer')
+  }
+
+  const autoName = String(expoConfig.name ?? '').trim() || 'Orca'
+
+  return { packageId, versionName, versionCode, autoName }
+}
+
+/**
+ * @param {string} metadataYaml
+ * @returns {FdroidMetadataVersionFields}
+ */
+export function parseFdroidMetadataVersionFields(metadataYaml) {
+  if (typeof metadataYaml !== 'string' || !metadataYaml.trim()) {
+    throw new Error('F-Droid metadata YAML must be a non-empty string')
+  }
+
+  // Builds entries are list items: `  - versionName: x.y.z` then indented versionCode.
+  const versionName = matchFirst(
+    metadataYaml,
+    /^\s*(?:-\s*)?versionName:\s*(\S+)\s*$/m,
+    'Builds.versionName'
+  )
+  const versionCode = parsePositiveInt(
+    matchFirst(metadataYaml, /^\s*(?:-\s*)?versionCode:\s*(\d+)\s*$/m, 'Builds.versionCode'),
+    'Builds.versionCode'
+  )
+  const currentVersion = matchFirst(metadataYaml, /^CurrentVersion:\s*(\S+)\s*$/m, 'CurrentVersion')
+  const currentVersionCode = parsePositiveInt(
+    matchFirst(metadataYaml, /^CurrentVersionCode:\s*(\d+)\s*$/m, 'CurrentVersionCode'),
+    'CurrentVersionCode'
+  )
+
+  return { versionName, versionCode, currentVersion, currentVersionCode }
+}
+
+/**
+ * @param {MobileAndroidAppIdentity} identity
+ * @param {FdroidMetadataVersionFields} fields
+ */
+export function assertFdroidMetadataAligned(identity, fields) {
+  const mismatches = []
+
+  if (fields.versionName !== identity.versionName) {
+    mismatches.push(
+      `Builds.versionName ${JSON.stringify(fields.versionName)} != app version ${JSON.stringify(identity.versionName)}`
+    )
+  }
+  if (fields.versionCode !== identity.versionCode) {
+    mismatches.push(
+      `Builds.versionCode ${fields.versionCode} != app versionCode ${identity.versionCode}`
+    )
+  }
+  if (fields.currentVersion !== identity.versionName) {
+    mismatches.push(
+      `CurrentVersion ${JSON.stringify(fields.currentVersion)} != app version ${JSON.stringify(identity.versionName)}`
+    )
+  }
+  if (fields.currentVersionCode !== identity.versionCode) {
+    mismatches.push(
+      `CurrentVersionCode ${fields.currentVersionCode} != app versionCode ${identity.versionCode}`
+    )
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `F-Droid metadata is out of sync with mobile/app.json:\n- ${mismatches.join('\n- ')}`
+    )
+  }
+}
+
+/**
+ * Rewrite version fields in metadata YAML to match app identity.
+ * Preserves the rest of the file (recipe, descriptions, scanignore, etc.).
+ *
+ * @param {string} metadataYaml
+ * @param {MobileAndroidAppIdentity} identity
+ * @returns {string}
+ */
+export function syncFdroidMetadataVersions(metadataYaml, identity) {
+  let next = metadataYaml
+
+  next = replaceAllLineMatches(
+    next,
+    /^(\s*(?:-\s*)?versionName:\s*)\S+(\s*)$/m,
+    `$1${identity.versionName}$2`
+  )
+  next = replaceAllLineMatches(
+    next,
+    /^(\s*(?:-\s*)?versionCode:\s*)\d+(\s*)$/m,
+    `$1${identity.versionCode}$2`
+  )
+  next = replaceAllLineMatches(
+    next,
+    /^(CurrentVersion:\s*)\S+(\s*)$/m,
+    `$1${identity.versionName}$2`
+  )
+  next = replaceAllLineMatches(
+    next,
+    /^(CurrentVersionCode:\s*)\d+(\s*)$/m,
+    `$1${identity.versionCode}$2`
+  )
+
+  // Keep the Builds.commit tag aligned with the production Android release tag scheme.
+  next = replaceAllLineMatches(
+    next,
+    /^(\s*(?:-\s*)?commit:\s*)mobile-android-v[\d.]+(\s*)$/m,
+    `$1mobile-android-v${identity.versionName}$2`
+  )
+
+  assertFdroidMetadataAligned(identity, parseFdroidMetadataVersionFields(next))
+  return next
+}
+
+/**
+ * @param {string} text
+ * @param {RegExp} re
+ * @param {string} label
+ */
+function matchFirst(text, re, label) {
+  const match = text.match(re)
+  if (!match?.[1]) {
+    throw new Error(`F-Droid metadata is missing ${label}`)
+  }
+  return match[1]
+}
+
+/**
+ * @param {string} raw
+ * @param {string} label
+ */
+function parsePositiveInt(raw, label) {
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  return value
+}
+
+/**
+ * @param {string} text
+ * @param {RegExp} re
+ * @param {string} replacement
+ */
+function replaceAllLineMatches(text, re, replacement) {
+  const next = text.replace(re, replacement)
+  if (next === text) {
+    throw new Error(`F-Droid metadata sync failed to update pattern ${re}`)
+  }
+  return next
+}

--- a/mobile/scripts/prepare-fdroid-android-build.mjs
+++ b/mobile/scripts/prepare-fdroid-android-build.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * FOSS Android build prep used by the in-repo F-Droid recipe.
+ * Mirrors .github/workflows/mobile-android-release.yml:
+ *   pnpm install → expo prebuild → (strip Play/release signing) → gradle assembleRelease
+ *
+ * Usage (from mobile/):
+ *   node scripts/prepare-fdroid-android-build.mjs
+ *
+ * Env:
+ *   MOBILE_ROOT — override mobile package root (tests)
+ *   SKIP_EXPO_PREBUILD=1 — only apply package/signing patches
+ */
+
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+
+/**
+ * @param {Record<string, unknown>} packageJson
+ * @returns {Record<string, unknown>}
+ */
+export function ensureExpoBuildFromSource(packageJson) {
+  const next = { ...packageJson }
+  const expo = typeof next.expo === 'object' && next.expo != null ? { ...next.expo } : {}
+  const autolinking =
+    typeof expo.autolinking === 'object' && expo.autolinking != null ? { ...expo.autolinking } : {}
+  const android =
+    typeof autolinking.android === 'object' && autolinking.android != null
+      ? { ...autolinking.android }
+      : {}
+
+  // Prefer compiling RN/Expo Android modules from source on F-Droid builders.
+  android.buildFromSource = ['.*']
+  autolinking.android = android
+  expo.autolinking = autolinking
+  next.expo = expo
+  return next
+}
+
+/**
+ * @param {string} gradleText
+ */
+export function stripReleaseSigningConfig(gradleText) {
+  // F-Droid re-signs APKs; drop app signingConfig lines so assembleRelease does not
+  // require a private keystore (same pattern as other Expo apps in fdroiddata).
+  return gradleText
+    .split('\n')
+    .filter((line) => !/^\s*signingConfig\s+/.test(line))
+    .join('\n')
+}
+
+/**
+ * @param {{ mobileRoot?: string, skipExpoPrebuild?: boolean }} [options]
+ */
+export function prepareFdroidAndroidBuild(options = {}) {
+  const mobileRoot = path.resolve(
+    options.mobileRoot || process.env.MOBILE_ROOT || path.join(import.meta.dirname, '..')
+  )
+  const skipExpoPrebuild = options.skipExpoPrebuild ?? process.env.SKIP_EXPO_PREBUILD === '1'
+  const packageJsonPath = path.join(mobileRoot, 'package.json')
+  const androidAppGradlePath = path.join(mobileRoot, 'android', 'app', 'build.gradle')
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  const patchedPackageJson = ensureExpoBuildFromSource(packageJson)
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(patchedPackageJson, null, 2)}\n`)
+  console.log('Patched package.json expo.autolinking.android.buildFromSource')
+
+  if (!skipExpoPrebuild) {
+    execFileSync('npx', ['expo', 'prebuild', '--platform', 'android', '--no-install'], {
+      cwd: mobileRoot,
+      stdio: 'inherit',
+      env: process.env
+    })
+  }
+
+  if (fs.existsSync(androidAppGradlePath)) {
+    const original = fs.readFileSync(androidAppGradlePath, 'utf8')
+    const stripped = stripReleaseSigningConfig(original)
+    if (stripped !== original) {
+      fs.writeFileSync(androidAppGradlePath, stripped)
+      console.log('Removed signingConfig lines from android/app/build.gradle')
+    } else {
+      console.log('No signingConfig lines to strip in android/app/build.gradle')
+    }
+  } else if (!skipExpoPrebuild) {
+    throw new Error(`Expected ${androidAppGradlePath} after expo prebuild`)
+  }
+
+  console.log('F-Droid Android prep complete')
+}
+
+const isMain =
+  process.argv[1] != null && path.resolve(import.meta.filename) === path.resolve(process.argv[1])
+
+if (isMain) {
+  try {
+    prepareFdroidAndroidBuild()
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  }
+}

--- a/mobile/scripts/validate-fdroid-metadata.mjs
+++ b/mobile/scripts/validate-fdroid-metadata.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+/**
+ * Validate (or sync) repo-root F-Droid metadata against mobile/app.json.
+ *
+ * Usage:
+ *   node scripts/validate-fdroid-metadata.mjs
+ *   node scripts/validate-fdroid-metadata.mjs --write
+ */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import {
+  assertFdroidMetadataAligned,
+  parseFdroidMetadataVersionFields,
+  readMobileAndroidAppIdentity,
+  syncFdroidMetadataVersions
+} from './fdroid-app-identity.mjs'
+
+const mobileRoot = path.resolve(import.meta.dirname, '..')
+const repoRoot = path.resolve(mobileRoot, '..')
+
+const appConfigPath = process.env.MOBILE_APP_CONFIG_PATH || path.join(mobileRoot, 'app.json')
+const metadataPath =
+  process.env.FDROID_METADATA_PATH || path.join(repoRoot, 'metadata', 'com.stably.orca.mobile.yml')
+
+const write = process.argv.includes('--write')
+
+const appConfig = JSON.parse(fs.readFileSync(appConfigPath, 'utf8'))
+const identity = readMobileAndroidAppIdentity(appConfig)
+
+if (identity.packageId !== 'com.stably.orca.mobile') {
+  console.error(
+    `Unexpected Android package id ${JSON.stringify(identity.packageId)}; expected com.stably.orca.mobile`
+  )
+  process.exit(1)
+}
+
+const originalYaml = fs.readFileSync(metadataPath, 'utf8')
+const nextYaml = write ? syncFdroidMetadataVersions(originalYaml, identity) : originalYaml
+
+if (write && nextYaml !== originalYaml) {
+  fs.writeFileSync(metadataPath, nextYaml)
+  console.log(
+    `Updated ${path.relative(repoRoot, metadataPath)} to ${identity.versionName} (${identity.versionCode})`
+  )
+}
+
+const fields = parseFdroidMetadataVersionFields(nextYaml)
+assertFdroidMetadataAligned(identity, fields)
+
+console.log(
+  `F-Droid metadata OK: ${identity.packageId} ${identity.versionName} (${identity.versionCode})`
+)

--- a/mobile/src/mobile-release/fdroid-app-identity.test.ts
+++ b/mobile/src/mobile-release/fdroid-app-identity.test.ts
@@ -1,0 +1,244 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  assertFdroidMetadataAligned,
+  parseFdroidMetadataVersionFields,
+  readMobileAndroidAppIdentity,
+  syncFdroidMetadataVersions
+} from '../../scripts/fdroid-app-identity.mjs'
+import {
+  ensureExpoBuildFromSource,
+  stripReleaseSigningConfig
+} from '../../scripts/prepare-fdroid-android-build.mjs'
+
+const validateScriptPath = fileURLToPath(
+  new URL('../../scripts/validate-fdroid-metadata.mjs', import.meta.url)
+)
+const repoRoot = fileURLToPath(new URL('../../..', import.meta.url))
+const committedAppConfigPath = join(repoRoot, 'mobile', 'app.json')
+const committedMetadataPath = join(repoRoot, 'metadata', 'com.stably.orca.mobile.yml')
+
+let tempDirs: string[] = []
+
+function createTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-fdroid-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+const sampleMetadata = `Categories:
+  - Development
+License: MIT
+SourceCode: https://github.com/stablyai/orca
+Repo: https://github.com/stablyai/orca.git
+AutoName: Orca
+
+Builds:
+  - versionName: 0.0.22
+    versionCode: 4
+    commit: mobile-android-v0.0.22
+    subdir: mobile
+
+CurrentVersion: 0.0.22
+CurrentVersionCode: 4
+`
+
+describe('fdroid app identity helpers', () => {
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { force: true, recursive: true })
+    }
+    tempDirs = []
+  })
+
+  it('reads package id, marketing version, and versionCode from app config', () => {
+    const identity = readMobileAndroidAppIdentity({
+      expo: {
+        name: 'Orca',
+        version: '0.0.32',
+        android: {
+          package: 'com.stably.orca.mobile',
+          versionCode: 8
+        }
+      }
+    })
+
+    expect(identity).toEqual({
+      packageId: 'com.stably.orca.mobile',
+      versionName: '0.0.32',
+      versionCode: 8,
+      autoName: 'Orca'
+    })
+  })
+
+  it('rejects invalid versionCode values', () => {
+    expect(() =>
+      readMobileAndroidAppIdentity({
+        expo: {
+          version: '1.0.0',
+          android: { package: 'com.stably.orca.mobile', versionCode: 0 }
+        }
+      })
+    ).toThrow(/versionCode must be a positive integer/)
+  })
+
+  it('parses F-Droid metadata version fields and enforces alignment', () => {
+    const identity = readMobileAndroidAppIdentity({
+      expo: {
+        name: 'Orca',
+        version: '0.0.22',
+        android: { package: 'com.stably.orca.mobile', versionCode: 4 }
+      }
+    })
+    const fields = parseFdroidMetadataVersionFields(sampleMetadata)
+    expect(fields).toEqual({
+      versionName: '0.0.22',
+      versionCode: 4,
+      currentVersion: '0.0.22',
+      currentVersionCode: 4
+    })
+    expect(() => assertFdroidMetadataAligned(identity, fields)).not.toThrow()
+  })
+
+  it('syncs metadata version fields and release tag commit to a new app identity', () => {
+    const nextIdentity = readMobileAndroidAppIdentity({
+      expo: {
+        name: 'Orca',
+        version: '0.0.32',
+        android: { package: 'com.stably.orca.mobile', versionCode: 8 }
+      }
+    })
+
+    const synced = syncFdroidMetadataVersions(sampleMetadata, nextIdentity)
+    expect(synced).toContain('versionName: 0.0.32')
+    expect(synced).toContain('versionCode: 8')
+    expect(synced).toContain('commit: mobile-android-v0.0.32')
+    expect(synced).toContain('CurrentVersion: 0.0.32')
+    expect(synced).toContain('CurrentVersionCode: 8')
+    assertFdroidMetadataAligned(nextIdentity, parseFdroidMetadataVersionFields(synced))
+  })
+
+  it('aligns committed F-Droid metadata with committed mobile/app.json', () => {
+    const appConfig = JSON.parse(readFileSync(committedAppConfigPath, 'utf8'))
+    const metadataYaml = readFileSync(committedMetadataPath, 'utf8')
+    const identity = readMobileAndroidAppIdentity(appConfig)
+    const fields = parseFdroidMetadataVersionFields(metadataYaml)
+
+    expect(identity.packageId).toBe('com.stably.orca.mobile')
+    expect(metadataYaml).toMatch(/License:\s*MIT/)
+    expect(metadataYaml).toMatch(/SourceCode:\s*https:\/\/github\.com\/stablyai\/orca/)
+    expect(metadataYaml).toMatch(/Repo:\s*https:\/\/github\.com\/stablyai\/orca\.git/)
+    expect(metadataYaml).toContain('pnpm install')
+    expect(metadataYaml).toContain('prepare-fdroid-android-build.mjs')
+    expect(metadataYaml).toContain('assembleRelease')
+    expect(metadataYaml).toMatch(/scanignore:[\s\S]*hermesc/)
+    expect(metadataYaml).toMatch(/scandelete:[\s\S]*node_modules/)
+    assertFdroidMetadataAligned(identity, fields)
+  })
+
+  it('validate-fdroid-metadata.mjs exits 0 for the committed files', () => {
+    const output = execFileSync(process.execPath, [validateScriptPath], {
+      encoding: 'utf8',
+      env: { ...process.env }
+    })
+    expect(output).toContain('F-Droid metadata OK: com.stably.orca.mobile')
+  })
+
+  it('validate-fdroid-metadata.mjs --write rewrites stale metadata via shipped sync helper', () => {
+    const dir = createTempDir()
+    const appConfigPath = join(dir, 'app.json')
+    const metadataPath = join(dir, 'com.stably.orca.mobile.yml')
+
+    writeFileSync(
+      appConfigPath,
+      `${JSON.stringify(
+        {
+          expo: {
+            name: 'Orca',
+            version: '0.0.32',
+            android: { package: 'com.stably.orca.mobile', versionCode: 8 }
+          }
+        },
+        null,
+        2
+      )}\n`
+    )
+    writeFileSync(metadataPath, sampleMetadata)
+
+    const output = execFileSync(process.execPath, [validateScriptPath, '--write'], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        MOBILE_APP_CONFIG_PATH: appConfigPath,
+        FDROID_METADATA_PATH: metadataPath
+      }
+    })
+
+    expect(output).toContain('0.0.32 (8)')
+    const rewritten = readFileSync(metadataPath, 'utf8')
+    expect(rewritten).toContain('versionName: 0.0.32')
+    expect(rewritten).toContain('versionCode: 8')
+    expect(rewritten).toContain('commit: mobile-android-v0.0.32')
+  })
+
+  it('validate-fdroid-metadata.mjs fails when metadata lags app.json', () => {
+    const dir = createTempDir()
+    const appConfigPath = join(dir, 'app.json')
+    const metadataPath = join(dir, 'com.stably.orca.mobile.yml')
+
+    writeFileSync(
+      appConfigPath,
+      `${JSON.stringify(
+        {
+          expo: {
+            name: 'Orca',
+            version: '0.0.32',
+            android: { package: 'com.stably.orca.mobile', versionCode: 8 }
+          }
+        },
+        null,
+        2
+      )}\n`
+    )
+    writeFileSync(metadataPath, sampleMetadata)
+
+    const result = spawnSync(process.execPath, [validateScriptPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        MOBILE_APP_CONFIG_PATH: appConfigPath,
+        FDROID_METADATA_PATH: metadataPath
+      }
+    })
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('out of sync')
+  })
+})
+
+describe('prepare-fdroid-android-build helpers', () => {
+  it('enables expo autolinking buildFromSource for FOSS builders', () => {
+    const next = ensureExpoBuildFromSource({ name: 'orca-mobile', version: '0.0.1' })
+    expect(next.expo.autolinking.android.buildFromSource).toEqual(['.*'])
+  })
+
+  it('strips signingConfig lines so F-Droid can re-sign', () => {
+    const gradle = `
+android {
+    buildTypes {
+        release {
+            signingConfig signingConfigs.debug
+            minifyEnabled false
+        }
+    }
+}
+`
+    const stripped = stripReleaseSigningConfig(gradle)
+    expect(stripped).not.toMatch(/signingConfig/)
+    expect(stripped).toContain('minifyEnabled false')
+  })
+})

--- a/mobile/src/mobile-release/fdroid-app-identity.test.ts
+++ b/mobile/src/mobile-release/fdroid-app-identity.test.ts
@@ -133,11 +133,60 @@ describe('fdroid app identity helpers', () => {
     expect(metadataYaml).toMatch(/SourceCode:\s*https:\/\/github\.com\/stablyai\/orca/)
     expect(metadataYaml).toMatch(/Repo:\s*https:\/\/github\.com\/stablyai\/orca\.git/)
     expect(metadataYaml).toContain('pnpm install')
-    expect(metadataYaml).toContain('prepare-fdroid-android-build.mjs')
+    // Inlined FOSS prep so Builds.commit can pin the release tag (which may predate packaging helpers).
+    expect(metadataYaml).toContain('npx expo prebuild --platform android --no-install')
+    expect(metadataYaml).toMatch(/sed -i -e '\/signingConfig \/d'/)
+    expect(metadataYaml).toContain('buildFromSource')
     expect(metadataYaml).toContain('assembleRelease')
     expect(metadataYaml).toMatch(/scanignore:[\s\S]*hermesc/)
     expect(metadataYaml).toMatch(/scandelete:[\s\S]*node_modules/)
+    // Recipe executable prebuild steps must not invoke an in-tree packaging helper
+    // that is absent on the pinned release tag (mobile-android-v0.0.32).
+    const prebuildSteps =
+      metadataYaml.match(/prebuild:\n([\s\S]*?)(?:\n    build:|\n\nAutoUpdateMode:)/)?.[1] ?? ''
+    expect(prebuildSteps).not.toMatch(/^\s+-\s+node\s+scripts\//m)
     assertFdroidMetadataAligned(identity, fields)
+  })
+
+  it('pinned Builds.commit is a real git rev that has mobile sources without needing packaging helpers', () => {
+    const metadataYaml = readFileSync(committedMetadataPath, 'utf8')
+    const commitMatch = metadataYaml.match(/^\s+commit:\s*(\S+)\s*$/m)
+    expect(commitMatch?.[1]).toBeTruthy()
+    const commit = commitMatch![1]
+
+    // Resolve the pinned rev (tag or SHA) and confirm mobile app identity files exist there.
+    const resolved = execFileSync('git', ['rev-parse', '--verify', `${commit}^{commit}`], {
+      encoding: 'utf8',
+      cwd: repoRoot
+    }).trim()
+    expect(resolved).toMatch(/^[0-9a-f]{40}$/)
+
+    const appJsonAtCommit = execFileSync('git', ['show', `${commit}:mobile/app.json`], {
+      encoding: 'utf8',
+      cwd: repoRoot
+    })
+    const identityAtCommit = readMobileAndroidAppIdentity(JSON.parse(appJsonAtCommit))
+    expect(identityAtCommit.packageId).toBe('com.stably.orca.mobile')
+    expect(identityAtCommit.versionName).toBe(
+      parseFdroidMetadataVersionFields(metadataYaml).versionName
+    )
+    expect(identityAtCommit.versionCode).toBe(
+      parseFdroidMetadataVersionFields(metadataYaml).versionCode
+    )
+
+    // Packaging helper is optional for the recipe (inlined prebuild); if the recipe ever
+    // reintroduces a tree-path script, that path must exist on the pinned commit.
+    const prebuildBlock =
+      metadataYaml.match(/prebuild:\n([\s\S]*?)(?:\n    build:|\n\nAutoUpdateMode:)/)?.[1] ?? ''
+    const scriptRefs = [...prebuildBlock.matchAll(/\b(?:node|bash|sh)\s+(scripts\/\S+)/g)].map(
+      (match) => match[1]
+    )
+    for (const scriptPath of scriptRefs) {
+      const result = spawnSync('git', ['cat-file', '-e', `${commit}:mobile/${scriptPath}`], {
+        cwd: repoRoot
+      })
+      expect(result.status, `missing ${scriptPath} on commit ${commit}`).toBe(0)
+    }
   })
 
   it('validate-fdroid-metadata.mjs exits 0 for the committed files', () => {


### PR DESCRIPTION
## Summary
- Add F-Droid app metadata at `metadata/com.stably.orca.mobile.yml` for package id `com.stably.orca.mobile` (MIT, source/repo URLs, Development category, AutoName, Builds recipe for marketing version / versionCode from `mobile/app.json`).
- Document a FOSS-from-source Android path that mirrors production CI: Node/JDK setup → `pnpm install` → Expo prebuild (via `mobile/scripts/prepare-fdroid-android-build.mjs`) → `gradle assembleRelease`, with Hermes scanignore / `node_modules` scandelete and release signingConfig stripped for F-Droid re-signing (no Play Store signing secrets).
- Add pure version/package alignment helpers + validate/sync CLI and Vitest coverage; README mobile blurb mentions in-repo F-Droid **prep** without claiming the app is already on f-droid.org.

## Follow-up (out of scope)
- Open an MR against [fdroiddata](https://gitlab.com/fdroid/fdroiddata) using this metadata once maintainers are ready.
- Rolling `android-latest` GitHub Release remains the primary ask of #7583 and is **not** implemented here.

## Test plan
- [x] `cd mobile && pnpm exec vitest run src/mobile-release/fdroid-app-identity.test.ts`
- [x] `node mobile/scripts/validate-fdroid-metadata.mjs` reports OK for 0.0.32 / versionCode 8
- [x] Metadata recipe stages match `.github/workflows/mobile-android-release.yml` (pnpm install → expo prebuild → assembleRelease)
- [ ] Full APK assemble on F-Droid builders / local JDK 17+ (local env only had JDK 14; recipe targets JDK 17)

Refs #7583