### PR TITLE
feat(terminal): opt-in process-isolated terminal panes (ORCA_TERMINAL_PROCESS_ISOLATION)

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -283,7 +283,10 @@ export const electronViteConfig: UserConfig = {
         input: {
           index: resolve('src/renderer/index.html'),
           popout: resolve('src/renderer/popout.html'),
-          web: resolve('src/renderer/web-index.html')
+          web: resolve('src/renderer/web-index.html'),
+          // Why: isolated terminal host page — its own renderer process via <webview>
+          // so app-renderer churn can't block keystroke echo.
+          'terminal-host': resolve('src/renderer/terminal-host.html')
         }
       }
     }

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -5777,6 +5777,62 @@ describe('registerPtyHandlers', () => {
     }
   })
 
+  it('routes daemon output emitted before spawn resolves to the isolated renderer', async () => {
+    vi.useFakeTimers()
+    const runtime = {
+      setPtyController: vi.fn(),
+      registerPty: vi.fn(),
+      noteTerminalSpawnCommand: vi.fn(),
+      onPtySpawned: vi.fn(),
+      onPtyExit: vi.fn(),
+      onPtyData: vi.fn(() => 1),
+      createPreAllocatedTerminalHandle: vi.fn(() => 'terminal-handle-isolated'),
+      registerPreAllocatedHandleForPty: vi.fn()
+    }
+    const isolatedRenderer = {
+      hostWebContents: mainWindow.webContents,
+      isDestroyed: vi.fn(() => false),
+      once: vi.fn(),
+      send: vi.fn()
+    }
+    const spawnBarrier = makeDeferred()
+
+    try {
+      const daemon = installObservableDaemonTestProvider()
+      daemon.spawn.mockImplementation(async (options: { sessionId?: string }) => {
+        daemon.emitData(options.sessionId ?? 'daemon-pty', 'early output')
+        await spawnBarrier.promise
+        return { id: options.sessionId ?? 'daemon-pty' }
+      })
+      registerPtyHandlers(mainWindow as never, runtime as never)
+
+      const pendingSpawn = handlers.get('pty:spawn')!(
+        { sender: isolatedRenderer },
+        {
+          cols: 80,
+          rows: 24,
+          sessionId: 'isolated-daemon-session'
+        }
+      ) as Promise<{ id: string }>
+      await vi.advanceTimersByTimeAsync(50)
+      spawnBarrier.resolve()
+      await pendingSpawn
+
+      expect(isolatedRenderer.send).toHaveBeenCalledWith('pty:data', {
+        id: 'isolated-daemon-session',
+        data: 'early output',
+        seq: 'early output'.length,
+        rawLength: 'early output'.length
+      })
+      expect(mainWindow.webContents.send).not.toHaveBeenCalledWith(
+        'pty:data',
+        expect.objectContaining({ id: 'isolated-daemon-session' })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   // Why: the cap/flag must never fire in the common case (renderer keeps up), so small output carries no droppedBacklog.
   it('does not flag droppedBacklog for ordinary small output under the cap', async () => {
     vi.useFakeTimers()

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2368,14 +2368,17 @@ export function registerPtyHandlers(
   function adoptIsolatedPtyRenderer(
     sender: Electron.WebContents | null | undefined,
     id: string
-  ): void {
+  ): boolean {
     // Only webview guests hosted by the main window are isolated terminal renderers.
     if (
       !sender ||
       sender === mainWindow.webContents ||
       sender.hostWebContents !== mainWindow.webContents
     ) {
-      return
+      return false
+    }
+    if (isolatedPtyRenderers.get(id) === sender) {
+      return true
     }
     isolatedPtyRenderers.set(id, sender)
     sender.once('destroyed', () => {
@@ -2383,6 +2386,7 @@ export function registerPtyHandlers(
         isolatedPtyRenderers.delete(id)
       }
     })
+    return true
   }
 
   function getPtyRendererWebContents(id: string): Electron.WebContents {
@@ -4832,6 +4836,7 @@ export function registerPtyHandlers(
       let result: PtySpawnResult
       let rejectedRegistrationCandidate: PtySpawnResult | null = null
       let pendingRegistrationPtyId: string | null = null
+      let pendingIsolatedPtyRendererId: string | null = null
       let preparedProvisionalExecutionContext = false
       let releaseWorktreeSpawn: (() => void) | undefined
       try {
@@ -4842,6 +4847,9 @@ export function registerPtyHandlers(
           }
           spawnTiming.mark('options')
           const expectedPtyId = effectiveSessionAppId ?? effectiveSessionId
+          if (expectedPtyId && adoptIsolatedPtyRenderer(event?.sender, expectedPtyId)) {
+            pendingIsolatedPtyRendererId = expectedPtyId
+          }
           if (expectedPtyId) {
             runtime?.beginPtyRegistration?.(expectedPtyId)
             pendingRegistrationPtyId = expectedPtyId
@@ -4857,6 +4865,13 @@ export function registerPtyHandlers(
             ? (runtime?.getPtyOutputSequence?.(expectedPtyId) ?? 0)
             : 0
           result = await provider.spawn(spawnOptions)
+          if (pendingIsolatedPtyRendererId && pendingIsolatedPtyRendererId !== result.id) {
+            if (isolatedPtyRenderers.get(pendingIsolatedPtyRendererId) === event?.sender) {
+              isolatedPtyRenderers.delete(pendingIsolatedPtyRendererId)
+            }
+            adoptIsolatedPtyRenderer(event?.sender, result.id)
+            pendingIsolatedPtyRendererId = result.id
+          }
           rejectedRegistrationCandidate = result
           if (pendingRegistrationPtyId !== result.id) {
             if (pendingRegistrationPtyId) {
@@ -4884,6 +4899,12 @@ export function registerPtyHandlers(
           )
           spawnTiming.mark('provider_spawn')
         } catch (err) {
+          if (
+            pendingIsolatedPtyRendererId &&
+            isolatedPtyRenderers.get(pendingIsolatedPtyRendererId) === event?.sender
+          ) {
+            isolatedPtyRenderers.delete(pendingIsolatedPtyRendererId)
+          }
           if ((isMintedSessionId || preparedProvisionalExecutionContext) && effectiveSessionAppId) {
             runtime?.preparePtyExecutionContext?.(effectiveSessionAppId, null, {
               resetIncarnation: true

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -2360,6 +2360,39 @@ export function registerPtyHandlers(
     return writtenOff
   }
 
+  // Why (terminal process isolation): PTYs spawned by a trusted terminal-host
+  // webview render in that guest's own renderer process, so pty:data/pty:exit
+  // must target the guest webContents — mainWindow's dispatcher never sees them.
+  const isolatedPtyRenderers = new Map<string, Electron.WebContents>()
+
+  function adoptIsolatedPtyRenderer(
+    sender: Electron.WebContents | null | undefined,
+    id: string
+  ): void {
+    // Only webview guests hosted by the main window are isolated terminal renderers.
+    if (
+      !sender ||
+      sender === mainWindow.webContents ||
+      sender.hostWebContents !== mainWindow.webContents
+    ) {
+      return
+    }
+    isolatedPtyRenderers.set(id, sender)
+    sender.once('destroyed', () => {
+      if (isolatedPtyRenderers.get(id) === sender) {
+        isolatedPtyRenderers.delete(id)
+      }
+    })
+  }
+
+  function getPtyRendererWebContents(id: string): Electron.WebContents {
+    const isolated = isolatedPtyRenderers.get(id)
+    if (isolated && !isolated.isDestroyed()) {
+      return isolated
+    }
+    return mainWindow.webContents
+  }
+
   function sendPtyDataToRenderer(id: string, payload: PtyDataPayload): boolean {
     const charCount = getPtyPayloadCharCount(payload)
     const accounting = rendererDeliveryAccountingByPty.get(id)
@@ -2378,7 +2411,7 @@ export function registerPtyHandlers(
     rendererInFlightTotalChars += charCount
     recordPtyRendererDeliveryPressure(id)
     try {
-      mainWindow.webContents.send('pty:data', payload)
+      getPtyRendererWebContents(id).send('pty:data', payload)
     } catch (error) {
       const current = rendererDeliveryAccountingByPty.get(id)
       if (current) {
@@ -2830,10 +2863,11 @@ export function registerPtyHandlers(
           schedulePendingDataAfterCreditReport(true)
         }
       }
-      mainWindow.webContents.send('pty:exit', {
+      getPtyRendererWebContents(payload.id).send('pty:exit', {
         ...payload,
         ...(reversibleStopOwnersByPtyId.has(payload.id) ? { preserveRendererBinding: true } : {})
       })
+      isolatedPtyRenderers.delete(payload.id)
     } finally {
       rendererExitingPtyIds.delete(payload.id)
     }
@@ -4373,7 +4407,7 @@ export function registerPtyHandlers(
   ipcMain.handle(
     'pty:spawn',
     async (
-      _event,
+      event,
       args: {
         cols: number
         rows: number
@@ -5167,6 +5201,9 @@ export function registerPtyHandlers(
             })
           }
         }
+        // Why here (not a separate register IPC): binding at spawn closes the race
+        // where first output bytes race an out-of-band registration message.
+        adoptIsolatedPtyRenderer(event?.sender, result.id)
         const response = {
           ...result,
           ...(!result.isReattach && effectiveLaunchConfig
@@ -5314,6 +5351,24 @@ export function registerPtyHandlers(
     !mainWindow.isDestroyed() &&
     !(typeof mainWebContents.isDestroyed === 'function' && mainWebContents.isDestroyed())
 
+  // Why: an isolated terminal-host guest may write ONLY to the PTY it spawned
+  // (adopted at pty:spawn); any other guest/pty combination stays rejected.
+  const isPtyWriteEventFromOwningIsolatedRenderer = (
+    event: IpcMainEvent | IpcMainInvokeEvent,
+    ptyId: string
+  ): boolean => {
+    const isolated = isolatedPtyRenderers.get(ptyId)
+    return isolated !== undefined && event.sender === isolated && !isolated.isDestroyed()
+  }
+
+  const isAuthorizedPtyWriteEvent = (
+    event: IpcMainEvent | IpcMainInvokeEvent,
+    args: unknown
+  ): args is PtyWritePayload =>
+    isPtyWritePayload(args) &&
+    (isPtyWriteEventFromMainWindow(event, mainWindow.webContents) ||
+      isPtyWriteEventFromOwningIsolatedRenderer(event, args.id))
+
   const writePtyInput = (args: PtyWritePayload): boolean | Promise<boolean> => {
     // Why: mobile-presence-lock defense-in-depth — the renderer's onData guard can let one keystroke slip during the state-flip lag, so catch it server-side. See docs/mobile-presence-lock.md.
     if (runtime?.getDriver(args.id).kind === 'mobile') {
@@ -5364,7 +5419,7 @@ export function registerPtyHandlers(
   const hostViewportClaimTails = new Map<string, Promise<boolean>>()
 
   ipcMain.on('pty:write', (event, args: unknown) => {
-    if (!isPtyWriteEventFromMainWindow(event, mainWindow.webContents) || !isPtyWritePayload(args)) {
+    if (!isAuthorizedPtyWriteEvent(event, args)) {
       return
     }
     const claimTail = hostViewportClaimTails.get(args.id)
@@ -5375,7 +5430,7 @@ export function registerPtyHandlers(
     writePtyInput(args)
   })
   ipcMain.handle('pty:writeAccepted', (event, args: unknown): boolean | Promise<boolean> => {
-    if (!isPtyWriteEventFromMainWindow(event, mainWindow.webContents) || !isPtyWritePayload(args)) {
+    if (!isAuthorizedPtyWriteEvent(event, args)) {
       return false
     }
     const claimTail = hostViewportClaimTails.get(args.id)

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -446,10 +446,46 @@ export function createMainWindow(
   // so register it with the window's other navigation policy.
   registerPluginPanelNavigationGuard(mainWindow.webContents)
 
+  // Why: the isolated terminal host is our own bundled page loaded from the same
+  // directory (and protocol) as the main renderer entry — anything else is untrusted.
+  const isTrustedTerminalHostSrc = (src: string): boolean => {
+    if (process.env.ORCA_TERMINAL_PROCESS_ISOLATION !== '1') {
+      return false
+    }
+    try {
+      const srcUrl = new URL(src)
+      const windowUrl = new URL(mainWindow.webContents.getURL())
+      const dirOf = (pathname: string): string => pathname.slice(0, pathname.lastIndexOf('/'))
+      return (
+        srcUrl.protocol === windowUrl.protocol &&
+        srcUrl.host === windowUrl.host &&
+        srcUrl.pathname.endsWith('/terminal-host.html') &&
+        dirOf(srcUrl.pathname) === dirOf(windowUrl.pathname)
+      )
+    } catch {
+      return false
+    }
+  }
+
   mainWindow.webContents.on('will-attach-webview', (event, webPreferences, params) => {
     const src = typeof params.src === 'string' ? params.src : ''
     const normalizedSrc = normalizeBrowserNavigationUrl(src)
     const partition = typeof webPreferences.partition === 'string' ? webPreferences.partition : ''
+
+    if (!partition && isTrustedTerminalHostSrc(src)) {
+      // Terminal-host guest is privileged on purpose: it gets the app preload so
+      // its xterm can drive the PTY IPC directly from its own renderer process.
+      // Main sets the preload path itself — attach params are never trusted for it.
+      webPreferences.preload = join(__dirname, '../preload/index.js')
+      delete (webPreferences as Record<string, unknown>).preloadURL
+      webPreferences.nodeIntegration = false
+      webPreferences.nodeIntegrationInSubFrames = false
+      webPreferences.contextIsolation = true
+      webPreferences.sandbox = true
+      webPreferences.webSecurity = true
+      webPreferences.allowRunningInsecureContent = false
+      return
+    }
 
     // Why: fail closed — deny any src or partition not in the registry allowlist so a renderer bug can't smuggle preload/Node into an unprivileged guest.
     if (!normalizedSrc || !browserSessionRegistry.isAllowedPartition(partition)) {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -73,6 +73,10 @@ import type { LinearIssueAttributeFilter } from '../shared/linear-issue-attribut
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
 import type {
+  TerminalHostAppearance,
+  TerminalHostEmbedderEvent
+} from '../shared/terminal-host-bridge'
+import type {
   AgentProviderSessionMetadata,
   SleepingAgentLaunchConfig
 } from '../shared/agent-session-resume'
@@ -1435,6 +1439,9 @@ export type PreloadApi = {
     ) => () => void
   }
   pty: {
+    // Why a preload constant (not IPC): the terminal-process-isolation flag is an
+    // env var only main/preload can read; renderer branches on it synchronously.
+    processIsolationEnabled: boolean
     spawn: (opts: {
       cols: number
       rows: number
@@ -1627,6 +1634,11 @@ export type PreloadApi = {
     clearPendingPaneSerializer: (paneKey: string, gen: number) => Promise<void>
     reportRendererSerializerReady?: (ptyId: string) => Promise<void>
     management: PtyManagementApi
+  }
+  /** Bridge for the isolated terminal-host <webview> guest (guest-side surface). */
+  terminalHost: {
+    sendToEmbedder: (event: TerminalHostEmbedderEvent) => void
+    onAppearance: (callback: (appearance: TerminalHostAppearance) => void) => () => void
   }
   feedback: {
     submit: (args: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,12 @@ import type { CodexConfigSyncStatus } from '../shared/codex-config-sync-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
+import {
+  TERMINAL_HOST_APPEARANCE_CHANNEL,
+  TERMINAL_HOST_EVENT_CHANNEL,
+  type TerminalHostAppearance,
+  type TerminalHostEmbedderEvent
+} from '../shared/terminal-host-bridge'
 import type {
   AgentProviderSessionMetadata,
   SleepingAgentLaunchConfig
@@ -866,6 +872,9 @@ const api = {
   } satisfies PreloadApi['workspacePorts'],
 
   pty: {
+    // Why a preload constant (not IPC): the terminal-process-isolation flag is an
+    // env var only main/preload can read; renderer branches on it synchronously.
+    processIsolationEnabled: process.env.ORCA_TERMINAL_PROCESS_ISOLATION === '1',
     spawn: (opts: {
       cols: number
       rows: number
@@ -1203,6 +1212,20 @@ const api = {
       killAll: () => ipcRenderer.invoke('pty:management:killAll'),
       killOne: (args: { sessionId: string }) => ipcRenderer.invoke('pty:management:killOne', args),
       restart: () => ipcRenderer.invoke('pty:management:restart')
+    }
+  },
+
+  terminalHost: {
+    /** Guest-side: forward a bridge event to the embedding app renderer. No-op outside a <webview>. */
+    sendToEmbedder: (event: TerminalHostEmbedderEvent): void => {
+      ipcRenderer.sendToHost(TERMINAL_HOST_EVENT_CHANNEL, event)
+    },
+    /** Guest-side: live appearance pushes from the embedder (theme/font/cursor). */
+    onAppearance: (callback: (appearance: TerminalHostAppearance) => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent, payload: TerminalHostAppearance) =>
+        callback(payload)
+      ipcRenderer.on(TERMINAL_HOST_APPEARANCE_CHANNEL, listener)
+      return () => ipcRenderer.removeListener(TERMINAL_HOST_APPEARANCE_CHANNEL, listener)
     }
   },
 

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -227,6 +227,9 @@ import {
   setRegularTerminalInputFocusAttribute
 } from './regular-terminal-focus-ownership'
 import { refreshTerminalImeInputContext } from './terminal-ime-input-context-refresh'
+import TerminalWebviewHost, {
+  isTerminalProcessIsolationEnabled
+} from './TerminalWebviewHost'
 
 type TerminalPaneProps = {
   tabId: string
@@ -274,7 +277,48 @@ function formatClipboardImagePasteError(error: unknown): string {
   return `Image paste failed: ${detail}`
 }
 
-export default function TerminalPane({
+function arePaneTitleOverlayRectsEqual(
+  a: Record<number, PaneTitleOverlayRect>,
+  b: Record<number, PaneTitleOverlayRect>
+): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+  return aKeys.every((key) => {
+    const paneId = Number(key)
+    const left = Math.abs((a[paneId]?.left ?? 0) - (b[paneId]?.left ?? 0))
+    const top = Math.abs((a[paneId]?.top ?? 0) - (b[paneId]?.top ?? 0))
+    const width = Math.abs((a[paneId]?.width ?? 0) - (b[paneId]?.width ?? 0))
+    return left < 0.5 && top < 0.5 && width < 0.5
+  })
+}
+
+export default function TerminalPane(props: TerminalPaneProps): React.JSX.Element {
+  // Terminal process isolation prototype (ORCA_TERMINAL_PROCESS_ISOLATION=1):
+  // local panes render in an isolated <webview> renderer so app churn can't
+  // block echo. Remote/runtime panes always take the legacy path (Phase A scope).
+  const isolate = useAppStore(
+    (store) =>
+      isTerminalProcessIsolationEnabled() &&
+      !getConnectionIdFromState(store, props.worktreeId) &&
+      getExplicitRuntimeEnvironmentIdForWorktree(store, props.worktreeId) === null
+  )
+  if (isolate) {
+    return (
+      <TerminalWebviewHost
+        tabId={props.tabId}
+        worktreeId={props.worktreeId}
+        cwd={props.cwd}
+        onPtyExit={props.onPtyExit}
+      />
+    )
+  }
+  return <LegacyTerminalPane {...props} />
+}
+
+function LegacyTerminalPane({
   tabId,
   worktreeId,
   cwd,

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -227,9 +227,7 @@ import {
   setRegularTerminalInputFocusAttribute
 } from './regular-terminal-focus-ownership'
 import { refreshTerminalImeInputContext } from './terminal-ime-input-context-refresh'
-import TerminalWebviewHost, {
-  isTerminalProcessIsolationEnabled
-} from './TerminalWebviewHost'
+import TerminalWebviewHost, { isTerminalProcessIsolationEnabled } from './TerminalWebviewHost'
 
 type TerminalPaneProps = {
   tabId: string
@@ -311,6 +309,9 @@ export default function TerminalPane(props: TerminalPaneProps): React.JSX.Elemen
         tabId={props.tabId}
         worktreeId={props.worktreeId}
         cwd={props.cwd}
+        isActive={props.isActive}
+        isVisible={props.isVisible ?? true}
+        isWorktreeActive={props.isWorktreeActive ?? props.isVisible ?? true}
         onPtyExit={props.onPtyExit}
       />
     )

--- a/src/renderer/src/components/terminal-pane/TerminalWebviewHost.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalWebviewHost.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { shouldFocusTerminalWebview } from './TerminalWebviewHost'
+
+describe('shouldFocusTerminalWebview', () => {
+  it('only focuses an active pane in the visible worktree', () => {
+    expect(
+      shouldFocusTerminalWebview({
+        isActive: true,
+        isVisible: true,
+        isWorktreeActive: true
+      })
+    ).toBe(true)
+    expect(
+      shouldFocusTerminalWebview({
+        isActive: false,
+        isVisible: true,
+        isWorktreeActive: true
+      })
+    ).toBe(false)
+    expect(
+      shouldFocusTerminalWebview({
+        isActive: true,
+        isVisible: false,
+        isWorktreeActive: true
+      })
+    ).toBe(false)
+    expect(
+      shouldFocusTerminalWebview({
+        isActive: true,
+        isVisible: true,
+        isWorktreeActive: false
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalWebviewHost.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalWebviewHost.tsx
@@ -1,0 +1,279 @@
+// Flag-gated (ORCA_TERMINAL_PROCESS_ISOLATION=1): renders a terminal in an
+// isolated <webview> renderer process so app-renderer churn cannot block
+// keystroke echo. Static config travels in the src URL query string (no
+// init-message race); live appearance rides webview.send; guest events
+// (spawn, agent status, titles, forwarded shortcuts) arrive via ipc-message.
+import { useEffect, useRef, useState } from 'react'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store'
+import { getBuiltinTheme, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
+import { resolveAgentStatusConnectionRouting } from '@/lib/agent-status-connection-ownership'
+import { composeActiveTerminalTheme } from './terminal-appearance'
+import { buildFontFamily } from './layout-serialization'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  TERMINAL_HOST_APPEARANCE_CHANNEL,
+  TERMINAL_HOST_EVENT_CHANNEL,
+  type TerminalHostAppearance,
+  type TerminalHostEmbedderEvent
+} from '../../../../shared/terminal-host-bridge'
+
+type TerminalWebviewHostProps = {
+  tabId: string
+  worktreeId: string
+  cwd?: string
+  onPtyExit: (ptyId: string) => void
+}
+
+export function isTerminalProcessIsolationEnabled(): boolean {
+  return window.api?.pty?.processIsolationEnabled === true
+}
+
+type PendingStartup = AppState['pendingStartupByTabId'][string]
+
+function composeAppearance(settings: AppState['settings']): TerminalHostAppearance | null {
+  if (!settings) {
+    return null
+  }
+  const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+  const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
+  const theme = composeActiveTerminalTheme(
+    appearance.theme ?? getBuiltinTheme(appearance.themeName),
+    settings
+  )
+  return {
+    ...(theme ? { themeJson: JSON.stringify(theme) } : {}),
+    fontFamily: buildFontFamily(settings.terminalFontFamily),
+    fontSize: settings.terminalFontSize,
+    ...(settings.terminalLineHeight !== undefined
+      ? { lineHeight: settings.terminalLineHeight }
+      : {}),
+    ...(settings.terminalCursorStyle ? { cursorStyle: settings.terminalCursorStyle } : {}),
+    ...(settings.terminalCursorBlink ? { cursorBlink: true } : {})
+  }
+}
+
+function buildTerminalHostUrl(args: {
+  tabId: string
+  leafId: string
+  worktreeId: string
+  cwd: string | undefined
+  startup: PendingStartup | undefined
+  paneKey: string
+}): string {
+  const url = new URL('terminal-host.html', window.location.href)
+  if (args.cwd) {
+    url.searchParams.set('cwd', args.cwd)
+  }
+  url.searchParams.set('worktreeId', args.worktreeId)
+  url.searchParams.set('tabId', args.tabId)
+  url.searchParams.set('leafId', args.leafId)
+  if (args.startup) {
+    const { command, env, envToDelete, launchConfig, resumeProviderSession, launchToken, launchAgent, startupCommandDelivery } =
+      args.startup
+    url.searchParams.set(
+      'startup',
+      JSON.stringify({
+        ...(command ? { command } : {}),
+        env: {
+          ...env,
+          // Pane identity env mirrors the legacy path so agent hooks can
+          // attribute their events back to this pane.
+          ORCA_PANE_KEY: args.paneKey,
+          ORCA_TAB_ID: args.tabId,
+          ORCA_WORKTREE_ID: args.worktreeId,
+          ...(launchToken ? { ORCA_AGENT_LAUNCH_TOKEN: launchToken } : {})
+        },
+        ...(envToDelete ? { envToDelete } : {}),
+        ...(launchConfig ? { launchConfig } : {}),
+        ...(resumeProviderSession ? { resumeProviderSession } : {}),
+        ...(launchToken ? { launchToken } : {}),
+        ...(launchAgent ? { launchAgent } : {}),
+        ...(startupCommandDelivery ? { startupCommandDelivery } : {})
+      })
+    )
+  }
+  // Initial appearance is baked into the URL; later changes ride the
+  // appearance channel so the guest doesn't reload (a reload drops the shell).
+  const appearance = composeAppearance(useAppStore.getState().settings)
+  if (appearance) {
+    if (appearance.themeJson) {
+      url.searchParams.set('theme', appearance.themeJson)
+    }
+    url.searchParams.set('fontFamily', appearance.fontFamily)
+    url.searchParams.set('fontSize', String(appearance.fontSize))
+    if (appearance.lineHeight !== undefined) {
+      url.searchParams.set('lineHeight', String(appearance.lineHeight))
+    }
+    if (appearance.cursorStyle) {
+      url.searchParams.set('cursorStyle', appearance.cursorStyle)
+    }
+    if (appearance.cursorBlink) {
+      url.searchParams.set('cursorBlink', '1')
+    }
+  }
+  return url.toString()
+}
+
+export default function TerminalWebviewHost({
+  tabId,
+  worktreeId,
+  cwd,
+  onPtyExit
+}: TerminalWebviewHostProps): React.JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null)
+  // Why: paneKey leaf ids must be durable UUIDs (stable-pane-id contract);
+  // the isolated pane has no layout leaf, so it mints one per mount.
+  const [leafId] = useState(() => crypto.randomUUID())
+  const [startup] = useState(() => useAppStore.getState().pendingStartupByTabId[tabId])
+  const consumeTabStartupCommand = useAppStore((store) => store.consumeTabStartupCommand)
+  const onPtyExitRef = useRef(onPtyExit)
+  onPtyExitRef.current = onPtyExit
+
+  useEffect(() => {
+    if (startup) {
+      consumeTabStartupCommand(tabId)
+    }
+  }, [startup, tabId, consumeTabStartupCommand])
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+    const paneKey = makePaneKey(tabId, leafId)
+    let ptyId: string | null = null
+
+    const dispatchAgentStatus = (
+      payload: Extract<TerminalHostEmbedderEvent, { kind: 'agent-status' }>['payload'],
+      eventPtyId: string
+    ): void => {
+      const routing = resolveAgentStatusConnectionRouting({ ptyId: eventPtyId })
+      if (!routing) {
+        return
+      }
+      useAppStore.getState().setAgentStatus(
+        paneKey,
+        payload,
+        undefined,
+        undefined,
+        { tabId, worktreeId, connectionId: routing.connectionId },
+        {
+          ...(startup?.launchConfig ? { launchConfig: startup.launchConfig } : {}),
+          ...(startup?.launchToken ? { launchToken: startup.launchToken } : {})
+        }
+      )
+    }
+
+    // Imperative creation matches the browser-pane pattern — webview is not a
+    // typed JSX intrinsic in this codebase.
+    const webview = document.createElement('webview') as Electron.WebviewTag
+    webview.src = buildTerminalHostUrl({ tabId, leafId, worktreeId, cwd, startup, paneKey })
+    webview.style.width = '100%'
+    webview.style.height = '100%'
+    webview.style.display = 'flex'
+
+    let domReady = false
+    let lastSentAppearance: string | null = null
+    const pushAppearance = (): void => {
+      if (!domReady) {
+        return
+      }
+      const appearance = composeAppearance(useAppStore.getState().settings)
+      if (!appearance) {
+        return
+      }
+      const serialized = JSON.stringify(appearance)
+      if (serialized === lastSentAppearance) {
+        return
+      }
+      lastSentAppearance = serialized
+      void webview.send(TERMINAL_HOST_APPEARANCE_CHANNEL, appearance)
+    }
+
+    const handleDomReady = (): void => {
+      domReady = true
+      // Why: the guest's xterm can only receive keys once the webview element
+      // itself has focus; hand it over as soon as the guest page is ready.
+      webview.focus()
+      // Baseline so only future settings changes are pushed as diffs.
+      lastSentAppearance = JSON.stringify(composeAppearance(useAppStore.getState().settings))
+    }
+    webview.addEventListener('dom-ready', handleDomReady)
+
+    const handleIpcMessage = (event: Electron.IpcMessageEvent): void => {
+      if (event.channel !== TERMINAL_HOST_EVENT_CHANNEL) {
+        return
+      }
+      const payload = event.args[0] as TerminalHostEmbedderEvent | undefined
+      if (!payload || typeof payload !== 'object') {
+        return
+      }
+      const state = useAppStore.getState()
+      switch (payload.kind) {
+        case 'spawned': {
+          ptyId = payload.ptyId
+          state.updateTabPtyId(tabId, payload.ptyId)
+          // Agents without native prompt hooks get a seeded working row, same
+          // as the legacy path's applyInitialAgentStatus.
+          const initialStatus = startup?.initialAgentStatus
+          if (initialStatus) {
+            dispatchAgentStatus(
+              {
+                state: 'working',
+                prompt: initialStatus.prompt,
+                agentType: initialStatus.agent
+              },
+              payload.ptyId
+            )
+          }
+          break
+        }
+        case 'agent-status': {
+          if (payload.ptyId === ptyId) {
+            dispatchAgentStatus(payload.payload, payload.ptyId)
+          }
+          break
+        }
+        case 'title': {
+          if (payload.ptyId === ptyId && payload.title.trim()) {
+            state.updateTabTitle(tabId, payload.title)
+          }
+          break
+        }
+        case 'exit': {
+          if (payload.ptyId === ptyId) {
+            state.clearTabPtyId(tabId, payload.ptyId)
+            onPtyExitRef.current(payload.ptyId)
+          }
+          break
+        }
+        case 'keydown': {
+          // Replay app-owned chords (clipboard/menu shortcuts the guest's
+          // xterm bypassed) on this document so app-level handlers fire.
+          document.dispatchEvent(
+            new KeyboardEvent('keydown', { ...payload.init, bubbles: true, cancelable: true })
+          )
+          break
+        }
+      }
+    }
+    webview.addEventListener('ipc-message', handleIpcMessage)
+
+    const unsubscribeSettings = useAppStore.subscribe((state, previousState) => {
+      if (state.settings !== previousState.settings) {
+        pushAppearance()
+      }
+    })
+
+    container.appendChild(webview)
+    return () => {
+      unsubscribeSettings()
+      webview.removeEventListener('ipc-message', handleIpcMessage)
+      webview.removeEventListener('dom-ready', handleDomReady)
+      webview.remove()
+    }
+  }, [tabId, leafId, worktreeId, cwd, startup])
+
+  return <div ref={containerRef} className="h-full w-full" />
+}

--- a/src/renderer/src/components/terminal-pane/TerminalWebviewHost.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalWebviewHost.tsx
@@ -22,11 +22,22 @@ type TerminalWebviewHostProps = {
   tabId: string
   worktreeId: string
   cwd?: string
+  isActive: boolean
+  isVisible: boolean
+  isWorktreeActive: boolean
   onPtyExit: (ptyId: string) => void
 }
 
 export function isTerminalProcessIsolationEnabled(): boolean {
   return window.api?.pty?.processIsolationEnabled === true
+}
+
+export function shouldFocusTerminalWebview(args: {
+  isActive: boolean
+  isVisible: boolean
+  isWorktreeActive: boolean
+}): boolean {
+  return args.isActive && args.isVisible && args.isWorktreeActive
 }
 
 type PendingStartup = AppState['pendingStartupByTabId'][string]
@@ -69,8 +80,16 @@ function buildTerminalHostUrl(args: {
   url.searchParams.set('tabId', args.tabId)
   url.searchParams.set('leafId', args.leafId)
   if (args.startup) {
-    const { command, env, envToDelete, launchConfig, resumeProviderSession, launchToken, launchAgent, startupCommandDelivery } =
-      args.startup
+    const {
+      command,
+      env,
+      envToDelete,
+      launchConfig,
+      resumeProviderSession,
+      launchToken,
+      launchAgent,
+      startupCommandDelivery
+    } = args.startup
     url.searchParams.set(
       'startup',
       JSON.stringify({
@@ -119,6 +138,9 @@ export default function TerminalWebviewHost({
   tabId,
   worktreeId,
   cwd,
+  isActive,
+  isVisible,
+  isWorktreeActive,
   onPtyExit
 }: TerminalWebviewHostProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -129,6 +151,8 @@ export default function TerminalWebviewHost({
   const consumeTabStartupCommand = useAppStore((store) => store.consumeTabStartupCommand)
   const onPtyExitRef = useRef(onPtyExit)
   onPtyExitRef.current = onPtyExit
+  const focusStateRef = useRef({ isActive, isVisible, isWorktreeActive })
+  focusStateRef.current = { isActive, isVisible, isWorktreeActive }
 
   useEffect(() => {
     if (startup) {
@@ -193,9 +217,9 @@ export default function TerminalWebviewHost({
 
     const handleDomReady = (): void => {
       domReady = true
-      // Why: the guest's xterm can only receive keys once the webview element
-      // itself has focus; hand it over as soon as the guest page is ready.
-      webview.focus()
+      if (shouldFocusTerminalWebview(focusStateRef.current)) {
+        webview.focus()
+      }
       // Baseline so only future settings changes are pushed as diffs.
       lastSentAppearance = JSON.stringify(composeAppearance(useAppStore.getState().settings))
     }

--- a/src/renderer/src/terminal-host/terminal-host-controller.ts
+++ b/src/renderer/src/terminal-host/terminal-host-controller.ts
@@ -1,0 +1,208 @@
+// Single-terminal controller for the isolated terminal host page. Deliberately
+// minimal: no app store, no React — nothing on this page's main thread besides
+// xterm and the PTY IPC, so keystroke echo can't be blocked by app churn.
+// App-level concerns (agent status rows, tab titles, forwarded shortcuts) are
+// parsed here but dispatched to the embedding renderer via the bridge.
+import { Terminal, type ITheme } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import '@xterm/xterm/css/xterm.css'
+import { createAgentStatusOscProcessor } from '../../../shared/agent-status-osc'
+import { extractAllOscTitles } from '../../../shared/agent-detection'
+import type { TerminalHostAppearance } from '../../../shared/terminal-host-bridge'
+import { shouldBypassXtermKeyboardEvent } from '../components/terminal-pane/xterm-bypass-policy'
+
+/** Startup payload forwarded verbatim from the app's pendingStartupByTabId entry. */
+export type TerminalHostStartup = {
+  command?: string
+  env?: Record<string, string>
+  envToDelete?: string[]
+  launchConfig?: unknown
+  resumeProviderSession?: unknown
+  launchToken?: string
+  launchAgent?: string
+  startupCommandDelivery?: unknown
+}
+
+export type TerminalHostConfig = {
+  cwd: string
+  worktreeId?: string
+  tabId?: string
+  leafId?: string
+  startup?: TerminalHostStartup
+  theme: ITheme | null
+  fontFamily: string
+  fontSize: number
+  lineHeight?: number
+  cursorStyle?: 'block' | 'underline' | 'bar'
+  cursorBlink?: boolean
+}
+
+function applyAppearance(terminal: Terminal, fit: FitAddon, appearance: TerminalHostAppearance): void {
+  if (appearance.themeJson) {
+    try {
+      terminal.options.theme = JSON.parse(appearance.themeJson) as ITheme
+    } catch {
+      // Malformed theme push; keep the current theme.
+    }
+  }
+  terminal.options.fontFamily = appearance.fontFamily
+  terminal.options.fontSize = appearance.fontSize
+  if (appearance.lineHeight !== undefined) {
+    terminal.options.lineHeight = appearance.lineHeight
+  }
+  terminal.options.cursorStyle = appearance.cursorStyle ?? 'block'
+  terminal.options.cursorBlink = appearance.cursorBlink ?? false
+  fit.fit()
+}
+
+export async function startTerminalHost(
+  container: HTMLElement,
+  config: TerminalHostConfig
+): Promise<void> {
+  const terminal = new Terminal({
+    allowProposedApi: true,
+    scrollback: 10_000,
+    theme: config.theme ?? undefined,
+    fontFamily: config.fontFamily,
+    fontSize: config.fontSize,
+    ...(config.lineHeight !== undefined ? { lineHeight: config.lineHeight } : {}),
+    cursorStyle: config.cursorStyle ?? 'block',
+    cursorBlink: config.cursorBlink ?? false
+  })
+  const fit = new FitAddon()
+  terminal.loadAddon(fit)
+  terminal.open(container)
+  // WebGL renderer keeps glyph drawing off this page's CPU path; canvas fallback
+  // is xterm's default when the context can't be created.
+  try {
+    const { WebglAddon } = await import('@xterm/addon-webgl')
+    const webgl = new WebglAddon()
+    webgl.onContextLoss(() => webgl.dispose())
+    terminal.loadAddon(webgl)
+  } catch {
+    // DOM/canvas renderer still works; the prototype measures input delay, not paint.
+  }
+  fit.fit()
+
+  const isMac = navigator.userAgent.includes('Mac')
+  // Chords the app owns (clipboard, menu accelerators) bypass xterm and are
+  // replayed on the embedder document so app-level handlers still fire.
+  terminal.attachCustomKeyEventHandler((e) => {
+    const bypass = shouldBypassXtermKeyboardEvent(e, {
+      isMac,
+      hasSelection: terminal.hasSelection()
+    })
+    if (bypass && e.type === 'keydown') {
+      window.api.terminalHost.sendToEmbedder({
+        kind: 'keydown',
+        init: {
+          key: e.key,
+          code: e.code,
+          keyCode: e.keyCode,
+          metaKey: e.metaKey,
+          ctrlKey: e.ctrlKey,
+          altKey: e.altKey,
+          shiftKey: e.shiftKey,
+          repeat: e.repeat
+        }
+      })
+    }
+    return !bypass
+  })
+
+  const startup = config.startup
+  const spawnResult = await window.api.pty.spawn({
+    cols: terminal.cols,
+    rows: terminal.rows,
+    cwd: config.cwd,
+    cwdFallback: 'worktree',
+    ...(config.worktreeId ? { worktreeId: config.worktreeId } : {}),
+    ...(config.tabId ? { tabId: config.tabId } : {}),
+    ...(config.leafId ? { leafId: config.leafId } : {}),
+    ...(startup?.command ? { command: startup.command } : {}),
+    ...(startup?.env ? { env: startup.env } : {}),
+    ...(startup?.envToDelete ? { envToDelete: startup.envToDelete } : {}),
+    ...(startup?.launchConfig
+      ? { launchConfig: startup.launchConfig as never }
+      : {}),
+    ...(startup?.resumeProviderSession
+      ? { resumeProviderSession: startup.resumeProviderSession as never }
+      : {}),
+    ...(startup?.launchToken ? { launchToken: startup.launchToken } : {}),
+    ...(startup?.launchAgent ? { launchAgent: startup.launchAgent as never } : {}),
+    ...(startup?.startupCommandDelivery
+      ? { startupCommandDelivery: startup.startupCommandDelivery as never }
+      : {})
+  })
+  const ptyId = spawnResult.id
+  window.api.terminalHost.sendToEmbedder({ kind: 'spawned', ptyId })
+  if (spawnResult.replay) {
+    terminal.write(spawnResult.replay)
+  } else if (spawnResult.snapshot) {
+    terminal.write(spawnResult.snapshot)
+  } else if (spawnResult.coldRestore) {
+    terminal.write(spawnResult.coldRestore.scrollback)
+    window.api.pty.ackColdRestore(ptyId)
+  }
+
+  // OSC 9999 agent-status payloads are stripped before xterm sees them (same
+  // as the legacy transport) and forwarded to the embedder, which owns the
+  // store writes. OSC 0/2 titles forward for tab-title + status display.
+  const processAgentStatus = createAgentStatusOscProcessor()
+  let lastForwardedTitle: string | null = null
+
+  // Cumulative ack keeps main's delivery accounting flowing for this guest
+  // exactly like the app renderer's dispatcher would.
+  let processedChars = 0
+  window.api.pty.onData((payload) => {
+    if (payload.id !== ptyId) {
+      return
+    }
+    const chunkChars = Math.max(0, payload.rawLength ?? payload.data.length)
+    const processed = processAgentStatus(payload.data)
+    for (const statusPayload of processed.payloads) {
+      window.api.terminalHost.sendToEmbedder({ kind: 'agent-status', ptyId, payload: statusPayload })
+    }
+    const titles = extractAllOscTitles(payload.data)
+    const latestTitle = titles.at(-1) ?? null
+    if (latestTitle !== null && latestTitle !== lastForwardedTitle) {
+      lastForwardedTitle = latestTitle
+      window.api.terminalHost.sendToEmbedder({ kind: 'title', ptyId, title: latestTitle })
+    }
+    if (processed.cleanData.length === 0) {
+      processedChars += chunkChars
+      window.api.pty.ackData(ptyId, chunkChars, processedChars)
+      return
+    }
+    terminal.write(processed.cleanData, () => {
+      processedChars += chunkChars
+      window.api.pty.ackData(ptyId, chunkChars, processedChars)
+    })
+  })
+  window.api.pty.onExit((payload) => {
+    if (payload.id !== ptyId) {
+      return
+    }
+    terminal.write('\r\n[process exited]\r\n')
+    window.api.terminalHost.sendToEmbedder({ kind: 'exit', ptyId })
+  })
+
+  window.api.terminalHost.onAppearance((appearance) => {
+    applyAppearance(terminal, fit, appearance)
+    window.api.pty.resize(ptyId, terminal.cols, terminal.rows)
+  })
+
+  terminal.onData((data) => {
+    window.api.pty.write(ptyId, data)
+  })
+  terminal.onResize(({ cols, rows }) => {
+    window.api.pty.resize(ptyId, cols, rows)
+  })
+
+  const resizeObserver = new ResizeObserver(() => {
+    fit.fit()
+  })
+  resizeObserver.observe(container)
+  window.addEventListener('focus', () => terminal.focus())
+  terminal.focus()
+}

--- a/src/renderer/src/terminal-host/terminal-host-entry.ts
+++ b/src/renderer/src/terminal-host/terminal-host-entry.ts
@@ -1,0 +1,60 @@
+// Entry for the isolated terminal host page (terminal-host.html), loaded in a
+// <webview> so the terminal renders in its own process. Config arrives via URL
+// query params — static at load time, so there is no init-message race.
+import {
+  startTerminalHost,
+  type TerminalHostConfig,
+  type TerminalHostStartup
+} from './terminal-host-controller'
+import { startTerminalHostProbe } from './terminal-host-probe'
+
+function parseConfig(): TerminalHostConfig {
+  const params = new URLSearchParams(window.location.search)
+  let theme: TerminalHostConfig['theme'] = null
+  const rawTheme = params.get('theme')
+  if (rawTheme) {
+    try {
+      theme = JSON.parse(rawTheme)
+    } catch {
+      theme = null
+    }
+  }
+  let startup: TerminalHostStartup | undefined
+  const rawStartup = params.get('startup')
+  if (rawStartup) {
+    try {
+      startup = JSON.parse(rawStartup) as TerminalHostStartup
+    } catch {
+      startup = undefined
+    }
+  }
+  const fontSize = Number(params.get('fontSize'))
+  const lineHeight = Number(params.get('lineHeight'))
+  const cursorStyle = params.get('cursorStyle')
+  return {
+    cwd: params.get('cwd') ?? '',
+    worktreeId: params.get('worktreeId') ?? undefined,
+    tabId: params.get('tabId') ?? undefined,
+    leafId: params.get('leafId') ?? undefined,
+    startup,
+    theme,
+    fontFamily: params.get('fontFamily') ?? 'monospace',
+    fontSize: Number.isFinite(fontSize) && fontSize > 0 ? fontSize : 13,
+    ...(Number.isFinite(lineHeight) && lineHeight > 0 ? { lineHeight } : {}),
+    ...(cursorStyle === 'block' || cursorStyle === 'underline' || cursorStyle === 'bar'
+      ? { cursorStyle }
+      : {}),
+    cursorBlink: params.get('cursorBlink') === '1'
+  }
+}
+
+const container = document.getElementById('terminal')
+if (container) {
+  const config = parseConfig()
+  startTerminalHostProbe(config.worktreeId ?? config.cwd)
+  void startTerminalHost(container, config).catch((error) => {
+    container.textContent = `Terminal host failed to start: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+  })
+}

--- a/src/renderer/src/terminal-host/terminal-host-probe.ts
+++ b/src/renderer/src/terminal-host/terminal-host-probe.ts
@@ -1,0 +1,78 @@
+// Latency probe for the isolated terminal host page. Mirrors the measurement
+// core of renderer-churn-probe but tags lines `[terminal-host]` so diag logs
+// can compare the host's input latency against the app renderer's under the
+// same load. No store instrumentation — this page has no app store.
+
+const REPORT_EVERY_MS = 5_000
+const EVENT_DURATION_THRESHOLD_MS = 16
+
+type ObserveOptions = PerformanceObserverInit & { durationThreshold?: number }
+
+function observe(
+  type: string,
+  onEntries: (entries: PerformanceEntryList) => void,
+  options: ObserveOptions = {}
+): void {
+  try {
+    const observer = new PerformanceObserver((list) => onEntries(list.getEntries()))
+    observer.observe({ type, buffered: true, ...options } as ObserveOptions)
+  } catch {
+    // Entry type unsupported in this Chromium build — skip that signal.
+  }
+}
+
+export function startTerminalHostProbe(label: string): void {
+  let longTaskCount = 0
+  let longTaskMaxMs = 0
+  let longTaskTotalMs = 0
+  observe('longtask', (entries) => {
+    for (const entry of entries) {
+      longTaskCount++
+      longTaskTotalMs += entry.duration
+      if (entry.duration > longTaskMaxMs) {
+        longTaskMaxMs = entry.duration
+      }
+    }
+  })
+
+  let inputCount = 0
+  let inputMaxDelayMs = 0
+  let inputMaxDurationMs = 0
+  observe(
+    'event',
+    (entries) => {
+      for (const entry of entries as PerformanceEventTiming[]) {
+        inputCount++
+        const delay = entry.processingStart - entry.startTime
+        if (delay > inputMaxDelayMs) {
+          inputMaxDelayMs = delay
+        }
+        if (entry.duration > inputMaxDurationMs) {
+          inputMaxDurationMs = entry.duration
+        }
+      }
+    },
+    { durationThreshold: EVENT_DURATION_THRESHOLD_MS }
+  )
+
+  window.setInterval(() => {
+    const report = {
+      label,
+      t: Math.round(performance.now()),
+      longTasks: longTaskCount,
+      longTaskMaxMs: Math.round(longTaskMaxMs),
+      longTaskTotalMs: Math.round(longTaskTotalMs),
+      inputs: inputCount,
+      inputMaxDelayMs: Math.round(inputMaxDelayMs),
+      inputMaxDurationMs: Math.round(inputMaxDurationMs)
+    }
+    longTaskCount = 0
+    longTaskMaxMs = 0
+    longTaskTotalMs = 0
+    inputCount = 0
+    inputMaxDelayMs = 0
+    inputMaxDurationMs = 0
+    // Forwarded to the diag log by main's console-message listener.
+    console.info(`[terminal-host] ${JSON.stringify(report)}`)
+  }, REPORT_EVERY_MS)
+}

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -795,6 +795,11 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     shell: createShellApi(),
     skills: createSkillsApi(),
     pty: createPtyApi(),
+    // Web clients have no <webview> guest; the bridge surface is inert.
+    terminalHost: {
+      sendToEmbedder: () => {},
+      onAppearance: () => () => {}
+    },
     ssh: createSshApi(),
     wsl: {
       isAvailable: () => callRuntimeResult<boolean>('host.wsl.isAvailable').catch(() => false),
@@ -2954,6 +2959,8 @@ function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
 
 function createPtyApi(): NonNullable<Partial<PreloadApi>['pty']> {
   return {
+    // Web clients have no webview tag, so terminal process isolation never applies.
+    processIsolationEnabled: false,
     spawn: () => Promise.reject(new Error('Local PTYs are unavailable in the web client.')),
     write: () => {},
     writeAccepted: () => Promise.resolve(false),

--- a/src/renderer/terminal-host.html
+++ b/src/renderer/terminal-host.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Orca Terminal Host</title>
+    <!-- CSP is relaxed during development; electron-vite injects a stricter policy for production builds -->
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        overflow: hidden;
+        background: transparent;
+      }
+      #terminal {
+        height: 100%;
+        width: 100%;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div id="terminal"></div>
+    <script type="module" src="/src/terminal-host/terminal-host-entry.ts"></script>
+  </body>
+</html>

--- a/src/shared/terminal-host-bridge.ts
+++ b/src/shared/terminal-host-bridge.ts
@@ -1,0 +1,37 @@
+// IPC contract between the app renderer (embedder) and the isolated
+// terminal-host <webview> guest (ORCA_TERMINAL_PROCESS_ISOLATION=1).
+// Guest → embedder travels over ipcRenderer.sendToHost; embedder → guest over
+// webview.send. Theme objects are passed as JSON strings so neither preload
+// nor this module needs an xterm type dependency.
+import type { ParsedAgentStatusPayload } from './agent-status-types'
+
+export const TERMINAL_HOST_EVENT_CHANNEL = 'terminal-host:event'
+export const TERMINAL_HOST_APPEARANCE_CHANNEL = 'terminal-host:appearance'
+
+export type TerminalHostAppearance = {
+  themeJson?: string
+  fontFamily: string
+  fontSize: number
+  lineHeight?: number
+  cursorStyle?: 'block' | 'underline' | 'bar'
+  cursorBlink?: boolean
+}
+
+/** Serializable keydown snapshot the embedder re-dispatches on its document. */
+export type TerminalHostForwardedKeydown = {
+  key: string
+  code: string
+  keyCode: number
+  metaKey: boolean
+  ctrlKey: boolean
+  altKey: boolean
+  shiftKey: boolean
+  repeat: boolean
+}
+
+export type TerminalHostEmbedderEvent =
+  | { kind: 'spawned'; ptyId: string }
+  | { kind: 'agent-status'; ptyId: string; payload: ParsedAgentStatusPayload }
+  | { kind: 'title'; ptyId: string; title: string }
+  | { kind: 'exit'; ptyId: string }
+  | { kind: 'keydown'; init: TerminalHostForwardedKeydown }


### PR DESCRIPTION
## Summary

Adds a fully opt-in isolated terminal renderer while preserving the legacy default and SSH/runtime fallbacks.

## What this is

An experimental, **fully flag-gated** (`ORCA_TERMINAL_PROCESS_ISOLATION=1`, default off — zero behavior change without it) mode that renders local terminal panes in their own renderer process, so keystroke echo can't be blocked by app-store churn.

## Why

xterm.js currently shares the app renderer's main thread with the whole React/zustand tree. Every store write runs every subscriber, and under load we measured the app renderer's input delay at **p90 121ms / max 482ms** with ~190 long tasks per session — that's what typing lag in a terminal pane actually is. We shipped store-churn fixes separately (they help), but architecturally the latency stays coupled to app complexity: any future feature that churns the store taxes the terminal again.

This PR decouples them. With the flag on, a local, single-pane, non-SSH terminal renders xterm inside a `<webview>` guest page (`terminal-host.html`) — a minimal page with no React and no app store. The PTY already lives in the main process, so this only moves the *rendering*.

## How it works

- Guest page owns one xterm instance + FitAddon/WebGL; it spawns its own PTY and handles data/resize/exit directly.
- Guest ↔ embedder bridge (`src/shared/terminal-host-bridge.ts`): the guest strips OSC 9999 agent-status payloads and OSC titles in-band and forwards them to the embedding renderer, which keeps ownership of all store writes (agent status, tab titles, ptyId binding). App-owned keyboard chords bypass xterm in the guest and are replayed on the embedder document, so global shortcuts keep working.
- Main-process routing: `pty:spawn` adopts the guest's webContents per ptyId; `pty:write` is authorized only for the main window or the owning isolated renderer; `will-attach-webview` forces the app preload + contextIsolation + sandbox for the trusted terminal-host src.
- Anything out of scope (SSH panes, runtime-env panes, splits) automatically falls back to the existing path, flag on or off.

## Proof / testing

Measured with an in-page event-timing probe, same machine, same busy workload, both paths side by side:

| | app-renderer terminal | isolated guest |
|---|---|---|
| input delay p90 | 121ms | **0ms** |
| input delay max | 482ms | 224ms (single blip) |
| long tasks / session | ~190 | 6 |

Subjectively it types like a native terminal even while the app is churning.

Suites: pty + createMainWindow unit tests (391 passing, including new coverage for guest adoption, write authorization and webview hardening), full terminal-pane renderer suite (2252 tests / 175 files), `pnpm typecheck` and production build both clean (build emits `out/renderer/terminal-host.html`). We've been daily-driving it on Linux for several days.

## Known gaps (why it's a flag)

Splits, terminal search UI, header/agent overlays, IME edge cases and the hibernation-reveal path still go through the legacy renderer path; per-pane process memory is ~30–60MB. We think the numbers justify iterating toward parity in-tree behind the flag, but happy to hear how you'd prefer this staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ELI5

Optional experimental mode (flag off by default) runs each local terminal pane in its own process so typing stays snappy when the main app is busy. Without the flag, nothing changes.


## Screenshots

No visual change.

## Testing

- [x] PTY and isolated-host suites: 393 tests passed.\n- [x] TypeScript checks passed.

## AI Review Report

Registered guest ownership before daemon output can flush and gated focus on active, visible pane state.

## Security Audit

Only trusted main-window webview guests can own isolated PTYs; provisional ownership is cleaned up on failure or ID changes.

## Notes

macOS, Linux, and Windows remain supported. SSH and runtime-environment terminals retain the legacy path.