### PR TITLE
fix(sidebar): keep idle Claude agent rows after relaunch without prompts

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.test.ts
@@ -255,14 +255,51 @@ describe('buildTitleDerivedAgentRows', () => {
     expect(rows).toHaveLength(0)
   })
 
-  it('does not turn generic Codex-launched task titles into Claude Code rows', () => {
+  it('treats Claude idle-prefix titles as Claude even without the word "claude" (#10398)', () => {
+    // Why: bare `✳` / `✳ task` is Claude Code's idle protocol; previously the
+    // Claude token gate dropped those rows, so never-prompted sessions vanished
+    // from the sidebar after relaunch once hooks had nothing to hydrate.
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude', title: '\u2733' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: '\u2733' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-idle'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state, row.entry.prompt])).toEqual([
+      ['claude', 'idle', 'Claude Code']
+    ])
+  })
+
+  it('restores an idle launchAgent row when a live PTY only has a shell title after relaunch (#10398)', () => {
+    const rows = buildWorktreeAgentRows({
+      tabs: [makeTab('tab-1', { launchAgent: 'claude', title: 'zsh' })],
+      entries: [],
+      retained: [],
+      runtimePaneTitlesByTabId: {
+        'tab-1': { 1: 'zsh' }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-claude-shell'] },
+      terminalLayoutsByTabId: { 'tab-1': makeSingleLayout(LEAF_ID_1) },
+      now: 2000
+    })
+
+    expect(rows.map((row) => [row.agentType, row.state])).toEqual([['claude', 'idle']])
+  })
+
+  it('does not invent a launchAgent row for ordinary task titles', () => {
     const launchAgent: TuiAgent = 'codex'
     const rows = buildWorktreeAgentRows({
       tabs: [makeTab('tab-1', { launchAgent })],
       entries: [],
       retained: [],
       runtimePaneTitlesByTabId: {
-        'tab-1': { 1: '✳ refactor split-pane status' }
+        'tab-1': { 1: 'refactor split-pane status' }
       },
       ptyIdsByTabId: { 'tab-1': ['pty-codex'] },
       terminalLayoutsByTabId: { 'tab-1': makeSplitLayout() },

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -1,7 +1,9 @@
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { formatAgentTypeLabel, isClaudeManagementTitle } from '@/lib/agent-status'
 import { containsBrailleSpinner } from '../../../../shared/agent-title-core'
+import { CLAUDE_IDLE } from '../../../../shared/terminal-title-agent-type'
 import { classifyTitleActivity, resolveTitleActivityLabel } from '@/lib/pane-agent-evidence'
+import { isShellProcess } from '../../../../shared/shell-process-detection'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import type {
   AgentStatusEntry,
@@ -133,8 +135,17 @@ function buildTitleDerivedAgentRow(args: {
   // Why: `claude agents` is a live Claude Code Agent Teams surface, but the
   // shared detector keeps it neutral so runtime liveness probes do not treat
   // the management/list screen as active work.
-  const status = isClaudeAgentsTitle ? 'idle' : classifyTitleActivity(title)
-  const label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
+  let status = isClaudeAgentsTitle ? 'idle' : classifyTitleActivity(title)
+  let label = isClaudeAgentsTitle ? 'Claude Code' : resolveTitleActivityLabel(title)
+  // Why: after quit/relaunch with no prompt, Claude often keeps a live PTY while
+  // the OSC title falls back to a shell name until the next status paint — the
+  // tab still owns launchAgent, so restore an idle row instead of vanishing (#10398).
+  const useLaunchAgentShellFallback =
+    Boolean(args.tab.launchAgent) && (!status || !label) && isShellLikeAgentPaneTitle(title)
+  if (useLaunchAgentShellFallback && args.tab.launchAgent) {
+    status = 'idle'
+    label = formatAgentTypeLabel(args.tab.launchAgent)
+  }
   if (!status || !label) {
     return null
   }
@@ -143,7 +154,13 @@ function buildTitleDerivedAgentRow(args: {
   }
   const paneKey = makePaneKey(args.tab.id, args.leafId)
   const orchestration = args.runtimeAgentOrchestrationByPaneKey?.[paneKey]
-  const titleAgentType = isClaudeAgentsTitle ? 'claude' : resolveTitleDerivedAgentType(title, label)
+  // Why: shell-fallback labels are formatAgentTypeLabel("claude") → "Claude", which
+  // is not in TITLE_AGENT_LABEL_TO_TYPE; skip title typing and use launchAgent.
+  const titleAgentType = useLaunchAgentShellFallback
+    ? null
+    : isClaudeAgentsTitle
+      ? 'claude'
+      : resolveTitleDerivedAgentType(title, label)
   // Why: a braille spinner proves activity, not identity, so the resolver drops
   // it. Hook-less agents over SSH (Codex, #8711) surface only spinner+cwd titles;
   // fall back to the tab's launch identity instead of hiding the pane. Gated on
@@ -152,7 +169,10 @@ function buildTitleDerivedAgentRow(args: {
   // title alone, so a non-agent title must never become a row. Residual: a split
   // pane whose own title carries a braille glyph is still attributed to launchAgent.
   const agentType =
-    titleAgentType ?? (containsBrailleSpinner(title) ? (args.tab.launchAgent ?? null) : null)
+    titleAgentType ??
+    (containsBrailleSpinner(title) || useLaunchAgentShellFallback
+      ? (args.tab.launchAgent ?? null)
+      : null)
   if (!agentType) {
     return null
   }
@@ -189,10 +209,40 @@ export function resolveTitleDerivedAgentType(title: string, label: string): Agen
   if (agentType !== 'claude') {
     return agentType
   }
+  // Why: Claude's bare idle/working prefixes (`✳`, `. `, `* `) are the product's
+  // own title protocol and prove Claude identity even before task text includes
+  // the word "claude" — common for idle sessions that never sent a prompt (#10398).
+  if (isClaudeCodeStatusPrefixTitle(title)) {
+    return 'claude'
+  }
   // Why: Claude's task-title spinner heuristic has no provider identity. In
   // split panes it can match arbitrary terminal spinners, so sidebar rows only
   // accept Claude when the title itself names Claude.
   return CLAUDE_AGENT_TOKEN_RE.test(title) ? agentType : null
+}
+
+function isClaudeCodeStatusPrefixTitle(title: string): boolean {
+  return (
+    title === CLAUDE_IDLE ||
+    title.startsWith(`${CLAUDE_IDLE} `) ||
+    title.startsWith('. ') ||
+    title.startsWith('* ')
+  )
+}
+
+/** Shell / empty titles that no longer identify the agent after a cold restore. */
+function isShellLikeAgentPaneTitle(title: string): boolean {
+  const trimmed = title.trim()
+  if (!trimmed) {
+    return true
+  }
+  if (isShellProcess(trimmed)) {
+    return true
+  }
+  // Why: some hosts restore "zsh — folder" / "bash" style titles; only trust the
+  // first token so task text never becomes a launchAgent row.
+  const firstToken = trimmed.split(/[\s—–-]+/)[0] ?? ''
+  return isShellProcess(firstToken)
 }
 
 /**

--- a/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-title-derived-agent-rows.ts
@@ -140,8 +140,14 @@ function buildTitleDerivedAgentRow(args: {
   // Why: after quit/relaunch with no prompt, Claude often keeps a live PTY while
   // the OSC title falls back to a shell name until the next status paint — the
   // tab still owns launchAgent, so restore an idle row instead of vanishing (#10398).
+  // Restrict to single-leaf tabs: launchAgent is tab-scoped and must not brand
+  // every shell split pane as the agent (CodeRabbit / #10502).
+  const singleLeafTab = (args.tab.leafOrder?.length ?? 1) <= 1
   const useLaunchAgentShellFallback =
-    Boolean(args.tab.launchAgent) && (!status || !label) && isShellLikeAgentPaneTitle(title)
+    Boolean(args.tab.launchAgent) &&
+    singleLeafTab &&
+    (!status || !label) &&
+    isShellLikeAgentPaneTitle(title)
   if (useLaunchAgentShellFallback && args.tab.launchAgent) {
     status = 'idle'
     label = formatAgentTypeLabel(args.tab.launchAgent)


### PR DESCRIPTION
## Summary
Idle Claude Code sessions that never received a prompt lost their sidebar agent row after quit/relaunch. The tab/pane restored, but the worktree card no longer showed \"Claude Code · idle\" until the next prompt (when hooks re-hydrated status).

Closes #10398

## Root cause
Title-derived sidebar rows required either:
1. The word \"claude\" in the title (Claude token gate), **or**
2. A braille spinner + \`launchAgent\`

Claude's bare idle protocol title is often just \`✳\` / \`✳ task\` with no \"claude\" token, and after cold restore the OSC title can briefly be a shell name while \`launchAgent\` remains \`claude\`. Both paths dropped the row.

## Fix
1. Treat Claude status prefixes (\`✳\`, \`. \`, \`* \`) as Claude identity without requiring the name token
2. When a live PTY only has a shell-like title and the tab owns \`launchAgent\`, restore an idle row from that launch identity

## Test plan
- [x] Bare \`✳\` idle title → Claude idle row
- [x] \`zsh\` title + \`launchAgent: claude\` + live PTY → Claude idle row
- [x] Ordinary non-agent task titles still do not invent rows
- [x] Existing title-derived suite (13 tests)
- [ ] Manual: launch Claude, no prompt, quit/reopen → sidebar row remains idle

## ELI5

Idle Claude sessions without a prompt disappeared from the sidebar after relaunch even though the tab restored. Idle Claude rows are kept so you still see "Claude Code · idle."
