### PR TITLE
fix(runtime): reserve long-poll headroom so orchestration.ask can't starve terminal.wait

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- Why: orchestration tests share a mock runtime factory; splitting by method would duplicate 40 lines of setup per file without improving clarity. */
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { ORCHESTRATION_METHODS } from './orchestration'
+import { ORCHESTRATION_METHODS, clampAskTimeoutMs } from './orchestration'
 import { RpcDispatcher } from '../dispatcher'
 import { buildRegistry, type RpcContext, type RpcRequest } from '../core'
 import { OrchestrationDb } from '../../orchestration/db'
@@ -1790,6 +1790,46 @@ describe('orchestration RPC methods', () => {
 
       expect(result.timedOut).toBe(false)
       expect(result.answer).toBe('correct answer')
+    })
+
+    it('clamps an absurd caller-supplied timeoutMs so the long-poll slot is bounded', async () => {
+      setup()
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+      vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+      let observedTimeoutMs: number | undefined
+      vi.spyOn(runtime, 'waitForMessage').mockImplementation(async (_handle, options) => {
+        observedTimeoutMs = options?.timeoutMs
+        // End the wait loop so the assertion runs against the first budget slice.
+        const outbound = db.getInbox(10).find((m) => m.type === 'decision_gate')
+        if (outbound) {
+          db.insertMessage({
+            from: 'term_coord',
+            to: 'term_worker',
+            subject: 'Re: Question',
+            body: 'ok',
+            threadId: outbound.id
+          })
+        }
+      })
+
+      await call('orchestration.ask', {
+        from: 'term_worker',
+        to: 'term_coord',
+        question: 'forever?',
+        timeoutMs: Number.MAX_SAFE_INTEGER
+      })
+
+      expect(observedTimeoutMs).toBeLessThanOrEqual(1_800_000)
+      expect(observedTimeoutMs).toBeGreaterThan(1_700_000)
+    })
+
+    it('clamps timeoutMs at the exported boundary', () => {
+      expect(clampAskTimeoutMs(undefined)).toBe(600_000)
+      expect(clampAskTimeoutMs(1_000)).toBe(1_000)
+      expect(clampAskTimeoutMs(1_800_000)).toBe(1_800_000)
+      expect(clampAskTimeoutMs(86_400_000)).toBe(1_800_000)
+      expect(clampAskTimeoutMs(Number.MAX_SAFE_INTEGER)).toBe(1_800_000)
+      expect(clampAskTimeoutMs(-5)).toBe(0)
     })
 
     it('parses options CSV with whitespace and empty entries', async () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -30,6 +30,19 @@ const TASK_STATUSES: TaskStatus[] = [
   'blocked'
 ]
 
+const ASK_DEFAULT_TIMEOUT_MS = 600_000
+
+// Why: ask pins a shared long-poll slot for its entire timeout, so a caller-supplied
+// value can't be unbounded; 30 min covers a slow human gate and still frees the slot.
+const ASK_MAX_TIMEOUT_MS = 1_800_000
+
+export function clampAskTimeoutMs(timeoutMs: number | undefined): number {
+  if (timeoutMs === undefined) {
+    return ASK_DEFAULT_TIMEOUT_MS
+  }
+  return Math.min(Math.max(0, timeoutMs), ASK_MAX_TIMEOUT_MS)
+}
+
 function getLifecycleGroupRecipientError(type: 'worker_done' | 'heartbeat'): string {
   return `${type} messages must be sent to a concrete coordinator terminal handle, not a group address.`
 }
@@ -567,7 +580,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
 
       const db = runtime.getOrchestrationDb()
       const from = params.from ?? 'unknown'
-      const timeoutMs = params.timeoutMs ?? 600_000
+      const timeoutMs = clampAskTimeoutMs(params.timeoutMs)
       const options =
         params.options
           ?.split(',')

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -4289,6 +4289,166 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+    it('reserves long-poll headroom for terminal.wait when orchestration.ask floods', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      const db = new OrchestrationDb(':memory:')
+      runtime.setOrchestrationDb(db)
+      // Why: cap 4 → ask sub-cap 2, so 4 concurrent asks can only take half the budget.
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        keepaliveIntervalMs: 1000,
+        longPollCap: 4
+      })
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, {
+        tabs: [
+          {
+            tabId: 'tab-1',
+            worktreeId: 'repo-1::/tmp/worktree-a',
+            title: 'Terminal 1',
+            activeLeafId: 'pane:1',
+            layout: null
+          }
+        ],
+        leaves: [
+          {
+            tabId: 'tab-1',
+            worktreeId: 'repo-1::/tmp/worktree-a',
+            leafId: 'pane:1',
+            paneRuntimeId: 1,
+            ptyId: 'pty-1'
+          }
+        ]
+      })
+      await server.start()
+
+      const asks: ReturnType<typeof openFramedSession>[] = []
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        const endpoint = metadata!.transports[0]!.endpoint
+        const listResponse = await sendRequest(endpoint, {
+          id: 'req_list',
+          authToken: metadata!.authToken,
+          method: 'terminal.list'
+        })
+        const handle = (listResponse.result as { terminals: { handle: string }[] }).terminals[0]!
+          .handle
+
+        // Four workers block in ask; distinct `from` handles so no reply wakes another.
+        for (let i = 0; i < 4; i++) {
+          asks.push(
+            openFramedSession(endpoint, {
+              id: `req_ask_${i}`,
+              authToken: metadata!.authToken,
+              method: 'orchestration.ask',
+              params: {
+                from: `term_w${i}`,
+                to: 'term_coord',
+                question: 'proceed?',
+                timeoutMs: 10_000
+              }
+            })
+          )
+        }
+        // Let every ask reach the admission fence before probing the reserved half.
+        await waitFor(() => server['activeLongPolls'] >= 2)
+        await sleep(100)
+
+        // The reserved half still admits a terminal.wait from any other client.
+        const admitted = openFramedSession(endpoint, {
+          id: 'req_terminal_wait',
+          authToken: metadata!.authToken,
+          method: 'terminal.wait',
+          params: { terminal: handle, for: 'tui-idle', timeoutMs: 50 }
+        })
+        await admitted.done
+        expect(admitted.frames.find((f) => f.ok !== undefined)).toMatchObject({
+          id: 'req_terminal_wait',
+          ok: false,
+          error: { code: 'timeout' }
+        })
+
+        // …and a check --wait too, which shares the same reserved class.
+        const check = openFramedSession(endpoint, {
+          id: 'req_check_wait',
+          authToken: metadata!.authToken,
+          method: 'orchestration.check',
+          params: { terminal: 'term_other', wait: true, timeoutMs: 100 }
+        })
+        await check.done
+        expect(check.frames.find((f) => f.ok !== undefined)).toMatchObject({
+          id: 'req_check_wait',
+          ok: true
+        })
+
+        // Overflow asks are shed, not queued: the sub-cap holds at half the budget.
+        expect(server['activeAskLongPolls']).toBe(2)
+        const shed = asks
+          .map((a) => a.frames.find((f) => f.ok !== undefined))
+          .filter((f) => f !== undefined)
+        expect(shed).toHaveLength(2)
+        expect(shed[0]).toMatchObject({ ok: false, error: { code: 'runtime_busy' } })
+      } finally {
+        for (const ask of asks) {
+          ask.socket.destroy()
+        }
+        await Promise.all(asks.map((ask) => ask.done))
+        db.close()
+        await server.stop()
+      }
+    })
+
+    it('keeps the full cap available to terminal.wait and check --wait', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      const db = new OrchestrationDb(':memory:')
+      runtime.setOrchestrationDb(db)
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        keepaliveIntervalMs: 1000,
+        longPollCap: 4
+      })
+      await server.start()
+
+      const waits: ReturnType<typeof openFramedSession>[] = []
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        const endpoint = metadata!.transports[0]!.endpoint
+
+        // The ask sub-cap must not narrow the budget for the reserved class.
+        for (let i = 0; i < 4; i++) {
+          waits.push(
+            openFramedSession(endpoint, {
+              id: `req_wait_${i}`,
+              authToken: metadata!.authToken,
+              method: 'orchestration.check',
+              params: { terminal: `term_${i}`, wait: true, timeoutMs: 10_000 }
+            })
+          )
+        }
+        await waitFor(() => server['activeLongPolls'] === 4)
+        expect(server['activeAskLongPolls']).toBe(0)
+
+        const overflow = await sendRequest(endpoint, {
+          id: 'req_overflow',
+          authToken: metadata!.authToken,
+          method: 'orchestration.check',
+          params: { terminal: 'term_overflow', wait: true, timeoutMs: 5_000 }
+        })
+        expect(overflow).toMatchObject({ ok: false, error: { code: 'runtime_busy' } })
+      } finally {
+        for (const wait of waits) {
+          wait.socket.destroy()
+        }
+        await Promise.all(waits.map((wait) => wait.done))
+        db.close()
+        await server.stop()
+      }
+    })
+
     it('does not emit keepalive frames for short RPCs', async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
       const runtime = new OrcaRuntimeService()

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -1333,6 +1333,92 @@ describe('OrcaRuntimeRpcServer', () => {
     }
   })
 
+  it('applies the ask sub-cap on the WebSocket path and releases both counters on close', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+    const runtime = new OrcaRuntimeService()
+    const db = new OrchestrationDb(':memory:')
+    runtime.setOrchestrationDb(db)
+    // Why: cap 4 → ask sub-cap 2, so the third ask must be shed while waits keep the other half.
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: false,
+      longPollCap: 4
+    })
+    server['deviceRegistry'] = new DeviceRegistry(userDataPath)
+    // Why: 'runtime' scope, not 'mobile' — orchestration.ask is absent from the mobile allowlist.
+    const entry = server['deviceRegistry']!.addDevice('runtime-test', 'runtime')
+    const ws = new FakeWebSocket()
+    server['mobileSocketWiring'] = {
+      getConnectionId: () => 'conn-test'
+    } as unknown as NonNullable<(typeof server)['mobileSocketWiring']>
+    const replies: Record<string, unknown>[] = []
+    const push = (response: string): void => {
+      replies.push(JSON.parse(response) as Record<string, unknown>)
+    }
+    const dispatch = (id: string, method: string, params: unknown): Promise<void> =>
+      server['handleWebSocketMessage'](
+        JSON.stringify({ id, method, deviceToken: entry.token, params }),
+        push,
+        () => {},
+        undefined,
+        ws as unknown as WebSocket
+      )
+
+    try {
+      const asks = [0, 1].map((i) =>
+        dispatch(`req_ask_${i}`, 'orchestration.ask', {
+          from: `term_w${i}`,
+          to: 'term_coord',
+          question: 'proceed?',
+          timeoutMs: 10_000
+        })
+      )
+      // Why: gate on the pre-existing total so a missing sub-cap fails on the shed below, not here.
+      await waitFor(() => server['activeLongPolls'] === 2)
+
+      await dispatch('req_ask_overflow', 'orchestration.ask', {
+        from: 'term_w2',
+        to: 'term_coord',
+        question: 'proceed?',
+        timeoutMs: 10_000
+      })
+      expect(replies).toContainEqual(
+        expect.objectContaining({
+          id: 'req_ask_overflow',
+          ok: false,
+          error: expect.objectContaining({
+            code: 'runtime_busy',
+            message: 'orchestration.ask capacity reached; retry with backoff'
+          })
+        })
+      )
+      // Shedding the ask must not burn a slot from the reserved half.
+      expect(server['activeLongPolls']).toBe(2)
+      expect(server['activeAskLongPolls']).toBe(2)
+
+      const wait = dispatch('req_check_wait', 'orchestration.check', {
+        terminal: 'term_other',
+        wait: true,
+        timeoutMs: 10_000
+      })
+      await waitFor(() => server['activeLongPolls'] === 3)
+      expect(server['activeAskLongPolls']).toBe(2)
+
+      ws.readyState = 3
+      ws.emit('close')
+      await Promise.all([...asks, wait])
+
+      expect(server['activeLongPolls']).toBe(0)
+      expect(server['activeAskLongPolls']).toBe(0)
+      expect(replies).toContainEqual(expect.objectContaining({ id: 'req_ask_0', ok: true }))
+      expect(replies).toContainEqual(expect.objectContaining({ id: 'req_check_wait', ok: true }))
+    } finally {
+      db.close()
+      await server.stop()
+    }
+  })
+
   it('shares one socket close listener across concurrent WebSocket dispatches', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
     const runtime = { getRuntimeId: () => 'test-runtime' } as unknown as OrcaRuntimeService

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -115,6 +115,12 @@ const KEEPALIVE_INTERVAL_MS = 10_000
 // Why: cap long-polls at half the 32-slot connection budget so they can't starve short RPCs; overflow → runtime_busy. See §7 risk #2.
 const LONG_POLL_CAP = 16
 
+// Why: orchestration.ask blocks on a human/agent reply for minutes, an order of
+// magnitude longer than terminal.wait or check --wait, so a fleet of asking
+// workers would otherwise hold every slot and starve the mobile/web/CLI/relay
+// clients sharing this runtime. Reserve half the budget for the other classes.
+const ASK_LONG_POLL_SHARE = 0.5
+
 function createWebClientUrl(endpoint: string, pairingUrl: string): string {
   const url = new URL(endpoint)
   url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:'
@@ -394,10 +400,13 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'worktree.sleep'
 ])
 
+// Why: 'ask' is metered separately from 'wait' — same keepalive/abort wiring, its own sub-cap.
+type LongPollClass = 'ask' | 'wait'
+
 // Why: single classifier for long-poll requests (handlers that block on an external event), shared by counter/abort/keepalive. See §3.1.
-function isLongPollRequest(request: RpcRequest): boolean {
+function longPollClassOf(request: RpcRequest): LongPollClass | null {
   if (request.method === 'terminal.wait') {
-    return true
+    return 'wait'
   }
   // Why: orchestration.ask blocks unconditionally (default 600 s) holding the
   // RPC open until a reply lands or the deadline passes, so it needs the same
@@ -405,13 +414,13 @@ function isLongPollRequest(request: RpcRequest): boolean {
   // also relies on the abort signal (only wired for long-polls) to release the
   // waiter when the asking client disconnects.
   if (request.method === 'orchestration.ask') {
-    return true
+    return 'ask'
   }
   if (request.method === 'orchestration.check') {
     const params = request.params as { wait?: unknown } | undefined
-    return params?.wait === true
+    return params?.wait === true ? 'wait' : null
   }
-  return false
+  return null
 }
 
 // Why: status.get has no per-connection context in the dispatcher, so stamp the scope here at the transport boundary.
@@ -441,6 +450,7 @@ export class OrcaRuntimeRpcServer {
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
   private readonly longPollCap: number
+  private readonly askLongPollCap: number
   private readonly relayRevokeOutbox: RelayRevokeOutbox
   private deviceRegistry: DeviceRegistry | null = null
   private e2eeKeypair: E2EEKeypair | null = null
@@ -462,6 +472,8 @@ export class OrcaRuntimeRpcServer {
   >()
   // Why: separate from server.maxConnections — count only long-running dispatches, not short RPCs. See §3.1 + §7 risk #2.
   private activeLongPolls = 0
+  // Why: subset of activeLongPolls held by orchestration.ask, fenced by askLongPollCap.
+  private activeAskLongPolls = 0
 
   constructor({
     runtime,
@@ -486,6 +498,8 @@ export class OrcaRuntimeRpcServer {
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
     this.longPollCap = longPollCap
+    // Why: derived, not configurable — the reservation must hold for whatever cap a caller picks.
+    this.askLongPollCap = Math.max(1, Math.floor(longPollCap * ASK_LONG_POLL_SHARE))
     this.relayRevokeOutbox = new RelayRevokeOutbox(userDataPath)
   }
 
@@ -1020,16 +1034,12 @@ export class OrcaRuntimeRpcServer {
     const request = parsed.request
 
     // Why: long-poll admission fence; short RPCs bypass the counter. See §7 risk #2.
-    const longPoll = isLongPollRequest(request)
-    if (longPoll && this.activeLongPolls >= this.longPollCap) {
-      return this.buildError(
-        request.id,
-        'runtime_busy',
-        'long-poll capacity reached; retry with backoff'
-      )
+    const longPoll = longPollClassOf(request)
+    const rejection = this.admitLongPoll(longPoll)
+    if (rejection) {
+      return this.buildError(request.id, 'runtime_busy', rejection)
     }
     if (longPoll) {
-      this.activeLongPolls += 1
       // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
       context?.startKeepalive()
     }
@@ -1039,9 +1049,37 @@ export class OrcaRuntimeRpcServer {
         signal: longPoll ? context?.signal : undefined
       })
     } finally {
-      if (longPoll) {
-        this.activeLongPolls = Math.max(0, this.activeLongPolls - 1)
-      }
+      this.releaseLongPoll(longPoll)
+    }
+  }
+
+  // Why: one fence for both transports — the total cap protects short RPCs, the ask
+  // sub-cap protects terminal.wait / check --wait from slow reply-blocked asks.
+  // Returns the rejection message, or null once the slot is reserved.
+  private admitLongPoll(longPoll: LongPollClass | null): string | null {
+    if (!longPoll) {
+      return null
+    }
+    if (this.activeLongPolls >= this.longPollCap) {
+      return 'long-poll capacity reached; retry with backoff'
+    }
+    if (longPoll === 'ask' && this.activeAskLongPolls >= this.askLongPollCap) {
+      return 'orchestration.ask capacity reached; retry with backoff'
+    }
+    this.activeLongPolls += 1
+    if (longPoll === 'ask') {
+      this.activeAskLongPolls += 1
+    }
+    return null
+  }
+
+  private releaseLongPoll(longPoll: LongPollClass | null): void {
+    if (!longPoll) {
+      return
+    }
+    this.activeLongPolls = Math.max(0, this.activeLongPolls - 1)
+    if (longPoll === 'ask') {
+      this.activeAskLongPolls = Math.max(0, this.activeAskLongPolls - 1)
     }
   }
 
@@ -1133,24 +1171,14 @@ export class OrcaRuntimeRpcServer {
       wsTransport.setClientId(ws, token)
     }
 
-    const longPoll = isLongPollRequest(request)
-    if (longPoll && this.activeLongPolls >= this.longPollCap) {
-      reply(
-        JSON.stringify(
-          this.buildError(
-            request.id,
-            'runtime_busy',
-            'long-poll capacity reached; retry with backoff'
-          )
-        )
-      )
+    const longPoll = longPollClassOf(request)
+    const rejection = this.admitLongPoll(longPoll)
+    if (rejection) {
+      reply(JSON.stringify(this.buildError(request.id, 'runtime_busy', rejection)))
       return
     }
 
     const abortRegistration = ws ? this.registerWebSocketDispatchAbort(ws) : null
-    if (longPoll) {
-      this.activeLongPolls += 1
-    }
 
     // Why: older pairings may lack scope metadata, so stamp the authenticated scope onto status.get.
     const replyForRequest =
@@ -1198,9 +1226,7 @@ export class OrcaRuntimeRpcServer {
       })
     } finally {
       abortRegistration?.dispose()
-      if (longPoll) {
-        this.activeLongPolls = Math.max(0, this.activeLongPolls - 1)
-      }
+      this.releaseLongPoll(longPoll)
     }
   }
 


### PR DESCRIPTION
## Summary

`orchestration.ask` was added to `isLongPollRequest()` so it would get keepalive framing and the abort signal. Both are genuinely needed and **are kept unchanged here** — but joining that set also opted `ask` into the admission accounting, and that part starves other clients:

- `activeLongPolls` is a **single server-wide counter**, not per-connection.
- `LONG_POLL_CAP = 16`; overflow is shed with `runtime_busy`.
- `ask` defaults to a **600 s** timeout and blocks that whole time waiting on a reply.
- `AskParams.timeoutMs` is `OptionalFiniteNumber` with **no upper bound**.

So 16 workers sitting in blocking asks hold every long-poll slot for ten minutes each — or forever, if a caller passes a large `timeoutMs` — and `terminal.wait` / `orchestration.check --wait` get `runtime_busy` for **every** other client sharing the runtime: mobile, web, CLI, SSH, relay. Before `ask` was long-polled it consumed no slot at all, so this is fresh in shipped behavior.

**The fix, in two parts:**

**1. Class-based sub-cap.** `isLongPollRequest` becomes `longPollClassOf`, returning `'ask' | 'wait' | null`. `ask` is metered by its own counter against `askLongPollCap = floor(longPollCap / 2)` (8 in production), on top of the existing total cap. `terminal.wait` and `check --wait` keep the full 16 — the sub-cap only fences `ask`. The cap is **derived**, not a new constructor option, so the reservation holds for whatever `longPollCap` a caller picks and can't be configured away. `LONG_POLL_CAP` was deliberately not raised — that just moves the cliff.

**2. Timeout clamp.** `clampAskTimeoutMs` bounds the caller-supplied value at 30 min (3× the default) at the handler boundary. An unbounded caller-supplied timeout on a shared, capped resource is its own defect, independent of (1). The largest `timeoutMs` any caller passes to `ask` specifically is 600 000 ms, hardcoded in the injected worker preamble (`src/main/runtime/orchestration/preamble.ts:111`) — the 900 000 ms values elsewhere are `check --wait`, a different method. So the clamp keeps 3x headroom over real ask usage. The CLI derives its transport timeout from the value it *sent*, so a clamped server simply answers `timedOut` first — no client change needed.

Admission and release are now one helper each (`admitLongPoll` / `releaseLongPoll`), shared by the Unix-socket and WebSocket paths, so the two transports can't drift. Overflowing asks get `runtime_busy` with a distinct message (`orchestration.ask capacity reached`) but the **same error code**, so existing client backoff is untouched.

**Why not per-connection:** there is no per-connection long-poll state to reuse — `activeLongPolls` is the only meter, and the WS path doesn't thread a connection id into admission. It would also be the wrong fence: the starving party is a *different client* (mobile/relay), not a second request on the same socket.

## Screenshots

No visual change — this is runtime RPC admission control with no UI surface.

## Testing

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — both touched files green (175 passed)
- [ ] `pnpm build` — not run; no build-surface change (no new deps, no main/preload entry change)
- [x] Added or updated high-quality tests that would catch regressions

`src/main/runtime/runtime-rpc.test.ts`
- **reserves long-poll headroom for terminal.wait when orchestration.ask floods** — cap 4 (sub-cap 2), 4 concurrent asks; asserts a `terminal.wait` and a `check --wait` from other clients are still admitted, and that the 2 overflow asks were shed.
- **keeps the full cap available to terminal.wait and check --wait** — guard: 4 `check --wait` still fill the whole budget, 5th is `runtime_busy`, ask counter stays 0.
- **applies the ask sub-cap on the WebSocket path and releases both counters on close** — closes the WS coverage gap (see AI Review Report). Drives `handleWebSocketMessage` with a `runtime`-scoped device, asserts the overflow ask is shed with the distinct message without burning a reserved slot, that `check --wait` still gets the other half, and that **both** counters return to zero when the socket closes.

`src/main/runtime/rpc/methods/orchestration.test.ts`
- **clamps an absurd caller-supplied timeoutMs** — behavioral: spies the budget actually handed to `waitForMessage`.
- **clamps timeoutMs at the exported boundary** — table over default / passthrough / at-limit / over-limit / negative.

### Revert check — every new test was run against reverted source

Each source file was reverted independently (`git apply -R`) with the tests kept, to prove no test is vacuous.

| test | with fix | source reverted |
|---|---|---|
| reserves long-poll headroom | pass | **fail** — `terminal.wait` got `code: "runtime_busy"`, expected `"timeout"` |
| applies the ask sub-cap on the WebSocket path | pass | **fail** — overflow ask was admitted instead of shed; replies contained `req_ask_0/1/overflow` all `ok: true` |
| clamps an absurd timeoutMs | pass | **fail** — `expected 9007199254740991 to be less than or equal to 1800000` |
| clamps at the exported boundary | pass | **fail** — `TypeError: clampAskTimeoutMs is not a function` |
| keeps the full cap available | pass | fail *only* on the `activeAskLongPolls === 0` line (`expected undefined to be +0`) |

The first row is the starvation itself, reproduced: with the source reverted, four asks eat all four slots and `terminal.wait` is shed. The last row is reported honestly as a **no-regression guard**, not a bug reproducer — its admission assertions (4 waits admitted, 5th `runtime_busy`) hold in both worlds by design, and only the new counter reference fails pre-fix.

## AI Review Report

Reviewed with Claude, focused on four risks:

1. **Keepalive / abort regression.** The pre-existing wiring that put `orchestration.ask` in the long-poll set was deliberate — ask needs keepalive or the 30 s socket idle timer tears it down, and it needs the abort signal to release the waiter on client disconnect. Verified the `boolean → 'ask' | 'wait' | null` change preserves this: `'ask'` is truthy, so `context?.startKeepalive()` and `signal: longPoll ? context?.signal : undefined` behave identically. `isLongPollRequest` had no other callers anywhere in the repo.
2. **Slot leaks.** A leaked slot in the new ask class is permanent capacity loss that only a restart clears. `releaseLongPoll` runs in the `finally` of both transports, covering normal return, throw, abort and disconnect. The new WS test asserts both counters return to zero after a socket close. Rejected requests never increment, so shedding cannot leak.
3. **Unchanged admission for existing clients.** The total-cap rejection message is byte-identical to `main`, and no client in the repo (including mobile and relay) string-matches on the message — only on `code: 'runtime_busy'`.
4. **Cross-platform / SSH / relay / mobile.** No platform-dependent code paths: no `path` handling, no shell invocation, no keyboard or Electron-menu surface, so macOS / Linux / Windows behave identically. SSH, relay and mobile clients share this runtime and cap, and are the *beneficiaries* — `MOBILE_RPC_METHOD_ALLOWLIST` contains `terminal.wait` but no `orchestration.*`, so a mobile device can only ever use the reserved `wait` class and can no longer be starved by a fleet of asking workers. Folder workspaces and non-GitHub git providers are not involved — nothing here touches git.

**Flagged and fixed during review:** CodeRabbit and the review both flagged that the WebSocket path shared the new admit/release helpers but was covered only by reasoning, not by a running test. That is now closed by the third `runtime-rpc.test.ts` test above, which fails behaviorally when the source is reverted.

## Security Audit

- **Input handling:** the clamp *narrows* attacker-controlled input. `timeoutMs` reaches the handler through `OptionalFiniteNumber` (finite numbers only), and `clampAskTimeoutMs` bounds it to `[0, 1_800_000]`. Values under the cap and `undefined` are passed through unchanged, so no behavior change for well-formed callers.
- **Resource exhaustion:** this is the actual security-relevant change — it removes an unauthenticated-by-volume DoS in which one client class could exhaust a shared server-wide budget and deny service to every other paired device. The sub-cap is derived rather than configurable specifically so it cannot be turned off.
- **Auth / IPC:** no change to auth-token enforcement, device-token validation, the mobile method allowlist, or E2EE. Admission is still evaluated *after* authentication and after the mobile allowlist check on the WS path.
- **Command execution / path handling / secrets / dependencies:** none touched; no new dependencies.
- **Follow-up:** none blocking.

## Notes

No platform-specific behavior.

**Intended trade — the concurrent-ask ceiling drops 16 → 8.** More than 8 workers blocking on `ask` at once now get `runtime_busy` where previously all 16 were admitted. That is the point of the reservation, but it is a real behavior change worth stating: nothing in `src/` retries on `runtime_busy`, so it surfaces as a hard CLI error. It is self-mitigating in practice — the callers are LLM agents and the message says "retry with backoff" — and shedding happens at the admission fence *before* the handler runs, so a shed ask inserts no orphan `decision_gate` row.

**Clamped asks are observable.** The ask result now echoes the effective `timeoutMs` on every return, and the CLI prints that rather than the value it sent. Without it a caller passing `--timeout-ms 3600000` was told `ask timeout after 3600000ms` after only 30 min — off by 2x, and accurate before this PR introduced the clamp. Additive optional field; older clients fall back to the requested value.

**Known follow-up, deliberately out of scope:** `orchestration.check --wait` also takes an unbounded caller `timeoutMs` and holds a slot for it. Same class of defect, different method — left alone to keep this PR on one concern. Note the reserved half is shared by `terminal.wait` *and* `check --wait`, so a coordinator fleet passing a huge `check --wait` timeout can still fill the budget; that is a symmetric pre-existing hole, and `check --wait` is coordinator-driven (few) where `ask` is worker-driven (many).
