### PR TITLE
fix(terminal): copy full session context without char budget

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-fork.ts
@@ -3,8 +3,9 @@ import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import {
   buildAgentSessionForkPrompt,
-  buildBoundedSessionTranscript
+  buildFullSessionTranscript
 } from '@/lib/agent-session-fork-context'
+import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from '../../../../shared/terminal-scrollback-policy'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
@@ -171,12 +172,17 @@ export async function copyAgentSessionForkContext(
   return copyForkContext(fork.prompt, fork.pane)
 }
 
-// Why: the standalone "Copy Context" action copies the bounded transcript on its
-// own — for pasting into another tool — so it must not carry the fork prompt's
-// "this is a fork… acknowledge and wait" framing the dialog button uses.
+// Why: standalone Copy Context is for pasting into another tool/model, so it
+// must yield the full cleaned transcript (no fork framing, no char budget)
+// using the pane's configured scrollback depth rather than a short 800-line tail.
 export async function copyAgentSessionContextFromPane(pane: ManagedPane): Promise<boolean> {
-  const transcript = buildBoundedSessionTranscript(
-    pane.serializeAddon.serialize({ scrollback: 800 })
+  const scrollbackRows =
+    typeof pane.terminal.options.scrollback === 'number' &&
+    Number.isFinite(pane.terminal.options.scrollback)
+      ? Math.max(1, Math.floor(pane.terminal.options.scrollback))
+      : DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT
+  const transcript = buildFullSessionTranscript(
+    pane.serializeAddon.serialize({ scrollback: scrollbackRows })
   )
   if (!transcript) {
     toast.error(

--- a/src/renderer/src/lib/agent-session-fork-context.test.ts
+++ b/src/renderer/src/lib/agent-session-fork-context.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   buildAgentSessionForkPrompt,
   buildBoundedSessionTranscript,
+  buildFullSessionTranscript,
   cleanAgentSessionForkTranscript
 } from './agent-session-fork-context'
 
@@ -81,6 +82,26 @@ describe('agent session fork context', () => {
 
   it('returns null from the bounded transcript when nothing survives cleanup', () => {
     expect(buildBoundedSessionTranscript('\x1b[0m\r\n\x1bc\x07')).toBeNull()
+  })
+
+  it('keeps the full cleaned transcript for Copy Context (#10395)', () => {
+    // Why: fork prompts still budget-trim; Copy Context must retain early turns
+    // so paste targets get the complete session, not a newest-only slice.
+    const early = `EARLY_MARKER ${'x'.repeat(40_000)}`
+    const late = '\nLATE_MARKER end of session'
+    const full = buildFullSessionTranscript(`${early}${late}`)
+    const bounded = buildBoundedSessionTranscript(`${early}${late}`)
+
+    expect(full).toContain('EARLY_MARKER')
+    expect(full).toContain('LATE_MARKER')
+    expect(full).not.toContain('Earlier terminal output omitted')
+    expect(bounded).toContain('Earlier terminal output omitted')
+    expect(bounded).not.toContain('EARLY_MARKER')
+    expect(bounded).toContain('LATE_MARKER')
+  })
+
+  it('returns null from the full transcript when nothing survives cleanup', () => {
+    expect(buildFullSessionTranscript('\x1b[0m\r\n\x1bc\x07')).toBeNull()
   })
 
   it('uses a longer fence when captured output contains markdown fences', () => {

--- a/src/renderer/src/lib/agent-session-fork-context.ts
+++ b/src/renderer/src/lib/agent-session-fork-context.ts
@@ -138,6 +138,16 @@ export function buildBoundedSessionTranscript(capturedText: string): string | nu
   return transcript || null
 }
 
+/**
+ * Full cleaned transcript for the standalone Copy Context action (#10395).
+ * Unlike fork prompts, this does not drop earlier scrollback to a char budget —
+ * users paste into external tools and need the complete session.
+ */
+export function buildFullSessionTranscript(capturedText: string): string | null {
+  const transcript = cleanAgentSessionForkTranscript(capturedText)
+  return transcript || null
+}
+
 export function buildAgentSessionForkPrompt({
   capturedText,
   sourceLabel,


### PR DESCRIPTION
## Summary
- **Copy Context** no longer truncates long sessions to ~36k characters with `[Earlier terminal output omitted: N characters]`
- Serializes the pane's full configured scrollback (not a fixed 800-line tail)
- Still strips ANSI/OSC and leaves **fork-session prompts** on the existing budget so agent injects stay bounded

Closes #10395

## Motivation
Users paste Copy Context into other models/analysis tools and need the complete terminal session, including early tool output. Truncation made the action unusable for long runs.

## Changes
- `buildFullSessionTranscript()` — clean only, no char budget
- `copyAgentSessionContextFromPane` uses full transcript + `terminal.options.scrollback`
- Fork path (`buildAgentSessionForkPrompt` / `buildBoundedSessionTranscript`) unchanged

## Test plan
- [x] Unit: full transcript retains early + late markers; bounded path still omits early
- [x] Existing fork/cleanup tests pass (10 total)
- [ ] Manual: long agent session → Copy Context → paste includes start of session without omit marker

## Notes
Clipboard write still respects the existing 16 MB write limit in main; oversized captures surface as a copy error toast rather than a silent omit.

## ELI5

Copy Context used to cut off long terminal sessions after ~36k characters, so early tool output was missing when you pasted elsewhere. Now it copies the full configured scrollback instead. Agent fork prompts still stay on a size budget so they do not get huge.
