### PR TITLE
fix(git): prune durable review-head refs when last worktree is deleted

### DIFF
--- a/src/main/git/review-head-ref-prune.test.ts
+++ b/src/main/git/review-head-ref-prune.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  deleteReviewHeadLocalRefs,
+  listOrcaReviewHeadLocalRefs,
+  otherWorktreesStillLinkReview,
+  pruneReviewHeadLocalRefsAfterWorktreeDelete
+} from './review-head-ref-prune'
+import type { WorktreeMeta } from '../../shared/types'
+
+function meta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    displayName: '',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('otherWorktreesStillLinkReview', () => {
+  it('is false when no other worktree shares the PR', () => {
+    expect(
+      otherWorktreesStillLinkReview(
+        {
+          'repo-a::/wt/pr-42': meta({ linkedPR: 42 }),
+          'repo-a::/wt/other': meta({ linkedPR: 7 })
+        },
+        {
+          excludeWorktreeId: 'repo-a::/wt/pr-42',
+          repoId: 'repo-a',
+          githubPrNumber: 42
+        }
+      )
+    ).toBe(false)
+  })
+
+  it('is true when a sibling worktree still links the same PR', () => {
+    expect(
+      otherWorktreesStillLinkReview(
+        {
+          'repo-a::/wt/pr-42-a': meta({ linkedPR: 42 }),
+          'repo-a::/wt/pr-42-b': meta({ linkedPR: 42 })
+        },
+        {
+          excludeWorktreeId: 'repo-a::/wt/pr-42-a',
+          repoId: 'repo-a',
+          githubPrNumber: 42
+        }
+      )
+    ).toBe(true)
+  })
+
+  it('ignores worktrees in a different repo', () => {
+    expect(
+      otherWorktreesStillLinkReview(
+        {
+          'repo-a::/wt/pr-42': meta({ linkedPR: 42 }),
+          'repo-b::/wt/pr-42': meta({ linkedPR: 42 })
+        },
+        {
+          excludeWorktreeId: 'repo-a::/wt/pr-42',
+          repoId: 'repo-a',
+          githubPrNumber: 42
+        }
+      )
+    ).toBe(false)
+  })
+})
+
+describe('pruneReviewHeadLocalRefsAfterWorktreeDelete', () => {
+  const gitExec = vi.fn()
+
+  beforeEach(() => {
+    gitExec.mockReset()
+  })
+
+  it('deletes matching durable PR refs when this was the last linked worktree', async () => {
+    gitExec.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        return {
+          stdout: [
+            'refs/orca/pull/origin-aaa/42',
+            'refs/orca/pull/origin-aaa/99',
+            'refs/orca/merge-requests/origin-aaa/42',
+            ''
+          ].join('\n'),
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const deleted = await pruneReviewHeadLocalRefsAfterWorktreeDelete({
+      repoPath: '/repo',
+      repoId: 'repo-a',
+      deletedWorktreeId: 'repo-a::/wt/pr-42',
+      meta: meta({ linkedPR: 42 }),
+      worktreeMetaById: {
+        'repo-a::/wt/pr-42': meta({ linkedPR: 42 }),
+        'repo-a::/wt/other': meta({ linkedPR: 7 })
+      },
+      gitExec
+    })
+
+    expect(deleted).toEqual(['refs/orca/pull/origin-aaa/42'])
+    expect(gitExec).toHaveBeenCalledWith(['update-ref', '-d', 'refs/orca/pull/origin-aaa/42'])
+    expect(gitExec).not.toHaveBeenCalledWith(['update-ref', '-d', 'refs/orca/pull/origin-aaa/99'])
+  })
+
+  it('does not delete when another worktree still links the PR', async () => {
+    const deleted = await pruneReviewHeadLocalRefsAfterWorktreeDelete({
+      repoPath: '/repo',
+      repoId: 'repo-a',
+      deletedWorktreeId: 'repo-a::/wt/pr-42-a',
+      meta: meta({ linkedPR: 42 }),
+      worktreeMetaById: {
+        'repo-a::/wt/pr-42-a': meta({ linkedPR: 42 }),
+        'repo-a::/wt/pr-42-b': meta({ linkedPR: 42 })
+      },
+      gitExec
+    })
+
+    expect(deleted).toEqual([])
+    expect(gitExec).not.toHaveBeenCalled()
+  })
+
+  it('prunes GitLab MR refs when linkedGitLabMR is set', async () => {
+    gitExec.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        return {
+          stdout: 'refs/orca/merge-requests/origin-bbb/15\nrefs/orca/pull/origin-bbb/15\n',
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const deleted = await pruneReviewHeadLocalRefsAfterWorktreeDelete({
+      repoPath: '/repo',
+      repoId: 'repo-a',
+      deletedWorktreeId: 'repo-a::/wt/mr-15',
+      meta: meta({ linkedGitLabMR: 15 }),
+      worktreeMetaById: {
+        'repo-a::/wt/mr-15': meta({ linkedGitLabMR: 15 })
+      },
+      gitExec
+    })
+
+    expect(deleted).toEqual(['refs/orca/merge-requests/origin-bbb/15'])
+  })
+
+  it('no-ops without linked PR/MR metadata', async () => {
+    const deleted = await pruneReviewHeadLocalRefsAfterWorktreeDelete({
+      repoPath: '/repo',
+      repoId: 'repo-a',
+      deletedWorktreeId: 'repo-a::/wt/plain',
+      meta: meta(),
+      worktreeMetaById: {},
+      gitExec
+    })
+    expect(deleted).toEqual([])
+    expect(gitExec).not.toHaveBeenCalled()
+  })
+})
+
+describe('listOrcaReviewHeadLocalRefs / deleteReviewHeadLocalRefs', () => {
+  it('lists and deletes refs', async () => {
+    const gitExec = vi
+      .fn()
+      .mockResolvedValueOnce({
+        stdout: 'refs/orca/pull/c/1\nrefs/orca/pull/c/2\n',
+        stderr: ''
+      })
+      .mockResolvedValue({ stdout: '', stderr: '' })
+
+    await expect(listOrcaReviewHeadLocalRefs(gitExec)).resolves.toEqual([
+      'refs/orca/pull/c/1',
+      'refs/orca/pull/c/2'
+    ])
+    await expect(deleteReviewHeadLocalRefs(gitExec, ['refs/orca/pull/c/1'])).resolves.toEqual([
+      'refs/orca/pull/c/1'
+    ])
+  })
+})

--- a/src/main/git/review-head-ref-prune.test.ts
+++ b/src/main/git/review-head-ref-prune.test.ts
@@ -23,6 +23,17 @@ function meta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
   }
 }
 
+/** Snapshot-style helper for single-threaded tests. */
+function finalizeFromMap(
+  map: Record<string, WorktreeMeta | undefined>,
+  deletedWorktreeId: string
+): () => Record<string, WorktreeMeta | undefined> {
+  return () => {
+    delete map[deletedWorktreeId]
+    return { ...map }
+  }
+}
+
 describe('otherWorktreesStillLinkReview', () => {
   it('is false when no other worktree shares the PR', () => {
     expect(
@@ -96,15 +107,17 @@ describe('pruneReviewHeadLocalRefsAfterWorktreeDelete', () => {
       return { stdout: '', stderr: '' }
     })
 
+    const map: Record<string, WorktreeMeta | undefined> = {
+      'repo-a::/wt/pr-42': meta({ linkedPR: 42 }),
+      'repo-a::/wt/other': meta({ linkedPR: 7 })
+    }
+
     const deleted = await pruneReviewHeadLocalRefsAfterWorktreeDelete({
       repoPath: '/repo',
       repoId: 'repo-a',
       deletedWorktreeId: 'repo-a::/wt/pr-42',
       meta: meta({ linkedPR: 42 }),
-      worktreeMetaById: {
-        'repo-a::/wt/pr-42': meta({ linkedPR: 42 }),
-        'repo-a::/wt/other': meta({ linkedPR: 7 })
-      },
+      finalizeDeletedMetaAndReadSiblings: finalizeFromMap(map, 'repo-a::/wt/pr-42'),
       gitExec
     })
 
@@ -114,20 +127,25 @@ describe('pruneReviewHeadLocalRefsAfterWorktreeDelete', () => {
   })
 
   it('does not delete when another worktree still links the PR', async () => {
+    const map: Record<string, WorktreeMeta | undefined> = {
+      'repo-a::/wt/pr-42-a': meta({ linkedPR: 42 }),
+      'repo-a::/wt/pr-42-b': meta({ linkedPR: 42 })
+    }
+
     const deleted = await pruneReviewHeadLocalRefsAfterWorktreeDelete({
       repoPath: '/repo',
       repoId: 'repo-a',
       deletedWorktreeId: 'repo-a::/wt/pr-42-a',
       meta: meta({ linkedPR: 42 }),
-      worktreeMetaById: {
-        'repo-a::/wt/pr-42-a': meta({ linkedPR: 42 }),
-        'repo-a::/wt/pr-42-b': meta({ linkedPR: 42 })
-      },
+      finalizeDeletedMetaAndReadSiblings: finalizeFromMap(map, 'repo-a::/wt/pr-42-a'),
       gitExec
     })
 
     expect(deleted).toEqual([])
     expect(gitExec).not.toHaveBeenCalled()
+    // First of two still-linked deletes only drops its own meta entry.
+    expect(map['repo-a::/wt/pr-42-a']).toBeUndefined()
+    expect(map['repo-a::/wt/pr-42-b']).toBeDefined()
   })
 
   it('prunes GitLab MR refs when linkedGitLabMR is set', async () => {
@@ -141,14 +159,16 @@ describe('pruneReviewHeadLocalRefsAfterWorktreeDelete', () => {
       return { stdout: '', stderr: '' }
     })
 
+    const map: Record<string, WorktreeMeta | undefined> = {
+      'repo-a::/wt/mr-15': meta({ linkedGitLabMR: 15 })
+    }
+
     const deleted = await pruneReviewHeadLocalRefsAfterWorktreeDelete({
       repoPath: '/repo',
       repoId: 'repo-a',
       deletedWorktreeId: 'repo-a::/wt/mr-15',
       meta: meta({ linkedGitLabMR: 15 }),
-      worktreeMetaById: {
-        'repo-a::/wt/mr-15': meta({ linkedGitLabMR: 15 })
-      },
+      finalizeDeletedMetaAndReadSiblings: finalizeFromMap(map, 'repo-a::/wt/mr-15'),
       gitExec
     })
 
@@ -161,11 +181,59 @@ describe('pruneReviewHeadLocalRefsAfterWorktreeDelete', () => {
       repoId: 'repo-a',
       deletedWorktreeId: 'repo-a::/wt/plain',
       meta: meta(),
-      worktreeMetaById: {},
+      finalizeDeletedMetaAndReadSiblings: () => ({}),
       gitExec
     })
     expect(deleted).toEqual([])
     expect(gitExec).not.toHaveBeenCalled()
+  })
+
+  it('prunes when two last linked worktrees delete concurrently (shared live meta)', async () => {
+    // Why: snapshot-before-lock would leave each call seeing the other sibling and both skip.
+    gitExec.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'for-each-ref') {
+        return {
+          stdout: 'refs/orca/pull/origin-aaa/42\n',
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    const liveMeta: Record<string, WorktreeMeta | undefined> = {
+      'repo-a::/wt/pr-42-a': meta({ linkedPR: 42 }),
+      'repo-a::/wt/pr-42-b': meta({ linkedPR: 42 })
+    }
+
+    const makeFinalize = (id: string) => () => {
+      delete liveMeta[id]
+      return { ...liveMeta }
+    }
+
+    const [deletedA, deletedB] = await Promise.all([
+      pruneReviewHeadLocalRefsAfterWorktreeDelete({
+        repoPath: '/repo',
+        repoId: 'repo-a',
+        deletedWorktreeId: 'repo-a::/wt/pr-42-a',
+        meta: meta({ linkedPR: 42 }),
+        finalizeDeletedMetaAndReadSiblings: makeFinalize('repo-a::/wt/pr-42-a'),
+        gitExec
+      }),
+      pruneReviewHeadLocalRefsAfterWorktreeDelete({
+        repoPath: '/repo',
+        repoId: 'repo-a',
+        deletedWorktreeId: 'repo-a::/wt/pr-42-b',
+        meta: meta({ linkedPR: 42 }),
+        finalizeDeletedMetaAndReadSiblings: makeFinalize('repo-a::/wt/pr-42-b'),
+        gitExec
+      })
+    ])
+
+    const allDeleted = [...deletedA, ...deletedB]
+    expect(allDeleted).toContain('refs/orca/pull/origin-aaa/42')
+    // Exactly one of the two finalizers should have performed the prune.
+    expect(allDeleted.filter((r) => r === 'refs/orca/pull/origin-aaa/42')).toHaveLength(1)
+    expect(liveMeta).toEqual({})
   })
 })
 

--- a/src/main/git/review-head-ref-prune.ts
+++ b/src/main/git/review-head-ref-prune.ts
@@ -10,7 +10,7 @@ type GitExec = (args: string[]) => Promise<{ stdout: string; stderr: string }>
 
 /**
  * Whether any *other* worktree in the same repo still links the same PR/MR.
- * Call before dropping metadata for the deleted worktree.
+ * Call after the deleted worktree’s metadata has been dropped from the view.
  */
 export function otherWorktreesStillLinkReview(
   worktreeMetaById: Record<string, WorktreeMeta | undefined>,
@@ -76,6 +76,37 @@ export async function deleteReviewHeadLocalRefs(
   return deleted
 }
 
+// Why: concurrent deletes for the same PR/MR can both observe a sibling and
+// both skip prune; serialize by review key so the last delete re-checks meta.
+const reviewHeadPruneChains = new Map<string, Promise<unknown>>()
+
+function reviewHeadPruneLockKey(
+  repoId: string,
+  githubPrNumber: number | null,
+  gitlabMrIid: number | null
+): string {
+  return `${repoId}:pr=${githubPrNumber ?? ''}:mr=${gitlabMrIid ?? ''}`
+}
+
+async function withReviewHeadPruneLock<T>(key: string, run: () => Promise<T>): Promise<T> {
+  const previous = reviewHeadPruneChains.get(key) ?? Promise.resolve()
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const chain = previous.then(() => gate)
+  reviewHeadPruneChains.set(key, chain)
+  await previous.catch(() => undefined)
+  try {
+    return await run()
+  } finally {
+    release()
+    if (reviewHeadPruneChains.get(key) === chain) {
+      reviewHeadPruneChains.delete(key)
+    }
+  }
+}
+
 /**
  * After a successful worktree delete, drop durable refs/orca/** pins for that
  * PR/MR when no sibling worktree still links them (#10431).
@@ -85,7 +116,12 @@ export async function pruneReviewHeadLocalRefsAfterWorktreeDelete(params: {
   repoId: string
   deletedWorktreeId: string
   meta: Pick<WorktreeMeta, 'linkedPR' | 'linkedGitLabMR'> | null | undefined
-  worktreeMetaById: Record<string, WorktreeMeta | undefined>
+  /**
+   * Under the prune lock: drop this worktree from the live sibling view, then
+   * return remaining meta. Snapshot-before-lock races leave durable refs forever
+   * when two last worktrees delete concurrently.
+   */
+  finalizeDeletedMetaAndReadSiblings: () => Record<string, WorktreeMeta | undefined>
   gitExec?: GitExec
   localGitOptions?: GitExecOptions
 }): Promise<string[]> {
@@ -95,32 +131,37 @@ export async function pruneReviewHeadLocalRefsAfterWorktreeDelete(params: {
     return []
   }
 
-  if (
-    otherWorktreesStillLinkReview(params.worktreeMetaById, {
-      excludeWorktreeId: params.deletedWorktreeId,
-      repoId: params.repoId,
+  const lockKey = reviewHeadPruneLockKey(params.repoId, githubPrNumber, gitlabMrIid)
+  return withReviewHeadPruneLock(lockKey, async () => {
+    // Why: metadata removal + sibling re-check must be the same lock-held txn.
+    const remainingMeta = params.finalizeDeletedMetaAndReadSiblings()
+    if (
+      otherWorktreesStillLinkReview(remainingMeta, {
+        excludeWorktreeId: params.deletedWorktreeId,
+        repoId: params.repoId,
+        githubPrNumber,
+        gitlabMrIid
+      })
+    ) {
+      return []
+    }
+
+    const gitExec: GitExec =
+      params.gitExec ??
+      ((args) =>
+        gitExecFileAsync(args, {
+          cwd: params.repoPath,
+          ...params.localGitOptions
+        }))
+
+    const refs = await listOrcaReviewHeadLocalRefs(gitExec)
+    const toDelete = selectReviewHeadLocalRefsToPrune(refs, {
       githubPrNumber,
       gitlabMrIid
     })
-  ) {
-    return []
-  }
-
-  const gitExec: GitExec =
-    params.gitExec ??
-    ((args) =>
-      gitExecFileAsync(args, {
-        cwd: params.repoPath,
-        ...params.localGitOptions
-      }))
-
-  const refs = await listOrcaReviewHeadLocalRefs(gitExec)
-  const toDelete = selectReviewHeadLocalRefsToPrune(refs, {
-    githubPrNumber,
-    gitlabMrIid
+    if (toDelete.length === 0) {
+      return []
+    }
+    return deleteReviewHeadLocalRefs(gitExec, toDelete)
   })
-  if (toDelete.length === 0) {
-    return []
-  }
-  return deleteReviewHeadLocalRefs(gitExec, toDelete)
 }

--- a/src/main/git/review-head-ref-prune.ts
+++ b/src/main/git/review-head-ref-prune.ts
@@ -1,0 +1,125 @@
+import type { WorktreeMeta } from '../../shared/types'
+import {
+  isValidReviewHeadNumber,
+  selectReviewHeadLocalRefsToPrune
+} from '../../shared/review-head-tracking-ref'
+import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
+import { gitExecFileAsync, type GitExecOptions } from './runner'
+
+type GitExec = (args: string[]) => Promise<{ stdout: string; stderr: string }>
+
+/**
+ * Whether any *other* worktree in the same repo still links the same PR/MR.
+ * Call before dropping metadata for the deleted worktree.
+ */
+export function otherWorktreesStillLinkReview(
+  worktreeMetaById: Record<string, WorktreeMeta | undefined>,
+  params: {
+    excludeWorktreeId: string
+    repoId: string
+    githubPrNumber?: number | null
+    gitlabMrIid?: number | null
+  }
+): boolean {
+  const wantPr = isValidReviewHeadNumber(params.githubPrNumber) ? params.githubPrNumber : null
+  const wantMr = isValidReviewHeadNumber(params.gitlabMrIid) ? params.gitlabMrIid : null
+  if (wantPr === null && wantMr === null) {
+    return false
+  }
+
+  for (const [worktreeId, meta] of Object.entries(worktreeMetaById)) {
+    if (!meta || worktreeId === params.excludeWorktreeId) {
+      continue
+    }
+    if (getRepoIdFromWorktreeId(worktreeId) !== params.repoId) {
+      continue
+    }
+    if (wantPr !== null && meta.linkedPR === wantPr) {
+      return true
+    }
+    if (wantMr !== null && meta.linkedGitLabMR === wantMr) {
+      return true
+    }
+  }
+  return false
+}
+
+export async function listOrcaReviewHeadLocalRefs(gitExec: GitExec): Promise<string[]> {
+  try {
+    const { stdout } = await gitExec(['for-each-ref', '--format=%(refname)', 'refs/orca/'])
+    return stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+  } catch {
+    // Why: empty orca namespace / older git — nothing to prune.
+    return []
+  }
+}
+
+export async function deleteReviewHeadLocalRefs(
+  gitExec: GitExec,
+  refNames: readonly string[]
+): Promise<string[]> {
+  const deleted: string[] = []
+  for (const refName of refNames) {
+    try {
+      // Why: update-ref -d is the standard way to drop a local ref without
+      // touching the worktree checkout (already removed at this point).
+      await gitExec(['update-ref', '-d', refName])
+      deleted.push(refName)
+    } catch (error) {
+      console.warn(`[git] Failed to prune durable review-head ref ${refName}:`, error)
+    }
+  }
+  return deleted
+}
+
+/**
+ * After a successful worktree delete, drop durable refs/orca/** pins for that
+ * PR/MR when no sibling worktree still links them (#10431).
+ */
+export async function pruneReviewHeadLocalRefsAfterWorktreeDelete(params: {
+  repoPath: string
+  repoId: string
+  deletedWorktreeId: string
+  meta: Pick<WorktreeMeta, 'linkedPR' | 'linkedGitLabMR'> | null | undefined
+  worktreeMetaById: Record<string, WorktreeMeta | undefined>
+  gitExec?: GitExec
+  localGitOptions?: GitExecOptions
+}): Promise<string[]> {
+  const githubPrNumber = params.meta?.linkedPR ?? null
+  const gitlabMrIid = params.meta?.linkedGitLabMR ?? null
+  if (!isValidReviewHeadNumber(githubPrNumber) && !isValidReviewHeadNumber(gitlabMrIid)) {
+    return []
+  }
+
+  if (
+    otherWorktreesStillLinkReview(params.worktreeMetaById, {
+      excludeWorktreeId: params.deletedWorktreeId,
+      repoId: params.repoId,
+      githubPrNumber,
+      gitlabMrIid
+    })
+  ) {
+    return []
+  }
+
+  const gitExec: GitExec =
+    params.gitExec ??
+    ((args) =>
+      gitExecFileAsync(args, {
+        cwd: params.repoPath,
+        ...params.localGitOptions
+      }))
+
+  const refs = await listOrcaReviewHeadLocalRefs(gitExec)
+  const toDelete = selectReviewHeadLocalRefsToPrune(refs, {
+    githubPrNumber,
+    gitlabMrIid
+  })
+  if (toDelete.length === 0) {
+    return []
+  }
+  return deleteReviewHeadLocalRefs(gitExec, toDelete)
+}

--- a/src/main/git/review-head-ref-prune.ts
+++ b/src/main/git/review-head-ref-prune.ts
@@ -51,8 +51,9 @@ export async function listOrcaReviewHeadLocalRefs(gitExec: GitExec): Promise<str
       .split('\n')
       .map((line) => line.trim())
       .filter((line) => line.length > 0)
-  } catch {
-    // Why: empty orca namespace / older git — nothing to prune.
+  } catch (error) {
+    // Why: empty namespace succeeds with empty stdout; real for-each-ref failures must still warn.
+    console.warn('[git] Failed to list durable review-head refs:', error)
     return []
   }
 }

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1,5 +1,6 @@
 /* oxlint-disable max-lines */
-import { ipcMain, type BrowserWindow } from 'electron'
+import type { BrowserWindow } from 'electron'
+import { ipcMain } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
@@ -12,13 +13,8 @@ import {
 } from '../../shared/workspace-scope'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-projection'
-import { TaskSourceContextSchema } from '../../shared/task-source-context-schema'
-import { WorkspaceLinkedItemSchema } from '../../shared/workspace-linked-item-schema'
-import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-linked-item-source-context'
-import { getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
-import { isPathInsideOrEqual, isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
-import { deleteWorktreeHistoryDir } from '../terminal-history-deletion'
+import { deleteWorktreeHistoryDir } from '../terminal-history'
 import type {
   AutomationWorkspaceProvenance,
   CliWorkspaceProvenance,
@@ -34,32 +30,10 @@ import type {
   Repo,
   RemoveWorktreeResult,
   Worktree,
-  WorktreeLineage,
-  WorkspaceLineage,
   WorktreeMeta
 } from '../../shared/types'
 import { assertWorktreeUnlockedForRemoval } from '../../shared/worktree-removal'
-import {
-  getRepoExecutionHostId,
-  LOCAL_EXECUTION_HOST_ID,
-  parseExecutionHostId,
-  toSshExecutionHostId,
-  type ExecutionHostId
-} from '../../shared/execution-host'
-import {
-  PROVIDER_REQUEST_ID_MAX_UTF8_BYTES,
-  type DirectSshDetectedWorktreeRequest,
-  type HostQualifiedKnownWorktreeResult,
-  type HostQualifiedDetectedWorktreeResult,
-  type ListKnownWorktreesForExecutionHostArgs,
-  type ListDetectedWorktreesArgs,
-  type ProviderRequestId
-} from '../../shared/detected-worktree-provider-contract'
-import type {
-  HostLineageSnapshot,
-  ListDesktopLineageForHostArgs
-} from '../../shared/host-lineage-contract'
-import { isAdmissibleDirectSshAuthority } from '../../shared/ssh-retained-payload-admission'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import {
   applyMetadataFallbackVisibility,
   buildKnownOrcaWorkspaceLayouts,
@@ -75,7 +49,7 @@ import {
 } from '../git/worktree'
 import { gitExecFileAsync } from '../git/runner'
 import { pruneReviewHeadLocalRefsAfterWorktreeDelete } from '../git/review-head-ref-prune'
-import { withWorktreeRemoveStageSpan, withWorktreeSpan } from '../observability/instrumentation'
+import { withWorktreeSpan } from '../observability/instrumentation'
 import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
 import {
   fetchGitHubPullRequestHeadRef,
@@ -94,7 +68,6 @@ import {
   loadHooks,
   parseOrcaYaml,
   readIssueCommand,
-  resolveSetupRunnerShell,
   runHook,
   hasHooksFile,
   hasUnrecognizedOrcaYamlKeys,
@@ -123,11 +96,10 @@ import {
   isENOENT,
   registerWorktreeRootsForRepo
 } from './filesystem-auth'
-import type { OrcaRuntimeService, RuntimeWorktreeLifecycleEvent } from '../runtime/orca-runtime'
+import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import { killAllProcessesForWorktree } from '../runtime/worktree-teardown'
 import { clearProviderPtyState, getLocalPtyProvider, getSshPtyProvider } from './pty'
 import { findExistingWorktreeSymlinkPaths, removeWorktreeLinkedPaths } from './worktree-symlinks'
-import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import { workspaceSourceSchema, type WorkspaceSource } from '../../shared/telemetry-events'
@@ -137,12 +109,6 @@ import {
   resolveAutomationWorkspaceProvenance
 } from '../automations/workspace-provenance'
 import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
-import {
-  getSshProviderAuthority,
-  isCurrentSshProviderAuthority,
-  registerSshProviderRequestAbort
-} from '../ssh/ssh-provider-authority'
-import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -153,36 +119,23 @@ type RemoveWorktreeArgs = {
   worktreeId: string
   hostId?: ExecutionHostId
   force?: boolean
-  /** Explicit Force Delete only — `force` alone is set by the ordinary confirmation (#11960). */
-  allowUnverifiedPtyStop?: boolean
   skipArchive?: boolean
 }
-
-type DetectedWorktreeRequestArgs = { repoId: string } | ListDetectedWorktreesArgs
 
 async function stopPtysForDestructiveWorktreeRemoval(
   runtime: OrcaRuntimeService,
   worktreeId: string,
-  options: { connectionId?: string; allowUnverifiedStop?: boolean } = {}
+  connectionId?: string
 ): Promise<void> {
-  const { connectionId, allowUnverifiedStop } = options
   const provider = connectionId ? getSshPtyProvider(connectionId) : getLocalPtyProvider()
   if (!provider) {
     throw new Error(`PTY provider unavailable for worktree deletion: ${worktreeId}`)
   }
   const teardownResult = await killAllProcessesForWorktree(worktreeId, {
     runtime,
-    // Why: `repoId::path` ids repeat across hosts, so an unfenced sweep stops a same-id
-    // workspace's terminals on another connection — and the selector lookup this replaces
-    // throws `selector_ambiguous` the moment two hosts own the id.
-    resolvedWorktreeId: worktreeId,
-    ...(connectionId ? { resolvedConnectionId: connectionId } : {}),
     localProvider: provider,
     onPtyStopped: clearProviderPtyState,
     requirePhysicalStop: true,
-    // Why (#11960): set only by an explicit Force Delete, never by the ordinary
-    // confirmation — otherwise the gate would be off on the primary delete path.
-    ...(allowUnverifiedStop ? { allowUnverifiedStop: true } : {}),
     ...(connectionId ? { includeLocalRegistry: false } : {})
   })
   const total =
@@ -229,11 +182,11 @@ import {
   stripOrcaProvenanceMetaUpdates,
   UNREGISTERED_MISSING_WORKTREE_MESSAGE
 } from '../worktree-removal-safety'
+import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import {
   FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
-  getRepoIdFromWorktreeId,
-  getWorktreePathBasenameFromId
+  getRepoIdFromWorktreeId
 } from '../../shared/worktree-id'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import {
@@ -250,38 +203,8 @@ import {
   recoverLocalWindowsWorktreeRemoval
 } from '../local-worktree-removal-recovery'
 
-const NullableWorkspaceLinkedItemSchema = WorkspaceLinkedItemSchema.nullable()
-const NullableTaskSourceContextSchema = TaskSourceContextSchema.nullable()
 const WORKTREE_ARCHIVE_HOOK_TIMEOUT_MS = 120_000
 const WORKTREE_LIST_ALL_CONCURRENCY = 8
-
-function normalizeLinkedWorkItemFields<
-  T extends {
-    linkedWorkItem?: unknown
-    linkedTaskSourceContext?: unknown
-  }
->(input: T): T {
-  const linkedWorkItem =
-    input.linkedWorkItem === undefined
-      ? undefined
-      : NullableWorkspaceLinkedItemSchema.parse(input.linkedWorkItem)
-  const linkedTaskSourceContext =
-    input.linkedTaskSourceContext === undefined
-      ? undefined
-      : NullableTaskSourceContextSchema.parse(input.linkedTaskSourceContext)
-  if (
-    linkedWorkItem &&
-    linkedTaskSourceContext &&
-    !isWorkspaceLinkedItemSourceContextMatch(linkedWorkItem, linkedTaskSourceContext)
-  ) {
-    throw new Error('Linked work item and source context identities must match')
-  }
-  return {
-    ...input,
-    ...(linkedWorkItem !== undefined ? { linkedWorkItem } : {}),
-    ...(linkedTaskSourceContext !== undefined ? { linkedTaskSourceContext } : {})
-  }
-}
 
 async function mapWithConcurrency<T, R>(
   items: readonly T[],
@@ -301,20 +224,6 @@ async function mapWithConcurrency<T, R>(
     })
   )
   return results
-}
-
-// Why: the worktree's own persisted host outranks the repo fallback; teardown and metadata purge must resolve the same owner
-// or the purge lands on the local partition while the SSH/runtime one keeps the workspace's tabs forever.
-function resolveWorktreeRemovalOwnerHostId(
-  store: Store,
-  worktreeId: string,
-  repo: Repo | undefined,
-  fallbackHostId?: ExecutionHostId
-): ExecutionHostId | undefined {
-  return (
-    store.getWorktreeMeta(worktreeId)?.hostId ??
-    (repo ? getRepoExecutionHostId(repo) : fallbackHostId)
-  )
 }
 
 /** Best-effort: drop durable refs/orca/** pins when the last linked worktree is gone (#10431). */
@@ -361,56 +270,14 @@ async function maybePruneReviewHeadRefsAfterWorktreeDelete(params: {
       error
     )
   }
-}): Promise<void> {
-  try {
-    const gitExec = params.sshGitProvider
-      ? (args: string[]) => params.sshGitProvider!.exec(args, params.repo.path)
-      : undefined
-    // Why: drop meta under the prune lock (not a pre-lock snapshot) so two
-    // concurrent last-worktree deletes cannot both see each other and skip.
-    await pruneReviewHeadLocalRefsAfterWorktreeDelete({
-      repoPath: params.repo.path,
-      repoId: params.repoId,
-      deletedWorktreeId: params.worktreeId,
-      meta: params.meta,
-      finalizeDeletedMetaAndReadSiblings: () => {
-        // Why: sibling detection only; full transient cleanup still runs after prune.
-        params.store.removeWorktreeMeta(params.worktreeId)
-        return params.store.getAllWorktreeMeta()
-      },
-      ...(gitExec ? { gitExec } : {}),
-      ...(params.sshGitProvider
-        ? {}
-        : {
-            localGitOptions: {
-              cwd: params.repo.path,
-              ...params.localGitOptions
-            }
-          })
-    })
-  } catch (error) {
-    console.warn(
-      `[worktrees] Failed to prune durable review-head refs after deleting ${params.worktreeId}:`,
-      error
-    )
-  }
 }
 
-function removeWorktreeMetadataAndTransientState(
-  store: Store,
-  worktreeId: string,
-  hostId?: ExecutionHostId
-): void {
+function removeWorktreeMetadataAndTransientState(store: Store, worktreeId: string): void {
   // Why: worktree IDs are path-derived and reusable; drop process-local caches before the same ID can map to a new workspace.
-  if (hostId) {
-    store.removeWorktreeMeta(worktreeId, hostId)
-  } else {
-    store.removeWorktreeMeta(worktreeId)
-  }
+  store.removeWorktreeMeta(worktreeId)
   advertisedUrlWatcher.forgetWorktree(worktreeId)
   // Why: drop this worktree's localhost label routes so they don't accumulate in the proxy's route maps all session.
   localhostWorktreeLabelProxy.unregisterWorktree(worktreeId)
-  // Why: schedule async history tree removal — never recursive-rmSync on the delete critical path.
   deleteWorktreeHistoryDir(worktreeId)
   // Why: release the removed worktree's PR-refresh aliases so coalesced queue entries don't retain it all session (memory creep).
   pruneWorktreePRRefreshAliases(worktreeId)
@@ -430,7 +297,7 @@ function getProjectHostSetupMetaUpdates(
     ...(sameSetup && existing?.projectId !== ownership.projectId
       ? { projectId: ownership.projectId }
       : {}),
-    ...(sameSetup && existing?.hostId === undefined ? { hostId: ownership.hostId } : {}),
+    ...(sameSetup && existing?.hostId !== ownership.hostId ? { hostId: ownership.hostId } : {}),
     ...(existing?.projectHostSetupId === undefined
       ? { projectHostSetupId: ownership.projectHostSetupId }
       : {})
@@ -513,17 +380,10 @@ function gitStatusErrorMeansNotRepository(error: unknown): boolean {
   return /not a git repository/i.test(`${message}\n${stderr}`)
 }
 
-function getWorktreeRemovalOptionsKey(args: {
-  force?: boolean
-  allowUnverifiedPtyStop?: boolean
-  skipArchive?: boolean
-}): string {
+function getWorktreeRemovalOptionsKey(args: { force?: boolean; skipArchive?: boolean }): string {
   const forceKey = args.force === true ? 'force' : 'normal'
   const archiveKey = args.skipArchive === true ? 'skip-archive' : 'run-archive'
-  // Why: a Force Delete retry must not coalesce onto the in-flight attempt that
-  // just failed the PTY gate — it would inherit that failure instead of retrying.
-  const ptyKey = args.allowUnverifiedPtyStop === true ? 'allow-unverified-pty' : 'require-pty-stop'
-  return `${forceKey}:${archiveKey}:${ptyKey}`
+  return `${forceKey}:${archiveKey}`
 }
 
 function getWorktreeRemovalInFlightKey(worktreeId: string, hostId?: ExecutionHostId): string {
@@ -663,8 +523,6 @@ function getPreservedBranchCleanupTarget(
 const loggedUnavailableSshGitProviders = new Set<string>()
 const loggedWorktreeListFailures = new Set<string>()
 const loggedMalformedWorktreeMetaKeys = new Set<string>()
-export const DETECTED_WORKTREE_PROVIDER_TIMEOUT_MS = 30_000
-export const LINEAGE_HYDRATION_TIMEOUT_MS = 5_000
 // Why: absorb renderer polling bursts while bounding external worktree-change lag to one short refresh window.
 const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5_000
 
@@ -817,18 +675,11 @@ function pruneLineageForMissingRepoWorktrees(
   }
   const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
   const repoPrefix = `${repo.id}::`
-  const expectedHostId = getRepoExecutionHostId(repo)
-  const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
-  const canMutateWorktree = (worktreeId: string): boolean => {
-    const hostId = store.getWorktreeMeta(worktreeId)?.hostId
-    return hostId ? hostId === expectedHostId : repoOwners.length === 1
-  }
   for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
     const childScope = parseWorkspaceKey(childWorkspaceKey)
     if (
       childScope?.type === 'worktree' &&
       childScope.worktreeId.startsWith(repoPrefix) &&
-      canMutateWorktree(childScope.worktreeId) &&
       !liveIds.has(childScope.worktreeId)
     ) {
       if (isWorkspaceKey(childWorkspaceKey)) {
@@ -837,16 +688,12 @@ function pruneLineageForMissingRepoWorktrees(
     }
   }
   for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-    if (childId.startsWith(repoPrefix) && canMutateWorktree(childId) && !liveIds.has(childId)) {
+    if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
       // Why: path-derived IDs can be reused; once a scan proves the child is gone, drop its lineage so a future same-path worktree can't inherit it.
       store.removeWorktreeLineage(childId)
       store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
     }
-    if (
-      lineage.parentWorktreeId.startsWith(repoPrefix) &&
-      canMutateWorktree(lineage.parentWorktreeId) &&
-      !liveIds.has(lineage.parentWorktreeId)
-    ) {
+    if (lineage.parentWorktreeId.startsWith(repoPrefix) && !liveIds.has(lineage.parentWorktreeId)) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
         // Why: keep child lineage for the "Missing parent" UI, but rotate the absent parent's identity once so a path reuse can't inherit it.
@@ -887,17 +734,6 @@ function createSshWorktreeMetaIndex(entries: [string, WorktreeMeta][]): SshWorkt
   return index
 }
 
-// Why: scopes parseWorktreeId to one repo's keys. The entry list itself is still materialized for the whole
-// store, so this is cheaper per call than the unfiltered index, not free.
-function createSshWorktreeMetaIndexForRepo(
-  allMeta: Record<string, WorktreeMeta>,
-  repoId: string
-): SshWorktreeMetaIndex {
-  return createSshWorktreeMetaIndex(
-    Object.entries(allMeta).filter(([worktreeId]) => getRepoIdFromWorktreeId(worktreeId) === repoId)
-  )
-}
-
 function synthesizeSshGitWorktree(repo: Repo, path: string, meta: WorktreeMeta): GitWorktreeInfo {
   return {
     path,
@@ -919,15 +755,7 @@ function listDisconnectedSshWorktrees(
   metaIndex: SshWorktreeMetaIndex
 ): ReturnType<typeof mergeWorktree>[] {
   const byWorktreeId = new Map<string, ReturnType<typeof mergeWorktree>>()
-  const expectedHostId = getRepoExecutionHostId(repo)
-  const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
   for (const candidate of metaIndex.get(repo.id) ?? []) {
-    if (
-      (candidate.meta.hostId && candidate.meta.hostId !== expectedHostId) ||
-      (!candidate.meta.hostId && repoOwners.length > 1)
-    ) {
-      continue
-    }
     const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, candidate.meta)
     const meta =
       Object.keys(ownershipUpdates).length > 0
@@ -936,15 +764,10 @@ function listDisconnectedSshWorktrees(
     if (Object.keys(ownershipUpdates).length > 0) {
       store.setWorktreeMeta(candidate.id, ownershipUpdates)
     }
-    // Why: synthesized rows carry no branch, so the title would fall through to the DESKTOP's basename()
-    // applied to a REMOTE path — a Windows remote then renders its whole C:\... path as the name. Rows must
-    // stay per-directory (repo.displayName would title every row identically), so use the separator-agnostic
-    // basename instead.
     const worktree = mergeWorktree(
       repo.id,
       synthesizeSshGitWorktree(repo, candidate.path, meta),
-      meta,
-      getWorktreePathBasenameFromId(candidate.id) ?? undefined
+      meta
     )
     byWorktreeId.delete(worktree.id)
     byWorktreeId.set(worktree.id, worktree)
@@ -1056,8 +879,6 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
     linkedBitbucketPR: meta.linkedBitbucketPR ?? null,
     linkedAzureDevOpsPR: meta.linkedAzureDevOpsPR ?? null,
     linkedGiteaPR: meta.linkedGiteaPR ?? null,
-    linkedWorkItem: meta.linkedWorkItem ?? null,
-    linkedTaskSourceContext: meta.linkedTaskSourceContext ?? null,
     isArchived: meta.isArchived ?? false,
     isUnread: meta.isUnread ?? false,
     isPinned: meta.isPinned ?? false,
@@ -1179,11 +1000,7 @@ function createFolderWorkspace(
     ...(args.linkedAzureDevOpsPR !== undefined
       ? { linkedAzureDevOpsPR: args.linkedAzureDevOpsPR }
       : {}),
-    ...(args.linkedGiteaPR !== undefined ? { linkedGiteaPR: args.linkedGiteaPR } : {}),
-    ...(args.linkedWorkItem !== undefined ? { linkedWorkItem: args.linkedWorkItem } : {}),
-    ...(args.linkedTaskSourceContext !== undefined
-      ? { linkedTaskSourceContext: args.linkedTaskSourceContext }
-      : {})
+    ...(args.linkedGiteaPR !== undefined ? { linkedGiteaPR: args.linkedGiteaPR } : {})
   })
   return { worktree: mergeFolderWorkspace(repo, worktreeId, meta) }
 }
@@ -1214,719 +1031,15 @@ function buildDisconnectedDetectedWorktrees(
   return projectResolvedWorktreeLineage(detected, store.getAllWorktreeLineage?.() ?? {})
 }
 
-function hasConflictingStoredWorktreeOwner(
-  store: Store,
-  repo: Repo,
-  worktreeIds: readonly string[]
-): boolean {
-  const expectedHostId = getRepoExecutionHostId(repo)
-  const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
-  return worktreeIds.some((worktreeId) => {
-    const meta = store.getWorktreeMeta(worktreeId)
-    return !!meta && (meta.hostId ? meta.hostId !== expectedHostId : repoOwnerCount > 1)
-  })
-}
-
-type RepoOwnershipEvidence =
-  | { status: 'owned'; hostId: ExecutionHostId }
-  | { status: 'malformed' }
-  | { status: 'contradictory' }
-
-function resolveRepoOwnershipEvidence(repo: Repo): RepoOwnershipEvidence {
-  const hasExplicitHost = repo.executionHostId !== null && repo.executionHostId !== undefined
-  const explicitHost = hasExplicitHost ? parseExecutionHostId(repo.executionHostId) : null
-  if (hasExplicitHost && !explicitHost) {
-    return { status: 'malformed' }
-  }
-  const hasConnection = repo.connectionId !== null && repo.connectionId !== undefined
-  const connectionId = hasConnection ? repo.connectionId?.trim() : null
-  if (hasConnection && !connectionId) {
-    return { status: 'malformed' }
-  }
-  const connectionHostId = connectionId ? toSshExecutionHostId(connectionId) : null
-  if (explicitHost && connectionHostId && explicitHost.id !== connectionHostId) {
-    return { status: 'contradictory' }
-  }
-  return {
-    status: 'owned',
-    hostId: explicitHost?.id ?? connectionHostId ?? LOCAL_EXECUTION_HOST_ID
-  }
-}
-
-function findExactRepoOwner(
-  store: Store,
-  repoId: string,
-  executionHostId?: ExecutionHostId
-): Repo | undefined {
-  const candidates = store.getRepos().filter((repo) => repo.id === repoId)
-  const evidence = candidates.map(resolveRepoOwnershipEvidence)
-  if (evidence.some((owner) => owner.status !== 'owned')) {
-    return undefined
-  }
-  const matches = candidates.filter((_, index) => {
-    const owner = evidence[index]
-    return (
-      owner?.status === 'owned' &&
-      (executionHostId === undefined || owner.hostId === executionHostId)
-    )
-  })
-  return matches.length === 1 ? matches[0] : undefined
-}
-
-function isCapturedRepoCurrent(
-  store: Store,
-  repo: Repo,
-  executionHostId?: ExecutionHostId
-): boolean {
-  const current = findExactRepoOwner(store, repo.id, executionHostId)
-  return (
-    current !== undefined &&
-    current.path === repo.path &&
-    (current.connectionId ?? null) === (repo.connectionId ?? null) &&
-    (current.executionHostId ?? null) === (repo.executionHostId ?? null)
-  )
-}
-
-async function listDetectedWorktreesForCapturedRepo(
-  store: Store,
-  repo: Repo,
-  isCurrent: () => boolean,
-  capturedProvider = repo.connectionId ? getSshGitProvider(repo.connectionId) : undefined,
-  providerAbort?: { signal: AbortSignal; status: () => 'canceled' | 'timed-out' }
-): Promise<DetectedWorktreeListResult | { providerAbortStatus: 'canceled' | 'timed-out' } | null> {
-  const abortedResult = () =>
-    providerAbort?.signal.aborted
-      ? ({ providerAbortStatus: providerAbort.status() } as const)
-      : undefined
-  const sshWorktreeMetaIndex = repo.connectionId
-    ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
-    : new Map()
-
-  try {
-    let gitWorktrees: GitWorktreeInfo[]
-    let freshScan = true
-    if (isFolderRepo(repo)) {
-      if (!isCurrent()) {
-        return null
-      }
-      const folderWorkspaceIds = Object.keys(store.getAllWorktreeMeta()).filter((worktreeId) =>
-        isFolderWorkspaceIdForRepo(repo, worktreeId)
-      )
-      if (hasConflictingStoredWorktreeOwner(store, repo, folderWorkspaceIds)) {
-        return {
-          repoId: repo.id,
-          authoritative: false,
-          source: 'metadata-fallback',
-          worktrees: []
-        }
-      }
-      return {
-        repoId: repo.id,
-        authoritative: true,
-        source: 'git',
-        worktrees: projectResolvedWorktreeLineage(
-          buildFolderDetectedWorktrees(store, repo),
-          store.getAllWorktreeLineage?.() ?? {}
-        )
-      }
-    }
-    if (repo.connectionId) {
-      if (!capturedProvider) {
-        const aborted = abortedResult()
-        if (aborted) {
-          return aborted
-        }
-        if (!isCurrent()) {
-          return null
-        }
-        const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
-        return {
-          repoId: repo.id,
-          authoritative: false,
-          source: 'metadata-fallback',
-          worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
-        }
-      }
-      gitWorktrees = await capturedProvider.listWorktrees(repo.path, {
-        signal: providerAbort?.signal
-      })
-    } else {
-      const scan = await listDetectedGitWorktrees(store, repo)
-      gitWorktrees = scan.gitWorktrees
-      freshScan = scan.fresh
-    }
-    const aborted = abortedResult()
-    if (aborted) {
-      return aborted
-    }
-    if (!isCurrent()) {
-      return null
-    }
-    const listedWorktreeIds = gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`)
-    if (hasConflictingStoredWorktreeOwner(store, repo, listedWorktreeIds)) {
-      return {
-        repoId: repo.id,
-        authoritative: false,
-        source: 'metadata-fallback',
-        worktrees: []
-      }
-    }
-    if (freshScan) {
-      rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
-    }
-    loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-    return {
-      repoId: repo.id,
-      authoritative: true,
-      source: 'git',
-      worktrees: buildDetectedGitWorktrees(store, repo, gitWorktrees)
-    }
-  } catch (err) {
-    const aborted = abortedResult()
-    if (aborted) {
-      return aborted
-    }
-    if (!isCurrent()) {
-      return null
-    }
-    warnOnce(
-      loggedWorktreeListFailures,
-      `${repo.id}:${repo.path}`,
-      `[worktrees] failed to list detected worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
-      err
-    )
-    if (repo.connectionId) {
-      const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
-      return {
-        repoId: repo.id,
-        authoritative: false,
-        source: 'metadata-fallback',
-        worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
-      }
-    }
-    return { repoId: repo.id, authoritative: false, source: 'metadata-fallback', worktrees: [] }
-  }
-}
-
-function hasValidDirectSshAuthority(
-  args: DirectSshDetectedWorktreeRequest
-): args is DirectSshDetectedWorktreeRequest {
-  return isAdmissibleDirectSshAuthority(args.expectedAuthority)
-}
-
-function hasValidLineageSshAuthority(
-  args: ListDesktopLineageForHostArgs
-): args is Extract<ListDesktopLineageForHostArgs, { expectedAuthority: unknown }> {
-  if (!('expectedAuthority' in args)) {
-    return false
-  }
-  return isAdmissibleDirectSshAuthority(args.expectedAuthority)
-}
-
-type LineageOwner =
-  | { status: 'owned'; hostId: ExecutionHostId }
-  | { status: 'ambiguous' | 'contradictory' | 'runtime' }
-
-type LineageFolder = ReturnType<Store['getFolderWorkspaces']>[number]
-type LineageGroup = ReturnType<Store['getProjectGroups']>[number]
-
-type LineageResolutionContext = {
-  store: Store
-  repos: Repo[]
-  groups: LineageGroup[]
-  reposById: Map<string, Repo[]>
-  foldersById: Map<string, LineageFolder[]>
-  groupsById: Map<string, LineageGroup[]>
-  groupSubtreeIdsByRoot: Map<string, Set<string>>
-  worktreeOwners: Map<string, LineageOwner>
-  folderOwners: Map<string, LineageOwner>
-  workspaceOwners: Map<string, LineageOwner>
-}
-
-function indexLineageEntriesById<T extends { id: string }>(
-  entries: readonly T[]
-): Map<string, T[]> {
-  const index = new Map<string, T[]>()
-  for (const entry of entries) {
-    const matching = index.get(entry.id) ?? []
-    matching.push(entry)
-    index.set(entry.id, matching)
-  }
-  return index
-}
-
-function createLineageResolutionContext(store: Store): LineageResolutionContext {
-  const repos = store.getRepos()
-  const folders = store.getFolderWorkspaces()
-  const groups = store.getProjectGroups()
-  return {
-    store,
-    repos,
-    groups,
-    reposById: indexLineageEntriesById(repos),
-    foldersById: indexLineageEntriesById(folders),
-    groupsById: indexLineageEntriesById(groups),
-    groupSubtreeIdsByRoot: new Map(),
-    worktreeOwners: new Map(),
-    folderOwners: new Map(),
-    workspaceOwners: new Map()
-  }
-}
-
-function resolveRepoLineageOwner(repo: Repo): LineageOwner {
-  const owner = resolveRepoOwnershipEvidence(repo)
-  if (owner.status === 'malformed') {
-    return { status: 'ambiguous' }
-  }
-  if (owner.status === 'contradictory') {
-    return { status: 'contradictory' }
-  }
-  return parseExecutionHostId(owner.hostId)?.kind === 'runtime' ? { status: 'runtime' } : owner
-}
-
-function resolveWorktreeLineageOwner(
-  context: LineageResolutionContext,
-  worktreeId: string
-): LineageOwner {
-  const cached = context.worktreeOwners.get(worktreeId)
-  if (cached) {
-    return cached
-  }
-  const remember = (owner: LineageOwner): LineageOwner => {
-    context.worktreeOwners.set(worktreeId, owner)
-    return owner
-  }
-  let repoId: string
-  try {
-    repoId = parseWorktreeId(worktreeId).repoId
-  } catch {
-    return remember({ status: 'ambiguous' })
-  }
-  const repos = context.reposById.get(repoId) ?? []
-  const meta = context.store.getWorktreeMeta(worktreeId)
-  const runtimeOwnerEnvironmentId = (
-    meta as (WorktreeMeta & { runtimeOwnerEnvironmentId?: string }) | undefined
-  )?.runtimeOwnerEnvironmentId?.trim()
-  if (runtimeOwnerEnvironmentId) {
-    return remember({ status: 'runtime' })
-  }
-  if (meta?.hostId) {
-    const explicitHost = parseExecutionHostId(meta.hostId)
-    if (!explicitHost) {
-      return remember({ status: 'ambiguous' })
-    }
-    if (explicitHost.kind === 'runtime') {
-      return remember({ status: 'runtime' })
-    }
-    const matchingRepos = repos.filter((repo) => {
-      const owner = resolveRepoLineageOwner(repo)
-      return owner.status === 'owned' && owner.hostId === explicitHost.id
-    })
-    if (matchingRepos.length === 1) {
-      return remember({ status: 'owned', hostId: explicitHost.id })
-    }
-    return remember(
-      matchingRepos.length > 1
-        ? { status: 'ambiguous' }
-        : { status: repos.length > 0 ? 'contradictory' : 'ambiguous' }
-    )
-  }
-  if (repos.length !== 1) {
-    return remember({ status: 'ambiguous' })
-  }
-  return remember(resolveRepoLineageOwner(repos[0]))
-}
-
-function getFolderLineageCandidateRepos(
-  context: LineageResolutionContext,
-  folder: LineageFolder
-): Repo[] {
-  let groupIds = context.groupSubtreeIdsByRoot.get(folder.projectGroupId)
-  if (!groupIds) {
-    groupIds = getProjectGroupSubtreeIds(context.groups, folder.projectGroupId)
-    context.groupSubtreeIdsByRoot.set(folder.projectGroupId, groupIds)
-  }
-  const grouped = context.repos.filter(
-    (repo) => typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)
-  )
-  const pathRepos = context.repos.filter(
-    (repo) =>
-      !(typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) &&
-      isPathInsideOrEqual(folder.folderPath, repo.path)
-  )
-  const group = context.groupsById.get(folder.projectGroupId)?.[0]
-  const connectionId = folder.connectionId ?? group?.connectionId ?? null
-  return connectionId
-    ? [...grouped, ...pathRepos.filter((repo) => (repo.connectionId ?? null) === connectionId)]
-    : grouped.length > 0
-      ? [
-          ...grouped,
-          ...pathRepos.filter((repo) =>
-            new Set(grouped.map((candidate) => candidate.connectionId ?? null)).has(
-              repo.connectionId ?? null
-            )
-          )
-        ]
-      : pathRepos
-}
-
-function resolveFolderLineageOwner(
-  context: LineageResolutionContext,
-  folderWorkspaceId: string
-): LineageOwner {
-  const cached = context.folderOwners.get(folderWorkspaceId)
-  if (cached) {
-    return cached
-  }
-  const remember = (owner: LineageOwner): LineageOwner => {
-    context.folderOwners.set(folderWorkspaceId, owner)
-    return owner
-  }
-  const folders = context.foldersById.get(folderWorkspaceId) ?? []
-  if (folders.length !== 1) {
-    return remember({ status: 'ambiguous' })
-  }
-  const folder = folders[0]
-  const groups = context.groupsById.get(folder.projectGroupId) ?? []
-  if (groups.length !== 1) {
-    return remember({ status: 'ambiguous' })
-  }
-  const group = groups[0]
-  const hosts = new Set<ExecutionHostId>()
-  if (folder.connectionId) {
-    hosts.add(`ssh:${encodeURIComponent(folder.connectionId)}`)
-  }
-  if (group.connectionId) {
-    hosts.add(`ssh:${encodeURIComponent(group.connectionId)}`)
-  }
-  if (group.executionHostId) {
-    const parsed = parseExecutionHostId(group.executionHostId)
-    if (!parsed) {
-      return remember({ status: 'ambiguous' })
-    }
-    hosts.add(parsed.id)
-  }
-  for (const repo of getFolderLineageCandidateRepos(context, folder)) {
-    const owner = resolveRepoLineageOwner(repo)
-    if (owner.status !== 'owned') {
-      return remember(owner)
-    }
-    hosts.add(owner.hostId)
-  }
-  if (hosts.size > 1) {
-    return remember({ status: 'contradictory' })
-  }
-  const hostId = [...hosts][0] ?? LOCAL_EXECUTION_HOST_ID
-  return remember(
-    parseExecutionHostId(hostId)?.kind === 'runtime'
-      ? { status: 'runtime' }
-      : { status: 'owned', hostId }
-  )
-}
-
-function resolveWorkspaceLineageOwner(
-  context: LineageResolutionContext,
-  workspaceKey: string
-): LineageOwner {
-  const cached = context.workspaceOwners.get(workspaceKey)
-  if (cached) {
-    return cached
-  }
-  const workspace = parseWorkspaceKey(workspaceKey)
-  const owner = !workspace
-    ? { status: 'ambiguous' as const }
-    : workspace.type === 'worktree'
-      ? resolveWorktreeLineageOwner(context, workspace.worktreeId)
-      : resolveFolderLineageOwner(context, workspace.folderWorkspaceId)
-  context.workspaceOwners.set(workspaceKey, owner)
-  return owner
-}
-
-function filterLineageForHost(
-  store: Store,
-  executionHostId: ExecutionHostId
-): {
-  worktreeLineageById: Record<string, WorktreeLineage>
-  workspaceLineageByChildKey: Record<string, WorkspaceLineage>
-} | null {
-  const context = createLineageResolutionContext(store)
-  const worktreeLineageById: Record<string, WorktreeLineage> = {}
-  const workspaceLineageByChildKey: Record<string, WorkspaceLineage> = {}
-  for (const [worktreeId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-    const child = resolveWorktreeLineageOwner(context, worktreeId)
-    const parent = resolveWorktreeLineageOwner(context, lineage.parentWorktreeId)
-    if (child.status === 'ambiguous' || child.status === 'contradictory') {
-      return null
-    }
-    if (parent.status === 'ambiguous' || parent.status === 'contradictory') {
-      return null
-    }
-    if (
-      child.status === 'owned' &&
-      parent.status === 'owned' &&
-      child.hostId === executionHostId &&
-      parent.hostId === executionHostId
-    ) {
-      worktreeLineageById[worktreeId] = structuredClone(lineage)
-    } else if (
-      child.status === 'owned' &&
-      parent.status === 'owned' &&
-      child.hostId !== parent.hostId
-    ) {
-      return null
-    }
-  }
-  for (const [childKey, lineage] of Object.entries(store.getAllWorkspaceLineage())) {
-    const child = resolveWorkspaceLineageOwner(context, childKey)
-    const parent = resolveWorkspaceLineageOwner(context, lineage.parentWorkspaceKey)
-    if (child.status === 'ambiguous' || child.status === 'contradictory') {
-      return null
-    }
-    if (parent.status === 'ambiguous' || parent.status === 'contradictory') {
-      return null
-    }
-    if (
-      child.status === 'owned' &&
-      parent.status === 'owned' &&
-      child.hostId === executionHostId &&
-      parent.hostId === executionHostId
-    ) {
-      workspaceLineageByChildKey[childKey] = structuredClone(lineage)
-    } else if (
-      child.status === 'owned' &&
-      parent.status === 'owned' &&
-      child.hostId !== parent.hostId
-    ) {
-      return null
-    }
-  }
-  return { worktreeLineageById, workspaceLineageByChildKey }
-}
-
-async function hydrateLineageWithinDeadline(runtime: OrcaRuntimeService): Promise<boolean> {
-  let timeout: ReturnType<typeof setTimeout> | undefined
-  const hydration = Promise.resolve()
-    .then(() => runtime.hydrateInferredWorktreeLineage())
-    .then(
-      () => true,
-      () => false
-    )
-  const deadline = new Promise<false>((resolve) => {
-    timeout = setTimeout(() => resolve(false), LINEAGE_HYDRATION_TIMEOUT_MS)
-  })
-  try {
-    return await Promise.race([hydration, deadline])
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout)
-    }
-  }
-}
-
-async function listDesktopLineageForHost(
-  store: Store,
-  runtime: OrcaRuntimeService,
-  args: ListDesktopLineageForHostArgs
-): Promise<HostLineageSnapshot> {
-  const parsedHost = parseExecutionHostId(args?.executionHostId)
-  const rejected = (
-    reason: Extract<HostLineageSnapshot, { authoritative: false }>['reason']
-  ): HostLineageSnapshot => ({
-    authoritative: false,
-    executionHostId: args.executionHostId,
-    reason
-  })
-  if (!parsedHost || parsedHost.kind === 'runtime') {
-    return rejected('rejected')
-  }
-  let provider: ReturnType<typeof getSshGitProvider> | undefined
-  let authority:
-    | Extract<ListDesktopLineageForHostArgs, { expectedAuthority: unknown }>['expectedAuthority']
-    | null = null
-  if (parsedHost.kind === 'local') {
-    if ('expectedAuthority' in args) {
-      return rejected('rejected')
-    }
-  } else {
-    if (
-      !hasValidLineageSshAuthority(args) ||
-      args.expectedAuthority.targetId !== parsedHost.targetId
-    ) {
-      return rejected('rejected')
-    }
-    authority = { ...args.expectedAuthority }
-    if (!isCurrentSshProviderAuthority(authority)) {
-      return rejected('stale')
-    }
-    provider = getSshGitProvider(parsedHost.targetId)
-    if (!provider) {
-      return rejected('unavailable')
-    }
-  }
-  if (!(await hydrateLineageWithinDeadline(runtime))) {
-    return rejected('unavailable')
-  }
-  if (
-    parsedHost.kind === 'ssh' &&
-    (!authority ||
-      getSshGitProvider(parsedHost.targetId) !== provider ||
-      !isCurrentSshProviderAuthority(authority))
-  ) {
-    return rejected('stale')
-  }
-  const lineage = filterLineageForHost(store, parsedHost.id)
-  if (!lineage) {
-    return rejected('ambiguous-owner')
-  }
-  if (parsedHost.kind === 'local') {
-    return {
-      authoritative: true,
-      authority: { kind: 'local', executionHostId: LOCAL_EXECUTION_HOST_ID },
-      ...lineage
-    }
-  }
-  if (!authority) {
-    return rejected('authority-unknown')
-  }
-  return {
-    authoritative: true,
-    authority: {
-      kind: 'direct-ssh',
-      executionHostId: parsedHost.id,
-      ...authority
-    },
-    ...lineage
-  }
-}
-
-async function listHostQualifiedDetectedWorktrees(
-  store: Store,
-  args: ListDetectedWorktreesArgs,
-  providerAbort?: { signal: AbortSignal; status: () => 'canceled' | 'timed-out' }
-): Promise<HostQualifiedDetectedWorktreeResult> {
-  const parsedHost = parseExecutionHostId(args.executionHostId)
-  const rejected = (status: 'rejected' | 'stale' | 'ambiguous-owner') => ({
-    providerRequestId: args.providerRequestId,
-    executionHostId: args.executionHostId,
-    status
-  })
-  if (
-    typeof args.providerRequestId !== 'string' ||
-    args.providerRequestId.length === 0 ||
-    Buffer.byteLength(args.providerRequestId, 'utf8') > PROVIDER_REQUEST_ID_MAX_UTF8_BYTES ||
-    !parsedHost ||
-    parsedHost.kind === 'runtime'
-  ) {
-    return rejected('rejected')
-  }
-  let capturedAuthority: DirectSshDetectedWorktreeRequest['expectedAuthority'] | null = null
-  if (parsedHost.kind === 'ssh') {
-    const directArgs = args as DirectSshDetectedWorktreeRequest
-    if (
-      !hasValidDirectSshAuthority(directArgs) ||
-      directArgs.expectedAuthority.targetId !== parsedHost.targetId
-    ) {
-      return rejected('rejected')
-    }
-    capturedAuthority = { ...directArgs.expectedAuthority }
-    if (!isCurrentSshProviderAuthority(capturedAuthority)) {
-      return rejected('stale')
-    }
-  }
-
-  const repoCandidates = store.getRepos().filter((candidate) => candidate.id === args.repoId)
-  if (
-    repoCandidates.some((candidate) => resolveRepoOwnershipEvidence(candidate).status !== 'owned')
-  ) {
-    return rejected('rejected')
-  }
-  const repo = findExactRepoOwner(store, args.repoId, args.executionHostId)
-  if (!repo) {
-    return rejected('ambiguous-owner')
-  }
-  if (
-    (parsedHost.kind === 'local' && repo.connectionId) ||
-    (parsedHost.kind === 'ssh' && repo.connectionId !== parsedHost.targetId)
-  ) {
-    return rejected('rejected')
-  }
-  const provider = parsedHost.kind === 'ssh' ? getSshGitProvider(parsedHost.targetId) : undefined
-  const isCurrent = (): boolean => {
-    if (!isCapturedRepoCurrent(store, repo, args.executionHostId)) {
-      return false
-    }
-    if (
-      (parsedHost.kind === 'local' && repo.connectionId) ||
-      (parsedHost.kind === 'ssh' && repo.connectionId !== parsedHost.targetId)
-    ) {
-      return false
-    }
-    if (parsedHost.kind !== 'ssh') {
-      return true
-    }
-    return (
-      capturedAuthority !== null &&
-      getSshGitProvider(parsedHost.targetId) === provider &&
-      isCurrentSshProviderAuthority(capturedAuthority)
-    )
-  }
-  const result = await listDetectedWorktreesForCapturedRepo(
-    store,
-    repo,
-    isCurrent,
-    provider,
-    providerAbort
-  )
-  if (!result) {
-    return rejected('stale')
-  }
-  if ('providerAbortStatus' in result) {
-    return {
-      providerRequestId: args.providerRequestId,
-      executionHostId: args.executionHostId,
-      status: result.providerAbortStatus
-    }
-  }
-  const status = result.authoritative ? 'complete' : 'non-authoritative'
-  if (parsedHost.kind === 'local') {
-    return {
-      status,
-      providerRequestId: args.providerRequestId,
-      repoId: repo.id,
-      authority: { kind: 'local', executionHostId: LOCAL_EXECUTION_HOST_ID },
-      result
-    }
-  }
-  if (!capturedAuthority) {
-    return rejected('rejected')
-  }
-  return {
-    status,
-    providerRequestId: args.providerRequestId,
-    repoId: repo.id,
-    authority: {
-      kind: 'direct-ssh',
-      executionHostId: args.executionHostId as `ssh:${string}`,
-      ...capturedAuthority
-    },
-    result
-  }
-}
-
 export function registerWorktreeHandlers(
   mainWindow: BrowserWindow,
   store: Store,
-  runtime: OrcaRuntimeService,
-  options?: { onWorktreeLifecycle?: (event: RuntimeWorktreeLifecycleEvent) => void }
+  runtime: OrcaRuntimeService
 ): void {
-  const detectedWorktreeCancellations = createSenderScopedRequestCancellations()
   // Remove previously registered handlers so re-register works when macOS re-activates and creates a new window.
   ipcMain.removeHandler('worktrees:listAll')
   ipcMain.removeHandler('worktrees:list')
   ipcMain.removeHandler('worktrees:listDetected')
-  ipcMain.removeHandler('worktrees:listKnownForExecutionHost')
-  ipcMain.removeHandler('worktrees:cancelListDetected')
   ipcMain.removeHandler('worktrees:create')
   ipcMain.removeHandler('worktrees:prefetchCreateBase')
   ipcMain.removeHandler('worktrees:resolvePrBase')
@@ -1936,7 +1049,6 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:forceDeletePreservedBranch')
   ipcMain.removeHandler('worktrees:updateMeta')
   ipcMain.removeHandler('worktrees:listLineage')
-  ipcMain.removeHandler('worktrees:listLineageForHost')
   ipcMain.removeHandler('worktrees:updateLineage')
   ipcMain.removeHandler('worktrees:persistSortOrder')
   ipcMain.removeHandler('worktrees:getBranchRenameFailureOutput')
@@ -2071,130 +1183,9 @@ export function registerWorktreeHandlers(
   })
 
   ipcMain.handle(
-    'worktrees:listKnownForExecutionHost',
-    (_event, args: ListKnownWorktreesForExecutionHostArgs): HostQualifiedKnownWorktreeResult => {
-      // Why: a malformed invoke must fail closed as `rejected`, not throw out of the handler. `ssh:` is inert —
-      // it owns no repo, so every guard below still rejects it.
-      const requestedRepoId = args?.repoId ?? ''
-      const requestedExecutionHostId = args?.executionHostId ?? 'ssh:'
-      const rejected = (): HostQualifiedKnownWorktreeResult => ({
-        status: 'rejected',
-        repoId: requestedRepoId,
-        executionHostId: requestedExecutionHostId
-      })
-      const parsedHost = parseExecutionHostId(requestedExecutionHostId)
-      if (parsedHost?.kind !== 'ssh') {
-        return rejected()
-      }
-      // Why: findExactRepoOwner repeats this same all-candidates-owned check, and getRepos() re-hydrates the
-      // whole catalog, so a separate pass here is pure cost.
-      const repo = findExactRepoOwner(store, requestedRepoId, requestedExecutionHostId)
-      if (!repo || repo.connectionId !== parsedHost.targetId) {
-        return rejected()
-      }
-      const complete = (worktrees: DetectedWorktree[]): HostQualifiedKnownWorktreeResult => ({
-        status: 'complete',
-        repoId: repo.id,
-        executionHostId: requestedExecutionHostId,
-        result: {
-          repoId: repo.id,
-          authoritative: false,
-          source: 'metadata-fallback',
-          worktrees
-        }
-      })
-      // Why: folder workspace ids carry an instance suffix the git-worktree synthesizer would read as a directory; build them the way every other listing does.
-      if (isFolderRepo(repo)) {
-        const folderWorkspaceIds = Object.keys(store.getAllWorktreeMeta()).filter((worktreeId) =>
-          isFolderWorkspaceIdForRepo(repo, worktreeId)
-        )
-        return hasConflictingStoredWorktreeOwner(store, repo, folderWorkspaceIds)
-          ? rejected()
-          : complete(
-              // Why: match the authoritative folder listing; without lineage these rows render flat and then
-              // reshuffle once the real scan lands.
-              projectResolvedWorktreeLineage(
-                buildFolderDetectedWorktrees(store, repo),
-                store.getAllWorktreeLineage?.() ?? {}
-              )
-            )
-      }
-      const metaIndex = createSshWorktreeMetaIndexForRepo(store.getAllWorktreeMeta(), repo.id)
-      return complete(
-        buildDisconnectedDetectedWorktrees(
-          store,
-          repo,
-          listDisconnectedSshWorktrees(store, repo, metaIndex)
-        )
-      )
-    }
-  )
-
-  ipcMain.handle(
     'worktrees:listDetected',
-    async (
-      event,
-      args: DetectedWorktreeRequestArgs
-    ): Promise<DetectedWorktreeListResult | HostQualifiedDetectedWorktreeResult> => {
-      if ('executionHostId' in args) {
-        const parsedHost = parseExecutionHostId(args.executionHostId)
-        const directSshRequest = parsedHost?.kind === 'ssh'
-        const controller = directSshRequest
-          ? detectedWorktreeCancellations.begin(event, args.providerRequestId)
-          : null
-        const directArgs = args as DirectSshDetectedWorktreeRequest
-        const removeAuthorityAbort =
-          controller &&
-          parsedHost?.kind === 'ssh' &&
-          hasValidDirectSshAuthority(directArgs) &&
-          directArgs.expectedAuthority.targetId === parsedHost.targetId
-            ? registerSshProviderRequestAbort(directArgs.expectedAuthority, controller)
-            : undefined
-        let timedOut = false
-        let removeAbortListener: (() => void) | undefined
-        const abortedResult = controller
-          ? new Promise<HostQualifiedDetectedWorktreeResult>((resolve) => {
-              const onAbort = (): void => {
-                resolve({
-                  providerRequestId: args.providerRequestId,
-                  executionHostId: args.executionHostId,
-                  status: timedOut ? 'timed-out' : 'canceled'
-                })
-              }
-              controller.signal.addEventListener('abort', onAbort, { once: true })
-              removeAbortListener = () => controller.signal.removeEventListener('abort', onAbort)
-            })
-          : undefined
-        const timeout = controller
-          ? setTimeout(() => {
-              timedOut = true
-              controller.abort()
-            }, DETECTED_WORKTREE_PROVIDER_TIMEOUT_MS)
-          : undefined
-        try {
-          const providerResult = listHostQualifiedDetectedWorktrees(
-            store,
-            args,
-            controller
-              ? {
-                  signal: controller.signal,
-                  status: () => (timedOut ? 'timed-out' : 'canceled')
-                }
-              : undefined
-          )
-          return abortedResult
-            ? await Promise.race([providerResult, abortedResult])
-            : await providerResult
-        } finally {
-          if (timeout) {
-            clearTimeout(timeout)
-          }
-          removeAbortListener?.()
-          removeAuthorityAbort?.()
-          detectedWorktreeCancellations.finish(event, args.providerRequestId, controller)
-        }
-      }
-      const repo = findExactRepoOwner(store, args.repoId)
+    async (_event, args: { repoId: string }): Promise<DetectedWorktreeListResult> => {
+      const repo = store.getRepo(args.repoId)
       if (!repo) {
         return {
           repoId: args.repoId,
@@ -2203,35 +1194,69 @@ export function registerWorktreeHandlers(
           worktrees: []
         }
       }
-      const provider = repo.connectionId ? getSshGitProvider(repo.connectionId) : undefined
-      const authority = repo.connectionId
-        ? { ...getSshProviderAuthority(repo.connectionId) }
-        : undefined
-      const result = await listDetectedWorktreesForCapturedRepo(
-        store,
-        repo,
-        () =>
-          isCapturedRepoCurrent(store, repo) &&
-          (!repo.connectionId ||
-            (getSshGitProvider(repo.connectionId) === provider &&
-              authority !== undefined &&
-              isCurrentSshProviderAuthority(authority))),
-        provider
-      )
-      return result && !('providerAbortStatus' in result)
-        ? result
-        : {
+      const sshWorktreeMetaIndex = repo.connectionId
+        ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
+        : new Map()
+
+      try {
+        let gitWorktrees: GitWorktreeInfo[]
+        let freshScan = true
+        if (isFolderRepo(repo)) {
+          return {
+            repoId: repo.id,
+            authoritative: true,
+            source: 'git',
+            worktrees: projectResolvedWorktreeLineage(
+              buildFolderDetectedWorktrees(store, repo),
+              store.getAllWorktreeLineage?.() ?? {}
+            )
+          }
+        } else if (repo.connectionId) {
+          const provider = getSshGitProvider(repo.connectionId)
+          if (!provider) {
+            const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+            return {
+              repoId: repo.id,
+              authoritative: false,
+              source: 'metadata-fallback',
+              worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
+            }
+          }
+          gitWorktrees = await provider.listWorktrees(repo.path)
+        } else {
+          const scan = await listDetectedGitWorktrees(store, repo)
+          gitWorktrees = scan.gitWorktrees
+          freshScan = scan.fresh
+        }
+        if (freshScan) {
+          rememberLocalWorktreeRoots(store, repo, gitWorktrees)
+          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        }
+        loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
+        return {
+          repoId: repo.id,
+          authoritative: true,
+          source: 'git',
+          worktrees: buildDetectedGitWorktrees(store, repo, gitWorktrees)
+        }
+      } catch (err) {
+        warnOnce(
+          loggedWorktreeListFailures,
+          `${repo.id}:${repo.path}`,
+          `[worktrees] failed to list detected worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
+          err
+        )
+        if (repo.connectionId) {
+          const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+          return {
             repoId: repo.id,
             authoritative: false,
             source: 'metadata-fallback',
-            worktrees: []
+            worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
           }
-    }
-  )
-  ipcMain.handle(
-    'worktrees:cancelListDetected',
-    (event, args: { providerRequestId: ProviderRequestId }): void => {
-      detectedWorktreeCancellations.cancel(event, args.providerRequestId)
+        }
+        return { repoId: repo.id, authoritative: false, source: 'metadata-fallback', worktrees: [] }
+      }
     }
   )
 
@@ -2252,8 +1277,7 @@ export function registerWorktreeHandlers(
 
   ipcMain.handle(
     'worktrees:create',
-    async (_event, rawArgs: CreateWorktreeArgs): Promise<CreateWorktreeResult> => {
-      const args = normalizeLinkedWorkItemFields(rawArgs)
+    async (_event, args: CreateWorktreeArgs): Promise<CreateWorktreeResult> => {
       // Why span here: parent the child git spans for the trace tree; don't attach branch name/remote URL (user content) — repo ID is the safer correlator.
       return withWorktreeSpan({ stage: 'create' }, async () => {
         const repo = store.getRepo(args.repoId)
@@ -2307,13 +1331,6 @@ export function registerWorktreeHandlers(
         if (isFolderRepo(repo)) {
           notifyWorktreesChanged(mainWindow, repo.id)
         }
-
-        options?.onWorktreeLifecycle?.({
-          kind: 'created',
-          worktreeId: result.worktree.id,
-          path: result.worktree.path,
-          branch: result.worktree.branch
-        })
 
         return result
       })
@@ -2431,9 +1448,10 @@ export function registerWorktreeHandlers(
       if (!repo) {
         throw new Error(`Repo not found: ${repoId}`)
       }
-      // The resolved repo supplies host ownership when legacy callers omit args.hostId.
-      const removalHostId = getRepoExecutionHostId(repo)
-      const inFlightKey = getWorktreeRemovalInFlightKey(args.worktreeId, removalHostId)
+      const inFlightKey = getWorktreeRemovalInFlightKey(
+        args.worktreeId,
+        getRepoExecutionHostId(repo)
+      )
       const optionsKey = getWorktreeRemovalOptionsKey(args)
       const inFlightRemoval = worktreeRemovalsInFlight.get(inFlightKey)
       if (inFlightRemoval) {
@@ -2445,312 +1463,125 @@ export function registerWorktreeHandlers(
 
       // Why: concurrent stale-toast/double-click/sidebar races can hit the same worktree; share the op so only one path touches Git and disk.
       const removal = (async (): Promise<RemoveWorktreeResult> => {
-        // Why: worktree.create is traced; delete freezes were invisible without a matching worktree.remove parent span.
-        return withWorktreeSpan({ stage: 'remove', path: worktreePath }, async () => {
-          if (isFolderRepo(repo)) {
-            if (args.worktreeId === getFolderWorkspaceRootId(repo)) {
-              throw new Error(
-                'Cannot delete the project root workspace. Remove the folder project instead.'
-              )
-            }
-            // Why: folder workspaces share one root, so there's no Git remove step to close shells; sweep PTYs before dropping metadata.
-            await withWorktreeRemoveStageSpan('pty_sweep', 'folder', async () => {
-              // Folder projects can be SSH-backed, so fence the sweep to the owning host exactly
-              // like the git paths — the local inventory must never reach a remote workspace's id.
-              // The resolved repo is authoritative here: path-derived metadata is shared by
-              // same-id host copies and can describe a different owner's workspace.
-              const ownerHost = parseExecutionHostId(removalHostId)
-              const sshPtyProvider =
-                ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
-              const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'
-              await killAllProcessesForWorktree(args.worktreeId, {
-                runtime,
-                resolvedWorktreeId: args.worktreeId,
-                ...(ownerHost?.kind === 'ssh' ? { resolvedConnectionId: ownerHost.targetId } : {}),
-                ...(ownerHost?.kind === 'runtime'
-                  ? { resolvedRuntimeEnvironmentId: ownerHost.environmentId }
-                  : {}),
-                localProvider: sshPtyProvider ?? getLocalPtyProvider(),
-                onPtyStopped: clearProviderPtyState,
-                ...(externalHost
-                  ? {
-                      includeProviderInventory:
-                        ownerHost?.kind === 'ssh' && Boolean(sshPtyProvider),
-                      includeLocalRegistry: false
-                    }
-                  : {})
-              }).catch((err) => {
-                console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
-              })
-            })
-            await withWorktreeRemoveStageSpan('metadata_purge', 'folder', async () => {
-              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-            })
-            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-            notifyWorktreesChanged(mainWindow, repoId)
-            return {}
+        if (isFolderRepo(repo)) {
+          if (args.worktreeId === getFolderWorkspaceRootId(repo)) {
+            throw new Error(
+              'Cannot delete the project root workspace. Remove the folder project instead.'
+            )
           }
+          // Why: folder workspaces share one root, so there's no Git remove step to close shells; sweep PTYs before dropping metadata.
+          await killAllProcessesForWorktree(args.worktreeId, {
+            runtime,
+            localProvider: getLocalPtyProvider(),
+            onPtyStopped: clearProviderPtyState
+          }).catch((err) => {
+            console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
+          })
+          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+          preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+          notifyWorktreesChanged(mainWindow, repoId)
+          return {}
+        }
 
-          // Why: renderer-supplied worktreeId embeds a path; re-derive the canonical path from git before any destructive action.
-          const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
-          const localWorktreeGitOptions = repo.connectionId
-            ? {}
-            : getLocalProjectWorktreeGitOptions(store, repo)
-          const hasLocalWorktreeGitOptions = Object.keys(localWorktreeGitOptions).length > 0
-          const registeredWorktrees = repo.connectionId
-            ? await provider!.listWorktrees(repo.path)
-            : hasLocalWorktreeGitOptions
-              ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
-              : await listGitWorktreesStrict(repo.path)
-          const removedMeta = store.getWorktreeMeta(args.worktreeId)
-          const removedPushTarget = removedMeta?.pushTarget
-          const registeredWorktree = findRegisteredDeletableWorktree(
-            repo.path,
-            worktreePath,
-            registeredWorktrees
-          )
-          if (!registeredWorktree) {
-            const fsProvider = repo.connectionId
-              ? getSshFilesystemProvider(repo.connectionId)
-              : null
-            let canCleanOrphanedDirectory = false
-            if (
-              canCleanupUnregisteredOrcaWorktreeDirectory({
-                meta: removedMeta
-              })
-            ) {
-              if (repo.connectionId) {
-                if (!fsProvider) {
-                  throw new Error('SSH filesystem provider unavailable')
-                }
-                if (!fsProvider.lstat) {
-                  throw new Error('SSH filesystem provider lstat unavailable')
-                }
-                canCleanOrphanedDirectory = await canSafelyRemoveOrphanedWorktreeDirectory(
-                  worktreePath,
-                  repo.path,
-                  (path) => fsProvider.lstat!(path),
-                  (path) => fsProvider.readFile(path)
-                )
-              } else {
-                const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
-                canCleanOrphanedDirectory =
-                  !isDangerousWorktreeRemovalPath(worktreePath, repo.path) &&
-                  (await canSafelyRemoveOrphanedWorktreeDirectory(
-                    toLocalWorktreeRuntimePath(worktreePath, localWorktreeGitOptions),
-                    toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-                    access.statPath,
-                    access.readPath
-                  ))
+        // Why: renderer-supplied worktreeId embeds a path; re-derive the canonical path from git before any destructive action.
+        const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
+        const localWorktreeGitOptions = repo.connectionId
+          ? {}
+          : getLocalProjectWorktreeGitOptions(store, repo)
+        const hasLocalWorktreeGitOptions = Object.keys(localWorktreeGitOptions).length > 0
+        const registeredWorktrees = repo.connectionId
+          ? await provider!.listWorktrees(repo.path)
+          : hasLocalWorktreeGitOptions
+            ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
+            : await listGitWorktreesStrict(repo.path)
+        const removedMeta = store.getWorktreeMeta(args.worktreeId)
+        const removedPushTarget = removedMeta?.pushTarget
+        const registeredWorktree = findRegisteredDeletableWorktree(
+          repo.path,
+          worktreePath,
+          registeredWorktrees
+        )
+        if (!registeredWorktree) {
+          const fsProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : null
+          let canCleanOrphanedDirectory = false
+          if (
+            canCleanupUnregisteredOrcaWorktreeDirectory({
+              meta: removedMeta
+            })
+          ) {
+            if (repo.connectionId) {
+              if (!fsProvider) {
+                throw new Error('SSH filesystem provider unavailable')
               }
+              if (!fsProvider.lstat) {
+                throw new Error('SSH filesystem provider lstat unavailable')
+              }
+              canCleanOrphanedDirectory = await canSafelyRemoveOrphanedWorktreeDirectory(
+                worktreePath,
+                repo.path,
+                (path) => fsProvider.lstat!(path),
+                (path) => fsProvider.readFile(path)
+              )
+            } else {
+              const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
+              canCleanOrphanedDirectory =
+                !isDangerousWorktreeRemovalPath(worktreePath, repo.path) &&
+                (await canSafelyRemoveOrphanedWorktreeDirectory(
+                  toLocalWorktreeRuntimePath(worktreePath, localWorktreeGitOptions),
+                  toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
+                  access.statPath,
+                  access.readPath
+                ))
             }
-            if (canCleanOrphanedDirectory) {
-              assertWorktreeDoesNotContainRegisteredWorktree(worktreePath, registeredWorktrees)
-              if (!args.force) {
-                throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
-              }
-              if (repo.connectionId) {
-                const removalGate = await runtime.acquireFileWatcherRemoval(
-                  worktreePath,
+          }
+          if (canCleanOrphanedDirectory) {
+            assertWorktreeDoesNotContainRegisteredWorktree(worktreePath, registeredWorktrees)
+            if (!args.force) {
+              throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
+            }
+            if (repo.connectionId) {
+              const removalGate = await runtime.acquireFileWatcherRemoval(
+                worktreePath,
+                repo.connectionId
+              )
+              let removalCompleted = false
+              try {
+                await stopPtysForDestructiveWorktreeRemoval(
+                  runtime,
+                  args.worktreeId,
                   repo.connectionId
                 )
-                let removalCompleted = false
-                try {
-                  await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
-                    connectionId: repo.connectionId,
-                    allowUnverifiedStop: args.allowUnverifiedPtyStop
-                  })
-                  await fsProvider!.deletePath(worktreePath, true)
-                  removalCompleted = true
-                } finally {
-                  await removalGate.finish(removalCompleted)
-                }
-                await cleanupUnusedWorktreePushTargetRemoteSsh(
-                  provider!,
-                  repo.path,
-                  args.worktreeId,
-                  removedPushTarget,
-                  store
-                )
-              } else {
-                const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
-                let removalCompleted = false
-                try {
-                  await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
-                    allowUnverifiedStop: args.allowUnverifiedPtyStop
-                  })
-                  await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
-                  removalCompleted = true
-                } finally {
-                  await removalGate.finish(removalCompleted)
-                }
-                await cleanupUnusedWorktreePushTargetRemote(
-                  repo.path,
-                  args.worktreeId,
-                  removedPushTarget,
-                  store,
-                  localWorktreeGitOptions
-                )
-                invalidateAuthorizedRootsCache()
+                await fsProvider!.deletePath(worktreePath, true)
+                removalCompleted = true
+              } finally {
+                await removalGate.finish(removalCompleted)
               }
-              runtime.clearOptimisticReconcileToken(args.worktreeId)
-              await maybePruneReviewHeadRefsAfterWorktreeDelete({
+              await cleanupUnusedWorktreePushTargetRemoteSsh(
+                provider!,
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
+                store
+              )
+            } else {
+              const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
+              let removalCompleted = false
+              try {
+                await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId)
+                await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
+                removalCompleted = true
+              } finally {
+                await removalGate.finish(removalCompleted)
+              }
+              await cleanupUnusedWorktreePushTargetRemote(
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
                 store,
-                repo,
-                repoId,
-                worktreeId: args.worktreeId,
-                meta: removedMeta,
-                localGitOptions: localWorktreeGitOptions,
-                sshGitProvider: null
-              })
-              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-              notifyWorktreesChanged(mainWindow, repoId)
-              return {}
-            }
-            if (!repo.connectionId) {
-              const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
-              const runtimeWorktreePath = toLocalWorktreeRuntimePath(
-                worktreePath,
                 localWorktreeGitOptions
               )
-              if (
-                await canCleanupUnregisteredOrcaLeftoverDirectory({
-                  meta: removedMeta,
-                  worktreePath,
-                  runtimeWorktreePath,
-                  repo,
-                  runtimeRepoPath: toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-                  registeredWorktrees,
-                  statPath: access.statPath,
-                  isGitRepository: (path) => isLocalGitRepository(path, localWorktreeGitOptions)
-                })
-              ) {
-                if (!args.force) {
-                  throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
-                }
-                const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
-                let removalCompleted = false
-                try {
-                  await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
-                    allowUnverifiedStop: args.allowUnverifiedPtyStop
-                  })
-                  await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
-                  removalCompleted = true
-                } finally {
-                  await removalGate.finish(removalCompleted)
-                }
-                await cleanupUnusedWorktreePushTargetRemote(
-                  repo.path,
-                  args.worktreeId,
-                  removedPushTarget,
-                  store,
-                  localWorktreeGitOptions
-                )
-                runtime.clearOptimisticReconcileToken(args.worktreeId)
-                await maybePruneReviewHeadRefsAfterWorktreeDelete({
-                  store,
-                  repo,
-                  repoId,
-                  worktreeId: args.worktreeId,
-                  meta: removedMeta,
-                  localGitOptions: localWorktreeGitOptions,
-                  sshGitProvider: null
-                })
-                removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-                preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-                invalidateAuthorizedRootsCache()
-                notifyWorktreesChanged(mainWindow, repoId)
-                return {}
-              }
+              invalidateAuthorizedRootsCache()
             }
-            if (await isAlreadyRemovedWorktreePath(repo, worktreePath, localWorktreeGitOptions)) {
-              if (!args.force && !removedMeta) {
-                // Why: without persisted metadata, require the renderer recovery path before deleting Orca-only state for an unregistered path.
-                throw new Error(UNREGISTERED_MISSING_WORKTREE_MESSAGE)
-              }
-              // Why: a manually deleted worktree is already gone; persisted metadata proves it was an Orca-known row, so no force is needed.
-              if (repo.connectionId) {
-                await cleanupUnusedWorktreePushTargetRemoteSsh(
-                  provider!,
-                  repo.path,
-                  args.worktreeId,
-                  removedPushTarget,
-                  store
-                )
-              } else {
-                await cleanupUnusedWorktreePushTargetRemote(
-                  repo.path,
-                  args.worktreeId,
-                  removedPushTarget,
-                  store,
-                  localWorktreeGitOptions
-                )
-                invalidateAuthorizedRootsCache()
-              }
-              runtime.clearOptimisticReconcileToken(args.worktreeId)
-              await maybePruneReviewHeadRefsAfterWorktreeDelete({
-                store,
-                repo,
-                repoId,
-                worktreeId: args.worktreeId,
-                meta: removedMeta,
-                localGitOptions: localWorktreeGitOptions,
-                sshGitProvider: null
-              })
-              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-              notifyWorktreesChanged(mainWindow, repoId)
-              return {}
-            }
-            throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
-          }
-          const canonicalWorktreePath = registeredWorktree.path
-          const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
-
-          // Why: a Git lock must block before archive hooks or linked-path cleanup mutate the workspace; dirty-file force is separate.
-          try {
-            assertWorktreeUnlockedForRemoval(registeredWorktree)
-          } catch (error) {
-            throw new Error(
-              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-            )
-          }
-
-          // Why: a prior forced Windows recovery can delete the dir but leave a stale Git registration; verify before clearing metadata.
-          if (
-            !repo.connectionId &&
-            args.force === true &&
-            process.platform === 'win32' &&
-            (isWindowsAbsolutePathLike(canonicalWorktreePath) ||
-              !!localWorktreeGitOptions.wslDistro) &&
-            removedMeta &&
-            (await isAlreadyRemovedWorktreePath(
-              repo,
-              canonicalWorktreePath,
-              localWorktreeGitOptions
-            ))
-          ) {
-            const removalResult = await removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval({
-              canonicalWorktreePath,
-              repoPath: repo.path,
-              localWorktreeGitOptions,
-              registeredWorktree,
-              deleteBranch
-            })
-            await cleanupUnusedWorktreePushTargetRemote(
-              repo.path,
-              args.worktreeId,
-              removedPushTarget,
-              store,
-              localWorktreeGitOptions
-            )
-            rememberPreservedBranchCleanupTarget(
-              args.worktreeId,
-              removalResult,
-              registeredWorktree.head,
-              removedPushTarget
-            )
             runtime.clearOptimisticReconcileToken(args.worktreeId)
             await maybePruneReviewHeadRefsAfterWorktreeDelete({
               store,
@@ -2759,277 +1590,137 @@ export function registerWorktreeHandlers(
               worktreeId: args.worktreeId,
               meta: removedMeta,
               localGitOptions: localWorktreeGitOptions,
-              sshGitProvider: null
+              sshGitProvider: provider
             })
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-            invalidateAuthorizedRootsCache()
+            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
             notifyWorktreesChanged(mainWindow, repoId)
-            return removalResult ?? {}
+            return {}
           }
-
-          // Run archive hook before removal so teardown scripts still see the worktree directory.
-          const hooks = await getArchiveHooksForRemoval(repo)
-          const archiveScript = hooks?.scripts.archive
-          if (archiveScript && !args.skipArchive) {
-            // Why the branch on connectionId: this block is shared by both flows, so a hardcoded
-            // 'remote' would file every local archive hook under the SSH breakdown.
-            await withWorktreeRemoveStageSpan(
-              'archive_hook',
-              repo.connectionId ? 'remote' : 'local',
-              async () => {
-                const result = repo.connectionId
-                  ? await runRemoteArchiveHook(repo, canonicalWorktreePath, archiveScript)
-                  : await runHook(
-                      'archive',
-                      canonicalWorktreePath,
-                      repo,
-                      undefined,
-                      localWorktreeGitOptions
-                    )
-                if (!result.success) {
-                  console.error(
-                    `[hooks] archive hook failed for ${canonicalWorktreePath}:`,
-                    result.output
-                  )
-                }
-              }
+          if (!repo.connectionId) {
+            const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
+            const runtimeWorktreePath = toLocalWorktreeRuntimePath(
+              worktreePath,
+              localWorktreeGitOptions
             )
-          }
-
-          const remoteConnectionId = repo.connectionId ?? undefined
-          if (remoteConnectionId) {
-            // Why: SSH deletion mirrors the local flow — hooks run while the directory is intact, then the clean check guards removal.
-            if (!args.force) {
-              const { clean, stdout } = await provider!.worktreeIsClean(canonicalWorktreePath)
-              if (!clean) {
-                const error = new Error('Worktree has uncommitted or untracked changes.')
-                ;(error as Error & { stdout?: string }).stdout = stdout
-                throw error
-              }
-            }
-
-            const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
-            const removalGate = await withWorktreeRemoveStageSpan(
-              'watcher_gate',
-              'remote',
-              async () =>
-                runtime.acquireFileWatcherRemoval(canonicalWorktreePath, remoteConnectionId)
-            )
-            let rawRemovalResult: RemoveWorktreeResult | undefined
-            let removalCompleted = false
-            try {
-              await withWorktreeRemoveStageSpan('pty_sweep', 'remote', async () => {
-                await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
-                  connectionId: remoteConnectionId,
-                  allowUnverifiedStop: args.allowUnverifiedPtyStop
-                })
+            if (
+              await canCleanupUnregisteredOrcaLeftoverDirectory({
+                meta: removedMeta,
+                worktreePath,
+                runtimeWorktreePath,
+                repo,
+                runtimeRepoPath: toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
+                registeredWorktrees,
+                statPath: access.statPath,
+                isGitRepository: (path) => isLocalGitRepository(path, localWorktreeGitOptions)
               })
-              rawRemovalResult = await withWorktreeRemoveStageSpan(
-                'git_remove',
-                'remote',
-                async () =>
-                  Object.keys(remoteRemoveOptions).length > 0
-                    ? provider!.removeWorktree(
-                        canonicalWorktreePath,
-                        args.force,
-                        remoteRemoveOptions
-                      )
-                    : provider!.removeWorktree(canonicalWorktreePath, args.force)
+            ) {
+              if (!args.force) {
+                throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
+              }
+              const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
+              let removalCompleted = false
+              try {
+                await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId)
+                await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
+                removalCompleted = true
+              } finally {
+                await removalGate.finish(removalCompleted)
+              }
+              await cleanupUnusedWorktreePushTargetRemote(
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
+                store,
+                localWorktreeGitOptions
               )
-              removalCompleted = true
-            } finally {
-              await removalGate.finish(removalCompleted)
+              runtime.clearOptimisticReconcileToken(args.worktreeId)
+              await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                store,
+                repo,
+                repoId,
+                worktreeId: args.worktreeId,
+                meta: removedMeta,
+                localGitOptions: localWorktreeGitOptions,
+                sshGitProvider: provider
+              })
+              removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+              invalidateAuthorizedRootsCache()
+              notifyWorktreesChanged(mainWindow, repoId)
+              return {}
             }
-            const removalResult = preserveBranchHeadFallback(
-              rawRemovalResult,
-              registeredWorktree.head
-            )
-            await cleanupUnusedWorktreePushTargetRemoteSsh(
-              provider!,
-              repo.path,
-              args.worktreeId,
-              removedPushTarget,
-              store
-            )
-            rememberPreservedBranchCleanupTarget(
-              args.worktreeId,
-              removalResult,
-              registeredWorktree.head,
-              removedPushTarget
-            )
+          }
+          if (await isAlreadyRemovedWorktreePath(repo, worktreePath, localWorktreeGitOptions)) {
+            if (!args.force && !removedMeta) {
+              // Why: without persisted metadata, require the renderer recovery path before deleting Orca-only state for an unregistered path.
+              throw new Error(UNREGISTERED_MISSING_WORKTREE_MESSAGE)
+            }
+            // Why: a manually deleted worktree is already gone; persisted metadata proves it was an Orca-known row, so no force is needed.
+            if (repo.connectionId) {
+              await cleanupUnusedWorktreePushTargetRemoteSsh(
+                provider!,
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
+                store
+              )
+            } else {
+              await cleanupUnusedWorktreePushTargetRemote(
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
+                store,
+                localWorktreeGitOptions
+              )
+              invalidateAuthorizedRootsCache()
+            }
             runtime.clearOptimisticReconcileToken(args.worktreeId)
-            await withWorktreeRemoveStageSpan('metadata_purge', 'remote', async () => {
-              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+            await maybePruneReviewHeadRefsAfterWorktreeDelete({
+              store,
+              repo,
+              repoId,
+              worktreeId: args.worktreeId,
+              meta: removedMeta,
+              localGitOptions: localWorktreeGitOptions,
+              sshGitProvider: provider
             })
+            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
             notifyWorktreesChanged(mainWindow, repoId)
-            return removalResult ?? {}
+            return {}
           }
+          throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
+        }
+        const canonicalWorktreePath = registeredWorktree.path
+        const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
 
-          const refreshedWorktrees = hasLocalWorktreeGitOptions
-            ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
-            : await listGitWorktreesStrict(repo.path)
-          const refreshedRegisteredWorktree = findRegisteredDeletableWorktree(
-            repo.path,
+        // Why: a Git lock must block before archive hooks or linked-path cleanup mutate the workspace; dirty-file force is separate.
+        try {
+          assertWorktreeUnlockedForRemoval(registeredWorktree)
+        } catch (error) {
+          throw new Error(
+            formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+          )
+        }
+
+        // Why: a prior forced Windows recovery can delete the dir but leave a stale Git registration; verify before clearing metadata.
+        if (
+          !repo.connectionId &&
+          args.force === true &&
+          process.platform === 'win32' &&
+          (isWindowsAbsolutePathLike(canonicalWorktreePath) ||
+            !!localWorktreeGitOptions.wslDistro) &&
+          removedMeta &&
+          (await isAlreadyRemovedWorktreePath(repo, canonicalWorktreePath, localWorktreeGitOptions))
+        ) {
+          const removalResult = await removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval({
             canonicalWorktreePath,
-            refreshedWorktrees
-          )
-          if (!refreshedRegisteredWorktree) {
-            throw new Error(
-              `Worktree registration changed during deletion: ${canonicalWorktreePath}. Retry deletion.`
-            )
-          }
-          try {
-            // Why: an archive hook can race another Git client that locks the row; recheck before linked-path/watcher/terminal teardown.
-            assertWorktreeUnlockedForRemoval(refreshedRegisteredWorktree)
-          } catch (error) {
-            throw new Error(
-              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-            )
-          }
-
-          // Why: `orca.yaml` shared directories are symlinked in too, and a
-          // directory-only ignore rule leaves those links untracked, so removal must
-          // tolerate and unlink them exactly like the per-user shared paths.
-          const linkedPaths = getWorktreeSharedLinkPaths(repo)
-          const ignoredLinkedPaths = args.force
-            ? []
-            : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)
-          try {
-            await (hasLocalWorktreeGitOptions
-              ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
-                  ...localWorktreeGitOptions,
-                  ...(ignoredLinkedPaths.length > 0
-                    ? { ignoredUntrackedPaths: ignoredLinkedPaths }
-                    : {})
-                })
-              : ignoredLinkedPaths.length > 0
-                ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
-                    ignoredUntrackedPaths: ignoredLinkedPaths
-                  })
-                : assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false))
-          } catch (error) {
-            if (!isOrphanCompatiblePreflightError(error)) {
-              throw new Error(
-                formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-              )
-            }
-            // Why: Git can still classify this as an orphan after preflight; keep strict PTY teardown before any recursive fallback deletion.
-          }
-
-          let removalResult: RemoveWorktreeResult | undefined
-          const removalGate = await withWorktreeRemoveStageSpan('watcher_gate', 'local', async () =>
-            runtime.acquireFileWatcherRemoval(canonicalWorktreePath)
-          )
-          let removalCompleted = false
-          try {
-            // Why: hold the watcher/terminal gate through Git and any recursive fallback so no late spawn recreates a native handle.
-            // Linked-path deletion is destructive too, so PTYs must release every handle before Windows or WSL filesystem cleanup starts.
-            await withWorktreeRemoveStageSpan('pty_sweep', 'local', async () => {
-              await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
-                allowUnverifiedStop: args.allowUnverifiedPtyStop
-              })
-            })
-
-            // Why: preflight only ignored these paths, not mutated them; keep watcher installs fenced through Git removal.
-            if (linkedPaths.length > 0) {
-              await removeWorktreeLinkedPaths(canonicalWorktreePath, linkedPaths)
-            }
-
-            try {
-              const removeOptions = {
-                ...(!deleteBranch ? { deleteBranch } : {}),
-                // Why: reuse the authoritative worktree list already computed here instead of rescanning siblings on the hot delete path.
-                knownRemovedWorktree: refreshedRegisteredWorktree,
-                ...(hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {})
-              }
-              removalResult = preserveBranchHeadFallback(
-                await withWorktreeRemoveStageSpan('git_remove', 'local', async () =>
-                  removeWorktree(
-                    repo.path,
-                    canonicalWorktreePath,
-                    args.force ?? false,
-                    removeOptions
-                  )
-                ),
-                refreshedRegisteredWorktree.head
-              )
-            } catch (error) {
-              // Why: Git for Windows can deregister a clean worktree before its recursive filesystem deletion fails transiently.
-              const recoveredRemovalResult = await recoverLocalWindowsWorktreeRemoval({
-                error,
-                force: args.force ?? false,
-                canonicalWorktreePath,
-                repoPath: repo.path,
-                localWorktreeGitOptions,
-                registeredWorktree: refreshedRegisteredWorktree,
-                deleteBranch,
-                closeWatcher: (worktreePath) => runtime.closeFileWatchersForRemoval(worktreePath)
-              })
-              if (recoveredRemovalResult) {
-                removalResult = recoveredRemovalResult
-                removalCompleted = true
-              } else if (isOrphanedWorktreeError(error)) {
-                // If git no longer tracks this worktree, clean up the directory and metadata
-                console.warn(
-                  `[worktrees] Orphaned worktree detected at ${canonicalWorktreePath}, cleaning up`
-                )
-                const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
-                if (
-                  await canSafelyRemoveOrphanedWorktreeDirectory(
-                    toLocalWorktreeRuntimePath(canonicalWorktreePath, localWorktreeGitOptions),
-                    toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-                    access.statPath,
-                    access.readPath
-                  )
-                ) {
-                  await runtime.closeFileWatchersForRemoval(canonicalWorktreePath)
-                  await removeLocalWorktreePath(
-                    canonicalWorktreePath,
-                    localWorktreeGitOptions
-                  ).catch(() => {})
-                } else {
-                  console.warn(
-                    `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
-                  )
-                }
-                // Why: remove failed so git still tracks it (.git/worktrees/<name>); prune or the stale entry keeps its branch locked.
-                await gitExecFileAsync(['worktree', 'prune'], {
-                  cwd: repo.path,
-                  ...localWorktreeGitOptions
-                }).catch(() => {})
-                await cleanupUnusedWorktreePushTargetRemote(
-                  repo.path,
-                  args.worktreeId,
-                  removedPushTarget,
-                  store,
-                  localWorktreeGitOptions
-                )
-                runtime.clearOptimisticReconcileToken(args.worktreeId)
-                await maybePruneReviewHeadRefsAfterWorktreeDelete({
-                  store,
-                  repo,
-                  repoId,
-                  worktreeId: args.worktreeId,
-                  meta: removedMeta,
-                  localGitOptions: localWorktreeGitOptions,
-                  sshGitProvider: null
-                })
-                removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
-                preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-                invalidateAuthorizedRootsCache()
-                notifyWorktreesChanged(mainWindow, repoId)
-                removalCompleted = true
-                return {}
-              } else {
-                throw new Error(
-                  formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-                )
-              }
-            }
-            removalCompleted = true
-          } finally {
-            await removalGate.finish(removalCompleted)
-          }
+            repoPath: repo.path,
+            localWorktreeGitOptions,
+            registeredWorktree,
+            deleteBranch
+          })
           await cleanupUnusedWorktreePushTargetRemote(
             repo.path,
             args.worktreeId,
@@ -3040,30 +1731,288 @@ export function registerWorktreeHandlers(
           rememberPreservedBranchCleanupTarget(
             args.worktreeId,
             removalResult,
-            refreshedRegisteredWorktree.head,
+            registeredWorktree.head,
             removedPushTarget
           )
           runtime.clearOptimisticReconcileToken(args.worktreeId)
-          await withWorktreeRemoveStageSpan('metadata_purge', 'local', async () => {
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+          await maybePruneReviewHeadRefsAfterWorktreeDelete({
+            store,
+            repo,
+            repoId,
+            worktreeId: args.worktreeId,
+            meta: removedMeta,
+            localGitOptions: localWorktreeGitOptions,
+            sshGitProvider: provider
           })
-          await withWorktreeRemoveStageSpan('cache_invalidation', 'local', async () => {
-            invalidateAuthorizedRootsCache()
-          })
-
+          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+          invalidateAuthorizedRootsCache()
           notifyWorktreesChanged(mainWindow, repoId)
           return removalResult ?? {}
+        }
+
+        // Run archive hook before removal so teardown scripts still see the worktree directory.
+        const hooks = await getArchiveHooksForRemoval(repo)
+        if (hooks?.scripts.archive && !args.skipArchive) {
+          const result = repo.connectionId
+            ? await runRemoteArchiveHook(repo, canonicalWorktreePath, hooks.scripts.archive)
+            : await runHook(
+                'archive',
+                canonicalWorktreePath,
+                repo,
+                undefined,
+                localWorktreeGitOptions
+              )
+          if (!result.success) {
+            console.error(
+              `[hooks] archive hook failed for ${canonicalWorktreePath}:`,
+              result.output
+            )
+          }
+        }
+
+        if (repo.connectionId) {
+          // Why: SSH deletion mirrors the local flow — hooks run while the directory is intact, then the clean check guards removal.
+          if (!args.force) {
+            const { clean, stdout } = await provider!.worktreeIsClean(canonicalWorktreePath)
+            if (!clean) {
+              const error = new Error('Worktree has uncommitted or untracked changes.')
+              ;(error as Error & { stdout?: string }).stdout = stdout
+              throw error
+            }
+          }
+
+          const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
+          const removalGate = await runtime.acquireFileWatcherRemoval(
+            canonicalWorktreePath,
+            repo.connectionId
+          )
+          let rawRemovalResult: RemoveWorktreeResult | undefined
+          let removalCompleted = false
+          try {
+            await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, repo.connectionId)
+            rawRemovalResult = await (Object.keys(remoteRemoveOptions).length > 0
+              ? provider!.removeWorktree(canonicalWorktreePath, args.force, remoteRemoveOptions)
+              : provider!.removeWorktree(canonicalWorktreePath, args.force))
+            removalCompleted = true
+          } finally {
+            await removalGate.finish(removalCompleted)
+          }
+          const removalResult = preserveBranchHeadFallback(
+            rawRemovalResult,
+            registeredWorktree.head
+          )
+          await cleanupUnusedWorktreePushTargetRemoteSsh(
+            provider!,
+            repo.path,
+            args.worktreeId,
+            removedPushTarget,
+            store
+          )
+          rememberPreservedBranchCleanupTarget(
+            args.worktreeId,
+            removalResult,
+            registeredWorktree.head,
+            removedPushTarget
+          )
+          runtime.clearOptimisticReconcileToken(args.worktreeId)
+          await maybePruneReviewHeadRefsAfterWorktreeDelete({
+            store,
+            repo,
+            repoId,
+            worktreeId: args.worktreeId,
+            meta: removedMeta,
+            localGitOptions: localWorktreeGitOptions,
+            sshGitProvider: provider
+          })
+          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+          notifyWorktreesChanged(mainWindow, repoId)
+          return removalResult ?? {}
+        }
+
+        const refreshedWorktrees = hasLocalWorktreeGitOptions
+          ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
+          : await listGitWorktreesStrict(repo.path)
+        const refreshedRegisteredWorktree = findRegisteredDeletableWorktree(
+          repo.path,
+          canonicalWorktreePath,
+          refreshedWorktrees
+        )
+        if (!refreshedRegisteredWorktree) {
+          throw new Error(
+            `Worktree registration changed during deletion: ${canonicalWorktreePath}. Retry deletion.`
+          )
+        }
+        try {
+          // Why: an archive hook can race another Git client that locks the row; recheck before linked-path/watcher/terminal teardown.
+          assertWorktreeUnlockedForRemoval(refreshedRegisteredWorktree)
+        } catch (error) {
+          throw new Error(
+            formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+          )
+        }
+
+        const linkedPaths = repo.symlinkPaths ?? []
+        const ignoredLinkedPaths = args.force
+          ? []
+          : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)
+        try {
+          await (hasLocalWorktreeGitOptions
+            ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
+                ...localWorktreeGitOptions,
+                ...(ignoredLinkedPaths.length > 0
+                  ? { ignoredUntrackedPaths: ignoredLinkedPaths }
+                  : {})
+              })
+            : ignoredLinkedPaths.length > 0
+              ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
+                  ignoredUntrackedPaths: ignoredLinkedPaths
+                })
+              : assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false))
+        } catch (error) {
+          if (!isOrphanCompatiblePreflightError(error)) {
+            throw new Error(
+              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+            )
+          }
+          // Why: Git can still classify this as an orphan after preflight; keep strict PTY teardown before any recursive fallback deletion.
+        }
+
+        let removalResult: RemoveWorktreeResult | undefined
+        const removalGate = await runtime.acquireFileWatcherRemoval(canonicalWorktreePath)
+        let removalCompleted = false
+        try {
+          // Why: preflight only ignored these paths, not mutated them; keep watcher installs fenced through Git removal.
+          if (linkedPaths.length > 0) {
+            await removeWorktreeLinkedPaths(canonicalWorktreePath, linkedPaths)
+          }
+
+          // Why: hold the watcher/terminal gate through Git and any recursive fallback so no late spawn recreates a native handle.
+          await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId)
+
+          try {
+            const removeOptions = {
+              ...(!deleteBranch ? { deleteBranch } : {}),
+              // Why: reuse the authoritative worktree list already computed here instead of rescanning siblings on the hot delete path.
+              knownRemovedWorktree: refreshedRegisteredWorktree,
+              ...(hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {})
+            }
+            removalResult = preserveBranchHeadFallback(
+              await removeWorktree(
+                repo.path,
+                canonicalWorktreePath,
+                args.force ?? false,
+                removeOptions
+              ),
+              refreshedRegisteredWorktree.head
+            )
+          } catch (error) {
+            // Why: Git for Windows can deregister a clean worktree before its recursive filesystem deletion fails transiently.
+            const recoveredRemovalResult = await recoverLocalWindowsWorktreeRemoval({
+              error,
+              force: args.force ?? false,
+              canonicalWorktreePath,
+              repoPath: repo.path,
+              localWorktreeGitOptions,
+              registeredWorktree: refreshedRegisteredWorktree,
+              deleteBranch,
+              closeWatcher: (worktreePath) => runtime.closeFileWatchersForRemoval(worktreePath)
+            })
+            if (recoveredRemovalResult) {
+              removalResult = recoveredRemovalResult
+              removalCompleted = true
+            } else if (isOrphanedWorktreeError(error)) {
+              // If git no longer tracks this worktree, clean up the directory and metadata
+              console.warn(
+                `[worktrees] Orphaned worktree detected at ${canonicalWorktreePath}, cleaning up`
+              )
+              const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
+              if (
+                await canSafelyRemoveOrphanedWorktreeDirectory(
+                  toLocalWorktreeRuntimePath(canonicalWorktreePath, localWorktreeGitOptions),
+                  toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
+                  access.statPath,
+                  access.readPath
+                )
+              ) {
+                await runtime.closeFileWatchersForRemoval(canonicalWorktreePath)
+                await removeLocalWorktreePath(canonicalWorktreePath, localWorktreeGitOptions).catch(
+                  () => {}
+                )
+              } else {
+                console.warn(
+                  `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
+                )
+              }
+              // Why: remove failed so git still tracks it (.git/worktrees/<name>); prune or the stale entry keeps its branch locked.
+              await gitExecFileAsync(['worktree', 'prune'], {
+                cwd: repo.path,
+                ...localWorktreeGitOptions
+              }).catch(() => {})
+              await cleanupUnusedWorktreePushTargetRemote(
+                repo.path,
+                args.worktreeId,
+                removedPushTarget,
+                store,
+                localWorktreeGitOptions
+              )
+              runtime.clearOptimisticReconcileToken(args.worktreeId)
+              await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                store,
+                repo,
+                repoId,
+                worktreeId: args.worktreeId,
+                meta: removedMeta,
+                localGitOptions: localWorktreeGitOptions,
+                sshGitProvider: provider
+              })
+              removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+              invalidateAuthorizedRootsCache()
+              notifyWorktreesChanged(mainWindow, repoId)
+              removalCompleted = true
+              return {}
+            } else {
+              throw new Error(
+                formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+              )
+            }
+          }
+          removalCompleted = true
+        } finally {
+          await removalGate.finish(removalCompleted)
+        }
+        await cleanupUnusedWorktreePushTargetRemote(
+          repo.path,
+          args.worktreeId,
+          removedPushTarget,
+          store,
+          localWorktreeGitOptions
+        )
+        rememberPreservedBranchCleanupTarget(
+          args.worktreeId,
+          removalResult,
+          refreshedRegisteredWorktree.head,
+          removedPushTarget
+        )
+        runtime.clearOptimisticReconcileToken(args.worktreeId)
+        await maybePruneReviewHeadRefsAfterWorktreeDelete({
+          store,
+          repo,
+          repoId,
+          worktreeId: args.worktreeId,
+          meta: removedMeta,
+          localGitOptions: localWorktreeGitOptions,
+          sshGitProvider: null
         })
+        removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+        invalidateAuthorizedRootsCache()
+
+        notifyWorktreesChanged(mainWindow, repoId)
+        return removalResult ?? {}
       })()
       worktreeRemovalsInFlight.set(inFlightKey, { optionsKey, promise: removal })
       try {
-        const result = await removal
-        options?.onWorktreeLifecycle?.({
-          kind: 'removed',
-          worktreeId: args.worktreeId,
-          path: parseWorktreeId(args.worktreeId).worktreePath
-        })
-        return result
+        return await removal
       } finally {
         if (worktreeRemovalsInFlight.get(inFlightKey)?.promise === removal) {
           worktreeRemovalsInFlight.delete(inFlightKey)
@@ -3081,12 +2030,13 @@ export function registerWorktreeHandlers(
     ): Promise<RemoveWorktreeResult> => {
       const { repoId } = parseWorktreeId(args.worktreeId)
       const repo = getRepoForWorktreeRemoval(store, repoId, args.hostId)
-      // Repo-first (unlike owner resolution below) so this key matches worktrees:remove's; meta only covers ownerless forgets.
+      if (!repo) {
+        throw new Error(`Repo not found: ${repoId}`)
+      }
+      // Why: share the removal in-flight map so concurrent remove and forgetLocal on the same id can't both mutate metadata.
       const inFlightKey = getWorktreeRemovalInFlightKey(
         args.worktreeId,
-        repo
-          ? getRepoExecutionHostId(repo)
-          : (store.getWorktreeMeta(args.worktreeId)?.hostId ?? args.hostId)
+        getRepoExecutionHostId(repo)
       )
       const optionsKey = 'forget-local'
       const inFlight = worktreeRemovalsInFlight.get(inFlightKey)
@@ -3098,50 +2048,23 @@ export function registerWorktreeHandlers(
       }
 
       const forget = (async (): Promise<RemoveWorktreeResult> => {
-        // Ambiguous repo lookup must not bypass a live folder root's deletion guard.
-        const isFolderRootOf = (candidate: Repo): boolean =>
-          isFolderRepo(candidate) && args.worktreeId === getFolderWorkspaceRootId(candidate)
-        if (repo ? isFolderRootOf(repo) : store.getRepos().some(isFolderRootOf)) {
+        if (isFolderRepo(repo) && args.worktreeId === getFolderWorkspaceRootId(repo)) {
           throw new Error(
             'Cannot delete the project root workspace. Remove the folder project instead.'
           )
         }
 
-        const ownerHostId = resolveWorktreeRemovalOwnerHostId(
-          store,
-          args.worktreeId,
-          repo,
-          args.hostId
-        )
-        const ownerHost = parseExecutionHostId(ownerHostId)
-        const sshPtyProvider =
-          ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
-        const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'
-        // External host inventories must never sweep a same-id local workspace.
+        // Why: best-effort PTY sweep; resolves synchronously for a dead SSH relay (tombstoned lease) so it never hangs.
         await killAllProcessesForWorktree(args.worktreeId, {
           runtime,
-          resolvedWorktreeId: args.worktreeId,
-          ...(ownerHost?.kind === 'ssh' ? { resolvedConnectionId: ownerHost.targetId } : {}),
-          ...(ownerHost?.kind === 'runtime'
-            ? { resolvedRuntimeEnvironmentId: ownerHost.environmentId }
-            : {}),
-          localProvider: sshPtyProvider ?? getLocalPtyProvider(),
-          onPtyStopped: clearProviderPtyState,
-          ...(externalHost
-            ? {
-                includeProviderInventory: ownerHost?.kind === 'ssh' && Boolean(sshPtyProvider),
-                includeLocalRegistry: false
-              }
-            : {})
+          localProvider: getLocalPtyProvider(),
+          onPtyStopped: clearProviderPtyState
         }).catch((err) => {
           console.warn(`[worktree-teardown] forget-local failed for ${args.worktreeId}:`, err)
         })
 
         runtime.clearOptimisticReconcileToken(args.worktreeId)
-        // The resolved owner, not args.hostId: an orphan forget with no hostId still has to purge its SSH/runtime partition.
-        removeWorktreeMetadataAndTransientState(store, args.worktreeId, ownerHost?.id)
-        // Why: cached roots outlive the forgotten workspace, so an ownerless path stays filesystem-authorized until a rebuild.
-        invalidateAuthorizedRootsCache()
+        removeWorktreeMetadataAndTransientState(store, args.worktreeId)
         preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
         notifyWorktreesChanged(mainWindow, repoId)
         return {}
@@ -3220,15 +2143,14 @@ export function registerWorktreeHandlers(
   ipcMain.handle(
     'worktrees:updateMeta',
     (_event, args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => {
-      const validatedUpdates = normalizeLinkedWorkItemFields(args.updates)
       const updates =
-        validatedUpdates.displayName !== undefined
+        args.updates.displayName !== undefined
           ? {
-              ...validatedUpdates,
+              ...args.updates,
               pendingFirstAgentMessageRename: false,
               firstAgentMessageRenameError: null
             }
-          : validatedUpdates
+          : args.updates
       const meta = store.setWorktreeMeta(args.worktreeId, stripOrcaProvenanceMetaUpdates(updates))
       // Do NOT notify here: renderer already applied this optimistically; a notification would re-sort the sidebar (bug PR #209).
       if (args.updates.displayName !== undefined) {
@@ -3246,12 +2168,6 @@ export function registerWorktreeHandlers(
       workspaceLineage: store.getAllWorkspaceLineage()
     }
   })
-
-  ipcMain.handle(
-    'worktrees:listLineageForHost',
-    (_event, args: ListDesktopLineageForHostArgs): Promise<HostLineageSnapshot> =>
-      listDesktopLineageForHost(store, runtime, args)
-  )
 
   ipcMain.handle(
     'worktrees:updateLineage',
@@ -3366,75 +2282,71 @@ export function registerWorktreeHandlers(
         repo,
         args.worktreePath,
         args.command,
-        getLocalProjectWorktreeGitOptions(store, repo),
-        resolveSetupRunnerShell(store.getSettings())
+        getLocalProjectWorktreeGitOptions(store, repo)
       )
     }
   )
 
-  ipcMain.handle(
-    'hooks:inspectSetupScriptImports',
-    async (_event, args: { repoId: string; hostId?: ExecutionHostId }) => {
-      const repo = getRepoForWorktreeRemoval(store, args.repoId, args.hostId)
-      if (!repo || isFolderRepo(repo)) {
-        return []
-      }
+  ipcMain.handle('hooks:inspectSetupScriptImports', async (_event, args: { repoId: string }) => {
+    const repo = store.getRepo(args.repoId)
+    if (!repo || isFolderRepo(repo)) {
+      return []
+    }
 
-      return inspectSetupScriptImportCandidates(
-        async (relativePath) => {
+    return inspectSetupScriptImportCandidates(
+      async (relativePath) => {
+        const filePath = joinWorktreeRelativePath(repo.path, relativePath)
+        if (repo.connectionId) {
+          const fsProvider = getSshFilesystemProvider(repo.connectionId)
+          if (!fsProvider) {
+            return null
+          }
+          try {
+            const result = await fsProvider.readFile(filePath)
+            return result.isBinary ? null : result.content
+          } catch {
+            return null
+          }
+        }
+
+        try {
+          return await readFile(filePath, 'utf-8')
+        } catch (error) {
+          if (!isENOENT(error)) {
+            console.warn('[hooks] Failed to inspect setup script import candidate:', error)
+          }
+          return null
+        }
+      },
+      {
+        fileExists: async (relativePath) => {
           const filePath = joinWorktreeRelativePath(repo.path, relativePath)
           if (repo.connectionId) {
             const fsProvider = getSshFilesystemProvider(repo.connectionId)
             if (!fsProvider) {
-              return null
+              return false
             }
             try {
-              const result = await fsProvider.readFile(filePath)
-              return result.isBinary ? null : result.content
+              const fileStat = await fsProvider.stat(filePath)
+              return fileStat.type !== 'directory'
             } catch {
-              return null
+              return false
             }
           }
 
           try {
-            return await readFile(filePath, 'utf-8')
+            const fileStat = await stat(filePath)
+            return !fileStat.isDirectory()
           } catch (error) {
             if (!isENOENT(error)) {
-              console.warn('[hooks] Failed to inspect setup script import candidate:', error)
+              console.warn('[hooks] Failed to stat setup script import candidate:', error)
             }
-            return null
-          }
-        },
-        {
-          fileExists: async (relativePath) => {
-            const filePath = joinWorktreeRelativePath(repo.path, relativePath)
-            if (repo.connectionId) {
-              const fsProvider = getSshFilesystemProvider(repo.connectionId)
-              if (!fsProvider) {
-                return false
-              }
-              try {
-                const fileStat = await fsProvider.stat(filePath)
-                return fileStat.type !== 'directory'
-              } catch {
-                return false
-              }
-            }
-
-            try {
-              const fileStat = await stat(filePath)
-              return !fileStat.isDirectory()
-            } catch (error) {
-              if (!isENOENT(error)) {
-                console.warn('[hooks] Failed to stat setup script import candidate:', error)
-              }
-              return false
-            }
+            return false
           }
         }
-      )
-    }
-  )
+      }
+    )
+  })
 
   ipcMain.handle(
     'hooks:readIssueCommand',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -361,6 +361,39 @@ async function maybePruneReviewHeadRefsAfterWorktreeDelete(params: {
       error
     )
   }
+}): Promise<void> {
+  try {
+    const gitExec = params.sshGitProvider
+      ? (args: string[]) => params.sshGitProvider!.exec(args, params.repo.path)
+      : undefined
+    // Why: drop meta under the prune lock (not a pre-lock snapshot) so two
+    // concurrent last-worktree deletes cannot both see each other and skip.
+    await pruneReviewHeadLocalRefsAfterWorktreeDelete({
+      repoPath: params.repo.path,
+      repoId: params.repoId,
+      deletedWorktreeId: params.worktreeId,
+      meta: params.meta,
+      finalizeDeletedMetaAndReadSiblings: () => {
+        // Why: sibling detection only; full transient cleanup still runs after prune.
+        params.store.removeWorktreeMeta(params.worktreeId)
+        return params.store.getAllWorktreeMeta()
+      },
+      ...(gitExec ? { gitExec } : {}),
+      ...(params.sshGitProvider
+        ? {}
+        : {
+            localGitOptions: {
+              cwd: params.repo.path,
+              ...params.localGitOptions
+            }
+          })
+    })
+  } catch (error) {
+    console.warn(
+      `[worktrees] Failed to prune durable review-head refs after deleting ${params.worktreeId}:`,
+      error
+    )
+  }
 }
 
 function removeWorktreeMetadataAndTransientState(

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1,6 +1,5 @@
 /* oxlint-disable max-lines */
-import type { BrowserWindow } from 'electron'
-import { ipcMain } from 'electron'
+import { ipcMain, type BrowserWindow } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
@@ -13,8 +12,13 @@ import {
 } from '../../shared/workspace-scope'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-projection'
+import { TaskSourceContextSchema } from '../../shared/task-source-context-schema'
+import { WorkspaceLinkedItemSchema } from '../../shared/workspace-linked-item-schema'
+import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-linked-item-source-context'
+import { getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
-import { deleteWorktreeHistoryDir } from '../terminal-history'
+import { isPathInsideOrEqual, isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
+import { deleteWorktreeHistoryDir } from '../terminal-history-deletion'
 import type {
   AutomationWorkspaceProvenance,
   CliWorkspaceProvenance,
@@ -30,10 +34,32 @@ import type {
   Repo,
   RemoveWorktreeResult,
   Worktree,
+  WorktreeLineage,
+  WorkspaceLineage,
   WorktreeMeta
 } from '../../shared/types'
 import { assertWorktreeUnlockedForRemoval } from '../../shared/worktree-removal'
-import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from '../../shared/execution-host'
+import {
+  PROVIDER_REQUEST_ID_MAX_UTF8_BYTES,
+  type DirectSshDetectedWorktreeRequest,
+  type HostQualifiedKnownWorktreeResult,
+  type HostQualifiedDetectedWorktreeResult,
+  type ListKnownWorktreesForExecutionHostArgs,
+  type ListDetectedWorktreesArgs,
+  type ProviderRequestId
+} from '../../shared/detected-worktree-provider-contract'
+import type {
+  HostLineageSnapshot,
+  ListDesktopLineageForHostArgs
+} from '../../shared/host-lineage-contract'
+import { isAdmissibleDirectSshAuthority } from '../../shared/ssh-retained-payload-admission'
 import {
   applyMetadataFallbackVisibility,
   buildKnownOrcaWorkspaceLayouts,
@@ -49,7 +75,7 @@ import {
 } from '../git/worktree'
 import { gitExecFileAsync } from '../git/runner'
 import { pruneReviewHeadLocalRefsAfterWorktreeDelete } from '../git/review-head-ref-prune'
-import { withWorktreeSpan } from '../observability/instrumentation'
+import { withWorktreeRemoveStageSpan, withWorktreeSpan } from '../observability/instrumentation'
 import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
 import {
   fetchGitHubPullRequestHeadRef,
@@ -68,6 +94,7 @@ import {
   loadHooks,
   parseOrcaYaml,
   readIssueCommand,
+  resolveSetupRunnerShell,
   runHook,
   hasHooksFile,
   hasUnrecognizedOrcaYamlKeys,
@@ -96,10 +123,11 @@ import {
   isENOENT,
   registerWorktreeRootsForRepo
 } from './filesystem-auth'
-import type { OrcaRuntimeService } from '../runtime/orca-runtime'
+import type { OrcaRuntimeService, RuntimeWorktreeLifecycleEvent } from '../runtime/orca-runtime'
 import { killAllProcessesForWorktree } from '../runtime/worktree-teardown'
 import { clearProviderPtyState, getLocalPtyProvider, getSshPtyProvider } from './pty'
 import { findExistingWorktreeSymlinkPaths, removeWorktreeLinkedPaths } from './worktree-symlinks'
+import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
 import { track } from '../telemetry/client'
 import { getCohortAtEmit } from '../telemetry/cohort-classifier'
 import { workspaceSourceSchema, type WorkspaceSource } from '../../shared/telemetry-events'
@@ -109,6 +137,12 @@ import {
   resolveAutomationWorkspaceProvenance
 } from '../automations/workspace-provenance'
 import { shouldEmitBoundedWarning } from './bounded-warning-dedupe'
+import {
+  getSshProviderAuthority,
+  isCurrentSshProviderAuthority,
+  registerSshProviderRequestAbort
+} from '../ssh/ssh-provider-authority'
+import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
 
 type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
@@ -119,23 +153,36 @@ type RemoveWorktreeArgs = {
   worktreeId: string
   hostId?: ExecutionHostId
   force?: boolean
+  /** Explicit Force Delete only — `force` alone is set by the ordinary confirmation (#11960). */
+  allowUnverifiedPtyStop?: boolean
   skipArchive?: boolean
 }
+
+type DetectedWorktreeRequestArgs = { repoId: string } | ListDetectedWorktreesArgs
 
 async function stopPtysForDestructiveWorktreeRemoval(
   runtime: OrcaRuntimeService,
   worktreeId: string,
-  connectionId?: string
+  options: { connectionId?: string; allowUnverifiedStop?: boolean } = {}
 ): Promise<void> {
+  const { connectionId, allowUnverifiedStop } = options
   const provider = connectionId ? getSshPtyProvider(connectionId) : getLocalPtyProvider()
   if (!provider) {
     throw new Error(`PTY provider unavailable for worktree deletion: ${worktreeId}`)
   }
   const teardownResult = await killAllProcessesForWorktree(worktreeId, {
     runtime,
+    // Why: `repoId::path` ids repeat across hosts, so an unfenced sweep stops a same-id
+    // workspace's terminals on another connection — and the selector lookup this replaces
+    // throws `selector_ambiguous` the moment two hosts own the id.
+    resolvedWorktreeId: worktreeId,
+    ...(connectionId ? { resolvedConnectionId: connectionId } : {}),
     localProvider: provider,
     onPtyStopped: clearProviderPtyState,
     requirePhysicalStop: true,
+    // Why (#11960): set only by an explicit Force Delete, never by the ordinary
+    // confirmation — otherwise the gate would be off on the primary delete path.
+    ...(allowUnverifiedStop ? { allowUnverifiedStop: true } : {}),
     ...(connectionId ? { includeLocalRegistry: false } : {})
   })
   const total =
@@ -182,11 +229,11 @@ import {
   stripOrcaProvenanceMetaUpdates,
   UNREGISTERED_MISSING_WORKTREE_MESSAGE
 } from '../worktree-removal-safety'
-import { isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
 import {
   FOLDER_WORKSPACE_INSTANCE_SEPARATOR,
-  getRepoIdFromWorktreeId
+  getRepoIdFromWorktreeId,
+  getWorktreePathBasenameFromId
 } from '../../shared/worktree-id'
 import { prefetchWorktreeCreateBase } from '../worktree-create-base-prefetch'
 import {
@@ -203,8 +250,38 @@ import {
   recoverLocalWindowsWorktreeRemoval
 } from '../local-worktree-removal-recovery'
 
+const NullableWorkspaceLinkedItemSchema = WorkspaceLinkedItemSchema.nullable()
+const NullableTaskSourceContextSchema = TaskSourceContextSchema.nullable()
 const WORKTREE_ARCHIVE_HOOK_TIMEOUT_MS = 120_000
 const WORKTREE_LIST_ALL_CONCURRENCY = 8
+
+function normalizeLinkedWorkItemFields<
+  T extends {
+    linkedWorkItem?: unknown
+    linkedTaskSourceContext?: unknown
+  }
+>(input: T): T {
+  const linkedWorkItem =
+    input.linkedWorkItem === undefined
+      ? undefined
+      : NullableWorkspaceLinkedItemSchema.parse(input.linkedWorkItem)
+  const linkedTaskSourceContext =
+    input.linkedTaskSourceContext === undefined
+      ? undefined
+      : NullableTaskSourceContextSchema.parse(input.linkedTaskSourceContext)
+  if (
+    linkedWorkItem &&
+    linkedTaskSourceContext &&
+    !isWorkspaceLinkedItemSourceContextMatch(linkedWorkItem, linkedTaskSourceContext)
+  ) {
+    throw new Error('Linked work item and source context identities must match')
+  }
+  return {
+    ...input,
+    ...(linkedWorkItem !== undefined ? { linkedWorkItem } : {}),
+    ...(linkedTaskSourceContext !== undefined ? { linkedTaskSourceContext } : {})
+  }
+}
 
 async function mapWithConcurrency<T, R>(
   items: readonly T[],
@@ -224,6 +301,20 @@ async function mapWithConcurrency<T, R>(
     })
   )
   return results
+}
+
+// Why: the worktree's own persisted host outranks the repo fallback; teardown and metadata purge must resolve the same owner
+// or the purge lands on the local partition while the SSH/runtime one keeps the workspace's tabs forever.
+function resolveWorktreeRemovalOwnerHostId(
+  store: Store,
+  worktreeId: string,
+  repo: Repo | undefined,
+  fallbackHostId?: ExecutionHostId
+): ExecutionHostId | undefined {
+  return (
+    store.getWorktreeMeta(worktreeId)?.hostId ??
+    (repo ? getRepoExecutionHostId(repo) : fallbackHostId)
+  )
 }
 
 /** Best-effort: drop durable refs/orca/** pins when the last linked worktree is gone (#10431). */
@@ -272,12 +363,21 @@ async function maybePruneReviewHeadRefsAfterWorktreeDelete(params: {
   }
 }
 
-function removeWorktreeMetadataAndTransientState(store: Store, worktreeId: string): void {
+function removeWorktreeMetadataAndTransientState(
+  store: Store,
+  worktreeId: string,
+  hostId?: ExecutionHostId
+): void {
   // Why: worktree IDs are path-derived and reusable; drop process-local caches before the same ID can map to a new workspace.
-  store.removeWorktreeMeta(worktreeId)
+  if (hostId) {
+    store.removeWorktreeMeta(worktreeId, hostId)
+  } else {
+    store.removeWorktreeMeta(worktreeId)
+  }
   advertisedUrlWatcher.forgetWorktree(worktreeId)
   // Why: drop this worktree's localhost label routes so they don't accumulate in the proxy's route maps all session.
   localhostWorktreeLabelProxy.unregisterWorktree(worktreeId)
+  // Why: schedule async history tree removal — never recursive-rmSync on the delete critical path.
   deleteWorktreeHistoryDir(worktreeId)
   // Why: release the removed worktree's PR-refresh aliases so coalesced queue entries don't retain it all session (memory creep).
   pruneWorktreePRRefreshAliases(worktreeId)
@@ -297,7 +397,7 @@ function getProjectHostSetupMetaUpdates(
     ...(sameSetup && existing?.projectId !== ownership.projectId
       ? { projectId: ownership.projectId }
       : {}),
-    ...(sameSetup && existing?.hostId !== ownership.hostId ? { hostId: ownership.hostId } : {}),
+    ...(sameSetup && existing?.hostId === undefined ? { hostId: ownership.hostId } : {}),
     ...(existing?.projectHostSetupId === undefined
       ? { projectHostSetupId: ownership.projectHostSetupId }
       : {})
@@ -380,10 +480,17 @@ function gitStatusErrorMeansNotRepository(error: unknown): boolean {
   return /not a git repository/i.test(`${message}\n${stderr}`)
 }
 
-function getWorktreeRemovalOptionsKey(args: { force?: boolean; skipArchive?: boolean }): string {
+function getWorktreeRemovalOptionsKey(args: {
+  force?: boolean
+  allowUnverifiedPtyStop?: boolean
+  skipArchive?: boolean
+}): string {
   const forceKey = args.force === true ? 'force' : 'normal'
   const archiveKey = args.skipArchive === true ? 'skip-archive' : 'run-archive'
-  return `${forceKey}:${archiveKey}`
+  // Why: a Force Delete retry must not coalesce onto the in-flight attempt that
+  // just failed the PTY gate — it would inherit that failure instead of retrying.
+  const ptyKey = args.allowUnverifiedPtyStop === true ? 'allow-unverified-pty' : 'require-pty-stop'
+  return `${forceKey}:${archiveKey}:${ptyKey}`
 }
 
 function getWorktreeRemovalInFlightKey(worktreeId: string, hostId?: ExecutionHostId): string {
@@ -523,6 +630,8 @@ function getPreservedBranchCleanupTarget(
 const loggedUnavailableSshGitProviders = new Set<string>()
 const loggedWorktreeListFailures = new Set<string>()
 const loggedMalformedWorktreeMetaKeys = new Set<string>()
+export const DETECTED_WORKTREE_PROVIDER_TIMEOUT_MS = 30_000
+export const LINEAGE_HYDRATION_TIMEOUT_MS = 5_000
 // Why: absorb renderer polling bursts while bounding external worktree-change lag to one short refresh window.
 const DETECTED_WORKTREE_SCAN_CACHE_TTL_MS = 5_000
 
@@ -675,11 +784,18 @@ function pruneLineageForMissingRepoWorktrees(
   }
   const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
   const repoPrefix = `${repo.id}::`
+  const expectedHostId = getRepoExecutionHostId(repo)
+  const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
+  const canMutateWorktree = (worktreeId: string): boolean => {
+    const hostId = store.getWorktreeMeta(worktreeId)?.hostId
+    return hostId ? hostId === expectedHostId : repoOwners.length === 1
+  }
   for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
     const childScope = parseWorkspaceKey(childWorkspaceKey)
     if (
       childScope?.type === 'worktree' &&
       childScope.worktreeId.startsWith(repoPrefix) &&
+      canMutateWorktree(childScope.worktreeId) &&
       !liveIds.has(childScope.worktreeId)
     ) {
       if (isWorkspaceKey(childWorkspaceKey)) {
@@ -688,12 +804,16 @@ function pruneLineageForMissingRepoWorktrees(
     }
   }
   for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-    if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
+    if (childId.startsWith(repoPrefix) && canMutateWorktree(childId) && !liveIds.has(childId)) {
       // Why: path-derived IDs can be reused; once a scan proves the child is gone, drop its lineage so a future same-path worktree can't inherit it.
       store.removeWorktreeLineage(childId)
       store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
     }
-    if (lineage.parentWorktreeId.startsWith(repoPrefix) && !liveIds.has(lineage.parentWorktreeId)) {
+    if (
+      lineage.parentWorktreeId.startsWith(repoPrefix) &&
+      canMutateWorktree(lineage.parentWorktreeId) &&
+      !liveIds.has(lineage.parentWorktreeId)
+    ) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
         // Why: keep child lineage for the "Missing parent" UI, but rotate the absent parent's identity once so a path reuse can't inherit it.
@@ -734,6 +854,17 @@ function createSshWorktreeMetaIndex(entries: [string, WorktreeMeta][]): SshWorkt
   return index
 }
 
+// Why: scopes parseWorktreeId to one repo's keys. The entry list itself is still materialized for the whole
+// store, so this is cheaper per call than the unfiltered index, not free.
+function createSshWorktreeMetaIndexForRepo(
+  allMeta: Record<string, WorktreeMeta>,
+  repoId: string
+): SshWorktreeMetaIndex {
+  return createSshWorktreeMetaIndex(
+    Object.entries(allMeta).filter(([worktreeId]) => getRepoIdFromWorktreeId(worktreeId) === repoId)
+  )
+}
+
 function synthesizeSshGitWorktree(repo: Repo, path: string, meta: WorktreeMeta): GitWorktreeInfo {
   return {
     path,
@@ -755,7 +886,15 @@ function listDisconnectedSshWorktrees(
   metaIndex: SshWorktreeMetaIndex
 ): ReturnType<typeof mergeWorktree>[] {
   const byWorktreeId = new Map<string, ReturnType<typeof mergeWorktree>>()
+  const expectedHostId = getRepoExecutionHostId(repo)
+  const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
   for (const candidate of metaIndex.get(repo.id) ?? []) {
+    if (
+      (candidate.meta.hostId && candidate.meta.hostId !== expectedHostId) ||
+      (!candidate.meta.hostId && repoOwners.length > 1)
+    ) {
+      continue
+    }
     const ownershipUpdates = getProjectHostSetupMetaUpdates(store, repo, candidate.meta)
     const meta =
       Object.keys(ownershipUpdates).length > 0
@@ -764,10 +903,15 @@ function listDisconnectedSshWorktrees(
     if (Object.keys(ownershipUpdates).length > 0) {
       store.setWorktreeMeta(candidate.id, ownershipUpdates)
     }
+    // Why: synthesized rows carry no branch, so the title would fall through to the DESKTOP's basename()
+    // applied to a REMOTE path — a Windows remote then renders its whole C:\... path as the name. Rows must
+    // stay per-directory (repo.displayName would title every row identically), so use the separator-agnostic
+    // basename instead.
     const worktree = mergeWorktree(
       repo.id,
       synthesizeSshGitWorktree(repo, candidate.path, meta),
-      meta
+      meta,
+      getWorktreePathBasenameFromId(candidate.id) ?? undefined
     )
     byWorktreeId.delete(worktree.id)
     byWorktreeId.set(worktree.id, worktree)
@@ -879,6 +1023,8 @@ function mergeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta
     linkedBitbucketPR: meta.linkedBitbucketPR ?? null,
     linkedAzureDevOpsPR: meta.linkedAzureDevOpsPR ?? null,
     linkedGiteaPR: meta.linkedGiteaPR ?? null,
+    linkedWorkItem: meta.linkedWorkItem ?? null,
+    linkedTaskSourceContext: meta.linkedTaskSourceContext ?? null,
     isArchived: meta.isArchived ?? false,
     isUnread: meta.isUnread ?? false,
     isPinned: meta.isPinned ?? false,
@@ -1000,7 +1146,11 @@ function createFolderWorkspace(
     ...(args.linkedAzureDevOpsPR !== undefined
       ? { linkedAzureDevOpsPR: args.linkedAzureDevOpsPR }
       : {}),
-    ...(args.linkedGiteaPR !== undefined ? { linkedGiteaPR: args.linkedGiteaPR } : {})
+    ...(args.linkedGiteaPR !== undefined ? { linkedGiteaPR: args.linkedGiteaPR } : {}),
+    ...(args.linkedWorkItem !== undefined ? { linkedWorkItem: args.linkedWorkItem } : {}),
+    ...(args.linkedTaskSourceContext !== undefined
+      ? { linkedTaskSourceContext: args.linkedTaskSourceContext }
+      : {})
   })
   return { worktree: mergeFolderWorkspace(repo, worktreeId, meta) }
 }
@@ -1031,15 +1181,719 @@ function buildDisconnectedDetectedWorktrees(
   return projectResolvedWorktreeLineage(detected, store.getAllWorktreeLineage?.() ?? {})
 }
 
+function hasConflictingStoredWorktreeOwner(
+  store: Store,
+  repo: Repo,
+  worktreeIds: readonly string[]
+): boolean {
+  const expectedHostId = getRepoExecutionHostId(repo)
+  const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
+  return worktreeIds.some((worktreeId) => {
+    const meta = store.getWorktreeMeta(worktreeId)
+    return !!meta && (meta.hostId ? meta.hostId !== expectedHostId : repoOwnerCount > 1)
+  })
+}
+
+type RepoOwnershipEvidence =
+  | { status: 'owned'; hostId: ExecutionHostId }
+  | { status: 'malformed' }
+  | { status: 'contradictory' }
+
+function resolveRepoOwnershipEvidence(repo: Repo): RepoOwnershipEvidence {
+  const hasExplicitHost = repo.executionHostId !== null && repo.executionHostId !== undefined
+  const explicitHost = hasExplicitHost ? parseExecutionHostId(repo.executionHostId) : null
+  if (hasExplicitHost && !explicitHost) {
+    return { status: 'malformed' }
+  }
+  const hasConnection = repo.connectionId !== null && repo.connectionId !== undefined
+  const connectionId = hasConnection ? repo.connectionId?.trim() : null
+  if (hasConnection && !connectionId) {
+    return { status: 'malformed' }
+  }
+  const connectionHostId = connectionId ? toSshExecutionHostId(connectionId) : null
+  if (explicitHost && connectionHostId && explicitHost.id !== connectionHostId) {
+    return { status: 'contradictory' }
+  }
+  return {
+    status: 'owned',
+    hostId: explicitHost?.id ?? connectionHostId ?? LOCAL_EXECUTION_HOST_ID
+  }
+}
+
+function findExactRepoOwner(
+  store: Store,
+  repoId: string,
+  executionHostId?: ExecutionHostId
+): Repo | undefined {
+  const candidates = store.getRepos().filter((repo) => repo.id === repoId)
+  const evidence = candidates.map(resolveRepoOwnershipEvidence)
+  if (evidence.some((owner) => owner.status !== 'owned')) {
+    return undefined
+  }
+  const matches = candidates.filter((_, index) => {
+    const owner = evidence[index]
+    return (
+      owner?.status === 'owned' &&
+      (executionHostId === undefined || owner.hostId === executionHostId)
+    )
+  })
+  return matches.length === 1 ? matches[0] : undefined
+}
+
+function isCapturedRepoCurrent(
+  store: Store,
+  repo: Repo,
+  executionHostId?: ExecutionHostId
+): boolean {
+  const current = findExactRepoOwner(store, repo.id, executionHostId)
+  return (
+    current !== undefined &&
+    current.path === repo.path &&
+    (current.connectionId ?? null) === (repo.connectionId ?? null) &&
+    (current.executionHostId ?? null) === (repo.executionHostId ?? null)
+  )
+}
+
+async function listDetectedWorktreesForCapturedRepo(
+  store: Store,
+  repo: Repo,
+  isCurrent: () => boolean,
+  capturedProvider = repo.connectionId ? getSshGitProvider(repo.connectionId) : undefined,
+  providerAbort?: { signal: AbortSignal; status: () => 'canceled' | 'timed-out' }
+): Promise<DetectedWorktreeListResult | { providerAbortStatus: 'canceled' | 'timed-out' } | null> {
+  const abortedResult = () =>
+    providerAbort?.signal.aborted
+      ? ({ providerAbortStatus: providerAbort.status() } as const)
+      : undefined
+  const sshWorktreeMetaIndex = repo.connectionId
+    ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
+    : new Map()
+
+  try {
+    let gitWorktrees: GitWorktreeInfo[]
+    let freshScan = true
+    if (isFolderRepo(repo)) {
+      if (!isCurrent()) {
+        return null
+      }
+      const folderWorkspaceIds = Object.keys(store.getAllWorktreeMeta()).filter((worktreeId) =>
+        isFolderWorkspaceIdForRepo(repo, worktreeId)
+      )
+      if (hasConflictingStoredWorktreeOwner(store, repo, folderWorkspaceIds)) {
+        return {
+          repoId: repo.id,
+          authoritative: false,
+          source: 'metadata-fallback',
+          worktrees: []
+        }
+      }
+      return {
+        repoId: repo.id,
+        authoritative: true,
+        source: 'git',
+        worktrees: projectResolvedWorktreeLineage(
+          buildFolderDetectedWorktrees(store, repo),
+          store.getAllWorktreeLineage?.() ?? {}
+        )
+      }
+    }
+    if (repo.connectionId) {
+      if (!capturedProvider) {
+        const aborted = abortedResult()
+        if (aborted) {
+          return aborted
+        }
+        if (!isCurrent()) {
+          return null
+        }
+        const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+        return {
+          repoId: repo.id,
+          authoritative: false,
+          source: 'metadata-fallback',
+          worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
+        }
+      }
+      gitWorktrees = await capturedProvider.listWorktrees(repo.path, {
+        signal: providerAbort?.signal
+      })
+    } else {
+      const scan = await listDetectedGitWorktrees(store, repo)
+      gitWorktrees = scan.gitWorktrees
+      freshScan = scan.fresh
+    }
+    const aborted = abortedResult()
+    if (aborted) {
+      return aborted
+    }
+    if (!isCurrent()) {
+      return null
+    }
+    const listedWorktreeIds = gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`)
+    if (hasConflictingStoredWorktreeOwner(store, repo, listedWorktreeIds)) {
+      return {
+        repoId: repo.id,
+        authoritative: false,
+        source: 'metadata-fallback',
+        worktrees: []
+      }
+    }
+    if (freshScan) {
+      rememberLocalWorktreeRoots(store, repo, gitWorktrees)
+      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+    }
+    loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
+    return {
+      repoId: repo.id,
+      authoritative: true,
+      source: 'git',
+      worktrees: buildDetectedGitWorktrees(store, repo, gitWorktrees)
+    }
+  } catch (err) {
+    const aborted = abortedResult()
+    if (aborted) {
+      return aborted
+    }
+    if (!isCurrent()) {
+      return null
+    }
+    warnOnce(
+      loggedWorktreeListFailures,
+      `${repo.id}:${repo.path}`,
+      `[worktrees] failed to list detected worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
+      err
+    )
+    if (repo.connectionId) {
+      const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+      return {
+        repoId: repo.id,
+        authoritative: false,
+        source: 'metadata-fallback',
+        worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
+      }
+    }
+    return { repoId: repo.id, authoritative: false, source: 'metadata-fallback', worktrees: [] }
+  }
+}
+
+function hasValidDirectSshAuthority(
+  args: DirectSshDetectedWorktreeRequest
+): args is DirectSshDetectedWorktreeRequest {
+  return isAdmissibleDirectSshAuthority(args.expectedAuthority)
+}
+
+function hasValidLineageSshAuthority(
+  args: ListDesktopLineageForHostArgs
+): args is Extract<ListDesktopLineageForHostArgs, { expectedAuthority: unknown }> {
+  if (!('expectedAuthority' in args)) {
+    return false
+  }
+  return isAdmissibleDirectSshAuthority(args.expectedAuthority)
+}
+
+type LineageOwner =
+  | { status: 'owned'; hostId: ExecutionHostId }
+  | { status: 'ambiguous' | 'contradictory' | 'runtime' }
+
+type LineageFolder = ReturnType<Store['getFolderWorkspaces']>[number]
+type LineageGroup = ReturnType<Store['getProjectGroups']>[number]
+
+type LineageResolutionContext = {
+  store: Store
+  repos: Repo[]
+  groups: LineageGroup[]
+  reposById: Map<string, Repo[]>
+  foldersById: Map<string, LineageFolder[]>
+  groupsById: Map<string, LineageGroup[]>
+  groupSubtreeIdsByRoot: Map<string, Set<string>>
+  worktreeOwners: Map<string, LineageOwner>
+  folderOwners: Map<string, LineageOwner>
+  workspaceOwners: Map<string, LineageOwner>
+}
+
+function indexLineageEntriesById<T extends { id: string }>(
+  entries: readonly T[]
+): Map<string, T[]> {
+  const index = new Map<string, T[]>()
+  for (const entry of entries) {
+    const matching = index.get(entry.id) ?? []
+    matching.push(entry)
+    index.set(entry.id, matching)
+  }
+  return index
+}
+
+function createLineageResolutionContext(store: Store): LineageResolutionContext {
+  const repos = store.getRepos()
+  const folders = store.getFolderWorkspaces()
+  const groups = store.getProjectGroups()
+  return {
+    store,
+    repos,
+    groups,
+    reposById: indexLineageEntriesById(repos),
+    foldersById: indexLineageEntriesById(folders),
+    groupsById: indexLineageEntriesById(groups),
+    groupSubtreeIdsByRoot: new Map(),
+    worktreeOwners: new Map(),
+    folderOwners: new Map(),
+    workspaceOwners: new Map()
+  }
+}
+
+function resolveRepoLineageOwner(repo: Repo): LineageOwner {
+  const owner = resolveRepoOwnershipEvidence(repo)
+  if (owner.status === 'malformed') {
+    return { status: 'ambiguous' }
+  }
+  if (owner.status === 'contradictory') {
+    return { status: 'contradictory' }
+  }
+  return parseExecutionHostId(owner.hostId)?.kind === 'runtime' ? { status: 'runtime' } : owner
+}
+
+function resolveWorktreeLineageOwner(
+  context: LineageResolutionContext,
+  worktreeId: string
+): LineageOwner {
+  const cached = context.worktreeOwners.get(worktreeId)
+  if (cached) {
+    return cached
+  }
+  const remember = (owner: LineageOwner): LineageOwner => {
+    context.worktreeOwners.set(worktreeId, owner)
+    return owner
+  }
+  let repoId: string
+  try {
+    repoId = parseWorktreeId(worktreeId).repoId
+  } catch {
+    return remember({ status: 'ambiguous' })
+  }
+  const repos = context.reposById.get(repoId) ?? []
+  const meta = context.store.getWorktreeMeta(worktreeId)
+  const runtimeOwnerEnvironmentId = (
+    meta as (WorktreeMeta & { runtimeOwnerEnvironmentId?: string }) | undefined
+  )?.runtimeOwnerEnvironmentId?.trim()
+  if (runtimeOwnerEnvironmentId) {
+    return remember({ status: 'runtime' })
+  }
+  if (meta?.hostId) {
+    const explicitHost = parseExecutionHostId(meta.hostId)
+    if (!explicitHost) {
+      return remember({ status: 'ambiguous' })
+    }
+    if (explicitHost.kind === 'runtime') {
+      return remember({ status: 'runtime' })
+    }
+    const matchingRepos = repos.filter((repo) => {
+      const owner = resolveRepoLineageOwner(repo)
+      return owner.status === 'owned' && owner.hostId === explicitHost.id
+    })
+    if (matchingRepos.length === 1) {
+      return remember({ status: 'owned', hostId: explicitHost.id })
+    }
+    return remember(
+      matchingRepos.length > 1
+        ? { status: 'ambiguous' }
+        : { status: repos.length > 0 ? 'contradictory' : 'ambiguous' }
+    )
+  }
+  if (repos.length !== 1) {
+    return remember({ status: 'ambiguous' })
+  }
+  return remember(resolveRepoLineageOwner(repos[0]))
+}
+
+function getFolderLineageCandidateRepos(
+  context: LineageResolutionContext,
+  folder: LineageFolder
+): Repo[] {
+  let groupIds = context.groupSubtreeIdsByRoot.get(folder.projectGroupId)
+  if (!groupIds) {
+    groupIds = getProjectGroupSubtreeIds(context.groups, folder.projectGroupId)
+    context.groupSubtreeIdsByRoot.set(folder.projectGroupId, groupIds)
+  }
+  const grouped = context.repos.filter(
+    (repo) => typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)
+  )
+  const pathRepos = context.repos.filter(
+    (repo) =>
+      !(typeof repo.projectGroupId === 'string' && groupIds.has(repo.projectGroupId)) &&
+      isPathInsideOrEqual(folder.folderPath, repo.path)
+  )
+  const group = context.groupsById.get(folder.projectGroupId)?.[0]
+  const connectionId = folder.connectionId ?? group?.connectionId ?? null
+  return connectionId
+    ? [...grouped, ...pathRepos.filter((repo) => (repo.connectionId ?? null) === connectionId)]
+    : grouped.length > 0
+      ? [
+          ...grouped,
+          ...pathRepos.filter((repo) =>
+            new Set(grouped.map((candidate) => candidate.connectionId ?? null)).has(
+              repo.connectionId ?? null
+            )
+          )
+        ]
+      : pathRepos
+}
+
+function resolveFolderLineageOwner(
+  context: LineageResolutionContext,
+  folderWorkspaceId: string
+): LineageOwner {
+  const cached = context.folderOwners.get(folderWorkspaceId)
+  if (cached) {
+    return cached
+  }
+  const remember = (owner: LineageOwner): LineageOwner => {
+    context.folderOwners.set(folderWorkspaceId, owner)
+    return owner
+  }
+  const folders = context.foldersById.get(folderWorkspaceId) ?? []
+  if (folders.length !== 1) {
+    return remember({ status: 'ambiguous' })
+  }
+  const folder = folders[0]
+  const groups = context.groupsById.get(folder.projectGroupId) ?? []
+  if (groups.length !== 1) {
+    return remember({ status: 'ambiguous' })
+  }
+  const group = groups[0]
+  const hosts = new Set<ExecutionHostId>()
+  if (folder.connectionId) {
+    hosts.add(`ssh:${encodeURIComponent(folder.connectionId)}`)
+  }
+  if (group.connectionId) {
+    hosts.add(`ssh:${encodeURIComponent(group.connectionId)}`)
+  }
+  if (group.executionHostId) {
+    const parsed = parseExecutionHostId(group.executionHostId)
+    if (!parsed) {
+      return remember({ status: 'ambiguous' })
+    }
+    hosts.add(parsed.id)
+  }
+  for (const repo of getFolderLineageCandidateRepos(context, folder)) {
+    const owner = resolveRepoLineageOwner(repo)
+    if (owner.status !== 'owned') {
+      return remember(owner)
+    }
+    hosts.add(owner.hostId)
+  }
+  if (hosts.size > 1) {
+    return remember({ status: 'contradictory' })
+  }
+  const hostId = [...hosts][0] ?? LOCAL_EXECUTION_HOST_ID
+  return remember(
+    parseExecutionHostId(hostId)?.kind === 'runtime'
+      ? { status: 'runtime' }
+      : { status: 'owned', hostId }
+  )
+}
+
+function resolveWorkspaceLineageOwner(
+  context: LineageResolutionContext,
+  workspaceKey: string
+): LineageOwner {
+  const cached = context.workspaceOwners.get(workspaceKey)
+  if (cached) {
+    return cached
+  }
+  const workspace = parseWorkspaceKey(workspaceKey)
+  const owner = !workspace
+    ? { status: 'ambiguous' as const }
+    : workspace.type === 'worktree'
+      ? resolveWorktreeLineageOwner(context, workspace.worktreeId)
+      : resolveFolderLineageOwner(context, workspace.folderWorkspaceId)
+  context.workspaceOwners.set(workspaceKey, owner)
+  return owner
+}
+
+function filterLineageForHost(
+  store: Store,
+  executionHostId: ExecutionHostId
+): {
+  worktreeLineageById: Record<string, WorktreeLineage>
+  workspaceLineageByChildKey: Record<string, WorkspaceLineage>
+} | null {
+  const context = createLineageResolutionContext(store)
+  const worktreeLineageById: Record<string, WorktreeLineage> = {}
+  const workspaceLineageByChildKey: Record<string, WorkspaceLineage> = {}
+  for (const [worktreeId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
+    const child = resolveWorktreeLineageOwner(context, worktreeId)
+    const parent = resolveWorktreeLineageOwner(context, lineage.parentWorktreeId)
+    if (child.status === 'ambiguous' || child.status === 'contradictory') {
+      return null
+    }
+    if (parent.status === 'ambiguous' || parent.status === 'contradictory') {
+      return null
+    }
+    if (
+      child.status === 'owned' &&
+      parent.status === 'owned' &&
+      child.hostId === executionHostId &&
+      parent.hostId === executionHostId
+    ) {
+      worktreeLineageById[worktreeId] = structuredClone(lineage)
+    } else if (
+      child.status === 'owned' &&
+      parent.status === 'owned' &&
+      child.hostId !== parent.hostId
+    ) {
+      return null
+    }
+  }
+  for (const [childKey, lineage] of Object.entries(store.getAllWorkspaceLineage())) {
+    const child = resolveWorkspaceLineageOwner(context, childKey)
+    const parent = resolveWorkspaceLineageOwner(context, lineage.parentWorkspaceKey)
+    if (child.status === 'ambiguous' || child.status === 'contradictory') {
+      return null
+    }
+    if (parent.status === 'ambiguous' || parent.status === 'contradictory') {
+      return null
+    }
+    if (
+      child.status === 'owned' &&
+      parent.status === 'owned' &&
+      child.hostId === executionHostId &&
+      parent.hostId === executionHostId
+    ) {
+      workspaceLineageByChildKey[childKey] = structuredClone(lineage)
+    } else if (
+      child.status === 'owned' &&
+      parent.status === 'owned' &&
+      child.hostId !== parent.hostId
+    ) {
+      return null
+    }
+  }
+  return { worktreeLineageById, workspaceLineageByChildKey }
+}
+
+async function hydrateLineageWithinDeadline(runtime: OrcaRuntimeService): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  const hydration = Promise.resolve()
+    .then(() => runtime.hydrateInferredWorktreeLineage())
+    .then(
+      () => true,
+      () => false
+    )
+  const deadline = new Promise<false>((resolve) => {
+    timeout = setTimeout(() => resolve(false), LINEAGE_HYDRATION_TIMEOUT_MS)
+  })
+  try {
+    return await Promise.race([hydration, deadline])
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+async function listDesktopLineageForHost(
+  store: Store,
+  runtime: OrcaRuntimeService,
+  args: ListDesktopLineageForHostArgs
+): Promise<HostLineageSnapshot> {
+  const parsedHost = parseExecutionHostId(args?.executionHostId)
+  const rejected = (
+    reason: Extract<HostLineageSnapshot, { authoritative: false }>['reason']
+  ): HostLineageSnapshot => ({
+    authoritative: false,
+    executionHostId: args.executionHostId,
+    reason
+  })
+  if (!parsedHost || parsedHost.kind === 'runtime') {
+    return rejected('rejected')
+  }
+  let provider: ReturnType<typeof getSshGitProvider> | undefined
+  let authority:
+    | Extract<ListDesktopLineageForHostArgs, { expectedAuthority: unknown }>['expectedAuthority']
+    | null = null
+  if (parsedHost.kind === 'local') {
+    if ('expectedAuthority' in args) {
+      return rejected('rejected')
+    }
+  } else {
+    if (
+      !hasValidLineageSshAuthority(args) ||
+      args.expectedAuthority.targetId !== parsedHost.targetId
+    ) {
+      return rejected('rejected')
+    }
+    authority = { ...args.expectedAuthority }
+    if (!isCurrentSshProviderAuthority(authority)) {
+      return rejected('stale')
+    }
+    provider = getSshGitProvider(parsedHost.targetId)
+    if (!provider) {
+      return rejected('unavailable')
+    }
+  }
+  if (!(await hydrateLineageWithinDeadline(runtime))) {
+    return rejected('unavailable')
+  }
+  if (
+    parsedHost.kind === 'ssh' &&
+    (!authority ||
+      getSshGitProvider(parsedHost.targetId) !== provider ||
+      !isCurrentSshProviderAuthority(authority))
+  ) {
+    return rejected('stale')
+  }
+  const lineage = filterLineageForHost(store, parsedHost.id)
+  if (!lineage) {
+    return rejected('ambiguous-owner')
+  }
+  if (parsedHost.kind === 'local') {
+    return {
+      authoritative: true,
+      authority: { kind: 'local', executionHostId: LOCAL_EXECUTION_HOST_ID },
+      ...lineage
+    }
+  }
+  if (!authority) {
+    return rejected('authority-unknown')
+  }
+  return {
+    authoritative: true,
+    authority: {
+      kind: 'direct-ssh',
+      executionHostId: parsedHost.id,
+      ...authority
+    },
+    ...lineage
+  }
+}
+
+async function listHostQualifiedDetectedWorktrees(
+  store: Store,
+  args: ListDetectedWorktreesArgs,
+  providerAbort?: { signal: AbortSignal; status: () => 'canceled' | 'timed-out' }
+): Promise<HostQualifiedDetectedWorktreeResult> {
+  const parsedHost = parseExecutionHostId(args.executionHostId)
+  const rejected = (status: 'rejected' | 'stale' | 'ambiguous-owner') => ({
+    providerRequestId: args.providerRequestId,
+    executionHostId: args.executionHostId,
+    status
+  })
+  if (
+    typeof args.providerRequestId !== 'string' ||
+    args.providerRequestId.length === 0 ||
+    Buffer.byteLength(args.providerRequestId, 'utf8') > PROVIDER_REQUEST_ID_MAX_UTF8_BYTES ||
+    !parsedHost ||
+    parsedHost.kind === 'runtime'
+  ) {
+    return rejected('rejected')
+  }
+  let capturedAuthority: DirectSshDetectedWorktreeRequest['expectedAuthority'] | null = null
+  if (parsedHost.kind === 'ssh') {
+    const directArgs = args as DirectSshDetectedWorktreeRequest
+    if (
+      !hasValidDirectSshAuthority(directArgs) ||
+      directArgs.expectedAuthority.targetId !== parsedHost.targetId
+    ) {
+      return rejected('rejected')
+    }
+    capturedAuthority = { ...directArgs.expectedAuthority }
+    if (!isCurrentSshProviderAuthority(capturedAuthority)) {
+      return rejected('stale')
+    }
+  }
+
+  const repoCandidates = store.getRepos().filter((candidate) => candidate.id === args.repoId)
+  if (
+    repoCandidates.some((candidate) => resolveRepoOwnershipEvidence(candidate).status !== 'owned')
+  ) {
+    return rejected('rejected')
+  }
+  const repo = findExactRepoOwner(store, args.repoId, args.executionHostId)
+  if (!repo) {
+    return rejected('ambiguous-owner')
+  }
+  if (
+    (parsedHost.kind === 'local' && repo.connectionId) ||
+    (parsedHost.kind === 'ssh' && repo.connectionId !== parsedHost.targetId)
+  ) {
+    return rejected('rejected')
+  }
+  const provider = parsedHost.kind === 'ssh' ? getSshGitProvider(parsedHost.targetId) : undefined
+  const isCurrent = (): boolean => {
+    if (!isCapturedRepoCurrent(store, repo, args.executionHostId)) {
+      return false
+    }
+    if (
+      (parsedHost.kind === 'local' && repo.connectionId) ||
+      (parsedHost.kind === 'ssh' && repo.connectionId !== parsedHost.targetId)
+    ) {
+      return false
+    }
+    if (parsedHost.kind !== 'ssh') {
+      return true
+    }
+    return (
+      capturedAuthority !== null &&
+      getSshGitProvider(parsedHost.targetId) === provider &&
+      isCurrentSshProviderAuthority(capturedAuthority)
+    )
+  }
+  const result = await listDetectedWorktreesForCapturedRepo(
+    store,
+    repo,
+    isCurrent,
+    provider,
+    providerAbort
+  )
+  if (!result) {
+    return rejected('stale')
+  }
+  if ('providerAbortStatus' in result) {
+    return {
+      providerRequestId: args.providerRequestId,
+      executionHostId: args.executionHostId,
+      status: result.providerAbortStatus
+    }
+  }
+  const status = result.authoritative ? 'complete' : 'non-authoritative'
+  if (parsedHost.kind === 'local') {
+    return {
+      status,
+      providerRequestId: args.providerRequestId,
+      repoId: repo.id,
+      authority: { kind: 'local', executionHostId: LOCAL_EXECUTION_HOST_ID },
+      result
+    }
+  }
+  if (!capturedAuthority) {
+    return rejected('rejected')
+  }
+  return {
+    status,
+    providerRequestId: args.providerRequestId,
+    repoId: repo.id,
+    authority: {
+      kind: 'direct-ssh',
+      executionHostId: args.executionHostId as `ssh:${string}`,
+      ...capturedAuthority
+    },
+    result
+  }
+}
+
 export function registerWorktreeHandlers(
   mainWindow: BrowserWindow,
   store: Store,
-  runtime: OrcaRuntimeService
+  runtime: OrcaRuntimeService,
+  options?: { onWorktreeLifecycle?: (event: RuntimeWorktreeLifecycleEvent) => void }
 ): void {
+  const detectedWorktreeCancellations = createSenderScopedRequestCancellations()
   // Remove previously registered handlers so re-register works when macOS re-activates and creates a new window.
   ipcMain.removeHandler('worktrees:listAll')
   ipcMain.removeHandler('worktrees:list')
   ipcMain.removeHandler('worktrees:listDetected')
+  ipcMain.removeHandler('worktrees:listKnownForExecutionHost')
+  ipcMain.removeHandler('worktrees:cancelListDetected')
   ipcMain.removeHandler('worktrees:create')
   ipcMain.removeHandler('worktrees:prefetchCreateBase')
   ipcMain.removeHandler('worktrees:resolvePrBase')
@@ -1049,6 +1903,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:forceDeletePreservedBranch')
   ipcMain.removeHandler('worktrees:updateMeta')
   ipcMain.removeHandler('worktrees:listLineage')
+  ipcMain.removeHandler('worktrees:listLineageForHost')
   ipcMain.removeHandler('worktrees:updateLineage')
   ipcMain.removeHandler('worktrees:persistSortOrder')
   ipcMain.removeHandler('worktrees:getBranchRenameFailureOutput')
@@ -1183,9 +2038,130 @@ export function registerWorktreeHandlers(
   })
 
   ipcMain.handle(
+    'worktrees:listKnownForExecutionHost',
+    (_event, args: ListKnownWorktreesForExecutionHostArgs): HostQualifiedKnownWorktreeResult => {
+      // Why: a malformed invoke must fail closed as `rejected`, not throw out of the handler. `ssh:` is inert —
+      // it owns no repo, so every guard below still rejects it.
+      const requestedRepoId = args?.repoId ?? ''
+      const requestedExecutionHostId = args?.executionHostId ?? 'ssh:'
+      const rejected = (): HostQualifiedKnownWorktreeResult => ({
+        status: 'rejected',
+        repoId: requestedRepoId,
+        executionHostId: requestedExecutionHostId
+      })
+      const parsedHost = parseExecutionHostId(requestedExecutionHostId)
+      if (parsedHost?.kind !== 'ssh') {
+        return rejected()
+      }
+      // Why: findExactRepoOwner repeats this same all-candidates-owned check, and getRepos() re-hydrates the
+      // whole catalog, so a separate pass here is pure cost.
+      const repo = findExactRepoOwner(store, requestedRepoId, requestedExecutionHostId)
+      if (!repo || repo.connectionId !== parsedHost.targetId) {
+        return rejected()
+      }
+      const complete = (worktrees: DetectedWorktree[]): HostQualifiedKnownWorktreeResult => ({
+        status: 'complete',
+        repoId: repo.id,
+        executionHostId: requestedExecutionHostId,
+        result: {
+          repoId: repo.id,
+          authoritative: false,
+          source: 'metadata-fallback',
+          worktrees
+        }
+      })
+      // Why: folder workspace ids carry an instance suffix the git-worktree synthesizer would read as a directory; build them the way every other listing does.
+      if (isFolderRepo(repo)) {
+        const folderWorkspaceIds = Object.keys(store.getAllWorktreeMeta()).filter((worktreeId) =>
+          isFolderWorkspaceIdForRepo(repo, worktreeId)
+        )
+        return hasConflictingStoredWorktreeOwner(store, repo, folderWorkspaceIds)
+          ? rejected()
+          : complete(
+              // Why: match the authoritative folder listing; without lineage these rows render flat and then
+              // reshuffle once the real scan lands.
+              projectResolvedWorktreeLineage(
+                buildFolderDetectedWorktrees(store, repo),
+                store.getAllWorktreeLineage?.() ?? {}
+              )
+            )
+      }
+      const metaIndex = createSshWorktreeMetaIndexForRepo(store.getAllWorktreeMeta(), repo.id)
+      return complete(
+        buildDisconnectedDetectedWorktrees(
+          store,
+          repo,
+          listDisconnectedSshWorktrees(store, repo, metaIndex)
+        )
+      )
+    }
+  )
+
+  ipcMain.handle(
     'worktrees:listDetected',
-    async (_event, args: { repoId: string }): Promise<DetectedWorktreeListResult> => {
-      const repo = store.getRepo(args.repoId)
+    async (
+      event,
+      args: DetectedWorktreeRequestArgs
+    ): Promise<DetectedWorktreeListResult | HostQualifiedDetectedWorktreeResult> => {
+      if ('executionHostId' in args) {
+        const parsedHost = parseExecutionHostId(args.executionHostId)
+        const directSshRequest = parsedHost?.kind === 'ssh'
+        const controller = directSshRequest
+          ? detectedWorktreeCancellations.begin(event, args.providerRequestId)
+          : null
+        const directArgs = args as DirectSshDetectedWorktreeRequest
+        const removeAuthorityAbort =
+          controller &&
+          parsedHost?.kind === 'ssh' &&
+          hasValidDirectSshAuthority(directArgs) &&
+          directArgs.expectedAuthority.targetId === parsedHost.targetId
+            ? registerSshProviderRequestAbort(directArgs.expectedAuthority, controller)
+            : undefined
+        let timedOut = false
+        let removeAbortListener: (() => void) | undefined
+        const abortedResult = controller
+          ? new Promise<HostQualifiedDetectedWorktreeResult>((resolve) => {
+              const onAbort = (): void => {
+                resolve({
+                  providerRequestId: args.providerRequestId,
+                  executionHostId: args.executionHostId,
+                  status: timedOut ? 'timed-out' : 'canceled'
+                })
+              }
+              controller.signal.addEventListener('abort', onAbort, { once: true })
+              removeAbortListener = () => controller.signal.removeEventListener('abort', onAbort)
+            })
+          : undefined
+        const timeout = controller
+          ? setTimeout(() => {
+              timedOut = true
+              controller.abort()
+            }, DETECTED_WORKTREE_PROVIDER_TIMEOUT_MS)
+          : undefined
+        try {
+          const providerResult = listHostQualifiedDetectedWorktrees(
+            store,
+            args,
+            controller
+              ? {
+                  signal: controller.signal,
+                  status: () => (timedOut ? 'timed-out' : 'canceled')
+                }
+              : undefined
+          )
+          return abortedResult
+            ? await Promise.race([providerResult, abortedResult])
+            : await providerResult
+        } finally {
+          if (timeout) {
+            clearTimeout(timeout)
+          }
+          removeAbortListener?.()
+          removeAuthorityAbort?.()
+          detectedWorktreeCancellations.finish(event, args.providerRequestId, controller)
+        }
+      }
+      const repo = findExactRepoOwner(store, args.repoId)
       if (!repo) {
         return {
           repoId: args.repoId,
@@ -1194,69 +2170,35 @@ export function registerWorktreeHandlers(
           worktrees: []
         }
       }
-      const sshWorktreeMetaIndex = repo.connectionId
-        ? createSshWorktreeMetaIndex(Object.entries(store.getAllWorktreeMeta()))
-        : new Map()
-
-      try {
-        let gitWorktrees: GitWorktreeInfo[]
-        let freshScan = true
-        if (isFolderRepo(repo)) {
-          return {
-            repoId: repo.id,
-            authoritative: true,
-            source: 'git',
-            worktrees: projectResolvedWorktreeLineage(
-              buildFolderDetectedWorktrees(store, repo),
-              store.getAllWorktreeLineage?.() ?? {}
-            )
-          }
-        } else if (repo.connectionId) {
-          const provider = getSshGitProvider(repo.connectionId)
-          if (!provider) {
-            const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
-            return {
-              repoId: repo.id,
-              authoritative: false,
-              source: 'metadata-fallback',
-              worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
-            }
-          }
-          gitWorktrees = await provider.listWorktrees(repo.path)
-        } else {
-          const scan = await listDetectedGitWorktrees(store, repo)
-          gitWorktrees = scan.gitWorktrees
-          freshScan = scan.fresh
-        }
-        if (freshScan) {
-          rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
-        }
-        loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
-        return {
-          repoId: repo.id,
-          authoritative: true,
-          source: 'git',
-          worktrees: buildDetectedGitWorktrees(store, repo, gitWorktrees)
-        }
-      } catch (err) {
-        warnOnce(
-          loggedWorktreeListFailures,
-          `${repo.id}:${repo.path}`,
-          `[worktrees] failed to list detected worktrees for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`,
-          err
-        )
-        if (repo.connectionId) {
-          const worktrees = listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
-          return {
+      const provider = repo.connectionId ? getSshGitProvider(repo.connectionId) : undefined
+      const authority = repo.connectionId
+        ? { ...getSshProviderAuthority(repo.connectionId) }
+        : undefined
+      const result = await listDetectedWorktreesForCapturedRepo(
+        store,
+        repo,
+        () =>
+          isCapturedRepoCurrent(store, repo) &&
+          (!repo.connectionId ||
+            (getSshGitProvider(repo.connectionId) === provider &&
+              authority !== undefined &&
+              isCurrentSshProviderAuthority(authority))),
+        provider
+      )
+      return result && !('providerAbortStatus' in result)
+        ? result
+        : {
             repoId: repo.id,
             authoritative: false,
             source: 'metadata-fallback',
-            worktrees: buildDisconnectedDetectedWorktrees(store, repo, worktrees)
+            worktrees: []
           }
-        }
-        return { repoId: repo.id, authoritative: false, source: 'metadata-fallback', worktrees: [] }
-      }
+    }
+  )
+  ipcMain.handle(
+    'worktrees:cancelListDetected',
+    (event, args: { providerRequestId: ProviderRequestId }): void => {
+      detectedWorktreeCancellations.cancel(event, args.providerRequestId)
     }
   )
 
@@ -1277,7 +2219,8 @@ export function registerWorktreeHandlers(
 
   ipcMain.handle(
     'worktrees:create',
-    async (_event, args: CreateWorktreeArgs): Promise<CreateWorktreeResult> => {
+    async (_event, rawArgs: CreateWorktreeArgs): Promise<CreateWorktreeResult> => {
+      const args = normalizeLinkedWorkItemFields(rawArgs)
       // Why span here: parent the child git spans for the trace tree; don't attach branch name/remote URL (user content) — repo ID is the safer correlator.
       return withWorktreeSpan({ stage: 'create' }, async () => {
         const repo = store.getRepo(args.repoId)
@@ -1331,6 +2274,13 @@ export function registerWorktreeHandlers(
         if (isFolderRepo(repo)) {
           notifyWorktreesChanged(mainWindow, repo.id)
         }
+
+        options?.onWorktreeLifecycle?.({
+          kind: 'created',
+          worktreeId: result.worktree.id,
+          path: result.worktree.path,
+          branch: result.worktree.branch
+        })
 
         return result
       })
@@ -1448,10 +2398,9 @@ export function registerWorktreeHandlers(
       if (!repo) {
         throw new Error(`Repo not found: ${repoId}`)
       }
-      const inFlightKey = getWorktreeRemovalInFlightKey(
-        args.worktreeId,
-        getRepoExecutionHostId(repo)
-      )
+      // The resolved repo supplies host ownership when legacy callers omit args.hostId.
+      const removalHostId = getRepoExecutionHostId(repo)
+      const inFlightKey = getWorktreeRemovalInFlightKey(args.worktreeId, removalHostId)
       const optionsKey = getWorktreeRemovalOptionsKey(args)
       const inFlightRemoval = worktreeRemovalsInFlight.get(inFlightKey)
       if (inFlightRemoval) {
@@ -1463,177 +2412,154 @@ export function registerWorktreeHandlers(
 
       // Why: concurrent stale-toast/double-click/sidebar races can hit the same worktree; share the op so only one path touches Git and disk.
       const removal = (async (): Promise<RemoveWorktreeResult> => {
-        if (isFolderRepo(repo)) {
-          if (args.worktreeId === getFolderWorkspaceRootId(repo)) {
-            throw new Error(
-              'Cannot delete the project root workspace. Remove the folder project instead.'
-            )
-          }
-          // Why: folder workspaces share one root, so there's no Git remove step to close shells; sweep PTYs before dropping metadata.
-          await killAllProcessesForWorktree(args.worktreeId, {
-            runtime,
-            localProvider: getLocalPtyProvider(),
-            onPtyStopped: clearProviderPtyState
-          }).catch((err) => {
-            console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
-          })
-          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-          preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-          notifyWorktreesChanged(mainWindow, repoId)
-          return {}
-        }
-
-        // Why: renderer-supplied worktreeId embeds a path; re-derive the canonical path from git before any destructive action.
-        const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
-        const localWorktreeGitOptions = repo.connectionId
-          ? {}
-          : getLocalProjectWorktreeGitOptions(store, repo)
-        const hasLocalWorktreeGitOptions = Object.keys(localWorktreeGitOptions).length > 0
-        const registeredWorktrees = repo.connectionId
-          ? await provider!.listWorktrees(repo.path)
-          : hasLocalWorktreeGitOptions
-            ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
-            : await listGitWorktreesStrict(repo.path)
-        const removedMeta = store.getWorktreeMeta(args.worktreeId)
-        const removedPushTarget = removedMeta?.pushTarget
-        const registeredWorktree = findRegisteredDeletableWorktree(
-          repo.path,
-          worktreePath,
-          registeredWorktrees
-        )
-        if (!registeredWorktree) {
-          const fsProvider = repo.connectionId ? getSshFilesystemProvider(repo.connectionId) : null
-          let canCleanOrphanedDirectory = false
-          if (
-            canCleanupUnregisteredOrcaWorktreeDirectory({
-              meta: removedMeta
+        // Why: worktree.create is traced; delete freezes were invisible without a matching worktree.remove parent span.
+        return withWorktreeSpan({ stage: 'remove', path: worktreePath }, async () => {
+          if (isFolderRepo(repo)) {
+            if (args.worktreeId === getFolderWorkspaceRootId(repo)) {
+              throw new Error(
+                'Cannot delete the project root workspace. Remove the folder project instead.'
+              )
+            }
+            // Why: folder workspaces share one root, so there's no Git remove step to close shells; sweep PTYs before dropping metadata.
+            await withWorktreeRemoveStageSpan('pty_sweep', 'folder', async () => {
+              // Folder projects can be SSH-backed, so fence the sweep to the owning host exactly
+              // like the git paths — the local inventory must never reach a remote workspace's id.
+              // The resolved repo is authoritative here: path-derived metadata is shared by
+              // same-id host copies and can describe a different owner's workspace.
+              const ownerHost = parseExecutionHostId(removalHostId)
+              const sshPtyProvider =
+                ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
+              const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'
+              await killAllProcessesForWorktree(args.worktreeId, {
+                runtime,
+                resolvedWorktreeId: args.worktreeId,
+                ...(ownerHost?.kind === 'ssh' ? { resolvedConnectionId: ownerHost.targetId } : {}),
+                ...(ownerHost?.kind === 'runtime'
+                  ? { resolvedRuntimeEnvironmentId: ownerHost.environmentId }
+                  : {}),
+                localProvider: sshPtyProvider ?? getLocalPtyProvider(),
+                onPtyStopped: clearProviderPtyState,
+                ...(externalHost
+                  ? {
+                      includeProviderInventory:
+                        ownerHost?.kind === 'ssh' && Boolean(sshPtyProvider),
+                      includeLocalRegistry: false
+                    }
+                  : {})
+              }).catch((err) => {
+                console.warn(`[worktree-teardown] failed for ${args.worktreeId}:`, err)
+              })
             })
-          ) {
-            if (repo.connectionId) {
-              if (!fsProvider) {
-                throw new Error('SSH filesystem provider unavailable')
-              }
-              if (!fsProvider.lstat) {
-                throw new Error('SSH filesystem provider lstat unavailable')
-              }
-              canCleanOrphanedDirectory = await canSafelyRemoveOrphanedWorktreeDirectory(
-                worktreePath,
-                repo.path,
-                (path) => fsProvider.lstat!(path),
-                (path) => fsProvider.readFile(path)
-              )
-            } else {
-              const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
-              canCleanOrphanedDirectory =
-                !isDangerousWorktreeRemovalPath(worktreePath, repo.path) &&
-                (await canSafelyRemoveOrphanedWorktreeDirectory(
-                  toLocalWorktreeRuntimePath(worktreePath, localWorktreeGitOptions),
-                  toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-                  access.statPath,
-                  access.readPath
-                ))
-            }
-          }
-          if (canCleanOrphanedDirectory) {
-            assertWorktreeDoesNotContainRegisteredWorktree(worktreePath, registeredWorktrees)
-            if (!args.force) {
-              throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
-            }
-            if (repo.connectionId) {
-              const removalGate = await runtime.acquireFileWatcherRemoval(
-                worktreePath,
-                repo.connectionId
-              )
-              let removalCompleted = false
-              try {
-                await stopPtysForDestructiveWorktreeRemoval(
-                  runtime,
-                  args.worktreeId,
-                  repo.connectionId
-                )
-                await fsProvider!.deletePath(worktreePath, true)
-                removalCompleted = true
-              } finally {
-                await removalGate.finish(removalCompleted)
-              }
-              await cleanupUnusedWorktreePushTargetRemoteSsh(
-                provider!,
-                repo.path,
-                args.worktreeId,
-                removedPushTarget,
-                store
-              )
-            } else {
-              const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
-              let removalCompleted = false
-              try {
-                await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId)
-                await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
-                removalCompleted = true
-              } finally {
-                await removalGate.finish(removalCompleted)
-              }
-              await cleanupUnusedWorktreePushTargetRemote(
-                repo.path,
-                args.worktreeId,
-                removedPushTarget,
-                store,
-                localWorktreeGitOptions
-              )
-              invalidateAuthorizedRootsCache()
-            }
-            runtime.clearOptimisticReconcileToken(args.worktreeId)
-            await maybePruneReviewHeadRefsAfterWorktreeDelete({
-              store,
-              repo,
-              repoId,
-              worktreeId: args.worktreeId,
-              meta: removedMeta,
-              localGitOptions: localWorktreeGitOptions,
-              sshGitProvider: provider
+            await withWorktreeRemoveStageSpan('metadata_purge', 'folder', async () => {
+              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
             })
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
             preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
             notifyWorktreesChanged(mainWindow, repoId)
             return {}
           }
-          if (!repo.connectionId) {
-            const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
-            const runtimeWorktreePath = toLocalWorktreeRuntimePath(
-              worktreePath,
-              localWorktreeGitOptions
-            )
+
+          // Why: renderer-supplied worktreeId embeds a path; re-derive the canonical path from git before any destructive action.
+          const provider = repo.connectionId ? requireSshGitProvider(repo.connectionId) : null
+          const localWorktreeGitOptions = repo.connectionId
+            ? {}
+            : getLocalProjectWorktreeGitOptions(store, repo)
+          const hasLocalWorktreeGitOptions = Object.keys(localWorktreeGitOptions).length > 0
+          const registeredWorktrees = repo.connectionId
+            ? await provider!.listWorktrees(repo.path)
+            : hasLocalWorktreeGitOptions
+              ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
+              : await listGitWorktreesStrict(repo.path)
+          const removedMeta = store.getWorktreeMeta(args.worktreeId)
+          const removedPushTarget = removedMeta?.pushTarget
+          const registeredWorktree = findRegisteredDeletableWorktree(
+            repo.path,
+            worktreePath,
+            registeredWorktrees
+          )
+          if (!registeredWorktree) {
+            const fsProvider = repo.connectionId
+              ? getSshFilesystemProvider(repo.connectionId)
+              : null
+            let canCleanOrphanedDirectory = false
             if (
-              await canCleanupUnregisteredOrcaLeftoverDirectory({
-                meta: removedMeta,
-                worktreePath,
-                runtimeWorktreePath,
-                repo,
-                runtimeRepoPath: toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-                registeredWorktrees,
-                statPath: access.statPath,
-                isGitRepository: (path) => isLocalGitRepository(path, localWorktreeGitOptions)
+              canCleanupUnregisteredOrcaWorktreeDirectory({
+                meta: removedMeta
               })
             ) {
+              if (repo.connectionId) {
+                if (!fsProvider) {
+                  throw new Error('SSH filesystem provider unavailable')
+                }
+                if (!fsProvider.lstat) {
+                  throw new Error('SSH filesystem provider lstat unavailable')
+                }
+                canCleanOrphanedDirectory = await canSafelyRemoveOrphanedWorktreeDirectory(
+                  worktreePath,
+                  repo.path,
+                  (path) => fsProvider.lstat!(path),
+                  (path) => fsProvider.readFile(path)
+                )
+              } else {
+                const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
+                canCleanOrphanedDirectory =
+                  !isDangerousWorktreeRemovalPath(worktreePath, repo.path) &&
+                  (await canSafelyRemoveOrphanedWorktreeDirectory(
+                    toLocalWorktreeRuntimePath(worktreePath, localWorktreeGitOptions),
+                    toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
+                    access.statPath,
+                    access.readPath
+                  ))
+              }
+            }
+            if (canCleanOrphanedDirectory) {
+              assertWorktreeDoesNotContainRegisteredWorktree(worktreePath, registeredWorktrees)
               if (!args.force) {
                 throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
               }
-              const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
-              let removalCompleted = false
-              try {
-                await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId)
-                await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
-                removalCompleted = true
-              } finally {
-                await removalGate.finish(removalCompleted)
+              if (repo.connectionId) {
+                const removalGate = await runtime.acquireFileWatcherRemoval(
+                  worktreePath,
+                  repo.connectionId
+                )
+                let removalCompleted = false
+                try {
+                  await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
+                    connectionId: repo.connectionId,
+                    allowUnverifiedStop: args.allowUnverifiedPtyStop
+                  })
+                  await fsProvider!.deletePath(worktreePath, true)
+                  removalCompleted = true
+                } finally {
+                  await removalGate.finish(removalCompleted)
+                }
+                await cleanupUnusedWorktreePushTargetRemoteSsh(
+                  provider!,
+                  repo.path,
+                  args.worktreeId,
+                  removedPushTarget,
+                  store
+                )
+              } else {
+                const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
+                let removalCompleted = false
+                try {
+                  await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
+                    allowUnverifiedStop: args.allowUnverifiedPtyStop
+                  })
+                  await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
+                  removalCompleted = true
+                } finally {
+                  await removalGate.finish(removalCompleted)
+                }
+                await cleanupUnusedWorktreePushTargetRemote(
+                  repo.path,
+                  args.worktreeId,
+                  removedPushTarget,
+                  store,
+                  localWorktreeGitOptions
+                )
+                invalidateAuthorizedRootsCache()
               }
-              await cleanupUnusedWorktreePushTargetRemote(
-                repo.path,
-                args.worktreeId,
-                removedPushTarget,
-                store,
-                localWorktreeGitOptions
-              )
               runtime.clearOptimisticReconcileToken(args.worktreeId)
               await maybePruneReviewHeadRefsAfterWorktreeDelete({
                 store,
@@ -1644,37 +2570,154 @@ export function registerWorktreeHandlers(
                 localGitOptions: localWorktreeGitOptions,
                 sshGitProvider: provider
               })
-              removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
               preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-              invalidateAuthorizedRootsCache()
               notifyWorktreesChanged(mainWindow, repoId)
               return {}
             }
-          }
-          if (await isAlreadyRemovedWorktreePath(repo, worktreePath, localWorktreeGitOptions)) {
-            if (!args.force && !removedMeta) {
-              // Why: without persisted metadata, require the renderer recovery path before deleting Orca-only state for an unregistered path.
-              throw new Error(UNREGISTERED_MISSING_WORKTREE_MESSAGE)
-            }
-            // Why: a manually deleted worktree is already gone; persisted metadata proves it was an Orca-known row, so no force is needed.
-            if (repo.connectionId) {
-              await cleanupUnusedWorktreePushTargetRemoteSsh(
-                provider!,
-                repo.path,
-                args.worktreeId,
-                removedPushTarget,
-                store
-              )
-            } else {
-              await cleanupUnusedWorktreePushTargetRemote(
-                repo.path,
-                args.worktreeId,
-                removedPushTarget,
-                store,
+            if (!repo.connectionId) {
+              const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
+              const runtimeWorktreePath = toLocalWorktreeRuntimePath(
+                worktreePath,
                 localWorktreeGitOptions
               )
-              invalidateAuthorizedRootsCache()
+              if (
+                await canCleanupUnregisteredOrcaLeftoverDirectory({
+                  meta: removedMeta,
+                  worktreePath,
+                  runtimeWorktreePath,
+                  repo,
+                  runtimeRepoPath: toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
+                  registeredWorktrees,
+                  statPath: access.statPath,
+                  isGitRepository: (path) => isLocalGitRepository(path, localWorktreeGitOptions)
+                })
+              ) {
+                if (!args.force) {
+                  throw new Error(ORPHANED_WORKTREE_DIRECTORY_MESSAGE)
+                }
+                const removalGate = await runtime.acquireFileWatcherRemoval(worktreePath)
+                let removalCompleted = false
+                try {
+                  await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
+                    allowUnverifiedStop: args.allowUnverifiedPtyStop
+                  })
+                  await removeLocalWorktreePath(worktreePath, localWorktreeGitOptions)
+                  removalCompleted = true
+                } finally {
+                  await removalGate.finish(removalCompleted)
+                }
+                await cleanupUnusedWorktreePushTargetRemote(
+                  repo.path,
+                  args.worktreeId,
+                  removedPushTarget,
+                  store,
+                  localWorktreeGitOptions
+                )
+                runtime.clearOptimisticReconcileToken(args.worktreeId)
+                await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                  store,
+                  repo,
+                  repoId,
+                  worktreeId: args.worktreeId,
+                  meta: removedMeta,
+                  localGitOptions: localWorktreeGitOptions,
+                  sshGitProvider: provider
+                })
+                removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+                preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+                invalidateAuthorizedRootsCache()
+                notifyWorktreesChanged(mainWindow, repoId)
+                return {}
+              }
             }
+            if (await isAlreadyRemovedWorktreePath(repo, worktreePath, localWorktreeGitOptions)) {
+              if (!args.force && !removedMeta) {
+                // Why: without persisted metadata, require the renderer recovery path before deleting Orca-only state for an unregistered path.
+                throw new Error(UNREGISTERED_MISSING_WORKTREE_MESSAGE)
+              }
+              // Why: a manually deleted worktree is already gone; persisted metadata proves it was an Orca-known row, so no force is needed.
+              if (repo.connectionId) {
+                await cleanupUnusedWorktreePushTargetRemoteSsh(
+                  provider!,
+                  repo.path,
+                  args.worktreeId,
+                  removedPushTarget,
+                  store
+                )
+              } else {
+                await cleanupUnusedWorktreePushTargetRemote(
+                  repo.path,
+                  args.worktreeId,
+                  removedPushTarget,
+                  store,
+                  localWorktreeGitOptions
+                )
+                invalidateAuthorizedRootsCache()
+              }
+              runtime.clearOptimisticReconcileToken(args.worktreeId)
+              await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                store,
+                repo,
+                repoId,
+                worktreeId: args.worktreeId,
+                meta: removedMeta,
+                localGitOptions: localWorktreeGitOptions,
+                sshGitProvider: provider
+              })
+              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+              notifyWorktreesChanged(mainWindow, repoId)
+              return {}
+            }
+            throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
+          }
+          const canonicalWorktreePath = registeredWorktree.path
+          const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
+
+          // Why: a Git lock must block before archive hooks or linked-path cleanup mutate the workspace; dirty-file force is separate.
+          try {
+            assertWorktreeUnlockedForRemoval(registeredWorktree)
+          } catch (error) {
+            throw new Error(
+              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+            )
+          }
+
+          // Why: a prior forced Windows recovery can delete the dir but leave a stale Git registration; verify before clearing metadata.
+          if (
+            !repo.connectionId &&
+            args.force === true &&
+            process.platform === 'win32' &&
+            (isWindowsAbsolutePathLike(canonicalWorktreePath) ||
+              !!localWorktreeGitOptions.wslDistro) &&
+            removedMeta &&
+            (await isAlreadyRemovedWorktreePath(
+              repo,
+              canonicalWorktreePath,
+              localWorktreeGitOptions
+            ))
+          ) {
+            const removalResult = await removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval({
+              canonicalWorktreePath,
+              repoPath: repo.path,
+              localWorktreeGitOptions,
+              registeredWorktree,
+              deleteBranch
+            })
+            await cleanupUnusedWorktreePushTargetRemote(
+              repo.path,
+              args.worktreeId,
+              removedPushTarget,
+              store,
+              localWorktreeGitOptions
+            )
+            rememberPreservedBranchCleanupTarget(
+              args.worktreeId,
+              removalResult,
+              registeredWorktree.head,
+              removedPushTarget
+            )
             runtime.clearOptimisticReconcileToken(args.worktreeId)
             await maybePruneReviewHeadRefsAfterWorktreeDelete({
               store,
@@ -1685,42 +2728,284 @@ export function registerWorktreeHandlers(
               localGitOptions: localWorktreeGitOptions,
               sshGitProvider: provider
             })
-            removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-            preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+            removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+            invalidateAuthorizedRootsCache()
             notifyWorktreesChanged(mainWindow, repoId)
-            return {}
+            return removalResult ?? {}
           }
-          throw new Error(`Refusing to delete unregistered worktree path: ${worktreePath}`)
-        }
-        const canonicalWorktreePath = registeredWorktree.path
-        const deleteBranch = removedMeta?.preserveBranchOnDelete !== true
 
-        // Why: a Git lock must block before archive hooks or linked-path cleanup mutate the workspace; dirty-file force is separate.
-        try {
-          assertWorktreeUnlockedForRemoval(registeredWorktree)
-        } catch (error) {
-          throw new Error(
-            formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-          )
-        }
+          // Run archive hook before removal so teardown scripts still see the worktree directory.
+          const hooks = await getArchiveHooksForRemoval(repo)
+          const archiveScript = hooks?.scripts.archive
+          if (archiveScript && !args.skipArchive) {
+            // Why the branch on connectionId: this block is shared by both flows, so a hardcoded
+            // 'remote' would file every local archive hook under the SSH breakdown.
+            await withWorktreeRemoveStageSpan(
+              'archive_hook',
+              repo.connectionId ? 'remote' : 'local',
+              async () => {
+                const result = repo.connectionId
+                  ? await runRemoteArchiveHook(repo, canonicalWorktreePath, archiveScript)
+                  : await runHook(
+                      'archive',
+                      canonicalWorktreePath,
+                      repo,
+                      undefined,
+                      localWorktreeGitOptions
+                    )
+                if (!result.success) {
+                  console.error(
+                    `[hooks] archive hook failed for ${canonicalWorktreePath}:`,
+                    result.output
+                  )
+                }
+              }
+            )
+          }
 
-        // Why: a prior forced Windows recovery can delete the dir but leave a stale Git registration; verify before clearing metadata.
-        if (
-          !repo.connectionId &&
-          args.force === true &&
-          process.platform === 'win32' &&
-          (isWindowsAbsolutePathLike(canonicalWorktreePath) ||
-            !!localWorktreeGitOptions.wslDistro) &&
-          removedMeta &&
-          (await isAlreadyRemovedWorktreePath(repo, canonicalWorktreePath, localWorktreeGitOptions))
-        ) {
-          const removalResult = await removeStaleLocalWorktreeRegistrationAfterFilesystemRemoval({
+          const remoteConnectionId = repo.connectionId ?? undefined
+          if (remoteConnectionId) {
+            // Why: SSH deletion mirrors the local flow — hooks run while the directory is intact, then the clean check guards removal.
+            if (!args.force) {
+              const { clean, stdout } = await provider!.worktreeIsClean(canonicalWorktreePath)
+              if (!clean) {
+                const error = new Error('Worktree has uncommitted or untracked changes.')
+                ;(error as Error & { stdout?: string }).stdout = stdout
+                throw error
+              }
+            }
+
+            const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
+            const removalGate = await withWorktreeRemoveStageSpan(
+              'watcher_gate',
+              'remote',
+              async () =>
+                runtime.acquireFileWatcherRemoval(canonicalWorktreePath, remoteConnectionId)
+            )
+            let rawRemovalResult: RemoveWorktreeResult | undefined
+            let removalCompleted = false
+            try {
+              await withWorktreeRemoveStageSpan('pty_sweep', 'remote', async () => {
+                await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
+                  connectionId: remoteConnectionId,
+                  allowUnverifiedStop: args.allowUnverifiedPtyStop
+                })
+              })
+              rawRemovalResult = await withWorktreeRemoveStageSpan(
+                'git_remove',
+                'remote',
+                async () =>
+                  Object.keys(remoteRemoveOptions).length > 0
+                    ? provider!.removeWorktree(
+                        canonicalWorktreePath,
+                        args.force,
+                        remoteRemoveOptions
+                      )
+                    : provider!.removeWorktree(canonicalWorktreePath, args.force)
+              )
+              removalCompleted = true
+            } finally {
+              await removalGate.finish(removalCompleted)
+            }
+            const removalResult = preserveBranchHeadFallback(
+              rawRemovalResult,
+              registeredWorktree.head
+            )
+            await cleanupUnusedWorktreePushTargetRemoteSsh(
+              provider!,
+              repo.path,
+              args.worktreeId,
+              removedPushTarget,
+              store
+            )
+            rememberPreservedBranchCleanupTarget(
+              args.worktreeId,
+              removalResult,
+              registeredWorktree.head,
+              removedPushTarget
+            )
+            runtime.clearOptimisticReconcileToken(args.worktreeId)
+            await maybePruneReviewHeadRefsAfterWorktreeDelete({
+              store,
+              repo,
+              repoId,
+              worktreeId: args.worktreeId,
+              meta: removedMeta,
+              localGitOptions: localWorktreeGitOptions,
+              sshGitProvider: provider
+            })
+            await withWorktreeRemoveStageSpan('metadata_purge', 'remote', async () => {
+              removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+            })
+            notifyWorktreesChanged(mainWindow, repoId)
+            return removalResult ?? {}
+          }
+
+          const refreshedWorktrees = hasLocalWorktreeGitOptions
+            ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
+            : await listGitWorktreesStrict(repo.path)
+          const refreshedRegisteredWorktree = findRegisteredDeletableWorktree(
+            repo.path,
             canonicalWorktreePath,
-            repoPath: repo.path,
-            localWorktreeGitOptions,
-            registeredWorktree,
-            deleteBranch
-          })
+            refreshedWorktrees
+          )
+          if (!refreshedRegisteredWorktree) {
+            throw new Error(
+              `Worktree registration changed during deletion: ${canonicalWorktreePath}. Retry deletion.`
+            )
+          }
+          try {
+            // Why: an archive hook can race another Git client that locks the row; recheck before linked-path/watcher/terminal teardown.
+            assertWorktreeUnlockedForRemoval(refreshedRegisteredWorktree)
+          } catch (error) {
+            throw new Error(
+              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+            )
+          }
+
+          // Why: `orca.yaml` shared directories are symlinked in too, and a
+          // directory-only ignore rule leaves those links untracked, so removal must
+          // tolerate and unlink them exactly like the per-user shared paths.
+          const linkedPaths = getWorktreeSharedLinkPaths(repo)
+          const ignoredLinkedPaths = args.force
+            ? []
+            : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)
+          try {
+            await (hasLocalWorktreeGitOptions
+              ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
+                  ...localWorktreeGitOptions,
+                  ...(ignoredLinkedPaths.length > 0
+                    ? { ignoredUntrackedPaths: ignoredLinkedPaths }
+                    : {})
+                })
+              : ignoredLinkedPaths.length > 0
+                ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
+                    ignoredUntrackedPaths: ignoredLinkedPaths
+                  })
+                : assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false))
+          } catch (error) {
+            if (!isOrphanCompatiblePreflightError(error)) {
+              throw new Error(
+                formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+              )
+            }
+            // Why: Git can still classify this as an orphan after preflight; keep strict PTY teardown before any recursive fallback deletion.
+          }
+
+          let removalResult: RemoveWorktreeResult | undefined
+          const removalGate = await withWorktreeRemoveStageSpan('watcher_gate', 'local', async () =>
+            runtime.acquireFileWatcherRemoval(canonicalWorktreePath)
+          )
+          let removalCompleted = false
+          try {
+            // Why: hold the watcher/terminal gate through Git and any recursive fallback so no late spawn recreates a native handle.
+            // Linked-path deletion is destructive too, so PTYs must release every handle before Windows or WSL filesystem cleanup starts.
+            await withWorktreeRemoveStageSpan('pty_sweep', 'local', async () => {
+              await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, {
+                allowUnverifiedStop: args.allowUnverifiedPtyStop
+              })
+            })
+
+            // Why: preflight only ignored these paths, not mutated them; keep watcher installs fenced through Git removal.
+            if (linkedPaths.length > 0) {
+              await removeWorktreeLinkedPaths(canonicalWorktreePath, linkedPaths)
+            }
+
+            try {
+              const removeOptions = {
+                ...(!deleteBranch ? { deleteBranch } : {}),
+                // Why: reuse the authoritative worktree list already computed here instead of rescanning siblings on the hot delete path.
+                knownRemovedWorktree: refreshedRegisteredWorktree,
+                ...(hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {})
+              }
+              removalResult = preserveBranchHeadFallback(
+                await withWorktreeRemoveStageSpan('git_remove', 'local', async () =>
+                  removeWorktree(
+                    repo.path,
+                    canonicalWorktreePath,
+                    args.force ?? false,
+                    removeOptions
+                  )
+                ),
+                refreshedRegisteredWorktree.head
+              )
+            } catch (error) {
+              // Why: Git for Windows can deregister a clean worktree before its recursive filesystem deletion fails transiently.
+              const recoveredRemovalResult = await recoverLocalWindowsWorktreeRemoval({
+                error,
+                force: args.force ?? false,
+                canonicalWorktreePath,
+                repoPath: repo.path,
+                localWorktreeGitOptions,
+                registeredWorktree: refreshedRegisteredWorktree,
+                deleteBranch,
+                closeWatcher: (worktreePath) => runtime.closeFileWatchersForRemoval(worktreePath)
+              })
+              if (recoveredRemovalResult) {
+                removalResult = recoveredRemovalResult
+                removalCompleted = true
+              } else if (isOrphanedWorktreeError(error)) {
+                // If git no longer tracks this worktree, clean up the directory and metadata
+                console.warn(
+                  `[worktrees] Orphaned worktree detected at ${canonicalWorktreePath}, cleaning up`
+                )
+                const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
+                if (
+                  await canSafelyRemoveOrphanedWorktreeDirectory(
+                    toLocalWorktreeRuntimePath(canonicalWorktreePath, localWorktreeGitOptions),
+                    toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
+                    access.statPath,
+                    access.readPath
+                  )
+                ) {
+                  await runtime.closeFileWatchersForRemoval(canonicalWorktreePath)
+                  await removeLocalWorktreePath(
+                    canonicalWorktreePath,
+                    localWorktreeGitOptions
+                  ).catch(() => {})
+                } else {
+                  console.warn(
+                    `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
+                  )
+                }
+                // Why: remove failed so git still tracks it (.git/worktrees/<name>); prune or the stale entry keeps its branch locked.
+                await gitExecFileAsync(['worktree', 'prune'], {
+                  cwd: repo.path,
+                  ...localWorktreeGitOptions
+                }).catch(() => {})
+                await cleanupUnusedWorktreePushTargetRemote(
+                  repo.path,
+                  args.worktreeId,
+                  removedPushTarget,
+                  store,
+                  localWorktreeGitOptions
+                )
+                runtime.clearOptimisticReconcileToken(args.worktreeId)
+                await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                  store,
+                  repo,
+                  repoId,
+                  worktreeId: args.worktreeId,
+                  meta: removedMeta,
+                  localGitOptions: localWorktreeGitOptions,
+                  sshGitProvider: null
+                })
+                removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+                preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
+                invalidateAuthorizedRootsCache()
+                notifyWorktreesChanged(mainWindow, repoId)
+                removalCompleted = true
+                return {}
+              } else {
+                throw new Error(
+                  formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
+                )
+              }
+            }
+            removalCompleted = true
+          } finally {
+            await removalGate.finish(removalCompleted)
+          }
           await cleanupUnusedWorktreePushTargetRemote(
             repo.path,
             args.worktreeId,
@@ -1731,7 +3016,7 @@ export function registerWorktreeHandlers(
           rememberPreservedBranchCleanupTarget(
             args.worktreeId,
             removalResult,
-            registeredWorktree.head,
+            refreshedRegisteredWorktree.head,
             removedPushTarget
           )
           runtime.clearOptimisticReconcileToken(args.worktreeId)
@@ -1742,277 +3027,28 @@ export function registerWorktreeHandlers(
             worktreeId: args.worktreeId,
             meta: removedMeta,
             localGitOptions: localWorktreeGitOptions,
-            sshGitProvider: provider
+            sshGitProvider: null
           })
-          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-          invalidateAuthorizedRootsCache()
+          await withWorktreeRemoveStageSpan('metadata_purge', 'local', async () => {
+            removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
+          })
+          await withWorktreeRemoveStageSpan('cache_invalidation', 'local', async () => {
+            invalidateAuthorizedRootsCache()
+          })
+
           notifyWorktreesChanged(mainWindow, repoId)
           return removalResult ?? {}
-        }
-
-        // Run archive hook before removal so teardown scripts still see the worktree directory.
-        const hooks = await getArchiveHooksForRemoval(repo)
-        if (hooks?.scripts.archive && !args.skipArchive) {
-          const result = repo.connectionId
-            ? await runRemoteArchiveHook(repo, canonicalWorktreePath, hooks.scripts.archive)
-            : await runHook(
-                'archive',
-                canonicalWorktreePath,
-                repo,
-                undefined,
-                localWorktreeGitOptions
-              )
-          if (!result.success) {
-            console.error(
-              `[hooks] archive hook failed for ${canonicalWorktreePath}:`,
-              result.output
-            )
-          }
-        }
-
-        if (repo.connectionId) {
-          // Why: SSH deletion mirrors the local flow — hooks run while the directory is intact, then the clean check guards removal.
-          if (!args.force) {
-            const { clean, stdout } = await provider!.worktreeIsClean(canonicalWorktreePath)
-            if (!clean) {
-              const error = new Error('Worktree has uncommitted or untracked changes.')
-              ;(error as Error & { stdout?: string }).stdout = stdout
-              throw error
-            }
-          }
-
-          const remoteRemoveOptions = !deleteBranch ? { deleteBranch } : {}
-          const removalGate = await runtime.acquireFileWatcherRemoval(
-            canonicalWorktreePath,
-            repo.connectionId
-          )
-          let rawRemovalResult: RemoveWorktreeResult | undefined
-          let removalCompleted = false
-          try {
-            await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId, repo.connectionId)
-            rawRemovalResult = await (Object.keys(remoteRemoveOptions).length > 0
-              ? provider!.removeWorktree(canonicalWorktreePath, args.force, remoteRemoveOptions)
-              : provider!.removeWorktree(canonicalWorktreePath, args.force))
-            removalCompleted = true
-          } finally {
-            await removalGate.finish(removalCompleted)
-          }
-          const removalResult = preserveBranchHeadFallback(
-            rawRemovalResult,
-            registeredWorktree.head
-          )
-          await cleanupUnusedWorktreePushTargetRemoteSsh(
-            provider!,
-            repo.path,
-            args.worktreeId,
-            removedPushTarget,
-            store
-          )
-          rememberPreservedBranchCleanupTarget(
-            args.worktreeId,
-            removalResult,
-            registeredWorktree.head,
-            removedPushTarget
-          )
-          runtime.clearOptimisticReconcileToken(args.worktreeId)
-          await maybePruneReviewHeadRefsAfterWorktreeDelete({
-            store,
-            repo,
-            repoId,
-            worktreeId: args.worktreeId,
-            meta: removedMeta,
-            localGitOptions: localWorktreeGitOptions,
-            sshGitProvider: provider
-          })
-          removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-          notifyWorktreesChanged(mainWindow, repoId)
-          return removalResult ?? {}
-        }
-
-        const refreshedWorktrees = hasLocalWorktreeGitOptions
-          ? await listGitWorktreesStrict(repo.path, localWorktreeGitOptions)
-          : await listGitWorktreesStrict(repo.path)
-        const refreshedRegisteredWorktree = findRegisteredDeletableWorktree(
-          repo.path,
-          canonicalWorktreePath,
-          refreshedWorktrees
-        )
-        if (!refreshedRegisteredWorktree) {
-          throw new Error(
-            `Worktree registration changed during deletion: ${canonicalWorktreePath}. Retry deletion.`
-          )
-        }
-        try {
-          // Why: an archive hook can race another Git client that locks the row; recheck before linked-path/watcher/terminal teardown.
-          assertWorktreeUnlockedForRemoval(refreshedRegisteredWorktree)
-        } catch (error) {
-          throw new Error(
-            formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-          )
-        }
-
-        const linkedPaths = repo.symlinkPaths ?? []
-        const ignoredLinkedPaths = args.force
-          ? []
-          : await findExistingWorktreeSymlinkPaths(canonicalWorktreePath, linkedPaths)
-        try {
-          await (hasLocalWorktreeGitOptions
-            ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
-                ...localWorktreeGitOptions,
-                ...(ignoredLinkedPaths.length > 0
-                  ? { ignoredUntrackedPaths: ignoredLinkedPaths }
-                  : {})
-              })
-            : ignoredLinkedPaths.length > 0
-              ? assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false, {
-                  ignoredUntrackedPaths: ignoredLinkedPaths
-                })
-              : assertWorktreeCleanForRemoval(canonicalWorktreePath, args.force ?? false))
-        } catch (error) {
-          if (!isOrphanCompatiblePreflightError(error)) {
-            throw new Error(
-              formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-            )
-          }
-          // Why: Git can still classify this as an orphan after preflight; keep strict PTY teardown before any recursive fallback deletion.
-        }
-
-        let removalResult: RemoveWorktreeResult | undefined
-        const removalGate = await runtime.acquireFileWatcherRemoval(canonicalWorktreePath)
-        let removalCompleted = false
-        try {
-          // Why: preflight only ignored these paths, not mutated them; keep watcher installs fenced through Git removal.
-          if (linkedPaths.length > 0) {
-            await removeWorktreeLinkedPaths(canonicalWorktreePath, linkedPaths)
-          }
-
-          // Why: hold the watcher/terminal gate through Git and any recursive fallback so no late spawn recreates a native handle.
-          await stopPtysForDestructiveWorktreeRemoval(runtime, args.worktreeId)
-
-          try {
-            const removeOptions = {
-              ...(!deleteBranch ? { deleteBranch } : {}),
-              // Why: reuse the authoritative worktree list already computed here instead of rescanning siblings on the hot delete path.
-              knownRemovedWorktree: refreshedRegisteredWorktree,
-              ...(hasLocalWorktreeGitOptions ? localWorktreeGitOptions : {})
-            }
-            removalResult = preserveBranchHeadFallback(
-              await removeWorktree(
-                repo.path,
-                canonicalWorktreePath,
-                args.force ?? false,
-                removeOptions
-              ),
-              refreshedRegisteredWorktree.head
-            )
-          } catch (error) {
-            // Why: Git for Windows can deregister a clean worktree before its recursive filesystem deletion fails transiently.
-            const recoveredRemovalResult = await recoverLocalWindowsWorktreeRemoval({
-              error,
-              force: args.force ?? false,
-              canonicalWorktreePath,
-              repoPath: repo.path,
-              localWorktreeGitOptions,
-              registeredWorktree: refreshedRegisteredWorktree,
-              deleteBranch,
-              closeWatcher: (worktreePath) => runtime.closeFileWatchersForRemoval(worktreePath)
-            })
-            if (recoveredRemovalResult) {
-              removalResult = recoveredRemovalResult
-              removalCompleted = true
-            } else if (isOrphanedWorktreeError(error)) {
-              // If git no longer tracks this worktree, clean up the directory and metadata
-              console.warn(
-                `[worktrees] Orphaned worktree detected at ${canonicalWorktreePath}, cleaning up`
-              )
-              const access = getLocalWorktreePathAccess(localWorktreeGitOptions)
-              if (
-                await canSafelyRemoveOrphanedWorktreeDirectory(
-                  toLocalWorktreeRuntimePath(canonicalWorktreePath, localWorktreeGitOptions),
-                  toLocalWorktreeRuntimePath(repo.path, localWorktreeGitOptions),
-                  access.statPath,
-                  access.readPath
-                )
-              ) {
-                await runtime.closeFileWatchersForRemoval(canonicalWorktreePath)
-                await removeLocalWorktreePath(canonicalWorktreePath, localWorktreeGitOptions).catch(
-                  () => {}
-                )
-              } else {
-                console.warn(
-                  `[worktrees] Refusing recursive cleanup for unproven worktree directory: ${canonicalWorktreePath}`
-                )
-              }
-              // Why: remove failed so git still tracks it (.git/worktrees/<name>); prune or the stale entry keeps its branch locked.
-              await gitExecFileAsync(['worktree', 'prune'], {
-                cwd: repo.path,
-                ...localWorktreeGitOptions
-              }).catch(() => {})
-              await cleanupUnusedWorktreePushTargetRemote(
-                repo.path,
-                args.worktreeId,
-                removedPushTarget,
-                store,
-                localWorktreeGitOptions
-              )
-              runtime.clearOptimisticReconcileToken(args.worktreeId)
-              await maybePruneReviewHeadRefsAfterWorktreeDelete({
-                store,
-                repo,
-                repoId,
-                worktreeId: args.worktreeId,
-                meta: removedMeta,
-                localGitOptions: localWorktreeGitOptions,
-                sshGitProvider: provider
-              })
-              removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-              preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
-              invalidateAuthorizedRootsCache()
-              notifyWorktreesChanged(mainWindow, repoId)
-              removalCompleted = true
-              return {}
-            } else {
-              throw new Error(
-                formatWorktreeRemovalError(error, canonicalWorktreePath, args.force ?? false)
-              )
-            }
-          }
-          removalCompleted = true
-        } finally {
-          await removalGate.finish(removalCompleted)
-        }
-        await cleanupUnusedWorktreePushTargetRemote(
-          repo.path,
-          args.worktreeId,
-          removedPushTarget,
-          store,
-          localWorktreeGitOptions
-        )
-        rememberPreservedBranchCleanupTarget(
-          args.worktreeId,
-          removalResult,
-          refreshedRegisteredWorktree.head,
-          removedPushTarget
-        )
-        runtime.clearOptimisticReconcileToken(args.worktreeId)
-        await maybePruneReviewHeadRefsAfterWorktreeDelete({
-          store,
-          repo,
-          repoId,
-          worktreeId: args.worktreeId,
-          meta: removedMeta,
-          localGitOptions: localWorktreeGitOptions,
-          sshGitProvider: null
         })
-        removeWorktreeMetadataAndTransientState(store, args.worktreeId)
-        invalidateAuthorizedRootsCache()
-
-        notifyWorktreesChanged(mainWindow, repoId)
-        return removalResult ?? {}
       })()
       worktreeRemovalsInFlight.set(inFlightKey, { optionsKey, promise: removal })
       try {
-        return await removal
+        const result = await removal
+        options?.onWorktreeLifecycle?.({
+          kind: 'removed',
+          worktreeId: args.worktreeId,
+          path: parseWorktreeId(args.worktreeId).worktreePath
+        })
+        return result
       } finally {
         if (worktreeRemovalsInFlight.get(inFlightKey)?.promise === removal) {
           worktreeRemovalsInFlight.delete(inFlightKey)
@@ -2030,13 +3066,12 @@ export function registerWorktreeHandlers(
     ): Promise<RemoveWorktreeResult> => {
       const { repoId } = parseWorktreeId(args.worktreeId)
       const repo = getRepoForWorktreeRemoval(store, repoId, args.hostId)
-      if (!repo) {
-        throw new Error(`Repo not found: ${repoId}`)
-      }
-      // Why: share the removal in-flight map so concurrent remove and forgetLocal on the same id can't both mutate metadata.
+      // Repo-first (unlike owner resolution below) so this key matches worktrees:remove's; meta only covers ownerless forgets.
       const inFlightKey = getWorktreeRemovalInFlightKey(
         args.worktreeId,
-        getRepoExecutionHostId(repo)
+        repo
+          ? getRepoExecutionHostId(repo)
+          : (store.getWorktreeMeta(args.worktreeId)?.hostId ?? args.hostId)
       )
       const optionsKey = 'forget-local'
       const inFlight = worktreeRemovalsInFlight.get(inFlightKey)
@@ -2048,23 +3083,50 @@ export function registerWorktreeHandlers(
       }
 
       const forget = (async (): Promise<RemoveWorktreeResult> => {
-        if (isFolderRepo(repo) && args.worktreeId === getFolderWorkspaceRootId(repo)) {
+        // Ambiguous repo lookup must not bypass a live folder root's deletion guard.
+        const isFolderRootOf = (candidate: Repo): boolean =>
+          isFolderRepo(candidate) && args.worktreeId === getFolderWorkspaceRootId(candidate)
+        if (repo ? isFolderRootOf(repo) : store.getRepos().some(isFolderRootOf)) {
           throw new Error(
             'Cannot delete the project root workspace. Remove the folder project instead.'
           )
         }
 
-        // Why: best-effort PTY sweep; resolves synchronously for a dead SSH relay (tombstoned lease) so it never hangs.
+        const ownerHostId = resolveWorktreeRemovalOwnerHostId(
+          store,
+          args.worktreeId,
+          repo,
+          args.hostId
+        )
+        const ownerHost = parseExecutionHostId(ownerHostId)
+        const sshPtyProvider =
+          ownerHost?.kind === 'ssh' ? getSshPtyProvider(ownerHost.targetId) : undefined
+        const externalHost = ownerHost?.kind === 'ssh' || ownerHost?.kind === 'runtime'
+        // External host inventories must never sweep a same-id local workspace.
         await killAllProcessesForWorktree(args.worktreeId, {
           runtime,
-          localProvider: getLocalPtyProvider(),
-          onPtyStopped: clearProviderPtyState
+          resolvedWorktreeId: args.worktreeId,
+          ...(ownerHost?.kind === 'ssh' ? { resolvedConnectionId: ownerHost.targetId } : {}),
+          ...(ownerHost?.kind === 'runtime'
+            ? { resolvedRuntimeEnvironmentId: ownerHost.environmentId }
+            : {}),
+          localProvider: sshPtyProvider ?? getLocalPtyProvider(),
+          onPtyStopped: clearProviderPtyState,
+          ...(externalHost
+            ? {
+                includeProviderInventory: ownerHost?.kind === 'ssh' && Boolean(sshPtyProvider),
+                includeLocalRegistry: false
+              }
+            : {})
         }).catch((err) => {
           console.warn(`[worktree-teardown] forget-local failed for ${args.worktreeId}:`, err)
         })
 
         runtime.clearOptimisticReconcileToken(args.worktreeId)
-        removeWorktreeMetadataAndTransientState(store, args.worktreeId)
+        // The resolved owner, not args.hostId: an orphan forget with no hostId still has to purge its SSH/runtime partition.
+        removeWorktreeMetadataAndTransientState(store, args.worktreeId, ownerHost?.id)
+        // Why: cached roots outlive the forgotten workspace, so an ownerless path stays filesystem-authorized until a rebuild.
+        invalidateAuthorizedRootsCache()
         preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
         notifyWorktreesChanged(mainWindow, repoId)
         return {}
@@ -2143,14 +3205,15 @@ export function registerWorktreeHandlers(
   ipcMain.handle(
     'worktrees:updateMeta',
     (_event, args: { worktreeId: string; updates: Partial<WorktreeMeta> }) => {
+      const validatedUpdates = normalizeLinkedWorkItemFields(args.updates)
       const updates =
-        args.updates.displayName !== undefined
+        validatedUpdates.displayName !== undefined
           ? {
-              ...args.updates,
+              ...validatedUpdates,
               pendingFirstAgentMessageRename: false,
               firstAgentMessageRenameError: null
             }
-          : args.updates
+          : validatedUpdates
       const meta = store.setWorktreeMeta(args.worktreeId, stripOrcaProvenanceMetaUpdates(updates))
       // Do NOT notify here: renderer already applied this optimistically; a notification would re-sort the sidebar (bug PR #209).
       if (args.updates.displayName !== undefined) {
@@ -2168,6 +3231,12 @@ export function registerWorktreeHandlers(
       workspaceLineage: store.getAllWorkspaceLineage()
     }
   })
+
+  ipcMain.handle(
+    'worktrees:listLineageForHost',
+    (_event, args: ListDesktopLineageForHostArgs): Promise<HostLineageSnapshot> =>
+      listDesktopLineageForHost(store, runtime, args)
+  )
 
   ipcMain.handle(
     'worktrees:updateLineage',
@@ -2282,71 +3351,75 @@ export function registerWorktreeHandlers(
         repo,
         args.worktreePath,
         args.command,
-        getLocalProjectWorktreeGitOptions(store, repo)
+        getLocalProjectWorktreeGitOptions(store, repo),
+        resolveSetupRunnerShell(store.getSettings())
       )
     }
   )
 
-  ipcMain.handle('hooks:inspectSetupScriptImports', async (_event, args: { repoId: string }) => {
-    const repo = store.getRepo(args.repoId)
-    if (!repo || isFolderRepo(repo)) {
-      return []
-    }
+  ipcMain.handle(
+    'hooks:inspectSetupScriptImports',
+    async (_event, args: { repoId: string; hostId?: ExecutionHostId }) => {
+      const repo = getRepoForWorktreeRemoval(store, args.repoId, args.hostId)
+      if (!repo || isFolderRepo(repo)) {
+        return []
+      }
 
-    return inspectSetupScriptImportCandidates(
-      async (relativePath) => {
-        const filePath = joinWorktreeRelativePath(repo.path, relativePath)
-        if (repo.connectionId) {
-          const fsProvider = getSshFilesystemProvider(repo.connectionId)
-          if (!fsProvider) {
-            return null
-          }
-          try {
-            const result = await fsProvider.readFile(filePath)
-            return result.isBinary ? null : result.content
-          } catch {
-            return null
-          }
-        }
-
-        try {
-          return await readFile(filePath, 'utf-8')
-        } catch (error) {
-          if (!isENOENT(error)) {
-            console.warn('[hooks] Failed to inspect setup script import candidate:', error)
-          }
-          return null
-        }
-      },
-      {
-        fileExists: async (relativePath) => {
+      return inspectSetupScriptImportCandidates(
+        async (relativePath) => {
           const filePath = joinWorktreeRelativePath(repo.path, relativePath)
           if (repo.connectionId) {
             const fsProvider = getSshFilesystemProvider(repo.connectionId)
             if (!fsProvider) {
-              return false
+              return null
             }
             try {
-              const fileStat = await fsProvider.stat(filePath)
-              return fileStat.type !== 'directory'
+              const result = await fsProvider.readFile(filePath)
+              return result.isBinary ? null : result.content
             } catch {
-              return false
+              return null
             }
           }
 
           try {
-            const fileStat = await stat(filePath)
-            return !fileStat.isDirectory()
+            return await readFile(filePath, 'utf-8')
           } catch (error) {
             if (!isENOENT(error)) {
-              console.warn('[hooks] Failed to stat setup script import candidate:', error)
+              console.warn('[hooks] Failed to inspect setup script import candidate:', error)
             }
-            return false
+            return null
+          }
+        },
+        {
+          fileExists: async (relativePath) => {
+            const filePath = joinWorktreeRelativePath(repo.path, relativePath)
+            if (repo.connectionId) {
+              const fsProvider = getSshFilesystemProvider(repo.connectionId)
+              if (!fsProvider) {
+                return false
+              }
+              try {
+                const fileStat = await fsProvider.stat(filePath)
+                return fileStat.type !== 'directory'
+              } catch {
+                return false
+              }
+            }
+
+            try {
+              const fileStat = await stat(filePath)
+              return !fileStat.isDirectory()
+            } catch (error) {
+              if (!isENOENT(error)) {
+                console.warn('[hooks] Failed to stat setup script import candidate:', error)
+              }
+              return false
+            }
           }
         }
-      }
-    )
-  })
+      )
+    }
+  )
 
   ipcMain.handle(
     'hooks:readIssueCommand',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -74,6 +74,7 @@ import {
   removeWorktree
 } from '../git/worktree'
 import { gitExecFileAsync } from '../git/runner'
+import { pruneReviewHeadLocalRefsAfterWorktreeDelete } from '../git/review-head-ref-prune'
 import { withWorktreeRemoveStageSpan, withWorktreeSpan } from '../observability/instrumentation'
 import { resolveGitHubPrStartPoint } from '../github/pr-start-point'
 import {
@@ -314,6 +315,52 @@ function resolveWorktreeRemovalOwnerHostId(
     store.getWorktreeMeta(worktreeId)?.hostId ??
     (repo ? getRepoExecutionHostId(repo) : fallbackHostId)
   )
+}
+
+/** Best-effort: drop durable refs/orca/** pins when the last linked worktree is gone (#10431). */
+async function maybePruneReviewHeadRefsAfterWorktreeDelete(params: {
+  store: Store
+  repo: Repo
+  repoId: string
+  worktreeId: string
+  meta: WorktreeMeta | undefined
+  localGitOptions: { cwd?: string; wslDistro?: string }
+  sshGitProvider: {
+    exec: (args: string[], cwd: string) => Promise<{ stdout: string; stderr: string }>
+  } | null
+}): Promise<void> {
+  try {
+    const gitExec = params.sshGitProvider
+      ? (args: string[]) => params.sshGitProvider!.exec(args, params.repo.path)
+      : undefined
+    // Why: drop meta under the prune lock (not a pre-lock snapshot) so two
+    // concurrent last-worktree deletes cannot both see each other and skip.
+    await pruneReviewHeadLocalRefsAfterWorktreeDelete({
+      repoPath: params.repo.path,
+      repoId: params.repoId,
+      deletedWorktreeId: params.worktreeId,
+      meta: params.meta,
+      finalizeDeletedMetaAndReadSiblings: () => {
+        // Why: sibling detection only; full transient cleanup still runs after prune.
+        params.store.removeWorktreeMeta(params.worktreeId)
+        return params.store.getAllWorktreeMeta()
+      },
+      ...(gitExec ? { gitExec } : {}),
+      ...(params.sshGitProvider
+        ? {}
+        : {
+            localGitOptions: {
+              cwd: params.repo.path,
+              ...params.localGitOptions
+            }
+          })
+    })
+  } catch (error) {
+    console.warn(
+      `[worktrees] Failed to prune durable review-head refs after deleting ${params.worktreeId}:`,
+      error
+    )
+  }
 }
 
 function removeWorktreeMetadataAndTransientState(
@@ -2514,6 +2561,15 @@ export function registerWorktreeHandlers(
                 invalidateAuthorizedRootsCache()
               }
               runtime.clearOptimisticReconcileToken(args.worktreeId)
+              await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                store,
+                repo,
+                repoId,
+                worktreeId: args.worktreeId,
+                meta: removedMeta,
+                localGitOptions: localWorktreeGitOptions,
+                sshGitProvider: null
+              })
               removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
               preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
               notifyWorktreesChanged(mainWindow, repoId)
@@ -2559,6 +2615,15 @@ export function registerWorktreeHandlers(
                   localWorktreeGitOptions
                 )
                 runtime.clearOptimisticReconcileToken(args.worktreeId)
+                await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                  store,
+                  repo,
+                  repoId,
+                  worktreeId: args.worktreeId,
+                  meta: removedMeta,
+                  localGitOptions: localWorktreeGitOptions,
+                  sshGitProvider: null
+                })
                 removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
                 preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
                 invalidateAuthorizedRootsCache()
@@ -2591,6 +2656,15 @@ export function registerWorktreeHandlers(
                 invalidateAuthorizedRootsCache()
               }
               runtime.clearOptimisticReconcileToken(args.worktreeId)
+              await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                store,
+                repo,
+                repoId,
+                worktreeId: args.worktreeId,
+                meta: removedMeta,
+                localGitOptions: localWorktreeGitOptions,
+                sshGitProvider: null
+              })
               removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
               preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
               notifyWorktreesChanged(mainWindow, repoId)
@@ -2645,6 +2719,15 @@ export function registerWorktreeHandlers(
               removedPushTarget
             )
             runtime.clearOptimisticReconcileToken(args.worktreeId)
+            await maybePruneReviewHeadRefsAfterWorktreeDelete({
+              store,
+              repo,
+              repoId,
+              worktreeId: args.worktreeId,
+              meta: removedMeta,
+              localGitOptions: localWorktreeGitOptions,
+              sshGitProvider: null
+            })
             removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
             invalidateAuthorizedRootsCache()
             notifyWorktreesChanged(mainWindow, repoId)
@@ -2889,6 +2972,15 @@ export function registerWorktreeHandlers(
                   localWorktreeGitOptions
                 )
                 runtime.clearOptimisticReconcileToken(args.worktreeId)
+                await maybePruneReviewHeadRefsAfterWorktreeDelete({
+                  store,
+                  repo,
+                  repoId,
+                  worktreeId: args.worktreeId,
+                  meta: removedMeta,
+                  localGitOptions: localWorktreeGitOptions,
+                  sshGitProvider: null
+                })
                 removeWorktreeMetadataAndTransientState(store, args.worktreeId, removalHostId)
                 preservedBranchCleanupByWorktreeId.delete(args.worktreeId)
                 invalidateAuthorizedRootsCache()

--- a/src/relay/git-exec-validator.ts
+++ b/src/relay/git-exec-validator.ts
@@ -24,7 +24,9 @@ const ALLOWED_GIT_SUBCOMMANDS = new Set([
   'commit',
   'for-each-ref',
   'check-ref-format',
-  'config'
+  'config',
+  // Why: durable review-head prune needs update-ref -d for refs/orca/** only (#10501).
+  'update-ref'
 ])
 const CONFIG_READ_ONLY_FLAGS = new Set(['--get', '--get-all', '--list', '--get-regexp', '-l'])
 // Why: checking presence of a read-only flag is insufficient — a request could
@@ -200,5 +202,13 @@ export function validateGitExecArgs(args: string[]): void {
   }
   if (subcommand === 'clone') {
     validateCloneArgs(args)
+  }
+  if (subcommand === 'update-ref') {
+    // Why: only durable Orca review-head pins may be deleted via generic exec.
+    if (args.length !== 3 || args[1] !== '-d' || !args[2]?.startsWith('refs/orca/')) {
+      throw new Error(
+        'git update-ref via exec is restricted to update-ref -d refs/orca/<…>'
+      )
+    }
   }
 }

--- a/src/shared/git-exec-mutation.ts
+++ b/src/shared/git-exec-mutation.ts
@@ -1,4 +1,4 @@
-const MUTATING_GIT_EXEC_SUBCOMMANDS = new Set(['clone', 'commit', 'init'])
+const MUTATING_GIT_EXEC_SUBCOMMANDS = new Set(['clone', 'commit', 'init', 'update-ref'])
 
 // Why: relay git.exec permits these narrow write shapes alongside read-only
 // probes, so cache invalidation must distinguish them before dispatch.

--- a/src/shared/review-head-tracking-ref.test.ts
+++ b/src/shared/review-head-tracking-ref.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import {
   githubPullRequestHeadLocalRef,
   gitlabMergeRequestHeadLocalRef,
-  reviewHeadRemoteRefComponent
+  isGithubPullRequestHeadLocalRefForNumber,
+  isGitlabMergeRequestHeadLocalRefForNumber,
+  reviewHeadRemoteRefComponent,
+  selectReviewHeadLocalRefsToPrune
 } from './review-head-tracking-ref'
 
 describe('reviewHeadRemoteRefComponent', () => {
@@ -35,5 +38,34 @@ describe('reviewHeadRemoteRefComponent', () => {
     expect(gitlabMergeRequestHeadLocalRef(component, 77)).toBe(
       `refs/orca/merge-requests/${component}/77`
     )
+  })
+})
+
+describe('review-head ref prune matching (#10431)', () => {
+  it('matches PR/MR refs by trailing number only', () => {
+    expect(isGithubPullRequestHeadLocalRefForNumber('refs/orca/pull/origin-abc/42', 42)).toBe(true)
+    expect(isGithubPullRequestHeadLocalRefForNumber('refs/orca/pull/origin-abc/420', 42)).toBe(
+      false
+    )
+    expect(
+      isGitlabMergeRequestHeadLocalRefForNumber('refs/orca/merge-requests/origin-abc/15', 15)
+    ).toBe(true)
+    expect(isGitlabMergeRequestHeadLocalRefForNumber('refs/orca/pull/origin-abc/15', 15)).toBe(
+      false
+    )
+  })
+
+  it('selects only the requested PR/MR refs', () => {
+    expect(
+      selectReviewHeadLocalRefsToPrune(
+        [
+          'refs/orca/pull/a/42',
+          'refs/orca/pull/b/42',
+          'refs/orca/pull/a/7',
+          'refs/orca/merge-requests/a/42'
+        ],
+        { githubPrNumber: 42 }
+      )
+    ).toEqual(['refs/orca/pull/a/42', 'refs/orca/pull/b/42'])
   })
 })

--- a/src/shared/review-head-tracking-ref.ts
+++ b/src/shared/review-head-tracking-ref.ts
@@ -47,3 +47,70 @@ export function isValidReviewHeadNumber(value: unknown): value is number {
 export function isSafeReviewHeadFetchRemote(remote: string): boolean {
   return !remote.startsWith('-')
 }
+
+/**
+ * Match durable local refs written for a GitHub PR number (any hosting remote
+ * component). Shape: refs/orca/pull/<remoteComponent>/<prNumber>
+ */
+export function isGithubPullRequestHeadLocalRefForNumber(
+  refName: string,
+  prNumber: number
+): boolean {
+  if (!isValidReviewHeadNumber(prNumber)) {
+    return false
+  }
+  const prefix = 'refs/orca/pull/'
+  if (!refName.startsWith(prefix)) {
+    return false
+  }
+  const rest = refName.slice(prefix.length)
+  const slash = rest.lastIndexOf('/')
+  if (slash <= 0 || slash === rest.length - 1) {
+    return false
+  }
+  return rest.slice(slash + 1) === String(prNumber)
+}
+
+/**
+ * Match durable local refs written for a GitLab MR iid.
+ * Shape: refs/orca/merge-requests/<remoteComponent>/<mrIid>
+ */
+export function isGitlabMergeRequestHeadLocalRefForNumber(refName: string, mrIid: number): boolean {
+  if (!isValidReviewHeadNumber(mrIid)) {
+    return false
+  }
+  const prefix = 'refs/orca/merge-requests/'
+  if (!refName.startsWith(prefix)) {
+    return false
+  }
+  const rest = refName.slice(prefix.length)
+  const slash = rest.lastIndexOf('/')
+  if (slash <= 0 || slash === rest.length - 1) {
+    return false
+  }
+  return rest.slice(slash + 1) === String(mrIid)
+}
+
+/** Select refs to delete after the last worktree for a PR/MR is removed (#10431). */
+export function selectReviewHeadLocalRefsToPrune(
+  refNames: readonly string[],
+  targets: { githubPrNumber?: number | null; gitlabMrIid?: number | null }
+): string[] {
+  const selected: string[] = []
+  for (const refName of refNames) {
+    if (
+      targets.githubPrNumber != null &&
+      isGithubPullRequestHeadLocalRefForNumber(refName, targets.githubPrNumber)
+    ) {
+      selected.push(refName)
+      continue
+    }
+    if (
+      targets.gitlabMrIid != null &&
+      isGitlabMergeRequestHeadLocalRefForNumber(refName, targets.gitlabMrIid)
+    ) {
+      selected.push(refName)
+    }
+  }
+  return selected
+}

--- a/src/shared/review-head-tracking-ref.ts
+++ b/src/shared/review-head-tracking-ref.ts
@@ -64,11 +64,12 @@ export function isGithubPullRequestHeadLocalRefForNumber(
     return false
   }
   const rest = refName.slice(prefix.length)
-  const slash = rest.lastIndexOf('/')
-  if (slash <= 0 || slash === rest.length - 1) {
+  // Why: durable shape is exactly <remoteComponent>/<number> — reject nested paths.
+  const parts = rest.split('/')
+  if (parts.length !== 2 || parts[0].length === 0 || parts[1].length === 0) {
     return false
   }
-  return rest.slice(slash + 1) === String(prNumber)
+  return parts[1] === String(prNumber)
 }
 
 /**
@@ -84,11 +85,12 @@ export function isGitlabMergeRequestHeadLocalRefForNumber(refName: string, mrIid
     return false
   }
   const rest = refName.slice(prefix.length)
-  const slash = rest.lastIndexOf('/')
-  if (slash <= 0 || slash === rest.length - 1) {
+  // Why: durable shape is exactly <remoteComponent>/<number> — reject nested paths.
+  const parts = rest.split('/')
+  if (parts.length !== 2 || parts[0].length === 0 || parts[1].length === 0) {
     return false
   }
-  return rest.slice(slash + 1) === String(mrIid)
+  return parts[1] === String(mrIid)
 }
 
 /** Select refs to delete after the last worktree for a PR/MR is removed (#10431). */


### PR DESCRIPTION
## Summary
Durable review-head refs introduced in #10429 (`refs/orca/pull/<remote>/<N>`, `refs/orca/merge-requests/<remote>/<N>`) were force-updated on every PR/MR resolve but **never deleted**. Heavy review usage leaves permanent pins in the shared git dir.

Closes #10431

## Behavior
On successful worktree delete (local + SSH):
1. Read `linkedPR` / `linkedGitLabMR` from the deleted worktree's metadata
2. If **no other worktree in the same repo** still links that review id, list `refs/orca/**` and `update-ref -d` the matching pins
3. Failures are best-effort (warn + continue) so delete never fails on prune

Non-PR/MR worktrees and multi-open worktrees for the same PR leave refs alone. Re-opening the same PR later force-fetches the ref again.

## Test plan
- [x] Shared matchers / select-to-prune
- [x] Sibling-worktree guard (same repo / other repo)
- [x] Last-linked delete removes PR ref only
- [x] GitLab MR path
- [x] No-op without linked metadata
- [ ] Manual: create fork-PR worktree → confirm `refs/orca/pull/...` exists → delete last worktree → ref gone

## Notes
Uses existing `WorktreeMeta.linkedPR` / `linkedGitLabMR` rather than new metadata fields — worktrees created from Tasks/PR start already set these.

## ELI5

Orca left permanent git refs for PR/MR review heads after worktrees were deleted, cluttering the shared object store. When the last worktree for a review is removed, those durable refs are pruned.
