### PR TITLE
feat(explorer): independent File Explorer font size setting

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -797,6 +797,7 @@ describe('FileExplorerRow collapse folder action', () => {
   it('passes the row node to the collapse folder handler', () => {
     const onCollapseFolderSubtree = vi.fn()
     const element = FileExplorerVirtualRows({
+      fontSize: 12,
       virtualizer: {
         getTotalSize: () => 26,
         getVirtualItems: () => [{ index: 0, key: 'src', start: 0 }],
@@ -850,6 +851,7 @@ describe('FileExplorerRow collapse folder action', () => {
   it('passes the row node to the find in folder handler', () => {
     const onFindInFolder = vi.fn()
     const element = FileExplorerVirtualRows({
+      fontSize: 12,
       virtualizer: {
         getTotalSize: () => 26,
         getVirtualItems: () => [{ index: 0, key: 'src', start: 0 }],
@@ -902,6 +904,7 @@ describe('FileExplorerRow collapse folder action', () => {
 
   it('passes the active connection id to virtualized rows', () => {
     const element = FileExplorerVirtualRows({
+      fontSize: 12,
       virtualizer: {
         getTotalSize: () => 26,
         getVirtualItems: () => [{ index: 0, key: 'index.ts', start: 0 }],
@@ -955,6 +958,7 @@ describe('FileExplorerRow collapse folder action', () => {
   it('passes the row node to the open in terminal handler', () => {
     const onOpenInTerminal = vi.fn()
     const element = FileExplorerVirtualRows({
+      fontSize: 12,
       virtualizer: {
         getTotalSize: () => 26,
         getVirtualItems: () => [{ index: 0, key: 'src', start: 0 }],
@@ -1008,6 +1012,7 @@ describe('FileExplorerRow collapse folder action', () => {
   it('passes the row node to the view file handler', () => {
     const onViewFile = vi.fn()
     const element = FileExplorerVirtualRows({
+      fontSize: 12,
       virtualizer: {
         getTotalSize: () => 26,
         getVirtualItems: () => [{ index: 0, key: 'src', start: 0 }],

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -55,6 +55,11 @@ import { CLOSE_ALL_CONTEXT_MENUS_EVENT } from '@/components/tab-bar/SortableTab'
 import type { RightSidebarExplorerView } from '../../../../shared/types'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { createNewTerminalTab } from '@/components/terminal/terminal-tab-create'
+import {
+  clampFileExplorerFontSize,
+  DEFAULT_FILE_EXPLORER_FONT_SIZE,
+  fileExplorerRowHeightPx
+} from '../../../../shared/file-explorer-font-size'
 
 function FileExplorerFiles(): React.JSX.Element {
   const explorerView = useAppStore((s) => s.rightSidebarExplorerView)
@@ -78,6 +83,10 @@ function FileExplorerFiles(): React.JSX.Element {
     [nameFilterQuery, showRightSidebarFiles, showRightSidebarSearch]
   )
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const fileExplorerFontSize = useAppStore((s) =>
+    clampFileExplorerFontSize(s.settings?.fileExplorerFontSize ?? DEFAULT_FILE_EXPLORER_FONT_SIZE)
+  )
+  const fileExplorerRowHeight = fileExplorerRowHeightPx(fileExplorerFontSize)
   const activeWorktree = useActiveWorktree()
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
   const supportsFolderDownload = useAppStore((s) => {
@@ -412,7 +421,7 @@ function FileExplorerFiles(): React.JSX.Element {
   const virtualizer = useVirtualizer({
     count: totalCount,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => 26,
+    estimateSize: () => fileExplorerRowHeight,
     overscan: 20,
     getItemKey: (index) => {
       if (inlineInputIndex >= 0) {
@@ -425,6 +434,10 @@ function FileExplorerFiles(): React.JSX.Element {
       return rowProjection.getRowAtIndex(index)?.path ?? `__fallback_${index}`
     }
   })
+
+  useEffect(() => {
+    virtualizer.measure()
+  }, [fileExplorerRowHeight, virtualizer])
 
   const cancelRevealTimers = useFileExplorerReveal({
     activeWorktreeId,
@@ -738,6 +751,7 @@ function FileExplorerFiles(): React.JSX.Element {
             {showTree && (
               <FileExplorerVirtualRows
                 virtualizer={virtualizer}
+                fontSize={fileExplorerFontSize}
                 inlineInputIndex={inlineInputIndex}
                 rowProjection={rowProjection}
                 inlineInput={inlineInput}

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -86,11 +86,13 @@ export type InlineInput = {
 
 export function InlineInputRow({
   depth,
+  fontSize = 12,
   inlineInput,
   onSubmit,
   onCancel
 }: {
   depth: number
+  fontSize?: number
   inlineInput: InlineInput
   onSubmit: (value: string) => void
   onCancel: () => void
@@ -203,8 +205,12 @@ export function InlineInputRow({
 
   return (
     <div
-      className="flex items-center w-full h-[26px] px-2 gap-1"
-      style={{ paddingLeft: `${depth * 16 + 8}px` }}
+      className="flex items-center w-full px-2 gap-1"
+      style={{
+        paddingLeft: `${depth * 16 + 8}px`,
+        height: `${fontSize + 14}px`,
+        fontSize: `${fontSize}px`
+      }}
     >
       <span className="size-3 shrink-0" />
       {inlineInput.type === 'folder' ? (
@@ -215,7 +221,8 @@ export function InlineInputRow({
       <input
         key={inlineInputKey}
         ref={setInputRef}
-        className="flex-1 min-w-0 bg-transparent text-xs text-foreground outline-none border border-ring rounded-sm px-1"
+        className="flex-1 min-w-0 bg-transparent text-foreground outline-none border border-ring rounded-sm px-1"
+        style={{ fontSize: `${fontSize}px` }}
         defaultValue={inlineInput.type === 'rename' ? inlineInput.existingName : ''}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
@@ -263,6 +270,7 @@ export function InlineInputRow({
 
 type FileExplorerRowProps = {
   node: TreeNode
+  fontSize?: number
   isExpanded: boolean
   isLoading: boolean
   isSelected: boolean
@@ -434,6 +442,7 @@ export async function copyFileToOsClipboard(
 
 export function FileExplorerRow({
   node,
+  fontSize = 12,
   isExpanded,
   isLoading,
   isSelected,
@@ -532,12 +541,16 @@ export function FileExplorerRow({
           data-file-explorer-row=""
           data-selected={isSelected ? 'true' : undefined}
           className={cn(
-            'flex w-full items-center gap-1 rounded-sm px-2 py-1 text-left text-xs transition-colors',
+            'flex w-full items-center gap-1 rounded-sm px-2 py-1 text-left transition-colors',
             !isSelected && 'hover:bg-accent hover:text-foreground',
             isSelected && 'text-accent-foreground',
             isFlashing && 'bg-amber-400/20 ring-1 ring-inset ring-amber-400/70'
           )}
-          style={{ paddingLeft: `${node.depth * 16 + 8}px` }}
+          style={{
+            paddingLeft: `${node.depth * 16 + 8}px`,
+            fontSize: `${fontSize}px`,
+            minHeight: `${fontSize + 14}px`
+          }}
           ref={setRowDragNode}
           data-native-file-drop-dir={rowDropDir}
           // Why: marks this draggable row so the wheel-capture handler can rescue

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRows.tsx
@@ -11,6 +11,7 @@ import type { RuntimeFileOperationArgs } from '@/runtime/runtime-file-client'
 
 type FileExplorerVirtualRowsProps = {
   virtualizer: Virtualizer<HTMLDivElement, Element>
+  fontSize: number
   inlineInputIndex: number
   rowProjection: FileExplorerRowProjection
   inlineInput: InlineInput | null
@@ -57,6 +58,7 @@ type FileExplorerVirtualRowsProps = {
 export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): React.JSX.Element {
   const {
     virtualizer,
+    fontSize,
     inlineInputIndex,
     rowProjection,
     inlineInput,
@@ -131,6 +133,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
             >
               <InlineInputRow
                 depth={inlineDepth}
+                fontSize={fontSize}
                 inlineInput={inlineInput!}
                 onSubmit={handleInlineSubmit}
                 onCancel={dismissInlineInput}
@@ -167,6 +170,7 @@ export function FileExplorerVirtualRows(props: FileExplorerVirtualRowsProps): Re
           >
             <FileExplorerRow
               node={n}
+              fontSize={fontSize}
               isExpanded={expanded.has(n.path)}
               isLoading={n.isDirectory && Boolean(dirCache[n.path]?.loading)}
               isSelected={selectedPaths.has(n.path) || activeFileId === n.path}

--- a/src/renderer/src/components/right-sidebar/FileExplorerVirtualRowsAddProject.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerVirtualRowsAddProject.test.tsx
@@ -49,6 +49,7 @@ describe('FileExplorerVirtualRows add-as-project action', () => {
   it('passes visibility and the row node to the add-as-project handler', () => {
     const onAddFolderAsProject = vi.fn()
     const element = FileExplorerVirtualRows({
+      fontSize: 12,
       virtualizer: {
         getTotalSize: () => 26,
         getVirtualItems: () => [{ index: 0, key: 'src', start: 0 }],

--- a/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-drag-scroll-marker.test.tsx
@@ -49,6 +49,7 @@ const directoryNode: TreeNode = {
 
 function virtualRowsElement(nodes: TreeNode[]): React.JSX.Element {
   return FileExplorerVirtualRows({
+    fontSize: 12,
     virtualizer: {
       getTotalSize: () => nodes.length * 26,
       getVirtualItems: () =>

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -20,6 +20,7 @@ import {
 } from './appearance-search'
 import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percentage-search'
 import { LeftSidebarAppearanceSetting } from './LeftSidebarAppearanceSetting'
+import { FileExplorerFontSizeSetting } from './FileExplorerFontSizeSetting'
 import {
   getLeftSidebarAppearanceEntry,
   getShowPinnedWorktreesInGroupsEntry,
@@ -379,6 +380,10 @@ export function AppearanceWindowSidebarSection({
                       }
                     />
                   </SearchableSetting>
+                  <FileExplorerFontSizeSetting
+                    settings={settings}
+                    updateSettings={updateSettings}
+                  />
                 </div>
               </div>
             ) : null}

--- a/src/renderer/src/components/settings/FileExplorerFontSizeSetting.tsx
+++ b/src/renderer/src/components/settings/FileExplorerFontSizeSetting.tsx
@@ -1,0 +1,94 @@
+import type React from 'react'
+import { Minus, Plus } from 'lucide-react'
+import type { GlobalSettings } from '../../../../shared/types'
+import {
+  clampFileExplorerFontSize,
+  DEFAULT_FILE_EXPLORER_FONT_SIZE,
+  MAX_FILE_EXPLORER_FONT_SIZE,
+  MIN_FILE_EXPLORER_FONT_SIZE
+} from '../../../../shared/file-explorer-font-size'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+import { SettingsRow } from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+import { translate } from '@/i18n/i18n'
+
+export function FileExplorerFontSizeSetting({
+  settings,
+  updateSettings,
+  forceVisible = false
+}: {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+  forceVisible?: boolean
+}): React.JSX.Element {
+  const fontSize = clampFileExplorerFontSize(
+    settings.fileExplorerFontSize ?? DEFAULT_FILE_EXPLORER_FONT_SIZE
+  )
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.FileExplorerFontSizeSetting.title',
+        'File Explorer Font Size'
+      )}
+      description={translate(
+        'auto.components.settings.FileExplorerFontSizeSetting.description',
+        'Font size for file and folder names in the File Explorer, independent of UI zoom.'
+      )}
+      keywords={['file explorer', 'font', 'size', 'sidebar', 'typography', 'resource manager']}
+      forceVisible={forceVisible}
+    >
+      <SettingsRow
+        label={translate(
+          'auto.components.settings.FileExplorerFontSizeSetting.title',
+          'File Explorer Font Size'
+        )}
+        control={
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={() => {
+                updateSettings({
+                  fileExplorerFontSize: clampFileExplorerFontSize(fontSize - 1)
+                })
+              }}
+              disabled={fontSize <= MIN_FILE_EXPLORER_FONT_SIZE}
+            >
+              <Minus className="size-3" />
+            </Button>
+            <Input
+              type="number"
+              min={MIN_FILE_EXPLORER_FONT_SIZE}
+              max={MAX_FILE_EXPLORER_FONT_SIZE}
+              value={fontSize}
+              onChange={(e) => {
+                const value = Number.parseInt(e.target.value, 10)
+                if (!Number.isNaN(value)) {
+                  updateSettings({ fileExplorerFontSize: clampFileExplorerFontSize(value) })
+                }
+              }}
+              className="w-14 text-center tabular-nums"
+            />
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={() => {
+                updateSettings({
+                  fileExplorerFontSize: clampFileExplorerFontSize(fontSize + 1)
+                })
+              }}
+              disabled={fontSize >= MAX_FILE_EXPLORER_FONT_SIZE}
+            >
+              <Plus className="size-3" />
+            </Button>
+            <span className="text-xs text-muted-foreground">
+              {translate('auto.components.settings.FileExplorerFontSizeSetting.px', 'px')}
+            </span>
+          </div>
+        }
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -139,6 +139,29 @@ export const getLayoutEntries = createLocalizedCatalog((): SettingsSearchEntry[]
       ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
       ...translateSearchKeyword('auto.components.settings.appearance.search.648eeada79', 'hide')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.appearance.search.fileExplorerFontSize',
+      'File Explorer Font Size'
+    ),
+    description: translate(
+      'auto.components.settings.appearance.search.fileExplorerFontSizeDescription',
+      'Font size for file and folder names in the File Explorer, independent of UI zoom.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.c1bca1885a',
+        'file explorer'
+      ),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.font', 'font'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.size', 'size'),
+      ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.typography',
+        'typography'
+      )
+    ]
   }
 ])
 

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -154,6 +154,11 @@ export const getLayoutEntries = createLocalizedCatalog((): SettingsSearchEntry[]
         'auto.components.settings.appearance.search.c1bca1885a',
         'file explorer'
       ),
+      // Why: settings copy also says "resource manager"; keep the outer catalog searchable by that alias.
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.resourceManager',
+        'resource manager'
+      ),
       ...translateSearchKeyword('auto.components.settings.appearance.search.font', 'font'),
       ...translateSearchKeyword('auto.components.settings.appearance.search.size', 'size'),
       ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -56,6 +56,10 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').confirmClosePinnedTab).toBe(true)
   })
 
+  it('defaults File Explorer font size to 12px (previous text-xs)', () => {
+    expect(getDefaultSettings('/tmp').fileExplorerFontSize).toBe(12)
+  })
+
   it('keeps file-editor word wrapping enabled by default', () => {
     expect(getDefaultSettings('/tmp').editorWordWrap).toBe(true)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -202,6 +202,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     primarySelectionMiddleClickPasteDefaultedForTerminalDefaults:
       getDefaultPrimarySelectionMiddleClickPaste(),
     terminalFontSize: 14,
+    fileExplorerFontSize: 12,
     terminalFontFamily: defaultTerminalFontFamily(),
     terminalFontWeight: DEFAULT_TERMINAL_FONT_WEIGHT,
     terminalLineHeight: 1,

--- a/src/shared/file-explorer-font-size.test.ts
+++ b/src/shared/file-explorer-font-size.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_FILE_EXPLORER_FONT_SIZE,
+  clampFileExplorerFontSize,
+  fileExplorerRowHeightPx
+} from './file-explorer-font-size'
+
+describe('clampFileExplorerFontSize', () => {
+  it('clamps to the supported range', () => {
+    expect(clampFileExplorerFontSize(9)).toBe(10)
+    expect(clampFileExplorerFontSize(21)).toBe(20)
+    expect(clampFileExplorerFontSize(14.6)).toBe(15)
+  })
+
+  it('falls back for non-finite values', () => {
+    expect(clampFileExplorerFontSize(Number.NaN)).toBe(DEFAULT_FILE_EXPLORER_FONT_SIZE)
+  })
+})
+
+describe('fileExplorerRowHeightPx', () => {
+  it('keeps the historical 26px row at the default 12px font', () => {
+    expect(fileExplorerRowHeightPx(12)).toBe(26)
+  })
+})

--- a/src/shared/file-explorer-font-size.ts
+++ b/src/shared/file-explorer-font-size.ts
@@ -1,0 +1,21 @@
+/** Default matches Tailwind `text-xs` used by File Explorer rows. */
+export const DEFAULT_FILE_EXPLORER_FONT_SIZE = 12
+export const MIN_FILE_EXPLORER_FONT_SIZE = 10
+export const MAX_FILE_EXPLORER_FONT_SIZE = 20
+
+export function clampFileExplorerFontSize(value: number): number {
+  if (!Number.isFinite(value)) {
+    return DEFAULT_FILE_EXPLORER_FONT_SIZE
+  }
+  return Math.min(
+    MAX_FILE_EXPLORER_FONT_SIZE,
+    Math.max(MIN_FILE_EXPLORER_FONT_SIZE, Math.round(value))
+  )
+}
+
+/** Virtual row height scales with font so larger type does not clip. */
+export function fileExplorerRowHeightPx(fontSize: number): number {
+  const size = clampFileExplorerFontSize(fontSize)
+  // Why: 12px type used 26px rows; keep ~14px vertical chrome around the glyph.
+  return size + 14
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2648,6 +2648,11 @@ export type GlobalSettings = {
    *  Linux/macOS while preserving later explicit opt-outs. */
   primarySelectionMiddleClickPasteDefaultedForTerminalDefaults?: boolean
   terminalFontSize: number
+  /**
+   * File Explorer row label size in px (independent of uiZoomLevel / terminal font).
+   * Default 12 matches the previous `text-xs` rows (#10259).
+   */
+  fileExplorerFontSize: number
   terminalFontFamily: string
   terminalFontWeight: number
   terminalLineHeight: number


### PR DESCRIPTION
## Summary
- Fixes #10259: File Explorer file/folder name size can be adjusted without global UI zoom or terminal font.
- New setting `fileExplorerFontSize` (default **12px**, range 10–20) under **Settings → Appearance → Window & Sidebar → File Explorer**.
- Virtual row height tracks the font size so larger type does not clip.

## Test plan
- [x] Unit tests for clamp/row-height + File Explorer virtual rows fixtures (72+ related passed in local runs)
- [ ] Change File Explorer font size in settings → explorer labels update; terminal/editor unchanged
- [ ] Default 12px matches previous `text-xs` appearance

## ELI5

You can set File Explorer font size on its own (10–20px, default 12) without changing global UI zoom or terminal font. Row heights grow with the font so names do not get clipped.
