### PR TITLE
fix(codex): persist plugin registrations across managed-home remirrors

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -30,6 +30,7 @@
     "../src/main/codex/codex-hook-identity.ts",
     "../src/main/codex/codex-hook-trust-grant.ts",
     "../src/main/codex/codex-managed-trust-reconciliation.ts",
+    "../src/main/codex/codex-plugin-registration-config.ts",
     "../src/main/codex/codex-process-exit-deadline.ts",
     "../src/main/codex/codex-trust-config-rollback.ts",
     "../src/main/codex/codex-trust-grant-telemetry.ts",

--- a/src/main/codex/codex-config-settings-preservation.ts
+++ b/src/main/codex/codex-config-settings-preservation.ts
@@ -1,5 +1,9 @@
 import { removePromotedSettingsFromContent } from './codex-config-settings-removal'
 import { upsertPromotedSettingsInContent } from './codex-config-settings-upsert'
+import {
+  applyCodexPluginRegistrationChanges,
+  isCodexPluginRegistrationKey
+} from './codex-plugin-registration-config'
 
 export function preserveRuntimeConflictValues(
   content: string,
@@ -9,10 +13,14 @@ export function preserveRuntimeConflictValues(
   const keys = new Set<string>()
   for (const [key, raw] of values) {
     const previous = result
-    result =
-      raw === null
-        ? removePromotedSettingsFromContent(result, new Set([key]))
-        : upsertPromotedSettingsInContent(result, new Map([[key, raw]]))
+    if (isCodexPluginRegistrationKey(key)) {
+      result = applyCodexPluginRegistrationChanges(result, new Map([[key, raw]]))
+    } else {
+      result =
+        raw === null
+          ? removePromotedSettingsFromContent(result, new Set([key]))
+          : upsertPromotedSettingsInContent(result, new Map([[key, raw]]))
+    }
     if (result !== previous) {
       keys.add(key)
     }

--- a/src/main/codex/codex-plugin-registration-config.ts
+++ b/src/main/codex/codex-plugin-registration-config.ts
@@ -1,0 +1,187 @@
+import { existsSync } from 'node:fs'
+import { readAgentStateFileSync } from '../agent-state-file-reader'
+import { parseTomlTableHeaderPath } from './config-toml-key-path'
+import { getTomlSections } from './config-toml-runtime-owned-sections'
+import type { CodexSettingsBaseline, CodexSettingsConflict } from './config-settings-baseline'
+import { resolveUntrackedCodexSetting } from './config-settings-conflict-resolution'
+
+const REGISTRATION_ROOTS = new Set(['marketplaces', 'plugins'])
+
+export function readCodexPluginRegistrationTables(configPath: string): Map<string, string> {
+  if (!existsSync(configPath)) {
+    return new Map()
+  }
+  const content = readAgentStateFileSync(configPath)
+  const lines = content.split('\n')
+  const registrations = new Map<string, string>()
+  for (const table of getTomlTableRanges(content)) {
+    const key = getCodexPluginRegistrationKey(table.header)
+    if (key && !registrations.has(key)) {
+      registrations.set(
+        key,
+        normalizeRegistrationBlock(lines.slice(table.start, table.end).join('\n'))
+      )
+    }
+  }
+  return registrations
+}
+
+export function isCodexPluginRegistrationKey(key: string): boolean {
+  const separator = key.indexOf('.')
+  if (!REGISTRATION_ROOTS.has(key.slice(0, separator))) {
+    return false
+  }
+  try {
+    return typeof JSON.parse(key.slice(separator + 1)) === 'string'
+  } catch {
+    return false
+  }
+}
+
+export function applyCodexPluginRegistrationChanges(
+  content: string,
+  changes: ReadonlyMap<string, string | null>
+): string {
+  let result = content
+  for (const [key, block] of changes) {
+    if (isCodexPluginRegistrationKey(key)) {
+      result = applyCodexPluginRegistrationChange(result, key, block)
+    }
+  }
+  return result
+}
+
+export function collectCodexPluginRegistrationChanges(context: {
+  baseline: CodexSettingsBaseline
+  runtimeRegistrations: ReadonlyMap<string, string>
+  systemRegistrations: ReadonlyMap<string, string>
+  registrationChanges: Map<string, string | null>
+  conflicts: Map<string, CodexSettingsConflict>
+  runtimeValuesToPreserve: Map<string, string | null>
+}): void {
+  const keys = new Set([
+    ...context.runtimeRegistrations.keys(),
+    ...context.systemRegistrations.keys(),
+    ...(context.baseline.pluginRegistrations?.keys() ?? []),
+    ...[...context.baseline.conflicts.keys()].filter(isCodexPluginRegistrationKey)
+  ])
+  for (const key of keys) {
+    const runtimeRaw = context.runtimeRegistrations.get(key) ?? null
+    const systemRaw = context.systemRegistrations.get(key) ?? null
+    const existingConflict = context.baseline.conflicts.get(key)
+    if (existingConflict || context.baseline.pluginRegistrations === null) {
+      const resolution = resolveUntrackedCodexSetting(runtimeRaw, systemRaw, existingConflict)
+      if (resolution.action === 'promote-runtime') {
+        context.registrationChanges.set(key, resolution.raw)
+      } else if (resolution.action === 'preserve') {
+        context.conflicts.set(key, resolution.conflict)
+        context.runtimeValuesToPreserve.set(key, runtimeRaw)
+      }
+      continue
+    }
+
+    const baselineRaw = context.baseline.pluginRegistrations.get(key) ?? null
+    if (runtimeRaw !== baselineRaw && systemRaw === baselineRaw) {
+      context.registrationChanges.set(key, runtimeRaw)
+    }
+  }
+}
+
+function getCodexPluginRegistrationKey(header: string): string | null {
+  const table = parseTomlTableHeaderPath(header)
+  if (
+    !table ||
+    table.isArray ||
+    table.segments.length !== 2 ||
+    !REGISTRATION_ROOTS.has(table.segments[0] ?? '')
+  ) {
+    return null
+  }
+  return `${table.segments[0]}.${JSON.stringify(table.segments[1])}`
+}
+
+function applyCodexPluginRegistrationChange(
+  content: string,
+  key: string,
+  block: string | null
+): string {
+  const lines = content.split('\n')
+  const matches = getTomlTableRanges(content).filter(
+    (table) => getCodexPluginRegistrationKey(table.header) === key
+  )
+
+  if (matches.length === 0) {
+    return block === null ? content : appendRegistrationBlock(content, block)
+  }
+
+  const firstStart = matches[0]?.start
+  for (const match of matches.toReversed()) {
+    if (block !== null && match.start === firstStart) {
+      let suffixStart = match.end
+      while (suffixStart > match.start + 1 && (lines[suffixStart - 1] ?? '').trim() === '') {
+        suffixStart -= 1
+      }
+      lines.splice(
+        match.start,
+        match.end - match.start,
+        ...renderRegistrationLines(block, content.includes('\r\n')),
+        ...lines.slice(suffixStart, match.end)
+      )
+    } else {
+      lines.splice(match.start, match.end - match.start)
+    }
+  }
+  return lines.join('\n')
+}
+
+function getTomlTableRanges(content: string): { header: string; start: number; end: number }[] {
+  const lines = content.split('\n')
+  const sections = getTomlSections(content)
+  const starts = sections.map((section) => {
+    let start = section.start
+    while (start > 0) {
+      const previous = (lines[start - 1] ?? '').trim()
+      if (previous !== '' && !previous.startsWith('#')) {
+        break
+      }
+      start -= 1
+    }
+    return start
+  })
+  return sections.map((section, index) => ({
+    header: section.header,
+    start: starts[index] ?? section.start,
+    end: starts[index + 1] ?? lines.length
+  }))
+}
+
+function appendRegistrationBlock(content: string, block: string): string {
+  const eol = content.includes('\r\n') ? '\r\n' : '\n'
+  const rendered = normalizeRegistrationBlock(block).replace(/\n/g, eol)
+  if (content.length === 0) {
+    return `${rendered}${eol}`
+  }
+  const separator = content.endsWith(`${eol}${eol}`)
+    ? ''
+    : content.endsWith(eol)
+      ? eol
+      : `${eol}${eol}`
+  return `${content}${separator}${rendered}${eol}`
+}
+
+function renderRegistrationLines(block: string, usesCrlf: boolean): string[] {
+  return normalizeRegistrationBlock(block)
+    .split('\n')
+    .map((line) => (usesCrlf ? `${line}\r` : line))
+}
+
+function normalizeRegistrationBlock(block: string): string {
+  const lines = block.replace(/\r\n/g, '\n').split('\n')
+  while (lines[0]?.trim() === '') {
+    lines.shift()
+  }
+  while (lines.at(-1)?.trim() === '') {
+    lines.pop()
+  }
+  return lines.join('\n')
+}

--- a/src/main/codex/config-plugin-registration-promotion.test.ts
+++ b/src/main/codex/config-plugin-registration-promotion.test.ts
@@ -69,13 +69,22 @@ enabled = true
     mirror()
 
     const system = config(systemHomePath)
-    expect(system).toContain('# marketplace note')
-    expect(system).toContain('["marketplaces"."acme"] # source stays documented')
-    expect(system).toContain("[plugins.'formatter@acme']")
-    expect(system).toContain('# user choice')
-    expect(system.indexOf('[features]')).toBeLessThan(system.indexOf('["marketplaces"'))
-    expect(system.indexOf('["marketplaces"')).toBeLessThan(system.indexOf("[plugins.'"))
-    expect(system.replaceAll('\r\n', '')).not.toContain('\n')
+    expect(system).toBe(
+      '# system preamble\r\n' +
+        'model = "gpt-5"\r\n' +
+        '\r\n' +
+        '[features]\r\n' +
+        'hooks = true\r\n' +
+        '\r\n' +
+        '# marketplace note\r\n' +
+        '["marketplaces"."acme"] # source stays documented\r\n' +
+        'source_type = "git"\r\n' +
+        'source = "https://example.invalid/acme/plugins.git"\r\n' +
+        '\r\n' +
+        "[plugins.'formatter@acme']\r\n" +
+        '# user choice\r\n' +
+        'enabled = true\r\n'
+    )
 
     const settledRuntime = config(runtimeHomePath)
     mirror()

--- a/src/main/codex/config-plugin-registration-promotion.test.ts
+++ b/src/main/codex/config-plugin-registration-promotion.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+
+let root: string
+let runtimeHomePath: string
+let systemHomePath: string
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'orca-codex-plugin-promotion-'))
+  runtimeHomePath = join(root, 'managed')
+  systemHomePath = join(root, 'system')
+  mkdirSync(runtimeHomePath)
+  mkdirSync(systemHomePath)
+})
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+function mirror(): void {
+  syncSystemConfigIntoManagedCodexHome({ runtimeHomePath, systemHomePath })
+}
+
+function config(home: string): string {
+  return readFileSync(join(home, 'config.toml'), 'utf-8')
+}
+
+function writeConfig(home: string, content: string): void {
+  writeFileSync(join(home, 'config.toml'), content, 'utf-8')
+}
+
+function registeredConfig(enabled = true): string {
+  return `model = "gpt-5"
+
+[marketplaces.acme]
+last_updated = "2026-07-25T00:00:00Z"
+source_type = "git"
+source = "https://example.invalid/acme/plugins.git"
+
+[plugins."formatter@acme"]
+enabled = ${enabled}
+`
+}
+
+describe('Codex plugin registration promotion', () => {
+  it('promotes quoted registrations byte-stably without disturbing comments, CRLF, or order', () => {
+    writeConfig(
+      systemHomePath,
+      '# system preamble\r\nmodel = "gpt-5"\r\n\r\n[features]\r\nhooks = true\r\n'
+    )
+    mirror()
+
+    writeConfig(
+      runtimeHomePath,
+      `${config(runtimeHomePath)}
+# marketplace note
+["marketplaces"."acme"] # source stays documented
+source_type = "git"
+source = "https://example.invalid/acme/plugins.git"
+
+[plugins.'formatter@acme']
+# user choice
+enabled = true
+`
+    )
+    mirror()
+
+    const system = config(systemHomePath)
+    expect(system).toContain('# marketplace note')
+    expect(system).toContain('["marketplaces"."acme"] # source stays documented')
+    expect(system).toContain("[plugins.'formatter@acme']")
+    expect(system).toContain('# user choice')
+    expect(system.indexOf('[features]')).toBeLessThan(system.indexOf('["marketplaces"'))
+    expect(system.indexOf('["marketplaces"')).toBeLessThan(system.indexOf("[plugins.'"))
+    expect(system.replaceAll('\r\n', '')).not.toContain('\n')
+
+    const settledRuntime = config(runtimeHomePath)
+    mirror()
+    expect(config(systemHomePath)).toBe(system)
+    expect(config(runtimeHomePath)).toBe(settledRuntime)
+    expect(config(systemHomePath).match(/formatter@acme/g)).toHaveLength(1)
+  })
+
+  it('promotes an enabled change and does not revive the prior value', () => {
+    writeConfig(systemHomePath, registeredConfig())
+    mirror()
+
+    writeConfig(
+      runtimeHomePath,
+      config(runtimeHomePath).replace('enabled = true', 'enabled = false')
+    )
+    mirror()
+
+    expect(config(systemHomePath)).toContain('enabled = false')
+    expect(config(runtimeHomePath)).toContain('enabled = false')
+    mirror()
+    expect(config(systemHomePath)).not.toContain('enabled = true')
+    expect(config(systemHomePath).match(/\[plugins\./g)).toHaveLength(1)
+  })
+
+  it('creates a missing system config from a registration-only install', () => {
+    mirror()
+    writeConfig(
+      runtimeHomePath,
+      `[marketplaces.acme]
+source_type = "git"
+source = "https://example.invalid/acme/plugins.git"
+
+[plugins."formatter@acme"]
+enabled = true
+`
+    )
+
+    mirror()
+
+    expect(config(systemHomePath)).toContain('[marketplaces.acme]')
+    expect(config(systemHomePath)).toContain('[plugins."formatter@acme"]')
+    expect(config(runtimeHomePath)).toContain('[plugins."formatter@acme"]')
+  })
+
+  it('lets an outside edit to the same registration win a conflict', () => {
+    writeConfig(systemHomePath, registeredConfig())
+    mirror()
+
+    writeConfig(
+      runtimeHomePath,
+      config(runtimeHomePath).replace('enabled = true', 'enabled = false')
+    )
+    writeConfig(
+      systemHomePath,
+      config(systemHomePath).replace('enabled = true', 'enabled = true # outside edit')
+    )
+    mirror()
+
+    expect(config(systemHomePath)).toContain('enabled = true # outside edit')
+    expect(config(runtimeHomePath)).toContain('enabled = true # outside edit')
+    expect(config(runtimeHomePath)).not.toContain('enabled = false')
+  })
+
+  it('anchors divergent registrations from a legacy baseline', () => {
+    writeConfig(systemHomePath, registeredConfig())
+    mirror()
+    const baselinePath = join(runtimeHomePath, '.orca-config-settings-baseline.json')
+    const baseline = JSON.parse(readFileSync(baselinePath, 'utf-8'))
+    delete baseline.pluginRegistrations
+    writeFileSync(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`)
+
+    writeConfig(
+      runtimeHomePath,
+      config(runtimeHomePath).replace('enabled = true', 'enabled = false')
+    )
+    writeConfig(
+      systemHomePath,
+      config(systemHomePath).replace('enabled = true', 'enabled = true # outside edit')
+    )
+    mirror()
+
+    expect(config(systemHomePath)).toContain('enabled = true # outside edit')
+    expect(config(runtimeHomePath)).toContain('enabled = false')
+    const conflicts = JSON.parse(readFileSync(baselinePath, 'utf-8')).conflicts
+    expect(conflicts['plugins."formatter@acme"']).toBeDefined()
+  })
+
+  it('promotes registration removals instead of resurrecting them', () => {
+    writeConfig(systemHomePath, registeredConfig())
+    mirror()
+
+    writeConfig(runtimeHomePath, 'model = "gpt-5"\n')
+    mirror()
+
+    expect(config(systemHomePath)).not.toContain('[marketplaces.')
+    expect(config(systemHomePath)).not.toContain('[plugins.')
+    expect(config(runtimeHomePath)).not.toContain('[marketplaces.')
+    expect(config(runtimeHomePath)).not.toContain('[plugins.')
+    const settledSystem = config(systemHomePath)
+    mirror()
+    expect(config(systemHomePath)).toBe(settledSystem)
+  })
+
+  it('does not infer registrations from marketplace or plugin cache files', () => {
+    writeConfig(systemHomePath, 'model = "gpt-5"\n')
+    mirror()
+    const pluginCache = join(runtimeHomePath, 'plugins', 'cache', 'formatter')
+    const marketplaceCache = join(runtimeHomePath, '.tmp', 'marketplaces', 'acme')
+    mkdirSync(pluginCache, { recursive: true })
+    mkdirSync(marketplaceCache, { recursive: true })
+    writeFileSync(join(pluginCache, 'plugin.json'), '{}')
+    writeFileSync(join(marketplaceCache, 'marketplace.json'), '{}')
+
+    mirror()
+
+    expect(config(systemHomePath)).toBe('model = "gpt-5"\n')
+    expect(config(runtimeHomePath)).not.toContain('[marketplaces.')
+    expect(config(runtimeHomePath)).not.toContain('[plugins.')
+  })
+})

--- a/src/main/codex/config-settings-baseline-upgrade.test.ts
+++ b/src/main/codex/config-settings-baseline-upgrade.test.ts
@@ -14,6 +14,7 @@ vi.mock('node:os', async (importOriginal) => {
 })
 
 import { syncSystemConfigIntoManagedCodexHome } from './codex-config-mirror'
+import { readCodexSettingsBaseline, writeCodexSettingsBaseline } from './config-settings-baseline'
 
 let tmpHome: string
 let userDataDir: string
@@ -78,6 +79,18 @@ function readBaseline(): {
 }
 
 describe('Codex settings baseline schema upgrade', () => {
+  it('preserves untracked plugin registrations when rewriting a baseline', () => {
+    mkdirSync(runtimeHomePath(), { recursive: true })
+    writeCodexSettingsBaseline(runtimeHomePath(), {
+      settings: new Map([['model', '"gpt-5"']]),
+      conflicts: new Map(),
+      pluginRegistrations: null
+    })
+
+    expect(readCodexSettingsBaseline(runtimeHomePath())?.pluginRegistrations).toBeNull()
+    expect(readBaseline()).not.toHaveProperty('pluginRegistrations')
+  })
+
   it('upgrades an aligned legacy baseline without creating a conflict', () => {
     const config = 'model = "gpt-5"\n\n[tui]\ntheme = "dark"\n'
     prepareLegacyState(config, config)

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -12,12 +12,14 @@ export type CodexSettingsConflict = {
 export type CodexSettingsBaseline = {
   settings: ReadonlyMap<string, string | null>
   conflicts: ReadonlyMap<string, CodexSettingsConflict>
+  pluginRegistrations: ReadonlyMap<string, string> | null
 }
 
 type StoredSettingsBaseline = {
   version: 1 | 2
   settings: Record<string, string | null>
   conflicts?: Record<string, CodexSettingsConflict>
+  pluginRegistrations?: Record<string, string>
 }
 
 export function readCodexSettingsBaseline(runtimeHomePath: string): CodexSettingsBaseline | null {
@@ -45,7 +47,14 @@ export function readCodexSettingsBaseline(runtimeHomePath: string): CodexSetting
         conflicts.set(key, conflict)
       }
     }
-    return { settings, conflicts }
+    const pluginRegistrations = Object.hasOwn(parsed, 'pluginRegistrations')
+      ? new Map(
+          Object.entries(parsed.pluginRegistrations ?? {}).filter(
+            (entry): entry is [string, string] => typeof entry[1] === 'string'
+          )
+        )
+      : null
+    return { settings, conflicts, pluginRegistrations }
   } catch {
     return null
   }
@@ -57,7 +66,8 @@ export function writeCodexSettingsBaseline(
 ): void {
   const file: StoredSettingsBaseline = {
     version: 2,
-    settings: Object.fromEntries(baseline.settings)
+    settings: Object.fromEntries(baseline.settings),
+    pluginRegistrations: Object.fromEntries(baseline.pluginRegistrations ?? [])
   }
   if (baseline.conflicts.size > 0) {
     file.conflicts = Object.fromEntries(baseline.conflicts)
@@ -84,6 +94,11 @@ function isStoredSettingsBaseline(value: unknown): value is StoredSettingsBaseli
     (candidate.version === 1 || candidate.version === 2) &&
     !!candidate.settings &&
     typeof candidate.settings === 'object' &&
-    !Array.isArray(candidate.settings)
+    !Array.isArray(candidate.settings) &&
+    (!Object.hasOwn(candidate, 'pluginRegistrations') ||
+      (!!candidate.pluginRegistrations &&
+        typeof candidate.pluginRegistrations === 'object' &&
+        !Array.isArray(candidate.pluginRegistrations) &&
+        Object.values(candidate.pluginRegistrations).every((value) => typeof value === 'string')))
   )
 }

--- a/src/main/codex/config-settings-baseline.ts
+++ b/src/main/codex/config-settings-baseline.ts
@@ -66,8 +66,10 @@ export function writeCodexSettingsBaseline(
 ): void {
   const file: StoredSettingsBaseline = {
     version: 2,
-    settings: Object.fromEntries(baseline.settings),
-    pluginRegistrations: Object.fromEntries(baseline.pluginRegistrations ?? [])
+    settings: Object.fromEntries(baseline.settings)
+  }
+  if (baseline.pluginRegistrations !== null) {
+    file.pluginRegistrations = Object.fromEntries(baseline.pluginRegistrations)
   }
   if (baseline.conflicts.size > 0) {
     file.conflicts = Object.fromEntries(baseline.conflicts)

--- a/src/main/codex/config-settings-conflict-resolution.ts
+++ b/src/main/codex/config-settings-conflict-resolution.ts
@@ -1,4 +1,4 @@
-import type { CodexSettingsConflict } from './config-settings-baseline'
+import type { CodexSettingsBaseline, CodexSettingsConflict } from './config-settings-baseline'
 
 export type CodexSettingsConflictResolution =
   | { action: 'aligned' }
@@ -32,4 +32,51 @@ export function resolveUntrackedCodexSetting(
     return { action: 'preserve', conflict: { runtime, system } }
   }
   return { action: 'preserve', conflict: existingConflict }
+}
+
+export type CodexPromotedSettingValue = {
+  raw: string
+  multiline: boolean
+}
+
+export function collectCodexSettingPromotionChanges(context: {
+  keys: readonly string[]
+  baseline: CodexSettingsBaseline
+  runtimeValues: ReadonlyMap<string, CodexPromotedSettingValue>
+  systemValues: ReadonlyMap<string, CodexPromotedSettingValue>
+  updates: Map<string, string>
+  conflicts: Map<string, CodexSettingsConflict>
+  runtimeValuesToPreserve: Map<string, string | null>
+}): void {
+  for (const key of context.keys) {
+    const runtimeRaw = getComparableRaw(context.runtimeValues.get(key))
+    const systemRaw = getComparableRaw(context.systemValues.get(key))
+    if (runtimeRaw === undefined || systemRaw === undefined) {
+      continue
+    }
+
+    const existingConflict = context.baseline.conflicts.get(key)
+    if (existingConflict || !context.baseline.settings.has(key)) {
+      const resolution = resolveUntrackedCodexSetting(runtimeRaw, systemRaw, existingConflict)
+      if (resolution.action === 'promote-runtime') {
+        context.updates.set(key, resolution.raw)
+      } else if (resolution.action === 'preserve') {
+        context.conflicts.set(key, resolution.conflict)
+        context.runtimeValuesToPreserve.set(key, runtimeRaw)
+      }
+      continue
+    }
+
+    const baselineRaw = context.baseline.settings.get(key)
+    if (runtimeRaw !== null && runtimeRaw !== baselineRaw && systemRaw === baselineRaw) {
+      context.updates.set(key, runtimeRaw)
+    }
+  }
+}
+
+function getComparableRaw(value: CodexPromotedSettingValue | undefined): string | null | undefined {
+  if (!value) {
+    return null
+  }
+  return value.multiline ? undefined : value.raw
 }

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -23,11 +23,18 @@ import { tuiStructuredKey, upsertPromotedSettingsInContent } from './codex-confi
 import {
   readCodexSettingsBaseline,
   writeCodexSettingsBaseline,
-  type CodexSettingsBaseline,
   type CodexSettingsConflict
 } from './config-settings-baseline'
-import { resolveUntrackedCodexSetting } from './config-settings-conflict-resolution'
+import {
+  collectCodexSettingPromotionChanges,
+  type CodexPromotedSettingValue
+} from './config-settings-conflict-resolution'
 import { extractOrdinaryCodexSettings } from './config-toml-runtime-owned-sections'
+import {
+  applyCodexPluginRegistrationChanges,
+  collectCodexPluginRegistrationChanges,
+  readCodexPluginRegistrationTables
+} from './codex-plugin-registration-config'
 
 // Why: the mirror reverts in-Codex config changes each launch; promotion salvages them by diffing the last baseline.
 
@@ -78,12 +85,6 @@ function matchTuiStructuredKey(
   return tuiBodyActive && tuiKey && isPromotedTuiKey(tuiKey) ? tuiStructuredKey(tuiKey) : null
 }
 
-type TopLevelSettingValue = {
-  raw: string
-  // Why: a multiline string/array value can't be replaced line-by-line, so it's excluded from promotion.
-  multiline: boolean
-}
-
 function matchPromotedStructuredKey(
   line: string,
   inPreamble: boolean,
@@ -110,8 +111,8 @@ function matchPromotedStructuredKey(
 // collected from the first bare [tui] table body or the dotted preamble form,
 // keyed by structured path. Any table header (including [tui.*] subtables) ends
 // the [tui] body, and [profiles.*]/other tables are still ignored.
-function readPromotedSettingValues(configPath: string): Map<string, TopLevelSettingValue> {
-  const result = new Map<string, TopLevelSettingValue>()
+function readPromotedSettingValues(configPath: string): Map<string, CodexPromotedSettingValue> {
+  const result = new Map<string, CodexPromotedSettingValue>()
   if (!existsSync(configPath)) {
     return result
   }
@@ -175,7 +176,10 @@ export function snapshotCodexRuntimeSettingsBaseline(
         settings.set(key, value?.raw ?? null)
       }
     }
-    writeCodexSettingsBaseline(runtimeHomePath, { settings, conflicts })
+    const pluginRegistrations = new Map(
+      [...readCodexPluginRegistrationTables(runtimeTomlPath)].filter(([key]) => !conflicts.has(key))
+    )
+    writeCodexSettingsBaseline(runtimeHomePath, { settings, conflicts, pluginRegistrations })
   } catch (error) {
     console.warn('[codex-settings-promotion] failed to snapshot settings baseline', error)
   }
@@ -235,9 +239,13 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
   const runtimeValues = readPromotedSettingValues(runtimeTomlPath)
   const systemValues = readPromotedSettingValues(systemTomlPath)
   const updates = new Map<string, string>()
+  const runtimeRegistrations = readCodexPluginRegistrationTables(runtimeTomlPath)
+  const systemRegistrations = readCodexPluginRegistrationTables(systemTomlPath)
+  const registrationChanges = new Map<string, string | null>()
   const conflicts = new Map<string, CodexSettingsConflict>()
   const runtimeValuesToPreserve = new Map<string, string | null>()
-  collectPromotionChanges({
+  collectCodexSettingPromotionChanges({
+    keys: PROMOTED_STRUCTURED_KEYS,
     baseline,
     runtimeValues,
     systemValues,
@@ -245,7 +253,15 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
     conflicts,
     runtimeValuesToPreserve
   })
-  if (updates.size === 0) {
+  collectCodexPluginRegistrationChanges({
+    baseline,
+    runtimeRegistrations,
+    systemRegistrations,
+    registrationChanges,
+    conflicts,
+    runtimeValuesToPreserve
+  })
+  if (updates.size === 0 && registrationChanges.size === 0) {
     return { conflicts, runtimeValuesToPreserve }
   }
   // Why: a fresh host has no ~/.codex; create it owner-only (holds auth.json) or the atomic write ENOENTs and the mirror wipes it.
@@ -261,8 +277,15 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
   const systemContent = targetExists
     ? readAgentStateFileSync(writeTarget.path)
     : extractOrdinaryCodexSettings(readAgentStateFileSync(runtimeTomlPath))
-  const nextContent = upsertPromotedSettingsInContent(systemContent, updates)
-  if (nextContent === systemContent) {
+  const nextContent = targetExists
+    ? applyCodexPluginRegistrationChanges(
+        upsertPromotedSettingsInContent(systemContent, updates),
+        registrationChanges
+      )
+    : systemContent.length > 0
+      ? `${systemContent}\n`
+      : systemContent
+  if (targetExists && nextContent === systemContent) {
     return { conflicts, runtimeValuesToPreserve }
   }
   if (targetExists && parseWslUncPath(writeTarget.path)) {
@@ -274,54 +297,6 @@ function promoteCodexRuntimeSettingsToSystemUnsafe(
     mode: writeTarget.mode
   })
   return { conflicts, runtimeValuesToPreserve }
-}
-
-type PromotionCollectionContext = {
-  baseline: CodexSettingsBaseline
-  runtimeValues: ReadonlyMap<string, TopLevelSettingValue>
-  systemValues: ReadonlyMap<string, TopLevelSettingValue>
-  updates: Map<string, string>
-  conflicts: Map<string, CodexSettingsConflict>
-  runtimeValuesToPreserve: Map<string, string | null>
-}
-
-function collectPromotionChanges(context: PromotionCollectionContext): void {
-  for (const key of PROMOTED_STRUCTURED_KEYS) {
-    const runtimeRaw = getComparableRaw(context.runtimeValues.get(key))
-    const systemRaw = getComparableRaw(context.systemValues.get(key))
-    if (runtimeRaw === undefined || systemRaw === undefined) {
-      continue
-    }
-
-    const existingConflict = context.baseline.conflicts.get(key)
-    if (existingConflict || !context.baseline.settings.has(key)) {
-      const resolution = resolveUntrackedCodexSetting(runtimeRaw, systemRaw, existingConflict)
-      if (resolution.action === 'promote-runtime') {
-        context.updates.set(key, resolution.raw)
-      } else if (resolution.action === 'preserve') {
-        // Why: a schema-new key has no three-way ancestor; preserve both values until content changes one side.
-        context.conflicts.set(key, resolution.conflict)
-        context.runtimeValuesToPreserve.set(key, runtimeRaw)
-      }
-      continue
-    }
-
-    if (runtimeRaw === null || runtimeRaw === context.baseline.settings.get(key)) {
-      continue
-    }
-    // Why: ~/.codex remains source of truth when both sides changed from a known baseline.
-    if (systemRaw !== context.baseline.settings.get(key)) {
-      continue
-    }
-    context.updates.set(key, runtimeRaw)
-  }
-}
-
-function getComparableRaw(value: TopLevelSettingValue | undefined): string | null | undefined {
-  if (!value) {
-    return null
-  }
-  return value.multiline ? undefined : value.raw
 }
 
 function emptyPromotionPlan(): CodexSettingsPromotionPlan {


### PR DESCRIPTION
## Summary

- Persist Codex marketplace and plugin registrations made inside an Orca-managed `CODEX_HOME` across config remirrors.
- Root cause: the existing baseline-based promotion tracked top-level and `[tui]` settings, but not the dynamic `[marketplaces.<name>]` and `[plugins."<plugin>@<marketplace>"]` tables, so the next system-config mirror replaced them.
- Extend the same baseline/reconciliation path to generalized marketplace and plugin table blocks, preserving quoted headers, comments, CRLF, table order, and byte stability.
- Treat registration removal as a managed-home change and never infer installation from cache contents.

### Reconciliation policy

- If only the managed runtime changed from a known baseline, promote its add, edit, disable, or removal to the system config.
- If the system config changed the same registration, keep the system value, matching the existing three-way policy.
- For legacy baselines without registration ancestry, use the existing anchored-conflict behavior rather than guessing a winner.
- Do not unconditionally preserve runtime plugin tables, so external removals cannot be resurrected.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Additional coverage:

- 9 related Codex config/mirror/account test files: 300 tests passed.
- Full suite: 3,396 test files and 36,011 tests passed; 7 files and 60 tests skipped.
- `oxfmt --check` passed for all changed files.
- Sandboxed `HOME`/`CODEX_HOME` regression with Codex CLI 0.145.0: marketplace add, plugin add/list, repeated real mirror byte stability, plugin/marketplace removal, and no resurrection after remirror.

## AI Review Report

- Reviewed the real mirror call path and all callers before changing the shared promotion layer.
- Checked TOML parsing and rewriting risks: quoted/literal headers, comments, CRLF, ordering, duplicate tables, legacy baselines, concurrent system edits, deletion/disable behavior, and cache-only state.
- Checked macOS, Linux, Windows, WSL, and SSH behavior. The change uses existing Node path/file primitives and explicit runtime/system home paths; it adds no shortcuts, labels, shell commands, or Electron platform branches.
- Checked folder workspaces and supported Git providers; this is isolated to Codex config mirroring and adds no git-worktree or GitHub-specific assumptions.
- Performance remains linear in the small config file per mirror, with no new polling, dependencies, or cache scans.

## Security Audit

- No new command execution, IPC, network access, dependencies, auth handling, or secret logging.
- Config writes continue through the existing atomic/symlink-aware promotion path and existing explicit home boundaries.
- Baseline registration payloads are validated as strings before use, and cache directories are never trusted as installation state.
- No follow-up security work identified.

## Notes

- This intentionally does not change system-default `CODEX_HOME` routing or authentication isolation; those remain separate from this managed-account persistence fix.
- `pnpm build` exited successfully with the existing bundle warnings and local `/usr/local/bin/orca-dev` symlink permission notice.
- X handle: not provided.

Fixes #10489

## ELI5

Codex marketplace and plugin registrations inside Orca-managed CODEX_HOME were wiped on the next config remirror. Those plugin tables are preserved across remirrors so installed plugins stick.
