### PR TITLE
feat(markdown): add follow-links navigation mode

### DIFF
--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -1157,6 +1157,12 @@
   cursor: pointer;
 }
 
+.rich-markdown-editor-shell[data-follow-links='true']
+  .rich-markdown-editor
+  a:not(.rich-markdown-html-superscript-link):not(:has(img)) {
+  cursor: pointer;
+}
+
 .dark .rich-markdown-editor a {
   color: #58a6ff;
 }

--- a/src/renderer/src/components/editor/EditorPanel.tsx
+++ b/src/renderer/src/components/editor/EditorPanel.tsx
@@ -24,6 +24,7 @@ import {
 } from './editor-panel-git-entry-selector'
 import { createEditorPanelDraftSelector } from './editor-panel-draft-selector'
 import { attemptEditorFileSave } from './editor-file-save-attempt'
+import { RichMarkdownFollowLinksProvider } from './rich-markdown-follow-links-state'
 
 function EditorPanelInner({
   activeFileId: activeFileIdProp,
@@ -352,56 +353,61 @@ function EditorPanelInner({
   return (
     // Why: each split pane needs an isolated bridge between its diff editor and header controls.
     <DiffNavigationProvider>
-      <EditorPanelShell
-        panelRef={setPanelRef}
-        activeFile={activeFile}
-        activeViewStateId={activeViewStateId}
-        model={model}
-        copiedPathVisible={copiedPathToast?.fileId === activeFile.id}
-        showMarkdownTableOfContents={isMarkdownTableOfContentsVisible}
-        canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
-        markdownFrontmatterVisible={isMarkdownFrontmatterVisible}
-        sideBySide={sideBySide}
-        openFiles={openFiles}
-        fileContents={fileContents}
-        diffContents={diffContents}
-        editorDrafts={editorDrafts}
-        pendingEditorReveal={pendingEditorReveal}
-        renameDialogFile={renameDialogFile}
-        renameError={renameError}
-        disableRenameBrowse={disableRenameBrowse}
-        onCopyPath={() => void handleCopyPath()}
-        onOpenDiffTargetFile={handleOpenDiffTargetFile}
-        onOpenPreviewToSide={handleOpenPreviewToSide}
-        onOpenMarkdownPreview={handleOpenMarkdownPreview}
-        onOpenContainingFolder={handleOpenContainingFolder}
-        onToggleSideBySide={() => setSideBySide((prev) => !prev)}
-        onEditorToggleChange={handleEditorToggleChange}
-        onToggleMarkdownTableOfContents={() =>
-          setMarkdownTableOfContentsVisible(
-            markdownDocumentStateFileId,
-            !isMarkdownTableOfContentsVisible
-          )
-        }
-        onToggleMarkdownFrontmatter={() =>
-          setMarkdownFrontmatterVisible(markdownDocumentStateFileId, !isMarkdownFrontmatterVisible)
-        }
-        onExportMarkdownToPdf={() =>
-          void exportActiveMarkdownToPdf({ fileId: activeFile.id, root: panelRef.current })
-        }
-        onContentChange={handleContentChange}
-        onContentChangeForFile={handleContentChangeForFile}
-        onDirtyStateHint={handleDirtyStateHint}
-        onSave={handleSave}
-        onSaveForFile={handleSaveForFile}
-        onReloadContent={reloadContent}
-        onCloseMarkdownTableOfContents={() =>
-          setMarkdownTableOfContentsVisible(markdownDocumentStateFileId, false)
-        }
-        onCloseRenameDialog={closeRenameDialog}
-        onRenameConfirm={handleRenameConfirm}
-        markdownAnnotationsEnabled={markdownAnnotationsEnabled}
-      />
+      <RichMarkdownFollowLinksProvider>
+        <EditorPanelShell
+          panelRef={setPanelRef}
+          activeFile={activeFile}
+          activeViewStateId={activeViewStateId}
+          model={model}
+          copiedPathVisible={copiedPathToast?.fileId === activeFile.id}
+          showMarkdownTableOfContents={isMarkdownTableOfContentsVisible}
+          canShowMarkdownFrontmatterToggle={canShowMarkdownFrontmatterToggle}
+          markdownFrontmatterVisible={isMarkdownFrontmatterVisible}
+          sideBySide={sideBySide}
+          openFiles={openFiles}
+          fileContents={fileContents}
+          diffContents={diffContents}
+          editorDrafts={editorDrafts}
+          pendingEditorReveal={pendingEditorReveal}
+          renameDialogFile={renameDialogFile}
+          renameError={renameError}
+          disableRenameBrowse={disableRenameBrowse}
+          onCopyPath={() => void handleCopyPath()}
+          onOpenDiffTargetFile={handleOpenDiffTargetFile}
+          onOpenPreviewToSide={handleOpenPreviewToSide}
+          onOpenMarkdownPreview={handleOpenMarkdownPreview}
+          onOpenContainingFolder={handleOpenContainingFolder}
+          onToggleSideBySide={() => setSideBySide((prev) => !prev)}
+          onEditorToggleChange={handleEditorToggleChange}
+          onToggleMarkdownTableOfContents={() =>
+            setMarkdownTableOfContentsVisible(
+              markdownDocumentStateFileId,
+              !isMarkdownTableOfContentsVisible
+            )
+          }
+          onToggleMarkdownFrontmatter={() =>
+            setMarkdownFrontmatterVisible(
+              markdownDocumentStateFileId,
+              !isMarkdownFrontmatterVisible
+            )
+          }
+          onExportMarkdownToPdf={() =>
+            void exportActiveMarkdownToPdf({ fileId: activeFile.id, root: panelRef.current })
+          }
+          onContentChange={handleContentChange}
+          onContentChangeForFile={handleContentChangeForFile}
+          onDirtyStateHint={handleDirtyStateHint}
+          onSave={handleSave}
+          onSaveForFile={handleSaveForFile}
+          onReloadContent={reloadContent}
+          onCloseMarkdownTableOfContents={() =>
+            setMarkdownTableOfContentsVisible(markdownDocumentStateFileId, false)
+          }
+          onCloseRenameDialog={closeRenameDialog}
+          onRenameConfirm={handleRenameConfirm}
+          markdownAnnotationsEnabled={markdownAnnotationsEnabled}
+        />
+      </RichMarkdownFollowLinksProvider>
     </DiffNavigationProvider>
   )
 }

--- a/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.test.tsx
@@ -73,6 +73,7 @@ describe('EditorPanelHeader', () => {
         hasEditorToggle={false}
         availableEditorToggleModes={[]}
         effectiveToggleValue="edit"
+        canShowRichMarkdownFollowLinks={false}
         canOpenPreviewToSide={false}
         canShowMarkdownPreview={false}
         canShowMarkdownTableOfContents={false}

--- a/src/renderer/src/components/editor/EditorPanelHeader.tsx
+++ b/src/renderer/src/components/editor/EditorPanelHeader.tsx
@@ -17,6 +17,7 @@ import { EditorPanelHeaderPath } from './EditorPanelHeaderPath'
 import { useDiffNavigation } from './diff-navigation-context'
 import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { RichMarkdownFollowLinksHeaderButton } from './RichMarkdownFollowLinksHeaderButton'
 
 type EditorPanelHeaderProps = {
   activeFile: OpenFile
@@ -29,6 +30,7 @@ type EditorPanelHeaderProps = {
   hasEditorToggle: boolean
   availableEditorToggleModes: readonly EditorToggleValue[]
   effectiveToggleValue: EditorToggleValue
+  canShowRichMarkdownFollowLinks: boolean
   canOpenPreviewToSide: boolean
   canShowMarkdownPreview: boolean
   canShowMarkdownTableOfContents: boolean
@@ -63,6 +65,7 @@ export function EditorPanelHeader({
   hasEditorToggle,
   availableEditorToggleModes,
   effectiveToggleValue,
+  canShowRichMarkdownFollowLinks,
   canOpenPreviewToSide,
   canShowMarkdownPreview,
   canShowMarkdownTableOfContents,
@@ -275,6 +278,7 @@ export function EditorPanelHeader({
           }
         />
       )}
+      {canShowRichMarkdownFollowLinks && <RichMarkdownFollowLinksHeaderButton />}
       {canShowMarkdownTableOfContents && (
         <TooltipProvider delayDuration={300}>
           <Tooltip>

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -106,6 +106,7 @@ export function EditorPanelShell({
           hasEditorToggle={model.hasEditorToggle}
           availableEditorToggleModes={model.availableEditorToggleModes}
           effectiveToggleValue={model.effectiveToggleValue}
+          canShowRichMarkdownFollowLinks={model.canShowRichMarkdownFollowLinks}
           canOpenPreviewToSide={model.canOpenPreviewToSide}
           canShowMarkdownPreview={model.canShowMarkdownPreview}
           canShowMarkdownTableOfContents={model.canShowMarkdownTableOfContents}

--- a/src/renderer/src/components/editor/RichMarkdownEditor.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditor.tsx
@@ -32,6 +32,10 @@ import {
   getSelectedHtmlSuperscriptLinkStatus
 } from './rich-markdown-selected-link-actions'
 import type { RichMarkdownEditorProps } from './rich-markdown-editor-props'
+import {
+  useCommittedRichMarkdownFollowLinksRef,
+  useRichMarkdownFollowLinks
+} from './rich-markdown-follow-links-state'
 
 export default function RichMarkdownEditor({
   fileId,
@@ -56,6 +60,8 @@ export default function RichMarkdownEditor({
   headerSlot
 }: RichMarkdownEditorProps): React.JSX.Element {
   const rootRef = useRef<HTMLDivElement | null>(null)
+  const followLinks = useRichMarkdownFollowLinks()
+  const followLinksOnClickRef = useCommittedRichMarkdownFollowLinksRef(followLinks?.active ?? false)
   const settings = useAppStore((s) => s.settings)
   const richMarkdownSpellcheckEnabled = settings?.richMarkdownSpellcheckEnabled ?? true
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
@@ -202,6 +208,7 @@ export default function RichMarkdownEditor({
     richMarkdownSpellcheckEnabled,
     settings,
     activateMarkdownLink,
+    followLinksOnClickRef,
     rootRef,
     editorRef,
     lastCommittedMarkdownRef,
@@ -352,6 +359,7 @@ export default function RichMarkdownEditor({
     <RichMarkdownEditorSurface
       editor={editor}
       editorFontZoomLevel={editorFontZoomLevel}
+      followLinks={followLinks ?? undefined}
       rootElement={rootRef.current}
       rootRef={setRootElement}
       scrollContainerRef={scrollContainerRef}

--- a/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
@@ -20,6 +20,7 @@ import type { MarkdownReviewNote } from '@/lib/markdown-review-notes'
 import type { RichMarkdownAnnotationTarget } from './rich-markdown-review-annotations'
 import type { RichMarkdownReviewNotePosition } from './rich-markdown-review-note-layout'
 import type { DiffComment } from '../../../../shared/types'
+import type { RichMarkdownFollowLinksState } from './rich-markdown-follow-links-state'
 
 function shouldFocusEmptyEditorFromSurfaceClick(
   event: React.MouseEvent<HTMLDivElement>,
@@ -38,6 +39,7 @@ function shouldFocusEmptyEditorFromSurfaceClick(
 type RichMarkdownEditorSurfaceProps = {
   editor: Editor | null
   editorFontZoomLevel: number
+  followLinks?: RichMarkdownFollowLinksState
   rootElement: HTMLDivElement | null
   rootRef: (node: HTMLDivElement | null) => void
   scrollContainerRef: React.RefObject<HTMLDivElement | null>
@@ -126,6 +128,7 @@ type RichMarkdownEditorSurfaceProps = {
 export function RichMarkdownEditorSurface({
   editor,
   editorFontZoomLevel,
+  followLinks,
   rootElement,
   rootRef,
   scrollContainerRef,
@@ -195,6 +198,7 @@ export function RichMarkdownEditorSurface({
         className={`rich-markdown-editor-shell ${
           reviewRailExpanded ? 'has-rich-markdown-review-notes' : ''
         }`.trim()}
+        data-follow-links={followLinks?.active ? 'true' : undefined}
         style={{ '--editor-font-zoom-level': editorFontZoomLevel } as React.CSSProperties}
       >
         <RichMarkdownToolbar

--- a/src/renderer/src/components/editor/RichMarkdownFollowLinksHeaderButton.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownFollowLinksHeaderButton.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { RichMarkdownFollowLinksHeaderButton } from './RichMarkdownFollowLinksHeaderButton'
+import { RichMarkdownFollowLinksProvider } from './rich-markdown-follow-links-state'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+describe('RichMarkdownFollowLinksHeaderButton', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('toggles pane-scoped follow-links state', () => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <RichMarkdownFollowLinksProvider>
+            <RichMarkdownFollowLinksHeaderButton />
+          </RichMarkdownFollowLinksProvider>
+        </TooltipProvider>
+      )
+    })
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Follow links on click"]'
+    )
+    expect(button?.getAttribute('aria-pressed')).toBe('false')
+
+    const mouseDown = new MouseEvent('mousedown', { bubbles: true, cancelable: true })
+    act(() => {
+      button?.dispatchEvent(mouseDown)
+    })
+    expect(mouseDown.defaultPrevented).toBe(true)
+
+    act(() => button?.click())
+    expect(button?.getAttribute('aria-pressed')).toBe('true')
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownFollowLinksHeaderButton.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownFollowLinksHeaderButton.tsx
@@ -1,0 +1,37 @@
+import { MousePointerClick } from 'lucide-react'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { translate } from '@/i18n/i18n'
+import { useRichMarkdownFollowLinks } from './rich-markdown-follow-links-state'
+
+export function RichMarkdownFollowLinksHeaderButton(): React.JSX.Element | null {
+  const followLinks = useRichMarkdownFollowLinks()
+  if (!followLinks) {
+    return null
+  }
+  const label = translate(
+    'auto.components.editor.RichMarkdownFollowLinksHeaderButton.followLinksOnClick',
+    'Follow links on click'
+  )
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className={`flex-shrink-0 rounded p-1 transition-colors hover:bg-accent hover:text-foreground ${
+            followLinks.active ? 'bg-accent text-foreground' : 'text-muted-foreground'
+          }`}
+          aria-label={label}
+          aria-pressed={followLinks.active}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={followLinks.onToggle}
+        >
+          <MousePointerClick size={14} />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={4}>
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/editor/editor-panel-render-model.test.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.test.ts
@@ -130,6 +130,70 @@ describe('getEditorPanelRenderModel read-only raw rendering (AI Vault View Log)'
   })
 })
 
+describe('getEditorPanelRenderModel rich Markdown link navigation affordance', () => {
+  it('shows the control only while an editable Markdown file uses the rich editor', () => {
+    expect(renderModel({}).canShowRichMarkdownFollowLinks).toBe(true)
+    expect(
+      renderModel({
+        markdownViewMode: { '/repo/README.md': 'source' }
+      }).canShowRichMarkdownFollowLinks
+    ).toBe(false)
+    expect(renderModel({ isChangesMode: true }).canShowRichMarkdownFollowLinks).toBe(false)
+    expect(
+      renderModel({
+        editorDrafts: { '/repo/README.md': '[example]: https://example.com' }
+      }).canShowRichMarkdownFollowLinks
+    ).toBe(false)
+  })
+
+  it('hides the control when the rich editor cannot mount', () => {
+    expect(
+      renderModel({
+        fileContents: {},
+        editorDrafts: { '/repo/README.md': '# Draft' }
+      }).canShowRichMarkdownFollowLinks
+    ).toBe(false)
+    expect(
+      renderModel({
+        fileContents: { '/repo/README.md': textContent({ loadError: 'missing' }) }
+      }).canShowRichMarkdownFollowLinks
+    ).toBe(false)
+    expect(
+      renderModel({
+        fileContents: { '/repo/README.md': textContent({ isBinary: true }) }
+      }).canShowRichMarkdownFollowLinks
+    ).toBe(false)
+    expect(
+      renderModel({
+        activeFile: markdownFile({
+          conflict: {
+            kind: 'conflict-editable',
+            conflictKind: 'both_modified',
+            conflictStatus: 'unresolved',
+            conflictStatusSource: 'git'
+          }
+        })
+      }).canShowRichMarkdownFollowLinks
+    ).toBe(false)
+  })
+
+  it('does not expose Markdown navigation on other rich viewers', () => {
+    const mermaid = markdownFile({
+      id: '/repo/diagram.mmd',
+      filePath: '/repo/diagram.mmd',
+      relativePath: 'diagram.mmd',
+      language: 'mermaid'
+    })
+
+    expect(
+      renderModel({
+        activeFile: mermaid,
+        fileContents: { [mermaid.id]: textContent({ content: 'graph TD' }) }
+      }).canShowRichMarkdownFollowLinks
+    ).toBe(false)
+  })
+})
+
 describe('getEditorPanelRenderModel markdown export affordance', () => {
   it('enables export for rendered markdown edit tabs', () => {
     expect(renderModel({}).canExportMarkdownToPdf).toBe(true)

--- a/src/renderer/src/components/editor/editor-panel-render-model.ts
+++ b/src/renderer/src/components/editor/editor-panel-render-model.ts
@@ -148,6 +148,17 @@ export function getEditorPanelRenderModel({
         fileContents[activeFile.id]?.isBinary !== true &&
         !fileContents[activeFile.id]?.loadError &&
         activeFile.conflict?.conflictStatus !== 'unresolved'))
+  const activeFileContent = activeFile.mode === 'edit' ? fileContents[activeFile.id] : undefined
+  const canShowRichMarkdownFollowLinks =
+    viewerLanguage === 'markdown' &&
+    activeFile.mode === 'edit' &&
+    activeFile.conflict?.kind !== 'conflict-placeholder' &&
+    activeFile.conflict?.conflictStatus !== 'unresolved' &&
+    activeFileContent !== undefined &&
+    activeFileContent.isBinary !== true &&
+    !activeFileContent.loadError &&
+    !isChangesMode &&
+    inlineMarkdownRenderMode === 'rich-editor'
   return {
     isSingleDiff,
     isDiffSurface: isSingleDiff || isChangesMode,
@@ -171,6 +182,7 @@ export function getEditorPanelRenderModel({
     hasEditorToggle: availableEditorToggleModes.length > 1,
     effectiveToggleValue,
     isMarkdownTableOfContentsDisabled: hasViewModeToggle && mdViewMode === 'source',
+    canShowRichMarkdownFollowLinks,
     shouldShowMarkdownExportAction,
     canExportMarkdownToPdf,
     canShowMarkdownTableOfContents:

--- a/src/renderer/src/components/editor/rich-markdown-editor-click-routing.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-click-routing.test.ts
@@ -1,84 +1,276 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+// @vitest-environment happy-dom
+
 import type { MutableRefObject } from 'react'
+import type { Editor } from '@tiptap/react'
 import type { EditorView } from '@tiptap/pm/view'
-import { handleRichMarkdownEditorClick } from './rich-markdown-editor-click-routing'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { HttpLinkSourceOwner } from '@/lib/http-link-routing'
+import { createRichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
 
-const openHttpLinkMock = vi.hoisted(() => vi.fn())
+const getCommentAtPosition = vi.hoisted(() => vi.fn())
+const openHttpLink = vi.hoisted(() => vi.fn())
 
-vi.mock('@/lib/http-link-routing', () => ({
-  openHttpLink: openHttpLinkMock
+vi.mock('./rich-markdown-review-annotations', () => ({
+  getRichMarkdownCommentAtPos: getCommentAtPosition
 }))
+vi.mock('@/lib/http-link-routing', () => ({ openHttpLink }))
 
-beforeEach(() => {
-  openHttpLinkMock.mockReset()
-})
+import {
+  handleRichMarkdownEditorClick,
+  type ActivateMarkdownLink
+} from './rich-markdown-editor-click-routing'
 
-// Why: the preview deliberately routes differently; this pins the editor side so a
-// future "make them consistent" change cannot land silently.
-function clickExternalLinkWithShift(sourceOwner: HttpLinkSourceOwner, isMac = true): boolean {
-  const href = 'https://example.com/docs'
-  const view = {
+type ClickNode = {
+  attrs: Record<string, unknown>
+  type: { name: string }
+}
+
+const baseEvent = {
+  button: 0,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false
+} as MouseEvent
+
+function ref<T>(current: T): MutableRefObject<T> {
+  return { current }
+}
+
+function editorView(node: ClickNode | null, href?: string): EditorView {
+  return {
     state: {
       doc: {
-        nodeAt: () => null,
+        nodeAt: () => node,
         resolve: () => ({
-          marks: () => [{ type: { name: 'link' }, attrs: { href } }]
+          marks: () =>
+            href
+              ? [
+                  {
+                    attrs: { href },
+                    type: { name: 'link' }
+                  }
+                ]
+              : []
         })
       }
     }
   } as unknown as EditorView
-
-  return handleRichMarkdownEditorClick({
-    activateMarkdownLink: vi.fn(),
-    editorRef: { current: {} } as unknown as MutableRefObject<unknown>,
-    event: { metaKey: isMac, ctrlKey: !isMac, shiftKey: true } as MouseEvent,
-    filePath: '/repo/docs/README.md',
-    isMac,
-    htmlSuperscriptLinkContext: {
-      getSnapshot: () => ({ sourceOwner })
-    },
-    markdownCommentsRef: { current: [] },
-    markdownSourceLineOffsetRef: { current: 0 },
-    onOpenDocLinkRef: { current: undefined },
-    pos: 1,
-    rootRef: { current: null },
-    scrollRichMarkdownReviewNoteCardIntoView: vi.fn(),
-    settings: {} as never,
-    view,
-    worktreeId: 'wt-1',
-    worktreeRoot: '/repo'
-  } as never)
 }
 
-describe('rich markdown editor Shift+modifier click on external links', () => {
-  // Why: intentionally NOT the preview's behavior — this path hands the link to the
-  // client OS, so it must keep forcing the system browser even when inverting is on.
-  it('forces the system browser rather than following the invert setting', () => {
-    expect(clickExternalLinkWithShift({ kind: 'local' })).toBe(true)
-    expect(openHttpLinkMock).toHaveBeenCalledWith('https://example.com/docs', {
-      forceSystemBrowser: true,
-      sourceOwner: { kind: 'local' }
+function routeClick({
+  activateMarkdownLink = vi.fn(),
+  event = baseEvent,
+  followLinksOnClick = false,
+  href,
+  isMac = false,
+  node = null,
+  onOpenDocLink = vi.fn(),
+  sourceOwner = { kind: 'ssh', connectionId: 'ssh-1' }
+}: {
+  activateMarkdownLink?: ActivateMarkdownLink
+  event?: MouseEvent
+  followLinksOnClick?: boolean
+  href?: string
+  isMac?: boolean
+  node?: ClickNode | null
+  onOpenDocLink?: (target: string) => void
+  sourceOwner?: HttpLinkSourceOwner
+}): boolean {
+  return handleRichMarkdownEditorClick({
+    activateMarkdownLink,
+    editorRef: ref({} as Editor),
+    event,
+    filePath: '/repo/docs/start.md',
+    followLinksOnClickRef: ref(followLinksOnClick),
+    htmlSuperscriptLinkContext: createRichMarkdownHtmlSuperscriptLinkContext({
+      sourceFilePath: '/repo/docs/start.md',
+      worktreeId: 'worktree-1',
+      worktreeRoot: '/repo',
+      sourceOwner
+    }),
+    isMac,
+    markdownCommentsRef: ref([]),
+    markdownSourceLineOffsetRef: ref(0),
+    onOpenDocLinkRef: ref(onOpenDocLink),
+    pos: 1,
+    rootRef: ref(null),
+    runtimeEnvironmentId: null,
+    scrollRichMarkdownReviewNoteCardIntoView: vi.fn(),
+    settings: { activeRuntimeEnvironmentId: null },
+    view: editorView(node, href),
+    worktreeId: 'worktree-1',
+    worktreeRoot: '/repo'
+  })
+}
+
+describe('handleRichMarkdownEditorClick Follow links routing', () => {
+  beforeEach(() => {
+    getCommentAtPosition.mockReset()
+    getCommentAtPosition.mockReturnValue(null)
+    openHttpLink.mockReset()
+  })
+
+  it('keeps a plain standard-link click editable when Follow links is off', () => {
+    const activateMarkdownLink = vi.fn()
+
+    expect(routeClick({ activateMarkdownLink, href: './next.md' })).toBe(false)
+    expect(activateMarkdownLink).not.toHaveBeenCalled()
+  })
+
+  it('activates a plain standard link with its SSH owner when Follow links is on', () => {
+    const activateMarkdownLink = vi.fn()
+
+    expect(
+      routeClick({
+        activateMarkdownLink,
+        followLinksOnClick: true,
+        href: './next.md'
+      })
+    ).toBe(true)
+    expect(activateMarkdownLink).toHaveBeenCalledWith('./next.md', {
+      sourceFilePath: '/repo/docs/start.md',
+      worktreeId: 'worktree-1',
+      worktreeRoot: '/repo',
+      runtimeEnvironmentId: null,
+      sourceOwner: { kind: 'ssh', connectionId: 'ssh-1' }
     })
   })
 
-  // Why: AGENTS.md — Shift+Ctrl is the chord off macOS, and modKey reads a
-  // different event field there.
-  it('uses the Ctrl chord off macOS', () => {
-    expect(clickExternalLinkWithShift({ kind: 'local' }, false)).toBe(true)
-    expect(openHttpLinkMock).toHaveBeenCalledWith('https://example.com/docs', {
+  it('uses the clicked anchor when the document position is at a mark boundary', () => {
+    const activateMarkdownLink = vi.fn()
+    const anchor = document.createElement('a')
+    anchor.setAttribute('href', './next.md')
+
+    expect(
+      routeClick({
+        activateMarkdownLink,
+        event: { ...baseEvent, target: anchor } as MouseEvent,
+        followLinksOnClick: true
+      })
+    ).toBe(true)
+    expect(activateMarkdownLink).toHaveBeenCalledWith('./next.md', expect.any(Object))
+  })
+
+  it.each([
+    { name: 'Cmd on macOS', isMac: true, event: { ...baseEvent, metaKey: true } as MouseEvent },
+    {
+      name: 'Ctrl on Linux and Windows',
+      isMac: false,
+      event: { ...baseEvent, ctrlKey: true } as MouseEvent
+    }
+  ])('activates a standard link with $name', ({ event, isMac }) => {
+    const activateMarkdownLink = vi.fn()
+
+    expect(routeClick({ activateMarkdownLink, event, href: './next.md', isMac })).toBe(true)
+    expect(activateMarkdownLink).toHaveBeenCalledWith('./next.md', expect.any(Object))
+  })
+
+  it('keeps modifier activation for images and document links', () => {
+    const activateMarkdownLink = vi.fn()
+    const onOpenDocLink = vi.fn()
+    const event = { ...baseEvent, ctrlKey: true } as MouseEvent
+
+    expect(
+      routeClick({
+        activateMarkdownLink,
+        event,
+        node: { type: { name: 'image' }, attrs: { src: './image.png' } }
+      })
+    ).toBe(true)
+    expect(activateMarkdownLink).toHaveBeenCalledWith('./image.png', expect.any(Object))
+
+    expect(
+      routeClick({
+        event,
+        node: { type: { name: 'markdownDocLink' }, attrs: { target: 'wiki-note' } },
+        onOpenDocLink
+      })
+    ).toBe(true)
+    expect(onOpenDocLink).toHaveBeenCalledWith('wiki-note')
+  })
+
+  it.each([
+    {
+      event: { ...baseEvent, metaKey: true, shiftKey: true } as MouseEvent,
+      isMac: true,
+      name: 'Cmd+Shift on macOS',
+      sourceOwner: { kind: 'local' } as HttpLinkSourceOwner
+    },
+    {
+      event: { ...baseEvent, ctrlKey: true, shiftKey: true } as MouseEvent,
+      isMac: false,
+      name: 'Ctrl+Shift on Linux and Windows',
+      sourceOwner: { kind: 'ssh', connectionId: 'ssh-1' } as HttpLinkSourceOwner
+    }
+  ])('keeps $name as the client-OS escape for standard links', ({ event, isMac, sourceOwner }) => {
+    expect(
+      routeClick({
+        event,
+        href: 'https://example.com',
+        isMac,
+        sourceOwner
+      })
+    ).toBe(true)
+    expect(openHttpLink).toHaveBeenCalledWith('https://example.com/', {
       forceSystemBrowser: true,
-      sourceOwner: { kind: 'local' }
+      sourceOwner
     })
   })
 
-  it('forwards a non-local source owner untouched', () => {
-    const sourceOwner = { kind: 'ssh', connectionId: 'conn-1' } as HttpLinkSourceOwner
+  it.each([
+    { name: 'image', attrs: { src: './image.png' } },
+    { name: 'markdownDocLink', attrs: { target: 'wiki-note' } },
+    {
+      name: 'richMarkdownHtmlSuperscriptLink',
+      attrs: { href: 'https://example.com/citation' }
+    }
+  ])('keeps plain $name clicks modifier-only', ({ name, attrs }) => {
+    const activateMarkdownLink = vi.fn()
+    const onOpenDocLink = vi.fn()
 
-    expect(clickExternalLinkWithShift(sourceOwner)).toBe(true)
-    expect(openHttpLinkMock).toHaveBeenCalledWith(
-      'https://example.com/docs',
-      expect.objectContaining({ forceSystemBrowser: true, sourceOwner })
-    )
+    expect(
+      routeClick({
+        activateMarkdownLink,
+        followLinksOnClick: true,
+        node: { type: { name }, attrs },
+        onOpenDocLink
+      })
+    ).toBe(false)
+    expect(activateMarkdownLink).not.toHaveBeenCalled()
+    expect(onOpenDocLink).not.toHaveBeenCalled()
+  })
+
+  it('preserves review-note selection for a plain non-link click', () => {
+    const scrollIntoView = vi.fn()
+    getCommentAtPosition.mockReturnValue({ id: 'comment-1' })
+
+    const handled = handleRichMarkdownEditorClick({
+      activateMarkdownLink: vi.fn(),
+      editorRef: ref({} as Editor),
+      event: baseEvent,
+      filePath: '/repo/docs/start.md',
+      followLinksOnClickRef: ref(true),
+      htmlSuperscriptLinkContext: createRichMarkdownHtmlSuperscriptLinkContext({
+        sourceFilePath: '/repo/docs/start.md',
+        worktreeId: 'worktree-1',
+        worktreeRoot: '/repo',
+        sourceOwner: { kind: 'local' }
+      }),
+      isMac: false,
+      markdownCommentsRef: ref([]),
+      markdownSourceLineOffsetRef: ref(0),
+      onOpenDocLinkRef: ref(undefined),
+      pos: 1,
+      rootRef: ref(null),
+      runtimeEnvironmentId: null,
+      scrollRichMarkdownReviewNoteCardIntoView: scrollIntoView,
+      settings: { activeRuntimeEnvironmentId: null },
+      view: editorView(null),
+      worktreeId: 'worktree-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(handled).toBe(false)
+    expect(scrollIntoView).toHaveBeenCalledWith('comment-1')
   })
 })

--- a/src/renderer/src/components/editor/rich-markdown-editor-click-routing.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-click-routing.ts
@@ -17,6 +17,10 @@ import {
   classifyHtmlSuperscriptLinkAction,
   type RichMarkdownHtmlSuperscriptLinkContext
 } from './rich-markdown-html-superscript-link-context'
+import {
+  getRichMarkdownLinkClickIntent,
+  isRichMarkdownLinkOpenModifier
+} from './rich-markdown-link-click-intent'
 
 export type ActivateMarkdownLink = (
   href: string,
@@ -36,6 +40,7 @@ type RichMarkdownEditorClickRoutingOptions = {
   editorRef: MutableRefObject<Editor | null>
   event: MouseEvent
   filePath: string
+  followLinksOnClickRef: MutableRefObject<boolean>
   isMac: boolean
   htmlSuperscriptLinkContext: RichMarkdownHtmlSuperscriptLinkContext
   markdownCommentsRef: MutableRefObject<DiffComment[]>
@@ -56,6 +61,7 @@ export function handleRichMarkdownEditorClick({
   editorRef,
   event,
   filePath,
+  followLinksOnClickRef,
   isMac,
   htmlSuperscriptLinkContext,
   markdownCommentsRef,
@@ -73,24 +79,16 @@ export function handleRichMarkdownEditorClick({
   const editor = editorRef.current
   const sourceSnapshot = htmlSuperscriptLinkContext.getSnapshot()
   const sourceOwner = sourceSnapshot.sourceOwner
-  const modKey = isMac ? event.metaKey : event.ctrlKey
+  const modifierHeld = isRichMarkdownLinkOpenModifier(event, isMac)
   if (!editor) {
     return false
   }
-  if (!modKey) {
-    const selectedComment = getRichMarkdownCommentAtPos(
-      editor,
-      markdownCommentsRef.current,
-      markdownSourceLineOffsetRef.current,
-      pos
-    )
-    if (selectedComment) {
-      scrollRichMarkdownReviewNoteCardIntoView(selectedComment.id)
-    }
-    return false
-  }
+  const activeEditor = editor
   const clickedNode = view.state.doc.nodeAt(pos)
   if (clickedNode?.type.name === 'image') {
+    if (!modifierHeld) {
+      return handleSelectionClick()
+    }
     return activateMarkdownImageClick({
       activateMarkdownLink,
       filePath,
@@ -102,45 +100,74 @@ export function handleRichMarkdownEditorClick({
     })
   }
   if (clickedNode?.type.name === 'markdownDocLink') {
+    if (!modifierHeld) {
+      return handleSelectionClick()
+    }
     onOpenDocLinkRef.current?.(clickedNode.attrs.target as string)
     return true
   }
-  const href =
-    clickedNode?.type.name === 'richMarkdownHtmlSuperscriptLink'
-      ? String(clickedNode.attrs.href ?? '')
-      : getClickedLinkHref(view, pos)
-  if (
-    clickedNode?.type.name === 'richMarkdownHtmlSuperscriptLink' &&
-    !classifyHtmlSuperscriptLinkAction(href, sourceSnapshot)
-  ) {
-    return true
+  if (clickedNode?.type.name === 'richMarkdownHtmlSuperscriptLink') {
+    if (!modifierHeld) {
+      return handleSelectionClick()
+    }
+    const href = String(clickedNode.attrs.href ?? '')
+    if (!classifyHtmlSuperscriptLinkAction(href, sourceSnapshot)) {
+      return true
+    }
+    const intent = getRichMarkdownLinkClickIntent(event, isMac, false)
+    return intent === 'select' ? handleSelectionClick() : activateStandardLink(href, intent)
   }
+  const href = getClickedLinkHref(view, pos, event)
   if (!href) {
+    return handleSelectionClick()
+  }
+  const intent = getRichMarkdownLinkClickIntent(event, isMac, followLinksOnClickRef.current)
+  if (intent === 'select') {
+    return handleSelectionClick()
+  }
+
+  return activateStandardLink(href, intent)
+
+  function handleSelectionClick(): false {
+    if (!modifierHeld) {
+      const selectedComment = getRichMarkdownCommentAtPos(
+        activeEditor,
+        markdownCommentsRef.current,
+        markdownSourceLineOffsetRef.current,
+        pos
+      )
+      if (selectedComment) {
+        scrollRichMarkdownReviewNoteCardIntoView(selectedComment.id)
+      }
+    }
     return false
   }
-  if (href.startsWith('#')) {
-    scrollToAnchorInEditor(rootRef.current, href.slice(1))
-    return true
-  }
-  if (event.shiftKey) {
-    openMarkdownLinkInClientOs({
-      href,
-      filePath,
+
+  function activateStandardLink(href: string, intent: 'activate' | 'open-in-client-os'): true {
+    if (href.startsWith('#')) {
+      scrollToAnchorInEditor(rootRef.current, href.slice(1))
+      return true
+    }
+    if (intent === 'open-in-client-os') {
+      openMarkdownLinkInClientOs({
+        href,
+        filePath,
+        runtimeEnvironmentId,
+        sourceOwner,
+        settings,
+        worktreeRoot
+      })
+      return true
+    }
+    void activateMarkdownLink(href, {
+      sourceFilePath: filePath,
+      worktreeId,
+      worktreeRoot,
       runtimeEnvironmentId,
-      sourceOwner,
-      settings,
-      worktreeRoot
+      sourceOwner
     })
     return true
   }
-  void activateMarkdownLink(href, {
-    sourceFilePath: filePath,
-    worktreeId,
-    worktreeRoot,
-    runtimeEnvironmentId,
-    sourceOwner
-  })
-  return true
 }
 
 function activateMarkdownImageClick({
@@ -173,7 +200,13 @@ function activateMarkdownImageClick({
   return true
 }
 
-function getClickedLinkHref(view: EditorView, pos: number): string {
+function getClickedLinkHref(view: EditorView, pos: number, event: MouseEvent): string {
+  if (event.target instanceof Element) {
+    const href = event.target.closest('a[href]')?.getAttribute('href') ?? ''
+    if (href) {
+      return href
+    }
+  }
   const linkMark = view.state.doc
     .resolve(pos)
     .marks()

--- a/src/renderer/src/components/editor/rich-markdown-editor-config.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-config.test.ts
@@ -45,6 +45,7 @@ function createConfigParams(overrides: Partial<EditorConfigParams> = {}): Editor
     richMarkdownSpellcheckEnabled: true,
     settings: { activeRuntimeEnvironmentId: null },
     activateMarkdownLink: vi.fn(),
+    followLinksOnClickRef: ref(false),
     rootRef: ref<HTMLDivElement | null>(null),
     editorRef: ref<Editor | null>(null),
     lastCommittedMarkdownRef: ref(''),

--- a/src/renderer/src/components/editor/rich-markdown-editor-config.ts
+++ b/src/renderer/src/components/editor/rich-markdown-editor-config.ts
@@ -50,6 +50,7 @@ export type EditorConfigParams = {
   richMarkdownSpellcheckEnabled: boolean
   settings: RichMarkdownRuntimeSettings
   activateMarkdownLink: ActivateMarkdownLink
+  followLinksOnClickRef: MutableRefObject<boolean>
   rootRef: MutableRefObject<HTMLDivElement | null>
   editorRef: MutableRefObject<Editor | null>
   lastCommittedMarkdownRef: MutableRefObject<string>
@@ -104,6 +105,7 @@ export function createRichMarkdownEditorConfig(params: EditorConfigParams): UseE
     richMarkdownSpellcheckEnabled,
     settings,
     activateMarkdownLink,
+    followLinksOnClickRef,
     rootRef,
     editorRef,
     lastCommittedMarkdownRef,
@@ -182,6 +184,7 @@ export function createRichMarkdownEditorConfig(params: EditorConfigParams): UseE
           editorRef,
           event,
           filePath,
+          followLinksOnClickRef,
           htmlSuperscriptLinkContext,
           isMac,
           markdownCommentsRef,

--- a/src/renderer/src/components/editor/rich-markdown-follow-links-state.test.tsx
+++ b/src/renderer/src/components/editor/rich-markdown-follow-links-state.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment happy-dom
+
+import { act, useLayoutEffect } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  RichMarkdownFollowLinksProvider,
+  useCommittedRichMarkdownFollowLinksRef,
+  useRichMarkdownFollowLinks
+} from './rich-markdown-follow-links-state'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function FollowLinksRefProbe({
+  onCommitted
+}: {
+  onCommitted: (active: boolean) => void
+}): React.JSX.Element {
+  const followLinks = useRichMarkdownFollowLinks()
+  const activeRef = useCommittedRichMarkdownFollowLinksRef(followLinks?.active ?? false)
+
+  useLayoutEffect(() => {
+    onCommitted(activeRef.current)
+  }, [activeRef, followLinks?.active, onCommitted])
+
+  return <button onClick={followLinks?.onToggle}>Toggle</button>
+}
+
+describe('useCommittedRichMarkdownFollowLinksRef', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it('exposes the provider state after each committed toggle', () => {
+    const onCommitted = vi.fn()
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    act(() => {
+      root.render(
+        <RichMarkdownFollowLinksProvider>
+          <FollowLinksRefProbe onCommitted={onCommitted} />
+        </RichMarkdownFollowLinksProvider>
+      )
+    })
+    expect(onCommitted).toHaveBeenLastCalledWith(false)
+
+    act(() => container.querySelector('button')?.click())
+    expect(onCommitted).toHaveBeenLastCalledWith(true)
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-follow-links-state.tsx
+++ b/src/renderer/src/components/editor/rich-markdown-follow-links-state.tsx
@@ -1,0 +1,49 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type ReactNode
+} from 'react'
+
+export type RichMarkdownFollowLinksState = {
+  active: boolean
+  onToggle: () => void
+}
+
+const RichMarkdownFollowLinksContext = createContext<RichMarkdownFollowLinksState | null>(null)
+
+export function RichMarkdownFollowLinksProvider({
+  children
+}: {
+  children: ReactNode
+}): React.JSX.Element {
+  const [active, setActive] = useState(false)
+  const onToggle = useCallback(() => setActive((current) => !current), [])
+  const value = useMemo(() => ({ active, onToggle }), [active, onToggle])
+
+  return (
+    <RichMarkdownFollowLinksContext.Provider value={value}>
+      {children}
+    </RichMarkdownFollowLinksContext.Provider>
+  )
+}
+
+export function useRichMarkdownFollowLinks(): RichMarkdownFollowLinksState | null {
+  return useContext(RichMarkdownFollowLinksContext)
+}
+
+export function useCommittedRichMarkdownFollowLinksRef(active: boolean): MutableRefObject<boolean> {
+  const activeRef = useRef(active)
+
+  useLayoutEffect(() => {
+    // Why: ProseMirror handlers must not observe state from a discarded React render.
+    activeRef.current = active
+  }, [active])
+
+  return activeRef
+}

--- a/src/renderer/src/components/editor/rich-markdown-link-click-intent.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-link-click-intent.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { getRichMarkdownLinkClickIntent } from './rich-markdown-link-click-intent'
+
+type ClickModifiers = {
+  button: number
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+}
+
+const plainClick: ClickModifiers = {
+  button: 0,
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false
+}
+
+describe('getRichMarkdownLinkClickIntent', () => {
+  it('keeps plain clicks in selection mode by default', () => {
+    expect(getRichMarkdownLinkClickIntent(plainClick, false, false)).toBe('select')
+  })
+
+  it('activates plain clicks while Follow links is enabled', () => {
+    expect(getRichMarkdownLinkClickIntent(plainClick, false, true)).toBe('activate')
+  })
+
+  it('uses Cmd on macOS and Ctrl on Linux and Windows', () => {
+    expect(getRichMarkdownLinkClickIntent({ ...plainClick, metaKey: true }, true, false)).toBe(
+      'activate'
+    )
+    expect(getRichMarkdownLinkClickIntent({ ...plainClick, ctrlKey: true }, true, false)).toBe(
+      'select'
+    )
+    expect(getRichMarkdownLinkClickIntent({ ...plainClick, ctrlKey: true }, false, false)).toBe(
+      'activate'
+    )
+    expect(getRichMarkdownLinkClickIntent({ ...plainClick, metaKey: true }, false, false)).toBe(
+      'select'
+    )
+  })
+
+  it('uses the client-OS escape only with Shift and the platform modifier', () => {
+    expect(
+      getRichMarkdownLinkClickIntent({ ...plainClick, metaKey: true, shiftKey: true }, true, false)
+    ).toBe('open-in-client-os')
+    expect(
+      getRichMarkdownLinkClickIntent({ ...plainClick, ctrlKey: true, shiftKey: true }, false, false)
+    ).toBe('open-in-client-os')
+    expect(getRichMarkdownLinkClickIntent({ ...plainClick, shiftKey: true }, false, false)).toBe(
+      'select'
+    )
+  })
+
+  it('treats Shift-click as normal activation when Follow links is enabled', () => {
+    expect(getRichMarkdownLinkClickIntent({ ...plainClick, shiftKey: true }, false, true)).toBe(
+      'activate'
+    )
+  })
+
+  it('does not turn a non-primary plain click into Follow links navigation', () => {
+    expect(getRichMarkdownLinkClickIntent({ ...plainClick, button: 1 }, false, true)).toBe('select')
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-link-click-intent.ts
+++ b/src/renderer/src/components/editor/rich-markdown-link-click-intent.ts
@@ -1,0 +1,25 @@
+type RichMarkdownLinkClickModifiers = Pick<
+  MouseEvent,
+  'button' | 'ctrlKey' | 'metaKey' | 'shiftKey'
+>
+
+export type RichMarkdownLinkClickIntent = 'select' | 'activate' | 'open-in-client-os'
+
+export function isRichMarkdownLinkOpenModifier(
+  event: Pick<MouseEvent, 'ctrlKey' | 'metaKey'>,
+  isMac: boolean
+): boolean {
+  return isMac ? event.metaKey : event.ctrlKey
+}
+
+export function getRichMarkdownLinkClickIntent(
+  event: RichMarkdownLinkClickModifiers,
+  isMac: boolean,
+  followLinksOnClick: boolean
+): RichMarkdownLinkClickIntent {
+  const modifierHeld = isRichMarkdownLinkOpenModifier(event, isMac)
+  if (modifierHeld && event.shiftKey) {
+    return 'open-in-client-os'
+  }
+  return modifierHeld || (followLinksOnClick && event.button === 0) ? 'activate' : 'select'
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13268,6 +13268,9 @@
           "6bbf827ef5": "Heading 5",
           "d1bbf9a835": "Collapsible section"
         },
+        "RichMarkdownFollowLinksHeaderButton": {
+          "followLinksOnClick": "Follow links on click"
+        },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "Save",
           "949711deb4": "Cancel",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12992,6 +12992,9 @@
           "deleteRow": "Eliminar fila",
           "deleteColumn": "Eliminar columna"
         },
+        "RichMarkdownFollowLinksHeaderButton": {
+          "followLinksOnClick": "Follow links on click"
+        },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "Guardar",
           "949711deb4": "Cancelar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12992,6 +12992,9 @@
           "deleteRow": "行を削除",
           "deleteColumn": "列を削除"
         },
+        "RichMarkdownFollowLinksHeaderButton": {
+          "followLinksOnClick": "Follow links on click"
+        },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "保存",
           "949711deb4": "キャンセル",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12992,6 +12992,9 @@
           "deleteRow": "행 삭제",
           "deleteColumn": "열 삭제"
         },
+        "RichMarkdownFollowLinksHeaderButton": {
+          "followLinksOnClick": "Follow links on click"
+        },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "저장",
           "949711deb4": "취소",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13012,6 +13012,9 @@
           "deleteRow": "删除行",
           "deleteColumn": "删除列"
         },
+        "RichMarkdownFollowLinksHeaderButton": {
+          "followLinksOnClick": "Follow links on click"
+        },
         "UntitledFileRenameDialog": {
           "a7dd27b0bc": "保存",
           "949711deb4": "取消",

--- a/src/renderer/src/store/slices/editor.test.ts
+++ b/src/renderer/src/store/slices/editor.test.ts
@@ -4623,6 +4623,95 @@ describe('createEditorSlice activateMarkdownLink', () => {
     expect(openUrlMock).not.toHaveBeenCalled()
   })
 
+  it('reuses one preview while following an in-worktree markdown chain', async () => {
+    const store = createEditorTabsStore()
+    pathExistsMock.mockResolvedValue(true)
+    store.getState().openFile({
+      filePath: '/repo/docs/start.md',
+      relativePath: 'docs/start.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      mode: 'edit'
+    })
+
+    await store.getState().activateMarkdownLink('./middle.md', {
+      sourceFilePath: '/repo/docs/start.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+    await store.getState().activateMarkdownLink('./finish.md', {
+      sourceFilePath: '/repo/docs/middle.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(store.getState().openFiles).toEqual([
+      expect.objectContaining({
+        filePath: '/repo/docs/start.md',
+        isPreview: undefined
+      }),
+      expect.objectContaining({
+        filePath: '/repo/docs/finish.md',
+        isPreview: true
+      })
+    ])
+    expect(
+      store.getState().unifiedTabsByWorktree['wt-1'].filter((tab) => tab.contentType === 'editor')
+    ).toHaveLength(2)
+  })
+
+  it('keeps an async markdown-link open in the group where navigation started', async () => {
+    const store = createEditorTabsStore()
+    store.getState().openFile({
+      filePath: '/repo/docs/start.md',
+      relativePath: 'docs/start.md',
+      worktreeId: 'wt-1',
+      language: 'markdown',
+      mode: 'edit'
+    })
+    const sourceTab = store
+      .getState()
+      .unifiedTabsByWorktree['wt-1'].find((tab) => tab.contentType === 'editor')
+    if (!sourceTab) {
+      throw new Error('expected source editor tab')
+    }
+    const secondGroupId = store.getState().createEmptySplitGroup('wt-1', sourceTab.groupId, 'right')
+    if (!secondGroupId) {
+      throw new Error('expected second split group')
+    }
+    store.setState({
+      activeGroupIdByWorktree: { 'wt-1': sourceTab.groupId }
+    })
+
+    let resolveStat!: (value: { size: number; isDirectory: boolean; mtime: number }) => void
+    fsStatMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStat = resolve
+        })
+    )
+    const opening = store.getState().activateMarkdownLink('./finish.md', {
+      sourceFilePath: '/repo/docs/start.md',
+      worktreeId: 'wt-1',
+      worktreeRoot: '/repo'
+    })
+
+    expect(fsStatMock).toHaveBeenCalledOnce()
+    store.setState({
+      activeGroupIdByWorktree: { 'wt-1': secondGroupId }
+    })
+    resolveStat({ size: 1, isDirectory: false, mtime: 1 })
+    await opening
+
+    const finishFile = store
+      .getState()
+      .openFiles.find((file) => file.filePath === '/repo/docs/finish.md')
+    const finishTab = store
+      .getState()
+      .unifiedTabsByWorktree['wt-1'].find((tab) => tab.entityId === finishFile?.id)
+    expect(finishTab?.groupId).toBe(sourceTab.groupId)
+  })
+
   it('opens remote-owned markdown links through the source file runtime owner', async () => {
     const store = createEditorStore()
     pathExistsMock.mockResolvedValue(true)

--- a/src/renderer/src/store/slices/editor.ts
+++ b/src/renderer/src/store/slices/editor.ts
@@ -4791,6 +4791,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   activateMarkdownLink: async (rawHref, ctx) => {
     const initialState = get()
+    const targetGroupId = initialState.activeGroupIdByWorktree?.[ctx.worktreeId]
     let inferredRuntimeEnvironmentId: string | null | undefined
     if (!ctx.sourceOwner && ctx.runtimeEnvironmentId === undefined) {
       const inferredRuntimeOwners = new Set(
@@ -4893,7 +4894,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
         },
         {
           preview: true,
-          targetGroupId: get().activeGroupIdByWorktree?.[ctx.worktreeId],
+          targetGroupId,
           recordReplacedPreview: true
         }
       )
@@ -4937,7 +4938,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       },
       {
         preview: true,
-        targetGroupId: get().activeGroupIdByWorktree?.[ctx.worktreeId],
+        targetGroupId,
         recordReplacedPreview: true
       }
     )

--- a/tests/e2e/rich-markdown-follow-links.spec.ts
+++ b/tests/e2e/rich-markdown-follow-links.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Reliability contract:
+ * - Invariant: Follow links turns plain Markdown-link clicks into bounded preview navigation.
+ * - Failure source: editor remounts can lose pane-local state or create a permanent tab per hop.
+ * - Oracle: the pressed toolbar state survives A -> B -> C while one preview remains in the group.
+ * - Layer: Electron is required because ProseMirror click routing and unified tabs meet here.
+ * - Wait: visible headings, link bubble, pressed toggle, and tab-strip state.
+ * - Artifacts: Playwright retains a trace and screenshot on failure.
+ * - Maturity: experimental pending CI soak history.
+ */
+
+import path from 'node:path'
+import type { Locator } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  cleanupMarkdownFixture,
+  createMarkdownFixture,
+  getActiveWorktreeContext,
+  openMarkdownFixture,
+  waitForRichMarkdownEditor
+} from './helpers/markdown-ordered-list-exit'
+
+async function clickVisibleInlineTarget(locator: Locator): Promise<void> {
+  await expect(locator).toBeVisible()
+  // Why: ProseMirror inline geometry never settles for Playwright actionability headlessly.
+  await locator.click({ force: true })
+}
+
+test.describe('Rich Markdown Follow links', () => {
+  test('follows a document chain through one replaceable preview', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+
+    const context = await getActiveWorktreeContext(orcaPage)
+    const fixturePaths: string[] = []
+
+    try {
+      const thirdPath = await createMarkdownFixture(
+        context,
+        'follow-links-third',
+        testInfo.workerIndex,
+        '# Follow links third\n'
+      )
+      fixturePaths.push(thirdPath)
+      const secondPath = await createMarkdownFixture(
+        context,
+        'follow-links-second',
+        testInfo.workerIndex,
+        `# Follow links second\n\n[Continue to third](./${path.basename(thirdPath)})\n`
+      )
+      fixturePaths.push(secondPath)
+      const firstPath = await createMarkdownFixture(
+        context,
+        'follow-links-first',
+        testInfo.workerIndex,
+        `# Follow links first\n\n[Continue to second](./${path.basename(secondPath)})\n`
+      )
+      fixturePaths.push(firstPath)
+
+      await openMarkdownFixture(orcaPage, context, firstPath)
+      await waitForRichMarkdownEditor(orcaPage)
+
+      const firstLink = orcaPage.getByRole('link', { name: 'Continue to second' })
+      await expect(
+        orcaPage.getByRole('heading', { name: 'Follow links first', level: 1 })
+      ).toBeVisible()
+
+      const editorHeader = orcaPage.locator('.editor-header')
+      const followLinksButton = editorHeader.getByRole('button', {
+        name: 'Follow links on click'
+      })
+      await expect(
+        orcaPage.locator('.rich-markdown-editor-toolbar').getByRole('button', {
+          name: 'Follow links on click'
+        })
+      ).toHaveCount(0)
+      await expect(followLinksButton).toHaveAttribute('aria-pressed', 'false')
+      await followLinksButton.click({ force: true })
+      await expect(followLinksButton).toHaveAttribute('aria-pressed', 'true')
+      await expect(orcaPage.locator('.rich-markdown-editor-shell')).toHaveAttribute(
+        'data-follow-links',
+        'true'
+      )
+
+      await clickVisibleInlineTarget(firstLink)
+      await expect(
+        orcaPage.getByRole('heading', { name: 'Follow links second', level: 1 })
+      ).toBeVisible()
+      await expect(followLinksButton).toHaveAttribute('aria-pressed', 'true')
+
+      await clickVisibleInlineTarget(orcaPage.getByRole('link', { name: 'Continue to third' }))
+      await expect(
+        orcaPage.getByRole('heading', { name: 'Follow links third', level: 1 })
+      ).toBeVisible()
+      await expect(followLinksButton).toHaveAttribute('aria-pressed', 'true')
+
+      const tabStrip = orcaPage.locator('[data-tab-group-strip-id]')
+      await expect(
+        tabStrip.locator('[data-tab-id]').filter({ hasText: path.basename(firstPath) })
+      ).toBeVisible()
+      await expect(
+        tabStrip.locator('[data-tab-id]').filter({ hasText: path.basename(thirdPath) })
+      ).toBeVisible()
+      await expect(
+        tabStrip.locator('[data-tab-id]').filter({ hasText: path.basename(secondPath) })
+      ).toHaveCount(0)
+    } finally {
+      await Promise.all(fixturePaths.map((filePath) => cleanupMarkdownFixture(filePath)))
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- add a pane-scoped **Follow links on click** control beside Markdown view/configuration controls
- let plain clicks navigate in the originating pane while reusing one replaceable preview
- preserve normal link editing while off, modifier activation, and specialized image/wiki/citation behavior
- synchronize the long-lived ProseMirror handler only from committed React state

## Screenshots

No screenshot is attached to avoid publishing unrelated live workspace content. The control placement and A -> B -> C same-pane behavior were manually accepted on Linux in the equivalent feature build.

## Testing

Exact published head: `7df544687cb81869016fe6c53300b058438003cb` on base `f71373953baa1d384b75bbdf4845fda17a847da5`.

- seven focused unit suites passed 228/228 on the equivalent feature stack
- focused Electron E2E passed the bounded A -> B -> C preview flow
- combined stable integration passed lint, all three TypeScript projects, and 3,563 focused desktop tests
- CodeRabbit's duplicate-`resolveStat` report was verified stale: the current head has one declaration and the TypeScript gate passes
- current installed/package acceptance is `e13fa51f38102e1c3bf972e206e68fd323927406`

## AI Review Report

The review checked committed-state synchronization, originating-pane capture across asynchronous resolution, macOS/Linux/Windows modifier policy, SSH/runtime path ownership, folder workspaces, bounded tab reuse, and design-system consistency. No background work, polling, agent behavior, or git-provider behavior is added.

## Security Audit

Activation stays on Orca's existing guarded link-routing and runtime-owned stat/open paths. Unsupported targets keep their established behavior. No dependency, command execution, authentication, secret handling, IPC, or permission surface is introduced.

## Notes

- Related to #3040; backlinks and workspace indexing remain out of scope.
- With the mode off, existing link editing remains unchanged.
- Manual acceptance was Linux; modifier behavior on macOS/Windows is unit-covered.
- X handle: not provided.

## ELI5

Turn the mode on and ordinary Markdown links browse within one pane instead of piling up preview tabs.
