### PR TITLE
fix(diff): keep scroll restore armed through layout shifts

### DIFF
--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts
@@ -135,6 +135,47 @@ describe('useVirtualizedScrollAnchor with marks + restoreSignal', () => {
     expect(virtualizer.scrollToIndex).not.toHaveBeenCalled()
   })
 
+  it('keeps retrying a restore that is still converging when layout moves the viewport', async () => {
+    const { harness, useVirtualizedScrollAnchor } = await loadHook()
+    // The first pass writes toward the anchor and remains armed.
+    const { el } = createScrollElement({
+      rowElements: [anchoredRowElement('row-1', -3_000)],
+      scrollTop: 746
+    })
+    const anchorRef = { current: { key: 'row-1', offset: 3_358, scrollTop: 746 } }
+    const virtualizer = virtualizerWithRow1()
+
+    const render = (): void => {
+      harness.beginRender()
+      // oxlint-disable-next-line react-hooks/rules-of-hooks -- test harness mocks React's hook dispatcher directly.
+      useVirtualizedScrollAnchor({
+        anchorRef,
+        getItemElementKey: (element: FakeRowElement) => element.key,
+        getRowKey: (row: string) => row,
+        itemElementSelector: '[data-row]',
+        programmaticScrollMarks: createProgrammaticScrollMarks(),
+        recordAnchorOnScroll: false,
+        restoreSignal: 'signal-a',
+        rows: ['row-0', 'row-1'],
+        scrollElementRef: { current: el },
+        scrollOffsetRef: { current: 746 },
+        totalSize: 30_000,
+        virtualizer
+      } as never)
+      harness.effects[1]?.effect()
+    }
+
+    render()
+    const attemptsAfterFirstPass = el.querySelectorAll.mock.calls.length
+    expect(attemptsAfterFirstPass).toBeGreaterThan(0)
+
+    // Simulate Monaco measurement shifting the viewport without user input.
+    el.scrollTop += 196
+
+    render()
+    expect(el.querySelectorAll.mock.calls.length).toBeGreaterThan(attemptsAfterFirstPass)
+  })
+
   it('lets the user position win when the viewport moved after the anchor was recorded', async () => {
     const { harness, useVirtualizedScrollAnchor } = await loadHook()
     const { el } = createScrollElement({

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts
@@ -137,12 +137,76 @@ describe('useVirtualizedScrollAnchor with marks + restoreSignal', () => {
 
   it('keeps retrying a restore that is still converging when layout moves the viewport', async () => {
     const { harness, useVirtualizedScrollAnchor } = await loadHook()
-    // The first pass writes toward the anchor and remains armed.
+    let rowTop = -3_000
+    const rowElement: FakeRowElement = {
+      getBoundingClientRect: () => ({
+        bottom: rowTop + 4_000,
+        height: 4_000,
+        top: rowTop
+      }),
+      isConnected: true,
+      key: 'row-1'
+    }
     const { el } = createScrollElement({
+      rowElements: [rowElement],
+      scrollTop: 746
+    })
+    const anchorRef = { current: { key: 'row-1', offset: 3_358, scrollTop: 746 } }
+    const virtualizer = virtualizerWithRow1()
+    // Stable across rerenders, like the real caller: fresh objects would reset
+    // the marks and offset bookkeeping the first pass left behind.
+    const programmaticScrollMarks = createProgrammaticScrollMarks()
+    const scrollElementRef = { current: el }
+    const scrollOffsetRef = { current: 746 }
+
+    const render = (): void => {
+      harness.beginRender()
+      // oxlint-disable-next-line react-hooks/rules-of-hooks -- test harness mocks React's hook dispatcher directly.
+      useVirtualizedScrollAnchor({
+        anchorRef,
+        getItemElementKey: (element: FakeRowElement) => element.key,
+        getRowKey: (row: string) => row,
+        itemElementSelector: '[data-row]',
+        programmaticScrollMarks,
+        recordAnchorOnScroll: false,
+        restoreSignal: 'signal-a',
+        rows: ['row-0', 'row-1'],
+        scrollElementRef,
+        scrollOffsetRef,
+        totalSize: 30_000,
+        virtualizer
+      } as never)
+      harness.effects[1]?.effect()
+    }
+
+    render()
+    const attemptsAfterFirstPass = el.querySelectorAll.mock.calls.length
+    expect(attemptsAfterFirstPass).toBeGreaterThan(0)
+    expect(el.scrollTop).toBe(1_104)
+
+    // Monaco grows content above while browser anchoring keeps the row pinned.
+    rowTop = -3_358
+    el.scrollTop += 196
+
+    render()
+    expect(el.querySelectorAll.mock.calls.length).toBeGreaterThan(attemptsAfterFirstPass)
+    const attemptsAfterConfirm = el.querySelectorAll.mock.calls.length
+    expect(anchorRef.current.scrollTop).toBe(1_300)
+
+    render()
+    expect(el.querySelectorAll.mock.calls.length).toBe(attemptsAfterConfirm)
+  })
+
+  it('lets an unmarked user scroll disarm a restore that is still converging', async () => {
+    const { harness, useVirtualizedScrollAnchor } = await loadHook()
+    const { el, emitScroll } = createScrollElement({
       rowElements: [anchoredRowElement('row-1', -3_000)],
       scrollTop: 746
     })
     const anchorRef = { current: { key: 'row-1', offset: 3_358, scrollTop: 746 } }
+    const programmaticScrollMarks = createProgrammaticScrollMarks()
+    const scrollElementRef = { current: el }
+    const scrollOffsetRef = { current: 746 }
     const virtualizer = virtualizerWithRow1()
 
     const render = (): void => {
@@ -153,27 +217,29 @@ describe('useVirtualizedScrollAnchor with marks + restoreSignal', () => {
         getItemElementKey: (element: FakeRowElement) => element.key,
         getRowKey: (row: string) => row,
         itemElementSelector: '[data-row]',
-        programmaticScrollMarks: createProgrammaticScrollMarks(),
+        programmaticScrollMarks,
         recordAnchorOnScroll: false,
         restoreSignal: 'signal-a',
         rows: ['row-0', 'row-1'],
-        scrollElementRef: { current: el },
-        scrollOffsetRef: { current: 746 },
+        scrollElementRef,
+        scrollOffsetRef,
         totalSize: 30_000,
         virtualizer
       } as never)
-      harness.effects[1]?.effect()
     }
 
     render()
+    harness.effects[0]?.effect()
+    harness.effects[1]?.effect()
     const attemptsAfterFirstPass = el.querySelectorAll.mock.calls.length
-    expect(attemptsAfterFirstPass).toBeGreaterThan(0)
+    expect(el.scrollTop).toBe(1_104)
 
-    // Simulate Monaco measurement shifting the viewport without user input.
-    el.scrollTop += 196
-
+    emitScroll(1_400)
     render()
-    expect(el.querySelectorAll.mock.calls.length).toBeGreaterThan(attemptsAfterFirstPass)
+    harness.effects[1]?.effect()
+
+    expect(el.scrollTop).toBe(1_400)
+    expect(el.querySelectorAll.mock.calls.length).toBe(attemptsAfterFirstPass)
   })
 
   it('lets the user position win when the viewport moved after the anchor was recorded', async () => {

--- a/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
+++ b/src/renderer/src/hooks/useVirtualizedScrollAnchor.ts
@@ -254,7 +254,8 @@ export function useVirtualizedScrollAnchor<
         // adjustment; restoring here would fight concurrent user scrolling.
         return
       }
-      if (anchor.scrollTop !== undefined) {
+      // Why: pending restores own layout shifts; unmarked user scrolls disarm them in the listener.
+      if (anchor.scrollTop !== undefined && !pendingRestoreRef.current) {
         const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight)
         const clampExplained =
           anchor.scrollTop > maxScrollTop + 1 && el.scrollTop >= maxScrollTop - 2


### PR DESCRIPTION
## Summary

- Preserve the combined diff's within-section scroll position while a remounted viewer converges after tab switches.
- Keep an in-flight anchor restore armed through measurement-driven viewport shifts; genuine unmarked user scrolls still disarm it through the scroll listener.
- Add a revert-proven unit regression for the dropped retry.

## Screenshots

No visual change to capture; this restores the existing scroll-position behavior.

## Testing

- [x] `npx oxfmt --check -c .oxfmtrc.json src/renderer/src/hooks/useVirtualizedScrollAnchor.ts src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts`
- [x] `npx oxlint src/renderer/src/hooks/useVirtualizedScrollAnchor.ts src/renderer/src/hooks/useVirtualizedScrollAnchor.marks-restore-signal.test.ts`
- [x] `npx tsc --noEmit -p config/tsconfig.node.json --composite false`
- [x] `npx tsc --noEmit -p config/tsconfig.web.json --composite false`
- [x] `npx vitest run --config config/vitest.config.ts src/renderer/src/hooks src/renderer/src/components/sidebar --reporter=dot` (2,036 tests)
- [x] `npx electron-vite build --mode e2e`
- [x] Combined diff scroll restore E2E on macOS: one normal run plus `--repeat-each=3` (4/4 passed)
- [x] Added a regression test that fails against the previous condition (`expected 1 to be greater than 1`) and passes with the fix

## AI Review Report

An independent read-only AI review found no issues. It checked the pending-restore state machine, verified that unmarked user input still wins through the listener disarm, confirmed marked restore and virtualizer writes remain programmatic, and confirmed `WorktreeList` is behaviorally unchanged because it does not pass `restoreSignal`.

Cross-platform review covered macOS, Linux, Windows, SSH, and folder workspaces. This renderer-local DOM state change touches no shortcuts, labels, paths, shell behavior, Git behavior, transport, or platform-specific Electron APIs.

## Security Audit

No security-sensitive surface changed. The patch adds no input handling, command execution, path handling, authentication, secrets, dependencies, IPC, or network behavior.

## Notes

- Related to #10519.
- `WorktreeList` remains on the legacy every-measurement restore path, so the one-shot signal consumption fixed here cannot strand the sidebar consumer.
- The scheduled failure is timing-dependent on Linux CI. The macOS passes validate local behavior but cannot prove the Linux fix; CI remains the authoritative check.
