### PR TITLE
fix(tasks): keep repos with a pending remote-identity probe in the picker

### DIFF
--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4386,6 +4386,29 @@ describe('Store', () => {
     expect(reloaded.getRepo('r1')!.upstream).toBeNull()
   })
 
+  it('updateRepo persists the resolved no-usable-remote identity marker', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+
+    const updated = store.updateRepo('r1', {
+      gitRemoteIdentity: {
+        canonicalKey: 'gitlab.example.com/team/orca',
+        remoteName: 'origin',
+        remoteUrl: 'git@gitlab.example.com:team/orca.git'
+      }
+    })
+    expect(updated!.gitRemoteIdentity).toEqual({
+      canonicalKey: 'gitlab.example.com/team/orca',
+      remoteName: 'origin',
+      remoteUrl: 'git@gitlab.example.com:team/orca.git'
+    })
+
+    store.updateRepo('r1', { gitRemoteIdentity: null })
+    store.flush()
+    const reloaded = await createStore()
+    expect(reloaded.getRepo('r1')!.gitRemoteIdentity).toBeNull()
+  })
+
   it('getRepo does not expose invalid persisted repo upstream metadata', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ upstream: { owner: '', repo: 42 } as never }))

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1315,7 +1315,12 @@ function sanitizeRepoUpstream(value: unknown): Repo['upstream'] | undefined {
   return owner && repo ? { owner, repo } : undefined
 }
 
-function sanitizeGitRemoteIdentity(value: unknown): GitRemoteIdentity | undefined {
+function sanitizeGitRemoteIdentity(value: unknown): GitRemoteIdentity | null | undefined {
+  // Why: `null` is a resolved "no usable remote" marker; dropping it would make
+  // a settled repo indistinguishable from one whose identity probe is pending.
+  if (value === null) {
+    return null
+  }
   if (!value || typeof value !== 'object') {
     return undefined
   }
@@ -1374,7 +1379,7 @@ function sanitizeRepoUpdatesForPersistence<
       sanitized.repoIcon = repoIcon
     }
   }
-  // Why: `null` is a valid "not a fork" marker; only drop malformed shapes.
+  // Why: `null` is a valid "not a fork" / "no usable remote" marker; only drop malformed shapes.
   if ('upstream' in sanitized) {
     const upstream = sanitizeRepoUpstream(sanitized.upstream)
     if (upstream === undefined) {

--- a/src/main/repo-git-remote-identity-enrichment.test.ts
+++ b/src/main/repo-git-remote-identity-enrichment.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { GitRemoteIdentity } from '../shared/git-remote-identity'
 import type { Repo } from '../shared/types'
-import { detectGitRemoteIdentity } from './repo-git-remote-identity'
+import { type GitRemoteIdentityProbe, probeGitRemoteIdentity } from './repo-git-remote-identity'
 import {
   enrichMissingRepoGitRemoteIdentities,
   flushRepoGitRemoteIdentityEnrichmentForTests,
@@ -9,7 +9,7 @@ import {
 } from './repo-git-remote-identity-enrichment'
 
 vi.mock('./repo-git-remote-identity', () => ({
-  detectGitRemoteIdentity: vi.fn()
+  probeGitRemoteIdentity: vi.fn()
 }))
 
 type RepoIdentityStore = {
@@ -23,6 +23,8 @@ const remoteIdentity: GitRemoteIdentity = {
   remoteName: 'origin',
   remoteUrl: 'git@git.company.test:team/sample-app.git'
 }
+
+const resolvedProbe: GitRemoteIdentityProbe = { status: 'resolved', identity: remoteIdentity }
 
 function makeRepo(overrides: Partial<Repo> = {}): Repo {
   return {
@@ -71,7 +73,7 @@ afterEach(() => {
 
 describe('enrichMissingRepoGitRemoteIdentities', () => {
   it('schedules remote identity enrichment without blocking the caller', async () => {
-    vi.mocked(detectGitRemoteIdentity).mockResolvedValue(remoteIdentity)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
     const repo = makeRepo()
     const store = makeStore(repo)
     const onChanged = vi.fn()
@@ -79,7 +81,7 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
     enrichMissingRepoGitRemoteIdentities(store, { onChanged })
 
     expect(repo.gitRemoteIdentity).toBeUndefined()
-    expect(detectGitRemoteIdentity).toHaveBeenCalledWith('/workspace/sample-app', undefined)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledWith('/workspace/sample-app', undefined)
 
     await flushRepoGitRemoteIdentityEnrichmentForTests()
 
@@ -88,17 +90,17 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
   })
 
   it('coalesces concurrent probes for the same repo location', async () => {
-    const probe = deferred<GitRemoteIdentity | null>()
-    vi.mocked(detectGitRemoteIdentity).mockReturnValue(probe.promise)
+    const probe = deferred<GitRemoteIdentityProbe>()
+    vi.mocked(probeGitRemoteIdentity).mockReturnValue(probe.promise)
     const repo = makeRepo()
     const store = makeStore(repo)
 
     enrichMissingRepoGitRemoteIdentities(store)
     enrichMissingRepoGitRemoteIdentities(store)
 
-    expect(detectGitRemoteIdentity).toHaveBeenCalledTimes(1)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(1)
 
-    probe.resolve(remoteIdentity)
+    probe.resolve(resolvedProbe)
     await flushRepoGitRemoteIdentityEnrichmentForTests()
 
     expect(store.updateRepo).toHaveBeenCalledTimes(1)
@@ -108,7 +110,7 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
   it('caches no-identity probes briefly so list calls do not retry every time', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
-    vi.mocked(detectGitRemoteIdentity).mockResolvedValue(null)
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({ status: 'no-remote' })
     const repo = makeRepo()
     const store = makeStore(repo)
 
@@ -117,18 +119,53 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
     enrichMissingRepoGitRemoteIdentities(store)
     await flushRepoGitRemoteIdentityEnrichmentForTests()
 
-    expect(detectGitRemoteIdentity).toHaveBeenCalledTimes(1)
+    expect(probeGitRemoteIdentity).toHaveBeenCalledTimes(1)
+  })
+
+  it('settles a repo git answered for but that has no usable remote', async () => {
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({ status: 'no-remote' })
+    const repo = makeRepo()
+    const store = makeStore(repo)
+
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(store.updateRepo).toHaveBeenCalledWith('repo-1', { gitRemoteIdentity: null })
+    expect(repo.gitRemoteIdentity).toBeNull()
+  })
+
+  it('leaves identity unresolved when the probe could not reach the host', async () => {
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({ status: 'unavailable' })
+    const repo = makeRepo({ connectionId: 'builder' })
+    const store = makeStore(repo)
+
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(store.updateRepo).not.toHaveBeenCalled()
+    expect(repo.gitRemoteIdentity).toBeUndefined()
+  })
+
+  it('does not rewrite the no-remote marker on a later retry', async () => {
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue({ status: 'no-remote' })
+    const repo = makeRepo({ gitRemoteIdentity: null })
+    const store = makeStore(repo)
+
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(store.updateRepo).not.toHaveBeenCalled()
   })
 
   it('does not write stale identity data after the repo path changes', async () => {
-    const probe = deferred<GitRemoteIdentity | null>()
-    vi.mocked(detectGitRemoteIdentity).mockReturnValue(probe.promise)
+    const probe = deferred<GitRemoteIdentityProbe>()
+    vi.mocked(probeGitRemoteIdentity).mockReturnValue(probe.promise)
     const repo = makeRepo()
     const store = makeStore(repo)
 
     enrichMissingRepoGitRemoteIdentities(store)
     repo.path = '/workspace/renamed-sample-app'
-    probe.resolve(remoteIdentity)
+    probe.resolve(resolvedProbe)
     await flushRepoGitRemoteIdentityEnrichmentForTests()
 
     expect(store.updateRepo).not.toHaveBeenCalled()

--- a/src/main/repo-git-remote-identity-enrichment.test.ts
+++ b/src/main/repo-git-remote-identity-enrichment.test.ts
@@ -157,6 +157,17 @@ describe('enrichMissingRepoGitRemoteIdentities', () => {
     expect(store.updateRepo).not.toHaveBeenCalled()
   })
 
+  it('resolves a settled no-remote repo once it gains a remote', async () => {
+    vi.mocked(probeGitRemoteIdentity).mockResolvedValue(resolvedProbe)
+    const repo = makeRepo({ gitRemoteIdentity: null })
+    const store = makeStore(repo)
+
+    enrichMissingRepoGitRemoteIdentities(store)
+    await flushRepoGitRemoteIdentityEnrichmentForTests()
+
+    expect(store.updateRepo).toHaveBeenCalledWith('repo-1', { gitRemoteIdentity: remoteIdentity })
+  })
+
   it('does not write stale identity data after the repo path changes', async () => {
     const probe = deferred<GitRemoteIdentityProbe>()
     vi.mocked(probeGitRemoteIdentity).mockReturnValue(probe.promise)

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -88,6 +88,10 @@ async function enrichMissingRepoGitRemoteIdentitiesInBackground(
   store: RepoIdentityStore,
   options: EnrichmentOptions
 ): Promise<void> {
+  // Why: the settled `null` marker stays a candidate on purpose — a repo that
+  // gains a remote later must still resolve. Do not tighten this to
+  // `=== undefined`; the retry TTL already bounds the cost and `writeIdentity`
+  // skips the redundant rewrite.
   const candidates = store
     .getRepos()
     .filter((repo) => repo.kind !== 'folder' && !repo.gitRemoteIdentity)

--- a/src/main/repo-git-remote-identity-enrichment.ts
+++ b/src/main/repo-git-remote-identity-enrichment.ts
@@ -1,5 +1,5 @@
 import type { Repo } from '../shared/types'
-import { detectGitRemoteIdentity } from './repo-git-remote-identity'
+import { probeGitRemoteIdentity } from './repo-git-remote-identity'
 
 const NO_IDENTITY_RETRY_TTL_MS = 5 * 60 * 1000
 
@@ -34,6 +34,23 @@ function isSameUnenrichedRepo(snapshot: Repo, current: Repo | undefined): boolea
   )
 }
 
+function writeIdentity(
+  store: RepoIdentityStore,
+  snapshot: Repo,
+  gitRemoteIdentity: Repo['gitRemoteIdentity']
+): boolean {
+  const current = getCurrentRepo(store, snapshot.id)
+  if (!isSameUnenrichedRepo(snapshot, current)) {
+    return false
+  }
+  // Why: the no-remote marker is re-derived on every retry; skip the redundant
+  // write so repo-list consumers do not churn.
+  if (gitRemoteIdentity === null && current?.gitRemoteIdentity === null) {
+    return false
+  }
+  return !!store.updateRepo(snapshot.id, { gitRemoteIdentity })
+}
+
 async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo): Promise<boolean> {
   const locationKey = getRepoLocationKey(repo)
   const retryAfter = noIdentityRetryAfterByLocation.get(locationKey) ?? 0
@@ -45,20 +62,19 @@ async function enrichRepoGitRemoteIdentity(store: RepoIdentityStore, repo: Repo)
     return inFlight
   }
   const probe = (async () => {
-    const identity = await detectGitRemoteIdentity(repo.path, repo.connectionId)
-    if (!identity) {
+    const result = await probeGitRemoteIdentity(repo.path, repo.connectionId)
+    if (result.status !== 'resolved') {
       // Why: repos without a parseable remote are common; cache misses briefly so
       // list calls stay cheap while still allowing recent remote changes to land.
       noIdentityRetryAfterByLocation.set(locationKey, Date.now() + NO_IDENTITY_RETRY_TTL_MS)
-      return false
+      // Why: only a probe that actually reached git settles "no usable remote".
+      // An unreachable host leaves the identity unknown so consumers can keep
+      // treating the repo as pending instead of ineligible.
+      return result.status === 'no-remote' ? writeIdentity(store, repo, null) : false
     }
 
     noIdentityRetryAfterByLocation.delete(locationKey)
-    const current = getCurrentRepo(store, repo.id)
-    if (!isSameUnenrichedRepo(repo, current)) {
-      return false
-    }
-    return !!store.updateRepo(repo.id, { gitRemoteIdentity: identity })
+    return writeIdentity(store, repo, result.identity)
   })().finally(() => {
     if (inFlightProbesByLocation.get(locationKey) === probe) {
       inFlightProbesByLocation.delete(locationKey)

--- a/src/main/repo-git-remote-identity.test.ts
+++ b/src/main/repo-git-remote-identity.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { gitExecFileAsync } from './git/runner'
+import { getSshGitProvider } from './providers/ssh-git-dispatch'
+import { probeGitRemoteIdentity } from './repo-git-remote-identity'
+
+vi.mock('./git/runner', () => ({ gitExecFileAsync: vi.fn() }))
+vi.mock('./providers/ssh-git-dispatch', () => ({ getSshGitProvider: vi.fn() }))
+
+const gitlabRemote = 'origin\tgit@gitlab.example.com:team/orca.git (fetch)\n'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('probeGitRemoteIdentity', () => {
+  it('resolves the canonical identity for a non-GitHub remote', async () => {
+    vi.mocked(gitExecFileAsync).mockResolvedValue({ stdout: gitlabRemote, stderr: '' })
+
+    await expect(probeGitRemoteIdentity('/repos/orca')).resolves.toEqual({
+      status: 'resolved',
+      identity: {
+        canonicalKey: 'gitlab.example.com/team/orca',
+        remoteName: 'origin',
+        remoteUrl: 'git@gitlab.example.com:team/orca.git'
+      }
+    })
+  })
+
+  it('settles on no-remote when git answers with nothing usable', async () => {
+    vi.mocked(gitExecFileAsync).mockResolvedValue({ stdout: '', stderr: '' })
+
+    await expect(probeGitRemoteIdentity('/repos/orca')).resolves.toEqual({ status: 'no-remote' })
+  })
+
+  it('reports unavailable when the SSH host has no connected git provider', async () => {
+    vi.mocked(getSshGitProvider).mockReturnValue(undefined)
+
+    await expect(probeGitRemoteIdentity('/repos/orca', 'builder')).resolves.toEqual({
+      status: 'unavailable'
+    })
+  })
+
+  it('reports unavailable when the remote git command fails', async () => {
+    vi.mocked(gitExecFileAsync).mockRejectedValue(new Error('ssh: connect to host builder: down'))
+
+    await expect(probeGitRemoteIdentity('/repos/orca')).resolves.toEqual({ status: 'unavailable' })
+  })
+})

--- a/src/main/repo-git-remote-identity.test.ts
+++ b/src/main/repo-git-remote-identity.test.ts
@@ -40,9 +40,30 @@ describe('probeGitRemoteIdentity', () => {
     })
   })
 
-  it('reports unavailable when the remote git command fails', async () => {
-    vi.mocked(gitExecFileAsync).mockRejectedValue(new Error('ssh: connect to host builder: down'))
+  it('reports unavailable when the local git command fails', async () => {
+    vi.mocked(gitExecFileAsync).mockRejectedValue(new Error('not a git repository'))
 
     await expect(probeGitRemoteIdentity('/repos/orca')).resolves.toEqual({ status: 'unavailable' })
+  })
+
+  it('reports unavailable when a connected SSH provider cannot reach the host', async () => {
+    const exec = vi.fn().mockRejectedValue(new Error('ssh: connect to host builder: down'))
+    vi.mocked(getSshGitProvider).mockReturnValue({ exec } as never)
+
+    await expect(probeGitRemoteIdentity('/repos/orca', 'builder')).resolves.toEqual({
+      status: 'unavailable'
+    })
+    expect(exec).toHaveBeenCalledWith(['remote', '-v'], '/repos/orca')
+    expect(gitExecFileAsync).not.toHaveBeenCalled()
+  })
+
+  it('settles on no-remote for an SSH repo git answered for with no remotes', async () => {
+    vi.mocked(getSshGitProvider).mockReturnValue({
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    } as never)
+
+    await expect(probeGitRemoteIdentity('/repos/orca', 'builder')).resolves.toEqual({
+      status: 'no-remote'
+    })
   })
 })

--- a/src/main/repo-git-remote-identity.ts
+++ b/src/main/repo-git-remote-identity.ts
@@ -2,17 +2,37 @@ import { deriveGitRemoteIdentity, type GitRemoteIdentity } from '../shared/git-r
 import { gitExecFileAsync } from './git/runner'
 import { getSshGitProvider } from './providers/ssh-git-dispatch'
 
-export async function detectGitRemoteIdentity(
+/** `no-remote` means git answered and the repo has no usable remote;
+ *  `unavailable` means the probe never reached git (host down, SSH not up
+ *  yet, git error) and says nothing about the repo. */
+export type GitRemoteIdentityProbe =
+  | { status: 'resolved'; identity: GitRemoteIdentity }
+  | { status: 'no-remote' }
+  | { status: 'unavailable' }
+
+export async function probeGitRemoteIdentity(
   repoPath: string,
   connectionId?: string | null
-): Promise<GitRemoteIdentity | null> {
+): Promise<GitRemoteIdentityProbe> {
   try {
     const result = connectionId
       ? await getSshGitProvider(connectionId)?.exec(['remote', '-v'], repoPath)
       : await gitExecFileAsync(['remote', '-v'], { cwd: repoPath })
-    return result ? deriveGitRemoteIdentity(result.stdout) : null
+    if (!result) {
+      return { status: 'unavailable' }
+    }
+    const identity = deriveGitRemoteIdentity(result.stdout)
+    return identity ? { status: 'resolved', identity } : { status: 'no-remote' }
   } catch {
     // Repo creation must not fail because a best-effort remote probe failed.
-    return null
+    return { status: 'unavailable' }
   }
+}
+
+export async function detectGitRemoteIdentity(
+  repoPath: string,
+  connectionId?: string | null
+): Promise<GitRemoteIdentity | null> {
+  const probe = await probeGitRemoteIdentity(repoPath, connectionId)
+  return probe.status === 'resolved' ? probe.identity : null
 }

--- a/src/renderer/src/components/task-page-default-repo-selection.test.ts
+++ b/src/renderer/src/components/task-page-default-repo-selection.test.ts
@@ -40,7 +40,7 @@ describe('getTaskEligibleRepos', () => {
           remoteUrl: 'git@gitlab.example.com:team/orca.git'
         }
       }),
-      repo({ id: 'local-only' }),
+      repo({ id: 'settled-no-remote', gitRemoteIdentity: null }),
       repo({
         id: 'incomplete-remote',
         gitRemoteIdentity: {
@@ -61,6 +61,54 @@ describe('getTaskEligibleRepos', () => {
       'github-icon',
       'gitlab-remote'
     ])
+  })
+
+  it('keeps a repo visible while its remote identity probe has not answered', () => {
+    const eligible = getTaskEligibleRepos([
+      repo({ id: 'probe-pending' }),
+      repo({ id: 'ssh-probe-pending', connectionId: 'builder' }),
+      repo({ id: 'settled-no-remote', gitRemoteIdentity: null })
+    ])
+
+    expect(eligible.map((candidate) => candidate.id)).toEqual([
+      'probe-pending',
+      'ssh-probe-pending'
+    ])
+  })
+
+  it('excludes folders and settled remote-less repos even while others are pending', () => {
+    const eligible = getTaskEligibleRepos([
+      repo({ id: 'folder-pending', kind: 'folder' }),
+      repo({ id: 'folder-settled', kind: 'folder', gitRemoteIdentity: null }),
+      repo({ id: 'git-pending' })
+    ])
+
+    expect(eligible.map((candidate) => candidate.id)).toEqual(['git-pending'])
+  })
+
+  it('treats a partially resolved remote identity as settled, not pending', () => {
+    const eligible = getTaskEligibleRepos([
+      repo({
+        id: 'gitlab-ssh-partial',
+        connectionId: 'builder',
+        gitRemoteIdentity: {
+          canonicalKey: 'gitlab.example.com/team/orca',
+          remoteName: 'origin',
+          remoteUrl: ''
+        }
+      }),
+      repo({
+        id: 'gitlab-ssh-complete',
+        connectionId: 'builder',
+        gitRemoteIdentity: {
+          canonicalKey: 'gitlab.example.com/team/orca',
+          remoteName: 'origin',
+          remoteUrl: 'git@gitlab.example.com:team/orca.git'
+        }
+      })
+    ])
+
+    expect(eligible.map((candidate) => candidate.id)).toEqual(['gitlab-ssh-complete'])
   })
 })
 
@@ -83,6 +131,22 @@ describe('getDefaultTaskRepoSelection', () => {
     ])
 
     expect([...selection].sort()).toEqual(['local-orca', 'other'])
+  })
+
+  it('keeps GitHub grouping intact while a pending-identity repo joins as its own project', () => {
+    const selection = getDefaultTaskRepoSelection(
+      getTaskEligibleRepos([
+        repo({ id: 'local-orca', upstream: { owner: 'StablyAI', repo: 'Orca' } }),
+        repo({
+          id: 'ssh-orca',
+          connectionId: 'builder',
+          upstream: { owner: 'stablyai', repo: 'orca' }
+        }),
+        repo({ id: 'ssh-gitlab-pending', connectionId: 'builder' })
+      ])
+    )
+
+    expect([...selection].sort()).toEqual(['local-orca', 'ssh-gitlab-pending'])
   })
 
   it('prefers local checkout over a remote checkout for the same project', () => {

--- a/src/renderer/src/components/task-page-default-repo-selection.ts
+++ b/src/renderer/src/components/task-page-default-repo-selection.ts
@@ -1,7 +1,8 @@
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import {
   getProjectIdentityKey,
-  hasProjectRemoteIdentity
+  hasProjectRemoteIdentity,
+  isProjectRemoteIdentityPending
 } from '../../../shared/project-host-setup-projection'
 import { isGitRepoKind } from '../../../shared/repo-kind'
 import type { Repo } from '../../../shared/types'
@@ -12,8 +13,15 @@ export type TaskProjectPickerGroup = {
   sources: Repo[]
 }
 
+// Why: a repo whose identity probe has not answered (offline SSH host, cold
+// launch) is unknown, not ineligible — hiding it made non-GitHub repos vanish
+// with no explanation. Only a settled "no usable remote" is filtered out.
 export function getTaskEligibleRepos(repos: readonly Repo[]): Repo[] {
-  return repos.filter((repo) => isGitRepoKind(repo) && hasProjectRemoteIdentity(repo))
+  return repos.filter(
+    (repo) =>
+      isGitRepoKind(repo) &&
+      (hasProjectRemoteIdentity(repo) || isProjectRemoteIdentityPending(repo))
+  )
 }
 
 export function getDefaultTaskRepoSelection(repos: readonly Repo[]): Set<string> {

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -3,7 +3,8 @@ import {
   projectHostSetupProjectionFromRepos,
   getProjectHostSetupsForProject,
   getProjectHostSetupWorktreeMeta,
-  isGitHubBackedRepo
+  isGitHubBackedRepo,
+  isProjectRemoteIdentityPending
 } from './project-host-setup-projection'
 import type { Repo } from './types'
 
@@ -506,5 +507,38 @@ describe('isGitHubBackedRepo', () => {
 
   it('is false for a plain local repo with no provider signal', () => {
     expect(isGitHubBackedRepo(repo({ id: 'r', path: '/r', displayName: 'r' }))).toBe(false)
+  })
+})
+
+describe('isProjectRemoteIdentityPending', () => {
+  const base = { id: 'r', path: '/r', displayName: 'r' } as const
+
+  it('is true while the background remote probe has not answered', () => {
+    expect(isProjectRemoteIdentityPending(repo({ ...base }))).toBe(true)
+    expect(isProjectRemoteIdentityPending(repo({ ...base, connectionId: 'builder' }))).toBe(true)
+  })
+
+  it('is false once the probe settles on no usable remote', () => {
+    expect(isProjectRemoteIdentityPending(repo({ ...base, gitRemoteIdentity: null }))).toBe(false)
+  })
+
+  it('is false once any provider-neutral identity resolves', () => {
+    expect(
+      isProjectRemoteIdentityPending(
+        repo({
+          ...base,
+          gitRemoteIdentity: {
+            canonicalKey: 'gitlab.example.com/team/orca',
+            remoteName: 'origin',
+            remoteUrl: 'git@gitlab.example.com:team/orca.git'
+          }
+        })
+      )
+    ).toBe(false)
+    expect(
+      isProjectRemoteIdentityPending(
+        repo({ ...base, upstream: { owner: 'stablyai', repo: 'orca' } })
+      )
+    ).toBe(false)
   })
 })

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -86,6 +86,16 @@ export function hasProjectRemoteIdentity(
   return getProjectProviderIdentity(repo) !== null || getProjectGitRemoteIdentity(repo) !== null
 }
 
+/** True while nothing has settled the repo's remote identity yet: the background
+ *  probe has not answered (or could not reach the host), as distinct from the
+ *  resolved `null` marker meaning "checked, no usable remote". Provider-neutral —
+ *  GitHub repos usually settle through persisted `upstream` instead. */
+export function isProjectRemoteIdentityPending(
+  repo: Pick<Repo, 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
+): boolean {
+  return repo.gitRemoteIdentity === undefined && !hasProjectRemoteIdentity(repo)
+}
+
 export function getProjectIdentityKey(
   repo: Pick<Repo, 'id' | 'upstream' | 'repoIcon' | 'gitRemoteIdentity'>
 ): string {


### PR DESCRIPTION
## The bug

`getTaskEligibleRepos` filtered on `isGitRepoKind(repo) && hasProjectRemoteIdentity(repo)`. That identity comes from a background `git remote -v` probe (`detectGitRemoteIdentity`, driven by `repo-git-remote-identity-enrichment.ts`), and a `null` result negative-caches for `NO_IDENTITY_RETRY_TTL_MS` (5 min).

Launch the app before an SSH connection is up, and an SSH-hosted GitLab repo **silently disappears from the Tasks picker** — with no explanation, and it stays hidden for a full 5 minutes *after* the connection recovers.

This lands on non-GitHub providers specifically: GitHub repos are largely shielded because a persisted `upstream` satisfies the identity projection through a different route. GitLab and everything else depend on the probe.

It also violates the standing rule against visibility-gating on pending state — a repo whose identity is merely **unknown** was rendered indistinguishable from one that is genuinely ineligible.

## The fix

Make "unknown" distinguishable from "settled", rather than hiding both:

| layer | change |
| --- | --- |
| `repo-git-remote-identity.ts` | `probeGitRemoteIdentity` returns `resolved` / `no-remote` (git answered, no usable remote) / `unavailable` (never reached git: SSH provider absent, git threw). `detectGitRemoteIdentity` stays as a thin wrapper for `repo-icon-autodetect`. |
| `repo-git-remote-identity-enrichment.ts` | Persist `gitRemoteIdentity: null` **only** on `no-remote`. `unavailable` leaves the identity undefined, so an unreachable host never marks a repo ineligible. Redundant no-remote rewrites are skipped so repo-list consumers do not churn. |
| `persistence.ts` | `sanitizeGitRemoteIdentity` preserves an explicit `null`, mirroring the existing `upstream: null` "not a fork" marker in the same function. Without this the marker is dropped on save/hydrate and nothing is ever settled. |
| `project-host-setup-projection.ts` | New provider-neutral `isProjectRemoteIdentityPending` — true only while `gitRemoteIdentity === undefined` and no other identity resolved. |
| `task-page-default-repo-selection.ts` | Eligible = git kind **and** (identity resolved **or** identity pending). |

Deliberately **not** "show every repo": folders and repos settled as `no-remote` stay filtered out. The negative-cache TTL is untouched — it now only delays *identity resolution*, not *visibility*.

Note on rollout: existing persisted repos with no remote currently have `gitRemoteIdentity` absent, so they reappear in the picker until the next enrichment pass writes the `null` marker. That is the safe direction (visible while unknown) and self-corrects within one pass.

## Follow-up (not in this PR — flagged, not dropped)

The 5-minute negative cache is **not** invalidated when an SSH connection recovers. With this fix that is no longer a visibility bug, but an SSH repo that comes online still waits out a timer it earned while offline before its identity (and therefore its cross-host project grouping) resolves. Wiring cache invalidation to connection-recovery events is a separate concern and a separate change.

## Verification

`npx vitest run --config config/vitest.config.ts` — 7 affected files, 476 tests, all pass; plus `repo-icon-autodetect`, `task-page-empty-state`, `task-page-cache-selectors` (30 tests). `npm run typecheck` and `npm run lint` both clean.

Every new test was revert-checked — source change backed out, test confirmed failing:

- **Revert the renderer gate** → 3 fail: `expected [] to deeply equal [ Array(2) ]` (pending repos vanish), `expected [] to deeply equal [ 'git-pending' ]`, `expected [ 'local-orca' ] to deeply equal [ 'local-orca', 'ssh-gitlab-pending' ]`.
- **Revert the persistence sanitizer** → `expected { …(3) } to be null` — the `null` marker is dropped and the stale identity survives the reload.
- **Revert the enrichment settle-write** → `expected "vi.fn()" to be called with arguments: [ 'repo-1', …(1) ]`.
- **Adversarial variant** (settle on *any* failed probe — the naive fix) → `leaves identity unresolved when the probe could not reach the host` fails with `expected "vi.fn()" to not be called at all, but actually been called 1 times`. This is the test that pins the SSH case.

The partial-identity test passes before and after — it is a guard against regressing the existing incomplete-identity exclusion, not a fix test.

**Not runtime-verified:** the real SSH-hosted-GitLab-with-connection-down scenario was not reproduced on hardware — this was validated on macOS through unit tests over the probe/enrichment/persistence/renderer seam, not against a live SSH host with a real GitLab remote. The `unavailable` path is covered by mocking `getSshGitProvider` to return `undefined` (provider not yet connected) and by a rejecting git exec.

---

## Screenshots

No visual change. This PR changes which repos pass an eligibility filter; it adds no new UI, no layout, no tokens, and no copy. The user-visible effect is that a repo that used to be *absent* from the existing Tasks project picker is now *present* in it, rendered by the unchanged existing picker component.

## Testing

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` (affected + adjacent: `repo-git-remote-identity`, `repo-git-remote-identity-enrichment`, `persistence`, `project-host-setup-projection`, `task-page-default-repo-selection`, `repo-icon-autodetect`) — 475 tests, all pass
- [x] `npm run build` — covered by the `verify` and `crash-survival (packaged build)` CI jobs, both green
- [x] Added tests that would catch regressions, each revert-checked (see **Verification** above and **AI Review Report** below)

## AI Review Report

Four independent AI reviewers were run over this branch in parallel (correctness/regressions, scope adversary, persistence compatibility, perf/platform/SSH), each reporting separately. **None found a blocker.** Scope of what they checked and what they found:

**Fixes the stated issue.** `getTaskEligibleRepos` (`task-page-default-repo-selection.ts:19`) is the only eligibility gate; its single caller is `TaskPage.tsx:3144`, memoized on `repos`. A pending repo now reaches the picker and, once selected, flows through the same unchanged `getTaskProjectPickerGroups` / `normalizeTaskRepoSelection` path as any other repo — its `getProjectIdentityKey` falls back to `repo:${id}`, so it forms its own project group until the probe settles and it regroups. No downstream consumer was found that special-cases identity presence.

**No regression from the new explicit `null`.** Every read site of `repo.gitRemoteIdentity` in `src/` and `mobile/` uses optional chaining or a truthiness check, so `null` behaves exactly as `undefined` did (`SourceControl.tsx:1500-1542`, `project-host-setup-projection.ts:58-71`, `repo-icon-autodetect.ts:322-327`, `mobile/src/tasks/smart-source-paste-intent.ts:63-72`, `mobile/src/components/NewWorktreeModal.tsx:75`). The only `=== undefined` comparison is the new `isProjectRemoteIdentityPending` itself. `Repo['gitRemoteIdentity']` was already declared `GitRemoteIdentity | null` at `types.ts:268` before this PR, and there is no zod/JSON-schema validator on the field.

**Forward/backward compatibility of the persisted marker.** An older build reading `gitRemoteIdentity: null` hits `if (!value || typeof value !== 'object') return undefined` in its own `sanitizeGitRemoteIdentity` — the key is dropped during hydrate, no crash, and the repo is treated as it always was. Downgrade therefore loses the marker rather than corrupting anything, and the next enrichment pass on a new build re-settles it. This build reading an older profile with the key absent treats it as pending, i.e. visible — the safe direction. The sanitizer change is a 4-line early return that mirrors the pre-existing `sanitizeRepoUpstream` null precedent at `persistence.ts:1306-1308`; the surrounding `sanitizeRepoUpdatesForPersistence` branch (`persistence.ts:1391-1398`) and the `hydrateRepo` spread (`persistence.ts:4631`) already keyed on `=== undefined`, so no other null began surviving.

**No perf regression; the redundant-write guard is load-bearing.** `enrichMissingRepoGitRemoteIdentities` runs on the `repos:list` / `projects:list` / `projectHostSetups:list` IPC handlers (`ipc/repos.ts:1144,1155,1171`), which are hot. `isSameUnenrichedRepo` tests `!current.gitRemoteIdentity`, which is falsy for `null` too, so a settled repo remains a probe candidate. Without the `gitRemoteIdentity === null && current?.gitRemoteIdentity === null` guard in `writeIdentity`, every remote-less repo would re-settle after each TTL expiry, return a non-null repo from `updateRepo`, fire `onChanged` → `notifyReposChanged` → renderer re-list → re-enrich, forever — a periodic disk write and full repo-list churn per repo. The guard is required, not an optimization. The renderer side adds one `isProjectRemoteIdentityPending` call per repo inside an already-`useMemo`'d filter.

**False-`no-remote` risk (the one that would be worse than the bug).** Settling `null` on a host that is merely unreachable would hide the repo *permanently*. Traced to a definitive answer: on the SSH path, `SshGitProvider.exec` (`providers/ssh-git-provider.ts:826`) forwards to relay `git.exec`, which runs `execFileAsync('git', …)` (`relay/git-handler.ts:1195` → `:315,342`); `execFileAsync` rejects on non-zero exit, and a dropped connection rejects at the multiplexer. Neither can resolve with empty stdout. `stdout === ''` with a zero exit means the repo genuinely has no remotes. A provider that is not yet registered returns `undefined` from `getSshGitProvider` and is mapped to `unavailable`, not `no-remote`.

**Cross-platform.** No platform-conditional code paths, no path-separator or key-modifier assumptions are added or changed. `git remote -v` predates the Git 2.25 baseline. `getRepoLocationKey` is unchanged by this PR.

**Provider neutrality.** `isProjectRemoteIdentityPending` is provider-neutral by construction — it delegates to `hasProjectRemoteIdentity`, which accepts either a provider identity or a generic git remote identity. GitHub repos usually settle earlier via the persisted `upstream`, which is why they were already shielded from this bug; that asymmetry is the pre-existing cause, not something introduced here. No GitHub-specific naming was used for a generic concept.

**Folder workspaces.** `isGitRepoKind` is evaluated first and short-circuits, so no `kind: 'folder'` workspace can enter through the new pending branch (pinned by the `excludes folders and settled remote-less repos even while others are pending` test). Enrichment's candidate filter already excludes folders.

**Scope.** The renderer-only alternative was challenged directly and does not work: `hasProjectRemoteIdentity` receives only the repo, and before this change "probe pending" and "no remote" were the *same* value, so no renderer-side predicate can separate them. Dropping the gate entirely fixes the symptom but permanently pollutes the picker with remote-less local repos, each as its own project group. An in-memory-only settled set would touch the same number of layers, add a second parallel channel, and re-flicker on every cold launch. Each of the five source files carries a change that is necessary and minimal (9, 34, 28, 12 and 10 changed lines); `detectGitRemoteIdentity` was kept as a 6-line wrapper specifically so `repo-icon-autodetect` did not have to change. No `max-lines` disable is added anywhere in the diff.

**What was NOT verified.** Everything above is static analysis plus unit tests on macOS. The real scenario — an SSH-hosted GitLab repo with the connection down at launch — was not reproduced on hardware. The `unavailable` path is exercised by mocking an absent provider and by rejecting `exec` on both a connected provider and the local runner.

## Security Audit

No new attack surface. The change introduces no new command execution, no new user-controlled input, and no new IPC method — `git remote -v` was already being run with a fixed argv array on the same paths and hosts, at the same frequency, through the same `execFile`/relay dispatch. Argument handling is unchanged, so no shell interpolation or argv-injection vector is added. The one behavioral delta is that a probe error is now classified as `unavailable` instead of being swallowed as `null`, which is strictly *more* conservative: it declines to record a state it could not confirm. The persisted field gains one new value (`null`) that is already type-declared and is sanitized on both the write and hydrate paths, so a hostile or corrupted profile cannot smuggle an unexpected shape through — malformed objects still normalize to "absent". No secrets, auth, or credential handling is touched.

## Notes

- **Rollout is self-correcting.** Existing persisted repos with no remote currently have `gitRemoteIdentity` absent, so they reappear in the picker until the next enrichment pass writes the `null` marker. That is the safe direction (visible while unknown) and resolves within one pass.
- **A repo whose local path has been deleted** now probes as `unavailable` rather than settling, so it stays visible in the picker instead of silently disappearing. This is a deliberate consequence of the same "unknown is not ineligible" rule and is the safer of the two behaviors, but it is a behavior change worth knowing about.
- **New transient at cold launch:** two checkouts of the *same* project (e.g. a local and an SSH clone of one GitLab repo) that are both still pending get distinct `repo:<id>` group keys, so the picker briefly shows two rows for one project and auto-selects both, then collapses to one group when the probes land. This is inherent to "show it while unknown" — a location-derived key would not merge them either, since the two checkouts have different paths, and excluding pending repos from the default selection would partly undo the fix (the repo would reappear but the user's tasks still would not). Accepted, and encoded in `keeps GitHub grouping intact while a pending-identity repo joins as its own project`.
- **Pre-existing issues found nearby but deliberately left out of scope** (all present on `main`, none made worse here): `probeGitRemoteIdentity` branches on `connectionId` alone, so a `runtime:<envId>` repo takes the local git branch and could resolve the wrong host's repo if the path happens to exist locally; the local probe passes no `timeout`, so a git wedged on a stale network mount never clears `inFlightProbesByLocation` and stalls the serial sweep; `areReposEqual` compares object-valued fields by reference against freshly-constructed hydrate output, so it never reports equal. Worth separate changes, not this one.
- **Deliberately not changed:** the repo-creation path (`repo-icon-autodetect.ts`) still does not persist the marker the way its sibling `upstream: null` does. Making it do so naively would be a *reintroduction* of this bug — that call site uses the collapsing `detectGitRemoteIdentity` wrapper, so a repo added while its SSH host is down would be permanently stamped no-remote. It would have to move to `probeGitRemoteIdentity` and write only on `no-remote`.
- **Deferred follow-up (unchanged from above):** the 5-minute negative cache is not invalidated on SSH connection recovery. This is safe to defer precisely because the visibility symptom is now fixed independently of it — a recovering repo is already in the picker and usable; only its cross-host project *grouping* waits out the remaining TTL. It is a resolution-latency issue, not a visibility one.

