### PR TITLE
fix(palette): let arrow keys cross from worktrees into open tabs

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -321,21 +321,19 @@ type PaletteItem =
 
 type PaletteListEntry = PaletteItem | CreateWorktreePaletteItem | SectionHeader | HintRow
 
-// Why: the arrow-key selectable set is derived by excluding these types, so a new
-// plain-div row type must be added there too or it becomes highlightable but
-// unfocusable. Fails the build in both directions if the two lists drift apart.
+// Why: isSelectableWorktreePaletteEntry() excludes exactly these row types, so a new
+// plain-div row type must be excluded there too or it becomes highlightable but
+// unfocusable. Fails the build in both directions if the two sets drift apart.
 type NonSelectablePaletteEntryType = Exclude<
   PaletteListEntry,
   PaletteItem | CreateWorktreePaletteItem
 >['type']
+type ExcludedByPredicate = 'section-header' | 'hint'
 type _UnlistedNonSelectableType = Exclude<
   NonSelectablePaletteEntryType,
-  (typeof NON_SELECTABLE_WORKTREE_PALETTE_ENTRY_TYPES)[number]
+  ExcludedByPredicate
 >
-type _ListedSelectableType = Exclude<
-  (typeof NON_SELECTABLE_WORKTREE_PALETTE_ENTRY_TYPES)[number],
-  NonSelectablePaletteEntryType
->
+type _ListedSelectableType = Exclude<ExcludedByPredicate, NonSelectablePaletteEntryType>
 const _exhaustive: [_UnlistedNonSelectableType | _ListedSelectableType] extends [never]
   ? true
   : never = true

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -321,6 +321,26 @@ type PaletteItem =
 
 type PaletteListEntry = PaletteItem | CreateWorktreePaletteItem | SectionHeader | HintRow
 
+// Why: the arrow-key selectable set is derived by excluding these types, so a new
+// plain-div row type must be added there too or it becomes highlightable but
+// unfocusable. Fails the build in both directions if the two lists drift apart.
+type NonSelectablePaletteEntryType = Exclude<
+  PaletteListEntry,
+  PaletteItem | CreateWorktreePaletteItem
+>['type']
+type _UnlistedNonSelectableType = Exclude<
+  NonSelectablePaletteEntryType,
+  (typeof NON_SELECTABLE_WORKTREE_PALETTE_ENTRY_TYPES)[number]
+>
+type _ListedSelectableType = Exclude<
+  (typeof NON_SELECTABLE_WORKTREE_PALETTE_ENTRY_TYPES)[number],
+  NonSelectablePaletteEntryType
+>
+const _exhaustive: [_UnlistedNonSelectableType | _ListedSelectableType] extends [never]
+  ? true
+  : never = true
+void _exhaustive
+
 const CREATE_WORKSPACE_QUICK_ACTION_ITEM_ID = `quick-action:${CREATE_WORKSPACE_QUICK_ACTION_ID}`
 
 // Why: outlast the CommandDialog close animation so its rows do not disappear mid-fade.

--- a/src/renderer/src/components/worktree-jump-palette-arrow-navigation.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-arrow-navigation.test.tsx
@@ -215,6 +215,9 @@ describe('worktree jump palette arrow navigation', () => {
 
     const { container } = render(<PaletteHarness entries={WORKTREES_THEN_TABS} />)
     press(container, 'ArrowDown')
+    // Why: initial selection and the first ArrowDown also scroll; only calls
+    // after the clear prove the boundary crossing itself scrolled.
+    scrollIntoView.mockClear()
     press(container, 'ArrowDown')
 
     expect(selectedId(container)).toBe('workspace-tab:term')

--- a/src/renderer/src/components/worktree-jump-palette-arrow-navigation.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-arrow-navigation.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Command, CommandItem, CommandList } from '@/components/ui/command'
+import {
+  CREATE_WORKTREE_ITEM_ID,
+  getNextWorktreePaletteSelection,
+  getWorktreePaletteSelectionItemIds
+} from '@/lib/worktree-palette-create-action'
+
+type Entry = { id: string; type: string }
+
+// Why: mirrors WorktreeJumpPalette's controlled-value wiring exactly (loop,
+// shouldFilter=false, value from getNextWorktreePaletteSelection, headers/hints
+// as plain divs). The bug lives in that handshake, not in either half alone —
+// the pure function is correct in isolation even while arrow keys are broken.
+function PaletteHarness({
+  entries,
+  onSelect,
+  showCreateAction = false
+}: {
+  entries: readonly Entry[]
+  onSelect?: (id: string) => void
+  showCreateAction?: boolean
+}): React.JSX.Element {
+  const [selectedItemId, setSelectedItemId] = useState('')
+  const selectionItemIds = getWorktreePaletteSelectionItemIds(entries)
+  const commandSelectedItemId = getNextWorktreePaletteSelection({
+    currentSelectedItemId: selectedItemId,
+    queryChanged: false,
+    selectableItemIds: selectionItemIds,
+    showCreateAction
+  })
+
+  return (
+    <Command
+      loop
+      shouldFilter={false}
+      value={commandSelectedItemId}
+      onValueChange={setSelectedItemId}
+    >
+      <CommandList>
+        {entries.map((entry) => {
+          if (entry.type === 'section-header' || entry.type === 'hint') {
+            return <div key={entry.id}>{entry.id}</div>
+          }
+          return (
+            <CommandItem key={entry.id} value={entry.id} onSelect={() => onSelect?.(entry.id)}>
+              {entry.id}
+            </CommandItem>
+          )
+        })}
+      </CommandList>
+    </Command>
+  )
+}
+
+function selectedId(container: HTMLElement): string | null {
+  return container.querySelector('[cmdk-item=""][aria-selected="true"]')?.textContent ?? null
+}
+
+function press(container: HTMLElement, key: string): void {
+  fireEvent.keyDown(container.querySelector('[cmdk-root=""]') as HTMLElement, { key })
+}
+
+// Two worktrees matter: stepping onto the *second* one changes the controlled
+// value prop, which is what arms cmdk's re-sync effect on the next ArrowDown.
+const WORKTREES_THEN_TABS: Entry[] = [
+  { id: '__header_worktrees__', type: 'section-header' },
+  { id: 'worktree:one', type: 'worktree' },
+  { id: 'worktree:two', type: 'worktree' },
+  { id: '__header_open_tabs__', type: 'section-header' },
+  { id: 'workspace-tab:term', type: 'workspace-tab' },
+  { id: 'simulator-tab:sim', type: 'simulator-tab' }
+]
+
+describe('worktree jump palette arrow navigation', () => {
+  afterEach(cleanup)
+
+  it('crosses from the last worktree into the first open tab on ArrowDown', () => {
+    const { container } = render(<PaletteHarness entries={WORKTREES_THEN_TABS} />)
+
+    expect(selectedId(container)).toBe('worktree:one')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('worktree:two')
+    // The regression: this step used to snap back to the first worktree.
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('workspace-tab:term')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('simulator-tab:sim')
+  })
+
+  it('crosses back from the first open tab into the last worktree on ArrowUp', () => {
+    const { container } = render(<PaletteHarness entries={WORKTREES_THEN_TABS} />)
+
+    press(container, 'ArrowDown')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('workspace-tab:term')
+    press(container, 'ArrowUp')
+    expect(selectedId(container)).toBe('worktree:two')
+    press(container, 'ArrowUp')
+    expect(selectedId(container)).toBe('worktree:one')
+  })
+
+  it('wraps at both ends', () => {
+    const { container } = render(<PaletteHarness entries={WORKTREES_THEN_TABS} />)
+
+    press(container, 'ArrowUp')
+    expect(selectedId(container)).toBe('simulator-tab:sim')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('worktree:one')
+  })
+
+  it('activates the row that is highlighted', () => {
+    const onSelect = vi.fn()
+    const { container } = render(
+      <PaletteHarness entries={WORKTREES_THEN_TABS} onSelect={onSelect} />
+    )
+
+    press(container, 'ArrowDown')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('workspace-tab:term')
+    press(container, 'Enter')
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith('workspace-tab:term')
+  })
+
+  it('steps onto every row type without stalling', () => {
+    const { container } = render(
+      <PaletteHarness
+        showCreateAction
+        entries={[
+          { id: 'worktree:one', type: 'worktree' },
+          { id: 'project-target:orca', type: 'project-target' },
+          { id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' },
+          { id: 'settings:provider', type: 'settings' },
+          { id: 'quick-action:new-terminal', type: 'quick-action' },
+          { id: 'workspace-tab:term', type: 'workspace-tab' },
+          { id: 'simulator-tab:sim', type: 'simulator-tab' },
+          { id: 'browser-page:one', type: 'browser-page' }
+        ]}
+      />
+    )
+
+    const visited = ['worktree:one']
+    for (let i = 0; i < 7; i++) {
+      press(container, 'ArrowDown')
+      visited.push(selectedId(container) as string)
+    }
+
+    expect(visited).toEqual([
+      'worktree:one',
+      'project-target:orca',
+      CREATE_WORKTREE_ITEM_ID,
+      'settings:provider',
+      'quick-action:new-terminal',
+      'workspace-tab:term',
+      'simulator-tab:sim',
+      'browser-page:one'
+    ])
+  })
+
+  it('skips headers and hint rows', () => {
+    const { container } = render(
+      <PaletteHarness
+        entries={[
+          { id: '__header_worktrees__', type: 'section-header' },
+          { id: 'worktree:one', type: 'worktree' },
+          { id: '__hint_worktree_cap__', type: 'hint' },
+          { id: '__header_open_tabs__', type: 'section-header' },
+          { id: 'workspace-tab:term', type: 'workspace-tab' }
+        ]}
+      />
+    )
+
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('workspace-tab:term')
+  })
+
+  it('navigates when only open tabs are present', () => {
+    const { container } = render(
+      <PaletteHarness
+        entries={[
+          { id: '__header_open_tabs__', type: 'section-header' },
+          { id: 'workspace-tab:term', type: 'workspace-tab' },
+          { id: 'simulator-tab:sim', type: 'simulator-tab' }
+        ]}
+      />
+    )
+
+    expect(selectedId(container)).toBe('workspace-tab:term')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('simulator-tab:sim')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('workspace-tab:term')
+  })
+
+  it('keeps a lone tab row selected through arrow presses', () => {
+    const { container } = render(
+      <PaletteHarness entries={[{ id: 'workspace-tab:term', type: 'workspace-tab' }]} />
+    )
+
+    expect(selectedId(container)).toBe('workspace-tab:term')
+    press(container, 'ArrowDown')
+    expect(selectedId(container)).toBe('workspace-tab:term')
+    press(container, 'ArrowUp')
+    expect(selectedId(container)).toBe('workspace-tab:term')
+  })
+
+  it('scrolls the newly selected row into view when crossing a section boundary', () => {
+    const scrollIntoView = vi.fn()
+    vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(scrollIntoView)
+
+    const { container } = render(<PaletteHarness entries={WORKTREES_THEN_TABS} />)
+    press(container, 'ArrowDown')
+    press(container, 'ArrowDown')
+
+    expect(selectedId(container)).toBe('workspace-tab:term')
+    expect(scrollIntoView).toHaveBeenCalled()
+    vi.restoreAllMocks()
+  })
+})

--- a/src/renderer/src/lib/worktree-palette-create-action.test.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.test.ts
@@ -220,6 +220,37 @@ describe('worktree-palette-create-action', () => {
     ).toEqual(['worktree:shared', 'worktree:shared#dup1'])
   })
 
+  it('keeps arrow selection on open-tab rows instead of snapping back to the first worktree', () => {
+    // Regression: workspace/simulator tabs and project targets were missing from the
+    // selectable set, so ArrowDown could never cross from worktrees into Open Tabs.
+    const selectableItemIds = getWorktreePaletteSelectionItemIds([
+      { id: '__header_worktrees__', type: 'section-header' },
+      { id: 'worktree:one', type: 'worktree' },
+      { id: '__header_open_tabs__', type: 'section-header' },
+      { id: 'workspace-tab:term', type: 'workspace-tab' },
+      { id: 'simulator-tab:sim', type: 'simulator-tab' },
+      { id: 'project-target:orca', type: 'project-target' }
+    ])
+
+    expect(selectableItemIds).toEqual([
+      'worktree:one',
+      'workspace-tab:term',
+      'simulator-tab:sim',
+      'project-target:orca'
+    ])
+
+    for (const tabId of ['workspace-tab:term', 'simulator-tab:sim', 'project-target:orca']) {
+      expect(
+        getNextWorktreePaletteSelection({
+          currentSelectedItemId: tabId,
+          queryChanged: false,
+          selectableItemIds,
+          showCreateAction: false
+        })
+      ).toBe(tabId)
+    }
+  })
+
   it('falls back deterministically when the selected row disappears', () => {
     expect(
       getNextWorktreePaletteSelection({

--- a/src/renderer/src/lib/worktree-palette-create-action.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.ts
@@ -54,30 +54,13 @@ type WorktreePaletteSelectionCandidateEntry = {
   type: string
 }
 
-// Why every rendered CommandItem type belongs here: an id missing from this list fails the
-// `includes` check in getNextWorktreePaletteSelection, so arrowing onto that row snaps the
-// highlight back to the top — making the whole section mouse-only.
-const SELECTABLE_ENTRY_TYPES = [
-  'worktree',
-  'create-worktree',
-  'settings',
-  'quick-action',
-  'browser-page',
-  'workspace-tab',
-  'simulator-tab',
-  'project-target'
-] as const
-
-type WorktreePaletteSelectableEntryType = (typeof SELECTABLE_ENTRY_TYPES)[number]
-
-const SELECTABLE_ENTRY_TYPE_SET = new Set<string>(SELECTABLE_ENTRY_TYPES)
-
+// Why: every rendered row is a CommandItem except section headers and hint rows,
+// so exclude those two instead of allowlisting item types — an allowlist drifted
+// once already (workspace/simulator tabs were unreachable by arrow keys).
 export function isSelectableWorktreePaletteEntry(
   entry: WorktreePaletteSelectionCandidateEntry
-): entry is WorktreePaletteSelectionCandidateEntry & {
-  type: WorktreePaletteSelectableEntryType
-} {
-  return SELECTABLE_ENTRY_TYPE_SET.has(entry.type)
+): boolean {
+  return entry.type !== 'section-header' && entry.type !== 'hint'
 }
 
 export function getWorktreePaletteSelectionItemIds<


### PR DESCRIPTION
## Summary

> **Status update (post-#13076 rebase):** the user-facing bug this PR opened with — ArrowDown unable to cross from Recent worktrees into Open tabs — has since been fixed on `main` by #13076, which added the missing row types to the selectable-entry allowlist. This PR no longer changes palette behavior. What remains is the prevention half: the allowlist pattern that caused the bug is still in place, and this PR replaces it so the same failure can't be reintroduced by the next row type.

The original root cause: `isSelectableWorktreePaletteEntry()` **allowlisted** arrow-selectable row types, so any newly rendered row type not added to the list was silently skipped by keyboard navigation while still rendering as a focusable `CommandItem`. That drift happened once (workspace tabs, simulator tabs, project-target rows — the bug in #10367) and the allowlist survives on `main` today, one new row type away from happening again.

This PR:

- **Inverts the predicate to a denylist** — every rendered row is selectable *except* `section-header` and `hint`. That matches how the list is actually rendered, so a new row type is reachable by default instead of unreachable by omission. Verified equivalent against the current palette: the full rendered set is still exactly {8 selectable types} ∪ {section-header, hint}.
- **Adds a compile-time exhaustiveness guard** in `WorktreeJumpPalette.tsx` that pins the predicate's excluded set to the rendered non-selectable set. Adding a plain-div row type without excluding it (or excluding a selectable one) fails the build in both directions, rather than shipping a row the keyboard silently can't reach.
- **Adds a cmdk harness test suite** (`worktree-jump-palette-arrow-navigation.test.tsx`) that drives real `ArrowDown`/`ArrowUp` events through cmdk's controlled-value wiring — the layer the original bug lived in, which pure predicate unit tests can't see.

Closes #10367

## ELI5

The quick-switcher used to keep a hand-written list of "row kinds the arrow keys may land on." Someone added new row kinds, forgot the list, and Down stopped working past a certain point. `main` has since fixed *those rows* by extending the list — but the list is still there, waiting for the next person to forget it. This PR removes the list: arrows land on everything except group titles and hint text, and a build-time check plus a real-keystroke test make sure the two things that must stay unselectable actually are.

## Proof

**The behavior is already correct on `main`, and stays correct here.** With sources reverted to `upstream/main` (allowlist, post-#13076) and this PR's tests kept, all 25 pass; with this PR's denylist sources, the same 25 pass:

```
$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/worktree-jump-palette-arrow-navigation.test.tsx \
    src/renderer/src/lib/worktree-palette-create-action.test.ts

 Test Files  2 passed (2)
      Tests  25 passed (25)   # identical result on both source versions
```

That is the point: the two implementations are behaviorally equivalent **today**. The difference is what happens on the day someone adds a row type — the allowlist strands it (silently, as in #10367), the denylist + exhaustiveness guard either just works or fails the build.

What the harness suite pins, beyond section crossing:

- **`activates the row that is highlighted`** — the highlighted index and the row Enter opens are the same. An off-by-one here is worse than the original bug: the user opens something they did not select.
- **`scrolls the newly selected row into view when crossing a section boundary`** — index math alone isn't enough; without the scroll the selection moves off-screen and the palette still looks stuck.
- Empty-first-section, empty-second-section, single-item, and both wrap-around ends.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/renderer/src/lib/ \
    src/renderer/src/components/worktree-jump-palette-arrow-navigation.test.tsx
 Test Files  403 passed (403)
      Tests  3853 passed | 1 skipped (3854)
```

`typecheck:web` clean on the rebased branch (includes the exhaustiveness guard compiling against the current `PaletteListEntry` union, post-#13076).
