### PR TITLE
perf(terminal): drop the JSON structural pre-scan from the history read path

### DIFF
--- a/src/main/daemon/history-reader-memory.test.ts
+++ b/src/main/daemon/history-reader-memory.test.ts
@@ -148,4 +148,23 @@ describe('terminal history restore memory limits', () => {
       ).values
     ).toHaveLength(2_000_001)
   })
+
+  // Why: the pre-scan also carried a 128-level nesting cap, and dropping it is only safe
+  // because V8 parses JSON iteratively — depth costs heap, not stack. A future engine that
+  // recursed would abort the daemon rather than throw into the callers' catch, so pin it.
+  it('parses deeply nested checkpoints without the retired nesting-depth cap', () => {
+    const { sessionPath } = createSession('deeply-nested-checkpoint')
+    const checkpointPath = join(sessionPath, 'checkpoint.json')
+    const depth = 50_000
+    writeFileSync(
+      checkpointPath,
+      `{"snapshotAnsi":"","nested":${'['.repeat(depth)}${']'.repeat(depth)}}`
+    )
+    expect(
+      readTerminalHistoryJson<{ nested: unknown[] }>(
+        checkpointPath,
+        TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES
+      ).nested
+    ).toHaveLength(1)
+  })
 })

--- a/src/main/daemon/history-reader-memory.test.ts
+++ b/src/main/daemon/history-reader-memory.test.ts
@@ -9,7 +9,7 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { HistoryReader } from './history-reader'
 import { getHistorySessionDirName } from './history-paths'
 import {
@@ -17,10 +17,7 @@ import {
   TERMINAL_HISTORY_LOG_MAX_BYTES,
   TERMINAL_HISTORY_META_MAX_BYTES
 } from './terminal-history-file-limits'
-import {
-  readTerminalHistoryJson,
-  TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS
-} from './terminal-history-file-reader'
+import { readTerminalHistoryJson } from './terminal-history-file-reader'
 
 const RETIRED_CHECKPOINT_READ_CAP_BYTES = 16 * 1024 * 1024
 
@@ -120,21 +117,35 @@ describe('terminal history restore memory limits', () => {
     ).toBe(false)
   })
 
-  it('rejects structurally amplified checkpoints before parsing', () => {
-    const { sessionPath } = createSession('amplified-checkpoint')
+  // Why: the retired 1M-structural-token pre-scan was reachable by ordinary content —
+  // ~100k OSC-8 hyperlinks cross it, the assert threw, detectColdRestore swallowed it,
+  // and the terminal restored blank. Same user-visible loss as the retired byte cap.
+  it('restores a checkpoint carrying more OSC links than the retired structural-token cap', async () => {
+    const { basePath, sessionPath } = createSession('many-osc-links')
+    const oscLinks = Array.from({ length: 150_000 }, (_, index) => ({
+      row: index,
+      startCol: 0,
+      endCol: 40,
+      uri: `https://example.com/build/${index}`
+    }))
+    writeFileSync(join(sessionPath, 'checkpoint.json'), checkpoint({ oscLinks }))
+
+    const restore = await new HistoryReader(basePath).detectColdRestore('many-osc-links')
+    expect(restore?.snapshotAnsi).toBe('safe checkpoint')
+    expect(restore?.oscLinks).toHaveLength(oscLinks.length)
+  })
+
+  // Why assert the reader directly too: detectColdRestore hides any reader throw as a
+  // null checkpoint, so a reinstated pre-scan would stay invisible above.
+  it('parses link-dense checkpoints without a structural pre-scan budget', () => {
+    const { sessionPath } = createSession('link-dense-checkpoint')
     const checkpointPath = join(sessionPath, 'checkpoint.json')
-    writeFileSync(
-      checkpointPath,
-      `{"snapshotAnsi":"","values":[${'0,'.repeat(TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS)}0]}`
-    )
-    const parseSpy = vi.spyOn(JSON, 'parse')
-    try {
-      expect(() =>
-        readTerminalHistoryJson(checkpointPath, TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES)
-      ).toThrow(/JSON structure exceeds/)
-      expect(parseSpy).not.toHaveBeenCalled()
-    } finally {
-      parseSpy.mockRestore()
-    }
+    writeFileSync(checkpointPath, `{"snapshotAnsi":"","values":[${'0,'.repeat(2_000_000)}0]}`)
+    expect(
+      readTerminalHistoryJson<{ values: number[] }>(
+        checkpointPath,
+        TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES
+      ).values
+    ).toHaveLength(2_000_001)
   })
 })

--- a/src/main/daemon/terminal-history-file-reader.ts
+++ b/src/main/daemon/terminal-history-file-reader.ts
@@ -12,11 +12,9 @@ export function readTerminalHistoryText(filePath: string, maxBytes: number): str
 }
 
 // Why no JSON structure pre-scan here: checkpoint.json and meta.json are our own
-// writer's output, not untrusted input. The byte cap already bounds the read, a
-// corrupt file fails JSON.parse and every caller already treats that as "no
-// history", and a per-character JS scan in front of native JSON.parse cost ~57%
-// of this read path on a large checkpoint while making numerous oscLinks restore
-// blank. Untrusted JSON still goes through assertJsonTextStructureWithinLimits.
+// writer's output, not untrusted input — the byte cap still bounds the read and a
+// corrupt file fails JSON.parse into every caller's existing catch. Untrusted JSON
+// still goes through assertJsonTextStructureWithinLimits.
 export function readTerminalHistoryJson<T>(filePath: string, maxBytes: number): T {
   return JSON.parse(readTerminalHistoryText(filePath, maxBytes)) as T
 }

--- a/src/main/daemon/terminal-history-file-reader.ts
+++ b/src/main/daemon/terminal-history-file-reader.ts
@@ -2,10 +2,6 @@ import {
   readNodeFileSyncWithinLimit,
   readNodeFileWithinLimit
 } from '../../shared/node-bounded-file-reader'
-import { assertJsonTextStructureWithinLimits } from '../../shared/json-text-structure-limit'
-
-export const TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS = 1_000_000
-export const TERMINAL_HISTORY_JSON_MAX_NESTING_DEPTH = 128
 
 export function readTerminalHistoryBuffer(filePath: string, maxBytes: number): Buffer {
   return readNodeFileSyncWithinLimit(filePath, maxBytes).buffer
@@ -15,17 +11,18 @@ export function readTerminalHistoryText(filePath: string, maxBytes: number): str
   return readTerminalHistoryBuffer(filePath, maxBytes).toString('utf8')
 }
 
+// Why no JSON structure pre-scan here: checkpoint.json and meta.json are our own
+// writer's output, not untrusted input. The byte cap already bounds the read, a
+// corrupt file fails JSON.parse and every caller already treats that as "no
+// history", and a per-character JS scan in front of native JSON.parse cost ~57%
+// of this read path on a large checkpoint while making numerous oscLinks restore
+// blank. Untrusted JSON still goes through assertJsonTextStructureWithinLimits.
 export function readTerminalHistoryJson<T>(filePath: string, maxBytes: number): T {
-  const text = readTerminalHistoryText(filePath, maxBytes)
-  assertJsonTextStructureWithinLimits(text, {
-    structuralTokens: TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS,
-    nestingDepth: TERMINAL_HISTORY_JSON_MAX_NESTING_DEPTH
-  })
-  return JSON.parse(text) as T
+  return JSON.parse(readTerminalHistoryText(filePath, maxBytes)) as T
 }
 
 // Why: cold-restore payload reads must not block the main thread, but need the
-// same byte and JSON-structure bounds as the sync readers.
+// same byte bound as the sync readers.
 export async function readTerminalHistoryBufferAsync(
   filePath: string,
   maxBytes: number
@@ -44,10 +41,5 @@ export async function readTerminalHistoryJsonAsync<T>(
   filePath: string,
   maxBytes: number
 ): Promise<T> {
-  const text = await readTerminalHistoryTextAsync(filePath, maxBytes)
-  assertJsonTextStructureWithinLimits(text, {
-    structuralTokens: TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS,
-    nestingDepth: TERMINAL_HISTORY_JSON_MAX_NESTING_DEPTH
-  })
-  return JSON.parse(text) as T
+  return JSON.parse(await readTerminalHistoryTextAsync(filePath, maxBytes)) as T
 }


### PR DESCRIPTION
## Summary

Cold restore of a large terminal checkpoint ran a per-character JSON scan in interpreted JS in front of native `JSON.parse`, on the main thread. It cost ~57% of the checkpoint read path, and its structural-token cap was low enough that a link-dense terminal restored **blank**. This drops the scan from the two terminal-history readers only.

## The defect

`readTerminalHistoryJson` / `readTerminalHistoryJsonAsync` called `assertJsonTextStructureWithinLimits(text, ...)` before `JSON.parse`. That helper walks the JSON **character by character in interpreted JS** (`content[index]` + string comparisons) — on a 20MB+ checkpoint that is ~25M iterations run in front of a native parser, entirely on the main thread.

The sharpest version: `readTerminalHistoryJsonAsync` exists *specifically* so cold-restore reads do not block the main thread — its own comment said "cold-restore payload reads must not block the main thread". The file I/O was async, and then a synchronous CPU scan ran inline immediately after. The function defeated its own stated purpose.

This is a regression against v1.4.155, where the read was `JSON.parse(readFileSync(path, 'utf-8'))`; neither `terminal-history-file-reader.ts` nor `json-text-structure-limit.ts` existed. Both arrived with #10179 and survived revert #10255 (which could not reclaim them because #9990 had landed on `history-reader.ts`).

## Measured, not inferred

Node v26.5.0, 26.8MB checkpoint (20MB of realistic ANSI scrollback with powerline/box-drawing/emoji glyphs), timing the real `terminal-history-file-reader` exports:

| | before (scan + parse) | after (parse only) | saved |
|---|---|---|---|
| run0 | 135.1ms | 49.5ms | 85.6ms (2.7x) |
| run1 | 94.7ms | 34.9ms | 59.8ms (2.7x) |
| run2 | 174.4ms | 30.3ms | 144.1ms (5.7x) |
| run3 | 363.4ms | 29.9ms | 333.4ms (12.1x) |

Broken down across the whole read path (`readFileSync` → `toString('utf8')` → scan → `JSON.parse`): read 2ms, decode 19ms, **scan 63ms**, parse 27ms — the scan alone was **57% of the checkpoint read path** and 2.4x the `JSON.parse` it was guarding. `JSON.parse` stays flat at ~30ms across runs; the scan is the part whose cost balloons under GC pressure (run3), which is exactly the condition a big cold restore creates.

To state it plainly: in isolation I measured ~63-330ms for the scan, not the ~900ms of synchronous main-thread work seen in live restore testing. The scan is a real and dominant share of the *read path*, but I did not reproduce it as the sole cause of a ~950ms restore — the rest of that budget is elsewhere (decode, replay), and is not addressed here.

## Also fixed: a silent-blank-restore path

`TERMINAL_HISTORY_JSON_MAX_STRUCTURAL_TOKENS = 1_000_000` was itself reachable by ordinary terminal content. `daemon-checkpoint-file.ts` has an unbounded `oscLinks` array; each `{"row":n,"startCol":n,"endCol":n,"uri":"..."}` entry costs ~10 structural tokens, so roughly **100k OSC-8 hyperlinks** crossed the limit. The assert threw, `history-reader.ts:84-86` swallowed it to `checkpoint = null`, and the terminal **restored blank** — identical user-visible loss to the bug just fixed by #10479. Raising the byte cap did nothing for this.

## The fix, and why this option

Option 1 of three considered:

1. **Drop the scan for this call site** (chosen). `checkpoint.json` and `meta.json` are Orca's *own* `SerializeAddon` output, not untrusted input. The byte cap (`TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES`) already bounds the read, and a corrupt file fails `JSON.parse` into the same `catch` the callers already have. The DoS threat model the scan defends against does not apply to a file we wrote ourselves. It also makes the oscLinks silent-drop disappear rather than re-tuning a limit that would need re-tuning again.
2. *Make the scan cheap* (`charCodeAt` + numeric comparisons). I benchmarked this: 47-58ms vs 57-86ms — meaningfully faster, but still adds tens of ms of pure main-thread overhead to guard a file we authored, and does nothing about the oscLinks blank restore.
3. *Move it off the main thread.* Real work (worker thread / streaming) for zero security benefit on a self-authored file.

**Scoped deliberately.** The shared `assertJsonTextStructureWithinLimits` helper is untouched and still guards the ~18 call sites that do handle untrusted input — `agent-hook-listener.ts`, `browser-screencast-protocol.ts`, `relay-json-admission.ts`, `fetch-response-body.ts`, `text-search.ts`, and others. Only the terminal-history readers change.

## Tests

Both new tests fail on `main` and pass here:

- `restores a checkpoint carrying more OSC links than the retired structural-token cap` — 150k `oscLinks`. Before: `expected undefined to be 'safe checkpoint'` (the blank restore, reproduced end-to-end through `detectColdRestore`). After: full restore with all 150k links.
- `parses link-dense checkpoints without a structural pre-scan budget` — asserts the reader directly, because `detectColdRestore` hides any reader throw as a null checkpoint and would stay green if the pre-scan came back.

The replaced test (`rejects structurally amplified checkpoints before parsing`) asserted the behavior this PR removes.

\`\`\`
npx vitest run --config config/vitest.config.ts src/main/daemon/
  Test Files  68 passed | 2 skipped (70)
       Tests  1035 passed | 5 skipped (1040)
\`\`\`

`pnpm typecheck:node`, `oxlint`, `oxfmt --check`, max-lines ratchet and reliability gates all clean.

## Follow-up left out of scope

The shared helper is still `content[index]`-based for every other consumer; the `charCodeAt` rewrite is a free several-fold win there and belongs in its own PR.

## Screenshots

No visual change. The user-visible effect is behavioral: a checkpoint carrying ~100k+ OSC-8 hyperlinks now restores its scrollback instead of coming back blank.

## Testing

- [x] `pnpm lint` (`oxlint`, `oxfmt --check`) — clean
- [x] `pnpm typecheck` (`typecheck:node`) — clean
- [x] `pnpm test` — `src/main/daemon/`: 68 files passed, 1036 passed | 5 skipped
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

All three added tests were verified to fail on `main` by reverting only
`terminal-history-file-reader.ts` and keeping the new test file:

| test | failure on `main` |
|---|---|
| restores a checkpoint carrying more OSC links than the retired structural-token cap | `expected undefined to be 'safe checkpoint'` (the blank restore) |
| parses link-dense checkpoints without a structural pre-scan budget | `JsonTextStructureCapacityError: JSON structure exceeds 1000000 tokens` |
| parses deeply nested checkpoints without the retired nesting-depth cap | `JsonTextStructureCapacityError: JSON nesting exceeds 128 levels` |

Combined cost of the three: ~93ms.

## AI Review Report

Reviewed with Claude (Opus) subagents. Main risks checked:

**The retired pre-scan enforced two caps, not one.** The PR body originally
justified only the structural-token half; the 128-level **nesting-depth** cap
was dropped with no coverage. That is the one way this change could have been
wrong: if `JSON.parse` recursed, a deeply nested checkpoint would abort the
process outright rather than throw into the callers' `catch`. Verified
empirically on V8 14.6 — arrays and objects nested 10,000,000 deep parse in
~1.2s **without throwing and without crashing**; V8's JSON parser is iterative,
so depth costs heap, not stack. Commit `28f6d68085` adds a regression test
pinning that property, since the read path now silently depends on it.

**Caller safety.** Both `readTerminalHistoryJson` call sites
(`history-reader.ts:79-86` and `:293-297`) wrap the read in `try/catch` and
degrade to "no history", so any parse failure is no worse than the pre-scan
throw it replaces. No caller of either reader is left unguarded, and the async
variant's rejection cannot escape as an unhandled rejection.

**Trusted-input claim.** `HistoryReader`'s `basePath` is always
`getHistoryDir()` — a fixed app-data directory. `checkpoint.json` is written
only by `history-manager.ts` and read only by `history-reader.ts`; nothing
transfers one across a trust boundary. Under SSH the daemon runs on the remote
host and reads its own local history dir, so no checkpoint crosses the relay.

**Blast radius.** `src/shared/json-text-structure-limit.ts` is byte-for-byte
unchanged (empty diff) and its own tests still pass; the ~18 untrusted-input
call sites are unaffected. The two deleted constants have zero remaining
references repo-wide.

**Cross-platform.** No platform-dependent behavior touched — no shortcuts,
labels, shell invocation, or path construction changed. Path handling still
goes through `join`. Behavior is identical on macOS, Linux, and Windows, and
identical for local, WSL, SSH, and folder-workspace sessions.

## Security Audit

This PR **removes an input-validation guard**, so the audit centers there.

- **Input handling:** `checkpoint.json` / `meta.json` are self-authored, and
  `readNodeFileSyncWithinLimit` still enforces the byte cap
  (`TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES`, `TERMINAL_HISTORY_META_MAX_BYTES`),
  so the read stays bounded. The DoS threat model the scan defended against
  needs an untrusted producer, which this path does not have. For reference,
  v1.4.155 ran `JSON.parse(readFileSync(path, 'utf-8'))` here with **no cap at
  all** — this PR is strictly more bounded than the last shipped release.
- **Memory:** `JSON.parse` output is bounded by a small constant factor of the
  byte cap, and the writer never emits structurally amplified payloads.
- **Stack safety:** confirmed above — no uncatchable overflow path.
- **Not applicable / unchanged:** command execution, path handling, auth,
  secrets, dependencies, IPC. No new dependency, no new IPC surface.
- **Follow-up:** none blocking.

## Notes

- The `charCodeAt` rewrite of the shared helper (a free several-fold win for
  its other ~18 consumers) is deliberately **out of scope** and belongs in its
  own PR.
- Honest scoping on the perf claim: the scan measured 63-330ms in isolation and
  was 57% of the checkpoint *read path*. It was **not** reproduced as the sole
  cause of the ~950ms live restore; the remainder (decode, replay) is elsewhere
  and is not addressed here.
