### PR TITLE
fix(terminal): keep the command exit status in OSC 133 precmd hooks

### DIFF
--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -98,7 +98,11 @@ async function runInteractiveZshRc(args: {
   return output
 }
 
-function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): string {
+function runInteractiveBashRcfile(
+  rcfileContent: string,
+  tempDir: string,
+  envOverrides: Record<string, string> = {}
+): string {
   const rcfile = join(tempDir, 'bash-osc133-rcfile')
   writeFileSync(rcfile, rcfileContent)
 
@@ -112,7 +116,8 @@ function runInteractiveBashRcfile(rcfileContent: string, tempDir: string): strin
         ...process.env,
         HOME: tempDir,
         ORCA_SHELL_READY_MARKER: '1',
-        TERM: process.env.TERM || 'xterm'
+        TERM: process.env.TERM || 'xterm',
+        ...envOverrides
       },
       timeout: 5000
     }
@@ -511,6 +516,27 @@ describePosix('daemon shell-ready launch config', () => {
       expectBashOsc133Lifecycle(output)
     }
   )
+
+  // Why: the precmd hook runs first in PROMPT_COMMAND, so leaking its own status makes
+  // prompt frameworks (powerline-go, starship) report a phantom failure every prompt.
+  itWithBash('passes the command exit status through to later prompt hooks', async () => {
+    const { getDaemonBashShellReadyRcfileContent } = await importFreshShellReady()
+    writeFileSync(
+      join(userDataPath, '.bash_profile'),
+      [
+        '__orca_exit_probe() { printf "EXIT_PROBE:%s\\n" "$?"; }',
+        "PROMPT_COMMAND='__orca_exit_probe'"
+      ].join('\n')
+    )
+
+    // Why: normal terminals run with the marker disabled, where the trailing marker test used to leak 1.
+    const output = runInteractiveBashRcfile(getDaemonBashShellReadyRcfileContent(), userDataPath, {
+      ORCA_SHELL_READY_MARKER: '0'
+    })
+
+    expect(output).toContain('EXIT_PROBE:0')
+    expect(output).toContain('EXIT_PROBE:1')
+  })
 
   itWithBash(
     'preserves prompt hooks and existing DEBUG traps without fake command markers',

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -139,6 +139,9 @@ __orca_osc133_precmd() {
   # so a framework that must be last in PROMPT_COMMAND — bash-preexec — is not
   # displaced by one of Orca's own hooks.
   [[ "\${ORCA_SHELL_READY_MARKER:-0}" == "1" ]] && printf "${SHELL_READY_MARKER}"
+  # Why: the marker test leaks its own status (1 when disabled), so restore the
+  # command's status or the user's prompt chain reports a phantom failure.
+  return "$exit_code"
 }
 __orca_run_user_debug_trap() {
   if [[ -n "\${__orca_user_debug_trap:-}" ]]; then
@@ -251,6 +254,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: printf would mask the command's status from later precmd hooks.
+  return "$exit_code"
 }
 __orca_osc133_preexec() {
   printf "\\033]133;C\\007"

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -143,6 +143,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: printf would mask the command's status from the user's prompt chain.
+  return "$exit_code"
 }
 __orca_osc133_prompt_done() {
   unset __orca_in_prompt_command
@@ -254,6 +256,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: printf would mask the command's status from later precmd hooks.
+  return "$exit_code"
 }
 __orca_osc133_preexec() {
   printf "\\033]133;C\\007"

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -161,6 +161,8 @@ __orca_osc133_precmd() {
     unset __orca_in_command
   fi
   printf "\\033]133;A\\007"
+  # Why: printf would mask the command's status from the user's prompt chain.
+  return "$exit_code"
 }
 __orca_osc133_prompt_done() {
   unset __orca_in_prompt_command


### PR DESCRIPTION
## Summary

In Orca's bash terminals, prompt frameworks such as powerline-go and starship render a permanent `ERROR` segment on every prompt, and — worse — never report a genuine command failure. The same shell outside Orca is fine, so it reads as a terminal bug.

`__orca_osc133_precmd` is prepended to `PROMPT_COMMAND`, so the status *it* returns is what the rest of the user's prompt chain reads as `$?`. The daemon bash wrapper ended on the shell-ready marker test:

```bash
[[ "${ORCA_SHELL_READY_MARKER:-0}" == "1" ]] && printf "\033]777;orca-shell-ready\007"
```

Whenever the marker is disabled — i.e. every prompt of a normal interactive terminal — that `&&` short-circuits and the function returns **1**, so the prompt reports a failure that never happened and the real status is already lost. The precmd hooks that end on `printf` have the mirror-image defect: they always return 0, so a real failure is reported to the prompt as success.

This returns the already-captured exit status at the end of every bash and zsh precmd hook (daemon, local PTY, and relay wrappers), which is what the PowerShell bootstrap already does deliberately — it captures `$global:?` first and re-asserts failure "for prompts that inspect it". The POSIX wrappers were simply missing that preservation.

Observed in real bash with a probe hook placed after Orca's in `PROMPT_COMMAND`, running `true` then `false`:

| | first prompt | after `true` | after `false` |
| --- | --- | --- | --- |
| before | 1 | 1 | 1 |
| after | 0 | 0 | 1 |

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — no new failures; local failures verified pre-existing (details below)
- [x] `pnpm build` — desktop bundle builds; `build:native` blocked by a local toolchain gap (details below)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New regression test in `src/main/daemon/shell-ready.test.ts` installs a probe hook after Orca's in `PROMPT_COMMAND` and asserts both `EXIT_PROBE:0` and `EXIT_PROBE:1` appear. Verified it fails on the pre-fix wrapper (missing `EXIT_PROBE:0`) and passes after, so it genuinely catches this regression rather than just covering the happy path.

The existing real-bash coverage missed this because `runInteractiveBashRcfile` always ran with `ORCA_SHELL_READY_MARKER=1` — the single case where the trailing marker test returns 0. The helper now accepts env overrides so the disabled-marker path (what every normal terminal uses) is exercised.

Being explicit about the two checks that are not a clean green locally, since I would rather flag it than tick a box:

- **`pnpm test`**: 35435 passed, 66 failed. I re-ran the 16 failing files on this branch and on its merge base and got exactly `66 failed | 1368 passed` on both, so none of them are caused by this change. Most of the local noise was self-inflicted: my global `commit.gpgsign = true` breaks the tests that build git fixtures (212 failures with signing on, 66 with it off). The three wrapper test files relevant here pass: `104 passed`.
- **`pnpm build`**: the electron-vite desktop bundle builds fine (9014 modules transformed). `build:native` fails on my machine in the macOS Swift `lipo` step (`lipo: no eligible inputs found`, alongside missing `/Library/Developer/CommandLineTools/Developer/...` search paths). I confirmed this reproduces on pristine `upstream/main` with none of my changes applied, so it is a local Xcode/Command-Line-Tools gap rather than a regression. This change touches no native or build code.

CI is the authoritative signal for both.

## AI Review Report

Reviewed with Claude Code. Risks checked: cross-platform compatibility, SSH/remote vs. local, shell-framework interaction, shell-ready/startup-command regression, performance, and security.

- **Cross-platform (macOS, Linux, Windows), explicitly checked.** The change is confined to POSIX shell text inside the bash and zsh wrapper templates. No path handling, keyboard shortcuts, shortcut labels, or Electron platform branches are touched. The Windows PowerShell bootstrap is untouched and was inspected: it already captures the success bit first and re-asserts failure before invoking the user's prompt, so all three platforms now preserve exit status consistently. `return` is POSIX shell builtin behavior, valid on the Git-for-Windows/WSL bash paths too.
- **SSH/remote vs. local.** The same hook exists in the relay wrapper (`src/relay/pty-shell-launch.ts`) and received the same fix, so SSH bash sessions behave like local ones. The relay zsh path defines no precmd hook, so there was nothing to change there. Confirmed 5 precmd hooks exist across the three wrapper modules and all 5 are now status-transparent.
- **Shell frameworks.** The hook keeps its position (prepended) and all emitted OSC sequences and their order are unchanged; only the function's return status changes. Existing bash-preexec / DEBUG-trap-rearm and prompt-hook tests still pass.
- **Startup-command readiness.** The shell-ready marker is emitted *before* the new `return`, so readiness detection is unaffected; verified the marker is still emitted the same number of times with `ORCA_SHELL_READY_MARKER=1`, and the OSC 133 C/D lifecycle assertions still hold.
- **Flagged during review and addressed.** The first pass fixed only the daemon bash hook that produced the reported phantom `ERROR`. Review surfaced that the four `printf`-terminated hooks silently mask real failures — the same defect with the opposite sign — so all five were made status-transparent in one change.
- **Performance.** One extra shell builtin per prompt; no measurable cost, nothing added to a hot path.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface is changed.

- `$exit_code` is a function-local integer captured from `$?` at hook entry and quoted at the return site. It is never interpolated into a command, path, or filename, so there is no injection or word-splitting surface; values are constrained to shell exit codes (0–255).
- No new dependencies, no new files written, no change to wrapper file locations or permissions (still `0644` under `userData`), and no change to what crosses the relay.
- Nothing sensitive is newly exposed: the fix makes an exit status the user's own prompt already intended to display accurate.
- No follow-up needed.

## Notes

- POSIX-only change (bash + zsh). Windows/PowerShell already had the equivalent preservation, so it needed no edit.
- Applies to local PTY, daemon, and SSH/relay bash sessions; existing installs pick it up when the wrapper files are regenerated, which happens whenever the generated content changes.
- The new test follows the file's existing platform gating (`describePosix` / `itWithBash`), so it is skipped on Windows and where bash is unavailable.
