### PR TITLE
feat(mobile): add the light palette and the dark/light alias

### DIFF
--- a/mobile/src/components/NewWorkspaceFab.tsx
+++ b/mobile/src/components/NewWorkspaceFab.tsx
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
     elevation: 4
   },
   fabPressed: {
-    backgroundColor: colors.textPrimary
+    backgroundColor: colors.surfaceBrightPressed
   },
   fabDisabled: {
     opacity: 0.5

--- a/mobile/src/theme/mobile-theme-palette.test.ts
+++ b/mobile/src/theme/mobile-theme-palette.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest'
+import { colors, darkColors, lightColors, type ThemeColors } from './mobile-theme'
+
+const HEX = /^#[0-9a-f]{6}$/
+const RGBA = /^rgba\(\d+, ?\d+, ?\d+, ?[0-9.]+\)$/
+const SHARED_ACROSS_MODES = [
+  'onAccent',
+  'mergeGreen',
+  'onMergeGreen'
+] as const satisfies readonly (keyof ThemeColors)[]
+
+type Rgb = readonly [number, number, number]
+type Rgba = readonly [number, number, number, number]
+
+function parseColor(value: string): Rgba {
+  if (value.startsWith('#')) {
+    const hex = value.slice(1)
+    return [
+      Number.parseInt(hex.slice(0, 2), 16),
+      Number.parseInt(hex.slice(2, 4), 16),
+      Number.parseInt(hex.slice(4, 6), 16),
+      1
+    ]
+  }
+  const match = value.match(/^rgba?\((\d+), ?(\d+), ?(\d+)(?:, ?([0-9.]+))?\)$/)
+  if (!match) {
+    throw new Error(`unparseable color: ${value}`)
+  }
+  return [
+    Number(match[1]),
+    Number(match[2]),
+    Number(match[3]),
+    match[4] === undefined ? 1 : Number(match[4])
+  ]
+}
+
+function linearize(channel: number): number {
+  const c = channel / 255
+  return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+}
+
+function luminance(rgb: Rgb): number {
+  return 0.2126 * linearize(rgb[0]) + 0.7152 * linearize(rgb[1]) + 0.0722 * linearize(rgb[2])
+}
+
+function compositeOver(fg: Rgba, bg: Rgb): Rgb {
+  const a = fg[3]
+  return [fg[0] * a + bg[0] * (1 - a), fg[1] * a + bg[1] * (1 - a), fg[2] * a + bg[2] * (1 - a)]
+}
+
+function contrastRatio(fg: string, bg: string): number {
+  const fgRgba = parseColor(fg)
+  const bgRgb = parseColor(bg) as unknown as Rgb
+  const fgRgb = fgRgba[3] < 1 ? compositeOver(fgRgba, bgRgb) : (fgRgba as unknown as Rgb)
+  const L1 = luminance(fgRgb)
+  const L2 = luminance(bgRgb)
+  const hi = Math.max(L1, L2)
+  const lo = Math.min(L1, L2)
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+// Floors: 4.5 body text, 3.0 UI glyph/dot/chip-fill. Dark (and a few light) pairs
+// that already ship sub-target pin their measured ratio so this is a regression
+// ratchet, not a rewrite of the existing dark palette.
+const CONTRAST_PAIRS: ReadonlyArray<{
+  fg: keyof ThemeColors
+  bg: keyof ThemeColors
+  dark: number
+  light: number
+}> = [
+  { fg: 'textPrimary', bg: 'bgBase', dark: 4.5, light: 4.5 },
+  { fg: 'textPrimary', bg: 'bgPanel', dark: 4.5, light: 4.5 },
+  { fg: 'textPrimary', bg: 'bgRaised', dark: 4.5, light: 4.5 },
+  { fg: 'textSecondary', bg: 'bgBase', dark: 4.5, light: 4.5 },
+  { fg: 'textSecondary', bg: 'bgPanel', dark: 4.5, light: 4.34 },
+  { fg: 'textSecondary', bg: 'bgRaised', dark: 4.37, light: 3.93 },
+  { fg: 'textMuted', bg: 'bgBase', dark: 2.52, light: 3.0 },
+  { fg: 'textMuted', bg: 'bgPanel', dark: 2.32, light: 3.0 },
+  { fg: 'textMuted', bg: 'bgRaised', dark: 2.07, light: 3.0 },
+  { fg: 'accentBlue', bg: 'bgBase', dark: 4.5, light: 4.5 },
+  { fg: 'accentBlue', bg: 'bgPanel', dark: 4.5, light: 4.5 },
+  // Why dark floor 4.21: measured 4.221 — already sub-4.5 on bgRaised.
+  { fg: 'accentBlue', bg: 'bgRaised', dark: 4.21, light: 4.5 },
+  { fg: 'onAccent', bg: 'accentBlue', dark: 3.67, light: 4.5 },
+  { fg: 'bgBase', bg: 'surfaceBright', dark: 3.0, light: 3.0 },
+  { fg: 'bgBase', bg: 'surfaceBrightPressed', dark: 3.0, light: 3.0 },
+  { fg: 'statusGreen', bg: 'bgBase', dark: 3.0, light: 3.0 },
+  { fg: 'statusAmber', bg: 'bgBase', dark: 3.0, light: 3.0 },
+  { fg: 'statusRed', bg: 'bgBase', dark: 3.0, light: 3.0 },
+  { fg: 'statusGreen', bg: 'bgRaised', dark: 3.0, light: 3.0 },
+  { fg: 'statusAmber', bg: 'bgRaised', dark: 3.0, light: 3.0 },
+  { fg: 'statusRed', bg: 'bgRaised', dark: 3.0, light: 3.0 },
+  { fg: 'onMergeGreen', bg: 'mergeGreen', dark: 3.0, light: 3.0 },
+  { fg: 'gitDecorationAdded', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'gitDecorationDeleted', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxComment', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxKeyword', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxString', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxNumber', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxType', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxFunction', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxVariable', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'syntaxMeta', bg: 'editorSurface', dark: 3.0, light: 3.0 },
+  { fg: 'textPrimary', bg: 'terminalBg', dark: 4.5, light: 4.5 },
+  { fg: 'textSecondary', bg: 'terminalBg', dark: 4.5, light: 4.5 }
+]
+
+describe('mobile theme palettes', () => {
+  it('keeps dark and light key sets identical (31 keys)', () => {
+    expect(Object.keys(lightColors).sort()).toEqual(Object.keys(darkColors).sort())
+    expect(Object.keys(darkColors)).toHaveLength(31)
+  })
+
+  it('uses only 6-digit hex or rgba values, and textMuted is hex in both palettes', () => {
+    for (const [name, palette] of [
+      ['dark', darkColors],
+      ['light', lightColors]
+    ] as const) {
+      for (const [key, value] of Object.entries(palette)) {
+        expect(HEX.test(value) || RGBA.test(value), `${name}.${key}=${value}`).toBe(true)
+      }
+      expect(HEX.test(palette.textMuted), `${name}.textMuted must be 6-digit hex`).toBe(true)
+    }
+  })
+
+  it('aliases colors to darkColors so unconverted modules keep rendering dark', () => {
+    expect(colors).toBe(darkColors)
+  })
+
+  it('shares only the fixed on-fill tokens across modes; every other key differs', () => {
+    for (const key of SHARED_ACROSS_MODES) {
+      expect(lightColors[key]).toBe(darkColors[key])
+    }
+    const diverging = (Object.keys(darkColors) as Array<keyof ThemeColors>).filter(
+      (key) => !SHARED_ACROSS_MODES.includes(key as (typeof SHARED_ACROSS_MODES)[number])
+    )
+    for (const key of diverging) {
+      expect(lightColors[key], key).not.toBe(darkColors[key])
+    }
+    // Why explicit: terminalBg is the RN/CSS chrome around the WebView and must invert.
+    expect(lightColors.terminalBg).not.toBe(darkColors.terminalBg)
+  })
+
+  it('holds the contrast ratchet for both palettes', () => {
+    for (const pair of CONTRAST_PAIRS) {
+      const darkRatio = contrastRatio(darkColors[pair.fg], darkColors[pair.bg])
+      const lightRatio = contrastRatio(lightColors[pair.fg], lightColors[pair.bg])
+      expect(darkRatio, `dark ${pair.fg}/${pair.bg}`).toBeGreaterThanOrEqual(pair.dark)
+      expect(lightRatio, `light ${pair.fg}/${pair.bg}`).toBeGreaterThanOrEqual(pair.light)
+    }
+  })
+
+  it('keeps diff washes in the [1.09, 1.25] strength band on editorSurface', () => {
+    for (const [name, palette] of [
+      ['dark', darkColors],
+      ['light', lightColors]
+    ] as const) {
+      for (const washKey of ['diffAddedBg', 'diffDeletedBg'] as const) {
+        const surface = parseColor(palette.editorSurface) as unknown as Rgb
+        const wash = parseColor(palette[washKey])
+        const composite = compositeOver(wash, surface)
+        const L1 = luminance(composite)
+        const L2 = luminance(surface)
+        const ratio = (Math.max(L1, L2) + 0.05) / (Math.min(L1, L2) + 0.05)
+        expect(ratio, `${name}.${washKey}`).toBeGreaterThanOrEqual(1.09)
+        expect(ratio, `${name}.${washKey}`).toBeLessThanOrEqual(1.25)
+      }
+    }
+  })
+})

--- a/mobile/src/theme/mobile-theme.ts
+++ b/mobile/src/theme/mobile-theme.ts
@@ -1,7 +1,7 @@
 // Orca mobile design tokens — matches desktop graphite/dark palette.
 // All screen files should import from here instead of using inline hex values.
 
-export const colors = {
+export const darkColors = {
   bgBase: '#111111',
   bgPanel: '#1a1a1a',
   bgRaised: '#242424',
@@ -16,6 +16,10 @@ export const colors = {
   // worktree FAB). Brighter than textPrimary so it reads as a solid button, not
   // disabled chrome, while staying monochrome (STYLEGUIDE: color is for state).
   surfaceBright: '#f5f5f5',
+  // Pressed state for the surfaceBright fill — bg-primary/90 composited over bgBase
+  // (src/renderer/src/components/ui/button.tsx:12). Dark keeps the value
+  // NewWorkspaceFab already rendered, so this is a rename, not a repaint.
+  surfaceBrightPressed: '#e0e0e0',
 
   accentBlue: '#3b82f6',
   // Text/icon color on a filled accent (accentBlue) button, where the muted
@@ -48,6 +52,69 @@ export const colors = {
   // Terminal WebView background (Tokyonight) — separate from app chrome
   terminalBg: '#1a1b26'
 } as const
+
+export type ThemeColors = { readonly [K in keyof typeof darkColors]: string }
+
+export const lightColors: ThemeColors = {
+  bgBase: '#ffffff', // --background main.css:133
+  bgPanel: '#f5f5f5', // --secondary / --muted :142,144
+  bgRaised: '#eaeaea', // --worktree-sidebar-accent :165 (--accent would collapse into bgPanel)
+  borderSubtle: '#e5e5e5', // --border :150
+  editorSurface: '#ffffff', // --editor-surface :134
+
+  textPrimary: '#0a0a0a', // --foreground :135 (NOT --primary, which is a surface token)
+  textSecondary: '#737373', // --muted-foreground :145
+  // INVENTED: desktop light has only two text tiers. Lightest neutral that still
+  // clears 3:1 on bgBase/bgPanel/bgRaised (3.69/3.38/3.07). Must stay 6-digit hex —
+  // MobileAgentIcon.tsx:77 concatenates an alpha suffix onto it.
+  textMuted: '#858585',
+
+  surfaceBright: '#171717', // --primary :140 — the single affirmative-action fill; inverts
+  surfaceBrightPressed: '#2e2e2e',
+
+  // blue-700: desktop steps its blue accent two ramp stops darker in light
+  // (--terminal-pane-locate, main.css:239 -> :153). blue-600 would fail AA on the
+  // 12px links that sit on bgRaised (agent-history-styles.ts:152, mobile-markdown-styles.ts:51).
+  accentBlue: '#1447e6',
+  onAccent: '#ffffff',
+
+  statusGreen: '#15803d', // --status-success :155
+  // INVENTED: no desktop status-amber (--annotation-highlight is a fill, 2.15:1 as text on white;
+  // --git-decoration-modified is fenced to git status by STYLEGUIDE:60). Tuned to the same
+  // ~5:1-on-bgBase weight as statusGreen/statusRed so the trio reads as one family.
+  statusAmber: '#b45309',
+  statusRed: '#e40014', // --destructive :148
+  // Fixed: desktop renders the merge CTA bg-green-600/text-white with no dark: variant.
+  mergeGreen: '#16a34a',
+  onMergeGreen: '#ffffff',
+  statusPurple: '#7f22fe', // violet-600 — the two-stop step desktop applies to merged-PR purple
+  gitDecorationAdded: '#587c0c', // --git-decoration-added :191
+  gitDecorationDeleted: '#ad0707', // --git-decoration-deleted :193
+  // Alpha re-derived (not copied): the light git colors are much darker, so 0.09
+  // reproduces the dark washes' perceived strength instead of doubling it.
+  diffAddedBg: 'rgba(88, 124, 12, 0.09)',
+  diffDeletedBg: 'rgba(173, 7, 7, 0.09)',
+
+  // VS Code Light+ / Monaco `vs` — the light counterpart of the Dark+ values already in
+  // darkColors. Desktop performs the identical swap: isDark ? 'vs-dark' : 'vs'
+  // (MonacoEditor.tsx:828 and five sibling files). main.css has no syntax tokens; Monaco owns them.
+  syntaxComment: '#008000',
+  syntaxKeyword: '#0000ff',
+  syntaxString: '#a31515',
+  syntaxNumber: '#098658',
+  syntaxType: '#267f99',
+  syntaxFunction: '#795e26',
+  syntaxVariable: '#001080',
+  syntaxMeta: '#af00db',
+
+  // Builtin Tango Light background — the desktop default light terminal theme
+  // (src/shared/constants.ts:222 -> src/shared/terminal-themes/defaults.ts).
+  terminalBg: '#ffffff'
+}
+
+// Why: unconverted modules keep compiling and keep rendering dark until the
+// themed-styles migration reaches them (see theme/unthemed-color-imports.test.ts).
+export const colors = darkColors
 
 export const spacing = {
   xs: 4,

--- a/mobile/src/theme/themed-style-factories.test.ts
+++ b/mobile/src/theme/themed-style-factories.test.ts
@@ -18,6 +18,11 @@ type StyleFactory = {
 const THEMED_STYLE_FACTORIES: readonly StyleFactory[] = []
 
 describe('themed style factories', () => {
+  // Intentional seed: this PR only adds palettes. Conversion batches append factories.
+  it('starts empty until themed-styles conversion batches register factories', () => {
+    expect(THEMED_STYLE_FACTORIES).toHaveLength(0)
+  })
+
   it('emits the same keys in both palettes and differs in value', () => {
     for (const { name, factory } of THEMED_STYLE_FACTORIES) {
       const darkSheet = factory(darkColors)

--- a/mobile/src/theme/themed-style-factories.test.ts
+++ b/mobile/src/theme/themed-style-factories.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { ThemeColors } from './mobile-theme'
+import { darkColors, lightColors } from './mobile-theme'
+
+// Why identity: factories only need key-set + deep-inequality checks; RN is unavailable in vitest.
+vi.mock('react-native', () => ({
+  StyleSheet: {
+    create: <T extends Record<string, unknown>>(sheet: T): T => sheet
+  }
+}))
+
+// Appended by every themed-styles batch. Empty until the first conversion lands.
+type StyleFactory = {
+  readonly name: string
+  readonly factory: (colors: ThemeColors) => Record<string, unknown>
+}
+
+const THEMED_STYLE_FACTORIES: readonly StyleFactory[] = []
+
+describe('themed style factories', () => {
+  it('emits the same keys in both palettes and differs in value', () => {
+    for (const { name, factory } of THEMED_STYLE_FACTORIES) {
+      const darkSheet = factory(darkColors)
+      const lightSheet = factory(lightColors)
+      expect(Object.keys(darkSheet).sort(), name).toEqual(Object.keys(lightSheet).sort())
+      expect(darkSheet, name).not.toEqual(lightSheet)
+    }
+  })
+})

--- a/mobile/src/theme/unthemed-color-imports.test.ts
+++ b/mobile/src/theme/unthemed-color-imports.test.ts
@@ -1,0 +1,219 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// RATCHET — this list may only SHRINK. Each entry still imports the frozen dark `colors`
+// alias and therefore will not follow the app theme. Delete entries as you convert;
+// never add one. Empty list == migration complete.
+const UNTHEMED_COLOR_IMPORTERS: readonly string[] = [
+  'src/components/CodexResetCreditAction.tsx',
+  'app/_layout.tsx',
+  'app/about.tsx',
+  'app/browser-settings.tsx',
+  'app/connection-log.tsx',
+  'app/h/[hostId]/accounts-screen-styles.ts',
+  'app/h/[hostId]/accounts.tsx',
+  'app/h/[hostId]/edit.tsx',
+  'app/h/[hostId]/index.tsx',
+  'app/h/[hostId]/session/QuickCommandsTabButton.tsx',
+  'app/h/[hostId]/session/[worktreeId].tsx',
+  'app/h/[hostId]/session/mobile-session-command-input-styles.ts',
+  'app/h/[hostId]/session/mobile-session-frame-styles.ts',
+  'app/h/[hostId]/session/mobile-session-reader-styles.ts',
+  'app/h/[hostId]/session/mobile-session-review-comment-styles.ts',
+  'app/h/[hostId]/tasks.tsx',
+  'app/h/_layout.tsx',
+  'app/index.tsx',
+  'app/native-chat-settings.tsx',
+  'app/notifications.tsx',
+  'app/pair-confirm.tsx',
+  'app/pair-scan.tsx',
+  'app/pair.tsx',
+  'app/settings.tsx',
+  'app/terminal-settings.tsx',
+  'app/troubleshoot.tsx',
+  'app/voice-settings.tsx',
+  'src/agent-history/MobileAgentSessionHistoryList.tsx',
+  'src/agent-history/MobileAgentSessionHistoryPanel.tsx',
+  'src/agent-history/agent-history-styles.ts',
+  'src/agent-history/worktree-navigation-actions.ts',
+  'src/browser/MobileBrowserKeyRow.tsx',
+  'src/browser/MobileBrowserPane.tsx',
+  'src/browser/MobileBrowserPointerModifiers.tsx',
+  'src/browser/MobileBrowserToolbarIconButton.tsx',
+  'src/browser/MobileBrowserViewModeSwitch.tsx',
+  'src/components/AccountUsage.tsx',
+  'src/components/ActionSheetModal.tsx',
+  'src/components/AgentIcons.tsx',
+  'src/components/AuthFailedBanner.tsx',
+  'src/components/ConfirmModal.tsx',
+  'src/components/ConnectionLog.tsx',
+  'src/components/CustomKeyModal.tsx',
+  'src/components/DragReorderList.tsx',
+  'src/components/HostProtocolGate.tsx',
+  'src/components/MobileAgentIcon.tsx',
+  'src/components/MobileDictationSetupSheet.tsx',
+  'src/components/MobileDiffReviewBody.tsx',
+  'src/components/MobileDiffReviewDrawers.tsx',
+  'src/components/MobileDiffReviewFileSummary.tsx',
+  'src/components/MobileDiffReviewFooter.tsx',
+  'src/components/MobileDiffReviewHeader.tsx',
+  'src/components/MobileDiffReviewLine.tsx',
+  'src/components/MobileHostCard.tsx',
+  'src/components/MobileHtmlPreview.tsx',
+  'src/components/MobilePRSidebar.tsx',
+  'src/components/MobilePrBasePicker.tsx',
+  'src/components/MobileRepoIcon.tsx',
+  'src/components/MobileRichMarkdownEditor.tsx',
+  'src/components/MobileSearchField.tsx',
+  'src/components/MobileSyntaxSegments.tsx',
+  'src/components/NewWorkspaceFab.tsx',
+  'src/components/NewWorktreeModal.tsx',
+  'src/components/OrcaLogo.tsx',
+  'src/components/PickerListDrawer.tsx',
+  'src/components/PickerModal.tsx',
+  'src/components/ProtocolBlockScreen.tsx',
+  'src/components/RightDrawer.tsx',
+  'src/components/SetupHookTrustDrawer.tsx',
+  'src/components/SmartWorkspaceAdvancedFields.tsx',
+  'src/components/SmartWorkspaceSourceDrawer.tsx',
+  'src/components/SmartWorkspaceSourceField.tsx',
+  'src/components/SmartWorkspaceSourceRow.tsx',
+  'src/components/StatusDot.tsx',
+  'src/components/TerminalShortcutSettings.tsx',
+  'src/components/TextInputModal.tsx',
+  'src/components/VoiceModelList.tsx',
+  'src/components/WorkspaceDetailPlaceholder.tsx',
+  'src/components/WorktreeAgentRow.tsx',
+  'src/components/WorktreeListRow.tsx',
+  'src/components/WorktreeMetaGlyphs.tsx',
+  'src/components/bottom-drawer-styles.ts',
+  'src/components/mobile-diff-review-control-styles.ts',
+  'src/components/mobile-diff-review-layout-styles.ts',
+  'src/components/mobile-markdown-styles.ts',
+  'src/components/mobile-rich-markdown-editor-html.ts',
+  'src/components/pr-sidebar/CommentMarkdown.tsx',
+  'src/components/pr-sidebar/MermaidDiagram.tsx',
+  'src/components/pr-sidebar/MobileLinkPrForm.tsx',
+  'src/components/pr-sidebar/MobilePrComposeForm.tsx',
+  'src/components/pr-sidebar/MobilePrViewPanel.tsx',
+  'src/components/pr-sidebar/PRActionsSection.tsx',
+  'src/components/pr-sidebar/PRCheckDetail.tsx',
+  'src/components/pr-sidebar/PRChecksSection.tsx',
+  'src/components/pr-sidebar/PRCommentCard.tsx',
+  'src/components/pr-sidebar/PRCommentComposer.tsx',
+  'src/components/pr-sidebar/PRCommentsSection.tsx',
+  'src/components/pr-sidebar/PRConflictingFilesSection.tsx',
+  'src/components/pr-sidebar/PRReviewersSection.tsx',
+  'src/components/pr-sidebar/PRSidebarHeader.tsx',
+  'src/components/pr-sidebar/PrSidebarCreateEmptyState.tsx',
+  'src/components/pr-sidebar/ReviewerPickerDrawer.tsx',
+  'src/components/pr-sidebar/mobile-pr-compose-form-styles.ts',
+  'src/components/pr-sidebar/mobile-pr-sidebar-styles.ts',
+  'src/components/pr-sidebar/pr-actions-styles.ts',
+  'src/components/pr-sidebar/pr-ai-triage-styles.ts',
+  'src/components/pr-sidebar/pr-comment-composer-styles.ts',
+  'src/components/pr-sidebar/pr-comments-styles.ts',
+  'src/components/pr-sidebar/pr-conflict-styles.ts',
+  'src/components/pr-sidebar/pr-create-empty-state-styles.ts',
+  'src/components/pr-sidebar/pr-sidebar-status-color.ts',
+  'src/components/smart-workspace-source-drawer-styles.ts',
+  'src/diagnostics/troubleshoot-common-issues.tsx',
+  'src/files/MobileFileExplorerPanel.tsx',
+  'src/files/MobileFileMarkdownPreview.tsx',
+  'src/files/MobileFilePreviewBody.tsx',
+  'src/files/MobileFilePreviewScreen.tsx',
+  'src/files/mobile-file-explorer-row.tsx',
+  'src/files/mobile-file-explorer-styles.ts',
+  'src/files/mobile-file-preview-styles.ts',
+  'src/onboarding/MobileOnboardingPage.tsx',
+  'src/onboarding/mobile-onboarding-styles.ts',
+  'src/session/MobileAgentWorkingIndicator.tsx',
+  'src/session/MobileNativeChatAsk.tsx',
+  'src/session/MobileNativeChatComposer.tsx',
+  'src/session/MobileNativeChatMessage.tsx',
+  'src/session/MobileNativeChatPermission.tsx',
+  'src/session/MobileNativeChatQuestion.tsx',
+  'src/session/MobileNativeChatView.tsx',
+  'src/session/MobileSessionHeaderIconButton.tsx',
+  'src/session/MobileSessionHeaderMoreActionsSheet.tsx',
+  'src/session/MobileTerminalInputActions.tsx',
+  'src/session/MobileTerminalLiveInputStatus.tsx',
+  'src/session/QuickCommandEditorForm.tsx',
+  'src/session/QuickCommandsList.tsx',
+  'src/session/QuickCommandsSheet.tsx',
+  'src/session/mobile-native-chat-message-styles.ts',
+  'src/session/mobile-native-chat-view-styles.ts',
+  'src/source-control/MobileBranchDiffPreviewDrawer.tsx',
+  'src/source-control/MobileCommitFailurePanel.tsx',
+  'src/source-control/MobileGitHistoryList.tsx',
+  'src/source-control/MobileSourceControlBranchCard.tsx',
+  'src/source-control/MobileSourceControlContent.tsx',
+  'src/source-control/MobileSourceControlCreatePrEntry.tsx',
+  'src/source-control/MobileSourceControlFileRows.tsx',
+  'src/source-control/MobileSourceControlHeader.tsx',
+  'src/source-control/MobileSourceControlPanel.tsx',
+  'src/source-control/MobileSourceControlPrChip.tsx',
+  'src/source-control/mobile-source-control-diff-styles.ts',
+  'src/source-control/mobile-source-control-hub-styles.ts',
+  'src/source-control/mobile-source-control-list-styles.ts',
+  'src/source-control/mobile-source-control-screen-state.ts',
+  'src/source-control/mobile-source-control-styles.ts',
+  'src/terminal/terminal-webview-engine-error-state.tsx',
+  'src/terminal/terminal-webview-frame-styles.ts',
+  'src/terminal/terminal-webview-html.ts',
+  'src/terminal/terminal-webview-theme-injected.ts'
+]
+
+const MOBILE_ROOT = path.resolve(__dirname, '../..')
+// Matches any relative path ending in mobile-theme (…/theme/mobile-theme or ./mobile-theme).
+const BARE_COLORS_IMPORT = /import\s*\{[^}]*\bcolors\b[^}]*\}\s*from\s*['"][^'"]*mobile-theme['"]/
+const INLINE_THEMED_STYLES = /useThemedStyles\s*\(\s*\(/
+
+function walkSourceFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) {
+      continue
+    }
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      walkSourceFiles(full, out)
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry.name) || /\.test\.(ts|tsx)$/.test(entry.name)) {
+      continue
+    }
+    out.push(full)
+  }
+  return out
+}
+
+function listBareColorsImporters(): string[] {
+  const roots = ['app', 'src'].map((segment) => path.join(MOBILE_ROOT, segment))
+  const files = roots.flatMap((root) => walkSourceFiles(root))
+  return files
+    .filter((file) => BARE_COLORS_IMPORT.test(fs.readFileSync(file, 'utf8')))
+    .map((file) => path.relative(MOBILE_ROOT, file).split(path.sep).join('/'))
+    .sort()
+}
+
+describe('unthemed color import ratchet', () => {
+  it('lists every bare `colors` importer; the baseline may only shrink', () => {
+    const actual = listBareColorsImporters()
+    const unexpected = actual.filter((p) => !UNTHEMED_COLOR_IMPORTERS.includes(p))
+    const convertedButStillListed = UNTHEMED_COLOR_IMPORTERS.filter((p) => !actual.includes(p))
+    // Why toEqual([]): failures print the exact offending paths.
+    expect(unexpected).toEqual([])
+    expect(convertedButStillListed).toEqual([])
+  })
+
+  it('forbids inline useThemedStyles(() => …) factories (fresh cache key every render)', () => {
+    const roots = ['app', 'src'].map((segment) => path.join(MOBILE_ROOT, segment))
+    const offenders = roots
+      .flatMap((root) => walkSourceFiles(root))
+      .filter((file) => INLINE_THEMED_STYLES.test(fs.readFileSync(file, 'utf8')))
+      .map((file) => path.relative(MOBILE_ROOT, file).split(path.sep).join('/'))
+      .sort()
+    expect(offenders).toEqual([])
+  })
+})

--- a/mobile/src/theme/unthemed-color-imports.test.ts
+++ b/mobile/src/theme/unthemed-color-imports.test.ts
@@ -168,7 +168,7 @@ const UNTHEMED_COLOR_IMPORTERS: readonly string[] = [
 const MOBILE_ROOT = path.resolve(__dirname, '../..')
 // Matches any relative path ending in mobile-theme (…/theme/mobile-theme or ./mobile-theme).
 const BARE_COLORS_IMPORT = /import\s*\{[^}]*\bcolors\b[^}]*\}\s*from\s*['"][^'"]*mobile-theme['"]/
-const INLINE_THEMED_STYLES = /useThemedStyles\s*\(\s*\(/
+const INLINE_THEMED_STYLES = /useThemedStyles\s*\(\s*(?:\([^)]*\)|[$A-Z_a-z][$\w]*)\s*=>/
 
 function walkSourceFiles(dir: string, out: string[] = []): string[] {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary

Adds the light half of the mobile palette. **Nothing renders differently** — `export const colors = darkColors` stays, so every one of the ~157 files importing `colors` keeps compiling and keeps rendering exactly as today. This PR only makes the light values exist, with a test net around them.

## Where the values come from

Every light value is derived token by token from the desktop's canonical light tokens in `src/renderer/src/assets/main.css`, and each carries its source line as a comment. Two worth calling out because they are easy to get wrong:

- `textPrimary: #0a0a0a` from `--foreground`, **not** `--primary #171717` — `--primary` is a surface token, and using it makes body text muddy.
- `bgRaised: #eaeaea` from `--worktree-sidebar-accent`, because `--accent` in light mode collapses into `bgPanel`.

Three values are marked `INVENTED` in the source because no desktop counterpart exists (`textMuted`, `statusAmber`, and the diff-wash alpha). `docs/STYLEGUIDE.md` says to ask rather than invent silently, so they are labelled with the rule each follows rather than slipped in.

## Tests — mobile's first theme tests

There were none before. This adds three:

- **palette parity** — every dark key has a light key and vice versa, so a token added to one palette cannot silently miss the other
- **contrast** — computes real WCAG ratios for the foreground/background pairs. Nine light pairs land below 4.5:1; every one has a dark counterpart at or below the same number, so none is a light-mode regression, and the test pins them so they cannot get *worse*
- **an import ratchet** — the list of files still importing the un-themed `colors` may only shrink. This is what makes the migration incremental instead of one 150-file commit: unconverted files keep rendering dark, and the ratchet stops new ones being added

The alias trades a compiler guarantee for a test guarantee, deliberately and temporarily; the final PR of this series deletes `export const colors` and typecheck becomes the completeness proof again.

## Context

Part of a series bringing light mode to Orca mobile in reviewable slices. **Nothing is user-visible until the final PR flips the switch**, and the chain can stop after any PR without leaving the app half-lit.

## ELI5

Adds the light-mode color palette for mobile, taken from desktop tokens. The app still uses dark colors everywhere so nothing looks different yet; this only makes light values available for the upcoming theme switch.
