### PR TITLE
fix(relay): stop permanently caching a failed OpenSSH DefaultShell probe

### DIFF
--- a/src/relay/openssh-default-shell.test.ts
+++ b/src/relay/openssh-default-shell.test.ts
@@ -32,6 +32,13 @@ function timeoutError(): Error {
   })
 }
 
+/** The rejection Node surfaces when reg.exe cannot be spawned at all. */
+function spawnFailureError(): Error {
+  // Why: spawn failures report killed/signal as `undefined` and a *string* code,
+  // unlike the numeric exit code of a probe that actually ran.
+  return Object.assign(new Error('spawn reg.exe ENOENT'), { code: 'ENOENT' })
+}
+
 /** Drive the promisified execFile callback with a per-attempt outcome. */
 function mockAttempts(outcomes: (string | Error)[]): { attempts: () => number } {
   let attempt = 0
@@ -106,6 +113,20 @@ describe('readOpenSshDefaultShell', () => {
     expect(await readOpenSshDefaultShell()).toBe('')
     expect(await readOpenSshDefaultShell()).toBe('')
     expect(attempts()).toBe(1)
+  })
+
+  it('retries when reg.exe could not be spawned at all', async () => {
+    // Why pinned: a spawn failure carries a string `code`, so `typeof code === 'number'`
+    // is the only thing keeping it retryable rather than cached for the process lifetime.
+    vi.useFakeTimers()
+    const { attempts } = mockAttempts([spawnFailureError(), regOutput(POWERSHELL_7)])
+    const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
+
+    expect(await readOpenSshDefaultShell()).toBe('')
+    vi.advanceTimersByTime(OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS)
+
+    expect(await readOpenSshDefaultShell()).toBe(POWERSHELL_7)
+    expect(attempts()).toBe(2)
   })
 
   it('retries after a transient failure and then returns the real DefaultShell', async () => {

--- a/src/relay/openssh-default-shell.test.ts
+++ b/src/relay/openssh-default-shell.test.ts
@@ -23,6 +23,15 @@ function valueNotSetError(): Error {
   })
 }
 
+function accessDeniedError(): Error {
+  return Object.assign(new Error('Command failed: reg.exe query'), {
+    code: 1,
+    killed: false,
+    signal: null,
+    stderr: 'ERROR: Access is denied.'
+  })
+}
+
 /** The rejection Node surfaces when the `timeout` option kills reg.exe. */
 function timeoutError(): Error {
   return Object.assign(new Error('Command failed: reg.exe query'), {
@@ -37,6 +46,14 @@ function spawnFailureError(): Error {
   // Why: spawn failures report killed/signal as `undefined` and a *string* code,
   // unlike the numeric exit code of a probe that actually ran.
   return Object.assign(new Error('spawn reg.exe ENOENT'), { code: 'ENOENT' })
+}
+
+function registryParentOutput(includeOpenSsh: boolean): string {
+  return [
+    'HKEY_LOCAL_MACHINE\\SOFTWARE',
+    'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft',
+    ...(includeOpenSsh ? ['HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH'] : [])
+  ].join('\n')
 }
 
 /** Drive the promisified execFile callback with a per-attempt outcome. */
@@ -80,25 +97,22 @@ describe('readOpenSshDefaultShell', () => {
     expect(attempts()).toBe(1)
     expect(execFileMock).toHaveBeenCalledWith(
       'reg.exe',
-      ['query', 'HKLM\\SOFTWARE\\OpenSSH', '/v', 'DefaultShell'],
+      ['query', 'HKLM\\SOFTWARE\\OpenSSH'],
       { encoding: 'utf8', timeout: 3000, windowsHide: true },
       expect.any(Function)
     )
   })
 
-  it('permanently caches "no DefaultShell set", which reg.exe reports as a non-zero exit', async () => {
-    // REGRESSION: on a default OpenSSH install the value does not exist, so reg.exe
-    // exits 1. Treating that as a probe failure would re-spawn reg.exe every cooldown
-    // for the life of the relay; it is an authoritative answer, so cache it.
+  it('permanently caches a missing OpenSSH registry key', async () => {
     vi.useFakeTimers()
-    const { attempts } = mockAttempts([valueNotSetError()])
+    const { attempts } = mockAttempts([valueNotSetError(), registryParentOutput(false)])
     const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
 
     expect(await readOpenSshDefaultShell()).toBe('')
     vi.advanceTimersByTime(OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS * 10)
 
     expect(await readOpenSshDefaultShell()).toBe('')
-    expect(attempts()).toBe(1)
+    expect(attempts()).toBe(2)
   })
 
   it('permanently caches a successful query that carries no DefaultShell value', async () => {
@@ -144,6 +158,22 @@ describe('readOpenSshDefaultShell', () => {
     expect(attempts()).toBe(2)
   })
 
+  it('retries access denied instead of permanently caching it as no DefaultShell', async () => {
+    vi.useFakeTimers()
+    const { attempts } = mockAttempts([
+      accessDeniedError(),
+      registryParentOutput(true),
+      regOutput(POWERSHELL_7)
+    ])
+    const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
+
+    expect(await readOpenSshDefaultShell()).toBe('')
+    vi.advanceTimersByTime(OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS)
+
+    expect(await readOpenSshDefaultShell()).toBe(POWERSHELL_7)
+    expect(attempts()).toBe(3)
+  })
+
   it('does not re-probe in a tight loop while a failure is still fresh', async () => {
     // Why: retryable must not mean "retried per PTY spawn" — a wedged reg.exe would
     // otherwise get a new subprocess for every spawn on the relay.
@@ -159,17 +189,30 @@ describe('readOpenSshDefaultShell', () => {
     expect(attempts()).toBe(1)
   })
 
-  it('shares one in-flight probe across concurrent callers', async () => {
-    const { attempts } = mockAttempts([regOutput(POWERSHELL_7)])
-    const { readOpenSshDefaultShell } = await loadModule()
+  it('shares failing and retrying probes, then clears the in-flight promise', async () => {
+    vi.useFakeTimers()
+    const callbacks: ((error: unknown, result: { stdout: string; stderr: string }) => void)[] = []
+    execFileMock.mockImplementation(
+      (_command: string, _args: string[], _opts: unknown, callback: never) => {
+        callbacks.push(callback as (typeof callbacks)[number])
+      }
+    )
+    const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
 
-    const results = await Promise.all([
-      readOpenSshDefaultShell(),
-      readOpenSshDefaultShell(),
-      readOpenSshDefaultShell()
-    ])
+    const first = readOpenSshDefaultShell()
+    const firstJoiner = readOpenSshDefaultShell()
+    expect(callbacks).toHaveLength(1)
 
-    expect(results).toEqual([POWERSHELL_7, POWERSHELL_7, POWERSHELL_7])
-    expect(attempts()).toBe(1)
+    callbacks[0](timeoutError(), { stdout: '', stderr: '' })
+    await expect(Promise.all([first, firstJoiner])).resolves.toEqual(['', ''])
+    vi.advanceTimersByTime(OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS)
+
+    const retry = readOpenSshDefaultShell()
+    const retryJoiner = readOpenSshDefaultShell()
+    expect(callbacks).toHaveLength(2)
+
+    callbacks[1](null, { stdout: regOutput(POWERSHELL_7), stderr: '' })
+    await expect(Promise.all([retry, retryJoiner])).resolves.toEqual([POWERSHELL_7, POWERSHELL_7])
+    expect(execFileMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/relay/openssh-default-shell.test.ts
+++ b/src/relay/openssh-default-shell.test.ts
@@ -3,7 +3,7 @@ import type * as OpenSshDefaultShellModule from './openssh-default-shell'
 
 const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
 
-vi.mock('child_process', () => ({ execFile: execFileMock }))
+vi.mock('node:child_process', () => ({ execFile: execFileMock }))
 
 const POWERSHELL_7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
 
@@ -11,6 +11,25 @@ function regOutput(value: string): string {
   return ['HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH', `    DefaultShell    REG_SZ    ${value}`].join(
     '\n'
   )
+}
+
+/** The rejection Node surfaces when reg.exe runs but the value is not set. */
+function valueNotSetError(): Error {
+  return Object.assign(new Error('Command failed: reg.exe query'), {
+    code: 1,
+    killed: false,
+    signal: null,
+    stderr: 'ERROR: The system was unable to find the specified registry key or value.'
+  })
+}
+
+/** The rejection Node surfaces when the `timeout` option kills reg.exe. */
+function timeoutError(): Error {
+  return Object.assign(new Error('Command failed: reg.exe query'), {
+    code: null,
+    killed: true,
+    signal: 'SIGTERM'
+  })
 }
 
 /** Drive the promisified execFile callback with a per-attempt outcome. */
@@ -60,9 +79,22 @@ describe('readOpenSshDefaultShell', () => {
     )
   })
 
-  it('permanently caches a successful "no DefaultShell set" answer', async () => {
-    // Why: a successful query that found nothing is authoritative — unlike a failed
-    // query, re-probing it forever would be pure waste.
+  it('permanently caches "no DefaultShell set", which reg.exe reports as a non-zero exit', async () => {
+    // REGRESSION: on a default OpenSSH install the value does not exist, so reg.exe
+    // exits 1. Treating that as a probe failure would re-spawn reg.exe every cooldown
+    // for the life of the relay; it is an authoritative answer, so cache it.
+    vi.useFakeTimers()
+    const { attempts } = mockAttempts([valueNotSetError()])
+    const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
+
+    expect(await readOpenSshDefaultShell()).toBe('')
+    vi.advanceTimersByTime(OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS * 10)
+
+    expect(await readOpenSshDefaultShell()).toBe('')
+    expect(attempts()).toBe(1)
+  })
+
+  it('permanently caches a successful query that carries no DefaultShell value', async () => {
     const { attempts } = mockAttempts([
       [
         'HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH',
@@ -81,7 +113,7 @@ describe('readOpenSshDefaultShell', () => {
     // lifetime of the relay process, so the host's configured OpenSSH shell was
     // never honored again until restart.
     vi.useFakeTimers()
-    const { attempts } = mockAttempts([new Error('reg.exe timed out'), regOutput(POWERSHELL_7)])
+    const { attempts } = mockAttempts([timeoutError(), regOutput(POWERSHELL_7)])
     const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
 
     expect(await readOpenSshDefaultShell()).toBe('')
@@ -95,7 +127,7 @@ describe('readOpenSshDefaultShell', () => {
     // Why: retryable must not mean "retried per PTY spawn" — a wedged reg.exe would
     // otherwise get a new subprocess for every spawn on the relay.
     vi.useFakeTimers()
-    const { attempts } = mockAttempts([new Error('reg.exe failed')])
+    const { attempts } = mockAttempts([timeoutError()])
     const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
 
     expect(await readOpenSshDefaultShell()).toBe('')

--- a/src/relay/openssh-default-shell.test.ts
+++ b/src/relay/openssh-default-shell.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as OpenSshDefaultShellModule from './openssh-default-shell'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+
+vi.mock('child_process', () => ({ execFile: execFileMock }))
+
+const POWERSHELL_7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
+
+function regOutput(value: string): string {
+  return ['HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH', `    DefaultShell    REG_SZ    ${value}`].join(
+    '\n'
+  )
+}
+
+/** Drive the promisified execFile callback with a per-attempt outcome. */
+function mockAttempts(outcomes: (string | Error)[]): { attempts: () => number } {
+  let attempt = 0
+  execFileMock.mockImplementation(
+    (_command: string, _args: string[], _opts: unknown, cb: never) => {
+      const callback = cb as (err: unknown, result: { stdout: string; stderr: string }) => void
+      const outcome = outcomes[Math.min(attempt, outcomes.length - 1)]
+      attempt += 1
+      if (outcome instanceof Error) {
+        callback(outcome, { stdout: '', stderr: '' })
+        return
+      }
+      callback(null, { stdout: outcome, stderr: '' })
+    }
+  )
+  return { attempts: () => attempt }
+}
+
+async function loadModule(): Promise<typeof OpenSshDefaultShellModule> {
+  return import('./openssh-default-shell')
+}
+
+beforeEach(() => {
+  vi.resetModules()
+  execFileMock.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('readOpenSshDefaultShell', () => {
+  it('reads and permanently caches a successful DefaultShell', async () => {
+    const { attempts } = mockAttempts([regOutput(POWERSHELL_7)])
+    const { readOpenSshDefaultShell } = await loadModule()
+
+    expect(await readOpenSshDefaultShell()).toBe(POWERSHELL_7)
+    expect(await readOpenSshDefaultShell()).toBe(POWERSHELL_7)
+    expect(attempts()).toBe(1)
+    expect(execFileMock).toHaveBeenCalledWith(
+      'reg.exe',
+      ['query', 'HKLM\\SOFTWARE\\OpenSSH', '/v', 'DefaultShell'],
+      { encoding: 'utf8', timeout: 3000, windowsHide: true },
+      expect.any(Function)
+    )
+  })
+
+  it('permanently caches a successful "no DefaultShell set" answer', async () => {
+    // Why: a successful query that found nothing is authoritative — unlike a failed
+    // query, re-probing it forever would be pure waste.
+    const { attempts } = mockAttempts([
+      [
+        'HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH',
+        '    DefaultShellCommandOption    REG_SZ    /c'
+      ].join('\n')
+    ])
+    const { readOpenSshDefaultShell } = await loadModule()
+
+    expect(await readOpenSshDefaultShell()).toBe('')
+    expect(await readOpenSshDefaultShell()).toBe('')
+    expect(attempts()).toBe(1)
+  })
+
+  it('retries after a transient failure and then returns the real DefaultShell', async () => {
+    // REGRESSION: a single transient reg.exe error used to memoize '' for the
+    // lifetime of the relay process, so the host's configured OpenSSH shell was
+    // never honored again until restart.
+    vi.useFakeTimers()
+    const { attempts } = mockAttempts([new Error('reg.exe timed out'), regOutput(POWERSHELL_7)])
+    const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
+
+    expect(await readOpenSshDefaultShell()).toBe('')
+    vi.advanceTimersByTime(OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS)
+
+    expect(await readOpenSshDefaultShell()).toBe(POWERSHELL_7)
+    expect(attempts()).toBe(2)
+  })
+
+  it('does not re-probe in a tight loop while a failure is still fresh', async () => {
+    // Why: retryable must not mean "retried per PTY spawn" — a wedged reg.exe would
+    // otherwise get a new subprocess for every spawn on the relay.
+    vi.useFakeTimers()
+    const { attempts } = mockAttempts([new Error('reg.exe failed')])
+    const { readOpenSshDefaultShell, OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS } = await loadModule()
+
+    expect(await readOpenSshDefaultShell()).toBe('')
+    vi.advanceTimersByTime(OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS - 1)
+    expect(await readOpenSshDefaultShell()).toBe('')
+    expect(await readOpenSshDefaultShell()).toBe('')
+
+    expect(attempts()).toBe(1)
+  })
+
+  it('shares one in-flight probe across concurrent callers', async () => {
+    const { attempts } = mockAttempts([regOutput(POWERSHELL_7)])
+    const { readOpenSshDefaultShell } = await loadModule()
+
+    const results = await Promise.all([
+      readOpenSshDefaultShell(),
+      readOpenSshDefaultShell(),
+      readOpenSshDefaultShell()
+    ])
+
+    expect(results).toEqual([POWERSHELL_7, POWERSHELL_7, POWERSHELL_7])
+    expect(attempts()).toBe(1)
+  })
+})

--- a/src/relay/openssh-default-shell.ts
+++ b/src/relay/openssh-default-shell.ts
@@ -32,8 +32,15 @@ let inFlight: Promise<string> | undefined
  * install, where the value simply does not exist — which is authoritative, not a
  * failure. Only a probe killed by the timeout or that failed to spawn is retryable.
  * Why exit code and not stderr text: reg.exe messages are localized.
+ *
+ * "Access is denied" also exits non-zero and so caches for the process lifetime.
+ * That matches the pre-async behavior, and a registry ACL does not flap the way a
+ * timeout does.
  */
 function probeCompleted(error: unknown): boolean {
+  // Why loose `== null`: a spawn failure (reg.exe missing) reports killed/signal as
+  // `undefined` rather than false/null, and carries a string `code` like 'ENOENT'.
+  // The `typeof code === 'number'` guard is what keeps those retryable.
   const { killed, signal, code } = (error ?? {}) as {
     killed?: boolean
     signal?: NodeJS.Signals | null
@@ -61,7 +68,7 @@ export async function readOpenSshDefaultShell(): Promise<string> {
   if (probe?.kind === 'resolved') {
     return probe.shell
   }
-  if (probe?.kind === 'failed' && Date.now() < probe.retryAtMs) {
+  if (probe?.kind === 'failed' && performance.now() < probe.retryAtMs) {
     return ''
   }
   // Why: share one in-flight probe so concurrent spawns don't each launch reg.exe.
@@ -73,7 +80,12 @@ export async function readOpenSshDefaultShell(): Promise<string> {
     .catch((error: unknown) => {
       probe = probeCompleted(error)
         ? { kind: 'resolved', shell: '' }
-        : { kind: 'failed', retryAtMs: Date.now() + OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS }
+        : {
+            kind: 'failed',
+            // Why monotonic: an NTP correction or VM resume must not stretch a 30s
+            // cooldown into an hour of not honoring the configured shell.
+            retryAtMs: performance.now() + OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS
+          }
       return ''
     })
     .finally(() => {

--- a/src/relay/openssh-default-shell.ts
+++ b/src/relay/openssh-default-shell.ts
@@ -1,0 +1,65 @@
+import { execFile as execFileCb } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFile = promisify(execFileCb)
+
+const OPENSSH_REGISTRY_KEY = 'HKLM\\SOFTWARE\\OpenSSH'
+const QUERY_TIMEOUT_MS = 3000
+// Why: a failed probe must stay retryable, but a relay admitting a burst of PTY
+// spawns must not re-run reg.exe once per spawn while the failure persists.
+export const OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS = 30_000
+
+/**
+ * Three distinct outcomes, deliberately not collapsed into `''`:
+ * - `undefined` — never probed.
+ * - `resolved` — the registry answered; `shell` is `''` when no DefaultShell is set.
+ *   Cached for the process lifetime, same as before.
+ * - `failed` — the probe itself failed. Suppresses re-probing only until `retryAtMs`,
+ *   so one transient registry error cannot permanently stop honoring the host's
+ *   configured OpenSSH shell.
+ */
+type DefaultShellProbe =
+  | { readonly kind: 'resolved'; readonly shell: string }
+  | { readonly kind: 'failed'; readonly retryAtMs: number }
+
+let probe: DefaultShellProbe | undefined
+let inFlight: Promise<string> | undefined
+
+async function queryDefaultShell(): Promise<string> {
+  const { stdout } = await execFile(
+    'reg.exe',
+    ['query', OPENSSH_REGISTRY_KEY, '/v', 'DefaultShell'],
+    { encoding: 'utf8', timeout: QUERY_TIMEOUT_MS, windowsHide: true }
+  )
+  const match = stdout.match(/^\s*DefaultShell\s+REG_\w+\s+(.+?)\s*$/im)
+  return match?.[1] ?? ''
+}
+
+/**
+ * Read the OpenSSH `DefaultShell` registry value, or `''` when none is set or the
+ * probe is in its post-failure cooldown. Async so a slow registry read cannot stall
+ * the relay's event loop.
+ */
+export async function readOpenSshDefaultShell(): Promise<string> {
+  if (probe?.kind === 'resolved') {
+    return probe.shell
+  }
+  if (probe?.kind === 'failed' && Date.now() < probe.retryAtMs) {
+    return ''
+  }
+  // Why: share one in-flight probe so concurrent spawns don't each launch reg.exe.
+  inFlight ??= queryDefaultShell()
+    .then((shell) => {
+      probe = { kind: 'resolved', shell }
+      return shell
+    })
+    .catch(() => {
+      probe = { kind: 'failed', retryAtMs: Date.now() + OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS }
+      return ''
+    })
+    .finally(() => {
+      inFlight = undefined
+    })
+
+  return inFlight
+}

--- a/src/relay/openssh-default-shell.ts
+++ b/src/relay/openssh-default-shell.ts
@@ -12,9 +12,10 @@ export const OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS = 30_000
 /**
  * Three distinct outcomes, deliberately not collapsed into `''`:
  * - `undefined` — never probed.
- * - `resolved` — the registry answered; `shell` is `''` when no DefaultShell is set.
- *   Cached for the process lifetime, same as before.
- * - `failed` — the probe itself failed. Suppresses re-probing only until `retryAtMs`,
+ * - `resolved` — reg.exe answered; `shell` is `''` when no DefaultShell is set
+ *   (which reg.exe reports as a non-zero exit). Cached for the process lifetime,
+ *   same as before.
+ * - `failed` — the probe never completed. Suppresses re-probing only until `retryAtMs`,
  *   so one transient registry error cannot permanently stop honoring the host's
  *   configured OpenSSH shell.
  */
@@ -24,6 +25,22 @@ type DefaultShellProbe =
 
 let probe: DefaultShellProbe | undefined
 let inFlight: Promise<string> | undefined
+
+/**
+ * Did reg.exe run to completion and answer, or did the probe itself never finish?
+ * A non-zero exit means "DefaultShell is not readable/set" — the default OpenSSH
+ * install, where the value simply does not exist — which is authoritative, not a
+ * failure. Only a probe killed by the timeout or that failed to spawn is retryable.
+ * Why exit code and not stderr text: reg.exe messages are localized.
+ */
+function probeCompleted(error: unknown): boolean {
+  const { killed, signal, code } = (error ?? {}) as {
+    killed?: boolean
+    signal?: NodeJS.Signals | null
+    code?: number | string | null
+  }
+  return killed !== true && signal == null && typeof code === 'number'
+}
 
 async function queryDefaultShell(): Promise<string> {
   const { stdout } = await execFile(
@@ -53,8 +70,10 @@ export async function readOpenSshDefaultShell(): Promise<string> {
       probe = { kind: 'resolved', shell }
       return shell
     })
-    .catch(() => {
-      probe = { kind: 'failed', retryAtMs: Date.now() + OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS }
+    .catch((error: unknown) => {
+      probe = probeCompleted(error)
+        ? { kind: 'resolved', shell: '' }
+        : { kind: 'failed', retryAtMs: Date.now() + OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS }
       return ''
     })
     .finally(() => {

--- a/src/relay/openssh-default-shell.ts
+++ b/src/relay/openssh-default-shell.ts
@@ -3,8 +3,11 @@ import { promisify } from 'node:util'
 
 const execFile = promisify(execFileCb)
 
-const OPENSSH_REGISTRY_KEY = 'HKLM\\SOFTWARE\\OpenSSH'
+const OPENSSH_REGISTRY_PARENT_KEY = 'HKLM\\SOFTWARE'
+const OPENSSH_REGISTRY_KEY = `${OPENSSH_REGISTRY_PARENT_KEY}\\OpenSSH`
+const OPENSSH_REGISTRY_OUTPUT_KEY = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\OPENSSH'
 const QUERY_TIMEOUT_MS = 3000
+const QUERY_OPTIONS = { encoding: 'utf8', timeout: QUERY_TIMEOUT_MS, windowsHide: true } as const
 // Why: a failed probe must stay retryable, but a relay admitting a burst of PTY
 // spawns must not re-run reg.exe once per spawn while the failure persists.
 export const OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS = 30_000
@@ -12,12 +15,11 @@ export const OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS = 30_000
 /**
  * Three distinct outcomes, deliberately not collapsed into `''`:
  * - `undefined` — never probed.
- * - `resolved` — reg.exe answered; `shell` is `''` when no DefaultShell is set
- *   (which reg.exe reports as a non-zero exit). Cached for the process lifetime,
- *   same as before.
- * - `failed` — the probe never completed. Suppresses re-probing only until `retryAtMs`,
- *   so one transient registry error cannot permanently stop honoring the host's
- *   configured OpenSSH shell.
+ * - `resolved` — the registry answered; `shell` is `''` when the key or value is
+ *   absent. Cached for the process lifetime, same as before.
+ * - `failed` — the probe could not establish an answer. Suppresses re-probing only
+ *   until `retryAtMs`, so one transient registry error cannot permanently stop
+ *   honoring the host's configured OpenSSH shell.
  */
 type DefaultShellProbe =
   | { readonly kind: 'resolved'; readonly shell: string }
@@ -26,37 +28,42 @@ type DefaultShellProbe =
 let probe: DefaultShellProbe | undefined
 let inFlight: Promise<string> | undefined
 
-/**
- * Did reg.exe run to completion and answer, or did the probe itself never finish?
- * A non-zero exit means "DefaultShell is not readable/set" — the default OpenSSH
- * install, where the value simply does not exist — which is authoritative, not a
- * failure. Only a probe killed by the timeout or that failed to spawn is retryable.
- * Why exit code and not stderr text: reg.exe messages are localized.
- *
- * "Access is denied" also exits non-zero and so caches for the process lifetime.
- * That matches the pre-async behavior, and a registry ACL does not flap the way a
- * timeout does.
- */
-function probeCompleted(error: unknown): boolean {
-  // Why loose `== null`: a spawn failure (reg.exe missing) reports killed/signal as
-  // `undefined` rather than false/null, and carries a string `code` like 'ENOENT'.
-  // The `typeof code === 'number'` guard is what keeps those retryable.
-  const { killed, signal, code } = (error ?? {}) as {
-    killed?: boolean
-    signal?: NodeJS.Signals | null
-    code?: number | string | null
-  }
-  return killed !== true && signal == null && typeof code === 'number'
+function hasNumericExitCode(error: unknown): boolean {
+  return typeof (error as { code?: unknown } | null)?.code === 'number'
+}
+
+function parseDefaultShell(output: string): string {
+  const match = output.match(/^\s*DefaultShell\s+REG_\w+\s+(.+?)\s*$/im)
+  return match?.[1] ?? ''
+}
+
+function outputContainsOpenSshKey(output: string): boolean {
+  return output
+    .split(/\r?\n/)
+    .some((line) => line.trim().toUpperCase() === OPENSSH_REGISTRY_OUTPUT_KEY)
 }
 
 async function queryDefaultShell(): Promise<string> {
-  const { stdout } = await execFile(
-    'reg.exe',
-    ['query', OPENSSH_REGISTRY_KEY, '/v', 'DefaultShell'],
-    { encoding: 'utf8', timeout: QUERY_TIMEOUT_MS, windowsHide: true }
-  )
-  const match = stdout.match(/^\s*DefaultShell\s+REG_\w+\s+(.+?)\s*$/im)
-  return match?.[1] ?? ''
+  try {
+    const { stdout } = await execFile('reg.exe', ['query', OPENSSH_REGISTRY_KEY], QUERY_OPTIONS)
+    return parseDefaultShell(stdout)
+  } catch (error) {
+    if (!hasNumericExitCode(error)) {
+      throw error
+    }
+
+    // Why: reg.exe uses exit code 1 for both a missing key and access denied.
+    // Parent enumeration distinguishes them without parsing localized stderr.
+    const { stdout } = await execFile(
+      'reg.exe',
+      ['query', OPENSSH_REGISTRY_PARENT_KEY],
+      QUERY_OPTIONS
+    )
+    if (outputContainsOpenSshKey(stdout)) {
+      throw error
+    }
+    return ''
+  }
 }
 
 /**
@@ -77,15 +84,13 @@ export async function readOpenSshDefaultShell(): Promise<string> {
       probe = { kind: 'resolved', shell }
       return shell
     })
-    .catch((error: unknown) => {
-      probe = probeCompleted(error)
-        ? { kind: 'resolved', shell: '' }
-        : {
-            kind: 'failed',
-            // Why monotonic: an NTP correction or VM resume must not stretch a 30s
-            // cooldown into an hour of not honoring the configured shell.
-            retryAtMs: performance.now() + OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS
-          }
+    .catch(() => {
+      probe = {
+        kind: 'failed',
+        // Why monotonic: an NTP correction or VM resume must not stretch a 30s
+        // cooldown into an hour of not honoring the configured shell.
+        retryAtMs: performance.now() + OPENSSH_DEFAULT_SHELL_RETRY_COOLDOWN_MS
+      }
       return ''
     })
     .finally(() => {

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -179,6 +179,36 @@ describe('PtyHandler', () => {
     expect(notifMethods).toContain('pty.ackData')
   })
 
+  it('awaits the async fallback shell at query, spawn, and revive call sites', async () => {
+    const fallbackShell = '/fallback-shell'
+    const resolveDefaultShellSpy = vi
+      .spyOn(ptyShellUtils, 'resolveDefaultShell')
+      .mockResolvedValue(fallbackShell)
+
+    expect(await dispatcher.callRequest('pty.getDefaultShell')).toBe(fallbackShell)
+    await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24, cwd: '/tmp' })
+    expect(mockPtySpawn).toHaveBeenLastCalledWith(
+      fallbackShell,
+      expect.any(Array),
+      expect.any(Object)
+    )
+
+    const state = (await dispatcher.callRequest('pty.serialize', { ids: ['pty-1'] })) as string
+    await handler.dispose({ waitForPhysicalExit: false })
+    mockPtySpawn.mockClear()
+    dispatcher = createMockDispatcher()
+    handler = new PtyHandler(dispatcher as unknown as RelayDispatcher)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      await dispatcher.callRequest('pty.revive', { state })
+    } finally {
+      killSpy.mockRestore()
+    }
+
+    expect(mockPtySpawn).toHaveBeenCalledWith(fallbackShell, expect.any(Array), expect.any(Object))
+    expect(resolveDefaultShellSpy).toHaveBeenCalledTimes(3)
+  })
+
   it('pauses native output at the producer hard water and resumes after retained writes settle', async () => {
     let onData: ((data: string) => void) | undefined
     const pause = vi.fn()

--- a/src/relay/pty-handler.test.ts
+++ b/src/relay/pty-handler.test.ts
@@ -616,7 +616,7 @@ describe('PtyHandler', () => {
     })
     const resolveDefaultShellSpy = vi
       .spyOn(ptyShellUtils, 'resolveDefaultShell')
-      .mockReturnValue('/default-shell')
+      .mockResolvedValue('/default-shell')
     try {
       await dispatcher.callRequest('pty.spawn', {
         cols: 80,
@@ -654,7 +654,7 @@ describe('PtyHandler', () => {
     })
     const resolveDefaultShellSpy = vi
       .spyOn(ptyShellUtils, 'resolveDefaultShell')
-      .mockReturnValue('/default-shell')
+      .mockResolvedValue('/default-shell')
     try {
       await dispatcher.callRequest('pty.spawn', {
         cols: 80,

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -1436,7 +1436,7 @@ export class PtyHandler {
     const shellOverride =
       typeof params.shellOverride === 'string' ? params.shellOverride.trim() : ''
     const resolvedShellOverride = resolvePtyShellOverride(shellOverride)
-    const shell = resolvedShellOverride || resolveDefaultShell()
+    const shell = resolvedShellOverride || (await resolveDefaultShell())
     let id: string
     do {
       id = `pty-${this.nextId++}`
@@ -1995,7 +1995,7 @@ export class PtyHandler {
     }
     // Why: serialized state may come from an older/untrusted client; reapply fresh-spawn bounds.
     const envToDelete = sanitizeEnvToDelete(entry.envToDelete)
-    const shell = resolveDefaultShell()
+    const shell = await resolveDefaultShell()
     const spawnEnv = this.buildSpawnEnv(
       revivedEnv,
       { id: entry.id, paneKey: entry.paneKey, shell },

--- a/src/relay/pty-shell-utils.test.ts
+++ b/src/relay/pty-shell-utils.test.ts
@@ -93,9 +93,9 @@ describe('isProcessAlive', () => {
 })
 
 describe('resolveWindowsDefaultShell', () => {
-  it('uses an existing SHELL override when one is provided', () => {
+  it('uses an existing SHELL override when one is provided', async () => {
     expect(
-      resolveWindowsDefaultShell(
+      await resolveWindowsDefaultShell(
         {
           SHELL: 'C:\\Tools\\pwsh.exe',
           SystemRoot: 'C:\\Windows',
@@ -109,11 +109,11 @@ describe('resolveWindowsDefaultShell', () => {
     ).toBe('C:\\Tools\\pwsh.exe')
   })
 
-  it('uses an existing OpenSSH DefaultShell path', () => {
+  it('uses an existing OpenSSH DefaultShell path', async () => {
     const powershell7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
 
     expect(
-      resolveWindowsDefaultShell(
+      await resolveWindowsDefaultShell(
         {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
@@ -124,76 +124,43 @@ describe('resolveWindowsDefaultShell', () => {
     ).toBe(powershell7)
   })
 
-  it('reads and memoizes the OpenSSH DefaultShell registry value', async () => {
-    execFileSyncMock.mockReturnValue(
-      [
-        'HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH',
-        '    DefaultShell    REG_SZ    C:\\Program Files\\PowerShell\\7\\pwsh.exe'
-      ].join('\n')
-    )
+  it('awaits an async DefaultShell probe and honors the resolved path', async () => {
+    const powershell7 = 'C:\\Program Files\\PowerShell\\7\\pwsh.exe'
 
-    const { readOpenSshDefaultShell } = await import('./pty-shell-utils')
-
-    expect(readOpenSshDefaultShell()).toBe('C:\\Program Files\\PowerShell\\7\\pwsh.exe')
-    expect(readOpenSshDefaultShell()).toBe('C:\\Program Files\\PowerShell\\7\\pwsh.exe')
-    expect(execFileSyncMock).toHaveBeenCalledTimes(1)
-    expect(execFileSyncMock).toHaveBeenCalledWith(
-      'reg.exe',
-      ['query', 'HKLM\\SOFTWARE\\OpenSSH', '/v', 'DefaultShell'],
-      { encoding: 'utf8', timeout: 3000, windowsHide: true }
-    )
+    expect(
+      await resolveWindowsDefaultShell(
+        {
+          SystemRoot: 'C:\\Windows',
+          ComSpec: 'C:\\Windows\\System32\\cmd.exe'
+        },
+        (path) => path === powershell7,
+        async () => powershell7
+      )
+    ).toBe(powershell7)
   })
 
-  it('treats malformed OpenSSH DefaultShell output as empty and preserves the fallback chain', async () => {
-    execFileSyncMock.mockReturnValue(
-      [
-        'HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenSSH',
-        '    DefaultShellCommandOption    REG_SZ    /c'
-      ].join('\n')
-    )
-
-    const { readOpenSshDefaultShell } = await import('./pty-shell-utils')
+  it('preserves the fallback chain when the async DefaultShell probe yields nothing', async () => {
+    // Why: covers both "no DefaultShell configured" and "the probe is in its
+    // post-failure cooldown" — readOpenSshDefaultShell reports '' for both.
     const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 
-    expect(readOpenSshDefaultShell()).toBe('')
     expect(
-      resolveWindowsDefaultShell(
+      await resolveWindowsDefaultShell(
         {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
         },
         (path) => path === powershell || path === 'C:\\Windows\\System32\\cmd.exe',
-        readOpenSshDefaultShell
+        async () => ''
       )
     ).toBe(powershell)
   })
 
-  it('treats reg.exe failures as empty and preserves the fallback chain', async () => {
-    execFileSyncMock.mockImplementation(() => {
-      throw new Error('reg.exe failed')
-    })
-
-    const { readOpenSshDefaultShell } = await import('./pty-shell-utils')
-    const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
-
-    expect(readOpenSshDefaultShell()).toBe('')
-    expect(
-      resolveWindowsDefaultShell(
-        {
-          SystemRoot: 'C:\\Windows',
-          ComSpec: 'C:\\Windows\\System32\\cmd.exe'
-        },
-        (path) => path === powershell || path === 'C:\\Windows\\System32\\cmd.exe',
-        readOpenSshDefaultShell
-      )
-    ).toBe(powershell)
-  })
-
-  it('preserves the fallback chain for an invalid OpenSSH DefaultShell', () => {
+  it('preserves the fallback chain for an invalid OpenSSH DefaultShell', async () => {
     const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 
     expect(
-      resolveWindowsDefaultShell(
+      await resolveWindowsDefaultShell(
         {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
@@ -204,11 +171,11 @@ describe('resolveWindowsDefaultShell', () => {
     ).toBe(powershell)
   })
 
-  it('honors a deliberate OpenSSH PowerShell 5.1 DefaultShell value', () => {
+  it('honors a deliberate OpenSSH PowerShell 5.1 DefaultShell value', async () => {
     const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 
     expect(
-      resolveWindowsDefaultShell(
+      await resolveWindowsDefaultShell(
         {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
@@ -219,11 +186,11 @@ describe('resolveWindowsDefaultShell', () => {
     ).toBe(powershell)
   })
 
-  it('prefers inbox PowerShell before ComSpec for an interactive Windows PTY', () => {
+  it('prefers inbox PowerShell before ComSpec for an interactive Windows PTY', async () => {
     const powershell = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'
 
     expect(
-      resolveWindowsDefaultShell(
+      await resolveWindowsDefaultShell(
         {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'
@@ -234,9 +201,9 @@ describe('resolveWindowsDefaultShell', () => {
     ).toBe(powershell)
   })
 
-  it('falls back to ComSpec when PowerShell cannot be found by path', () => {
+  it('falls back to ComSpec when PowerShell cannot be found by path', async () => {
     expect(
-      resolveWindowsDefaultShell(
+      await resolveWindowsDefaultShell(
         {
           SystemRoot: 'C:\\Windows',
           ComSpec: 'C:\\Windows\\System32\\cmd.exe'

--- a/src/relay/pty-shell-utils.ts
+++ b/src/relay/pty-shell-utils.ts
@@ -1,4 +1,4 @@
-import { execFile as execFileCb, execFileSync } from 'node:child_process'
+import { execFile as execFileCb } from 'node:child_process'
 import { existsSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { win32 as pathWin32 } from 'node:path'
@@ -16,6 +16,7 @@ import {
   shouldInspectOuterWrapperForegroundProcess
 } from '../shared/foreground-wrapper-agent'
 import { isShellProcess } from '../shared/shell-process-detection'
+import { readOpenSshDefaultShell } from './openssh-default-shell'
 import {
   resolveWindowsAgentForegroundProcess,
   shouldInspectWindowsAgentForeground
@@ -23,40 +24,17 @@ import {
 
 const execFile = promisify(execFileCb)
 
-const OPENSSH_REGISTRY_KEY = 'HKLM\\SOFTWARE\\OpenSSH'
-let openSshDefaultShell: string | undefined
-
-export function readOpenSshDefaultShell(): string {
-  if (openSshDefaultShell !== undefined) {
-    return openSshDefaultShell
-  }
-
-  try {
-    const output = execFileSync('reg.exe', ['query', OPENSSH_REGISTRY_KEY, '/v', 'DefaultShell'], {
-      encoding: 'utf8',
-      timeout: 3000,
-      windowsHide: true
-    })
-    const match = output.match(/^\s*DefaultShell\s+REG_\w+\s+(.+?)\s*$/im)
-    openSshDefaultShell = match?.[1] ?? ''
-  } catch {
-    openSshDefaultShell = ''
-  }
-
-  return openSshDefaultShell
-}
-
-export function resolveWindowsDefaultShell(
+export async function resolveWindowsDefaultShell(
   env: NodeJS.ProcessEnv = process.env,
   existsPath: (path: string) => boolean = existsSync,
-  readDefaultShell: () => string = readOpenSshDefaultShell
-): string {
+  readDefaultShell: () => string | Promise<string> = readOpenSshDefaultShell
+): Promise<string> {
   const envShell = env.SHELL
   if (envShell && existsPath(envShell)) {
     return envShell
   }
 
-  const configuredShell = readDefaultShell()
+  const configuredShell = await readDefaultShell()
   if (configuredShell && existsPath(configuredShell)) {
     return configuredShell
   }
@@ -85,7 +63,7 @@ export function resolveWindowsDefaultShell(
  * Resolve the default shell for PTY spawning.
  * Prefers $SHELL, then common fallbacks.
  */
-export function resolveDefaultShell(): string {
+export async function resolveDefaultShell(): Promise<string> {
   if (process.platform === 'win32') {
     return resolveWindowsDefaultShell()
   }


### PR DESCRIPTION
## Summary

Windows relays no longer permanently forget the host's configured OpenSSH `DefaultShell` after a transient `reg.exe` failure. The registry probe is asynchronous, shares one in-flight request, caches successful answers (including a confirmed absence) for process lifetime, and retries failed probes after a monotonic 30-second cooldown.

`reg.exe` returns exit code 1 for both a missing value and access denied. The probe therefore queries the OpenSSH key itself and, only when that fails numerically, enumerates `HKLM\SOFTWARE` to distinguish a missing key from a present-but-unreadable key without parsing localized stderr. This preserves the cheap lifetime cache for a genuine absence while keeping access and other probe failures retryable.

Reliability invariant (`relay-shell.default-resolution-recovery`): a transient registry-read failure must not permanently suppress a configured Windows OpenSSH shell, concurrent callers must share one bounded probe, and every settled probe must release its in-flight reference. The motivating failure was process-lifetime cache poisoning after one failed registry query. The deterministic oracle injects timeout, spawn, and access-denied failures, advances the cooldown, and requires the configured shell on retry; query, spawn, and revive tests require all three async call sites to consume the fallback safely.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full aggregate not run; repository-wide `npx oxlint` and `npm run check:max-lines-ratchet` passed.
- [x] `pnpm typecheck` — equivalent `npm run typecheck` passed all three TypeScript projects.
- [ ] `pnpm test` — full repository suite not run; focused relay suite below passed.
- [ ] `pnpm build` — full desktop build not run; `pnpm build:relay` produced all six relay platform bundles plus the WSL hook bundle.
- [x] Added or updated high-quality regression tests.

Executed after rebasing onto `origin/main` at `8ddf575fe6`:

- `npx vitest run --config config/vitest.config.ts src/relay/openssh-default-shell.test.ts src/relay/pty-shell-utils.test.ts src/relay/pty-handler.test.ts` — 163 passed, 7 skipped.
- Intentional break: changed the failure catch back to process-lifetime resolved `''` while keeping tests; 4 of 8 probe tests failed (timeout retry, spawn retry, access-denied retry, and in-flight cleanup). Restoring the source returned the focused suite to green.
- `npm run typecheck` — passed.
- `npx oxlint` — passed repository-wide.
- `npm run check:max-lines-ratchet` — passed with no new bypasses.
- `pnpm build:relay` — passed.

No matching `config/reliability-gates.jsonc` entry exists for this narrow shell-resolution invariant; the focused deterministic suite is the PR-specific gate, and absence of a live target is the accepted gap documented below.

## AI Review Report

A same-model, same-reasoning independent reviewer audited the cache state machine, concurrent failing callers, joiners after an expired cooldown, promise cleanup, all three call sites, cross-platform behavior, and subprocess cost. It blocked the original branch because every numeric `reg.exe` error—including access denied—was permanently cached as “none set.” Commit `54f4342366` fixes that distinction and adds the missing race/call-site coverage; two follow-up reviews returned `CLEAN`.

The 30-second cooldown was evaluated rather than assumed: it bounds a persistent failure to at most one probe per 30 seconds, keeps at most one child in flight, and limits a transient fallback window to 30 seconds after settlement. Shortening it near the 3-second command timeout would repeatedly impose failed spawn work during a terminal burst. A successful “none set” answer remains a deliberate process-lifetime cache, preserving prior behavior and avoiding subprocess churn.

Cross-platform review: only a Windows relay host reaches `reg.exe`; Linux/macOS SSH relays and WSL bypass the probe, path handling is unchanged, folder workspaces do not affect resolution, and no UI, Electron, shortcut, label, or provider-specific review behavior changed.

CodeRabbit dispositions:

- Node builtin mock specifier mismatch — actioned in rewritten commit `8660518676`; the test mocks `node:child_process` exactly.
- PR-template/description warning — actioned by this description update with Screenshots, Testing, AI Review Report, Security Audit, and Notes sections.
- Post-rebase CodeRabbit thread sweep found no new actionable code comment; its informational full-review note remained in progress without updates after 00:02:30 UTC.
- Docstring coverage warning — declined: the remaining undocumented functions are private, single-purpose helpers with clear names; adding boilerplate docstrings would conflict with the repository's concise, non-obvious-comments-only rule.
- “Fix failing CI” finishing-touch suggestion — actioned: the unrelated Linux packaged-watchdog timeout passed on one rerun, and the aggregate `verify` plus every required check is green.

## Security Audit

The probe executes fixed `reg.exe` arguments only; no user-controlled command text, shell interpolation, registry writes, auth data, secrets, IPC schema, or dependencies were added. Registry output is parsed only for the exact `DefaultShell` value and canonical OpenSSH key path; the resolved executable still passes the existing path-existence validation before PTY launch. Errors fail closed to the existing PowerShell/`ComSpec` fallback and retry later.

## Notes

The requested live Docker SSH relay rig was not reachable from this Windows host: Docker Desktop/CLI was absent, and the available Ubuntu WSL distro had no Docker, Podman, or nerdctl. No Electron validation is claimed. The fallback evidence is layered: real Windows probes confirmed missing and access-denied queries both return exit code 1; unit tests inject transient failures and prove recovery; resolver tests prove the Windows fallback; handler tests prove `pty.getDefaultShell`, fresh spawn, and revive await and use it. The parent enumeration measured 48 ms and 777 output characters on this host and runs only on the first numeric key-query failure before a confirmed absence is cached.

Residual live gaps: no Windows OpenSSH target was fault-injected during an active relay, and no Linux Docker relay transport was exercised on this host. Linux/macOS relay behavior is unaffected because the Windows registry branch is unreachable there.


