### PR TITLE
fix(terminal): split panes into equal shares past the second pane

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -231,7 +231,10 @@ export function replayTerminalLayout(
 
     const createdPane = manager.splitPane(paneId, node.direction as TerminalPaneSplitDirection, {
       ratio: node.ratio,
-      leafId: getLeftmostLeafId(node.second)
+      leafId: getLeftmostLeafId(node.second),
+      // Why: a replay reproduces the saved tree exactly; an unset ratio means
+      // "the two halves were even", not "re-balance against the whole tree".
+      preserveSiblingSizes: true
     })
     if (!createdPane) {
       restoreNode(node.first, paneId)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-reconciliation.ts
@@ -75,7 +75,10 @@ export function useTerminalPaneReconciliation(controller: TerminalPaneCloseContr
           ...(splitRatio !== undefined && { ratio: splitRatio }),
           leafId: insertion.newLeafId,
           ptyId,
-          placement: insertion.placement
+          placement: insertion.placement,
+          // Why: the host owns this layout; mirror its sizes rather than
+          // re-balancing panes the host deliberately left uneven.
+          preserveSiblingSizes: true
         }
       )
       if (createdPane) {

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -27,6 +27,8 @@ export type PaneSpawnHints = {
 export type PaneSplitOptions = PaneSpawnHints & {
   ratio?: number
   leafId?: string
+  /** Keep the sizes the caller/host already chose instead of re-balancing the tree. */
+  preserveSiblingSizes?: boolean
 }
 
 export type ClosedPaneInfo = {

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -17,6 +17,7 @@ vi.mock('./pane-tree-ops', () => ({
   captureScrollState,
   equalizePaneSplitSizes: vi.fn(),
   findPaneChildren: vi.fn(),
+  isExplicitSplitRatio: vi.fn(() => false),
   promoteSibling: vi.fn(),
   removeDividers: vi.fn(),
   safeFit: vi.fn(),

--- a/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.test.ts
@@ -13,7 +13,9 @@ const applyPaneOpacity = vi.hoisted(() => vi.fn())
 const applyDividerStyles = vi.hoisted(() => vi.fn())
 
 vi.mock('./pane-tree-ops', () => ({
+  arePaneSplitSizesEqualized: vi.fn(() => false),
   captureScrollState,
+  equalizePaneSplitSizes: vi.fn(),
   findPaneChildren: vi.fn(),
   promoteSibling: vi.fn(),
   removeDividers: vi.fn(),

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -12,6 +12,7 @@ import {
   captureScrollState,
   equalizePaneSplitSizes,
   findPaneChildren,
+  isExplicitSplitRatio,
   promoteSibling,
   removeDividers,
   safeFit,
@@ -99,7 +100,9 @@ function getLayoutRoot(root: HTMLElement): HTMLElement | null {
 // would land at 50/25/25. Re-weight the whole tree unless the sizes are no
 // longer the caller's to choose — a dragged divider or a replayed ratio.
 function shouldEqualizeAfterSplit(args: SplitManagedPaneArgs): boolean {
-  if (args.opts?.preserveSiblingSizes || args.opts?.ratio !== undefined) {
+  // Why: share wrapInSplit's own test — a ratio it discards leaves an even
+  // split, which is still ours to re-weight.
+  if (args.opts?.preserveSiblingSizes || isExplicitSplitRatio(args.opts?.ratio)) {
     return false
   }
   return arePaneSplitSizesEqualized(getLayoutRoot(args.root))

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -8,7 +8,9 @@ import type {
 import type { DragReorderCallbacks } from './pane-drag-reorder'
 import { updateMultiPaneState } from './pane-drag-reorder'
 import {
+  arePaneSplitSizesEqualized,
   captureScrollState,
+  equalizePaneSplitSizes,
   findPaneChildren,
   promoteSibling,
   removeDividers,
@@ -64,8 +66,12 @@ export function splitManagedPane(args: SplitManagedPaneArgs): ManagedPane | null
   const divider = args.createDivider(isVertical)
 
   const movedPaneStates = prepareMovedPanesForSplit(existingContainer, existing, args.panes)
+  const equalizeAfterSplit = shouldEqualizeAfterSplit(args)
 
   wrapInSplit(existingContainer, newPane.container, isVertical, divider, args.opts)
+  if (equalizeAfterSplit) {
+    equalizePaneSplitSizes(getLayoutRoot(args.root))
+  }
   args.setActivePaneId(newPane.id)
   openSplitPane(args, newPane, args.opts?.cwd)
 
@@ -80,6 +86,23 @@ export function splitManagedPane(args: SplitManagedPaneArgs): ManagedPane | null
   }
 
   return toPublicPane(newPane)
+}
+
+function getLayoutRoot(root: HTMLElement): HTMLElement | null {
+  // Why: duck-typed instead of `instanceof HTMLElement` so this stays callable
+  // where no DOM global exists; pane trees only ever hold HTML elements.
+  const first = root.firstElementChild
+  return first && 'style' in first ? (first as HTMLElement) : null
+}
+
+// Why: wrapInSplit nests the new split inside the old one, so a third pane
+// would land at 50/25/25. Re-weight the whole tree unless the sizes are no
+// longer the caller's to choose — a dragged divider or a replayed ratio.
+function shouldEqualizeAfterSplit(args: SplitManagedPaneArgs): boolean {
+  if (args.opts?.preserveSiblingSizes || args.opts?.ratio !== undefined) {
+    return false
+  }
+  return arePaneSplitSizesEqualized(getLayoutRoot(args.root))
 }
 
 function prepareMovedPanesForSplit(

--- a/src/renderer/src/lib/pane-manager/pane-split-equal-sizes.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-equal-sizes.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+
+vi.mock('./pane-tree-ops', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  captureScrollState: vi.fn(() => null),
+  safeFit: vi.fn()
+}))
+
+vi.mock('./pane-lifecycle', () => ({
+  disposePane: vi.fn(),
+  openTerminal: vi.fn()
+}))
+
+vi.mock('./pane-webgl-renderer', () => ({ disposeWebgl: vi.fn() }))
+vi.mock('./pane-webgl-reattach', () => ({ reattachWebglIfNeeded: vi.fn() }))
+vi.mock('./pane-split-scroll', () => ({
+  clearPendingSplitScrollRestore: vi.fn(),
+  scheduleSplitScrollRestore: vi.fn()
+}))
+vi.mock('./pane-drag-reorder', () => ({ updateMultiPaneState: vi.fn() }))
+vi.mock('./pane-divider', () => ({
+  applyDividerStyles: vi.fn(),
+  applyPaneOpacity: vi.fn()
+}))
+
+import { splitManagedPane } from './pane-split-close'
+
+let nextPaneId = 0
+
+function createPane(): ManagedPaneInternal {
+  nextPaneId += 1
+  const container = document.createElement('div')
+  container.className = 'pane'
+  container.dataset.paneId = String(nextPaneId)
+  return {
+    id: nextPaneId,
+    leafId: `leaf-${nextPaneId}` as TerminalLeafId,
+    terminal: { focus: vi.fn() },
+    container,
+    webglAddon: null,
+    pendingSplitScrollState: null
+  } as unknown as ManagedPaneInternal
+}
+
+/** Rendered share of each pane, left to right, as flex-grow weights. */
+function paneFlexGrowths(root: HTMLElement): number[] {
+  return Array.from(root.querySelectorAll<HTMLElement>('.pane')).map((pane) => {
+    let share = Number.parseFloat(pane.style.flex) || 1
+    let node = pane.parentElement
+    while (node && node !== root) {
+      if (node.classList.contains('pane-split')) {
+        const siblings = Array.from(node.children).filter(
+          (child): child is HTMLElement =>
+            child instanceof HTMLElement &&
+            (child.classList.contains('pane') || child.classList.contains('pane-split'))
+        )
+        const total = siblings.reduce(
+          (sum, sibling) => sum + (Number.parseFloat(sibling.style.flex) || 1),
+          0
+        )
+        share *= (Number.parseFloat(node.style.flex) || 1) / (total || 1)
+      }
+      node = node.parentElement
+    }
+    return Math.round(share * 1000) / 1000
+  })
+}
+
+describe('splitManagedPane pane sizing', () => {
+  let root: HTMLElement
+  let panes: Map<number, ManagedPaneInternal>
+
+  const split = (paneId: number, opts?: Parameters<typeof splitManagedPane>[0]['opts']) =>
+    splitManagedPane({
+      paneId,
+      direction: 'vertical',
+      opts,
+      panes,
+      root,
+      styleOptions: {},
+      managerOptions: { linkOpenHint: () => '' },
+      createPaneInternal: () => {
+        const pane = createPane()
+        panes.set(pane.id, pane)
+        return pane
+      },
+      createDivider: () => {
+        const divider = document.createElement('div')
+        divider.className = 'pane-divider'
+        return divider
+      },
+      publishPaneCreated: vi.fn(),
+      getDragCallbacks: () => ({}) as never,
+      setActivePaneId: vi.fn(),
+      isDestroyed: () => false
+    })
+
+  beforeEach(() => {
+    nextPaneId = 0
+    root = document.createElement('div')
+    document.body.replaceChildren(root)
+    const initial = createPane()
+    root.appendChild(initial.container)
+    panes = new Map([[initial.id, initial]])
+  })
+
+  it('splits an untouched layout into equal shares as panes are added', () => {
+    split(1)
+    expect(paneFlexGrowths(root)).toEqual([0.5, 0.5])
+
+    split(2)
+    expect(paneFlexGrowths(root)).toEqual([0.333, 0.333, 0.333])
+
+    split(3)
+    expect(paneFlexGrowths(root)).toEqual([0.25, 0.25, 0.25, 0.25])
+  })
+
+  it('keeps a dragged divider ratio instead of re-equalizing', () => {
+    split(1)
+    const [first, second] = Array.from(root.querySelectorAll<HTMLElement>('.pane'))
+    first.style.flex = '0.8 1 0%'
+    second.style.flex = '0.2 1 0%'
+
+    split(2)
+
+    expect(paneFlexGrowths(root)).toEqual([0.8, 0.1, 0.1])
+  })
+
+  it('keeps caller-supplied ratios so layout replay restores exact sizes', () => {
+    split(1, { ratio: 0.75 })
+    expect(paneFlexGrowths(root)).toEqual([0.75, 0.25])
+  })
+
+  it('keeps sizes when the caller preserves them', () => {
+    split(1)
+    split(2, { preserveSiblingSizes: true })
+
+    expect(paneFlexGrowths(root)).toEqual([0.5, 0.25, 0.25])
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-split-equal-sizes.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-equal-sizes.test.ts
@@ -134,6 +134,15 @@ describe('splitManagedPane pane sizing', () => {
     expect(paneFlexGrowths(root)).toEqual([0.75, 0.25])
   })
 
+  it('equalizes past a ratio that would collapse a pane, since it is not applied', () => {
+    split(1)
+    // Why: wrapInSplit discards a ratio outside (0, 1), leaving an even split —
+    // so the layout is still ours to re-weight.
+    split(2, { ratio: 0 })
+
+    expect(paneFlexGrowths(root)).toEqual([0.333, 0.333, 0.333])
+  })
+
   it('keeps sizes when the caller preserves them', () => {
     split(1)
     split(2, { preserveSiblingSizes: true })

--- a/src/renderer/src/lib/pane-manager/pane-subtree-split.ts
+++ b/src/renderer/src/lib/pane-manager/pane-subtree-split.ts
@@ -13,6 +13,7 @@ export type SplitPaneAroundLeafIdsOptions = {
   leafId?: string
   ptyId?: string
   placement?: 'before' | 'after'
+  preserveSiblingSizes?: boolean
 }
 
 type SplitPaneAroundLeafIdsArgs = {

--- a/src/renderer/src/lib/pane-manager/pane-tree-equalization.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-equalization.ts
@@ -23,7 +23,7 @@ function getEqualizeWeight(el: HTMLElement, direction: 'vertical' | 'horizontal'
   )
 }
 
-export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
+function walkEqualizedPaneSplitSizes(root: HTMLElement | null, apply: boolean): boolean {
   if (!root) {
     return false
   }
@@ -43,7 +43,9 @@ export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
         const weight = getEqualizeWeight(child, direction)
         const nextFlex = `${weight} 1 0%`
         if (child.style.flex !== nextFlex) {
-          child.style.flex = nextFlex
+          if (apply) {
+            child.style.flex = nextFlex
+          }
           changed = true
         }
       }
@@ -56,4 +58,14 @@ export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
 
   visit(root)
   return changed
+}
+
+export function equalizePaneSplitSizes(root: HTMLElement | null): boolean {
+  return walkEqualizedPaneSplitSizes(root, true)
+}
+
+/** True when every split already renders its panes at equal shares — i.e. no
+ *  divider has been dragged and no ratio was restored. */
+export function arePaneSplitSizesEqualized(root: HTMLElement | null): boolean {
+  return !walkEqualizedPaneSplitSizes(root, false)
 }

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import {
+  arePaneSplitSizesEqualized,
   cancelPendingSafeFitContinuations,
   equalizePaneSplitSizes,
   safeFit,
@@ -850,5 +851,48 @@ describe('equalizePaneSplitSizes', () => {
   it('returns false when there is no split tree to change', () => {
     expect(equalizePaneSplitSizes(pane() as unknown as HTMLElement)).toBe(false)
     expect(equalizePaneSplitSizes(null)).toBe(false)
+  })
+})
+
+describe('arePaneSplitSizesEqualized', () => {
+  const pane = (flex = '1 1 0%'): MockHTMLElement => new MockHTMLElement(['pane'], [], flex)
+  const split = (
+    direction: 'vertical' | 'horizontal',
+    children: MockHTMLElement[],
+    flex = '1 1 0%'
+  ): MockHTMLElement =>
+    new MockHTMLElement(
+      ['pane-split', direction === 'vertical' ? 'is-vertical' : 'is-horizontal'],
+      children,
+      flex
+    )
+
+  it('treats a single pane and an even two-pane split as equalized', () => {
+    expect(arePaneSplitSizesEqualized(null)).toBe(true)
+    expect(arePaneSplitSizesEqualized(pane() as unknown as HTMLElement)).toBe(true)
+    const root = split('vertical', [pane(), pane()])
+    expect(arePaneSplitSizesEqualized(root as unknown as HTMLElement)).toBe(true)
+  })
+
+  it('reports a dragged divider as not equalized', () => {
+    const root = split('vertical', [pane('0.7 1 0%'), pane('0.3 1 0%')])
+    expect(arePaneSplitSizesEqualized(root as unknown as HTMLElement)).toBe(false)
+  })
+
+  it('reports an unweighted nested same-axis split as not equalized', () => {
+    const root = split('vertical', [pane(), split('vertical', [pane(), pane()])])
+    expect(arePaneSplitSizesEqualized(root as unknown as HTMLElement)).toBe(false)
+  })
+
+  it('reports a weighted nested same-axis split as equalized', () => {
+    const root = split('vertical', [pane(), split('vertical', [pane(), pane()], '2 1 0%')])
+    expect(arePaneSplitSizesEqualized(root as unknown as HTMLElement)).toBe(true)
+  })
+
+  it('does not mutate the tree it inspects', () => {
+    const left = pane('0.7 1 0%')
+    const root = split('vertical', [left, pane('0.3 1 0%')])
+    arePaneSplitSizesEqualized(root as unknown as HTMLElement)
+    expect(left.style.flex).toBe('0.7 1 0%')
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -15,7 +15,11 @@ export {
   type SafeFitContinuationHandle
 } from './pane-fit'
 export { captureScrollState, restoreScrollState } from './pane-scroll'
-export { equalizePaneSplitSizes, findPaneChildren } from './pane-tree-equalization'
+export {
+  arePaneSplitSizesEqualized,
+  equalizePaneSplitSizes,
+  findPaneChildren
+} from './pane-tree-equalization'
 
 // ---------------------------------------------------------------------------
 // Split-tree manipulation: detach, insert, promote sibling

--- a/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
+++ b/src/renderer/src/lib/pane-manager/pane-tree-ops.ts
@@ -246,6 +246,12 @@ export function removeDividers(parent: HTMLElement): void {
   }
 }
 
+/** A ratio only sizes a split when it leaves both panes on screen; anything
+ *  else falls through to an even split, so callers must agree on the test. */
+export function isExplicitSplitRatio(ratio: number | undefined): ratio is number {
+  return ratio !== undefined && ratio > 0 && ratio < 1
+}
+
 /**
  * Create a flex split wrapper that replaces `existingContainer` in the DOM,
  * then places [existing] [divider] [new] inside it.
@@ -288,7 +294,7 @@ export function wrapInSplit(
 
   // Apply custom ratio if provided
   const ratio = opts?.ratio
-  if (ratio !== undefined && ratio > 0 && ratio < 1) {
+  if (isExplicitSplitRatio(ratio)) {
     existingContainer.style.flex = `${ratio} 1 0%`
     newContainer.style.flex = `${1 - ratio} 1 0%`
   }


### PR DESCRIPTION
## Summary

Splitting a terminal pane past the second pane no longer collapses into uneven shares. `Cmd+D` on a two-pane layout produced 50/25/25 instead of thirds, and a fourth split made it worse (50/25/12.5/12.5).

The cause is structural: `wrapInSplit` always wraps the split target in a *new* split node, so a third split builds `split(A, split(B, C))`. Both levels default to `flex: 1 1 0%`, so A keeps half the width while B and C divide the other half. The pane-count weighting that fixes this already existed in `equalizePaneSplitSizes`, but only ran from the manual "Equalize split sizes" action.

`splitManagedPane` now re-equalizes after a split — but only when the layout was still evenly divided beforehand, so sizes the user or the host chose are never overwritten:

- a dragged divider leaves the tree unequal, so the split keeps the existing proportions and just halves the target pane (old behavior)
- an explicit `ratio` (layout replay) is left untouched. The guard shares `wrapInSplit`'s own `isExplicitSplitRatio` test, so a ratio `wrapInSplit` discards — outside `(0, 1)` — still equalizes, since what it actually rendered was an even split.
- a new `preserveSiblingSizes` opt-out covers the two callers that reproduce a layout rather than create one: `replayTerminalLayout` and the host-authoritative live layout insertions in `TerminalPane`. Without it, a saved 50/25/25 layout would silently re-balance to thirds on restore, because an even sub-split serializes with no explicit ratio.

## Screenshots

1. BEFORE  — three panes on unpatched `main`      → 50 / 25 / 25

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/2085ee29-c406-4308-8f99-8f627b9a9921" />

3. AFTER   — three panes on this branch           → 33 / 33 / 33

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/6f219053-bd6b-48c4-823b-612799f1b6d9" />

No screenshot. The change is pane geometry, and it is pinned precisely by measured widths instead: the numbers below come from driving the real app (Playwright + Electron, `Cmd+D` twice from a single pane) on an identical window, before and after the fix.

| panes | before | after |
| --- | --- | --- |
| 2 | 50 / 50 | 50 / 50 |
| 3 | **436 / 214 / 214 px — 50 / 25 / 25** | **291 / 286 / 286 px — 34 / 33 / 33** |
| 4 | 50 / 25 / 12.5 / 12.5 | 25 / 25 / 25 / 25 |

(The 4-pane row is from unit tests rather than the app run.)

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`pnpm test` reports 13 pre-existing failures in this checkout (electron-builder/packaging/WSL/localStorage suites); the identical 13 files and 45 cases fail on unmodified `main` here, so they are environmental and unrelated. Everything under `src/renderer/src/lib/pane-manager/` and `src/renderer/src/components/terminal-pane/` passes (239 files, 2983 cases).

New tests:
- `pane-split-equal-sizes.test.ts` — drives `splitManagedPane` against a real DOM and asserts the rendered share of each pane after successive splits, plus the cases that must *not* re-equalize (dragged divider, explicit ratio, `preserveSiblingSizes`) and the one that must (a ratio outside `(0, 1)`, which `wrapInSplit` discards).
- `pane-tree-ops.test.ts` — unit coverage for `arePaneSplitSizesEqualized`, including that it does not mutate the tree it inspects.

Verified end-to-end in the running app on macOS via the measured widths above.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Silently overwriting user intent** — the main risk. Re-equalizing unconditionally would discard dragged divider positions. Verified the guard reads the layout *before* `wrapInSplit` mutates it, and added a regression test for the dragged-divider case.
- **Layout restore fidelity** — traced serialization round-trips. `serializePaneTree` omits a ratio when it is within 0.005 of 0.5, so a saved 50/25/25 tree replays as two ratio-less splits; without `preserveSiblingSizes` the replay would have re-balanced it to thirds. Covered by a test.
- **Remote/SSH, web runtime, local** — `splitPaneAroundLeafIds` funnels into the same function. The host-authoritative insertion path in `TerminalPane` mirrors a host layout, so it opts out; user- and CLI-initiated splits (`Cmd+D`, split menu, `SPLIT_TERMINAL_PANE_EVENT`) equalize. `splitWebRuntimeTerminal` short-circuits before this code for web-runtime panes, so paired web terminals still take their split from the host.
- **Agent and integration compatibility** — nothing here reads agent identity, PTY contents, or integration state; a pane is sized the same whether it hosts a plain shell, a CLI agent, or a remote session. No provider- or agent-specific branch was added.
- **Performance** — the added work is one tree walk over `.pane` / `.pane-split` nodes on split only (typically <10 nodes, bounded by pane count), not on resize, render, or PTY data. The probe pass allocates nothing and short-circuits to `equalizePaneSplitSizes`'s existing walk. No hot path touched.
- **UI quality** — verified in the running app: dividers stay aligned, no visible reflow flash, and the existing `safeFit`/`ResizeObserver` path refits terminals after the flex change, so no pane is left with a stale grid.
- **Cross-platform (macOS/Linux/Windows)** — no platform-dependent code touched: no shortcuts, labels, paths, or shell behavior. The change is flex-style arithmetic on DOM nodes, identical on all three. The `Cmd+D`/`Ctrl+D` binding itself is unchanged.
- **DOM-global availability** — `getLayoutRoot` uses a duck-typed check instead of `instanceof HTMLElement` so `pane-split-close` stays importable in the `node` test environment.

CodeRabbit flagged that the original guard skipped equalization for *any* defined ratio while `wrapInSplit` only honors one inside `(0, 1)`; both now share `isExplicitSplitRatio` so the two tests cannot drift apart, with a test for the discarded-ratio case.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface is touched. The change reads and writes `style.flex` on already-trusted, app-created DOM nodes; no new persisted state and no new external data enters the layout path.

## Notes

`preserveSiblingSizes` is opt-out rather than opt-in deliberately: a missed call site then re-balances a layout (visible, harmless) instead of silently discarding sizes a user or host chose. The two replay call sites are the only ones that reproduce an existing layout.

## ELI5

Splitting terminals past two panes gave uneven sizes (50/25/25 instead of equal thirds). New splits redistribute space so every pane gets an equal share.
