### PR TITLE
fix(stats): count agent sessions from hook status pipeline

### DIFF
--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -6,6 +6,8 @@ import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
 export const AGENT_AWAKE_STATUS_STALE_AFTER_MS = 2 * 60 * 60 * 1000
 
 export type AgentAwakeStatus = {
+  /** Present when statuses come from AgentHookServer; awake logic does not require it. */
+  paneKey?: string
   state: AgentStatusState
   receivedAt: number
   observedInCurrentRuntime: boolean

--- a/src/main/agent-awake-service.ts
+++ b/src/main/agent-awake-service.ts
@@ -6,8 +6,6 @@ import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
 export const AGENT_AWAKE_STATUS_STALE_AFTER_MS = 2 * 60 * 60 * 1000
 
 export type AgentAwakeStatus = {
-  /** Present when statuses come from AgentHookServer; awake logic does not require it. */
-  paneKey?: string
   state: AgentStatusState
   receivedAt: number
   observedInCurrentRuntime: boolean

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -2332,6 +2332,9 @@ describe('AgentHookServer listener replay', () => {
 
       expect(secondServer.getStatusChangeSnapshot()).toEqual([
         expect.objectContaining({
+          // Why: per-pane consumers (stats bridge, awake) key off paneKey; dropping it
+          // collapses every agent onto one session key instead of failing loudly.
+          paneKey: PANE,
           state: 'working',
           observedInCurrentRuntime: false
         })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -116,6 +116,8 @@ type PersistedAgentHookAuthorityCommitment = {
 }
 
 export type AgentHookStatusChangeEntry = {
+  /** Stable pane identity for per-agent consumers (stats, awake). */
+  paneKey: string
   state: AgentStatusState
   receivedAt: number
   observedInCurrentRuntime: boolean

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -939,6 +939,7 @@ export class AgentHookServer {
       }
       if (!enriched.providerSessionOnly) {
         statuses.push({
+          paneKey,
           state: enriched.payload.state,
           receivedAt: enriched.receivedAt,
           observedInCurrentRuntime: this.runtimeObservedStatusPaneKeys.has(paneKey)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -233,6 +233,7 @@ import { StarNagService } from './star-nag/service'
 import { agentHookServer, type AgentHookProviderSessionIdentity } from './agent-hooks/server'
 import { createHookProviderSessionInvalidator } from './agent-hooks/hook-provider-session-invalidation'
 import { createHookStatusSessionTabsInvalidator } from './agent-hooks/hook-status-session-tabs-invalidation'
+import { createHookStatusStatsBridge } from './stats/hook-status-stats-bridge'
 import { wslHookRelayManager } from './agent-hooks/wsl-hook-relay-manager'
 import { maybeAutoRenameBranchOnFirstWork } from './agent-hooks/first-work-branch-rename'
 import { rememberBranchRenameFailureOutput } from './agent-hooks/branch-rename-failure-output'
@@ -339,6 +340,7 @@ let starNag: StarNagService | null = null
 let agentAwakeService: AgentAwakeService | null = null
 let crashReports: CrashReportStore | null = null
 let unsubscribeAgentAwakeStatusChanges: (() => void) | null = null
+let unsubscribeHookStatusStatsBridge: (() => void) | null = null
 let unsubscribeSystemResumeBroadcast: (() => void) | null = null
 let watcherShutdownPromise: Promise<void> | null = null
 let watcherShutdownDone = false
@@ -2202,6 +2204,16 @@ void app.whenReady().then(async () => {
   initCohortClassifier(store)
   initOnboardingCohortClassifier(store)
   stats = new StatsCollector()
+  // Why: lifetime "Agents spawned" / "Time agents worked" only heard OSC titles via
+  // AgentDetector; modern agents report status through hooks, so feed that stream
+  // into StatsCollector too (#10201). Keys are pane-scoped with a hook: prefix so
+  // they never collide with residual OSC ptyId sessions.
+  {
+    const bridge = createHookStatusStatsBridge(stats)
+    unsubscribeHookStatusStatsBridge = agentHookServer.subscribeStatusChanges((statuses) => {
+      bridge.apply(statuses)
+    })
+  }
   claudeUsage = new ClaudeUsageStore(store)
   codexUsage = new CodexUsageStore(store)
   openCodeUsage = new OpenCodeUsageStore(store)
@@ -2987,6 +2999,8 @@ app.on('before-quit', () => {
   unsubscribeSystemResumeBroadcast = null
   unsubscribeAgentAwakeStatusChanges?.()
   unsubscribeAgentAwakeStatusChanges = null
+  unsubscribeHookStatusStatsBridge?.()
+  unsubscribeHookStatusStatsBridge = null
   agentAwakeService?.dispose()
   agentAwakeService = null
   // Why: defer PTY cleanup to will-quit so the renderer captures scrollback before PTY-exit events unmount TerminalPane (dropping its capture callbacks).

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2219,7 +2219,7 @@ void app.whenReady().then(async () => {
     unsubscribeHookStatusStatsBridge = () => {
       unsubscribe()
       // Why: an empty snapshot closes every hook-opened session through the
-      // bridge's staleness bound. Without it stats.flush() below credits a pane
+      // bridge's staleness bound. Without it stats.flushAsync() below credits a pane
       // stuck at 'working' since a killed agent with wall-clock time to quit.
       bridge.apply([])
     }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3009,8 +3009,6 @@ app.on('before-quit', () => {
   unsubscribeSystemResumeBroadcast = null
   unsubscribeAgentAwakeStatusChanges?.()
   unsubscribeAgentAwakeStatusChanges = null
-  unsubscribeHookStatusStatsBridge?.()
-  unsubscribeHookStatusStatsBridge = null
   agentAwakeService?.dispose()
   agentAwakeService = null
   // Why: defer PTY cleanup to will-quit so the renderer captures scrollback before PTY-exit events unmount TerminalPane (dropping its capture callbacks).
@@ -3060,6 +3058,13 @@ app.on('will-quit', (e) => {
   const pluginHostShutdown = pluginService?.dispose() ?? Promise.resolve()
   pluginService = null
   setUnreadDockBadgeCount(0)
+  // Why here, not before-quit: before-quit also fires on aborted quits (updater
+  // defer, dirty-editor veto) and there is no re-subscribe path — tearing down
+  // there silently reverts #10201 for the rest of the process. will-quit only
+  // runs on the committed path, and the sweep must precede the stats flush
+  // below so hook sessions close at their staleness bound, not wall clock.
+  unsubscribeHookStatusStatsBridge?.()
+  unsubscribeHookStatusStatsBridge = null
   agentHookServer.stop()
   // Why: cancels relay restart/reinstall timers and kills wsl.exe children deterministically, not via stdio-pipe teardown.
   wslHookRelayManager.disposeAll()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2210,6 +2210,9 @@ void app.whenReady().then(async () => {
   // they never collide with residual OSC ptyId sessions.
   {
     const bridge = createHookStatusStatsBridge(stats)
+    // Why: subscribeStatusChanges does not replay existing rows; seed so panes already
+    // working at startup still open a stats session without waiting for another event.
+    bridge.apply(agentHookServer.getStatusChangeSnapshot())
     unsubscribeHookStatusStatsBridge = agentHookServer.subscribeStatusChanges((statuses) => {
       bridge.apply(statuses)
     })

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2206,16 +2206,23 @@ void app.whenReady().then(async () => {
   stats = new StatsCollector()
   // Why: lifetime "Agents spawned" / "Time agents worked" only heard OSC titles via
   // AgentDetector; modern agents report status through hooks, so feed that stream
-  // into StatsCollector too (#10201). Keys are pane-scoped with a hook: prefix so
-  // they never collide with residual OSC ptyId sessions.
+  // into StatsCollector too (#10201). Both producers watch the same pane, so the
+  // bridge borrows the pane's live ptyId as its session key and the collector
+  // counts whichever one opens the session first.
   {
-    const bridge = createHookStatusStatsBridge(stats)
-    // Why: subscribeStatusChanges does not replay existing rows; seed so panes already
-    // working at startup still open a stats session without waiting for another event.
-    bridge.apply(agentHookServer.getStatusChangeSnapshot())
-    unsubscribeHookStatusStatsBridge = agentHookServer.subscribeStatusChanges((statuses) => {
+    const bridge = createHookStatusStatsBridge(stats, {
+      resolvePtyId: (paneKey) => runtime?.getTerminalPtyIdForPaneKey(paneKey) ?? null
+    })
+    const unsubscribe = agentHookServer.subscribeStatusChanges((statuses) => {
       bridge.apply(statuses)
     })
+    unsubscribeHookStatusStatsBridge = () => {
+      unsubscribe()
+      // Why: an empty snapshot closes every hook-opened session through the
+      // bridge's staleness bound. Without it stats.flush() below credits a pane
+      // stuck at 'working' since a killed agent with wall-clock time to quit.
+      bridge.apply([])
+    }
   }
   claudeUsage = new ClaudeUsageStore(store)
   codexUsage = new CodexUsageStore(store)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15971,6 +15971,13 @@ export class OrcaRuntimeService {
     return leaf?.worktreeId ?? this.getPtyRecordForPaneKey(paneKey)?.worktreeId ?? null
   }
 
+  /** PTY currently backing a pane. Lets pane-keyed consumers (the hook status
+   *  stats bridge) share PTY-scoped identity with the OSC AgentDetector so one
+   *  physical agent is not counted twice. */
+  getTerminalPtyIdForPaneKey(paneKey: string): string | null {
+    return this.getPtyRecordForPaneKey(paneKey)?.ptyId ?? null
+  }
+
   /** Read-only context of the worktree the user is focused on, for plugin
    *  panels (workspace.readContext). Prefers the persisted session focus and
    *  falls back to the last-focused pane's worktree; null when neither

--- a/src/main/runtime/terminal-pty-id-for-pane-key.test.ts
+++ b/src/main/runtime/terminal-pty-id-for-pane-key.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The hook status stats bridge keys its StatsCollector sessions by the ptyId this
+ * method returns, so that both it and the OSC AgentDetector land on one session
+ * for the same pane. If it ever returns null the bridge silently falls back to a
+ * `hook:` key and every OSC-visible pane is counted twice again — the exact
+ * regression #10396 exists to prevent, and one that no stats test can see because
+ * those inject their own resolver.
+ */
+import { describe, expect, it } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const PANE_KEY = 'tab-1:6c1a5f7e-6a3c-4a55-8a4d-9d0d3b0e6f11'
+
+type RuntimeInternals = {
+  ptysById: Map<string, { ptyId: string; paneKey: string | null; connected: boolean }>
+  leaves: Map<string, { ptyId: string | null }>
+}
+
+function seedPty(
+  runtime: OrcaRuntimeService,
+  pty: { ptyId: string; paneKey: string | null; connected: boolean }
+): void {
+  ;(runtime as unknown as RuntimeInternals).ptysById.set(pty.ptyId, pty)
+}
+
+/** Mirrors getLeafKey's `${tabId}::${leafId}` layout. */
+function seedLeaf(runtime: OrcaRuntimeService, paneKey: string, ptyId: string): void {
+  const [tabId, leafId] = paneKey.split(':')
+  ;(runtime as unknown as RuntimeInternals).leaves.set(`${tabId}::${leafId}`, { ptyId })
+}
+
+describe('OrcaRuntimeService.getTerminalPtyIdForPaneKey', () => {
+  it('resolves through the mounted leaf, the path production hits first', () => {
+    const runtime = new OrcaRuntimeService()
+    seedLeaf(runtime, PANE_KEY, 'pty-leaf')
+    seedPty(runtime, { ptyId: 'pty-leaf', paneKey: null, connected: true })
+
+    // The leaf-backed PTY carries no paneKey of its own, so only the leaf lookup
+    // can find it — a resolver that relied on the linear scan alone returns null.
+    expect(runtime.getTerminalPtyIdForPaneKey(PANE_KEY)).toBe('pty-leaf')
+  })
+
+  it('resolves the pane to the PTY backing it', () => {
+    const runtime = new OrcaRuntimeService()
+    seedPty(runtime, { ptyId: 'pty-1', paneKey: PANE_KEY, connected: true })
+
+    expect(runtime.getTerminalPtyIdForPaneKey(PANE_KEY)).toBe('pty-1')
+  })
+
+  it('prefers the connected PTY when a disconnected one still claims the pane', () => {
+    const runtime = new OrcaRuntimeService()
+    seedPty(runtime, { ptyId: 'pty-old', paneKey: PANE_KEY, connected: false })
+    seedPty(runtime, { ptyId: 'pty-new', paneKey: PANE_KEY, connected: true })
+
+    expect(runtime.getTerminalPtyIdForPaneKey(PANE_KEY)).toBe('pty-new')
+  })
+
+  it('returns null for a pane no PTY claims', () => {
+    const runtime = new OrcaRuntimeService()
+    seedPty(runtime, { ptyId: 'pty-1', paneKey: 'tab-9:0', connected: true })
+
+    expect(runtime.getTerminalPtyIdForPaneKey(PANE_KEY)).toBeNull()
+  })
+})

--- a/src/main/ssh/ssh-connection-utils.ts
+++ b/src/main/ssh/ssh-connection-utils.ts
@@ -49,9 +49,7 @@ export function isAuthError(err: Error): boolean {
     msg.includes('all configured authentication methods failed') ||
     msg.includes('authentication failed') ||
     msg.includes('too many authentication failures') ||
-    /permission denied(?:, please try again\.?| \([^)]*(?:publickey|password|keyboard-interactive|gssapi|hostbased)[^)]*\))/.test(
-      msg
-    ) ||
+    /permission denied(?:, please try again\.?| \([^)]*(?:publickey|password|keyboard-interactive|gssapi|hostbased)[^)]*\))/.test(msg) ||
     (err as { level?: string }).level === 'client-authentication'
   )
 }

--- a/src/main/ssh/ssh-connection.test.ts
+++ b/src/main/ssh/ssh-connection.test.ts
@@ -1799,7 +1799,9 @@ describe('SshConnection', () => {
 
       await expect(settled).resolves.toBeUndefined()
       expect(spawnSystemSshCommandMock).toHaveBeenCalledTimes(2)
-      expect(removeControlSocketPathMock).toHaveBeenCalledWith('/tmp/orca-ssh-501/stale-socket')
+      expect(removeControlSocketPathMock).toHaveBeenCalledWith(
+        '/tmp/orca-ssh-501/stale-socket'
+      )
       expect(spawnSystemSshCommandMock).toHaveBeenNthCalledWith(
         2,
         expect.anything(),
@@ -1814,7 +1816,10 @@ describe('SshConnection', () => {
   it('skips a second probe for a definite host failure', async () => {
     getOrcaControlSocketPathMock.mockReturnValue('/tmp/orca-ssh-501/stale-socket')
     spawnSystemSshCommandMock.mockImplementation(() =>
-      createFailingSystemCommandChannel(255, 'ssh: connect to host box port 22: No route to host')
+      createFailingSystemCommandChannel(
+        255,
+        'ssh: connect to host box port 22: No route to host'
+      )
     )
     vi.mocked(resolveWithSshG).mockResolvedValue(createResolvedConfig())
     const conn = new SshConnection(createTarget({ configHost: 'fdpass-host' }), createCallbacks())
@@ -1858,7 +1863,9 @@ describe('SshConnection', () => {
 
       await expect(settled).resolves.toBeDefined()
       expect(spawnSystemSshMock).toHaveBeenCalledTimes(2)
-      expect(removeControlSocketPathMock).toHaveBeenCalledWith('/tmp/orca-ssh-501/stale-socket')
+      expect(removeControlSocketPathMock).toHaveBeenCalledWith(
+        '/tmp/orca-ssh-501/stale-socket'
+      )
       expect(spawnSystemSshMock).toHaveBeenNthCalledWith(
         2,
         expect.anything(),

--- a/src/main/ssh/ssh-connection.ts
+++ b/src/main/ssh/ssh-connection.ts
@@ -977,7 +977,11 @@ export class SshConnection {
     try {
       await this.doSystemSshProbe(connectGeneration)
     } catch (err) {
-      if (!controlPath || this.disposed || connectGeneration !== this.connectGeneration) {
+      if (
+        !controlPath ||
+        this.disposed ||
+        connectGeneration !== this.connectGeneration
+      ) {
         throw err
       }
       removeControlSocketPath(controlPath)

--- a/src/main/stats/agent-session-double-count.test.ts
+++ b/src/main/stats/agent-session-double-count.test.ts
@@ -42,7 +42,9 @@ async function loadStats() {
   const bridge = bridgeModule.createHookStatusStatsBridge(stats, {
     resolvePtyId: (paneKey) => (paneKey === PANE_KEY ? PTY_ID : null)
   })
-  return { stats, detector, bridge }
+  const createBridge = (resolvePtyId: (paneKey: string) => string | null) =>
+    bridgeModule.createHookStatusStatsBridge(stats, { resolvePtyId })
+  return { stats, detector, bridge, createBridge }
 }
 
 function hookStatus(state: 'working' | 'done', receivedAt: number) {
@@ -155,5 +157,172 @@ describe('agent session counting across the OSC and hook producers', () => {
 
     expect(stats.getSummary().totalAgentsSpawned).toBe(1)
     expect(stats.getSummary().totalAgentTimeMs).toBe(2_000)
+  })
+
+  it('an OSC title cycle mid-turn never splits a live hook session', async () => {
+    const { stats, detector, bridge } = await loadStats()
+    const { AGENT_STATUS_STALE_AFTER_MS } = await import('../../shared/agent-status-types')
+
+    // A long tool call hides the spinner: the OSC title goes idle and comes
+    // back mid-turn while the hook row stays 'working' with no new events.
+    bridge.apply(hookStatus('working', 1_000))
+    detector.onData(PTY_ID, agentChunk('claude working'), 2_000)
+    detector.onData(PTY_ID, agentChunk('claude ready'), 10_000)
+    const spinnerBack = 1_000 + AGENT_STATUS_STALE_AFTER_MS + 60_000
+    detector.onData(PTY_ID, agentChunk('claude working'), spinnerBack)
+    const doneAt = spinnerBack + 60_000
+    bridge.apply(hookStatus('done', doneAt))
+
+    // Hook-event silence is not death: one turn, hook-owned boundary, full span.
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(doneAt - 1_000)
+  })
+
+  it('the quit sweep keeps wall clock off a dead agent, and flush stays a no-op after it', async () => {
+    const { stats, bridge } = await loadStats()
+    const { AGENT_STATUS_STALE_AFTER_MS } = await import('../../shared/agent-status-types')
+
+    // Agent SIGKILLed right after its only hook event; user quits hours later.
+    bridge.apply(hookStatus('working', 1_000))
+    bridge.apply([], 1_000 + 4 * AGENT_STATUS_STALE_AFTER_MS)
+    stats.flush()
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(0)
+  })
+
+  it('a late hook event adopts an open OSC session and inherits its span', async () => {
+    const { stats, detector, bridge } = await loadStats()
+    const { AGENT_STATUS_STALE_AFTER_MS } = await import('../../shared/agent-status-types')
+
+    // Hooks can attach long after OSC opened the session. Adoption inherits
+    // the span — evidence cadence is not liveness, so rotating here would
+    // split genuinely live sessions (measured before this rule was settled).
+    detector.onData(PTY_ID, agentChunk('claude working'), 1_000)
+    const hookAt = 1_000 + AGENT_STATUS_STALE_AFTER_MS + 60_000
+    bridge.apply(hookStatus('working', hookAt))
+    bridge.apply(hookStatus('done', hookAt + 5_000))
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(hookAt + 5_000 - 1_000)
+  })
+
+  it('a tool call outlasting the horizon splits the turn — accepted granularity residual', async () => {
+    const { stats, bridge } = await loadStats()
+    const { AGENT_STATUS_STALE_AFTER_MS } = await import('../../shared/agent-status-types')
+
+    // Hooks carry no heartbeat, so a single tool call longer than the horizon
+    // is indistinguishable from a killed agent. The rotation splits the turn
+    // and credits only hook-proven spans; every liveness signal tried against
+    // this (terminal output, working titles) made a worse case unbounded. See
+    // the residuals note in hook-status-stats-bridge.ts.
+    bridge.apply(hookStatus('working', 1_000))
+    const postToolUse = 1_000 + AGENT_STATUS_STALE_AFTER_MS + 60_000
+    bridge.apply(hookStatus('working', postToolUse))
+    bridge.apply(hookStatus('done', postToolUse + 5_000))
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(2)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(5_000)
+  })
+
+  it('user shell output never keeps a dead row alive', async () => {
+    const { stats, detector, bridge } = await loadStats()
+    const { AGENT_STATUS_STALE_AFTER_MS } = await import('../../shared/agent-status-types')
+
+    // Agent killed after its only hook event; the user keeps using the pane's
+    // shell all day. Output alone is not liveness — only an agent-painted
+    // working title is — so the next turn must rotate, not inherit the gap.
+    bridge.apply(hookStatus('working', 1_000))
+    const nextDay = 1_000 + 24 * 60 * 60 * 1_000
+    for (let at = 60_000; at < nextDay; at += AGENT_STATUS_STALE_AFTER_MS / 2) {
+      detector.onData(PTY_ID, 'ls -la\r\ntotal 128\r\n', at)
+    }
+
+    bridge.apply(hookStatus('working', nextDay))
+    bridge.apply(hookStatus('done', nextDay + 5_000))
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(2)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(5_000)
+  })
+
+  it('a repeated OSC start never claims hook ownership', async () => {
+    const { stats } = await loadStats()
+
+    stats.onAgentStart(PTY_ID, 1_000)
+    // Title cycles re-fire starts; the OSC producer must keep owning its own
+    // session or its stop below would be refused and the session never close.
+    stats.onAgentStart(PTY_ID, 2_000)
+    stats.onAgentStop(PTY_ID, 3_000)
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(2_000)
+  })
+
+  it('hasLiveAgent mirrors open sessions', async () => {
+    const { stats } = await loadStats()
+
+    expect(stats.hasLiveAgent(PTY_ID)).toBe(false)
+    stats.onAgentStart(PTY_ID, 1_000, undefined, undefined, 'hook')
+    expect(stats.hasLiveAgent(PTY_ID)).toBe(true)
+    stats.onAgentStop(PTY_ID, 2_000, 'hook')
+    expect(stats.hasLiveAgent(PTY_ID)).toBe(false)
+  })
+
+  it('does not mint phantom spawns from a frozen sibling row', async () => {
+    const { stats, createBridge } = await loadStats()
+    const bridge = createBridge(() => PTY_ID)
+    const row = (paneKey: string, state: 'working' | 'done', receivedAt: number) => ({
+      paneKey,
+      state,
+      receivedAt,
+      observedInCurrentRuntime: true
+    })
+
+    // B's agent dies right after its only event; A closes the shared session.
+    bridge.apply([row('tab-a:0', 'working', 1_000), row('tab-b:0', 'working', 1_000)])
+    bridge.apply([row('tab-a:0', 'done', 5_000), row('tab-b:0', 'working', 1_000)])
+    // B's frozen row is redelivered on every later notification.
+    bridge.apply([row('tab-a:0', 'done', 5_000), row('tab-b:0', 'working', 1_000)])
+    bridge.apply([row('tab-a:0', 'done', 5_000), row('tab-b:0', 'working', 1_000)])
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(4_000)
+  })
+
+  it('reopens a shared-key session when the survivor proves it is still working', async () => {
+    const { stats, createBridge } = await loadStats()
+    // One PTY surfaced by two rows. Production advances one row per
+    // notification: only the pane that fired carries a fresh receivedAt.
+    const bridge = createBridge(() => PTY_ID)
+    const row = (paneKey: string, state: 'working' | 'done', receivedAt: number) => ({
+      paneKey,
+      state,
+      receivedAt,
+      observedInCurrentRuntime: true
+    })
+
+    bridge.apply([row('tab-a:0', 'working', 1_000), row('tab-b:0', 'working', 1_000)])
+    bridge.apply([row('tab-a:0', 'done', 5_000), row('tab-b:0', 'working', 1_000)])
+    bridge.apply([row('tab-a:0', 'done', 5_000), row('tab-b:0', 'working', 6_000)])
+    bridge.apply([row('tab-b:0', 'done', 9_000)])
+
+    // A's span (4000) plus B's tail from its reopen (3000). The 5000→6000 gap
+    // is the documented quiet-row residual.
+    expect(stats.getSummary().totalAgentsSpawned).toBe(2)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(7_000)
+  })
+
+  it('flush closes hook-owned sessions with their own source', async () => {
+    const { stats, bridge } = await loadStats()
+
+    const startedAt = Date.now() - 5_000
+    bridge.apply(hookStatus('working', startedAt))
+    stats.flush()
+
+    // A flush that replayed the wrong source would leave the hook session open
+    // and credit nothing.
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBeGreaterThanOrEqual(5_000)
+    expect(stats.getSummary().totalAgentTimeMs).toBeLessThan(60_000)
   })
 })

--- a/src/main/stats/agent-session-double-count.test.ts
+++ b/src/main/stats/agent-session-double-count.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Why: OSC title detection and the hook status pipeline both observe the same
+// physical agent, and on a hook-enabled machine OSC still fires constantly
+// (measured on a maintainer install: ~390 agent_start/day, 55%+ of them on
+// panes the hook pipeline also reports). Without a shared session key the
+// "Agents spawned" and "Time agents worked" cards roughly double. These tests
+// drive the real AgentDetector and the real bridge into one real StatsCollector,
+// so they fail if either producer stops sharing the pane's PTY-scoped key.
+
+let userDataDir: string
+
+vi.mock('electron', () => ({
+  app: { getPath: () => userDataDir }
+}))
+
+const PTY_ID = 'repo-1::/tmp/wt@@abc123'
+const PANE_KEY = 'tab-1:6c1a5f7e-6a3c-4a55-8a4d-9d0d3b0e6f11'
+
+/** OSC 0 title sequence followed by ordinary output, the shape a real agent emits. */
+function agentChunk(title: string): string {
+  return `\x1b]0;${title}\x07wrote src/app.ts\r\n`
+}
+
+/** Title update with no printable output, which leaves lastMeaningfulOutputAt null. */
+function titleOnlyChunk(title: string): string {
+  return `\x1b]0;${title}\x07`
+}
+
+async function loadStats() {
+  const [{ StatsCollector, initStatsPath }, { AgentDetector }, bridgeModule] = await Promise.all([
+    import('./collector'),
+    import('./agent-detector'),
+    import('./hook-status-stats-bridge')
+  ])
+  initStatsPath()
+  const stats = new StatsCollector()
+  const detector = new AgentDetector(stats)
+  const bridge = bridgeModule.createHookStatusStatsBridge(stats, {
+    resolvePtyId: (paneKey) => (paneKey === PANE_KEY ? PTY_ID : null)
+  })
+  return { stats, detector, bridge }
+}
+
+function hookStatus(state: 'working' | 'done', receivedAt: number) {
+  return [{ paneKey: PANE_KEY, state, receivedAt, observedInCurrentRuntime: true }]
+}
+
+describe('agent session counting across the OSC and hook producers', () => {
+  beforeEach(() => {
+    userDataDir = mkdtempSync(join(tmpdir(), 'orca-stats-dedupe-'))
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    rmSync(userDataDir, { recursive: true, force: true })
+  })
+
+  it('counts one session when hooks open the turn and OSC titles echo it', async () => {
+    const { stats, detector, bridge } = await loadStats()
+
+    bridge.apply(hookStatus('working', 1_000))
+    detector.onData(PTY_ID, agentChunk('claude working'), 1_100)
+    detector.onData(PTY_ID, agentChunk('claude ready'), 5_000)
+    bridge.apply(hookStatus('done', 5_100))
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+  })
+
+  it('counts one session when OSC titles open the turn and hooks echo it', async () => {
+    const { stats, detector, bridge } = await loadStats()
+
+    detector.onData(PTY_ID, agentChunk('claude working'), 1_000)
+    bridge.apply(hookStatus('working', 1_100))
+    bridge.apply(hookStatus('done', 5_000))
+    detector.onData(PTY_ID, agentChunk('claude ready'), 5_100)
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+  })
+
+  it('adds worked time once, on the hook boundary, not once per producer', async () => {
+    const { stats, detector, bridge } = await loadStats()
+
+    bridge.apply(hookStatus('working', 1_000))
+    detector.onData(PTY_ID, agentChunk('claude working'), 1_000)
+    detector.onData(PTY_ID, agentChunk('claude ready'), 4_000)
+    bridge.apply(hookStatus('done', 4_100))
+
+    // The hook stream owns the session, so the turn ends at its 4100 'done',
+    // not at the detector's 4000 last-meaningful-output stop.
+    expect(stats.getSummary().totalAgentTimeMs).toBe(3_100)
+  })
+
+  it('still counts consecutive turns on the same pane', async () => {
+    const { stats, bridge } = await loadStats()
+
+    bridge.apply(hookStatus('working', 1_000))
+    bridge.apply(hookStatus('done', 2_000))
+    bridge.apply(hookStatus('working', 3_000))
+    bridge.apply(hookStatus('done', 4_000))
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(2)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(2_000)
+  })
+
+  it('lets the hook stream keep the turn boundary when OSC emits titles only', async () => {
+    const { stats, detector, bridge } = await loadStats()
+
+    // No printable output, so the detector's stop time collapses to its own
+    // session start. If it were allowed to close the hook-owned session, the
+    // turn would be recorded as ~0ms — the near-zero numbers issue #10201 is about.
+    bridge.apply(hookStatus('working', 1_000))
+    detector.onData(PTY_ID, titleOnlyChunk('claude working'), 1_100)
+    detector.onData(PTY_ID, titleOnlyChunk('claude ready'), 5_000)
+    bridge.apply(hookStatus('done', 5_100))
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(4_100)
+  })
+
+  it('hands the boundary to hooks even when OSC opened the turn first', async () => {
+    const { stats, detector, bridge } = await loadStats()
+
+    detector.onData(PTY_ID, titleOnlyChunk('claude working'), 1_000)
+    bridge.apply(hookStatus('working', 1_100))
+    detector.onData(PTY_ID, titleOnlyChunk('claude ready'), 5_000)
+    bridge.apply(hookStatus('done', 6_000))
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(5_000)
+  })
+
+  it('still counts a pane the hook pipeline never reports', async () => {
+    const { stats, detector } = await loadStats()
+
+    detector.onData('other-pty', agentChunk('claude working'), 1_000)
+    detector.onData('other-pty', agentChunk('claude ready'), 4_000)
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(3_000)
+  })
+
+  it('counts a hook-only pane with no resolvable PTY', async () => {
+    const { stats, bridge } = await loadStats()
+
+    bridge.apply([
+      { paneKey: 'tab-9:0', state: 'working', receivedAt: 1_000, observedInCurrentRuntime: true }
+    ])
+    bridge.apply([
+      { paneKey: 'tab-9:0', state: 'done', receivedAt: 3_000, observedInCurrentRuntime: true }
+    ])
+
+    expect(stats.getSummary().totalAgentsSpawned).toBe(1)
+    expect(stats.getSummary().totalAgentTimeMs).toBe(2_000)
+  })
+})

--- a/src/main/stats/collector.ts
+++ b/src/main/stats/collector.ts
@@ -91,10 +91,18 @@ export class StatsCollector {
       // hook-status bridge, which reuses the pane's ptyId as its session key. A
       // second start would double both totalAgentsSpawned and totalAgentTimeMs.
       // The hook stream still takes over the boundaries: it sees the agent's real
-      // turn end, while an OSC title can flip to idle mid-turn.
-      if (source === 'hook') {
-        live.source = 'hook'
+      // turn end, while an OSC title can flip to idle mid-turn. An OSC start
+      // must not claim ownership either, or the OSC producer's own stop would
+      // be refused and its session could never close.
+      if (source === 'osc') {
+        return
       }
+      // A late hook adoption inherits the session's span, dangling or not —
+      // rotating on evidence age was tried and misclassified live sessions
+      // (no per-producer signal distinguishes a quiet agent from a dead one).
+      // For a dangling row this matches the quit path, which bills the open
+      // span at flush; the PTY-exit path would have billed 0.
+      live.source = 'hook'
       return
     }
     this.liveAgents.set(ptyId, { startedAt: at, source })
@@ -105,6 +113,12 @@ export class StatsCollector {
       worktreeId,
       meta: { ptyId }
     })
+  }
+
+  /** Whether a session is currently open under this key. The bridge uses this to
+   *  reopen after another row sharing the key closed it. */
+  hasLiveAgent(ptyId: string): boolean {
+    return this.liveAgents.has(ptyId)
   }
 
   onAgentStop(ptyId: string, at: number, source: AgentSessionSource = 'osc'): void {

--- a/src/main/stats/collector.ts
+++ b/src/main/stats/collector.ts
@@ -5,6 +5,9 @@ import type { StatsEvent, StatsAggregates } from './types'
 import { loadStatsFile, STATS_SCHEMA_VERSION } from './stats-file-loader'
 import { StatsSnapshotWriter } from './stats-snapshot-writer'
 
+/** Which producer opened an agent session: legacy OSC titles, or the hook pipeline. */
+export type AgentSessionSource = 'osc' | 'hook'
+
 const MAX_EVENTS = 10_000
 // Why: countedPRs is a deduplication registry that grows with every PR created
 // through Orca. Without a cap, a heavily-used instance accumulates thousands of
@@ -35,7 +38,9 @@ function getStatsFile(): string {
 export class StatsCollector {
   private events: StatsEvent[]
   private aggregates: StatsAggregates
-  private liveAgents = new Map<string, number>() // ptyId → startTimestamp
+  // ptyId → the open session. `source` is the producer that currently owns the
+  // session's boundaries; see onAgentStart/onAgentStop.
+  private liveAgents = new Map<string, { startedAt: number; source: AgentSessionSource }>()
   private writeTimer: ReturnType<typeof setTimeout> | null = null
   private readonly snapshotWriter = new StatsSnapshotWriter(getStatsFile)
   /** Set by flushAsync so the quit flush is the final write; see scheduleSave. */
@@ -73,8 +78,26 @@ export class StatsCollector {
 
   // ── Agent lifecycle (AgentDetector OSC path + hook-status bridge) ─
 
-  onAgentStart(ptyId: string, at: number, repoId?: string, worktreeId?: string): void {
-    this.liveAgents.set(ptyId, at)
+  onAgentStart(
+    ptyId: string,
+    at: number,
+    repoId?: string,
+    worktreeId?: string,
+    source: AgentSessionSource = 'osc'
+  ): void {
+    const live = this.liveAgents.get(ptyId)
+    if (live) {
+      // Why: two producers watch the same pane — the OSC AgentDetector and the
+      // hook-status bridge, which reuses the pane's ptyId as its session key. A
+      // second start would double both totalAgentsSpawned and totalAgentTimeMs.
+      // The hook stream still takes over the boundaries: it sees the agent's real
+      // turn end, while an OSC title can flip to idle mid-turn.
+      if (source === 'hook') {
+        live.source = 'hook'
+      }
+      return
+    }
+    this.liveAgents.set(ptyId, { startedAt: at, source })
     this.record({
       type: 'agent_start',
       at,
@@ -84,13 +107,22 @@ export class StatsCollector {
     })
   }
 
-  onAgentStop(ptyId: string, at: number): void {
-    const startAt = this.liveAgents.get(ptyId)
-    if (startAt === undefined) {
+  onAgentStop(ptyId: string, at: number, source: AgentSessionSource = 'osc'): void {
+    const live = this.liveAgents.get(ptyId)
+    if (live === undefined) {
+      return
+    }
+    // Why: only the owning producer sets the end boundary. An OSC idle title
+    // stops at lastMeaningfulOutputAt, which collapses to the session start when
+    // the agent emitted nothing printable — letting that truncate a turn the
+    // hooks are still reporting would rebuild the near-zero numbers this exists
+    // to fix. flush() replays each session's own source so shutdown still closes
+    // every straggler.
+    if (live.source !== source) {
       return
     }
     this.liveAgents.delete(ptyId)
-    const durationMs = Math.max(0, at - startAt)
+    const durationMs = Math.max(0, at - live.startedAt)
     this.aggregates.totalAgentTimeMs += durationMs
     this.record({
       type: 'agent_stop',
@@ -165,9 +197,9 @@ export class StatsCollector {
     const now = Date.now()
     // Why snapshot keys: onAgentStop mutates liveAgents, so we snapshot
     // the keys first to avoid iterator invalidation.
-    const livePtyIds = Array.from(this.liveAgents.keys())
-    for (const ptyId of livePtyIds) {
-      this.onAgentStop(ptyId, now)
+    const liveSessions = Array.from(this.liveAgents.entries())
+    for (const [ptyId, session] of liveSessions) {
+      this.onAgentStop(ptyId, now, session.source)
     }
   }
 

--- a/src/main/stats/collector.ts
+++ b/src/main/stats/collector.ts
@@ -71,7 +71,7 @@ export class StatsCollector {
     this.scheduleSave()
   }
 
-  // ── Agent lifecycle (called by AgentDetector) ─────────────────────
+  // ── Agent lifecycle (AgentDetector OSC path + hook-status bridge) ─
 
   onAgentStart(ptyId: string, at: number, repoId?: string, worktreeId?: string): void {
     this.liveAgents.set(ptyId, at)

--- a/src/main/stats/hook-status-stats-bridge-wiring.test.ts
+++ b/src/main/stats/hook-status-stats-bridge-wiring.test.ts
@@ -48,7 +48,7 @@ describe('hook status stats bridge wiring', () => {
 
     const willQuitSlice = source.slice(willQuitStart, windowAllClosedStart)
     const teardownIndex = willQuitSlice.indexOf('unsubscribeHookStatusStatsBridge?.()')
-    const flushIndex = willQuitSlice.indexOf('stats?.flush()')
+    const flushIndex = willQuitSlice.indexOf('stats?.flushAsync()')
     expect(teardownIndex).toBeGreaterThanOrEqual(0)
     expect(flushIndex).toBeGreaterThan(teardownIndex)
   })

--- a/src/main/stats/hook-status-stats-bridge-wiring.test.ts
+++ b/src/main/stats/hook-status-stats-bridge-wiring.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Why source-slice tests: the bridge's unit tests inject their own resolver and
+// lifecycle, so they stay green if index.ts stops wiring the real ones — which
+// silently brings back the exact double count and wall-clock billing the bridge
+// exists to prevent. Same pattern as desktop-startup-ordering.test.ts.
+
+function readIndexSource(): string {
+  return readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+}
+
+describe('hook status stats bridge wiring', () => {
+  it('wires the bridge to the real pane→PTY resolver', () => {
+    const source = readIndexSource()
+    const createIndex = source.indexOf('createHookStatusStatsBridge(stats')
+    expect(createIndex).toBeGreaterThanOrEqual(0)
+    const optionsSlice = source.slice(createIndex, createIndex + 400)
+    expect(optionsSlice).toContain('resolvePtyId')
+    expect(optionsSlice).toContain('getTerminalPtyIdForPaneKey')
+  })
+
+  it('sweeps open hook sessions inside the teardown closure', () => {
+    const source = readIndexSource()
+    const assignIndex = source.indexOf('unsubscribeHookStatusStatsBridge = () => {')
+    expect(assignIndex).toBeGreaterThanOrEqual(0)
+    const closureEnd = source.indexOf('}', source.indexOf('bridge.apply([])', assignIndex))
+    expect(closureEnd).toBeGreaterThan(assignIndex)
+    expect(source.slice(assignIndex, closureEnd)).toContain('bridge.apply([])')
+  })
+
+  it('tears the bridge down only on the committed quit path, before the stats flush', () => {
+    const source = readIndexSource()
+    const beforeQuitStart = source.indexOf("app.on('before-quit'")
+    const willQuitStart = source.indexOf("app.on('will-quit'")
+    const windowAllClosedStart = source.indexOf("app.on('window-all-closed'", willQuitStart)
+    expect(beforeQuitStart).toBeGreaterThanOrEqual(0)
+    expect(willQuitStart).toBeGreaterThan(beforeQuitStart)
+    expect(windowAllClosedStart).toBeGreaterThan(willQuitStart)
+
+    // before-quit also fires on aborted quits (updater defer, dirty-editor
+    // veto); tearing down there would silently revert #10201 for the rest of
+    // the process because nothing re-subscribes.
+    expect(source.slice(beforeQuitStart, willQuitStart)).not.toContain(
+      'unsubscribeHookStatusStatsBridge'
+    )
+
+    const willQuitSlice = source.slice(willQuitStart, windowAllClosedStart)
+    const teardownIndex = willQuitSlice.indexOf('unsubscribeHookStatusStatsBridge?.()')
+    const flushIndex = willQuitSlice.indexOf('stats?.flush()')
+    expect(teardownIndex).toBeGreaterThanOrEqual(0)
+    expect(flushIndex).toBeGreaterThan(teardownIndex)
+  })
+})

--- a/src/main/stats/hook-status-stats-bridge.test.ts
+++ b/src/main/stats/hook-status-stats-bridge.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createHookStatusStatsBridge,
+  toHookStatsSessionKey,
+  type HookStatusStatsInput
+} from './hook-status-stats-bridge'
+
+function status(
+  overrides: Partial<HookStatusStatsInput> & Pick<HookStatusStatsInput, 'paneKey' | 'state'>
+): HookStatusStatsInput {
+  return {
+    receivedAt: 1_000,
+    observedInCurrentRuntime: true,
+    ...overrides
+  }
+}
+
+describe('createHookStatusStatsBridge', () => {
+  it('starts a stats session when a pane enters working', () => {
+    const onAgentStart = vi.fn()
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+
+    expect(onAgentStart).toHaveBeenCalledTimes(1)
+    expect(onAgentStart).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 100)
+    expect(onAgentStop).not.toHaveBeenCalled()
+    expect(bridge.getLivePaneKeys()).toEqual(['tab-a:0'])
+  })
+
+  it('does not double-start while the pane stays working', () => {
+    const onAgentStart = vi.fn()
+    const bridge = createHookStatusStatsBridge({
+      onAgentStart,
+      onAgentStop: vi.fn()
+    })
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 200 })])
+
+    expect(onAgentStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops the session when the pane leaves working', () => {
+    const onAgentStart = vi.fn()
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 500 })])
+
+    expect(onAgentStop).toHaveBeenCalledTimes(1)
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 500)
+    expect(bridge.getLivePaneKeys()).toEqual([])
+  })
+
+  it('ignores disk-hydrated statuses that were not observed in this runtime', () => {
+    const onAgentStart = vi.fn()
+    const bridge = createHookStatusStatsBridge({
+      onAgentStart,
+      onAgentStop: vi.fn()
+    })
+
+    bridge.apply([
+      status({
+        paneKey: 'tab-a:0',
+        state: 'working',
+        receivedAt: 100,
+        observedInCurrentRuntime: false
+      })
+    ])
+
+    expect(onAgentStart).not.toHaveBeenCalled()
+    expect(bridge.getLivePaneKeys()).toEqual([])
+  })
+
+  it('stops a live session when the pane disappears from the snapshot', () => {
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge({
+      onAgentStart: vi.fn(),
+      onAgentStop
+    })
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+    bridge.apply([], 900)
+
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 900)
+    expect(bridge.getLivePaneKeys()).toEqual([])
+  })
+
+  it('tracks multiple panes independently', () => {
+    const onAgentStart = vi.fn()
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 110 })
+    ])
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 200 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 210 })
+    ])
+
+    expect(onAgentStart).toHaveBeenCalledTimes(2)
+    expect(onAgentStop).toHaveBeenCalledTimes(1)
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 200)
+    expect(bridge.getLivePaneKeys()).toEqual(['tab-b:0'])
+  })
+})

--- a/src/main/stats/hook-status-stats-bridge.test.ts
+++ b/src/main/stats/hook-status-stats-bridge.test.ts
@@ -15,58 +15,73 @@ function status(
   }
 }
 
+// Mirrors StatsCollector's dedupe: hasLiveAgent reflects start/stop pairs so the
+// bridge's reopen guard sees the same live-session view production would.
+function fakeStats() {
+  const live = new Set<string>()
+  return {
+    onAgentStart: vi.fn(
+      (
+        sessionKey: string,
+        _at?: number,
+        _repoId?: string,
+        _worktreeId?: string,
+        _source?: 'osc' | 'hook'
+      ) => {
+        live.add(sessionKey)
+      }
+    ),
+    onAgentStop: vi.fn((sessionKey: string, _at?: number, _source?: 'osc' | 'hook') => {
+      live.delete(sessionKey)
+    }),
+    hasLiveAgent: (sessionKey: string) => live.has(sessionKey)
+  }
+}
+
 describe('createHookStatusStatsBridge', () => {
   it('starts a stats session when a pane enters working', () => {
-    const onAgentStart = vi.fn()
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
 
-    expect(onAgentStart).toHaveBeenCalledTimes(1)
-    expect(onAgentStart).toHaveBeenCalledWith(
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStart).toHaveBeenCalledWith(
       toHookStatsSessionKey('tab-a:0'),
       100,
       undefined,
       undefined,
       'hook'
     )
-    expect(onAgentStop).not.toHaveBeenCalled()
+    expect(stats.onAgentStop).not.toHaveBeenCalled()
     expect(bridge.getLivePaneKeys()).toEqual(['tab-a:0'])
   })
 
   it('does not double-start while the pane stays working', () => {
-    const onAgentStart = vi.fn()
-    const bridge = createHookStatusStatsBridge({
-      onAgentStart,
-      onAgentStop: vi.fn()
-    })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 200 })])
 
-    expect(onAgentStart).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(1)
   })
 
   it('stops the session when the pane leaves working', () => {
-    const onAgentStart = vi.fn()
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 500 })])
 
-    expect(onAgentStop).toHaveBeenCalledTimes(1)
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 500, 'hook')
+    expect(stats.onAgentStop).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 500, 'hook')
     expect(bridge.getLivePaneKeys()).toEqual([])
   })
 
   it('ignores disk-hydrated statuses that were not observed in this runtime', () => {
-    const onAgentStart = vi.fn()
-    const bridge = createHookStatusStatsBridge({
-      onAgentStart,
-      onAgentStop: vi.fn()
-    })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     bridge.apply([
       status({
@@ -77,64 +92,53 @@ describe('createHookStatusStatsBridge', () => {
       })
     ])
 
-    expect(onAgentStart).not.toHaveBeenCalled()
+    expect(stats.onAgentStart).not.toHaveBeenCalled()
     expect(bridge.getLivePaneKeys()).toEqual([])
   })
 
   it('stops a live session when the pane disappears from the snapshot', () => {
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge({
-      onAgentStart: vi.fn(),
-      onAgentStop
-    })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
     bridge.apply([], 900)
 
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 900, 'hook')
+    expect(stats.onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 900, 'hook')
     expect(bridge.getLivePaneKeys()).toEqual([])
   })
 
   it('keys the session by the pane ptyId so the OSC detector path is not double-counted', () => {
-    const onAgentStart = vi.fn()
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge(
-      { onAgentStart, onAgentStop },
-      { resolvePtyId: (paneKey) => (paneKey === 'tab-a:0' ? 'pty-1' : null) }
-    )
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, {
+      resolvePtyId: (paneKey) => (paneKey === 'tab-a:0' ? 'pty-1' : null)
+    })
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 500 })])
 
-    expect(onAgentStart).toHaveBeenCalledWith('pty-1', 100, undefined, undefined, 'hook')
-    expect(onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
+    expect(stats.onAgentStart).toHaveBeenCalledWith('pty-1', 100, undefined, undefined, 'hook')
+    expect(stats.onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
   })
 
   it('closes with the session key captured at start when the pane PTY is swapped', () => {
-    const onAgentStop = vi.fn()
+    const stats = fakeStats()
     let ptyId = 'pty-1'
-    const bridge = createHookStatusStatsBridge(
-      { onAgentStart: vi.fn(), onAgentStop },
-      { resolvePtyId: () => ptyId }
-    )
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => ptyId })
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
     ptyId = 'pty-2'
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 500 })])
 
-    expect(onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
+    expect(stats.onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
   })
 
   it('falls back to the hook-prefixed key when no PTY backs the pane', () => {
-    const onAgentStart = vi.fn()
-    const bridge = createHookStatusStatsBridge(
-      { onAgentStart, onAgentStop: vi.fn() },
-      { resolvePtyId: () => null }
-    )
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => null })
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
 
-    expect(onAgentStart).toHaveBeenCalledWith(
+    expect(stats.onAgentStart).toHaveBeenCalledWith(
       toHookStatsSessionKey('tab-a:0'),
       100,
       undefined,
@@ -144,32 +148,55 @@ describe('createHookStatusStatsBridge', () => {
   })
 
   it('credits only up to the last hook evidence when a stale working row is swept', () => {
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge({ onAgentStart: vi.fn(), onAgentStop })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     // Agent is killed mid-turn, so no further hook event ever lands; the pane
     // row stays 'working' until the user closes the tab six hours later.
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
     bridge.apply([], 1_000 + 6 * 60 * 60 * 1_000)
 
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 1_000, 'hook')
+    expect(stats.onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 1_000, 'hook')
   })
 
   it('uses the teardown time when the swept row is still fresh', () => {
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge({ onAgentStart: vi.fn(), onAgentStop })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 60_000 })])
     bridge.apply([], 90_000)
 
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 90_000, 'hook')
+    expect(stats.onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 90_000, 'hook')
+  })
+
+  it('hook events inside the horizon keep a long turn as one session', () => {
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
+    const twentyMin = 20 * 60 * 1_000
+
+    // A 60-minute turn whose hook events never gap past the horizon: each
+    // working event advances the row's evidence, so the rotation must not
+    // split it — the residual is bounded to genuine >horizon silent gaps.
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 + twentyMin })])
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 + 2 * twentyMin })
+    ])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 1_000 + 3 * twentyMin })])
+
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStop).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStop).toHaveBeenCalledWith(
+      toHookStatsSessionKey('tab-a:0'),
+      1_000 + 3 * twentyMin,
+      'hook'
+    )
   })
 
   it('rotates a stale working session when the pane is reused', () => {
-    const onAgentStart = vi.fn()
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
     const nextDay = 1_000 + 24 * 60 * 60 * 1_000
 
     // Agent killed mid-turn — the row never leaves 'working'. Reusing the pane
@@ -178,9 +205,14 @@ describe('createHookStatusStatsBridge', () => {
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: nextDay })])
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: nextDay + 5_000 })])
 
-    expect(onAgentStop).toHaveBeenNthCalledWith(1, toHookStatsSessionKey('tab-a:0'), 1_000, 'hook')
-    expect(onAgentStart).toHaveBeenCalledTimes(2)
-    expect(onAgentStop).toHaveBeenNthCalledWith(
+    expect(stats.onAgentStop).toHaveBeenNthCalledWith(
+      1,
+      toHookStatsSessionKey('tab-a:0'),
+      1_000,
+      'hook'
+    )
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(2)
+    expect(stats.onAgentStop).toHaveBeenNthCalledWith(
       2,
       toHookStatsSessionKey('tab-a:0'),
       nextDay + 5_000,
@@ -188,30 +220,151 @@ describe('createHookStatusStatsBridge', () => {
     )
   })
 
-  it('does not close a session the moved pane key just adopted', () => {
-    const onAgentStart = vi.fn()
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge(
-      { onAgentStart, onAgentStop },
-      { resolvePtyId: () => 'pty-1' }
+  it('reopens the shared session when a sibling row on the same PTY closed it', () => {
+    const stats = fakeStats()
+    // One PTY surfaced by two rows. Production advances one row's receivedAt
+    // per notification — only the pane that fired carries a fresh stamp.
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => 'pty-1' })
+
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 1_000 })
+    ])
+    // Pane A goes idle and closes the shared collector session; B's row is
+    // unchanged in that snapshot, so nothing reopens yet.
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 5_000 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 1_000 })
+    ])
+    expect(stats.onAgentStop).toHaveBeenCalledWith('pty-1', 5_000, 'hook')
+    expect(stats.hasLiveAgent('pty-1')).toBe(false)
+
+    // B's next real event proves it still works: reopen.
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 5_000 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 6_000 })
+    ])
+    expect(stats.onAgentStart).toHaveBeenLastCalledWith(
+      'pty-1',
+      6_000,
+      undefined,
+      undefined,
+      'hook'
     )
+    expect(stats.hasLiveAgent('pty-1')).toBe(true)
+
+    bridge.apply([status({ paneKey: 'tab-b:0', state: 'done', receivedAt: 9_000 })])
+    expect(stats.onAgentStop).toHaveBeenLastCalledWith('pty-1', 9_000, 'hook')
+  })
+
+  it('keeps the newest close when an older close stamps the same survivors', () => {
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => 'pty-1' })
+    const row = (paneKey: string, state: 'working' | 'done', receivedAt: number) =>
+      status({ paneKey, state, receivedAt })
+
+    bridge.apply([
+      row('tab-a:0', 'working', 1_000),
+      row('tab-b:0', 'working', 1_000),
+      row('tab-c:0', 'working', 1_000)
+    ])
+    // A closes at 5000, stamping B and C; B then closes at an OLDER stamp —
+    // C's clamp must keep the newest close, not regress.
+    bridge.apply([
+      row('tab-a:0', 'done', 5_000),
+      row('tab-b:0', 'working', 1_000),
+      row('tab-c:0', 'working', 1_000)
+    ])
+    bridge.apply([row('tab-b:0', 'done', 2_000), row('tab-c:0', 'working', 1_000)])
+    bridge.apply([row('tab-c:0', 'working', 3_000)])
+
+    expect(stats.onAgentStart).toHaveBeenLastCalledWith(
+      'pty-1',
+      5_000,
+      undefined,
+      undefined,
+      'hook'
+    )
+  })
+
+  it('reopens no earlier than the key’s last close', () => {
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => 'pty-1' })
+
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 1_000 })
+    ])
+    // B's newest event predates A's close. Reopening at B's own stamp would
+    // bill the 3000→5000 overlap twice — clamp to the close.
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 5_000 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 3_000 })
+    ])
+
+    expect(stats.onAgentStart).toHaveBeenLastCalledWith(
+      'pty-1',
+      5_000,
+      undefined,
+      undefined,
+      'hook'
+    )
+  })
+
+  it('does not reopen while the collector still holds the session', () => {
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => 'pty-1' })
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 200 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 300 })])
+
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reopen from a frozen row that carries no new evidence', () => {
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => 'pty-1' })
+
+    // Agent dies mid-turn: its row is redelivered unchanged in every later
+    // snapshot. After the collector's key is freed (sibling close), a redelivery
+    // must not mint a phantom spawn.
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
+    stats.onAgentStop('pty-1', 5_000, 'hook')
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(1)
+
+    // A genuinely new hook event (the agent is alive again) does reopen.
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 2_000 })])
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(2)
+    expect(stats.onAgentStart).toHaveBeenLastCalledWith(
+      'pty-1',
+      2_000,
+      undefined,
+      undefined,
+      'hook'
+    )
+  })
+
+  it('does not close a session the moved pane key just adopted', () => {
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => 'pty-1' })
 
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
     // transferPaneAuthority renames the row inside one notification.
     bridge.apply([status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 200 })])
 
-    expect(onAgentStop).not.toHaveBeenCalled()
+    expect(stats.onAgentStop).not.toHaveBeenCalled()
     expect(bridge.getLivePaneKeys()).toEqual(['tab-b:0'])
 
     bridge.apply([status({ paneKey: 'tab-b:0', state: 'done', receivedAt: 500 })])
-    expect(onAgentStop).toHaveBeenCalledTimes(1)
-    expect(onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
+    expect(stats.onAgentStop).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
   })
 
   it('tracks multiple panes independently', () => {
-    const onAgentStart = vi.fn()
-    const onAgentStop = vi.fn()
-    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats)
 
     bridge.apply([
       status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 }),
@@ -222,9 +375,9 @@ describe('createHookStatusStatsBridge', () => {
       status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 210 })
     ])
 
-    expect(onAgentStart).toHaveBeenCalledTimes(2)
-    expect(onAgentStop).toHaveBeenCalledTimes(1)
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 200, 'hook')
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(2)
+    expect(stats.onAgentStop).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 200, 'hook')
     expect(bridge.getLivePaneKeys()).toEqual(['tab-b:0'])
   })
 })

--- a/src/main/stats/hook-status-stats-bridge.test.ts
+++ b/src/main/stats/hook-status-stats-bridge.test.ts
@@ -24,7 +24,13 @@ describe('createHookStatusStatsBridge', () => {
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
 
     expect(onAgentStart).toHaveBeenCalledTimes(1)
-    expect(onAgentStart).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 100)
+    expect(onAgentStart).toHaveBeenCalledWith(
+      toHookStatsSessionKey('tab-a:0'),
+      100,
+      undefined,
+      undefined,
+      'hook'
+    )
     expect(onAgentStop).not.toHaveBeenCalled()
     expect(bridge.getLivePaneKeys()).toEqual(['tab-a:0'])
   })
@@ -51,7 +57,7 @@ describe('createHookStatusStatsBridge', () => {
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 500 })])
 
     expect(onAgentStop).toHaveBeenCalledTimes(1)
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 500)
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 500, 'hook')
     expect(bridge.getLivePaneKeys()).toEqual([])
   })
 
@@ -85,8 +91,121 @@ describe('createHookStatusStatsBridge', () => {
     bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
     bridge.apply([], 900)
 
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 900)
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 900, 'hook')
     expect(bridge.getLivePaneKeys()).toEqual([])
+  })
+
+  it('keys the session by the pane ptyId so the OSC detector path is not double-counted', () => {
+    const onAgentStart = vi.fn()
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge(
+      { onAgentStart, onAgentStop },
+      { resolvePtyId: (paneKey) => (paneKey === 'tab-a:0' ? 'pty-1' : null) }
+    )
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 500 })])
+
+    expect(onAgentStart).toHaveBeenCalledWith('pty-1', 100, undefined, undefined, 'hook')
+    expect(onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
+  })
+
+  it('closes with the session key captured at start when the pane PTY is swapped', () => {
+    const onAgentStop = vi.fn()
+    let ptyId = 'pty-1'
+    const bridge = createHookStatusStatsBridge(
+      { onAgentStart: vi.fn(), onAgentStop },
+      { resolvePtyId: () => ptyId }
+    )
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+    ptyId = 'pty-2'
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: 500 })])
+
+    expect(onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
+  })
+
+  it('falls back to the hook-prefixed key when no PTY backs the pane', () => {
+    const onAgentStart = vi.fn()
+    const bridge = createHookStatusStatsBridge(
+      { onAgentStart, onAgentStop: vi.fn() },
+      { resolvePtyId: () => null }
+    )
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+
+    expect(onAgentStart).toHaveBeenCalledWith(
+      toHookStatsSessionKey('tab-a:0'),
+      100,
+      undefined,
+      undefined,
+      'hook'
+    )
+  })
+
+  it('credits only up to the last hook evidence when a stale working row is swept', () => {
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge({ onAgentStart: vi.fn(), onAgentStop })
+
+    // Agent is killed mid-turn, so no further hook event ever lands; the pane
+    // row stays 'working' until the user closes the tab six hours later.
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
+    bridge.apply([], 1_000 + 6 * 60 * 60 * 1_000)
+
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 1_000, 'hook')
+  })
+
+  it('uses the teardown time when the swept row is still fresh', () => {
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge({ onAgentStart: vi.fn(), onAgentStop })
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 60_000 })])
+    bridge.apply([], 90_000)
+
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 90_000, 'hook')
+  })
+
+  it('rotates a stale working session when the pane is reused', () => {
+    const onAgentStart = vi.fn()
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge({ onAgentStart, onAgentStop })
+    const nextDay = 1_000 + 24 * 60 * 60 * 1_000
+
+    // Agent killed mid-turn — the row never leaves 'working'. Reusing the pane
+    // the next day must not bill the dead gap to the new turn.
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: nextDay })])
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'done', receivedAt: nextDay + 5_000 })])
+
+    expect(onAgentStop).toHaveBeenNthCalledWith(1, toHookStatsSessionKey('tab-a:0'), 1_000, 'hook')
+    expect(onAgentStart).toHaveBeenCalledTimes(2)
+    expect(onAgentStop).toHaveBeenNthCalledWith(
+      2,
+      toHookStatsSessionKey('tab-a:0'),
+      nextDay + 5_000,
+      'hook'
+    )
+  })
+
+  it('does not close a session the moved pane key just adopted', () => {
+    const onAgentStart = vi.fn()
+    const onAgentStop = vi.fn()
+    const bridge = createHookStatusStatsBridge(
+      { onAgentStart, onAgentStop },
+      { resolvePtyId: () => 'pty-1' }
+    )
+
+    bridge.apply([status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 100 })])
+    // transferPaneAuthority renames the row inside one notification.
+    bridge.apply([status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 200 })])
+
+    expect(onAgentStop).not.toHaveBeenCalled()
+    expect(bridge.getLivePaneKeys()).toEqual(['tab-b:0'])
+
+    bridge.apply([status({ paneKey: 'tab-b:0', state: 'done', receivedAt: 500 })])
+    expect(onAgentStop).toHaveBeenCalledTimes(1)
+    expect(onAgentStop).toHaveBeenCalledWith('pty-1', 500, 'hook')
   })
 
   it('tracks multiple panes independently', () => {
@@ -105,7 +224,7 @@ describe('createHookStatusStatsBridge', () => {
 
     expect(onAgentStart).toHaveBeenCalledTimes(2)
     expect(onAgentStop).toHaveBeenCalledTimes(1)
-    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 200)
+    expect(onAgentStop).toHaveBeenCalledWith(toHookStatsSessionKey('tab-a:0'), 200, 'hook')
     expect(bridge.getLivePaneKeys()).toEqual(['tab-b:0'])
   })
 })

--- a/src/main/stats/hook-status-stats-bridge.test.ts
+++ b/src/main/stats/hook-status-stats-bridge.test.ts
@@ -219,6 +219,33 @@ describe('createHookStatusStatsBridge', () => {
       'hook'
     )
   })
+  it('rotates stale rows sharing a session key only once per snapshot', () => {
+    const stats = fakeStats()
+    const bridge = createHookStatusStatsBridge(stats, { resolvePtyId: () => 'pty-1' })
+    const nextDay = 1_000 + 24 * 60 * 60 * 1_000
+
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'working', receivedAt: 1_000 }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: 1_000 })
+    ])
+    bridge.apply([
+      status({ paneKey: 'tab-a:0', state: 'working', receivedAt: nextDay }),
+      status({ paneKey: 'tab-b:0', state: 'working', receivedAt: nextDay })
+    ])
+
+    expect(stats.onAgentStop).toHaveBeenCalledTimes(1)
+    expect(stats.onAgentStop).toHaveBeenCalledWith('pty-1', 1_000, 'hook')
+    // Both initial rows reach the collector; its shared-key dedupe makes the second a no-op.
+    expect(stats.onAgentStart).toHaveBeenCalledTimes(3)
+    expect(stats.onAgentStart).toHaveBeenLastCalledWith(
+      'pty-1',
+      nextDay,
+      undefined,
+      undefined,
+      'hook'
+    )
+    expect(stats.hasLiveAgent('pty-1')).toBe(true)
+  })
 
   it('reopens the shared session when a sibling row on the same PTY closed it', () => {
     const stats = fakeStats()

--- a/src/main/stats/hook-status-stats-bridge.ts
+++ b/src/main/stats/hook-status-stats-bridge.ts
@@ -1,0 +1,79 @@
+import type { AgentStatusState } from '../../shared/agent-status-types'
+
+/**
+ * Minimal status shape from AgentHookServer status-change notifications.
+ * paneKey is required so lifetime stats can track per-agent sessions.
+ */
+export type HookStatusStatsInput = {
+  paneKey: string
+  state: AgentStatusState
+  receivedAt: number
+  observedInCurrentRuntime: boolean
+}
+
+type StatsAgentLifecycle = {
+  onAgentStart: (sessionKey: string, at: number) => void
+  onAgentStop: (sessionKey: string, at: number) => void
+}
+
+/**
+ * Mirrors AgentDetector's working→idle session boundaries, but driven by the
+ * hook status pipeline (Claude/Codex/OpenCode/…) instead of OSC titles.
+ *
+ * Why a separate session key prefix: OSC-based AgentDetector still keys by
+ * ptyId; prefixing avoids clobbering concurrent live maps if both paths fire
+ * for the same physical agent (hooks are the accurate path; OSC rarely fires).
+ */
+export function createHookStatusStatsBridge(stats: StatsAgentLifecycle): {
+  apply: (statuses: readonly HookStatusStatsInput[], now?: number) => void
+  /** Test/inspection helper — paneKeys currently counted as working. */
+  getLivePaneKeys: () => string[]
+} {
+  // paneKey → start timestamp
+  const liveWorking = new Map<string, number>()
+
+  return {
+    apply(statuses, now = Date.now()) {
+      const present = new Set<string>()
+
+      for (const status of statuses) {
+        present.add(status.paneKey)
+        // Why: disk-hydrated rows are UI continuity only — counting them would
+        // invent agent_start events for sessions that ran in a previous process.
+        if (!status.observedInCurrentRuntime) {
+          continue
+        }
+
+        if (status.state === 'working') {
+          if (!liveWorking.has(status.paneKey)) {
+            liveWorking.set(status.paneKey, status.receivedAt)
+            stats.onAgentStart(toHookStatsSessionKey(status.paneKey), status.receivedAt)
+          }
+          continue
+        }
+
+        if (liveWorking.has(status.paneKey)) {
+          liveWorking.delete(status.paneKey)
+          stats.onAgentStop(toHookStatsSessionKey(status.paneKey), status.receivedAt)
+        }
+      }
+
+      // Why: a cleared pane (tab close / status drop) leaves no snapshot row;
+      // close the open working session so totalAgentTimeMs does not leak.
+      for (const paneKey of Array.from(liveWorking.keys())) {
+        if (present.has(paneKey)) {
+          continue
+        }
+        liveWorking.delete(paneKey)
+        stats.onAgentStop(toHookStatsSessionKey(paneKey), now)
+      }
+    },
+    getLivePaneKeys() {
+      return [...liveWorking.keys()]
+    }
+  }
+}
+
+export function toHookStatsSessionKey(paneKey: string): string {
+  return `hook:${paneKey}`
+}

--- a/src/main/stats/hook-status-stats-bridge.ts
+++ b/src/main/stats/hook-status-stats-bridge.ts
@@ -21,6 +21,7 @@ type StatsAgentLifecycle = {
     source?: AgentSessionSource
   ) => void
   onAgentStop: (sessionKey: string, at: number, source?: AgentSessionSource) => void
+  hasLiveAgent: (sessionKey: string) => boolean
 }
 
 export type HookStatusStatsBridgeOptions = {
@@ -50,6 +51,29 @@ export type HookStatusStatsBridgeOptions = {
  * where the staleness bound below credits it correctly. Letting the OSC detector
  * close it on PTY exit instead was tried and repeatedly produced worse bugs than
  * the delay it fixed; the real fix is evicting stale rows in AgentHookServer.
+ *
+ * Accepted residuals, all rooted in rows nothing evicts and in hook events
+ * carrying no liveness heartbeat. Cross-producer evidence (terminal output,
+ * then working titles) was tried against each and made another case worse —
+ * output let a user's shell keep a dead session alive forever, and agents do
+ * not repaint working titles inside a turn (Claude writes its title once per
+ * session, measured). The real fix for all of them is upstream stale-row
+ * eviction in AgentHookServer:
+ * - A turn whose tool call outlasts the staleness horizon with no hook event
+ *   in between splits into two counted sessions at the next working event,
+ *   crediting only the spans the hook stream proved. On such turns this
+ *   credits LESS than the OSC path alone would (its output-bounded close
+ *   spans the whole turn) — for hook-enabled panes that is a real regression
+ *   scoped to >30-min hook-silent tool calls, accepted over the unbounded
+ *   dead-row billing every rejected alternative reintroduced.
+ * - Two rows sharing one session key can diverge; a row whose events went
+ *   quiet before its sibling closed the session loses its tail time until its
+ *   next working event — and loses the remainder of the turn when that next
+ *   event is its own done. The reopen below refuses frozen rows because
+ *   honoring them would mint unbounded phantom spawns from dead panes.
+ * - A hook agent killed without a Stop parks its session on the pane's key
+ *   until its next hook turn rotates it, and OSC-only agents in that pane go
+ *   uncounted while it is parked.
  */
 export function createHookStatusStatsBridge(
   stats: StatsAgentLifecycle,
@@ -62,7 +86,12 @@ export function createHookStatusStatsBridge(
   // paneKey → the session this bridge opened for it. The key is stored rather
   // than re-resolved so a PTY swap mid-turn cannot orphan the open session, and
   // lastEvidenceAt tracks the newest hook event that proved the pane was working.
-  const liveWorking = new Map<string, { sessionKey: string; lastEvidenceAt: number }>()
+  // keyClosedAt is stamped on surviving rows when a sibling closes their shared
+  // key, so a reopen can never back-date into the span already credited.
+  const liveWorking = new Map<
+    string,
+    { sessionKey: string; lastEvidenceAt: number; keyClosedAt?: number }
+  >()
 
   const closeSession = (paneKey: string, at: number): void => {
     const session = liveWorking.get(paneKey)
@@ -71,6 +100,11 @@ export function createHookStatusStatsBridge(
     }
     liveWorking.delete(paneKey)
     stats.onAgentStop(session.sessionKey, at, 'hook')
+    for (const survivor of liveWorking.values()) {
+      if (survivor.sessionKey === session.sessionKey) {
+        survivor.keyClosedAt = Math.max(survivor.keyClosedAt ?? 0, at)
+      }
+    }
   }
 
   return {
@@ -94,10 +128,26 @@ export function createHookStatusStatsBridge(
             // the abandoned session sits on the pane's ptyId, an OSC-only agent
             // in that pane is counted by nobody (its start hits a live key, its
             // stop hits the wrong owner). Reopening restores both boundaries.
+            // A live turn whose tool call outlasts the horizon splits here too;
+            // that granularity residual is documented above.
             if (status.receivedAt - open.lastEvidenceAt > AGENT_STATUS_STALE_AFTER_MS) {
               closeSession(status.paneKey, open.lastEvidenceAt)
             } else {
+              const previousEvidenceAt = open.lastEvidenceAt
               open.lastEvidenceAt = Math.max(open.lastEvidenceAt, status.receivedAt)
+              // Why reopen: the collector can lose this key while our row stays
+              // working — another pane sharing the ptyId (one PTY, two leaves)
+              // went idle and closed the shared session. Without this the rest
+              // of the turn is counted by nobody. Only a row carrying NEW
+              // evidence reopens: a dead agent's frozen row would otherwise
+              // mint a phantom zero-time spawn per snapshot once its key was
+              // freed. The reopen starts no earlier than the key's last close,
+              // or the overlap behind the sibling's boundary would be billed
+              // twice.
+              if (status.receivedAt > previousEvidenceAt && !stats.hasLiveAgent(open.sessionKey)) {
+                const reopenAt = Math.max(status.receivedAt, open.keyClosedAt ?? 0)
+                stats.onAgentStart(open.sessionKey, reopenAt, undefined, undefined, 'hook')
+              }
               continue
             }
           }

--- a/src/main/stats/hook-status-stats-bridge.ts
+++ b/src/main/stats/hook-status-stats-bridge.ts
@@ -110,6 +110,8 @@ export function createHookStatusStatsBridge(
   return {
     apply(statuses, now = Date.now()) {
       const present = new Set<string>()
+      // Why: multiple stale rows can share a PTY-backed key; one snapshot rotates it once.
+      const rotatedSessionKeys = new Set<string>()
 
       for (const status of statuses) {
         present.add(status.paneKey)
@@ -131,6 +133,11 @@ export function createHookStatusStatsBridge(
             // A live turn whose tool call outlasts the horizon splits here too;
             // that granularity residual is documented above.
             if (status.receivedAt - open.lastEvidenceAt > AGENT_STATUS_STALE_AFTER_MS) {
+              if (rotatedSessionKeys.has(open.sessionKey)) {
+                open.lastEvidenceAt = Math.max(open.lastEvidenceAt, status.receivedAt)
+                continue
+              }
+              rotatedSessionKeys.add(open.sessionKey)
               closeSession(status.paneKey, open.lastEvidenceAt)
             } else {
               const previousEvidenceAt = open.lastEvidenceAt

--- a/src/main/stats/hook-status-stats-bridge.ts
+++ b/src/main/stats/hook-status-stats-bridge.ts
@@ -1,4 +1,5 @@
-import type { AgentStatusState } from '../../shared/agent-status-types'
+import { AGENT_STATUS_STALE_AFTER_MS, type AgentStatusState } from '../../shared/agent-status-types'
+import type { AgentSessionSource } from './collector'
 
 /**
  * Minimal status shape from AgentHookServer status-change notifications.
@@ -12,25 +13,65 @@ export type HookStatusStatsInput = {
 }
 
 type StatsAgentLifecycle = {
-  onAgentStart: (sessionKey: string, at: number) => void
-  onAgentStop: (sessionKey: string, at: number) => void
+  onAgentStart: (
+    sessionKey: string,
+    at: number,
+    repoId?: string,
+    worktreeId?: string,
+    source?: AgentSessionSource
+  ) => void
+  onAgentStop: (sessionKey: string, at: number, source?: AgentSessionSource) => void
+}
+
+export type HookStatusStatsBridgeOptions = {
+  /**
+   * PTY currently backing a pane, or null when none resolves.
+   *
+   * Why: the OSC AgentDetector and the hook pipeline watch the same physical
+   * agent, and on a hook-enabled machine OSC titles still fire constantly
+   * (measured: ~390 agent_start/day, 55%+ of them on panes the hook pipeline
+   * also reports). Reusing the PTY-scoped key lets StatsCollector recognize the
+   * session as already open instead of counting spawns and worked time twice.
+   */
+  resolvePtyId?: (paneKey: string) => string | null
 }
 
 /**
  * Mirrors AgentDetector's working→idle session boundaries, but driven by the
  * hook status pipeline (Claude/Codex/OpenCode/…) instead of OSC titles.
  *
- * Why a separate session key prefix: OSC-based AgentDetector still keys by
- * ptyId; prefixing avoids clobbering concurrent live maps if both paths fire
- * for the same physical agent (hooks are the accurate path; OSC rarely fires).
+ * Session keys prefer the pane's live ptyId so both producers converge on one
+ * StatsCollector session. The `hook:` fallback only applies to panes with no
+ * resolvable PTY, where a collision with the OSC path is impossible anyway.
+ *
+ * Closing is deliberately driven only by the status stream. PTY teardown clears
+ * a pane's row only when a spawn-time paneKey was recorded, so a session on a
+ * pane that misses that clear stays open until the row drops or the app quits,
+ * where the staleness bound below credits it correctly. Letting the OSC detector
+ * close it on PTY exit instead was tried and repeatedly produced worse bugs than
+ * the delay it fixed; the real fix is evicting stale rows in AgentHookServer.
  */
-export function createHookStatusStatsBridge(stats: StatsAgentLifecycle): {
+export function createHookStatusStatsBridge(
+  stats: StatsAgentLifecycle,
+  options: HookStatusStatsBridgeOptions = {}
+): {
   apply: (statuses: readonly HookStatusStatsInput[], now?: number) => void
   /** Test/inspection helper — paneKeys currently counted as working. */
   getLivePaneKeys: () => string[]
 } {
-  // paneKey → start timestamp
-  const liveWorking = new Map<string, number>()
+  // paneKey → the session this bridge opened for it. The key is stored rather
+  // than re-resolved so a PTY swap mid-turn cannot orphan the open session, and
+  // lastEvidenceAt tracks the newest hook event that proved the pane was working.
+  const liveWorking = new Map<string, { sessionKey: string; lastEvidenceAt: number }>()
+
+  const closeSession = (paneKey: string, at: number): void => {
+    const session = liveWorking.get(paneKey)
+    if (session === undefined) {
+      return
+    }
+    liveWorking.delete(paneKey)
+    stats.onAgentStop(session.sessionKey, at, 'hook')
+  }
 
   return {
     apply(statuses, now = Date.now()) {
@@ -45,27 +86,66 @@ export function createHookStatusStatsBridge(stats: StatsAgentLifecycle): {
         }
 
         if (status.state === 'working') {
-          if (!liveWorking.has(status.paneKey)) {
-            liveWorking.set(status.paneKey, status.receivedAt)
-            stats.onAgentStart(toHookStatsSessionKey(status.paneKey), status.receivedAt)
+          const open = liveWorking.get(status.paneKey)
+          if (open) {
+            // Why rotate on a stale row: a pane whose agent was killed mid-turn
+            // keeps its 'working' row forever, so reusing that pane days later
+            // would bill the whole dead gap to the turn that follows — and while
+            // the abandoned session sits on the pane's ptyId, an OSC-only agent
+            // in that pane is counted by nobody (its start hits a live key, its
+            // stop hits the wrong owner). Reopening restores both boundaries.
+            if (status.receivedAt - open.lastEvidenceAt > AGENT_STATUS_STALE_AFTER_MS) {
+              closeSession(status.paneKey, open.lastEvidenceAt)
+            } else {
+              open.lastEvidenceAt = Math.max(open.lastEvidenceAt, status.receivedAt)
+              continue
+            }
           }
+          // Why the hook: fallback is not just a fallback path: a working event
+          // that lands before the runtime has rebuilt this pane's PTY record
+          // (daemon reattach right after relaunch) keeps the fallback key for
+          // that whole turn, so that one turn can still be counted twice. The
+          // window is one turn per pane per restart; re-keying a live session
+          // would cost a duplicate spawn, which is worse.
+          const sessionKey =
+            options.resolvePtyId?.(status.paneKey) ?? toHookStatsSessionKey(status.paneKey)
+          liveWorking.set(status.paneKey, { sessionKey, lastEvidenceAt: status.receivedAt })
+          stats.onAgentStart(sessionKey, status.receivedAt, undefined, undefined, 'hook')
           continue
         }
 
-        if (liveWorking.has(status.paneKey)) {
-          liveWorking.delete(status.paneKey)
-          stats.onAgentStop(toHookStatsSessionKey(status.paneKey), status.receivedAt)
+        closeSession(status.paneKey, status.receivedAt)
+      }
+
+      // Why: a pane move renames the row inside one notification — the new key
+      // adopted this same PTY session above, so the vanished old key must not
+      // close it or the rest of the turn goes uncounted.
+      const adoptedSessionKeys = new Set<string>()
+      for (const [paneKey, session] of liveWorking) {
+        if (present.has(paneKey)) {
+          adoptedSessionKeys.add(session.sessionKey)
         }
       }
 
       // Why: a cleared pane (tab close / status drop) leaves no snapshot row;
       // close the open working session so totalAgentTimeMs does not leak.
-      for (const paneKey of Array.from(liveWorking.keys())) {
+      for (const [paneKey, session] of Array.from(liveWorking)) {
         if (present.has(paneKey)) {
           continue
         }
         liveWorking.delete(paneKey)
-        stats.onAgentStop(toHookStatsSessionKey(paneKey), now)
+        if (adoptedSessionKeys.has(session.sessionKey)) {
+          continue
+        }
+        // Why not always `now`: nothing evicts a stale 'working' row, so an agent
+        // that was SIGKILLed (or lost its Stop hook) leaves the pane "working"
+        // until the tab closes hours later. Billing that whole gap would dwarf
+        // the real totals on the very cards this exists to fix. Past the
+        // staleness horizon, credit only up to the last hook event that actually
+        // proved work — the OSC path bounds itself the same way with
+        // lastMeaningfulOutputAt.
+        const stale = now - session.lastEvidenceAt > AGENT_STATUS_STALE_AFTER_MS
+        stats.onAgentStop(session.sessionKey, stale ? session.lastEvidenceAt : now, 'hook')
       }
     },
     getLivePaneKeys() {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -383,7 +383,7 @@ export class GitHandler {
     // Why: pointer/range probes are part of the same SSH request and must not outlive its cancellation.
     const requestGit: GitExec = (args, cwd, options) =>
       this.git(args, cwd, { ...options, signal: context.signal })
-    // Why: moved clean gitlinks need committed changes surfaced.
+  // Why: moved clean gitlinks need committed changes surfaced.
     const { fromOid, toOid } = await resolveSubmoduleCommitRange(
       requestGit,
       worktreePath,
@@ -775,7 +775,7 @@ export class GitHandler {
   private async branchCompare(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
     const baseRef = params.baseRef as string
-    // Why: reject flag-like base refs to prevent rev-parse option injection.
+      // Why: reject flag-like base refs to prevent rev-parse option injection.
     if (baseRef.startsWith('-')) {
       throw new Error('Base ref must not start with "-"')
     }


### PR DESCRIPTION
## Summary
- Feed `AgentHookServer` status-change snapshots into `StatsCollector` so Stats & Usage **Agents spawned** / **Time agents worked** reflect modern hook-based agents
- Previously only `AgentDetector` (OSC terminal titles) called `onAgentStart`/`onAgentStop`, which barely fires once agents moved to native hooks
- Add `paneKey` on status-change entries so stats can key sessions per pane

Closes #10201

## Behavior
- Start a stats session when a pane enters `working` and was observed in this runtime
- Stop when it leaves `working` or drops out of the snapshot (tab close / clear)
- Ignore disk-hydrated statuses (`observedInCurrentRuntime: false`) so restart does not invent history
- Session keys use a `hook:` prefix so residual OSC pty sessions never collide

## Test plan
- [x] Unit: hook-status-stats-bridge (start/stop/dedupe/hydrate skip/multi-pane)
- [x] agent-awake + server snapshot tests still pass
- [ ] Manual: run a Claude/Codex turn with hooks on → `orca-stats.json` gains `agent_start`/`agent_stop` and totals move

## Notes
- OSC `AgentDetector` path is left in place for agents that still only publish titles; double-count is rare because OSC detection almost never fires for hook-integrated agents.

## ELI5

Stats for agents spawned and time worked barely updated once agents moved to hook-based status. Status snapshots now feed the stats collector so those numbers match modern agents again.
