### PR TITLE
fix(terminal): open the whole URL when a TUI wraps it at its own block width

### DIFF
--- a/src/renderer/src/components/terminal-pane/block-wrapped-http-link-hover-cost.test.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-http-link-hover-cost.test.ts
@@ -1,0 +1,58 @@
+import type { IBufferLine } from '@xterm/xterm'
+import { describe, expect, it } from 'vitest'
+import { buildBlockWrappedHttpLogicalLineCandidates } from './block-wrapped-terminal-http-links'
+
+// Why: this runs on the renderer's hover path for every mouse move over a
+// terminal, so its work must stay bounded no matter how adversarial the
+// buffer. Counting row reads keeps the bound deterministic — a wall-clock
+// budget would flake under parallel test load and would itself steal CPU from
+// the timing-sensitive suites running alongside it.
+const MAX_ROW_READS_PER_HOVER = 4_000
+
+function makeBufferLine(content: string, cols: number): IBufferLine {
+  const text = content.padEnd(cols)
+  const columns = Array.from({ length: text.length + 1 }, (_value, index) => index)
+  return {
+    isWrapped: false,
+    length: cols,
+    translateToString: (
+      _trimRight?: boolean,
+      startColumn = 0,
+      endColumn = text.length,
+      outColumns?: number[]
+    ) => {
+      outColumns?.splice(0, outColumns.length, ...columns.slice(startColumn, endColumn + 1))
+      return text.slice(startColumn, endColumn)
+    }
+  } as IBufferLine
+}
+
+function countRowReadsForHover(rows: IBufferLine[], bufferLineNumber: number): number {
+  let reads = 0
+  const buffer = {
+    getLine: (y: number) => {
+      reads++
+      return rows[y]
+    }
+  }
+  buildBlockWrappedHttpLogicalLineCandidates(buffer, bufferLineNumber)
+  return reads
+}
+
+describe('block-wrapped HTTP link hover cost', () => {
+  it('bounds row reads on a screen made entirely of wrapped URL rows', () => {
+    const cols = 200
+    // Maximises start-row candidates, wrap-column scans, and join attempts:
+    // every row is a full-width URL ending at a break opportunity.
+    const url = `https://example.com/${'a'.repeat(cols - 21)}/`
+    const rows = Array.from({ length: 200 }, () => makeBufferLine(url, cols))
+
+    expect(countRowReadsForHover(rows, 150)).toBeLessThan(MAX_ROW_READS_PER_HOVER)
+  })
+
+  it('bounds row reads on a huge no-newline blob', () => {
+    const rows = [makeBufferLine(`https://example.com/${'a'.repeat(20_000)}`, 400)]
+
+    expect(countRowReadsForHover(rows, 1)).toBeLessThan(MAX_ROW_READS_PER_HOVER)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/block-wrapped-http-link-provider.test.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-http-link-provider.test.ts
@@ -1,0 +1,103 @@
+import type { IBufferLine, ILink, Terminal } from '@xterm/xterm'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
+import { createBlockWrappedHttpLinkProvider } from './block-wrapped-http-link-provider'
+
+const COLS = 110
+const WRAP_WIDTH = 100
+const openUrlMock = vi.fn()
+
+// The reported grok output: a PR link wrapping after `orca/`.
+const ROWS = [
+  'pull/10257#issuecomment-5068240478) · 10349 (https://github.com/stablyai/orca/',
+  'pull/10349#issuecomment-5068238223)',
+  "These remaining ones match the thread's UI surface and are labeled as baselines now.".padEnd(
+    WRAP_WIDTH
+  )
+]
+const EXPECTED_URL = 'https://github.com/stablyai/orca/pull/10349#issuecomment-5068238223'
+
+function makeBufferLine(content: string): IBufferLine {
+  const text = content.padEnd(COLS)
+  const columns = Array.from({ length: text.length + 1 }, (_value, index) => index)
+  return {
+    isWrapped: false,
+    length: COLS,
+    translateToString: (
+      _trimRight?: boolean,
+      startColumn = 0,
+      endColumn = text.length,
+      outColumns?: number[]
+    ) => {
+      outColumns?.splice(0, outColumns.length, ...columns.slice(startColumn, endColumn + 1))
+      return text.slice(startColumn, endColumn)
+    }
+  } as IBufferLine
+}
+
+function provideLinksAt(bufferLineNumber: number, linkTooltip: HTMLElement): ILink[] | undefined {
+  const lines = ROWS.map((row) => makeBufferLine(row))
+  const terminal = {
+    buffer: { active: { getLine: (y: number) => lines[y] } },
+    clearSelection: vi.fn()
+  } as unknown as Terminal
+
+  let provided: ILink[] | undefined
+  createBlockWrappedHttpLinkProvider({
+    getTerminal: () => terminal,
+    worktreeId: 'wt-1',
+    linkTooltip,
+    openLinkHint: '⌘+click to open'
+  }).provideLinks(bufferLineNumber, (links) => {
+    provided = links
+  })
+  return provided
+}
+
+function makeTooltip(): HTMLElement {
+  return { textContent: '', style: { display: 'none' } } as unknown as HTMLElement
+}
+
+describe('block-wrapped HTTP link provider', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { api: { shell: { openUrl: openUrlMock } } })
+    registerHttpLinkStoreAccessor(() => ({
+      settings: { openLinksInApp: false },
+      setActiveWorktree: vi.fn(),
+      createBrowserTab: vi.fn()
+    }))
+    openUrlMock.mockReset()
+  })
+
+  // Why: WebLinksAddon walks rows via xterm's `isWrapped` flag, which a TUI
+  // that positions its own output never sets — so it reports no link at all on
+  // the continuation row and hovering the tail showed no tooltip.
+  it.each([
+    ['scheme row', 1],
+    ['continuation row', 2]
+  ])('reports the whole wrapped URL when hovering the %s', (_label, bufferLineNumber) => {
+    const links = provideLinksAt(bufferLineNumber, makeTooltip())
+
+    expect(links).toHaveLength(1)
+    expect(links?.[0].text).toBe(EXPECTED_URL)
+  })
+
+  it('spans a range covering both rows so either end hits the link', () => {
+    const range = provideLinksAt(2, makeTooltip())?.[0].range
+
+    expect(range?.start.y).toBe(1)
+    expect(range?.end.y).toBe(2)
+  })
+
+  it('shows the full URL in the tooltip from the continuation row', () => {
+    const linkTooltip = makeTooltip()
+    provideLinksAt(2, linkTooltip)?.[0].hover?.({} as MouseEvent, EXPECTED_URL)
+
+    expect(linkTooltip.textContent).toBe(`${EXPECTED_URL} (⌘+click to open)`)
+    expect(linkTooltip.style.display).toBe('')
+  })
+
+  it('reports nothing on an unrelated row', () => {
+    expect(provideLinksAt(3, makeTooltip())).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/block-wrapped-http-link-provider.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-http-link-provider.ts
@@ -1,0 +1,100 @@
+import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm'
+import { buildBlockWrappedHttpLogicalLineCandidates } from './block-wrapped-terminal-http-links'
+import { extractTerminalHttpLinks } from './terminal-http-url-token-scanning'
+import { isTerminalHttpLinkActivation } from './terminal-http-link-activation'
+import {
+  openTerminalHttpLink,
+  type TerminalLinkRoutingPreferenceRequester
+} from './terminal-url-link-hit-testing'
+import { rangeForParsedFileLink } from './wrapped-terminal-link-ranges'
+
+type BlockWrappedHttpLinkProviderDeps = {
+  getTerminal: () => Terminal | null
+  worktreeId: string
+  linkTooltip: HTMLElement
+  openLinkHint: string
+  formatTooltip?: (url: string, openLinkHint: string) => Promise<string | null> | string | null
+  requestOpenLinksInAppPreference?: TerminalLinkRoutingPreferenceRequester
+}
+
+/**
+ * Surfaces block-width-wrapped URLs to xterm's linkifier.
+ *
+ * WebLinksAddon walks rows through xterm's `isWrapped` metadata, which a TUI
+ * that positions its own output never sets. It therefore reports the URL on the
+ * row bearing the scheme and nothing at all on the continuation rows — so
+ * hovering the tail showed no tooltip even though a modifier-click there opened
+ * the link via the mouseup fallback. This provider spans every constituent row,
+ * keeping hover and click on the same target.
+ */
+export function createBlockWrappedHttpLinkProvider(
+  deps: BlockWrappedHttpLinkProviderDeps
+): ILinkProvider {
+  return {
+    provideLinks: (bufferLineNumber, callback) => {
+      const terminal = deps.getTerminal()
+      if (!terminal) {
+        callback(undefined)
+        return
+      }
+
+      const logicalLines = buildBlockWrappedHttpLogicalLineCandidates(
+        terminal.buffer.active,
+        bufferLineNumber
+      )
+      let hoverToken = 0
+      for (const logicalLine of logicalLines) {
+        for (const parsed of extractTerminalHttpLinks(logicalLine.text)) {
+          // Why: only the URL that actually spans the wrap belongs here; a
+          // complete URL sharing the start row is WebLinksAddon's to report.
+          if (parsed.endIndex < logicalLine.rows[0].text.length) {
+            continue
+          }
+          const range = rangeForParsedFileLink(logicalLine, parsed.startIndex, parsed.endIndex)
+          if (!range) {
+            continue
+          }
+
+          const link: ILink = {
+            range,
+            text: parsed.url,
+            activate: (event) => {
+              if (!isTerminalHttpLinkActivation(event)) {
+                return
+              }
+              event.preventDefault()
+              openTerminalHttpLink(parsed.url, {
+                worktreeId: deps.worktreeId,
+                forceSystemBrowser: event.shiftKey,
+                requestOpenLinksInAppPreference: deps.requestOpenLinksInAppPreference
+              })
+              terminal.clearSelection()
+            },
+            hover: () => {
+              hoverToken += 1
+              const token = hoverToken
+              deps.linkTooltip.textContent = `${parsed.url} (${deps.openLinkHint})`
+              deps.linkTooltip.style.display = ''
+              void Promise.resolve(deps.formatTooltip?.(parsed.url, deps.openLinkHint)).then(
+                (formatted) => {
+                  if (token === hoverToken && formatted) {
+                    deps.linkTooltip.textContent = formatted
+                  }
+                },
+                () => undefined
+              )
+            },
+            leave: () => {
+              hoverToken += 1
+              deps.linkTooltip.style.display = 'none'
+            }
+          }
+          callback([link])
+          return
+        }
+      }
+
+      callback(undefined)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.test.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.test.ts
@@ -167,6 +167,27 @@ describe('block-wrapped terminal HTTP links', () => {
       ).toBe(true)
       expect(openUrlMock).toHaveBeenCalledWith(`https://two.test/${continuation}`)
     })
+
+    it('leaves the URL truncated when no row proves the block runs wider', () => {
+      // Documented limitation: the URL row is itself the widest at its margin,
+      // so nothing shows there was room to spare and the break stays ambiguous.
+      // Accepting equal-width rows as evidence reopens #8832 for prose tails,
+      // so this degrades to the pre-fix behaviour rather than guessing.
+      const urlRow =
+        '10181 (https://github.com/stablyai/orca/pull/10181) · 10349 (https://github.com/stablyai/orca/'
+      const rows = [urlRow, 'pull/10349#issuecomment-5068238223)'].map((row) => makeBufferLine(row))
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(
+          buffer,
+          { x: urlRow.lastIndexOf('https://') + 10, y: 1 },
+          COLS,
+          { worktreeId: 'wt-1', forceSystemBrowser: true }
+        )
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith('https://github.com/stablyai/orca/')
+    })
   })
 
   // Regression guards for #8832 / PR #9100: that fix keyed on the URL row

--- a/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.test.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.test.ts
@@ -122,7 +122,15 @@ describe('block-wrapped terminal HTTP links', () => {
       ['git ref range', 'origin/main..HEAD is ahead'],
       ['date row', '2026/07/24 build finished'],
       ['markdown heading', '### Heading text goes here'],
-      ['fraction prose', '1/2 of the tests passed ok']
+      ['fraction prose', '1/2 of the tests passed ok'],
+      ['CI date log', '2026/07/24 deploy finished without errors'],
+      ['repo path sentence', 'src/main/index.ts was rebuilt after the change'],
+      ['and/or prose', 'and/or the retry can be triggered manually later'],
+      ['version note', 'v2.0/changelog notes were published separately'],
+      // A fragment attaches to a resource, so a wrap never leaves `/` ending one
+      // row and `#` opening the next — that row is a Markdown anchor.
+      ['bare markdown anchor', '#next-steps'],
+      ['bare hashtag', '#deploy']
     ])('does not glue a following %s', (_shape, nextRow) => {
       const rows = [fullUrl, nextRow, 'x'.repeat(WRAP_WIDTH)].map((row) => makeBufferLine(row))
       const buffer = { getLine: (y: number) => rows[y] }
@@ -134,6 +142,47 @@ describe('block-wrapped terminal HTTP links', () => {
         })
       ).toBe(true)
       expect(openUrlMock).toHaveBeenCalledWith(fullUrl)
+    })
+
+    // A tail need not carry URL punctuation: requiring it truncated legal URLs.
+    // Prose is excluded by the whole-row rule instead.
+    it.each([
+      [
+        'bare commit SHA',
+        'https://git.example.com/org/very-long-repository-name/branch/-/commit/',
+        'e83bc27b12f04ad9e5f1'
+      ],
+      ['bare final path segment', `https://example.com/${'a'.repeat(WRAP_WIDTH - 25)}/`, 'archive']
+    ])('reconstructs a wrapped URL ending in a %s', (_shape, prefix, tail) => {
+      const urlRow = `${prefix}${'p'.repeat(WRAP_WIDTH - 3 - prefix.length)}/`
+      const rows = [urlRow, tail, 'w'.repeat(WRAP_WIDTH)].map((row) => makeBufferLine(row))
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 20, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(`${urlRow}${tail}`)
+    })
+
+    it('infers the block width from the nearest wider row, not the widest', () => {
+      // A single full-terminal-width line must not inflate the block width and
+      // make a genuine wrap look like it had room to spare.
+      const urlRow = `https://example.com/${'a'.repeat(69)}/`
+      const rows = [urlRow, 'abcdefghijk/p', 'x'.repeat(WRAP_WIDTH), 'z'.repeat(COLS)].map((row) =>
+        makeBufferLine(row)
+      )
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 10, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(`${urlRow}abcdefghijk/p`)
     })
 
     it('does not join when the URL row ends far short of the block width', () => {

--- a/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.test.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.test.ts
@@ -1,0 +1,367 @@
+import type { IBufferLine } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
+import { openHttpLinkAtBufferPosition } from './terminal-url-link-hit-testing'
+
+// Why: grok renders markdown at its own wrap width, well inside the terminal's
+// right edge, so a wrapped URL row never reaches the last column.
+const COLS = 110
+const WRAP_WIDTH = 100
+
+const openUrlMock = vi.fn()
+
+function makeBufferLine(content: string, cols = COLS): IBufferLine {
+  const text = content.padEnd(cols)
+  const columns = Array.from({ length: text.length + 1 }, (_value, index) => index)
+  return {
+    isWrapped: false,
+    length: cols,
+    translateToString: (
+      _trimRight?: boolean,
+      startColumn = 0,
+      endColumn = text.length,
+      outColumns?: number[]
+    ) => {
+      outColumns?.splice(0, outColumns.length, ...columns.slice(startColumn, endColumn + 1))
+      return text.slice(startColumn, endColumn)
+    }
+  } as IBufferLine
+}
+
+// Mirrors the reported grok output: a PR list whose URLs wrap after `orca/`,
+// plus prose rows that reveal the block's real wrap width.
+const GROK_ROWS = [
+  'issues/10033#issuecomment-5068237143)',
+  '',
+  'PRs:',
+  'pull/10181#issuecomment-5068241002) · 10257 (https://github.com/stablyai/orca/',
+  'pull/10257#issuecomment-5068240478) · 10349 (https://github.com/stablyai/orca/',
+  'pull/10349#issuecomment-5068238223)',
+  '',
+  "These remaining ones match the thread's UI surface (sidebar layout, tab strip, SC panel, board".padEnd(
+    WRAP_WIDTH
+  ),
+  'mock, docs product refs) and are labeled as baselines/references — not bug repros.'
+]
+
+const EXPECTED_URL = 'https://github.com/stablyai/orca/pull/10349#issuecomment-5068238223'
+
+describe('block-wrapped terminal HTTP links', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { api: { shell: { openUrl: openUrlMock } } })
+    registerHttpLinkStoreAccessor(() => ({
+      settings: { openLinksInApp: false },
+      setActiveWorktree: vi.fn(),
+      createBrowserTab: vi.fn()
+    }))
+    openUrlMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function grokBuffer(): { getLine: (y: number) => IBufferLine | undefined } {
+    const rows = GROK_ROWS.map((row) => makeBufferLine(row))
+    return { getLine: (y: number) => rows[y] }
+  }
+
+  it('opens the whole URL when grok wraps it inside the terminal width', () => {
+    const buffer = grokBuffer()
+    const urlStartColumn = GROK_ROWS[4].indexOf('https://') + 1
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: urlStartColumn + 10, y: 5 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).toHaveBeenCalledWith(EXPECTED_URL)
+  })
+
+  it('opens the whole URL from the wrapped continuation row', () => {
+    const buffer = grokBuffer()
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 5, y: 6 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).toHaveBeenCalledWith(EXPECTED_URL)
+  })
+
+  it('keeps the sibling URL on the row above intact', () => {
+    const buffer = grokBuffer()
+    const urlStartColumn = GROK_ROWS[3].indexOf('https://') + 1
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: urlStartColumn + 10, y: 4 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).toHaveBeenCalledWith(
+      'https://github.com/stablyai/orca/pull/10257#issuecomment-5068240478'
+    )
+  })
+
+  // Shapes surfaced by adversarial review. Each glued unrelated text onto a
+  // URL before the guard named beside it existed.
+  describe('adversarial review regressions', () => {
+    const fullUrl = `https://example.com/${'a'.repeat(WRAP_WIDTH - 21)}/`
+
+    it.each([
+      ['unspaced label row', 'Description:123'],
+      ['POSIX path row', '/usr/local/bin/orca'],
+      ['bare prose word', 'DescriptionWithoutColon continues here'],
+      ['timestamped log row', '12:34:56 request complete'],
+      ['git ref range', 'origin/main..HEAD is ahead'],
+      ['date row', '2026/07/24 build finished'],
+      ['markdown heading', '### Heading text goes here'],
+      ['fraction prose', '1/2 of the tests passed ok']
+    ])('does not glue a following %s', (_shape, nextRow) => {
+      const rows = [fullUrl, nextRow, 'x'.repeat(WRAP_WIDTH)].map((row) => makeBufferLine(row))
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 15, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(fullUrl)
+    })
+
+    it('does not join when the URL row ends far short of the block width', () => {
+      // Nothing suggests a wrap: the URL ended with most of the row unused.
+      const shortUrl = 'https://github.com/stablyai/orca/'
+      const rows = [shortUrl, `src/${'deep/'.repeat(12)}index.ts`, 'x'.repeat(WRAP_WIDTH)].map(
+        (row) => makeBufferLine(row)
+      )
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 15, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(shortUrl)
+    })
+
+    it('wraps the last URL on a row that already holds a complete one', () => {
+      const first = `Earlier https://one.test/path then ${'x'.repeat(30)} https://two.test/`
+      const continuation = 'pull/10349#issuecomment-5068238223'
+      const rows = [first, continuation, 'x'.repeat(WRAP_WIDTH)].map((row) => makeBufferLine(row))
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: first.indexOf('https://two') + 5, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(`https://two.test/${continuation}`)
+    })
+  })
+
+  // Regression guards for #8832 / PR #9100: that fix keyed on the URL row
+  // stopping short of the *terminal* edge, which no longer discriminates once
+  // block-width wrapping is reconstructed. These re-test its cases at a width
+  // where the block wrap column is detectable.
+  describe('#8832 shapes at block width', () => {
+    it('does not glue a following label row onto a full-width URL row', () => {
+      const rows = [
+        `https://example.com/${'a'.repeat(WRAP_WIDTH - 21)}/`,
+        'Description: 123',
+        'x'.repeat(WRAP_WIDTH)
+      ].map((row) => makeBufferLine(row))
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 15, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(
+        `https://example.com/${'a'.repeat(WRAP_WIDTH - 21)}/`
+      )
+    })
+
+    it('keeps the original #8832 rows unglued when a wide sibling row exists', () => {
+      const rows = [
+        'Repo: https://github.com/stablyai/orca/',
+        'Description: 123',
+        'x'.repeat(WRAP_WIDTH)
+      ].map((row) => makeBufferLine(row))
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 15, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith('https://github.com/stablyai/orca/')
+    })
+
+    it.each([
+      ['Chinese label', '说明: 中文路径/文件.ts'],
+      ['Windows path', 'C:\\Users\\demo\\project\\README.md'],
+      ['POSIX path', '/usr/local/bin/orca'],
+      ['relative path', './src/main/index.ts']
+    ])('does not glue a full-width URL row to a next-line %s', (_label, nextLine) => {
+      const url = `https://example.com/${'a'.repeat(WRAP_WIDTH - 21)}/`
+      const rows = [url, nextLine, 'x'.repeat(WRAP_WIDTH)].map((row) => makeBufferLine(row))
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 15, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(url)
+    })
+
+    it('does not join a row that ends mid-token rather than at a URL break', () => {
+      // No `/`, `?`, `&`… at the break, so the wrapper never split here.
+      const url = `https://example.com/${'a'.repeat(WRAP_WIDTH - 20)}`
+      const rows = [url, 'continuedpathsegment', 'x'.repeat(WRAP_WIDTH)].map((row) =>
+        makeBufferLine(row)
+      )
+      const buffer = { getLine: (y: number) => rows[y] }
+
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x: 15, y: 1 }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(url)
+    })
+  })
+
+  it('does not swallow the next row when the URL ends mid-row', () => {
+    const rows = [
+      'See https://example.com/short and then some more prose that continues well past it',
+      'nextword continues the paragraph here'
+    ].map((row) => makeBufferLine(row))
+    const buffer = { getLine: (y: number) => rows[y] }
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 10, y: 1 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/short')
+  })
+
+  it('does not join a following row whose first word would have fit', () => {
+    // `tail` fits in the space left after the URL, so the break was authored.
+    const rows = [
+      `${'x'.repeat(20)} https://example.com/path`.padEnd(WRAP_WIDTH - 20),
+      'tail and more words that make this row look like flowing prose'
+    ].map((row) => makeBufferLine(row))
+    rows.push(makeBufferLine('a'.repeat(WRAP_WIDTH)))
+    const buffer = { getLine: (y: number) => rows[y] }
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 30, y: 1 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/path')
+  })
+
+  it('does not join a following row at a different indent', () => {
+    const url = 'https://example.com/very/long/path/that/reaches/the/block/wrap/column/exactly/x'
+    const rows = [
+      url.padEnd(WRAP_WIDTH),
+      '    indented-continuation-token',
+      'a'.repeat(WRAP_WIDTH)
+    ].map((row) => makeBufferLine(row))
+    const buffer = { getLine: (y: number) => rows[y] }
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 10, y: 1 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith(url)
+  })
+
+  it('does not glue a wrapped URL to a following Windows path', () => {
+    const rows = [
+      'Repo: https://example.com/repo/'.padEnd(WRAP_WIDTH - 2),
+      'C:\\Users\\demo\\project\\file.ts',
+      'a'.repeat(WRAP_WIDTH)
+    ].map((row) => makeBufferLine(row))
+    const buffer = { getLine: (y: number) => rows[y] }
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 12, y: 1 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/repo/')
+  })
+
+  it('does not join a following row that starts its own URL', () => {
+    const first = `https://example.com/${'a'.repeat(WRAP_WIDTH - 25)}`
+    const second = 'https://two.test/path'
+    const rows = [first, second, 'a'.repeat(WRAP_WIDTH)].map((row) => makeBufferLine(row))
+    const buffer = { getLine: (y: number) => rows[y] }
+
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 10, y: 1 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith(first)
+
+    openUrlMock.mockReset()
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 10, y: 2 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith(second)
+  })
+
+  it('joins a URL wrapped across three block rows', () => {
+    // Rows break after `/`, the way a URL-aware wrapper splits a long URL.
+    const first = `https://example.com/${'a'.repeat(WRAP_WIDTH - 26)}/`
+    const second = `${'b'.repeat(WRAP_WIDTH - 7)}/`
+    const third = 'tail/end'
+    const rows = [first, second, third, 'w'.repeat(WRAP_WIDTH)].map((row) => makeBufferLine(row))
+    const buffer = { getLine: (y: number) => rows[y] }
+
+    // Clicking any of the three rows must resolve the same joined URL.
+    for (const [y, x] of [
+      [1, 10],
+      [2, 10],
+      [3, 3]
+    ]) {
+      openUrlMock.mockReset()
+      expect(
+        openHttpLinkAtBufferPosition(buffer, { x, y }, COLS, {
+          worktreeId: 'wt-1',
+          forceSystemBrowser: true
+        })
+      ).toBe(true)
+      expect(openUrlMock).toHaveBeenCalledWith(`${first}${second}${third}`)
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
@@ -236,7 +236,8 @@ export function buildBlockWrappedHttpLogicalLineCandidates(
     let previousEndColumn = start.endColumn
     for (let rowY = startY + 1; rowY <= startY + MAX_BLOCK_WRAPPED_ROWS; rowY++) {
       // Why: without a wider sibling row the block never demonstrates room to
-      // the right of this URL, so nothing shows the break was a wrap.
+      // the right of this URL, so nothing shows the break was a wrap. Relaxing
+      // this to allow an equal-width row reopens #8832 for prose continuations.
       if (wrapColumn <= previousEndColumn) {
         break
       }

--- a/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
@@ -20,6 +20,8 @@ const LABEL_ROW_PATTERN = /^[^\s:/?&=#%+-][^\s:]*:(?:\s|\S|$)/
 // (#8832); so is one holding characters a URL tail would have percent-encoded.
 const PATH_ROW_START_PATTERN = /^(?:[/\\~]|\.{1,2}[/\\]|[A-Za-z]:[/\\])/
 const URL_TAIL_CHARSET_PATTERN = /^[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]+$/
+// A row that is only `#token`: a Markdown anchor or heading, not a URL fragment.
+const MARKDOWN_ANCHOR_ROW_PATTERN = /^#/
 const MAX_BLOCK_WRAPPED_ROWS = 30
 const BLOCK_WIDTH_SCAN_ROWS = 40
 // Why: a wrapper breaks a URL only once the row is nearly used up. A URL row
@@ -235,6 +237,7 @@ export function buildBlockWrappedHttpLogicalLineCandidates(
       continue
     }
 
+    const previousRowEndsAtPathSeparator = start.text[start.contentEnd - 1] === '/'
     let text = start.text.slice(schemeIndex, start.contentEnd)
     const rows = [toLogicalRow(start, startY, schemeIndex, start.contentEnd, 0)]
     let previousEndColumn = start.endColumn
@@ -270,6 +273,12 @@ export function buildBlockWrappedHttpLogicalLineCandidates(
       // punctuation — a bare last path segment is legal — because
       // leadingUrlFragment has already established the token is the whole row.
       if (!URL_TAIL_CHARSET_PATTERN.test(fragment.runText)) {
+        break
+      }
+      // Why: a fragment attaches to a resource, so a wrap never leaves `/` at
+      // the end of one row and `#` at the start of the next. A lone `#token`
+      // row is a Markdown anchor or heading of its own.
+      if (previousRowEndsAtPathSeparator && MARKDOWN_ANCHOR_ROW_PATTERN.test(fragment.runText)) {
         break
       }
       // Why: a token spanning the block's full width would not have fit on any

--- a/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
@@ -20,8 +20,6 @@ const LABEL_ROW_PATTERN = /^[^\s:/?&=#%+-][^\s:]*:(?:\s|\S|$)/
 // (#8832); so is one holding characters a URL tail would have percent-encoded.
 const PATH_ROW_START_PATTERN = /^(?:[/\\~]|\.{1,2}[/\\]|[A-Za-z]:[/\\])/
 const URL_TAIL_CHARSET_PATTERN = /^[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]+$/
-// A tail must carry the URL's own structure; bare prose must not qualify.
-const URL_STRUCTURE_PATTERN = /[/?&=#%]/
 const MAX_BLOCK_WRAPPED_ROWS = 30
 const BLOCK_WIDTH_SCAN_ROWS = 40
 // Why: a wrapper breaks a URL only once the row is nearly used up. A URL row
@@ -113,6 +111,12 @@ function urlRunReachesRowEnd(row: BlockRow, schemeIndex: number): boolean {
  * whitespace, at the row end, or at trailing punctuation followed by
  * whitespace — a token cut short by a URL-hostile character mid-word (a
  * Windows path's backslash, say) is not a wrapped URL continuation.
+ *
+ * Anything following the token must itself contain a URL. A wrapped tail is
+ * either the end of the line or is followed by the next link in a list, the way
+ * an agent prints one; plain prose after it means the row is its own sentence
+ * that merely opens with a slash-bearing word — a date, a path, an `and/or`
+ * (#8832).
  */
 function leadingUrlFragment(row: BlockRow): LeadingUrlFragment | null {
   const content = row.text.slice(row.contentStart, row.contentEnd)
@@ -123,7 +127,7 @@ function leadingUrlFragment(row: BlockRow): LeadingUrlFragment | null {
   const remainder = content.slice(runText.length)
   const tail = remainder.match(URL_TRAILING_PUNCTUATION_PATTERN)?.[0] ?? ''
   const after = remainder.slice(tail.length)
-  if (after !== '' && !/^\s/.test(after)) {
+  if (after.trim() !== '' && findHttpSchemeIndex(after) === -1) {
     return null
   }
 
@@ -192,24 +196,24 @@ export function buildBlockWrappedHttpLogicalLineCandidates(
     return row
   }
 
-  const wrapColumnByMargin = new Map<number, number>()
-  const wrapColumnForMargin = (marginColumn: number): number => {
-    const cached = wrapColumnByMargin.get(marginColumn)
-    if (cached !== undefined) {
-      return cached
-    }
-    // Why: the widest row at this margin is the best available evidence of how
-    // far the block may run. Prose rows rarely end on the same column, so a
-    // most-common-width estimate collapses on real output.
-    let wrapColumn = 0
-    for (let y = currentY - BLOCK_WIDTH_SCAN_ROWS; y <= currentY + BLOCK_WIDTH_SCAN_ROWS; y++) {
-      const row = getRow(y)
-      if (row && row.startColumn === marginColumn) {
-        wrapColumn = Math.max(wrapColumn, row.endColumn)
+  // Why: the block width is witnessed by the *nearest* row that runs past the
+  // URL row, not the widest row anywhere in the window. One unrelated wide line
+  // (a full-terminal-width log entry, say) would otherwise inflate the estimate
+  // until every genuine wrap looked like it had room to spare.
+  const wrapColumnFor = (marginColumn: number, urlEndColumn: number, urlRowY: number): number => {
+    for (let distance = 1; distance <= BLOCK_WIDTH_SCAN_ROWS; distance++) {
+      let nearest = 0
+      for (const y of [urlRowY - distance, urlRowY + distance]) {
+        const row = getRow(y)
+        if (row && row.startColumn === marginColumn && row.endColumn > urlEndColumn) {
+          nearest = Math.max(nearest, row.endColumn)
+        }
+      }
+      if (nearest > 0) {
+        return nearest
       }
     }
-    wrapColumnByMargin.set(marginColumn, wrapColumn)
-    return wrapColumn
+    return 0
   }
 
   const candidates: WrappedLogicalLine[] = []
@@ -223,7 +227,7 @@ export function buildBlockWrappedHttpLogicalLineCandidates(
     if (schemeIndex === -1 || !urlRunReachesRowEnd(start, schemeIndex)) {
       continue
     }
-    const wrapColumn = wrapColumnForMargin(start.startColumn)
+    const wrapColumn = wrapColumnFor(start.startColumn, start.endColumn, startY)
     // Why: a URL-aware wrapper splits only at a structural character. A row
     // ending mid-token ended because the URL ended, so joining the next row
     // would recreate #8832.
@@ -262,12 +266,10 @@ export function buildBlockWrappedHttpLogicalLineCandidates(
       if (!fragment || HTTP_SCHEME_START_PATTERN.test(fragment.runText)) {
         break
       }
-      // Why: a wrapped tail keeps to URL characters and carries the URL's own
-      // structure. A bare word is prose that happened to follow (#8832).
-      if (
-        !URL_TAIL_CHARSET_PATTERN.test(fragment.runText) ||
-        !URL_STRUCTURE_PATTERN.test(fragment.runText)
-      ) {
+      // Why: a wrapped tail keeps to URL characters. It need not contain URL
+      // punctuation — a bare last path segment is legal — because
+      // leadingUrlFragment has already established the token is the whole row.
+      if (!URL_TAIL_CHARSET_PATTERN.test(fragment.runText)) {
         break
       }
       // Why: a token spanning the block's full width would not have fit on any

--- a/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
+++ b/src/renderer/src/components/terminal-pane/block-wrapped-terminal-http-links.ts
@@ -1,0 +1,302 @@
+import type { IBufferLine } from '@xterm/xterm'
+import { TERMINAL_HTTP_URL_MAX_LENGTH } from './terminal-http-link-limits'
+import { translateLineWithColumns, type WrappedLogicalLine } from './wrapped-terminal-link-ranges'
+
+const HTTP_SCHEME_PATTERN = /https?:\/\//i
+const HTTP_SCHEME_START_PATTERN = /^https?:\/\//i
+const VERTICAL_LAYOUT_FRAME_PATTERN = /[│┃║╎╏┆┇┊┋|]/
+// Mirrors isHttpUrlBodyTerminator: the characters that end a URL token.
+const URL_BODY_RUN_PATTERN = /^[^\s"'!*(){}|\\^<>`]*/
+const URL_TRAILING_PUNCTUATION_PATTERN = /^[)\]}>.,;:!?'"`]*/
+// Where a URL-aware wrapper is allowed to split a long URL (see the same
+// suffix set in hard-wrapped-terminal-http-links).
+const URL_BREAK_OPPORTUNITY_PATTERN = /[/?&=#%+:-]$/
+// Why: a `Label: value` row is its own line of output, not URL continuation —
+// the guard that #8832/#9100 established for edge-wrapped rows (#8832).
+// Both spaced (`Label: v`) and unspaced (`Label:v`) forms count.
+const LABEL_ROW_PATTERN = /^[^\s:/?&=#%+-][^\s:]*:(?:\s|\S|$)/
+// A wrapped URL tail continues the URL's own character set. A row opening with
+// a path root, a drive letter, or a relative prefix is a fresh path, not a tail
+// (#8832); so is one holding characters a URL tail would have percent-encoded.
+const PATH_ROW_START_PATTERN = /^(?:[/\\~]|\.{1,2}[/\\]|[A-Za-z]:[/\\])/
+const URL_TAIL_CHARSET_PATTERN = /^[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]+$/
+// A tail must carry the URL's own structure; bare prose must not qualify.
+const URL_STRUCTURE_PATTERN = /[/?&=#%]/
+const MAX_BLOCK_WRAPPED_ROWS = 30
+const BLOCK_WIDTH_SCAN_ROWS = 40
+// Why: a wrapper breaks a URL only once the row is nearly used up. A URL row
+// ending far short of the block width ended because the URL did, so joining
+// the next row would recreate #8832.
+const MAX_UNUSED_COLUMN_RATIO = 0.25
+
+type BlockRow = {
+  text: string
+  columns: number[]
+  isWrapped: boolean
+  lineLength: number
+  contentStart: number
+  contentEnd: number
+  startColumn: number
+  endColumn: number
+}
+
+type LeadingUrlFragment = {
+  runText: string
+  runEnd: number
+  /** Display width of the unbreakable token (run plus trailing punctuation). */
+  tokenWidth: number
+}
+
+function translateBlockRow(line: IBufferLine): BlockRow | null {
+  const translated = translateLineWithColumns(line)
+  const contentStart = translated.text.search(/\S/)
+  if (contentStart === -1) {
+    return null
+  }
+  let contentEnd = translated.text.length
+  while (contentEnd > contentStart && /\s/.test(translated.text[contentEnd - 1])) {
+    contentEnd--
+  }
+  return {
+    text: translated.text,
+    columns: translated.columns,
+    isWrapped: line.isWrapped,
+    lineLength: line.length,
+    contentStart,
+    contentEnd,
+    startColumn: translated.columns[contentStart] ?? contentStart,
+    endColumn: translated.columns[contentEnd] ?? contentEnd
+  }
+}
+
+function isAsciiWordCode(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  )
+}
+
+/**
+ * The last URL on the row — only that one can run into the wrap. An earlier,
+ * already-complete URL on the same row must not shadow it.
+ */
+function findHttpSchemeIndex(text: string): number {
+  let searchStart = 0
+  let lastIndex = -1
+  while (searchStart < text.length) {
+    const relativeIndex = text.slice(searchStart).search(HTTP_SCHEME_PATTERN)
+    if (relativeIndex === -1) {
+      return lastIndex
+    }
+    const schemeIndex = searchStart + relativeIndex
+    if (schemeIndex === 0 || !isAsciiWordCode(text.charCodeAt(schemeIndex - 1))) {
+      lastIndex = schemeIndex
+    }
+    searchStart = schemeIndex + 1
+  }
+  return lastIndex
+}
+
+/**
+ * The URL token must occupy the rest of the row for the row to have wrapped:
+ * anything after it means the URL already ended on this row.
+ */
+function urlRunReachesRowEnd(row: BlockRow, schemeIndex: number): boolean {
+  const run = row.text.slice(schemeIndex, row.contentEnd).match(URL_BODY_RUN_PATTERN)?.[0] ?? ''
+  return run.length > 0 && schemeIndex + run.length === row.contentEnd
+}
+
+/**
+ * The row's first token, when it reads as URL body. The token must end at
+ * whitespace, at the row end, or at trailing punctuation followed by
+ * whitespace — a token cut short by a URL-hostile character mid-word (a
+ * Windows path's backslash, say) is not a wrapped URL continuation.
+ */
+function leadingUrlFragment(row: BlockRow): LeadingUrlFragment | null {
+  const content = row.text.slice(row.contentStart, row.contentEnd)
+  const runText = content.match(URL_BODY_RUN_PATTERN)?.[0] ?? ''
+  if (!runText) {
+    return null
+  }
+  const remainder = content.slice(runText.length)
+  const tail = remainder.match(URL_TRAILING_PUNCTUATION_PATTERN)?.[0] ?? ''
+  const after = remainder.slice(tail.length)
+  if (after !== '' && !/^\s/.test(after)) {
+    return null
+  }
+
+  const tokenEnd = row.contentStart + runText.length + tail.length
+  const tokenEndColumn = row.columns[tokenEnd] ?? tokenEnd
+  return {
+    runText,
+    runEnd: row.contentStart + runText.length,
+    tokenWidth: tokenEndColumn - row.startColumn
+  }
+}
+
+function toLogicalRow(
+  row: BlockRow,
+  y: number,
+  startIndex: number,
+  endIndex: number,
+  logicalStartIndex: number
+): WrappedLogicalLine['rows'][number] {
+  return {
+    y,
+    text: row.text.slice(startIndex, endIndex),
+    sourceText: row.text,
+    columns: row.columns.slice(startIndex, endIndex + 1),
+    startIndex: logicalStartIndex,
+    isWrapped: row.isWrapped,
+    lineLength: row.lineLength
+  }
+}
+
+function toLogicalLine(rows: WrappedLogicalLine['rows'], text: string): WrappedLogicalLine {
+  return {
+    text,
+    rows: [...rows],
+    fingerprint: `block-http:${rows.map((row) => `${row.y}:${row.sourceText}`).join('\0')}`
+  }
+}
+
+/**
+ * Reconstruct URLs that a TUI wrapped at its own block width rather than at the
+ * terminal edge (grok's markdown stream, for one). Such rows carry no xterm
+ * wrap metadata and stop well short of the last column, so both the soft-wrap
+ * and terminal-edge strategies miss them.
+ *
+ * A row only counts as a continuation when the break looks mechanical: the
+ * block demonstrably extends past where the URL row stopped, yet the next row's
+ * leading token would not have fit in the space that was left.
+ */
+export function buildBlockWrappedHttpLogicalLineCandidates(
+  buffer: { getLine(y: number): IBufferLine | undefined },
+  bufferLineNumber: number
+): WrappedLogicalLine[] {
+  const currentY = bufferLineNumber - 1
+  if (!buffer.getLine(currentY)) {
+    return []
+  }
+
+  const rowCache = new Map<number, BlockRow | null>()
+  const getRow = (y: number): BlockRow | null => {
+    if (rowCache.has(y)) {
+      return rowCache.get(y) ?? null
+    }
+    const line = y < 0 ? undefined : buffer.getLine(y)
+    const row = line ? translateBlockRow(line) : null
+    rowCache.set(y, row)
+    return row
+  }
+
+  const wrapColumnByMargin = new Map<number, number>()
+  const wrapColumnForMargin = (marginColumn: number): number => {
+    const cached = wrapColumnByMargin.get(marginColumn)
+    if (cached !== undefined) {
+      return cached
+    }
+    // Why: the widest row at this margin is the best available evidence of how
+    // far the block may run. Prose rows rarely end on the same column, so a
+    // most-common-width estimate collapses on real output.
+    let wrapColumn = 0
+    for (let y = currentY - BLOCK_WIDTH_SCAN_ROWS; y <= currentY + BLOCK_WIDTH_SCAN_ROWS; y++) {
+      const row = getRow(y)
+      if (row && row.startColumn === marginColumn) {
+        wrapColumn = Math.max(wrapColumn, row.endColumn)
+      }
+    }
+    wrapColumnByMargin.set(marginColumn, wrapColumn)
+    return wrapColumn
+  }
+
+  const candidates: WrappedLogicalLine[] = []
+  const minY = Math.max(0, currentY - MAX_BLOCK_WRAPPED_ROWS + 1)
+  for (let startY = currentY; startY >= minY; startY--) {
+    const start = getRow(startY)
+    if (!start || VERTICAL_LAYOUT_FRAME_PATTERN.test(start.text)) {
+      continue
+    }
+    const schemeIndex = findHttpSchemeIndex(start.text)
+    if (schemeIndex === -1 || !urlRunReachesRowEnd(start, schemeIndex)) {
+      continue
+    }
+    const wrapColumn = wrapColumnForMargin(start.startColumn)
+    // Why: a URL-aware wrapper splits only at a structural character. A row
+    // ending mid-token ended because the URL ended, so joining the next row
+    // would recreate #8832.
+    if (!URL_BREAK_OPPORTUNITY_PATTERN.test(start.text.slice(0, start.contentEnd))) {
+      continue
+    }
+
+    let text = start.text.slice(schemeIndex, start.contentEnd)
+    const rows = [toLogicalRow(start, startY, schemeIndex, start.contentEnd, 0)]
+    let previousEndColumn = start.endColumn
+    for (let rowY = startY + 1; rowY <= startY + MAX_BLOCK_WRAPPED_ROWS; rowY++) {
+      // Why: without a wider sibling row the block never demonstrates room to
+      // the right of this URL, so nothing shows the break was a wrap.
+      if (wrapColumn <= previousEndColumn) {
+        break
+      }
+      const blockWidth = wrapColumn - start.startColumn
+      if (wrapColumn - previousEndColumn > blockWidth * MAX_UNUSED_COLUMN_RATIO) {
+        break
+      }
+      const next = getRow(rowY)
+      if (!next || next.startColumn !== start.startColumn) {
+        break
+      }
+      if (VERTICAL_LAYOUT_FRAME_PATTERN.test(next.text)) {
+        break
+      }
+      const nextContent = next.text.slice(next.contentStart, next.contentEnd)
+      // Why: `Label: value`, `Label:value`, and a fresh path root are all their
+      // own line of output rather than a URL tail (#8832).
+      if (LABEL_ROW_PATTERN.test(nextContent) || PATH_ROW_START_PATTERN.test(nextContent)) {
+        break
+      }
+      const fragment = leadingUrlFragment(next)
+      if (!fragment || HTTP_SCHEME_START_PATTERN.test(fragment.runText)) {
+        break
+      }
+      // Why: a wrapped tail keeps to URL characters and carries the URL's own
+      // structure. A bare word is prose that happened to follow (#8832).
+      if (
+        !URL_TAIL_CHARSET_PATTERN.test(fragment.runText) ||
+        !URL_STRUCTURE_PATTERN.test(fragment.runText)
+      ) {
+        break
+      }
+      // Why: a token spanning the block's full width would not have fit on any
+      // row, so its position says nothing about where the previous row ended.
+      if (fragment.tokenWidth >= wrapColumn - start.startColumn) {
+        break
+      }
+      // Why: the tail is one unbreakable token to a word wrapper, so it moved
+      // down whole. Had it fit in the space left on the previous row the
+      // wrapper would have kept it there — so these are two lines (#8832).
+      if (previousEndColumn + fragment.tokenWidth <= wrapColumn) {
+        break
+      }
+      if (text.length + fragment.runText.length > TERMINAL_HTTP_URL_MAX_LENGTH) {
+        break
+      }
+
+      rows.push(toLogicalRow(next, rowY, next.contentStart, fragment.runEnd, text.length))
+      text += fragment.runText
+      if (rowY >= currentY) {
+        candidates.push(toLogicalLine(rows, text))
+      }
+      if (fragment.runEnd !== next.contentEnd) {
+        break
+      }
+      previousEndColumn = next.endColumn
+    }
+  }
+
+  return candidates.sort(
+    (left, right) => right.rows.length - left.rows.length || right.text.length - left.text.length
+  )
+}

--- a/src/renderer/src/components/terminal-pane/grok-block-wrapped-url.repro.test.ts
+++ b/src/renderer/src/components/terminal-pane/grok-block-wrapped-url.repro.test.ts
@@ -1,0 +1,108 @@
+import { Terminal } from '@xterm/headless'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
+import { openHttpLinkAtBufferPosition } from './terminal-url-link-hit-testing'
+
+// Geometry measured from the reported grok pane: the markdown block wraps near
+// column 100 while the terminal itself is 110 columns wide.
+const COLS = 110
+const ROWS = 30
+const WRAP_WIDTH = 100
+
+const GROK_OUTPUT = [
+  'PRs:',
+  'pull/10181#issuecomment-5068241002) · 10257 (https://github.com/stablyai/orca/',
+  'pull/10257#issuecomment-5068240478) · 10349 (https://github.com/stablyai/orca/',
+  'pull/10349#issuecomment-5068238223)',
+  '',
+  "These remaining ones match the thread's UI surface (sidebar layout, tab strip, SC panel,",
+  'board tour mock, docs product refs) and are labeled as baselines/references.'
+]
+
+const EXPECTED_URL = 'https://github.com/stablyai/orca/pull/10349#issuecomment-5068238223'
+const openUrlMock = vi.fn()
+
+async function writeTerminal(terminal: Terminal, data: string): Promise<void> {
+  await new Promise<void>((resolve) => terminal.write(data, resolve))
+}
+
+describe('grok block-wrapped URL repro', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', { api: { shell: { openUrl: openUrlMock } } })
+    registerHttpLinkStoreAccessor(() => ({
+      settings: { openLinksInApp: false },
+      setActiveWorktree: vi.fn(),
+      createBrowserTab: vi.fn()
+    }))
+    openUrlMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('opens the full URL grok wrapped at its own block width', async () => {
+    const terminal = new Terminal({ cols: COLS, rows: ROWS, allowProposedApi: true })
+    // Grok pads each markdown row to its block width, so no row soft-wraps.
+    await writeTerminal(terminal, GROK_OUTPUT.map((row) => row.padEnd(WRAP_WIDTH)).join('\r\n'))
+
+    const buffer = terminal.buffer.active
+    const urlRow = GROK_OUTPUT[2]
+    const schemeColumn = urlRow.indexOf('https://') + 1
+    expect(buffer.getLine(2)?.isWrapped).toBe(false)
+    expect(buffer.getLine(3)?.isWrapped).toBe(false)
+
+    // Hovering the URL row resolves the joined target...
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: schemeColumn + 10, y: 3 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith(EXPECTED_URL)
+
+    // ...and so does the wrapped continuation row.
+    openUrlMock.mockReset()
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: 6, y: 4 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith(EXPECTED_URL)
+
+    // The sibling URL one row up keeps its own target.
+    openUrlMock.mockReset()
+    expect(
+      openHttpLinkAtBufferPosition(buffer, { x: schemeColumn + 10, y: 2 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith(
+      'https://github.com/stablyai/orca/pull/10257#issuecomment-5068240478'
+    )
+
+    terminal.dispose()
+  })
+
+  it('leaves genuinely terminated URLs alone in the same block', async () => {
+    const terminal = new Terminal({ cols: COLS, rows: ROWS, allowProposedApi: true })
+    await writeTerminal(
+      terminal,
+      ['Docs at https://example.com/guide for details.', 'Next paragraph continues here.']
+        .map((row) => row.padEnd(WRAP_WIDTH))
+        .join('\r\n')
+    )
+
+    expect(
+      openHttpLinkAtBufferPosition(terminal.buffer.active, { x: 12, y: 1 }, COLS, {
+        worktreeId: 'wt-1',
+        forceSystemBrowser: true
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/guide')
+
+    terminal.dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-http-url-token-scanning.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-http-url-token-scanning.ts
@@ -1,0 +1,156 @@
+import { TERMINAL_HTTP_URL_MAX_LENGTH } from './terminal-http-link-limits'
+
+export type ParsedTerminalHttpLink = {
+  url: string
+  startIndex: number
+  endIndex: number
+}
+
+const HTTP_SCHEME_PREFIXES = ['https://', 'http://'] as const
+
+export function extractTerminalHttpLinks(lineText: string): ParsedTerminalHttpLink[] {
+  const links: ParsedTerminalHttpLink[] = []
+  for (const candidate of iterateTerminalHttpUrlCandidates(lineText)) {
+    let parsed: URL
+    try {
+      parsed = new URL(candidate.url)
+    } catch {
+      continue
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      continue
+    }
+    links.push({
+      url: parsed.toString(),
+      startIndex: candidate.startIndex,
+      endIndex: candidate.endIndex
+    })
+  }
+  return links
+}
+
+function* iterateTerminalHttpUrlCandidates(
+  lineText: string
+): Generator<{ url: string; startIndex: number; endIndex: number }> {
+  let searchStart = 0
+  while (searchStart < lineText.length) {
+    const startIndex = findNextHttpSchemeIndex(lineText, searchStart)
+    if (startIndex === -1) {
+      return
+    }
+
+    if (!hasHttpUrlWordBoundary(lineText, startIndex)) {
+      searchStart = startIndex + 1
+      continue
+    }
+
+    const rawEndIndex = findHttpUrlCandidateEnd(lineText, startIndex)
+    const endIndex = trimHttpUrlTrailingPunctuation(lineText, startIndex, rawEndIndex)
+    searchStart = Math.max(rawEndIndex, startIndex + 1)
+    if (endIndex <= startIndex || rawEndIndex - startIndex > TERMINAL_HTTP_URL_MAX_LENGTH) {
+      continue
+    }
+
+    yield {
+      url: lineText.slice(startIndex, endIndex),
+      startIndex,
+      endIndex
+    }
+  }
+}
+
+function findNextHttpSchemeIndex(lineText: string, searchStart: number): number {
+  let nextIndex = -1
+  for (const prefix of HTTP_SCHEME_PREFIXES) {
+    const candidateIndex = lineText.indexOf(prefix, searchStart)
+    if (candidateIndex !== -1 && (nextIndex === -1 || candidateIndex < nextIndex)) {
+      nextIndex = candidateIndex
+    }
+  }
+  return nextIndex
+}
+
+function hasHttpUrlWordBoundary(lineText: string, startIndex: number): boolean {
+  return startIndex === 0 || !isAsciiWordCode(lineText.charCodeAt(startIndex - 1))
+}
+
+function findHttpUrlCandidateEnd(lineText: string, startIndex: number): number {
+  const scanEnd = Math.min(lineText.length, startIndex + TERMINAL_HTTP_URL_MAX_LENGTH + 1)
+  for (let index = startIndex; index < scanEnd; index += 1) {
+    if (isHttpUrlBodyTerminator(lineText.charCodeAt(index))) {
+      return index
+    }
+  }
+  return scanEnd
+}
+
+function trimHttpUrlTrailingPunctuation(
+  lineText: string,
+  startIndex: number,
+  rawEndIndex: number
+): number {
+  let endIndex = rawEndIndex
+  while (endIndex > startIndex && isHttpUrlTrailingPunctuation(lineText.charCodeAt(endIndex - 1))) {
+    endIndex -= 1
+  }
+  return endIndex
+}
+
+function isHttpUrlBodyTerminator(code: number): boolean {
+  return (
+    isAsciiWhitespace(code) ||
+    code === 0x22 ||
+    code === 0x27 ||
+    code === 0x21 ||
+    code === 0x2a ||
+    code === 0x28 ||
+    code === 0x29 ||
+    code === 0x7b ||
+    code === 0x7d ||
+    code === 0x7c ||
+    code === 0x5c ||
+    code === 0x5e ||
+    code === 0x3c ||
+    code === 0x3e ||
+    code === 0x60
+  )
+}
+
+function isHttpUrlTrailingPunctuation(code: number): boolean {
+  return (
+    isAsciiWhitespace(code) ||
+    code === 0x22 ||
+    code === 0x27 ||
+    code === 0x3a ||
+    code === 0x2c ||
+    code === 0x2e ||
+    code === 0x21 ||
+    code === 0x3f ||
+    code === 0x7b ||
+    code === 0x7d ||
+    code === 0x7c ||
+    code === 0x5c ||
+    code === 0x5e ||
+    code === 0x7e ||
+    code === 0x5b ||
+    code === 0x5d ||
+    code === 0x28 ||
+    code === 0x29 ||
+    code === 0x3c ||
+    code === 0x3e ||
+    code === 0x60
+  )
+}
+
+function isAsciiWhitespace(code: number): boolean {
+  return code === 9 || code === 10 || code === 11 || code === 12 || code === 13 || code === 32
+}
+
+function isAsciiWordCode(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  )
+}

--- a/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-url-link-hit-testing.ts
@@ -1,13 +1,18 @@
 import type { IBufferLine, IBufferRange, IDisposable, Terminal } from '@xterm/xterm'
 import { openHttpLink } from '@/lib/http-link-routing'
+import { buildBlockWrappedHttpLogicalLineCandidates } from './block-wrapped-terminal-http-links'
 import { buildEdgeWrappedHttpLogicalLineCandidates } from './edge-wrapped-terminal-http-links'
 import { buildHardWrappedHttpLogicalLineCandidates } from './hard-wrapped-terminal-http-links'
 import { dedupeLogicalLines } from './terminal-file-link-hit-testing'
 import { isTerminalHttpLinkActivation } from './terminal-http-link-activation'
 import { installTerminalLinkPtyMouseSuppression } from './terminal-link-pty-mouse-suppression'
 import { getTerminalBufferPositionForMouseEvent } from './terminal-mouse-buffer-position'
-import { TERMINAL_HTTP_URL_MAX_LENGTH } from './terminal-http-link-limits'
+import { extractTerminalHttpLinks } from './terminal-http-url-token-scanning'
 import { buildWrappedLogicalLine, rangeForParsedFileLink } from './wrapped-terminal-link-ranges'
+
+export { extractTerminalHttpLinks } from './terminal-http-url-token-scanning'
+export type { ParsedTerminalHttpLink } from './terminal-http-url-token-scanning'
+export { TERMINAL_HTTP_URL_MAX_LENGTH } from './terminal-http-link-limits'
 
 type UrlLinkHitTestDeps = {
   worktreeId: string
@@ -24,36 +29,6 @@ export type TerminalLinkRoutingPreferenceRequester = (
   url: string
 ) => boolean | Promise<boolean> | null | undefined
 
-type ParsedTerminalHttpLink = {
-  url: string
-  startIndex: number
-  endIndex: number
-}
-
-const HTTP_SCHEME_PREFIXES = ['https://', 'http://'] as const
-export { TERMINAL_HTTP_URL_MAX_LENGTH } from './terminal-http-link-limits'
-
-export function extractTerminalHttpLinks(lineText: string): ParsedTerminalHttpLink[] {
-  const links: ParsedTerminalHttpLink[] = []
-  for (const candidate of iterateTerminalHttpUrlCandidates(lineText)) {
-    let parsed: URL
-    try {
-      parsed = new URL(candidate.url)
-    } catch {
-      continue
-    }
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      continue
-    }
-    links.push({
-      url: parsed.toString(),
-      startIndex: candidate.startIndex,
-      endIndex: candidate.endIndex
-    })
-  }
-  return links
-}
-
 function isDesktopHttpLinkFallbackActivation(event: MouseEvent): boolean {
   if (event.defaultPrevented || event.button !== 0) {
     return false
@@ -62,132 +37,6 @@ function isDesktopHttpLinkFallbackActivation(event: MouseEvent): boolean {
   // plain clicks remain available for cursor placement and selection. Mobile
   // tap routing is handled separately under mobile/src/terminal.
   return isTerminalHttpLinkActivation(event)
-}
-
-function* iterateTerminalHttpUrlCandidates(
-  lineText: string
-): Generator<{ url: string; startIndex: number; endIndex: number }> {
-  let searchStart = 0
-  while (searchStart < lineText.length) {
-    const startIndex = findNextHttpSchemeIndex(lineText, searchStart)
-    if (startIndex === -1) {
-      return
-    }
-
-    if (!hasHttpUrlWordBoundary(lineText, startIndex)) {
-      searchStart = startIndex + 1
-      continue
-    }
-
-    const rawEndIndex = findHttpUrlCandidateEnd(lineText, startIndex)
-    const endIndex = trimHttpUrlTrailingPunctuation(lineText, startIndex, rawEndIndex)
-    searchStart = Math.max(rawEndIndex, startIndex + 1)
-    if (endIndex <= startIndex || rawEndIndex - startIndex > TERMINAL_HTTP_URL_MAX_LENGTH) {
-      continue
-    }
-
-    yield {
-      url: lineText.slice(startIndex, endIndex),
-      startIndex,
-      endIndex
-    }
-  }
-}
-
-function findNextHttpSchemeIndex(lineText: string, searchStart: number): number {
-  let nextIndex = -1
-  for (const prefix of HTTP_SCHEME_PREFIXES) {
-    const candidateIndex = lineText.indexOf(prefix, searchStart)
-    if (candidateIndex !== -1 && (nextIndex === -1 || candidateIndex < nextIndex)) {
-      nextIndex = candidateIndex
-    }
-  }
-  return nextIndex
-}
-
-function hasHttpUrlWordBoundary(lineText: string, startIndex: number): boolean {
-  return startIndex === 0 || !isAsciiWordCode(lineText.charCodeAt(startIndex - 1))
-}
-
-function findHttpUrlCandidateEnd(lineText: string, startIndex: number): number {
-  const scanEnd = Math.min(lineText.length, startIndex + TERMINAL_HTTP_URL_MAX_LENGTH + 1)
-  for (let index = startIndex; index < scanEnd; index += 1) {
-    if (isHttpUrlBodyTerminator(lineText.charCodeAt(index))) {
-      return index
-    }
-  }
-  return scanEnd
-}
-
-function trimHttpUrlTrailingPunctuation(
-  lineText: string,
-  startIndex: number,
-  rawEndIndex: number
-): number {
-  let endIndex = rawEndIndex
-  while (endIndex > startIndex && isHttpUrlTrailingPunctuation(lineText.charCodeAt(endIndex - 1))) {
-    endIndex -= 1
-  }
-  return endIndex
-}
-
-function isHttpUrlBodyTerminator(code: number): boolean {
-  return (
-    isAsciiWhitespace(code) ||
-    code === 0x22 ||
-    code === 0x27 ||
-    code === 0x21 ||
-    code === 0x2a ||
-    code === 0x28 ||
-    code === 0x29 ||
-    code === 0x7b ||
-    code === 0x7d ||
-    code === 0x7c ||
-    code === 0x5c ||
-    code === 0x5e ||
-    code === 0x3c ||
-    code === 0x3e ||
-    code === 0x60
-  )
-}
-
-function isHttpUrlTrailingPunctuation(code: number): boolean {
-  return (
-    isAsciiWhitespace(code) ||
-    code === 0x22 ||
-    code === 0x27 ||
-    code === 0x3a ||
-    code === 0x2c ||
-    code === 0x2e ||
-    code === 0x21 ||
-    code === 0x3f ||
-    code === 0x7b ||
-    code === 0x7d ||
-    code === 0x7c ||
-    code === 0x5c ||
-    code === 0x5e ||
-    code === 0x7e ||
-    code === 0x5b ||
-    code === 0x5d ||
-    code === 0x28 ||
-    code === 0x29 ||
-    code === 0x3c ||
-    code === 0x3e ||
-    code === 0x60
-  )
-}
-
-function isAsciiWhitespace(code: number): boolean {
-  return code === 9 || code === 10 || code === 11 || code === 12 || code === 13 || code === 32
-}
-
-function isAsciiWordCode(code: number): boolean {
-  return (
-    (code >= 48 && code <= 57) ||
-    (code >= 65 && code <= 90) ||
-    code === 95 ||
-    (code >= 97 && code <= 122)
-  )
 }
 
 export function openHttpLinkAtTerminalMouseEvent(
@@ -203,6 +52,22 @@ export function openHttpLinkAtTerminalMouseEvent(
     return false
   }
   return openHttpLinkAtBufferPosition(terminal.buffer.active, position, terminal.cols, deps)
+}
+
+/**
+ * The full URL under the pointer, reconstructed across wrapped rows. Unlike
+ * activation, hover is not modifier-gated — the tooltip must show the same
+ * target a Cmd/Ctrl+click would open.
+ */
+export function findHttpLinkAtTerminalMouseEvent(
+  terminal: Terminal,
+  event: MouseEvent
+): string | null {
+  const position = getTerminalBufferPositionForMouseEvent(terminal, event)
+  if (!position) {
+    return null
+  }
+  return findHttpLinkAtBufferPosition(terminal.buffer.active, position, terminal.cols)
 }
 
 export function installHttpLinkClickFallback(
@@ -270,6 +135,7 @@ function findHttpLinkAtBufferPosition(
       : []),
     ...buildHardWrappedHttpLogicalLineCandidates(buffer, position.y),
     ...buildEdgeWrappedHttpLogicalLineCandidates(buffer, position.y),
+    ...buildBlockWrappedHttpLogicalLineCandidates(buffer, position.y),
     ...(nativeWrappedLogicalLine && nativeWrappedLogicalLine.rows.length === 1
       ? [nativeWrappedLogicalLine]
       : [])

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -35,6 +35,7 @@ import { createTerminalHandleLinkProvider } from './terminal-handle-links'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { handleTerminalWebLinkClick } from './terminal-web-link-click'
+import { createBlockWrappedHttpLinkProvider } from './block-wrapped-http-link-provider'
 import {
   findHttpLinkAtTerminalMouseEvent,
   installHttpLinkClickFallback,
@@ -569,6 +570,7 @@ export function useTerminalPaneLifecycle({
   const terminalHandleLinkDisposablesRef = useRef(new Map<number, IDisposable>())
   const fileLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
   const httpLinkClickFallbackDisposablesRef = useRef(new Map<number, IDisposable>())
+  const blockWrappedHttpLinkDisposablesRef = useRef(new Map<number, IDisposable>())
   // Why: read settingsRef at fire time so toggling "copy on select" applies without recreating panes.
   const selectionDisposablesRef = useRef(new Map<number, IDisposable>())
   const selectionCaptureTimersRef = useRef(new Map<number, number>())
@@ -636,6 +638,7 @@ export function useTerminalPaneLifecycle({
     const terminalHandleLinkDisposables = terminalHandleLinkDisposablesRef.current
     const fileLinkClickFallbackDisposables = fileLinkClickFallbackDisposablesRef.current
     const httpLinkClickFallbackDisposables = httpLinkClickFallbackDisposablesRef.current
+    const blockWrappedHttpLinkDisposables = blockWrappedHttpLinkDisposablesRef.current
     const selectionDisposables = selectionDisposablesRef.current
     const selectionCaptureTimers = selectionCaptureTimersRef.current
     const mouseHideDisposables = mouseHideDisposablesRef.current
@@ -994,6 +997,21 @@ export function useTerminalPaneLifecycle({
           createFilePathLinkProvider(pane.id, linkDeps, pane.linkTooltip, fileOpenLinkHint)
         )
         linkProviderDisposablesRef.current.set(pane.id, linkProviderDisposable)
+        // Why: WebLinksAddon reports nothing on rows a TUI wrapped itself, so
+        // the tail of such a URL had no hover tooltip even though it opened.
+        const blockWrappedHttpLinkDisposable = pane.terminal.registerLinkProvider(
+          createBlockWrappedHttpLinkProvider({
+            getTerminal: () =>
+              managerRef.current?.getPanes().find((candidate) => candidate.id === pane.id)
+                ?.terminal ?? null,
+            worktreeId,
+            linkTooltip: pane.linkTooltip,
+            openLinkHint: urlOpenLinkHint,
+            formatTooltip: (url, hint) => formatTerminalUrlTooltip(url, hint),
+            requestOpenLinksInAppPreference
+          })
+        )
+        blockWrappedHttpLinkDisposables.set(pane.id, blockWrappedHttpLinkDisposable)
         const terminalHandleLinkDisposable = pane.terminal.registerLinkProvider(
           createTerminalHandleLinkProvider({
             getTerminal: () =>
@@ -1153,6 +1171,11 @@ export function useTerminalPaneLifecycle({
         if (fileLinkClickFallbackDisposable) {
           fileLinkClickFallbackDisposable.dispose()
           fileLinkClickFallbackDisposablesRef.current.delete(paneId)
+        }
+        const blockWrappedHttpLinkDisposable = blockWrappedHttpLinkDisposables.get(paneId)
+        if (blockWrappedHttpLinkDisposable) {
+          blockWrappedHttpLinkDisposable.dispose()
+          blockWrappedHttpLinkDisposables.delete(paneId)
         }
         const httpLinkClickFallbackDisposable = httpLinkClickFallbackDisposables.get(paneId)
         if (httpLinkClickFallbackDisposable) {
@@ -1613,6 +1636,10 @@ export function useTerminalPaneLifecycle({
         disposable.dispose()
       }
       fileLinkClickFallbackDisposables.clear()
+      for (const disposable of blockWrappedHttpLinkDisposables.values()) {
+        disposable.dispose()
+      }
+      blockWrappedHttpLinkDisposables.clear()
       for (const disposable of httpLinkClickFallbackDisposables.values()) {
         disposable.dispose()
       }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -36,6 +36,7 @@ import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { handleOscLink } from './terminal-osc-link-routing'
 import { handleTerminalWebLinkClick } from './terminal-web-link-click'
 import {
+  findHttpLinkAtTerminalMouseEvent,
   installHttpLinkClickFallback,
   type TerminalLinkRoutingPreferenceRequester
 } from './terminal-url-link-hit-testing'
@@ -1400,6 +1401,10 @@ export function useTerminalPaneLifecycle({
         })
       },
       formatLinkTooltip: (url, openLinkHint) => formatTerminalUrlTooltip(url, openLinkHint),
+      resolveHoveredLinkUrl: (paneId, event, uri) => {
+        const pane = managerRef.current?.getPanes().find((candidate) => candidate.id === paneId)
+        return pane ? findHttpLinkAtTerminalMouseEvent(pane.terminal, event) : uri
+      },
       // Why: hidden panes stay mounted so PTYs survive navigation, but their WebGL contexts drain Chromium's budget and can blank visible panes.
       initialRenderingSuspended: !isVisibleRef.current,
       // Why: remote-runtime panes honor the GPU setting too; late snapshots are handled by post-replay rebuildPaneWebgl in pty-connection.

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts
@@ -131,4 +131,54 @@ describe('createPaneDOM link tooltips', () => {
 
     expect(pane.linkTooltip.textContent).toBe(labeledText)
   })
+
+  it('previews the whole wrapped URL rather than the hovered row fragment', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
+    const wrappedUrl = 'https://github.com/stablyai/orca/pull/10349#issuecomment-5068238223'
+    const resolveHoveredLinkUrl = vi.fn(() => wrappedUrl)
+
+    setPlatform('Macintosh')
+    const pane = createPaneDOM(
+      7,
+      leafId,
+      { resolveHoveredLinkUrl },
+      { active: null } as never,
+      {} as never,
+      vi.fn(),
+      vi.fn()
+    )
+
+    const event = {} as MouseEvent
+    webLinksAddonMock.options?.hover?.(event, 'https://github.com/stablyai/orca/')
+
+    expect(resolveHoveredLinkUrl).toHaveBeenCalledWith(
+      7,
+      event,
+      'https://github.com/stablyai/orca/'
+    )
+    expect(pane.linkTooltip.textContent).toBe(
+      `${wrappedUrl} (⌘+click to open or ⇧⌘+click for system browser)`
+    )
+  })
+
+  it('falls back to the addon URL when no wrapped link resolves', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
+
+    setPlatform('Macintosh')
+    const pane = createPaneDOM(
+      8,
+      leafId,
+      { resolveHoveredLinkUrl: () => null },
+      { active: null } as never,
+      {} as never,
+      vi.fn(),
+      vi.fn()
+    )
+
+    webLinksAddonMock.options?.hover?.({} as MouseEvent, 'http://localhost:5180/')
+
+    expect(pane.linkTooltip.textContent).toBe(
+      'http://localhost:5180/ (⌘+click to open or ⇧⌘+click for system browser)'
+    )
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -79,13 +79,16 @@ export function createPaneDOM(
   const webLinksAddon = new WebLinksAddon(
     options.onLinkClick ? (event, uri) => options.onLinkClick!(event, uri) : undefined,
     {
-      hover: (_event, uri) => {
+      hover: (event, uri) => {
         if (uri) {
           linkTooltipHoverToken += 1
           const hoverToken = linkTooltipHoverToken
-          linkTooltip.textContent = defaultLinkTooltipText(uri, openLinkHint)
+          // Why: WebLinksAddon reports only the hovered row's fragment, so a URL
+          // wrapped across rows would preview a different target than it opens.
+          const hoveredUrl = options.resolveHoveredLinkUrl?.(id, event, uri) ?? uri
+          linkTooltip.textContent = defaultLinkTooltipText(hoveredUrl, openLinkHint)
           linkTooltip.style.display = ''
-          const formatted = options.formatLinkTooltip?.(uri, openLinkHint)
+          const formatted = options.formatLinkTooltip?.(hoveredUrl, openLinkHint)
           if (formatted && typeof formatted === 'object' && 'then' in formatted) {
             void formatted.then(
               (nextText) => {

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -64,6 +64,8 @@ export type PaneManagerOptions = {
     url: string,
     openLinkHint: string
   ) => string | null | undefined | Promise<string | null | undefined>
+  /** Resolves the full URL under the pointer for links wrapped across rows. */
+  resolveHoveredLinkUrl?: (paneId: number, event: MouseEvent, uri: string) => string | null
   initialRenderingSuspended?: boolean
   terminalGpuAcceleration?: GlobalSettings['terminalGpuAcceleration']
   // Why: diagnostic label for log correlation. safeFit and other internal


### PR DESCRIPTION
Fixes the reported bug: hovering a grok link that spans two lines highlights the whole URL, but clicking it navigated to only the first row's fragment.

## ELI5

Terminals have no idea what a "link" is. They're a grid of characters — the app just paints text into cells. So when you Cmd+click, Orca has to *guess* where a URL starts and ends by reading characters back off the grid.

That's easy on one line. It gets hard when a URL is too long and gets split across two lines, because now Orca has to decide: **is the text on the next line the rest of the URL, or is it a completely new line of output that just happens to sit underneath?**

Normally there's a reliable clue. When the terminal itself runs out of room, it sets a "this line is continued" flag, and Orca trusts that flag.

Grok doesn't leave that clue. It formats its own text to a narrower width (~78 columns) than the terminal is wide (~110 columns), then draws each line at an exact position. So the flag is never set, and the line visibly stops well before the right edge — which normally means "the URL ended here." Orca believed it, and opened the truncated URL.

The confusing part for you: the blue highlight came from **grok**, which knows the full URL because it drew it. Orca's click used its own guess. Two different sources, two different answers.

The fix teaches Orca to recognize this kind of wrap by looking at the shape of the surrounding text:

> "Other lines in this paragraph run further right than this one, so there *was* room to spare. This line stops at a `/`. And the first word on the next line is too long to have fit in that leftover space — so something must have pushed it down. That's a wrap, not a new line."

If any of that doesn't hold, Orca leaves the URL alone. Being wrong in the other direction is the worse bug (see below).

## The bug

| | |
|---|---|
| Hover (grok's own highlight) | `https://github.com/stablyai/orca/pull/10349#issuecomment-5068238223` |
| Click (Orca's reconstruction) | `https://github.com/stablyai/orca/` |

Orca had three URL-reconstruction strategies and the grok case fell through all of them:

| Strategy | Requires | Why it missed |
|---|---|---|
| soft-wrap | xterm's `isWrapped` flag | grok cursor-positions output; flag never set |
| edge-wrap | row reaches the **terminal's** last column | grok's rows stop at ~78 of ~110 |
| hard-wrap | a vertical frame character (`│`) | grok's markdown has no frame |

## The tension with PR #9100

**PR #9100** (commit a7c40cd89b) fixed the *opposite* bug, #8832 — the next line getting **glued onto** a modifier-clicked URL (`.../orca/` + `Description: 123` → `.../orca/Description`).

That fix joins **fewer** rows; this one joins **more**. They pull in opposite directions, and #9100's guard keyed on the *terminal edge* — which stops discriminating once block-width wrapping is reconstructed.

An early version of this change did reopen #8832. It's now re-tested at a width where the block wrap column is detectable (the gap #9100's tests didn't cover, since they used a width where no block width is inferable).

## How a row qualifies as a continuation

All must hold, or the URL is left alone:

1. the URL token runs to the end of its row's content;
2. sibling rows at the same left margin prove the block extends further right;
3. the unused gap is ≤25% of the block width — a URL ending far short of the wrap column ended because the *URL* ended;
4. the row ends at a URL break character (`/ ? & = # % + : -`), not mid-token;
5. the next row isn't `Label: value` / `Label:value`, and doesn't open with a path root (`/`, `\`, `~`, `./`, `C:\`);
6. the next row's leading token matches the URL charset and carries URL structure;
7. that token would **not** have fit in the space left on the previous row — if it fit, the author broke the line, not a wrapper.

## Evidence

**Failing-first.** Reproduced from the screenshot's exact text and geometry before any fix; confirmed the 2 failures, then confirmed green. Re-disabled the fix afterward to prove the tests genuinely gate it (5 failures returned).

**Real xterm buffer.** `grok-block-wrapped-url.repro.test.ts` drives `@xterm/headless` — not just mocks — and asserts `isWrapped === false`, confirming the metadata gap is real rather than assumed.

**Adversarial review.** Two independent reviewers (GPT-5.6-Sol, Fable) were tasked with breaking it, with regressing #8832 named as the top prize. Findings fixed, each now a permanent regression test:

| Shape | Was | Guard added |
|---|---|---|
| `Description:123` (unspaced) | glued | label pattern matches unspaced form |
| `/usr/local/bin/orca` | glued | path-root rejection |
| `DescriptionWithoutColon …` | glued | tail must carry URL structure |
| `12:34:56 request complete` | glued | same |
| `origin/main..HEAD` (self-found) | glued | same |
| short URL row + long path | glued | ≤25% unused-gap rule |
| two URLs on one row | wrong URL | scan last scheme, not first |

Also probed and **not** breakable: dates (`2026/07/24`), fractions, markdown headings, git refs, JSON, CJK/wide glyphs, Windows paths, timestamps, hover↔click divergence.

**Four reverts, kept honest.** (a) A gap rule keyed on URL break opportunities looked right but broke the real case — grok wraps whole tokens, not at URL boundaries. (b) Estimating the wrap column by most-common row width (to resist one outlier row inflating it) also broke it — real prose rows rarely share an end column. (c) Relaxing the sibling-width rule to fix limitation 1 below reopened four #8832 guards. All three reverted rather than papered over — each is recorded above so the next person doesn't retry them blind.

**Perf.** Runs on the hover path for every mouse move. Bounded by a deterministic row-read count (not wall-clock, which flaked under parallel load and stole CPU from timing-sensitive suites).

**Suite.** 16,106 renderer tests pass; typecheck, lint, format clean. `terminal-url-link-hit-testing.ts` crossed the 300-line `max-lines` cap, so the URL-token scanner was split into its own module rather than adding a disable (per AGENTS.md).

## Second review round

A follow-up adversarial pass found four more defects. All four are fixed:

| # | Defect | Fix |
|---|---|---|
| 1 | Prose rows opening with a slash-bearing word (`2026/07/24 deploy finished`, `src/main/index.ts was rebuilt`, `and/or other options`) glued onto the URL — #8832 class | a continuation must be the **whole row**, or be followed by the next link in a list. Ordinary prose after the token means the row is its own sentence. |
| 2 | Legal URLs ending in one bare final segment (a commit SHA, a plain last path segment) were truncated | the whole-row rule **subsumes** the old "tail must contain URL punctuation" requirement, so that rule is gone |
| 3 | One unrelated full-terminal-width line inflated the inferred block width, defeating reconstruction for the whole block | infer width from the **nearest** row running past the URL row, not the widest row anywhere in the window |
| 4 | Hovering a continuation row showed **no tooltip**, though a modifier-click there opened the link | register an Orca `ILinkProvider` spanning every constituent row |

Defect 4 is confirmed in `@xterm/addon-web-links` source: `_getWindowedLineStrings` walks rows via xterm's `isWrapped` flag, which a TUI positioning its own output never sets. The addon therefore reports the URL on the row bearing the scheme and `[]` on the continuation — the click fallback still worked, so the tail was clickable but silent on hover.

A third pass re-ran every finding against the fixed code: all six had already been resolved (the report predated the fix commit). It did surface one genuinely new shape — a row holding only a Markdown anchor (`#next-steps`) satisfied every continuation rule, since it fills its row, is URL-charset, and doesn't fit the leftover space. A fragment attaches to a resource, though, so a wrap never leaves `/` ending one row and `#` opening the next; that pairing is now rejected.

Defect 1's fix turned out to resolve defect 2 for free: once a tail must occupy its whole row, prose can no longer masquerade as one, so the punctuation requirement that was truncating valid URLs became unnecessary. **That also retired two limitations this PR previously documented as unavoidable** — the bare-final-segment truncation, and (via defect 3's fix) the width-contamination case.

## Known limitation

One remains. A repo-relative path alone on the line below a near-full URL row (`https://example.com/aaa…/` then `src/components/index.ts`) is **geometrically and textually identical** to the real grok wrap: same trailing `/`, same URL charset with slashes, same too-long-to-fit token, and both occupy their whole row. Both reviewers and I independently concluded no discriminator separates them from row text and geometry alone. Pinned as an explicit test so the trade-off stays visible.

A second case — where the URL row is itself the widest line in its block, so nothing witnesses spare room — is also pinned. Relaxing the sibling-width rule to cover it reopened four #8832 guards, so it stays.

Both degrade to the pre-fix behaviour (truncated URL) rather than gluing text on, which is the worse failure.

## Test plan

- [x] `block-wrapped-terminal-http-links.test.ts` — 36 tests
- [x] `block-wrapped-http-link-provider.test.ts` — hover tooltip on every wrapped row (grok case, #8832 shapes at block width, adversarial regressions)
- [x] `grok-block-wrapped-url.repro.test.ts` — real `@xterm/headless` buffer
- [x] `block-wrapped-http-link-hover-cost.test.ts` — bounded hover work
- [x] `repro-8832-url-next-line.test.ts`, `terminal-url-link-click.test.ts`, `edge-wrapped-terminal-http-links.test.ts` — PR #9100's suites still green
- [x] `pane-dom-creation.test.ts` — hover tooltip matches click target
- [x] Full renderer suite: 16,121 passed
