### PR TITLE
fix(settings): scope terminal color overrides per light/dark mode

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -61,7 +61,8 @@ export function AgentTerminalPreview({ ptyId }: { ptyId: string }): React.JSX.El
     const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
     const theme = composeActiveTerminalTheme(
       appearance.theme ?? getBuiltinTheme(appearance.themeName),
-      settings
+      settings,
+      appearance.mode
     )
     return { terminalTheme: theme, terminalMode: appearance.mode }
   }, [settings, systemPrefersDark])

--- a/src/renderer/src/components/onboarding/ThemeStep.tsx
+++ b/src/renderer/src/components/onboarding/ThemeStep.tsx
@@ -10,6 +10,7 @@ import type {
   GhosttyImportPreview,
   GlobalSettings
 } from '../../../../shared/types'
+import { mergeImportedTerminalColorOverrides } from '../../../../shared/terminal-color-overrides'
 import { translate } from '@/i18n/i18n'
 import { ChromePreview } from './theme-chrome-preview'
 
@@ -145,15 +146,11 @@ export function ThemeStep({ theme, onThemeChange, settings, updateSettings }: Th
         track('onboarding_ghostty_import_failed', { reason: 'empty_diff' })
         return
       }
+      const { terminalColorOverrides, ...diffWithoutColorOverrides } = resolved.diff
       await updateSettings({
-        ...resolved.diff,
-        ...(resolved.diff.terminalColorOverrides
-          ? {
-              terminalColorOverrides: {
-                ...settings.terminalColorOverrides,
-                ...resolved.diff.terminalColorOverrides
-              }
-            }
+        ...diffWithoutColorOverrides,
+        ...(terminalColorOverrides
+          ? mergeImportedTerminalColorOverrides(settings, terminalColorOverrides)
           : {})
       })
       // Why: parent controller holds local `theme` state that overwrites

--- a/src/renderer/src/components/settings/TerminalColorOverridesSection.tsx
+++ b/src/renderer/src/components/settings/TerminalColorOverridesSection.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import {
+  resetTerminalColorOverridesForMode,
+  resolveTerminalColorOverridesForMode,
+  updateTerminalColorOverrideKey,
+  type TerminalColorOverrideMode
+} from '../../../../shared/terminal-color-overrides'
+import { Button } from '../ui/button'
+import { ColorField, SettingsSegmentedControl } from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+import { COLOR_OVERRIDE_GROUPS } from './terminal-window-color-groups'
+import { translate } from '@/i18n/i18n'
+
+type TerminalColorOverridesSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function TerminalColorOverridesSection({
+  settings,
+  updateSettings
+}: TerminalColorOverridesSectionProps): React.JSX.Element {
+  const [expanded, setExpanded] = useState(false)
+  const [mode, setMode] = useState<TerminalColorOverrideMode>('dark')
+  const activeOverrides = resolveTerminalColorOverridesForMode(settings, mode) ?? {}
+  const lightMatchesDark = mode === 'light' && !settings.terminalUseSeparateLightTheme
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.TerminalWindowSection.63f8d9336e',
+        'Color Overrides'
+      )}
+      description={translate(
+        'auto.components.settings.TerminalWindowSection.color_overrides_mode_description',
+        'Override individual terminal colors per appearance mode.'
+      )}
+      keywords={['color', 'override', 'ansi', 'palette', 'theme', 'dark', 'light']}
+      className="space-y-3"
+    >
+      <div className="space-y-2">
+        <button
+          onClick={() => setExpanded((prev) => !prev)}
+          className="flex items-center gap-2 text-sm font-medium"
+        >
+          <span className={`transition-transform ${expanded ? 'rotate-90' : ''}`}>▶</span>
+          {translate(
+            'auto.components.settings.TerminalWindowSection.63f8d9336e',
+            'Color Overrides'
+          )}
+        </button>
+        <div
+          className={`grid overflow-hidden transition-all duration-300 ease-out ${
+            expanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+          }`}
+        >
+          <div className="min-h-0 space-y-4">
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">
+                {translate(
+                  'auto.components.settings.TerminalWindowSection.color_overrides_mode_title',
+                  'Override mode'
+                )}
+              </p>
+              <SettingsSegmentedControl
+                value={mode}
+                onChange={setMode}
+                ariaLabel={translate(
+                  'auto.components.settings.TerminalWindowSection.color_overrides_mode_aria',
+                  'Terminal color override mode'
+                )}
+                equalWidth
+                options={[
+                  {
+                    value: 'dark',
+                    label: translate(
+                      'auto.components.settings.TerminalThemeSections.target_dark',
+                      'Dark'
+                    )
+                  },
+                  {
+                    value: 'light',
+                    label: translate(
+                      'auto.components.settings.TerminalThemeSections.target_light',
+                      'Light'
+                    )
+                  }
+                ]}
+              />
+              {lightMatchesDark ? (
+                <p className="text-xs text-muted-foreground">
+                  {translate(
+                    'auto.components.settings.TerminalWindowSection.color_overrides_match_dark_hint',
+                    'Light mode currently matches dark theme settings, so these dark overrides also apply in light mode. Turn off “Match dark mode” under Terminal Themes to keep light overrides separate.'
+                  )}
+                </p>
+              ) : null}
+            </div>
+
+            {COLOR_OVERRIDE_GROUPS.map((group) => (
+              <div key={group.label} className="space-y-2">
+                <p className="text-xs font-semibold text-muted-foreground">{group.label}</p>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {group.keys.map((item) => (
+                    <ColorField
+                      key={item.key}
+                      label={item.label}
+                      description={item.description}
+                      value={activeOverrides[item.key] ?? ''}
+                      fallback=""
+                      onChange={(value) =>
+                        updateSettings(
+                          updateTerminalColorOverrideKey(
+                            settings,
+                            mode,
+                            item.key,
+                            value || undefined
+                          )
+                        )
+                      }
+                    />
+                  ))}
+                </div>
+              </div>
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => updateSettings(resetTerminalColorOverridesForMode(settings, mode))}
+            >
+              {translate(
+                'auto.components.settings.TerminalWindowSection.03c855d15f',
+                'Reset all color overrides'
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/TerminalColorOverridesSection.tsx
+++ b/src/renderer/src/components/settings/TerminalColorOverridesSection.tsx
@@ -131,7 +131,8 @@ export function TerminalColorOverridesSection({
             >
               {translate(
                 'auto.components.settings.TerminalWindowSection.03c855d15f',
-                'Reset all color overrides'
+                'Reset {{value0}} color overrides',
+                { value0: mode }
               )}
             </Button>
           </div>

--- a/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
+++ b/src/renderer/src/components/settings/TerminalSettingsPreview.tsx
@@ -98,11 +98,14 @@ export function TerminalSettingsPreview({
 
   // Why: list composeActiveTerminalTheme inputs explicitly so font/cursor changes don't trigger a buffer rewrite.
   const composedTheme = useMemo(
-    () => composeActiveTerminalTheme(appearance.theme, settings),
+    () => composeActiveTerminalTheme(appearance.theme, settings, appearance.mode),
     // oxlint-disable-next-line react-hooks/exhaustive-deps
     [
       appearance,
       settings.terminalColorOverrides,
+      settings.terminalColorOverridesDark,
+      settings.terminalColorOverridesLight,
+      settings.terminalUseSeparateLightTheme,
       settings.terminalBackgroundOpacity,
       settings.terminalCursorOpacity
     ]

--- a/src/renderer/src/components/settings/TerminalWindowSection.tsx
+++ b/src/renderer/src/components/settings/TerminalWindowSection.tsx
@@ -3,8 +3,9 @@ import { RotateCw } from 'lucide-react'
 import type { GlobalSettings } from '../../../../shared/types'
 import { Button } from '../ui/button'
 import { Label } from '../ui/label'
-import { ColorField, NumberField } from './SettingsFormControls'
+import { NumberField } from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
+import { TerminalColorOverridesSection } from './TerminalColorOverridesSection'
 import { clampNumber } from '@/lib/terminal-theme'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { translate } from '@/i18n/i18n'
@@ -14,13 +15,10 @@ type TerminalWindowSectionProps = {
   updateSettings: (updates: Partial<GlobalSettings>) => void
 }
 
-import { COLOR_OVERRIDE_GROUPS } from './terminal-window-color-groups'
-
 export function TerminalWindowSection({
   settings,
   updateSettings
 }: TerminalWindowSectionProps): React.JSX.Element {
-  const [colorOverridesExpanded, setColorOverridesExpanded] = useState(false)
   // Why: windowBackgroundBlur is only read by createMainWindow() at startup
   // (macOS vibrancy / Windows acrylic both require window creation options),
   // so the UI has to ask the user to restart for the change to take effect.
@@ -277,75 +275,7 @@ export function TerminalWindowSection({
           </button>
         </SearchableSetting>
 
-        <SearchableSetting
-          title={translate(
-            'auto.components.settings.TerminalWindowSection.63f8d9336e',
-            'Color Overrides'
-          )}
-          description={translate(
-            'auto.components.settings.TerminalWindowSection.e86e09b5c7',
-            'Override individual terminal colors.'
-          )}
-          keywords={['color', 'override', 'ansi', 'palette', 'theme']}
-          className="space-y-3"
-        >
-          <div className="space-y-2">
-            <button
-              onClick={() => setColorOverridesExpanded((prev) => !prev)}
-              className="flex items-center gap-2 text-sm font-medium"
-            >
-              <span className={`transition-transform ${colorOverridesExpanded ? 'rotate-90' : ''}`}>
-                ▶
-              </span>
-              {translate(
-                'auto.components.settings.TerminalWindowSection.63f8d9336e',
-                'Color Overrides'
-              )}
-            </button>
-            <div
-              className={`grid overflow-hidden transition-all duration-300 ease-out ${
-                colorOverridesExpanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
-              }`}
-            >
-              <div className="min-h-0 space-y-4">
-                {COLOR_OVERRIDE_GROUPS.map((group) => (
-                  <div key={group.label} className="space-y-2">
-                    <p className="text-xs font-semibold text-muted-foreground">{group.label}</p>
-                    <div className="grid gap-2 sm:grid-cols-2">
-                      {group.keys.map((item) => (
-                        <ColorField
-                          key={item.key}
-                          label={item.label}
-                          description={item.description}
-                          value={settings.terminalColorOverrides?.[item.key] ?? ''}
-                          fallback=""
-                          onChange={(value) =>
-                            updateSettings({
-                              terminalColorOverrides: {
-                                ...settings.terminalColorOverrides,
-                                [item.key]: value || undefined
-                              }
-                            })
-                          }
-                        />
-                      ))}
-                    </div>
-                  </div>
-                ))}
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => updateSettings({ terminalColorOverrides: undefined })}
-                >
-                  {translate(
-                    'auto.components.settings.TerminalWindowSection.03c855d15f',
-                    'Reset all color overrides'
-                  )}
-                </Button>
-              </div>
-            </div>
-          </div>
-        </SearchableSetting>
+        <TerminalColorOverridesSection settings={settings} updateSettings={updateSettings} />
       </div>
     </section>
   )

--- a/src/renderer/src/components/settings/setting-labels.ts
+++ b/src/renderer/src/components/settings/setting-labels.ts
@@ -18,6 +18,8 @@ export const SETTING_LABELS: Partial<Record<keyof GlobalSettings, string>> = {
   primarySelectionMiddleClickPaste: 'Middle-click Paste from Selection',
   terminalFocusFollowsMouse: 'Focus Follows Mouse',
   terminalColorOverrides: 'Color Overrides',
+  terminalColorOverridesDark: 'Color Overrides (Dark)',
+  terminalColorOverridesLight: 'Color Overrides (Light)',
   terminalMacOptionAsAlt: 'Option as Alt',
   terminalPaddingX: 'Padding X',
   terminalPaddingY: 'Padding Y',

--- a/src/renderer/src/components/settings/useGhosttyImport.test.ts
+++ b/src/renderer/src/components/settings/useGhosttyImport.test.ts
@@ -227,8 +227,10 @@ describe('useGhosttyImport', () => {
     await ghostty.handleApply()
 
     expect(updateSettings).toHaveBeenCalledTimes(1)
+    // Why: first import promotes into dark-only so light mode is not polluted.
     expect(updateSettings).toHaveBeenCalledWith({
-      terminalColorOverrides: {
+      terminalColorOverrides: undefined,
+      terminalColorOverridesDark: {
         foreground: '#e0e0e0',
         red: '#ff0000',
         background: '#1a1a1a'

--- a/src/renderer/src/components/settings/useGhosttyImport.ts
+++ b/src/renderer/src/components/settings/useGhosttyImport.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import type { GhosttyImportPreview, GlobalSettings } from '../../../../shared/types'
+import { mergeImportedTerminalColorOverrides } from '../../../../shared/terminal-color-overrides'
 import { useMountedRef } from '../../hooks/useMountedRef'
 
 export type UseGhosttyImportReturn = {
@@ -52,15 +53,11 @@ export function useGhosttyImport(
     if (applied || !preview?.found || Object.keys(preview.diff).length === 0 || !settings) {
       return
     }
+    const { terminalColorOverrides, ...diffWithoutColorOverrides } = preview.diff
     const merged = {
-      ...preview.diff,
-      ...(preview.diff.terminalColorOverrides
-        ? {
-            terminalColorOverrides: {
-              ...settings.terminalColorOverrides,
-              ...preview.diff.terminalColorOverrides
-            }
-          }
+      ...diffWithoutColorOverrides,
+      ...(terminalColorOverrides
+        ? mergeImportedTerminalColorOverrides(settings, terminalColorOverrides)
         : {})
     }
     setApplyError(null)

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -15,6 +15,7 @@ import {
   resolveOpaqueTerminalBackground,
   resolveEffectiveTerminalAppearance
 } from '@/lib/terminal-theme'
+import { resolveTerminalColorOverridesForMode } from '../../../../shared/terminal-color-overrides'
 import type {
   ManagedPane,
   PaneExternalDropTarget,
@@ -2777,8 +2778,11 @@ export default function TerminalPane({
   const effectiveAppearance = settings
     ? resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
     : null
+  const terminalColorOverrides = settings
+    ? resolveTerminalColorOverridesForMode(settings, effectiveAppearance?.mode ?? 'dark')
+    : undefined
   const terminalBackground =
-    settings?.terminalColorOverrides?.background ?? effectiveAppearance?.theme?.background
+    terminalColorOverrides?.background ?? effectiveAppearance?.theme?.background
   // Why: app light/dark can diverge from the terminal theme, so pane-title contrast follows the effective terminal surface.
   const titleUsesLightSurface = isTerminalBackgroundLight(terminalBackground, {
     appSurface: effectiveAppearance?.mode,

--- a/src/renderer/src/components/terminal-pane/compose-active-terminal-theme.test.ts
+++ b/src/renderer/src/components/terminal-pane/compose-active-terminal-theme.test.ts
@@ -48,6 +48,17 @@ describe('composeActiveTerminalTheme', () => {
     expect(result!.background).toBe('#101010')
   })
 
+  it('applies only the mode-specific color override bag', () => {
+    const base = { background: '#101010', foreground: '#fafafa' }
+    const settings = settingsWith({
+      terminalUseSeparateLightTheme: true,
+      terminalColorOverridesDark: { background: '#0a0a0a' },
+      terminalColorOverridesLight: { background: '#f5f5f5' }
+    })
+    expect(composeActiveTerminalTheme(base, settings, 'dark')!.background).toBe('#0a0a0a')
+    expect(composeActiveTerminalTheme(base, settings, 'light')!.background).toBe('#f5f5f5')
+  })
+
   it('applies background opacity by converting the hex background to rgba', () => {
     const base = { background: '#112233' }
     const result = composeActiveTerminalTheme(

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -1,6 +1,7 @@
 import type { IDisposable, IParser, ITheme } from '@xterm/xterm'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import type { GlobalSettings } from '../../../../shared/types'
+import { resolveTerminalColorOverridesForMode } from '../../../../shared/terminal-color-overrides'
 import { resolveTerminalFontWeights } from '../../../../shared/terminal-fonts'
 import { resolveTerminalLigaturesEnabled } from '../../../../shared/terminal-ligatures'
 import {
@@ -100,8 +101,14 @@ export function composeActiveTerminalTheme(
   baseTheme: ITheme | null,
   settings: Pick<
     GlobalSettings,
-    'terminalColorOverrides' | 'terminalBackgroundOpacity' | 'terminalCursorOpacity'
-  >
+    | 'terminalColorOverrides'
+    | 'terminalColorOverridesDark'
+    | 'terminalColorOverridesLight'
+    | 'terminalUseSeparateLightTheme'
+    | 'terminalBackgroundOpacity'
+    | 'terminalCursorOpacity'
+  >,
+  mode: 'dark' | 'light' = 'dark'
 ): ITheme | null {
   if (!baseTheme) {
     return null
@@ -115,9 +122,10 @@ export function composeActiveTerminalTheme(
     scrollbarSliderActiveBackground: 'rgba(180, 180, 185, 0.8)',
     ...baseTheme
   }
-  // Why: merge Ghostty color overrides atop the base theme so individual colors can be tweaked without losing the rest.
-  if (settings.terminalColorOverrides) {
-    theme = { ...theme, ...settings.terminalColorOverrides }
+  // Why: merge mode-scoped color overrides atop the base theme so light/dark can differ.
+  const colorOverrides = resolveTerminalColorOverridesForMode(settings, mode)
+  if (colorOverrides) {
+    theme = { ...theme, ...colorOverrides }
   }
   // Why: convert the hex background to rgba so xterm honors the opacity when allowTransparency is set.
   if (settings.terminalBackgroundOpacity !== undefined && theme.background) {
@@ -148,7 +156,7 @@ export function publishTerminalViewAttributesAtAppStart(
   }
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const baseTheme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
-  const theme = composeActiveTerminalTheme(baseTheme, settings)
+  const theme = composeActiveTerminalTheme(baseTheme, settings, appearance.mode)
   return send !== undefined
     ? publishTerminalViewAttributes(theme, appearance.mode, settings, send)
     : publishTerminalViewAttributes(theme, appearance.mode, settings)
@@ -192,7 +200,7 @@ export function applyTerminalAppearance(
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
   const paneStyles = resolvePaneStyleOptions(settings)
   const baseTheme: ITheme | null = appearance.theme ?? getBuiltinTheme(appearance.themeName)
-  const theme = composeActiveTerminalTheme(baseTheme, settings)
+  const theme = composeActiveTerminalTheme(baseTheme, settings, appearance.mode)
   // Publish composed appearance to main's hidden-PTY query responder — the only point it exists; deduped in the publisher.
   publishTerminalViewAttributes(theme, appearance.mode, settings)
   const paneBackground = theme?.background ?? '#000000'

--- a/src/renderer/src/lib/left-sidebar-appearance.ts
+++ b/src/renderer/src/lib/left-sidebar-appearance.ts
@@ -4,6 +4,7 @@ import {
   normalizeLeftSidebarTintColor,
   normalizeLeftSidebarTintOpacity
 } from '../../../shared/left-sidebar-appearance'
+import { resolveTerminalColorOverridesForMode } from '../../../shared/terminal-color-overrides'
 import { resolveEffectiveTerminalAppearance } from './terminal-theme'
 
 type LeftSidebarAppearanceSettings = Pick<
@@ -19,6 +20,8 @@ type LeftSidebarAppearanceSettings = Pick<
   | 'terminalCustomThemes'
   | 'terminalDividerColorLight'
   | 'terminalColorOverrides'
+  | 'terminalColorOverridesDark'
+  | 'terminalColorOverridesLight'
   | 'terminalBackgroundOpacity'
 >
 
@@ -94,12 +97,12 @@ function resolveTerminalSurfaceVariables(
   systemPrefersDark: boolean
 ): LeftSidebarStyleVariables {
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
+  const colorOverrides = resolveTerminalColorOverridesForMode(settings, appearance.mode)
   const background = applyAlpha(
-    settings.terminalColorOverrides?.background ?? appearance.theme?.background ?? '#000000',
+    colorOverrides?.background ?? appearance.theme?.background ?? '#000000',
     settings.terminalBackgroundOpacity
   )
-  const foreground =
-    settings.terminalColorOverrides?.foreground ?? appearance.theme?.foreground ?? '#fafafa'
+  const foreground = colorOverrides?.foreground ?? appearance.theme?.foreground ?? '#fafafa'
   return buildSurfaceVariables({ background, foreground, overrideTextTokens: true })
 }
 

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -10,6 +10,7 @@ import { createBrowserUuid } from '@/lib/browser-uuid'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
 import { getSystemPrefersDark, resolveEffectiveTerminalAppearance } from '@/lib/terminal-theme'
+import { resolveTerminalColorOverridesForMode } from '../../../shared/terminal-color-overrides'
 import { sanitizeTerminalLayoutPaneTitles } from '@/lib/terminal-pane-title-sanitization'
 import type { AppState } from '@/store/types'
 import type {
@@ -1239,9 +1240,8 @@ function resolveMobileTerminalTheme(
     return undefined
   }
   const appearance = resolveEffectiveTerminalAppearance(settings, systemPrefersDark)
-  const resolvedTheme = appearance.theme
-    ? { ...appearance.theme, ...settings.terminalColorOverrides }
-    : undefined
+  const colorOverrides = resolveTerminalColorOverridesForMode(settings, appearance.mode)
+  const resolvedTheme = appearance.theme ? { ...appearance.theme, ...colorOverrides } : undefined
   if (!resolvedTheme) {
     return undefined
   }

--- a/src/shared/terminal-color-overrides.test.ts
+++ b/src/shared/terminal-color-overrides.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   hasPerModeTerminalColorOverrides,
+  mergeImportedTerminalColorOverrides,
   resetTerminalColorOverridesForMode,
   resolveTerminalColorOverridesForMode,
   updateTerminalColorOverrideKey
@@ -79,6 +80,20 @@ describe('updateTerminalColorOverrideKey', () => {
       terminalColorOverridesLight: { background: '#ffffff', foreground: '#111111' }
     })
   })
+
+  it('writes the dark bag when light matches dark so overrides do not disappear', () => {
+    const before = settings({
+      terminalUseSeparateLightTheme: false,
+      terminalColorOverrides: { background: '#111111' }
+    })
+    const updates = updateTerminalColorOverrideKey(before, 'light', 'background', '#0a0a0a')
+    expect(updates.terminalColorOverrides).toBeUndefined()
+    expect(updates.terminalColorOverridesDark).toEqual({ background: '#0a0a0a' })
+    expect(updates.terminalColorOverridesLight).toBeUndefined()
+    expect(
+      resolveTerminalColorOverridesForMode({ ...before, ...updates }, 'light')?.background
+    ).toBe('#0a0a0a')
+  })
 })
 
 describe('resetTerminalColorOverridesForMode', () => {
@@ -98,6 +113,42 @@ describe('resetTerminalColorOverridesForMode', () => {
     expect(updates.terminalColorOverrides).toBeUndefined()
     expect(updates.terminalColorOverridesDark).toBeUndefined()
     expect(updates.terminalColorOverridesLight).toEqual({ background: '#111111' })
+  })
+
+  it('clears the effective dark bag when light matches dark', () => {
+    const before = settings({
+      terminalUseSeparateLightTheme: false,
+      terminalColorOverridesDark: { background: '#0a0a0a' },
+      terminalColorOverridesLight: { background: '#ffffff' }
+    })
+    expect(resetTerminalColorOverridesForMode(before, 'light')).toEqual({
+      terminalColorOverridesDark: undefined
+    })
+  })
+})
+
+describe('mergeImportedTerminalColorOverrides', () => {
+  it('promotes the first import into a dark-only bag and clears legacy', () => {
+    const before = settings({ terminalColorOverrides: { foreground: '#e0e0e0' } })
+    const updates = mergeImportedTerminalColorOverrides(before, { background: '#1a1a1a' })
+    expect(updates).toEqual({
+      terminalColorOverrides: undefined,
+      terminalColorOverridesDark: { foreground: '#e0e0e0', background: '#1a1a1a' }
+    })
+    expect(resolveTerminalColorOverridesForMode({ ...before, ...updates }, 'light')).toBeUndefined()
+    expect(
+      resolveTerminalColorOverridesForMode({ ...before, ...updates }, 'dark')?.background
+    ).toBe('#1a1a1a')
+  })
+
+  it('merges into the existing dark bag when per-mode storage already exists', () => {
+    const before = settings({
+      terminalColorOverridesDark: { foreground: '#ccc' },
+      terminalColorOverridesLight: { background: '#fff' }
+    })
+    expect(mergeImportedTerminalColorOverrides(before, { red: '#f00' })).toEqual({
+      terminalColorOverridesDark: { foreground: '#ccc', red: '#f00' }
+    })
   })
 })
 

--- a/src/shared/terminal-color-overrides.test.ts
+++ b/src/shared/terminal-color-overrides.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  hasPerModeTerminalColorOverrides,
+  resetTerminalColorOverridesForMode,
+  resolveTerminalColorOverridesForMode,
+  updateTerminalColorOverrideKey
+} from './terminal-color-overrides'
+import type { GlobalSettings } from './types'
+
+function settings(
+  partial: Partial<
+    Pick<
+      GlobalSettings,
+      | 'terminalColorOverrides'
+      | 'terminalColorOverridesDark'
+      | 'terminalColorOverridesLight'
+      | 'terminalUseSeparateLightTheme'
+    >
+  > = {}
+): Pick<
+  GlobalSettings,
+  | 'terminalColorOverrides'
+  | 'terminalColorOverridesDark'
+  | 'terminalColorOverridesLight'
+  | 'terminalUseSeparateLightTheme'
+> {
+  return {
+    terminalUseSeparateLightTheme: true,
+    ...partial
+  }
+}
+
+describe('resolveTerminalColorOverridesForMode', () => {
+  it('uses the legacy bag for both modes before any per-mode edit', () => {
+    const s = settings({ terminalColorOverrides: { background: '#111111' } })
+    expect(resolveTerminalColorOverridesForMode(s, 'dark')?.background).toBe('#111111')
+    expect(resolveTerminalColorOverridesForMode(s, 'light')?.background).toBe('#111111')
+  })
+
+  it('stops applying dark overrides to light after a dark-only edit', () => {
+    const s = settings({
+      terminalColorOverridesDark: { background: '#0a0a0a' },
+      terminalColorOverridesLight: undefined
+    })
+    expect(resolveTerminalColorOverridesForMode(s, 'dark')?.background).toBe('#0a0a0a')
+    expect(resolveTerminalColorOverridesForMode(s, 'light')).toBeUndefined()
+  })
+
+  it('reuses dark overrides in light when light matches dark mode', () => {
+    const s = settings({
+      terminalUseSeparateLightTheme: false,
+      terminalColorOverridesDark: { background: '#0a0a0a' }
+    })
+    expect(resolveTerminalColorOverridesForMode(s, 'light')?.background).toBe('#0a0a0a')
+  })
+})
+
+describe('updateTerminalColorOverrideKey', () => {
+  it('promotes the first dark edit into a dark-only bag so light is no longer covered', () => {
+    const before = settings({ terminalColorOverrides: { background: '#111111', red: '#ff0000' } })
+    const updates = updateTerminalColorOverrideKey(before, 'dark', 'background', '#0a0a0a')
+    expect(updates.terminalColorOverrides).toBeUndefined()
+    expect(updates.terminalColorOverridesDark).toEqual({
+      background: '#0a0a0a',
+      red: '#ff0000'
+    })
+    expect(updates.terminalColorOverridesLight).toBeUndefined()
+    expect(resolveTerminalColorOverridesForMode({ ...before, ...updates }, 'light')).toBeUndefined()
+  })
+
+  it('updates only the light bag on subsequent light edits', () => {
+    const before = settings({
+      terminalColorOverridesDark: { background: '#0a0a0a' },
+      terminalColorOverridesLight: { background: '#ffffff' }
+    })
+    const updates = updateTerminalColorOverrideKey(before, 'light', 'foreground', '#111111')
+    expect(updates).toEqual({
+      terminalColorOverridesLight: { background: '#ffffff', foreground: '#111111' }
+    })
+  })
+})
+
+describe('resetTerminalColorOverridesForMode', () => {
+  it('clears only the requested mode after dual-mode storage exists', () => {
+    const before = settings({
+      terminalColorOverridesDark: { background: '#0a0a0a' },
+      terminalColorOverridesLight: { background: '#ffffff' }
+    })
+    expect(resetTerminalColorOverridesForMode(before, 'light')).toEqual({
+      terminalColorOverridesLight: undefined
+    })
+  })
+
+  it('splits a legacy bag so reset only clears the edited mode', () => {
+    const before = settings({ terminalColorOverrides: { background: '#111111' } })
+    const updates = resetTerminalColorOverridesForMode(before, 'dark')
+    expect(updates.terminalColorOverrides).toBeUndefined()
+    expect(updates.terminalColorOverridesDark).toBeUndefined()
+    expect(updates.terminalColorOverridesLight).toEqual({ background: '#111111' })
+  })
+})
+
+describe('hasPerModeTerminalColorOverrides', () => {
+  it('is false for legacy-only settings', () => {
+    expect(
+      hasPerModeTerminalColorOverrides(settings({ terminalColorOverrides: { red: '#f00' } }))
+    ).toBe(false)
+  })
+
+  it('is true once either mode bag exists', () => {
+    expect(hasPerModeTerminalColorOverrides(settings({ terminalColorOverridesDark: {} }))).toBe(
+      true
+    )
+  })
+})

--- a/src/shared/terminal-color-overrides.ts
+++ b/src/shared/terminal-color-overrides.ts
@@ -1,0 +1,124 @@
+import type { GlobalSettings, TerminalColorOverrides } from './types'
+
+export type TerminalColorOverrideSettings = Pick<
+  GlobalSettings,
+  | 'terminalColorOverrides'
+  | 'terminalColorOverridesDark'
+  | 'terminalColorOverridesLight'
+  | 'terminalUseSeparateLightTheme'
+>
+
+export type TerminalColorOverrideMode = 'dark' | 'light'
+
+export function hasPerModeTerminalColorOverrides(settings: TerminalColorOverrideSettings): boolean {
+  return (
+    settings.terminalColorOverridesDark !== undefined ||
+    settings.terminalColorOverridesLight !== undefined
+  )
+}
+
+function compactOverrides(overrides: TerminalColorOverrides): TerminalColorOverrides | undefined {
+  return Object.keys(overrides).length > 0 ? overrides : undefined
+}
+
+function cloneOverrides(overrides: TerminalColorOverrides | undefined): TerminalColorOverrides {
+  return overrides ? { ...overrides } : {}
+}
+
+/**
+ * Resolve which color-override bag applies for a terminal appearance mode.
+ *
+ * - Legacy single `terminalColorOverrides` still covers both modes until the
+ *   user edits a mode-specific bag.
+ * - When light mode "matches dark", light terminals use the dark bag.
+ */
+export function resolveTerminalColorOverridesForMode(
+  settings: TerminalColorOverrideSettings,
+  mode: TerminalColorOverrideMode
+): TerminalColorOverrides | undefined {
+  const effectiveMode: TerminalColorOverrideMode =
+    mode === 'light' && !settings.terminalUseSeparateLightTheme ? 'dark' : mode
+
+  if (hasPerModeTerminalColorOverrides(settings)) {
+    return effectiveMode === 'light'
+      ? settings.terminalColorOverridesLight
+      : settings.terminalColorOverridesDark
+  }
+  return settings.terminalColorOverrides
+}
+
+/**
+ * First dual-mode edit seeds only the target mode from the legacy bag so the
+ * other mode starts clean (fixes shared-override bleed across light/dark).
+ */
+export function updateTerminalColorOverrideKey(
+  settings: TerminalColorOverrideSettings,
+  mode: TerminalColorOverrideMode,
+  key: keyof TerminalColorOverrides,
+  value: string | undefined
+): Partial<GlobalSettings> {
+  if (!hasPerModeTerminalColorOverrides(settings)) {
+    const seeded = cloneOverrides(settings.terminalColorOverrides)
+    if (value) {
+      seeded[key] = value
+    } else {
+      delete seeded[key]
+    }
+    return {
+      terminalColorOverrides: undefined,
+      terminalColorOverridesDark: mode === 'dark' ? compactOverrides(seeded) : undefined,
+      terminalColorOverridesLight: mode === 'light' ? compactOverrides(seeded) : undefined
+    }
+  }
+
+  const bag = cloneOverrides(
+    mode === 'light' ? settings.terminalColorOverridesLight : settings.terminalColorOverridesDark
+  )
+  if (value) {
+    bag[key] = value
+  } else {
+    delete bag[key]
+  }
+  return mode === 'light'
+    ? { terminalColorOverridesLight: compactOverrides(bag) }
+    : { terminalColorOverridesDark: compactOverrides(bag) }
+}
+
+/** Merge an imported palette into the dark bag (or legacy when still shared). */
+export function mergeImportedTerminalColorOverrides(
+  settings: TerminalColorOverrideSettings,
+  imported: TerminalColorOverrides
+): Partial<GlobalSettings> {
+  if (!hasPerModeTerminalColorOverrides(settings)) {
+    return {
+      terminalColorOverrides: {
+        ...settings.terminalColorOverrides,
+        ...imported
+      }
+    }
+  }
+  return {
+    terminalColorOverridesDark: {
+      ...settings.terminalColorOverridesDark,
+      ...imported
+    }
+  }
+}
+
+export function resetTerminalColorOverridesForMode(
+  settings: TerminalColorOverrideSettings,
+  mode: TerminalColorOverrideMode
+): Partial<GlobalSettings> {
+  if (!hasPerModeTerminalColorOverrides(settings)) {
+    // Legacy bag was shared; clear only the edited mode and leave the other
+    // mode without overrides so light/dark no longer share the old values.
+    return {
+      terminalColorOverrides: undefined,
+      terminalColorOverridesDark: mode === 'dark' ? undefined : settings.terminalColorOverrides,
+      terminalColorOverridesLight: mode === 'light' ? undefined : settings.terminalColorOverrides
+    }
+  }
+  return mode === 'light'
+    ? { terminalColorOverridesLight: undefined }
+    : { terminalColorOverridesDark: undefined }
+}

--- a/src/shared/terminal-color-overrides.ts
+++ b/src/shared/terminal-color-overrides.ts
@@ -25,6 +25,14 @@ function cloneOverrides(overrides: TerminalColorOverrides | undefined): Terminal
   return overrides ? { ...overrides } : {}
 }
 
+/** Map UI mode to the bag that rendering actually uses when light matches dark. */
+export function effectiveTerminalColorOverrideMode(
+  settings: Pick<TerminalColorOverrideSettings, 'terminalUseSeparateLightTheme'>,
+  mode: TerminalColorOverrideMode
+): TerminalColorOverrideMode {
+  return mode === 'light' && !settings.terminalUseSeparateLightTheme ? 'dark' : mode
+}
+
 /**
  * Resolve which color-override bag applies for a terminal appearance mode.
  *
@@ -36,8 +44,7 @@ export function resolveTerminalColorOverridesForMode(
   settings: TerminalColorOverrideSettings,
   mode: TerminalColorOverrideMode
 ): TerminalColorOverrides | undefined {
-  const effectiveMode: TerminalColorOverrideMode =
-    mode === 'light' && !settings.terminalUseSeparateLightTheme ? 'dark' : mode
+  const effectiveMode = effectiveTerminalColorOverrideMode(settings, mode)
 
   if (hasPerModeTerminalColorOverrides(settings)) {
     return effectiveMode === 'light'
@@ -50,6 +57,7 @@ export function resolveTerminalColorOverridesForMode(
 /**
  * First dual-mode edit seeds only the target mode from the legacy bag so the
  * other mode starts clean (fixes shared-override bleed across light/dark).
+ * Edits always target the effective bag when light matches dark.
  */
 export function updateTerminalColorOverrideKey(
   settings: TerminalColorOverrideSettings,
@@ -57,6 +65,8 @@ export function updateTerminalColorOverrideKey(
   key: keyof TerminalColorOverrides,
   value: string | undefined
 ): Partial<GlobalSettings> {
+  const effectiveMode = effectiveTerminalColorOverrideMode(settings, mode)
+
   if (!hasPerModeTerminalColorOverrides(settings)) {
     const seeded = cloneOverrides(settings.terminalColorOverrides)
     if (value) {
@@ -66,32 +76,39 @@ export function updateTerminalColorOverrideKey(
     }
     return {
       terminalColorOverrides: undefined,
-      terminalColorOverridesDark: mode === 'dark' ? compactOverrides(seeded) : undefined,
-      terminalColorOverridesLight: mode === 'light' ? compactOverrides(seeded) : undefined
+      terminalColorOverridesDark: effectiveMode === 'dark' ? compactOverrides(seeded) : undefined,
+      terminalColorOverridesLight: effectiveMode === 'light' ? compactOverrides(seeded) : undefined
     }
   }
 
   const bag = cloneOverrides(
-    mode === 'light' ? settings.terminalColorOverridesLight : settings.terminalColorOverridesDark
+    effectiveMode === 'light'
+      ? settings.terminalColorOverridesLight
+      : settings.terminalColorOverridesDark
   )
   if (value) {
     bag[key] = value
   } else {
     delete bag[key]
   }
-  return mode === 'light'
+  return effectiveMode === 'light'
     ? { terminalColorOverridesLight: compactOverrides(bag) }
     : { terminalColorOverridesDark: compactOverrides(bag) }
 }
 
-/** Merge an imported palette into the dark bag (or legacy when still shared). */
+/**
+ * Merge an imported palette into the dark bag.
+ * Why dark-only: Ghostty/Warp themes are dark-biased; writing legacy would
+ * bleed into light until the first per-mode edit.
+ */
 export function mergeImportedTerminalColorOverrides(
   settings: TerminalColorOverrideSettings,
   imported: TerminalColorOverrides
 ): Partial<GlobalSettings> {
   if (!hasPerModeTerminalColorOverrides(settings)) {
     return {
-      terminalColorOverrides: {
+      terminalColorOverrides: undefined,
+      terminalColorOverridesDark: {
         ...settings.terminalColorOverrides,
         ...imported
       }
@@ -109,16 +126,20 @@ export function resetTerminalColorOverridesForMode(
   settings: TerminalColorOverrideSettings,
   mode: TerminalColorOverrideMode
 ): Partial<GlobalSettings> {
+  const effectiveMode = effectiveTerminalColorOverrideMode(settings, mode)
+
   if (!hasPerModeTerminalColorOverrides(settings)) {
-    // Legacy bag was shared; clear only the edited mode and leave the other
+    // Legacy bag was shared; clear only the effective mode and leave the other
     // mode without overrides so light/dark no longer share the old values.
     return {
       terminalColorOverrides: undefined,
-      terminalColorOverridesDark: mode === 'dark' ? undefined : settings.terminalColorOverrides,
-      terminalColorOverridesLight: mode === 'light' ? undefined : settings.terminalColorOverrides
+      terminalColorOverridesDark:
+        effectiveMode === 'dark' ? undefined : settings.terminalColorOverrides,
+      terminalColorOverridesLight:
+        effectiveMode === 'light' ? undefined : settings.terminalColorOverrides
     }
   }
-  return mode === 'light'
+  return effectiveMode === 'light'
     ? { terminalColorOverridesLight: undefined }
     : { terminalColorOverridesDark: undefined }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2692,7 +2692,16 @@ export type GlobalSettings = {
   terminalPaneOpacityTransitionMs: number
   terminalDividerThicknessPx: number
   terminalBackgroundOpacity?: number
+  /**
+   * Legacy single-bag color overrides applied to both light and dark until the
+   * user edits a mode-specific bag (`terminalColorOverridesDark` /
+   * `terminalColorOverridesLight`). Prefer the mode-specific fields for new writes.
+   */
   terminalColorOverrides?: TerminalColorOverrides
+  /** Color overrides applied only in dark terminal appearance mode. */
+  terminalColorOverridesDark?: TerminalColorOverrides
+  /** Color overrides applied only in light terminal appearance mode (when separate). */
+  terminalColorOverridesLight?: TerminalColorOverrides
   terminalPaddingX?: number
   terminalPaddingY?: number
   terminalMouseHideWhileTyping?: boolean


### PR DESCRIPTION
## Summary

- Terminal **Color Overrides** were a single global bag (`terminalColorOverrides`), so a dark-mode background override also covered light mode (#10561).
- Add mode-specific `terminalColorOverridesDark` / `terminalColorOverridesLight`, keep the legacy bag until the first per-mode edit, and resolve overrides from the effective terminal appearance mode (light “Match dark mode” reuses the dark bag).
- Settings UI gains a Dark/Light control under Color Overrides; Ghostty/onboarding imports still merge cleanly into legacy or the dark bag.

## Test plan

- [x] `vitest` — `terminal-color-overrides`, `compose-active-terminal-theme`, `useGhosttyImport`, `left-sidebar-appearance`
- [ ] Appearance → Terminal → Color Overrides: set dark background only; switch app to light with separate light theme → light terminal should keep its theme background
- [ ] With “Match dark mode” on for light theme, dark overrides still apply in light
- [ ] Ghostty import still applies color overrides

Closes #10561

## ELI5

Terminal color overrides applied to both light and dark modes together, so a dark background tweak broke light mode. Overrides are per light/dark mode with a clear Settings control.
