### PR TITLE
fix(runtime): headless terminal create --focus without renderer window

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -848,6 +848,7 @@ import {
   getTerminalViewColorQueryReplyColors,
   registerTerminalViewAttributesApplier
 } from './terminal-view-attribute-store'
+import { shouldCreateTerminalInBackground } from './terminal-create-background-decision'
 import { killAllProcessesForWorktree, teardownRpcDeadline } from './worktree-teardown'
 import {
   MobileNotificationReplayBuffer,
@@ -21496,14 +21497,13 @@ export class OrcaRuntimeService {
     // requires a resolvable selector, so route the no-selector case through
     // the renderer IPC path to preserve that behavior.
     const rendererWindow = opts.rendererBacked === true ? availableAuthoritativeWindow : null
-    const shouldCreateInBackground =
-      worktreeSelector !== undefined &&
-      (Boolean(opts.agentSessionClaim) ||
-        (!requiresRendererFocus && opts.rendererBacked !== true) ||
-        // Why: `orca serve` exposes the local runtime without a renderer
-        // window. Renderer-backed Codex terminals are preferred for the app,
-        // but headless CLI users still need a usable terminal handle.
-        (opts.rendererBacked === true && rendererWindow === null))
+    const shouldCreateInBackground = shouldCreateTerminalInBackground({
+      worktreeSelector,
+      agentSessionClaim: Boolean(opts.agentSessionClaim),
+      requiresRendererFocus,
+      rendererBacked: opts.rendererBacked === true,
+      hasAuthoritativeWindow: availableAuthoritativeWindow !== null
+    })
 
     if (shouldCreateInBackground) {
       if (!this.ptyController?.spawn) {

--- a/src/main/runtime/terminal-create-background-decision.test.ts
+++ b/src/main/runtime/terminal-create-background-decision.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { shouldCreateTerminalInBackground } from './terminal-create-background-decision'
+
+describe('shouldCreateTerminalInBackground', () => {
+  it('returns false when no worktree selector is provided', () => {
+    expect(
+      shouldCreateTerminalInBackground({
+        worktreeSelector: undefined,
+        agentSessionClaim: false,
+        requiresRendererFocus: true,
+        rendererBacked: false,
+        hasAuthoritativeWindow: false
+      })
+    ).toBe(false)
+  })
+
+  it('prefers background for agent session claims', () => {
+    expect(
+      shouldCreateTerminalInBackground({
+        worktreeSelector: 'wt-1',
+        agentSessionClaim: true,
+        requiresRendererFocus: true,
+        rendererBacked: true,
+        hasAuthoritativeWindow: true
+      })
+    ).toBe(true)
+  })
+
+  it('uses background for non-focus non-renderer-backed creates', () => {
+    expect(
+      shouldCreateTerminalInBackground({
+        worktreeSelector: 'wt-1',
+        agentSessionClaim: false,
+        requiresRendererFocus: false,
+        rendererBacked: false,
+        hasAuthoritativeWindow: true
+      })
+    ).toBe(true)
+  })
+
+  it('keeps focus creates on renderer when a window exists', () => {
+    expect(
+      shouldCreateTerminalInBackground({
+        worktreeSelector: 'wt-1',
+        agentSessionClaim: false,
+        requiresRendererFocus: true,
+        rendererBacked: false,
+        hasAuthoritativeWindow: true
+      })
+    ).toBe(false)
+  })
+
+  it('falls back to background for focus creates without a renderer window (orca serve)', () => {
+    // Repro #10333: Mac UI + / terminal create --focus on headless remote server
+    expect(
+      shouldCreateTerminalInBackground({
+        worktreeSelector: 'wt-1',
+        agentSessionClaim: false,
+        requiresRendererFocus: true,
+        rendererBacked: false,
+        hasAuthoritativeWindow: false
+      })
+    ).toBe(true)
+  })
+
+  it('falls back to background for renderer-backed creates without a window', () => {
+    expect(
+      shouldCreateTerminalInBackground({
+        worktreeSelector: 'wt-1',
+        agentSessionClaim: false,
+        requiresRendererFocus: false,
+        rendererBacked: true,
+        hasAuthoritativeWindow: false
+      })
+    ).toBe(true)
+  })
+
+  it('keeps renderer-backed creates on renderer when a window exists', () => {
+    expect(
+      shouldCreateTerminalInBackground({
+        worktreeSelector: 'wt-1',
+        agentSessionClaim: false,
+        requiresRendererFocus: false,
+        rendererBacked: true,
+        hasAuthoritativeWindow: true
+      })
+    ).toBe(false)
+  })
+})

--- a/src/main/runtime/terminal-create-background-decision.ts
+++ b/src/main/runtime/terminal-create-background-decision.ts
@@ -1,0 +1,35 @@
+/**
+ * Decide whether createTerminal should spawn via the headless/background path
+ * instead of renderer IPC.
+ *
+ * Headless `orca serve` has no BrowserWindow. Focus-requested creates (Mac UI
+ * "+", `terminal create --focus`) must fall back to background spawn rather
+ * than throw "No renderer window available".
+ */
+export function shouldCreateTerminalInBackground(args: {
+  worktreeSelector: string | undefined
+  agentSessionClaim: boolean
+  requiresRendererFocus: boolean
+  rendererBacked: boolean
+  hasAuthoritativeWindow: boolean
+}): boolean {
+  if (args.worktreeSelector === undefined) {
+    return false
+  }
+
+  if (args.agentSessionClaim) {
+    return true
+  }
+
+  if (!args.requiresRendererFocus && !args.rendererBacked) {
+    return true
+  }
+
+  // Why: no local BrowserWindow (orca serve / headless) — background spawn is
+  // the only usable path whether the client asked for focus or rendererBacked.
+  if (!args.hasAuthoritativeWindow) {
+    return true
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary
- Fixes #10333: Mac UI `+` agent launch and `terminal create --focus` on headless `orca serve` no longer throw `No renderer window available`.
- When there is no authoritative BrowserWindow, create with a worktree selector uses the existing background spawn path (same idea as the current `rendererBacked` headless fallback).
- Pure decision helper + unit tests for focus/headless and related matrix.

## Root cause
`shouldCreateInBackground` only covered headless when `rendererBacked === true` (or when focus was not required). Focus-requested creates still called `getAuthoritativeWindow()`, which throws on serve with no windows.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/terminal-create-background-decision.test.ts`
- [ ] On headless remote: `orca --environment <remote> terminal create --worktree <wt> --command "echo test" --focus --json` returns ok (background surface) instead of runtime_error
- [ ] Mac UI `+` → agent on headless remote server creates a usable terminal handle

## ELI5

Launching an agent or terminal create --focus on headless orca serve crashed with No renderer window available. Headless creates now use the background spawn path when there is no UI window.
