### PR TITLE
perf(runtime): event-driven detected-worktree scan + adaptive per-repo scan scheduling

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -267,6 +267,7 @@ const ORIGIN_HEAD_COMPONENT = reviewHeadRemoteRefComponent('origin', ORIGIN_REMO
 import {
   __getDetectedWorktreeScanCacheStatsForTests,
   __resetDetectedWorktreeScanCacheForTests,
+  DETECTED_WORKTREE_SCAN_CACHE_TTL_MS,
   registerWorktreeHandlers
 } from './worktrees'
 
@@ -2707,7 +2708,7 @@ describe('registerWorktreeHandlers', () => {
         ])
 
       await handlers['worktrees:listDetected'](null, { repoId: 'repo-1' })
-      await vi.advanceTimersByTimeAsync(5_001)
+      await vi.advanceTimersByTimeAsync(DETECTED_WORKTREE_SCAN_CACHE_TTL_MS + 1)
       const second = (await handlers['worktrees:listDetected'](null, {
         repoId: 'repo-1'
       })) as { worktrees: Worktree[] }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -476,8 +476,15 @@ function getPreservedBranchCleanupTarget(
 const loggedUnavailableSshGitProviders = new Set<string>()
 const loggedWorktreeListFailures = new Set<string>()
 const loggedMalformedWorktreeMetaKeys = new Set<string>()
-// Why: absorb renderer polling bursts while bounding external worktree-change lag to one short refresh window.
-const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5_000
+// Why: this is now a coarse backstop, not the freshness mechanism. Real
+// worktree add/remove is delivered promptly by the base-directory poller (2s,
+// with a 30s full-scan backstop) and by Orca's own worktree ops, both of which
+// call invalidateDetectedWorktreeScanCache. A short TTL here just re-ran
+// `git worktree list` across every repo on each renderer poll even when nothing
+// changed — the dominant steady-state freeze on multi-worktree profiles (#7576:
+// `git worktree` bursts of 8+ spawns caused recurring 250ms+ stalls). Hold long
+// so idle polls hit cache; event invalidation keeps it correct.
+export const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5 * 60_000
 
 type DetectedWorktreeScanCacheEntry = {
   expiresAt: number

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -38583,9 +38583,10 @@ describe('resolveWorktreeScanCacheTtlMs', () => {
     ).toBe(BASE_TTL_MS)
   })
 
-  it('keeps a scratch repo scan cached past the base TTL while normal repos rescan', async () => {
-    // Why: the whole fix lives in the cache-stamp call site; pin the wiring so
-    // a revert to the flat TTL fails CI, not just the pure-function tests.
+  it('serves cached scans stale-while-revalidate and rescans only when the adaptive schedule is due', async () => {
+    // Why: cache lifetime is driven by the adaptive WorktreeScanSchedule (60s hot
+    // floor, exponential idle backoff, ±25% jitter), not the flat TTL; pin the
+    // call-site wiring so a revert to synchronous TTL rescans fails CI.
     vi.useFakeTimers()
     // Why: the shared listWorktrees stub keeps call history across this file's
     // tests; absolute counts need a clean baseline.
@@ -38613,13 +38614,19 @@ describe('resolveWorktreeScanCacheTtlMs', () => {
       expect(scanCallsFor('/tmp/repo')).toBe(1)
       expect(scanCallsFor(scratchPath)).toBe(1)
 
+      // Inside the first scheduled interval (>=90s even with full downward
+      // jitter for an idle repo): serve the cache, no rescan for either repo.
       vi.advanceTimersByTime(BASE_TTL_MS + 1_000)
       await internals.listResolvedWorktrees()
-      expect(scanCallsFor('/tmp/repo')).toBe(2)
+      expect(scanCallsFor('/tmp/repo')).toBe(1)
       expect(scanCallsFor(scratchPath)).toBe(1)
 
-      vi.advanceTimersByTime(SCRATCH_TTL_MS)
+      // Past the max jittered first interval (150s): both repos come due and
+      // refresh in the background while the cached scan is still served.
+      vi.advanceTimersByTime(150_000)
       await internals.listResolvedWorktrees()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(scanCallsFor('/tmp/repo')).toBe(2)
       expect(scanCallsFor(scratchPath)).toBe(2)
     } finally {
       vi.useRealTimers()

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31611,14 +31611,11 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(1)
   })
 
-  it('worktree scan cache: expires scans per repo without coupling sibling repos', async () => {
+  it('worktree scan cache: serves stale within the interval, refreshes in background after it', async () => {
     vi.mocked(listWorktrees).mockClear()
     vi.useFakeTimers({ now: 0 })
     try {
-      const repos = [
-        { ...store.getRepos()[0], id: 'repo-a', path: '/tmp/repo-a' },
-        { ...store.getRepos()[0], id: 'repo-b', path: '/tmp/repo-b' }
-      ]
+      const repos = [{ ...store.getRepos()[0], id: 'repo-a', path: '/tmp/repo-a' }]
       const runtime = new OrcaRuntimeService({
         ...store,
         getRepos: () => repos,
@@ -31626,15 +31623,23 @@ describe('OrcaRuntimeService', () => {
       } as never)
       vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [makeWorktreeInfo(repoPath)])
 
+      // Cold start scans synchronously.
       await runtime.listDetectedManagedWorktrees('id:repo-a')
-      await vi.advanceTimersByTimeAsync(10_000)
-      await runtime.listDetectedManagedWorktrees('id:repo-b')
-      await vi.advanceTimersByTimeAsync(20_000)
-      await runtime.listDetectedManagedWorktrees('id:repo-a')
-      await runtime.listDetectedManagedWorktrees('id:repo-b')
+      expect(listWorktrees).toHaveBeenCalledTimes(1)
 
-      expect(listWorktrees).toHaveBeenCalledTimes(3)
-      expect(listWorktrees).toHaveBeenNthCalledWith(3, '/tmp/repo-a')
+      // Within the adaptive interval: stale-while-revalidate serves cache, no rescan.
+      await runtime.listDetectedManagedWorktrees('id:repo-a')
+      expect(listWorktrees).toHaveBeenCalledTimes(1)
+
+      // Past the cold cap (max jittered interval is 75min): the next access serves
+      // cache immediately and kicks a background refresh.
+      await vi.advanceTimersByTimeAsync(2 * 60 * 60_000)
+      await runtime.listDetectedManagedWorktrees('id:repo-a')
+      // Flush the fire-and-forget background scan.
+      await vi.advanceTimersByTimeAsync(0)
+      await Promise.resolve()
+      expect(listWorktrees).toHaveBeenCalledTimes(2)
+      expect(listWorktrees).toHaveBeenNthCalledWith(2, '/tmp/repo-a')
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -31645,6 +31645,40 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('worktree scan cache: discarded background results do not re-arm an invalidated schedule', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    vi.useFakeTimers({ now: 0 })
+    try {
+      const backgroundScan = deferred<ReturnType<typeof makeWorktreeInfo>[]>()
+      vi.mocked(listWorktrees)
+        .mockResolvedValueOnce([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+        .mockReturnValueOnce(backgroundScan.promise)
+      const runtime = createRuntime()
+
+      await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      await vi.advanceTimersByTimeAsync(2 * 60 * 60_000)
+      await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      await Promise.resolve()
+      expect(listWorktrees).toHaveBeenCalledTimes(2)
+
+      runtime.notifyBranchRenamed(TEST_REPO_ID)
+      const schedule = (
+        runtime as unknown as {
+          worktreeScanSchedule: { recordRefresh: (repoId: string, isHot: boolean) => void }
+        }
+      ).worktreeScanSchedule
+      const recordRefresh = vi.spyOn(schedule, 'recordRefresh')
+
+      backgroundScan.resolve([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+      await vi.advanceTimersByTimeAsync(0)
+      await Promise.resolve()
+
+      expect(recordRefresh).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('worktree scan cache: does not cache non-authoritative scan failures', async () => {
     vi.mocked(listWorktrees).mockClear()
     const runtime = createRuntime()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -811,6 +811,8 @@ import {
   getDefaultVoiceSettings
 } from '../../shared/constants'
 import { listRepoWorktrees } from '../repo-worktrees'
+import { WorktreeScanSchedule } from './worktree-scan-schedule'
+import { registerWorktreeChangeInvalidator } from '../ipc/worktree-change-invalidators'
 import {
   createWorktreeCopiedPaths,
   createWorktreeLinkedPaths,
@@ -2315,7 +2317,6 @@ type RuntimeWorktreeScanCache = {
   generation: number
   runtimeKey: string
   result: Extract<RuntimeWorktreeScanResult, { ok: true }>
-  expiresAt: number
 }
 
 type RuntimeWorktreeScanInFlight = {
@@ -2578,6 +2579,12 @@ export class OrcaRuntimeService {
   private worktreeScanGenerations = new Map<string, number>()
   private worktreeScanCache = new Map<string, RuntimeWorktreeScanCache>()
   private worktreeScanInFlight = new Map<string, RuntimeWorktreeScanInFlight>()
+  // Why: adaptive per-repo refresh cadence (hot repo 60s → cold 1h ±25% jitter)
+  // so the fleet's `git worktree list` scans never fire together (#7576).
+  private readonly worktreeScanSchedule = new WorktreeScanSchedule({
+    now: () => Date.now(),
+    random: () => Math.random()
+  })
   private cloneInFlightByPath = new Map<string, Promise<void>>()
   private agentDetector: AgentDetector | null = null
   private ptyForegroundAgentRefreshes = new Map<string, PtyForegroundAgentRefresh>()
@@ -3019,6 +3026,10 @@ export class OrcaRuntimeService {
       this.store?.setMobileClientTabSelections?.(state)
     })
     this.orchestrationEnvironmentTransport = deps?.orchestrationEnvironmentTransport ?? null
+    // Why: external `git worktree add/remove` (detected by the base-directory
+    // poller) must drop this repo's cached scan, or stale-while-revalidate could
+    // serve a list missing the change; Orca's own ops already invalidate directly.
+    registerWorktreeChangeInvalidator((repoId) => this.invalidateWorktreeScanCacheForRepo(repoId))
     if (stats) {
       this.stats = stats
       this.agentDetector = new AgentDetector(stats)
@@ -25421,7 +25432,6 @@ export class OrcaRuntimeService {
     repo: Repo,
     projectRuntimeByRepoId?: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
   ): Promise<RuntimeWorktreeScanResult> {
-    const now = Date.now()
     const generation = this.worktreeScanGenerations.get(repo.id) ?? 0
     const projectRuntime = projectRuntimeByRepoId
       ? projectRuntimeByRepoId.get(repo.id)
@@ -25436,13 +25446,19 @@ export class OrcaRuntimeService {
         ? `ssh:${repo.connectionId}:${getSshGitProviderGeneration(repo.connectionId)}`
         : 'local:default'
     const cached = this.worktreeScanCache.get(repo.id)
-    if (
-      cached?.generation === generation &&
-      cached.runtimeKey === runtimeKey &&
-      cached.expiresAt > now
-    ) {
+    if (cached?.generation === generation && cached.runtimeKey === runtimeKey) {
+      // Stale-while-revalidate: a repo's worktree LIST is structurally stable and
+      // add/remove invalidates within ~2s via the base poller, so serve the
+      // last-known scan immediately and only re-scan in the background when the
+      // adaptive schedule says this repo is due. Kills the synchronized fleet
+      // fan-out that fired every repo's `git worktree list` at once (#7576).
+      if (this.worktreeScanSchedule.isDue(repo.id) && !this.worktreeScanInFlight.has(repo.id)) {
+        void this.refreshWorktreeScanInBackground(repo, projectRuntime, generation, runtimeKey)
+      }
       return cached.result
     }
+    // No valid cache (cold start, or invalidated by a structural / runtime-key
+    // change): resolve synchronously so the caller never sees a stale generation.
     const inFlight = this.worktreeScanInFlight.get(repo.id)
     if (inFlight?.generation === generation && inFlight.runtimeKey === runtimeKey) {
       return inFlight.promise
@@ -25451,24 +25467,64 @@ export class OrcaRuntimeService {
     this.worktreeScanInFlight.set(repo.id, { generation, runtimeKey, promise })
     try {
       const result = await promise
-      if (
-        result.ok &&
-        generation === (this.worktreeScanGenerations.get(repo.id) ?? 0) &&
-        this.worktreeScanInFlight.get(repo.id)?.promise === promise
-      ) {
-        this.worktreeScanCache.set(repo.id, {
-          generation,
-          runtimeKey,
-          result,
-          expiresAt: Date.now() + resolveWorktreeScanCacheTtlMs(repo)
-        })
-      }
+      this.commitWorktreeScanResult(repo.id, generation, runtimeKey, result, promise)
       return result
     } finally {
       if (this.worktreeScanInFlight.get(repo.id)?.promise === promise) {
         this.worktreeScanInFlight.delete(repo.id)
       }
     }
+  }
+
+  private commitWorktreeScanResult(
+    repoId: string,
+    generation: number,
+    runtimeKey: string,
+    result: RuntimeWorktreeScanResult,
+    promise: Promise<RuntimeWorktreeScanResult>
+  ): void {
+    // Only cache a successful, still-current result; always (re)schedule so a
+    // transient failure backs off on the curve instead of hot-looping.
+    if (
+      result.ok &&
+      generation === (this.worktreeScanGenerations.get(repoId) ?? 0) &&
+      this.worktreeScanInFlight.get(repoId)?.promise === promise
+    ) {
+      this.worktreeScanCache.set(repoId, { generation, runtimeKey, result })
+    }
+    this.worktreeScanSchedule.recordRefresh(repoId, this.isRepoHotForScan(repoId))
+  }
+
+  private async refreshWorktreeScanInBackground(
+    repo: Repo,
+    projectRuntime: ProjectExecutionRuntimeResolution | undefined,
+    generation: number,
+    runtimeKey: string
+  ): Promise<void> {
+    if (this.worktreeScanInFlight.has(repo.id)) {
+      return
+    }
+    const promise = this.listRepoWorktreesForResolutionUncached(repo, projectRuntime)
+    this.worktreeScanInFlight.set(repo.id, { generation, runtimeKey, promise })
+    try {
+      const result = await promise
+      this.commitWorktreeScanResult(repo.id, generation, runtimeKey, result, promise)
+    } catch {
+      // Best-effort: keep serving the prior cached result, but reschedule so a
+      // failing repo doesn't re-attempt on every access.
+      this.worktreeScanSchedule.recordRefresh(repo.id, this.isRepoHotForScan(repo.id))
+    } finally {
+      if (this.worktreeScanInFlight.get(repo.id)?.promise === promise) {
+        this.worktreeScanInFlight.delete(repo.id)
+      }
+    }
+  }
+
+  // A repo is "hot" (short refresh floor) when it owns the active worktree; cold
+  // repos back off toward the 1h cap. Live-pane repos could extend this later.
+  private isRepoHotForScan(repoId: string): boolean {
+    const activeWorktreeId = this.store?.getWorkspaceSession?.()?.activeWorktreeId
+    return Boolean(activeWorktreeId && splitWorktreeId(activeWorktreeId)?.repoId === repoId)
   }
 
   private async listRepoWorktreesForResolutionUncached(
@@ -25536,6 +25592,9 @@ export class OrcaRuntimeService {
     this.worktreeScanGenerations.set(repoId, (this.worktreeScanGenerations.get(repoId) ?? 0) + 1)
     this.worktreeScanCache.delete(repoId)
     this.worktreeScanInFlight.delete(repoId)
+    // Why: forget the schedule so the next access re-scans immediately (a real
+    // structural change must show right away, not wait out the backoff).
+    this.worktreeScanSchedule.forget(repoId)
   }
 
   private invalidateSshWorktreeScanCacheInternal(targetId: string): void {
@@ -31057,6 +31116,8 @@ const DEFAULT_WORKTREE_LIST_LIMIT = 200
 const DEFAULT_WORKTREE_PS_LIMIT = 200
 const DISCONNECTED_PTY_RECORD_MAX = 128
 const RESOLVED_WORKTREE_CACHE_TTL_MS = 1000
+// Superseded by the adaptive worktreeScanSchedule for cache lifetime; kept because
+// resolveWorktreeScanCacheTtlMs is still part of the exported surface (and its tests).
 const WORKTREE_SCAN_CACHE_TTL_MS = 30_000
 // Why: agent-scratch repos don't need 30s freshness — the steady-state scan
 // fan-out was measured at ~128 git execs/min on real installs, mostly against

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -25483,16 +25483,24 @@ export class OrcaRuntimeService {
     result: RuntimeWorktreeScanResult,
     promise: Promise<RuntimeWorktreeScanResult>
   ): void {
-    // Only cache a successful, still-current result; always (re)schedule so a
-    // transient failure backs off on the curve instead of hot-looping.
-    if (
-      result.ok &&
-      generation === (this.worktreeScanGenerations.get(repoId) ?? 0) &&
-      this.worktreeScanInFlight.get(repoId)?.promise === promise
-    ) {
+    const isCurrent = this.isWorktreeScanCurrent(repoId, generation, promise)
+    if (result.ok && isCurrent) {
       this.worktreeScanCache.set(repoId, { generation, runtimeKey, result })
     }
-    this.worktreeScanSchedule.recordRefresh(repoId, this.isRepoHotForScan(repoId))
+    if (isCurrent) {
+      this.worktreeScanSchedule.recordRefresh(repoId, this.isRepoHotForScan(repoId))
+    }
+  }
+
+  private isWorktreeScanCurrent(
+    repoId: string,
+    generation: number,
+    promise: Promise<RuntimeWorktreeScanResult>
+  ): boolean {
+    return (
+      generation === (this.worktreeScanGenerations.get(repoId) ?? 0) &&
+      this.worktreeScanInFlight.get(repoId)?.promise === promise
+    )
   }
 
   private async refreshWorktreeScanInBackground(
@@ -25509,10 +25517,13 @@ export class OrcaRuntimeService {
     try {
       const result = await promise
       this.commitWorktreeScanResult(repo.id, generation, runtimeKey, result, promise)
-    } catch {
-      // Best-effort: keep serving the prior cached result, but reschedule so a
-      // failing repo doesn't re-attempt on every access.
-      this.worktreeScanSchedule.recordRefresh(repo.id, this.isRepoHotForScan(repo.id))
+    } catch (error) {
+      console.error(`[runtime] Background worktree scan failed for ${repo.id}:`, error)
+      if (this.isWorktreeScanCurrent(repo.id, generation, promise)) {
+        // Best-effort: keep serving the prior cached result, but reschedule so a
+        // failing repo doesn't re-attempt on every access.
+        this.worktreeScanSchedule.recordRefresh(repo.id, this.isRepoHotForScan(repo.id))
+      }
     } finally {
       if (this.worktreeScanInFlight.get(repo.id)?.promise === promise) {
         this.worktreeScanInFlight.delete(repo.id)

--- a/src/main/runtime/worktree-scan-schedule.test.ts
+++ b/src/main/runtime/worktree-scan-schedule.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  COLD_REFRESH_CAP_MS,
+  HOT_REFRESH_FLOOR_MS,
+  WorktreeScanSchedule
+} from './worktree-scan-schedule'
+
+let clock = 0
+let rand = 0.5 // 0.5 => zero jitter, so tiers are exact unless a test overrides
+const make = (): WorktreeScanSchedule =>
+  new WorktreeScanSchedule({ now: () => clock, random: () => rand })
+
+beforeEach(() => {
+  clock = 0
+  rand = 0.5
+})
+
+describe('WorktreeScanSchedule', () => {
+  it('treats an unseen repo as due, and not-due until its interval elapses', () => {
+    const schedule = make()
+    expect(schedule.isDue('r')).toBe(true)
+
+    schedule.recordRefresh('r', true)
+    expect(schedule.isDue('r')).toBe(false)
+
+    clock = HOT_REFRESH_FLOOR_MS - 1
+    expect(schedule.isDue('r')).toBe(false)
+    clock = HOT_REFRESH_FLOOR_MS
+    expect(schedule.isDue('r')).toBe(true)
+  })
+
+  it('holds a hot repo at the floor across repeated refreshes', () => {
+    const schedule = make()
+    schedule.recordRefresh('r', true)
+    clock = HOT_REFRESH_FLOOR_MS
+    const dueAt = schedule.recordRefresh('r', true)
+    expect(dueAt).toBe(clock + HOT_REFRESH_FLOOR_MS)
+  })
+
+  it('backs a cold repo off by doubling, capped', () => {
+    const schedule = make()
+    const intervals: number[] = []
+    let last = 0
+    // First refresh cold: doubles from the floor default.
+    for (let i = 0; i < 8; i += 1) {
+      const dueAt = schedule.recordRefresh('r', false)
+      intervals.push(dueAt - clock)
+      clock = dueAt
+      last = dueAt
+    }
+    // 120s, 240s, 480s ... then capped at 1h.
+    expect(intervals[0]).toBe(2 * HOT_REFRESH_FLOOR_MS)
+    expect(intervals[1]).toBe(4 * HOT_REFRESH_FLOOR_MS)
+    expect(intervals.at(-1)).toBe(COLD_REFRESH_CAP_MS)
+    expect(last).toBeGreaterThan(0)
+  })
+
+  it('resets backoff to the floor the moment a repo goes hot again', () => {
+    const schedule = make()
+    schedule.recordRefresh('r', false)
+    schedule.recordRefresh('r', false) // now backed off to 4x floor
+    const dueAt = schedule.recordRefresh('r', true)
+    expect(dueAt - clock).toBe(HOT_REFRESH_FLOOR_MS)
+  })
+
+  it('applies ±25% jitter so cold-cap repos spread ~45–75min', () => {
+    const scheduleLow = new WorktreeScanSchedule({ now: () => 0, random: () => 0 })
+    const scheduleHigh = new WorktreeScanSchedule({ now: () => 0, random: () => 1 })
+    // Drive both to the cap.
+    let low = 0
+    let high = 0
+    for (let i = 0; i < 10; i += 1) {
+      low = scheduleLow.recordRefresh('r', false)
+      high = scheduleHigh.recordRefresh('r', false)
+    }
+    expect(low).toBe(COLD_REFRESH_CAP_MS * 0.75) // 45min
+    expect(high).toBe(COLD_REFRESH_CAP_MS * 1.25) // 75min
+  })
+
+  it('forgets per-repo state', () => {
+    const schedule = make()
+    schedule.recordRefresh('r', true)
+    expect(schedule.isDue('r')).toBe(false)
+    schedule.forget('r')
+    expect(schedule.isDue('r')).toBe(true)
+  })
+})

--- a/src/main/runtime/worktree-scan-schedule.ts
+++ b/src/main/runtime/worktree-scan-schedule.ts
@@ -1,0 +1,69 @@
+// Adaptive, jittered refresh scheduling for per-repo worktree-list scans.
+//
+// The runtime used to re-scan every repo's `git worktree list` on a flat 30s
+// TTL, firing the whole fleet at once — the recurring 8-spawn burst behind the
+// steady-state freezes and ~50% CPU spikes (#7576). This schedules each repo
+// independently instead: a repo holding the active worktree (or a live pane)
+// refreshes at a short floor; an idle repo backs off exponentially to a capped
+// interval; and every interval carries ±25% jitter so no two repos come due
+// together. Pure, with injectable clock/rng, so the curve is unit-testable.
+
+export const HOT_REFRESH_FLOOR_MS = 60_000
+// 1h cap; ±25% jitter spreads cold repos across ~45–75 min so their refreshes
+// never align into a burst.
+export const COLD_REFRESH_CAP_MS = 60 * 60_000
+export const REFRESH_JITTER_RATIO = 0.25
+
+// Floor for the jittered result so a downward jitter swing can't schedule a
+// near-immediate re-run.
+const MIN_SCHEDULED_INTERVAL_MS = HOT_REFRESH_FLOOR_MS / 2
+
+type RepoScanState = {
+  intervalMs: number
+  dueAt: number
+}
+
+export type WorktreeScanScheduleDeps = {
+  now: () => number
+  random: () => number
+}
+
+export class WorktreeScanSchedule {
+  private readonly state = new Map<string, RepoScanState>()
+
+  constructor(private readonly deps: WorktreeScanScheduleDeps) {}
+
+  /** A repo with no scheduled state, or one past its due time, should refresh. */
+  isDue(repoId: string): boolean {
+    const entry = this.state.get(repoId)
+    return entry === undefined || this.deps.now() >= entry.dueAt
+  }
+
+  /**
+   * Record that a scan just completed and compute the next due time. `isHot`
+   * (repo owns the active worktree or a live pane) resets the backoff to the
+   * floor; otherwise the interval doubles up to the cap. Returns the next dueAt.
+   */
+  recordRefresh(repoId: string, isHot: boolean): number {
+    const previous = this.state.get(repoId)
+    const baseIntervalMs = isHot
+      ? HOT_REFRESH_FLOOR_MS
+      : Math.min((previous?.intervalMs ?? HOT_REFRESH_FLOOR_MS) * 2, COLD_REFRESH_CAP_MS)
+    const dueAt = this.deps.now() + this.jitter(baseIntervalMs)
+    this.state.set(repoId, { intervalMs: baseIntervalMs, dueAt })
+    return dueAt
+  }
+
+  forget(repoId: string): void {
+    this.state.delete(repoId)
+  }
+
+  clear(): void {
+    this.state.clear()
+  }
+
+  private jitter(intervalMs: number): number {
+    const delta = intervalMs * REFRESH_JITTER_RATIO * (this.deps.random() * 2 - 1)
+    return Math.max(MIN_SCHEDULED_INTERVAL_MS, Math.round(intervalMs + delta))
+  }
+}


### PR DESCRIPTION
## Summary

Replaces synchronized worktree polling with event-driven invalidation and adaptive per-repo scheduling.

## What this fixes

After fixing the git-spawn storm we still saw ~50% main-process CPU in steady state with the app idle. The remaining source was worktree scanning: the runtime re-ran every repo's `git worktree list` on a flat 30s TTL, and because all repos share the same TTL they all came due **at the same moment** — we measured a synchronized burst of ~128 git execs/min on a 10-repo install, firing even when the machine was untouched. A second 5s poll re-scanned detected worktrees on top of that.

## What it does

Two commits:

1. **Make the detected-worktree scan event-driven.** It now runs when something actually changed (repo add, worktree ops, base-directory events) instead of on a 5s loop.
2. **Replace the flat 30s TTL with a per-repo adaptive schedule** (`worktree-scan-schedule.ts`, pure module with injectable clock/rng, unit tested):
   - the repo owning the active worktree refreshes at a 60s floor;
   - idle repos back off exponentially up to a 1h cap;
   - every interval carries ±25% jitter, so cold repos spread across ~45–75 min and never align into a burst;
   - reads are stale-while-revalidate — callers always get the last-known scan instantly, refreshes happen in the background.

   Correctness is kept by wiring the runtime scan cache into the existing worktree-change invalidators: an external `git worktree add/remove` (caught by the base-directory poller) drops the repo's cache within ~2s, and Orca's own operations invalidate directly, same as before. Generation/runtimeKey invalidation and in-flight coalescing are unchanged.

The third commit updates the scan-wiring test to assert the schedule semantics instead of the old TTL expiry.

## Proof / testing

- Before/after on the same 10-repo profile: the ~128 execs/min synchronized fleet scan is gone; idle CPU dropped accordingly, and the periodic freeze windows tied to the scan burst no longer show up in the tracer.
- Worktree add/remove from an external terminal still shows up in the sidebar within a couple of seconds (invalidator path), verified manually on native and SSH repos.
- `worktree-scan-schedule.test.ts` covers the backoff curve, jitter bounds and hot/cold transitions; the full `orca-runtime` suite passes (870/871 — the one failure is `polls floating tabs with targeted PTY liveness`, which fails identically on current `main` without this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

With many repos, worktree scanning hammered the CPU on a fixed timer even when idle—all repos fired together. Scanning is now more event-driven and staggered so idle machines stay quiet.


## Screenshots

No visual change.

## Testing

- [x] Worktree-scan focused run: 158 tests passed.\n- [x] TypeScript checks passed.

## AI Review Report

Generation and in-flight identity now gate both cache writes and schedule updates; background failures are observable.

## Security Audit

No new IPC authority, credentials, subprocess arguments, or input surface.

## Notes

Uses no newer Git options; Git 2.25, native, WSL, SSH, runtime, and folder workspaces remain supported.