### PR TITLE
fix(browser): emulate CDP page focus for rich-editor insertText

### DIFF
--- a/src/main/browser/cdp-bridge-integration.test.ts
+++ b/src/main/browser/cdp-bridge-integration.test.ts
@@ -352,6 +352,13 @@ describe('Browser automation pipeline (integration)', () => {
       name: 'More information...'
     })
     expect(activeGuest.debugger.attach).toHaveBeenCalledTimes(1)
+    expect(
+      activeGuestHarness.sendCommandMock.mock.calls.some(
+        ([method, params]) =>
+          method === 'Emulation.setFocusEmulationEnabled' &&
+          JSON.stringify(params) === JSON.stringify({ enabled: true })
+      )
+    ).toBe(true)
   })
 
   it('preserves debugger listeners owned by other browser streams', async () => {

--- a/src/main/browser/cdp-bridge.ts
+++ b/src/main/browser/cdp-bridge.ts
@@ -48,6 +48,7 @@ import {
 import { insertTextThroughCdp } from './browser-text-insertion'
 import type { BrowserManager } from './browser-manager'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
+import { enableCdpFocusEmulation } from './cdp-focus-emulation'
 
 const CAPTURE_LOG_LIMIT = 1000
 
@@ -1161,6 +1162,14 @@ export class CdpBridge {
     await sender('Page.addScriptToEvaluateOnNewDocument', {
       source: ANTI_DETECTION_SCRIPT
     })
+
+    // Why: keep document.hasFocus() true for guest views that are not the OS
+    // first responder so rich-editor insertText/fill paths commit (#10375).
+    try {
+      await enableCdpFocusEmulation(sender)
+    } catch {
+      /* best-effort */
+    }
 
     // Why: only remove this bridge's listeners; screencast/proxy sessions share the debugger and own their teardown.
     this.removeDebuggerListeners(guest, state)

--- a/src/main/browser/cdp-focus-emulation.test.ts
+++ b/src/main/browser/cdp-focus-emulation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CDP_FOCUS_EMULATION_METHOD, enableCdpFocusEmulation } from './cdp-focus-emulation'
+
+describe('enableCdpFocusEmulation', () => {
+  it('enables Emulation.setFocusEmulationEnabled over CDP', async () => {
+    const send = vi.fn(async () => ({}))
+
+    await enableCdpFocusEmulation(send)
+
+    expect(send).toHaveBeenCalledWith(CDP_FOCUS_EMULATION_METHOD, { enabled: true })
+  })
+})

--- a/src/main/browser/cdp-focus-emulation.test.ts
+++ b/src/main/browser/cdp-focus-emulation.test.ts
@@ -9,4 +9,20 @@ describe('enableCdpFocusEmulation', () => {
 
     expect(send).toHaveBeenCalledWith(CDP_FOCUS_EMULATION_METHOD, { enabled: true })
   })
+
+  it('bounds a stalled debugger command', async () => {
+    vi.useFakeTimers()
+    try {
+      const send = vi.fn(() => new Promise<unknown>(() => {}))
+      const result = enableCdpFocusEmulation(send)
+      const expectation = expect(result).rejects.toThrow('CDP focus emulation timed out')
+
+      await vi.advanceTimersByTimeAsync(5_000)
+
+      await expectation
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/browser/cdp-focus-emulation.ts
+++ b/src/main/browser/cdp-focus-emulation.ts
@@ -1,0 +1,17 @@
+/**
+ * CDP focus emulation so `document.hasFocus()` reports true even when the
+ * guest WebContents is not the OS first responder (Electron 43+ / multi-view).
+ *
+ * Required for rich editors (Draft.js, etc.) that gate Input.insertText and
+ * execCommand on frame focus — see #10375 / regression of #7035.
+ */
+export const CDP_FOCUS_EMULATION_METHOD = 'Emulation.setFocusEmulationEnabled' as const
+
+export type CdpFocusEmulationSender = (
+  method: string,
+  params?: Record<string, unknown>
+) => Promise<unknown>
+
+export async function enableCdpFocusEmulation(send: CdpFocusEmulationSender): Promise<void> {
+  await send(CDP_FOCUS_EMULATION_METHOD, { enabled: true })
+}

--- a/src/main/browser/cdp-focus-emulation.ts
+++ b/src/main/browser/cdp-focus-emulation.ts
@@ -6,6 +6,7 @@
  * execCommand on frame focus — see #10375 / regression of #7035.
  */
 export const CDP_FOCUS_EMULATION_METHOD = 'Emulation.setFocusEmulationEnabled' as const
+const CDP_FOCUS_EMULATION_TIMEOUT_MS = 5_000
 
 export type CdpFocusEmulationSender = (
   method: string,
@@ -13,5 +14,20 @@ export type CdpFocusEmulationSender = (
 ) => Promise<unknown>
 
 export async function enableCdpFocusEmulation(send: CdpFocusEmulationSender): Promise<void> {
-  await send(CDP_FOCUS_EMULATION_METHOD, { enabled: true })
+  let timer: ReturnType<typeof setTimeout> | null = null
+  try {
+    await Promise.race([
+      send(CDP_FOCUS_EMULATION_METHOD, { enabled: true }),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`CDP focus emulation timed out: ${CDP_FOCUS_EMULATION_METHOD}`)),
+          CDP_FOCUS_EMULATION_TIMEOUT_MS
+        )
+      })
+    ])
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
 }

--- a/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
+++ b/src/main/browser/cdp-ws-proxy-focus-replay.test.ts
@@ -53,6 +53,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setFocusEmulationEnabled', { enabled: true }],
       ['DOM.focus', { backendNodeId: 99 }],
       ['DOM.focus', { backendNodeId: 99 }],
       ['Input.insertText', { text: 'hello' }]
@@ -81,6 +82,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setFocusEmulationEnabled', { enabled: true }],
       ['DOM.focus', { backendNodeId: 123 }, 'oopif-session-123'],
       ['DOM.focus', { backendNodeId: 123 }, 'oopif-session-123'],
       ['Input.insertText', { text: 'frame text' }, 'oopif-session-123']
@@ -113,6 +115,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setFocusEmulationEnabled', { enabled: true }],
       ['DOM.focus', { backendNodeId: 44 }],
       ['Runtime.callFunctionOn', { functionDeclaration: '() => document.activeElement?.id' }],
       ['Input.insertText', { text: 'after eval' }]
@@ -156,6 +159,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setFocusEmulationEnabled', { enabled: true }],
       ['DOM.focus', { backendNodeId: 55 }],
       ['Input.insertText', { text: 'fallback' }]
     ])
@@ -198,6 +202,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandCalls(mock)).toEqual([
       ['Page.enable', {}],
       ['Page.addScriptToEvaluateOnNewDocument', expect.any(Object)],
+      ['Emulation.setFocusEmulationEnabled', { enabled: true }],
       ['DOM.focus', { backendNodeId: 77 }],
       ['DOM.focus', { backendNodeId: 77 }]
     ])
@@ -243,6 +248,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'DOM.focus',
       'DOM.focus',
       'Input.insertText'
@@ -273,6 +279,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'DOM.focus',
       'Input.insertText'
     ])
@@ -299,6 +306,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'DOM.focus',
       'Page.captureScreenshot',
       'Input.insertText'
@@ -325,6 +333,7 @@ describe('CdpWsProxy DOM.focus replay', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'DOM.focus',
       'Input.insertText'
     ])

--- a/src/main/browser/cdp-ws-proxy.test.ts
+++ b/src/main/browser/cdp-ws-proxy.test.ts
@@ -56,6 +56,13 @@ describe('CdpWsProxy', () => {
     expect(mock.webContents.debugger.attach).toHaveBeenCalledWith('1.3')
   })
 
+  it('enables CDP focus emulation on attach so document.hasFocus() can be true (#10375)', () => {
+    expect(mock.webContents.debugger.sendCommand).toHaveBeenCalledWith(
+      'Emulation.setFocusEmulationEnabled',
+      { enabled: true }
+    )
+  })
+
   // ── CDP message ID correlation ──
 
   it('correlates CDP request/response IDs', async () => {
@@ -403,6 +410,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'Input.insertText'
     ])
     client.close()
@@ -422,6 +430,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'Network.enable',
       'Page.enable',
       'Page.setLifecycleEventsEnabled',
@@ -443,6 +452,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'Network.enable',
       'Page.enable',
       'Page.setLifecycleEventsEnabled'
@@ -462,7 +472,7 @@ describe('CdpWsProxy', () => {
       sessionId: 'iframe-session-123'
     })
 
-    expect(getSendCommandCalls(mock).slice(2)).toEqual([
+    expect(getSendCommandCalls(mock).slice(3)).toEqual([
       ['Network.enable', {}, 'iframe-session-123'],
       ['Page.enable', {}, 'iframe-session-123'],
       ['Page.setLifecycleEventsEnabled', { enabled: true }, 'iframe-session-123'],
@@ -481,7 +491,7 @@ describe('CdpWsProxy', () => {
       sessionId: 'iframe-session-123'
     })
 
-    expect(getSendCommandCalls(mock).slice(2)).toEqual([
+    expect(getSendCommandCalls(mock).slice(3)).toEqual([
       ['Network.enable', {}, 'iframe-session-123'],
       ['Page.enable', {}, 'iframe-session-123'],
       ['Page.setLifecycleEventsEnabled', { enabled: true }, 'iframe-session-123'],
@@ -565,6 +575,7 @@ describe('CdpWsProxy', () => {
     expect(getSendCommandMethods(mock)).toEqual([
       'Page.enable',
       'Page.addScriptToEvaluateOnNewDocument',
+      'Emulation.setFocusEmulationEnabled',
       'Runtime.evaluate'
     ])
     client.close()

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -6,6 +6,7 @@ import { captureScreenshot } from './cdp-screenshot'
 import { buildPrintToPdfOptions, CdpPdfStreamStore } from './cdp-print-to-pdf'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
+import { enableCdpFocusEmulation } from './cdp-focus-emulation'
 
 const LIFECYCLE_PRIMING_TIMEOUT_MS = 1_000
 
@@ -231,6 +232,17 @@ export class CdpWsProxy {
       })
     } catch {
       /* best-effort — page domain may not be ready yet */
+    }
+
+    // Why: Electron 43+ tracks WebContentsView focus correctly, so embedded
+    // tabs can report document.hasFocus()===false even when Orca is frontmost.
+    // Rich editors (Draft.js) then drop Input.insertText / execCommand (#10375).
+    try {
+      await enableCdpFocusEmulation((method, params) =>
+        this.webContents.debugger.sendCommand(method, params ?? {})
+      )
+    } catch {
+      /* best-effort — older CDP stacks may lack the method */
     }
 
     this.debuggerMessageHandler = (_event: unknown, ...rest: unknown[]) => {

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -238,26 +238,9 @@ export class CdpWsProxy {
     // tabs can report document.hasFocus()===false even when Orca is frontmost.
     // Rich editors (Draft.js) then drop Input.insertText / execCommand (#10375).
     try {
-      // Why: bound stalled debugger commands so attach does not hang agent-browser (30s CDP default).
-      const FOCUS_EMULATION_COMMAND_TIMEOUT_MS = 5_000
-      await enableCdpFocusEmulation(async (method, params) => {
-        let timer: ReturnType<typeof setTimeout> | null = null
-        try {
-          return await Promise.race([
-            this.webContents.debugger.sendCommand(method, params ?? {}),
-            new Promise<never>((_, reject) => {
-              timer = setTimeout(
-                () => reject(new Error(`CDP focus emulation timed out: ${method}`)),
-                FOCUS_EMULATION_COMMAND_TIMEOUT_MS
-              )
-            })
-          ])
-        } finally {
-          if (timer) {
-            clearTimeout(timer)
-          }
-        }
-      })
+      await enableCdpFocusEmulation((method, params) =>
+        this.webContents.debugger.sendCommand(method, params ?? {})
+      )
     } catch {
       /* best-effort — older CDP stacks may lack the method */
     }

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -238,9 +238,26 @@ export class CdpWsProxy {
     // tabs can report document.hasFocus()===false even when Orca is frontmost.
     // Rich editors (Draft.js) then drop Input.insertText / execCommand (#10375).
     try {
-      await enableCdpFocusEmulation((method, params) =>
-        this.webContents.debugger.sendCommand(method, params ?? {})
-      )
+      // Why: bound stalled debugger commands so attach does not hang agent-browser (30s CDP default).
+      const FOCUS_EMULATION_COMMAND_TIMEOUT_MS = 5_000
+      await enableCdpFocusEmulation(async (method, params) => {
+        let timer: ReturnType<typeof setTimeout> | null = null
+        try {
+          return await Promise.race([
+            this.webContents.debugger.sendCommand(method, params ?? {}),
+            new Promise<never>((_, reject) => {
+              timer = setTimeout(
+                () => reject(new Error(`CDP focus emulation timed out: ${method}`)),
+                FOCUS_EMULATION_COMMAND_TIMEOUT_MS
+              )
+            })
+          ])
+        } finally {
+          if (timer) {
+            clearTimeout(timer)
+          }
+        }
+      })
     } catch {
       /* best-effort — older CDP stacks may lack the method */
     }


### PR DESCRIPTION
## Summary

Fixes #10375: embedded automation guests can report `document.hasFocus() === false`, causing CDP text input to no-op. CDP focus emulation is enabled on both bridge paths while preserving existing DOM-focus replay.

## Takeover / attribution

Original implementation and diagnosis by @innocarpe. I took over the PR after reproducing the shipped regression, centralized its 5 s best-effort timeout so direct CdpBridge attach cannot hang, and added bridge-path plus timeout regression tests.

## ELI5

The page thinks it is not selected, so some editors ignore typing. We tell Chromium to treat the automation page as focused before sending text.

## Fix proof

Live Orca 1.4.159-rc.1: active `https://httpbin.org/forms/post` returned `document.hasFocus() = false`; after clicking Customer name, `orca type --input AAA` returned success but the input value remained empty. Commit `eaf21cbb1f` sends `Emulation.setFocusEmulationEnabled({ enabled: true })` on both CDP attach paths.

## No-regression proof / trade-offs

- 0 regressions / risk: UNKNOWN. Focus emulation intentionally changes focus semantics for automation guests; live macOS regression is reproduced, but Linux/Windows Electron validation remains pending.
- One CDP command per debugger attach, bounded to 5,000 ms; stalled commands no longer hold either attach path.
- SSH and folder workspaces are unaffected: no path, provider, or Git behavior changes.

## Review loops

2 loops; final verdict: implementation clean after direct-bridge coverage and shared timeout. Remaining proof is a newly built app on non-macOS.

## Tests

- `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/cdp-focus-emulation.test.ts src/main/browser/cdp-bridge-integration.test.ts src/main/browser/cdp-ws-proxy.test.ts src/main/browser/cdp-ws-proxy-focus-replay.test.ts`
- `pnpm run typecheck:node`
- `git diff --check`

## Linked issue

Fixes #10375.

## Screenshots / evidence

No uploadable URL: Orca CLI captured the active browser viewport as in-memory PNG data, without a file path usable by `gh image` or `gh attach`. Command/evaluation evidence is recorded above and in the category report.