### PR TITLE
fix(agent-status): surface Pi ask_user input waits as needs-input

### DIFF
--- a/src/renderer/src/components/AgentStateDot.test.ts
+++ b/src/renderer/src/components/AgentStateDot.test.ts
@@ -55,7 +55,7 @@ describe('AgentStateDot', () => {
     expect(markup).toContain('text-emerald-500')
   })
 
-  it.each(['permission', 'waiting'] satisfies AgentDotState[])(
+  it.each(['permission', 'waiting', 'blocked'] satisfies AgentDotState[])(
     'renders %s as the shared question glyph',
     (state) => {
       const markup = renderMarkup(state)
@@ -68,7 +68,7 @@ describe('AgentStateDot', () => {
     }
   )
 
-  it.each(['blocked', 'interrupted'] satisfies AgentDotState[])(
+  it.each(['interrupted'] satisfies AgentDotState[])(
     'renders %s as a red attention dot',
     (state) => {
       const classNames = renderDotClassNames(state)

--- a/src/renderer/src/components/AgentStateDot.tsx
+++ b/src/renderer/src/components/AgentStateDot.tsx
@@ -96,7 +96,10 @@ export const AgentStateDot = React.memo(function AgentStateDot({
     )
   }
 
-  if (state === 'permission' || state === 'waiting') {
+  // Why: 'blocked' is an input/permission wait too (Pi/Copilot ask tools), not
+  // an error — share the amber question glyph with 'waiting'/'permission', the
+  // same collapse the worktree level already does via 'permission'.
+  if (state === 'permission' || state === 'waiting' || state === 'blocked') {
     return (
       <span
         className={cn('inline-flex shrink-0 items-center justify-center', box, className)}
@@ -116,9 +119,7 @@ export const AgentStateDot = React.memo(function AgentStateDot({
         className={cn(
           'block rounded-full',
           inner,
-          state === 'blocked' || state === 'interrupted' || state === 'failed'
-            ? 'bg-red-500'
-            : 'bg-neutral-500/40'
+          state === 'interrupted' || state === 'failed' ? 'bg-red-500' : 'bg-neutral-500/40'
         )}
       />
     </span>

--- a/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
+++ b/src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx
@@ -258,13 +258,15 @@ describe('DashboardAgentRow', () => {
     expect(tokens).not.toContain('bg-red-500')
   })
 
-  it('keeps blocked rows red', () => {
+  it('renders blocked rows with the amber question glyph', () => {
     const markup = renderRow(makeAgent({}, { state: 'blocked' }))
     const tokens = classTokens(markup)
 
     expect(markup).toContain('aria-label="Blocked"')
-    expect(tokens).toContain('bg-red-500')
-    expect(tokens).not.toContain('bg-amber-500')
+    expect(markup).toContain('lucide-message-circle-question-mark')
+    expect(tokens).toContain('text-agent-question')
+    expect(tokens).not.toContain('text-amber-500')
+    expect(tokens).not.toContain('bg-red-500')
   })
 
   it('keeps each row hover boundary inside an anonymous ancestor group', () => {

--- a/src/shared/agent-hook-listener-pi-compatible.test.ts
+++ b/src/shared/agent-hook-listener-pi-compatible.test.ts
@@ -87,6 +87,135 @@ describe('shared agent-hook-listener', () => {
     expect(blocked?.payload.interactivePrompt).toBe(JSON.stringify(questions))
   })
 
+  it('maps Pi tool_call ask_user to blocked with interactivePrompt', () => {
+    // Why: pi-ask-user extension tools are named ask_user with a
+    // {question, context, options} input; they block the TUI on a human
+    // answer exactly like ask_user_question, so the wait must not read as
+    // working.
+    const input = {
+      question: 'Merge PR #2 now?',
+      context: 'PR #2 is clean and mergeable.',
+      options: [
+        { label: 'Merge PR #2 now', description: 'Merge into main; do not deploy yet.' },
+        { label: 'Leave PR #2 open' }
+      ]
+    }
+    const blocked = normalizeHookPayload(
+      state,
+      'pi',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        env: 'production',
+        version: '1',
+        payload: {
+          hook_event_name: 'tool_call',
+          tool_name: 'ask_user',
+          tool_input: input
+        }
+      },
+      'production'
+    )
+    expect(blocked?.payload).toMatchObject({
+      state: 'blocked',
+      agentType: 'pi',
+      toolName: 'ask_user'
+    })
+    expect(blocked?.payload.interactivePrompt).toBe(JSON.stringify(input))
+  })
+
+  it('maps Pi tool_execution_start ask_user to blocked with interactivePrompt', () => {
+    const input = { question: 'Proceed?', options: ['yes', 'no'] }
+    const blocked = normalizeHookPayload(
+      state,
+      'pi',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        env: 'production',
+        version: '1',
+        payload: {
+          hook_event_name: 'tool_execution_start',
+          tool_name: 'ask_user',
+          tool_input: input
+        }
+      },
+      'production'
+    )
+    expect(blocked?.payload).toMatchObject({
+      state: 'blocked',
+      agentType: 'pi',
+      toolName: 'ask_user'
+    })
+    expect(blocked?.payload.interactivePrompt).toBe(JSON.stringify(input))
+  })
+
+  it('keeps Pi ask_user blocked when tool_input is missing', () => {
+    const blocked = normalizeHookPayload(
+      state,
+      'pi',
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt',
+        env: 'production',
+        version: '1',
+        payload: {
+          hook_event_name: 'tool_call',
+          tool_name: 'ask_user'
+        }
+      },
+      'production'
+    )
+    expect(blocked?.payload).toMatchObject({
+      state: 'blocked',
+      agentType: 'pi',
+      toolName: 'ask_user'
+    })
+    expect(blocked?.payload.interactivePrompt).toBeUndefined()
+  })
+
+  it('clears Pi ask_user blocked once the tool_execution_end arrives', () => {
+    const base = {
+      paneKey: PANE_KEY,
+      tabId: 'tab-1',
+      worktreeId: 'wt',
+      env: 'production' as const,
+      version: '1'
+    }
+    const blocked = normalizeHookPayload(
+      state,
+      'pi',
+      {
+        ...base,
+        payload: {
+          hook_event_name: 'tool_call',
+          tool_name: 'ask_user',
+          tool_input: { question: 'Ship it?', options: ['yes', 'no'] }
+        }
+      },
+      'production'
+    )
+    expect(blocked?.payload.state).toBe('blocked')
+
+    const cleared = normalizeHookPayload(
+      state,
+      'pi',
+      {
+        ...base,
+        payload: {
+          hook_event_name: 'tool_execution_end',
+          tool_name: 'ask_user'
+        }
+      },
+      'production'
+    )
+    expect(cleared?.payload.state).toBe('working')
+    expect(cleared?.payload.interactivePrompt).toBeUndefined()
+  })
+
   it('keeps Pi regular tool_call notifications as working', () => {
     const working = normalizeHookPayload(
       state,

--- a/src/shared/agent-question-answered-intent.ts
+++ b/src/shared/agent-question-answered-intent.ts
@@ -12,13 +12,18 @@ export type AgentQuestionAnsweredInferenceRequest = {
 }
 
 /** True for the ask-the-user-a-question tool across agents: Claude's
- *  `AskUserQuestion`, grok/Pi's `ask_user_question`, and Codex ≥0.145's
- *  `request_user_input` (same questions/options input shape).
+ *  `AskUserQuestion`, grok/Pi's `ask_user_question`, Pi extension tools named
+ *  `ask_user` (e.g. pi-ask-user, whose overlay blocks the TUI on a human
+ *  answer the same way), and Codex ≥0.145's `request_user_input`.
  *  Why: this is the structured "pick an option" prompt whose full input the
  *  clients render as a live card. */
 export function isAskUserQuestionTool(toolName: string | undefined): boolean {
   const normalized = toolName?.replaceAll(/[^a-z0-9]/gi, '').toLowerCase()
-  return normalized === 'askuserquestion' || normalized === 'requestuserinput'
+  return (
+    normalized === 'askuserquestion' ||
+    normalized === 'askuser' ||
+    normalized === 'requestuserinput'
+  )
 }
 
 const QUESTION_ANSWER_ENTER_INPUTS: ReadonlySet<string> = new Set([


### PR DESCRIPTION
Closes #10454

## Summary

When a Pi session blocks on an interactive question tool named `ask_user` (e.g. the `pi-ask-user` extension, whose overlay holds the TUI until the user answers), Orca showed the session as "Working…" indefinitely instead of the amber needs-input state every other agent's question prompt gets. Two one-line-scope fixes:

1. **`isAskUserQuestionTool` now matches `askuser`** alongside `askuserquestion` / `requestuserinput`, so Pi `tool_call` / `tool_execution_start` events for `ask_user` map to `blocked` (and the question payload is carried as `interactivePrompt`, same as `ask_user_question`). Verified every other call site is safe: the Claude/Codex paths have no `ask_user` tool, the server-side and renderer keystroke-inference consumers are Claude-gated, and Copilot/Droid already had their own `askuser` matchers.
2. **`AgentStateDot` renders `blocked` with the amber "?" glyph** (same as `waiting`/`permission`) instead of a red error dot shared with interrupted/failed. The worktree level already collapsed `blocked → permission`; the row level now agrees. Also fixes the same presentation for Copilot's `ask_user`.

## Screenshots

Before (Pi blocked on `ask_user`, sidebar shows "Working…" — more in #10454):

![working spinner next to the blocked Pi session](https://gist.githubusercontent.com/gatsby74/d2f6cc81899a2b9f13e0aed4b91c05ac/raw/before-sidebar-working-closeup.png)

After (blocked Pi session shows the amber "?" glyph at both levels):

![agent row shows the question glyph](https://gist.githubusercontent.com/gatsby74/d2f6cc81899a2b9f13e0aed4b91c05ac/raw/after-sidebar-question-glyph.png)

![Pi blocked on ask_user with needs-input state at worktree and row level](https://gist.githubusercontent.com/gatsby74/d2f6cc81899a2b9f13e0aed4b91c05ac/raw/after-pi-ask-user-blocked.png)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 35,614 passed; 44 failures in 9 files are pre-existing environmental issues on this machine (node 26 vs wanted 24, localStorage/electron-contract harness failures), verified to fail identically on the pristine base without these changes
- [x] `pnpm build`
- [x] Added/updated tests: 4 new `agent-hook-listener` cases for Pi `ask_user` (tool_call → blocked with payload, tool_execution_start → blocked, blocked without tool_input, clears on tool_execution_end); `AgentStateDot` and `DashboardAgentRow` glyph tests updated to assert blocked → amber question glyph

## AI Review Report

Review (AI agent, Claude) traced every `isAskUserQuestionTool` call site before broadening the shared matcher: Pi blocked-gate (the fix), `deriveInteractivePrompt` (Claude/Codex/Pi/Grok extractors — none have an `ask_user` tool that isn't a question prompt), Grok waiting gate (no such tool), server-side permission stickiness and renderer keystroke inference (both Claude-gated), Codex auto-approval suppression (Codex-gated). Checked the `blocked` visual-state consumers (`AgentStateDot`, summary grouping, hibernation/cleanup idle sets) — all treat `blocked`/`waiting` equivalently, so the glyph collapse is presentation-only. Cross-platform check: changes are a tool-name string match and a renderer glyph/aria-label — no keyboard shortcuts, platform labels, paths, shell behavior, or Electron platform differences are touched; behavior is identical on macOS, Linux, and Windows, including SSH-hosted terminals since the hook payload path is unchanged.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only widens a tool-name comparison (`askuser`) and swaps a CSS glyph; the serialized `interactivePrompt` JSON remains capped and parsed defensively (`JSON.parse` in try/catch) as before. No follow-up needed.

## Notes

- The native-chat question card still can't render Pi questions (Pi is not a native-chat-supported agent and `ask_user`'s `{question, options}` shape would need a registered parser) — deliberately out of scope; the status/attention state is what this PR fixes.
- The pre-existing local test failures noted above are environmental to this machine's toolchain, not introduced here.

## ELI5

When the Pi agent asked you a question with ask_user, Orca kept saying Working forever instead of the amber needs-input state. This fix treats ask_user like other agents so the status correctly shows it is waiting on you.
