### PR TITLE
fix: ignore a node_modules symlink, not just a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ src/**/*.d.ts
 !src/types/build-constants.d.ts
 
 # Dependencies
-node_modules/
+node_modules
 
 # Build output
 dist/

--- a/config/scripts/gitignore-node-modules-symlink.test.ts
+++ b/config/scripts/gitignore-node-modules-symlink.test.ts
@@ -1,0 +1,88 @@
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, rm, symlink, writeFile, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repoGitignorePath = path.resolve('.gitignore')
+const tempRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+// Why: asserting on the shipped .gitignore requires a throwaway repo; the real one already
+// tracks nothing named node_modules, so there is no in-place way to observe the rule.
+async function createRepoUsingShippedGitignore(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'orca-gitignore-node-modules-'))
+  tempRoots.push(root)
+  const repo = path.join(root, 'repo')
+  await mkdir(repo)
+  execFileSync('git', ['init', '-q'], { cwd: repo })
+  // Why: a developer's global excludes or the init template would otherwise decide the
+  // outcome, hiding whether the shipped pattern is the thing doing the ignoring.
+  execFileSync('git', ['config', 'core.excludesFile', ''], { cwd: repo })
+  await writeFile(path.join(repo, '.git', 'info', 'exclude'), '')
+  await writeFile(path.join(repo, '.gitignore'), await readFile(repoGitignorePath, 'utf8'))
+  return repo
+}
+
+function isIgnored(repo: string, relativePath: string): boolean {
+  try {
+    execFileSync('git', ['check-ignore', '-q', '--', relativePath], { cwd: repo })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Why: creating a symlink on Windows needs Developer Mode or elevation, but WSL and
+// dev-container checkouts of this repo hit the shared-install layout that this guards.
+describe.skipIf(process.platform === 'win32')('shipped .gitignore node_modules coverage', () => {
+  it('ignores a node_modules symlink pointing at a shared install', async () => {
+    const repo = await createRepoUsingShippedGitignore()
+    const sharedInstall = path.join(repo, '..', 'shared-install')
+    await mkdir(sharedInstall)
+    await symlink(sharedInstall, path.join(repo, 'node_modules'), 'dir')
+
+    expect(isIgnored(repo, 'node_modules')).toBe(true)
+  })
+
+  it('keeps a node_modules symlink out of git add -A', async () => {
+    const repo = await createRepoUsingShippedGitignore()
+    const sharedInstall = path.join(repo, '..', 'shared-install')
+    await mkdir(sharedInstall)
+    await symlink(sharedInstall, path.join(repo, 'node_modules'), 'dir')
+
+    execFileSync('git', ['add', '-A'], { cwd: repo })
+    const staged = execFileSync('git', ['diff', '--cached', '--name-only'], {
+      cwd: repo,
+      encoding: 'utf8'
+    })
+
+    // Why: staging the link commits mode 120000 whose blob is an absolute local path.
+    expect(staged.split('\n').filter(Boolean)).not.toContain('node_modules')
+  })
+
+  it('still ignores a real node_modules directory at the root and nested', async () => {
+    const repo = await createRepoUsingShippedGitignore()
+    await mkdir(path.join(repo, 'node_modules'))
+    await mkdir(path.join(repo, 'packages', 'app', 'node_modules'), { recursive: true })
+
+    expect(isIgnored(repo, 'node_modules')).toBe(true)
+    expect(isIgnored(repo, 'packages/app/node_modules')).toBe(true)
+  })
+
+  // Why: paths under docs/ cannot be used as fixtures here — `docs/**` is ignored
+  // wholesale by an unrelated rule, which would mask what this case is checking.
+  it('does not ignore sources whose name merely contains node_modules', async () => {
+    const repo = await createRepoUsingShippedGitignore()
+    await mkdir(path.join(repo, 'packages', 'app'), { recursive: true })
+    await writeFile(path.join(repo, 'packages', 'app', 'node_modules.md'), '')
+    await mkdir(path.join(repo, 'node_modules_cache'))
+    await writeFile(path.join(repo, 'node_modules_cache', 'entry.txt'), '')
+
+    expect(isIgnored(repo, 'packages/app/node_modules.md')).toBe(false)
+    expect(isIgnored(repo, 'node_modules_cache/entry.txt')).toBe(false)
+  })
+})

--- a/config/scripts/gitignore-node-modules-symlink.test.ts
+++ b/config/scripts/gitignore-node-modules-symlink.test.ts
@@ -47,8 +47,13 @@ function isIgnored(repo: string, relativePath: string): boolean {
   try {
     git(repo, ['check-ignore', '-q', '--', relativePath])
     return true
-  } catch {
-    return false
+  } catch (error) {
+    // Why: check-ignore exits 1 for a real non-match; other statuses mean a broken
+    // command/repo and must not be reported as "not ignored".
+    if (error !== null && typeof error === 'object' && 'status' in error && error.status === 1) {
+      return false
+    }
+    throw error
   }
 }
 

--- a/config/scripts/gitignore-node-modules-symlink.test.ts
+++ b/config/scripts/gitignore-node-modules-symlink.test.ts
@@ -11,6 +11,22 @@ afterEach(async () => {
   await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
+// Why: command-scope GIT_CONFIG_* can inject excludes that make the suite pass even
+// against main, silently stopping it from detecting the regression under test.
+function gitEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env }
+  for (const key of Object.keys(env)) {
+    if (key.startsWith('GIT_CONFIG')) {
+      delete env[key]
+    }
+  }
+  return env
+}
+
+function git(repo: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf8', env: gitEnv() })
+}
+
 // Why: asserting on the shipped .gitignore requires a throwaway repo; the real one already
 // tracks nothing named node_modules, so there is no in-place way to observe the rule.
 async function createRepoUsingShippedGitignore(): Promise<string> {
@@ -18,10 +34,10 @@ async function createRepoUsingShippedGitignore(): Promise<string> {
   tempRoots.push(root)
   const repo = path.join(root, 'repo')
   await mkdir(repo)
-  execFileSync('git', ['init', '-q'], { cwd: repo })
+  git(repo, ['init', '-q'])
   // Why: a developer's global excludes or the init template would otherwise decide the
   // outcome, hiding whether the shipped pattern is the thing doing the ignoring.
-  execFileSync('git', ['config', 'core.excludesFile', ''], { cwd: repo })
+  git(repo, ['config', 'core.excludesFile', ''])
   await writeFile(path.join(repo, '.git', 'info', 'exclude'), '')
   await writeFile(path.join(repo, '.gitignore'), await readFile(repoGitignorePath, 'utf8'))
   return repo
@@ -29,40 +45,43 @@ async function createRepoUsingShippedGitignore(): Promise<string> {
 
 function isIgnored(repo: string, relativePath: string): boolean {
   try {
-    execFileSync('git', ['check-ignore', '-q', '--', relativePath], { cwd: repo })
+    git(repo, ['check-ignore', '-q', '--', relativePath])
     return true
   } catch {
     return false
   }
 }
 
-// Why: creating a symlink on Windows needs Developer Mode or elevation, but WSL and
-// dev-container checkouts of this repo hit the shared-install layout that this guards.
-describe.skipIf(process.platform === 'win32')('shipped .gitignore node_modules coverage', () => {
-  it('ignores a node_modules symlink pointing at a shared install', async () => {
-    const repo = await createRepoUsingShippedGitignore()
-    const sharedInstall = path.join(repo, '..', 'shared-install')
-    await mkdir(sharedInstall)
-    await symlink(sharedInstall, path.join(repo, 'node_modules'), 'dir')
+describe('shipped .gitignore node_modules coverage', () => {
+  // Why: creating a symlink on Windows needs Developer Mode or elevation, but WSL and
+  // dev-container checkouts of this repo hit the shared-install layout that this guards.
+  it.skipIf(process.platform === 'win32')(
+    'ignores a node_modules symlink pointing at a shared install',
+    async () => {
+      const repo = await createRepoUsingShippedGitignore()
+      const sharedInstall = path.join(repo, '..', 'shared-install')
+      await mkdir(sharedInstall)
+      await symlink(sharedInstall, path.join(repo, 'node_modules'), 'dir')
 
-    expect(isIgnored(repo, 'node_modules')).toBe(true)
-  })
+      expect(isIgnored(repo, 'node_modules')).toBe(true)
+    }
+  )
 
-  it('keeps a node_modules symlink out of git add -A', async () => {
-    const repo = await createRepoUsingShippedGitignore()
-    const sharedInstall = path.join(repo, '..', 'shared-install')
-    await mkdir(sharedInstall)
-    await symlink(sharedInstall, path.join(repo, 'node_modules'), 'dir')
+  it.skipIf(process.platform === 'win32')(
+    'keeps a node_modules symlink out of git add -A',
+    async () => {
+      const repo = await createRepoUsingShippedGitignore()
+      const sharedInstall = path.join(repo, '..', 'shared-install')
+      await mkdir(sharedInstall)
+      await symlink(sharedInstall, path.join(repo, 'node_modules'), 'dir')
 
-    execFileSync('git', ['add', '-A'], { cwd: repo })
-    const staged = execFileSync('git', ['diff', '--cached', '--name-only'], {
-      cwd: repo,
-      encoding: 'utf8'
-    })
+      git(repo, ['add', '-A'])
+      const staged = git(repo, ['diff', '--cached', '--name-only'])
 
-    // Why: staging the link commits mode 120000 whose blob is an absolute local path.
-    expect(staged.split('\n').filter(Boolean)).not.toContain('node_modules')
-  })
+      // Why: staging the link commits mode 120000 whose blob is an absolute local path.
+      expect(staged.split('\n').filter(Boolean)).not.toContain('node_modules')
+    }
+  )
 
   it('still ignores a real node_modules directory at the root and nested', async () => {
     const repo = await createRepoUsingShippedGitignore()


### PR DESCRIPTION
## Summary

`.gitignore` line 19 is `node_modules/`. The trailing slash makes Git match the pattern against **directories only**, so a *symlink* named `node_modules` is not ignored — it is a blob, not a directory.

That is not a hypothetical shape. Sharing one install across several worktrees by symlinking `node_modules` is a normal thing to do in an Orca worktree setup, and when you do it `git add -A` silently stages the link:

```
$ ls -l node_modules
lrwxr-xr-x  node_modules -> /Users/me/orca/workspaces/orca/other-tree/node_modules

$ git add -A && git diff --cached --stat
 node_modules | 1 +
```

The committed blob is the symlink's absolute target, so it also leaks a local filesystem path into the repo. Anyone who checks the branch out gets a dangling `node_modules` symlink pointing at a directory that does not exist on their machine, which breaks the install before it starts.

Dropping the trailing slash makes the pattern cover a directory, a file, or a symlink of that name. Later docs allowlist rules (`!docs/assets/**`, `!docs/readme/**`) can still re-include exact-name `node_modules` under those trees — same as before for symlinks, not a regression — but elsewhere the unslashed pattern applies at any depth.

## ELI5

Git was told to ignore the *folder* called `node_modules`. But some people don't keep a real folder there — they keep a shortcut that points at one shared copy elsewhere on their machine, to avoid downloading the same thing five times. Git doesn't count a shortcut as a folder, so it never ignored it, and the shortcut got committed by accident. Worse, what actually got saved was the literal path on that person's computer, like `/Users/alice/…`. Anyone else who downloaded the branch got a shortcut pointing at a folder that doesn't exist on their machine. Removing one `/` tells Git to ignore anything by that name, shortcut included.

## Proof of fix

The original PR had no test; one is added here. `config/scripts/gitignore-node-modules-symlink.test.ts` copies the **shipped** `.gitignore` into a throwaway repo — with global excludes, `.git/info/exclude`, and command-scope `GIT_CONFIG_*` neutralized, so the shipped pattern is provably the thing doing the ignoring rather than the developer's environment — and exercises it with real `git`.

With `.gitignore` reverted to `origin/main` (`node_modules/`), the two symlink cases fail and the two control cases already pass:

```
$ git checkout origin/main -- .gitignore && grep -n '^node_modules' .gitignore
19:node_modules/

$ npx vitest run --config config/vitest.config.ts config/scripts/gitignore-node-modules-symlink.test.ts

 FAIL  shipped .gitignore node_modules coverage > ignores a node_modules symlink pointing at a shared install
AssertionError: expected false to be true // Object.is equality
 ❯ config/scripts/gitignore-node-modules-symlink.test.ts:48:45

 FAIL  shipped .gitignore node_modules coverage > keeps a node_modules symlink out of git add -A
AssertionError: expected [ '.gitignore', 'node_modules' ] to not include 'node_modules'
 ❯ config/scripts/gitignore-node-modules-symlink.test.ts:64:52

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

With this PR's `.gitignore` (`node_modules`):

```
$ git checkout HEAD -- .gitignore && grep -n '^node_modules' .gitignore
19:node_modules

$ npx vitest run --config config/vitest.config.ts config/scripts/gitignore-node-modules-symlink.test.ts

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The path leak is real, not theoretical — the staged entry is mode `120000` whose blob content is an absolute local path:

```
$ ln -s /tmp/shared_nm node_modules && printf 'node_modules/\n' > .gitignore
$ git add -A && git commit -qm init
$ git ls-tree HEAD node_modules
120000 blob 55224bcb506ba714f80c2f021e43aa3c3eb8637e	node_modules
$ git cat-file -p $(git rev-parse HEAD:node_modules)
/tmp/shared_nm
```

## Proof of no regressions

```
$ pnpm lint                                          # exit 0
max-lines ratchet OK — 354 grandfathered suppression(s), no new bypasses.
Verified 10336 localization key references against en.json.
Localization coverage check passed with 6 allowlisted candidates.

$ pnpm typecheck                                     # exit 0

$ npx vitest run --config config/vitest.config.ts config/scripts/
 Test Files  54 passed (54)
      Tests  426 passed | 4 skipped (430)

$ npx vitest run --config config/vitest.config.ts \
    src/main/git/check-ignored-paths.test.ts \
    src/main/git/huge-folder-ignore.test.ts \
    src/main/git/status-discard-symlink.test.ts
 Test Files  3 passed (3)
      Tests  19 passed (19)

$ npx oxfmt --check config/scripts/gitignore-node-modules-symlink.test.ts
All matched files use the correct format.
```

Full behavior matrix across both patterns, so the exact scope of the change is explicit:

| path | `node_modules/` (before) | `node_modules` (after) |
| --- | --- | --- |
| `node_modules` (real dir) | ignored | ignored |
| `foo/node_modules` (nested dir) | ignored | ignored |
| `node_modules` (symlink) | **not ignored** | **ignored** ← the fix |
| `foo/node_modules` (file) | **not ignored** | **ignored** ← intended |
| `packages/app/node_modules.md` | not ignored | not ignored |
| `src/node_modules_extra.ts` | not ignored | not ignored |
| `node_modules_cache/a.txt` | not ignored | not ignored |
| `my_node_modules/a.txt` | not ignored | not ignored |

Only two rows change, both intended. Specifically checked:

- **Nothing tracked is newly ignored.** `git ls-tree -r --name-only origin/main | grep -E '(^|/)node_modules($|/)'` is empty. Ignore rules never apply to already-tracked files anyway — verified directly: a tracked file named `node_modules` stays in `git ls-files` and still reports `M` after the pattern switch.
- **Negation under docs allowlists.** Later `!docs/assets/**` and `!docs/readme/**` re-include exact-name `node_modules` under those trees (`git check-ignore -v docs/assets/node_modules` shows the allowlist winning, and `git add -n` will stage one). That is **not a regression** — the old directory-only pattern did not ignore symlinks there either — but it means the rule is not absolute at every depth under `docs/`. Other `!` patterns (`src/**/*.d.ts`) do not interact with this entry.
- **Directory pruning is preserved.** Git still refuses to descend into an ignored `node_modules/`; `git status` reports the parent, not thousands of children.
- **No tooling depends on the slash.** The file explorer's ignore logic delegates to `git check-ignore` (`getRuntimeGitIgnoredPaths` → `git.checkIgnored`), so it inherits the fix rather than parsing patterns itself. `electron-builder` matches `node_modules/**` from its own config, not from `.gitignore`. The e2e fixtures write their own `.gitignore`. Nested-repo discovery *does* custom-parse project `.gitignore` files (local and SSH/remote) via `parseGitignoreRules` in `src/main/project-groups/nested-repo-discovery.ts`, but that parser strips trailing slashes (`.replace(/\/+$/, '')`), so `node_modules/` and `node_modules` are already equivalent to it — this one-character change causes **no** parser/Git divergence.

No user-visible behavior changes beyond the fix: this is repo hygiene. The built app does not depend on the trailing slash for correct behavior (see nested-repo parser note above).

## Compatibility

- **Platforms:** Ignore-pattern matching is done by Git itself and is identical on macOS, Linux, and Windows; no code, path handling, shortcut/label logic, or Electron platform difference is touched. Verified on macOS with Git 2.44.0. The trailing-slash rule is long-standing `gitignore(5)` behavior, well below the repo's Git 2.25 baseline, so no capability probe or fallback is needed. The failure mode is *not* uniform, though: creating a symlink on Windows needs Developer Mode or elevation, so this mostly bites macOS, Linux, WSL, and dev-container contributors. The fix is still correct everywhere and costs Windows nothing. Only the two symlink specs use `it.skipIf(process.platform === 'win32')` for that reason (same convention as `codex-primary-home-tripwire.test.ts`); the real-directory and near-match cases still run on Windows.
- **SSH / remote:** `.gitignore` governs the developer's own checkout of this repo. Nested-repo discovery on SSH/remote hosts also parses project `.gitignore` files, but as noted above the trailing-slash strip means this change is a no-op for that parser.
- **Performance:** No hot-path change. `git status` timings on this repo are unchanged (0.06–0.18s before and after, run-to-run noise); directory pruning still applies, so Git does not start descending into `node_modules`.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

`pnpm lint` and `pnpm typecheck` were run in full and both exit 0 (output under **Proof of no regressions**).

`pnpm test` and `pnpm build` were **not** run, so they are left unticked rather than assumed green. In place of the full suite, the tests covering the touched area were run: all 54 files in `config/scripts/` (426 passed, 4 skipped) plus the three git ignore/symlink suites (19 passed). No source file is changed, so there is no build input to break — the diff is one `.gitignore` line and one new test file.

## AI Review Report

Reviewed with Claude Code, then re-reviewed adversarially as maintainer. What it checked:

- **Pattern semantics.** Confirmed against `gitignore(5)` that a trailing `/` restricts a pattern to directories, and that the unslashed form matches a file, directory, or symlink — verified empirically with real `git`, not from the docs alone. Docs allowlist exceptions are called out above.
- **Over-matching.** Built the full before/after matrix above, including near-miss names (`node_modules.md`, `node_modules_extra.ts`, `node_modules_cache/`, `my_node_modules/`). Exactly two rows change, both intended. Nothing tracked is named `node_modules`.
- **Cross-platform (macOS, Linux, Windows).** Explicitly checked, including shortcuts, labels, paths, shell behavior, and Electron platform differences: none are touched, because the change contains no code. See **Compatibility** for the one platform-specific wrinkle (symlink creation on Windows) and how the new test handles it.
- **Blast radius.** One ignore line, no code, no build input, no runtime behavior change for the app's gitignore parser.

Defects found and fixed as a result:

- **The PR shipped with no test.** Added one that fails on `main` and passes with the fix. This is the substantive change from the original patch.
- **A bug in that new test.** The first draft asserted `docs/node_modules.md` stays unignored; it failed because `docs/**` is ignored wholesale by an unrelated rule, which would have masked what the case was checking. The fixture moved to `packages/app/`, with a comment so it is not reintroduced.
- **PR body overstatements (review feedback).** Corrected the "no negation interaction" / "at any depth" claims (docs allowlists re-include exact-name `node_modules`), and the "built app does not read this file" claim (`parseGitignoreRules` does — but strips trailing slashes, so no divergence). Hardened the test against command-scope `GIT_CONFIG_*` and narrowed Windows skip to the two symlink specs only.

## Security Audit

The bug is itself a minor information-disclosure issue: the committed blob is an absolute path from the contributor's machine (`/Users/<name>/…`), which discloses a local username and directory layout to anyone reading the repo. This PR removes the mechanism that lets that happen by accident. The disclosure was confirmed concretely — the object is mode `120000` and `git cat-file` prints the local path (transcript under **Proof of fix**).

There is a second, sharper reason this pattern is worth getting right: `node_modules` is a code-execution surface, not inert data. Node resolves and runs whatever the link points at, verified directly:

```
$ ln -s /tmp/nmexec/elsewhere proj/node_modules
$ cd proj && node -e "require('evil'); console.log(require.resolve('evil'))"
  >>> CODE FROM THE SYMLINK TARGET EXECUTED <<<
/private/tmp/nmexec/elsewhere/evil/index.js
```

So a committed `node_modules` symlink is a committed instruction about where a checkout should load code from — and on the author's machine it silently keeps resolving to their real install, which is exactly why the mistake survives local testing. Git does not follow the link for anyone else, so a fresh checkout gets a dangling link and fails loudly at install time rather than executing anything unexpected. That makes this a robustness and hygiene fix rather than a live vulnerability, but it is the reason the pattern should not have been directory-only.

No input handling, command execution, runtime path handling, auth, secrets, dependency, or IPC surface is otherwise involved. The added file is a test and ships in no bundle. No follow-up security work needed.

## Notes

Two things deliberately left out of this PR:

1. Repos that already committed the symlink are not fixed by this change — ignore rules do not untrack anything. Those need `git rm --cached node_modules` once, after which this pattern keeps it from coming back.
2. `mobile/.gitignore` still has `node_modules/`, but it is now redundant: the root pattern is depth-independent and already covers `mobile/node_modules` (verified with `git check-ignore`). Harmless, so not touched here.

Related, and worth a separate issue rather than widening this PR: `appendFolderToGitignore` in `src/main/git/huge-folder-ignore.ts` writes `` `${safeFolderName}/` `` while `findKnownHugeFolderPathsToIgnore` detects candidates with `stat()`, which follows symlinks. So Orca's own "ignore this huge folder" action reports success on a `node_modules` symlink but does not actually ignore it, and re-offers the folder forever. That bug predates this PR and is not fixed by it. It also is not a one-line slash removal — the same function handles `dist`, `build`, `target`, and `vendor`, and dropping the slash there would newly ignore *files* by those names (e.g. a `./build` script), so it needs its own analysis.

Follow-up on the same theme: several other patterns in this file are directory-only for the same reason (`dist/`, `out/`, `release/`, `.pnpm-store/`). `node_modules` is the one with a demonstrated real-world failure, so it is fixed alone here rather than widening this into a sweep.

Original patch by @MumuTW.
