### PR TITLE
fix(macos): close both macOS 26 main-thread deadlock doors and restore the reveal reflow

### DIFF
--- a/src/main/appkit-scene-mutation.test.ts
+++ b/src/main/appkit-scene-mutation.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { deferAppKitSceneMutation } from './appkit-scene-mutation'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('deferAppKitSceneMutation', () => {
+  it('runs the mutation on a later turn, never inside the caller stack', () => {
+    const mutate = vi.fn()
+
+    deferAppKitSceneMutation(mutate)
+    expect(mutate).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(0)
+    expect(mutate).toHaveBeenCalledOnce()
+  })
+
+  it('keeps scheduled mutations in call order', () => {
+    const order: string[] = []
+
+    deferAppKitSceneMutation(() => order.push('first'))
+    deferAppKitSceneMutation(() => order.push('second'))
+    vi.advanceTimersByTime(0)
+
+    expect(order).toEqual(['first', 'second'])
+  })
+})

--- a/src/main/appkit-scene-mutation.ts
+++ b/src/main/appkit-scene-mutation.ts
@@ -1,0 +1,6 @@
+// Why: macOS 26 backs AppKit objects (windows, NSStatusItem) with scenes, and a scene
+// update sent re-entrantly from inside AppKit's own dispatch self-deadlocks the main
+// thread in FrontBoardServices; a fresh event-loop turn vacates that callout frame.
+export function deferAppKitSceneMutation(mutate: () => void): void {
+  setTimeout(mutate, 0)
+}

--- a/src/main/tray/system-tray.test.ts
+++ b/src/main/tray/system-tray.test.ts
@@ -142,7 +142,14 @@ function builtMenuItems(): MenuItem[] {
   return menuFromTemplateMock.mock.calls.at(-1)?.[0] as MenuItem[]
 }
 
+// Why: tray image/tooltip writes are deferred off the caller's stack to keep the
+// NSStatusItem scene update out of AppKit's dispatch; run the pending turn.
+function flushTraySceneMutation(): void {
+  vi.advanceTimersByTime(0)
+}
+
 beforeEach(() => {
+  vi.useFakeTimers()
   trayInstances.length = 0
   menuFromTemplateMock.mockClear()
   composeAttentionMock.mockClear()
@@ -180,6 +187,7 @@ beforeEach(() => {
 
 afterEach(() => {
   setPlatform(originalPlatform)
+  vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
@@ -296,6 +304,7 @@ describe('dev instance indicator', () => {
     createSystemTray(createOptions({ isDevInstance: true, devInstanceLabel: 'my-branch' }))
 
     setTrayAttention(true)
+    flushTraySceneMutation()
 
     expect(tintTemplateMock).toHaveBeenCalledWith(devBadgeImage, false)
   })
@@ -334,8 +343,10 @@ describe('dev instance indicator', () => {
     created.setToolTip.mockClear()
 
     setTrayAttention(true)
+    flushTraySceneMutation()
     expect(created.setToolTip).toHaveBeenCalledWith('Orca DEV (my-branch) - activity waiting')
     setTrayAttention(false)
+    flushTraySceneMutation()
     expect(created.setToolTip).toHaveBeenLastCalledWith('Orca DEV (my-branch)')
   })
 
@@ -388,9 +399,11 @@ describe('setTrayAttention', () => {
     created.setImage.mockClear()
 
     setTrayAttention(true)
+    flushTraySceneMutation()
     expect(composeAttentionMock).toHaveBeenCalledWith(resizedImage)
     expect(created.setImage).toHaveBeenCalledWith(attentionImage)
     setTrayAttention(false)
+    flushTraySceneMutation()
     expect(created.setImage).toHaveBeenLastCalledWith(resizedImage)
   })
 
@@ -403,6 +416,7 @@ describe('setTrayAttention', () => {
     created.setToolTip.mockClear()
 
     setTrayAttention(true)
+    flushTraySceneMutation()
     expect(tintTemplateMock).toHaveBeenCalledWith(baseMacImage, false)
     expect(composeAttentionMock).toHaveBeenCalledWith(tintedMacImage)
     // Why: the attention image is rebuilt from 1x pixels, so the @2x
@@ -417,6 +431,7 @@ describe('setTrayAttention', () => {
     expect(created.setToolTip).toHaveBeenCalledWith('Orca - activity waiting')
 
     setTrayAttention(false)
+    flushTraySceneMutation()
     expect(baseMacImage.setTemplateImage).toHaveBeenLastCalledWith(true)
     expect(created.setImage).toHaveBeenLastCalledWith(baseMacImage)
     expect(created.setToolTip).toHaveBeenLastCalledWith('Orca')
@@ -427,11 +442,15 @@ describe('setTrayAttention', () => {
     const { createSystemTray, setTrayAttention } = await loadModule()
     createSystemTray(createOptions())
     setTrayAttention(true)
+    flushTraySceneMutation()
     tintTemplateMock.mockClear()
     nativeThemeMock.shouldUseDarkColors = true
 
     themeState.updatedListener?.()
+    // Why: appearance changes arrive on an AppKit dispatch too, so the recompose defers.
+    expect(tintTemplateMock).not.toHaveBeenCalled()
 
+    flushTraySceneMutation()
     expect(tintTemplateMock).toHaveBeenCalledWith(baseMacImage, true)
   })
 
@@ -453,8 +472,72 @@ describe('setTrayAttention', () => {
 
     setTrayAttention(true)
     setTrayAttention(true)
+    flushTraySceneMutation()
 
     expect(created.setImage).toHaveBeenCalledTimes(1)
+  })
+
+  it('never touches the NSStatusItem scene inside the caller stack', async () => {
+    setPlatform('darwin')
+    const { createSystemTray, setTrayAttention } = await loadModule()
+    createSystemTray(createOptions())
+    const created = trayInstances[0]
+    created.setImage.mockClear()
+    created.setToolTip.mockClear()
+
+    // Why: show/restore call this from AppKit's window-state dispatch; a scene
+    // update sent there self-deadlocks the main thread on macOS 26.
+    setTrayAttention(true)
+    expect(created.setImage).not.toHaveBeenCalled()
+    expect(created.setToolTip).not.toHaveBeenCalled()
+
+    flushTraySceneMutation()
+    expect(created.setImage).toHaveBeenCalledWith(attentionImage)
+  })
+
+  it('collapses a burst of toggles into one deferred repaint', async () => {
+    setPlatform('darwin')
+    const { createSystemTray, setTrayAttention } = await loadModule()
+    createSystemTray(createOptions())
+    const created = trayInstances[0]
+    created.setImage.mockClear()
+
+    setTrayAttention(true)
+    setTrayAttention(false)
+    setTrayAttention(true)
+    flushTraySceneMutation()
+
+    expect(created.setImage).toHaveBeenCalledTimes(1)
+    expect(created.setImage).toHaveBeenCalledWith(attentionImage)
+  })
+
+  it('still dedupes after the deferred repaint has run', async () => {
+    setPlatform('darwin')
+    const { createSystemTray, setTrayAttention } = await loadModule()
+    createSystemTray(createOptions())
+    const created = trayInstances[0]
+    created.setImage.mockClear()
+
+    setTrayAttention(true)
+    flushTraySceneMutation()
+    setTrayAttention(true)
+    flushTraySceneMutation()
+
+    expect(created.setImage).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not throw when the tray is destroyed before the deferred repaint runs', async () => {
+    setPlatform('darwin')
+    const { createSystemTray, destroySystemTray, setTrayAttention } = await loadModule()
+    createSystemTray(createOptions())
+    const created = trayInstances[0]
+    created.setImage.mockClear()
+
+    setTrayAttention(true)
+    destroySystemTray()
+
+    expect(() => flushTraySceneMutation()).not.toThrow()
+    expect(created.setImage).not.toHaveBeenCalled()
   })
 
   it('keeps a pending attention dot across a macOS hide/show toggle', async () => {
@@ -514,7 +597,8 @@ describe('macOS hardening', () => {
       throw new Error('native image failure')
     })
 
-    expect(() => setTrayAttention(true)).not.toThrow()
+    setTrayAttention(true)
+    expect(() => flushTraySceneMutation()).not.toThrow()
     expect(created.setImage).toHaveBeenLastCalledWith(baseMacImage)
     expect(created.setToolTip).toHaveBeenLastCalledWith('Orca')
     expect(warn).toHaveBeenCalledWith(

--- a/src/main/tray/system-tray.ts
+++ b/src/main/tray/system-tray.ts
@@ -1,6 +1,7 @@
 import { Menu, Tray, nativeImage, nativeTheme, type NativeImage } from 'electron'
 import menuBarIconPath from '../../../resources/tray/orca-menu-barTemplate.png?asset&asarUnpack'
 import menuBarIconRetinaPath from '../../../resources/tray/orca-menu-barTemplate@2x.png?asset&asarUnpack'
+import { deferAppKitSceneMutation } from '../appkit-scene-mutation'
 import { createAppIconImage } from '../app-icon'
 import { translateMain } from '../i18n/main-i18n'
 import { composeTrayAttentionIcon, tintTrayTemplateForAttention } from './tray-attention-icon'
@@ -107,6 +108,23 @@ function applyTrayImage(): void {
   tray.setImage(attentionActive ? composeTrayAttentionIcon(baseTrayImage) : baseTrayImage)
 }
 
+// Why: collapse bursts (rapid show/hide) into one repaint; the deferred pass reads
+// current module state, so a dropped schedule can never land a stale icon.
+let trayImageRepaintPending = false
+
+// Why: tray.setImage/setToolTip drive an NSStatusItem scene update, which deadlocks
+// the main thread when sent from inside an AppKit callout; run it on a fresh turn.
+function scheduleTrayImage(): void {
+  if (trayImageRepaintPending) {
+    return
+  }
+  trayImageRepaintPending = true
+  deferAppKitSceneMutation(() => {
+    trayImageRepaintPending = false
+    applyTrayImage()
+  })
+}
+
 function createMacMenuBarImage(): NativeImage | null {
   const image = nativeImage.createFromPath(menuBarIconPath)
   const { width, height } = image.getSize()
@@ -172,7 +190,8 @@ function watchMacAppearance(): void {
   }
   nativeThemeUpdatedListener = () => {
     if (attentionActive) {
-      applyTrayImage()
+      // Why: 'updated' fires from AppKit's appearance-change dispatch.
+      scheduleTrayImage()
     }
   }
   nativeTheme.on('updated', nativeThemeUpdatedListener)
@@ -299,8 +318,10 @@ export function setTrayAttention(active: boolean): void {
   if (attentionActive === active) {
     return
   }
+  // Why: the dedup latch must settle synchronously or rapid show/hide mis-dedupes;
+  // only the native scene mutation moves off the caller's (AppKit) stack.
   attentionActive = active
-  applyTrayImage()
+  scheduleTrayImage()
 }
 
 /** Destroys the tray icon if present. Safe to call repeatedly or with no tray. */

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -531,6 +531,58 @@ describe('createMainWindow', () => {
     expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
   })
 
+  it('still reflows a maximized macOS 26 window, which the size nudge had to skip', () => {
+    vi.useFakeTimers()
+    macosTahoeMock.value = true
+    const windowHandlers = new Map<string, ((...args: any[]) => void)[]>()
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn(),
+      enableDeviceEmulation: vi.fn(),
+      disableDeviceEmulation: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        const handlers = windowHandlers.get(event) ?? []
+        handlers.push(handler)
+        windowHandlers.set(event, handlers)
+      }),
+      isDestroyed: vi.fn(() => false),
+      // Why: the maximized/fullscreen bail-out only ever protected setSize from un-maximizing
+      // the window; emulation leaves the frame alone, so the reflow must still happen here.
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => true),
+      getSize: vi.fn(() => [1200, 800]),
+      getContentSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    withPlatform('darwin', () => createMainWindow(null))
+
+    windowHandlers.get('show')?.[0]?.()
+    vi.advanceTimersByTime(300)
+
+    expect(webContents.enableDeviceEmulation).toHaveBeenCalled()
+    expect(webContents.disableDeviceEmulation).toHaveBeenCalled()
+    expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
+  })
+
   it('reflows without the size nudge when macOS 26 wakes from sleep', () => {
     vi.useFakeTimers()
     macosTahoeMock.value = true

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -481,7 +481,9 @@ describe('createMainWindow', () => {
       send: vi.fn(),
       isDevToolsOpened: vi.fn(),
       openDevTools: vi.fn(),
-      closeDevTools: vi.fn()
+      closeDevTools: vi.fn(),
+      enableDeviceEmulation: vi.fn(),
+      disableDeviceEmulation: vi.fn()
     }
     const browserWindowInstance = {
       webContents,
@@ -494,6 +496,7 @@ describe('createMainWindow', () => {
       isMaximized: vi.fn(() => false),
       isFullScreen: vi.fn(() => false),
       getSize: vi.fn(() => [1200, 800]),
+      getContentSize: vi.fn(() => [1200, 800]),
       setSize: vi.fn(),
       maximize: vi.fn(),
       show: vi.fn(),
@@ -513,6 +516,83 @@ describe('createMainWindow', () => {
     vi.advanceTimersByTime(300)
     expect(webContents.invalidate).toHaveBeenCalledTimes(2)
     expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
+
+    // Why (STA-2383): invalidate repaints but never reflows, so Tahoe still has to recompute the
+    // dvh root — via the emulated viewport, which leaves the deadlock-prone frame untouched.
+    expect(webContents.enableDeviceEmulation).toHaveBeenCalledWith({
+      screenPosition: 'desktop',
+      screenSize: { width: 1200, height: 801 },
+      viewPosition: { x: 0, y: 0 },
+      deviceScaleFactor: 0,
+      viewSize: { width: 1200, height: 801 },
+      scale: 1
+    })
+    expect(webContents.disableDeviceEmulation).toHaveBeenCalled()
+    expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
+  })
+
+  it('reflows without the size nudge when macOS 26 wakes from sleep', () => {
+    vi.useFakeTimers()
+    macosTahoeMock.value = true
+    const windowHandlers = new Map<string, ((...args: any[]) => void)[]>()
+    const webContents = {
+      on: vi.fn(),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn(),
+      enableDeviceEmulation: vi.fn(),
+      disableDeviceEmulation: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn((event: string, handler: (...args: any[]) => void) => {
+        const handlers = windowHandlers.get(event) ?? []
+        handlers.push(handler)
+        windowHandlers.set(event, handlers)
+      }),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => false),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      getContentSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    withPlatform('darwin', () => createMainWindow(null))
+
+    // Why: 'resume' is the other AppKit dispatch context implicated in the 109-minute freeze,
+    // so it must take the frame-free path too — not just show/restore.
+    const resumeHandler = powerMonitorOnMock.mock.calls.find(
+      ([event]) => event === 'resume'
+    )?.[1] as (() => void) | undefined
+    expect(resumeHandler).toBeDefined()
+    resumeHandler?.()
+
+    expect(webContents.invalidate).toHaveBeenCalled()
+    vi.advanceTimersByTime(300)
+    expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
+    expect(webContents.enableDeviceEmulation).toHaveBeenCalledWith({
+      screenPosition: 'desktop',
+      screenSize: { width: 1200, height: 801 },
+      viewPosition: { x: 0, y: 0 },
+      deviceScaleFactor: 0,
+      viewSize: { width: 1200, height: 801 },
+      scale: 1
+    })
+    expect(webContents.disableDeviceEmulation).toHaveBeenCalled()
   })
 
   it('supports all minus key variants for terminal zoom out', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -49,6 +49,7 @@ import { rectHasVisibleAreaOnAnyDisplay } from './window-bounds-validation'
 import { closeDashboardPopout } from './dashboard-popout-window'
 import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
 import { isMacosTahoeOrNewer } from './macos-tahoe-release'
+import { reflowRendererViewport } from './renderer-viewport-reflow'
 
 // Why: show/restore/resume can overlap before the size nudge resets; never capture the temporary width as the next baseline.
 const activeRepaintJiggles = new WeakSet<BrowserWindow>()
@@ -63,8 +64,10 @@ function forceRepaint(window: BrowserWindow): void {
   if (window.isMaximized() || window.isFullScreen() || activeRepaintJiggles.has(window)) {
     return
   }
-  // Why: macOS 26 scene-backed windows can deadlock the main thread on re-entrant frame updates; invalidate alone recovers the compositor there.
+  // Why: macOS 26 scene-backed windows deadlock the main thread on frame mutation, but invalidate
+  // alone never reflows the dvh root (STA-2383); emulation reflows without touching the frame.
   if (isMacosTahoeOrNewer()) {
+    reflowRendererViewport(window)
     return
   }
   activeRepaintJiggles.add(window)
@@ -75,16 +78,26 @@ function forceRepaint(window: BrowserWindow): void {
       return
     }
     const [width, height] = window.getSize()
-    window.setSize(width + 1, height)
-    setTimeout(() => {
-      if (!window.isDestroyed()) {
-        const [currentWidth, currentHeight] = window.getSize()
-        // Why: a real user resize during the jiggle owns the final bounds.
-        if (currentWidth === width + 1 && currentHeight === height) {
-          window.setSize(width, height)
-        }
-      }
+    // Why: if the nudge throws mid-flight the WeakSet entry must still clear, or this window
+    // never repaints again.
+    try {
+      window.setSize(width + 1, height)
+    } catch {
       activeRepaintJiggles.delete(window)
+      return
+    }
+    setTimeout(() => {
+      try {
+        if (!window.isDestroyed()) {
+          const [currentWidth, currentHeight] = window.getSize()
+          // Why: a real user resize during the jiggle owns the final bounds.
+          if (currentWidth === width + 1 && currentHeight === height) {
+            window.setSize(width, height)
+          }
+        }
+      } finally {
+        activeRepaintJiggles.delete(window)
+      }
     }, 32)
   }, 0)
 }

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -61,13 +61,15 @@ function forceRepaint(window: BrowserWindow): void {
     return
   }
   window.webContents.invalidate()
-  if (window.isMaximized() || window.isFullScreen() || activeRepaintJiggles.has(window)) {
-    return
-  }
   // Why: macOS 26 scene-backed windows deadlock the main thread on frame mutation, but invalidate
   // alone never reflows the dvh root (STA-2383); emulation reflows without touching the frame.
+  // Runs before the maximized/fullscreen bail-out below, which only exists to protect setSize —
+  // emulation leaves those states intact, and a maximized window goes stale just the same.
   if (isMacosTahoeOrNewer()) {
     reflowRendererViewport(window)
+    return
+  }
+  if (window.isMaximized() || window.isFullScreen() || activeRepaintJiggles.has(window)) {
     return
   }
   activeRepaintJiggles.add(window)

--- a/src/main/window/renderer-viewport-reflow.test.ts
+++ b/src/main/window/renderer-viewport-reflow.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import type { BrowserWindow } from 'electron'
+import { reflowRendererViewport, VIEWPORT_REFLOW_SETTLE_MS } from './renderer-viewport-reflow'
+
+function createWindow(overrides: Record<string, unknown> = {}): BrowserWindow {
+  const webContents = {
+    isDestroyed: vi.fn(() => false),
+    enableDeviceEmulation: vi.fn(),
+    disableDeviceEmulation: vi.fn()
+  }
+  return {
+    webContents,
+    isDestroyed: vi.fn(() => false),
+    getContentSize: vi.fn(() => [1200, 800]),
+    setSize: vi.fn(),
+    setBounds: vi.fn(),
+    ...overrides
+  } as unknown as BrowserWindow
+}
+
+describe('reflowRendererViewport', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('never mutates the native window frame', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.setSize).not.toHaveBeenCalled()
+    expect(window.setBounds).not.toHaveBeenCalled()
+  })
+
+  it('defers the emulation off the caller stack, then restores the real viewport', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    // Why: nothing may run while AppKit's callout frame is still on the stack.
+    expect(window.webContents.enableDeviceEmulation).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(0)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledWith({
+      screenPosition: 'desktop',
+      screenSize: { width: 1200, height: 801 },
+      viewPosition: { x: 0, y: 0 },
+      deviceScaleFactor: 0,
+      viewSize: { width: 1200, height: 801 },
+      scale: 1
+    })
+    expect(window.webContents.disableDeviceEmulation).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS)
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses a burst of reveals into one emulation cycle', () => {
+    const window = createWindow()
+    for (let i = 0; i < 5; i += 1) {
+      reflowRendererViewport(window)
+    }
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1)
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms once the cycle finishes', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips a window destroyed before the deferred turn runs', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.mocked(window.isDestroyed).mockReturnValue(true)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).not.toHaveBeenCalled()
+  })
+
+  it('skips a webContents destroyed before the deferred turn runs', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.mocked(window.webContents.isDestroyed).mockReturnValue(true)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).not.toHaveBeenCalled()
+  })
+
+  it('does not leave emulation on when the window dies mid-cycle', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(0)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1)
+
+    vi.mocked(window.isDestroyed).mockReturnValue(true)
+    expect(() => vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS)).not.toThrow()
+    expect(window.webContents.disableDeviceEmulation).not.toHaveBeenCalled()
+
+    // Why: a stuck latch would silently disable every later reflow for this window.
+    vi.mocked(window.isDestroyed).mockReturnValue(false)
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers the latch when enabling emulation throws', () => {
+    const window = createWindow()
+    vi.mocked(window.webContents.enableDeviceEmulation).mockImplementationOnce(() => {
+      throw new Error('Object has been destroyed')
+    })
+    reflowRendererViewport(window)
+    expect(() => vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)).not.toThrow()
+    // Why: nothing was applied, so no restore should be attempted.
+    expect(window.webContents.disableDeviceEmulation).not.toHaveBeenCalled()
+
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers the latch when disabling emulation throws', () => {
+    const window = createWindow()
+    vi.mocked(window.webContents.disableDeviceEmulation).mockImplementationOnce(() => {
+      throw new Error('Object has been destroyed')
+    })
+    reflowRendererViewport(window)
+    expect(() => vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)).not.toThrow()
+
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/window/renderer-viewport-reflow.test.ts
+++ b/src/main/window/renderer-viewport-reflow.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import type { BrowserWindow } from 'electron'
-import { reflowRendererViewport, VIEWPORT_REFLOW_SETTLE_MS } from './renderer-viewport-reflow'
+import {
+  reflowRendererViewport,
+  VIEWPORT_REFLOW_RESTORE_ATTEMPTS,
+  VIEWPORT_REFLOW_SETTLE_MS
+} from './renderer-viewport-reflow'
 
 function createWindow(overrides: Record<string, unknown> = {}): BrowserWindow {
   const webContents = {
@@ -123,16 +127,70 @@ describe('reflowRendererViewport', () => {
     expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
   })
 
-  it('recovers the latch when disabling emulation throws', () => {
+  it('retries the restore rather than stranding a live renderer at the overshot viewport', () => {
     const window = createWindow()
     vi.mocked(window.webContents.disableDeviceEmulation).mockImplementationOnce(() => {
-      throw new Error('Object has been destroyed')
+      throw new Error('transient failure')
     })
     reflowRendererViewport(window)
     expect(() => vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)).not.toThrow()
 
+    // Why: the webContents is still alive, so the emulated viewport is still applied — giving up
+    // here would leave the renderer stuck at the overshot height forever.
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(2)
+
+    // Why: the retry succeeded, so the latch is free and later reveals still reflow.
     reflowRendererViewport(window)
     vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
     expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
+  })
+
+  it('holds the latch while a restore is still being retried', () => {
+    const window = createWindow()
+    vi.mocked(window.webContents.disableDeviceEmulation).mockImplementation(() => {
+      throw new Error('still failing')
+    })
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+
+    // Why: stacking a second emulation over an unrestored viewport would compound the overshoot.
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops retrying the restore and re-arms after the attempt budget', () => {
+    const window = createWindow()
+    vi.mocked(window.webContents.disableDeviceEmulation).mockImplementation(() => {
+      throw new Error('always fails')
+    })
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS * (VIEWPORT_REFLOW_RESTORE_ATTEMPTS + 4))
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(
+      VIEWPORT_REFLOW_RESTORE_ATTEMPTS + 1
+    )
+
+    // Why: an unbounded retry would pin the latch and silently kill every later reflow.
+    vi.mocked(window.webContents.disableDeviceEmulation).mockImplementation(() => undefined)
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
+  })
+
+  it('abandons the restore once the webContents is gone', () => {
+    const window = createWindow()
+    vi.mocked(window.webContents.disableDeviceEmulation).mockImplementation(() => {
+      throw new Error('always fails')
+    })
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1)
+
+    // Why: a destroyed renderer takes its emulated viewport with it; retrying is pointless.
+    vi.mocked(window.webContents.isDestroyed).mockReturnValue(true)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS * 5)
+    expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/window/renderer-viewport-reflow.ts
+++ b/src/main/window/renderer-viewport-reflow.ts
@@ -1,0 +1,71 @@
+import type { BrowserWindow } from 'electron'
+
+// Why: long enough for the emulated viewport to reach the renderer and lay out, short enough
+// that a user never sees the 1px overshoot.
+export const VIEWPORT_REFLOW_SETTLE_MS = 32
+
+// Why: overlapping reveals must not stack emulation calls; the outer one owns the restore.
+const activeViewportReflows = new WeakSet<BrowserWindow>()
+
+function isWindowGone(window: BrowserWindow): boolean {
+  return window.isDestroyed() || window.webContents.isDestroyed()
+}
+
+/**
+ * Force the renderer to recompute its viewport without touching the native window frame.
+ *
+ * Why: `webContents.invalidate()` repaints but never reflows, so a stale `dvh` root keeps the
+ * status bar clipped off-screen (STA-2383). The frame jiggle that used to fix that mutates
+ * NSWindow, which self-deadlocks the main thread on macOS 26's scene-backed windows. Device
+ * emulation drives the same resize through the compositor instead — real reflow, no scene update.
+ */
+export function reflowRendererViewport(window: BrowserWindow): void {
+  if (activeViewportReflows.has(window) || isWindowGone(window)) {
+    return
+  }
+  activeViewportReflows.add(window)
+  // Why: reveal/resume fire from inside AppKit's dispatch; start on a fresh turn so nothing
+  // native runs while that callout frame is still on the stack.
+  setTimeout(() => {
+    if (isWindowGone(window)) {
+      activeViewportReflows.delete(window)
+      return
+    }
+    let emulating = false
+    try {
+      const [width, height] = window.getContentSize()
+      // Why: emulating the current size is a no-op — the +1 delta is what triggers the reflow.
+      const viewSize = { width, height: height + 1 }
+      window.webContents.enableDeviceEmulation({
+        screenPosition: 'desktop',
+        // Why: Electron types every field as required, so the rest carry their documented
+        // defaults — screenSize is mobile-only, and 0 keeps the real device scale factor.
+        screenSize: viewSize,
+        viewPosition: { x: 0, y: 0 },
+        deviceScaleFactor: 0,
+        viewSize,
+        scale: 1
+      })
+      emulating = true
+    } catch {
+      // Why: a teardown race can destroy the webContents mid-call; nothing was applied.
+    }
+    if (!emulating) {
+      activeViewportReflows.delete(window)
+      return
+    }
+    // Why: emulation must always be undone — leaving it on strands the renderer at the
+    // overshot viewport for the rest of the window's life.
+    setTimeout(() => {
+      try {
+        if (!isWindowGone(window)) {
+          window.webContents.disableDeviceEmulation()
+        }
+      } catch {
+        // Why: same teardown race; the emulated viewport dies with the webContents.
+      } finally {
+        activeViewportReflows.delete(window)
+      }
+    }, VIEWPORT_REFLOW_SETTLE_MS)
+  }, 0)
+}

--- a/src/main/window/renderer-viewport-reflow.ts
+++ b/src/main/window/renderer-viewport-reflow.ts
@@ -4,6 +4,10 @@ import type { BrowserWindow } from 'electron'
 // that a user never sees the 1px overshoot.
 export const VIEWPORT_REFLOW_SETTLE_MS = 32
 
+// Why: a restore that keeps failing on a live webContents would loop forever; give up and
+// release the latch so a later reveal can try a fresh cycle.
+export const VIEWPORT_REFLOW_RESTORE_ATTEMPTS = 3
+
 // Why: overlapping reveals must not stack emulation calls; the outer one owns the restore.
 const activeViewportReflows = new WeakSet<BrowserWindow>()
 
@@ -56,16 +60,28 @@ export function reflowRendererViewport(window: BrowserWindow): void {
     }
     // Why: emulation must always be undone — leaving it on strands the renderer at the
     // overshot viewport for the rest of the window's life.
-    setTimeout(() => {
-      try {
-        if (!isWindowGone(window)) {
-          window.webContents.disableDeviceEmulation()
-        }
-      } catch {
-        // Why: same teardown race; the emulated viewport dies with the webContents.
-      } finally {
-        activeViewportReflows.delete(window)
-      }
-    }, VIEWPORT_REFLOW_SETTLE_MS)
+    restoreRealViewport(window, 0)
   }, 0)
+}
+
+function restoreRealViewport(window: BrowserWindow, attempt: number): void {
+  setTimeout(() => {
+    if (isWindowGone(window)) {
+      // Why: the emulated viewport dies with the webContents, so there is nothing to restore.
+      activeViewportReflows.delete(window)
+      return
+    }
+    try {
+      window.webContents.disableDeviceEmulation()
+      activeViewportReflows.delete(window)
+    } catch {
+      // Why: the webContents is still alive, so the renderer is stuck at the overshot viewport;
+      // keep retrying and hold the latch so no second cycle stacks on the unrestored state.
+      if (attempt >= VIEWPORT_REFLOW_RESTORE_ATTEMPTS) {
+        activeViewportReflows.delete(window)
+        return
+      }
+      restoreRealViewport(window, attempt + 1)
+    }
+  }, VIEWPORT_REFLOW_SETTLE_MS)
 }


### PR DESCRIPTION
## Why

A user's app froze for 109 minutes on macOS 26 Tahoe (Darwin 25.5.0, v1.4.152) and had to be force-quit. macOS 26 backs AppKit objects with scenes, and a scene update sent re-entrantly from inside AppKit's own dispatch self-deadlocks the main thread in FrontBoardServices (`FBSScene _sendUpdate:` -> `BSServiceDispatchQueue performAsyncAndWait:` -> `_dispatch_event_loop_wait_for_ownership`). Because the freeze is on the main process, every telemetry path is silenced with it — the app just stops.

#10253 fixed the window half by skipping the repaint size nudge on macOS 26. This PR closes the remaining hole and repairs the regression that fix introduced.

## What this changes

**1. The reveal reflow was lost on macOS 26 (regression from #10253).**
`webContents.invalidate()` repaints but does not *reflow*, so the `h-dvh` app-shell root kept a stale dynamic-viewport height and the StatusBar stayed clipped below the viewport — the exact "no bottom bar" bug #10056 had just fixed. On Tahoe `forceRepaint` returned right after `invalidate()`, so every reveal, restore and wake got the known-insufficient behavior. Neither commit has shipped in a stable release, so this was caught before users saw it.

The fix drives the reflow through Chrome device emulation: a +1px emulated viewport, reverted a frame later. The renderer recomputes layout for real, and no NSWindow mutation ever happens — so the deadlock is still never reachable.

**2. The tray was a second, un-fixed door into the same deadlock.**
`window.on('show'/'restore')` calls `setTrayAttention(false)` straight from the AppKit handler, and `tray.setImage`/`setToolTip` drive an `NSStatusItem` scene update — the same re-entrant pattern, matching the stackshot in openai/codex#23695. The native mutation now runs on a fresh event-loop turn. The attention flag itself still flips synchronously, or rapid show/hide would mis-dedupe against a value that had not landed yet.

**3. Maximized and fullscreen windows never reflowed.**
That bail-out predates the Tahoe path and existed only to stop `setSize` from resizing a window out of those states. Emulation leaves the frame alone, so the guard was suppressing the reflow for nothing.

**4. A failed restore could strand the renderer.**
If `disableDeviceEmulation` threw while the `webContents` was still alive, the first version cleared its latch anyway — pinning the renderer at the overshot viewport for the window's lifetime and letting the next reveal stack another cycle on top. The restore now retries on a bounded schedule and holds the latch while a retry is pending.

**5. Two smaller defects found along the way.**
- The pre-Tahoe size jiggle could leak its `WeakSet` latch if `setSize` threw, permanently suppressing every later repaint for that window. Now cleared in a `finally`.
- The Tahoe test only drove `show`; `powerMonitor 'resume'` — the other dispatch context implicated in the incident — was uncovered. Now tested.

## Verification

Behavior was measured against real Electron 43.1.0 on macOS 26.3.1 (Darwin 25.3.0), not just mocks:

- the renderer receives the resize and relayouts; layout ends correct in every configuration tried
- `getSize()` is unchanged throughout — the native frame is never touched
- viewport and `devicePixelRatio` restore exactly, across zoom levels 0/+1/-1
- maximized and fullscreen windows reflow and stay maximized/fullscreen
- overlapping reveals collapse to one cycle; the latch re-arms after, and is held across retries
- window destroyed mid-cycle, and `enable`/`disable` throwing, leave no stuck emulation
- 40 aggressive show/hide/minimize/restore cycles against the combined window+tray logic, with the main thread continuously responsive
- **no SIGWINCH**: even with a pane tuned to sit exactly on an xterm row boundary — the worst case — the 32 ms revert lands before the fit stabilizes, so no pane reports new geometry. The old jiggle nudged *width*, which was strictly riskier.

Every new test was mutation-checked: reverting the corresponding fix makes it fail, so none pass vacuously.

`pnpm typecheck:node` clean, `oxlint` clean, full main-process suite green (**15,000 tests**).

## Limits worth stating

- **The original deadlock is not deterministically reproducible.** It is a race; repeated attempts on this machine (both sync frame and sync tray mutation from AppKit callouts) completed normally. The fix rests on the documented mechanism and the stackshots, plus the fact that the crashing v1.4.152 build mutated the frame *synchronously* inside the callout.
- **The dvh staleness itself did not reproduce locally either**, so item 1 is verified at the mechanism level — a real reflow reaches the renderer without touching the frame — rather than by observing the clipped status bar recover.
- With the renderer blocked past the 32 ms window, Chromium coalesces the intermediate viewport, so the renderer never observes the +1px step. Layout still ends correct, and the 250 ms second repaint plus the next reveal both retry.

## Notes

- Behavior on macOS < 26, Windows and Linux is unchanged apart from the added `try/finally`.
- One consequence at parity with what non-Tahoe macOS already did via the jiggle: an open text-selection popup or link bubble dismisses on reveal.
