### PR TITLE
fix(github): resolve owner/repo through SSH Host aliases

### DIFF
--- a/src/main/github/github-owner-repo-ssh-alias.ts
+++ b/src/main/github/github-owner-repo-ssh-alias.ts
@@ -1,0 +1,54 @@
+import type { GitHubOwnerRepo } from '../../shared/types'
+import { loadUserSshConfig } from '../ssh/ssh-config-parser'
+import { resolveWithSshG } from '../ssh/ssh-g-config-resolution'
+import {
+  hostnameFromSshConfigHosts,
+  parseGitHubOwnerRepo,
+  parseGitHubOwnerRepoWithResolvedHostname,
+  parseGitHubRemoteIdentity
+} from './github-remote-identity-parsing'
+
+// Why: skip ssh -G for already-qualified hostnames (GHES / public forges) —
+// they are not Host aliases and spawning ssh on every miss is pure cost.
+function isLikelyLiteralHost(host: string): boolean {
+  return host.includes('.')
+}
+
+async function resolveSshAliasHostname(alias: string): Promise<string | null> {
+  // Why: ~/.ssh/config Host → HostName covers the common multi-account alias
+  // case without spawning ssh; fall back to `ssh -G` for Include/Match.
+  const fromConfig = hostnameFromSshConfigHosts(alias, loadUserSshConfig())
+  if (fromConfig) {
+    return fromConfig
+  }
+  if (isLikelyLiteralHost(alias)) {
+    return null
+  }
+  const resolved = await resolveWithSshG(alias)
+  const hostname = resolved?.hostname?.trim()
+  return hostname ? hostname : null
+}
+
+/**
+ * Resolve github.com owner/repo, expanding SSH config Host aliases when the
+ * remote host token is not literally github.com (#10284).
+ */
+export async function resolveGitHubOwnerRepoFromRemoteUrl(
+  remoteUrl: string
+): Promise<GitHubOwnerRepo | null> {
+  const direct = parseGitHubOwnerRepo(remoteUrl)
+  if (direct) {
+    return direct
+  }
+  const identity = parseGitHubRemoteIdentity(remoteUrl)
+  if (!identity) {
+    return null
+  }
+  // Why: SSH config Host aliases (git@github-work:org/repo) keep a non-github
+  // host token in remote.origin.url; expand HostName before classifying.
+  const resolvedHostname = await resolveSshAliasHostname(identity.host)
+  if (!resolvedHostname) {
+    return null
+  }
+  return parseGitHubOwnerRepoWithResolvedHostname(remoteUrl, resolvedHostname)
+}

--- a/src/main/github/github-remote-identity-parsing.test.ts
+++ b/src/main/github/github-remote-identity-parsing.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { parseGitHubOwnerRepo, parseGitHubRemoteIdentity } from './github-remote-identity-parsing'
+import {
+  hostnameFromSshConfigHosts,
+  parseGitHubOwnerRepo,
+  parseGitHubOwnerRepoWithResolvedHostname,
+  parseGitHubRemoteIdentity
+} from './github-remote-identity-parsing'
 
 describe('parseGitHubRemoteIdentity', () => {
   it('parses a plain github.com https remote', () => {
@@ -105,5 +110,46 @@ describe('parseGitHubOwnerRepo', () => {
       owner: 'team',
       repo: 'orca'
     })
+  })
+
+  // Why: #10284 — multi-account SSH Host aliases keep a non-github.com token in remote.url.
+  it('returns null for an SSH Host alias without HostName expansion', () => {
+    expect(parseGitHubOwnerRepo('git@github-work:team/orca.git')).toBeNull()
+    expect(parseGitHubOwnerRepo('ssh://git@github-work/team/orca.git')).toBeNull()
+  })
+})
+
+describe('parseGitHubOwnerRepoWithResolvedHostname (#10284)', () => {
+  it('accepts SCP remotes once HostName expands to github.com', () => {
+    expect(
+      parseGitHubOwnerRepoWithResolvedHostname('git@github-work:team/orca.git', 'ssh.github.com')
+    ).toEqual({ owner: 'team', repo: 'orca' })
+  })
+
+  it('accepts ssh:// remotes once HostName expands to github.com', () => {
+    expect(
+      parseGitHubOwnerRepoWithResolvedHostname(
+        'ssh://git@github.com-work/team/orca.git',
+        'github.com'
+      )
+    ).toEqual({ owner: 'team', repo: 'orca' })
+  })
+
+  it('still rejects when HostName is not github.com', () => {
+    expect(
+      parseGitHubOwnerRepoWithResolvedHostname('git@lab-work:team/orca.git', 'gitlab.com')
+    ).toBeNull()
+  })
+
+  it('maps Host alias → HostName from parsed SSH config hosts', () => {
+    expect(
+      hostnameFromSshConfigHosts('github-work', [
+        { host: 'github-work', hostname: 'ssh.github.com' },
+        { host: 'other', hostname: 'example.com' }
+      ])
+    ).toBe('ssh.github.com')
+    expect(
+      hostnameFromSshConfigHosts('missing', [{ host: 'github-work', hostname: 'github.com' }])
+    ).toBeNull()
   })
 })

--- a/src/main/github/github-remote-identity-parsing.ts
+++ b/src/main/github/github-remote-identity-parsing.ts
@@ -2,10 +2,14 @@ import type { GitHubOwnerRepo } from '../../shared/types'
 
 export type GitHubRemoteIdentity = GitHubOwnerRepo & { host: string }
 
-function normalizeGitHubRemoteHost(host: string): string {
+export function normalizeGitHubRemoteHost(host: string): string {
   const normalizedHost = host.toLowerCase()
   // Why: GitHub documents ssh.github.com as SSH-over-HTTPS for github.com repos.
   return normalizedHost === 'ssh.github.com' ? 'github.com' : normalizedHost
+}
+
+export function isGitHubDotComHost(host: string): boolean {
+  return normalizeGitHubRemoteHost(host) === 'github.com'
 }
 
 // Why: HTTP ports identify the GHES web/API endpoint; SSH and git ports are
@@ -49,7 +53,39 @@ export function parseGitHubRemoteIdentity(remoteUrl: string): GitHubRemoteIdenti
 
 export function parseGitHubOwnerRepo(remoteUrl: string): GitHubOwnerRepo | null {
   const identity = parseGitHubRemoteIdentity(remoteUrl)
-  if (!identity || identity.host.toLowerCase() !== 'github.com') {
+  if (!identity || !isGitHubDotComHost(identity.host)) {
+    return null
+  }
+  return { owner: identity.owner, repo: identity.repo }
+}
+
+/** Pure helper: map an SSH config Host alias to HostName when present. */
+export function hostnameFromSshConfigHosts(
+  alias: string,
+  hosts: readonly { host: string; hostname?: string }[]
+): string | null {
+  const entry = hosts.find((host) => host.host === alias)
+  const hostname = entry?.hostname?.trim()
+  return hostname ? hostname : null
+}
+
+/**
+ * When the remote host token is an SSH config Host alias (e.g. github-work →
+ * ssh.github.com), re-check github.com after the alias is expanded.
+ */
+export function parseGitHubOwnerRepoWithResolvedHostname(
+  remoteUrl: string,
+  resolvedHostname: string
+): GitHubOwnerRepo | null {
+  const direct = parseGitHubOwnerRepo(remoteUrl)
+  if (direct) {
+    return direct
+  }
+  const identity = parseGitHubRemoteIdentity(remoteUrl)
+  if (!identity || isGitHubDotComHost(identity.host)) {
+    return null
+  }
+  if (!isGitHubDotComHost(resolvedHostname)) {
     return null
   }
   return { owner: identity.owner, repo: identity.repo }

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -7,6 +7,7 @@ import {
   parseGitHubRemoteIdentity,
   type GitHubRemoteIdentity
 } from './github-remote-identity-parsing'
+import { resolveGitHubOwnerRepoFromRemoteUrl } from './github-owner-repo-ssh-alias'
 import { isStableMissingGitRemoteError } from './stable-missing-git-remote-error'
 import { githubRepoIdentityKey } from '../../shared/github-repository-identity-key'
 
@@ -177,7 +178,13 @@ async function resolveOwnerRepoForRemote(
   const now = Date.now()
   try {
     const remoteUrl = await getRemoteUrlForRepo(context, remoteName)
-    const result = remoteUrl ? parseGitHubOwnerRepo(remoteUrl) : null
+    // Why: do not expand SSH aliases over SSH-provider remotes — host is already
+    // the remote machine, not the user's local OpenSSH config.
+    const result = remoteUrl
+      ? context.connectionId
+        ? parseGitHubOwnerRepo(remoteUrl)
+        : await resolveGitHubOwnerRepoFromRemoteUrl(remoteUrl)
+      : null
     if (result) {
       ownerRepoCache.set(cacheKey, {
         value: result,


### PR DESCRIPTION
## Summary

- After a literal `github.com` host parse misses, expand SSH config **Host → HostName** (then `ssh -G` when needed) so multi-account remotes like `git@github-work:owner/repo` resolve to github.com.
- Wire the expansion into `getOwnerRepoForRemote` (local host only — SSH-provider remotes stay on the literal parser).
- Leave the remote URL unchanged for Git transport so the correct `IdentityFile` still applies.

Fixes #10284.

## Why

`parseGitHubOwnerRepo` rejects any host that is not literally `github.com`. SSH config Host aliases are common for multiple GitHub accounts; HostName is already `github.com` / `ssh.github.com`, but Orca never expanded it, so Squash and merge failed with “Could not resolve GitHub owner/repo for this repository” even though the PR UI worked.

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/github/github-remote-identity-parsing.test.ts` (19)
- [ ] Manual: `git@github-work:OWNER/REPO` remote + Squash and merge succeeds when HostName maps to github.com

## Screenshots

No visual change.