### PR TITLE
feat(codex-accounts): import existing CODEX_HOME without re-login

### DIFF
--- a/src/main/codex-accounts/import-existing-codex-home.test.ts
+++ b/src/main/codex-accounts/import-existing-codex-home.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  assertSourceHomeIsNotManagedStorage,
+  copyExistingCodexHomeIntoManaged,
+  readRawAuthJsonFromHome,
+  resolveImportableCodexHomePath
+} from './import-existing-codex-home'
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-import-codex-home-'))
+  roots.push(root)
+  return root
+}
+
+describe('import-existing-codex-home', () => {
+  it('resolves a directory that has auth.json', () => {
+    const root = makeRoot()
+    const home = join(root, '.codex-work')
+    mkdirSync(home)
+    writeFileSync(join(home, 'auth.json'), '{"tokens":{}}', 'utf-8')
+
+    expect(resolveImportableCodexHomePath(home)).toBe(home)
+  })
+
+  it('rejects missing auth.json', () => {
+    const root = makeRoot()
+    const home = join(root, 'empty')
+    mkdirSync(home)
+
+    expect(() => resolveImportableCodexHomePath(home)).toThrow(/missing auth\.json/)
+  })
+
+  it('rejects paths inside managed storage', () => {
+    const root = makeRoot()
+    const managedRoot = join(root, 'codex-accounts')
+    const nested = join(managedRoot, 'account-1', 'home')
+    mkdirSync(nested, { recursive: true })
+    writeFileSync(join(nested, 'auth.json'), '{}', 'utf-8')
+
+    expect(() => assertSourceHomeIsNotManagedStorage(nested, managedRoot)).toThrow(
+      /already inside Orca managed/
+    )
+  })
+
+  it('copies home contents and rewrites the Orca ownership marker', () => {
+    const root = makeRoot()
+    const source = join(root, 'source')
+    const managed = join(root, 'managed')
+    mkdirSync(source)
+    mkdirSync(managed)
+    writeFileSync(join(source, 'auth.json'), '{"tokens":{"id_token":"x"}}', 'utf-8')
+    writeFileSync(join(source, 'config.toml'), 'sandbox_mode = "workspace-write"\n', 'utf-8')
+    writeFileSync(join(source, '.orca-managed-home'), 'other-id\n', 'utf-8')
+    writeFileSync(join(managed, '.orca-managed-home'), 'account-import\n', 'utf-8')
+    mkdirSync(join(source, 'sessions'))
+    writeFileSync(join(source, 'sessions', 'a.jsonl'), 'session\n', 'utf-8')
+
+    copyExistingCodexHomeIntoManaged({
+      sourceHomePath: source,
+      managedHomePath: managed,
+      accountId: 'account-import'
+    })
+
+    expect(readFileSync(join(managed, 'auth.json'), 'utf-8')).toContain('id_token')
+    expect(readFileSync(join(managed, 'config.toml'), 'utf-8')).toContain('workspace-write')
+    expect(readFileSync(join(managed, 'sessions', 'a.jsonl'), 'utf-8')).toBe('session\n')
+    expect(readFileSync(join(managed, '.orca-managed-home'), 'utf-8')).toBe('account-import\n')
+    expect(existsSync(join(source, 'auth.json'))).toBe(true)
+  })
+
+  it('parses auth.json without leaking parse errors for corrupt files', () => {
+    const root = makeRoot()
+    const home = join(root, 'home')
+    mkdirSync(home)
+    writeFileSync(join(home, 'auth.json'), '{not-json', 'utf-8')
+
+    expect(() => readRawAuthJsonFromHome(home)).toThrow(/corrupt or not valid JSON/)
+  })
+})

--- a/src/main/codex-accounts/import-existing-codex-home.test.ts
+++ b/src/main/codex-accounts/import-existing-codex-home.test.ts
@@ -53,7 +53,7 @@ describe('import-existing-codex-home', () => {
     )
   })
 
-  it('copies home contents and rewrites the Orca ownership marker', () => {
+  it('copies home contents and rewrites the Orca ownership marker', async () => {
     const root = makeRoot()
     const source = join(root, 'source')
     const managed = join(root, 'managed')
@@ -66,7 +66,7 @@ describe('import-existing-codex-home', () => {
     mkdirSync(join(source, 'sessions'))
     writeFileSync(join(source, 'sessions', 'a.jsonl'), 'session\n', 'utf-8')
 
-    copyExistingCodexHomeIntoManaged({
+    await copyExistingCodexHomeIntoManaged({
       sourceHomePath: source,
       managedHomePath: managed,
       accountId: 'account-import'

--- a/src/main/codex-accounts/import-existing-codex-home.ts
+++ b/src/main/codex-accounts/import-existing-codex-home.ts
@@ -1,0 +1,116 @@
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  writeFileSync
+} from 'node:fs'
+import { join, resolve, sep } from 'node:path'
+
+const ORCA_MANAGED_HOME_MARKER = '.orca-managed-home'
+
+/**
+ * Resolve and validate a user-selected directory as an importable CODEX_HOME.
+ * Does not require Orca ownership — the source is an external home the user already authenticated.
+ */
+export function resolveImportableCodexHomePath(sourceHomePath: string): string {
+  const trimmed = sourceHomePath.trim()
+  if (!trimmed) {
+    throw new Error('Choose a CODEX_HOME directory to import.')
+  }
+
+  const resolved = resolve(trimmed)
+  if (!existsSync(resolved)) {
+    throw new Error(`CODEX_HOME does not exist: ${resolved}`)
+  }
+
+  let stats
+  try {
+    stats = lstatSync(resolved)
+  } catch (error) {
+    throw new Error(`Could not inspect CODEX_HOME: ${resolved}`, { cause: error })
+  }
+  if (!stats.isDirectory()) {
+    throw new Error(`CODEX_HOME must be a directory: ${resolved}`)
+  }
+
+  const authPath = join(resolved, 'auth.json')
+  if (!existsSync(authPath) || !lstatSync(authPath).isFile()) {
+    throw new Error(
+      `Not a valid CODEX_HOME (missing auth.json): ${resolved}. Sign in with Codex in that directory first, then import again.`
+    )
+  }
+
+  return resolved
+}
+
+/** Refuse to import from inside Orca managed storage (would re-copy Orca's own homes). */
+export function assertSourceHomeIsNotManagedStorage(
+  sourceHomePath: string,
+  managedAccountsRoot: string
+): void {
+  const sourceReal = safeRealpath(sourceHomePath)
+  const managedReal = safeRealpath(managedAccountsRoot)
+  if (!sourceReal || !managedReal) {
+    return
+  }
+  const prefix = managedReal.endsWith(sep) ? managedReal : `${managedReal}${sep}`
+  if (sourceReal === managedReal || sourceReal.startsWith(prefix)) {
+    throw new Error(
+      'That directory is already inside Orca managed Codex storage. Pick an external CODEX_HOME (for example ~/.codex-work).'
+    )
+  }
+}
+
+/**
+ * Copy an external CODEX_HOME into a freshly created managed home.
+ * Preserves auth and credentials; keeps the Orca ownership marker authoritative.
+ */
+export function copyExistingCodexHomeIntoManaged(params: {
+  sourceHomePath: string
+  managedHomePath: string
+  accountId: string
+}): void {
+  const { sourceHomePath, managedHomePath, accountId } = params
+  const entries = readdirSync(sourceHomePath, { withFileTypes: true })
+  for (const entry of entries) {
+    if (entry.name === ORCA_MANAGED_HOME_MARKER) {
+      continue
+    }
+    const from = join(sourceHomePath, entry.name)
+    const to = join(managedHomePath, entry.name)
+    cpSync(from, to, {
+      recursive: true,
+      force: true,
+      // Why: CODEX_HOME often holds symlinks (skills, config overlays); copy
+      // contents so the managed home stays self-contained on every host.
+      dereference: true
+    })
+  }
+  writeFileSync(join(managedHomePath, ORCA_MANAGED_HOME_MARKER), `${accountId}\n`, 'utf-8')
+}
+
+export function readRawAuthJsonFromHome(homePath: string): Record<string, unknown> {
+  const authFilePath = join(homePath, 'auth.json')
+  const authFileContents = readFileSync(authFilePath, 'utf-8')
+  try {
+    return JSON.parse(authFileContents) as Record<string, unknown>
+  } catch {
+    // Why: never echo credential bytes into logs/error UI.
+    throw new Error('Codex auth.json is corrupt or not valid JSON')
+  }
+}
+
+function safeRealpath(path: string): string | null {
+  try {
+    return realpathSync(path)
+  } catch {
+    try {
+      return resolve(path)
+    } catch {
+      return null
+    }
+  }
+}

--- a/src/main/codex-accounts/import-existing-codex-home.ts
+++ b/src/main/codex-accounts/import-existing-codex-home.ts
@@ -1,12 +1,12 @@
 import {
-  cpSync,
   existsSync,
-  lstatSync,
   readdirSync,
   readFileSync,
   realpathSync,
+  statSync,
   writeFileSync
 } from 'node:fs'
+import { cp } from 'node:fs/promises'
 import { join, resolve, sep } from 'node:path'
 
 const ORCA_MANAGED_HOME_MARKER = '.orca-managed-home'
@@ -28,7 +28,8 @@ export function resolveImportableCodexHomePath(sourceHomePath: string): string {
 
   let stats
   try {
-    stats = lstatSync(resolved)
+    // Why: follow symlinks so a linked external home / auth.json is importable.
+    stats = statSync(resolved)
   } catch (error) {
     throw new Error(`Could not inspect CODEX_HOME: ${resolved}`, { cause: error })
   }
@@ -37,7 +38,7 @@ export function resolveImportableCodexHomePath(sourceHomePath: string): string {
   }
 
   const authPath = join(resolved, 'auth.json')
-  if (!existsSync(authPath) || !lstatSync(authPath).isFile()) {
+  if (!existsSync(authPath) || !statSync(authPath).isFile()) {
     throw new Error(
       `Not a valid CODEX_HOME (missing auth.json): ${resolved}. Sign in with Codex in that directory first, then import again.`
     )
@@ -68,11 +69,11 @@ export function assertSourceHomeIsNotManagedStorage(
  * Copy an external CODEX_HOME into a freshly created managed home.
  * Preserves auth and credentials; keeps the Orca ownership marker authoritative.
  */
-export function copyExistingCodexHomeIntoManaged(params: {
+export async function copyExistingCodexHomeIntoManaged(params: {
   sourceHomePath: string
   managedHomePath: string
   accountId: string
-}): void {
+}): Promise<void> {
   const { sourceHomePath, managedHomePath, accountId } = params
   const entries = readdirSync(sourceHomePath, { withFileTypes: true })
   for (const entry of entries) {
@@ -81,7 +82,8 @@ export function copyExistingCodexHomeIntoManaged(params: {
     }
     const from = join(sourceHomePath, entry.name)
     const to = join(managedHomePath, entry.name)
-    cpSync(from, to, {
+    // Why: async copy so large CODEX_HOME trees do not freeze the Electron main process.
+    await cp(from, to, {
       recursive: true,
       force: true,
       // Why: CODEX_HOME often holds symlinks (skills, config overlays); copy

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -851,7 +851,7 @@ describe('CodexAccountService config sync', () => {
       )
 
       await expect(service.addAccount()).rejects.toThrow(
-        'Orca cannot add a Codex OAuth account while ~/.codex/config.toml pins the custom provider "codex-lb". Keep using the system-default account for this provider, or remove model_provider (or set it to "openai") before adding an OAuth account. Orca left your config unchanged.'
+        'Orca cannot add a Codex OAuth account while the active Codex config pins the custom provider "codex-lb". Keep using the system-default account for this provider, or remove model_provider (or set it to "openai") before adding an OAuth account. Orca left your config unchanged.'
       )
 
       expect(spawnMock).not.toHaveBeenCalled()
@@ -918,6 +918,54 @@ describe('CodexAccountService config sync', () => {
       expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalled()
       // Source home is left intact (copy, not move).
       expect(existsSync(join(sourceHome, 'auth.json'))).toBe(true)
+    } finally {
+      vi.doUnmock('node:crypto')
+      vi.doUnmock('node:child_process')
+    }
+  })
+
+  it('rejects an imported OAuth home that pins a custom provider without canonical config', async () => {
+    vi.resetModules()
+    vi.doMock('node:crypto', () => ({ randomUUID: () => 'should-not-create' }))
+    const spawnMock = vi.fn()
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: spawnMock }))
+
+    try {
+      const sourceHome = join(testState.fakeHomeDir, '.codex-custom-provider')
+      const sourceConfig = [
+        'model_provider = "codex-lb"',
+        '',
+        '[model_providers.codex-lb]',
+        'base_url = "https://codex-lb.example.test/v1"',
+        'env_key = "CODEX_LB_API_KEY"',
+        ''
+      ].join('\n')
+      mkdirSync(sourceHome, { recursive: true })
+      writeFileSync(
+        join(sourceHome, 'auth.json'),
+        createCodexAuthJson('imported@example.com', 'provider-imported', 'refresh-imported'),
+        'utf-8'
+      )
+      writeFileSync(join(sourceHome, 'config.toml'), sourceConfig, 'utf-8')
+
+      const settings = createSettings()
+      const store = createStore(settings)
+      const service = new (await import('./service')).CodexAccountService(
+        store as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      await expect(service.importAccountFromExistingHome(sourceHome)).rejects.toThrow(
+        'Orca cannot add a Codex OAuth account while the active Codex config pins the custom provider "codex-lb".'
+      )
+
+      expect(spawnMock).not.toHaveBeenCalled()
+      expect(store.updateSettings).not.toHaveBeenCalled()
+      expect(existsSync(join(testState.userDataDir, 'codex-accounts', 'should-not-create'))).toBe(
+        false
+      )
+      expect(readFileSync(join(sourceHome, 'config.toml'), 'utf-8')).toBe(sourceConfig)
     } finally {
       vi.doUnmock('node:crypto')
       vi.doUnmock('node:child_process')

--- a/src/main/codex-accounts/service.test.ts
+++ b/src/main/codex-accounts/service.test.ts
@@ -867,6 +867,117 @@ describe('CodexAccountService config sync', () => {
     }
   })
 
+  it('imports an existing CODEX_HOME without running codex login', async () => {
+    vi.resetModules()
+    vi.doMock('node:crypto', () => ({ randomUUID: () => 'imported-account-id' }))
+    const spawnMock = vi.fn()
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: spawnMock }))
+
+    try {
+      const sourceHome = join(testState.fakeHomeDir, '.codex-work')
+      mkdirSync(sourceHome, { recursive: true })
+      writeFileSync(
+        join(sourceHome, 'auth.json'),
+        createCodexAuthJson('imported@example.com', 'provider-imported', 'refresh-imported'),
+        'utf-8'
+      )
+      writeFileSync(join(sourceHome, 'config.toml'), 'sandbox_mode = "workspace-write"\n', 'utf-8')
+      writeFileSync(join(sourceHome, 'extra-marker.txt'), 'keep-me\n', 'utf-8')
+
+      const settings = createSettings()
+      const store = createStore(settings)
+      const rateLimits = createRateLimits()
+      const runtimeHome = createRuntimeHome()
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeHome as never
+      )
+
+      const snapshot = await service.importAccountFromExistingHome(sourceHome)
+
+      expect(spawnMock).not.toHaveBeenCalled()
+      expect(snapshot.accounts).toHaveLength(1)
+      expect(snapshot.accounts[0]?.email).toBe('imported@example.com')
+      expect(snapshot.activeAccountId).toBe('imported-account-id')
+
+      const managedHomePath = join(
+        testState.userDataDir,
+        'codex-accounts',
+        'imported-account-id',
+        'home'
+      )
+      expect(readFileSync(join(managedHomePath, '.orca-managed-home'), 'utf-8')).toBe(
+        'imported-account-id\n'
+      )
+      expect(readFileSync(join(managedHomePath, 'extra-marker.txt'), 'utf-8')).toBe('keep-me\n')
+      expect(readFileSync(join(managedHomePath, 'auth.json'), 'utf-8')).toContain(
+        'provider-imported'
+      )
+      expect(runtimeHome.syncForCurrentSelection).toHaveBeenCalled()
+      // Source home is left intact (copy, not move).
+      expect(existsSync(join(sourceHome, 'auth.json'))).toBe(true)
+    } finally {
+      vi.doUnmock('node:crypto')
+      vi.doUnmock('node:child_process')
+    }
+  })
+
+  it('rejects import when the selected home has no resolvable OAuth email', async () => {
+    vi.resetModules()
+    vi.doMock('node:crypto', () => ({ randomUUID: () => 'should-not-create' }))
+    const spawnMock = vi.fn()
+    vi.doMock('node:child_process', () => ({ execFileSync: vi.fn(), spawn: spawnMock }))
+
+    try {
+      const sourceHome = join(testState.fakeHomeDir, '.codex-api-key-only')
+      mkdirSync(sourceHome, { recursive: true })
+      writeFileSync(
+        join(sourceHome, 'auth.json'),
+        JSON.stringify({ OPENAI_API_KEY: 'sk-test' }),
+        'utf-8'
+      )
+
+      const store = createStore(createSettings())
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      await expect(service.importAccountFromExistingHome(sourceHome)).rejects.toThrow(
+        /Could not resolve an account email/
+      )
+      expect(spawnMock).not.toHaveBeenCalled()
+      expect(existsSync(join(testState.userDataDir, 'codex-accounts', 'should-not-create'))).toBe(
+        false
+      )
+    } finally {
+      vi.doUnmock('node:crypto')
+      vi.doUnmock('node:child_process')
+    }
+  })
+
+  it('rejects importing into a WSL account slot', async () => {
+    vi.resetModules()
+    const store = createStore(createSettings())
+    const { CodexAccountService } = await import('./service')
+    const service = new CodexAccountService(
+      store as never,
+      createRateLimits() as never,
+      createRuntimeHome() as never
+    )
+
+    await expect(
+      service.importAccountFromExistingHome('/tmp/does-not-matter', {
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu'
+      })
+    ).rejects.toThrow(/WSL account slot is not supported/)
+  })
+
   it('recreates the expected missing managed home before reauthenticating', async () => {
     vi.resetModules()
 

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -737,7 +737,7 @@ export class CodexAccountService {
     const { managedHomePath } = managedHome
     try {
       const canonicalConfig = this.readCanonicalConfigForManagedHome(managedHomePath)
-      this.assertOAuthAccountAddAllowed(canonicalConfig)
+      this.assertOAuthAccountAddAllowed(canonicalConfig?.contents ?? null)
       this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, canonicalConfig, accountId)
       await this.runCodexLogin(managedHomePath)
       return await this.persistCapturedCodexAccount(accountId, managedHome)
@@ -756,7 +756,7 @@ export class CodexAccountService {
     const { managedHomePath } = managedHome
     try {
       const canonicalConfig = this.readCanonicalConfigForManagedHome(managedHomePath)
-      this.assertOAuthAccountAddAllowed(canonicalConfig)
+      this.assertOAuthAccountAddAllowed(canonicalConfig?.contents ?? null)
       this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, canonicalConfig, accountId)
       this.importCodexAuthFromHome(sourceHome, managedHomePath, accountId)
       return await this.persistCapturedCodexAccount(accountId, managedHome)
@@ -766,7 +766,7 @@ export class CodexAccountService {
     }
   }
 
-/**
+  /**
    * Import an already-authenticated external CODEX_HOME into Orca managed storage
    * without running `codex login` again (Option B from issue #10366).
    */
@@ -794,13 +794,17 @@ export class CodexAccountService {
       )
     }
 
+    // Why: when the canonical home has no config, the import copy is the config
+    // Codex will use. Apply the same OAuth provider policy before copying it.
+    const sourceConfig = this.readImportConfigForOAuthPolicy(resolvedSource)
+
     const accountId = randomUUID()
     const managedHome = this.createManagedHome(accountId, target)
     const { managedHomePath } = managedHome
 
     try {
       const canonicalConfig = this.readCanonicalConfigForManagedHome(managedHomePath)
-      this.assertOAuthAccountAddAllowed(canonicalConfig)
+      this.assertOAuthAccountAddAllowed(canonicalConfig?.contents ?? sourceConfig)
       await copyExistingCodexHomeIntoManaged({
         sourceHomePath: resolvedSource,
         managedHomePath,
@@ -1375,6 +1379,19 @@ export class CodexAccountService {
     }
   }
 
+  private readImportConfigForOAuthPolicy(sourceHomePath: string): string | null {
+    const configPath = join(sourceHomePath, 'config.toml')
+    if (!existsSync(configPath)) {
+      return null
+    }
+
+    try {
+      return readFileSync(configPath, 'utf-8')
+    } catch (error) {
+      throw new Error(`Could not read imported CODEX_HOME config: ${configPath}`, { cause: error })
+    }
+  }
+
   private readCanonicalConfigForManagedHome(managedHomePath: string): CanonicalCodexConfig | null {
     const wslInfo = parseWslUncPath(managedHomePath)
     if (!wslInfo) {
@@ -1406,10 +1423,8 @@ export class CodexAccountService {
     }
   }
 
-  private assertOAuthAccountAddAllowed(canonicalConfig: CanonicalCodexConfig | null): void {
-    const modelProvider = canonicalConfig
-      ? readCodexTopLevelModelProvider(canonicalConfig.contents)
-      : null
+  private assertOAuthAccountAddAllowed(configContents: string | null): void {
+    const modelProvider = configContents ? readCodexTopLevelModelProvider(configContents) : null
     if (!modelProvider || modelProvider === 'openai') {
       return
     }
@@ -1417,7 +1432,7 @@ export class CodexAccountService {
     // Why: mirroring a custom-provider pin into an OAuth managed home makes
     // the new OAuth credentials inert; fail before login and leave user config intact.
     throw new Error(
-      `Orca cannot add a Codex OAuth account while ~/.codex/config.toml pins the custom provider ${JSON.stringify(modelProvider)}. Keep using the system-default account for this provider, or remove model_provider (or set it to "openai") before adding an OAuth account. Orca left your config unchanged.`
+      `Orca cannot add a Codex OAuth account while the active Codex config pins the custom provider ${JSON.stringify(modelProvider)}. Keep using the system-default account for this provider, or remove model_provider (or set it to "openai") before adding an OAuth account. Orca left your config unchanged.`
     )
   }
 

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -57,6 +57,12 @@ import {
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { assertOwnedHostCodexManagedHomePath } from './host-codex-managed-home-ownership'
+import {
+  assertSourceHomeIsNotManagedStorage,
+  copyExistingCodexHomeIntoManaged,
+  readRawAuthJsonFromHome,
+  resolveImportableCodexHomePath
+} from './import-existing-codex-home'
 
 const LOGIN_TIMEOUT_MS = 120_000
 const MAX_LOGIN_OUTPUT_CHARS = 4_000
@@ -295,6 +301,15 @@ export class CodexAccountService {
     target?: CodexAccountAddTarget
   ): Promise<CodexRateLimitAccountsState> {
     return this.serializeMutation(() => this.doAddAccountFromHome(sourceHome, target))
+  }
+
+async importAccountFromExistingHome(
+    sourceHomePath: string,
+    target?: CodexAccountAddTarget
+  ): Promise<CodexRateLimitAccountsState> {
+    return this.serializeMutation(() =>
+      this.doImportAccountFromExistingHome(sourceHomePath, target)
+    )
   }
 
   async reauthenticateAccount(accountId: string): Promise<CodexRateLimitAccountsState> {
@@ -744,6 +759,63 @@ export class CodexAccountService {
       this.assertOAuthAccountAddAllowed(canonicalConfig)
       this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, canonicalConfig, accountId)
       this.importCodexAuthFromHome(sourceHome, managedHomePath, accountId)
+      return await this.persistCapturedCodexAccount(accountId, managedHome)
+    } catch (error) {
+      this.safeRemoveManagedHome(managedHomePath, accountId)
+      throw error
+    }
+  }
+
+/**
+   * Import an already-authenticated external CODEX_HOME into Orca managed storage
+   * without running `codex login` again (Option B from issue #10366).
+   */
+  private async doImportAccountFromExistingHome(
+    sourceHomePath: string,
+    target?: CodexAccountAddTarget
+  ): Promise<CodexRateLimitAccountsState> {
+    if (target?.runtime === 'wsl') {
+      throw new Error(
+        'Importing an existing CODEX_HOME into a WSL account slot is not supported yet. Switch Account location to this device, or use Add Account for WSL.'
+      )
+    }
+
+    const resolvedSource = resolveImportableCodexHomePath(sourceHomePath)
+    assertSourceHomeIsNotManagedStorage(resolvedSource, this.getManagedAccountsRoot())
+
+    // Why: resolve identity from the external home before allocating storage so a
+    // missing email / corrupt auth fails cleanly without leaving empty managed dirs.
+    const sourceIdentity = this.resolveIdentityFromCredentials(
+      this.extractOAuthCredentials(readRawAuthJsonFromHome(resolvedSource))
+    )
+    if (!sourceIdentity.email) {
+      throw new Error(
+        'Could not resolve an account email from the selected CODEX_HOME. Orca only imports OAuth-authenticated Codex homes (auth.json with an id_token email claim).'
+      )
+    }
+
+    const accountId = randomUUID()
+    const managedHome = this.createManagedHome(accountId, target)
+    const { managedHomePath } = managedHome
+
+    try {
+      const canonicalConfig = this.readCanonicalConfigForManagedHome(managedHomePath)
+      this.assertOAuthAccountAddAllowed(canonicalConfig)
+      copyExistingCodexHomeIntoManaged({
+        sourceHomePath: resolvedSource,
+        managedHomePath,
+        accountId
+      })
+      // Why: after copying user config/auth, re-seed Orca-managed hooks/settings
+      // so the imported home matches other managed accounts for sandbox defaults.
+      this.safeSyncCanonicalConfigIntoManagedHome(managedHomePath, canonicalConfig, accountId)
+      const identity = this.readIdentityFromHome(managedHomePath, accountId)
+      if (!identity.email) {
+        throw new Error(
+          'Import copied auth.json, but Orca could not resolve the account email from the managed home.'
+        )
+      }
+
       return await this.persistCapturedCodexAccount(accountId, managedHome)
     } catch (error) {
       this.safeRemoveManagedHome(managedHomePath, accountId)

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -303,7 +303,7 @@ export class CodexAccountService {
     return this.serializeMutation(() => this.doAddAccountFromHome(sourceHome, target))
   }
 
-async importAccountFromExistingHome(
+  async importAccountFromExistingHome(
     sourceHomePath: string,
     target?: CodexAccountAddTarget
   ): Promise<CodexRateLimitAccountsState> {
@@ -801,7 +801,7 @@ async importAccountFromExistingHome(
     try {
       const canonicalConfig = this.readCanonicalConfigForManagedHome(managedHomePath)
       this.assertOAuthAccountAddAllowed(canonicalConfig)
-      copyExistingCodexHomeIntoManaged({
+      await copyExistingCodexHomeIntoManaged({
         sourceHomePath: resolvedSource,
         managedHomePath,
         accountId

--- a/src/main/ipc/codex-accounts.ts
+++ b/src/main/ipc/codex-accounts.ts
@@ -38,6 +38,11 @@ export function registerCodexAccountHandlers(
   ipcMain.handle('codexAccounts:add', (_event, args?: CodexAccountAddTarget) =>
     codexAccounts.addAccount(args)
   )
+  ipcMain.handle(
+    'codexAccounts:importExistingHome',
+    (_event, args: { sourceHomePath: string } & CodexAccountAddTarget) =>
+      codexAccounts.importAccountFromExistingHome(args.sourceHomePath, args)
+  )
   ipcMain.handle('codexAccounts:reauthenticate', (_event, args: { accountId: string }) =>
     codexAccounts.reauthenticateAccount(args.accountId)
   )

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2408,6 +2408,11 @@ export type PreloadApi = {
       runtime?: 'host' | 'wsl'
       wslDistro?: string | null
     }) => Promise<CodexRateLimitAccountsState>
+    importExistingHome: (args: {
+      sourceHomePath: string
+      runtime?: 'host' | 'wsl'
+      wslDistro?: string | null
+    }) => Promise<CodexRateLimitAccountsState>
     reauthenticate: (args: { accountId: string }) => Promise<CodexRateLimitAccountsState>
     remove: (args: { accountId: string }) => Promise<CodexRateLimitAccountsState>
     select: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2051,6 +2051,11 @@ const api = {
     list: (): Promise<unknown> => ipcRenderer.invoke('codexAccounts:list'),
     add: (args?: { runtime?: 'host' | 'wsl'; wslDistro?: string | null }): Promise<unknown> =>
       ipcRenderer.invoke('codexAccounts:add', args),
+    importExistingHome: (args: {
+      sourceHomePath: string
+      runtime?: 'host' | 'wsl'
+      wslDistro?: string | null
+    }): Promise<unknown> => ipcRenderer.invoke('codexAccounts:importExistingHome', args),
     reauthenticate: (args: { accountId: string }): Promise<unknown> =>
       ipcRenderer.invoke('codexAccounts:reauthenticate', args),
     remove: (args: { accountId: string }): Promise<unknown> =>

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -382,7 +382,12 @@ export function AccountsPane({
     useState<CodexRateLimitAccountsState>(emptyCodexAccountsState)
   const [codexAccountsLoaded, setCodexAccountsLoaded] = useState(false)
   const [codexAction, setCodexAction] = useState<
-    'idle' | 'adding' | `reauth:${string}` | `remove:${string}` | `select:${string | 'system'}`
+    | 'idle'
+    | 'adding'
+    | 'importing'
+    | `reauth:${string}`
+    | `remove:${string}`
+    | `select:${string | 'system'}`
   >('idle')
   const [claudeAccounts, setClaudeAccounts] =
     useState<ClaudeRateLimitAccountsState>(emptyClaudeAccountsState)
@@ -724,6 +729,7 @@ export function AccountsPane({
       const nextActiveAccountId = getProviderAccountActiveIdForView(next, actionRuntime)
       const shouldPromptRestart =
         action === 'adding' ||
+        action === 'importing' ||
         (action.startsWith('select:') && previousActiveAccountId !== nextActiveAccountId) ||
         (action.startsWith('reauth:') &&
           nextActiveAccountId !== null &&
@@ -1218,34 +1224,73 @@ export function AccountsPane({
                     )}
               </p>
             </div>
-            <Button
-              variant="outline"
-              size="xs"
-              onClick={() =>
-                void runCodexAccountAction('adding', () =>
-                  window.api.codexAccounts.add({
-                    runtime: accountRuntime.runtime,
-                    wslDistro: accountRuntime.wslDistro
-                  })
-                )
-              }
-              disabled={
-                // Why: interactive `codex login` needs a desktop browser and
-                // would authenticate against this device, not the server.
-                isRemoteAccountScope ||
-                codexAction !== 'idle' ||
-                wslCapabilitiesLoading ||
-                accountRuntimeUnavailable
-              }
-              className="gap-1.5"
-            >
-              {codexAction === 'adding' ? (
-                <Loader2 className="size-3 animate-spin" />
-              ) : (
-                <Plus className="size-3" />
-              )}
-              {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
-            </Button>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() =>
+                  void runCodexAccountAction('adding', () =>
+                    window.api.codexAccounts.add({
+                      runtime: accountRuntime.runtime,
+                      wslDistro: accountRuntime.wslDistro
+                    })
+                  )
+                }
+                disabled={
+                  // Why: interactive `codex login` needs a desktop browser and
+                  // would authenticate against this device, not the server.
+                  isRemoteAccountScope ||
+                  codexAction !== 'idle' ||
+                  wslCapabilitiesLoading ||
+                  accountRuntimeUnavailable
+                }
+                className="gap-1.5"
+              >
+                {codexAction === 'adding' ? (
+                  <Loader2 className="size-3 animate-spin" />
+                ) : (
+                  <Plus className="size-3" />
+                )}
+                {translate('auto.components.settings.AccountsPane.b0e948a4f9', 'Add Account')}
+              </Button>
+              <Button
+                variant="outline"
+                size="xs"
+                onClick={() => {
+                  void (async () => {
+                    // Why: folder pick is separate from the mutation so canceling
+                    // the dialog does not flash an error toast.
+                    const sourceHomePath = await window.api.shell.pickDirectory({})
+                    if (!sourceHomePath) {
+                      return
+                    }
+                    await runCodexAccountAction('importing', () =>
+                      window.api.codexAccounts.importExistingHome({
+                        sourceHomePath,
+                        runtime: accountRuntime.runtime,
+                        wslDistro: accountRuntime.wslDistro
+                      })
+                    )
+                  })()
+                }}
+                disabled={
+                  // Why: import copies a host-visible CODEX_HOME into managed
+                  // storage; remote scopes and WSL slots are not supported yet.
+                  isRemoteAccountScope ||
+                  accountRuntime.runtime === 'wsl' ||
+                  codexAction !== 'idle' ||
+                  wslCapabilitiesLoading ||
+                  accountRuntimeUnavailable
+                }
+                className="gap-1.5"
+              >
+                {codexAction === 'importing' ? <Loader2 className="size-3 animate-spin" /> : null}
+                {translate(
+                  'auto.components.settings.AccountsPane.importCodexHome',
+                  'Import CODEX_HOME'
+                )}
+              </Button>
+            </div>
           </div>
           {remoteAccountScopeNotice}
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3064,6 +3064,7 @@ function createAccountsApi(): never {
   return {
     list: () => Promise.resolve(empty),
     add: () => Promise.resolve(empty),
+    importExistingHome: () => Promise.resolve(empty),
     cancelPendingLogin: () => Promise.resolve(false),
     reauthenticate: () => Promise.resolve(empty),
     remove: () => Promise.resolve(empty),


### PR DESCRIPTION
## Summary
- Adds **Import CODEX_HOME** next to Add Account in Settings → Codex Accounts
- Copies an already-authenticated external `CODEX_HOME` into Orca managed storage and registers it as a normal managed account **without** running `codex login` again (issue Option B)
- Validates `auth.json`, resolves OAuth identity (email required), refuses import from Orca managed storage or WSL slots (host only for now)

Closes #10366

## Motivation
Power users keep isolated homes (`~/.codex-work`, device-auth flows, enterprise login). Today every extra account must go through Orca's browser login, so those homes cannot be reused.

## Implementation
- `CodexAccountService.importAccountFromExistingHome(sourceHomePath, target?)`
- Shared helpers in `import-existing-codex-home.ts` (validate, copy, ownership marker)
- IPC `codexAccounts:importExistingHome` + preload API
- UI: folder picker → import; disabled for remote / WSL scope
- Applies the OAuth provider policy to the imported config when no canonical config exists

## Test plan
- [x] Unit: import helpers (auth.json required, reject managed storage, copy + marker)
- [x] Unit: service imports without spawn/`codex login`, rejects API-key-only and WSL target
- [x] Full `service.test.ts` + helper tests (72 pass, including custom-provider import rejection)
- [ ] Manual: Settings → Codex Accounts → Import CODEX_HOME → pick `~/.codex-*` with prior `codex login` → account appears and becomes active without browser login

## Notes
- Host runtime only; WSL import can follow if needed
- Source directory is left intact (copy, not move)

## ELI5

You can import an already-logged-in CODEX_HOME into Orca managed accounts without running codex login again. Handy if you keep separate Codex homes for different workflows.
