### PR TITLE
fix(terminal): prune explicitly-killed SSH tabs on create

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -32,6 +32,7 @@ import {
 import { createPtyInputWriteQueue } from './pty-input-write-queue'
 import type { PtyDataMeta } from './pty-dispatcher'
 import type { IpcPtyTransportOptions, PtyConnectResult, PtyTransport } from './pty-transport-types'
+import { markTerminalSessionRetired } from '@/store/slices/terminal-retired-session-ids'
 import { createBellDetector } from '../../../../shared/terminal-bell-detector'
 import {
   hasTerminalDisplayContent,
@@ -810,6 +811,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
         }
         // Why: re-spawning a Kill-All'd session throws TerminalKilledError; swallow it (pane still shows "Process exited"), don't toast (src/main/daemon/daemon-pty-adapter.ts).
         if (msg.includes('was explicitly killed')) {
+          // Why: mark the dead session so orphan tab cleanup can drop the tab on
+          // the next createTab instead of reviving it from a stale ptyId (#10342).
+          markTerminalSessionRetired(options.sessionId)
           return undefined
         }
         // Why: on cold start the SSH provider isn't registered yet, so pty:spawn throws a raw IPC error; replace with a friendly message.

--- a/src/renderer/src/store/slices/terminal-orphan-helpers.test.ts
+++ b/src/renderer/src/store/slices/terminal-orphan-helpers.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { TerminalTab } from '../../../../shared/types'
 import { getOrphanTerminalIds } from './terminal-orphan-helpers'
 import { buildTerminalTabRetirementPlan } from './terminal-tab-retirement'
+import {
+  _resetTerminalRetiredSessionIdsForTest,
+  markTerminalSessionRetired
+} from './terminal-retired-session-ids'
 
 // Regression coverage for #9911 ("Terminal window auto-closing. Unable to
 // recover."). After hydration / SSH-relay disconnect the tab row's ptyId and
@@ -111,5 +115,34 @@ describe('getOrphanTerminalIds reconnect-map liveness', () => {
     })
 
     expect(getOrphanTerminalIds(state, 'wt-1')).toContain('stale-layout')
+  })
+
+  // #10342: killed serve-* sessions leave tab.ptyId set; without retirement
+  // marking they look reconnectable and survive every createTab orphan sweep.
+  it('orphans a tab whose only ptyId is an explicitly retired killed session', () => {
+    _resetTerminalRetiredSessionIdsForTest()
+    markTerminalSessionRetired('serve-dead-uuid')
+    const state = makeState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'phantom', ptyId: 'serve-dead-uuid' })]
+      },
+      ptyIdsByTabId: { phantom: [] },
+      unifiedTabsByWorktree: { 'wt-1': [] }
+    })
+
+    expect(getOrphanTerminalIds(state, 'wt-1')).toContain('phantom')
+  })
+
+  it('does not orphan a tab whose ptyId is a non-retired wake hint', () => {
+    _resetTerminalRetiredSessionIdsForTest()
+    const state = makeState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'sleeping', ptyId: 'serve-alive-uuid' })]
+      },
+      ptyIdsByTabId: { sleeping: [] },
+      unifiedTabsByWorktree: { 'wt-1': [] }
+    })
+
+    expect(getOrphanTerminalIds(state, 'wt-1')).not.toContain('sleeping')
   })
 })

--- a/src/renderer/src/store/slices/terminal-orphan-helpers.ts
+++ b/src/renderer/src/store/slices/terminal-orphan-helpers.ts
@@ -1,4 +1,5 @@
 import type { AppState } from '../types'
+import { isTerminalSessionRetired } from './terminal-retired-session-ids'
 
 type TerminalTabReconnectState = Pick<
   AppState,
@@ -25,13 +26,27 @@ export function terminalTabHasReconnectablePty(
   tabId: string,
   rowPtyId: string | null | undefined
 ): boolean {
-  return Boolean(
-    (state.ptyIdsByTabId[tabId]?.length ?? 0) > 0 ||
-    rowPtyId ||
-    state.lastKnownRelayPtyIdByTabId[tabId] ||
-    state.deferredSshSessionIdsByTabId[tabId] ||
-    state.pendingReconnectPtyIdByTabId[tabId]
-  )
+  if ((state.ptyIdsByTabId[tabId]?.length ?? 0) > 0) {
+    return true
+  }
+  const deferred = state.deferredSshSessionIdsByTabId[tabId]
+  if (deferred && !isTerminalSessionRetired(deferred)) {
+    return true
+  }
+  const pending = state.pendingReconnectPtyIdByTabId[tabId]
+  if (pending && !isTerminalSessionRetired(pending)) {
+    return true
+  }
+  const lastKnown = state.lastKnownRelayPtyIdByTabId[tabId]
+  if (lastKnown && !isTerminalSessionRetired(lastKnown)) {
+    return true
+  }
+  // Why: tab.ptyId is a sleep/reattach wake hint, but an explicitly-killed
+  // serve-* session must not keep the tab off the orphan sweep (#10342).
+  if (rowPtyId && !isTerminalSessionRetired(rowPtyId)) {
+    return true
+  }
+  return false
 }
 
 type OrphanTerminalCleanupState = Pick<

--- a/src/renderer/src/store/slices/terminal-orphan-helpers.ts
+++ b/src/renderer/src/store/slices/terminal-orphan-helpers.ts
@@ -26,7 +26,9 @@ export function terminalTabHasReconnectablePty(
   tabId: string,
   rowPtyId: string | null | undefined
 ): boolean {
-  if ((state.ptyIdsByTabId[tabId]?.length ?? 0) > 0) {
+  // Why: cold reattach can leave a retired serve-* id in ptyIdsByTabId before spawn;
+  // only a non-retired live map entry should keep the tab off the orphan sweep.
+  if ((state.ptyIdsByTabId[tabId] ?? []).some((id) => !isTerminalSessionRetired(id))) {
     return true
   }
   const deferred = state.deferredSshSessionIdsByTabId[tabId]

--- a/src/renderer/src/store/slices/terminal-retired-session-ids.test.ts
+++ b/src/renderer/src/store/slices/terminal-retired-session-ids.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  _resetTerminalRetiredSessionIdsForTest,
+  isTerminalSessionRetired,
+  markTerminalSessionRetired,
+  markTerminalSessionsRetired
+} from './terminal-retired-session-ids'
+
+describe('terminal-retired-session-ids', () => {
+  beforeEach(() => {
+    _resetTerminalRetiredSessionIdsForTest()
+  })
+
+  it('marks a session as retired so it cannot reconnect', () => {
+    expect(isTerminalSessionRetired('serve-dead')).toBe(false)
+    markTerminalSessionRetired('serve-dead')
+    expect(isTerminalSessionRetired('serve-dead')).toBe(true)
+  })
+
+  it('ignores empty session ids', () => {
+    markTerminalSessionRetired(null)
+    markTerminalSessionRetired(undefined)
+    markTerminalSessionRetired('')
+    expect(isTerminalSessionRetired('')).toBe(false)
+  })
+
+  it('marks multiple session ids', () => {
+    markTerminalSessionsRetired(['a', 'b'])
+    expect(isTerminalSessionRetired('a')).toBe(true)
+    expect(isTerminalSessionRetired('b')).toBe(true)
+  })
+})

--- a/src/renderer/src/store/slices/terminal-retired-session-ids.ts
+++ b/src/renderer/src/store/slices/terminal-retired-session-ids.ts
@@ -1,0 +1,30 @@
+// Why: SSH/daemon "Session was explicitly killed" leaves tabs whose ptyId still
+// points at a dead serve-* id. Orphan cleanup previously required ptyId==null,
+// so those phantoms survived createTab and remote session rehydration (#10342).
+
+const retiredSessionIds = new Set<string>()
+
+export function markTerminalSessionRetired(sessionId: string | null | undefined): void {
+  if (!sessionId) {
+    return
+  }
+  retiredSessionIds.add(sessionId)
+}
+
+export function isTerminalSessionRetired(sessionId: string | null | undefined): boolean {
+  if (!sessionId) {
+    return false
+  }
+  return retiredSessionIds.has(sessionId)
+}
+
+export function markTerminalSessionsRetired(sessionIds: readonly string[]): void {
+  for (const sessionId of sessionIds) {
+    markTerminalSessionRetired(sessionId)
+  }
+}
+
+/** @internal tests only */
+export function _resetTerminalRetiredSessionIdsForTest(): void {
+  retiredSessionIds.clear()
+}

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -54,6 +54,7 @@ import { pushClosedTerminalTabSnapshot, pushRecentlyClosedTabKind } from './rece
 import { isClaudeAgent } from '@/lib/agent-status'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import { buildOrphanTerminalCleanupPatch, getOrphanTerminalIds } from './terminal-orphan-helpers'
+import { markTerminalSessionsRetired } from './terminal-retired-session-ids'
 import {
   dedupeTabOrder,
   ensureGroup,
@@ -1162,6 +1163,18 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ? opts.precomputedRetirementPlan
         : buildTerminalTabRetirementPlan(get(), tabId)
     let closingWorktreeId: string | null = null
+
+    // Why: durable close for dead SSH/daemon sessions — mark every session id
+    // this tab owned so createTab orphan sweep and rehydration cannot revive it (#10342).
+    if (retiresSession) {
+      const retiredIds = [
+        ...retirementPlan.localOrSshPtyIds,
+        ...retirementPlan.runtimeTerminals.map((terminal) => terminal.ptyId),
+        ...retirementPlan.cleanupOnlyPtyIds,
+        get().lastKnownRelayPtyIdByTabId[tabId]
+      ].filter((id): id is string => Boolean(id))
+      markTerminalSessionsRetired(retiredIds)
+    }
 
     // Why: a parked tab has no mounted TerminalPane cleanup, so revoke its observer/candidate state before provider exit races.
     retireParkedTerminalTab(tabId)


### PR DESCRIPTION
## Summary

- Mark PTY/session ids as **retired** when spawn fails with `TerminalKilledError` or when the user closes a tab (cleanup/user).
- Treat retired ids as **non-reconnectable** in orphan detection so `createTab` permanently sweeps dead `serve-*` tabs that still have a stale `ptyId`.
- Keeps sleep/reattach wake hints working for non-retired sessions.

Fixes #10342.

## Why

Phantom SSH tabs showed `Session "serve-…" was explicitly killed` and reappeared after close when a new terminal was opened. Orphan cleanup treated any non-null `tab.ptyId` as reconnectable, so killed sessions never got swept.

## Test plan

- [x] `terminal-orphan-helpers` + `terminal-retired-session-ids` + `pty-transport` (91 tests)
- [ ] Manual: kill remote serve session → open new terminal → dead tabs pruned; close dead tab → create terminal → stay gone

## Screenshots

No visual chrome change.

## ELI5

Closed or killed SSH terminal tabs sometimes came back as phantoms when you opened a new terminal. Explicitly killed sessions are marked retired so create permanently cleans them up.
