### PR TITLE
fix(codex): classify weekly-only rate limits on the backend path

### DIFF
--- a/src/main/rate-limits/codex-fetcher-backend.test.ts
+++ b/src/main/rate-limits/codex-fetcher-backend.test.ts
@@ -97,6 +97,47 @@ describe('Codex backend rate-limit requests', () => {
     )
   })
 
+  it('labels a sole seven-day backend primary window as weekly, not a 5h session', async () => {
+    readFileMock.mockResolvedValue(
+      JSON.stringify({
+        tokens: { access_token: 'access-token', account_id: 'account-id' }
+      })
+    )
+    vi.mocked(fetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          plan_type: 'plus',
+          // Why: weekly-only plans expose the sole 7-day quota as primary_window with no secondary.
+          rate_limit: {
+            primary_window: {
+              used_percent: 37,
+              limit_window_seconds: 7 * 24 * 60 * 60,
+              reset_at: 1_800_000_000
+            },
+            secondary_window: null
+          }
+        })
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ available_count: 0, credits: [] })
+      } as Response)
+
+    await expect(
+      fetchCodexRateLimits({
+        codexHomePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\account\\home'
+      })
+    ).resolves.toMatchObject({
+      session: null,
+      weekly: { usedPercent: 37, windowMinutes: 10_080, resetsAt: 1_800_000_000_000 },
+      status: 'ok'
+    })
+
+    expect(childSpawnMock).not.toHaveBeenCalled()
+    expect(ptySpawnMock).not.toHaveBeenCalled()
+  })
+
   it('aborts callers while sharing one stalled backend auth read', async () => {
     let resolveRead!: (content: string) => void
     readFileMock.mockImplementation(

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -14,8 +14,8 @@ import {
   classifyCodexRateLimitWindows,
   CODEX_SESSION_WINDOW_MINUTES,
   CODEX_WEEKLY_WINDOW_MINUTES,
-  type CodexRpcRateLimits,
-  type CodexRpcRateWindow
+  type CodexRateLimitWindowsSnapshot,
+  type CodexRateWindowSnapshot
 } from './codex-rate-limit-window-classification'
 import { resolveCodexCommand } from '../codex-cli/command'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
@@ -73,7 +73,7 @@ type RateLimitResetCredits = {
 
 // Why: the Codex app-server wraps rate limit data as { rateLimits: { primary, secondary, ... } }.
 type RpcRateLimitsResponse = {
-  rateLimits?: CodexRpcRateLimits | null
+  rateLimits?: CodexRateLimitWindowsSnapshot | null
   rateLimitResetCredits?: {
     availableCount?: number
     totalEarnedCount?: number
@@ -444,7 +444,7 @@ export async function consumeCodexRateLimitResetCredit(options: {
 }
 
 function mapRpcWindow(
-  raw: CodexRpcRateWindow | null | undefined,
+  raw: CodexRateWindowSnapshot | null | undefined,
   expectedWindowMinutes: number
 ): RateLimitWindow | null {
   if (!raw || typeof raw.usedPercent !== 'number' || !Number.isFinite(raw.usedPercent)) {
@@ -479,27 +479,32 @@ function mapRpcWindow(
   }
 }
 
-function mapBackendUsageWindow(
-  raw: BackendRateLimitWindow | null | undefined,
-  fallbackWindowMinutes: number
-): RateLimitWindow | null {
-  const limitWindowSeconds = raw?.limit_window_seconds
-  // Why: match Codex backend-client's window_minutes_from_seconds — actual bucket duration, rounding partial minutes up.
-  const windowMinutes =
+function backendWindowToSnapshot(
+  raw: BackendRateLimitWindow | null | undefined
+): CodexRateWindowSnapshot | null {
+  if (!raw) {
+    return null
+  }
+  const limitWindowSeconds = raw.limit_window_seconds
+  // Why: match Codex backend-client's window_minutes_from_seconds so the shared classifier sees the same bucket duration the RPC path reports.
+  const windowDurationMins =
     typeof limitWindowSeconds === 'number' &&
     Number.isFinite(limitWindowSeconds) &&
     limitWindowSeconds > 0
       ? Math.ceil(limitWindowSeconds / 60)
-      : fallbackWindowMinutes
-  return mapRpcWindow(
-    raw
-      ? {
-          usedPercent: raw.used_percent,
-          resetsAt: raw.reset_at
-        }
-      : undefined,
-    windowMinutes
-  )
+      : undefined
+  return { usedPercent: raw.used_percent, windowDurationMins, resetsAt: raw.reset_at }
+}
+
+// Why: the backend reports exact bucket seconds, so keep that real duration for the label; only fall back to canonical when it is missing.
+function snapshotWindowMinutes(
+  snapshot: CodexRateWindowSnapshot | null,
+  fallbackWindowMinutes: number
+): number {
+  const duration = snapshot?.windowDurationMins
+  return typeof duration === 'number' && Number.isFinite(duration) && duration > 0
+    ? duration
+    : fallbackWindowMinutes
 }
 
 async function fetchViaBackend(
@@ -524,10 +529,21 @@ async function fetchViaBackend(
   if (typeof payload.plan_type !== 'string') {
     return null
   }
+  // Why: classify by window duration, not field position, so a weekly-only plan (sole 7-day window) is not mislabeled as a 5h session.
+  const classified = classifyCodexRateLimitWindows({
+    primary: backendWindowToSnapshot(payload.rate_limit?.primary_window),
+    secondary: backendWindowToSnapshot(payload.rate_limit?.secondary_window)
+  })
   return {
     provider: 'codex',
-    session: mapBackendUsageWindow(payload.rate_limit?.primary_window, 300),
-    weekly: mapBackendUsageWindow(payload.rate_limit?.secondary_window, 10080),
+    session: mapRpcWindow(
+      classified.session,
+      snapshotWindowMinutes(classified.session, CODEX_SESSION_WINDOW_MINUTES)
+    ),
+    weekly: mapRpcWindow(
+      classified.weekly,
+      snapshotWindowMinutes(classified.weekly, CODEX_WEEKLY_WINDOW_MINUTES)
+    ),
     // Surfaced for the status-bar Usage row (e.g. "Codex · Plus").
     planType: payload.plan_type,
     ...(payload.rate_limit_reset_credits !== undefined

--- a/src/main/rate-limits/codex-rate-limit-window-classification.test.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   classifyCodexRateLimitWindows,
-  type CodexRpcRateLimits
+  type CodexRateLimitWindowsSnapshot
 } from './codex-rate-limit-window-classification'
 
-function usedPercentByWindow(result: CodexRpcRateLimits | null): {
+function usedPercentByWindow(result: CodexRateLimitWindowsSnapshot | null): {
   session: number | null
   weekly: number | null
 } {

--- a/src/main/rate-limits/codex-rate-limit-window-classification.ts
+++ b/src/main/rate-limits/codex-rate-limit-window-classification.ts
@@ -4,27 +4,29 @@ export const CODEX_WEEKLY_WINDOW_MINUTES = 10080
 // Why: tolerate the one-minute drift seen in older Codex bucket lengths without absorbing other durations.
 const CODEX_WINDOW_DURATION_TOLERANCE_MINUTES = 1
 
-export type CodexRpcRateWindow = {
+// Why: shared classifier input for both the app-server RPC and backend HTTPS paths;
+// each transport reshapes its raw window into this duration-carrying snapshot.
+export type CodexRateWindowSnapshot = {
   usedPercent?: unknown
   windowDurationMins?: unknown
   resetsAt?: unknown
 }
 
-export type CodexRpcRateLimits = {
-  primary?: CodexRpcRateWindow | null
-  secondary?: CodexRpcRateWindow | null
+export type CodexRateLimitWindowsSnapshot = {
+  primary?: CodexRateWindowSnapshot | null
+  secondary?: CodexRateWindowSnapshot | null
 }
 
-type MappableCodexRpcRateWindow = CodexRpcRateWindow & { usedPercent: number }
+type MappableCodexRateWindowSnapshot = CodexRateWindowSnapshot & { usedPercent: number }
 type CodexRateLimitWindowKind = 'session' | 'weekly' | null
 
-function isMappableCodexRpcRateWindow(
-  raw: CodexRpcRateWindow | null | undefined
-): raw is MappableCodexRpcRateWindow {
+function isMappableCodexRateWindowSnapshot(
+  raw: CodexRateWindowSnapshot | null | undefined
+): raw is MappableCodexRateWindowSnapshot {
   return typeof raw?.usedPercent === 'number' && Number.isFinite(raw.usedPercent)
 }
 
-function classifyWindowDuration(raw: MappableCodexRpcRateWindow): CodexRateLimitWindowKind {
+function classifyWindowDuration(raw: MappableCodexRateWindowSnapshot): CodexRateLimitWindowKind {
   const duration = raw.windowDurationMins
   if (typeof duration !== 'number' || !Number.isFinite(duration)) {
     return null
@@ -40,14 +42,16 @@ function classifyWindowDuration(raw: MappableCodexRpcRateWindow): CodexRateLimit
   return null
 }
 
-export function classifyCodexRateLimitWindows(result: CodexRpcRateLimits | null | undefined): {
-  session: MappableCodexRpcRateWindow | null
-  weekly: MappableCodexRpcRateWindow | null
+export function classifyCodexRateLimitWindows(
+  result: CodexRateLimitWindowsSnapshot | null | undefined
+): {
+  session: MappableCodexRateWindowSnapshot | null
+  weekly: MappableCodexRateWindowSnapshot | null
 } {
-  const primary = isMappableCodexRpcRateWindow(result?.primary) ? result.primary : null
-  const secondary = isMappableCodexRpcRateWindow(result?.secondary) ? result.secondary : null
-  let session: MappableCodexRpcRateWindow | null = null
-  let weekly: MappableCodexRpcRateWindow | null = null
+  const primary = isMappableCodexRateWindowSnapshot(result?.primary) ? result.primary : null
+  const secondary = isMappableCodexRateWindowSnapshot(result?.secondary) ? result.secondary : null
+  let session: MappableCodexRateWindowSnapshot | null = null
+  let weekly: MappableCodexRateWindowSnapshot | null = null
 
   for (const window of [primary, secondary]) {
     if (!window) {

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1238,10 +1238,13 @@ function VerboseProviderUsage({
     return window !== null
   })
 
+  // Why: weekly-only plans have no session window; the mini meter follows the weekly quota instead of vanishing.
+  const meterWindow = p.session ?? p.weekly
+
   return (
     <>
-      {p.session && !compact ? (
-        <MiniBar usedPct={clampUsedPercent(p.session.usedPercent)} display={display} />
+      {meterWindow && !compact ? (
+        <MiniBar usedPct={clampUsedPercent(meterWindow.usedPercent)} display={display} />
       ) : null}
       {visibleWindows.map((window, index) => (
         <React.Fragment key={window.key}>

--- a/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
+++ b/src/renderer/src/components/status-bar/inline-usage-bars.test.tsx
@@ -99,6 +99,32 @@ describe('InlineUsageBars', () => {
     expect(markup).toContain('32% used now')
   })
 
+  it('keeps the mini meter for a weekly-only Codex plan (session window absent)', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+    const limits: ProviderRateLimits = {
+      provider: 'codex',
+      session: null,
+      weekly: {
+        usedPercent: 37,
+        windowMinutes: 10_080,
+        resetsAt: null,
+        resetDescription: null
+      },
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={limits} compact={false} display="used" />
+    )
+
+    // Why: without the session??weekly fallback the meter would vanish for weekly-only plans.
+    expect(markup).toContain('w-[48px] h-[6px]')
+    expect(markup).toContain('width:37%')
+    expect(markup).toContain('37% used wk')
+  })
+
   it('shows remaining copy and remaining meter fill', async () => {
     mocks.usagePercentageDisplay = 'remaining'
     const { InlineUsageBars } = await import('./StatusBar')


### PR DESCRIPTION
## Summary

#10136 taught the **app-server RPC** path to classify Codex rate-limit windows by duration, but the **backend HTTPS** path — the one WSL uses — still assumed `primary = 5h` / `secondary = weekly` **by position**. Weekly-only plans (current Pro) expose their sole 7-day quota as the *primary* window, so WSL users saw it mislabeled as a `5h` session.

Verified against the live backend for a weekly-only Pro account:

```
primary_window:   used_percent=100  limit_window_seconds=604800  (=10080 min)
secondary_window: null
```

Changes:
- Route backend windows through the same duration classifier by reshaping them into the shared window snapshot, preserving the exact bucket duration the backend reports.
- Rename the classifier's input types to be transport-neutral now that both paths share them (`CodexRpc*` → `CodexRateLimitWindows*`).
- Status bar: follow the weekly window when there is no session window, so weekly-only plans keep their compact mini meter instead of losing it (`p.session ?? p.weekly`).

5h-only, 5h+weekly, and unknown-duration plans are unchanged on both paths.

## Context

Found while retesting #9969 on `v1.4.156-rc.0`. The native (RPC) half of that mislabel is already fixed by #10136 — confirmed live, the Codex row went from `5h · Resets in 6d 15h` to `wk · Resets in 5d 19h`. This PR closes the remaining **WSL** half.

Note this does **not** fix #9969's reported symptom (limits resetting earlier than the displayed countdown) — that is upstream OpenAI reset behavior, not a client-side parsing bug.

## Testing

- [x] `typecheck:node` + `typecheck:web` clean
- [x] 59 test files / 601 tests green (`src/main/rate-limits/` + `src/renderer/src/components/status-bar/`), incl. 3 new/updated test files
- [x] Live-verified the backend payload shape for a weekly-only Pro account (macOS)
- [ ] **Not verified on real WSL** — the changed path only runs on WSL. Needs a WSL smoke check: weekly-only Codex account should show `wk` (not `5h`) plus its mini meter.