### PR TITLE
fix(terminal): stop cold restore dropping all scrollback on large checkpoints

### DIFF
--- a/src/main/daemon/history-reader-memory.test.ts
+++ b/src/main/daemon/history-reader-memory.test.ts
@@ -22,6 +22,8 @@ import {
   TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS
 } from './terminal-history-file-reader'
 
+const RETIRED_CHECKPOINT_READ_CAP_BYTES = 16 * 1024 * 1024
+
 const directories: string[] = []
 
 function createSession(sessionId: string): { basePath: string; sessionPath: string } {
@@ -49,7 +51,7 @@ function createSparseFile(path: string, bytes: number): void {
   closeSync(descriptor)
 }
 
-function checkpoint(): string {
+function checkpoint(overrides?: Record<string, unknown>): string {
   return JSON.stringify({
     snapshotAnsi: 'safe checkpoint',
     scrollbackAnsi: '',
@@ -62,7 +64,8 @@ function checkpoint(): string {
       mouseTracking: false,
       applicationCursor: false,
       alternateScreen: false
-    }
+    },
+    ...overrides
   })
 }
 
@@ -82,6 +85,18 @@ describe('terminal history restore memory limits', () => {
     expect(restore?.snapshotAnsi).toBe('safe checkpoint')
   })
 
+  // Why: the read cap once sat at 16MiB while the writer stayed unbounded, so a big-scrollback
+  // session cold-restored to an empty terminal — checkpoint nulled, and every fallback collapsed.
+  it('restores a checkpoint larger than the retired 16MiB read cap', async () => {
+    const { basePath, sessionPath } = createSession('large-checkpoint')
+    const scrollbackAnsi = 'x'.repeat(RETIRED_CHECKPOINT_READ_CAP_BYTES + 1)
+    writeFileSync(join(sessionPath, 'checkpoint.json'), checkpoint({ scrollbackAnsi }))
+
+    const restore = await new HistoryReader(basePath).detectColdRestore('large-checkpoint')
+    expect(restore?.scrollbackAnsi).toBe(scrollbackAnsi)
+  })
+
+  // Why the cap survives at all: it bounds a corrupt/runaway file, well above legitimate output.
   it('ignores oversized checkpoint and metadata files before parsing', async () => {
     const checkpointSession = createSession('oversized-checkpoint')
     createSparseFile(

--- a/src/main/daemon/history-reader-memory.test.ts
+++ b/src/main/daemon/history-reader-memory.test.ts
@@ -99,10 +99,13 @@ describe('terminal history restore memory limits', () => {
   // Why the cap survives at all: it bounds a corrupt/runaway file, well above legitimate output.
   it('ignores oversized checkpoint and metadata files before parsing', async () => {
     const checkpointSession = createSession('oversized-checkpoint')
-    createSparseFile(
-      join(checkpointSession.sessionPath, 'checkpoint.json'),
-      TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES + 1
-    )
+    const oversizedCheckpoint = join(checkpointSession.sessionPath, 'checkpoint.json')
+    createSparseFile(oversizedCheckpoint, TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES + 1)
+    // Why assert the reader directly too: detectColdRestore returns null for any unparseable
+    // checkpoint, so it would stay green with the byte cap removed entirely.
+    expect(() =>
+      readTerminalHistoryJson(oversizedCheckpoint, TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES)
+    ).toThrow(/File too large/)
     expect(
       await new HistoryReader(checkpointSession.basePath).detectColdRestore('oversized-checkpoint')
     ).toBeNull()

--- a/src/main/daemon/terminal-history-file-limits.ts
+++ b/src/main/daemon/terminal-history-file-limits.ts
@@ -1,4 +1,10 @@
+import { LEGACY_TERMINAL_SCROLLBACK_BYTES_100_MB } from '../../shared/terminal-scrollback-policy'
+
 export const TERMINAL_HISTORY_META_MAX_BYTES = 64 * 1024
 export const TERMINAL_HISTORY_LOG_MAX_BYTES = 5 * 1024 * 1024
-export const TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES = 16 * 1024 * 1024
+// Why 2x the policy's 100MB budget for the 50k-row max preset: the checkpoint writer is
+// unbounded, and a read cap under what it can emit silently drops ALL scrollback on cold
+// restore. Guards corruption, not retention; 2x covers JSON escaping, where each ANSI ESC
+// serializes to a 6-byte unicode escape.
+export const TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES = 2 * LEGACY_TERMINAL_SCROLLBACK_BYTES_100_MB
 export const TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES = 16 * 1024 * 1024

--- a/src/main/daemon/terminal-history-file-limits.ts
+++ b/src/main/daemon/terminal-history-file-limits.ts
@@ -1,10 +1,8 @@
-import { LEGACY_TERMINAL_SCROLLBACK_BYTES_100_MB } from '../../shared/terminal-scrollback-policy'
-
 export const TERMINAL_HISTORY_META_MAX_BYTES = 64 * 1024
 export const TERMINAL_HISTORY_LOG_MAX_BYTES = 5 * 1024 * 1024
-// Why 2x the policy's 100MB budget for the 50k-row max preset: the checkpoint writer is
-// unbounded, and a read cap under what it can emit silently drops ALL scrollback on cold
-// restore. Guards corruption, not retention; 2x covers JSON escaping, where each ANSI ESC
-// serializes to a 6-byte unicode escape.
-export const TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES = 2 * LEGACY_TERMINAL_SCROLLBACK_BYTES_100_MB
+// Why deliberately generous: the checkpoint writer is unbounded, and a read cap under what it
+// can emit silently drops ALL scrollback on cold restore. This guards a corrupt/runaway file,
+// not retention — a 50k-row max-preset buffer serializes far below it, so overshooting costs a
+// one-off sub-second parse while undershooting loses the user's entire terminal.
+export const TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES = 200_000_000
 export const TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES = 16 * 1024 * 1024

--- a/src/main/daemon/terminal-history-file-limits.ts
+++ b/src/main/daemon/terminal-history-file-limits.ts
@@ -2,7 +2,7 @@ export const TERMINAL_HISTORY_META_MAX_BYTES = 64 * 1024
 export const TERMINAL_HISTORY_LOG_MAX_BYTES = 5 * 1024 * 1024
 // Why deliberately generous: the checkpoint writer is unbounded, and a read cap under what it
 // can emit silently drops ALL scrollback on cold restore. This guards a corrupt/runaway file,
-// not retention — a 50k-row max-preset buffer serializes far below it, so overshooting costs a
-// one-off sub-second parse while undershooting loses the user's entire terminal.
+// not retention — a 50k-row max preset of ordinary text serializes to ~14MB, ~15x under. Output
+// colored per cell can still exceed this; trimming the snapshot writer-side is the real fix.
 export const TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES = 200_000_000
 export const TERMINAL_HISTORY_LEGACY_SCROLLBACK_MAX_BYTES = 16 * 1024 * 1024


### PR DESCRIPTION
## Summary

Cold restore silently loses **all** terminal scrollback when `checkpoint.json` exceeds 16 MiB. This release shipped a READ bound without its matching WRITE bound.

**Read side is bounded:** `src/main/daemon/history-reader.ts:80-86` reads the checkpoint via `readTerminalHistoryJsonAsync(..., TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES)`, where the constant was `16 * 1024 * 1024`. `src/shared/node-bounded-file-reader.ts:26-28` throws past the cap, and the bare `catch` at `history-reader.ts:84-86` swallows it to `checkpoint = null`.

**Write side is not:** `src/main/daemon/history-manager.ts:210` is a plain `JSON.stringify(checkpointFile)` with no bound.

**Every fallback then collapses**, so the failure is total, not partial:
- `restoreFromIncrementalLog` takes `else if (log.generation !== 0) return null` (`history-reader.ts:207`); any session that has ever checkpointed has `generation >= 1`.
- The legacy `scrollback.bin` was unlinked at `openSession`.

`detectColdRestore` returns `null` and the terminal reopens **empty, with nothing surfaced to the user**.

At `v1.4.155` the checkpoint was read unbounded, so this failure mode did not exist. #10179 introduced both halves; the revert in #10255 reclaimed the writer but could not reclaim the reader, because #9990 had already landed on `history-reader.ts`. `git diff v1.4.155..origin/main -- src/main/daemon/history-manager.ts` is empty, confirming the writer sits at exactly the release base.

**The fix:** raise the read cap to `200_000_000`. A bound is retained, so a corrupt or runaway file still cannot read unboundedly into the main process.

### Why not bound the writer instead

Restoring `stringifyJsonWithinByteLimit` at `history-manager.ts:210` **would not recover the lost scrollback**, and would trade one silent failure for a worse one:

1. The throw lands in the same `try`, whose `catch` calls `handleWriteError` → `this.disabledSessions.add(sessionId)` (`history-manager.ts:328-331`). That permanently stops **all** history writes for that session — `appendIncrements` (`:148`) and `checkpoint` (`:179`) both return early thereafter.
2. It would not even be observable: `onWriteError` is never wired in production. The sole non-test construction site is `new HistoryManager(opts.historyPath)` at `src/main/daemon/daemon-pty-adapter.ts:181`, with no options object.

So option (a) converts a per-restore silent failure into a per-session permanent one, with zero observability.

### Reachability — stated honestly

On a real heavy-use machine, 1279 `checkpoint.json` files at the default 5000-row preset max out at 0.97 MiB (mean 0.05 MiB, none above 8 MiB) — roughly 16x under the old cap. Realistic exposure is the 25k/50k row presets combined with dense output. **Narrow but real** — and when it hits, the loss is silent and total.

## Screenshots

No visual change. This PR changes one numeric constant and a test file.

## Testing

- [x] `oxlint` — clean on both changed files
- [x] `npm run typecheck` — clean, all three tsconfigs
- [x] `pnpm test` — full daemon suite: **68 files passed / 2 skipped (70)**, **1029 tests passed / 5 skipped (1034)**
- [ ] `pnpm build` — **not run.** The change is one numeric constant plus a test file, with no build-surface change. Flagging rather than ticking.
- [x] `oxfmt --check` — "All matched files use the correct format". `check:max-lines-ratchet` clean, no new bypasses.
- [x] Added high-quality tests that would catch regressions — see below

Two tests, both proven to fail when their guard is removed:

1. **New:** `restores a checkpoint larger than the retired 16MiB read cap`. Pinning `TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES` back to `16 * 1024 * 1024` makes it fail with `expected undefined to be 'xxx…'` — `detectColdRestore` returning `null`, precisely the silent-empty-restore symptom.
2. **Repaired:** `ignores oversized checkpoint and metadata files before parsing` previously asserted only `detectColdRestore(...) === null`, which was **vacuous** — 200MB of NUL bytes fails `JSON.parse` regardless, so the test stayed green with the byte cap disabled entirely (it merely slowed from 1ms to 1489ms). It now also asserts the bounded reader directly (`expect(() => readTerminalHistoryJson(...)).toThrow(/File too large/)`), the idiom already used at `:129-131`. Verified two ways: with the size check in `node-bounded-file-reader` stubbed out, the old form passed 4/4 while the new form fails.

Note this test previously asserted that an oversized checkpoint restores to `null`. That assertion was written when the writer guaranteed such a file could not exist; it encoded the broken asymmetry rather than protecting against it, so it was re-scoped rather than defended.

Not executed: no live Electron cold restore of a real >16 MiB session — the fix is exercised through `detectColdRestore` at the unit level, not through an actual crash-and-reopen. Not run on Windows, Linux, SSH, or WSL.

## AI Review Report

Three independent review rounds, each re-reviewing the prior round's output until one returned clean. Risks checked: the read/write asymmetry itself, the write-side alternative, main-process memory and latency on the startup path, test validity, scope creep, and cross-platform behavior.

**Round 1 — flagged the cap's derivation as false.** The constant was introduced as `2 * LEGACY_TERMINAL_SCROLLBACK_BYTES_100_MB`, justified as "the policy's 100MB budget for the 50k-row max preset." No such budget exists: `legacyTerminalScrollbackBytesToRows` maps anything `>= 75_000_000` to 50k rows, so that bucket has **no upper byte bound**, and the anchor is a frozen migration input with no other consumer — a dead constant made the sole anchor of a live memory bound. The claimed drift protection was illusory, since the writer has no byte bound to drift under. Changed to a literal `200_000_000` (identical value, zero behavior change) with the actual reasoning stated. Real drift protection is the >16MiB regression test, not the expression.

**Round 2 — found the vacuous test above**, and corrected the comment's remaining overclaim to a measured figure.

**Round 3 — returned clean**, no changes.

**Cross-platform:** explicitly checked for macOS, Linux, and Windows. The change is a platform-independent integer with no path, shell, shortcut, or Electron-specific behavior, so macOS/Linux/Windows/WSL/SSH behavior is identical. The one platform note is the oversized-file test fixture, now `200,000,001` bytes: sparse and free on APFS/ext4. This test never runs on Windows in CI — `pr.yml` is a single `ubuntu-latest` job, the only Windows vitest job (`computer-e2e.yml:82-95`) uses a file allowlist that excludes it, and `win-crash-survival-e2e.yml` path-filters `!src/**/*.test.*`. On local Windows, libuv's `ftruncate` maps to `SetEndOfFile`; NTFS tracks Valid Data Length, so the region is allocated rather than zero-filled. The new test costs 76ms; the whole file runs in ~387ms.

**Performance — the key question, measured rather than estimated.** At the 200MB cap on Node 26: read 12-15ms (async, yields), `toString('utf8')` 21-77ms, structural scan 472-478ms, `JSON.parse` 87-168ms — **~593-723ms of synchronous main-thread stall, ~360-630MB transient RSS**. `MAX_STRING_LENGTH` (536,870,888) is not reachable at this cap. Note this read runs in the Electron **main** process (`DaemonPtyAdapter` is constructed at `daemon-init.ts:666`), not in the forked PTY server, and it happens *before* `coldRestoreReplaySemaphore.acquire` (`history-reader.ts:187`), so N parallel pane mounts each hold their own copy.

The cap was deliberately not lowered. The failure is asymmetric: undershooting means silent, total scrollback loss (this bug), while overshooting costs a one-off sub-second stall on a file that must be corrupt or pathological to exist. A 64MB cap would bound the stall at ~230ms but re-opens the silent-blank failure for exactly the 25k/50k users this PR exists to protect.

**On JSON escaping (raised in review and withdrawn).** JSON expansion is exactly `1 + 5f` where `f` is the fraction of bytes that are C0 controls, so exceeding 2x needs **>20% of all bytes to be control characters**. Measured against a real `@xterm/headless` + `SerializeAddon` pipeline: 1.01x plain, 1.13x SGR-dense, 1.15x per-cell truecolor, 2.00x at the densest reachable shape (19.96% ESC). The 6x all-ESC figure is not reachable — decisively, feeding `Buffer.alloc(4096, 0x1b)` through the real terminal yields a serialized length of **0**. The checkpoint is `SerializeAddon` output regenerated from the parsed buffer (`headless-emulator.ts`), not raw PTY bytes, so bare ESC cannot reach `checkpoint.json` at all.

## Security Audit

No new input-handling, command-execution, path-handling, auth, secrets, dependency, or IPC surface. The change relaxes a resource bound on an already-existing read path.

The relevant risk is denial-of-service via resource exhaustion, and it is a **real increase**: a malicious or corrupt `checkpoint.json` can now pull up to 200MB into main-process memory instead of 16 MiB. Mitigating factors: the file is written by the app itself into its own user-scoped history directory (not attacker-supplied over any network or IPC boundary), a bound is still enforced before any allocation (`validateSize` throws on `stats.size` before `Buffer.allocUnsafe`), and this is the same exposure `v1.4.155` shipped with.

One finding for follow-up, not fixed here — see Notes.

## Notes

**Residual risk, stated plainly:**

1. **The cap is stated, not derived.** No invariant stops the writer drifting past it. The previous derivation implied such protection but did not provide it.
2. **The writer remains unbounded** at `history-manager.ts:210`, so this is a guard, not a guarantee. Measured through the real serializer, a 50k-row max preset of ordinary text is ~4.1MB at 80 cols, ~10.1MB at 200 cols, and ~13.8MB at 200 cols with 6 SGR runs per row — comfortably under. But **per-cell-colored output can exceed even 200MB**: image rendering (`chafa`, `viu`) filling a 50k-row buffer extrapolates to ~391MB serialized, which hits this same silent-drop path. That figure is extrapolated from a 2,000-row run; the 50k-row run OOM'd the serializer. **No read-cap value fixes this case** — only bounding the writer's snapshot does. This is the real follow-up.
3. **The swallowing `catch` at `history-reader.ts:84-86` is unchanged**, so any future checkpoint read failure remains silent. Left alone deliberately to keep this PR to one concern.
4. **A second silent-drop path exists on that same catch, and is not fixed here.** `TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS = 1_000_000` (`terminal-history-file-reader.ts:7`) meets an unbounded `oscLinks` array (`daemon-checkpoint-file.ts:11`; `headless-osc-link-ranges.ts` applies no cap). Each `{row,startCol,endCol,uri}` entry is ~10 structural tokens, so roughly 100,000 OSC-8 hyperlinks trips the limit and throws into the same catch, producing an identical empty restore. `ls --hyperlink=auto` across a 50k-row buffer can plausibly reach that. Worth a follow-up.
5. **Memory/latency ceiling rose** — see the measured figures above. Most notable on memory-constrained hosts.

**On the structural-token guard:** it does not defend this file shape. The checkpoint is a flat object whose payload is a few giant *string values*, and the scanner skips string interiors — a 200MB checkpoint counts ~34 structural tokens against a 1,000,000 limit. It defends a different shape (many small nodes), and via unbounded `oscLinks` it is itself a drop path (4 above).
