### PR TITLE
feat(editor): syntax highlighting for MATLAB (.m) and LaTeX (.tex)

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -20,6 +20,14 @@ describe('detectLanguage', () => {
     expect(detectLanguage('packages/app.nimble')).toBe('nim')
   })
 
+  it('maps MATLAB .m and LaTeX family extensions', () => {
+    expect(detectLanguage('sim/plot_results.m')).toBe('matlab')
+    expect(detectLanguage('C:\\thesis\\main.TEX')).toBe('latex')
+    expect(detectLanguage('paper/chapter.ltx')).toBe('latex')
+    expect(detectLanguage('styles/custom.sty')).toBe('latex')
+    expect(detectLanguage('classes/report.cls')).toBe('latex')
+  })
+
   it('maps exact filenames from Windows paths', () => {
     expect(detectLanguage('C:\\Users\\alice\\repo\\Dockerfile')).toBe('dockerfile')
     expect(detectLanguage('C:\\Users\\alice\\repo\\CMakeLists.txt')).toBe('cmake')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -91,6 +91,14 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.nim': 'nim',
   '.nims': 'nim',
   '.nimble': 'nim',
+  // Why: #10363 — .m/.tex were plaintext; MATLAB TextMate + LaTeX Monarch.
+  // .m is also Objective-C, but we never mapped it before and the report is MATLAB.
+  '.m': 'matlab',
+  '.tex': 'latex',
+  '.ltx': 'latex',
+  '.latex': 'latex',
+  '.sty': 'latex',
+  '.cls': 'latex',
   '.tf': 'hcl',
   '.hcl': 'hcl',
   '.prisma': 'graphql',

--- a/src/renderer/src/lib/monaco-languages/register-latex.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-latex.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  LATEX_LANGUAGE_ID,
+  latexLanguageConfiguration,
+  latexMonarchLanguage,
+  registerLatexLanguage
+} from './register-latex'
+
+function createMonacoMock(existing: { id: string }[] = []) {
+  return {
+    languages: {
+      getLanguages: vi.fn(() => existing),
+      register: vi.fn(),
+      setLanguageConfiguration: vi.fn(),
+      setMonarchTokensProvider: vi.fn()
+    }
+  }
+}
+
+describe('registerLatexLanguage', () => {
+  it('registers LaTeX extensions with a Monarch tokens provider', () => {
+    const monaco = createMonacoMock()
+
+    registerLatexLanguage(monaco as never)
+
+    expect(monaco.languages.register).toHaveBeenCalledWith({
+      id: LATEX_LANGUAGE_ID,
+      extensions: ['.tex', '.ltx', '.latex', '.sty', '.cls'],
+      aliases: ['LaTeX', 'latex', 'TeX', 'tex']
+    })
+    expect(monaco.languages.setLanguageConfiguration).toHaveBeenCalledWith(
+      LATEX_LANGUAGE_ID,
+      latexLanguageConfiguration
+    )
+    expect(monaco.languages.setMonarchTokensProvider).toHaveBeenCalledWith(
+      LATEX_LANGUAGE_ID,
+      latexMonarchLanguage
+    )
+  })
+
+  it('is idempotent when the language is already registered', () => {
+    const monaco = createMonacoMock([{ id: LATEX_LANGUAGE_ID }])
+
+    registerLatexLanguage(monaco as never)
+
+    expect(monaco.languages.register).not.toHaveBeenCalled()
+  })
+
+  it('tokenizes comments and commands in the Monarch root state', () => {
+    expect(latexMonarchLanguage.tokenizer.root).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining([/%.*$/, 'comment']),
+        expect.arrayContaining([expect.any(RegExp), 'keyword'])
+      ])
+    )
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-latex.ts
+++ b/src/renderer/src/lib/monaco-languages/register-latex.ts
@@ -1,0 +1,118 @@
+import type * as Monaco from 'monaco-editor'
+
+type MonacoModule = typeof Monaco
+
+export const LATEX_LANGUAGE_ID = 'latex'
+
+export const latexLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  comments: {
+    lineComment: '%'
+  },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')']
+  ],
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '$', close: '$' },
+    { open: '`', close: "'" }
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: '$', close: '$' }
+  ]
+}
+
+// Why: Full VS Code LaTeX TextMate grammars pull dozens of embedded language
+// scopes (python, julia, …). A presentation-only Monarch tokenizer covers
+// comments, commands, environments, and math delimiters without that graph.
+export const latexMonarchLanguage: Monaco.languages.IMonarchLanguage = {
+  defaultToken: '',
+  tokenPostfix: '.latex',
+  ignoreCase: false,
+
+  tokenizer: {
+    root: [
+      { include: '@whitespace' },
+      // Line comments
+      [/%.*$/, 'comment'],
+      // Display / inline math environments
+      [/\\\[/, 'string', '@displayMathBracket'],
+      [/\\\(/, 'string', '@inlineMathParen'],
+      [/\$\$/, 'string', '@displayMathDollar'],
+      [/\$/, 'string', '@inlineMathDollar'],
+      // \begin{env} / \end{env}
+      [
+        /\\(begin|end)\s*\{[a-zA-Z*]+\}/,
+        {
+          cases: {
+            '@default': 'keyword'
+          }
+        }
+      ],
+      // Commands: \command, \command*, \\, and special single-char commands
+      [/\\(?:[a-zA-Z]+|[^a-zA-Z\s])/, 'keyword'],
+      // Grouping braces / optional args
+      [/[{}]/, '@brackets'],
+      [/[[\]]/, '@brackets'],
+      // Plain text
+      [/[^\\%$[\]{}]+/, '']
+    ],
+
+    whitespace: [[/[ \t\r\n]+/, 'white']],
+
+    displayMathBracket: [
+      [/\\\]/, 'string', '@pop'],
+      [/%.*$/, 'comment'],
+      [/\\(?:[a-zA-Z]+|[^a-zA-Z\s])/, 'keyword'],
+      [/[^\\%\]]+/, 'string'],
+      [/./, 'string']
+    ],
+
+    inlineMathParen: [
+      [/\\\)/, 'string', '@pop'],
+      [/%.*$/, 'comment'],
+      [/\\(?:[a-zA-Z]+|[^a-zA-Z\s])/, 'keyword'],
+      [/[^\\%)]+/, 'string'],
+      [/./, 'string']
+    ],
+
+    displayMathDollar: [
+      [/\$\$/, 'string', '@pop'],
+      [/%.*$/, 'comment'],
+      [/\\(?:[a-zA-Z]+|[^a-zA-Z\s])/, 'keyword'],
+      [/[^\\%$]+/, 'string'],
+      [/./, 'string']
+    ],
+
+    inlineMathDollar: [
+      [/\$/, 'string', '@pop'],
+      [/%.*$/, 'comment'],
+      [/\\(?:[a-zA-Z]+|[^a-zA-Z\s])/, 'keyword'],
+      [/[^\\%$]+/, 'string'],
+      [/./, 'string']
+    ]
+  }
+}
+
+export function registerLatexLanguage(monaco: MonacoModule): void {
+  const languageAlreadyRegistered = monaco.languages
+    .getLanguages()
+    .some((language) => language.id === LATEX_LANGUAGE_ID)
+  if (languageAlreadyRegistered) {
+    return
+  }
+
+  monaco.languages.register({
+    id: LATEX_LANGUAGE_ID,
+    extensions: ['.tex', '.ltx', '.latex', '.sty', '.cls'],
+    aliases: ['LaTeX', 'latex', 'TeX', 'tex']
+  })
+  monaco.languages.setLanguageConfiguration(LATEX_LANGUAGE_ID, latexLanguageConfiguration)
+  monaco.languages.setMonarchTokensProvider(LATEX_LANGUAGE_ID, latexMonarchLanguage)
+}

--- a/src/renderer/src/lib/monaco-languages/register-matlab.test.ts
+++ b/src/renderer/src/lib/monaco-languages/register-matlab.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MATLAB_LANGUAGE_ID,
+  MATLAB_TEXTMATE_SCOPE,
+  loadMatlabTextMateGrammar,
+  matlabLanguageConfiguration,
+  registerMatlabLanguage
+} from './register-matlab'
+
+function createMonacoMock() {
+  return {
+    languages: {
+      getLanguages: vi.fn(() => []),
+      register: vi.fn(),
+      setLanguageConfiguration: vi.fn(),
+      registerTokensProviderFactory: vi.fn()
+    }
+  }
+}
+
+describe('registerMatlabLanguage', () => {
+  it('maps .m to the TextMate-backed matlab language', () => {
+    const monaco = createMonacoMock()
+
+    registerMatlabLanguage(monaco as never)
+
+    expect(monaco.languages.register).toHaveBeenCalledWith({
+      id: MATLAB_LANGUAGE_ID,
+      extensions: ['.m'],
+      aliases: ['MATLAB', 'matlab']
+    })
+    expect(monaco.languages.setLanguageConfiguration).toHaveBeenCalledWith(
+      MATLAB_LANGUAGE_ID,
+      matlabLanguageConfiguration
+    )
+    expect(monaco.languages.registerTokensProviderFactory).toHaveBeenCalledWith(
+      MATLAB_LANGUAGE_ID,
+      expect.objectContaining({ create: expect.any(Function) })
+    )
+  })
+})
+
+describe('loadMatlabTextMateGrammar', () => {
+  it('loads the vendored MATLAB TextMate grammar', async () => {
+    const grammar = await loadMatlabTextMateGrammar(MATLAB_TEXTMATE_SCOPE)
+
+    expect(grammar).toMatchObject({
+      scopeName: MATLAB_TEXTMATE_SCOPE,
+      fileTypes: ['m']
+    })
+  })
+
+  it('ignores unrelated TextMate scopes', async () => {
+    await expect(loadMatlabTextMateGrammar('source.python')).resolves.toBeNull()
+  })
+})

--- a/src/renderer/src/lib/monaco-languages/register-matlab.ts
+++ b/src/renderer/src/lib/monaco-languages/register-matlab.ts
@@ -1,0 +1,58 @@
+import type * as Monaco from 'monaco-editor'
+import type { IRawGrammar } from 'vscode-textmate'
+import { registerTextMateLanguage } from './textmate-language-registration'
+
+type MonacoModule = typeof Monaco
+
+export const MATLAB_LANGUAGE_ID = 'matlab'
+export const MATLAB_TEXTMATE_SCOPE = 'source.matlab'
+
+export const matlabLanguageConfiguration: Monaco.languages.LanguageConfiguration = {
+  comments: {
+    lineComment: '%'
+  },
+  brackets: [
+    ['{', '}'],
+    ['[', ']'],
+    ['(', ')']
+  ],
+  autoClosingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: "'", close: "'" },
+    { open: '"', close: '"' }
+  ],
+  surroundingPairs: [
+    { open: '{', close: '}' },
+    { open: '[', close: ']' },
+    { open: '(', close: ')' },
+    { open: "'", close: "'" },
+    { open: '"', close: '"' }
+  ]
+}
+
+export async function loadMatlabTextMateGrammar(scopeName: string): Promise<IRawGrammar | null> {
+  if (scopeName !== MATLAB_TEXTMATE_SCOPE) {
+    return null
+  }
+
+  // Why: MathWorks MATLAB TextMate grammar (BSD-style; see matlab-LICENSE.txt).
+  const grammarModule = await import('./textmate-grammars/matlab.tmLanguage.json')
+  return grammarModule.default as unknown as IRawGrammar
+}
+
+export function registerMatlabLanguage(monaco: MonacoModule): void {
+  registerTextMateLanguage(monaco, {
+    language: {
+      id: MATLAB_LANGUAGE_ID,
+      // Why: issue #10363 — .m files currently have no mapping and render as
+      // plaintext. Prefer MATLAB over Monaco's unused objective-c registration.
+      extensions: ['.m'],
+      aliases: ['MATLAB', 'matlab']
+    },
+    configuration: matlabLanguageConfiguration,
+    scopeName: MATLAB_TEXTMATE_SCOPE,
+    loadGrammar: loadMatlabTextMateGrammar
+  })
+}

--- a/src/renderer/src/lib/monaco-languages/textmate-grammars/matlab-LICENSE.txt
+++ b/src/renderer/src/lib/monaco-languages/textmate-grammars/matlab-LICENSE.txt
@@ -1,0 +1,9 @@
+Copyright 2018 The MathWorks, Inc.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/renderer/src/lib/monaco-languages/textmate-grammars/matlab.tmLanguage.json
+++ b/src/renderer/src/lib/monaco-languages/textmate-grammars/matlab.tmLanguage.json
@@ -1,0 +1,1099 @@
+{
+  "displayName": "MATLAB",
+  "fileTypes": ["m"],
+  "name": "MATLAB",
+  "patterns": [
+    {
+      "include": "#all_before_command_dual"
+    },
+    {
+      "include": "#command_dual"
+    },
+    {
+      "include": "#all_after_command_dual"
+    }
+  ],
+  "repository": {
+    "all_after_command_dual": {
+      "patterns": [
+        {
+          "include": "#string"
+        },
+        {
+          "include": "#line_continuation"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#conjugate_transpose"
+        },
+        {
+          "include": "#transpose"
+        },
+        {
+          "include": "#constants"
+        },
+        {
+          "include": "#variables"
+        },
+        {
+          "include": "#numbers"
+        },
+        {
+          "include": "#operators"
+        }
+      ]
+    },
+    "all_before_command_dual": {
+      "patterns": [
+        {
+          "include": "#classdef"
+        },
+        {
+          "include": "#function"
+        },
+        {
+          "include": "#blocks"
+        },
+        {
+          "include": "#control_statements"
+        },
+        {
+          "include": "#global_persistent"
+        },
+        {
+          "include": "#parens"
+        },
+        {
+          "include": "#square_brackets"
+        },
+        {
+          "include": "#indexing_curly_brackets"
+        },
+        {
+          "include": "#curly_brackets"
+        }
+      ]
+    },
+    "blocks": {
+      "patterns": [
+        {
+          "begin": "\\s*(?:^|[,;\\s])(for)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.for.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.for.matlab"
+            }
+          },
+          "name": "meta.for.matlab",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*(?:^|[,;\\s])(if)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.if.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.if.matlab"
+            },
+            "2": {
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            }
+          },
+          "name": "meta.if.matlab",
+          "patterns": [
+            {
+              "captures": {
+                "2": {
+                  "name": "keyword.control.elseif.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              },
+              "end": "^",
+              "match": "(\\s*)(?:^|[,;\\s])(elseif)\\b(.*)$\\n?",
+              "name": "meta.elseif.matlab"
+            },
+            {
+              "captures": {
+                "2": {
+                  "name": "keyword.control.else.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              },
+              "end": "^",
+              "match": "(\\s*)(?:^|[,;\\s])(else)\\b(.*)?$\\n?",
+              "name": "meta.else.matlab"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*(?:^|[,;\\s])(parfor)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.for.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.for.matlab"
+            }
+          },
+          "name": "meta.parfor.matlab",
+          "patterns": [
+            {
+              "begin": "\\G(?!$)",
+              "end": "$\\n?",
+              "name": "meta.parfor-quantity.matlab",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*(?:^|[,;\\s])(spmd)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.spmd.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.spmd.matlab"
+            }
+          },
+          "name": "meta.spmd.matlab",
+          "patterns": [
+            {
+              "begin": "\\G(?!$)",
+              "end": "$\\n?",
+              "name": "meta.spmd-statement.matlab",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*(?:^|[,;\\s])(switch)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.switch.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.switch.matlab"
+            }
+          },
+          "name": "meta.switch.matlab",
+          "patterns": [
+            {
+              "captures": {
+                "2": {
+                  "name": "keyword.control.case.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              },
+              "end": "^",
+              "match": "(\\s*)(?:^|[,;\\s])(case)\\b(.*)$\\n?",
+              "name": "meta.case.matlab"
+            },
+            {
+              "captures": {
+                "2": {
+                  "name": "keyword.control.otherwise.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              },
+              "end": "^",
+              "match": "(\\s*)(?:^|[,;\\s])(otherwise)\\b(.*)?$\\n?",
+              "name": "meta.otherwise.matlab"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*(?:^|[,;\\s])(try)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.try.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.try.matlab"
+            }
+          },
+          "name": "meta.try.matlab",
+          "patterns": [
+            {
+              "captures": {
+                "2": {
+                  "name": "keyword.control.catch.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              },
+              "end": "^",
+              "match": "(\\s*)(?:^|[,;\\s])(catch)\\b(.*)?$\\n?",
+              "name": "meta.catch.matlab"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        },
+        {
+          "begin": "\\s*(?:^|[,;\\s])(while)\\b",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.while.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.while.matlab"
+            }
+          },
+          "name": "meta.while.matlab",
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "braced_validator_list": {
+      "begin": "\\s*(\\{)\\s*",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.matlab"
+        }
+      },
+      "end": "(})",
+      "endCaptures": {
+        "1": {
+          "name": "storage.type.matlab"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#braced_validator_list"
+        },
+        {
+          "include": "#validator_strings"
+        },
+        {
+          "include": "#line_continuation"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "storage.type.matlab"
+            }
+          },
+          "match": "([^\"'.{}]+)"
+        },
+        {
+          "match": "\\.",
+          "name": "storage.type.matlab"
+        }
+      ]
+    },
+    "classdef": {
+      "patterns": [
+        {
+          "begin": "^(\\s*)(classdef)\\b\\s*(.*)",
+          "beginCaptures": {
+            "2": {
+              "name": "storage.type.class.matlab"
+            },
+            "3": {
+              "patterns": [
+                {
+                  "captures": {
+                    "1": {
+                      "patterns": [
+                        {
+                          "match": "[A-Za-z][0-9A-Z_a-z]*",
+                          "name": "variable.parameter.class.matlab"
+                        },
+                        {
+                          "begin": "=\\s*",
+                          "end": ",|(?=\\))",
+                          "patterns": [
+                            {
+                              "match": "true|false",
+                              "name": "constant.language.boolean.matlab"
+                            },
+                            {
+                              "include": "#string"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "2": {
+                      "name": "meta.class-declaration.matlab"
+                    },
+                    "3": {
+                      "name": "entity.name.section.class.matlab"
+                    },
+                    "4": {
+                      "name": "keyword.operator.other.matlab"
+                    },
+                    "5": {
+                      "patterns": [
+                        {
+                          "match": "[A-Za-z][0-9A-Z_a-z]*(\\.[A-Za-z][0-9A-Z_a-z]*)*",
+                          "name": "entity.other.inherited-class.matlab"
+                        },
+                        {
+                          "match": "&",
+                          "name": "keyword.operator.other.matlab"
+                        }
+                      ]
+                    },
+                    "6": {
+                      "patterns": [
+                        {
+                          "include": "$self"
+                        }
+                      ]
+                    }
+                  },
+                  "match": "(\\([^)]*\\))?\\s*(([A-Za-z][0-9A-Z_a-z]*)(?:\\s*(<)\\s*([^%]*))?)\\s*($|(?=(%|...)).*)"
+                }
+              ]
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.class.matlab"
+            }
+          },
+          "name": "meta.class.matlab",
+          "patterns": [
+            {
+              "begin": "^(\\s*)(properties)\\b([^%]*)\\s*(\\([^)]*\\))?\\s*($|(?=%))",
+              "beginCaptures": {
+                "2": {
+                  "name": "keyword.control.properties.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "match": "[A-Za-z][0-9A-Z_a-z]*",
+                      "name": "variable.parameter.properties.matlab"
+                    },
+                    {
+                      "begin": "=\\s*",
+                      "end": ",|(?=\\))",
+                      "patterns": [
+                        {
+                          "match": "true|false",
+                          "name": "constant.language.boolean.matlab"
+                        },
+                        {
+                          "match": "p(?:ublic|rotected|rivate)",
+                          "name": "constant.language.access.matlab"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "end": "\\s*(?:^|[,;\\s])(end)\\b",
+              "endCaptures": {
+                "1": {
+                  "name": "keyword.control.end.properties.matlab"
+                }
+              },
+              "name": "meta.properties.matlab",
+              "patterns": [
+                {
+                  "include": "#validators"
+                },
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "begin": "^(\\s*)(methods)\\b([^%]*)\\s*(\\([^)]*\\))?\\s*($|(?=%))",
+              "beginCaptures": {
+                "2": {
+                  "name": "keyword.control.methods.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "match": "[A-Za-z][0-9A-Z_a-z]*",
+                      "name": "variable.parameter.methods.matlab"
+                    },
+                    {
+                      "begin": "=\\s*",
+                      "end": ",|(?=\\))",
+                      "patterns": [
+                        {
+                          "match": "true|false",
+                          "name": "constant.language.boolean.matlab"
+                        },
+                        {
+                          "match": "p(?:ublic|rotected|rivate)",
+                          "name": "constant.language.access.matlab"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "end": "\\s*(?:^|[,;\\s])(end)\\b",
+              "endCaptures": {
+                "1": {
+                  "name": "keyword.control.end.methods.matlab"
+                }
+              },
+              "name": "meta.methods.matlab",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "begin": "^(\\s*)(events)\\b([^%]*)\\s*(\\([^)]*\\))?\\s*($|(?=%))",
+              "beginCaptures": {
+                "2": {
+                  "name": "keyword.control.events.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "match": "[A-Za-z][0-9A-Z_a-z]*",
+                      "name": "variable.parameter.events.matlab"
+                    },
+                    {
+                      "begin": "=\\s*",
+                      "end": ",|(?=\\))",
+                      "patterns": [
+                        {
+                          "match": "true|false",
+                          "name": "constant.language.boolean.matlab"
+                        },
+                        {
+                          "match": "p(?:ublic|rotected|rivate)",
+                          "name": "constant.language.access.matlab"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "end": "\\s*(?:^|[,;\\s])(end)\\b",
+              "endCaptures": {
+                "1": {
+                  "name": "keyword.control.end.events.matlab"
+                }
+              },
+              "name": "meta.events.matlab",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "begin": "^(\\s*)(enumeration)\\b([^%]*)\\s*($|(?=%))",
+              "beginCaptures": {
+                "2": {
+                  "name": "keyword.control.enumeration.matlab"
+                }
+              },
+              "end": "\\s*(?:^|[,;\\s])(end)\\b",
+              "endCaptures": {
+                "1": {
+                  "name": "keyword.control.end.enumeration.matlab"
+                }
+              },
+              "name": "meta.enumeration.matlab",
+              "patterns": [
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "command_dual": {
+      "captures": {
+        "1": {
+          "name": "string.interpolated.matlab"
+        },
+        "2": {
+          "name": "variable.other.command.matlab"
+        },
+        "28": {
+          "name": "comment.line.percentage.matlab"
+        }
+      },
+      "match": "^\\s*(([A-HJ-MO-Zbcdfghklmoq-z]\\w*|an??|a([0-9A-Z_a-mo-z]\\w*|n[0-9A-Z_a-rt-z]\\w*|ns\\w+)|ep??|e([0-9A-Z_a-oq-z]\\w*|p[0-9A-Z_a-rt-z]\\w*|ps\\w+)|in|i([0-9A-Z_a-mo-z]\\w*|n[0-9A-Z_a-eg-z]\\w*|nf\\w+)|In??|I([0-9A-Z_a-mo-z]\\w*|n[0-9A-Z_a-eg-z]\\w*|nf\\w+)|j\\w+|Na??|N([0-9A-Z_b-z]\\w*|a[0-9A-MO-Z_a-z]\\w*|aN\\w+)|na??|narg??|nargi|nargou??|n([0-9A-Z_b-z]\\w*|a([0-9A-Z_a-mopqs-z]\\w*|n\\w+|r([0-9A-Z_a-fh-z]\\w*|g([0-9A-Z_a-hj-nq-z]\\w*|i([0-9A-Z_a-mo-z]\\w*|n\\w+)|o([0-9A-Z_a-tv-z]\\w*|u([A-Za-su-z]\\w*|t\\w+))))))|p|p[0-9A-Z_a-hj-z]\\w*|pi\\w+)\\s+((([^\"%-/:->@\\\\^{|~\\s]|(?=')|(?=\"))|(\\.\\^|\\.\\*|\\./|\\.\\\\|\\.'|\\.\\(|&&|==|\\|\\||&(?=[^\\&])|\\|(?=[^|])|~=|<=|>=|~(?!=)|<(?!=)|>(?!=)|[-*+/:@\\\\^])(\\S|\\s*(?=%)|\\s+$|\\s+([]\\&)*,/:->@\\\\^|}]|(\\.(?:[^.\\d]|\\.[^.]))))|(\\.[^'(*/A-Z\\\\^a-z\\s]))([^%]|'[^']*'|\"[^\"]*\")*|(\\.(?=\\s)|\\.[A-Za-z]|(?=\\{))([^\"%'(=]|==|'[^']*'|\"[^\"]*\"|\\(|\\([^%)]*\\)|\\[|\\[[^]%]*]|\\{|\\{[^%}]*})*(\\.\\.\\.[^%]*)?((?=%)|$)))(%.*)?$"
+    },
+    "comment_block": {
+      "begin": "^(\\s*)%\\{[^\\n\\S]*+\\n",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.comment.matlab"
+        }
+      },
+      "end": "^\\s*%}[^\\n\\S]*+(?:\\n|$)",
+      "name": "comment.block.percentage.matlab",
+      "patterns": [
+        {
+          "include": "#comment_block"
+        },
+        {
+          "match": "^[^\\n]*\\n"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "(^[\\t ]+)?(?=%%\\s)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.matlab"
+            }
+          },
+          "end": "(?!\\G)",
+          "patterns": [
+            {
+              "begin": "%%",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.matlab"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.double-percentage.matlab",
+              "patterns": [
+                {
+                  "begin": "\\G[^\\n\\S]*(?![\\n\\s])",
+                  "contentName": "meta.cell.matlab",
+                  "end": "(?=\\n)"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "include": "#comment_block"
+        },
+        {
+          "begin": "(^[\\t ]+)?(?=%)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.matlab"
+            }
+          },
+          "end": "(?!\\G)",
+          "patterns": [
+            {
+              "begin": "%",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.matlab"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.percentage.matlab"
+            }
+          ]
+        }
+      ]
+    },
+    "conjugate_transpose": {
+      "match": "((?<=\\S)|(?<=])|(?<=\\))|(?<=}))'",
+      "name": "keyword.operator.transpose.matlab"
+    },
+    "constants": {
+      "match": "(?<!\\.)\\b(eps|false|Inf|inf|intmax|intmin|namelengthmax|NaN|nan|on|off|realmax|realmin|true|pi)\\b",
+      "name": "constant.language.matlab"
+    },
+    "control_statements": {
+      "captures": {
+        "1": {
+          "name": "keyword.control.matlab"
+        }
+      },
+      "match": "\\s*(?:^|[,;\\s])(break|continue|return)\\b",
+      "name": "meta.control.matlab"
+    },
+    "curly_brackets": {
+      "begin": "\\{",
+      "end": "}",
+      "patterns": [
+        {
+          "include": "#end_in_parens"
+        },
+        {
+          "include": "#all_before_command_dual"
+        },
+        {
+          "include": "#all_after_command_dual"
+        },
+        {
+          "include": "#end_in_parens"
+        },
+        {
+          "include": "#block_keywords"
+        }
+      ]
+    },
+    "end_in_parens": {
+      "match": "\\bend\\b",
+      "name": "keyword.operator.symbols.matlab"
+    },
+    "function": {
+      "patterns": [
+        {
+          "begin": "^(\\s*)(function)\\s+(?:(?:(\\[)([^]]*)(])|([A-Za-z][0-9A-Z_a-z]*))\\s*=\\s*)?([A-Za-z][0-9A-Z_a-z]*(\\.[A-Za-z][0-9A-Z_a-z]*)*)\\s*",
+          "beginCaptures": {
+            "2": {
+              "name": "storage.type.function.matlab"
+            },
+            "3": {
+              "name": "punctuation.definition.arguments.begin.matlab"
+            },
+            "4": {
+              "patterns": [
+                {
+                  "match": "\\w+",
+                  "name": "variable.parameter.output.matlab"
+                }
+              ]
+            },
+            "5": {
+              "name": "punctuation.definition.arguments.end.matlab"
+            },
+            "6": {
+              "name": "variable.parameter.output.function.matlab"
+            },
+            "7": {
+              "name": "entity.name.function.matlab"
+            }
+          },
+          "end": "\\s*(?:^|[,;\\s])(end)\\b(\\s*\\n)?",
+          "endCaptures": {
+            "1": {
+              "name": "keyword.control.end.function.matlab"
+            }
+          },
+          "name": "meta.function.matlab",
+          "patterns": [
+            {
+              "begin": "\\G\\(",
+              "end": "\\)",
+              "name": "meta.arguments.function.matlab",
+              "patterns": [
+                {
+                  "include": "#line_continuation"
+                },
+                {
+                  "match": "\\w+",
+                  "name": "variable.parameter.input.matlab"
+                }
+              ]
+            },
+            {
+              "begin": "^(\\s*)(arguments)\\b([^%]*)\\s*(\\([^)]*\\))?\\s*($|(?=%))",
+              "beginCaptures": {
+                "2": {
+                  "name": "keyword.control.arguments.matlab"
+                },
+                "3": {
+                  "patterns": [
+                    {
+                      "match": "[A-Za-z][0-9A-Z_a-z]*",
+                      "name": "variable.parameter.arguments.matlab"
+                    }
+                  ]
+                }
+              },
+              "end": "\\s*(?:^|[,;\\s])(end)\\b",
+              "endCaptures": {
+                "1": {
+                  "name": "keyword.control.end.arguments.matlab"
+                }
+              },
+              "name": "meta.arguments.matlab",
+              "patterns": [
+                {
+                  "include": "#validators"
+                },
+                {
+                  "include": "$self"
+                }
+              ]
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      ]
+    },
+    "global_persistent": {
+      "captures": {
+        "1": {
+          "name": "keyword.control.globalpersistent.matlab"
+        }
+      },
+      "match": "^\\s*(global|persistent)\\b",
+      "name": "meta.globalpersistent.matlab"
+    },
+    "indexing_curly_brackets": {
+      "Comment": "Match identifier{idx, idx, } and stop at newline without ... This helps with partially written code like x{idx ",
+      "begin": "([A-Za-z][.0-9A-Z_a-z]*\\s*)\\{",
+      "beginCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      },
+      "end": "(}|(?<!\\.\\.\\.).\\n)",
+      "patterns": [
+        {
+          "include": "#end_in_parens"
+        },
+        {
+          "include": "#all_before_command_dual"
+        },
+        {
+          "include": "#all_after_command_dual"
+        },
+        {
+          "include": "#end_in_parens"
+        },
+        {
+          "include": "#block_keywords"
+        }
+      ]
+    },
+    "line_continuation": {
+      "captures": {
+        "1": {
+          "name": "keyword.operator.symbols.matlab"
+        },
+        "2": {
+          "name": "comment.line.continuation.matlab"
+        }
+      },
+      "match": "(\\.\\.\\.)(.*)$",
+      "name": "meta.linecontinuation.matlab"
+    },
+    "numbers": {
+      "match": "(?<=[(*-\\-/:=\\[\\\\{\\s]|^)\\d*\\.?\\d+([Ee][-+]?\\d)?([0-9&&[^.]])*([ij])?\\b",
+      "name": "constant.numeric.matlab"
+    },
+    "operators": {
+      "match": "(?<=\\s)(==|~=|>=??|<=??|&&??|[:|]|\\|\\||[-*+]|\\.\\*|/|\\./|\\\\|\\.\\\\|\\^|\\.\\^)(?=\\s)",
+      "name": "keyword.operator.symbols.matlab"
+    },
+    "parens": {
+      "begin": "\\(",
+      "end": "(\\)|(?<!\\.\\.\\.).\\n)",
+      "patterns": [
+        {
+          "include": "#end_in_parens"
+        },
+        {
+          "include": "#all_before_command_dual"
+        },
+        {
+          "include": "#all_after_command_dual"
+        },
+        {
+          "include": "#block_keywords"
+        }
+      ]
+    },
+    "square_brackets": {
+      "begin": "\\[",
+      "end": "]",
+      "patterns": [
+        {
+          "include": "#all_before_command_dual"
+        },
+        {
+          "include": "#all_after_command_dual"
+        },
+        {
+          "include": "#block_keywords"
+        }
+      ]
+    },
+    "string": {
+      "patterns": [
+        {
+          "captures": {
+            "1": {
+              "name": "string.interpolated.matlab"
+            },
+            "2": {
+              "name": "punctuation.definition.string.begin.matlab"
+            }
+          },
+          "match": "^\\s*((!).*$\\n?)"
+        },
+        {
+          "begin": "((?<=([\\&(*-/:->\\[\\\\^{|~\\s]))|^)'",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.matlab"
+            }
+          },
+          "end": "'(?=([\\&(-/:->\\[-^{-~\\s]))",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.matlab"
+            }
+          },
+          "name": "string.quoted.single.matlab",
+          "patterns": [
+            {
+              "match": "''",
+              "name": "constant.character.escape.matlab"
+            },
+            {
+              "match": "'(?=.)",
+              "name": "invalid.illegal.unescaped-quote.matlab"
+            },
+            {
+              "match": "((%([-+0]?\\d{0,3}(\\.\\d{1,3})?)([EGc-gs]|(([bt])?([Xoux]))))|%%|\\\\([\\\\bfnrt]))",
+              "name": "constant.character.escape.matlab"
+            }
+          ]
+        },
+        {
+          "begin": "((?<=([\\&(*-/:->\\[\\\\^{|~\\s]))|^)\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.matlab"
+            }
+          },
+          "end": "\"(?=([\\&(-/:->\\[-^{-~\\s]))",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.matlab"
+            }
+          },
+          "name": "string.quoted.double.matlab",
+          "patterns": [
+            {
+              "match": "\"\"",
+              "name": "constant.character.escape.matlab"
+            },
+            {
+              "match": "\"(?=.)",
+              "name": "invalid.illegal.unescaped-quote.matlab"
+            }
+          ]
+        }
+      ]
+    },
+    "transpose": {
+      "match": "\\.'",
+      "name": "keyword.operator.transpose.matlab"
+    },
+    "validator_strings": {
+      "patterns": [
+        {
+          "patterns": [
+            {
+              "begin": "((?<=([\\&(*-/:->\\[\\\\^{|~\\s]))|^)'",
+              "end": "'(?=([\\&(-/:->\\[-^{-~\\s]))",
+              "name": "storage.type.matlab",
+              "patterns": [
+                {
+                  "match": "''"
+                },
+                {
+                  "match": "'(?=.)"
+                },
+                {
+                  "match": "([^']+)"
+                }
+              ]
+            },
+            {
+              "begin": "((?<=([\\&(*-/:->\\[\\\\^{|~\\s]))|^)\"",
+              "end": "\"(?=([\\&(-/:->\\[-^{-~\\s]))",
+              "name": "storage.type.matlab",
+              "patterns": [
+                {
+                  "match": "\"\""
+                },
+                {
+                  "match": "\"(?=.)"
+                },
+                {
+                  "match": "[^\"]+"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "validators": {
+      "begin": "\\s*;?\\s*([A-Za-z][.0-9?A-Z_a-z]*)",
+      "end": "([\\n%;=].*)",
+      "endCaptures": {
+        "1": {
+          "patterns": [
+            {
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              },
+              "match": "(%.*)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "$self"
+                    }
+                  ]
+                }
+              },
+              "match": "(=[^;]*)"
+            },
+            {
+              "captures": {
+                "1": {
+                  "patterns": [
+                    {
+                      "include": "#validators"
+                    }
+                  ]
+                }
+              },
+              "match": "([\\n;]\\s*[A-Za-z].*)"
+            },
+            {
+              "include": "$self"
+            }
+          ]
+        }
+      },
+      "patterns": [
+        {
+          "include": "#line_continuation"
+        },
+        {
+          "match": "\\s*(\\([^)]*\\))",
+          "name": "storage.type.matlab"
+        },
+        {
+          "match": "([A-Za-z][.0-9A-Z_a-z]*)",
+          "name": "storage.type.matlab"
+        },
+        {
+          "include": "#braced_validator_list"
+        }
+      ]
+    },
+    "variables": {
+      "match": "(?<!\\.)\\b(nargin|nargout|varargin|varargout)\\b",
+      "name": "variable.other.function.matlab"
+    }
+  },
+  "scopeName": "source.matlab"
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -9,6 +9,8 @@ import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker'
 import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker'
 import { registerAstroLanguage } from './monaco-languages/register-astro'
 import { registerJsonlLanguage } from './monaco-languages/register-jsonl'
+import { registerLatexLanguage } from './monaco-languages/register-latex'
+import { registerMatlabLanguage } from './monaco-languages/register-matlab'
 import { registerNimLanguage } from './monaco-languages/register-nim'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
@@ -78,6 +80,8 @@ registerVueLanguage(monaco)
 registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
+registerMatlabLanguage(monaco)
+registerLatexLanguage(monaco)
 registerJsonlLanguage(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)


### PR DESCRIPTION
## Summary
- Fixes #10363: `.m` and `.tex` (plus common LaTeX family extensions) no longer open as flat plaintext.
- **MATLAB**: TextMate-backed language using the MathWorks grammar (BSD-style license vendored beside the grammar), same registration path as Nim.
- **LaTeX**: presentation-only Monarch tokenizer for comments (`%`), commands, `\begin`/`\end` environments, and math delimiters. Full VS Code LaTeX TextMate pulls many embedded language scopes; Monarch keeps the graph small while covering the reported need.
- `detectLanguage` maps extensions so Monaco picks the new language ids.

## Notes
- `.m` is also used by Objective-C; Orca never mapped it before (plaintext). This change maps `.m` → MATLAB per the issue. We can add content-based sniffing later if Obj-C users need it.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/monaco-languages/register-matlab.test.ts src/renderer/src/lib/monaco-languages/register-latex.test.ts src/renderer/src/lib/language-detect.test.ts` (17 passed)
- [ ] Open a `.m` file → keywords/comments/strings colored
- [ ] Open a `.tex` file → `%` comments and `\commands` colored

## ELI5

MATLAB (.m) and LaTeX (.tex) files opened as plain text with no coloring. They now get syntax highlighting so code and markup are easier to read in the editor.
