### PR TITLE
fix(daemon): keep agent-completion detection alive on pre-v27 daemons

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -6,6 +6,7 @@ import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync
 import { DaemonClient } from './client'
 import { DaemonProtocolError } from './daemon-errors'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION } from './daemon-protocol-version'
 import { DaemonServer } from './daemon-server'
 import { HeadlessEmulator } from './headless-emulator'
 import { getHistorySessionDirName } from './history-paths'
@@ -924,6 +925,80 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       const { id } = await adapter.spawn({ cols: 80, rows: 24 })
       vi.mocked(lastSubprocess.getForegroundProcess).mockReturnValue('codex')
       expect(await adapter.getForegroundProcess(id)).toBe('codex')
+    })
+  })
+
+  describe('inspectProcess on pre-inspection daemon protocols', () => {
+    // Why: daemons outlive an in-place app update, so a v26 daemon must still answer inspections
+    // client-side; throwing here leaves agent-completion detection permanently retrying.
+    type ClientInternals = {
+      client: { request: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> }
+    }
+
+    function createLegacyAdapter(request: ReturnType<typeof vi.fn>): DaemonPtyAdapter {
+      const legacy = new DaemonPtyAdapter({
+        socketPath,
+        tokenPath,
+        protocolVersion: COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION - 1
+      })
+      ;(legacy as unknown as ClientInternals).client = { request, disconnect: vi.fn() }
+      return legacy
+    }
+
+    it('composes a real inspection from the foreground call the daemon does support', async () => {
+      const request = vi.fn(async () => ({ foregroundProcess: 'codex' }))
+      const legacy = createLegacyAdapter(request)
+
+      expect(await legacy.inspectProcess('sess-a')).toEqual({
+        foregroundProcess: 'codex',
+        hasChildProcesses: true
+      })
+      // Why: the fallback must not depend on a capability the legacy daemon lacks.
+      expect(request).toHaveBeenCalledWith('getForegroundProcess', { sessionId: 'sess-a' })
+      expect(request).not.toHaveBeenCalledWith('inspectProcess', expect.anything())
+
+      legacy.dispose()
+    })
+
+    it('reports an idle shell as having no child processes', async () => {
+      const legacy = createLegacyAdapter(vi.fn(async () => ({ foregroundProcess: 'bash' })))
+
+      expect(await legacy.inspectProcess('sess-a')).toEqual({
+        foregroundProcess: 'bash',
+        hasChildProcesses: false
+      })
+
+      legacy.dispose()
+    })
+
+    it('rejects rather than reading as idle when the daemon call fails', async () => {
+      // Why: getForegroundProcess swallows errors into null; composing through it would turn a dead
+      // socket into a false "agent exited" completion, the mirror of the bug this path fixes.
+      const legacy = createLegacyAdapter(
+        vi.fn(async () => {
+          throw new Error('socket_closed')
+        })
+      )
+
+      await expect(legacy.inspectProcess('sess-a')).rejects.toThrow('socket_closed')
+
+      legacy.dispose()
+    })
+
+    it('still delegates to the daemon once the protocol supports inspectProcess', async () => {
+      const request = vi.fn(async () => ({ foregroundProcess: 'codex', hasChildProcesses: true }))
+      const current = new DaemonPtyAdapter({
+        socketPath,
+        tokenPath,
+        protocolVersion: COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION
+      })
+      ;(current as unknown as ClientInternals).client = { request, disconnect: vi.fn() }
+
+      await current.inspectProcess('sess-a')
+
+      expect(request).toHaveBeenCalledWith('inspectProcess', { sessionId: 'sess-a' })
+
+      current.dispose()
     })
   })
 

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -971,6 +971,21 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       legacy.dispose()
     })
 
+    it('reports a null foreground as idle, matching what the legacy daemon can report', async () => {
+      // Why: pins the one response shape whose semantics differ from v27, where inspectProcess goes
+      // through getAliveSession() and throws for a vanished session while getForegroundProcess stays
+      // null-not-throw. Reading it as idle is deliberate — this is also the only shape that reaches a
+      // user-visible completion — so the divergence must not change silently.
+      const legacy = createLegacyAdapter(vi.fn(async () => ({ foregroundProcess: null })))
+
+      expect(await legacy.inspectProcess('sess-a')).toEqual({
+        foregroundProcess: null,
+        hasChildProcesses: false
+      })
+
+      legacy.dispose()
+    })
+
     it('rejects rather than reading as idle when the daemon call fails', async () => {
       // Why: getForegroundProcess swallows errors into null; composing through it would turn a dead
       // socket into a false "agent exited" completion, the mirror of the bug this path fixes.

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -818,17 +818,30 @@ export class DaemonPtyAdapter implements IPtyProvider {
     // No flow control for daemon-backed terminals
   }
 
-  async hasChildProcesses(id: string): Promise<boolean> {
-    const foregroundProcess = await this.getForegroundProcess(id)
-    // Why: daemon-backed PTYs can host long-lived agents while detached; cleanup prompts must not treat them as idle shells.
+  // Why: daemon-backed PTYs can host long-lived agents while detached; cleanup prompts must not treat them as idle shells.
+  private hasChildProcessesFromForeground(foregroundProcess: string | null): boolean {
     return foregroundProcess !== null && !isShellProcess(foregroundProcess)
+  }
+
+  async hasChildProcesses(id: string): Promise<boolean> {
+    return this.hasChildProcessesFromForeground(await this.getForegroundProcess(id))
   }
 
   async inspectProcess(
     id: string
   ): Promise<{ foregroundProcess: string | null; hasChildProcesses: boolean }> {
     if (this.protocolVersion < COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION) {
-      throw new Error('terminal_liveness_unavailable')
+      // Why: pre-v27 daemons survive an in-place app update; compose the inspection client-side from the
+      // one call they do support instead of throwing, or completion detection stays dead until recreate.
+      // Requests directly (not via getForegroundProcess) so a dead socket still rejects rather than
+      // reading as an idle foreground and dispatching a false completion.
+      const { foregroundProcess } = await this.client.request<{
+        foregroundProcess: string | null
+      }>('getForegroundProcess', { sessionId: id })
+      return {
+        foregroundProcess,
+        hasChildProcesses: this.hasChildProcessesFromForeground(foregroundProcess)
+      }
     }
     return this.client.request<{
       foregroundProcess: string | null


### PR DESCRIPTION
## Summary

Agent-finished notifications and title-driven agent status stayed permanently dead for any user who updated in place to 1.4.156 while agent terminals were open. Daemons deliberately survive app updates (`PREVIOUS_DAEMON_PROTOCOL_VERSIONS` spans v1–v27), so those PTYs keep routing through a pre-v27 adapter — and `DaemonPtyAdapter.inspectProcess()` threw instead of answering:

- `src/main/daemon/daemon-pty-adapter.ts:830-832` — threw `terminal_liveness_unavailable` when `protocolVersion < COMPLETION_PROCESS_INSPECTION_PROTOCOL_VERSION` (27).
- `src/main/providers/pty-process-inspection.ts:19-25` — the intended fallback only fires when a provider **lacks** `inspectProcess`. `DaemonPtyAdapter` always defines it (and `DaemonPtyRouter:192` / `DegradedDaemonPtyProvider:156` both delegate to it), so the fallback was unreachable and the throw propagated.
- `src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts:560-563` — swallows it into `consecutiveInspectionErrors`; `:635-639` caps backoff at ~10s, so it retried forever and never recovered.

Consequences for affected users: process-exit completions never dispatched (`:509-518`), and pending-title validation took the `!inspectionSucceeded -> dropPendingTitle()` path (`:579-581`). Both stayed broken until the terminal was recreated. The same code is reached by the `terminal.inspectProcess` RPC (`src/main/ipc/pty.ts:3806`) and the `pty:inspectProcess` IPC handler (`:5393`), so paired/mobile viewers lost it too.

**Fix:** when `protocolVersion < 27`, compose the inspection client-side instead of throwing. `hasChildProcesses` was already derived client-side from `getForegroundProcess` — which v26 fully supports — so the predicate is now shared via `hasChildProcessesFromForeground` and the two paths cannot drift. No new wire traffic, no new daemon capability, no behavior change for v27+.

**One deliberate deviation from the obvious composition:** it issues the `getForegroundProcess` RPC directly rather than calling `this.getForegroundProcess()`. That wrapper swallows RPC errors into `null` (`:852-862`), and `hasChildProcesses` is exactly the guard the coordinator uses at `:493` to suppress spurious completions. Composing through the swallowing wrapper would make a dropped daemon socket read as "idle foreground" and, after two samples, dispatch a **false** agent-finished completion — the mirror of the bug being fixed. Requesting directly preserves v27's semantics: transport failure rejects (`client.ts:196-207` throws on both `Not connected` and timeout) and the coordinator's error backoff handles it. A regression test pins this.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — clean (full `&&` chain through `verify:localization-coverage`).
- [x] `pnpm typecheck` — clean (all three tsconfig projects).
- [x] `pnpm test` — ran the affected suites, not the full repo suite (CI covers that): `daemon-pty-adapter` 114 passed; `daemon-pty-router` + `degraded-daemon-pty-provider` + `daemon-protocol-version` + `pty-process-inspection` + `terminal-host` 79 passed; `agent-completion-coordinator` 69 passed.
- [ ] `pnpm build` — not run locally; no build-surface change (no new deps, no config or native-module change).
- [x] Added or updated high-quality tests that would catch regressions.

**The new tests were verified to genuinely fail without the source change** by reverting only `daemon-pty-adapter.ts` to `origin/main` and re-running: 4 of the 5 fail with `Error: terminal_liveness_unavailable` (and `expected 'socket_closed' … got 'terminal_liveness_unavailable'`). The 5th asserts v27+ still delegates to the daemon RPC — it passes either way by design, guarding the version boundary against a future widening of the gate.

New tests cover: composition returns a real inspection on v26; an idle shell reports `hasChildProcesses: false`; a **null** foreground reads as idle (added in review — this is the one response shape whose semantics diverge from v27, and the only one that reaches a user-visible completion, so the deliberate choice is now pinned); a failing daemon call rejects rather than reading as idle; and v27+ still delegates to `inspectProcess`.

## AI Review Report

Reviewed by three independent subagents (correctness/coverage, tests/perf, adversarial) plus direct verification. All three returned **CONFIRM land-ready**; the one actionable finding (the null-foreground test gap) is fixed in this PR. Risks checked and outcomes:

- **Route coverage** — traced every caller of `inspectProcess`. Both entry points (`ipc/pty.ts:3806` runtime RPC, `:5393` IPC handler) go through `inspectPtyProviderProcess(getProviderForPty(...))`, and `DaemonPtyRouter.adapterForInspection` (`:357-366`) resolves to the session-owning adapter — which is exactly the legacy adapter in the bug scenario. `DegradedDaemonPtyProvider:156` delegates likewise. A third route also exists and is likewise fixed: `runtime/rpc/methods/terminal.ts:1165-1170` → `orca-runtime.ts:15821-15833` calls `ptyController.inspectProcess` directly. That one is worth calling out because `:15828` checks the method's *existence*, not its success, so pre-v27 it invoked the adapter, ate the throw, and never reached its own composition at `:15831-15832` — meaning the mobile/relay/web `terminal.inspectProcess` path was equally dead and is unwedged by this change. No route still reaches the throw.
- **No multi-daemon variant** — `adapterForInspection` (`:357-366`) has no fallback to `this.current`, unlike `adapterFor` (`:353-355`); it throws `terminal_gone`. So there is no "wrong adapter answers null → false completion" case.
- **Error-string coupling** — confirmed nothing depended on this path throwing `terminal_liveness_unavailable`. The other producers (`orca-runtime.ts` liveness/sleep flows, `remote-worktree-sleep.ts:55`, `web-preload-api.ts:2944`) come from `refreshPtyWorktreeRecordsFromController`, an unrelated path; that code is not orphaned.
- **Legacy `hasChildProcesses` correctness** — matches the v27 daemon-side derivation exactly: `terminal-host.ts:150-159` computes `foregroundProcess !== null && !isShellProcess(foregroundProcess)`, identical to the shared client-side predicate.
- **Performance** (this is a polling path, so it was measured, not assumed) — the legacy path issues **one** RPC per inspection, the same count as the v27 path, and the daemon serves `getForegroundProcess` from the same `session.getForegroundProcess()` call that v27's `inspectProcess` uses (`daemon-server.ts:916-921` → `terminal-host.ts` → `session.ts:454` → `pty-subprocess.ts:998`, a synchronous read of node-pty's `.process` plus a TTL-cached agent foreground; the heavy `ps`/PowerShell-CIM scan is scheduled out-of-band and throttled to ≤1/s per session, so there is no `/proc` walk or subprocess spawn on the request path). Per-call daemon cost is therefore identical to v27. `hasChildProcesses()` is not called on the same tick as `inspectProcess()`, so this is not 2 RPCs where there was 1. Absolute rates per terminal: ~80 RPC/min worst case in the active tier (750ms), 30 idle, 20 hidden, 4 no-evidence — under an app-wide ceiling of `MAX_INSPECTION_STARTS_PER_SECOND = 8` / `MAX_CONCURRENT_INSPECTIONS = 4` (`agent-process-inspection-queue.ts:8-9`) = 480 RPC/min regardless of terminal count. Net effect is that affected terminals resume the intended cadence instead of sitting in a 10s error-backoff loop making ~6 futile attempts/min and detecting nothing — that is the feature working, not fix overhead, and it costs no more than a healthy v27 daemon.
- **Cross-platform (macOS / Linux / Windows)** — explicitly checked. This change adds no path handling, no keyboard shortcut, no shell invocation and no platform branch; it is pure protocol-version gating plus a boolean derivation. The one platform-sensitive helper it reuses, `isShellProcess` (`src/shared/shell-process-detection.ts`), already normalizes Windows `.exe` basenames, and it is the same helper the v27 daemon path uses, so both paths behave identically on all three platforms. SSH hosts reach inspection through `ssh-pty-provider.ts:284` / the relay, not this adapter, so they are unaffected. Folder workspaces and git worktrees are equally unaffected — nothing here touches workspace shape.
- **Scope** — the diff is 21 lines of source in one method plus an extracted predicate, and tests. No unrelated refactor.

## Security Audit

No new attack surface. No input handling, command execution, path handling, auth, secrets, or dependency changes. The one added call reuses an existing daemon RPC (`getForegroundProcess`) with the same `{ sessionId }` payload the sibling method already sends over the same authenticated socket; no new IPC or RPC method is exposed and no handler signature changes. The change makes an error path *less* silent, which is the safer direction: a transport failure still rejects rather than being coerced into a benign-looking "idle" result. No follow-up needed.

## Notes

- **Not verified against a real pre-v27 daemon.** The v26 path is covered by a stubbed client because the in-repo test `DaemonServer` rejects a v26 handshake with `Protocol version mismatch`. The actual update-in-place scenario (live v26 daemon + 1.4.156 app) was not reproduced end-to-end, and the paired/mobile route via `pty.ts:3806` is reasoned from the call graph rather than exercised on a device.
- **Residual behavioral divergence, accepted deliberately and now pinned by a test.** v27's daemon-side `inspectProcess` uses `getAliveSession()`, which throws for a session the daemon no longer has; `getForegroundProcess` is intentionally null-not-throw (`terminal-host.ts:141-148`). So on the legacy path a vanished session reads as `{ foregroundProcess: null, hasChildProcesses: false }` where v27 would reject. This was examined closely because it is the only shape that can reach a user-visible notification, and it was judged **not** a reachable false completion: three independent guards would all have to fail at once — the `hasPty`/`activeSessionIds` pre-check throwing `terminal_gone` (`pty-process-inspection.ts:16-18`, `daemon-pty-adapter.ts:595-597`), the runtime route's stale-handle rejection (`orca-runtime.ts:9667-9672`), and the coordinator's requirement of two consecutive idle samples with a matching agent identity (`:499-508`). The only window is between the daemon dropping the session and the exit event retiring the pane, and that event arrives on the same connection that just answered, so by sample #2 `options.isLive()` is false and polling has stopped (`:531`, `:645`). Hardening it further would also buy nothing actionable: the `hasChildProcesses` guard at `:493` is *already* a no-op for every daemon-backed PTY including v27, because `terminal-host.ts:157` derives it from the same foreground string and so can never be `true` when the foreground is null or a shell — only relay/local providers do a real child check (`relay/pty-handler.ts:1404`). Spending a second RPC on a 750ms poll to recover a distinction the coordinator cannot act on, inside a window the exit event already closes, is a bad trade. A regression test now pins the chosen semantics.
- v26 daemons report foreground process slightly less precisely than v27's server-side inspection, so completion detection may be marginally noisier there. A single bad sample still cannot announce completion; two consecutive idle samples are required.
- Protocol versions below v26 fall out of this gate too. The `getForegroundProcess` RPC only landed at `PROTOCOL_VERSION = 11` (commit `519a120828`) while `PREVIOUS_DAEMON_PROTOCOL_VERSIONS` reaches back to v1, so a v1–v10 daemon rejects with `Unknown request type` (`daemon-server.ts:1029` → `ok: false` → `client.ts:421-425`). That is behaviorally identical to the pre-fix throw, so it is a strict non-regression, and such daemons predate this fallback's target window anyway.
- Reinforcing evidence for the deviation being load-bearing rather than stylistic: protocol 27 was introduced by `7ab601487c` — *"fix(remote): don't classify a stale/gone remote handle as agent completion (#9263)"*. Composing through the swallowing wrapper would undo that very fix on the legacy route. And because legacy adapters are built with no `respawn` closure against a protocol-specific socket path (`daemon-init.ts:1063-1071`), a dead legacy daemon stays dead — so the wrapper would mark *every* pane on it agent-finished, not just one.
