### PR TITLE
fix(sidebar): surface agent row live worktree mismatch

### DIFF
--- a/src/renderer/src/components/dashboard/useDashboardData.ts
+++ b/src/renderer/src/components/dashboard/useDashboardData.ts
@@ -30,6 +30,9 @@ export type DashboardAgentRow = {
    *  stateHistory entry, falling back to updatedAt when no history exists yet.
    *  Used to sort agents by when they started. */
   startedAt: number
+  /** When the pane's live cwd maps to a different known sibling worktree than
+   *  the row's parent card. Attribution stays put; compact secondary shows this. */
+  liveWorktreeMismatchLabel?: string
   lineage?: {
     depth: 0 | 1
     isFirstSibling: boolean

--- a/src/renderer/src/components/sidebar/live-pane-cwd-registry.test.ts
+++ b/src/renderer/src/components/sidebar/live-pane-cwd-registry.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearLivePaneCwd,
+  getLivePaneCwd,
+  getLivePaneCwdVersion,
+  resetLivePaneCwdRegistryForTests,
+  setLivePaneCwd,
+  subscribeLivePaneCwd
+} from './live-pane-cwd-registry'
+
+afterEach(() => {
+  resetLivePaneCwdRegistryForTests()
+})
+
+describe('live-pane-cwd-registry', () => {
+  it('stores confirmed cwd and notifies subscribers once per change', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeLivePaneCwd(listener)
+    const before = getLivePaneCwdVersion()
+
+    setLivePaneCwd('tab:leaf', '/repo/worktree-a')
+    setLivePaneCwd('tab:leaf', '/repo/worktree-a')
+    expect(getLivePaneCwd('tab:leaf')).toBe('/repo/worktree-a')
+    expect(getLivePaneCwdVersion()).toBe(before + 1)
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    setLivePaneCwd('tab:leaf', '/repo/worktree-b')
+    expect(getLivePaneCwdVersion()).toBe(before + 2)
+    expect(listener).toHaveBeenCalledTimes(2)
+
+    clearLivePaneCwd('tab:leaf')
+    expect(getLivePaneCwd('tab:leaf')).toBeUndefined()
+    expect(listener).toHaveBeenCalledTimes(3)
+    unsubscribe()
+  })
+})

--- a/src/renderer/src/components/sidebar/live-pane-cwd-registry.ts
+++ b/src/renderer/src/components/sidebar/live-pane-cwd-registry.ts
@@ -1,0 +1,65 @@
+/**
+ * Live shell cwd reported by confirmed OSC 7, keyed by paneKey.
+ * Why: agent rows need worktree-mismatch labels without polling getCwd (lsof)
+ * for every sidebar card. OSC 7 is already parsed for split inheritance; this
+ * registry mirrors confirmed values for React subscribers.
+ */
+
+let version = 0
+const cwdByPaneKey = new Map<string, string>()
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  version += 1
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+export function setLivePaneCwd(paneKey: string, cwd: string): void {
+  const trimmed = cwd.trim()
+  if (!trimmed) {
+    clearLivePaneCwd(paneKey)
+    return
+  }
+  if (cwdByPaneKey.get(paneKey) === trimmed) {
+    return
+  }
+  cwdByPaneKey.set(paneKey, trimmed)
+  notify()
+}
+
+export function clearLivePaneCwd(paneKey: string): void {
+  if (!cwdByPaneKey.delete(paneKey)) {
+    return
+  }
+  notify()
+}
+
+export function getLivePaneCwd(paneKey: string): string | undefined {
+  return cwdByPaneKey.get(paneKey)
+}
+
+export function getLivePaneCwdMap(): ReadonlyMap<string, string> {
+  return cwdByPaneKey
+}
+
+export function getLivePaneCwdVersion(): number {
+  return version
+}
+
+export function subscribeLivePaneCwd(onStoreChange: () => void): () => void {
+  listeners.add(onStoreChange)
+  return () => {
+    listeners.delete(onStoreChange)
+  }
+}
+
+/** Test-only: drop all entries without bumping if already empty. */
+export function resetLivePaneCwdRegistryForTests(): void {
+  if (cwdByPaneKey.size === 0) {
+    return
+  }
+  cwdByPaneKey.clear()
+  notify()
+}

--- a/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
+++ b/src/renderer/src/components/sidebar/useWorktreeAgentRows.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useSyncExternalStore } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
 import { applyAgentRowLineage } from '@/components/dashboard/agent-row-lineage'
@@ -20,6 +20,14 @@ import {
   createWorktreeAgentFreshnessSelector,
   EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
 } from './worktree-agent-freshness-selector'
+import {
+  getLivePaneCwdMap,
+  getLivePaneCwdVersion,
+  subscribeLivePaneCwd
+} from './live-pane-cwd-registry'
+import { applyLiveWorktreeMismatchLabels } from './worktree-agent-live-worktree-mismatch'
+import { getWorktreeMapFromState } from '@/store/selectors'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
 
 export { buildWorktreeAgentRows } from './worktree-agent-rows'
 export {
@@ -77,6 +85,28 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
   const agentFreshnessSignature = useAppStore((s) =>
     active ? selectAgentFreshness(s) : EMPTY_WORKTREE_AGENT_FRESHNESS_SIGNATURE
   )
+  // Why: OSC 7 live cwd is outside the zustand store; version bumps only when a
+  // confirmed pane cwd changes so cards do not re-render on ordinary title pings.
+  const livePaneCwdVersion = useSyncExternalStore(
+    subscribeLivePaneCwd,
+    getLivePaneCwdVersion,
+    getLivePaneCwdVersion
+  )
+  const siblingWorktrees = useAppStore(
+    useShallow((s) => {
+      if (!active || !s.worktreesByRepo) {
+        return []
+      }
+      const repoId = getRepoIdFromWorktreeId(worktreeId)
+      const attributed = getWorktreeMapFromState(s).get(worktreeId)
+      return (s.worktreesByRepo[repoId] ?? []).filter(
+        (worktree) =>
+          worktree.hostId === undefined ||
+          attributed?.hostId === undefined ||
+          worktree.hostId === attributed.hostId
+      )
+    })
+  )
 
   return useMemo<DashboardAgentRow[]>(() => {
     if (!active) {
@@ -96,16 +126,22 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
           ]
         : liveEntries
     return applyAgentRowLineage(
-      buildWorktreeAgentRows({
-        tabs: tabs ?? [],
-        entries,
-        retained,
-        runtimePaneTitlesByTabId,
-        ptyIdsByTabId,
-        terminalLayoutsByTabId,
-        runtimeAgentOrchestrationByPaneKey,
-        now
-      })
+      applyLiveWorktreeMismatchLabels(
+        buildWorktreeAgentRows({
+          tabs: tabs ?? [],
+          entries,
+          retained,
+          runtimePaneTitlesByTabId,
+          ptyIdsByTabId,
+          terminalLayoutsByTabId,
+          runtimeAgentOrchestrationByPaneKey,
+          now
+        }),
+        {
+          liveCwdByPaneKey: getLivePaneCwdMap(),
+          worktrees: siblingWorktrees
+        }
+      )
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -118,6 +154,8 @@ export function useWorktreeAgentRows(worktreeId: string, active = true): Dashboa
     ptyIdsByTabId,
     terminalLayoutsByTabId,
     runtimeAgentOrchestrationByPaneKey,
-    agentFreshnessSignature
+    agentFreshnessSignature,
+    livePaneCwdVersion,
+    siblingWorktrees
   ])
 }

--- a/src/renderer/src/components/sidebar/worktree-agent-live-worktree-mismatch.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-live-worktree-mismatch.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  applyLiveWorktreeMismatchLabels,
+  formatLiveWorktreeMismatchLabel,
+  resolveLiveWorktreeFromCwd,
+  resolveLiveWorktreeMismatchLabel,
+  type LiveWorktreeMismatchCandidate
+} from './worktree-agent-live-worktree-mismatch'
+
+const MAIN: LiveWorktreeMismatchCandidate = {
+  id: 'repo::/repo/main',
+  repoId: 'repo',
+  path: '/repo/main',
+  branch: 'refs/heads/main',
+  displayName: 'main'
+}
+
+const FEATURE: LiveWorktreeMismatchCandidate = {
+  id: 'repo::/repo/.claude/worktrees/worktree-foo',
+  repoId: 'repo',
+  path: '/repo/.claude/worktrees/worktree-foo',
+  branch: 'refs/heads/worktree-foo',
+  displayName: 'worktree-foo'
+}
+
+const OTHER_REPO: LiveWorktreeMismatchCandidate = {
+  id: 'other::/other/main',
+  repoId: 'other',
+  path: '/other/main',
+  branch: 'refs/heads/main',
+  displayName: 'other-main'
+}
+
+function makeTab(worktreeId: string): TerminalTab {
+  return {
+    id: 'tab-1',
+    worktreeId,
+    ptyId: null,
+    title: 'Claude',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeRow(overrides?: Partial<DashboardAgentRow>): DashboardAgentRow {
+  const paneKey = makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222')
+  const entry: AgentStatusEntry = {
+    paneKey,
+    state: 'working',
+    stateStartedAt: 1000,
+    updatedAt: 1000,
+    stateHistory: [],
+    prompt: 'do work',
+    agentType: 'claude'
+  }
+  return {
+    paneKey,
+    entry,
+    tab: makeTab(MAIN.id),
+    agentType: 'claude',
+    rowSource: 'live',
+    state: 'working',
+    startedAt: 1000,
+    ...overrides
+  }
+}
+
+describe('resolveLiveWorktreeFromCwd', () => {
+  it('picks the longest matching known worktree path', () => {
+    expect(
+      resolveLiveWorktreeFromCwd('/repo/.claude/worktrees/worktree-foo/src', [MAIN, FEATURE])?.id
+    ).toBe(FEATURE.id)
+  })
+
+  it('returns null for ordinary paths outside known worktrees', () => {
+    expect(resolveLiveWorktreeFromCwd('/tmp/scratch', [MAIN, FEATURE])).toBeNull()
+  })
+
+  it('returns null for relative or empty cwd', () => {
+    expect(resolveLiveWorktreeFromCwd('relative', [MAIN])).toBeNull()
+    expect(resolveLiveWorktreeFromCwd('', [MAIN])).toBeNull()
+    expect(resolveLiveWorktreeFromCwd(null, [MAIN])).toBeNull()
+  })
+})
+
+describe('resolveLiveWorktreeMismatchLabel', () => {
+  it('labels a live cwd that maps to a sibling worktree of the same repo', () => {
+    expect(
+      resolveLiveWorktreeMismatchLabel({
+        liveCwd: '/repo/.claude/worktrees/worktree-foo',
+        attributedWorktreeId: MAIN.id,
+        worktrees: [MAIN, FEATURE]
+      })
+    ).toBe('in worktree-foo')
+  })
+
+  it('returns null when live cwd is still inside the attributed worktree', () => {
+    expect(
+      resolveLiveWorktreeMismatchLabel({
+        liveCwd: '/repo/main/packages/app',
+        attributedWorktreeId: MAIN.id,
+        worktrees: [MAIN, FEATURE]
+      })
+    ).toBeNull()
+  })
+
+  it('ignores other-repo path matches so ordinary multi-repo noise is avoided', () => {
+    expect(
+      resolveLiveWorktreeMismatchLabel({
+        liveCwd: '/other/main',
+        attributedWorktreeId: MAIN.id,
+        worktrees: [MAIN, FEATURE, OTHER_REPO]
+      })
+    ).toBeNull()
+  })
+
+  it('returns null when attributed worktree is unknown', () => {
+    expect(
+      resolveLiveWorktreeMismatchLabel({
+        liveCwd: FEATURE.path,
+        attributedWorktreeId: 'missing',
+        worktrees: [MAIN, FEATURE]
+      })
+    ).toBeNull()
+  })
+})
+
+describe('formatLiveWorktreeMismatchLabel', () => {
+  it('prefers branch over displayName', () => {
+    expect(
+      formatLiveWorktreeMismatchLabel({
+        branch: 'refs/heads/worktree-foo',
+        displayName: 'Scratch',
+        path: '/repo/.claude/worktrees/worktree-foo'
+      })
+    ).toBe('in worktree-foo')
+  })
+
+  it('falls back to path basename when branch and displayName are empty', () => {
+    expect(
+      formatLiveWorktreeMismatchLabel({
+        branch: '',
+        displayName: '',
+        path: '/repo/.claude/worktrees/agent-abc'
+      })
+    ).toBe('in agent-abc')
+  })
+})
+
+describe('applyLiveWorktreeMismatchLabels', () => {
+  it('annotates matching live rows and leaves same-worktree rows untouched', () => {
+    const paneKey = makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222')
+    const otherKey = makePaneKey('tab-1', '33333333-3333-4333-8333-333333333333')
+    const rows = [
+      makeRow({ paneKey }),
+      makeRow({
+        paneKey: otherKey,
+        entry: {
+          ...makeRow().entry,
+          paneKey: otherKey
+        }
+      })
+    ]
+    const liveCwdByPaneKey = new Map([
+      [paneKey, FEATURE.path],
+      [otherKey, '/repo/main/src']
+    ])
+
+    const next = applyLiveWorktreeMismatchLabels(rows, {
+      liveCwdByPaneKey,
+      worktrees: [MAIN, FEATURE]
+    })
+
+    expect(next[0].liveWorktreeMismatchLabel).toBe('in worktree-foo')
+    expect(next[1].liveWorktreeMismatchLabel).toBeUndefined()
+    // Why: attribution stays on the original worktree card — no row reparenting.
+    expect(next[0].tab.worktreeId).toBe(MAIN.id)
+  })
+
+  it('uses activationPaneKey for subagent children of a mismatched parent', () => {
+    const parentKey = makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222')
+    const child = makeRow({
+      paneKey: `${parentKey}\u0000subagent:1`,
+      activationPaneKey: parentKey,
+      rowSource: 'subagent'
+    })
+    const next = applyLiveWorktreeMismatchLabels([child], {
+      liveCwdByPaneKey: { [parentKey]: FEATURE.path },
+      worktrees: [MAIN, FEATURE]
+    })
+    expect(next[0].liveWorktreeMismatchLabel).toBe('in worktree-foo')
+  })
+
+  it('returns the same array reference when nothing changes', () => {
+    const rows = [makeRow()]
+    const next = applyLiveWorktreeMismatchLabels(rows, {
+      liveCwdByPaneKey: {},
+      worktrees: [MAIN, FEATURE]
+    })
+    expect(next).toBe(rows)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-agent-live-worktree-mismatch.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-live-worktree-mismatch.ts
@@ -1,0 +1,174 @@
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import { branchName } from '@/lib/git-utils'
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
+import { splitWorktreeIdForFilesystem } from '../../../../shared/worktree-id'
+import {
+  getRuntimePathBasename,
+  isPathInsideOrEqual,
+  isRuntimePathAbsolute,
+  normalizeRuntimePathForComparison
+} from '../../../../shared/cross-platform-path'
+import type { Worktree } from '../../../../shared/types'
+
+export type LiveWorktreeMismatchCandidate = Pick<
+  Worktree,
+  'id' | 'repoId' | 'path' | 'branch' | 'displayName' | 'priorWorktreeIds' | 'hostId'
+>
+
+type WorktreePathCandidate = {
+  worktree: LiveWorktreeMismatchCandidate
+  path: string
+  source: 'current-path' | 'prior-path'
+}
+
+/**
+ * Resolve the known worktree whose path contains liveCwd (longest match wins).
+ * Ordinary cds outside every known worktree return null — no noise.
+ */
+export function resolveLiveWorktreeFromCwd(
+  liveCwd: string | null | undefined,
+  worktrees: readonly LiveWorktreeMismatchCandidate[]
+): LiveWorktreeMismatchCandidate | null {
+  const terminalCwd = liveCwd?.trim()
+  if (!terminalCwd || !isRuntimePathAbsolute(terminalCwd)) {
+    return null
+  }
+
+  const best = buildWorktreePathCandidates(worktrees)
+    .filter((candidate) => isTerminalCwdInsideWorktree(candidate.path, terminalCwd))
+    .sort(compareWorktreePathCandidates)[0]
+
+  return best?.worktree ?? null
+}
+
+/**
+ * When live cwd maps to a different known sibling worktree of the same repo
+ * (and host), return a compact label like `in worktree-foo`. Otherwise null.
+ */
+export function resolveLiveWorktreeMismatchLabel(args: {
+  liveCwd: string | null | undefined
+  attributedWorktreeId: string
+  worktrees: readonly LiveWorktreeMismatchCandidate[]
+}): string | null {
+  const attributed = args.worktrees.find((worktree) => worktree.id === args.attributedWorktreeId)
+  if (!attributed) {
+    return null
+  }
+
+  const siblings = args.worktrees.filter(
+    (worktree) =>
+      worktree.repoId === attributed.repoId &&
+      (worktree.hostId === undefined ||
+        attributed.hostId === undefined ||
+        worktree.hostId === attributed.hostId)
+  )
+  const live = resolveLiveWorktreeFromCwd(args.liveCwd, siblings)
+  if (!live || live.id === attributed.id) {
+    return null
+  }
+  return formatLiveWorktreeMismatchLabel(live)
+}
+
+export function formatLiveWorktreeMismatchLabel(
+  worktree: Pick<LiveWorktreeMismatchCandidate, 'branch' | 'displayName' | 'path'>
+): string {
+  const branch = worktree.branch?.trim() ? branchName(worktree.branch).trim() : ''
+  const displayName = worktree.displayName?.trim() ?? ''
+  const base = branch || displayName || getRuntimePathBasename(worktree.path) || worktree.path
+  return `in ${base}`
+}
+
+/** Attach mismatch labels from live OSC-7 cwd without re-attributing rows. */
+export function applyLiveWorktreeMismatchLabels(
+  rows: DashboardAgentRow[],
+  args: {
+    liveCwdByPaneKey: ReadonlyMap<string, string> | Record<string, string>
+    worktrees: readonly LiveWorktreeMismatchCandidate[]
+  }
+): DashboardAgentRow[] {
+  if (rows.length === 0 || args.worktrees.length === 0) {
+    return rows
+  }
+
+  let changed = false
+  const next = rows.map((row) => {
+    const lookupKey = row.activationPaneKey ?? row.paneKey
+    const liveCwd = readLiveCwd(args.liveCwdByPaneKey, lookupKey)
+    const label = resolveLiveWorktreeMismatchLabel({
+      liveCwd,
+      attributedWorktreeId: row.tab.worktreeId,
+      worktrees: args.worktrees
+    })
+    if (label === (row.liveWorktreeMismatchLabel ?? null)) {
+      return row
+    }
+    changed = true
+    if (!label) {
+      if (row.liveWorktreeMismatchLabel === undefined) {
+        return row
+      }
+      const { liveWorktreeMismatchLabel: _removed, ...rest } = row
+      return rest
+    }
+    return { ...row, liveWorktreeMismatchLabel: label }
+  })
+  return changed ? next : rows
+}
+
+function readLiveCwd(
+  map: ReadonlyMap<string, string> | Record<string, string>,
+  paneKey: string
+): string | undefined {
+  if (map instanceof Map) {
+    return map.get(paneKey)
+  }
+  return map[paneKey]
+}
+
+function buildWorktreePathCandidates(
+  worktrees: readonly LiveWorktreeMismatchCandidate[]
+): WorktreePathCandidate[] {
+  const candidates: WorktreePathCandidate[] = []
+  for (const worktree of worktrees) {
+    if (hasUsablePath(worktree.path)) {
+      candidates.push({ worktree, path: worktree.path, source: 'current-path' })
+    }
+    for (const priorWorktreeId of worktree.priorWorktreeIds ?? []) {
+      const parsed = splitWorktreeIdForFilesystem(priorWorktreeId)
+      if (!parsed || parsed.repoId !== worktree.repoId || !hasUsablePath(parsed.worktreePath)) {
+        continue
+      }
+      candidates.push({ worktree, path: parsed.worktreePath, source: 'prior-path' })
+    }
+  }
+  return candidates
+}
+
+function hasUsablePath(pathValue: string): boolean {
+  const trimmed = pathValue.trim()
+  return Boolean(trimmed && isRuntimePathAbsolute(trimmed))
+}
+
+function isTerminalCwdInsideWorktree(worktreePath: string, terminalCwd: string): boolean {
+  if (isPathInsideOrEqual(worktreePath, terminalCwd)) {
+    return true
+  }
+  const wslPath = parseWslUncPath(worktreePath)
+  return wslPath ? isPathInsideOrEqual(wslPath.linuxPath, terminalCwd) : false
+}
+
+function compareWorktreePathCandidates(
+  left: WorktreePathCandidate,
+  right: WorktreePathCandidate
+): number {
+  const lengthDifference =
+    normalizeRuntimePathForComparison(right.path).length -
+    normalizeRuntimePathForComparison(left.path).length
+  if (lengthDifference !== 0) {
+    return lengthDifference
+  }
+  if (left.source === right.source) {
+    return 0
+  }
+  return left.source === 'current-path' ? -1 : 1
+}

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-row.tsx
@@ -11,6 +11,7 @@ import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
 import { useAgentRowConversationName } from '@/components/dashboard/use-agent-row-conversation-name'
 import { lastEnteredDoneAt } from '@/components/dashboard/agent-finished-timestamp'
 import CacheTimer, { usePromptCacheCountdownForPane } from './CacheTimer'
+import { getCompactAgentSecondary } from './worktree-card-compact-agent-secondary'
 
 function formatShortTimeAgo(ts: number, now: number): string {
   const delta = now - ts
@@ -34,31 +35,6 @@ function getCompactAgentPrimary(
 ): string {
   const prompt = conversationName ?? getAgentRowPrimaryText(agent.entry)
   return prompt || agentStateLabel(getAgentDotState(agent))
-}
-
-function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
-  if (agent.entry.interrupted === true) {
-    return 'Interrupted by user'
-  }
-  if (agent.state === 'working') {
-    const toolName = agent.entry.toolName?.trim() ?? ''
-    const toolInput = agent.entry.toolInput?.trim() ?? ''
-    if (toolName && toolInput) {
-      return `${toolName}: ${toolInput}`
-    }
-    if (toolName) {
-      return toolName
-    }
-  }
-  const lastAssistantMessage = agent.entry.lastAssistantMessage?.trim()
-  if (lastAssistantMessage) {
-    return lastAssistantMessage
-  }
-  // Why: child rows without descriptions use their role as primary text; repeating its formatted label adds no information.
-  if (agent.rowSource === 'subagent' && agent.entry.prompt?.trim() === agent.agentType.trim()) {
-    return ''
-  }
-  return formatAgentTypeLabel(agent.agentType)
 }
 
 function getCompactAgentTime(agent: DashboardAgentRowData, now: number): string | null {

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-secondary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-secondary.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import type { DashboardAgentRow } from '@/components/dashboard/useDashboardData'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import type { TerminalTab } from '../../../../shared/types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { getCompactAgentSecondary } from './worktree-card-compact-agent-secondary'
+
+function makeAgent(overrides?: Partial<DashboardAgentRow>): DashboardAgentRow {
+  const paneKey = makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222')
+  const tab: TerminalTab = {
+    id: 'tab-1',
+    worktreeId: 'repo::/repo/main',
+    ptyId: null,
+    title: 'Claude',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+  const baseEntry: AgentStatusEntry = {
+    paneKey,
+    state: 'working',
+    stateStartedAt: 1000,
+    updatedAt: 1000,
+    stateHistory: [],
+    prompt: 'do work',
+    agentType: 'claude'
+  }
+  const { entry: entryOverrides, ...rowOverrides } = overrides ?? {}
+  return {
+    paneKey,
+    entry: { ...baseEntry, ...entryOverrides },
+    tab,
+    agentType: 'claude',
+    rowSource: 'live',
+    state: 'working',
+    startedAt: 1000,
+    ...rowOverrides
+  }
+}
+
+describe('getCompactAgentSecondary', () => {
+  it('surfaces live worktree mismatch alone when there is no tool detail', () => {
+    expect(
+      getCompactAgentSecondary(
+        makeAgent({
+          liveWorktreeMismatchLabel: 'in worktree-foo',
+          state: 'waiting'
+        })
+      )
+    ).toBe('in worktree-foo')
+  })
+
+  it('prefixes mismatch before tool detail while working', () => {
+    expect(
+      getCompactAgentSecondary(
+        makeAgent({
+          liveWorktreeMismatchLabel: 'in worktree-foo',
+          entry: {
+            paneKey: makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222'),
+            state: 'working',
+            stateStartedAt: 1000,
+            updatedAt: 1000,
+            stateHistory: [],
+            prompt: 'do work',
+            agentType: 'claude',
+            toolName: 'Edit',
+            toolInput: 'src/a.ts'
+          }
+        })
+      )
+    ).toBe('in worktree-foo · Edit: src/a.ts')
+  })
+
+  it('keeps existing tool secondary when there is no mismatch', () => {
+    expect(
+      getCompactAgentSecondary(
+        makeAgent({
+          entry: {
+            paneKey: makePaneKey('tab-1', '22222222-2222-4222-8222-222222222222'),
+            state: 'working',
+            stateStartedAt: 1000,
+            updatedAt: 1000,
+            stateHistory: [],
+            prompt: 'do work',
+            agentType: 'claude',
+            toolName: 'Bash'
+          }
+        })
+      )
+    ).toBe('Bash')
+  })
+
+  it('falls back to agent type label without mismatch detail', () => {
+    expect(getCompactAgentSecondary(makeAgent({ state: 'done' }))).toBe('Claude')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-compact-agent-secondary.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-compact-agent-secondary.ts
@@ -1,0 +1,46 @@
+import type { DashboardAgentRow as DashboardAgentRowData } from '@/components/dashboard/useDashboardData'
+import { formatAgentTypeLabel } from '@/lib/agent-status'
+
+/**
+ * Compact agent-row secondary line. Surfaces live worktree mismatch first so a
+ * row still filed under its spawn worktree is not silently wrong (#10572).
+ */
+export function getCompactAgentSecondary(agent: DashboardAgentRowData): string {
+  const mismatch = agent.liveWorktreeMismatchLabel?.trim() ?? ''
+  const detail = getCompactAgentSecondaryDetail(agent)
+  if (mismatch && detail) {
+    return `${mismatch} · ${detail}`
+  }
+  if (mismatch) {
+    return mismatch
+  }
+  if (detail) {
+    return detail
+  }
+  // Why: child rows without descriptions use their role as primary text; repeating its formatted label adds no information.
+  if (agent.rowSource === 'subagent' && agent.entry.prompt?.trim() === agent.agentType.trim()) {
+    return ''
+  }
+  return formatAgentTypeLabel(agent.agentType)
+}
+
+function getCompactAgentSecondaryDetail(agent: DashboardAgentRowData): string {
+  if (agent.entry.interrupted === true) {
+    return 'Interrupted by user'
+  }
+  if (agent.state === 'working') {
+    const toolName = agent.entry.toolName?.trim() ?? ''
+    const toolInput = agent.entry.toolInput?.trim() ?? ''
+    if (toolName && toolInput) {
+      return `${toolName}: ${toolInput}`
+    }
+    if (toolName) {
+      return toolName
+    }
+  }
+  const lastAssistantMessage = agent.entry.lastAssistantMessage?.trim()
+  if (lastAssistantMessage) {
+    return lastAssistantMessage
+  }
+  return ''
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -70,6 +70,7 @@ import { pushMode2031SeedReply } from './terminal-mode-2031-replies'
 import { handleOsc52ClipboardRequest } from './osc52-clipboard'
 import { showOsc52ClipboardBlockedToast } from './osc52-clipboard-blocked-toast'
 import { parseOsc7 } from './parse-osc7'
+import { clearLivePaneCwd, setLivePaneCwd } from '@/components/sidebar/live-pane-cwd-registry'
 import { guardParserHandler } from './terminal-parser-handler-guard'
 import { resolveTerminalJisYenInput } from './terminal-jis-yen-input'
 import { installTerminalImeCompositionTracker } from './terminal-ime-composition-tracker'
@@ -831,6 +832,11 @@ export function useTerminalPaneLifecycle({
             if (parsedCwd) {
               const confirmed = !isPaneReplaying(replayingPanesRef, pane.id)
               paneCwdRef.current.set(pane.id, { cwd: parsedCwd, confirmed })
+              // Why: confirmed OSC 7 only — replayed scrollback must not flip
+              // sidebar agent worktree-mismatch labels (#10572).
+              if (confirmed && pane.leafId) {
+                setLivePaneCwd(makePaneKey(tabId, pane.leafId), parsedCwd)
+              }
             }
             return true
           })
@@ -1202,6 +1208,9 @@ export function useTerminalPaneLifecycle({
         }
         // Why: drop the tracked cwd so the map doesn't accumulate dead entries over long sessions.
         paneCwdRef.current.delete(paneId)
+        if (closedPane?.leafId) {
+          clearLivePaneCwd(makePaneKey(tabId, closedPane.leafId))
+        }
         const mouseHideDisposable = mouseHideDisposablesRef.current.get(paneId)
         if (mouseHideDisposable) {
           mouseHideDisposable.dispose()


### PR DESCRIPTION
## Summary
- Keeps agent row attribution on the worktree where the pane was created (no jumpy re-attribution).
- When OSC 7 cwd maps to a **known sibling worktree** of the same repo, compact agent secondary shows e.g. `in worktree-foo`.
- Ordinary `cd` outside known worktrees stays quiet.

## Fixes
Closes #10572

## Test plan
- [x] Sidebar suite including mismatch / secondary composition
- [ ] Manual: split pane, `claude -w` into sibling worktree; parent card shows `in <name>` on the agent row

## ELI5

If an agent pane's cwd moves into a sibling worktree of the same repo, the sidebar quietly notes that (e.g. "in worktree-foo") without re-attaching the agent row to the wrong place, so you know where the agent is working.
