### PR TITLE
fix(runtime): report the effective ask timeout so a clamped wait isn't misreported

### DIFF
--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -618,6 +618,7 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       messageId: string | null
       threadId: string
       timedOut: boolean
+      timeoutMs?: number
     }>(
       'orchestration.ask',
       {
@@ -638,7 +639,9 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
     }
     if (result.result.timedOut) {
       if (!json) {
-        console.error(`ask timeout after ${timeoutMs}ms (thread ${result.result.threadId})`)
+        // Why: report the server's effective budget — it clamps large values, so the requested one would overstate the wait.
+        const waitedMs = result.result.timeoutMs ?? timeoutMs
+        console.error(`ask timeout after ${waitedMs}ms (thread ${result.result.threadId})`)
       }
       process.exitCode = 1
     }

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1801,26 +1801,28 @@ describe('orchestration RPC methods', () => {
         observedTimeoutMs = options?.timeoutMs
         // End the wait loop so the assertion runs against the first budget slice.
         const outbound = db.getInbox(10).find((m) => m.type === 'decision_gate')
-        if (outbound) {
-          db.insertMessage({
-            from: 'term_coord',
-            to: 'term_worker',
-            subject: 'Re: Question',
-            body: 'ok',
-            threadId: outbound.id
-          })
-        }
+        // Why: without a reply the handler's while(true) spins on this mock until vitest times out, hanging instead of failing.
+        expect(outbound).toBeDefined()
+        db.insertMessage({
+          from: 'term_coord',
+          to: 'term_worker',
+          subject: 'Re: Question',
+          body: 'ok',
+          threadId: outbound!.id
+        })
       })
 
-      await call('orchestration.ask', {
+      const result = (await call('orchestration.ask', {
         from: 'term_worker',
         to: 'term_coord',
         question: 'forever?',
         timeoutMs: Number.MAX_SAFE_INTEGER
-      })
+      })) as { timeoutMs: number }
 
       expect(observedTimeoutMs).toBeLessThanOrEqual(1_800_000)
       expect(observedTimeoutMs).toBeGreaterThan(1_700_000)
+      // The clamp must be observable: callers report the budget waited, not the one they asked for.
+      expect(result.timeoutMs).toBe(1_800_000)
     })
 
     it('clamps timeoutMs at the exported boundary', () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -580,6 +580,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
 
       const db = runtime.getOrchestrationDb()
       const from = params.from ?? 'unknown'
+      // Why: echoed on every return so a clamped caller reports the budget actually waited, not the one it asked for.
       const timeoutMs = clampAskTimeoutMs(params.timeoutMs)
       const options =
         params.options
@@ -613,15 +614,16 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
             answer: reply.body,
             messageId: reply.id,
             threadId,
-            timedOut: false
+            timedOut: false,
+            timeoutMs
           }
         }
         if (signal?.aborted) {
-          return { answer: null, messageId: null, threadId, timedOut: true }
+          return { answer: null, messageId: null, threadId, timedOut: true, timeoutMs }
         }
         const remainingMs = deadline - Date.now()
         if (remainingMs <= 0) {
-          return { answer: null, messageId: null, threadId, timedOut: true }
+          return { answer: null, messageId: null, threadId, timedOut: true, timeoutMs }
         }
         // Why: signal releases the waiter on client disconnect while the already-sent decision gate stays visible to the recipient.
         await runtime.waitForMessage(from, { timeoutMs: remainingMs, signal })


### PR DESCRIPTION
## Summary

Follow-up to #10529, which added a 30-minute clamp on `orchestration.ask`'s `timeoutMs`. The clamp was **silent**: the ask result carried no timeout figure, so the CLI printed the value the caller *sent*.

A worker passing `--timeout-ms 3600000` is told `ask timeout after 3600000ms` after only 30 minutes of real waiting — off by 2x, and accurate before #10529 introduced the clamp. An agent reads that as "the coordinator is dead" and escalates, when re-asking is the correct response.

This echoes the effective budget on every ask return and prints that instead.

## Why this is a separate PR

This commit was written during #10529's review and pushed to that branch, but **GitHub never synced the PR head** (`head.sha` stayed at the previous commit with no `synchronize` event for ~45 min), so the squash merge silently used the older sha and the fix was left behind. Recovering it here rather than losing it.

## Shape

- Additive **optional** field on the ask result — older clients fall back to the requested value.
- CLI prefers the server's effective figure when present.
- Also fixes a real test hazard: the clamp test's `if (outbound)` meant a missing reply let the handler's `while (true)` spin until vitest timed out, **hanging instead of failing**. Now asserts `outbound` is defined.

## Verification

- `orchestration.test.ts` — 116/116 pass on merged `main`
- **Mutation-verified non-vacuous:** removing *only* the echo while leaving the clamp intact fails with `AssertionError: expected undefined to be 1800000`. So the new assertion pins observability specifically, not the clamp it depends on.

## Not verified

No live SSH/relay/mobile client was driven. The `orca serve` / web reachability of `orchestration.ask` over WebSocket (scope `runtime` bypasses the mobile allowlist) is established by reading `index.ts` and `ipc/mobile.ts`, not by running one.