### PR TITLE
fix(worktrees): let repos reveal coding-agent scratch worktrees

### DIFF
--- a/docs/agent-scratch-worktree-visibility.md
+++ b/docs/agent-scratch-worktree-visibility.md
@@ -1,0 +1,211 @@
+# Agent Scratch Worktree Visibility
+
+## Problem
+
+\#9535 classified `<repo>/.claude/worktrees/**` and `<repo>/.gsd-workspaces/**` as
+`agent-scratch` and suppressed them unconditionally so sub-agent fan-out stops flooding the
+sidebar (#9388). The suppression has no opt-out, and it removed every surface that could
+explain or undo it.
+
+- `shouldShowWorktree` returns `false` for `agent-scratch` before it consults
+  `externalWorktreeVisibility`, so setting a repo to `show` has no effect on these worktrees.
+- Every recovery surface funnels through `isUserFacingExternalWorktree`, which excludes
+  `agent-scratch`. The sidebar row is absent, the `Hiding N discovered worktrees` line never
+  renders, the new-external-worktree inbox never offers the path, and the `Non-Orca worktrees`
+  dialog reports `0 worktrees currently shown` while the worktree sits on disk.
+- `importedExternalWorktreePaths` is the only field that overrides the gate, and its only
+  writer is the inbox — which excludes `agent-scratch`. No in-app path reveals the worktree.
+
+This is not a hypothetical. Claude Code's `claude -w` / `--worktree` flag creates session
+worktrees at `<repo>/.claude/worktrees/<name>`; users who start parallel work there and
+continue it in Orca lose the worktree from the sidebar with no way to diagnose or recover.
+Observed after upgrading to 1.4.155 from a pre-1.4.148 build: four worktrees across three
+repos disappeared, all of them visible on the prior build. Orca still tracks them — it mints
+`worktreeMeta` entries with `workspaceStatus: "in-progress"` for paths the UI reports as `0`.
+
+`AGENT_SCRATCH_PATH_PREFIXES` is also a moving target by nature: agent CLIs and their plugins
+add and relocate scratch directories on their own schedule, so the list is always somewhat
+behind. That cuts both ways — a location the list misses spams the sidebar, and a location it
+covers vanishes silently. Curating the list more aggressively cannot resolve that tension on
+its own; users need to see what the list decided and be able to override it.
+
+## Goal
+
+Restore user control without reverting #9388.
+
+1. A repo-level opt-in that makes `agent-scratch` worktrees appear in the sidebar. The default
+   stays hidden.
+2. The `Non-Orca worktrees` dialog accounts for `agent-scratch` worktrees and offers that
+   toggle, so "why is my worktree missing" is answerable inside the app.
+
+Invariant: every worktree `git worktree list` reports is either unconditionally visible (the
+selected checkout, an explicit import, or `orca-managed`) or counted in exactly one of the four
+accessor buckets — `getHiddenExternalWorktrees`, `getVisibleExternalWorktrees`,
+`getHiddenAgentScratchWorktrees`, `getVisibleAgentScratchWorktrees` (the dialog itself reads
+only one scratch bucket at a time, based on the setting). This catches a worktree being
+**dropped** from every bucket; it does not catch a worktree being **misclassified** into the
+wrong one.
+
+## Non-goals
+
+- **Changing the default.** Agent scratch stays hidden unless the user opts in. The #9388
+  fan-out protection is unchanged.
+- **Changing `AGENT_SCRATCH_PATH_PREFIXES`.** No scratch locations are added or removed here.
+  Adding one hides worktrees that are visible today, which is the very regression this change
+  exists to make recoverable, so it should not ride along with the fix.
+- **Per-path selection for agent scratch.** Repo-level is sufficient;
+  `importedExternalWorktreePaths` already covers the per-path case for worktrees that reach
+  the inbox.
+- **Re-attributing agent sessions on pane `cd`.** Agent rows derive from `tabsByWorktree`
+  (`useWorktreeAgentRows.ts:47`) and bind at pane creation, so running `claude -w` inside a
+  split pane leaves its agent under the original worktree row. That is a different subsystem
+  and a separate design question; this change does not address it.
+
+## Design
+
+### Data model
+
+One optional field on `Repo`, beside `externalWorktreeVisibility`:
+
+```ts
+/** Controls whether coding-agent scratch worktrees (.claude/worktrees, …) reach the sidebar. */
+agentWorktreeVisibility?: ExternalWorktreeVisibility
+```
+
+Reuses the existing `'show' | 'hide'` union. Absent means hide, which matches today's
+behavior, so no migration and no legacy-repo carve-out — unlike
+`externalWorktreeVisibility`, this setting has no pre-rollout meaning to preserve.
+
+Named `agentWorktreeVisibility`, not `agentScratchWorktreeVisibility`, deliberately: it matches
+the user-facing "Agent worktrees" copy rather than the `agent-scratch` code vocabulary. That
+divergence from the code's naming is intentional, not an oversight — renaming a persisted field
+later needs a migration, so the rationale is recorded here.
+
+### Visibility gate
+
+`shouldShowWorktree` (`worktree-ownership.ts:242-244`) trades its unconditional `false` for a
+repo lookup:
+
+```ts
+if (args.ownership === 'agent-scratch') {
+  return args.repo.agentWorktreeVisibility === 'show'
+}
+```
+
+The earlier selected-checkout (`:227`) and explicit-import (`:234`) branches keep their
+precedence. `applyMetadataFallbackVisibility` (`:251-255`) keeps its scratch early-return:
+when metadata lookup fails the fallback fails open, and scratch must not flood in on that
+path.
+
+### Counting
+
+`isUserFacingExternalWorktree` (`external-worktree-inbox.ts:57-63`) is left alone. It feeds
+the sidebar `Hiding N discovered worktrees` line, the discovery card, and the
+new-external-worktree inbox; unfiltering it there would reinstate the #9388 spam. Two new
+accessors serve the dialog instead:
+
+```ts
+export function getHiddenAgentScratchWorktrees(detected): DetectedWorktree[]
+export function getVisibleAgentScratchWorktrees(detected): DetectedWorktree[]
+```
+
+The pair mirrors the existing `getHiddenExternalWorktrees` / `getVisibleExternalWorktrees`, so
+the dialog reads the hidden count while the setting is off and the shown count while it is on.
+
+Only `WorktreeVisibilityDialog` consumes them. The inbox and discovery card are untouched.
+
+### UI
+
+`WorktreeVisibilityDialog` gains a second row below the existing one:
+
+```text
+┌─ Non-Orca worktrees ──────────────────────┐
+│  pilot                                    │
+│  ┌───────────────────────────────────────┐│
+│  │ 👁  Shown in sidebar                  ││
+│  │    0 worktrees currently shown  [Hide]││
+│  └───────────────────────────────────────┘│
+│  ┌───────────────────────────────────────┐│
+│  │ 🤖  Agent worktrees hidden            ││
+│  │    1 in .claude/worktrees/     [Show] ││
+│  └───────────────────────────────────────┘│
+└───────────────────────────────────────────┘
+```
+
+- The subtitle names the parent path group (reusing `getExternalWorktreeParentPath`) so the
+  reason for the absence is legible where the fix is — unless the hidden worktrees span more
+  than one parent, in which case it reports a location count instead of naming just one of them.
+- The row is omitted when the repo has not opted in and has no agent-scratch worktrees.
+  Once opted in, the row always renders — including with zero worktrees currently present —
+  so the opt-in stays visible and reversible.
+- Toggling refreshes via `fetchWorktrees(repoId, { requireAuthoritative: true })` and rolls
+  the field back on failure, following `showImportedWorktreesCard`
+  (`imported-worktrees-card-actions.ts:47-66`).
+- The project-menu item (`WorktreeList.tsx:4577`) is unchanged; the entry point stays put.
+
+## Data Flow
+
+`agentWorktreeVisibility` follows the route `externalWorktreeVisibility` already takes:
+
+```text
+WorktreeVisibilityDialog → store/slices/repos.ts → preload/api-types.ts
+  → main/ipc/repos.ts → runtime/rpc/methods/repo-update-schema.ts
+  → main/runtime/orca-runtime.ts → main/persistence.ts
+```
+
+Each hop carries a `Pick<Repo, …>` allowlist that must name the new field, and
+`repo-update-schema.ts` needs the matching zod entry. Detection is unchanged: `main/ipc/
+worktrees.ts` and `orca-runtime.ts` already build an `AgentScratchWorktreePathMatcher` per
+repo and pass it into `toDetectedWorktree`, which now resolves `visible` from the new field.
+
+## Edge Cases
+
+- **Selected checkout.** A scratch path registered as its own project stays visible
+  regardless of the setting — the `isSelectedCheckout` branch precedes the gate.
+- **Explicit import.** A path already in `importedExternalWorktreePaths` stays visible with
+  the setting off.
+- **Metadata fallback.** Detection failure keeps scratch hidden rather than failing open.
+- **Orca-created worktrees under a scratch path.** `hasStrongOrcaMetadata` still wins before
+  the path check, so an Orca-created worktree that happens to live under `.claude/worktrees/`
+  remains `orca-managed`.
+- **Setting on, zero scratch worktrees.** The second dialog row still renders, offering `Hide` —
+  the opt-in must stay visible and reversible even after the agent that created the worktrees
+  cleans them up, or there is no way to opt back out. Only the not-opted-in, zero-worktree case
+  omits the row.
+- **Scratch worktrees under more than one parent directory.** `AGENT_SCRATCH_PATH_PREFIXES`
+  covers more than one directory family and the matcher anchors to any registered checkout, so
+  hidden scratch worktrees can legitimately span multiple parents. The subtitle names the single
+  parent only when every hidden worktree shares one; otherwise it reports a location count
+  instead of naming just the first one's directory.
+- **Scan backoff.** #9985's 5-minute TTL for agent-scratch *repo roots*
+  (`isAgentScratchRepoRootPath`) is a separate matcher on repo paths and is unaffected.
+
+## Test Plan
+
+- `worktree-ownership.test.ts` — `agentWorktreeVisibility: 'show'` reveals scratch; absent and
+  `'hide'` keep it hidden. Selected-checkout and explicit-import precedence preserved.
+  `applyMetadataFallbackVisibility` still keeps scratch hidden.
+- `external-worktree-inbox.test.ts` — the new accessors return only agent scratch, and
+  `getHiddenExternalWorktrees` / `getVisibleExternalWorktrees` / inbox results are byte-for-byte
+  unchanged. This is the #9535 regression guard.
+- `WorktreeVisibilityDialog` — second row renders with count and parent path; omitted when not
+  opted in with zero worktrees, but stays visible with a `Hide` control when opted in with zero;
+  names a location count instead of a single path when hidden worktrees span multiple parents;
+  toggle failure rolls the field back and surfaces the error, and stays visible even if the
+  rollback write itself fails.
+- **Invariant test** — for a repo whose `git worktree list` includes the main checkout, an
+  Orca-created worktree, a plain external worktree, and a `.claude/worktrees/` worktree, each
+  is either unconditionally visible or counted in exactly one dialog row, with both settings
+  on and off. This is what stops a future path-list change from silently dropping a worktree
+  again.
+
+## Rollout
+
+No migration. The field is optional and its absence reproduces current behavior, so existing
+repos are untouched on upgrade. Users who lost worktrees to #9535 recover them from the
+project menu once this ships.
+
+Once a recovery path exists, adding a scratch location to
+`AGENT_SCRATCH_PATH_PREFIXES` stops being a one-way door — a user who disagrees with the
+classification can undo it from the project menu. That makes future list changes cheaper, but
+none are proposed here.

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -2099,6 +2099,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
             | 'issueSourcePreference'
             | 'forkSyncMode'
             | 'externalWorktreeVisibility'
+            | 'agentWorktreeVisibility'
             | 'externalWorktreeVisibilityPromptDismissedAt'
             | 'externalWorktreeInboxBaselinePaths'
             | 'importedExternalWorktreePaths'
@@ -2171,6 +2172,14 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         updates.externalWorktreeVisibility !== 'show'
       ) {
         delete updates.externalWorktreeVisibility
+      }
+      if (
+        'agentWorktreeVisibility' in updates &&
+        updates.agentWorktreeVisibility !== undefined &&
+        updates.agentWorktreeVisibility !== 'hide' &&
+        updates.agentWorktreeVisibility !== 'show'
+      ) {
+        delete updates.agentWorktreeVisibility
       }
       if (
         'externalWorktreeVisibilityPromptDismissedAt' in updates &&

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4230,6 +4230,19 @@ describe('Store', () => {
     ])
   })
 
+  it('persists agentWorktreeVisibility through updateRepo', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+
+    const updated = store.updateRepo('r1', { agentWorktreeVisibility: 'show' })
+    expect(updated).not.toBeNull()
+    expect(updated!.agentWorktreeVisibility).toBe('show')
+    expect(store.getRepo('r1')!.agentWorktreeVisibility).toBe('show')
+
+    store.updateRepo('r1', { agentWorktreeVisibility: 'hide' })
+    expect(store.getRepo('r1')!.agentWorktreeVisibility).toBe('hide')
+  })
+
   it('updateRepo keeps project host setup compatibility records in sync', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ worktreeBasePath: '../worktrees' }))

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4812,6 +4812,7 @@ export class Store {
         | 'issueSourcePreference'
         | 'forkSyncMode'
         | 'externalWorktreeVisibility'
+        | 'agentWorktreeVisibility'
         | 'externalWorktreeVisibilityPromptDismissedAt'
         | 'externalWorktreeInboxBaselinePaths'
         | 'importedExternalWorktreePaths'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -18813,6 +18813,7 @@ export class OrcaRuntimeService {
         | 'symlinkPaths'
         | 'issueSourcePreference'
         | 'externalWorktreeVisibility'
+        | 'agentWorktreeVisibility'
         | 'externalWorktreeVisibilityPromptDismissedAt'
         | 'externalWorktreeInboxBaselinePaths'
         | 'importedExternalWorktreePaths'

--- a/src/main/runtime/rpc/methods/repo-update-schema.ts
+++ b/src/main/runtime/rpc/methods/repo-update-schema.ts
@@ -51,6 +51,7 @@ export function createRepoUpdateSchema<T extends z.ZodRawShape>(
       issueSourcePreference: z.enum(['auto', 'upstream', 'origin']).optional(),
       forkSyncMode: z.enum(['ask', 'safe-auto', 'off']).optional(),
       externalWorktreeVisibility: z.enum(['hide', 'show']).optional(),
+      agentWorktreeVisibility: z.enum(['hide', 'show']).optional(),
       externalWorktreeVisibilityPromptDismissedAt: z.number().finite().optional(),
       externalWorktreeInboxBaselinePaths: z.array(z.string()).optional(),
       importedExternalWorktreePaths: z.array(z.string()).optional(),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1250,6 +1250,7 @@ export type PreloadApi = {
           | 'kind'
           | 'issueSourcePreference'
           | 'externalWorktreeVisibility'
+          | 'agentWorktreeVisibility'
           | 'externalWorktreeVisibilityPromptDismissedAt'
           | 'externalWorktreeInboxBaselinePaths'
           | 'importedExternalWorktreePaths'

--- a/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.agent-worktrees.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.agent-worktrees.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment happy-dom
+
+import type { ReactNode } from 'react'
+import '@testing-library/jest-dom/vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DetectedWorktree } from '../../../../shared/types'
+
+const mocks = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mocks.state)
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h1>{children}</h1>
+}))
+
+afterEach(cleanup)
+
+import WorktreeVisibilityDialog from './WorktreeVisibilityDialog'
+
+function scratchWorktreeAt(path: string, visible: boolean): DetectedWorktree {
+  return {
+    id: path,
+    path,
+    ownership: 'agent-scratch',
+    selectedCheckout: false,
+    visible
+  } as unknown as DetectedWorktree
+}
+
+function hiddenScratchAt(path: string): DetectedWorktree {
+  return scratchWorktreeAt(path, false)
+}
+
+function visibleScratchAt(path: string): DetectedWorktree {
+  return scratchWorktreeAt(path, true)
+}
+
+function renderDialog(options: {
+  repo?: Record<string, unknown>
+  detected?: DetectedWorktree[]
+  fetchWorktreesResult?: boolean
+  // Why: scripted per-call resolutions so a rollback write can be made to fail
+  // independently of the initial write, matching the real store's call order.
+  updateRepoResults?: boolean[]
+}): {
+  updateRepo: ReturnType<typeof vi.fn>
+  fetchWorktrees: ReturnType<typeof vi.fn>
+  closeModal: ReturnType<typeof vi.fn>
+} {
+  const updateRepoResults = options.updateRepoResults ?? []
+  let updateRepoCallCount = 0
+  // Why: mutates state like the real store, so a stuck-after-failed-rollback
+  // field can actually flip which bucket the row reads from mid-test.
+  const updateRepo = vi.fn(async (_projectId: string, updates: Record<string, unknown>) => {
+    const result =
+      updateRepoCallCount < updateRepoResults.length ? updateRepoResults[updateRepoCallCount] : true
+    updateRepoCallCount += 1
+    if (result) {
+      Object.assign((mocks.state.repos as Record<string, unknown>[])[0], updates)
+    }
+    return result
+  })
+  const fetchWorktrees = vi.fn().mockResolvedValue(options.fetchWorktreesResult ?? true)
+  const closeModal = vi.fn()
+  mocks.state = {
+    activeModal: 'worktree-visibility',
+    modalData: { repoId: 'repo-1' },
+    closeModal,
+    repos: [
+      {
+        id: 'repo-1',
+        kind: 'git',
+        displayName: 'orca',
+        path: '/repos/app',
+        ...options.repo
+      }
+    ],
+    updateRepo,
+    fetchWorktrees,
+    detectedWorktreesByRepo: {
+      'repo-1': { authoritative: true, worktrees: options.detected ?? [] }
+    }
+  }
+  render(<WorktreeVisibilityDialog />)
+  return { updateRepo, fetchWorktrees, closeModal }
+}
+
+describe('WorktreeVisibilityDialog agent worktrees row', () => {
+  it('shows the hidden count and parent path when the repo has not opted in', async () => {
+    renderDialog({
+      repo: { agentWorktreeVisibility: undefined },
+      detected: [hiddenScratchAt('/repos/app/.claude/worktrees/eager-dazzling-rose')]
+    })
+
+    expect(await screen.findByText(/Agent worktrees hidden/i)).toBeInTheDocument()
+    expect(screen.getByText('/repos/app/.claude/worktrees')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Show agent worktrees$/ })).toBeInTheDocument()
+  })
+
+  it('omits the row when the repo has no agent scratch worktrees', () => {
+    renderDialog({
+      repo: { agentWorktreeVisibility: undefined, externalWorktreeVisibility: 'hide' },
+      detected: []
+    })
+
+    expect(screen.queryByText(/Agent worktrees/i)).not.toBeInTheDocument()
+    // Why: a positive anchor — without it this assertion would also pass if
+    // the whole dialog failed to render, not just this row.
+    expect(screen.getByText(/Hidden from sidebar/i)).toBeInTheDocument()
+  })
+
+  it('writes the opt-in and refreshes without closing the dialog', async () => {
+    const { updateRepo, fetchWorktrees, closeModal } = renderDialog({
+      repo: { agentWorktreeVisibility: undefined },
+      detected: [hiddenScratchAt('/repos/app/.claude/worktrees/eager-dazzling-rose')]
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /^Show agent worktrees$/ }))
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { agentWorktreeVisibility: 'show' })
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { requireAuthoritative: true })
+    expect(closeModal).not.toHaveBeenCalled()
+  })
+
+  it('rolls the field back and surfaces an error when the refresh fails', async () => {
+    const { updateRepo } = renderDialog({
+      repo: { agentWorktreeVisibility: undefined },
+      detected: [hiddenScratchAt('/repos/app/.claude/worktrees/eager-dazzling-rose')],
+      fetchWorktreesResult: false
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /^Show agent worktrees$/ }))
+
+    expect(updateRepo).toHaveBeenLastCalledWith('repo-1', { agentWorktreeVisibility: 'hide' })
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Could not show agent worktrees/i)
+  })
+
+  it('keeps the row and its error visible when the rollback write also fails', async () => {
+    renderDialog({
+      repo: { agentWorktreeVisibility: undefined },
+      detected: [hiddenScratchAt('/repos/app/.claude/worktrees/eager-dazzling-rose')],
+      fetchWorktreesResult: false,
+      // Why: first call (the opt-in write) succeeds and sticks; second call
+      // (the rollback) fails, leaving agentWorktreeVisibility stuck at 'show'
+      // against the stale, unrefreshed `detected` list.
+      updateRepoResults: [true, false]
+    })
+
+    await userEvent.click(screen.getByRole('button', { name: /^Show agent worktrees$/ }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Could not show agent worktrees/i)
+    // Why: /Agent worktrees/i alone also matches the error text above — assert
+    // the row's title specifically to confirm the row itself, not just the
+    // alert, survived the stuck-visibility flip.
+    expect(screen.getByText(/Agent worktrees shown/i)).toBeInTheDocument()
+  })
+
+  it('offers Hide with the shown count once opted in', () => {
+    renderDialog({
+      repo: { agentWorktreeVisibility: 'show' },
+      detected: [visibleScratchAt('/repos/app/.claude/worktrees/eager-dazzling-rose')]
+    })
+
+    expect(screen.getByText(/1 currently shown/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Hide agent worktrees$/ })).toBeInTheDocument()
+  })
+
+  it('keeps the row visible with a Hide control when opted in but currently empty', () => {
+    // Why: the agent finished and cleaned up its scratch worktree, so the
+    // hidden/visible buckets are both empty even though the repo opted in —
+    // the row must not disappear, or there is no way to opt back out.
+    renderDialog({
+      repo: { agentWorktreeVisibility: 'show' },
+      detected: []
+    })
+
+    expect(screen.getByText(/Agent worktrees shown/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^Hide agent worktrees$/ })).toBeInTheDocument()
+  })
+
+  it('keeps the min-w-0 chain that lets the path truncate instead of overflowing the dialog', () => {
+    // Why: happy-dom computes no real layout — getBoundingClientRect and
+    // scrollWidth/clientWidth all report 0 (verified empirically) — so this
+    // cannot assert actual truncation or that the row stays inside the
+    // dialog. It can only guard the specific utility classes a real browser
+    // needs for that to happen, which is exactly what shipped broken
+    // silently before: `flex-1` on the label defeats truncate (flex-basis:0
+    // forces it to claim all row slack instead of shrinking), and the two
+    // ancestor `div`s between the label and DialogContent's grid need
+    // min-w-0 or their intrinsic content width — the full untruncated path —
+    // inflates the shared grid column and drags the sibling non-Orca row's
+    // width along with it. The e2e harness is the only real guard for the
+    // geometry itself; see tests/e2e/zz-agent-scratch-visibility-*.spec.ts.
+    renderDialog({
+      repo: { agentWorktreeVisibility: undefined },
+      detected: [hiddenScratchAt('/repos/app/.claude/worktrees/eager-dazzling-rose')]
+    })
+
+    const label = screen.getByText('/repos/app/.claude/worktrees')
+    const labelClasses = label.className.split(' ')
+    expect(labelClasses).not.toContain('flex-1')
+    expect(labelClasses).toContain('min-w-0')
+    expect(labelClasses).toContain('truncate')
+
+    const subtitleRow = label.parentElement
+    const contentColumn = subtitleRow?.parentElement
+    const borderedRow = contentColumn?.parentElement
+    const gridWrapper = borderedRow?.parentElement
+    expect(borderedRow?.className.split(' ')).toContain('min-w-0')
+    expect(gridWrapper?.className.split(' ')).toContain('min-w-0')
+  })
+
+  it('shows a location count instead of a single path when scratch worktrees span multiple locations', () => {
+    renderDialog({
+      repo: { agentWorktreeVisibility: undefined },
+      detected: [
+        hiddenScratchAt('/repos/app/.claude/worktrees/eager-dazzling-rose'),
+        hiddenScratchAt('/repos/app/.gsd-workspaces/brave-comet')
+      ]
+    })
+
+    expect(screen.getByText(/2 across 2 locations/i)).toBeInTheDocument()
+    // Why: naming just the first worktree's parent would misreport where the
+    // second one actually lives — assert neither single path is shown alone.
+    expect(screen.queryByText('/repos/app/.claude/worktrees')).not.toBeInTheDocument()
+    expect(screen.queryByText('/repos/app/.gsd-workspaces')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from 'react'
-import { Eye, EyeOff } from 'lucide-react'
+import React, { useCallback, useState } from 'react'
+import { Bot, Eye, EyeOff } from 'lucide-react'
 import { useAppStore } from '@/store'
 import {
   Dialog,
@@ -10,7 +10,9 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import {
+  getHiddenAgentScratchWorktrees,
   getHiddenExternalWorktrees,
+  getVisibleAgentScratchWorktrees,
   getVisibleExternalWorktrees
 } from '../../../../shared/external-worktree-inbox'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
@@ -19,6 +21,13 @@ import {
   isLegacyRepoForExternalWorktreeVisibility
 } from '../../../../shared/worktree-ownership'
 import { translate } from '@/i18n/i18n'
+import { groupWorktreesByParentPath } from './ImportedWorktreesVisibilityLine'
+import { TruncatedSidebarLabel } from './truncated-sidebar-label'
+
+// Why: locales reorder count/path in the sentence (#9294-style); translate the
+// whole sentence with the path as a sentinel token, then split on it to embed
+// the path in its own element. NUL cannot appear in a real filesystem path.
+const AGENT_PARENT_PATH_TOKEN = '\u0000'
 
 export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
   const activeModal = useAppStore((s) => s.activeModal)
@@ -41,6 +50,30 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
   const hiddenWorktreeLabel = `${hiddenCount} ${hiddenCount === 1 ? 'worktree' : 'worktrees'}`
   const shownWorktreeLabel = `${otherCount} ${otherCount === 1 ? 'worktree' : 'worktrees'}`
 
+  const [agentError, setAgentError] = useState<string | null>(null)
+  const [agentPending, setAgentPending] = useState(false)
+  // Why: if the rollback updateRepo also fails, agentWorktreeVisibility is
+  // stuck at the failed `next` value, which can flip which (now-stale) bucket
+  // agentWorktrees reads to an empty one — force the row to stay rendered so
+  // the error below doesn't vanish with it.
+  const [agentForceVisible, setAgentForceVisible] = useState(false)
+  const showAgent = repo?.agentWorktreeVisibility === 'show'
+  const agentWorktrees = showAgent
+    ? getVisibleAgentScratchWorktrees(detected)
+    : getHiddenAgentScratchWorktrees(detected)
+  // Why: AGENT_SCRATCH_PATH_PREFIXES spans multiple directory families and the
+  // matcher anchors to any registered checkout, so hidden scratch worktrees
+  // can legitimately sit under more than one parent — naming just the first
+  // one would misreport where the others actually are (see #agent-scratch-
+  // worktree-visibility.md "subtitle can name the wrong directory").
+  const agentWorktreeGroups = groupWorktreesByParentPath(agentWorktrees)
+  const agentParentPath = agentWorktreeGroups.length === 1 ? agentWorktreeGroups[0].path : ''
+  const [agentHiddenCountBeforePath, agentHiddenCountAfterPath] = translate(
+    'sidebar.worktreeVisibility.agentWorktrees.hiddenCount',
+    '{{count}} in {{path}}',
+    { count: agentWorktrees.length, path: AGENT_PARENT_PATH_TOKEN }
+  ).split(AGENT_PARENT_PATH_TOKEN)
+
   const handleToggle = useCallback(async () => {
     if (!repoId) {
       return
@@ -56,6 +89,47 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
     await fetchWorktrees(repoId)
     closeModal()
   }, [closeModal, fetchWorktrees, repoId, showOther, updateRepo])
+
+  // Why: unlike handleToggle, this must not close the dialog — the point of
+  // surfacing agent worktrees is letting the user watch the count move.
+  const handleToggleAgent = useCallback(async () => {
+    if (!repoId) {
+      return
+    }
+    const next = showAgent ? 'hide' : 'show'
+    const previous = showAgent ? 'show' : 'hide'
+    setAgentPending(true)
+    setAgentError(null)
+    setAgentForceVisible(false)
+    const failureMessage = showAgent
+      ? translate(
+          'sidebar.worktreeVisibility.agentWorktrees.hideError',
+          'Could not hide agent worktrees. Try again.'
+        )
+      : translate(
+          'sidebar.worktreeVisibility.agentWorktrees.showError',
+          'Could not show agent worktrees. Try again.'
+        )
+
+    const updated = await updateRepo(repoId, { agentWorktreeVisibility: next })
+    if (!updated) {
+      setAgentPending(false)
+      setAgentError(failureMessage)
+      return
+    }
+    const refreshed = await fetchWorktrees(repoId, { requireAuthoritative: true })
+    if (!refreshed) {
+      // Why: mirror showImportedWorktreesCard — a stale list must not look like a successful toggle.
+      const rolledBack = await updateRepo(repoId, { agentWorktreeVisibility: previous })
+      setAgentPending(false)
+      setAgentError(failureMessage)
+      if (!rolledBack) {
+        setAgentForceVisible(true)
+      }
+      return
+    }
+    setAgentPending(false)
+  }, [fetchWorktrees, repoId, showAgent, updateRepo])
 
   if (activeModal !== 'worktree-visibility' || !repo || !isGitRepoKind(repo)) {
     return null
@@ -114,6 +188,82 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
               : translate('auto.components.sidebar.WorktreeVisibilityDialog.f1f71b9f02', 'Import')}
           </Button>
         </div>
+
+        {showAgent || agentWorktrees.length > 0 || agentForceVisible ? (
+          <div className="grid min-w-0 gap-1">
+            <div className="flex min-w-0 items-center gap-3 rounded-lg border border-border bg-muted/30 p-3">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-background text-muted-foreground">
+                <Bot className="size-4" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium">
+                  {showAgent
+                    ? translate(
+                        'sidebar.worktreeVisibility.agentWorktrees.shownTitle',
+                        'Agent worktrees shown'
+                      )
+                    : translate(
+                        'sidebar.worktreeVisibility.agentWorktrees.hiddenTitle',
+                        'Agent worktrees hidden'
+                      )}
+                </div>
+                {showAgent ? (
+                  <div className="text-xs text-muted-foreground">
+                    {translate(
+                      'sidebar.worktreeVisibility.agentWorktrees.shownCount',
+                      '{{count}} currently shown',
+                      { count: agentWorktrees.length }
+                    )}
+                  </div>
+                ) : agentWorktreeGroups.length > 1 ? (
+                  <div className="text-xs text-muted-foreground">
+                    {translate(
+                      'sidebar.worktreeVisibility.agentWorktrees.hiddenCountAcrossLocations',
+                      '{{count}} across {{locations}} locations',
+                      { count: agentWorktrees.length, locations: agentWorktreeGroups.length }
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex min-w-0 items-center text-xs text-muted-foreground">
+                    <span className="shrink-0 whitespace-pre">{agentHiddenCountBeforePath}</span>
+                    <TruncatedSidebarLabel
+                      text={agentParentPath}
+                      tooltipSide="top"
+                      className="font-mono"
+                    />
+                    <span className="shrink-0 whitespace-pre">{agentHiddenCountAfterPath}</span>
+                  </div>
+                )}
+              </div>
+              <Button
+                type="button"
+                variant={showAgent ? 'secondary' : 'outline'}
+                disabled={agentPending}
+                aria-label={
+                  showAgent
+                    ? translate(
+                        'sidebar.worktreeVisibility.agentWorktrees.hideAriaLabel',
+                        'Hide agent worktrees'
+                      )
+                    : translate(
+                        'sidebar.worktreeVisibility.agentWorktrees.showAriaLabel',
+                        'Show agent worktrees'
+                      )
+                }
+                onClick={handleToggleAgent}
+              >
+                {showAgent
+                  ? translate('sidebar.worktreeVisibility.agentWorktrees.hide', 'Hide')
+                  : translate('sidebar.worktreeVisibility.agentWorktrees.show', 'Show')}
+              </Button>
+            </div>
+            {agentError ? (
+              <p className="px-1 text-[11px] leading-4 text-destructive" role="alert">
+                {agentError}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
       </DialogContent>
     </Dialog>
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -138,6 +138,23 @@
       "ariaActive": "Filter: {{value0}} active."
     }
   },
+  "sidebar": {
+    "worktreeVisibility": {
+      "agentWorktrees": {
+        "hiddenTitle": "Agent worktrees hidden",
+        "shownTitle": "Agent worktrees shown",
+        "hiddenCount": "{{count}} in {{path}}",
+        "hiddenCountAcrossLocations": "{{count}} across {{locations}} locations",
+        "shownCount": "{{count}} currently shown",
+        "show": "Show",
+        "hide": "Hide",
+        "showAriaLabel": "Show agent worktrees",
+        "hideAriaLabel": "Hide agent worktrees",
+        "showError": "Could not show agent worktrees. Try again.",
+        "hideError": "Could not hide agent worktrees. Try again."
+      }
+    }
+  },
   "auto": {
     "App": {
       "221a95ba38": "Retry onboarding or close it and continue in the app.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14723,5 +14723,22 @@
         "unknown": "Restart Orca to try again."
       }
     }
+  },
+  "sidebar": {
+    "worktreeVisibility": {
+      "agentWorktrees": {
+        "hiddenTitle": "Worktrees de agentes ocultos",
+        "shownTitle": "Worktrees de agentes mostrados",
+        "hiddenCount": "{{count}} en {{path}}",
+        "shownCount": "{{count}} mostrados actualmente",
+        "show": "Mostrar",
+        "hide": "Ocultar",
+        "showError": "No se pudieron mostrar los worktrees de agentes. Inténtalo de nuevo.",
+        "hideError": "No se pudieron ocultar los worktrees de agentes. Inténtalo de nuevo.",
+        "hiddenCountAcrossLocations": "{{count}} en {{locations}} ubicaciones",
+        "showAriaLabel": "Mostrar worktrees de agentes",
+        "hideAriaLabel": "Ocultar worktrees de agentes"
+      }
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14723,5 +14723,22 @@
         "unknown": "Restart Orca to try again."
       }
     }
+  },
+  "sidebar": {
+    "worktreeVisibility": {
+      "agentWorktrees": {
+        "hiddenTitle": "エージェントのワークツリーは非表示",
+        "shownTitle": "エージェントのワークツリーを表示中",
+        "hiddenCount": "{{path}}に{{count}}件",
+        "shownCount": "現在{{count}}件を表示中",
+        "show": "表示",
+        "hide": "非表示",
+        "showError": "エージェントのワークツリーを表示できませんでした。もう一度お試しください。",
+        "hideError": "エージェントのワークツリーを非表示にできませんでした。もう一度お試しください。",
+        "hiddenCountAcrossLocations": "{{locations}}箇所に{{count}}件",
+        "showAriaLabel": "エージェントのワークツリーを表示",
+        "hideAriaLabel": "エージェントのワークツリーを非表示"
+      }
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14734,5 +14734,22 @@
         "unknown": "Restart Orca to try again."
       }
     }
+  },
+  "sidebar": {
+    "worktreeVisibility": {
+      "agentWorktrees": {
+        "hiddenTitle": "에이전트 워크트리 숨겨짐",
+        "shownTitle": "에이전트 워크트리 표시됨",
+        "hiddenCount": "{{path}}에 {{count}}개",
+        "shownCount": "현재 {{count}}개 표시됨",
+        "show": "표시",
+        "hide": "숨기기",
+        "showError": "에이전트 워크트리를 표시할 수 없습니다. 다시 시도해 주세요.",
+        "hideError": "에이전트 워크트리를 숨길 수 없습니다. 다시 시도해 주세요.",
+        "hiddenCountAcrossLocations": "{{locations}}곳에 걸쳐 {{count}}개",
+        "showAriaLabel": "에이전트 워크트리 표시",
+        "hideAriaLabel": "에이전트 워크트리 숨기기"
+      }
+    }
   }
 }

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14743,5 +14743,22 @@
         "unknown": "请重启 Orca 以重试。"
       }
     }
+  },
+  "sidebar": {
+    "worktreeVisibility": {
+      "agentWorktrees": {
+        "hiddenTitle": "智能体工作树已隐藏",
+        "shownTitle": "智能体工作树已显示",
+        "hiddenCount": "{{path}} 中有 {{count}} 个",
+        "shownCount": "当前显示 {{count}} 个",
+        "show": "显示",
+        "hide": "隐藏",
+        "showError": "无法显示智能体工作树。请重试。",
+        "hideError": "无法隐藏智能体工作树。请重试。",
+        "hiddenCountAcrossLocations": "分布在 {{locations}} 个位置，共 {{count}} 个",
+        "showAriaLabel": "显示智能体工作树",
+        "hideAriaLabel": "隐藏智能体工作树"
+      }
+    }
   }
 }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -128,6 +128,7 @@ export type RepoUpdate = Partial<
     | 'issueSourcePreference'
     | 'forkSyncMode'
     | 'externalWorktreeVisibility'
+    | 'agentWorktreeVisibility'
     | 'externalWorktreeVisibilityPromptDismissedAt'
     | 'externalWorktreeInboxBaselinePaths'
     | 'importedExternalWorktreePaths'

--- a/src/shared/external-worktree-inbox.test.ts
+++ b/src/shared/external-worktree-inbox.test.ts
@@ -8,8 +8,10 @@ import type {
   Worktree
 } from './types'
 import {
+  getHiddenAgentScratchWorktrees,
   getHiddenExternalWorktrees,
   getNewExternalWorktreeInboxWorktrees,
+  getVisibleAgentScratchWorktrees,
   getVisibleExternalWorktrees,
   mergeExternalWorktreeInboxPaths,
   shouldOfferNewExternalWorktreeInbox
@@ -206,5 +208,75 @@ describe('external worktree inbox', () => {
         repo
       )
     ).toEqual([])
+  })
+})
+
+describe('agent scratch accessors', () => {
+  const scratch = {
+    id: 'agent-scratch',
+    path: '/repos/app/.claude/worktrees/eager-dazzling-rose',
+    ownership: 'agent-scratch' as const,
+    selectedCheckout: false,
+    visible: false
+  } as unknown as DetectedWorktree
+  const external = {
+    id: 'external',
+    path: '/repos/manual',
+    ownership: 'external' as const,
+    selectedCheckout: false,
+    visible: false
+  } as unknown as DetectedWorktree
+  const selectedScratch = {
+    id: 'selected-scratch',
+    path: '/repos/app/.claude/worktrees/adopted',
+    ownership: 'agent-scratch' as const,
+    selectedCheckout: true,
+    visible: true
+  } as unknown as DetectedWorktree
+
+  function detectedList(worktrees: DetectedWorktree[]): DetectedWorktreeListResult {
+    return { authoritative: true, worktrees } as unknown as DetectedWorktreeListResult
+  }
+
+  it('returns only hidden agent scratch worktrees', () => {
+    expect(getHiddenAgentScratchWorktrees(detectedList([scratch, external]))).toEqual([scratch])
+  })
+
+  it('returns only visible agent scratch worktrees', () => {
+    const revealed = { ...scratch, visible: true }
+    expect(getVisibleAgentScratchWorktrees(detectedList([revealed, external]))).toEqual([revealed])
+    expect(getHiddenAgentScratchWorktrees(detectedList([revealed]))).toEqual([])
+  })
+
+  it('excludes the selected checkout from both counts', () => {
+    // Why: the selected checkout is always shown and is not what the toggle governs.
+    expect(getVisibleAgentScratchWorktrees(detectedList([selectedScratch]))).toEqual([])
+    // Test the hidden count with an actual hidden selected scratch to ensure
+    // !worktree.selectedCheckout guard is exercised.
+    const hiddenSelected = detectedWorktree({
+      id: 'hidden-selected-scratch',
+      ownership: 'agent-scratch',
+      selectedCheckout: true,
+      visible: false
+    })
+    expect(getHiddenAgentScratchWorktrees(detectedList([hiddenSelected]))).toEqual([])
+  })
+
+  it('returns nothing for a non-authoritative result', () => {
+    const stale = {
+      authoritative: false,
+      worktrees: [scratch]
+    } as unknown as DetectedWorktreeListResult
+    expect(getHiddenAgentScratchWorktrees(stale)).toEqual([])
+    expect(getVisibleAgentScratchWorktrees(stale)).toEqual([])
+    expect(getHiddenAgentScratchWorktrees(undefined)).toEqual([])
+    expect(getVisibleAgentScratchWorktrees(undefined)).toEqual([])
+  })
+
+  it('keeps the external accessors free of agent scratch', () => {
+    // Why: #9535 regression guard — the discovery card and inbox read these.
+    const list = detectedList([scratch, { ...scratch, visible: true }, external])
+    expect(getHiddenExternalWorktrees(list)).toEqual([external])
+    expect(getVisibleExternalWorktrees(list)).toEqual([])
   })
 })

--- a/src/shared/external-worktree-inbox.ts
+++ b/src/shared/external-worktree-inbox.ts
@@ -54,6 +54,35 @@ export function getVisibleExternalWorktrees(
   )
 }
 
+export function getHiddenAgentScratchWorktrees(
+  detected: DetectedWorktreeListResult | undefined
+): DetectedWorktree[] {
+  return filterAgentScratchWorktrees(detected, false)
+}
+
+export function getVisibleAgentScratchWorktrees(
+  detected: DetectedWorktreeListResult | undefined
+): DetectedWorktree[] {
+  return filterAgentScratchWorktrees(detected, true)
+}
+
+function filterAgentScratchWorktrees(
+  detected: DetectedWorktreeListResult | undefined,
+  visible: boolean
+): DetectedWorktree[] {
+  if (detected?.authoritative !== true) {
+    return []
+  }
+  // Why: the selected checkout is always shown and is not governed by the
+  // agent-worktree toggle, so it belongs in neither count.
+  return detected.worktrees.filter(
+    (worktree) =>
+      worktree.visible === visible &&
+      worktree.ownership === 'agent-scratch' &&
+      !worktree.selectedCheckout
+  )
+}
+
 function isUserFacingExternalWorktree(worktree: DetectedWorktree): boolean {
   // Why: an explicit scratch import may be visible, but agent plumbing must
   // stay outside repo-wide discovery and visibility controls (#9388).

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -278,6 +278,8 @@ export type Repo = {
   gitRemoteIdentity?: GitRemoteIdentity | null
   /** Controls whether worktrees Orca did not create appear in the sidebar. */
   externalWorktreeVisibility?: ExternalWorktreeVisibility
+  /** Controls whether coding-agent scratch worktrees (.claude/worktrees, …) reach the sidebar. */
+  agentWorktreeVisibility?: ExternalWorktreeVisibility
   /** True when the repo predates hidden-by-default external worktrees. */
   externalWorktreeVisibilityLegacy?: boolean
   /** One-shot guard for the optional existing-user visibility prompt. */

--- a/src/shared/worktree-accounting-invariant.test.ts
+++ b/src/shared/worktree-accounting-invariant.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getHiddenAgentScratchWorktrees,
+  getHiddenExternalWorktrees,
+  getVisibleAgentScratchWorktrees,
+  getVisibleExternalWorktrees
+} from './external-worktree-inbox'
+import { buildKnownOrcaWorkspaceLayouts, toDetectedWorktree } from './worktree-ownership'
+import type {
+  DetectedWorktreeListResult,
+  ExternalWorktreeVisibility,
+  GlobalSettings,
+  Repo,
+  Worktree
+} from './types'
+
+const REPO_PATH = '/repos/app'
+const SETTINGS = {
+  workspaceDir: '/repos/workspaces',
+  nestWorkspaces: true,
+  workspaceDirHistory: []
+} as unknown as GlobalSettings
+
+// Every worktree git reports, one per ownership class the sidebar can produce.
+const PATHS = {
+  main: REPO_PATH,
+  orcaManaged: '/repos/workspaces/app/feature-x',
+  external: '/repos/manual-checkout',
+  agentScratch: `${REPO_PATH}/.claude/worktrees/eager-dazzling-rose`
+}
+
+function makeRepo(agentWorktreeVisibility?: ExternalWorktreeVisibility): Repo {
+  return {
+    id: 'repo-1',
+    path: REPO_PATH,
+    displayName: 'app',
+    badgeColor: '#000',
+    addedAt: Date.UTC(2026, 6, 1),
+    kind: 'git',
+    externalWorktreeVisibility: 'show',
+    externalWorktreeVisibilityLegacy: false,
+    ...(agentWorktreeVisibility ? { agentWorktreeVisibility } : {})
+  } as unknown as Repo
+}
+
+function makeWorktree(path: string): Worktree {
+  return {
+    id: `repo-1::${path}`,
+    repoId: 'repo-1',
+    path,
+    head: 'abc',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: path === REPO_PATH,
+    displayName: 'wt',
+    workspaceStatus: 'todo'
+  } as unknown as Worktree
+}
+
+function detectAll(repo: Repo): DetectedWorktreeListResult {
+  const layouts = buildKnownOrcaWorkspaceLayouts(SETTINGS, repo)
+  const worktrees = Object.values(PATHS).map((path) =>
+    toDetectedWorktree({
+      repo,
+      settings: SETTINGS,
+      worktree: makeWorktree(path),
+      knownOrcaLayouts: layouts,
+      // Only the Orca-created path carries creation metadata.
+      ...(path === PATHS.orcaManaged
+        ? { meta: { orcaCreatedAt: 1, displayName: '', comment: '' } as never }
+        : {})
+    })
+  )
+  return { authoritative: true, worktrees } as unknown as DetectedWorktreeListResult
+}
+
+describe('worktree accounting invariant', () => {
+  for (const setting of [undefined, 'hide', 'show'] as const) {
+    it(`accounts for every worktree with agentWorktreeVisibility=${setting ?? 'unset'}`, () => {
+      const repo = makeRepo(setting)
+      const detected = detectAll(repo)
+
+      const buckets = [
+        getHiddenExternalWorktrees(detected),
+        getVisibleExternalWorktrees(detected),
+        getHiddenAgentScratchWorktrees(detected),
+        getVisibleAgentScratchWorktrees(detected)
+      ]
+
+      for (const worktree of detected.worktrees) {
+        const alwaysVisible = worktree.selectedCheckout || worktree.ownership === 'orca-managed'
+        const hits = buckets.filter((bucket) => bucket.some((w) => w.id === worktree.id)).length
+
+        if (alwaysVisible) {
+          expect({ path: worktree.path, hits, visible: worktree.visible }).toEqual({
+            path: worktree.path,
+            hits: 0,
+            visible: true
+          })
+          continue
+        }
+        // Why: exactly one bucket — zero means the worktree is invisible everywhere,
+        // which is the #9535 failure mode this test exists to prevent.
+        expect({ path: worktree.path, hits }).toEqual({ path: worktree.path, hits: 1 })
+      }
+    })
+  }
+
+  it('moves agent scratch from the hidden bucket to the shown bucket on opt-in', () => {
+    expect(getHiddenAgentScratchWorktrees(detectAll(makeRepo())).map((w) => w.path)).toEqual([
+      PATHS.agentScratch
+    ])
+    expect(getVisibleAgentScratchWorktrees(detectAll(makeRepo('show'))).map((w) => w.path)).toEqual(
+      [PATHS.agentScratch]
+    )
+  })
+})

--- a/src/shared/worktree-ownership.test.ts
+++ b/src/shared/worktree-ownership.test.ts
@@ -580,4 +580,76 @@ describe('agent scratch worktrees', () => {
       })
     ).not.toBe('agent-scratch')
   })
+
+  it('reveals agent scratch when the repo opts in', () => {
+    expect(
+      shouldShowWorktree({
+        repo: makeRepo({ agentWorktreeVisibility: 'show' }),
+        worktree: makeWorktree({ path: scratchPath, isMainWorktree: false }),
+        ownership: 'agent-scratch',
+        isLegacyRepoForVisibility: false,
+        isSelectedCheckout: false
+      })
+    ).toBe(true)
+  })
+
+  it('keeps agent scratch hidden when the repo has not opted in', () => {
+    for (const repo of [makeRepo(), makeRepo({ agentWorktreeVisibility: 'hide' })]) {
+      expect(
+        shouldShowWorktree({
+          repo,
+          worktree: makeWorktree({ path: scratchPath, isMainWorktree: false }),
+          ownership: 'agent-scratch',
+          isLegacyRepoForVisibility: false,
+          isSelectedCheckout: false
+        })
+      ).toBe(false)
+    }
+  })
+
+  it('opts in independently of the non-Orca worktree setting', () => {
+    // Why: the two toggles are orthogonal; 'hide' for externals must not veto the opt-in.
+    expect(
+      shouldShowWorktree({
+        repo: makeRepo({
+          externalWorktreeVisibility: 'hide',
+          agentWorktreeVisibility: 'show'
+        }),
+        worktree: makeWorktree({ path: scratchPath, isMainWorktree: false }),
+        ownership: 'agent-scratch',
+        isLegacyRepoForVisibility: false,
+        isSelectedCheckout: false
+      })
+    ).toBe(true)
+  })
+
+  it('marks opted-in agent scratch visible end to end', () => {
+    const repo = makeRepo({ agentWorktreeVisibility: 'show' })
+    const settings = makeSettings()
+    const detected = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeWorktree({ path: scratchPath, isMainWorktree: false }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+
+    expect(detected).toMatchObject({ ownership: 'agent-scratch', visible: true })
+  })
+
+  it('preserves an opted-in reveal through the metadata fallback', () => {
+    const repo = makeRepo({ agentWorktreeVisibility: 'show' })
+    const settings = makeSettings()
+    const detected = toDetectedWorktree({
+      repo,
+      settings,
+      worktree: makeWorktree({ path: scratchPath, isMainWorktree: false }),
+      knownOrcaLayouts: buildKnownOrcaWorkspaceLayouts(settings, repo)
+    })
+
+    const result = applyMetadataFallbackVisibility(detected)
+    expect(result).toBe(detected)
+    // Why: identity alone holds for any agent-scratch worktree regardless of
+    // the setting — assert the reveal itself so a broken gate would fail this.
+    expect(result).toMatchObject({ visible: true })
+  })
 })

--- a/src/shared/worktree-ownership.ts
+++ b/src/shared/worktree-ownership.ts
@@ -221,10 +221,10 @@ export function shouldShowWorktree(args: {
   ) {
     return true
   }
-  // Why: agent scratch stays hidden even when the repo shows non-Orca
-  // worktrees; only an explicit import or selected checkout reveals it.
+  // Why: agent scratch stays hidden until the repo opts in; an explicit import
+  // or selected checkout still reveals it without the setting (#9388).
   if (args.ownership === 'agent-scratch') {
-    return false
+    return args.repo.agentWorktreeVisibility === 'show'
   }
   if (args.ownership === 'unknown-legacy' && args.isLegacyRepoForVisibility) {
     return true


### PR DESCRIPTION
## Problem

Since #9535 (fixing #9388), worktrees under `<repo>/.claude/worktrees/**` and `<repo>/.gsd-workspaces/**` are classified `agent-scratch` and suppressed **unconditionally**. That stops sub-agent fan-out from flooding the sidebar, which is the right default — but it left no way out and no trace.

A worktree created by Claude Code's `claude -w` lands in `<repo>/.claude/worktrees/<name>`. When a user starts parallel work there and wants to continue it in Orca, the worktree is simply gone:

- no sidebar row
- setting the repo to show non-Orca worktrees has no effect — `shouldShowWorktree` returns on the `agent-scratch` branch before it reaches that check
- the `Non-Orca worktrees` dialog reports `0 worktrees currently shown` while the worktree sits on disk, because every surface funnels through `isUserFacingExternalWorktree`, which excludes scratch
- `importedExternalWorktreePaths` is the only field that overrides the gate, and its only writer is the new-worktree inbox — which also excludes scratch

So there is no in-app path to see that the worktree exists, let alone recover it. Orca even mints `worktreeMeta` for these paths (with `workspaceStatus: "in-progress"`) while the UI reports `0`.

Reported after upgrading to 1.4.155 from a pre-1.4.148 build: four worktrees across three repos disappeared, all of them visible on the prior build.

This is the gap #7912 asks to close, and the diagnosis matches the confirming comment on that issue — `externalWorktreeVisibility: 'show'` stopped working as a workaround once the `agent-scratch` classification began running ahead of the visibility check.

## Fix

A per-repo `agentWorktreeVisibility` opt-in, **default hide**, so #9388's protection stays the default and no migration is needed — an absent field reproduces today's behavior exactly.

- `shouldShowWorktree`'s single `agent-scratch` branch now reads the field instead of returning `false`. Selected-checkout, `orca-managed`, and explicit-import branches keep their precedence.
- The `Non-Orca worktrees` dialog gains a second row that counts scratch worktrees and toggles the field. It names the containing directory — or a location count when they span more than one — because that path is the diagnostic payload. Once a repo has opted in the row stays visible even at zero, so the opt-in is always reversible.
- `isUserFacingExternalWorktree` is deliberately **untouched**, so the discovery card and the new-worktree inbox keep excluding scratch. Two sibling accessors serve the dialog instead.
- The project-menu entry point is unchanged.

### Accounting invariant

`src/shared/worktree-accounting-invariant.test.ts` asserts that every worktree `git worktree list` reports is either unconditionally visible (selected checkout, explicit import, or `orca-managed`) or counted in exactly one accessor bucket. It catches a worktree being *dropped* from every bucket — the failure mode above — and is what should stop a future `AGENT_SCRATCH_PATH_PREFIXES` change from reintroducing it. (It does not catch a *misclassification* that retags a worktree into a different bucket; that is stated in the design doc.)

## Relation to #7912

#7912 asks for agent-created worktrees to be adopted rather than hidden. Against its checklist:

- *Recognize agent-created worktrees as a distinct category* — already true via the `agent-scratch` class from #9535.
- *Adopt them without flipping `externalWorktreeVisibility` for every unrelated worktree* — this PR, via a separate `agentWorktreeVisibility` toggle.
- *Make the default discoverable* — this PR; the dialog row reports the count and the containing directory.
- *Detect them promptly, without a manual refresh* — **not addressed here.** The worktree scan caches `git worktree list` on a short TTL and `requireAuthoritative` does not bypass it, so a worktree created outside Orca takes a few seconds to appear. Separate change.

## Non-goals

- **No default change.** Agent scratch stays hidden unless the user opts in.
- **No `AGENT_SCRATCH_PATH_PREFIXES` change.** Adding a location hides worktrees that are visible today — the very regression this makes recoverable — so it should not ride along.
- **No agent-session re-attribution.** Running `claude -w` inside a split pane leaves its agent row under the original worktree, because agent rows derive from `tabsByWorktree` and bind at pane creation (`useWorktreeAgentRows.ts:47`). Different subsystem, separate discussion.

## Verification

Automated:

- `src/shared`, sidebar, `persistence`, `i18n` suites: **3079 passing**, output pristine
- `pnpm run typecheck` (all three projects): clean
- `pnpm run lint` (including `verify-localization-catalog`, `audit-localization-coverage`, `check-max-lines-ratchet`): clean
- three pre-existing sidebar spec failures (`mobile-sidebar-onboarding-badge`, `SidebarToolbar`, `LinearAgentSkillSetupPrompt.reminder-toast`) reproduce identically on the merge base and are untouched by this branch

Against the running app, driven through the repo's Playwright Electron harness with a real `git worktree add <repo>/.claude/worktrees/…`:

1. detected, classified `agent-scratch`, `visible: false`, **no sidebar row** — the reported bug
2. the dialog names the containing directory and offers Show
3. Show reveals the sidebar row, the dialog stays open and flips to the shown state, and `agentWorktreeVisibility` persists as `'show'`

That run is also what caught the path overflowing the dialog. `DialogContent` is a single-column grid, so a child at full content width inflates the shared column and stretches its siblings. Measured before and after:

```
before   dialog 540→972 (433px)   row0 564→1405   row1 564→1405
after    dialog 541→971 (431px)   row0 565→947    row1 565→947
```

`row0` is the pre-existing non-Orca row — it was being stretched by ours and returns to normal. Fixed with `min-w-0` on two containers so the path truncates instead.

<!--
  Screenshot 1 goes here: the dialog with the agent row in its hidden state —
  the row title, the containing directory, and the Show button, with the row
  inside the dialog bounds.
-->

<!--
  Screenshot 2 goes here: after clicking Show — the scratch worktree now has a
  sidebar row, and the dialog is still open with the row flipped to the shown
  state and a Hide button.
-->

### Reproducing it yourself

```bash
cd <a repo registered in Orca>
git worktree add -b some-branch .claude/worktrees/scratch-example
```

Wait a few seconds — the worktree scan caches `git worktree list` on a short TTL, so a worktree created outside Orca takes a moment to appear. Then: project menu → `Hide non-Orca worktrees` / `Show hidden worktrees` → the second row reports the count and its container → `Show`.

## Localization

The new row is filled in for all five catalogs, using each one's existing dominant terms, so it reads in the same language as the non-Orca row directly above it rather than falling back to English mid-dialog.

## Design doc

`docs/agent-scratch-worktree-visibility.md`, force-added past the `docs/**` gitignore entry, following the precedent in 70ff47ea9 and 3efc93090.

Refs #7912, #9388, #9535

## ELI5

Agent scratch worktrees (like Claude's .claude/worktrees) were always hidden with no way to open them in Orca. Repos can reveal those coding-agent worktrees when you need to continue work there.
