### PR TITLE
fix: OpenCode sessions missing on Windows (#10332) + Pi Shift+Enter submits after tool (#9703)

### DIFF
--- a/src/main/opencode-usage/scanner.test.ts
+++ b/src/main/opencode-usage/scanner.test.ts
@@ -5,9 +5,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import Database from '../sqlite/sync-database'
 import {
   attributeOpenCodeUsageEvent,
+  listOpenCodeDatabases,
   parseOpenCodeUsageDatabase,
   parseOpenCodeUsageRow,
-  resolveOpenCodeDataDirectory,
   scanOpenCodeUsageDatabases
 } from './scanner'
 
@@ -22,20 +22,81 @@ function createTempDb(): { db: Database.Database; path: string } {
   return { db: new Database(path), path }
 }
 
-describe('resolveOpenCodeDataDirectory', () => {
-  it('uses XDG_DATA_HOME when set', () => {
-    expect(resolveOpenCodeDataDirectory({ env: { XDG_DATA_HOME: '/custom/xdg' }, homeDir: '/home/u' }))
-      .toBe(join('/custom/xdg', 'opencode'))
+describe('listOpenCodeDatabases', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+  let home: string
+  let previousEnv: Partial<Record<string, string | undefined>>
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'orca-opencode-home-'))
+    tempDirs.push(home)
+    previousEnv = {
+      HOME: process.env.HOME,
+      USERPROFILE: process.env.USERPROFILE,
+      XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+      LOCALAPPDATA: process.env.LOCALAPPDATA,
+      APPDATA: process.env.APPDATA,
+      OPENCODE_DB: process.env.OPENCODE_DB
+    }
+    process.env.HOME = home
+    process.env.USERPROFILE = home
+    delete process.env.XDG_DATA_HOME
+    delete process.env.OPENCODE_DB
   })
 
-  it('falls back to ~/.local/share on every platform, ignoring %LOCALAPPDATA% on Windows (#10332)', () => {
-    // Why: OpenCode stores its DB at ~/.local/share/opencode cross-platform; the
-    // previous Windows branch pointed at %LOCALAPPDATA%/opencode and never found it.
-    const winLike = { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local', APPDATA: 'C:\\Users\\u\\AppData\\Roaming' }
-    expect(resolveOpenCodeDataDirectory({ env: winLike, homeDir: 'C:\\Users\\u' }))
-      .toBe(join('C:\\Users\\u', '.local', 'share', 'opencode'))
-    expect(resolveOpenCodeDataDirectory({ env: {}, homeDir: '/home/u' }))
-      .toBe(join('/home/u', '.local', 'share', 'opencode'))
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+    for (const [key, value] of Object.entries(previousEnv)) {
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true })
+    }
+    tempDirs = []
+  })
+
+  it('finds opencode.db under ~/.local/share on Windows instead of %LOCALAPPDATA% (#10332)', async () => {
+    // Why: OpenCode resolves its data dir via xdg-basedir on Windows too, so the DB
+    // lands in ~/.local/share/opencode while %LOCALAPPDATA%\opencode never exists.
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    process.env.LOCALAPPDATA = join(home, 'AppData', 'Local')
+    process.env.APPDATA = join(home, 'AppData', 'Roaming')
+    mkdirSync(join(home, 'AppData', 'Local'), { recursive: true })
+    const dataDir = join(home, '.local', 'share', 'opencode')
+    mkdirSync(dataDir, { recursive: true })
+    const dbPath = join(dataDir, 'opencode.db')
+    new Database(dbPath).close()
+
+    expect(await listOpenCodeDatabases()).toEqual([dbPath])
+  })
+
+  it('still honors XDG_DATA_HOME when set', async () => {
+    const xdgRoot = mkdtempSync(join(tmpdir(), 'orca-opencode-xdg-'))
+    tempDirs.push(xdgRoot)
+    process.env.XDG_DATA_HOME = xdgRoot
+    mkdirSync(join(xdgRoot, 'opencode'), { recursive: true })
+    const dbPath = join(xdgRoot, 'opencode', 'opencode.db')
+    new Database(dbPath).close()
+
+    expect(await listOpenCodeDatabases()).toEqual([dbPath])
+  })
+
+  it('keeps an explicit OPENCODE_DB override ahead of the derived directory', async () => {
+    const overrideDir = mkdtempSync(join(tmpdir(), 'orca-opencode-override-'))
+    tempDirs.push(overrideDir)
+    const overridePath = join(overrideDir, 'opencode.db')
+    new Database(overridePath).close()
+    mkdirSync(join(home, '.local', 'share', 'opencode'), { recursive: true })
+    new Database(join(home, '.local', 'share', 'opencode', 'opencode.db')).close()
+    process.env.OPENCODE_DB = overridePath
+
+    expect(await listOpenCodeDatabases()).toEqual([overridePath])
   })
 })
 

--- a/src/main/opencode-usage/scanner.test.ts
+++ b/src/main/opencode-usage/scanner.test.ts
@@ -7,6 +7,7 @@ import {
   attributeOpenCodeUsageEvent,
   parseOpenCodeUsageDatabase,
   parseOpenCodeUsageRow,
+  resolveOpenCodeDataDirectory,
   scanOpenCodeUsageDatabases
 } from './scanner'
 
@@ -20,6 +21,23 @@ function createTempDb(): { db: Database.Database; path: string } {
   const path = join(dir, 'opencode.db')
   return { db: new Database(path), path }
 }
+
+describe('resolveOpenCodeDataDirectory', () => {
+  it('uses XDG_DATA_HOME when set', () => {
+    expect(resolveOpenCodeDataDirectory({ env: { XDG_DATA_HOME: '/custom/xdg' }, homeDir: '/home/u' }))
+      .toBe(join('/custom/xdg', 'opencode'))
+  })
+
+  it('falls back to ~/.local/share on every platform, ignoring %LOCALAPPDATA% on Windows (#10332)', () => {
+    // Why: OpenCode stores its DB at ~/.local/share/opencode cross-platform; the
+    // previous Windows branch pointed at %LOCALAPPDATA%/opencode and never found it.
+    const winLike = { LOCALAPPDATA: 'C:\\Users\\u\\AppData\\Local', APPDATA: 'C:\\Users\\u\\AppData\\Roaming' }
+    expect(resolveOpenCodeDataDirectory({ env: winLike, homeDir: 'C:\\Users\\u' }))
+      .toBe(join('C:\\Users\\u', '.local', 'share', 'opencode'))
+    expect(resolveOpenCodeDataDirectory({ env: {}, homeDir: '/home/u' }))
+      .toBe(join('/home/u', '.local', 'share', 'opencode'))
+  })
+})
 
 function worktrees() {
   return [

--- a/src/main/opencode-usage/scanner.ts
+++ b/src/main/opencode-usage/scanner.ts
@@ -79,18 +79,22 @@ function looksLikeWindowsPath(pathValue: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
 }
 
-function getXdgDataHome(): string {
-  if (process.env.XDG_DATA_HOME?.trim()) {
-    return process.env.XDG_DATA_HOME.trim()
-  }
-  if (process.platform === 'win32') {
-    return process.env.LOCALAPPDATA || process.env.APPDATA || join(homedir(), 'AppData', 'Local')
-  }
-  return join(homedir(), '.local', 'share')
+type OpenCodeDataDirOptions = {
+  env?: NodeJS.ProcessEnv
+  homeDir?: string
+}
+
+// Why: OpenCode stores its data at ~/.local/share/opencode on every platform, including Windows — not under %LOCALAPPDATA% (#10332). Exported pure form lets the Windows path be regression-tested without a real home dir.
+export function resolveOpenCodeDataDirectory(opts: OpenCodeDataDirOptions = {}): string {
+  const env = opts.env ?? process.env
+  const home = opts.homeDir ?? homedir()
+  const xdg = env.XDG_DATA_HOME?.trim()
+  const dataHome = xdg ? xdg : join(home, '.local', 'share')
+  return join(dataHome, 'opencode')
 }
 
 function getOpenCodeDataDirectory(): string {
-  return join(getXdgDataHome(), 'opencode')
+  return resolveOpenCodeDataDirectory()
 }
 
 function getOpenCodeDatabasePathFromEnv(): string | null {

--- a/src/main/opencode-usage/scanner.ts
+++ b/src/main/opencode-usage/scanner.ts
@@ -79,22 +79,11 @@ function looksLikeWindowsPath(pathValue: string): boolean {
   return /^[A-Za-z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\')
 }
 
-type OpenCodeDataDirOptions = {
-  env?: NodeJS.ProcessEnv
-  homeDir?: string
-}
-
-// Why: OpenCode stores its data at ~/.local/share/opencode on every platform, including Windows — not under %LOCALAPPDATA% (#10332). Exported pure form lets the Windows path be regression-tested without a real home dir.
-export function resolveOpenCodeDataDirectory(opts: OpenCodeDataDirOptions = {}): string {
-  const env = opts.env ?? process.env
-  const home = opts.homeDir ?? homedir()
-  const xdg = env.XDG_DATA_HOME?.trim()
-  const dataHome = xdg ? xdg : join(home, '.local', 'share')
-  return join(dataHome, 'opencode')
-}
-
+// Why: OpenCode resolves its data dir through xdg-basedir on every platform, so on
+// Windows the DB is at ~/.local/share/opencode, not %LOCALAPPDATA% (#10332).
 function getOpenCodeDataDirectory(): string {
-  return resolveOpenCodeDataDirectory()
+  const xdgDataHome = process.env.XDG_DATA_HOME?.trim()
+  return join(xdgDataHome || join(homedir(), '.local', 'share'), 'opencode')
 }
 
 function getOpenCodeDatabasePathFromEnv(): string | null {

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -14,6 +14,16 @@ describe('resolveWindowsShiftEnterEncoding', () => {
     expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'droid' })).toBe('alt-enter')
   })
 
+  it('uses CSI-u for trusted Pi process evidence so Shift+Enter survives tool-subprocess churn (#9703)', () => {
+    expect(
+      resolveWindowsShiftEnterEncoding({
+        foreground: { agent: 'pi', routingTrusted: true, shellForeground: false }
+      })
+    ).toBe('csi-u')
+    // Why: launch ownership alone must not route input — only trusted foreground evidence.
+    expect(resolveWindowsShiftEnterEncoding({ launchAgentType: 'pi' })).toBe('alt-enter')
+  })
+
   it('does not let hook or OSC-derived status forge Droid input routing', () => {
     const state = {
       paneForegroundAgentByPaneKey: {},
@@ -35,6 +45,16 @@ describe('resolveWindowsShiftEnterEncoding', () => {
       ).toBe('alt-enter')
     }
     expect(resolveWindowsShiftEnterEncoding({})).toBe('alt-enter')
+  })
+
+  it('keeps the legacy byte for trusted agents without a CSI-u override (e.g. Gemini, Cursor)', () => {
+    for (const agent of ['gemini', 'cursor', 'codex'] as const) {
+      expect(
+        resolveWindowsShiftEnterEncoding({
+          foreground: { agent, routingTrusted: true, shellForeground: false }
+        })
+      ).toBe('alt-enter')
+    }
   })
 
   it('lets current process identity override stale launch ownership', () => {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -118,7 +118,9 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     expectedProcess: 'pi',
     promptInjectionMode: 'argv',
     // Why: pi has no `--prefill` and paste-after-ready races its long startup; the orca-prefill extension seeds this env var instead.
-    draftPromptEnvVar: 'ORCA_PI_PREFILL'
+    draftPromptEnvVar: 'ORCA_PI_PREFILL',
+    // Why: Pi enables the Kitty keyboard protocol at startup and decodes CSI-u; trust it on Windows so Shift+Enter stays a newline after tool-subprocess churn instead of falling back to Esc+CR (submit) (#9703).
+    windowsShiftEnterEncoding: 'csi-u'
   },
   omp: {
     detectCmd: 'omp',


### PR DESCRIPTION
## Summary

Two independent Windows bugs, one line of behavior change each.

**1. OpenCode sessions missing from Agent Session History on Windows (#10332).** OpenCode resolves its data directory through [`xdg-basedir`](https://github.com/sindresorhus/xdg-basedir) on *every* platform, so on Windows its SQLite DB lands at `~/.local/share/opencode/opencode.db` — not under `%LOCALAPPDATA%`. This is a known, still-open quirk on OpenCode's side ([sst/opencode#8235](https://github.com/anomalyco/opencode/issues/8235) — "Config and Data directories follow the Linux XDG standard even on windows"). Orca's `getOpenCodeDataDirectory()` had a `process.platform === 'win32'` branch pointing at `%LOCALAPPDATA%\opencode`, which never exists. The `readdir` threw, the `catch` swallowed it, `listOpenCodeDatabases()` returned `[]`, and the OpenCode SQLite scanner was never invoked — so every other agent showed up and only OpenCode was missing. Fix: drop the Windows branch, keeping the `XDG_DATA_HOME` override.

**2. Pi Shift+Enter submits instead of inserting a newline after a tool call (#9703).** `TUI_AGENT_CONFIG['pi']` never set `windowsShiftEnterEncoding`, so on Windows Pi could only reach CSI-u via the live-KKP-flag path. Pi pushes the Kitty keyboard protocol once at startup and never re-pushes; when a tool spawns a subprocess that emits a reset sequence (RIS / DECSTR / alt-screen swap), the tracker's flags drop to 0, Orca falls back to `Esc+CR`, and Pi reads that as a plain Enter → **submit**. It self-heals on the next pane refocus, which is exactly the reported "works at start, breaks after a tool, fixed by clicking the pane" pattern. Fix: set `windowsShiftEnterEncoding: 'csi-u'` for `pi`, mirroring the existing Droid (#7668) and Grok (#8385) fixes, so the trusted route no longer depends on KKP-flag churn.

## ELI5

Orca was looking for OpenCode's history file in the wrong folder on Windows, so the Agents panel always showed an empty list for OpenCode even though the history was there — we now look in the folder OpenCode actually uses. Separately, when chatting with the Pi agent on Windows, pressing Shift+Enter to add a new line would accidentally send the message instead, but only right after Pi used a tool. Orca now tells Pi's keypresses apart reliably, so Shift+Enter always just adds a new line.

## Proof of fix

### Fix A — OpenCode Windows path (#10332)

The regression test drives the real entry point (`listOpenCodeDatabases`) with `process.platform` stubbed to `win32`, a temp `$HOME`, `%LOCALAPPDATA%` populated, and a real `opencode.db` on disk at the XDG location.

With `src/main/opencode-usage/scanner.ts` checked out from `origin/main`:

```
 FAIL  src/main/opencode-usage/scanner.test.ts > listOpenCodeDatabases > finds opencode.db under ~/.local/share on Windows instead of %LOCALAPPDATA% (#10332)
AssertionError: expected [] to deeply equal [ Array(1) ]

- Expected
+ Received

- [
-   ".../orca-opencode-home-c70KOx/.local/share/opencode/opencode.db",
- ]
+ []

 ❯ src/main/opencode-usage/scanner.test.ts:76:43

 Test Files  1 failed (1)
      Tests  1 failed | 15 passed (16)
```

With the fix applied:

```
 Test Files  1 passed (1)
      Tests  16 passed (16)
```

**Verified on a real Windows 11 box** (`win32 x64`, Node v24.18.0), running both resolution strategies side by side against a seeded DB:

```
platform      : win32 | homedir: C:\Users\neil
LOCALAPPDATA  : C:\Users\neil\AppData\Local
MAIN  scans   : C:\Users\neil\AppData\Local\opencode -> dbs found: []
FIXED scans   : C:\Users\neil\.local\share\opencode -> dbs found: ["C:\\Users\\neil\\.local\\share\\opencode\\opencode.db"]
```

An independent directory listing on that same box confirms `C:\Users\neil\.local\share\` is a real, populated location (it already holds `claude` and `devex`), while a recursive search for `opencode.db` under `%LOCALAPPDATA%` and `%APPDATA%` returns nothing.

**Confirmed on a real Windows 11 box** (win32 x64) — the premise is not inferred from the upstream issue, it is observed on disk:

```
EXISTS  C:\Users\neil\.local\share\opencode
missing C:\Users\neil\AppData\Local\opencode
missing C:\Users\neil\AppData\Roaming\opencode
XDG_DATA_HOME=(unset)
```

OpenCode's data directory is present at the XDG path and absent from both `%LOCALAPPDATA%` and `%APPDATA%` — exactly the directory `main` was reading, which is why `readdir` threw and the scanner silently returned `[]`. (`opencode.db` itself is absent on that box because OpenCode has not been run there; the directory location is the claim under test.)

### Fix B — Pi Shift+Enter (#9703)

With `src/shared/tui-agent-config.ts` checked out from `origin/main`:

```
 FAIL  src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts > resolveWindowsShiftEnterEncoding > uses CSI-u for trusted Pi process evidence so Shift+Enter survives tool-subprocess churn (#9703)
AssertionError: expected 'alt-enter' to be 'csi-u' // Object.is equality

Expected: "csi-u"
Received: "alt-enter"

 ❯ src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts:22:7

 Test Files  1 failed (1)
      Tests  1 failed | 8 passed (9)
```

With the fix applied:

```
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/main/opencode-usage/ src/main/ai-vault/
 Test Files  34 passed (34)
      Tests  224 passed (224)

$ npx vitest run --config config/vitest.config.ts \
    src/renderer/src/components/terminal-pane/terminal-shortcut-policy.test.ts \
    src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts \
    src/renderer/src/components/terminal-pane/pty-connection.test.ts \
    src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
 Test Files  4 passed (4)
      Tests  542 passed (542)

$ npx tsc --noEmit -p config/tsconfig.node.json     # clean, exit 0
$ npx tsc --noEmit -p config/tsconfig.tc.web.json   # clean, exit 0
$ npx oxlint <the four changed files>               # clean, 0 warnings
```

No user-visible behavior changes beyond the two fixes. Justification:

- **Fix A** only removes a `process.platform === 'win32'` branch. macOS and Linux never entered it, so their resolved path is byte-identical. The `XDG_DATA_HOME` and `OPENCODE_DB` overrides are unchanged and both are now covered by tests (the `OPENCODE_DB` case was added per review feedback). The only behavior that changes is on Windows, where the scanned directory moves from a path that never exists to the one that does.
- **Fix B** adds one property to a single entry in `TUI_AGENT_CONFIG`. I diffed the file against `origin/main`: the *only* changed lines are inside the `pi` entry (a trailing comma, a comment, and the new key). Claude, Codex, OpenCode, Cursor, Gemini, Grok, Droid and every other agent config are byte-unchanged. Plain Enter is untouched — it is handled by a different branch of `terminal-shortcut-policy.ts` that never consults this config, and the Shift+Enter branch is the only reader. A new test pins that trusted agents *without* an override (gemini, cursor, codex) still resolve to `alt-enter`.

## Compatibility

- **Platforms:** Windows — both fixes verified. Fix A's path resolution was executed on a real Windows 11 box (output above); Fix B's resolver is unit-tested with the Windows code path exercised directly. macOS/Linux — Fix A provably unchanged (the removed branch was Windows-gated); Fix B is gated behind `isWindowsTerminalHost()` at the call site in `terminal-shortcut-policy.ts`, and an existing test already pins that off-Windows panes require active KKP negotiation regardless of the configured encoding. All paths use `path.join`; no separator is hardcoded. Note that `listOpenCodeDatabases` uses `readdir` plus a filename regex rather than a glob library, so there is no forward-slash-in-pattern hazard.
- **SSH / remote:** No impact. Remote and WSL OpenCode sources are resolved separately in `session-scanner-opencode-sources.ts`, which already used `~/.local/share/opencode` for WSL homes and is untouched by this PR. This change only affects the local-host lookup, which now agrees with the WSL logic instead of contradicting it.
- **Performance:** No hot-path change. Fix A is one `path.join` in a scan that already hits the filesystem. Fix B is a record property read, and the call site is lazy — `getWindowsShiftEnterEncoding` is only invoked on Shift+Enter, never on ordinary keystrokes (an existing test asserts this).

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (`npx oxlint` on the changed files)
- [x] `pnpm typecheck` (`config/tsconfig.node.json` + `config/tsconfig.tc.web.json`)
- [x] `pnpm test` — ran the affected suites rather than the full 30+ min suite: `src/main/opencode-usage/`, `src/main/ai-vault/`, and the four `terminal-pane` suites covering Shift+Enter (766 tests, all passing)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed for correctness, cross-platform behavior, SSH/remote impact, performance, and regression surface.

The review flagged one real defect in the original patch, which is fixed here. The first version of the Fix A regression test exported a new pure resolver `resolveOpenCodeDataDirectory({ env, homeDir })` and asserted against injected values. That test was **vacuous**: main's bug lives behind `process.platform === 'win32'`, which the test never stubbed, so on any non-Windows CI host main's own logic satisfies the same assertion. Transplanting main's resolver verbatim and running the assertion against it confirmed it returns the expected value on macOS/Linux. On `origin/main` the test failed only with `TypeError: resolveOpenCodeDataDirectory is not a function` — i.e. it was detecting a missing symbol, not a wrong path, and would have kept passing if someone reintroduced the `%LOCALAPPDATA%` branch. Replaced it with a test that drives the real `listOpenCodeDatabases` entry point with `process.platform` stubbed to `win32` and a real DB on disk; it now fails on main for the correct reason (see Proof of fix). That also made the exported options-injection API unnecessary, so `getOpenCodeDataDirectory` is back to a 4-line private function and the production diff shrank.

Cross-platform compatibility was checked explicitly for macOS, Linux, and Windows, covering path separators, drive letters, the glob-vs-`readdir` distinction, shortcut byte protocols, and the Windows-host gating of the Shift+Enter encoding — see **Compatibility** above for the per-platform findings. The review also confirmed neither bug is already fixed on `main`, and that the Fix B config change touches only the `pi` entry.

## Security Audit

No new attack surface. No command execution, no network calls, no IPC surface, no auth or secret handling, no dependency changes.

- **Path handling:** the change narrows the set of directories Orca reads — it removes a lookup location rather than adding one. The resolved directory is still derived from `homedir()` or the pre-existing `XDG_DATA_HOME` override, and the filename filter remains an anchored regex (`/^opencode(?:-[A-Za-z0-9_.-]+)?\.db$/`) applied to `readdir` entry names, so it cannot traverse outside the data directory. Reads stay wrapped in the existing `try/catch`.
- **Input handling:** the Shift+Enter change routes a fixed, hardcoded byte sequence (`\x1b[13;2u`) and is only reachable via trusted foreground process evidence. Hook- and OSC-derived status remain excluded from routing authority, so PTY output still cannot forge it — the existing test covering that is unchanged and passing.

No follow-up security work needed.

## Notes

- **Why these two fixes ship together:** they were reported and submitted as one Windows-bugfix pair, and each is a genuinely independent one-line behavior change in a different subsystem (`src/main/opencode-usage/` vs `src/shared/`) with no shared code, no shared test file, and no interaction. Splitting would add review overhead without reducing risk; each fix has its own separately-labelled failing-on-main proof above, so either can be reverted alone.
- `listOpenCodeDatabases()` still swallows `readdir` errors and returns `[]`, so a genuinely unreadable or missing data directory remains silent in the UI. That is what made #10332 hard to diagnose in the first place. Surfacing an `AiVaultScanIssue` there is a worthwhile follow-up but is deliberately out of scope for a targeted bugfix.
- Fix B addresses Pi specifically, per the issue. The underlying fragility the issue describes — every agent without `windowsShiftEnterEncoding` relies on live KKP flags that tool subprocesses can reset — still applies to the remaining agents. Making the KKP tracker resilient to reset sequences, or re-pushing KKP on focus return, would fix the whole class rather than one agent at a time; that is a larger change and a good follow-up.

Closes #10332
Closes #9703

Original patch by @itisvincent.

