### PR TITLE
test(runtime): guard both halves of the headless hydrate repo gate

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1846,8 +1846,30 @@ describe('OrcaRuntimeService', () => {
     expect(hasPty).toHaveBeenCalledTimes(4)
     expect(hasPty).toHaveBeenCalledWith(floatingPtyId)
     expect(listProcesses).not.toHaveBeenCalled()
-    // Why: headless hydrate may consult getRepos to skip tabs for deleted repos;
-    // floating liveness must still avoid provider process inventory scans.
+    // Why: a floating tab's worktree id carries no repoId, so the hydrate repo gate
+    // must never resolve the inventory for it — #9343 made that read eager and
+    // regressed this poll path. Keep both halves of the contract asserted.
+    expect(getRepos).not.toHaveBeenCalled()
+  })
+
+  it('hydrates persisted tabs when the store cannot report repos', async () => {
+    // Why: #9343 read the repo gate as `getRepos?.() ?? []`, so a store that cannot
+    // report its inventory looked like "every repo is gone" and hydrated nothing —
+    // every tab vanished. An unavailable list must fail open; only a list the store
+    // actually returned may prune a dead repo's session key.
+    const { runtimeStore } = makeRuntimeStoreWithWorkspaceSession(
+      makeWorkspaceSessionWithHeadlessTerminal()
+    )
+    const runtime = new OrcaRuntimeService({
+      ...runtimeStore,
+      getRepos: () => undefined
+    } as never)
+
+    const tabs = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+
+    expect(tabs.tabs).toEqual([
+      expect.objectContaining({ type: 'terminal', parentTabId: 'host-tab' })
+    ])
   })
 
   it('advertises browser screencast only when a renderer window is available', () => {


### PR DESCRIPTION
## Summary

No user-visible change — test-only. #10437 fixed two real behaviors, but **neither is asserted on `main` today**, so a revert of either would land silently. This adds a guard for each.

#9343 broke two contracts at once:

1. **Fail-open on an unavailable inventory.** The gate read `this.store?.getRepos?.() ?? []`, so a store that *cannot* report repos yielded an empty set — indistinguishable from "every repo is gone" — and hydrated zero tabs.
2. **The floating-tab poll stays inventory-free.** The gate resolved `getRepos` eagerly on every hydrate, including the hot poll path that is contractually free of repo/provider inventory work.

#10437 fixed both. But the way the failing tests were repaired in `772081577e` (#10429) left both unguarded:

- The poll test's `expect(getRepos).not.toHaveBeenCalled()` was **deleted** and replaced with a comment saying hydrate "may consult getRepos".
- `orca-runtime-terminal-retirement.test.ts` was given `getRepos: () => [LIVE_REPO]`, so its store always reports a live repo and never exercises the unavailable case.

## Screenshots

No visual change.

## Testing

- [x] `pnpm typecheck` — passes
- [x] `pnpm test` — `src/main/runtime/` = 2623 passed, 1 skipped
- [x] `pnpm lint` — oxlint clean on the touched file (via lint-staged)
- [ ] `pnpm build` — not run; this PR touches one `.test.ts` file, no production code.
- [x] **Both guards verified to fail against the pre-#10437 code**, not just to pass against the current code:

  | Guard | Regression reintroduced | Result |
  |---|---|---|
  | Poll stays inventory-free | eager `new Set((getRepos?.() ?? []).map(...))` | `expected "vi.fn()" to not be called at all, but actually been called 2 times` |
  | Fail open when unavailable | `new Set((knownRepos ?? []).map(...))` — laziness kept, `null` collapsed | `expected [] to deeply equal [ ObjectContaining{…} ]` |

  The production file is byte-identical to `main` in this PR; the reverts above were local scratch edits, used only to confirm each assertion has teeth.

### Note on the first attempt

My initial fail-open test lived in `orca-runtime-terminal-retirement.test.ts` and **passed even with the regression reintroduced** — `syncSplit()` populates the tabs in memory, so hydration never ran and the assertion proved nothing. It's rewritten here against `makeWorkspaceSessionWithHeadlessTerminal()`, which reaches the gate for real. Flagging it because a green test that cannot fail is worse than no test.

## AI Review Report

Self-reviewed. Checks run:

- **Does this reverse a deliberate decision?** #10429's comment frames the relaxation as intentional ("headless hydrate may consult getRepos"), and that was accurate *at the time* — the gate was eager, so the assertion could not hold. #10437 then made it lazy, which makes the original contract true again. This restores it rather than overriding a still-valid call.
- **Is the poll assertion correct post-#10437?** Yes. A floating tab's worktree id carries no `repoId`, so `splitWorktreeIdForFilesystem(...)?.repoId` is undefined and the lazy resolve is never triggered for it. Verified by the passing run.
- **Cross-platform (macOS / Linux / Windows):** no platform-dependent behavior; no paths, shells, or accelerators involved.
- **Scope:** one test file, no production change, no new helpers beyond the two cases.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface touched — two test cases against an in-memory store mock. Nothing to follow up.

## Notes

- Prompted by review of the main-red cleanup: `772081577e` (#10429) and #10437 both touched `orca-runtime.ts`, and the merge kept #10429's relaxed test alongside #10437's fix. The behavior is correct on `main` today; only the coverage was missing.