### PR TITLE
test(e2e): fix two stale E2E specs failing on main (runtime host seeding, alt-screen snapshot)

### DIFF
--- a/tests/e2e/helpers/alt-screen-frame.ts
+++ b/tests/e2e/helpers/alt-screen-frame.ts
@@ -31,7 +31,8 @@ export async function readRenderedAltScreenFrame(
       if (!pane) {
         throw new Error(`No terminal pane for tab ${tabId}`)
       }
-      const pattern = new RegExp(`${marker} frame (\\d{3})`)
+      // marker is a literal, so escape it rather than letting `[`/`.`/`+` act as regex syntax.
+      const pattern = new RegExp(`${marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} frame (\\d{3})`)
       const buffer = pane.terminal.buffer.active
       for (let row = 0; row < pane.terminal.rows; row += 1) {
         const line = buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? ''

--- a/tests/e2e/helpers/alt-screen-frame.ts
+++ b/tests/e2e/helpers/alt-screen-frame.ts
@@ -1,0 +1,75 @@
+import type { Page } from '@stablyai/playwright-test'
+
+// Boxed alt-screen TUI frame: enters the alternate buffer, clears it, and paints
+// a marker line carrying a zero-padded frame number.
+export function buildAltScreenFrame(marker: string, frame: number): string {
+  const progress = `${'█'.repeat((frame % 8) + 1)}${'░'.repeat(8 - ((frame % 8) + 1))}`
+  return [
+    '\x1b[?2026h',
+    '\x1b[?1049h',
+    '\x1b[2J\x1b[H',
+    '\x1b[?25l',
+    `╭────────────────────────────────────────────────────────────────────╮`,
+    `│ ${marker} frame ${String(frame).padStart(3, '0')} ${progress}                     │`,
+    `│ Dimension              │ Rating                                      │`,
+    `╰────────────────────────────────────────────────────────────────────╯`,
+    '\x1b[?2026l'
+  ].join('\r\n')
+}
+
+// Why: the live-write and the reveal restore paint the same layout, so the frame
+// number is the only thing on screen that says which of the two landed last.
+export async function readRenderedAltScreenFrame(
+  page: Page,
+  tabId: string,
+  marker: string
+): Promise<number | null> {
+  return page.evaluate(
+    ({ tabId, marker }) => {
+      const manager = window.__paneManagers?.get(tabId)
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+      if (!pane) {
+        throw new Error(`No terminal pane for tab ${tabId}`)
+      }
+      const pattern = new RegExp(`${marker} frame (\\d{3})`)
+      const buffer = pane.terminal.buffer.active
+      for (let row = 0; row < pane.terminal.rows; row += 1) {
+        const line = buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? ''
+        const match = pattern.exec(line)
+        if (match) {
+          return Number(match[1])
+        }
+      }
+      return null
+    },
+    { tabId, marker }
+  )
+}
+
+export function describeAltScreenRenderPath(
+  renderedFrame: number | null,
+  liveFrame: number,
+  restoreFrame: number
+): string {
+  if (renderedFrame === restoreFrame) {
+    return 'reveal restore'
+  }
+  if (renderedFrame === liveFrame) {
+    return 'live write (no restore)'
+  }
+  return renderedFrame === null ? 'no marker' : `unexpected frame ${renderedFrame}`
+}
+
+export async function writeToPaneTerminal(page: Page, tabId: string, data: string): Promise<void> {
+  await page.evaluate(
+    ({ tabId, data }) => {
+      const manager = window.__paneManagers?.get(tabId)
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+      if (!pane) {
+        throw new Error(`No terminal pane for tab ${tabId}`)
+      }
+      return new Promise<void>((resolve) => pane.terminal.write(data, resolve))
+    },
+    { tabId, data }
+  )
+}

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -12,6 +12,7 @@ import { waitForSessionReady } from './helpers/store'
 import type { Page } from '@stablyai/playwright-test'
 import type { GlobalSettings, TuiAgent } from '../../src/shared/types'
 import { ONBOARDING_FINAL_STEP } from '../../src/shared/constants'
+import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../../src/shared/pairing'
 
 type OnboardingState = {
   closedAt: number | null
@@ -421,43 +422,38 @@ test.describe('Onboarding flow', () => {
     await expect(orcaPage.getByRole('heading', { name: /Pick your default agent/i })).toBeVisible({
       timeout: 15_000
     })
-    await orcaPage.evaluate(async () => {
+    // Why: since #10011 `settings:set` strips activeRuntimeEnvironmentId — the
+    // durable Active Server preference is only writable through its dedicated
+    // handler, which resolves the id against the main-process environment
+    // store. So the host has to be registered for real, not faked in the
+    // renderer. Pairing is offline (no live server needed).
+    const pairingCode = encodePairingOffer({
+      v: PAIRING_OFFER_VERSION,
+      scope: 'runtime',
+      endpoint: 'wss://e2e.invalid/ws',
+      deviceToken: 'e2e-device-token',
+      publicKeyB64: 'ZTJlLXB1YmxpYy1rZXk'
+    })
+    const environmentId = await orcaPage.evaluate(async (code) => {
       const store = window.__store
       if (!store) {
         throw new Error('window.__store is not available')
       }
+      const { environment } = await window.api.runtimeEnvironments.addFromPairingCode({
+        name: 'E2E Server',
+        pairingCode: code
+      })
       // Why: after #5071 the server-path add step gates on the registered
       // runtime-environment list (store.runtimeEnvironments), not just the
-      // activeRuntimeEnvironmentId setting. Seed a redacted environment so the
-      // host option exists and the "on host" add UI renders.
-      const now = Date.now()
-      store.getState().setRuntimeEnvironments([
-        {
-          id: 'env-e2e',
-          name: 'E2E Server',
-          createdAt: now,
-          updatedAt: now,
-          lastUsedAt: null,
-          runtimeId: null,
-          source: 'manual',
-          endpoints: [
-            {
-              id: 'ws-env-e2e',
-              kind: 'websocket',
-              label: 'WebSocket',
-              endpoint: 'wss://e2e.invalid/ws'
-            }
-          ],
-          preferredEndpointId: 'ws-env-e2e'
-        }
-      ])
+      // activeRuntimeEnvironmentId setting.
+      store.getState().setRuntimeEnvironments(await window.api.runtimeEnvironments.list())
       // Why: a runtime host is only auto-selectable (health 'available') when it
       // has a live, protocol-compatible status; without one it reads
       // 'disconnected' and the Add Project dialog falls back to Local Mac.
       // runtimeProtocolVersion 3 clears MIN_COMPATIBLE_RUNTIME_SERVER_VERSION.
-      store.getState().setRuntimeEnvironmentStatus('env-e2e', {
+      store.getState().setRuntimeEnvironmentStatus(environment.id, {
         status: {
-          runtimeId: 'env-e2e-runtime',
+          runtimeId: `${environment.id}-runtime`,
           rendererGraphEpoch: 0,
           graphStatus: 'ready',
           authoritativeWindowId: null,
@@ -466,15 +462,23 @@ test.describe('Onboarding flow', () => {
           runtimeProtocolVersion: 3,
           minCompatibleRuntimeClientVersion: 1
         },
-        checkedAt: now
+        checkedAt: Date.now()
       })
-      await store.getState().updateSettings({ activeRuntimeEnvironmentId: 'env-e2e' })
-    })
+      // Why: the store's switchRuntimeEnvironment probes reachability, which a
+      // synthetic host can't satisfy — write the preference directly and push
+      // the returned settings in rather than refetching (fetchSettings would
+      // kick off a status hydrate that clobbers the seeded 'available' health).
+      const settings = await window.api.settings.setActiveRuntimeEnvironmentPreference({
+        environmentId: environment.id
+      })
+      store.setState({ settings })
+      return environment.id
+    }, pairingCode)
     await expect
       .poll(async () => (await getSettings(orcaPage)).activeRuntimeEnvironmentId, {
         timeout: 5_000
       })
-      .toBe('env-e2e')
+      .toBe(environmentId)
 
     await onboardingFooterButton(orcaPage, SKIP_TO_PROJECT_SETUP_BUTTON).click()
 

--- a/tests/e2e/terminal-tab-switch-visual-restore.spec.ts
+++ b/tests/e2e/terminal-tab-switch-visual-restore.spec.ts
@@ -1,5 +1,11 @@
 import type { Page, TestInfo } from '@stablyai/playwright-test'
 import { test, expect } from './helpers/orca-app'
+import {
+  buildAltScreenFrame,
+  describeAltScreenRenderPath,
+  readRenderedAltScreenFrame,
+  writeToPaneTerminal
+} from './helpers/alt-screen-frame'
 import { runNodeScriptInTerminal } from './helpers/run-node-script-in-terminal'
 import {
   ensureTerminalVisible,
@@ -287,35 +293,6 @@ async function injectPaneData(
   if (!injected) {
     throw new Error(`No terminal PTY data injector registered for ${paneKey}`)
   }
-}
-
-function buildAltScreenFrame(marker: string, frame: number): string {
-  const progress = `${'█'.repeat((frame % 8) + 1)}${'░'.repeat(8 - ((frame % 8) + 1))}`
-  return [
-    '\x1b[?2026h',
-    '\x1b[?1049h',
-    '\x1b[2J\x1b[H',
-    '\x1b[?25l',
-    `╭────────────────────────────────────────────────────────────────────╮`,
-    `│ ${marker} frame ${String(frame).padStart(3, '0')} ${progress}                     │`,
-    `│ Dimension              │ Rating                                      │`,
-    `╰────────────────────────────────────────────────────────────────────╯`,
-    '\x1b[?2026l'
-  ].join('\r\n')
-}
-
-async function writeToPaneTerminal(page: Page, tabId: string, data: string): Promise<void> {
-  await page.evaluate(
-    ({ tabId, data }) => {
-      const manager = window.__paneManagers?.get(tabId)
-      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
-      if (!pane) {
-        throw new Error(`No terminal pane for tab ${tabId}`)
-      }
-      return new Promise<void>((resolve) => pane.terminal.write(data, resolve))
-    },
-    { tabId, data }
-  )
 }
 
 async function setHiddenSnapshotOverride(
@@ -652,20 +629,38 @@ test.describe('Terminal tab switch visual restore', () => {
     )
 
     const corruptionReports: string[] = []
+    const renderPaths: string[] = []
     for (let cycle = 0; cycle < 6; cycle += 1) {
-      const redraw = buildAltScreenFrame(finalMarker, cycle * 4)
+      const liveFrame = cycle * 4
+      const restoreFrame = liveFrame + 1
+      const redraw = buildAltScreenFrame(finalMarker, liveFrame)
       // Why: this frame never transits the PTY, so a reveal restore would
-      // repaint main's model over it. Publish it as the snapshot too, so both
-      // the live-write and restore paths land the same frame. Identity is
-      // re-read per cycle because a reattach would re-key the override.
+      // repaint main's model over it. Publish an equivalent frame as the
+      // snapshot so either path leaves a valid screen — numbered one higher so
+      // the readback still reports which one painted. Identity is re-read per
+      // cycle because a reattach would re-key the override.
       const { ptyId, cols, rows } = await readPaneIdentityOnTab(orcaPage, firstTabId)
-      await setHiddenSnapshotOverride(orcaPage, ptyId, { data: redraw, cols, rows })
+      await setHiddenSnapshotOverride(orcaPage, ptyId, {
+        data: buildAltScreenFrame(finalMarker, restoreFrame),
+        cols,
+        rows
+      })
       await activateTerminalTab(orcaPage, secondTabId)
       await writeToPaneTerminal(orcaPage, firstTabId, redraw)
       await activateTerminalTab(orcaPage, firstTabId)
 
       const geometry = await readTabTerminalGeometry(orcaPage, firstTabId, `${runId}_ALT`)
-      const issue = geometryLooksCorrupted(geometry)
+      const renderedFrame = await readRenderedAltScreenFrame(orcaPage, firstTabId, finalMarker)
+      renderPaths.push(
+        `cycle ${cycle}: ${describeAltScreenRenderPath(renderedFrame, liveFrame, restoreFrame)}`
+      )
+      // Why: whichever path won must have painted its own frame. Anything else
+      // on screen means the restore replayed stale content.
+      const staleFrame =
+        renderedFrame !== null && renderedFrame !== liveFrame && renderedFrame !== restoreFrame
+          ? `alt-screen shows frame ${renderedFrame}, expected ${liveFrame} (live write) or ${restoreFrame} (reveal restore)`
+          : null
+      const issue = geometryLooksCorrupted(geometry) ?? staleFrame
       if (issue || !geometry.markerPresent) {
         corruptionReports.push(
           `cycle ${cycle}: ${issue ?? 'marker missing after alt-screen redraw'}`
@@ -678,6 +673,15 @@ test.describe('Terminal tab switch visual restore', () => {
         )
       }
     }
+
+    // Why: which cycles latched a restore is load-dependent, so it is recorded
+    // rather than asserted — without it a "both paths agree" run is opaque.
+    // Logged as well because the list reporter omits annotations.
+    testInfo.annotations.push({
+      type: 'alt-screen-render-path',
+      description: renderPaths.join(', ')
+    })
+    console.log('[tab-switch-repro] alt-screen render path:', renderPaths.join(', '))
 
     expect(
       corruptionReports,

--- a/tests/e2e/terminal-tab-switch-visual-restore.spec.ts
+++ b/tests/e2e/terminal-tab-switch-visual-restore.spec.ts
@@ -289,6 +289,35 @@ async function injectPaneData(
   }
 }
 
+function buildAltScreenFrame(marker: string, frame: number): string {
+  const progress = `${'█'.repeat((frame % 8) + 1)}${'░'.repeat(8 - ((frame % 8) + 1))}`
+  return [
+    '\x1b[?2026h',
+    '\x1b[?1049h',
+    '\x1b[2J\x1b[H',
+    '\x1b[?25l',
+    `╭────────────────────────────────────────────────────────────────────╮`,
+    `│ ${marker} frame ${String(frame).padStart(3, '0')} ${progress}                     │`,
+    `│ Dimension              │ Rating                                      │`,
+    `╰────────────────────────────────────────────────────────────────────╯`,
+    '\x1b[?2026l'
+  ].join('\r\n')
+}
+
+async function writeToPaneTerminal(page: Page, tabId: string, data: string): Promise<void> {
+  await page.evaluate(
+    ({ tabId, data }) => {
+      const manager = window.__paneManagers?.get(tabId)
+      const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
+      if (!pane) {
+        throw new Error(`No terminal pane for tab ${tabId}`)
+      }
+      return new Promise<void>((resolve) => pane.terminal.write(data, resolve))
+    },
+    { tabId, data }
+  )
+}
+
 async function setHiddenSnapshotOverride(
   page: Page,
   ptyId: string,
@@ -611,63 +640,28 @@ test.describe('Terminal tab switch visual restore', () => {
 
     const { firstTabId, secondTabId } = await ensureTwoTerminalTabs(orcaPage)
     await forceWebglOnActiveTab(orcaPage)
+    await waitForPanePtyIdOnTab(orcaPage, firstTabId)
 
     const runId = `${Date.now()}`
     const finalMarker = `${TAB_SWITCH_MARKER_PREFIX}_${runId}_ALT_24`
 
-    await orcaPage.evaluate(
-      ({ tabId, finalMarker }) => {
-        const manager = window.__paneManagers?.get(tabId)
-        const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
-        if (!pane) {
-          throw new Error(`No terminal pane for tab ${tabId}`)
-        }
-        const frames = Array.from({ length: 25 }, (_, frame) => {
-          const progress = `${'█'.repeat((frame % 8) + 1)}${'░'.repeat(8 - ((frame % 8) + 1))}`
-          return [
-            '\x1b[?2026h',
-            '\x1b[?1049h',
-            '\x1b[2J\x1b[H',
-            '\x1b[?25l',
-            `╭────────────────────────────────────────────────────────────────────╮`,
-            `│ ${finalMarker} frame ${String(frame).padStart(3, '0')} ${progress}                     │`,
-            `│ Dimension              │ Rating                                      │`,
-            `╰────────────────────────────────────────────────────────────────────╯`,
-            '\x1b[?2026l'
-          ].join('\r\n')
-        }).join('')
-        return new Promise<void>((resolve) => pane.terminal.write(frames, resolve))
-      },
-      { tabId: firstTabId, finalMarker }
+    await writeToPaneTerminal(
+      orcaPage,
+      firstTabId,
+      Array.from({ length: 25 }, (_, frame) => buildAltScreenFrame(finalMarker, frame)).join('')
     )
 
     const corruptionReports: string[] = []
     for (let cycle = 0; cycle < 6; cycle += 1) {
+      const redraw = buildAltScreenFrame(finalMarker, cycle * 4)
+      // Why: this frame never transits the PTY, so a reveal restore would
+      // repaint main's model over it. Publish it as the snapshot too, so both
+      // the live-write and restore paths land the same frame. Identity is
+      // re-read per cycle because a reattach would re-key the override.
+      const { ptyId, cols, rows } = await readPaneIdentityOnTab(orcaPage, firstTabId)
+      await setHiddenSnapshotOverride(orcaPage, ptyId, { data: redraw, cols, rows })
       await activateTerminalTab(orcaPage, secondTabId)
-      await orcaPage.evaluate(
-        ({ tabId, finalMarker, cycle }) => {
-          const manager = window.__paneManagers?.get(tabId)
-          const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0]
-          if (!pane) {
-            throw new Error(`No terminal pane for tab ${tabId}`)
-          }
-          const frame = cycle * 4
-          const progress = `${'█'.repeat((frame % 8) + 1)}${'░'.repeat(8 - ((frame % 8) + 1))}`
-          const redraw = [
-            '\x1b[?2026h',
-            '\x1b[?1049h',
-            '\x1b[2J\x1b[H',
-            '\x1b[?25l',
-            `╭────────────────────────────────────────────────────────────────────╮`,
-            `│ ${finalMarker} frame ${String(frame).padStart(3, '0')} ${progress}                     │`,
-            `│ Dimension              │ Rating                                      │`,
-            `╰────────────────────────────────────────────────────────────────────╯`,
-            '\x1b[?2026l'
-          ].join('\r\n')
-          return new Promise<void>((resolve) => pane.terminal.write(redraw, resolve))
-        },
-        { tabId: firstTabId, finalMarker, cycle }
-      )
+      await writeToPaneTerminal(orcaPage, firstTabId, redraw)
       await activateTerminalTab(orcaPage, firstTabId)
 
       const geometry = await readTabTerminalGeometry(orcaPage, firstTabId, `${runId}_ALT`)


### PR DESCRIPTION
Two of the eight specs failing on main's scheduled E2E were **test defects**, not product bugs. This fixes both. Part of #10519.

Both recur in every recent scheduled run — not runner flake. Confirmed on the latest scheduled run [30167442014](https://github.com/stablyai/orca/actions/runs/30167442014) (sha `505967eba0`): `onboarding.spec.ts:420` in shard 3, `terminal-tab-switch-visual-restore.spec.ts:604` in shard 9.

## 1. `onboarding.spec.ts:420` — "Skip preserves runtime server project setup UI"

Failed `expect(...activeRuntimeEnvironmentId).toBe('env-e2e')`, received `null`.

The spec faked a runtime environment in the **renderer** store and then wrote the durable Active Server preference through the generic `settings:set` IPC. Since #10011 (`88b7e69ba1`, `src/main/ipc/settings.ts:98`) that handler does `delete sanitizedArgs.activeRuntimeEnvironmentId` — the preference is writable only through `settings:set-active-runtime-environment-preference`, which resolves the id against the **main-process** environment store. `88b7e69ba1` lands exactly in the last-pass → first-fail window.

CI corroborates the diagnosis beyond the assertion diff — the same test logged:

```
Error occurred in handler for 'runtimeEnvironments:subscribe':
  RuntimeEnvironmentStoreError: Unknown environment: env-e2e
Error occurred in handler for 'runtimeEnvironments:call':
  RuntimeEnvironmentStoreError: Unknown environment: env-e2e
```

i.e. main never knew about the renderer-fabricated host. This is intended product hardening, and no product code writes that key through the generic setter (grepped across `src/`, `mobile/`, `tests/`) — the test was stale.

**Fix:** register the host for real via `runtimeEnvironments:addFromPairingCode` (offline — the pairing offer is just parsed and persisted to `orca-environments.json`, no live server or network), then write the preference through its dedicated channel. The seeded `available` health and the assertion now key off the returned environment id, and the `Unknown environment` stderr noise goes away too.

## 2. `terminal-tab-switch-visual-restore.spec.ts:604` — alt-screen redraws

Failed only `cycle 0: marker missing after alt-screen redraw`; cycles 1–5 passed.

The spec writes frames straight into the renderer's xterm via `pane.terminal.write`, so those bytes never transit the PTY and main's model cannot contain them. On cycle 0 the freshly-spawned shell still has queued startup output, so hiding the pane makes main's hidden-delivery gate drop bytes and latch a reveal restore; the restore then repaints main's snapshot over the fabricated frame. Later cycles run ~4s later against an idle shell — nothing queued, no restore fires, and the frame survives.

Not a product defect: for real PTY-driven TUIs main's model tracks the alternate screen (`pty:getMainBufferSnapshot` returns `alternateScreen`), so a genuine hidden TUI frame *is* restored. Only harness-fabricated renderer state is discarded.

**Fix:** arm the existing `setHiddenSnapshotOverride` seam — already used by two sibling tests in this same file — so the reveal restore paints a valid frame instead of stale main-model content. The `markerPresent` assertion is kept: deleting it would remove the coverage. Pane identity is re-read per cycle so a reattach can't leave the override keyed to a stale PTY id.

The snapshot frame is numbered **one higher** than the live-written frame. Both carry the marker, so `markerPresent` holds whichever path wins, but the frame number on screen still says *which* path painted last. That buys back the signal a same-frame fix would have destroyed, and adds coverage the test never had:

- a new readback asserts the screen shows either the live frame or the restore frame — **anything else now fails**, so a restore that replays stale content is caught;
- the per-cycle path (`reveal restore` / `live write (no restore)`) is recorded as a `testInfo` annotation and logged, so a green run is no longer opaque about whether restores fired.

Which cycles latch a restore is load-dependent, so it is reported rather than asserted. The alt-screen frame authoring/readback helpers moved to `tests/e2e/helpers/alt-screen-frame.ts` — the additions pushed the spec past the 800-line `max-lines` cap, and disabling that rule is not allowed.

## Verification

Local, macOS, one invocation:

```
npx playwright test tests/e2e/onboarding.spec.ts \
  tests/e2e/terminal-tab-switch-visual-restore.spec.ts \
  --config tests/playwright.config.ts --project=electron-headless --workers=1
→ 17 passed (2.4m)
```

The new instrumentation reported, on this run:

```
[tab-switch-repro] alt-screen render path: cycle 0: live write (no restore),
cycle 1: live write (no restore), cycle 2: live write (no restore),
cycle 3: live write (no restore), cycle 4: reveal restore,
cycle 5: live write (no restore)
```

Cycle 4 latched a reveal restore and painted the override frame — so the seam this PR arms is demonstrably exercised on macOS, even though the *cycle-0* timing that fails in CI does not reproduce here. Before this change that distinction was invisible from a green run.

**What this local run does and does not prove.** For `onboarding.spec.ts` the failure is deterministic (the IPC strips the key on every platform), so the local pass is meaningful. For the alt-screen spec it is not: I re-ran the **unpatched** test on this machine twice and it **passed both times** (2.7m, 1.5m). It does not reproduce on macOS, so the local green is not a before/after for that one — only the Linux CI run can confirm it.

Also re-ran the two specs #10595 already fixed, to confirm that work holds on this base (`e564603d54`) — `daemon-slow-health-check-preservation.spec.ts` and `headless-serve-desktop-activation.spec.ts`: **2 passed**. Not re-fixed here.

Gates: `tsc` (node + web), `oxfmt --check`, `oxlint` — all clean.

> [!IMPORTANT]
> **A macOS local pass does not prove the Linux CI fix.** CI runs on Linux and only some of the eight failures reproduce on macOS. Please trigger a `workflow_dispatch` E2E run on this branch before merging.

## Why spec 2 is a harness artifact rather than a regression

This one deserved more scrutiny than "the mechanism is plausible", so I checked the failure history per-run rather than trusting the triage:

| scheduled run | sha | alt-screen |
|---|---|---|
| 30167442014 (07-25) | `505967eba0` | fail |
| 30130776139 (07-24) | `4dcb68f8fb` | fail |
| 30113308910 (07-24) | `17959a22b8` | fail |
| 30049572354 (07-23) | `94d3db4a24` | fail |
| 30029668048 (07-23) | `8f40ddf328` | pass |
| 29962554850 (07-22) | `9bdb8204e1` | pass |
| 29942534312 (07-22) | `6ad62410c9` | pass |
| 29873284541 (07-21) | `e986a7ba1a` | pass |
| 29853174139 (07-21) | `827cd49f41` | fail |

There is **no clean first-fail boundary** — it failed on 07-21, passed for four runs, then has failed every run since 07-23. Nothing in the `8f40ddf328..94d3db4a24` window touches the hidden-delivery gate or the reveal-restore path (the commits are source-control UI, relay broker startup, mobile, LAN renaming, OOM diagnostics, PR cards, orphan-sweep). And the test passes on macOS on demand. That pattern is a load-sensitive race that CI has recently been losing more often, not a regression introduced by a specific commit.

**On coverage.** An earlier revision of this PR made both paths render the *same* frame, which would have left the test unable to tell "a restore fired" from "no restore fired". That is fixed above by numbering the two frames differently: the marker assertion is path-agnostic (so the flake is gone) while the frame readback stays path-aware (so the signal is kept), and an unrecognised frame is now a failure.

What is still not covered: these frames are written with `pane.terminal.write` rather than driven through a real PTY, so this test exercises the restore *mechanism*, not main's alternate-screen tracking. That tracking is real (`pty:getMainBufferSnapshot` returns `alternateScreen`), and covering it end-to-end would mean emitting frames from a shell process and living with prompt output landing in the alt buffer — a different test, not a tweak to this one.

## Scope

Test-side only — no product code touched. Sibling branches own the four product bugs from #10519. Unrelated observation while reading run 30167442014: shard 4 also failed `rich-markdown-link-bubble-stacking.spec.ts:36`, which isn't in the triaged list of eight.
