### PR TITLE
fix(terminal): make primary-selection paste suppression single-shot

### DIFF
--- a/src/renderer/src/hooks/usePrimarySelectionPaste.terminal-native-paste.test.tsx
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.terminal-native-paste.test.tsx
@@ -47,7 +47,7 @@ function appendXtermHelperTextarea(): HTMLTextAreaElement {
   return textarea
 }
 
-function dispatchPaste(target: HTMLElement): Event {
+function dispatchPasteBeforeInput(target: HTMLElement): Event {
   const event = new InputEvent('beforeinput', {
     bubbles: true,
     cancelable: true,
@@ -94,8 +94,8 @@ describe('terminal-armed native paste suppression', () => {
     let keyboardPaste!: Event
 
     await act(async () => {
-      nativeFollowUp = dispatchPaste(terminalTextarea)
-      keyboardPaste = dispatchPaste(terminalTextarea)
+      nativeFollowUp = dispatchPasteBeforeInput(terminalTextarea)
+      keyboardPaste = dispatchPasteBeforeInput(terminalTextarea)
     })
 
     expect(nativeFollowUp.defaultPrevented).toBe(true)
@@ -124,7 +124,7 @@ describe('terminal-armed native paste suppression', () => {
 
     let paste!: Event
     await act(async () => {
-      paste = dispatchPaste(terminalTextarea)
+      paste = dispatchPasteBeforeInput(terminalTextarea)
     })
 
     expect(paste.defaultPrevented).toBe(false)
@@ -138,7 +138,7 @@ describe('terminal-armed native paste suppression', () => {
 
     let paste!: Event
     await act(async () => {
-      paste = dispatchPaste(terminalTextarea)
+      paste = dispatchPasteBeforeInput(terminalTextarea)
     })
 
     expect(paste.defaultPrevented).toBe(false)

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.terminal-native-paste.test.tsx
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.terminal-native-paste.test.tsx
@@ -58,6 +58,14 @@ function dispatchPaste(target: HTMLElement): Event {
   return event
 }
 
+// Why: `paste` is the event that actually reaches the PTY — xterm forwards from
+// a `paste` listener and never listens to `beforeinput`.
+function dispatchClipboardPaste(target: HTMLElement): Event {
+  const event = new Event('paste', { bubbles: true, cancelable: true })
+  target.dispatchEvent(event)
+  return event
+}
+
 beforeEach(() => {
   resetPrimarySelectionForTests()
   setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
@@ -88,6 +96,22 @@ describe('terminal-armed native paste suppression', () => {
     await act(async () => {
       nativeFollowUp = dispatchPaste(terminalTextarea)
       keyboardPaste = dispatchPaste(terminalTextarea)
+    })
+
+    expect(nativeFollowUp.defaultPrevented).toBe(true)
+    expect(keyboardPaste.defaultPrevented).toBe(false)
+  })
+
+  it('swallows one clipboard paste per arm, the event xterm forwards to the PTY', async () => {
+    await renderProbe()
+    const terminalTextarea = appendXtermHelperTextarea()
+    armPrimarySelectionNativePasteSuppression()
+    let nativeFollowUp!: Event
+    let keyboardPaste!: Event
+
+    await act(async () => {
+      nativeFollowUp = dispatchClipboardPaste(terminalTextarea)
+      keyboardPaste = dispatchClipboardPaste(terminalTextarea)
     })
 
     expect(nativeFollowUp.defaultPrevented).toBe(true)

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.terminal-native-paste.test.tsx
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.terminal-native-paste.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+// Why: the sibling hook test mocks @/lib/primary-selection, so it cannot prove
+// the armed window is really single-shot. This file wires the hook to the real
+// module and exercises the Linux terminal middle-click follow-up end to end.
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  armPrimarySelectionNativePasteSuppression,
+  resetPrimarySelectionForTests
+} from '@/lib/primary-selection'
+import { usePrimarySelectionPaste } from './usePrimarySelectionPaste'
+
+const originalUserAgent = navigator.userAgent
+
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+function Probe(): null {
+  usePrimarySelectionPaste(true)
+  return null
+}
+
+function setUserAgent(userAgent: string): void {
+  Object.defineProperty(navigator, 'userAgent', { configurable: true, value: userAgent })
+}
+
+async function renderProbe(): Promise<void> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  await act(async () => {
+    root?.render(<Probe />)
+  })
+}
+
+// Stand-in for xterm's hidden helper textarea inside its `.xterm` container.
+function appendXtermHelperTextarea(): HTMLTextAreaElement {
+  const terminal = document.createElement('div')
+  terminal.className = 'xterm'
+  const textarea = document.createElement('textarea')
+  textarea.className = 'xterm-helper-textarea'
+  terminal.appendChild(textarea)
+  document.body.appendChild(terminal)
+  return textarea
+}
+
+function dispatchPaste(target: HTMLElement): Event {
+  const event = new InputEvent('beforeinput', {
+    bubbles: true,
+    cancelable: true,
+    data: 'pasted',
+    inputType: 'insertFromPaste'
+  })
+  target.dispatchEvent(event)
+  return event
+}
+
+beforeEach(() => {
+  resetPrimarySelectionForTests()
+  setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
+})
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root?.unmount()
+    })
+  }
+  root = null
+  container?.remove()
+  container = null
+  document.body.replaceChildren()
+  setUserAgent(originalUserAgent)
+  resetPrimarySelectionForTests()
+})
+
+describe('terminal-armed native paste suppression', () => {
+  it('swallows the first follow-up paste but not a later real paste in the same window', async () => {
+    await renderProbe()
+    const terminalTextarea = appendXtermHelperTextarea()
+    armPrimarySelectionNativePasteSuppression()
+    let nativeFollowUp!: Event
+    let keyboardPaste!: Event
+
+    await act(async () => {
+      nativeFollowUp = dispatchPaste(terminalTextarea)
+      keyboardPaste = dispatchPaste(terminalTextarea)
+    })
+
+    expect(nativeFollowUp.defaultPrevented).toBe(true)
+    expect(keyboardPaste.defaultPrevented).toBe(false)
+  })
+
+  it('keeps suppressing nothing when the terminal never armed the window', async () => {
+    await renderProbe()
+    const terminalTextarea = appendXtermHelperTextarea()
+
+    let paste!: Event
+    await act(async () => {
+      paste = dispatchPaste(terminalTextarea)
+    })
+
+    expect(paste.defaultPrevented).toBe(false)
+  })
+
+  it('does not arm on macOS, where Chromium emits no native follow-up paste', async () => {
+    setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)')
+    await renderProbe()
+    const terminalTextarea = appendXtermHelperTextarea()
+    armPrimarySelectionNativePasteSuppression()
+
+    let paste!: Event
+    await act(async () => {
+      paste = dispatchPaste(terminalTextarea)
+    })
+
+    expect(paste.defaultPrevented).toBe(false)
+  })
+})

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.test.tsx
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.test.tsx
@@ -4,21 +4,21 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  readPrimarySelectionText,
-  shouldSuppressPrimarySelectionNativePaste
+  consumePrimarySelectionNativePasteSuppression,
+  readPrimarySelectionText
 } from '@/lib/primary-selection'
 import { usePrimarySelectionPaste } from './usePrimarySelectionPaste'
 
 vi.mock('@/lib/primary-selection', () => ({
+  consumePrimarySelectionNativePasteSuppression: vi.fn(() => false),
   readPrimarySelectionText: vi.fn(),
   setPrimarySelectionEnabled: vi.fn(),
-  setPrimarySelectionText: vi.fn(),
-  shouldSuppressPrimarySelectionNativePaste: vi.fn(() => false)
+  setPrimarySelectionText: vi.fn()
 }))
 
 const originalUserAgent = navigator.userAgent
 const readPrimarySelectionTextMock = vi.mocked(readPrimarySelectionText)
-const shouldSuppressNativePasteMock = vi.mocked(shouldSuppressPrimarySelectionNativePaste)
+const consumeNativePasteMock = vi.mocked(consumePrimarySelectionNativePasteSuppression)
 
 let root: Root | null = null
 let container: HTMLDivElement | null = null
@@ -123,7 +123,7 @@ async function renderProbe(): Promise<void> {
 
 beforeEach(() => {
   setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)')
-  shouldSuppressNativePasteMock.mockReturnValue(false)
+  consumeNativePasteMock.mockReturnValue(false)
 })
 
 afterEach(async () => {
@@ -211,7 +211,7 @@ describe('usePrimarySelectionPaste', () => {
 
   it('swallows terminal-armed native paste follow-up even when it has no pending DOM target', async () => {
     setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
-    shouldSuppressNativePasteMock.mockReturnValue(true)
+    consumeNativePasteMock.mockReturnValue(true)
     await renderProbe()
     // Stand-in for xterm's helper textarea, which owns its own middle-click
     // paste and never registers a pending primary-selection DOM target.
@@ -230,11 +230,32 @@ describe('usePrimarySelectionPaste', () => {
     expect(readPrimarySelectionTextMock).not.toHaveBeenCalled()
   })
 
+  it('lets a keyboard paste through once the armed follow-up has been consumed', async () => {
+    setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
+    // Single-shot: the arm owes one follow-up, so a real Ctrl+V that lands
+    // inside the same window must reach the terminal.
+    consumeNativePasteMock.mockReturnValueOnce(true).mockReturnValue(false)
+    await renderProbe()
+    const terminalTextarea = appendXtermHelperTextarea()
+    let nativeFollowUp!: Event
+    let keyboardPaste!: Event
+
+    await act(async () => {
+      nativeFollowUp = dispatchNativePasteBeforeInput(terminalTextarea)
+      keyboardPaste = dispatchNativePasteBeforeInput(terminalTextarea)
+      await flushPromises()
+    })
+
+    expect(nativeFollowUp.defaultPrevented).toBe(true)
+    expect(keyboardPaste.defaultPrevented).toBe(false)
+    expect(consumeNativePasteMock).toHaveBeenCalledTimes(2)
+  })
+
   it('does not suppress an unrelated document paste while the terminal window is armed', async () => {
     setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
     // Armed window is active, but the paste targets a control outside the
     // terminal (e.g. right-click Paste into a form field) and must survive.
-    shouldSuppressNativePasteMock.mockReturnValue(true)
+    consumeNativePasteMock.mockReturnValue(true)
     await renderProbe()
     const unrelatedTextarea = appendTextarea()
     let nativeBeforeInput!: Event
@@ -252,7 +273,7 @@ describe('usePrimarySelectionPaste', () => {
 
   it('does not suppress native paste when the terminal has not armed the window', async () => {
     setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
-    shouldSuppressNativePasteMock.mockReturnValue(false)
+    consumeNativePasteMock.mockReturnValue(false)
     await renderProbe()
     const textarea = appendTextarea()
 

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.test.tsx
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.test.tsx
@@ -230,10 +230,10 @@ describe('usePrimarySelectionPaste', () => {
     expect(readPrimarySelectionTextMock).not.toHaveBeenCalled()
   })
 
-  it('lets a keyboard paste through once the armed follow-up has been consumed', async () => {
+  it('re-asks per paste event instead of caching the first suppression answer', async () => {
     setUserAgent('Mozilla/5.0 (X11; Linux x86_64)')
-    // Single-shot: the arm owes one follow-up, so a real Ctrl+V that lands
-    // inside the same window must reach the terminal.
+    // Single-shot lives in the module, which is mocked here; this only pins that
+    // the hook asks once per event, so the real one-shot answer is honored.
     consumeNativePasteMock.mockReturnValueOnce(true).mockReturnValue(false)
     await renderProbe()
     const terminalTextarea = appendXtermHelperTextarea()
@@ -269,6 +269,9 @@ describe('usePrimarySelectionPaste', () => {
 
     expect(nativeBeforeInput.defaultPrevented).toBe(false)
     expect(nativePaste.defaultPrevented).toBe(false)
+    // Consuming mutates, so the target check must short-circuit first: an
+    // unrelated paste that burned the arm would let the follow-up double-paste.
+    expect(consumeNativePasteMock).not.toHaveBeenCalled()
   })
 
   it('does not suppress native paste when the terminal has not armed the window', async () => {

--- a/src/renderer/src/hooks/usePrimarySelectionPaste.ts
+++ b/src/renderer/src/hooks/usePrimarySelectionPaste.ts
@@ -1,10 +1,10 @@
 import { useEffect } from 'react'
 import { isLinuxUserAgent, isMacUserAgent } from '@/components/terminal-pane/pane-helpers'
 import {
+  consumePrimarySelectionNativePasteSuppression,
   readPrimarySelectionText,
   setPrimarySelectionEnabled,
-  setPrimarySelectionText,
-  shouldSuppressPrimarySelectionNativePaste
+  setPrimarySelectionText
 } from '@/lib/primary-selection'
 import {
   findEditablePrimarySelectionPasteTarget,
@@ -110,9 +110,10 @@ export function usePrimarySelectionPaste(enabled: boolean): void {
       // a pending DOM target, so honor its armed window to swallow the follow-up
       // native paste event that xterm would otherwise forward to the PTY — but
       // only for the terminal's own surface, never unrelated document pastes.
+      // Consuming leaves the window disarmed so a later real paste survives.
       if (
         isTerminalNativePasteTarget(event.target) &&
-        shouldSuppressPrimarySelectionNativePaste()
+        consumePrimarySelectionNativePasteSuppression()
       ) {
         suppressEvent(event)
       }

--- a/src/renderer/src/lib/primary-selection.test.ts
+++ b/src/renderer/src/lib/primary-selection.test.ts
@@ -2,12 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   PRIMARY_SELECTION_MAX_LENGTH,
   armPrimarySelectionNativePasteSuppression,
+  consumePrimarySelectionNativePasteSuppression,
   getPrimarySelectionText,
   readPrimarySelectionText,
   resetPrimarySelectionForTests,
   setPrimarySelectionEnabled,
   setPrimarySelectionText,
-  shouldSuppressPrimarySelectionNativePaste,
   shouldUseSystemPrimarySelectionClipboard
 } from './primary-selection'
 
@@ -144,29 +144,55 @@ describe('primary-selection native paste suppression', () => {
 
   it('does not arm suppression while primary selection is disabled', () => {
     armPrimarySelectionNativePasteSuppression(1_000)
-    expect(shouldSuppressPrimarySelectionNativePaste(1_000)).toBe(false)
+    expect(consumePrimarySelectionNativePasteSuppression(1_000)).toBe(false)
   })
 
   it('does not arm suppression off Linux, where there is no native follow-up paste', () => {
     vi.stubGlobal('navigator', { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)' })
     setPrimarySelectionEnabled(true)
     armPrimarySelectionNativePasteSuppression(1_000)
-    expect(shouldSuppressPrimarySelectionNativePaste(1_000)).toBe(false)
+    expect(consumePrimarySelectionNativePasteSuppression(1_000)).toBe(false)
   })
 
   it('suppresses the follow-up native paste within the armed window', () => {
     setPrimarySelectionEnabled(true)
     armPrimarySelectionNativePasteSuppression(1_000)
 
-    expect(shouldSuppressPrimarySelectionNativePaste(1_000)).toBe(true)
-    expect(shouldSuppressPrimarySelectionNativePaste(1_700)).toBe(true)
+    expect(consumePrimarySelectionNativePasteSuppression(1_000)).toBe(true)
+  })
+
+  it('suppresses a follow-up that arrives late in the armed window', () => {
+    setPrimarySelectionEnabled(true)
+    armPrimarySelectionNativePasteSuppression(1_000)
+
+    expect(consumePrimarySelectionNativePasteSuppression(1_700)).toBe(true)
+  })
+
+  it('lets a real paste through after the follow-up is consumed inside the window', () => {
+    setPrimarySelectionEnabled(true)
+    armPrimarySelectionNativePasteSuppression(1_000)
+
+    expect(consumePrimarySelectionNativePasteSuppression(1_000)).toBe(true)
+    expect(consumePrimarySelectionNativePasteSuppression(1_050)).toBe(false)
+    expect(consumePrimarySelectionNativePasteSuppression(1_700)).toBe(false)
+  })
+
+  it('consumes only one follow-up per arm across repeated middle-clicks', () => {
+    setPrimarySelectionEnabled(true)
+    armPrimarySelectionNativePasteSuppression(1_000)
+    expect(consumePrimarySelectionNativePasteSuppression(1_010)).toBe(true)
+    expect(consumePrimarySelectionNativePasteSuppression(1_020)).toBe(false)
+
+    armPrimarySelectionNativePasteSuppression(1_100)
+    expect(consumePrimarySelectionNativePasteSuppression(1_110)).toBe(true)
+    expect(consumePrimarySelectionNativePasteSuppression(1_120)).toBe(false)
   })
 
   it('stops suppressing once the armed window elapses', () => {
     setPrimarySelectionEnabled(true)
     armPrimarySelectionNativePasteSuppression(1_000)
 
-    expect(shouldSuppressPrimarySelectionNativePaste(1_800)).toBe(false)
+    expect(consumePrimarySelectionNativePasteSuppression(1_800)).toBe(false)
   })
 
   it('clears the armed window when primary selection is disabled', () => {
@@ -176,6 +202,6 @@ describe('primary-selection native paste suppression', () => {
     setPrimarySelectionEnabled(false)
     setPrimarySelectionEnabled(true)
 
-    expect(shouldSuppressPrimarySelectionNativePaste(1_000)).toBe(false)
+    expect(consumePrimarySelectionNativePasteSuppression(1_000)).toBe(false)
   })
 })

--- a/src/renderer/src/lib/primary-selection.ts
+++ b/src/renderer/src/lib/primary-selection.ts
@@ -63,8 +63,14 @@ export function armPrimarySelectionNativePasteSuppression(now: number = Date.now
   nativePasteSuppressionUntil = now + PRIMARY_SELECTION_NATIVE_PASTE_SUPPRESSION_MS
 }
 
-export function shouldSuppressPrimarySelectionNativePaste(now: number = Date.now()): boolean {
-  return enabled && now <= nativePasteSuppressionUntil
+// Why: single-shot — the arm owes exactly one follow-up paste, so clearing the
+// deadline on consume keeps a real keyboard paste inside the same 750ms alive.
+export function consumePrimarySelectionNativePasteSuppression(now: number = Date.now()): boolean {
+  if (!enabled || nativePasteSuppressionUntil === 0 || now > nativePasteSuppressionUntil) {
+    return false
+  }
+  nativePasteSuppressionUntil = 0
+  return true
 }
 
 export function isPrimarySelectionEnabled(): boolean {


### PR DESCRIPTION
## Summary

On Linux, middle-clicking in the integrated terminal armed a 750ms window (`PRIMARY_SELECTION_NATIVE_PASTE_SUPPRESSION_MS`) that swallowed **every** paste event on the terminal surface for its full duration. Press <kbd>Ctrl</kbd>+<kbd>V</kbd> within 750ms of a middle-click paste and the keyboard paste was silently dropped — no error, no text, no feedback.

The armed window exists for exactly one reason: the terminal injects the primary selection into the PTY itself on middle-click, so Chromium's *single* follow-up native paste event has to be swallowed to avoid a double paste. #8993, which introduced the window, says so in its own commit message: "This swallows the single native paste event so the selection reaches the PTY exactly once." The 750ms is an upper bound on when that one event arrives — not a period during which all pastes should die. `shouldSuppressPrimarySelectionNativePaste` never cleared the deadline once consumed, so it kept answering `true` until it timed out.

**Fix:** make the suppression single-shot. `consumePrimarySelectionNativePasteSuppression` clears the deadline on first use, so the arm owes at most one event. 750ms stays as the expiry bound for that one event.

The rename makes the mutation obvious at the call site — the old name promised a pure predicate. `usePrimarySelectionPaste` is the only non-test consumer (`TerminalPane` only *arms*), and the short-circuit order is preserved so a paste outside the terminal surface never eats the arm.

Platform gating is untouched: `armPrimarySelectionNativePasteSuppression` still no-ops off Linux/X11, and `setPrimarySelectionEnabled(false)` still resets the deadline to `0`.

17 net source lines across 2 files; the rest is test coverage.

## Screenshots

`No visual change` — this is terminal input-event behavior with no UI surface.

## Testing

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — the three touched files: **28 passed**. Wider sweep: `src/renderer/src/lib/` + `src/renderer/src/hooks/` = 373 files / 3414 passed, and `src/renderer/src/components/terminal-pane/` = 183 files / 2381 passed.
- [x] `pnpm build` — via CI `verify`
- [x] Added regression tests, **verified non-vacuous**

Non-vacuity was proven by reverting *only* the source logic (restoring the non-consuming predicate body while keeping the new name, so failures are about logic and not imports) and re-running:

```
× lets a real paste through after the follow-up is consumed inside the window
  → expected true to be false
× consumes only one follow-up per arm across repeated middle-clicks
  → expected true to be false
× swallows the first follow-up paste but not a later real paste in the same window
  → expected true to be false
× swallows one clipboard paste per arm, the event xterm forwards to the PTY
  → expected true to be false
 Tests  4 failed | 24 passed (28)
```

With the fix restored: `Tests 28 passed (28)`.

The last two failures are from a new file, `usePrimarySelectionPaste.terminal-native-paste.test.tsx`. The existing hook test mocks `@/lib/primary-selection` wholesale, so it structurally *cannot* observe single-shot behavior — a same-file test there would pass with or without the fix. The new file wires the hook to the real module and dispatches two paste events at an `.xterm-helper-textarea`, asserting the first is prevented and the second is not — once as `beforeinput`, and once as a real `paste` `ClipboardEvent`, which is the event xterm actually forwards to the PTY. Those are the end-to-end assertions for the bug.

The short-circuit order in `usePrimarySelectionPaste.ts` also became load-bearing once `consume` gained a side effect: swapping the operands would burn the arm on an unrelated paste and let the real follow-up double-paste, while leaving `defaultPrevented` unchanged. That swap is now caught by asserting `consume` is never reached for a non-terminal target (verified by simulating the swap: the guard fails, and without it the swap was invisible).

Also kept from the existing suite: time-based expiry, the disable-clears-armed-state case, off-Linux no-arm, and "unrelated document paste is not swallowed while armed."

## AI Review Report

Reviewed with parallel AI subagents (correctness/regression, and scope/standards) plus a throwaway runtime probe, looping until clean.

Risks checked and what came back:

- **Does it fix the reported bug?** Yes. Verified against the *production* arm sequence, which arms twice per gesture — `TerminalPane` arms on both `mousedown` (`TerminalPane.tsx:2663`) and `auxclick` (`TerminalPane.tsx:2740`). A runtime probe confirmed arm→arm→consume leaves the window disarmed, so the follow-up is eaten and a subsequent real paste survives.
- **Double-paste regression (the main risk).** Under the old code both `paste` and `beforeinput` were suppressed for the whole window; single-shot eats only the first. This is safe because only one of the two can reach the handler per native paste: Blink dispatches `paste` first, and the capture-phase `preventDefault` aborts the paste pipeline, so `beforeinput` never fires. It is also the event that matters — xterm forwards to the PTY from a `paste` listener on its textarea/element (`@xterm/xterm` `CoreBrowserTerminal.ts`), and does not listen to `beforeinput`. A probe confirmed a real `paste` `ClipboardEvent` is suppressed exactly once per arm.
- **Cross-platform (macOS / Linux / Windows).** Explicitly checked. Behavior is Linux/X11-only by construction: `armPrimarySelectionNativePasteSuppression` early-returns unless `isLinuxUserAgent(getUserAgent())`, so macOS and Windows never arm and are byte-for-byte unaffected. No shortcuts, labels, paths, shell behavior, or Electron main-process code are touched — this is renderer-only DOM event handling. A macOS no-arm case is covered in the new test file.
- **SSH / folder workspaces / non-GitHub git providers.** Not applicable: the change is entirely in the renderer's DOM paste path and never reaches PTY transport, workspace resolution, or any git provider.
- **Perf.** Neutral-to-better. `consume` is the same O(1) numeric comparison the predicate was, on the same capture-phase handler, with no new allocation, timer, or listener. It now *reduces* work in the common case, since a disarmed window short-circuits on `nativePasteSuppressionUntil === 0`.
- **Scope.** One concern only: one commit, 5 files, 17 net source lines. No unrelated changes, no drive-by refactors, no `max-lines` disables (AGENTS.md), no stale references to the old symbol name anywhere in the repo.

## Security Audit

No new attack surface. No input parsing, no command execution, no path handling, no auth, no secrets, no dependency changes, and no IPC surface is touched. The change narrows when a DOM event is suppressed inside the renderer; it does not alter what text is read, where it comes from, or what is written to the PTY. Clipboard content still flows through the existing `PRIMARY_SELECTION_MAX_LENGTH` / `maxBytes` bounds, which are unchanged. If anything the change is defensively *better*: it shortens the window during which the app silently discards user input. No follow-up needed.

## Notes

Platform-specific behavior and residual risks, stated honestly:

- **Not runtime-verified on real Linux/X11.** Developed and reviewed on macOS. The Chromium event-sequence claims were checked in a real Electron probe (Electron 43.1.0 / Chromium 150, Orca's shipped runtime), which confirmed `paste` fires first, is cancelable, and that cancelling it at document capture suppresses `beforeinput` and `input` entirely. But that probe drove `Editor::Paste`, not an actual X11 middle-click; the real primary-selection follow-up on a Linux host is still unexercised. This is the one thing worth a Linux reviewer's eyes.
- **Arm without a follow-up.** If a middle-click arms but no native follow-up ever arrives (empty primary selection, a Wayland compositor with no primary paste, or focus off the helper textarea), the deadline dangles and the first real paste inside 750ms is still eaten. Strictly better than today — where *every* paste in the window dies rather than one — but not zero. Fixing that would mean disarming on a signal this layer does not have.
- **Pre-existing arm/auxclick ordering (unchanged by this PR).** `TerminalPane` arms on `mousedown` and re-arms on `auxclick`. If Chromium's native paste ever landed *between* those two, the consume would disarm and `auxclick` would immediately re-arm an unowed window. Checked against Blink: `event_handler.cc` dispatches pointerup/mouseup and then auxclick via `DispatchMouseClickIfNeeded`, and only then runs the paste — `selection_controller.cc` confirms the paste happens on mouse-up "after the event handlers have been fired." So the paste lands after both arms and the spare-arm path is not reachable. Left alone deliberately: touching it would mean changing `TerminalPane`, which is out of scope here.
