### PR TITLE
fix(sidebar): include folder workspaces in Cmd+Shift+Arrow cycling

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.arrow-cycling-folder-workspaces.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.arrow-cycling-folder-workspaces.test.tsx
@@ -1,0 +1,383 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  FolderWorkspace,
+  ProjectGroup,
+  Repo,
+  Worktree,
+  WorktreeCardProperty
+} from '../../../../shared/types'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mockStore = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>,
+  activateWorktreeFromSidebar: vi.fn(),
+  activateAndRevealWorktree: vi.fn(),
+  openModal: vi.fn()
+}))
+
+type WorktreeListComponent = React.ComponentType<{
+  scrollOffsetRef: React.RefObject<number>
+  scrollAnchorRef: React.RefObject<unknown>
+}>
+
+let WorktreeList: WorktreeListComponent
+
+vi.mock('@/store', () => {
+  const useAppStore = ((selector: (state: Record<string, unknown>) => unknown) =>
+    selector(mockStore.state)) as ((
+    selector: (state: Record<string, unknown>) => unknown
+  ) => unknown) & {
+    getState: () => Record<string, unknown>
+  }
+  useAppStore.getState = () => mockStore.state
+  return { useAppStore }
+})
+
+// Why: pin the platform so the chord below is deterministic instead of depending on the test env's userAgent.
+vi.mock('@/lib/shortcut-platform', () => ({
+  getShortcutPlatform: () => 'darwin'
+}))
+
+vi.mock('@tanstack/react-virtual', () => ({
+  defaultRangeExtractor: ({ startIndex, endIndex }: { startIndex: number; endIndex: number }) =>
+    Array.from({ length: endIndex - startIndex + 1 }, (_, index) => startIndex + index),
+  measureElement: () => 32,
+  useVirtualizer: ({ count }: { count: number }) => ({
+    elementsCache: new Map(),
+    getTotalSize: () => count * 96,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: `row-${index}`,
+        start: index * 96
+      })),
+    measureElement: vi.fn(),
+    scrollToIndex: vi.fn()
+  })
+}))
+
+vi.mock('@/hooks/useVirtualizedScrollAnchor', () => ({
+  VIRTUALIZED_SCROLL_ANCHOR_RECORD_EVENT: 'orca:test-record-scroll-anchor',
+  useVirtualizedScrollAnchor: vi.fn()
+}))
+
+vi.mock('./project-header-drag', () => ({
+  useRepoHeaderDrag: () => ({
+    state: { draggingRepoId: null, dropIndicatorY: null },
+    onHandlePointerDown: vi.fn()
+  }),
+  isRepoHeaderActionTarget: () => false
+}))
+
+vi.mock('@/components/ui/hover-card', () => ({
+  HoverCard: ({ children }: { children: ReactNode }) => <>{children}</>,
+  HoverCardContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  HoverCardTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onSelect }: { children: ReactNode; onSelect?: () => void }) => (
+    <button onClick={onSelect}>{children}</button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuSub: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuSubContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/lib/sidebar-worktree-activation', () => ({
+  activateWorktreeFromSidebar: mockStore.activateWorktreeFromSidebar
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: mockStore.activateAndRevealWorktree
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  getActiveRuntimeTarget: () => ({ kind: 'local' }),
+  callRuntimeRpc: vi.fn()
+}))
+
+vi.mock('./WorktreeCardAgents', () => ({
+  default: () => <div>Agent row</div>,
+  SUPPRESS_WORKTREE_LIST_SCROLL_ADJUSTMENT_EVENT: 'orca:test-suppress-scroll-adjustment'
+}))
+
+vi.mock('./WorktreeCard', async () => {
+  const ReactModule = await import('react')
+  const MockWorktreeCard = ReactModule.memo(function WorktreeCard({
+    worktree
+  }: {
+    worktree: Worktree
+  }) {
+    return <div data-mock-worktree-card={worktree.id} />
+  })
+  return { default: MockWorktreeCard }
+})
+
+const REPO_ID = 'repo-1'
+const FOLDER_WORKSPACE_ID = 'folder-1'
+const FOLDER_WORKSPACE_KEY = folderWorkspaceKey(FOLDER_WORKSPACE_ID)
+
+function makeRepo(): Repo {
+  return {
+    id: REPO_ID,
+    path: '/tmp/arrow-cycling',
+    displayName: 'arrow-cycling',
+    badgeColor: '#999999',
+    addedAt: 1
+  }
+}
+
+function makeWorktree(id: string, sortOrder: number): Worktree {
+  return {
+    id,
+    instanceId: `${id}-instance`,
+    repoId: REPO_ID,
+    path: `/tmp/arrow-cycling/${id}`,
+    displayName: id,
+    branch: `${id}-branch`,
+    head: 'abc123',
+    isBare: false,
+    isMainWorktree: false,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder,
+    lastActivityAt: sortOrder
+  }
+}
+
+function makeProjectGroup(): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Group 1',
+    parentPath: '/tmp/arrow-cycling-group',
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+function makeFolderWorkspace(): FolderWorkspace {
+  return {
+    id: FOLDER_WORKSPACE_ID,
+    projectGroupId: 'group-1',
+    name: 'Folder 1',
+    folderPath: '/tmp/arrow-cycling-group/folder-1',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 1,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+function setSidebarState(activeWorktreeId: string | null): void {
+  const repo = makeRepo()
+  mockStore.state = {
+    fetchFolderWorkspacePathStatus: vi.fn(),
+    folderWorkspacePathStatuses: {},
+    folderWorkspaces: [makeFolderWorkspace()],
+    getFolderWorkspacePathStatusCacheKey: (request: unknown) => JSON.stringify(request),
+    getFreshFolderWorkspacePathStatus: vi.fn(() => null),
+    // Why 'none': the keydown handler bails on any open modal.
+    activeModal: 'none',
+    activeView: 'terminal',
+    activeWorkspaceKey: null,
+    activeWorktreeId,
+    agentStatusByPaneKey: {},
+    agentStatusEpoch: 0,
+    browserTabsByWorktree: {},
+    clearPendingRevealWorktreeId: vi.fn(),
+    collapsedGroups: new Set<string>(),
+    deleteStateByWorktreeId: {},
+    detectedWorktreesByRepo: {},
+    fetchHostedReviewForBranch: vi.fn(),
+    fetchIssue: vi.fn(),
+    fetchLinearIssue: vi.fn(),
+    filterRepoIds: [],
+    gitConflictOperationByWorktree: {},
+    // Why 'repo': buildRows only emits project-group and folder-workspace rows in this grouping mode.
+    groupBy: 'repo',
+    hideDefaultBranchWorkspace: false,
+    hostedReviewCache: {},
+    issueCache: {},
+    keybindings: undefined,
+    linearIssueCache: {},
+    linearStatus: null,
+    migrationUnsupportedByPtyId: {},
+    openModal: mockStore.openModal,
+    openSettingsPage: vi.fn(),
+    openSettingsTarget: null,
+    openTaskPage: vi.fn(),
+    pendingRevealWorktree: null,
+    prCache: {},
+    projectGroups: [makeProjectGroup()],
+    ptyIdsByTabId: {},
+    recordFeatureInteraction: vi.fn(),
+    remoteBranchConflictByWorktreeId: {},
+    reorderRepos: vi.fn(),
+    reportVisibleGitHubPRRefreshCandidates: vi.fn(),
+    repos: [repo],
+    retainedAgentsByPaneKey: {},
+    revealWorktreeInSidebar: vi.fn(),
+    runtimePaneTitlesByTabId: {},
+    setFilterRepoIds: vi.fn(),
+    setHideDefaultBranchWorkspace: vi.fn(),
+    setRenamingWorktreeId: vi.fn(),
+    setShowSleepingWorkspaces: vi.fn(),
+    setSortBy: vi.fn(),
+    setWorktreesPinnedAndReveal: vi.fn(),
+    settings: null,
+    showSleepingWorkspaces: true,
+    sortBy: 'manual',
+    sortEpoch: 0,
+    sshConnectedGeneration: 0,
+    sshConnectionStates: new Map(),
+    sshTargetLabels: new Map(),
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    toggleCollapsedGroup: vi.fn(),
+    updateRepo: vi.fn(),
+    updateWorktreeMeta: vi.fn(),
+    updateWorktreesMeta: vi.fn(),
+    workspaceHostScope: 'all',
+    workspacePortScan: null,
+    workspaceStatuses: [],
+    worktreeCardProperties: ['status', 'pr', 'comment'] satisfies WorktreeCardProperty[],
+    worktreeLineageById: {},
+    worktreeNavHistory: [],
+    worktreeNavHistoryIndex: -1,
+    worktreesByRepo: {
+      [REPO_ID]: [makeWorktree('wt-a', 20), makeWorktree('wt-b', 10)]
+    }
+  }
+}
+
+const mountedRoots: Root[] = []
+
+async function renderList(root: Root): Promise<void> {
+  await act(async () => {
+    root.render(
+      <WorktreeList scrollOffsetRef={{ current: 0 }} scrollAnchorRef={{ current: null }} />
+    )
+  })
+}
+
+async function pressCycle(root: Root, direction: 'up' | 'down'): Promise<string | null> {
+  mockStore.activateAndRevealWorktree.mockClear()
+  await act(async () => {
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: direction === 'down' ? 'ArrowDown' : 'ArrowUp',
+        metaKey: true,
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+    )
+  })
+  const target = mockStore.activateAndRevealWorktree.mock.calls.at(-1)?.[0] ?? null
+  if (typeof target === 'string') {
+    // Why: activation is mocked, so advance the selection by hand to let the next press continue.
+    mockStore.state = { ...mockStore.state, activeWorktreeId: target }
+    await renderList(root)
+    return target
+  }
+  return null
+}
+
+async function collectCycle(root: Root, direction: 'up' | 'down', steps: number) {
+  const visited: string[] = []
+  for (let i = 0; i < steps; i++) {
+    const target = await pressCycle(root, direction)
+    if (target === null) {
+      break
+    }
+    visited.push(target)
+  }
+  return visited
+}
+
+describe('arrow cycling covers folder workspaces', () => {
+  beforeAll(async () => {
+    WorktreeList = (await import('./WorktreeList')).default as WorktreeListComponent
+  }, 60_000)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setSidebarState('wt-a')
+  })
+
+  afterEach(async () => {
+    await act(async () => {
+      for (const root of mountedRoots.splice(0)) {
+        root.unmount()
+      }
+    })
+    document.body.innerHTML = ''
+  })
+
+  async function mount(): Promise<Root> {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    mountedRoots.push(root)
+    await renderList(root)
+    return root
+  }
+
+  it('reaches the folder workspace when cycling down', async () => {
+    const root = await mount()
+    const visited = await collectCycle(root, 'down', 4)
+
+    expect(visited).toContain(FOLDER_WORKSPACE_KEY)
+    // Every sidebar row is reachable, so a full lap visits all three workspaces.
+    expect(new Set(visited)).toEqual(new Set(['wt-a', 'wt-b', FOLDER_WORKSPACE_KEY]))
+  })
+
+  it('reaches the folder workspace when cycling up', async () => {
+    const root = await mount()
+    const visited = await collectCycle(root, 'up', 4)
+
+    expect(visited).toContain(FOLDER_WORKSPACE_KEY)
+  })
+
+  it('steps off the folder workspace instead of getting stuck on it', async () => {
+    setSidebarState(FOLDER_WORKSPACE_KEY)
+    const root = await mount()
+
+    const target = await pressCycle(root, 'down')
+
+    expect(target).not.toBe(FOLDER_WORKSPACE_KEY)
+    expect(['wt-a', 'wt-b']).toContain(target)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -298,10 +298,7 @@ import {
   getProjectGroupExecutionHostIdForRows
 } from './worktree-list-host-filtering'
 import { getFolderWorkspaceCardPrDisplay } from './folder-workspace-card-pr-display'
-import {
-  getPreferredWorktreeRows,
-  getRenderedWorktreesInSidebarOrder
-} from './worktree-sidebar-row-preference'
+import { getRenderedWorktreesInSidebarOrder } from './worktree-sidebar-row-preference'
 import {
   resolveWorktreeNavigationAnchorId,
   resolveWorktreeNavigationTargetId
@@ -665,6 +662,8 @@ type VirtualizedWorktreeViewportProps = {
   agentSendTargetWorktreeId: string | null
   worktrees: Worktree[]
   folderWorkspaces: readonly FolderWorkspace[]
+  /** Host-scope-filtered subset that actually renders as rows; drives keyboard cycling. */
+  visibleFolderWorkspaces: readonly FolderWorkspace[]
   selectedWorktreeIds: ReadonlySet<string>
   selectedWorktrees: readonly Worktree[]
   onSelectionGesture: (event: React.MouseEvent<HTMLElement>, worktreeId: string) => boolean
@@ -1354,6 +1353,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   agentSendTargetWorktreeId,
   worktrees,
   folderWorkspaces,
+  visibleFolderWorkspaces,
   selectedWorktreeIds,
   selectedWorktrees,
   onSelectionGesture,
@@ -2471,7 +2471,7 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const navigateWorktree = useCallback(
     (direction: 'up' | 'down') => {
       // Why: cycle over an all-expanded layout so navigation doesn't skip worktrees in collapsed groups; reveal uncollapses the target.
-      const allWorktreeRows = buildRows(
+      const allRows = buildRows(
         groupBy,
         worktrees,
         repoMap,
@@ -2490,15 +2490,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         new Map(),
         [],
         projectGrouping,
-        [],
+        visibleFolderWorkspaces,
         undefined,
         defaultHostId,
         pinnedDisplayPolicy
-      ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
-      const navigableWorktreeIds = getPreferredWorktreeRows(
-        allWorktreeRows,
+      )
+      // Why: same ordering helper Cmd+1–9 uses, so folder workspaces cycle in visual order instead of being skipped.
+      const navigableWorktreeIds = getRenderedWorktreesInSidebarOrder(
+        allRows,
         pinnedDisplayPolicy
-      ).map((r) => r.worktree.id)
+      ).map((workspace) => workspace.id)
       // Why: read nav history at press time instead of subscribing — the sidebar re-renders on every entry.
       const { worktreeNavHistory, worktreeNavHistoryIndex } = useAppStore.getState()
       const nextWorktreeId = resolveWorktreeNavigationTargetId({
@@ -2543,7 +2544,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       settings,
       projectGroups,
       projectGrouping,
-      pinnedDisplayPolicy
+      pinnedDisplayPolicy,
+      visibleFolderWorkspaces
     ]
   )
 
@@ -6769,6 +6771,7 @@ const WorktreeList = React.memo(function WorktreeList({
         agentSendTargetWorktreeId={agentSendTargetWorktreeId}
         worktrees={worktrees}
         folderWorkspaces={folderWorkspaces}
+        visibleFolderWorkspaces={visibleFolderWorkspacesForRows}
         selectedWorktreeIds={selectedWorktreeIds}
         selectedWorktrees={selectedWorktrees}
         onSelectionGesture={updateSelectionForGesture}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -302,6 +302,10 @@ import {
   getPreferredWorktreeRows,
   getRenderedWorktreesInSidebarOrder
 } from './worktree-sidebar-row-preference'
+import {
+  resolveWorktreeNavigationAnchorId,
+  resolveWorktreeNavigationTargetId
+} from './worktree-list-keyboard-navigation'
 
 export {
   getScrollTopToRevealBounds,
@@ -2491,29 +2495,25 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         defaultHostId,
         pinnedDisplayPolicy
       ).filter((r): r is Extract<Row, { type: 'item' }> => r.type === 'item')
-      const worktreeRows = getPreferredWorktreeRows(allWorktreeRows, pinnedDisplayPolicy)
-      if (worktreeRows.length === 0) {
+      const navigableWorktreeIds = getPreferredWorktreeRows(
+        allWorktreeRows,
+        pinnedDisplayPolicy
+      ).map((r) => r.worktree.id)
+      // Why: read nav history at press time instead of subscribing — the sidebar re-renders on every entry.
+      const { worktreeNavHistory, worktreeNavHistoryIndex } = useAppStore.getState()
+      const nextWorktreeId = resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds,
+        anchorWorktreeId: resolveWorktreeNavigationAnchorId({
+          selectedWorktreeId: activeWorktreeId,
+          navHistory: worktreeNavHistory,
+          navHistoryIndex: worktreeNavHistoryIndex,
+          navigableWorktreeIds
+        }),
+        direction
+      })
+      if (nextWorktreeId === null) {
         return
       }
-
-      let nextIndex = 0
-      const currentIndex = worktreeRows.findIndex((r) => r.worktree.id === activeWorktreeId)
-
-      if (currentIndex !== -1) {
-        if (direction === 'up') {
-          nextIndex = currentIndex - 1
-          if (nextIndex < 0) {
-            nextIndex = worktreeRows.length - 1
-          }
-        } else {
-          nextIndex = currentIndex + 1
-          if (nextIndex >= worktreeRows.length) {
-            nextIndex = 0
-          }
-        }
-      }
-
-      const nextWorktreeId = worktreeRows[nextIndex].worktree.id
       // Why: keyboard cycling is real navigation; route through the activation helper that records history.
       activateAndRevealWorktree(nextWorktreeId)
 

--- a/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveWorktreeNavigationAnchorId,
+  resolveWorktreeNavigationTargetId
+} from './worktree-list-keyboard-navigation'
+
+const ROWS = ['wt-1', 'wt-2', 'wt-3']
+
+describe('resolveWorktreeNavigationAnchorId', () => {
+  it('prefers the selected workspace', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: 'wt-2',
+        navHistory: ['wt-1'],
+        navHistoryIndex: 0,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('falls back to the current history entry when nothing is selected', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: ['wt-1', 'wt-2'],
+        navHistoryIndex: 1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('ignores history entries ahead of the history cursor', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: ['wt-1', 'wt-2', 'wt-3'],
+        navHistoryIndex: 1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('skips view entries and task-detail entries', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: [
+          'wt-2',
+          'tasks',
+          { kind: 'task-detail', source: 'linear', issue: { id: 'iss-1' } }
+        ] as never,
+        navHistoryIndex: 2,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-2')
+  })
+
+  it('skips history entries that are no longer in the list', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: ['wt-1', 'wt-deleted'],
+        navHistoryIndex: 1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-1')
+  })
+
+  it('returns null when neither selection nor history resolves to a listed workspace', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: null,
+        navHistory: [],
+        navHistoryIndex: -1,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBeNull()
+  })
+
+  it('ignores a selection that is filtered out of the list', () => {
+    expect(
+      resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId: 'wt-hidden',
+        navHistory: ['wt-3'],
+        navHistoryIndex: 0,
+        navigableWorktreeIds: ROWS
+      })
+    ).toBe('wt-3')
+  })
+})
+
+describe('resolveWorktreeNavigationTargetId', () => {
+  it('steps down and wraps at the end', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-2',
+        direction: 'down'
+      })
+    ).toBe('wt-3')
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-3',
+        direction: 'down'
+      })
+    ).toBe('wt-1')
+  })
+
+  it('steps up and wraps at the start', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-2',
+        direction: 'up'
+      })
+    ).toBe('wt-1')
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: 'wt-1',
+        direction: 'up'
+      })
+    ).toBe('wt-3')
+  })
+
+  it('enters the list from either end when there is no anchor', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: null,
+        direction: 'down'
+      })
+    ).toBe('wt-1')
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ROWS,
+        anchorWorktreeId: null,
+        direction: 'up'
+      })
+    ).toBe('wt-3')
+  })
+
+  it('returns null for an empty list', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: [],
+        anchorWorktreeId: 'wt-1',
+        direction: 'down'
+      })
+    ).toBeNull()
+  })
+
+  it('keeps cycling on a single-row list', () => {
+    expect(
+      resolveWorktreeNavigationTargetId({
+        navigableWorktreeIds: ['wt-1'],
+        anchorWorktreeId: 'wt-1',
+        direction: 'down'
+      })
+    ).toBe('wt-1')
+  })
+})
+
+describe('closing the active workspace keeps sidebar cycling in place', () => {
+  // Repro: 3 workspaces, cycle 1 -> 2, close 2's last tab (landing fallback clears the
+  // selection), then Cmd+Shift+Down must land on 3 instead of restarting at 1.
+  const cycleFrom = (
+    selectedWorktreeId: string | null,
+    navHistory: string[],
+    direction: 'up' | 'down'
+  ): string | null =>
+    resolveWorktreeNavigationTargetId({
+      navigableWorktreeIds: ROWS,
+      anchorWorktreeId: resolveWorktreeNavigationAnchorId({
+        selectedWorktreeId,
+        navHistory,
+        navHistoryIndex: navHistory.length - 1,
+        navigableWorktreeIds: ROWS
+      }),
+      direction
+    })
+
+  it('continues forward from the closed workspace', () => {
+    expect(cycleFrom(null, ['wt-1', 'wt-2'], 'down')).toBe('wt-3')
+  })
+
+  it('continues backward from the closed workspace', () => {
+    expect(cycleFrom(null, ['wt-1', 'wt-2'], 'up')).toBe('wt-1')
+  })
+
+  it('does not re-open the same workspace after closing the first one', () => {
+    expect(cycleFrom(null, ['wt-1'], 'down')).toBe('wt-2')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-keyboard-navigation.ts
@@ -1,0 +1,65 @@
+import type { WorktreeNavHistoryEntry } from '@/store/slices/worktree-nav-history'
+
+type AnchorArgs = {
+  selectedWorktreeId: string | null
+  navHistory: readonly WorktreeNavHistoryEntry[]
+  navHistoryIndex: number
+  navigableWorktreeIds: readonly string[]
+}
+
+// Why: page sentinels share the history entry type with workspace IDs, and object entries are task details.
+function historyEntryWorkspaceId(entry: WorktreeNavHistoryEntry | undefined): string | null {
+  if (typeof entry !== 'string' || entry === 'tasks' || entry === 'automations') {
+    return null
+  }
+  return entry
+}
+
+/**
+ * Pick the row keyboard cycling should step from. Closing a workspace's last tab clears the
+ * selection (landing fallback), so fall back to the nav-history cursor — otherwise every step
+ * after a close restarts at the top of the sidebar.
+ */
+export function resolveWorktreeNavigationAnchorId({
+  selectedWorktreeId,
+  navHistory,
+  navHistoryIndex,
+  navigableWorktreeIds
+}: AnchorArgs): string | null {
+  const navigable = new Set(navigableWorktreeIds)
+  if (selectedWorktreeId !== null && navigable.has(selectedWorktreeId)) {
+    return selectedWorktreeId
+  }
+  for (let i = Math.min(navHistoryIndex, navHistory.length - 1); i >= 0; i--) {
+    const workspaceId = historyEntryWorkspaceId(navHistory[i])
+    if (workspaceId !== null && navigable.has(workspaceId)) {
+      return workspaceId
+    }
+  }
+  return null
+}
+
+/** Step one row from the anchor, wrapping around; with no anchor, enter from the matching end. */
+export function resolveWorktreeNavigationTargetId({
+  navigableWorktreeIds,
+  anchorWorktreeId,
+  direction
+}: {
+  navigableWorktreeIds: readonly string[]
+  anchorWorktreeId: string | null
+  direction: 'up' | 'down'
+}): string | null {
+  if (navigableWorktreeIds.length === 0) {
+    return null
+  }
+  const anchorIndex =
+    anchorWorktreeId === null ? -1 : navigableWorktreeIds.indexOf(anchorWorktreeId)
+  if (anchorIndex === -1) {
+    const entryIndex = direction === 'down' ? 0 : navigableWorktreeIds.length - 1
+    return navigableWorktreeIds[entryIndex]
+  }
+  const step = direction === 'down' ? 1 : -1
+  const nextIndex =
+    (anchorIndex + step + navigableWorktreeIds.length) % navigableWorktreeIds.length
+  return navigableWorktreeIds[nextIndex]
+}


### PR DESCRIPTION
## Summary

Folder workspaces could never be reached with `Cmd/Ctrl+Shift+↓/↑`, even though they render as sidebar rows and `Cmd/Ctrl+1–9` already navigates to them.

Repro (needs a folder-backed project group — import a parent directory containing several git repos as a group, then add a workspace from the group header's `+`):

```
sidebar (Group by project)     Cmd+Shift+↓ repeatedly
─────────────────────────      ─────────────────────────
1  feature-a   (worktree)  →   visited
2  design      (folder ws)  →  skipped   ← visible, unreachable
3  feature-b   (worktree)  →   visited
```

Cycling ran 1 → 3 → 1 → 3. Pressing `Cmd+2` went to the folder workspace fine, so the two shortcuts disagreed about which rows exist.

### Root cause

`navigateWorktree` built its own all-expanded row layout but passed `[]` for `buildRows`' `folderWorkspaces` argument, so `folder-workspace` rows were never constructed as navigation candidates. The main render path passes `visibleFolderWorkspacesForRows` and therefore does show them. `Cmd/Ctrl+1–9` reads `getRenderedWorktreesInSidebarOrder`, which folds `folder-workspace` rows in — hence the mismatch.

### Fix

- Thread the host-scope-filtered list down as a new `visibleFolderWorkspaces` prop (the viewport's existing `folderWorkspaces` prop is the unfiltered store list, which would let cycling jump to a row the sidebar is hiding).
- Build the navigable IDs with `getRenderedWorktreesInSidebarOrder` — the same ordering helper `Cmd+1–9` uses — instead of filtering to `item` rows and calling `getPreferredWorktreeRows` directly. Both shortcuts now cover the same rows in the same visual order, and pinned-row de-duplication still happens inside that helper.

Reveal/scroll and activation needed no changes: `renderRowContainsWorktree` already matches `folderWorkspaceKey(...)`, and `activateAndRevealWorktree` already routes folder workspace keys to `setActiveFolderWorkspace`.

Scope note: `buildRows` only emits project-group and folder-workspace rows when `groupBy === 'repo'`, so this affects the "Group by project" sidebar mode — the only mode where folder workspaces are visible at all.

## Screenshots

`No visual change` — only which workspace a keyboard shortcut activates.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New component test `WorktreeList.arrow-cycling-folder-workspaces.test.tsx` mounts the real sidebar with a folder-backed project group, dispatches the actual chord, and asserts a full lap visits all three workspaces in both directions plus that cycling steps *off* a folder workspace anchor. Verified it is a real regression guard: reverting just the `folderWorkspaces` argument makes it fail with `expected [ 'wt-b', 'wt-a', 'wt-b', 'wt-a' ] to include 'folder:folder-1'`.

Full suite: `Test Files 9 failed | 3388 passed | 7 skipped`, `Tests 44 failed | 35978 passed | 60 skipped`. None are caused by this change:

- 8 of them are the same pre-existing failures documented in #10555 (`relay/agent-exec-handler`, `browser-pane/markup/use-markup-draw-hint`, three `right-sidebar/*`, and three `sidebar/*` — mostly `window.localStorage.* is not a function` in the shared test env).
- The 9th, `src/main/runtime/multi-client-navigation-isolation.integration.test.ts`, is flaky under load: it fails in the full run (`expected 'host-tab' to be 'client-a-tab'`) and passes 5/5 when run on its own. It exercises main-process client tab routing, which this renderer-only change cannot reach.

Sidebar suite on its own: 181 passed, only the 3 pre-existing sidebar failures.

## AI Review Report

Reviewed with Claude Code (Opus 5) against the checks in CONTRIBUTING:

- **Cross-platform (macOS/Linux/Windows):** no platform-dependent code. The chord still resolves through `keybindingMatchesAction` + `getShortcutPlatform()`; the new test pins the platform to `darwin` so it does not depend on the runner's userAgent.
- **SSH / remote / local:** the new prop is the host-scope-filtered list, so a folder workspace hosted on a host that is currently filtered out of the sidebar stays out of cycling. Using the unfiltered `folderWorkspaces` prop would have introduced exactly that bug; called out here because the two props now look similar at the call site.
- **Folder workspaces vs git worktrees:** this is the change — both are now navigable, ordered by `getRenderedWorktreesInSidebarOrder`. Folder workspace IDs (`folder:<id>`) already share the ID space used by the anchor logic, activation, and reveal.
- **Agent / integration / git-provider neutrality:** nothing provider-specific involved.
- **Performance:** no new subscriptions. `getRenderedWorktreesInSidebarOrder` runs on the same rows that were already being built for this keypress and is O(rows); the previous code did an equivalent filter + de-dup pass.
- **UI quality:** no visual surface touched; STYLEGUIDE does not apply.
- **Behavior change, intended:** cycling now has more stops than before for users with folder workspaces. That is the point of the fix, and it aligns arrow cycling with `Cmd+1–9`.

## Security Audit

No security-relevant surface. Renderer-side state computation over workspace IDs already in the store: no input parsing, command execution, path handling, auth, secrets, IPC, or network calls, and no new dependencies. The threaded list comes from store state that the sidebar already renders.

## Notes

- **Stacked on #10555.** This branch contains that PR's commit as its parent, so until #10555 merges the diff here shows both commits. Once it lands, this PR's diff reduces to the single folder-workspace commit. Reviewing #10555 first is the easier order.
- Follows up the pre-existing inconsistency flagged in #10555's Notes; CodeRabbit raised the same gap on the earlier revision of that PR.

X (Twitter): https://x.com/jeongph_dev

🤖 Generated with Claude Code
