### PR TITLE
fix(git): read core.sparseCheckout the way git does

### DIFF
--- a/src/main/git/worktree-sparse-checkout.test.ts
+++ b/src/main/git/worktree-sparse-checkout.test.ts
@@ -193,8 +193,10 @@ describe('parseCoreSparseCheckoutFlag', () => {
   })
 
   it('does not treat trailing junk as a second assignment', () => {
-    // Git rejects this line outright (a value runs to end of line, so only one assignment can share
-    // a line); reading the whole tail as the value keeps us on the conservative "not sparse" side.
+    // Git parses this line fine and takes the whole tail as one value (`git config --list` reports
+    // `core.sparsecheckout=true bogus = false`) — a value runs to end of line, so only one
+    // assignment can share a line. Git then fails the boolean coercion outright, so reading the
+    // whole tail as the value keeps us on the conservative "not sparse" side.
     expect(parseCoreSparseCheckoutFlag('[core] sparseCheckout = true bogus = false\n')).toBe(false)
   })
 })

--- a/src/main/git/worktree-sparse-checkout.test.ts
+++ b/src/main/git/worktree-sparse-checkout.test.ts
@@ -72,6 +72,42 @@ describe('sparse-checkout detection', () => {
       expect(mainWorktree(await listWorktrees(repoPath)).isSparse).toBeFalsy()
     }
   )
+
+  it.skipIf(process.platform === 'win32')(
+    'ignores config.worktree while extensions.worktreeConfig is off',
+    async () => {
+      const repoPath = await createRepoWithTwoDirs()
+
+      git(repoPath, ['sparse-checkout', 'set', 'keep'])
+      git(repoPath, ['config', 'extensions.worktreeConfig', 'false'])
+      git(repoPath, ['config', 'core.sparseCheckout', 'false'])
+      await writeFile(
+        path.join(repoPath, '.git', 'config.worktree'),
+        '[core]\n\tsparseCheckout = true\n'
+      )
+
+      expect(git(repoPath, ['config', '--get', 'core.sparseCheckout']).trim()).toBe('false')
+      expect(mainWorktree(await listWorktrees(repoPath)).isSparse).toBeFalsy()
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'honors config.worktree while extensions.worktreeConfig is on',
+    async () => {
+      const repoPath = await createRepoWithTwoDirs()
+
+      git(repoPath, ['sparse-checkout', 'set', 'keep'])
+      git(repoPath, ['config', 'extensions.worktreeConfig', 'true'])
+      git(repoPath, ['config', 'core.sparseCheckout', 'false'])
+      await writeFile(
+        path.join(repoPath, '.git', 'config.worktree'),
+        '[core]\n\tsparseCheckout = true\n'
+      )
+
+      expect(git(repoPath, ['config', '--get', 'core.sparseCheckout']).trim()).toBe('true')
+      expect(mainWorktree(await listWorktrees(repoPath)).isSparse).toBe(true)
+    }
+  )
 })
 
 describe('parseCoreSparseCheckoutFlag', () => {
@@ -112,5 +148,53 @@ describe('parseCoreSparseCheckoutFlag', () => {
 
   it('ignores an inline comment after the value', () => {
     expect(parseCoreSparseCheckoutFlag('[core]\n\tsparseCheckout = true # on\n')).toBe(true)
+  })
+
+  // Git's config parser is character- not line-based, so a header may be followed on the same line
+  // by the assignment. Every expectation below was confirmed against `git config --file --get`.
+  it('reads an assignment on the same line as the section header', () => {
+    expect(parseCoreSparseCheckoutFlag('[core] sparseCheckout = true\n')).toBe(true)
+    expect(parseCoreSparseCheckoutFlag('[core] sparseCheckout = false\n')).toBe(false)
+    expect(parseCoreSparseCheckoutFlag('[core]sparseCheckout=true\n')).toBe(true)
+    expect(parseCoreSparseCheckoutFlag('[core] sparseCheckout\n')).toBe(true)
+  })
+
+  it('keeps the section open for later lines after a same-line assignment', () => {
+    expect(
+      parseCoreSparseCheckoutFlag('[core] sparseCheckout = false\n\tsparseCheckout = true\n')
+    ).toBe(true)
+  })
+
+  it('lets the last header on a line decide the section', () => {
+    expect(parseCoreSparseCheckoutFlag('[core "sub"] [core] sparseCheckout = true\n')).toBe(true)
+    expect(parseCoreSparseCheckoutFlag('[core] [other] sparseCheckout = true\n')).toBeUndefined()
+  })
+
+  it('ignores a same-line assignment under a [core "subsection"] header', () => {
+    expect(parseCoreSparseCheckoutFlag('[core "sub"] sparseCheckout = true\n')).toBeUndefined()
+  })
+
+  it('honors the last assignment across mixed same-line and indented forms', () => {
+    expect(
+      parseCoreSparseCheckoutFlag(
+        '[core] sparseCheckout = true\n[core]\n\tsparseCheckout = false\n'
+      )
+    ).toBe(false)
+    expect(
+      parseCoreSparseCheckoutFlag(
+        '[core]\n\tsparseCheckout = false\n[core] sparseCheckout = true\n'
+      )
+    ).toBe(true)
+  })
+
+  it('handles comments and whitespace around a same-line header', () => {
+    expect(parseCoreSparseCheckoutFlag('[core]# c\n\tsparseCheckout = true\n')).toBe(true)
+    expect(parseCoreSparseCheckoutFlag('\t[core] sparseCheckout = true ; c\n')).toBe(true)
+  })
+
+  it('does not treat trailing junk as a second assignment', () => {
+    // Git rejects this line outright (a value runs to end of line, so only one assignment can share
+    // a line); reading the whole tail as the value keeps us on the conservative "not sparse" side.
+    expect(parseCoreSparseCheckoutFlag('[core] sparseCheckout = true bogus = false\n')).toBe(false)
   })
 })

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1436,16 +1436,22 @@ async function resolveGitCommonDir(gitDir: string): Promise<string> {
 // `config.worktree`; later files override earlier ones, matching git's config precedence.
 async function isSparseCheckoutEnabled(gitDir: string): Promise<boolean> {
   const commonDir = await resolveGitCommonDir(gitDir)
-  const sharedFlag = await readCoreSparseCheckoutFlag(join(commonDir, 'config'))
-  const worktreeFlag = await readCoreSparseCheckoutFlag(join(gitDir, 'config.worktree'))
-  return worktreeFlag ?? sharedFlag ?? false
+  const sharedConfig = await readGitConfigText(join(commonDir, 'config'))
+  const sharedFlag = parseCoreSparseCheckoutFlag(sharedConfig)
+  // Git reads `config.worktree` only while extensions.worktreeConfig is on; without that gate a
+  // stale worktree config left behind by an earlier sparse checkout overrides the real repo value.
+  if (parseGitConfigFlag(sharedConfig, 'extensions', 'worktreeconfig') !== true) {
+    return sharedFlag ?? false
+  }
+  const worktreeConfig = await readGitConfigText(join(gitDir, 'config.worktree'))
+  return parseCoreSparseCheckoutFlag(worktreeConfig) ?? sharedFlag ?? false
 }
 
-async function readCoreSparseCheckoutFlag(configPath: string): Promise<boolean | undefined> {
+async function readGitConfigText(configPath: string): Promise<string> {
   try {
-    return parseCoreSparseCheckoutFlag(await readFile(configPath, 'utf-8'))
+    return await readFile(configPath, 'utf-8')
   } catch {
-    return undefined
+    return ''
   }
 }
 
@@ -1454,23 +1460,38 @@ async function readCoreSparseCheckoutFlag(configPath: string): Promise<boolean |
 // git-config parsing edge cases can be unit tested without touching the filesystem. Only the last
 // assignment wins, and a `[core "subsection"]` header is intentionally not treated as `[core]`.
 export function parseCoreSparseCheckoutFlag(configContent: string): boolean | undefined {
-  let inCoreSection = false
+  return parseGitConfigFlag(configContent, 'core', 'sparsecheckout')
+}
+
+// A section header may be followed on the same line by further headers and then one assignment
+// (`[core] sparseCheckout = true` is legal git config); the value runs to end of line, so at most
+// one assignment can share a line and the last header before it decides the section.
+const GIT_CONFIG_SECTION_HEADER = /^\[\s*([A-Za-z0-9.-]+)(\s+"(?:[^"\\]|\\.)*")?\s*\]/
+const GIT_CONFIG_ASSIGNMENT = /^([A-Za-z][A-Za-z0-9-]*)\s*(?:=\s*(.*))?$/
+
+// `section` and `key` must be lowercase: git config names are case-insensitive.
+function parseGitConfigFlag(
+  configContent: string,
+  section: string,
+  key: string
+): boolean | undefined {
+  let inSection = false
   let value: boolean | undefined
   for (const rawLine of configContent.split(/\r?\n/)) {
-    const line = stripGitConfigComment(rawLine).trim()
-    if (line.length === 0) {
+    let rest = stripGitConfigComment(rawLine).trim()
+    for (
+      let header = rest.match(GIT_CONFIG_SECTION_HEADER);
+      header;
+      header = rest.match(GIT_CONFIG_SECTION_HEADER)
+    ) {
+      inSection = header[1].toLowerCase() === section && header[2] === undefined
+      rest = rest.slice(header[0].length).trim()
+    }
+    if (!inSection || rest.length === 0) {
       continue
     }
-    const sectionHeader = line.match(/^\[\s*([A-Za-z0-9.-]+)(\s+"(?:[^"\\]|\\.)*")?\s*\]$/)
-    if (sectionHeader) {
-      inCoreSection = sectionHeader[1].toLowerCase() === 'core' && sectionHeader[2] === undefined
-      continue
-    }
-    if (!inCoreSection) {
-      continue
-    }
-    const assignment = line.match(/^([A-Za-z][A-Za-z0-9-]*)\s*(?:=\s*(.*))?$/)
-    if (!assignment || assignment[1].toLowerCase() !== 'sparsecheckout') {
+    const assignment = rest.match(GIT_CONFIG_ASSIGNMENT)
+    if (!assignment || assignment[1].toLowerCase() !== key) {
       continue
     }
     value = parseGitConfigBoolean(assignment[2])


### PR DESCRIPTION
## Summary

Sparse-checkout detection (`isSparseCheckoutEnabled` in `src/main/git/worktree.ts`) reads git's config files directly — deliberately, to avoid the per-poll `git sparse-checkout list` subprocess fan-out that PR #1290 removed. Two bugs made it disagree with git:

1. **The section-header regex was anchored `^...$`.** Git's config parser is character-based, not line-based, so a header may be followed by an assignment on the same line. `[core] sparseCheckout = true` matched neither the header branch nor the assignment branch — the line was silently skipped, the parser never entered `[core]`, and detection returned `false`. A genuinely sparse worktree lost its `sparse` badge (`WorktreeCard.tsx`, `WorkspaceSpaceManagerPanel.tsx`) and its partial-checkout warning.
2. **`config.worktree` was read unconditionally.** The function's own comment said it applies "when extensions.worktreeConfig is on", but the extension was never checked. Git honors that file only while `extensions.worktreeConfig=true`, so a stale `config.worktree` left behind by an earlier sparse checkout could override the repo's real setting.

**Fix**

- Consume section headers left-to-right off each line, then match at most one assignment on the remainder. Verified against real git: several headers may share a line (`[core "sub"] [core] x = true` -> the *last* one wins), but a value runs to end of line, so only one assignment can share a line.
- Gate `config.worktree` on `extensions.worktreeConfig` read from the **shared repo config** — exactly git's own rule, and not circular. Confirmed empirically that git honors this extension at `core.repositoryformatversion = 0`, and that `git sparse-checkout` writes the extension to the shared config itself whenever it writes `config.worktree`, so the gate never hides a flag git would have read.

Deliberate existing behaviors are preserved: only the last assignment wins, `[core "subsection"]` is still not treated as `[core]`, comment stripping and the valueless-boolean form (`sparseCheckout` => true) are unchanged.

**The header fix also removes a pre-existing false positive**, in the opposite direction from the bug in the title. A line shaped `[section "sub"]key = value` (header plus assignment on one line) matched *neither* branch of the old anchored regex, so the parser never left `[core]` and credited the following indented line to it:

```
[core]
[core "sub"]worktreeConfig = x
	sparseCheckout = true
```

Git reports `core.sparseCheckout` as unset here; the old parser returned `true`, badging a non-sparse worktree as sparse. The new parser returns unset. Covered by a regression test that fails on the pre-fix parser.

No subprocess, no new git invocation, no capability probing — the Git 2.25 baseline is unaffected, and SSH / WSL / folder-workspace paths are untouched (this reads files through the same fs calls as before). The gate also *removes* an fs read in the common case, since `config.worktree` is no longer opened when the extension is off.

## Screenshots

No visual change. The change restores an existing badge/warning; it does not alter their appearance.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`src/main/git/worktree-sparse-checkout.test.ts`, 21 pass. New: 8 parser cases (same-line assignment incl. no-space and valueless, section stays open for later lines, last-header-wins, subsection same-line, mixed-form last-assignment-wins, comment/whitespace variants, trailing junk, subsection-header-with-same-line-assignment) and 2 real-repo cases for the extension gate that assert `git config --get core.sparseCheckout` agrees with detection.

**Revert-check** (source reverted with `git apply -R`, tests kept): **8 failed | 13 passed**. Restored: **21 passed**. The two new tests that pass either way are intentional regression guards against the *opposite* failure mode (`[core "sub"]` still ignored; `config.worktree` honored when the extension is on).

Full `src/main/git` suite: 39 files, 592 tests, all pass.

## AI Review Report

Reviewed with an AI agent plus two independent adversarial subagents (parser-fuzzing lens; extension-gate/integration lens). Both returned CLEAN; neither disputed the verdict.

Main risks checked and what was found:

- **False positives from loosening the regex** — the primary risk, since wrongly badging a non-sparse worktree is a new bug in the opposite direction. Fuzz vectors were compared against the real git binary (`git config --file --get --type=bool`): BOM, CRLF, `[CORE]`/caps key, quoted `"true"`, quoted value containing `#`, empty value, hyphenated key, `[core "a]b"]`, unterminated quote, `[[core]]`, and `[alias]`/`core.editor` values containing literal `[core] sparseCheckout = true` text. **The parser matches git on all of them, with zero false positives.** A differential sweep over ~5,100 generated configs agreed with git on every git-parseable case, while the pre-fix parser produced 8 false positives and 234 false negatives on the same corpora. On inputs git treats as `fatal`, the parser conservatively yields not-sparse — and those are unreachable anyway, since `git worktree list --porcelain` itself dies on a bad config, so no worktree is ever produced to badge.
- **Badge-loss regression from the new gate** — checked by building a real linked worktree: `git sparse-checkout set` in a linked worktree writes `extensions.worktreeConfig=true` to the *shared* config and `core.sparseCheckout=true` to that worktree's `config.worktree`, at `repositoryformatversion=0`. The new code badges the linked worktree sparse and the main worktree not-sparse, matching git. The gate can therefore never hide a flag git would have honored.
- **Blast radius** — `parseCoreSparseCheckoutFlag` is consumed only by its own test; the removed `readCoreSparseCheckoutFlag` had no other callers.
- **Cross-platform (macOS/Linux/Windows)** — explicitly checked. The source change is pure string parsing plus `path.join`; `split(/\r?\n/)` handles CRLF and `String.trim()` strips a BOM, both verified. No shell invocation, no shortcut/label/accelerator surface, no Electron platform-specific behavior is touched. Verified at runtime on macOS only; the real-repo tests are `skipIf(win32)`, consistent with the pre-existing tests in this file.
- **Git binary compatibility** — no new git invocation, so no `GitCapabilityCache` entry is needed and the Git 2.25 baseline is untouched.

Fixed as a result of review: (a) a test comment claimed git "rejects this line outright" for `[core] sparseCheckout = true bogus = false`; the binary actually parses the line and takes the whole tail as one value (`git config --list` reports `core.sparsecheckout=true bogus = false`), failing only the boolean coercion — comment corrected, expectation unchanged; (b) added the regression test for the false-positive class described above, which previously had no coverage.

## Security Audit

Low risk. No command execution, no IPC, no auth, no secrets, no dependency change. Input handling is the one relevant surface: the parser consumes local git config text, and the regexes were reviewed for catastrophic backtracking — both are linear with no nested unbounded quantifiers, and the header loop strictly shortens the remaining string each iteration, so it terminates. Path handling uses `join` on an already-resolved gitdir with fixed filenames (`config`, `config.worktree`), so there is no user-controlled path component. Read failures fall back to empty text rather than throwing, and every ambiguous or malformed input resolves to "not sparse", which is the non-destructive default.

## Notes

Knowingly not fixed — both are real gaps, both are out of scope for this one-concern PR, since implementing a git-config resolver by hand is a much larger change and a real regression risk:

- **`[include] path = ...` / `includeIf` indirection is ignored**, so a sparse flag reached through an include is missed. Note this cuts both ways: an `[include]`-provided `extensions.worktreeConfig` resolves to `true` under `git config --get`, yet git still does *not* honor `config.worktree`, because `read_repository_format` does not process includes. The direct-file read used here matches git's real behavior; a `git config --get`-based implementation would not.
- **Hierarchical resolution is not implemented.** Git resolves `core.sparseCheckout` across system -> global -> repo -> worktree; this reads repo config + `config.worktree` only. A `--global core.sparseCheckout` would be missed. In practice `git sparse-checkout` always writes repo-scoped, so this is an edge case.

Also pre-existing and deliberately untouched: line continuations (a trailing `\`) are not followed, and a couple of exotic value forms (`sparseCheckout = 2`, `sparseCheckout = tr"ue"`) read as false where git reads true. All are byte-identical before and after this PR, and all are bounded by the fact that the parser is only reached when `<gitdir>/info/sparse-checkout` exists and is non-empty.

Asking git itself instead was considered and rejected: `detectSparseCheckout` runs on the list path, and `listWorktreesStrict` deliberately does not thread its `GitWorktreeExecOptions` into `annotateSparseCheckoutStatus`, so a subprocess could not be routed to the right host (WSL distro / SSH provider / relay). Threading exec options through the whole list path plus a per-host `GitCapabilityCache` entry is a different, larger PR. A narrower "just read the global config file too" shortcut is *worse* than the gap it closes, because on SSH/WSL it would resolve the wrong host's home directory.
