### PR TITLE
test(terminal): pin checkpoint-only cold restore of a large checkpoint

### DIFF
--- a/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
+++ b/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
@@ -23,12 +23,17 @@ const ROWS = 40
 // Why per-cell color: the serialized checkpoint must clear 16MiB to cover the pre-#10479 cap, and
 // SGR-per-cell is how real agent/build output inflates a snapshot well past its plain-text size.
 function writeLargeScrollback(emulator: HeadlessEmulator, fillerLines: number): void {
+  let written = true
   for (let index = 0; index < fillerLines; index += 1) {
-    emulator.writeSync(`\x1b[3${index % 8}m${'x'.repeat(COLS - 1)}\x1b[0m\r\n`)
+    written = emulator.writeSync(`\x1b[3${index % 8}m${'x'.repeat(COLS - 1)}\x1b[0m\r\n`) && written
   }
   for (let index = 0; index < MARKERS; index += 1) {
-    emulator.writeSync(`MARKER-${index}\r\n`)
+    written = emulator.writeSync(`MARKER-${index}\r\n`) && written
   }
+  // Why assert: writeSync returns false if xterm's private _core.writeSync ever goes away, which
+  // would leave an empty snapshot. The size assertions below catch that, but the endedAt gate is
+  // size-independent and would still pass — pinning the gate over no scrollback at all.
+  expect(written).toBe(true)
 }
 
 describe('checkpoint-only cold restore of a large checkpoint', () => {

--- a/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
+++ b/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdtempSync, rmSync, statSync } from 'node:fs'
+import { HistoryManager } from './history-manager'
+import { HistoryReader } from './history-reader'
+import { HeadlessEmulator } from './headless-emulator'
+import { LOG_HEADER_BYTES } from './terminal-history-log'
+
+// Guards checkpoint-only cold restore: the route taken when the daemon dies right after a
+// checkpoint, so output.log is header-only and checkpoint.json is the sole recovery source.
+// #10179 shipped a read cap (16MiB) under what the unbounded checkpoint writer can emit; past it
+// the read threw, the catch swallowed it to checkpoint=null, and the pane reopened empty (#10479
+// raised the cap; nothing pinned the round trip that the cap silently broke). The
+// reader-level bound is covered in history-reader-memory.test.ts — this asserts the round trip
+// through the real writer, which is what actually decides whether a user sees their scrollback.
+
+const MARKERS = 300
+const SESSION_ID = 'repo-1::/Users/dev/large-scrollback'
+const COLS = 800
+const ROWS = 40
+
+// Why per-cell color: the serialized checkpoint must clear 16MiB to cover the pre-#10479 cap, and
+// SGR-per-cell is how real agent/build output inflates a snapshot well past its plain-text size.
+function writeLargeScrollback(emulator: HeadlessEmulator, fillerLines: number): void {
+  for (let index = 0; index < fillerLines; index += 1) {
+    emulator.writeSync(`\x1b[3${index % 8}m${'x'.repeat(COLS - 1)}\x1b[0m\r\n`)
+  }
+  for (let index = 0; index < MARKERS; index += 1) {
+    emulator.writeSync(`MARKER-${index}\r\n`)
+  }
+}
+
+describe('checkpoint-only cold restore of a large checkpoint', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'large-checkpoint-restore-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('recovers the full scrollback from a checkpoint larger than the pre-fix 16MiB read cap', async () => {
+    const manager = new HistoryManager(dir)
+    const reader = new HistoryReader(dir)
+    const emulator = new HeadlessEmulator({ cols: COLS, rows: ROWS, scrollback: 100_000 })
+    writeLargeScrollback(emulator, 26_000)
+
+    await manager.openSession(SESSION_ID, {
+      cwd: '/Users/dev/large-scrollback',
+      cols: COLS,
+      rows: ROWS
+    })
+    await manager.checkpoint(SESSION_ID, emulator.getSnapshot())
+    emulator.dispose()
+
+    const sessionDir = join(dir, encodeURIComponent(SESSION_ID))
+    // checkpoint() resets the log to its header, so this is genuinely checkpoint-only: any
+    // recovered content had to come through the checkpoint read, not incremental log replay.
+    expect(statSync(join(sessionDir, 'output.log')).size).toBe(LOG_HEADER_BYTES)
+    expect(statSync(join(sessionDir, 'checkpoint.json')).size).toBeGreaterThan(16 * 1024 * 1024)
+
+    const info = await reader.detectColdRestore(SESSION_ID)
+    expect(info).not.toBeNull()
+    // The adapter seeds a non-alt-screen restore with rehydrateSequences + snapshotAnsi.
+    const seed = info!.rehydrateSequences + info!.snapshotAnsi
+    expect(info!.modes.alternateScreen).toBe(false)
+    for (const index of [0, MARKERS - 1]) {
+      expect(seed).toContain(`MARKER-${index}`)
+    }
+    expect(seed.length).toBeGreaterThan(16 * 1024 * 1024)
+  }, 300_000)
+
+  // Why pinned: this gate, not any size cap, is what makes a checkpoint-only restore come back
+  // blank. Two separate investigations mistook a cleanly-ended session for a size regression.
+  it('restores after an unclean exit but not after a clean one, at the same checkpoint size', async () => {
+    const restoreAfter = async (endCleanly: boolean): Promise<boolean> => {
+      const manager = new HistoryManager(dir)
+      const emulator = new HeadlessEmulator({ cols: COLS, rows: ROWS, scrollback: 100_000 })
+      writeLargeScrollback(emulator, 50)
+      await manager.openSession(SESSION_ID, {
+        cwd: '/Users/dev/large-scrollback',
+        cols: COLS,
+        rows: ROWS
+      })
+      await manager.checkpoint(SESSION_ID, emulator.getSnapshot())
+      emulator.dispose()
+      if (endCleanly) {
+        await manager.closeSession(SESSION_ID, 0)
+      }
+      const info = await new HistoryReader(dir).detectColdRestore(SESSION_ID)
+      rmSync(join(dir, encodeURIComponent(SESSION_ID)), { recursive: true, force: true })
+      return info !== null
+    }
+
+    expect(await restoreAfter(false)).toBe(true)
+    expect(await restoreAfter(true)).toBe(false)
+  }, 300_000)
+})

--- a/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
+++ b/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
@@ -6,6 +6,7 @@ import { HistoryManager } from './history-manager'
 import { HistoryReader } from './history-reader'
 import { HeadlessEmulator } from './headless-emulator'
 import { LOG_HEADER_BYTES } from './terminal-history-log'
+import { getHistorySessionDirName } from './history-paths'
 
 // Guards checkpoint-only cold restore: the route taken when the daemon dies right after a
 // checkpoint, so output.log is header-only and checkpoint.json is the sole recovery source.
@@ -35,7 +36,7 @@ const FILLER_ROWS = Array.from(
 function writeLargeScrollback(emulator: HeadlessEmulator, fillerLines: number): void {
   let written = true
   for (let index = 0; index < fillerLines; index += 1) {
-    written = emulator.writeSync(FILLER_ROWS[index % 8]) && written
+    written = emulator.writeSync(FILLER_ROWS[index % FILLER_ROWS.length]) && written
   }
   for (let index = 0; index < MARKERS; index += 1) {
     written = emulator.writeSync(`MARKER-${index}\r\n`) && written
@@ -68,10 +69,12 @@ describe('checkpoint-only cold restore of a large checkpoint', () => {
       cols: COLS,
       rows: ROWS
     })
-    await manager.checkpoint(SESSION_ID, emulator.getSnapshot())
+    // Why dispose first: a throwing checkpoint() must not leak the buffer for the worker's life.
+    const snapshot = emulator.getSnapshot()
     emulator.dispose()
+    await manager.checkpoint(SESSION_ID, snapshot)
 
-    const sessionDir = join(dir, encodeURIComponent(SESSION_ID))
+    const sessionDir = join(dir, getHistorySessionDirName(SESSION_ID))
     // checkpoint() resets the log to its header, so this is genuinely checkpoint-only: any
     // recovered content had to come through the checkpoint read, not incremental log replay.
     expect(statSync(join(sessionDir, 'output.log')).size).toBe(LOG_HEADER_BYTES)
@@ -86,7 +89,7 @@ describe('checkpoint-only cold restore of a large checkpoint', () => {
       expect(seed).toContain(`MARKER-${index}`)
     }
     expect(seed.length).toBeGreaterThan(16 * 1024 * 1024)
-  }, 300_000)
+  }, 60_000)
 
   // Why pinned: this gate, not any size cap, is what makes a checkpoint-only restore come back
   // blank. Two separate investigations mistook a cleanly-ended session for a size regression.
@@ -100,17 +103,18 @@ describe('checkpoint-only cold restore of a large checkpoint', () => {
         cols: COLS,
         rows: ROWS
       })
-      await manager.checkpoint(SESSION_ID, emulator.getSnapshot())
+      const snapshot = emulator.getSnapshot()
       emulator.dispose()
+      await manager.checkpoint(SESSION_ID, snapshot)
       if (endCleanly) {
         await manager.closeSession(SESSION_ID, 0)
       }
       const info = await new HistoryReader(dir).detectColdRestore(SESSION_ID)
-      rmSync(join(dir, encodeURIComponent(SESSION_ID)), { recursive: true, force: true })
+      rmSync(join(dir, getHistorySessionDirName(SESSION_ID)), { recursive: true, force: true })
       return info !== null
     }
 
     expect(await restoreAfter(false)).toBe(true)
     expect(await restoreAfter(true)).toBe(false)
-  }, 300_000)
+  }, 60_000)
 })

--- a/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
+++ b/src/main/daemon/terminal-history-large-checkpoint-cold-restore.test.ts
@@ -20,12 +20,22 @@ const SESSION_ID = 'repo-1::/Users/dev/large-scrollback'
 const COLS = 800
 const ROWS = 40
 
-// Why per-cell color: the serialized checkpoint must clear 16MiB to cover the pre-#10479 cap, and
+// Why per-cell color: the restore seed must clear 16MiB to cover the pre-#10479 cap, and
 // SGR-per-cell is how real agent/build output inflates a snapshot well past its plain-text size.
+// It is also what keeps the fixture affordable — the xterm buffer costs rows x cols, so carrying
+// the bytes in SGR runs instead of rows reaches 25MiB of seed from 5.5k rows rather than 26k,
+// cutting this file's peak RSS from ~1.2GiB to ~800MiB. Only 8 distinct rows exist under
+// (row + col) % 8, so build them once rather than per line.
+const FILLER_ROWS = Array.from(
+  { length: 8 },
+  (_unused, row) =>
+    `${Array.from({ length: COLS - 1 }, (_cell, col) => `\x1b[3${(row + col) % 8}mx`).join('')}\x1b[0m\r\n`
+)
+
 function writeLargeScrollback(emulator: HeadlessEmulator, fillerLines: number): void {
   let written = true
   for (let index = 0; index < fillerLines; index += 1) {
-    written = emulator.writeSync(`\x1b[3${index % 8}m${'x'.repeat(COLS - 1)}\x1b[0m\r\n`) && written
+    written = emulator.writeSync(FILLER_ROWS[index % 8]) && written
   }
   for (let index = 0; index < MARKERS; index += 1) {
     written = emulator.writeSync(`MARKER-${index}\r\n`) && written
@@ -51,7 +61,7 @@ describe('checkpoint-only cold restore of a large checkpoint', () => {
     const manager = new HistoryManager(dir)
     const reader = new HistoryReader(dir)
     const emulator = new HeadlessEmulator({ cols: COLS, rows: ROWS, scrollback: 100_000 })
-    writeLargeScrollback(emulator, 26_000)
+    writeLargeScrollback(emulator, 5_500)
 
     await manager.openSession(SESSION_ID, {
       cwd: '/Users/dev/large-scrollback',


### PR DESCRIPTION
## Summary

Test only — no production code. Pins two things about checkpoint-only cold restore that had no coverage and have now been misdiagnosed twice.

**Triage first: this is *not* a v1.4.156 regression.** A live test reported that checkpoint-only cold restore comes back visually blank at every size tried (1.0, 5.5, 11.2, 20.3 MiB), which would have been a release blocker for v1.4.156. It isn't. The baseline in that test was the PR base (`origin/main` = v1.4.156); v1.4.155 was never run.

I ran a real A/B: a `git worktree` checked out at `v1.4.155` against `origin/main`, driving the **real** `HistoryManager.checkpoint()` writer and the **real** `HistoryReader.detectColdRestore()` reader over a genuinely header-only `output.log` (9 bytes = `LOG_HEADER_BYTES`), which is exactly the checkpoint-only route.

| checkpoint | v1.4.155 | origin/main |
|---|---|---|
| 1.01 MiB | OK — 300/300 markers, seed 1016391 | OK — 300/300 markers, seed 1016391 |
| 5.56 MiB | OK — 300/300 markers, seed 5602391 | OK — 300/300 markers, seed 5602391 |
| 11.30 MiB | OK — 300/300 markers, seed 11382391 | OK — 300/300 markers, seed 11382391 |
| 20.61 MiB | OK — 300/300 markers, seed 20754391 | OK — 300/300 markers, seed 20754391 |

Byte-identical on both refs, at the reporter's own sizes, with a 3.5 KB control passing on both to prove the harness. #10179's bounded reader, #9990's async/semaphore rewrite and #10479's 200MB cap are output-equivalent to v1.4.155's bare `JSON.parse(readFileSync())`.

### What actually produces a blank

Blankness tracks the `meta.endedAt` eligibility gate, **not** size. Same probe, varying only how the daemon went away:

| shutdown | 3.5 KB | 1.01 MiB | 5.56 MiB |
|---|---|---|---|
| crash (`endedAt` null) | restore OK | restore OK | restore OK |
| `dispose()` / `closeSession()` (`endedAt` set) | **blank** | **blank** | **blank** |

Identical on both refs. A cleanly ended session refuses to cold-restore at any size — by design (`history-manager.ts:277`: *"an unwritten endedAt looks like an unclean shutdown → false cold restore next launch"*). That is the size-independent blank that was mistaken for a size cap. Cold restore requires the daemon to die *uncleanly*; a graceful shutdown runs `HistoryManager.dispose()` and correctly disqualifies every session.

### What this PR adds

The triage surfaced a real coverage gap: #10179's 16MiB read cap sat under what the unbounded checkpoint writer can emit, so a large checkpoint threw, got swallowed to `checkpoint=null`, and the pane reopened empty. #10479 raised the cap, but nothing pinned the writer→reader round trip the cap had broken — `history-reader-memory.test.ts` covers the bounded reader at its limit, and its >16MiB case hand-writes `checkpoint.json`, so it never exercises the real writer.

- **Large-checkpoint round trip** through the real writer and reader over a header-only log. Fails at the pre-#10479 16MiB cap with the exact production symptom (`AssertionError: expected null not to be null`), passes at the shipped cap.
- **The `endedAt` gate**, pinned at a fixed checkpoint size so the size variable is held constant. Two separate investigations have now read this gate as a size regression.

## Screenshots

No visual change — test-only.

## Testing

- [x] `pnpm lint` — `oxlint` + `oxfmt` clean
- [x] `pnpm typecheck` — `tsc -p config/tsconfig.node.json` clean
- [x] `pnpm test` — new suite 2 passed (~2.8s); full `src/main/daemon/` suite 1036 passed / 5 skipped, no interference
- [ ] `pnpm build` — not run; no production code changed
- [x] Added or updated high-quality tests that would catch regressions

Runs in ~2.8s (60s timeout). Temp dirs are created with `mkdtempSync` and removed in `afterEach`; verified zero leaked directories across 5 runs including 2 deliberate failures.

Peak RSS of the full `src/main/daemon/` suite: **241 MiB** without this file, **793 MiB** with it. The first cut of the fixture cost 1,244 MiB — see the memory finding below.

## AI Review Report

Reviewed with an AI agent whose primary mandate was to **disprove the tests** — because earlier in this same release cycle a retained oversized-checkpoint test was found to be vacuous (a 200MB NUL-byte fixture fails `JSON.parse` either way, so it stayed green with the byte cap disabled). A vacuous regression test is worse than none. Every claim below was executed, not read.

**Both tests were proven non-vacuous by mutation:**

| mutation | result |
|---|---|
| `TERMINAL_HISTORY_CHECKPOINT_MAX_BYTES` → `16 * 1024 * 1024` | test 1 fails: `expected null not to be null` |
| `endedAt` gate deleted (`history-reader.ts:70`) | test 2 fails: `expected true to be false` |
| `writeSync` forced unavailable | **both** fail (see finding below) |

**It fails for the right reason.** An instrumented probe confirmed the throw at the reverted cap is `NodeFileReadTooLargeError: File too large: 46.1MB exceeds 16MB limit` — the byte cap specifically, not `JSON.parse` and not the other bound in that same read path. The structural-token limit is not in play: `assertJsonTextStructureWithinLimits` skips string contents, and the checkpoint is a flat 11-key object, so its token count stays in the dozens no matter how large the payload gets. That bound targets structural amplification, which `history-reader-memory.test.ts` covers separately.

**The fixture is realistic, not filler.** At the shipped cap the file parses into a real `TerminalCheckpointFile` with all 11 top-level keys (`snapshotAnsi, scrollbackAnsi, oscLinks, rehydrateSequences, cwd, cols, rows, modes, scrollbackLines, generation, checkpointedAt`), and all **300/300** distinct markers survive the round trip — `checkpoint.json` 46.13 MiB, seed 26,381,501 chars. `output.log` is exactly 9 bytes = `LOG_HEADER_BYTES` and `rehydrateSequences` is empty, so log replay contributes nothing and the checkpoint-only route is genuine.

**It measures what the user actually sees.** `daemon-pty-adapter.ts:57-62` `getRecoveredHistorySeed` composes exactly `rehydrateSequences + snapshotAnsi` on the non-alt-screen branch, which the test pins with `expect(modes.alternateScreen).toBe(false)`.

### Defects found and fixed

**1. A silent-vacuity hole in the `endedAt` test** (also flagged by CodeRabbit, 45e178d). `writeLargeScrollback` ignored `writeSync`'s boolean, which returns `false` if xterm's private `_core.writeSync` ever goes away. The large-checkpoint test self-guards (fails `expected 416 to be greater than 16777216`), but the `endedAt` gate is size-independent, so **that test silently passed on a 416-byte checkpoint** — pinning the gate over no scrollback at all. Fixed with an accumulator plus a single assertion in the helper; both tests now fail loudly.

**2. The fixture raised the whole daemon suite's peak memory 5.2x** (33edb2b). Despite the comment claiming SGR-per-cell, the filler coloured per *line*, so the serialized seed only tracked plain-text size and needed 26k buffer rows to clear 16MiB. The xterm buffer costs rows × cols, so this one file took `src/main/daemon/` from 241 MiB to 1,244 MiB peak RSS — a real CI OOM risk immediately after #10299 bounded shared readers for that same reason. Carrying the bytes in SGR runs instead of rows reaches a *larger* seed from 5.5k rows:

| | before | after |
|---|---|---|
| suite peak RSS | 1,244 MiB | **793 MiB** |
| seed margin over 16MiB | 1.19x (20.0 MiB) | **1.57x (25.16 MiB)** |
| `checkpoint.json` margin | 1.20x (20.16 MiB) | **2.88x (46.1 MiB)** |
| file runtime | 3.4s | 2.8s |

So it is cheaper *and* better-pinned, and the fixture now matches its own comment and is more representative of real coloured agent output. All three mutations were re-verified against the new fixture.

**3. Review follow-ups** (370d10d8). Two independent reviewers returned LAND-READY; one reproduced the memory finding above with matching numbers. Their non-blocking points, applied: import `getHistorySessionDirName` rather than hand-rolling `encodeURIComponent` (equivalent today, but that helper exists to absorb encoding changes, so the copy would silently diverge from the writer it checks); index `FILLER_ROWS` by its own length so growing the array cannot leave rows unused; and drop the timeout from `300_000` to `60_000`, since the file runs in ~2.8s and vitest's own default is 30s — a 5-minute ceiling turns a hung regression into a stalled job rather than a failure.

One suggested change I applied only on its secondary rationale: taking the snapshot, disposing, then checkpointing is exception-safe, but it is **not** the memory saving it was proposed as. Peak RSS is set at `getSnapshot()`, where the live buffer and the serialized strings coexist, so disposing before `checkpoint()` cannot move it — measured ~800 MiB either way across three runs each. I also declined renaming test 2, whose "at the same checkpoint size" refers to holding size constant across the two branches, which is accurate as written.

**Cross-platform (macOS/Linux/Windows):** `getHistorySessionDirName` is `encodeURIComponent` (`history-paths.ts`), so the test's manual encoding matches production and the POSIX-looking `SESSION_ID` is encoded to a valid Windows path segment — the reason that helper exists. All paths go through `path.join`; temp dirs come from `os.tmpdir()`. No shell invocation, no shortcuts, no labels, no Electron-specific behavior touched.

**Considered and declined as gold-plating:** asserting all 300/300 markers rather than first/last — the regression class is all-or-nothing, and `seed.length > 16MiB` already catches content loss loudly, including a future writer-side trim.

## Security Audit

Low risk: test-only, no production code, no new dependencies. No command execution, no IPC, no auth, no secrets, no network. Input handling is confined to a synthetic in-process ANSI fixture. Path handling writes only under a `mkdtempSync` directory removed in `afterEach`; the `rmSync(..., { recursive: true, force: true })` targets are derived from that temp root, not from user input. No follow-up needed.

## Notes

- This exercises the main-side path down to `ColdRestoreInfo`. I did **not** drive two full Electron builds through a real UI, so a purely renderer-side blank is not excluded by this evidence. Given the main-side output is byte-identical across the refs, any such blank would not be a v1.4.156 regression in the restore read path.
- One genuine v1.4.156-introduced behaviour change I found and verified but did **not** fix here, as it is out of scope and not the reported defect: `ColdRestorePayloadCache`'s new 16MiB bound makes an oversized payload self-evict during its own `set()` (measured: `oversizedSurvivesAlone=false`, and it evicts prior entries too), where v1.4.155 used an unbounded `Map`. Both call sites appear to tolerate it — the spawn path returns the payload directly, and the sleep path guards with `has()` and re-reads from disk on wake — so I believe it self-heals, but I have not end-to-end verified the wake path. Worth a follow-up.
- `terminal-history-file-limits.ts` notes that trimming the snapshot writer-side is the real fix for oversized checkpoints; the 200MB cap bounds a corrupt/runaway file, not retention.
