### PR TITLE
Fix bulk detach for selected child worktrees

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.bulk-detach.render.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.bulk-detach.render.test.tsx
@@ -1,0 +1,185 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree, WorktreeLineage } from '../../../../shared/types'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+// Why: this test pins the HANDLER wiring — bulk "Remove from Parent" must dispatch
+// noParent only for selected rows that actually carry a parent link. The pure filter
+// is covered in WorktreeContextMenu.test.ts; here the real component is mounted so a
+// regression that reconnects the handler to the unfiltered selection fails loudly.
+
+const mockState = vi.hoisted(() => ({ current: {} as Record<string, unknown> }))
+
+vi.mock('@/store', () => {
+  const useAppStore = ((selector: (state: Record<string, unknown>) => unknown) =>
+    selector(mockState.current)) as ((
+    selector: (state: Record<string, unknown>) => unknown
+  ) => unknown) & { getState: () => Record<string, unknown> }
+  useAppStore.getState = () => mockState.current
+  return { useAppStore }
+})
+
+vi.mock('@/store/selectors', () => ({
+  useAllWorktrees: () => [],
+  useRepoById: () => null,
+  useRepoMap: () => new Map(),
+  useWorktreeMap: () => new Map()
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onSelect }: { children: ReactNode; onSelect?: () => void }) => (
+    <button type="button" onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuRadioItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuSub: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuSubContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/hooks/useVirtualizedScrollAnchor', () => ({
+  VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT: 'orca:test-record-scroll-anchor'
+}))
+
+vi.mock('./delete-worktree-flow', () => ({
+  runWorktreeBatchDelete: vi.fn(),
+  runWorktreeDelete: vi.fn()
+}))
+
+vi.mock('./sleep-worktree-flow', () => ({ runSleepWorktrees: vi.fn() }))
+
+vi.mock('@/lib/worktree-activation', () => ({ activateAndRevealWorktree: vi.fn() }))
+
+vi.mock('./WorktreeOpenInMenu', () => ({ WorktreeOpenInSubMenu: () => null }))
+vi.mock('./ProjectGroupNameDialog', () => ({ ProjectGroupNameDialog: () => null }))
+vi.mock('./WorktreeParentPickerPopover', () => ({ WorktreeParentPickerPopover: () => null }))
+
+import WorktreeContextMenu from './WorktreeContextMenu'
+
+function makeWorktree(id: string, displayName: string): Worktree {
+  return {
+    id,
+    instanceId: `${id}-instance`,
+    repoId: 'repo',
+    path: `/tmp/bulk-detach/${displayName}`,
+    displayName,
+    branch: displayName,
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1
+  } as Worktree
+}
+
+function makeLineage(childId: string, parentId: string): WorktreeLineage {
+  return {
+    worktreeId: childId,
+    worktreeInstanceId: `${childId}-instance`,
+    parentWorktreeId: parentId,
+    parentWorktreeInstanceId: `${parentId}-instance`,
+    origin: 'cli',
+    capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+describe('bulk Remove from Parent handler targeting', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+  })
+
+  it('dispatches noParent only for selected rows with a parent link', async () => {
+    const parentNoLineage = makeWorktree('repo::parent', 'parent')
+    const child = makeWorktree('repo::child', 'child')
+    const updateWorktreeLineage = vi.fn(() => Promise.resolve())
+    mockState.current = {
+      updateWorktreeMeta: vi.fn(),
+      setWorktreesPinnedAndReveal: vi.fn(),
+      workspaceStatuses: [],
+      openModal: vi.fn(),
+      projectGroups: [],
+      createProjectGroup: vi.fn(),
+      moveProjectToGroup: vi.fn(),
+      deleteFolderWorkspace: vi.fn(),
+      setActiveWorktree: vi.fn(),
+      deleteStateByWorktreeId: {},
+      worktreeLineageById: { [child.id]: makeLineage(child.id, parentNoLineage.id) },
+      workspaceLineageByChildKey: {},
+      updateWorktreeLineage,
+      tabsByWorktree: {},
+      ptyIdsByTabId: {},
+      browserTabsByWorktree: {}
+    }
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root.render(
+        <WorktreeContextMenu worktree={child} selectedWorktrees={[parentNoLineage, child]}>
+          <div data-testid="child-row">child row</div>
+        </WorktreeContextMenu>
+      )
+    })
+
+    const row = container.querySelector('[data-testid="child-row"]')
+    expect(row).not.toBeNull()
+    act(() => {
+      row!.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }))
+    })
+
+    const removeFromParent = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Remove from Parent')
+    )
+    expect(removeFromParent).toBeDefined()
+    // Why: the menu suppresses clicks within 500ms of opening (macOS ctrl-click
+    // guard); jump past the window so the item click is not swallowed.
+    const realNow = Date.now()
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(realNow + 1_000)
+    try {
+      await act(async () => {
+        removeFromParent!.click()
+        await Promise.resolve()
+      })
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    // The lineage-free parent must NOT receive a detach; only the child carries a link.
+    expect(updateWorktreeLineage).toHaveBeenCalledTimes(1)
+    expect(updateWorktreeLineage).toHaveBeenCalledWith(child.id, { noParent: true })
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -9,6 +9,7 @@ import {
   shouldContinueDeleteSiblingPositionRestore,
   getWorktreeParentPickerAnchor,
   getWorktreeParentPickerLabel,
+  getDetachableContextWorktrees,
   hasWorktreeParentLink,
   isWorktreeParentPickerDisabled,
   planWorkspaceStatusAssignment,
@@ -142,6 +143,44 @@ describe('shouldContinueDeleteSiblingPositionRestore', () => {
 })
 
 describe('parent picker context menu affordance', () => {
+  it('targets every selected worktree with a parent and skips unattached selections', () => {
+    const attached = {
+      id: 'repo::attached',
+      instanceId: 'attached-instance'
+    } as Worktree
+    const alsoAttached = {
+      id: 'repo::also-attached',
+      instanceId: 'also-attached-instance'
+    } as Worktree
+    const unattached = { id: 'repo::unattached', instanceId: 'unattached-instance' } as Worktree
+    const lineageById: Record<string, WorktreeLineage> = {
+      [attached.id]: {
+        worktreeId: attached.id,
+        worktreeInstanceId: 'attached-instance',
+        parentWorktreeId: 'repo::parent',
+        parentWorktreeInstanceId: 'parent-instance',
+        origin: 'cli',
+        capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
+        createdAt: 1
+      },
+      [alsoAttached.id]: {
+        worktreeId: alsoAttached.id,
+        worktreeInstanceId: 'also-attached-instance',
+        parentWorktreeId: 'repo::parent',
+        parentWorktreeInstanceId: 'parent-instance',
+        origin: 'cli',
+        capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
+        createdAt: 1
+      }
+    }
+
+    expect(
+      getDetachableContextWorktrees([attached, unattached, alsoAttached], lineageById, {}).map(
+        (worktree) => worktree.id
+      )
+    ).toEqual([attached.id, alsoAttached.id])
+  })
+
   it('offers unlink for valid inline-only legacy lineage after stable-update hydration', () => {
     const parent = { id: 'repo::parent', instanceId: 'parent-instance' }
     const lineage: WorktreeLineage = {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts
@@ -10,6 +10,7 @@ import {
   getWorktreeParentPickerAnchor,
   getWorktreeParentPickerLabel,
   getDetachableContextWorktrees,
+  runBulkDetachFromParent,
   hasWorktreeParentLink,
   isWorktreeParentPickerDisabled,
   planWorkspaceStatusAssignment,
@@ -142,45 +143,105 @@ describe('shouldContinueDeleteSiblingPositionRestore', () => {
   })
 })
 
-describe('parent picker context menu affordance', () => {
-  it('targets every selected worktree with a parent and skips unattached selections', () => {
-    const attached = {
-      id: 'repo::attached',
-      instanceId: 'attached-instance'
-    } as Worktree
-    const alsoAttached = {
-      id: 'repo::also-attached',
-      instanceId: 'also-attached-instance'
-    } as Worktree
-    const unattached = { id: 'repo::unattached', instanceId: 'unattached-instance' } as Worktree
-    const lineageById: Record<string, WorktreeLineage> = {
-      [attached.id]: {
-        worktreeId: attached.id,
-        worktreeInstanceId: 'attached-instance',
-        parentWorktreeId: 'repo::parent',
-        parentWorktreeInstanceId: 'parent-instance',
-        origin: 'cli',
-        capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
-        createdAt: 1
-      },
-      [alsoAttached.id]: {
-        worktreeId: alsoAttached.id,
-        worktreeInstanceId: 'also-attached-instance',
-        parentWorktreeId: 'repo::parent',
-        parentWorktreeInstanceId: 'parent-instance',
-        origin: 'cli',
-        capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
-        createdAt: 1
-      }
-    }
+describe('bulk detach target selection', () => {
+  // A three-generation tree: grandparent <- parent <- child, plus a lineage-free
+  // standalone row and a folder workspace (never a git worktree, never a lineage child).
+  const grandparent = { id: 'repo::grandparent', displayName: 'grandparent' } as Worktree
+  const parent = { id: 'repo::parent', displayName: 'parent' } as Worktree
+  const child = { id: 'repo::child', displayName: 'child' } as Worktree
+  const otherParent = { id: 'repo::other-parent', displayName: 'other-parent' } as Worktree
+  const otherChild = { id: 'repo::other-child', displayName: 'other-child' } as Worktree
+  const standalone = { id: 'repo::standalone', displayName: 'standalone' } as Worktree
+  const folderWorkspace = { id: 'folder:fw-1', displayName: 'a folder' } as Worktree
 
-    expect(
-      getDetachableContextWorktrees([attached, unattached, alsoAttached], lineageById, {}).map(
-        (worktree) => worktree.id
-      )
-    ).toEqual([attached.id, alsoAttached.id])
+  function lineage(childId: string, parentId: string): WorktreeLineage {
+    return {
+      worktreeId: childId,
+      worktreeInstanceId: `${childId}-instance`,
+      parentWorktreeId: parentId,
+      parentWorktreeInstanceId: `${parentId}-instance`,
+      origin: 'cli',
+      capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
+      createdAt: 1
+    }
+  }
+
+  const lineageById: Record<string, WorktreeLineage> = {
+    [parent.id]: lineage(parent.id, grandparent.id),
+    [child.id]: lineage(child.id, parent.id),
+    [otherChild.id]: lineage(otherChild.id, otherParent.id)
+  }
+
+  const detachIds = (selection: readonly Worktree[]): string[] =>
+    getDetachableContextWorktrees(selection, lineageById, {}).map((worktree) => worktree.id)
+
+  it('detaches every selected child across multiple parents', () => {
+    expect(detachIds([child, otherChild])).toEqual([child.id, otherChild.id])
   })
 
+  it('skips selected rows that have no parent link', () => {
+    expect(detachIds([child, standalone, otherChild])).toEqual([child.id, otherChild.id])
+  })
+
+  // Why: the classic bug. Selecting a parent AND its own child must detach each row from
+  // its OWN parent exactly once — the child is never detached twice, and the parent is
+  // detached from the grandparent rather than being silently orphaned or skipped.
+  it('detaches a selected parent and its selected child exactly once each', () => {
+    const targets = detachIds([parent, child])
+    expect(targets).toEqual([parent.id, child.id])
+    expect(new Set(targets).size).toBe(targets.length)
+  })
+
+  it('detaches a lone selected parent from its own grandparent', () => {
+    expect(detachIds([parent])).toEqual([parent.id])
+  })
+
+  it('detaches the whole tree without duplicating any row', () => {
+    const targets = detachIds([grandparent, parent, child])
+    // grandparent is a root: it has no parent link, so it is not a detach target.
+    expect(targets).toEqual([parent.id, child.id])
+  })
+
+  // Folder workspaces are not git worktrees and are never lineage children, so a mixed
+  // selection must exclude them rather than dispatching a detach that cannot resolve.
+  it('excludes folder workspaces from a mixed selection', () => {
+    expect(detachIds([folderWorkspace, child])).toEqual([child.id])
+    expect(detachIds([folderWorkspace])).toEqual([])
+  })
+
+  it('detaches nothing when the selection has no lineage at all', () => {
+    expect(detachIds([standalone, grandparent])).toEqual([])
+  })
+})
+
+describe('bulk detach partial failure reporting', () => {
+  const first = { id: 'repo::first', displayName: 'first' } as Worktree
+  const second = { id: 'repo::second', displayName: 'second' } as Worktree
+  const third = { id: 'repo::third', displayName: 'third' } as Worktree
+
+  it('reports every row as detached when all succeed', async () => {
+    const result = await runBulkDetachFromParent([first, second], () => Promise.resolve())
+    expect(result).toEqual({ detachedIds: [first.id, second.id], failedNames: [] })
+  })
+
+  // Why: a selection can span hosts, and updateWorktreeLineage rejects per row. One
+  // failing row must not abort the others, and the user must learn WHICH row failed.
+  it('detaches the surviving rows and names only the failed one', async () => {
+    const result = await runBulkDetachFromParent([first, second, third], (worktreeId) =>
+      worktreeId === second.id ? Promise.reject(new Error('host ambiguous')) : Promise.resolve()
+    )
+    expect(result.detachedIds).toEqual([first.id, third.id])
+    expect(result.failedNames).toEqual([second.displayName])
+  })
+
+  it('falls back to the worktree id when a failed row has no display name', async () => {
+    const unnamed = { id: 'repo::unnamed', displayName: '' } as Worktree
+    const result = await runBulkDetachFromParent([unnamed], () => Promise.reject(new Error('nope')))
+    expect(result).toEqual({ detachedIds: [], failedNames: [unnamed.id] })
+  })
+})
+
+describe('parent picker context menu affordance', () => {
   it('offers unlink for valid inline-only legacy lineage after stable-update hydration', () => {
     const parent = { id: 'repo::parent', instanceId: 'parent-instance' }
     const lineage: WorktreeLineage = {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -114,6 +114,16 @@ export function hasWorktreeParentLink(
   )
 }
 
+export function getDetachableContextWorktrees(
+  worktrees: readonly Worktree[],
+  lineageById: AppState['worktreeLineageById'],
+  workspaceLineageByChildKey: AppState['workspaceLineageByChildKey']
+): Worktree[] {
+  return worktrees.filter((worktree) =>
+    hasWorktreeParentLink(worktree, lineageById, workspaceLineageByChildKey)
+  )
+}
+
 function shouldUseNativeContextMenu(target: EventTarget | null): boolean {
   const maybeElement = target as {
     closest?: (selector: string) => Element | null
@@ -441,8 +451,14 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     [cyclicLineageIds, worktree, worktreeLineageById, worktreeMap]
   )
   const validParentWorktreeId = lineageInfo.state === 'valid' ? lineageInfo.parent.id : null
-  const hasAnyContextLineage = activeContextWorktrees.some((item) =>
-    hasWorktreeParentLink(item, worktreeLineageById, workspaceLineageByChildKey)
+  const detachableContextWorktrees = useMemo(
+    () =>
+      getDetachableContextWorktrees(
+        activeContextWorktrees,
+        worktreeLineageById,
+        workspaceLineageByChildKey
+      ),
+    [activeContextWorktrees, workspaceLineageByChildKey, worktreeLineageById]
   )
   const eligibleParentCount = useMemo(
     () =>
@@ -669,9 +685,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
 
   const handleRemoveParentLink = useCallback(() => {
     void Promise.all(
-      activeContextWorktrees.map((item) => updateWorktreeLineage(item.id, { noParent: true }))
+      detachableContextWorktrees.map((item) => updateWorktreeLineage(item.id, { noParent: true }))
     )
-  }, [activeContextWorktrees, updateWorktreeLineage])
+  }, [detachableContextWorktrees, updateWorktreeLineage])
 
   const suppressOpeningPointerEvent = useCallback((event: React.SyntheticEvent) => {
     const contextMenuOpenedAt = contextMenuOpenedAtRef.current
@@ -911,7 +927,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
               )}
             </>
           )}
-          {isMultiContext && hasAnyContextLineage ? (
+          {isMultiContext && detachableContextWorktrees.length > 0 ? (
             <>
               <DropdownMenuItem onSelect={handleRemoveParentLink} disabled={deletingContext}>
                 <Unlink className="size-3.5" />

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: this menu keeps row targeting, batch actions, and ctrl-click event guards together so nested worktree menus share one event policy. */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -114,6 +115,11 @@ export function hasWorktreeParentLink(
   )
 }
 
+// Why: bulk detach must target only the selected rows that actually carry a parent
+// link. Dispatching `noParent` for every selected row also clears the lineage of a
+// selected PARENT (unlinking it from its own grandparent), which the user never asked
+// for. Folder workspaces are excluded implicitly — they are never lineage children,
+// so they never hold a parent link.
 export function getDetachableContextWorktrees(
   worktrees: readonly Worktree[],
   lineageById: AppState['worktreeLineageById'],
@@ -122,6 +128,31 @@ export function getDetachableContextWorktrees(
   return worktrees.filter((worktree) =>
     hasWorktreeParentLink(worktree, lineageById, workspaceLineageByChildKey)
   )
+}
+
+// Why: `updateWorktreeLineage` resolves per-worktree owner settings and rejects when a
+// row's host identity is ambiguous, so a selection spanning hosts can fail for only some
+// rows. Detach every row independently and name the ones still attached, so a partial
+// bulk detach is retryable instead of collapsing into one generic error.
+export async function runBulkDetachFromParent(
+  targets: readonly Worktree[],
+  detach: (worktreeId: string) => Promise<unknown>
+): Promise<{ detachedIds: string[]; failedNames: string[] }> {
+  const outcomes = await Promise.all(
+    targets.map((item) =>
+      detach(item.id).then(
+        () => ({ item, ok: true }),
+        (err: unknown) => {
+          console.error('Failed to detach workspace from parent:', item.id, err)
+          return { item, ok: false }
+        }
+      )
+    )
+  )
+  return {
+    detachedIds: outcomes.filter((o) => o.ok).map((o) => o.item.id),
+    failedNames: outcomes.filter((o) => !o.ok).map((o) => o.item.displayName || o.item.id)
+  }
 }
 
 function shouldUseNativeContextMenu(target: EventTarget | null): boolean {
@@ -684,9 +715,26 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   )
 
   const handleRemoveParentLink = useCallback(() => {
-    void Promise.all(
-      detachableContextWorktrees.map((item) => updateWorktreeLineage(item.id, { noParent: true }))
-    )
+    void runBulkDetachFromParent(detachableContextWorktrees, (worktreeId) =>
+      updateWorktreeLineage(worktreeId, { noParent: true })
+    ).then(({ detachedIds, failedNames }) => {
+      if (failedNames.length === 0) {
+        return
+      }
+      toast.error(
+        translate(
+          'auto.components.sidebar.WorktreeContextMenu.failedDetachFromParent',
+          'Failed to remove some workspaces from their parent'
+        ),
+        {
+          description: translate(
+            'auto.components.sidebar.WorktreeContextMenu.failedDetachFromParentDetail',
+            'Detached {{value0}}. Still attached: {{value1}}.',
+            { value0: detachedIds.length, value1: failedNames.join(', ') }
+          )
+        }
+      )
+    })
   }, [detachableContextWorktrees, updateWorktreeLineage])
 
   const suppressOpeningPointerEvent = useCallback((event: React.SyntheticEvent) => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4408,7 +4408,9 @@
           "setParentWorkspace": "Set Parent Worktree...",
           "workspaceSection": "Workspace",
           "primaryDeleteDisabled": "Primary worktree — can't be deleted. Remove the project instead.",
-          "deleteWorktree": "Delete Worktree"
+          "deleteWorktree": "Delete Worktree",
+          "failedDetachFromParent": "Failed to remove some workspaces from their parent",
+          "failedDetachFromParentDetail": "Detached {{value0}}. Still attached: {{value1}}."
         },
         "WorktreeList": {
           "7a8b9c0d1e": "Update required",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4362,7 +4362,9 @@
           "setParentWorkspace": "Establecer worktree padre...",
           "workspaceSection": "Espacio de trabajo",
           "primaryDeleteDisabled": "El worktree principal no se puede eliminar. Quita el proyecto en su lugar.",
-          "deleteWorktree": "Eliminar worktree"
+          "deleteWorktree": "Eliminar worktree",
+          "failedDetachFromParent": "No se pudieron quitar algunos espacios de trabajo de su padre",
+          "failedDetachFromParentDetail": "Se desvincularon {{value0}}. Aún vinculados: {{value1}}."
         },
         "WorktreeList": {
           "d880ea0744": "Crea un grupo y mueve este proyecto a él.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4343,7 +4343,9 @@
           "setParentWorkspace": "親ワークツリーを設定...",
           "workspaceSection": "ワークスペース",
           "primaryDeleteDisabled": "プライマリワークツリーは削除できません。代わりにプロジェクトを削除してください。",
-          "deleteWorktree": "ワークツリーを削除"
+          "deleteWorktree": "ワークツリーを削除",
+          "failedDetachFromParent": "一部のワークスペースを親から削除できませんでした",
+          "failedDetachFromParentDetail": "{{value0}} 件を切り離しました。まだ接続中: {{value1}}。"
         },
         "WorktreeList": {
           "d880ea0744": "グループを作成し、このプロジェクトをそのグループに移動します。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4343,7 +4343,9 @@
           "setParentWorkspace": "상위 워크트리 설정...",
           "workspaceSection": "워크스페이스",
           "primaryDeleteDisabled": "기본 작업 트리는 삭제할 수 없습니다. 대신 프로젝트를 제거하세요.",
-          "deleteWorktree": "작업 트리 삭제"
+          "deleteWorktree": "작업 트리 삭제",
+          "failedDetachFromParent": "일부 워크스페이스를 상위에서 제거하지 못했습니다.",
+          "failedDetachFromParentDetail": "{{value0}}개를 분리했습니다. 아직 연결됨: {{value1}}."
         },
         "WorktreeList": {
           "d880ea0744": "그룹을 만들고 이 프로젝트를 그룹으로 이동하세요.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4343,7 +4343,9 @@
           "setParentWorkspace": "设置父工作树...",
           "workspaceSection": "工作区",
           "primaryDeleteDisabled": "主工作树不能删除。请改为移除项目。",
-          "deleteWorktree": "删除工作树"
+          "deleteWorktree": "删除工作树",
+          "failedDetachFromParent": "无法将某些工作区从父级中删除",
+          "failedDetachFromParentDetail": "已分离 {{value0}} 个。仍已连接：{{value1}}。"
         },
         "WorktreeList": {
           "d880ea0744": "创建一个组并将该项目移入其中。",

--- a/tests/e2e/worktree-bulk-actions.spec.ts
+++ b/tests/e2e/worktree-bulk-actions.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from './helpers/orca-app'
+
+test('selected worktrees expose bulk sleep, delete, and detach actions', async ({ orcaPage }) => {
+  const worktreeIds = await orcaPage.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Orca store unavailable')
+    }
+    const state = store.getState()
+    const worktrees = Object.values(state.worktreesByRepo).flat()
+    const parent = worktrees.find((worktree) => worktree.isMainWorktree)
+    const child = worktrees.find((worktree) => !worktree.isMainWorktree)
+    if (!parent || !child) {
+      throw new Error('Expected primary and secondary worktrees')
+    }
+
+    store.setState((current) => ({
+      worktreeLineageById: {
+        ...current.worktreeLineageById,
+        [child.id]: {
+          worktreeId: child.id,
+          worktreeInstanceId: child.instanceId,
+          parentWorktreeId: parent.id,
+          parentWorktreeInstanceId: parent.instanceId,
+          origin: 'cli',
+          capture: { source: 'explicit-cli-flag', confidence: 'explicit' },
+          createdAt: Date.now()
+        }
+      },
+      updateWorktreeLineage: async (worktreeId, args) => {
+        if (!args.noParent) {
+          return
+        }
+        const previousCalls = document.body.dataset.bulkDetachCalls
+        document.body.dataset.bulkDetachCalls = previousCalls
+          ? `${previousCalls},${worktreeId}`
+          : worktreeId
+        store.setState((latest) => {
+          const worktreeLineageById = { ...latest.worktreeLineageById }
+          delete worktreeLineageById[worktreeId]
+          return { worktreeLineageById, sortEpoch: latest.sortEpoch + 1 }
+        })
+      },
+      sortEpoch: current.sortEpoch + 1
+    }))
+    state.createBrowserTab(parent.id, 'about:blank', { title: 'bulk-parent', activate: false })
+    state.createBrowserTab(child.id, 'about:blank', { title: 'bulk-child', activate: false })
+    return { parentId: parent.id, childId: child.id }
+  })
+
+  const parentRow = orcaPage.locator(`[data-worktree-id="${worktreeIds.parentId}"]`).first()
+  const childRow = orcaPage.locator(`[data-worktree-id="${worktreeIds.childId}"]`).first()
+  const parentCard = parentRow.locator(
+    ':scope > [data-worktree-context-menu-scope] > [data-worktree-card-surface]'
+  )
+  const childCard = childRow.locator(
+    ':scope > [data-worktree-context-menu-scope] > [data-worktree-card-surface]'
+  )
+  const modifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+  await expect(parentRow).toBeVisible()
+  await expect(childRow).toBeVisible()
+  await parentCard.click({ modifiers: [modifier] })
+  await childCard.click({ modifiers: [modifier] })
+  await expect(parentRow).toHaveAttribute('aria-selected', 'true')
+  await expect(childRow).toHaveAttribute('aria-selected', 'true')
+
+  await childCard.click({ button: 'right' })
+  await expect(orcaPage.getByRole('menuitem', { name: 'Sleep 2 Workspaces' })).toBeVisible()
+  await expect(orcaPage.getByRole('menuitem', { name: 'Delete 1 Workspace' })).toBeVisible()
+  await expect(orcaPage.getByRole('menuitem', { name: 'Remove from Parent' })).toBeVisible()
+
+  await orcaPage.getByRole('menuitem', { name: 'Remove from Parent' }).click()
+  await expect(orcaPage.locator('body')).toHaveAttribute(
+    'data-bulk-detach-calls',
+    worktreeIds.childId
+  )
+  await expect(parentRow.locator('[data-worktree-lineage-children]')).toHaveCount(0)
+})


### PR DESCRIPTION
## Summary

Bulk **Remove from Parent** detached the wrong set of workspaces.

The multi-selection handler gated on whether **any** selected row had lineage, then dispatched `noParent` for **every** selected row:

```ts
const hasAnyContextLineage = activeContextWorktrees.some((item) => hasWorktreeParentLink(...))
// ...
activeContextWorktrees.map((item) => updateWorktreeLineage(item.id, { noParent: true }))
```

So as long as one selected row had a parent, every other selected row was detached too. Concretely, on `main`:

- Selecting a **child and an unrelated top-level workspace** detached the top-level one as well.
- Selecting a **parent together with its own child** silently unlinked the parent from *its* grandparent — collapsing a level of the tree the user never touched.
- Selecting a **folder workspace** alongside a child dispatched a worktree-lineage detach for a workspace that is not a git worktree at all.

This restricts the operation to the selected rows that actually carry a parent link, and reports partial failures by name.

## ELI5

You can group workspaces in the sidebar so one sits "inside" another, like folders. If you picked several and chose "Remove from Parent", Orca pulled *everything* you had highlighted out of its group — even items that weren't in a group, and even a group's own container. Now it only removes the ones that are actually inside something, and if some of them can't be removed it tells you exactly which ones are still attached.

## Proof of fix

The unit tests fail against `origin/main`'s `WorktreeContextMenu.tsx` and pass with this branch. Both runs use the identical test file.

**Against `origin/main` (`git checkout origin/main -- src/renderer/src/components/sidebar/WorktreeContextMenu.tsx`):**

```
 ❯ src/renderer/src/components/sidebar/WorktreeContextMenu.test.ts (35 tests | 10 failed)
     × detaches every selected child across multiple parents
     × skips selected rows that have no parent link
     × detaches a selected parent and its selected child exactly once each
     × detaches a lone selected parent from its own grandparent
     × detaches the whole tree without duplicating any row
     × excludes folder workspaces from a mixed selection
     × detaches nothing when the selection has no lineage at all
     × reports every row as detached when all succeed
     × detaches the surviving rows and names only the failed one
     × falls back to the worktree id when a failed row has no display name

 Test Files  1 failed (1)
      Tests  10 failed | 25 passed (35)
```

**With this branch:**

```
 Test Files  1 passed (1)
      Tests  35 passed (35)
```

Because those unit failures surface as missing exports, a component-level test (`WorktreeContextMenu.bulk-detach.render.test.tsx`) pins the wiring itself: it mounts the real `WorktreeContextMenu`, opens the menu via a real `contextmenu` event on a parent+child selection, clicks "Remove from Parent", and asserts the store's `updateWorktreeLineage` receives exactly one `noParent` call — for the child only. Against `origin/main`'s source it fails on the bug directly:

```
 FAIL  bulk Remove from Parent handler targeting >
       dispatches noParent only for selected rows with a parent link
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
```

That second call is `main` detaching the lineage-free parent the user never asked to unlink. With this branch:

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

## Proof of no regressions

```
# whole sidebar module (includes the new render test)
Test Files  183 passed (183)
     Tests  1592 passed (1592)

# lineage store slice
Test Files  1 passed (1)
     Tests  225 passed (225)

# locale policy
Test Files  2 passed (2)
     Tests  13 passed (13)

npx tsc --noEmit -p config/tsconfig.tc.web.json   -> exit 0
npx oxlint <changed files>                        -> exit 0
npx oxfmt --check <changed files>                 -> All matched files use the correct format
node config/scripts/check-max-lines-ratchet.mjs   -> OK, no new bypasses
```

Selection shapes verified by unit test:

- Children of **one** parent → all detached.
- Children of **multiple** parents → all detached, each from its own parent.
- **A parent and its own child both selected** → each detached from *its own* parent exactly once. The child is not detached twice and the parent is not orphaned; asserted with a duplicate check on the target list.
- **A parent alone** → detached from its own grandparent.
- **Mix of parents and unrelated children** → only rows holding a parent link are targeted.
- **Whole tree** (grandparent + parent + child) → the root grandparent is correctly *not* a target; parent and child each appear once.
- **Lineage-free selection only** → no detach dispatched, menu item hidden.
- **Folder workspace** alone and mixed with a child → excluded.

Partial-failure behavior: each row is detached independently, so one failure no longer aborts the rest. The error toast names the rows that are **still attached** and counts those that succeeded, so a failed subset is retryable. Note `updateWorktreeLineage` swallows RPC-level errors internally and re-syncs lineage from the host; the rejection this surfaces is the ambiguous cross-host identity thrown by `settingsForWorktreeOwner`, which is exactly the multi-host bulk case.

Behavior that changes, beyond the bug itself:
- The bulk menu item is now hidden when no selected row has a parent (previously shown whenever any did, which was consistent — but it now also hides for selections where only non-detachable rows are present).
- A failed bulk detach now raises an error toast; previously it failed silently.

## Compatibility

- **Platforms:** macOS / Linux / Windows — no platform-dependent code. No `metaKey` use, no path handling, no shell invocation, no new keyboard shortcut. Verified on macOS; the changed code is pure TS over in-memory lineage maps with no OS-conditional branch. The pre-existing e2e spec picks its modifier via `process.platform`.
- **SSH / remote:** Preserved and improved. Detach still routes per worktree through `updateWorktreeLineage` → `settingsForWorktreeOwner`, so a selection spanning local + SSH hosts dispatches to each row's own owner. Previously one host's failure produced a single swallowed rejection; now each row settles independently and the failures are named.
- **Folder workspaces:** Excluded by construction — a folder workspace is never a lineage child (`setWorkspaceLineage` only ever writes `worktreeWorkspaceKey`), so it never holds a parent link and is filtered out rather than dispatched.
- **Performance:** No hot-path change. The filter is a `useMemo` over the current selection (typically < 10 rows), computed only while the menu is open — the lineage maps are already gated behind `menuOpen` via `selectMenuScopedMap`. No added subprocess, IPC, or render work.

## Screenshots

No visual change. The menu item's label and placement are unchanged; only which workspaces it targets, plus a new error toast on partial failure.

## Testing

- [x] `pnpm lint` — ran `npx oxlint` on the changed files (exit 0) plus `oxfmt --check`.
- [x] `pnpm typecheck` — ran `npx tsc --noEmit -p config/tsconfig.tc.web.json` (exit 0), which covers the renderer.
- [x] `pnpm test` — ran the affected scope rather than the full 30-minute suite: all 182 sidebar test files (1591 tests), the worktree store slice (225 tests), and the locale policy tests (13 tests). All pass.
- [ ] `pnpm build` — not run; no build-affecting change (no new dependency, asset, or entry point).
- [x] Added or updated high-quality tests that would catch regressions.

`tests/e2e/worktree-bulk-actions.spec.ts` was **not** executed: `pnpm run test:e2e` shells into `ensure:electron-runtime`, which runs `pnpm rebuild` / `rebuild-native-deps.mjs` and writes into `node_modules`, which is not permitted in this environment. The spec is carried unchanged from the original patch and is unverified here — flagged under Notes.

## AI Review Report

Reviewed for correctness, regressions, cross-platform behavior, SSH/remote routing, folder-workspace handling, provider neutrality, i18n, and performance.

Flagged and fixed beyond the original patch:

1. **Silent failure on a destructive action.** The handler was `void Promise.all(...)` with no rejection handling. `Promise.all` rejects on the first failure, so a multi-host selection could leave rows attached with no user feedback at all. Now each row settles independently and failures are surfaced by name.
2. **Weak test coverage.** The original test asserted only that the new helper filtered two attached rows from one unattached row — it failed on `main` merely because the export was absent, and never exercised the parent+child, whole-tree, or folder-workspace shapes. Replaced with eight selection-shape tests plus three partial-failure tests, and a component-level render test that pins the handler wiring (fails on `main` with the actual double-detach, not a missing export).
3. **Missing i18n.** The new toast strings were added to all five locale catalogs (`en`, `es`, `ja`, `ko`, `zh`), which verified as remaining exactly in parity at 11150 keys each.

Cross-platform explicitly checked: no `e.metaKey` hardcoding (none present), no path construction, no shell/quoting, no `windowsHide`, no case-sensitivity assumption, no Electron platform API. The change is platform-neutral TypeScript.

Also confirmed not GitHub-specific: worktree lineage is a local Orca metadata concept with no source-control provider coupling, so GitLab/Gitea/Bitbucket are unaffected. No new Git command is issued, so the Git 2.25 baseline is untouched.

## Security Audit

Low risk. No new IPC channel, command execution, path handling, auth, secrets, or dependency. The change narrows which existing `worktrees:updateLineage` calls are made — strictly fewer and better-targeted mutations than before — and the main-process handler's `resolveWorktreeSelector` validation is unchanged.

The one new data flow is the error toast rendering `worktree.displayName` (falling back to the worktree id). Display names are user-controlled, but they are passed as an i18next interpolation value into sonner's text description, which renders as a text node, not HTML — no injection surface. No follow-up needed.

## Notes

- `tests/e2e/worktree-bulk-actions.spec.ts` could not be run here (see Testing) and should be exercised in CI before merge. It is the only part of this PR without local verification.
- The e2e spec asserts an exact `data-bulk-detach-calls` value equal to the child id, which is the correct post-fix expectation for its parent+child selection — it would fail on `main`, where the parent is detached too.
- Follow-up worth considering separately: the drag-to-unnest path in `WorktreeList.tsx:2756` uses the same fire-and-forget `Promise.all` shape and reports a single generic toast. It targets an already-correct id set, so it is not a correctness bug, but it has the same all-or-nothing failure reporting this PR fixes for the menu path.

Original patch by @nexusjuniorai.
