### PR TITLE
fix: prevent UI freeze from dual-modal race in action sheets

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -5091,8 +5091,8 @@ export default function SessionScreen() {
                 {
                   label: 'Browser',
                   icon: Globe,
+                  closeBeforePress: true,
                   onPress: () => {
-                    setShowCreateTabDrawer(false)
                     if (browserScreencastSupported !== true) {
                       showToast('Desktop update required for mobile browser streaming', 1600)
                       return
@@ -5168,9 +5168,11 @@ export default function SessionScreen() {
           {
             label: 'Refresh',
             icon: RefreshCw,
+            // Why: dirty refresh opens ConfirmModal; wait for this sheet's native
+            // Modal to unmount first (same dual-Modal race as tab Rename, #10331).
+            closeBeforePress: true,
             onPress: () => {
               const target = markdownActionTarget
-              setMarkdownActionTarget(null)
               if (target) {
                 discardMarkdownLocalContent(target)
               }

--- a/mobile/src/session/mobile-terminal-action-sheet-actions.test.ts
+++ b/mobile/src/session/mobile-terminal-action-sheet-actions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getMobileTerminalActionSheetActions } from './mobile-terminal-action-sheet-actions'
+
+vi.mock('lucide-react-native', () => ({
+  Eraser: vi.fn(),
+  MessageSquare: vi.fn(),
+  Monitor: vi.fn(),
+  Smartphone: vi.fn(),
+  SquareTerminal: vi.fn()
+}))
+
+describe('getMobileTerminalActionSheetActions', () => {
+  it('defers Rename until after the action sheet closes', () => {
+    const target = { handle: 'terminal-1' }
+    const onDismiss = vi.fn()
+    const onRename = vi.fn()
+    const actions = getMobileTerminalActionSheetActions({
+      target,
+      tabs: [],
+      isTabChatView: () => false,
+      nativeChatTranscriptIsLocalReadable: true,
+      onDismiss,
+      onToggleChat: vi.fn(),
+      isPhoneMode: () => false,
+      onToggleDisplayMode: vi.fn(),
+      onRename,
+      onClear: vi.fn(),
+      onClose: vi.fn()
+    })
+
+    const rename = actions.find((action) => action.label === 'Rename')
+    expect(rename).toMatchObject({ closeBeforePress: true })
+
+    rename?.onPress()
+    expect(onRename).toHaveBeenCalledWith(target)
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/session/mobile-terminal-action-sheet-actions.ts
+++ b/mobile/src/session/mobile-terminal-action-sheet-actions.ts
@@ -44,8 +44,8 @@ export function getMobileTerminalActionSheetActions<Target extends { handle: str
     },
     {
       label: 'Rename',
+      closeBeforePress: true,
       onPress: () => {
-        args.onDismiss()
         args.onRename(target)
       }
     },


### PR DESCRIPTION
## Summary

Fixes UI freeze when renaming a tab on mobile by closing the action sheet before modal-opening callbacks fire. The freeze was caused by a dual-modal race condition where opening a ConfirmModal while the action sheet was still mounted prevents proper navigation.

## Screenshots

No visual change.

## Testing

- [x] Added unit test for `getMobileTerminalActionSheetActions` verifying Rename action has `closeBeforePress: true`
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`

## AI Review Report

TODO: Summarize code review findings, including cross-platform compatibility verification.

## Security Audit

TODO: Provide security audit summary.

## Notes

Mobile-specific fix for React Native modal race condition. Applied `closeBeforePress: true` to Rename, Browser, and Refresh actions in action sheets to ensure proper unmounting order before handlers that open modals. Related to #10331.