### PR TITLE
fix(terminal): stop ConstrainedLanguage hosts from swallowing PowerShell cwd restore

### DIFF
--- a/src/main/powershell-osc133-bootstrap.test.ts
+++ b/src/main/powershell-osc133-bootstrap.test.ts
@@ -32,9 +32,8 @@ describe('PowerShell OSC 133 bootstrap', () => {
   })
 
   it('isolates its early-return guards so they cannot abort the caller payload', () => {
-    // Why: a top-level `return` ends the whole -EncodedCommand script. Callers
-    // append the cwd restore and the user's startup command to the same
-    // payload, so the guards must return out of a scriptblock, not the script.
+    // Why: a top-level `return` ends the whole -EncodedCommand script, taking
+    // the cwd restore and startup command callers append with it.
     const script = getPowerShellOsc133Bootstrap()
 
     expect(script.startsWith('. {\n')).toBe(true)
@@ -48,8 +47,12 @@ describe('PowerShell OSC 133 bootstrap', () => {
     expect(languageModeGuard).toBeGreaterThan(blockStart)
     expect(reentryGuard).toBeGreaterThan(blockStart)
 
-    // Anything appended after the bootstrap stays outside the guarded block.
-    expect(`${script}Write-Host after`.trimEnd().endsWith('Write-Host after')).toBe(true)
+    // Balanced braces: an unclosed block would swallow whatever callers append.
+    const depth = [...script].reduce(
+      (acc, char) => acc + (char === '{' ? 1 : char === '}' ? -1 : 0),
+      0
+    )
+    expect(depth).toBe(0)
   })
 
   it('encodes commands as UTF-16LE base64 for PowerShell -EncodedCommand', () => {

--- a/src/main/powershell-osc133-bootstrap.test.ts
+++ b/src/main/powershell-osc133-bootstrap.test.ts
@@ -31,6 +31,27 @@ describe('PowerShell OSC 133 bootstrap', () => {
     expect(script).not.toContain('NoProfile')
   })
 
+  it('isolates its early-return guards so they cannot abort the caller payload', () => {
+    // Why: a top-level `return` ends the whole -EncodedCommand script. Callers
+    // append the cwd restore and the user's startup command to the same
+    // payload, so the guards must return out of a scriptblock, not the script.
+    const script = getPowerShellOsc133Bootstrap()
+
+    expect(script.startsWith('. {\n')).toBe(true)
+    expect(script.trimEnd().endsWith('}')).toBe(true)
+
+    const blockStart = script.indexOf('. {')
+    const languageModeGuard = script.indexOf(
+      '$ExecutionContext.SessionState.LanguageMode -ne "FullLanguage"'
+    )
+    const reentryGuard = script.indexOf('Test-Path variable:global:__OrcaOsc133State')
+    expect(languageModeGuard).toBeGreaterThan(blockStart)
+    expect(reentryGuard).toBeGreaterThan(blockStart)
+
+    // Anything appended after the bootstrap stays outside the guarded block.
+    expect(`${script}Write-Host after`.trimEnd().endsWith('Write-Host after')).toBe(true)
+  })
+
   it('encodes commands as UTF-16LE base64 for PowerShell -EncodedCommand', () => {
     expect(encodePowerShellCommand('Write-Output ok')).toBe(
       Buffer.from('Write-Output ok', 'utf16le').toString('base64')

--- a/src/main/powershell-osc133-bootstrap.ts
+++ b/src/main/powershell-osc133-bootstrap.ts
@@ -69,12 +69,10 @@ if ($Global:__OrcaOsc133State.HasPSReadLine -and
 `
 
 export function getPowerShellOsc133Bootstrap(): string {
-  // Why: the guards above exit with a top-level `return`, which aborts the
-  // ENTIRE -EncodedCommand payload — not just this bootstrap. Callers append
-  // the cwd restore and the user's startup command to the same payload, so on a
-  // ConstrainedLanguage host (WDAC/AppLocker) those were silently dropped.
-  // Dot-sourcing a scriptblock scopes `return` to the block while still running
-  // in the caller's scope, so unscoped state like $OutputEncoding stays global.
+  // Why: the guards above `return`, which at top level aborts the whole
+  // -EncodedCommand payload — including the cwd restore and startup command
+  // callers append. Dot-sourcing scopes `return` to the block while still
+  // running in the caller's scope, so $OutputEncoding stays global.
   return `. {\n${POWERSHELL_OSC133_BOOTSTRAP}}\n`
 }
 

--- a/src/main/powershell-osc133-bootstrap.ts
+++ b/src/main/powershell-osc133-bootstrap.ts
@@ -69,7 +69,13 @@ if ($Global:__OrcaOsc133State.HasPSReadLine -and
 `
 
 export function getPowerShellOsc133Bootstrap(): string {
-  return POWERSHELL_OSC133_BOOTSTRAP
+  // Why: the guards above exit with a top-level `return`, which aborts the
+  // ENTIRE -EncodedCommand payload — not just this bootstrap. Callers append
+  // the cwd restore and the user's startup command to the same payload, so on a
+  // ConstrainedLanguage host (WDAC/AppLocker) those were silently dropped.
+  // Dot-sourcing a scriptblock scopes `return` to the block while still running
+  // in the caller's scope, so unscoped state like $OutputEncoding stays global.
+  return `. {\n${POWERSHELL_OSC133_BOOTSTRAP}}\n`
 }
 
 export function isPowerShellExecutableName(shellName: string): boolean {

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -131,11 +131,8 @@ describe('resolveWindowsShellLaunchArgs', () => {
   })
 
   it('runs cwd restore and startup command outside the shell-integration guards', () => {
-    // Why: the OSC 133 bootstrap bails with a top-level `return` when the host
-    // runs in ConstrainedLanguage (WDAC/AppLocker). Both the cwd restore and
-    // the startup command must sit outside that guarded block, or a managed
-    // host silently opens the terminal in the wrong directory and never runs
-    // the startup command.
+    // Why: on a ConstrainedLanguage host (WDAC/AppLocker) the bootstrap bails,
+    // so both must sit outside its guarded block to survive.
     const startupCommand = "& 'codex' '--no-alt-screen'"
     const result = resolveWindowsShellLaunchArgs(
       'powershell.exe',
@@ -157,11 +154,8 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(cwdRestoreIndex).toBeGreaterThanOrEqual(0)
     expect(guardBlockIndex).toBeGreaterThanOrEqual(0)
     expect(languageModeGuardIndex).toBeGreaterThanOrEqual(0)
-    // cwd restore precedes the guarded block entirely.
     expect(cwdRestoreIndex).toBeLessThan(guardBlockIndex)
-    // the guards live inside that block, not at script top level.
     expect(guardBlockIndex).toBeLessThan(languageModeGuardIndex)
-    // the startup command trails the block's closing brace.
     expect(command.lastIndexOf('}')).toBeLessThan(command.indexOf(startupCommand))
     expect(command.trimEnd().endsWith(startupCommand)).toBe(true)
   })

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -121,12 +121,49 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(codexRestoreIndex).toBeGreaterThan(outputEncodingIndex)
     expect(codexRestoreIndex).toBeGreaterThan(ompWrapperIndex)
     expect(promptIndex).toBeGreaterThan(codexRestoreIndex)
-    expect(cwdRestoreIndex).toBeGreaterThan(promptIndex)
+    expect(cwdRestoreIndex).toBeGreaterThanOrEqual(0)
+    expect(cwdRestoreIndex).toBeLessThan(outputEncodingIndex)
     expect(command).toContain('Esc = [char]27')
     expect(command).toContain('Bel = [char]7')
     expect(command).toContain(')]133;D;$fakeExitCode$(')
     expect(command).toContain(')]133;C$(')
     expect(command).not.toContain('`e]133')
+  })
+
+  it('runs cwd restore and startup command outside the shell-integration guards', () => {
+    // Why: the OSC 133 bootstrap bails with a top-level `return` when the host
+    // runs in ConstrainedLanguage (WDAC/AppLocker). Both the cwd restore and
+    // the startup command must sit outside that guarded block, or a managed
+    // host silently opens the terminal in the wrong directory and never runs
+    // the startup command.
+    const startupCommand = "& 'codex' '--no-alt-screen'"
+    const result = resolveWindowsShellLaunchArgs(
+      'powershell.exe',
+      'C:\\Users\\alice\\repo',
+      'C:\\Users\\alice',
+      undefined,
+      startupCommand
+    )
+
+    const command = decodePowerShellCommand(result)
+    const cwdRestoreIndex = command.indexOf(
+      expectedPowerShellRestoreCwdCommand("'C:\\Users\\alice\\repo'")
+    )
+    const guardBlockIndex = command.indexOf('. {')
+    const languageModeGuardIndex = command.indexOf(
+      '$ExecutionContext.SessionState.LanguageMode -ne "FullLanguage"'
+    )
+
+    expect(cwdRestoreIndex).toBeGreaterThanOrEqual(0)
+    expect(guardBlockIndex).toBeGreaterThanOrEqual(0)
+    expect(languageModeGuardIndex).toBeGreaterThanOrEqual(0)
+    // cwd restore precedes the guarded block entirely.
+    expect(cwdRestoreIndex).toBeLessThan(guardBlockIndex)
+    // the guards live inside that block, not at script top level.
+    expect(guardBlockIndex).toBeLessThan(languageModeGuardIndex)
+    // the startup command trails the block's closing brace.
+    expect(command.lastIndexOf('}')).toBeLessThan(command.indexOf(startupCommand))
+    expect(command.trimEnd().endsWith(startupCommand)).toBe(true)
   })
 
   it('normalizes MSYS drive cwd before spawning native PowerShell', () => {

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -83,9 +83,9 @@ function getCmdShellArgStartupCommand(command?: string): string | null {
  */
 function getPowerShellRestoreCwdCommand(cwd: string): string {
   return [
-    '',
     '# Profiles can change location; restore the PTY cwd after profile loading.',
-    `try { Set-Location -LiteralPath ${quoteStartupArg(cwd, 'powershell')} -ErrorAction Stop } catch { Write-Warning "Failed to restore working directory: $_" }`
+    `try { Set-Location -LiteralPath ${quoteStartupArg(cwd, 'powershell')} -ErrorAction Stop } catch { Write-Warning "Failed to restore working directory: $_" }`,
+    ''
   ].join('\n')
 }
 
@@ -96,7 +96,10 @@ function getPowerShellEncodedCommand(
   encodedCommand: string
   startupCommandDeliveredInShellArgs?: boolean
 } {
-  const bootstrap = `${getPowerShellOsc133Bootstrap()}${getPowerShellRestoreCwdCommand(cwd)}`
+  // Why: cwd restore runs FIRST so shell-integration setup failing — or being
+  // skipped entirely under ConstrainedLanguage — can never strand the terminal
+  // in the wrong directory. Set-Location is permitted in ConstrainedLanguage.
+  const bootstrap = `${getPowerShellRestoreCwdCommand(cwd)}${getPowerShellOsc133Bootstrap()}`
   if (!startupCommand || startupCommand.length > STARTUP_COMMAND_TEXT_MAX_CHARS) {
     return { encodedCommand: encodePowerShellCommand(bootstrap) }
   }

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -96,9 +96,8 @@ function getPowerShellEncodedCommand(
   encodedCommand: string
   startupCommandDeliveredInShellArgs?: boolean
 } {
-  // Why: cwd restore runs FIRST so shell-integration setup failing — or being
-  // skipped entirely under ConstrainedLanguage — can never strand the terminal
-  // in the wrong directory. Set-Location is permitted in ConstrainedLanguage.
+  // Why: cwd restore runs first so shell integration failing — or being skipped
+  // under ConstrainedLanguage — cannot strand the terminal in the wrong directory.
   const bootstrap = `${getPowerShellRestoreCwdCommand(cwd)}${getPowerShellOsc133Bootstrap()}`
   if (!startupCommand || startupCommand.length > STARTUP_COMMAND_TEXT_MAX_CHARS) {
     return { encodedCommand: encodePowerShellCommand(bootstrap) }


### PR DESCRIPTION
## Summary

On Windows, Orca launches PowerShell with a single `-EncodedCommand` payload built from three concatenated parts:

```
<OSC 133 shell-integration bootstrap><cwd restore><startup command>
```

The bootstrap opens with two **top-level `return`** guards:

```powershell
if ((Test-Path variable:global:__OrcaOsc133State) -and ...) { return }
if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") { return }
```

A top-level `return` in an `-EncodedCommand` script ends the **whole script**, not just the bootstrap section. So whenever either guard fired, everything after it was silently discarded:

- the `Set-Location` cwd restore never ran — the terminal opened in the wrong directory
- the user's configured startup command never ran

Both failed silently. This is one defect with two symptoms.

The language-mode guard fires on any WDAC/AppLocker-managed host running ConstrainedLanguage. The re-entry guard fires on **any** host, including FullLanguage ones, whenever the bootstrap is injected into a session that already has it — so the blast radius is wider than enterprise-managed machines.

**The fix** is two changes:

1. **`powershell-osc133-bootstrap.ts`** — dot-source the bootstrap as a scriptblock (`. { ... }`). `return` then exits only the block, while the body still runs in the caller's scope, so unscoped state such as `$OutputEncoding` stays global exactly as before. Both guards keep working; they just can no longer abort the caller's payload.
2. **`windows-shell-args.ts`** — move the cwd restore *ahead* of the bootstrap, so shell-integration setup failing or being skipped can never strand the terminal in the wrong directory.

Resulting payload order: cwd restore → guarded shell-integration block → startup command.

## ELI5

On Windows, Orca sends the terminal one long list of setup instructions: "turn on the fancy prompt features, then go to the right folder, then run the command the user asked for."

The first instruction had an early exit in it — meant to skip *just* the fancy prompt features on locked-down work computers. But that early exit quit the entire list instead. So the terminal never went to the right folder and never ran the user's command, with no error message explaining why.

The fix puts the fancy-prompt part in its own container, so when it bails out it only bails out of itself. Going to the right folder now also happens first, so it can't be skipped.

## Proof of fix

### 1. Real Windows 11, real generated payloads, ConstrainedLanguage vs FullLanguage

The strongest available evidence. The exact `-EncodedCommand` base64 Orca generates was extracted from `resolveWindowsShellLaunchArgs` — once with the PR's sources (`new`) and once with `origin/main`'s sources (`old`) — transferred byte-exact to a Windows 11 box (lengths verified: `old_plain 12852`, `new_plain 12868`), then executed in a child PowerShell whose language mode was downgraded **before the payload is parsed**. The child starts in `C:\Windows`; a correct payload moves it to the target directory and prints `MARKER`.

`powershell.exe` (5.1.26100.8875):

```
===== powershell.exe / ConstrainedLanguage / old_plain.b64 =====
    childmode=ConstrainedLanguage
    cwd_before=C:\Windows
    cwd_after=C:\Windows                      <-- cwd NOT restored, startup command never ran
    osc133=False
===== powershell.exe / ConstrainedLanguage / new_plain.b64 =====
    childmode=ConstrainedLanguage
    cwd_before=C:\Windows
  MARKER pwd=[C:\Users\neil\AppData\Local\Temp\prbash-10535\plain] osc133=False mode=ConstrainedLanguage
    cwd_after=C:\Users\neil\AppData\Local\Temp\prbash-10535\plain
    osc133=False                              <-- cwd restored, startup ran, integration correctly skipped
===== powershell.exe / FullLanguage / old_plain.b64 =====
    childmode=FullLanguage
  MARKER pwd=[C:\Users\neil\AppData\Local\Temp\prbash-10535\plain] osc133=True mode=FullLanguage
    cwd_after=C:\Users\neil\AppData\Local\Temp\prbash-10535\plain
    osc133=True
===== powershell.exe / FullLanguage / new_plain.b64 =====
    childmode=FullLanguage
  MARKER pwd=[C:\Users\neil\AppData\Local\Temp\prbash-10535\plain] osc133=True mode=FullLanguage
    cwd_after=C:\Users\neil\AppData\Local\Temp\prbash-10535\plain
    osc133=True                               <-- identical to old: FullLanguage users unaffected
```

`pwsh.exe` (7.6.4.0) — same four cases, same outcome:

```
===== pwsh.exe / ConstrainedLanguage / old_plain.b64 =====
    cwd_before=C:\Windows
    cwd_after=C:\Windows
    osc133=False
===== pwsh.exe / ConstrainedLanguage / new_plain.b64 =====
  MARKER pwd=[...\plain] osc133=False mode=ConstrainedLanguage
    cwd_after=C:\Users\neil\AppData\Local\Temp\prbash-10535\plain
===== pwsh.exe / FullLanguage / old_plain.b64 =====
  MARKER pwd=[...\plain] osc133=True mode=FullLanguage
===== pwsh.exe / FullLanguage / new_plain.b64 =====
  MARKER pwd=[...\plain] osc133=True mode=FullLanguage
```

### 2. Is the replacement construct actually ConstrainedLanguage-safe?

The central risk is swapping one blocked construct for another, which would leave the bug in place. Every construct that ends up **outside** the guard was enumerated from the real generated payload:

```
=== Constructs BEFORE the guarded block (must be ConstrainedLanguage-safe) ===
  try { Set-Location -LiteralPath 'C:\Users\neil\orca' -ErrorAction Stop } catch { Write-Warning "..." }

=== Constructs AFTER the block closes ===
  Write-Host ORCA_STARTUP_RAN

=== CL-blocked constructs in body, and their position vs the language-mode guard (L9) ===
  type-literal method ::: 4 occurrence(s); all after language-mode guard? True
  New-Object:             0 occurrence(s)
  Add-Type:               0 occurrence(s)
  type cast [x]:          7 occurrence(s); all after language-mode guard? True
```

The only things outside the guard are `try/catch`, `Set-Location -LiteralPath`, `Write-Warning` and the user's own startup command. `Set-Location` is an allowed cmdlet in ConstrainedLanguage, and `-LiteralPath` takes a plain string — no type resolution. Every genuinely blocked construct (`[Console]::OutputEncoding`, `[System.Text.UTF8Encoding]::new()`, `[char]27`, `[int](...)`) stays behind the language-mode guard. The `. { }` wrapper itself is plain PowerShell grammar, not a type/method call, so it introduces no new restricted construct — confirmed by the executed runs above, where the new payload works under ConstrainedLanguage.

### 3. Unit tests: fail on `main`, pass with the PR

Sources reverted to `origin/main` while keeping this PR's tests:

```
     × isolates its early-return guards so they cannot abort the caller payload
     × returns PowerShell args that install OSC 133 bootstrap after normal profile loading
     × runs cwd restore and startup command outside the shell-integration guards

 FAIL  src/main/powershell-osc133-bootstrap.test.ts
AssertionError: expected false to be true // Object.is equality
 FAIL  src/main/providers/windows-shell-args.test.ts
AssertionError: expected 4511 to be less than 542
 FAIL  src/main/providers/windows-shell-args.test.ts
AssertionError: expected -1 to be greater than or equal to 0

 Test Files  2 failed (2)
      Tests  3 failed | 26 passed (29)
```

With the PR's sources restored:

```
 Test Files  2 passed (2)
      Tests  29 passed (29)
```

## Proof of no regressions

```
$ npx vitest run --config config/vitest.config.ts src/main/providers/pty \
    src/main/powershell-osc133-bootstrap.test.ts src/main/providers/windows-shell-args.test.ts
 Test Files  5 passed (5)
      Tests  40 passed (40)

$ npx vitest run --config config/vitest.config.ts \
    src/main/providers/local-pty-shell-ready.test.ts src/main/daemon/shell-ready.test.ts
 Test Files  2 passed (2)
      Tests  91 passed (91)

$ npx tsc --noEmit -p config/tsconfig.node.json
TYPECHECK_EXIT=0

$ npx oxlint src/main/powershell-osc133-bootstrap.ts src/main/providers/windows-shell-args.ts \
    src/main/powershell-osc133-bootstrap.test.ts src/main/providers/windows-shell-args.test.ts
(clean — no findings)
```

**Non-PowerShell shells are provably untouched.** `resolveWindowsShellLaunchArgs` output was generated on both `origin/main` and this PR and compared:

```
cmd:     identical old vs new = True
gitbash: identical old vs new = True
wsl:     identical old vs new = True
```

**FullLanguage users are unaffected** — see the two FullLanguage rows in Proof of fix §1: old and new produce identical cwd, identical startup execution, and `osc133=True` in both.

Behavior that **does** change, all of it intended:

- On a ConstrainedLanguage host, the cwd restore and startup command now run instead of being silently dropped.
- On **any** host (FullLanguage included), re-injecting the bootstrap into a session that already has it no longer swallows the cwd restore and startup command. Verified on Windows — injecting the same payload twice into one FullLanguage session:

  ```
  ===== RE-ENTRY powershell.exe / FullLanguage / old_plain.b64 =====
      --- injection 2 (re-entry) ---
      after2 cwd=C:\Windows            <-- swallowed even on FullLanguage
      promptWrapped=True
  ===== RE-ENTRY powershell.exe / FullLanguage / new_plain.b64 =====
      --- injection 2 (re-entry) ---
    MARKER pwd=[...\plain] osc133=True mode=FullLanguage
      after2 cwd=...\prbash-10535\plain
      promptWrapped=True               <-- prompt wrapped exactly once, no double-wrap
  ```

  This means the original bug report understated the scope: the defect was never limited to enterprise ConstrainedLanguage hosts.
- The cwd restore now runs *before* the UTF-8 encoding assignment rather than after. Verified with a non-ASCII directory name (`orca-日本語-café` exists on the test box): `Set-Location` succeeds, and the failure path's `Write-Warning` renders correctly.

## Compatibility

- **Platforms:** Windows-only code path; no macOS or Linux behavior is touched. Executed on real Windows 11 (10.0.26100) against **both** `powershell.exe` 5.1.26100.8875 and `pwsh.exe` 7.6.4.0, in ConstrainedLanguage and FullLanguage. `cmd.exe`, Git Bash and WSL launch args are byte-identical to `main` (shown above).
- **SSH / remote:** No impact. The SSH PowerShell helper (`ssh-remote-powershell.ts`) encodes its own scripts and does not use this bootstrap; the `wsl.exe` branch launches a POSIX login shell, not PowerShell. The two other callers that encode the bootstrap standalone (`local-pty-shell-ready.ts`, `daemon/shell-ready.ts`) append nothing after it, so the wrapper is inert there — their 91 tests pass unchanged.
- **Performance:** No hot-path change. The payload grows by 16 characters (`. {` + `}` + newlines) in a string built once per terminal spawn; no added process spawn, I/O, or per-keystroke work.

## Screenshots

No visual change.

## Testing

- [x] `oxlint` on all four changed files — clean
- [x] `typecheck:node` (`tsc --noEmit -p config/tsconfig.node.json`) — exit 0
- [x] `vitest` — `powershell-osc133-bootstrap` + `windows-shell-args` 29 passed; `pty` suite 40 passed; `local-pty-shell-ready` + `daemon/shell-ready` 91 passed
- [x] Added regression tests; confirmed all 3 fail when the two source files are reverted to `origin/main`
- [x] Manual verification on real Windows 11 against `powershell.exe` 5.1 and `pwsh.exe` 7 (transcripts above)
- [ ] `pnpm build` — not run (no build-affecting change; string-construction only)

## AI Review Report

Reviewed adversarially, re-deriving the defect rather than trusting the description. Checks performed and their outcomes:

- **Is the replacement construct actually ConstrainedLanguage-safe?** The main way this fix could be silently wrong is swapping one blocked construct for another. Every cmdlet and operator now sitting outside the guard was enumerated against ConstrainedLanguage's restrictions (`[type]::Method()`, `New-Object` on arbitrary types, `Add-Type`, type casts) — see Proof of fix §2. Only `try/catch`, `Set-Location -LiteralPath`, and `Write-Warning` are outside; all blocked constructs remain behind the guard. Confirmed by execution, not just by reading.
- **Dot-source language-mode risk** — the known failure where `.` throws *"Cannot dot-source this command because it was defined in a different language mode"*. This does not occur here: the scriptblock is defined and invoked inside the same payload, crossing no trust boundary. The executed ConstrainedLanguage runs confirm no throw and that the statement after the block still runs.
- **Quoting / injection** — see Security Audit.
- **Re-entry** — surfaced a real finding: the defect also affects FullLanguage hosts on re-injection (documented above under behavior changes). Prompt is wrapped exactly once; no double-wrap.
- **Cross-platform** — Windows-only branch; `cmd.exe` / Git Bash / WSL launch args proven byte-identical to `main`. macOS and Linux do not reach this code. No shortcut, label, or path-separator surface is touched.
- **Other callers** — `daemon/shell-ready.ts` and `local-pty-shell-ready.ts` append nothing after the bootstrap, so the wrapper is inert; verified by reading both call sites and running their tests.
- **Brace balance** — an unclosed block would swallow whatever callers append, which is the same class of bug being fixed; asserted directly in the test.

## Security Audit

The only untrusted input reaching the payload is the cwd (plus the user's own startup command, which is user-authored by definition). Quoting is `quoteStartupArg(cwd, 'powershell')` — single-quote wrapping with `''` doubling (`src/shared/tui-agent-startup-shell.ts:79`) — and the consumer is `Set-Location -LiteralPath`.

**PowerShell quoting was tested by execution, not assumed.** A hostile cwd containing a single quote, a space, a `$`, and a backtick round-trips intact in both shells and both language modes:

```
MARKER pwd=[C:\Users\neil\AppData\Local\Temp\prbash-10535\sp ace's $env `tick] ... mode=ConstrainedLanguage
  cwd_after=C:\Users\neil\AppData\Local\Temp\prbash-10535\sp ace's $env `tick
```

A deliberate quote-escape injection attempt is neutralized. For cwd `C:\tmp'; Write-Host PWNED_INJECTION; '` the payload renders the inert literal:

```
try { Set-Location -LiteralPath 'C:\tmp''; Write-Host PWNED_INJECTION; ''' -ErrorAction Stop } catch { ... }
```

Executed in both modes — `PWNED_INJECTION` never appears in the output; only the legitimate startup command runs:

```
===== powershell.exe / ConstrainedLanguage / inj.b64 =====
  ORCA_STARTUP_RAN
===== powershell.exe / FullLanguage / inj.b64 =====
  ORCA_STARTUP_RAN
```

Inside single quotes PowerShell performs no interpolation, so `$` and backtick are literal; `-LiteralPath` additionally neutralizes glob metacharacters such as `[a]`. This quoting is unchanged by the PR — the same helper and the same consumer as on `main`; only the position in the payload moved.

Moving `Set-Location` ahead of the language-mode guard does not widen the attack surface: it is permitted in ConstrainedLanguage and was already reachable on every FullLanguage host. No new command execution, IPC, auth, secret, or dependency surface. Failure degrades to a `Write-Warning` rather than aborting the payload.

## Notes

- **Verification limit — stated plainly.** No true WDAC/AppLocker-enforced host was available. `__PSLockdownPolicy=4` was tried first and is **ignored on this machine** (child sessions of both `powershell.exe` and `pwsh.exe` stayed `FullLanguage`), so ConstrainedLanguage was induced at the engine level via `$ExecutionContext.SessionState.LanguageMode` in the child session, before the payload is parsed. That is a genuine engine-level downgrade and it exercises the exact guard that fires in production, but it does not reproduce WDAC's script-provenance trust boundaries. The lockdown was scoped strictly to child processes; the box was confirmed afterwards to be `FullLanguage` with no `__PSLockdownPolicy` set at process, user, or machine scope.
- The re-entry finding means this is worth backporting attention: FullLanguage users could already hit the swallowed-startup-command symptom.
- Windows-only code path; no macOS or Linux behavior is touched.

Original patch by @OrcaWin.
