### PR TITLE
fix(cli): explain SIGABRT serve exits instead of naming the signal

### DIFF
--- a/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
@@ -1,0 +1,99 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { serveSignalExitError } from './serve-signal-exit-diagnostic'
+import { superviseForegroundServe } from './serve-update-supervisor'
+import { RuntimeClientError } from './types'
+
+class FakeChildProcess extends EventEmitter {
+  kill = vi.fn()
+  pid = 5150
+}
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+}
+
+function superviseUntilExit(code: number | null, signal: NodeJS.Signals | null): Promise<number> {
+  const child = new FakeChildProcess()
+  const supervised = superviseForegroundServe({
+    executable: '/Applications/Orca.app/Contents/MacOS/Orca',
+    childArgs: ['--serve'],
+    spawnOptions: {},
+    spawnChild: vi.fn() as never,
+    handoffPath: null,
+    child: child as never,
+    expectedHandoff: null
+  })
+  child.emit('exit', code, signal)
+  return supervised
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', originalPlatform)
+})
+
+describe('serveSignalExitError', () => {
+  it('explains the macOS window-server abort on darwin SIGABRT', () => {
+    const error = serveSignalExitError('SIGABRT', 'darwin')
+
+    expect(error).toBeInstanceOf(RuntimeClientError)
+    expect(error.code).toBe('runtime_serve_failed')
+    expect(error.message).toContain('SIGABRT during macOS application startup')
+    expect(error.message).toContain('macOS window server')
+    expect(error.data).toMatchObject({
+      nextSteps: [
+        expect.stringContaining('normal terminal session'),
+        expect.stringContaining('~/Library/Logs/DiagnosticReports/Orca-*.ips')
+      ]
+    })
+  })
+
+  it('does not claim the macOS cause off darwin', () => {
+    for (const platform of ['linux', 'win32'] as const) {
+      const error = serveSignalExitError('SIGABRT', platform)
+
+      expect(error.message).toBe('Orca serve exited via SIGABRT.')
+      expect(error.data).toBeUndefined()
+    }
+  })
+
+  it('does not claim the macOS cause for other darwin signals', () => {
+    const error = serveSignalExitError('SIGKILL', 'darwin')
+
+    expect(error.message).toBe('Orca serve exited via SIGKILL.')
+    expect(error.data).toBeUndefined()
+  })
+
+  it('stays clear when neither a code nor a signal is reported', () => {
+    expect(serveSignalExitError(null, 'darwin').message).toBe(
+      'Orca serve exited without reporting an exit code or signal.'
+    )
+  })
+})
+
+describe('superviseForegroundServe signal exits', () => {
+  it('throws the macOS diagnostic when the child aborts on darwin', async () => {
+    setPlatform('darwin')
+
+    await expect(superviseUntilExit(null, 'SIGABRT')).rejects.toThrow(
+      /SIGABRT during macOS application startup/
+    )
+  })
+
+  it('reports the plain signal on linux', async () => {
+    setPlatform('linux')
+
+    await expect(superviseUntilExit(null, 'SIGABRT')).rejects.toThrow(
+      'Orca serve exited via SIGABRT.'
+    )
+  })
+
+  it('returns numeric exit codes unchanged', async () => {
+    setPlatform('darwin')
+
+    await expect(superviseUntilExit(0, null)).resolves.toBe(0)
+    await expect(superviseUntilExit(7, null)).resolves.toBe(7)
+  })
+})

--- a/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
@@ -40,7 +40,7 @@ describe('serveSignalExitError', () => {
 
     expect(error).toBeInstanceOf(RuntimeClientError)
     expect(error.code).toBe('runtime_serve_failed')
-    expect(error.message).toContain('SIGABRT during macOS application startup')
+    expect(error.message).toContain('aborted with SIGABRT on macOS')
     expect(error.message).toContain('macOS window server')
     expect(error.data).toMatchObject({
       nextSteps: [
@@ -78,7 +78,7 @@ describe('superviseForegroundServe signal exits', () => {
     setPlatform('darwin')
 
     await expect(superviseUntilExit(null, 'SIGABRT')).rejects.toThrow(
-      /SIGABRT during macOS application startup/
+      /aborted with SIGABRT on macOS/
     )
   })
 

--- a/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.test.ts
@@ -44,7 +44,7 @@ describe('serveSignalExitError', () => {
     expect(error.message).toContain('macOS window server')
     expect(error.data).toMatchObject({
       nextSteps: [
-        expect.stringContaining('normal terminal session'),
+        expect.stringContaining('macOS desktop login'),
         expect.stringContaining('~/Library/Logs/DiagnosticReports/Orca-*.ips')
       ]
     })

--- a/src/cli/runtime/serve-signal-exit-diagnostic.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.ts
@@ -23,7 +23,7 @@ export function serveSignalExitError(
     'Orca serve aborted with SIGABRT on macOS. This most often happens at application startup, when the process cannot register with the macOS window server, which is common in restricted or sandboxed environments, SSH sessions without a GUI login, and CI.',
     {
       nextSteps: [
-        'Run `orca serve` from a normal terminal session on the Mac desktop.',
+        'Re-run `orca serve` outside a sandboxed or restricted environment, with a macOS desktop login active.',
         `Look for a crash report at ${MAC_CRASH_REPORT_GLOB}.`
       ]
     }

--- a/src/cli/runtime/serve-signal-exit-diagnostic.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.ts
@@ -15,11 +15,12 @@ export function serveSignalExitError(
   if (platform !== 'darwin' || signal !== 'SIGABRT') {
     return new RuntimeClientError('runtime_serve_failed', `Orca serve exited via ${signal}.`)
   }
-  // Why: this abort happens inside +[NSApplication sharedApplication], before any of our JS runs,
-  // so the parent CLI is the only place the failure can be explained at all.
+  // Why: the startup abort happens inside +[NSApplication sharedApplication], before any of our JS
+  // runs, so the parent CLI is the only place it can be explained. We only see the signal, never the
+  // phase, so the cause is offered as the likely one rather than asserted.
   return new RuntimeClientError(
     'runtime_serve_failed',
-    'Orca serve exited via SIGABRT during macOS application startup. This usually means the process could not register with the macOS window server, which is common in restricted or sandboxed environments, SSH sessions without a GUI login, and CI.',
+    'Orca serve aborted with SIGABRT on macOS. This most often happens at application startup, when the process cannot register with the macOS window server, which is common in restricted or sandboxed environments, SSH sessions without a GUI login, and CI.',
     {
       nextSteps: [
         'Run `orca serve` from a normal terminal session on the Mac desktop.',

--- a/src/cli/runtime/serve-signal-exit-diagnostic.ts
+++ b/src/cli/runtime/serve-signal-exit-diagnostic.ts
@@ -1,0 +1,30 @@
+import { RuntimeClientError } from './types'
+
+export const MAC_CRASH_REPORT_GLOB = '~/Library/Logs/DiagnosticReports/Orca-*.ips'
+
+export function serveSignalExitError(
+  signal: NodeJS.Signals | null,
+  platform: NodeJS.Platform = process.platform
+): RuntimeClientError {
+  if (!signal) {
+    return new RuntimeClientError(
+      'runtime_serve_failed',
+      'Orca serve exited without reporting an exit code or signal.'
+    )
+  }
+  if (platform !== 'darwin' || signal !== 'SIGABRT') {
+    return new RuntimeClientError('runtime_serve_failed', `Orca serve exited via ${signal}.`)
+  }
+  // Why: this abort happens inside +[NSApplication sharedApplication], before any of our JS runs,
+  // so the parent CLI is the only place the failure can be explained at all.
+  return new RuntimeClientError(
+    'runtime_serve_failed',
+    'Orca serve exited via SIGABRT during macOS application startup. This usually means the process could not register with the macOS window server, which is common in restricted or sandboxed environments, SSH sessions without a GUI login, and CI.',
+    {
+      nextSteps: [
+        'Run `orca serve` from a normal terminal session on the Mac desktop.',
+        `Look for a crash report at ${MAC_CRASH_REPORT_GLOB}.`
+      ]
+    }
+  )
+}

--- a/src/cli/runtime/serve-update-supervisor.ts
+++ b/src/cli/runtime/serve-update-supervisor.ts
@@ -6,7 +6,7 @@ import {
   parseServeUpdateHandoffState,
   type ServeUpdateHandoffState
 } from '../../shared/serve-update-handoff'
-import { RuntimeClientError } from './types'
+import { serveSignalExitError } from './serve-signal-exit-diagnostic'
 import { waitForMacBundleVersion } from './mac-app-update-bundle'
 
 export const SERVE_REPLACEMENT_READY_TIMEOUT_MS = 60_000
@@ -80,7 +80,7 @@ export async function superviseForegroundServe(
       if (typeof result.code === 'number') {
         return result.code
       }
-      throw new RuntimeClientError('runtime_serve_failed', `Orca serve exited via ${result.signal}`)
+      throw serveSignalExitError(result.signal)
     }
 
     const installed = await waitForMacBundleVersion(args.executable, handoff.targetVersion)


### PR DESCRIPTION
Fixes #10461.

## Problem

When `orca serve` died from a signal, the CLI reported only:

```text
Orca serve exited via SIGABRT
```

No cause, no next step, no pointer to where a crash report lives.

This is not cosmetic. In #9282 it was the only signal a user had, and it sent a P0 investigation down the wrong path — a suspected code-signature / ASAR corruption defect, including a PR that was written and then closed — for what turned out to be an environmental failure. The information needed to diagnose it correctly was on the machine the whole time: macOS had written `~/Library/Logs/DiagnosticReports/Orca-*.ips` naming the crashing frame, and Electron had printed `task_name_for_pid: (os/kern) failure (5)` to stderr. Neither surfaced through our CLI.

The actual crash was an abort during macOS application registration, before any of our JS runs:

```text
abort → ___RegisterApplication_block_invoke → _RegisterApplication → GetCurrentProcess
→ _NSInitializeAppContext → -[NSApplication init] → +[NSApplication sharedApplication] → ElectronMain
```

Because there's no JS on the stack, this can't be caught in-process — the parent CLI is the only place it can be explained.

## Fix

Extracts a pure `serveSignalExitError(signal, platform)` builder and swaps the bare throw in `superviseForegroundServe` for it:

- **darwin + SIGABRT** — offers the window-server registration failure as the likely cause along with the environments it shows up in (restricted/sandboxed, SSH without a GUI login, CI), and routes a remedy plus the `~/Library/Logs/DiagnosticReports/Orca-*.ips` pointer through `RuntimeClientError`'s existing `data.nextSteps` channel, which `format.ts` already renders in both human and `--json` output. The parent only ever observes the signal, never the phase, so the cause is offered as likely rather than asserted.
- **Other platforms/signals** — a plain `exited via <SIGNAL>.` with no invented cause.
- **Neither code nor signal** — its own clear line instead of rendering `exited via null`.

Verbatim human output on darwin + SIGABRT:

```text
Orca serve aborted with SIGABRT on macOS. This most often happens at application startup, when the process cannot register with the macOS window server, which is common in restricted or sandboxed environments, SSH sessions without a GUI login, and CI.
Next step: Re-run `orca serve` outside a sandboxed or restricted environment, with a macOS desktop login active.
Next step: Look for a crash report at ~/Library/Logs/DiagnosticReports/Orca-*.ips.
```

The remedy deliberately does not tell users to stop serving over SSH — SSH serve is supported; what it needs is an active macOS desktop login for the window-server connection.

## Scope

Tier 1 from the issue only. Deliberately excluded:

- **Tier 2** stderr ring-buffer parsing — `launch.ts` spawns with `stdio: 'inherit'`, so the parent can't observe child stderr without rewiring the pass-through path. Deferred until this recurs.
- **`crashReporter.start()`** — Orca collects no crash data of its own today. That's the systemic version of this problem and needs its own issue (consent, privacy, an endpoint).

## Test plan

- New test file covering the pure builder (darwin SIGABRT explains; off-darwin — linux and win32 — doesn't claim the macOS cause; other darwin signals don't either; null signal stays clear) and `superviseForegroundServe` end-to-end (darwin SIGABRT throws the diagnostic, linux SIGABRT doesn't, numeric exits `0`/`7` return unchanged).
- `vitest src/cli/runtime` → **63 passed** across 9 files.
- `vitest src/cli` → **511 passed** across 39 files.
- `typecheck:cli` + `typecheck:node` clean; oxlint clean on touched files; max-lines ratchet OK.
