### PR TITLE
fix(runtime): degrade focused terminal create on headless serve

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -12064,6 +12064,66 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('degrades focused terminal creates on headless serve instead of requiring a renderer window', async () => {
+    // Why (#10553): desktop clients always send presentation:'focused' for agent
+    // creates; headless orca serve must still return a handle, not hard-error.
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-focused-headless' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await expect(
+      runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        command: 'codex',
+        presentation: 'focused'
+      })
+    ).resolves.toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      surface: 'background',
+      handle: expect.stringMatching(/^term_/)
+    })
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        worktreeId: TEST_WORKTREE_ID,
+        persistHostSessionBinding: true
+      })
+    )
+  })
+
+  it('degrades focused createAgentSession on headless serve without a renderer window', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-agent-headless' })
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+    const clientOperationId = `${Date.now()}-0123456789abcdef0123456789abcdef`
+
+    await expect(
+      runtime.createAgentSession({
+        clientOperationId,
+        worktree: `path:${TEST_WORKTREE_PATH}`,
+        agent: 'codex',
+        prompt: 'hello',
+        presentation: 'focused'
+      })
+    ).resolves.toMatchObject({
+      disposition: 'created',
+      terminal: expect.objectContaining({
+        worktreeId: TEST_WORKTREE_ID,
+        surface: 'background',
+        handle: expect.stringMatching(/^term_/)
+      })
+    })
+    expect(spawn).toHaveBeenCalled()
+  })
+
   it('accepts renderer-backed terminal create replies only from the target renderer', async () => {
     const webContents = { send: vi.fn() }
     const send = vi.fn((_channel: string, payload: { requestId: string }) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -21621,7 +21621,12 @@ export class OrcaRuntimeService {
         // Why: `orca serve` exposes the local runtime without a renderer
         // window. Renderer-backed Codex terminals are preferred for the app,
         // but headless CLI users still need a usable terminal handle.
-        (opts.rendererBacked === true && rendererWindow === null))
+        (opts.rendererBacked === true && rendererWindow === null) ||
+        // Why (#10553): paired desktop clients send presentation:'focused' for
+        // agent creates. Without a BrowserWindow (headless `orca serve`), fall
+        // through to the headless spawn path instead of getAuthoritativeWindow()
+        // hard-erroring with "No renderer window available".
+        (requiresRendererFocus && availableAuthoritativeWindow === null))
 
     if (shouldCreateInBackground) {
       if (!this.ptyController?.spawn) {


### PR DESCRIPTION
## Summary

Fixes #10553 — agent creates from a paired desktop client against headless `orca serve` no longer fail with `No renderer window available`.

Since `terminal.createAgentSession`, clients send `presentation: 'focused'` for user-initiated agent creates. On a windowless serve host, that took the renderer-IPC path and called `getAuthoritativeWindow()`, which throws when `BrowserWindow.fromId` is null.

### Fix
If `presentation`/`focus` requires a renderer window but none is available, use the existing **headless/background** `createTerminal` path (same as non-focused CLI creates and `rendererBacked` without a window). The PTY still spawns; surface is returned as `background` with the usual optional reveal warning when no notifier can promote a tab.

## Test plan

- [x] `orca-runtime.test.ts` — focused create without window → background surface
- [x] `orca-runtime.test.ts` — focused `createAgentSession` without window
- [x] existing renderer-backed-without-window case still passes
- [ ] Manual: desktop client paired to headless `orca serve` can create agents without error

## ELI5

Creating a focused agent from a paired client against headless `orca serve` failed with "No renderer window." Focused creates now degrade gracefully to a windowless path so remote agents still start.
