### PR TITLE
fix(codex): treat non-Codex transcript as stale resume metadata

### DIFF
--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  claimsTrustedCodexRolloutLayout,
   findTrustedCodexSessionResume,
   resolveTrustedCodexSessionResumeHome
 } from './codex-session-resume-home'
@@ -222,5 +223,41 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
         listSessionFiles
       })
     ).resolves.toBeNull()
+  })
+})
+
+describe('claimsTrustedCodexRolloutLayout', () => {
+  it('is true for a rollout path under a trusted CODEX_HOME even if the file is missing', () => {
+    expect(
+      claimsTrustedCodexRolloutLayout({
+        transcriptPath: '/Users/example/.codex/sessions/2026/07/20/rollout-session.jsonl',
+        trustedCodexHomes: ['/managed/account/home', '/Users/example/.codex']
+      })
+    ).toBe(true)
+  })
+
+  it('is false for Claude (or other non-Codex) transcript paths', () => {
+    expect(
+      claimsTrustedCodexRolloutLayout({
+        transcriptPath:
+          '/Users/example/.claude/projects/-Users-example-repo/019f81b9-19a9-7651-a8d1-352d9420bd11.jsonl',
+        trustedCodexHomes: ['/Users/example/.codex', '/managed/account/home']
+      })
+    ).toBe(false)
+  })
+
+  it('is false for empty provenance and paths outside trusted homes', () => {
+    expect(
+      claimsTrustedCodexRolloutLayout({
+        transcriptPath: undefined,
+        trustedCodexHomes: ['/Users/example/.codex']
+      })
+    ).toBe(false)
+    expect(
+      claimsTrustedCodexRolloutLayout({
+        transcriptPath: '/tmp/sessions/2026/07/20/rollout-a.jsonl',
+        trustedCodexHomes: ['/Users/example/.codex']
+      })
+    ).toBe(false)
   })
 })

--- a/src/main/codex/codex-session-resume-home.test.ts
+++ b/src/main/codex/codex-session-resume-home.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
-  claimsTrustedCodexRolloutLayout,
+  claimsCodexRolloutLayout,
   findTrustedCodexSessionResume,
   resolveTrustedCodexSessionResumeHome
 } from './codex-session-resume-home'
@@ -226,38 +226,46 @@ describe('resolveTrustedCodexSessionResumeHome', () => {
   })
 })
 
-describe('claimsTrustedCodexRolloutLayout', () => {
-  it('is true for a rollout path under a trusted CODEX_HOME even if the file is missing', () => {
+describe('claimsCodexRolloutLayout', () => {
+  it('is true for a rollout path even if the file is missing', () => {
     expect(
-      claimsTrustedCodexRolloutLayout({
-        transcriptPath: '/Users/example/.codex/sessions/2026/07/20/rollout-session.jsonl',
-        trustedCodexHomes: ['/managed/account/home', '/Users/example/.codex']
-      })
+      claimsCodexRolloutLayout('/Users/example/.codex/sessions/2026/07/20/rollout-session.jsonl')
+    ).toBe(true)
+  })
+
+  it('is true for compressed rollouts and Windows-separated paths', () => {
+    expect(
+      claimsCodexRolloutLayout(
+        '/Users/example/.codex/sessions/2026/07/20/rollout-session.jsonl.zst'
+      )
+    ).toBe(true)
+    expect(
+      claimsCodexRolloutLayout(
+        'C:\\Users\\example\\.codex\\sessions\\2026\\07\\20\\rollout-session.jsonl'
+      )
+    ).toBe(true)
+  })
+
+  it('is true for a rollout under a home Orca no longer trusts, so resume cannot silently fall through to the selected account', () => {
+    expect(
+      claimsCodexRolloutLayout('/removed/account/home/sessions/2026/07/20/rollout-a.jsonl')
     ).toBe(true)
   })
 
   it('is false for Claude (or other non-Codex) transcript paths', () => {
     expect(
-      claimsTrustedCodexRolloutLayout({
-        transcriptPath:
-          '/Users/example/.claude/projects/-Users-example-repo/019f81b9-19a9-7651-a8d1-352d9420bd11.jsonl',
-        trustedCodexHomes: ['/Users/example/.codex', '/managed/account/home']
-      })
+      claimsCodexRolloutLayout(
+        '/Users/example/.claude/projects/-Users-example-repo/019f81b9-19a9-7651-a8d1-352d9420bd11.jsonl'
+      )
     ).toBe(false)
   })
 
-  it('is false for empty provenance and paths outside trusted homes', () => {
+  it('is false for empty provenance and JSONL misplaced inside a sessions root', () => {
+    expect(claimsCodexRolloutLayout(undefined)).toBe(false)
+    expect(claimsCodexRolloutLayout('   ')).toBe(false)
+    expect(claimsCodexRolloutLayout('/Users/example/.codex/sessions/rollout-a.jsonl')).toBe(false)
     expect(
-      claimsTrustedCodexRolloutLayout({
-        transcriptPath: undefined,
-        trustedCodexHomes: ['/Users/example/.codex']
-      })
-    ).toBe(false)
-    expect(
-      claimsTrustedCodexRolloutLayout({
-        transcriptPath: '/tmp/sessions/2026/07/20/rollout-a.jsonl',
-        trustedCodexHomes: ['/Users/example/.codex']
-      })
+      claimsCodexRolloutLayout('/Users/example/.codex/sessions/2026/07/20/nested/rollout-a.jsonl')
     ).toBe(false)
   })
 })

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -76,6 +76,27 @@ export function resolveTrustedCodexSessionResumeHome(args: {
   return resolveTrustedCodexSessionResume(args)?.homePath ?? null
 }
 
+/**
+ * True when transcriptPath sits under a trusted CODEX_HOME sessions rollout layout.
+ * Does not check file existence — used to distinguish rejected Codex provenance
+ * (must hard-fail resume) from cross-agent / non-Codex paths (stale metadata → fresh).
+ */
+export function claimsTrustedCodexRolloutLayout(args: {
+  transcriptPath: string | undefined
+  trustedCodexHomes: readonly string[]
+}): boolean {
+  const persistedPath = args.transcriptPath?.trim()
+  if (!persistedPath) {
+    return false
+  }
+  for (const homePath of args.trustedCodexHomes) {
+    if (isCodexRolloutInsideSessionsRoot(join(homePath, 'sessions'), persistedPath)) {
+      return true
+    }
+  }
+  return false
+}
+
 export async function findTrustedCodexSessionResume(args: {
   sessionId: string
   transcriptPath: string | undefined

--- a/src/main/codex/codex-session-resume-home.ts
+++ b/src/main/codex/codex-session-resume-home.ts
@@ -8,7 +8,10 @@ import {
 import { listCodexSessionRolloutFilesIncrementally } from './codex-session-file-listing'
 
 // Why: only Codex's dated rollout layout may establish account-home provenance; nested/misplaced JSONL must not select credentials.
-const ROLLOUT_RELATIVE_PATH = /^\d{4}\/\d{2}\/\d{2}\/rollout-[^/]+\.jsonl(?:\.zst)?$/
+const DATED_ROLLOUT_TAIL = String.raw`\d{4}/\d{2}/\d{2}/rollout-[^/]+\.jsonl(?:\.zst)?`
+const ROLLOUT_RELATIVE_PATH = new RegExp(`^${DATED_ROLLOUT_TAIL}$`)
+// Why: case-insensitive because trusted-home matching folds Windows path case too.
+const CODEX_ROLLOUT_LAYOUT_PATH = new RegExp(`(?:^|/)sessions/${DATED_ROLLOUT_TAIL}$`, 'i')
 
 function isCodexRolloutInsideSessionsRoot(sessionsRoot: string, filePath: string): boolean {
   const relativePath = relativePathInsideRoot(sessionsRoot, filePath)
@@ -77,24 +80,17 @@ export function resolveTrustedCodexSessionResumeHome(args: {
 }
 
 /**
- * True when transcriptPath sits under a trusted CODEX_HOME sessions rollout layout.
- * Does not check file existence — used to distinguish rejected Codex provenance
- * (must hard-fail resume) from cross-agent / non-Codex paths (stale metadata → fresh).
+ * True when transcriptPath claims Codex's dated rollout layout, under any home and without
+ * checking existence — separating rejected Codex provenance from cross-agent/stale metadata.
+ * Not scoped to trusted homes: a rollout under a removed home is still rejected provenance,
+ * and admitting it would resume that session under whichever account is selected now.
  */
-export function claimsTrustedCodexRolloutLayout(args: {
-  transcriptPath: string | undefined
-  trustedCodexHomes: readonly string[]
-}): boolean {
-  const persistedPath = args.transcriptPath?.trim()
+export function claimsCodexRolloutLayout(transcriptPath: string | undefined): boolean {
+  const persistedPath = transcriptPath?.trim()
   if (!persistedPath) {
     return false
   }
-  for (const homePath of args.trustedCodexHomes) {
-    if (isCodexRolloutInsideSessionsRoot(join(homePath, 'sessions'), persistedPath)) {
-      return true
-    }
-  }
-  return false
+  return CODEX_ROLLOUT_LAYOUT_PATH.test(persistedPath.replace(/\\/g, '/'))
 }
 
 export async function findTrustedCodexSessionResume(args: {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -168,7 +168,10 @@ import { startCodexSessionIndexHealInBackground } from './codex/codex-session-in
 import { createCodexSessionMigrationScheduler } from './codex/codex-session-migration-scheduler'
 import { prepareLegacySharedCodexSessionResume } from './codex/codex-legacy-session-resume'
 import { resolveHostCodexSessionSourceHome } from './codex/codex-session-source-home'
-import { findTrustedCodexSessionResume } from './codex/codex-session-resume-home'
+import {
+  claimsTrustedCodexRolloutLayout,
+  findTrustedCodexSessionResume
+} from './codex/codex-session-resume-home'
 import { getSystemCodexHomePath } from './codex/codex-home-paths'
 import { normalizeRuntimePathForComparison } from '../shared/cross-platform-path'
 import type { AgentProviderSessionMetadata } from '../shared/agent-session-resume'
@@ -850,7 +853,15 @@ async function prepareCodexSessionResumeForLaunch(args: {
     trustedCodexHomes: trustedHomes
   })
   if (!sessionSource) {
-    if (args.providerSession.transcriptPath) {
+    // Why: only block when path claimed Codex rollout provenance under a trusted home but failed
+    // verification. Cross-agent/stale paths (e.g. ~/.claude/… with agent mislabeled "codex") must
+    // start fresh instead of hard-failing resume.
+    if (
+      claimsTrustedCodexRolloutLayout({
+        transcriptPath: args.providerSession.transcriptPath,
+        trustedCodexHomes: trustedHomes
+      })
+    ) {
       throw new Error(
         'Orca could not verify the originating Codex session file, so automatic resume was stopped to avoid using a different account.'
       )

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -169,7 +169,7 @@ import { createCodexSessionMigrationScheduler } from './codex/codex-session-migr
 import { prepareLegacySharedCodexSessionResume } from './codex/codex-legacy-session-resume'
 import { resolveHostCodexSessionSourceHome } from './codex/codex-session-source-home'
 import {
-  claimsTrustedCodexRolloutLayout,
+  claimsCodexRolloutLayout,
   findTrustedCodexSessionResume
 } from './codex/codex-session-resume-home'
 import { getSystemCodexHomePath } from './codex/codex-home-paths'
@@ -853,15 +853,9 @@ async function prepareCodexSessionResumeForLaunch(args: {
     trustedCodexHomes: trustedHomes
   })
   if (!sessionSource) {
-    // Why: only block when path claimed Codex rollout provenance under a trusted home but failed
-    // verification. Cross-agent/stale paths (e.g. ~/.claude/… with agent mislabeled "codex") must
-    // start fresh instead of hard-failing resume.
-    if (
-      claimsTrustedCodexRolloutLayout({
-        transcriptPath: args.providerSession.transcriptPath,
-        trustedCodexHomes: trustedHomes
-      })
-    ) {
+    // Why: an unverifiable Codex rollout still blocks; only paths that never claimed Codex
+    // provenance (e.g. ~/.claude/… on a pane mislabeled "codex") fall through to a normal launch.
+    if (claimsCodexRolloutLayout(args.providerSession.transcriptPath)) {
       throw new Error(
         'Orca could not verify the originating Codex session file, so automatic resume was stopped to avoid using a different account.'
       )


### PR DESCRIPTION
## Summary

Fixes #10517: panes mislabeled `agent: "codex"` while still holding a Claude `transcriptPath` (e.g. `~/.claude/projects/...`) hard-failed auto-resume with:

> Orca could not verify the originating Codex session file...

The resume guard treated **any** non-empty `transcriptPath` that failed trusted Codex verification as an account-safety hard fail. That is correct when the path claims a Codex rollout, but wrong when the path is cross-agent / stale metadata after a pane was reclassified (Claude running `codex exec`, etc.).

### Change

- Add `claimsCodexRolloutLayout` — true when `transcriptPath` sits in Codex's dated rollout layout (`sessions/YYYY/MM/DD/rollout-*.jsonl[.zst]`), under **any** home and without requiring the file to exist.
- In `prepareCodexSessionResumeForLaunch`, **throw only** when that claim is true and verification still failed.
- Paths that never claimed Codex provenance return `null`, so the pane relaunches instead of being blocked.

Account-safety for real Codex provenance is unchanged: a rollout-shaped path that cannot be verified still hard-fails, including one under a home Orca no longer trusts.

### Why shape and not trust

Scoping the check to *currently trusted* homes would let a real Codex rollout under an untrusted home (a removed managed account, or the import-only `codexSessionSourceHome`) skip the throw. That matters because returning `null` only declines to override `CODEX_HOME` — the renderer has already baked `codex resume <id>` into the command (`agent-session-resume.ts:241`) and `pty.ts` never rewrites it, so the session would resume under whichever account is selected. Once #10770's session bridge hardlinks rollouts across homes preserving the session-id filename, codex would *find* that id and resume silently under the wrong account. Trust is already decided upstream by `findTrustedCodexSessionResume`; the question this guard asks is whether the path claims Codex provenance at all.

### What `null` actually does

It declines to override `CODEX_HOME` — it does **not** rewrite the launch command. The pane relaunches into a usable terminal and codex reports the stale id as not found, rather than Orca blocking the spawn outright. Actually starting fresh means dropping the resume argv renderer-side; tracked in #10793. Root cause (keeping `agent` and `providerSession` in sync on reclassification) is #10792.

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/codex/`
- [x] `pnpm typecheck`, `pnpm lint`
- [x] Manual: Claude-path pane mislabeled codex → relaunches, no hard-fail error
- [x] Manual: real Codex resume with valid rollout path still works, history intact
- [x] Manual: rejected Codex path under trusted home still blocks
- [x] Manual: real rollout under an *untrusted* home still blocks (the case this guard turns on)

Live-validated against a real Orca dev build; details in the review comments below.