### PR TITLE
ci(release-cut): restore the skill-independent version commit

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -521,14 +521,7 @@ jobs:
           # message and tag name explicitly (avoids npm's `v1.2.3` prefix
           # assumptions and any lifecycle scripts that would run on bump).
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-          # Why: release cut is the single authoritative point where the released
-          # skill ledger advances — this version's working-tree bytes become an
-          # immutable released revision so future builds recognize them as an
-          # official snapshot. It is the only place skill artifacts regenerate;
-          # ordinary lint verifies working-tree bytes against the committed ledger
-          # and never walks tags. Uses only Node built-ins, so no install needed.
-          node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"
-          git add package.json resources/skills
+          git add package.json
           commit_message="release: v$VERSION"
           if [[ "$EVENT_NAME" == "schedule" ]]; then
             commit_message="$commit_message [rc-slot:$SLOT]"


### PR DESCRIPTION
Un-reds `main`. One file, +1 / -8.

## Summary

`main` and every open PR have been red since #10340 merged. This restores the release-cut step to the invariant #9119 established, so CI goes green.

`config/scripts/package-electron-runtime-contract.test.mjs:455` — *"keeps release-cut version commits skill-independent and taggable on retries"* — asserts the cut step must not contain `generate-skill-bundle-manifest` or `resources/skills`. #10340 added both.

```diff
- node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"
- git add package.json resources/skills
+ git add package.json
```

**Why nothing caught it before merge:** #9119 wrote the assertion, #10340 violated it, and neither branch contained the other. Both were green on their own; the failure only exists in the merge result. Required checks on each PR cannot see that — it needs a merge queue or a required up-to-date branch. Worth considering separately, because this class will recur.

**Deliberately kept:** the `--release` implementation in `generate-skill-bundle-manifest.mjs`. It is correct — `argv.indexOf('--release')` at line 625 on main, and it does append a ledger row when skills actually change. It is simply unused by the cut, and harmless. #10340's root fix — verify no longer walking local git tags — is untouched and does not depend on the cut step.

Credit: root cause and the follow-up shape below are @brennanb2025's analysis on the #10340 branch.

## Screenshots

No visual change — CI workflow only.

## Testing

- [ ] `pnpm lint` — not run; no source, config, or locale files changed (workflow YAML only)
- [ ] `pnpm typecheck` — not run; no TypeScript changed
- [x] `pnpm test` — ran the relevant subset locally: `package-electron-runtime-contract.test.mjs` **24/24** (was 1 failing), and the full `config/scripts/` suite **417 passed / 4 skipped, 53 files**. The complete suite runs as `verify` in CI on this PR.
- [ ] `pnpm build` — not run; no application code changed
- [x] Regression coverage already exists and is what caught this: the assertion in `package-electron-runtime-contract.test.mjs` fails on `main` today and passes here. No new test added, because the correct test already existed and was simply violated.

## AI Review Report

Reviewed the change for whether the revert is the right call versus updating the assertion, and confirmed the failure is not caused by the PR that surfaced it — reproduced the identical failure on `origin/main` at `b600e25fa1` in a clean worktree with no other changes.

Checked one claim that turned out to be wrong before acting on it: an initial reading concluded `--release` was unimplemented. That was verified against a stale pre-#10340 checkout. `git merge-base --is-ancestor 8d61d76a59` confirmed the tree lacked the merge; `origin/main` does implement the flag. The apparent "writes nothing" repro was the dedupe no-op path, which is correct behavior for a cut where no skill changed. The flag is therefore left in place rather than removed.

The review also caught a self-inflicted defect in the first push: a `node_modules` **symlink** was committed, because `.gitignore` line 19 is `node_modules/` — a trailing slash matches directories only, so a symlink of that name is not ignored and `git add -A` staged it. CI failed with `ENOTDIR: not a directory, mkdir node_modules` before reaching any test. Amended and force-pushed; the PR now contains exactly one file. Notably CodeRabbit did not flag it — CI did.

Cross-platform: this step runs only on the GitHub-hosted release-cut runner, not on user machines. No shortcuts, labels, path handling, shell behavior, or Electron platform differences are touched. The remaining `git add package.json` is platform-neutral, and the removed `node ...` invocation was the only platform-sensitive element (it is gone, not changed).

## Security Audit

Net reduction in surface. The change **removes** a command execution from CI — a `node` invocation that interpolated the workflow-controlled `$VERSION` into its arguments (correctly quoted, but now absent entirely). No input handling, auth, secrets, dependency, or IPC surface is touched.

Staging is narrowed from `git add package.json resources/skills` to `git add package.json`, so the automated release commit can no longer carry unintended `resources/skills` content. No new secrets, permissions, or third-party actions.

## Notes

**Known incompleteness — please do not drop this.** This revert leaves #10340 semantically incomplete.

Pre-#10340 the registry gained released revisions from the tag walk. #10340 replaced that with committed-ledger seeding. With nothing advancing the ledger at cut, the mapping freezes, and each new skill change re-uses the same unreleased tail revision number for different bytes. Older installs whose bytes occupied that slot then match no known snapshot and classify as `unrecognized`.

That is not a silent failure — it surfaces in the UI. Since #10436, an `unrecognized` copy renders an amber **"Needs attention"** badge with **no update offered**, because the global command cannot converge an unrecognized copy. When the degraded copy is the canonical one, it withholds the update for that skill entirely.

Slow burn — skills are thin stubs with low churn, so days or weeks are fine — but it needs the follow-up.

**Proposed follow-up:** reintroduce the advance narrowly. At a real cut only `release-mapping.json` actually changes, because the PR that changed the skill already committed the registry tail. So stage exactly `resources/skills/release-mapping.json`, and narrow the #9119 assertion to forbid mutating the content-addressed artifacts (`current-manifest.json`, `snapshot-registry.json`) while permitting the provenance row. That satisfies both invariants instead of trading one for the other.
