### PR TITLE
feat(terminal): resume agent session when reopening closed tab

### DIFF
--- a/src/renderer/src/store/slices/closed-terminal-agent-resume.test.ts
+++ b/src/renderer/src/store/slices/closed-terminal-agent-resume.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { extractClosedTerminalAgentResume } from './closed-terminal-agent-resume'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
+
+function liveEntry(
+  overrides: Partial<AgentStatusEntry> & Pick<AgentStatusEntry, 'paneKey'>
+): AgentStatusEntry {
+  return {
+    state: 'idle',
+    prompt: '',
+    updatedAt: 100,
+    stateStartedAt: 100,
+    agentType: 'claude',
+    providerSession: { key: 'session_id', id: 'sess-1' },
+    ...overrides
+  }
+}
+
+describe('extractClosedTerminalAgentResume', () => {
+  it('returns the newest live resumable agent for the closed tab', () => {
+    const result = extractClosedTerminalAgentResume({
+      tabId: 'tab-1',
+      agentStatusByPaneKey: {
+        'tab-1:leaf-a': liveEntry({
+          paneKey: 'tab-1:leaf-a',
+          updatedAt: 10,
+          providerSession: { key: 'session_id', id: 'old' }
+        }),
+        'tab-1:leaf-b': liveEntry({
+          paneKey: 'tab-1:leaf-b',
+          agentType: 'codex',
+          updatedAt: 50,
+          providerSession: { key: 'session_id', id: 'new' }
+        }),
+        'tab-2:leaf-a': liveEntry({
+          paneKey: 'tab-2:leaf-a',
+          updatedAt: 99,
+          providerSession: { key: 'session_id', id: 'other-tab' }
+        })
+      },
+      sleepingAgentSessionsByPaneKey: {}
+    })
+
+    expect(result).toEqual({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'new' }
+    })
+  })
+
+  it('falls back to a sleeping record when no live status remains', () => {
+    const sleeping: SleepingAgentSessionRecord = {
+      paneKey: 'tab-9:leaf',
+      tabId: 'tab-9',
+      worktreeId: 'wt',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'sleep-sess' },
+      prompt: 'hi',
+      state: 'idle',
+      capturedAt: 1,
+      updatedAt: 1,
+      launchConfig: { agentArgs: '--foo', agentEnv: {} }
+    }
+
+    expect(
+      extractClosedTerminalAgentResume({
+        tabId: 'tab-9',
+        agentStatusByPaneKey: {},
+        sleepingAgentSessionsByPaneKey: { 'tab-9:leaf': sleeping }
+      })
+    ).toEqual({
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'sleep-sess' },
+      launchConfig: { agentArgs: '--foo', agentEnv: {} }
+    })
+  })
+
+  it('returns null when the tab has no resumable provider session', () => {
+    expect(
+      extractClosedTerminalAgentResume({
+        tabId: 'tab-1',
+        agentStatusByPaneKey: {
+          'tab-1:leaf': liveEntry({
+            paneKey: 'tab-1:leaf',
+            agentType: 'claude',
+            providerSession: undefined
+          })
+        },
+        sleepingAgentSessionsByPaneKey: {}
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/store/slices/closed-terminal-agent-resume.test.ts
+++ b/src/renderer/src/store/slices/closed-terminal-agent-resume.test.ts
@@ -127,6 +127,47 @@ describe('extractClosedTerminalAgentResume', () => {
     })
   })
 
+  it('prefers the newest sleeping record when multiple pane keys match the tab', () => {
+    const older: SleepingAgentSessionRecord = {
+      paneKey: 'tab-9:leaf-a',
+      tabId: 'tab-9',
+      worktreeId: 'wt',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'old-sleep' },
+      prompt: 'old',
+      state: 'idle',
+      capturedAt: 1,
+      updatedAt: 10
+    }
+    const newer: SleepingAgentSessionRecord = {
+      paneKey: 'tab-9:leaf-b',
+      tabId: 'tab-9',
+      worktreeId: 'wt',
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'new-sleep' },
+      prompt: 'new',
+      state: 'idle',
+      capturedAt: 2,
+      updatedAt: 50,
+      launchConfig: { agentArgs: '--latest', agentEnv: {} }
+    }
+
+    expect(
+      extractClosedTerminalAgentResume({
+        tabId: 'tab-9',
+        agentStatusByPaneKey: {},
+        sleepingAgentSessionsByPaneKey: {
+          'tab-9:leaf-a': older,
+          'tab-9:leaf-b': newer
+        }
+      })
+    ).toEqual({
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'new-sleep' },
+      launchConfig: { agentArgs: '--latest', agentEnv: {} }
+    })
+  })
+
   it('returns null when the tab has no resumable provider session', () => {
     expect(
       extractClosedTerminalAgentResume({

--- a/src/renderer/src/store/slices/closed-terminal-agent-resume.test.ts
+++ b/src/renderer/src/store/slices/closed-terminal-agent-resume.test.ts
@@ -48,6 +48,58 @@ describe('extractClosedTerminalAgentResume', () => {
     })
   })
 
+  it('attaches per-launch config from the live registry (not only sleeping records)', () => {
+    const launchConfig = { agentArgs: '--model o3', agentEnv: { FOO: '1' } }
+    const result = extractClosedTerminalAgentResume({
+      tabId: 'tab-1',
+      agentStatusByPaneKey: {
+        'tab-1:leaf': liveEntry({
+          paneKey: 'tab-1:leaf',
+          agentType: 'claude',
+          providerSession: { key: 'session_id', id: 'live-sess' }
+        })
+      },
+      sleepingAgentSessionsByPaneKey: {},
+      agentLaunchConfigByPaneKey: {
+        'tab-1:leaf': {
+          launchConfig,
+          identity: { agentType: 'claude' }
+        }
+      }
+    })
+
+    expect(result).toEqual({
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'live-sess' },
+      launchConfig
+    })
+  })
+
+  it('ignores registry launch config when agent type does not match the live row', () => {
+    const result = extractClosedTerminalAgentResume({
+      tabId: 'tab-1',
+      agentStatusByPaneKey: {
+        'tab-1:leaf': liveEntry({
+          paneKey: 'tab-1:leaf',
+          agentType: 'claude',
+          providerSession: { key: 'session_id', id: 'live-sess' }
+        })
+      },
+      sleepingAgentSessionsByPaneKey: {},
+      agentLaunchConfigByPaneKey: {
+        'tab-1:leaf': {
+          launchConfig: { agentArgs: '--wrong', agentEnv: {} },
+          identity: { agentType: 'codex' }
+        }
+      }
+    })
+
+    expect(result).toEqual({
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'live-sess' }
+    })
+  })
+
   it('falls back to a sleeping record when no live status remains', () => {
     const sleeping: SleepingAgentSessionRecord = {
       paneKey: 'tab-9:leaf',

--- a/src/renderer/src/store/slices/closed-terminal-agent-resume.ts
+++ b/src/renderer/src/store/slices/closed-terminal-agent-resume.ts
@@ -1,0 +1,76 @@
+import {
+  getAgentResumeArgv,
+  isResumableTuiAgent,
+  type AgentProviderSessionMetadata,
+  type ResumableTuiAgent,
+  type SleepingAgentLaunchConfig,
+  type SleepingAgentSessionRecord
+} from '../../../../shared/agent-session-resume'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+
+export type ClosedTerminalAgentResume = {
+  agent: ResumableTuiAgent
+  providerSession: AgentProviderSessionMetadata
+  launchConfig?: SleepingAgentLaunchConfig
+}
+
+/**
+ * Prefer a live agent-status row for the closed tab; fall back to a sleeping
+ * record still keyed to that tab (before close retirement clears it).
+ */
+export function extractClosedTerminalAgentResume(args: {
+  tabId: string
+  agentStatusByPaneKey: Record<string, AgentStatusEntry> | undefined
+  sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord> | undefined
+}): ClosedTerminalAgentResume | null {
+  const tabPrefix = `${args.tabId}:`
+  let bestLive: ClosedTerminalAgentResume | null = null
+  let bestLiveUpdatedAt = -1
+
+  for (const [paneKey, entry] of Object.entries(args.agentStatusByPaneKey ?? {})) {
+    if (!paneKey.startsWith(tabPrefix) && entry.tabId !== args.tabId) {
+      continue
+    }
+    const resume = resumeFromAgentStatusEntry(entry)
+    if (!resume) {
+      continue
+    }
+    if (entry.updatedAt >= bestLiveUpdatedAt) {
+      bestLive = resume
+      bestLiveUpdatedAt = entry.updatedAt
+    }
+  }
+  if (bestLive) {
+    return bestLive
+  }
+
+  for (const [paneKey, record] of Object.entries(args.sleepingAgentSessionsByPaneKey ?? {})) {
+    if (record.tabId !== args.tabId && !paneKey.startsWith(tabPrefix)) {
+      continue
+    }
+    if (!getAgentResumeArgv(record.agent, record.providerSession)) {
+      continue
+    }
+    return {
+      agent: record.agent,
+      providerSession: record.providerSession,
+      ...(record.launchConfig ? { launchConfig: record.launchConfig } : {})
+    }
+  }
+
+  return null
+}
+
+function resumeFromAgentStatusEntry(entry: AgentStatusEntry): ClosedTerminalAgentResume | null {
+  const agent = entry.agentType
+  if (!isResumableTuiAgent(agent) || !entry.providerSession) {
+    return null
+  }
+  if (!getAgentResumeArgv(agent, entry.providerSession)) {
+    return null
+  }
+  return {
+    agent,
+    providerSession: entry.providerSession
+  }
+}

--- a/src/renderer/src/store/slices/closed-terminal-agent-resume.ts
+++ b/src/renderer/src/store/slices/closed-terminal-agent-resume.ts
@@ -51,6 +51,10 @@ export function extractClosedTerminalAgentResume(args: {
     return bestLive
   }
 
+  // Why: prefer newest sleeping record (same as live loop) when a closed tab
+  // still has multiple pane keys with sessions (#10386 CodeRabbit).
+  let bestSleeping: ClosedTerminalAgentResume | null = null
+  let bestSleepingUpdatedAt = -1
   for (const [paneKey, record] of Object.entries(args.sleepingAgentSessionsByPaneKey ?? {})) {
     if (record.tabId !== args.tabId && !paneKey.startsWith(tabPrefix)) {
       continue
@@ -58,14 +62,18 @@ export function extractClosedTerminalAgentResume(args: {
     if (!getAgentResumeArgv(record.agent, record.providerSession)) {
       continue
     }
-    return {
+    if (record.updatedAt < bestSleepingUpdatedAt) {
+      continue
+    }
+    bestSleepingUpdatedAt = record.updatedAt
+    bestSleeping = {
       agent: record.agent,
       providerSession: record.providerSession,
       ...(record.launchConfig ? { launchConfig: record.launchConfig } : {})
     }
   }
 
-  return null
+  return bestSleeping
 }
 
 function resumeFromAgentStatusEntry(

--- a/src/renderer/src/store/slices/closed-terminal-agent-resume.ts
+++ b/src/renderer/src/store/slices/closed-terminal-agent-resume.ts
@@ -14,6 +14,11 @@ export type ClosedTerminalAgentResume = {
   launchConfig?: SleepingAgentLaunchConfig
 }
 
+type LaunchConfigRegistryLookup = {
+  launchConfig: SleepingAgentLaunchConfig
+  identity?: { agentType?: string }
+}
+
 /**
  * Prefer a live agent-status row for the closed tab; fall back to a sleeping
  * record still keyed to that tab (before close retirement clears it).
@@ -22,6 +27,8 @@ export function extractClosedTerminalAgentResume(args: {
   tabId: string
   agentStatusByPaneKey: Record<string, AgentStatusEntry> | undefined
   sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord> | undefined
+  /** Why: live status rows do not carry per-launch args/env; the registry does. */
+  agentLaunchConfigByPaneKey?: Record<string, LaunchConfigRegistryLookup> | undefined
 }): ClosedTerminalAgentResume | null {
   const tabPrefix = `${args.tabId}:`
   let bestLive: ClosedTerminalAgentResume | null = null
@@ -31,7 +38,7 @@ export function extractClosedTerminalAgentResume(args: {
     if (!paneKey.startsWith(tabPrefix) && entry.tabId !== args.tabId) {
       continue
     }
-    const resume = resumeFromAgentStatusEntry(entry)
+    const resume = resumeFromAgentStatusEntry(entry, args.agentLaunchConfigByPaneKey?.[paneKey])
     if (!resume) {
       continue
     }
@@ -61,7 +68,10 @@ export function extractClosedTerminalAgentResume(args: {
   return null
 }
 
-function resumeFromAgentStatusEntry(entry: AgentStatusEntry): ClosedTerminalAgentResume | null {
+function resumeFromAgentStatusEntry(
+  entry: AgentStatusEntry,
+  registryEntry?: LaunchConfigRegistryLookup
+): ClosedTerminalAgentResume | null {
   const agent = entry.agentType
   if (!isResumableTuiAgent(agent) || !entry.providerSession) {
     return null
@@ -69,8 +79,15 @@ function resumeFromAgentStatusEntry(entry: AgentStatusEntry): ClosedTerminalAgen
   if (!getAgentResumeArgv(agent, entry.providerSession)) {
     return null
   }
+  // Why: keep per-launch args/env that sleeping-record resume already preserves (#10386).
+  const launchConfig =
+    registryEntry?.launchConfig &&
+    (registryEntry.identity?.agentType === undefined || registryEntry.identity.agentType === agent)
+      ? registryEntry.launchConfig
+      : undefined
   return {
     agent,
-    providerSession: entry.providerSession
+    providerSession: entry.providerSession,
+    ...(launchConfig ? { launchConfig } : {})
   }
 }

--- a/src/renderer/src/store/slices/recently-closed-tabs.test.ts
+++ b/src/renderer/src/store/slices/recently-closed-tabs.test.ts
@@ -267,6 +267,53 @@ describe('reopenClosedTerminalTab', () => {
     expect(store.getState().reopenClosedTerminalTab(WT)).toBe(true)
     expect(store.getState().tabsByWorktree[WT]?.[0]?.startupCwd).toBe('/remote/wt1/packages/app')
   })
+
+  it('resumes a closed agent tab via provider session instead of a bare shell', () => {
+    const store = makeSeededStore()
+    const tab = store
+      .getState()
+      .createTab(WT, undefined, undefined, { startupCwd: '/path/wt1/src' })
+    store.getState().setTabCustomTitle(tab.id, 'claude work')
+    store.setState({
+      agentStatusByPaneKey: {
+        [`${tab.id}:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa`]: {
+          state: 'idle',
+          prompt: 'hello',
+          updatedAt: 1,
+          stateStartedAt: 1,
+          agentType: 'claude',
+          paneKey: `${tab.id}:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa`,
+          providerSession: { key: 'session_id', id: 'claude-session-xyz' }
+        }
+      }
+    })
+
+    store.getState().closeTab(tab.id)
+
+    const snapshot = store.getState().recentlyClosedTerminalTabsByWorktree[WT]?.[0]
+    expect(snapshot).toMatchObject({
+      startupCwd: '/path/wt1/src',
+      customTitle: 'claude work',
+      agent: 'claude',
+      providerSession: { key: 'session_id', id: 'claude-session-xyz' }
+    })
+
+    expect(store.getState().reopenClosedTerminalTab(WT)).toBe(true)
+    const restored = store.getState().tabsByWorktree[WT]?.[0]
+    expect(restored).toMatchObject({
+      launchAgent: 'claude',
+      customTitle: 'claude work',
+      startupCwd: '/path/wt1/src'
+    })
+    const pending = store.getState().pendingStartupByTabId[restored!.id]
+    expect(pending).toMatchObject({
+      launchAgent: 'claude',
+      resumeProviderSession: { key: 'session_id', id: 'claude-session-xyz' },
+      showSessionRestoredBanner: true
+    })
+    expect(pending?.command).toContain('claude')
+    expect(pending?.command).toContain('--resume')
+  })
 })
 
 describe('restoreRecentlyClosedTabPosition', () => {

--- a/src/renderer/src/store/slices/recently-closed-tabs.ts
+++ b/src/renderer/src/store/slices/recently-closed-tabs.ts
@@ -312,7 +312,8 @@ function tryReopenClosedTerminalWithAgentResume(
     showSessionRestoredBanner: true,
     telemetry: {
       agent_kind: tuiAgentToAgentKind(snapshot.agent),
-      launch_source: 'sidebar',
+      // Why: Cmd/Ctrl+Shift+T reopen is a keyboard shortcut path, not a sidebar launch.
+      launch_source: 'shortcut',
       request_kind: 'resume'
     }
   })

--- a/src/renderer/src/store/slices/recently-closed-tabs.ts
+++ b/src/renderer/src/store/slices/recently-closed-tabs.ts
@@ -254,14 +254,22 @@ function getClientPlatform(): NodeJS.Platform {
   return 'darwin'
 }
 
-function getResumeLaunchPlatform(get: StoreGet, worktreeId: string): NodeJS.Platform {
+// Why: SSH hosts need both Linux platform and isRemote so the planner uses the
+// remote `orca` shim; WSL is Linux platform but still a local path (not isRemote).
+function getResumeLaunchTarget(
+  get: StoreGet,
+  worktreeId: string
+): { platform: NodeJS.Platform; isRemote: boolean } {
   const state = get()
   const worktree = state.getKnownWorktreeById?.(worktreeId)
   const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : null
-  if (repo?.connectionId || (worktree?.path && isWslUncPath(worktree.path))) {
-    return 'linux'
+  if (repo?.connectionId) {
+    return { platform: 'linux', isRemote: true }
   }
-  return getClientPlatform()
+  if (worktree?.path && isWslUncPath(worktree.path)) {
+    return { platform: 'linux', isRemote: false }
+  }
+  return { platform: getClientPlatform(), isRemote: false }
 }
 
 /** Resume a closed agent tab when the snapshot carries a resumable provider session. */
@@ -275,6 +283,7 @@ function tryReopenClosedTerminalWithAgentResume(
   }
   const state = get()
   const launchConfig = snapshot.launchConfig
+  const { platform, isRemote } = getResumeLaunchTarget(get, worktreeId)
   const startupPlan = buildAgentResumeStartupPlan({
     agent: snapshot.agent,
     providerSession: snapshot.providerSession,
@@ -288,7 +297,13 @@ function tryReopenClosedTerminalWithAgentResume(
         ? launchConfig.agentEnv
         : resolveTuiAgentLaunchEnv(snapshot.agent, state.settings?.agentDefaultEnv),
     ...(launchConfig?.agentCommand ? { agentCommand: launchConfig.agentCommand } : {}),
-    platform: getResumeLaunchPlatform(get, worktreeId)
+    // Why: OMP cold resume stores a file path in the sleeping launch config; drop it
+    // and the planner builds resume argv without the locator.
+    ...(launchConfig?.ompResumeFilePath
+      ? { ompResumeFilePath: launchConfig.ompResumeFilePath }
+      : {}),
+    platform,
+    isRemote
   })
   if (!startupPlan) {
     return false

--- a/src/renderer/src/store/slices/recently-closed-tabs.ts
+++ b/src/renderer/src/store/slices/recently-closed-tabs.ts
@@ -1,6 +1,12 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { buildAgentResumeStartupPlan } from '@/lib/tui-agent-startup'
+import { tuiAgentToAgentKind } from '@/lib/telemetry'
+import {
+  resolveTuiAgentLaunchArgs,
+  resolveTuiAgentLaunchEnv
+} from '../../../../shared/tui-agent-launch-defaults'
 import {
   isWindowsAbsolutePathLike,
   relativePathInsideRoot
@@ -9,6 +15,12 @@ import {
   restoreRecentlyClosedTabPosition,
   type RecentlyClosedTabPosition
 } from './recently-closed-tab-position'
+import type {
+  AgentProviderSessionMetadata,
+  ResumableTuiAgent,
+  SleepingAgentLaunchConfig
+} from '../../../../shared/agent-session-resume'
+import { isWslUncPath } from '../../../../shared/wsl-paths'
 
 export {
   createRecentlyClosedTabPositionIndex,
@@ -21,15 +33,19 @@ export type {
   RecentlyClosedTabPositionIndex
 } from './recently-closed-tab-position'
 
-/** Snapshot of a terminal tab captured at user-initiated close time. Reopen
- *  recreates a fresh shell in the same startup directory (Ghostty semantics) —
- *  never the old PTY, scrollback, or a relaunched agent session. */
+/** Snapshot of a terminal tab captured at user-initiated close time.
+ *  Reopen recreates a fresh tab (never the old PTY/scrollback). Plain shells
+ *  restore Ghostty-style cwd/shell; resumable agent tabs relaunch via resume
+ *  argv (#10377). */
 export type ClosedTerminalTabSnapshot = {
   startupCwd?: string
   shellOverride?: string
   customTitle?: string
   color?: string
   position?: RecentlyClosedTabPosition
+  agent?: ResumableTuiAgent
+  providerSession?: AgentProviderSessionMetadata
+  launchConfig?: SleepingAgentLaunchConfig
 }
 
 export type RecentlyClosedTabKind = 'terminal' | 'browser' | 'editor'
@@ -151,16 +167,16 @@ export const createRecentlyClosedTabsSlice: StateCreator<
       return false
     }
 
+    const resumed = tryReopenClosedTerminalWithAgentResume(get, worktreeId, snapshot)
+    if (resumed) {
+      return true
+    }
+
     const tab = get().createTab(worktreeId, snapshot.position?.groupId, snapshot.shellOverride, {
       ...(snapshot.startupCwd ? { startupCwd: snapshot.startupCwd } : {}),
       activate: true
     })
-    if (snapshot.customTitle) {
-      get().setTabCustomTitle(tab.id, snapshot.customTitle)
-    }
-    if (snapshot.color) {
-      get().setTabColor(tab.id, snapshot.color)
-    }
+    applyClosedTerminalTabPresentation(get, tab.id, snapshot)
     get().setActiveTabType('terminal')
     restoreRecentlyClosedTabPosition(get, worktreeId, tab.id, snapshot.position)
     return true
@@ -201,3 +217,118 @@ export const createRecentlyClosedTabsSlice: StateCreator<
     }
   }
 })
+
+type StoreGet = () => AppState
+
+function applyClosedTerminalTabPresentation(
+  get: StoreGet,
+  tabId: string,
+  snapshot: ClosedTerminalTabSnapshot
+): void {
+  if (snapshot.customTitle) {
+    get().setTabCustomTitle(tabId, snapshot.customTitle)
+  }
+  if (snapshot.color) {
+    get().setTabColor(tabId, snapshot.color)
+  }
+}
+
+function appendTabToBarOrder(get: StoreGet, worktreeId: string, tabId: string): void {
+  const order = get().tabBarOrderByWorktree[worktreeId]
+  if (order && !order.includes(tabId)) {
+    get().setTabBarOrder(worktreeId, [...order, tabId])
+  }
+}
+
+function getClientPlatform(): NodeJS.Platform {
+  // Why: avoid importing new-workspace here — it pulls the full store and
+  // creates a circular init cycle with this slice.
+  if (typeof navigator !== 'undefined') {
+    if (navigator.userAgent.includes('Windows')) {
+      return 'win32'
+    }
+    if (navigator.userAgent.includes('Linux')) {
+      return 'linux'
+    }
+  }
+  return 'darwin'
+}
+
+function getResumeLaunchPlatform(get: StoreGet, worktreeId: string): NodeJS.Platform {
+  const state = get()
+  const worktree = state.getKnownWorktreeById?.(worktreeId)
+  const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : null
+  if (repo?.connectionId || (worktree?.path && isWslUncPath(worktree.path))) {
+    return 'linux'
+  }
+  return getClientPlatform()
+}
+
+/** Resume a closed agent tab when the snapshot carries a resumable provider session. */
+function tryReopenClosedTerminalWithAgentResume(
+  get: StoreGet,
+  worktreeId: string,
+  snapshot: ClosedTerminalTabSnapshot
+): boolean {
+  if (!snapshot.agent || !snapshot.providerSession) {
+    return false
+  }
+  const state = get()
+  const launchConfig = snapshot.launchConfig
+  const startupPlan = buildAgentResumeStartupPlan({
+    agent: snapshot.agent,
+    providerSession: snapshot.providerSession,
+    cmdOverrides: state.settings?.agentCmdOverrides ?? {},
+    agentArgs:
+      launchConfig !== undefined
+        ? launchConfig.agentArgs
+        : resolveTuiAgentLaunchArgs(snapshot.agent, state.settings?.agentDefaultArgs),
+    agentEnv:
+      launchConfig !== undefined
+        ? launchConfig.agentEnv
+        : resolveTuiAgentLaunchEnv(snapshot.agent, state.settings?.agentDefaultEnv),
+    ...(launchConfig?.agentCommand ? { agentCommand: launchConfig.agentCommand } : {}),
+    platform: getResumeLaunchPlatform(get, worktreeId)
+  })
+  if (!startupPlan) {
+    return false
+  }
+
+  const tab = state.createTab(worktreeId, snapshot.position?.groupId, snapshot.shellOverride, {
+    launchAgent: snapshot.agent,
+    ...(snapshot.startupCwd ? { startupCwd: snapshot.startupCwd } : {}),
+    activate: true
+  })
+  state.queueTabStartupCommand(tab.id, {
+    command: startupPlan.launchCommand,
+    ...(startupPlan.env ? { env: startupPlan.env } : {}),
+    launchConfig: startupPlan.launchConfig,
+    resumeProviderSession: snapshot.providerSession,
+    launchAgent: snapshot.agent,
+    ...(launchConfig ? { agentArgsOverride: launchConfig.agentArgs } : {}),
+    ...(startupPlan.startupCommandDelivery
+      ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+      : {}),
+    showSessionRestoredBanner: true,
+    telemetry: {
+      agent_kind: tuiAgentToAgentKind(snapshot.agent),
+      launch_source: 'sidebar',
+      request_kind: 'resume'
+    }
+  })
+  state.claimAutomaticAgentResume(tab.id, {
+    worktreeId,
+    launchAgent: snapshot.agent,
+    providerSession: snapshot.providerSession
+  })
+  applyClosedTerminalTabPresentation(get, tab.id, snapshot)
+  get().setActiveTabType('terminal')
+  // Why: prefer main's closed-tab position restore when captured; fall back to
+  // append so agent resume still works on older snapshots without position.
+  if (snapshot.position) {
+    restoreRecentlyClosedTabPosition(get, worktreeId, tab.id, snapshot.position)
+  } else {
+    appendTabToBarOrder(get, worktreeId, tab.id)
+  }
+  return true
+}

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -63,6 +63,7 @@ import {
   pushClosedTerminalTabSnapshot,
   pushRecentlyClosedTabKind
 } from './recently-closed-tabs'
+import { extractClosedTerminalAgentResume } from './closed-terminal-agent-resume'
 import { isClaudeAgent } from '@/lib/agent-status'
 import { recordTerminalInputActivity } from '@/lib/terminal-input-activity-coalescing'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
@@ -1665,6 +1666,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         closedWorktreeId && closedTab
           ? getRecentlyClosedTabPosition(s, closedWorktreeId, closedTab.id)
           : undefined
+      // Capture resumable agent identity before sleeping/status retirement so Cmd+Shift+T can resume (#10377).
+      const agentResume =
+        closedTab &&
+        extractClosedTerminalAgentResume({
+          tabId: closedTab.id,
+          agentStatusByPaneKey: s.agentStatusByPaneKey,
+          sleepingAgentSessionsByPaneKey: s.sleepingAgentSessionsByPaneKey
+        })
       const capturedSnapshot =
         closeReason === 'user' &&
         opts?.captureRecentlyClosed !== false &&
@@ -1675,7 +1684,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
               ...(closedTab.shellOverride ? { shellOverride: closedTab.shellOverride } : {}),
               ...(closedTab.customTitle ? { customTitle: closedTab.customTitle } : {}),
               ...(closedTab.color ? { color: closedTab.color } : {}),
-              ...(closedPosition ? { position: closedPosition } : {})
+              ...(closedPosition ? { position: closedPosition } : {}),
+              ...(agentResume
+                ? {
+                    agent: agentResume.agent,
+                    providerSession: agentResume.providerSession,
+                    ...(agentResume.launchConfig ? { launchConfig: agentResume.launchConfig } : {})
+                  }
+                : {})
             }
           : null
       const nextExpanded = { ...s.expandedPaneByTabId }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -1672,7 +1672,8 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         extractClosedTerminalAgentResume({
           tabId: closedTab.id,
           agentStatusByPaneKey: s.agentStatusByPaneKey,
-          sleepingAgentSessionsByPaneKey: s.sleepingAgentSessionsByPaneKey
+          sleepingAgentSessionsByPaneKey: s.sleepingAgentSessionsByPaneKey,
+          agentLaunchConfigByPaneKey: s.agentLaunchConfigByPaneKey
         })
       const capturedSnapshot =
         closeReason === 'user' &&


### PR DESCRIPTION
## Summary
- Fixes #10377: Cmd/Ctrl+Shift+T on a just-closed **agent** tab resumes the provider session instead of opening a bare shell.
- On user close, `ClosedTerminalTabSnapshot` now stores optional `agent` + `providerSession` (+ `launchConfig` when known) from live agent status or sleeping records.
- Reopen uses `buildAgentResumeStartupPlan` + `queueTabStartupCommand` with the same session-restored banner path as sleep/wake resume.
- Non-agent tabs and non-resumable agents keep Ghostty-style cwd/shell reopen. Still never restores the old PTY/scrollback.
- Compatible with #9352: only explicit reopen resumes; no auto-respawn of closed tabs.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/closed-terminal-agent-resume.test.ts src/renderer/src/store/slices/recently-closed-tabs.test.ts` (20 passed)
- [ ] Close a Claude/Codex agent tab → Cmd+Shift+T → agent resumes with session restored banner
- [ ] Close a plain shell → Cmd+Shift+T → fresh shell at previous cwd

## ELI5

Reopening a closed agent tab with Cmd/Ctrl+Shift+T used to open a bare shell. Now it resumes the same agent session when possible, like sleep/wake, so you do not lose the conversation.
