### PR TITLE
fix(terminal): re-seed kitty keyboard flags after reattach replay

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7943,6 +7943,14 @@ export function connectPanePty(
           writeReplayData('\x1b[2J\x1b[3J\x1b[H')
           // Why: re-arm the kitty keyboard mirror from the snapshot preamble so Option chords keep their encoding after a window reload.
           kittyKeyboardModes.scanReplay(connectResult.snapshot)
+          // Why: stackless replay can zero nested push/pop windows while the live
+          // TUI still has protocol flags; seed from the daemon emulator (#10381).
+          if (
+            typeof connectResult.snapshotKittyKeyboardFlags === 'number' &&
+            connectResult.snapshotKittyKeyboardFlags > 0
+          ) {
+            kittyKeyboardModes.applyAuthoritativeFlags(connectResult.snapshotKittyKeyboardFlags)
+          }
           writeReplayData(connectResult.snapshot)
           // Snapshot reattach keeps a live session, so drop only renderer-owned state instead of the broader mode reset — unless this is a cold restore, whose owner is gone.
           writeReplayData(
@@ -7993,6 +8001,12 @@ export function connectPanePty(
               }
             }
             kittyKeyboardModes.scanReplay(modelData)
+            if (
+              typeof connectResult?.snapshotKittyKeyboardFlags === 'number' &&
+              connectResult.snapshotKittyKeyboardFlags > 0
+            ) {
+              kittyKeyboardModes.applyAuthoritativeFlags(connectResult.snapshotKittyKeyboardFlags)
+            }
             // Why shared: park+reveal of an alt-screen TUI needs the same
             // ?1049l/?1049h rebuild as applyMainBufferSnapshot (main strips
             // the ?1049h marker when splitting scrollbackAnsi) — inlined here
@@ -8020,15 +8034,19 @@ export function connectPanePty(
             writeReplayData('\x1b[2J\x1b[3J\x1b[H')
             // Why: raw relay replay may contain the app's own kitty pushes; re-arm with set semantics so redelivery can't grow the stack.
             kittyKeyboardModes.scanReplay(connectResult.replay)
+            if (
+              typeof connectResult.snapshotKittyKeyboardFlags === 'number' &&
+              connectResult.snapshotKittyKeyboardFlags > 0
+            ) {
+              kittyKeyboardModes.applyAuthoritativeFlags(connectResult.snapshotKittyKeyboardFlags)
+            }
             writeReplayData(connectResult.replay)
             writeReplayData(
               reattachReplayResetSequence(connectResult.replay, Boolean(connectResult.coldRestore))
             )
             sendFocusedReattachFocusInAfterReplay(ptyId, attemptGeneration)
-            if (connectResult.coldRestore) {
-              if (!isRemoteRuntimePtyId(ptyId)) {
-                window.api.pty.ackColdRestore(ptyId)
-              }
+            if (connectResult.coldRestore && !isRemoteRuntimePtyId(ptyId)) {
+              window.api.pty.ackColdRestore(ptyId)
             }
           }
         } else if (connectResult?.coldRestore) {

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -62,6 +62,12 @@ export type PtyConnectResult = {
   sessionExpired?: boolean
   coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }
   replay?: string
+  /**
+   * Live PTY kitty keyboard flags from the daemon emulator at reattach time.
+   * Prefer this over stackless scanReplay arithmetic so Option chords stay
+   * protocol-encoded while the TUI still has the protocol pushed (#10381).
+   */
+  snapshotKittyKeyboardFlags?: number
   startupCwdFallback?: { kind: 'worktree'; cwd: string }
   /** Main declined an unverifiable provider-session resume and launched fresh. */
   agentResumeUnavailable?: true

--- a/src/shared/terminal-kitty-keyboard-mode-tracker.test.ts
+++ b/src/shared/terminal-kitty-keyboard-mode-tracker.test.ts
@@ -147,4 +147,26 @@ describe('TerminalKittyKeyboardModeTracker', () => {
     ranAndExited.scanReplay('\x1b[>1uoutput\x1b[<u')
     expect(ranAndExited.flags).toBe(0)
   })
+
+  it('applyAuthoritativeFlags re-seeds after a lossy stackless replay (#10381)', () => {
+    const tracker = new TerminalKittyKeyboardModeTracker()
+    // Nested push/push/pop in a retained window collapses under stackless replay.
+    tracker.scanReplay('\x1b[>7u\x1b[>7u\x1b[<u')
+    expect(tracker.flags).toBe(0)
+
+    tracker.applyAuthoritativeFlags(7)
+    expect(tracker.flags).toBe(7)
+
+    // Live exit pop still drains to inactive after authoritative seed.
+    tracker.scan('\x1b[<u')
+    expect(tracker.flags).toBe(0)
+  })
+
+  it('ignores non-positive authoritative flags', () => {
+    const tracker = new TerminalKittyKeyboardModeTracker()
+    tracker.scan('\x1b[>7u')
+    tracker.applyAuthoritativeFlags(0)
+    tracker.applyAuthoritativeFlags(-1)
+    expect(tracker.flags).toBe(7)
+  })
 })

--- a/src/shared/terminal-kitty-keyboard-mode-tracker.ts
+++ b/src/shared/terminal-kitty-keyboard-mode-tracker.ts
@@ -45,6 +45,28 @@ export class TerminalKittyKeyboardModeTracker {
     return this.alternateScreenSwitchObserved
   }
 
+  /**
+   * Seed flags from the live PTY/emulator (daemon snapshot modes), not from
+   * stackless history replay. Reattach must never leave the mirror at 0 while
+   * the running TUI still has the protocol pushed (#10381).
+   */
+  applyAuthoritativeFlags(flags: number): void {
+    if (!Number.isInteger(flags) || flags <= 0) {
+      return
+    }
+    this.currentFlags = flags
+    // Why: drop stack frames that may have been left wrong by stackless
+    // scanReplay so a later live pop drains cleanly to inactive rather than a
+    // phantom pre-push value.
+    this.mainStack = []
+    this.altStack = []
+    if (this.alternateScreenActive) {
+      this.altFlags = flags
+    } else {
+      this.mainFlags = flags
+    }
+  }
+
   reset(): void {
     this.scanTail = ''
     this.currentFlags = 0


### PR DESCRIPTION
## Summary
- Fixes #10381: long-running kitty-protocol TUIs (e.g. Pi) no longer permanently lose Option/modifier chords after pane reattach/replay.
- **Root cause:** `scanReplay` applies pushes as stackless sets; nested push/pop in the retained window can leave the renderer mirror at flags `0` while the live TUI still has the protocol pushed. Option then falls back to macOS composition (`ø`, …).
- **Fix:** After snapshot/replay scan on reattach, re-seed the tracker from the daemon's live `snapshotKittyKeyboardFlags` (already returned on reattach, previously only used for headless seed).

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-kitty-keyboard-mode-tracker.test.ts` (15 passed)
- [ ] Long Pi session: switch panes / sleep-wake / reattach → Option chords still CSI-u encoded
- [ ] Ctrl+Z / `fg` still works as before (re-push path)

## ELI5

After reattaching a pane, long-running kitty-keyboard TUIs (like Pi) lost Option/modifier shortcuts and fell back to macOS special characters. Reattach now re-seeds live keyboard flags so modifiers keep working.
