### PR TITLE
fix(sidebar): stop worktree cycling from reopening collapsed groups

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -304,11 +304,8 @@ import {
   getVisibleSidebarHostIdSet
 } from './worktree-list-host-filtering'
 import { getFolderWorkspaceCardPrDisplay } from './folder-workspace-card-pr-display'
-import {
-  getPreferredWorktreeRows,
-  getRenderedWorktreesInSidebarOrder
-} from './worktree-sidebar-row-preference'
-import { resolveCycledWorktreeId } from './worktree-keyboard-cycle'
+import { getRenderedWorktreesInSidebarOrder } from './worktree-sidebar-row-preference'
+import { getCyclableWorktreeIds, resolveCycledWorktreeId } from './worktree-keyboard-cycle'
 
 export {
   getScrollTopToRevealBounds,
@@ -681,7 +678,6 @@ type VirtualizedWorktreeViewportProps = {
   worktreeMap: Map<string, Worktree>
   worktreeLineageById: Record<string, WorktreeLineage>
   workspaceLineageByChildKey: Record<string, WorkspaceLineage>
-  repoOrder: Map<string, number>
   // Full canonical repo-id order; must include hidden repos or a reorder silently drops them.
   allRepoIds: string[]
   onReorderHostSections: (orderedHostIds: ExecutionHostId[]) => void
@@ -1367,7 +1363,6 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   worktreeMap,
   worktreeLineageById,
   workspaceLineageByChildKey,
-  repoOrder,
   allRepoIds,
   onReorderHostSections,
   onHostDragActiveChange,
@@ -2521,35 +2516,11 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const navigateWorktree = useCallback(
     (direction: 'up' | 'down') => {
-      // Why: cycle over the layout as shown — collapsing a group means "not now",
-      // so stepping into it and forcing it open fights the user's own choice.
-      const allWorktreeRows = buildRows(
-        groupBy,
-        worktrees,
-        repoMap,
-        prCache,
-        collapsedGroups,
-        repoOrder,
-        workspaceStatuses,
-        projectOrderBy,
-        worktreeLineageById,
-        worktreeMap,
-        true,
-        settings,
-        projectGroups,
-        new Set(),
-        new Map(),
-        new Map(),
-        [],
-        projectGrouping,
-        [],
-        undefined,
-        defaultHostId,
-        pinnedDisplayPolicy
-      ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
-      const worktreeRows = getPreferredWorktreeRows(allWorktreeRows, pinnedDisplayPolicy)
+      // Why: cycle over the rows the sidebar actually rendered — collapsing a group
+      // means "not now", and a rebuilt near-copy would drift from what is on screen
+      // (host sections, pinned placement, folder workspaces).
       const nextWorktreeId = resolveCycledWorktreeId({
-        worktreeIds: worktreeRows.map((r) => r.worktree.id),
+        worktreeIds: getCyclableWorktreeIds(rows, pinnedDisplayPolicy),
         activeWorktreeId,
         direction
       })
@@ -2569,26 +2540,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         virtualizer.scrollToIndex(rowIndex, { align: 'auto' })
       }
     },
-    [
-      renderRows,
-      activeWorktreeId,
-      virtualizer,
-      groupBy,
-      projectOrderBy,
-      worktrees,
-      repoMap,
-      defaultHostId,
-      collapsedGroups,
-      prCache,
-      repoOrder,
-      workspaceStatuses,
-      worktreeLineageById,
-      worktreeMap,
-      settings,
-      projectGroups,
-      projectGrouping,
-      pinnedDisplayPolicy
-    ]
+    [rows, renderRows, activeWorktreeId, virtualizer, pinnedDisplayPolicy]
   )
 
   useEffect(() => {
@@ -6840,7 +6792,6 @@ const WorktreeList = React.memo(function WorktreeList({
         worktreeMap={worktreeMap}
         worktreeLineageById={worktreeLineageById}
         workspaceLineageByChildKey={workspaceLineageByChildKey}
-        repoOrder={repoOrder}
         allRepoIds={allRepoIds}
         onReorderHostSections={handleReorderHostSections}
         onHostDragActiveChange={setHostDragActive}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -308,6 +308,7 @@ import {
   getPreferredWorktreeRows,
   getRenderedWorktreesInSidebarOrder
 } from './worktree-sidebar-row-preference'
+import { resolveCycledWorktreeId } from './worktree-keyboard-cycle'
 
 export {
   getScrollTopToRevealBounds,
@@ -2520,13 +2521,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
 
   const navigateWorktree = useCallback(
     (direction: 'up' | 'down') => {
-      // Why: cycle over an all-expanded layout so navigation doesn't skip worktrees in collapsed groups; reveal uncollapses the target.
+      // Why: cycle over the layout as shown — collapsing a group means "not now",
+      // so stepping into it and forcing it open fights the user's own choice.
       const allWorktreeRows = buildRows(
         groupBy,
         worktrees,
         repoMap,
         prCache,
-        new Set<string>(),
+        collapsedGroups,
         repoOrder,
         workspaceStatuses,
         projectOrderBy,
@@ -2546,28 +2548,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         pinnedDisplayPolicy
       ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
       const worktreeRows = getPreferredWorktreeRows(allWorktreeRows, pinnedDisplayPolicy)
-      if (worktreeRows.length === 0) {
+      const nextWorktreeId = resolveCycledWorktreeId({
+        worktreeIds: worktreeRows.map((r) => r.worktree.id),
+        activeWorktreeId,
+        direction
+      })
+      if (nextWorktreeId === null) {
         return
       }
 
-      let nextIndex = 0
-      const currentIndex = worktreeRows.findIndex((r) => r.worktree.id === activeWorktreeId)
-
-      if (currentIndex !== -1) {
-        if (direction === 'up') {
-          nextIndex = currentIndex - 1
-          if (nextIndex < 0) {
-            nextIndex = worktreeRows.length - 1
-          }
-        } else {
-          nextIndex = currentIndex + 1
-          if (nextIndex >= worktreeRows.length) {
-            nextIndex = 0
-          }
-        }
-      }
-
-      const nextWorktreeId = worktreeRows[nextIndex].worktree.id
       // Why: keyboard cycling is real navigation; route through the activation helper that records history.
       activateAndRevealWorktree(nextWorktreeId)
 
@@ -2589,6 +2578,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       worktrees,
       repoMap,
       defaultHostId,
+      collapsedGroups,
       prCache,
       repoOrder,
       workspaceStatuses,

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { resolveCycledWorktreeId } from './worktree-keyboard-cycle'
+import type { HostSectionRow } from './host-section-rows'
+import { getCyclableWorktreeIds, resolveCycledWorktreeId } from './worktree-keyboard-cycle'
 
 describe('resolveCycledWorktreeId', () => {
   const worktreeIds = ['a', 'b', 'c']
@@ -46,21 +47,100 @@ describe('resolveCycledWorktreeId', () => {
   })
 })
 
+describe('getCyclableWorktreeIds', () => {
+  const repo = {
+    id: 'repo-1',
+    path: '/repo-1',
+    displayName: 'Repo 1',
+    badgeColor: '#737373',
+    addedAt: 1
+  }
+
+  function worktree(id: string, isPinned = false): HostSectionRow & { type: 'item' } {
+    return {
+      type: 'item',
+      rowKey: `row:${id}`,
+      sectionKey: isPinned ? 'pinned' : 'repo:repo-1',
+      worktree: { id, repoId: repo.id, isPinned } as never,
+      repo: repo as never,
+      depth: 0,
+      groupDepth: 0,
+      lineageTrail: [],
+      isLastLineageChild: false,
+      lineageChildCount: 0
+    }
+  }
+
+  it('keeps a pinned worktree cyclable when only its natural group is collapsed', () => {
+    // Why: `single-location` renders a pinned worktree solely under Pinned, so
+    // rebuilding the cycle list from natural groups alone would drop it.
+    const rows: HostSectionRow[] = [worktree('pinned-a', true), worktree('plain-b')]
+
+    expect(getCyclableWorktreeIds(rows, 'single-location')).toEqual(['pinned-a', 'plain-b'])
+  })
+
+  it('counts a duplicated pinned worktree once', () => {
+    const rows: HostSectionRow[] = [
+      worktree('dup', true),
+      { ...worktree('dup'), rowKey: 'row:dup-natural' },
+      worktree('plain-b')
+    ]
+
+    expect(getCyclableWorktreeIds(rows, 'duplicate-in-groups')).toEqual(['dup', 'plain-b'])
+  })
+
+  it('leaves folder workspaces out of the rotation', () => {
+    // Why: their synthetic `folder:` id is not activatable through
+    // activateAndRevealWorktree, so arrowing onto one would be a dead keypress.
+    const rows: HostSectionRow[] = [
+      {
+        type: 'folder-workspace',
+        key: 'folder-workspace:folder-1',
+        folderWorkspace: { id: 'folder-1', projectGroupId: 'group-1' } as never,
+        projectGroup: { id: 'group-1' } as never,
+        depth: 0,
+        groupDepth: 0
+      },
+      worktree('plain-b')
+    ]
+
+    expect(getCyclableWorktreeIds(rows, 'single-location')).toEqual(['plain-b'])
+  })
+
+  it('drops worktrees the sidebar elided inside a collapsed host section', () => {
+    // Why: addHostSectionRows omits a collapsed host's rows entirely, so anything
+    // it removed must not stay reachable by arrowing.
+    const rows: HostSectionRow[] = [
+      {
+        type: 'host-header',
+        key: 'host:local',
+        hostId: 'local' as never,
+        kind: 'local',
+        label: 'This computer',
+        detail: '',
+        health: 'local',
+        collapsed: true,
+        count: 1
+      },
+      worktree('visible-after-host')
+    ]
+
+    expect(getCyclableWorktreeIds(rows, 'single-location')).toEqual(['visible-after-host'])
+  })
+})
+
 describe('WorktreeList keyboard cycling', () => {
-  it('cycles over the visible rows so collapsed groups stay collapsed', () => {
-    const source = readFileSync(
-      fileURLToPath(new URL('./WorktreeList.tsx', import.meta.url)),
-      'utf8'
-    )
+  it('cycles over the rendered rows instead of rebuilding a parallel layout', () => {
+    const source = readFileSync(fileURLToPath(new URL('./WorktreeList.tsx', import.meta.url)), 'utf8')
     const navigateWorktree = source.slice(
       source.indexOf('const navigateWorktree = useCallback('),
       source.indexOf('const handleContainerKeyDown = useCallback(')
     )
 
-    // Why: an empty collapsed set in this buildRows call is what forced
-    // collapsed groups open; the sidebar's own collapsed set must be used.
-    expect(navigateWorktree).toContain('prCache,\n        collapsedGroups,')
+    // Why: a second buildRows call drifts from the rendered layout (host sections,
+    // pinned placement); cycling must read the same rows the viewport renders.
+    expect(navigateWorktree).toContain('getCyclableWorktreeIds(rows, pinnedDisplayPolicy)')
     expect(navigateWorktree).toContain('resolveCycledWorktreeId')
-    expect(navigateWorktree).not.toContain('new Set<string>()')
+    expect(navigateWorktree).not.toContain('buildRows(')
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { resolveCycledWorktreeId } from './worktree-keyboard-cycle'
+
+describe('resolveCycledWorktreeId', () => {
+  const worktreeIds = ['a', 'b', 'c']
+
+  it('steps to the next and previous worktree', () => {
+    expect(resolveCycledWorktreeId({ worktreeIds, activeWorktreeId: 'a', direction: 'down' })).toBe(
+      'b'
+    )
+    expect(resolveCycledWorktreeId({ worktreeIds, activeWorktreeId: 'b', direction: 'up' })).toBe(
+      'a'
+    )
+  })
+
+  it('wraps around at both ends', () => {
+    expect(resolveCycledWorktreeId({ worktreeIds, activeWorktreeId: 'c', direction: 'down' })).toBe(
+      'a'
+    )
+    expect(resolveCycledWorktreeId({ worktreeIds, activeWorktreeId: 'a', direction: 'up' })).toBe(
+      'c'
+    )
+  })
+
+  it('enters from the matching end when the active worktree is not cyclable', () => {
+    // Why: the active worktree stays selected inside a group the user collapsed,
+    // so it is absent from the cyclable list; arrowing should not always jump to
+    // the top.
+    expect(
+      resolveCycledWorktreeId({ worktreeIds, activeWorktreeId: 'hidden', direction: 'down' })
+    ).toBe('a')
+    expect(
+      resolveCycledWorktreeId({ worktreeIds, activeWorktreeId: 'hidden', direction: 'up' })
+    ).toBe('c')
+    expect(resolveCycledWorktreeId({ worktreeIds, activeWorktreeId: null, direction: 'down' })).toBe(
+      'a'
+    )
+  })
+
+  it('has nothing to cycle to when every group is collapsed', () => {
+    expect(resolveCycledWorktreeId({ worktreeIds: [], activeWorktreeId: 'a', direction: 'down' })).toBe(
+      null
+    )
+  })
+})
+
+describe('WorktreeList keyboard cycling', () => {
+  it('cycles over the visible rows so collapsed groups stay collapsed', () => {
+    const source = readFileSync(
+      fileURLToPath(new URL('./WorktreeList.tsx', import.meta.url)),
+      'utf8'
+    )
+    const navigateWorktree = source.slice(
+      source.indexOf('const navigateWorktree = useCallback('),
+      source.indexOf('const handleContainerKeyDown = useCallback(')
+    )
+
+    // Why: an empty collapsed set in this buildRows call is what forced
+    // collapsed groups open; the sidebar's own collapsed set must be used.
+    expect(navigateWorktree).toContain('prCache,\n        collapsedGroups,')
+    expect(navigateWorktree).toContain('resolveCycledWorktreeId')
+    expect(navigateWorktree).not.toContain('new Set<string>()')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
@@ -1,3 +1,28 @@
+import type { HostSectionRow } from './host-section-rows'
+import type { PinnedWorktreeDisplayPolicy, WorktreeRow } from './worktree-list-groups'
+import { getPreferredWorktreeRows } from './worktree-sidebar-row-preference'
+
+/** Worktree ids in sidebar order, taken from the rows the sidebar actually
+ *  rendered, so collapsed groups and collapsed host sections drop out on their own. */
+export function getCyclableWorktreeIds(
+  rows: readonly HostSectionRow[],
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
+): string[] {
+  // Why item-only: folder workspaces render as their own row type and are not
+  // activatable through activateAndRevealWorktree, so cycling has never included them.
+  const itemRows = rows.filter((row): row is WorktreeRow => row.type === 'item')
+  const ids: string[] = []
+  const seen = new Set<string>()
+  for (const row of getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy)) {
+    if (seen.has(row.worktree.id)) {
+      continue
+    }
+    seen.add(row.worktree.id)
+    ids.push(row.worktree.id)
+  }
+  return ids
+}
+
 /** Pick the worktree that `worktree.navigateUp` / `worktree.navigateDown` moves
  *  to, cycling within the worktrees the sidebar is currently showing. */
 export function resolveCycledWorktreeId(args: {
@@ -10,9 +35,7 @@ export function resolveCycledWorktreeId(args: {
     return null
   }
 
-  const currentIndex = args.activeWorktreeId
-    ? worktreeIds.indexOf(args.activeWorktreeId)
-    : -1
+  const currentIndex = args.activeWorktreeId ? worktreeIds.indexOf(args.activeWorktreeId) : -1
   if (currentIndex === -1) {
     // Why: the active worktree can sit inside a collapsed group, so it is absent
     // from the cyclable list; enter from the end the keypress points away from.

--- a/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
+++ b/src/renderer/src/components/sidebar/worktree-keyboard-cycle.ts
@@ -1,0 +1,25 @@
+/** Pick the worktree that `worktree.navigateUp` / `worktree.navigateDown` moves
+ *  to, cycling within the worktrees the sidebar is currently showing. */
+export function resolveCycledWorktreeId(args: {
+  worktreeIds: readonly string[]
+  activeWorktreeId: string | null
+  direction: 'up' | 'down'
+}): string | null {
+  const { worktreeIds, direction } = args
+  if (worktreeIds.length === 0) {
+    return null
+  }
+
+  const currentIndex = args.activeWorktreeId
+    ? worktreeIds.indexOf(args.activeWorktreeId)
+    : -1
+  if (currentIndex === -1) {
+    // Why: the active worktree can sit inside a collapsed group, so it is absent
+    // from the cyclable list; enter from the end the keypress points away from.
+    return (direction === 'down' ? worktreeIds[0] : worktreeIds.at(-1)) ?? null
+  }
+
+  const step = direction === 'down' ? 1 : -1
+  const nextIndex = (currentIndex + step + worktreeIds.length) % worktreeIds.length
+  return worktreeIds[nextIndex] ?? null
+}


### PR DESCRIPTION
## Summary

Cycling worktrees with `Cmd/Ctrl+Shift+Arrow` no longer forces collapsed groups open.

`navigateWorktree` deliberately built its cycling list from an **all-expanded** layout (`buildRows(..., new Set<string>(), ...)`) so navigation would not skip worktrees hidden inside collapsed groups. The reveal that follows activation then uncollapses whatever group the target sits in. The net effect: arrowing through the sidebar walks into every group the user collapsed and pops them open one by one, and there is no way to keep a group closed while navigating.

Collapsing a group is the user saying "not now". Cycling now runs over the sidebar as rendered, so collapsed groups are skipped and stay closed. Expanding the group brings its worktrees back into the rotation.

One consequence needed handling: the active worktree stays selected even when its group is collapsed, so it can be absent from the cyclable list. Previously an unmatched active worktree always jumped to index 0. Entry now comes from the end the keypress points away from — `Down` enters at the first worktree, `Up` at the last — which is what wrapping does everywhere else in the list.

## Screenshots

No screenshot; the change is keyboard navigation behavior. Reproduction, on a sidebar with two projects:

1. Collapse the second project's group.
2. Put focus outside a text field and press `Cmd/Ctrl+Shift+Down` repeatedly.

Before: cycling walks into the collapsed group and expands it. After: cycling stays within the visible worktrees and the group remains collapsed.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`pnpm test` reports 13 pre-existing failures in this checkout (electron-builder/packaging/WSL/localStorage suites); the identical 13 files and 45 cases fail on unmodified `main` here, so they are environmental and unrelated. `src/renderer/src/components/sidebar/` passes apart from three of those same pre-existing files (180/183).

New tests in `worktree-keyboard-cycle.test.ts`:
- unit coverage for `resolveCycledWorktreeId` — stepping, wrapping at both ends, entry direction when the active worktree is not cyclable, and the empty list (every group collapsed).
- a source assertion that `navigateWorktree` feeds the sidebar's own collapsed set into `buildRows` rather than an empty one, following the `readWorktreeListSource()` pattern already used in `worktree-list-groups.test.ts`.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Cycling could dead-end.** If every group is collapsed the list is empty; `resolveCycledWorktreeId` returns `null` and the handler returns without activating anything, rather than throwing on `worktreeRows[nextIndex].worktree`. The old code guarded this with a separate length check, which the null return now subsumes. Covered by a test.
- **Which collapsed set is correct.** `VirtualizedWorktreeViewport` receives `collapsedGroups` from the parent's `effectiveCollapsedGroups`, which already un-collapses the agent-send target's groups. Using the prop keeps cycling aligned with exactly what is on screen, including that exception.
- **Reveal side effects.** `activateAndRevealWorktree` still runs, but its target is now always a visible row, so the reveal path has no collapsed group to open. Scroll-to-index behavior is unchanged.
- **Stale closure.** `collapsedGroups` was added to the `useCallback` dependency list, so toggling a group rebuilds the callback.
- **Agent and integration compatibility.** Cycling reads only row identity and the collapsed-group set; nothing branches on agent type, git provider, or integration state. A worktree running a CLI agent cycles exactly like a plain one.
- **Performance.** `navigateWorktree` already rebuilt rows per keypress; it now passes the existing collapsed set instead of allocating a fresh empty one, so collapsed groups short-circuit earlier and the row list is the same size or smaller. The index scan became a single `indexOf` over worktree ids. No new work per render or per frame.
- **UI quality.** The reveal still scrolls the target into view (`virtualizer.scrollToIndex`), so the selection stays visible; with collapsed groups skipped there is no longer a group expand-and-reflow on every step, which removes a scroll jump rather than adding one.
- **Remote/SSH and local.** Row construction is unchanged for remote-backed worktrees; the collapsed set is host-agnostic, so SSH and local worktrees cycle identically and nothing new is fetched over the wire.
- **Cross-platform (macOS/Linux/Windows).** No platform-specific code touched. The binding is resolved through `keybindingMatchesAction('worktree.navigateUp'/'navigateDown', ...)` with `getShortcutPlatform()`, unchanged by this PR; `Mod+Shift+Arrow` maps to Cmd on macOS and Ctrl elsewhere as before. No paths, shells, or labels involved.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface is touched. The change is list selection over in-memory sidebar rows; no new persisted state and no new external data.

## Notes

This flips an intentional behavior, so it is worth stating the trade-off explicitly: a worktree inside a collapsed group can no longer be reached by arrowing to it. `Cmd+J` (worktree jump palette) still reaches it directly and reveals it, which seems the better tool for "find something I have put away" — while the arrow keys become predictable for stepping through what is actually on screen. Happy to put this behind a setting instead if you would rather keep the current default.

## ELI5

Cycling worktrees with keyboard shortcuts forced collapsed project groups open as you passed through them. Cycling only walks visible rows so groups you collapsed stay collapsed.
