### PR TITLE
fix(release-cut): gate an explicit RC against its own series

### DIFF
--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -42,7 +42,7 @@ on:
         default: false
         type: boolean
       version_suffix:
-        description: Extra prerelease identifier appended to an rc version (e.g. "perf" -> 1.2.3-rc.4.perf). rc kind only.
+        description: Extra prerelease identifier appended to an rc version (e.g. "perf" -> 1.2.3-rc.4.perf). Applies to kind=rc, or to an explicit version that is a bare X.Y.Z-rc.N.
         required: false
         type: string
         default: ''
@@ -515,9 +515,13 @@ jobs:
           new=""
           if [[ -n "${EXPLICIT_VERSION:-}" ]]; then
             explicit="${EXPLICIT_VERSION#v}"
-            # Why the optional trailing identifier: the rc path can cut
-            # suffixed side-branch RCs (X.Y.Z-rc.N.perf), and a shape this
-            # regex rejects can never be re-cut through the override.
+            # Why the optional trailing identifier: it lets an operator name a
+            # suffixed side-branch RC (X.Y.Z-rc.N.perf) directly, the same shape
+            # the rc path cuts. Note this only ever admits one *above* the
+            # series head — the gate below refuses a suffixed rc at or below it
+            # just like a bare one, so this is a second spelling of
+            # `version=X.Y.Z-rc.N` + `version_suffix`, not a way back into a
+            # series that already shipped.
             # Why rc.(0|[1-9][0-9]{0,8}): the `-le` below compares with bash's
             # machine-width integers, so both ends of that range fall *open* on
             # exactly the RCs this gate must catch. A leading zero (rc.08) is an
@@ -564,7 +568,7 @@ jobs:
                 # series on that base. A minor/major series (1.5.0-rc.N) exists
                 # only because this override created it, and pointing an
                 # operator at kind=rc there would cut an unrelated release.
-                echo "::error::Refusing explicit version $explicit: rc.$explicit_rc is not above rc.$highest_explicit_rc, the highest already cut for $explicit_base. Request rc.$((highest_explicit_rc + 1)) or higher. If you are resuming an unpublished tag and $explicit_base is the next patch after latest stable $latest_stable, dispatch kind=rc instead, which recovers the existing tag; otherwise cut rc.$((highest_explicit_rc + 1)) and leave the unpublished tag alone." >&2
+                echo "::error::Refusing explicit version $explicit: rc.$explicit_rc is not above rc.$highest_explicit_rc, the highest already cut for $explicit_base. Request rc.$((highest_explicit_rc + 1)) or higher. If you are resuming an unpublished tag and $explicit_base is the next patch after latest stable $latest_stable, dispatch kind=rc instead, which recovers that tag when it was cut from the ref you dispatch; otherwise cut rc.$((highest_explicit_rc + 1)) and leave the unpublished tag alone." >&2
                 exit 1
               fi
             fi
@@ -575,7 +579,9 @@ jobs:
             # stable X.Y.Z.perf is not valid semver, and re-suffixing an
             # already-suffixed rc would produce rc.N.perf.perf.
             if [[ -n "${VERSION_SUFFIX:-}" ]]; then
-              if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+              # Same bounded rc pattern as the shape check above, so the two
+              # cannot drift apart under a later edit.
+              if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.(0|[1-9][0-9]{0,8})$ ]]; then
                 echo "::error::version_suffix applies only to a bare X.Y.Z-rc.N version, got: $explicit" >&2
                 exit 1
               fi

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -400,7 +400,7 @@ jobs:
             # tag step keeps the literal input — so the shipped package.json
             # version and its own release tag would name different releases.
             if [[ ! "$1" =~ ^(0|[1-9][0-9]*|[0-9A-Za-z]*[A-Za-z][0-9A-Za-z]*)$ ]]; then
-              echo "::error::version suffix must be alphanumeric with no leading zero on an all-digit identifier, got: $1" >&2
+              echo "::error::version_suffix (or the trailing .identifier in version) must be alphanumeric with no leading zero on an all-digit identifier, got: $1" >&2
               exit 1
             fi
           }
@@ -522,10 +522,12 @@ jobs:
             # machine-width integers, so both ends of that range fall *open* on
             # exactly the RCs this gate must catch. A leading zero (rc.08) is an
             # invalid octal literal, and the failed test makes the `if` false.
-            # Past INTMAX (rc.99999999999999999999) bash saturates, so the test
-            # reads as "above the published rc" and the cut lands a tag that
-            # then pins highest_rc_for_base at 1e20 forever — every later cut
-            # wraps to a *lower* rc the fleet never updates to. Nine digits is
+            # Past INTMAX the literal wraps two's-complement, so whether it
+            # reads as above or below the published rc depends on the value:
+            # rc.99999999999999999999 wraps to 7766279631452241919 and sails
+            # through. The cut then lands a tag that pins highest_rc_for_base
+            # at 1e20 forever, and every later cut wraps to a *lower* rc that
+            # sorts below it, so the fleet never updates again. Nine digits is
             # far above any real series and exact in bash math either way.
             if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.(0|[1-9][0-9]{0,8})(\.[0-9A-Za-z]+)?)?$ ]]; then
               echo "::error::version must be X.Y.Z, X.Y.Z-rc.N, or X.Y.Z-rc.N.suffix, got: $EXPLICIT_VERSION" >&2
@@ -557,7 +559,12 @@ jobs:
               explicit_rc="${explicit_rc%%.*}"
               highest_explicit_rc="$(highest_rc_for_base "$explicit_base")"
               if [[ -n "$highest_explicit_rc" && "$explicit_rc" -le "$highest_explicit_rc" ]]; then
-                echo "::error::Refusing explicit version $explicit: rc.$explicit_rc is not above rc.$highest_explicit_rc, the highest already cut for $explicit_base. Request rc.$((highest_explicit_rc + 1)) or higher; to resume an unpublished tag in this series, dispatch kind=rc instead." >&2
+                # Why the remedy is spelled this narrowly: kind=rc derives its
+                # base from bump(latest_stable, patch), so it can only resume a
+                # series on that base. A minor/major series (1.5.0-rc.N) exists
+                # only because this override created it, and pointing an
+                # operator at kind=rc there would cut an unrelated release.
+                echo "::error::Refusing explicit version $explicit: rc.$explicit_rc is not above rc.$highest_explicit_rc, the highest already cut for $explicit_base. Request rc.$((highest_explicit_rc + 1)) or higher. If you are resuming an unpublished tag and $explicit_base is the next patch after latest stable $latest_stable, dispatch kind=rc instead, which recovers the existing tag; otherwise cut rc.$((highest_explicit_rc + 1)) and leave the unpublished tag alone." >&2
                 exit 1
               fi
             fi

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -47,7 +47,7 @@ on:
         type: string
         default: ''
       version:
-        description: Exact version to cut (e.g. 1.4.155 or 1.4.155-rc.0), bypassing kind-based computation. Use to leapfrog a deleted/rolled-back stable that regressed the release list. Must be greater than the latest published stable.
+        description: Exact version to cut (e.g. 1.4.155 or 1.4.155-rc.4), bypassing kind-based computation. Use to leapfrog a deleted/rolled-back stable that regressed the release list. Must be greater than the latest published stable, and an -rc.N must be above the highest RC already cut for its own base.
         required: false
         type: string
         default: ''
@@ -388,6 +388,18 @@ jobs:
             node config/scripts/release-rc-history.mjs "$1"
           }
 
+          require_valid_version_suffix() {
+            # Why a dot-appended identifier (rc.N.perf): it sorts just
+            # above its own base rc.N but BELOW rc.N+1, so suffixed side-
+            # branch builds never outrank the main RC series and cannot
+            # hijack the update channel; clients find them by matching the
+            # identifier ("perf") in the prerelease components.
+            if [[ ! "$1" =~ ^[0-9A-Za-z]+$ ]]; then
+              echo "::error::version_suffix must be alphanumeric, got: $1" >&2
+              exit 1
+            fi
+          }
+
           current_package_stable() {
             node -e '
               const { version } = require("./package.json");
@@ -498,8 +510,15 @@ jobs:
           new=""
           if [[ -n "${EXPLICIT_VERSION:-}" ]]; then
             explicit="${EXPLICIT_VERSION#v}"
-            if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
-              echo "::error::version must be X.Y.Z or X.Y.Z-rc.N, got: $EXPLICIT_VERSION" >&2
+            # Why the optional trailing identifier: the rc path can cut
+            # suffixed side-branch RCs (X.Y.Z-rc.N.perf), and a shape this
+            # regex rejects can never be re-cut through the override.
+            # Why rc.(0|[1-9][0-9]*): semver forbids a leading zero on a
+            # numeric identifier, and rc.08 would otherwise reach the `-le`
+            # below as an invalid octal literal, whose error makes the test
+            # false — falling *open* on exactly the RCs this gate must catch.
+            if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.(0|[1-9][0-9]*)(\.[0-9A-Za-z]+)?)?$ ]]; then
+              echo "::error::version must be X.Y.Z, X.Y.Z-rc.N, or X.Y.Z-rc.N.suffix, got: $EXPLICIT_VERSION" >&2
               exit 1
             fi
             # Same updater-safety gate the kind path enforces: stable line must
@@ -509,7 +528,37 @@ jobs:
               echo "::error::Refusing explicit version $explicit: not greater than latest stable $latest_stable." >&2
               exit 1
             fi
+            # Why a second gate for prereleases: semver_gt compares through
+            # strip_pre(), so the stable-line check reads 1.4.156-rc.0 as
+            # 1.4.156 and waves it past a 1.4.155 stable even when rc.0..rc.3
+            # already shipped — republishing an RC *below* what clients run,
+            # the same regression class as the rc.4 cut that orphaned live
+            # daemons. Anchor on the same rc history the kind path uses so the
+            # override can only ever advance the series it targets.
+            if [[ "$explicit" == *-rc.* ]]; then
+              explicit_base="${explicit%%-*}"
+              explicit_rc="${explicit#*-rc.}"
+              explicit_rc="${explicit_rc%%.*}"
+              highest_explicit_rc="$(highest_rc_for_base "$explicit_base")"
+              if [[ -n "$highest_explicit_rc" && "$explicit_rc" -le "$highest_explicit_rc" ]]; then
+                echo "::error::Refusing explicit version $explicit: rc.$explicit_rc is not above rc.$highest_explicit_rc, the highest already cut for $explicit_base. Request rc.$((highest_explicit_rc + 1)) or higher; to resume an unpublished tag in this series, dispatch kind=rc instead." >&2
+                exit 1
+              fi
+            fi
             new="$explicit"
+            # Why here too: the suffix append below lives in the kind path the
+            # override skips, so an operator passing both inputs used to get
+            # their suffix silently dropped. Only a bare rc can take one — a
+            # stable X.Y.Z.perf is not valid semver, and re-suffixing an
+            # already-suffixed rc would produce rc.N.perf.perf.
+            if [[ -n "${VERSION_SUFFIX:-}" ]]; then
+              if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]; then
+                echo "::error::version_suffix applies only to a bare X.Y.Z-rc.N version, got: $explicit" >&2
+                exit 1
+              fi
+              require_valid_version_suffix "$VERSION_SUFFIX"
+              new="${new}.${VERSION_SUFFIX}"
+            fi
             echo "Explicit version override: $new"
           fi
 
@@ -539,15 +588,7 @@ jobs:
                 new="${base}-rc.$((highest_rc + 1))"
               fi
               if [[ -n "${VERSION_SUFFIX:-}" ]]; then
-                # Why a dot-appended identifier (rc.N.perf): it sorts just
-                # above its own base rc.N but BELOW rc.N+1, so suffixed side-
-                # branch builds never outrank the main RC series and cannot
-                # hijack the update channel; clients find them by matching the
-                # identifier ("perf") in the prerelease components.
-                if [[ ! "$VERSION_SUFFIX" =~ ^[0-9A-Za-z]+$ ]]; then
-                  echo "::error::version_suffix must be alphanumeric, got: $VERSION_SUFFIX" >&2
-                  exit 1
-                fi
+                require_valid_version_suffix "$VERSION_SUFFIX"
                 new="${new}.${VERSION_SUFFIX}"
               fi
               ;;

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -394,8 +394,13 @@ jobs:
             # branch builds never outrank the main RC series and cannot
             # hijack the update channel; clients find them by matching the
             # identifier ("perf") in the prerelease components.
-            if [[ ! "$1" =~ ^[0-9A-Za-z]+$ ]]; then
-              echo "::error::version_suffix must be alphanumeric, got: $1" >&2
+            # Why the numeric alternation rather than plain [0-9A-Za-z]+:
+            # semver forbids a leading zero on an all-digit identifier, and
+            # `npm version` silently renormalizes rc.4.01 to rc.4.1 while the
+            # tag step keeps the literal input — so the shipped package.json
+            # version and its own release tag would name different releases.
+            if [[ ! "$1" =~ ^(0|[1-9][0-9]*|[0-9A-Za-z]*[A-Za-z][0-9A-Za-z]*)$ ]]; then
+              echo "::error::version suffix must be alphanumeric with no leading zero on an all-digit identifier, got: $1" >&2
               exit 1
             fi
           }
@@ -513,13 +518,24 @@ jobs:
             # Why the optional trailing identifier: the rc path can cut
             # suffixed side-branch RCs (X.Y.Z-rc.N.perf), and a shape this
             # regex rejects can never be re-cut through the override.
-            # Why rc.(0|[1-9][0-9]*): semver forbids a leading zero on a
-            # numeric identifier, and rc.08 would otherwise reach the `-le`
-            # below as an invalid octal literal, whose error makes the test
-            # false — falling *open* on exactly the RCs this gate must catch.
-            if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.(0|[1-9][0-9]*)(\.[0-9A-Za-z]+)?)?$ ]]; then
+            # Why rc.(0|[1-9][0-9]{0,8}): the `-le` below compares with bash's
+            # machine-width integers, so both ends of that range fall *open* on
+            # exactly the RCs this gate must catch. A leading zero (rc.08) is an
+            # invalid octal literal, and the failed test makes the `if` false.
+            # Past INTMAX (rc.99999999999999999999) bash saturates, so the test
+            # reads as "above the published rc" and the cut lands a tag that
+            # then pins highest_rc_for_base at 1e20 forever — every later cut
+            # wraps to a *lower* rc the fleet never updates to. Nine digits is
+            # far above any real series and exact in bash math either way.
+            if [[ ! "$explicit" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.(0|[1-9][0-9]{0,8})(\.[0-9A-Za-z]+)?)?$ ]]; then
               echo "::error::version must be X.Y.Z, X.Y.Z-rc.N, or X.Y.Z-rc.N.suffix, got: $EXPLICIT_VERSION" >&2
               exit 1
+            fi
+            # Why route the embedded identifier through the same validator the
+            # kind path uses: the regex above only checks shape, and rc.4.01
+            # is a shape-valid identifier that is not valid semver.
+            if [[ "$explicit" == *-rc.*.* ]]; then
+              require_valid_version_suffix "${explicit##*.}"
             fi
             # Same updater-safety gate the kind path enforces: stable line must
             # strictly increase over the latest published stable (prerelease

--- a/config/scripts/release-rc-history.mjs
+++ b/config/scripts/release-rc-history.mjs
@@ -38,7 +38,12 @@ export function rcNumberFromReleaseSubject(base, subject) {
     return null
   }
 
-  const match = /^(\d+)(?:\s|$)/.exec(subject.slice(prefix.length))
+  // Why the same optional .identifier as the tag form: the commit subject is
+  // the only record left once a tag is deleted, and that is exactly when the
+  // explicit-version gate leans on this. Without it, deleting a
+  // v1.2.3-rc.4.perf tag drops the series back to rc.3 and an explicit
+  // 1.2.3-rc.4 is waved through — below what perf-channel clients already run.
+  const match = /^(\d+)(?:\.[0-9A-Za-z]+)?(?:\s|$)/.exec(subject.slice(prefix.length))
   return match ? Number(match[1]) : null
 }
 

--- a/config/scripts/release-rc-history.test.mjs
+++ b/config/scripts/release-rc-history.test.mjs
@@ -53,6 +53,29 @@ describe('release RC history', () => {
     expect(rcNumberFromReleaseSubject('1.4.36', 'fix: v1.4.36-rc.6')).toBeNull()
   })
 
+  it('counts a suffixed side-branch RC from its subject as well as its tag', () => {
+    expect(rcNumberFromTag('1.4.36', 'v1.4.36-rc.6.perf')).toBe(6)
+    expect(rcNumberFromReleaseSubject('1.4.36', 'release: v1.4.36-rc.6.perf')).toBe(6)
+    expect(
+      rcNumberFromReleaseSubject('1.4.36', 'release: v1.4.36-rc.6.perf [rc-slot:2026-05-30-03]')
+    ).toBe(6)
+  })
+
+  it('keeps a suffixed RC counted once its tag is deleted', () => {
+    withGitRepo((repo) => {
+      commit(repo, 'initial')
+      commit(repo, 'release: v1.4.36-rc.5')
+      git(repo, ['tag', 'v1.4.36-rc.5'])
+      // Why this case: the subject is the only record left after the tag goes,
+      // and that is precisely when release-cut's explicit-version gate reads
+      // this. Under-reporting rc.6 here lets an explicit 1.4.36-rc.6 cut land
+      // below the v1.4.36-rc.6.perf build that clients already run.
+      commit(repo, 'release: v1.4.36-rc.6.perf')
+
+      expect(highestRcForBase('1.4.36', { cwd: repo })).toBe(6)
+    })
+  })
+
   it('keeps RC numbers monotonic after a stale tag is deleted', () => {
     withGitRepo((repo) => {
       commit(repo, 'initial')


### PR DESCRIPTION
## The hole

The `version` manual-dispatch override is validated only against the stable line:

```bash
if ! semver_gt "$explicit" "$latest_stable"; then   # refuse
```

`semver_gt` runs both operands through `strip_pre()`, which throws the prerelease identifier away. So `1.4.156-rc.0` is compared as `1.4.156` against stable `1.4.155` — and passes.

Meanwhile the kind-based RC path anchors on `highest_rc_for_base "$base"` and can therefore only ever move to `rc.N+1`. The explicit path bypasses that anchor entirely.

### Concretely

Latest stable is **v1.4.155**. The 1.4.156 series is mid-bake: **rc.0 … rc.3 are published** and clients on the RC channel are running rc.3.

1. rc.0 turned out to be broken, so someone deletes the `v1.4.156-rc.0` tag/release to clean it up. (Deleting a bad tag is routine — the whole reason this override exists is that deletions regress the release list.)
2. An operator dispatches `Cut Release` with `version=1.4.156-rc.0`, intending to "redo rc.0".
3. Today's gate: `strip_pre(1.4.156-rc.0)` = `1.4.156` > `1.4.155` ✅ — accepted. The tag no longer exists, so the collision check at the end of the step is also clear.
4. CI cuts and publishes **v1.4.156-rc.0** off current `main`, hundreds of commits ahead of the original rc.0.

Everyone on rc.3 now sees `1.4.156-rc.0` as the newest release in the channel, which is *lower* semver than what they run, so they never update; anything that does land on it is a build whose `PROTOCOL_VERSION` and daemon contract came from a version the fleet already moved past. This is the same regression class as the rc.4 incident that cut off an older branch, reverted ~100 commits, and orphaned the live v28 daemon with blank terminals.

## The fix

When the explicit version carries a prerelease, gate it against the RC history for **its own base** — reusing `highest_rc_for_base`, not a second source of truth:

```bash
if [[ "$explicit" == *-rc.* ]]; then
  explicit_base="${explicit%%-*}"
  explicit_rc="${explicit#*-rc.}"; explicit_rc="${explicit_rc%%.*}"
  highest_explicit_rc="$(highest_rc_for_base "$explicit_base")"
  if [[ -n "$highest_explicit_rc" && "$explicit_rc" -le "$highest_explicit_rc" ]]; then
    # refuse
```

That helper reads both `v<base>-rc.*` tags **and** `release: v<base>-rc.N` commit subjects on `HEAD`/`origin/main`, so a deleted tag still counts — which is what makes the attack above fail closed.

The existing stable-line gate is unchanged, and the legitimate use case survives: a human leapfrogging to an exact stable (`1.4.155`, `1.4.156`) is untouched, and cutting `1.4.156-rc.4` after rc.3 works. I deliberately did **not** add an escape-hatch input: the only thing the strict gate takes away is resuming an unpublished RC tag by exact number, and `kind=rc` already resumes that case through `recover_unpublished_tag`. The error message says so.

### Sibling gaps in the same block

- **`version_suffix` was silently dropped.** The suffix append lives inside the `if [[ -z "$new" ]]` kind branch that the explicit path skips, so passing both inputs quietly produced an unsuffixed version. It now applies on the explicit path too. Only a bare `X.Y.Z-rc.N` can take one — `1.4.156.perf` is not valid semver and re-suffixing an already-suffixed RC would yield `rc.4.perf.perf` — and both are now loud errors rather than a silent drop. The alphanumeric check is extracted to `require_valid_version_suffix` so the kind path and the explicit path share one definition (its "Why dot-appended" comment moved with it).
- **The shape regex rejected suffixed RCs.** `^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$` refused `X.Y.Z-rc.N.perf`, a shape the rc path itself can produce — so a suffixed RC could never be re-cut through the override. Now accepted.
- **Leading-zero octal trap (found while testing).** `[[ 08 -le 3 ]]` is not false — it *errors*, and the failed test makes the `if` false, so `1.4.156-rc.08` would have slipped straight past the new gate. The regex now enforces semver's no-leading-zero rule on the RC number (`(0|[1-9][0-9]*)`), which is also what stops an invalid tag shape from being cut.

## Verification

There is no unit-test harness for bash-inside-YAML, so I wrote a scratch harness that **extracts the real helper functions and the real explicit-version block out of `release-cut.yml`** with awk (dedent + stub `highest_rc_for_base`), so the assertions run the shipped code rather than a paraphrase of it. Fixture: latest stable `1.4.155`, published `1.4.156-rc.0 … rc.3`.

```
PASS  explicit 1.4.156-rc.0 (below published rc.3)               -> REJECT
PASS  explicit 1.4.156-rc.3 (equals published rc.3)              -> REJECT
PASS  explicit 1.4.156-rc.4 (advances series)                    -> OK (1.4.156-rc.4)
PASS  explicit 1.4.156 (stable promotion)                        -> OK (1.4.156)
PASS  explicit 1.4.155 (equals latest stable)                    -> REJECT
PASS  explicit 1.4.154 (below latest stable)                     -> REJECT
PASS  explicit 1.4.157-rc.0 (fresh base, no history)             -> OK (1.4.157-rc.0)
PASS  explicit rc + version_suffix lands                         -> OK (1.4.156-rc.4.perf)
PASS  explicit 1.4.156-rc.4.perf (suffixed shape)                -> OK (1.4.156-rc.4.perf)
PASS  explicit 1.4.156-rc.3.perf (suffixed, below)               -> REJECT
PASS  explicit stable + suffix (loud, not silent)                -> REJECT
PASS  explicit suffixed rc + suffix (no rc.N.a.b)                -> REJECT
PASS  explicit rc + non-alnum suffix                             -> REJECT
PASS  explicit v-prefixed 1.4.156-rc.4                           -> OK (1.4.156-rc.4)
PASS  explicit 1.4.156-rc.08 (octal trap)                        -> REJECT
PASS  explicit 1.4.156-rc.010 (octal trap, >rc.3)                -> REJECT
PASS  explicit garbage 1.4                                       -> REJECT
PASS  no explicit version (kind path)                            -> OK
passed=18 failed=0
```

Same harness against the **unmodified file at `f009500677`** — every new assertion fails there, so none of them pass vacuously:

```
FAIL  explicit 1.4.156-rc.0 (below published rc.3)   -> OK (1.4.156-rc.0)      <-- the bug
FAIL  explicit 1.4.156-rc.3 (equals published rc.3)  -> OK (1.4.156-rc.3)
FAIL  explicit rc + version_suffix lands             -> OK (1.4.156-rc.4)      <-- suffix dropped
FAIL  explicit 1.4.156-rc.4.perf (suffixed shape)    -> REJECT (regex)
FAIL  explicit stable + suffix (loud, not silent)    -> OK (1.4.156)
FAIL  explicit rc + non-alnum suffix                 -> OK (1.4.156-rc.4)
FAIL  explicit 1.4.156-rc.08 (octal trap)            -> OK (1.4.156-rc.08)
FAIL  explicit 1.4.156-rc.010 (octal trap, >rc.3)    -> OK (1.4.156-rc.010)
passed=10 failed=8
```

A second harness extracts the **`kind=rc` branch** to prove the shared-validator refactor changed nothing there — identical results before and after: `rc advances to rc.4` ✅, `rc + suffix appends` → `1.4.156-rc.4.perf` ✅, `rc + non-alnum suffix` → rejected ✅.

Also: `bash -n` on the full extracted "Compute next version" step passes, and the workflow still parses as YAML (all 10 jobs load).

**Not verified:** nothing is exercised against a real GitHub Actions run or a real `gh release` state — the harness stubs `highest_rc_for_base` with a fixture rather than driving the actual `release-rc-history.mjs` against a live tag/log set. `npx prettier --check` warns on this file, but it warns identically on the unmodified file at `f009500677` (4 pre-existing `''` vs `""` lines, none of them mine); the repo formatter is `oxfmt`, which does not cover YAML, so I left those alone rather than reformat unrelated lines.

---

## Review addendum (added during review — 4 follow-up commits)

Two reviewers plus CodeRabbit went over this. Four defects were found in the original commit and fixed on the branch; the PR now touches **3 files** and carries **four concerns**, named here so nobody meets them in a failed release cut instead.

| Commit | What it fixes |
|---|---|
| `698c5beeaa` | Gate fell **open** past INTMAX (bash wraps two's-complement, so `rc.99999999999999999999` → `7766279631452241919` > 3 and passed); leading-zero identifier caused a tag/`package.json` divergence because `npm version` silently renormalizes `rc.4.01` → `rc.4.1` |
| `5914f0a429` | Refusal message pointed minor/major RC series at `kind=rc`, which anchors on `bump(latest_stable, patch)` and would cut an unrelated release |
| `a44f406624` | `rcNumberFromReleaseSubject` was blind to suffixed RCs, so a deleted `v…-rc.4.perf` tag dropped the series and an explicit `rc.4` was accepted **below** what perf-channel clients run — the deleted-tag fallback is the only thing making this gate non-vacuous |
| `0dbcf7597e` | Four operator-facing corrections (see below) |

### The four concerns in this PR

1. **The RC gate** — the stated fix.
2. **`version_suffix` now applies on the explicit path.** Previously it was silently dropped. **Behavior change to flag:** `version=X.Y.Z` + `version_suffix=perf` used to succeed (cutting `X.Y.Z`, suffix discarded) and now **hard-fails**. That is a judgment call rather than a defect — it fails at the first step, before `npm version`/commit/tag/push, and silently discarding an explicitly-set input is the same failure shape this PR closes — but it is a real change and both reviewers thought this hunk was severable and could be its own PR. **Your call whether to split it.**
3. **The shape regex accepts `X.Y.Z-rc.N.suffix`.** Redundant with (2) — it is a second spelling of `version=X.Y.Z-rc.N` + `version_suffix`. Kept and documented rather than removed, since removing it would delete a working spelling.
4. **`require_valid_version_suffix` is shared with the `kind=rc` path**, and is now stricter, so `version_suffix=01`/`007` are rejected there too.

### Corrections to the original description

- **"A second harness … proves the shared-validator refactor changed nothing there — identical results before and after."** True of `cf4100b661`, **no longer true of the branch**: the kind path now differs from pre-PR in 3 of 35 combinations (`01`/`007` rejected, one message reworded). All intentional, but the claim is stale.
- **"Not verified: … the harness stubs `highest_rc_for_base`."** Now closed — driven against a real git repo with real tags, a real `git tag -d`, and the real unstubbed `release-rc-history.mjs`.
- The trailing-identifier comment justified itself as preserving a shape that "can never be re-cut through the override" — **falsified by the gate this PR adds**. Reworded in `0dbcf7597e`, along with `version_suffix`'s "rc kind only" description, an unbounded rc pattern in the suffix guard, and an unconditional "recovers the existing tag" claim.

### Verified

Legitimate operations confirmed still working, on a real git fixture: leapfrogging a deleted/rolled-back stable, creating **and** advancing a minor/major RC series (which `kind=rc` structurally cannot produce), and suffixed side-branch cuts. Gate assertions pass 26/26 on **both** bash 3.2 and bash 5.2 — bash version is the real portability axis here, and the two genuinely disagree on the oversized-integer comparison behind the first fix. Parser round-trip 875/875 shapes; new tests revert-checked (2 fail with the source reverted, `expected 5 to be 6` and `expected null to be 6`); 30/30 suites.

**Known gap, deliberately left:** nothing pins the workflow's bash automatically. `config/scripts/package-electron-runtime-contract.test.mjs` is at **exactly** its 600-line `max-lines` cap for `**/*.mjs` (the 800 override covers only `.test.ts`/`.test.tsx`), so it cannot be extended without a disable or cap bump — both banned by AGENTS.md — and a `toContain` on regex text would not have caught any of the four defects. A behavioral extract-and-run harness is the valuable version and belongs in its own PR.
