### PR TITLE
fix(worktree): grow the composer note to fit a prefilled PR title

### DIFF
--- a/docs/reference/plans/2026-07-26-worktree-composer-note-autosize.md
+++ b/docs/reference/plans/2026-07-26-worktree-composer-note-autosize.md
@@ -1,0 +1,70 @@
+# Worktree Composer Note Auto-Size
+
+## Problem
+
+Issue https://github.com/stablyai/orca/issues/10575 reports that the Create Worktree dialog clips the note it prefills from a linked PR.
+
+Picking a PR on the Smart tab writes `PR #<number> — <title>` into the Note field. PR titles routinely wrap past one line, but the box stays one row tall and the overflow is unreachable:
+
+- `src/renderer/src/hooks/useComposerState.ts:2771` calls `setNote(suggestedNote)` after the PR base resolves; `:2798` does the same for GitLab MRs.
+- `src/renderer/src/components/NewWorkspaceComposerCard.tsx` sized the note textarea only inside its `onInput` handler.
+- The same textarea carried `rows={1}`, `resize-none`, and `overflow-hidden`.
+
+Reported symptom: focusing the note and pressing Down scrolls the caret into view but the field still renders one row, so the note reads as truncated no matter what the user does.
+
+## Root Cause
+
+`onInput` fires for text the user types or pastes. It does not fire when React writes a controlled `value` from state, which is exactly how the PR/MR prefill arrives. The auto-size pass therefore never ran for prefilled notes and the textarea kept its `rows={1}` height.
+
+`overflow-hidden` then removed every fallback: no scrollbar, no wheel scrolling, and `resize-none` meant no drag handle either. The only thing that moved was the caret, which scrolls `scrollTop` without changing the rendered height.
+
+Scope of the bug:
+
+- PRs and GitLab MRs only. GitHub issues (`useComposerState.ts:2767` gates on `identity.type === 'pr'`) and Linear issues (`:3116`) deliberately do not prefill the note.
+- Hand-typed notes were unaffected, because typing does fire `onInput`.
+- `WorktreeMetaDialog` — the note editor for an existing worktree — was already correct: it sizes from a ref callback on mount and pairs `max-h-60` with `overflow-y-auto`.
+
+## Non-Goals
+
+- Adding a drag-to-resize handle. Auto-size plus scrolling removes the need, and `resize-none` keeps the field consistent with `WorktreeMetaDialog`.
+- Changing which sources prefill the note, or the prefill text itself.
+- Reworking the other auto-sizing textareas (`WorktreeMetaDialog`, `LinearIssueTextEditor`); they already behave correctly.
+
+## Design
+
+1. Add `src/renderer/src/hooks/useAutoSizedTextarea.ts`. It takes the current value and returns a ref callback, sizing the element both on attach and in a `useLayoutEffect` keyed on the value. Measuring in a layout effect covers programmatic writes and runs before paint, so the field never flashes at the wrong height.
+
+2. Point the composer's note textarea at that hook and drop the `onInput` handler. Value-keyed resizing is a superset of it — typing updates `note`, which re-runs the effect.
+
+3. Swap `overflow-hidden` for `overflow-y-auto scrollbar-sleek` while keeping `max-h-40`. The height stops growing at 160px and the remainder scrolls, so no content is ever unreachable. `scrollbar-sleek` is required by `pnpm check:styled-scrollbars` for any scrollable element.
+
+`rows={1}` stays: it is the empty-state height, and the hook takes over as soon as there is content.
+
+## Data Flow
+
+- User picks a PR on the Smart tab.
+- `handleSmartGitHubItemSelect` resolves the PR base, then `handleBaseBranchPrSelect` calls `setNote('PR #… — …')`.
+- `NewWorkspaceComposerCard` re-renders with the new `note` prop.
+- `useAutoSizedTextarea`'s layout effect resets the height to `auto`, reads `scrollHeight`, and writes it back.
+- CSS `max-h-40` clamps the result; anything past it scrolls.
+
+## Edge Cases
+
+- **Collapsed Advanced drawer.** The drawer animates with `grid-rows-[0fr]` and always renders its children, so the textarea keeps its own layout box and `scrollHeight` stays measurable while collapsed. Expanding reveals an already-correct height.
+- **Shrinking value.** `sizeToContent` resets to `height: auto` before measuring, so clearing the source (which resets the note to `''`) collapses the box instead of stranding the taller height.
+- **Chunked large paste.** `pasteTextIntoTextControl` writes the DOM value in chunks and fires one final input event; React's `onChange` then updates `note` and the effect resizes. The box settles once the paste completes rather than growing mid-paste.
+- **Notes longer than the clamp.** Height stops at `max-h-40` and the sleek scrollbar takes over — the previous `overflow-hidden` made this content unreachable.
+- **Draft restore.** `persistDraft` composers mount with a non-empty note; the ref callback sizes on attach, so the restored note is not clipped either.
+
+## Test Plan
+
+- Unit (`src/renderer/src/components/NewWorkspaceComposerCard.test.tsx`, `NewWorkspaceComposerCard note field`):
+  - a note present at mount sizes the box to its content;
+  - a note that arrives after mount (the reported PR-prefill path) regrows the box;
+  - the field keeps `max-h-40` and is scrollable rather than `overflow-hidden`.
+  - happy-dom has no layout, so the suite stubs `HTMLElement.prototype.scrollHeight` for textareas — the same approach as `MobileHero.test.tsx`.
+- `pnpm lint`, `pnpm typecheck`, `pnpm test`.
+
+## UI Quality Bar
+
+An empty note still renders as a single compact row, so the collapsed dialog is unchanged. A prefilled note renders at its full wrapped height, up to 160px, after which a sleek scrollbar appears. No new controls, copy, or color values.

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -196,69 +196,80 @@ function renderCard(
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
-  act(() => {
-    root.render(
-      <NewWorkspaceComposerCard
-        quickAgent={null}
-        onQuickAgentChange={() => {}}
-        eligibleRepos={[]}
-        repoId="repo-a"
-        projectOptions={projectOptions}
-        selectedProjectId="project-group:platform"
-        selectedRepoIsGit
-        onRepoChange={() => {}}
-        onProjectChange={() => {}}
-        primaryActionLabel="Create workspace"
-        name=""
-        onNameValueChange={() => {}}
-        onSmartGitHubItemSelect={() => {}}
-        onSmartGitLabItemSelect={() => {}}
-        onSmartBranchSelect={() => {}}
-        onSmartLinearIssueSelect={() => {}}
-        smartNameSelection={null}
-        onClearSmartNameSelection={() => {}}
-        canReuseSelectedBranch={false}
-        reuseSelectedBranch={false}
-        onReuseSelectedBranchChange={() => {}}
-        branchNameOverride=""
-        onBranchNameOverrideChange={() => {}}
-        forkPushWarning={null}
-        detectedAgentIds={null}
-        onOpenAgentSettings={() => {}}
-        advancedOpen={false}
-        onToggleAdvanced={() => {}}
-        createDisabled={false}
-        projectError={null}
-        creating={false}
-        onCreate={() => {}}
-        note=""
-        onNoteChange={() => {}}
-        setupConfig={null}
-        requiresExplicitSetupChoice={false}
-        setupDecision={null}
-        onSetupDecisionChange={() => {}}
-        setupAgentStartupPolicy="start-immediately"
-        onSetupAgentStartupPolicyChange={() => {}}
-        shouldWaitForSetupCheck={false}
-        resolvedSetupDecision={null}
-        createError={null}
-        selectedRepoConnectionId={null}
-        selectedRepoSshStatus={null}
-        selectedRepoRequiresConnection={false}
-        selectedRepoConnectInProgress={false}
-        onConnectSelectedRepo={async () => {}}
-        canUseSparseCheckout={false}
-        sparsePresets={[]}
-        sparseSelectedPresetId={null}
-        onSparseSelectPreset={() => {}}
-        branchesEnabled={false}
-        setupControlsEnabled={false}
-        sparseControlsEnabled={false}
-        {...overrides}
-      />
-    )
-  })
-  return { container, root }
+  const render = (
+    nextOverrides: Partial<React.ComponentProps<typeof NewWorkspaceComposerCard>>
+  ): void => {
+    act(() => {
+      root.render(cardElement(nextOverrides))
+    })
+  }
+  render(overrides)
+  return { container, root, rerender: render }
+}
+
+function cardElement(
+  overrides: Partial<React.ComponentProps<typeof NewWorkspaceComposerCard>>
+): React.JSX.Element {
+  return (
+    <NewWorkspaceComposerCard
+      quickAgent={null}
+      onQuickAgentChange={() => {}}
+      eligibleRepos={[]}
+      repoId="repo-a"
+      projectOptions={projectOptions}
+      selectedProjectId="project-group:platform"
+      selectedRepoIsGit
+      onRepoChange={() => {}}
+      onProjectChange={() => {}}
+      primaryActionLabel="Create workspace"
+      name=""
+      onNameValueChange={() => {}}
+      onSmartGitHubItemSelect={() => {}}
+      onSmartGitLabItemSelect={() => {}}
+      onSmartBranchSelect={() => {}}
+      onSmartLinearIssueSelect={() => {}}
+      smartNameSelection={null}
+      onClearSmartNameSelection={() => {}}
+      canReuseSelectedBranch={false}
+      reuseSelectedBranch={false}
+      onReuseSelectedBranchChange={() => {}}
+      branchNameOverride=""
+      onBranchNameOverrideChange={() => {}}
+      forkPushWarning={null}
+      detectedAgentIds={null}
+      onOpenAgentSettings={() => {}}
+      advancedOpen={false}
+      onToggleAdvanced={() => {}}
+      createDisabled={false}
+      projectError={null}
+      creating={false}
+      onCreate={() => {}}
+      note=""
+      onNoteChange={() => {}}
+      setupConfig={null}
+      requiresExplicitSetupChoice={false}
+      setupDecision={null}
+      onSetupDecisionChange={() => {}}
+      setupAgentStartupPolicy="start-immediately"
+      onSetupAgentStartupPolicyChange={() => {}}
+      shouldWaitForSetupCheck={false}
+      resolvedSetupDecision={null}
+      createError={null}
+      selectedRepoConnectionId={null}
+      selectedRepoSshStatus={null}
+      selectedRepoRequiresConnection={false}
+      selectedRepoConnectInProgress={false}
+      onConnectSelectedRepo={async () => {}}
+      canUseSparseCheckout={false}
+      sparsePresets={[]}
+      sparseSelectedPresetId={null}
+      onSparseSelectPreset={() => {}}
+      branchesEnabled={false}
+      setupControlsEnabled={false}
+      sparseControlsEnabled={false}
+      {...overrides}
+    />
+  )
 }
 
 function findInputByLabel(container: HTMLElement, labelText: string): HTMLInputElement | null {
@@ -853,5 +864,64 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
 
     expect(hostChanges).toEqual(['setup-builder'])
     expect(recipeChanges).toEqual([null])
+  })
+})
+
+describe('NewWorkspaceComposerCard note field', () => {
+  const originalScrollHeight = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'scrollHeight'
+  )
+
+  beforeEach(() => {
+    // happy-dom has no layout, so every scrollHeight is 0; stand in a wrapped-content height.
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get(this: HTMLElement) {
+        if (this.tagName !== 'TEXTAREA') {
+          return 0
+        }
+        return (this as HTMLTextAreaElement).value ? 76 : 34
+      }
+    })
+  })
+
+  afterEach(() => {
+    act(() => current?.root.unmount())
+    current?.container.remove()
+    current = null
+    if (originalScrollHeight) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', originalScrollHeight)
+    }
+  })
+
+  it('sizes the note box to a note prefilled from a linked PR', () => {
+    current = renderCard({
+      advancedOpen: true,
+      note: 'PR #10555 — fix(sidebar): keep Cmd+Shift+Arrow cycling in place for folder workspaces'
+    })
+
+    const textarea = current.container.querySelector('textarea')
+    expect(textarea?.style.height).toBe('76px')
+  })
+
+  // The reported bug: resolving the linked PR sets the note from outside the textarea, so no
+  // input event fires and the box stayed one row tall with its overflow unreachable.
+  it('regrows when the prefilled note arrives after mount', () => {
+    const card = renderCard({ advancedOpen: true, note: '' })
+    current = card
+    expect(card.container.querySelector('textarea')?.style.height).toBe('34px')
+
+    card.rerender({ advancedOpen: true, note: 'PR #10555 — fix(sidebar): keep cycling' })
+    expect(card.container.querySelector('textarea')?.style.height).toBe('76px')
+  })
+
+  it('scrolls instead of clipping once the note passes the max height', () => {
+    current = renderCard({ advancedOpen: true, note: 'a long note' })
+
+    const className = current.container.querySelector('textarea')?.className ?? ''
+    expect(className).toContain('max-h-40')
+    expect(className).toContain('overflow-y-auto')
+    expect(className).not.toContain('overflow-hidden')
   })
 })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -43,6 +43,7 @@ import {
   shouldHandleTextControlPaste
 } from '@/lib/text-control-paste'
 import { getScreenSubmitModifierLabel } from '@/lib/screen-submit-shortcut'
+import { useAutoSizedTextarea } from '@/hooks/useAutoSizedTextarea'
 import { useContextualTour } from '@/components/contextual-tours/use-contextual-tour'
 import { filterEnabledTuiAgents } from '../../../shared/tui-agent-selection'
 import type {
@@ -1118,6 +1119,7 @@ export default function NewWorkspaceComposerCard({
     },
     []
   )
+  const setNoteTextarea = useAutoSizedTextarea(note)
   const handleNotePaste = React.useCallback((event: React.ClipboardEvent<HTMLTextAreaElement>) => {
     const text = event.clipboardData.getData('text/plain')
     const byteLengthMeasurement = measureTextControlPasteByteLength(text, {
@@ -1553,21 +1555,16 @@ export default function NewWorkspaceComposerCard({
                   {translate('auto.components.NewWorkspaceComposerCard.f8728aa4f9', 'Note')}
                 </label>
                 <textarea
+                  ref={setNoteTextarea}
                   value={note}
                   onChange={(event) => onNoteChange(event.target.value)}
                   onPaste={handleNotePaste}
-                  onInput={(event) => {
-                    // Why: reset then size to content so short notes stay compact and long ones grow without a scrollbar until max-h clamps.
-                    const ta = event.currentTarget
-                    ta.style.height = 'auto'
-                    ta.style.height = `${ta.scrollHeight}px`
-                  }}
                   placeholder={translate(
                     'auto.components.NewWorkspaceComposerCard.090cfedeb4',
                     'Write a note'
                   )}
                   rows={1}
-                  className="w-full min-w-0 resize-none overflow-hidden rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 max-h-40"
+                  className="w-full min-w-0 resize-none overflow-y-auto scrollbar-sleek rounded-md border border-input bg-transparent px-3 py-1.5 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 max-h-40"
                 />
               </div>
 

--- a/src/renderer/src/hooks/useAutoSizedTextarea.ts
+++ b/src/renderer/src/hooks/useAutoSizedTextarea.ts
@@ -6,15 +6,7 @@ function sizeToContent(textarea: HTMLTextAreaElement): void {
   textarea.style.height = `${textarea.scrollHeight}px`
 }
 
-/**
- * Keeps a textarea's height matched to its content.
- *
- * Why: an `onInput` handler only covers text the user types — a value written from
- * React state (prefilling a note from a linked PR, restoring a draft) fires no input
- * event, so the field would keep its `rows` height and clip everything below it. Pair
- * with a `max-h-*` plus a scrollable overflow so long content clamps instead of growing
- * without bound.
- */
+/** Why: `onInput` misses values React writes from state, so a prefill would keep the `rows` height. */
 export function useAutoSizedTextarea(value: string): (node: HTMLTextAreaElement | null) => void {
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
 

--- a/src/renderer/src/hooks/useAutoSizedTextarea.ts
+++ b/src/renderer/src/hooks/useAutoSizedTextarea.ts
@@ -1,0 +1,33 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+
+function sizeToContent(textarea: HTMLTextAreaElement): void {
+  // Why: collapse first so a shrinking value re-measures instead of keeping the taller height.
+  textarea.style.height = 'auto'
+  textarea.style.height = `${textarea.scrollHeight}px`
+}
+
+/**
+ * Keeps a textarea's height matched to its content.
+ *
+ * Why: an `onInput` handler only covers text the user types — a value written from
+ * React state (prefilling a note from a linked PR, restoring a draft) fires no input
+ * event, so the field would keep its `rows` height and clip everything below it. Pair
+ * with a `max-h-*` plus a scrollable overflow so long content clamps instead of growing
+ * without bound.
+ */
+export function useAutoSizedTextarea(value: string): (node: HTMLTextAreaElement | null) => void {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useLayoutEffect(() => {
+    if (textareaRef.current) {
+      sizeToContent(textareaRef.current)
+    }
+  }, [value])
+
+  return useCallback((node: HTMLTextAreaElement | null) => {
+    textareaRef.current = node
+    if (node) {
+      sizeToContent(node)
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary

Fixes #10575.

Linking an existing PR in **Create Worktree** prefills the Note with `PR #<number> — <title>`, but the box never grew to fit it. The note's auto-size pass lived only in the textarea's `onInput` handler, and `onInput` does not fire when React writes a controlled `value` from state — which is exactly how the prefill arrives (`setNote(...)` in `useComposerState`). The field kept its `rows={1}` height, and `overflow-hidden` + `resize-none` left no scrollbar, no wheel scrolling, and no drag handle, so the clipped text was unreachable. Arrow keys moved the caret but the box stayed one row tall.

- Adds `useAutoSizedTextarea`, which sizes a textarea on attach **and** in a `useLayoutEffect` keyed on its value, so programmatic writes resize too. Measuring in a layout effect lands before paint, so there is no flash at the wrong height.
- Points the composer's note field at the hook and drops the `onInput` handler — value-keyed resizing is a superset of it.
- Swaps `overflow-hidden` for `overflow-y-auto scrollbar-sleek`, keeping `max-h-40`. Height stops growing at 160px and the rest scrolls, so nothing is ever unreachable.

`rows={1}` stays as the empty-state height, so a blank note still renders as one compact row. Full write-up in `docs/reference/plans/2026-07-26-worktree-composer-note-autosize.md`.

Scope: PRs and GitLab MRs were the only affected sources — GitHub issues and Linear issues deliberately do not prefill the note, and hand-typed notes already worked because typing fires `onInput`. `WorktreeMetaDialog`'s note field was already correct and is untouched.

## Screenshots

Both shots are the same dialog with PR #10576 linked on the Smart tab, Advanced expanded.

**Before** — the Note is one row tall. Only the first line of `PR #<number> — <title>` is legible; the second line is cut off mid-glyph at the bottom border, and nothing scrolls, resizes, or otherwise brings it back.

<img width="521" height="635" alt="Create Worktree dialog before the fix, with the Note field clipping the second line of the PR title" src="https://github.com/user-attachments/assets/60f1d754-cf03-493c-b2c7-e60b97eea4a0" />

**After** — the Note renders at its full wrapped height, so the whole title is visible. Past 160px the height clamps and a sleek scrollbar takes over. An empty Note still renders as one compact row either way, so the collapsed dialog is unchanged.

<img width="521" height="615" alt="Create Worktree dialog after the fix, with the Note field showing the full PR title across two lines" src="https://github.com/user-attachments/assets/bd908dee-0146-46a4-8bbb-026ca1b32104" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Three regression tests in `NewWorkspaceComposerCard.test.tsx` (`NewWorkspaceComposerCard note field`), all confirmed red against the previous code:

1. a note present at mount sizes the box to its content;
2. a note that arrives after mount — the reported PR-prefill path — regrows the box (previously `style.height` was never set at all);
3. the field keeps `max-h-40` and is scrollable rather than `overflow-hidden`.

happy-dom has no layout engine, so the suite stubs `HTMLElement.prototype.scrollHeight` for textareas, matching the approach already used in `MobileHero.test.tsx`.

`pnpm test`: 35930 passed, 47 failed across 14 files. Those 14 files fail identically at the parent commit (`6592c015`) — same file set, same 47 tests — so they are pre-existing and unrelated. They are local-environment failures (`window.localStorage.clear is not a function` and similar), none of them touching the composer.

## AI Review Report

Reviewed with Claude Code, working root-cause-first: traced the prefill from `handleSmartGitHubItemSelect` → `handleBaseBranchPrSelect` → `setNote`, then compared the broken field against the working `WorktreeMetaDialog` note field to isolate the three differences (no resize on programmatic write, `overflow-hidden`, `rows={1}`). The failing tests were written and confirmed red before the fix.

Risks checked:

- **Collapsed Advanced drawer.** It animates with `grid-rows-[0fr]` and always renders its children rather than unmounting them, so the textarea keeps a layout box and `scrollHeight` stays measurable while collapsed; expanding reveals an already-correct height.
- **Shrinking values.** `sizeToContent` resets to `height: auto` before measuring, so clearing the linked source collapses the box instead of stranding the taller height.
- **Chunked large paste.** `pasteTextIntoTextControl` writes the DOM value in chunks and fires one final input event; React's `onChange` then updates `note` and the effect resizes. Dropping `onInput` means the box settles once the paste completes instead of growing mid-paste — cosmetic, and the final height is correct.
- **Unbounded growth.** `max-h-40` still clamps, and the new `overflow-y-auto` is what makes the clamped remainder reachable.
- **Scrollbar styling gate.** `overflow-y-auto` requires a styled scrollbar class; `scrollbar-sleek` satisfies `pnpm check:styled-scrollbars`, which passes.

Cross-platform: explicitly checked. The change is renderer-only CSS and DOM measurement — no keyboard shortcuts, no modifier keys, no shortcut labels, no filesystem paths, no shell or Electron main-process behavior. `scrollHeight` and `style.height` behave identically across Chromium on macOS, Linux, and Windows, and `scrollbar-sleek` already ships `::-webkit-scrollbar` styling used app-wide. Nothing here is SSH-, WSL-, or Git-version-dependent, and the composer path is the same for folder workspaces and git worktrees.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The hook only reads `scrollHeight` and writes `style.height` on a DOM node it already owns; the note value itself is unchanged and still flows through the existing `pasteTextIntoTextControl` size guard, which keeps the oversized-paste rejection and its toast. No new dependencies. No follow-up needed.

## Notes

- No behavior change for GitHub issues or Linear issues — they never prefilled the note.
- `useAutoSizedTextarea` is deliberately not retrofitted onto `WorktreeMetaDialog` or `LinearIssueTextEditor` in this PR; both already size correctly, and consolidating them is a separate cleanup.
- A drag-to-resize handle was considered and skipped: auto-size plus scrolling removes the need, and `resize-none` keeps this field consistent with the other note editors.

## ELI5

Same PR-note clipping issue: prefilled Create Worktree notes didn't trigger height resize. The note grows with the prefilled PR title instead of hiding it behind overflow.
