### PR TITLE
fix(mobile-terminal): stop reassigning an identical xterm theme

### DIFF
--- a/mobile/src/terminal/TerminalWebView.tsx
+++ b/mobile/src/terminal/TerminalWebView.tsx
@@ -109,7 +109,10 @@ export const TerminalWebView = forwardRef<TerminalWebViewHandle, Props>(function
         onWebReady?.()
       }
       // Why: reload clears queued commands, so readiness must always restore the
-      // native-selected theme even when its value did not change in React.
+      // native-selected theme even when its value did not change in React. This is
+      // state restore only — the theme write is value-gated, so the iOS foreground
+      // repaint is owned by the visibilitychange handler in
+      // terminal-webview-webgl-recovery-injected.ts, not by this re-post.
       sendToWebView({ type: 'set-theme', terminalTheme })
       flushPendingMessages()
     },

--- a/mobile/src/terminal/terminal-webview-engine.test.ts
+++ b/mobile/src/terminal/terminal-webview-engine.test.ts
@@ -230,7 +230,7 @@ describe('terminal WebView bundled engine', () => {
     harness.document.visibilityState = 'visible'
     harness.fireVisibilityChange()
 
-    expect(harness.applyTerminalTheme).toHaveBeenCalledWith(harness.terminalThemeInput)
+    expect(harness.applyTerminalTheme).toHaveBeenCalledWith(harness.terminalThemeInput, true)
     expect(harness.addons[0]?.clearTextureAtlas).toHaveBeenCalledTimes(1)
     expect(harness.term.refresh).toHaveBeenCalledTimes(1)
   })

--- a/mobile/src/terminal/terminal-webview-theme-injected.test.ts
+++ b/mobile/src/terminal/terminal-webview-theme-injected.test.ts
@@ -159,4 +159,52 @@ describe('mobile terminal-webview contrast floor gate', () => {
 
     expect(writes.contrast).toBe(1)
   })
+
+  it('skips the write when the very first palette already equals the seeded default', () => {
+    // terminal-webview-html.ts:292 seeds terminalTheme with defaultTheme, not null, so the
+    // gate must already hold on the first apply — the null seed elsewhere short-circuits it.
+    const writes = { theme: 0 }
+    const term = {
+      options: {
+        set theme(next: unknown) {
+          writes.theme += 1
+          void next
+        },
+        set minimumContrastRatio(next: number) {
+          void next
+        }
+      }
+    }
+    const context = loadThemeInjected({
+      term,
+      document: {
+        documentElement: { style: { background: '' } },
+        body: { style: { background: '' } }
+      },
+      terminalTheme: { background: '#1a1b26', foreground: '#c0caf5' }
+    }) as ThemeInjectedContext
+
+    context.applyTerminalTheme({ theme: { background: '#1a1b26', foreground: '#c0caf5' } })
+
+    expect(writes.theme).toBe(0)
+  })
+
+  it('keeps the module palette current when no terminal exists yet', () => {
+    // Why this matters: terminal-webview-html.ts:713 applies a theme and only then runs
+    // new Terminal({ theme: terminalTheme }), so moving the assignment inside `if (term)`
+    // would construct the terminal from a stale default.
+    const context = loadThemeInjected({
+      // terminal-webview-html.ts declares `term` before the terminal is constructed.
+      term: null,
+      document: {
+        documentElement: { style: { background: '' } },
+        body: { style: { background: '' } }
+      }
+    }) as ThemeInjectedContext
+
+    context.applyTerminalTheme({ theme: { background: '#282828' } })
+
+    expect(context.terminalTheme).toMatchObject({ background: '#282828' })
+    expect(context.terminalMinimumContrastRatio).toBe(DARK_FLOOR)
+  })
 })

--- a/mobile/src/terminal/terminal-webview-theme-injected.test.ts
+++ b/mobile/src/terminal/terminal-webview-theme-injected.test.ts
@@ -11,10 +11,53 @@ const LIGHT_FLOOR = 4.5
 function loadThemeInjected(extra: Record<string, unknown> = {}): Record<string, unknown> {
   const context: Record<string, unknown> = {
     defaultTheme: { background: '#1a1b26', foreground: '#c0caf5' },
+    // terminal-webview-html.ts:292 declares this at script load; applyTerminalTheme reads it.
+    terminalTheme: null,
     ...extra
   }
   new Script(TERMINAL_WEBVIEW_THEME_JS).runInNewContext(context)
   return context
+}
+
+type ThemeInjectedContext = Record<string, unknown> & {
+  applyTerminalTheme: (input: unknown, force?: boolean) => void
+}
+
+// Counting accessors: xterm rebuilds its palette on every options.theme write, so the
+// value gate is only observable as a write count, never as a final value.
+function loadThemeInjectedWithCountingTerm(): {
+  context: ThemeInjectedContext
+  writes: { theme: number; contrast: number }
+} {
+  const writes = { theme: 0, contrast: 0 }
+  let theme: unknown
+  let minimumContrastRatio = 1
+  const term = {
+    options: {
+      get theme() {
+        return theme
+      },
+      set theme(next: unknown) {
+        writes.theme += 1
+        theme = next
+      },
+      get minimumContrastRatio() {
+        return minimumContrastRatio
+      },
+      set minimumContrastRatio(next: number) {
+        writes.contrast += 1
+        minimumContrastRatio = next
+      }
+    }
+  }
+  const context = loadThemeInjected({
+    term,
+    document: {
+      documentElement: { style: { background: '' } },
+      body: { style: { background: '' } }
+    }
+  }) as ThemeInjectedContext
+  return { context, writes }
 }
 
 describe('mobile terminal-webview contrast floor gate', () => {
@@ -75,5 +118,45 @@ describe('mobile terminal-webview contrast floor gate', () => {
 
     context.applyTerminalTheme({ theme: { background: '#1e242a' } })
     expect(term.options.minimumContrastRatio).toBe(DARK_FLOOR)
+  })
+
+  it('does not rewrite an identical palette, but keeps the module theme vars current', () => {
+    const { context, writes } = loadThemeInjectedWithCountingTerm()
+    const second = { theme: { background: '#1a1b26', foreground: '#c0caf5' } }
+
+    context.applyTerminalTheme({ theme: { background: '#1a1b26', foreground: '#c0caf5' } })
+    context.applyTerminalTheme(second)
+
+    expect(writes.theme).toBe(1)
+    // terminal-webview-html.ts:713-718 builds the Terminal from these right after an apply.
+    expect(context.terminalThemeInput).toBe(second)
+    expect(context.terminalTheme).toMatchObject({ background: '#1a1b26' })
+  })
+
+  it('rewrites the palette when a color actually changes', () => {
+    const { context, writes } = loadThemeInjectedWithCountingTerm()
+
+    context.applyTerminalTheme({ theme: { background: '#1a1b26' } })
+    context.applyTerminalTheme({ theme: { background: '#282828' } })
+
+    expect(writes.theme).toBe(2)
+  })
+
+  it('rewrites an identical palette when forced by the iOS visibility repaint', () => {
+    const { context, writes } = loadThemeInjectedWithCountingTerm()
+
+    context.applyTerminalTheme({ theme: { background: '#1a1b26' } })
+    context.applyTerminalTheme({ theme: { background: '#1a1b26' } }, true)
+
+    expect(writes.theme).toBe(2)
+  })
+
+  it('does not rewrite the contrast floor when it is unchanged', () => {
+    const { context, writes } = loadThemeInjectedWithCountingTerm()
+
+    context.applyTerminalTheme({ theme: { background: '#1a1b26' } })
+    context.applyTerminalTheme({ theme: { background: '#282828' } })
+
+    expect(writes.contrast).toBe(1)
   })
 })

--- a/mobile/src/terminal/terminal-webview-theme-injected.ts
+++ b/mobile/src/terminal/terminal-webview-theme-injected.ts
@@ -94,16 +94,36 @@ export const TERMINAL_WEBVIEW_THEME_JS = `
     return Object.assign({}, defaultTheme, next);
   }
 
-  function applyTerminalTheme(input) {
+  // normalizeTerminalTheme always returns exactly defaultTheme's key set, so those keys
+  // are the complete value comparison.
+  function terminalThemesEqual(a, b) {
+    if (!a || !b) return false;
+    var keys = Object.keys(defaultTheme);
+    for (var i = 0; i < keys.length; i++) {
+      if (a[keys[i]] !== b[keys[i]]) return false;
+    }
+    return true;
+  }
+
+  function applyTerminalTheme(input, force) {
     terminalThemeInput = input;
-    terminalTheme = normalizeTerminalTheme(input);
+    var nextTheme = normalizeTerminalTheme(input);
+    var themeChanged = !terminalThemesEqual(terminalTheme, nextTheme);
+    terminalTheme = nextTheme;
     var background = terminalTheme.background || '${colors.terminalBg}';
     document.documentElement.style.background = background;
     document.body.style.background = background;
     terminalMinimumContrastRatio = resolveTerminalContrastFloor(background);
     if (term) {
-      term.options.theme = terminalTheme;
-      term.options.minimumContrastRatio = terminalMinimumContrastRatio;
+      // Why gated: writing options.theme rebuilds xterm's palette and discards a TUI's live
+      // OSC 4/10/11 mutations (mirrors terminal-appearance.ts:207-210). force = iOS repaint.
+      if (force || themeChanged) {
+        term.options.theme = terminalTheme;
+      }
+      // Why gated: writing minimumContrastRatio clears xterm's contrast cache (terminal-appearance.ts:218-220).
+      if (term.options.minimumContrastRatio !== terminalMinimumContrastRatio) {
+        term.options.minimumContrastRatio = terminalMinimumContrastRatio;
+      }
     }
   }
 `

--- a/mobile/src/terminal/terminal-webview-webgl-recovery-injected.ts
+++ b/mobile/src/terminal/terminal-webview-webgl-recovery-injected.ts
@@ -55,7 +55,8 @@ export const TERMINAL_WEBGL_RECOVERY_JS = `
     if (document.visibilityState !== 'visible') return;
     // Why: iOS may restore the xterm model while discarding GPU pixels/theme
     // paint state, so visibility must rebuild the atlas and repaint every row.
-    applyTerminalTheme(terminalThemeInput);
+    // force bypasses the no-op theme gate, which would otherwise skip this repaint.
+    applyTerminalTheme(terminalThemeInput, true);
     try { if (webglAddon && webglAddon.clearTextureAtlas) webglAddon.clearTextureAtlas(); } catch (e) {}
     refreshTerminalSurface();
   });


### PR DESCRIPTION
## Summary

A TUI that sets its own colours through OSC 4/10/11 loses them whenever mobile re-sends the terminal theme: the WebView assigns `term.options.theme` unconditionally, and that assignment rebuilds xterm's palette from the configured values. Desktop already refuses that no-op write in `terminal-appearance.ts`; mobile now matches, and the contrast-floor write is gated the same way.

The mobile theme value is fixed today, so the redundant write mostly arrives on WebView readiness and reload rather than on user action — the palette loss is real when it does.

## Tests

Written failing first, then fixed:

- `does not rewrite an identical palette` — was 2 theme writes, now 1
- `does not rewrite the contrast floor when it is unchanged`
- `rewrites an identical palette when forced by the iOS visibility repaint`
- `skips the write when the very first palette already equals the seeded default` — production seeds `terminalTheme` with `defaultTheme`, not `null`, so the gate must already hold on the first apply
- `keeps the module palette current when no terminal exists yet` — `terminal-webview-html.ts` applies a theme and only *then* runs `new Terminal({ theme: terminalTheme })`, so the module assignment must stay outside the `if (term)` gate. Mutation-checked: moving it inside fails 6 tests.

`mobile/src/terminal/` 38 files / 410 tests pass; mobile typecheck, oxlint, oxfmt and the max-lines ratchet are clean. The injected JS still parses at the ES2019 acorn gate.

### Note for reviewers

`force` looks removable. It is not: it is threaded from exactly one call site, the `visibilitychange` handler in `terminal-webview-webgl-recovery-injected.ts`, which deliberately repaints the palette after an iOS foreground transition. Removing it silently disables that repaint, and only a real background/foreground cycle on a device proves it is still needed — no unit test can. The unit test pins the parameter; this paragraph is here so it isn't "simplified" away.

## ELI5

Mobile was re-applying the same xterm theme on every message, which rebuilds the palette and can wipe live TUI colour tweaks. Desktop already skipped no-op theme writes; mobile now does the same.
