### PR TITLE
fix(worktree): bound the .worktreeinclude copy so a huge include can't freeze workspace creation

### DIFF
--- a/src/main/git/worktree-include-file.test.ts
+++ b/src/main/git/worktree-include-file.test.ts
@@ -125,6 +125,20 @@ describe('resolveWorktreeIncludePaths', () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('unsafe'))
   })
 
+  it('stops after 1000 entries so one repo file cannot request unbounded work', async () => {
+    const names = Array.from({ length: 1001 }, (_, index) => `ignored-${index}.env`)
+    for (const name of names) {
+      writeFileSync(join(repo, name), 'A=1')
+    }
+    writeInclude(`${names.join('\n')}\n`)
+    mockCheckIgnore()
+
+    const resolved = await resolveWorktreeIncludePaths(repo)
+
+    expect(resolved).toHaveLength(1000)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('more than 1000 entries'))
+  })
+
   it('resolves to [] when git fails instead of throwing', async () => {
     writeInclude('.env\n')
     writeFileSync(join(repo, '.env'), 'A=1')

--- a/src/main/ipc/worktree-apfs-clone.ts
+++ b/src/main/ipc/worktree-apfs-clone.ts
@@ -95,24 +95,51 @@ async function getCachedDarwinFilesystemInfo(
   return pending
 }
 
+async function isSameApfsVolume(
+  source: string,
+  targetDirectory: string,
+  deps: ApfsCloneDeps,
+  cache: DarwinFilesystemCache
+): Promise<boolean> {
+  const [sourceInfo, targetInfo] = await Promise.all([
+    getCachedDarwinFilesystemInfo(source, deps, cache),
+    getCachedDarwinFilesystemInfo(targetDirectory, deps, cache)
+  ])
+  return (
+    sourceInfo.device === targetInfo.device &&
+    sourceInfo.filesystemName === 'APFS' &&
+    targetInfo.filesystemName === 'APFS'
+  )
+}
+
 async function assertSameApfsVolume(
   source: string,
   target: string,
   deps: ApfsCloneDeps,
   cache: DarwinFilesystemCache
 ): Promise<void> {
-  const [sourceInfo, targetInfo] = await Promise.all([
-    getCachedDarwinFilesystemInfo(source, deps, cache),
-    getCachedDarwinFilesystemInfo(dirname(target), deps, cache)
-  ])
-  if (
-    sourceInfo.device !== targetInfo.device ||
-    sourceInfo.filesystemName !== 'APFS' ||
-    targetInfo.filesystemName !== 'APFS'
-  ) {
+  if (!(await isSameApfsVolume(source, dirname(target), deps, cache))) {
     throw new ApfsCloneUnavailableError(
       'APFS clone-copy requires source and target on the same APFS volume'
     )
+  }
+}
+
+/** Whether copying `source` into `targetDirectory` would take the clonefile
+ *  path. Pure probe: it reuses the cached df+diskutil pair the clone itself
+ *  runs and writes nothing, so a caller can size the work before any bytes
+ *  land. A failed probe answers "no", matching the clone's own fallback to a
+ *  real copy. */
+export async function canCloneWithApfs(
+  source: string,
+  targetDirectory: string,
+  deps: ApfsCloneDeps = defaultApfsCloneDeps,
+  filesystemCache: DarwinFilesystemCache = new Map()
+): Promise<boolean> {
+  try {
+    return await isSameApfsVolume(source, targetDirectory, deps, filesystemCache)
+  } catch {
+    return false
   }
 }
 

--- a/src/main/ipc/worktree-include-copy-budget.test.ts
+++ b/src/main/ipc/worktree-include-copy-budget.test.ts
@@ -111,24 +111,44 @@ describe('worktree copy budget tracker', () => {
   })
 
   it('charges the walk itself so repeated over-budget sources cannot re-walk forever', async () => {
-    for (const dir of ['a', 'b']) {
-      mkdirSync(join(root, dir))
-      writeFileSync(join(root, dir, 'one'), 'x'.repeat(200))
+    // 10 sources of 2 entries each, against a walk ceiling of maxEntries * 5.
+    for (let index = 0; index < 10; index += 1) {
+      mkdirSync(join(root, `dir-${index}`))
+      writeFileSync(join(root, `dir-${index}`, 'one'), 'x'.repeat(200))
     }
     writeFileSync(join(root, 'tiny'), '')
-    // Each refused source walks 2 entries before busting the byte limit, so the
-    // two of them exhaust a 4-entry ceiling.
     const tracker = createWorktreeCopyBudgetTracker({ maxBytes: 64, maxEntries: 4 })
 
-    await expect(tracker.admit(join(root, 'a'))).resolves.toMatchObject({ withinBudget: false })
-    await expect(tracker.admit(join(root, 'b'))).resolves.toMatchObject({ withinBudget: false })
+    for (let index = 0; index < 10; index += 1) {
+      await expect(tracker.admit(join(root, `dir-${index}`))).resolves.toMatchObject({
+        withinBudget: false
+      })
+    }
 
-    // Neither was admitted, so the copy budget itself is untouched and `tiny`
-    // would fit — it is refused purely because the walk ceiling is spent.
+    // Nothing was admitted, so the copy budget itself is untouched and `tiny`
+    // would fit — it is refused purely because the walk ceiling is spent, and
+    // says so rather than blaming limits it never approached.
     await expect(tracker.admit(join(root, 'tiny'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'sizing'
+    })
+  })
+
+  it('lets a small entry through after one huge entry is refused on file count', async () => {
+    // The regression this guards: sizing `node_modules` burns maxEntries + 1
+    // walk, which without headroom would starve every entry listed after it.
+    mkdirSync(join(root, 'node_modules'))
+    for (let index = 0; index < 12; index += 1) {
+      writeFileSync(join(root, 'node_modules', `pkg-${index}`), '')
+    }
+    writeFileSync(join(root, '.env'), 'A=1\n')
+    const tracker = createWorktreeCopyBudgetTracker({ maxBytes: 1024, maxEntries: 4 })
+
+    await expect(tracker.admit(join(root, 'node_modules'))).resolves.toEqual({
       withinBudget: false,
       reason: 'entries'
     })
+    await expect(tracker.admit(join(root, '.env'))).resolves.toMatchObject({ withinBudget: true })
   })
 
   posixIt('counts a nested symlink without following it', async () => {
@@ -157,6 +177,18 @@ describe('formatWorktreeIncludeCopyWarning', () => {
     expect(warning).toContain('"node_modules"')
     expect(warning).toContain('".cache"')
     expect(warning).toContain('.worktreeinclude')
+  })
+
+  it('does not quote the size limits at an entry that was never measured', () => {
+    const warning = formatWorktreeIncludeCopyWarning([
+      { path: 'node_modules', reason: 'entries' },
+      { path: '.env', reason: 'sizing' }
+    ])
+
+    expect(warning).toContain('"node_modules"')
+    expect(warning).toContain('earlier entries used up the budget for measuring')
+    // The limits belong to node_modules' sentence, not to `.env`'s.
+    expect(warning).not.toMatch(/"\.env"[^.]*file limit/u)
   })
 })
 

--- a/src/main/ipc/worktree-include-copy-budget.test.ts
+++ b/src/main/ipc/worktree-include-copy-budget.test.ts
@@ -205,6 +205,28 @@ describe('formatWorktreeIncludeCopyWarning', () => {
     expect(warning).toContain('.worktreeinclude')
   })
 
+  it('warns that an interrupted copy may have left leftovers behind', () => {
+    const warning = formatWorktreeIncludeCopyWarning([
+      { path: 'models', reason: 'bytes', mayBePartial: true }
+    ])
+
+    expect(warning).toContain('"models" may hold a partial copy')
+    expect(warning).toContain('check it before reusing this workspace')
+  })
+
+  it('caps how many entries it names so the warning cannot grow unbounded', () => {
+    const warning = formatWorktreeIncludeCopyWarning(
+      Array.from({ length: 30 }, (_, index) => ({
+        path: `dir-${index}`,
+        reason: 'bytes' as const
+      }))
+    )
+
+    expect(warning).toContain('"dir-0"')
+    expect(warning).toContain('and 25 more')
+    expect(warning).not.toContain('"dir-6"')
+  })
+
   it('reads grammatically for a single skipped entry', () => {
     const warning = formatWorktreeIncludeCopyWarning([{ path: 'node_modules', reason: 'bytes' }])
 
@@ -355,9 +377,52 @@ describe('createWorktreeCopiedPaths copy budget', () => {
     })
 
     expect(cloneWorktreePath).toHaveBeenCalledTimes(1)
-    expect(skipped).toEqual([{ path: 'models', reason: 'bytes' }])
+    expect(skipped).toEqual([{ path: 'models', reason: 'bytes', mayBePartial: true }])
     // The whole point: no unbudgeted byte-for-byte copy ran behind the failure.
     expect(existsSync(join(worktree, 'models'))).toBe(false)
+  })
+
+  it('still copies when the clone was never predicted, so its bytes were already charged', async () => {
+    // Sized so that billing it a second time would bust the 64-byte budget —
+    // that is what makes this test notice a missing short-circuit.
+    writeFileSync(join(primary, '.env'), 'x'.repeat(40))
+    // A wedged df/diskutil makes the volume probe answer "no clone", so bytes
+    // are charged up front and the real-copy fallback must simply proceed.
+    const apfsCloneDeps = {
+      execFileAsync: async () => {
+        throw new Error('diskutil unavailable')
+      },
+      randomUUID: () => 'test'
+    }
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['.env'], {
+      platform: 'darwin',
+      apfsCloneDeps,
+      copyBudget: TINY_BYTE_BUDGET
+    })
+
+    expect(skipped).toEqual([])
+    expect(readFileSync(join(worktree, '.env'), 'utf8')).toBe('x'.repeat(40))
+  })
+
+  it('bills a recovered clone fallback so a later entry sees the spent budget', async () => {
+    writeFileSync(join(primary, 'one'), 'x'.repeat(50))
+    writeFileSync(join(primary, 'two'), 'x'.repeat(50))
+    // Clone is predicted for both, then fails, so each falls back to a real
+    // copy. The first bills 50 of the 64-byte budget; the second cannot.
+    const cloneWorktreePath = vi.fn(async () => {
+      throw new Error('clonefile failed')
+    })
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['one', 'two'], {
+      platform: 'darwin',
+      cloneWorktreePath,
+      copyBudget: TINY_BYTE_BUDGET
+    })
+
+    expect(readFileSync(join(worktree, 'one'), 'utf8')).toBe('x'.repeat(50))
+    expect(skipped).toEqual([{ path: 'two', reason: 'bytes', mayBePartial: true }])
+    expect(existsSync(join(worktree, 'two'))).toBe(false)
   })
 
   posixIt('leaves link mode unbounded — symlinks cost no bytes', async () => {

--- a/src/main/ipc/worktree-include-copy-budget.test.ts
+++ b/src/main/ipc/worktree-include-copy-budget.test.ts
@@ -1,0 +1,231 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createWorktreeCopyBudgetTracker,
+  formatWorktreeIncludeCopyWarning
+} from './worktree-include-copy-budget'
+import { createWorktreeCopiedPaths, createWorktreeLinkedPaths } from './worktree-symlinks'
+
+const posixIt = process.platform === 'win32' ? it.skip : it
+
+// A byte budget small enough to trip on a fixture that stays trivial on disk —
+// the bound must be injectable or testing it would mean writing gigabytes.
+const TINY_BYTE_BUDGET = { maxBytes: 64, maxEntries: 10_000 }
+const TINY_ENTRY_BUDGET = { maxBytes: 1024 * 1024 * 1024, maxEntries: 3 }
+
+describe('worktree copy budget tracker', () => {
+  let root: string
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-copy-budget-'))
+  })
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('admits a source that fits and reports its measured size', async () => {
+    writeFileSync(join(root, 'small.env'), 'A=1\n')
+    const tracker = createWorktreeCopyBudgetTracker(TINY_BYTE_BUDGET)
+
+    await expect(tracker.admit(join(root, 'small.env'))).resolves.toEqual({
+      withinBudget: true,
+      bytes: 4,
+      entries: 1
+    })
+  })
+
+  it('refuses a directory whose total bytes exceed the budget', async () => {
+    mkdirSync(join(root, 'node_modules'))
+    writeFileSync(join(root, 'node_modules', 'a'), 'x'.repeat(40))
+    writeFileSync(join(root, 'node_modules', 'b'), 'x'.repeat(40))
+    const tracker = createWorktreeCopyBudgetTracker(TINY_BYTE_BUDGET)
+
+    await expect(tracker.admit(join(root, 'node_modules'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'bytes'
+    })
+  })
+
+  it('refuses a directory with too many entries even when it weighs nothing', async () => {
+    mkdirSync(join(root, 'cache'))
+    for (const name of ['a', 'b', 'c', 'd', 'e']) {
+      writeFileSync(join(root, 'cache', name), '')
+    }
+    const tracker = createWorktreeCopyBudgetTracker(TINY_ENTRY_BUDGET)
+
+    await expect(tracker.admit(join(root, 'cache'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'entries'
+    })
+  })
+
+  it('spends one budget across every admitted source', async () => {
+    writeFileSync(join(root, 'first'), 'x'.repeat(40))
+    writeFileSync(join(root, 'second'), 'x'.repeat(40))
+    const tracker = createWorktreeCopyBudgetTracker(TINY_BYTE_BUDGET)
+
+    await expect(tracker.admit(join(root, 'first'))).resolves.toMatchObject({ withinBudget: true })
+    await expect(tracker.admit(join(root, 'second'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'bytes'
+    })
+  })
+
+  it('does not spend budget on a refused source, so a later small one still fits', async () => {
+    writeFileSync(join(root, 'big'), 'x'.repeat(200))
+    writeFileSync(join(root, 'small'), 'A=1\n')
+    const tracker = createWorktreeCopyBudgetTracker(TINY_BYTE_BUDGET)
+
+    await expect(tracker.admit(join(root, 'big'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'bytes'
+    })
+    await expect(tracker.admit(join(root, 'small'))).resolves.toMatchObject({ withinBudget: true })
+  })
+
+  posixIt('counts a nested symlink without following it', async () => {
+    mkdirSync(join(root, 'payload'))
+    writeFileSync(join(root, 'payload', 'real'), 'x'.repeat(40))
+    mkdirSync(join(root, 'dir'))
+    // Following this would re-count `payload` and blow the byte budget.
+    symlinkSync(join(root, 'payload'), join(root, 'dir', 'alias'))
+    const tracker = createWorktreeCopyBudgetTracker(TINY_BYTE_BUDGET)
+
+    await expect(tracker.admit(join(root, 'dir'))).resolves.toMatchObject({ withinBudget: true })
+  })
+})
+
+describe('formatWorktreeIncludeCopyWarning', () => {
+  it('is undefined when nothing was skipped', () => {
+    expect(formatWorktreeIncludeCopyWarning([])).toBeUndefined()
+  })
+
+  it('names every skipped entry so the omission is not silent', () => {
+    const warning = formatWorktreeIncludeCopyWarning([
+      { path: 'node_modules', reason: 'bytes' },
+      { path: '.cache', reason: 'entries' }
+    ])
+
+    expect(warning).toContain('"node_modules"')
+    expect(warning).toContain('".cache"')
+    expect(warning).toContain('.worktreeinclude')
+  })
+})
+
+describe('createWorktreeCopiedPaths copy budget', () => {
+  let root: string
+  let primary: string
+  let worktree: string
+  let warn: ReturnType<typeof vi.spyOn>
+  let error: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'orca-copy-budget-paths-'))
+    primary = join(root, 'primary')
+    worktree = join(root, 'worktree')
+    mkdirSync(primary, { recursive: true })
+    mkdirSync(worktree, { recursive: true })
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    error = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warn.mockRestore()
+    error.mockRestore()
+    rmSync(root, { recursive: true, force: true })
+  })
+
+  it('refuses an over-budget directory before writing anything into the worktree', async () => {
+    mkdirSync(join(primary, 'node_modules'))
+    writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'x'.repeat(200))
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['node_modules'], {
+      platform: 'linux',
+      copyBudget: TINY_BYTE_BUDGET
+    })
+
+    expect(skipped).toEqual([{ path: 'node_modules', reason: 'bytes' }])
+    expect(existsSync(join(worktree, 'node_modules'))).toBe(false)
+  })
+
+  it('refuses an entry that busts the file-count limit', async () => {
+    mkdirSync(join(primary, '.cache'))
+    for (const name of ['a', 'b', 'c', 'd', 'e']) {
+      writeFileSync(join(primary, '.cache', name), '')
+    }
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['.cache'], {
+      platform: 'linux',
+      copyBudget: TINY_ENTRY_BUDGET
+    })
+
+    expect(skipped).toEqual([{ path: '.cache', reason: 'entries' }])
+    expect(existsSync(join(worktree, '.cache'))).toBe(false)
+  })
+
+  it('still copies the entries that fit alongside one that does not', async () => {
+    writeFileSync(join(primary, '.env'), 'A=1\n')
+    mkdirSync(join(primary, 'node_modules'))
+    writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'x'.repeat(200))
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['node_modules', '.env'], {
+      platform: 'linux',
+      copyBudget: TINY_BYTE_BUDGET
+    })
+
+    expect(skipped).toEqual([{ path: 'node_modules', reason: 'bytes' }])
+    expect(readFileSync(join(worktree, '.env'), 'utf8')).toBe('A=1\n')
+  })
+
+  it('copies a normal small include fully and reports nothing skipped', async () => {
+    writeFileSync(join(primary, '.env'), 'A=1\n')
+    mkdirSync(join(primary, '.vscode'))
+    writeFileSync(join(primary, '.vscode', 'settings.json'), '{}')
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['.env', '.vscode'], {
+      platform: 'linux'
+    })
+
+    expect(skipped).toEqual([])
+    expect(readFileSync(join(worktree, '.env'), 'utf8')).toBe('A=1\n')
+    expect(readFileSync(join(worktree, '.vscode', 'settings.json'), 'utf8')).toBe('{}')
+  })
+
+  it('does not run the macOS APFS clone for an over-budget entry', async () => {
+    mkdirSync(join(primary, 'node_modules'))
+    writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'x'.repeat(200))
+    const cloneWorktreePath = vi.fn(async () => undefined)
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['node_modules'], {
+      platform: 'darwin',
+      cloneWorktreePath,
+      copyBudget: TINY_BYTE_BUDGET
+    })
+
+    expect(skipped).toEqual([{ path: 'node_modules', reason: 'bytes' }])
+    expect(cloneWorktreePath).not.toHaveBeenCalled()
+  })
+
+  posixIt('leaves link mode unbounded — symlinks cost no bytes', async () => {
+    mkdirSync(join(primary, 'node_modules'))
+    writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'x'.repeat(200))
+
+    await createWorktreeLinkedPaths(primary, worktree, ['node_modules'], {
+      platform: 'linux',
+      copyBudget: TINY_BYTE_BUDGET
+    })
+
+    expect(existsSync(join(worktree, 'node_modules', 'pkg.js'))).toBe(true)
+  })
+})

--- a/src/main/ipc/worktree-include-copy-budget.test.ts
+++ b/src/main/ipc/worktree-include-copy-budget.test.ts
@@ -214,6 +214,19 @@ describe('formatWorktreeIncludeCopyWarning', () => {
     expect(warning).toContain('check it before reusing this workspace')
   })
 
+  it('caps the partial-copy list too, so it cannot grow unbounded either', () => {
+    const warning = formatWorktreeIncludeCopyWarning(
+      Array.from({ length: 10 }, (_, index) => ({
+        path: `dir-${index}`,
+        reason: 'bytes' as const,
+        mayBePartial: true
+      }))
+    )
+
+    expect(warning).toContain('"dir-4" and 5 more may hold a partial copy')
+    expect(warning).not.toContain('"dir-5"')
+  })
+
   it('caps how many entries it names so the warning cannot grow unbounded', () => {
     const warning = formatWorktreeIncludeCopyWarning(
       Array.from({ length: 30 }, (_, index) => ({
@@ -421,7 +434,9 @@ describe('createWorktreeCopiedPaths copy budget', () => {
     })
 
     expect(readFileSync(join(worktree, 'one'), 'utf8')).toBe('x'.repeat(50))
-    expect(skipped).toEqual([{ path: 'two', reason: 'bytes', mayBePartial: true }])
+    // No mayBePartial: a failed *file* clone publishes via link(2) from a temp
+    // path, so it never leaves anything at the target to go check.
+    expect(skipped).toEqual([{ path: 'two', reason: 'bytes' }])
     expect(existsSync(join(worktree, 'two'))).toBe(false)
   })
 

--- a/src/main/ipc/worktree-include-copy-budget.test.ts
+++ b/src/main/ipc/worktree-include-copy-budget.test.ts
@@ -94,6 +94,43 @@ describe('worktree copy budget tracker', () => {
     await expect(tracker.admit(join(root, 'small'))).resolves.toMatchObject({ withinBudget: true })
   })
 
+  it('ignores the byte limit when the backend copies on write, but still counts entries', async () => {
+    writeFileSync(join(root, 'huge'), 'x'.repeat(400))
+    const tracker = createWorktreeCopyBudgetTracker(TINY_BYTE_BUDGET)
+
+    await expect(
+      tracker.admit(join(root, 'huge'), { bytesAreCopied: false })
+    ).resolves.toMatchObject({ withinBudget: true })
+
+    // The same source is refused once its bytes actually have to be written.
+    const byteTracker = createWorktreeCopyBudgetTracker(TINY_BYTE_BUDGET)
+    await expect(byteTracker.admit(join(root, 'huge'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'bytes'
+    })
+  })
+
+  it('charges the walk itself so repeated over-budget sources cannot re-walk forever', async () => {
+    for (const dir of ['a', 'b']) {
+      mkdirSync(join(root, dir))
+      writeFileSync(join(root, dir, 'one'), 'x'.repeat(200))
+    }
+    writeFileSync(join(root, 'tiny'), '')
+    // Each refused source walks 2 entries before busting the byte limit, so the
+    // two of them exhaust a 4-entry ceiling.
+    const tracker = createWorktreeCopyBudgetTracker({ maxBytes: 64, maxEntries: 4 })
+
+    await expect(tracker.admit(join(root, 'a'))).resolves.toMatchObject({ withinBudget: false })
+    await expect(tracker.admit(join(root, 'b'))).resolves.toMatchObject({ withinBudget: false })
+
+    // Neither was admitted, so the copy budget itself is untouched and `tiny`
+    // would fit — it is refused purely because the walk ceiling is spent.
+    await expect(tracker.admit(join(root, 'tiny'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'entries'
+    })
+  })
+
   posixIt('counts a nested symlink without following it', async () => {
     mkdirSync(join(root, 'payload'))
     writeFileSync(join(root, 'payload', 'real'), 'x'.repeat(40))
@@ -202,7 +239,7 @@ describe('createWorktreeCopiedPaths copy budget', () => {
     expect(readFileSync(join(worktree, '.vscode', 'settings.json'), 'utf8')).toBe('{}')
   })
 
-  it('does not run the macOS APFS clone for an over-budget entry', async () => {
+  it('still clones on macOS when only the byte budget would be exceeded', async () => {
     mkdirSync(join(primary, 'node_modules'))
     writeFileSync(join(primary, 'node_modules', 'pkg.js'), 'x'.repeat(200))
     const cloneWorktreePath = vi.fn(async () => undefined)
@@ -213,7 +250,27 @@ describe('createWorktreeCopiedPaths copy budget', () => {
       copyBudget: TINY_BYTE_BUDGET
     })
 
-    expect(skipped).toEqual([{ path: 'node_modules', reason: 'bytes' }])
+    // An APFS clone is copy-on-write: bytes cost nothing, so refusing on bytes
+    // would deny a copy that is already free.
+    expect(skipped).toEqual([])
+    expect(cloneWorktreePath).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run the macOS APFS clone for an entry over the file-count limit', async () => {
+    mkdirSync(join(primary, '.cache'))
+    for (const name of ['a', 'b', 'c', 'd', 'e']) {
+      writeFileSync(join(primary, '.cache', name), '')
+    }
+    const cloneWorktreePath = vi.fn(async () => undefined)
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['.cache'], {
+      platform: 'darwin',
+      cloneWorktreePath,
+      copyBudget: TINY_ENTRY_BUDGET
+    })
+
+    // Inodes are real work even on the clone path, so the entry limit holds.
+    expect(skipped).toEqual([{ path: '.cache', reason: 'entries' }])
     expect(cloneWorktreePath).not.toHaveBeenCalled()
   })
 

--- a/src/main/ipc/worktree-include-copy-budget.test.ts
+++ b/src/main/ipc/worktree-include-copy-budget.test.ts
@@ -134,6 +134,32 @@ describe('worktree copy budget tracker', () => {
     })
   })
 
+  it('blames the walk ceiling, not the file limit, for an entry that would have fit', async () => {
+    // 9 sources of 2 entries each leave 2 of the 20-entry walk ceiling — enough
+    // to start measuring `fits`, not enough to finish — while the 4-entry copy
+    // budget stays completely unspent.
+    for (let index = 0; index < 9; index += 1) {
+      mkdirSync(join(root, `dir-${index}`))
+      writeFileSync(join(root, `dir-${index}`, 'one'), 'x'.repeat(200))
+    }
+    mkdirSync(join(root, 'fits'))
+    for (const name of ['a', 'b', 'c']) {
+      writeFileSync(join(root, 'fits', name), '')
+    }
+    const tracker = createWorktreeCopyBudgetTracker({ maxBytes: 64, maxEntries: 4 })
+
+    for (let index = 0; index < 9; index += 1) {
+      await tracker.admit(join(root, `dir-${index}`))
+    }
+
+    // `fits` is 4 entries against an untouched 4-entry budget — the only thing
+    // refusing it is the spent walk, so it must not be told it busted a limit.
+    await expect(tracker.admit(join(root, 'fits'))).resolves.toEqual({
+      withinBudget: false,
+      reason: 'sizing'
+    })
+  })
+
   it('lets a small entry through after one huge entry is refused on file count', async () => {
     // The regression this guards: sizing `node_modules` burns maxEntries + 1
     // walk, which without headroom would starve every entry listed after it.
@@ -177,6 +203,14 @@ describe('formatWorktreeIncludeCopyWarning', () => {
     expect(warning).toContain('"node_modules"')
     expect(warning).toContain('".cache"')
     expect(warning).toContain('.worktreeinclude')
+  })
+
+  it('reads grammatically for a single skipped entry', () => {
+    const warning = formatWorktreeIncludeCopyWarning([{ path: 'node_modules', reason: 'bytes' }])
+
+    expect(warning).toContain('entry "node_modules" was not copied')
+    expect(warning).toContain('copying it would exceed')
+    expect(warning).toContain('Copy it in manually if this workspace needs it.')
   })
 
   it('does not quote the size limits at an entry that was never measured', () => {
@@ -304,6 +338,26 @@ describe('createWorktreeCopiedPaths copy budget', () => {
     // Inodes are real work even on the clone path, so the entry limit holds.
     expect(skipped).toEqual([{ path: '.cache', reason: 'entries' }])
     expect(cloneWorktreePath).not.toHaveBeenCalled()
+  })
+
+  it('does not fall back to a real copy when a failed clone would escape the byte budget', async () => {
+    mkdirSync(join(primary, 'models'))
+    writeFileSync(join(primary, 'models', 'checkpoint'), 'x'.repeat(500))
+    // The clone was predicted (so bytes went uncharged) but fails mid-copy.
+    const cloneWorktreePath = vi.fn(async () => {
+      throw Object.assign(new Error('EPERM'), { code: 'EPERM' })
+    })
+
+    const skipped = await createWorktreeCopiedPaths(primary, worktree, ['models'], {
+      platform: 'darwin',
+      cloneWorktreePath,
+      copyBudget: TINY_BYTE_BUDGET
+    })
+
+    expect(cloneWorktreePath).toHaveBeenCalledTimes(1)
+    expect(skipped).toEqual([{ path: 'models', reason: 'bytes' }])
+    // The whole point: no unbudgeted byte-for-byte copy ran behind the failure.
+    expect(existsSync(join(worktree, 'models'))).toBe(false)
   })
 
   posixIt('leaves link mode unbounded — symlinks cost no bytes', async () => {

--- a/src/main/ipc/worktree-include-copy-budget.ts
+++ b/src/main/ipc/worktree-include-copy-budget.ts
@@ -55,6 +55,10 @@ export type WorktreeCopyBudgetTracker = {
    *  measurement walk and written after it, so concurrent callers would both
    *  size against the same stale pool and could jointly bust the budget. */
   admit: (source: string, options?: WorktreeCopyAdmitOptions) => Promise<WorktreeCopySizeVerdict>
+  /** Bill bytes that were measured but not charged, because the copy was
+   *  expected to clone and then didn't. Returns false if they no longer fit,
+   *  in which case the caller must not run the copy. */
+  chargeBytes: (bytes: number) => boolean
 }
 
 type MeasuredCopySize = {
@@ -68,7 +72,8 @@ type MeasuredCopySize = {
 async function measureCopySize(
   source: string,
   remainingBytes: number,
-  remainingEntries: number
+  remainingEntries: number,
+  remainingWalk: number
 ): Promise<MeasuredCopySize> {
   let bytes = 0
   let entries = 0
@@ -83,8 +88,12 @@ async function measureCopySize(
       continue
     }
     entries += 1
-    if (entries > remainingEntries) {
-      return { verdict: { withinBudget: false, reason: 'entries' }, walked: entries }
+    if (entries > Math.min(remainingEntries, remainingWalk)) {
+      // Why: attribute to whichever ceiling actually bound. Blaming the file
+      // limit for a walk that earlier entries used up would quote the user a
+      // limit this entry never approached.
+      const reason = remainingWalk < remainingEntries ? 'sizing' : 'entries'
+      return { verdict: { withinBudget: false, reason }, walked: entries }
     }
     // Why: both copy backends reproduce a nested symlink as a symlink rather
     // than following it, so walking through one would double-count a shared
@@ -132,7 +141,8 @@ export function createWorktreeCopyBudgetTracker(
       const { verdict, walked } = await measureCopySize(
         source,
         bytesAreCopied ? remainingBytes : Number.POSITIVE_INFINITY,
-        Math.min(remainingEntries, remainingWalk)
+        remainingEntries,
+        remainingWalk
       )
       remainingWalk -= walked
       if (verdict.withinBudget) {
@@ -142,6 +152,13 @@ export function createWorktreeCopyBudgetTracker(
         remainingEntries -= verdict.entries
       }
       return verdict
+    },
+    chargeBytes: (bytes) => {
+      if (bytes > remainingBytes) {
+        return false
+      }
+      remainingBytes -= bytes
+      return true
     }
   }
 }
@@ -169,6 +186,7 @@ export function formatWorktreeIncludeCopyWarning(
     const verb = entries.length === 1 ? 'was' : 'were'
     return `.worktreeinclude ${subject} ${names} ${verb} not copied into the new workspace`
   }
+  const pronoun = (count: number): string => (count === 1 ? 'it' : 'them')
   // Why: an entry refused because earlier ones exhausted the sizing walk never
   // approached the limits itself, so quoting them at the user would be a lie.
   const overBudget = skipped.filter((entry) => entry.reason !== 'sizing')
@@ -176,8 +194,9 @@ export function formatWorktreeIncludeCopyWarning(
   const sentences: string[] = []
   if (overBudget.length > 0) {
     sentences.push(
-      `${describe(overBudget)}: copying them would exceed the ${formatByteLimit(budget.maxBytes)} / ` +
-        `${budget.maxEntries.toLocaleString('en-US')} file limit that keeps workspace creation responsive.`
+      `${describe(overBudget)}: copying ${pronoun(overBudget.length)} would exceed the ` +
+        `${formatByteLimit(budget.maxBytes)} / ${budget.maxEntries.toLocaleString('en-US')} ` +
+        `file limit that keeps workspace creation responsive.`
     )
   }
   if (unsized.length > 0) {
@@ -185,6 +204,8 @@ export function formatWorktreeIncludeCopyWarning(
       `${describe(unsized)}: earlier entries used up the budget for measuring what to copy.`
     )
   }
-  sentences.push('Copy them in manually if this workspace needs them.')
+  sentences.push(
+    `Copy ${pronoun(skipped.length)} in manually if this workspace needs ${pronoun(skipped.length)}.`
+  )
   return sentences.join(' ')
 }

--- a/src/main/ipc/worktree-include-copy-budget.ts
+++ b/src/main/ipc/worktree-include-copy-budget.ts
@@ -185,16 +185,18 @@ export function formatWorktreeIncludeCopyWarning(
   if (skipped.length === 0) {
     return undefined
   }
-  const describe = (entries: readonly SkippedWorktreeCopyPath[]): string => {
-    // Why: `.worktreeinclude` allows 1000 entries and every one can be skipped,
-    // so enumerating them all would put a multi-kilobyte sentence in a warning.
+  // Why: `.worktreeinclude` allows 1000 entries and every one can be skipped,
+  // so enumerating them all would put a multi-kilobyte sentence in a warning.
+  const nameList = (entries: readonly SkippedWorktreeCopyPath[]): string => {
     const shown = entries.slice(0, MAX_NAMED_SKIPPED_ENTRIES)
     const names = shown.map((entry) => `"${entry.path}"`).join(', ')
     const rest = entries.length - shown.length
+    return rest > 0 ? `${names} and ${rest.toLocaleString('en-US')} more` : names
+  }
+  const describe = (entries: readonly SkippedWorktreeCopyPath[]): string => {
     const subject = entries.length === 1 ? 'entry' : 'entries'
     const verb = entries.length === 1 ? 'was' : 'were'
-    const suffix = rest > 0 ? ` and ${rest.toLocaleString('en-US')} more` : ''
-    return `.worktreeinclude ${subject} ${names}${suffix} ${verb} not copied into the new workspace`
+    return `.worktreeinclude ${subject} ${nameList(entries)} ${verb} not copied into the new workspace`
   }
   const pronoun = (count: number): string => (count === 1 ? 'it' : 'them')
   // Why: an entry refused because earlier ones exhausted the sizing walk never
@@ -218,12 +220,8 @@ export function formatWorktreeIncludeCopyWarning(
   if (partial.length > 0) {
     // Why: the copy was abandoned after it started, so "copy it in manually"
     // would merge into whatever the interrupted run already left behind.
-    const names = partial
-      .slice(0, MAX_NAMED_SKIPPED_ENTRIES)
-      .map((entry) => `"${entry.path}"`)
-      .join(', ')
     sentences.push(
-      `${names} may hold a partial copy from the interrupted attempt — check ` +
+      `${nameList(partial)} may hold a partial copy from the interrupted attempt — check ` +
         `${pronoun(partial.length)} before reusing this workspace.`
     )
   }

--- a/src/main/ipc/worktree-include-copy-budget.ts
+++ b/src/main/ipc/worktree-include-copy-budget.ts
@@ -31,18 +31,36 @@ export type SkippedWorktreeCopyPath = {
   reason: WorktreeCopyBudgetExceededReason
 }
 
+export type WorktreeCopyAdmitOptions = {
+  /** False when the backend clones copy-on-write (APFS `clonefile`), where
+   *  bytes cost nothing and only inode count is real work. */
+  bytesAreCopied?: boolean
+}
+
 export type WorktreeCopyBudgetTracker = {
   /** Measure `source` against what is left of the budget. A `withinBudget`
    *  verdict consumes the measured size; an over-budget verdict consumes
-   *  nothing, so later, smaller entries still get their chance. */
-  admit: (source: string) => Promise<WorktreeCopySizeVerdict>
+   *  nothing, so later, smaller entries still get their chance.
+   *
+   *  Await each call before the next: the remaining pool is read before the
+   *  measurement walk and written after it, so concurrent callers would both
+   *  size against the same stale pool and could jointly bust the budget. */
+  admit: (source: string, options?: WorktreeCopyAdmitOptions) => Promise<WorktreeCopySizeVerdict>
+}
+
+type MeasuredCopySize = {
+  verdict: WorktreeCopySizeVerdict
+  /** Entries actually walked, whatever the verdict — this is the measurement's
+   *  own cost, which the tracker charges so a long list of over-budget entries
+   *  cannot re-freeze creation by re-walking for each one. */
+  walked: number
 }
 
 async function measureCopySize(
   source: string,
   remainingBytes: number,
   remainingEntries: number
-): Promise<WorktreeCopySizeVerdict> {
+): Promise<MeasuredCopySize> {
   let bytes = 0
   let entries = 0
   const pending: string[] = [source]
@@ -57,7 +75,7 @@ async function measureCopySize(
     }
     entries += 1
     if (entries > remainingEntries) {
-      return { withinBudget: false, reason: 'entries' }
+      return { verdict: { withinBudget: false, reason: 'entries' }, walked: entries }
     }
     // Why: both copy backends reproduce a nested symlink as a symlink rather
     // than following it, so walking through one would double-count a shared
@@ -77,10 +95,10 @@ async function measureCopySize(
     }
     bytes += stats.size
     if (bytes > remainingBytes) {
-      return { withinBudget: false, reason: 'bytes' }
+      return { verdict: { withinBudget: false, reason: 'bytes' }, walked: entries }
     }
   }
-  return { withinBudget: true, bytes, entries }
+  return { verdict: { withinBudget: true, bytes, entries }, walked: entries }
 }
 
 /** Why a pre-measurement pass rather than aborting mid-copy: `fs.cp` ignores
@@ -93,11 +111,25 @@ export function createWorktreeCopyBudgetTracker(
 ): WorktreeCopyBudgetTracker {
   let remainingBytes = budget.maxBytes
   let remainingEntries = budget.maxEntries
+  // Why: refused entries consume no copy budget, so without a separate ceiling
+  // on walking itself a `.worktreeinclude` listing 1000 over-budget directories
+  // would pay a fresh full-limit walk for each one — the very stall this bounds.
+  let remainingWalk = budget.maxEntries
   return {
-    admit: async (source) => {
-      const verdict = await measureCopySize(source, remainingBytes, remainingEntries)
+    admit: async (source, { bytesAreCopied = true } = {}) => {
+      if (remainingWalk <= 0) {
+        return { withinBudget: false, reason: 'entries' }
+      }
+      const { verdict, walked } = await measureCopySize(
+        source,
+        bytesAreCopied ? remainingBytes : Number.POSITIVE_INFINITY,
+        Math.min(remainingEntries, remainingWalk)
+      )
+      remainingWalk -= walked
       if (verdict.withinBudget) {
-        remainingBytes -= verdict.bytes
+        if (bytesAreCopied) {
+          remainingBytes -= verdict.bytes
+        }
         remainingEntries -= verdict.entries
       }
       return verdict

--- a/src/main/ipc/worktree-include-copy-budget.ts
+++ b/src/main/ipc/worktree-include-copy-budget.ts
@@ -20,7 +20,16 @@ export const DEFAULT_WORKTREE_COPY_BUDGET: WorktreeCopyBudget = {
   maxEntries: 50_000
 }
 
-export type WorktreeCopyBudgetExceededReason = 'bytes' | 'entries'
+// Why: the sizing walk gets headroom over the copy budget so one refused
+// `node_modules` cannot starve the small entries listed after it — it burns
+// maxEntries+1 measuring, and without headroom nothing else would be sized.
+const WORKTREE_COPY_SIZING_HEADROOM = 5
+
+export type WorktreeCopyBudgetExceededReason =
+  | 'bytes'
+  | 'entries'
+  /** Not this entry's fault: earlier entries used up the total sizing walk. */
+  | 'sizing'
 
 export type WorktreeCopySizeVerdict =
   | { withinBudget: true; bytes: number; entries: number }
@@ -114,11 +123,11 @@ export function createWorktreeCopyBudgetTracker(
   // Why: refused entries consume no copy budget, so without a separate ceiling
   // on walking itself a `.worktreeinclude` listing 1000 over-budget directories
   // would pay a fresh full-limit walk for each one — the very stall this bounds.
-  let remainingWalk = budget.maxEntries
+  let remainingWalk = budget.maxEntries * WORKTREE_COPY_SIZING_HEADROOM
   return {
     admit: async (source, { bytesAreCopied = true } = {}) => {
       if (remainingWalk <= 0) {
-        return { withinBudget: false, reason: 'entries' }
+        return { withinBudget: false, reason: 'sizing' }
       }
       const { verdict, walked } = await measureCopySize(
         source,
@@ -154,13 +163,28 @@ export function formatWorktreeIncludeCopyWarning(
   if (skipped.length === 0) {
     return undefined
   }
-  const names = skipped.map((entry) => `"${entry.path}"`).join(', ')
-  const subject = skipped.length === 1 ? 'entry' : 'entries'
-  const verb = skipped.length === 1 ? 'was' : 'were'
-  return (
-    `.worktreeinclude ${subject} ${names} ${verb} not copied into the new workspace: ` +
-    `copying them would exceed the ${formatByteLimit(budget.maxBytes)} / ` +
-    `${budget.maxEntries.toLocaleString('en-US')} file limit that keeps workspace creation responsive. ` +
-    `Copy them in manually if this workspace needs them.`
-  )
+  const describe = (entries: readonly SkippedWorktreeCopyPath[]): string => {
+    const names = entries.map((entry) => `"${entry.path}"`).join(', ')
+    const subject = entries.length === 1 ? 'entry' : 'entries'
+    const verb = entries.length === 1 ? 'was' : 'were'
+    return `.worktreeinclude ${subject} ${names} ${verb} not copied into the new workspace`
+  }
+  // Why: an entry refused because earlier ones exhausted the sizing walk never
+  // approached the limits itself, so quoting them at the user would be a lie.
+  const overBudget = skipped.filter((entry) => entry.reason !== 'sizing')
+  const unsized = skipped.filter((entry) => entry.reason === 'sizing')
+  const sentences: string[] = []
+  if (overBudget.length > 0) {
+    sentences.push(
+      `${describe(overBudget)}: copying them would exceed the ${formatByteLimit(budget.maxBytes)} / ` +
+        `${budget.maxEntries.toLocaleString('en-US')} file limit that keeps workspace creation responsive.`
+    )
+  }
+  if (unsized.length > 0) {
+    sentences.push(
+      `${describe(unsized)}: earlier entries used up the budget for measuring what to copy.`
+    )
+  }
+  sentences.push('Copy them in manually if this workspace needs them.')
+  return sentences.join(' ')
 }

--- a/src/main/ipc/worktree-include-copy-budget.ts
+++ b/src/main/ipc/worktree-include-copy-budget.ts
@@ -1,0 +1,134 @@
+import { lstat, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+
+/** Ceiling on what one worktree materialization may copy, measured before any
+ *  bytes are written. Both limits are cumulative across the whole run, so a
+ *  hundred medium entries trip the same guard one huge entry does. */
+export type WorktreeCopyBudget = {
+  maxBytes: number
+  maxEntries: number
+}
+
+// Why: `.worktreeinclude` is a repo-authored list, and a repo that lists
+// `node_modules` freezes worktree creation for minutes behind an inline copy
+// (macOS gets a cheap APFS clone; Linux/Windows get a full `fs.cp`). These
+// limits clear real payloads — `.env` files, `.vscode/`, small build caches —
+// and refuse dependency trees. The entry limit matters as much as the byte
+// limit: 200k tiny files are slow to copy even though they weigh little.
+export const DEFAULT_WORKTREE_COPY_BUDGET: WorktreeCopyBudget = {
+  maxBytes: 2 * 1024 * 1024 * 1024,
+  maxEntries: 50_000
+}
+
+export type WorktreeCopyBudgetExceededReason = 'bytes' | 'entries'
+
+export type WorktreeCopySizeVerdict =
+  | { withinBudget: true; bytes: number; entries: number }
+  | { withinBudget: false; reason: WorktreeCopyBudgetExceededReason }
+
+export type SkippedWorktreeCopyPath = {
+  path: string
+  reason: WorktreeCopyBudgetExceededReason
+}
+
+export type WorktreeCopyBudgetTracker = {
+  /** Measure `source` against what is left of the budget. A `withinBudget`
+   *  verdict consumes the measured size; an over-budget verdict consumes
+   *  nothing, so later, smaller entries still get their chance. */
+  admit: (source: string) => Promise<WorktreeCopySizeVerdict>
+}
+
+async function measureCopySize(
+  source: string,
+  remainingBytes: number,
+  remainingEntries: number
+): Promise<WorktreeCopySizeVerdict> {
+  let bytes = 0
+  let entries = 0
+  const pending: string[] = [source]
+  while (pending.length > 0) {
+    const current = pending.pop() as string
+    let stats: Awaited<ReturnType<typeof lstat>>
+    try {
+      stats = await lstat(current)
+    } catch {
+      // Raced away between the walk and now — the copy will skip it too.
+      continue
+    }
+    entries += 1
+    if (entries > remainingEntries) {
+      return { withinBudget: false, reason: 'entries' }
+    }
+    // Why: both copy backends reproduce a nested symlink as a symlink rather
+    // than following it, so walking through one would double-count a shared
+    // target and could loop forever on a cycle.
+    if (stats.isSymbolicLink()) {
+      continue
+    }
+    if (stats.isDirectory()) {
+      try {
+        for (const name of await readdir(current)) {
+          pending.push(join(current, name))
+        }
+      } catch {
+        // Unreadable directory — nothing measurable, and the copy will report it.
+      }
+      continue
+    }
+    bytes += stats.size
+    if (bytes > remainingBytes) {
+      return { withinBudget: false, reason: 'bytes' }
+    }
+  }
+  return { withinBudget: true, bytes, entries }
+}
+
+/** Why a pre-measurement pass rather than aborting mid-copy: `fs.cp` ignores
+ *  its `signal` option, so a copy that has started cannot be cancelled and
+ *  would leave a partial tree behind. Refusing before the first byte is
+ *  written keeps the worktree in a state the user can reason about. The walk
+ *  is itself bounded — it returns the moment either limit is crossed. */
+export function createWorktreeCopyBudgetTracker(
+  budget: WorktreeCopyBudget = DEFAULT_WORKTREE_COPY_BUDGET
+): WorktreeCopyBudgetTracker {
+  let remainingBytes = budget.maxBytes
+  let remainingEntries = budget.maxEntries
+  return {
+    admit: async (source) => {
+      const verdict = await measureCopySize(source, remainingBytes, remainingEntries)
+      if (verdict.withinBudget) {
+        remainingBytes -= verdict.bytes
+        remainingEntries -= verdict.entries
+      }
+      return verdict
+    }
+  }
+}
+
+function formatByteLimit(maxBytes: number): string {
+  const gigabytes = maxBytes / (1024 * 1024 * 1024)
+  if (gigabytes >= 1) {
+    return `${Number(gigabytes.toFixed(1))} GB`
+  }
+  return `${Math.max(1, Math.round(maxBytes / (1024 * 1024)))} MB`
+}
+
+/** User-facing warning for entries the budget refused. Returns undefined when
+ *  nothing was skipped so callers can spread it conditionally. */
+export function formatWorktreeIncludeCopyWarning(
+  skipped: readonly SkippedWorktreeCopyPath[],
+  budget: WorktreeCopyBudget = DEFAULT_WORKTREE_COPY_BUDGET
+): string | undefined {
+  if (skipped.length === 0) {
+    return undefined
+  }
+  const names = skipped.map((entry) => `"${entry.path}"`).join(', ')
+  const subject = skipped.length === 1 ? 'entry' : 'entries'
+  const verb = skipped.length === 1 ? 'was' : 'were'
+  return (
+    `.worktreeinclude ${subject} ${names} ${verb} not copied into the new workspace: ` +
+    `copying them would exceed the ${formatByteLimit(budget.maxBytes)} / ` +
+    `${budget.maxEntries.toLocaleString('en-US')} file limit that keeps workspace creation responsive. ` +
+    `Copy them in manually if this workspace needs them.`
+  )
+}

--- a/src/main/ipc/worktree-include-copy-budget.ts
+++ b/src/main/ipc/worktree-include-copy-budget.ts
@@ -38,6 +38,9 @@ export type WorktreeCopySizeVerdict =
 export type SkippedWorktreeCopyPath = {
   path: string
   reason: WorktreeCopyBudgetExceededReason
+  /** The copy was abandoned after it had started, so leftovers may remain —
+   *  "copy it in manually" would then merge into a half-populated directory. */
+  mayBePartial?: boolean
 }
 
 export type WorktreeCopyAdmitOptions = {
@@ -171,6 +174,8 @@ function formatByteLimit(maxBytes: number): string {
   return `${Math.max(1, Math.round(maxBytes / (1024 * 1024)))} MB`
 }
 
+const MAX_NAMED_SKIPPED_ENTRIES = 5
+
 /** User-facing warning for entries the budget refused. Returns undefined when
  *  nothing was skipped so callers can spread it conditionally. */
 export function formatWorktreeIncludeCopyWarning(
@@ -181,10 +186,15 @@ export function formatWorktreeIncludeCopyWarning(
     return undefined
   }
   const describe = (entries: readonly SkippedWorktreeCopyPath[]): string => {
-    const names = entries.map((entry) => `"${entry.path}"`).join(', ')
+    // Why: `.worktreeinclude` allows 1000 entries and every one can be skipped,
+    // so enumerating them all would put a multi-kilobyte sentence in a warning.
+    const shown = entries.slice(0, MAX_NAMED_SKIPPED_ENTRIES)
+    const names = shown.map((entry) => `"${entry.path}"`).join(', ')
+    const rest = entries.length - shown.length
     const subject = entries.length === 1 ? 'entry' : 'entries'
     const verb = entries.length === 1 ? 'was' : 'were'
-    return `.worktreeinclude ${subject} ${names} ${verb} not copied into the new workspace`
+    const suffix = rest > 0 ? ` and ${rest.toLocaleString('en-US')} more` : ''
+    return `.worktreeinclude ${subject} ${names}${suffix} ${verb} not copied into the new workspace`
   }
   const pronoun = (count: number): string => (count === 1 ? 'it' : 'them')
   // Why: an entry refused because earlier ones exhausted the sizing walk never
@@ -199,9 +209,22 @@ export function formatWorktreeIncludeCopyWarning(
         `file limit that keeps workspace creation responsive.`
     )
   }
+  const partial = skipped.filter((entry) => entry.mayBePartial)
   if (unsized.length > 0) {
     sentences.push(
       `${describe(unsized)}: earlier entries used up the budget for measuring what to copy.`
+    )
+  }
+  if (partial.length > 0) {
+    // Why: the copy was abandoned after it started, so "copy it in manually"
+    // would merge into whatever the interrupted run already left behind.
+    const names = partial
+      .slice(0, MAX_NAMED_SKIPPED_ENTRIES)
+      .map((entry) => `"${entry.path}"`)
+      .join(', ')
+    sentences.push(
+      `${names} may hold a partial copy from the interrupted attempt — check ` +
+        `${pronoun(partial.length)} before reusing this workspace.`
     )
   }
   sentences.push(

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -96,6 +96,7 @@ import {
 } from './worktree-push-target-setup'
 import { isENOENT, registerWorktreeRootsForRepo } from './filesystem-auth'
 import { createWorktreeCopiedPaths, createWorktreeLinkedPaths } from './worktree-symlinks'
+import { formatWorktreeIncludeCopyWarning } from './worktree-include-copy-budget'
 import { resolveWorktreeIncludePaths } from '../git/worktree-include-file'
 import { normalizeSparseDirectories } from './sparse-checkout-directories'
 import { joinWorktreeRelativePath } from '../runtime/runtime-relative-paths'
@@ -2466,9 +2467,18 @@ export async function createLocalWorktree(
   const includePaths = await timing.time('resolve_worktreeinclude', () =>
     resolveWorktreeIncludePaths(repo.path, localWorktreeGitOptions)
   )
+  let includeCopyWarning: string | undefined
   if (includePaths.length > 0) {
     await timing.time('copy_worktreeinclude', async () => {
-      await createWorktreeCopiedPaths(repo.path, created.path, includePaths)
+      const skippedIncludePaths = await createWorktreeCopiedPaths(
+        repo.path,
+        created.path,
+        includePaths
+      )
+      includeCopyWarning = formatWorktreeIncludeCopyWarning(skippedIncludePaths)
+      if (includeCopyWarning) {
+        console.warn(`[worktree-include] ${includeCopyWarning}`)
+      }
     })
   }
 
@@ -2542,7 +2552,11 @@ export async function createLocalWorktree(
       ? { localBaseRefUpdateSuggestion: addResult.localBaseRefUpdateSuggestion }
       : {}),
     ...(stagedStartup.startupTerminal ? { startupTerminal: stagedStartup.startupTerminal } : {}),
-    ...(stagedStartup.warning ? { warning: stagedStartup.warning } : {}),
+    ...(stagedStartup.warning
+      ? { warning: appendWorktreeCreateWarning(includeCopyWarning, stagedStartup.warning) }
+      : includeCopyWarning
+        ? { warning: includeCopyWarning }
+        : {}),
     timing: timing.finish()
   }
 }

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -266,9 +266,14 @@ async function materializeWorktreePaths(
       )
     } catch (error) {
       if (error instanceof WorktreeCopyBudgetFallbackError) {
-        // Why: the clone had already started, and it only removes an *empty*
-        // reservation on failure, so leftovers can survive at the target.
-        skipped.push({ path: safePath.rel, reason: 'bytes', mayBePartial: true })
+        // Why: a directory clone reserves the target and only removes it when
+        // it is still *empty*, so leftovers can survive. A file clone publishes
+        // from a temp path with link(2), so a failure leaves nothing behind.
+        skipped.push({
+          path: safePath.rel,
+          reason: 'bytes',
+          ...(sourceIsDirectory ? { mayBePartial: true } : {})
+        })
         console.warn(`[worktree-symlinks] Skipping "${safePath.rel}": ${error.message}`)
         continue
       }

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -73,6 +73,15 @@ async function copyWorktreePath(source: string, target: string): Promise<void> {
   await cp(source, target, { recursive: true, force: false, errorOnExist: false })
 }
 
+/** An APFS clone was expected (so its bytes were never charged) but failed, and
+ *  the byte-for-byte fallback would escape the budget. */
+class WorktreeCopyBudgetFallbackError extends Error {
+  constructor(target: string) {
+    super(`APFS clone failed and a real copy of "${target}" would exceed the copy budget`)
+    this.name = 'WorktreeCopyBudgetFallbackError'
+  }
+}
+
 async function createWorktreeLinkedPath(
   source: string,
   copySource: string,
@@ -81,7 +90,8 @@ async function createWorktreeLinkedPath(
   sourceIsSymbolicLink: boolean,
   mode: WorktreeMaterializeMode,
   options: WorktreeLinkedPathOptions,
-  apfsFilesystemCache: DarwinFilesystemCache
+  apfsFilesystemCache: DarwinFilesystemCache,
+  realCopyFallbackAllowed: () => boolean
 ): Promise<void> {
   if (options.platform === 'darwin' && (!sourceIsSymbolicLink || mode === 'copy')) {
     try {
@@ -106,6 +116,13 @@ async function createWorktreeLinkedPath(
       // appeared after our preflight.
       if (!(error instanceof ApfsCloneUnavailableError)) {
         console.warn(`[worktree-symlinks] APFS clone-copy unavailable for "${target}":`, error)
+        // Why: the fallback is a real byte-for-byte copy. If this entry was
+        // admitted as a free clone its bytes were never charged, so bill them
+        // now — and refuse if they no longer fit, rather than silently
+        // reopening the unbounded copy this budget exists to close.
+        if (mode === 'copy' && !realCopyFallbackAllowed()) {
+          throw new WorktreeCopyBudgetFallbackError(target)
+        }
       }
     }
   }
@@ -201,6 +218,8 @@ async function materializeWorktreePaths(
     // worktree would leak back into the primary checkout (or escape it entirely if
     // the link points outside). Resolve the real source so we copy content.
     let copySource = source
+    let bytesAreCopied = true
+    let measuredBytes = 0
     if (mode === 'copy') {
       try {
         if (sourceIsSymbolicLink) {
@@ -209,7 +228,7 @@ async function materializeWorktreePaths(
         // Why: an APFS clone is copy-on-write — a 2.7 GB tree clones in ~20ms
         // and consumes no disk — so bytes are not the cost there, inodes are.
         // Charging bytes on that path would refuse work that is already free.
-        const bytesAreCopied = !(await copyIsCopyOnWrite(
+        bytesAreCopied = !(await copyIsCopyOnWrite(
           copySource,
           worktreePath,
           effectiveOptions,
@@ -226,6 +245,7 @@ async function materializeWorktreePaths(
           )
           continue
         }
+        measuredBytes = verdict.bytes
       } catch (error) {
         console.error(`[worktree-symlinks] Failed to size "${safePath.rel}" (${source}):`, error)
         continue
@@ -241,9 +261,15 @@ async function materializeWorktreePaths(
         sourceIsSymbolicLink,
         mode,
         effectiveOptions,
-        apfsFilesystemCache
+        apfsFilesystemCache,
+        () => bytesAreCopied || copyBudget.chargeBytes(measuredBytes)
       )
     } catch (error) {
+      if (error instanceof WorktreeCopyBudgetFallbackError) {
+        skipped.push({ path: safePath.rel, reason: 'bytes' })
+        console.warn(`[worktree-symlinks] Skipping "${safePath.rel}": ${error.message}`)
+        continue
+      }
       console.error(
         `[worktree-symlinks] Failed to link "${safePath.rel}" (${source} -> ${target}):`,
         error

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -266,7 +266,9 @@ async function materializeWorktreePaths(
       )
     } catch (error) {
       if (error instanceof WorktreeCopyBudgetFallbackError) {
-        skipped.push({ path: safePath.rel, reason: 'bytes' })
+        // Why: the clone had already started, and it only removes an *empty*
+        // reservation on failure, so leftovers can survive at the target.
+        skipped.push({ path: safePath.rel, reason: 'bytes', mayBePartial: true })
         console.warn(`[worktree-symlinks] Skipping "${safePath.rel}": ${error.message}`)
         continue
       }

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -2,6 +2,7 @@ import { symlink, mkdir, stat, lstat, unlink, cp, realpath } from 'node:fs/promi
 import { dirname, isAbsolute, resolve } from 'node:path'
 import {
   ApfsCloneUnavailableError,
+  canCloneWithApfs,
   cloneWorktreePathWithApfs,
   defaultApfsCloneDeps,
   WorktreeLinkedPathTargetExistsError,
@@ -115,6 +116,30 @@ async function createWorktreeLinkedPath(
   await symlinkWorktreePath(source, target, sourceIsDirectory)
 }
 
+/** Whether this copy will land as an APFS clone rather than a byte-for-byte
+ *  copy. Only the volume probe can answer it, and that probe writes nothing. */
+async function copyIsCopyOnWrite(
+  source: string,
+  worktreePath: string,
+  options: WorktreeLinkedPathOptions,
+  apfsFilesystemCache: DarwinFilesystemCache
+): Promise<boolean> {
+  if (options.platform !== 'darwin') {
+    return false
+  }
+  // An injected clone stands in for the real one, so treat it as cloning —
+  // probing the real filesystem here would make these tests host-dependent.
+  if (options.cloneWorktreePath) {
+    return true
+  }
+  return await canCloneWithApfs(
+    source,
+    worktreePath,
+    options.apfsCloneDeps ?? defaultApfsCloneDeps,
+    apfsFilesystemCache
+  )
+}
+
 async function targetExists(target: string): Promise<boolean> {
   try {
     // Why: lstat so a pre-existing symlink (even a broken one) is detected and
@@ -181,7 +206,16 @@ async function materializeWorktreePaths(
         if (sourceIsSymbolicLink) {
           copySource = await realpath(source)
         }
-        const verdict = await copyBudget.admit(copySource)
+        // Why: an APFS clone is copy-on-write — a 2.7 GB tree clones in ~20ms
+        // and consumes no disk — so bytes are not the cost there, inodes are.
+        // Charging bytes on that path would refuse work that is already free.
+        const bytesAreCopied = !(await copyIsCopyOnWrite(
+          copySource,
+          worktreePath,
+          effectiveOptions,
+          apfsFilesystemCache
+        ))
+        const verdict = await copyBudget.admit(copySource, { bytesAreCopied })
         if (!verdict.withinBudget) {
           // Why: refuse before the first byte is written. Aborting mid-copy is
           // not available (`fs.cp` ignores its `signal`) and would strand a

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -8,11 +8,19 @@ import {
   type ApfsCloneDeps,
   type DarwinFilesystemCache
 } from './worktree-apfs-clone'
+import {
+  createWorktreeCopyBudgetTracker,
+  type SkippedWorktreeCopyPath,
+  type WorktreeCopyBudget
+} from './worktree-include-copy-budget'
 
 type WorktreeLinkedPathOptions = {
   platform?: NodeJS.Platform
   cloneWorktreePath?: (source: string, target: string, sourceIsDirectory: boolean) => Promise<void>
   apfsCloneDeps?: ApfsCloneDeps
+  /** Copy-mode only. Overridable so tests can trip the bound without writing
+   *  gigabytes to disk. */
+  copyBudget?: WorktreeCopyBudget
 }
 
 // 'link': symlink when APFS clone is unavailable (user-configured shared paths).
@@ -66,6 +74,7 @@ async function copyWorktreePath(source: string, target: string): Promise<void> {
 
 async function createWorktreeLinkedPath(
   source: string,
+  copySource: string,
   target: string,
   sourceIsDirectory: boolean,
   sourceIsSymbolicLink: boolean,
@@ -73,11 +82,6 @@ async function createWorktreeLinkedPath(
   options: WorktreeLinkedPathOptions,
   apfsFilesystemCache: DarwinFilesystemCache
 ): Promise<void> {
-  // Why: copy mode promises each worktree an independent copy; copying the
-  // symlink itself would recreate a link to the shared target, so edits in the
-  // worktree would leak back into the primary checkout (or escape it entirely if
-  // the link points outside). Resolve the real source so we copy content.
-  const copySource = mode === 'copy' && sourceIsSymbolicLink ? await realpath(source) : source
   if (options.platform === 'darwin' && (!sourceIsSymbolicLink || mode === 'copy')) {
     try {
       const cloneWorktreePath =
@@ -128,11 +132,15 @@ async function materializeWorktreePaths(
   paths: readonly string[],
   mode: WorktreeMaterializeMode,
   options: WorktreeLinkedPathOptions = {}
-): Promise<void> {
+): Promise<SkippedWorktreeCopyPath[]> {
   const effectiveOptions = { platform: process.platform, ...options }
   // Why: one df+diskutil probe per distinct volume for the whole materialization,
   // not per copied path — see DarwinFilesystemCache.
   const apfsFilesystemCache: DarwinFilesystemCache = new Map()
+  // Why: one budget for the whole materialization, so a hundred medium entries
+  // are refused for the same reason one `node_modules` entry is.
+  const copyBudget = createWorktreeCopyBudgetTracker(options.copyBudget)
+  const skipped: SkippedWorktreeCopyPath[] = []
 
   for (const rawPath of paths) {
     const safePath = getSafeRelativePath(rawPath)
@@ -163,9 +171,37 @@ async function materializeWorktreePaths(
       continue
     }
 
+    // Why: copy mode promises each worktree an independent copy; copying the
+    // symlink itself would recreate a link to the shared target, so edits in the
+    // worktree would leak back into the primary checkout (or escape it entirely if
+    // the link points outside). Resolve the real source so we copy content.
+    let copySource = source
+    if (mode === 'copy') {
+      try {
+        if (sourceIsSymbolicLink) {
+          copySource = await realpath(source)
+        }
+        const verdict = await copyBudget.admit(copySource)
+        if (!verdict.withinBudget) {
+          // Why: refuse before the first byte is written. Aborting mid-copy is
+          // not available (`fs.cp` ignores its `signal`) and would strand a
+          // partial tree; the caller surfaces this as a create warning.
+          skipped.push({ path: safePath.rel, reason: verdict.reason })
+          console.warn(
+            `[worktree-symlinks] Skipping "${safePath.rel}": copy exceeds the worktree copy budget (${verdict.reason})`
+          )
+          continue
+        }
+      } catch (error) {
+        console.error(`[worktree-symlinks] Failed to size "${safePath.rel}" (${source}):`, error)
+        continue
+      }
+    }
+
     try {
       await createWorktreeLinkedPath(
         source,
+        copySource,
         target,
         sourceIsDirectory,
         sourceIsSymbolicLink,
@@ -180,6 +216,7 @@ async function materializeWorktreePaths(
       )
     }
   }
+  return skipped
 }
 
 export async function createWorktreeLinkedPaths(
@@ -194,14 +231,18 @@ export async function createWorktreeLinkedPaths(
 /** Copy `.worktreeinclude`-resolved paths from the primary checkout into a
  *  freshly-created worktree. Same per-path failure isolation as
  *  createWorktreeLinkedPaths, but the non-APFS fallback is a real copy, never a
- *  symlink: the convention promises each worktree its own private copy. */
+ *  symlink: the convention promises each worktree its own private copy.
+ *
+ *  Returns the entries refused by the copy budget so worktree creation can
+ *  surface them — a workspace quietly missing its included files is worse than
+ *  one that says which entries it left behind. */
 export async function createWorktreeCopiedPaths(
   primaryPath: string,
   worktreePath: string,
   paths: readonly string[],
   options: WorktreeLinkedPathOptions = {}
-): Promise<void> {
-  await materializeWorktreePaths(primaryPath, worktreePath, paths, 'copy', options)
+): Promise<SkippedWorktreeCopyPath[]> {
+  return await materializeWorktreePaths(primaryPath, worktreePath, paths, 'copy', options)
 }
 
 /** Create filesystem symlinks from the primary checkout into a freshly-created

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -792,6 +792,7 @@ import {
   findExistingWorktreeSymlinkPaths,
   removeWorktreeLinkedPaths
 } from '../ipc/worktree-symlinks'
+import { formatWorktreeIncludeCopyWarning } from '../ipc/worktree-include-copy-budget'
 import { resolveWorktreeIncludePaths } from '../git/worktree-include-file'
 import { deleteWorktreeHistoryDir } from '../terminal-history'
 import {
@@ -18930,12 +18931,21 @@ export class OrcaRuntimeService {
       repo.path,
       localWorktreeGitOptions
     )
+    let includeCopyWarning: string | undefined
     if (worktreeIncludePaths.length > 0) {
-      await createWorktreeCopiedPaths(repo.path, created.path, worktreeIncludePaths)
+      const skippedIncludePaths = await createWorktreeCopiedPaths(
+        repo.path,
+        created.path,
+        worktreeIncludePaths
+      )
+      includeCopyWarning = formatWorktreeIncludeCopyWarning(skippedIncludePaths)
+      if (includeCopyWarning) {
+        console.warn(`[worktree-include] ${includeCopyWarning}`)
+      }
     }
 
     let setup: CreateWorktreeResult['setup']
-    let warning: string | undefined
+    let warning: string | undefined = includeCopyWarning
     // Why: CLI-created worktrees do not have a renderer preview to mismatch
     // against. Trust is granted by the direct CLI invocation (`--run-hooks`),
     // so loading the setup hook from the created worktree is intentional here.
@@ -18989,8 +18999,9 @@ export class OrcaRuntimeService {
       }
     } else if (hooks?.scripts.setup && effectiveDecision !== 'skip') {
       // Runtime RPC calls have no renderer trust prompt, so hooks require explicit CLI opt-in.
-      warning = `orca.yaml setup hook skipped for ${worktreePath}; pass --setup run to run it.`
-      console.warn(`[hooks] ${warning}`)
+      const setupSkipped = `orca.yaml setup hook skipped for ${worktreePath}; pass --setup run to run it.`
+      warning = warning ? `${warning} Also ${setupSkipped}` : setupSkipped
+      console.warn(`[hooks] ${setupSkipped}`)
     }
 
     this.invalidateResolvedWorktreeCache()


### PR DESCRIPTION
## Problem

`.worktreeinclude` copying is bounded in **entry count** (`WORKTREE_INCLUDE_MAX_ENTRIES = 1000`) but not in **bytes or files**, and it is awaited inline during worktree creation:

- `src/main/ipc/worktree-remote.ts` (desktop create)
- `src/main/runtime/orca-runtime.ts` (CLI / RPC / automation create)

macOS takes the cheap APFS clone path, so it is nearly free there. Linux and Windows fall back to a full `fs.cp` with no timeout and no cancellation. A repo whose `.worktreeinclude` lists `node_modules` freezes workspace creation for minutes behind the create dialog.

Per-path failures are caught and logged in `worktree-symlinks.ts`, so a mid-copy failure also leaves a partial tree with no cleanup.

## Fix — one concern: bound the copy

New `src/main/ipc/worktree-include-copy-budget.ts` measures each copy-mode source against a **cumulative budget (2 GB / 50,000 files)** *before the first byte is written*, and refuses entries that bust it. The budget is shared across the whole materialization, so a hundred medium entries trip the same guard one huge entry does.

The measurement walk is itself bounded — it returns the moment either limit is crossed, so sizing `node_modules` is not itself a freeze.

**Failing is not silent.** Refused entries are returned from `createWorktreeCopiedPaths` and surfaced on the existing `CreateWorktreeResult.warning` channel at both create sites, naming each skipped entry. A workspace quietly missing its included files would be a worse bug than the freeze.

### Why pre-measurement instead of aborting mid-copy

`fs.cp` **ignores its `signal` option** — verified on this runtime:

```
$ node -e "const fs=require('fs/promises');const ac=new AbortController();ac.abort();
  fs.cp('/tmp','/tmp/x',{recursive:true,signal:ac.signal})
    .then(()=>console.log('RESOLVED - signal ignored')).catch(e=>console.log('REJECTED',e.code))"
RESOLVED - signal ignored
```

A copy that has started cannot be cancelled, so a timeout could only stop *awaiting* it — leaving an unbounded copy still writing and a partial tree behind. Refusing up front means there is no partial state to clean up at all.

## Deliberately deferred (follow-ups, not dropped)

1. **Timeout on the copy.** Coupled to cancellation + cleanup for the reason above. On the macOS APFS path the `/bin/cp` subprocess *is* killable via `execFileAsync`'s `timeout`, but adding it only there gives asymmetric cross-platform semantics and reintroduces the partial-directory question (`cloneDirectoryWithApfs` only cleans up an *empty* reservation).
2. **Partial-tree cleanup on failure/abort.** Unreachable for the bound case now (nothing is written), but still open for a genuine mid-copy I/O failure.
3. **Full cancellation wiring** (create dialog → copy). Needs UI plumbing that does not belong in this PR.
4. **`CreateWorktreeResult.warning` has no desktop renderer consumer.** Pre-existing gap, found while wiring this up: `src/cli/handlers/worktree.ts:48` prints it and `src/main/index.ts:2098` uses it for automations, but `worktree-creation-flow.ts` drops it. So today this warning reaches CLI/automation users and main-process logs, not a desktop toast. Making the desktop flow surface `result.warning` would also start showing the existing setup-hook-skipped and startup-terminal-failed warnings, which is a separate behavior change.

## Cross-platform

- Bound applies on every platform — it gates the APFS clone and the `fs.cp` fallback identically (test: `does not run the macOS APFS clone for an over-budget entry`).
- All path handling goes through `node:path` `join`/`resolve`; no separator assumptions. The one symlink-specific test is `posixIt`-gated like the rest of the file.
- SSH / remote create (`worktree-remote.ts`) and folder workspaces are covered — the bound lives in the shared materialization path, not at one call site.
- **Link mode (`repo.symlinkPaths`) is deliberately untouched** — symlinks cost no bytes. Only copy mode (`.worktreeinclude`) is budgeted.

## Tests

New `src/main/ipc/worktree-include-copy-budget.test.ts` (14 tests) + one added to `worktree-include-file.test.ts`. The bound is injectable (`options.copyBudget`) so fixtures trip it for the right reason without writing gigabytes to disk.

- over-byte-bound entry refused, **nothing written** into the worktree
- over-file-count entry refused even though it weighs ~0 bytes
- entries that fit still copy alongside one that does not
- a normal small include copies fully and reports nothing skipped
- budget is cumulative; a refused source does not consume budget
- nested symlinks are counted, not followed
- the existing 1000-entry count bound still holds

### Revert-check (each new test genuinely fails without the fix)

Reverting `worktree-symlinks.ts` (enforcement removed):
```
Tests  5 failed | 9 passed (14)
× refuses an over-budget directory before writing anything into the worktree
× refuses an entry that busts the file-count limit
× still copies the entries that fit alongside one that does not
× copies a normal small include fully and reports nothing skipped
× does not run the macOS APFS clone for an over-budget entry
```

Neutering `admit()` inside the budget module (measurement disabled):
```
Tests  9 failed | 5 passed (14)
```

Raising `WORKTREE_INCLUDE_MAX_ENTRIES` to `Number.MAX_SAFE_INTEGER`:
```
× stops after 1000 entries so one repo file cannot request unbounded work
AssertionError: expected [ 'ignored-0.env', …(1000) ] to have a length of 1000 but got 1001
```

Restored, all green: **63 passed** across the three files; `worktrees.test.ts` + `worktree-symlink-reconciliation.real.test.ts` 203 passed. `oxlint` 0 errors, `tsc` clean on node + cli projects, max-lines ratchet OK.

## Not runtime-verified

I am on macOS, which takes the cheap APFS-clone path — **I could not runtime-reproduce the Linux/Windows `fs.cp` freeze**, nor observe the bound preventing it on those platforms. Linux/Windows behavior here is covered by tests that force `platform: 'linux'` and by static reading, not by a live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
