### PR TITLE
fix(window): stop viewport reflow from moving screen geometry

### DIFF
--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -91,21 +91,42 @@ describe('registerSystemResumeBroadcast', () => {
     clock.value += 109 * 60_000
     fireResume()
 
-    expect(breadcrumbNames()).toEqual(['system_suspended', 'system_resumed'])
+    expect(breadcrumbNames()).toEqual(['system_slept'])
     expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({ suspendedForMs: 109 * 60_000 })
   })
 
-  it('omits the sleep span when resume arrives without a recorded suspend', () => {
+  it('records nothing when resume arrives without a recorded suspend', () => {
     const { source, fireResume } = createResumeSource()
-    registerSystemResumeBroadcast({ resumeSource: source, getWindows: () => [] })
+    const window = createWindow()
+    registerSystemResumeBroadcast({ resumeSource: source, getWindows: () => [window] })
 
     fireResume()
 
-    expect(breadcrumbNames()).toEqual(['system_resumed'])
-    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toBeUndefined()
+    expect(breadcrumbNames()).toEqual([])
+    expect(window.webContents.send).toHaveBeenCalledWith(SYSTEM_RESUMED_CHANNEL)
   })
 
-  it('measures each sleep span independently across repeated cycles', () => {
+  it('ignores maintenance sleeps too short to swallow a renderer heartbeat', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 0 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    // Why: 20 maintenance cycles must not evict the 30-entry breadcrumb ring.
+    for (let cycle = 0; cycle < 20; cycle++) {
+      fireSuspend()
+      clock.value += 2_000
+      fireResume()
+      clock.value += 30_000
+    }
+
+    expect(breadcrumbNames()).toEqual([])
+  })
+
+  it('measures each reportable sleep independently across repeated cycles', () => {
     const { source, fireSuspend, fireResume } = createResumeSource()
     const clock = { value: 0 }
     registerSystemResumeBroadcast({
@@ -115,19 +136,17 @@ describe('registerSystemResumeBroadcast', () => {
     })
 
     fireSuspend()
-    clock.value += 5_000
+    clock.value += 5 * 60_000
     fireResume()
     clock.value += 60_000
     fireSuspend()
-    clock.value += 2_000
+    clock.value += 2 * 60_000
     fireResume()
     // Why: a spurious resume after the cycles must not re-report the last sleep.
-    clock.value += 30_000
+    clock.value += 30 * 60_000
     fireResume()
 
-    const spans = getCrashBreadcrumbSnapshot()
-      .filter((breadcrumb) => breadcrumb.name === 'system_resumed')
-      .map((breadcrumb) => breadcrumb.data?.suspendedForMs)
-    expect(spans).toEqual([5_000, 2_000, undefined])
+    const spans = getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.data?.suspendedForMs)
+    expect(spans).toEqual([5 * 60_000, 2 * 60_000])
   })
 })

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -100,6 +100,28 @@ describe('registerSystemResumeBroadcast', () => {
     expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({ suspendedForMs: 109 * 60_000 })
   })
 
+  it('spans from the first suspend when dark wake swallows the intervening resume', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 0 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    fireSuspend()
+    clock.value += 90 * 60_000
+    // Why: dark wake re-suspends without a resume; reporting only the trailing 20s
+    // would leave the 90 preceding minutes looking like an unexplained freeze.
+    fireSuspend()
+    clock.value += 20_000
+    fireResume()
+
+    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({
+      suspendedForMs: 90 * 60_000 + 20_000
+    })
+  })
+
   it('records nothing when resume arrives without a recorded suspend', () => {
     const { source, fireResume } = createResumeSource()
     const window = createWindow()

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot
+} from './crash-reporting/crash-breadcrumb-store'
 import { registerSystemResumeBroadcast, SYSTEM_RESUMED_CHANNEL } from './system-resume-broadcast'
 
 vi.mock('electron', () => ({
@@ -6,19 +10,30 @@ vi.mock('electron', () => ({
   powerMonitor: { on: vi.fn(), off: vi.fn() }
 }))
 
+beforeEach(clearCrashBreadcrumbsForTest)
+
 type ResumeListener = () => void
+type PowerLifecycleEvent = 'suspend' | 'resume'
 
 function createResumeSource() {
-  const state: { listener: ResumeListener | null } = { listener: null }
+  const listeners = new Map<PowerLifecycleEvent, ResumeListener>()
   const source = {
-    on: vi.fn((_event: 'resume', callback: ResumeListener) => {
-      state.listener = callback
+    on: vi.fn((event: PowerLifecycleEvent, callback: ResumeListener) => {
+      listeners.set(event, callback)
     }),
-    off: vi.fn((_event: 'resume', _callback: ResumeListener) => {
-      state.listener = null
+    off: vi.fn((event: PowerLifecycleEvent, _callback: ResumeListener) => {
+      listeners.delete(event)
     })
   }
-  return { source, fireResume: () => state.listener?.() }
+  return {
+    source,
+    fireSuspend: () => listeners.get('suspend')?.(),
+    fireResume: () => listeners.get('resume')?.()
+  }
+}
+
+function breadcrumbNames(): string[] {
+  return getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.name)
 }
 
 function createWindow(destroyed = false): {
@@ -58,7 +73,61 @@ describe('registerSystemResumeBroadcast', () => {
     unsubscribe()
     fireResume()
 
-    expect(source.off).toHaveBeenCalledTimes(1)
+    expect(source.off).toHaveBeenCalledWith('resume', expect.any(Function))
+    expect(source.off).toHaveBeenCalledWith('suspend', expect.any(Function))
     expect(window.webContents.send).not.toHaveBeenCalled()
+  })
+
+  it('records the sleep span so a heartbeat gap is attributable to suspend', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 1_000 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    fireSuspend()
+    clock.value += 109 * 60_000
+    fireResume()
+
+    expect(breadcrumbNames()).toEqual(['system_suspended', 'system_resumed'])
+    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toEqual({ suspendedForMs: 109 * 60_000 })
+  })
+
+  it('omits the sleep span when resume arrives without a recorded suspend', () => {
+    const { source, fireResume } = createResumeSource()
+    registerSystemResumeBroadcast({ resumeSource: source, getWindows: () => [] })
+
+    fireResume()
+
+    expect(breadcrumbNames()).toEqual(['system_resumed'])
+    expect(getCrashBreadcrumbSnapshot().at(-1)?.data).toBeUndefined()
+  })
+
+  it('measures each sleep span independently across repeated cycles', () => {
+    const { source, fireSuspend, fireResume } = createResumeSource()
+    const clock = { value: 0 }
+    registerSystemResumeBroadcast({
+      resumeSource: source,
+      getWindows: () => [],
+      now: () => clock.value
+    })
+
+    fireSuspend()
+    clock.value += 5_000
+    fireResume()
+    clock.value += 60_000
+    fireSuspend()
+    clock.value += 2_000
+    fireResume()
+    // Why: a spurious resume after the cycles must not re-report the last sleep.
+    clock.value += 30_000
+    fireResume()
+
+    const spans = getCrashBreadcrumbSnapshot()
+      .filter((breadcrumb) => breadcrumb.name === 'system_resumed')
+      .map((breadcrumb) => breadcrumb.data?.suspendedForMs)
+    expect(spans).toEqual([5_000, 2_000, undefined])
   })
 })

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -21,8 +21,12 @@ function createResumeSource() {
     on: vi.fn((event: PowerLifecycleEvent, callback: ResumeListener) => {
       listeners.set(event, callback)
     }),
-    off: vi.fn((event: PowerLifecycleEvent, _callback: ResumeListener) => {
-      listeners.delete(event)
+    // Why: match on identity so detaching a different closure than the one
+    // registered still leaves a live listener, as it would on real powerMonitor.
+    off: vi.fn((event: PowerLifecycleEvent, callback: ResumeListener) => {
+      if (listeners.get(event) === callback) {
+        listeners.delete(event)
+      }
     })
   }
   return {
@@ -73,8 +77,9 @@ describe('registerSystemResumeBroadcast', () => {
     unsubscribe()
     fireResume()
 
-    expect(source.off).toHaveBeenCalledWith('resume', expect.any(Function))
-    expect(source.off).toHaveBeenCalledWith('suspend', expect.any(Function))
+    // Why: detaching a different closure than the one registered leaks a real
+    // powerMonitor listener, and for 'suspend' that leak is otherwise unobservable.
+    expect(source.off.mock.calls).toEqual(source.on.mock.calls)
     expect(window.webContents.send).not.toHaveBeenCalled()
   })
 

--- a/src/main/system-resume-broadcast.test.ts
+++ b/src/main/system-resume-broadcast.test.ts
@@ -133,7 +133,7 @@ describe('registerSystemResumeBroadcast', () => {
     expect(window.webContents.send).toHaveBeenCalledWith(SYSTEM_RESUMED_CHANNEL)
   })
 
-  it('ignores maintenance sleeps too short to swallow a renderer heartbeat', () => {
+  it('ignores sleeps too short to open a gap, keeping ring slots for real evidence', () => {
     const { source, fireSuspend, fireResume } = createResumeSource()
     const clock = { value: 0 }
     registerSystemResumeBroadcast({
@@ -142,7 +142,7 @@ describe('registerSystemResumeBroadcast', () => {
       now: () => clock.value
     })
 
-    // Why: 20 maintenance cycles must not evict the 30-entry breadcrumb ring.
+    // Why: 20 sub-heartbeat cycles must not evict the 30-entry breadcrumb ring.
     for (let cycle = 0; cycle < 20; cycle++) {
       fireSuspend()
       clock.value += 2_000

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -21,9 +21,9 @@ type SystemResumeBroadcastOptions = {
   now?: () => number
 }
 
-// Why: macOS maintenance-sleeps dozens of times a day (median span ~2s), which would
-// flood the 30-entry breadcrumb ring and evict the crash evidence this is meant to
-// explain. Only a sleep long enough to swallow a renderer heartbeat is worth recording.
+// Why: a sleep shorter than the renderer's 60s memory-sample interval only delays a
+// heartbeat, it cannot open the multi-minute gap this attributes -- so recording one
+// spends a slot in the 30-entry ring without explaining anything.
 const MIN_REPORTABLE_SUSPEND_MS = 60_000
 
 // Why: renderers cannot observe OS sleep/wake directly, and Linux has no

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -1,10 +1,13 @@
 import { BrowserWindow, powerMonitor } from 'electron'
+import { recordCrashBreadcrumb } from './crash-reporting/crash-breadcrumb-store'
 
 export const SYSTEM_RESUMED_CHANNEL = 'system:resumed'
 
+type PowerLifecycleEvent = 'suspend' | 'resume'
+
 type ResumeEventSource = {
-  on(event: 'resume', listener: () => void): unknown
-  off(event: 'resume', listener: () => void): unknown
+  on(event: PowerLifecycleEvent, listener: () => void): unknown
+  off(event: PowerLifecycleEvent, listener: () => void): unknown
 }
 
 type ResumeBroadcastWindow = {
@@ -15,6 +18,7 @@ type ResumeBroadcastWindow = {
 type SystemResumeBroadcastOptions = {
   resumeSource?: ResumeEventSource
   getWindows?: () => ResumeBroadcastWindow[]
+  now?: () => number
 }
 
 // Why: renderers cannot observe OS sleep/wake directly, and Linux has no
@@ -25,15 +29,31 @@ export function registerSystemResumeBroadcast(
 ): () => void {
   const resumeSource = options.resumeSource ?? powerMonitor
   const getWindows = options.getWindows ?? (() => BrowserWindow.getAllWindows())
+  const now = options.now ?? Date.now
+  // Why: renderer timers stop across OS sleep, so an unexplained heartbeat gap
+  // reads identically to a freeze. Stamping suspend lets resume report the span.
+  let suspendedAt: number | null = null
+
+  const onSuspend = (): void => {
+    suspendedAt = now()
+    recordCrashBreadcrumb('system_suspended')
+  }
+
   const onResume = (): void => {
+    const suspendedForMs = suspendedAt === null ? undefined : Math.max(0, now() - suspendedAt)
+    suspendedAt = null
+    recordCrashBreadcrumb('system_resumed', suspendedForMs === undefined ? {} : { suspendedForMs })
     for (const window of getWindows()) {
       if (!window.isDestroyed()) {
         window.webContents.send(SYSTEM_RESUMED_CHANNEL)
       }
     }
   }
+
+  resumeSource.on('suspend', onSuspend)
   resumeSource.on('resume', onResume)
   return () => {
+    resumeSource.off('suspend', onSuspend)
     resumeSource.off('resume', onResume)
   }
 }

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -21,6 +21,11 @@ type SystemResumeBroadcastOptions = {
   now?: () => number
 }
 
+// Why: macOS maintenance-sleeps dozens of times a day (median span ~2s), which would
+// flood the 30-entry breadcrumb ring and evict the crash evidence this is meant to
+// explain. Only a sleep long enough to swallow a renderer heartbeat is worth recording.
+const MIN_REPORTABLE_SUSPEND_MS = 60_000
+
 // Why: renderers cannot observe OS sleep/wake directly, and Linux has no
 // window-occlusion tracking so visibilitychange never fires around suspend.
 // Wake-sensitive renderer recovery needs this explicit resume signal.
@@ -36,13 +41,14 @@ export function registerSystemResumeBroadcast(
 
   const onSuspend = (): void => {
     suspendedAt = now()
-    recordCrashBreadcrumb('system_suspended')
   }
 
   const onResume = (): void => {
-    const suspendedForMs = suspendedAt === null ? undefined : Math.max(0, now() - suspendedAt)
+    const suspendedForMs = suspendedAt === null ? null : Math.max(0, now() - suspendedAt)
     suspendedAt = null
-    recordCrashBreadcrumb('system_resumed', suspendedForMs === undefined ? {} : { suspendedForMs })
+    if (suspendedForMs !== null && suspendedForMs >= MIN_REPORTABLE_SUSPEND_MS) {
+      recordCrashBreadcrumb('system_slept', { suspendedForMs })
+    }
     for (const window of getWindows()) {
       if (!window.isDestroyed()) {
         window.webContents.send(SYSTEM_RESUMED_CHANNEL)

--- a/src/main/system-resume-broadcast.ts
+++ b/src/main/system-resume-broadcast.ts
@@ -40,7 +40,11 @@ export function registerSystemResumeBroadcast(
   let suspendedAt: number | null = null
 
   const onSuspend = (): void => {
-    suspendedAt = now()
+    // Why: resume maps to NSWorkspaceDidWake, which stays silent for dark wake, so
+    // suspend can repeat before a resume. Keep the earliest stamp: over-reporting the
+    // span is visibly inconsistent with surviving heartbeats, while under-reporting
+    // leaves a long gap looking unexplained -- the false freeze this exists to rule out.
+    suspendedAt ??= now()
   }
 
   const onResume = (): void => {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -523,8 +523,7 @@ describe('createMainWindow', () => {
     // dvh root — via the emulated viewport, which leaves the deadlock-prone frame untouched.
     expect(webContents.enableDeviceEmulation).toHaveBeenCalledWith({
       screenPosition: 'desktop',
-      screenSize: { width: 1200, height: 800 },
-      viewPosition: { x: 0, y: 0 },
+      screenSize: { width: 0, height: 0 },
       deviceScaleFactor: 2.25,
       viewSize: { width: 1200, height: 800 },
       scale: 1
@@ -642,8 +641,7 @@ describe('createMainWindow', () => {
     expect(browserWindowInstance.setSize).not.toHaveBeenCalled()
     expect(webContents.enableDeviceEmulation).toHaveBeenCalledWith({
       screenPosition: 'desktop',
-      screenSize: { width: 1200, height: 800 },
-      viewPosition: { x: 0, y: 0 },
+      screenSize: { width: 0, height: 0 },
       deviceScaleFactor: 2.25,
       viewSize: { width: 1200, height: 800 },
       scale: 1

--- a/src/main/window/renderer-viewport-reflow.test.ts
+++ b/src/main/window/renderer-viewport-reflow.test.ts
@@ -7,6 +7,10 @@ vi.mock('electron', () => ({
 }))
 
 import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot
+} from '../crash-reporting/crash-breadcrumb-store'
+import {
   reflowRendererViewport,
   VIEWPORT_REFLOW_RESTORE_ATTEMPTS,
   VIEWPORT_REFLOW_SETTLE_MS
@@ -33,6 +37,7 @@ describe('reflowRendererViewport', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     scaleFactorMock.value = 1
+    clearCrashBreadcrumbsForTest()
   })
   afterEach(() => {
     vi.useRealTimers()
@@ -55,8 +60,7 @@ describe('reflowRendererViewport', () => {
     vi.advanceTimersByTime(0)
     expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledWith({
       screenPosition: 'desktop',
-      screenSize: { width: 1200, height: 800 },
-      viewPosition: { x: 0, y: 0 },
+      screenSize: { width: 0, height: 0 },
       deviceScaleFactor: 1.25,
       viewSize: { width: 1200, height: 800 },
       scale: 1
@@ -76,8 +80,20 @@ describe('reflowRendererViewport', () => {
     const [params] = (window.webContents.enableDeviceEmulation as ReturnType<typeof vi.fn>).mock
       .calls[0] as [Electron.Parameters]
     expect(params.viewSize).toEqual({ width: 1200, height: 800 })
-    expect(params.screenSize).toEqual({ width: 1200, height: 800 })
     expect(params.scale).toBe(1)
+  })
+
+  // Why: Blink applies screenSize/viewPosition ahead of the desktop branch, so overriding them
+  // moves screen.width and window.screenX for the whole hold — a context menu opened mid-reflow
+  // would land at the wrong coordinates. Only the scale factor may move.
+  it('leaves screen geometry and window position untouched while emulating', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(0)
+    const [params] = (window.webContents.enableDeviceEmulation as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [Electron.Parameters]
+    expect(params.screenSize).toEqual({ width: 0, height: 0 })
+    expect(params).not.toHaveProperty('viewPosition')
   })
 
   // Why: a constant scale factor would equal the real one on a 1.25x display and reflow nothing.
@@ -220,6 +236,27 @@ describe('reflowRendererViewport', () => {
     reflowRendererViewport(window)
     vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS + 1)
     expect(window.webContents.enableDeviceEmulation).toHaveBeenCalledTimes(2)
+  })
+
+  it('leaves evidence when it gives up with the viewport still emulated', () => {
+    const window = createWindow()
+    vi.mocked(window.webContents.disableDeviceEmulation).mockImplementation(() => {
+      throw new Error('always fails')
+    })
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS * (VIEWPORT_REFLOW_RESTORE_ATTEMPTS + 4))
+
+    expect(getCrashBreadcrumbSnapshot().map((crumb) => crumb.name)).toEqual([
+      'viewport_reflow_restore_failed'
+    ])
+  })
+
+  it('records nothing when the restore succeeds', () => {
+    const window = createWindow()
+    reflowRendererViewport(window)
+    vi.advanceTimersByTime(VIEWPORT_REFLOW_SETTLE_MS * (VIEWPORT_REFLOW_RESTORE_ATTEMPTS + 4))
+
+    expect(getCrashBreadcrumbSnapshot()).toEqual([])
   })
 
   it('abandons the restore once the webContents is gone', () => {

--- a/src/main/window/renderer-viewport-reflow.ts
+++ b/src/main/window/renderer-viewport-reflow.ts
@@ -1,5 +1,6 @@
 import { screen } from 'electron'
 import type { BrowserWindow } from 'electron'
+import { recordCrashBreadcrumb } from '../crash-reporting/crash-breadcrumb-store'
 
 // Why: long enough for the emulated scale factor to reach the renderer and drive a relayout.
 export const VIEWPORT_REFLOW_SETTLE_MS = 32
@@ -52,16 +53,19 @@ export function reflowRendererViewport(window: BrowserWindow): void {
       // Why: emulating the current factor is a no-op, so offset from this window's own display
       // rather than a constant, which would match on a 1.25x screen and reflow nothing.
       const realScaleFactor = screen.getDisplayMatching(window.getBounds()).scaleFactor || 1
+      // Why: Blink reads screenSize/viewPosition before the desktop branch, so 'desktop' does
+      // not make them inert despite the mobile-only docs. Passing the content size and 0,0
+      // moved screen.width and window.screenX for the 32ms hold, misplacing anything that
+      // translates screen coords (the BrowserPane context menu). Empty screenSize means "no
+      // override", and an omitted viewPosition stays nullopt so the real position survives --
+      // Electron's types require the key, but its converter only assigns when present.
       window.webContents.enableDeviceEmulation({
         screenPosition: 'desktop',
-        // Why: Electron types every field as required; screenSize is mobile-only and scale is
-        // the emulated-view zoom, so both carry their documented no-op defaults.
-        screenSize: viewSize,
-        viewPosition: { x: 0, y: 0 },
+        screenSize: { width: 0, height: 0 },
         deviceScaleFactor: realScaleFactor + VIEWPORT_REFLOW_SCALE_DELTA,
         viewSize,
         scale: 1
-      })
+      } as Parameters<typeof window.webContents.enableDeviceEmulation>[0])
       emulating = true
     } catch {
       // Why: a teardown race can destroy the webContents mid-call; nothing was applied.
@@ -90,6 +94,10 @@ function restoreRealViewport(window: BrowserWindow, attempt: number): void {
       // Why: the webContents is still alive, so the renderer is stuck at the emulated scale;
       // keep retrying and hold the latch so no second cycle stacks on the unrestored state.
       if (attempt >= VIEWPORT_REFLOW_RESTORE_ATTEMPTS) {
+        // Why: releasing the latch beats pinning it — a later reveal can still restore. But the
+        // renderer is stranded at the wrong scale factor until one happens, so leave evidence
+        // rather than let a permanently-emulated viewport look like a rendering bug.
+        recordCrashBreadcrumb('viewport_reflow_restore_failed', { attempts: attempt + 1 })
         activeViewportReflows.delete(window)
         return
       }


### PR DESCRIPTION
## Why

Follow-up hardening on #10473/#10485, from an adversarial audit of the merged emulation path. Neither PR is reverted — both fix a real macOS 26 frame-mutation hazard. This corrects two defects in the final implementation.

### 1. "Scale-only" emulation was also moving screen geometry

`reflowRendererViewport` passed `screenSize: viewSize` and `viewPosition: {x:0,y:0}` alongside `screenPosition: 'desktop'`, on the documented assumption that both fields are mobile-only no-ops. **They are not.** Blink's `ScreenMetricsEmulator::Apply` checks each one *before* the desktop/mobile branch:

```cpp
if (!emulation_params_.screen_size.IsEmpty()) {
    screen_rect = gfx::Rect(gfx::Size(emulation_params_.screen_size));
  } else if (!emulating_desktop()) {   // <-- desktop check is the fallback

if (emulation_params_.view_position) {
    widget_pos = emulation_params_.view_position.value();
    window_pos = widget_pos;
  } else if (!emulating_desktop()) {
```

So for the full 32 ms hold, `screen.width`/`availWidth` reported the content size and the window origin was forced to 0,0.

**Concrete failure:** `BrowserPane.tsx:3167-3168` translates OS cursor coords via `event.screenX - window.screenX`. A browser context menu opened during a reveal/resume reflow computes against a bogus origin and lands in the wrong place.

**Fix:** empty `screenSize` is the actual documented "no override", and an omitted `viewPosition` stays `nullopt` — Electron's converter only assigns when the key is present (`blink_converter.cc` reads it into a local behind an `if (dict.Get(...))`, unlike the other fields). Electron's TS types mark it required, hence the narrow cast. Only the scale factor moves now, which is all the reflow needs.

### 2. Giving up on the restore was silent

When `disableDeviceEmulation()` exhausts `VIEWPORT_REFLOW_RESTORE_ATTEMPTS` on a live `webContents`, the latch is released and the renderer is left at the wrong scale factor until some later reveal happens to fix it. Releasing the latch is the right call — pinning it would kill every future reflow — but the invariant breach left no trace, so it would surface as an unexplained rendering bug. Now records a `viewport_reflow_restore_failed` breadcrumb.

## Testing

18 tests in `renderer-viewport-reflow.test.ts` (2 new), all mutation-verified:

| mutation | caught |
|---|---|
| restore `screenSize: viewSize` | 2 tests |
| re-add `viewPosition: {x:0,y:0}` | 2 tests |
| drop the give-up breadcrumb | 1 test |

Also asserts the success path records **nothing**, so the breadcrumb can't leak into the 30-entry ring on healthy reveals.

Related suites: **30 files / 320 tests pass**. Typecheck clean on all three projects; lint and format clean.

## Audit findings not acted on

- **#10473 deadlock rationale unsupported by telemetry** — agreed, and already documented in #10530. `before-quit` sets `isQuitting` synchronously at `index.ts:2479-2486` and `getExpectedTeardownScope` only returns `app-shutdown` from that state, so a main thread deadlocked in AppKit could not have run those callbacks. Not a code defect.
- **#10487 dimension guard** — audited clean, correctly scoped to two transient dismissal listeners. No change.
- **DevTools device-emulation collision** (electron#4099) — real but developer-facing and deterministic; not worth a runtime branch here.

Made with [Orca](https://github.com/stablyai/orca) 🐋
