### PR TITLE
fix(terminal): answer color queries bundled ConPTY forwards

### DIFF
--- a/docs/reference/plans/2026-07-19-windows-conpty-startup-query-and-focus-authority.md
+++ b/docs/reference/plans/2026-07-19-windows-conpty-startup-query-and-focus-authority.md
@@ -34,16 +34,19 @@ backend.
 
 ## 2026-07-20 Ownership Amendment
 
+> Its query-consumption rules are superseded by the 2026-07-25 amendment above. Its backend
+> classification rule still stands.
+
 Fresh paired-runtime evidence showed that the display/controller platform is not a safe proxy for
 the PTY backend. A macOS client can attach to a native ConPTY owned by a paired Windows runtime, so
 renderer-side local/SSH/remote heuristics can transfer OSC 10/11 authority to the wrong responder.
 
 The PTY-owning process now classifies the backend from its own platform and the shell that actually
-won spawn: `windows-conpty`, `windows-wsl`, or `posix-pty`. Native ConPTY consumes complete OSC 10/11
-queries before model, replay, or view delivery. During the bounded startup window it replies once
-when validated theme colors are available; after the deadline, or without colors, it consumes the
-query without replying. A consuming-view handshake does not transfer this authority. Split query
-candidates remain bounded and private across authority-close, expiry, and snapshot barriers; a
+won spawn: `windows-conpty`, `windows-wsl`, or `posix-pty`. ~~Native ConPTY consumes complete OSC
+10/11 queries before model, replay, or view delivery. During the bounded startup window it replies
+once when validated theme colors are available; after the deadline, or without colors, it consumes
+the query without replying. A consuming-view handshake does not transfer this authority. Split query
+candidates remain bounded and private across authority-close, expiry, and snapshot barriers~~; a
 candidate that proves malformed is released unchanged.
 
 WSL and POSIX PTYs continue to transfer authority to the normal visible/hidden responder after the

--- a/docs/reference/plans/2026-07-19-windows-conpty-startup-query-and-focus-authority.md
+++ b/docs/reference/plans/2026-07-19-windows-conpty-startup-query-and-focus-authority.md
@@ -2,7 +2,35 @@
 
 Date: 2026-07-19
 
-Status: Implemented with the 2026-07-20 ownership amendment below
+Status: Implemented with the 2026-07-20 and 2026-07-25 amendments below
+
+## 2026-07-25 Bundled ConPTY Amendment
+
+The "native ConPTY consumes OSC 10/11 for the life of the PTY" rule was measured against the
+**system** ConPTY. Every Windows spawn now passes `useConptyDll: true`
+([`pty-subprocess.ts`](../../../src/main/daemon/pty-subprocess.ts),
+[`local-pty-utils.ts`](../../../src/main/providers/local-pty-utils.ts)), so the bundled
+OpenConsole binary owns the pseudoconsole instead. A node-pty harness on both backends shows they
+behave in opposite ways:
+
+| backend | forwards `OSC 10/11 ?` to the terminal | reply reaches the client | cooked echo of the reply |
+| --- | --- | --- | --- |
+| system ConPTY (`useConptyDll: false`) | no | no | n/a |
+| bundled ConPTY (`useConptyDll: true`) | yes | yes, byte-for-byte | none observed |
+
+Consuming an unanswerable query on the bundled backend therefore silences the only responder the
+agent can reach. Codex then falls back to `GetConsoleScreenBufferInfoEx`
+(`codex-rs/tui/src/terminal_probe.rs`), reads the pseudoconsole palette — `bgIndex=0`,
+`#0c0c0c` — and renders a dark theme inside a light pane. This reproduced whenever the query
+arrived after the 5 s startup deadline or after both slots had already been answered once.
+
+The startup transaction now transfers OSC 10/11 authority identically on every backend: a query it
+answers is consumed, a query it cannot answer is released to the normal delivered/hidden responder.
+The measured echo projection stays gated on `windows-conpty` so a host that still reaches the system
+ConPTY keeps its cooked-echo protection. Residual risk: on such a host a downstream reply's echo is
+not suppressed, because only source-written replies register an expected projection — accepted
+because a dark-on-light agent is deterministic while that echo is not reproducible on the bundled
+backend.
 
 ## 2026-07-20 Ownership Amendment
 

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -245,7 +245,10 @@ describe('Session', () => {
       expect(snapshot?.outputSequence).toBe('\x1b]10;?\x07]10;rgb:2e2e/'.length)
     })
 
-    it('reproduces the legacy paired-runtime leak and removes its downstream producer', () => {
+    // Why: after startup authority closes, both backends hand the query to the downstream
+    // responder. Bundled ConPTY forwards OSC 10/11 and produces no cooked echo, so consuming the
+    // query there would leave the agent on the pseudoconsole palette instead of the pane theme.
+    it('hands a post-authority color query to the downstream responder on both backends', () => {
       const query = '\x1b]10;?\x07'
       const reply = '\x1b]10;rgb:2e2e/3434/3434\x1b\\'
       const projectedEcho = ']10;rgb:2e2e/3434/3434\\'
@@ -286,9 +289,9 @@ describe('Session', () => {
       subprocess.simulateData(query)
       subprocess.simulateData('prompt')
 
-      expect(fixedReplyProducers).toEqual([])
-      expect(subprocess.written).toEqual([])
-      expect(fixedOnData.mock.calls).toEqual([['', query.length, true, query.length], ['prompt']])
+      expect(fixedReplyProducers).toEqual(['remote-visible-renderer'])
+      expect(subprocess.written).toEqual([reply])
+      expect(fixedOnData.mock.calls).toEqual([[query], ['prompt']])
       expect(session.getSnapshot()?.snapshotAnsi).not.toContain(']10;rgb')
     })
   })

--- a/src/main/daemon/terminal-host-pty-owner-backend.test.ts
+++ b/src/main/daemon/terminal-host-pty-owner-backend.test.ts
@@ -52,7 +52,8 @@ describe('TerminalHost PTY owner backend', () => {
   async function createSession(
     shellPath: string,
     requestedWslDistro?: string,
-    onData = vi.fn()
+    onData = vi.fn(),
+    startupIngress?: { colors: { foreground: string; background: string }; deadlineMs: number }
   ): Promise<TestSubprocess> {
     const subprocess = createSubprocess(shellPath)
     host = new TerminalHost({ spawnSubprocess: () => subprocess })
@@ -63,26 +64,45 @@ describe('TerminalHost PTY owner backend', () => {
       ...(requestedWslDistro
         ? { shellOverride: 'wsl.exe', terminalWindowsWslDistro: requestedWslDistro }
         : { shellOverride: 'powershell.exe' }),
+      ...(startupIngress ? { startupIngress } : {}),
       streamClient: { onData, onExit: vi.fn() }
     })
     return subprocess
   }
 
+  // Why: the backends now differ only in the ConPTY cooked-echo projection, so the stale-metadata
+  // contract is proven by which stream suppresses the ESC-stripped echo of its own reply.
   it('uses the spawned native shell over stale requested WSL metadata', async () => {
-    const replyProducers: string[] = []
-    const onData = vi.fn((data: string) => {
-      if (data === '\x1b]10;?\x07') {
-        replyProducers.push('renderer')
-        host.write('owner-test', '\x1b]10;rgb:ffff/ffff/ffff\x1b\\')
-      }
-    })
-    const subprocess = await createSession('powershell.exe', 'Ubuntu', onData)
+    const intent = {
+      colors: { foreground: '#2e3434', background: '#ffffff' },
+      deadlineMs: 5_000
+    }
+    const delivered: string[] = []
+    const onData = vi.fn((data: string) => delivered.push(data))
+    const subprocess = await createSession('powershell.exe', 'Ubuntu', onData, intent)
 
     subprocess.emitData('\x1b]10;?\x07')
+    subprocess.emitData(']10;rgb:2e2e/3434/3434\\')
+    subprocess.emitData('prompt')
 
-    expect(replyProducers).toEqual([])
-    expect(onData).toHaveBeenCalledWith('', '\x1b]10;?\x07'.length, true, '\x1b]10;?\x07'.length)
-    expect(subprocess.write).not.toHaveBeenCalled()
+    expect(subprocess.write).toHaveBeenCalledWith('\x1b]10;rgb:2e2e/3434/3434\x1b\\')
+    expect(delivered.join('')).toBe('prompt')
+  })
+
+  it('keeps the ConPTY echo projection off an actually spawned WSL shell', async () => {
+    const intent = {
+      colors: { foreground: '#2e3434', background: '#ffffff' },
+      deadlineMs: 5_000
+    }
+    const delivered: string[] = []
+    const onData = vi.fn((data: string) => delivered.push(data))
+    const subprocess = await createSession('wsl.exe', undefined, onData, intent)
+
+    subprocess.emitData('\x1b]10;?\x07')
+    subprocess.emitData(']10;rgb:2e2e/3434/3434\\')
+
+    expect(subprocess.write).toHaveBeenCalledWith('\x1b]10;rgb:2e2e/3434/3434\x1b\\')
+    expect(delivered.join('')).toBe(']10;rgb:2e2e/3434/3434\\')
   })
 
   it('keeps replies for an actually spawned WSL shell', async () => {

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -1752,7 +1752,9 @@ describe('LocalPtyProvider', () => {
       ])
     })
 
-    it('consumes a native Windows OSC color query before renderer delivery', async () => {
+    // Why: bundled ConPTY forwards OSC 10/11 instead of answering it, so a query this PTY has no
+    // startup colors for must reach the renderer responder rather than being consumed silently.
+    it('delivers an unanswerable native Windows OSC color query to the renderer', async () => {
       Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
       const dataHandler = vi.fn()
       provider.onData(dataHandler)
@@ -1766,13 +1768,7 @@ describe('LocalPtyProvider', () => {
 
       onDataCb(query)
 
-      expect(dataHandler).toHaveBeenCalledWith({
-        id,
-        data: '',
-        sequenceChars: query.length,
-        seq: query.length,
-        transformed: true
-      })
+      expect(dataHandler).toHaveBeenCalledWith({ id, data: query })
       expect(mockProc.write).not.toHaveBeenCalled()
     })
 

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -1244,7 +1244,9 @@ describe('PtyHandler', () => {
     }
   })
 
-  it('consumes a color query at a native Windows SSH relay owner', async () => {
+  // Why: bundled ConPTY forwards OSC 10/11 rather than answering it, so a relay owner without
+  // startup colors must forward the query to the client responder instead of consuming it.
+  it('forwards an unanswerable color query at a native Windows SSH relay owner', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     try {
@@ -1265,10 +1267,7 @@ describe('PtyHandler', () => {
       expect(term.write).not.toHaveBeenCalled()
       expect(dispatcher.notify).toHaveBeenCalledWith('pty.data', {
         id: 'pty-1',
-        data: '',
-        rawLength: '\x1b]10;?\x07'.length,
-        seq: '\x1b]10;?\x07'.length,
-        transformed: true
+        data: '\x1b]10;?\x07'
       })
     } finally {
       if (originalPlatform) {

--- a/src/shared/pty-startup-ingress.test.ts
+++ b/src/shared/pty-startup-ingress.test.ts
@@ -133,7 +133,9 @@ describe('PtyStartupIngress', () => {
     ])
   })
 
-  it('consumes a native ConPTY color query before any downstream responder at every split', () => {
+  it('releases an unanswerable native ConPTY color query to the downstream responder at every split', () => {
+    // Why: bundled ConPTY forwards the query instead of answering it. Consuming a query this
+    // transaction cannot answer leaves the agent with the pseudoconsole palette (#0c0c0c).
     const query = '\x1b]11;?\x1b\\'
     for (let split = 0; split <= query.length; split += 1) {
       const writes: string[] = []
@@ -149,14 +151,44 @@ describe('PtyStartupIngress', () => {
       ingress.drainAndClose()
 
       expect(writes, `split ${split}`).toEqual([])
-      expect(visible(emissions), `split ${split}`).toBe('')
-      expect(emissions, `split ${split}`).toEqual([
-        { data: '', rawStartSeq: 0, rawEndSeq: query.length, transformed: true }
-      ])
+      expect(visible(emissions), `split ${split}`).toBe(query)
     }
   })
 
-  it('keeps native ConPTY startup authority until it can answer with owner-supplied colors', () => {
+  it('transfers native ConPTY authority on close and after the startup deadline', () => {
+    vi.useFakeTimers()
+    const closeWrites: string[] = []
+    const closeEmissions: PtyIngressEmission[] = []
+    const closed = new PtyStartupIngress({
+      intent: { colors: COLORS, deadlineMs: 5_000 },
+      ownerBackend: 'windows-conpty',
+      write: (data) => closeWrites.push(data),
+      onEmission: (emission) => closeEmissions.push(emission)
+    })
+
+    closed.accept('\x1b]10;')
+    closed.closeQueryAuthority()
+    closed.accept('?\x07')
+
+    expect(closeWrites).toEqual([])
+    expect(visible(closeEmissions)).toBe('\x1b]10;?\x07')
+
+    const lateWrites: string[] = []
+    const lateEmissions: PtyIngressEmission[] = []
+    const late = new PtyStartupIngress({
+      intent: { colors: COLORS, deadlineMs: 5_000 },
+      ownerBackend: 'windows-conpty',
+      write: (data) => lateWrites.push(data),
+      onEmission: (emission) => lateEmissions.push(emission)
+    })
+    vi.advanceTimersByTime(5_001)
+    late.accept('\x1b]11;?\x1b\\')
+
+    expect(lateWrites).toEqual([])
+    expect(visible(lateEmissions)).toBe('\x1b]11;?\x1b\\')
+  })
+
+  it('releases a native ConPTY query the transaction already answered once', () => {
     const writes: string[] = []
     const emissions: PtyIngressEmission[] = []
     const ingress = new PtyStartupIngress({
@@ -166,15 +198,15 @@ describe('PtyStartupIngress', () => {
       onEmission: (emission) => emissions.push(emission)
     })
 
-    ingress.accept('\x1b]10;')
-    ingress.closeQueryAuthority()
-    ingress.accept('?\x07')
+    ingress.accept('\x1b]10;?\x1b\\\x1b]11;?\x1b\\')
+    emissions.length = 0
+    ingress.accept('\x1b]11;?\x1b\\')
 
-    expect(writes).toEqual(['\x1b]10;rgb:2e2e/3434/3434\x1b\\'])
-    expect(visible(emissions)).toBe('')
+    expect(writes).toEqual(['\x1b]10;rgb:2e2e/3434/3434\x1b\\', '\x1b]11;rgb:ffff/ffff/ffff\x1b\\'])
+    expect(visible(emissions)).toBe('\x1b]11;?\x1b\\')
   })
 
-  it('keeps a split native ConPTY query private across close, expiry, and snapshot barriers', () => {
+  it('releases a split native ConPTY query losslessly across close, expiry, and snapshot barriers', () => {
     vi.useFakeTimers()
     for (const barrier of ['close', 'expire', 'snapshot'] as const) {
       const emissions: PtyIngressEmission[] = []
@@ -192,14 +224,10 @@ describe('PtyStartupIngress', () => {
       } else {
         ingress.snapshotBarrier()
       }
-      expect(emissions, barrier).toEqual([])
 
       ingress.accept('?\x07')
 
-      expect(visible(emissions), barrier).toBe('')
-      expect(emissions, barrier).toEqual([
-        { data: '', rawStartSeq: 0, rawEndSeq: '\x1b]10;?\x07'.length, transformed: true }
-      ])
+      expect(visible(emissions), barrier).toBe('\x1b]10;?\x07')
     }
 
     const malformedEmissions: PtyIngressEmission[] = []
@@ -257,7 +285,7 @@ describe('PtyStartupIngress', () => {
     nativeIngress.accept(`${input}\x1b]10;?\x07`)
 
     expect(writes).toEqual([])
-    expect(visible(emissions)).toBe(input)
+    expect(visible(emissions)).toBe(`${input}\x1b]10;?\x07`)
   })
 
   it('ignores callbacks after teardown without recreating the raw sequence domain', () => {

--- a/src/shared/pty-startup-ingress.ts
+++ b/src/shared/pty-startup-ingress.ts
@@ -119,18 +119,13 @@ export class PtyStartupIngress {
         this.processEchoSpan(operation.chunk)
         return
       case 'close-query':
-        if (this.ownerBackend !== 'windows-conpty') {
-          this.queryOpen = false
-          this.releaseQueryPending()
-        }
-        // Why: ConPTY cannot safely transfer color-query authority to a downstream view.
+        this.queryOpen = false
+        this.releaseQueryPending()
         return
       case 'expire':
         this.queryOpen = false
         this.releaseEchoPending()
-        if (this.ownerBackend !== 'windows-conpty') {
-          this.releaseQueryPending()
-        }
+        this.releaseQueryPending()
         this.expectedEchoes.length = 0
         this.clearDeadline()
         return
@@ -181,8 +176,10 @@ export class PtyStartupIngress {
   private processQuerySpan(span: PtyIngressSourceSpan): void {
     const input = combinePtyIngressSourceSpans(this.queryPending, span)
     this.queryPending = null
-    const suppressConptyQuery = this.ownerBackend === 'windows-conpty'
-    if ((!this.queryOpen || !this.intent) && !suppressConptyQuery) {
+    if (!this.queryOpen || !this.intent) {
+      // Why: bundled ConPTY forwards OSC 10/11 queries instead of answering them, so a query
+      // this transaction cannot answer must reach the normal view/model responder or the agent
+      // falls back to the pseudoconsole palette (always #0c0c0c) and renders a dark theme.
       this.emit(input, false)
       return
     }
@@ -218,7 +215,7 @@ export class PtyStartupIngress {
       }
       const querySpan = slicePtyIngressSourceSpan(input, candidateIndex, query.endIndex)
       const answered = this.queryOpen && this.intent && this.answerQuery(query.slots)
-      if (answered || suppressConptyQuery) {
+      if (answered) {
         this.emit(querySpan, true, '')
       } else {
         this.emit(querySpan, false)
@@ -296,9 +293,7 @@ export class PtyStartupIngress {
       this.expectedEchoes.shift()
       this.releaseEchoPending()
     }
-    if (this.ownerBackend !== 'windows-conpty') {
-      this.releaseQueryPending()
-    }
+    this.releaseQueryPending()
   }
 
   private emit(span: PtyIngressSourceSpan, transformed: boolean, data = span.data): void {

--- a/tests/e2e/terminal-osc-color-queries.spec.ts
+++ b/tests/e2e/terminal-osc-color-queries.spec.ts
@@ -44,6 +44,36 @@ async function setActiveTerminalTheme(page: Page, theme: TerminalTheme): Promise
   }, theme)
 }
 
+type PaneOscObserverWindow = Window & { __oscBackgroundQueriesSeen?: string[] }
+
+// Why: both responders write the identical reply, so observing the reply cannot prove which one
+// produced it. Record the queries the pane's parser sees instead: the startup transaction consumes
+// what it answers, so a query reaching this handler proves it was released downstream.
+async function recordPaneOscBackgroundQueries(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('No active terminal pane to observe')
+    }
+    const observerWindow = window as PaneOscObserverWindow
+    observerWindow.__oscBackgroundQueriesSeen = []
+    pane.terminal.parser.registerOscHandler(11, (data: string) => {
+      observerWindow.__oscBackgroundQueriesSeen?.push(data)
+      // Why: false keeps the existing color-query responder in the chain.
+      return false
+    })
+  })
+}
+
 async function injectPtyOutput(page: Page, paneKey: string, data: string): Promise<boolean> {
   return page.evaluate(
     ({ targetPaneKey, output }) =>
@@ -92,9 +122,11 @@ test('answers OSC foreground and background color queries from the active termin
 })
 
 // Why: bundled ConPTY forwards OSC 10/11 to Orca instead of answering it. A query the startup
-// transaction cannot answer must still reach this responder, or the program falls back to the
+// transaction cannot answer must still reach the pane responder, or the program falls back to the
 // pseudoconsole palette (#0c0c0c) and paints a dark UI inside a light pane.
-test('answers a color query a real PTY emits outside the startup window', async ({
+const STARTUP_INGRESS_DEADLINE_MS = 5_000
+
+test('releases a color query a real PTY emits after the startup window closes', async ({
   electronApp,
   orcaPage
 }) => {
@@ -109,7 +141,12 @@ test('answers a color query a real PTY emits outside the startup window', async 
     foreground: '#2e3434',
     background: 'rgba(255, 255, 255, 1)'
   })
+  await recordPaneOscBackgroundQueries(orcaPage)
   await clearTerminalPtyWriteLog(electronApp)
+
+  // Why: the query must land after any startup transaction has expired, otherwise the source owner
+  // could answer it and the assertions below would not describe the downstream responder.
+  await orcaPage.waitForTimeout(STARTUP_INGRESS_DEADLINE_MS + 500)
 
   // Why: BEL terminates the query without a backslash, so the one command line survives both
   // PowerShell and POSIX shell quoting.
@@ -118,13 +155,17 @@ test('answers a color query a real PTY emits outside the startup window', async 
   await expect
     .poll(
       async () =>
-        (await readTerminalPtyWriteEntries(electronApp))
-          .filter((entry) => entry.id === ptyId)
-          .map((entry) => entry.data),
+        orcaPage.evaluate(() => (window as PaneOscObserverWindow).__oscBackgroundQueriesSeen ?? []),
       {
         timeout: 20_000,
-        message: 'the PTY-emitted color query was consumed instead of answered'
+        message: 'the post-startup color query never reached the pane responder'
       }
     )
-    .toContain('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
+    .toContain('?')
+
+  expect(
+    (await readTerminalPtyWriteEntries(electronApp))
+      .filter((entry) => entry.id === ptyId)
+      .map((entry) => entry.data)
+  ).toContain('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
 })

--- a/tests/e2e/terminal-osc-color-queries.spec.ts
+++ b/tests/e2e/terminal-osc-color-queries.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
 import {
+  execInTerminal,
   waitForActivePaneHookDescriptor,
   waitForActivePanePtyId,
   waitForActiveTerminalManager
@@ -88,4 +89,42 @@ test('answers OSC foreground and background color queries from the active termin
       }
     )
     .toEqual(['\x1b]10;rgb:2e2e/3434/3434\x1b\\', '\x1b]11;rgb:ffff/ffff/ffff\x1b\\'])
+})
+
+// Why: bundled ConPTY forwards OSC 10/11 to Orca instead of answering it. A query the startup
+// transaction cannot answer must still reach this responder, or the program falls back to the
+// pseudoconsole palette (#0c0c0c) and paints a dark UI inside a light pane.
+test('answers a color query a real PTY emits outside the startup window', async ({
+  electronApp,
+  orcaPage
+}) => {
+  await installTerminalPtyWriteSpy(electronApp)
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+  await ensureTerminalVisible(orcaPage)
+  await waitForActiveTerminalManager(orcaPage, 30_000)
+
+  const ptyId = await waitForActivePanePtyId(orcaPage)
+  await setActiveTerminalTheme(orcaPage, {
+    foreground: '#2e3434',
+    background: 'rgba(255, 255, 255, 1)'
+  })
+  await clearTerminalPtyWriteLog(electronApp)
+
+  // Why: BEL terminates the query without a backslash, so the one command line survives both
+  // PowerShell and POSIX shell quoting.
+  await execInTerminal(orcaPage, ptyId, `node -e "process.stdout.write('\\x1b]11;?\\x07')"`)
+
+  await expect
+    .poll(
+      async () =>
+        (await readTerminalPtyWriteEntries(electronApp))
+          .filter((entry) => entry.id === ptyId)
+          .map((entry) => entry.data),
+      {
+        timeout: 20_000,
+        message: 'the PTY-emitted color query was consumed instead of answered'
+      }
+    )
+    .toContain('\x1b]11;rgb:ffff/ffff/ffff\x1b\\')
 })


### PR DESCRIPTION
## Summary

On Windows, an agent's OSC 10/11 startup color probe often goes unanswered, so the agent falls back to its own default and paints a dark TUI inside a light pane. Codex reproduces this reliably: open a terminal, wait past the 5s startup window, then type `codex` — the composer renders dark regardless of the Orca theme.

`PtyStartupIngress` consumes **every** OSC 10/11 query on a `windows-conpty` owner and replies only while its startup window is open. That rule ("ConPTY cannot safely transfer color-query authority to a downstream view", 2026-07-19 design) was measured against the **system** ConPTY. Every Windows spawn now passes `useConptyDll: true` (`pty-subprocess.ts`, `local-pty-utils.ts`), so the bundled OpenConsole owns the pseudoconsole instead — and the two backends behave in opposite ways.

Measured with a node-pty harness on Windows 11, node-pty 1.1.0, bundled ConPTY 1.23.251008001:

| backend | forwards `OSC 10/11 ?` to the terminal | outer reply reaches the client | cooked echo of the reply |
| --- | --- | --- | --- |
| system ConPTY (`useConptyDll: false`) | no | no | n/a |
| bundled ConPTY (`useConptyDll: true`) | **yes** | **yes, byte-for-byte** | **none observed** |

So on the backend Orca actually uses, consuming a query the transaction cannot answer silences the only responder the program can reach. Codex then falls back to `GetConsoleScreenBufferInfoEx` (`codex-rs/tui/src/terminal_probe.rs`), reads the pseudoconsole palette — `bgIndex=0`, `#0c0c0c` — and renders dark. Measured inside a bundled-ConPTY session:

```
BEFORE attr=0x0007 bgIndex=0 bgCOLORREF=0x0c0c0c rgb=#0c0c0c
```

This triggers whenever the query lands after the startup deadline or after both slots were already answered once, which matches the reported "mostly fine, sometimes dark" behavior.

Startup query authority now transfers identically on every backend: a query this transaction answers is consumed, a query it cannot answer is released to the normal delivered/hidden responder (visible xterm parser handler, or the hidden-startup responder for agent panes). The measured ConPTY echo projection stays gated on `windows-conpty`, so a host that still reaches the system ConPTY keeps its cooked-echo protection.

## Screenshots

No visual change to Orca's own UI. The user-visible effect is inside the agent TUI (Codex composer following the pane theme instead of rendering dark); no before/after capture of that is included — see Notes.

## Testing

- [ ] `pnpm lint` — oxlint, switch-exhaustiveness, styled-scrollbars, reliability gates (48), and the max-lines ratchet all pass. The run then stops at `verify:skill-bundle-manifest` ("Generated skill artifacts are stale"), which reproduces on a clean `origin/main` checkout on this machine, so it is a pre-existing local/baseline condition rather than something this PR introduces. Nothing here touches `resources/skills`.
- [x] `pnpm typecheck` — node and web projects clean.
- [ ] `pnpm test` — ran the affected suites rather than the full run: `pty-startup-ingress`, `session`, `terminal-host-pty-owner-backend`, `local-pty-provider`, `relay/pty-handler`. All pass except 15 pre-existing `relay/pty-handler` failures that also fail on `main` on this machine (kill/shutdown timing, unrelated to color).
- [x] `pnpm build` — `build:win` produced a signed installer; installed and launched it on Windows 11.
- [x] Added or updated high-quality tests that would catch regressions

Test detail:

- `pty-startup-ingress.test.ts`: three ConPTY contract tests rewritten to the new rule, plus regressions for release-after-close, release-after-deadline, and release-of-an-already-answered slot.
- `session.test.ts`, `local-pty-provider.test.ts`, `relay/pty-handler.test.ts`: same contract at the daemon, local provider, and relay owners.
- `terminal-host-pty-owner-backend.test.ts`: the stale-WSL-metadata contract now distinguishes backends by the cooked-echo projection, the only remaining difference between them.
- `tests/e2e/terminal-osc-color-queries.spec.ts`: new Electron e2e where a real PTY emits the query after the startup window closes. Per review feedback it is now gated on a deterministic post-startup condition — it waits past the startup deadline before emitting the query, and its primary assertion is that the pane's own OSC 11 parser handler saw the query. That distinguishes the responders: the startup transaction consumes what it answers, so a query reaching the pane handler proves it was released downstream. The reply assertion is kept as a secondary check. Verified by reverting only the source fix and rerunning: the spec fails 4/4 runs without it.

## AI Review Report

Risks checked and what came of them:

- **Is there still a responder after release?** Traced all three cases: visible pane answers via the xterm parser handlers (`terminal-capability-replies.ts`), hidden agent panes answer via `writeHiddenStartupRendererQueries` (`pty-connection.ts`, explicitly built for Codex's 100 ms probe budget), hidden non-agent panes are not skipped by `shouldSkipHiddenRendererOutput` so the data reaches xterm normally. No gap found.
- **Double answers?** Each query still has exactly one responder — the transaction consumes only what it answered; everything else is released once.
- **Replay safety.** Released queries now appear in snapshots. Replay paths already return early (`isReplaying()`), so a replayed query still produces no provider write.
- **Lossless drains.** `expire`, `close-query`, and `snapshot` now release a held partial candidate on ConPTY too, which is stricter than the previous behavior (it held bytes until teardown).
- **Cross-platform.** The change removes a Windows-only special case, so POSIX and WSL behavior is unchanged; the only remaining backend-specific code is the echo projection, still gated on `windows-conpty`. The new e2e uses a BEL-terminated query so its single command line survives both PowerShell and POSIX shell quoting. No shortcuts, labels, or path handling touched.
- **Flaky neighbour, measured rather than assumed:** the pre-existing spec in that file (`answers OSC foreground and background color queries...`) intermittently fails when the two specs run in the same batch, because its strict `toEqual` on the whole write log admits no extra writes — observed failures picked up unrelated `CSI c` / `CSI I` replies once and two empty writes another time. I suspected this change had raised the rate (more queries now reach xterm and get answered), so I measured it: reverting only the source fix and running the file three times, the legacy spec still failed 1/3, versus 2/5 with the fix. No discrimination at that sample size, so it is pre-existing flakiness, not something this PR introduces. Left untouched as out of scope; worth a separate fix (compare only that PTY's OSC color replies rather than the entire write log).

## Security Audit

- No new input parsing: the OSC grammar, bounds (`MAX_QUERY_CANDIDATE_CHARS`), and reply construction are untouched. The change only decides whether an already-parsed span is consumed or forwarded.
- No command execution, path handling, auth, secrets, or dependency changes. The new e2e runs `node -e` inside the test terminal only.
- IPC surface unchanged — same emission contract (`data`, `rawStartSeq`, `rawEndSeq`, `transformed`), same raw-sequence accounting.
- Widened data path considered: bytes previously dropped now reach the model, snapshots, and views. They are the program's own color query, already subject to the existing OSC parser, and replay remains reply-silent.

## Notes

- Residual risk: on a host that still reaches the **system** ConPTY, a downstream reply's cooked echo is no longer suppressed, because only source-written replies register an expected projection. Accepted because the dark-on-light failure is deterministic on the bundled backend while that echo is not reproducible there. If any spawn path can still land on the system ConPTY, that would be worth naming explicitly.
- Not verified: a visual before/after of Codex rendering inside Orca. The evidence covers the PTY-level mechanism and the reply path, not the agent's rendering.
- The 2026-07-20 amendment in the design doc had its query-consumption sentences struck through and pointed at the new amendment, so the plan states one behavior (per review feedback).

- Related PR: #6975 addresses the same OSC 10/11 path but is not a duplicate. It suppresses downstream color replies for native Windows ConPTY to prevent reply leakage. This PR targets the later PTY-owner startup-ingress architecture and the bundled ConPTY backend Orca actually enables, which measurements show forwards both the query and the outer reply without cooked echo. On that backend, suppressing or retaining an unanswered query removes the only responder Codex can reach, so this change releases only queries the startup transaction cannot answer while retaining the existing Windows echo projection for replies it does answer.

## ELI5

On Windows, agents probing terminal colors at startup often got no reply and rendered a dark TUI in a light pane. Orca answers those color queries when ConPTY forwards them so themes match.
