### PR TITLE
fix(worktree): collapse duplicate "Local Mac" run targets in the host picker

### DIFF
--- a/src/main/git/repo-detection.test.ts
+++ b/src/main/git/repo-detection.test.ts
@@ -11,7 +11,12 @@ import {
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { getGitRepoRoot, isGitRepo, normalizeGitRepoRootForInputPath } from './repo'
+import {
+  getGitRepoRoot,
+  getLinkedWorktreeMainRepoRoot,
+  isGitRepo,
+  normalizeGitRepoRootForInputPath
+} from './repo'
 
 function git(cwd: string, args: string[]): string {
   return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
@@ -326,6 +331,85 @@ describe('isGitRepo', () => {
     git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
 
     expect(getGitRepoRoot(bareRepo)).toBe(bareRepo)
+  })
+})
+
+describe('getLinkedWorktreeMainRepoRoot', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'orca-linked-worktree-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  function initRepoWithCommit(repoRoot: string): void {
+    mkdirSync(repoRoot, { recursive: true })
+    git(repoRoot, ['init', '--quiet'])
+    git(repoRoot, ['config', 'user.email', 'test@orca.test'])
+    git(repoRoot, ['config', 'user.name', 'Orca Test'])
+    writeFileSync(path.join(repoRoot, 'README.md'), 'seed\n')
+    git(repoRoot, ['add', 'README.md'])
+    git(repoRoot, ['commit', '--quiet', '-m', 'seed'])
+  }
+
+  it('resolves a linked worktree back to its main checkout', () => {
+    const repoRoot = path.join(tmpDir, 'repo')
+    initRepoWithCommit(repoRoot)
+    const linked = path.join(tmpDir, 'linked')
+    git(repoRoot, ['worktree', 'add', '--quiet', '-b', 'feature', linked])
+
+    const expectedMainRoot = git(repoRoot, ['rev-parse', '--show-toplevel'])
+      .trim()
+      .replace(/\\/g, '/')
+    expect(getLinkedWorktreeMainRepoRoot(linked)).toBe(expectedMainRoot)
+  })
+
+  it('returns null for the main checkout itself', () => {
+    const repoRoot = path.join(tmpDir, 'repo')
+    initRepoWithCommit(repoRoot)
+
+    expect(getLinkedWorktreeMainRepoRoot(repoRoot)).toBeNull()
+  })
+
+  it('returns null for a nested directory inside the main checkout', () => {
+    const repoRoot = path.join(tmpDir, 'repo')
+    initRepoWithCommit(repoRoot)
+    const nested = path.join(repoRoot, 'packages', 'web')
+    mkdirSync(nested, { recursive: true })
+
+    expect(getLinkedWorktreeMainRepoRoot(nested)).toBeNull()
+  })
+
+  it('returns null for a bare repository', () => {
+    const bareRepo = path.join(tmpDir, 'bare.git')
+    git(tmpDir, ['init', '--bare', '--quiet', bareRepo])
+
+    expect(getLinkedWorktreeMainRepoRoot(bareRepo)).toBeNull()
+  })
+
+  it('returns null for a non-repository directory', () => {
+    const plain = path.join(tmpDir, 'plain')
+    mkdirSync(plain)
+
+    expect(getLinkedWorktreeMainRepoRoot(plain)).toBeNull()
+  })
+
+  it('returns null for a missing path', () => {
+    expect(getLinkedWorktreeMainRepoRoot(path.join(tmpDir, 'does-not-exist'))).toBeNull()
+  })
+
+  it('returns null when git cannot be run rather than guessing a main checkout', () => {
+    const repoRoot = path.join(tmpDir, 'repo')
+    initRepoWithCommit(repoRoot)
+    const linked = path.join(tmpDir, 'linked')
+    git(repoRoot, ['worktree', 'add', '--quiet', '-b', 'feature', linked])
+
+    withGitUnavailable(() => {
+      expect(getLinkedWorktreeMainRepoRoot(linked)).toBeNull()
+    })
   })
 })
 

--- a/src/main/git/repo.ts
+++ b/src/main/git/repo.ts
@@ -155,6 +155,52 @@ export function getGitRepoRoot(path: string): string {
   return path
 }
 
+function canonicalizeGitDirPath(path: string): string {
+  return resolveRealPathSync(path) ?? path
+}
+
+/**
+ * Main-checkout path when `path` is a *linked* worktree, else null (main worktree, bare repo,
+ * non-repo, or any git failure). A linked worktree's `--git-dir` is `<common>/worktrees/<name>`
+ * while the main worktree's equals `--git-common-dir`; comparing the two from one invocation is
+ * git's own canonical test and avoids symlink-canonicalization mismatches. Baseline-safe: both
+ * flags long predate Git 2.25, and a relative answer resolves against `path` as old Git reports it.
+ */
+export function getLinkedWorktreeMainRepoRoot(path: string): string | null {
+  try {
+    if (!existsSync(path) || !statSync(path).isDirectory()) {
+      return null
+    }
+    if (gitExecFileSync(['rev-parse', '--is-inside-work-tree'], { cwd: path }).trim() !== 'true') {
+      return null
+    }
+    const [gitDir, commonDir] = gitExecFileSync(['rev-parse', '--git-dir', '--git-common-dir'], {
+      cwd: path
+    })
+      .split('\n')
+      .map((line) => line.trim())
+    if (!gitDir || !commonDir) {
+      return null
+    }
+    // Why realpath both: git answers one flag absolutely (already symlink-resolved) and the other
+    // relative to cwd, so a repo under a symlinked root (macOS /var -> /private/var) compares
+    // unequal on raw strings and a main checkout gets misread as a linked worktree.
+    const absoluteCommonDir = canonicalizeGitDirPath(resolve(path, commonDir))
+    if (canonicalizeGitDirPath(resolve(path, gitDir)) === absoluteCommonDir) {
+      return null
+    }
+    // A bare/separate git dir has no adjacent working checkout to point at.
+    if (basename(absoluteCommonDir) !== '.git') {
+      return null
+    }
+    // Re-resolve through getGitRepoRoot so the returned path matches the canonical form
+    // add-project stores for the main checkout (symlinks resolved the way git reports them).
+    return getGitRepoRoot(dirname(absoluteCommonDir))
+  } catch {
+    return null
+  }
+}
+
 export function normalizeGitRepoRootForInputPath(inputPath: string, rootPath: string): string {
   const inputWsl = parseWslUncPath(inputPath)
   if (inputWsl && rootPath.startsWith('/')) {

--- a/src/main/ipc/repos-add-linked-worktree.test.ts
+++ b/src/main/ipc/repos-add-linked-worktree.test.ts
@@ -167,6 +167,18 @@ describe('repos:add with git worktrees', () => {
     expect(mockStore.addRepo).not.toHaveBeenCalled()
   })
 
+  it('does not match a folder record sitting on the main-checkout path', async () => {
+    mockStore.getRepos.mockReturnValue([
+      { ...trackedMainRepo(), id: 'folder-repo-id', kind: 'folder' } as Repo
+    ])
+    getLinkedWorktreeMainRepoRootMock.mockReturnValue(MAIN_CHECKOUT)
+
+    const result = await callAdd({ path: LINKED_WORKTREE })
+
+    expect(mockStore.addRepo).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ repo: expect.objectContaining({ path: LINKED_WORKTREE }) })
+  })
+
   it('does not match a tracked SSH repo that shares the local main-checkout path', async () => {
     mockStore.getRepos.mockReturnValue([
       { ...trackedMainRepo(), id: 'ssh-repo-id', connectionId: 'builder' } as Repo

--- a/src/main/ipc/repos-add-linked-worktree.test.ts
+++ b/src/main/ipc/repos-add-linked-worktree.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression tests for repos:add + git worktrees.
+ *
+ * A linked worktree reports itself as its own `--show-toplevel`, so the path-based dedupe in
+ * addLocalRepoFromPath cannot see that it belongs to an already-tracked repo. Adding it anyway
+ * produced a second ready ProjectHostSetup on the same project and host — a duplicate "Local Mac"
+ * run-target row pointing at a transient worktree path.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import type { Repo } from '../../shared/types'
+
+const {
+  handleMock,
+  removeHandlerMock,
+  mockStore,
+  isGitRepoMock,
+  getGitRepoRootMock,
+  getLinkedWorktreeMainRepoRootMock,
+  invalidateAuthorizedRootsCacheMock,
+  prepareLocalWorktreeRootForRepoMock,
+  detectRepoIconAndUpstreamMock
+} = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  removeHandlerMock: vi.fn(),
+  mockStore: {
+    getRepos: vi.fn().mockReturnValue([]),
+    addRepo: vi.fn(),
+    removeProject: vi.fn(),
+    getRepo: vi.fn(),
+    updateRepo: vi.fn()
+  },
+  isGitRepoMock: vi.fn().mockReturnValue(true),
+  getGitRepoRootMock: vi.fn(),
+  getLinkedWorktreeMainRepoRootMock: vi.fn(),
+  invalidateAuthorizedRootsCacheMock: vi.fn(),
+  prepareLocalWorktreeRootForRepoMock: vi.fn(),
+  detectRepoIconAndUpstreamMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  dialog: { showOpenDialog: vi.fn() },
+  ipcMain: { handle: handleMock, removeHandler: removeHandlerMock }
+}))
+
+vi.mock('../git/repo', () => ({
+  isGitRepo: isGitRepoMock,
+  getGitRepoRoot: getGitRepoRootMock,
+  getLinkedWorktreeMainRepoRoot: getLinkedWorktreeMainRepoRootMock,
+  getRepoName: vi.fn().mockImplementation((path: string) => path.split('/').pop()),
+  getBaseRefDefault: vi.fn().mockResolvedValue('origin/main'),
+  searchBaseRefs: vi.fn().mockResolvedValue([])
+}))
+
+vi.mock('../repo-detection', () => ({
+  detectRepoIconAndUpstream: detectRepoIconAndUpstreamMock
+}))
+
+vi.mock('./filesystem-auth', () => ({
+  invalidateAuthorizedRootsCache: invalidateAuthorizedRootsCacheMock
+}))
+
+vi.mock('../worktree-root-preparation', () => ({
+  prepareLocalWorktreeRootForRepo: prepareLocalWorktreeRootForRepoMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({ getSshGitProvider: vi.fn() }))
+vi.mock('./ssh', () => ({ getActiveMultiplexer: vi.fn() }))
+
+import { registerRepoHandlers } from './repos'
+
+const MAIN_CHECKOUT = '/Users/dev/projects/orca'
+const LINKED_WORKTREE = '/Users/dev/orca/workspaces/orca/pr-3235'
+
+type AddResult = { repo: Repo } | { error: string }
+
+describe('repos:add with git worktrees', () => {
+  const handlers = new Map<string, (event: unknown, args: unknown) => unknown>()
+  const mockWindow = { isDestroyed: () => false, webContents: { send: vi.fn() } }
+
+  const trackedMainRepo = (): Repo =>
+    ({
+      id: 'main-repo-id',
+      path: MAIN_CHECKOUT,
+      displayName: 'orca',
+      badgeColor: '#ef4444',
+      addedAt: 1,
+      kind: 'git'
+    }) as Repo
+
+  const callAdd = (args: { path: string; kind?: 'git' | 'folder' }): Promise<AddResult> => {
+    const handler = handlers.get('repos:add')
+    if (!handler) {
+      throw new Error('repos:add handler was never registered')
+    }
+    return handler(null, args) as Promise<AddResult>
+  }
+
+  beforeEach(() => {
+    handlers.clear()
+    handleMock.mockReset()
+    handleMock.mockImplementation((channel: string, handler: (...a: unknown[]) => unknown) => {
+      handlers.set(channel, handler as (event: unknown, args: unknown) => unknown)
+    })
+    removeHandlerMock.mockReset()
+    mockStore.getRepos.mockReset().mockReturnValue([])
+    mockStore.addRepo.mockReset()
+    isGitRepoMock.mockReset().mockReturnValue(true)
+    // A linked worktree is its own toplevel — this is exactly why path dedupe alone misses it.
+    getGitRepoRootMock.mockReset().mockImplementation((path: string) => path)
+    getLinkedWorktreeMainRepoRootMock.mockReset().mockReturnValue(null)
+    detectRepoIconAndUpstreamMock.mockReset().mockResolvedValue({})
+    invalidateAuthorizedRootsCacheMock.mockReset()
+    prepareLocalWorktreeRootForRepoMock.mockReset().mockResolvedValue(undefined)
+
+    registerRepoHandlers(mockWindow as never, mockStore as never)
+  })
+
+  it('returns the tracked main checkout instead of adding its linked worktree', async () => {
+    mockStore.getRepos.mockReturnValue([trackedMainRepo()])
+    getLinkedWorktreeMainRepoRootMock.mockReturnValue(MAIN_CHECKOUT)
+
+    const result = await callAdd({ path: LINKED_WORKTREE })
+
+    expect(result).toEqual({ repo: expect.objectContaining({ id: 'main-repo-id' }) })
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
+  it('still adds a linked worktree whose main checkout is not tracked', async () => {
+    mockStore.getRepos.mockReturnValue([])
+    getLinkedWorktreeMainRepoRootMock.mockReturnValue(MAIN_CHECKOUT)
+
+    const result = await callAdd({ path: LINKED_WORKTREE })
+
+    expect(mockStore.addRepo).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ repo: expect.objectContaining({ path: LINKED_WORKTREE }) })
+  })
+
+  it('adds a normal repo when git reports it is not a linked worktree', async () => {
+    mockStore.getRepos.mockReturnValue([trackedMainRepo()])
+    getLinkedWorktreeMainRepoRootMock.mockReturnValue(null)
+
+    const result = await callAdd({ path: '/Users/dev/projects/other' })
+
+    expect(mockStore.addRepo).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ repo: expect.objectContaining({ path: '/Users/dev/projects/other' }) })
+  })
+
+  it('does not consult worktree detection for folder projects', async () => {
+    mockStore.getRepos.mockReturnValue([trackedMainRepo()])
+
+    await callAdd({ path: '/Users/dev/notes', kind: 'folder' })
+
+    expect(getLinkedWorktreeMainRepoRootMock).not.toHaveBeenCalled()
+    expect(mockStore.addRepo).toHaveBeenCalledTimes(1)
+  })
+
+  it('matches the tracked main checkout across path separator differences', async () => {
+    mockStore.getRepos.mockReturnValue([
+      { ...trackedMainRepo(), path: 'C:\\Users\\dev\\projects\\orca' } as Repo
+    ])
+    getLinkedWorktreeMainRepoRootMock.mockReturnValue('C:/Users/dev/projects/orca')
+
+    const result = await callAdd({ path: 'C:/Users/dev/worktrees/pr-3235' })
+
+    expect(result).toEqual({ repo: expect.objectContaining({ id: 'main-repo-id' }) })
+    expect(mockStore.addRepo).not.toHaveBeenCalled()
+  })
+
+  it('does not match a tracked SSH repo that shares the local main-checkout path', async () => {
+    mockStore.getRepos.mockReturnValue([
+      { ...trackedMainRepo(), id: 'ssh-repo-id', connectionId: 'builder' } as Repo
+    ])
+    getLinkedWorktreeMainRepoRootMock.mockReturnValue(MAIN_CHECKOUT)
+
+    const result = await callAdd({ path: LINKED_WORKTREE })
+
+    expect(mockStore.addRepo).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({ repo: expect.objectContaining({ path: LINKED_WORKTREE }) })
+  })
+})

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -59,6 +59,7 @@ import { createNestedRepoImportTargetResolver } from '../project-groups/nested-r
 import {
   isGitRepo,
   getGitRepoRoot,
+  getLinkedWorktreeMainRepoRoot,
   getRepoName,
   getBaseRefDefault,
   getRemoteCount,
@@ -192,6 +193,25 @@ async function addLocalRepoFromPath(
       )
     if (existingAfterRootResolve) {
       return { repo: existingAfterRootResolve, alreadyExisted: true }
+    }
+  }
+
+  // Why: a linked worktree reports itself as its own toplevel, so the path checks above can't see that
+  // it belongs to an already-tracked repo. Adding it anyway yields a second "ready" host setup on the
+  // same project and host — a duplicate run-target row that resolves to a transient worktree path.
+  if (repoKind === 'git') {
+    const mainRepoRoot = getLinkedWorktreeMainRepoRoot(resolvedPath)
+    if (mainRepoRoot) {
+      const mainRepoKey = normalizeRuntimePathForComparison(mainRepoRoot)
+      const trackedMainRepo = store
+        .getRepos()
+        .find(
+          (repo) =>
+            !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === mainRepoKey
+        )
+      if (trackedMainRepo) {
+        return { repo: trackedMainRepo, alreadyExisted: true }
+      }
     }
   }
 

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -203,11 +203,15 @@ async function addLocalRepoFromPath(
     const mainRepoRoot = getLinkedWorktreeMainRepoRoot(resolvedPath)
     if (mainRepoRoot) {
       const mainRepoKey = normalizeRuntimePathForComparison(mainRepoRoot)
+      // Why !isFolderRepo: only a git-kind main checkout projects onto the same project as its
+      // worktree, so matching a folder record would suppress the add without deduping anything.
       const trackedMainRepo = store
         .getRepos()
         .find(
           (repo) =>
-            !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === mainRepoKey
+            !repo.connectionId &&
+            !isFolderRepo(repo) &&
+            normalizeRuntimePathForComparison(repo.path) === mainRepoKey
         )
       if (trackedMainRepo) {
         return { repo: trackedMainRepo, alreadyExisted: true }

--- a/src/renderer/src/lib/project-host-setup-options.test.ts
+++ b/src/renderer/src/lib/project-host-setup-options.test.ts
@@ -199,6 +199,42 @@ describe('buildProjectHostSetupOptions', () => {
     expect(options.map((option) => option.id)).toEqual(['ready'])
   })
 
+  it('collapses duplicate ready setups on one host to the setup creation actually uses', () => {
+    // Why: a linked worktree added as its own project projected a second ready `local` setup for the
+    // same project, which rendered as repeated identical "Local Mac" rows separated only by path.
+    const options = buildProjectHostSetupOptions({
+      projectId: 'project-1',
+      eligibleRepos: [repo('main-checkout'), repo('worktree-a'), repo('worktree-b')],
+      hosts: [host('local')],
+      projectHostSetups: [
+        setup('main', 'project-1', 'local', 'main-checkout', { path: '/Users/dev/projects/orca' }),
+        setup('dup-a', 'project-1', 'local', 'worktree-a', {
+          path: '/Users/dev/worktrees/pr-1908'
+        }),
+        setup('dup-b', 'project-1', 'local', 'worktree-b', { path: '/Users/dev/worktrees/pr-3235' })
+      ]
+    })
+
+    expect(options).toEqual([
+      expect.objectContaining({ id: 'main', kind: 'ready', label: LOCAL_HOST_LABEL })
+    ])
+  })
+
+  it('keeps one ready choice per host when a project is set up on several hosts', () => {
+    const options = buildProjectHostSetupOptions({
+      projectId: 'project-1',
+      eligibleRepos: [repo('local-repo'), repo('local-dup'), repo('remote-repo')],
+      hosts: [host('local'), host('ssh:builder', { label: 'Builder' })],
+      projectHostSetups: [
+        setup('local', 'project-1', 'local', 'local-repo'),
+        setup('local-dup', 'project-1', 'local', 'local-dup'),
+        setup('remote', 'project-1', 'ssh:builder', 'remote-repo')
+      ]
+    })
+
+    expect(options.map((option) => option.id)).toEqual(['local', 'remote'])
+  })
+
   it('includes known hosts that still need project setup', () => {
     const options = buildProjectHostSetupOptions({
       projectId: 'project-1',

--- a/src/renderer/src/lib/project-host-setup-options.ts
+++ b/src/renderer/src/lib/project-host-setup-options.ts
@@ -136,6 +136,23 @@ function buildReadySetupOptions({
       detail: setup.displayName,
       path: setup.path
     }))
+    .filter(dedupeByHost())
+}
+
+// Why: a project resolves to at most one setup per host — resolveWorkspaceCreationTarget takes the
+// first project+host match and ignores the rest, so extra same-host setups are unreachable. Legacy
+// profiles can still hold them (a linked worktree added as its own project projects a second local
+// setup), which rendered as repeated identical "Local Mac" rows. Keep the first in input order so
+// the row shown is the one workspace creation actually uses.
+function dedupeByHost(): (option: ReadyProjectHostSetupOption) => boolean {
+  const seenHosts = new Set<ExecutionHostId>()
+  return (option) => {
+    if (seenHosts.has(option.hostId)) {
+      return false
+    }
+    seenHosts.add(option.hostId)
+    return true
+  }
 }
 
 function buildNeedsSetupOptions({

--- a/src/renderer/src/lib/project-host-workspace-target.test.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.test.ts
@@ -121,6 +121,51 @@ describe('project-host workspace target resolution', () => {
     })
   })
 
+  it('canonicalizes a stale same-host setup id to the setup the picker shows', () => {
+    // Why: the run-target picker renders one row per host. A draft persisted before that collapse
+    // can still name a duplicate local setup; creation must land in the displayed path, not a
+    // transient worktree path the user never sees.
+    const repos = [makeRepo('orca-main'), makeRepo('orca-worktree')]
+    const projects = [makeProject('github:stablyai/orca', ['orca-main', 'orca-worktree'])]
+    const projectHostSetups = [
+      makeSetup('orca-main', 'github:stablyai/orca', 'local', 'orca-main'),
+      makeSetup('orca-worktree', 'github:stablyai/orca', 'local', 'orca-worktree')
+    ]
+
+    const resolution = resolveWorkspaceCreationTarget({
+      eligibleRepos: repos,
+      projects,
+      projectHostSetups,
+      projectHostSetupId: 'orca-worktree'
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'ready',
+      target: { projectHostSetupId: 'orca-main', repoId: 'orca-main', hostId: 'local' }
+    })
+  })
+
+  it('keeps an explicit setup id that is the only one on its host', () => {
+    const repos = [makeRepo('orca-local'), makeRepo('orca-ssh', { connectionId: 'builder' })]
+    const projects = [makeProject('github:stablyai/orca', ['orca-local', 'orca-ssh'])]
+    const projectHostSetups = [
+      makeSetup('orca-local', 'github:stablyai/orca', 'local', 'orca-local'),
+      makeSetup('orca-ssh', 'github:stablyai/orca', 'ssh:builder', 'orca-ssh')
+    ]
+
+    expect(
+      resolveWorkspaceCreationTarget({
+        eligibleRepos: repos,
+        projects,
+        projectHostSetups,
+        projectHostSetupId: 'orca-ssh'
+      })
+    ).toMatchObject({
+      status: 'ready',
+      target: { projectHostSetupId: 'orca-ssh', repoId: 'orca-ssh', hostId: 'ssh:builder' }
+    })
+  })
+
   it('does not merge same-name repos without shared project identity', () => {
     const repos = [
       makeRepo('personal-orca', { displayName: 'orca' }),

--- a/src/renderer/src/lib/project-host-workspace-target.ts
+++ b/src/renderer/src/lib/project-host-workspace-target.ts
@@ -130,9 +130,17 @@ export function resolveWorkspaceCreationTarget(
     if (!isReadySetup(setup)) {
       return { status: 'unavailable', reason: 'setup-not-ready' }
     }
-    const target = createTarget(setup, repoById)
-    if (target) {
-      return { status: 'ready', target }
+    // Why: a project resolves to one setup per host, and the run-target picker shows only the first.
+    // A stale draft can still name a same-host duplicate from a legacy profile; canonicalize to the
+    // same setup the picker displays so the shown path is the path the workspace is created in.
+    const canonical =
+      findReadySetupTarget(
+        setups,
+        repoById,
+        (entry) => entry.projectId === setup.projectId && entry.hostId === setup.hostId
+      ) ?? createTarget(setup, repoById)
+    if (canonical) {
+      return { status: 'ready', target: canonical }
     }
     return { status: 'unavailable', reason: 'setup-not-found' }
   }


### PR DESCRIPTION
## Problem

The **Run on** picker in the Create Worktree dialog rendered several identical **Local Mac** rows for one project — same label, same icon, differing only by the path subtitle. Two of the three pointed at git worktree directories that no longer exist on disk.

<img src="https://github.com/stablyai/orca/blob/46243b35850b2e2f504fff2cfb30ae715ec88f62/run-on-before.png?raw=true" width="420" />

Worse than the visual noise: **only the first row was ever reachable.** `resolveWorkspaceCreationTarget` picks the first matching `projectId` + `hostId` setup and ignores the rest, so clicking rows 2 or 3 selected a target that silently resolved back to row 1's path. The dialog could show one path and create the workspace in another.

### Root cause

Three separate `Repo` records collapsed into a single project. Project identity is derived in `getProjectProviderIdentity` with a fallback chain — `upstream` → `repoIcon.label` → `gitRemoteIdentity`. A linked worktree of `stablyai/orca` carries `repoIcon.label: "stablyai/orca"`, identical to the main checkout, so all three landed on project `github:stablyai/orca`. The projection then emits **one `ProjectHostSetup` per `Repo`**, giving three `ready` setups on `hostId: local`, and the picker labels each row by *host*.

They became separate repos because `repos:add` deduped on **path only**. A linked worktree reports itself as its own `--show-toplevel`, so no path check can tell that it belongs to an already-tracked repo.

## ELI5

You have one toolbox in the garage. You also made two shortcuts to that toolbox on your desk. The app looked at all three, saw "toolbox," and listed **three toolboxes** — but only ever opened the garage one. Two shortcuts were pointing at drawers you'd already thrown away.

This PR (a) stops the app from filing a shortcut as a new toolbox, and (b) makes the list show one entry per place, so what you click is what you get.

## Changes

| File | Change |
|---|---|
| `src/main/git/repo.ts` | New `getLinkedWorktreeMainRepoRoot()` — returns the main checkout when a path is a *linked* worktree, else `null`. |
| `src/main/ipc/repos.ts` | `addLocalRepoFromPath` returns the tracked main checkout instead of adding a duplicate. **Prevents new duplicates.** |
| `src/renderer/src/lib/project-host-setup-options.ts` | `buildReadySetupOptions` dedupes ready options by host. **Fixes existing profiles.** |
| `src/renderer/src/lib/project-host-workspace-target.ts` | A stale draft naming a hidden same-host duplicate canonicalizes to the setup the picker shows. **Closes the shown-path ≠ created-path gap.** |

### On the detection method

`getLinkedWorktreeMainRepoRoot` compares `--git-dir` against `--git-common-dir` from a **single** `rev-parse` invocation — git's own canonical test. A linked worktree's git dir is `<common>/worktrees/<name>`; a main worktree's *equals* the common dir.

The first implementation compared `--show-toplevel` to `dirname(--git-common-dir)` and **misread main checkouts as linked worktrees on macOS** — git returns `--show-toplevel` symlink-resolved (`/private/var/...`) while `resolve()` yields `/var/...`. Both sides are now `realpath`-ed before comparison, which also handles git answering one flag absolutely and the other relative to cwd.

**Git 2.25 baseline:** both flags long predate it, and a relative answer resolves against `path` the way older git reports it.

## Evidence of fix

**Visible proof** — same dev profile, same three stale repo records still on disk, live-reproducing. Uncropped app state, one Local Mac row, correctly resolved to the real main checkout `/Users/nwparker/projects/orca`:

<img src="https://github.com/stablyai/orca/blob/46243b35850b2e2f504fff2cfb30ae715ec88f62/run-on-after.png?raw=true" width="900" />

Store state at capture time confirms the duplicates were still present and the fix is a *display + resolution* correction, not a data migration:

```json
{"projectId": "github:stablyai/orca", "setups": [
  {"host":"local", "path":"/Users/nwparker/projects/orca",                                 "state":"ready"},
  {"host":"local", "path":".../workspaces/orca/pr-3235-terminal-file-link-actions",        "state":"ready"},
  {"host":"local", "path":".../workspaces/orca/pr-1908-external-editor-links",             "state":"ready"},
  {"host":"ssh:ssh-1784717562259-ryvoxs", "path":"/home/neil/Documents/orca",              "state":"ready"}
]}
```

Three `local` setups in state → **one** `Local Mac` row rendered, and the `ssh` host still renders separately as `openclaw`.

**Tests** — 15 new tests across 4 files:

- `repo-detection.test.ts` — 7 tests against real `git worktree add`: linked worktree, main checkout, nested dir, bare repo, non-repo, missing path, git-unavailable. **31/31 pass.**
- `repos-add-linked-worktree.test.ts` *(new)* — 6 tests: returns tracked main checkout; still adds when main checkout is untracked; adds a normal repo; skips detection for `kind: 'folder'`; matches across Windows/POSIX separators; does **not** match a tracked SSH repo sharing the local path.
- `project-host-setup-options.test.ts` — dedupe keeps the setup creation actually uses; one choice per host across multiple hosts.
- `project-host-workspace-target.test.ts` — stale same-host id canonicalizes; a sole-on-host explicit id is preserved.

**Guard against vacuous tests:** stashed the 3 source files and confirmed **exactly 5 of the new tests fail** without the fix, then restored.

**Full sweep:** `1049 test files / 10973 tests passed, 0 failures` · `typecheck` clean · `lint` clean.

## Regressions

**None found.** Areas checked:

- **SSH / remote hosts** — dedupe is keyed on `ExecutionHostId`, so `local` and each `ssh:<id>` stay distinct rows; verified on screen (`openclaw` renders alongside `Local Mac`). The `repos:add` guard filters on `!repo.connectionId`, so a tracked SSH repo whose remote path coincides with a local main checkout is **not** matched — covered by a dedicated test.
- **Folder workspaces** — the guard is gated on `repoKind === 'git'`; folder workspaces never invoke worktree detection. Covered by a test.
- **Multi-host projects** — one row per host preserved; not collapsed to a single row.
- **Legitimately distinct projects** — dedupe is scoped per project's ready options, so two different projects each keep their own `Local Mac`.
- **Adding a worktree of an untracked repo** — still adds normally; the guard only fires when the main checkout is already tracked.
- **Cross-platform** — path comparison goes through the existing `normalizeRuntimePathForComparison`; separator-difference test included. No new platform-conditional logic.
- **Git compatibility** — no flags newer than the 2.25 baseline; every git failure path returns `null` and falls back to current behavior.

### Review follow-up (found in adversarial review)

The `repos:add` guard originally matched **any** tracked repo on the main-checkout path, including a `kind: 'folder'` record. A folder repo doesn't project onto the same project as the git worktree, so matching one would have suppressed a legitimate add while deduping nothing. The guard now also requires `!isFolderRepo(repo)`, with a regression test verified to fail without the fix (commit `8f4c3da`).

**Not covered:** no data migration — existing profiles keep the redundant `Repo` records, they're just no longer rendered or resolvable as separate targets. Removing them is a separate, riskier change (they may hold per-repo settings), so it's deliberately out of scope here.

**Also not covered — SSH duplicate *prevention*:** `addRemoteRepoFromPath` has no equivalent linked-worktree guard. `getLinkedWorktreeMainRepoRoot` is synchronous and local-only, while the SSH path resolves through the async `gitProvider.isGitRepoAsync`; covering it needs a new provider method, so it's a separate change. The renderer dedupe still fixes the **visible** symptom on SSH hosts — a remote project with duplicate same-host setups renders one row, and each distinct `ssh:<id>` host keeps its own row.

Made with [Orca](https://github.com/stablyai/orca) 🐋

