### PR TITLE
ci(pr): run E2E when a PR touches tests/e2e paths

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,5 +1,9 @@
 name: E2E
 
+# Why: checkout + artifact upload only; callers can only further restrict.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -165,3 +165,39 @@ jobs:
       # temp copy so Node cannot mask missing package deps with repo node_modules.
       - name: Smoke packaged CLI
         run: node config/scripts/smoke-packaged-cli.mjs --app-dir=dist/linux-unpacked
+
+  # Why: regression specs under tests/e2e/** used to merge green without ever
+  # running — e2e.yml only fired on schedule/release (#10518). Path-filter so
+  # ordinary PRs stay light; any E2E suite change still gets a full shard run.
+  e2e-paths:
+    name: detect e2e path changes
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    outputs:
+      should_run: ${{ steps.filter.outputs.should_run }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Filter E2E-relevant paths
+        id: filter
+        run: |
+          set -euo pipefail
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          if git diff --name-only "$BASE" "$HEAD" | grep -E '^(tests/e2e/|playwright\.|\.github/workflows/e2e\.yml$)' >/dev/null; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "E2E path changes detected"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "No E2E path changes"
+          fi
+
+  e2e:
+    name: e2e
+    needs: e2e-paths
+    if: needs.e2e-paths.outputs.should_run == 'true'
+    uses: ./.github/workflows/e2e.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -173,6 +173,9 @@ jobs:
     name: detect e2e path changes
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
+    # Why: detector only needs to read the checkout; do not inherit repo defaults.
+    permissions:
+      contents: read
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
     steps:
@@ -188,7 +191,11 @@ jobs:
           set -euo pipefail
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          if git diff --name-only "$BASE" "$HEAD" | grep -E '^(tests/e2e/|playwright\.|\.github/workflows/e2e\.yml$)' >/dev/null; then
+          # Why: capture first so a failed git diff does not look like "no matches"
+          # (pipeline status in `if` is not aborted by set -e). Three-dot / merge-base
+          # limits the list to files this PR introduced, not base-branch drift.
+          CHANGED="$(git diff --name-only --merge-base "$BASE" "$HEAD")"
+          if printf '%s\n' "$CHANGED" | grep -E '^(tests/e2e/|playwright\.|\.github/workflows/e2e\.yml$)' >/dev/null; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             echo "E2E path changes detected"
           else
@@ -200,4 +207,7 @@ jobs:
     name: e2e
     needs: e2e-paths
     if: needs.e2e-paths.outputs.should_run == 'true'
+    # Why: reusable e2e.yml only checkouts, builds, and uploads artifacts.
+    permissions:
+      contents: read
     uses: ./.github/workflows/e2e.yml


### PR DESCRIPTION
## Summary

- `pr.yml` never called `e2e.yml`, so a PR could add a red regression test and still go green (#10518).
- Path-filter on PR: if the diff touches `tests/e2e/**`, `playwright.*`, or `.github/workflows/e2e.yml`, `workflow_call` the existing E2E suite.
- Ordinary PRs stay light; E2E-only changes get full sharded signal.

## Test plan

- [ ] Open a PR that only touches `src/` → no e2e job
- [ ] Open a PR that touches `tests/e2e/**` → e2e workflow runs

Closes #10518

## ELI5

PRs that only touched E2E tests never ran the E2E workflow, so broken tests could look green. Path filters now trigger E2E when test/e2e paths change while leaving ordinary PRs light.
