### PR TITLE
fix(ui): surface RC/perf update channel modifiers visibly

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1009,10 +1009,10 @@ function getSystemTrayOptions(): SystemTrayOptions | null {
     devInstanceLabel: devInstanceIdentity.devLabel,
     onOpen: showMainWindowFromTray,
     onOpenSettings: openSettingsFromSystemMenu,
-    onCheckForUpdates: () => {
+    onCheckForUpdates: (options) => {
       // Why: updater status renders in the main window, so a bare check would complete invisibly.
       showMainWindowFromTray()
-      runUserInitiatedUpdateCheck()
+      runUserInitiatedUpdateCheck(options)
     },
     onQuit: quitFromSystemTray
   }

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -107,8 +107,13 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     })
   }
 
+  // Why: native menus cannot show tooltips; append RC/perf modifiers so the
+  // power-user channels are discoverable from the app/Help menu (#10590).
+  const checkForUpdatesChannelHint = isMac
+    ? translateMain('menu.checkForUpdatesChannelsMac', '⇧ RC · ⌘ Perf')
+    : translateMain('menu.checkForUpdatesChannels', 'Shift RC · Ctrl Perf')
   const checkForUpdatesItem: Electron.MenuItemConstructorOptions = {
-    label: translateMain('menu.checkForUpdates', 'Check for Updates...'),
+    label: `${translateMain('menu.checkForUpdates', 'Check for Updates...')} (${checkForUpdatesChannelHint})`,
     click: checkForUpdatesClick
   }
 

--- a/src/main/tray/system-tray.test.ts
+++ b/src/main/tray/system-tray.test.ts
@@ -111,7 +111,15 @@ vi.mock('./tray-dev-badge', () => ({
 }))
 
 type TrayModule = typeof SystemTrayModule
-type MenuItem = { label?: string; type?: string; click?: () => void }
+type MenuItem = {
+  label?: string
+  type?: string
+  click?: (
+    menuItem?: unknown,
+    browserWindow?: unknown,
+    event?: Partial<Electron.KeyboardEvent>
+  ) => void
+}
 
 const originalPlatform = process.platform
 
@@ -231,7 +239,7 @@ describe('createSystemTray', () => {
       'Open Orca',
       undefined,
       'Settings',
-      'Check for Updates...',
+      'Check for Updates... (⇧ RC · ⌘ Perf)',
       undefined,
       'Quit'
     ])
@@ -241,7 +249,6 @@ describe('createSystemTray', () => {
     for (const [label, callback] of [
       ['Open Orca', options.onOpen],
       ['Settings', options.onOpenSettings],
-      ['Check for Updates...', options.onCheckForUpdates],
       ['Quit', options.onQuit]
     ] as const) {
       builtMenuItems()
@@ -249,6 +256,44 @@ describe('createSystemTray', () => {
         ?.click?.()
       expect(callback).toHaveBeenCalledOnce()
     }
+
+    const checkForUpdates = builtMenuItems().find((item) =>
+      item.label?.startsWith('Check for Updates...')
+    )
+    checkForUpdates?.click?.()
+    expect(options.onCheckForUpdates).toHaveBeenCalledOnce()
+    expect(options.onCheckForUpdates).toHaveBeenCalledWith({
+      includePrerelease: false,
+      includePerfPrerelease: false
+    })
+  })
+
+  it('routes Check for Updates modifier clicks to prerelease and perf checks', async () => {
+    setPlatform('darwin')
+    const { createSystemTray } = await loadModule()
+    const options = createOptions()
+    createSystemTray(options)
+
+    const item = builtMenuItems().find((entry) => entry.label?.startsWith('Check for Updates...'))
+    item?.click?.({}, undefined, { shiftKey: true })
+    item?.click?.({}, undefined, {})
+    item?.click?.({}, undefined, { shiftKey: true, metaKey: true })
+    item?.click?.({}, undefined, { metaKey: true })
+    item?.click?.({}, undefined, { ctrlKey: true })
+    item?.click?.({}, undefined, {
+      triggeredByAccelerator: true,
+      shiftKey: true,
+      metaKey: true
+    })
+
+    expect(options.onCheckForUpdates.mock.calls).toEqual([
+      [{ includePrerelease: true, includePerfPrerelease: false }],
+      [{ includePrerelease: false, includePerfPrerelease: false }],
+      [{ includePrerelease: true, includePerfPrerelease: true }],
+      [{ includePrerelease: false, includePerfPrerelease: true }],
+      [{ includePrerelease: false, includePerfPrerelease: false }],
+      [{ includePrerelease: false, includePerfPrerelease: false }]
+    ])
   })
 
   it('does not create a blank macOS item when the template asset fails to load', async () => {

--- a/src/main/tray/system-tray.ts
+++ b/src/main/tray/system-tray.ts
@@ -273,7 +273,13 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
             click: safeMenuAction(() => opts.onOpenSettings())
           },
           {
-            label: translateMain('menu.checkForUpdates', 'Check for Updates...'),
+            // Why: tray menus cannot show tooltips; surface RC/perf modifiers
+            // in the label so channels stay discoverable (#10590).
+            label: `${translateMain('menu.checkForUpdates', 'Check for Updates...')} (${
+              process.platform === 'darwin'
+                ? translateMain('menu.checkForUpdatesChannelsMac', '⇧ RC · ⌘ Perf')
+                : translateMain('menu.checkForUpdatesChannels', 'Shift RC · Ctrl Perf')
+            })`,
             click: safeMenuAction(() => opts.onCheckForUpdates())
           },
           { type: 'separator' }

--- a/src/main/tray/system-tray.ts
+++ b/src/main/tray/system-tray.ts
@@ -1,6 +1,7 @@
 import { Menu, Tray, nativeImage, nativeTheme, type NativeImage } from 'electron'
 import menuBarIconPath from '../../../resources/tray/orca-menu-barTemplate.png?asset&asarUnpack'
 import menuBarIconRetinaPath from '../../../resources/tray/orca-menu-barTemplate@2x.png?asset&asarUnpack'
+import type { UpdateCheckOptions } from '../../shared/types'
 import { deferAppKitSceneMutation } from '../appkit-scene-mutation'
 import { createAppIconImage } from '../app-icon'
 import { translateMain } from '../i18n/main-i18n'
@@ -18,8 +19,8 @@ export type SystemTrayOptions = {
   onOpen: () => void
   /** Restore the main window and open its Settings surface. */
   onOpenSettings: () => void
-  /** Run the existing user-initiated update check. */
-  onCheckForUpdates: () => void
+  /** Run the existing user-initiated update check (same channel routing as the app menu). */
+  onCheckForUpdates: (options: UpdateCheckOptions) => void
   /** Quit Orca for real (caller must set the quitting latch before quitting). */
   onQuit: () => void
 }
@@ -208,14 +209,28 @@ function stopWatchingMacAppearance(): void {
 // Why: Electron Menu/Tray click callbacks are plain event listeners (not
 // promise-wrapped like ipcMain.handle), so an uncaught throw here is fatal to
 // the main process; contain it to a logged, failed menu action instead.
-function safeMenuAction(action: () => void): () => void {
-  return () => {
+function safeMenuAction<TArgs extends unknown[]>(
+  action: (...args: TArgs) => void
+): (...args: TArgs) => void {
+  return (...args: TArgs) => {
     try {
-      action()
+      action(...args)
     } catch (error) {
       console.error('[system-tray] menu action failed', error)
     }
   }
+}
+
+// Why: tray and app-menu must share identical RC/perf modifier routing (#10590).
+function updateCheckOptionsFromMenuEvent(
+  event: Electron.KeyboardEvent | undefined
+): UpdateCheckOptions {
+  const modifierClick = event?.triggeredByAccelerator !== true
+  const includePerfPrerelease =
+    modifierClick &&
+    (process.platform === 'darwin' ? event?.metaKey === true : event?.ctrlKey === true)
+  const includePrerelease = modifierClick && event?.shiftKey === true
+  return { includePrerelease, includePerfPrerelease }
 }
 
 /**
@@ -280,7 +295,9 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
                 ? translateMain('menu.checkForUpdatesChannelsMac', '⇧ RC · ⌘ Perf')
                 : translateMain('menu.checkForUpdatesChannels', 'Shift RC · Ctrl Perf')
             })`,
-            click: safeMenuAction(() => opts.onCheckForUpdates())
+            click: safeMenuAction((_menuItem, _window, event) => {
+              opts.onCheckForUpdates(updateCheckOptionsFromMenuEvent(event))
+            })
           },
           { type: 'separator' }
         ] as Electron.MenuItemConstructorOptions[])

--- a/src/renderer/src/components/settings/GeneralRemoteServerUpdates.tsx
+++ b/src/renderer/src/components/settings/GeneralRemoteServerUpdates.tsx
@@ -102,7 +102,7 @@ export function GeneralRemoteServerUpdates(): React.JSX.Element | null {
           )}
         </p>
       </div>
-      <div>
+      <div className="flex flex-col items-start gap-1.5">
         <Button
           type="button"
           variant="outline"
@@ -130,6 +130,7 @@ export function GeneralRemoteServerUpdates(): React.JSX.Element | null {
                 'Check for Server Updates'
               )}
         </Button>
+        <p className="text-xs text-muted-foreground">{updateCheckHint}</p>
       </div>
       <p className="text-xs text-muted-foreground">{summary}</p>
     </SearchableSetting>

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -86,64 +86,69 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
         keywords={['update', 'version', 'release notes', 'download']}
         className="space-y-3"
       >
-        <div className="flex items-center gap-3">
-          <Button
-            variant="outline"
-            size="sm"
-            // Why: modifier-click channels are power-user update affordances, not
-            // persistent settings toggles.
-            onClick={(event) => window.api.updater.check(getUpdateCheckClickOptions(event))}
-            title={updateCheckHint}
-            disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
-            className="gap-2"
-          >
-            {updateStatus.state === 'checking' ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              <RefreshCw className="size-3.5" />
-            )}
-            {translate(
-              'auto.components.settings.GeneralUpdateSettingsSection.e1a647adc5',
-              'Check for Updates'
-            )}
-          </Button>
-
-          {updateStatus.state === 'available' ? (
+        <div className="flex flex-col items-start gap-1.5">
+          <div className="flex items-center gap-3">
             <Button
-              variant="default"
+              variant="outline"
               size="sm"
-              onClick={() => {
-                void window.api.updater.download().catch((error) => {
-                  toast.error(
-                    translate(
-                      'auto.components.settings.GeneralUpdateSettingsSection.02dc082e70',
-                      'Could not start the update download.'
-                    ),
-                    {
-                      description: String((error as Error)?.message ?? error)
-                    }
-                  )
-                })
-              }}
+              // Why: modifier-click channels are power-user update affordances, not
+              // persistent settings toggles.
+              onClick={(event) => window.api.updater.check(getUpdateCheckClickOptions(event))}
+              title={updateCheckHint}
+              disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
               className="gap-2"
             >
-              <Download className="size-3.5" />
-              {translate(
-                'auto.components.settings.GeneralUpdateSettingsSection.42717918f4',
-                'Install Update ('
+              {updateStatus.state === 'checking' ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3.5" />
               )}
-              {updateStatus.version})
-            </Button>
-          ) : updateStatus.state === 'downloaded' ? (
-            <Button variant="default" size="sm" onClick={handleRestartToUpdate} className="gap-2">
-              <Download className="size-3.5" />
               {translate(
-                'auto.components.settings.GeneralUpdateSettingsSection.f44299636f',
-                'Restart to Update ('
+                'auto.components.settings.GeneralUpdateSettingsSection.e1a647adc5',
+                'Check for Updates'
               )}
-              {updateStatus.version})
             </Button>
-          ) : null}
+
+            {updateStatus.state === 'available' ? (
+              <Button
+                variant="default"
+                size="sm"
+                onClick={() => {
+                  void window.api.updater.download().catch((error) => {
+                    toast.error(
+                      translate(
+                        'auto.components.settings.GeneralUpdateSettingsSection.02dc082e70',
+                        'Could not start the update download.'
+                      ),
+                      {
+                        description: String((error as Error)?.message ?? error)
+                      }
+                    )
+                  })
+                }}
+                className="gap-2"
+              >
+                <Download className="size-3.5" />
+                {translate(
+                  'auto.components.settings.GeneralUpdateSettingsSection.42717918f4',
+                  'Install Update ('
+                )}
+                {updateStatus.version})
+              </Button>
+            ) : updateStatus.state === 'downloaded' ? (
+              <Button variant="default" size="sm" onClick={handleRestartToUpdate} className="gap-2">
+                <Download className="size-3.5" />
+                {translate(
+                  'auto.components.settings.GeneralUpdateSettingsSection.f44299636f',
+                  'Restart to Update ('
+                )}
+                {updateStatus.version})
+              </Button>
+            ) : null}
+          </div>
+          {/* Why: native title tooltips need hover dwell and vanish while disabled;
+            keep RC/perf modifiers as always-visible muted copy (#10590). */}
+          <p className="text-xs text-muted-foreground">{updateCheckHint}</p>
         </div>
 
         <p className="text-xs text-muted-foreground">

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -750,52 +750,59 @@ export function RuntimeEnvironmentsPane({
               )}
             </p>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
+          <div className="flex shrink-0 flex-col items-end gap-1">
+            <div className="flex items-center gap-2">
+              {environments.length > 0 ? (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  title={updateCheckHint}
+                  onClick={(event) => {
+                    setRemoteServerUpdateDialogOpen(true)
+                    void refreshRemoteServerUpdates(getUpdateCheckClickOptions(event))
+                  }}
+                  disabled={remoteServerUpdatesChecking && remoteServerUpdates.size === 0}
+                >
+                  {remoteServerUpdatesChecking || remoteServerUpdatesRunning ? (
+                    <Loader2 className="animate-spin" />
+                  ) : (
+                    <RefreshCw />
+                  )}
+                  {remoteServerUpdatesRunning
+                    ? translate(
+                        'auto.components.settings.RuntimeEnvironmentsPane.updatingServers',
+                        'Updating servers…'
+                      )
+                    : translate(
+                        'auto.components.settings.RuntimeEnvironmentsPane.reviewServerUpdates',
+                        'Check for Server Updates'
+                      )}
+                </Button>
+              ) : null}
+              {addServerFormOpen ? null : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => setAddServerFormOpen(true)}
+                  disabled={isBusy}
+                >
+                  <Plus />
+                  {translate(
+                    'auto.components.settings.RuntimeEnvironmentsPane.9bee6bbeeb',
+                    'Add Server'
+                  )}
+                </Button>
+              )}
+            </div>
             {environments.length > 0 ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                title={updateCheckHint}
-                onClick={(event) => {
-                  setRemoteServerUpdateDialogOpen(true)
-                  void refreshRemoteServerUpdates(getUpdateCheckClickOptions(event))
-                }}
-                disabled={remoteServerUpdatesChecking && remoteServerUpdates.size === 0}
-              >
-                {remoteServerUpdatesChecking || remoteServerUpdatesRunning ? (
-                  <Loader2 className="animate-spin" />
-                ) : (
-                  <RefreshCw />
-                )}
-                {remoteServerUpdatesRunning
-                  ? translate(
-                      'auto.components.settings.RuntimeEnvironmentsPane.updatingServers',
-                      'Updating servers…'
-                    )
-                  : translate(
-                      'auto.components.settings.RuntimeEnvironmentsPane.reviewServerUpdates',
-                      'Check for Server Updates'
-                    )}
-              </Button>
+              <p className="max-w-[16rem] text-right text-[10px] text-muted-foreground">
+                {updateCheckHint}
+              </p>
             ) : null}
-            {addServerFormOpen ? null : (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                onClick={() => setAddServerFormOpen(true)}
-                disabled={isBusy}
-              >
-                <Plus />
-                {translate(
-                  'auto.components.settings.RuntimeEnvironmentsPane.9bee6bbeeb',
-                  'Add Server'
-                )}
-              </Button>
-            )}
           </div>
         </div>
 

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -322,16 +322,26 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
               onPointerDown={handleCheckForUpdatesPointerDown}
               onSelect={handleCheckForUpdates}
               title={updateCheckHint}
+              className="items-start"
             >
               {updateStatus.state === 'checking' ? (
-                <Loader2 className="size-3.5 animate-spin" />
+                <Loader2 className="mt-0.5 size-3.5 animate-spin" />
               ) : (
-                <RefreshCw className="size-3.5" />
+                <RefreshCw className="mt-0.5 size-3.5" />
               )}
-              {translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
-                'Check for Updates'
-              )}
+              <span className="flex min-w-0 flex-col gap-0.5">
+                <span>
+                  {translate(
+                    'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
+                    'Check for Updates'
+                  )}
+                </span>
+                {/* Why: menus are clicked immediately so title tooltips never
+                    dwell; keep RC/perf modifiers as always-visible copy (#10590). */}
+                <span className="text-[10px] font-normal text-muted-foreground">
+                  {updateCheckHint}
+                </span>
+              </span>
             </DropdownMenuItem>
             {showAdminOptions ? (
               <>

--- a/src/renderer/src/lib/update-check-click-options.test.ts
+++ b/src/renderer/src/lib/update-check-click-options.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getUpdateCheckClickOptions, getUpdateCheckHint } from './update-check-click-options'
+import {
+  getUpdateCheckClickOptions,
+  getUpdateCheckHint,
+  getUpdateCheckMenuHint
+} from './update-check-click-options'
 
 function clickEvent(
   overrides: Partial<Pick<MouseEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>>
@@ -55,12 +59,17 @@ describe('getUpdateCheckClickOptions', () => {
     })
   })
 
-  it('formats the tooltip hint by platform', () => {
+  it('formats the visible channel hint by platform', () => {
     expect(getUpdateCheckHint(true)).toBe(
       '⇧+click checks the latest RC; ⌘+click checks the latest perf build. ⌥+click chooses a local macOS build.'
     )
     expect(getUpdateCheckHint(false)).toBe(
       'Shift+click checks the latest RC; Ctrl+click checks the latest perf build.'
     )
+  })
+
+  it('formats a compact menu/tray hint by platform', () => {
+    expect(getUpdateCheckMenuHint(true)).toBe('⇧ RC · ⌘ Perf')
+    expect(getUpdateCheckMenuHint(false)).toBe('Shift RC · Ctrl Perf')
   })
 })

--- a/src/renderer/src/lib/update-check-click-options.ts
+++ b/src/renderer/src/lib/update-check-click-options.ts
@@ -1,4 +1,5 @@
 import type { UpdateCheckOptions } from '../../../shared/types'
+import { translate } from '@/i18n/i18n'
 import { getShortcutPlatform } from './shortcut-platform'
 
 type UpdateCheckClickEvent = Pick<MouseEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>
@@ -8,10 +9,26 @@ function isMacShortcutPlatform(): boolean {
 }
 
 export function getUpdateCheckHint(isMac = isMacShortcutPlatform()): string {
-  const rcClickLabel = isMac ? '⇧+click' : 'Shift+click'
-  const perfClickLabel = isMac ? '⌘+click' : 'Ctrl+click'
-  const releaseHints = `${rcClickLabel} checks the latest RC; ${perfClickLabel} checks the latest perf build.`
-  return isMac ? `${releaseHints} ⌥+click chooses a local macOS build.` : releaseHints
+  // Why: surface channel modifiers as real UI copy (not a native title-only
+  // tooltip) so RC/perf checks are discoverable and localizable (#10590).
+  if (isMac) {
+    return translate(
+      'auto.lib.update-check-click-options.hint_mac',
+      '⇧+click checks the latest RC; ⌘+click checks the latest perf build. ⌥+click chooses a local macOS build.'
+    )
+  }
+  return translate(
+    'auto.lib.update-check-click-options.hint_other',
+    'Shift+click checks the latest RC; Ctrl+click checks the latest perf build.'
+  )
+}
+
+/** Compact native menu / tray label suffix for modifier channels. */
+export function getUpdateCheckMenuHint(isMac = isMacShortcutPlatform()): string {
+  if (isMac) {
+    return translate('auto.lib.update-check-click-options.menu_hint_mac', '⇧ RC · ⌘ Perf')
+  }
+  return translate('auto.lib.update-check-click-options.menu_hint_other', 'Shift RC · Ctrl Perf')
 }
 
 export function getUpdateCheckClickOptions(


### PR DESCRIPTION
## Summary

- RC/perf update channels only lived in a native `title` tooltip that users never see (#10590).
- Show the localized modifier hint as always-visible muted text under Check for Updates (and related server-update buttons).
- Append compact channel hints on native app menu / tray labels (no tooltip support there).

## Test plan

- [x] `vitest` `update-check-click-options.test.ts`
- [ ] Settings → General → Updates: hint visible without hovering
- [ ] Help menu item shows RC/perf subtitle

Closes #10590

## ELI5

RC and perf update channels were only in a hard-to-see tooltip. The modifier hints are shown as visible muted text under Check for Updates (and on menus) so the shortcuts are obvious.
