### PR TITLE
fix(computer-use): probe Linux editables via get_editable_text_iface

### DIFF
--- a/config/scripts/verify-computer-native.mjs
+++ b/config/scripts/verify-computer-native.mjs
@@ -185,6 +185,16 @@ function verifyNativeArgumentGuardrails() {
   )
   const windows = readFileSync(join(repoRoot, 'native/computer-use-windows/runtime.ps1'), 'utf8')
   const failures = []
+  // Why: GI bindings do not expose the C-only editable-text predicate; looking
+  // it up as an attribute raises before attempt() can catch it (#10569).
+  if (linux.includes('node.is_editable_text') || linux.includes('is_editable_text,')) {
+    failures.push(
+      'Linux set_value must not look up node.is_editable_text (use get_editable_text_iface)'
+    )
+  }
+  if (!linux.includes('get_editable_text_iface')) {
+    failures.push('Linux set_value must probe editability via get_editable_text_iface')
+  }
   if (linux.includes('count or 1') || linux.includes('pages or 1')) {
     failures.push('Linux provider must not coerce explicit zero action values to defaults')
   }

--- a/config/scripts/verify-computer-native.mjs
+++ b/config/scripts/verify-computer-native.mjs
@@ -187,17 +187,26 @@ function stripPythonComments(source) {
     const ch = source[i]
     const next = source[i + 1]
     // Triple-quoted strings (keep contents so string literals still scan).
+    // Why: honor escaped delimiters so `\"\"\"` inside a triple-string does not
+    // end the string early and reclassify later code as comments (#10586 CR).
     if ((ch === '"' || ch === "'") && next === ch && source[i + 2] === ch) {
       const quote = ch.repeat(3)
       out += quote
       i += 3
-      while (i < n && source.slice(i, i + 3) !== quote) {
+      while (i < n) {
+        if (source[i] === '\\' && i + 1 < n) {
+          out += source[i]
+          out += source[i + 1]
+          i += 2
+          continue
+        }
+        if (source.slice(i, i + 3) === quote) {
+          out += quote
+          i += 3
+          break
+        }
         out += source[i]
         i += 1
-      }
-      if (i < n) {
-        out += quote
-        i += 3
       }
       continue
     }
@@ -245,10 +254,9 @@ function verifyNativeArgumentGuardrails() {
   const failures = []
   // Why: GI bindings do not expose the C-only editable-text predicate; looking
   // it up as an attribute raises before attempt() can catch it (#10569).
-  if (linux.includes('node.is_editable_text') || linux.includes('is_editable_text,')) {
-    failures.push(
-      'Linux set_value must not look up node.is_editable_text (use get_editable_text_iface)'
-    )
+  // Match any attribute lookup form, not only `node.is_editable_text` (#10586 CR).
+  if (/(?:^|[^A-Za-z0-9_])is_editable_text(?:\s*[,(]|\s*$)/m.test(linux)) {
+    failures.push('Linux set_value must not look up is_editable_text (use get_editable_text_iface)')
   }
   if (!linux.includes('get_editable_text_iface')) {
     failures.push('Linux set_value must probe editability via get_editable_text_iface')

--- a/config/scripts/verify-computer-native.mjs
+++ b/config/scripts/verify-computer-native.mjs
@@ -177,8 +177,66 @@ function verifyWindowsProviderHandshake() {
   }
 }
 
+// Why: editable-text probes must not false-fail on explanatory comments or
+// false-pass when the required call only appears in a comment (#10569 CR).
+function stripPythonComments(source) {
+  let out = ''
+  let i = 0
+  const n = source.length
+  while (i < n) {
+    const ch = source[i]
+    const next = source[i + 1]
+    // Triple-quoted strings (keep contents so string literals still scan).
+    if ((ch === '"' || ch === "'") && next === ch && source[i + 2] === ch) {
+      const quote = ch.repeat(3)
+      out += quote
+      i += 3
+      while (i < n && source.slice(i, i + 3) !== quote) {
+        out += source[i]
+        i += 1
+      }
+      if (i < n) {
+        out += quote
+        i += 3
+      }
+      continue
+    }
+    // Single/double quoted strings.
+    if (ch === '"' || ch === "'") {
+      const quote = ch
+      out += quote
+      i += 1
+      while (i < n) {
+        const cur = source[i]
+        out += cur
+        i += 1
+        if (cur === '\\' && i < n) {
+          out += source[i]
+          i += 1
+          continue
+        }
+        if (cur === quote) {
+          break
+        }
+      }
+      continue
+    }
+    if (ch === '#') {
+      while (i < n && source[i] !== '\n') {
+        i += 1
+      }
+      continue
+    }
+    out += ch
+    i += 1
+  }
+  return out
+}
+
 function verifyNativeArgumentGuardrails() {
-  const linux = readFileSync(join(repoRoot, 'native/computer-use-linux/runtime.py'), 'utf8')
+  const linuxSource = readFileSync(join(repoRoot, 'native/computer-use-linux/runtime.py'), 'utf8')
+  // Why: comment-only mentions of forbidden/required probes must not drive the guard.
+  const linux = stripPythonComments(linuxSource)
   const macos = readFileSync(
     join(repoRoot, 'native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift'),
     'utf8'

--- a/native/computer-use-linux/runtime.py
+++ b/native/computer-use-linux/runtime.py
@@ -1010,9 +1010,14 @@ def write_clipboard(value):
 
 
 def set_value(node, value):
-    if node is not None and bool(attempt(node.is_editable_text, False)):
+    # Why: Python GI Atspi.Accessible lacks the C-only editable-text predicate;
+    # probing it as an attribute raises AttributeError before attempt() runs.
+    # Use get_editable_text_iface, which the GI bindings expose (#10569).
+    if node is not None:
         editable = attempt(node.get_editable_text_iface)
-        if editable is not None and attempt(lambda: Atspi.EditableText.set_text_contents(editable, str(value)), False):
+        if editable is not None and attempt(
+            lambda: Atspi.EditableText.set_text_contents(editable, str(value)), False
+        ):
             return True
     value_iface = attempt(node.get_value_iface) if node is not None else None
     if value_iface is not None:

--- a/native/computer-use-linux/set_value_test.py
+++ b/native/computer-use-linux/set_value_test.py
@@ -1,0 +1,100 @@
+# Why: set_value must not touch Accessible.is_editable_text (not in Python GI).
+# This module-level unit test stubs ATSPI and exercises the iface probe path.
+# Source: bbingz set_value_test.py from #12603 (a0d9c0547), folded into #10586.
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def load_runtime_with_stub_atspi():
+    atspi = types.ModuleType("gi.repository.Atspi")
+
+    class EditableText:
+        @staticmethod
+        def set_text_contents(editable, value):
+            editable["text"] = value
+            return True
+
+    class Value:
+        @staticmethod
+        def set_current_value(iface, value):
+            iface["value"] = value
+            return True
+
+    atspi.EditableText = EditableText
+    atspi.Value = Value
+
+    gi = types.ModuleType("gi")
+    repository = types.ModuleType("gi.repository")
+    repository.Atspi = atspi
+    gi.repository = repository
+    gi.require_version = lambda *args, **kwargs: None
+
+    # Why: patch.dict only for load — permanent sys.modules["gi"] stubs leak into
+    # later tests that import real GI (#10569 review).
+    path = Path(__file__).with_name("runtime.py")
+    sys.modules.pop("computer_use_linux_runtime", None)
+    with mock.patch.dict(
+        sys.modules,
+        {"gi": gi, "gi.repository": repository, "gi.repository.Atspi": atspi},
+    ):
+        spec = importlib.util.spec_from_file_location("computer_use_linux_runtime", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+
+
+class SetValueTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.runtime = load_runtime_with_stub_atspi()
+
+    def test_set_value_uses_editable_text_iface_without_is_editable_text(self):
+        editable = {"text": ""}
+
+        class Node:
+            def get_editable_text_iface(self):
+                return editable
+
+            def get_value_iface(self):
+                return None
+
+        node = Node()
+        # Ensure the broken attribute is absent (mirrors real GI bindings).
+        self.assertFalse(hasattr(node, "is_editable_text"))
+        self.assertTrue(self.runtime.set_value(node, "hello"))
+        self.assertEqual(editable["text"], "hello")
+
+    def test_set_value_falls_back_to_value_iface(self):
+        value_iface = {"value": 0.0}
+
+        class Node:
+            def get_editable_text_iface(self):
+                return None
+
+            def get_value_iface(self):
+                return value_iface
+
+        self.assertTrue(self.runtime.set_value(Node(), "3.5"))
+        self.assertEqual(value_iface["value"], 3.5)
+
+    def test_set_value_returns_false_when_no_ifaces(self):
+        class Node:
+            def get_editable_text_iface(self):
+                return None
+
+            def get_value_iface(self):
+                return None
+
+        self.assertFalse(self.runtime.set_value(Node(), "x"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Linux `computer set-value` always failed with `'Accessible' object has no attribute 'is_editable_text'` (#10569).
- `set_value` evaluated `node.is_editable_text` **before** `attempt()`, so the AttributeError from Python GI bindings escaped instead of falling through to Value.
- Probe editability with `get_editable_text_iface` (exposed by GI) and pin the regression in `verify-computer-native`.

## Root cause

```python
# before — attribute lookup raises before attempt() runs
attempt(node.is_editable_text, False)
```

`atspi_accessible_is_editable_text` exists in C but is not bound on `Atspi.Accessible` in `gir1.2-atspi-2.0`. `get_editable_text_iface()` is available and is the correct probe.

## Test plan

- [x] `python3 -c 'ast.parse(runtime.py)'` syntax-ok
- [x] guardrail string checks for the bad lookup pattern
- [ ] On Linux: `orca computer set-value` against an editable field after rebuild/repackage of computer-use-linux

Closes #10569

## ELI5

On Linux, computer-use set-value always failed on editable text because of a bad attribute probe. It now checks the correct editable-text interface so typing into fields works.
