### PR TITLE
fix(worktree): refresh base-ref catalog and prefer canonical remote

### DIFF
--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -94,7 +94,8 @@ vi.mock('../git/repo', async () => {
     getRepoName: vi.fn().mockImplementation((path: string) => path.split('/').pop()),
     getBaseRefDefault: vi.fn().mockResolvedValue('origin/main'),
     getRemoteCount: vi.fn().mockResolvedValue(1),
-    searchBaseRefs: vi.fn().mockResolvedValue([])
+    searchBaseRefs: vi.fn().mockResolvedValue([]),
+    searchBaseRefDetails: vi.fn().mockResolvedValue([])
   }
 })
 
@@ -3142,5 +3143,83 @@ describe('repos:searchBaseRefs SSH relay', () => {
     })
 
     expect(result).toEqual([])
+  })
+})
+
+describe('repos:searchBaseRefs local catalog refresh', () => {
+  const handlers = new Map<string, (_event: unknown, args: unknown) => unknown>()
+  const mockWindow = {
+    isDestroyed: () => false,
+    webContents: { send: vi.fn() }
+  }
+  const fetchRemoteWithCache = vi.fn().mockResolvedValue(undefined)
+
+  beforeEach(async () => {
+    handlers.clear()
+    handleMock.mockReset()
+    handleMock.mockImplementation((channel: string, handler: (...a: unknown[]) => unknown) => {
+      handlers.set(channel, handler)
+    })
+    mockStore.getRepo.mockReset()
+    fetchRemoteWithCache.mockClear()
+    const repoModule = await import('../git/repo')
+    vi.mocked(repoModule.searchBaseRefDetails)
+      .mockReset()
+      .mockResolvedValue([
+        { refName: 'upstream/release-1.4.156', localBranchName: 'release-1.4.156' }
+      ])
+    registerRepoHandlers(mockWindow as never, mockStore as never, { fetchRemoteWithCache })
+  })
+
+  it('fetches the canonical remote before enumerating local refs', async () => {
+    mockStore.getRepo.mockReturnValue({
+      id: 'r1',
+      path: '/Users/me/fork',
+      kind: 'git',
+      gitRemoteIdentity: {
+        remoteName: 'upstream',
+        remoteUrl: 'https://github.com/stablyai/orca.git',
+        canonicalKey: 'github.com/stablyai/orca'
+      }
+    })
+
+    const result = await handlers.get('repos:searchBaseRefs')!(null, {
+      repoId: 'r1',
+      query: 'release'
+    })
+
+    expect(fetchRemoteWithCache).toHaveBeenCalledWith('/Users/me/fork', 'upstream')
+    expect(result).toEqual(['upstream/release-1.4.156'])
+  })
+
+  it('falls back to origin when gitRemoteIdentity is unset', async () => {
+    mockStore.getRepo.mockReturnValue({
+      id: 'r1',
+      path: '/Users/me/repo',
+      kind: 'git'
+    })
+
+    await handlers.get('repos:searchBaseRefs')!(null, {
+      repoId: 'r1',
+      query: 'main'
+    })
+
+    expect(fetchRemoteWithCache).toHaveBeenCalledWith('/Users/me/repo', 'origin')
+  })
+
+  it('still returns local refs when the discovery fetch fails', async () => {
+    fetchRemoteWithCache.mockRejectedValueOnce(new Error('offline'))
+    mockStore.getRepo.mockReturnValue({
+      id: 'r1',
+      path: '/Users/me/repo',
+      kind: 'git'
+    })
+
+    const result = await handlers.get('repos:searchBaseRefs')!(null, {
+      repoId: 'r1',
+      query: 'release'
+    })
+
+    expect(result).toEqual(['upstream/release-1.4.156'])
   })
 })

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -76,6 +76,7 @@ import {
   mergeBaseRefSearchResultGroups,
   searchBaseRefDetails
 } from '../git/repo'
+import { resolveWorktreeBroadFetchRemoteName } from '../../shared/worktree-broad-fetch-remote'
 import { getSshGitProvider } from '../providers/ssh-git-dispatch'
 import { getSshGitCapabilityCache } from '../git/git-capability-state'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
@@ -1260,7 +1261,16 @@ async function runNestedRepoScanForIpc(
   }
 }
 
-export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): void {
+export type RepoHandlerRuntime = {
+  /** Best-effort `git fetch <remote>` with the runtime remote-fetch cache (local native only). */
+  fetchRemoteWithCache: (repoPath: string, remote: string) => Promise<void>
+}
+
+export function registerRepoHandlers(
+  mainWindow: BrowserWindow,
+  store: Store,
+  runtime?: RepoHandlerRuntime
+): void {
   // Remove previously registered handlers so we can re-register on macOS app re-activation (new window).
   ipcMain.removeHandler('repos:list')
   ipcMain.removeHandler('repos:listForExecutionHost')
@@ -2600,7 +2610,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       _event,
       args: { repoId: string; query: string; limit?: number; hostId?: ExecutionHostId }
     ) => {
-      return (await searchBaseRefDetailsForRepo(store, args)).map((entry) => entry.refName)
+      return (await searchBaseRefDetailsForRepo(store, args, runtime)).map((entry) => entry.refName)
     }
   )
 
@@ -2610,14 +2620,15 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       _event,
       args: { repoId: string; query: string; limit?: number; hostId?: ExecutionHostId }
     ) => {
-      return searchBaseRefDetailsForRepo(store, args)
+      return searchBaseRefDetailsForRepo(store, args, runtime)
     }
   )
 }
 
 async function searchBaseRefDetailsForRepo(
   store: Store,
-  args: { repoId: string; query: string; limit?: number; hostId?: ExecutionHostId }
+  args: { repoId: string; query: string; limit?: number; hostId?: ExecutionHostId },
+  runtime?: RepoHandlerRuntime
 ): Promise<BaseRefSearchResult[]> {
   const repo = getRepoForExecutionHost(store, args.repoId, args.hostId)
   if (!repo || isFolderRepo(repo)) {
@@ -2686,6 +2697,16 @@ async function searchBaseRefDetailsForRepo(
         err
       })
       return []
+    }
+  }
+  // Why: the picker only sees local remote-tracking refs. A best-effort fetch of
+  // the canonical remote (deduped/cached by the runtime) discovers branches pushed
+  // since the last fetch so search doesn't silently look empty.
+  if (runtime) {
+    try {
+      await runtime.fetchRemoteWithCache(repo.path, resolveWorktreeBroadFetchRemoteName(repo))
+    } catch {
+      // Why: offline/auth failures must not block listing whatever local refs we already have.
     }
   }
   return searchBaseRefDetails(repo.path, args.query, limit)

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -33,6 +33,7 @@ import { resolveLocalGitUsername, getSshGitUsername } from '../git/git-username'
 import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
+import { resolveWorktreeBroadFetchRemoteName } from '../../shared/worktree-broad-fetch-remote'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
 import type { ForgeProviderId } from '../source-control/forge-provider'
 import { validateGitPushTarget } from '../git/push-target-validation'
@@ -2024,8 +2025,10 @@ export async function createLocalWorktree(
       !(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
     ) {
       // Why: non-remote-prefix bases (plain main/master/local) keep the legacy best-effort fetch; verified PR SHA bases already have the object.
+      // Prefer the recorded canonical remote (forks often use `upstream`).
+      const broadFetchRemote = resolveWorktreeBroadFetchRemoteName(repo)
       legacyFetchPromise = runtime
-        .fetchRemoteWithCache(repo.path, 'origin', ...localWorktreeGitOptionArgs)
+        .fetchRemoteWithCache(repo.path, broadFetchRemote, ...localWorktreeGitOptionArgs)
         .then(() => undefined)
         .catch(() => undefined)
       emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
@@ -2034,7 +2037,8 @@ export async function createLocalWorktree(
     if (
       !(await hasLocalWorktreeBaseRefWithOptions(repo.path, baseBranch, localWorktreeGitOptions))
     ) {
-      legacyFetchPromise = gitExecFileAsync(['fetch', 'origin'], {
+      const broadFetchRemote = resolveWorktreeBroadFetchRemoteName(repo)
+      legacyFetchPromise = gitExecFileAsync(['fetch', broadFetchRemote], {
         ...localGitExecOptions,
         timeout: CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS
       })

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -654,6 +654,28 @@ describe('registerWorktreeHandlers', () => {
     expect(addWorktreeMock).not.toHaveBeenCalled()
   })
 
+  it('prefetches the recorded canonical remote when identity is not origin', async () => {
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(null)
+    store.getRepo.mockReturnValue({
+      id: 'repo-1',
+      path: '/workspace/repo',
+      kind: 'git',
+      gitRemoteIdentity: {
+        remoteName: 'upstream',
+        remoteUrl: 'https://github.com/stablyai/orca.git',
+        canonicalKey: 'github.com/stablyai/orca'
+      }
+    })
+
+    await handlers['worktrees:prefetchCreateBase'](null, {
+      repoId: 'repo-1',
+      baseBranch: 'main'
+    })
+
+    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'upstream')
+    expect(runtimeStub.fetchRemoteWithCache).not.toHaveBeenCalledWith('/workspace/repo', 'origin')
+  })
+
   it('prefetches origin for local branch bases containing slashes', async () => {
     runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(null)
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -107,6 +107,7 @@ import { isAbsolute, join, resolve } from 'node:path'
 import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
+import { resolveWorktreeBroadFetchRemoteName } from '../../shared/worktree-broad-fetch-remote'
 import { OrchestrationDb } from './orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from './orchestration/worker-terminal-release-reconciliation'
 import { OrchestrationError } from './orchestration/orchestration-error'
@@ -21885,8 +21886,13 @@ export class OrcaRuntimeService {
     ) {
       // Why: local bases keep legacy best-effort fetch behavior. Verified PR
       // SHA bases already have the commit object needed by `git worktree add`.
+      // Prefer the recorded canonical remote (forks often use `upstream`).
       try {
-        await this.fetchRemoteWithCache(repo.path, 'origin', ...localWorktreeGitOptionArgs)
+        await this.fetchRemoteWithCache(
+          repo.path,
+          resolveWorktreeBroadFetchRemoteName(repo),
+          ...localWorktreeGitOptionArgs
+        )
       } catch {
         // Why: belt-and-suspenders. fetchRemoteWithCache already logs and does
         // not throw; the outer try/catch guarantees create-path tolerance even

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -104,7 +104,9 @@ export function attachMainWindowServices(
   }
 ): void {
   registerAppReloadHandler(mainWindow, options?.onBeforeRendererReload)
-  registerRepoHandlers(mainWindow, store)
+  registerRepoHandlers(mainWindow, store, {
+    fetchRemoteWithCache: (repoPath, remote) => runtime.fetchRemoteWithCache(repoPath, remote)
+  })
   // Why: repo IPC mutations must also invalidate paired clients' catalogs (#11994).
   setRepoRemoteClientNotifier(runtime)
   registerWorktreeHandlers(mainWindow, store, runtime, {

--- a/src/main/worktree-create-base-prefetch.ts
+++ b/src/main/worktree-create-base-prefetch.ts
@@ -1,5 +1,6 @@
 import { isFolderRepo } from '../shared/repo-kind'
 import type { Repo } from '../shared/types'
+import { resolveWorktreeBroadFetchRemoteName } from '../shared/worktree-broad-fetch-remote'
 import { hasLocalCommitObject, isFullGitObjectId } from './git/commit-object-ref'
 import { hasWorktreeBaseCommitRef } from './git/worktree-base-ref-probe'
 import { getBaseRefDefault } from './git/repo'
@@ -89,7 +90,8 @@ async function prefetchLocalWorktreeCreateBase(
 
   // Why: keep optimistic prefetch on the same best-effort fallback path as
   // create so the real create can reuse the runtime's remote fetch cache.
-  await runtime.fetchRemoteWithCache(repo.path, 'origin')
+  // Prefer the repo's canonical remote (often `upstream` on forks), not a hardcoded origin.
+  await runtime.fetchRemoteWithCache(repo.path, resolveWorktreeBroadFetchRemoteName(repo))
 }
 
 export async function prefetchWorktreeCreateBase(args: {

--- a/src/shared/worktree-broad-fetch-remote.test.ts
+++ b/src/shared/worktree-broad-fetch-remote.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeBroadFetchRemoteName } from './worktree-broad-fetch-remote'
+
+describe('resolveWorktreeBroadFetchRemoteName', () => {
+  it('falls back to origin when identity is missing or blank', () => {
+    expect(resolveWorktreeBroadFetchRemoteName({})).toBe('origin')
+    expect(resolveWorktreeBroadFetchRemoteName({ gitRemoteIdentity: null })).toBe('origin')
+    expect(
+      resolveWorktreeBroadFetchRemoteName({
+        gitRemoteIdentity: { remoteName: '   ' }
+      })
+    ).toBe('origin')
+  })
+
+  it('uses the recorded canonical remote name for fork-style clones', () => {
+    expect(
+      resolveWorktreeBroadFetchRemoteName({
+        gitRemoteIdentity: { remoteName: 'upstream' }
+      })
+    ).toBe('upstream')
+  })
+})

--- a/src/shared/worktree-broad-fetch-remote.ts
+++ b/src/shared/worktree-broad-fetch-remote.ts
@@ -1,0 +1,11 @@
+/**
+ * Remote name for best-effort full `git fetch <remote>` when creating worktrees
+ * or refreshing the base-ref catalog. Prefer the repo's recorded canonical
+ * remote (often `upstream` on fork clones); fall back to `origin`.
+ */
+export function resolveWorktreeBroadFetchRemoteName(repo: {
+  gitRemoteIdentity?: { remoteName?: string } | null
+}): string {
+  const remoteName = repo.gitRemoteIdentity?.remoteName?.trim()
+  return remoteName && remoteName.length > 0 ? remoteName : 'origin'
+}


### PR DESCRIPTION
## Summary

Fixes #10516: Create-worktree **Branch** search only enumerated local refs, so a branch pushed since the last fetch looked nonexistent (no refresh affordance, no last-fetched signal). Prefetch/create broad-fetch fallbacks also hard-coded `origin`, which is wrong on fork clones whose canonical remote is `upstream`.

### Changes

1. **Base-ref search discovery fetch** — before local `for-each-ref` search, best-effort `fetchRemoteWithCache` for the repo’s recorded canonical remote (deduped/freshness-cached by the existing runtime helper). Offline/auth failures still return whatever local refs exist.
2. **Canonical remote helper** — `resolveWorktreeBroadFetchRemoteName` uses `gitRemoteIdentity.remoteName`, falling back to `origin`.
3. **Create / prefetch fallbacks** — replace hard-coded `origin` with that helper in:
   - `worktree-create-base-prefetch.ts`
   - `orca-runtime` create path
   - `worktree-remote` create path (runtime + legacy `git fetch` fallback)

SSH base-ref search is unchanged (already lists on the remote host).

Not in this PR: UI last-fetched timestamp / manual refresh button, or single-branch refspec diagnostics (footnote in the issue).

## Test plan

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/worktree-broad-fetch-remote.test.ts src/main/ipc/repos-remote.test.ts src/main/ipc/worktrees.test.ts` (309+ tests)
- [ ] Manual: push a new remote branch without fetching in Orca → Create worktree → Branch search finds it after the catalog refresh
- [ ] Manual: fork clone with `upstream` identity fetches `upstream`, not only `origin`
- [ ] Manual: offline / failed fetch still shows existing local refs without erroring the picker

## ELI5

Create Worktree branch search only saw local refs, so newly pushed remote branches looked missing, and fetches hard-coded origin. Search refreshes the canonical remote first and prefers the right remote on forks.
