### PR TITLE
fix(terminal): serialize PTY writes and harden large terminal sends

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/WooseongKim/Projects/OpenSources/orca/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/WooseongKim/Projects/OpenSources/orca/node_modules

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15611,29 +15611,41 @@ describe('OrcaRuntimeService', () => {
   })
 
   it('writes large terminal input in 16 KiB chunks without inter-chunk delay', async () => {
-    const writes: string[] = []
-    const runtime = new OrcaRuntimeService(store)
-    runtime.setPtyController({
-      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
-      write: (_ptyId, data) => {
-        writes.push(data)
-        return true
-      },
-      kill: () => true,
-      getForegroundProcess: async () => null
-    })
-    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    vi.useFakeTimers()
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
 
-    await runtime.sendTerminal(handle, { text: 'x' })
-    expect(writes).toEqual(['x'])
+      await runtime.sendTerminal(handle, { text: 'x' })
+      expect(writes).toEqual(['x'])
+      expect(vi.getTimerCount()).toBe(0)
 
-    writes.length = 0
-    const text = 'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
-    await runtime.sendTerminal(handle, { text })
-    expect(writes).toEqual([
-      'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES),
-      'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)
-    ])
+      writes.length = 0
+      const text = 'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+      // Why: flush microtasks only — advancing timers would let a reintroduced gap pass this test.
+      const send = runtime.sendTerminal(handle, { text })
+      for (let i = 0; i < 32 && writes.length < 2; i += 1) {
+        await Promise.resolve()
+      }
+      expect(vi.getTimerCount()).toBe(0)
+      expect(writes).toEqual([
+        'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES),
+        'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)
+      ])
+      await send
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('serializes concurrent terminal sends per PTY', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15610,6 +15610,103 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('paces Windows chunks without delaying single writes', async () => {
+    vi.useFakeTimers()
+    setPlatform('win32')
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+
+      await runtime.sendTerminal(handle, { text: 'x' })
+      expect(writes).toEqual(['x'])
+      expect(vi.getTimerCount()).toBe(0)
+
+      const pacedSend = runtime.sendTerminal(handle, {
+        text: 'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+      })
+      await vi.advanceTimersByTimeAsync(15)
+      expect(writes).toHaveLength(2)
+      await vi.runAllTimersAsync()
+      await pacedSend
+      expect(writes.slice(1).join('')).toBe('y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('serializes concurrent terminal sends per PTY', async () => {
+    vi.useFakeTimers()
+    setPlatform('win32')
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const first = 'a'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+      const second = 'b'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+
+      const firstSend = runtime.sendTerminal(handle, { text: first })
+      const secondSend = runtime.sendTerminal(handle, { text: second })
+      await vi.runAllTimersAsync()
+      await Promise.all([firstSend, secondSend])
+
+      expect(writes.join('')).toBe(first + second)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels paced input when its PTY exits', async () => {
+    vi.useFakeTimers()
+    setPlatform('win32')
+    try {
+      const writes: string[] = []
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+        write: (_ptyId, data) => {
+          writes.push(data)
+          return true
+        },
+        kill: () => true,
+        getForegroundProcess: async () => null
+      })
+      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+      const send = runtime.sendTerminal(handle, {
+        text: 'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 4)
+      })
+      const rejection = expect(send).rejects.toThrow('terminal_not_writable')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(writes).toHaveLength(1)
+
+      runtime.onPtyExit('pty-bg', 0)
+
+      await rejection
+      expect(writes).toHaveLength(1)
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('chunks large terminal.send text before provider writes', async () => {
     const writes: string[] = []
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -15610,101 +15610,80 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('paces Windows chunks without delaying single writes', async () => {
-    vi.useFakeTimers()
-    setPlatform('win32')
-    try {
-      const writes: string[] = []
-      const runtime = new OrcaRuntimeService(store)
-      runtime.setPtyController({
-        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
-        write: (_ptyId, data) => {
-          writes.push(data)
-          return true
-        },
-        kill: () => true,
-        getForegroundProcess: async () => null
-      })
-      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+  it('writes large terminal input in 16 KiB chunks without inter-chunk delay', async () => {
+    const writes: string[] = []
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
 
-      await runtime.sendTerminal(handle, { text: 'x' })
-      expect(writes).toEqual(['x'])
-      expect(vi.getTimerCount()).toBe(0)
+    await runtime.sendTerminal(handle, { text: 'x' })
+    expect(writes).toEqual(['x'])
 
-      const pacedSend = runtime.sendTerminal(handle, {
-        text: 'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
-      })
-      await vi.advanceTimersByTimeAsync(15)
-      expect(writes).toHaveLength(2)
-      await vi.runAllTimersAsync()
-      await pacedSend
-      expect(writes.slice(1).join('')).toBe('y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2))
-    } finally {
-      vi.useRealTimers()
-    }
+    writes.length = 0
+    const text = 'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+    await runtime.sendTerminal(handle, { text })
+    expect(writes).toEqual([
+      'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES),
+      'y'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)
+    ])
   })
 
   it('serializes concurrent terminal sends per PTY', async () => {
-    vi.useFakeTimers()
-    setPlatform('win32')
-    try {
-      const writes: string[] = []
-      const runtime = new OrcaRuntimeService(store)
-      runtime.setPtyController({
-        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
-        write: (_ptyId, data) => {
-          writes.push(data)
-          return true
-        },
-        kill: () => true,
-        getForegroundProcess: async () => null
-      })
-      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
-      const first = 'a'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
-      const second = 'b'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+    const writes: string[] = []
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
+    const first = 'a'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
+    const second = 'b'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 2)
 
-      const firstSend = runtime.sendTerminal(handle, { text: first })
-      const secondSend = runtime.sendTerminal(handle, { text: second })
-      await vi.runAllTimersAsync()
-      await Promise.all([firstSend, secondSend])
+    await Promise.all([
+      runtime.sendTerminal(handle, { text: first }),
+      runtime.sendTerminal(handle, { text: second })
+    ])
 
-      expect(writes.join('')).toBe(first + second)
-    } finally {
-      vi.useRealTimers()
-    }
+    expect(writes.join('')).toBe(first + second)
   })
 
-  it('cancels paced input when its PTY exits', async () => {
-    vi.useFakeTimers()
-    setPlatform('win32')
-    try {
-      const writes: string[] = []
-      const runtime = new OrcaRuntimeService(store)
-      runtime.setPtyController({
-        spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
-        write: (_ptyId, data) => {
-          writes.push(data)
-          return true
-        },
-        kill: () => true,
-        getForegroundProcess: async () => null
-      })
-      const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
-      const send = runtime.sendTerminal(handle, {
-        text: 'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 4)
-      })
-      const rejection = expect(send).rejects.toThrow('terminal_not_writable')
-      await vi.advanceTimersByTimeAsync(0)
-      expect(writes).toHaveLength(1)
+  it('stops multi-chunk terminal input when the PTY exits after the first chunk', async () => {
+    const writes: string[] = []
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-bg' }),
+      write: (_ptyId, data) => {
+        writes.push(data)
+        // Why: exit after accepting the first chunk so later chunks hit the cancelled queue.
+        if (writes.length === 1) {
+          runtime.onPtyExit('pty-bg', 0)
+        }
+        return true
+      },
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const { handle } = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`)
 
-      runtime.onPtyExit('pty-bg', 0)
-
-      await rejection
-      expect(writes).toHaveLength(1)
-      expect(vi.getTimerCount()).toBe(0)
-    } finally {
-      vi.useRealTimers()
-    }
+    await expect(
+      runtime.sendTerminal(handle, {
+        text: 'x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES * 3)
+      })
+    ).rejects.toThrow('terminal_not_writable')
+    expect(writes).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES)])
   })
 
   it('chunks large terminal.send text before provider writes', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -17100,10 +17100,8 @@ export class OrcaRuntimeService {
       }
       await options.afterWrite?.(ptyId)
       chunk = chunks.next()
-      // Why: non-Windows gap is 0 — skip the timer so we do not force an event-loop turn per chunk.
+      // Why: gap 0 skips the timer so multi-chunk sends do not force a delay per chunk.
       if (!chunk.done && chunkGapMs > 0) {
-        // Why: Windows ConPTY needs a real gap, not just setTimeout(0), or long
-        // injects are silently truncated to a tail fragment (#10416).
         await this.waitForTerminalInputGap(queue, chunkGapMs)
       }
     }
@@ -17135,7 +17133,7 @@ export class OrcaRuntimeService {
         }
         wrotePasteBytes = true
         chunk = chunks.next()
-        // Why: non-Windows gap is 0 — skip the timer so we do not force an event-loop turn per chunk.
+        // Why: gap 0 skips the timer so multi-chunk pastes do not force a delay per chunk.
         if (!chunk.done && chunkGapMs > 0) {
           await this.waitForTerminalInputGap(queue, chunkGapMs)
         }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16993,7 +16993,8 @@ export class OrcaRuntimeService {
       }
       await options.afterWrite?.(ptyId)
       chunk = chunks.next()
-      if (!chunk.done) {
+      // Why: non-Windows gap is 0 — skip the timer so we do not force an event-loop turn per chunk.
+      if (!chunk.done && chunkGapMs > 0) {
         // Why: Windows ConPTY needs a real gap, not just setTimeout(0), or long
         // injects are silently truncated to a tail fragment (#10416).
         await new Promise((resolve) => setTimeout(resolve, chunkGapMs))
@@ -17024,7 +17025,8 @@ export class OrcaRuntimeService {
         }
         wrotePasteBytes = true
         chunk = chunks.next()
-        if (!chunk.done) {
+        // Why: non-Windows gap is 0 — skip the timer so we do not force an event-loop turn per chunk.
+        if (!chunk.done && chunkGapMs > 0) {
           await new Promise((resolve) => setTimeout(resolve, chunkGapMs))
         }
       }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2718,6 +2718,13 @@ type NativeChatLaunchDraftResolutionTombstone = RuntimeNativeChatLaunchDraftReso
 
 const MAX_NATIVE_CHAT_LAUNCH_DRAFT_RESOLUTION_TOMBSTONES = 200
 
+type TerminalInputWriteQueue = {
+  tail: Promise<void>
+  pending: number
+  cancelled: boolean
+  delays: Set<{ timer: ReturnType<typeof setTimeout>; reject: (error: Error) => void }>
+}
+
 async function hasLocalWorktreeBaseRef(
   repoPath: string,
   baseRef: string,
@@ -2859,6 +2866,7 @@ export class OrcaRuntimeService {
   private detachedPreAllocatedLeaves = new Map<string, RuntimeLeafRecord>()
   private graphSyncCallbacks: (() => void)[] = []
   private waitersByHandle = new Map<string, Set<TerminalWaiter>>()
+  private terminalInputWriteQueues = new Map<string, TerminalInputWriteQueue>()
   private ptyController: RuntimePtyController | null = null
   private notifier: RuntimeNotifier | null = null
   private clientEventListeners = new Set<(event: RuntimeClientEvent) => void>()
@@ -4892,6 +4900,11 @@ export class OrcaRuntimeService {
   }
 
   setPtyController(controller: RuntimePtyController | null): void {
+    if (!controller) {
+      for (const ptyId of this.terminalInputWriteQueues.keys()) {
+        this.cancelTerminalInputWrites(ptyId)
+      }
+    }
     // Why: CLI terminal writes must go through the main-owned PTY registry
     // instead of tunneling back through renderer IPC, or live handles could
     // drift from the process they are supposed to control during reloads.
@@ -7900,6 +7913,7 @@ export class OrcaRuntimeService {
       if (tab.id === tabId) {
         const pty = this.findPtyForMobileTerminalTab(worktreeId, tab)
         if (pty) {
+          this.cancelTerminalInputWrites(pty.ptyId)
           this.ptyController?.kill(pty.ptyId)
         } else {
           this.notifier?.closeTerminal(tab.parentTabId)
@@ -8083,6 +8097,7 @@ export class OrcaRuntimeService {
     }
     if (options.killPtys !== false) {
       for (const ptyId of ptyIdsToKill) {
+        this.cancelTerminalInputWrites(ptyId)
         this.ptyController?.kill(ptyId)
       }
     }
@@ -10922,14 +10937,16 @@ export class OrcaRuntimeService {
     }
     try {
       await assertTerminalInputWithinLimitWithYield(data)
-      await this.writeTerminalInputChunks(ptyId, data, {
-        // Why: a phone can claim the floor while a paste yields between chunks.
-        beforeWrite: () => {
-          if (this.getDriver(ptyId).kind === 'mobile') {
-            throw new Error('terminal_mobile_driver_active')
+      await this.enqueueTerminalInputWrite(ptyId, (queue) =>
+        this.writeTerminalInputChunks(ptyId, data, queue, {
+          // Why: a phone can claim the floor while a paste yields between chunks.
+          beforeWrite: () => {
+            if (this.getDriver(ptyId).kind === 'mobile') {
+              throw new Error('terminal_mobile_driver_active')
+            }
           }
-        }
-      })
+        })
+      )
       return true
     } catch {
       return false
@@ -13333,6 +13350,7 @@ export class OrcaRuntimeService {
     if (exitIncarnationId && pty?.incarnationId && exitIncarnationId !== pty.incarnationId) {
       return
     }
+    this.cancelTerminalInputWrites(ptyId)
     const preservesAbnormalSshSurface =
       this.isSshOwnedPtyId(ptyId) && pty?.connectionId != null && exitCode < 0
     if (preservesAbnormalSshSurface) {
@@ -16411,7 +16429,9 @@ export class OrcaRuntimeService {
         throw new Error('invalid_terminal_send')
       }
       await assertTerminalInputWithinLimitWithYield(action.text)
-      await this.writeTerminalAction(pty.pty.ptyId, action, payload, options)
+      await this.enqueueTerminalInputWrite(pty.pty.ptyId, (queue) =>
+        this.writeTerminalAction(pty.pty.ptyId, action, payload, queue, options)
+      )
       return {
         handle,
         accepted: true,
@@ -16436,7 +16456,9 @@ export class OrcaRuntimeService {
       throw new Error('terminal_not_writable')
     }
 
-    await this.writeTerminalAction(leaf.ptyId, action, payload, options)
+    await this.enqueueTerminalInputWrite(leaf.ptyId, (queue) =>
+      this.writeTerminalAction(leaf.ptyId!, action, payload, queue, options)
+    )
 
     return {
       handle,
@@ -16461,7 +16483,9 @@ export class OrcaRuntimeService {
         throw new Error('terminal_not_writable')
       }
       await assertTerminalInputWithinLimitWithYield(payload)
-      await this.writeTerminalAgentPrompt(pty.pty.ptyId, payload, options)
+      await this.enqueueTerminalInputWrite(pty.pty.ptyId, (queue) =>
+        this.writeTerminalAgentPrompt(pty.pty.ptyId, payload, queue, options)
+      )
       return { handle, accepted: true, bytesWritten }
     }
 
@@ -16475,7 +16499,9 @@ export class OrcaRuntimeService {
     if (await this.isLeafPtyProvenAbsent(leaf.ptyId)) {
       throw new Error('terminal_not_writable')
     }
-    await this.writeTerminalAgentPrompt(leaf.ptyId, payload, options)
+    await this.enqueueTerminalInputWrite(leaf.ptyId, (queue) =>
+      this.writeTerminalAgentPrompt(leaf.ptyId!, payload, queue, options)
+    )
     return { handle, accepted: true, bytesWritten }
   }
 
@@ -16919,10 +16945,86 @@ export class OrcaRuntimeService {
     return bestStatus ? { status: bestStatus, updatedAt: bestUpdatedAt } : null
   }
 
+  private cancelTerminalInputWrites(ptyId: string): void {
+    const queue = this.terminalInputWriteQueues.get(ptyId)
+    if (!queue) {
+      return
+    }
+    queue.cancelled = true
+    this.terminalInputWriteQueues.delete(ptyId)
+    for (const delay of queue.delays) {
+      clearTimeout(delay.timer)
+      delay.reject(new Error('terminal_not_writable'))
+    }
+    queue.delays.clear()
+  }
+
+  private assertTerminalInputWriteActive(queue: TerminalInputWriteQueue): void {
+    if (queue.cancelled) {
+      throw new Error('terminal_not_writable')
+    }
+  }
+
+  private waitForTerminalInputGap(
+    queue: TerminalInputWriteQueue,
+    delayMs: number
+  ): Promise<void> {
+    if (queue.cancelled) {
+      return Promise.reject(new Error('terminal_not_writable'))
+    }
+    return new Promise<void>((resolve, reject) => {
+      const delay = {
+        timer: setTimeout(() => {
+          queue.delays.delete(delay)
+          if (queue.cancelled) {
+            reject(new Error('terminal_not_writable'))
+          } else {
+            resolve()
+          }
+        }, delayMs),
+        reject
+      }
+      queue.delays.add(delay)
+    })
+  }
+
+  private enqueueTerminalInputWrite<T>(
+    ptyId: string,
+    operation: (queue: TerminalInputWriteQueue) => Promise<T>
+  ): Promise<T> {
+    let queue = this.terminalInputWriteQueues.get(ptyId)
+    if (!queue || queue.cancelled) {
+      queue = { tail: Promise.resolve(), pending: 0, cancelled: false, delays: new Set() }
+      this.terminalInputWriteQueues.set(ptyId, queue)
+    }
+    const activeQueue = queue
+    activeQueue.pending += 1
+    const result = activeQueue.tail.then(() => {
+      if (activeQueue.cancelled) {
+        throw new Error('terminal_not_writable')
+      }
+      return operation(activeQueue)
+    })
+    activeQueue.tail = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result.finally(() => {
+      activeQueue.pending -= 1
+      if (
+        activeQueue.pending === 0 &&
+        this.terminalInputWriteQueues.get(ptyId) === activeQueue
+      ) {
+        this.terminalInputWriteQueues.delete(ptyId)
+      }
+    })
+  }
+
   private async writeTerminalAction(
     ptyId: string,
     action: { text?: string; enter?: boolean; interrupt?: boolean },
     payload: string,
+    queue: TerminalInputWriteQueue,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
       reserveWrite?: (ptyId: string) => void
@@ -16935,15 +17037,16 @@ export class OrcaRuntimeService {
     const hasText = typeof action.text === 'string' && action.text.length > 0
     const hasSuffix = action.enter || action.interrupt
     if (hasText) {
-      await this.writeTerminalInputChunks(ptyId, action.text!, options)
+      await this.writeTerminalInputChunks(ptyId, action.text!, queue, options)
     }
     if (hasSuffix) {
       const suffix = (action.enter ? '\r' : '') + (action.interrupt ? '\x03' : '')
       if (hasText) {
-        await new Promise((resolve) => setTimeout(resolve, 500))
+        await this.waitForTerminalInputGap(queue, 500)
       }
       try {
         await options.beforeWrite?.(ptyId)
+        this.assertTerminalInputWriteActive(queue)
         options.reserveWrite?.(ptyId)
       } catch (error) {
         if (options.suffixFailureError) {
@@ -16963,6 +17066,7 @@ export class OrcaRuntimeService {
     }
 
     await options.beforeWrite?.(ptyId)
+    this.assertTerminalInputWriteActive(queue)
     options.reserveWrite?.(ptyId)
     const wrote = this.ptyController?.write(ptyId, payload) ?? false
     if (!wrote) {
@@ -16974,18 +17078,21 @@ export class OrcaRuntimeService {
   private async writeTerminalInputChunks(
     ptyId: string,
     text: string,
+    queue: TerminalInputWriteQueue,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
       reserveWrite?: (ptyId: string) => void
       afterWrite?: (ptyId: string) => void | Promise<void>
     } = {}
   ): Promise<void> {
-    const chunkMaxBytes = getTerminalInputChunkMaxBytes()
-    const chunkGapMs = getTerminalInputChunkGapMs()
+    const platform = this.getPtyExecutionHostMetadata(ptyId).hostPlatform ?? process.platform
+    const chunkMaxBytes = getTerminalInputChunkMaxBytes(platform)
+    const chunkGapMs = getTerminalInputChunkGapMs(platform)
     const chunks = iterateTerminalInputChunks(text, chunkMaxBytes)
     let chunk = chunks.next()
     while (!chunk.done) {
       await options.beforeWrite?.(ptyId)
+      this.assertTerminalInputWriteActive(queue)
       options.reserveWrite?.(ptyId)
       const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
       if (!wrote) {
@@ -16997,7 +17104,7 @@ export class OrcaRuntimeService {
       if (!chunk.done && chunkGapMs > 0) {
         // Why: Windows ConPTY needs a real gap, not just setTimeout(0), or long
         // injects are silently truncated to a tail fragment (#10416).
-        await new Promise((resolve) => setTimeout(resolve, chunkGapMs))
+        await this.waitForTerminalInputGap(queue, chunkGapMs)
       }
     }
   }
@@ -17005,6 +17112,7 @@ export class OrcaRuntimeService {
   private async writeTerminalAgentPrompt(
     ptyId: string,
     pastePayload: string,
+    queue: TerminalInputWriteQueue,
     options: {
       beforeWrite?: (ptyId: string) => void | Promise<void>
       suffixFailureError?: string
@@ -17013,12 +17121,14 @@ export class OrcaRuntimeService {
     let wrotePasteBytes = false
     let completedPaste = false
     try {
-      const chunkMaxBytes = getTerminalInputChunkMaxBytes()
-      const chunkGapMs = getTerminalInputChunkGapMs()
+      const platform = this.getPtyExecutionHostMetadata(ptyId).hostPlatform ?? process.platform
+      const chunkMaxBytes = getTerminalInputChunkMaxBytes(platform)
+      const chunkGapMs = getTerminalInputChunkGapMs(platform)
       const chunks = iterateTerminalInputChunks(pastePayload, chunkMaxBytes)
       let chunk = chunks.next()
       while (!chunk.done) {
         await options.beforeWrite?.(ptyId)
+        this.assertTerminalInputWriteActive(queue)
         const wrote = this.ptyController?.write(ptyId, chunk.value) ?? false
         if (!wrote) {
           throw new Error('terminal_not_writable')
@@ -17027,20 +17137,21 @@ export class OrcaRuntimeService {
         chunk = chunks.next()
         // Why: non-Windows gap is 0 — skip the timer so we do not force an event-loop turn per chunk.
         if (!chunk.done && chunkGapMs > 0) {
-          await new Promise((resolve) => setTimeout(resolve, chunkGapMs))
+          await this.waitForTerminalInputGap(queue, chunkGapMs)
         }
       }
       completedPaste = true
     } catch (error) {
-      if (wrotePasteBytes && !completedPaste) {
+      if (wrotePasteBytes && !completedPaste && !queue.cancelled) {
         this.ptyController?.write(ptyId, AGENT_PROMPT_BRACKETED_PASTE_END)
       }
       throw error
     }
 
-    await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_SUBMIT_DELAY_MS))
+    await this.waitForTerminalInputGap(queue, AGENT_PROMPT_SUBMIT_DELAY_MS)
     try {
       await options.beforeWrite?.(ptyId)
+      this.assertTerminalInputWriteActive(queue)
     } catch (error) {
       if (options.suffixFailureError) {
         throw new Error(options.suffixFailureError)
@@ -26777,6 +26888,7 @@ export class OrcaRuntimeService {
       const siblingCount = surface?.tab.parentLayout
         ? countTerminalLayoutLeaves(surface.tab.parentLayout.root)
         : this.countLeavesInTab(tabId)
+      this.cancelTerminalInputWrites(pty.pty.ptyId)
       const ptyKilled = this.ptyController?.kill(pty.pty.ptyId) ?? false
       if (!ptyKilled || siblingCount <= 1) {
         if (surface) {
@@ -26799,6 +26911,7 @@ export class OrcaRuntimeService {
     const { leaf } = this.getLiveLeafForHandle(handle)
     let ptyKilled = false
     if (leaf.ptyId) {
+      this.cancelTerminalInputWrites(leaf.ptyId)
       ptyKilled = this.ptyController?.kill(leaf.ptyId) ?? false
     }
     // Why: in a multi-pane tab, killing the PTY is enough (renderer's exit handler closes the pane); an extra IPC close would race it and close the whole tab.
@@ -27126,6 +27239,7 @@ export class OrcaRuntimeService {
       if (options.deadline !== undefined && Date.now() >= options.deadline) {
         break
       }
+      this.cancelTerminalInputWrites(ptyId)
       const stop = (): boolean | Promise<boolean> => {
         if (options.deadline !== undefined && Date.now() >= options.deadline) {
           return false

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -83,6 +83,8 @@ import { buildOrchestrationTaskDisplayMetadata } from '../../shared/orchestratio
 import {
   isTerminalInputTooLargeWithYield,
   TERMINAL_INPUT_TOO_LARGE_ERROR,
+  getTerminalInputChunkGapMs,
+  getTerminalInputChunkMaxBytes,
   iterateTerminalInputChunks
 } from '../../shared/terminal-input'
 import {
@@ -16978,7 +16980,9 @@ export class OrcaRuntimeService {
       afterWrite?: (ptyId: string) => void | Promise<void>
     } = {}
   ): Promise<void> {
-    const chunks = iterateTerminalInputChunks(text)
+    const chunkMaxBytes = getTerminalInputChunkMaxBytes()
+    const chunkGapMs = getTerminalInputChunkGapMs()
+    const chunks = iterateTerminalInputChunks(text, chunkMaxBytes)
     let chunk = chunks.next()
     while (!chunk.done) {
       await options.beforeWrite?.(ptyId)
@@ -16990,7 +16994,9 @@ export class OrcaRuntimeService {
       await options.afterWrite?.(ptyId)
       chunk = chunks.next()
       if (!chunk.done) {
-        await new Promise((resolve) => setTimeout(resolve, 0))
+        // Why: Windows ConPTY needs a real gap, not just setTimeout(0), or long
+        // injects are silently truncated to a tail fragment (#10416).
+        await new Promise((resolve) => setTimeout(resolve, chunkGapMs))
       }
     }
   }
@@ -17006,7 +17012,9 @@ export class OrcaRuntimeService {
     let wrotePasteBytes = false
     let completedPaste = false
     try {
-      const chunks = iterateTerminalInputChunks(pastePayload)
+      const chunkMaxBytes = getTerminalInputChunkMaxBytes()
+      const chunkGapMs = getTerminalInputChunkGapMs()
+      const chunks = iterateTerminalInputChunks(pastePayload, chunkMaxBytes)
       let chunk = chunks.next()
       while (!chunk.done) {
         await options.beforeWrite?.(ptyId)
@@ -17017,7 +17025,7 @@ export class OrcaRuntimeService {
         wrotePasteBytes = true
         chunk = chunks.next()
         if (!chunk.done) {
-          await new Promise((resolve) => setTimeout(resolve, 0))
+          await new Promise((resolve) => setTimeout(resolve, chunkGapMs))
         }
       }
       completedPaste = true

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -5418,6 +5418,31 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+    it('keeps paced terminal sends alive without consuming long-poll capacity', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
+      const startKeepalive = vi.fn()
+      server['dispatcher'].dispatch = vi.fn().mockResolvedValue({
+        id: 'req_send',
+        ok: true,
+        result: { send: { handle: 'term-1', accepted: true, bytesWritten: 1 } }
+      })
+
+      await server['handleMessage'](
+        JSON.stringify({
+          id: 'req_send',
+          authToken: server['authToken'],
+          method: 'terminal.send',
+          params: { terminal: 'term-1', text: 'x' }
+        }),
+        { signal: new AbortController().signal, startKeepalive }
+      )
+
+      expect(startKeepalive).toHaveBeenCalledOnce()
+      expect(server['activeLongPolls']).toBe(0)
+    })
+
     it('does not emit keepalive frames for short RPCs', async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
       const runtime = new OrcaRuntimeService()

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1533,8 +1533,9 @@ export class OrcaRuntimeRpcServer {
     if (rejection) {
       return this.buildError(request.id, 'runtime_busy', rejection)
     }
-    if (longPoll) {
-      // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
+    if (longPoll || request.method === 'terminal.send') {
+      // Why: Windows pacing can keep a large send open past the socket idle
+      // timeout, but sends must not consume the bounded long-poll budget.
       context?.startKeepalive()
     }
 

--- a/src/shared/terminal-input.test.ts
+++ b/src/shared/terminal-input.test.ts
@@ -40,13 +40,14 @@ describe('terminal input bounds', () => {
     expect(chunks).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES), 'x'])
   })
 
-  it('uses smaller chunks and a real gap on Windows for ConPTY pacing (#10416)', () => {
-    expect(getTerminalInputChunkMaxBytes('win32')).toBe(TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32)
+  it('uses the same chunk budget on all platforms (no Windows ConPTY pacing)', () => {
+    // Why: #10416 truncation was not reproduced; 1 KiB/16 ms pacing is not shipped.
+    expect(getTerminalInputChunkMaxBytes('win32')).toBe(TERMINAL_INPUT_CHUNK_MAX_BYTES)
     expect(getTerminalInputChunkMaxBytes('darwin')).toBe(TERMINAL_INPUT_CHUNK_MAX_BYTES)
-    expect(getTerminalInputChunkGapMs('win32')).toBe(TERMINAL_INPUT_CHUNK_GAP_MS_WIN32)
+    expect(getTerminalInputChunkGapMs('win32')).toBe(0)
     expect(getTerminalInputChunkGapMs('linux')).toBe(TERMINAL_INPUT_CHUNK_GAP_MS)
-    expect(TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32).toBeLessThan(TERMINAL_INPUT_CHUNK_MAX_BYTES)
-    expect(TERMINAL_INPUT_CHUNK_GAP_MS_WIN32).toBeGreaterThan(TERMINAL_INPUT_CHUNK_GAP_MS)
+    expect(TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32).toBe(TERMINAL_INPUT_CHUNK_MAX_BYTES)
+    expect(TERMINAL_INPUT_CHUNK_GAP_MS_WIN32).toBe(TERMINAL_INPUT_CHUNK_GAP_MS)
   })
 
   it('iterates chunks lazily without prebuilding every terminal input chunk', () => {

--- a/src/shared/terminal-input.test.ts
+++ b/src/shared/terminal-input.test.ts
@@ -1,9 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   TERMINAL_INPUT_CHUNK_MAX_BYTES,
+  TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32,
+  TERMINAL_INPUT_CHUNK_GAP_MS,
+  TERMINAL_INPUT_CHUNK_GAP_MS_WIN32,
   TERMINAL_INPUT_TOO_LARGE_ERROR,
   assertTerminalInputWithinLimit,
   getTerminalInputByteLength,
+  getTerminalInputChunkGapMs,
+  getTerminalInputChunkMaxBytes,
   iterateTerminalInputChunks,
   isTerminalInputTooLarge,
   isTerminalInputTooLargeWithDeferredMeasurement,
@@ -33,6 +38,15 @@ describe('terminal input bounds', () => {
     const chunks = splitTerminalInputChunks('x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES + 1))
 
     expect(chunks).toEqual(['x'.repeat(TERMINAL_INPUT_CHUNK_MAX_BYTES), 'x'])
+  })
+
+  it('uses smaller chunks and a real gap on Windows for ConPTY pacing (#10416)', () => {
+    expect(getTerminalInputChunkMaxBytes('win32')).toBe(TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32)
+    expect(getTerminalInputChunkMaxBytes('darwin')).toBe(TERMINAL_INPUT_CHUNK_MAX_BYTES)
+    expect(getTerminalInputChunkGapMs('win32')).toBe(TERMINAL_INPUT_CHUNK_GAP_MS_WIN32)
+    expect(getTerminalInputChunkGapMs('linux')).toBe(TERMINAL_INPUT_CHUNK_GAP_MS)
+    expect(TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32).toBeLessThan(TERMINAL_INPUT_CHUNK_MAX_BYTES)
+    expect(TERMINAL_INPUT_CHUNK_GAP_MS_WIN32).toBeGreaterThan(TERMINAL_INPUT_CHUNK_GAP_MS)
   })
 
   it('iterates chunks lazily without prebuilding every terminal input chunk', () => {

--- a/src/shared/terminal-input.ts
+++ b/src/shared/terminal-input.ts
@@ -5,27 +5,26 @@ import {
 } from './clipboard-text'
 
 export const TERMINAL_INPUT_CHUNK_MAX_BYTES = 16 * 1024
-// Why: #10416 reports ConPTY loss with 16 KiB/setTimeout(0); 1 KiB per
-// 16 ms caps each burst to one 60 Hz host-drain interval.
-export const TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32 = 1024
 export const TERMINAL_INPUT_CHUNK_GAP_MS = 0
-export const TERMINAL_INPUT_CHUNK_GAP_MS_WIN32 = 16
+// Why: #10416 silent truncation was never reproduced on real ConPTY (see #10504
+// review); keep win32 aliases equal to the shared budget so host-aware call sites
+// still compile without reintroducing 1 KiB / 16 ms pacing cost.
+export const TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32 = TERMINAL_INPUT_CHUNK_MAX_BYTES
+export const TERMINAL_INPUT_CHUNK_GAP_MS_WIN32 = TERMINAL_INPUT_CHUNK_GAP_MS
 export const TERMINAL_INPUT_MAX_BYTES = 16 * 1024 * 1024
 export const TERMINAL_INPUT_TOO_LARGE_ERROR =
   'Terminal input is too large for a safe terminal send.'
 
-/** Platform-aware chunk size for paced PTY writes (inject / terminal send). */
+/** Chunk size for PTY writes (inject / terminal send). `platform` reserved for host-aware callers. */
 export function getTerminalInputChunkMaxBytes(
-  platform: NodeJS.Platform = process.platform
+  _platform: NodeJS.Platform = process.platform
 ): number {
-  return platform === 'win32'
-    ? TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32
-    : TERMINAL_INPUT_CHUNK_MAX_BYTES
+  return TERMINAL_INPUT_CHUNK_MAX_BYTES
 }
 
-/** Gap between PTY input chunks so TUI hosts can drain without dropping. */
-export function getTerminalInputChunkGapMs(platform: NodeJS.Platform = process.platform): number {
-  return platform === 'win32' ? TERMINAL_INPUT_CHUNK_GAP_MS_WIN32 : TERMINAL_INPUT_CHUNK_GAP_MS
+/** Gap between PTY input chunks; 0 skips the timer (all platforms after #10504 review). */
+export function getTerminalInputChunkGapMs(_platform: NodeJS.Platform = process.platform): number {
+  return TERMINAL_INPUT_CHUNK_GAP_MS
 }
 
 export function getTerminalInputByteLength(text: string): number {

--- a/src/shared/terminal-input.ts
+++ b/src/shared/terminal-input.ts
@@ -5,9 +5,8 @@ import {
 } from './clipboard-text'
 
 export const TERMINAL_INPUT_CHUNK_MAX_BYTES = 16 * 1024
-// Why: Windows ConPTY / TUI agents (Claude) drop mid-burst input when large
-// single or back-to-back writes flood the console host — 16 KiB + setTimeout(0)
-// still truncates long orchestration injects to a tail fragment (#10416).
+// Why: #10416 reports ConPTY loss with 16 KiB/setTimeout(0); 1 KiB per
+// 16 ms caps each burst to one 60 Hz host-drain interval.
 export const TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32 = 1024
 export const TERMINAL_INPUT_CHUNK_GAP_MS = 0
 export const TERMINAL_INPUT_CHUNK_GAP_MS_WIN32 = 16

--- a/src/shared/terminal-input.ts
+++ b/src/shared/terminal-input.ts
@@ -5,9 +5,29 @@ import {
 } from './clipboard-text'
 
 export const TERMINAL_INPUT_CHUNK_MAX_BYTES = 16 * 1024
+// Why: Windows ConPTY / TUI agents (Claude) drop mid-burst input when large
+// single or back-to-back writes flood the console host — 16 KiB + setTimeout(0)
+// still truncates long orchestration injects to a tail fragment (#10416).
+export const TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32 = 1024
+export const TERMINAL_INPUT_CHUNK_GAP_MS = 0
+export const TERMINAL_INPUT_CHUNK_GAP_MS_WIN32 = 16
 export const TERMINAL_INPUT_MAX_BYTES = 16 * 1024 * 1024
 export const TERMINAL_INPUT_TOO_LARGE_ERROR =
   'Terminal input is too large for a safe terminal send.'
+
+/** Platform-aware chunk size for paced PTY writes (inject / terminal send). */
+export function getTerminalInputChunkMaxBytes(
+  platform: NodeJS.Platform = process.platform
+): number {
+  return platform === 'win32'
+    ? TERMINAL_INPUT_CHUNK_MAX_BYTES_WIN32
+    : TERMINAL_INPUT_CHUNK_MAX_BYTES
+}
+
+/** Gap between PTY input chunks so TUI hosts can drain without dropping. */
+export function getTerminalInputChunkGapMs(platform: NodeJS.Platform = process.platform): number {
+  return platform === 'win32' ? TERMINAL_INPUT_CHUNK_GAP_MS_WIN32 : TERMINAL_INPUT_CHUNK_GAP_MS
+}
 
 export function getTerminalInputByteLength(text: string): number {
   return measureClipboardTextByteLength(text).byteLength


### PR DESCRIPTION
## Summary

Hardens large terminal sends without shipping unproven Windows ConPTY pacing:

- **Per-PTY write serialization** so concurrent `sendTerminal` / paste paths do not interleave chunk-wise
- **Host-platform-aware** chunk helper inputs (local vs SSH/WSL) for any future policy
- **Teardown cancellation** of in-flight paced/chunked writes when a PTY exits or is replaced
- **RPC keepalive** so long multi-chunk sends do not trip local socket idle timeouts
- **No 1 KiB / 16 ms Windows pacing** — independent real-Windows ConPTY probes (author + maintainer) did not reproduce silent truncation from #10416; the cost of that pacing was large and unjustified

Refs #10416

## ELI5

Orca keeps long messages for the same terminal in order and cleans up if the terminal closes mid-send. It no longer deliberately slows Windows pastes with tiny pauses, because we could not prove that was fixing a real drop.

## Test plan

- [x] `serializes concurrent terminal sends per PTY` regression (fails on main without the queue)
- [x] `terminal-input` chunk budget is platform-uniform (no Windows-only gap)
- [x] Maintainer re-review of serialize / host / teardown / keepalive paths
- [ ] Manual: large paste on Windows still feels snappy; concurrent sends stay ordered

## Review notes

Following @nwparker’s real-Windows measurements: keep the infrastructure that stands alone; drop pacing until #10416 has a reproducible repro.