### PR TITLE
ci(release-cut): include source ref/commit and cutter in SignPath Slack

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -72,6 +72,11 @@ jobs:
       tag: ${{ steps.tag.outputs.tag || steps.version.outputs.recovered_tag }}
       should_release: ${{ steps.tag.outputs.tag != '' || steps.version.outputs.recovered_tag != '' }}
       latest_published_rc_tag: ${{ steps.publish_drafts.outputs.latest_published_tag }}
+      # Why: downstream SignPath Slack pings need the cut source (not only the
+      # new tag) so approvers know what they're signing and who cut it.
+      source_ref: ${{ steps.resolve.outputs.ref }}
+      source_sha: ${{ steps.resolve.outputs.sha }}
+      source_short_sha: ${{ steps.resolve.outputs.short_sha }}
     steps:
       # Why inlined (not m-s-abeer/update-gha-summary-with-workflow-inputs):
       # this job runs with contents:write and secret scope, so avoid executing
@@ -122,9 +127,12 @@ jobs:
           SERVER_URL: ${{ github.server_url }}
         run: |
           set -euo pipefail
+          input_ref="${INPUT_REF:-main}"
           sha="$(git rev-parse HEAD)"
           short_sha="$(git rev-parse --short=12 HEAD)"
+          echo "ref=$input_ref" >>"$GITHUB_OUTPUT"
           echo "sha=$sha" >>"$GITHUB_OUTPUT"
+          echo "short_sha=$short_sha" >>"$GITHUB_OUTPUT"
 
           # Why: only push the version-bump commit back to main when the
           # caller is releasing the exact tip of main. For any older or
@@ -142,7 +150,6 @@ jobs:
           # `ref` input alone is ambiguous (branch vs tag vs SHA); for SHA
           # inputs it also hides the human-readable names operators need
           # when auditing RC cuts.
-          input_ref="${INPUT_REF:-main}"
           repo_url="${SERVER_URL}/${REPO}"
 
           branches="$(
@@ -1278,6 +1285,12 @@ jobs:
           SIGNPATH_REQUEST_ID: ${{ steps.submit-inner-signing.outputs.signing-request-id }}
           SIGNPATH_REQUEST_URL: ${{ steps.submit-inner-signing.outputs.signing-request-web-url }}
           TAG: ${{ needs.cut.outputs.tag }}
+          SOURCE_REF: ${{ needs.cut.outputs.source_ref }}
+          SOURCE_SHA: ${{ needs.cut.outputs.source_sha }}
+          SOURCE_SHORT_SHA: ${{ needs.cut.outputs.source_short_sha }}
+          # Prefer triggering_actor so re-runs name who re-ran; fall back to actor.
+          CUT_BY: ${{ github.triggering_actor || github.actor }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           if ([string]::IsNullOrWhiteSpace($env:SLACK_WEBHOOK_URL)) {
@@ -1289,7 +1302,26 @@ jobs:
             $requestUrl = "https://app.signpath.io/Web/$env:SIGNPATH_ORGANIZATION_ID/SigningRequests/$env:SIGNPATH_REQUEST_ID"
           }
 
-          $message = "Orca Windows release $env:TAG inner-binaries signing request (1 of 2) is ready for SignPath approval.`n<$requestUrl|Open SignPath signing request>`n<$env:GITHUB_RUN_URL|Open GitHub Actions run>"
+          # Why: approvers need tag + source ref/commit + who cut, not only the tag.
+          $sourceRef = if (-not [string]::IsNullOrWhiteSpace($env:SOURCE_REF)) { $env:SOURCE_REF } else { 'unknown' }
+          $shortSha = if (-not [string]::IsNullOrWhiteSpace($env:SOURCE_SHORT_SHA)) {
+            $env:SOURCE_SHORT_SHA
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:SOURCE_SHA)) {
+            $env:SOURCE_SHA.Substring(0, [Math]::Min(12, $env:SOURCE_SHA.Length))
+          } else {
+            'unknown'
+          }
+          $commitLink = if (-not [string]::IsNullOrWhiteSpace($env:SOURCE_SHA)) {
+            "<$($env:REPO_URL)/commit/$($env:SOURCE_SHA)|``$shortSha``>"
+          } else {
+            "``$shortSha``"
+          }
+          $cutBy = if (-not [string]::IsNullOrWhiteSpace($env:CUT_BY)) {
+            "<https://github.com/$($env:CUT_BY)|@$($env:CUT_BY)>"
+          } else {
+            'unknown'
+          }
+          $message = "Orca Windows release ``$($env:TAG)`` inner-binaries signing request (1 of 2) is ready for SignPath approval.`nSource: ``$sourceRef`` @ $commitLink · cut by $cutBy`n<$requestUrl|Open SignPath signing request>`n<$($env:GITHUB_RUN_URL)|Open GitHub Actions run>"
           $payload = @{
             text = $message
             blocks = @(
@@ -1463,6 +1495,12 @@ jobs:
           SIGNPATH_REQUEST_ID: ${{ steps.submit-signing-request.outputs.signing-request-id }}
           SIGNPATH_REQUEST_URL: ${{ steps.submit-signing-request.outputs.signing-request-web-url }}
           TAG: ${{ needs.cut.outputs.tag }}
+          SOURCE_REF: ${{ needs.cut.outputs.source_ref }}
+          SOURCE_SHA: ${{ needs.cut.outputs.source_sha }}
+          SOURCE_SHORT_SHA: ${{ needs.cut.outputs.source_short_sha }}
+          # Prefer triggering_actor so re-runs name who re-ran; fall back to actor.
+          CUT_BY: ${{ github.triggering_actor || github.actor }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
           GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           INNER_SIGNING_SUBMITTED: ${{ steps.submit-inner-signing.outcome == 'success' }}
         run: |
@@ -1477,7 +1515,26 @@ jobs:
 
           # Why: releases where inner signing fell through have only this one request.
           $stage = if ($env:INNER_SIGNING_SUBMITTED -eq 'true') { 'installer signing request (2 of 2)' } else { 'signing request' }
-          $message = "Orca Windows release $env:TAG $stage is ready for SignPath approval.`n<$requestUrl|Open SignPath signing request>`n<$env:GITHUB_RUN_URL|Open GitHub Actions run>"
+          # Why: approvers need tag + source ref/commit + who cut, not only the tag.
+          $sourceRef = if (-not [string]::IsNullOrWhiteSpace($env:SOURCE_REF)) { $env:SOURCE_REF } else { 'unknown' }
+          $shortSha = if (-not [string]::IsNullOrWhiteSpace($env:SOURCE_SHORT_SHA)) {
+            $env:SOURCE_SHORT_SHA
+          } elseif (-not [string]::IsNullOrWhiteSpace($env:SOURCE_SHA)) {
+            $env:SOURCE_SHA.Substring(0, [Math]::Min(12, $env:SOURCE_SHA.Length))
+          } else {
+            'unknown'
+          }
+          $commitLink = if (-not [string]::IsNullOrWhiteSpace($env:SOURCE_SHA)) {
+            "<$($env:REPO_URL)/commit/$($env:SOURCE_SHA)|``$shortSha``>"
+          } else {
+            "``$shortSha``"
+          }
+          $cutBy = if (-not [string]::IsNullOrWhiteSpace($env:CUT_BY)) {
+            "<https://github.com/$($env:CUT_BY)|@$($env:CUT_BY)>"
+          } else {
+            'unknown'
+          }
+          $message = "Orca Windows release ``$($env:TAG)`` $stage is ready for SignPath approval.`nSource: ``$sourceRef`` @ $commitLink · cut by $cutBy`n<$requestUrl|Open SignPath signing request>`n<$($env:GITHUB_RUN_URL)|Open GitHub Actions run>"
           $payload = @{
             text = $message
             blocks = @(

--- a/config/scripts/release-cut-signpath-slack.test.mjs
+++ b/config/scripts/release-cut-signpath-slack.test.mjs
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+
+describe('release-cut SignPath Slack approval pings', () => {
+  it('includes cut source ref/commit and who triggered the cut', () => {
+    const workflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/release-cut.yml'), 'utf8')
+    )
+
+    const cutOutputs = workflow.jobs.cut.outputs
+    expect(cutOutputs.source_ref).toContain('steps.resolve.outputs.ref')
+    expect(cutOutputs.source_sha).toContain('steps.resolve.outputs.sha')
+    expect(cutOutputs.source_short_sha).toContain('steps.resolve.outputs.short_sha')
+
+    const steps = workflow.jobs.build.steps
+    const notifySteps = steps.filter(
+      (step) =>
+        step.name === 'Notify Slack that inner-binary signing is waiting for approval' ||
+        step.name === 'Notify Slack that Windows signing is waiting for approval'
+    )
+    expect(notifySteps).toHaveLength(2)
+
+    for (const step of notifySteps) {
+      expect(step.env.SOURCE_REF).toContain('needs.cut.outputs.source_ref')
+      expect(step.env.SOURCE_SHA).toContain('needs.cut.outputs.source_sha')
+      expect(step.env.SOURCE_SHORT_SHA).toContain('needs.cut.outputs.source_short_sha')
+      expect(step.env.CUT_BY).toMatch(/github\.(triggering_actor|actor)/)
+      expect(step.run).toContain('Source:')
+      expect(step.run).toContain('cut by')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

SignPath approval Slack messages previously only said the release **tag**. Approvers also need:

1. **Source ref** (e.g. `main`, `hotfix/...`)
2. **Source commit** (clickable short SHA)
3. **Who cut** — GitHub username of whoever triggered the Cut Release workflow (`github.triggering_actor`, falling back to `github.actor`)

Both Windows SignPath pings (inner binaries 1/2 and installer 2/2) now look like:

```
Orca Windows release `v1.4.156-rc.1` installer signing request (2 of 2) is ready for SignPath approval.
Source: `main` @ `abc1234def56` · cut by @nwparker
Open SignPath signing request
Open GitHub Actions run
```

(Commit and `@user` are Slack links to GitHub.)

## Screenshots

No product UI change. Slack message text only.

## Testing

- [x] `pnpm exec vitest run config/scripts/release-cut-signpath-slack.test.mjs`
- [ ] Live: next Windows RC cut should show the new Slack line

## AI Review Report

Checked:
- Job outputs plumb from `resolve` (`ref` / `sha` / `short_sha`) into build-job Slack env
- Actor uses `triggering_actor || actor` so re-runs name who re-ran
- YAML stays parseable (single-line PowerShell strings)
- Cross-platform: Windows-only pwsh steps; no macOS/Linux surface change

## Security Audit

- No new secrets; only public ref/commit metadata and GitHub usernames in Slack
- Dispatch-controlled ref already treated as data via cut job outputs

## Notes

Depends on the resolve outputs from #10482 (already on main).