### PR TITLE
fix(floating-workspace): route tab shortcuts to focused floating panel

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -2352,6 +2352,176 @@ describe('createMainWindow', () => {
     expect(webContents.send).toHaveBeenCalledWith('ui:openNewWorkspace')
   })
 
+  it('skips jumpToWorktreeIndex and jumpToTabIndex when floating terminal input is focused', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const setFocusedListener = vi
+      .mocked(ipcMain.on)
+      .mock.calls.find(([channel]) => channel === 'ui:setFloatingTerminalInputFocused')?.[1]
+    expect(setFocusedListener).toBeTypeOf('function')
+    setFocusedListener?.({ sender: webContents } as never, true)
+
+    const isDarwin = process.platform === 'darwin'
+
+    const preventDefault1 = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault: preventDefault1 } as never,
+      {
+        type: 'keyDown',
+        code: 'Digit1',
+        key: '1',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: false
+      } as never
+    )
+    expect(preventDefault1).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:jumpToWorktreeIndex', expect.anything())
+
+    const preventDefault2 = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault: preventDefault2 } as never,
+      isDarwin
+        ? ({
+            type: 'keyDown',
+            code: 'Digit1',
+            key: '1',
+            meta: false,
+            control: true,
+            alt: false,
+            shift: false
+          } as never)
+        : ({
+            type: 'keyDown',
+            code: 'Digit1',
+            key: '1',
+            meta: false,
+            control: false,
+            alt: true,
+            shift: false
+          } as never)
+    )
+    expect(preventDefault2).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:jumpToTabIndex', expect.anything())
+  })
+
+  it('skips jumpToWorktreeIndex and jumpToTabIndex when floating panel chrome is focused', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const setPanelFocusedListener = vi
+      .mocked(ipcMain.on)
+      .mock.calls.find(([channel]) => channel === 'ui:setFloatingPanelFocused')?.[1]
+    expect(setPanelFocusedListener).toBeTypeOf('function')
+    setPanelFocusedListener?.({ sender: webContents } as never, true)
+
+    const isDarwin = process.platform === 'darwin'
+
+    const preventDefault1 = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault: preventDefault1 } as never,
+      {
+        type: 'keyDown',
+        code: 'Digit1',
+        key: '1',
+        meta: isDarwin,
+        control: !isDarwin,
+        alt: false,
+        shift: false
+      } as never
+    )
+    expect(preventDefault1).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:jumpToWorktreeIndex', expect.anything())
+
+    const preventDefault2 = vi.fn()
+    windowHandlers['before-input-event'](
+      { preventDefault: preventDefault2 } as never,
+      isDarwin
+        ? ({
+            type: 'keyDown',
+            code: 'Digit1',
+            key: '1',
+            meta: false,
+            control: true,
+            alt: false,
+            shift: false
+          } as never)
+        : ({
+            type: 'keyDown',
+            code: 'Digit1',
+            key: '1',
+            meta: false,
+            control: false,
+            alt: true,
+            shift: false
+          } as never)
+    )
+    expect(preventDefault2).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:jumpToTabIndex', expect.anything())
+  })
+
   it('still intercepts Cmd+Shift+B and Cmd+Alt+B when the markdown editor is focused', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -468,6 +468,8 @@ export function createMainWindow(
   let markdownEditorFocused = false
   let terminalInputFocused = false
   let floatingTerminalInputFocused = false
+  // Why: panel chrome (tab bar) can hold focus without xterm; digit shortcuts still need to skip main interception.
+  let floatingPanelFocused = false
   let shortcutRecorderFocused = false
 
   const markdownFocusChannel = 'ui:setMarkdownEditorFocused'
@@ -497,6 +499,14 @@ export function createMainWindow(
     floatingTerminalInputFocused = focused === true
   }
   ipcMain.on(floatingTerminalInputFocusChannel, onFloatingTerminalInputFocused)
+  const floatingPanelFocusChannel = 'ui:setFloatingPanelFocused'
+  const onFloatingPanelFocused = (event: Electron.IpcMainEvent, focused: unknown): void => {
+    if (event.sender !== mainWindow.webContents) {
+      return
+    }
+    floatingPanelFocused = focused === true
+  }
+  ipcMain.on(floatingPanelFocusChannel, onFloatingPanelFocused)
   const shortcutRecorderFocusChannel = 'ui:setShortcutRecorderFocused'
   // Why: the Settings recorder must receive app shortcuts to rebind them; before-input-event would otherwise consume the key first.
   const onShortcutRecorderFocused = (event: Electron.IpcMainEvent, focused: unknown): void => {
@@ -526,6 +536,9 @@ export function createMainWindow(
   }
   const resetFloatingTerminalInputFocus = (): void => {
     floatingTerminalInputFocused = false
+  }
+  const resetFloatingPanelFocus = (): void => {
+    floatingPanelFocused = false
   }
   const resetShortcutRecorderFocus = (): void => {
     shortcutRecorderFocused = false
@@ -586,6 +599,7 @@ export function createMainWindow(
     resetMarkdownEditorFocus()
     resetTerminalInputFocus()
     resetFloatingTerminalInputFocus()
+    resetFloatingPanelFocus()
     resetShortcutRecorderFocus()
     // Why: macOS reports BrowserWindow teardown as renderer killed/SIGKILL after close — window noise, not a crash.
     if (!windowClosing) {
@@ -601,6 +615,7 @@ export function createMainWindow(
     resetMarkdownEditorFocus()
     resetTerminalInputFocus()
     resetFloatingTerminalInputFocus()
+    resetFloatingPanelFocus()
     resetShortcutRecorderFocus()
   })
   mainWindow.webContents.on('did-start-navigation', (_e, _url, _isInPlace, isMainFrame) => {
@@ -608,6 +623,7 @@ export function createMainWindow(
       resetMarkdownEditorFocus()
       resetTerminalInputFocus()
       resetFloatingTerminalInputFocus()
+      resetFloatingPanelFocus()
       resetShortcutRecorderFocus()
     }
   })
@@ -691,6 +707,13 @@ export function createMainWindow(
     if (
       floatingTerminalInputFocused &&
       (action.type === 'toggleLeftSidebar' || action.type === 'toggleRightSidebar')
+    ) {
+      return false
+    }
+    // Why: leave digit jumps for the floating panel's capture handler; main IPC would switch the workspace behind it.
+    if (
+      (floatingTerminalInputFocused || floatingPanelFocused) &&
+      (action.type === 'jumpToWorktreeIndex' || action.type === 'jumpToTabIndex')
     ) {
       return false
     }
@@ -1070,6 +1093,7 @@ export function createMainWindow(
     markdownEditorFocused = false
     terminalInputFocused = false
     floatingTerminalInputFocused = false
+    floatingPanelFocused = false
     shortcutRecorderFocused = false
     clearRendererRecoveryTimer()
     ipcMain.removeListener(trafficLightChannel, onSyncTrafficLights)
@@ -1084,6 +1108,7 @@ export function createMainWindow(
     ipcMain.removeListener(markdownFocusChannel, onMarkdownEditorFocused)
     ipcMain.removeListener(terminalInputFocusChannel, onTerminalInputFocused)
     ipcMain.removeListener(floatingTerminalInputFocusChannel, onFloatingTerminalInputFocused)
+    ipcMain.removeListener(floatingPanelFocusChannel, onFloatingPanelFocused)
     ipcMain.removeListener(shortcutRecorderFocusChannel, onShortcutRecorderFocused)
     // Why: powerMonitor is app-global; without this the resume relay leaks and fires against a destroyed webContents.
     powerMonitor.removeListener('resume', onSystemResume)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3037,6 +3037,7 @@ export type PreloadApi = {
     setMarkdownEditorFocused: (focused: boolean) => void
     setTerminalInputFocused: (focused: boolean) => void
     setFloatingTerminalInputFocused: (focused: boolean) => void
+    setFloatingPanelFocused: (focused: boolean) => void
     setShortcutRecorderFocused: (focused: boolean) => void
     onRichMarkdownContextCommand: (
       callback: (payload: RichMarkdownContextMenuCommandPayload) => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3825,6 +3825,9 @@ const api = {
     setFloatingTerminalInputFocused: (focused: boolean): void => {
       ipcRenderer.send('ui:setFloatingTerminalInputFocused', focused)
     },
+    setFloatingPanelFocused: (focused: boolean): void => {
+      ipcRenderer.send('ui:setFloatingPanelFocused', focused)
+    },
     setShortcutRecorderFocused: (focused: boolean): void => {
       ipcRenderer.send('ui:setShortcutRecorderFocused', focused)
     },

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -114,6 +114,7 @@ const mocks = vi.hoisted(() => ({
   pickFloatingMarkdownDocument: vi.fn(),
   pinFile: vi.fn(),
   setFloatingTerminalInputFocused: vi.fn(),
+  setFloatingPanelFocused: vi.fn(),
   setActiveTab: vi.fn(),
   setRenamingTabId: vi.fn(),
   setTabColor: vi.fn(),
@@ -769,7 +770,10 @@ describe('FloatingTerminalPanel close behavior', () => {
         },
         browser: { notifyActiveTabChanged: vi.fn() },
         cli: { getInstallStatus: mocks.getInstallStatus },
-        ui: { setFloatingTerminalInputFocused: mocks.setFloatingTerminalInputFocused }
+        ui: {
+          setFloatingTerminalInputFocused: mocks.setFloatingTerminalInputFocused,
+          setFloatingPanelFocused: mocks.setFloatingPanelFocused
+        }
       },
       innerHeight: 800,
       innerWidth: 1200,

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -35,6 +35,7 @@ import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
 import {
   isFloatingWorkspacePanelShortcut,
   isFloatingWorkspaceTerminalInputTarget,
+  shouldDeferFloatingWorkspaceTabCloseToPane,
   switchFloatingWorkspaceTab
 } from '@/lib/floating-workspace-terminal-actions'
 import { extractIpcErrorMessage } from '@/lib/ipc-error'
@@ -156,6 +157,14 @@ function setFloatingTerminalInputFocusedInMain(focused: boolean): void {
     return
   }
   setInputFocused(focused)
+}
+
+function setFloatingPanelFocusedInMain(focused: boolean): void {
+  const setPanelFocused = window.api.ui.setFloatingPanelFocused
+  if (typeof setPanelFocused !== 'function') {
+    return
+  }
+  setPanelFocused(focused)
 }
 
 export function FloatingTerminalPanel({
@@ -1024,6 +1033,18 @@ export function FloatingTerminalPanel({
         return true
       }
       if (matches('tab.close')) {
+        // Why: split terminals close one pane via TerminalPane; closing the whole tab here would skip that path.
+        if (
+          shouldDeferFloatingWorkspaceTabCloseToPane({
+            contentType: activeClosableTab?.contentType,
+            isFloatingTerminalInput,
+            layoutRootType: activeClosableTab
+              ? state.terminalLayoutsByTabId?.[activeClosableTab.entityId]?.root?.type
+              : null
+          })
+        ) {
+          return false
+        }
         consume()
         if (activeClosableTab) {
           closeFloatingItem(activeClosableTab.id)
@@ -1040,6 +1061,23 @@ export function FloatingTerminalPanel({
       if (matchesFloatingChrome('tab.rename') && activeTab) {
         consume()
         state.setRenamingTabId(activeTab.id)
+        return true
+      }
+      // Why: main process usually owns workspace.selectByIndex as sidebar jumps; remap while this panel has focus.
+      const worktreeIndex = matchKeybindingDigitIndex(
+        'workspace.selectByIndex',
+        input,
+        platform,
+        state.keybindings,
+        floatingChromeMatchOptions
+      )
+      if (worktreeIndex !== null) {
+        const visibleId = visibleFloatingTabOrder[worktreeIndex]
+        if (!visibleId) {
+          return false
+        }
+        consume()
+        activateFloatingItem(visibleId)
         return true
       }
       const selectedTabIndex = matchKeybindingDigitIndex(
@@ -1123,6 +1161,13 @@ export function FloatingTerminalPanel({
           state.keybindings,
           floatingChromeMatchOptions
         ) ||
+        matchKeybindingDigitIndex(
+          'workspace.selectByIndex',
+          nativeEvent,
+          platform,
+          state.keybindings,
+          floatingChromeMatchOptions
+        ) !== null ||
         matchKeybindingDigitIndex(
           'tab.selectByIndex',
           nativeEvent,
@@ -1297,8 +1342,12 @@ export function FloatingTerminalPanel({
   useEffect(() => {
     if (!open) {
       setFloatingTerminalInputFocusedInMain(false)
+      setFloatingPanelFocusedInMain(false)
     }
-    return () => setFloatingTerminalInputFocusedInMain(false)
+    return () => {
+      setFloatingTerminalInputFocusedInMain(false)
+      setFloatingPanelFocusedInMain(false)
+    }
   }, [open])
 
   useEffect(() => {
@@ -1312,6 +1361,7 @@ export function FloatingTerminalPanel({
         return
       }
       setFloatingTerminalInputFocusedInMain(false)
+      setFloatingPanelFocusedInMain(false)
       const active = document.activeElement
       if (active instanceof HTMLElement && panel.contains(active)) {
         // Why: regular tab strip items are non-focusable, so clicking them can
@@ -1329,6 +1379,7 @@ export function FloatingTerminalPanel({
       // Why: browser webviews focus out-of-process and do not emit renderer
       // pointerdown events, so release floating ownership on renderer blur too.
       setFloatingTerminalInputFocusedInMain(false)
+      setFloatingPanelFocusedInMain(false)
       if (isFloatingWorkspaceTerminalInputTarget(active)) {
         // Why: the terminal focus lifecycle preserves this exact helper across
         // app blur so macOS can rebuild its native input context on return.
@@ -1479,12 +1530,23 @@ export function FloatingTerminalPanel({
         const rect = event.currentTarget.getBoundingClientRect()
         commitUserBounds({ ...stagedBoundsRef.current, width: rect.width, height: rect.height })
       }}
-      onFocusCapture={(event) => setFloatingTerminalInputFocused(event.target)}
+      onFocusCapture={(event) => {
+        setFloatingTerminalInputFocused(event.target)
+        setFloatingPanelFocusedInMain(true)
+      }}
       onBlurCapture={(event) => {
         // Why: keep terminal-first shortcut ownership latched during the
         // synchronous macOS IME refresh blur; refocus or its skip callback settles it.
         if (!isTerminalImeInputContextRefreshing(event.target)) {
           setFloatingTerminalInputFocused(event.relatedTarget)
+        }
+        const panel = panelRef.current
+        if (
+          !event.relatedTarget ||
+          !(event.relatedTarget instanceof Node) ||
+          !panel?.contains(event.relatedTarget)
+        ) {
+          setFloatingPanelFocusedInMain(false)
         }
       }}
       onKeyDownCapture={handleShortcutSurfaceKeyDown}

--- a/src/renderer/src/lib/floating-workspace-shortcut-policy.ts
+++ b/src/renderer/src/lib/floating-workspace-shortcut-policy.ts
@@ -56,3 +56,16 @@ export function isFloatingWorkspacePanelShortcut(
     keybindingMatchesAction(actionId, event, platform, keybindings, options)
   )
 }
+
+/** When true, Cmd/Ctrl+W must reach the pane handler instead of closing the whole floating tab. */
+export function shouldDeferFloatingWorkspaceTabCloseToPane(options: {
+  contentType: string | null | undefined
+  isFloatingTerminalInput: boolean
+  layoutRootType: string | null | undefined
+}): boolean {
+  return (
+    options.contentType === 'terminal' &&
+    options.isFloatingTerminalInput &&
+    options.layoutRootType === 'split'
+  )
+}

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.test.ts
@@ -12,6 +12,7 @@ import {
   isFloatingWorkspacePanelShortcutTarget,
   isFloatingWorkspaceTerminalInputTarget,
   isFloatingWorkspacePanelVisible,
+  shouldDeferFloatingWorkspaceTabCloseToPane,
   shouldMinimizeFloatingWorkspacePanelOnCloseShortcut,
   switchFloatingWorkspaceTab
 } from './floating-workspace-terminal-actions'
@@ -328,6 +329,39 @@ describe('isFloatingWorkspacePanelShortcut', () => {
         false,
         panelRoot
       )
+    ).toBe(false)
+  })
+})
+
+describe('shouldDeferFloatingWorkspaceTabCloseToPane', () => {
+  it('defers close only for split terminal tabs while floating xterm owns focus', () => {
+    expect(
+      shouldDeferFloatingWorkspaceTabCloseToPane({
+        contentType: 'terminal',
+        isFloatingTerminalInput: true,
+        layoutRootType: 'split'
+      })
+    ).toBe(true)
+    expect(
+      shouldDeferFloatingWorkspaceTabCloseToPane({
+        contentType: 'terminal',
+        isFloatingTerminalInput: true,
+        layoutRootType: 'leaf'
+      })
+    ).toBe(false)
+    expect(
+      shouldDeferFloatingWorkspaceTabCloseToPane({
+        contentType: 'terminal',
+        isFloatingTerminalInput: false,
+        layoutRootType: 'split'
+      })
+    ).toBe(false)
+    expect(
+      shouldDeferFloatingWorkspaceTabCloseToPane({
+        contentType: 'browser',
+        isFloatingTerminalInput: true,
+        layoutRootType: 'split'
+      })
     ).toBe(false)
   })
 })

--- a/src/renderer/src/lib/floating-workspace-terminal-actions.ts
+++ b/src/renderer/src/lib/floating-workspace-terminal-actions.ts
@@ -18,7 +18,8 @@ export {
 } from './floating-workspace-tab-creation'
 export {
   isFloatingWorkspacePanelShortcut,
-  isFloatingWorkspacePanelShortcutTarget
+  isFloatingWorkspacePanelShortcutTarget,
+  shouldDeferFloatingWorkspaceTabCloseToPane
 } from './floating-workspace-shortcut-policy'
 
 type FloatingWorkspaceTabSwitchMode = 'same-type' | 'all-types' | 'terminal'

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2569,6 +2569,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     setMarkdownEditorFocused: () => {},
     setTerminalInputFocused: () => {},
     setFloatingTerminalInputFocused: () => {},
+    setFloatingPanelFocused: () => {},
     setShortcutRecorderFocused: () => {},
     onRichMarkdownContextCommand: () => noopUnsubscribe,
     onFullscreenChanged: () => noopUnsubscribe,


### PR DESCRIPTION
## Summary

- When the floating workspace is focused, Cmd/Ctrl+1–9 (and related digit chords) no longer switch tabs/workspaces in the **main** window behind the panel; they switch within the floating panel instead.
- Cmd/Ctrl+W on a split floating terminal closes only the focused pane (not the whole tab).
- Closes #10288

## Root cause

1. **Digit jumps**: Main-process `before-input-event` always dispatched `jumpToWorktreeIndex` / `jumpToTabIndex` and `preventDefault`’d the key, so the floating panel’s capture handler never saw it. `floatingTerminalInputFocused` only skipped sidebar toggles and only tracked xterm focus—not tab-bar/chrome focus.
2. **Pane close**: Floating panel’s `tab.close` handler always called `closeFloatingItem()` (whole tab) with `stopImmediatePropagation`, so the split-pane close path never ran.

## Fix

- Add `ui:setFloatingPanelFocused` IPC so main knows when *any* floating panel focus exists (chrome or terminal).
- Skip main interception of indexed jumps when floating terminal input **or** floating panel is focused.
- Remap `workspace.selectByIndex` in the floating panel capture handler to activate floating tabs.
- Defer `tab.close` to the terminal pane handler when the active floating terminal layout is a split.

## Test plan

- [x] Unit: main skips `jumpToWorktreeIndex` / `jumpToTabIndex` when floating terminal input is focused
- [x] Unit: main skips the same when only floating panel chrome is focused
- [x] Unit: `shouldDeferFloatingWorkspaceTabCloseToPane` only true for split terminal + terminal input
- [x] Existing `FloatingTerminalPanel` / `createMainWindow` suites pass
- [x] `pnpm typecheck` passes
- [ ] Manual: open floating workspace, 2+ tabs, focus panel → Cmd/Ctrl+1/2 switches **floating** tabs only
- [ ] Manual: Cmd/Ctrl+D split in floating → Cmd/Ctrl+W closes focused pane only; last pane closes tab

## Platform notes

Cross-platform: uses existing keybinding matchers (Cmd on macOS, Ctrl/Alt elsewhere). No platform-specific branching beyond existing shortcut tables.