### PR TITLE
fix(cli): remint stale ORCA_TERMINAL_HANDLE for orchestration check identity

### DIFF
--- a/src/cli/handlers/orchestration-check-receiver-handle.test.ts
+++ b/src/cli/handlers/orchestration-check-receiver-handle.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+const getTerminalHandleMock = vi.hoisted(() => vi.fn())
+const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
+const originalPaneKey = process.env.ORCA_PANE_KEY
+
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { RuntimeClientError } from '../runtime-client'
+
+function staleHandleError(): RuntimeClientError {
+  return new RuntimeClientError('terminal_handle_stale', 'terminal_handle_stale')
+}
+
+// Queues the stale-handle remint chain: stale terminal.show → resolvePane returns
+// liveHandle → downstream orchestration.check result.
+function stubStaleHandleRemint(liveHandle: string, downstream: unknown): void {
+  callMock
+    .mockRejectedValueOnce(staleHandleError())
+    .mockResolvedValueOnce({ result: { terminal: { handle: liveHandle } } })
+    .mockResolvedValueOnce(downstream)
+}
+
+afterEach(() => {
+  getTerminalHandleMock.mockReset()
+  if (originalTerminalHandle === undefined) {
+    delete process.env.ORCA_TERMINAL_HANDLE
+  } else {
+    process.env.ORCA_TERMINAL_HANDLE = originalTerminalHandle
+  }
+  if (originalPaneKey === undefined) {
+    delete process.env.ORCA_PANE_KEY
+  } else {
+    process.env.ORCA_PANE_KEY = originalPaneKey
+  }
+})
+
+// Why: `check` resolves its implicit identity via validateEnvHandle, so a stale
+// ORCA_TERMINAL_HANDLE left by an app restart is reminted instead of listening on
+// a dead mailbox. Mirrors the dispatch coordinator-handle remint coverage.
+describe('orchestration check receiver handle', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    getTerminalHandleMock.mockReset()
+    delete process.env.ORCA_TERMINAL_HANDLE
+    delete process.env.ORCA_PANE_KEY
+  })
+
+  const invokeCheck = (flags: Map<string, string | boolean>) =>
+    ORCHESTRATION_HANDLERS['orchestration check']({
+      flags,
+      client: { call: callMock },
+      cwd: '/tmp/repo',
+      json: true
+    } as never)
+
+  it('remints a stale receiver env handle from the caller pane key', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_worker'
+    process.env.ORCA_PANE_KEY = 'tab_worker:leaf_worker'
+    stubStaleHandleRemint('term_live_worker', { result: { messages: [], count: 0 } })
+    getTerminalHandleMock.mockRejectedValue(new Error('active terminal fallback is unsafe'))
+
+    await invokeCheck(new Map())
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.show', {
+      terminal: 'term_stale_worker'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'terminal.resolvePane', {
+      paneKey: 'tab_worker:leaf_worker'
+    })
+    // Why: the reminted live handle — not the dead env handle — is the mailbox check listens on.
+    expect(callMock).toHaveBeenNthCalledWith(3, 'orchestration.check', {
+      terminal: 'term_live_worker',
+      unread: undefined,
+      peek: undefined,
+      all: undefined,
+      types: undefined,
+      inject: undefined,
+      wait: undefined,
+      timeoutMs: undefined
+    })
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+  })
+
+  it('uses a live receiver env handle as-is without reminting', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_worker'
+    process.env.ORCA_PANE_KEY = 'tab_worker:leaf_worker'
+    callMock
+      .mockResolvedValueOnce({ result: { terminal: { handle: 'term_worker' } } })
+      .mockResolvedValueOnce({ result: { messages: [], count: 0 } })
+
+    await invokeCheck(new Map())
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.show', { terminal: 'term_worker' })
+    expect(callMock).not.toHaveBeenCalledWith('terminal.resolvePane', expect.anything())
+    expect(callMock).toHaveBeenNthCalledWith(2, 'orchestration.check', {
+      terminal: 'term_worker',
+      unread: undefined,
+      peek: undefined,
+      all: undefined,
+      types: undefined,
+      inject: undefined,
+      wait: undefined,
+      timeoutMs: undefined
+    })
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+  })
+
+  it('lets an explicit --terminal flag win without probing the env handle', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_worker'
+    process.env.ORCA_PANE_KEY = 'tab_worker:leaf_worker'
+    callMock.mockResolvedValue({ result: { messages: [], count: 0 } })
+
+    await invokeCheck(new Map<string, string | boolean>([['terminal', 'term_explicit']]))
+
+    expect(callMock).not.toHaveBeenCalledWith('terminal.show', expect.anything())
+    expect(callMock).not.toHaveBeenCalledWith('terminal.resolvePane', expect.anything())
+    expect(callMock).toHaveBeenNthCalledWith(1, 'orchestration.check', {
+      terminal: 'term_explicit',
+      unread: undefined,
+      peek: undefined,
+      all: undefined,
+      types: undefined,
+      inject: undefined,
+      wait: undefined,
+      timeoutMs: undefined
+    })
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+  })
+
+  it('falls through to active-terminal resolution when the stale receiver pane cannot remint', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_worker'
+    // No ORCA_PANE_KEY: pane remint is unavailable, so the receiver path degrades to
+    // the active-terminal selector rather than throwing the sender-only error.
+    callMock
+      .mockRejectedValueOnce(staleHandleError())
+      .mockResolvedValueOnce({ result: { messages: [], count: 0 } })
+    getTerminalHandleMock.mockResolvedValue('term_active_worker')
+
+    await invokeCheck(new Map())
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.show', {
+      terminal: 'term_stale_worker'
+    })
+    expect(getTerminalHandleMock).toHaveBeenCalled()
+    expect(callMock).toHaveBeenNthCalledWith(2, 'orchestration.check', {
+      terminal: 'term_active_worker',
+      unread: undefined,
+      peek: undefined,
+      all: undefined,
+      types: undefined,
+      inject: undefined,
+      wait: undefined,
+      timeoutMs: undefined
+    })
+  })
+})

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -139,15 +139,19 @@ async function resolveOrchestrationTerminalHandle(
   }
   const envHandle = process.env.ORCA_TERMINAL_HANDLE
   if (envHandle && envHandle.length > 0) {
-    if (flagName === 'from' && options.validateEnvHandle) {
-      // Why: long-lived shells can retain a stale ORCA_TERMINAL_HANDLE after remint; don't bake it into coordinator preambles.
+    if (options.validateEnvHandle) {
+      // Why: long-lived shells can retain a stale ORCA_TERMINAL_HANDLE after an app restart remints the pane; don't bake it into coordinator preambles or listen on a dead mailbox.
       const live = await isLiveTerminalHandle(envHandle, client)
       if (!live) {
         const reminted = await resolveOrchestrationPaneTerminalHandle(client)
         if (reminted) {
           return reminted
         }
-        throwNoActiveSenderTerminal()
+        // Why: sender path must fail loudly; recipient (--terminal) path falls through to active-terminal resolution.
+        if (flagName === 'from') {
+          throwNoActiveSenderTerminal()
+        }
+        return await getTerminalHandle(flags, cwd, client)
       }
     }
     return envHandle
@@ -391,7 +395,9 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       )
     }
     const timeoutMs = getOptionalPositiveIntegerValueFlag(flags, 'timeout-ms')
-    const terminal = await resolveOrchestrationTerminalHandle(flags, cwd, client, 'terminal')
+    const terminal = await resolveOrchestrationTerminalHandle(flags, cwd, client, 'terminal', {
+      validateEnvHandle: true
+    })
 
     // Why: Claude Code auto-backgrounds subprocesses silent ~2 min; emit JSON keepalives to stderr (stdout stays one payload). See §3.4.
     const stopKeepalive = wait ? startCheckKeepalive(timeoutMs) : null


### PR DESCRIPTION
Fixes #10406

## Summary

`orca orchestration check` resolves its implicit identity from `ORCA_TERMINAL_HANDLE` verbatim. The env var is baked at shell launch; after an app restart the pane is reminted a new handle, so a long-lived coordinator listens on a dead mailbox — silently (`ok: true, count: 0`) — while dispatch (which already validates+remints via `validateEnvHandle`) bakes the live reply address into worker preambles. The CLI itself splits send/receive identity and `worker_done` mail queues undelivered. Full diagnosis with controlled experiments in #10406.

Fix — extend the existing liveness-probe + pane-key remint path (already used for dispatch `--from`) to `check`'s identity resolution:
- `resolveOrchestrationTerminalHandle`: allow the `validateEnvHandle` branch for `flagName === 'terminal'`, not just `'from'`.
- the `check` call site now passes `validateEnvHandle: true`.

When the stale env handle cannot be reminted (no `ORCA_PANE_KEY` / pane gone), the recipient path falls through to the existing active-terminal selector (`getTerminalHandle`, yielding `no_active_terminal`) instead of the sender-only `no_active_sender_terminal` error — no new error codes introduced.

Lifecycle-sender paths (`send`/`reply`/`ask` `--from`) are intentionally untouched — per the in-code comments they must keep the stale handle so `worker_done` survives mid-restart windows and older runtimes can match `assignee_handle`.

## Screenshots

No visual change (CLI-only).

## Testing

- [x] `pnpm lint` — ran the fast gates touched by this change: `oxlint` on the changed files, `lint:switch-exhaustiveness` (type-aware, covers `src/cli`), and `check:max-lines-ratchet` (OK, no new bypasses). Did not run the full `pnpm lint` (it includes unrelated bundle/localization gates and the Electron toolchain).
- [x] `pnpm typecheck` — `typecheck:cli` passes.
- [x] `pnpm test` — targeted: `vitest run src/cli/handlers/orchestration.test.ts src/cli/handlers/orchestration-check-receiver-handle.test.ts` → 50 passed. Did not run the full suite (requires the native/Electron runtime).
- [ ] `pnpm build` — not run (full Electron build out of scope for this CLI-only change).
- [x] Added a new test file `orchestration-check-receiver-handle.test.ts` (mirrors the existing dispatch coordinator-handle remint tests) covering: stale env handle + valid pane key → reminted via `terminal.resolvePane`; live env handle → used as-is (no remint); explicit `--terminal` → wins with no probe; stale handle with no pane key → falls through to active-terminal resolution. Split into a new file rather than extending `orchestration.test.ts` to stay under the repo's `max-lines` ratchet.

## AI Review Report

Reviewed the change for scope and regressions. Confirmed the remint path already exists and is exercised for dispatch; this PR reuses it. Verified the deliberate carve-out for lifecycle senders (`send`/`reply`/`ask` `--from`) is untouched. Existing `check` tests still pass — a live env handle short-circuits the added `terminal.show` probe and behaves as before. Cross-platform: no OS-specific code paths, shell behavior, paths, or Electron surfaces are touched; the change is pure CLI identity-resolution logic shared across macOS/Linux/Windows.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surfaces. The change routes an existing env-var-derived identity through an already-present liveness probe + pane-key remint RPC, and adds an error-path fall-through to an existing selector. No untrusted input is newly parsed or executed.

## Notes

Minimal diff: the handler condition, the `check` call site, and tests only. No refactors or drive-by cleanups.

## ELI5

After restarting Orca, orchestration check kept using an old terminal handle from the environment, so coordinators listened on a dead mailbox and saw zero messages. Now the CLI remints a fresh handle when the old one is stale, like dispatch already does.
