### PR TITLE
fix(ui): fade the parked floating workspace toggle so it stops covering terminal text

### DIFF
--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.test.tsx
@@ -295,3 +295,44 @@ describe('FloatingTerminalToggleButton attention dot', () => {
     expect(hasProp(element, 'data-floating-terminal-attention')).toBe(false)
   })
 })
+
+describe('FloatingTerminalToggleButton idle transparency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hookRuntime.effects = []
+    hookRuntime.layoutEffects = []
+    hookRuntime.index = 0
+    hookRuntime.values = []
+    storeState.hasFloatingUnread = false
+    vi.stubGlobal('window', {
+      addEventListener: vi.fn(),
+      innerHeight: 800,
+      innerWidth: 1200,
+      localStorage: { getItem: vi.fn(() => null), setItem: vi.fn() },
+      removeEventListener: vi.fn()
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('fades the parked launcher and restores it on hover or focus', async () => {
+    const element = await renderToggle(false)
+    const className = getToggleButton(element).props.className as string
+    expect(className).toContain('opacity-45')
+    expect(className).toContain('hover:opacity-100')
+    expect(className).toContain('focus-visible:opacity-100')
+  })
+
+  it('keeps the control opaque while the panel is open', async () => {
+    const element = await renderToggle(true)
+    expect(getToggleButton(element).props.className as string).not.toContain('opacity-45')
+  })
+
+  it('keeps the control opaque while activity is pending', async () => {
+    storeState.hasFloatingUnread = true
+    const element = await renderToggle(false)
+    expect(getToggleButton(element).props.className as string).not.toContain('opacity-45')
+  })
+})

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalToggleButton.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { FloatingTerminalIconContextMenu } from './FloatingTerminalIconContextMenu'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
+import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { selectFloatingWorkspaceHasUnread } from '@/store/selectors'
 import {
@@ -70,6 +71,7 @@ export function FloatingTerminalToggleButton({
   // closes — the offending tab (see selectFloatingWorkspaceHasUnread).
   const hasFloatingUnread = useAppStore(selectFloatingWorkspaceHasUnread)
   const showAttentionDot = !open && hasFloatingUnread
+  const dimWhenIdle = !open && !showAttentionDot
   const initialPositionState = useRef<FloatingTerminalTriggerPositionState | null>(null)
   if (initialPositionState.current === null) {
     initialPositionState.current = readInitialTriggerPosition()
@@ -210,7 +212,14 @@ export function FloatingTerminalToggleButton({
             // pages a soft drop shadow lifts it; on near-black dark surfaces a
             // drop shadow vanishes, so use a distinctly lighter fill plus a
             // bright hairline ring to define the edge.
-            className="relative cursor-grab rounded-lg border-transparent text-foreground bg-card shadow-[0_4px_12px_rgb(0_0_0_/_0.22),0_0_0_1px_color-mix(in_srgb,var(--foreground)_12%,transparent)] hover:-translate-y-0.5 hover:bg-accent active:translate-y-0 active:cursor-grabbing dark:bg-accent dark:shadow-[0_6px_16px_rgb(0_0_0_/_0.55),0_0_0_1px_rgb(255_255_255_/_0.22)] dark:hover:bg-[color-mix(in_srgb,var(--accent)_82%,white)]"
+            className={cn(
+              'relative cursor-grab rounded-lg border-transparent text-foreground bg-card shadow-[0_4px_12px_rgb(0_0_0_/_0.22),0_0_0_1px_color-mix(in_srgb,var(--foreground)_12%,transparent)] hover:-translate-y-0.5 hover:bg-accent active:translate-y-0 active:cursor-grabbing dark:bg-accent dark:shadow-[0_6px_16px_rgb(0_0_0_/_0.55),0_0_0_1px_rgb(255_255_255_/_0.22)] dark:hover:bg-[color-mix(in_srgb,var(--accent)_82%,white)]',
+              // Why: parked over content it can cover (a terminal prompt row),
+              // so idle it fades back and any pointer/keyboard approach restores
+              // it. Unread activity and the open panel stay full strength.
+              dimWhenIdle &&
+                'opacity-45 hover:opacity-100 focus-visible:opacity-100 active:opacity-100'
+            )}
             data-floating-terminal-toggle
             aria-label={
               open

--- a/tests/e2e/floating-workspace-toggle-idle-opacity.spec.ts
+++ b/tests/e2e/floating-workspace-toggle-idle-opacity.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { execInTerminal, waitForActivePanePtyId, waitForTerminalOutput } from './helpers/terminal'
+
+// Why: the context-menu wrapper carries the same data attribute, so scope to the
+// button that actually owns the fade.
+const TOGGLE_SELECTOR = 'button[data-floating-terminal-toggle]'
+
+// Why: the parked launcher covers the bottom-right of the session area, which is
+// where terminal output lands. Flood the viewport so every row the button
+// overlaps actually carries text — otherwise the screenshots prove nothing.
+const FLOOD_COMMAND =
+  "node -e \"for (let i = 0; i < 60; i++) console.log('orca'.repeat(80)); console.log('FLOOD-DONE')\""
+
+test.describe('floating workspace toggle idle opacity', () => {
+  test('fades while parked and returns to full strength on hover', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+
+    await orcaPage.evaluate(() => {
+      const store = window.__store
+      const state = store?.getState()
+      if (!store || !state?.settings) {
+        throw new Error('Store unavailable')
+      }
+      store.setState({
+        // Why: with the right sidebar open the launcher parks over sidebar
+        // chrome, not terminal output — the reported overlap only happens when
+        // the terminal owns the full width.
+        rightSidebarOpen: false,
+        settings: {
+          ...state.settings,
+          floatingTerminalEnabled: true,
+          floatingTerminalTriggerLocation: 'floating-button',
+          // Why: dark is the surface where the launcher's own fill is closest to
+          // the terminal background, so it is the strictest read of the fade.
+          theme: 'dark'
+        }
+      })
+    })
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await execInTerminal(orcaPage, ptyId, FLOOD_COMMAND)
+    await waitForTerminalOutput(orcaPage, 'FLOOD-DONE')
+
+    const toggle = orcaPage.locator(TOGGLE_SELECTOR)
+    await expect(toggle).toBeVisible()
+
+    // Why: the fade is a CSS transition, so read the settled computed value
+    // rather than the class list — this is what actually catches a Tailwind
+    // scale miss where `opacity-45` never gets generated.
+    const readOpacity = async (): Promise<number> =>
+      Number(await toggle.evaluate((node) => getComputedStyle(node).opacity))
+
+    await expect.poll(readOpacity, { message: 'idle toggle never faded' }).toBeCloseTo(0.45, 2)
+
+    const box = await toggle.boundingBox()
+    if (!box) {
+      throw new Error('Toggle has no bounding box')
+    }
+    const clip = {
+      x: Math.max(0, box.x - 320),
+      y: Math.max(0, box.y - 24),
+      width: 320 + box.width + 24,
+      height: box.height + 48
+    }
+    const captureShot = async (name: string): Promise<void> => {
+      const shotPath = testInfo.outputPath(name)
+      await orcaPage.screenshot({ clip, path: shotPath })
+      await testInfo.attach(name, { path: shotPath, contentType: 'image/png' })
+    }
+    // Why: the terminal repaints on animation frames that a headless window
+    // throttles until it sees input. Park the pointer well clear of the launcher
+    // so the flood is actually on screen while the button is still idle.
+    await orcaPage.mouse.move(clip.x + 8, clip.y + 8)
+    await orcaPage.waitForTimeout(500)
+    await captureShot('idle-faded.png')
+
+    await toggle.hover()
+    await expect.poll(readOpacity, { message: 'hover never restored the toggle' }).toBe(1)
+    await captureShot('hover-restored.png')
+
+    // Why: an open panel owns the same control as "minimize"; it must never sit
+    // at reduced strength over its own chrome.
+    await toggle.click()
+    await expect(orcaPage.locator('[data-floating-terminal-panel]')).toBeVisible()
+    await orcaPage.mouse.move(10, 10)
+    await expect.poll(readOpacity, { message: 'open panel left the toggle faded' }).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

The floating workspace launcher parks at the bottom-right of the session area — which is exactly where a terminal's output and prompt rows land — and it rendered fully opaque, so it covered whatever text sat underneath it.

The parked launcher now renders at 45% opacity and returns to full strength on hover, keyboard focus, and drag. Two cases deliberately stay fully opaque:

- **panel open** — the same control is the "minimize" affordance and sits over the floating panel's own chrome
- **pending unread activity** — the amber attention dot must never be dimmed

Nothing about position, drag, click, context menu, or the shortcut changes.

## Screenshots

Captured from the real app via the e2e harness (headless Electron, dark theme, right sidebar collapsed so the terminal owns the full width). The crop is the 380px around the launcher; the terminal is flooded with `orca` repeated so every row the button overlaps carries text.

**Before** — `main`, computed opacity `1`. The text under the button is gone:

<img width="380" height="84" alt="before-parked" src="https://github.com/user-attachments/assets/7f804a16-8397-4226-a88a-21d91a7d8af2" />

**After (idle)** — this branch, computed opacity `0.45`. The same text reads through:

<img width="380" height="84" alt="after-idle-faded" src="https://github.com/user-attachments/assets/fd25acf3-9f4e-4d9a-9d2e-27865597dfa2" />

**After (hover)** — computed opacity back to `1`:

<img width="380" height="84" alt="after-hover-restored" src="https://github.com/user-attachments/assets/17a3c312-9785-42c0-9ea0-bf176f457ee0" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
  - 41 tests across 7 files fail in my environment (`use-markup-draw-hint`, 3 × `right-sidebar`, 3 × `sidebar`), all with `window.localStorage.<method> is not a function`. I reproduced the identical 41 failures on unmodified `main`, so they are pre-existing here and unrelated to this change — most likely because my local Node is v25.5.0 while the repo pins `engines.node: 24`. Everything else passes: 35,964 passed / 62 skipped.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Tests added:

- `FloatingTerminalToggleButton.test.tsx` — three cases covering the idle/open/unread branches of the fade.
- `tests/e2e/floating-workspace-toggle-idle-opacity.spec.ts` — launches the app and reads the **settled computed opacity** while parked, on hover, and with the panel open. This exists because the unit test only proves the class list: it would still pass if Tailwind never emitted the utility. The spec also attaches the idle/hover crops so the fade stays reviewable from CI artifacts. Verified passing locally against a `--mode e2e` build; I also ran the same capture against `main` to confirm it reads `1` there.

Separately confirmed the built stylesheet actually contains `.opacity-45{opacity:.45}`.

## AI Review Report

Reviewed with Claude Code. Risks checked and findings:

- **Cross-platform (macOS / Linux / Windows).** The diff is one conditional Tailwind class string in a renderer component. No `metaKey`/`ctrlKey`, no shortcut label, no path handling, no shell, no Electron main-process or menu code — nothing that can diverge per platform. `opacity` renders identically across the three Chromium builds. No platform-specific behavior introduced or touched.
- **SSH / remote / local.** The floating workspace is a local synthetic workspace; this change touches only its trigger button's presentation. No process, file, credential, shell, or network path is assumed or added, so local, remote-server, and SSH-worktree sessions are unaffected.
- **Agent / integration / git-provider compatibility.** None of these are in the code path. No provider-specific naming or branching added.
- **Performance.** No new state, effects, listeners, or timers. One `cn()` call per render of a component that already re-renders on the same inputs. The transition rides the `transition-all` already on the `Button` base — no new transition was introduced. `opacity` is compositor-driven and the element is a 36×36 fixed control, so the extra stacking context is negligible. Nothing is added to a hot path.
- **UI quality.** Follows `docs/STYLEGUIDE.md`: no new color, size, or shadow tier — the existing `bg-card` / `dark:bg-accent` treatment is untouched and only composited at reduced alpha, so light and dark both hold. The pattern matches its closest siblings (`ui/dialog.tsx`, `ui/sheet.tsx` close buttons: dimmed idle, `hover:opacity-100`), which are likewise ungated by `can-hover:` — correct here because the control stays visible and tappable at 45%, so touch users lose nothing functional. Affordance is preserved: the tooltip, the attention dot, and `focus-visible` restoration all still work, and keyboard users always see it at full contrast.
- **Security.** No input handling, command execution, path handling, auth, secrets, IPC, or dependency changes. The e2e spec runs one fixed `node -e` string in its own test PTY with no interpolation of external input.

Changed as a result of the review: the fade is scoped with `active:opacity-100` so a drag never runs at reduced strength, and it is suppressed entirely while unread activity is pending so the attention dot is never dimmed.

## Security Audit

No security-relevant surface is touched. Concretely reviewed and found clean:

- **Input handling** — none added; the existing pointer/click handlers are unchanged.
- **Command execution** — none in product code. The only command in the diff is the fixed `node -e "…"` flood string inside the e2e spec, written to a test-owned PTY with no user or environment input interpolated.
- **Path handling** — none. The e2e spec writes screenshots through Playwright's `testInfo.outputPath()`, which stays inside the run's output directory.
- **Auth / secrets** — none read, written, or logged.
- **IPC** — no new channels, and no change to existing ones.
- **Dependencies** — none added or bumped.

No follow-up security work needed.

## Notes

- No platform-specific, remote/SSH-specific, agent-specific, integration-specific, or git-provider-specific behavior.
- 45% was chosen so terminal text reads through while the control is still easy to spot on both `bg-card` (light) and `dark:bg-accent` (dark). It is a single class if a maintainer wants it dialed differently.
- Possible follow-up, deliberately out of scope: honoring `prefers-reduced-transparency` to keep the launcher fully opaque for users who ask the OS to reduce transparency. Happy to add it here if you'd prefer it in this PR.
- On touch surfaces there is no hover, so the launcher stays at 45% until it is pressed (`active:` restores it). That is intentional — the overlap it causes is the same on touch — but flagging it in case you want a `can-hover:` gate instead.

## ELI5

The floating workspace toggle sat opaque over the bottom-right of the terminal and hid prompt text. When parked it fades until you hover or focus it, so output stays readable.
