### PR TITLE
fix(startup): stop a lock-losing launch from clobbering runtime discovery files

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1777,8 +1777,9 @@ function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
 }
 
 app.whenReady().then(async () => {
-  // Why: app.quit() above is async, so a lock-losing launch still reaches ready; returning keeps it from
-  // republishing orca-runtime.json / agent-hooks endpoint files over the live instance's (STA-1513).
+  // Why: Linux defers the app.quit() above until after ready, so a lock-losing launch still runs this
+  // handler and republishes orca-runtime.json / agent-hooks endpoints over the live instance's, leaving
+  // the CLI pointed at a dead pid. macOS quits before ready, so this is a no-op there. (STA-1513)
   if (!hasSingleInstanceLock) {
     return
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1777,6 +1777,11 @@ function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
 }
 
 app.whenReady().then(async () => {
+  // Why: app.quit() above is async, so a lock-losing launch still reaches ready; returning keeps it from
+  // republishing orca-runtime.json / agent-hooks endpoint files over the live instance's (STA-1513).
+  if (!hasSingleInstanceLock) {
+    return
+  }
   logStartupMilestone('app-ready')
   // Why: install certificate decisions before any webview or headless window issues its first TLS request.
   app.on(

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -87,11 +87,15 @@ describe('startup ordering', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const readyStart = source.indexOf('app.whenReady().then(async () => {')
     const guard = source.indexOf('if (!hasSingleInstanceLock) {', readyStart)
+    const guardEnd = source.indexOf('}', guard)
     const rpcStart = source.indexOf('runtimeRpc.start()', readyStart)
     const startupServices = source.indexOf('startTerminalRuntimeStartupServices()', readyStart)
 
     expect(readyStart).toBeGreaterThanOrEqual(0)
     expect(guard).toBeGreaterThan(readyStart)
+    // Why: ordering alone would still pass if the body were emptied to a no-op.
+    expect(guardEnd).toBeGreaterThan(guard)
+    expect(source.slice(guard, guardEnd)).toContain('return')
     expect(rpcStart).toBeGreaterThan(guard)
     expect(startupServices).toBeGreaterThan(guard)
     // Why: the bail must precede every side effect in the handler, not merely the RPC publish.

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -81,6 +81,23 @@ describe('startup ordering', () => {
     expect(supervisorReady).toBeGreaterThan(readyStart)
   })
 
+  it('abandons ready-time startup when the single-instance lock was lost', () => {
+    // Why: app.quit() is async, so a losing launch still reaches ready; without this guard it
+    // republishes orca-runtime.json over the live instance and strands the CLI on a dead pid.
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const readyStart = source.indexOf('app.whenReady().then(async () => {')
+    const guard = source.indexOf('if (!hasSingleInstanceLock) {', readyStart)
+    const rpcStart = source.indexOf('runtimeRpc.start()', readyStart)
+    const startupServices = source.indexOf('startTerminalRuntimeStartupServices()', readyStart)
+
+    expect(readyStart).toBeGreaterThanOrEqual(0)
+    expect(guard).toBeGreaterThan(readyStart)
+    expect(rpcStart).toBeGreaterThan(guard)
+    expect(startupServices).toBeGreaterThan(guard)
+    // Why: the bail must precede every side effect in the handler, not merely the RPC publish.
+    expect(source.slice(readyStart, guard)).not.toContain('logStartupMilestone')
+  })
+
   it('does not run the rate-limit quota fetch before the first window can show results', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const attachIndex = source.indexOf('rateLimits.attach(window)')

--- a/tests/e2e/headless-serve-desktop-activation.spec.ts
+++ b/tests/e2e/headless-serve-desktop-activation.spec.ts
@@ -29,6 +29,7 @@ import type {
   RuntimeTerminalRead
 } from '../../src/shared/runtime-types'
 import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
+import { getRuntimeMetadataPath, type RuntimeMetadata } from '../../src/shared/runtime-bootstrap'
 
 const electronPackageDir = path.join(process.cwd(), 'node_modules', 'electron')
 const electronPath = path.join(
@@ -65,6 +66,18 @@ function readDaemonPid(userDataDir: string): number {
     throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
   }
   return parsed.pid
+}
+
+// Why: status.get answers from the owner's live server, so only the file on disk can show whether a
+// lock-losing launch republished its own pid over the owner's. Guards Linux CI, where the quit is
+// deferred past ready and the clobber is reachable; macOS quits earlier, so it is a no-op. (STA-1513)
+function readRuntimeMetadataFromDisk(userDataDir: string): RuntimeMetadata {
+  const metadataPath = getRuntimeMetadataPath(userDataDir)
+  const parsed = JSON.parse(readFileSync(metadataPath, 'utf8')) as Partial<RuntimeMetadata>
+  if (typeof parsed.pid !== 'number' || typeof parsed.runtimeId !== 'string') {
+    throw new Error(`Runtime metadata lacked a pid/runtimeId: ${metadataPath}`)
+  }
+  return parsed as RuntimeMetadata
 }
 
 async function waitForProcessExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
@@ -127,6 +140,7 @@ test('promotes the headless owner without replacing its daemon terminal', async 
 
     const beforeStatus = await client.call<RuntimeStatus>('status.get')
     const daemonPidBefore = readDaemonPid(userDataDir)
+    const runtimeMetadataBefore = readRuntimeMetadataFromDisk(userDataDir)
     await client.call('repo.add', { path: repoPath, kind: 'git' })
     const created = await client.call<{ terminal: RuntimeTerminalCreate }>('terminal.create', {
       worktree: `path:${repoPath}`,
@@ -194,6 +208,11 @@ test('promotes the headless owner without replacing its daemon terminal', async 
     expect(promotedPtyId).toBe(terminal.ptyId)
     expect(readDaemonPid(userDataDir)).toBe(daemonPidBefore)
     expect(await waitForProcessExit(activatingProcess, 10_000)).toBe(true)
+    // Why: the loser publishes during its own startup, so only a post-exit read proves the
+    // owner's discovery record survived the whole second launch.
+    const runtimeMetadataAfter = readRuntimeMetadataFromDisk(userDataDir)
+    expect(runtimeMetadataAfter.pid).toBe(runtimeMetadataBefore.pid)
+    expect(runtimeMetadataAfter.runtimeId).toBe(runtimeMetadataBefore.runtimeId)
     await waitForTerminalOutput(page, beforeMarker, 30_000)
 
     const afterMarker = `SERVE_PROMOTION_AFTER_${Date.now()}`


### PR DESCRIPTION
Addresses #7848 (STA-1513) — the **Linux** manifestation. Deliberately not `Fixes`: the issue was filed against macOS, and macOS is provably immune to this mechanism (evidence below), so the macOS half needs separate investigation and the issue should stay open.

## Problem

A second launch that loses the single-instance lock logs the failure and calls `app.quit()`. **On Linux that quit is deferred until after the ready event**, so the process still runs `app.whenReady()`, completes the full startup path, and publishes both canonical discovery files with its own pid and socket:

- `orca-runtime.json` via `runtimeRpc.start()`
- the agent-hooks endpoint file via `startTerminalRuntimeStartupServices()`

It then exits, leaving the records pointing at a dead pid while the real app is still running. `orca status` reports `stale_bootstrap` / `app.running: false` and terminal commands fail with `runtime_unavailable`, all while `ps -p <pid>` shows Orca alive. `orca open` relaunches, briefly repairs, and the next transient clobbers it again — the ready → `stale_bootstrap` flap in the report.

macOS terminates the process before ready, so the clobber is unreachable there — confirmed both for the raw binary and for a real `.app` launched through LaunchServices with a forced new instance (`open -n`). That platform split is why this only ever surfaced from Linux, and why the macOS report in #7848 must have a different cause.

## Reproduction

A minimal two-process Electron probe (single-instance lock + an unconditional `whenReady` that writes a record) reproduces it exactly, and an A/B against the same build confirms the fix:

```
GUARD=0 (no fix)
  [LOSER] requestSingleInstanceLock -> false
  [LOSER] lock LOST; calling app.quit()
  [LOSER] whenReady FIRED (hasLock=false)      <-- runs anyway on Linux
  [LOSER] PUBLISHED metadata as LOSER pid=119
  final record: LOSER pid=119                  *** CLOBBERED *** (owner alive at pid 25)

GUARD=1 (this fix)
  [LOSER] lock LOST; calling app.quit()
  [LOSER] GUARD: bailing out of ready handler (no lock)
  final record: OWNER pid=183                  owner INTACT
```

The same probe on macOS never reaches `whenReady` for the loser, confirming the platform split.

This matches the artifact in the report — `orca-runtime.json` naming pid 1017084 (nonexistent) with a socket absent from disk, while the live Orca ran as pid 168807 bound elsewhere — and confirms the reporter's inferred mechanism was correct.

## Root cause

The module-level guard already skips userData side effects when the lock is lost, and `single-instance-lock.ts`'s docstring explicitly describes preventing this exact clobber. But that guard ends at line 671 while the ready handler runs unconditionally — `hasSingleInstanceLock` was never consulted again.

## Fix

Bail out of the ready handler when the lock was lost, before any side effect.

`hasSingleInstanceLock` is false only when the lock was genuinely lost and `app.quit()` has already been called, so no legitimate startup is skipped — the dev skip and the macOS bypass both resolve to `true`.

I considered a write-side ownership guard mirroring `clearRuntimeMetadataIfOwned` and rejected it: a legitimate restart *must* overwrite, so the metadata layer cannot distinguish a real new instance from a transient loser. The single-instance lock is the only thing that knows.

## Test plan

- **Unit**: regression test in the existing `desktop-startup-ordering.test.ts` source-invariant pattern, asserting the bail precedes every side effect *and* that its body actually returns. Verified it fails without the guard.
- **E2E**: `headless-serve-desktop-activation.spec.ts` now asserts the on-disk runtime record still names the owner after the lock-losing launch exits. It previously asserted `runtimeId` via `status.get`, which answers from the owner's live server and therefore could not observe a clobbered file — it would have stayed green through this bug. That suite runs on `ubuntu-latest`, where the clobber is reachable.
- `vitest src/main/startup/ src/main/runtime/` → 2790 passed, 0 failed. typecheck + oxlint clean.

## Not addressed

An already-clobbered record still needs an Orca restart to be rewritten. With the clobber prevented, a stale record now only follows a genuine crash, where `stale_bootstrap` is the correct report. Durable self-repair would be defense-in-depth against mechanisms we have not seen and belongs in its own change.

