### PR TITLE
fix(computer-use): settle Screen Recording trust like Accessibility

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -601,7 +601,7 @@ final class Provider {
         windowIndex: Int?,
         restoreWindow: Bool
     ) throws -> Snapshot {
-        guard accessibilityTrusted() else {
+        guard accessibilityTrustedSettled() else {
             // Why: agents retry failed observations. Only the explicit setup flow
             // should open macOS privacy prompts/settings; runtime calls stay quiet.
             throw ProviderError.coded(
@@ -1018,6 +1018,15 @@ private func accessibilityTrusted() -> Bool {
     AXIsProcessTrusted()
 }
 
+/// One-shot `AXIsProcessTrusted()` lies to fresh processes: tccd answers a
+/// just-spawned helper with `preflight_unknown`/`do_not_cache` before settling
+/// on the real grant (#9458), and every CLI call spawns a fresh helper. Poll
+/// briefly so a real grant is never mistaken for a denial; already-trusted
+/// processes pass on the first probe with no added latency.
+private func accessibilityTrustedSettled() -> Bool {
+    AccessibilityTrustSettling.settle(probe: accessibilityTrusted).settled
+}
+
 private func screenCaptureTrusted() -> Bool {
     CGPreflightScreenCaptureAccess()
 }
@@ -1049,6 +1058,37 @@ private func enableManualAccessibilityIfNeeded(_ appElement: AXUIElement, app: A
 
 private func focusedWindow(appElement: AXUIElement, app: AppDescriptor, visibleWindowCount: Int, allowRecovery: Bool) throws -> AXUIElement {
     let systemWide = AXUIElementCreateSystemWide()
+    if let window = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app) {
+        return window
+    }
+    if allowRecovery {
+        recoverWindow(app)
+        if let window = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app) {
+            return window
+        }
+    }
+    if visibleWindowCount > 0 {
+        // Why: on a fresh helper process AX reads can be denied by tccd's
+        // uncached preflight answer for a moment even though trust is granted
+        // (#9458) — the "visible windows but no accessibility window" state.
+        // Give the AX session time to settle before declaring it broken.
+        var settledWindow: AXUIElement?
+        let outcome = AccessibilityTrustSettling.settle {
+            settledWindow = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app)
+            return settledWindow != nil
+        }
+        if let window = settledWindow, outcome.settled {
+            return window
+        }
+        throw ProviderError.coded(
+            "permission_denied",
+            "app '\(app.name)' has visible windows but no accessibility window (AX reads stayed blocked for \(outcome.waitedMs)ms after retries). macOS Accessibility may need Orca Computer Use toggled off and on again in System Settings."
+        )
+    }
+    throw ProviderError.coded("window_not_found", "app '\(app.name)' has no accessibility window; make sure the app has a visible window, then retry with --restore-window.")
+}
+
+private func lookupUsableWindow(systemWide: AXUIElement, appElement: AXUIElement, app: AppDescriptor) -> AXUIElement? {
     if let window = focusedSystemWindow(systemWide: systemWide, app: app) {
         return window
     }
@@ -1060,27 +1100,7 @@ private func focusedWindow(appElement: AXUIElement, app: AppDescriptor, visibleW
             return window
         }
     }
-    if allowRecovery {
-        recoverWindow(app)
-        if let window = focusedSystemWindow(systemWide: systemWide, app: app) {
-            return window
-        }
-        if let window = copyElement(appElement, kAXFocusedWindowAttribute as String), usableWindow(window) {
-            return window
-        }
-        if let windows = copyArray(appElement, kAXWindowsAttribute as String) {
-            if let window = windows.first(where: usableWindow) {
-                return window
-            }
-        }
-    }
-    let permissionHint = visibleWindowCount > 0
-        ? " The app has visible windows, so macOS Accessibility may need Orca Computer Use toggled off and on again in System Settings."
-        : ""
-    if visibleWindowCount > 0 {
-        throw ProviderError.coded("permission_denied", "app '\(app.name)' has visible windows but no accessibility window.\(permissionHint)")
-    }
-    throw ProviderError.coded("window_not_found", "app '\(app.name)' has no accessibility window; make sure the app has a visible window, then retry with --restore-window.")
+    return nil
 }
 
 private func focusedSystemWindow(systemWide: AXUIElement, app: AppDescriptor) -> AXUIElement? {
@@ -3664,13 +3684,13 @@ private func runPermissionCheck(initialPermission: PermissionKind? = nil) {
 }
 
 private func printPermissionStatus() {
-    let accessibility = accessibilityTrusted() ? "granted" : "not-granted"
+    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
     let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
     print(#"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#)
 }
 
 private func writePermissionStatus(to path: String) {
-    let accessibility = accessibilityTrusted() ? "granted" : "not-granted"
+    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
     let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
     let text = #"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#
     do {

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -619,7 +619,7 @@ final class Provider {
             allowRecovery: restoreWindow
         )
         let focusedTitle = stringAttribute(focused, kAXTitleAttribute as String) ?? app.name
-        let canCaptureScreenshot = includeScreenshot && screenCaptureTrusted()
+        let canCaptureScreenshot = includeScreenshot && screenCaptureTrustedSettled()
         guard let capture = WindowCapture.resolve(
             candidates: windowCandidates,
             titleHint: focusedTitle,
@@ -1029,6 +1029,45 @@ private func accessibilityTrustedSettled() -> Bool {
 
 private func screenCaptureTrusted() -> Bool {
     CGPreflightScreenCaptureAccess()
+}
+
+/// Settles Screen Recording trust for a freshly spawned helper.
+///
+/// Why: `CGPreflightScreenCaptureAccess()` has the same fresh-process
+/// `preflight_unknown` race as Accessibility (stablyai/orca#9458). Users can
+/// already have Screen Recording toggled ON for Orca Computer Use while
+/// one-shot preflight still returns false, so the permission UI keeps asking
+/// them to drag the app into a list it is already in. After preflight settle
+/// fails, attempt one real `CGWindowListCreateImage` capture — that warms
+/// tccd and detects grants that Settings shows but preflight still denies.
+private func screenCaptureTrustedSettled() -> Bool {
+    if AccessibilityTrustSettling.settle(probe: screenCaptureTrusted).settled {
+        return true
+    }
+    if screenCaptureTrustedByCaptureProbe() {
+        return true
+    }
+    return AccessibilityTrustSettling.settle(timeoutMs: 500, probe: screenCaptureTrusted).settled
+}
+
+private func screenCaptureTrustedByCaptureProbe() -> Bool {
+    guard let infos = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]] else {
+        return false
+    }
+    for info in infos {
+        guard let layer = info[kCGWindowLayer as String] as? Int, layer == 0,
+              let number = info[kCGWindowNumber as String] as? NSNumber
+        else {
+            continue
+        }
+        let windowId = CGWindowID(number.uint32Value)
+        if CGWindowListCreateImage(.null, [.optionIncludingWindow], windowId, [.boundsIgnoreFraming]) != nil {
+            return true
+        }
+        // One real capture attempt is enough to settle tccd for this pid.
+        break
+    }
+    return false
 }
 
 private func requestScreenCaptureAccess() -> Bool {
@@ -2735,7 +2774,7 @@ private enum PermissionKind: CaseIterable {
         case .accessibility:
             "Drag Orca Computer Use into the list above to allow Accessibility."
         case .screenshots:
-            "Drag Orca Computer Use into the list above to allow Screenshots."
+            "If Orca Computer Use is already listed and enabled, toggle it off/on, then Quit and reopen Orca. Otherwise drag it into the Screen Recording list."
         }
     }
 
@@ -2769,9 +2808,9 @@ private enum PermissionKind: CaseIterable {
     var isGranted: Bool {
         switch self {
         case .accessibility:
-            accessibilityTrusted()
+            accessibilityTrustedSettled()
         case .screenshots:
-            screenCaptureTrusted()
+            screenCaptureTrustedSettled()
         }
     }
 
@@ -3685,13 +3724,13 @@ private func runPermissionCheck(initialPermission: PermissionKind? = nil) {
 
 private func printPermissionStatus() {
     let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
-    let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
+    let screenshots = screenCaptureTrustedSettled() ? "granted" : "not-granted"
     print(#"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#)
 }
 
 private func writePermissionStatus(to path: String) {
     let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
-    let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
+    let screenshots = screenCaptureTrustedSettled() ? "granted" : "not-granted"
     let text = #"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#
     do {
         try text.write(toFile: path, atomically: true, encoding: .utf8)

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Retries a trust/readability probe until it succeeds or a deadline passes.
+///
+/// Why: tccd answers a freshly spawned helper process with
+/// `preflight_unknown` / `do_not_cache` for a short window after spawn, so the
+/// first Accessibility answers a new process sees can be `denied` even though
+/// the grant is real, flipping to `granted` moments later within the same pid
+/// (stablyai/orca#9458). Every CLI invocation spawns a fresh helper, so a
+/// one-shot check loses that race on every call.
+public enum AccessibilityTrustSettling {
+    public struct Outcome: Equatable {
+        public let settled: Bool
+        public let attempts: Int
+        public let waitedMs: Int
+
+        public init(settled: Bool, attempts: Int, waitedMs: Int) {
+            self.settled = settled
+            self.attempts = attempts
+            self.waitedMs = waitedMs
+        }
+    }
+
+    public static let defaultTimeoutMs = 1500
+    public static let defaultIntervalMs = 100
+
+    /// Probes immediately, then keeps probing on `intervalMs` boundaries until
+    /// `probe` returns true or `timeoutMs` has been spent sleeping. The happy
+    /// path (already trusted) returns after one probe with zero sleeps.
+    public static func settle(
+        timeoutMs: Int = defaultTimeoutMs,
+        intervalMs: Int = defaultIntervalMs,
+        sleepMs: (Int) -> Void = { interval in
+            usleep(useconds_t(interval * 1000))
+        },
+        probe: () -> Bool
+    ) -> Outcome {
+        precondition(intervalMs > 0, "intervalMs must be positive")
+        var attempts = 0
+        var waitedMs = 0
+        while true {
+            attempts += 1
+            if probe() {
+                return Outcome(settled: true, attempts: attempts, waitedMs: waitedMs)
+            }
+            if waitedMs >= timeoutMs {
+                return Outcome(settled: false, attempts: attempts, waitedMs: waitedMs)
+            }
+            let interval = min(intervalMs, timeoutMs - waitedMs)
+            sleepMs(interval)
+            waitedMs += interval
+        }
+    }
+}

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/AccessibilityTrustSettling.swift
@@ -4,10 +4,13 @@ import Foundation
 ///
 /// Why: tccd answers a freshly spawned helper process with
 /// `preflight_unknown` / `do_not_cache` for a short window after spawn, so the
-/// first Accessibility answers a new process sees can be `denied` even though
-/// the grant is real, flipping to `granted` moments later within the same pid
-/// (stablyai/orca#9458). Every CLI invocation spawns a fresh helper, so a
-/// one-shot check loses that race on every call.
+/// first Accessibility / Screen Recording preflight answers a new process sees
+/// can be `denied` even though the grant is real, flipping to `granted` moments
+/// later within the same pid (stablyai/orca#9458). The same race hits
+/// `CGPreflightScreenCaptureAccess()` while System Settings already shows
+/// Screen Recording enabled for Orca Computer Use — one-shot checks then keep
+/// the drag-assistant UI up forever. Every CLI invocation spawns a fresh
+/// helper, so a one-shot check loses that race on every call.
 public enum AccessibilityTrustSettling {
     public struct Outcome: Equatable {
         public let settled: Bool

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AccessibilityTrustSettlingTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/AccessibilityTrustSettlingTests.swift
@@ -1,0 +1,62 @@
+import Testing
+@testable import OrcaComputerUseMacOSCore
+
+@Suite("AccessibilityTrustSettling")
+struct AccessibilityTrustSettlingTests {
+    @Test("already-trusted probe returns immediately with zero waiting")
+    func immediateSuccess() {
+        var sleeps: [Int] = []
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 1500,
+            intervalMs: 100,
+            sleepMs: { sleeps.append($0) },
+            probe: { true }
+        )
+        #expect(outcome == .init(settled: true, attempts: 1, waitedMs: 0))
+        #expect(sleeps.isEmpty)
+    }
+
+    @Test("probe that turns true after a few denials settles with the elapsed wait")
+    func lateGrant() {
+        var calls = 0
+        var sleeps: [Int] = []
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 1500,
+            intervalMs: 100,
+            sleepMs: { sleeps.append($0) },
+            probe: {
+                calls += 1
+                return calls >= 4
+            }
+        )
+        #expect(outcome == .init(settled: true, attempts: 4, waitedMs: 300))
+        #expect(sleeps == [100, 100, 100])
+    }
+
+    @Test("probe that never turns true stops at the timeout")
+    func neverGranted() {
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 1000,
+            intervalMs: 300,
+            sleepMs: { _ in },
+            probe: { false }
+        )
+        #expect(outcome.settled == false)
+        #expect(outcome.waitedMs == 1000)
+        // 4 sleeps (300+300+300+100 clamped) plus the final probe after the last wait.
+        #expect(outcome.attempts == 5)
+    }
+
+    @Test("final interval is clamped so total wait never exceeds the timeout")
+    func clampsFinalInterval() {
+        var sleeps: [Int] = []
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 250,
+            intervalMs: 100,
+            sleepMs: { sleeps.append($0) },
+            probe: { false }
+        )
+        #expect(sleeps == [100, 100, 50])
+        #expect(outcome.waitedMs == 250)
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/ScreenCaptureTrustSettlingTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/ScreenCaptureTrustSettlingTests.swift
@@ -1,0 +1,22 @@
+import Testing
+@testable import OrcaComputerUseMacOSCore
+
+@Suite("ScreenCapture trust settling reuse")
+struct ScreenCaptureTrustSettlingTests {
+    @Test("screen-recording style probes can reuse AccessibilityTrustSettling")
+    func settleReusableForScreenCapturePreflight() {
+        var calls = 0
+        let outcome = AccessibilityTrustSettling.settle(
+            timeoutMs: 500,
+            intervalMs: 100,
+            sleepMs: { _ in },
+            probe: {
+                calls += 1
+                // Simulate CGPreflightScreenCaptureAccess flipping true after warm-up.
+                return calls >= 3
+            }
+        )
+        #expect(outcome.settled == true)
+        #expect(outcome.attempts == 3)
+    }
+}


### PR DESCRIPTION
## Summary

- Settle `CGPreflightScreenCaptureAccess()` with the same fresh-helper retry used for Accessibility (#9458 / #10122).
- If preflight still fails, attempt one real `CGWindowListCreateImage` probe to warm tccd and detect grants that System Settings already shows as enabled.
- Drive `permissions --json`, permission-UI `isGranted`, and screenshot gating through the settled check so the drag-assistant stops looping when Orca Computer Use is already listed/enabled.
- Update Screen Recording drag-assistant copy for the already-listed case.

Fixes / related: #10372 (also related to #9458).

Built on top of #10122 (`AccessibilityTrustSettling`) so both TCC preflight races are covered together.

## Test plan

- [ ] Unit: `ScreenCaptureTrustSettlingTests` + existing `AccessibilityTrustSettlingTests`
- [ ] On macOS with Screen Recording already enabled for Orca Computer Use:
  - `orca computer permissions --json` → `"screenshots": "granted"`
  - permission setup UI does not keep asking to drag an already-listed app
  - `orca computer get-app-state --app com.google.Chrome --json` can capture (or report a non-permission error)
- [ ] On a machine without Screen Recording grant, status still reports `not-granted` and setup UI still guides correctly


Made with [Cursor](https://cursor.com)

## ELI5

macOS Screen Recording permission could look enabled in Settings while Orca still thought it was denied, looping the computer-use assistant. Permission checks now settle like Accessibility, including a real probe when preflight lies.
