### PR TITLE
test: realign sparse-checkout and PowerShell unit tests with shipped behavior

### DIFF
--- a/src/main/git/remove-worktree.test.ts
+++ b/src/main/git/remove-worktree.test.ts
@@ -8,12 +8,14 @@ const {
   gitExecFileSyncMock,
   translateWslOutputPathsMock,
   statMock,
+  readFileMock,
   resolveGitDirMock
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileSyncMock: vi.fn(),
   translateWslOutputPathsMock: vi.fn((output: string) => output),
   statMock: vi.fn(),
+  readFileMock: vi.fn(),
   resolveGitDirMock: vi.fn()
 }))
 
@@ -30,7 +32,7 @@ vi.mock('./status', () => ({
 
 vi.mock('fs/promises', async () => {
   const actual = await vi.importActual<typeof FsPromises>('fs/promises')
-  return { ...actual, stat: statMock }
+  return { ...actual, stat: statMock, readFile: readFileMock }
 })
 
 import { clearGitCapabilityStateForTests } from './git-capability-state'
@@ -85,6 +87,23 @@ function mockGitCommands(results: Record<string, MockResult>): void {
   })
 }
 
+function enoent(): Error {
+  return Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+}
+
+// Why: a non-empty pattern file is necessary but not sufficient — `git sparse-checkout disable`
+// leaves it behind, so detection also reads the gitdir config for core.sparseCheckout. Serve that
+// config only for the gitdirs a test wants sparse; everything else reads as absent.
+function mockSparseCheckoutEnabledFor(isSparseGitDirConfig: (configPath: string) => boolean): void {
+  readFileMock.mockImplementation(async (filePath: string) => {
+    const normalized = String(filePath).replaceAll('\\', '/')
+    if (normalized.endsWith('/config') && isSparseGitDirConfig(normalized)) {
+      return '[core]\n\tsparseCheckout = true\n'
+    }
+    throw enoent()
+  })
+}
+
 function getGitCalls(): string[] {
   return gitExecFileAsyncMock.mock.calls.map((call) => `git ${call[0].join(' ')}`)
 }
@@ -101,9 +120,11 @@ describe('removeWorktree', () => {
     translateWslOutputPathsMock.mockReset()
     translateWslOutputPathsMock.mockImplementation((output: string) => output)
     statMock.mockReset()
-    // Default: no worktree has a sparse-checkout config file. Tests that need
-    // sparse detection override this.
-    statMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    // Default: no worktree has a sparse-checkout pattern file, and no gitdir config enables
+    // sparse checkout. Tests that need sparse detection override both.
+    statMock.mockRejectedValue(enoent())
+    readFileMock.mockReset()
+    readFileMock.mockRejectedValue(enoent())
     resolveGitDirMock.mockReset()
     resolveGitDirMock.mockImplementation(async (worktreePath: string) => `${worktreePath}/.git`)
   })
@@ -936,9 +957,11 @@ describe('listWorktrees', () => {
     translateWslOutputPathsMock.mockReset()
     translateWslOutputPathsMock.mockImplementation((output: string) => output)
     statMock.mockReset()
-    // Default: no worktree has a sparse-checkout config file. Tests that need
-    // sparse detection override this.
-    statMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    // Default: no worktree has a sparse-checkout pattern file, and no gitdir config enables
+    // sparse checkout. Tests that need sparse detection override both.
+    statMock.mockRejectedValue(enoent())
+    readFileMock.mockReset()
+    readFileMock.mockRejectedValue(enoent())
     resolveGitDirMock.mockReset()
     resolveGitDirMock.mockImplementation(async (worktreePath: string) => `${worktreePath}/.git`)
   })
@@ -1087,8 +1110,9 @@ describe('listWorktrees', () => {
       if (filePath.includes('repo-feature') && filePath.includes('sparse-checkout')) {
         return { isFile: () => true, size: 32 }
       }
-      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      throw enoent()
     })
+    mockSparseCheckoutEnabledFor((configPath) => configPath.includes('repo-feature'))
 
     const worktrees = await listWorktrees('\\\\wsl.localhost\\Ubuntu\\home\\me\\repo')
 
@@ -1143,8 +1167,9 @@ describe('listWorktrees', () => {
       if (filePath.replaceAll('\\', '/').includes(sparseWorktreePath)) {
         return { isFile: () => true, size: 32 }
       }
-      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      throw enoent()
     })
+    mockSparseCheckoutEnabledFor((configPath) => configPath.includes(sparseWorktreePath))
 
     let completed = false
     const listPromise = listWorktrees('/repo').finally(() => {
@@ -1256,9 +1281,11 @@ describe('addSparseWorktree', () => {
     translateWslOutputPathsMock.mockReset()
     translateWslOutputPathsMock.mockImplementation((output: string) => output)
     statMock.mockReset()
-    // Default: no worktree has a sparse-checkout config file. Tests that need
-    // sparse detection override this.
-    statMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
+    // Default: no worktree has a sparse-checkout pattern file, and no gitdir config enables
+    // sparse checkout. Tests that need sparse detection override both.
+    statMock.mockRejectedValue(enoent())
+    readFileMock.mockReset()
+    readFileMock.mockRejectedValue(enoent())
     resolveGitDirMock.mockReset()
     resolveGitDirMock.mockImplementation(async (worktreePath: string) => `${worktreePath}/.git`)
   })

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -224,10 +224,7 @@ import {
 import { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { hasLiveClaudePtys, markClaudePtySpawned } from '../claude-accounts/live-pty-gate'
 import * as livePtyGate from '../claude-accounts/live-pty-gate'
-import {
-  encodePowerShellCommand,
-  getPowerShellOsc133Bootstrap
-} from '../powershell-osc133-bootstrap'
+import { getPowerShellOsc133Bootstrap } from '../powershell-osc133-bootstrap'
 import {
   SSH_PTY_IDENTITY_MISMATCH_ERROR,
   SSH_SESSION_EXPIRED_ERROR
@@ -235,12 +232,17 @@ import {
 import { _resetWslCachesForTests, _setWslCachesForTests } from '../wsl'
 import { acquireWatcherRemovalGate } from './watcher-removal-gate'
 
-const POWERSHELL_OSC133_ARGS = [
-  '-NoLogo',
-  '-NoExit',
-  '-EncodedCommand',
-  encodePowerShellCommand(getPowerShellOsc133Bootstrap())
-]
+// Why: the encoded payload also carries a cwd-dependent Set-Location suffix (PR #7435), so assert
+// the arg shape plus the bootstrap it must contain; windows-shell-args.test.ts owns the exact
+// payload contract.
+function expectPowerShellOsc133Spawn(expectedShell: string): void {
+  const [shell, shellArgs] = spawnMock.mock.calls.at(-1) ?? []
+  expect(shell).toBe(expectedShell)
+  expect(shellArgs?.slice(0, 3)).toEqual(['-NoLogo', '-NoExit', '-EncodedCommand'])
+  expect(Buffer.from(shellArgs?.[3] ?? '', 'base64').toString('utf16le')).toContain(
+    getPowerShellOsc133Bootstrap()
+  )
+}
 // Why: Windows resolves a bare PowerShell name to an absolute exe before ConPTY, else CreateProcessW fails with error 5 (PR #6537 / #5161).
 const RESOLVED_WINDOWS_POWERSHELL = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 const RESOLVED_PWSH7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
@@ -8220,11 +8222,7 @@ describe('registerPtyHandlers', () => {
       registerPtyHandlers(mainWindow as never)
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
-        POWERSHELL_OSC133_ARGS,
-        expect.any(Object)
-      )
+      expectPowerShellOsc133Spawn('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
     })
 
     it('sets Console encoding for pwsh.exe', async () => {
@@ -8233,11 +8231,7 @@ describe('registerPtyHandlers', () => {
       registerPtyHandlers(mainWindow as never)
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
-        POWERSHELL_OSC133_ARGS,
-        expect.any(Object)
-      )
+      expectPowerShellOsc133Spawn('C:\\Program Files\\PowerShell\\7\\pwsh.exe')
     })
 
     it('sets PYTHONUTF8=1 in the spawn environment on Windows', async () => {
@@ -8293,11 +8287,7 @@ describe('registerPtyHandlers', () => {
       )
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        RESOLVED_WINDOWS_POWERSHELL,
-        POWERSHELL_OSC133_ARGS,
-        expect.any(Object)
-      )
+      expectPowerShellOsc133Spawn(RESOLVED_WINDOWS_POWERSHELL)
     })
 
     it('uses the host shell when resolved project runtime overrides a stale WSL shell default', async () => {
@@ -8417,11 +8407,7 @@ describe('registerPtyHandlers', () => {
       )
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        RESOLVED_WINDOWS_POWERSHELL,
-        POWERSHELL_OSC133_ARGS,
-        expect.any(Object)
-      )
+      expectPowerShellOsc133Spawn(RESOLVED_WINDOWS_POWERSHELL)
     })
 
     it('spawns pwsh.exe when PowerShell 7 is selected and available', async () => {
@@ -8440,11 +8426,7 @@ describe('registerPtyHandlers', () => {
       )
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        RESOLVED_PWSH7,
-        POWERSHELL_OSC133_ARGS,
-        expect.any(Object)
-      )
+      expectPowerShellOsc133Spawn(RESOLVED_PWSH7)
     })
 
     it('keeps PowerShell 7 selected when the pwsh availability probe is cold-false', async () => {
@@ -8463,11 +8445,7 @@ describe('registerPtyHandlers', () => {
       )
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24 })
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        RESOLVED_PWSH7,
-        POWERSHELL_OSC133_ARGS,
-        expect.any(Object)
-      )
+      expectPowerShellOsc133Spawn(RESOLVED_PWSH7)
       expect(isPwshAvailableMock).not.toHaveBeenCalled()
     })
 
@@ -8487,11 +8465,7 @@ describe('registerPtyHandlers', () => {
       )
       await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, shellOverride: 'pwsh.exe' })
 
-      expect(spawnMock).toHaveBeenCalledWith(
-        RESOLVED_PWSH7,
-        POWERSHELL_OSC133_ARGS,
-        expect.any(Object)
-      )
+      expectPowerShellOsc133Spawn(RESOLVED_PWSH7)
       expect(isPwshAvailableMock).not.toHaveBeenCalled()
     })
 


### PR DESCRIPTION
## Summary

No user-visible change — test-only. Repairs 10 unit tests on `main` that two PRs merged this morning invalidated. Because PR Checks merges each PR into `main`, these failures were breaking `verify` for every other open PR.

Both merged PRs are correct; only their stale test expectations are fixed here.

| Cluster | Broken by | Root cause |
|---|---|---|
| 3 × `remove-worktree.test.ts` | `e3cc08f185` (#9922) | Sparse detection now confirms `core.sparseCheckout` with a `readFile` after the `stat` fast-path. The harness mocked only `stat`, so the new read hit the **real** filesystem: sparse worktrees read back as non-sparse, and the real async I/O broke the microtask drain `bounds concurrent sparse-checkout filesystem probes` depends on — leaving a pending `listWorktrees` that leaked into the next test (which is why the third failure passes in isolation). Now mocks `readFile` alongside `stat`. |
| 7 × `pty.test.ts` | `c1d2c4be08` (#7435) | The PowerShell `-EncodedCommand` payload became **cwd-dependent** (a trailing `Set-Location` to the PTY cwd), so equality against `encodePowerShellCommand(getPowerShellOsc133Bootstrap())` can never hold again. These cases are about *which exe* gets spawned in the OSC 133 encoded form, so they now assert the arg shape plus the decoded bootstrap; `windows-shell-args.test.ts` (updated by #7435) remains the owner of the exact payload contract. |

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — clean for this diff. Still reports the **pre-existing** `RichMarkdownEditor.tsx` max-lines error that landed with #8083; that one is fixed in #10437, not here. See merge order below.
- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — the 10 tests above now pass. Full-suite run also shows the 3 `orca-runtime` failures fixed by #10437, plus ~47 failures in 13 files that reproduce identically on stock `main` (`b71f71904f`) with none of these commits — pre-existing and out of scope.
- [ ] `pnpm build` — not run; this PR touches only two `.test.ts` files, no production code.
- [x] Tests are the deliverable here.

### Merge order

`main` is red in four independent clusters. This PR fixes two of them; #10437 fixes the other two (the #9343 runtime cluster and the #8083 max-lines lint). **Land #10437 first** — until it does, this PR's `verify` will fail on that inherited lint error, since lint runs before tests.

## AI Review Report

Self-reviewed the diff. Checks run:

- **Did the production fixes stay untouched?** Yes — the diff is two `.test.ts` files. #9922's and #7435's shipped behavior is unchanged, and both keep their own regression tests (`worktree-sparse-checkout.test.ts`, `windows-shell-args.test.ts`).
- **Do the repaired tests still fail for the right reasons?** The sparse tests still assert `isSparse: true` via a mocked git config, so a regression that stops honoring `core.sparseCheckout` still fails them. The pty tests still assert the resolved exe and that the OSC 133 bootstrap is delivered encoded.
- **Cross-platform (macOS / Linux / Windows):** both clusters are Windows- and WSL-behavior tests that run on every platform. The new config-path matcher normalizes `\` to `/` before matching, so it holds under both `path.join` flavors; no `process.platform` assumptions were added.
- **Test-isolation risk:** the probe-concurrency failure was leaking state into a later test. Fixed at the source (mock the I/O) rather than by loosening the follow-on assertion.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface is touched — the diff only adds mock plumbing inside two test files. The mocked git-config content is a fixed literal; no fixture reaches a real filesystem or subprocess. Nothing to follow up.

## Notes

- Fixing these in tests (not production) is deliberate: both merged PRs describe intended behavior changes and shipped their own tests for them. The failures were stale expectations elsewhere in the suite that CI never re-ran against them before merge.
- `remove-worktree.test.ts` gained a shared `mockSparseCheckoutEnabledFor` helper so future sparse cases don't re-learn that a pattern file alone no longer implies sparse.