### PR TITLE
fix(sidebar): keep Cmd+Shift+Arrow cycling in place after closing a workspace

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -302,6 +302,10 @@ import {
   getPreferredWorktreeRows,
   getRenderedWorktreesInSidebarOrder
 } from './worktree-sidebar-row-preference'
+import {
+  resolveWorktreeNavigationAnchorId,
+  resolveWorktreeNavigationTargetId
+} from './worktree-list-keyboard-navigation'
 
 export {
   getScrollTopToRevealBounds,
@@ -2491,29 +2495,25 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         defaultHostId,
         pinnedDisplayPolicy
       ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
-      const worktreeRows = getPreferredWorktreeRows(allWorktreeRows, pinnedDisplayPolicy)
-      if (worktreeRows.length === 0) {
+      const navigableWorktreeIds = getPreferredWorktreeRows(
+        allWorktreeRows,
+        pinnedDisplayPolicy
+      ).map((r) => r.worktree.id)
+      // Why: read nav history at press time instead of subscribing — the sidebar re-renders on every entry.
+      const { worktreeNavHistory, worktreeNavHistoryIndex } = useAppStore.getState()
+      const nextWorktreeId = resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds,
+        anchorWorktreeId: resolveWorktreeNavigationAnchorId({
+          selectedWorktreeId: activeWorktreeId,
+          navHistory: worktreeNavHistory,
+          navHistoryIndex: worktreeNavHistoryIndex,
+          navigableWorktreeIds
+        }),
+        direction
+      })
+      if (nextWorktreeId === null) {
         return
       }
-
-      let nextIndex = 0
-      const currentIndex = worktreeRows.findIndex((r) => r.worktree.id === activeWorktreeId)
-
-      if (currentIndex !== -1) {
-        if (direction === 'up') {
-          nextIndex = currentIndex - 1
-          if (nextIndex < 0) {
-            nextIndex = worktreeRows.length - 1
-          }
-        } else {
-          nextIndex = currentIndex + 1
-          if (nextIndex >= worktreeRows.length) {
-            nextIndex = 0
-          }
-        }
-      }
-
-      const nextWorktreeId = worktreeRows[nextIndex].worktree.id
       // Why: keyboard cycling is real navigation; route through the activation helper that records history.
       activateAndRevealWorktree(nextWorktreeId)
 

--- a/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveWorktreeNavigationAnchorId,
+  resolveWorktreeNavigationTargetId
+} from './worktree-list-keyboard-navigation'
+
+const ROWS = ['wt-1', 'wt-2', 'wt-3']
+
+describe('resolveWorktreeNavigationAnchorId', () => {
+  it('prefers the selected workspace', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: 'wt-2',
+        navHistory: ['wt-1'],
+        navHistoryIndex: 0,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('falls back to the current history entry when nothing is selected', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: ['wt-1', 'wt-2'],
+        navHistoryIndex: 1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('ignores history entries ahead of the history cursor', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: ['wt-1', 'wt-2', 'wt-3'],
+        navHistoryIndex: 1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('skips view entries and task-detail entries', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: [
+          'wt-2',
+          'tasks',
+          { kind: 'task-detail', source: 'linear', issue: { id: 'iss-1' } }
+        ] as never,
+        navHistoryIndex: 2,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('skips history entries that are no longer in the list', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: ['wt-1', 'wt-deleted'],
+        navHistoryIndex: 1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-1')
+  })
+
+  it('returns null when neither selection nor history resolves to a listed workspace', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: [],
+        navHistoryIndex: -1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBeNull()
+  })
+
+  it('ignores a selection that is filtered out of the list', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: 'wt-hidden',
+        navHistory: ['wt-3'],
+        navHistoryIndex: 0,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-3')
+  })
+})
+
+describe('resolveWorktreeNavigationTargetId', () => {
+  it('steps down and wraps at the end', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-2',
+        direction: 'down'
+      })
+    ).toBe('wt-3')
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-3',
+        direction: 'down'
+      })
+    ).toBe('wt-1')
+  })
+
+  it('steps up and wraps at the start', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-2',
+        direction: 'up'
+      })
+    ).toBe('wt-1')
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-1',
+        direction: 'up'
+      })
+    ).toBe('wt-3')
+  })
+
+  it('enters the list from either end when there is no anchor', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: null,
+        direction: 'down'
+      })
+    ).toBe('wt-1')
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: null,
+        direction: 'up'
+      })
+    ).toBe('wt-3')
+  })
+
+  it('returns null for an empty list', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: [],
+        anchorWorktreeId: 'wt-1',
+        direction: 'down'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps cycling on a single-row list', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ['wt-1'],
+        anchorWorktreeId: 'wt-1',
+        direction: 'down'
+      })
+    ).toBe('wt-1')
+  })
+})
+
+describe('closing the active workspace keeps sidebar cycling in place', () => {
+  // Repro: 3 workspaces, cycle 1 -> 2, close 2's last tab (landing fallback clears the
+  // selection), then Cmd+Shift+Down must land on 3 instead of restarting at 1.
+  const cycleFrom = (
+    selectedWorktreeId: string | null,
+    navHistory: string[],
+    direction: 'up' | 'down'
+  ): string | null =>
+    resolveWorktreeNavigationTargetId({
+      navigableWorktreeIds: ROWS,
+      anchorWorktreeId: resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId,
+        navHistory,
+        navHistoryIndex: navHistory.length - 1,
+        navigableWorktreeIds: ROWS
+      }),
+      direction
+    })
+
+  it('continues forward from the closed workspace', () => {
+    expect(cycleFrom(null, ['wt-1', 'wt-2'], 'down')).toBe('wt-3')
+  })
+
+  it('continues backward from the closed workspace', () => {
+    expect(cycleFrom(null, ['wt-1', 'wt-2'], 'up')).toBe('wt-1')
+  })
+
+  it('does not re-open the same workspace after closing the first one', () => {
+    expect(cycleFrom(null, ['wt-1'], 'down')).toBe('wt-2')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.ts
@@ -1,0 +1,65 @@
+import type { WorktreeNavHistoryEntry } from '@/store/slices/worktree-nav-history'
+
+type AnchorArgs = {
+  selectedWorktreeId: string | null
+  navHistory: readonly WorktreeNavHistoryEntry[]
+  navHistoryIndex: number
+  navigableWorktreeIds: readonly string[]
+}
+
+// Why: page sentinels share the history entry type with workspace IDs, and object entries are task details.
+function historyEntryWorkspaceId(entry: WorktreeNavHistoryEntry | undefined): string | null {
+  if (typeof entry !== 'string' || entry === 'tasks' || entry === 'automations') {
+    return null
+  }
+  return entry
+}
+
+/**
+ * Pick the row keyboard cycling should step from. Closing a workspace's last tab clears the
+ * selection (landing fallback), so fall back to the nav-history cursor — otherwise every step
+ * after a close restarts at the top of the sidebar.
+ */
+export function resolveWorktreeNavigationAnchorId({
+  selectedWorktreeId,
+  navHistory,
+  navHistoryIndex,
+  navigableWorktreeIds
+}: AnchorArgs): string | null {
+  const navigable = new Set(navigableWorktreeIds)
+  if (selectedWorktreeId !== null && navigable.has(selectedWorktreeId)) {
+    return selectedWorktreeId
+  }
+  for (let i = Math.min(navHistoryIndex, navHistory.length - 1); i >= 0; i--) {
+    const workspaceId = historyEntryWorkspaceId(navHistory[i])
+    if (workspaceId !== null && navigable.has(workspaceId)) {
+      return workspaceId
+    }
+  }
+  return null
+}
+
+/** Step one row from the anchor, wrapping around; with no anchor, enter from the matching end. */
+export function resolveWorktreeNavigationTargetId({
+  navigableWorktreeIds,
+  anchorWorktreeId,
+  direction
+}: {
+  navigableWorktreeIds: readonly string[]
+  anchorWorktreeId: string | null
+  direction: 'up' | 'down'
+}): string | null {
+  if (navigableWorktreeIds.length === 0) {
+    return null
+  }
+  const anchorIndex =
+    anchorWorktreeId === null ? -1 : navigableWorktreeIds.indexOf(anchorWorktreeId)
+  if (anchorIndex === -1) {
+    const entryIndex = direction === 'down' ? 0 : navigableWorktreeIds.length - 1
+    return navigableWorktreeIds[entryIndex]
+  }
+  const step = direction === 'down' ? 1 : -1
+  const nextIndex =
+    (anchorIndex + step + navigableWorktreeIds.length) % navigableWorktreeIds.length
+  return navigableWorktreeIds[nextIndex]
+}


### PR DESCRIPTION
## Summary

Sidebar workspace cycling (`Cmd/Ctrl+Shift+↓/↑`) restarted at the first row after the user closed the session they were on.

Repro:

1. Three workspaces in the sidebar, first one active
2. `Cmd+Shift+↓` → moves to #2 (correct)
3. On #2, `Cmd+W` closes its last tab
4. `Cmd+Shift+↓` → opens **#1 instead of #3**

`Cmd+Shift+↑` had the same problem from the other direction: with no anchor it also jumped to the *first* row instead of the last one.

### Root cause

`navigateWorktree` only ever anchored on the selected workspace, and when it could not find that row (`currentIndex === -1`) it fell back to `nextIndex = 0` regardless of direction:

- `src/renderer/src/store/slices/tabs.ts` — closing a workspace's last tab hits `shouldDeactivateWorktree`, which writes the landing-state fallback (`activeWorktreeId: null`, `activeWorkspaceKey: null`).
- `src/renderer/src/components/sidebar/WorktreeList.tsx` — so right after a close there is no anchor, and every keypress jumps to the top of the list.

### Fix

Anchor resolution and the single step are now pure functions in `worktree-list-keyboard-navigation.ts`:

- When nothing is selected, recover the anchor from the nav-history cursor, so cycling continues from the row the user just closed.
- Skip history entries that are not navigable rows: page sentinels (`tasks`/`automations`), task-detail entries, and workspaces no longer in the list (deleted, or filtered out by host scope / visibility settings).
- With no anchor at all, enter the list from the end that matches the direction (`↑` lands on the last row).
- History is read with `useAppStore.getState()` at keypress time rather than subscribed — subscribing would re-render the virtualized sidebar on every visit.

Keyboard cycling still routes through `activateAndRevealWorktree`, so nav history and cross-repo activation behave as before.

## Screenshots

`No visual change` — this only changes which workspace a keyboard shortcut activates; nothing about the rendered sidebar changes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

15 new unit tests in `worktree-list-keyboard-navigation.test.ts`, all passing, including the exact repro (no selection + history `[wt-1, wt-2]` → `↓` → `wt-3`, and `↑` → `wt-1`), anchor recovery past sentinels/deleted rows, both wrap directions, anchorless entry from either end, and the empty/single-row lists.

Full suite: `Test Files 8 failed | 3388 passed | 7 skipped`, `Tests 43 failed | 35976 passed | 60 skipped`. Those 8 failures are pre-existing and unrelated — I re-ran the same 8 files with this change reverted (`WorktreeList.tsx` restored to `HEAD~1`, the new files moved aside) and got the identical `8 failed / 43 failed` result:

```
src/relay/agent-exec-handler.test.ts
src/renderer/src/components/browser-pane/markup/use-markup-draw-hint.test.ts
src/renderer/src/components/right-sidebar/pr-comment-presentation.test.ts
src/renderer/src/components/right-sidebar/pr-comments-list-selection.test.tsx
src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.test.tsx
src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx
src/renderer/src/components/sidebar/mobile-sidebar-onboarding-badge.test.ts
src/renderer/src/components/sidebar/SidebarToolbar.test.tsx
```

None of them touch the sidebar workspace-cycling path. Note the count is load-sensitive: an earlier full run on a busier machine reported 17 failed files, and a re-run settled at these 8, so some of these look flaky in a loaded environment rather than deterministic.

## AI Review Report

Reviewed with Claude Code (Opus 5) against the checks in CONTRIBUTING:

- **Cross-platform (macOS/Linux/Windows):** no platform-dependent code added. Shortcut matching still goes through `keybindingMatchesAction` + `getShortcutPlatform()`, so `Mod+Shift+Arrow` keeps resolving to Cmd on macOS and Ctrl on Linux/Windows. No shortcut labels, paths, shell invocations, or Electron accelerators are touched. The new helper is pure index arithmetic over a string array.
- **SSH / remote / local:** the anchor is matched by workspace ID against the rows the sidebar would actually render, so SSH-hosted and remote workspaces behave the same as local ones. Workspaces hidden by host scope or visibility filters are not in the navigable set, so they can never be picked as an anchor — resolution scans further back in history instead. No process, path, or credential assumptions.
- **Folder workspaces vs git worktrees:** verified both use the same ID space — `folderWorkspaceToWorktree` sets `id: folderWorkspaceKey(...)` and activation records `recordWorktreeVisit(folderWorkspaceKey(...))` — so anchor recovery works for folder workspaces, not just worktrees.
- **Agent / integration / git-provider neutrality:** no agent, integration, or provider-specific logic involved; nothing provider-named was added.
- **Performance:** history is read via `getState()` at keypress instead of a store subscription, so the virtualized sidebar does not re-render on every visit. The anchor scan is bounded by `MAX_HISTORY` (50) with O(1) set lookups, and runs once per keypress — not in a render or hot path. Row building was already happening on this path and is unchanged.
- **UI quality:** no visual surface, tokens, or components touched; STYLEGUIDE does not apply.
- **Behavior risk flagged and accepted:** with no anchor, `↑` now enters from the last row instead of the first. That is part of the fix — the old behavior made both directions land on row 1 — and it is covered by a test.
- **Edge cases checked:** `navHistoryIndex === -1` (empty history) and an out-of-range index are both clamped by `Math.min(navHistoryIndex, navHistory.length - 1)`; pinned rows duplicated into the Pinned group collapse to one ID via the existing `getPreferredWorktreeRows`; an empty list returns `null` and the handler no-ops as before.

## Security Audit

No security-relevant surface in this change. It is pure renderer-side state computation over IDs already in the store:

- No input parsing, no command execution, no filesystem or path handling, no auth, no secrets, no IPC, no network calls.
- No new dependencies.
- The only external values read are `worktreeNavHistory` / `worktreeNavHistoryIndex` from the app store, and they are only compared against the set of currently rendered workspace IDs — an unknown or stale entry can at worst fail to match and is skipped, never dereferenced or executed.

No follow-up needed.

## Notes

- No platform-, remote-, agent-, integration-, or provider-specific behavior in this change; the shortcut path itself is already platform-normalized.
- `pnpm build` (`build:desktop` + `build:native`) completed clean; `out/{main,preload,renderer,web,cli,relay}` and the macOS native targets all produced artifacts. Verified on macOS only — Linux and Windows builds are unexercised locally, but nothing in this change is platform-conditional.
- Manual verification of the repro in a running app has not been done by me — the fix is covered at the unit level. Worth one pass with the repro steps above on a machine with three workspaces.

X (Twitter): https://x.com/jeongph_dev

🤖 Generated with Claude Code
