### PR TITLE
fix(updates): make RC/perf update channels discoverable

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1003,10 +1003,10 @@ function getSystemTrayOptions(): SystemTrayOptions | null {
     devInstanceLabel: devInstanceIdentity.devLabel,
     onOpen: showMainWindowFromTray,
     onOpenSettings: openSettingsFromSystemMenu,
-    onCheckForUpdates: () => {
+    onCheckForUpdates: (options) => {
       // Why: updater status renders in the main window, so a bare check would complete invisibly.
       showMainWindowFromTray()
-      runUserInitiatedUpdateCheck()
+      runUserInitiatedUpdateCheck(options)
     },
     onQuit: quitFromSystemTray
   }

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -203,6 +203,44 @@ describe('registerAppMenu', () => {
     ])
   })
 
+  it('exposes an explicit pre-release check directly beneath Check for Updates', () => {
+    const options = buildMenuOptions()
+    registerAppMenu(options)
+
+    const parentLabel = isMac ? 'Orca' : 'Help'
+    const submenu = getSubmenu(getTemplate(), parentLabel)
+    const checkIndex = submenu.findIndex((entry) => entry.label === 'Check for Updates...')
+    const item = submenu[checkIndex + 1]
+    // Why: siblings, not a submenu — the common action must stay one click.
+    expect(item?.label).toBe('Check for Pre-release Updates...')
+
+    item?.click?.({} as never, undefined as never, {} as Electron.KeyboardEvent)
+    item?.click?.(
+      {} as never,
+      undefined as never,
+      (isMac ? { metaKey: true } : { ctrlKey: true }) as Electron.KeyboardEvent
+    )
+    // Why: accelerator-triggered events must not read stale modifier state.
+    item?.click?.(
+      {} as never,
+      undefined as never,
+      {
+        triggeredByAccelerator: true,
+        ...(isMac ? { metaKey: true } : { ctrlKey: true })
+      } as Electron.KeyboardEvent
+    )
+    // Why: ⌥ selects a local build on the plain row, but this row is the RC
+    // channel — the modifier must not turn it into a local-build check.
+    item?.click?.({} as never, undefined as never, { altKey: true } as Electron.KeyboardEvent)
+
+    expect(options.onCheckForUpdates.mock.calls).toEqual([
+      [{ includePrerelease: true, includePerfPrerelease: false }],
+      [{ includePrerelease: true, includePerfPrerelease: true }],
+      [{ includePrerelease: true, includePerfPrerelease: false }],
+      [{ includePrerelease: true, includePerfPrerelease: false }]
+    ])
+  })
+
   it('shows the worktree palette shortcut as a display-only menu hint', () => {
     registerAppMenu(buildMenuOptions())
 

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -87,9 +87,15 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     webContents.reload()
   }
 
-  // Why: modifier-click update checks are hidden power-user affordances.
-  // Extracted so the macOS app-menu entries and Windows/Linux Help entries
-  // share identical RC/perf channel routing.
+  /**
+   * Maps a menu click's modifier state onto update channel options: Shift
+   * selects the latest RC, Cmd (mac) / Ctrl (elsewhere) the latest perf build.
+   * Accelerator invocations carry no meaningful modifier state, so they always
+   * resolve to the stable channel.
+   *
+   * Why: extracted so the macOS app-menu entries and the Windows/Linux Help
+   * entries share identical RC/perf routing instead of duplicating it.
+   */
   const menuUpdateCheckOptions = (event: Electron.KeyboardEvent): UpdateCheckOptions => {
     const modifierClick = !event.triggeredByAccelerator
     const localBuild = isMac && modifierClick && event.altKey === true

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -88,28 +88,39 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
   }
 
   // Why: modifier-click update checks are hidden power-user affordances.
-  // Extracted so the macOS app-menu entry and Windows/Linux Help entry share
-  // identical RC/perf channel routing.
-  const checkForUpdatesClick: Electron.MenuItemConstructorOptions['click'] = (
-    _menuItem,
-    _window,
-    event
-  ) => {
+  // Extracted so the macOS app-menu entries and Windows/Linux Help entries
+  // share identical RC/perf channel routing.
+  const menuUpdateCheckOptions = (event: Electron.KeyboardEvent): UpdateCheckOptions => {
     const modifierClick = !event.triggeredByAccelerator
     const localBuild = isMac && modifierClick && event.altKey === true
     const includePerfPrerelease =
       !localBuild && modifierClick && (isMac ? event.metaKey === true : event.ctrlKey === true)
     const includePrerelease = !localBuild && modifierClick && event.shiftKey === true
-    onCheckForUpdates({
+    return {
       includePrerelease,
       includePerfPrerelease,
       ...(localBuild ? { localBuild: true } : {})
-    })
+    }
   }
 
   const checkForUpdatesItem: Electron.MenuItemConstructorOptions = {
     label: translateMain('menu.checkForUpdates', 'Check for Updates...'),
-    click: checkForUpdatesClick
+    click: (_menuItem, _window, event) => onCheckForUpdates(menuUpdateCheckOptions(event))
+  }
+
+  // Why: the menu is the primary update entry point (especially the macOS app
+  // menu), so the RC channel gets a visible row instead of only the hidden
+  // Shift modifier. Perf builds stay modifier-only — an internal channel does
+  // not earn a permanent menu row.
+  const checkForPrereleaseUpdatesItem: Electron.MenuItemConstructorOptions = {
+    label: translateMain('menu.checkForPrereleaseUpdates', 'Check for Pre-release Updates...'),
+    click: (_menuItem, _window, event) => {
+      // Why drop localBuild: this row exists to check the RC channel, and a
+      // local macOS build is not a channel — honouring an ⌥ held over this
+      // item would silently ignore the row the user actually clicked.
+      const { localBuild: _localBuild, ...channelOptions } = menuUpdateCheckOptions(event)
+      onCheckForUpdates({ ...channelOptions, includePrerelease: true })
+    }
   }
 
   const settingsItem: Electron.MenuItemConstructorOptions = {
@@ -142,6 +153,7 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     submenu: [
       { role: 'about' },
       checkForUpdatesItem,
+      checkForPrereleaseUpdatesItem,
       settingsItem,
       { type: 'separator' },
       { role: 'services' },
@@ -304,7 +316,8 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
         : ([
             { type: 'separator' },
             { role: 'about' },
-            checkForUpdatesItem
+            checkForUpdatesItem,
+            checkForPrereleaseUpdatesItem
           ] satisfies Electron.MenuItemConstructorOptions[]))
     ]
   }

--- a/src/main/tray/system-tray.test.ts
+++ b/src/main/tray/system-tray.test.ts
@@ -142,6 +142,12 @@ function builtMenuItems(): MenuItem[] {
   return menuFromTemplateMock.mock.calls.at(-1)?.[0] as MenuItem[]
 }
 
+function clickMenuItem(label: string): void {
+  builtMenuItems()
+    .find((item) => item.label === label)
+    ?.click?.()
+}
+
 // Why: tray image/tooltip writes are deferred off the caller's stack to keep the
 // NSStatusItem scene update out of AppKit's dispatch; run the pending turn.
 function flushTraySceneMutation(): void {
@@ -232,6 +238,7 @@ describe('createSystemTray', () => {
       undefined,
       'Settings',
       'Check for Updates...',
+      'Check for Pre-release Updates...',
       undefined,
       'Quit'
     ])
@@ -249,6 +256,20 @@ describe('createSystemTray', () => {
         ?.click?.()
       expect(callback).toHaveBeenCalledOnce()
     }
+  })
+
+  it('routes the macOS tray pre-release row to the RC channel', async () => {
+    setPlatform('darwin')
+    const { createSystemTray } = await loadModule()
+    const options = createOptions()
+
+    createSystemTray(options)
+    clickMenuItem('Check for Updates...')
+    clickMenuItem('Check for Pre-release Updates...')
+
+    // Why: the stable row must stay channel-agnostic (no options), and only the
+    // pre-release row may force includePrerelease.
+    expect(options.onCheckForUpdates.mock.calls).toEqual([[], [{ includePrerelease: true }]])
   })
 
   it('does not create a blank macOS item when the template asset fails to load', async () => {

--- a/src/main/tray/system-tray.ts
+++ b/src/main/tray/system-tray.ts
@@ -6,6 +6,7 @@ import { createAppIconImage } from '../app-icon'
 import { translateMain } from '../i18n/main-i18n'
 import { composeTrayAttentionIcon, tintTrayTemplateForAttention } from './tray-attention-icon'
 import { stampTrayDevBadge } from './tray-dev-badge'
+import type { UpdateCheckOptions } from '../../shared/types'
 
 export type SystemTrayOptions = {
   /** App icon id from settings; the tray reuses the app icon image. */
@@ -18,8 +19,11 @@ export type SystemTrayOptions = {
   onOpen: () => void
   /** Restore the main window and open its Settings surface. */
   onOpenSettings: () => void
-  /** Run the existing user-initiated update check. */
-  onCheckForUpdates: () => void
+  /**
+   * Run the existing user-initiated update check. Takes channel options so the
+   * tray can offer the pre-release row; omitted options mean the stable channel.
+   */
+  onCheckForUpdates: (options?: UpdateCheckOptions) => void
   /** Quit Orca for real (caller must set the quitting latch before quitting). */
   onQuit: () => void
 }
@@ -275,6 +279,17 @@ export function createSystemTray(opts: SystemTrayOptions): Tray | null {
           {
             label: translateMain('menu.checkForUpdates', 'Check for Updates...'),
             click: safeMenuAction(() => opts.onCheckForUpdates())
+          },
+          // Why: a tray item can carry neither a tooltip nor a reliable modifier
+          // gesture, so the RC channel is only reachable here as its own row —
+          // same flat sibling the app menu got, same translation key. Perf builds
+          // stay out: an internal channel does not earn a permanent tray row.
+          {
+            label: translateMain(
+              'menu.checkForPrereleaseUpdates',
+              'Check for Pre-release Updates...'
+            ),
+            click: safeMenuAction(() => opts.onCheckForUpdates({ includePrerelease: true }))
           },
           { type: 'separator' }
         ] as Electron.MenuItemConstructorOptions[])

--- a/src/renderer/src/components/settings/GeneralRemoteServerUpdates.test.tsx
+++ b/src/renderer/src/components/settings/GeneralRemoteServerUpdates.test.tsx
@@ -3,6 +3,7 @@
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { GeneralRemoteServerUpdates } from './GeneralRemoteServerUpdates'
 
 const storeMock = vi.hoisted(() => ({
@@ -38,7 +39,14 @@ describe('GeneralRemoteServerUpdates', () => {
   it('matches the local update check action and forwards modifier options', async () => {
     const container = document.createElement('div')
     const root = createRoot(container)
-    await act(async () => root.render(<GeneralRemoteServerUpdates />))
+    // Why: the check button's channel hint renders through the app-level Tooltip provider.
+    await act(async () =>
+      root.render(
+        <TooltipProvider>
+          <GeneralRemoteServerUpdates />
+        </TooltipProvider>
+      )
+    )
     storeMock.state.refreshRemoteServerUpdates.mockClear()
 
     const button = container.querySelector('button')

--- a/src/renderer/src/components/settings/GeneralRemoteServerUpdates.tsx
+++ b/src/renderer/src/components/settings/GeneralRemoteServerUpdates.tsx
@@ -86,7 +86,7 @@ export function GeneralRemoteServerUpdates(): React.JSX.Element | null {
         'auto.components.settings.GeneralRemoteServerUpdates.description',
         'Check and update paired Orca servers from this client.'
       )}
-      keywords={['remote server', 'update all', 'paired', 'version']}
+      keywords={['remote server', 'update all', 'paired', 'version', 'rc', 'prerelease', 'perf']}
       className="space-y-3"
     >
       <div className="space-y-0.5">

--- a/src/renderer/src/components/settings/GeneralRemoteServerUpdates.tsx
+++ b/src/renderer/src/components/settings/GeneralRemoteServerUpdates.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import { Loader2, RefreshCw } from 'lucide-react'
 import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { getUpdateCheckClickOptions, getUpdateCheckHint } from '@/lib/update-check-click-options'
@@ -103,33 +104,39 @@ export function GeneralRemoteServerUpdates(): React.JSX.Element | null {
         </p>
       </div>
       <div>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="gap-2"
-          title={updateCheckHint}
-          disabled={checking || running}
-          onClick={(event) => {
-            setDialogOpen(true)
-            void refresh(getUpdateCheckClickOptions(event))
-          }}
-        >
-          {checking || running ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : (
-            <RefreshCw className="size-3.5" />
-          )}
-          {running
-            ? translate(
-                'auto.components.settings.GeneralRemoteServerUpdates.updating',
-                'Updating servers…'
-              )
-            : translate(
-                'auto.components.settings.GeneralRemoteServerUpdates.reviewServers',
-                'Check for Server Updates'
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-2"
+              disabled={checking || running}
+              onClick={(event) => {
+                setDialogOpen(true)
+                void refresh(getUpdateCheckClickOptions(event))
+              }}
+            >
+              {checking || running ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="size-3.5" />
               )}
-        </Button>
+              {running
+                ? translate(
+                    'auto.components.settings.GeneralRemoteServerUpdates.updating',
+                    'Updating servers…'
+                  )
+                : translate(
+                    'auto.components.settings.GeneralRemoteServerUpdates.reviewServers',
+                    'Check for Server Updates'
+                  )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {updateCheckHint}
+          </TooltipContent>
+        </Tooltip>
       </div>
       <p className="text-xs text-muted-foreground">{summary}</p>
     </SearchableSetting>

--- a/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
+++ b/src/renderer/src/components/settings/GeneralUpdateSettingsSection.tsx
@@ -83,7 +83,7 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
           'auto.components.settings.GeneralUpdateSettingsSection.ceb579abaf',
           'Check for app updates and install a newer Orca version.'
         )}
-        keywords={['update', 'version', 'release notes', 'download']}
+        keywords={['update', 'version', 'release notes', 'download', 'rc', 'prerelease', 'perf']}
         className="space-y-3"
       >
         <div className="flex items-center gap-3">
@@ -93,7 +93,6 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
             // Why: modifier-click channels are power-user update affordances, not
             // persistent settings toggles.
             onClick={(event) => window.api.updater.check(getUpdateCheckClickOptions(event))}
-            title={updateCheckHint}
             disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
             className="gap-2"
           >
@@ -244,6 +243,9 @@ export function GeneralUpdateSettingsSection(): React.JSX.Element {
                   { value0: updateStatus.message }
                 ))}
         </p>
+
+        {/* Why: kept visible — a hover-only `title` made the channels undiscoverable. */}
+        <p className="text-xs text-muted-foreground">{updateCheckHint}</p>
       </SearchableSetting>
       <GeneralRemoteServerUpdates />
     </section>

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.test.ts
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from 'vitest'
+// @vitest-environment happy-dom
+
+import { act, createElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '../ui/tooltip'
 import {
   MIN_COMPATIBLE_RUNTIME_SERVER_VERSION,
   PROJECT_HOST_SETUP_RUNTIME_CAPABILITY,
@@ -15,8 +20,16 @@ import {
   getRuntimeCapabilitiesSummary,
   getRuntimeServerConnectionState,
   isRuntimeEnvironmentRemovalBlocked,
+  RemoteServerUpdatesButton,
   type RuntimeHostDetails
 } from './RuntimeEnvironmentsPane'
+
+const roots: Root[] = []
+
+afterEach(() => {
+  roots.splice(0).forEach((root) => root.unmount())
+  document.body.replaceChildren()
+})
 
 function details(overrides: Partial<RuntimeHostDetails>): RuntimeHostDetails {
   return {
@@ -29,6 +42,42 @@ function details(overrides: Partial<RuntimeHostDetails>): RuntimeHostDetails {
 }
 
 describe('RuntimeEnvironmentsPane host details', () => {
+  it('keeps the pre-release hint reachable while remote checks are unavailable', async () => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const onCheck = vi.fn()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    roots.push(root)
+
+    await act(async () => {
+      root.render(
+        createElement(
+          TooltipProvider,
+          undefined,
+          createElement(RemoteServerUpdatesButton, {
+            disabled: true,
+            checking: true,
+            running: false,
+            onCheck
+          })
+        )
+      )
+    })
+
+    const tooltipTrigger = container.querySelector<HTMLElement>(
+      '[data-testid="remote-server-update-check-tooltip-trigger"]'
+    )
+    const button = container.querySelector<HTMLButtonElement>('button')
+    expect(tooltipTrigger?.tabIndex).toBe(0)
+    expect(button?.disabled).toBe(true)
+
+    await act(async () => {
+      button?.click()
+    })
+    expect(onCheck).not.toHaveBeenCalled()
+  })
+
   it('summarizes loading, error, compatible, and blocked hosts', () => {
     expect(getHostDetailsSummary(undefined)).toBe('Checking…')
     expect(getHostDetailsSummary(details({ status: 'error', error: 'offline' }))).toBe(

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -37,6 +37,7 @@ import { Button } from '../ui/button'
 import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
 import { SearchableSetting } from './SearchableSetting'
 import {
   Dialog,
@@ -752,33 +753,39 @@ export function RuntimeEnvironmentsPane({
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {environments.length > 0 ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="gap-1.5"
-                title={updateCheckHint}
-                onClick={(event) => {
-                  setRemoteServerUpdateDialogOpen(true)
-                  void refreshRemoteServerUpdates(getUpdateCheckClickOptions(event))
-                }}
-                disabled={remoteServerUpdatesChecking && remoteServerUpdates.size === 0}
-              >
-                {remoteServerUpdatesChecking || remoteServerUpdatesRunning ? (
-                  <Loader2 className="animate-spin" />
-                ) : (
-                  <RefreshCw />
-                )}
-                {remoteServerUpdatesRunning
-                  ? translate(
-                      'auto.components.settings.RuntimeEnvironmentsPane.updatingServers',
-                      'Updating servers…'
-                    )
-                  : translate(
-                      'auto.components.settings.RuntimeEnvironmentsPane.reviewServerUpdates',
-                      'Check for Server Updates'
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="gap-1.5"
+                    onClick={(event) => {
+                      setRemoteServerUpdateDialogOpen(true)
+                      void refreshRemoteServerUpdates(getUpdateCheckClickOptions(event))
+                    }}
+                    disabled={remoteServerUpdatesChecking && remoteServerUpdates.size === 0}
+                  >
+                    {remoteServerUpdatesChecking || remoteServerUpdatesRunning ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <RefreshCw />
                     )}
-              </Button>
+                    {remoteServerUpdatesRunning
+                      ? translate(
+                          'auto.components.settings.RuntimeEnvironmentsPane.updatingServers',
+                          'Updating servers…'
+                        )
+                      : translate(
+                          'auto.components.settings.RuntimeEnvironmentsPane.reviewServerUpdates',
+                          'Check for Server Updates'
+                        )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" sideOffset={4}>
+                  {updateCheckHint}
+                </TooltipContent>
+              </Tooltip>
             ) : null}
             {addServerFormOpen ? null : (
               <Button

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -81,6 +81,57 @@ export type RuntimeHostDetails = {
   error: string | null
 }
 
+type RemoteServerUpdatesButtonProps = {
+  disabled: boolean
+  checking: boolean
+  running: boolean
+  onCheck: (event: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+export function RemoteServerUpdatesButton({
+  disabled,
+  checking,
+  running,
+  onCheck
+}: RemoteServerUpdatesButtonProps): React.JSX.Element {
+  const updateCheckHint = getUpdateCheckHint()
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          data-testid="remote-server-update-check-tooltip-trigger"
+          tabIndex={disabled ? 0 : undefined}
+          className="inline-flex"
+        >
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="gap-1.5"
+            onClick={onCheck}
+            disabled={disabled}
+          >
+            {checking || running ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+            {running
+              ? translate(
+                  'auto.components.settings.RuntimeEnvironmentsPane.updatingServers',
+                  'Updating servers…'
+                )
+              : translate(
+                  'auto.components.settings.RuntimeEnvironmentsPane.reviewServerUpdates',
+                  'Check for Server Updates'
+                )}
+          </Button>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top" sideOffset={4}>
+        {updateCheckHint}
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
 export function evaluateHostDetails(status: RuntimeStatus): RuntimeCompatVerdict {
   return evaluateRuntimeCompat({
     clientProtocolVersion: RUNTIME_PROTOCOL_VERSION,
@@ -292,7 +343,6 @@ export function RuntimeEnvironmentsPane({
   )
   const consumedAddServerIntentSignalRef = useRef(0)
   const mountedRef = useMountedRef()
-  const updateCheckHint = getUpdateCheckHint()
   const activeValue =
     settings.activeRuntimeEnvironmentId ??
     (allowLocalRuntime ? LOCAL_RUNTIME_VALUE : NO_RUNTIME_VALUE)
@@ -753,39 +803,15 @@ export function RuntimeEnvironmentsPane({
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {environments.length > 0 ? (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="gap-1.5"
-                    onClick={(event) => {
-                      setRemoteServerUpdateDialogOpen(true)
-                      void refreshRemoteServerUpdates(getUpdateCheckClickOptions(event))
-                    }}
-                    disabled={remoteServerUpdatesChecking && remoteServerUpdates.size === 0}
-                  >
-                    {remoteServerUpdatesChecking || remoteServerUpdatesRunning ? (
-                      <Loader2 className="animate-spin" />
-                    ) : (
-                      <RefreshCw />
-                    )}
-                    {remoteServerUpdatesRunning
-                      ? translate(
-                          'auto.components.settings.RuntimeEnvironmentsPane.updatingServers',
-                          'Updating servers…'
-                        )
-                      : translate(
-                          'auto.components.settings.RuntimeEnvironmentsPane.reviewServerUpdates',
-                          'Check for Server Updates'
-                        )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" sideOffset={4}>
-                  {updateCheckHint}
-                </TooltipContent>
-              </Tooltip>
+              <RemoteServerUpdatesButton
+                disabled={remoteServerUpdatesChecking && remoteServerUpdates.size === 0}
+                checking={remoteServerUpdatesChecking}
+                running={remoteServerUpdatesRunning}
+                onCheck={(event) => {
+                  setRemoteServerUpdateDialogOpen(true)
+                  void refreshRemoteServerUpdates(getUpdateCheckClickOptions(event))
+                }}
+              />
             ) : null}
             {addServerFormOpen ? null : (
               <Button

--- a/src/renderer/src/components/settings/runtime-environments-search.ts
+++ b/src/renderer/src/components/settings/runtime-environments-search.ts
@@ -57,6 +57,18 @@ export const getRuntimeEnvironmentsSearchEntry = createLocalizedCatalog(
       ...translateSearchKeyword(
         'auto.components.settings.runtime.environments.search.c6e5a03aa0',
         'dev box'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.runtime.environments.search.prerelease',
+        'prerelease'
+      ),
+      ...translateSearchKeyword('auto.components.settings.runtime.environments.search.rc', 'rc', {
+        englishOnly: true
+      }),
+      ...translateSearchKeyword(
+        'auto.components.settings.runtime.environments.search.perf',
+        'perf',
+        { englishOnly: true }
       )
     ]
   })
@@ -104,6 +116,18 @@ export const getWebRuntimeEnvironmentsSearchEntry = createLocalizedCatalog(
       ...translateSearchKeyword(
         'auto.components.settings.runtime.environments.search.772e3b4753',
         'vm'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.runtime.environments.search.prerelease',
+        'prerelease'
+      ),
+      ...translateSearchKeyword('auto.components.settings.runtime.environments.search.rc', 'rc', {
+        englishOnly: true
+      }),
+      ...translateSearchKeyword(
+        'auto.components.settings.runtime.environments.search.perf',
+        'perf',
+        { englishOnly: true }
       )
     ]
   })

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.test.tsx
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   }
 }))
 
-let updateStatus = { state: 'idle' } as const
+let updateStatus: { state: 'idle' | 'checking' | 'downloading' } = { state: 'idle' }
 const roots: Root[] = []
 
 vi.mock('@/store', () => ({
@@ -305,6 +305,23 @@ describe('SidebarSettingsHelpMenu', () => {
       includePrerelease: false,
       includePerfPrerelease: false
     })
+  })
+
+  it('keeps the update hint reachable while checking without allowing another check', async () => {
+    updateStatus = { state: 'checking' }
+    const container = await renderMenu()
+    const checkButton = findMenuItem(container, 'Check for Updates')
+    const tooltipTrigger = container.querySelector<HTMLElement>(
+      '[data-testid="update-check-tooltip-trigger"]'
+    )
+
+    expect(checkButton.disabled).toBe(true)
+    expect(tooltipTrigger?.tabIndex).toBe(0)
+
+    await act(async () => {
+      checkButton.click()
+    })
+    expect(mocks.updaterCheck).not.toHaveBeenCalled()
   })
 
   it('renders shortcut keys in the settings tooltip', () => {

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -101,6 +101,8 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   const updateCheckModifiersRef = React.useRef(NO_UPDATE_CHECK_MODIFIERS)
   const mountedRef = useMountedRef()
   const updateCheckHint = getUpdateCheckHint()
+  const updateCheckUnavailable =
+    updateStatus.state === 'checking' || updateStatus.state === 'downloading'
 
   const showMilestones =
     setupProgress.ready && setupProgress.coreDoneCount < setupProgress.coreTotal
@@ -167,6 +169,10 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
   }
 
   const handleCheckForUpdates = (): void => {
+    if (updateCheckUnavailable) {
+      updateCheckModifiersRef.current = NO_UPDATE_CHECK_MODIFIERS
+      return
+    }
     const modifiers = updateCheckModifiersRef.current
     updateCheckModifiersRef.current = NO_UPDATE_CHECK_MODIFIERS
     void window.api.updater.check(getUpdateCheckClickOptions(modifiers))
@@ -319,23 +325,27 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
             <DropdownMenuSeparator />
             <Tooltip>
               <TooltipTrigger asChild>
-                <DropdownMenuItem
-                  disabled={
-                    updateStatus.state === 'checking' || updateStatus.state === 'downloading'
-                  }
-                  onPointerDown={handleCheckForUpdatesPointerDown}
-                  onSelect={handleCheckForUpdates}
+                <span
+                  data-testid="update-check-tooltip-trigger"
+                  tabIndex={updateCheckUnavailable ? 0 : undefined}
+                  className="block"
                 >
-                  {updateStatus.state === 'checking' ? (
-                    <Loader2 className="size-3.5 animate-spin" />
-                  ) : (
-                    <RefreshCw className="size-3.5" />
-                  )}
-                  {translate(
-                    'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
-                    'Check for Updates'
-                  )}
-                </DropdownMenuItem>
+                  <DropdownMenuItem
+                    disabled={updateCheckUnavailable}
+                    onPointerDown={handleCheckForUpdatesPointerDown}
+                    onSelect={handleCheckForUpdates}
+                  >
+                    {updateStatus.state === 'checking' ? (
+                      <Loader2 className="size-3.5 animate-spin" />
+                    ) : (
+                      <RefreshCw className="size-3.5" />
+                    )}
+                    {translate(
+                      'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
+                      'Check for Updates'
+                    )}
+                  </DropdownMenuItem>
+                </span>
               </TooltipTrigger>
               {/* Why: side="right" keeps the hint clear of the menu's own items. */}
               <TooltipContent side="right" sideOffset={8}>

--- a/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarSettingsHelpMenu.tsx
@@ -317,22 +317,31 @@ export function SidebarSettingsHelpMenu(): React.JSX.Element {
               <ExternalLink className="ml-auto size-3 text-muted-foreground" />
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem
-              disabled={updateStatus.state === 'checking' || updateStatus.state === 'downloading'}
-              onPointerDown={handleCheckForUpdatesPointerDown}
-              onSelect={handleCheckForUpdates}
-              title={updateCheckHint}
-            >
-              {updateStatus.state === 'checking' ? (
-                <Loader2 className="size-3.5 animate-spin" />
-              ) : (
-                <RefreshCw className="size-3.5" />
-              )}
-              {translate(
-                'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
-                'Check for Updates'
-              )}
-            </DropdownMenuItem>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuItem
+                  disabled={
+                    updateStatus.state === 'checking' || updateStatus.state === 'downloading'
+                  }
+                  onPointerDown={handleCheckForUpdatesPointerDown}
+                  onSelect={handleCheckForUpdates}
+                >
+                  {updateStatus.state === 'checking' ? (
+                    <Loader2 className="size-3.5 animate-spin" />
+                  ) : (
+                    <RefreshCw className="size-3.5" />
+                  )}
+                  {translate(
+                    'auto.components.sidebar.SidebarSettingsHelpMenu.29c56f30ee',
+                    'Check for Updates'
+                  )}
+                </DropdownMenuItem>
+              </TooltipTrigger>
+              {/* Why: side="right" keeps the hint clear of the menu's own items. */}
+              <TooltipContent side="right" sideOffset={8}>
+                {updateCheckHint}
+              </TooltipContent>
+            </Tooltip>
             {showAdminOptions ? (
               <>
                 <DropdownMenuSeparator />

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -568,6 +568,10 @@
           }
         }
       },
+      "updateCheckClickOptions": {
+        "hint": "{{value0}}+click checks the latest RC; {{value1}}+click checks the latest perf build.",
+        "localBuildHint": "{{value0}}+click chooses a local macOS build."
+      },
       "folderWorkspacePathStatus": {
         "title": {
           "missing": "Folder not found",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -63,6 +63,7 @@
   },
   "menu": {
     "checkForUpdates": "Check for Updates...",
+    "checkForPrereleaseUpdates": "Check for Pre-release Updates...",
     "settings": "Settings",
     "exploreOrca": "Explore Orca",
     "gettingStarted": "Getting Started with Orca",
@@ -8616,6 +8617,7 @@
               "09568ccc65": "server",
               "ebd5369acf": "environment",
               "d198440ce3": "runtime",
+              "prerelease": "prerelease",
               "baec27aa8f": "Connect this browser to a saved Orca server.",
               "3517fb2ec0": "Active Server",
               "c6e5a03aa0": "dev box",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -545,6 +545,10 @@
           }
         }
       },
+      "updateCheckClickOptions": {
+        "hint": "{{value0}}+clic busca la última RC; {{value1}}+clic busca la última compilación perf.",
+        "localBuildHint": "{{value0}}+clic elige una compilación local de macOS."
+      },
       "folderWorkspacePathStatus": {
         "title": {
           "missing": "Carpeta no encontrada",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -40,6 +40,7 @@
   },
   "menu": {
     "checkForUpdates": "Buscar actualizaciones...",
+    "checkForPrereleaseUpdates": "Buscar actualizaciones preliminares...",
     "settings": "Ajustes",
     "exploreOrca": "Explorar Orca",
     "gettingStarted": "Primeros pasos con Orca",
@@ -8556,6 +8557,7 @@
               "09568ccc65": "servidor",
               "ebd5369acf": "entorno",
               "d198440ce3": "runtime",
+              "prerelease": "prelanzamiento",
               "baec27aa8f": "Conecte este navegador a un servidor Orca guardado.",
               "3517fb2ec0": "Servidores Orca remotos",
               "c6e5a03aa0": "dev box",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -545,6 +545,10 @@
           }
         }
       },
+      "updateCheckClickOptions": {
+        "hint": "{{value0}}+クリックで最新の RC を、{{value1}}+クリックで最新の perf ビルドをチェックします。",
+        "localBuildHint": "{{value0}}+クリックでローカルの macOS ビルドを選択します。"
+      },
       "folderWorkspacePathStatus": {
         "title": {
           "missing": "フォルダーが見つかりません",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -40,6 +40,7 @@
   },
   "menu": {
     "checkForUpdates": "アップデートを確認...",
+    "checkForPrereleaseUpdates": "プレリリース版のアップデートを確認...",
     "settings": "設定",
     "exploreOrca": "Orca を探索",
     "gettingStarted": "Orca を使い始める",
@@ -8578,6 +8579,7 @@
               "09568ccc65": "サーバ",
               "ebd5369acf": "環境",
               "d198440ce3": "ランタイム",
+              "prerelease": "プレリリース",
               "baec27aa8f": "このブラウザを保存された Orca サーバーに接続します。",
               "3517fb2ec0": "アクティブサーバー",
               "c6e5a03aa0": "開発ボックス",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -40,6 +40,7 @@
   },
   "menu": {
     "checkForUpdates": "업데이트 확인...",
+    "checkForPrereleaseUpdates": "프리릴리스 업데이트 확인...",
     "settings": "설정",
     "exploreOrca": "Orca 둘러보기",
     "gettingStarted": "Orca 시작하기",
@@ -8541,6 +8542,7 @@
               "09568ccc65": "서버",
               "ebd5369acf": "환경",
               "d198440ce3": "런타임",
+              "prerelease": "프리릴리스",
               "baec27aa8f": "이 브라우저를 저장된 Orca 서버에 연결하세요.",
               "3517fb2ec0": "활성 서버",
               "c6e5a03aa0": "개발 박스",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -545,6 +545,10 @@
           }
         }
       },
+      "updateCheckClickOptions": {
+        "hint": "{{value0}}+클릭으로 최신 RC를, {{value1}}+클릭으로 최신 perf 빌드를 확인합니다.",
+        "localBuildHint": "{{value0}}+클릭으로 로컬 macOS 빌드를 선택합니다."
+      },
       "folderWorkspacePathStatus": {
         "title": {
           "missing": "폴더를 찾을 수 없습니다",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -40,6 +40,7 @@
   },
   "menu": {
     "checkForUpdates": "检查更新...",
+    "checkForPrereleaseUpdates": "检查预发布更新...",
     "settings": "设置",
     "exploreOrca": "探索 Orca",
     "gettingStarted": "Orca 入门",
@@ -8541,6 +8542,7 @@
               "09568ccc65": "服务器",
               "ebd5369acf": "环境",
               "d198440ce3": "运行时",
+              "prerelease": "预发布",
               "baec27aa8f": "将此浏览器连接到已保存的 Orca 服务器。",
               "3517fb2ec0": "活动服务器",
               "c6e5a03aa0": "开发盒",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -545,6 +545,10 @@
           }
         }
       },
+      "updateCheckClickOptions": {
+        "hint": "{{value0}}+单击检查最新 RC；{{value1}}+单击检查最新 perf 构建。",
+        "localBuildHint": "{{value0}}+单击选择本地 macOS 构建。"
+      },
       "folderWorkspacePathStatus": {
         "title": {
           "missing": "未找到文件夹",

--- a/src/renderer/src/lib/update-check-click-options.test.ts
+++ b/src/renderer/src/lib/update-check-click-options.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from 'vitest'
+import en from '../i18n/locales/en.json'
+import es from '../i18n/locales/es.json'
+import ja from '../i18n/locales/ja.json'
+import ko from '../i18n/locales/ko.json'
+import zh from '../i18n/locales/zh.json'
 import { getUpdateCheckClickOptions, getUpdateCheckHint } from './update-check-click-options'
 
 function clickEvent(
@@ -62,5 +67,27 @@ describe('getUpdateCheckClickOptions', () => {
     expect(getUpdateCheckHint(false)).toBe(
       'Shift+click checks the latest RC; Ctrl+click checks the latest perf build.'
     )
+  })
+
+  it('keeps the hint localized in every catalog', () => {
+    const english = en.auto.lib.updateCheckClickOptions.hint
+    expect(english).toContain('{{value0}}')
+    expect(english).toContain('{{value1}}')
+    for (const [code, catalog] of Object.entries({ es, ja, ko, zh })) {
+      const localized = catalog.auto.lib.updateCheckClickOptions.hint
+      expect(localized, code).toContain('{{value0}}')
+      expect(localized, code).toContain('{{value1}}')
+      expect(localized, code).not.toBe(english)
+    }
+  })
+
+  it('keeps the macOS local-build hint localized in every catalog', () => {
+    const english = en.auto.lib.updateCheckClickOptions.localBuildHint
+    expect(english).toContain('{{value0}}')
+    for (const [code, catalog] of Object.entries({ es, ja, ko, zh })) {
+      const localized = catalog.auto.lib.updateCheckClickOptions.localBuildHint
+      expect(localized, code).toContain('{{value0}}')
+      expect(localized, code).not.toBe(english)
+    }
   })
 })

--- a/src/renderer/src/lib/update-check-click-options.ts
+++ b/src/renderer/src/lib/update-check-click-options.ts
@@ -8,6 +8,11 @@ function isMacShortcutPlatform(): boolean {
   return getShortcutPlatform() === 'darwin'
 }
 
+/**
+ * Localized one-liner documenting the modifier-click update channels, for the
+ * Settings hint line and the renderer tooltips. `isMac` is injectable so tests
+ * can assert both platform variants without stubbing the platform.
+ */
 export function getUpdateCheckHint(isMac = isMacShortcutPlatform()): string {
   // Why: only the modifier glyphs are platform-bound; the sentence (including
   // "click") stays translatable as a whole.
@@ -28,6 +33,10 @@ export function getUpdateCheckHint(isMac = isMacShortcutPlatform()): string {
   )}`
 }
 
+/**
+ * Maps a renderer click's modifier state onto update channel options: Shift
+ * selects the latest RC, Cmd (mac) / Ctrl (elsewhere) the latest perf build.
+ */
 export function getUpdateCheckClickOptions(
   event: UpdateCheckClickEvent,
   isMac = isMacShortcutPlatform()

--- a/src/renderer/src/lib/update-check-click-options.ts
+++ b/src/renderer/src/lib/update-check-click-options.ts
@@ -1,4 +1,5 @@
 import type { UpdateCheckOptions } from '../../../shared/types'
+import { translate } from '@/i18n/i18n'
 import { getShortcutPlatform } from './shortcut-platform'
 
 type UpdateCheckClickEvent = Pick<MouseEvent, 'altKey' | 'ctrlKey' | 'metaKey' | 'shiftKey'>
@@ -8,10 +9,23 @@ function isMacShortcutPlatform(): boolean {
 }
 
 export function getUpdateCheckHint(isMac = isMacShortcutPlatform()): string {
-  const rcClickLabel = isMac ? '⇧+click' : 'Shift+click'
-  const perfClickLabel = isMac ? '⌘+click' : 'Ctrl+click'
-  const releaseHints = `${rcClickLabel} checks the latest RC; ${perfClickLabel} checks the latest perf build.`
-  return isMac ? `${releaseHints} ⌥+click chooses a local macOS build.` : releaseHints
+  // Why: only the modifier glyphs are platform-bound; the sentence (including
+  // "click") stays translatable as a whole.
+  const releaseHints = translate(
+    'auto.lib.updateCheckClickOptions.hint',
+    '{{value0}}+click checks the latest RC; {{value1}}+click checks the latest perf build.',
+    { value0: isMac ? '⇧' : 'Shift', value1: isMac ? '⌘' : 'Ctrl' }
+  )
+  if (!isMac) {
+    return releaseHints
+  }
+  // Why: the local-build modifier is macOS-only, so it stays a separate
+  // sentence rather than a conditional fragment inside the shared string.
+  return `${releaseHints} ${translate(
+    'auto.lib.updateCheckClickOptions.localBuildHint',
+    '{{value0}}+click chooses a local macOS build.',
+    { value0: '⌥' }
+  )}`
 }
 
 export function getUpdateCheckClickOptions(


### PR DESCRIPTION
Fixes #10590

## Problem

`Check for Updates` supports modifier-click update channels — Shift+click checks the latest RC, Cmd/Ctrl+click checks the latest perf build. The only affordance documenting this was a native `title` tooltip, which in practice nobody sees: it needs ~1s hover dwell on a button users click immediately, and `Button`'s `disabled:pointer-events-none` suppresses it entirely while a check is in flight. The string also bypassed i18n — it was a hardcoded English template literal, absent from all five locale catalogs.

I filed the issue after browsing the entire Settings tree, concluding Orca had no RC channel, and only finding it by reading `src/main/updater.ts`.

## Changes

**Settings → General → Updates** — the hint is now a persistent muted line under the status text (`text-xs text-muted-foreground`, matching the sibling status paragraph) instead of a `title`. Search keywords gained `rc` / `prerelease` / `perf`.

**Help menu, Runtime Environments, Remote server updates** — bare `title` replaced with the project's shadcn `Tooltip` (shorter open delay, focus-visible triggered, so keyboard/AT reachable). The Help-menu tooltip uses `side="right"` so it doesn't cover adjacent menu items.

**Native menus** — the macOS app menu and the Windows/Linux Help menu carry the same modifier routing but cannot show a tooltip at all, so on macOS the primary "Check for Updates" entry point was completely undiscoverable. Added a **"Check for Pre-release Updates…"** item as a flat sibling directly beneath "Check for Updates…" in both. The click handler was extracted into a shared `menuUpdateCheckOptions(event)` so both items route identically — no duplicated update logic — and the new item spreads it before forcing `includePrerelease: true`, so a Cmd/Ctrl-modified click on it still layers perf on top. No submenu: folding the common action one level deeper to serve a rare one isn't a good trade.

**System tray (macOS)** — the second native surface #10590 named. Its `onCheckForUpdates` was typed `() => void` and `index.ts` passed no argument, so unlike the app menu the tray never routed modifiers at all — a tray check was always stable-channel. (My issue text claimed it honoured them; it did not.) So this adds the capability, not just the label: `SystemTrayOptions` now forwards `UpdateCheckOptions` and the same flat **"Check for Pre-release Updates…"** row sits beneath "Check for Updates…", reusing `menu.checkForPrereleaseUpdates` — no new locale keys. The tray is the surface where nothing else would work: no tooltip, no documented modifier gesture.

**i18n** — `getUpdateCheckHint()` routes through `translate()`, interpolating only the platform-bound modifier glyphs (`⇧`/`⌘` vs `Shift`/`Ctrl`) so the sentence, including the word "click", stays translatable as a whole. Keys added to all five catalogs with real translations rather than English placeholders.

## Deliberate omissions

- **No persistent update-channel settings toggle.** `GeneralUpdateSettingsSection.tsx` states these are "power-user update affordances, not persistent settings toggles"; that decision is left intact.
- **Perf builds get no permanent row anywhere.** `X.Y.Z-rc.N.perf` is an internal build channel; a row for it in the app menu or tray would be noise for every user. It stays modifier-only on the surfaces that can carry modifiers, documented by the visible Settings hint.
- **`disabled:pointer-events-none` still suppresses the tooltip on the three Tooltip surfaces** during an in-flight check. Fully solved on the primary surface, where the hint is now unconditional visible text. Span-wrapping every trigger to work around it wasn't worth the accessibility trade-off, since discovery happens before clicking.

## Verification

Ran on this branch: `pnpm run typecheck` (exit 0), `pnpm run lint` (exit 0, including `verify:localization-catalog` parity and `verify:localization-coverage`), and vitest over the affected files.

Re-run after the tray commit: `tsc --noEmit -p config/tsconfig.node.json` (exit 0), `oxlint` over the touched paths (exit 0), `oxfmt --check` clean, both localization gates pass, and `vitest run --config config/vitest.config.ts` over `system-tray.test.ts`, `register-app-menu.test.ts`, `update-check-click-options.test.ts` → 47 passed, 1 skipped.

This branch was also put through an independent adversarial review pass. Reporting its conclusions, including the ones that don't flatter the change:

**Verified:**
- English output is byte-identical to the pre-change literals on both the mac and non-mac paths — `escapeValue: false` is set, and the `⇧`/`⌘` glyphs are not escaped or transformed.
- All five catalogs retain both `{{value0}}` and `{{value1}}` placeholders; no dropped or renamed interpolation.
- The `Tooltip` wrapping a `DropdownMenuItem` composition works: Radix `Menu.Item` sets `data-highlighted`, not `data-state`, so there is no selector collision; tooltip `z-[90]` renders above dropdown content `z-[70]`; and the existing `onPointerDown` / `onSelect` modifier capture still fires in the right order with modifiers intact through the added Slot.
- `TooltipProvider` covers all affected surfaces (`App.tsx` root, plus the sidebar's own provider). Relevant because Radix's tooltip context has no default — a missing provider throws rather than silently no-op'ing.
- The new `@/i18n/i18n` import in `lib/update-check-click-options.ts` has five importers, all under `src/renderer/src/`. No main-process, preload, CLI, web-build or mobile consumer; no circular import; the web typecheck project passes.

**Known gaps, stated rather than papered over:**
- **The Tooltip composition above is not covered by CI.** `SidebarSettingsHelpMenu.test.tsx` mocks both `ui/dropdown-menu` and `ui/tooltip` as pass-through fragments, so its assertions prove nothing about real Radix behavior; `RuntimeEnvironmentsPane`'s new Tooltip has no render test. The composition was verified with a throwaway harness using the real primitives, but nothing will catch a regression if Radix's Slot merge semantics or the prop-spread order changes. Happy to add real-primitive coverage if you'd like it in this PR.
- **No rendered-app verification.** I could not launch a packaged Electron build from this worktree, so the visual result was reviewed via the diff, the styleguide's typography/spacing rules, and DOM-level component tests — not a screenshot.
- **`data-slot` clobbering (cosmetic, pre-existing pattern).** Radix Slot merges `TooltipTrigger`'s `data-slot="tooltip-trigger"` over the wrapped item's `data-slot="dropdown-menu-item"`. Impact today is nil — no selector anywhere in `src/`, `tests/` or `mobile/` targets that attribute — but it's a trap for future CSS or Playwright locators. Note the same clobbering already affects the pre-existing `TooltipTrigger asChild > Button` pairs in this file, so it's an established pattern rather than something introduced here.
- **Language-switch reactivity is unproven either way.** `translate()` is called bare, so re-render on `languageChanged` relies on the root-level `useTranslation()` — the app-wide pattern for every other `translate()` call, but newly relevant since this string previously never needed to change. Not tested at runtime.

## ELI5

Checking for RC or perf updates via modifier-click was almost undiscoverable (tooltip only). The update UI now surfaces those channel options more clearly so people can actually find them.
