### PR TITLE
fix(terminal): recover panes when a workspace delete fails after killing their shells

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -122,6 +122,7 @@ type StoreState = {
   terminalLayoutsByTabId?: Record<string, TerminalLayoutSnapshot>
   unreadTerminalTabs?: Record<string, true>
   deleteStateByWorktreeId?: Record<string, { isDeleting?: boolean; phase?: string }>
+  getKnownWorktreeById?: (worktreeId: string) => { id: string } | null
   worktreesByRepo: Record<
     string,
     {
@@ -789,6 +790,12 @@ describe('connectPanePty', () => {
       },
       unreadTerminalTabs: {},
       deleteStateByWorktreeId: {},
+      // Why: read through the live mockStoreState so tests that drop a workspace
+      // mid-run (a completed delete) see it disappear, as the real store does.
+      getKnownWorktreeById: (worktreeId: string) =>
+        Object.values(mockStoreState.worktreesByRepo)
+          .flat()
+          .find((worktree) => worktree.id === worktreeId) ?? null,
       worktreesByRepo: {
         repo1: [{ id: 'wt-1', repoId: 'repo1', path: '/tmp/wt-1', displayName: 'feat/notis' }]
       },
@@ -1052,6 +1059,62 @@ describe('connectPanePty', () => {
     expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
   })
 
+  // Why: main kills the workspace's PTYs before the removal can fail, so a delete
+  // that fails partway leaves this pane's shells dead. The skip above is one-shot
+  // (the pane connects once), so without re-arming the spawn the user is left with
+  // a blank dead pane until they switch workspaces.
+  it('respawns the pane after a failed workspace delete clears the removal fence', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: { 'wt-1': { isDeleting: true, phase: 'deleting' } }
+    }
+    const deps = createDeps({ tabId: 'tab-removal-failed-respawn' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+    expect(transport.connect).not.toHaveBeenCalled()
+
+    // removeWorktree's failure branch: isDeleting clears, the workspace survives.
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: { 'wt-1': { isDeleting: false, phase: 'deleting' } }
+    }
+    notifyStoreSubscribers()
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalled()
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+  })
+
+  it('does not respawn a suppressed pane when the workspace delete succeeds', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: { 'wt-1': { isDeleting: true, phase: 'deleting' } }
+    }
+    const deps = createDeps({ tabId: 'tab-removal-succeeded-no-respawn' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    // removeWorktree's success branch drops both the delete state and the workspace.
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: {},
+      worktreesByRepo: { repo1: [] }
+    }
+    notifyStoreSubscribers()
+    await flushAsyncTicks()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+  })
+
   it('fresh-spawns normally when the pane worktree is not being deleted', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()
@@ -1094,6 +1157,45 @@ describe('connectPanePty', () => {
       `Error invoking remote method 'pty:spawn': Error: ${TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE}`
     )
     expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+  })
+
+  // Why: a parent workspace's removal fences this child pane's spawn, and
+  // startFreshSpawn's own-worktree skip cannot see it. Swallowing that fence is
+  // right while the removal runs, but if it FAILS the child pane keeps a mounted,
+  // shell-less surface — so the swallowed spawn has to be retried.
+  it('respawns after a swallowed removal fence once the removal settles', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE } =
+      await import('../../../../shared/worktree-removal-fence-error')
+    const transport = createMockTransport()
+    const capturedOnError: { current: ((message: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedOnError.current = callbacks.onError ?? null
+      return 'pty-1'
+    })
+    transportFactoryQueue.push(transport)
+    // A parent/overlapping root is being removed; this pane's own workspace is not.
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: { 'wt-parent': { isDeleting: true, phase: 'deleting' } }
+    }
+    const deps = createDeps({ tabId: 'tab-fence-respawn' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    expect(capturedOnError.current).toBeTypeOf('function')
+    expect(transport.connect).toHaveBeenCalledTimes(1)
+    capturedOnError.current!(
+      `Error invoking remote method 'pty:spawn': Error: ${TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE}`
+    )
+    expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+
+    mockStoreState = { ...mockStoreState, deleteStateByWorktreeId: {} }
+    notifyStoreSubscribers()
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalledTimes(2)
   })
 
   it('still surfaces non-fence spawn errors through the pane error sink', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -123,6 +123,7 @@ type StoreState = {
   unreadTerminalTabs?: Record<string, true>
   deleteStateByWorktreeId?: Record<string, { isDeleting?: boolean; phase?: string }>
   getKnownWorktreeById?: (worktreeId: string) => { id: string } | null
+  detectedWorktreesByRepo?: Record<string, { worktrees: { id: string }[] } | undefined>
   worktreesByRepo: Record<
     string,
     {
@@ -792,10 +793,18 @@ describe('connectPanePty', () => {
       deleteStateByWorktreeId: {},
       // Why: read through the live mockStoreState so tests that drop a workspace
       // mid-run (a completed delete) see it disappear, as the real store does.
+      // Mirrors findKnownWorktreeById's fallback to the on-disk detection scan,
+      // which removeWorktree does NOT prune — the removal-respawn retry must not
+      // read that stale row as "the workspace survived the delete".
       getKnownWorktreeById: (worktreeId: string) =>
         Object.values(mockStoreState.worktreesByRepo)
           .flat()
-          .find((worktree) => worktree.id === worktreeId) ?? null,
+          .find((worktree) => worktree.id === worktreeId) ??
+        Object.values(mockStoreState.detectedWorktreesByRepo ?? {})
+          .flatMap((result) => result?.worktrees ?? [])
+          .find((worktree) => worktree.id === worktreeId) ??
+        null,
+      detectedWorktreesByRepo: {},
       worktreesByRepo: {
         repo1: [{ id: 'wt-1', repoId: 'repo1', path: '/tmp/wt-1', displayName: 'feat/notis' }]
       },
@@ -1113,6 +1122,78 @@ describe('connectPanePty', () => {
 
     expect(transport.connect).not.toHaveBeenCalled()
     expect(deps.onPtyErrorRef.current).not.toHaveBeenCalled()
+  })
+
+  // Why: removeWorktree drops the row from worktreesByRepo but never prunes the
+  // on-disk detection scan, and findKnownWorktreeById falls back to it. Reading
+  // that stale row would respawn a shell into the directory just deleted.
+  it('does not respawn when a stale detected row outlives a successful delete', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: { 'wt-1': { isDeleting: true, phase: 'deleting' } },
+      detectedWorktreesByRepo: { repo1: { worktrees: [{ id: 'wt-1' }] } }
+    }
+    const deps = createDeps({ tabId: 'tab-removal-stale-detected-no-respawn' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+    expect(transport.connect).not.toHaveBeenCalled()
+
+    // Success branch: the visible row goes, the detection scan is left stale.
+    mockStoreState = {
+      ...mockStoreState,
+      deleteStateByWorktreeId: {},
+      worktreesByRepo: { repo1: [] }
+    }
+    notifyStoreSubscribers()
+    await flushAsyncTicks()
+
+    expect(transport.connect).not.toHaveBeenCalled()
+  })
+
+  // Why: a fence that keeps re-firing (main still rejecting) must not retry
+  // forever, and must not fall back to silence either — the pane needs an
+  // explanation once the cap is spent, which is the defect this path fixes.
+  it('surfaces the blocked-spawn banner once removal respawn retries are spent', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE } =
+      await import('../../../../shared/worktree-removal-fence-error')
+    const { MAX_WORKTREE_REMOVAL_RESPAWN_ATTEMPTS, WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE } =
+      await import('./worktree-removal-respawn')
+    const transport = createMockTransport()
+    const capturedOnError: { current: ((message: string) => void) | null } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedOnError.current = callbacks.onError ?? null
+      return 'pty-1'
+    })
+    transportFactoryQueue.push(transport)
+    const fencedRemoval = { 'wt-parent': { isDeleting: true, phase: 'deleting' } }
+    mockStoreState = { ...mockStoreState, deleteStateByWorktreeId: { ...fencedRemoval } }
+    const deps = createDeps({ tabId: 'tab-fence-retries-exhausted' })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks()
+
+    // Each round: main fences the spawn, the removal settles, the pane retries.
+    for (let attempt = 0; attempt <= MAX_WORKTREE_REMOVAL_RESPAWN_ATTEMPTS; attempt++) {
+      mockStoreState = { ...mockStoreState, deleteStateByWorktreeId: { ...fencedRemoval } }
+      capturedOnError.current!(
+        `Error invoking remote method 'pty:spawn': Error: ${TERMINAL_REMOVAL_IN_PROGRESS_MESSAGE}`
+      )
+      mockStoreState = { ...mockStoreState, deleteStateByWorktreeId: {} }
+      notifyStoreSubscribers()
+      await flushAsyncTicks()
+    }
+
+    // Bounded: the cap stops the retry loop rather than reconnecting forever.
+    expect(transport.connect).toHaveBeenCalledTimes(MAX_WORKTREE_REMOVAL_RESPAWN_ATTEMPTS + 1)
+    expect(deps.onPtyErrorRef.current).toHaveBeenCalledWith(
+      expect.anything(),
+      WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE
+    )
   })
 
   it('fresh-spawns normally when the pane worktree is not being deleted', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -14,6 +14,12 @@ import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-ki
 import { isRuntimeOwnedSshTargetId } from '../../../../shared/execution-host'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import { isWorktreeRemovalFenceError } from '../../../../shared/worktree-removal-fence-error'
+import {
+  MAX_WORKTREE_REMOVAL_RESPAWN_ATTEMPTS,
+  WORKTREE_REMOVAL_RESPAWN_FALLBACK_MS,
+  WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE,
+  resolveWorktreeRemovalRespawnDecision
+} from './worktree-removal-respawn'
 import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
 import {
   HIDDEN_STARTUP_RENDERER_QUERY_PENDING_CHARS,
@@ -3180,6 +3186,10 @@ export function connectPanePty(
           (workspace) => workspace.id === parsedWorkspaceKey.folderWorkspaceId
         )
       : null
+  // Why: the floating terminal's synthetic workspace is registered nowhere, so a
+  // later "not found" must not be read as "this workspace was just deleted" by the
+  // removal-respawn retry below. Record whether it was ever known at all.
+  const paneWorkspaceWasRegistered = state.getKnownWorktreeById?.(deps.worktreeId) != null
   const workspaceEnv: Record<string, string> = { ORCA_WORKSPACE_ID: deps.worktreeId }
   if (folderWorkspace) {
     workspaceEnv.ORCA_PROJECT_GROUP_ID = folderWorkspace.projectGroupId
@@ -4197,6 +4207,82 @@ export function connectPanePty(
       deps.onPtyErrorRef?.current?.(pane.id, createTerminalZeroDimensionsMessage(cols, rows))
     }
 
+    // Why: both removal fences (main's pty:spawn rejection and startFreshSpawn's
+    // isDeleting skip) suppress exactly one spawn, but a pane only connects once.
+    // When the removal then FAILS, its shells are already dead and nothing
+    // re-triggers a spawn — the pane stays blank until the user switches
+    // workspaces. Re-arm the spawn for when every in-flight removal settles with
+    // this workspace still present.
+    let removalRespawnAttempts = 0
+    let pendingRemovalRespawn: (() => void) | null = null
+    let removalRespawnUnsubscribe: (() => void) | null = null
+    let removalRespawnFallbackTimer: ReturnType<typeof setTimeout> | null = null
+    const releaseRemovalRespawn = (): void => {
+      pendingRemovalRespawn = null
+      if (removalRespawnFallbackTimer !== null) {
+        clearTimeout(removalRespawnFallbackTimer)
+        removalRespawnFallbackTimer = null
+      }
+      const unsubscribe = removalRespawnUnsubscribe
+      removalRespawnUnsubscribe = null
+      const teardownIndex = waitTeardowns.indexOf(releaseRemovalRespawn)
+      if (teardownIndex !== -1) {
+        waitTeardowns.splice(teardownIndex, 1)
+      }
+      unsubscribe?.()
+    }
+    const evaluateRemovalRespawn = (): void => {
+      if (disposed || !pendingRemovalRespawn) {
+        releaseRemovalRespawn()
+        return
+      }
+      const state = useAppStore.getState()
+      // Why: getKnownWorktreeById, not the repo-backed worktree map — folder
+      // workspaces are synthesized on lookup and never live in worktreesByRepo.
+      const decision = resolveWorktreeRemovalRespawnDecision(
+        state.deleteStateByWorktreeId,
+        !paneWorkspaceWasRegistered || state.getKnownWorktreeById?.(deps.worktreeId) != null
+      )
+      if (decision === 'wait') {
+        return
+      }
+      const respawn = pendingRemovalRespawn
+      // Why: release before respawning so a fence on the retry can arm a fresh wait.
+      releaseRemovalRespawn()
+      if (decision === 'respawn') {
+        removalRespawnAttempts++
+        respawn()
+      }
+    }
+    const armRemovalRespawn = (respawn: () => void): boolean => {
+      if (disposed || removalRespawnAttempts >= MAX_WORKTREE_REMOVAL_RESPAWN_ATTEMPTS) {
+        return false
+      }
+      pendingRemovalRespawn = respawn
+      if (removalRespawnUnsubscribe) {
+        return true
+      }
+      removalRespawnUnsubscribe = useAppStore.subscribe(evaluateRemovalRespawn)
+      if (
+        resolveWorktreeRemovalRespawnDecision(
+          useAppStore.getState().deleteStateByWorktreeId,
+          true
+        ) !== 'wait'
+      ) {
+        // Why: a removal driven from the CLI, a paired client, or a runtime host
+        // never sets isDeleting in this renderer, so the store may never emit for
+        // it. Only that unobservable case needs a timed re-check.
+        removalRespawnFallbackTimer = setTimeout(
+          evaluateRemovalRespawn,
+          WORKTREE_REMOVAL_RESPAWN_FALLBACK_MS
+        )
+      }
+      // Why: dispose() drains waitTeardowns, so a pane torn down mid-wait cannot
+      // leak this subscriber or fire a spawn into a dead transport.
+      waitTeardowns.push(releaseRemovalRespawn)
+      return true
+    }
+
     const reportError = (message: string): void => {
       // Why: the transport connect can reject asynchronously after the pane has been
       // disposed (e.g. its workspace was deleted) — dropping a late error avoids a toast
@@ -4210,6 +4296,12 @@ export function connectPanePty(
         // user-facing failure — the pane unmounts once removal completes, so never
         // surface the raw fence error. Covers the parent-removal-fences-child case
         // that startFreshSpawn's own-worktree isDeleting skip cannot see.
+        if (armRemovalRespawn(() => void startFreshSpawn())) {
+          return
+        }
+        // Retries exhausted and the pane is still mounted and shell-less: a blank
+        // pane with no explanation is worse than the diagnostic.
+        deps.onPtyErrorRef?.current?.(pane.id, WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE)
         return
       }
       deps.onPtyErrorRef?.current?.(pane.id, message)
@@ -4757,6 +4849,9 @@ export function connectPanePty(
         // filesystem teardown. A fresh shell must not spawn into a directory the
         // removal is about to delete (main fences it anyway), and the pane is
         // about to unmount — so skip the doomed respawn instead of racing it.
+        // If the removal fails, the pane stays mounted with dead shells and this
+        // skipped spawn is the only one it would ever get, so queue a retry.
+        armRemovalRespawn(() => void startFreshSpawn(startupOverride, options))
         return Promise.resolve(null)
       }
       clearPaneMode2031State()

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -18,6 +18,7 @@ import {
   MAX_WORKTREE_REMOVAL_RESPAWN_ATTEMPTS,
   WORKTREE_REMOVAL_RESPAWN_FALLBACK_MS,
   WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE,
+  isWorkspaceStillRegistered,
   resolveWorktreeRemovalRespawnDecision
 } from './worktree-removal-respawn'
 import { parseTerminalOscColorQuery } from '../../../../shared/terminal-osc-color-reply'
@@ -3180,16 +3181,20 @@ export function connectPanePty(
   // and agentStatusByPaneKey. Treat it as opaque outside Orca.
   const state = useAppStore.getState()
   const parsedWorkspaceKey = parseWorkspaceKey(deps.worktreeId)
+  const paneFolderWorkspaceId =
+    parsedWorkspaceKey?.type === 'folder' ? parsedWorkspaceKey.folderWorkspaceId : null
   const folderWorkspace =
-    parsedWorkspaceKey?.type === 'folder'
-      ? state.folderWorkspaces.find(
-          (workspace) => workspace.id === parsedWorkspaceKey.folderWorkspaceId
-        )
+    paneFolderWorkspaceId !== null
+      ? state.folderWorkspaces.find((workspace) => workspace.id === paneFolderWorkspaceId)
       : null
   // Why: the floating terminal's synthetic workspace is registered nowhere, so a
   // later "not found" must not be read as "this workspace was just deleted" by the
   // removal-respawn retry below. Record whether it was ever known at all.
-  const paneWorkspaceWasRegistered = state.getKnownWorktreeById?.(deps.worktreeId) != null
+  const paneWorkspaceWasRegistered = isWorkspaceStillRegistered(
+    state,
+    deps.worktreeId,
+    paneFolderWorkspaceId
+  )
   const workspaceEnv: Record<string, string> = { ORCA_WORKSPACE_ID: deps.worktreeId }
   if (folderWorkspace) {
     workspaceEnv.ORCA_PROJECT_GROUP_ID = folderWorkspace.projectGroupId
@@ -4237,11 +4242,10 @@ export function connectPanePty(
         return
       }
       const state = useAppStore.getState()
-      // Why: getKnownWorktreeById, not the repo-backed worktree map — folder
-      // workspaces are synthesized on lookup and never live in worktreesByRepo.
       const decision = resolveWorktreeRemovalRespawnDecision(
         state.deleteStateByWorktreeId,
-        !paneWorkspaceWasRegistered || state.getKnownWorktreeById?.(deps.worktreeId) != null
+        !paneWorkspaceWasRegistered ||
+          isWorkspaceStillRegistered(state, deps.worktreeId, paneFolderWorkspaceId)
       )
       if (decision === 'wait') {
         return
@@ -4850,8 +4854,12 @@ export function connectPanePty(
         // removal is about to delete (main fences it anyway), and the pane is
         // about to unmount — so skip the doomed respawn instead of racing it.
         // If the removal fails, the pane stays mounted with dead shells and this
-        // skipped spawn is the only one it would ever get, so queue a retry.
-        armRemovalRespawn(() => void startFreshSpawn(startupOverride, options))
+        // skipped spawn is the only one it would ever get, so queue a retry. Once
+        // the retries are spent, say so rather than silently leaving it blank —
+        // that silence is the bug this path exists to fix.
+        if (!armRemovalRespawn(() => void startFreshSpawn(startupOverride, options)) && !disposed) {
+          deps.onPtyErrorRef?.current?.(pane.id, WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE)
+        }
         return Promise.resolve(null)
       }
       clearPaneMode2031State()

--- a/src/renderer/src/components/terminal-pane/worktree-removal-respawn.test.ts
+++ b/src/renderer/src/components/terminal-pane/worktree-removal-respawn.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveWorktreeRemovalRespawnDecision } from './worktree-removal-respawn'
+import {
+  isWorkspaceStillRegistered,
+  resolveWorktreeRemovalRespawnDecision
+} from './worktree-removal-respawn'
 
 describe('resolveWorktreeRemovalRespawnDecision', () => {
   it('waits while this workspace is still being removed', () => {
@@ -26,5 +29,34 @@ describe('resolveWorktreeRemovalRespawnDecision', () => {
 
   it('abandons when the workspace is gone', () => {
     expect(resolveWorktreeRemovalRespawnDecision({}, false)).toBe('abandon')
+  })
+})
+
+describe('isWorkspaceStillRegistered', () => {
+  it('reads the visible worktree map', () => {
+    const state = { worktreesByRepo: { repo1: [{ id: 'wt-1' }] } }
+    expect(isWorkspaceStillRegistered(state, 'wt-1', null)).toBe(true)
+    expect(isWorkspaceStillRegistered({ worktreesByRepo: { repo1: [] } }, 'wt-1', null)).toBe(false)
+  })
+
+  // Why: removeWorktree never prunes the on-disk detection scan, so a deleted
+  // workspace lingers there. Respawning off that stale row would start a shell
+  // in the directory the removal just deleted.
+  it('ignores a stale on-disk detection row for a deleted workspace', () => {
+    const state = {
+      worktreesByRepo: { repo1: [] },
+      detectedWorktreesByRepo: { repo1: { worktrees: [{ id: 'wt-1' }] } }
+    }
+    expect(isWorkspaceStillRegistered(state, 'wt-1', null)).toBe(false)
+  })
+
+  // Why: folder workspaces are synthesized on lookup and never live in
+  // worktreesByRepo, so they must resolve through the folder list instead.
+  it('resolves folder workspaces through folderWorkspaces', () => {
+    const state = { worktreesByRepo: {}, folderWorkspaces: [{ id: 'folder-1' }] }
+    expect(isWorkspaceStillRegistered(state, 'folder:folder-1', 'folder-1')).toBe(true)
+    expect(isWorkspaceStillRegistered({ worktreesByRepo: {} }, 'folder:folder-1', 'folder-1')).toBe(
+      false
+    )
   })
 })

--- a/src/renderer/src/components/terminal-pane/worktree-removal-respawn.test.ts
+++ b/src/renderer/src/components/terminal-pane/worktree-removal-respawn.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeRemovalRespawnDecision } from './worktree-removal-respawn'
+
+describe('resolveWorktreeRemovalRespawnDecision', () => {
+  it('waits while this workspace is still being removed', () => {
+    expect(resolveWorktreeRemovalRespawnDecision({ 'wt-1': { isDeleting: true } }, true)).toBe(
+      'wait'
+    )
+  })
+
+  // Why: an overlapping parent/child root removal fences this pane's spawn in main
+  // even though the pane's own workspace carries no delete state.
+  it('waits while any other workspace removal is in flight', () => {
+    expect(resolveWorktreeRemovalRespawnDecision({ 'wt-parent': { isDeleting: true } }, true)).toBe(
+      'wait'
+    )
+  })
+
+  it('respawns once every removal settled and the workspace survived', () => {
+    expect(resolveWorktreeRemovalRespawnDecision({ 'wt-1': { isDeleting: false } }, true)).toBe(
+      'respawn'
+    )
+    expect(resolveWorktreeRemovalRespawnDecision({}, true)).toBe('respawn')
+    expect(resolveWorktreeRemovalRespawnDecision(undefined, true)).toBe('respawn')
+  })
+
+  it('abandons when the workspace is gone', () => {
+    expect(resolveWorktreeRemovalRespawnDecision({}, false)).toBe('abandon')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/worktree-removal-respawn.ts
+++ b/src/renderer/src/components/terminal-pane/worktree-removal-respawn.ts
@@ -1,0 +1,44 @@
+// A workspace removal fences terminal spawns twice: main rejects pty:spawn with
+// TerminalRemovalInProgressError, and the renderer skips its own doomed respawn
+// while `isDeleting` is set. Both suppressions are one-shot — a pane's connect
+// runs once — so a removal that FAILS after killing the shells strands the pane
+// blank with nothing left to re-trigger a spawn. These helpers decide when that
+// suppression has settled and the pane should try again.
+
+export type WorktreeRemovalRespawnDecision =
+  // A removal is still in flight; keep waiting.
+  | 'wait'
+  // Every removal settled and the workspace survived — the delete failed, so respawn.
+  | 'respawn'
+  // The workspace is gone; the pane is about to unmount, so stay quiet.
+  | 'abandon'
+
+// Why: bounds pathological arm→spawn→fence→arm cycles (e.g. a removal driven
+// from the CLI or a paired client that the renderer store never observes).
+export const MAX_WORKTREE_REMOVAL_RESPAWN_ATTEMPTS = 3
+
+// Why: removals started outside this renderer never set `isDeleting`, so the
+// store may never emit. Re-evaluate on a timer as well, long enough that a
+// normal removal has either finished or failed first.
+export const WORKTREE_REMOVAL_RESPAWN_FALLBACK_MS = 4_000
+
+// Why: last resort when the retries above never got through. Mirrors
+// terminal-zero-dimensions-diagnostic: a plain diagnostic string for the pane's
+// error banner, so the user is never left with a blank pane and no explanation.
+export const WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE =
+  'This terminal could not start: a workspace deletion is still blocking new shells. Reopen this tab once the deletion finishes or is cancelled.'
+
+export function resolveWorktreeRemovalRespawnDecision(
+  deleteStateByWorktreeId: Record<string, { isDeleting?: boolean } | undefined> | undefined,
+  worktreeExists: boolean
+): WorktreeRemovalRespawnDecision {
+  // Why: an overlapping parent/child root removal fences this pane too, and the
+  // pane's own worktree has no delete state in that case — so wait on every
+  // in-flight removal, not just this workspace's.
+  for (const entry of Object.values(deleteStateByWorktreeId ?? {})) {
+    if (entry?.isDeleting === true) {
+      return 'wait'
+    }
+  }
+  return worktreeExists ? 'respawn' : 'abandon'
+}

--- a/src/renderer/src/components/terminal-pane/worktree-removal-respawn.ts
+++ b/src/renderer/src/components/terminal-pane/worktree-removal-respawn.ts
@@ -28,6 +28,28 @@ export const WORKTREE_REMOVAL_RESPAWN_FALLBACK_MS = 4_000
 export const WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE =
   'This terminal could not start: a workspace deletion is still blocking new shells. Reopen this tab once the deletion finishes or is cancelled.'
 
+// Why NOT getKnownWorktreeById: it falls back to `detectedWorktreesByRepo`, which
+// is the repo's full on-disk worktree scan (registered rows carry `visible: true`)
+// and which removeWorktree never prunes. A successfully deleted workspace stays
+// resolvable there until the next detection refresh, so reading it would respawn a
+// shell into the directory that was just deleted. Only consult the maps the
+// removal clears in the same set() as the deletion.
+export function isWorkspaceStillRegistered(
+  state: {
+    worktreesByRepo?: Record<string, readonly { id: string }[] | undefined>
+    folderWorkspaces?: readonly { id: string }[]
+  },
+  workspaceId: string,
+  folderWorkspaceId: string | null
+): boolean {
+  if (folderWorkspaceId !== null) {
+    return (state.folderWorkspaces ?? []).some((workspace) => workspace.id === folderWorkspaceId)
+  }
+  return Object.values(state.worktreesByRepo ?? {}).some((worktrees) =>
+    (worktrees ?? []).some((worktree) => worktree.id === workspaceId)
+  )
+}
+
 export function resolveWorktreeRemovalRespawnDecision(
   deleteStateByWorktreeId: Record<string, { isDeleting?: boolean } | undefined> | undefined,
   worktreeExists: boolean


### PR DESCRIPTION
## The defect

A workspace removal fences terminal spawns in two places:

- main rejects `pty:spawn` with `TerminalRemovalInProgressError`, and the renderer deliberately swallows that fence in `reportError` (`pty-connection.ts`), because during a *successful* removal the pane is about to unmount and the raw fence text would just flash on the tab.
- `startFreshSpawn` skips its own doomed respawn while `deleteStateByWorktreeId[worktreeId].isDeleting` is set.

Both suppressions are correct while the removal is running. The problem is that they are **one-shot**: a pane runs its connect exactly once (`connectStarted`). Main kills every PTY in the workspace *before* the removal can fail, so when a delete fails partway the pane is left mounted, shell-less, and blank — and nothing ever re-triggers a spawn when `isDeleting` clears. It stays blank until the user switches workspaces and forces a remount.

Trigger observed in the field: `worktrees:remove` throwing after the PTY teardown sweep, which sets `deleteStateByWorktreeId[id] = { isDeleting: false, error }` and returns `{ ok: false }`. The root cause of that particular throw is out of scope here — this PR is only about not stranding the panes when a delete fails for *any* reason.

**Correcting one part of the report:** the workspace-level failure *is* already surfaced. Every `removeWorktree` caller toasts on failure (`delete-worktree-flow.ts` via `showDeleteWorktreeFailureToast`, `DeleteWorktreeDialog.tsx`, `WorkspaceSpaceManagerPanel.tsx`, `workspace-cleanup.ts`). What was silent was the **pane**: no message, no recovery, no retry.

## The fix

Re-arm the suppressed spawn instead of dropping it:

- Both suppression sites now register a retry. When every in-flight removal has settled and the pane's workspace is still registered, the spawn runs.
- `useAppStore.subscribe` drives it; the unsubscribe is registered in `waitTeardowns`, which `dispose()` already drains, so a pane torn down mid-wait cannot leak the subscriber or spawn into a dead transport.
- A successful removal is distinguished from a failed one by whether the workspace is still known — on success the pane just unmounts, exactly as before.
- If retries are exhausted and the pane is still mounted and shell-less, the fence is no longer swallowed silently: the pane's existing error banner explains that a workspace deletion is blocking new shells, rather than leaving a blank surface with no explanation.

`resolveWorktreeRemovalRespawnDecision` waits on *every* in-flight removal, not just this workspace's, because an overlapping parent/child root removal fences a child pane whose own workspace carries no delete state.

## Cross-cutting cases

- **SSH / remote runtime / paired clients**: the retry re-enters `startFreshSpawn`, which is transport-agnostic (local, SSH, and runtime-RPC panes all go through it). `removeWorktree` sets the delete state for the runtime-RPC route too.
- **Folder workspaces**: uses `getKnownWorktreeById`, not the repo-backed worktree map — `folder:<id>` workspaces are synthesized on lookup and never live in `worktreesByRepo`, so the map would have read every folder workspace as "deleted" and abandoned the retry.
- **Floating terminal**: its synthetic workspace is registered nowhere, so "workspace was never known" is recorded at connect time and a later miss is not misread as a deletion.
- **Removals this renderer cannot observe** (CLI, paired client, runtime host) never set `isDeleting` here, so the store may never emit. Only that case arms a timed re-check; an observable removal wakes the subscriber directly. Attempts are capped so an unobservable removal cannot drive an arm/fence/arm loop.

## Tests

`src/renderer/src/components/terminal-pane/pty-connection.test.ts`
- `respawns the pane after a failed workspace delete clears the removal fence` — pane connects while `isDeleting`, no spawn; delete fails (`isDeleting: false`, workspace still present); pane spawns.
- `respawns after a swallowed removal fence once the removal settles` — a parent workspace removal fences the child pane's spawn, the fence is swallowed, and the spawn is retried once the removal settles.
- `does not respawn a suppressed pane when the workspace delete succeeds` — negative control: delete state and workspace both drop, no spawn, no error.

`src/renderer/src/components/terminal-pane/worktree-removal-respawn.test.ts` covers the decision function directly (wait on own removal, wait on an overlapping removal, respawn on settle, abandon on removal).

**Revert-verified**: with `pty-connection.ts` reverted (tests kept), both regression tests fail and the negative control still passes.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/pty-connection.test.ts \
  src/renderer/src/components/terminal-pane/worktree-removal-respawn.test.ts
# 483 passed (483)
```

`typecheck:web` clean. `oxlint`, switch-exhaustiveness, styled-scrollbars, reliability-gates, max-lines-ratchet, localization-catalog and localization-coverage all pass. (`verify:skill-bundle-manifest` fails on this branch with these changes stashed too — pre-existing, unrelated.)

## Scope

No changes to the removal path itself (`worktree-teardown.ts`, `pty-descendant-termination.ts`, `windows-pty-root-identity.ts` untouched), no broad refactor of `pty-connection.ts`, no new toast/notification primitives.

## Review round (commit `94b4e6590`)

Independent review found and fixed one blocking defect plus one gap:

**1. The pane could respawn into a *successfully* deleted workspace.** The retry decided "the delete failed, so respawn" by asking `getKnownWorktreeById` whether the workspace survived. That helper falls back to `detectedWorktreesByRepo` (`worktrees.ts:707-711`) — the repo's full on-disk worktree scan, in which registered rows carry `visible: true` — and `removeWorktree`'s atomic set never prunes it. So after a *successful* delete the workspace stayed resolvable there, the decision came back `respawn`, and the pane started a shell in the directory that had just been deleted. Zustand listeners run synchronously inside `set()`, so this fired before the pane unmounted. The original negative-control test could not catch it: its mock `getKnownWorktreeById` read only `worktreesByRepo`.

Fixed with `isWorkspaceStillRegistered`, which resolves only through the maps the removal clears in the same `set()` as the deletion — `worktreesByRepo`, or `folderWorkspaces` for `folder:<id>` workspaces.

*Revert-verified*: restoring the `getKnownWorktreeById` predicate makes `does not respawn when a stale detected row outlives a successful delete` fail with `transport.connect` called once — i.e. it demonstrably spawns into the deleted workspace.

**2. The `isDeleting` skip gave up silently when retries were spent** (raised by CodeRabbit). It discarded `armRemovalRespawn`'s return value and returned `null`, leaving the pane blank — the very defect this path exists to fix. It now surfaces `WORKTREE_REMOVAL_SPAWN_BLOCKED_MESSAGE` when `!disposed`, matching the fence path.

New tests: `does not respawn when a stale detected row outlives a successful delete`, `surfaces the blocked-spawn banner once removal respawn retries are spent` (which also pins boundedness — `transport.connect` called exactly `MAX + 1` times), and direct coverage of `isWorkspaceStillRegistered` including the stale-detected-row and folder-workspace cases. The `pty-connection.test.ts` store mock now models the real `findKnownWorktreeById` detected fallback, so this class of bug is reproducible in tests at all.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/components/terminal-pane/pty-connection.test.ts \
  src/renderer/src/components/terminal-pane/worktree-removal-respawn.test.ts
# 488 passed (488)
```

`typecheck:web`, `oxlint` and `check:max-lines-ratchet` clean.

## Verification scope / limitation

This is verified at **component level only** — there is no end-to-end repro of a partially-failed workspace delete driving a real pane back to life. The regression tests drive `connectPanePty` against a mocked store and transport; the store-ordering guarantees they depend on (that `worktreesByRepo` / `folderWorkspaces` and the delete state clear in one `set()`, and that `detectedWorktreesByRepo` does not) were established by reading `removeWorktree`, not by observing a live delete. A live Windows repro of the original `Failed to physically stop every PTY` failure was not attempted.
