### PR TITLE
fix(window): reflow via scale factor so terminals stop re-gridding

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -42,7 +42,8 @@ vi.mock('electron', () => ({
   nativeTheme: { shouldUseDarkColors: false },
   powerMonitor: { on: powerMonitorOnMock, removeListener: powerMonitorRemoveListenerMock },
   screen: {
-    getPrimaryDisplay: () => ({ workAreaSize: { width: 1440, height: 900 } })
+    getPrimaryDisplay: () => ({ workAreaSize: { width: 1440, height: 900 } }),
+    getDisplayMatching: () => ({ scaleFactor: 2 })
   },
   shell: { openExternal: openExternalMock }
 }))
@@ -497,6 +498,7 @@ describe('createMainWindow', () => {
       isFullScreen: vi.fn(() => false),
       getSize: vi.fn(() => [1200, 800]),
       getContentSize: vi.fn(() => [1200, 800]),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 840 })),
       setSize: vi.fn(),
       maximize: vi.fn(),
       show: vi.fn(),
@@ -521,10 +523,10 @@ describe('createMainWindow', () => {
     // dvh root — via the emulated viewport, which leaves the deadlock-prone frame untouched.
     expect(webContents.enableDeviceEmulation).toHaveBeenCalledWith({
       screenPosition: 'desktop',
-      screenSize: { width: 1200, height: 801 },
+      screenSize: { width: 1200, height: 800 },
       viewPosition: { x: 0, y: 0 },
-      deviceScaleFactor: 0,
-      viewSize: { width: 1200, height: 801 },
+      deviceScaleFactor: 2.25,
+      viewSize: { width: 1200, height: 800 },
       scale: 1
     })
     expect(webContents.disableDeviceEmulation).toHaveBeenCalled()
@@ -563,6 +565,7 @@ describe('createMainWindow', () => {
       isFullScreen: vi.fn(() => true),
       getSize: vi.fn(() => [1200, 800]),
       getContentSize: vi.fn(() => [1200, 800]),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 840 })),
       setSize: vi.fn(),
       maximize: vi.fn(),
       show: vi.fn(),
@@ -613,6 +616,7 @@ describe('createMainWindow', () => {
       isFullScreen: vi.fn(() => false),
       getSize: vi.fn(() => [1200, 800]),
       getContentSize: vi.fn(() => [1200, 800]),
+      getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 840 })),
       setSize: vi.fn(),
       maximize: vi.fn(),
       show: vi.fn(),
@@ -638,10 +642,10 @@ describe('createMainWindow', () => {
     expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
     expect(webContents.enableDeviceEmulation).toHaveBeenCalledWith({
       screenPosition: 'desktop',
-      screenSize: { width: 1200, height: 801 },
+      screenSize: { width: 1200, height: 800 },
       viewPosition: { x: 0, y: 0 },
-      deviceScaleFactor: 0,
-      viewSize: { width: 1200, height: 801 },
+      deviceScaleFactor: 2.25,
+      viewSize: { width: 1200, height: 800 },
       scale: 1
     })
     expect(webContents.disableDeviceEmulation).toHaveBeenCalled()

--- a/src/main/window/renderer-viewport-reflow.test.ts
+++ b/src/main/window/renderer-viewport-reflow.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import type { BrowserWindow } from 'electron'
+
+const scaleFactorMock = { value: 1 }
+vi.mock('electron', () => ({
+  screen: { getDisplayMatching: vi.fn(() => ({ scaleFactor: scaleFactorMock.value })) }
+}))
+
 import {
   reflowRendererViewport,
   VIEWPORT_REFLOW_RESTORE_ATTEMPTS,
@@ -16,6 +22,7 @@ function createWindow(overrides: Record<string, unknown> = {}): BrowserWindow {
     webContents,
     isDestroyed: vi.fn(() => false),
     getContentSize: vi.fn(() => [1200, 800]),
+    getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 840 })),
     setSize: vi.fn(),
     setBounds: vi.fn(),
     ...overrides
@@ -25,6 +32,7 @@ function createWindow(overrides: Record<string, unknown> = {}): BrowserWindow {
 describe('reflowRendererViewport', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    scaleFactorMock.value = 1
   })
   afterEach(() => {
     vi.useRealTimers()
@@ -47,16 +55,51 @@ describe('reflowRendererViewport', () => {
     vi.advanceTimersByTime(0)
     expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledWith({
       screenPosition: 'desktop',
-      screenSize: { width: 1200, height: 801 },
+      screenSize: { width: 1200, height: 800 },
       viewPosition: { x: 0, y: 0 },
-      deviceScaleFactor: 0,
-      viewSize: { width: 1200, height: 801 },
+      deviceScaleFactor: 1.25,
+      viewSize: { width: 1200, height: 800 },
       scale: 1
     })
     expect(window.webContents.disableDeviceEmulation).not.toHaveBeenCalled()
 
     vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS)
     expect(window.webContents.disableDeviceEmulation).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: a CSS-pixel delta re-grids terminals sitting on an xterm row boundary, so the emulated
+  // viewport must match the real one exactly — the scale factor is the only thing allowed to move.
+  it('emulates the real viewport size so no terminal re-grids mid-reflow', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(0)
+    const [params] = (window.webContents.enableDeviceEmulation as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [Electron.Parameters]
+    expect(params.viewSize).toEqual({ width: 1200, height: 800 })
+    expect(params.screenSize).toEqual({ width: 1200, height: 800 })
+    expect(params.scale).toBe(1)
+  })
+
+  // Why: a constant scale factor would equal the real one on a 1.25x display and reflow nothing.
+  it('offsets from the display the window is actually on', () => {
+    scaleFactorMock.value = 1.25
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(0)
+    const [params] = (window.webContents.enableDeviceEmulation as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [Electron.Parameters]
+    expect(params.deviceScaleFactor).toBe(1.5)
+  })
+
+  // Why: a display reporting 0 would emulate 0.25 and shrink everything.
+  it('falls back to 1x when the display reports no scale factor', () => {
+    scaleFactorMock.value = 0
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(0)
+    const [params] = (window.webContents.enableDeviceEmulation as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [Electron.Parameters]
+    expect(params.deviceScaleFactor).toBe(1.25)
   })
 
   it('collapses a burst of reveals into one emulation cycle', () => {

--- a/src/main/window/renderer-viewport-reflow.ts
+++ b/src/main/window/renderer-viewport-reflow.ts
@@ -1,8 +1,11 @@
+import { screen } from 'electron'
 import type { BrowserWindow } from 'electron'
 
-// Why: long enough for the emulated viewport to reach the renderer and lay out, short enough
-// that a user never sees the 1px overshoot.
+// Why: long enough for the emulated scale factor to reach the renderer and drive a relayout.
 export const VIEWPORT_REFLOW_SETTLE_MS = 32
+
+// Why: any delta re-runs layout; 0.25 stays clear of float-compare noise against the real factor.
+const VIEWPORT_REFLOW_SCALE_DELTA = 0.25
 
 // Why: a restore that keeps failing on a live webContents would loop forever; give up and
 // release the latch so a later reveal can try a fresh cycle.
@@ -22,6 +25,12 @@ function isWindowGone(window: BrowserWindow): boolean {
  * status bar clipped off-screen (STA-2383). The frame jiggle that used to fix that mutates
  * NSWindow, which self-deadlocks the main thread on macOS 26's scene-backed windows. Device
  * emulation drives the same resize through the compositor instead — real reflow, no scene update.
+ *
+ * Why scale factor and not a +1px viewport: a one-pixel height delta changes the CSS box, so a
+ * terminal sitting just under an xterm row boundary gains a row, and the pane fit observer reads
+ * that transient grid as stable and forwards a real PTY resize — then reverses it on restore.
+ * Measured 3/54 window heights SIGWINCHing twice per reveal. A scale-factor delta re-runs layout
+ * with byte-identical CSS geometry: 0/54, with no WebGL atlas rebuild or context loss.
  */
 export function reflowRendererViewport(window: BrowserWindow): void {
   if (activeViewportReflows.has(window) || isWindowGone(window)) {
@@ -38,15 +47,18 @@ export function reflowRendererViewport(window: BrowserWindow): void {
     let emulating = false
     try {
       const [width, height] = window.getContentSize()
-      // Why: emulating the current size is a no-op — the +1 delta is what triggers the reflow.
-      const viewSize = { width, height: height + 1 }
+      // Why: the real viewport, unchanged — only the scale factor moves.
+      const viewSize = { width, height }
+      // Why: emulating the current factor is a no-op, so offset from this window's own display
+      // rather than a constant, which would match on a 1.25x screen and reflow nothing.
+      const realScaleFactor = screen.getDisplayMatching(window.getBounds()).scaleFactor || 1
       window.webContents.enableDeviceEmulation({
         screenPosition: 'desktop',
-        // Why: Electron types every field as required, so the rest carry their documented
-        // defaults — screenSize is mobile-only, and 0 keeps the real device scale factor.
+        // Why: Electron types every field as required; screenSize is mobile-only and scale is
+        // the emulated-view zoom, so both carry their documented no-op defaults.
         screenSize: viewSize,
         viewPosition: { x: 0, y: 0 },
-        deviceScaleFactor: 0,
+        deviceScaleFactor: realScaleFactor + VIEWPORT_REFLOW_SCALE_DELTA,
         viewSize,
         scale: 1
       })
@@ -58,8 +70,8 @@ export function reflowRendererViewport(window: BrowserWindow): void {
       activeViewportReflows.delete(window)
       return
     }
-    // Why: emulation must always be undone — leaving it on strands the renderer at the
-    // overshot viewport for the rest of the window's life.
+    // Why: emulation must always be undone — leaving it on strands the renderer at the wrong
+    // scale factor for the rest of the window's life.
     restoreRealViewport(window, 0)
   }, 0)
 }
@@ -75,7 +87,7 @@ function restoreRealViewport(window: BrowserWindow, attempt: number): void {
       window.webContents.disableDeviceEmulation()
       activeViewportReflows.delete(window)
     } catch {
-      // Why: the webContents is still alive, so the renderer is stuck at the overshot viewport;
+      // Why: the webContents is still alive, so the renderer is stuck at the emulated scale;
       // keep retrying and hold the latch so no second cycle stacks on the unrestored state.
       if (attempt >= VIEWPORT_REFLOW_RESTORE_ATTEMPTS) {
         activeViewportReflows.delete(window)


### PR DESCRIPTION
Follow-up to #10473. That PR replaced the deadlock-prone frame jiggle with a `+1px` emulated viewport. The `+1px` was a real CSS-geometry change, and it re-grids terminals.

## The regression

`renderer-viewport-reflow.ts` emulated `height + 1`. For a terminal whose pane height sits one pixel under an xterm row boundary, that adds a row. The pane fit observer's two-frame stability check (`pane-fit-resize-observer.ts:101-138`) sees the same proposed grid on two consecutive animation frames — ~16.7ms apart, comfortably inside the 32ms hold — declares it stable, and fits. `performSafeFit`'s no-op guard (`pane-fit.ts:137`) doesn't help, because the grid genuinely differs. The PTY gets a real resize, and the restore reverses it.

Measured with real xterm + FitAddon + the real stability loop, sweeping window heights across a full cell height (cellH=16, 54 configs):

| mechanism | configs with SIGWINCH | PTY resizes |
| --- | --- | --- |
| `height + 1` (#10473) | **3/54 (5.6%)** | 6 |
| old `setSize` jiggle | 0/54 | 0 |
| **scale factor (this PR)** | **0/54** | **0** |

Concretely, at `paneH=655`: rows 40 → 41 → 40, two SIGWINCHes per reveal. `createMainWindow.ts`'s 250ms second repaint doubles that on show/restore.

Worth being direct: #10473 made this *worse than the code it replaced* on this axis. The old jiggle changed window width, which doesn't cross row boundaries; the new one changed viewport height, which does.

## The fix

Nudge `deviceScaleFactor` by +0.25 instead, leaving `viewSize` at the real content size. Layout re-runs, `dvh` recomputes, and the CSS box is byte-identical, so no terminal re-grids.

The delta is derived from `screen.getDisplayMatching(window.getBounds()).scaleFactor` rather than a constant — a hardcoded 1.25 would equal the real factor on a 1.25x display and reflow nothing. `|| 1` guards a display reporting 0.

## Verification (real Electron 43.1.0, macOS 26.3.1)

Full 54-config sweep against the shipped logic, with the **WebGL** renderer (what Orca actually uses — `pane-webgl-renderer.ts`) and a real PTY resize listener:

- SIGWINCH **0/54**
- reflow signal fired **54/54** (the fix still does its job)
- DPR restored **54/54**, layout correct **54/54**
- WebGL context loss: **0**; canvas/atlas dimensions unchanged
- burst of 8 → 1 resize event, still re-arms

Also fixes the third reported issue: `<webview>` guests sat under the same `100dvh` chain and took two native resizes per reflow. No CSS geometry change means no guest resize.

## Tests

Four new tests in `renderer-viewport-reflow.test.ts` pin the mechanism: emulated `viewSize`/`screenSize` must equal the *real* content size, the delta must come from the window's own display, and the 0-scale-factor fallback. Mutation-tested — restoring `height + 1` fails 4 tests.

`typecheck:node` clean, `oxlint` clean, full `src/main/` suite **15,003 passed | 47 skipped**.

## Credit

Both the maximized/fullscreen gap (fixed in #10473) and this row-boundary SIGWINCH were surfaced by adversarial review agents. My original "no SIGWINCH" check used `paneH=544` — exactly *on* a 32px row boundary, the safe case — so it passed while the bug was real. The boundary-crossing height is what exposes it.

## Limits

The stale-`dvh` state this reflow exists to fix still does not reproduce locally — I tried again here, manufacturing it by resizing the frame while the window was hidden, and layout was already correct on show, so `invalidate()` had nothing to fix and the test couldn't discriminate. Carried forward from #10473: the reflow is verified at the mechanism level (it demonstrably drives a real layout recomputation with the frame untouched), not against a reproduced stale state.

The 32ms restore still has no renderer acknowledgement, so a renderer blocked past the hold can coalesce the cycle away. That degrades to "no reflow this time," not to a wrong layout. A renderer-ack handshake is the principled fix and is not in this PR.
