### PR TITLE
fix(terminal): make Zellij/TUI OSC 52 clipboard copy work by default

### DIFF
--- a/config/scripts/locale-ko-key-overrides.json
+++ b/config/scripts/locale-ko-key-overrides.json
@@ -2814,7 +2814,7 @@
     "ko": "{{value0}} 메가바이트"
   },
   "auto.components.settings.TerminalPane.6e6480a7df": {
-    "ko": "terminal의 프로그램(tmux, Neovim, fzf, SSH)이 시스템 클립보드에 복사할 수 있게 합니다."
+    "ko": "terminal의 프로그램(Zellij, tmux, Neovim, fzf, Grok, SSH)이 시스템 클립보드에 복사할 수 있게 합니다."
   },
   "auto.components.settings.TerminalPane.8eefeaa3da": {
     "ko": "마우스를 따라 포커스 이동"

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2917,7 +2917,9 @@ describe('Store', () => {
     vi.useFakeTimers()
     try {
       const store = await createStore()
-      vi.advanceTimersByTime(1000)
+      // Why over-advance: the debounce is exactly 1000ms, so an exact-fit advance turns a
+      // future debounce raise into a confusing no-write instead of a loud failure.
+      vi.advanceTimersByTime(5000)
       await store.waitForPendingWrite()
     } finally {
       vi.useRealTimers()
@@ -2953,7 +2955,7 @@ describe('Store', () => {
     expect(store.getSettings().terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
   })
 
-  it('arms the one-shot notice when the OSC 52 flip overrides a persisted opt-out', async () => {
+  it('arms the one-shot notice when the OSC 52 flip overrides a persisted off', async () => {
     writeDataFile({
       schemaVersion: 1,
       repos: [],
@@ -2968,7 +2970,7 @@ describe('Store', () => {
     expect(store.getUI().osc52ClipboardDefaultOnNoticePending).toBe(true)
   })
 
-  it('leaves the OSC 52 notice disarmed for a profile that never opted out', async () => {
+  it('leaves the OSC 52 notice disarmed for a profile with no persisted value', async () => {
     // Why: the notice explains an overridden choice; a fresh profile made no choice.
     writeDataFile({
       schemaVersion: 1,
@@ -2984,24 +2986,35 @@ describe('Store', () => {
     expect(store.getUI().osc52ClipboardDefaultOnNoticePending).toBe(false)
   })
 
-  it('keeps the OSC 52 notice armed until the renderer clears it', async () => {
-    // Why: the flip happens during load, before any window exists — a crash or a quit
-    // before the toast renders must not consume the only notice the user ever gets.
+  it('keeps the OSC 52 notice armed on disk until the renderer clears it', async () => {
+    // Why the disk assertion: the flip happens during load, before any window exists, and
+    // once the settings stamp lands the arming predicate is false forever — so the on-disk
+    // ui flag is the only thing that survives a crash before the toast renders.
     writeDataFile({
       schemaVersion: 1,
       repos: [],
       worktreeMeta: {},
-      settings: {
-        terminalAllowOsc52Clipboard: true,
-        terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
-      },
-      ui: { osc52ClipboardDefaultOnNoticePending: true },
+      settings: { terminalAllowOsc52Clipboard: false },
+      ui: {},
       githubCache: { pr: {}, issue: {} },
       workspaceSession: {}
     })
 
-    const store = await createStore()
-    expect(store.getUI().osc52ClipboardDefaultOnNoticePending).toBe(true)
+    const armed = await createStore()
+    armed.flush()
+    const armedOnDisk = readDataFile() as {
+      ui?: { osc52ClipboardDefaultOnNoticePending?: boolean }
+    }
+    expect(armedOnDisk.ui?.osc52ClipboardDefaultOnNoticePending).toBe(true)
+
+    const reloaded = await createStore()
+    expect(reloaded.getUI().osc52ClipboardDefaultOnNoticePending).toBe(true)
+
+    reloaded.updateUI({ osc52ClipboardDefaultOnNoticePending: false })
+    reloaded.flush()
+    const cleared = await createStore()
+    // Why re-check after the stamp: a cleared notice must not be resurrected by a later load.
+    expect(cleared.getUI().osc52ClipboardDefaultOnNoticePending).toBe(false)
   })
 
   it('migrates the legacy Linux primary-selection default to enabled', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2953,6 +2953,57 @@ describe('Store', () => {
     expect(store.getSettings().terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
   })
 
+  it('arms the one-shot notice when the OSC 52 flip overrides a persisted opt-out', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalAllowOsc52Clipboard: false },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().osc52ClipboardDefaultOnNoticePending).toBe(true)
+  })
+
+  it('leaves the OSC 52 notice disarmed for a profile that never opted out', async () => {
+    // Why: the notice explains an overridden choice; a fresh profile made no choice.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().osc52ClipboardDefaultOnNoticePending).toBe(false)
+  })
+
+  it('keeps the OSC 52 notice armed until the renderer clears it', async () => {
+    // Why: the flip happens during load, before any window exists — a crash or a quit
+    // before the toast renders must not consume the only notice the user ever gets.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        terminalAllowOsc52Clipboard: true,
+        terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+      },
+      ui: { osc52ClipboardDefaultOnNoticePending: true },
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getUI().osc52ClipboardDefaultOnNoticePending).toBe(true)
+  })
+
   it('migrates the legacy Linux primary-selection default to enabled', async () => {
     await withPlatform('linux', async () => {
       writeDataFile({

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2872,6 +2872,43 @@ describe('Store', () => {
     expect(store.getSettings().floatingTerminalDefaultedForAllUsers).toBe(true)
   })
 
+  it('migrates the legacy OSC 52 clipboard disabled default to enabled', async () => {
+    // Why this migration exists: the old off default was persisted for every
+    // profile, so without the one-shot flip #10567 would only fix new installs.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: { terminalAllowOsc52Clipboard: false },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().terminalAllowOsc52Clipboard).toBe(true)
+    expect(store.getSettings().terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
+  })
+
+  it('preserves a post-migration OSC 52 clipboard opt-out', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {
+        terminalAllowOsc52Clipboard: false,
+        terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+      },
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+
+    const store = await createStore()
+    expect(store.getSettings().terminalAllowOsc52Clipboard).toBe(false)
+    expect(store.getSettings().terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
+  })
+
   it('migrates the legacy Linux primary-selection default to enabled', async () => {
     await withPlatform('linux', async () => {
       writeDataFile({

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -2890,6 +2890,50 @@ describe('Store', () => {
     expect(store.getSettings().terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
   })
 
+  it('persists the OSC 52 clipboard migration stamp back to disk', async () => {
+    // Why round-trip a store first: on a bare legacy profile ~30 other migrations also
+    // set loadNeedsSave, so the save happens regardless and this migration's own dirty
+    // flag goes untested. Re-loading a profile the new build already wrote leaves OSC 52
+    // as the only unmigrated key — which is exactly the upgrade case that matters.
+    // Why no flush(): flush() writes unconditionally, so only the debounced load-path
+    // save proves this migration marked the state dirty by itself.
+    writeDataFile({
+      schemaVersion: 1,
+      repos: [],
+      worktreeMeta: {},
+      settings: {},
+      ui: {},
+      githubCache: { pr: {}, issue: {} },
+      workspaceSession: {}
+    })
+    const migrated = await createStore()
+    migrated.flush()
+
+    const settled = readDataFile() as { settings: Record<string, unknown> }
+    settled.settings.terminalAllowOsc52Clipboard = false
+    delete settled.settings.terminalAllowOsc52ClipboardDefaultedOnForAllUsers
+    writeDataFile(settled)
+
+    vi.useFakeTimers()
+    try {
+      const store = await createStore()
+      vi.advanceTimersByTime(1000)
+      await store.waitForPendingWrite()
+    } finally {
+      vi.useRealTimers()
+    }
+
+    const persisted = readDataFile() as {
+      settings?: {
+        terminalAllowOsc52Clipboard?: boolean
+        terminalAllowOsc52ClipboardDefaultedOnForAllUsers?: boolean
+      }
+    }
+
+    expect(persisted.settings?.terminalAllowOsc52Clipboard).toBe(true)
+    expect(persisted.settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
+  })
+
   it('preserves a post-migration OSC 52 clipboard opt-out', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2909,6 +2909,15 @@ export class Store {
         const migratedFloatingTerminalEnabled = floatingTerminalDefaultedForAllUsers
           ? (parsed.settings?.floatingTerminalEnabled ?? true)
           : true
+        const osc52ClipboardDefaultedOnForAllUsers =
+          parsed.settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers === true
+        // Why: every profile saved under the old off default persisted `false`, so it can't be told apart from a real opt-out; flip unmigrated profiles once so #10567 reaches existing installs, and let a later opt-out survive reload.
+        const migratedTerminalAllowOsc52Clipboard = osc52ClipboardDefaultedOnForAllUsers
+          ? (parsed.settings?.terminalAllowOsc52Clipboard ?? true)
+          : true
+        if (!osc52ClipboardDefaultedOnForAllUsers) {
+          this.loadNeedsSave = true
+        }
         const floatingTerminalCwdMigrated =
           parsed.settings?.floatingTerminalCwdMigratedToAppWorkspace === true
         // Why: an earlier migration wrote '' for the notes dir; floating terminals still open at home, notes use a separate IPC.
@@ -3141,6 +3150,8 @@ export class Store {
             localWindowsRuntimeDefault: migratedWindowsRuntimeDefault,
             localAccountRuntime: migratedLocalAccountRuntime,
             localAccountRuntimeDefaultedToAutoForAllUsers: true,
+            terminalAllowOsc52Clipboard: migratedTerminalAllowOsc52Clipboard,
+            terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true,
             floatingTerminalEnabled: migratedFloatingTerminalEnabled,
             floatingTerminalDefaultedForAllUsers: true,
             floatingTerminalCwd: migratedFloatingTerminalCwd,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -225,7 +225,7 @@ import {
 import { normalizeTerminalCursorStyleDefault } from '../shared/terminal-cursor-style-settings'
 import {
   normalizeOsc52ClipboardDefaultOn,
-  osc52ClipboardDefaultOnFlipsPersistedOptOut
+  osc52ClipboardDefaultOnOverridesPersistedOff
 } from '../shared/osc52-clipboard-settings'
 import { normalizeTerminalLineHeight } from '../shared/terminal-line-height-settings'
 import { normalizeUiLanguage } from '../shared/ui-language'
@@ -2916,7 +2916,7 @@ export class Store {
         // Why: the old off default persisted `false` for every profile, indistinguishable from a real opt-out — flip unmigrated profiles once (#10567).
         const migratedOsc52Clipboard = normalizeOsc52ClipboardDefaultOn(parsed.settings)
         const osc52ClipboardNoticePending =
-          osc52ClipboardDefaultOnFlipsPersistedOptOut(parsed.settings) ||
+          osc52ClipboardDefaultOnOverridesPersistedOff(parsed.settings) ||
           parsed.ui?.osc52ClipboardDefaultOnNoticePending === true
         if (parsed.settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers !== true) {
           this.loadNeedsSave = true

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -223,6 +223,7 @@ import {
   normalizeTuiAgentEnvRecord
 } from '../shared/tui-agent-launch-defaults'
 import { normalizeTerminalCursorStyleDefault } from '../shared/terminal-cursor-style-settings'
+import { normalizeOsc52ClipboardDefaultOn } from '../shared/osc52-clipboard-settings'
 import { normalizeTerminalLineHeight } from '../shared/terminal-line-height-settings'
 import { normalizeUiLanguage } from '../shared/ui-language'
 import { normalizeBrowserPageZoomLevel } from '../shared/browser-page-zoom'
@@ -2909,13 +2910,9 @@ export class Store {
         const migratedFloatingTerminalEnabled = floatingTerminalDefaultedForAllUsers
           ? (parsed.settings?.floatingTerminalEnabled ?? true)
           : true
-        const osc52ClipboardDefaultedOnForAllUsers =
-          parsed.settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers === true
-        // Why: every profile saved under the old off default persisted `false`, so it can't be told apart from a real opt-out; flip unmigrated profiles once so #10567 reaches existing installs, and let a later opt-out survive reload.
-        const migratedTerminalAllowOsc52Clipboard = osc52ClipboardDefaultedOnForAllUsers
-          ? (parsed.settings?.terminalAllowOsc52Clipboard ?? true)
-          : true
-        if (!osc52ClipboardDefaultedOnForAllUsers) {
+        // Why: the old off default persisted `false` for every profile, indistinguishable from a real opt-out — flip unmigrated profiles once (#10567).
+        const migratedOsc52Clipboard = normalizeOsc52ClipboardDefaultOn(parsed.settings)
+        if (parsed.settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers !== true) {
           this.loadNeedsSave = true
         }
         const floatingTerminalCwdMigrated =
@@ -3150,8 +3147,7 @@ export class Store {
             localWindowsRuntimeDefault: migratedWindowsRuntimeDefault,
             localAccountRuntime: migratedLocalAccountRuntime,
             localAccountRuntimeDefaultedToAutoForAllUsers: true,
-            terminalAllowOsc52Clipboard: migratedTerminalAllowOsc52Clipboard,
-            terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true,
+            ...migratedOsc52Clipboard,
             floatingTerminalEnabled: migratedFloatingTerminalEnabled,
             floatingTerminalDefaultedForAllUsers: true,
             floatingTerminalCwd: migratedFloatingTerminalCwd,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -223,7 +223,10 @@ import {
   normalizeTuiAgentEnvRecord
 } from '../shared/tui-agent-launch-defaults'
 import { normalizeTerminalCursorStyleDefault } from '../shared/terminal-cursor-style-settings'
-import { normalizeOsc52ClipboardDefaultOn } from '../shared/osc52-clipboard-settings'
+import {
+  normalizeOsc52ClipboardDefaultOn,
+  osc52ClipboardDefaultOnFlipsPersistedOptOut
+} from '../shared/osc52-clipboard-settings'
 import { normalizeTerminalLineHeight } from '../shared/terminal-line-height-settings'
 import { normalizeUiLanguage } from '../shared/ui-language'
 import { normalizeBrowserPageZoomLevel } from '../shared/browser-page-zoom'
@@ -2912,6 +2915,9 @@ export class Store {
           : true
         // Why: the old off default persisted `false` for every profile, indistinguishable from a real opt-out — flip unmigrated profiles once (#10567).
         const migratedOsc52Clipboard = normalizeOsc52ClipboardDefaultOn(parsed.settings)
+        const osc52ClipboardNoticePending =
+          osc52ClipboardDefaultOnFlipsPersistedOptOut(parsed.settings) ||
+          parsed.ui?.osc52ClipboardDefaultOnNoticePending === true
         if (parsed.settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers !== true) {
           this.loadNeedsSave = true
         }
@@ -3332,6 +3338,9 @@ export class Store {
                   : false,
               setupGuideBrowserMilestoneLegacyComplete:
                 parsed.ui?.setupGuideBrowserMilestoneLegacyComplete === true,
+              // Why persist rather than notify inline: the flip lands during load, before any
+              // window exists, and it must survive a crash before the user ever sees the notice.
+              osc52ClipboardDefaultOnNoticePending: osc52ClipboardNoticePending,
               sortBy: migrate ? ('smart' as const) : sort,
               showDotfilesByWorktree: normalizeShowDotfilesByWorktree(
                 parsed.ui?.showDotfilesByWorktree
@@ -5478,6 +5487,8 @@ export class Store {
       statusBarUsageMode: normalizeStatusBarUsageMode(this.state.ui?.statusBarUsageMode),
       // Why: strict boolean coercion so a missing/legacy value reads as false (first-run notice still fires).
       trayMinimizeNoticeShown: this.state.ui?.trayMinimizeNoticeShown === true,
+      osc52ClipboardDefaultOnNoticePending:
+        this.state.ui?.osc52ClipboardDefaultOnNoticePending === true,
       markdownTocPanelWidth: clampMarkdownTocPanelWidth(this.state.ui?.markdownTocPanelWidth),
       visibleWorkspaceHostIds: normalizeVisibleExecutionHostIds(
         this.state.ui?.visibleWorkspaceHostIds

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -227,6 +227,7 @@ export const UiUpdate = z
     dismissedUpdateNudgeId: NullableString.optional(),
     notificationPermissionRequested: z.boolean().optional(),
     updateReassuranceSeen: z.boolean().optional(),
+    osc52ClipboardDefaultOnNoticePending: z.boolean().optional(),
     acknowledgedAgentsByPaneKey: z.record(z.string(), z.number().finite()).optional(),
     browserDefaultUrl: NullableString.optional(),
     browserDefaultSearchEngine: z

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -397,6 +397,30 @@ describe('client UI RPC methods', () => {
     expect(response).toMatchObject({ ok: true, result: { ui: updated } })
   })
 
+  it('lets a paired client clear the OSC 52 default-on notice', async () => {
+    // Why pin this key: the update schema is strict, so an omitted field does not get
+    // stripped — it rejects the whole call. The renderer only logs that failure, so the
+    // one-shot notice would re-toast on every launch of every web/SSH/relay client.
+    const updated: PersistedUIState = {
+      ...getDefaultUIState(),
+      osc52ClipboardDefaultOnNoticePending: false
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateUIState: vi.fn(() => updated)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: CLIENT_UI_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('ui.set', { osc52ClipboardDefaultOnNoticePending: false })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.updateUIState).toHaveBeenCalledWith({
+      osc52ClipboardDefaultOnNoticePending: false
+    })
+  })
+
   it('accepts persisted literal UI arrays and nested UI state', async () => {
     const updated: PersistedUIState = {
       ...getDefaultUIState(),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -198,6 +198,7 @@ import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut
 import { resolveMountedLazyModalIds, type LazyModalId } from './lazy-modal-mount-state'
 import { translate } from '@/i18n/i18n'
 import PinnedTabCloseDialog from './components/terminal-pane/PinnedTabCloseDialog'
+import { useOsc52ClipboardDefaultOnNotice } from './components/terminal-pane/osc52-clipboard-default-on-notice'
 import {
   hasRequestedBackgroundTerminalWorktreeMount,
   subscribeBackgroundTerminalWorktreeMountRequests
@@ -642,6 +643,7 @@ function App(): React.JSX.Element {
   const acknowledgedAgentsByPaneKey = useAppStore((s) => s.acknowledgedAgentsByPaneKey)
   const persistedUIReady = useAppStore((s) => s.persistedUIReady)
   const shouldMountContextualTourOverlay = activeContextualTourId !== null
+  useOsc52ClipboardDefaultOnNotice(persistedUIReady)
   const shouldMountSetupGuideTelemetryObserver = persistedUIReady
   const shouldMountUpdateCard = shouldMountUpdateCardForStatus(updateStatus)
   const rightSidebarWidth = useAppStore((s) => s.rightSidebarWidth)

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -365,6 +365,20 @@ describe('renderer startup runtime routing', () => {
     expect(source).not.toContain("window.addEventListener('blur', handleBlur)")
   })
 
+  it('arms the OSC 52 default-on notice behind a statically mounted Toaster (#10567)', () => {
+    const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
+
+    // Why pin the call site: the hook is the only caller, so deleting this line silences
+    // the migration notice on desktop with every unit suite still green.
+    expect(source).toContain('useOsc52ClipboardDefaultOnNotice(persistedUIReady)')
+    // Why pin the static import and the unconditional mount: sonner drops a toast enqueued
+    // before any Toaster subscribes, and never replays it — a lazy Toaster would burn the
+    // profile's one notice with its callbacks never firing, so it could never re-arm.
+    expect(source).toContain("import { Toaster } from '@/components/ui/sonner'")
+    expect(source).not.toContain("import('@/components/ui/sonner')")
+    expect(source).toContain('<Toaster closeButton')
+  })
+
   it('checkpoints activeView and all session snapshots through one beforeunload handler (#9002)', () => {
     const source = readFileSync(join(process.cwd(), 'src/renderer/src/App.tsx'), 'utf8')
     const checkpointStart = source.indexOf(

--- a/src/renderer/src/components/settings/TerminalInteractionSection.tsx
+++ b/src/renderer/src/components/settings/TerminalInteractionSection.tsx
@@ -340,12 +340,13 @@ export function TerminalInteractionSection({
           )}
           description={translate(
             'auto.components.settings.TerminalPane.69c64a479c',
-            'Let Grok, tmux, Neovim, and fzf copy to the system clipboard over the PTY (including over SSH).'
+            'Let Zellij, tmux, Neovim, fzf, and Grok copy to the system clipboard over the PTY (including over SSH).'
           )}
           keywords={[
             'osc 52',
             'osc52',
             'clipboard',
+            'zellij',
             'tmux',
             'neovim',
             'nvim',
@@ -364,7 +365,7 @@ export function TerminalInteractionSection({
             )}
             description={translate(
               'auto.components.settings.TerminalPane.6e6480a7df',
-              'Let programs in the terminal (Grok, tmux, Neovim, fzf, SSH) copy to your system clipboard.'
+              'Let programs in the terminal (Zellij, tmux, Neovim, fzf, Grok, SSH) copy to your system clipboard.'
             )}
             checked={settings.terminalAllowOsc52Clipboard}
             onChange={() =>

--- a/src/renderer/src/components/settings/osc52-clipboard-copy.test.ts
+++ b/src/renderer/src/components/settings/osc52-clipboard-copy.test.ts
@@ -6,18 +6,40 @@ import ko from '@/i18n/locales/ko.json'
 import zh from '@/i18n/locales/zh.json'
 
 // Why assert the catalog rather than the component: en.json is bundled as the `en`
-// resource, so a catalog value wins over translate()'s code fallback. #10588 shipped
-// copy edits to the fallbacks only, which rendered nothing.
+// resource, so a catalog value wins over translate()'s code fallback. Editing a fallback
+// alone renders nothing, and nothing else in CI compares the two.
 describe('OSC 52 setting copy', () => {
   const locales = { en, es, ja, ko, zh }
 
   for (const [name, locale] of Object.entries(locales)) {
-    it(`names Zellij and Grok in the ${name} setting description and switch label`, () => {
+    it(`names Zellij and Grok in both ${name} OSC 52 setting descriptions`, () => {
       const pane = locale.auto.components.settings.TerminalPane
       for (const copy of [pane['69c64a479c'], pane['6e6480a7df']]) {
         expect(copy).toContain('Zellij')
         expect(copy).toContain('Grok')
       }
+    })
+  }
+
+  // The notice is a one-shot the user sees exactly once, so a stale catalog value would
+  // ship unnoticed. Pin en.json to the code fallbacks verbatim.
+  it('keeps the migration notice catalog identical to its code fallbacks', () => {
+    const notice = en.auto.components.terminal.pane.osc52.clipboard.default.on.notice
+    expect(notice.title).toBe('TUI clipboard writes are now on by default')
+    expect(notice.description).toBe(
+      'Zellij, tmux, Neovim and other terminal programs can now copy to your clipboard. Turn it off in Terminal settings.'
+    )
+    expect(notice.action).toBe('Open Setting')
+  })
+
+  for (const [name, locale] of Object.entries({ es, ja, ko, zh })) {
+    it(`translates the ${name} migration notice rather than leaving English placeholders`, () => {
+      const notice = locale.auto.components.terminal.pane.osc52.clipboard.default.on.notice
+      const english = en.auto.components.terminal.pane.osc52.clipboard.default.on.notice
+      expect(notice.title).not.toBe(english.title)
+      expect(notice.description).not.toBe(english.description)
+      // Product names must survive translation — they are how the user recognizes the change.
+      expect(notice.description).toContain('Zellij')
     })
   }
 })

--- a/src/renderer/src/components/settings/osc52-clipboard-copy.test.ts
+++ b/src/renderer/src/components/settings/osc52-clipboard-copy.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import en from '@/i18n/locales/en.json'
+import es from '@/i18n/locales/es.json'
+import ja from '@/i18n/locales/ja.json'
+import ko from '@/i18n/locales/ko.json'
+import zh from '@/i18n/locales/zh.json'
+
+// Why assert the catalog rather than the component: en.json is bundled as the `en`
+// resource, so a catalog value wins over translate()'s code fallback. #10588 shipped
+// copy edits to the fallbacks only, which rendered nothing.
+describe('OSC 52 setting copy', () => {
+  const locales = { en, es, ja, ko, zh }
+
+  for (const [name, locale] of Object.entries(locales)) {
+    it(`names Zellij in the ${name} setting description and switch label`, () => {
+      const pane = locale.auto.components.settings.TerminalPane
+      expect(pane['69c64a479c']).toContain('Zellij')
+      expect(pane['6e6480a7df']).toContain('Zellij')
+    })
+  }
+})

--- a/src/renderer/src/components/settings/osc52-clipboard-copy.test.ts
+++ b/src/renderer/src/components/settings/osc52-clipboard-copy.test.ts
@@ -12,10 +12,12 @@ describe('OSC 52 setting copy', () => {
   const locales = { en, es, ja, ko, zh }
 
   for (const [name, locale] of Object.entries(locales)) {
-    it(`names Zellij in the ${name} setting description and switch label`, () => {
+    it(`names Zellij and Grok in the ${name} setting description and switch label`, () => {
       const pane = locale.auto.components.settings.TerminalPane
-      expect(pane['69c64a479c']).toContain('Zellij')
-      expect(pane['6e6480a7df']).toContain('Zellij')
+      for (const copy of [pane['69c64a479c'], pane['6e6480a7df']]) {
+        expect(copy).toContain('Zellij')
+        expect(copy).toContain('Grok')
+      }
     })
   }
 })

--- a/src/renderer/src/components/settings/terminal-clipboard-search.ts
+++ b/src/renderer/src/components/settings/terminal-clipboard-search.ts
@@ -77,10 +77,15 @@ export const getTerminalClipboardSearchEntries = createLocalizedCatalog(() => [
         'auto.components.settings.terminal.clipboard.search.10d73e22d3',
         'clipboard'
       ),
+      // englishOnly: a product name; localizing it would index a word nobody types.
       ...translateSearchKeyword(
         'auto.components.settings.terminal.clipboard.search.zellij',
-        'zellij'
+        'zellij',
+        { englishOnly: true }
       ),
+      ...translateSearchKeyword('auto.components.settings.terminal.clipboard.search.grok', 'grok', {
+        englishOnly: true
+      }),
       ...translateSearchKeyword(
         'auto.components.settings.terminal.clipboard.search.5ffcd13c90',
         'tmux'

--- a/src/renderer/src/components/settings/terminal-clipboard-search.ts
+++ b/src/renderer/src/components/settings/terminal-clipboard-search.ts
@@ -78,6 +78,10 @@ export const getTerminalClipboardSearchEntries = createLocalizedCatalog(() => [
         'clipboard'
       ),
       ...translateSearchKeyword(
+        'auto.components.settings.terminal.clipboard.search.zellij',
+        'zellij'
+      ),
+      ...translateSearchKeyword(
         'auto.components.settings.terminal.clipboard.search.5ffcd13c90',
         'tmux'
       ),

--- a/src/renderer/src/components/settings/terminal-search.test.ts
+++ b/src/renderer/src/components/settings/terminal-search.test.ts
@@ -218,6 +218,21 @@ describe('getTerminalPaneSearchEntries', () => {
     expect(matchesSettingsSearch('compact', getAppearancePaneSearchEntries())).toBe(true)
   })
 
+  // The notice tells users to "turn it off in Terminal settings", so the product names in
+  // the copy have to be the ones that find it.
+  it.each(['zellij', 'grok', 'tmux', 'osc 52'])(
+    'finds the OSC 52 clipboard setting by searching %s',
+    (query) => {
+      const entries = getTerminalPaneSearchEntries({ isWindows: false, isMac: true })
+      const osc52 = entries.filter((entry) =>
+        entry.title.includes('Allow TUI Clipboard Writes (OSC 52)')
+      )
+
+      expect(osc52).toHaveLength(1)
+      expect(matchesSettingsSearch(query, osc52)).toBe(true)
+    }
+  )
+
   it('includes pinned worktree duplicate display in sidebar and Appearance search', () => {
     const entry = getShowPinnedWorktreesInGroupsEntry()
 

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
@@ -74,6 +74,21 @@ describe('showOsc52ClipboardBlockedToast', () => {
     expect(toastInfoMock).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps the session notice unspent when the toast throws', async () => {
+    // Why: with the latch above toast.info, a throw burns the opted-out user's one
+    // hint and every later blocked write fails silently. Only a throwing first call
+    // separates the two orderings — the passing case satisfies both.
+    const { showOsc52ClipboardBlockedToast } = await importToastModule()
+    toastInfoMock.mockImplementationOnce(() => {
+      throw new Error('toast unavailable')
+    })
+
+    expect(() => showOsc52ClipboardBlockedToast()).toThrow('toast unavailable')
+    showOsc52ClipboardBlockedToast()
+
+    expect(toastInfoMock).toHaveBeenCalledTimes(2)
+  })
+
   it('mentions Grok and Zellij in every supported locale', () => {
     // Why assert the catalog, not the code fallback: en.json is bundled as the
     // `en` resource, so a catalog value silently wins over translate()'s fallback.

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.test.ts
@@ -74,13 +74,16 @@ describe('showOsc52ClipboardBlockedToast', () => {
     expect(toastInfoMock).toHaveBeenCalledTimes(1)
   })
 
-  it('mentions Grok in every supported locale', () => {
+  it('mentions Grok and Zellij in every supported locale', () => {
+    // Why assert the catalog, not the code fallback: en.json is bundled as the
+    // `en` resource, so a catalog value silently wins over translate()'s fallback.
     const locales = [en, es, ja, ko, zh]
 
     for (const locale of locales) {
-      expect(
+      const description =
         locale.auto.components.terminal.pane.osc52.clipboard.blocked.toast['7cf51f74fd']
-      ).toContain('Grok')
+      expect(description).toContain('Grok')
+      expect(description).toContain('Zellij')
     }
   })
 })

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
@@ -19,7 +19,7 @@ export function showOsc52ClipboardBlockedToast(): void {
     {
       description: translate(
         'auto.components.terminal.pane.osc52.clipboard.blocked.toast.7cf51f74fd',
-        'Enable TUI clipboard writes in Terminal settings to copy from SSH, tmux, Neovim, fzf, or Grok.'
+        'Enable TUI clipboard writes in Terminal settings to copy from SSH, Zellij, tmux, Neovim, fzf, or Grok.'
       ),
       duration: 12_000,
       action: {

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-blocked-toast.ts
@@ -9,7 +9,6 @@ export function showOsc52ClipboardBlockedToast(): void {
   if (hasShownOsc52ClipboardBlockedToast) {
     return
   }
-  hasShownOsc52ClipboardBlockedToast = true
 
   toast.info(
     translate(
@@ -42,4 +41,7 @@ export function showOsc52ClipboardBlockedToast(): void {
       }
     }
   )
+  // Why latch after: a throw above would otherwise burn the session's one notice
+  // without ever showing it, leaving the opted-out user with silent failures.
+  hasShownOsc52ClipboardBlockedToast = true
 }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
@@ -87,19 +87,24 @@ describe('useOsc52ClipboardDefaultOnNotice', () => {
     document.body.innerHTML = ''
   })
 
-  it('toasts the armed profile and then consumes the notice', async () => {
+  it('toasts the armed profile without spending the notice up front', async () => {
+    // Why not consume on enqueue: quitting inside the toast's 15s would burn the profile's
+    // only notice on a launch where the posture change was never actually communicated.
     await mountProbe(true)
 
     expect(toastInfoMock).toHaveBeenCalledTimes(1)
+    expect(storeState.clearOsc52ClipboardDefaultOnNotice).not.toHaveBeenCalled()
+  })
+
+  it.each(['onAutoClose', 'onDismiss'] as const)('consumes the notice on %s', async (callback) => {
+    await mountProbe(true)
+
+    toastInfoMock.mock.calls[0]?.[1]?.[callback]?.()
+
     expect(storeState.clearOsc52ClipboardDefaultOnNotice).toHaveBeenCalledTimes(1)
-    expect(toastInfoMock.mock.invocationCallOrder[0]).toBeLessThan(
-      storeState.clearOsc52ClipboardDefaultOnNotice.mock.invocationCallOrder[0] ?? Infinity
-    )
   })
 
   it('keeps the notice armed when the toast throws, so it is not burned unshown', async () => {
-    // Why this ordering matters: clearing first spends the profile's only notice on a
-    // launch where nothing was ever displayed, and nothing can re-arm it afterwards.
     toastInfoMock.mockImplementationOnce(() => {
       throw new Error('toast unavailable')
     })
@@ -128,6 +133,9 @@ describe('useOsc52ClipboardDefaultOnNotice', () => {
 
     options.action.onClick()
 
+    // Why assert the clear here: sonner's action path deletes the toast without firing
+    // onDismiss, so acting on the notice would otherwise leave it to re-toast next launch.
+    expect(storeState.clearOsc52ClipboardDefaultOnNotice).toHaveBeenCalledTimes(1)
     expect(storeState.setSettingsSearchQuery).toHaveBeenCalledWith('')
     expect(storeState.openSettingsTarget).toHaveBeenCalledWith({
       pane: 'terminal',

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { shouldShowOsc52ClipboardDefaultOnNotice } from './osc52-clipboard-default-on-notice'
+
+describe('shouldShowOsc52ClipboardDefaultOnNotice', () => {
+  it('shows once the migrating profile has hydrated', () => {
+    expect(
+      shouldShowOsc52ClipboardDefaultOnNotice({ persistedUIReady: true, noticePending: true })
+    ).toBe(true)
+  })
+
+  it('stays quiet before hydration, when the flag still reads its default', () => {
+    // Why: pre-hydration the store holds `false` for everyone, so firing on that
+    // value would nag every profile — including the ones never opted out.
+    expect(
+      shouldShowOsc52ClipboardDefaultOnNotice({ persistedUIReady: false, noticePending: true })
+    ).toBe(false)
+    expect(
+      shouldShowOsc52ClipboardDefaultOnNotice({ persistedUIReady: false, noticePending: false })
+    ).toBe(false)
+  })
+
+  it('stays quiet for a profile the migration did not override', () => {
+    expect(
+      shouldShowOsc52ClipboardDefaultOnNotice({ persistedUIReady: true, noticePending: false })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
@@ -99,9 +99,24 @@ describe('useOsc52ClipboardDefaultOnNotice', () => {
   it.each(['onAutoClose', 'onDismiss'] as const)('consumes the notice on %s', async (callback) => {
     await mountProbe(true)
 
-    toastInfoMock.mock.calls[0]?.[1]?.[callback]?.()
+    // Why assert the option exists before invoking: optional chaining makes a missing
+    // callback a silent no-op, so a revert to clear-at-enqueue would satisfy the count
+    // below without ever wiring this close path.
+    const close = toastInfoMock.mock.calls[0]?.[1]?.[callback]
+    expect(close).toBeTypeOf('function')
+    expect(storeState.clearOsc52ClipboardDefaultOnNotice).not.toHaveBeenCalled()
+
+    close()
 
     expect(storeState.clearOsc52ClipboardDefaultOnNotice).toHaveBeenCalledTimes(1)
+  })
+
+  it('dedupes the StrictMode double-invoke with a stable toast id', async () => {
+    // Why pin the id: the effect re-runs against the same closure, so the early return
+    // cannot catch the second pass — sonner collapses it only because the id matches.
+    await mountProbe(true)
+
+    expect(toastInfoMock.mock.calls[0]?.[1]?.id).toBe('osc52-clipboard-default-on-notice')
   })
 
   it('keeps the notice armed when the toast throws, so it is not burned unshown', async () => {
@@ -130,6 +145,10 @@ describe('useOsc52ClipboardDefaultOnNotice', () => {
     const options = toastInfoMock.mock.calls[0]?.[1]
     expect(options.description).toContain('Zellij')
     expect(options.action.label).toBe('Open Setting')
+
+    // Why assert unspent first: without it, a revert to clear-at-enqueue satisfies the
+    // count below and the action's own clear becomes deletable with nothing going red.
+    expect(storeState.clearOsc52ClipboardDefaultOnNotice).not.toHaveBeenCalled()
 
     options.action.onClick()
 

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.test.ts
@@ -1,5 +1,49 @@
-import { describe, expect, it } from 'vitest'
-import { shouldShowOsc52ClipboardDefaultOnNotice } from './osc52-clipboard-default-on-notice'
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { OSC52_CLIPBOARD_SETTING_ID } from './osc52-clipboard-setting-anchor'
+import {
+  shouldShowOsc52ClipboardDefaultOnNotice,
+  useOsc52ClipboardDefaultOnNotice
+} from './osc52-clipboard-default-on-notice'
+
+const { toastInfoMock, storeState } = vi.hoisted(() => ({
+  toastInfoMock: vi.fn(),
+  storeState: {
+    osc52ClipboardDefaultOnNoticePending: true,
+    clearOsc52ClipboardDefaultOnNotice: vi.fn(),
+    setSettingsSearchQuery: vi.fn(),
+    openSettingsTarget: vi.fn(),
+    openSettingsPage: vi.fn()
+  }
+}))
+
+vi.mock('sonner', () => ({ toast: { info: toastInfoMock } }))
+
+vi.mock('@/store', () => {
+  const useAppStore = <T>(selector: (state: typeof storeState) => T): T => selector(storeState)
+  useAppStore.getState = (): typeof storeState => storeState
+  return { useAppStore }
+})
+
+const mountedRoots: Root[] = []
+
+function HookProbe({ persistedUIReady }: { persistedUIReady: boolean }): null {
+  useOsc52ClipboardDefaultOnNotice(persistedUIReady)
+  return null
+}
+
+async function mountProbe(persistedUIReady: boolean): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  mountedRoots.push(root)
+  await act(async () => {
+    root.render(createElement(HookProbe, { persistedUIReady }))
+  })
+}
 
 describe('shouldShowOsc52ClipboardDefaultOnNotice', () => {
   it('shows once the migrating profile has hydrated', () => {
@@ -23,5 +67,73 @@ describe('shouldShowOsc52ClipboardDefaultOnNotice', () => {
     expect(
       shouldShowOsc52ClipboardDefaultOnNotice({ persistedUIReady: true, noticePending: false })
     ).toBe(false)
+  })
+})
+
+describe('useOsc52ClipboardDefaultOnNotice', () => {
+  beforeEach(() => {
+    toastInfoMock.mockReset()
+    storeState.osc52ClipboardDefaultOnNoticePending = true
+    storeState.clearOsc52ClipboardDefaultOnNotice.mockReset()
+    storeState.setSettingsSearchQuery.mockReset()
+    storeState.openSettingsTarget.mockReset()
+    storeState.openSettingsPage.mockReset()
+  })
+
+  afterEach(() => {
+    for (const root of mountedRoots.splice(0)) {
+      act(() => root.unmount())
+    }
+    document.body.innerHTML = ''
+  })
+
+  it('toasts the armed profile and then consumes the notice', async () => {
+    await mountProbe(true)
+
+    expect(toastInfoMock).toHaveBeenCalledTimes(1)
+    expect(storeState.clearOsc52ClipboardDefaultOnNotice).toHaveBeenCalledTimes(1)
+    expect(toastInfoMock.mock.invocationCallOrder[0]).toBeLessThan(
+      storeState.clearOsc52ClipboardDefaultOnNotice.mock.invocationCallOrder[0] ?? Infinity
+    )
+  })
+
+  it('keeps the notice armed when the toast throws, so it is not burned unshown', async () => {
+    // Why this ordering matters: clearing first spends the profile's only notice on a
+    // launch where nothing was ever displayed, and nothing can re-arm it afterwards.
+    toastInfoMock.mockImplementationOnce(() => {
+      throw new Error('toast unavailable')
+    })
+
+    await expect(mountProbe(true)).rejects.toThrow('toast unavailable')
+    expect(storeState.clearOsc52ClipboardDefaultOnNotice).not.toHaveBeenCalled()
+  })
+
+  it('stays silent for a disarmed profile and before hydration', async () => {
+    storeState.osc52ClipboardDefaultOnNoticePending = false
+    await mountProbe(true)
+    expect(toastInfoMock).not.toHaveBeenCalled()
+
+    storeState.osc52ClipboardDefaultOnNoticePending = true
+    await mountProbe(false)
+    expect(toastInfoMock).not.toHaveBeenCalled()
+    expect(storeState.clearOsc52ClipboardDefaultOnNotice).not.toHaveBeenCalled()
+  })
+
+  it('deep-links to the OSC 52 terminal setting', async () => {
+    await mountProbe(true)
+
+    const options = toastInfoMock.mock.calls[0]?.[1]
+    expect(options.description).toContain('Zellij')
+    expect(options.action.label).toBe('Open Setting')
+
+    options.action.onClick()
+
+    expect(storeState.setSettingsSearchQuery).toHaveBeenCalledWith('')
+    expect(storeState.openSettingsTarget).toHaveBeenCalledWith({
+      pane: 'terminal',
+      repoId: null,
+      sectionId: OSC52_CLIPBOARD_SETTING_ID
+    })
+    expect(storeState.openSettingsPage).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
@@ -1,0 +1,58 @@
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+import { OSC52_CLIPBOARD_SETTING_ID } from './osc52-clipboard-setting-anchor'
+
+/** Whether the migrating launch should tell the user their OSC 52 opt-out was overridden. */
+export function shouldShowOsc52ClipboardDefaultOnNotice(input: {
+  persistedUIReady: boolean
+  noticePending: boolean
+}): boolean {
+  // Why gate on hydration: before ui.get() lands the flag reads false, and firing
+  // on the default would nag every profile that was never opted out.
+  return input.persistedUIReady && input.noticePending
+}
+
+export function useOsc52ClipboardDefaultOnNotice(persistedUIReady: boolean): void {
+  const noticePending = useAppStore((s) => s.osc52ClipboardDefaultOnNoticePending)
+  const clearNotice = useAppStore((s) => s.clearOsc52ClipboardDefaultOnNotice)
+
+  useEffect(() => {
+    if (!shouldShowOsc52ClipboardDefaultOnNotice({ persistedUIReady, noticePending })) {
+      return
+    }
+    // Why clear first: the store write flips `noticePending`, so clearing up front
+    // keeps a re-render from queueing a second toast before the state settles.
+    clearNotice()
+    toast.info(
+      translate(
+        'auto.components.terminal.pane.osc52.clipboard.default.on.notice.title',
+        'TUI clipboard writes are now on by default'
+      ),
+      {
+        description: translate(
+          'auto.components.terminal.pane.osc52.clipboard.default.on.notice.description',
+          'Zellij, tmux, Neovim and other terminal programs can now copy to your clipboard. Turn it off in Terminal settings.'
+        ),
+        duration: 15_000,
+        action: {
+          label: translate(
+            'auto.components.terminal.pane.osc52.clipboard.default.on.notice.action',
+            'Open Setting'
+          ),
+          onClick: () => {
+            const store = useAppStore.getState()
+            store.setSettingsSearchQuery('')
+            store.openSettingsTarget({
+              pane: 'terminal',
+              repoId: null,
+              sectionId: OSC52_CLIPBOARD_SETTING_ID
+            })
+            store.openSettingsPage()
+          }
+        }
+      }
+    )
+  }, [clearNotice, noticePending, persistedUIReady])
+}

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
@@ -22,9 +22,6 @@ export function useOsc52ClipboardDefaultOnNotice(persistedUIReady: boolean): voi
     if (!shouldShowOsc52ClipboardDefaultOnNotice({ persistedUIReady, noticePending })) {
       return
     }
-    // Why clear first: the store write flips `noticePending`, so clearing up front
-    // keeps a re-render from queueing a second toast before the state settles.
-    clearNotice()
     toast.info(
       translate(
         'auto.components.terminal.pane.osc52.clipboard.default.on.notice.title',
@@ -54,5 +51,8 @@ export function useOsc52ClipboardDefaultOnNotice(persistedUIReady: boolean): voi
         }
       }
     )
+    // Why clear after: a throw above would burn the profile's one notice without ever
+    // showing it. Nothing re-renders between the two calls, so this cannot double-fire.
+    clearNotice()
   }, [clearNotice, noticePending, persistedUIReady])
 }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
@@ -28,6 +28,9 @@ export function useOsc52ClipboardDefaultOnNotice(persistedUIReady: boolean): voi
         'TUI clipboard writes are now on by default'
       ),
       {
+        // Why a stable id: StrictMode re-runs this effect against the same closure, so
+        // the early return can't catch the second pass — sonner dedupes it instead.
+        id: 'osc52-clipboard-default-on-notice',
         description: translate(
           'auto.components.terminal.pane.osc52.clipboard.default.on.notice.description',
           'Zellij, tmux, Neovim and other terminal programs can now copy to your clipboard. Turn it off in Terminal settings.'
@@ -52,7 +55,8 @@ export function useOsc52ClipboardDefaultOnNotice(persistedUIReady: boolean): voi
       }
     )
     // Why clear after: a throw above would burn the profile's one notice without ever
-    // showing it. Nothing re-renders between the two calls, so this cannot double-fire.
+    // enqueueing it. The toast is only queued at this point, not painted, so a crash in
+    // the gap still loses it — accepted, since the alternative loses it far more often.
     clearNotice()
   }, [clearNotice, noticePending, persistedUIReady])
 }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard-default-on-notice.ts
@@ -36,12 +36,22 @@ export function useOsc52ClipboardDefaultOnNotice(persistedUIReady: boolean): voi
           'Zellij, tmux, Neovim and other terminal programs can now copy to your clipboard. Turn it off in Terminal settings.'
         ),
         duration: 15_000,
+        // Why consume on close rather than on enqueue: this is the profile's one notice that
+        // a security posture changed under it, and the flag can never re-arm once the settings
+        // stamp lands. Clearing at enqueue spends it on launches where nothing was ever seen —
+        // a quit inside the 15s, a crash in the gap. Clearing on close costs at most a repeat
+        // next launch, which the user ends by dismissing it.
+        onAutoClose: clearNotice,
+        onDismiss: clearNotice,
         action: {
           label: translate(
             'auto.components.terminal.pane.osc52.clipboard.default.on.notice.action',
             'Open Setting'
           ),
           onClick: () => {
+            // Why clear here too: sonner's action path deletes the toast without firing
+            // onDismiss, so acting on the notice would otherwise leave it armed.
+            clearNotice()
             const store = useAppStore.getState()
             store.setSettingsSearchQuery('')
             store.openSettingsTarget({
@@ -54,9 +64,5 @@ export function useOsc52ClipboardDefaultOnNotice(persistedUIReady: boolean): voi
         }
       }
     )
-    // Why clear after: a throw above would burn the profile's one notice without ever
-    // enqueueing it. The toast is only queued at this point, not painted, so a crash in
-    // the gap still loses it — accepted, since the alternative loses it far more often.
-    clearNotice()
   }, [clearNotice, noticePending, persistedUIReady])
 }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -123,8 +123,8 @@ describe('handleOsc52ClipboardRequest', () => {
   })
 
   it('never answers a clipboard query even with writes enabled', () => {
-    // Why: enabled is now the default, so the query block has to hold in the
-    // configuration nearly every user runs — not just the opted-out one.
+    // A guard, not coverage of this change: queries were already refused. It matters
+    // more now only because default-on makes `allowClipboardWrite: true` the norm.
     const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
 
     for (const query of ['c;?', ';?']) {
@@ -134,6 +134,27 @@ describe('handleOsc52ClipboardRequest', () => {
     }
 
     expect(writeClipboardText).not.toHaveBeenCalled()
+  })
+
+  it('routes every selection kind to the system clipboard, including bare PRIMARY', () => {
+    // Pins today's behavior rather than endorsing it: `selections` is parsed but never
+    // consulted, so a `p`-only write lands in CLIPBOARD. Routing it to the PRIMARY sink
+    // on Linux is a live question — this test is what makes that a deliberate break.
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+
+    for (const selections of ['p', 'q', 's0', 'pc']) {
+      handleOsc52ClipboardRequest(`${selections};${b64(`via ${selections}`)}`, {
+        allowClipboardWrite: true,
+        writeClipboardText
+      })
+    }
+
+    expect(writeClipboardText.mock.calls.map(([text]) => text)).toEqual([
+      'via p',
+      'via q',
+      'via s0',
+      'via pc'
+    ])
   })
 
   it('does not surface blocked queries because Orca must not answer them', () => {
@@ -150,9 +171,17 @@ describe('handleOsc52ClipboardRequest', () => {
 })
 
 describe('createOsc52OscHandler', () => {
-  function setup(overrides: { settingEnabled?: boolean | null; replaying?: boolean } = {}) {
+  function setup(
+    overrides: {
+      settingEnabled?: boolean | null
+      replaying?: boolean
+      writeClipboardText?: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>
+    } = {}
+  ) {
     const settingEnabled = 'settingEnabled' in overrides ? overrides.settingEnabled : true
-    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+    const writeClipboardText =
+      overrides.writeClipboardText ??
+      vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
     const showBlockedWriteToast = vi.fn()
     const handler = createOsc52OscHandler({
       getSettingEnabled: () => settingEnabled,
@@ -210,6 +239,83 @@ describe('createOsc52OscHandler', () => {
     handler(`c;${b64('after')}`)
     await Promise.resolve()
     expect(writeClipboardText).toHaveBeenCalledExactlyOnceWith('after')
+  })
+
+  // The coalesced write runs in a microtask, outside the parser handler xterm guards, so
+  // a bridge failure there escapes the pane as an uncaught error instead of a failed copy.
+  it.each([
+    [
+      // Dropping the try/catch turns this into an uncaught exception that fails the run.
+      'a clipboard bridge that throws synchronously',
+      vi.fn<(text: string) => Promise<void>>(() => {
+        throw new Error('clipboard unavailable')
+      })
+    ],
+    [
+      // Not revert-proof on its own — dropping the `?.` turns this into a TypeError the
+      // try/catch also swallows. It pins the behavior: a bad bridge must not crash the pane.
+      'a preload whose bridge returns nothing',
+      vi.fn<(text: string) => Promise<void>>(() => undefined as unknown as Promise<void>)
+    ]
+  ])('survives %s', async (_label, writeClipboardText) => {
+    const { handler } = setup({ writeClipboardText })
+
+    expect(handler(`c;${b64('copy me')}`)).toBe(true)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(writeClipboardText).toHaveBeenCalledWith('copy me')
+  })
+
+  it('swallows a rejected clipboard write rather than leaking an unhandled rejection', async () => {
+    // Why the listener: an unhandled rejection here does not fail this suite on its own,
+    // so without it the `.catch` on the coalesced write is deletable with nothing going red.
+    const unhandled: unknown[] = []
+    const record = (reason: unknown): void => {
+      unhandled.push(reason)
+    }
+    process.on('unhandledRejection', record)
+    const written: string[] = []
+    try {
+      // Why not vi.fn here: the spy tracks settled results, which marks the rejection
+      // handled and hides exactly the leak this test exists to catch.
+      const handler = createOsc52OscHandler({
+        getSettingEnabled: () => true,
+        getReplaying: () => false,
+        writeClipboardText: (text) => {
+          written.push(text)
+          return Promise.reject(new Error('denied by OS'))
+        },
+        showBlockedWriteToast: vi.fn()
+      })
+
+      expect(handler(`c;${b64('copy me')}`)).toBe(true)
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    } finally {
+      process.off('unhandledRejection', record)
+    }
+
+    expect(written).toEqual(['copy me'])
+    expect(unhandled).toEqual([])
+  })
+
+  it('keeps coalescing after a failed write instead of wedging the pane', async () => {
+    // Why: the flush latch is reset before the write, so a throw must not strand it —
+    // otherwise the first failure silently kills clipboard copy for the session.
+    const writeClipboardText = vi
+      .fn<(text: string) => Promise<void>>()
+      .mockImplementationOnce(() => {
+        throw new Error('clipboard unavailable')
+      })
+      .mockResolvedValue(undefined)
+    const { handler } = setup({ writeClipboardText })
+
+    handler(`c;${b64('first')}`)
+    await Promise.resolve()
+    handler(`c;${b64('second')}`)
+    await Promise.resolve()
+
+    expect(writeClipboardText).toHaveBeenNthCalledWith(2, 'second')
   })
 
   it('drops a replayed write and stays silent about it', async () => {

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  createOsc52OscHandler,
   handleOsc52ClipboardRequest,
   parseOsc52,
   resolveOsc52ClipboardGate
@@ -145,6 +146,65 @@ describe('handleOsc52ClipboardRequest', () => {
     })
 
     expect(onBlockedWrite).not.toHaveBeenCalled()
+  })
+})
+
+describe('createOsc52OscHandler', () => {
+  function setup(overrides: { settingEnabled?: boolean | null; replaying?: boolean } = {}) {
+    const settingEnabled = 'settingEnabled' in overrides ? overrides.settingEnabled : true
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+    const showBlockedWriteToast = vi.fn()
+    const handler = createOsc52OscHandler({
+      getSettingEnabled: () => settingEnabled,
+      getReplaying: () => overrides.replaying ?? false,
+      writeClipboardText,
+      showBlockedWriteToast
+    })
+    return { handler, writeClipboardText, showBlockedWriteToast }
+  }
+
+  it('writes through to the clipboard for a live pane', () => {
+    const { handler, writeClipboardText } = setup()
+    expect(handler(`c;${b64('live copy')}`)).toBe(true)
+    expect(writeClipboardText).toHaveBeenCalledWith('live copy')
+  })
+
+  it('reads the gate inputs at fire time so a mid-session toggle applies', () => {
+    // Why getters, not values: settings hydrate and toggle after the handler is registered.
+    let enabled = false
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+    const handler = createOsc52OscHandler({
+      getSettingEnabled: () => enabled,
+      getReplaying: () => false,
+      writeClipboardText,
+      showBlockedWriteToast: vi.fn()
+    })
+
+    handler(`c;${b64('before')}`)
+    expect(writeClipboardText).not.toHaveBeenCalled()
+
+    enabled = true
+    handler(`c;${b64('after')}`)
+    expect(writeClipboardText).toHaveBeenCalledExactlyOnceWith('after')
+  })
+
+  it('drops a replayed write and stays silent about it', () => {
+    // Revert-proof for the wiring: dropping the replay getter makes this fail.
+    const { handler, writeClipboardText, showBlockedWriteToast } = setup({ replaying: true })
+    expect(handler(`c;${b64('stale scrollback copy')}`)).toBe(true)
+    expect(writeClipboardText).not.toHaveBeenCalled()
+    expect(showBlockedWriteToast).not.toHaveBeenCalled()
+  })
+
+  it('toasts only for a real opt-out, never for unhydrated settings', () => {
+    const optedOut = setup({ settingEnabled: false })
+    optedOut.handler(`c;${b64('blocked')}`)
+    expect(optedOut.showBlockedWriteToast).toHaveBeenCalledTimes(1)
+
+    const unhydrated = setup({ settingEnabled: null })
+    unhydrated.handler(`c;${b64('blocked')}`)
+    expect(unhydrated.writeClipboardText).not.toHaveBeenCalled()
+    expect(unhydrated.showBlockedWriteToast).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -51,11 +51,14 @@ describe('parseOsc52', () => {
     expect(parseOsc52(b64('no-semicolon'))).toMatchObject({ kind: 'invalid' })
   })
 
-  it('rejects empty selection list', () => {
-    // Why: the spec defaults to "s0" on empty, but treating malformed
-    // payloads as clipboard writes would let buggy/malicious emitters
-    // mutate the clipboard unintentionally.
-    expect(parseOsc52(`;${b64('x')}`)).toMatchObject({ kind: 'invalid' })
+  it('treats empty selection list as clipboard (XTerm/Zellij default)', () => {
+    // Why: multiplexers may emit `\e]52;;base64` with empty Pc; the XTerm
+    // default is clipboard, so reject-empty broke Zellij copy (#10567).
+    expect(parseOsc52(`;${b64('from zellij')}`)).toEqual({
+      kind: 'write',
+      selections: 'c',
+      text: 'from zellij'
+    })
   })
 
   it('rejects unknown selection letters', () => {

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -58,7 +58,7 @@ describe('parseOsc52', () => {
 
   it('treats an empty selection list as clipboard, the way tmux emits it', () => {
     // Why: tmux copies via `\e]52;;<base64>` with no selection letter, so
-    // rejecting empty Pc broke tmux copy. Zellij always sends an explicit 'c'.
+    // rejecting empty Pc broke tmux copy. Zellij always sends an explicit 'c'/'p'.
     expect(parseOsc52(`;${b64('from tmux')}`)).toEqual({
       kind: 'write',
       selections: 'c',
@@ -71,8 +71,8 @@ describe('parseOsc52', () => {
   })
 
   it('rejects an empty payload instead of blanking the clipboard', () => {
-    // Why: a truncated sequence is the only realistic source, and the gate is
-    // now default-on — silently clearing the clipboard would be worse than a no-op.
+    // Why: this is XTerm's "clear the selection", which we decline to honor — with
+    // the gate default-on, any PTY could otherwise blank the clipboard for free.
     expect(parseOsc52(';')).toMatchObject({ kind: 'invalid' })
     expect(parseOsc52('c;')).toMatchObject({ kind: 'invalid' })
     expect(parseOsc52('c;   ')).toMatchObject({ kind: 'invalid' })
@@ -163,13 +163,35 @@ describe('createOsc52OscHandler', () => {
     return { handler, writeClipboardText, showBlockedWriteToast }
   }
 
-  it('writes through to the clipboard for a live pane', () => {
+  it('writes through to the clipboard for a live pane', async () => {
     const { handler, writeClipboardText } = setup()
     expect(handler(`c;${b64('live copy')}`)).toBe(true)
+    await Promise.resolve()
     expect(writeClipboardText).toHaveBeenCalledWith('live copy')
   })
 
-  it('reads the gate inputs at fire time so a mid-session toggle applies', () => {
+  it('coalesces a flood of writes into one clipboard call', async () => {
+    // Why: a 15-byte sequence repeated across one hostile chunk would otherwise fire
+    // a million IPC round-trips and native clipboard writes. Last write still wins.
+    const { handler, writeClipboardText } = setup()
+    for (let i = 0; i < 1000; i++) {
+      handler(`c;${b64(`copy ${i}`)}`)
+    }
+    await Promise.resolve()
+    expect(writeClipboardText).toHaveBeenCalledExactlyOnceWith('copy 999')
+  })
+
+  it('does not coalesce across separate turns', async () => {
+    const { handler, writeClipboardText } = setup()
+    handler(`c;${b64('first')}`)
+    await Promise.resolve()
+    handler(`c;${b64('second')}`)
+    await Promise.resolve()
+    expect(writeClipboardText).toHaveBeenNthCalledWith(1, 'first')
+    expect(writeClipboardText).toHaveBeenNthCalledWith(2, 'second')
+  })
+
+  it('reads the gate inputs at fire time so a mid-session toggle applies', async () => {
     // Why getters, not values: settings hydrate and toggle after the handler is registered.
     let enabled = false
     const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
@@ -181,28 +203,31 @@ describe('createOsc52OscHandler', () => {
     })
 
     handler(`c;${b64('before')}`)
+    await Promise.resolve()
     expect(writeClipboardText).not.toHaveBeenCalled()
 
     enabled = true
     handler(`c;${b64('after')}`)
+    await Promise.resolve()
     expect(writeClipboardText).toHaveBeenCalledExactlyOnceWith('after')
   })
 
-  it('drops a replayed write and stays silent about it', () => {
-    // Revert-proof for the wiring: dropping the replay getter makes this fail.
+  it('drops a replayed write and stays silent about it', async () => {
     const { handler, writeClipboardText, showBlockedWriteToast } = setup({ replaying: true })
     expect(handler(`c;${b64('stale scrollback copy')}`)).toBe(true)
+    await Promise.resolve()
     expect(writeClipboardText).not.toHaveBeenCalled()
     expect(showBlockedWriteToast).not.toHaveBeenCalled()
   })
 
-  it('toasts only for a real opt-out, never for unhydrated settings', () => {
+  it('toasts only for a real opt-out, never for unhydrated settings', async () => {
     const optedOut = setup({ settingEnabled: false })
     optedOut.handler(`c;${b64('blocked')}`)
     expect(optedOut.showBlockedWriteToast).toHaveBeenCalledTimes(1)
 
     const unhydrated = setup({ settingEnabled: null })
     unhydrated.handler(`c;${b64('blocked')}`)
+    await Promise.resolve()
     expect(unhydrated.writeClipboardText).not.toHaveBeenCalled()
     expect(unhydrated.showBlockedWriteToast).not.toHaveBeenCalled()
   })
@@ -218,7 +243,7 @@ describe('resolveOsc52ClipboardGate', () => {
 
   it('drops replayed writes so restore cannot clobber the clipboard', () => {
     // Why: reattach re-writes recorded PTY bytes through the same parser, so an old
-    // copy would silently overwrite what the user has copied since (#10588 review).
+    // copy would silently overwrite what the user has copied since (#10588).
     expect(resolveOsc52ClipboardGate({ settingEnabled: true, replaying: true })).toEqual({
       allowClipboardWrite: false,
       shouldSurfaceBlockedWrite: false

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -300,8 +300,9 @@ describe('createOsc52OscHandler', () => {
   })
 
   it('keeps coalescing after a failed write instead of wedging the pane', async () => {
-    // Why: the flush latch is reset before the write, so a throw must not strand it —
-    // otherwise the first failure silently kills clipboard copy for the session.
+    // Why: a stranded flush latch silently kills clipboard copy for the rest of the session.
+    // Today two things prevent it — the latch resets before the write, and the try/catch means
+    // the microtask reaches its end either way — so this binds the pair, not the ordering alone.
     const writeClipboardText = vi
       .fn<(text: string) => Promise<void>>()
       .mockImplementationOnce(() => {

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
-import { handleOsc52ClipboardRequest, parseOsc52 } from './osc52-clipboard'
+import {
+  handleOsc52ClipboardRequest,
+  parseOsc52,
+  resolveOsc52ClipboardGate
+} from './osc52-clipboard'
 
 function b64(s: string): string {
   return Buffer.from(s, 'utf-8').toString('base64')
@@ -51,14 +55,26 @@ describe('parseOsc52', () => {
     expect(parseOsc52(b64('no-semicolon'))).toMatchObject({ kind: 'invalid' })
   })
 
-  it('treats empty selection list as clipboard (XTerm/Zellij default)', () => {
-    // Why: multiplexers may emit `\e]52;;base64` with empty Pc; the XTerm
-    // default is clipboard, so reject-empty broke Zellij copy (#10567).
-    expect(parseOsc52(`;${b64('from zellij')}`)).toEqual({
+  it('treats an empty selection list as clipboard, the way tmux emits it', () => {
+    // Why: tmux copies via `\e]52;;<base64>` with no selection letter, so
+    // rejecting empty Pc broke tmux copy. Zellij always sends an explicit 'c'.
+    expect(parseOsc52(`;${b64('from tmux')}`)).toEqual({
       kind: 'write',
       selections: 'c',
-      text: 'from zellij'
+      text: 'from tmux'
     })
+  })
+
+  it('still refuses to answer a query when Pc is empty', () => {
+    expect(parseOsc52(';?')).toEqual({ kind: 'query' })
+  })
+
+  it('rejects an empty payload instead of blanking the clipboard', () => {
+    // Why: a truncated sequence is the only realistic source, and the gate is
+    // now default-on — silently clearing the clipboard would be worse than a no-op.
+    expect(parseOsc52(';')).toMatchObject({ kind: 'invalid' })
+    expect(parseOsc52('c;')).toMatchObject({ kind: 'invalid' })
+    expect(parseOsc52('c;   ')).toMatchObject({ kind: 'invalid' })
   })
 
   it('rejects unknown selection letters', () => {
@@ -105,6 +121,20 @@ describe('handleOsc52ClipboardRequest', () => {
     expect(onBlockedWrite).toHaveBeenCalledTimes(1)
   })
 
+  it('never answers a clipboard query even with writes enabled', () => {
+    // Why: enabled is now the default, so the query block has to hold in the
+    // configuration nearly every user runs — not just the opted-out one.
+    const writeClipboardText = vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined)
+
+    for (const query of ['c;?', ';?']) {
+      expect(
+        handleOsc52ClipboardRequest(query, { allowClipboardWrite: true, writeClipboardText })
+      ).toBe(true)
+    }
+
+    expect(writeClipboardText).not.toHaveBeenCalled()
+  })
+
   it('does not surface blocked queries because Orca must not answer them', () => {
     const onBlockedWrite = vi.fn()
 
@@ -115,5 +145,41 @@ describe('handleOsc52ClipboardRequest', () => {
     })
 
     expect(onBlockedWrite).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolveOsc52ClipboardGate', () => {
+  it('allows a live write once the setting is on', () => {
+    expect(resolveOsc52ClipboardGate({ settingEnabled: true, replaying: false })).toEqual({
+      allowClipboardWrite: true,
+      shouldSurfaceBlockedWrite: false
+    })
+  })
+
+  it('drops replayed writes so restore cannot clobber the clipboard', () => {
+    // Why: reattach re-writes recorded PTY bytes through the same parser, so an old
+    // copy would silently overwrite what the user has copied since (#10588 review).
+    expect(resolveOsc52ClipboardGate({ settingEnabled: true, replaying: true })).toEqual({
+      allowClipboardWrite: false,
+      shouldSurfaceBlockedWrite: false
+    })
+  })
+
+  it('surfaces the blocked toast only for a real opt-out', () => {
+    expect(resolveOsc52ClipboardGate({ settingEnabled: false, replaying: false })).toEqual({
+      allowClipboardWrite: false,
+      shouldSurfaceBlockedWrite: true
+    })
+  })
+
+  it('stays quiet when a write races settings hydration', () => {
+    // Why: the toast latches once per renderer session; an unhydrated read looks
+    // blocked even though the default is on, so burning it there hides the real one.
+    for (const settingEnabled of [null, undefined]) {
+      expect(resolveOsc52ClipboardGate({ settingEnabled, replaying: false })).toEqual({
+        allowClipboardWrite: false,
+        shouldSurfaceBlockedWrite: false
+      })
+    }
   })
 })

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -1,6 +1,6 @@
 // OSC 52 — "Manipulate Selection Data". xterm.js does not implement this
-// handler itself; applications register it to let TUIs (tmux, Zellij, neovim,
-// fzf, ripgrep) copy to the host clipboard over SSH or through the PTY.
+// handler itself; applications register it to let TUIs (Zellij, tmux, Neovim,
+// fzf, Grok) copy to the host clipboard over SSH or through the PTY.
 //
 // Wire format (xterm.js strips the leading `\x1b]52;` and trailing BEL/ST
 // before handing us the payload string):
@@ -8,11 +8,12 @@
 //     Pc ; Pd
 //
 // Pc is zero or more selection-kind letters ("c"=clipboard, "p"=primary,
-// "q"=secondary, "s"=select). Empty Pc is treated as clipboard — the XTerm
-// default and what some multiplexers (including Zellij paths) emit. Pd is
-// base64-encoded UTF-8. If Pd is "?" the TUI is *querying* the clipboard —
-// we deliberately ignore that case to avoid leaking clipboard contents to
-// any process writing to the PTY.
+// "q"=secondary, "s"=select). Orca maps every selection kind to the one
+// system clipboard — it has no separate primary/cut-buffer sink here — so
+// `selections` is reported for callers but not used to route the write.
+// Pd is base64-encoded UTF-8. If Pd is "?" the TUI is *querying* the
+// clipboard — we deliberately ignore that case to avoid leaking clipboard
+// contents to any process writing to the PTY.
 //
 // Safety: OSC 52 is a classic data-exfil / overwrite vector — piping an
 // attacker-controlled log into the terminal could silently replace the
@@ -20,6 +21,7 @@
 // on; query stays blocked; payload size is capped).
 
 export type Osc52ParseResult =
+  /** `selections` is normalized: an empty Pc is reported as 'c'. */
   | { kind: 'write'; selections: string; text: string }
   | { kind: 'query' }
   | { kind: 'invalid'; reason: string }
@@ -31,6 +33,29 @@ export type Osc52ClipboardRequestOptions = {
 }
 
 const MAX_OSC52_BYTES = 128 * 1024
+
+/** Resolves whether an incoming OSC 52 write may touch the clipboard, and whether a
+ *  refusal is worth telling the user about. */
+export function resolveOsc52ClipboardGate(input: {
+  /** Null/undefined until settings hydrate. */
+  settingEnabled: boolean | null | undefined
+  /** True while recorded PTY bytes are being written back into this pane. */
+  replaying: boolean
+}): { allowClipboardWrite: boolean; shouldSurfaceBlockedWrite: boolean } {
+  // Why drop during replay: reattach and cold-restore re-write recorded PTY bytes through the same
+  // parser, so a stale `\e]52;c;…` would overwrite whatever the user has copied since. No fresh intent.
+  const allowClipboardWrite = !input.replaying && input.settingEnabled === true
+  return {
+    allowClipboardWrite,
+    // Why not toast on replay or pre-hydration: the toast latches once per renderer session, and neither
+    // case is a real opt-out — unhydrated settings read as blocked even though the default is on.
+    shouldSurfaceBlockedWrite:
+      !allowClipboardWrite &&
+      !input.replaying &&
+      input.settingEnabled !== null &&
+      input.settingEnabled !== undefined
+  }
+}
 
 export function handleOsc52ClipboardRequest(
   data: string,
@@ -57,8 +82,9 @@ export function parseOsc52(data: string): Osc52ParseResult {
   if (semi === -1) {
     return { kind: 'invalid', reason: 'missing selection/data separator' }
   }
-  // Why empty → "c": XTerm defaults empty Pc to the clipboard, and Zellij /
-  // some copy paths emit `\e]52;;<base64>\a` without an explicit letter.
+  // Why accept empty Pc: tmux copies via `\e]52;;<base64>` (window-copy.c passes an
+  // empty clip through the `Ms` capability). XTerm would read that as `s0`, but Orca
+  // has one clipboard sink so every kind lands there anyway. Zellij always sends `c`/`p`.
   const selections = data.slice(0, semi) || 'c'
   const payload = data.slice(semi + 1)
 
@@ -80,6 +106,12 @@ export function parseOsc52(data: string): Osc52ParseResult {
   const decoded = decodeBase64Utf8(payload)
   if (decoded === null) {
     return { kind: 'invalid', reason: 'payload is not valid base64' }
+  }
+  // Why reject empty: XTerm reads an empty Pd as "clear the selection", but the
+  // only realistic source is a truncated sequence — and with the gate default-on
+  // that would silently blank the clipboard. No TUI copies the empty string.
+  if (decoded === '') {
+    return { kind: 'invalid', reason: 'empty payload' }
   }
   return { kind: 'write', selections, text: decoded }
 }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -17,10 +17,18 @@
 // clipboard — we deliberately ignore that case to avoid leaking clipboard
 // contents to any process writing to the PTY.
 //
-// Safety: OSC 52 is a classic data-exfil / overwrite vector — piping an
-// attacker-controlled log into the terminal could silently replace the
-// user's clipboard. Callers gate on `terminalAllowOsc52Clipboard` (default
-// on; query stays blocked; payload size is capped).
+// Safety: OSC 52 is a classic clipboard-overwrite vector — piping an
+// attacker-controlled log into the terminal could silently replace the user's
+// clipboard. Callers gate on `terminalAllowOsc52Clipboard` (default on; query
+// stays blocked, so nothing is exfiltrated; payload size is capped).
+//
+// Accepted residual risk of default-on: the decoded text is written verbatim,
+// newlines and all, so a hostile PTY can stage an execute-on-paste payload.
+// We do not filter here — a multi-line copy out of a TUI is the feature — and
+// the mitigation belongs at paste time, where bracketed paste keeps a pasted
+// newline out of the shell's input (see terminal-bracketed-paste.ts). This
+// matches kitty and Ghostty, which both allow OSC 52 writes unprompted by
+// default while still gating reads.
 
 export type Osc52ParseResult =
   /** `selections` is normalized: an empty Pc is reported as 'c'. */
@@ -46,6 +54,12 @@ export function resolveOsc52ClipboardGate(input: {
 }): { allowClipboardWrite: boolean; shouldSurfaceBlockedWrite: boolean } {
   // Why drop during replay: reattach and cold-restore re-write recorded PTY bytes through the same
   // parser, so a stale `\e]52;c;…` would overwrite whatever the user has copied since. No fresh intent.
+  //
+  // Known over-suppression: the flag is read when xterm parses, not when the bytes were queued, and
+  // the replay path drains queued live bytes before engaging the guard (pty-connection.ts, "drain any
+  // queued background bytes BEFORE the replay paint"). A copy issued in the same tick as a reattach
+  // is therefore dropped silently. Fixing it means tagging chunks at queue time; a lost copy the user
+  // can repeat is the cheaper side of that trade.
   const allowClipboardWrite = !input.replaying && input.settingEnabled === true
   return {
     allowClipboardWrite,
@@ -68,8 +82,9 @@ export function createOsc52OscHandler(deps: {
   showBlockedWriteToast: () => void
 }): (data: string) => boolean {
   // Why coalesce: each sequence is only ~15 bytes, so one hostile chunk can fire a
-  // million parser callbacks — each a main-process clipboard write. Only the last
-  // one is observable anyway, so keep it and drop the rest.
+  // million parser callbacks — each a main-process clipboard write. Only the last of
+  // a microtask's worth is observable, so keep that and drop the rest. This bounds a
+  // flood to roughly one write per xterm parse yield, not to one write overall.
   let pendingText: string | null = null
   let flushScheduled = false
   const writeCoalesced = (text: string): Promise<void> => {

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -8,9 +8,11 @@
 //     Pc ; Pd
 //
 // Pc is zero or more selection-kind letters ("c"=clipboard, "p"=primary,
-// "q"=secondary, "s"=select). Orca maps every selection kind to the one
-// system clipboard — it has no separate primary/cut-buffer sink here — so
-// `selections` is reported for callers but not used to route the write.
+// "q"=secondary, "s"=select). Orca deliberately merges all of them into the
+// system clipboard: a PRIMARY sink does exist (writeSelectionClipboardText),
+// but Zellij defaults to `p` on Linux and means the system clipboard by it,
+// so routing `p` there would break the case this default-on flip is for.
+// `selections` is reported for callers but does not route the write.
 // Pd is base64-encoded UTF-8. If Pd is "?" the TUI is *querying* the
 // clipboard — we deliberately ignore that case to avoid leaking clipboard
 // contents to any process writing to the PTY.
@@ -32,7 +34,7 @@ export type Osc52ClipboardRequestOptions = {
   onBlockedWrite?: () => void
 }
 
-const MAX_OSC52_BYTES = 128 * 1024
+const MAX_OSC52_BASE64_CHARS = 128 * 1024
 
 /** Resolves whether an incoming OSC 52 write may touch the clipboard, and whether a
  *  refusal is worth telling the user about. */
@@ -65,6 +67,29 @@ export function createOsc52OscHandler(deps: {
   writeClipboardText: (text: string) => Promise<void>
   showBlockedWriteToast: () => void
 }): (data: string) => boolean {
+  // Why coalesce: each sequence is only ~15 bytes, so one hostile chunk can fire a
+  // million parser callbacks — each a main-process clipboard write. Only the last
+  // one is observable anyway, so keep it and drop the rest.
+  let pendingText: string | null = null
+  let flushScheduled = false
+  const writeCoalesced = (text: string): Promise<void> => {
+    pendingText = text
+    if (!flushScheduled) {
+      flushScheduled = true
+      queueMicrotask(() => {
+        flushScheduled = false
+        const next = pendingText
+        pendingText = null
+        if (next !== null) {
+          void deps.writeClipboardText(next).catch(() => {
+            /* ignore clipboard write failures */
+          })
+        }
+      })
+    }
+    return Promise.resolve()
+  }
+
   return (data) => {
     const gate = resolveOsc52ClipboardGate({
       settingEnabled: deps.getSettingEnabled(),
@@ -72,7 +97,7 @@ export function createOsc52OscHandler(deps: {
     })
     return handleOsc52ClipboardRequest(data, {
       allowClipboardWrite: gate.allowClipboardWrite,
-      writeClipboardText: deps.writeClipboardText,
+      writeClipboardText: writeCoalesced,
       onBlockedWrite: gate.shouldSurfaceBlockedWrite ? deps.showBlockedWriteToast : undefined
     })
   }
@@ -104,8 +129,8 @@ export function parseOsc52(data: string): Osc52ParseResult {
     return { kind: 'invalid', reason: 'missing selection/data separator' }
   }
   // Why accept empty Pc: tmux copies via `\e]52;;<base64>` (window-copy.c passes an
-  // empty clip through the `Ms` capability). XTerm would read that as `s0`, but Orca
-  // has one clipboard sink so every kind lands there anyway. Zellij always sends `c`/`p`.
+  // empty clip through the `Ms` capability). XTerm would read that as `s0`; we merge
+  // every kind into the clipboard regardless (see header). Zellij always sends `c`/`p`.
   const selections = data.slice(0, semi) || 'c'
   const payload = data.slice(semi + 1)
 
@@ -120,7 +145,7 @@ export function parseOsc52(data: string): Osc52ParseResult {
   // Why guard size: xterm's own parser caps OSC payloads at ~10 MB; we cap
   // tighter because a legitimate clipboard write is rarely more than a
   // screenful and any multi-MB payload is almost certainly a bug or abuse.
-  if (payload.length > MAX_OSC52_BYTES) {
+  if (payload.length > MAX_OSC52_BASE64_CHARS) {
     return { kind: 'invalid', reason: 'payload exceeds size limit' }
   }
 
@@ -128,9 +153,9 @@ export function parseOsc52(data: string): Osc52ParseResult {
   if (decoded === null) {
     return { kind: 'invalid', reason: 'payload is not valid base64' }
   }
-  // Why reject empty: XTerm reads an empty Pd as "clear the selection", but the
-  // only realistic source is a truncated sequence — and with the gate default-on
-  // that would silently blank the clipboard. No TUI copies the empty string.
+  // Why reject empty: this is XTerm's "clear the selection", which we decline to
+  // honor — with the gate default-on, any PTY could blank the clipboard for free.
+  // (A truncated sequence never lands here; xterm only calls us on parse success.)
   if (decoded === '') {
     return { kind: 'invalid', reason: 'empty payload' }
   }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -1,21 +1,23 @@
 // OSC 52 — "Manipulate Selection Data". xterm.js does not implement this
-// handler itself; applications register it to let TUIs (tmux, neovim, fzf,
-// ripgrep) copy to the host clipboard over SSH or through the PTY.
+// handler itself; applications register it to let TUIs (tmux, Zellij, neovim,
+// fzf, ripgrep) copy to the host clipboard over SSH or through the PTY.
 //
 // Wire format (xterm.js strips the leading `\x1b]52;` and trailing BEL/ST
 // before handing us the payload string):
 //
 //     Pc ; Pd
 //
-// Pc is one or more selection-kind letters ("c"=clipboard, "p"=primary,
-// "q"=secondary, "s"=select); Pd is base64-encoded UTF-8. If Pd is "?" the
-// TUI is *querying* the clipboard — we deliberately ignore that case to
-// avoid leaking clipboard contents to any process writing to the PTY.
+// Pc is zero or more selection-kind letters ("c"=clipboard, "p"=primary,
+// "q"=secondary, "s"=select). Empty Pc is treated as clipboard — the XTerm
+// default and what some multiplexers (including Zellij paths) emit. Pd is
+// base64-encoded UTF-8. If Pd is "?" the TUI is *querying* the clipboard —
+// we deliberately ignore that case to avoid leaking clipboard contents to
+// any process writing to the PTY.
 //
 // Safety: OSC 52 is a classic data-exfil / overwrite vector — piping an
 // attacker-controlled log into the terminal could silently replace the
-// user's clipboard. Callers must gate on the user-opt-in setting
-// `terminalAllowOsc52Clipboard` before invoking the handler.
+// user's clipboard. Callers gate on `terminalAllowOsc52Clipboard` (default
+// on; query stays blocked; payload size is capped).
 
 export type Osc52ParseResult =
   | { kind: 'write'; selections: string; text: string }
@@ -55,16 +57,11 @@ export function parseOsc52(data: string): Osc52ParseResult {
   if (semi === -1) {
     return { kind: 'invalid', reason: 'missing selection/data separator' }
   }
-  const selections = data.slice(0, semi)
+  // Why empty → "c": XTerm defaults empty Pc to the clipboard, and Zellij /
+  // some copy paths emit `\e]52;;<base64>\a` without an explicit letter.
+  const selections = data.slice(0, semi) || 'c'
   const payload = data.slice(semi + 1)
 
-  // Why reject empty selections: the spec allows it (defaults to "s0"), but
-  // every TUI we care about emits at least one letter, and treating empty
-  // as "apply to clipboard" would let malformed payloads mutate the
-  // clipboard by accident.
-  if (selections.length === 0) {
-    return { kind: 'invalid', reason: 'empty selection list' }
-  }
   if (!/^[cpqs0-7]+$/.test(selections)) {
     return { kind: 'invalid', reason: 'unknown selection kind' }
   }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -8,11 +8,11 @@
 //     Pc ; Pd
 //
 // Pc is zero or more selection-kind letters ("c"=clipboard, "p"=primary,
-// "q"=secondary, "s"=select). Orca deliberately merges all of them into the
-// system clipboard: a PRIMARY sink does exist (writeSelectionClipboardText),
-// but Zellij defaults to `p` on Linux and means the system clipboard by it,
-// so routing `p` there would break the case this default-on flip is for.
-// `selections` is reported for callers but does not route the write.
+// "q"=secondary, "s"=select). Every kind lands in the system clipboard and
+// `selections` does not route the write — longstanding behavior this flip
+// only makes reachable by default. A PRIMARY sink exists
+// (writeSelectionClipboardText), so routing `p` there on Linux is an open
+// question, deliberately left out of a change that is about the gate.
 // Pd is base64-encoded UTF-8. If Pd is "?" the TUI is *querying* the
 // clipboard — we deliberately ignore that case to avoid leaking clipboard
 // contents to any process writing to the PTY.
@@ -81,9 +81,16 @@ export function createOsc52OscHandler(deps: {
         const next = pendingText
         pendingText = null
         if (next !== null) {
-          void deps.writeClipboardText(next).catch(() => {
+          // Why try/catch and not just .catch(): the write moved out of the guarded
+          // parser handler into a microtask, where a sync throw (or a preload that
+          // never installed writeClipboardText) would surface as an uncaught error.
+          try {
+            void deps.writeClipboardText(next)?.catch(() => {
+              /* ignore clipboard write failures */
+            })
+          } catch {
             /* ignore clipboard write failures */
-          })
+          }
         }
       })
     }

--- a/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
+++ b/src/renderer/src/components/terminal-pane/osc52-clipboard.ts
@@ -57,6 +57,27 @@ export function resolveOsc52ClipboardGate(input: {
   }
 }
 
+/** Composes the gate with the request handler into an xterm OSC handler.
+ *  Extracted so the wiring is covered too, not just the gate in isolation. */
+export function createOsc52OscHandler(deps: {
+  getSettingEnabled: () => boolean | null | undefined
+  getReplaying: () => boolean
+  writeClipboardText: (text: string) => Promise<void>
+  showBlockedWriteToast: () => void
+}): (data: string) => boolean {
+  return (data) => {
+    const gate = resolveOsc52ClipboardGate({
+      settingEnabled: deps.getSettingEnabled(),
+      replaying: deps.getReplaying()
+    })
+    return handleOsc52ClipboardRequest(data, {
+      allowClipboardWrite: gate.allowClipboardWrite,
+      writeClipboardText: deps.writeClipboardText,
+      onBlockedWrite: gate.shouldSurfaceBlockedWrite ? deps.showBlockedWriteToast : undefined
+    })
+  }
+}
+
 export function handleOsc52ClipboardRequest(
   data: string,
   options: Osc52ClipboardRequestOptions

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -67,7 +67,7 @@ import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
 import { applyTerminalAppearance, installMode2031Handlers } from './terminal-appearance'
 import { pushMode2031SeedReply } from './terminal-mode-2031-replies'
-import { handleOsc52ClipboardRequest, resolveOsc52ClipboardGate } from './osc52-clipboard'
+import { createOsc52OscHandler } from './osc52-clipboard'
 import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
 import { guardParserHandler } from './terminal-parser-handler-guard'
@@ -806,19 +806,15 @@ export function useTerminalPaneLifecycle({
         // Why: read settingsRef at fire time so mid-session gate toggles apply; return true in both paths so xterm doesn't fall through.
         const osc52Disposable = pane.terminal.parser.registerOscHandler(
           52,
-          guardParserHandler('osc-52-clipboard', (data) => {
-            const gate = resolveOsc52ClipboardGate({
-              settingEnabled: settingsRef.current?.terminalAllowOsc52Clipboard,
-              replaying: isPaneReplaying(replayingPanesRef, pane.id)
+          guardParserHandler(
+            'osc-52-clipboard',
+            createOsc52OscHandler({
+              getSettingEnabled: () => settingsRef.current?.terminalAllowOsc52Clipboard,
+              getReplaying: () => isPaneReplaying(replayingPanesRef, pane.id),
+              writeClipboardText: (text) => window.api.ui.writeClipboardText(text),
+              showBlockedWriteToast: showOsc52ClipboardBlockedToast
             })
-            return handleOsc52ClipboardRequest(data, {
-              allowClipboardWrite: gate.allowClipboardWrite,
-              writeClipboardText: window.api.ui.writeClipboardText,
-              onBlockedWrite: gate.shouldSurfaceBlockedWrite
-                ? showOsc52ClipboardBlockedToast
-                : undefined
-            })
-          })
+          )
         )
         osc52DisposablesRef.current.set(pane.id, osc52Disposable)
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -67,7 +67,7 @@ import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { applyExpandedLayoutTo, restoreExpandedLayoutFrom } from './expand-collapse'
 import { applyTerminalAppearance, installMode2031Handlers } from './terminal-appearance'
 import { pushMode2031SeedReply } from './terminal-mode-2031-replies'
-import { handleOsc52ClipboardRequest } from './osc52-clipboard'
+import { handleOsc52ClipboardRequest, resolveOsc52ClipboardGate } from './osc52-clipboard'
 import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
 import { guardParserHandler } from './terminal-parser-handler-guard'
@@ -806,13 +806,19 @@ export function useTerminalPaneLifecycle({
         // Why: read settingsRef at fire time so mid-session gate toggles apply; return true in both paths so xterm doesn't fall through.
         const osc52Disposable = pane.terminal.parser.registerOscHandler(
           52,
-          guardParserHandler('osc-52-clipboard', (data) =>
-            handleOsc52ClipboardRequest(data, {
-              allowClipboardWrite: settingsRef.current?.terminalAllowOsc52Clipboard === true,
-              writeClipboardText: window.api.ui.writeClipboardText,
-              onBlockedWrite: showOsc52ClipboardBlockedToast
+          guardParserHandler('osc-52-clipboard', (data) => {
+            const gate = resolveOsc52ClipboardGate({
+              settingEnabled: settingsRef.current?.terminalAllowOsc52Clipboard,
+              replaying: isPaneReplaying(replayingPanesRef, pane.id)
             })
-          )
+            return handleOsc52ClipboardRequest(data, {
+              allowClipboardWrite: gate.allowClipboardWrite,
+              writeClipboardText: window.api.ui.writeClipboardText,
+              onBlockedWrite: gate.shouldSurfaceBlockedWrite
+                ? showOsc52ClipboardBlockedToast
+                : undefined
+            })
+          })
         )
         osc52DisposablesRef.current.set(pane.id, osc52Disposable)
 

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -802,7 +802,7 @@ export function useTerminalPaneLifecycle({
         })
         mode2031DisposablesRef.current.set(pane.id, mode2031Disposables)
 
-        // OSC 52 — TUI-initiated clipboard writes (tmux/nvim/fzf/ssh).
+        // OSC 52 — TUI-initiated clipboard writes (Zellij/tmux/nvim/fzf/ssh).
         // Why: read settingsRef at fire time so mid-session gate toggles apply; return true in both paths so xterm doesn't fall through.
         const osc52Disposable = pane.terminal.parser.registerOscHandler(
           52,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2669,7 +2669,7 @@
               "blocked": {
                 "toast": {
                   "97c98f1afe": "Open Setting",
-                  "7cf51f74fd": "Enable TUI clipboard writes in Terminal settings to copy from SSH, tmux, Neovim, fzf, or Grok.",
+                  "7cf51f74fd": "Enable TUI clipboard writes in Terminal settings to copy from SSH, Zellij, tmux, Neovim, fzf, or Grok.",
                   "89eaa3e80b": "Terminal clipboard write blocked"
                 }
               }
@@ -7002,9 +7002,9 @@
           "d23b43c5be": "Setup Script Location",
           "34a0dfa06e": "Where the repository setup script runs when a new workspace is created.",
           "21f8da2078": "Workspace Setup Script",
-          "6e6480a7df": "Let programs in the terminal (Grok, tmux, Neovim, fzf, SSH) copy to your system clipboard.",
+          "6e6480a7df": "Let programs in the terminal (Zellij, tmux, Neovim, fzf, Grok, SSH) copy to your system clipboard.",
           "3338dcf8c1": "Allow TUI Clipboard Writes (OSC 52)",
-          "69c64a479c": "Let Grok, tmux, Neovim, and fzf copy to the system clipboard over the PTY (including over SSH).",
+          "69c64a479c": "Let Zellij, tmux, Neovim, fzf, and Grok copy to the system clipboard over the PTY (including over SSH).",
           "4729c645fc": "Automatically copy terminal selections to the clipboard.",
           "902f5dee1f": "Copy on Select",
           "9129b7e805": "Hovering a terminal pane activates it without needing to click.",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2672,6 +2672,15 @@
                   "7cf51f74fd": "Enable TUI clipboard writes in Terminal settings to copy from SSH, Zellij, tmux, Neovim, fzf, or Grok.",
                   "89eaa3e80b": "Terminal clipboard write blocked"
                 }
+              },
+              "default": {
+                "on": {
+                  "notice": {
+                    "title": "TUI clipboard writes are now on by default",
+                    "description": "Zellij, tmux, Neovim and other terminal programs can now copy to your clipboard. Turn it off in Terminal settings.",
+                    "action": "Open Setting"
+                  }
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2649,6 +2649,15 @@
                   "7cf51f74fd": "Habilita las escrituras al portapapeles TUI en los ajustes de Terminal para copiar desde SSH, Zellij, tmux, Neovim, fzf o Grok.",
                   "89eaa3e80b": "Escritura al portapapeles del terminal bloqueada"
                 }
+              },
+              "default": {
+                "on": {
+                  "notice": {
+                    "title": "La escritura del portapapeles desde TUI ahora está activada de forma predeterminada",
+                    "description": "Zellij, tmux, Neovim y otros programas de terminal ya pueden copiar a tu portapapeles. Desactívalo en la configuración de Terminal.",
+                    "action": "Abrir ajuste"
+                  }
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2646,7 +2646,7 @@
               "blocked": {
                 "toast": {
                   "97c98f1afe": "Abrir ajustes",
-                  "7cf51f74fd": "Habilita las escrituras al portapapeles TUI en los ajustes de Terminal para copiar desde SSH, tmux, Neovim, fzf o Grok.",
+                  "7cf51f74fd": "Habilita las escrituras al portapapeles TUI en los ajustes de Terminal para copiar desde SSH, Zellij, tmux, Neovim, fzf o Grok.",
                   "89eaa3e80b": "Escritura al portapapeles del terminal bloqueada"
                 }
               }
@@ -6942,9 +6942,9 @@
           "d23b43c5be": "Ubicación del script de configuración",
           "34a0dfa06e": "Dónde se ejecuta el script de configuración del repositorio cuando se crea un nuevo espacio de trabajo.",
           "21f8da2078": "Script de configuración del espacio de trabajo",
-          "6e6480a7df": "Permite que los programas del terminal (Grok, tmux, Neovim, fzf, SSH) copien al portapapeles del sistema.",
+          "6e6480a7df": "Permite que los programas del terminal (Zellij, tmux, Neovim, fzf, Grok, SSH) copien al portapapeles del sistema.",
           "3338dcf8c1": "Permitir escrituras en el portapapeles TUI (OSC 52)",
-          "69c64a479c": "Permite que Grok, tmux, Neovim y fzf copien al portapapeles del sistema a través de PTY (incluso por SSH).",
+          "69c64a479c": "Permite que Zellij, tmux, Neovim, fzf y Grok copien al portapapeles del sistema a través de PTY (incluso por SSH).",
           "4729c645fc": "Copia automáticamente las selecciones del terminal al portapapeles.",
           "902f5dee1f": "Copiar al seleccionar",
           "9129b7e805": "Al pasar el cursor sobre un panel de terminal, se activa sin necesidad de hacer clic.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2649,6 +2649,15 @@
                   "7cf51f74fd": "SSH、Zellij、tmux、Neovim、fzf、または Grok からコピーするには、Terminal 設定で TUI クリップボードへの書き込みを有効にします。",
                   "89eaa3e80b": "Terminal のクリップボードへの書き込みがブロックされました"
                 }
+              },
+              "default": {
+                "on": {
+                  "notice": {
+                    "title": "TUI からのクリップボードへの書き込みがデフォルトで有効になりました",
+                    "description": "Zellij、tmux、Neovim などのターミナルプログラムがクリップボードにコピーできるようになりました。Terminal 設定で無効にできます。",
+                    "action": "設定を開く"
+                  }
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2646,7 +2646,7 @@
               "blocked": {
                 "toast": {
                   "97c98f1afe": "設定を開く",
-                  "7cf51f74fd": "SSH、tmux、Neovim、fzf、または Grok からコピーするには、Terminal 設定で TUI クリップボードへの書き込みを有効にします。",
+                  "7cf51f74fd": "SSH、Zellij、tmux、Neovim、fzf、または Grok からコピーするには、Terminal 設定で TUI クリップボードへの書き込みを有効にします。",
                   "89eaa3e80b": "Terminal のクリップボードへの書き込みがブロックされました"
                 }
               }
@@ -6964,9 +6964,9 @@
           "d23b43c5be": "セットアップスクリプトの場所",
           "34a0dfa06e": "新規ワークスペースの作成時に repos セットアップ スクリプトが実行される場所。",
           "21f8da2078": "ワークスペースセットアップスクリプト",
-          "6e6480a7df": "terminal 内のプログラム (Grok、tmux、Neovim、fzf、SSH) をシステムのクリップボードにコピーします。",
+          "6e6480a7df": "terminal 内のプログラム (Zellij、tmux、Neovim、fzf、Grok、SSH) をシステムのクリップボードにコピーします。",
           "3338dcf8c1": "TUI クリップボードへの書き込みを許可する (OSC 52)",
-          "69c64a479c": "Grok、tmux、Neovim、および fzf が PTY 経由 (SSH 経由を含む) でシステム クリップボードにコピーできるようにします。",
+          "69c64a479c": "Zellij、tmux、Neovim、fzf、および Grok が PTY 経由 (SSH 経由を含む) でシステム クリップボードにコピーできるようにします。",
           "4729c645fc": "terminal の選択内容をクリップボードに自動的にコピーします。",
           "902f5dee1f": "選択時にコピー",
           "9129b7e805": "terminal ペインにマウスを移動すると、クリックしなくても terminal ペインがアクティブになります。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2649,6 +2649,15 @@
                   "7cf51f74fd": "SSH, Zellij, tmux, Neovim, fzf 또는 Grok에서 복사하려면 Terminal 설정에서 TUI 클립보드 쓰기를 활성화하세요.",
                   "89eaa3e80b": "Terminal 클립보드 쓰기가 차단되었습니다."
                 }
+              },
+              "default": {
+                "on": {
+                  "notice": {
+                    "title": "TUI 클립보드 쓰기가 이제 기본으로 켜져 있습니다",
+                    "description": "Zellij, tmux, Neovim 등 터미널 프로그램이 클립보드에 복사할 수 있습니다. Terminal 설정에서 끌 수 있습니다.",
+                    "action": "설정 열기"
+                  }
+                }
               }
             }
           },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2646,7 +2646,7 @@
               "blocked": {
                 "toast": {
                   "97c98f1afe": "설정 열기",
-                  "7cf51f74fd": "SSH, tmux, Neovim, fzf 또는 Grok에서 복사하려면 Terminal 설정에서 TUI 클립보드 쓰기를 활성화하세요.",
+                  "7cf51f74fd": "SSH, Zellij, tmux, Neovim, fzf 또는 Grok에서 복사하려면 Terminal 설정에서 TUI 클립보드 쓰기를 활성화하세요.",
                   "89eaa3e80b": "Terminal 클립보드 쓰기가 차단되었습니다."
                 }
               }
@@ -6927,9 +6927,9 @@
           "d23b43c5be": "설정 스크립트 위치",
           "34a0dfa06e": "새 워크스페이스를 만들 때 repos 설정 스크립트를 실행할 위치입니다.",
           "21f8da2078": "워크스페이스 설정 스크립트",
-          "6e6480a7df": "terminal의 프로그램(Grok, tmux, Neovim, fzf, SSH)이 시스템 클립보드에 복사할 수 있게 합니다.",
+          "6e6480a7df": "terminal의 프로그램(Zellij, tmux, Neovim, fzf, Grok, SSH)이 시스템 클립보드에 복사할 수 있게 합니다.",
           "3338dcf8c1": "TUI 클립보드 쓰기 허용(OSC 52)",
-          "69c64a479c": "Grok, tmux, Neovim 및 fzf가 PTY(SSH 포함)를 통해 시스템 클립보드에 복사하도록 합니다.",
+          "69c64a479c": "Zellij, tmux, Neovim, fzf 및 Grok이 PTY(SSH 포함)를 통해 시스템 클립보드에 복사하도록 합니다.",
           "4729c645fc": "terminal 선택 사항을 클립보드에 자동으로 복사합니다.",
           "902f5dee1f": "선택 시 복사",
           "9129b7e805": "terminal 패널에 마우스를 가리키면 클릭하지 않고도 활성화됩니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2646,7 +2646,7 @@
               "blocked": {
                 "toast": {
                   "97c98f1afe": "打开设置",
-                  "7cf51f74fd": "在终端设置中启用 TUI 剪贴板写入，以从 SSH、tmux、Neovim、fzf 或 Grok 进行复制。",
+                  "7cf51f74fd": "在终端设置中启用 TUI 剪贴板写入，以从 SSH、Zellij、tmux、Neovim、fzf 或 Grok 进行复制。",
                   "89eaa3e80b": "终端剪贴板写入被阻止"
                 }
               }
@@ -6927,9 +6927,9 @@
           "d23b43c5be": "安装脚本位置",
           "34a0dfa06e": "创建新工作区时运行存储库设置脚本的位置。",
           "21f8da2078": "工作区设置脚本",
-          "6e6480a7df": "让终端中的程序（Grok、tmux、Neovim、fzf、SSH）复制到系统剪贴板。",
+          "6e6480a7df": "让终端中的程序（Zellij、tmux、Neovim、fzf、Grok、SSH）复制到系统剪贴板。",
           "3338dcf8c1": "允许 TUI 剪贴板写入 (OSC 52)",
-          "69c64a479c": "让 Grok、tmux、Neovim 和 fzf 通过 PTY（包括通过 SSH）复制到系统剪贴板。",
+          "69c64a479c": "让 Zellij、tmux、Neovim、fzf 和 Grok 通过 PTY（包括通过 SSH）复制到系统剪贴板。",
           "4729c645fc": "自动将终端选择复制到剪贴板。",
           "902f5dee1f": "选择时复制",
           "9129b7e805": "将鼠标悬停在终端窗格上即可将其激活，无需单击。",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2649,6 +2649,15 @@
                   "7cf51f74fd": "在终端设置中启用 TUI 剪贴板写入，以从 SSH、Zellij、tmux、Neovim、fzf 或 Grok 进行复制。",
                   "89eaa3e80b": "终端剪贴板写入被阻止"
                 }
+              },
+              "default": {
+                "on": {
+                  "notice": {
+                    "title": "TUI 剪贴板写入现已默认开启",
+                    "description": "Zellij、tmux、Neovim 等终端程序现在可以复制到你的剪贴板。可在 Terminal 设置中关闭。",
+                    "action": "打开设置"
+                  }
+                }
               }
             }
           },

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -3395,3 +3395,33 @@ describe('openDiffNotesSendMenuForActiveWorktree', () => {
     expect(store.getState().diffNotesSendMenuOpenRequest).toBeNull()
   })
 })
+
+describe('createUISlice clearOsc52ClipboardDefaultOnNotice', () => {
+  it('restores the armed notice from persisted UI', () => {
+    const store = createUIStore()
+
+    expect(store.getState().osc52ClipboardDefaultOnNoticePending).toBe(false)
+    store
+      .getState()
+      .hydratePersistedUI(makePersistedUI({ osc52ClipboardDefaultOnNoticePending: true }))
+
+    expect(store.getState().osc52ClipboardDefaultOnNoticePending).toBe(true)
+  })
+
+  it('stops the toast this session even when the persist fails', () => {
+    // Why local-first: the flag is the only thing keeping the toast off screen, and a
+    // rejected ui.set must not leave it re-firing on every render of this session. Losing
+    // the persist just re-arms the notice next launch, which is the safe direction.
+    const setUI = vi.fn(() => Promise.reject(new Error('runtime offline')))
+    vi.stubGlobal('window', { api: { ui: { set: setUI } } })
+    const store = createUIStore()
+    store
+      .getState()
+      .hydratePersistedUI(makePersistedUI({ osc52ClipboardDefaultOnNoticePending: true }))
+
+    store.getState().clearOsc52ClipboardDefaultOnNotice()
+
+    expect(store.getState().osc52ClipboardDefaultOnNoticePending).toBe(false)
+    expect(setUI).toHaveBeenCalledWith({ osc52ClipboardDefaultOnNoticePending: false })
+  })
+})

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -2584,7 +2584,8 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   },
   osc52ClipboardDefaultOnNoticePending: false,
   clearOsc52ClipboardDefaultOnNotice: () => {
-    // Why clear locally first: the notice must not repeat if the persist round-trip fails.
+    // Why clear locally first: a failed persist must not re-toast this session. It will
+    // re-arm on the next launch, which is the safe direction for a one-shot notice.
     set({ osc52ClipboardDefaultOnNoticePending: false })
     void window.api.ui.set({ osc52ClipboardDefaultOnNoticePending: false }).catch(console.error)
   },

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -966,6 +966,9 @@ export type UISlice = {
   setUpdateCardCollapsed: (collapsed: boolean) => void
   updateReassuranceSeen: boolean
   markUpdateReassuranceSeen: () => void
+  /** True on the launch where the OSC 52 default-on migration overrode a persisted `false`. */
+  osc52ClipboardDefaultOnNoticePending: boolean
+  clearOsc52ClipboardDefaultOnNotice: () => void
   isFullScreen: boolean
   setIsFullScreen: (v: boolean) => void
   /** URL opened when a new browser tab is created. Null = blank tab (default). */
@@ -2464,6 +2467,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
         })(),
         dismissedUpdateVersion: ui.dismissedUpdateVersion ?? null,
         updateReassuranceSeen: ui.updateReassuranceSeen ?? false,
+        osc52ClipboardDefaultOnNoticePending: ui.osc52ClipboardDefaultOnNoticePending === true,
         browserDefaultUrl: ui.browserDefaultUrl ?? null,
         browserDefaultSearchEngine: ui.browserDefaultSearchEngine ?? null,
         browserDefaultZoomLevel: normalizeBrowserPageZoomLevel(ui.browserDefaultZoomLevel),
@@ -2577,6 +2581,12 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
   markUpdateReassuranceSeen: () => {
     void window.api.ui.set({ updateReassuranceSeen: true }).catch(console.error)
     set({ updateReassuranceSeen: true })
+  },
+  osc52ClipboardDefaultOnNoticePending: false,
+  clearOsc52ClipboardDefaultOnNotice: () => {
+    // Why clear locally first: the notice must not repeat if the persist round-trip fails.
+    set({ osc52ClipboardDefaultOnNoticePending: false })
+    void window.api.ui.set({ osc52ClipboardDefaultOnNoticePending: false }).catch(console.error)
   },
   isFullScreen: false,
   setIsFullScreen: (v) => set({ isFullScreen: v }),

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -560,6 +560,25 @@ describe('web settings preload API', () => {
     expect(storedUi.osc52ClipboardDefaultOnNoticePending).not.toBe(true)
   })
 
+  it('arms the OSC 52 notice when ui.get is the read that runs the migration', async () => {
+    // Why seed after install: readLocalWebUIState must run the settings migration before it
+    // snapshots the UI blob, and only a ui.get that is itself the first settings read can
+    // show that. Reading first returns a pre-arm state every caller then writes back — and
+    // the stamp means nothing can raise the arm again. Another tab populating localStorage
+    // after this one loaded is the shape that reaches it.
+    const globals = installBrowserGlobals('Linux')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    globals.storage.setItem(
+      'orca.web.settings.v1',
+      JSON.stringify({ terminalAllowOsc52Clipboard: false })
+    )
+
+    const ui = await globals.window.api.ui.get()
+
+    expect(ui.osc52ClipboardDefaultOnNoticePending).toBe(true)
+  })
+
   it('preserves OSC 52 clipboard web opt-outs after migration', async () => {
     const globals = installBrowserGlobals('Linux')
     globals.storage.setItem(

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -506,6 +506,46 @@ describe('web settings preload API', () => {
     expect(settings.terminalCursorStyleDefaultedToBlock).toBe(true)
   })
 
+  it('migrates OSC 52 clipboard writes on for stored web settings once', async () => {
+    // Why: the web store is a second, independent settings store — the constants-level
+    // default flip only reaches profiles that never persisted the old `false` (#10567).
+    const globals = installBrowserGlobals('Linux')
+    globals.storage.setItem(
+      'orca.web.settings.v1',
+      JSON.stringify({ terminalAllowOsc52Clipboard: false })
+    )
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const settings = await globals.window.api.settings.get()
+    const stored = JSON.parse(globals.storage.getItem('orca.web.settings.v1') ?? '{}') as {
+      terminalAllowOsc52Clipboard?: boolean
+      terminalAllowOsc52ClipboardDefaultedOnForAllUsers?: boolean
+    }
+
+    expect(settings.terminalAllowOsc52Clipboard).toBe(true)
+    expect(settings.terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
+    expect(stored.terminalAllowOsc52Clipboard).toBe(true)
+    expect(stored.terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
+  })
+
+  it('preserves OSC 52 clipboard web opt-outs after migration', async () => {
+    const globals = installBrowserGlobals('Linux')
+    globals.storage.setItem(
+      'orca.web.settings.v1',
+      JSON.stringify({
+        terminalAllowOsc52Clipboard: false,
+        terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+      })
+    )
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const settings = await globals.window.api.settings.get()
+    expect(settings.terminalAllowOsc52Clipboard).toBe(false)
+    expect(settings.terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
+  })
+
   it('preserves first-work branch auto-rename web opt-outs after migration', async () => {
     const globals = installBrowserGlobals('Linux')
     globals.storage.setItem(

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1921,6 +1921,70 @@ describe('web UI preload API', () => {
     expect(stored.contextualToursSeenIds).toEqual(['tasks', 'browser'])
   })
 
+  it('keeps the local OSC 52 notice armed when ui.get returns an unmigrated host', async () => {
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            // Why false: the host store always projects this key, so a plain spread
+            // would overwrite the arm the web client's own settings migration raised.
+            result: { ui: { osc52ClipboardDefaultOnNoticePending: false } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    globals.storage.setItem(
+      'orca.web.ui.v1',
+      JSON.stringify({ osc52ClipboardDefaultOnNoticePending: true })
+    )
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const ui = await globals.window.api.ui.get()
+    expect(ui.osc52ClipboardDefaultOnNoticePending).toBe(true)
+
+    await globals.window.api.ui.set({ osc52ClipboardDefaultOnNoticePending: false })
+    const cleared = await globals.window.api.ui.get()
+    expect(cleared.osc52ClipboardDefaultOnNoticePending).toBe(false)
+  })
+
+  it('keeps the local OSC 52 notice armed when recordFeatureInteraction returns an unmigrated host', async () => {
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            result: { ui: { osc52ClipboardDefaultOnNoticePending: false } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    globals.storage.setItem(
+      'orca.web.ui.v1',
+      JSON.stringify({ osc52ClipboardDefaultOnNoticePending: true })
+    )
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const ui = await globals.window.api.ui.recordFeatureInteraction('tasks')
+    expect(ui.osc52ClipboardDefaultOnNoticePending).toBe(true)
+  })
+
   it('does not keep a local shadow copy of main-owned feature telemetry markers', async () => {
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -529,6 +529,37 @@ describe('web settings preload API', () => {
     expect(stored.terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
   })
 
+  it('arms the OSC 52 notice in the web UI store when the flip overrides an opt-out', async () => {
+    const globals = installBrowserGlobals('Linux')
+    globals.storage.setItem(
+      'orca.web.settings.v1',
+      JSON.stringify({ terminalAllowOsc52Clipboard: false })
+    )
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await globals.window.api.settings.get()
+    const storedUi = JSON.parse(globals.storage.getItem('orca.web.ui.v1') ?? '{}') as {
+      osc52ClipboardDefaultOnNoticePending?: boolean
+    }
+
+    expect(storedUi.osc52ClipboardDefaultOnNoticePending).toBe(true)
+  })
+
+  it('does not arm the OSC 52 notice for a web profile that never opted out', async () => {
+    const globals = installBrowserGlobals('Linux')
+    globals.storage.setItem('orca.web.settings.v1', JSON.stringify({ terminalFontSize: 15 }))
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await globals.window.api.settings.get()
+    const storedUi = JSON.parse(globals.storage.getItem('orca.web.ui.v1') ?? '{}') as {
+      osc52ClipboardDefaultOnNoticePending?: boolean
+    }
+
+    expect(storedUi.osc52ClipboardDefaultOnNoticePending).not.toBe(true)
+  })
+
   it('preserves OSC 52 clipboard web opt-outs after migration', async () => {
     const globals = installBrowserGlobals('Linux')
     globals.storage.setItem(

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -529,7 +529,7 @@ describe('web settings preload API', () => {
     expect(stored.terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
   })
 
-  it('arms the OSC 52 notice in the web UI store when the flip overrides an opt-out', async () => {
+  it('arms the OSC 52 notice in the web UI store when the flip overrides a persisted off', async () => {
     const globals = installBrowserGlobals('Linux')
     globals.storage.setItem(
       'orca.web.settings.v1',
@@ -546,7 +546,7 @@ describe('web settings preload API', () => {
     expect(storedUi.osc52ClipboardDefaultOnNoticePending).toBe(true)
   })
 
-  it('does not arm the OSC 52 notice for a web profile that never opted out', async () => {
+  it('does not arm the OSC 52 notice for a web profile with no persisted value', async () => {
     const globals = installBrowserGlobals('Linux')
     globals.storage.setItem('orca.web.settings.v1', JSON.stringify({ terminalFontSize: 15 }))
     const { installWebPreloadApi } = await import('./web-preload-api')

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -79,7 +79,7 @@ import { normalizeAutoRenameBranchFromWorkDefaultOn } from '../../../shared/auto
 import { normalizeTerminalCursorStyleDefault } from '../../../shared/terminal-cursor-style-settings'
 import {
   normalizeOsc52ClipboardDefaultOn,
-  osc52ClipboardDefaultOnFlipsPersistedOptOut
+  osc52ClipboardDefaultOnOverridesPersistedOff
 } from '../../../shared/osc52-clipboard-settings'
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
 import { normalizeUiLanguage } from '../../../shared/ui-language'
@@ -3372,7 +3372,7 @@ function getStoredSettings(): GlobalSettings {
       const parsed = JSON.parse(rawStoredSettings) as unknown
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         writeJson(SETTINGS_STORAGE_KEY, migratedStored)
-        if (osc52ClipboardDefaultOnFlipsPersistedOptOut(stored)) {
+        if (osc52ClipboardDefaultOnOverridesPersistedOff(stored)) {
           // Why a raw merge, not readLocalWebUIState(): that path calls back into
           // getStoredSettings(), and writing through it here would recurse.
           writeJson(UI_STORAGE_KEY, {
@@ -3590,8 +3590,11 @@ function closeWebOnboarding(base: OnboardingState): OnboardingState {
 
 function readLocalWebUIState(): PersistedUIState {
   const defaults = getDefaultUIState()
-  const stored = readJson<Partial<PersistedUIState>>(UI_STORAGE_KEY, {})
+  // Why settings first: getStoredSettings() runs the OSC 52 migration, which writes the
+  // notice arm into UI_STORAGE_KEY. Reading before it would snapshot a pre-arm state that
+  // every caller then writes back, erasing the arm the stamp can never raise again.
   const storedSettings = getStoredSettings()
+  const stored = readJson<Partial<PersistedUIState>>(UI_STORAGE_KEY, {})
   const base = {
     ...defaults,
     // Why: mirror the main-process missing-property seed from legacy card layout mode when runtime ui.get is unavailable.

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3362,6 +3362,8 @@ function getStoredSettings(): GlobalSettings {
       stored.terminalCursorStyle !== migratedStored.terminalCursorStyle ||
       stored.terminalCursorStyleDefaultedToBlock !==
         migratedStored.terminalCursorStyleDefaultedToBlock ||
+      // Kept even though the terminalCustomThemes reference compare below already forces
+      // this branch for every stored blob: no migration should rely on that accident.
       stored.terminalAllowOsc52Clipboard !== migratedStored.terminalAllowOsc52Clipboard ||
       stored.terminalAllowOsc52ClipboardDefaultedOnForAllUsers !==
         migratedStored.terminalAllowOsc52ClipboardDefaultedOnForAllUsers ||

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -77,7 +77,10 @@ import {
 } from '../../../shared/tui-agent-launch-defaults'
 import { normalizeAutoRenameBranchFromWorkDefaultOn } from '../../../shared/auto-rename-branch-from-work-settings'
 import { normalizeTerminalCursorStyleDefault } from '../../../shared/terminal-cursor-style-settings'
-import { normalizeOsc52ClipboardDefaultOn } from '../../../shared/osc52-clipboard-settings'
+import {
+  normalizeOsc52ClipboardDefaultOn,
+  osc52ClipboardDefaultOnFlipsPersistedOptOut
+} from '../../../shared/osc52-clipboard-settings'
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
 import { normalizeUiLanguage } from '../../../shared/ui-language'
 import { normalizeUsagePercentageDisplay } from '../../../shared/usage-percentage-display'
@@ -3367,6 +3370,14 @@ function getStoredSettings(): GlobalSettings {
       const parsed = JSON.parse(rawStoredSettings) as unknown
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         writeJson(SETTINGS_STORAGE_KEY, migratedStored)
+        if (osc52ClipboardDefaultOnFlipsPersistedOptOut(stored)) {
+          // Why a raw merge, not readLocalWebUIState(): that path calls back into
+          // getStoredSettings(), and writing through it here would recurse.
+          writeJson(UI_STORAGE_KEY, {
+            ...readJson<Partial<PersistedUIState>>(UI_STORAGE_KEY, {}),
+            osc52ClipboardDefaultOnNoticePending: true
+          })
+        }
       }
     } catch {
       // Keep readJson's invalid-JSON fallback non-destructive.

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -77,6 +77,7 @@ import {
 } from '../../../shared/tui-agent-launch-defaults'
 import { normalizeAutoRenameBranchFromWorkDefaultOn } from '../../../shared/auto-rename-branch-from-work-settings'
 import { normalizeTerminalCursorStyleDefault } from '../../../shared/terminal-cursor-style-settings'
+import { normalizeOsc52ClipboardDefaultOn } from '../../../shared/osc52-clipboard-settings'
 import { normalizeTerminalCustomThemes } from '../../../shared/terminal-custom-themes'
 import { normalizeUiLanguage } from '../../../shared/ui-language'
 import { normalizeUsagePercentageDisplay } from '../../../shared/usage-percentage-display'
@@ -3344,6 +3345,7 @@ function getStoredSettings(): GlobalSettings {
     ...stored,
     ...normalizeAutoRenameBranchFromWorkDefaultOn(stored),
     ...normalizeTerminalCursorStyleDefault(stored),
+    ...normalizeOsc52ClipboardDefaultOn(stored),
     terminalCustomThemes: normalizeTerminalCustomThemes(stored.terminalCustomThemes),
     uiLanguage: normalizeUiLanguage(stored.uiLanguage)
   }
@@ -3355,6 +3357,9 @@ function getStoredSettings(): GlobalSettings {
       stored.terminalCursorStyle !== migratedStored.terminalCursorStyle ||
       stored.terminalCursorStyleDefaultedToBlock !==
         migratedStored.terminalCursorStyleDefaultedToBlock ||
+      stored.terminalAllowOsc52Clipboard !== migratedStored.terminalAllowOsc52Clipboard ||
+      stored.terminalAllowOsc52ClipboardDefaultedOnForAllUsers !==
+        migratedStored.terminalAllowOsc52ClipboardDefaultedOnForAllUsers ||
       stored.terminalCustomThemes !== migratedStored.terminalCustomThemes ||
       stored.uiLanguage !== migratedStored.uiLanguage)
   ) {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2399,6 +2399,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
         const local = readLocalWebUIState()
         const next = {
           ...mergeWebUIState(local, result.ui),
+          osc52ClipboardDefaultOnNoticePending: mergeOsc52ClipboardNoticePending(local, result.ui),
           featureInteractions: mergeFeatureInteractionState(
             local.featureInteractions,
             result.ui.featureInteractions
@@ -2448,6 +2449,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
         const local = readLocalWebUIState()
         const next = {
           ...mergeWebUIState(local, result.ui),
+          osc52ClipboardDefaultOnNoticePending: mergeOsc52ClipboardNoticePending(local, result.ui),
           featureInteractions: mergeFeatureInteractionState(
             local.featureInteractions,
             result.ui.featureInteractions
@@ -3671,6 +3673,19 @@ function mergeContextualTourSeenIds(
     merged.add(id)
   }
   return [...merged]
+}
+
+/** Why OR rather than let the host win: the web client migrates its own localStorage
+ *  settings, so an arm raised here has no counterpart on the host, and the plain spread
+ *  would drop it — flipping the opt-out in silence, which is what the notice exists to stop. */
+function mergeOsc52ClipboardNoticePending(
+  current: PersistedUIState,
+  incoming: PersistedUIState
+): boolean {
+  return (
+    current.osc52ClipboardDefaultOnNoticePending === true ||
+    incoming.osc52ClipboardDefaultOnNoticePending === true
+  )
 }
 
 function mergeSettings(

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -36,6 +36,11 @@ describe('getDefaultSettings', () => {
     expect(getDefaultSettings('/tmp').terminalCursorStyleDefaultedToBlock).toBe(true)
   })
 
+  it('allows OSC 52 clipboard writes by default for new settings', () => {
+    expect(getDefaultSettings('/tmp').terminalAllowOsc52Clipboard).toBe(true)
+    expect(getDefaultSettings('/tmp').terminalAllowOsc52ClipboardDefaultedOnForAllUsers).toBe(true)
+  })
+
   it('enables separate light terminal theme by default', () => {
     expect(getDefaultSettings('/tmp').terminalUseSeparateLightTheme).toBe(true)
   })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -249,6 +249,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     terminalClipboardOnSelect: false,
     // Why: default on so Zellij/tmux/nvim copy works out of the box. Query
     // replies stay disabled and payload size is capped in the OSC 52 handler.
+    // This default only covers new profiles; existing ones persisted `false`
+    // and are flipped once by the stamp below (see persistence.ts).
     terminalAllowOsc52Clipboard: true,
     terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true,
     claudeAgentTeamsMode: 'off',

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -489,7 +489,7 @@ export function getDefaultUIState(): PersistedUIState {
     setupGuideBrowserMilestoneLegacyComplete: false,
     browserImportHintHidden: false,
     trayMinimizeNoticeShown: false,
-    // Why: new profiles were never opted out, so they have nothing to be told about.
+    // Why: fresh profiles start on the new default, so nothing was overridden to report.
     osc52ClipboardDefaultOnNoticePending: false,
     mobileEmulatorTabIntroDismissed: false,
     mobileEmulatorAgentSetupDismissed: false,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -247,8 +247,9 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // Why: default-on everywhere so it round-trips across platforms; only darwin acts on it.
     showMenuBarIcon: true,
     terminalClipboardOnSelect: false,
-    // Why: OSC 52 is a clipboard data-exfiltration vector; default off (query stays disabled separately).
-    terminalAllowOsc52Clipboard: false,
+    // Why: default on so Zellij/tmux/nvim copy works out of the box. Query
+    // replies stay disabled and payload size is capped in the OSC 52 handler.
+    terminalAllowOsc52Clipboard: true,
     claudeAgentTeamsMode: 'off',
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackRows: DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -250,7 +250,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // Why: default on so Zellij/tmux/nvim copy works out of the box. Query
     // replies stay disabled and payload size is capped in the OSC 52 handler.
     // This default only covers new profiles; existing ones persisted `false`
-    // and are flipped once by the stamp below (see persistence.ts).
+    // and are flipped once by the stamp below (shared/osc52-clipboard-settings.ts,
+    // applied by both the Electron store and the web client's localStorage store).
     terminalAllowOsc52Clipboard: true,
     terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true,
     claudeAgentTeamsMode: 'off',
@@ -488,6 +489,8 @@ export function getDefaultUIState(): PersistedUIState {
     setupGuideBrowserMilestoneLegacyComplete: false,
     browserImportHintHidden: false,
     trayMinimizeNoticeShown: false,
+    // Why: new profiles were never opted out, so they have nothing to be told about.
+    osc52ClipboardDefaultOnNoticePending: false,
     mobileEmulatorTabIntroDismissed: false,
     mobileEmulatorAgentSetupDismissed: false,
     // Why: only upgraded profiles saw the old ordering, so only they get the one-time notice.

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -250,6 +250,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // Why: default on so Zellij/tmux/nvim copy works out of the box. Query
     // replies stay disabled and payload size is capped in the OSC 52 handler.
     terminalAllowOsc52Clipboard: true,
+    terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true,
     claudeAgentTeamsMode: 'off',
     setupScriptLaunchMode: 'new-tab',
     terminalScrollbackRows: DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT,

--- a/src/shared/osc52-clipboard-settings.test.ts
+++ b/src/shared/osc52-clipboard-settings.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeOsc52ClipboardDefaultOn } from './osc52-clipboard-settings'
+
+describe('normalizeOsc52ClipboardDefaultOn', () => {
+  it('flips an unstamped profile on, because its `false` came from the old default', () => {
+    // Why: every profile saved before #10567 persisted `false`, which the settings
+    // merge then wins with — indistinguishable on disk from a deliberate opt-out.
+    expect(normalizeOsc52ClipboardDefaultOn({ terminalAllowOsc52Clipboard: false })).toEqual({
+      terminalAllowOsc52Clipboard: true,
+      terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+    })
+  })
+
+  it('leaves a stamped opt-out off', () => {
+    expect(
+      normalizeOsc52ClipboardDefaultOn({
+        terminalAllowOsc52Clipboard: false,
+        terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+      })
+    ).toEqual({
+      terminalAllowOsc52Clipboard: false,
+      terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+    })
+  })
+
+  it('defaults a fresh or absent profile on', () => {
+    for (const settings of [
+      undefined,
+      {},
+      { terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true }
+    ]) {
+      expect(normalizeOsc52ClipboardDefaultOn(settings)).toEqual({
+        terminalAllowOsc52Clipboard: true,
+        terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+      })
+    }
+  })
+
+  it('is idempotent, so a crash before the write-back cannot re-flip an opt-out', () => {
+    const once = normalizeOsc52ClipboardDefaultOn({ terminalAllowOsc52Clipboard: false })
+    expect(normalizeOsc52ClipboardDefaultOn(once)).toEqual(once)
+
+    const optedOut = normalizeOsc52ClipboardDefaultOn({
+      terminalAllowOsc52Clipboard: false,
+      terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+    })
+    expect(normalizeOsc52ClipboardDefaultOn(optedOut)).toEqual(optedOut)
+  })
+})

--- a/src/shared/osc52-clipboard-settings.test.ts
+++ b/src/shared/osc52-clipboard-settings.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   normalizeOsc52ClipboardDefaultOn,
-  osc52ClipboardDefaultOnFlipsPersistedOptOut
+  osc52ClipboardDefaultOnOverridesPersistedOff
 } from './osc52-clipboard-settings'
 
 describe('normalizeOsc52ClipboardDefaultOn', () => {
@@ -51,25 +51,25 @@ describe('normalizeOsc52ClipboardDefaultOn', () => {
   })
 })
 
-describe('osc52ClipboardDefaultOnFlipsPersistedOptOut', () => {
+describe('osc52ClipboardDefaultOnOverridesPersistedOff', () => {
   it('is true only when the migration overrides a persisted off', () => {
     expect(
-      osc52ClipboardDefaultOnFlipsPersistedOptOut({ terminalAllowOsc52Clipboard: false })
+      osc52ClipboardDefaultOnOverridesPersistedOff({ terminalAllowOsc52Clipboard: false })
     ).toBe(true)
   })
 
-  it('is false for a fresh profile, which was never opted out', () => {
+  it('is false for a fresh profile, which has no persisted value to override', () => {
     // Why: a notice here would nag every new install about a setting they never touched.
-    expect(osc52ClipboardDefaultOnFlipsPersistedOptOut(undefined)).toBe(false)
-    expect(osc52ClipboardDefaultOnFlipsPersistedOptOut({})).toBe(false)
-    expect(osc52ClipboardDefaultOnFlipsPersistedOptOut({ terminalAllowOsc52Clipboard: true })).toBe(
-      false
-    )
+    expect(osc52ClipboardDefaultOnOverridesPersistedOff(undefined)).toBe(false)
+    expect(osc52ClipboardDefaultOnOverridesPersistedOff({})).toBe(false)
+    expect(
+      osc52ClipboardDefaultOnOverridesPersistedOff({ terminalAllowOsc52Clipboard: true })
+    ).toBe(false)
   })
 
-  it('is false once stamped, because that opt-out is honored rather than overridden', () => {
+  it('is false once stamped, because a stamped value is honored rather than overridden', () => {
     expect(
-      osc52ClipboardDefaultOnFlipsPersistedOptOut({
+      osc52ClipboardDefaultOnOverridesPersistedOff({
         terminalAllowOsc52Clipboard: false,
         terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
       })

--- a/src/shared/osc52-clipboard-settings.test.ts
+++ b/src/shared/osc52-clipboard-settings.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { normalizeOsc52ClipboardDefaultOn } from './osc52-clipboard-settings'
+import {
+  normalizeOsc52ClipboardDefaultOn,
+  osc52ClipboardDefaultOnFlipsPersistedOptOut
+} from './osc52-clipboard-settings'
 
 describe('normalizeOsc52ClipboardDefaultOn', () => {
   it('flips an unstamped profile on, because its `false` came from the old default', () => {
@@ -45,5 +48,31 @@ describe('normalizeOsc52ClipboardDefaultOn', () => {
       terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
     })
     expect(normalizeOsc52ClipboardDefaultOn(optedOut)).toEqual(optedOut)
+  })
+})
+
+describe('osc52ClipboardDefaultOnFlipsPersistedOptOut', () => {
+  it('is true only when the migration overrides a persisted off', () => {
+    expect(
+      osc52ClipboardDefaultOnFlipsPersistedOptOut({ terminalAllowOsc52Clipboard: false })
+    ).toBe(true)
+  })
+
+  it('is false for a fresh profile, which was never opted out', () => {
+    // Why: a notice here would nag every new install about a setting they never touched.
+    expect(osc52ClipboardDefaultOnFlipsPersistedOptOut(undefined)).toBe(false)
+    expect(osc52ClipboardDefaultOnFlipsPersistedOptOut({})).toBe(false)
+    expect(osc52ClipboardDefaultOnFlipsPersistedOptOut({ terminalAllowOsc52Clipboard: true })).toBe(
+      false
+    )
+  })
+
+  it('is false once stamped, because that opt-out is honored rather than overridden', () => {
+    expect(
+      osc52ClipboardDefaultOnFlipsPersistedOptOut({
+        terminalAllowOsc52Clipboard: false,
+        terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+      })
+    ).toBe(false)
   })
 })

--- a/src/shared/osc52-clipboard-settings.ts
+++ b/src/shared/osc52-clipboard-settings.ts
@@ -19,3 +19,15 @@ export function normalizeOsc52ClipboardDefaultOn(
     terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
   }
 }
+
+/** True when the migration is about to turn OSC 52 on over a persisted `false`.
+ *  Why surface it: that `false` may have been a deliberate opt-out, and flipping a
+ *  security posture back on without telling anyone is worse than the copy bug. */
+export function osc52ClipboardDefaultOnFlipsPersistedOptOut(
+  settings: Partial<Osc52ClipboardSettings> | undefined
+): boolean {
+  return (
+    settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers !== true &&
+    settings?.terminalAllowOsc52Clipboard === false
+  )
+}

--- a/src/shared/osc52-clipboard-settings.ts
+++ b/src/shared/osc52-clipboard-settings.ts
@@ -1,0 +1,21 @@
+import type { GlobalSettings } from './types'
+
+type Osc52ClipboardSettings = Pick<
+  GlobalSettings,
+  'terminalAllowOsc52Clipboard' | 'terminalAllowOsc52ClipboardDefaultedOnForAllUsers'
+>
+
+export function normalizeOsc52ClipboardDefaultOn(
+  settings: Partial<Osc52ClipboardSettings> | undefined
+): Osc52ClipboardSettings {
+  const defaultedOn = settings?.terminalAllowOsc52ClipboardDefaultedOnForAllUsers === true
+
+  return {
+    // Why: profiles saved under the old off default persisted `false`, which is
+    // indistinguishable from a real opt-out; only stamped profiles can express one.
+    terminalAllowOsc52Clipboard: defaultedOn
+      ? (settings?.terminalAllowOsc52Clipboard ?? true)
+      : true,
+    terminalAllowOsc52ClipboardDefaultedOnForAllUsers: true
+  }
+}

--- a/src/shared/osc52-clipboard-settings.ts
+++ b/src/shared/osc52-clipboard-settings.ts
@@ -21,9 +21,13 @@ export function normalizeOsc52ClipboardDefaultOn(
 }
 
 /** True when the migration is about to turn OSC 52 on over a persisted `false`.
- *  Why surface it: that `false` may have been a deliberate opt-out, and flipping a
- *  security posture back on without telling anyone is worse than the copy bug. */
-export function osc52ClipboardDefaultOnFlipsPersistedOptOut(
+ *  Why surface it: flipping a security posture back on without telling anyone is worse
+ *  than the copy bug. Scope is deliberately wide — both stores rewrite the whole settings
+ *  object on every save, so every profile saved under the old off default holds `false`,
+ *  opt-out or not. This is an upgrade notice, not an opt-out notice; the cohort that
+ *  genuinely chose `false` is not distinguishable on disk. Fresh profiles have no
+ *  persisted value and are correctly excluded. */
+export function osc52ClipboardDefaultOnOverridesPersistedOff(
   settings: Partial<Osc52ClipboardSettings> | undefined
 ): boolean {
   return (

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2727,8 +2727,10 @@ export type GlobalSettings = {
   terminalFocusFollowsMouse: boolean
   /** X11/gnome-terminal "copy on select": selecting text auto-copies to the clipboard; default off. */
   terminalClipboardOnSelect: boolean
-  /** Enables OSC 52 clipboard writes for TUIs (SSH clipboard bridge); default off since OSC 52 is a clipboard-exfiltration vector. */
+  /** Enables OSC 52 clipboard writes for TUIs (tmux/Zellij/nvim, incl. over SSH); default on. Clipboard *queries* stay blocked and payload size is capped, so this is write-only exposure. */
   terminalAllowOsc52Clipboard: boolean
+  /** One-shot stamp: profiles saved under the old off default get flipped on once, after which an explicit opt-out sticks. */
+  terminalAllowOsc52ClipboardDefaultedOnForAllUsers?: boolean
   /** Experimental Claude Agent Teams; native panes use a tmux-compatible shim so teammate output stays on the normal PTY path. */
   claudeAgentTeamsMode?: ClaudeAgentTeamsMode
   /** Where the repo setup script runs on workspace create; defaults to a background "Setup" tab to keep the main terminal usable. */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3303,6 +3303,8 @@ export type PersistedUIState = {
   browserImportHintHidden?: boolean
   /** Why: Windows-only. Set once on first hide to tray so the "Orca is still running" notice shows only once. */
   trayMinimizeNoticeShown?: boolean
+  /** Set by the OSC 52 default-on migration when it overrode a persisted `false`; the renderer shows one notice and clears it. */
+  osc52ClipboardDefaultOnNoticePending?: boolean
   /** User dismissed the first-run Mobile Emulator intro; reversible only by re-enabling the feature in Settings. */
   mobileEmulatorTabIntroDismissed?: boolean
   /** User deferred the in-pane Mobile Emulator CLI + skill setup guide. */


### PR DESCRIPTION
## Summary

- Inside Zellij (and similar multiplexers), copy goes through **OSC 52** to the host terminal. Orca had OSC 52 **default off**, so Zellij copy failed while bare-shell copy still worked (#10567).
- Empty `Pc` (`\e]52;;base64`) is a valid XTerm default meaning clipboard; we previously rejected it as invalid.
- Default `terminalAllowOsc52Clipboard` to **on** for new installs (clipboard **query** remains disabled; payload size still capped).
- Mention Zellij in Terminal settings + blocked-toast copy so users who turned the gate off can find it.

## Test plan

- [x] `vitest` — `osc52-clipboard`, blocked toast, terminal-search (58 tests)
- [ ] With OSC 52 on: copy selection in Zellij lands on the macOS clipboard
- [ ] With OSC 52 off: blocked toast points at Terminal → Allow TUI Clipboard Writes
- [ ] Empty-Pc OSC 52 write is accepted as clipboard

Closes #10567