### PR TITLE
fix(gitea): treat HTTP 404 as no-PR in the hosted-review branch lookup

### DIFF
--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -287,6 +287,16 @@ describe('Gitea client', () => {
     ])
   })
 
+  it('resolves null without throwing when the scan returns an empty list', async () => {
+    // Gitea has no head-branch filter, so "branch has no PR" arrives as a 200
+    // with [] from the repo listing — never a 404. The throwing variant must
+    // still report that as a plain "no PR".
+    const fetchMock = vi.fn(async () => Response.json([]))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getGiteaPullRequestForBranchOrThrow('/repo', 'feature/gitea')).resolves.toBeNull()
+  })
+
   it('still throws on a 404 from the /pulls scan so a misconfigured host is not read as "no PR"', async () => {
     const fetchMock = vi.fn(async () => Response.json({ message: 'not found' }, { status: 404 }))
     vi.stubGlobal('fetch', fetchMock)

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -267,6 +267,15 @@ describe('Gitea client', () => {
     )
   })
 
+  it('treats HTTP 404 as "no PR" even in the throwing variant', async () => {
+    const fetchMock = vi.fn(async () => Response.json({ message: 'not found' }, { status: 404 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    // 404 = resource absent (PR deleted, private repo masked) — an accepted
+    // "no PR", not a lookup failure worth rejecting the IPC handler over.
+    await expect(getGiteaPullRequestForBranchOrThrow('/repo', 'feature/gitea')).resolves.toBeNull()
+  })
+
   it('expires successful scans and bounds retained repository listings', async () => {
     vi.useFakeTimers()
     try {

--- a/src/main/gitea/client.test.ts
+++ b/src/main/gitea/client.test.ts
@@ -267,13 +267,35 @@ describe('Gitea client', () => {
     )
   })
 
-  it('treats HTTP 404 as "no PR" even in the throwing variant', async () => {
+  it('treats a 404 on the linked PR as "no PR" rather than a lookup failure', async () => {
+    const requested: string[] = []
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      requested.push(new URL(String(url)).pathname)
+      // The branch scan succeeds and is simply empty; only PR #42 is gone.
+      return String(url).includes('/pulls/42')
+        ? Response.json({ message: 'not found' }, { status: 404 })
+        : Response.json([])
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(
+      getGiteaPullRequestForBranchOrThrow('/repo', 'feature/gitea', 42)
+    ).resolves.toBeNull()
+    expect(requested).toEqual([
+      '/api/v1/repos/team/repo/pulls',
+      '/api/v1/repos/team/repo/pulls/42'
+    ])
+  })
+
+  it('still throws on a 404 from the /pulls scan so a misconfigured host is not read as "no PR"', async () => {
     const fetchMock = vi.fn(async () => Response.json({ message: 'not found' }, { status: 404 }))
     vi.stubGlobal('fetch', fetchMock)
 
-    // 404 = resource absent (PR deleted, private repo masked) — an accepted
-    // "no PR", not a lookup failure worth rejecting the IPC handler over.
-    await expect(getGiteaPullRequestForBranchOrThrow('/repo', 'feature/gitea')).resolves.toBeNull()
+    // A repo-level 404 means wrong base URL / repo absent / token lacks scope —
+    // collapsing it to "no PR" would hide the misconfiguration indefinitely.
+    await expect(getGiteaPullRequestForBranchOrThrow('/repo', 'feature/gitea')).rejects.toThrow(
+      /Gitea request failed: HTTP 404/
+    )
   })
 
   it('expires successful scans and bounds retained repository listings', async () => {

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -39,6 +39,8 @@ export type GiteaAuthStatus = {
 type RequestOptions = {
   searchParams?: Record<string, string | number>
   timeoutMs?: number
+  // Why: only a single-resource fetch may read 404 as "absent". See requestJsonAtBase.
+  allowNotFound?: boolean
 }
 
 function envValue(name: string): string | null {
@@ -97,11 +99,12 @@ async function requestJsonAtBase<T>(
     })
     if (!response.ok) {
       await cancelUnreadResponseBody(response)
-      // Why: 404 means the resource is absent (PR deleted, repo not on this
-      // forge, or Gitea masking a private repo) — that's an accepted "no PR",
-      // not a transport/auth failure. Throwing it spammed the main-process log
-      // on every hostedReview:forBranch refresh for unaffiliated branches.
-      if (throwOnFailure && response.status !== 404) {
+      // Why: 404 only means "this resource is absent" for a single-resource
+      // fetch the caller opted in with allowNotFound (PR #N deleted, or Gitea
+      // masking it). On any other path a 404 is indistinguishable from a wrong
+      // base URL, a repo that isn't on this forge, or a token without scope —
+      // collapsing that to "no PR" would hide a misconfigured host forever.
+      if (throwOnFailure && !(options.allowNotFound && response.status === 404)) {
         throw new Error(`Gitea request failed: HTTP ${response.status}`)
       }
       return null
@@ -310,7 +313,9 @@ export async function getGiteaPullRequestForBranch(
   const raw = await requestJson<RawGiteaPullRequest>(
     repo,
     `/repos/${encodedRepoPath(repo)}/pulls/${encodeURIComponent(String(linkedPRNumber))}`,
-    {},
+    // Why: a linked PR number can legitimately be gone (deleted, or on a repo
+    // the token can't see). That is a real "no PR", not a lookup failure.
+    { allowNotFound: true },
     throwOnFailure
   )
   return raw ? normalizePullRequest(repo, raw) : null

--- a/src/main/gitea/client.ts
+++ b/src/main/gitea/client.ts
@@ -97,7 +97,11 @@ async function requestJsonAtBase<T>(
     })
     if (!response.ok) {
       await cancelUnreadResponseBody(response)
-      if (throwOnFailure) {
+      // Why: 404 means the resource is absent (PR deleted, repo not on this
+      // forge, or Gitea masking a private repo) — that's an accepted "no PR",
+      // not a transport/auth failure. Throwing it spammed the main-process log
+      // on every hostedReview:forBranch refresh for unaffiliated branches.
+      if (throwOnFailure && response.status !== 404) {
         throw new Error(`Gitea request failed: HTTP ${response.status}`)
       }
       return null


### PR DESCRIPTION
## Summary

Against a self-hosted Gitea/Forgejo, the hosted-review lookup for a branch whose linked PR no longer exists rejected instead of reporting "no PR". Gitea answers a deleted/invisible `/pulls/{n}` with HTTP 404, but the Gitea client treated every non-OK status as a lookup failure, so the eligibility check recorded `reviewLookupOutcome: 'unavailable'` and the Create-PR path refused with "Orca could not confirm whether this branch already has a pull request."

The 404 exemption is scoped to the single-resource `/pulls/{n}` fetch only, via an explicit `allowNotFound` request option. A 404 from the repo-level `/pulls` listing still throws, because there it is indistinguishable from a wrong `ORCA_GITEA_API_BASE_URL`, a repo that isn't on this forge, or a token missing scope.

## ELI5

Orca asks your Gitea server "does this branch already have a pull request?" so it knows whether to offer a Create button. If it asked about one specific pull request that had been deleted, the server said "not found" — and Orca treated that as "the server is broken" instead of "that one is gone." So it got stuck and refused to help.

Now Orca understands the difference between "that specific pull request is gone" (fine, carry on) and "I can't find your repository at all" (a real problem worth reporting). That second case still shows an error on purpose — if we hid it, someone with a mistyped server address would see "no pull requests" forever and never learn their setup was wrong.

## Proof of fix

New test `treats a 404 on the linked PR as "no PR" rather than a lookup failure` against `origin/main`'s `client.ts`:

```
 ❯ src/main/gitea/client.test.ts (18 tests | 1 failed) 40ms
     × treats a 404 on the linked PR as "no PR" rather than a lookup failure 4ms

 FAIL  src/main/gitea/client.test.ts > Gitea client > treats a 404 on the linked PR as "no PR" rather than a lookup failure
AssertionError: promise rejected "Error: Gitea request failed: HTTP 404" instead of resolving
 ❯ src/main/gitea/client.test.ts:283:5

Caused by: Error: Gitea request failed: HTTP 404
 ❯ requestJsonAtBase src/main/gitea/client.ts:101:15
 ❯ getGiteaPullRequestForBranch src/main/gitea/client.ts:306:15

 Test Files  1 failed (1)
      Tests  1 failed | 17 passed (18)
```

With the fix applied:

```
 Test Files  1 passed (1)
      Tests  18 passed (18)
```

Two companion tests lock in the halves that must NOT change, so the exemption cannot be widened back to the listing without a failing test:

- `still throws on a 404 from the /pulls scan so a misconfigured host is not read as "no PR"`
- `resolves null without throwing when the scan returns an empty list`

The endpoint split was verified empirically rather than assumed — instrumenting `fetch` for a branch lookup shows repo resolution runs over local git, not HTTP, and only one HTTP call is made:

```json
{
  "urls": ["https://git.example.com/api/v1/repos/team/repo/pulls?state=all&sort=recentupdate&page=1&limit=50"],
  "git": [[["remote", "get-url", "origin"], { "cwd": "/repo" }]]
}
```

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/main/gitea/ src/main/source-control/ src/main/bitbucket/
 Test Files  16 passed (16)
      Tests  130 passed (130)

$ npx tsc --noEmit -p config/tsconfig.node.json && tsc --noEmit -p config/tsconfig.tc.cli.json && tsc --noEmit -p config/tsconfig.tc.web.json
NODE_OK
CLI_OK
WEB_OK

$ npx oxlint            # exit 0; 27 pre-existing warnings, none in src/main/gitea
$ npx oxlint src/main/gitea/
0 findings
```

Behavior that changes, exhaustively:

- A linked PR number returning 404 now resolves to "no PR" instead of blocking the Create-PR preflight with "could not confirm whether this branch already has a pull request." This is the intended fix.
- Nothing else. `allowNotFound` defaults to unset, so every other request keeps its current behavior; the non-throwing path already collapsed all failures to `null` and is untouched. The existing 403 test asserting the throwing variant still rejects continues to pass.

## Compatibility

- **Platforms:** macOS / Linux / Windows — no platform-dependent code. The change is HTTP status handling with no paths, shell invocation, or key handling; the whole `src/main/gitea` suite passes on macOS and contains no platform branches.
- **SSH / remote:** unchanged and covered. Repo resolution goes through `getGiteaRepoRef`, which dispatches to the SSH git provider when `connectionId` is set; this change touches only the HTTP response branch downstream of that, identically for native, WSL, and SSH hosts.
- **Performance:** no hot-path change. Same number of requests, same `/pulls` scan cache and TTL; the diff adds one boolean check on an already-failing response.

## Screenshots

No visual change. The user-visible effect is that the Create-PR preflight no longer refuses with "Orca could not confirm whether this branch already has a pull request" in the deleted-linked-PR case; no UI markup, layout, or styling is touched.

## Testing

- [x] `pnpm lint` — ran the `oxlint` stage repo-wide (exit 0; 27 pre-existing warnings, none in `src/main/gitea`). The later stages in the `lint` chain (localization catalog, max-lines ratchet, bundled-skill verifiers) were not run; they cover asset/i18n surfaces this diff does not touch.
- [x] `pnpm typecheck` — ran all three projects the script runs (`tsconfig.node.json`, `tsconfig.tc.cli.json`, `tsconfig.tc.web.json`), all clean.
- [ ] `pnpm test` — not run in full (30+ min). Ran the affected modules instead: `src/main/gitea/`, `src/main/source-control/`, `src/main/bitbucket/` → 16 files, 130 tests, all passing.
- [ ] `pnpm build` — not run. This is a main-process TypeScript logic change with no new dependency, asset, or native module; `typecheck` covers the compile surface.
- [x] Added or updated high-quality tests that would catch regressions — three tests: the fix itself (verified failing on `origin/main`), plus two that pin the must-throw and empty-list paths so the exemption can't silently widen.

## AI Review Report

Reviewed with Claude. The main risk checked was **error swallowing**, and it found a real defect in the original patch.

**What it flagged and I changed.** The original patch exempted 404 inside the shared `requestJsonAtBase` helper (`response.status !== 404`), which applies to *every* request made with `throwOnFailure` — including the repo-level `/pulls` listing. There a 404 means a wrong base URL, a repo absent from the forge, or a token without scope. A user who mistyped `ORCA_GITEA_API_BASE_URL` would have seen a permanent, silent "no pull requests" with nothing logged, which is worse than the log noise the patch set out to remove. The exemption is now opt-in per request via `allowNotFound`, set only on `/pulls/{n}`.

**How the two 404s are distinguished.** Not by parsing the response body or URL, but structurally, by which call site opted in — the caller knows whether it asked for one specific resource or for a listing. A listing endpoint that 404s is never "no PR": Gitea has no head-branch filter, so Orca pages `/repos/{owner}/{repo}/pulls` and matches client-side, and "no PR on this branch" arrives as **200 with `[]`**. Both shapes are covered by tests. This is also why the body/URL-sniffing alternative was rejected: it would couple behavior to Gitea's error copy, which varies across Gitea and Forgejo versions, while the call-site split is exact.

**Matching the real error shape.** This client uses `fetch` directly and raises ``new Error(`Gitea request failed: HTTP ${status}`)`` from its own helper — there is no octokit-style typed `.status`. The predicate reads `response.status` on the real `Response` before any error is constructed, and the tests drive it with genuine `Response.json(..., { status })` objects rather than hand-built error doubles, so the predicate and the runtime shape cannot drift.

**Cross-platform (macOS / Linux / Windows) explicitly reviewed:** no shortcuts, labels, path handling, shell invocation, or Electron platform APIs are touched. The only filesystem-adjacent call in this path is `git remote get-url`, unchanged. Nothing here branches on platform, and there is no `path` usage to get separator-wrong.

## Security Audit

- **Auth/permission masking — the central risk, and the reason for the narrowing.** Gitea returns 404 rather than 403 for repos an unauthorized token cannot see, so a broadly-swallowed 404 can hide a genuine authorization failure. Bounded by keeping the listing 404 throwing: an unauthorized or misconfigured host surfaces as `reviewLookupOutcome: 'unavailable'`, which the preflight turns into a visible, actionable refusal. The residual swallow is deliberately narrow — one specific PR number the caller already asked for by number, where "absent" and "not visible to you" are equivalent for the decision being made (whether to offer Create).
- **Duplicate-PR invariant preserved.** `hosted-review-creation.ts` refuses to create when a lookup is `unavailable`, so a masked failure cannot cause a duplicate PR. Widening the swallow would have broken that invariant for Gitea only; the narrowed version keeps it.
- **Secrets:** none added or logged. The token is still read from `ORCA_GITEA_TOKEN` and sent only as an `Authorization` header; no error path added here interpolates it, and the thrown message contains only the numeric status.
- **Input handling / command execution / path handling / IPC:** unchanged. No new subprocess, no new IPC channel, no path construction; the URL is still built with `new URL` + `encodeURIComponent` on owner/repo/number as before.
- **Dependencies:** none added.
- **Follow-up needed:** none.

## Notes

**Provider consistency.** Each provider expresses the same contract in its own transport's idiom, and this change keeps Gitea aligned rather than inventing a new pattern:

- **Bitbucket** and **Azure DevOps** use the same `throwOnFailure` per-request flag; their branch lookups query a filtered endpoint that returns an empty collection, so they have no 404-as-absent case to special-case.
- **GitLab** wraps `glab` and throws on failure via `getMergeRequestForBranchOrThrow`.
- **GitHub** goes through `getPRForBranchOutcome`, which returns a discriminated union and distinguishes `not_found` from transient failures with `classifyGhError` — the closest analogue, and it likewise narrows 404 to specific lookups (`client.ts:1990`, "only fall through to PR #N on a genuine 404") rather than blanket-swallowing.

**A correction to the original description.** Its premise — that Gitea returns 404 for a branch with no PR — isn't what this code path does. Orca never queries a branch-filtered endpoint; "no PR on this branch" is a 200 with `[]`, and the genuine 404 case is the linked-PR-number fallback. The summary above reflects the actual behavior.

**On the earlier automated review comment** ("every `fetch` returns 404, so repository resolution can return `null` first"): that doesn't apply — `getGiteaRepoRef` resolves from `git remote get-url`, not over HTTP, as the instrumented `fetch` trace above shows. The underlying suggestion was still worth acting on, so the new tests assert the exact request sequence (`/pulls` then `/pulls/42`) and can't pass for the wrong reason.

**Residual risk:** low. The diff narrows behavior relative to both the previous revision of this PR and, in one specific case, `main`; every other request path is byte-identical.

Original patch by @Donach.
