### PR TITLE
feat(diff): stage, unstage, and discard whole files from View All Changes

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -555,12 +555,8 @@ export default function CombinedDiffViewer({
     })
     if (remapped) {
       if (remapped.sections !== sectionsRef.current) {
-        const previousSections = sectionsRef.current
-        setSectionHeights((prev) =>
-          remapped.sections.length === previousSections.length
-            ? prev
-            : remapCombinedDiffSectionHeights(prev, remapped.sourceIndexes)
-        )
+        // Why: same length can still permute (area group reorder); always follow sourceIndexes.
+        setSectionHeights((prev) => remapCombinedDiffSectionHeights(prev, remapped.sourceIndexes))
         loadedIndicesRef.current = new Set(
           remapped.sections.flatMap((section, index) => (section.loading ? [] : [index]))
         )

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -25,8 +25,22 @@ import { getDiffCommentLineLabel } from '@/lib/diff-comment-compat'
 import {
   getRuntimeGitBranchDiff,
   getRuntimeGitCommitDiff,
-  getRuntimeGitDiff
+  getRuntimeGitDiff,
+  discardRuntimeGitPath,
+  stageRuntimeGitPath,
+  unstageRuntimeGitPath
 } from '@/runtime/runtime-git-client'
+import {
+  canDiscardStatusEntry,
+  canStageStatusEntry,
+  canUnstageStatusEntry
+} from '@/components/right-sidebar/source-control-entry-actions'
+import { refreshGitStatusForWorktree } from '@/components/right-sidebar/git-status-refresh'
+import {
+  SourceControlDiscardDialog,
+  type PendingDiscardConfirmation
+} from '@/components/right-sidebar/source-control-discard-dialog'
+import { notifyEditorExternalFileChange, requestEditorSaveQuiesce } from './editor-autosave'
 import '@/lib/monaco-setup'
 import { Button } from '@/components/ui/button'
 import {
@@ -46,7 +60,19 @@ import type {
   GitDiffResult,
   GitStatusEntry
 } from '../../../../shared/types'
-import { Check, Copy, MessageSquare, PanelLeftOpen, Sparkles, Trash2, WrapText } from 'lucide-react'
+import {
+  Check,
+  Copy,
+  MessageSquare,
+  Minus,
+  PanelLeftOpen,
+  Plus,
+  Sparkles,
+  Trash,
+  Trash2,
+  Undo2,
+  WrapText
+} from 'lucide-react'
 import { toast } from 'sonner'
 import { DiffSectionItem } from './DiffSectionItem'
 import { DiffNotesSendMenu } from './DiffNotesSendMenu'
@@ -75,6 +101,10 @@ import { getInitialCombinedDiffSectionLoadIndices } from './combined-diff-initia
 import { removeDiffSectionMeasuredHeight } from './diff-section-height-cache'
 import { createCombinedDiffLoadScheduler } from './combined-diff-load-scheduler'
 import { combinedDiffSectionsMatchEntryMetadata } from './combined-diff-section-cache-match'
+import {
+  remapCombinedDiffSectionsForAreaMove,
+  remapCombinedDiffSectionHeights
+} from './combined-diff-section-area-remap'
 import {
   beginCombinedDiffScrollbarDrag,
   type CombinedDiffScrollbarDragCleanup
@@ -124,23 +154,6 @@ function invalidateCombinedDiffCachesForRelativePath(relativePath: string): void
       combinedDiffViewStateCache.delete(key)
     }
   }
-}
-
-function getRetainedResolvedSnapshotEntries(sections: readonly DiffSection[]): GitStatusEntry[] {
-  return sections.flatMap((section) =>
-    section.area === undefined
-      ? []
-      : [
-          {
-            path: section.path,
-            status: section.status as GitStatusEntry['status'],
-            area: section.area,
-            oldPath: section.oldPath,
-            added: section.added,
-            removed: section.removed
-          }
-        ]
-  )
 }
 
 if (typeof window !== 'undefined') {
@@ -414,11 +427,7 @@ export default function CombinedDiffViewer({
       return getCombinedUncommittedEntries(gitStatusEntries, file.combinedAreaFilter)
     }
     // Why: row load-state changes must not rebuild the snapshot list; the ref is consulted only when live Git status changes.
-    return resolveCombinedUncommittedSnapshotEntries(
-      snapshotEntries,
-      gitStatusEntries,
-      getRetainedResolvedSnapshotEntries(sectionsRef.current)
-    )
+    return resolveCombinedUncommittedSnapshotEntries(snapshotEntries, gitStatusEntries)
   }, [snapshotEntries, gitStatusEntries, file.combinedAreaFilter])
   const branchEntries = React.useMemo<GitBranchChangeEntry[]>(() => {
     return getCombinedBranchEntries(file.branchEntriesSnapshot, liveBranchEntries)
@@ -535,6 +544,28 @@ export default function CombinedDiffViewer({
       scrollOffsetRef.current = combinedDiffScrollTopCache.get(viewStateKey) ?? cached.scrollTop
       scrollAnchorRef.current = combinedDiffScrollAnchorCache.get(viewStateKey) ?? null
       latestDomScrollAnchorRef.current = scrollAnchorRef.current
+      return
+    }
+
+    // Why: stage/unstage/discard remaps or drops rows — keep loaded bodies to avoid flicker (#10276).
+    const remapped = remapCombinedDiffSectionsForAreaMove({
+      sections: sectionsRef.current,
+      entries,
+      treeMode
+    })
+    if (remapped) {
+      if (remapped.sections !== sectionsRef.current) {
+        const previousSections = sectionsRef.current
+        setSectionHeights((prev) =>
+          remapped.sections.length === previousSections.length
+            ? prev
+            : remapCombinedDiffSectionHeights(prev, remapped.sourceIndexes)
+        )
+        loadedIndicesRef.current = new Set(
+          remapped.sections.flatMap((section, index) => (section.loading ? [] : [index]))
+        )
+        setSections(remapped.sections)
+      }
       return
     }
 
@@ -1169,6 +1200,109 @@ export default function CombinedDiffViewer({
       openCommitDiff,
       openFile
     ]
+  )
+
+  // Why: whole-file stage/unstage/discard from the combined-diff header (#10276); same APIs as SC.
+  const stagingSectionKeysRef = useRef(new Set<string>())
+  const [pendingDiscard, setPendingDiscard] = useState<PendingDiscardConfirmation | null>(null)
+
+  const refreshWorktreeGitStatus = useCallback(async (): Promise<void> => {
+    const state = useAppStore.getState()
+    const fileSettings = settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId)
+    const worktree = findWorktreeById(state.worktreesByRepo, file.worktreeId)
+    await refreshGitStatusForWorktree({
+      settings: fileSettings,
+      worktreeId: file.worktreeId,
+      worktreePath: file.filePath,
+      connectionId: getCombinedDiffSectionConnectionId(file.worktreeId, file.filePath, '.'),
+      pushTarget: worktree?.pushTarget,
+      deps: {
+        setGitStatus: state.setGitStatus,
+        updateWorktreeGitIdentity: state.updateWorktreeGitIdentity,
+        setUpstreamStatus: state.setUpstreamStatus,
+        fetchUpstreamStatus: state.fetchUpstreamStatus
+      }
+    })
+  }, [file.filePath, file.runtimeEnvironmentId, file.worktreeId])
+
+  const stageOrUnstageSection = useCallback(
+    async (section: DiffSection, action: 'stage' | 'unstage') => {
+      const sectionKey = `${section.area ?? ''}\0${section.path}`
+      if (stagingSectionKeysRef.current.has(sectionKey)) {
+        return
+      }
+      stagingSectionKeysRef.current.add(sectionKey)
+      try {
+        const state = useAppStore.getState()
+        const fileSettings = settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId)
+        const connectionId = getCombinedDiffSectionConnectionId(
+          file.worktreeId,
+          file.filePath,
+          section.path
+        )
+        const context = {
+          settings: fileSettings,
+          worktreeId: file.worktreeId,
+          worktreePath: file.filePath,
+          connectionId
+        }
+        await (action === 'stage'
+          ? stageRuntimeGitPath(context, section.path)
+          : unstageRuntimeGitPath(context, section.path))
+        await refreshWorktreeGitStatus()
+      } catch {
+        // Why: match SC row handlers — failed git ops stay silent here.
+      } finally {
+        stagingSectionKeysRef.current.delete(sectionKey)
+      }
+    },
+    [file.filePath, file.runtimeEnvironmentId, file.worktreeId, refreshWorktreeGitStatus]
+  )
+
+  const discardSection = useCallback(
+    async (entry: GitStatusEntry) => {
+      const sectionKey = `discard\0${entry.path}`
+      if (stagingSectionKeysRef.current.has(sectionKey)) {
+        return
+      }
+      stagingSectionKeysRef.current.add(sectionKey)
+      try {
+        const state = useAppStore.getState()
+        const fileSettings = settingsForRuntimeOwner(state.settings, file.runtimeEnvironmentId)
+        const connectionId = getCombinedDiffSectionConnectionId(
+          file.worktreeId,
+          file.filePath,
+          entry.path
+        )
+        await requestEditorSaveQuiesce({
+          worktreeId: file.worktreeId,
+          worktreePath: file.filePath,
+          relativePath: entry.path,
+          runtimeEnvironmentId: file.runtimeEnvironmentId
+        })
+        await discardRuntimeGitPath(
+          {
+            settings: fileSettings,
+            worktreeId: file.worktreeId,
+            worktreePath: file.filePath,
+            connectionId
+          },
+          entry.path
+        )
+        notifyEditorExternalFileChange({
+          worktreeId: file.worktreeId,
+          worktreePath: file.filePath,
+          relativePath: entry.path,
+          runtimeEnvironmentId: file.runtimeEnvironmentId
+        })
+        await refreshWorktreeGitStatus()
+      } catch {
+        // Why: match SC row handlers — failed git ops stay silent here.
+      } finally {
+        stagingSectionKeysRef.current.delete(sectionKey)
+      }
+    },
+    [file.filePath, file.runtimeEnvironmentId, file.worktreeId, refreshWorktreeGitStatus]
   )
 
   const handleSectionSave = useCallback(
@@ -1919,16 +2053,109 @@ export default function CombinedDiffViewer({
                           const fileNotes = diffCommentsForWorktree.filter(
                             (comment) => comment.filePath === section.path
                           )
-                          return fileNotes.length > 0 ? (
-                            <DiffNotesSendMenu
-                              worktreeId={file.worktreeId}
-                              groupId={activeGroupId ?? file.worktreeId}
-                              comments={diffCommentsForWorktree}
-                              filePath={section.path}
-                              showFileScope
-                              triggerClassName="p-0.5 can-hover:opacity-0 group-hover:opacity-100"
-                            />
-                          ) : null
+                          const liveEntry =
+                            section.area === undefined
+                              ? undefined
+                              : gitStatusEntries.find(
+                                  (entry) =>
+                                    entry.path === section.path && entry.area === section.area
+                                )
+                          const canDiscard = liveEntry ? canDiscardStatusEntry(liveEntry) : false
+                          const canStage = liveEntry ? canStageStatusEntry(liveEntry) : false
+                          const canUnstage = liveEntry ? canUnstageStatusEntry(liveEntry) : false
+                          const discardTitle = !liveEntry
+                            ? ''
+                            : liveEntry.area === 'untracked'
+                              ? translate(
+                                  'auto.components.right.sidebar.SourceControl.11463f7a98',
+                                  'Delete untracked file'
+                                )
+                              : liveEntry.status === 'deleted'
+                                ? translate(
+                                    'auto.components.right.sidebar.SourceControl.989f3d5e34',
+                                    'Restore file'
+                                  )
+                                : translate(
+                                    'auto.components.right.sidebar.SourceControl.d54dd48b0b',
+                                    'Discard changes'
+                                  )
+                          const notesMenu =
+                            fileNotes.length > 0 ? (
+                              <DiffNotesSendMenu
+                                worktreeId={file.worktreeId}
+                                groupId={activeGroupId ?? file.worktreeId}
+                                comments={diffCommentsForWorktree}
+                                filePath={section.path}
+                                showFileScope
+                                triggerClassName="p-0.5 can-hover:opacity-0 group-hover:opacity-100"
+                              />
+                            ) : null
+                          if (!canDiscard && !canStage && !canUnstage && !notesMenu) {
+                            return null
+                          }
+                          return (
+                            <>
+                              {canDiscard && liveEntry && (
+                                <button
+                                  type="button"
+                                  className="p-0.5 rounded text-muted-foreground hover:text-foreground can-hover:opacity-0 group-hover:opacity-100 transition-opacity"
+                                  title={discardTitle}
+                                  aria-label={discardTitle}
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    setPendingDiscard({ kind: 'entry', entry: liveEntry })
+                                  }}
+                                >
+                                  {liveEntry.area === 'untracked' ? (
+                                    <Trash className="size-3.5" />
+                                  ) : (
+                                    <Undo2 className="size-3.5" />
+                                  )}
+                                </button>
+                              )}
+                              {canStage && (
+                                <button
+                                  type="button"
+                                  className="p-0.5 rounded text-muted-foreground hover:text-foreground can-hover:opacity-0 group-hover:opacity-100 transition-opacity"
+                                  title={translate(
+                                    'auto.components.right.sidebar.SourceControl.8cde1a2fb0',
+                                    'Stage'
+                                  )}
+                                  aria-label={translate(
+                                    'auto.components.right.sidebar.SourceControl.8cde1a2fb0',
+                                    'Stage'
+                                  )}
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    void stageOrUnstageSection(section, 'stage')
+                                  }}
+                                >
+                                  <Plus className="size-3.5" />
+                                </button>
+                              )}
+                              {canUnstage && (
+                                <button
+                                  type="button"
+                                  className="p-0.5 rounded text-muted-foreground hover:text-foreground can-hover:opacity-0 group-hover:opacity-100 transition-opacity"
+                                  title={translate(
+                                    'auto.components.right.sidebar.SourceControl.df5040e3c3',
+                                    'Unstage'
+                                  )}
+                                  aria-label={translate(
+                                    'auto.components.right.sidebar.SourceControl.df5040e3c3',
+                                    'Unstage'
+                                  )}
+                                  onClick={(event) => {
+                                    event.stopPropagation()
+                                    void stageOrUnstageSection(section, 'unstage')
+                                  }}
+                                >
+                                  <Minus className="size-3.5" />
+                                </button>
+                              )}
+                              {notesMenu}
+                            </>
+                          )
                         }}
                       />
                     </div>
@@ -1952,6 +2179,17 @@ export default function CombinedDiffViewer({
           </div>
         </div>
       </div>
+      <SourceControlDiscardDialog
+        pendingDiscard={pendingDiscard}
+        onCancel={() => setPendingDiscard(null)}
+        onConfirm={() => {
+          const pending = pendingDiscard
+          setPendingDiscard(null)
+          if (pending?.kind === 'entry') {
+            void discardSection(pending.entry)
+          }
+        }}
+      />
       <Dialog
         open={clearNotesDialogVisible}
         onOpenChange={(open) => {

--- a/src/renderer/src/components/editor/combined-diff-entries.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-entries.test.ts
@@ -92,14 +92,17 @@ describe('resolveCombinedUncommittedSnapshotEntries', () => {
     )
   })
 
-  it('keeps a retained resolved area when live status no longer includes the path', () => {
+  it('drops snapshot rows when live status no longer includes the path', () => {
     const snapshotEntries: GitStatusEntry[] = [
-      { path: 'src/file.ts', status: 'modified', area: 'unstaged' }
+      { path: 'src/file.ts', status: 'modified', area: 'unstaged' },
+      { path: 'src/keep.ts', status: 'modified', area: 'staged' }
     ]
-    const retained: GitStatusEntry[] = [{ path: 'src/file.ts', status: 'modified', area: 'staged' }]
+    const liveEntries: GitStatusEntry[] = [
+      { path: 'src/keep.ts', status: 'modified', area: 'staged' }
+    ]
 
-    expect(resolveCombinedUncommittedSnapshotEntries(snapshotEntries, [], retained)).toEqual([
-      { path: 'src/file.ts', status: 'modified', area: 'staged' }
+    expect(resolveCombinedUncommittedSnapshotEntries(snapshotEntries, liveEntries)).toEqual([
+      { path: 'src/keep.ts', status: 'modified', area: 'staged' }
     ])
   })
 
@@ -127,45 +130,6 @@ describe('resolveCombinedUncommittedSnapshotEntries', () => {
         added: 3,
         removed: 1
       }
-    ])
-  })
-
-  it('keeps retained staged and unstaged sections distinct when live status disappears', () => {
-    const snapshotEntries: GitStatusEntry[] = [
-      { path: 'src/file.ts', status: 'modified', area: 'staged', added: 4 },
-      { path: 'src/file.ts', status: 'modified', area: 'unstaged', added: 2 }
-    ]
-    const retained: GitStatusEntry[] = [
-      { path: 'src/file.ts', status: 'modified', area: 'staged' },
-      { path: 'src/file.ts', status: 'modified', area: 'unstaged' }
-    ]
-
-    expect(resolveCombinedUncommittedSnapshotEntries(snapshotEntries, [], retained)).toEqual(
-      snapshotEntries
-    )
-  })
-
-  it('does not remap duplicate-path snapshots to a retained fallback area', () => {
-    const snapshotEntries: GitStatusEntry[] = [
-      { path: 'src/file.ts', status: 'modified', area: 'staged', added: 4 },
-      { path: 'src/file.ts', status: 'modified', area: 'unstaged', added: 2 }
-    ]
-    const retained: GitStatusEntry[] = [{ path: 'src/file.ts', status: 'modified', area: 'staged' }]
-
-    expect(resolveCombinedUncommittedSnapshotEntries(snapshotEntries, [], retained)).toEqual([
-      { path: 'src/file.ts', status: 'modified', area: 'staged', added: 4 }
-    ])
-  })
-
-  it('does not let a retained stale area duplicate an original target area', () => {
-    const snapshotEntries: GitStatusEntry[] = [
-      { path: 'src/file.ts', status: 'modified', area: 'unstaged', added: 2 },
-      { path: 'src/file.ts', status: 'modified', area: 'staged', added: 4 }
-    ]
-    const retained: GitStatusEntry[] = [{ path: 'src/file.ts', status: 'modified', area: 'staged' }]
-
-    expect(resolveCombinedUncommittedSnapshotEntries(snapshotEntries, [], retained)).toEqual([
-      { path: 'src/file.ts', status: 'modified', area: 'staged', added: 4 }
     ])
   })
 

--- a/src/renderer/src/components/editor/combined-diff-entries.ts
+++ b/src/renderer/src/components/editor/combined-diff-entries.ts
@@ -21,11 +21,9 @@ export function getCombinedUncommittedEntries(
 
 export function resolveCombinedUncommittedSnapshotEntries(
   snapshotEntries: readonly GitStatusEntry[],
-  liveEntries: readonly GitStatusEntry[],
-  retainedResolvedEntries: readonly GitStatusEntry[] = []
+  liveEntries: readonly GitStatusEntry[]
 ): GitStatusEntry[] {
   const liveEntriesByPath = getGitStatusEntriesByPath(liveEntries)
-  const retainedEntriesByPath = getGitStatusEntriesByPath(retainedResolvedEntries)
   const snapshotAreaKeys = new Set(snapshotEntries.map(getUncommittedAreaPathKey))
   const resolvedEntries: GitStatusEntry[] = []
   const resolvedAreaKeys = new Set<string>()
@@ -45,17 +43,12 @@ export function resolveCombinedUncommittedSnapshotEntries(
       continue
     }
 
-    const retainedPathEntries = retainedEntriesByPath.get(snapshotEntry.path) ?? []
-    if (
-      livePathEntries.length === 0 &&
-      retainedPathEntries.some((retainedEntry) => retainedEntry.area === snapshotEntry.area)
-    ) {
-      pushResolvedEntry(snapshotEntry)
+    // Why: discard/delete/commit removed the path — don't keep an empty ghost row.
+    if (livePathEntries.length === 0) {
       continue
     }
 
-    const movedEntry =
-      livePathEntries[0] ?? (retainedPathEntries.length === 1 ? retainedPathEntries[0] : undefined)
+    const movedEntry = livePathEntries[0]
     if (!movedEntry || movedEntry.area === snapshotEntry.area) {
       pushResolvedEntry(snapshotEntry)
       continue

--- a/src/renderer/src/components/editor/combined-diff-entries.ts
+++ b/src/renderer/src/components/editor/combined-diff-entries.ts
@@ -19,6 +19,13 @@ export function getCombinedUncommittedEntries(
   })
 }
 
+/**
+ * Resolve a tab-open uncommitted snapshot against live git status.
+ *
+ * Keeps snapshot rows whose area still exists, remaps a row when its path only
+ * remains in another area (stage/unstage), and drops paths gone from live status
+ * (discard/delete/commit) so the combined view does not keep ghost sections.
+ */
 export function resolveCombinedUncommittedSnapshotEntries(
   snapshotEntries: readonly GitStatusEntry[],
   liveEntries: readonly GitStatusEntry[]
@@ -100,6 +107,12 @@ function getUncommittedAreaPathKey(entry: Pick<GitStatusEntry, 'area' | 'path'>)
   return `${entry.area}\0${entry.path}`
 }
 
+/**
+ * Prefer an explicit branch-diff snapshot over live entries.
+ *
+ * An empty snapshot stays empty so a tab opened with no files does not drift
+ * when later Source Control refreshes populate live branch changes.
+ */
 export function getCombinedBranchEntries(
   snapshotEntries: readonly GitBranchChangeEntry[] | undefined,
   liveEntries: readonly GitBranchChangeEntry[]
@@ -109,6 +122,12 @@ export function getCombinedBranchEntries(
   return [...(snapshotEntries ?? liveEntries)]
 }
 
+/**
+ * Whether combined-diff should rebuild section content from live git status.
+ *
+ * Only non-snapshot uncommitted tabs auto-reload; snapshot-backed tabs keep the
+ * tab-open file list and rely on targeted remaps / editor-write reloads instead.
+ */
 export function shouldAutoReloadCombinedDiffFromGitStatus({
   mode,
   hasUncommittedEntriesSnapshot

--- a/src/renderer/src/components/editor/combined-diff-file-tree-model.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-model.ts
@@ -27,9 +27,21 @@ export function getCombinedDiffFileTreeSectionKey(
 }
 
 export function createCombinedDiffSectionIndexMap(
-  sections: readonly { key: string }[]
+  sections: readonly { key: string; path?: string; area?: string }[]
 ): Map<string, number> {
-  return new Map(sections.map((section, index) => [section.key, index]))
+  const map = new Map<string, number>()
+  for (let index = 0; index < sections.length; index += 1) {
+    const section = sections[index]
+    if (!section) {
+      continue
+    }
+    map.set(section.key, index)
+    // Why: stage/unstage keeps the original key for Monaco identity while area updates.
+    if (section.area && section.path) {
+      map.set(`${section.area}:${section.path}`, index)
+    }
+  }
+  return map
 }
 
 export function getCombinedDiffFileTreeNavigationIndex({

--- a/src/renderer/src/components/editor/combined-diff-file-tree-model.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-model.ts
@@ -26,6 +26,12 @@ export function getCombinedDiffFileTreeSectionKey(
   return `${mode === 'commit' ? 'combined-commit' : 'combined-branch'}:${entry.path}`
 }
 
+/**
+ * Build section lookup keys for the combined-diff file tree.
+ *
+ * Indexes by stable Monaco section `key` and by `area:path` so navigation still
+ * finds a row after stage/unstage updates `area` without rewriting the key.
+ */
 export function createCombinedDiffSectionIndexMap(
   sections: readonly { key: string; path?: string; area?: string }[]
 ): Map<string, number> {

--- a/src/renderer/src/components/editor/combined-diff-section-area-remap.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-area-remap.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import type { GitStatusEntry } from '../../../../shared/types'
+import type { DiffSection } from './diff-section-types'
+import {
+  remapCombinedDiffSectionHeights,
+  remapCombinedDiffSectionsForAreaMove
+} from './combined-diff-section-area-remap'
+
+function section(overrides: Partial<DiffSection>): DiffSection {
+  return {
+    key: 'unstaged:src/file.ts',
+    path: 'src/file.ts',
+    status: 'modified',
+    area: 'unstaged',
+    originalContent: 'old',
+    modifiedContent: 'new',
+    collapsed: false,
+    loading: false,
+    dirty: false,
+    diffResult: { kind: 'text', originalContent: 'old', modifiedContent: 'new' },
+    largeDiffRenderLimit: null,
+    ...overrides
+  }
+}
+
+describe('remapCombinedDiffSectionsForAreaMove', () => {
+  it('keeps loaded content and stable key when only area moves', () => {
+    const entry: GitStatusEntry = {
+      path: 'src/file.ts',
+      status: 'modified',
+      area: 'staged',
+      added: 2,
+      removed: 1
+    }
+    const existing = section({ added: 2, removed: 1 })
+
+    expect(
+      remapCombinedDiffSectionsForAreaMove({
+        sections: [existing],
+        entries: [entry],
+        treeMode: 'all'
+      })
+    ).toEqual({
+      sections: [
+        {
+          ...existing,
+          key: 'unstaged:src/file.ts',
+          area: 'staged',
+          added: 2,
+          removed: 1
+        }
+      ],
+      sourceIndexes: [0]
+    })
+  })
+
+  it('drops removed paths while keeping remaining loaded sections', () => {
+    const keep = section({
+      key: 'staged:src/keep.ts',
+      path: 'src/keep.ts',
+      area: 'staged',
+      originalContent: 'keep-old',
+      modifiedContent: 'keep-new'
+    })
+    const gone = section({
+      key: 'untracked:src/gone.ts',
+      path: 'src/gone.ts',
+      area: 'untracked',
+      status: 'untracked'
+    })
+    const keepEntry: GitStatusEntry = {
+      path: 'src/keep.ts',
+      status: 'modified',
+      area: 'staged'
+    }
+
+    expect(
+      remapCombinedDiffSectionsForAreaMove({
+        sections: [gone, keep],
+        entries: [keepEntry],
+        treeMode: 'all'
+      })
+    ).toEqual({
+      sections: [keep],
+      sourceIndexes: [1]
+    })
+  })
+
+  it('returns the same sections reference when metadata is unchanged', () => {
+    const entry: GitStatusEntry = {
+      path: 'src/file.ts',
+      status: 'modified',
+      area: 'unstaged',
+      added: 2,
+      removed: 1
+    }
+    const existing = section({ added: 2, removed: 1 })
+    const sections = [existing]
+
+    const remapped = remapCombinedDiffSectionsForAreaMove({
+      sections,
+      entries: [entry],
+      treeMode: 'all'
+    })
+    expect(remapped?.sections).toBe(sections)
+  })
+
+  it('returns null when a new path appears', () => {
+    const entry: GitStatusEntry = {
+      path: 'src/other.ts',
+      status: 'modified',
+      area: 'staged'
+    }
+
+    expect(
+      remapCombinedDiffSectionsForAreaMove({
+        sections: [section({})],
+        entries: [entry],
+        treeMode: 'all'
+      })
+    ).toBeNull()
+  })
+})
+
+describe('remapCombinedDiffSectionHeights', () => {
+  it('reindexes heights after a removal', () => {
+    expect(remapCombinedDiffSectionHeights({ 0: 120, 1: 340, 2: 50 }, [1, 2])).toEqual({
+      0: 340,
+      1: 50
+    })
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-section-area-remap.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-area-remap.test.ts
@@ -17,7 +17,13 @@ function section(overrides: Partial<DiffSection>): DiffSection {
     collapsed: false,
     loading: false,
     dirty: false,
-    diffResult: { kind: 'text', originalContent: 'old', modifiedContent: 'new' },
+    diffResult: {
+      kind: 'text',
+      originalContent: 'old',
+      modifiedContent: 'new',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    },
     largeDiffRenderLimit: null,
     ...overrides
   }
@@ -120,6 +126,65 @@ describe('remapCombinedDiffSectionsForAreaMove', () => {
       })
     ).toBeNull()
   })
+
+  it('permutes sourceIndexes when an area move reorders without changing count', () => {
+    const stagedB = section({
+      key: 'staged:src/b.ts',
+      path: 'src/b.ts',
+      area: 'staged',
+      originalContent: 'b-old',
+      modifiedContent: 'b-new'
+    })
+    const stagedD = section({
+      key: 'staged:src/d.ts',
+      path: 'src/d.ts',
+      area: 'staged',
+      originalContent: 'd-old',
+      modifiedContent: 'd-new'
+    })
+    const unstagedA = section({
+      key: 'unstaged:src/a.ts',
+      path: 'src/a.ts',
+      area: 'unstaged',
+      originalContent: 'a-old',
+      modifiedContent: 'a-new'
+    })
+    const unstagedC = section({
+      key: 'unstaged:src/c.ts',
+      path: 'src/c.ts',
+      area: 'unstaged',
+      originalContent: 'c-old',
+      modifiedContent: 'c-new'
+    })
+    const entries: GitStatusEntry[] = [
+      { path: 'src/a.ts', status: 'modified', area: 'staged' },
+      { path: 'src/b.ts', status: 'modified', area: 'staged' },
+      { path: 'src/d.ts', status: 'modified', area: 'staged' },
+      { path: 'src/c.ts', status: 'modified', area: 'unstaged' }
+    ]
+
+    const remapped = remapCombinedDiffSectionsForAreaMove({
+      sections: [stagedB, stagedD, unstagedA, unstagedC],
+      entries,
+      treeMode: 'all'
+    })
+
+    expect(remapped?.sourceIndexes).toEqual([2, 0, 1, 3])
+    expect(remapped?.sections.map((row) => row.path)).toEqual([
+      'src/a.ts',
+      'src/b.ts',
+      'src/d.ts',
+      'src/c.ts'
+    ])
+    expect(remapped?.sections[0]).toMatchObject({
+      key: 'unstaged:src/a.ts',
+      area: 'staged',
+      modifiedContent: 'a-new'
+    })
+    expect(
+      remapCombinedDiffSectionHeights({ 0: 100, 1: 200, 2: 300, 3: 400 }, remapped!.sourceIndexes)
+    ).toEqual({ 0: 300, 1: 100, 2: 200, 3: 400 })
+  })
 })
 
 describe('remapCombinedDiffSectionHeights', () => {
@@ -127,6 +192,17 @@ describe('remapCombinedDiffSectionHeights', () => {
     expect(remapCombinedDiffSectionHeights({ 0: 120, 1: 340, 2: 50 }, [1, 2])).toEqual({
       0: 340,
       1: 50
+    })
+  })
+
+  it('reindexes heights for a same-length permutation', () => {
+    expect(
+      remapCombinedDiffSectionHeights({ 0: 100, 1: 200, 2: 300, 3: 400 }, [2, 0, 1, 3])
+    ).toEqual({
+      0: 300,
+      1: 100,
+      2: 200,
+      3: 400
     })
   })
 })

--- a/src/renderer/src/components/editor/combined-diff-section-area-remap.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-area-remap.ts
@@ -10,7 +10,13 @@ export type RemappedCombinedDiffSections = {
 
 /**
  * Remap loaded sections onto the current entry list (area moves + removals).
- * Keeps Monaco bodies/keys stable. Returns null when a new path appears.
+ *
+ * Matches by path (preferring same area, then any area) so Monaco bodies and
+ * section keys stay stable across stage/unstage. Builds `sourceIndexes` in the
+ * new `entries` order so measured heights can follow permutations.
+ *
+ * @returns Remapped sections + prior indexes, or `null` when a new path appears
+ *   (caller should rebuild from scratch).
  */
 export function remapCombinedDiffSectionsForAreaMove({
   sections,
@@ -95,6 +101,13 @@ export function remapCombinedDiffSectionsForAreaMove({
   return { sections: remapped, sourceIndexes }
 }
 
+/**
+ * Reindex measured section heights to match a remapped row order.
+ *
+ * `sourceIndexes[i]` is the previous section index that now sits at `i`, so
+ * height at the old index moves with the row even when length is unchanged
+ * (same-length area-group permutations from stage/unstage).
+ */
 export function remapCombinedDiffSectionHeights(
   previousHeights: Record<number, number>,
   sourceIndexes: readonly number[]

--- a/src/renderer/src/components/editor/combined-diff-section-area-remap.ts
+++ b/src/renderer/src/components/editor/combined-diff-section-area-remap.ts
@@ -1,0 +1,114 @@
+import type { GitBranchChangeEntry, GitStatusEntry } from '../../../../shared/types'
+import type { CombinedDiffFileTreeMode } from './combined-diff-file-tree-model'
+import type { DiffSection } from './diff-section-types'
+
+export type RemappedCombinedDiffSections = {
+  sections: DiffSection[]
+  /** Previous section index for each remapped row; used to keep measured heights. */
+  sourceIndexes: number[]
+}
+
+/**
+ * Remap loaded sections onto the current entry list (area moves + removals).
+ * Keeps Monaco bodies/keys stable. Returns null when a new path appears.
+ */
+export function remapCombinedDiffSectionsForAreaMove({
+  sections,
+  entries
+}: {
+  sections: readonly DiffSection[]
+  entries: readonly (GitStatusEntry | GitBranchChangeEntry)[]
+  treeMode: CombinedDiffFileTreeMode
+}): RemappedCombinedDiffSections | null {
+  if (sections.length === 0) {
+    return entries.length === 0 ? { sections: sections as DiffSection[], sourceIndexes: [] } : null
+  }
+
+  const usedSectionIndexes = new Set<number>()
+  const remapped: DiffSection[] = []
+  const sourceIndexes: number[] = []
+  let changed = sections.length !== entries.length
+
+  for (const entry of entries) {
+    const entryArea = 'area' in entry ? entry.area : undefined
+    const entryAdded = 'added' in entry ? entry.added : undefined
+    const entryRemoved = 'removed' in entry ? entry.removed : undefined
+
+    let matchIndex = -1
+    for (let index = 0; index < sections.length; index += 1) {
+      if (usedSectionIndexes.has(index)) {
+        continue
+      }
+      const section = sections[index]
+      if (section && section.path === entry.path && section.area === entryArea) {
+        matchIndex = index
+        break
+      }
+    }
+    if (matchIndex < 0) {
+      for (let index = 0; index < sections.length; index += 1) {
+        if (usedSectionIndexes.has(index)) {
+          continue
+        }
+        const section = sections[index]
+        if (section && section.path === entry.path) {
+          matchIndex = index
+          break
+        }
+      }
+    }
+    if (matchIndex < 0) {
+      return null
+    }
+
+    usedSectionIndexes.add(matchIndex)
+    const section = sections[matchIndex]
+    if (!section) {
+      return null
+    }
+    sourceIndexes.push(matchIndex)
+
+    if (
+      section.status !== entry.status ||
+      section.area !== entryArea ||
+      section.oldPath !== entry.oldPath ||
+      section.added !== entryAdded ||
+      section.removed !== entryRemoved
+    ) {
+      changed = true
+      remapped.push({
+        ...section,
+        status: entry.status,
+        area: entryArea,
+        oldPath: entry.oldPath,
+        added: entryAdded,
+        removed: entryRemoved
+      })
+      continue
+    }
+    remapped.push(section)
+  }
+
+  if (!changed) {
+    return { sections: sections as DiffSection[], sourceIndexes }
+  }
+  return { sections: remapped, sourceIndexes }
+}
+
+export function remapCombinedDiffSectionHeights(
+  previousHeights: Record<number, number>,
+  sourceIndexes: readonly number[]
+): Record<number, number> {
+  const next: Record<number, number> = {}
+  for (let index = 0; index < sourceIndexes.length; index += 1) {
+    const sourceIndex = sourceIndexes[index]
+    if (sourceIndex === undefined) {
+      continue
+    }
+    const height = previousHeights[sourceIndex]
+    if (height !== undefined) {
+      next[index] = height
+    }
+  }
+  return next
+}


### PR DESCRIPTION
Expose Source Control whole-file actions on combined-diff section headers, and remap/drop sections in place so status changes do not flicker or leave ghost rows.

## Summary

- Adds **Stage**, **Unstage**, and **Discard** (whole file) on each uncommitted file section header in **View All Changes**, so you can review → act without leaving the combined diff for the Source Control sidebar.
- Reuses the same runtime git APIs and eligibility gates as Source Control (`canStage` / `canUnstage` / `canDiscard`, including conflict and submodule cases).
- After mutations, refreshes git status and **remaps or drops** existing sections in place (keeps loaded Monaco bodies/heights) instead of rebuilding the list, so staging/unstaging does not flicker and discarded paths do not leave ghost rows.
- Fixes snapshot resolution so paths removed from live status (discard/delete/commit) are dropped rather than retained as empty rows.

## Screenshots


https://github.com/user-attachments/assets/97def815-209e-43d0-a8c4-dd5b7fbf5075



## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - Added `combined-diff-section-area-remap.test.ts` for area move / drop / height remapping.
  - Updated snapshot-entry resolution tests in `combined-diff-entries.test.ts` for drop-on-remove behavior.

## AI Review Report

Reviewed the combined-diff header actions and section remapping path for #10276.

**Risks checked**
- Reuse of SC stage/unstage/discard APIs vs inventing a second git path
- Eligibility gating (conflicts, submodule / worktree-only rows) matching Source Control
- Local + SSH/runtime routing via `settingsForRuntimeOwner` and `getCombinedDiffSectionConnectionId`
- UI flicker / ghost rows after area moves or discard (section remap + snapshot drop)
- Discard confirmation + save quiesce before restoring/deleting working-tree content
- Double-click / in-flight mutation races on the same section key

**Cross-platform**
- macOS / Linux / Windows: no new hardcoded shortcuts or platform-specific accelerator labels; actions are header buttons with shared Stage/Unstage/Discard copy.
- Paths: section paths still go through existing `joinPath` / connection-id resolution (folder workspaces + SSH child repos).
- Shell / Electron: no new shell or OS process spawning; mutations stay on existing `window.api.git` / runtime RPC `git.stage` / `git.unstage` / discard paths.
- No platform-specific Electron menu or path-separator changes in this PR.

**Outcome**
- Confirmed header actions call the same runtime clients as SC and refresh status afterward.
- Confirmed remap keeps section identity across area moves and drops removed paths instead of retaining ghosts.
- No remaining review findings blocking merge from this pass.

## Security Audit

- **Command execution:** No new git subcommands; uses existing `git add` / `git restore --staged` / discard paths already exposed for Source Control.
- **Path handling:** File paths come from git status entries already shown in the UI; still passed through existing literal pathspec / connection scoping helpers (including folder-workspace SSH child-repo routing).
- **IPC / auth / secrets:** No new IPC channels, auth surfaces, or secret handling; no dependency additions.
- **Destructive action:** Discard reuses the shared confirmation dialog and editor save quiesce before mutating the working tree.
- **Follow-up:** None required for this change set beyond normal PR CI.

## Notes

- Closes #10276 (whole-file stage/unstage from View All Changes). Discard on the header is included for parity with Source Control row actions.
- Not hunk/line staging (tracked separately).
- Works for local and SSH/runtime worktrees by reusing existing stage/unstage/discard + status refresh plumbing.
- Manual check: open View All Changes → Stage/Unstage a file from the header → confirm it moves without flicker; Discard an unstaged file → confirm confirmation dialog + row removal with no ghost section.


Made with [Cursor](https://cursor.com)

## ELI5

In View All Changes you can Stage, Unstage, or Discard whole files from each file header without going back to the Source Control sidebar. The combined diff updates in place without flicker or ghost rows.
