### PR TITLE
fix(codex): cache weekly-only accounts when switching Codex accounts

### DIFF
--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -1786,6 +1786,25 @@ describe('RateLimitService', () => {
     )
   })
 
+  it('does not cache an outgoing Codex account that has no usage windows', async () => {
+    const service = new RateLimitService()
+    service.setInactiveCodexAccountsResolver(() => [
+      { id: 'account-empty', managedHomePath: '/tmp/account-empty/home' }
+    ])
+
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits)
+      .mockResolvedValueOnce(errorProvider('codex', 'codex not signed in'))
+      .mockResolvedValueOnce(okProvider('codex', 40, Date.now()))
+
+    await service.refresh()
+    await service.refreshForCodexAccountChange('account-empty')
+
+    expect(service.getState().inactiveCodexAccounts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ accountId: 'account-empty' })])
+    )
+  })
+
   it('does not cache host Claude usage under an outgoing WSL account', async () => {
     const service = new RateLimitService()
     service.setInactiveClaudeAccountsResolver(() => [

--- a/src/main/rate-limits/service.test.ts
+++ b/src/main/rate-limits/service.test.ts
@@ -1751,6 +1751,41 @@ describe('RateLimitService', () => {
     )
   })
 
+  it('caches an outgoing weekly-only Codex account so the switcher keeps its inline bars', async () => {
+    const service = new RateLimitService()
+    service.setInactiveCodexAccountsResolver(() => [
+      { id: 'account-weekly', managedHomePath: '/tmp/account-weekly/home' }
+    ])
+
+    const weeklyOnly: ProviderRateLimits = {
+      provider: 'codex',
+      session: null,
+      weekly: { usedPercent: 76, windowMinutes: 10080, resetsAt: null, resetDescription: null },
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
+    vi.mocked(fetchCodexRateLimits)
+      .mockResolvedValueOnce(weeklyOnly)
+      .mockResolvedValueOnce(okProvider('codex', 40, Date.now()))
+
+    await service.refresh()
+    await service.refreshForCodexAccountChange('account-weekly')
+
+    expect(service.getState().inactiveCodexAccounts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          accountId: 'account-weekly',
+          rateLimits: expect.objectContaining({
+            session: null,
+            weekly: expect.objectContaining({ usedPercent: 76 })
+          })
+        })
+      ])
+    )
+  })
+
   it('does not cache host Claude usage under an outgoing WSL account', async () => {
     const service = new RateLimitService()
     service.setInactiveClaudeAccountsResolver(() => [

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -378,9 +378,11 @@ export class RateLimitService {
     target?: CodexAccountSelectionTarget
   ): Promise<RateLimitState> {
     const nextTarget = normalizeCodexAccountSelectionTarget(target)
+    // Why: weekly-only plans report no session window, so gating on session alone
+    // dropped their snapshot and left the switcher's inline bars empty.
     if (
       outgoingAccountId &&
-      this.state.codex?.session &&
+      (this.state.codex?.session || this.state.codex?.weekly) &&
       this.isSameCodexTarget(this.codexFetchTarget, nextTarget)
     ) {
       this.inactiveCodexCache.set(outgoingAccountId, this.state.codex)


### PR DESCRIPTION
## Summary

`refreshForCodexAccountChange` snapshotted the outgoing account into `inactiveCodexCache` only when `this.state.codex.session` was populated:

```ts
outgoingAccountId &&
this.state.codex?.session &&        // weekly-only plans have session === null
this.isSameCodexTarget(...)
```

Weekly-only plans (current Codex Pro) report **no session window**, so their snapshot was dropped and the account switcher's inline bars rendered empty for exactly those accounts. The gate's intent is "only cache a snapshot that has real usage data" — a populated `weekly` window qualifies.

**#10136 made this reachable.** Before duration-based classification, a weekly-only quota landed in the `session` slot, so the gate happened to pass. Now that it is correctly classified as `weekly`, `session` is `null` and the cache is skipped.

Claude is intentionally untouched — it has no weekly-only plan shape, and its analogous gate at `service.ts:462` is left as-is to keep this change to one concern.

## What this looks like for you

You're affected if you're on a **weekly-only Codex plan** (current Codex Pro) **and** have more than one Codex account. The switcher renders inline usage bars under each *inactive* account, so the symptom only appears once you switch away from an account.

A successful switch collapses the switcher (`StatusBar.tsx:1473`), so you see this the next time you expand it.

**Before** — the outgoing account's reading was thrown away, so that row has to re-probe from scratch and shows a pulsing empty skeleton (`StatusBar.tsx:1787`) until it lands. The preview probe is RPC-only (`service.ts:633` — no PTY fallback, so it can't spawn hidden PTYs per account), bounded by `RPC_TIMEOUT_MS` 10s native / `WSL_RPC_TIMEOUT_MS` 25s WSL (`codex-fetcher.ts:40-41`), and accounts are probed **sequentially** (`service.ts:615`) — so with several inactive accounts the last row waits behind all the ones before it.

```
Codex
  work@example.com                                       Active
  personal@example.com
  ░░░░░░░░░░░░░░░░░░░░░   ░░░░░░░░░░░░░░░░░░░░░          ‹ pulsing, no numbers ›
```

If that probe fails you land on "Sign in to see usage" or an empty row — instead of the reading you had a second ago.

**After** — the last-known reading is kept, so the bar is there immediately and refreshes in place:

```
Codex
  work@example.com                                       Active
  personal@example.com
  ████████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░  76% wk
```

Weekly-only accounts get a single full-width bar, because the grid allocates one column per populated window (`StatusBar.tsx:1028`). While the background re-probe runs, the populated bar pulses in place (`StatusBar.tsx:1026`) and each row updates independently as its own probe returns (`service.ts:661`).

**Unchanged** for accounts that do report a session window — they already worked, and still show both bars:

```
  ██████░░░░░░░░░░░░░░  12% 4h 30m   ███████████░░░░░░░░░  58% wk
```

Also unchanged for Claude accounts, and unchanged for the account you switch **to** — that one is already force-refetched immediately on switch (`service.ts:400-402`), with the old reading cleared first so the previous account's numbers never show under the new identity. This PR only concerns the account you switch **away from**, which can't be re-queried cheaply because it needs its own `CODEX_HOME` spun up.

> Mockups rendered from the component source, not screenshots — this path wasn't exercised in a live app (see Testing).

## Testing

- [x] `typecheck:node` clean
- [x] `src/main/rate-limits/` + `src/main/codex-accounts/` — 580 tests green (2 new)
- [x] Both new tests are **mutation-checked**, and each mutation kills exactly one test:
  - reverting the gate to `session &&` fails the weekly-only test (`expected [] to deeply equal ArrayContaining{…}`)
  - loosening it to a bare `this.state.codex &&` fails the negative test (`expected [ Array(1) ] to not deeply equal ArrayContaining{…}`) — this second case pins that a windowless/error record is still *not* cached, so the switcher can't render a blank bar row
- Multi-account switching was not exercised in a live app; covered by unit tests only.

## Context

Found while retesting #9969 on `v1.4.156-rc.0`. Independent of #10466 (backend-path classification) — different subsystem, no overlapping hunks.
