### PR TITLE
fix(editor): preserve PDF zoom and scroll across tab hide/show

### DIFF
--- a/src/renderer/src/components/editor/PdfViewer.tsx
+++ b/src/renderer/src/components/editor/PdfViewer.tsx
@@ -28,6 +28,7 @@ import {
   clampPdfViewPosition,
   createPdfViewPositionRecorder
 } from './pdf-view-position'
+import { getPdfViewSession, setPdfViewSession } from './pdf-view-session-state'
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = workerUrl
 
@@ -64,8 +65,11 @@ export default function PdfViewer({
   const findControllerRef = useRef<InstanceType<typeof PDFFindController> | null>(null)
   const pdfViewerRef = useRef<InstanceType<typeof PdfJsViewer> | null>(null)
   // Why: content reloads rebuild the pdf.js viewer; keep zoom across updates of
-  // the same file, and only reset when the open path changes.
-  const scalePreferenceRef = useRef<PdfScalePreference>('page-width')
+  // the same file, and only reset when the open path changes. Session state also
+  // survives tab hide/show unmounts (#10352).
+  const scalePreferenceRef = useRef<PdfScalePreference>(
+    getPdfViewSession(filePath)?.scalePreference ?? 'page-width'
+  )
 
   const filename = useMemo(() => filePath.split(/[/\\]/).pop() || filePath, [filePath])
   const cleanedContent = useMemo(() => content.replace(/\s/g, ''), [content])
@@ -74,10 +78,11 @@ export default function PdfViewer({
   // reset out of render (refs mutated in render can leak from discarded renders)
   // and covers same-content/different-path opens the load effect skips.
   useEffect(() => {
-    scalePreferenceRef.current = 'page-width'
+    const session = getPdfViewSession(filePath)
+    scalePreferenceRef.current = session?.scalePreference ?? 'page-width'
     const viewer = pdfViewerRef.current
     if (viewer) {
-      applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
+      applyPdfScalePreference(viewer, scalePreferenceRef.current, SCALE_BOUNDS)
     }
   }, [filePath])
 
@@ -128,6 +133,12 @@ export default function PdfViewer({
     const handleScaleChanging = (evt: { scale: number }): void => {
       if (!cancelled) {
         setScale(evt.scale)
+        // Why: toolbar/keyboard zoom updates absolute scale; keep session in sync
+        // for tab remount even when preference was page-width before.
+        if (scalePreferenceRef.current !== 'page-width') {
+          scalePreferenceRef.current = evt.scale
+        }
+        setPdfViewSession(filePath, { scalePreference: scalePreferenceRef.current })
       }
     }
     eventBus.on('scalechanging', handleScaleChanging)
@@ -253,6 +264,8 @@ export default function PdfViewer({
         viewer.setDocument(doc)
         linkService.setDocument(doc)
         findController.setDocument(doc)
+        // Why: apply the stored scale after pdf.js has a document; the position
+        // recorder handles scroll restoration from the pagesinit/pagesloaded events.
         applyPdfScalePreference(viewer, scalePreferenceRef.current, SCALE_BOUNDS)
       })
       .catch((err) => {
@@ -296,7 +309,7 @@ export default function PdfViewer({
     // Why: scrollCacheKey is a dependency because two distinct paths can hold
     // identical bytes — without it this effect would not re-run on the switch,
     // and the second file would restore to the first file's position.
-  }, [cleanedContent, scrollCacheKey])
+  }, [cleanedContent, filePath, scrollCacheKey])
 
   const closeFindBar = useCallback(() => {
     const eventBus = eventBusRef.current
@@ -308,15 +321,19 @@ export default function PdfViewer({
 
   // Why: every zoom entry point (toolbar + keyboard) must record the scale
   // preference so the next content reload restores it (see scalePreferenceRef).
-  const stepZoom = useCallback((direction: 'in' | 'out') => {
-    const viewer = pdfViewerRef.current
-    if (!viewer) {
-      return
-    }
-    const next = stepPdfScalePreference(viewer.currentScale, direction, SCALE_BOUNDS)
-    viewer.currentScale = next.scale
-    scalePreferenceRef.current = next.preference
-  }, [])
+  const stepZoom = useCallback(
+    (direction: 'in' | 'out') => {
+      const viewer = pdfViewerRef.current
+      if (!viewer) {
+        return
+      }
+      const next = stepPdfScalePreference(viewer.currentScale, direction, SCALE_BOUNDS)
+      viewer.currentScale = next.scale
+      scalePreferenceRef.current = next.preference
+      setPdfViewSession(filePath, { scalePreference: next.preference })
+    },
+    [filePath]
+  )
 
   const zoomIn = useCallback(() => stepZoom('in'), [stepZoom])
   const zoomOut = useCallback(() => stepZoom('out'), [stepZoom])
@@ -328,7 +345,8 @@ export default function PdfViewer({
     }
     scalePreferenceRef.current = 'page-width'
     applyPdfScalePreference(viewer, 'page-width', SCALE_BOUNDS)
-  }, [])
+    setPdfViewSession(filePath, { scalePreference: 'page-width' })
+  }, [filePath])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {

--- a/src/renderer/src/components/editor/pdf-view-session-state.test.ts
+++ b/src/renderer/src/components/editor/pdf-view-session-state.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  _resetPdfViewSessionStateForTest,
+  getPdfViewSession,
+  setPdfViewSession
+} from './pdf-view-session-state'
+
+describe('pdf-view-session-state', () => {
+  beforeEach(() => {
+    _resetPdfViewSessionStateForTest()
+  })
+
+  it('stores and restores the scale preference for a file path', () => {
+    setPdfViewSession('/repo/doc.pdf', { scalePreference: 2 })
+    expect(getPdfViewSession('/repo/doc.pdf')).toEqual({ scalePreference: 2 })
+  })
+
+  it('merges partial updates without losing the existing scale preference', () => {
+    setPdfViewSession('/repo/doc.pdf', { scalePreference: 1.5 })
+    setPdfViewSession('/repo/doc.pdf', {})
+    expect(getPdfViewSession('/repo/doc.pdf')).toEqual({ scalePreference: 1.5 })
+  })
+
+  it('keeps separate session state per file path', () => {
+    setPdfViewSession('/a.pdf', { scalePreference: 2 })
+    setPdfViewSession('/b.pdf', { scalePreference: 'page-width' })
+    expect(getPdfViewSession('/a.pdf')?.scalePreference).toBe(2)
+    expect(getPdfViewSession('/b.pdf')?.scalePreference).toBe('page-width')
+  })
+})

--- a/src/renderer/src/components/editor/pdf-view-session-state.ts
+++ b/src/renderer/src/components/editor/pdf-view-session-state.ts
@@ -1,0 +1,37 @@
+import type { PdfScalePreference } from './pdf-scale-preference'
+
+export type PdfViewSessionState = {
+  scalePreference: PdfScalePreference
+}
+
+// Why: tab hide/show unmounts PdfViewer; keep its zoom preference for the open
+// path in this app session. PDF scroll is stored separately in pdf.js user space
+// by the shared position cache, so it remains correct across zoom and pane width.
+const sessionByPath = new Map<string, PdfViewSessionState>()
+
+export function getPdfViewSession(filePath: string): PdfViewSessionState | undefined {
+  if (!filePath) {
+    return undefined
+  }
+  return sessionByPath.get(filePath)
+}
+
+export function setPdfViewSession(
+  filePath: string,
+  next: Partial<PdfViewSessionState>
+): PdfViewSessionState | undefined {
+  if (!filePath) {
+    return undefined
+  }
+  const previous = sessionByPath.get(filePath)
+  const merged: PdfViewSessionState = {
+    scalePreference: next.scalePreference ?? previous?.scalePreference ?? 'page-width'
+  }
+  sessionByPath.set(filePath, merged)
+  return merged
+}
+
+/** @internal tests only */
+export function _resetPdfViewSessionStateForTest(): void {
+  sessionByPath.clear()
+}


### PR DESCRIPTION
## Summary

- Preserve a PDF file's zoom preference for the lifetime of the Orca app session.
- Restore that preference when switching away from and back to a PDF tab, including viewer remounts.
- Keep the scale-independent PDF scroll restoration already present on main; this PR supplies the remaining zoom half of the original report.

Follow-up to #10352. PDF scroll restoration is covered by #12163; this change keeps the two pieces independent so zoom changes cannot overwrite the cached PDF position.

## Why

PdfViewer is rebuilt when an editor tab is hidden and shown again. The existing in-component preference survives content reloads while the viewer remains mounted, but it cannot survive that unmount. A small in-memory, per-file session map carries only the zoom preference across the remount; no disk or schema changes are introduced.

## Scope and design

- The session state is keyed by file path and lives only in the current app process.
- Numeric zoom preferences are reapplied after pdf.js receives the document.
- Fit-to-width remains the default for files without a session preference.
- The scale-independent position cache on main remains the source of truth for PDF scroll, avoiding duplicate pixel-offset state.

## Test plan

- [x] PDF session-state unit tests
- [x] Existing PDF scale-preference tests
- [x] Existing PDF position-cache tests
- [x] Typecheck
- [x] Oxlint, React Doctor lint, Oxfmt, and diff checks
- [ ] Manual: open a PDF, zoom, switch tabs, and verify the same zoom on return

## Screenshots

No visual chrome changes.

## Security audit

No new network, filesystem, or persistent-storage behavior. The preference is held in an in-memory map and is scoped to the current app session.

## Platform review

The change uses the existing React and pdf.js lifecycle and does not add platform-specific behavior. It was reviewed for macOS, Linux, and Windows viewer lifecycles.

## ELI5

Leaving a PDF tab and coming back no longer forgets the zoom level. Scroll position continues to use the scale-independent PDF position cache already on main.
