### PR TITLE
perf(worktree): park the git-common existence poll while the window is hidden

### DIFF
--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { appendFile, mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
 import { chmodSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -19,6 +20,20 @@ vi.mock('./parcel-watcher-process', () => ({
   subscribeViaWatcherProcess: vi.fn()
 }))
 
+// Records every stat target so a test can assert which paths a parked poll stopped touching.
+const { statCalls } = vi.hoisted(() => ({ statCalls: [] as string[] }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    stat: (...args: Parameters<typeof actual.stat>) => {
+      statCalls.push(String(args[0]))
+      return actual.stat(...args)
+    }
+  }
+})
+
 const POLL_MS = 25
 
 const alwaysVisible: WorktreePollerWindowVisibility = {
@@ -30,18 +45,18 @@ function createVisibilityHarness(): {
   source: WorktreePollerWindowVisibility
   hide: () => void
   show: () => void
+  listenerCount: () => number
 } {
   let visible = true
-  let listener: (() => void) | null = null
+  // A set, not a single slot: the darwin path parks two independent watches.
+  const listeners = new Set<() => void>()
   return {
     source: {
       isWindowVisible: () => visible,
       onWindowBecameVisible: (nextListener) => {
-        listener = nextListener
+        listeners.add(nextListener)
         return () => {
-          if (listener === nextListener) {
-            listener = null
-          }
+          listeners.delete(nextListener)
         }
       }
     },
@@ -50,8 +65,11 @@ function createVisibilityHarness(): {
     },
     show: () => {
       visible = true
-      listener?.()
-    }
+      for (const listener of listeners) {
+        listener()
+      }
+    },
+    listenerCount: () => listeners.size
   }
 }
 
@@ -70,6 +88,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
   afterEach(async () => {
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
     childSubscriptions = []
+    statCalls.length = 0
     subscribeMock.mockReset()
   })
 
@@ -204,6 +223,110 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await vi.waitFor(() => {
       expect(subscribeMock).toHaveBeenCalledTimes(1)
     })
+  })
+
+  async function startHiddenExistencePoll(visibility: {
+    source: WorktreePollerWindowVisibility
+    hide: () => void
+  }): Promise<{ commonDir: string; worktreesDir: string; received: WorktreeBasePollEvent[][] }> {
+    const commonDir = await makeCommonDir(false)
+    const received: WorktreeBasePollEvent[][] = []
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin',
+      visibility.source
+    )
+    cleanups.push(() => watch.unsubscribe())
+    visibility.hide()
+    // Let the armed poll observe the hidden window and park itself.
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
+    statCalls.length = 0
+    return { commonDir, worktreesDir: join(commonDir, 'worktrees'), received }
+  }
+
+  it('parks the existence poll while the window is hidden', async () => {
+    installSubscribeMock()
+    const visibility = createVisibilityHarness()
+    const { worktreesDir, received } = await startHiddenExistencePoll(visibility)
+
+    await mkdir(worktreesDir)
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
+
+    expect(statCalls.filter((path) => path === worktreesDir)).toHaveLength(0)
+    expect(subscribeMock).not.toHaveBeenCalled()
+    expect(received.flat()).toHaveLength(0)
+  })
+
+  it('re-checks on show and still reports a worktrees dir created while hidden', async () => {
+    installSubscribeMock()
+    const visibility = createVisibilityHarness()
+    const { worktreesDir, received } = await startHiddenExistencePoll(visibility)
+
+    await mkdir(worktreesDir)
+    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
+    expect(subscribeMock).not.toHaveBeenCalled()
+
+    visibility.show()
+    // Promptly: the re-check stats on show, not a poll interval later.
+    expect(statCalls.filter((path) => path === worktreesDir)).toHaveLength(1)
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(1)
+    })
+    expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
+  })
+
+  it('resumes polling when the dir is still absent on show', async () => {
+    installSubscribeMock()
+    const visibility = createVisibilityHarness()
+    const { worktreesDir } = await startHiddenExistencePoll(visibility)
+
+    visibility.show()
+    await mkdir(worktreesDir)
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('keeps polling and reporting while the window stays visible', async () => {
+    installSubscribeMock()
+    const visibility = createVisibilityHarness()
+    const commonDir = await makeCommonDir(false)
+    const worktreesDir = join(commonDir, 'worktrees')
+    const received: WorktreeBasePollEvent[][] = []
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      (events) => received.push(events),
+      POLL_MS,
+      'darwin',
+      visibility.source
+    )
+    cleanups.push(() => watch.unsubscribe())
+
+    await mkdir(worktreesDir)
+    await vi.waitFor(() => {
+      expect(subscribeMock).toHaveBeenCalledTimes(1)
+    })
+    expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
+  })
+
+  it('drops both visibility subscriptions on dispose', async () => {
+    installSubscribeMock()
+    const visibility = createVisibilityHarness()
+    const commonDir = await makeCommonDir(false)
+    const watch = await startGitCommonWatch(
+      makeTarget(commonDir),
+      () => {},
+      POLL_MS,
+      'darwin',
+      visibility.source
+    )
+
+    // Narrow watch + primary-metadata poll each park on window visibility.
+    expect(visibility.listenerCount()).toBe(2)
+    await watch.unsubscribe()
+    expect(visibility.listenerCount()).toBe(0)
   })
 
   it('keeps the native stream live while the primary poll is parked', async () => {

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -149,13 +149,15 @@ async function startSnapshotDiffPoller(
 async function startGitCommonNarrowWatch(
   target: WorktreeBaseWatchTarget,
   onEvents: (events: WorktreeBasePollEvent[]) => void,
-  pollIntervalMs: number
+  pollIntervalMs: number,
+  visibility: WorktreePollerWindowVisibility
 ): Promise<WorktreeBaseSubscription> {
   const worktreesDir = join(target.path, 'worktrees')
   let disposed = false
   let subscription: WorktreeBaseSubscription | null = null
   let existenceTimer: ReturnType<typeof setInterval> | null = null
   let subscribing = false
+  let parkedWhileHidden = false
 
   const stopExistencePoll = (): void => {
     if (existenceTimer) {
@@ -164,30 +166,59 @@ async function startGitCommonNarrowWatch(
     }
   }
 
+  const tryUpgradeToNarrowWatch = async (): Promise<void> => {
+    if (disposed || subscribing || subscription) {
+      return
+    }
+    subscribing = true
+    try {
+      const installed = await trySubscribe()
+      if (installed && !disposed) {
+        stopExistencePoll()
+        // The dir appearing means a first linked worktree was just
+        // registered; surface it so the repo's worktree list refreshes.
+        onEvents([{ type: 'create', path: worktreesDir }])
+      }
+    } finally {
+      subscribing = false
+    }
+  }
+
   const armExistencePoll = (): void => {
-    if (disposed || existenceTimer) {
+    if (disposed || existenceTimer || subscription) {
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      parkedWhileHidden = true
       return
     }
     existenceTimer = setInterval(() => {
-      if (disposed || subscribing || subscription) {
+      if (disposed) {
         return
       }
-      subscribing = true
-      void trySubscribe()
-        .then((installed) => {
-          if (installed && !disposed) {
-            stopExistencePoll()
-            // The dir appearing means a first linked worktree was just
-            // registered; surface it so the repo's worktree list refreshes.
-            onEvents([{ type: 'create', path: worktreesDir }])
-          }
-        })
-        .finally(() => {
-          subscribing = false
-        })
+      // Why: a hidden window has nothing to refresh, so stop stat'ing the dir
+      // entirely instead of burning a syscall per repo per tick in the background.
+      if (!visibility.isWindowVisible()) {
+        parkedWhileHidden = true
+        stopExistencePoll()
+        return
+      }
+      void tryUpgradeToNarrowWatch()
     }, pollIntervalMs)
     existenceTimer.unref?.()
   }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (disposed || !parkedWhileHidden) {
+      return
+    }
+    parkedWhileHidden = false
+    // Why: the first linked worktree may have been registered while hidden — check
+    // now (emitting the create) rather than losing it for a full interval.
+    void tryUpgradeToNarrowWatch().finally(() => {
+      armExistencePoll()
+    })
+  })
 
   const trySubscribe = async (): Promise<boolean> => {
     try {
@@ -269,6 +300,7 @@ async function startGitCommonNarrowWatch(
     unsubscribe: async () => {
       disposed = true
       stopExistencePoll()
+      unsubscribeVisibility()
       const current = subscription
       subscription = null
       if (current) {
@@ -288,7 +320,7 @@ export async function startGitCommonWatch(
 ): Promise<WorktreeBaseSubscription> {
   if (platform === 'darwin') {
     const [narrowWatch, primaryMetadataPoll] = await Promise.all([
-      startGitCommonNarrowWatch(target, onEvents, pollIntervalMs),
+      startGitCommonNarrowWatch(target, onEvents, pollIntervalMs, visibility),
       startSnapshotDiffPoller(
         () => snapshotPrimaryCheckoutMetadata(target.path),
         onEvents,


### PR DESCRIPTION
## Problem

`startGitCommonNarrowWatch` (`src/main/ipc/worktree-git-common-watch.ts`) is the only watch entry point that never received the `WorktreePollerWindowVisibility` object. Every sibling takes one:

- `startSnapshotDiffPoller` parks on `isWindowVisible()` and re-arms via `onWindowBecameVisible`
- `startGitCommonPolling` (the non-darwin branch) is handed `visibility` and gates the same way

At the call site the two darwin watches start side by side — the primary-metadata poller got `visibility`, the narrow watch did not.

Inside, `armExistencePoll` ran a bare `setInterval` (2s default) that stats `<common>/.git/worktrees` every tick to detect the first linked worktree appearing. Nothing parked it when the window was hidden, so a repo with no linked worktree kept paying ~0.5 stat/sec forever with the app in the background — 0.5×N across N such repos.

**Scope: macOS only.** The narrow watch is the `platform === 'darwin'` branch of `startGitCommonWatch`; every other platform already goes through `startGitCommonPolling`, which is gated.

## Fix

Thread `WorktreePollerWindowVisibility` into `startGitCommonNarrowWatch` and match `startSnapshotDiffPoller`'s existing park/re-arm pattern rather than inventing a second mechanism:

- the poll skips its work and `clearInterval`s itself on the first tick that observes a hidden window (and never arms at all if the window is already hidden)
- `onWindowBecameVisible` re-checks immediately instead of waiting a full interval, then resumes the interval if the dir still isn't there
- the create-event notification is preserved: a `worktrees/` dir that appeared while hidden still upgrades to the native stream **and** emits `{type:'create'}` on show, so the repo's worktree list refreshes
- the visibility listener is unsubscribed in the dispose path (no leak)

The existing subscribe-attempt body is extracted to `tryUpgradeToNarrowWatch` so the interval and the became-visible re-check share one path. No other restructuring.

## Tests

`src/main/ipc/worktree-git-common-watch.test.ts`. The visibility harness now holds a set of listeners rather than one slot — the darwin path parks two independent watches, and a single slot silently dropped the narrow watch's registration. `node:fs/promises#stat` is wrapped with a delegating recorder so a test can assert on stat targets directly rather than on a proxy signal.

New cases:
- `parks the existence poll while the window is hidden` — creates `worktrees/` while hidden, asserts **zero** stats of that path, no subscribe, no events
- `re-checks on show and still reports a worktrees dir created while hidden` — asserts nothing happened while hidden, then that `show()` stats synchronously (promptly, not an interval later), subscribes, and emits the `create`
- `drops both visibility subscriptions on dispose` — listener count 2 → 0
- `resumes polling when the dir is still absent on show` and `keeps polling and reporting while the window stays visible` — visible-path behavior unchanged (these are controls; they pass with and without the fix)

### Revert check

Source change reverted, tests kept — 3 of the 5 new tests fail, and the 2 control tests pass as intended:

```
× parks the existence poll while the window is hidden
    AssertionError: expected [ Array(1) ] to have a length of +0 but got 1
    at worktree-git-common-watch.test.ts:257  (statCalls.filter(path => path === worktreesDir))
× re-checks on show and still reports a worktrees dir created while hidden
    AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
× drops both visibility subscriptions on dispose
    AssertionError: expected 1 to be 2

Tests  3 failed | 16 passed (19)
```

With the fix: `Tests 19 passed (19)`.

`pnpm run typecheck` and `pnpm run lint` both exit 0.