### PR TITLE
fix(settings): guide Windows skill setup when npx is missing

### DIFF
--- a/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
@@ -30,10 +30,11 @@ export function MobileEmulatorAgentSetupGuideSteps({
 }: MobileEmulatorAgentSetupGuideStepsProps): React.JSX.Element {
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const skillInstallCommand = buildSkillCommandForRuntime(
-    ORCA_CLI_SKILL_INSTALL_COMMAND,
-    activeSkillRuntime.agentRuntime
-  )
+  // Why: a repair-required runtime resolves to a WSL distro that is missing, so
+  // fall back to the plain command rather than emitting an unrunnable wsl.exe one.
+  const skillInstallCommand = activeSkillRuntime.installDisabledReason
+    ? ORCA_CLI_SKILL_INSTALL_COMMAND
+    : buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
   const terminalWorktreeId = `mobile-emulator-${worktreeId}-orca-cli-skill-terminal`
   const showSkillPreInstallNotice = shouldShowMobileEmulatorSkillPreInstallNotice({
     cliEnabled: setup.cliEnabled,
@@ -169,8 +170,10 @@ export function MobileEmulatorAgentSetupGuideSteps({
             terminalShellOverride={activeSkillRuntime.terminalShellOverride}
             installed={setup.cliSkillInstalled}
             loading={setup.cliSkillLoading || setup.setupRechecking}
-            error={setup.cliSkillError}
-            installDisabled={setup.step2Blocked}
+            error={activeSkillRuntime.installDisabledReason ?? setup.cliSkillError}
+            installDisabled={
+              setup.step2Blocked || Boolean(activeSkillRuntime.installDisabledReason)
+            }
             showInstallWhenInstalled={!setup.cliSkillInstalled}
             terminalHeightPx={112}
             preInstallNotice={

--- a/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
@@ -2,11 +2,13 @@ import { Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { ORCA_CLI_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
+import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
   ensureOrcaCliAvailableForAgentSkillTerminal
 } from '@/lib/agent-skill-cli-prerequisite'
 import { AgentSkillSetupPanel } from '../settings/AgentSkillSetupPanel'
+import { buildSkillCommandForRuntime } from '../settings/CliSkillRuntimeSetup'
 import { StepBadge } from '../settings/BrowserUseStepBadge'
 import { Button } from '../ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
@@ -27,6 +29,11 @@ export function MobileEmulatorAgentSetupGuideSteps({
   worktreeId
 }: MobileEmulatorAgentSetupGuideStepsProps): React.JSX.Element {
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
+  const activeSkillRuntime = useActiveProjectSkillRuntime()
+  const skillInstallCommand = buildSkillCommandForRuntime(
+    ORCA_CLI_SKILL_INSTALL_COMMAND,
+    activeSkillRuntime.agentRuntime
+  )
   const terminalWorktreeId = `mobile-emulator-${worktreeId}-orca-cli-skill-terminal`
   const showSkillPreInstallNotice = shouldShowMobileEmulatorSkillPreInstallNotice({
     cliEnabled: setup.cliEnabled,
@@ -149,7 +156,7 @@ export function MobileEmulatorAgentSetupGuideSteps({
               'auto.components.emulator.pane.MobileEmulatorAgentSetupGuideSteps.64fb057667',
               'Teaches agents the orca emulator commands for this worktree.'
             )}
-            command={ORCA_CLI_SKILL_INSTALL_COMMAND}
+            command={skillInstallCommand}
             terminalTitle={translate(
               'auto.components.emulator.pane.MobileEmulatorAgentSetupGuideSteps.5c59ea96ca',
               'Mobile emulator Orca CLI skill setup'
@@ -159,6 +166,7 @@ export function MobileEmulatorAgentSetupGuideSteps({
               'Mobile emulator Orca CLI skill install terminal'
             )}
             terminalWorktreeId={terminalWorktreeId}
+            terminalShellOverride={activeSkillRuntime.terminalShellOverride}
             installed={setup.cliSkillInstalled}
             loading={setup.cliSkillLoading || setup.setupRechecking}
             error={setup.cliSkillError}

--- a/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
@@ -30,11 +30,9 @@ export function MobileEmulatorAgentSetupGuideSteps({
 }: MobileEmulatorAgentSetupGuideStepsProps): React.JSX.Element {
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  // Why: a repair-required runtime resolves to a WSL distro that is missing, so
-  // fall back to the plain command rather than emitting an unrunnable wsl.exe one.
-  const skillInstallCommand = activeSkillRuntime.installDisabledReason
-    ? ORCA_CLI_SKILL_INSTALL_COMMAND
-    : buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
+  // Why: skill detection here scans the local host only, so keep building host
+  // commands; routing them to a WSL runtime would install where we never look.
+  const skillInstallCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)
   const terminalWorktreeId = `mobile-emulator-${worktreeId}-orca-cli-skill-terminal`
   const showSkillPreInstallNotice = shouldShowMobileEmulatorSkillPreInstallNotice({
     cliEnabled: setup.cliEnabled,
@@ -170,10 +168,8 @@ export function MobileEmulatorAgentSetupGuideSteps({
             terminalShellOverride={activeSkillRuntime.terminalShellOverride}
             installed={setup.cliSkillInstalled}
             loading={setup.cliSkillLoading || setup.setupRechecking}
-            error={activeSkillRuntime.installDisabledReason ?? setup.cliSkillError}
-            installDisabled={
-              setup.step2Blocked || Boolean(activeSkillRuntime.installDisabledReason)
-            }
+            error={setup.cliSkillError}
+            installDisabled={setup.step2Blocked}
             showInstallWhenInstalled={!setup.cliSkillInstalled}
             terminalHeightPx={112}
             preInstallNotice={

--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
@@ -10,10 +10,14 @@ import { translate } from '@/i18n/i18n'
 
 export function CliSkillSetupTerminal(): React.JSX.Element {
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const skillCommand = buildSkillCommandForRuntime(
-    ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
-    activeSkillRuntime.agentRuntime
-  )
+  // Why: a repair-required runtime resolves to a WSL distro that is missing, so
+  // fall back to the plain command rather than emitting an unrunnable wsl.exe one.
+  const skillCommand = activeSkillRuntime.installDisabledReason
+    ? ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND
+    : buildSkillCommandForRuntime(
+        ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
 
   const handleCopySkillCommand = async (): Promise<void> => {
     try {

--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
@@ -3,13 +3,21 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { OnboardingInlineCommandTerminal } from '@/components/onboarding/OnboardingInlineCommandTerminal'
+import { buildSkillCommandForRuntime } from '@/components/settings/CliSkillRuntimeSetup'
 import { ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
+import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
 import { translate } from '@/i18n/i18n'
 
 export function CliSkillSetupTerminal(): React.JSX.Element {
+  const activeSkillRuntime = useActiveProjectSkillRuntime()
+  const skillCommand = buildSkillCommandForRuntime(
+    ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
+    activeSkillRuntime.agentRuntime
+  )
+
   const handleCopySkillCommand = async (): Promise<void> => {
     try {
-      await window.api.ui.writeClipboardText(ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND)
+      await window.api.ui.writeClipboardText(skillCommand)
       toast.success(
         translate(
           'auto.components.feature.tips.CliSkillSetupTerminal.b8ad063571',
@@ -32,7 +40,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
     <div className="min-w-0">
       <div className="flex min-w-0 items-center gap-2 rounded-md border border-border bg-muted/35 px-3 py-2">
         <code className="scrollbar-sleek min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
-          {ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND}
+          {skillCommand}
         </code>
         <Tooltip>
           <TooltipTrigger asChild>
@@ -58,7 +66,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
         </Tooltip>
       </div>
       <OnboardingInlineCommandTerminal
-        command={ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND}
+        command={skillCommand}
         title={translate(
           'auto.components.feature.tips.CliSkillSetupTerminal.84e9576dac',
           'Skill setup'
@@ -76,6 +84,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
         descriptionPaddingClassName="px-4 py-2"
         autoScrollIntoView={false}
         worktreeId="feature-tip-cli-skills-terminal"
+        shellOverride={activeSkillRuntime.terminalShellOverride}
       />
     </div>
   )

--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
@@ -11,13 +11,13 @@ import { translate } from '@/i18n/i18n'
 export function CliSkillSetupTerminal(): React.JSX.Element {
   const activeSkillRuntime = useActiveProjectSkillRuntime()
   // Why: a repair-required runtime resolves to a WSL distro that is missing, so
-  // fall back to the plain command rather than emitting an unrunnable wsl.exe one.
-  const skillCommand = activeSkillRuntime.installDisabledReason
-    ? ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND
-    : buildSkillCommandForRuntime(
-        ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
-        activeSkillRuntime.agentRuntime
-      )
+  // drop back to the host runtime. This terminal auto-pastes with no install
+  // gate, and repair-required only happens on Windows, so it still needs the
+  // npx preflight.
+  const skillCommand = buildSkillCommandForRuntime(
+    ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
+    activeSkillRuntime.installDisabledReason ? undefined : activeSkillRuntime.agentRuntime
+  )
 
   const handleCopySkillCommand = async (): Promise<void> => {
     try {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -219,17 +219,29 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
 
   it('skips the Windows preflight while a remote runtime environment is focused', () => {
     const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    const windowsHost = { runtime: 'host', label: 'Windows' } as const
+    const previous = useAppStore.getState()
     useAppStore.setState({
-      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'remote-linux' }
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'remote-linux' },
+      runtimeEnvironments: [{ id: 'remote-linux' }] as never
     })
 
     try {
       // Setup terminals spawn on the focused runtime, so cmd.exe would not exist there.
-      expect(
-        buildSkillCommandForRuntime(installCommand, { runtime: 'host', label: 'Windows' }, 'win32')
-      ).toBe(installCommand)
+      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(installCommand)
+
+      // A second saved environment routes the terminal back to the Windows host.
+      useAppStore.setState({
+        runtimeEnvironments: [{ id: 'remote-linux' }, { id: 'other' }] as never
+      })
+      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toContain(
+        'where.exe npx'
+      )
     } finally {
-      useAppStore.setState({ settings: getDefaultSettings('/tmp') })
+      useAppStore.setState({
+        settings: previous.settings,
+        runtimeEnvironments: previous.runtimeEnvironments
+      })
     }
   })
 

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -29,6 +29,12 @@ function getWslOuterShellScript(command: string): string {
 }
 
 describe('CliSkillRuntimeSetup runtime helpers', () => {
+  const windowsNpxPreflightPrefix =
+    'cmd.exe /d /s /c "where.exe npx.cmd >nul 2>nul & if errorlevel 1 ('
+  const windowsNpxGuidance =
+    'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx, then restart Orca and try again. & echo If Node.js is already installed, add it to PATH before restarting Orca. & exit /b 1'
+  const windowsNpxCommand = (command: string): string => command.replace(/^npx\b/i, 'npx.cmd')
+
   it('wraps WSL skill installs as a directly runnable selected-distro command', () => {
     const skillCommand = 'npx skills add orchestration --global'
     const command = buildSkillInstallCommandForRuntime(skillCommand, {
@@ -41,6 +47,25 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     expect(command).toBe(
       `& { $PSNativeCommandArgumentPassing = 'Legacy'; wsl.exe -d 'Ubuntu' -- sh -c 'eval \\"\`printf %s ${encoded} | base64 -d\`\\"' } # Runs: ${skillCommand}`
     )
+    expect(decodeWslLoginShellScript(command)).toContain(
+      'exec "$_orca_wsl_shell" -ilc \'npx skills add orchestration --global\''
+    )
+  })
+
+  it('keeps a Windows-selected WSL install inside WSL without the host preflight', () => {
+    const skillCommand = 'npx skills add orchestration --global'
+    const command = buildSkillCommandForRuntime(
+      skillCommand,
+      {
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu',
+        label: 'WSL Ubuntu'
+      },
+      'win32'
+    )
+
+    expect(command).toContain("wsl.exe -d 'Ubuntu'")
+    expect(command).not.toContain('where.exe npx.cmd')
     expect(decodeWslLoginShellScript(command)).toContain(
       'exec "$_orca_wsl_shell" -ilc \'npx skills add orchestration --global\''
     )
@@ -118,7 +143,34 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     }
   )
 
-  it('reinstalls Windows-host skill updates through the add path', () => {
+  it('preflights npx before Windows-host skill installs', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])
+
+    expect(
+      buildSkillCommandForRuntime(
+        installCommand,
+        {
+          runtime: 'host',
+          label: 'Windows'
+        },
+        'win32'
+      )
+    ).toBe(
+      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
+    )
+  })
+
+  it('treats missing runtime as a preflighted Windows host fallback for skill installs', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])
+
+    expect(buildSkillCommandForRuntime(installCommand, undefined, 'win32')).toBe(
+      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
+    )
+  })
+
+  it('reinstalls Windows-host skill updates after the npx preflight', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+
     expect(
       buildSkillCommandForRuntime(
         'npx skills update orchestration --global',
@@ -128,13 +180,34 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         },
         'win32'
       )
-    ).toBe(buildAgentFeatureSkillInstallCommand(['orchestration']))
+    ).toBe(
+      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
+    )
   })
 
-  it('treats missing runtime as a Windows host fallback for skill updates', () => {
+  it('treats missing runtime as a preflighted Windows host fallback for skill updates', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orca-cli'])
+
     expect(
       buildSkillCommandForRuntime('npx skills update orca-cli --global', undefined, 'win32')
-    ).toBe(buildAgentFeatureSkillInstallCommand(['orca-cli']))
+    ).toBe(
+      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
+    )
+  })
+
+  it('keeps non-Windows host skill installs on the direct npx path', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+
+    expect(
+      buildSkillCommandForRuntime(
+        installCommand,
+        {
+          runtime: 'host',
+          label: 'This device'
+        },
+        'linux'
+      )
+    ).toBe(installCommand)
   })
 
   it('keeps non-Windows host skill updates on the update path', () => {
@@ -148,6 +221,19 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         'linux'
       )
     ).toBe('npx skills update orchestration --global')
+  })
+
+  it('does not wrap unrelated Windows host commands', () => {
+    expect(
+      buildSkillCommandForRuntime(
+        'orca skills list',
+        {
+          runtime: 'host',
+          label: 'Windows'
+        },
+        'win32'
+      )
+    ).toBe('orca skills list')
   })
 
   it('preserves the selected WSL distro for skill discovery', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -227,16 +227,14 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     })
 
     try {
-      // Setup terminals spawn on the focused runtime, so cmd.exe would not exist there.
+      // Setup terminals can spawn on the focused runtime, so cmd.exe may not exist there.
       expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(installCommand)
 
-      // A second saved environment routes the terminal back to the Windows host.
+      // Extra saved environments must not reintroduce the wrapper either.
       useAppStore.setState({
         runtimeEnvironments: [{ id: 'remote-linux' }, { id: 'other' }] as never
       })
-      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toContain(
-        'where.exe npx'
-      )
+      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(installCommand)
     } finally {
       useAppStore.setState({
         settings: previous.settings,

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
+import { useAppStore } from '@/store'
 import {
   buildSkillCommandForRuntime,
   buildSkillInstallCommandForRuntime,
@@ -214,6 +215,22 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         'linux'
       )
     ).toBe('npx skills update orchestration --global')
+  })
+
+  it('skips the Windows preflight while a remote runtime environment is focused', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    useAppStore.setState({
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: 'remote-linux' }
+    })
+
+    try {
+      // Setup terminals spawn on the focused runtime, so cmd.exe would not exist there.
+      expect(
+        buildSkillCommandForRuntime(installCommand, { runtime: 'host', label: 'Windows' }, 'win32')
+      ).toBe(installCommand)
+    } finally {
+      useAppStore.setState({ settings: getDefaultSettings('/tmp') })
+    }
   })
 
   it('does not wrap unrelated Windows host commands', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -9,6 +9,7 @@ import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-co
 import {
   buildSkillCommandForRuntime,
   buildSkillInstallCommandForRuntime,
+  getAgentSkillTerminalShellOverride,
   getSelectedAgentRuntime,
   getSkillDiscoveryTargetForRuntime
 } from './CliSkillRuntimeSetup'
@@ -29,11 +30,9 @@ function getWslOuterShellScript(command: string): string {
 }
 
 describe('CliSkillRuntimeSetup runtime helpers', () => {
-  const windowsNpxPreflightPrefix =
-    'cmd.exe /d /s /c "where.exe npx.cmd >nul 2>nul & if errorlevel 1 ('
+  const windowsNpxPreflightPrefix = 'cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 ('
   const windowsNpxGuidance =
-    'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx, then restart Orca and try again. & echo If Node.js is already installed, add it to PATH before restarting Orca. & exit /b 1'
-  const windowsNpxCommand = (command: string): string => command.replace(/^npx\b/i, 'npx.cmd')
+    'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1'
 
   it('wraps WSL skill installs as a directly runnable selected-distro command', () => {
     const skillCommand = 'npx skills add orchestration --global'
@@ -65,7 +64,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     )
 
     expect(command).toContain("wsl.exe -d 'Ubuntu'")
-    expect(command).not.toContain('where.exe npx.cmd')
+    expect(command).not.toContain('where.exe npx')
     expect(decodeWslLoginShellScript(command)).toContain(
       'exec "$_orca_wsl_shell" -ilc \'npx skills add orchestration --global\''
     )
@@ -155,16 +154,14 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         },
         'win32'
       )
-    ).toBe(
-      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
-    )
+    ).toBe(`${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`)
   })
 
   it('treats missing runtime as a preflighted Windows host fallback for skill installs', () => {
     const installCommand = buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])
 
     expect(buildSkillCommandForRuntime(installCommand, undefined, 'win32')).toBe(
-      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
+      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`
     )
   })
 
@@ -180,9 +177,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         },
         'win32'
       )
-    ).toBe(
-      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
-    )
+    ).toBe(`${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`)
   })
 
   it('treats missing runtime as a preflighted Windows host fallback for skill updates', () => {
@@ -190,9 +185,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
 
     expect(
       buildSkillCommandForRuntime('npx skills update orca-cli --global', undefined, 'win32')
-    ).toBe(
-      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${windowsNpxCommand(installCommand)})"`
-    )
+    ).toBe(`${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`)
   })
 
   it('keeps non-Windows host skill installs on the direct npx path', () => {
@@ -234,6 +227,39 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         'win32'
       )
     ).toBe('orca skills list')
+  })
+
+  it('emits a cmd.exe payload that cannot break its own if/else block', () => {
+    const wrapped = buildSkillCommandForRuntime(
+      buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration']),
+      { runtime: 'host', label: 'Windows' },
+      'win32'
+    )
+
+    // cmd.exe /s strips only the first and last quote and passes the rest verbatim.
+    expect(wrapped.match(/"/g)).toHaveLength(2)
+    const blocks = /if errorlevel 1 \((.*)\) else \((.*)\)"$/.exec(wrapped)
+    expect(blocks).not.toBeNull()
+    for (const block of [blocks![1], blocks![2]]) {
+      // Any of these would close the block early or redirect inside cmd.exe.
+      expect(block).not.toMatch(/[()"%!^|<>]/)
+    }
+  })
+
+  it('forces PowerShell for the skill terminal when Windows runs a POSIX-family shell', () => {
+    const hostRuntime = { runtime: 'host', label: 'Windows' } as const
+    const overrideFor = (terminalWindowsShell: string): string | undefined =>
+      getAgentSkillTerminalShellOverride(
+        'win32',
+        { ...getDefaultSettings('/tmp'), terminalWindowsShell },
+        hostRuntime
+      )
+
+    // Git Bash rewrites the leading /d /s /c arguments as MSYS paths.
+    expect(overrideFor('git-bash')).toBe('powershell.exe')
+    expect(overrideFor('wsl.exe')).toBe('powershell.exe')
+    expect(overrideFor('cmd.exe')).toBeUndefined()
+    expect(overrideFor('powershell.exe')).toBeUndefined()
   })
 
   it('preserves the selected WSL distro for skill discovery', () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -86,7 +86,11 @@ export function buildSkillCommandForRuntime(
     currentPlatform
   )
   if (resolvedRuntime.runtime !== 'wsl') {
-    return normalizedCommand
+    return wrapWindowsSkillCommandWithNpxPrerequisite(
+      normalizedCommand,
+      resolvedRuntime,
+      currentPlatform
+    )
   }
 
   const distroArg = resolvedRuntime.wslDistro?.trim()
@@ -122,6 +126,28 @@ function normalizeWindowsSkillUpdateCommand(
   // Windows, while reinstalling from the same repo source is idempotent and
   // keeps the setup affordance working.
   return buildAgentFeatureSkillInstallCommand([updateMatch[1]])
+}
+
+function wrapWindowsSkillCommandWithNpxPrerequisite(
+  command: string,
+  runtime: LocalAgentRuntime,
+  currentPlatform: NodeJS.Platform
+): string {
+  const trimmedCommand = command.trim()
+  if (
+    runtime.runtime === 'wsl' ||
+    currentPlatform !== 'win32' ||
+    !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)
+  ) {
+    return command
+  }
+
+  const missingNpxGuidance =
+    'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx, then restart Orca and try again. & echo If Node.js is already installed, add it to PATH before restarting Orca. & exit /b 1'
+  const executableCommand = trimmedCommand.replace(/^npx\b/i, 'npx.cmd')
+  // Why: cmd.exe provides one shell-neutral boundary for PowerShell, Command
+  // Prompt, and Git Bash while executing the exact shim that the preflight found.
+  return `cmd.exe /d /s /c "where.exe npx.cmd >nul 2>nul & if errorlevel 1 (${missingNpxGuidance}) else (${executableCommand})"`
 }
 
 function getSkillCommandPlatform(): NodeJS.Platform {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -9,7 +9,6 @@ import {
 } from '../../../../shared/powershell-native-argument'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
 import { getProjectAgentSkillTerminalShellOverride } from '@/lib/project-skill-runtime'
-import { getSingleFocusedRuntimeEnvironmentId } from '@/lib/single-runtime-legacy-owner'
 import { useAppStore } from '@/store'
 import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { toast } from 'sonner'
@@ -151,9 +150,11 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
 }
 
 function isRemoteRuntimeEnvironmentFocused(): boolean {
-  // Why: match the resolver the setup terminal itself routes through, so the
-  // wrapper is skipped exactly when the terminal lands off the Windows host.
-  return getSingleFocusedRuntimeEnvironmentId(useAppStore.getState()) !== null
+  // Why: the terminal router also weighs how many environments are saved, but
+  // that slice has no subscriber here. Read only the focused id, which every
+  // caller re-renders on: it over-skips rather than ever handing a cmd.exe
+  // command to a remote shell.
+  return Boolean(useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim())
 }
 
 function getSkillCommandPlatform(): NodeJS.Platform {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../../shared/powershell-native-argument'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
 import { getProjectAgentSkillTerminalShellOverride } from '@/lib/project-skill-runtime'
+import { useAppStore } from '@/store'
 import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
@@ -130,7 +131,13 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
   currentPlatform: NodeJS.Platform
 ): string {
   const trimmedCommand = command.trim()
-  if (currentPlatform !== 'win32' || !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)) {
+  if (
+    currentPlatform !== 'win32' ||
+    // Why: skill setup terminals spawn on the focused runtime environment, so a
+    // Windows client must not hand a cmd.exe command to a remote host.
+    isRemoteRuntimeEnvironmentFocused() ||
+    !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)
+  ) {
     return command
   }
 
@@ -140,6 +147,10 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
   // Prompt, and it resolves the bare name through PATHEXT for both the
   // preflight and the executed command, so shims such as npx.exe still count.
   return `cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (${missingNpxGuidance}) else (${trimmedCommand})"`
+}
+
+function isRemoteRuntimeEnvironmentFocused(): boolean {
+  return Boolean(useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim())
 }
 
 function getSkillCommandPlatform(): NodeJS.Platform {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../../shared/powershell-native-argument'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
 import { getProjectAgentSkillTerminalShellOverride } from '@/lib/project-skill-runtime'
+import { getSingleFocusedRuntimeEnvironmentId } from '@/lib/single-runtime-legacy-owner'
 import { useAppStore } from '@/store'
 import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { toast } from 'sonner'
@@ -150,7 +151,9 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
 }
 
 function isRemoteRuntimeEnvironmentFocused(): boolean {
-  return Boolean(useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim())
+  // Why: match the resolver the setup terminal itself routes through, so the
+  // wrapper is skipped exactly when the terminal lands off the Windows host.
+  return getSingleFocusedRuntimeEnvironmentId(useAppStore.getState()) !== null
 }
 
 function getSkillCommandPlatform(): NodeJS.Platform {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -8,7 +8,7 @@ import {
   quotePowerShellNativeArgument
 } from '../../../../shared/powershell-native-argument'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
-import { resolveWindowsShellStartupFamily } from '../../../../shared/windows-terminal-shell'
+import { getProjectAgentSkillTerminalShellOverride } from '@/lib/project-skill-runtime'
 import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
@@ -87,11 +87,7 @@ export function buildSkillCommandForRuntime(
     currentPlatform
   )
   if (resolvedRuntime.runtime !== 'wsl') {
-    return wrapWindowsSkillCommandWithNpxPrerequisite(
-      normalizedCommand,
-      resolvedRuntime,
-      currentPlatform
-    )
+    return wrapWindowsSkillCommandWithNpxPrerequisite(normalizedCommand, currentPlatform)
   }
 
   const distroArg = resolvedRuntime.wslDistro?.trim()
@@ -131,15 +127,10 @@ function normalizeWindowsSkillUpdateCommand(
 
 function wrapWindowsSkillCommandWithNpxPrerequisite(
   command: string,
-  runtime: LocalAgentRuntime,
   currentPlatform: NodeJS.Platform
 ): string {
   const trimmedCommand = command.trim()
-  if (
-    runtime.runtime === 'wsl' ||
-    currentPlatform !== 'win32' ||
-    !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)
-  ) {
+  if (currentPlatform !== 'win32' || !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)) {
     return command
   }
 
@@ -188,17 +179,11 @@ export function getAgentSkillTerminalShellOverride(
   settings: GlobalSettings,
   runtime: LocalAgentRuntime
 ): string | undefined {
-  if (currentPlatform !== 'win32') {
-    return undefined
-  }
-  if (runtime.runtime === 'wsl') {
-    return 'powershell.exe'
-  }
-  // Why: generated skill commands are PowerShell/cmd syntax, so a POSIX-family
-  // Windows shell (wsl.exe, Git Bash) would mangle the wrapper we hand it.
-  return resolveWindowsShellStartupFamily(settings.terminalWindowsShell) === 'posix'
-    ? 'powershell.exe'
-    : undefined
+  return getProjectAgentSkillTerminalShellOverride(
+    currentPlatform as NodeJS.Platform,
+    settings,
+    runtime
+  )
 }
 
 export async function ensureWslCliAvailableForAgentSkillTerminal(

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -8,6 +8,7 @@ import {
   quotePowerShellNativeArgument
 } from '../../../../shared/powershell-native-argument'
 import { buildWslLoginShellCommand } from '../../../../shared/wsl-login-shell-command'
+import { resolveWindowsShellStartupFamily } from '../../../../shared/windows-terminal-shell'
 import { buildAgentFeatureSkillInstallCommand } from '../../../../shared/agent-feature-install-commands'
 import { toast } from 'sonner'
 import type { CliInstallStatus } from '../../../../shared/cli-install-types'
@@ -143,11 +144,11 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
   }
 
   const missingNpxGuidance =
-    'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx, then restart Orca and try again. & echo If Node.js is already installed, add it to PATH before restarting Orca. & exit /b 1'
-  const executableCommand = trimmedCommand.replace(/^npx\b/i, 'npx.cmd')
-  // Why: cmd.exe provides one shell-neutral boundary for PowerShell, Command
-  // Prompt, and Git Bash while executing the exact shim that the preflight found.
-  return `cmd.exe /d /s /c "where.exe npx.cmd >nul 2>nul & if errorlevel 1 (${missingNpxGuidance}) else (${executableCommand})"`
+    'echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1'
+  // Why: cmd.exe is one shell-neutral boundary for PowerShell and Command
+  // Prompt, and it resolves the bare name through PATHEXT for both the
+  // preflight and the executed command, so shims such as npx.exe still count.
+  return `cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (${missingNpxGuidance}) else (${trimmedCommand})"`
 }
 
 function getSkillCommandPlatform(): NodeJS.Platform {
@@ -193,7 +194,11 @@ export function getAgentSkillTerminalShellOverride(
   if (runtime.runtime === 'wsl') {
     return 'powershell.exe'
   }
-  return settings.terminalWindowsShell.toLowerCase() === 'wsl.exe' ? 'powershell.exe' : undefined
+  // Why: generated skill commands are PowerShell/cmd syntax, so a POSIX-family
+  // Windows shell (wsl.exe, Git Bash) would mangle the wrapper we hand it.
+  return resolveWindowsShellStartupFamily(settings.terminalWindowsShell) === 'posix'
+    ? 'powershell.exe'
+    : undefined
 }
 
 export async function ensureWslCliAvailableForAgentSkillTerminal(

--- a/src/renderer/src/components/settings/EphemeralVmsPane.tsx
+++ b/src/renderer/src/components/settings/EphemeralVmsPane.tsx
@@ -45,20 +45,20 @@ export function EphemeralVmsPane(): React.JSX.Element {
   const [promptCopied, setPromptCopied] = useState(false)
   const mountedRef = useMountedRef()
 
-  const installCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          EPHEMERAL_VMS_SKILL_INSTALL_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : EPHEMERAL_VMS_SKILL_INSTALL_COMMAND
-  const updateCommand =
-    activeSkillRuntime.agentRuntime && !activeSkillRuntime.installDisabledReason
-      ? buildSkillCommandForRuntime(
-          EPHEMERAL_VMS_SKILL_UPDATE_COMMAND,
-          activeSkillRuntime.agentRuntime
-        )
-      : EPHEMERAL_VMS_SKILL_UPDATE_COMMAND
+  // Why: an absent runtime still resolves to the local host, which is what the
+  // seven sibling panes rely on to reach the Windows npx preflight.
+  const installCommand = activeSkillRuntime.installDisabledReason
+    ? EPHEMERAL_VMS_SKILL_INSTALL_COMMAND
+    : buildSkillCommandForRuntime(
+        EPHEMERAL_VMS_SKILL_INSTALL_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
+  const updateCommand = activeSkillRuntime.installDisabledReason
+    ? EPHEMERAL_VMS_SKILL_UPDATE_COMMAND
+    : buildSkillCommandForRuntime(
+        EPHEMERAL_VMS_SKILL_UPDATE_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
 
   const {
     installed: skillDetected,

--- a/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
+++ b/src/renderer/src/components/settings/LinearAgentSkillPane.tsx
@@ -69,30 +69,21 @@ export function LinearAgentSkillPane(): React.JSX.Element {
     sourceKinds: GLOBAL_AGENT_SKILL_SOURCE_KINDS
   })
 
-  const installCommand = useMemo(
-    () =>
-      activeSkillRuntime.installDisabledReason
-        ? ORCA_LINEAR_SKILL_INSTALL_COMMAND
-        : buildSkillCommandForRuntime(
-            ORCA_LINEAR_SKILL_INSTALL_COMMAND,
-            activeSkillRuntime.agentRuntime
-          ),
-    [activeSkillRuntime.agentRuntime, activeSkillRuntime.installDisabledReason]
-  )
+  // Why: the built command also depends on the focused runtime environment, so
+  // memoizing it on the runtime alone can serve a stale Windows host command.
+  const installCommand = activeSkillRuntime.installDisabledReason
+    ? ORCA_LINEAR_SKILL_INSTALL_COMMAND
+    : buildSkillCommandForRuntime(
+        ORCA_LINEAR_SKILL_INSTALL_COMMAND,
+        activeSkillRuntime.agentRuntime
+      )
   const updateTarget = useMemo(
     () => getLinearAgentSkillUpdateTarget(linearSkills, linearSkillInstalled),
     [linearSkillInstalled, linearSkills]
   )
-  const updateCommand = useMemo(() => {
-    const command = updateTarget.command
-    return activeSkillRuntime.installDisabledReason
-      ? command
-      : buildSkillCommandForRuntime(command, activeSkillRuntime.agentRuntime)
-  }, [
-    activeSkillRuntime.agentRuntime,
-    activeSkillRuntime.installDisabledReason,
-    updateTarget.command
-  ])
+  const updateCommand = activeSkillRuntime.installDisabledReason
+    ? updateTarget.command
+    : buildSkillCommandForRuntime(updateTarget.command, activeSkillRuntime.agentRuntime)
 
   return (
     <SearchableSetting

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
@@ -8,6 +8,7 @@ import {
   ensureOrcaCliAvailableForAgentSkillTerminal
 } from '@/lib/agent-skill-cli-prerequisite'
 import { cn } from '@/lib/utils'
+import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
 import { useMobileEmulatorAgentSetupState } from '../emulator-pane/use-mobile-emulator-agent-setup-state'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { buildSkillCommandForRuntime } from './CliSkillRuntimeSetup'
@@ -26,6 +27,7 @@ const EMULATOR_CLI_COMMANDS = [
 
 export function MobileEmulatorAgentControlRow(): React.JSX.Element {
   const setup = useMobileEmulatorAgentSetupState(true)
+  const activeSkillRuntime = useActiveProjectSkillRuntime()
   const cliSkillInstallCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)
   const cliSkillUpdateCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND)
 
@@ -157,6 +159,7 @@ export function MobileEmulatorAgentControlRow(): React.JSX.Element {
             terminalTitle="Orca CLI skill setup"
             terminalAriaLabel="Orca CLI skill install terminal"
             terminalWorktreeId="settings-mobile-emulator-orca-cli-skill-terminal"
+            terminalShellOverride={activeSkillRuntime.terminalShellOverride}
             installed={setup.cliSkillInstalled}
             loading={setup.cliSkillLoading}
             error={setup.cliSkillError}

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
@@ -28,14 +28,10 @@ const EMULATOR_CLI_COMMANDS = [
 export function MobileEmulatorAgentControlRow(): React.JSX.Element {
   const setup = useMobileEmulatorAgentSetupState(true)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  // Why: a repair-required runtime resolves to a WSL distro that is missing, so
-  // fall back to the plain command rather than emitting an unrunnable wsl.exe one.
-  const cliSkillInstallCommand = activeSkillRuntime.installDisabledReason
-    ? ORCA_CLI_SKILL_INSTALL_COMMAND
-    : buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
-  const cliSkillUpdateCommand = activeSkillRuntime.installDisabledReason
-    ? ORCA_CLI_SKILL_UPDATE_COMMAND
-    : buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND, activeSkillRuntime.agentRuntime)
+  // Why: skill detection here scans the local host only, so keep building host
+  // commands; routing them to a WSL runtime would install where we never look.
+  const cliSkillInstallCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)
+  const cliSkillUpdateCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND)
 
   const handleEnableCli = async (): Promise<void> => {
     await setup.handleEnableCli()

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
@@ -28,8 +28,14 @@ const EMULATOR_CLI_COMMANDS = [
 export function MobileEmulatorAgentControlRow(): React.JSX.Element {
   const setup = useMobileEmulatorAgentSetupState(true)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  const cliSkillInstallCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)
-  const cliSkillUpdateCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND)
+  // Why: a repair-required runtime resolves to a WSL distro that is missing, so
+  // fall back to the plain command rather than emitting an unrunnable wsl.exe one.
+  const cliSkillInstallCommand = activeSkillRuntime.installDisabledReason
+    ? ORCA_CLI_SKILL_INSTALL_COMMAND
+    : buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND, activeSkillRuntime.agentRuntime)
+  const cliSkillUpdateCommand = activeSkillRuntime.installDisabledReason
+    ? ORCA_CLI_SKILL_UPDATE_COMMAND
+    : buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND, activeSkillRuntime.agentRuntime)
 
   const handleEnableCli = async (): Promise<void> => {
     await setup.handleEnableCli()

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -10,6 +10,8 @@ import { OrchestrationPane } from './OrchestrationPane'
 const INSTALL_COMMAND =
   'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
 const UPDATE_COMMAND = INSTALL_COMMAND
+const WINDOWS_INSTALL_COMMAND =
+  'cmd.exe /d /s /c "where.exe npx.cmd >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx, then restart Orca and try again. & echo If Node.js is already installed, add it to PATH before restarting Orca. & exit /b 1) else (npx.cmd skills add https://github.com/stablyai/orca --skill orchestration --global)"'
 
 const mocks = vi.hoisted(() => ({
   dialogProps: [] as Record<string, unknown>[],
@@ -163,8 +165,8 @@ describe('OrchestrationPane', () => {
 
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({
-        command: INSTALL_COMMAND,
-        installedCommand: UPDATE_COMMAND
+        command: WINDOWS_INSTALL_COMMAND,
+        installedCommand: WINDOWS_INSTALL_COMMAND
       })
     )
 
@@ -199,10 +201,10 @@ describe('OrchestrationPane', () => {
 
     expect(mocks.dialogProps.at(-1)).toEqual(
       expect.objectContaining({
-        command: INSTALL_COMMAND,
+        command: WINDOWS_INSTALL_COMMAND,
         open: true
       })
     )
-    expect(rendered.textContent).toContain(INSTALL_COMMAND)
+    expect(rendered.textContent).toContain(WINDOWS_INSTALL_COMMAND)
   })
 })

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -11,7 +11,7 @@ const INSTALL_COMMAND =
   'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
 const UPDATE_COMMAND = INSTALL_COMMAND
 const WINDOWS_INSTALL_COMMAND =
-  'cmd.exe /d /s /c "where.exe npx.cmd >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx, then restart Orca and try again. & echo If Node.js is already installed, add it to PATH before restarting Orca. & exit /b 1) else (npx.cmd skills add https://github.com/stablyai/orca --skill orchestration --global)"'
+  'cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (echo ERROR: npx was not found. Install Node.js LTS from https://nodejs.org/ to get npx. & echo Then close this terminal and start skill setup again - a new terminal picks up the updated PATH. & exit /b 1) else (npx skills add https://github.com/stablyai/orca --skill orchestration --global)"'
 
 const mocks = vi.hoisted(() => ({
   dialogProps: [] as Record<string, unknown>[],

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -31,7 +31,13 @@ const updateCapableCallers = new Map<string, readonly string[]>([
   ],
   [
     'src/renderer/src/components/settings/EphemeralVmsPane.tsx',
-    ['EPHEMERAL_VMS_SKILL_UPDATE_COMMAND', 'installedCommand={updateCommand}']
+    [
+      'EPHEMERAL_VMS_SKILL_UPDATE_COMMAND',
+      'installedCommand={updateCommand}',
+      // An absent runtime must still resolve to the host so the Windows npx
+      // preflight applies, as it does on the sibling panes.
+      'const installCommand = activeSkillRuntime.installDisabledReason'
+    ]
   ],
   [
     'src/renderer/src/components/settings/CliSection.tsx',

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -64,7 +64,10 @@ const updateCapableCallers = new Map<string, readonly string[]>([
     [
       'ORCA_CLI_SKILL_UPDATE_COMMAND',
       'installedCommand={cliSkillUpdateCommand}',
-      'terminalShellOverride={activeSkillRuntime.terminalShellOverride}'
+      'terminalShellOverride={activeSkillRuntime.terminalShellOverride}',
+      // Detection here scans the local host only, so the command must stay host-built.
+      'buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)',
+      'buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND)'
     ]
   ]
 ])
@@ -73,7 +76,8 @@ const installOnlyCallers = new Map<string, readonly string[]>([
   [
     'src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx',
     [
-      'buildSkillCommandForRuntime(',
+      // Detection here scans the local host only, so the command must stay host-built.
+      'buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)',
       'command={skillInstallCommand}',
       'terminalShellOverride={activeSkillRuntime.terminalShellOverride}',
       'showInstallWhenInstalled={!setup.cliSkillInstalled}'

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -61,7 +61,11 @@ const updateCapableCallers = new Map<string, readonly string[]>([
   ],
   [
     'src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx',
-    ['ORCA_CLI_SKILL_UPDATE_COMMAND', 'installedCommand={cliSkillUpdateCommand}']
+    [
+      'ORCA_CLI_SKILL_UPDATE_COMMAND',
+      'installedCommand={cliSkillUpdateCommand}',
+      'terminalShellOverride={activeSkillRuntime.terminalShellOverride}'
+    ]
   ]
 ])
 

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -151,6 +151,11 @@ describe('AgentSkillSetupPanel installed-command call sites', () => {
     expect(source).toContain('command={skillCommand}')
     expect(source).toContain('shellOverride={activeSkillRuntime.terminalShellOverride}')
     expect(source).not.toContain('command={ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND}')
+    // This terminal auto-pastes with no install gate, so a repair-required runtime
+    // must fall back to the host rather than skip the Windows npx preflight.
+    expect(source).toContain(
+      'activeSkillRuntime.installDisabledReason ? undefined : activeSkillRuntime.agentRuntime'
+    )
   })
 
   it('fails when a production caller can show the default Update action without installedCommand', () => {

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -68,7 +68,11 @@ const updateCapableCallers = new Map<string, readonly string[]>([
 const installOnlyCallers = new Map<string, readonly string[]>([
   [
     'src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx',
-    ['showInstallWhenInstalled={!setup.cliSkillInstalled}']
+    [
+      'buildSkillCommandForRuntime(',
+      'command={skillInstallCommand}',
+      'showInstallWhenInstalled={!setup.cliSkillInstalled}'
+    ]
   ]
 ])
 
@@ -127,6 +131,17 @@ describe('AgentSkillSetupPanel installed-command call sites', () => {
     expect(source).toContain('installedCommand={orchestrationUpdateCommand}')
     expect(source).not.toContain('Copy update command')
     expect(source).not.toContain('copyUpdateCommand')
+  })
+
+  it('routes the combined feature-tip install through runtime command setup', () => {
+    const source = readRepoFile(
+      'src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx'
+    )
+
+    expect(source).toContain('buildSkillCommandForRuntime(')
+    expect(source).toContain('command={skillCommand}')
+    expect(source).toContain('shellOverride={activeSkillRuntime.terminalShellOverride}')
+    expect(source).not.toContain('command={ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND}')
   })
 
   it('fails when a production caller can show the default Update action without installedCommand', () => {

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -71,6 +71,7 @@ const installOnlyCallers = new Map<string, readonly string[]>([
     [
       'buildSkillCommandForRuntime(',
       'command={skillInstallCommand}',
+      'terminalShellOverride={activeSkillRuntime.terminalShellOverride}',
       'showInstallWhenInstalled={!setup.cliSkillInstalled}'
     ]
   ]

--- a/src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts
+++ b/src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { getLinearPromptTerminalShellOverride } from './linear-agent-skill-runtime'
+
+const hostRuntime = { runtime: 'host', label: 'Windows' } as const
+
+describe('getLinearPromptTerminalShellOverride', () => {
+  // Why: this prompt pastes the same generated Windows command as the settings
+  // panes, and Git Bash rewrites its leading /d /s /c arguments as MSYS paths.
+  it('forces PowerShell for POSIX-family Windows shells', () => {
+    for (const terminalWindowsShell of ['git-bash', 'wsl.exe']) {
+      expect(
+        getLinearPromptTerminalShellOverride('win32', { terminalWindowsShell }, hostRuntime)
+      ).toBe('powershell.exe')
+    }
+  })
+
+  it('leaves cmd and PowerShell shells alone, and never overrides off Windows', () => {
+    expect(
+      getLinearPromptTerminalShellOverride(
+        'win32',
+        { terminalWindowsShell: 'cmd.exe' },
+        hostRuntime
+      )
+    ).toBeUndefined()
+    expect(
+      getLinearPromptTerminalShellOverride(
+        'darwin',
+        { terminalWindowsShell: 'git-bash' },
+        hostRuntime
+      )
+    ).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/sidebar/linear-agent-skill-runtime.ts
+++ b/src/renderer/src/components/sidebar/linear-agent-skill-runtime.ts
@@ -2,6 +2,7 @@ import type { GlobalSettings } from '../../../../shared/types'
 import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
 import type { SkillDiscoveryTarget } from '../../../../shared/skills'
 import { translate } from '@/i18n/i18n'
+import { getProjectAgentSkillTerminalShellOverride } from '@/lib/project-skill-runtime'
 import type { LocalAgentRuntime } from '../settings/CliSkillRuntimeSetup'
 
 const LOCAL_DISMISS_STORAGE_KEY_PREFIX = 'orca.linearTicketsSkill.setupDismissed'
@@ -92,13 +93,7 @@ export function getLinearPromptTerminalShellOverride(
   settings: LinearAgentSkillPromptSettings | null | undefined,
   runtime: LocalAgentRuntime
 ): string | undefined {
-  if (currentPlatform !== 'win32') {
-    return undefined
-  }
-  if (runtime.runtime === 'wsl') {
-    return 'powershell.exe'
-  }
-  return settings?.terminalWindowsShell?.toLowerCase() === 'wsl.exe' ? 'powershell.exe' : undefined
+  return getProjectAgentSkillTerminalShellOverride(currentPlatform, settings, runtime)
 }
 
 export function getLinearPromptSetupCheckIdentity(args: {

--- a/src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx
+++ b/src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { getDefaultSettings } from '../../../shared/constants'
+import { useAppStore } from '@/store'
+import { useActiveProjectSkillRuntime } from './useActiveProjectSkillRuntime'
+
+function setPlatform(platform: NodeJS.Platform): void {
+  ;(window as unknown as { api: unknown }).api = {
+    platform: { get: () => ({ platform }) }
+  }
+}
+
+function setWindowsShell(terminalWindowsShell: string): void {
+  useAppStore.setState({
+    settings: { ...getDefaultSettings('/tmp'), terminalWindowsShell }
+  })
+}
+
+describe('useActiveProjectSkillRuntime', () => {
+  beforeEach(() => {
+    setPlatform('win32')
+    setWindowsShell('git-bash')
+  })
+
+  afterEach(() => {
+    delete (window as unknown as { api?: unknown }).api
+  })
+
+  // Why: with no local project runtime, buildSkillCommandForRuntime still emits the
+  // Windows host cmd.exe wrapper, which Git Bash would mangle into MSYS paths.
+  it('still overrides a POSIX-family Windows shell when no project runtime resolves', () => {
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.projectRuntime).toBeUndefined()
+    expect(result.current.terminalShellOverride).toBe('powershell.exe')
+  })
+
+  it('leaves the shell alone on non-Windows hosts', () => {
+    setPlatform('darwin')
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.terminalShellOverride).toBeUndefined()
+  })
+})

--- a/src/renderer/src/hooks/useActiveProjectSkillRuntime.ts
+++ b/src/renderer/src/hooks/useActiveProjectSkillRuntime.ts
@@ -50,7 +50,16 @@ export function useActiveProjectSkillRuntime(): ActiveProjectSkillRuntime {
       }
     )
     if (!projectRuntime) {
-      return EMPTY_ACTIVE_PROJECT_SKILL_RUNTIME
+      // Why: buildSkillCommandForRuntime still builds a Windows host command
+      // without a project runtime, so the terminal has to match that shell.
+      const terminalShellOverride = getProjectAgentSkillTerminalShellOverride(
+        currentPlatform,
+        runtimeState.settings,
+        undefined
+      )
+      return terminalShellOverride
+        ? { installDisabledReason: null, terminalShellOverride }
+        : EMPTY_ACTIVE_PROJECT_SKILL_RUNTIME
     }
 
     const agentRuntime = getProjectAgentSkillRuntime(projectRuntime, currentPlatform)

--- a/src/renderer/src/lib/project-skill-runtime.test.ts
+++ b/src/renderer/src/lib/project-skill-runtime.test.ts
@@ -84,4 +84,22 @@ describe('project skill runtime helpers', () => {
       )
     ).toBe('powershell.exe')
   })
+
+  it('forces PowerShell for host setup when the terminal shell is Git Bash', () => {
+    // Git Bash rewrites the leading /d /s /c arguments of the generated command as MSYS paths.
+    expect(
+      getProjectAgentSkillTerminalShellOverride(
+        'win32',
+        { terminalWindowsShell: 'git-bash' },
+        getProjectAgentSkillRuntime(hostRuntime, 'win32')
+      )
+    ).toBe('powershell.exe')
+    expect(
+      getProjectAgentSkillTerminalShellOverride(
+        'win32',
+        { terminalWindowsShell: 'cmd.exe' },
+        getProjectAgentSkillRuntime(hostRuntime, 'win32')
+      )
+    ).toBeUndefined()
+  })
 })

--- a/src/renderer/src/lib/project-skill-runtime.ts
+++ b/src/renderer/src/lib/project-skill-runtime.ts
@@ -1,6 +1,7 @@
 import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
 import type { SkillDiscoveryTarget } from '../../../shared/skills'
 import type { GlobalSettings } from '../../../shared/types'
+import { resolveWindowsShellStartupFamily } from '../../../shared/windows-terminal-shell'
 import { translate } from '@/i18n/i18n'
 
 export type ProjectAgentSkillRuntime = {
@@ -48,7 +49,11 @@ export function getProjectAgentSkillTerminalShellOverride(
   if (runtime?.runtime === 'wsl') {
     return 'powershell.exe'
   }
-  return settings?.terminalWindowsShell.toLowerCase() === 'wsl.exe' ? 'powershell.exe' : undefined
+  // Why: generated skill commands are PowerShell/cmd syntax, so a POSIX-family
+  // Windows shell (wsl.exe, Git Bash) would mangle the wrapper we hand it.
+  return resolveWindowsShellStartupFamily(settings?.terminalWindowsShell) === 'posix'
+    ? 'powershell.exe'
+    : undefined
 }
 
 export function getProjectSkillInstallDisabledReason(


### PR DESCRIPTION
## Summary

Fixes #10438.

Windows skill setup currently opens a terminal with an `npx skills` command even when `npx` is unavailable. PowerShell then reports a generic `CommandNotFoundException`, leaving users without a recovery path.

This change:

- checks for `npx.cmd` before native Windows skill install and update commands
- prints actionable Node.js LTS, `PATH`, and restart guidance when it is missing
- executes the exact `npx.cmd` shim found by the prerequisite check
- routes the feature-tip and mobile-emulator setup terminals through the existing runtime-aware command builder
- preserves existing WSL, macOS, Linux, and unrelated-command behavior

## Screenshots

No visual change.

The command behavior was validated on a Windows machine with both missing and installed `npx`. I would appreciate additional Windows users validating the full interactive setup flow through Orca as well.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the full run reached 35,652 passing and 62 skipped tests. Two affected settings expectations were corrected and now pass; five unrelated timing-sensitive failures passed in isolation. One untouched release-package contract test remains inconsistent with the current upstream release workflow.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Additional validation:

- Focused runtime and call-site tests: 22/22 passed.
- Changed-file Oxlint, React Doctor, Oxfmt, and `git diff --check` passed.
- Mobile TypeScript, lint, formatting, and tests passed: 2,451 passed and two skipped.
- Expo Android prebuild and Gradle `assembleRelease` passed: 987 tasks completed.
- On Windows PowerShell 5.1, the exact generated command printed the expected recovery guidance and returned exit code 1 when `npx.cmd` was absent.
- After installing Node.js LTS, the same command resolved and launched the real `C:\Program Files\nodejs\npx.cmd` shim.

## AI Review Report

The review traced every changed skill-install surface and the shared runtime command builder. It explicitly checked native Windows host execution, the missing-runtime Windows fallback, WSL distro selection, non-Windows hosts, and unrelated commands.

The review flagged that checking bare `npx` could resolve a different PowerShell shim than the command eventually executed. The implementation now checks and runs `npx.cmd` consistently behind a `cmd.exe` boundary that is valid from PowerShell, Command Prompt, and Git Bash.

It also found setup surfaces that bypassed the runtime-aware builder. The feature-tip and mobile-emulator terminals now use that builder and propagate the selected terminal shell. Regression tests guard those call sites.

Cross-platform review covered macOS, Linux, Windows, WSL, local terminals, SSH behavior, paths, shell parsing, and Electron renderer platform detection. The new branch is restricted to native Windows; WSL and non-Windows commands retain their previous forms.

## Security Audit

The wrapper applies only to known `npx skills add` and `npx skills update` commands produced by Orca. The command is not constructed from user input.

No new IPC, authentication, credentials, dependencies, filesystem writes, or network APIs are introduced. The review checked command quoting and shell metacharacter boundaries across PowerShell, Command Prompt, and Git Bash. WSL commands remain inside their selected distro and are not routed through the Windows host prerequisite.

## Notes

- No documentation update is required; this restores a recoverable setup path rather than introducing a new workflow.
- Additional interactive verification from Windows users would be welcome.
- X: [@0bkevin](https://x.com/0bkevin)

## ELI5

On Windows, skill setup ran npx even when Node was missing, so PowerShell only showed a cryptic command-not-found error. Now Orca checks for npx first and tells you how to install Node and fix PATH if it is missing.
