### PR TITLE
fix(skills): advance the release ledger at the cut so shipped revisions freeze

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -554,7 +554,9 @@ jobs:
           # which step staged what or how the commit was spelled.
           # -F because the allowlist is literal: unanchored, `.` would match any
           # character and quietly admit a path like `packageXjson`.
-          committed="$(git diff-tree --no-commit-id --name-only -r HEAD |
+          # -m --first-parent: plain diff-tree prints NOTHING for a merge commit,
+          # which would make this guard pass silently rather than fail closed.
+          committed="$(git diff-tree --no-commit-id --name-only -r -m --first-parent HEAD |
             grep -vxF -e 'package.json' -e 'resources/skills/release-mapping.json' || true)"
           if [[ -n "$committed" ]]; then
             echo "::error::Release commit carries unexpected paths: $(echo "$committed" | tr '\n' ' ')Only package.json and the skill release-mapping row may ship in a version commit." >&2

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -534,18 +534,6 @@ jobs:
             exit 1
           fi
           git add package.json resources/skills/release-mapping.json
-          # Why: a lint that greps this file cannot see a path built from an env
-          # var, a composite action, or string concatenation. Assert the index
-          # itself so the release commit can only ever carry the version bump and
-          # the provenance row, no matter which step staged what.
-          # -F because the allowlist is literal: unanchored, `.` would match any
-          # character and quietly admit a path like `packageXjson`.
-          unexpected="$(git diff --cached --name-only |
-            grep -vxF -e 'package.json' -e 'resources/skills/release-mapping.json' || true)"
-          if [[ -n "$unexpected" ]]; then
-            echo "::error::Release commit would carry unexpected paths: $(echo "$unexpected" | tr '\n' ' ')Only package.json and the skill release-mapping row may be staged." >&2
-            exit 1
-          fi
           commit_message="release: v$VERSION"
           if [[ "$EVENT_NAME" == "schedule" ]]; then
             commit_message="$commit_message [rc-slot:$SLOT]"
@@ -557,6 +545,20 @@ jobs:
             git commit --allow-empty -m "$commit_message"
           else
             git commit -m "$commit_message"
+          fi
+          # Why: a lint that greps this file cannot see a path built from an env
+          # var, a composite action, or concatenation, and `git commit` has forms
+          # (-a, -i, --only, a pathspec) that commit the working tree rather than
+          # the index. Assert what the commit actually carries, so the tag can
+          # only ever ship the version bump and the provenance row, no matter
+          # which step staged what or how the commit was spelled.
+          # -F because the allowlist is literal: unanchored, `.` would match any
+          # character and quietly admit a path like `packageXjson`.
+          committed="$(git diff-tree --no-commit-id --name-only -r HEAD |
+            grep -vxF -e 'package.json' -e 'resources/skills/release-mapping.json' || true)"
+          if [[ -n "$committed" ]]; then
+            echo "::error::Release commit carries unexpected paths: $(echo "$committed" | tr '\n' ' ')Only package.json and the skill release-mapping row may ship in a version commit." >&2
+            exit 1
           fi
           git tag -a "v$VERSION" -m "v$VERSION"
           echo "tag=v$VERSION" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -529,7 +529,10 @@ jobs:
           # artifacts do not already match this ref and writes just the mapping
           # row, so the version commit stays skill-independent. Node built-ins
           # only, so this needs no install.
-          node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"
+          if ! node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"; then
+            echo "::error::Refusing to record release provenance for v$VERSION: the committed skill artifacts do not match this ref. Land a regeneration on main, then re-run the cut." >&2
+            exit 1
+          fi
           git add package.json resources/skills/release-mapping.json
           commit_message="release: v$VERSION"
           if [[ "$EVENT_NAME" == "schedule" ]]; then

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -534,6 +534,16 @@ jobs:
             exit 1
           fi
           git add package.json resources/skills/release-mapping.json
+          # Why: a lint that greps this file cannot see a path built from an env
+          # var, a composite action, or string concatenation. Assert the index
+          # itself so the release commit can only ever carry the version bump and
+          # the provenance row, no matter which step staged what.
+          unexpected="$(git diff --cached --name-only |
+            grep -vx -e 'package.json' -e 'resources/skills/release-mapping.json' || true)"
+          if [[ -n "$unexpected" ]]; then
+            echo "::error::Release commit would carry unexpected paths: $(echo "$unexpected" | tr '\n' ' ')Only package.json and the skill release-mapping row may be staged." >&2
+            exit 1
+          fi
           commit_message="release: v$VERSION"
           if [[ "$EVENT_NAME" == "schedule" ]]; then
             commit_message="$commit_message [rc-slot:$SLOT]"

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -538,8 +538,10 @@ jobs:
           # var, a composite action, or string concatenation. Assert the index
           # itself so the release commit can only ever carry the version bump and
           # the provenance row, no matter which step staged what.
+          # -F because the allowlist is literal: unanchored, `.` would match any
+          # character and quietly admit a path like `packageXjson`.
           unexpected="$(git diff --cached --name-only |
-            grep -vx -e 'package.json' -e 'resources/skills/release-mapping.json' || true)"
+            grep -vxF -e 'package.json' -e 'resources/skills/release-mapping.json' || true)"
           if [[ -n "$unexpected" ]]; then
             echo "::error::Release commit would carry unexpected paths: $(echo "$unexpected" | tr '\n' ' ')Only package.json and the skill release-mapping row may be staged." >&2
             exit 1

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -521,7 +521,16 @@ jobs:
           # message and tag name explicitly (avoids npm's `v1.2.3` prefix
           # assumptions and any lifecycle scripts that would run on bump).
           npm version "$VERSION" --no-git-tag-version --allow-same-version
-          git add package.json
+          # Why: the cut is the only point where committed skill bytes become a
+          # released revision. Without this row the ledger never advances, so the
+          # next skill change rebuilds the revision this tag ships over different
+          # bytes and every install of it stops matching a known snapshot.
+          # --release is provenance-only: it fails if the content-addressed
+          # artifacts do not already match this ref and writes just the mapping
+          # row, so the version commit stays skill-independent. Node built-ins
+          # only, so this needs no install.
+          node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"
+          git add package.json resources/skills/release-mapping.json
           commit_message="release: v$VERSION"
           if [[ "$EVENT_NAME" == "schedule" ]]; then
             commit_message="$commit_message [rc-slot:$SLOT]"

--- a/config/scripts/generate-skill-bundle-manifest.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.mjs
@@ -652,7 +652,10 @@ async function main() {
 
   // Why: released snapshots are append-only. The committed registry/mapping are
   // read fresh here so the artifacts (which may have appended a release row) can
-  // never alias what we validate against.
+  // never alias what we validate against. This mapping must stay the PRE-append
+  // one to match artifacts.releasedSnapshotCounts, which seeding fixed before the
+  // row existed; the post-append mapping names one more revision than the counts
+  // do, which reads as incomplete history and would throw on every cut.
   assertReleasedHistoryPreserved(committedRegistry, artifacts, committedMapping)
 
   const shouldWrite = releaseVersion !== null || argv.includes('--write')

--- a/config/scripts/generate-skill-bundle-manifest.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.mjs
@@ -18,6 +18,11 @@ const OUTPUT_ROOT = path.join(REPO_ROOT, 'resources', 'skills')
 const CURRENT_MANIFEST_PATH = path.join(OUTPUT_ROOT, 'current-manifest.json')
 const SNAPSHOT_REGISTRY_PATH = path.join(OUTPUT_ROOT, 'snapshot-registry.json')
 const RELEASE_MAPPING_PATH = path.join(OUTPUT_ROOT, 'release-mapping.json')
+// Why: the manifest and registry are content-addressed — they describe skill
+// bytes. The mapping is provenance: which already-committed revision a tag
+// shipped. A release cut may append the second without regenerating the first.
+const CONTENT_ADDRESSED_PATHS = [CURRENT_MANIFEST_PATH, SNAPSHOT_REGISTRY_PATH]
+const ALL_ARTIFACT_PATHS = [...CONTENT_ADDRESSED_PATHS, RELEASE_MAPPING_PATH]
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex')
@@ -551,13 +556,14 @@ function serialized(value) {
   return `${JSON.stringify(value, null, 2)}\n`
 }
 
-async function writeArtifacts(artifacts) {
-  await mkdir(OUTPUT_ROOT, { recursive: true })
-  await Promise.all([
-    writeFile(CURRENT_MANIFEST_PATH, serialized(artifacts.currentManifest)),
-    writeFile(SNAPSHOT_REGISTRY_PATH, serialized(artifacts.snapshotRegistry)),
-    writeFile(RELEASE_MAPPING_PATH, serialized(artifacts.releaseMapping))
+async function writeArtifacts(artifacts, paths = ALL_ARTIFACT_PATHS) {
+  const values = new Map([
+    [CURRENT_MANIFEST_PATH, artifacts.currentManifest],
+    [SNAPSHOT_REGISTRY_PATH, artifacts.snapshotRegistry],
+    [RELEASE_MAPPING_PATH, artifacts.releaseMapping]
   ])
+  await mkdir(OUTPUT_ROOT, { recursive: true })
+  await Promise.all(paths.map((filePath) => writeFile(filePath, serialized(values.get(filePath)))))
 }
 
 // Why: cutting a release tag adds a trailing mapping row on every checkout at
@@ -592,12 +598,12 @@ function isToleratedReleaseMappingPrefix(committedText, artifacts) {
     .every((release) => isDeepStrictEqual(release.skills, currentRevisions))
 }
 
-async function verifyArtifacts(artifacts) {
+async function verifyArtifacts(artifacts, paths = ALL_ARTIFACT_PATHS) {
   const expected = [
     [CURRENT_MANIFEST_PATH, artifacts.currentManifest, null],
     [SNAPSHOT_REGISTRY_PATH, artifacts.snapshotRegistry, null],
     [RELEASE_MAPPING_PATH, artifacts.releaseMapping, isToleratedReleaseMappingPrefix]
-  ]
+  ].filter(([filePath]) => paths.includes(filePath))
   const stale = []
   for (const [filePath, value, tolerated] of expected) {
     try {
@@ -636,6 +642,11 @@ async function main() {
   const artifacts = await buildArtifacts(releasedHistory)
 
   if (releaseVersion) {
+    // Why: the row names revisions the committed registry must already contain,
+    // so proving those artifacts match this ref is what lets the cut record
+    // provenance without regenerating them. If regeneration disagrees with what
+    // is committed, the row would name a revision this tag does not ship.
+    await verifyArtifacts(artifacts, CONTENT_ADDRESSED_PATHS)
     appendReleaseRow(artifacts, releaseVersion)
   }
 
@@ -645,7 +656,8 @@ async function main() {
   assertReleasedHistoryPreserved(committedRegistry, artifacts, committedMapping)
 
   const shouldWrite = releaseVersion !== null || argv.includes('--write')
-  await (shouldWrite ? writeArtifacts : verifyArtifacts)(artifacts)
+  const writePaths = releaseVersion ? [RELEASE_MAPPING_PATH] : ALL_ARTIFACT_PATHS
+  await (shouldWrite ? writeArtifacts(artifacts, writePaths) : verifyArtifacts(artifacts))
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === import.meta.filename) {

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -483,8 +483,10 @@ describe('skill bundle manifest generator', () => {
     // spelled, only these two paths may ship. Asserted on the commit rather than
     // the index because `git commit -a/-i/--only/<pathspec>` bypasses the index.
     // -F is part of the contract; without it `.` admits a path like packageXjson.
+    // Flags pinned, not just the command: a `--diff-filter` slipped in here would
+    // silence modifications, and dropping -m makes a merge commit report nothing.
     expect(bumpStep.run).toMatch(
-      /git diff-tree --no-commit-id --name-only -r HEAD[\s\S]*grep -vxF -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
+      /git diff-tree --no-commit-id --name-only -r -m --first-parent HEAD\s*\|\s*grep -vxF -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
     )
     expect(bumpStep.run.indexOf('grep -vxF')).toBeLessThan(bumpStep.run.indexOf('git tag'))
     // ...and that it aborts. A guard degraded to a warning still reads as covered.

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -480,10 +480,11 @@ describe('skill bundle manifest generator', () => {
     const bumpStep = runSteps.find((step) => step.name === 'Bump package.json and tag')
 
     // The load-bearing check: whatever staged it, only these two paths may ship.
+    // -F is part of the contract; without it `.` admits a path like packageXjson.
     expect(bumpStep.run).toMatch(
-      /git diff --cached --name-only[\s\S]*grep -vx -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
+      /git diff --cached --name-only[\s\S]*grep -vxF -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
     )
-    expect(bumpStep.run.indexOf('grep -vx')).toBeLessThan(bumpStep.run.indexOf('git commit'))
+    expect(bumpStep.run.indexOf('grep -vxF')).toBeLessThan(bumpStep.run.indexOf('git commit'))
     // Tripwire only. A step that merely READS this directory may be added here;
     // one that writes or stages it must not, and the guard above will reject it.
     expect(runSteps.filter((s) => /resources[/\\]skills/.test(s.run)).map((s) => s.name)).toEqual([

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -464,20 +464,28 @@ describe('skill bundle manifest generator', () => {
     expect(gitTreeSha(files)).toBe(expected)
   })
 
-  // Why: the runtime contract test only inspects the bump step, but every step
-  // in the cut job shares one workspace and one index, so an earlier step could
-  // regenerate and stage the content-addressed artifacts into the version commit.
+  // Why: every step in the cut job shares one workspace and one index, so any of
+  // them can stage the content-addressed artifacts and the bump step's own commit
+  // then carries them into the tag. Grepping the workflow cannot see a path built
+  // from an env var, a composite action, or concatenation, so the cut asserts its
+  // own index before committing; this test pins that guard and adds a tripwire
+  // for the literal spellings.
   it('keeps the whole release-cut job off skill regeneration', async () => {
     const workflow = parse(
       await readFile(path.join(REPO_ROOT, '.github/workflows/release-cut.yml'), 'utf8')
     )
     const runSteps = workflow.jobs.cut.steps
       .filter((step) => typeof step.run === 'string')
-      .map((step) => ({ name: step.name, run: step.run.replace(/^\s*#.*$/gm, '') }))
+      .map((step) => ({ name: step.name ?? '(unnamed)', run: step.run.replace(/^\s*#.*$/gm, '') }))
+    const bumpStep = runSteps.find((step) => step.name === 'Bump package.json and tag')
 
-    expect(runSteps.length).toBeGreaterThan(0)
-    // Only the step that appends the provenance row may name the directory, and
-    // no step anywhere may regenerate — under either the flag or its alias.
+    // The load-bearing check: whatever staged it, only these two paths may ship.
+    expect(bumpStep.run).toMatch(
+      /git diff --cached --name-only[\s\S]*grep -vx -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
+    )
+    expect(bumpStep.run.indexOf('grep -vx')).toBeLessThan(bumpStep.run.indexOf('git commit'))
+    // Tripwire only. A step that merely READS this directory may be added here;
+    // one that writes or stages it must not, and the guard above will reject it.
     expect(runSteps.filter((s) => /resources[/\\]skills/.test(s.run)).map((s) => s.name)).toEqual([
       'Bump package.json and tag'
     ])

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -479,16 +479,18 @@ describe('skill bundle manifest generator', () => {
       .map((step) => ({ name: step.name ?? '(unnamed)', run: step.run.replace(/^\s*#.*$/gm, '') }))
     const bumpStep = runSteps.find((step) => step.name === 'Bump package.json and tag')
 
-    // The load-bearing check: whatever staged it, only these two paths may ship.
+    // The load-bearing check: whatever staged it and however the commit was
+    // spelled, only these two paths may ship. Asserted on the commit rather than
+    // the index because `git commit -a/-i/--only/<pathspec>` bypasses the index.
     // -F is part of the contract; without it `.` admits a path like packageXjson.
     expect(bumpStep.run).toMatch(
-      /git diff --cached --name-only[\s\S]*grep -vxF -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
+      /git diff-tree --no-commit-id --name-only -r HEAD[\s\S]*grep -vxF -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
     )
-    expect(bumpStep.run.indexOf('grep -vxF')).toBeLessThan(bumpStep.run.indexOf('git commit'))
+    expect(bumpStep.run.indexOf('grep -vxF')).toBeLessThan(bumpStep.run.indexOf('git tag'))
     // ...and that it aborts. A guard degraded to a warning still reads as covered.
     // The exit must be inside the guard's own block, not borrowed from a later one.
     expect(bumpStep.run).toMatch(
-      /if \[\[ -n "\$unexpected" \]\]; then(?:(?!\bfi\b)[\s\S])*exit 1[\s\S]*?fi/
+      /if \[\[ -n "\$committed" \]\]; then(?:(?!\bfi\b)[\s\S])*exit 1[\s\S]*?fi/
     )
     // Tripwire only. A step that merely READS this directory may be added here;
     // one that writes or stages it must not, and the guard above will reject it.

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -1,5 +1,15 @@
 import { execFileSync } from 'node:child_process'
-import { chmod, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -23,6 +33,26 @@ async function createPackage() {
   const directory = await mkdtemp(path.join(tmpdir(), 'orca-skill-manifest-'))
   temporaryDirectories.push(directory)
   return directory
+}
+
+// Why: the generator resolves its repo root from its own location, so a copy of
+// the script inside a throwaway tree exercises the real CLI — including which
+// artifacts each mode is allowed to write — without touching resources/skills.
+async function createReleaseSandbox() {
+  // Node resolves the entry point through symlinks, so the script's own
+  // repo-root check only matches when the sandbox path is already resolved.
+  const root = await realpath(await createPackage())
+  const skillRoot = path.join(root, 'skills', 'demo')
+  const script = path.join(root, 'config', 'scripts', 'generate-skill-bundle-manifest.mjs')
+  await mkdir(path.dirname(script), { recursive: true })
+  await mkdir(skillRoot, { recursive: true })
+  await copyFile(path.join(import.meta.dirname, 'generate-skill-bundle-manifest.mjs'), script)
+  await writeFile(path.join(skillRoot, 'SKILL.md'), 'demo skill\n')
+  return {
+    generate: (...args) => execFileSync(process.execPath, [script, ...args], { stdio: 'pipe' }),
+    read: (name) => readFile(path.join(root, 'resources', 'skills', name), 'utf8'),
+    editSkill: (body) => writeFile(path.join(skillRoot, 'SKILL.md'), body)
+  }
 }
 
 afterEach(async () => {
@@ -313,6 +343,62 @@ describe('skill bundle manifest generator', () => {
     }
 
     expect(() => appendReleaseRow(artifacts, '1.4.151')).toThrow(/already has a row for 1\.4\.151/)
+  })
+
+  it('records a release without regenerating the content-addressed artifacts', async () => {
+    const sandbox = await createReleaseSandbox()
+
+    sandbox.generate('--write')
+    const [manifest, registry] = await Promise.all([
+      sandbox.read('current-manifest.json'),
+      sandbox.read('snapshot-registry.json')
+    ])
+    sandbox.generate('--release', 'v1.4.156')
+
+    // The cut records provenance for bytes that are already committed, so a
+    // version-only cut can never rewrite a shipped identity.
+    expect(JSON.parse(await sandbox.read('release-mapping.json')).releases).toEqual([
+      { appVersion: '1.4.156', skills: { demo: 1 } }
+    ])
+    expect(await sandbox.read('current-manifest.json')).toBe(manifest)
+    expect(await sandbox.read('snapshot-registry.json')).toBe(registry)
+
+    // Bytes that changed since the last regeneration would make the row name a
+    // revision this tag does not ship — refuse rather than record it.
+    await sandbox.editSkill('edited after the last regeneration\n')
+    expect(() => sandbox.generate('--release', '1.4.157')).toThrow(
+      /Generated skill artifacts are stale/
+    )
+    expect(JSON.parse(await sandbox.read('release-mapping.json')).releases).toHaveLength(1)
+  })
+
+  it('freezes a revision once a release records it, and only until then', async () => {
+    const sandbox = await createReleaseSandbox()
+    const demoSnapshots = async () =>
+      JSON.parse(await sandbox.read('snapshot-registry.json')).skills.demo
+
+    sandbox.generate('--write')
+    const unreleased = (await demoSnapshots())[0].packageDigest
+
+    // Nothing has shipped revision 1 yet, so re-deriving it over new bytes is
+    // correct: the tail floats until a release names it.
+    await sandbox.editSkill('about to ship\n')
+    sandbox.generate('--write')
+    const shipped = await demoSnapshots()
+    expect(shipped).toHaveLength(1)
+    expect(shipped[0].packageDigest).not.toBe(unreleased)
+
+    sandbox.generate('--release', '1.4.156')
+
+    // The cut named revision 1, so the next change appends revision 2 instead of
+    // rebuilding revision 1. Installs carrying the shipped digest keep matching a
+    // known snapshot — without the ledger row they would match nothing.
+    await sandbox.editSkill('changed again after the cut\n')
+    sandbox.generate('--write')
+    const frozen = await demoSnapshots()
+    expect(frozen).toHaveLength(2)
+    expect(frozen[0]).toEqual(shipped[0])
+    expect(frozen[1].releaseRevision).toBe(2)
   })
 
   it.runIf(process.platform !== 'win32')(

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -486,7 +486,10 @@ describe('skill bundle manifest generator', () => {
     )
     expect(bumpStep.run.indexOf('grep -vxF')).toBeLessThan(bumpStep.run.indexOf('git commit'))
     // ...and that it aborts. A guard degraded to a warning still reads as covered.
-    expect(bumpStep.run).toMatch(/if \[\[ -n "\$unexpected" \]\]; then[\s\S]*?exit 1[\s\S]*?fi/)
+    // The exit must be inside the guard's own block, not borrowed from a later one.
+    expect(bumpStep.run).toMatch(
+      /if \[\[ -n "\$unexpected" \]\]; then(?:(?!\bfi\b)[\s\S])*exit 1[\s\S]*?fi/
+    )
     // Tripwire only. A step that merely READS this directory may be added here;
     // one that writes or stages it must not, and the guard above will reject it.
     expect(runSteps.filter((s) => /resources[/\\]skills/.test(s.run)).map((s) => s.name)).toEqual([

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -485,6 +485,8 @@ describe('skill bundle manifest generator', () => {
       /git diff --cached --name-only[\s\S]*grep -vxF -e 'package\.json' -e 'resources\/skills\/release-mapping\.json'/
     )
     expect(bumpStep.run.indexOf('grep -vxF')).toBeLessThan(bumpStep.run.indexOf('git commit'))
+    // ...and that it aborts. A guard degraded to a warning still reads as covered.
+    expect(bumpStep.run).toMatch(/if \[\[ -n "\$unexpected" \]\]; then[\s\S]*?exit 1[\s\S]*?fi/)
     // Tripwire only. A step that merely READS this directory may be added here;
     // one that writes or stages it must not, and the guard above will reject it.
     expect(runSteps.filter((s) => /resources[/\\]skills/.test(s.run)).map((s) => s.name)).toEqual([

--- a/config/scripts/generate-skill-bundle-manifest.test.mjs
+++ b/config/scripts/generate-skill-bundle-manifest.test.mjs
@@ -13,6 +13,7 @@ import {
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
 import {
   appendReleaseRow,
   assertReleasedHistoryPreserved,
@@ -28,6 +29,7 @@ import {
 } from './generate-skill-bundle-manifest.mjs'
 
 const temporaryDirectories = []
+const REPO_ROOT = path.resolve(import.meta.dirname, '..', '..')
 
 async function createPackage() {
   const directory = await mkdtemp(path.join(tmpdir(), 'orca-skill-manifest-'))
@@ -460,5 +462,27 @@ describe('skill bundle manifest generator', () => {
     }).trim()
 
     expect(gitTreeSha(files)).toBe(expected)
+  })
+
+  // Why: the runtime contract test only inspects the bump step, but every step
+  // in the cut job shares one workspace and one index, so an earlier step could
+  // regenerate and stage the content-addressed artifacts into the version commit.
+  it('keeps the whole release-cut job off skill regeneration', async () => {
+    const workflow = parse(
+      await readFile(path.join(REPO_ROOT, '.github/workflows/release-cut.yml'), 'utf8')
+    )
+    const runSteps = workflow.jobs.cut.steps
+      .filter((step) => typeof step.run === 'string')
+      .map((step) => ({ name: step.name, run: step.run.replace(/^\s*#.*$/gm, '') }))
+
+    expect(runSteps.length).toBeGreaterThan(0)
+    // Only the step that appends the provenance row may name the directory, and
+    // no step anywhere may regenerate — under either the flag or its alias.
+    expect(runSteps.filter((s) => /resources[/\\]skills/.test(s.run)).map((s) => s.name)).toEqual([
+      'Bump package.json and tag'
+    ])
+    for (const step of runSteps) {
+      expect(step.run, step.name).not.toMatch(/--write|generate:skill-bundle-manifest/)
+    }
   })
 })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -463,10 +463,13 @@ describe('Electron runtime package contract', () => {
     expect(generateIndex).toBeGreaterThan(bumpIndex)
     expect(stageIndex).toBeGreaterThan(generateIndex)
     expect(stagedPaths).toEqual(['package.json', 'resources/skills/release-mapping.json'])
-    // Every mention must be staged, so a copy or redirect cannot reach the
-    // content-addressed artifacts; the alias and `commit -a` bypass them too.
-    expect(commands.match(/resources\/skills\/\S*/g)).toEqual(stagedPaths.slice(1))
-    expect(commands).not.toMatch(/--write|generate:skill-bundle-manifest|commit\s[^\n]*\s-a\b/)
+    // Every mention must be staged, so a copy, a redirect, or a path held in a
+    // variable cannot reach the content-addressed artifacts. Matched without a
+    // trailing slash so `dir="resources/skills"` still counts as a mention.
+    expect(commands.match(/resources[/\\]skills\S*/g)).toEqual(stagedPaths.slice(1))
+    // Regeneration is banned job-wide by the generator suite. Here: `-a`, `-am`,
+    // and `--all` sweep unstaged artifacts in; `--allow-empty` below must not.
+    expect(commands).not.toMatch(/\bcommit\b[^\n]*\s(?:-a(?:\b|[a-z])|--all\b)/)
     expect(bumpStep.run).toContain('git diff --cached --quiet')
     expect(bumpStep.run).toContain('git commit --allow-empty -m "$commit_message"')
   })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -470,7 +470,7 @@ describe('Electron runtime package contract', () => {
     expect([...mentioned]).toEqual(stagedPaths.slice(1))
     // Regeneration is banned job-wide by the generator suite. Here: `-a`, `-am`,
     // and `--all` sweep unstaged artifacts in; `--allow-empty` below must not.
-    expect(commands).not.toMatch(/\bcommit\b[^\n]*\s(?:-a(?:\b|[a-z])|--all\b)/)
+    expect(commands).not.toMatch(/\bcommit\b[^\n]*(?:\s-[a-z]*a[a-z]*\b|\s--all\b)/)
     expect(bumpStep.run).toContain('git diff --cached --quiet')
     expect(bumpStep.run).toContain('git commit --allow-empty -m "$commit_message"')
   })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -450,23 +450,24 @@ describe('Electron runtime package contract', () => {
     const generateIndex = bumpStep.run.indexOf(
       'node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"'
     )
-    const stageIndex = bumpStep.run.indexOf('git add package.json')
     const commands = bumpStep.run.replace(/^\s*#.*$/gm, '')
     // Unanchored: a `git add` chained after `&&` stages just as effectively.
     const stagedPaths = [...commands.matchAll(/\bgit add (.+)$/gm)].flatMap((match) =>
       match[1].trim().split(/\s+/)
     )
+    // Quotes trimmed and deduped: the index guard names the row a second time.
+    const mentioned = new Set(commands.match(/resources[/\\]skills[^\s'"]*/g))
     expect(checkoutStep.with['fetch-depth']).toBe(0)
     expect(bumpIndex).toBeGreaterThanOrEqual(0)
     // Why: the cut is the only point that advances the release ledger, so this
     // tag's revision is never rebuilt later — it appends that row, nothing else.
     expect(generateIndex).toBeGreaterThan(bumpIndex)
-    expect(stageIndex).toBeGreaterThan(generateIndex)
+    expect(bumpStep.run.indexOf('git add package.json')).toBeGreaterThan(generateIndex)
     expect(stagedPaths).toEqual(['package.json', 'resources/skills/release-mapping.json'])
-    // Every mention must be staged, so a copy, a redirect, or a path held in a
-    // variable cannot reach the content-addressed artifacts. Matched without a
-    // trailing slash so `dir="resources/skills"` still counts as a mention.
-    expect(commands.match(/resources[/\\]skills\S*/g)).toEqual(stagedPaths.slice(1))
+    // Every distinct mention must be staged, so a copy, a redirect, or a path
+    // held in a variable cannot reach the content-addressed artifacts. Matched
+    // without a trailing slash so `dir="resources/skills"` still counts.
+    expect([...mentioned]).toEqual(stagedPaths.slice(1))
     // Regeneration is banned job-wide by the generator suite. Here: `-a`, `-am`,
     // and `--all` sweep unstaged artifacts in; `--allow-empty` below must not.
     expect(commands).not.toMatch(/\bcommit\b[^\n]*\s(?:-a(?:\b|[a-z])|--all\b)/)

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -433,7 +433,7 @@ describe('Electron runtime package contract', () => {
     expect(afterInstallScript).not.toContain('chmod 0755 "$sandbox"')
   })
 
-  it('keeps release-cut version commits skill-independent and taggable on retries', () => {
+  it('advances only the skill release ledger in a taggable release-cut commit', () => {
     const releaseWorkflow = readFileSync(
       join(projectDir, '.github/workflows/release-cut.yml'),
       'utf8'
@@ -447,13 +447,23 @@ describe('Electron runtime package contract', () => {
     const bumpIndex = bumpStep.run.indexOf(
       'npm version "$VERSION" --no-git-tag-version --allow-same-version'
     )
+    const generateIndex = bumpStep.run.indexOf(
+      'node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"'
+    )
     const stageIndex = bumpStep.run.indexOf('git add package.json')
+    const stagedPaths = [...bumpStep.run.matchAll(/^\s*git add (.+)$/gm)].flatMap((match) =>
+      match[1].trim().split(/\s+/)
+    )
     expect(checkoutStep.with['fetch-depth']).toBe(0)
     expect(bumpIndex).toBeGreaterThanOrEqual(0)
-    expect(stageIndex).toBeGreaterThan(bumpIndex)
-    // Why: version-only cuts must not mutate content-addressed skill artifacts.
-    expect(bumpStep.run).not.toContain('generate-skill-bundle-manifest')
-    expect(bumpStep.run).not.toContain('resources/skills')
+    // Why: the cut is the only point that advances the release ledger, so the
+    // revision this tag ships is never rebuilt over different bytes later. It
+    // may append that provenance row and nothing else — regenerating or staging
+    // the content-addressed artifacts is what made version bumps rewrite them.
+    expect(generateIndex).toBeGreaterThan(bumpIndex)
+    expect(stageIndex).toBeGreaterThan(generateIndex)
+    expect(bumpStep.run).not.toContain('--write')
+    expect(stagedPaths).toEqual(['package.json', 'resources/skills/release-mapping.json'])
     expect(bumpStep.run).toContain('git diff --cached --quiet')
     expect(bumpStep.run).toContain('git commit --allow-empty -m "$commit_message"')
   })

--- a/config/scripts/package-electron-runtime-contract.test.mjs
+++ b/config/scripts/package-electron-runtime-contract.test.mjs
@@ -451,19 +451,22 @@ describe('Electron runtime package contract', () => {
       'node config/scripts/generate-skill-bundle-manifest.mjs --release "$VERSION"'
     )
     const stageIndex = bumpStep.run.indexOf('git add package.json')
-    const stagedPaths = [...bumpStep.run.matchAll(/^\s*git add (.+)$/gm)].flatMap((match) =>
+    const commands = bumpStep.run.replace(/^\s*#.*$/gm, '')
+    // Unanchored: a `git add` chained after `&&` stages just as effectively.
+    const stagedPaths = [...commands.matchAll(/\bgit add (.+)$/gm)].flatMap((match) =>
       match[1].trim().split(/\s+/)
     )
     expect(checkoutStep.with['fetch-depth']).toBe(0)
     expect(bumpIndex).toBeGreaterThanOrEqual(0)
-    // Why: the cut is the only point that advances the release ledger, so the
-    // revision this tag ships is never rebuilt over different bytes later. It
-    // may append that provenance row and nothing else — regenerating or staging
-    // the content-addressed artifacts is what made version bumps rewrite them.
+    // Why: the cut is the only point that advances the release ledger, so this
+    // tag's revision is never rebuilt later — it appends that row, nothing else.
     expect(generateIndex).toBeGreaterThan(bumpIndex)
     expect(stageIndex).toBeGreaterThan(generateIndex)
-    expect(bumpStep.run).not.toContain('--write')
     expect(stagedPaths).toEqual(['package.json', 'resources/skills/release-mapping.json'])
+    // Every mention must be staged, so a copy or redirect cannot reach the
+    // content-addressed artifacts; the alias and `commit -a` bypass them too.
+    expect(commands.match(/resources\/skills\/\S*/g)).toEqual(stagedPaths.slice(1))
+    expect(commands).not.toMatch(/--write|generate:skill-bundle-manifest|commit\s[^\n]*\s-a\b/)
     expect(bumpStep.run).toContain('git diff --cached --quiet')
     expect(bumpStep.run).toContain('git commit --allow-empty -m "$commit_message"')
   })


### PR DESCRIPTION
## Summary

The skill release ledger never advances, so the **second** skill content change after any release silently orphans every install of the first one.

`config/scripts/generate-skill-bundle-manifest.mjs`:
- [`:390`](https://github.com/stablyai/orca/blob/main/config/scripts/generate-skill-bundle-manifest.mjs#L390) — `releasedCount` comes **solely** from `resources/skills/release-mapping.json`.
- [`:461`](https://github.com/stablyai/orca/blob/main/config/scripts/generate-skill-bundle-manifest.mjs#L461) — a changed skill gets `releaseRevision = releasedCount + 1`, i.e. array index `releasedCount`.
- [`:518`](https://github.com/stablyai/orca/blob/main/config/scripts/generate-skill-bundle-manifest.mjs#L518) — `protectedCount = committedReleasedCounts[name]`, so index `releasedCount` is **unprotected**.

That unprotected tail is correct while it is unreleased. It stops being correct the moment a tag ships it, and nothing records that it shipped:

- #10340 replaced the git-tag walk with the committed ledger and added the `--release` advance at the cut.
- #10460 reverted the two workflow lines because they broke the #9119 contract test (`cc1ad064d7`): a version-only cut must not run `generate-skill-bundle-manifest` or stage `resources/skills`. Its own message says *"This leaves #10340 semantically incomplete and that must not be dropped."*

So today: a tag ships skill X at revision N; the mapping still names N-1 as the max released revision; the next content change re-derives revision **N** over different bytes. Every install carrying the digest the tag actually shipped matches no known snapshot, reads as unrecognized / needs-attention, and the update command cannot deliver.

v1.4.156 itself is clean — all 9 registry tails currently equal their mapped counts. Corruption lands on the second change after the cut.

### Fix

Restore the ledger advance in a form the #9119 contract can keep enforcing, rather than one that has to be exempted from it.

**`--release` is now provenance-only** (`generate-skill-bundle-manifest.mjs`):
1. Verifies `current-manifest.json` and `snapshot-registry.json` already match the ref being tagged — the cut proves it is *not* regenerating them.
2. Appends the mapping row (unchanged `appendReleaseRow`: v-prefix strip, dedupe, re-cut overwrite).
3. Writes **only** `release-mapping.json`. `writeArtifacts`/`verifyArtifacts` take a path set; `--write` and plain verify keep all three.

**`release-cut.yml`** runs that step and stages exactly `package.json resources/skills/release-mapping.json`.

**The contract test is narrowed, not deleted** — it asserts the cut runs `--release`, that every `resources/skills` mention in the bump step is exactly what gets staged, and that the staged set is `['package.json', 'resources/skills/release-mapping.json']`. A companion job-wide test asserts no step anywhere in the cut job regenerates the artifacts. See Contract-gate hardening below.

#### Why this is safe where #10340 was not

#10340 ran the full `writeArtifacts` and staged the whole `resources/skills` directory, so a version-only cut *could* rewrite content-addressed artifacts — exactly the regression #9119 fixed. The invariant is now enforced by the script itself, not by workflow convention: the release path can only write the provenance file, and it aborts before writing anything if the manifest or registry disagree with the ref.

#9119's stated harm was that version bumps made committed artifacts stale on every open branch, and dragged the `resources/skills`-filtered update-roundtrip matrix onto unrelated PRs. Neither recurs here: the mapping is passed through from the committed file rather than re-derived, so an open branch that rebases onto the cut still verifies clean, and the roundtrip matrix triggers on `push: main` — the cut's own commit, not unrelated PRs.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — `oxlint config/scripts/` clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — `config/scripts` suite: 53 files, 420 passed / 4 skipped
- [ ] `pnpm build` — not run; no runtime/bundled code changed
- [x] Added or updated high-quality tests that would catch regressions

Two new tests in `generate-skill-bundle-manifest.test.mjs` drive the real CLI inside a throwaway tree (the script resolves its repo root from its own location, so a copy runs against a synthetic `skills/demo`; nothing touches `resources/skills`):

- **`records a release without regenerating the content-addressed artifacts`** — asserts the row is appended, the manifest and registry are byte-identical afterwards, and a `--release` over unregenerated skill bytes fails with `Generated skill artifacts are stale` and writes nothing.
- **`freezes a revision once a release records it, and only until then`** — an unreleased tail may be re-derived over new bytes; once `--release` names revision 1, the next change appends revision 2 and revision 1 stays byte-identical.

**Correction to an earlier revision of this description**, which called the second test "the tail-reuse regression test." It is not. With only `generate-skill-bundle-manifest.mjs` reverted to `origin/main` and both new tests kept, that test **passes** — `--release` and `appendReleaseRow` already exist on main, because #10460 reverted only the two workflow lines and deliberately left the script implementation in place. It is a characterization test of pre-existing script behavior; its assertions are non-vacuous (they die under a targeted mutation), but it does not fail without this PR. The thing actually missing in production was the **workflow never invoking `--release`**, and that is gated solely by the contract test in `package-electron-runtime-contract.test.mjs`.

Mutation results (each reverted afterwards):

| mutation | result |
|---|---|
| revert `generate-skill-bundle-manifest.mjs` to `origin/main`, keep new tests | test 1 fails at the `Generated skill artifacts are stale` assertion; **test 2 passes** |
| drop the ledger-advance step from `release-cut.yml` | contract test fails (`expected -1 to be greater than 216`) |
| drop the content-artifact verification from `--release` | test 1 fails |
| make the cut not record the row | tests 1 and 2 fail — test 2 at the genuine tail-reuse assertion (registry stays length 1, revision 1 rebuilt over new bytes) |
| release path writes ALL artifacts instead of only the mapping | **nothing fails** — see below |

The last row is not a coverage gap but is worth stating plainly: with the verification guard in place, `verifyArtifacts` has already established that both content-addressed files serialize byte-identically, so rewriting them is a no-op. The "writes only `release-mapping.json`" narrowing is redundant defense-in-depth that no test can kill. If the verification guard is ever weakened, that narrowing silently becomes load-bearing and unprotected.

### Contract-gate hardening

Closing this took four rounds of adversarial review, and the first three fixes were all wrong in the same way. Every mutation below was confirmed to reintroduce #9119 while the test suite stayed green, then confirmed to fail after the fix.

- **Round 1** — inside the bump step: a `git add` chained after `&&` (invisible to a regex anchored to line start); a write reaching `resources/skills` with no `git add` at all; and `pnpm run generate:skill-bundle-manifest`, the `package.json` alias for `--write`, whose colon form never matched the banned hyphenated name. That last one also passed the pre-#10460 assertions, so it predates this PR.
- **Round 2** — the gate inspected only the bump step, but the cut job has 15 steps sharing one workspace and one git index, so an earlier step could regenerate and stage, and the bump step's own commit swept it into the tag. Separately, the mention scan required a trailing slash (so a path in a shell variable was invisible) and the `commit -a` ban matched *nothing at all* — `commit\s` consumed the only separator.
- **Round 3** — the job-wide grep was defeated three more ways: an `env:` block holding `--write` and `resources/skills`; a composite `uses:` action whose steps the workflow never spells out; and plain concatenation (`root=resources; leaf=skills`).

Round 3 is the load-bearing lesson: **grepping shell source for path literals is inherently evadable**, and each fix had only relocated the previous hole. So the invariant moved to where it cannot be dodged. **Round 6** then showed the first attempt at that still asserted the wrong thing — it validated the *index*, but `git commit -a/-i/--only/<pathspec>` commits the working tree, so a rogue step could leave regenerated artifacts unstaged and `git commit -i resources` would carry them into the tag with every gate green (`--only resources` additionally dropped `package.json` from the tag). Enumerating those flags is the same losing game, so the guard now asserts the **outcome** — after committing and before tagging:

```bash
committed="$(git diff-tree --no-commit-id --name-only -r HEAD |
  grep -vxF -e 'package.json' -e 'resources/skills/release-mapping.json' || true)"
```

It uses `-m --first-parent` because plain `diff-tree` prints nothing for a merge commit, which would make the guard pass *silently* — the one direction that matters here. It is indifferent to which step staged what and to how the commit was spelled. Verified blocking the whole family — `-i`, `--only`, `-a`, `-am`, `-vam`, a bare pathspec, and an alias expanding to `commit -i` — while a stock commit and an `--allow-empty` re-cut still pass. **Round 4** caught that the original `grep -vx` matched patterns as regexes, so the `.` in `package.json` admitted a staged `packageXjson`; `-F` fixes it. The guard also fails closed on paths with spaces or non-ASCII characters (git quotes those) and on staged deletions.

The workflow grep survives as a cheap tripwire for literal spellings, now paired with positive assertions that the index guard exists, precedes the commit, and actually aborts — indirection can hide a path, but it cannot hide a *missing* guard. That last assertion came from **round 4**: replacing the guard's `exit 1` with `:` had left every test green while the cut logged the error and shipped the artifact anyway — the same shape-not-effect mistake the earlier rounds kept making. **Round 5** then found two holes in those very guards: the abort check could borrow an `exit 1` from a later `if ... fi` in the same step, and the `commit -a` ban only matched when `a` led the flag cluster, so `-vam`/`-va`/`-qam` survived. That second one is the sharper of the two — `commit -a` stages at commit time, *after* the index guard has inspected a clean index, making it the one way to defeat layer 1. Both are fixed and their mutants verified failing. The job-wide test lives in the generator suite because the contract file sits at its hard 600-line `max-lines` cap, which is never raised or disabled.

Knowingly accepted: `stagedPaths` still fails on a line-continuation, a `git add --` separator, or a trailing comment on the staging line, and the static tripwire still cannot see env-var or composite-action indirection. Both are fail-*closed* or backstopped by the runtime guard.

## AI Review Report

Reviewed with two independent Opus subagents (correctness/regression and test-verification) plus direct verification. Checked: the whole `main()` control flow, argument-parsing edge cases, ordering of verify-before-append, the `paths` refactor's effect on everyday lint, workflow retry/idempotency, and scope.

Confirmed clean:
- `--release ""` and a missing operand both throw at `:633`, so `releaseVersion !== null` and the truthy checks cannot disagree.
- The `--release`/`--write`/verify paths are **git-free** — working-tree hashing is pure Node `sha1`; `readGitBlobs`/`releaseTags` are reachable only from `--rebuild-from-tags`. The cut needs no `git` history and no `pnpm install`.
- Plain verify still fails for each of the three artifacts individually; the default path set is unchanged.
- Real-repo lifecycle reproduced independently: a content change plus `--release` appended one row, left `current-manifest.json` and `snapshot-registry.json` byte-identical (proved by `git hash-object` before/after), was idempotent on a second run, and exited 1 against unregenerated bytes. A second change then produced revision **37** with revision **36 frozen**; without the row, revision 36 was **rebuilt over different bytes**. The specific digests quoted in an earlier revision of this description are functions of the reviewer's own probe edit and are not independently reproducible; the revision numbers, file-touch set, idempotency, and exit codes all are.

Cross-platform: the changed contract assertions are pure string parsing over YAML and are platform-independent. The generator changes add no platform-dependent behavior — no new path handling, shell invocation, or keyboard/UI surface. The new generator tests still have the macOS-only caveat noted under Notes.

## Security Audit

No new input handling, command execution, path construction, auth, secrets, or IPC surface. The one new execution point is a `node` invocation in the release-cut workflow whose only argument is `$VERSION`, already validated upstream by the version/tag-collision logic; it is passed as a single `execFileSync`-style argv element by the shell, not interpolated into a shell string. The script writes to a fixed path derived from its own location. The contract-test changes are read-only parsing. `--release` reduces privilege relative to #10340: the release path can now write exactly one file.

## Notes

**Residual risk**

- **A concurrent cut and an in-flight PR can still corrupt the ledger, with lint green.** If a branch regenerates artifacts *before* a cut and merges *after* it, the branch legitimately claims the free tail revision N over its bytes B, while the cut names revision N as shipped bytes A. Because the cut never touches `snapshot-registry.json`, the merge is clean (mapping from main, registry from the branch) and plain verify **passes** on the result — the ledger then says revision N = digest B while the tag shipped digest A. Reproduced end to end in a synthetic repo, and **also reproduced against `origin/main`'s script**, so this PR does not introduce it; it fixes the sequential case and leaves this one. Scheduled RC cuts make the window non-rare. A real fix needs the shipped digest recorded in the mapping row so the mismatch is detectable, which is a schema change and a separate PR.
- **A stale main blocks the cut.** If `resources/skills` on main is out of sync with `skills/`, `--release` now fails the cut instead of silently regenerating. That state means PR lint was already red; a blocked release beats a corrupt ledger row, but it is a new way for the cut to fail.
- **Off-main releases still drift.** When the cut does not push main (`push_main != true`), the row exists at the tag but never lands on main, so that release's revision can still be rebuilt later. Pre-existing and unchanged.
- **One extra CI run per cut.** The release commit now touches `resources/skills/release-mapping.json`, matching the `push: main` trigger of `skill-update-roundtrip.yml`. #9119's concern was that matrix landing on unrelated *PRs*; this only affects the cut's own commit on main.
- `isToleratedReleaseMappingPrefix` becomes near-vestigial on the committed path (it still guards `--rebuild-from-tags`). Left in place — removing it is a separate concern.

**Static-only — not executed here**

- **The `release-cut.yml` job itself has not run.** Its shape is asserted only by parsing the YAML (step order, staged paths, `Setup Node.js` before `Bump package.json and tag`), plus the confirmation that the script imports only `node:*` built-ins and shells out to `git` only on the `--rebuild-from-tags` path.
- Windows/Linux behavior of the new generator tests; only macOS ran. The sandbox helper resolves the temp path through `realpath` because Node resolves the entry point through symlinks (`/var` → `/private/var` on macOS), which is a no-op elsewhere.
- The runtime UI consequence (a skill reading as unrecognized) is reasoned from the registry/mapping semantics, not observed in the app.
