### PR TITLE
fix(sidebar): show Cursor agent rows for native cursor agent titles

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -271,4 +271,38 @@ describe('buildTitleDerivedAgentRows', () => {
 
     expect(rows).toHaveLength(0)
   })
+
+  it('shows a Cursor row for the native "cursor agent" title (#10258)', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor', title: 'cursor agent' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'cursor agent' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.lastAssistantMessage])).toEqual([
+      ['cursor', 'idle', 'Idle']
+    ])
+  })
+
+  it('shows a Cursor row for synthetic hook titles without a live hook entry', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'cursor' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'cursor ready' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-cursor'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['cursor', 'idle']])
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,6 +1,6 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
-import { containsBrailleSpinner } from '../../../../shared/agent-title-core'
+import { containsBrailleSpinner, isCursorAgentTitle } from '../../../../shared/agent-title-core'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import type {
@@ -133,8 +133,14 @@ function buildTitleDerivedAgentRow(args: {
   // Why: `claude agents` is a live Claude Code Agent Teams surface, but the
   // shared detector keeps it neutral so runtime liveness probes do not treat
   // the management/list screen as active work.
-  const status = isClaudeAgentsTitle ? 'idle' : classifyTitleActivity(title)
-  const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
+  const titleStatus = isClaudeAgentsTitle ? 'idle' : classifyTitleActivity(title)
+  const titleLabel = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
+  // Why: Cursor's native title ("cursor agent") intentionally returns null from
+  // detectAgentStatusFromTitle so re-emissions don't stomp hook-synthesized
+  // state. Identity still resolves via getAgentLabel → "Cursor", so treat that
+  // as idle and keep the sidebar row (#10258).
+  const status = titleStatus ?? (isCursorAgentTitle(title) ? ('idle' as const) : null)
+  const label = titleLabel
   if (!status || !label) {
     return null
   }


### PR DESCRIPTION
## Summary
- Fixes #10258: Cursor sessions launched from `+` appear in the left worktree agent list even when the terminal title is the constant native `"cursor agent"` string and hooks have not (yet) painted a synthetic status title.
- **Root cause:** `detectAgentStatusFromTitle("cursor agent")` intentionally returns `null` so re-emissions do not stomp hook-synthesized state. Title-derived sidebar rows required a non-null activity status, so Cursor never got a row from the title path (Codex usually has spinner/working titles).
- **Fix:** In title-derived row building, treat Cursor identity titles (`isCursorAgentTitle`) as `idle` when activity classification is null. Identity still comes from the existing Cursor label map.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts src/renderer/src/components/sidebar/useWorktreeAgentRows.test.ts` (41 passed)
- [ ] Launch Cursor from `+` on Windows → row appears under the worktree with Idle/Running as titles update

## ELI5

Cursor agent sessions from + never appeared in the sidebar agent list when the terminal title was the plain cursor agent string. Those sessions now show up as agent rows even before hooks paint a richer title.
