### PR TITLE
Stack head identity above base ref in compare row

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -5450,7 +5450,6 @@ function SourceControlInner(): React.JSX.Element {
     <>
       <div ref={setSourceControlRoot} className="relative flex h-full flex-col overflow-hidden">
         <SourceControlHeaderToolbar
-          gitIdentityDisplay={gitIdentityDisplay}
           filterQuery={filterQuery}
           filterExpanded={filterExpanded}
           onFilterQueryChange={setFilterQuery}
@@ -5471,6 +5470,7 @@ function SourceControlInner(): React.JSX.Element {
           onExpandNotes={() => setDiffCommentsExpanded(true)}
           branchSummary={branchSummary}
           compareBaseRef={compareBaseRef}
+          headDisplay={gitIdentityDisplay}
           upstreamStatus={remoteStatus}
           manualReviewUrl={manualReviewUrl}
         />

--- a/src/renderer/src/components/right-sidebar/source-control-branch-context-row.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-branch-context-row.test.tsx
@@ -32,10 +32,173 @@ describe('SourceControlBranchContextRow', () => {
       />
     )
 
+    // Display drops refs/remotes/; full ref stays in the title attribute.
+    expect(markup).toContain('origin/FRONT-192-ZisVoucherStrip')
     expect(markup).toContain('refs/remotes/origin/FRONT-192-ZisVoucherStrip')
     expect(markup).toContain('max-w-full')
     expect(markup).toContain('min-w-0 flex-1')
-    expect(markup).not.toContain('max-w-[9rem]')
+  })
+
+  it('stacks head above → base so both keep full row width', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={readySummary}
+        compareBaseRef={null}
+        headDisplay={{ kind: 'branch', branchName: 'fix-fork-pr-fetch-head-race' }}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    const headIndex = markup.indexOf('fix-fork-pr-fetch-head-race')
+    const arrowIndex = markup.indexOf('→')
+    const baseIndex = markup.indexOf('origin/FRONT-192-ZisVoucherStrip')
+    expect(headIndex).toBeGreaterThan(-1)
+    expect(arrowIndex).toBeGreaterThan(headIndex)
+    expect(baseIndex).toBeGreaterThan(arrowIndex)
+    // Stacked column, not a single-line head→base pair.
+    expect(markup).toContain('flex-col')
+    expect(markup).not.toContain('>vs<')
+    expect(markup).toContain(
+      'aria-label="fix-fork-pr-fetch-head-race → origin/FRONT-192-ZisVoucherStrip"'
+    )
+  })
+
+  it('falls back to "vs base" when head identity is missing', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={readySummary}
+        compareBaseRef={null}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('>vs<')
+    expect(markup).toContain('origin/FRONT-192-ZisVoucherStrip')
+    expect(markup).not.toContain('→')
+  })
+
+  it('shows head-only identity when there is no compare base', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={null}
+        compareBaseRef={null}
+        headDisplay={{ kind: 'branch', branchName: 'local-only-branch' }}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('data-testid="source-control-head-identity"')
+    expect(markup).toContain('local-only-branch')
+    expect(markup).toContain('aria-label="Current branch: local-only-branch"')
+    expect(markup).toContain('tabindex="0"')
+    expect(markup).not.toContain('→')
+    expect(markup).not.toContain('>vs<')
+  })
+
+  it('marks the loading path busy and announces comparing', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={{ ...readySummary, status: 'loading' }}
+        compareBaseRef={null}
+        headDisplay={{ kind: 'branch', branchName: 'loading-branch' }}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('aria-busy="true"')
+    expect(markup).toContain('Comparing against')
+    expect(markup).toContain('aria-label="loading-branch → origin/FRONT-192-ZisVoucherStrip"')
+  })
+
+  it('shows detached head-only identity when there is no compare base', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={null}
+        compareBaseRef={null}
+        headDisplay={{
+          kind: 'detached',
+          shortHead: '8cec248',
+          sidebarLabel: 'Detached HEAD @ 8cec248',
+          sourceControlLabel: 'Detached HEAD · 8cec248',
+          tooltip: 'Detached HEAD at 8cec248. You are viewing a commit, not a branch.'
+        }}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('Detached HEAD · 8cec248')
+    expect(markup).toContain('tabindex="0"')
+    expect(markup).not.toContain('→')
+    expect(markup).not.toContain('>vs<')
+  })
+
+  it('renders nothing when neither base nor head identity is available', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={null}
+        compareBaseRef={null}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(markup).toBe('')
+  })
+
+  it('renders detached HEAD identity above the base with keyboard-reachable badge', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={readySummary}
+        compareBaseRef={null}
+        headDisplay={{
+          kind: 'detached',
+          shortHead: '8cec248',
+          sidebarLabel: 'Detached HEAD @ 8cec248',
+          sourceControlLabel: 'Detached HEAD · 8cec248',
+          tooltip: 'Detached HEAD at 8cec248. You are viewing a commit, not a branch.'
+        }}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    const headIndex = markup.indexOf('Detached HEAD · 8cec248')
+    const baseIndex = markup.indexOf('origin/FRONT-192-ZisVoucherStrip')
+    expect(headIndex).toBeGreaterThan(-1)
+    expect(baseIndex).toBeGreaterThan(headIndex)
+    expect(markup).toContain(
+      'aria-label="Detached HEAD at 8cec248. You are viewing a commit, not a branch."'
+    )
+    expect(markup).toContain('tabindex="0"')
+    expect(markup).toContain(
+      'aria-label="Detached HEAD · 8cec248 → origin/FRONT-192-ZisVoucherStrip"'
+    )
+  })
+
+  it('keeps the head→base label on the error path', () => {
+    const markup = renderToStaticMarkup(
+      <SourceControlBranchContextRow
+        summary={{
+          ...readySummary,
+          status: 'error',
+          errorMessage: 'Could not compare against base'
+        }}
+        compareBaseRef={null}
+        headDisplay={{ kind: 'branch', branchName: 'feature/retry-me' }}
+        onChangeBaseRef={vi.fn()}
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('role="group"')
+    expect(markup).toContain('aria-label="feature/retry-me → origin/FRONT-192-ZisVoucherStrip"')
+    expect(markup).toContain('Could not compare against base')
+    expect(markup).toContain('Retry')
   })
 
   it('renders a compact external review link when a manual URL is available', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-branch-context-row.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-branch-context-row.tsx
@@ -4,32 +4,40 @@ import type { GitBranchCompareSummary, GitUpstreamStatus } from '../../../../sha
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
+import type { WorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { SourceControlHeaderIconButton } from './source-control-header-icon-button'
 import {
   buildSourceControlBranchContextStats,
-  resolveSourceControlDisplayedBaseRef,
-  shouldShowSourceControlBranchContextRow
+  formatSourceControlRefLabel,
+  resolveSourceControlDisplayedBaseRef
 } from './source-control-branch-context-stats'
-
-export { shouldShowSourceControlBranchContextRow } from './source-control-branch-context-stats'
 
 function BaseRefButton({
   baseRef,
+  displayLabel,
   onClick,
   title
 }: {
   baseRef: string
+  displayLabel: string
   onClick: () => void
   title: string
 }): React.JSX.Element {
+  const accessibleName = translate(
+    'auto.components.right.sidebar.SourceControl.c7d4e2f801',
+    'Change base ref: {{value0}}',
+    { value0: displayLabel }
+  )
   return (
     <button
       type="button"
       className="min-w-0 max-w-full truncate rounded-sm border-0 bg-transparent p-0 text-left font-mono text-[10.5px] font-medium text-foreground/90 underline decoration-border underline-offset-2 hover:text-foreground hover:decoration-foreground"
       onClick={onClick}
       title={`${title} (${baseRef})`}
+      aria-label={accessibleName}
     >
-      {baseRef}
+      {displayLabel}
     </button>
   )
 }
@@ -41,7 +49,9 @@ function ContextStat({
 }): React.JSX.Element {
   const className = cn(
     'shrink-0 tabular-nums text-muted-foreground',
-    stat.tone === 'muted' && 'text-muted-foreground/70'
+    stat.tone === 'muted' && 'text-muted-foreground/70',
+    stat.tone === 'ahead' && 'text-[color:var(--git-decoration-added)]',
+    stat.tone === 'behind' && 'text-[color:var(--git-decoration-deleted)]'
   )
 
   if (!stat.title) {
@@ -82,9 +92,179 @@ function ManualReviewLinkButton({
   )
 }
 
+function resolveHeadFlowLabel(
+  display: WorktreeGitIdentityDisplay | null | undefined
+): string | null {
+  if (display?.kind === 'branch') {
+    return display.branchName
+  }
+  if (display?.kind === 'detached') {
+    return display.sourceControlLabel
+  }
+  return null
+}
+
+function HeadIdentity({ display }: { display: WorktreeGitIdentityDisplay }): React.JSX.Element {
+  if (display.kind === 'detached') {
+    return (
+      <DetachedHeadBadge
+        display={display}
+        side="bottom"
+        // Why: tooltip carries the full detached explanation; keep it keyboard-reachable.
+        tabIndex={0}
+        className="min-w-0 max-w-full shrink"
+      />
+    )
+  }
+
+  const branchAriaLabel = translate(
+    'auto.components.right.sidebar.SourceControl.a4e93c21d7',
+    'Current branch: {{value0}}',
+    { value0: display.branchName }
+  )
+
+  // Why: focusable + tooltip so truncated long branch names stay discoverable.
+  // Native title omitted — Radix Tooltip already surfaces the full name on hover.
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="min-w-0 max-w-full truncate rounded-sm font-mono text-[10.5px] font-medium text-foreground/90 outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          tabIndex={0}
+          aria-label={branchAriaLabel}
+          data-testid="source-control-head-identity"
+        >
+          {display.branchName}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6} className="max-w-72 break-all font-mono">
+        {display.branchName}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+function CompareFlowGroup({
+  flowLabel,
+  busy,
+  className,
+  children
+}: {
+  flowLabel: string | undefined
+  busy?: boolean
+  className: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div
+      className={className}
+      role={flowLabel != null ? 'group' : undefined}
+      aria-label={flowLabel}
+      aria-busy={busy ? true : undefined}
+    >
+      {children}
+    </div>
+  )
+}
+
+function BaseLine({
+  baseRef,
+  baseLabel,
+  onChangeBaseRef,
+  changeBaseTitle,
+  showArrow,
+  leading,
+  trailing
+}: {
+  baseRef: string
+  baseLabel: string
+  onChangeBaseRef: () => void
+  changeBaseTitle: string
+  showArrow: boolean
+  leading?: React.ReactNode
+  trailing?: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div className="flex min-w-0 items-center gap-1.5">
+      {leading}
+      {showArrow ? (
+        <span className="shrink-0 text-muted-foreground/70" aria-hidden="true">
+          →
+        </span>
+      ) : (
+        <span className="shrink-0 text-muted-foreground">
+          {translate('auto.components.right.sidebar.SourceControl.e8a1c4b203', 'vs')}
+        </span>
+      )}
+      <span className="min-w-0 flex-1">
+        <BaseRefButton
+          baseRef={baseRef}
+          displayLabel={baseLabel}
+          onClick={onChangeBaseRef}
+          title={changeBaseTitle}
+        />
+      </span>
+      {trailing}
+    </div>
+  )
+}
+
+// Why: stacked head / → base (option B) so long branch names fit narrow sidebars
+// without truncating both sides of a single-line head→base pair.
+function StackedCompareFlow({
+  headDisplay,
+  baseRef,
+  baseLabel,
+  onChangeBaseRef,
+  changeBaseTitle,
+  leading,
+  trailing
+}: {
+  headDisplay: WorktreeGitIdentityDisplay | null
+  baseRef: string
+  baseLabel: string
+  onChangeBaseRef: () => void
+  changeBaseTitle: string
+  leading?: React.ReactNode
+  trailing?: React.ReactNode
+}): React.JSX.Element {
+  if (!headDisplay) {
+    return (
+      <BaseLine
+        baseRef={baseRef}
+        baseLabel={baseLabel}
+        onChangeBaseRef={onChangeBaseRef}
+        changeBaseTitle={changeBaseTitle}
+        showArrow={false}
+        leading={leading}
+        trailing={trailing}
+      />
+    )
+  }
+
+  return (
+    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+      <div className="min-w-0">
+        <HeadIdentity display={headDisplay} />
+      </div>
+      {/* Why: spinner/actions sit on the base line — they describe compare state, not HEAD. */}
+      <BaseLine
+        baseRef={baseRef}
+        baseLabel={baseLabel}
+        onChangeBaseRef={onChangeBaseRef}
+        changeBaseTitle={changeBaseTitle}
+        showArrow
+        leading={leading}
+        trailing={trailing}
+      />
+    </div>
+  )
+}
+
 export function SourceControlBranchContextRow({
   summary,
   compareBaseRef,
+  headDisplay = null,
   upstreamStatus,
   manualReviewUrl,
   onChangeBaseRef,
@@ -92,64 +272,100 @@ export function SourceControlBranchContextRow({
 }: {
   summary: GitBranchCompareSummary | null
   compareBaseRef: string | null
+  headDisplay?: WorktreeGitIdentityDisplay | null
   upstreamStatus?: GitUpstreamStatus
   manualReviewUrl?: string | null
   onChangeBaseRef: () => void
   onRetry: () => void
 }): React.JSX.Element | null {
   const displayedBaseRef = resolveSourceControlDisplayedBaseRef(summary, compareBaseRef)
-  if (!shouldShowSourceControlBranchContextRow(summary, compareBaseRef) || !displayedBaseRef) {
-    return null
+
+  // Why: no base → still show HEAD identity so branch/detached never vanish when
+  // compare isn't configured (replaces the separate identity row from #10215).
+  if (!displayedBaseRef) {
+    if (!headDisplay) {
+      return null
+    }
+    return (
+      <div className="min-w-0 text-[11px] text-muted-foreground">
+        <HeadIdentity display={headDisplay} />
+      </div>
+    )
   }
 
+  const baseLabel = formatSourceControlRefLabel(displayedBaseRef)
   const changeBaseTitle = translate(
     'auto.components.right.sidebar.SourceControl.493f963029',
     'Change base ref'
   )
+  const headLabel = resolveHeadFlowLabel(headDisplay)
+  const flowLabel =
+    headLabel != null
+      ? translate(
+          'auto.components.right.sidebar.SourceControl.b8c2e1a904',
+          '{{value0}} → {{value1}}',
+          { value0: headLabel, value1: baseLabel }
+        )
+      : undefined
 
   if (!summary || summary.status === 'loading') {
     return (
-      <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-        <Loader2 className="size-3 shrink-0 animate-spin" />
-        <span className="shrink-0 text-muted-foreground">
-          {translate('auto.components.right.sidebar.SourceControl.e8a1c4b203', 'vs')}
+      <CompareFlowGroup
+        flowLabel={flowLabel}
+        busy
+        className="min-w-0 text-[11px] text-muted-foreground"
+      >
+        <StackedCompareFlow
+          headDisplay={headDisplay}
+          baseRef={displayedBaseRef}
+          baseLabel={baseLabel}
+          onChangeBaseRef={onChangeBaseRef}
+          changeBaseTitle={changeBaseTitle}
+          leading={<Loader2 className="size-3 shrink-0 animate-spin" aria-hidden="true" />}
+          trailing={<ManualReviewLinkButton url={manualReviewUrl} />}
+        />
+        <span className="sr-only">
+          {translate('auto.components.right.sidebar.SourceControl.11b5dd8e41', 'Comparing against')}
         </span>
-        <span className="min-w-0 flex-1">
-          <BaseRefButton
-            baseRef={displayedBaseRef}
-            onClick={onChangeBaseRef}
-            title={changeBaseTitle}
-          />
-        </span>
-        <ManualReviewLinkButton url={manualReviewUrl} />
-      </div>
+      </CompareFlowGroup>
     )
   }
 
   if (summary.status !== 'ready') {
     return (
-      <div className="flex min-w-0 items-center gap-1.5 text-[11px] text-muted-foreground">
-        <span className="min-w-0 flex-1">
-          <BaseRefButton
-            baseRef={displayedBaseRef}
-            onClick={onChangeBaseRef}
-            title={changeBaseTitle}
-          />
-        </span>
-        <span className="min-w-0 flex-1 truncate" title={summary.errorMessage ?? undefined}>
+      <CompareFlowGroup
+        flowLabel={flowLabel}
+        className="flex min-w-0 flex-col gap-0.5 text-[11px] text-muted-foreground"
+      >
+        <StackedCompareFlow
+          headDisplay={headDisplay}
+          baseRef={displayedBaseRef}
+          baseLabel={baseLabel}
+          onChangeBaseRef={onChangeBaseRef}
+          changeBaseTitle={changeBaseTitle}
+          trailing={
+            <>
+              <ManualReviewLinkButton url={manualReviewUrl} />
+              <SourceControlHeaderIconButton
+                icon={RefreshCw}
+                label={translate('auto.components.right.sidebar.SourceControl.286dbda4d6', 'Retry')}
+                onClick={onRetry}
+              />
+            </>
+          }
+        />
+        {/* Why: pl-4 under the base line so the error reads as compare state, not HEAD. */}
+        <span
+          className={cn('min-w-0 truncate', headDisplay != null && 'pl-4')}
+          title={summary.errorMessage ?? undefined}
+        >
           {summary.errorMessage ??
             translate(
               'auto.components.right.sidebar.SourceControl.715d229c86',
               'Branch compare unavailable'
             )}
         </span>
-        <ManualReviewLinkButton url={manualReviewUrl} />
-        <SourceControlHeaderIconButton
-          icon={RefreshCw}
-          label={translate('auto.components.right.sidebar.SourceControl.286dbda4d6', 'Retry')}
-          onClick={onRetry}
-        />
-      </div>
+      </CompareFlowGroup>
     )
   }
 
@@ -159,20 +375,8 @@ export function SourceControlBranchContextRow({
     upstreamStatus
   })
 
-  return (
-    <div className="flex min-w-0 items-center justify-between gap-1.5 text-[11px] text-muted-foreground">
-      <div className="flex min-w-0 flex-1 items-center gap-1.5">
-        <span className="shrink-0">
-          {translate('auto.components.right.sidebar.SourceControl.e8a1c4b203', 'vs')}
-        </span>
-        <span className="min-w-0 flex-1">
-          <BaseRefButton
-            baseRef={displayedBaseRef}
-            onClick={onChangeBaseRef}
-            title={changeBaseTitle}
-          />
-        </span>
-      </div>
+  const trailing = (
+    <>
       {stats.length > 0 ? (
         <span className="inline-flex shrink-0 items-center gap-1.5">
           {stats.map((stat) => (
@@ -181,6 +385,19 @@ export function SourceControlBranchContextRow({
         </span>
       ) : null}
       <ManualReviewLinkButton url={manualReviewUrl} />
-    </div>
+    </>
+  )
+
+  return (
+    <CompareFlowGroup flowLabel={flowLabel} className="min-w-0 text-[11px] text-muted-foreground">
+      <StackedCompareFlow
+        headDisplay={headDisplay}
+        baseRef={displayedBaseRef}
+        baseLabel={baseLabel}
+        onChangeBaseRef={onChangeBaseRef}
+        changeBaseTitle={changeBaseTitle}
+        trailing={trailing}
+      />
+    </CompareFlowGroup>
   )
 }

--- a/src/renderer/src/components/right-sidebar/source-control-branch-context-stats.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-branch-context-stats.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildSourceControlBranchContextStats,
+  formatSourceControlRefLabel,
   resolveSourceControlDisplayedBaseRef,
+  shouldShowSourceControlBranchContextChrome,
   shouldShowSourceControlBranchContextRow
 } from './source-control-branch-context-stats'
 import type { GitBranchCompareSummary } from '../../../../shared/types'
@@ -26,44 +28,110 @@ describe('source-control branch context stats', () => {
     expect(resolveSourceControlDisplayedBaseRef(null, null)).toBeNull()
   })
 
-  it('shows the row when compare summary or configured base ref exists', () => {
+  it('formats refs for scannable labels without dropping remote qualification', () => {
+    expect(formatSourceControlRefLabel('refs/remotes/origin/main')).toBe('origin/main')
+    expect(formatSourceControlRefLabel('refs/heads/feature/foo')).toBe('feature/foo')
+    expect(formatSourceControlRefLabel('origin/main')).toBe('origin/main')
+    expect(formatSourceControlRefLabel('refs/tags/v1.2.3')).toBe('v1.2.3')
+  })
+
+  it('shows the row only when a displayable base ref exists', () => {
     expect(shouldShowSourceControlBranchContextRow(null, null)).toBe(false)
     expect(shouldShowSourceControlBranchContextRow(null, 'origin/main')).toBe(true)
     expect(
       shouldShowSourceControlBranchContextRow({ ...readySummary, status: 'loading' }, null)
     ).toBe(true)
     expect(shouldShowSourceControlBranchContextRow(readySummary, null)).toBe(true)
+    // Summary without a usable base must not claim the row is visible.
+    expect(shouldShowSourceControlBranchContextRow({ ...readySummary, baseRef: '   ' }, null)).toBe(
+      false
+    )
+    expect(shouldShowSourceControlBranchContextRow({ ...readySummary, baseRef: '' }, null)).toBe(
+      false
+    )
   })
 
-  it('renders upstream ahead and behind counts', () => {
+  it('shows toolbar chrome when head identity exists even without a base', () => {
+    expect(shouldShowSourceControlBranchContextChrome(null, null, null)).toBe(false)
+    expect(
+      shouldShowSourceControlBranchContextChrome(null, null, {
+        kind: 'branch',
+        branchName: 'local-only'
+      })
+    ).toBe(true)
+    expect(shouldShowSourceControlBranchContextChrome(readySummary, null, null)).toBe(true)
+  })
+
+  it('renders upstream ahead and behind counts against the tracking branch', () => {
     const stats = buildSourceControlBranchContextStats({
       summary: { ...readySummary, commitsAhead: 0 },
       baseRef: 'origin/main',
-      upstreamStatus: { hasUpstream: true, ahead: 2, behind: 1 }
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/feature',
+        ahead: 2,
+        behind: 1
+      }
     })
     expect(stats.map((stat) => stat.label)).toEqual(['↑2', '↓1'])
-    expect(stats[0]?.title).toBe('2 commits ahead of origin/main')
-    expect(stats[1]?.title).toBe('1 commit behind origin/main')
+    expect(stats[0]?.title).toBe('2 commits ahead of origin/feature')
+    expect(stats[1]?.title).toBe('1 commit behind origin/feature')
+  })
+
+  it('shows both upstream and compare ahead when counts match but targets differ', () => {
+    const stats = buildSourceControlBranchContextStats({
+      summary: readySummary,
+      baseRef: 'origin/main',
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/feature',
+        ahead: 3,
+        behind: 0
+      }
+    })
+    expect(stats.map((stat) => ({ key: stat.key, label: stat.label, title: stat.title }))).toEqual([
+      {
+        key: 'upstream-ahead',
+        label: '↑3',
+        title: '3 commits ahead of origin/feature'
+      },
+      {
+        key: 'compare-ahead',
+        label: '↑3',
+        title: '3 commits ahead of origin/main'
+      }
+    ])
   })
 
   it('shows branch-compare ahead when it differs from upstream ahead', () => {
     const stats = buildSourceControlBranchContextStats({
       summary: readySummary,
       baseRef: 'origin/main',
-      upstreamStatus: { hasUpstream: true, ahead: 1, behind: 0 }
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/feature',
+        ahead: 1,
+        behind: 0
+      }
     })
     expect(stats.map((stat) => stat.label)).toEqual(['↑1', '↑3'])
-    expect(stats[0]?.title).toBe('1 commit ahead of origin/main')
+    expect(stats[0]?.title).toBe('1 commit ahead of origin/feature')
     expect(stats[1]?.title).toBe('3 commits ahead of origin/main')
   })
 
-  it('dedupes branch-compare ahead when it matches upstream ahead', () => {
+  it('dedupes branch-compare ahead only when target and count match upstream', () => {
     const stats = buildSourceControlBranchContextStats({
       summary: { ...readySummary, commitsAhead: 2 },
       baseRef: 'origin/main',
-      upstreamStatus: { hasUpstream: true, ahead: 2, behind: 0 }
+      upstreamStatus: {
+        hasUpstream: true,
+        upstreamName: 'origin/main',
+        ahead: 2,
+        behind: 0
+      }
     })
     expect(stats.map((stat) => stat.label)).toEqual(['↑2'])
+    expect(stats[0]?.key).toBe('upstream-ahead')
     expect(stats[0]?.title).toBe('2 commits ahead of origin/main')
   })
 
@@ -74,6 +142,23 @@ describe('source-control branch context stats', () => {
     })
     expect(stats.map((stat) => stat.label)).toEqual(['↑3'])
     expect(stats[0]?.title).toBe('3 commits ahead of origin/main')
+  })
+
+  it('formats namespaced base refs in stat titles', () => {
+    const stats = buildSourceControlBranchContextStats({
+      summary: readySummary,
+      baseRef: 'refs/remotes/origin/main'
+    })
+    expect(stats[0]?.title).toBe('3 commits ahead of origin/main')
+  })
+
+  it('falls back to a generic upstream label when upstreamName is missing', () => {
+    const stats = buildSourceControlBranchContextStats({
+      summary: { ...readySummary, commitsAhead: 0 },
+      baseRef: 'origin/main',
+      upstreamStatus: { hasUpstream: true, ahead: 2, behind: 0 }
+    })
+    expect(stats[0]?.title).toBe('2 commits ahead of upstream')
   })
 
   it('returns no stats when branch is even with base', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-branch-context-stats.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-branch-context-stats.ts
@@ -1,4 +1,5 @@
 import type { GitBranchCompareSummary, GitUpstreamStatus } from '../../../../shared/types'
+import type { WorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { translate } from '@/i18n/i18n'
 
 function formatAheadOfBaseTitle(count: number, baseRef: string): string {
@@ -48,11 +49,41 @@ export function resolveSourceControlDisplayedBaseRef(
   return configuredRef || null
 }
 
+// Why: context-row labels should stay scannable — drop git namespace prefixes
+// but keep remote qualification (origin/main) so multi-remote bases stay distinct.
+export function formatSourceControlRefLabel(ref: string): string {
+  return ref
+    .trim()
+    .replace(/^refs\/remotes\//, '')
+    .replace(/^refs\/heads\//, '')
+    .replace(/^refs\/tags\//, '')
+}
+
+// Why: the compare row needs a displayable base; a summary alone with an empty
+// baseRef would still fail the component's displayedBaseRef guard.
 export function shouldShowSourceControlBranchContextRow(
   summary: GitBranchCompareSummary | null | undefined,
   compareBaseRef: string | null | undefined
 ): boolean {
-  return summary != null || resolveSourceControlDisplayedBaseRef(summary, compareBaseRef) != null
+  return resolveSourceControlDisplayedBaseRef(summary, compareBaseRef) != null
+}
+
+// Why: head-only identity still mounts when there is no base, so toolbar chrome
+// visibility is "base OR head" — not base alone.
+export function shouldShowSourceControlBranchContextChrome(
+  summary: GitBranchCompareSummary | null | undefined,
+  compareBaseRef: string | null | undefined,
+  headDisplay: WorktreeGitIdentityDisplay | null | undefined
+): boolean {
+  return shouldShowSourceControlBranchContextRow(summary, compareBaseRef) || headDisplay != null
+}
+
+function resolveUpstreamDisplayLabel(upstreamStatus: GitUpstreamStatus): string {
+  const named = upstreamStatus.upstreamName?.trim()
+  if (named) {
+    return formatSourceControlRefLabel(named)
+  }
+  return translate('auto.components.right.sidebar.SourceControl.f3a1b8c204', 'upstream')
 }
 
 export function buildSourceControlBranchContextStats({
@@ -69,13 +100,17 @@ export function buildSourceControlBranchContextStats({
   }
 
   const stats: SourceControlBranchContextStat[] = []
+  const baseLabel = formatSourceControlRefLabel(baseRef)
+  const hasUpstream = Boolean(upstreamStatus?.hasUpstream)
+  const upstreamLabel =
+    hasUpstream && upstreamStatus ? resolveUpstreamDisplayLabel(upstreamStatus) : null
 
-  if (upstreamStatus?.hasUpstream) {
+  if (hasUpstream && upstreamStatus && upstreamLabel != null) {
     if (upstreamStatus.ahead > 0) {
       stats.push({
         key: 'upstream-ahead',
         label: `↑${upstreamStatus.ahead}`,
-        title: formatAheadOfBaseTitle(upstreamStatus.ahead, baseRef),
+        title: formatAheadOfBaseTitle(upstreamStatus.ahead, upstreamLabel),
         tone: 'ahead'
       })
     }
@@ -83,7 +118,7 @@ export function buildSourceControlBranchContextStats({
       stats.push({
         key: 'upstream-behind',
         label: `↓${upstreamStatus.behind}`,
-        title: formatBehindBaseTitle(upstreamStatus.behind, baseRef),
+        title: formatBehindBaseTitle(upstreamStatus.behind, upstreamLabel),
         tone: 'behind'
       })
     }
@@ -91,12 +126,19 @@ export function buildSourceControlBranchContextStats({
 
   const commitsAhead = summary.commitsAhead
   if (typeof commitsAhead === 'number' && commitsAhead > 0) {
-    const upstreamAhead = upstreamStatus?.hasUpstream ? upstreamStatus.ahead : 0
-    if (commitsAhead !== upstreamAhead) {
+    // Why: only collapse compare-ahead into upstream-ahead when both describe the
+    // same ref and count — equal numbers against different targets must both show.
+    const sameTargetAsUpstream =
+      hasUpstream &&
+      upstreamStatus != null &&
+      upstreamLabel != null &&
+      upstreamLabel === baseLabel &&
+      commitsAhead === upstreamStatus.ahead
+    if (!sameTargetAsUpstream) {
       stats.push({
         key: 'compare-ahead',
         label: `↑${commitsAhead}`,
-        title: formatAheadOfBaseTitle(commitsAhead, baseRef),
+        title: formatAheadOfBaseTitle(commitsAhead, baseLabel),
         tone: 'ahead'
       })
     }

--- a/src/renderer/src/components/right-sidebar/source-control-header-toolbar-identity.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-header-toolbar-identity.test.tsx
@@ -1,9 +1,10 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { describe, expect, it, vi } from 'vitest'
+import { SourceControlHeaderToolbar } from './source-control-header-toolbar'
+import type { GitBranchCompareSummary } from '../../../../shared/types'
 import type { WorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import type { PrimaryAction } from './source-control-primary-action'
-import { SourceControlHeaderToolbar } from './source-control-header-toolbar'
 
 vi.mock('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -15,11 +16,6 @@ vi.mock('./source-control-header-overflow-menu', () => ({
   SourceControlHeaderOverflowMenu: () => <button type="button">More actions</button>
 }))
 
-vi.mock('./source-control-branch-context-row', () => ({
-  shouldShowSourceControlBranchContextRow: () => false,
-  SourceControlBranchContextRow: () => null
-}))
-
 const CREATE_PR_ACTION: PrimaryAction = {
   kind: 'create_pr',
   label: 'Create PR',
@@ -27,27 +23,29 @@ const CREATE_PR_ACTION: PrimaryAction = {
   disabled: false
 }
 
-function renderToolbar(
-  overrides: {
-    gitIdentityDisplay?: WorktreeGitIdentityDisplay | null
-    createPrAction?: PrimaryAction | null
-  } = {}
-): string {
-  const gitIdentityDisplay =
-    overrides.gitIdentityDisplay === undefined
-      ? ({ kind: 'branch', branchName: 'brennanb2025/source-control-branch-name' } as const)
-      : overrides.gitIdentityDisplay
-  const createPrAction =
-    overrides.createPrAction === undefined ? CREATE_PR_ACTION : overrides.createPrAction
+const readySummary: GitBranchCompareSummary = {
+  baseRef: 'origin/main',
+  baseOid: 'base',
+  compareRef: 'feature',
+  headOid: 'head',
+  mergeBase: 'base',
+  changedFiles: 0,
+  commitsAhead: 1,
+  status: 'ready'
+}
 
+function renderToolbar(options?: {
+  headDisplay?: WorktreeGitIdentityDisplay | null
+  branchSummary?: GitBranchCompareSummary | null
+  compareBaseRef?: string | null
+}): string {
   return renderToStaticMarkup(
     <SourceControlHeaderToolbar
-      gitIdentityDisplay={gitIdentityDisplay}
       filterQuery=""
       filterExpanded={false}
       onFilterQueryChange={vi.fn()}
       onFilterExpandedChange={vi.fn()}
-      visibleCreatePrHeaderAction={createPrAction}
+      visibleCreatePrHeaderAction={CREATE_PR_ACTION}
       hostedReview={null}
       isCreatePrIntentInFlight={false}
       isCreatingPr={false}
@@ -61,31 +59,47 @@ function renderToolbar(
       branchCompareRefreshDisabled={false}
       diffCommentCount={0}
       onExpandNotes={vi.fn()}
-      branchSummary={null}
-      compareBaseRef={null}
+      branchSummary={options?.branchSummary === undefined ? readySummary : options.branchSummary}
+      compareBaseRef={options?.compareBaseRef === undefined ? null : options.compareBaseRef}
+      headDisplay={
+        options?.headDisplay === undefined
+          ? { kind: 'branch', branchName: 'brennanb2025/source-control-branch-name' }
+          : options.headDisplay
+      }
     />
   )
 }
 
 describe('SourceControlHeaderToolbar branch identity', () => {
-  it('keeps the Create PR button while showing the branch identity above it', () => {
+  it('keeps Create PR while stacking head above base in the context row', () => {
     const markup = renderToolbar()
     const branchIndex = markup.indexOf('brennanb2025/source-control-branch-name')
     const createPrIndex = markup.indexOf('Create PR')
 
-    // Why: the #9787 revert regression — identity must not evict Create PR.
-    expect(markup).toContain('data-testid="source-control-git-identity-row"')
+    // Why: the #9787 regression — identity must not evict Create PR.
     expect(branchIndex).toBeGreaterThan(-1)
     expect(createPrIndex).toBeGreaterThan(-1)
-    // Identity row renders above the toolbar row that hosts Create PR.
-    expect(branchIndex).toBeLessThan(createPrIndex)
+    expect(markup).toContain('aria-label="brennanb2025/source-control-branch-name → origin/main"')
     expect(markup).toContain('aria-label="Current branch: brennanb2025/source-control-branch-name"')
-    expect(markup).toContain('min-w-0 truncate')
+    expect(markup).toContain('data-testid="source-control-head-identity"')
   })
 
-  it('renders detached HEAD identity alongside the Create PR button', () => {
+  it('shows head-only identity with Create PR when no compare base is configured', () => {
     const markup = renderToolbar({
-      gitIdentityDisplay: {
+      branchSummary: null,
+      compareBaseRef: null,
+      headDisplay: { kind: 'branch', branchName: 'local-only-branch' }
+    })
+
+    expect(markup).toContain('Create PR')
+    expect(markup).toContain('data-testid="source-control-head-identity"')
+    expect(markup).toContain('local-only-branch')
+    expect(markup).not.toContain('→')
+  })
+
+  it('renders detached HEAD with Create PR when compare base is present', () => {
+    const markup = renderToolbar({
+      headDisplay: {
         kind: 'detached',
         shortHead: '8cec248',
         sidebarLabel: 'Detached HEAD @ 8cec248',
@@ -94,22 +108,21 @@ describe('SourceControlHeaderToolbar branch identity', () => {
       }
     })
 
-    expect(markup).not.toContain('aria-label="Current branch:')
-    expect(markup).toContain('data-testid="source-control-git-identity-row"')
     expect(markup).toContain('Detached HEAD · 8cec248')
-    // Detached badge stays keyboard-reachable and exposes the full tooltip as its label.
-    expect(markup).toContain(
-      'aria-label="Detached HEAD at 8cec248. You are viewing a commit, not a branch."'
-    )
     expect(markup).toContain('tabindex="0"')
     expect(markup).toContain('Create PR')
+    expect(markup).toContain('aria-label="Detached HEAD · 8cec248 → origin/main"')
   })
 
-  it('omits the identity row when there is no git identity', () => {
-    const markup = renderToolbar({ gitIdentityDisplay: null })
+  it('omits identity chrome when there is no git identity and no base', () => {
+    const markup = renderToolbar({
+      headDisplay: null,
+      branchSummary: null,
+      compareBaseRef: null
+    })
 
-    expect(markup).not.toContain('data-testid="source-control-git-identity-row"')
-    expect(markup).not.toContain('aria-label="Current branch:')
+    expect(markup).not.toContain('data-testid="source-control-head-identity"')
+    expect(markup).not.toContain('→')
     expect(markup).toContain('Create PR')
   })
 })

--- a/src/renderer/src/components/right-sidebar/source-control-header-toolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-header-toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react'
-import { GitBranch, GitPullRequestArrow, Loader2, Search, X } from 'lucide-react'
+import { GitPullRequestArrow, Loader2, Search, X } from 'lucide-react'
 import type {
   GitBranchCompareSummary,
   GitUpstreamStatus,
@@ -11,17 +11,13 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
-import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
 import type { WorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
 import { HostedReviewHeaderLink, HostedReviewIcon } from './hosted-review-header-chrome'
-import {
-  shouldShowSourceControlBranchContextRow,
-  SourceControlBranchContextRow
-} from './source-control-branch-context-row'
+import { SourceControlBranchContextRow } from './source-control-branch-context-row'
+import { shouldShowSourceControlBranchContextChrome } from './source-control-branch-context-stats'
 import { SourceControlHeaderOverflowMenu } from './source-control-header-overflow-menu'
 
 type SourceControlHeaderToolbarProps = {
-  gitIdentityDisplay: WorktreeGitIdentityDisplay | null
   filterQuery: string
   filterExpanded: boolean
   onFilterQueryChange: (value: string) => void
@@ -42,58 +38,9 @@ type SourceControlHeaderToolbarProps = {
   onExpandNotes: () => void
   branchSummary: GitBranchCompareSummary | null
   compareBaseRef: string | null
+  headDisplay?: WorktreeGitIdentityDisplay | null
   upstreamStatus?: GitUpstreamStatus
   manualReviewUrl?: string | null
-}
-
-// Why: its own row above the toolbar so branch identity coexists with the Create PR
-// button instead of competing for the single toolbar slot (#9787 restore).
-function SourceControlGitIdentityRow({
-  display
-}: {
-  display: WorktreeGitIdentityDisplay
-}): React.JSX.Element {
-  if (display.kind === 'detached') {
-    return (
-      <div data-testid="source-control-git-identity-row" className="mb-1 flex min-w-0 items-center">
-        <DetachedHeadBadge
-          display={display}
-          side="bottom"
-          className="min-w-0 max-w-full shrink"
-          tabIndex={0}
-        />
-      </div>
-    )
-  }
-
-  const branchName = display.branchName
-  const label = translate(
-    'auto.components.right.sidebar.SourceControl.a4e93c21d7',
-    'Current branch: {{value0}}',
-    { value0: branchName }
-  )
-
-  return (
-    <div data-testid="source-control-git-identity-row" className="mb-1 flex min-w-0 items-center">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span
-            className="flex min-w-0 items-center gap-1 rounded-sm font-mono text-[10.5px] font-medium leading-none text-foreground/90 outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            aria-label={label}
-            tabIndex={0}
-          >
-            <GitBranch className="size-3 shrink-0 text-muted-foreground" aria-hidden="true" />
-            {/* Why: match the 'vs main' base-ref typography (font/size/color) but no
-                underline — this label isn't clickable, so the underline would mislead. */}
-            <span className="min-w-0 truncate">{branchName}</span>
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="bottom" sideOffset={6} className="max-w-72 break-all font-mono">
-          {branchName}
-        </TooltipContent>
-      </Tooltip>
-    </div>
-  )
 }
 
 function HostedReviewToolbarLink({
@@ -177,7 +124,6 @@ function renderOverflowMenu(
 }
 
 export function SourceControlHeaderToolbar({
-  gitIdentityDisplay,
   filterQuery,
   filterExpanded,
   onFilterQueryChange,
@@ -198,6 +144,7 @@ export function SourceControlHeaderToolbar({
   onExpandNotes,
   branchSummary,
   compareBaseRef,
+  headDisplay = null,
   upstreamStatus,
   manualReviewUrl
 }: SourceControlHeaderToolbarProps): React.JSX.Element {
@@ -244,7 +191,6 @@ export function SourceControlHeaderToolbar({
 
   return (
     <div className="border-b border-border px-3 pt-1.5 pb-1">
-      {gitIdentityDisplay ? <SourceControlGitIdentityRow display={gitIdentityDisplay} /> : null}
       <div
         className={cn('flex min-w-0 items-center gap-1', filterExpanded && 'w-full gap-1.5')}
         data-filter-expanded={filterExpanded ? 'true' : 'false'}
@@ -339,11 +285,12 @@ export function SourceControlHeaderToolbar({
         )}
       </div>
 
-      {shouldShowSourceControlBranchContextRow(branchSummary, compareBaseRef) ? (
+      {shouldShowSourceControlBranchContextChrome(branchSummary, compareBaseRef, headDisplay) ? (
         <div className="mt-1">
           <SourceControlBranchContextRow
             summary={branchSummary}
             compareBaseRef={compareBaseRef}
+            headDisplay={headDisplay}
             upstreamStatus={upstreamStatus}
             manualReviewUrl={manualReviewUrl}
             onChangeBaseRef={onChangeBaseRef}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9892,7 +9892,6 @@
             "b715ef615b": "{{value0}} commits ahead of {{value1}}",
             "c1a8f3e204": "1 commit behind {{value0}}",
             "d2b9g4f315": "{{value0}} commits behind {{value1}}",
-            "e9c2a5d416": "Even with {{value0}}",
             "4b4a7de138": "Open review page in browser",
             "createPrIntentCommitBlockedSummary": "Commit blocked: {{value0}} Fix the issue, then retry Create PR.",
             "pushRecovery": {
@@ -9911,7 +9910,10 @@
               "783a808870": "Close"
             },
             "97e7124eac": "Could not refresh Source Control. Try again.",
-            "a4e93c21d7": "Current branch: {{value0}}"
+            "b8c2e1a904": "{{value0}} → {{value1}}",
+            "a4e93c21d7": "Current branch: {{value0}}",
+            "c7d4e2f801": "Change base ref: {{value0}}",
+            "f3a1b8c204": "upstream"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -9869,7 +9869,6 @@
             "b715ef615b": "{{value0}} commits por delante de {{value1}}",
             "c1a8f3e204": "1 commit por detrás de {{value0}}",
             "d2b9g4f315": "{{value0}} commits por detrás de {{value1}}",
-            "e9c2a5d416": "A la par con {{value0}}",
             "4b4a7de138": "Abrir página de revisión en el navegador",
             "createPrIntentCommitBlockedSummary": "Commit bloqueado: {{value0}} Corrige el issue y reintenta crear PR.",
             "pushRecovery": {
@@ -9888,7 +9887,10 @@
               "783a808870": "Cerrar"
             },
             "97e7124eac": "No se pudo actualizar Source Control. Vuelve a intentarlo.",
-            "a4e93c21d7": "Rama actual: {{value0}}"
+            "b8c2e1a904": "{{value0}} → {{value1}}",
+            "a4e93c21d7": "Rama actual: {{value0}}",
+            "c7d4e2f801": "Cambiar ref base: {{value0}}",
+            "f3a1b8c204": "upstream"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "No se pudo iniciar el agente seleccionado.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -9869,7 +9869,6 @@
             "b715ef615b": "{{value1}}より{{value0}}commits 進んでいます",
             "c1a8f3e204": "{{value0}}より1commit 遅れています",
             "d2b9g4f315": "{{value1}}より{{value0}}commits 遅れています",
-            "e9c2a5d416": "{{value0}}と同じ状態",
             "4b4a7de138": "ブラウザでレビューページを開く",
             "createPrIntentCommitBlockedSummary": "コミットがブロックされました：{{value0}} イシューを修正して、PR作成を再試行してください。",
             "pushRecovery": {
@@ -9888,7 +9887,10 @@
               "783a808870": "閉じる"
             },
             "97e7124eac": "Source Control を更新できませんでした。もう一度お試しください。",
-            "a4e93c21d7": "現在のブランチ: {{value0}}"
+            "b8c2e1a904": "{{value0}} → {{value1}}",
+            "a4e93c21d7": "現在のブランチ: {{value0}}",
+            "c7d4e2f801": "ベース ref を変更: {{value0}}",
+            "f3a1b8c204": "upstream"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "選択した agent を開始できませんでした。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -9869,7 +9869,6 @@
             "b715ef615b": "{{value1}}보다 {{value0}} commits 앞서 있음",
             "c1a8f3e204": "{{value0}}보다 1 commit 뒤처짐",
             "d2b9g4f315": "{{value1}}보다 {{value0}} commits 뒤처짐",
-            "e9c2a5d416": "{{value0}}와 동일한 상태",
             "4b4a7de138": "브라우저에서 검토 페이지 열기",
             "createPrIntentCommitBlockedSummary": "커밋이 차단됨: {{value0}} 이슈를 수정한 후 PR 만들기를 다시 시도하세요.",
             "pushRecovery": {
@@ -9888,7 +9887,10 @@
               "783a808870": "닫기"
             },
             "97e7124eac": "Source Control을 새로 고칠 수 없습니다. 다시 시도하세요.",
-            "a4e93c21d7": "현재 브랜치: {{value0}}"
+            "b8c2e1a904": "{{value0}} → {{value1}}",
+            "a4e93c21d7": "현재 브랜치: {{value0}}",
+            "c7d4e2f801": "베이스 ref 변경: {{value0}}",
+            "f3a1b8c204": "upstream"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "선택한 agent를 시작할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -9869,7 +9869,6 @@
             "b715ef615b": "领先 {{value1}} {{value0}} 个提交",
             "c1a8f3e204": "落后 {{value0}} 1 个提交",
             "d2b9g4f315": "落后 {{value1}} {{value0}} 个提交",
-            "e9c2a5d416": "与 {{value0}} 同步",
             "4b4a7de138": "在浏览器中打开审查页面",
             "createPrIntentCommitBlockedSummary": "提交被阻止：{{value0}} 修复问题后重试创建 PR。",
             "pushRecovery": {
@@ -9888,7 +9887,10 @@
               "783a808870": "关闭"
             },
             "97e7124eac": "无法刷新 Source Control。请重试。",
-            "a4e93c21d7": "当前分支：{{value0}}"
+            "b8c2e1a904": "{{value0}} → {{value1}}",
+            "a4e93c21d7": "当前分支：{{value0}}",
+            "c7d4e2f801": "更改基引用：{{value0}}",
+            "f3a1b8c204": "upstream"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "无法启动选定的智能体。",


### PR DESCRIPTION
## Summary

Rearranges the branch compare UI from a single-line `head vs base` layout to a stacked `head` / `→ base` layout. This gives long branch names full row width in narrow sidebars instead of truncating both sides of a single-line pair.

## Changes

- Move `gitIdentityDisplay` prop from `SourceControlHeaderToolbar` to `SourceControlBranchContextRow` (renamed to `headDisplay`)
- Replace inline flex with stacked flex-col layout for compare flow
- Add new utility functions:
  - `formatSourceControlRefLabel()`: Strips ref namespace prefixes while preserving remote qualification (e.g., `refs/remotes/origin/main` → `origin/main`)
  - `shouldShowSourceControlBranchContextChrome()`: Show chrome when base *or* head identity exists
  - `resolveHeadFlowLabel()`: Resolve display label from head identity
- Update stats display to use formatted labels and upstream tracking names when available
- Improve accessibility: add role="group" with aria-label for head→base flow, keyboard navigation for head identity badges
- Add i18n strings for flow label (`{{value0}} → {{value1}}`) and upstream label fallback

## Testing

- Extended test coverage for stacked layout, head-only identity, loading/error states
- Tests verify head renders above base with full row width via flex-col
- Tests verify fallback to "vs" when head identity is missing
- Verify Create PR button coexists with stacked identity (no eviction regression from #9787)