### PR TITLE
fix(browser): keep live agent view when opening in-app browser

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.test.tsx
@@ -71,6 +71,8 @@ describe('BrowserPaneOverlayLayer', () => {
     expect(markup).toContain('data-browser-pane-id="browser-a"')
     expect(markup).toContain('data-browser-pane-id="browser-b"')
     expect(markup).toContain('data-browser-pane-active="false"')
+    // Why (#10546): off-screen parking keeps CDP paint without covering the agent surface.
+    expect(markup).toContain('left:-10000px')
   })
 
   it('parks browser panes when their worktree is hidden', () => {

--- a/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPaneOverlayLayer.tsx
@@ -56,31 +56,60 @@ const BrowserOverlaySlot = memo(function BrowserOverlaySlot({
   const shouldMountPane = isWorktreeActive || automationVisible || mobileDriven
   // Why: CSS anchor positioning pins the overlay to its owning group's body — a tab move only swaps positionAnchor, no measurement/state.
   // Orphan branch (no anchorName) stays display:none until the tab is reassigned or destroyed.
-  const style: React.CSSProperties = useMemo(
-    () =>
-      anchorName
-        ? {
-            position: 'absolute',
-            positionAnchor: anchorName,
-            top: `anchor(${anchorName} top)`,
-            left: `anchor(${anchorName} left)`,
-            width: `anchor-size(${anchorName} width)`,
-            height: `anchor-size(${anchorName} height)`,
-            display: isPaintable ? 'flex' : 'none',
-            pointerEvents: isActive ? 'auto' : 'none',
-            opacity: isActive ? 1 : 0
-          }
-        : {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: 0,
-            height: 0,
-            display: 'none',
-            pointerEvents: 'none'
-          },
-    [anchorName, isActive, isPaintable]
-  )
+  // Why (#10546): non-active paintable panes (automation/mobile) used to sit opacity-0 over the
+  // agent terminal. Electron webviews ignore parent pointer-events, so they stole focus and
+  // made the live agent conversation appear dismissed. Park them off-screen while still
+  // paintable for CDP/screencast.
+  const style: React.CSSProperties = useMemo(() => {
+    if (!anchorName) {
+      return {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: 0,
+        height: 0,
+        display: 'none',
+        pointerEvents: 'none'
+      }
+    }
+    if (isActive) {
+      return {
+        position: 'absolute',
+        positionAnchor: anchorName,
+        top: `anchor(${anchorName} top)`,
+        left: `anchor(${anchorName} left)`,
+        width: `anchor-size(${anchorName} width)`,
+        height: `anchor-size(${anchorName} height)`,
+        display: 'flex',
+        pointerEvents: 'auto',
+        opacity: 1
+      }
+    }
+    if (isPaintable) {
+      return {
+        position: 'fixed',
+        top: 0,
+        left: -10000,
+        width: 1280,
+        height: 720,
+        display: 'flex',
+        // Why: off-screen + no pointer events keeps CDP paint without covering the agent.
+        pointerEvents: 'none',
+        opacity: 1
+      }
+    }
+    return {
+      position: 'absolute',
+      positionAnchor: anchorName,
+      top: `anchor(${anchorName} top)`,
+      left: `anchor(${anchorName} left)`,
+      width: `anchor-size(${anchorName} width)`,
+      height: `anchor-size(${anchorName} height)`,
+      display: 'none',
+      pointerEvents: 'none',
+      opacity: 0
+    }
+  }, [anchorName, isActive, isPaintable])
   const handleFocus = useCallback(() => {
     if (groupId !== undefined && onFocusOwningGroup) {
       onFocusOwningGroup(groupId)

--- a/src/renderer/src/lib/browser-open-beside-live-agent.test.ts
+++ b/src/renderer/src/lib/browser-open-beside-live-agent.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+import { shouldOpenBrowserBesideLiveAgent } from './browser-open-beside-live-agent'
+
+function liveEntry(
+  overrides: Partial<AgentStatusEntry> & Pick<AgentStatusEntry, 'paneKey'>
+): AgentStatusEntry {
+  return {
+    state: 'working',
+    prompt: 'review UI',
+    updatedAt: 1,
+    stateStartedAt: 1,
+    stateHistory: [],
+    ...overrides
+  }
+}
+
+describe('shouldOpenBrowserBesideLiveAgent', () => {
+  it('returns false when the worktree is not active', () => {
+    expect(
+      shouldOpenBrowserBesideLiveAgent(
+        {
+          activeWorktreeId: 'wt-other',
+          activeTabType: 'terminal',
+          agentStatusByPaneKey: {
+            'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee': liveEntry({
+              paneKey: 'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+              tabId: 'tab-1',
+              worktreeId: 'wt-1'
+            })
+          },
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] }
+        },
+        'wt-1'
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when the active surface is already browser', () => {
+    expect(
+      shouldOpenBrowserBesideLiveAgent(
+        {
+          activeWorktreeId: 'wt-1',
+          activeTabType: 'browser',
+          agentStatusByPaneKey: {
+            'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee': liveEntry({
+              paneKey: 'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+              tabId: 'tab-1',
+              worktreeId: 'wt-1'
+            })
+          },
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] }
+        },
+        'wt-1'
+      )
+    ).toBe(false)
+  })
+
+  it('returns true when a live agent terminal is on the active worktree surface', () => {
+    expect(
+      shouldOpenBrowserBesideLiveAgent(
+        {
+          activeWorktreeId: 'wt-1',
+          activeTabType: 'terminal',
+          agentStatusByPaneKey: {
+            'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee': liveEntry({
+              paneKey: 'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+              tabId: 'tab-1',
+              worktreeId: 'wt-1'
+            })
+          },
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] }
+        },
+        'wt-1'
+      )
+    ).toBe(true)
+  })
+
+  it('returns false when agents are done', () => {
+    expect(
+      shouldOpenBrowserBesideLiveAgent(
+        {
+          activeWorktreeId: 'wt-1',
+          activeTabType: 'terminal',
+          agentStatusByPaneKey: {
+            'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee': liveEntry({
+              paneKey: 'tab-1:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+              tabId: 'tab-1',
+              worktreeId: 'wt-1',
+              state: 'done'
+            })
+          },
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] }
+        },
+        'wt-1'
+      )
+    ).toBe(false)
+  })
+
+  it('returns false when the live agent belongs to another worktree', () => {
+    expect(
+      shouldOpenBrowserBesideLiveAgent(
+        {
+          activeWorktreeId: 'wt-1',
+          activeTabType: 'terminal',
+          agentStatusByPaneKey: {
+            'tab-2:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee': liveEntry({
+              paneKey: 'tab-2:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+              tabId: 'tab-2',
+              worktreeId: 'wt-2'
+            })
+          },
+          tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] }
+        },
+        'wt-1'
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/browser-open-beside-live-agent.ts
+++ b/src/renderer/src/lib/browser-open-beside-live-agent.ts
@@ -1,0 +1,60 @@
+import type { AgentStatusEntry, AgentStatusState } from '../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../shared/stable-pane-id'
+
+const LIVE_AGENT_STATES = new Set<AgentStatusState>(['working', 'blocked', 'waiting'])
+
+export type BrowserOpenBesideLiveAgentState = {
+  activeWorktreeId: string | null
+  activeTabType: string | null
+  agentStatusByPaneKey?: Record<string, AgentStatusEntry> | null
+  tabsByWorktree?: Record<string, readonly { id: string }[]>
+}
+
+/**
+ * True when activating a browser tab in `worktreeId` would replace a live agent
+ * terminal the user is currently watching. Callers should open the browser in a
+ * side split instead of swapping the group active tab.
+ */
+export function shouldOpenBrowserBesideLiveAgent(
+  state: BrowserOpenBesideLiveAgentState,
+  worktreeId: string
+): boolean {
+  if (state.activeWorktreeId !== worktreeId) {
+    return false
+  }
+  // Why: only the terminal surface is the live agent conversation; editor/browser
+  // already replaced it, so a normal browser activate is fine.
+  if (state.activeTabType !== 'terminal') {
+    return false
+  }
+
+  const statuses = state.agentStatusByPaneKey
+  if (!statuses) {
+    return false
+  }
+
+  const terminalIds = new Set((state.tabsByWorktree?.[worktreeId] ?? []).map((tab) => tab.id))
+  if (terminalIds.size === 0) {
+    return false
+  }
+
+  for (const entry of Object.values(statuses)) {
+    if (!LIVE_AGENT_STATES.has(entry.state)) {
+      continue
+    }
+    if (entry.worktreeId && entry.worktreeId !== worktreeId) {
+      continue
+    }
+    const tabId = entry.tabId ?? parsePaneKey(entry.paneKey)?.tabId
+    if (tabId && terminalIds.has(tabId)) {
+      return true
+    }
+    // Why: some rows only carry worktreeId before tab attribution hydrates —
+    // still treat a live row on this worktree as a surface to preserve.
+    if (!tabId && entry.worktreeId === worktreeId) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -52,7 +52,22 @@ function createTestStore() {
         activeTabType: 'terminal',
         activeTabTypeByWorktree: {},
         worktreesByRepo: {},
+        groupsByWorktree: {},
+        activeGroupIdByWorktree: {},
+        agentStatusByPaneKey: {},
         createUnifiedTab: vi.fn(),
+        createUnifiedTabInSplit: vi.fn().mockReturnValue({
+          id: 'unified-browser-split',
+          entityId: 'workspace-split',
+          groupId: 'group-split',
+          worktreeId: 'wt-1',
+          contentType: 'browser',
+          label: 'split',
+          customLabel: null,
+          color: null,
+          sortOrder: 0,
+          createdAt: 1
+        }),
         closeUnifiedTab: vi.fn(),
         activateTab: vi.fn(),
         setTabLabel: vi.fn(),
@@ -223,8 +238,75 @@ describe('createBrowserSlice annotations', () => {
       'browser',
       expect.objectContaining({ activate: false })
     )
+    expect(store.getState().createUnifiedTabInSplit).not.toHaveBeenCalled()
     expect(store.getState().activeTabType).toBe('terminal')
     expect(store.getState().activeBrowserTabIdByWorktree['wt-1']).toBeNull()
+  })
+
+  it('opens an activated browser beside a live agent instead of replacing it', () => {
+    const store = createTestStore()
+    store.setState({
+      activeTabType: 'terminal',
+      tabsByWorktree: { 'wt-1': [{ id: 'agent-tab' }] as AppState['tabsByWorktree'][string] },
+      activeGroupIdByWorktree: { 'wt-1': 'group-agent' },
+      groupsByWorktree: {
+        'wt-1': [
+          {
+            id: 'group-agent',
+            worktreeId: 'wt-1',
+            activeTabId: 'unified-agent',
+            tabOrder: ['unified-agent']
+          }
+        ]
+      },
+      agentStatusByPaneKey: {
+        'agent-tab:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee': {
+          state: 'working',
+          prompt: 'review UI',
+          updatedAt: 1,
+          stateStartedAt: 1,
+          stateHistory: [],
+          paneKey: 'agent-tab:aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',
+          tabId: 'agent-tab',
+          worktreeId: 'wt-1'
+        }
+      }
+    })
+
+    const tab = store.getState().createBrowserTab('wt-1', 'https://example.com', {
+      activate: true,
+      title: 'Review target'
+    })
+
+    expect(store.getState().createUnifiedTabInSplit).toHaveBeenCalledWith(
+      'wt-1',
+      'browser',
+      { sourceGroupId: 'group-agent', splitDirection: 'right' },
+      expect.objectContaining({
+        entityId: tab.id,
+        label: 'Review target',
+        activate: true
+      })
+    )
+    expect(store.getState().createUnifiedTab).not.toHaveBeenCalled()
+  })
+
+  it('does not surface a browser tab from a background worktree as the global active surface', () => {
+    const store = createTestStore()
+    store.setState({
+      activeWorktreeId: 'wt-active',
+      activeTabType: 'terminal'
+    })
+    const backgroundTab = store.getState().createBrowserTab('wt-bg', 'https://example.com', {
+      activate: false,
+      title: 'Background'
+    })
+
+    store.getState().setActiveBrowserTab(backgroundTab.id)
+
+    expect(store.getState().activeBrowserTabIdByWorktree['wt-bg']).toBe(backgroundTab.id)
+    expect(store.getState().activeTabType).toBe('terminal')
+    expect(store.getState().activeBrowserTabId).not.toBe(backgroundTab.id)
   })
 
   it('uses local browser profile defaults for client-local fallback pages', () => {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -36,6 +36,7 @@ import type {
   BrowserProfileListResult
 } from '../../../../shared/runtime-types'
 import { createBrowserUuid } from '@/lib/browser-uuid'
+import { shouldOpenBrowserBesideLiveAgent } from '@/lib/browser-open-beside-live-agent'
 import { translate } from '@/i18n/i18n'
 import {
   getSettingsFocusedExecutionHostId,
@@ -572,6 +573,19 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       options?.sessionPartition
     )
 
+    const shouldActivate = options?.activate ?? true
+    // Why (#10546): decide before set() — activating flips activeTabType to browser and
+    // would hide the live agent surface we are trying to preserve.
+    const preCreateState = get()
+    const openBesideLiveAgent =
+      shouldActivate &&
+      options?.targetGroupId === undefined &&
+      shouldOpenBrowserBesideLiveAgent(preCreateState, worktreeId)
+    const sourceGroupIdForSplit = openBesideLiveAgent
+      ? (preCreateState.activeGroupIdByWorktree[worktreeId] ??
+        preCreateState.groupsByWorktree[worktreeId]?.[0]?.id)
+      : undefined
+
     set((s) => {
       const existingTabs = s.browserTabsByWorktree[worktreeId] ?? []
       const nextTabBarOrder = (() => {
@@ -594,7 +608,6 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         return base
       })()
 
-      const shouldActivate = options?.activate ?? true
       const shouldUpdateGlobalActiveSurface = shouldActivate && s.activeWorktreeId === worktreeId
       const shouldFocusFloatingTab = shouldActivate && worktreeId === FLOATING_TERMINAL_WORKTREE_ID
       const shouldFocusAddressBar =
@@ -647,11 +660,32 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       (t) => t.contentType === 'browser' && t.entityId === workspaceId
     )
     if (!alreadyHasUnifiedTab) {
+      // Why (#10546): open a right split so the live agent conversation stays visible beside
+      // the browser instead of being replaced in the same group.
+      if (
+        openBesideLiveAgent &&
+        sourceGroupIdForSplit &&
+        typeof state.createUnifiedTabInSplit === 'function'
+      ) {
+        const splitTab = state.createUnifiedTabInSplit(
+          worktreeId,
+          'browser',
+          { sourceGroupId: sourceGroupIdForSplit, splitDirection: 'right' },
+          {
+            entityId: workspaceId,
+            label: browserTab.title,
+            activate: true
+          }
+        )
+        if (splitTab) {
+          return browserTab
+        }
+      }
       state.createUnifiedTab(worktreeId, 'browser', {
         entityId: workspaceId,
         label: browserTab.title,
         targetGroupId: options?.targetGroupId,
-        activate: options?.activate ?? true
+        activate: shouldActivate
       })
     }
     return browserTab
@@ -933,13 +967,16 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
       if (!browserTab) {
         return s
       }
+      // Why (#10546): only surface the browser pane when the tab's worktree is already
+      // active — never yank the global agent/terminal surface from another worktree.
+      const isActiveWorktree = s.activeWorktreeId === browserTab.worktreeId
       return {
-        activeBrowserTabId: tabId,
+        activeBrowserTabId: isActiveWorktree ? tabId : s.activeBrowserTabId,
         activeBrowserTabIdByWorktree: {
           ...s.activeBrowserTabIdByWorktree,
           [browserTab.worktreeId]: tabId
         },
-        activeTabType: 'browser',
+        activeTabType: isActiveWorktree ? 'browser' : s.activeTabType,
         activeTabTypeByWorktree: {
           ...s.activeTabTypeByWorktree,
           [browserTab.worktreeId]: 'browser'


### PR DESCRIPTION
## Summary

Fixes #10546 — opening/using the in-app browser no longer dismisses a live multi-agent conversation surface.

- When a browser tab **activates** while the user is watching a **live agent terminal** (`working` / `blocked` / `waiting`), open the browser in a **right split** instead of replacing the agent group tab.
- `setActiveBrowserTab` only flips the **global** surface when the browser belongs to the **active worktree** (matches `createBrowserTab` / `focusBrowserTabInWorktree`).
- Non-active automation-visible browser overlays are parked **off-screen** so Electron webviews cannot cover/steal focus from the agent conversation while still remaining CDP-paintable.

## Test plan

- [x] `vitest` — `browser-open-beside-live-agent.test.ts`
- [x] `vitest` — `browser.test.ts` (incl. beside-live-agent + background worktree surface)
- [x] `vitest` — `BrowserPaneOverlayLayer.test.tsx`
- [x] `vitest` — related `store-cascades` createBrowserTab cases
- [ ] Manual: start a live agent, open browser (link / new tab) → agent stays visible in left pane, browser on right
- [ ] Manual: agent automation without `--focus` still does not steal the surface
- [ ] Manual: empty browser discovery / unavailable backend does not leave a broken agent view

## ELI5

Opening the in-app browser while watching a live agent conversation used to replace that agent surface. Live agent views stay; the browser opens in a split (or without stealing focus) so multi-agent work isn't interrupted.
