### PR TITLE
fix(mac): disable unstable Skia Graphite renderer

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -398,6 +398,29 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('max-active-webgl-contexts', '128')
   })
 
+  it('disables Skia Graphite only on macOS without disabling hardware acceleration', async () => {
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    delete process.env.ORCA_E2E_USER_DATA_DIR
+    vi.mocked(app.disableHardwareAcceleration).mockClear()
+
+    for (const platform of ['darwin', 'linux', 'win32'] as const) {
+      setPlatform(platform)
+      vi.mocked(app.commandLine.appendSwitch).mockClear()
+
+      enableMainProcessGpuFeatures()
+
+      if (platform === 'darwin') {
+        expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('disable-skia-graphite')
+      } else {
+        expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('disable-skia-graphite')
+      }
+    }
+
+    expect(app.disableHardwareAcceleration).not.toHaveBeenCalled()
+  })
+
   it('disables the GPU sandbox on Linux Wayland without disabling acceleration', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -262,6 +262,11 @@ export function enableMainProcessGpuFeatures(): void {
     return
   }
 
+  if (process.platform === 'darwin') {
+    // Why: Graphite can strand corrupt Metal tiles after idle; Ganesh preserves GPU compositing without the stale surface.
+    app.commandLine.appendSwitch('disable-skia-graphite')
+  }
+
   // Why: Blink evicts the oldest WebGL context past 16/renderer and each terminal pane holds one, silently downgrading panes to DOM.
   // 128 raises the ceiling for real layouts while staying bounded so context leaks still surface.
   app.commandLine.appendSwitch('max-active-webgl-contexts', '128')


### PR DESCRIPTION
## Summary

- disable Skia Graphite on macOS to prevent stale or corrupted compositor tiles after idle and app switching
- preserve hardware acceleration, GPU compositing, and terminal WebGL through the Ganesh fallback
- cover the Darwin-only switch and unchanged Linux/Windows behavior

VS Code traced the same rendering corruption to Graphite recording failures and shipped this targeted workaround: https://github.com/microsoft/vscode/issues/284162

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/configure-process.test.ts`
- `pnpm exec oxlint src/main/startup/configure-process.ts src/main/startup/configure-process.test.ts`
- `pnpm run typecheck:node`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`