### PR TITLE
fix(sidebar): stop browser-pane selections from hijacking sidebar hover

### DIFF
--- a/src/main/ipc/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers.test.ts
@@ -56,6 +56,7 @@ const {
   registerCodexConfigSyncHandlersMock,
   registerOnboardingHandlersMock,
   registerDashboardPopoutHandlersMock,
+  registerWebviewHoverLeakHandlersMock,
   registerTerminalPreviewHandlersMock,
   registerSpeechHandlersMock,
   registerSkillsHandlersMock,
@@ -121,6 +122,7 @@ const {
   registerCodexConfigSyncHandlersMock: vi.fn(),
   registerOnboardingHandlersMock: vi.fn(),
   registerDashboardPopoutHandlersMock: vi.fn(),
+  registerWebviewHoverLeakHandlersMock: vi.fn(),
   registerTerminalPreviewHandlersMock: vi.fn(),
   registerSpeechHandlersMock: vi.fn(),
   registerSkillsHandlersMock: vi.fn(),
@@ -156,6 +158,10 @@ vi.mock('./onboarding', () => ({
 
 vi.mock('./dashboard-popout', () => ({
   registerDashboardPopoutHandlers: registerDashboardPopoutHandlersMock
+}))
+
+vi.mock('./webview-hover-leak', () => ({
+  registerWebviewHoverLeakHandlers: registerWebviewHoverLeakHandlersMock
 }))
 
 vi.mock('./terminal-preview', () => ({
@@ -436,6 +442,7 @@ describe('registerCoreHandlers', () => {
     registerHostedReviewHandlersMock.mockReset()
     registerExportHandlersMock.mockReset()
     registerDashboardPopoutHandlersMock.mockReset()
+    registerWebviewHoverLeakHandlersMock.mockReset()
     registerTerminalPreviewHandlersMock.mockReset()
     registerSpeechHandlersMock.mockReset()
     registerSkillsHandlersMock.mockReset()
@@ -517,6 +524,7 @@ describe('registerCoreHandlers', () => {
     expect(registerDeveloperPermissionHandlersMock).toHaveBeenCalled()
     expect(registerComputerUsePermissionHandlersMock).toHaveBeenCalled()
     expect(registerDashboardPopoutHandlersMock).toHaveBeenCalledWith(store, undefined)
+    expect(registerWebviewHoverLeakHandlersMock).toHaveBeenCalled()
     expect(registerTerminalPreviewHandlersMock).toHaveBeenCalledWith(runtime)
     expect(registerSettingsHandlersMock).toHaveBeenCalledWith(store, agentAwakeService)
     expect(registerSkillsHandlersMock).toHaveBeenCalledWith(store)

--- a/src/main/ipc/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers.ts
@@ -59,6 +59,7 @@ import { registerAgentHookHandlers } from './agent-hooks'
 import { registerCodexConfigSyncHandlers } from './codex-config-sync'
 import { getPtyIdForPaneKey } from './pty'
 import { registerAgentTrustHandlers } from './agent-trust'
+import { registerWebviewHoverLeakHandlers } from './webview-hover-leak'
 import { registerClaudeAccountHandlers } from './claude-accounts'
 import { registerMiniMaxCredentialsHandlers } from './minimax-credentials'
 import { registerGrokAccountHandlers } from './grok-accounts'
@@ -213,6 +214,7 @@ export function registerCoreHandlers(
       prepareRuntimeAiVaultSessionResume(app.getPath('userData'), environmentId, args)
   })
   registerNativeChatHandlers()
+  registerWebviewHoverLeakHandlers()
   registerClipboardHandlers(store)
   registerUpdaterHandlers(store)
   registerSpeechHandlers(store)

--- a/src/main/ipc/webview-hover-leak.test.ts
+++ b/src/main/ipc/webview-hover-leak.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const handlers = new Map<string, (event: unknown, ...args: unknown[]) => unknown>()
+const sendInputEvent = vi.fn()
+const fromWebContents = vi.fn()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: (event: unknown, ...args: unknown[]) => unknown) => {
+      handlers.set(channel, handler)
+    },
+    removeHandler: (channel: string) => {
+      handlers.delete(channel)
+    }
+  },
+  BrowserWindow: {
+    fromWebContents: (...args: unknown[]) => fromWebContents(...args)
+  }
+}))
+
+const {
+  CLEAR_STALE_HOVER_CHANNEL,
+  registerWebviewHoverLeakHandlers,
+  resetWebviewHoverLeakThrottleForTests
+} = await import('./webview-hover-leak')
+
+describe('registerWebviewHoverLeakHandlers', () => {
+  let now = 1000
+
+  beforeEach(() => {
+    now = 1000
+    sendInputEvent.mockClear()
+    fromWebContents.mockReset()
+    resetWebviewHoverLeakThrottleForTests()
+    registerWebviewHoverLeakHandlers(() => now)
+  })
+
+  afterEach(() => {
+    handlers.clear()
+  })
+
+  function invoke(senderId = 1): unknown {
+    const handler = handlers.get(CLEAR_STALE_HOVER_CHANNEL)
+    if (!handler) {
+      throw new Error('handler was not registered')
+    }
+    return handler({ sender: { id: senderId } })
+  }
+
+  it('clears hover with a mouseLeave carrying no renderer-supplied coordinates', () => {
+    fromWebContents.mockReturnValue({ isDestroyed: () => false, webContents: { sendInputEvent } })
+
+    invoke()
+
+    expect(sendInputEvent).toHaveBeenCalledWith({ type: 'mouseLeave', x: -1, y: -1 })
+  })
+
+  it('coalesces bursts from one renderer', () => {
+    fromWebContents.mockReturnValue({ isDestroyed: () => false, webContents: { sendInputEvent } })
+
+    invoke()
+    invoke()
+    now += 10
+    invoke()
+
+    expect(sendInputEvent).toHaveBeenCalledTimes(1)
+
+    now += 50
+    invoke()
+
+    expect(sendInputEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it('throttles per renderer rather than globally', () => {
+    fromWebContents.mockReturnValue({ isDestroyed: () => false, webContents: { sendInputEvent } })
+
+    invoke(1)
+    invoke(2)
+
+    expect(sendInputEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores a destroyed or detached window', () => {
+    fromWebContents.mockReturnValue({ isDestroyed: () => true, webContents: { sendInputEvent } })
+    invoke()
+
+    fromWebContents.mockReturnValue(null)
+    invoke(2)
+
+    expect(sendInputEvent).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/webview-hover-leak.ts
+++ b/src/main/ipc/webview-hover-leak.ts
@@ -1,0 +1,43 @@
+import { BrowserWindow, ipcMain } from 'electron'
+
+/**
+ * Resets a window's stale CSS hover state after Chromium leaks guest coordinates out of a `<webview>`.
+ *
+ * Why here and not in the renderer: releasing the mouse inside a browser/mobile pane delivers the
+ * embedder a `pointerup` carrying the guest's *viewport* coordinates (screen coordinates stay correct),
+ * so Blink hit-tests a point one webview-origin away from the real cursor and parks `:hover` on whatever
+ * sidebar row sits there. Only trusted input moves Blink's hover state, and renderers cannot synthesize
+ * it — `pointer-events: none` and untrusted events both leave the stale hover in place. A `mouseLeave`
+ * is the honest correction: the real pointer is inside the guest, so nothing in the host is hovered.
+ */
+export const CLEAR_STALE_HOVER_CHANNEL = 'ui:clearStaleHoverState'
+
+/** Why: one leak per mouse release, but coalesce bursts so a wedged renderer cannot flood input. */
+const MIN_RESET_INTERVAL_MS = 50
+
+const lastResetByWebContentsId = new Map<number, number>()
+
+export function registerWebviewHoverLeakHandlers(now: () => number = Date.now): void {
+  ipcMain.removeHandler(CLEAR_STALE_HOVER_CHANNEL)
+  ipcMain.handle(CLEAR_STALE_HOVER_CHANNEL, (event) => {
+    const window = BrowserWindow.fromWebContents(event.sender)
+    if (!window || window.isDestroyed()) {
+      return
+    }
+    const senderId = event.sender.id
+    const at = now()
+    const last = lastResetByWebContentsId.get(senderId)
+    if (last !== undefined && at - last < MIN_RESET_INTERVAL_MS) {
+      return
+    }
+    lastResetByWebContentsId.set(senderId, at)
+    // Why: coordinates are fixed here rather than taken from the renderer — the only capability this
+    // exposes is "forget the hover in your own window", never a synthetic click at a chosen point.
+    window.webContents.sendInputEvent({ type: 'mouseLeave', x: -1, y: -1 })
+  })
+}
+
+/** Test seam: drop coalescing state between cases. */
+export function resetWebviewHoverLeakThrottleForTests(): void {
+  lastResetByWebContentsId.clear()
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3022,6 +3022,7 @@ export type PreloadApi = {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null
     }) => Promise<string | null>
+    clearStaleHoverState: () => Promise<void>
     writeClipboardText: (text: string) => Promise<void>
     writeSelectionClipboardText: (text: string) => Promise<void>
     writeClipboardImage: (dataUrl: string) => Promise<void>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3794,6 +3794,9 @@ const api = {
       connectionId?: string | null
       runtimeEnvironmentId?: string | null
     }): Promise<string | null> => ipcRenderer.invoke('clipboard:saveImageAsTempFile', args),
+    // Why: Chromium leaks guest-local pointer coordinates out of a <webview> on release, parking CSS
+    // hover on an unrelated host element. Only trusted input clears Blink's hover state.
+    clearStaleHoverState: (): Promise<void> => ipcRenderer.invoke('ui:clearStaleHoverState'),
     writeClipboardText: (text: string): Promise<void> =>
       ipcRenderer.invoke('clipboard:writeText', text),
     writeSelectionClipboardText: (text: string): Promise<void> =>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -92,6 +92,7 @@ import RecentTabSwitcher from './components/tab-bar/RecentTabSwitcher'
 import { useGitStatusPolling } from './components/right-sidebar/useGitStatusPolling'
 import { useEditorExternalWatch } from './hooks/useEditorExternalWatch'
 import { useAutoAckViewedAgent } from './hooks/useAutoAckViewedAgent'
+import { installWebviewPointerLeakCorrection } from './hooks/webview-leaked-pointer-guard'
 import { useDashboardPopoutBridge } from './components/dashboard/useDashboardPopoutBridge'
 import { useUnreadDockBadge } from './hooks/useUnreadDockBadge'
 import {
@@ -612,6 +613,10 @@ function App(): React.JSX.Element {
     },
     [floatingTerminalOpen, rememberFloatingTerminalReturnFocus, restoreFloatingTerminalReturnFocus]
   )
+
+  // Why: repairs the window's hover state after Chromium leaks guest-local pointer coordinates out of a
+  // <webview>, which otherwise leaves a sidebar row stuck in its hover style.
+  useEffect(() => installWebviewPointerLeakCorrection(), [])
 
   useEffect(() => {
     const toggleFloatingTerminal = (): void => {

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.hover-focus.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.hover-focus.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+
+import { act, useEffect } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { WorktreeCardDetailsHover } from './WorktreeCardMeta'
+import {
+  useWorktreeCardDetailsHoverControl,
+  type WorktreeCardDetailsHoverControl
+} from './worktree-card-details-hover-state'
+import {
+  calibrateHostPointerOrigin,
+  resetHostPointerOriginForTests
+} from '@/hooks/webview-leaked-pointer-guard'
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+describe('WorktreeCardDetailsHover focus handling', () => {
+  let container: HTMLDivElement
+  let root: Root
+  let control: WorktreeCardDetailsHoverControl | null = null
+
+  afterEach(() => {
+    act(() => {
+      root.unmount()
+    })
+    container.remove()
+    control = null
+    resetHostPointerOriginForTests()
+  })
+
+  function Harness(): React.JSX.Element {
+    const hoverControl = useWorktreeCardDetailsHoverControl()
+    useEffect(() => {
+      control = hoverControl
+    })
+    return (
+      <WorktreeCardDetailsHover
+        issue={null}
+        linearIssue={null}
+        review={null}
+        comment={null}
+        automationProvenance={null}
+        automationHostId={undefined}
+        branchName="feat/KRB-1823-condition-guard-event-labels"
+        workspaceTitle="Debug cjv3 20k users"
+        openDelay={0}
+        closeDelay={0}
+        hoverControl={hoverControl}
+      >
+        <div data-testid="trigger">
+          <button type="button" data-testid="inner">
+            delete workspace
+          </button>
+        </div>
+      </WorktreeCardDetailsHover>
+    )
+  }
+
+  function mountHarness(): void {
+    container = document.createElement('div')
+    document.body.append(container)
+    root = createRoot(container)
+    act(() => {
+      root.render(<Harness />)
+    })
+  }
+
+  async function settleOpenDelay(): Promise<void> {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+    })
+  }
+
+  // Captured from a real drag-select: window origin (459,25), webview origin (281,87).
+  const WINDOW_ORIGIN = { x: 459, y: 25 }
+  const WEBVIEW_ORIGIN = { x: 281, y: 87 }
+
+  function calibrate(): void {
+    calibrateHostPointerOrigin(
+      {
+        clientX: 186,
+        clientY: 620,
+        screenX: 186 + WINDOW_ORIGIN.x,
+        screenY: 620 + WINDOW_ORIGIN.y
+      },
+      { authoritative: true }
+    )
+  }
+
+  async function enterTrigger(init: {
+    clientX: number
+    clientY: number
+    screenX: number
+    screenY: number
+  }): Promise<void> {
+    const trigger = container.querySelector<HTMLElement>('[data-testid="trigger"]')
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent('pointerover', { ...init, bubbles: true, buttons: 0 }))
+    })
+    await settleOpenDelay()
+  }
+
+  it('opens when the pointer really is over the card', async () => {
+    mountHarness()
+    calibrate()
+
+    await enterTrigger({
+      clientX: 140,
+      clientY: 60,
+      screenX: 140 + WINDOW_ORIGIN.x,
+      screenY: 60 + WINDOW_ORIGIN.y
+    })
+
+    expect(control?.hoverOpen).toBe(true)
+  })
+
+  it('ignores a webview-leaked enter carrying guest-local coordinates', async () => {
+    mountHarness()
+    calibrate()
+
+    // Why: the captured leak — client says 129,60 in the sidebar while screen says the pointer is
+    // really inside the browser pane, one webview origin away.
+    await enterTrigger({
+      clientX: 129,
+      clientY: 60,
+      screenX: 129 + WINDOW_ORIGIN.x + WEBVIEW_ORIGIN.x,
+      screenY: 60 + WINDOW_ORIGIN.y + WEBVIEW_ORIGIN.y
+    })
+
+    expect(control?.hoverOpen).toBe(false)
+  })
+
+  it('does not open when focus lands on a control inside the card', async () => {
+    mountHarness()
+
+    const inner = container.querySelector<HTMLButtonElement>('[data-testid="inner"]')
+    await act(async () => {
+      inner?.dispatchEvent(new Event('focusin', { bubbles: true }))
+    })
+    await settleOpenDelay()
+
+    expect(control?.hoverOpen).toBe(false)
+  })
+
+  it('still opens when the trigger itself takes focus', async () => {
+    mountHarness()
+
+    const trigger = container.querySelector<HTMLElement>('[data-testid="trigger"]')
+    await act(async () => {
+      trigger?.dispatchEvent(new Event('focusin', { bubbles: true }))
+    })
+    await settleOpenDelay()
+
+    expect(control?.hoverOpen).toBe(true)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.tsx
@@ -28,6 +28,7 @@ import { WorktreeCardReviewDetailSection } from './WorktreeCardReviewDetailSecti
 import { WorktreeCardAutomationDetailSection } from './WorktreeCardAutomationDetailSection'
 import { WorktreeCardIssueDetailSection } from './WorktreeCardIssueDetailSection'
 import { WorktreeCardHoverIdentityHeader } from './WorktreeCardHoverIdentityHeader'
+import { isGenuineHostPointerEnter } from '@/hooks/webview-leaked-pointer-guard'
 
 export type {
   WorktreeCardIssueDisplay,
@@ -254,7 +255,28 @@ export function WorktreeCardDetailsHover({
       openDelay={openDelay}
       closeDelay={closeDelay}
     >
-      <HoverCardTrigger asChild>{children}</HoverCardTrigger>
+      <HoverCardTrigger
+        asChild
+        // Why: selecting text in a browser/mobile pane leaks guest-local pointer coordinates into the
+        // host document, which hit-test onto the sidebar and open this card over the page the user is
+        // reading — with no matching leave to ever close it. Only real motion over the card opens it.
+        onPointerEnter={(event) => {
+          if (!isGenuineHostPointerEnter(event)) {
+            event.preventDefault()
+          }
+        }}
+        // Why: the trigger wraps the whole card, so `focusin` bubbling from an inner control (or focus
+        // restored after an action) would open the card with the pointer somewhere else entirely — over
+        // the browser pane there is then no pointer leave to ever close it again. Focus on the trigger
+        // itself still opens, which is the keyboard path Radix wants.
+        onFocus={(event) => {
+          if (event.target !== event.currentTarget) {
+            event.preventDefault()
+          }
+        }}
+      >
+        {children}
+      </HoverCardTrigger>
       <HoverCardContent
         side="right"
         align="start"

--- a/src/renderer/src/components/sidebar/worktree-card-details-hover-state.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-details-hover-state.test.tsx
@@ -92,6 +92,63 @@ describe('useWorktreeCardDetailsHoverControl', () => {
     expect(control?.hoverOpen).toBe(true)
   })
 
+  function focusInsideWebviewGuest(): void {
+    const webview = document.createElement('webview')
+    document.body.append(webview)
+    act(() => {
+      webview.dispatchEvent(new Event('focusin', { bubbles: true }))
+    })
+    webview.remove()
+  }
+
+  it('closes the hover when focus moves into a webview guest', () => {
+    mountProbe()
+
+    act(() => {
+      control?.handleHoverOpenChange(true)
+    })
+    expect(control?.hoverOpen).toBe(true)
+
+    focusInsideWebviewGuest()
+
+    expect(control?.hoverOpen).toBe(false)
+  })
+
+  it('closes the detail menu layer that would otherwise swallow the close', () => {
+    mountProbe()
+
+    act(() => {
+      control?.handleHoverOpenChange(true)
+      control?.handleReviewMenuOpenChange(true)
+    })
+    expect(control?.hoverOpen).toBe(true)
+
+    focusInsideWebviewGuest()
+
+    expect(control?.hoverOpen).toBe(false)
+    expect(control?.reviewMenuOpen).toBe(false)
+  })
+
+  it('leaves a closed hover alone and ignores focus outside a guest', () => {
+    mountProbe()
+
+    focusInsideWebviewGuest()
+    expect(control?.hoverOpen).toBe(false)
+
+    act(() => {
+      control?.handleHoverOpenChange(true)
+    })
+    const outside = document.createElement('div')
+    document.body.append(outside)
+    act(() => {
+      outside.dispatchEvent(new Event('focusin', { bubbles: true }))
+    })
+    outside.remove()
+
+    // Why: Radix owns dismissal for ordinary host DOM; only guest surfaces need the assist.
+    expect(control?.hoverOpen).toBe(true)
+  })
+
   it('closes both layers from closeHover', () => {
     mountProbe()
     expect(control).not.toBeNull()

--- a/src/renderer/src/components/sidebar/worktree-card-details-hover-state.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-details-hover-state.ts
@@ -1,4 +1,5 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { addWebviewGuestFocusListener } from '@/hooks/webview-guest-focus-listener'
 
 type WorktreeCardDetailMenu = 'issue' | 'review'
 
@@ -26,6 +27,15 @@ export function useWorktreeCardDetailsHoverControl() {
     },
     [openMenu]
   )
+
+  // Why: the card floats over the browser/mobile panes, and a press inside a guest never reaches this
+  // document, so Radix's outside-press dismissal never runs. Retire both layers on guest focus instead.
+  useEffect(() => {
+    if (!open && !openMenu) {
+      return
+    }
+    return addWebviewGuestFocusListener(closeHover)
+  }, [closeHover, open, openMenu])
 
   const setDetailMenuOpen = useCallback((menu: WorktreeCardDetailMenu, next: boolean) => {
     setOpenMenu(next ? menu : null)

--- a/src/renderer/src/hooks/webview-guest-focus-listener.test.ts
+++ b/src/renderer/src/hooks/webview-guest-focus-listener.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { addWebviewGuestFocusListener } from './webview-guest-focus-listener'
+
+describe('addWebviewGuestFocusListener', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function mountWebview(): HTMLElement {
+    const webview = document.createElement('webview')
+    document.body.append(webview)
+    return webview
+  }
+
+  it('fires when focus lands on a webview guest', () => {
+    const onGuestFocus = vi.fn()
+    const stop = addWebviewGuestFocusListener(onGuestFocus)
+
+    mountWebview().dispatchEvent(new Event('focusin', { bubbles: true }))
+
+    expect(onGuestFocus).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('fires for focus inside a webview guest', () => {
+    const onGuestFocus = vi.fn()
+    const stop = addWebviewGuestFocusListener(onGuestFocus)
+    const inner = document.createElement('div')
+    mountWebview().append(inner)
+
+    inner.dispatchEvent(new Event('focusin', { bubbles: true }))
+
+    expect(onGuestFocus).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('ignores focus outside a webview guest', () => {
+    const onGuestFocus = vi.fn()
+    const stop = addWebviewGuestFocusListener(onGuestFocus)
+    const sibling = document.createElement('button')
+    document.body.append(sibling)
+    mountWebview()
+
+    sibling.dispatchEvent(new Event('focusin', { bubbles: true }))
+
+    expect(onGuestFocus).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('still fires when the guest stops propagation', () => {
+    const onGuestFocus = vi.fn()
+    const stop = addWebviewGuestFocusListener(onGuestFocus)
+    const webview = mountWebview()
+    webview.addEventListener('focusin', (event) => event.stopPropagation())
+
+    webview.dispatchEvent(new Event('focusin', { bubbles: true }))
+
+    expect(onGuestFocus).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('stops listening once unsubscribed', () => {
+    const onGuestFocus = vi.fn()
+    const stop = addWebviewGuestFocusListener(onGuestFocus)
+    const webview = mountWebview()
+
+    stop()
+    webview.dispatchEvent(new Event('focusin', { bubbles: true }))
+
+    expect(onGuestFocus).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/webview-guest-focus-listener.ts
+++ b/src/renderer/src/hooks/webview-guest-focus-listener.ts
@@ -1,0 +1,24 @@
+/**
+ * Run `onGuestFocus` when focus moves into an embedded `<webview>` guest (browser pane, mobile emulator).
+ *
+ * Why: interacting inside a guest never reaches the host document as a `pointerdown`, so Radix's
+ * outside-press dismissal cannot retire an open hover card, and it deliberately ignores focus leaving the
+ * layer. Focus landing on the `<webview>` is the one host-visible signal that the user has moved into the
+ * guest, which is when a card floating over that pane has to go.
+ */
+const GUEST_FOCUS_EVENT = 'focusin'
+
+export function addWebviewGuestFocusListener(
+  onGuestFocus: () => void,
+  target: Document = document
+): () => void {
+  const handleFocusIn = (event: Event): void => {
+    const node = event.target
+    if (!(node instanceof Element) || !node.closest('webview')) {
+      return
+    }
+    onGuestFocus()
+  }
+  target.addEventListener(GUEST_FOCUS_EVENT, handleFocusIn, true)
+  return () => target.removeEventListener(GUEST_FOCUS_EVENT, handleFocusIn, true)
+}

--- a/src/renderer/src/hooks/webview-leaked-pointer-guard.test.ts
+++ b/src/renderer/src/hooks/webview-leaked-pointer-guard.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  calibrateHostPointerOrigin,
+  installWebviewPointerLeakCorrection,
+  isGenuineHostPointerEnter,
+  isLeakedGuestPointerEvent,
+  resetHostPointerOriginForTests
+} from './webview-leaked-pointer-guard'
+
+// Captured from a real drag-select in a browser pane: window origin (459,25), webview origin (281,87).
+const WINDOW_ORIGIN = { x: 459, y: 25 }
+const WEBVIEW_ORIGIN = { x: 281, y: 87 }
+
+function hostEvent(clientX: number, clientY: number, buttons = 0) {
+  return {
+    clientX,
+    clientY,
+    screenX: clientX + WINDOW_ORIGIN.x,
+    screenY: clientY + WINDOW_ORIGIN.y,
+    buttons
+  }
+}
+
+/** A guest event handed to the host verbatim: client stays guest-local, screen stays correct. */
+function leakedEvent(guestClientX: number, guestClientY: number, buttons = 0) {
+  return {
+    clientX: guestClientX,
+    clientY: guestClientY,
+    screenX: guestClientX + WINDOW_ORIGIN.x + WEBVIEW_ORIGIN.x,
+    screenY: guestClientY + WINDOW_ORIGIN.y + WEBVIEW_ORIGIN.y,
+    buttons
+  }
+}
+
+describe('webview pointer leak detection', () => {
+  afterEach(() => {
+    resetHostPointerOriginForTests()
+  })
+
+  it('treats events as genuine until calibrated so hover never breaks', () => {
+    expect(isLeakedGuestPointerEvent(leakedEvent(93, 155))).toBe(false)
+  })
+
+  it('flags the captured leak once calibrated from a host press', () => {
+    calibrateHostPointerOrigin(hostEvent(186, 620), { authoritative: true })
+
+    expect(isLeakedGuestPointerEvent(hostEvent(140, 60))).toBe(false)
+    expect(isLeakedGuestPointerEvent(leakedEvent(129, 60))).toBe(true)
+    expect(isLeakedGuestPointerEvent(leakedEvent(153, 184))).toBe(true)
+  })
+
+  it('needs two agreeing moves before trusting a new origin', () => {
+    calibrateHostPointerOrigin(hostEvent(100, 100), { authoritative: true })
+    const moved = { clientX: 100, clientY: 100, screenX: 700, screenY: 400, buttons: 0 }
+
+    calibrateHostPointerOrigin(moved, { authoritative: false })
+    // Why: a single disagreeing sample could be a leak, so the reference must not move yet.
+    expect(isLeakedGuestPointerEvent(moved)).toBe(true)
+
+    calibrateHostPointerOrigin(moved, { authoritative: false })
+    expect(isLeakedGuestPointerEvent(moved)).toBe(false)
+  })
+
+  it('re-calibrates immediately from a press after the window moves', () => {
+    calibrateHostPointerOrigin(hostEvent(100, 100), { authoritative: true })
+    const afterWindowMove = { clientX: 100, clientY: 100, screenX: 900, screenY: 500, buttons: 0 }
+
+    calibrateHostPointerOrigin(afterWindowMove, { authoritative: true })
+
+    expect(isLeakedGuestPointerEvent(afterWindowMove)).toBe(false)
+  })
+
+  it('rejects hover intent for leaks and for held buttons, accepts real enters', () => {
+    calibrateHostPointerOrigin(hostEvent(186, 620), { authoritative: true })
+
+    expect(isGenuineHostPointerEnter(hostEvent(140, 60))).toBe(true)
+    expect(isGenuineHostPointerEnter(leakedEvent(129, 60))).toBe(false)
+    expect(isGenuineHostPointerEnter(hostEvent(140, 60, 1))).toBe(false)
+  })
+})
+
+describe('installWebviewPointerLeakCorrection', () => {
+  const clearStaleHoverState = vi.fn(() => Promise.resolve())
+
+  beforeEach(() => {
+    clearStaleHoverState.mockClear()
+    Object.assign(window, { api: { ui: { clearStaleHoverState } } })
+    document.body.innerHTML = '<div id="row" style="width:100px;height:20px">row</div>'
+  })
+
+  afterEach(() => {
+    resetHostPointerOriginForTests()
+    document.body.innerHTML = ''
+  })
+
+  function dispatch(type: string, sample: ReturnType<typeof hostEvent>): void {
+    window.dispatchEvent(new MouseEvent(type, { ...sample, bubbles: true }))
+  }
+
+  it('asks the main process to drop hover when a leak lands on hovered UI', () => {
+    const stop = installWebviewPointerLeakCorrection()
+    dispatch('pointerdown', hostEvent(186, 620))
+    // Why: happy-dom reports no :hover, so stand in for Blink's stale hover state.
+    const querySelectorAll = vi
+      .spyOn(document, 'querySelectorAll')
+      .mockReturnValue([document.getElementById('row')] as unknown as NodeListOf<Element>)
+
+    dispatch('pointerup', leakedEvent(129, 60))
+
+    expect(clearStaleHoverState).toHaveBeenCalledTimes(1)
+    querySelectorAll.mockRestore()
+    stop()
+  })
+
+  it('leaves genuine events alone', () => {
+    const stop = installWebviewPointerLeakCorrection()
+    dispatch('pointerdown', hostEvent(186, 620))
+
+    dispatch('pointerup', hostEvent(190, 615))
+    dispatch('pointerover', hostEvent(140, 60))
+
+    expect(clearStaleHoverState).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('skips the round-trip when nothing is hovered', () => {
+    const stop = installWebviewPointerLeakCorrection()
+    dispatch('pointerdown', hostEvent(186, 620))
+
+    dispatch('pointerup', leakedEvent(129, 60))
+
+    expect(clearStaleHoverState).not.toHaveBeenCalled()
+    stop()
+  })
+})

--- a/src/renderer/src/hooks/webview-leaked-pointer-guard.ts
+++ b/src/renderer/src/hooks/webview-leaked-pointer-guard.ts
@@ -1,0 +1,138 @@
+/**
+ * Detects pointer events Chromium leaks out of a `<webview>` guest, and repairs the hover state they
+ * corrupt.
+ *
+ * Why: releasing the mouse inside a browser/mobile pane delivers the embedder a `pointerup` whose
+ * `screenX/screenY` are correct but whose `clientX/clientY` are the *guest's* viewport coordinates,
+ * untranslated. Blink hit-tests that point in the host document — one webview origin up and to the left
+ * of the real cursor, so usually the sidebar — which both fires phantom hover affordances and parks
+ * `:hover` on a row the pointer never visited.
+ *
+ * The tell is exact rather than heuristic: for a genuine host event `screen - client` equals the window's
+ * content origin, while a leaked one is off by the webview's origin. The origin is learned from the
+ * events Chromium never leaks (press and move) so this keeps working across window moves, platform frame
+ * differences, and display scale changes.
+ */
+const ORIGIN_TOLERANCE_PX = 1
+
+type PointerSample = { clientX: number; clientY: number; screenX: number; screenY: number }
+
+// Why scalars, not an object: calibration runs on every host pointermove, so the common path must not
+// allocate. It is also the reason each branch below re-reads the two deltas instead of boxing them.
+let calibrated = false
+let originX = 0
+let originY = 0
+let hasPending = false
+let pendingX = 0
+let pendingY = 0
+let installed = false
+
+function near(a: number, b: number): boolean {
+  const delta = a - b
+  return delta <= ORIGIN_TOLERANCE_PX && delta >= -ORIGIN_TOLERANCE_PX
+}
+
+/**
+ * Feed an event Chromium delivers with embedder coordinates. `pointerdown` is authoritative (a press
+ * inside a guest produces no host press at all); a `pointermove` only re-calibrates after two agreeing
+ * samples, so one anomalous event cannot move the reference.
+ */
+export function calibrateHostPointerOrigin(
+  event: PointerSample,
+  { authoritative }: { authoritative: boolean }
+): void {
+  const x = event.screenX - event.clientX
+  const y = event.screenY - event.clientY
+  if (calibrated && near(x, originX) && near(y, originY)) {
+    hasPending = false
+    return
+  }
+  if (authoritative || !calibrated) {
+    calibrated = true
+    originX = x
+    originY = y
+    hasPending = false
+    return
+  }
+  if (hasPending && near(x, pendingX) && near(y, pendingY)) {
+    originX = x
+    originY = y
+    hasPending = false
+    return
+  }
+  hasPending = true
+  pendingX = x
+  pendingY = y
+}
+
+/** True when the event's client coordinates belong to a `<webview>` guest rather than this document. */
+export function isLeakedGuestPointerEvent(event: PointerSample): boolean {
+  if (!calibrated) {
+    // Why: fail open — before calibration, treating events as leaked would break all hover.
+    return false
+  }
+  return (
+    !near(event.screenX - event.clientX, originX) || !near(event.screenY - event.clientY, originY)
+  )
+}
+
+/**
+ * True when `event` is real hover intent: coordinates that belong to this document, with no button held.
+ * The held-button clause matches `focus-follows-mouse`, where a press means a selection or drag.
+ */
+export function isGenuineHostPointerEnter(event: PointerSample & { buttons: number }): boolean {
+  return event.buttons === 0 && !isLeakedGuestPointerEvent(event)
+}
+
+/**
+ * Watch for leaks and ask the main process to drop the window's hover state when one lands. Renderers
+ * cannot clear it themselves: `pointer-events: none` leaves the stale `:hover` applied and untrusted
+ * events never move Blink's hover target.
+ */
+export function installWebviewPointerLeakCorrection(): () => void {
+  if (installed) {
+    return () => {}
+  }
+  installed = true
+  const onAuthoritative = (event: PointerEvent): void => {
+    calibrateHostPointerOrigin(event, { authoritative: true })
+  }
+  const onMotion = (event: PointerEvent): void => {
+    calibrateHostPointerOrigin(event, { authoritative: false })
+  }
+  const onLeakCandidate = (event: PointerEvent): void => {
+    if (!isLeakedGuestPointerEvent(event)) {
+      return
+    }
+    // Why: with nothing hovered there is nothing to repair, which also keeps repeated leaks from
+    // re-invoking the main process on every mouse release.
+    if (document.querySelectorAll(':hover').length === 0) {
+      return
+    }
+    void window.api.ui.clearStaleHoverState().catch(() => {
+      // Why: hover repair is cosmetic — a closed window or missing host must not surface an error.
+    })
+  }
+  const listeners: [string, (event: PointerEvent) => void][] = [
+    ['pointerdown', onAuthoritative],
+    ['pointermove', onMotion],
+    ['pointerup', onLeakCandidate],
+    ['pointerover', onLeakCandidate]
+  ]
+  for (const [type, listener] of listeners) {
+    window.addEventListener(type, listener as EventListener, { capture: true, passive: true })
+  }
+  return () => {
+    for (const [type, listener] of listeners) {
+      window.removeEventListener(type, listener as EventListener, { capture: true })
+    }
+    installed = false
+  }
+}
+
+/** Test seam: forget calibration between cases. */
+export function resetHostPointerOriginForTests(): void {
+  calibrated = false
+  hasPending = false
+  installed = false
+}


### PR DESCRIPTION
## What changed

Selecting text in a browser tab moved hover onto the left sidebar. A workspace card's details popover
opened over the page and stayed there, and sidebar nav rows kept their hover tint until the mouse moved
again. Neither followed the pointer — it was still inside the browser pane.

### Before / after

Both clips drag-select text in a browser tab.

**Before** — the workspace popover opens over the page and the sidebar nav row lights up, neither
following the pointer:

https://github.com/user-attachments/assets/74550230-fe88-45aa-8cfa-ec95166faf00

**After** — the pointer stays where it is and the sidebar is left alone:

https://github.com/user-attachments/assets/30b44637-c52d-4534-ae44-938e1cc8c712

## Root cause

Chromium hands the embedder a `pointerup` whose `screenX/screenY` are correct but whose
`clientX/clientY` are the **guest's viewport coordinates, untranslated**. The host hit-tests that point
one webview origin up and to the left of the real cursor, which lands in the sidebar.

Measured on a real drag-select, with the guest and host instrumented simultaneously:

| | `screen − client` |
|---|---|
| genuine host event | `(459, 25)` = window content origin |
| leaked event | `(740, 112)` = window origin **+ webview origin (281, 87)** |

Guest `pointerup client=(129,60)` arrived at the host as `client=(129,60)` verbatim. Ruled out along the
way: Orca does not inject input (no `sendInputEvent` anywhere in `src/`, no synthetic `MouseEvent`/
`PointerEvent` dispatch in renderer or preload), and it is not a CSS transform mismapping (the webview's
ancestor chain has no `transform`/`zoom`/`scale`, `visualViewport.scale` is 1).

Two further measurements shaped the fix:

- A press inside a guest produces **no host `pointerdown`** at all, only a later `pointerup`. That is why
  Radix's outside-press dismissal never retired the popover.
- CSS `:hover` cannot be reset from a renderer. `pointer-events: none` on the sidebar leaves the row
  `:hover` (verified), and untrusted events never move Blink's hover target. A trusted `mouseLeave` does
  clear it; a trusted move aimed *at* the webview does not, because it routes to the guest.

## Fix

**Detection is exact, not heuristic** (`src/renderer/src/hooks/webview-leaked-pointer-guard.ts`). For a
genuine host event `screen − client` equals the window's content origin. The origin is learned from the
events Chromium never leaks: `pointerdown` is authoritative, and `pointermove` re-calibrates only after
two agreeing samples. It therefore survives window moves, platform frame differences, and display-scale
changes, and it **fails open** before calibration so hover can never break.

1. **The popover no longer opens from leaked coordinates**, or while a button is held. The held-button
   clause matches `focus-follows-mouse.ts:29-33`, which already refuses to act on hover mid-drag because
   a held button means a selection or drag rather than hover intent.
2. **The stale hover state is repaired** (`src/main/ipc/webview-hover-leak.ts`): on a detected leak with
   something hovered, main sends `sendInputEvent({type: 'mouseLeave', x: -1, y: -1})`. Coordinates are
   fixed in main, so the only capability exposed is "forget hover in your own window", never a synthetic
   click at a chosen point. Coalesced to one per 50 ms per renderer, and skipped entirely when nothing is
   hovered — after a repair the hover count is zero, so repeat leaks cost nothing.
3. **An open popover is retired when focus moves into a guest**
   (`src/renderer/src/hooks/webview-guest-focus-listener.ts`), since Radix cannot dismiss without a host
   `pointerdown` and ignores focus leaving the layer by design. Focus bubbling from a control inside a
   card also no longer opens the popover with the pointer elsewhere.

Guards 1 and 2 fix the reported bug. Guard 3 is Radix-specific and separable — happy to split it into a
follow-up if you'd prefer a tighter PR.

## Tests

28 cases across four files, each mutation-checked (reverting the guard fails the test):

- `webview-leaked-pointer-guard.test.ts` — the captured leak `client=(129,60)` with its `+281,+87` screen
  offset, fail-open before calibration, two-sample move re-calibration, authoritative press
  re-calibration, and the IPC being skipped when nothing is hovered.
- `webview-hover-leak.test.ts` — the `mouseLeave` payload, per-renderer coalescing, destroyed/detached
  windows.
- `WorktreeCardMeta.hover-focus.test.tsx` — opens on a real enter, ignores a leaked enter, ignores
  descendant focus, still opens on focus of the trigger itself.
- `webview-guest-focus-listener.test.ts`, `worktree-card-details-hover-state.test.tsx` — guest-focus
  retirement including the detail-menu layer that otherwise swallows the close.

## AI code review summary

- **Cross-platform**: no platform branches. No hardcoded modifiers or path assumptions. The detector is
  calibrated from observed events rather than assuming a frame geometry, so a platform where
  `screen − client` behaves differently degrades to today's behaviour instead of breaking hover.
  Reproduced and verified on macOS only; the leak is Chromium-side so Windows/Linux are expected to
  match, but I have not confirmed it there.
- **SSH / remote**: remote and paired browser panes render DOM (screencast), not a `<webview>`, so no
  leak occurs and both guards are inert. No filesystem, git, or network assumptions.
- **Agents / integrations / git providers**: untouched — no agent, provider, or integration code paths
  involved.
- **Performance** (measured, 100k events): 0.82 µs per `pointermove` and per `pointerup`, both upper
  bounds since the baseline event type had no listeners and the delta includes other app listeners. All
  four listeners are `passive`, calibration exits after two comparisons on the common path and does not
  allocate. The `:hover` query (5.6 µs) and the IPC (0.2–1.3 ms) run only on a detected leak, at most once
  per mouse release.
- **UI quality**: no visual changes; no tokens, styles, or components altered. Behaviour only:
  hover affordances stop firing for a pointer that is not there.
- **Security**: one new IPC with no renderer-supplied parameters. It resolves the sender's own window and
  can only clear that window's hover state; it cannot target another window, move the OS cursor, or
  synthesize a click. Rate-limited per renderer.

## Notes

`pnpm lint`, `pnpm typecheck`, and `pnpm build` pass. On `pnpm test`, the local suite shows 8 failing
files, none from this change: 6 fail identically on a clean `main` (verified by stashing), and 2 in
`src/main/daemon/` are flaky — they pass in isolation and a different one failed on each run. That is
likely an artifact of invoking vitest directly under Node 24 to bypass `ensure-native-runtime`, since
`pnpm test` refuses to start on Node 26.

X: [@nduongg04](https://x.com/nduongg04)

## ELI5

Selecting text inside a browser pane incorrectly put hover on the left sidebar, opening workspace popovers and tinting nav rows. Browser selections no longer hijack sidebar hover.
