### PR TITLE
feat(sidebar): interleave project groups with ungrouped projects

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -156,6 +156,7 @@ import {
 } from './project-header-drop'
 import { useProjectGroupHeaderDrag } from './project-group-header-drag'
 import { getSidebarOrderedProjectGroupHeaderIdsByBucket } from './project-group-header-drop'
+import { encodeSidebarRootSlotKey, getSidebarOrderedRootSlots } from './sidebar-root-slot-order'
 import {
   buildManualOrderUpdatesForGroupDrop,
   buildManualOrderUpdatesForVisibleGroups,
@@ -1670,6 +1671,20 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
       ),
     [projectGroupByIdForHeaderDrag, rows]
   )
+  const sidebarRootSlots = useMemo(
+    () =>
+      hasProjectGroups
+        ? getSidebarOrderedRootSlots(rows.filter((row): row is Row => row.type !== 'host-header'))
+        : [],
+    [hasProjectGroups, rows]
+  )
+  const rootSlotIndexByKey = useMemo(() => {
+    const map = new Map<string, number>()
+    sidebarRootSlots.forEach((slot, index) => {
+      map.set(encodeSidebarRootSlotKey(slot), index)
+    })
+    return map
+  }, [sidebarRootSlots])
   const repoHeaderIndexByRepoId = useMemo(() => {
     const map = new Map<string, number>()
     for (const repoIds of sidebarRepoHeaderIdsByBucket.values()) {
@@ -1677,8 +1692,14 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         map.set(repoId, index)
       })
     }
+    // Why: root ungrouped projects share indices with root groups for one drop list.
+    for (const slot of sidebarRootSlots) {
+      if (slot.kind === 'repo') {
+        map.set(slot.id, rootSlotIndexByKey.get(encodeSidebarRootSlotKey(slot)) ?? 0)
+      }
+    }
     return map
-  }, [sidebarRepoHeaderIdsByBucket])
+  }, [rootSlotIndexByKey, sidebarRepoHeaderIdsByBucket, sidebarRootSlots])
   const repoHeaderBucketByRepoId = useMemo(() => {
     const map = new Map<string, string>()
     for (const [bucketKey, repoIds] of sidebarRepoHeaderIdsByBucket) {
@@ -1695,8 +1716,13 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         map.set(groupId, index)
       })
     }
+    for (const slot of sidebarRootSlots) {
+      if (slot.kind === 'project-group') {
+        map.set(slot.id, rootSlotIndexByKey.get(encodeSidebarRootSlotKey(slot)) ?? 0)
+      }
+    }
     return map
-  }, [sidebarProjectGroupHeaderIdsByBucket])
+  }, [rootSlotIndexByKey, sidebarProjectGroupHeaderIdsByBucket, sidebarRootSlots])
   const projectGroupHeaderBucketByGroupId = useMemo(() => {
     const map = new Map<string, string>()
     for (const [bucketKey, groupIds] of sidebarProjectGroupHeaderIdsByBucket) {
@@ -1729,16 +1755,22 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
   const repoDrag = useRepoHeaderDrag({
     orderedRepoIds: allRepoIds,
     sidebarRepoHeaderIdsByBucket,
+    sidebarRootSlots,
     repoById: repoMap,
+    projectGroupById: projectGroupByIdForHeaderDrag,
     usesProjectGroupOrdering: hasProjectGroups,
     onCommitRepoOrder: commitRepoReorder,
     onCommitProjectGroupOrder: commitProjectGroupOrder,
+    onCommitProjectGroupTabOrder: commitProjectGroupHeaderOrder,
     getScrollContainer: () => scrollRef.current
   })
   const projectGroupDrag = useProjectGroupHeaderDrag({
     sidebarProjectGroupHeaderIdsByBucket,
+    sidebarRootSlots,
     projectGroupById: projectGroupByIdForHeaderDrag,
+    repoById: repoMap,
     onCommitProjectGroupTabOrder: commitProjectGroupHeaderOrder,
+    onCommitProjectGroupOrder: commitProjectGroupOrder,
     getScrollContainer: () => scrollRef.current
   })
   const [primaryActiveWorktreeRow, setPrimaryActiveWorktreeRow] = useState<{
@@ -1796,9 +1828,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         rows: renderRows,
         firstHeaderIndex,
         sidebarRepoHeaderIdsByBucket,
-        repoHeaderBucketByRepoId
+        repoHeaderBucketByRepoId,
+        sidebarRootSlots
       }),
-    [firstHeaderIndex, renderRows, repoHeaderBucketByRepoId, sidebarRepoHeaderIdsByBucket]
+    [
+      firstHeaderIndex,
+      renderRows,
+      repoHeaderBucketByRepoId,
+      sidebarRepoHeaderIdsByBucket,
+      sidebarRootSlots
+    ]
   )
   const projectGroupHeaderSectionEndByGroupId = useMemo(
     () =>
@@ -1806,13 +1845,15 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         rows: renderRows,
         firstHeaderIndex,
         sidebarProjectGroupHeaderIdsByBucket,
-        projectGroupHeaderBucketByGroupId
+        projectGroupHeaderBucketByGroupId,
+        sidebarRootSlots
       }),
     [
       firstHeaderIndex,
       projectGroupHeaderBucketByGroupId,
       renderRows,
-      sidebarProjectGroupHeaderIdsByBucket
+      sidebarProjectGroupHeaderIdsByBucket,
+      sidebarRootSlots
     ]
   )
   const firstHeaderIndexRef = useRef(firstHeaderIndex)
@@ -4151,14 +4192,16 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                 isRepoHeader &&
                 projectIdForHeader &&
                 repoHeaderBucketKey &&
-                (sidebarRepoHeaderIdsByBucket.get(repoHeaderBucketKey)?.length ?? 0) > 1
+                ((repoHeaderBucketKey === 'ungrouped' && sidebarRootSlots.length > 1) ||
+                  (sidebarRepoHeaderIdsByBucket.get(repoHeaderBucketKey)?.length ?? 0) > 1)
               )
               const isDraggableProjectGroupHeader = Boolean(
                 canReorderProjectGroupHeaders &&
                 projectGroupIdForHeader &&
                 projectGroupHeaderBucketKey &&
-                (sidebarProjectGroupHeaderIdsByBucket.get(projectGroupHeaderBucketKey)?.length ??
-                  0) > 1
+                ((projectGroupHeaderBucketKey === 'root' && sidebarRootSlots.length > 1) ||
+                  (sidebarProjectGroupHeaderIdsByBucket.get(projectGroupHeaderBucketKey)?.length ??
+                    0) > 1)
               )
               const isDraggingThis =
                 canReorderRepoHeaders &&

--- a/src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-commit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { commitProjectGroupHeaderDragDrop } from './project-group-header-drag-commit'
 import type { ProjectGroupHeaderDragSession } from './project-group-header-drag-contract'
-import type { ProjectGroup } from '../../../../shared/types'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
 
 function group(id: string, overrides: Partial<ProjectGroup> = {}): ProjectGroup {
   return {
@@ -23,12 +23,14 @@ function group(id: string, overrides: Partial<ProjectGroup> = {}): ProjectGroup 
 
 function makeSession(
   groupId: string,
-  sidebarProjectGroupHeaderIds: readonly string[]
+  sidebarProjectGroupHeaderIds: readonly string[],
+  orderedRootSlots: ProjectGroupHeaderDragSession['orderedRootSlots'] = null
 ): ProjectGroupHeaderDragSession {
   return {
     groupId,
     bucketKey: 'root',
     sidebarProjectGroupHeaderIds,
+    orderedRootSlots,
     pointerId: 1,
     headerRects: [],
     handleEl: document.createElement('div'),
@@ -53,7 +55,9 @@ describe('commitProjectGroupHeaderDragDrop', () => {
       session: makeSession('c', ['a', 'b', 'c']),
       sidebarDropIndex: 0,
       projectGroupById,
-      onCommitProjectGroupTabOrder
+      repoById: new Map(),
+      onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder: vi.fn()
     })
 
     expect(onCommitProjectGroupTabOrder.mock.calls).toEqual([
@@ -77,7 +81,9 @@ describe('commitProjectGroupHeaderDragDrop', () => {
       session: makeSession('sibling-b', ['sibling-a', 'sibling-b']),
       sidebarDropIndex: 0,
       projectGroupById,
-      onCommitProjectGroupTabOrder
+      repoById: new Map(),
+      onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder: vi.fn()
     })
 
     expect(onCommitProjectGroupTabOrder.mock.calls).toEqual([
@@ -95,7 +101,9 @@ describe('commitProjectGroupHeaderDragDrop', () => {
       session: makeSession('b', ['a', 'b', 'c']),
       sidebarDropIndex: 2,
       projectGroupById,
-      onCommitProjectGroupTabOrder
+      repoById: new Map(),
+      onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder: vi.fn()
     })
 
     expect(onCommitProjectGroupTabOrder).not.toHaveBeenCalled()
@@ -110,9 +118,104 @@ describe('commitProjectGroupHeaderDragDrop', () => {
       session: makeSession('c', ['a', 'b']),
       sidebarDropIndex: 0,
       projectGroupById,
-      onCommitProjectGroupTabOrder
+      repoById: new Map(),
+      onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder: vi.fn()
     })
 
     expect(onCommitProjectGroupTabOrder).not.toHaveBeenCalled()
+  })
+
+  it('renumbers root groups and ungrouped projects together after a root drop', () => {
+    const onCommitProjectGroupTabOrder = vi.fn()
+    const onCommitProjectGroupOrder = vi.fn()
+    const groups = [group('group-a', { tabOrder: 0 }), group('group-b', { tabOrder: 1 })]
+    const repos: Repo[] = [
+      {
+        id: 'repo-x',
+        path: '/x',
+        displayName: 'x',
+        badgeColor: '#000',
+        addedAt: 0,
+        projectGroupId: null,
+        projectGroupOrder: 2
+      } as Repo
+    ]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+    const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+    const orderedRootSlots = [
+      { kind: 'project-group' as const, id: 'group-a' },
+      { kind: 'project-group' as const, id: 'group-b' },
+      { kind: 'repo' as const, id: 'repo-x' }
+    ]
+
+    commitProjectGroupHeaderDragDrop({
+      session: makeSession(
+        'group-b',
+        orderedRootSlots.map((slot) =>
+          slot.kind === 'project-group' ? `project-group:${slot.id}` : `repo:${slot.id}`
+        ),
+        orderedRootSlots
+      ),
+      // Drop group-b before group-a → [group-b, group-a, repo-x]
+      sidebarDropIndex: 0,
+      projectGroupById,
+      repoById,
+      onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder
+    })
+
+    expect(onCommitProjectGroupTabOrder.mock.calls).toEqual([
+      ['group-b', 0],
+      ['group-a', 1]
+    ])
+    // Why: repo-x stays at index 2 so its projectGroupOrder is already dense.
+    expect(onCommitProjectGroupOrder).not.toHaveBeenCalled()
+  })
+
+  it('writes projectGroupOrder when a root group drop changes an ungrouped slot index', () => {
+    const onCommitProjectGroupTabOrder = vi.fn()
+    const onCommitProjectGroupOrder = vi.fn()
+    const groups = [group('group-a', { tabOrder: 0 }), group('group-b', { tabOrder: 1 })]
+    const repos: Repo[] = [
+      {
+        id: 'repo-x',
+        path: '/x',
+        displayName: 'x',
+        badgeColor: '#000',
+        addedAt: 0,
+        projectGroupId: null,
+        projectGroupOrder: 2
+      } as Repo
+    ]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+    const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+    const orderedRootSlots = [
+      { kind: 'project-group' as const, id: 'group-a' },
+      { kind: 'project-group' as const, id: 'group-b' },
+      { kind: 'repo' as const, id: 'repo-x' }
+    ]
+
+    commitProjectGroupHeaderDragDrop({
+      session: makeSession(
+        'group-a',
+        orderedRootSlots.map((slot) =>
+          slot.kind === 'project-group' ? `project-group:${slot.id}` : `repo:${slot.id}`
+        ),
+        orderedRootSlots
+      ),
+      // Drop group-a after repo-x → [group-b, repo-x, group-a]
+      sidebarDropIndex: 3,
+      projectGroupById,
+      repoById,
+      onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder
+    })
+
+    expect(onCommitProjectGroupTabOrder.mock.calls).toEqual([
+      ['group-b', 0],
+      ['group-a', 2]
+    ])
+    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('repo-x', null, 1)
   })
 })

--- a/src/renderer/src/components/sidebar/project-group-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-commit.ts
@@ -1,13 +1,36 @@
 import { getProjectGroupTabOrderUpdatesForSidebarDrop } from './project-group-header-drop'
 import type { ProjectGroupHeaderDragSession } from './project-group-header-drag-contract'
-import type { ProjectGroup } from '../../../../shared/types'
+import {
+  applyRootSlotOrderUpdates,
+  getRootSlotOrderUpdatesForSidebarDrop
+} from './sidebar-root-slot-order'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
 
 export function commitProjectGroupHeaderDragDrop(args: {
   session: ProjectGroupHeaderDragSession
   sidebarDropIndex: number
   projectGroupById: ReadonlyMap<string, ProjectGroup>
+  repoById: ReadonlyMap<string, Repo>
   onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
+  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
 }): void {
+  const orderedRootSlots = args.session.orderedRootSlots
+  if (orderedRootSlots && orderedRootSlots.length > 0) {
+    const updates = getRootSlotOrderUpdatesForSidebarDrop({
+      orderedRootSlots,
+      dragged: { kind: 'project-group', id: args.session.groupId },
+      sidebarDropIndex: args.sidebarDropIndex,
+      projectGroupById: args.projectGroupById,
+      repoById: args.repoById
+    })
+    applyRootSlotOrderUpdates({
+      updates,
+      onCommitProjectGroupTabOrder: args.onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder: args.onCommitProjectGroupOrder
+    })
+    return
+  }
+
   const updates = getProjectGroupTabOrderUpdatesForSidebarDrop({
     sidebarProjectGroupHeaderIds: args.session.sidebarProjectGroupHeaderIds,
     draggedGroupId: args.session.groupId,

--- a/src/renderer/src/components/sidebar/project-group-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-contract.ts
@@ -4,7 +4,8 @@ import type {
   ProjectGroupHeaderDragBucketKey,
   ProjectGroupHeaderDragRect
 } from './project-group-header-drop'
-import type { ProjectGroup } from '../../../../shared/types'
+import type { SidebarRootSlot, SidebarRootSlotDragRect } from './sidebar-root-slot-order'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
 
 export type ProjectGroupDragState = {
   draggingGroupId: string | null
@@ -23,8 +24,11 @@ export type UseProjectGroupHeaderDragArgs = {
     ProjectGroupHeaderDragBucketKey,
     readonly string[]
   >
+  sidebarRootSlots: readonly SidebarRootSlot[]
   projectGroupById: ReadonlyMap<string, ProjectGroup>
+  repoById: ReadonlyMap<string, Repo>
   onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
+  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
   getScrollContainer: () => HTMLElement | null
 }
 
@@ -37,8 +41,10 @@ export type ProjectGroupHeaderDragSession = {
   groupId: string
   bucketKey: ProjectGroupHeaderDragBucketKey
   sidebarProjectGroupHeaderIds: readonly string[]
+  /** When set, root drop renumbers groups + ungrouped projects as one list. */
+  orderedRootSlots: readonly SidebarRootSlot[] | null
   pointerId: number
-  headerRects: ProjectGroupHeaderDragRect[]
+  headerRects: (ProjectGroupHeaderDragRect | SidebarRootSlotDragRect)[]
   handleEl: HTMLElement
   startX: number
   startY: number

--- a/src/renderer/src/components/sidebar/project-group-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-start.test.ts
@@ -48,6 +48,10 @@ describe('createProjectGroupHeaderDragSession', () => {
       groupId: 'group-a',
       projectGroupById,
       sidebarProjectGroupHeaderIdsByBucket,
+      sidebarRootSlots: [
+        { kind: 'project-group', id: 'group-a' },
+        { kind: 'project-group', id: 'group-b' }
+      ],
       getScrollContainer: () => scrollContainer
     })
 
@@ -82,6 +86,10 @@ describe('createProjectGroupHeaderDragSession', () => {
       groupId: 'group-a',
       projectGroupById,
       sidebarProjectGroupHeaderIdsByBucket,
+      sidebarRootSlots: [
+        { kind: 'project-group', id: 'group-a' },
+        { kind: 'project-group', id: 'group-b' }
+      ],
       getScrollContainer: () => scrollContainer
     })
 

--- a/src/renderer/src/components/sidebar/project-group-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag-start.ts
@@ -10,6 +10,12 @@ import {
   isProjectGroupHeaderDragHandleTarget,
   type ProjectGroupHeaderDragSession
 } from './project-group-header-drag-contract'
+import {
+  encodeSidebarRootSlotKey,
+  measureSidebarRootSlotDragRects,
+  SIDEBAR_ROOT_SLOT_BUCKET,
+  type SidebarRootSlot
+} from './sidebar-root-slot-order'
 import type { ProjectGroup } from '../../../../shared/types'
 
 export function createProjectGroupHeaderDragSession(args: {
@@ -20,6 +26,7 @@ export function createProjectGroupHeaderDragSession(args: {
     ProjectGroupHeaderDragBucketKey,
     readonly string[]
   >
+  sidebarRootSlots: readonly SidebarRootSlot[]
   getScrollContainer: () => HTMLElement | null
 }): ProjectGroupHeaderDragSession | null {
   if (args.event.button !== 0) {
@@ -36,10 +43,17 @@ export function createProjectGroupHeaderDragSession(args: {
     return null
   }
   const bucketKey = getProjectGroupHeaderDragBucketKey(group, args.projectGroupById)
+  const usesRootSlotOrdering =
+    bucketKey === SIDEBAR_ROOT_SLOT_BUCKET && args.sidebarRootSlots.length > 1
   const sidebarProjectGroupHeaderIds =
     args.sidebarProjectGroupHeaderIdsByBucket.get(bucketKey) ?? []
-  // Why: a lone group in a parent bucket cannot move without reparenting.
-  if (sidebarProjectGroupHeaderIds.length <= 1) {
+  // Why: root can move against ungrouped projects; nested buckets still need 2+ groups.
+  if (usesRootSlotOrdering) {
+    // ok
+  } else if (sidebarProjectGroupHeaderIds.length <= 1) {
+    return null
+  }
+  if (usesRootSlotOrdering && args.sidebarRootSlots.length <= 1) {
     return null
   }
   const container = args.getScrollContainer()
@@ -47,14 +61,20 @@ export function createProjectGroupHeaderDragSession(args: {
     return null
   }
   const handleEl = args.event.currentTarget
+  const orderedRootSlots = usesRootSlotOrdering ? args.sidebarRootSlots : null
   // Why: defer pointer capture until the threshold so ordinary group header
   // clicks still toggle collapse through the row handler.
   return {
     groupId: args.groupId,
     bucketKey,
-    sidebarProjectGroupHeaderIds,
+    sidebarProjectGroupHeaderIds: usesRootSlotOrdering
+      ? orderedRootSlots!.map(encodeSidebarRootSlotKey)
+      : sidebarProjectGroupHeaderIds,
+    orderedRootSlots,
     pointerId: args.event.pointerId,
-    headerRects: measureProjectGroupHeaderDragRects(container, bucketKey),
+    headerRects: usesRootSlotOrdering
+      ? measureSidebarRootSlotDragRects(container)
+      : measureProjectGroupHeaderDragRects(container, bucketKey),
     handleEl,
     startX: args.event.clientX,
     startY: args.event.clientY,

--- a/src/renderer/src/components/sidebar/project-group-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drag.ts
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import {
   computeProjectGroupHeaderDropPreview,
   measureProjectGroupHeaderDragRects
 } from './project-group-header-drop'
 import { commitProjectGroupHeaderDragDrop } from './project-group-header-drag-commit'
+import { measureSidebarRootSlotDragRects } from './sidebar-root-slot-order'
 import {
   INITIAL_PROJECT_GROUP_DRAG_STATE,
   PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX,
@@ -14,15 +15,18 @@ import {
   type UseProjectGroupHeaderDragArgs
 } from './project-group-header-drag-contract'
 import { createProjectGroupHeaderDragSession } from './project-group-header-drag-start'
-import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+import { useSidebarHeaderPointerDragSession } from './sidebar-header-pointer-drag-session'
 
 // Why pointer events instead of HTML5 DnD: Project Group rows are virtualized
 // and may unmount while scrolling; cached row-model indices keep drops stable.
 
 export function useProjectGroupHeaderDrag({
   sidebarProjectGroupHeaderIdsByBucket,
+  sidebarRootSlots,
   projectGroupById,
+  repoById,
   onCommitProjectGroupTabOrder,
+  onCommitProjectGroupOrder,
   getScrollContainer
 }: UseProjectGroupHeaderDragArgs): ProjectGroupHeaderDragController {
   const [state, setState] = useState<ProjectGroupDragState>(INITIAL_PROJECT_GROUP_DRAG_STATE)
@@ -31,14 +35,18 @@ export function useProjectGroupHeaderDrag({
   latestDropIndexRef.current = state.dropIndex
   const sidebarProjectGroupHeaderIdsByBucketRef = useRef(sidebarProjectGroupHeaderIdsByBucket)
   sidebarProjectGroupHeaderIdsByBucketRef.current = sidebarProjectGroupHeaderIdsByBucket
+  const sidebarRootSlotsRef = useRef(sidebarRootSlots)
+  sidebarRootSlotsRef.current = sidebarRootSlots
   const projectGroupByIdRef = useRef(projectGroupById)
   projectGroupByIdRef.current = projectGroupById
+  const repoByIdRef = useRef(repoById)
+  repoByIdRef.current = repoById
   const onCommitProjectGroupTabOrderRef = useRef(onCommitProjectGroupTabOrder)
   onCommitProjectGroupTabOrderRef.current = onCommitProjectGroupTabOrder
+  const onCommitProjectGroupOrderRef = useRef(onCommitProjectGroupOrder)
+  onCommitProjectGroupOrderRef.current = onCommitProjectGroupOrder
   const getContainerRef = useRef(getScrollContainer)
   getContainerRef.current = getScrollContainer
-  const autoscrollLastFrameTimeRef = useRef<number | null>(null)
-  const autoscrollFrameIdRef = useRef<number | null>(null)
 
   const dragSessionRef = useRef<ProjectGroupHeaderDragSession | null>(null)
   const clickSwallowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -49,7 +57,9 @@ export function useProjectGroupHeaderDrag({
     if (!container || !session) {
       return []
     }
-    const rects = measureProjectGroupHeaderDragRects(container, session.bucketKey)
+    const rects = session.orderedRootSlots
+      ? measureSidebarRootSlotDragRects(container)
+      : measureProjectGroupHeaderDragRects(container, session.bucketKey)
     session.headerRects = rects
     return rects
   }, [])
@@ -91,13 +101,24 @@ export function useProjectGroupHeaderDrag({
     []
   )
 
-  const cancelAutoscroll = useCallback(() => {
-    if (autoscrollFrameIdRef.current !== null) {
-      window.cancelAnimationFrame(autoscrollFrameIdRef.current)
-      autoscrollFrameIdRef.current = null
-    }
-    autoscrollLastFrameTimeRef.current = null
-  }, [])
+  const endDragRef = useRef<(commit: boolean) => void>(() => {})
+  const { cancelAutoscroll, releasePointerCapture, armClickSwallow } =
+    useSidebarHeaderPointerDragSession({
+      sessionArmed,
+      dragSessionRef,
+      clickSwallowTimeoutRef,
+      getScrollContainer: () => getContainerRef.current(),
+      dragThresholdPx: PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX,
+      isDragging: state.draggingGroupId !== null,
+      refreshHeaderRects,
+      onPromoted: (session) => {
+        setState({ draggingGroupId: session.groupId, dropIndex: null, dropIndicatorY: null })
+      },
+      onPointerMoveDrop: (session, clientY) => {
+        applyDrop(session.groupId, computeDrop(clientY))
+      },
+      endDrag: (commit) => endDragRef.current(commit)
+    })
 
   const endDrag = useCallback(
     (commit: boolean) => {
@@ -108,26 +129,9 @@ export function useProjectGroupHeaderDrag({
         setSessionArmed(false)
         return
       }
-      try {
-        session.handleEl.releasePointerCapture(session.pointerId)
-      } catch {
-        // capture may already be released (pointercancel, element unmounted)
-      }
+      releasePointerCapture(session)
       if (session.promoted) {
-        const handleEl = session.handleEl
-        const swallow = (event: MouseEvent): void => {
-          const target = event.target as Node | null
-          if (target && handleEl.contains(target)) {
-            event.stopPropagation()
-            event.preventDefault()
-          }
-          window.removeEventListener('click', swallow, true)
-        }
-        window.addEventListener('click', swallow, true)
-        clickSwallowTimeoutRef.current = setTimeout(() => {
-          window.removeEventListener('click', swallow, true)
-          clickSwallowTimeoutRef.current = null
-        }, 0)
+        armClickSwallow(session)
       }
       const sidebarDropIndex =
         commit && session.promoted && latestDropIndexRef.current !== null
@@ -139,155 +143,18 @@ export function useProjectGroupHeaderDrag({
       if (sidebarDropIndex === null) {
         return
       }
-
       commitProjectGroupHeaderDragDrop({
         session,
         sidebarDropIndex,
         projectGroupById: projectGroupByIdRef.current,
-        onCommitProjectGroupTabOrder: onCommitProjectGroupTabOrderRef.current
+        repoById: repoByIdRef.current,
+        onCommitProjectGroupTabOrder: onCommitProjectGroupTabOrderRef.current,
+        onCommitProjectGroupOrder: onCommitProjectGroupOrderRef.current
       })
     },
-    [cancelAutoscroll]
+    [armClickSwallow, cancelAutoscroll, releasePointerCapture]
   )
-
-  const runAutoscrollFrame = useCallback(
-    (frameTime: number) => {
-      autoscrollFrameIdRef.current = null
-      const session = dragSessionRef.current
-      const container = getContainerRef.current()
-      if (!session?.promoted || !container) {
-        cancelAutoscroll()
-        return
-      }
-
-      const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
-      autoscrollLastFrameTimeRef.current = frameTime
-      const autoscroll = getWorktreeSidebarDragAutoscroll({
-        point: { clientX: 0, clientY: session.latestPointerY },
-        containerRect: container.getBoundingClientRect(),
-        scrollTop: container.scrollTop,
-        scrollHeight: container.scrollHeight,
-        clientHeight: container.clientHeight,
-        elapsedMs: frameTime - previousFrameTime
-      })
-      if (autoscroll) {
-        container.scrollTop = autoscroll.scrollTop
-        refreshHeaderRects()
-      }
-
-      applyDrop(session.groupId, computeDrop(session.latestPointerY))
-
-      autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
-    },
-    [applyDrop, cancelAutoscroll, computeDrop, refreshHeaderRects]
-  )
-
-  const ensureAutoscroll = useCallback(() => {
-    if (autoscrollFrameIdRef.current !== null) {
-      return
-    }
-    autoscrollLastFrameTimeRef.current = null
-    autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
-  }, [runAutoscrollFrame])
-
-  useEffect(() => {
-    if (!sessionArmed) {
-      return
-    }
-    const onPointerMove = (event: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || event.pointerId !== session.pointerId) {
-        return
-      }
-      session.latestPointerY = event.clientY
-      if (!session.promoted) {
-        const dx = event.clientX - session.startX
-        const dy = event.clientY - session.startY
-        if (
-          dx * dx + dy * dy <
-          PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX * PROJECT_GROUP_HEADER_DRAG_THRESHOLD_PX
-        ) {
-          return
-        }
-        session.promoted = true
-        // Why: virtualized headers may detach during drag; global listeners
-        // still keep the operation alive if pointer capture is unavailable.
-        if (session.handleEl.isConnected) {
-          try {
-            session.handleEl.setPointerCapture(session.pointerId)
-          } catch {
-            // Ignore capture failure; global listeners will handle the drag.
-          }
-        }
-        refreshHeaderRects()
-        setState({ draggingGroupId: session.groupId, dropIndex: null, dropIndicatorY: null })
-      }
-      refreshHeaderRects()
-      applyDrop(session.groupId, computeDrop(event.clientY))
-      ensureAutoscroll()
-    }
-    const onPointerUp = (event: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || event.pointerId !== session.pointerId) {
-        return
-      }
-      endDrag(true)
-    }
-    const onPointerCancel = (event: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || event.pointerId !== session.pointerId) {
-        return
-      }
-      endDrag(false)
-    }
-    const onKeyDown = (event: KeyboardEvent): void => {
-      if (event.key === 'Escape') {
-        endDrag(false)
-      }
-    }
-    const onBlur = (): void => endDrag(false)
-
-    window.addEventListener('pointermove', onPointerMove)
-    window.addEventListener('pointerup', onPointerUp)
-    window.addEventListener('pointercancel', onPointerCancel)
-    window.addEventListener('keydown', onKeyDown)
-    window.addEventListener('blur', onBlur)
-    return () => {
-      window.removeEventListener('pointermove', onPointerMove)
-      window.removeEventListener('pointerup', onPointerUp)
-      window.removeEventListener('pointercancel', onPointerCancel)
-      window.removeEventListener('keydown', onKeyDown)
-      window.removeEventListener('blur', onBlur)
-      cancelAutoscroll()
-      if (clickSwallowTimeoutRef.current !== null) {
-        clearTimeout(clickSwallowTimeoutRef.current)
-        clickSwallowTimeoutRef.current = null
-      }
-    }
-  }, [
-    applyDrop,
-    cancelAutoscroll,
-    computeDrop,
-    endDrag,
-    ensureAutoscroll,
-    refreshHeaderRects,
-    sessionArmed
-  ])
-
-  useEffect(() => {
-    if (state.draggingGroupId === null) {
-      return
-    }
-    const body = document.body
-    const prevCursor = body.style.cursor
-    const prevUserSelect = body.style.userSelect
-    body.style.cursor = 'grabbing'
-    body.style.userSelect = 'none'
-    return () => {
-      body.style.cursor = prevCursor
-      body.style.userSelect = prevUserSelect
-    }
-  }, [state.draggingGroupId])
+  endDragRef.current = endDrag
 
   const onHandlePointerDown = useCallback(
     (event: React.PointerEvent<HTMLElement>, groupId: string) => {
@@ -296,6 +163,7 @@ export function useProjectGroupHeaderDrag({
         groupId,
         projectGroupById: projectGroupByIdRef.current,
         sidebarProjectGroupHeaderIdsByBucket: sidebarProjectGroupHeaderIdsByBucketRef.current,
+        sidebarRootSlots: sidebarRootSlotsRef.current,
         getScrollContainer: getContainerRef.current
       })
       if (!session) {

--- a/src/renderer/src/components/sidebar/project-group-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-drop.ts
@@ -1,5 +1,6 @@
 import {
   computeWorktreeSidebarHeaderDropPreview,
+  type WorktreeSidebarHeaderDragRect,
   type WorktreeSidebarHeaderDropPreview
 } from './worktree-sidebar-header-drop-preview'
 import type { Row } from './worktree-list-groups'
@@ -182,7 +183,7 @@ export function computeProjectGroupHeaderDropPreview(args: {
   pointerY: number
   containerTop: number
   scrollTop: number
-  rects: readonly ProjectGroupHeaderDragRect[]
+  rects: readonly WorktreeSidebarHeaderDropPreviewRect[]
   sidebarProjectGroupHeaderIds: readonly string[]
   contentBottom?: number
 }): ProjectGroupHeaderDropPreview | null {
@@ -193,7 +194,17 @@ export function computeProjectGroupHeaderDropPreview(args: {
     scrollTop: args.scrollTop,
     rects,
     headerCount: sidebarProjectGroupHeaderIds.length,
-    getId: (rect) => rect.groupId,
+    getId: (rect) =>
+      'slotKey' in rect && typeof rect.slotKey === 'string'
+        ? rect.slotKey
+        : 'groupId' in rect && typeof rect.groupId === 'string'
+          ? rect.groupId
+          : String(rect.headerIndex),
     contentBottom: args.contentBottom
   })
+}
+
+type WorktreeSidebarHeaderDropPreviewRect = WorktreeSidebarHeaderDragRect & {
+  groupId?: string
+  slotKey?: string
 }

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { commitProjectHeaderDragDrop } from './project-header-drag-commit'
 import type { ProjectHeaderDragSession } from './project-header-drag-contract'
-import type { Repo } from '../../../../shared/types'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
 
 function makeRepo(id: string, overrides: Partial<Repo> = {}): Repo {
   return {
@@ -18,12 +18,14 @@ function makeRepo(id: string, overrides: Partial<Repo> = {}): Repo {
 
 function makeSession(
   repoId: string,
-  sidebarRepoHeaderIds: readonly string[]
+  sidebarRepoHeaderIds: readonly string[],
+  orderedRootSlots: ProjectHeaderDragSession['orderedRootSlots'] = null
 ): ProjectHeaderDragSession {
   return {
     repoId,
     bucketKey: 'ungrouped',
     sidebarRepoHeaderIds,
+    orderedRootSlots,
     pointerId: 1,
     headerRects: [],
     handleEl: document.createElement('div'),
@@ -45,9 +47,11 @@ describe('commitProjectHeaderDragDrop', () => {
       sidebarDropIndex: 0,
       orderedRepoIds: ['a', 'b', 'c'],
       repoById,
+      projectGroupById: new Map(),
       usesProjectGroupOrdering: false,
       onCommitRepoOrder,
-      onCommitProjectGroupOrder: vi.fn()
+      onCommitProjectGroupOrder: vi.fn(),
+      onCommitProjectGroupTabOrder: vi.fn()
     })
 
     expect(onCommitRepoOrder).toHaveBeenCalledWith(['c', 'a', 'b'])
@@ -63,9 +67,11 @@ describe('commitProjectHeaderDragDrop', () => {
       sidebarDropIndex: 0,
       orderedRepoIds: ['b', 'same', 'c', 'same'],
       repoById,
+      projectGroupById: new Map(),
       usesProjectGroupOrdering: false,
       onCommitRepoOrder,
-      onCommitProjectGroupOrder: vi.fn()
+      onCommitProjectGroupOrder: vi.fn(),
+      onCommitProjectGroupTabOrder: vi.fn()
     })
 
     expect(onCommitRepoOrder).toHaveBeenCalledWith(['same', 'same', 'b', 'c'])
@@ -81,9 +87,11 @@ describe('commitProjectHeaderDragDrop', () => {
       sidebarDropIndex: 2,
       orderedRepoIds: ['b', 'same', 'c', 'same'],
       repoById,
+      projectGroupById: new Map(),
       usesProjectGroupOrdering: false,
       onCommitRepoOrder,
-      onCommitProjectGroupOrder: vi.fn()
+      onCommitProjectGroupOrder: vi.fn(),
+      onCommitProjectGroupTabOrder: vi.fn()
     })
 
     expect(onCommitRepoOrder).not.toHaveBeenCalled()
@@ -103,11 +111,81 @@ describe('commitProjectHeaderDragDrop', () => {
       sidebarDropIndex: 0,
       orderedRepoIds: ['a', 'b', 'c'],
       repoById,
+      projectGroupById: new Map(),
       usesProjectGroupOrdering: true,
       onCommitRepoOrder: vi.fn(),
-      onCommitProjectGroupOrder
+      onCommitProjectGroupOrder,
+      onCommitProjectGroupTabOrder: vi.fn()
     })
 
     expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('c', 'group-1', -1)
+  })
+
+  it('renumbers root groups and ungrouped projects when dropping an ungrouped repo', () => {
+    const onCommitProjectGroupOrder = vi.fn()
+    const onCommitProjectGroupTabOrder = vi.fn()
+    const groups: ProjectGroup[] = [
+      {
+        id: 'group-a',
+        name: 'A',
+        parentPath: null,
+        parentGroupId: null,
+        createdFrom: 'manual',
+        tabOrder: 0,
+        isCollapsed: false,
+        color: null,
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: 'group-b',
+        name: 'B',
+        parentPath: null,
+        parentGroupId: null,
+        createdFrom: 'manual',
+        tabOrder: 1,
+        isCollapsed: false,
+        color: null,
+        createdAt: 1,
+        updatedAt: 1
+      }
+    ]
+    const repos = [
+      makeRepo('repo-x', { projectGroupId: null, projectGroupOrder: 2 }),
+      makeRepo('repo-y', { projectGroupId: null, projectGroupOrder: 3 })
+    ]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+    const repoById = new Map(repos.map((repo) => [repo.id, repo]))
+    const orderedRootSlots = [
+      { kind: 'project-group' as const, id: 'group-a' },
+      { kind: 'project-group' as const, id: 'group-b' },
+      { kind: 'repo' as const, id: 'repo-x' },
+      { kind: 'repo' as const, id: 'repo-y' }
+    ]
+
+    commitProjectHeaderDragDrop({
+      session: makeSession(
+        'repo-y',
+        orderedRootSlots.map((slot) =>
+          slot.kind === 'project-group' ? `project-group:${slot.id}` : `repo:${slot.id}`
+        ),
+        orderedRootSlots
+      ),
+      // Drop repo-y between the two groups → [group-a, repo-y, group-b, repo-x]
+      sidebarDropIndex: 1,
+      orderedRepoIds: ['repo-x', 'repo-y'],
+      repoById,
+      projectGroupById,
+      usesProjectGroupOrdering: true,
+      onCommitRepoOrder: vi.fn(),
+      onCommitProjectGroupOrder,
+      onCommitProjectGroupTabOrder
+    })
+
+    expect(onCommitProjectGroupTabOrder.mock.calls).toEqual([['group-b', 2]])
+    expect(onCommitProjectGroupOrder.mock.calls).toEqual([
+      ['repo-y', null, 1],
+      ['repo-x', null, 3]
+    ])
   })
 })

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.ts
@@ -6,19 +6,53 @@ import {
   mapSidebarRepoDropIndexToAllRepoInsertAt
 } from './project-header-drop'
 import type { ProjectHeaderDragSession } from './project-header-drag-contract'
-import type { Repo } from '../../../../shared/types'
+import {
+  applyRootSlotOrderUpdates,
+  getRootSlotOrderUpdatesForSidebarDrop
+} from './sidebar-root-slot-order'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
 
 export function commitProjectHeaderDragDrop(args: {
   session: ProjectHeaderDragSession
   sidebarDropIndex: number
   orderedRepoIds: readonly string[]
   repoById: ReadonlyMap<string, Repo>
+  projectGroupById: ReadonlyMap<string, ProjectGroup>
   usesProjectGroupOrdering: boolean
   onCommitRepoOrder: (orderedIds: string[]) => void
   onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
+  onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
 }): void {
   const draggedRepo = args.repoById.get(args.session.repoId)
   if (!draggedRepo) {
+    return
+  }
+
+  const orderedRootSlots = args.session.orderedRootSlots
+  if (orderedRootSlots && orderedRootSlots.length > 0) {
+    const sourceIndex = orderedRootSlots.findIndex(
+      (slot) => slot.kind === 'repo' && slot.id === args.session.repoId
+    )
+    // Why: both slots bordering the dragged header are visual no-ops.
+    if (
+      sourceIndex === -1 ||
+      args.sidebarDropIndex === sourceIndex ||
+      args.sidebarDropIndex === sourceIndex + 1
+    ) {
+      return
+    }
+    const updates = getRootSlotOrderUpdatesForSidebarDrop({
+      orderedRootSlots,
+      dragged: { kind: 'repo', id: args.session.repoId },
+      sidebarDropIndex: args.sidebarDropIndex,
+      projectGroupById: args.projectGroupById,
+      repoById: args.repoById
+    })
+    applyRootSlotOrderUpdates({
+      updates,
+      onCommitProjectGroupTabOrder: args.onCommitProjectGroupTabOrder,
+      onCommitProjectGroupOrder: args.onCommitProjectGroupOrder
+    })
     return
   }
 

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -1,7 +1,8 @@
 import type { PointerEvent } from 'react'
 
 import type { ProjectHeaderDragBucketKey, ProjectHeaderDragRect } from './project-header-drop'
-import type { Repo } from '../../../../shared/types'
+import type { SidebarRootSlot, SidebarRootSlotDragRect } from './sidebar-root-slot-order'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
 
 export type RepoDragState = {
   draggingRepoId: string | null
@@ -18,10 +19,13 @@ export const INITIAL_REPO_DRAG_STATE: RepoDragState = {
 export type UseRepoHeaderDragArgs = {
   orderedRepoIds: string[]
   sidebarRepoHeaderIdsByBucket: ReadonlyMap<ProjectHeaderDragBucketKey, readonly string[]>
+  sidebarRootSlots: readonly SidebarRootSlot[]
   repoById: ReadonlyMap<string, Repo>
+  projectGroupById: ReadonlyMap<string, ProjectGroup>
   usesProjectGroupOrdering: boolean
   onCommitRepoOrder: (orderedIds: string[]) => void
   onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
+  onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
   getScrollContainer: () => HTMLElement | null
 }
 
@@ -34,8 +38,10 @@ export type ProjectHeaderDragSession = {
   repoId: string
   bucketKey: ProjectHeaderDragBucketKey
   sidebarRepoHeaderIds: readonly string[]
+  /** When set, ungrouped root drop renumbers groups + projects as one list. */
+  orderedRootSlots: readonly SidebarRootSlot[] | null
   pointerId: number
-  headerRects: ProjectHeaderDragRect[]
+  headerRects: (ProjectHeaderDragRect | SidebarRootSlotDragRect)[]
   handleEl: HTMLElement
   startX: number
   startY: number

--- a/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
@@ -39,6 +39,8 @@ describe('createProjectHeaderDragSession', () => {
       repoId: 'repo-a',
       repoById,
       sidebarRepoHeaderIdsByBucket,
+      sidebarRootSlots: [],
+      usesProjectGroupOrdering: false,
       getScrollContainer: () => scrollContainer
     })
 
@@ -69,6 +71,8 @@ describe('createProjectHeaderDragSession', () => {
       repoId: 'repo-a',
       repoById,
       sidebarRepoHeaderIdsByBucket,
+      sidebarRootSlots: [],
+      usesProjectGroupOrdering: false,
       getScrollContainer: () => scrollContainer
     })
 
@@ -100,6 +104,8 @@ describe('createProjectHeaderDragSession', () => {
       repoId: 'repo-a',
       repoById,
       sidebarRepoHeaderIdsByBucket,
+      sidebarRootSlots: [],
+      usesProjectGroupOrdering: false,
       getScrollContainer: () => scrollContainer
     })
 
@@ -132,6 +138,8 @@ describe('createProjectHeaderDragSession', () => {
       repoId: 'repo-a',
       repoById,
       sidebarRepoHeaderIdsByBucket,
+      sidebarRootSlots: [],
+      usesProjectGroupOrdering: false,
       getScrollContainer: () => scrollContainer
     })
 

--- a/src/renderer/src/components/sidebar/project-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.ts
@@ -10,6 +10,11 @@ import {
   isRepoHeaderActionTarget,
   type ProjectHeaderDragSession
 } from './project-header-drag-contract'
+import {
+  encodeSidebarRootSlotKey,
+  measureSidebarRootSlotDragRects,
+  type SidebarRootSlot
+} from './sidebar-root-slot-order'
 import type { Repo } from '../../../../shared/types'
 
 export function createProjectHeaderDragSession(args: {
@@ -17,6 +22,8 @@ export function createProjectHeaderDragSession(args: {
   repoId: string
   repoById: ReadonlyMap<string, Repo>
   sidebarRepoHeaderIdsByBucket: ReadonlyMap<ProjectHeaderDragBucketKey, readonly string[]>
+  sidebarRootSlots: readonly SidebarRootSlot[]
+  usesProjectGroupOrdering: boolean
   getScrollContainer: () => HTMLElement | null
 }): ProjectHeaderDragSession | null {
   if (args.event.button !== 0) {
@@ -33,10 +40,16 @@ export function createProjectHeaderDragSession(args: {
     return null
   }
   const bucketKey = getProjectHeaderDragBucketKey(repo)
+  const usesRootSlotOrdering =
+    args.usesProjectGroupOrdering && bucketKey === 'ungrouped' && args.sidebarRootSlots.length > 1
   const sidebarRepoHeaderIds = args.sidebarRepoHeaderIdsByBucket.get(bucketKey) ?? []
   // Why: a single project in its bucket has nowhere to land, so skip arming
-  // drag and let the header click toggle collapse instead.
-  if (sidebarRepoHeaderIds.length <= 1) {
+  // drag and let the header click toggle collapse instead. Root interleave can
+  // still move one ungrouped project against groups.
+  if (!usesRootSlotOrdering && sidebarRepoHeaderIds.length <= 1) {
+    return null
+  }
+  if (usesRootSlotOrdering && args.sidebarRootSlots.length <= 1) {
     return null
   }
   const container = args.getScrollContainer()
@@ -44,14 +57,20 @@ export function createProjectHeaderDragSession(args: {
     return null
   }
   const handleEl = args.event.currentTarget
+  const orderedRootSlots = usesRootSlotOrdering ? args.sidebarRootSlots : null
   // Why: defer setPointerCapture until the drag threshold is crossed so a
   // header click still reaches the inner collapse handler on pointerup.
   return {
     repoId: args.repoId,
     bucketKey,
-    sidebarRepoHeaderIds,
+    sidebarRepoHeaderIds: usesRootSlotOrdering
+      ? orderedRootSlots!.map(encodeSidebarRootSlotKey)
+      : sidebarRepoHeaderIds,
+    orderedRootSlots,
     pointerId: args.event.pointerId,
-    headerRects: measureProjectHeaderDragRects(container, bucketKey),
+    headerRects: usesRootSlotOrdering
+      ? measureSidebarRootSlotDragRects(container)
+      : measureProjectHeaderDragRects(container, bucketKey),
     handleEl,
     startX: args.event.clientX,
     startY: args.event.clientY,

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 
 import {
   computeProjectHeaderDropPreview,
   measureProjectHeaderDragRects
 } from './project-header-drop'
 import { commitProjectHeaderDragDrop } from './project-header-drag-commit'
+import { measureSidebarRootSlotDragRects } from './sidebar-root-slot-order'
 import {
   INITIAL_REPO_DRAG_STATE,
   PROJECT_HEADER_DRAG_THRESHOLD_PX,
@@ -14,7 +15,7 @@ import {
   type UseRepoHeaderDragArgs
 } from './project-header-drag-contract'
 import { createProjectHeaderDragSession } from './project-header-drag-start'
-import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+import { useSidebarHeaderPointerDragSession } from './sidebar-header-pointer-drag-session'
 
 // Why pointer events instead of HTML5 DnD: rows are absolutely-positioned by
 // react-virtual and unmount/remount as scroll changes, so DnD enter/leave fire
@@ -24,10 +25,13 @@ import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autosc
 export function useRepoHeaderDrag({
   orderedRepoIds,
   sidebarRepoHeaderIdsByBucket,
+  sidebarRootSlots,
   repoById,
+  projectGroupById,
   usesProjectGroupOrdering,
   onCommitRepoOrder,
   onCommitProjectGroupOrder,
+  onCommitProjectGroupTabOrder,
   getScrollContainer
 }: UseRepoHeaderDragArgs): RepoHeaderDragController {
   const [state, setState] = useState<RepoDragState>(INITIAL_REPO_DRAG_STATE)
@@ -38,18 +42,22 @@ export function useRepoHeaderDrag({
   orderedIdsRef.current = orderedRepoIds
   const sidebarRepoHeaderIdsByBucketRef = useRef(sidebarRepoHeaderIdsByBucket)
   sidebarRepoHeaderIdsByBucketRef.current = sidebarRepoHeaderIdsByBucket
+  const sidebarRootSlotsRef = useRef(sidebarRootSlots)
+  sidebarRootSlotsRef.current = sidebarRootSlots
   const repoByIdRef = useRef(repoById)
   repoByIdRef.current = repoById
+  const projectGroupByIdRef = useRef(projectGroupById)
+  projectGroupByIdRef.current = projectGroupById
   const usesProjectGroupOrderingRef = useRef(usesProjectGroupOrdering)
   usesProjectGroupOrderingRef.current = usesProjectGroupOrdering
   const onCommitRepoOrderRef = useRef(onCommitRepoOrder)
   onCommitRepoOrderRef.current = onCommitRepoOrder
   const onCommitProjectGroupOrderRef = useRef(onCommitProjectGroupOrder)
   onCommitProjectGroupOrderRef.current = onCommitProjectGroupOrder
+  const onCommitProjectGroupTabOrderRef = useRef(onCommitProjectGroupTabOrder)
+  onCommitProjectGroupTabOrderRef.current = onCommitProjectGroupTabOrder
   const getContainerRef = useRef(getScrollContainer)
   getContainerRef.current = getScrollContainer
-  const autoscrollLastFrameTimeRef = useRef<number | null>(null)
-  const autoscrollFrameIdRef = useRef<number | null>(null)
 
   const dragSessionRef = useRef<ProjectHeaderDragSession | null>(null)
   const clickSwallowTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -60,7 +68,9 @@ export function useRepoHeaderDrag({
     if (!container || !session) {
       return []
     }
-    const rects = measureProjectHeaderDragRects(container, session.bucketKey)
+    const rects = session.orderedRootSlots
+      ? measureSidebarRootSlotDragRects(container)
+      : measureProjectHeaderDragRects(container, session.bucketKey)
     session.headerRects = rects
     return rects
   }, [])
@@ -101,13 +111,24 @@ export function useRepoHeaderDrag({
     []
   )
 
-  const cancelAutoscroll = useCallback(() => {
-    if (autoscrollFrameIdRef.current !== null) {
-      window.cancelAnimationFrame(autoscrollFrameIdRef.current)
-      autoscrollFrameIdRef.current = null
-    }
-    autoscrollLastFrameTimeRef.current = null
-  }, [])
+  const endDragRef = useRef<(commit: boolean) => void>(() => {})
+  const { cancelAutoscroll, releasePointerCapture, armClickSwallow } =
+    useSidebarHeaderPointerDragSession({
+      sessionArmed,
+      dragSessionRef,
+      clickSwallowTimeoutRef,
+      getScrollContainer: () => getContainerRef.current(),
+      dragThresholdPx: PROJECT_HEADER_DRAG_THRESHOLD_PX,
+      isDragging: state.draggingRepoId !== null,
+      refreshHeaderRects,
+      onPromoted: (session) => {
+        setState({ draggingRepoId: session.repoId, dropIndex: null, dropIndicatorY: null })
+      },
+      onPointerMoveDrop: (session, clientY) => {
+        applyDrop(session.repoId, computeDrop(clientY))
+      },
+      endDrag: (commit) => endDragRef.current(commit)
+    })
 
   const endDrag = useCallback(
     (commit: boolean) => {
@@ -118,26 +139,9 @@ export function useRepoHeaderDrag({
         setSessionArmed(false)
         return
       }
-      try {
-        session.handleEl.releasePointerCapture(session.pointerId)
-      } catch {
-        // capture may already be released (pointercancel, element unmounted)
-      }
+      releasePointerCapture(session)
       if (session.promoted) {
-        const handleEl = session.handleEl
-        const swallow = (e: MouseEvent): void => {
-          const target = e.target as Node | null
-          if (target && handleEl.contains(target)) {
-            e.stopPropagation()
-            e.preventDefault()
-          }
-          window.removeEventListener('click', swallow, true)
-        }
-        window.addEventListener('click', swallow, true)
-        clickSwallowTimeoutRef.current = setTimeout(() => {
-          window.removeEventListener('click', swallow, true)
-          clickSwallowTimeoutRef.current = null
-        }, 0)
+        armClickSwallow(session)
       }
       const sidebarDropIndex =
         commit && session.promoted && latestDropIndexRef.current !== null
@@ -149,159 +153,21 @@ export function useRepoHeaderDrag({
       if (sidebarDropIndex === null) {
         return
       }
-
       commitProjectHeaderDragDrop({
         session,
         sidebarDropIndex,
         orderedRepoIds: orderedIdsRef.current,
         repoById: repoByIdRef.current,
+        projectGroupById: projectGroupByIdRef.current,
         usesProjectGroupOrdering: usesProjectGroupOrderingRef.current,
         onCommitRepoOrder: onCommitRepoOrderRef.current,
-        onCommitProjectGroupOrder: onCommitProjectGroupOrderRef.current
+        onCommitProjectGroupOrder: onCommitProjectGroupOrderRef.current,
+        onCommitProjectGroupTabOrder: onCommitProjectGroupTabOrderRef.current
       })
     },
-    [cancelAutoscroll]
+    [armClickSwallow, cancelAutoscroll, releasePointerCapture]
   )
-
-  const runAutoscrollFrame = useCallback(
-    (frameTime: number) => {
-      autoscrollFrameIdRef.current = null
-      const session = dragSessionRef.current
-      const container = getContainerRef.current()
-      if (!session?.promoted || !container) {
-        cancelAutoscroll()
-        return
-      }
-
-      const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
-      autoscrollLastFrameTimeRef.current = frameTime
-      const autoscroll = getWorktreeSidebarDragAutoscroll({
-        point: { clientX: 0, clientY: session.latestPointerY },
-        containerRect: container.getBoundingClientRect(),
-        scrollTop: container.scrollTop,
-        scrollHeight: container.scrollHeight,
-        clientHeight: container.clientHeight,
-        elapsedMs: frameTime - previousFrameTime
-      })
-      if (autoscroll) {
-        container.scrollTop = autoscroll.scrollTop
-        refreshHeaderRects()
-      }
-
-      applyDrop(session.repoId, computeDrop(session.latestPointerY))
-
-      autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
-    },
-    [applyDrop, cancelAutoscroll, computeDrop, refreshHeaderRects]
-  )
-
-  const ensureAutoscroll = useCallback(() => {
-    if (autoscrollFrameIdRef.current !== null) {
-      return
-    }
-    autoscrollLastFrameTimeRef.current = null
-    autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
-  }, [runAutoscrollFrame])
-
-  useEffect(() => {
-    if (!sessionArmed) {
-      return
-    }
-    const onPointerMove = (e: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || e.pointerId !== session.pointerId) {
-        return
-      }
-      session.latestPointerY = e.clientY
-      if (!session.promoted) {
-        const dx = e.clientX - session.startX
-        const dy = e.clientY - session.startY
-        if (
-          dx * dx + dy * dy <
-          PROJECT_HEADER_DRAG_THRESHOLD_PX * PROJECT_HEADER_DRAG_THRESHOLD_PX
-        ) {
-          return
-        }
-        session.promoted = true
-        // Why: setPointerCapture can throw if the element is detached. Check
-        // isConnected first to avoid the throw; the global pointer listeners
-        // still fire, so dragging keeps working even if capture fails.
-        if (session.handleEl.isConnected) {
-          try {
-            session.handleEl.setPointerCapture(session.pointerId)
-          } catch {
-            // Ignore capture failure; global listeners will handle the drag.
-          }
-        }
-        refreshHeaderRects()
-        setState({ draggingRepoId: session.repoId, dropIndex: null, dropIndicatorY: null })
-      }
-      refreshHeaderRects()
-      applyDrop(session.repoId, computeDrop(e.clientY))
-      ensureAutoscroll()
-    }
-    const onPointerUp = (e: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || e.pointerId !== session.pointerId) {
-        return
-      }
-      endDrag(true)
-    }
-    const onPointerCancel = (e: PointerEvent): void => {
-      const session = dragSessionRef.current
-      if (!session || e.pointerId !== session.pointerId) {
-        return
-      }
-      endDrag(false)
-    }
-    const onKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === 'Escape') {
-        endDrag(false)
-      }
-    }
-    const onBlur = (): void => endDrag(false)
-
-    window.addEventListener('pointermove', onPointerMove)
-    window.addEventListener('pointerup', onPointerUp)
-    window.addEventListener('pointercancel', onPointerCancel)
-    window.addEventListener('keydown', onKeyDown)
-    window.addEventListener('blur', onBlur)
-    return () => {
-      window.removeEventListener('pointermove', onPointerMove)
-      window.removeEventListener('pointerup', onPointerUp)
-      window.removeEventListener('pointercancel', onPointerCancel)
-      window.removeEventListener('keydown', onKeyDown)
-      window.removeEventListener('blur', onBlur)
-      cancelAutoscroll()
-      if (clickSwallowTimeoutRef.current !== null) {
-        clearTimeout(clickSwallowTimeoutRef.current)
-        clickSwallowTimeoutRef.current = null
-      }
-    }
-  }, [
-    applyDrop,
-    cancelAutoscroll,
-    computeDrop,
-    endDrag,
-    ensureAutoscroll,
-    refreshHeaderRects,
-    sessionArmed
-  ])
-
-  useEffect(() => {
-    if (state.draggingRepoId === null) {
-      return
-    }
-    const body = document.body
-    const prevCursor = body.style.cursor
-    const prevUserSelect = body.style.userSelect
-    body.style.cursor = 'grabbing'
-    body.style.userSelect = 'none'
-    return () => {
-      body.style.cursor = prevCursor
-      body.style.userSelect = prevUserSelect
-    }
-  }, [state.draggingRepoId])
+  endDragRef.current = endDrag
 
   const onHandlePointerDown = useCallback(
     (event: React.PointerEvent<HTMLElement>, repoId: string) => {
@@ -310,6 +176,8 @@ export function useRepoHeaderDrag({
         repoId,
         repoById: repoByIdRef.current,
         sidebarRepoHeaderIdsByBucket: sidebarRepoHeaderIdsByBucketRef.current,
+        sidebarRootSlots: sidebarRootSlotsRef.current,
+        usesProjectGroupOrdering: usesProjectGroupOrderingRef.current,
         getScrollContainer: getContainerRef.current
       })
       if (!session) {

--- a/src/renderer/src/components/sidebar/project-header-drop.ts
+++ b/src/renderer/src/components/sidebar/project-header-drop.ts
@@ -1,6 +1,7 @@
 import { getEffectiveProjectGroupManualRank } from '../../../../shared/project-groups'
 import {
   computeWorktreeSidebarHeaderDropPreview,
+  type WorktreeSidebarHeaderDragRect,
   type WorktreeSidebarHeaderDropPreview
 } from './worktree-sidebar-header-drop-preview'
 import type { Row } from './worktree-list-groups'
@@ -196,7 +197,7 @@ export function computeProjectHeaderDropPreview(args: {
   pointerY: number
   containerTop: number
   scrollTop: number
-  rects: readonly ProjectHeaderDragRect[]
+  rects: readonly WorktreeSidebarHeaderDropPreviewRect[]
   sidebarRepoHeaderIds: readonly string[]
   contentBottom?: number
 }): ProjectHeaderDropPreview | null {
@@ -207,9 +208,19 @@ export function computeProjectHeaderDropPreview(args: {
     scrollTop: args.scrollTop,
     rects,
     headerCount: sidebarRepoHeaderIds.length,
-    getId: (rect) => rect.repoId,
+    getId: (rect) =>
+      'slotKey' in rect && typeof rect.slotKey === 'string'
+        ? rect.slotKey
+        : 'repoId' in rect && typeof rect.repoId === 'string'
+          ? rect.repoId
+          : String(rect.headerIndex),
     contentBottom: args.contentBottom
   })
+}
+
+type WorktreeSidebarHeaderDropPreviewRect = WorktreeSidebarHeaderDragRect & {
+  repoId?: string
+  slotKey?: string
 }
 
 export function applyAllRepoInsertAt(

--- a/src/renderer/src/components/sidebar/sidebar-header-pointer-drag-session.ts
+++ b/src/renderer/src/components/sidebar/sidebar-header-pointer-drag-session.ts
@@ -1,0 +1,215 @@
+import { useCallback, useEffect, useRef, type MutableRefObject } from 'react'
+
+import { getWorktreeSidebarDragAutoscroll } from './worktree-sidebar-drag-autoscroll'
+
+export type SidebarHeaderPointerDragSessionBase = {
+  pointerId: number
+  handleEl: HTMLElement
+  startX: number
+  startY: number
+  latestPointerY: number
+  promoted: boolean
+}
+
+/** Shared window listeners + autoscroll for virtualized sidebar header drags. */
+export function useSidebarHeaderPointerDragSession<
+  TSession extends SidebarHeaderPointerDragSessionBase
+>(args: {
+  sessionArmed: boolean
+  dragSessionRef: MutableRefObject<TSession | null>
+  clickSwallowTimeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null>
+  getScrollContainer: () => HTMLElement | null
+  dragThresholdPx: number
+  isDragging: boolean
+  refreshHeaderRects: () => void
+  onPromoted: (session: TSession) => void
+  onPointerMoveDrop: (session: TSession, clientY: number) => void
+  endDrag: (commit: boolean) => void
+}): {
+  cancelAutoscroll: () => void
+  releasePointerCapture: (session: TSession) => void
+  armClickSwallow: (session: TSession) => void
+} {
+  const autoscrollLastFrameTimeRef = useRef<number | null>(null)
+  const autoscrollFrameIdRef = useRef<number | null>(null)
+  const getContainerRef = useRef(args.getScrollContainer)
+  getContainerRef.current = args.getScrollContainer
+  const refreshHeaderRectsRef = useRef(args.refreshHeaderRects)
+  refreshHeaderRectsRef.current = args.refreshHeaderRects
+  const onPointerMoveDropRef = useRef(args.onPointerMoveDrop)
+  onPointerMoveDropRef.current = args.onPointerMoveDrop
+  const onPromotedRef = useRef(args.onPromoted)
+  onPromotedRef.current = args.onPromoted
+  const endDragRef = useRef(args.endDrag)
+  endDragRef.current = args.endDrag
+  const dragThresholdPx = args.dragThresholdPx
+
+  const cancelAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      window.cancelAnimationFrame(autoscrollFrameIdRef.current)
+      autoscrollFrameIdRef.current = null
+    }
+    autoscrollLastFrameTimeRef.current = null
+  }, [])
+
+  const runAutoscrollFrame = useCallback(
+    (frameTime: number) => {
+      autoscrollFrameIdRef.current = null
+      const session = args.dragSessionRef.current
+      const container = getContainerRef.current()
+      if (!session?.promoted || !container) {
+        cancelAutoscroll()
+        return
+      }
+      const previousFrameTime = autoscrollLastFrameTimeRef.current ?? frameTime
+      autoscrollLastFrameTimeRef.current = frameTime
+      const autoscroll = getWorktreeSidebarDragAutoscroll({
+        point: { clientX: 0, clientY: session.latestPointerY },
+        containerRect: container.getBoundingClientRect(),
+        scrollTop: container.scrollTop,
+        scrollHeight: container.scrollHeight,
+        clientHeight: container.clientHeight,
+        elapsedMs: frameTime - previousFrameTime
+      })
+      if (autoscroll) {
+        container.scrollTop = autoscroll.scrollTop
+        refreshHeaderRectsRef.current()
+      }
+      onPointerMoveDropRef.current(session, session.latestPointerY)
+      autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+    },
+    [args.dragSessionRef, cancelAutoscroll]
+  )
+
+  const ensureAutoscroll = useCallback(() => {
+    if (autoscrollFrameIdRef.current !== null) {
+      return
+    }
+    autoscrollLastFrameTimeRef.current = null
+    autoscrollFrameIdRef.current = window.requestAnimationFrame(runAutoscrollFrame)
+  }, [runAutoscrollFrame])
+
+  const releasePointerCapture = useCallback((session: TSession) => {
+    try {
+      session.handleEl.releasePointerCapture(session.pointerId)
+    } catch {
+      // capture may already be released (pointercancel, element unmounted)
+    }
+  }, [])
+
+  const armClickSwallow = useCallback(
+    (session: TSession) => {
+      const handleEl = session.handleEl
+      const swallow = (event: MouseEvent): void => {
+        const target = event.target as Node | null
+        if (target && handleEl.contains(target)) {
+          event.stopPropagation()
+          event.preventDefault()
+        }
+        window.removeEventListener('click', swallow, true)
+      }
+      window.addEventListener('click', swallow, true)
+      args.clickSwallowTimeoutRef.current = setTimeout(() => {
+        window.removeEventListener('click', swallow, true)
+        args.clickSwallowTimeoutRef.current = null
+      }, 0)
+    },
+    [args.clickSwallowTimeoutRef]
+  )
+
+  useEffect(() => {
+    if (!args.sessionArmed) {
+      return
+    }
+    const onPointerMove = (event: PointerEvent): void => {
+      const session = args.dragSessionRef.current
+      if (!session || event.pointerId !== session.pointerId) {
+        return
+      }
+      session.latestPointerY = event.clientY
+      if (!session.promoted) {
+        const dx = event.clientX - session.startX
+        const dy = event.clientY - session.startY
+        if (dx * dx + dy * dy < dragThresholdPx * dragThresholdPx) {
+          return
+        }
+        session.promoted = true
+        // Why: virtualized headers may detach; global listeners keep drag alive.
+        if (session.handleEl.isConnected) {
+          try {
+            session.handleEl.setPointerCapture(session.pointerId)
+          } catch {
+            // Ignore capture failure; global listeners will handle the drag.
+          }
+        }
+        refreshHeaderRectsRef.current()
+        onPromotedRef.current(session)
+      }
+      refreshHeaderRectsRef.current()
+      onPointerMoveDropRef.current(session, event.clientY)
+      ensureAutoscroll()
+    }
+    const onPointerUp = (event: PointerEvent): void => {
+      const session = args.dragSessionRef.current
+      if (!session || event.pointerId !== session.pointerId) {
+        return
+      }
+      endDragRef.current(true)
+    }
+    const onPointerCancel = (event: PointerEvent): void => {
+      const session = args.dragSessionRef.current
+      if (!session || event.pointerId !== session.pointerId) {
+        return
+      }
+      endDragRef.current(false)
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        endDragRef.current(false)
+      }
+    }
+    const onBlur = (): void => endDragRef.current(false)
+
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+    window.addEventListener('pointercancel', onPointerCancel)
+    window.addEventListener('keydown', onKeyDown)
+    window.addEventListener('blur', onBlur)
+    return () => {
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+      window.removeEventListener('pointercancel', onPointerCancel)
+      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('blur', onBlur)
+      cancelAutoscroll()
+      if (args.clickSwallowTimeoutRef.current !== null) {
+        clearTimeout(args.clickSwallowTimeoutRef.current)
+        args.clickSwallowTimeoutRef.current = null
+      }
+    }
+  }, [
+    args.clickSwallowTimeoutRef,
+    args.dragSessionRef,
+    args.sessionArmed,
+    cancelAutoscroll,
+    dragThresholdPx,
+    ensureAutoscroll
+  ])
+
+  useEffect(() => {
+    if (!args.isDragging) {
+      return
+    }
+    const body = document.body
+    const prevCursor = body.style.cursor
+    const prevUserSelect = body.style.userSelect
+    body.style.cursor = 'grabbing'
+    body.style.userSelect = 'none'
+    return () => {
+      body.style.cursor = prevCursor
+      body.style.userSelect = prevUserSelect
+    }
+  }, [args.isDragging])
+
+  return { cancelAutoscroll, releasePointerCapture, armClickSwallow }
+}

--- a/src/renderer/src/components/sidebar/sidebar-root-slot-order.test.ts
+++ b/src/renderer/src/components/sidebar/sidebar-root-slot-order.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getRootSlotOrderUpdatesForSidebarDrop,
+  getSidebarOrderedRootSlots,
+  getSidebarRootSlotRank
+} from './sidebar-root-slot-order'
+import type { Row } from './worktree-list-groups'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
+
+function group(id: string, overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function repo(id: string, overrides: Partial<Repo> = {}): Repo {
+  return {
+    id,
+    path: `/${id}`,
+    displayName: id,
+    badgeColor: '#000',
+    addedAt: 0,
+    ...overrides
+  } as Repo
+}
+
+function headerRow(partial: Partial<Row> & { key: string }): Row {
+  return {
+    type: 'header',
+    label: partial.key,
+    count: 0,
+    tone: '',
+    ...partial
+  } as Row
+}
+
+describe('getSidebarRootSlotRank', () => {
+  it('ranks groups by tabOrder', () => {
+    expect(
+      getSidebarRootSlotRank({
+        kind: 'project-group',
+        tabOrder: 3,
+        maxRootGroupTabOrder: 5,
+        ungroupedFallbackIndex: 0
+      })
+    ).toBe(3)
+  })
+
+  it('uses explicit projectGroupOrder for ungrouped projects', () => {
+    expect(
+      getSidebarRootSlotRank({
+        kind: 'repo',
+        projectGroupOrder: 1,
+        maxRootGroupTabOrder: 5,
+        ungroupedFallbackIndex: 0
+      })
+    ).toBe(1)
+  })
+
+  it('sinks ungrouped projects without projectGroupOrder after every group', () => {
+    expect(
+      getSidebarRootSlotRank({
+        kind: 'repo',
+        projectGroupOrder: null,
+        maxRootGroupTabOrder: 2,
+        ungroupedFallbackIndex: 0
+      })
+    ).toBe(3)
+    expect(
+      getSidebarRootSlotRank({
+        kind: 'repo',
+        projectGroupOrder: undefined,
+        maxRootGroupTabOrder: 2,
+        ungroupedFallbackIndex: 1
+      })
+    ).toBe(4)
+  })
+})
+
+describe('getSidebarOrderedRootSlots', () => {
+  it('collects depth-0 group and ungrouped repo headers in visual order', () => {
+    const rootA = group('a')
+    const rootB = group('b')
+    const child = group('child', { parentGroupId: rootA.id })
+    const ungrouped = repo('u1')
+    const nested = repo('nested', { projectGroupId: rootA.id })
+
+    const rows = [
+      headerRow({ key: 'project-group:a', projectGroup: rootA, projectGroupDepth: 0 }),
+      headerRow({ key: 'repo:nested', repo: nested, projectGroupDepth: 1 }),
+      headerRow({
+        key: 'project-group:child',
+        projectGroup: child,
+        projectGroupDepth: 1
+      }),
+      headerRow({ key: 'repo:u1', repo: ungrouped, projectGroupDepth: 0 }),
+      headerRow({ key: 'project-group:b', projectGroup: rootB, projectGroupDepth: 0 })
+    ]
+
+    expect(getSidebarOrderedRootSlots(rows)).toEqual([
+      { kind: 'project-group', id: 'a' },
+      { kind: 'repo', id: 'u1' },
+      { kind: 'project-group', id: 'b' }
+    ])
+  })
+})
+
+describe('getRootSlotOrderUpdatesForSidebarDrop', () => {
+  it('densely renumbers both tabOrder and projectGroupOrder', () => {
+    const groups = [group('a', { tabOrder: 0 }), group('b', { tabOrder: 1 })]
+    const repos = [repo('x', { projectGroupOrder: 2 }), repo('y', { projectGroupOrder: 3 })]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+    const repoById = new Map(repos.map((entry) => [entry.id, entry]))
+    const orderedRootSlots = [
+      { kind: 'project-group' as const, id: 'a' },
+      { kind: 'project-group' as const, id: 'b' },
+      { kind: 'repo' as const, id: 'x' },
+      { kind: 'repo' as const, id: 'y' }
+    ]
+
+    // Move y between the groups: [a, y, b, x]
+    expect(
+      getRootSlotOrderUpdatesForSidebarDrop({
+        orderedRootSlots,
+        dragged: { kind: 'repo', id: 'y' },
+        sidebarDropIndex: 1,
+        projectGroupById,
+        repoById
+      })
+    ).toEqual([
+      { kind: 'repo', repoId: 'y', projectGroupOrder: 1 },
+      { kind: 'project-group', groupId: 'b', tabOrder: 2 },
+      { kind: 'repo', repoId: 'x', projectGroupOrder: 3 }
+    ])
+    // a stays at index 0 with tabOrder 0 — omitted from updates.
+  })
+
+  it('returns no updates when the drop keeps the slot in place', () => {
+    const groups = [group('a', { tabOrder: 0 }), group('b', { tabOrder: 1 })]
+    const projectGroupById = new Map(groups.map((entry) => [entry.id, entry]))
+
+    expect(
+      getRootSlotOrderUpdatesForSidebarDrop({
+        orderedRootSlots: [
+          { kind: 'project-group', id: 'a' },
+          { kind: 'project-group', id: 'b' }
+        ],
+        dragged: { kind: 'project-group', id: 'a' },
+        sidebarDropIndex: 1,
+        projectGroupById,
+        repoById: new Map()
+      })
+    ).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/sidebar-root-slot-order.ts
+++ b/src/renderer/src/components/sidebar/sidebar-root-slot-order.ts
@@ -1,0 +1,252 @@
+import type { Row } from './worktree-list-groups'
+import type { ProjectGroup, Repo } from '../../../../shared/types'
+import type { WorktreeSidebarHeaderDragRect } from './worktree-sidebar-header-drop-preview'
+
+function mapSidebarRootDropIndexToSiblingInsertIndex(args: {
+  sidebarDropIndex: number
+  sourceIndex: number
+  siblingCount: number
+}): number {
+  // Why: sidebar drop indices include the dragged header; order is computed
+  // against the sibling list after that header is removed.
+  const adjustedDropIndex =
+    args.sourceIndex >= 0 && args.sidebarDropIndex > args.sourceIndex
+      ? args.sidebarDropIndex - 1
+      : args.sidebarDropIndex
+  return Math.max(0, Math.min(args.siblingCount, adjustedDropIndex))
+}
+
+/** One root-level sidebar slot: either a top-level Project Group or an ungrouped project. */
+export type SidebarRootSlot = { kind: 'project-group'; id: string } | { kind: 'repo'; id: string }
+
+export type RootSlotOrderUpdate =
+  | { kind: 'project-group'; groupId: string; tabOrder: number }
+  | { kind: 'repo'; repoId: string; projectGroupOrder: number }
+
+export const SIDEBAR_ROOT_SLOT_BUCKET = 'root'
+
+export function encodeSidebarRootSlotKey(slot: SidebarRootSlot): string {
+  return slot.kind === 'project-group' ? `project-group:${slot.id}` : `repo:${slot.id}`
+}
+
+export function parseSidebarRootSlotKey(key: string): SidebarRootSlot | null {
+  if (key.startsWith('project-group:')) {
+    const id = key.slice('project-group:'.length)
+    return id.length > 0 ? { kind: 'project-group', id } : null
+  }
+  if (key.startsWith('repo:')) {
+    const id = key.slice('repo:'.length)
+    return id.length > 0 ? { kind: 'repo', id } : null
+  }
+  return null
+}
+
+export function sidebarRootSlotsEqual(left: SidebarRootSlot, right: SidebarRootSlot): boolean {
+  return left.kind === right.kind && left.id === right.id
+}
+
+/** Visual root slots from the row model (depth-0 group headers + ungrouped repo headers). */
+export function getSidebarOrderedRootSlots(rows: readonly Row[]): SidebarRootSlot[] {
+  const slots: SidebarRootSlot[] = []
+  for (const row of rows) {
+    if (row.type !== 'header') {
+      continue
+    }
+    const depth = row.projectGroupDepth ?? 0
+    if (depth !== 0) {
+      continue
+    }
+    if (row.repo) {
+      // Why: depth-0 repo headers are root slots (ungrouped or orphaned membership).
+      slots.push({ kind: 'repo', id: row.repo.id })
+      continue
+    }
+    if (row.projectGroup && typeof row.projectGroup.id === 'string') {
+      slots.push({ kind: 'project-group', id: row.projectGroup.id })
+    }
+  }
+  return slots
+}
+
+export function getRootSlotOrderUpdatesForSidebarDrop(args: {
+  orderedRootSlots: readonly SidebarRootSlot[]
+  dragged: SidebarRootSlot
+  sidebarDropIndex: number
+  projectGroupById: ReadonlyMap<string, ProjectGroup>
+  repoById: ReadonlyMap<string, Repo>
+}): RootSlotOrderUpdate[] {
+  const sourceIndex = args.orderedRootSlots.findIndex((slot) =>
+    sidebarRootSlotsEqual(slot, args.dragged)
+  )
+  if (sourceIndex === -1) {
+    return []
+  }
+  const siblingSlots = args.orderedRootSlots.filter(
+    (slot) => !sidebarRootSlotsEqual(slot, args.dragged)
+  )
+  const siblingDropIndex = mapSidebarRootDropIndexToSiblingInsertIndex({
+    sidebarDropIndex: args.sidebarDropIndex,
+    sourceIndex,
+    siblingCount: siblingSlots.length
+  })
+  const sourceIndexInSiblings = Math.min(sourceIndex, siblingSlots.length)
+  if (siblingDropIndex === sourceIndexInSiblings) {
+    return []
+  }
+
+  const orderedSlots = siblingSlots.slice()
+  orderedSlots.splice(siblingDropIndex, 0, args.dragged)
+
+  const updates: RootSlotOrderUpdate[] = []
+  for (const [index, slot] of orderedSlots.entries()) {
+    if (slot.kind === 'project-group') {
+      const group = args.projectGroupById.get(slot.id)
+      if (!group || group.tabOrder === index) {
+        continue
+      }
+      updates.push({ kind: 'project-group', groupId: slot.id, tabOrder: index })
+      continue
+    }
+    const repo = args.repoById.get(slot.id)
+    if (!repo || repo.projectGroupOrder === index) {
+      continue
+    }
+    updates.push({ kind: 'repo', repoId: slot.id, projectGroupOrder: index })
+  }
+  return updates
+}
+
+/** Rank used to interleave root groups with ungrouped projects. Explicit
+ *  projectGroupOrder shares the axis with group tabOrder; unset sinks after
+ *  every group so legacy sidebars stay group-first. */
+export function getSidebarRootSlotRank(args: {
+  kind: 'project-group' | 'repo'
+  tabOrder?: number
+  projectGroupOrder?: number | null
+  maxRootGroupTabOrder: number
+  ungroupedFallbackIndex: number
+}): number {
+  if (args.kind === 'project-group') {
+    return args.tabOrder ?? 0
+  }
+  const order = args.projectGroupOrder
+  if (typeof order === 'number' && Number.isFinite(order)) {
+    return order
+  }
+  const groupFloor = Number.isFinite(args.maxRootGroupTabOrder) ? args.maxRootGroupTabOrder : -1
+  return groupFloor + 1 + args.ungroupedFallbackIndex
+}
+
+export type SidebarRootSlotDragRect = WorktreeSidebarHeaderDragRect & {
+  slotKey: string
+}
+
+function getVirtualRowStart(virtualRow: HTMLElement | null): number | null {
+  if (!virtualRow) {
+    return null
+  }
+  const rawStart = virtualRow.getAttribute('data-worktree-virtual-row-start')
+  if (rawStart === null) {
+    return null
+  }
+  const start = Number(rawStart)
+  return Number.isFinite(start) ? start : null
+}
+
+function getOptionalNumberAttribute(element: HTMLElement, attribute: string): number | undefined {
+  const rawValue = element.getAttribute(attribute)
+  if (rawValue === null) {
+    return undefined
+  }
+  const value = Number(rawValue)
+  return Number.isFinite(value) ? value : undefined
+}
+
+function measureRootSlotElement(
+  element: HTMLElement,
+  containerRect: DOMRect,
+  containerScrollTop: number,
+  slotKey: string,
+  headerIndex: number,
+  sectionEndAttribute: string
+): SidebarRootSlotDragRect {
+  const rect = element.getBoundingClientRect()
+  const virtualRow = element.closest<HTMLElement>('[data-worktree-virtual-row]')
+  const virtualRowStart = getVirtualRowStart(virtualRow)
+  const top =
+    virtualRow && virtualRowStart !== null
+      ? virtualRowStart + rect.top - virtualRow.getBoundingClientRect().top
+      : rect.top - containerRect.top + containerScrollTop
+  return {
+    slotKey,
+    headerIndex,
+    top,
+    bottom: top + rect.height,
+    sectionBottom: getOptionalNumberAttribute(element, sectionEndAttribute)
+  }
+}
+
+/** Measure root group headers and ungrouped repo headers as one drop list. */
+export function measureSidebarRootSlotDragRects(container: HTMLElement): SidebarRootSlotDragRect[] {
+  const containerRect = container.getBoundingClientRect()
+  const rects: SidebarRootSlotDragRect[] = []
+
+  container
+    .querySelectorAll<HTMLElement>('[data-project-group-header-bucket="root"]')
+    .forEach((element) => {
+      const groupId = element.getAttribute('data-project-group-header-id')
+      const rawHeaderIndex = element.getAttribute('data-project-group-header-index')
+      const headerIndex = rawHeaderIndex === null ? Number.NaN : Number(rawHeaderIndex)
+      if (!groupId || !Number.isFinite(headerIndex)) {
+        return
+      }
+      rects.push(
+        measureRootSlotElement(
+          element,
+          containerRect,
+          container.scrollTop,
+          encodeSidebarRootSlotKey({ kind: 'project-group', id: groupId }),
+          headerIndex,
+          'data-project-group-header-section-end'
+        )
+      )
+    })
+
+  container
+    .querySelectorAll<HTMLElement>('[data-repo-header-bucket="ungrouped"]')
+    .forEach((element) => {
+      const repoId = element.getAttribute('data-repo-header-id')
+      const rawHeaderIndex = element.getAttribute('data-repo-header-index')
+      const headerIndex = rawHeaderIndex === null ? Number.NaN : Number(rawHeaderIndex)
+      if (!repoId || !Number.isFinite(headerIndex)) {
+        return
+      }
+      rects.push(
+        measureRootSlotElement(
+          element,
+          containerRect,
+          container.scrollTop,
+          encodeSidebarRootSlotKey({ kind: 'repo', id: repoId }),
+          headerIndex,
+          'data-repo-header-section-end'
+        )
+      )
+    })
+
+  rects.sort((left, right) => left.top - right.top)
+  return rects
+}
+
+export function applyRootSlotOrderUpdates(args: {
+  updates: readonly RootSlotOrderUpdate[]
+  onCommitProjectGroupTabOrder: (groupId: string, tabOrder: number) => void
+  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
+}): void {
+  for (const update of args.updates) {
+    if (update.kind === 'project-group') {
+      args.onCommitProjectGroupTabOrder(update.groupId, update.tabOrder)
+      continue
+    }
+    args.onCommitProjectGroupOrder(update.repoId, null, update.projectGroupOrder)
+  }
+}

--- a/src/renderer/src/components/sidebar/worktree-header-section-boundaries.ts
+++ b/src/renderer/src/components/sidebar/worktree-header-section-boundaries.ts
@@ -1,3 +1,4 @@
+import type { SidebarRootSlot } from './sidebar-root-slot-order'
 import { estimateRenderRowSize, type RenderRow } from './worktree-list-virtual-rows'
 
 function getEstimatedRenderRowStarts(
@@ -62,11 +63,42 @@ function findProjectGroupSectionEndIndex(
   return rows.length
 }
 
+function findRootSlotRenderRowIndex(rows: readonly RenderRow[], slot: SidebarRootSlot): number {
+  if (slot.kind === 'repo') {
+    return findRepoHeaderRenderRowIndex(rows, slot.id)
+  }
+  return findProjectGroupHeaderRenderRowIndex(rows, slot.id)
+}
+
+function getNextRootSlotEndIndex(
+  rows: readonly RenderRow[],
+  sidebarRootSlots: readonly SidebarRootSlot[] | undefined,
+  slot: SidebarRootSlot,
+  fallbackStartIndex: number,
+  depth: number,
+  preferProjectGroupSectionEnd: boolean
+): number {
+  if (sidebarRootSlots && sidebarRootSlots.length > 0) {
+    const rootIndex = sidebarRootSlots.findIndex(
+      (candidate) => candidate.kind === slot.kind && candidate.id === slot.id
+    )
+    const nextSlot = rootIndex >= 0 ? sidebarRootSlots[rootIndex + 1] : undefined
+    if (nextSlot) {
+      return findRootSlotRenderRowIndex(rows, nextSlot)
+    }
+    return preferProjectGroupSectionEnd
+      ? findProjectGroupSectionEndIndex(rows, fallbackStartIndex, depth)
+      : findNextHeaderRenderRowIndex(rows, fallbackStartIndex)
+  }
+  return -1
+}
+
 export function getRepoHeaderSectionEndByRepoId(args: {
   rows: readonly RenderRow[]
   firstHeaderIndex: number
   sidebarRepoHeaderIdsByBucket: ReadonlyMap<string, readonly string[]>
   repoHeaderBucketByRepoId: ReadonlyMap<string, string>
+  sidebarRootSlots?: readonly SidebarRootSlot[]
 }): Map<string, number> {
   const rowStarts = getEstimatedRenderRowStarts(args.rows, args.firstHeaderIndex)
   const sectionEndByRepoId = new Map<string, number>()
@@ -77,12 +109,25 @@ export function getRepoHeaderSectionEndByRepoId(args: {
       continue
     }
     const bucketKey = args.repoHeaderBucketByRepoId.get(repoId)
-    const bucketRepoIds = bucketKey ? args.sidebarRepoHeaderIdsByBucket.get(bucketKey) : undefined
-    const bucketIndex = bucketRepoIds?.indexOf(repoId) ?? -1
-    const nextRepoId = bucketIndex >= 0 ? bucketRepoIds?.[bucketIndex + 1] : undefined
-    const endIndex = nextRepoId
-      ? findRepoHeaderRenderRowIndex(args.rows, nextRepoId)
-      : findNextHeaderRenderRowIndex(args.rows, index + 1)
+    const usesRootSlots = bucketKey === 'ungrouped' && (args.sidebarRootSlots?.length ?? 0) > 0
+    let endIndex = usesRootSlots
+      ? getNextRootSlotEndIndex(
+          args.rows,
+          args.sidebarRootSlots,
+          { kind: 'repo', id: repoId },
+          index + 1,
+          0,
+          false
+        )
+      : -1
+    if (endIndex < 0) {
+      const bucketRepoIds = bucketKey ? args.sidebarRepoHeaderIdsByBucket.get(bucketKey) : undefined
+      const bucketIndex = bucketRepoIds?.indexOf(repoId) ?? -1
+      const nextRepoId = bucketIndex >= 0 ? bucketRepoIds?.[bucketIndex + 1] : undefined
+      endIndex = nextRepoId
+        ? findRepoHeaderRenderRowIndex(args.rows, nextRepoId)
+        : findNextHeaderRenderRowIndex(args.rows, index + 1)
+    }
     sectionEndByRepoId.set(
       repoId,
       rowStarts[endIndex >= 0 ? endIndex : args.rows.length] ?? rowStarts[args.rows.length] ?? 0
@@ -96,6 +141,7 @@ export function getProjectGroupHeaderSectionEndByGroupId(args: {
   firstHeaderIndex: number
   sidebarProjectGroupHeaderIdsByBucket: ReadonlyMap<string, readonly string[]>
   projectGroupHeaderBucketByGroupId: ReadonlyMap<string, string>
+  sidebarRootSlots?: readonly SidebarRootSlot[]
 }): Map<string, number> {
   const rowStarts = getEstimatedRenderRowStarts(args.rows, args.firstHeaderIndex)
   const sectionEndByGroupId = new Map<string, number>()
@@ -113,15 +159,28 @@ export function getProjectGroupHeaderSectionEndByGroupId(args: {
       continue
     }
     const bucketKey = args.projectGroupHeaderBucketByGroupId.get(groupId)
-    const bucketGroupIds = bucketKey
-      ? args.sidebarProjectGroupHeaderIdsByBucket.get(bucketKey)
-      : undefined
-    const bucketIndex = bucketGroupIds?.indexOf(groupId) ?? -1
-    const nextGroupId = bucketIndex >= 0 ? bucketGroupIds?.[bucketIndex + 1] : undefined
     const depth = projectGroupHeader.row.projectGroupDepth ?? 0
-    const endIndex = nextGroupId
-      ? findProjectGroupHeaderRenderRowIndex(args.rows, nextGroupId)
-      : findProjectGroupSectionEndIndex(args.rows, index + 1, depth)
+    const usesRootSlots = bucketKey === 'root' && (args.sidebarRootSlots?.length ?? 0) > 0
+    let endIndex = usesRootSlots
+      ? getNextRootSlotEndIndex(
+          args.rows,
+          args.sidebarRootSlots,
+          { kind: 'project-group', id: groupId },
+          index + 1,
+          depth,
+          true
+        )
+      : -1
+    if (endIndex < 0) {
+      const bucketGroupIds = bucketKey
+        ? args.sidebarProjectGroupHeaderIdsByBucket.get(bucketKey)
+        : undefined
+      const bucketIndex = bucketGroupIds?.indexOf(groupId) ?? -1
+      const nextGroupId = bucketIndex >= 0 ? bucketGroupIds?.[bucketIndex + 1] : undefined
+      endIndex = nextGroupId
+        ? findProjectGroupHeaderRenderRowIndex(args.rows, nextGroupId)
+        : findProjectGroupSectionEndIndex(args.rows, index + 1, depth)
+    }
     sectionEndByGroupId.set(
       groupId,
       rowStarts[endIndex >= 0 ? endIndex : args.rows.length] ?? rowStarts[args.rows.length] ?? 0

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -2421,6 +2421,129 @@ describe('project groups', () => {
     ])
   })
 
+  it('keeps ungrouped projects after every root group when projectGroupOrder is unset', () => {
+    const groupA: ProjectGroup = {
+      id: 'group-a',
+      name: 'A',
+      parentPath: null,
+      parentGroupId: null,
+      createdFrom: 'manual',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const groupB: ProjectGroup = { ...groupA, id: 'group-b', name: 'B', tabOrder: 1 }
+    const ungroupedEarly: Repo = {
+      ...repo,
+      id: 'repo-early',
+      displayName: 'early',
+      projectGroupId: null
+    }
+    const ungroupedLate: Repo = {
+      ...repo,
+      id: 'repo-late',
+      displayName: 'late',
+      projectGroupId: null
+    }
+    const wtEarly: Worktree = {
+      ...worktree,
+      id: 'wt-early',
+      repoId: ungroupedEarly.id,
+      path: '/tmp/early'
+    }
+    const wtLate: Worktree = {
+      ...worktree,
+      id: 'wt-late',
+      repoId: ungroupedLate.id,
+      path: '/tmp/late'
+    }
+
+    const rows = buildRows(
+      'repo',
+      [wtLate, wtEarly],
+      new Map([
+        [ungroupedEarly.id, ungroupedEarly],
+        [ungroupedLate.id, ungroupedLate]
+      ]),
+      null,
+      new Set(),
+      new Map([
+        [ungroupedLate.id, 0],
+        [ungroupedEarly.id, 1]
+      ]),
+      undefined,
+      'manual',
+      {},
+      new Map([
+        [wtEarly.id, wtEarly],
+        [wtLate.id, wtLate]
+      ]),
+      false,
+      undefined,
+      [groupA, groupB]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-a',
+      'project-group:group-b',
+      'repo:repo-late',
+      'repo:repo-early'
+    ])
+  })
+
+  it('interleaves ungrouped projects with root groups when projectGroupOrder is set', () => {
+    const groupA: ProjectGroup = {
+      id: 'group-a',
+      name: 'A',
+      parentPath: null,
+      parentGroupId: null,
+      createdFrom: 'manual',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const groupB: ProjectGroup = { ...groupA, id: 'group-b', name: 'B', tabOrder: 2 }
+    const ungrouped: Repo = {
+      ...repo,
+      id: 'repo-mid',
+      displayName: 'mid',
+      projectGroupId: null,
+      projectGroupOrder: 1
+    }
+    const wtMid: Worktree = {
+      ...worktree,
+      id: 'wt-mid',
+      repoId: ungrouped.id,
+      path: '/tmp/mid'
+    }
+
+    const rows = buildRows(
+      'repo',
+      [wtMid],
+      new Map([[ungrouped.id, ungrouped]]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      'manual',
+      {},
+      new Map([[wtMid.id, wtMid]]),
+      false,
+      undefined,
+      [groupA, groupB]
+    )
+
+    expect(rows.filter((row) => row.type === 'header').map((row) => row.key)).toEqual([
+      'project-group:group-a',
+      'repo:repo-mid',
+      'project-group:group-b'
+    ])
+  })
+
   it('renders repos whose Project Group metadata is missing as top-level repo rows', () => {
     const group: ProjectGroup = {
       id: 'group-1',

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -29,6 +29,7 @@ import {
   getEffectiveProjectGroupManualRank,
   UNGROUPED_PROJECT_GROUP_KEY
 } from '../../../../shared/project-groups'
+import { getSidebarRootSlotRank } from './sidebar-root-slot-order'
 import { cloneDefaultWorkspaceStatuses } from '../../../../shared/workspace-statuses'
 import type { AppState } from '../../store/types'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from '../../store/slices/github-cache-key'
@@ -1453,10 +1454,6 @@ export function buildRows(
     groupByProjectGroupId.delete(projectGroup.id)
   }
 
-  for (const projectGroup of childGroupsByParentId.get(null) ?? []) {
-    appendProjectGroup(projectGroup, 0)
-  }
-
   const remainingRepoEntries = [...(groupByProjectGroupId.get(null) ?? [])]
   for (const [projectGroupId, entries] of groupByProjectGroupId) {
     if (projectGroupId === null || projectGroupsById.has(projectGroupId)) {
@@ -1466,10 +1463,69 @@ export function buildRows(
     // not fetched yet; missing metadata must not make those repos disappear.
     remainingRepoEntries.push(...entries)
   }
-  appendOrderedGroups(
-    withRepoSectionDisplayLabels(sortRepoEntriesWithinGroup(remainingRepoEntries)),
-    0
+
+  // Why: root is one ordered list of slots (group tabOrder + ungrouped
+  // projectGroupOrder). Explicit ranks interleave; unset projectGroupOrder
+  // sinks after every group for backward compatibility.
+  const rootGroups = childGroupsByParentId.get(null) ?? []
+  const maxRootGroupTabOrder = rootGroups.reduce(
+    (max, group) => Math.max(max, group.tabOrder),
+    Number.NEGATIVE_INFINITY
   )
+  // Why: disambiguate basenames across the full ungrouped set before splitting
+  // into interleaved root slots (single-entry labeling would keep duplicates).
+  const sortedUngroupedEntries = withRepoSectionDisplayLabels(
+    sortRepoEntriesWithinGroup(remainingRepoEntries)
+  )
+  type RootAppendSlot =
+    | { kind: 'group'; group: ProjectGroup; rank: number; secondary: number; name: string }
+    | {
+        kind: 'repo'
+        entry: OrderedGroupEntry
+        rank: number
+        secondary: number
+        name: string
+      }
+  const rootSlots: RootAppendSlot[] = rootGroups.map((group) => ({
+    kind: 'group',
+    group,
+    rank: getSidebarRootSlotRank({
+      kind: 'project-group',
+      tabOrder: group.tabOrder,
+      maxRootGroupTabOrder,
+      ungroupedFallbackIndex: 0
+    }),
+    secondary: 0,
+    name: group.name
+  }))
+  sortedUngroupedEntries.forEach((entry, ungroupedFallbackIndex) => {
+    const repo = entry[1].repo
+    rootSlots.push({
+      kind: 'repo',
+      entry,
+      rank: getSidebarRootSlotRank({
+        kind: 'repo',
+        projectGroupOrder: repo?.projectGroupOrder,
+        maxRootGroupTabOrder,
+        ungroupedFallbackIndex
+      }),
+      secondary: 1,
+      name: entry[1].label ?? entry[0]
+    })
+  })
+  rootSlots.sort(
+    (left, right) =>
+      left.rank - right.rank ||
+      left.secondary - right.secondary ||
+      left.name.localeCompare(right.name)
+  )
+  for (const slot of rootSlots) {
+    if (slot.kind === 'group') {
+      appendProjectGroup(slot.group, 0)
+      continue
+    }
+    appendOrderedGroups([slot.entry], 0)
+  }
 
   return result
 }


### PR DESCRIPTION
## Summary
- Sidebar root is one ordered list of slots (Project Group **or** ungrouped project).
- Unset `projectGroupOrder` still sinks ungrouped projects below groups (backward compatible).
- Explicit drag renumbers both `tabOrder` and `projectGroupOrder` so ungrouped projects can sit between groups — no new persisted fields.

## Fixes
Closes #10515

## Test plan
- [x] Sidebar suite (interleave layout + drop renumber)
- [ ] Manual: drag ungrouped project between two groups; order persists after restart

## ELI5

Ungrouped projects can sit between project groups in the sidebar instead of always sinking below groups. Drag-and-drop renumbers order so mixed layouts stick after restart.
