### PR TITLE
fix(mobile): reuse host tab when viewing a live terminal from phone

### DIFF
--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -16,7 +16,7 @@ import { OPEN_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceBoa
 import { SPLIT_TERMINAL_PANE_EVENT, CLOSE_TERMINAL_PANE_EVENT } from '@/constants/terminal'
 import { requestBackgroundTerminalWorktreeMount } from '@/components/terminal/background-terminal-worktree-mount'
 import { planMobileTerminalTabMount } from '@/lib/mobile-terminal-tab-mount'
-import { resolveTerminalTabIdForPtyId } from '@/lib/terminal-tab-for-pty-id'
+import { resolveTerminalTabPtyOwnership } from '@/lib/terminal-tab-for-pty-id'
 import {
   hasRegisteredRuntimeTerminalTab,
   focusRuntimeTerminalSurface
@@ -1509,21 +1509,21 @@ export function useIpcEvents(): void {
               activateTerminalInitiatedWorktree(store, worktreeId)
             }
             const worktreeTabs = store.tabsByWorktree[worktreeId] ?? []
-            const existingTab = ptyId
-              ? worktreeTabs.find(
-                  (candidate) =>
-                    candidate.ptyId === ptyId ||
-                    (store.ptyIdsByTabId[candidate.id] ?? []).includes(ptyId)
-                )
-              : undefined
-            // Why (#10486): mobile view/focus reveals a live host PTY; if we miss
-            // ownership only present in layout, createTab would open a second
-            // tab showing the same session on desktop.
-            const ownedTabId =
-              !existingTab && ptyId ? resolveTerminalTabIdForPtyId(store, worktreeId, ptyId) : null
-            const existingOwnedTab = ownedTabId
-              ? worktreeTabs.find((candidate) => candidate.id === ownedTabId)
-              : undefined
+            // Why (#10486 / CodeRabbit #10556): one ownership path only — never
+            // short-circuit on first direct match (stale duplicates), and never
+            // treat ambiguous ownership as "unowned" (would create another tab).
+            const ptyOwnership = ptyId
+              ? resolveTerminalTabPtyOwnership(store, worktreeId, ptyId)
+              : { kind: 'none' as const }
+            if (ptyOwnership.kind === 'ambiguous') {
+              throw new Error(
+                `Ambiguous terminal tab ownership for ptyId ${ptyId}; refusing to create a duplicate tab`
+              )
+            }
+            const existingOwnedTab =
+              ptyOwnership.kind === 'owned'
+                ? worktreeTabs.find((candidate) => candidate.id === ptyOwnership.tabId)
+                : undefined
             const isSplitReveal = Boolean(ptyId && tabId && leafId && splitFromLeafId)
             const splitTargetTab = isSplitReveal
               ? worktreeTabs.find((candidate) => candidate.id === tabId)
@@ -1542,7 +1542,7 @@ export function useIpcEvents(): void {
                   })
                 : undefined
             // Why: runtime fallback reveals a PTY for a renderer-created pending tab; adopt only when the hinted tab has no PTY yet.
-            const reusedTab = existingTab ?? existingOwnedTab ?? splitTargetTab ?? hintedPendingTab
+            const reusedTab = existingOwnedTab ?? splitTargetTab ?? hintedPendingTab
             const tab =
               reusedTab ??
               (ptyId

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -16,6 +16,7 @@ import { OPEN_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceBoa
 import { SPLIT_TERMINAL_PANE_EVENT, CLOSE_TERMINAL_PANE_EVENT } from '@/constants/terminal'
 import { requestBackgroundTerminalWorktreeMount } from '@/components/terminal/background-terminal-worktree-mount'
 import { planMobileTerminalTabMount } from '@/lib/mobile-terminal-tab-mount'
+import { resolveTerminalTabIdForPtyId } from '@/lib/terminal-tab-for-pty-id'
 import {
   hasRegisteredRuntimeTerminalTab,
   focusRuntimeTerminalSurface
@@ -1515,6 +1516,14 @@ export function useIpcEvents(): void {
                     (store.ptyIdsByTabId[candidate.id] ?? []).includes(ptyId)
                 )
               : undefined
+            // Why (#10486): mobile view/focus reveals a live host PTY; if we miss
+            // ownership only present in layout, createTab would open a second
+            // tab showing the same session on desktop.
+            const ownedTabId =
+              !existingTab && ptyId ? resolveTerminalTabIdForPtyId(store, worktreeId, ptyId) : null
+            const existingOwnedTab = ownedTabId
+              ? worktreeTabs.find((candidate) => candidate.id === ownedTabId)
+              : undefined
             const isSplitReveal = Boolean(ptyId && tabId && leafId && splitFromLeafId)
             const splitTargetTab = isSplitReveal
               ? worktreeTabs.find((candidate) => candidate.id === tabId)
@@ -1533,7 +1542,7 @@ export function useIpcEvents(): void {
                   })
                 : undefined
             // Why: runtime fallback reveals a PTY for a renderer-created pending tab; adopt only when the hinted tab has no PTY yet.
-            const reusedTab = existingTab ?? splitTargetTab ?? hintedPendingTab
+            const reusedTab = existingTab ?? existingOwnedTab ?? splitTargetTab ?? hintedPendingTab
             const tab =
               reusedTab ??
               (ptyId

--- a/src/renderer/src/lib/mobile-terminal-tab-mount.test.ts
+++ b/src/renderer/src/lib/mobile-terminal-tab-mount.test.ts
@@ -2,17 +2,19 @@ import { describe, expect, it, vi } from 'vitest'
 import type { AppState } from '@/store/types'
 import { planMobileTerminalTabMount } from './mobile-terminal-tab-mount'
 
-type PlannerState = Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>
+type PlannerState = Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId'>
 
 function state(tabCount = 1): PlannerState {
+  const tabs = Array.from({ length: tabCount }, (_, index) => ({
+    id: `tab-${index}`,
+    ptyId: `wt@@${index}`
+  }))
   return {
     tabsByWorktree: {
-      wt: Array.from({ length: tabCount }, (_, index) => ({
-        id: `tab-${index}`,
-        ptyId: `wt@@${index}`
-      }))
+      wt: tabs
     } as unknown as AppState['tabsByWorktree'],
-    terminalLayoutsByTabId: {}
+    terminalLayoutsByTabId: {},
+    ptyIdsByTabId: Object.fromEntries(tabs.map((tab) => [tab.id, tab.ptyId ? [tab.ptyId] : []]))
   }
 }
 

--- a/src/renderer/src/lib/mobile-terminal-tab-mount.ts
+++ b/src/renderer/src/lib/mobile-terminal-tab-mount.ts
@@ -14,7 +14,7 @@ type MobileTerminalTabMountOptions = {
 
 /** Why: exact-tab planning prevents a stale ptyId from mounting every saved xterm (#8597). */
 export function planMobileTerminalTabMount(
-  state: Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>,
+  state: Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId'>,
   request: MobileTerminalTabMountRequest,
   options: MobileTerminalTabMountOptions = {}
 ): BackgroundMountTerminalWorktreeDetail | null {

--- a/src/renderer/src/lib/terminal-tab-for-pty-id.test.ts
+++ b/src/renderer/src/lib/terminal-tab-for-pty-id.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it } from 'vitest'
 import { resolveTerminalTabIdForPtyId } from './terminal-tab-for-pty-id'
 import type { AppState } from '@/store/types'
 
-type ResolverState = Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>
+type ResolverState = Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId'>
 
 function state(partial: {
   tabs?: Record<string, { id: string; ptyId?: string | null }[]>
   layouts?: Record<string, { ptyIdsByLeafId?: Record<string, string> }>
+  ptyIdsByTabId?: Record<string, string[]>
 }): ResolverState {
   return {
     tabsByWorktree: (partial.tabs ?? {}) as unknown as AppState['tabsByWorktree'],
-    terminalLayoutsByTabId: (partial.layouts ?? {}) as unknown as AppState['terminalLayoutsByTabId']
+    terminalLayoutsByTabId: (partial.layouts ??
+      {}) as unknown as AppState['terminalLayoutsByTabId'],
+    ptyIdsByTabId: partial.ptyIdsByTabId ?? {}
   }
 }
 
@@ -33,6 +36,14 @@ describe('resolveTerminalTabIdForPtyId', () => {
       layouts: { 'tab-a': { ptyIdsByLeafId: { leaf1: 'wt@@1', leaf2: 'wt@@9' } } }
     })
     expect(resolveTerminalTabIdForPtyId(s, 'wt', 'wt@@9')).toBe('tab-a')
+  })
+
+  it('matches a tab via the live ptyIdsByTabId map when layout is empty', () => {
+    const s = state({
+      tabs: { wt: [{ id: 'tab-live', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-live': ['wt@@live'] }
+    })
+    expect(resolveTerminalTabIdForPtyId(s, 'wt', 'wt@@live')).toBe('tab-live')
   })
 
   it('returns null when no tab owns the ptyId', () => {

--- a/src/renderer/src/lib/terminal-tab-for-pty-id.test.ts
+++ b/src/renderer/src/lib/terminal-tab-for-pty-id.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveTerminalTabIdForPtyId } from './terminal-tab-for-pty-id'
+import {
+  resolveTerminalTabIdForPtyId,
+  resolveTerminalTabPtyOwnership
+} from './terminal-tab-for-pty-id'
 import type { AppState } from '@/store/types'
 
 type ResolverState = Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId'>
@@ -17,8 +20,70 @@ function state(partial: {
   }
 }
 
-describe('resolveTerminalTabIdForPtyId', () => {
+describe('resolveTerminalTabPtyOwnership', () => {
   it('matches a tab by its own ptyId', () => {
+    const s = state({
+      tabs: {
+        wt: [
+          { id: 'tab-a', ptyId: 'wt@@1' },
+          { id: 'tab-b', ptyId: 'wt@@2' }
+        ]
+      }
+    })
+    expect(resolveTerminalTabPtyOwnership(s, 'wt', 'wt@@2')).toEqual({
+      kind: 'owned',
+      tabId: 'tab-b'
+    })
+  })
+
+  it('matches a tab by a split leaf ptyId in its saved layout', () => {
+    const s = state({
+      tabs: { wt: [{ id: 'tab-a', ptyId: null }] },
+      layouts: { 'tab-a': { ptyIdsByLeafId: { leaf1: 'wt@@1', leaf2: 'wt@@9' } } }
+    })
+    expect(resolveTerminalTabPtyOwnership(s, 'wt', 'wt@@9')).toEqual({
+      kind: 'owned',
+      tabId: 'tab-a'
+    })
+  })
+
+  it('matches a tab via the live ptyIdsByTabId map when layout is empty', () => {
+    const s = state({
+      tabs: { wt: [{ id: 'tab-live', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-live': ['wt@@live'] }
+    })
+    expect(resolveTerminalTabPtyOwnership(s, 'wt', 'wt@@live')).toEqual({
+      kind: 'owned',
+      tabId: 'tab-live'
+    })
+  })
+
+  it('returns none when no tab owns the ptyId', () => {
+    const s = state({ tabs: { wt: [{ id: 'tab-a', ptyId: 'wt@@1' }] } })
+    expect(resolveTerminalTabPtyOwnership(s, 'wt', 'wt@@nope')).toEqual({ kind: 'none' })
+  })
+
+  it('returns ambiguous when stale persistence binds the ptyId to multiple tabs', () => {
+    const s = state({
+      tabs: {
+        wt: [
+          { id: 'tab-a', ptyId: 'wt@@1' },
+          { id: 'tab-b', ptyId: null }
+        ]
+      },
+      layouts: { 'tab-b': { ptyIdsByLeafId: { leaf2: 'wt@@1' } } }
+    })
+    expect(resolveTerminalTabPtyOwnership(s, 'wt', 'wt@@1')).toEqual({ kind: 'ambiguous' })
+  })
+
+  it('returns none for an unknown worktree', () => {
+    const s = state({ tabs: { wt: [{ id: 'tab-a', ptyId: 'wt@@1' }] } })
+    expect(resolveTerminalTabPtyOwnership(s, 'other', 'wt@@1')).toEqual({ kind: 'none' })
+  })
+})
+
+describe('resolveTerminalTabIdForPtyId', () => {
+  it('returns the owning tab id when ownership is unique', () => {
     const s = state({
       tabs: {
         wt: [
@@ -30,29 +95,11 @@ describe('resolveTerminalTabIdForPtyId', () => {
     expect(resolveTerminalTabIdForPtyId(s, 'wt', 'wt@@2')).toBe('tab-b')
   })
 
-  it('matches a tab by a split leaf ptyId in its saved layout', () => {
-    const s = state({
-      tabs: { wt: [{ id: 'tab-a', ptyId: null }] },
-      layouts: { 'tab-a': { ptyIdsByLeafId: { leaf1: 'wt@@1', leaf2: 'wt@@9' } } }
-    })
-    expect(resolveTerminalTabIdForPtyId(s, 'wt', 'wt@@9')).toBe('tab-a')
-  })
+  it('returns null for none and for ambiguous ownership', () => {
+    const none = state({ tabs: { wt: [{ id: 'tab-a', ptyId: 'wt@@1' }] } })
+    expect(resolveTerminalTabIdForPtyId(none, 'wt', 'wt@@nope')).toBeNull()
 
-  it('matches a tab via the live ptyIdsByTabId map when layout is empty', () => {
-    const s = state({
-      tabs: { wt: [{ id: 'tab-live', ptyId: null }] },
-      ptyIdsByTabId: { 'tab-live': ['wt@@live'] }
-    })
-    expect(resolveTerminalTabIdForPtyId(s, 'wt', 'wt@@live')).toBe('tab-live')
-  })
-
-  it('returns null when no tab owns the ptyId', () => {
-    const s = state({ tabs: { wt: [{ id: 'tab-a', ptyId: 'wt@@1' }] } })
-    expect(resolveTerminalTabIdForPtyId(s, 'wt', 'wt@@nope')).toBeNull()
-  })
-
-  it('returns null when stale persistence binds the ptyId to multiple tabs', () => {
-    const s = state({
+    const ambiguous = state({
       tabs: {
         wt: [
           { id: 'tab-a', ptyId: 'wt@@1' },
@@ -61,11 +108,6 @@ describe('resolveTerminalTabIdForPtyId', () => {
       },
       layouts: { 'tab-b': { ptyIdsByLeafId: { leaf2: 'wt@@1' } } }
     })
-    expect(resolveTerminalTabIdForPtyId(s, 'wt', 'wt@@1')).toBeNull()
-  })
-
-  it('returns null for an unknown worktree', () => {
-    const s = state({ tabs: { wt: [{ id: 'tab-a', ptyId: 'wt@@1' }] } })
-    expect(resolveTerminalTabIdForPtyId(s, 'other', 'wt@@1')).toBeNull()
+    expect(resolveTerminalTabIdForPtyId(ambiguous, 'wt', 'wt@@1')).toBeNull()
   })
 })

--- a/src/renderer/src/lib/terminal-tab-for-pty-id.ts
+++ b/src/renderer/src/lib/terminal-tab-for-pty-id.ts
@@ -1,8 +1,13 @@
 import type { AppState } from '@/store/types'
 
-/** Resolve a synthetic mobile handle's ptyId through persisted tab and split bindings. */
+export type TerminalTabPtyOwnershipState = Pick<
+  AppState,
+  'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId'
+>
+
+/** Resolve a synthetic mobile handle's ptyId through live and persisted tab bindings. */
 export function resolveTerminalTabIdForPtyId(
-  state: Pick<AppState, 'tabsByWorktree' | 'terminalLayoutsByTabId'>,
+  state: TerminalTabPtyOwnershipState,
   worktreeId: string,
   ptyId: string
 ): string | null {
@@ -10,8 +15,11 @@ export function resolveTerminalTabIdForPtyId(
   let resolvedTabId: string | null = null
   for (const tab of tabs) {
     const ptyIdsByLeafId = state.terminalLayoutsByTabId[tab.id]?.ptyIdsByLeafId
+    // Why (#10486): mobile focus/reveal can race layout hydration; the live
+    // ptyIdsByTabId map still owns the binding when layout rows are empty.
     const ownsPty =
       tab.ptyId === ptyId ||
+      (state.ptyIdsByTabId[tab.id] ?? []).includes(ptyId) ||
       (ptyIdsByLeafId !== undefined && Object.values(ptyIdsByLeafId).includes(ptyId))
     if (!ownsPty) {
       continue

--- a/src/renderer/src/lib/terminal-tab-for-pty-id.ts
+++ b/src/renderer/src/lib/terminal-tab-for-pty-id.ts
@@ -5,12 +5,18 @@ export type TerminalTabPtyOwnershipState = Pick<
   'tabsByWorktree' | 'terminalLayoutsByTabId' | 'ptyIdsByTabId'
 >
 
-/** Resolve a synthetic mobile handle's ptyId through live and persisted tab bindings. */
-export function resolveTerminalTabIdForPtyId(
+/** Ownership of a PTY across tabs in one worktree. Ambiguous ≠ unowned. */
+export type TerminalTabPtyOwnership =
+  | { kind: 'owned'; tabId: string }
+  | { kind: 'none' }
+  | { kind: 'ambiguous' }
+
+/** Resolve a PTY through live and persisted tab bindings; never pick first-of-many. */
+export function resolveTerminalTabPtyOwnership(
   state: TerminalTabPtyOwnershipState,
   worktreeId: string,
   ptyId: string
-): string | null {
+): TerminalTabPtyOwnership {
   const tabs = state.tabsByWorktree[worktreeId] ?? []
   let resolvedTabId: string | null = null
   for (const tab of tabs) {
@@ -27,9 +33,19 @@ export function resolveTerminalTabIdForPtyId(
     if (resolvedTabId && resolvedTabId !== tab.id) {
       // Why: stale duplicate ownership must not attach whichever hidden tab
       // happens to appear first in persisted order.
-      return null
+      return { kind: 'ambiguous' }
     }
     resolvedTabId = tab.id
   }
-  return resolvedTabId
+  return resolvedTabId ? { kind: 'owned', tabId: resolvedTabId } : { kind: 'none' }
+}
+
+/** Resolve a synthetic mobile handle's ptyId; null for none or ambiguous. */
+export function resolveTerminalTabIdForPtyId(
+  state: TerminalTabPtyOwnershipState,
+  worktreeId: string,
+  ptyId: string
+): string | null {
+  const ownership = resolveTerminalTabPtyOwnership(state, worktreeId, ptyId)
+  return ownership.kind === 'owned' ? ownership.tabId : null
 }


### PR DESCRIPTION
## Summary

Fixes #10486 — viewing an active host terminal from a paired mobile client no longer opens a second desktop tab with the same session.

When mobile focus/reveal asks the host to surface a live PTY, the renderer must **adopt the existing tab** that already owns that PTY. Ownership was only checked via `tab.ptyId` / a partial map path; if the binding lived only in `terminalLayoutsByTabId` (or the live `ptyIdsByTabId` map was not consulted by the resolver), `createTab({ initialPtyId })` minted a duplicate UI tab on the same content.

### Changes
- `resolveTerminalTabIdForPtyId` also consults `ptyIdsByTabId`.
- `onCreateTerminal` reuses a tab resolved via that full ownership check before creating.
- Planner state for mobile tab mounts includes `ptyIdsByTabId` for consistent resolution.

## Test plan

- [x] `terminal-tab-for-pty-id.test.ts` (incl. live map ownership)
- [x] `mobile-terminal-tab-mount.test.ts`
- [ ] Manual: desktop agent terminal open → view from phone → return to desktop → only one tab for that session
- [ ] Manual: split-pane terminal leaf viewed from mobile still targets the parent tab

## ELI5

Viewing a live desktop terminal from mobile opened a second duplicate tab on the host. The host now reuses the existing tab that already owns that session instead of creating another one.
