### PR TITLE
feat(codex): surface a stalled config sync instead of failing silently

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -41,6 +41,7 @@
     "../src/main/codex/config-settings-baseline.ts",
     "../src/main/codex/config-settings-conflict-resolution.ts",
     "../src/main/codex/config-settings-promotion.ts",
+    "../src/main/codex/config-sync-stall.ts",
     "../src/main/codex/config-toml-deprecated-hook-flag.ts",
     "../src/main/codex/config-toml-key-path.ts",
     "../src/main/codex/config-toml-line-scan.ts",

--- a/src/main/codex-accounts/runtime-home-mirrored-status-home.test.ts
+++ b/src/main/codex-accounts/runtime-home-mirrored-status-home.test.ts
@@ -18,7 +18,14 @@ beforeEach(() => {
   vi.resetModules()
   testState.userData = mkdtempSync(join(tmpdir(), 'orca-codex-status-home-ud-'))
   testState.home = mkdtempSync(join(tmpdir(), 'orca-codex-status-home-'))
-  for (const key of ['ORCA_USER_DATA_PATH', 'ORCA_CODEX_SYSTEM_DEFAULT_REAL_HOME']) {
+  // Why: the real-home check consults CODEX_HOME and the shell rc, so a
+  // developer who exports one would otherwise fail this suite locally.
+  for (const key of [
+    'ORCA_USER_DATA_PATH',
+    'ORCA_CODEX_SYSTEM_DEFAULT_REAL_HOME',
+    'CODEX_HOME',
+    'ORCA_CODEX_HOME'
+  ]) {
     previousEnv[key] = process.env[key]
     delete process.env[key]
   }

--- a/src/main/codex-accounts/runtime-home-mirrored-status-home.test.ts
+++ b/src/main/codex-accounts/runtime-home-mirrored-status-home.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as NodeOs from 'node:os'
+import type { CodexManagedAccount, GlobalSettings } from '../../shared/types'
+
+const testState = { userData: '', home: '' }
+const previousEnv: Record<string, string | undefined> = {}
+
+vi.mock('electron', () => ({ app: { getPath: () => testState.userData } }))
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return { ...actual, homedir: () => testState.home }
+})
+
+beforeEach(() => {
+  vi.resetModules()
+  testState.userData = mkdtempSync(join(tmpdir(), 'orca-codex-status-home-ud-'))
+  testState.home = mkdtempSync(join(tmpdir(), 'orca-codex-status-home-'))
+  for (const key of ['ORCA_USER_DATA_PATH', 'ORCA_CODEX_SYSTEM_DEFAULT_REAL_HOME']) {
+    previousEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+  process.env.ORCA_USER_DATA_PATH = testState.userData
+  mkdirSync(join(testState.home, '.codex'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(testState.userData, { recursive: true, force: true })
+  rmSync(testState.home, { recursive: true, force: true })
+  for (const [key, value] of Object.entries(previousEnv)) {
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+})
+
+function createStore(accounts: CodexManagedAccount[], activeId: string | null) {
+  const settings = {
+    codexManagedAccounts: accounts,
+    activeCodexManagedAccountId: activeId,
+    activeCodexManagedAccountIdsByRuntime: { host: activeId, wsl: {} }
+  } as GlobalSettings
+  return {
+    getSettings: () => settings,
+    updateSettings: (updates: Partial<GlobalSettings>) => Object.assign(settings, updates)
+  }
+}
+
+function createManagedAccount(id: string): CodexManagedAccount {
+  const home = join(testState.userData, 'codex-accounts', id, 'home')
+  mkdirSync(home, { recursive: true })
+  writeFileSync(join(home, '.orca-managed-home'), `${id}\n`, 'utf-8')
+  writeFileSync(join(home, 'auth.json'), '{}', 'utf-8')
+  return {
+    id,
+    providerAccountId: id,
+    email: `${id}@example.com`,
+    managedHomePath: home,
+    runtime: 'host'
+  } as unknown as CodexManagedAccount
+}
+
+// Why: the config-sync status is only correct if it names the home the current
+// selection actually mirrors into. Nothing else pins that resolution, so a
+// change to the lane rules or the shared-home layout would silence the banner
+// with every other test still green.
+describe('CodexRuntimeHomeService.getMirroredHostHomePathForStatus', () => {
+  it('returns null for the system default, which runs on the real home with no mirror', async () => {
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(createStore([], null) as never)
+
+    expect(service.getMirroredHostHomePathForStatus()).toBeNull()
+  })
+
+  it('returns the selected account own home, which is what its mirror targets', async () => {
+    const account = createManagedAccount('acct-1')
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(createStore([account], account.id) as never)
+
+    expect(service.getMirroredHostHomePathForStatus()).toBe(account.managedHomePath)
+  })
+
+  it('returns the shared runtime home when the real-home lane is off', async () => {
+    process.env.ORCA_CODEX_SYSTEM_DEFAULT_REAL_HOME = '0'
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const { getOrcaManagedCodexHomePath } = await import('../codex/codex-home-paths')
+    const service = new CodexRuntimeHomeService(createStore([], null) as never)
+
+    // Why: compare against the real helper, not a repeated literal, so the
+    // status cannot silently drift if the managed home layout ever moves.
+    expect(service.getMirroredHostHomePathForStatus()).toBe(getOrcaManagedCodexHomePath())
+  })
+})

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -34,6 +34,7 @@ import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
 import { writeFileAtomically } from './fs-utils'
 import {
   getOrcaManagedCodexHomePath,
+  getOrcaUserDataPath,
   getCodexSessionBackfillStateDirPath,
   getSystemCodexHomePath,
   syncCodexGlobalInstructionsIntoManagedHome,
@@ -1148,6 +1149,27 @@ export class CodexRuntimeHomeService {
 
   private getRuntimeHomePath(): string {
     return getOrcaManagedCodexHomePath()
+  }
+
+  /**
+   * Resolves the managed home the config mirror actually targets for the
+   * current HOST selection, or null when no mirror runs for it.
+   *
+   * Read-only on purpose: unlike the launch and quota-fetch paths this prepares
+   * nothing and creates no directories, so surfacing sync health cannot alter
+   * the state it is reporting on. Returns null for the system default on the
+   * real-home lane, which runs Codex directly against ~/.codex — there is no
+   * mirror there, so there is nothing that can fall behind.
+   */
+  getMirroredHostHomePathForStatus(): string | null {
+    const selfContainedAccount = this.getSelfContainedManagedHostAccount()
+    if (selfContainedAccount) {
+      return this.getTrustedSelfContainedManagedHomePath(selfContainedAccount)
+    }
+    if (this.isHostSystemDefaultRealHome()) {
+      return null
+    }
+    return join(getOrcaUserDataPath(), 'codex-runtime-home', 'home')
   }
 
   private getRuntimeAuthPath(): string {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -261,6 +261,15 @@ export class CodexAccountService {
     this.safeSyncCanonicalConfigToManagedHomes()
   }
 
+  /**
+   * Read-only access for surfaces that report on the runtime home rather than
+   * prepare it — notably the config-sync status channel, which must resolve the
+   * home the current selection actually mirrors into without creating anything.
+   */
+  get runtimeHomeService(): CodexRuntimeHomeService {
+    return this.runtimeHome
+  }
+
   private serializeMutation<T>(fn: () => Promise<T>): Promise<T> {
     const next = this.mutationQueue.then(fn, fn)
     this.mutationQueue = next.catch(() => {})

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -46,7 +46,11 @@ export function syncSystemConfigIntoManagedCodexHome(
   try {
     mirrorResult = syncSystemConfigIntoManagedCodexHomeUnsafe(homes, promotionPlan)
   } catch (error) {
-    console.warn('[codex-config] Failed to mirror system Codex config:', error)
+    // Why: an unreadable source throws out of the mirror, so reporting only on
+    // the success path would leave that stall latch-less — logging the generic
+    // failure on every launch and quota poll while the surfaced reason never
+    // reaches the user.
+    reportCodexConfigSyncOutcome(homes.runtimeHomePath, getCodexConfigSyncStatus(homes), error)
     return
   }
   // Why: report from the same pass that decided, so the surfaced status can

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -40,6 +40,10 @@ export function syncSystemConfigIntoManagedCodexHome(
   if (!promotionPlan) {
     // Why: mirroring after a failed write-back would erase the runtime change;
     // leave both runtime and its old baseline intact so the next launch retries.
+    // Report first: once a baseline exists, an unreadable source throws inside
+    // promotion rather than the mirror, so reporting only later would leave the
+    // steady-state stall logging a reasonless failure on every pass forever.
+    reportCodexConfigSyncOutcome(homes.runtimeHomePath, getCodexConfigSyncStatus(homes))
     return
   }
   let mirrorResult: CodexConfigMirrorResult

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -43,7 +43,13 @@ export function syncSystemConfigIntoManagedCodexHome(
     // Report first: once a baseline exists, an unreadable source throws inside
     // promotion rather than the mirror, so reporting only later would leave the
     // steady-state stall logging a reasonless failure on every pass forever.
-    reportCodexConfigSyncOutcome(homes.runtimeHomePath, getCodexConfigSyncStatus(homes))
+    // Only a stall, never a clear: promotion failing on a readable source still
+    // means no mirror ran, so clearing the latch here would claim a recovery
+    // that did not happen and silence every later pass.
+    const stalledStatus = getCodexConfigSyncStatus(homes)
+    if (stalledStatus.state === 'stalled') {
+      reportCodexConfigSyncOutcome(homes.runtimeHomePath, stalledStatus)
+    }
     return
   }
   let mirrorResult: CodexConfigMirrorResult

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -13,6 +13,7 @@ import {
   type CodexSettingsPromotionPlan
 } from './config-settings-promotion'
 import { readCodexSettingsBaseline } from './config-settings-baseline'
+import { getCodexConfigSyncStatus, reportCodexConfigSyncOutcome } from './config-sync-stall'
 import { preserveRuntimeConflictValues } from './codex-config-settings-preservation'
 import {
   deduplicateProjectTomlSections,
@@ -48,6 +49,9 @@ export function syncSystemConfigIntoManagedCodexHome(
     console.warn('[codex-config] Failed to mirror system Codex config:', error)
     return
   }
+  // Why: report from the same pass that decided, so the surfaced status can
+  // never disagree with what the mirror actually did.
+  reportCodexConfigSyncOutcome(homes.runtimeHomePath, getCodexConfigSyncStatus(homes))
   if (mirrorResult.status === 'skipped-missing-source') {
     // Why: advancing an existing baseline would mark the unmirrored runtime
     // change as promoted, so it could never retry once the source reappears.

--- a/src/main/codex/config-sync-stall.test.ts
+++ b/src/main/codex/config-sync-stall.test.ts
@@ -107,6 +107,12 @@ describe('reportCodexConfigSyncOutcome', () => {
     resetCodexConfigSyncStallLatchForTests()
   })
 
+  // Why: a failing assertion skips an inline mockRestore, and a leaked
+  // console.warn spy makes every later case in this block fail spuriously.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('logs a stall once per episode rather than on every sync pass', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
@@ -116,10 +122,9 @@ describe('reportCodexConfigSyncOutcome', () => {
     }
 
     expect(warn.mock.calls.filter((call) => String(call[0]).includes('stalled'))).toHaveLength(1)
-    warn.mockRestore()
   })
 
-  it('logs the recovery once the source config returns', () => {
+  it('logs once when the stall clears after the source config returns', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
     syncSystemConfigIntoManagedCodexHome(homes)
@@ -128,8 +133,41 @@ describe('reportCodexConfigSyncOutcome', () => {
     syncSystemConfigIntoManagedCodexHome(homes)
     syncSystemConfigIntoManagedCodexHome(homes)
 
-    expect(warn.mock.calls.filter((call) => String(call[0]).includes('recovered'))).toHaveLength(1)
-    warn.mockRestore()
+    expect(
+      warn.mock.calls.filter((call) => String(call[0]).includes('stall cleared'))
+    ).toHaveLength(1)
+  })
+
+  it('latches an unreadable source instead of logging the raw failure every pass', () => {
+    // Why: an unreadable source throws out of the mirror, so before the catch
+    // path reported it this stall logged the generic failure on every launch
+    // and quota poll and never surfaced its reason.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+    mkdirSync(systemConfigPath(), { recursive: true })
+
+    for (let pass = 0; pass < 3; pass += 1) {
+      syncSystemConfigIntoManagedCodexHome(homes)
+    }
+
+    const stallLogs = warn.mock.calls.filter((call) => String(call[0]).includes('stalled'))
+    expect(stallLogs).toHaveLength(1)
+    expect(String(stallLogs[0]?.[0])).toContain('unreadable-source')
+  })
+
+  it('clears a stall without claiming the source became readable', () => {
+    // Why: a removed runtime config also reads as synced, so "readable again"
+    // would be a false claim about a source that is still gone.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    rmSync(runtimeConfigPath())
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    const cleared = warn.mock.calls.filter((call) => String(call[0]).includes('stall cleared'))
+    expect(cleared).toHaveLength(1)
+    expect(String(cleared[0]?.[0])).not.toContain('readable again')
   })
 
   it('logs again when the stall reason changes', () => {
@@ -143,6 +181,5 @@ describe('reportCodexConfigSyncOutcome', () => {
     const stallLogs = warn.mock.calls.filter((call) => String(call[0]).includes('stalled'))
     expect(stallLogs).toHaveLength(2)
     expect(String(stallLogs[1]?.[0])).toContain('blank-source')
-    warn.mockRestore()
   })
 })

--- a/src/main/codex/config-sync-stall.test.ts
+++ b/src/main/codex/config-sync-stall.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  getCodexConfigSyncStatus,
+  resetCodexConfigSyncStallLatchForTests
+} from './config-sync-stall'
+import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+
+let root: string
+let homes: { runtimeHomePath: string; systemHomePath: string }
+
+function systemConfigPath(): string {
+  return join(homes.systemHomePath, 'config.toml')
+}
+
+function runtimeConfigPath(): string {
+  return join(homes.runtimeHomePath, 'config.toml')
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'orca-codex-sync-stall-'))
+  homes = { runtimeHomePath: join(root, 'runtime'), systemHomePath: join(root, 'system') }
+  mkdirSync(homes.runtimeHomePath, { recursive: true })
+  mkdirSync(homes.systemHomePath, { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('getCodexConfigSyncStatus', () => {
+  it('reports synced while the source config is usable', () => {
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    writeFileSync(runtimeConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+
+    expect(getCodexConfigSyncStatus(homes)).toEqual({
+      state: 'synced',
+      reason: null,
+      systemConfigPath: systemConfigPath()
+    })
+  })
+
+  it('reports a stall when the source config is missing', () => {
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+
+    expect(getCodexConfigSyncStatus(homes)).toEqual({
+      state: 'stalled',
+      reason: 'missing-source',
+      systemConfigPath: systemConfigPath()
+    })
+  })
+
+  it('reports a stall when the source config is blank', () => {
+    writeFileSync(systemConfigPath(), '\n  \n', 'utf-8')
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+
+    expect(getCodexConfigSyncStatus(homes).reason).toBe('blank-source')
+  })
+
+  it('reports a stall when the source config cannot be read', () => {
+    // Why: a directory at the config path survives existsSync but throws on
+    // read, standing in for a permission-denied or otherwise unreadable home.
+    mkdirSync(systemConfigPath(), { recursive: true })
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+
+    expect(getCodexConfigSyncStatus(homes).reason).toBe('unreadable-source')
+  })
+
+  it('stays synced before the runtime config exists, since nothing can fall behind yet', () => {
+    expect(getCodexConfigSyncStatus(homes)).toEqual({
+      state: 'synced',
+      reason: null,
+      systemConfigPath: systemConfigPath()
+    })
+  })
+
+  // Why: the status must never claim a sync the mirror would decline, so pin it
+  // to the mirror's real behavior rather than to a duplicated predicate.
+  it('reports a stall exactly when the mirror preserves the runtime config', () => {
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+    expect(getCodexConfigSyncStatus(homes).state).toBe('synced')
+
+    rmSync(systemConfigPath())
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    expect(getCodexConfigSyncStatus(homes).state).toBe('stalled')
+    // The mirror keeps serving the last good settings — that is what makes the
+    // stall silent, and why it needs surfacing.
+    expect(readFileSync(runtimeConfigPath(), 'utf-8')).toContain('model = "gpt-5"')
+  })
+
+  it('clears the stall once the source config returns', () => {
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+    expect(getCodexConfigSyncStatus(homes).state).toBe('stalled')
+
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+
+    expect(getCodexConfigSyncStatus(homes).state).toBe('synced')
+  })
+})
+
+describe('reportCodexConfigSyncOutcome', () => {
+  beforeEach(() => {
+    resetCodexConfigSyncStallLatchForTests()
+  })
+
+  it('logs a stall once per episode rather than on every sync pass', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+
+    for (let pass = 0; pass < 3; pass += 1) {
+      syncSystemConfigIntoManagedCodexHome(homes)
+    }
+
+    expect(warn.mock.calls.filter((call) => String(call[0]).includes('stalled'))).toHaveLength(1)
+    warn.mockRestore()
+  })
+
+  it('logs the recovery once the source config returns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    expect(warn.mock.calls.filter((call) => String(call[0]).includes('recovered'))).toHaveLength(1)
+    warn.mockRestore()
+  })
+
+  it('logs again when the stall reason changes', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    writeFileSync(systemConfigPath(), '   \n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    const stallLogs = warn.mock.calls.filter((call) => String(call[0]).includes('stalled'))
+    expect(stallLogs).toHaveLength(2)
+    expect(String(stallLogs[1]?.[0])).toContain('blank-source')
+    warn.mockRestore()
+  })
+})

--- a/src/main/codex/config-sync-stall.test.ts
+++ b/src/main/codex/config-sync-stall.test.ts
@@ -178,36 +178,41 @@ describe('reportCodexConfigSyncOutcome', () => {
     expect(String(cleared[0]?.[0])).not.toContain('readable again')
   })
 
-  it('does not claim recovery on a pass where no mirror ran', () => {
-    // Why: promotion throwing still means the mirror was skipped, so the runtime
-    // config is not tracking the source. Clearing the latch there would claim a
-    // recovery that never happened and silence every later pass.
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
-    syncSystemConfigIntoManagedCodexHome(homes)
-
-    // In-Codex change while the source is gone -> stall latches, and the change
-    // stays pending promotion.
-    rmSync(systemConfigPath())
-    writeFileSync(runtimeConfigPath(), 'model = "o4"\n', 'utf-8')
-    syncSystemConfigIntoManagedCodexHome(homes)
-    expect(warn.mock.calls.filter((c) => String(c[0]).includes('stalled'))).toHaveLength(1)
-    warn.mockClear()
-
-    // Source returns readable, but promotion cannot write the pending change
-    // back into a read-only ~/.codex, so it throws and the mirror is skipped.
-    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
-    chmodSync(homes.systemHomePath, 0o555)
-    try {
+  // chmod on a directory does not block writes on Windows, so promotion would
+  // succeed there and the scenario could not be constructed.
+  it.skipIf(process.platform === 'win32')(
+    'does not claim recovery on a pass where no mirror ran',
+    () => {
+      // Why: promotion throwing still means the mirror was skipped, so the runtime
+      // config is not tracking the source. Clearing the latch there would claim a
+      // recovery that never happened and silence every later pass.
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
       syncSystemConfigIntoManagedCodexHome(homes)
-    } finally {
-      chmodSync(homes.systemHomePath, 0o755)
-    }
 
-    expect(warn.mock.calls.filter((c) => String(c[0]).includes('stall cleared'))).toHaveLength(0)
-    // The runtime never picked up the source, so the change must still be there.
-    expect(readFileSync(runtimeConfigPath(), 'utf-8')).toContain('model = "o4"')
-  })
+      // In-Codex change while the source is gone -> stall latches, and the change
+      // stays pending promotion.
+      rmSync(systemConfigPath())
+      writeFileSync(runtimeConfigPath(), 'model = "o4"\n', 'utf-8')
+      syncSystemConfigIntoManagedCodexHome(homes)
+      expect(warn.mock.calls.filter((c) => String(c[0]).includes('stalled'))).toHaveLength(1)
+      warn.mockClear()
+
+      // Source returns readable, but promotion cannot write the pending change
+      // back into a read-only ~/.codex, so it throws and the mirror is skipped.
+      writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+      chmodSync(homes.systemHomePath, 0o555)
+      try {
+        syncSystemConfigIntoManagedCodexHome(homes)
+      } finally {
+        chmodSync(homes.systemHomePath, 0o755)
+      }
+
+      expect(warn.mock.calls.filter((c) => String(c[0]).includes('stall cleared'))).toHaveLength(0)
+      // The runtime never picked up the source, so the change must still be there.
+      expect(readFileSync(runtimeConfigPath(), 'utf-8')).toContain('model = "o4"')
+    }
+  )
 
   it('logs again when the stall reason changes', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})

--- a/src/main/codex/config-sync-stall.test.ts
+++ b/src/main/codex/config-sync-stall.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
@@ -176,6 +176,37 @@ describe('reportCodexConfigSyncOutcome', () => {
     const cleared = warn.mock.calls.filter((call) => String(call[0]).includes('stall cleared'))
     expect(cleared).toHaveLength(1)
     expect(String(cleared[0]?.[0])).not.toContain('readable again')
+  })
+
+  it('does not claim recovery on a pass where no mirror ran', () => {
+    // Why: promotion throwing still means the mirror was skipped, so the runtime
+    // config is not tracking the source. Clearing the latch there would claim a
+    // recovery that never happened and silence every later pass.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+
+    // In-Codex change while the source is gone -> stall latches, and the change
+    // stays pending promotion.
+    rmSync(systemConfigPath())
+    writeFileSync(runtimeConfigPath(), 'model = "o4"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('stalled'))).toHaveLength(1)
+    warn.mockClear()
+
+    // Source returns readable, but promotion cannot write the pending change
+    // back into a read-only ~/.codex, so it throws and the mirror is skipped.
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    chmodSync(homes.systemHomePath, 0o555)
+    try {
+      syncSystemConfigIntoManagedCodexHome(homes)
+    } finally {
+      chmodSync(homes.systemHomePath, 0o755)
+    }
+
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('stall cleared'))).toHaveLength(0)
+    // The runtime never picked up the source, so the change must still be there.
+    expect(readFileSync(runtimeConfigPath(), 'utf-8')).toContain('model = "o4"')
   })
 
   it('logs again when the stall reason changes', () => {

--- a/src/main/codex/config-sync-stall.test.ts
+++ b/src/main/codex/config-sync-stall.test.ts
@@ -143,7 +143,15 @@ describe('reportCodexConfigSyncOutcome', () => {
     // path reported it this stall logged the generic failure on every launch
     // and quota poll and never surfaced its reason.
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    writeFileSync(runtimeConfigPath(), 'model = "runtime-model"\n', 'utf-8')
+    // Why: seed a baseline with one healthy pass first. Without it promotion
+    // no-ops before touching the source and the mirror is what throws — which
+    // is NOT the steady state every real install is in, where promotion reads
+    // the source first and throws there instead.
+    writeFileSync(systemConfigPath(), 'model = "gpt-5"\n', 'utf-8')
+    syncSystemConfigIntoManagedCodexHome(homes)
+    warn.mockClear()
+
+    rmSync(systemConfigPath())
     mkdirSync(systemConfigPath(), { recursive: true })
 
     for (let pass = 0; pass < 3; pass += 1) {

--- a/src/main/codex/config-sync-stall.ts
+++ b/src/main/codex/config-sync-stall.ts
@@ -1,0 +1,78 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
+import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from './codex-home-paths'
+import type { CodexSettingsPromotionHomes } from './config-settings-promotion'
+import type {
+  CodexConfigSyncStallReason,
+  CodexConfigSyncStatus
+} from '../../shared/codex-config-sync-types'
+
+// Why: the mirror preserves the managed runtime config when ~/.codex/config.toml
+// is missing or blank, which is silent by design — but the stall can persist for
+// every launch (a downed WSL distro, an unhydrated cloud-synced home), leaving
+// "Orca ignores my config edits" with nothing to diagnose. Derived on demand from
+// the same predicates the mirror uses so the two can never disagree.
+export function getCodexConfigSyncStatus(
+  homes: CodexSettingsPromotionHomes = {
+    runtimeHomePath: getOrcaManagedCodexHomePath(),
+    systemHomePath: getSystemCodexHomePath()
+  }
+): CodexConfigSyncStatus {
+  const systemConfigPath = join(homes.systemHomePath, 'config.toml')
+  const runtimeConfigPath = join(homes.runtimeHomePath, 'config.toml')
+  // Why: a stall only withholds settings once a managed runtime config exists;
+  // without one the mirror seeds it and there is nothing yet to fall behind.
+  if (!existsSync(runtimeConfigPath)) {
+    return { state: 'synced', reason: null, systemConfigPath }
+  }
+  if (!existsSync(systemConfigPath)) {
+    return { state: 'stalled', reason: 'missing-source', systemConfigPath }
+  }
+  let rawSystemConfig: string
+  try {
+    rawSystemConfig = readAgentStateFileSync(systemConfigPath)
+  } catch {
+    // Why: the mirror aborts on an unreadable source too, so report the stall
+    // rather than claiming a sync that cannot happen.
+    return { state: 'stalled', reason: 'unreadable-source', systemConfigPath }
+  }
+  if (rawSystemConfig.trim() === '') {
+    return { state: 'stalled', reason: 'blank-source', systemConfigPath }
+  }
+  return { state: 'synced', reason: null, systemConfigPath }
+}
+
+// Why: the mirror runs on every launch and on the quota poll, so logging each
+// skip would bury the log. Latch per home and log the transition instead, so an
+// ongoing stall stays one line and a recovery is visible.
+const stalledHomes = new Map<string, CodexConfigSyncStallReason>()
+
+export function reportCodexConfigSyncOutcome(
+  runtimeHomePath: string,
+  status: CodexConfigSyncStatus
+): void {
+  const previousReason = stalledHomes.get(runtimeHomePath)
+  if (status.state === 'synced') {
+    if (previousReason) {
+      stalledHomes.delete(runtimeHomePath)
+      console.warn(
+        `[codex-config] Config sync recovered for ${runtimeHomePath}; ${status.systemConfigPath} is readable again.`
+      )
+    }
+    return
+  }
+  if (previousReason === status.reason) {
+    return
+  }
+  stalledHomes.set(runtimeHomePath, status.reason)
+  console.warn(
+    `[codex-config] Config sync stalled (${status.reason}): ${status.systemConfigPath} is unusable, so ${runtimeHomePath} keeps its last synced settings. Edits to the source will not apply until it is readable.`
+  )
+}
+
+// Why: the latch is module state, so suites that assert on transitions need a
+// clean slate between cases.
+export function resetCodexConfigSyncStallLatchForTests(): void {
+  stalledHomes.clear()
+}

--- a/src/main/codex/config-sync-stall.ts
+++ b/src/main/codex/config-sync-stall.ts
@@ -8,11 +8,16 @@ import type {
   CodexConfigSyncStatus
 } from '../../shared/codex-config-sync-types'
 
-// Why: the mirror preserves the managed runtime config when ~/.codex/config.toml
-// is missing or blank, which is silent by design — but the stall can persist for
-// every launch (a downed WSL distro, an unhydrated cloud-synced home), leaving
-// "Orca ignores my config edits" with nothing to diagnose. Derived on demand from
-// the same predicates the mirror uses so the two can never disagree.
+/**
+ * Reports whether the managed Codex runtime config is still tracking the user's
+ * real `~/.codex/config.toml`, and why it is not when it has fallen behind.
+ *
+ * The mirror preserves the managed runtime config when the source is missing or
+ * blank, which is silent by design — but the stall can persist for every launch
+ * (a downed WSL distro, an unhydrated cloud-synced home), leaving "Orca ignores
+ * my config edits" with nothing to diagnose. Derived on demand from the same
+ * predicates the mirror uses, so the two can never disagree.
+ */
 export function getCodexConfigSyncStatus(
   homes: CodexSettingsPromotionHomes = {
     runtimeHomePath: getOrcaManagedCodexHomePath(),
@@ -48,17 +53,33 @@ export function getCodexConfigSyncStatus(
 // ongoing stall stays one line and a recovery is visible.
 const stalledHomes = new Map<string, CodexConfigSyncStallReason>()
 
+/**
+ * Logs a config-sync stall once per episode instead of once per sync pass, and
+ * logs again when the stall clears or its reason changes.
+ *
+ * Pass `mirrorError` from the mirror's catch path — an unreadable source throws
+ * out of the mirror, and without it that stall would log the raw failure on
+ * every launch and quota poll while never latching.
+ */
 export function reportCodexConfigSyncOutcome(
   runtimeHomePath: string,
-  status: CodexConfigSyncStatus
+  status: CodexConfigSyncStatus,
+  mirrorError?: unknown
 ): void {
   const previousReason = stalledHomes.get(runtimeHomePath)
   if (status.state === 'synced') {
     if (previousReason) {
       stalledHomes.delete(runtimeHomePath)
+      // Why: a removed runtime config also reads as synced, so this cannot
+      // claim the source became readable — only that the stall no longer holds.
       console.warn(
-        `[codex-config] Config sync recovered for ${runtimeHomePath}; ${status.systemConfigPath} is readable again.`
+        `[codex-config] Config sync stall cleared for ${runtimeHomePath} (was ${previousReason}).`
       )
+    }
+    if (mirrorError) {
+      // Why: the mirror still failed for some reason the stall check cannot
+      // name, so surface it rather than swallowing it behind a clean status.
+      console.warn('[codex-config] Failed to mirror system Codex config:', mirrorError)
     }
     return
   }
@@ -71,8 +92,7 @@ export function reportCodexConfigSyncOutcome(
   )
 }
 
-// Why: the latch is module state, so suites that assert on transitions need a
-// clean slate between cases.
+/** Clears the per-home episode latch; the latch is module state, so suites that assert on transitions need a clean slate between cases. */
 export function resetCodexConfigSyncStallLatchForTests(): void {
   stalledHomes.clear()
 }

--- a/src/main/ipc/codex-config-sync.test.ts
+++ b/src/main/ipc/codex-config-sync.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as NodeOs from 'node:os'
+
+const { handleMock, removeHandlerMock, homedirMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: handleMock, removeHandler: removeHandlerMock }
+}))
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeOs>()
+  return { ...actual, homedir: homedirMock }
+})
+
+import { registerCodexConfigSyncHandlers } from './codex-config-sync'
+import type { CodexRuntimeHomeService } from '../codex-accounts/runtime-home-service'
+import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
+
+let root: string
+
+function invokeHandler(mirroredHome: string | null): CodexConfigSyncStatus {
+  handleMock.mockClear()
+  const runtimeHome = {
+    getMirroredHostHomePathForStatus: () => mirroredHome
+  } as unknown as CodexRuntimeHomeService
+  registerCodexConfigSyncHandlers(runtimeHome)
+  const handler = handleMock.mock.calls.at(-1)?.[1] as () => CodexConfigSyncStatus
+  return handler()
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'orca-config-sync-ipc-'))
+  homedirMock.mockReturnValue(root)
+  mkdirSync(join(root, '.codex'), { recursive: true })
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+  vi.clearAllMocks()
+})
+
+describe('codexConfigSync:status handler', () => {
+  it('reports the stall for the home the current selection actually mirrors into', () => {
+    // Why: a managed account mirrors into its own per-account home, not the
+    // shared one — reporting on the shared home would miss the stall entirely.
+    const perAccountHome = join(root, 'codex-accounts', 'acct-1', 'home')
+    mkdirSync(perAccountHome, { recursive: true })
+    writeFileSync(join(perAccountHome, 'config.toml'), 'model = "runtime-model"\n', 'utf-8')
+
+    expect(invokeHandler(perAccountHome)).toEqual({
+      state: 'stalled',
+      reason: 'missing-source',
+      systemConfigPath: join(root, '.codex', 'config.toml')
+    })
+  })
+
+  it('reports synced when the selection runs directly on the real home', () => {
+    // Why: the system default has no mirror, so a stale shared runtime home
+    // must not produce a warning about a config that lane never reads.
+    const staleSharedHome = join(root, 'codex-runtime-home', 'home')
+    mkdirSync(staleSharedHome, { recursive: true })
+    writeFileSync(join(staleSharedHome, 'config.toml'), 'model = "stale"\n', 'utf-8')
+
+    expect(invokeHandler(null)).toEqual({
+      state: 'synced',
+      reason: null,
+      systemConfigPath: join(root, '.codex', 'config.toml')
+    })
+  })
+
+  it('re-registers cleanly so a reload cannot leak a duplicate handler', () => {
+    invokeHandler(null)
+    expect(removeHandlerMock).toHaveBeenCalledWith('codexConfigSync:status')
+  })
+})

--- a/src/main/ipc/codex-config-sync.test.ts
+++ b/src/main/ipc/codex-config-sync.test.ts
@@ -20,17 +20,15 @@ vi.mock('node:os', async (importOriginal) => {
 })
 
 import { registerCodexConfigSyncHandlers } from './codex-config-sync'
-import type { CodexRuntimeHomeService } from '../codex-accounts/runtime-home-service'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 
 let root: string
 
 function invokeHandler(mirroredHome: string | null): CodexConfigSyncStatus {
   handleMock.mockClear()
-  const runtimeHome = {
+  registerCodexConfigSyncHandlers({
     getMirroredHostHomePathForStatus: () => mirroredHome
-  } as unknown as CodexRuntimeHomeService
-  registerCodexConfigSyncHandlers(runtimeHome)
+  })
   const handler = handleMock.mock.calls.at(-1)?.[1] as () => CodexConfigSyncStatus
   return handler()
 }

--- a/src/main/ipc/codex-config-sync.ts
+++ b/src/main/ipc/codex-config-sync.ts
@@ -2,7 +2,7 @@ import { ipcMain } from 'electron'
 import { getCodexConfigSyncStatus } from '../codex/config-sync-stall'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 
-/** Registers the IPC channel the settings UI polls for Codex config sync health. */
+/** Registers the read-only IPC channel the settings pane reads once per mount for Codex config sync health. */
 export function registerCodexConfigSyncHandlers(): void {
   ipcMain.removeHandler('codexConfigSync:status')
   ipcMain.handle('codexConfigSync:status', (): CodexConfigSyncStatus => getCodexConfigSyncStatus())

--- a/src/main/ipc/codex-config-sync.ts
+++ b/src/main/ipc/codex-config-sync.ts
@@ -4,12 +4,12 @@ import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { getCodexConfigSyncStatus } from '../codex/config-sync-stall'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 
-/** Registers the read-only IPC channel the settings pane reads once per mount for Codex config sync health. */
 /** The read-only slice of the runtime home service this channel needs. */
 type CodexMirroredHomeResolver = {
   getMirroredHostHomePathForStatus: () => string | null
 }
 
+/** Registers the read-only IPC channel the settings pane reads once per mount for Codex config sync health. */
 export function registerCodexConfigSyncHandlers(runtimeHome: CodexMirroredHomeResolver): void {
   ipcMain.removeHandler('codexConfigSync:status')
   ipcMain.handle('codexConfigSync:status', (): CodexConfigSyncStatus => {

--- a/src/main/ipc/codex-config-sync.ts
+++ b/src/main/ipc/codex-config-sync.ts
@@ -2,6 +2,7 @@ import { ipcMain } from 'electron'
 import { getCodexConfigSyncStatus } from '../codex/config-sync-stall'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 
+/** Registers the IPC channel the settings UI polls for Codex config sync health. */
 export function registerCodexConfigSyncHandlers(): void {
   ipcMain.removeHandler('codexConfigSync:status')
   ipcMain.handle('codexConfigSync:status', (): CodexConfigSyncStatus => getCodexConfigSyncStatus())

--- a/src/main/ipc/codex-config-sync.ts
+++ b/src/main/ipc/codex-config-sync.ts
@@ -2,11 +2,15 @@ import { ipcMain } from 'electron'
 import { join } from 'node:path'
 import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { getCodexConfigSyncStatus } from '../codex/config-sync-stall'
-import type { CodexRuntimeHomeService } from '../codex-accounts/runtime-home-service'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 
 /** Registers the read-only IPC channel the settings pane reads once per mount for Codex config sync health. */
-export function registerCodexConfigSyncHandlers(runtimeHome: CodexRuntimeHomeService): void {
+/** The read-only slice of the runtime home service this channel needs. */
+type CodexMirroredHomeResolver = {
+  getMirroredHostHomePathForStatus: () => string | null
+}
+
+export function registerCodexConfigSyncHandlers(runtimeHome: CodexMirroredHomeResolver): void {
   ipcMain.removeHandler('codexConfigSync:status')
   ipcMain.handle('codexConfigSync:status', (): CodexConfigSyncStatus => {
     const systemHomePath = getSystemCodexHomePath()

--- a/src/main/ipc/codex-config-sync.ts
+++ b/src/main/ipc/codex-config-sync.ts
@@ -1,0 +1,8 @@
+import { ipcMain } from 'electron'
+import { getCodexConfigSyncStatus } from '../codex/config-sync-stall'
+import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
+
+export function registerCodexConfigSyncHandlers(): void {
+  ipcMain.removeHandler('codexConfigSync:status')
+  ipcMain.handle('codexConfigSync:status', (): CodexConfigSyncStatus => getCodexConfigSyncStatus())
+}

--- a/src/main/ipc/codex-config-sync.ts
+++ b/src/main/ipc/codex-config-sync.ts
@@ -1,9 +1,26 @@
 import { ipcMain } from 'electron'
+import { join } from 'node:path'
+import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { getCodexConfigSyncStatus } from '../codex/config-sync-stall'
+import type { CodexRuntimeHomeService } from '../codex-accounts/runtime-home-service'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 
 /** Registers the read-only IPC channel the settings pane reads once per mount for Codex config sync health. */
-export function registerCodexConfigSyncHandlers(): void {
+export function registerCodexConfigSyncHandlers(runtimeHome: CodexRuntimeHomeService): void {
   ipcMain.removeHandler('codexConfigSync:status')
-  ipcMain.handle('codexConfigSync:status', (): CodexConfigSyncStatus => getCodexConfigSyncStatus())
+  ipcMain.handle('codexConfigSync:status', (): CodexConfigSyncStatus => {
+    const systemHomePath = getSystemCodexHomePath()
+    const runtimeHomePath = runtimeHome.getMirroredHostHomePathForStatus()
+    if (!runtimeHomePath) {
+      // Why: the system default runs Codex directly against ~/.codex, so there
+      // is no mirror that can fall behind. Reporting on the shared home here
+      // would warn about a config that lane never reads.
+      return {
+        state: 'synced',
+        reason: null,
+        systemConfigPath: join(systemHomePath, 'config.toml')
+      }
+    }
+    return getCodexConfigSyncStatus({ runtimeHomePath, systemHomePath })
+  })
 }

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -53,6 +53,7 @@ const {
   registerGitLabHandlersMock,
   registerHostedReviewHandlersMock,
   registerExportHandlersMock,
+  registerCodexConfigSyncHandlersMock,
   registerOnboardingHandlersMock,
   registerDashboardPopoutHandlersMock,
   registerTerminalPreviewHandlersMock,
@@ -117,6 +118,7 @@ const {
   registerGitLabHandlersMock: vi.fn(),
   registerHostedReviewHandlersMock: vi.fn(),
   registerExportHandlersMock: vi.fn(),
+  registerCodexConfigSyncHandlersMock: vi.fn(),
   registerOnboardingHandlersMock: vi.fn(),
   registerDashboardPopoutHandlersMock: vi.fn(),
   registerTerminalPreviewHandlersMock: vi.fn(),
@@ -142,6 +144,10 @@ vi.mock('../../shared/runtime-environment-store', () => ({
 
 vi.mock('./runtime-environment-transport-routing', () => ({
   callRuntimeEnvironment: callRuntimeEnvironmentMock
+}))
+
+vi.mock('./codex-config-sync', () => ({
+  registerCodexConfigSyncHandlers: registerCodexConfigSyncHandlersMock
 }))
 
 vi.mock('./onboarding', () => ({

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -454,7 +454,7 @@ describe('registerCoreHandlers', () => {
     const claudeUsage = { marker: 'claudeUsage' }
     const codexUsage = { marker: 'codexUsage' }
     const openCodeUsage = { marker: 'openCodeUsage' }
-    const codexAccounts = { marker: 'codexAccounts' }
+    const codexAccounts = { marker: 'codexAccounts', runtimeHomeService: { marker: 'runtimeHome' } }
     const claudeAccounts = { marker: 'claudeAccounts' }
     const rateLimits = { marker: 'rateLimits' }
     const agentAwakeService = { marker: 'agentAwakeService' }
@@ -496,7 +496,9 @@ describe('registerCoreHandlers', () => {
     expect(registerAgentHookHandlersMock).toHaveBeenCalledWith(runtime, {
       getPtyIdForPaneKey: expect.any(Function)
     })
-    expect(registerCodexConfigSyncHandlersMock).toHaveBeenCalled()
+    expect(registerCodexConfigSyncHandlersMock).toHaveBeenCalledWith(
+      codexAccounts.runtimeHomeService
+    )
     expect(registerPetHandlersMock).toHaveBeenCalled()
     expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
     expect(registerMiniMaxCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)

--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -496,6 +496,7 @@ describe('registerCoreHandlers', () => {
     expect(registerAgentHookHandlersMock).toHaveBeenCalledWith(runtime, {
       getPtyIdForPaneKey: expect.any(Function)
     })
+    expect(registerCodexConfigSyncHandlersMock).toHaveBeenCalled()
     expect(registerPetHandlersMock).toHaveBeenCalled()
     expect(registerClaudeAccountHandlersMock).toHaveBeenCalledWith(claudeAccounts)
     expect(registerMiniMaxCredentialsHandlersMock).toHaveBeenCalledWith(rateLimits)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -56,6 +56,7 @@ import { registerTerminalRenderDesyncEvidenceHandler } from './terminal-render-d
 import { registerOrcaProfileHandlers } from './orca-profiles'
 import { registerCodexAccountHandlers } from './codex-accounts'
 import { registerAgentHookHandlers } from './agent-hooks'
+import { registerCodexConfigSyncHandlers } from './codex-config-sync'
 import { getPtyIdForPaneKey } from './pty'
 import { registerAgentTrustHandlers } from './agent-trust'
 import { registerClaudeAccountHandlers } from './claude-accounts'
@@ -137,6 +138,7 @@ export function registerCoreHandlers(
   registerOpenCodeUsageHandlers(openCodeUsage)
   registerCodexAccountHandlers(codexAccounts)
   registerAgentHookHandlers(runtime, { getPtyIdForPaneKey })
+  registerCodexConfigSyncHandlers()
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
   registerMiniMaxCredentialsHandlers(rateLimits)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -138,7 +138,7 @@ export function registerCoreHandlers(
   registerOpenCodeUsageHandlers(openCodeUsage)
   registerCodexAccountHandlers(codexAccounts)
   registerAgentHookHandlers(runtime, { getPtyIdForPaneKey })
-  registerCodexConfigSyncHandlers()
+  registerCodexConfigSyncHandlers(codexAccounts.runtimeHomeService)
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
   registerMiniMaxCredentialsHandlers(rateLimits)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -313,6 +313,7 @@ import type { BrowserSetAnnotationViewportBridgeArgs } from '../shared/browser-a
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { E2EConfig } from '../shared/e2e-config'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
+import type { CodexConfigSyncStatus } from '../shared/codex-config-sync-types'
 import type {
   AgentStatusClearIpcPayload,
   AgentStatusIpcPayload,
@@ -2214,6 +2215,7 @@ export type PreloadApi = {
     claudeStatus: () => Promise<AgentHookInstallStatus>
     openClaudeStatus: () => Promise<AgentHookInstallStatus>
     codexStatus: () => Promise<AgentHookInstallStatus>
+    codexConfigSyncStatus: () => Promise<CodexConfigSyncStatus>
     geminiStatus: () => Promise<AgentHookInstallStatus>
     antigravityStatus: () => Promise<AgentHookInstallStatus>
     ampStatus: () => Promise<AgentHookInstallStatus>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2211,11 +2211,13 @@ export type PreloadApi = {
     installWsl: (args?: { distro?: string | null }) => Promise<CliInstallStatus>
     removeWsl: (args?: { distro?: string | null }) => Promise<CliInstallStatus>
   }
+  codexConfigSync: {
+    status: () => Promise<CodexConfigSyncStatus>
+  }
   agentHooks: {
     claudeStatus: () => Promise<AgentHookInstallStatus>
     openClaudeStatus: () => Promise<AgentHookInstallStatus>
     codexStatus: () => Promise<AgentHookInstallStatus>
-    codexConfigSyncStatus: () => Promise<CodexConfigSyncStatus>
     geminiStatus: () => Promise<AgentHookInstallStatus>
     antigravityStatus: () => Promise<AgentHookInstallStatus>
     ampStatus: () => Promise<AgentHookInstallStatus>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,7 @@ import type {
 } from '../shared/terminal-preview'
 import type { CliInstallStatus } from '../shared/cli-install-types'
 import type { AgentHookInstallStatus } from '../shared/agent-hook-types'
+import type { CodexConfigSyncStatus } from '../shared/codex-config-sync-types'
 import type { TerminalPaneSplitSource } from '../shared/feature-education-telemetry'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
@@ -1951,6 +1952,8 @@ const api = {
       ipcRenderer.invoke('agentHooks:openClaudeStatus'),
     codexStatus: (): Promise<AgentHookInstallStatus> =>
       ipcRenderer.invoke('agentHooks:codexStatus'),
+    codexConfigSyncStatus: (): Promise<CodexConfigSyncStatus> =>
+      ipcRenderer.invoke('codexConfigSync:status'),
     geminiStatus: (): Promise<AgentHookInstallStatus> =>
       ipcRenderer.invoke('agentHooks:geminiStatus'),
     antigravityStatus: (): Promise<AgentHookInstallStatus> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1945,6 +1945,9 @@ const api = {
       ipcRenderer.invoke('cli:removeWsl', args)
   },
 
+  codexConfigSync: {
+    status: (): Promise<CodexConfigSyncStatus> => ipcRenderer.invoke('codexConfigSync:status')
+  },
   agentHooks: {
     claudeStatus: (): Promise<AgentHookInstallStatus> =>
       ipcRenderer.invoke('agentHooks:claudeStatus'),
@@ -1952,8 +1955,6 @@ const api = {
       ipcRenderer.invoke('agentHooks:openClaudeStatus'),
     codexStatus: (): Promise<AgentHookInstallStatus> =>
       ipcRenderer.invoke('agentHooks:codexStatus'),
-    codexConfigSyncStatus: (): Promise<CodexConfigSyncStatus> =>
-      ipcRenderer.invoke('codexConfigSync:status'),
     geminiStatus: (): Promise<AgentHookInstallStatus> =>
       ipcRenderer.invoke('agentHooks:geminiStatus'),
     antigravityStatus: (): Promise<AgentHookInstallStatus> =>

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -65,6 +65,8 @@ import {
   DialogTitle
 } from '../ui/dialog'
 import { getCodexAccountAuthWarning } from './codex-account-auth-warning'
+import { getCodexConfigSyncWarning } from './codex-config-sync-warning'
+import type { CodexConfigSyncStatus } from '../../../../shared/codex-config-sync-types'
 import {
   getProviderAccountActiveIdForView,
   getProviderAccountRuntime,
@@ -430,6 +432,33 @@ export function AccountsPane({
         authKind: activeCodexAccountId === null ? systemCodexIdentity?.authKind : undefined
       })
     : null
+  // Why: the mirror keeps serving the last synced settings when ~/.codex is
+  // unusable, so without this the user only sees their edits being ignored.
+  const [codexConfigSync, setCodexConfigSync] = useState<CodexConfigSyncStatus | null>(null)
+  useEffect(() => {
+    if (isRemoteAccountScope) {
+      // Remote scopes own their own config; the desktop status says nothing about them.
+      setCodexConfigSync(null)
+      return
+    }
+    let cancelled = false
+    void window.api.agentHooks
+      .codexConfigSyncStatus()
+      .then((status) => {
+        if (!cancelled) {
+          setCodexConfigSync(status)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setCodexConfigSync(null)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isRemoteAccountScope, codexAccountsLoaded])
+  const codexConfigSyncWarning = getCodexConfigSyncWarning(codexConfigSync)
   const systemCodexMissingSignIn = activeCodexAuthWarning === 'missing-sign-in'
   const systemCodexNeedsSignIn = activeCodexAccountId === null && Boolean(activeCodexAuthWarning)
   const accountRuntimeUnavailable =
@@ -1098,6 +1127,30 @@ export function AccountsPane({
                         'auto.components.settings.AccountsPane.e4a28e8894',
                         'Codex reported that the {{value0}} login needs a fresh sign-in. Sign in again before starting new Codex sessions.',
                         { value0: accountRuntimeSentenceLabel }
+                      )}
+              </span>
+            </div>
+          ) : null}
+          {codexConfigSyncWarning ? (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+              <span>
+                {codexConfigSyncWarning === 'missing-source'
+                  ? translate(
+                      'auto.components.settings.AccountsPane.codexConfigSyncMissingSource',
+                      'Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.',
+                      { value0: codexConfigSync?.systemConfigPath ?? '' }
+                    )
+                  : codexConfigSyncWarning === 'blank-source'
+                    ? translate(
+                        'auto.components.settings.AccountsPane.codexConfigSyncBlankSource',
+                        'Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.',
+                        { value0: codexConfigSync?.systemConfigPath ?? '' }
+                      )
+                    : translate(
+                        'auto.components.settings.AccountsPane.codexConfigSyncUnreadableSource',
+                        "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions.",
+                        { value0: codexConfigSync?.systemConfigPath ?? '' }
                       )}
               </span>
             </div>

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -436,14 +436,16 @@ export function AccountsPane({
   // unusable, so without this the user only sees their edits being ignored.
   const [codexConfigSync, setCodexConfigSync] = useState<CodexConfigSyncStatus | null>(null)
   useEffect(() => {
-    if (isRemoteAccountScope) {
-      // Remote scopes own their own config; the desktop status says nothing about them.
+    // Why: the status resolves the host's own ~/.codex and shared runtime home.
+    // A WSL or remote scope mirrors different homes entirely, so showing it there
+    // would name a config file that has nothing to do with the selected runtime.
+    if (isRemoteAccountScope || accountRuntime.runtime !== 'host') {
       setCodexConfigSync(null)
       return
     }
     let cancelled = false
-    void window.api.agentHooks
-      .codexConfigSyncStatus()
+    void window.api.codexConfigSync
+      .status()
       .then((status) => {
         if (!cancelled) {
           setCodexConfigSync(status)
@@ -457,7 +459,7 @@ export function AccountsPane({
     return () => {
       cancelled = true
     }
-  }, [isRemoteAccountScope, codexAccountsLoaded])
+  }, [isRemoteAccountScope, accountRuntime.runtime, codexAccountsLoaded])
   const codexConfigSyncWarning = getCodexConfigSyncWarning(codexConfigSync)
   const systemCodexMissingSignIn = activeCodexAuthWarning === 'missing-sign-in'
   const systemCodexNeedsSignIn = activeCodexAccountId === null && Boolean(activeCodexAuthWarning)

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -459,7 +459,10 @@ export function AccountsPane({
     return () => {
       cancelled = true
     }
-  }, [isRemoteAccountScope, accountRuntime.runtime, codexAccountsLoaded])
+    // Why: the status resolves whichever home the ACTIVE selection mirrors into
+    // (per-account, shared, or none for the real-home lane), so switching
+    // accounts must refetch or the banner describes the previous account.
+  }, [isRemoteAccountScope, accountRuntime.runtime, activeCodexAccountId, codexAccountsLoaded])
   const codexConfigSyncWarning = getCodexConfigSyncWarning(codexConfigSync)
   const systemCodexMissingSignIn = activeCodexAuthWarning === 'missing-sign-in'
   const systemCodexNeedsSignIn = activeCodexAccountId === null && Boolean(activeCodexAuthWarning)

--- a/src/renderer/src/components/settings/codex-config-sync-warning.test.ts
+++ b/src/renderer/src/components/settings/codex-config-sync-warning.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { getCodexConfigSyncWarning } from './codex-config-sync-warning'
+
+const systemConfigPath = '/home/user/.codex/config.toml'
+
+describe('getCodexConfigSyncWarning', () => {
+  it('stays silent while syncing normally', () => {
+    expect(getCodexConfigSyncWarning({ state: 'synced', reason: null, systemConfigPath })).toBeNull()
+  })
+
+  it('stays silent before the status has loaded', () => {
+    expect(getCodexConfigSyncWarning(null)).toBeNull()
+    expect(getCodexConfigSyncWarning(undefined)).toBeNull()
+  })
+
+  it('surfaces the stall reason so the component can localize it', () => {
+    for (const reason of ['missing-source', 'blank-source', 'unreadable-source'] as const) {
+      expect(getCodexConfigSyncWarning({ state: 'stalled', reason, systemConfigPath })).toBe(reason)
+    }
+  })
+})

--- a/src/renderer/src/components/settings/codex-config-sync-warning.ts
+++ b/src/renderer/src/components/settings/codex-config-sync-warning.ts
@@ -1,0 +1,12 @@
+import type {
+  CodexConfigSyncStallReason,
+  CodexConfigSyncStatus
+} from '../../../../shared/codex-config-sync-types'
+
+// Why: the stall reason stays machine-readable all the way to the component so
+// the sentence is localized at the edge like every other Accounts warning.
+export function getCodexConfigSyncWarning(
+  status: CodexConfigSyncStatus | null | undefined
+): CodexConfigSyncStallReason | null {
+  return status && status.state === 'stalled' ? status.reason : null
+}

--- a/src/renderer/src/components/settings/codex-config-sync-warning.ts
+++ b/src/renderer/src/components/settings/codex-config-sync-warning.ts
@@ -3,8 +3,13 @@ import type {
   CodexConfigSyncStatus
 } from '../../../../shared/codex-config-sync-types'
 
-// Why: the stall reason stays machine-readable all the way to the component so
-// the sentence is localized at the edge like every other Accounts warning.
+/**
+ * Returns the stall reason to warn about, or null when Codex settings are
+ * syncing normally or the status has not loaded yet.
+ *
+ * The reason stays machine-readable all the way to the component so the sentence
+ * is localized at the edge like every other Accounts warning.
+ */
 export function getCodexConfigSyncWarning(
   status: CodexConfigSyncStatus | null | undefined
 ): CodexConfigSyncStallReason | null {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5070,7 +5070,10 @@
           "remoteEmptyClaudeAccounts": "No managed Claude accounts on {{value0}}. It uses its system default Claude login; add accounts on that server.",
           "remoteEmptyCodexAccounts": "No managed Codex accounts on {{value0}}. It uses its system default Codex login; add accounts on that server.",
           "codexSystemDefaultCustomProvider": "Custom provider — no usage tracked.",
-          "codexSystemDefaultNeedsSignIn": "No Codex sign-in was found for {{value0}}."
+          "codexSystemDefaultNeedsSignIn": "No Codex sign-in was found for {{value0}}.",
+          "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
+          "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Restart",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5047,7 +5047,10 @@
           "remoteEmptyClaudeAccounts": "No hay cuentas de Claude administradas en {{value0}}. Usa su inicio de sesión de Claude predeterminado del sistema; agrega cuentas en ese servidor.",
           "remoteEmptyCodexAccounts": "No hay cuentas de Codex administradas en {{value0}}. Usa su inicio de sesión de Codex predeterminado del sistema; agrega cuentas en ese servidor.",
           "codexSystemDefaultCustomProvider": "Proveedor personalizado — no se registra el uso.",
-          "codexSystemDefaultNeedsSignIn": "No se encontró ningún inicio de sesión de Codex para {{value0}}."
+          "codexSystemDefaultNeedsSignIn": "No se encontró ningún inicio de sesión de Codex para {{value0}}.",
+          "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
+          "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
         },
         "AdvancedPane": {
           "40b29e0bf3": "Reiniciar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5032,7 +5032,10 @@
           "remoteEmptyClaudeAccounts": "{{value0}} に管理対象の Claude アカウントはありません。システム既定の Claude ログインを使用します。アカウントの追加はそのサーバー上で行ってください。",
           "remoteEmptyCodexAccounts": "{{value0}} に管理対象の Codex アカウントはありません。システム既定の Codex ログインを使用します。アカウントの追加はそのサーバー上で行ってください。",
           "codexSystemDefaultCustomProvider": "カスタムプロバイダー — 使用量は追跡されません。",
-          "codexSystemDefaultNeedsSignIn": "{{value0}} の Codex サインインが見つかりません。"
+          "codexSystemDefaultNeedsSignIn": "{{value0}} の Codex サインインが見つかりません。",
+          "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
+          "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
         },
         "AdvancedPane": {
           "40b29e0bf3": "再起動",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5032,7 +5032,10 @@
           "remoteEmptyClaudeAccounts": "{{value0}}에 관리되는 Claude 계정이 없습니다. 해당 서버의 시스템 기본 Claude 로그인을 사용하며, 계정 추가는 그 서버에서 진행하세요.",
           "remoteEmptyCodexAccounts": "{{value0}}에 관리되는 Codex 계정이 없습니다. 해당 서버의 시스템 기본 Codex 로그인을 사용하며, 계정 추가는 그 서버에서 진행하세요.",
           "codexSystemDefaultCustomProvider": "사용자 지정 제공업체 — 사용량을 추적하지 않습니다.",
-          "codexSystemDefaultNeedsSignIn": "{{value0}}에 대한 Codex 로그인을 찾을 수 없습니다."
+          "codexSystemDefaultNeedsSignIn": "{{value0}}에 대한 Codex 로그인을 찾을 수 없습니다.",
+          "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
+          "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
         },
         "AdvancedPane": {
           "40b29e0bf3": "다시 시작",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5032,7 +5032,10 @@
           "remoteEmptyClaudeAccounts": "{{value0}} 上没有受管理的 Claude 账户。它使用其系统默认的 Claude 登录；请在该服务器上添加账户。",
           "remoteEmptyCodexAccounts": "{{value0}} 上没有受管理的 Codex 账户。它使用其系统默认的 Codex 登录；请在该服务器上添加账户。",
           "codexSystemDefaultCustomProvider": "自定义提供商 — 不跟踪使用情况。",
-          "codexSystemDefaultNeedsSignIn": "未找到 {{value0}} 的 Codex 登录信息。"
+          "codexSystemDefaultNeedsSignIn": "未找到 {{value0}} 的 Codex 登录信息。",
+          "codexConfigSyncMissingSource": "Codex is still using the settings it last synced because {{value0}} is missing. Restore that file to resume syncing.",
+          "codexConfigSyncBlankSource": "Codex is still using the settings it last synced because {{value0}} is empty. That is expected while a synced folder finishes downloading.",
+          "codexConfigSyncUnreadableSource": "Codex is still using the settings it last synced because {{value0}} could not be read. Check that file's permissions."
         },
         "AdvancedPane": {
           "40b29e0bf3": "重新启动",

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -776,6 +776,12 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     claudeAccounts: createAccountsApi(),
     cli: createCliApi(),
     agentHooks: createAgentHooksApi(),
+    // Why: the desktop derives this from the host filesystem, which the web
+    // client has no view of; reporting synced keeps the warning banner silent.
+    codexConfigSync: {
+      status: () =>
+        Promise.resolve({ state: 'synced', reason: null, systemConfigPath: '' } as const)
+    },
     developerPermissions: createDeveloperPermissionsApi(),
     computerUsePermissions: createComputerUsePermissionsApi(),
     updater: createUpdaterApi(),
@@ -2708,10 +2714,6 @@ function createAgentHooksApi(): NonNullable<Partial<PreloadApi>['agentHooks']> {
       detail: 'Agent hook status is only available on the Orca server.'
     } as const)
   return {
-    // Why: the desktop derives this from the host filesystem, which the web
-    // client has no view of; reporting synced keeps the warning banner silent.
-    codexConfigSyncStatus: () =>
-      Promise.resolve({ state: 'synced', reason: null, systemConfigPath: '' } as const),
     claudeStatus: () => status('claude'),
     openClaudeStatus: () => status('openclaude'),
     codexStatus: () => status('codex'),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2708,6 +2708,10 @@ function createAgentHooksApi(): NonNullable<Partial<PreloadApi>['agentHooks']> {
       detail: 'Agent hook status is only available on the Orca server.'
     } as const)
   return {
+    // Why: the desktop derives this from the host filesystem, which the web
+    // client has no view of; reporting synced keeps the warning banner silent.
+    codexConfigSyncStatus: () =>
+      Promise.resolve({ state: 'synced', reason: null, systemConfigPath: '' } as const),
     claudeStatus: () => status('claude'),
     openClaudeStatus: () => status('openclaude'),
     codexStatus: () => status('codex'),

--- a/src/shared/codex-config-sync-types.ts
+++ b/src/shared/codex-config-sync-types.ts
@@ -1,0 +1,8 @@
+// Why: the managed runtime config keeps serving the last good settings while the
+// source is unusable, so a stall is "working but not picking up your edits" —
+// the reason is what makes it actionable, and the path is what the user fixes.
+export type CodexConfigSyncStallReason = 'missing-source' | 'blank-source' | 'unreadable-source'
+
+export type CodexConfigSyncStatus =
+  | { state: 'synced'; reason: null; systemConfigPath: string }
+  | { state: 'stalled'; reason: CodexConfigSyncStallReason; systemConfigPath: string }


### PR DESCRIPTION
## Summary

When Orca can't read `~/.codex/config.toml`, the mirror keeps serving the settings it last synced instead of wiping the managed runtime config (#9127). That is the right call for data safety, but it was completely invisible — no log line, no UI, no IPC. The user's symptom is "I edited my Codex config and Orca ignores it," with nothing to diagnose.

This surfaces the stall.

## ELI5

If Orca can't read your Codex settings file, it keeps using the last copy it understood — so nothing breaks. But it never told you that was happening, so your edits looked like they were being ignored for no reason. Now it says so, and names the file to fix.

## What changed

- **Codex account settings shows a banner** naming the exact file and what to do. The copy is reason-specific: a blank file reads as "expected while a synced folder finishes downloading", not as an error.
- **One log line per stall episode**, not one per launch and quota poll, plus a recovery line when it clears.
- Three distinct causes are kept apart rather than collapsed: `missing-source`, `blank-source`, `unreadable-source`.

Status is derived on demand from the same predicates the mirror uses, so the two can't drift — there is no cached state to invalidate. The value crossing IPC stays machine-readable (`state` + `reason` + path); the sentence is localized at the edge via `translate()` like every other Accounts warning.

## Evidence

Captured against a real Codex setup (real `codex-cli 0.145.0`, a real managed Codex account selected, real per-account home).

The stall banner in the Codex section of AI Provider Accounts, naming the exact source config that is missing:

![real-02-banner.png](https://github.com/user-attachments/assets/f9d4bcf3-b23d-4539-add3-028698cf093d)

A real Codex terminal session in the same run, showing Orca injected the **per-account** home as `CODEX_HOME` — the same home the status resolver reported on and the mirror logged, so all three agree:

![real-03-codex-session.png](https://github.com/user-attachments/assets/4c8d34e4-464c-40ec-94b7-d1b296f6c44d)

The stall clears as soon as the source returns; that transition is covered by the unit tests rather than a screenshot.

Diagnostic log line from that same run:

```
[codex-config] Config sync stalled (missing-source): /tmp/.../.codex/config.toml is unusable,
so .../codex-runtime-home/home keeps its last synced settings. Edits to the source will not
apply until it is readable.
```

The banner is derived on demand so the UI clears instantly, while the log line follows the next mirror pass. That asymmetry is deliberate: the UI reflects truth now, the log records what the mirror actually did.

## Validation

- 3761 tests pass across `src/main/codex`, `src/main/ipc`, `src/renderer/.../settings`, `src/renderer/src/web`.
- Typecheck clean, lint 0 errors, max-lines ratchet clean (no new bypasses).
- Each new test fails when its own fix is reverted — verified by reverting the blank-source detection and the episode latch independently.

## Deliberately out of scope

Each of these deserves its own change rather than riding along:

- A **"Re-sync now"** button. The mirror already runs every launch and on the quota poll, so it saves little time; its real value is confirmation feedback.
- A **supported reset path**. Emptying `~/.codex/config.toml` used to clear runtime settings and no longer does, with nothing offered in its place.
- The mirror also **pauses the runtime config's duplicate-`[projects.*]` self-heal** while stalled.

## Screenshots

Included above under **Evidence** — stall banner and the recovered (cleared) state, captured from a dev build.

## Testing

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `npx vitest run --config config/vitest.config.ts src/main/codex src/main/ipc src/renderer/src/components/settings src/renderer/src/web` — 3792 passed
- [x] `pnpm run check:max-lines-ratchet` — no new bypasses
- [x] Manual: dev build with an unreadable source, banner verified in Settings -> AI Provider Accounts, then verified it clears on recovery
- [x] Revert-proofed: each new test fails when its own fix is reverted

Known unrelated failure: `config/scripts/package-electron-runtime-contract.test.mjs > keeps release-cut version commits skill-independent and taggable on retries` fails identically on clean `origin/main` (verified in a detached worktree at `e133d93b7b`). This PR touches no release tooling.

## AI Review Report

Automated review raised two functional findings, both fixed in `6d0c85bb8b`:

1. **Major** — `unreadable-source` never reached the episode latch, because that case throws out of the mirror and reporting only happened on the success path. It logged the raw failure on every launch and quota poll while the reason never surfaced. Now reported from the catch path, with a regression test asserting one latched `unreadable-source` line across three passes.
2. **Minor** — the clear message claimed the source was "readable again", which is false when the stall ended because the runtime config was removed. Reworded to "stall cleared", with a test asserting the phrase is absent.

While fixing those I also found the tests' inline `mockRestore()` was skipped by a failing assertion, leaking a `console.warn` spy and cascading spurious failures into later cases; cleanup moved to `afterEach`.

## Security Audit

- No new network calls, subprocesses, or filesystem writes. The added code only **reads** `~/.codex/config.toml` and `existsSync`-checks two paths.
- The absolute config path is shown in the user's own settings UI and written to the app log. It is a path, not file contents — no config values, tokens, or credentials are read into the status or logged.
- New IPC channel `codexConfigSync:status` is read-only, takes no arguments, and returns a closed union plus that path.
- The web fallback returns `synced`, so a browser client cannot infer anything about the host filesystem.

## Known gap

A **promotion-blocked** mirror is not surfaced in the UI. If `~/.codex/config.toml` is present and readable but the write-back cannot be performed (read-only `~/.codex`, or a symlink cycle), promotion throws, the mirror is skipped, and the stall is logged with a reason but the banner stays silent — `getCodexConfigSyncStatus` derives from disk and has no visibility into "promotion threw".

Not a regression: that failure mode was equally silent before this PR, and the log line is new. Surfacing it needs a fourth stall reason plus coupling the IPC status to the module latch, which would give up the stateless "status and mirror cannot disagree" property this PR is built on. Tracked as a follow-up rather than bundled here.

## Notes

Follow-ups deliberately not bundled here, each listed under **Deliberately out of scope** above: a "Re-sync now" button, a supported reset path, and the paused duplicate-`[projects.*]` self-heal.


