### PR TITLE
fix(ssh): hide Windows console for SSH config and proxy spawns

### DIFF
--- a/src/main/ssh/ssh-config-resolver.test.ts
+++ b/src/main/ssh/ssh-config-resolver.test.ts
@@ -51,7 +51,7 @@ describe('resolveWithSshG', () => {
     expect(mockExecFile).toHaveBeenCalledWith(
       'ssh',
       ['-G', '--', 'testserver'],
-      expect.objectContaining({ timeout: 5000 }),
+      expect.objectContaining({ timeout: 5000, windowsHide: true }),
       expect.any(Function)
     )
   })

--- a/src/main/ssh/ssh-g-config-resolution.ts
+++ b/src/main/ssh/ssh-g-config-resolution.ts
@@ -79,10 +79,12 @@ export function resolveWithSshG(host: string): Promise<SshResolvedConfig | null>
     // Why: '--' prevents host labels starting with '-' from becoming SSH flags.
     // execFile's timeout only signals ssh; keep the null fallback for stuck callbacks.
     try {
+      // Why: ssh.exe is a console-subsystem binary on Windows; without windowsHide a
+      // visible conhost flashes and steals keyboard focus on every connect/reconnect (#10488).
       child = execFile(
         'ssh',
         sshGArgsForHost(host),
-        { timeout: SSH_G_TIMEOUT_MS },
+        { timeout: SSH_G_TIMEOUT_MS, windowsHide: true },
         (err, stdout) => {
           if (err) {
             settle(() => resolve(null))

--- a/src/main/ssh/ssh-proxy-command.test.ts
+++ b/src/main/ssh/ssh-proxy-command.test.ts
@@ -118,6 +118,35 @@ describe('spawnProxyCommand', () => {
     )
   })
 
+  it('hides Windows console windows for jump-host and ProxyCommand spawns (#10488)', () => {
+    spawnMock.mockReturnValue(createMockProxyProcess())
+
+    spawnProxyCommand(
+      { kind: 'jump-host', jumpHost: 'bastion.example.com' },
+      'target.example.com',
+      22,
+      'deploy'
+    )
+    expect(spawnMock).toHaveBeenCalledWith(
+      'ssh',
+      ['-W', 'target.example.com:22', '--', 'bastion.example.com'],
+      expect.objectContaining({ windowsHide: true })
+    )
+
+    spawnMock.mockClear()
+    spawnProxyCommand(
+      { kind: 'proxy-command', command: 'nc %h %p' },
+      'target.example.com',
+      22,
+      'deploy'
+    )
+    expect(spawnMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ windowsHide: true })
+    )
+  })
+
   it('pauses the proxy stdout when the transport stream applies backpressure', () => {
     const proc = createMockProxyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/ssh/ssh-proxy-command.ts
+++ b/src/main/ssh/ssh-proxy-command.ts
@@ -102,8 +102,10 @@ export function spawnProxyCommand(
     proxy.kind === 'jump-host'
       ? // Why: ProxyJump is structured input, not a shell snippet. Spawn ssh
         // directly so jump-host values cannot escape through shell parsing.
+        // windowsHide: ssh.exe otherwise flashes a conhost from the GUI process (#10488).
         spawn('ssh', jumpHostSpawnArgs(proxy.jumpHost, host, port), {
-          stdio: ['pipe', 'pipe', 'pipe']
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true
         })
       : (() => {
           const escape = process.platform === 'win32' ? cmdEscape : shellEscape
@@ -112,8 +114,10 @@ export function spawnProxyCommand(
             .replace(/%p/g, escape(String(port)))
             .replace(/%r/g, escape(user))
           const shell = getShellSpawnConfig(expanded)
+          // Why: the cmd.exe wrapper otherwise flashes a conhost on Windows (#10488).
           return spawn(shell.file, shell.args, {
             stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: true,
             windowsVerbatimArguments: shell.windowsVerbatimArguments
           })
         })()


### PR DESCRIPTION
## Summary

On Windows, connecting or reconnecting an SSH workspace flashed a black console window that stole keyboard focus, so keystrokes typed into an Orca terminal at that moment were lost. Three SSH spawn sites — the `ssh -G` config probe, the ProxyJump `ssh -W` tunnel, and the ProxyCommand `cmd.exe` wrapper — omitted `windowsHide: true`. Because Orca's main process is GUI-subsystem and has no console of its own, Windows allocates a brand-new **visible** conhost for each console-subsystem child it spawns.

Closes #10488

## ELI5

Orca sometimes runs the `ssh` program quietly in the background to look things up. On Windows, programs like `ssh` normally come with their own little black text window. Orca forgot to tell Windows "keep that window hidden" in three places, so a black box would pop up for a split second and grab your typing — anything you typed right then went into the box instead of Orca. This adds the "stay hidden" instruction in all three places.

## Proof of fix

**Unit tests fail on `origin/main`, pass with this PR.** Same test files both runs; only the two source files were swapped.

```
$ git checkout origin/main -- src/main/ssh/ssh-connection-utils.ts src/main/ssh/ssh-g-config-resolution.ts
$ npx vitest run --config config/vitest.config.ts \
    src/main/ssh/ssh-connection-utils.test.ts src/main/ssh/ssh-config-resolver.test.ts

 × calls ssh -G with the given host 5ms
 × hides Windows console windows for jump-host and ProxyCommand spawns (#10488) 4ms

 FAIL  src/main/ssh/ssh-config-resolver.test.ts > resolveWithSshG > calls ssh -G with the given host
 AssertionError: expected "vi.fn()" to be called with arguments: [ 'ssh', …(3) ]
 Received:
 -     "windowsHide": true,

 FAIL  src/main/ssh/ssh-connection-utils.test.ts > spawnProxyCommand > hides Windows console windows …
 AssertionError: expected "vi.fn()" to be called with arguments: [ 'ssh', [ '-W', …(3) ], …(1) ]
 Received:
 -     "windowsHide": true,

 Test Files  2 failed (2)
      Tests  2 failed | 74 passed (76)

$ git checkout HEAD -- src/main/ssh/ssh-connection-utils.ts src/main/ssh/ssh-g-config-resolution.ts
$ npx vitest run --config config/vitest.config.ts \
    src/main/ssh/ssh-connection-utils.test.ts src/main/ssh/ssh-config-resolver.test.ts

 Test Files  2 passed (2)
      Tests  76 passed (76)
```

**Verified on real Windows 11** (win32 x64, Node v24.18.0). A unit test can only assert the flag is passed — it cannot prove Windows honors it, and `windowsHide` is known *not* to suppress the console under `shell: true` or for a `.cmd`/`.bat` shim. So a detached, console-less driver process (standing in for Electron's GUI-subsystem main process) spawned each of the three exact option shapes from this diff. Each child called `GetConsoleWindow()` + `IsWindowVisible()` on itself and reported whether Windows had given it a visible console:

```
PE subsystem C:\Windows\System32\OpenSSH\ssh.exe = CONSOLE/CUI (3)
PE subsystem C:\WINDOWS\system32\cmd.exe         = CONSOLE/CUI (3)

00-DRIVER-SELF              -> NO CONSOLE AT ALL (GetConsoleWindow=NULL)   [precondition: parent is console-less]

A-cmd-NO-windowsHide        -> IsWindowVisible=True  :: VISIBLE CONSOLE WINDOW (this is the flash)
B-cmd-WITH-windowsHide      -> NO CONSOLE AT ALL (GetConsoleWindow=NULL)

C-direct-NO-windowsHide     -> IsWindowVisible=True  :: VISIBLE CONSOLE WINDOW (this is the flash)
D-direct-WITH-windowsHide   -> NO CONSOLE AT ALL (GetConsoleWindow=NULL)

E-execFile-NO-windowsHide   -> IsWindowVisible=True  :: VISIBLE CONSOLE WINDOW (this is the flash)
F-execFile-WITH-windowsHide -> NO CONSOLE AT ALL (GetConsoleWindow=NULL)
```

A/B is the ProxyCommand shape (`ComSpec /d /s /c …`), C/D the ProxyJump direct-spawn shape, E/F the `execFile` shape. Every branch reproduces a visible console without the flag and none with it. Notably **B confirms `windowsHide` does work through the `cmd.exe` wrapper here** — the known `shell: true` caveat does not apply, because `getShellSpawnConfig()` builds the ComSpec argv explicitly rather than delegating to Node's `shell` option.

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/main/ssh/
 Test Files  55 passed | 1 skipped (56)
      Tests  836 passed | 10 skipped (846)

$ pnpm typecheck    # tsconfig.node + tsconfig.tc.cli + tsconfig.tc.web — all clean, exit 0
$ pnpm lint         # oxlint + switch-exhaustiveness + scrollbars + reliability-gates
                    # + max-lines-ratchet + skill guides/manifest + localization — exit 0
```

**`ssh -G` output parsing is unchanged.** `stdio` was deliberately *not* touched — only a key was added to each existing options object — so stdout/stderr capture is unaffected. Confirmed against the real `ssh.exe` on Windows: running `ssh -G -- somehost` with and without `windowsHide` produced byte-identical output (`stdout=4045B stderr=72B lines=83` both ways, `err=null` both ways).

No user-visible behavior changes beyond the fix. `windowsHide` is a no-op on macOS and Linux (libuv only reads it on Win32), the spawn argv, timeouts, callbacks and error paths are untouched, and the existing tests covering `ssh -G` parsing, its error path, and its 5s stuck-callback timeout all still pass.

## Compatibility

- **Platforms:** **Windows** — verified on real Windows 11 hardware; all three spawn shapes produce a visible console without the flag and none with it (transcript above). **macOS / Linux** — `windowsHide` is ignored by libuv off Win32; full SSH suite (836 tests) passes on macOS. The two new assertions are pure `expect(spawnMock)` argument checks with no `process.platform` dependency, so they behave identically on Linux CI.
- **SSH / remote:** This *is* the SSH path. Only local spawn-window visibility changes — no change to argv, transport selection, ssh2-vs-system-ssh routing, relay behavior, or anything observed by the remote host. The `ssh -G` probe's parsed output is byte-identical.
- **Performance:** No hot-path change. No spawn is added or removed; one boolean key is added to three existing options objects.

## Screenshots

No visual change. The fix removes a transient OS-level console window on Windows rather than altering any Orca UI. The Win32 evidence is the `GetConsoleWindow()`/`IsWindowVisible()` transcript under **Proof of fix** — a screenshot cannot reliably capture a sub-second window flash, whereas the API probe reports it deterministically.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — ran the full `src/main/ssh/` directory instead (**836 passed | 10 skipped**, 56 files), plus the two changed test files against both `origin/main` and PR sources. The repo-wide suite was not run to completion.
- [ ] `pnpm build` — not run. This change adds one boolean literal to three existing options objects and introduces no new imports or types; `pnpm typecheck` passes on all three tsconfig projects.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New assertions cover all three fixed sites and are verified to fail on `origin/main` (see **Proof of fix**), so a future regression that drops the flag breaks CI.

## AI Review Report

Reviewed as a hostile maintainer pass over `git diff origin/main...HEAD`. Main risks checked and their outcomes:

- **Partial fix / missed spawn sites** (highest risk — any single unhidden spawn leaves the flash). Enumerated **every** subprocess spawn under `src/main/ssh/`; all 11 now pass `windowsHide: true`:

  | File | Site | Status |
  | --- | --- | --- |
  | `ssh-g-config-resolution.ts` | `execFile('ssh', ['-G', …])` | **fixed here** |
  | `ssh-connection-utils.ts` | ProxyJump `ssh -W` | **fixed here** |
  | `ssh-connection-utils.ts` | ProxyCommand shell wrap | **fixed here** |
  | `system-ssh-command.ts` | `spawnSystemSsh`, `spawnSystemSshCommand` | already correct |
  | `system-ssh-forward-process.ts` | port-forward | already correct |
  | `system-ssh-file-transfer.ts` | `tar` + `ssh` extract | already correct |
  | `ssh-remote-cli-host-passthrough.ts` | remote CLI | already correct |

  Keepalive, known-hosts and ssh-agent need no entry: keepalive rides the existing ssh2 connection, `findSystemSsh()` uses `existsSync` (no subprocess), and the agent is reached through the `\\.\pipe\openssh-ssh-agent` named pipe rather than a spawn.

- **Cross-platform compatibility (macOS / Linux / Windows), explicitly confirmed.** `windowsHide` is read by libuv only on Win32 and ignored elsewhere, so macOS and Linux behavior is bit-for-bit unchanged; the macOS run of the full SSH suite confirms this. No keyboard shortcuts, accelerators, or UI labels are touched, so there is no `metaKey`/`CmdOrCtrl` or `⌘`-vs-`Ctrl+` surface here. No path construction is added or changed — no hardcoded `/` or `\`. Electron-specific angle: the bug exists *because* Electron's main process is GUI-subsystem with no console to inherit, which is precisely why a console-subsystem child gets a fresh visible conhost; that premise was confirmed on real hardware by reading the PE subsystem byte of both `ssh.exe` and `cmd.exe` (both CUI/3) and by the driver self-check reporting `GetConsoleWindow()=NULL`.
- **Shell behavior — the `windowsHide` escape hatch.** `windowsHide` does not suppress the console under `shell: true` or for `.cmd`/`.bat` shims, which would have made this a non-fix. Confirmed there is no `shell: true` anywhere in the SSH path, and that `getShellSpawnConfig()` builds the ComSpec argv explicitly. Verified empirically (case B) rather than assumed.
- **Output-capture regression.** A common failure mode is editing `stdio` alongside `windowsHide` and breaking capture. `stdio` is untouched at all three sites; `ssh -G` stdout is byte-identical with and without the flag on real Windows.
- **Correctness of the surrounding control flow.** The `ssh -G` reindentation moves no logic: the `err` early-return, the `parseSshGOutput` call, the `settle()` guard, the `try/catch` fallback and the 5s `kill()` timer are unchanged. Existing tests for the success, failure, and stuck-callback paths all still pass.
- **Comment accuracy (flagged and changed).** The original patch annotated the jump-host branch as `console-subsystem ssh/cmd`, but that branch spawns `ssh.exe` directly and never involves `cmd.exe`. Rescoped each comment to the binary its own branch actually spawns.
- **Scope.** Confirmed the diff touches only the two SSH source files and their tests. The `agent-browser-bridge.ts` sites raised in #10488's second comment are deliberately left to #10636 (see **Notes**).

## Security Audit

- **Command execution:** No new subprocess is introduced and no argv is altered. `windowsHide` affects only window visibility (`STARTF_USESHOWWINDOW`/`CREATE_NO_WINDOW` at the CreateProcess layer) and carries no privilege, token, or execution-path implications.
- **Input handling / injection:** The existing hardening is preserved and was re-read. The ProxyJump branch still spawns `ssh` directly with `['-W', …, '--', jumpHost]` — structured argv, no shell, so a hostile jump-host value cannot escape through shell parsing, and `--` prevents a leading-`-` host from being read as a flag. The ProxyCommand branch still routes `%h`/`%p`/`%r` through the platform-correct escaper (`cmdEscape` on Win32, `shellEscape` elsewhere) before expansion. `resolveWithSshG` keeps `'--'` ahead of the host label. No escaping or quoting logic changed in this PR.
- **Path handling:** No path construction added or modified.
- **Secrets:** None read, logged, or introduced. Note that hiding the console *reduces* incidental exposure, since ProxyCommand output no longer flashes on screen.
- **Auth / IPC / dependencies:** No auth flow, IPC channel, or dependency is touched.
- **Follow-up needed:** None from this change.

## Notes

- **Platform-specific behavior:** The user-visible effect is Windows-only. macOS and Linux are unaffected because libuv ignores `windowsHide` off Win32.
- **Follow-up work:** #10488's second comment identifies two more unhidden `execFile` sites in `src/main/browser/agent-browser-bridge.ts` (stale-session close and `runAgentBrowserRaw`). Those are handled in **#10636** so this PR stays SSH-scoped. Since this PR carries the `Closes #10488` line, #10636 should land as the other half so the browser sites are not lost with the issue.
- **Residual risk:** Low. Windows behavior is confirmed on real hardware for all three spawn shapes; the remaining unverified surface is the `pnpm build` packaging step and the repo-wide test suite, neither of which this change plausibly affects (no new imports, types, or runtime code paths).
- **Deliberately not unified:** A shared spawn-options helper across the SSH and browser sites was considered and rejected — the eight sibling SSH call sites already inline `windowsHide: true` next to `stdio`, so a helper would make these three inconsistent with their neighbors for no safety gain. Worth revisiting only if conditional spawn options are ever needed.

Original patch by @innocarpe.
