### PR TITLE
fix(ai-vault): prefer Orca tab renames in session history lists

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -61,8 +61,13 @@ export default function AiVaultPanel(): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
   const agentCmdOverrides = settings?.agentCmdOverrides
-  const { getOriginalPaneTarget, getSessionLiveState, jumpToOriginalPane, jumpToWorktree } =
-    useAiVaultOriginalPaneActions()
+  const {
+    getOriginalPaneTarget,
+    getSessionLiveState,
+    orcaCustomTitleByProviderKey,
+    jumpToOriginalPane,
+    jumpToWorktree
+  } = useAiVaultOriginalPaneActions()
   const [query, setQuery] = useState('')
   // Why: scope depends on current workspace/project availability, so only stable view options persist.
   const [scope, setScope] = useState<AiVaultScope>(DEFAULT_AI_VAULT_SCOPE)
@@ -158,7 +163,8 @@ export default function AiVaultPanel(): React.JSX.Element {
     activeWorktree: activeWorktree ?? null,
     activeWorktreeId: activeWorktreeId ?? activeWorktree?.id ?? null,
     targetState: resumeTargetState,
-    agentCmdOverrides
+    agentCmdOverrides,
+    orcaCustomTitleByProviderKey
   })
   const viewAdjustmentCount = countAiVaultViewAdjustments({
     agents,
@@ -203,13 +209,15 @@ export default function AiVaultPanel(): React.JSX.Element {
         activeProjectKey,
         sessionProjectById,
         projectLabelByKey,
-        hideEmptySessions
+        hideEmptySessions,
+        orcaCustomTitleByProviderKey
       }),
     [
       activeProjectKey,
       activeWorktreePaths,
       agents,
       hideEmptySessions,
+      orcaCustomTitleByProviderKey,
       projectLabelByKey,
       query,
       scope,
@@ -355,6 +363,7 @@ export default function AiVaultPanel(): React.JSX.Element {
         getSessionResumeActions={getSessionResumeActions}
         getOriginalPaneTarget={getOriginalPaneTarget}
         getSessionLiveState={getSessionLiveState}
+        orcaCustomTitleByProviderKey={orcaCustomTitleByProviderKey}
         getWorktreeInfo={(session) => sessionWorktreeById.get(session.id) ?? null}
         onToggleGroup={toggleGroup}
         onJumpToOriginalPane={jumpToOriginalPane}

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -29,6 +29,7 @@ import type { AgentStatusState } from '../../../../shared/agent-status-types'
 
 export function VaultSessionRow({
   session,
+  displayTitle,
   liveState,
   resumeStartup,
   realHomeResumeStartup,
@@ -54,6 +55,7 @@ export function VaultSessionRow({
   onOpenCwd
 }: {
   session: AiVaultSession
+  displayTitle: string
   liveState: AgentStatusState | null
   resumeStartup: AiVaultResumeStartup
   realHomeResumeStartup: AiVaultResumeStartup
@@ -99,7 +101,7 @@ export function VaultSessionRow({
       writeAiVaultSessionDragData(event.dataTransfer, {
         agent: session.agent,
         sessionId: session.sessionId,
-        title: session.title,
+        title: displayTitle,
         command: resumeStartup.command,
         sessionFilePath: session.filePath,
         sessionExecutionHostId: session.executionHostId,
@@ -111,7 +113,7 @@ export function VaultSessionRow({
       })
       window.dispatchEvent(new Event(AI_VAULT_SESSION_DRAG_START_EVENT))
     },
-    [realHomeResumeStartup, resumeDisabled, session, resumeStartup]
+    [displayTitle, realHomeResumeStartup, resumeDisabled, session, resumeStartup]
   )
 
   return (
@@ -141,7 +143,7 @@ export function VaultSessionRow({
                 detailsExpanded ? 'line-clamp-2 [overflow-wrap:anywhere]' : 'line-clamp-1'
               )}
             >
-              {session.title}
+              {displayTitle}
             </div>
             <SessionRowTrailingActions
               session={session}

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
@@ -32,6 +32,10 @@ import {
   VAULT_SESSION_ROW_HEIGHT
 } from './ai-vault-virtual-rows'
 import { canContinueAiVaultSessionInNewSession } from './ai-vault-session-continuation'
+import {
+  aiVaultProviderSessionKey,
+  resolveAiVaultSessionDisplayTitle
+} from '../../../../shared/ai-vault-session-display-title'
 
 const VAULT_ROW_OVERSCAN = 8
 const VAULT_EXPANDED_SESSION_ROW_ESTIMATED_HEIGHT = 420
@@ -51,6 +55,7 @@ export function AiVaultSessionVirtualList({
   buildResumeStartup,
   getOriginalPaneTarget,
   getSessionLiveState,
+  orcaCustomTitleByProviderKey,
   getWorktreeInfo,
   getSessionResumeState,
   getSessionResumeActions,
@@ -76,6 +81,7 @@ export function AiVaultSessionVirtualList({
   buildResumeStartup: (session: AiVaultSession, worktreeId?: string | null) => AiVaultResumeStartup
   getOriginalPaneTarget: (session: AiVaultSession) => AiVaultOriginalPaneTarget | null
   getSessionLiveState: (session: AiVaultSession) => AgentStatusState | null
+  orcaCustomTitleByProviderKey: ReadonlyMap<string, string>
   getWorktreeInfo: (session: AiVaultSession) => AiVaultSessionWorktreeInfo | null
   getSessionResumeState: (session: AiVaultSession) => AiVaultSessionResumeState
   getSessionResumeActions: (session: AiVaultSession) => AiVaultSessionResumeActions
@@ -204,6 +210,7 @@ export function AiVaultSessionVirtualList({
               buildResumeStartup={buildResumeStartup}
               getOriginalPaneTarget={getOriginalPaneTarget}
               getSessionLiveState={getSessionLiveState}
+              orcaCustomTitleByProviderKey={orcaCustomTitleByProviderKey}
               getWorktreeInfo={getWorktreeInfo}
               getSessionResumeState={getSessionResumeState}
               getSessionResumeActions={getSessionResumeActions}
@@ -239,6 +246,7 @@ function AiVaultVirtualRow({
   buildResumeStartup,
   getOriginalPaneTarget,
   getSessionLiveState,
+  orcaCustomTitleByProviderKey,
   getWorktreeInfo,
   getSessionResumeState,
   getSessionResumeActions,
@@ -266,6 +274,7 @@ function AiVaultVirtualRow({
   buildResumeStartup: (session: AiVaultSession, worktreeId?: string | null) => AiVaultResumeStartup
   getOriginalPaneTarget: (session: AiVaultSession) => AiVaultOriginalPaneTarget | null
   getSessionLiveState: (session: AiVaultSession) => AgentStatusState | null
+  orcaCustomTitleByProviderKey: ReadonlyMap<string, string>
   getWorktreeInfo: (session: AiVaultSession) => AiVaultSessionWorktreeInfo | null
   getSessionResumeState: (session: AiVaultSession) => AiVaultSessionResumeState
   getSessionResumeActions: (session: AiVaultSession) => AiVaultSessionResumeActions
@@ -336,6 +345,12 @@ function AiVaultVirtualRow({
       ) : (
         <VaultSessionRow
           session={row.session}
+          displayTitle={resolveAiVaultSessionDisplayTitle(
+            row.session.title,
+            orcaCustomTitleByProviderKey.get(
+              aiVaultProviderSessionKey(row.session.agent, row.session.sessionId)
+            )
+          )}
           liveState={getSessionLiveState(row.session)}
           resumeStartup={buildResumeStartup(row.session, resumeState?.worktreeId)}
           realHomeResumeStartup={buildResumeStartup(

--- a/src/renderer/src/components/right-sidebar/ai-vault-orca-title-by-session.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-orca-title-by-session.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { aiVaultProviderSessionKey } from '../../../../shared/ai-vault-session-display-title'
+import type { TerminalTab } from '../../../../shared/types'
+import { buildAiVaultOrcaCustomTitleByProviderKey } from './ai-vault-orca-title-by-session'
+
+function makeTab(id: string, customTitle: string | null): TerminalTab {
+  return {
+    id,
+    worktreeId: 'wt-1',
+    title: 'Codex ready',
+    customTitle,
+    quickCommandLabel: null,
+    generatedTitle: null,
+    defaultTitle: 'Terminal 1',
+    createdAt: 1,
+    cwd: '/repo',
+    shellType: null,
+    splitDirection: null,
+    splitWithTabId: null
+  } as TerminalTab
+}
+
+function liveEntry(args: {
+  paneKey: string
+  tabId: string
+  sessionId: string
+  agentType?: AgentStatusEntry['agentType']
+}): AgentStatusEntry {
+  return {
+    state: 'idle',
+    prompt: 'task',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    agentType: args.agentType ?? 'codex',
+    paneKey: args.paneKey,
+    tabId: args.tabId,
+    worktreeId: 'wt-1',
+    stateHistory: [],
+    providerSession: { key: 'session_id', id: args.sessionId }
+  }
+}
+
+describe('buildAiVaultOrcaCustomTitleByProviderKey', () => {
+  it('maps a live pane customTitle by provider session', () => {
+    const titles = buildAiVaultOrcaCustomTitleByProviderKey({
+      agentStatusByPaneKey: {
+        'tab-1:leaf': liveEntry({
+          paneKey: 'tab-1:leaf',
+          tabId: 'tab-1',
+          sessionId: 'sess-1'
+        })
+      },
+      retainedAgentsByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {},
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-1', 'Patient sync')]
+      }
+    })
+
+    expect(titles.get(aiVaultProviderSessionKey('codex', 'sess-1'))).toBe('Patient sync')
+  })
+
+  it('skips entries without a provider session or empty customTitle', () => {
+    const titles = buildAiVaultOrcaCustomTitleByProviderKey({
+      agentStatusByPaneKey: {
+        'tab-1:leaf': {
+          ...liveEntry({ paneKey: 'tab-1:leaf', tabId: 'tab-1', sessionId: 'sess-1' }),
+          providerSession: undefined
+        },
+        'tab-2:leaf': liveEntry({
+          paneKey: 'tab-2:leaf',
+          tabId: 'tab-2',
+          sessionId: 'sess-2'
+        })
+      },
+      retainedAgentsByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {},
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-1', 'Ignored'), makeTab('tab-2', '   ')]
+      }
+    })
+
+    expect(titles.size).toBe(0)
+  })
+
+  it('prefers live customTitle over retained/sleeping for the same provider session', () => {
+    const titles = buildAiVaultOrcaCustomTitleByProviderKey({
+      agentStatusByPaneKey: {
+        'tab-live:leaf': liveEntry({
+          paneKey: 'tab-live:leaf',
+          tabId: 'tab-live',
+          sessionId: 'sess-1'
+        })
+      },
+      retainedAgentsByPaneKey: {
+        'tab-old:leaf': {
+          entry: liveEntry({
+            paneKey: 'tab-old:leaf',
+            tabId: 'tab-old',
+            sessionId: 'sess-1'
+          }),
+          worktreeId: 'wt-1',
+          tab: { id: 'tab-old' },
+          agentType: 'codex',
+          startedAt: 1
+        }
+      },
+      sleepingAgentSessionsByPaneKey: {
+        'tab-sleep:leaf': {
+          paneKey: 'tab-sleep:leaf',
+          tabId: 'tab-sleep',
+          worktreeId: 'wt-1',
+          agent: 'codex',
+          providerSession: { key: 'session_id', id: 'sess-1' },
+          prompt: 'task',
+          state: 'done',
+          capturedAt: 1,
+          updatedAt: 1,
+          origin: 'live'
+        }
+      },
+      tabsByWorktree: {
+        'wt-1': [
+          makeTab('tab-live', 'Live name'),
+          makeTab('tab-old', 'Retained name'),
+          makeTab('tab-sleep', 'Sleeping name')
+        ]
+      }
+    })
+
+    expect(titles.get(aiVaultProviderSessionKey('codex', 'sess-1'))).toBe('Live name')
+  })
+
+  it('falls back to retained then sleeping when live has no rename', () => {
+    const retainedOnly = buildAiVaultOrcaCustomTitleByProviderKey({
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {
+        'tab-old:leaf': {
+          entry: liveEntry({
+            paneKey: 'tab-old:leaf',
+            tabId: 'tab-old',
+            sessionId: 'sess-2'
+          }),
+          worktreeId: 'wt-1',
+          tab: { id: 'tab-old' },
+          agentType: 'codex',
+          startedAt: 1
+        }
+      },
+      sleepingAgentSessionsByPaneKey: {},
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-old', 'Retained name')]
+      }
+    })
+    expect(retainedOnly.get(aiVaultProviderSessionKey('codex', 'sess-2'))).toBe('Retained name')
+
+    const sleepingOnly = buildAiVaultOrcaCustomTitleByProviderKey({
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {},
+      sleepingAgentSessionsByPaneKey: {
+        'tab-sleep:leaf': {
+          paneKey: 'tab-sleep:leaf',
+          tabId: 'tab-sleep',
+          worktreeId: 'wt-1',
+          agent: 'claude',
+          providerSession: { key: 'session_id', id: 'sess-3' },
+          prompt: 'task',
+          state: 'done',
+          capturedAt: 1,
+          updatedAt: 1,
+          origin: 'live'
+        }
+      },
+      tabsByWorktree: {
+        'wt-1': [makeTab('tab-sleep', 'Sleeping name')]
+      }
+    })
+    expect(sleepingOnly.get(aiVaultProviderSessionKey('claude', 'sess-3'))).toBe('Sleeping name')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-orca-title-by-session.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-orca-title-by-session.ts
@@ -1,0 +1,86 @@
+import { aiVaultProviderSessionKey } from '../../../../shared/ai-vault-session-display-title'
+import type { OriginalPaneState } from './ai-vault-original-pane'
+
+type TabsByWorktree = OriginalPaneState['tabsByWorktree']
+
+/**
+ * Maps providerKey(agent, sessionId) → non-empty Orca tab customTitle.
+ * Live entries win over retained/sleeping when both exist.
+ */
+export function buildAiVaultOrcaCustomTitleByProviderKey(
+  state: Pick<
+    OriginalPaneState,
+    | 'agentStatusByPaneKey'
+    | 'retainedAgentsByPaneKey'
+    | 'sleepingAgentSessionsByPaneKey'
+    | 'tabsByWorktree'
+  >
+): Map<string, string> {
+  const titles = new Map<string, string>()
+  const tabsById = indexTabsById(state.tabsByWorktree)
+
+  for (const entry of Object.values(state.agentStatusByPaneKey)) {
+    if (!entry?.agentType || !entry.providerSession) {
+      continue
+    }
+    const customTitle = customTitleForTab(tabsById, entry.tabId)
+    if (customTitle) {
+      titles.set(aiVaultProviderSessionKey(entry.agentType, entry.providerSession.id), customTitle)
+    }
+  }
+
+  for (const retained of Object.values(state.retainedAgentsByPaneKey)) {
+    if (!retained?.agentType || !retained.entry.providerSession) {
+      continue
+    }
+    const key = aiVaultProviderSessionKey(retained.agentType, retained.entry.providerSession.id)
+    if (titles.has(key)) {
+      continue
+    }
+    const customTitle = customTitleForTab(tabsById, retained.entry.tabId ?? retained.tab.id)
+    if (customTitle) {
+      titles.set(key, customTitle)
+    }
+  }
+
+  for (const record of Object.values(state.sleepingAgentSessionsByPaneKey)) {
+    if (!record) {
+      continue
+    }
+    const key = aiVaultProviderSessionKey(record.agent, record.providerSession.id)
+    if (titles.has(key)) {
+      continue
+    }
+    const customTitle = customTitleForTab(tabsById, record.tabId)
+    if (customTitle) {
+      titles.set(key, customTitle)
+    }
+  }
+
+  return titles
+}
+
+function indexTabsById(
+  tabsByWorktree: TabsByWorktree
+): Map<string, { customTitle: string | null }> {
+  const byId = new Map<string, { customTitle: string | null }>()
+  for (const tabs of Object.values(tabsByWorktree)) {
+    if (!tabs) {
+      continue
+    }
+    for (const tab of tabs) {
+      byId.set(tab.id, tab)
+    }
+  }
+  return byId
+}
+
+function customTitleForTab(
+  tabsById: Map<string, { customTitle: string | null }>,
+  tabId: string | undefined
+): string | null {
+  if (!tabId) {
+    return null
+  }
+  return tabsById.get(tabId)?.customTitle?.trim() || null
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
@@ -13,12 +13,14 @@ import {
   findAiVaultSessionLiveStateInIndex,
   findOriginalAiVaultSessionPaneInIndex
 } from './ai-vault-original-pane-index'
+import { buildAiVaultOrcaCustomTitleByProviderKey } from './ai-vault-orca-title-by-session'
 
 export function useAiVaultOriginalPaneActions(): {
   getOriginalPaneTarget: (
     session: AiVaultSession
   ) => ReturnType<typeof findOriginalAiVaultSessionPane>
   getSessionLiveState: (session: AiVaultSession) => AgentStatusState | null
+  orcaCustomTitleByProviderKey: ReadonlyMap<string, string>
   jumpToOriginalPane: (session: AiVaultSession) => void
   jumpToWorktree: (worktreeId: string) => void
 } {
@@ -35,6 +37,10 @@ export function useAiVaultOriginalPaneActions(): {
   // Build once on the first actual lookup, then share it across visible rows.
   const getOriginalPaneIndex = useMemo(
     () => createLazyAiVaultOriginalPaneIndex(originalPaneLookupState),
+    [originalPaneLookupState]
+  )
+  const orcaCustomTitleByProviderKey = useMemo(
+    () => buildAiVaultOrcaCustomTitleByProviderKey(originalPaneLookupState),
     [originalPaneLookupState]
   )
 
@@ -90,5 +96,11 @@ export function useAiVaultOriginalPaneActions(): {
     }
   }, [])
 
-  return { getOriginalPaneTarget, getSessionLiveState, jumpToOriginalPane, jumpToWorktree }
+  return {
+    getOriginalPaneTarget,
+    getSessionLiveState,
+    orcaCustomTitleByProviderKey,
+    jumpToOriginalPane,
+    jumpToWorktree
+  }
 }

--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-index.ts
@@ -1,4 +1,5 @@
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
+import { aiVaultProviderSessionKey } from '../../../../shared/ai-vault-session-display-title'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import {
   promptsMatchSession,
@@ -23,12 +24,6 @@ export type AiVaultOriginalPaneIndex = {
   sleepingByProvider: ProviderIndex<SleepingEntry>
 }
 
-function providerKey(agent: string, sessionId: string): string {
-  // Why: unlike punctuation delimiters, NUL cannot collide with agent or
-  // provider-session text, so distinct identity pairs stay distinct keys.
-  return `${agent}\u0000${sessionId}`
-}
-
 function appendToIndex<T>(index: Map<string, T[]>, key: string, value: T): void {
   const entries = index.get(key)
   if (entries) {
@@ -50,7 +45,11 @@ export function buildAiVaultOriginalPaneIndex(state: OriginalPaneState): AiVault
       continue
     }
     if (entry.providerSession) {
-      appendToIndex(liveByProvider, providerKey(entry.agentType, entry.providerSession.id), entry)
+      appendToIndex(
+        liveByProvider,
+        aiVaultProviderSessionKey(entry.agentType, entry.providerSession.id),
+        entry
+      )
     } else if (entry.providerSession === undefined) {
       appendToIndex(liveWithoutProviderByAgent, entry.agentType, entry)
     }
@@ -62,7 +61,7 @@ export function buildAiVaultOriginalPaneIndex(state: OriginalPaneState): AiVault
     if (retained.entry.providerSession) {
       appendToIndex(
         retainedByProvider,
-        providerKey(retained.agentType, retained.entry.providerSession.id),
+        aiVaultProviderSessionKey(retained.agentType, retained.entry.providerSession.id),
         retained
       )
     } else if (retained.entry.providerSession === undefined) {
@@ -73,7 +72,7 @@ export function buildAiVaultOriginalPaneIndex(state: OriginalPaneState): AiVault
     if (record) {
       appendToIndex(
         sleepingByProvider,
-        providerKey(record.agent, record.providerSession.id),
+        aiVaultProviderSessionKey(record.agent, record.providerSession.id),
         record
       )
     }
@@ -103,7 +102,7 @@ export function findOriginalAiVaultSessionPaneInIndex(
   index: AiVaultOriginalPaneIndex,
   session: AiVaultSession
 ): AiVaultOriginalPaneTarget | null {
-  const key = providerKey(session.agent, session.sessionId)
+  const key = aiVaultProviderSessionKey(session.agent, session.sessionId)
   const promptMatchedTargets: AiVaultOriginalPaneTarget[] = []
 
   for (const entry of index.liveByProvider.get(key) ?? []) {
@@ -175,7 +174,9 @@ export function findAiVaultSessionLiveStateInIndex(
   index: AiVaultOriginalPaneIndex,
   session: AiVaultSession
 ): AgentStatusState | null {
-  const direct = index.liveByProvider.get(providerKey(session.agent, session.sessionId))
+  const direct = index.liveByProvider.get(
+    aiVaultProviderSessionKey(session.agent, session.sessionId)
+  )
   if (direct?.[0]) {
     return direct[0].state
   }

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-continuation.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-continuation.test.ts
@@ -57,12 +57,24 @@ describe('AI Vault session continuation', () => {
       launchSource: 'sidebar',
       source: {
         sourceAgent: 'claude',
+        sourceTitle: 'Finish the editor refactor',
         lastPrompt: 'Finish the editor refactor',
         lastAssistantMessage: 'The component tests still need work.'
       }
     })
     expect(request.source.transcriptPath).toContain('session.jsonl')
     expect(request.source.capturedText).toContain('assistant: The component tests still need work.')
+  })
+
+  it('uses the Orca custom title for sourceTitle when provided', () => {
+    const request = prepareAiVaultSessionContinuation({
+      session: session(),
+      targetWorktreeId: 'worktree-1',
+      targetWorkspacePath: '/Users/ada/Desktop/current-worktree',
+      orcaCustomTitle: 'Editor refactor spike'
+    })
+
+    expect(request.source.sourceTitle).toBe('Editor refactor spike')
   })
 
   it('never treats a preview tool result as the user prompt', () => {

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-continuation.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-continuation.ts
@@ -1,4 +1,5 @@
 import type { AgentSessionContinuationRequest } from '@/lib/agent-session-continuation'
+import { resolveAiVaultSessionDisplayTitle } from '../../../../shared/ai-vault-session-display-title'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 
 export function canContinueAiVaultSessionInNewSession(
@@ -15,13 +16,14 @@ export function prepareAiVaultSessionContinuation(args: {
   session: AiVaultSession
   targetWorktreeId: string
   targetWorkspacePath: string
+  orcaCustomTitle?: string | null
 }): AgentSessionContinuationRequest {
-  const { session, targetWorktreeId, targetWorkspacePath } = args
+  const { session, targetWorktreeId, targetWorkspacePath, orcaCustomTitle } = args
   return {
     source: {
       capturedText: previewTranscript(session),
       sourceAgent: session.agent,
-      sourceTitle: session.title,
+      sourceTitle: resolveAiVaultSessionDisplayTitle(session.title, orcaCustomTitle),
       sourceWorkingDirectory: session.cwd,
       transcriptPath: session.filePath.trim() || null,
       // Why: preview user entries can be tool results or injected skill text; only provider-authenticated prompts are safe hints.

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -28,18 +28,24 @@ import {
 } from './ai-vault-session-resume'
 import { prepareAiVaultSessionContinuation } from './ai-vault-session-continuation'
 import type { AgentSessionContinuationRequest } from '@/lib/agent-session-continuation'
-import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { aiVaultProviderSessionKey } from '../../../../shared/ai-vault-session-display-title'
+import {
+  notifyAiVaultSessionPreparationFailure,
+  resolveAiVaultTargetWorkspacePath
+} from './ai-vault-session-launch-workspace-path'
 
 export function useAiVaultSessionLaunchActions({
   activeWorktree,
   activeWorktreeId,
   targetState,
-  agentCmdOverrides
+  agentCmdOverrides,
+  orcaCustomTitleByProviderKey
 }: {
   activeWorktree: Worktree | null
   activeWorktreeId: string | null
   targetState: AiVaultSessionResumeTargetState
   agentCmdOverrides?: Partial<Record<AiVaultAgent, string | null>>
+  orcaCustomTitleByProviderKey?: ReadonlyMap<string, string>
 }): {
   buildResumeStartup: (session: AiVaultSession, worktreeId?: string | null) => AiVaultResumeStartup
   copyResumeCommand: (session: AiVaultSession, worktreeId?: string | null) => Promise<void>
@@ -180,11 +186,14 @@ export function useAiVaultSessionLaunchActions({
         prepareAiVaultSessionContinuation({
           session,
           targetWorktreeId: targetId.worktreeId,
-          targetWorkspacePath
+          targetWorkspacePath,
+          orcaCustomTitle: orcaCustomTitleByProviderKey?.get(
+            aiVaultProviderSessionKey(session.agent, session.sessionId)
+          )
         })
       )
     },
-    [activeWorktree?.id, activeWorktreeId, targetState]
+    [activeWorktree?.id, activeWorktreeId, orcaCustomTitleByProviderKey, targetState]
   )
 
   const handleContinuationDialogOpenChange = useCallback((open: boolean): void => {
@@ -201,32 +210,6 @@ export function useAiVaultSessionLaunchActions({
     continuationRequest,
     handleContinuationDialogOpenChange
   }
-}
-
-function notifyAiVaultSessionPreparationFailure(error: unknown): void {
-  toast.error(
-    error instanceof Error
-      ? error.message
-      : translate(
-          'auto.components.right.sidebar.AiVaultPanel.prepareSessionResumeFailed',
-          'Could not prepare this session for resume.'
-        )
-  )
-}
-
-function resolveAiVaultTargetWorkspacePath(
-  state: AiVaultSessionResumeTargetState,
-  workspaceId: string
-): string | null {
-  const scope = parseWorkspaceKey(workspaceId)
-  if (scope?.type === 'folder') {
-    return (
-      state.folderWorkspaces.find((workspace) => workspace.id === scope.folderWorkspaceId)
-        ?.folderPath ?? null
-    )
-  }
-  const worktreeId = scope?.type === 'worktree' ? scope.worktreeId : workspaceId
-  return findWorktreeById(state.worktreesByRepo, worktreeId)?.path ?? null
 }
 
 export type AiVaultSessionLaunchTarget =

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-workspace-path.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-workspace-path.ts
@@ -1,0 +1,31 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { findWorktreeById } from '@/store/slices/worktree-helpers'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import type { AiVaultSessionResumeTargetState } from './ai-vault-session-resume'
+
+export function notifyAiVaultSessionPreparationFailure(error: unknown): void {
+  toast.error(
+    error instanceof Error
+      ? error.message
+      : translate(
+          'auto.components.right.sidebar.AiVaultPanel.prepareSessionResumeFailed',
+          'Could not prepare this session for resume.'
+        )
+  )
+}
+
+export function resolveAiVaultTargetWorkspacePath(
+  state: AiVaultSessionResumeTargetState,
+  workspaceId: string
+): string | null {
+  const scope = parseWorkspaceKey(workspaceId)
+  if (scope?.type === 'folder') {
+    return (
+      state.folderWorkspaces.find((workspace) => workspace.id === scope.folderWorkspaceId)
+        ?.folderPath ?? null
+    )
+  }
+  const worktreeId = scope?.type === 'worktree' ? scope.worktreeId : workspaceId
+  return findWorktreeById(state.worktreesByRepo, worktreeId)?.path ?? null
+}

--- a/src/shared/ai-vault-session-display-title.test.ts
+++ b/src/shared/ai-vault-session-display-title.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import {
+  aiVaultProviderSessionKey,
+  resolveAiVaultSessionDisplayTitle
+} from './ai-vault-session-display-title'
+
+describe('resolveAiVaultSessionDisplayTitle', () => {
+  it('prefers a non-empty Orca custom title', () => {
+    expect(resolveAiVaultSessionDisplayTitle('Scanner title', 'My rename')).toBe('My rename')
+  })
+
+  it('falls through blank or whitespace custom titles', () => {
+    expect(resolveAiVaultSessionDisplayTitle('Scanner title', null)).toBe('Scanner title')
+    expect(resolveAiVaultSessionDisplayTitle('Scanner title', undefined)).toBe('Scanner title')
+    expect(resolveAiVaultSessionDisplayTitle('Scanner title', '   ')).toBe('Scanner title')
+  })
+})
+
+describe('aiVaultProviderSessionKey', () => {
+  it('keeps distinct agent/session pairs distinct', () => {
+    expect(aiVaultProviderSessionKey('codex', 'a')).not.toBe(
+      aiVaultProviderSessionKey('claude', 'a')
+    )
+    expect(aiVaultProviderSessionKey('codex', 'a')).not.toBe(
+      aiVaultProviderSessionKey('codex', 'b')
+    )
+  })
+})

--- a/src/shared/ai-vault-session-display-title.ts
+++ b/src/shared/ai-vault-session-display-title.ts
@@ -1,0 +1,14 @@
+/** Stable key for agent + provider-session identity pairs. */
+export function aiVaultProviderSessionKey(agent: string, sessionId: string): string {
+  // Why: unlike punctuation delimiters, NUL cannot collide with agent or
+  // provider-session text, so distinct identity pairs stay distinct keys.
+  return `${agent}\u0000${sessionId}`
+}
+
+/** Orca tab rename wins; scanner title already encodes harness/AI/prompt/fallback. */
+export function resolveAiVaultSessionDisplayTitle(
+  sessionTitle: string,
+  orcaCustomTitle?: string | null
+): string {
+  return orcaCustomTitle?.trim() || sessionTitle
+}

--- a/src/shared/ai-vault-session-filters.test.ts
+++ b/src/shared/ai-vault-session-filters.test.ts
@@ -8,6 +8,7 @@ import {
   parseVaultQuery
 } from './ai-vault-session-filters'
 import { sessionPreviewSearchText } from './ai-vault-session-display'
+import { aiVaultProviderSessionKey } from './ai-vault-session-display-title'
 
 const baseSession: AiVaultSession = {
   id: 'claude:1',
@@ -112,5 +113,32 @@ describe('/shared ai-vault-session-filters (lifted core)', () => {
 
   it('builds preview search text from conversation turns', () => {
     expect(sessionPreviewSearchText(baseSession)).toContain('scope tabs')
+  })
+
+  it('matches query terms against the Orca custom title overlay', () => {
+    expect(
+      filterAiVaultSessions([baseSession], {
+        query: 'patient-sync',
+        agents: ['claude'],
+        scope: 'all',
+        sort: 'updated',
+        activeWorktreePaths: [],
+        hideEmptySessions: true,
+        orcaCustomTitleByProviderKey: new Map([
+          [aiVaultProviderSessionKey('claude', 'session-1'), 'patient-sync spike']
+        ])
+      }).map((session) => session.id)
+    ).toEqual(['claude:1'])
+
+    expect(
+      filterAiVaultSessions([baseSession], {
+        query: 'patient-sync',
+        agents: ['claude'],
+        scope: 'all',
+        sort: 'updated',
+        activeWorktreePaths: [],
+        hideEmptySessions: true
+      })
+    ).toEqual([])
   })
 })

--- a/src/shared/ai-vault-session-filters.ts
+++ b/src/shared/ai-vault-session-filters.ts
@@ -19,6 +19,10 @@ import {
 } from './ai-vault-types'
 import type { ExecutionHostId } from './execution-host'
 import { sessionPreviewSearchText } from './ai-vault-session-display'
+import {
+  aiVaultProviderSessionKey,
+  resolveAiVaultSessionDisplayTitle
+} from './ai-vault-session-display-title'
 
 // Why: the plain project descriptor is relocated here (no runtime dep) so the
 // filter-state type can reference it without dragging the renderer-located
@@ -42,6 +46,8 @@ export type AiVaultSessionFilterState = {
   sessionProjectById?: ReadonlyMap<string, AiVaultSessionProject>
   projectLabelByKey?: ReadonlyMap<string, string>
   hideEmptySessions: boolean
+  /** Orca tab renames keyed by aiVaultProviderSessionKey(agent, sessionId). */
+  orcaCustomTitleByProviderKey?: ReadonlyMap<string, string>
 }
 
 export type AiVaultSessionGroup = {
@@ -184,10 +190,16 @@ export function parseVaultQuery(query: string): ParsedQuery {
 function matchesQuery(
   session: AiVaultSession,
   parsed: ParsedQuery,
-  filters: Pick<AiVaultSessionFilterState, 'sessionProjectById' | 'projectLabelByKey'>
+  filters: Pick<
+    AiVaultSessionFilterState,
+    'sessionProjectById' | 'projectLabelByKey' | 'orcaCustomTitleByProviderKey'
+  >
 ): boolean {
+  const orcaCustomTitle = filters.orcaCustomTitleByProviderKey?.get(
+    aiVaultProviderSessionKey(session.agent, session.sessionId)
+  )
   const searchable = [
-    session.title,
+    resolveAiVaultSessionDisplayTitle(session.title, orcaCustomTitle),
     session.sessionId,
     session.agent,
     session.branch,


### PR DESCRIPTION
Overlay customTitle onto vault/resume/continuation labels when a provider session still links to a live, retained, or sleeping tab (#10250).

## Summary

Agent Session History / resume / continuation labels now prefer an Orca tab rename (`customTitle`) when that session is still linked to a live, retained, or sleeping pane. Otherwise they keep the existing scanner title (harness custom title → AI title → first prompt → fallback), so many concurrent sessions stay easier to identify.

## Screenshots

No visual change

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Unit coverage added for display-title resolution, provider-session → `customTitle` lookup (live/retained/sleeping precedence), vault search overlay matching, and continuation `sourceTitle` overlay.

## AI Review Report

Reviewed the read-side overlay approach against #10250’s precedence goal.

**Risks checked**
- Wrong session getting another tab’s rename (provider key collisions, live vs retained/sleeping precedence)
- Applying Orca renames to subagent rows that share a parent session id
- Mutating scanner/`session.title` used by path/worktree matching heuristics
- Cross-harness continuation inventing a new label when an Orca rename is known
- Cross-platform: no new shortcuts, UI accelerator labels, path separators, shell commands, or Electron platform branches; display overlay is pure string resolution keyed by agent + provider session id (NUL delimiter already used by the original-pane index). macOS / Linux / Windows behavior is identical for this change.

**Flags / verification**
- Subagent vault lines intentionally left on scanner titles (shared parent session id would incorrectly inherit the parent rename).
- Overlay is unavailable after a session is fully gone (no live/retained/sleeping tab link); closed sessions keep scanner titles by design (no new persistence).
- Search/filter uses the resolved display title; worktree extraction and prompt-match heuristics still use raw `session.title`.

## Security Audit

Low risk, display-only overlay.

- **Input handling:** trims user `customTitle`; blank/whitespace falls through to scanner title.
- **Command execution / IPC:** no new shell, resume argv, or IPC surfaces; resume commands unchanged.
- **Paths:** no new filesystem reads/writes; workspace path resolution only moved between modules.
- **Auth / secrets / deps:** none touched.
- **Follow-up:** none required for this PR.

## Notes

- Follow-up if needed: persist Orca renames by provider session id so Vault still shows them after the tab is fully closed.
- Fixes / tracks stablyai/orca#10250.

Made with [Cursor](https://cursor.com)

## ELI5

Session history lists often showed generic AI titles even after you renamed the tab. If the session still links to a live or sleeping tab, the list now prefers your custom tab name so concurrent sessions are easier to tell apart.
