### PR TITLE
fix(worktrees): sweep PTYs when purging externally deleted worktrees

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -4,6 +4,7 @@ import { ipcMain } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../shared/constants'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { readBranchRenameFailureOutputForDisplay } from '../agent-hooks/branch-rename-failure-output'
 import {
@@ -995,6 +996,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:resolveMrBase')
   ipcMain.removeHandler('worktrees:remove')
   ipcMain.removeHandler('worktrees:forgetLocal')
+  ipcMain.removeHandler('worktrees:sweepOrphanProcesses')
   ipcMain.removeHandler('worktrees:forceDeletePreservedBranch')
   ipcMain.removeHandler('worktrees:updateMeta')
   ipcMain.removeHandler('worktrees:listLineage')
@@ -1902,6 +1904,30 @@ export function registerWorktreeHandlers(
           worktreeRemovalsInFlight.delete(inFlightKey)
         }
       }
+    }
+  )
+
+  // Why: authoritative bulk/hydrate purge drops UI maps but used to leave PTYs
+  // alive after external `git worktree remove` (#10562). Best-effort process
+  // sweep only — never requirePhysicalStop (no filesystem phase follows).
+  ipcMain.handle(
+    'worktrees:sweepOrphanProcesses',
+    async (
+      _event,
+      args: { worktreeId: string }
+    ): Promise<{ ok: true }> => {
+      if (!args.worktreeId || args.worktreeId === FLOATING_TERMINAL_WORKTREE_ID) {
+        return { ok: true }
+      }
+      await killAllProcessesForWorktree(args.worktreeId, {
+        runtime,
+        localProvider: getLocalPtyProvider(),
+        onPtyStopped: clearProviderPtyState,
+        requirePhysicalStop: false
+      }).catch((err) => {
+        console.warn(`[worktree-teardown] orphan sweep failed for ${args.worktreeId}:`, err)
+      })
+      return { ok: true }
     }
   )
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1241,6 +1241,8 @@ export type PreloadApi = {
       worktreeId: string
       hostId?: ExecutionHostId
     }) => Promise<RemoveWorktreeResult>
+    /** Best-effort PTY/agent sweep after authoritative external worktree loss (#10562). */
+    sweepOrphanProcesses: (args: { worktreeId: string }) => Promise<{ ok: true }>
     forceDeletePreservedBranch: (args: {
       worktreeId: string
       branchName: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -680,6 +680,8 @@ const api = {
 
     forgetLocal: (args) => ipcRenderer.invoke('worktrees:forgetLocal', args),
 
+    sweepOrphanProcesses: (args) => ipcRenderer.invoke('worktrees:sweepOrphanProcesses', args),
+
     forceDeletePreservedBranch: (args) =>
       ipcRenderer.invoke('worktrees:forceDeletePreservedBranch', args),
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -75,6 +75,7 @@ import {
   type ExecutionHostId
 } from '../../../../shared/execution-host'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { forEachWithConcurrency } from '../../../../shared/map-with-concurrency'
 import {
   resolveWorktreeOperationRoute,
   settingsForWorktreeOperationRoute
@@ -113,6 +114,8 @@ const ACTIVE_WORKTREE_TERMINAL_PREP_IDLE_TIMEOUT_MS = 180
 const FOLDER_WORKSPACE_ACTIVITY_PERSIST_INTERVAL_MS = 1_000
 // Why: each repo's `git worktree list` is an independent main-process child; a higher ceiling cuts startup scan batches (#7225) while staying bounded against launching every git probe at once.
 export const WORKTREE_REFRESH_CONCURRENCY = 8
+// Why: bulk hydration purge can touch hundreds of worktrees; bound orphan PTY sweeps so one purge cannot open unbounded main-process scans.
+const ORPHAN_PROCESS_SWEEP_CONCURRENCY = 4
 const pendingActivationTerminalPrepCancels = new Map<string, () => void>()
 const detachedHeadAutoDerivedDisplayNames = new Map<string, string>()
 const folderWorkspaceWorktreeCache = new WeakMap<FolderWorkspace, Worktree>()
@@ -4949,11 +4952,17 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     // Callers that already killed (explicit remove) tolerate a second no-op sweep.
     const sweep = window.api?.worktrees?.sweepOrphanProcesses
     if (typeof sweep === 'function') {
-      for (const worktreeId of purgeableWorktreeIds) {
-        void sweep({ worktreeId }).catch((err: unknown) => {
-          console.warn(`[worktree-teardown] orphan sweep failed for ${worktreeId}:`, err)
-        })
-      }
+      void forEachWithConcurrency(
+        purgeableWorktreeIds,
+        ORPHAN_PROCESS_SWEEP_CONCURRENCY,
+        async (worktreeId) => {
+          try {
+            await sweep({ worktreeId })
+          } catch (err: unknown) {
+            console.warn(`[worktree-teardown] orphan sweep failed for ${worktreeId}:`, err)
+          }
+        }
+      )
     }
   },
 

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4943,6 +4943,18 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
       return
     }
     set((s) => buildWorktreePurgeState(s, purgeableWorktreeIds))
+    // Why: bulk/hydrate purge used to drop UI maps only. External
+    // `git worktree remove` then left daemon/relay PTYs alive with no surface
+    // to kill them — sweep best-effort when maps are purged (#10562).
+    // Callers that already killed (explicit remove) tolerate a second no-op sweep.
+    const sweep = window.api?.worktrees?.sweepOrphanProcesses
+    if (typeof sweep === 'function') {
+      for (const worktreeId of purgeableWorktreeIds) {
+        void sweep({ worktreeId }).catch((err: unknown) => {
+          console.warn(`[worktree-teardown] orphan sweep failed for ${worktreeId}:`, err)
+        })
+      }
+    }
   },
 
   purgeStaleRuntimeHostState: (removedEnvironmentIds) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1608,6 +1608,14 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
     forgetLocal: () => {
       throw new Error('Forgetting a workspace is unavailable in paired web clients.')
     },
+    // Why: authoritative external worktree loss still needs a process sweep on
+    // the host runtime so orphan PTYs don't linger (#10562).
+    sweepOrphanProcesses: async ({ worktreeId }) => {
+      await callRuntimeResult('terminal.stop', {
+        worktree: toRuntimeWorktreeSelector(worktreeId)
+      }).catch(() => undefined)
+      return { ok: true as const }
+    },
     forceDeletePreservedBranch: ({ worktreeId, branchName, expectedHead }) =>
       callRuntimeResult<ForceDeleteWorktreeBranchResult>('worktree.forceDeleteBranch', {
         worktree: toRuntimeWorktreeSelector(worktreeId),


### PR DESCRIPTION
## Summary

- External `git worktree remove` caused Orca to drop UI maps on authoritative reconcile but left daemon/relay PTYs alive (#10562).
- On `purgeWorktreeTerminalState`, best-effort `worktrees:sweepOrphanProcesses` → `killAllProcessesForWorktree` (no `requirePhysicalStop`).
- Web client forwards stop to runtime; floating worktree id is skipped.

## Test plan

- [ ] Local: create worktree, start agent, `git worktree remove` outside Orca, wait for scan → process gone
- [ ] Disconnect SSH and fail scan → no sweep
- [ ] Explicit removeWorktree path unchanged

Closes #10562

## ELI5

If a worktree was deleted outside Orca, the UI dropped it but terminal processes could keep running. Purging that state now best-effort kills orphan PTYs so nothing leaks in the background.
