### PR TITLE
fix(mobile): heal an orphaned native-chat image paste across screen unmounts

### DIFF
--- a/mobile/src/session/mobile-native-chat-permission-send.test.ts
+++ b/mobile/src/session/mobile-native-chat-permission-send.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it, vi } from 'vitest'
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
-import { sendMobileNativeChatPermissionResponse } from './mobile-native-chat-permission-send'
+import {
+  sendMobileNativeChatPermissionResponse,
+  useMobileNativeChatPermissionSend
+} from './mobile-native-chat-permission-send'
+import {
+  isMobileNativeChatInputStale,
+  markMobileNativeChatInputStale,
+  resetMobileNativeChatStaleInputForTests
+} from './mobile-native-chat-stale-input'
 
 describe('sendMobileNativeChatPermissionResponse', () => {
   it('writes an approval as raw bytes without appending Return', async () => {
@@ -39,5 +49,52 @@ describe('sendMobileNativeChatPermissionResponse', () => {
         text: '1'
       })
     ).resolves.toBe('unknown')
+  })
+})
+
+describe('useMobileNativeChatPermissionSend', () => {
+  let renderer: ReactTestRenderer | null = null
+  let respond: ((text: string) => Promise<boolean>) | null = null
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    resetMobileNativeChatStaleInputForTests()
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+    respond = null
+  })
+
+  it('keeps the marker for a permission choice, which never submits the composer', async () => {
+    const sendRequest = vi.fn().mockResolvedValue({
+      ok: true,
+      result: { send: { handle: 'terminal', accepted: true, bytesWritten: 1 } }
+    })
+    function Harness(): null {
+      respond = useMobileNativeChatPermissionSend({
+        client: { sendRequest } as unknown as RpcClient,
+        enabled: true,
+        handleRef: { current: 'terminal' },
+        deviceTokenRef: { current: null },
+        onSendError: vi.fn()
+      })
+      return null
+    }
+    act(() => {
+      renderer = create(createElement(Harness))
+    })
+    markMobileNativeChatInputStale('terminal')
+
+    await act(async () => {
+      await expect(respond?.('1')).resolves.toBe(true)
+    })
+    // A choice is a bare key for a live overlay that swallows a clear while the
+    // host still acks it, so healing here would burn the marker and leave the
+    // paste to corrupt the next real message. Only the choice may go.
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '1', enter: false })
+    expect(isMobileNativeChatInputStale('terminal')).toBe(true)
   })
 })

--- a/mobile/src/session/mobile-native-chat-permission-send.ts
+++ b/mobile/src/session/mobile-native-chat-permission-send.ts
@@ -36,6 +36,9 @@ export function useMobileNativeChatPermissionSend(args: {
         args.onSendError('Response not sent (disconnected)')
         return false
       }
+      // No stale-input heal here (unlike the text/ask sends): a choice is an
+      // `enter: false` key for an active overlay that swallows the clear, so it
+      // would consume the marker still protecting the next real message.
       const outcome = await sendMobileNativeChatPermissionResponse({
         client: args.client,
         terminal,

--- a/mobile/src/session/mobile-native-chat-stale-input.test.ts
+++ b/mobile/src/session/mobile-native-chat-stale-input.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import {
+  clearMobileNativeChatInputStale,
+  healMobileNativeChatStaleInput,
+  isMobileNativeChatInputStale,
+  markMobileNativeChatInputStale,
+  resetMobileNativeChatStaleInputForTests
+} from './mobile-native-chat-stale-input'
+
+function sendResult(accepted: boolean) {
+  return {
+    id: 'send',
+    ok: true as const,
+    result: { send: { accepted } },
+    _meta: { runtimeId: 'runtime' }
+  }
+}
+
+function makeClient(accepted = true): Pick<RpcClient, 'sendRequest'> {
+  return { sendRequest: vi.fn().mockResolvedValue(sendResult(accepted)) }
+}
+
+describe('mobile native chat stale input markers', () => {
+  beforeEach(() => {
+    resetMobileNativeChatStaleInputForTests()
+  })
+
+  it('tracks each terminal independently', () => {
+    markMobileNativeChatInputStale('term-1')
+    expect(isMobileNativeChatInputStale('term-1')).toBe(true)
+    expect(isMobileNativeChatInputStale('term-2')).toBe(false)
+    clearMobileNativeChatInputStale('term-1')
+    expect(isMobileNativeChatInputStale('term-1')).toBe(false)
+  })
+
+  it('writes nothing when the terminal is not marked', async () => {
+    const client = makeClient()
+    await expect(
+      healMobileNativeChatStaleInput({ client, terminal: 'term-1', deviceToken: null })
+    ).resolves.toBe(true)
+    expect(client.sendRequest).not.toHaveBeenCalled()
+  })
+
+  it('clears the line and consumes the marker', async () => {
+    const client = makeClient()
+    markMobileNativeChatInputStale('term-1')
+    await expect(
+      healMobileNativeChatStaleInput({ client, terminal: 'term-1', deviceToken: 'device' })
+    ).resolves.toBe(true)
+    expect(client.sendRequest).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(client.sendRequest).mock.calls[0]?.[1]).toMatchObject({
+      terminal: 'term-1',
+      text: '\x15',
+      enter: false,
+      client: { id: 'device', type: 'mobile' }
+    })
+    expect(isMobileNativeChatInputStale('term-1')).toBe(false)
+  })
+
+  it('keeps the marker when the host rejects the clear', async () => {
+    const client = makeClient(false)
+    markMobileNativeChatInputStale('term-1')
+    await expect(
+      healMobileNativeChatStaleInput({ client, terminal: 'term-1', deviceToken: null })
+    ).resolves.toBe(false)
+    expect(isMobileNativeChatInputStale('term-1')).toBe(true)
+  })
+
+  it('keeps the marker when the clear throws', async () => {
+    const client = { sendRequest: vi.fn().mockRejectedValue(new Error('offline')) }
+    markMobileNativeChatInputStale('term-1')
+    await expect(
+      healMobileNativeChatStaleInput({ client, terminal: 'term-1', deviceToken: null })
+    ).resolves.toBe(false)
+    expect(isMobileNativeChatInputStale('term-1')).toBe(true)
+  })
+})

--- a/mobile/src/session/mobile-native-chat-stale-input.ts
+++ b/mobile/src/session/mobile-native-chat-stale-input.ts
@@ -1,0 +1,63 @@
+import type { RpcClient } from '../transport/rpc-client'
+import { pasteMobileNativeChatImagePaths } from './mobile-native-chat-image-send'
+
+// The condition tracked here — a bracketed image paste left sitting on the agent's
+// unsubmitted input line — lives on the HOST terminal, so it outlives any one
+// session screen. Keyed by terminal handle at module scope: React state died with
+// the screen and let the orphaned paste glue onto the next message (#10228).
+const staleInputTerminals = new Set<string>()
+
+export function markMobileNativeChatInputStale(terminal: string): void {
+  staleInputTerminals.add(terminal)
+}
+
+export function isMobileNativeChatInputStale(terminal: string): boolean {
+  return staleInputTerminals.has(terminal)
+}
+
+export function clearMobileNativeChatInputStale(terminal: string): void {
+  staleInputTerminals.delete(terminal)
+}
+
+/** Test-only: module scope outlives a single test's hooks. */
+export function resetMobileNativeChatStaleInputForTests(): void {
+  staleInputTerminals.clear()
+}
+
+/** Clears a marked terminal's unsubmitted input line before a write that could
+ *  submit it, consuming the marker only once the host accepts the clear.
+ *
+ *  Returns true when the line is safe to submit (nothing marked, or cleared);
+ *  false when a needed clear failed — the marker stays set for the next attempt
+ *  and the caller must not submit, or the stale paste rides along with it.
+ *
+ *  Only for writes that can commit the composer. Pure dialog control (permission
+ *  choices, Escape) is `enter: false` against an overlay that swallows the keys,
+ *  so a clear there would not reach the input line yet would still consume the
+ *  marker — leaving the next real message to be corrupted by the paste. */
+export async function healMobileNativeChatStaleInput(args: {
+  readonly client: Pick<RpcClient, 'sendRequest'>
+  readonly terminal: string
+  readonly deviceToken: string | null
+}): Promise<boolean> {
+  if (!isMobileNativeChatInputStale(args.terminal)) {
+    return true
+  }
+  let cleared = false
+  try {
+    cleared = await pasteMobileNativeChatImagePaths({
+      client: args.client,
+      terminal: args.terminal,
+      deviceToken: args.deviceToken,
+      imagePaths: []
+    })
+  } catch {
+    // Leave marked for the next attempt.
+    return false
+  }
+  if (!cleared) {
+    return false
+  }
+  clearMobileNativeChatInputStale(args.terminal)
+  return true
+}

--- a/mobile/src/session/mobile-native-chat-stale-input.ts
+++ b/mobile/src/session/mobile-native-chat-stale-input.ts
@@ -31,10 +31,12 @@ export function resetMobileNativeChatStaleInputForTests(): void {
  *  false when a needed clear failed — the marker stays set for the next attempt
  *  and the caller must not submit, or the stale paste rides along with it.
  *
- *  Only for writes that can commit the composer. Pure dialog control (permission
- *  choices, Escape) is `enter: false` against an overlay that swallows the keys,
- *  so a clear there would not reach the input line yet would still consume the
- *  marker — leaving the next real message to be corrupted by the paste. */
+ *  Only for writes that can commit the composer. Dialog control (permission
+ *  choices, Escape) and selector answers carry no commit — the host coerces their
+ *  `enter` to false — and go to an active overlay that swallows the keys, so a
+ *  clear there would not reach the input line yet would still consume the marker,
+ *  leaving the next real message to be corrupted by the paste. The host acks a
+ *  write, never a cleared line, so consumption can't be made conditional on it. */
 export async function healMobileNativeChatStaleInput(args: {
   readonly client: Pick<RpcClient, 'sendRequest'>
   readonly terminal: string

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -6,6 +6,11 @@ import type { RpcClient } from '../transport/rpc-client'
 import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import { MOBILE_NATIVE_CHAT_QUESTION_STEP_MS } from './mobile-native-chat-answer-stepping'
 import type { AskPrompt } from './mobile-native-chat-ask'
+import {
+  isMobileNativeChatInputStale,
+  markMobileNativeChatInputStale,
+  resetMobileNativeChatStaleInputForTests
+} from './mobile-native-chat-stale-input'
 import { useMobileNativeChatAnswerSend } from './use-mobile-native-chat-answer-send'
 
 type AnswerSend = ReturnType<typeof useMobileNativeChatAnswerSend>
@@ -39,6 +44,7 @@ describe('useMobileNativeChatAnswerSend', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    resetMobileNativeChatStaleInputForTests()
   })
 
   afterEach(() => {
@@ -227,6 +233,40 @@ describe('useMobileNativeChatAnswerSend', () => {
     // Grok's question tool commits the pasted answer: label text + one Enter.
     expect(sendRequest).toHaveBeenCalledTimes(1)
     expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: 'Spaces', enter: true })
+  })
+
+  it('clears an orphaned image paste before an answer that commits with Enter (#10228)', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, vi.fn(), 'grok')
+    // An earlier image send left its path on this terminal's composer line.
+    markMobileNativeChatInputStale('terminal')
+
+    await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
+    // Without the leading clear, the pasted label + Enter would submit
+    // "<image path>Spaces" as one prompt.
+    expect(sendRequest).toHaveBeenCalledTimes(2)
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '\x15', enter: false })
+    expect(sendRequest.mock.calls[1]?.[1]).toMatchObject({ text: 'Spaces', enter: true })
+    expect(isMobileNativeChatInputStale('terminal')).toBe(false)
+  })
+
+  it('does not answer when the healing clear is rejected, keeping the marker', async () => {
+    const onSendError = vi.fn()
+    const sendRequest = vi.fn().mockResolvedValue({
+      id: 'send',
+      ok: true as const,
+      result: { send: { accepted: false } },
+      _meta: { runtimeId: 'runtime' }
+    })
+    await mount({ sendRequest } as unknown as RpcClient, onSendError, 'grok')
+    markMobileNativeChatInputStale('terminal')
+
+    await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(false)
+    // Only the clear was attempted; the answer must not ride on a dirty line.
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '\x15', enter: false })
+    expect(onSendError).toHaveBeenCalledWith('Answer not sent')
+    expect(isMobileNativeChatInputStale('terminal')).toBe(true)
   })
 
   it('stops at the first rejected write and reports failure', async () => {

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -250,6 +250,20 @@ describe('useMobileNativeChatAnswerSend', () => {
     expect(isMobileNativeChatInputStale('terminal')).toBe(false)
   })
 
+  it('keeps the marker for a selector answer, which cannot submit the composer', async () => {
+    const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
+    await mount({ sendRequest } as unknown as RpcClient, vi.fn(), 'claude')
+    markMobileNativeChatInputStale('terminal')
+
+    await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
+    // A single-select answer is a bare option digit against a live overlay: the
+    // clear would be swallowed but still acked, burning the marker and leaving the
+    // paste to corrupt the next real message. Only the digit may go.
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '2', enter: false })
+    expect(isMobileNativeChatInputStale('terminal')).toBe(true)
+  })
+
   it('does not answer when the healing clear is rejected, keeping the marker', async () => {
     const onSendError = vi.fn()
     const sendRequest = vi.fn().mockResolvedValue({

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -10,6 +10,7 @@ import {
   type AskPrompt
 } from './mobile-native-chat-ask'
 import { sendMobileNativeChatMessageWithOutcome } from './mobile-native-chat-send'
+import { healMobileNativeChatStaleInput } from './mobile-native-chat-stale-input'
 import {
   resolveNativeChatTranscriptAgent,
   shouldStepNativeChatAskAnswer
@@ -102,6 +103,22 @@ export function useMobileNativeChatAnswerSend(args: {
       // A new answer supersedes any still-pending keystroke writes.
       cancelPending()
       const generation = generationRef.current
+      // Both answer shapes commit with Enter, so an orphaned image paste left on
+      // the composer would be submitted along with the answer if the overlay has
+      // already gone away (#10228). Clear it before the first keystroke.
+      if (
+        !(await healMobileNativeChatStaleInput({
+          client,
+          terminal: handle,
+          deviceToken: deviceTokenRef.current
+        }))
+      ) {
+        onSendError('Answer not sent')
+        return false
+      }
+      if (generationRef.current !== generation) {
+        return false
+      }
       let sawUnknownOutcome = false
       const sendTerminal = async (body: string, enter: boolean): Promise<boolean> => {
         const activeRoute = activeRouteRef.current

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -103,22 +103,6 @@ export function useMobileNativeChatAnswerSend(args: {
       // A new answer supersedes any still-pending keystroke writes.
       cancelPending()
       const generation = generationRef.current
-      // Both answer shapes commit with Enter, so an orphaned image paste left on
-      // the composer would be submitted along with the answer if the overlay has
-      // already gone away (#10228). Clear it before the first keystroke.
-      if (
-        !(await healMobileNativeChatStaleInput({
-          client,
-          terminal: handle,
-          deviceToken: deviceTokenRef.current
-        }))
-      ) {
-        onSendError('Answer not sent')
-        return false
-      }
-      if (generationRef.current !== generation) {
-        return false
-      }
       let sawUnknownOutcome = false
       const sendTerminal = async (body: string, enter: boolean): Promise<boolean> => {
         const activeRoute = activeRouteRef.current
@@ -172,6 +156,29 @@ export function useMobileNativeChatAnswerSend(args: {
       // Grok commits pasted labels; Claude and Codex need their selector-specific
       // keystrokes paced so each step renders before the next lands.
       if (!shouldStepNativeChatAskAnswer(agentRef.current)) {
+        // This shape pastes the label into the composer and commits it, so an
+        // orphaned image paste would be submitted along with the answer (#10228).
+        // The selector shapes below deliberately skip the heal: their keys are
+        // `enter: false` for an active overlay, and a single-select answer is a
+        // bare option digit that cannot submit the line at all, so clearing there
+        // would consume the marker still protecting the next real message.
+        // Desktop splits it identically — use-native-chat-interactive-send.ts
+        // routes only the pasted-label shape through the clearing sender.
+        if (
+          !(await healMobileNativeChatStaleInput({
+            client,
+            terminal: handle,
+            deviceToken: deviceTokenRef.current
+          }))
+        ) {
+          if (generationRef.current === generation) {
+            onSendError('Answer not sent')
+          }
+          return false
+        }
+        if (generationRef.current !== generation) {
+          return false
+        }
         return (await sendTerminal(formatAskAnswer(prompt, selections), true)) || fail()
       }
       const groups =

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -46,6 +46,11 @@ vi.mock('./mobile-native-chat-send', () => ({
 
 import { sendMobileNativeChatMessageWithOutcome } from './mobile-native-chat-send'
 import {
+  isMobileNativeChatInputStale,
+  markMobileNativeChatInputStale,
+  resetMobileNativeChatStaleInputForTests
+} from './mobile-native-chat-stale-input'
+import {
   useMobileNativeChatController,
   type MobileNativeChatController
 } from './use-mobile-native-chat-controller'
@@ -64,10 +69,13 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
   let renderer: ReactTestRenderer | null = null
   let controller: MobileNativeChatController | null = null
   const onSendError = vi.fn()
+  // Only the stale-input heal reaches the transport directly (the message send
+  // itself is mocked above).
+  const clientStub = { sendRequest: vi.fn() }
 
   function Harness(): null {
     controller = useMobileNativeChatController({
-      client: {} as RpcClient,
+      client: clientStub as unknown as RpcClient,
       hostId: 'h',
       worktreeId: 'w',
       activeSessionTab: null,
@@ -84,6 +92,7 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     vi.clearAllMocks()
+    resetMobileNativeChatStaleInputForTests()
     captureSendOrigin.mockReturnValue(ORIGIN)
     const original = console.error
     const spy = vi.spyOn(console, 'error').mockImplementation((...a) => {
@@ -104,6 +113,49 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
     act(() => renderer?.unmount())
     renderer = null
     controller = null
+  })
+
+  it('clears an orphaned image paste before a question-card answer (#10228)', async () => {
+    // The chat overlay wires the question card straight to this send, bypassing
+    // the image hook that used to own the only heal.
+    markMobileNativeChatInputStale('term-1')
+    clientStub.sendRequest.mockResolvedValue({
+      id: 'send',
+      ok: true,
+      result: { send: { accepted: true } },
+      _meta: { runtimeId: 'r' }
+    })
+    sendWithOutcome.mockResolvedValue('accepted')
+    let accepted = false
+    await act(async () => {
+      accepted = await controller!.handleNativeChatSend('answer')
+    })
+    expect(accepted).toBe(true)
+    expect(clientStub.sendRequest).toHaveBeenCalledTimes(1)
+    expect(clientStub.sendRequest.mock.calls[0]?.[1]).toMatchObject({
+      terminal: 'term-1',
+      text: '\x15',
+      enter: false
+    })
+    expect(isMobileNativeChatInputStale('term-1')).toBe(false)
+  })
+
+  it('does not send when the healing clear is rejected, keeping the marker', async () => {
+    markMobileNativeChatInputStale('term-1')
+    clientStub.sendRequest.mockResolvedValue({
+      id: 'send',
+      ok: true,
+      result: { send: { accepted: false } },
+      _meta: { runtimeId: 'r' }
+    })
+    let accepted = true
+    await act(async () => {
+      accepted = await controller!.handleNativeChatSend('answer')
+    })
+    expect(accepted).toBe(false)
+    expect(sendWithOutcome).not.toHaveBeenCalled()
+    expect(onSendError).toHaveBeenCalledWith('Message not sent')
+    expect(isMobileNativeChatInputStale('term-1')).toBe(true)
   })
 
   it('threads the optimistic-echo image URIs into acceptSend on an accepted send', async () => {

--- a/mobile/src/session/use-mobile-native-chat-controller.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.test.ts
@@ -158,6 +158,20 @@ describe('useMobileNativeChatController handleNativeChatSend', () => {
     expect(isMobileNativeChatInputStale('term-1')).toBe(true)
   })
 
+  it('keeps the marker when Escape cancels an ask, which never submits the composer', async () => {
+    markMobileNativeChatInputStale('term-1')
+    sendWithOutcome.mockResolvedValue('accepted')
+    let accepted = false
+    await act(async () => {
+      accepted = await controller!.handleNativeChatCancelAsk()
+    })
+    expect(accepted).toBe(true)
+    // The clear would be swallowed by the live overlay but still acked, burning
+    // the marker and leaving the paste to corrupt the next real message.
+    expect(clientStub.sendRequest).not.toHaveBeenCalled()
+    expect(isMobileNativeChatInputStale('term-1')).toBe(true)
+  })
+
   it('threads the optimistic-echo image URIs into acceptSend on an accepted send', async () => {
     sendWithOutcome.mockResolvedValue('accepted')
     let accepted = false

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -21,6 +21,7 @@ import {
   sendMobileNativeChatMessageWithOutcome,
   type MobileNativeChatSendOutcome
 } from './mobile-native-chat-send'
+import { healMobileNativeChatStaleInput } from './mobile-native-chat-stale-input'
 import { useMobileNativeChatAnswerSend } from './use-mobile-native-chat-answer-send'
 import {
   useMobileNativeChatDrafts,
@@ -184,6 +185,8 @@ export function useMobileNativeChatController(args: {
       return false
     }
     cancelNativeChatAnswer()
+    // Escape never submits the composer, so no stale-input heal: it would consume
+    // the marker still protecting the next real message.
     const outcome = await sendMobileNativeChatMessageWithOutcome({
       client,
       terminal: handle,
@@ -239,6 +242,14 @@ export function useMobileNativeChatController(args: {
       const origin = captureSendOrigin(text)
       if (!client || !handle || !origin || !nativeChatInputLeaseReady) {
         onSendError('Message not sent (disconnected)')
+        return 'rejected'
+      }
+      // The composer may still hold an orphaned image paste from an earlier send
+      // (#10228); submitting on top of it would glue the image onto this message.
+      // Also covers question-card answers, which reach this send directly.
+      const healArgs = { client, terminal: handle, deviceToken: deviceTokenRef.current }
+      if (!(await healMobileNativeChatStaleInput(healArgs))) {
+        onSendError('Message not sent')
         return 'rejected'
       }
       const outcome = await sendMobileNativeChatMessageWithOutcome({

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.test.ts
@@ -3,6 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcResponse, RpcSuccess } from '../transport/types'
+import { resetMobileNativeChatStaleInputForTests } from './mobile-native-chat-stale-input'
 import { useMobileNativeChatImageAttachments } from './use-mobile-native-chat-image-attachments'
 
 // Fully stub the picker so the real expo/react-native chain never loads under
@@ -84,6 +85,9 @@ describe('useMobileNativeChatImageAttachments', () => {
   beforeEach(() => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     pick.mockReset()
+    // Stale markers live at module scope now (they outlive the screen), so they
+    // also outlive a test.
+    resetMobileNativeChatStaleInputForTests()
   })
   afterEach(() => {
     act(() => renderer?.unmount())
@@ -545,6 +549,42 @@ describe('useMobileNativeChatImageAttachments', () => {
     expect(sendCalls).toHaveLength(3)
     expect(sendCalls[2]?.params).toMatchObject({ text: '\x15', enter: false })
     expect(baseSend).toHaveBeenNthCalledWith(1, 'pic', ['file:///a.jpg'])
+    expect(baseSend).toHaveBeenNthCalledWith(2, 'later message')
+  })
+
+  it('still heals after the session screen unmounts and remounts (#10228)', async () => {
+    pick.mockResolvedValue({ base64: 'AAAA', uri: 'file:///a.jpg' })
+    const client = makeClient([
+      methodNotFound('start'),
+      ok('save', '/tmp/a.png'),
+      sendResult(true), // Ctrl+U clear
+      sendResult(true), // image paste accepted — path now sits on term-1's input
+      sendResult(true) // healing Ctrl+U on the remounted screen
+    ])
+    const baseSend = vi.fn().mockResolvedValueOnce('unknown').mockResolvedValueOnce('accepted')
+    mount(baseArgs({ client: client as unknown as RpcClient, baseSend }))
+    await act(async () => {
+      await hook!.attachImage('library')
+    })
+    await act(async () => {
+      await hook!.sendNativeChat('pic')
+    })
+
+    // Back out of the session screen and return. The orphaned paste sits on the
+    // HOST's input line, so a fresh hook must still know to clear it.
+    act(() => renderer!.unmount())
+    renderer = null
+    mount(baseArgs({ client: client as unknown as RpcClient, baseSend }))
+    expect(hook!.attachments).toEqual([])
+
+    let accepted = false
+    await act(async () => {
+      accepted = await hook!.sendNativeChat('later message')
+    })
+    expect(accepted).toBe(true)
+    const sendCalls = client.calls.filter((c) => c.method === 'terminal.send')
+    expect(sendCalls).toHaveLength(3)
+    expect(sendCalls[2]?.params).toMatchObject({ terminal: 'term-1', text: '\x15', enter: false })
     expect(baseSend).toHaveBeenNthCalledWith(2, 'later message')
   })
 

--- a/mobile/src/session/use-mobile-native-chat-image-attachments.ts
+++ b/mobile/src/session/use-mobile-native-chat-image-attachments.ts
@@ -16,6 +16,12 @@ import {
   pasteMobileNativeChatImagePaths
 } from './mobile-native-chat-image-send'
 import type { MobileNativeChatSendOutcome } from './mobile-native-chat-send'
+import {
+  clearMobileNativeChatInputStale,
+  healMobileNativeChatStaleInput,
+  isMobileNativeChatInputStale,
+  markMobileNativeChatInputStale
+} from './mobile-native-chat-stale-input'
 
 type CurrentRef<T> = { readonly current: T }
 type ShowToast = (message: string, durationMs?: number) => void
@@ -77,10 +83,6 @@ function withScopeAttachments(
   return remaining
 }
 
-function markTerminalInputStale(staleInputs: Set<string>, terminal: string): void {
-  staleInputs.add(terminal)
-}
-
 const defaultSleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -109,8 +111,6 @@ export function useMobileNativeChatImageAttachments({
   // checked 'connected' at entry, so only a ref can see a mid-upload disconnect.
   const connStateRef = useRef(connState)
   connStateRef.current = connState
-  // Terminals whose input may hold a failed paste; each must heal independently.
-  const staleInputTerminalsRef = useRef(new Set<string>())
   // Serialize clear/paste/submit ownership per terminal while allowing other tabs to send.
   const sendInFlightTerminalsRef = useRef(new Set<string>())
 
@@ -220,25 +220,15 @@ export function useMobileNativeChatImageAttachments({
           // otherwise glue the stale image paste onto this message. Best-effort —
           // on failure the marker stays set and the text must not be submitted.
           const staleTerminal = activeHandleRef.current
-          if (staleTerminal && staleInputTerminalsRef.current.has(staleTerminal) && client) {
-            let cleared = false
-            try {
-              cleared = await pasteMobileNativeChatImagePaths({
-                client,
-                terminal: staleTerminal,
-                deviceToken: deviceTokenRef.current,
-                imagePaths: []
-              })
-            } catch {
-              // Leave marked for the next attempt.
-            }
-            if (!cleared) {
-              onError?.()
-              showToast('Message not sent', 1500)
-              return false
-            }
-            staleInputTerminalsRef.current.delete(staleTerminal)
-            if (activeHandleRef.current !== staleTerminal) {
+          if (staleTerminal && isMobileNativeChatInputStale(staleTerminal) && client) {
+            const healed = await healMobileNativeChatStaleInput({
+              client,
+              terminal: staleTerminal,
+              deviceToken: deviceTokenRef.current
+            })
+            // A tab switch during the clear would send this text to a terminal the
+            // clear never touched, so abort rather than reroute it.
+            if (!healed || activeHandleRef.current !== staleTerminal) {
               onError?.()
               showToast('Message not sent', 1500)
               return false
@@ -263,13 +253,13 @@ export function useMobileNativeChatImageAttachments({
           })
           if (!pasted) {
             // Keep the chips so the user can retry; the failed paste never submitted.
-            markTerminalInputStale(staleInputTerminalsRef.current, handle)
+            markMobileNativeChatInputStale(handle)
             onError?.()
             showToast('Message not sent', 1500)
             return false
           }
           // The paste's leading Ctrl+U cleared any earlier stale input in `handle`.
-          staleInputTerminalsRef.current.delete(handle)
+          clearMobileNativeChatInputStale(handle)
           // Let the TUI absorb the image paste before the text + Enter follow. The
           // preview URIs ride along to baseSend so the sent bubble shows the photo
           // immediately (empty text still submits a bare Enter through baseSend).
@@ -278,7 +268,7 @@ export function useMobileNativeChatImageAttachments({
           // route the text + Enter to a different terminal than the images. Abort —
           // the chips keep their scope and a retry's Ctrl+U clears the stale paste.
           if (activeHandleRef.current !== handle) {
-            markTerminalInputStale(staleInputTerminalsRef.current, handle)
+            markMobileNativeChatInputStale(handle)
             onError?.()
             showToast('Message not sent', 1500)
             return false
@@ -291,7 +281,7 @@ export function useMobileNativeChatImageAttachments({
             // 'rejected' leaves the pasted image path on this input line; 'unknown'
             // may have lost the text+Enter AFTER the paste landed, orphaning the
             // image onto whatever is sent next (#10228) — both must heal first.
-            markTerminalInputStale(staleInputTerminalsRef.current, handle)
+            markMobileNativeChatInputStale(handle)
           }
           if (outcome !== 'rejected') {
             // Drop only what rode along — a chip attached while this send was in
@@ -311,7 +301,7 @@ export function useMobileNativeChatImageAttachments({
           // A thrown paste/send (network/RPC) keeps the chips and honors the
           // Promise<boolean> contract instead of rejecting. Retry-safe: the next
           // attempt's leading Ctrl+U clears whatever fraction of the paste landed.
-          markTerminalInputStale(staleInputTerminalsRef.current, handle)
+          markMobileNativeChatInputStale(handle)
           onError?.()
           showToast('Message not sent', 1500)
           return false


### PR DESCRIPTION
## Summary

Mobile native chat marks a terminal's composer line "stale" when an image paste lands but the follow-up text+Enter never confirms, so the next send clears it with a leading Ctrl+U first. That marker was component-local React state:

- `mobile/src/session/use-mobile-native-chat-image-attachments.ts:113` (pre-fix) — `staleInputTerminalsRef = useRef(new Set<string>())`

The hook is per-session-screen (`mobile/app/h/[hostId]/session/[worktreeId].tsx:3623` → `mobile/src/session/use-mobile-session-image-attachments.ts:73`), but the condition it tracks — a bracketed paste sitting unsubmitted on the agent's composer line — lives on the **host** and outlives the screen.

**Failure 1 — marker lost on unmount.** Attach an image and send; the paste lands (`mobile/src/session/mobile-native-chat-image-send.ts:39-52`), the text+Enter returns `unknown`, so the terminal is marked stale and the chips clear. Back out of the session screen and return → the hook remounts with an empty `Set` → the stale check is `false`, the healing `\x15` is skipped, and the agent receives `<image path><text>`: the image is silently re-attached and the message body corrupted. This is exactly what the in-code comment ("both must heal first") says must not happen.

**Failure 2 — one reader.** The marker was read at exactly one site. The chat overlay wires the question card straight past the image hook that owned that read (`mobile/src/session/MobileNativeChatOverlay.tsx:51` — `onAnswerQuestion={controller.handleNativeChatSend}`), and the ask-answer path submits its own Enter, so both could commit on top of the orphaned paste.

### The fix

New `mobile/src/session/mobile-native-chat-stale-input.ts` owns the marker in a module-level store keyed by terminal handle — a lifetime that matches the host-side condition instead of the screen — plus a single `healMobileNativeChatStaleInput` that clears the line and consumes the marker only once the host accepts the clear.

Consulted and consumed by every write path that can **submit the composer**:

| Path | Why |
|---|---|
| image hook text-only send | pre-existing reader, now on the shared store |
| `handleNativeChatSendWithOutcome` | closes the question-card overlay bypass |
| `answerAsk` (pasted-label shape only) | it pastes the label into the composer and commits it |

**User-visible change:** a message sent after a session screen was left and re-entered no longer silently re-attaches the previous image. If the healing clear itself is rejected, the send is refused with the existing "Message not sent" / "Answer not sent" toast rather than submitting onto a dirty line.

### Deliberate scope call (deviates from the filed spec)

The task asked for *permission/ask/cancel* to heal too. Ask does, but **only in its pasted-label shape** — see the correction below. **Permission choices and the Escape cancel deliberately do not**, and healing them would be a regression rather than a fix: those are `enter: false` keys for an active overlay that swallows the clear (`mobile-native-chat-permission.ts` sends only `1`/`y`/`n`/`a`/ESC, never Enter). A Ctrl+U there would not reach the composer, yet would still *consume* the marker — leaving the next real message to be corrupted by the paste still sitting there. That is Failure 1 through a different door. Since these paths cannot submit the composer, a stale line cannot corrupt them, and leaving the marker armed for the next text send is strictly safer.

Desktop scopes its Ctrl+U at least as narrowly: `clearUnsubmittedAgentInput` is called only from `sendNativeChatMessage` and `sendNativeChatMessageWithImageAttachments` (`native-chat-runtime-send.ts:73, :166`) and their cancel hooks, so approval digits and ESC bypass it entirely (`use-native-chat-interactive-send.ts:74-82, :155-158`). The comment at `native-chat-runtime-send.ts:33-37` carves out *verified option commands* for a different reason (a model-switch observer can miss confirmation markers), so it is not the citation for this skip. All skips are commented in-code so they read as decisions, not oversights.

**Correction (review, `86f6c81982`).** The first version of this change healed *every* ask answer, on the stated premise that "both answer shapes commit with Enter." That is false for the selector shapes, and the heal was over-broad in exactly the way this section argues against: Claude's single-question single-select builds `[{raw:'2'}]` and Codex's builds `[{raw:'1'}]` — no Enter at all (`src/shared/native-chat-ask.ts:211-213, :259-262`; the trailing `ASK_ENTER` is gated at `:220-223` on multi-question or multi-select) — and every stepping group is written `enter: false` (`use-mobile-native-chat-answer-send.ts:187`), which the host coerces anyway (`src/main/runtime/rpc/methods/terminal.ts:1345`). A bare option digit cannot submit the composer, so healing there burned the one-shot marker against the overlay where the live-overlay premise is *strongest* (the ask card is built from the structured `interactivePrompt` and the user is tapping it), leaving the paste to corrupt the next real message. That was newly reachable in this PR — on `main` the ask path never touched the marker. The heal is now scoped to the pasted-label shape, matching desktop's split at `use-native-chat-interactive-send.ts:132-140`, and the three skips (selector answer, permission choice, Escape cancel) are test-pinned so the argument is an invariant rather than a comment.

Residual, stated plainly: for the multi-question / multi-select / free-text shapes that *do* end in a raw `\r`, a stale card whose overlay already closed can still submit the composer. Desktop accepts the same risk, and the selector groups would land as literal text in that case anyway, so the line is garbage either way — but the marker now survives to clean it before the next real message. Properly fixing that belongs in card invalidation (`use-mobile-native-chat-ask-dismiss.ts`), not in pre-clearing.

## Screenshots

No visual change. This is terminal-write sequencing behind the existing composer; no UI, layout, copy, or token changes.

## Testing

- [x] `pnpm lint` — root `npm run lint` passes end-to-end; `mobile/` `oxlint` clean (incl. `config/oxlint-react-doctor.json` via pre-commit) and `oxfmt --check` clean.
- [x] `pnpm typecheck` — root passes; `mobile/` `tsc --noEmit` clean.
- [x] `pnpm test` — **full mobile suite: 339 files / 2465 tests pass**, 2 skipped (2462 at `bb46ca226a`, +3 from the review fix). The root desktop suite was not run: the change is entirely under `mobile/`, and the root tsconfig/vitest do not compile or include `mobile/`.
- [ ] `pnpm build` — not run. Electron desktop packaging is unaffected by a mobile-only change.
- [x] Added or updated high-quality tests that would catch regressions

**Regression tests were verified to actually catch the bug.** I stashed only the source changes while keeping the new tests, and confirmed the 5 behavior tests fail against pre-fix code and pass after:

- marker lost on unmount/remount (Failure 1)
- overlay/question-card send never clears (Failure 2)
- ask-answer send never clears (Failure 2)
- a rejected healing clear must retain the marker and refuse the send (both send and answer paths)

Plus `mobile-native-chat-stale-input.test.ts` unit-covers per-terminal isolation, no-write-when-unmarked, consume-on-accept, and marker retention when the clear is rejected or throws.

All touched files stay under their `max-lines` caps with no disable and no per-file bump — the image hook shrank 281 → 272 effective lines.

## AI Review Report

Reviewed by CodeRabbit (`bb46ca226a`, all 9 files): **no actionable comments generated** — zero inline findings. Two non-code pre-merge checks were raised; the description one is actioned by this rewrite, and I've declined the 80% docstring-coverage threshold in a PR comment with reasoning, because hitting it would mean documenting three self-describing one-line `Set` wrappers, which `AGENTS.md` ("Concise/Brief Non-obvious comments ONLY … DO NOT explain the obvious") explicitly prohibits.

My own review focused on the risks specific to moving state out of React:

- **Test isolation** — module-level state outlives a test. This actually surfaced as a real failure during development (an unrelated test inherited a marker) and is fixed by `resetMobileNativeChatStaleInputForTests()` in the `beforeEach` of all three affected suites.
- **No double-clear on the image path** — after a successful paste the marker is cleared before `baseSend`, so the controller's new heal is a no-op there; verified by the pre-existing ride-along tests that assert exact `terminal.send` counts.
- **Accept semantics unchanged** — the heal reuses the same `pasteMobileNativeChatImagePaths` → `isTerminalSendRpcAccepted` path as the old inline block, so only an explicit `accepted === true` consumes the marker; an ambiguous ack conservatively retains it.
- **Supersession** — the ask path captures its generation before the heal's `await` and re-checks it after, so a concurrent answer cannot double-step the selector.
- **Writer audit** — I enumerated every `terminal.send` writer under `mobile/src/session/` to confirm none that can submit the composer was missed. `use-mobile-native-chat-stop.ts` sends only Escape, so it is correctly in the skip category.

**Cross-platform:** nothing platform-dependent is touched. No `metaKey`/`ctrlKey` or accelerators, no shortcut labels, no filesystem paths or path separators, no shell invocation, no Electron main/renderer or IPC code, no native modules. The change is pure TypeScript in the React Native client operating on an existing RPC, so it behaves identically for macOS, Linux, and Windows hosts, and over SSH and folder workspaces as well as git worktrees (a terminal handle is opaque to this logic).

## Security Audit

Low risk; no new attack surface.

- **Input handling** — no user-controlled data is newly parsed or interpolated. The only byte introduced is a fixed `\x15` control character sent to a terminal the user already owns and already writes to via this same path.
- **No new RPC surface** — reuses the existing `terminal.send` request and the existing device-token client field; no new method, no protocol version change, no runtime-compatibility concern.
- **Command execution / path handling** — none added. Image paths are not newly constructed or resolved; the heal sends an *empty* `imagePaths` list.
- **Auth / secrets** — untouched. The device token is passed through exactly as before and is never logged.
- **State scope** — the new module-level store holds only opaque terminal-handle strings, never image bytes, paths, or message text.

## Notes

Residual risk and adjacent work:

- The store is in-memory, so a **full app restart** still loses the marker while the host line stays dirty. That is narrower than the bug fixed here (leaving a screen is routine; a cold start is not) and avoids putting an `await` on persisted storage in front of every send. A persisted store keyed by handle would close it.
- Markers are never reaped or invalidated. Handles are globally unique (`term_<uuid>` per pty), so a marker can never clear the wrong terminal, and an entry for a dead handle is inert. But it can go stale on a **live** handle: nothing observes the host line being cleaned out of band — the desktop user submitting or Ctrl+U-ing it themselves, or the same tab viewed as a raw terminal and submitted there. The next mobile send then fires one `\x15` that wipes whatever is on that line. Pre-fix this window closed on screen unmount; now it stays open, which is the cost of matching the marker's lifetime to the host-side condition. Reaping markers for handles absent from the session route's tab list would narrow it.
- A question-card answer tapped during an image send's 300ms settle can still interleave with that send's paste. Pre-existing and independent of the marker; left alone to keep this to one concern.
- **Adjacent surface deliberately left untouched**, flagged as follow-up rather than widened into here: `mobile/src/session/use-mobile-diff-review-send-actions.ts:77-80` submits a review prompt with `enter: true` to a chosen terminal, so it can also commit on top of a stale paste. It is not a native-chat write path and does not regress with this change, but the same heal would apply.

**Not device-verified.** No phone or paired relay was used — this reproduces the defect at the hook/controller seam with a stubbed RPC transport, not against a real agent TUI. Specifically not verified on-device: that the healing `\x15` visibly clears a real Claude/Codex composer after a backgrounded-and-restored screen, and the premise above that a live permission overlay swallows Ctrl+U. Worth one manual pass: attach an image, send on a flaky connection until the send reports unconfirmed, back out of the session and return, then send a plain message and confirm no image rides along.

