### PR TITLE
fix(sidebar): stop a worktree drag preview from closing the Agent Dashboard

### DIFF
--- a/src/renderer/src/components/sidebar/Sidebar.test.tsx
+++ b/src/renderer/src/components/sidebar/Sidebar.test.tsx
@@ -4,12 +4,19 @@ import type { CSSProperties, ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { tmpdir } from 'node:os'
 import { cleanup, render, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../../shared/constants'
 import type { GlobalSettings } from '../../../../shared/types'
 
 const mocks = vi.hoisted(() => ({
-  state: {} as Record<string, unknown>
+  state: {} as Record<string, unknown>,
+  // Stable callback identities so companion-board Effects only re-run on real state changes.
+  closeWorkspaceBoard: vi.fn(),
+  panel: {
+    workspaceBoardOpen: false,
+    workspaceBoardRenderedOpen: true,
+    workspaceBoardDragPreviewOpen: false
+  }
 }))
 
 vi.mock('@/store', () => ({
@@ -74,14 +81,12 @@ vi.mock('./useSidebarProjectDrop', () => ({
 
 vi.mock('./useWorkspaceBoardPanel', () => ({
   useWorkspaceBoardPanel: () => ({
-    workspaceBoardOpen: false,
-    workspaceBoardRenderedOpen: true,
-    workspaceBoardDragPreviewOpen: false,
+    ...mocks.panel,
     workspaceBoardMenuOpen: false,
     toggleWorkspaceBoard: vi.fn(),
     handleWorkspaceBoardOpenChange: vi.fn(),
     setWorkspaceBoardMenuOpen: vi.fn(),
-    closeWorkspaceBoard: vi.fn(),
+    closeWorkspaceBoard: mocks.closeWorkspaceBoard,
     previewWorkspaceBoardFromDrag: vi.fn(),
     solidifyWorkspaceBoardFromDrag: vi.fn(),
     cancelWorkspaceBoardDragPreview: vi.fn()
@@ -116,6 +121,15 @@ function sidebarElement(): ReactNode {
     <Sidebar worktreeScrollOffsetRef={{ current: 0 }} worktreeScrollAnchorRef={{ current: null }} />
   )
 }
+
+beforeEach(() => {
+  mocks.closeWorkspaceBoard.mockClear()
+  mocks.panel = {
+    workspaceBoardOpen: false,
+    workspaceBoardRenderedOpen: true,
+    workspaceBoardDragPreviewOpen: false
+  }
+})
 
 afterEach(cleanup)
 
@@ -203,5 +217,64 @@ describe('Sidebar', () => {
     }
     view.rerender(sidebarElement())
     await waitFor(() => expect(fetchAllWorktrees).toHaveBeenCalledTimes(1))
+  })
+
+  describe('companion board mutual exclusion', () => {
+    function renderWithDashboardOpen(): {
+      view: ReturnType<typeof render>
+      setAgentDashboardDrawerOpen: ReturnType<typeof vi.fn>
+    } {
+      setSidebarState(getDefaultSettings(tmpdir()))
+      const setAgentDashboardDrawerOpen = vi.fn()
+      mocks.state = { ...mocks.state, agentDashboardDrawerOpen: true, setAgentDashboardDrawerOpen }
+      mocks.panel = {
+        workspaceBoardOpen: false,
+        workspaceBoardRenderedOpen: false,
+        workspaceBoardDragPreviewOpen: false
+      }
+      return { view: render(sidebarElement()), setAgentDashboardDrawerOpen }
+    }
+
+    it('keeps the agent dashboard open while a worktree drag only previews the board', () => {
+      const { view, setAgentDashboardDrawerOpen } = renderWithDashboardOpen()
+
+      mocks.panel = {
+        workspaceBoardOpen: false,
+        workspaceBoardRenderedOpen: true,
+        workspaceBoardDragPreviewOpen: true
+      }
+      view.rerender(sidebarElement())
+
+      expect(setAgentDashboardDrawerOpen).not.toHaveBeenCalled()
+    })
+
+    it('closes the agent dashboard when the workspace board is actually opened', () => {
+      const { view, setAgentDashboardDrawerOpen } = renderWithDashboardOpen()
+
+      mocks.panel = {
+        workspaceBoardOpen: true,
+        workspaceBoardRenderedOpen: true,
+        workspaceBoardDragPreviewOpen: false
+      }
+      view.rerender(sidebarElement())
+
+      expect(setAgentDashboardDrawerOpen).toHaveBeenCalledWith(false)
+    })
+
+    it('closes the workspace board when the agent dashboard opens', () => {
+      setSidebarState(getDefaultSettings(tmpdir()))
+      mocks.panel = {
+        workspaceBoardOpen: true,
+        workspaceBoardRenderedOpen: true,
+        workspaceBoardDragPreviewOpen: false
+      }
+      const view = render(sidebarElement())
+      mocks.closeWorkspaceBoard.mockClear()
+
+      mocks.state = { ...mocks.state, agentDashboardDrawerOpen: true }
+      view.rerender(sidebarElement())
+
+      expect(mocks.closeWorkspaceBoard).toHaveBeenCalled()
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/index.tsx
+++ b/src/renderer/src/components/sidebar/index.tsx
@@ -146,11 +146,13 @@ function Sidebar({
       closeWorkspaceBoard()
     }
   }, [agentDashboardDrawerOpen, closeWorkspaceBoard])
+  // Why: a transient drag preview is not the user opening the board, so it must
+  // not evict the dashboard — key on the opened state, not the rendered state.
   useEffect(() => {
-    if (workspaceBoardRenderedOpen) {
+    if (workspaceBoardOpen) {
       setAgentDashboardDrawerOpen(false)
     }
-  }, [setAgentDashboardDrawerOpen, workspaceBoardRenderedOpen])
+  }, [setAgentDashboardDrawerOpen, workspaceBoardOpen])
 
   const { containerRef, onResizeStart, isResizing } = useSidebarResize<HTMLDivElement>({
     isOpen: sidebarOpen,


### PR DESCRIPTION
## Problem

Dragging **any** worktree card closed the Agent Dashboard drawer, and cancelling the drag never restored it.

The companion-board mutual-exclusion Effect in `src/renderer/src/components/sidebar/index.tsx` keyed on `workspaceBoardRenderedOpen`. That flag is not "the workspace board is open" — per `useWorkspaceBoardPanel.ts:149` it is:

```ts
workspaceBoardRenderedOpen: workspaceBoardOpen || workspaceBoardDragPreviewOpen
```

and `WorktreeList.tsx:2791-2799` sets the drag preview as soon as *any* card drag becomes active:

```ts
// Why: show the board preview as soon as a card drag begins so the drop target is visible up front...
if (!drag.workspaceBoardDragPreviewRequested && !workspaceBoardOpen && !hasWorkspaceKanbanSidebarDropBoard()) {
  drag.workspaceBoardDragPreviewRequested = true
  onWorkspaceBoardDragPreviewStart()
}
```

That gate is not conditioned on the pointer being over the board, so even a pure reorder within a group — which never opens the board — flipped `workspaceBoardRenderedOpen` and evicted the dashboard.

## Fix

Key the Effect on `workspaceBoardOpen`. A transient drag preview is not the user opening the board, so it should not dismiss the other companion board. The reciprocal Effect (`agentDashboardDrawerOpen => closeWorkspaceBoard`) was already correct and is untouched.

## Tests

Three tests in `Sidebar.test.tsx`, each proven non-vacuous by its own targeted mutation:

| Test | Mutation that kills it | Result |
| --- | --- | --- |
| drag preview alone must not close the dashboard | restore `workspaceBoardRenderedOpen` (the bug) | ✗ fails |
| opening the board still closes the dashboard | delete the board→dashboard Effect | ✗ fails |
| opening the dashboard still closes the board | delete the dashboard→board Effect | ✗ fails |

All three pass with the fix (`7 passed`). Gates: `npm run typecheck` and `npm run lint` both exit 0.

## Known trade-off (not papered over)

Both sheets render at identical geometry (`side="left"`, same `left`/`top`/`bottom`/`width`, both non-modal). With this fix, dragging a card while the dashboard is open now renders the board **drag preview** over the dashboard for the duration of the drag, where previously the dashboard was destroyed outright. Both terminal states are correct — drop into the board solidifies it and the mutual-exclusion Effect closes the dashboard; cancel clears the preview and the dashboard is still there. Suppressing the preview entirely while the dashboard is open would need a flag threaded into `WorktreeList`, which is out of scope for this one-line fix.

## Verification scope

Static + unit only. The real pointer-drag interaction was **not** exercised in a running Electron app; the drag-preview call path was verified by reading `flushWorktreePointerDrag` and `handleWorktreeRowPointerDown`, not by driving a live drag.