### PR TITLE
fix(runtime): stop the headless hydration repo gate from dropping every tab

### DIFF
--- a/src/main/runtime/orca-runtime-headless-hydration-repo-gate.test.ts
+++ b/src/main/runtime/orca-runtime-headless-hydration-repo-gate.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID, getDefaultWorkspaceSession } from '../../shared/constants'
+import type { WorkspaceSessionState } from '../../shared/types'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const WORKTREE_ID = 'repo::/worktree'
+const REPO_ID = 'repo'
+
+function makeSession(worktreeId: string): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: {
+      [worktreeId]: [
+        {
+          id: 'tab',
+          ptyId: 'pty-1',
+          worktreeId,
+          title: 'Terminal',
+          customTitle: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }
+      ]
+    }
+  }
+}
+
+// The repo gate (#9343) skips persisted session keys whose repo is gone. These
+// pin the two ways that gate must not overreach.
+describe('headless mobile session hydration repo gate', () => {
+  it('hydrates when the store cannot report repos at all', async () => {
+    const runtime = new OrcaRuntimeService({
+      getWorkspaceSession: () => makeSession(WORKTREE_ID)
+    } as never)
+
+    // No getRepos on the store: an unavailable inventory must not read as
+    // "every repo is gone" and silently drop every persisted tab.
+    const result = await runtime.listMobileSessionTabs(`id:${WORKTREE_ID}`)
+    expect(result.tabs.length).toBeGreaterThan(0)
+  })
+
+  it('still skips a key whose repo is absent from a known inventory', async () => {
+    const runtime = new OrcaRuntimeService({
+      getWorkspaceSession: () => makeSession('ghost-repo::/worktree'),
+      getRepos: () => [{ id: REPO_ID, path: '/repo', name: 'repo' }]
+    } as never)
+
+    const result = await runtime.listMobileSessionTabs('id:ghost-repo::/worktree')
+    expect(result.tabs).toEqual([])
+  })
+
+  it('does not read the repo inventory for an unparseable worktree id', async () => {
+    const getRepos = vi.fn(() => [{ id: REPO_ID, path: '/repo', name: 'repo' }])
+    const runtime = new OrcaRuntimeService({
+      getWorkspaceSession: () => makeSession(FLOATING_TERMINAL_WORKTREE_ID),
+      // A separator-less id is validated against getRepo (singular) first.
+      getRepo: () => null,
+      getRepos
+    } as never)
+
+    // Floating terminals carry no `repoId::path` identity, and this hydrate runs
+    // on a hot poll path — it must not enumerate repos.
+    await runtime.listMobileSessionTabs(`id:${FLOATING_TERMINAL_WORKTREE_ID}`)
+    expect(getRepos).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -4106,11 +4106,20 @@ export class OrcaRuntimeService {
     // or a stale browser-persisted session). Hydrating such a key would surface a
     // phantom "unknown"/duplicate workspace with no live repo behind it. Only
     // hydrate sessions whose repo still exists; leave unparseable keys alone.
-    const liveRepoIds = new Set((this.store?.getRepos?.() ?? []).map((repo) => repo.id))
+    // Resolved lazily so unparseable keys (floating terminals) never pay for a
+    // repo inventory on the hot poll path, and `null` when the store cannot
+    // report repos — an unavailable list must not read as "every repo is gone".
+    let liveRepoIds: Set<string> | null | undefined
     for (const [entryWorktreeId, persistedTabs] of entries) {
       const ownerRepoId = splitWorktreeIdForFilesystem(entryWorktreeId)?.repoId
-      if (ownerRepoId && !liveRepoIds.has(ownerRepoId)) {
-        continue
+      if (ownerRepoId) {
+        if (liveRepoIds === undefined) {
+          const knownRepos = this.store?.getRepos?.()
+          liveRepoIds = knownRepos ? new Set(knownRepos.map((repo) => repo.id)) : null
+        }
+        if (liveRepoIds && !liveRepoIds.has(ownerRepoId)) {
+          continue
+        }
       }
       const existing = this.mobileSessionTabsByWorktree.get(entryWorktreeId)
       if (

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -24,7 +24,7 @@ import {
   runRichMarkdownContextCommand
 } from './rich-markdown-context-command-routing'
 import { useRichMarkdownSpellcheckAttribute } from './rich-markdown-spellcheck'
-import { autoFocusRichEditor } from './rich-markdown-auto-focus'
+import { useRichMarkdownPendingFocus } from './useRichMarkdownPendingFocus'
 import { useRichMarkdownSuperscriptLinkSetup } from './useRichMarkdownSuperscriptLinkSetup'
 import {
   formatSelectedHtmlSuperscriptLinkStatus,
@@ -80,11 +80,6 @@ export default function RichMarkdownEditor({
   const richMarkdownSpellcheckEnabled = settings?.richMarkdownSpellcheckEnabled ?? true
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const activateMarkdownLink = useAppStore((s) => s.activateMarkdownLink)
-  const pendingEditorFocusRequest = useAppStore((s) => {
-    const request = s.pendingEditorFocusRequest
-    return request?.fileId === fileId && request.worktreeId === worktreeId ? request : null
-  })
-  const consumeEditorFocusRequest = useAppStore((s) => s.consumeEditorFocusRequest)
   const addDiffComment = useAppStore((s) => s.addDiffComment)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
   const updateDiffComment = useAppStore((s) => s.updateDiffComment)
@@ -265,14 +260,7 @@ export default function RichMarkdownEditor({
     setDocLinkMenu: menu.setDocLinkMenu
   })
 
-  useEffect(() => {
-    if (!editor || !pendingEditorFocusRequest) {
-      return
-    }
-    cancelAutoFocusRef.current?.()
-    cancelAutoFocusRef.current = autoFocusRichEditor(editor, rootRef.current, true)
-    consumeEditorFocusRequest(pendingEditorFocusRequest.token)
-  }, [consumeEditorFocusRequest, editor, pendingEditorFocusRequest])
+  useRichMarkdownPendingFocus({ editor, fileId, worktreeId, rootRef, cancelAutoFocusRef })
 
   // Why: useEditor defaults shouldRerenderOnTransaction to false, so selection-only
   // citation NodeSelections would leave aria status stale without useEditorState.

--- a/src/renderer/src/components/editor/useRichMarkdownPendingFocus.ts
+++ b/src/renderer/src/components/editor/useRichMarkdownPendingFocus.ts
@@ -1,0 +1,39 @@
+import { useEffect, type RefObject } from 'react'
+import type { Editor } from '@tiptap/react'
+import { useAppStore } from '@/store'
+import { autoFocusRichEditor } from './rich-markdown-auto-focus'
+
+type PendingFocusOptions = {
+  editor: Editor | null
+  fileId: string
+  worktreeId: string
+  rootRef: RefObject<HTMLDivElement | null>
+  cancelAutoFocusRef: RefObject<(() => void) | null>
+}
+
+/**
+ * Focuses the editor when the Explorer opens this document for find (issue #8083), then consumes
+ * the request so a later remount of the same file does not steal focus again.
+ */
+export function useRichMarkdownPendingFocus({
+  editor,
+  fileId,
+  worktreeId,
+  rootRef,
+  cancelAutoFocusRef
+}: PendingFocusOptions): void {
+  const pendingEditorFocusRequest = useAppStore((s) => {
+    const request = s.pendingEditorFocusRequest
+    return request?.fileId === fileId && request.worktreeId === worktreeId ? request : null
+  })
+  const consumeEditorFocusRequest = useAppStore((s) => s.consumeEditorFocusRequest)
+
+  useEffect(() => {
+    if (!editor || !pendingEditorFocusRequest) {
+      return
+    }
+    cancelAutoFocusRef.current?.()
+    cancelAutoFocusRef.current = autoFocusRichEditor(editor, rootRef.current, true)
+    consumeEditorFocusRequest(pendingEditorFocusRequest.token)
+  }, [cancelAutoFocusRef, consumeEditorFocusRequest, editor, pendingEditorFocusRequest, rootRef])
+}


### PR DESCRIPTION
## Problem

`main` is currently red for every PR. Three tests have been failing since #9343 (`c2371c0cd8`) landed:

- `orca-runtime-terminal-retirement.test.ts` — "honors a legacy persisted tombstone before its first migration write", "publishes the host-rebased layout after a stale client pane update"
- `orca-runtime.test.ts` — "polls floating tabs with targeted PTY liveness and no repo/provider inventory"

#9343 added a repo gate to `hydrateHeadlessMobileSessionTabsFromWorkspaceSession` — a correct idea (don't hydrate a session key whose repo is gone) with two problems in how the inventory is read:

```ts
const liveRepoIds = new Set((this.store?.getRepos?.() ?? []).map((repo) => repo.id))
if (ownerRepoId && !liveRepoIds.has(ownerRepoId)) continue
```

1. **Fails closed instead of open.** `?? []` collapses *"the store cannot report repos"* into *"there are zero live repos"*. Every parseable `repoId::path` key is then skipped, so **nothing hydrates** — headless/mobile session tabs silently vanish rather than one stale key being pruned.
2. **Enumerates repos on a hot path.** `getRepos()` ran on every hydrate, including the floating-tab poll that `orca-runtime.test.ts` explicitly pins as free of repo/provider inventory work.

## Fix

Resolve the inventory lazily, and only for keys that actually parse to a repoId; keep `null` (unavailable) distinct from an empty list (all repos genuinely gone).

- Absent list → fail open and hydrate (a store with no `getRepos` no longer wipes tabs)
- Known list, repo missing → still skipped, exactly as #9343 intended
- Unparseable id (floating terminals have no `repoId::path`) → inventory never consulted, so the poll path stays clean

## Tests

#9343 shipped with no tests, which is how it broke three existing ones. Added `orca-runtime-headless-hydration-repo-gate.test.ts` covering all three properties above. Verified the two new behavioral tests fail without this fix and the gate-still-prunes test passes both before and after, so they pin the fix rather than the implementation.

Full `src/main/runtime/` suite: 2614 passed / 5 skipped. `oxlint` and `tsc --noEmit -p config/tsconfig.node.json` clean.

Not addressed here: whether the phantom-workspace scenario #9343 targeted also needs the delete-path/load-time complements it mentions (#9025, #9200) — this PR only repairs the regression.
