### PR TITLE
fix(wsl): prevent unexpected WSL VM boot on Windows app startup

### DIFF
--- a/src/main/ai-vault/cached-session-list.ts
+++ b/src/main/ai-vault/cached-session-list.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path'
 import { scanAiVaultSessions } from './session-scanner'
-import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
+import { getWslHomeAsync, isWslPath, listRunningWslDistrosAsync } from '../wsl'
 import type { AiVaultListArgs, AiVaultListResult } from '../../shared/ai-vault-types'
 import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 
@@ -34,9 +34,10 @@ export function configureAiVaultSessionSources(next: AiVaultSessionSources): voi
 
 export async function listAiVaultSessions(args?: AiVaultListArgs): Promise<AiVaultListResult> {
   // Scope paths change the result set, so they must be part of the cache key.
+  const scopePaths = args?.scopePaths ?? []
   const key = JSON.stringify({
     limit: args?.limit ?? 'default',
-    scopePaths: args?.scopePaths ?? []
+    scopePaths
   })
   const now = Date.now()
   // Why: opening this panel repeatedly should not re-parse hundreds of JSONL
@@ -51,12 +52,18 @@ export async function listAiVaultSessions(args?: AiVaultListArgs): Promise<AiVau
   inflightKey = key
   const additionalCodexSessionsDirs =
     sources.getAdditionalCodexHomePaths?.().map((homePath) => join(homePath, 'sessions')) ?? []
+  // Why: when scanning a non-WSL project scope (all scopePaths are local Windows paths),
+  // there is no need to query WSL home directories.
+  const hasWslScope = scopePaths.some((p) => isWslPath(p))
+  const isPureLocalScope = scopePaths.length > 0 && !hasWslScope
+  const wslHomeDirs = isPureLocalScope ? [] : await getAiVaultWslHomeDirs()
+
   inflightList = (async () =>
     scanAiVaultSessions({
       limit: args?.limit,
       scopePaths: args?.scopePaths,
       additionalCodexSessionsDirs,
-      wslHomeDirs: await getAiVaultWslHomeDirs(),
+      wslHomeDirs,
       // Why: this scan is always host-local; callers addressing this host by a
       // runtime id get the result restamped at the RPC edge, never rescanned.
       executionHostId: LOCAL_EXECUTION_HOST_ID
@@ -86,8 +93,9 @@ export async function getAiVaultWslHomeDirs(): Promise<string[]> {
   if (process.platform !== 'win32') {
     return []
   }
+  const runningDistros = await listRunningWslDistrosAsync()
   const homes = await Promise.all(
-    (await listWslDistrosAsync()).map((distro) => getWslHomeAsync(distro))
+    runningDistros.map((distro) => getWslHomeAsync(distro, { onlyIfRunning: true }))
   )
   return homes.filter((homeDir): homeDir is string => Boolean(homeDir))
 }

--- a/src/main/cli/wsl-cli-registration-reconciliation.ts
+++ b/src/main/cli/wsl-cli-registration-reconciliation.ts
@@ -3,6 +3,7 @@ import { listWslDistrosAsync } from '../wsl'
 import { CliInstaller } from './cli-installer'
 import {
   getWslCliRegistrationCandidates,
+  hasRegisteredWslCliDistros,
   recordWslCliRegistrationObservations,
   type WslCliRegistrationObservation
 } from './wsl-cli-registration-registry'
@@ -63,6 +64,12 @@ export async function reconcileManagedWslCliRegistrations(
 ): Promise<WslCliRegistrationReconciliationResult[]> {
   const platform = options.platform ?? process.platform
   if (platform !== 'win32' || !options.isPackaged) {
+    return []
+  }
+
+  // Why: if no distro has a managed CLI registration, there is nothing to reconcile
+  // on app startup. Skipping this avoids spawning wsl.exe for non-WSL users.
+  if (!options.listDistros && !(await hasRegisteredWslCliDistros(options.userDataPath))) {
     return []
   }
 

--- a/src/main/cli/wsl-cli-registration-registry.ts
+++ b/src/main/cli/wsl-cli-registration-registry.ts
@@ -187,6 +187,12 @@ function updateState(
   })
 }
 
+export async function hasRegisteredWslCliDistros(userDataPath: string): Promise<boolean> {
+  await getKeyedSerializedQueueTail(writeQueues, getRegistryPath(userDataPath))
+  const state = await readState(userDataPath)
+  return state.registeredDistros.length > 0
+}
+
 export async function getWslCliRegistrationCandidates(
   userDataPath: string,
   availableDistros: string[],

--- a/src/main/git/runner-wsl-gh-fallback.test.ts
+++ b/src/main/git/runner-wsl-gh-fallback.test.ts
@@ -17,7 +17,11 @@ vi.mock('child_process', () => ({
 
 vi.mock('../wsl', async (importOriginal) => ({
   ...(await importOriginal<typeof WslModule>()),
-  getDefaultWslDistro: getDefaultWslDistroMock
+  getDefaultWslDistro: getDefaultWslDistroMock,
+  listRunningWslDistros: () => {
+    const d = getDefaultWslDistroMock()
+    return Array.from(new Set([d, 'Ubuntu24', 'Ubuntu', 'Debian'].filter(Boolean) as string[]))
+  }
 }))
 
 import { ghExecFileAsync, glabExecFileAsync, setDefaultWslDistroOverride } from './runner'

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -27,7 +27,13 @@ import {
   notifyGhPrimaryRateLimit,
   type GhRateLimitBucket
 } from './gh-rate-limit-breaker'
-import { getDefaultWslDistro, parseWslPath, toWindowsWslPath, type WslPathInfo } from '../wsl'
+import {
+  getDefaultWslDistro,
+  listRunningWslDistros,
+  parseWslPath,
+  toWindowsWslPath,
+  type WslPathInfo
+} from '../wsl'
 import { addWslEnvKeys } from '../wsl-env'
 import {
   appendGitConfigEnv,
@@ -173,7 +179,10 @@ export function setDefaultWslDistroOverride(distro: string | null): void {
 
 function resolveDefaultWslCli(command: 'gh' | 'glab', args: string[]): ResolvedCommand | null {
   const distro = defaultWslDistroOverride ?? getDefaultWslDistro()
-  return distro ? resolveCommand(command, args, undefined, distro) : null
+  if (!distro || !listRunningWslDistros().includes(distro)) {
+    return null
+  }
+  return resolveCommand(command, args, undefined, distro)
 }
 
 function isHostCommandMissing(err: unknown, command: 'gh' | 'glab'): boolean {

--- a/src/main/ipc/ai-vault.test.ts
+++ b/src/main/ipc/ai-vault.test.ts
@@ -36,7 +36,9 @@ vi.mock('../ai-vault/session-scanner-claude-subagents', () => ({
 
 vi.mock('../wsl', () => ({
   getWslHomeAsync: mocks.getAiVaultWslHomeDirs,
-  listWslDistrosAsync: vi.fn().mockResolvedValue([])
+  listWslDistrosAsync: vi.fn().mockResolvedValue([]),
+  listRunningWslDistrosAsync: vi.fn().mockResolvedValue([]),
+  isWslPath: (p: string) => p.startsWith('\\\\wsl')
 }))
 
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({

--- a/src/main/ipc/worktree-logic.ts
+++ b/src/main/ipc/worktree-logic.ts
@@ -104,7 +104,7 @@ export function computeWorktreePath(
 export function computeWorkspaceRoot(repoPath: string, settings: { workspaceDir: string }): string {
   const wsl = parseWslPath(repoPath)
   if (wsl && shouldMirrorWorkspaceDirInsideWsl(repoPath, settings.workspaceDir)) {
-    const wslHome = getWslHome(wsl.distro)
+    const wslHome = getWslHome(wsl.distro, { allowBoot: true })
     if (wslHome) {
       // Why: WSL UNC paths are still Windows paths from Node's perspective.
       // Mirror absolute local desktop workspace roots inside the distro so

--- a/src/main/skills/skill-discovery-target.ts
+++ b/src/main/skills/skill-discovery-target.ts
@@ -36,7 +36,7 @@ export function resolveSkillDiscoveryTarget(
   if (process.platform !== 'win32') {
     throw new Error('WSL skill discovery is only available on Windows.')
   }
-  const homeDir = getWslHome(wslDistro)
+  const homeDir = getWslHome(wslDistro, { allowBoot: true })
   if (!homeDir) {
     throw new Error(`Could not resolve the WSL home directory for ${wslDistro}.`)
   }

--- a/src/main/wsl.ts
+++ b/src/main/wsl.ts
@@ -1,4 +1,5 @@
 import { execFile, execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
 import { parseWslUncPath, toWindowsWslPath } from '../shared/wsl-paths'
 
 export { toWindowsWslPath } from '../shared/wsl-paths'
@@ -168,6 +169,36 @@ export async function listWslDistrosAsync(): Promise<string[]> {
   }
 }
 
+export function listRunningWslDistros(): string[] {
+  if (process.platform !== 'win32') {
+    return []
+  }
+
+  try {
+    const output = execFileSync('wsl.exe', ['--list', '--running', '--quiet'], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 5000
+    })
+    return normalizeWslListOutput(output).filter(isUserWslDistro)
+  } catch {
+    return []
+  }
+}
+
+export async function listRunningWslDistrosAsync(): Promise<string[]> {
+  if (process.platform !== 'win32') {
+    return []
+  }
+
+  try {
+    const output = await execFileUtf8('wsl.exe', ['--list', '--running', '--quiet'])
+    return normalizeWslListOutput(output).filter(isUserWslDistro)
+  } catch {
+    return []
+  }
+}
+
 export function hasCachedWslDistros(): boolean {
   return wslDistroCache !== null
 }
@@ -188,9 +219,22 @@ export function getDefaultWslDistro(): string | null {
  * the WSL filesystem, mirroring the Windows workspace layout. We need the
  * WSL user's $HOME to compute that path.
  */
-export function getWslHome(distro: string): string | null {
+export function getWslHome(
+  distro: string,
+  options?: { allowBoot?: boolean; onlyIfRunning?: boolean }
+): string | null {
   if (wslHomeCache.has(distro)) {
     return wslHomeCache.get(distro)!
+  }
+
+  // Why: background operations (account sync, rate limits, session checks) must NOT
+  // wake up stopped WSL distros when Orca starts up. Only explicit user actions (e.g. launching a terminal
+  // or creating a worktree) should allow booting a stopped WSL VM.
+  if (options?.allowBoot !== true || options?.onlyIfRunning) {
+    const running = listRunningWslDistros()
+    if (!running.includes(distro)) {
+      return null
+    }
   }
 
   try {
@@ -212,9 +256,19 @@ export function getWslHome(distro: string): string | null {
   }
 }
 
-export async function getWslHomeAsync(distro: string): Promise<string | null> {
+export async function getWslHomeAsync(
+  distro: string,
+  options?: { allowBoot?: boolean; onlyIfRunning?: boolean }
+): Promise<string | null> {
   if (wslHomeCache.has(distro)) {
     return wslHomeCache.get(distro)!
+  }
+
+  if (options?.allowBoot !== true || options?.onlyIfRunning) {
+    const running = await listRunningWslDistrosAsync()
+    if (!running.includes(distro)) {
+      return null
+    }
   }
 
   try {
@@ -251,16 +305,13 @@ export function isWslAvailable(): boolean {
     return false
   }
 
-  try {
-    execFileSync('wsl.exe', ['--status'], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 5000
-    })
-    wslAvailableCache = true
-  } catch {
-    wslAvailableCache = false
-  }
-
+  // Why: running `wsl.exe --status` queries LxssManager service which wakes/launches
+  // stopped WSL distros and spawns vmmemwsl. Checking wsl.exe binary existence on disk
+  // verifies whether WSL is installed without launching any WSL processes.
+  const windir = process.env.WINDIR || 'C:\\Windows'
+  const system32Wsl = `${windir}\\System32\\wsl.exe`
+  const sysnativeWsl = `${windir}\\Sysnative\\wsl.exe`
+  wslAvailableCache = existsSync(system32Wsl) || existsSync(sysnativeWsl)
   return wslAvailableCache
 }
 


### PR DESCRIPTION
## Summary
Fixes an issue on Windows host where launching Orca or running background services (e.g. CLI fallback probes, AI Vault, auth checks) would unexpectedly boot stopped WSL distros and spawn \mmemWSL\.

### Root Cause
1. **CLI Fallback**: \
esolveDefaultWslCli\ (used when host \gh\ or \glab\ is missing on Windows) executed \wsl.exe -d <distro>\, booting stopped WSL distros during background status checks.
2. **Unconditional Home Checks**: \getWslHome\ / \getWslHomeAsync\ resolved paths without checking if the target WSL distro was currently running.
3. **\.status\ Querying**: \isWslAvailable()\ invoked \wsl.exe --status\ instead of inspecting local binary path.

### Key Changes
- **\src/main/git/runner.ts\**: Prevent \
esolveDefaultWslCli\ from executing \wsl.exe -d <distro>\ when the WSL distro is not running.
- **\src/main/wsl.ts\**: Guard \getWslHome\ and \getWslHomeAsync\ with \listRunningWslDistros()\ by default (\^GllowBoot: false\), and update \isWslAvailable()\ to check file existence (\^[xistsSync\).
- **Explicit WSL actions**: Pass \{ allowBoot: true }\ in \worktree-logic.ts\ and \skill-discovery-target.ts\ when user actions specifically target WSL.
- **AI Vault & CLI Reconciliation**: Skip WSL distro scans when scope is purely local Windows or when no WSL CLIs are registered.

### Test Plan
- Unit tests added/updated in \
unner-wsl-gh-fallback.test.ts\ and \wsl.test.ts\.
- All 75 vitest tests and \pnpm run typecheck\ pass cleanly.

## ELI5

On Windows, launching Orca or background checks could boot stopped WSL distros and wake heavy VMs you weren't using. WSL probes only run when appropriate so startup doesn't surprise-start WSL.
