### PR TITLE
feat(diagnostics): record OS suspend/resume so sleep gaps aren't read as freezes

### DIFF
--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -91,21 +91,42 @@ describe('registerSystemResumeBroadcast', () => {
     clock.value += 109 * 60_000
     fireResume()
 
-    expect(breadcrumbNames()).toEqual(['system_suspended', 'system_resumed'])
+    expect(breadcrumbNames()).toEqual(['system_slept'])
     expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({ suspendedForMs: 109 * 60_000 })
   })
 
-  it('omits the sleep span when resume arrives without a recorded suspend', () => {
+  it('records nothing when resume arrives without a recorded suspend', () => {
     const { source, fireResume } = createResumeSource()
-    registerSystemResumeBroadcast({ resumeSource: source, getWindows: () => [] })
+    const window = createWindow()
+    registerSystemResumeBroadcast({ resumeSource: source, getWindows: () => [window] })
 
     fireResume()
 
-    expect(breadcrumbNames()).toEqual(['system_resumed'])
-    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toBeUndefined()
+    expect(breadcrumbNames()).toEqual([])
+    expect(window.webContents.send).toHaveBeenCalledWith(SYSTEM_RESUMED_CHANNEL)
   })
 
-  it('measures each sleep span independently across repeated cycles', () => {
+  it('ignores maintenance sleeps too short to swallow a renderer heartbeat', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 0 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    // Why: 20 maintenance cycles must not evict the 30-entry breadcrumb ring.
+    for (let cycle = 0; cycle < 20; cycle++) {
+      fireSuspend()
+      clock.value += 2_000
+      fireResume()
+      clock.value += 30_000
+    }
+
+    expect(breadcrumbNames()).toEqual([])
+  })
+
+  it('measures each reportable sleep independently across repeated cycles', () => {
     const { source, fireSuspend, fireResume } = createResumeSource()
     const clock = { value: 0 }
     registerSystemResumeBroadcast({
@@ -115,19 +136,17 @@ describe('registerSystemResumeBroadcast', () => {
     })
 
     fireSuspend()
-    clock.value += 5_000
+    clock.value += 5 * 60_000
     fireResume()
     clock.value += 60_000
     fireSuspend()
-    clock.value += 2_000
+    clock.value += 2 * 60_000
     fireResume()
     // Why: a spurious resume after the cycles must not re-report the last sleep.
-    clock.value += 30_000
+    clock.value += 30 * 60_000
     fireResume()
 
-    const spans = getCrashBreadcrumbSnapshot()
-      .filter((breadcrumb) => breadcrumb.name === 'system_resumed')
-      .map((breadcrumb) => breadcrumb.data?.suspendedForMs)
-    expect(spans).toEqual([5_000, 2_000, undefined])
+    const spans = getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.data?.suspendedForMs)
+    expect(spans).toEqual([5 * 60_000, 2 * 60_000])
   })
 })

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -100,6 +100,28 @@ describe('registerSystemResumeBroadcast', () => {
     expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({ suspendedForMs: 109 * 60_000 })
   })
 
+  it('spans from the first suspend when dark wake swallows the intervening resume', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 0 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    fireSuspend()
+    clock.value += 90 * 60_000
+    // Why: dark wake re-suspends without a resume; reporting only the trailing 20s
+    // would leave the 90 preceding minutes looking like an unexplained freeze.
+    fireSuspend()
+    clock.value += 20_000
+    fireResume()
+
+    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({
+      suspendedForMs: 90 * 60_000 + 20_000
+    })
+  })
+
   it('records nothing when resume arrives without a recorded suspend', () => {
     const { source, fireResume } = createResumeSource()
     const window = createWindow()

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot
+} from './crash-reporting/crash-breadcrumb-store'
 import { registerSystemResumeBroadcast, SYSTEM_RESUMED_CHANNEL } from './system-resume-broadcast'
 
 vi.mock('electron', () => ({
@@ -6,19 +10,30 @@ vi.mock('electron', () => ({
   powerMonitor: { on: vi.fn(), off: vi.fn() }
 }))
 
+beforeEach(clearCrashBreadcrumbsForTest)
+
 type ResumeListener = () => void
+type PowerLifecycleEvent = 'suspend' | 'resume'
 
 function createResumeSource() {
-  const state: { listener: ResumeListener | null } = { listener: null }
+  const listeners = new Map<PowerLifecycleEvent, ResumeListener>()
   const source = {
-    on: vi.fn((_event: 'resume', callback: ResumeListener) => {
-      state.listener = callback
+    on: vi.fn((event: PowerLifecycleEvent, callback: ResumeListener) => {
+      listeners.set(event, callback)
     }),
-    off: vi.fn((_event: 'resume', _callback: ResumeListener) => {
-      state.listener = null
+    off: vi.fn((event: PowerLifecycleEvent, _callback: ResumeListener) => {
+      listeners.delete(event)
     })
   }
-  return { source, fireResume: () => state.listener?.() }
+  return {
+    source,
+    fireSuspend: () => listeners.get('suspend')?.(),
+    fireResume: () => listeners.get('resume')?.()
+  }
+}
+
+function breadcrumbNames(): string[] {
+  return getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.name)
 }
 
 function createWindow(destroyed = false): {
@@ -58,7 +73,61 @@ describe('registerSystemResumeBroadcast', () => {
     unsubscribe()
     fireResume()
 
-    expect(source.off).toHaveBeenCalledTimes(1)
+    expect(source.off).toHaveBeenCalledWith('resume', expect.any(Function))
+    expect(source.off).toHaveBeenCalledWith('suspend', expect.any(Function))
     expect(window.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('records the sleep span so a heartbeat gap is attributable to suspend', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 1_000 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    fireSuspend()
+    clock.value += 109 * 60_000
+    fireResume()
+
+    expect(breadcrumbNames()).toEqual(['system_suspended', 'system_resumed'])
+    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({ suspendedForMs: 109 * 60_000 })
+  })
+
+  it('omits the sleep span when resume arrives without a recorded suspend', () => {
+    const { source, fireResume } = createResumeSource()
+    registerSystemResumeBroadcast({ resumeSource: source, getWindows: () => [] })
+
+    fireResume()
+
+    expect(breadcrumbNames()).toEqual(['system_resumed'])
+    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toBeUndefined()
+  })
+
+  it('measures each sleep span independently across repeated cycles', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 0 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    fireSuspend()
+    clock.value += 5_000
+    fireResume()
+    clock.value += 60_000
+    fireSuspend()
+    clock.value += 2_000
+    fireResume()
+    // Why: a spurious resume after the cycles must not re-report the last sleep.
+    clock.value += 30_000
+    fireResume()
+
+    const spans = getCrashBreadcrumbSnapshot()
+      .filter((breadcrumb) => breadcrumb.name === 'system_resumed')
+      .map((breadcrumb) => breadcrumb.data?.suspendedForMs)
+    expect(spans).toEqual([5_000, 2_000, undefined])
   })
 })

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -21,8 +21,12 @@ function createResumeSource() {
     on: vi.fn((event: PowerLifecycleEvent, callback: ResumeListener) => {
       listeners.set(event, callback)
     }),
-    off: vi.fn((event: PowerLifecycleEvent, _callback: ResumeListener) => {
-      listeners.delete(event)
+    // Why: match on identity so detaching a different closure than the one
+    // registered still leaves a live listener, as it would on real powerMonitor.
+    off: vi.fn((event: PowerLifecycleEvent, callback: ResumeListener) => {
+      if (listeners.get(event) === callback) {
+        listeners.delete(event)
+      }
     })
   }
   return {
@@ -73,8 +77,9 @@ describe('registerSystemResumeBroadcast', () => {
     unsubscribe()
     fireResume()
 
-    expect(source.off).toHaveBeenCalledWith('resume', expect.any(Function))
-    expect(source.off).toHaveBeenCalledWith('suspend', expect.any(Function))
+    // Why: detaching a different closure than the one registered leaks a real
+    // powerMonitor listener, and for 'suspend' that leak is otherwise unobservable.
+    expect(source.off.mock.calls).toEqual(source.on.mock.calls)
     expect(window.webContents.send).not.toHaveBeenCalled()
   })
 

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -133,7 +133,7 @@ describe('registerSystemResumeBroadcast', () => {
     expect(window.webContents.send).toHaveBeenCalledWith(SYSTEM_RESUMED_CHANNEL)
   })
 
-  it('ignores maintenance sleeps too short to swallow a renderer heartbeat', () => {
+  it('ignores sleeps too short to open a gap, keeping ring slots for real evidence', () => {
     const { source, fireSuspend, fireResume } = createResumeSource()
     const clock = { value: 0 }
     registerSystemResumeBroadcast({
@@ -142,7 +142,7 @@ describe('registerSystemResumeBroadcast', () => {
       now: () => clock.value
     })
 
-    // Why: 20 maintenance cycles must not evict the 30-entry breadcrumb ring.
+    // Why: 20 sub-heartbeat cycles must not evict the 30-entry breadcrumb ring.
     for (let cycle = 0; cycle < 20; cycle++) {
       fireSuspend()
       clock.value += 2_000

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -21,9 +21,9 @@ type SystemResumeBroadcastOptions = {
   now?: () => number
 }
 
-// Why: macOS maintenance-sleeps dozens of times a day (median span ~2s), which would
-// flood the 30-entry breadcrumb ring and evict the crash evidence this is meant to
-// explain. Only a sleep long enough to swallow a renderer heartbeat is worth recording.
+// Why: a sleep shorter than the renderer's 60s memory-sample interval only delays a
+// heartbeat, it cannot open the multi-minute gap this attributes -- so recording one
+// spends a slot in the 30-entry ring without explaining anything.
 const MIN_REPORTABLE_SUSPEND_MS = 60_000
 
 // Why: renderers cannot observe OS sleep/wake directly, and Linux has no

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -1,10 +1,13 @@
 import { BrowserWindow, powerMonitor } from 'electron'
+import { recordCrashBreadcrumb } from './crash-reporting/crash-breadcrumb-store'
 
 export const SYSTEM_RESUMED_CHANNEL = 'system:resumed'
 
+type PowerLifecycleEvent = 'suspend' | 'resume'
+
 type ResumeEventSource = {
-  on(event: 'resume', listener: () => void): unknown
-  off(event: 'resume', listener: () => void): unknown
+  on(event: PowerLifecycleEvent, listener: () => void): unknown
+  off(event: PowerLifecycleEvent, listener: () => void): unknown
 }
 
 type ResumeBroadcastWindow = {
@@ -15,6 +18,7 @@ type ResumeBroadcastWindow = {
 type SystemResumeBroadcastOptions = {
   resumeSource?: ResumeEventSource
   getWindows?: () => ResumeBroadcastWindow[]
+  now?: () => number
 }
 
 // Why: renderers cannot observe OS sleep/wake directly, and Linux has no
@@ -25,15 +29,31 @@ export function registerSystemResumeBroadcast(
 ): () => void {
   const resumeSource = options.resumeSource ?? powerMonitor
   const getWindows = options.getWindows ?? (() => BrowserWindow.getAllWindows())
+  const now = options.now ?? Date.now
+  // Why: renderer timers stop across OS sleep, so an unexplained heartbeat gap
+  // reads identically to a freeze. Stamping suspend lets resume report the span.
+  let suspendedAt: number | null = null
+
+  const onSuspend = (): void => {
+    suspendedAt = now()
+    recordCrashBreadcrumb('system_suspended')
+  }
+
   const onResume = (): void => {
+    const suspendedForMs = suspendedAt === null ? undefined : Math.max(0, now() - suspendedAt)
+    suspendedAt = null
+    recordCrashBreadcrumb('system_resumed', suspendedForMs === undefined ? {} : { suspendedForMs })
     for (const window of getWindows()) {
       if (!window.isDestroyed()) {
         window.webContents.send(SYSTEM_RESUMED_CHANNEL)
       }
     }
   }
+
+  resumeSource.on('suspend', onSuspend)
   resumeSource.on('resume', onResume)
   return () => {
+    resumeSource.off('suspend', onSuspend)
     resumeSource.off('resume', onResume)
   }
 }

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -21,6 +21,11 @@ type SystemResumeBroadcastOptions = {
   now?: () => number
 }
 
+// Why: macOS maintenance-sleeps dozens of times a day (median span ~2s), which would
+// flood the 30-entry breadcrumb ring and evict the crash evidence this is meant to
+// explain. Only a sleep long enough to swallow a renderer heartbeat is worth recording.
+const MIN_REPORTABLE_SUSPEND_MS = 60_000
+
 // Why: renderers cannot observe OS sleep/wake directly, and Linux has no
 // window-occlusion tracking so visibilitychange never fires around suspend.
 // Wake-sensitive renderer recovery needs this explicit resume signal.
@@ -36,13 +41,14 @@ export function registerSystemResumeBroadcast(
 
   const onSuspend = (): void => {
     suspendedAt = now()
-    recordCrashBreadcrumb('system_suspended')
   }
 
   const onResume = (): void => {
-    const suspendedForMs = suspendedAt === null ? undefined : Math.max(0, now() - suspendedAt)
+    const suspendedForMs = suspendedAt === null ? null : Math.max(0, now() - suspendedAt)
     suspendedAt = null
-    recordCrashBreadcrumb('system_resumed', suspendedForMs === undefined ? {} : { suspendedForMs })
+    if (suspendedForMs !== null && suspendedForMs >= MIN_REPORTABLE_SUSPEND_MS) {
+      recordCrashBreadcrumb('system_slept', { suspendedForMs })
+    }
     for (const window of getWindows()) {
       if (!window.isDestroyed()) {
         window.webContents.send(SYSTEM_RESUMED_CHANNEL)

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -40,7 +40,11 @@ export function registerSystemResumeBroadcast(
   let suspendedAt: number | null = null
 
   const onSuspend = (): void => {
-    suspendedAt = now()
+    // Why: resume maps to NSWorkspaceDidWake, which stays silent for dark wake, so
+    // suspend can repeat before a resume. Keep the earliest stamp: over-reporting the
+    // span is visibly inconsistent with surviving heartbeats, while under-reporting
+    // leaves a long gap looking unexplained -- the false freeze this exists to rule out.
+    suspendedAt ??= now()
   }
 
   const onResume = (): void => {


### PR DESCRIPTION
## Why

> **Correction (post-merge).** The framing below is wrong in one important way, and the record should say so.
>
> The user's actual report was: *"Orca keeps freezing on me after closing my laptop and coming back to it."* The gap being sleep-shaped does **not** contradict that — sleep is the *precondition*, and the freeze is at the **tail** of the gap, on wake. This PR proved the gap was sleep and wrongly treated that as evidence no freeze occurred.
>
> A mechanism was already found and fixed independently: **v1.4.152 does not contain #10253**, so it shipped `forceRepaint()` calling `window.setSize(width + 1, height)` **synchronously** from `window.on('restore')`/`on('show')` (`src/main/window/createMainWindow.ts:66` at that tag). #10253 carries a kernel-confirmed spindump showing exactly that re-entrant frame mutation self-deadlocking the main thread in FrontBoardServices on macOS 26's scene-backed windows. Lid-open fires `restore`/`show`; the user was on Darwin 25.5.0 (Tahoe). That matches the report mechanism-for-mechanism, and it explains the absence of any crash report: a main thread deadlocked in AppKit cannot run the JS that would record one.
>
> So #10473/#10485/#10487 are most likely **the actual fix**, not unconfirmed extras. This PR's value is unchanged and narrower than claimed: it makes sleep spans explicit so a future gap is attributable instead of ambiguous.
>
> Caveat: a synthetic repro driving `show()`/`minimize()`/`restore()` on macOS 26.3.1 did **not** reproduce the hang (6/6 clean, harness validated to fire the handlers). Programmatic window-state changes do not reproduce a genuine FrontBoardServices lid-open wake, so this is weak counter-evidence against a kernel-confirmed spindump — but it is not nothing, and the deadlock remains inferred rather than reproduced.

The uber-crash investigation hinged on a 109-minute `renderer_memory` heartbeat gap that read as a wedged renderer. It isn't diagnostic:

- The same session had a **122-minute** gap 11 hours earlier (10:31→12:34) with **identical heap on both sides** — then ran fine for another 9 hours.
- A healthy machine's full-fidelity trace has a **427-minute** mid-session gap with `reason=interval`, plus 35 more over 90s. Nearly every one contains `pmset` sleep events.

Renderer timers stop across OS sleep, so "app frozen" and "laptop closed" produce a byte-identical hole in the telemetry. `powerMonitor.on('resume')` was already wired here for renderer wake recovery but left no breadcrumb, so nothing in a crash report could separate the two.

## What

Suspend stamps a timestamp. Resume emits a single `system_slept` breadcrumb carrying the measured `suspendedForMs`, past a 60s threshold.

Two details are load-bearing, both driven by the same fact: **`powerMonitor`'s `resume` maps to `NSWorkspaceDidWake`, which does not fire for dark wake.**

**1. Suspend keeps the _earliest_ stamp (`suspendedAt ??= now()`).** macOS routinely delivers `suspend → (dark wake, no resume) → suspend → resume`. Overwriting the stamp would report only the trailing segment — and when that segment falls under the gate, a 90-minute sleep records **nothing at all**, leaving exactly the unexplained gap this PR exists to rule out. The mutation test for this asserts the breadcrumb is present, not merely smaller.

**2. The 60s gate.** A sleep shorter than the renderer's 60s `RENDERER_MEMORY_SAMPLE_INTERVAL_MS` only delays a heartbeat; it cannot open a multi-minute gap, so recording it spends a slot in the 30-entry ring without explaining anything.

Measured by replaying 6 days of this machine's real `pmset` history (78 `Sleep`, 29 full `Wake`, 51 `DarkWake`) through the shipped state machine:

| | value |
|---|---|
| breadcrumbs / 6 days | **29** (~5/day) |
| worst 60-min burst | **4** |
| ring capacity | 30 |
| dropped by the gate | 3 events (12s, 8s, 4s) |

Note this corrects an earlier revision of this description, which claimed ~70 cycles and a worst burst of 7 and justified the gate as flood control. That was wrong: it counted `Wake Requests` scheduling lines as wakes. Maintenance sleeps overwhelmingly resolve as `DarkWake`, which never fires `resume` — so they never recorded a breadcrumb in the first place. There was no flooding risk to solve; the gate's real job is the narrower one above.

## Testing

7 unit tests, all mutation-verified — each mutation below fails at least one test:

| mutation | caught by |
|---|---|
| `suspendedAt = now()` instead of `??=` (dark-wake truncation) | dark-wake test (breadcrumb vanishes entirely) |
| remove the 60s threshold | 20-cycle sub-heartbeat test |
| never reset `suspendedAt` | repeated-cycles (spurious trailing resume) |
| record even when no suspend was seen | resume-without-suspend |
| teardown detaches a foreign closure | unsubscribe (`off` calls deep-equal `on` calls) |
| drop the resume broadcast | broadcast + resume-without-suspend |

The `off` mock is identity-aware, so detaching a different closure than the one registered fails the suite — for `'suspend'` that leak is otherwise unobservable through the public API.

Full suite: 35813 passed. The 2 failures in `src/relay/agent-exec-handler.test.ts` reproduce on clean `main` with this change stashed — pre-existing and unrelated. Typecheck clean on all three projects; lint clean.

## Scope

Main-process only, no platform branches — `powerMonitor` suspend/resume is supported on macOS, Linux, and Windows. Registered once at `src/main/index.ts:1875` with a paired teardown at `:2488`; `suspendedAt` is closure-scoped, so re-registration cannot cross-contaminate.

## Note on the earlier PRs

This does **not** revert #10473 / #10485 / #10487. Those fix a real macOS 26 frame-mutation hazard that v1.4.152 genuinely shipped — and per the correction above, that hazard is now the **best-supported explanation** for this user's freeze, not merely a latent extra. This PR closes the instrumentation gap that made the attribution unfalsifiable in the first place.

