### PR TITLE
fix(kimi): wait for welcome banner before stdin prompt injection

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15108,8 +15108,14 @@ describe('OrcaRuntimeService', () => {
         condition: 'tui-idle',
         timeoutMs: 10_000
       })
-      // Why: banner is no longer an immediate known-ready match — quiet after welcome.
-      await vi.advanceTimersByTimeAsync(5_000)
+      let resolved = false
+      void waitPromise.then(() => {
+        resolved = true
+      })
+      // Why: quiet window is 3s; stay just under it so immediate banner resolve fails the test.
+      await vi.advanceTimersByTimeAsync(2_500)
+      expect(resolved).toBe(false)
+      await vi.advanceTimersByTimeAsync(2_500)
 
       await expect(waitPromise).resolves.toMatchObject({
         handle,

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15087,28 +15087,69 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
-  it('resolves tui-idle from a Kimi welcome banner preview (#10336)', async () => {
-    const runtime = new OrcaRuntimeService(store)
-    runtime.setPtyController({
-      spawn: vi.fn().mockResolvedValue({ id: 'pty-kimi' }),
-      write: () => true,
-      kill: () => true,
-      getForegroundProcess: async () => 'kimi'
-    })
-    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
-    runtime.onPtyData(
-      'pty-kimi',
-      '╭─────────────────────────────────────────╮\n│  Welcome to Kimi Code!                   │\n╰─────────────────────────────────────────╯\n',
-      Date.now()
-    )
+  it('resolves tui-idle after Kimi welcome banner then process quiet (#10336/#10369)', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-kimi' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'kimi'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData(
+        'pty-kimi',
+        '╭─────────────────────────────────────────╮\n│  Welcome to Kimi Code!                   │\n╰─────────────────────────────────────────╯\n',
+        Date.now()
+      )
 
-    await expect(
-      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
-    ).resolves.toMatchObject({
-      handle,
-      condition: 'tui-idle',
-      status: 'running'
-    })
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 10_000
+      })
+      // Why: banner is no longer an immediate known-ready match — quiet after welcome.
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expect(waitPromise).resolves.toMatchObject({
+        handle,
+        condition: 'tui-idle',
+        status: 'running'
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('does not treat a Kimi welcome banner alone as tui-idle while output is still arriving (#10369)', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-kimi-busy' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'kimi'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      runtime.onPtyData('pty-kimi-busy', 'Welcome to Kimi Code!\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 4_000
+      })
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+      // Why: keep lastOutputAt fresh so quiet fallback cannot fire despite banner,
+      // and advance past the wait timeout so the rejection settles under fake timers.
+      for (let i = 0; i < 10; i += 1) {
+        await vi.advanceTimersByTimeAsync(450)
+        runtime.onPtyData('pty-kimi-busy', `generating ${i}\n`, Date.now())
+      }
+
+      await timeoutAssertion
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('does not treat a quiet Kimi process as tui-idle before the welcome banner (#10336)', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15087,6 +15087,58 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('resolves tui-idle from a Kimi welcome banner preview (#10336)', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-kimi' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => 'kimi'
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    runtime.onPtyData(
+      'pty-kimi',
+      '╭─────────────────────────────────────────╮\n│  Welcome to Kimi Code!                   │\n╰─────────────────────────────────────────╯\n',
+      Date.now()
+    )
+
+    await expect(
+      runtime.waitForTerminal(handle, { condition: 'tui-idle', timeoutMs: 1_000 })
+    ).resolves.toMatchObject({
+      handle,
+      condition: 'tui-idle',
+      status: 'running'
+    })
+  })
+
+  it('does not treat a quiet Kimi process as tui-idle before the welcome banner (#10336)', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-kimi-quiet' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => 'kimi'
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      // Why: some early process noise then silence — quiet fallback must not fire for kimi.
+      runtime.onPtyData('pty-kimi-quiet', 'starting kimi...\n', Date.now())
+
+      const waitPromise = runtime.waitForTerminal(handle, {
+        condition: 'tui-idle',
+        timeoutMs: 8_000
+      })
+      const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
+
+      await vi.advanceTimersByTimeAsync(8_000)
+
+      await timeoutAssertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('resolves tui-idle from an Antigravity ready prompt preview', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10362,6 +10362,9 @@ export class OrcaRuntimeService {
       pty.lastAgentStatusObservedLive = false
       pty.managementTitle = null
       pty.managementTitleAt = null
+      // Why: welcome-banner readiness is per process generation; a reused ptyId
+      // must re-wait for the new Kimi mount (#10369 CodeRabbit).
+      pty.kimiWelcomeBannerSeen = false
     }
     for (const leaf of this.getLeavesForPty(ptyId)) {
       leaf.lastOscTitle = null
@@ -10814,10 +10817,7 @@ export class OrcaRuntimeService {
     // A spawn published (or admission pending) this generation already
     // attaches the provider stream; a replacement under a reused id must not
     // read as the discovered never-attached session it replaced.
-    if (
-      this.spawnPublishedPtys.has(ptyId) ||
-      this.pendingPtyRegistrationIncarnations.has(ptyId)
-    ) {
+    if (this.spawnPublishedPtys.has(ptyId) || this.pendingPtyRegistrationIncarnations.has(ptyId)) {
       return false
     }
     // SSH panes have their own lease/reattach machinery.
@@ -21444,6 +21444,14 @@ export class OrcaRuntimeService {
       const observeData = (data: string): void => {
         const { ready, armQuietTimer: shouldArm } = scanner.observe(data)
         if (ready) {
+          // Why: stamp once when draft-ready sees Kimi's banner so later tui-idle
+          // quiet fallback does not depend on a tail that may have scrolled away.
+          if (readySignal === 'kimi-welcome-banner') {
+            const pty = this.ptysById.get(ptyId)
+            if (pty) {
+              pty.kimiWelcomeBannerSeen = true
+            }
+          }
           finish(ptyId)
           return
         }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1271,6 +1271,10 @@ type RuntimePtyWorktreeRecord = {
   title: string | null
   titleUpdatedAt: number | null
   lastOutputAt: number | null
+  // Why: Kimi has no idle OSC; once "Welcome to Kimi" has been observed, quiet
+  // may mean composer-ready. Before that, process quiet alone is a false idle
+  // during TUI mount (#10336 / #10369).
+  kimiWelcomeBannerSeen: boolean
   tailBuffer: string[]
   tailTranscriptBuffer: string[]
   tailTranscriptChars: number
@@ -28983,6 +28987,7 @@ export class OrcaRuntimeService {
         title: state.title ?? null,
         titleUpdatedAt: titleObservedAt,
         lastOutputAt: state.lastOutputAt ?? null,
+        kimiWelcomeBannerSeen: false,
         tailBuffer: [],
         tailTranscriptBuffer: [],
         tailTranscriptChars: 0,
@@ -31695,9 +31700,13 @@ export class OrcaRuntimeService {
           foregroundPollInFlight = true
           startedForegroundPoll = true
           const fg = await this.ptyController.getForegroundProcess(leaf.ptyId)
-          // Why: Kimi's process is live long before the TUI accepts input; quiet
-          // alone false-positives and drops orchestration dispatch paste (#10336).
-          if (fg && !isShellProcess(fg) && !isExpectedAgentProcess(fg, 'kimi')) {
+          const leafPty = this.ptysById.get(leaf.ptyId)
+          // Why: Kimi process quiet before "Welcome to Kimi" is not composer-ready;
+          // after the banner has been seen once, quiet is a normal later-turn idle.
+          const kimiOk =
+            !isExpectedAgentProcess(fg, 'kimi') ||
+            kimiAllowsQuietIdleFallback(leafPty, leafWaitText)
+          if (fg && !isShellProcess(fg) && kimiOk) {
             const quietMs = leaf.lastOutputAt ? Date.now() - leaf.lastOutputAt : 0
             if (quietMs >= TUI_IDLE_QUIESCENCE_MS) {
               if (waiter.pollInterval) {
@@ -31763,8 +31772,10 @@ export class OrcaRuntimeService {
           foregroundPollInFlight = true
           startedForegroundPoll = true
           const fg = await this.ptyController.getForegroundProcess(pty.ptyId)
-          // Why: Kimi process liveness + quiet is not composer-ready (#10336).
-          if (fg && !isShellProcess(fg) && !isExpectedAgentProcess(fg, 'kimi')) {
+          // Why: require welcome once, then allow quiet for later turns (#10336/#10369).
+          const kimiOk =
+            !isExpectedAgentProcess(fg, 'kimi') || kimiAllowsQuietIdleFallback(pty, ptyWaitText)
+          if (fg && !isShellProcess(fg) && kimiOk) {
             const quietMs = pty.lastOutputAt ? Date.now() - pty.lastOutputAt : 0
             if (quietMs >= TUI_IDLE_QUIESCENCE_MS) {
               if (waiter.pollInterval) {
@@ -36595,22 +36606,38 @@ function findDismissedStartupModalIndex(normalized: string): number | null {
 }
 
 function findKnownReadyPromptIndex(normalized: string): number | null {
+  // Why: do not include Kimi's welcome banner here — `isKnownReadyPromptPreview`
+  // satisfies every later `tui-idle` wait, and a sticky banner in the tail would
+  // resolve while Kimi is still generating. Kimi readiness is process-quiet
+  // gated on `kimiWelcomeBannerSeen` instead (#10369 CodeRabbit).
   const indexes = [
     findCodexReadyPromptIndex(normalized),
     findAntigravityReadyPromptIndex(normalized),
-    findCursorReadyPromptIndex(normalized),
-    // Why: Kimi has no reliable agent-status OSC; "Welcome to Kimi" is the
-    // composer-ready marker used for stdin-after-start injection (#10336).
-    findKimiReadyPromptIndex(normalized)
+    findCursorReadyPromptIndex(normalized)
   ].filter((index): index is number => index !== null)
   return indexes.length > 0 ? Math.max(...indexes) : null
 }
 
-// Why: match the same stream marker as draftPasteReadySignal `kimi-welcome-banner`
-// so orchestration worker-start's tui-idle wait and worktree follow-up stay aligned.
-function findKimiReadyPromptIndex(normalized: string): number | null {
-  const index = normalized.lastIndexOf('welcome to kimi')
-  return index === -1 ? null : index
+const KIMI_WELCOME_BANNER_PREVIEW = 'welcome to kimi'
+
+function noteKimiWelcomeBannerSeen(
+  pty: RuntimePtyWorktreeRecord | null | undefined,
+  waitText: string
+): void {
+  if (!pty || pty.kimiWelcomeBannerSeen) {
+    return
+  }
+  if (waitText.toLowerCase().includes(KIMI_WELCOME_BANNER_PREVIEW)) {
+    pty.kimiWelcomeBannerSeen = true
+  }
+}
+
+function kimiAllowsQuietIdleFallback(
+  pty: RuntimePtyWorktreeRecord | null | undefined,
+  waitText: string
+): boolean {
+  noteKimiWelcomeBannerSeen(pty, waitText)
+  return Boolean(pty?.kimiWelcomeBannerSeen)
 }
 
 // Why: match the banner's last occurrence to skip the trust dialog's own "Cursor Agent" text; "→" is cursor-agent's persistent input prompt.

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1714,6 +1714,8 @@ type WorktreeStartupDraftPaste = {
 type WorktreeStartupFollowup = {
   expectedProcess: string
   prompt: string
+  /** When set and the agent declares draftPasteReadySignal, wait for that too (#10336). */
+  agent?: TuiAgent
 }
 
 function getAgentLaunchPlatformForRepo(
@@ -21057,7 +21059,8 @@ export class OrcaRuntimeService {
         ? {
             followup: {
               expectedProcess: startupPlan.expectedProcess,
-              prompt: startupPlan.followupPrompt
+              prompt: startupPlan.followupPrompt,
+              agent
             }
           }
         : {})
@@ -21195,17 +21198,34 @@ export class OrcaRuntimeService {
   }
 
   private sendStartupFollowupWhenReady(handle: string, followup: WorktreeStartupFollowup): void {
-    void this.waitForStartupFollowupReady(handle, followup.expectedProcess)
-      .then((ptyId) => {
-        if (!ptyId) {
+    void (async () => {
+      try {
+        const processPtyId = await this.waitForStartupFollowupReady(
+          handle,
+          followup.expectedProcess
+        )
+        if (!processPtyId) {
           console.warn('[worktree-create] agent did not become ready for follow-up prompt')
           return
         }
+        // Why: process liveness alone is too early for agents whose TUI mounts
+        // later (Kimi); wait for the configured stream marker when present (#10336).
+        let ptyId = processPtyId
+        if (followup.agent && TUI_AGENT_CONFIG[followup.agent].draftPasteReadySignal) {
+          const draftReadyPtyId = await this.waitForStartupDraftReady(handle, followup.agent)
+          if (!draftReadyPtyId) {
+            console.warn(
+              '[worktree-create] agent process started but draft-ready signal never fired; skipping follow-up prompt'
+            )
+            return
+          }
+          ptyId = draftReadyPtyId
+        }
         this.ptyController?.write(ptyId, `${followup.prompt}\r`)
-      })
-      .catch((error) => {
+      } catch (error) {
         console.warn('[worktree-create] failed to send startup follow-up prompt:', error)
-      })
+      }
+    })()
   }
 
   private async createDefaultTabTerminals(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1747,6 +1747,10 @@ const BRACKETED_PASTE_BEGIN = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
 const DRAFT_PASTE_READY_TIMEOUT_MS = 8000
+// Why: post-paste quiet settle is ~8s; full TUI mount (e.g. Kimi welcome banner
+// on a loaded remote/headless host) regularly needs longer before stdin is safe
+// (#10336 / issuecomment-5204525896).
+const STARTUP_FOLLOWUP_DRAFT_READY_TIMEOUT_MS = 20_000
 const MOBILE_TERMINAL_SURFACE_TIMEOUT_MS = 10_000
 const MOBILE_TERMINAL_READY_FALLBACK_MS = 1000
 const RECENT_PTY_PATH_CANDIDATE_LIMIT = 1024
@@ -21212,7 +21216,11 @@ export class OrcaRuntimeService {
         // later (Kimi); wait for the configured stream marker when present (#10336).
         let ptyId = processPtyId
         if (followup.agent && TUI_AGENT_CONFIG[followup.agent].draftPasteReadySignal) {
-          const draftReadyPtyId = await this.waitForStartupDraftReady(handle, followup.agent)
+          const draftReadyPtyId = await this.waitForStartupDraftReady(
+            handle,
+            followup.agent,
+            STARTUP_FOLLOWUP_DRAFT_READY_TIMEOUT_MS
+          )
           if (!draftReadyPtyId) {
             console.warn(
               '[worktree-create] agent process started but draft-ready signal never fired; skipping follow-up prompt'
@@ -21388,7 +21396,11 @@ export class OrcaRuntimeService {
     return null
   }
 
-  private waitForStartupDraftReady(handle: string, agent: TuiAgent): Promise<string | null> {
+  private waitForStartupDraftReady(
+    handle: string,
+    agent: TuiAgent,
+    timeoutMs: number = DRAFT_PASTE_READY_TIMEOUT_MS
+  ): Promise<string | null> {
     const livePty = this.getLivePtyForHandle(handle)
     const ptyId = livePty?.pty.ptyId
     if (!ptyId) {
@@ -21441,7 +21453,7 @@ export class OrcaRuntimeService {
       if (replay) {
         observeData(replay)
       }
-      hardTimer = setTimeout(() => finish(null), DRAFT_PASTE_READY_TIMEOUT_MS)
+      hardTimer = setTimeout(() => finish(null), timeoutMs)
     })
   }
 
@@ -31683,7 +31695,9 @@ export class OrcaRuntimeService {
           foregroundPollInFlight = true
           startedForegroundPoll = true
           const fg = await this.ptyController.getForegroundProcess(leaf.ptyId)
-          if (fg && !isShellProcess(fg)) {
+          // Why: Kimi's process is live long before the TUI accepts input; quiet
+          // alone false-positives and drops orchestration dispatch paste (#10336).
+          if (fg && !isShellProcess(fg) && !isExpectedAgentProcess(fg, 'kimi')) {
             const quietMs = leaf.lastOutputAt ? Date.now() - leaf.lastOutputAt : 0
             if (quietMs >= TUI_IDLE_QUIESCENCE_MS) {
               if (waiter.pollInterval) {
@@ -31749,7 +31763,8 @@ export class OrcaRuntimeService {
           foregroundPollInFlight = true
           startedForegroundPoll = true
           const fg = await this.ptyController.getForegroundProcess(pty.ptyId)
-          if (fg && !isShellProcess(fg)) {
+          // Why: Kimi process liveness + quiet is not composer-ready (#10336).
+          if (fg && !isShellProcess(fg) && !isExpectedAgentProcess(fg, 'kimi')) {
             const quietMs = pty.lastOutputAt ? Date.now() - pty.lastOutputAt : 0
             if (quietMs >= TUI_IDLE_QUIESCENCE_MS) {
               if (waiter.pollInterval) {
@@ -36583,9 +36598,19 @@ function findKnownReadyPromptIndex(normalized: string): number | null {
   const indexes = [
     findCodexReadyPromptIndex(normalized),
     findAntigravityReadyPromptIndex(normalized),
-    findCursorReadyPromptIndex(normalized)
+    findCursorReadyPromptIndex(normalized),
+    // Why: Kimi has no reliable agent-status OSC; "Welcome to Kimi" is the
+    // composer-ready marker used for stdin-after-start injection (#10336).
+    findKimiReadyPromptIndex(normalized)
   ].filter((index): index is number => index !== null)
   return indexes.length > 0 ? Math.max(...indexes) : null
+}
+
+// Why: match the same stream marker as draftPasteReadySignal `kimi-welcome-banner`
+// so orchestration worker-start's tui-idle wait and worktree follow-up stay aligned.
+function findKimiReadyPromptIndex(normalized: string): number | null {
+  const index = normalized.lastIndexOf('welcome to kimi')
+  return index === -1 ? null : index
 }
 
 // Why: match the banner's last occurrence to skip the trust dialog's own "Cursor Agent" text; "→" is cursor-agent's persistent input prompt.

--- a/src/shared/draft-paste-ready-scanner.test.ts
+++ b/src/shared/draft-paste-ready-scanner.test.ts
@@ -135,4 +135,33 @@ describe('createDraftPasteReadyScanner', () => {
       })
     })
   })
+
+  describe('kimi-welcome-banner (#10336)', () => {
+    it('is ready only after the Welcome to Kimi banner text appears', () => {
+      const scanner = createDraftPasteReadyScanner('kimi-welcome-banner')
+      expect(scanner.observe('starting kimi...\n')).toEqual({
+        ready: false,
+        armQuietTimer: false
+      })
+      expect(scanner.observe('  Welcome to Kimi Code!\n')).toEqual({
+        ready: true,
+        armQuietTimer: false
+      })
+    })
+
+    it('does not arm the quiet window before or after the banner', () => {
+      const scanner = createDraftPasteReadyScanner('kimi-welcome-banner')
+      expect(scanner.observe(DECSET_BRACKETED_PASTE)).toEqual({
+        ready: false,
+        armQuietTimer: false
+      })
+      expect(scanner.observe('Welcome to Kimi')).toEqual({ ready: true, armQuietTimer: false })
+    })
+
+    it('detects the banner split across chunks', () => {
+      const scanner = createDraftPasteReadyScanner('kimi-welcome-banner')
+      expect(scanner.observe('Welcome to Ki')).toEqual({ ready: false, armQuietTimer: false })
+      expect(scanner.observe('mi Code!')).toEqual({ ready: true, armQuietTimer: false })
+    })
+  })
 })

--- a/src/shared/draft-paste-ready-scanner.ts
+++ b/src/shared/draft-paste-ready-scanner.ts
@@ -12,6 +12,9 @@ const CODEX_COMPOSER_PROMPT = '›'
 // racing the composer mount under slow/noisy startup. mimo-code uses the same
 // signal by parity; the quiet-window fallback covers any agent that differs.
 const DECTCEM_SHOW_CURSOR = '\x1b[?25h'
+// Why: Kimi prints this after the TUI is mounted; stdin before it is echoed as
+// scrollback instead of landing in the composer (#10336).
+const KIMI_WELCOME_BANNER = 'Welcome to Kimi'
 
 export type DraftPasteReadyScanResult = {
   /** The agent-specific ready signal fired — caller should deliver the paste now. */
@@ -39,6 +42,9 @@ export type DraftPasteReadyScanResult = {
  *     the caller's hard timeout is the backstop if it never appears.
  *   - `render-quiet-after-bracketed-paste` (default): no signal marker; arms the
  *     quiet window once DECSET 2004 is seen.
+ *   - `kimi-welcome-banner`: ready when "Welcome to Kimi" renders. Does not wait
+ *     for DECSET 2004 (Kimi may not enable bracketed paste first) and does not
+ *     arm the quiet window.
  *
  * A 512-byte ring (`recent` / `postHandshakeRecent`) covers escape sequences
  * split across chunk boundaries without retaining terminal scrollback.
@@ -49,6 +55,19 @@ export function createDraftPasteReadyScanner(readySignal: DraftPasteReadySignal)
   let recent = ''
   let postHandshakeRecent = ''
   let saw2004 = false
+
+  if (readySignal === 'kimi-welcome-banner') {
+    return {
+      observe(data: string): DraftPasteReadyScanResult {
+        const combined = recent + data
+        recent = combined.slice(-512)
+        if (combined.includes(KIMI_WELCOME_BANNER)) {
+          return { ready: true, armQuietTimer: false }
+        }
+        return { ready: false, armQuietTimer: false }
+      }
+    }
+  }
 
   const signalMarker =
     readySignal === 'codex-composer-prompt'

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -13,6 +13,8 @@ export type DraftPasteReadySignal =
   | 'render-quiet-after-bracketed-paste'
   | 'codex-composer-prompt'
   | 'render-cursor-after-bracketed-paste'
+  /** Kimi Code welcome banner — composer is ready after this renders (#10336). */
+  | 'kimi-welcome-banner'
 
 export type TuiAgentDetectionRuntime = NodeJS.Platform | 'wsl'
 
@@ -245,7 +247,10 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     detectCmd: 'kimi',
     launchCmd: 'kimi',
     expectedProcess: 'kimi',
-    promptInjectionMode: 'stdin-after-start'
+    promptInjectionMode: 'stdin-after-start',
+    // Why: Kimi's process is live long before the TUI composer accepts input; the
+    // welcome banner is the reliable "ready" marker (#10336).
+    draftPasteReadySignal: 'kimi-welcome-banner'
   },
   'mistral-vibe': {
     // Why: installer exposes binary `vibe` though the package is mistral-vibe; keep old name as alias for wrapped installs.

--- a/src/shared/tui-agent-startup.test.ts
+++ b/src/shared/tui-agent-startup.test.ts
@@ -713,6 +713,19 @@ describe('tui agent startup plans', () => {
     expect(plan?.launchCommand).toBe("opencode --prompt 'fix it'")
   })
 
+  it('waits for the Kimi welcome banner before stdin follow-up prompts (#10336)', () => {
+    expect(TUI_AGENT_CONFIG.kimi.promptInjectionMode).toBe('stdin-after-start')
+    expect(TUI_AGENT_CONFIG.kimi.draftPasteReadySignal).toBe('kimi-welcome-banner')
+    const plan = buildAgentStartupPlan({
+      agent: 'kimi',
+      prompt: 'Ship the migration',
+      cmdOverrides: {},
+      platform: 'darwin'
+    })
+    expect(plan?.followupPrompt).toBe('Ship the migration')
+    expect(plan?.launchCommand).toContain('kimi')
+  })
+
   it('keeps opencode and mimo-code on the cursor-gated paste draft route', () => {
     expect(TUI_AGENT_CONFIG.opencode.draftPasteReadySignal).toBe(
       'render-cursor-after-bracketed-paste'


### PR DESCRIPTION
## Description

Kimi Code `stdin-after-start` prompt injection now waits for the **Welcome to Kimi** banner (and a longer readiness budget) before writing the follow-up prompt. Orchestration `tui-idle` also treats that banner as ready and no longer false-positives on a quiet `kimi` process alone.

## Focused fix

- In scope: Kimi welcome-banner readiness for worktree-create follow-up prompts + orchestration `tui-idle` readiness for the same marker
- Out of scope: Kimi agent-status OSC / usage analytics (#4570); changing `dispatch_input: accepted` to mean “agent consumed bytes” rather than “write accepted”

## Preserves

- Other agents’ readiness signals and the existing 8s draft-paste quiet timeout for paste-settle paths
- `worker-start` / `sendTerminalAgentPrompt` write contract (`accepted` still means the write path completed)

## Evidence

- Tests: `pnpm exec vitest run --config config/vitest.config.ts src/shared/draft-paste-ready-scanner.test.ts src/shared/tui-agent-startup.test.ts` (83)
- Tests: `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t 'tui-idle|Kimi|#10336'` (including banner ready + quiet-kimi not idle)
- Field: [issuecomment-5204525896](https://github.com/stablyai/orca/issues/10336#issuecomment-5204525896) on v1.4.175 remote orchestration (banner signal missing on release; quiet race + 8s budget)

## User-regression-tradeoffs

- On timeout after process start without banner, worktree follow-up still **skips** the prompt (warn log) rather than writing into scrollback
- Kimi `tui-idle` waits for the banner instead of process quiet — slower ready on hosts where Kimi is quiet mid-boot, but avoids silent empty dispatch

Fixes #10336