### PR TITLE
test(git): cover the sparse-checkout false-positive class removed by #10537

### DIFF
--- a/src/main/git/worktree-sparse-checkout.test.ts
+++ b/src/main/git/worktree-sparse-checkout.test.ts
@@ -174,6 +174,17 @@ describe('parseCoreSparseCheckoutFlag', () => {
     expect(parseCoreSparseCheckoutFlag('[core "sub"] sparseCheckout = true\n')).toBeUndefined()
   })
 
+  it('leaves [core] when a subsection header carries its own same-line assignment', () => {
+    // A `[section "sub"]key = value` line matched neither branch of the old anchored regex, so the
+    // parser never left `[core]` and credited the next indented line to it — a bogus sparse badge.
+    // Git reports core.sparseCheckout as unset here.
+    expect(
+      parseCoreSparseCheckoutFlag(
+        '[core]\n[core "sub"]worktreeConfig = x\n\tsparseCheckout = true\n'
+      )
+    ).toBeUndefined()
+  })
+
   it('honors the last assignment across mixed same-line and indented forms', () => {
     expect(
       parseCoreSparseCheckoutFlag(


### PR DESCRIPTION
## Summary

Recovers a regression test written during the review of #10537 that was lost to a GitHub PR/ref desync: the branch ref advanced, but the PR object's `head.sha` stayed stale and no `synchronize` event fired, so the squash merge used the older sha.

The fix itself shipped in #10537. Only this test was missed. No source changes here.

## What it covers

A `[section "sub"]key = value` line matched **neither** branch of the old anchored `^\[...\]$` regex, so the parser never left `[core]` and credited the next indented line to it — reporting sparse for a worktree git says is not.

```
[core]
[core "sub"]worktreeConfig = x
	sparseCheckout = true
```

Verified against a real git binary: `git config --file <f> --get --type=bool core.sparseCheckout` reports **unset**. The pre-#10537 parser returned `true` (bogus sparse badge); the shipped parser returns `undefined`.

This pins the *opposite* failure mode from the one #10537 set out to fix — loosening the header regex could have introduced false positives, and this proves it did not.

## Verification

- `worktree-sparse-checkout.test.ts` — 21/21 pass on merged `main`
- Vector confirmed against real git 2.x, not just reasoned from the spec