### PR TITLE
fix(terminal): recover wedged panes after input

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4803,6 +4803,30 @@ describe('connectPanePty', () => {
     binding.dispose()
   })
 
+  it('does not arm the wedge probe when acknowledged input is rejected', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    const { WRITE_PIPELINE_STALL_CHECK_MS } =
+      await import('@/lib/pane-manager/terminal-write-pipeline-health')
+    const transport = createMockTransport('pty-rejected')
+    transport.sendInputAccepted = vi.fn().mockResolvedValue(false)
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const binding = connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks()
+    pane.terminal.write.mockClear()
+    pane.terminal.write.mockImplementation(() => {})
+
+    sendTerminalInputThroughPane(pane, '\x03')
+    await flushAsyncTicks()
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS * 2)
+    await flushAsyncTicks()
+
+    expect(transport.sendInputAccepted).toHaveBeenCalledWith('\x03')
+    expect(pane.terminal.write).not.toHaveBeenCalledWith('', expect.any(Function))
+    binding.dispose()
+  })
+
   it('blocks input when tab-level ptyId is stale even if panePtyId is null', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -4777,6 +4777,32 @@ describe('connectPanePty', () => {
     expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
   })
 
+  it('recovers a wedged write pipeline after accepted input without renderer output', async () => {
+    vi.useFakeTimers()
+    const { connectPanePty } = await import('./pty-connection')
+    const { settleTerminalWriteStallWatch, WRITE_PIPELINE_STALL_CHECK_MS } =
+      await import('@/lib/pane-manager/terminal-write-pipeline-health')
+    const remountTerminalTabForRecovery = vi.fn<(tabId: string) => boolean>(() => true)
+    mockStoreState = { ...mockStoreState, remountTerminalTabForRecovery } as StoreState
+    const transport = createMockTransport('pty-wedged')
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    const binding = connectPanePty(pane as never, createManager(1) as never, createDeps() as never)
+    await flushAsyncTicks()
+    pane.terminal.write.mockClear()
+    pane.terminal.write.mockImplementation(() => {})
+
+    sendTerminalInputThroughPane(pane, 'x')
+    settleTerminalWriteStallWatch(pane.terminal)
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS * 2)
+    await flushAsyncTicks()
+
+    expect(transport.sendInput).toHaveBeenCalledWith('x')
+    expect(pane.terminal.write).toHaveBeenCalledWith('', expect.any(Function))
+    expect(remountTerminalTabForRecovery).toHaveBeenCalledWith('tab-1')
+    binding.dispose()
+  })
+
   it('blocks input when tab-level ptyId is stale even if panePtyId is null', async () => {
     const { connectPanePty } = await import('./pty-connection')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -75,6 +75,7 @@ import {
   waitForTerminalReplayWritesParsed
 } from './replay-guard'
 import {
+  armTerminalWriteStallWatch,
   isTerminalWritePipelineCertifiedDead,
   registerUndeliverableWriteHandler
 } from '@/lib/pane-manager/terminal-write-pipeline-health'
@@ -3604,6 +3605,10 @@ export function connectPanePty(
   // pre-existing session when a late reattach resolves, so a remount racing
   // a slow-but-alive connect costs a wasted view rebuild, not a shell.
   const TRANSPORT_CONNECT_SETTLE_GRACE_MS = 60_000
+  // Why: user input must probe a wedged xterm even when no PTY output reaches the renderer.
+  const armWritePipelineWatchForUserInput = (): void => {
+    armTerminalWriteStallWatch(pane.terminal, { requireProbe: true })
+  }
   const requestRecoveryForUndeliverableInput = (): void => {
     if (transport.isConnected?.() && transport.getPtyId() !== null) {
       return
@@ -3729,6 +3734,7 @@ export function connectPanePty(
       }
       clearPendingTerminalInputIntent()
       markTerminalInputSent()
+      armWritePipelineWatchForUserInput()
       const writePromise = transport
         .sendInputAccepted(data)
         .then((accepted) => {
@@ -3754,6 +3760,7 @@ export function connectPanePty(
       claimViewportForUserActivity()
       if (transport.sendInput(data)) {
         markAcceptedTerminalInputSent()
+        armWritePipelineWatchForUserInput()
         observeAcceptedShellCommandInput(data)
         observeAcceptedTerminalInput(data, intent)
       } else {
@@ -3765,6 +3772,7 @@ export function connectPanePty(
     claimViewportForUserActivity()
     if (transport.sendInput(data)) {
       markAcceptedTerminalInputSent()
+      armWritePipelineWatchForUserInput()
       observeAcceptedShellCommandInput(data)
       observeAcceptedTerminalInput(data)
       observeSentTerminalInputIntent(data)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -75,9 +75,9 @@ import {
   waitForTerminalReplayWritesParsed
 } from './replay-guard'
 import {
-  armTerminalWriteStallWatch,
   isTerminalWritePipelineCertifiedDead,
-  registerUndeliverableWriteHandler
+  registerUndeliverableWriteHandler,
+  requestTerminalWritePipelineProbe
 } from '@/lib/pane-manager/terminal-write-pipeline-health'
 import {
   captureTerminalPaneRecoveryGeneration,
@@ -3358,6 +3358,8 @@ export function connectPanePty(
   const MAX_DEFERRED_REATTACH_LIVE_CHUNKS = 1_024
   const markTerminalInputSent = (): void => {
     lastTerminalInputAt = performance.now()
+    // Why: input must probe a wedged xterm even when the PTY produces no renderer output.
+    requestTerminalWritePipelineProbe(pane.terminal)
   }
   const recordTerminalInputForHibernation = (): void => {
     useAppStore.getState().recordTerminalInput(cacheKey)
@@ -3605,10 +3607,6 @@ export function connectPanePty(
   // pre-existing session when a late reattach resolves, so a remount racing
   // a slow-but-alive connect costs a wasted view rebuild, not a shell.
   const TRANSPORT_CONNECT_SETTLE_GRACE_MS = 60_000
-  // Why: user input must probe a wedged xterm even when no PTY output reaches the renderer.
-  const armWritePipelineWatchForUserInput = (): void => {
-    armTerminalWriteStallWatch(pane.terminal, { requireProbe: true })
-  }
   const requestRecoveryForUndeliverableInput = (): void => {
     if (transport.isConnected?.() && transport.getPtyId() !== null) {
       return
@@ -3734,7 +3732,6 @@ export function connectPanePty(
       }
       clearPendingTerminalInputIntent()
       markTerminalInputSent()
-      armWritePipelineWatchForUserInput()
       const writePromise = transport
         .sendInputAccepted(data)
         .then((accepted) => {
@@ -3760,7 +3757,6 @@ export function connectPanePty(
       claimViewportForUserActivity()
       if (transport.sendInput(data)) {
         markAcceptedTerminalInputSent()
-        armWritePipelineWatchForUserInput()
         observeAcceptedShellCommandInput(data)
         observeAcceptedTerminalInput(data, intent)
       } else {
@@ -3772,7 +3768,6 @@ export function connectPanePty(
     claimViewportForUserActivity()
     if (transport.sendInput(data)) {
       markAcceptedTerminalInputSent()
-      armWritePipelineWatchForUserInput()
       observeAcceptedShellCommandInput(data)
       observeAcceptedTerminalInput(data)
       observeSentTerminalInputIntent(data)

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3731,12 +3731,12 @@ export function connectPanePty(
         cancelSuspendedShellCommandInference()
       }
       clearPendingTerminalInputIntent()
-      markTerminalInputSent()
       const writePromise = transport
         .sendInputAccepted(data)
         .then((accepted) => {
           if (accepted) {
-            recordTerminalInputForHibernationFallback()
+            // Why: rejected writes use transport recovery and must not arm a parser probe.
+            markAcceptedTerminalInputSent()
             observeAcceptedShellCommandInput(data)
             observeAcceptedTerminalInput(data, acknowledgedIntent)
             interruptInference.observeInputIntent(acknowledgedIntent)

--- a/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.test.ts
@@ -236,6 +236,32 @@ describe('terminal write pipeline health', () => {
     _resetWritePipelineHealthForTests(terminal)
   })
 
+  it('keeps a requested probe alive while the pipeline makes parse progress', () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    terminal.dropCallbacks = true
+    const handler = vi.fn()
+    registerUndeliverableWriteHandler(terminal, handler)
+
+    requestTerminalWritePipelineProbe(terminal)
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS)
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS / 2)
+    settleTerminalWriteStallWatch(terminal)
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS / 2)
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS / 2)
+    settleTerminalWriteStallWatch(terminal)
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS / 2)
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(isTerminalWritePipelineCertifiedDead(terminal)).toBe(false)
+
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS)
+
+    expect(handler).toHaveBeenCalledWith('write-stalled')
+    expect(isTerminalWritePipelineCertifiedDead(terminal)).toBe(true)
+    _resetWritePipelineHealthForTests(terminal)
+  })
+
   it('notifies at most once per terminal instance', () => {
     const terminal = makeTerminal()
     const handler = vi.fn()

--- a/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.test.ts
@@ -9,6 +9,7 @@ import {
   isTerminalWritePipelineCertifiedDead,
   notifyUndeliverableWrite,
   registerUndeliverableWriteHandler,
+  requestTerminalWritePipelineProbe,
   settleTerminalWriteStallWatch,
   WRITE_PIPELINE_STALL_CHECK_MS
 } from './terminal-write-pipeline-health'
@@ -113,14 +114,15 @@ describe('terminal write pipeline health', () => {
     _resetWritePipelineHealthForTests(terminal)
   })
 
-  it('keeps a required probe armed through unrelated parse progress', () => {
+  it('keeps a requested probe armed through unrelated parse progress', () => {
     vi.useFakeTimers()
     const terminal = makeTerminal()
     terminal.dropCallbacks = true
     const handler = vi.fn()
     registerUndeliverableWriteHandler(terminal, handler)
 
-    armTerminalWriteStallWatch(terminal, { requireProbe: true })
+    armTerminalWriteStallWatch(terminal)
+    requestTerminalWritePipelineProbe(terminal)
     settleTerminalWriteStallWatch(terminal)
     vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS * 2)
 

--- a/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.test.ts
@@ -113,6 +113,22 @@ describe('terminal write pipeline health', () => {
     _resetWritePipelineHealthForTests(terminal)
   })
 
+  it('keeps a required probe armed through unrelated parse progress', () => {
+    vi.useFakeTimers()
+    const terminal = makeTerminal()
+    terminal.dropCallbacks = true
+    const handler = vi.fn()
+    registerUndeliverableWriteHandler(terminal, handler)
+
+    armTerminalWriteStallWatch(terminal, { requireProbe: true })
+    settleTerminalWriteStallWatch(terminal)
+    vi.advanceTimersByTime(WRITE_PIPELINE_STALL_CHECK_MS * 2)
+
+    expect(handler).toHaveBeenCalledWith('write-stalled')
+    expect(isTerminalWritePipelineCertifiedDead(terminal)).toBe(true)
+    _resetWritePipelineHealthForTests(terminal)
+  })
+
   it('a slow-but-alive pipeline disarms when the probe parses', () => {
     vi.useFakeTimers()
     const terminal = makeTerminal()

--- a/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.ts
@@ -6,10 +6,11 @@
 // delivery ack credits leak, and the pane becomes a fossil the user can only
 // cure by reloading the window. Detection here is probe-certified (mirroring
 // replay-guard.ts): a stalled completion triggers an empty probe write; xterm
-// parses in FIFO order, so a probe that also never completes proves the
-// pipeline is dead rather than slow. Certification notifies a per-terminal
-// handler (registered by the pane's PTY connection) that requests pane
-// recovery — a remount that rebuilds the xterm and reattaches the live PTY.
+// parses in FIFO order, so a completing probe proves preceding work drained. A
+// silent probe is only certified dead after a full interval without any parse
+// progress. Certification notifies a per-terminal handler (registered by the
+// pane's PTY connection) that requests pane recovery — a remount that rebuilds
+// the xterm and reattaches the live PTY.
 
 type WriteTarget = {
   write(data: string, callback?: () => void): void
@@ -109,9 +110,9 @@ export function isTerminalWritePipelineCertifiedDead(terminal: object): boolean 
  * Arm (or keep armed) the stall watch for a terminal that just had a write
  * issued. Cleared by settleTerminalWriteStallWatch from the write-completion
  * callback. If the completion never arrives, an empty probe write certifies
- * dead-vs-slow exactly like replay-guard.ts: probe completes → pipeline is
- * alive (slow parse), re-arm and keep waiting; probe silent for another
- * interval → dead, notify.
+ * dead-vs-slow conservatively like replay-guard.ts: probe completes → pipeline
+ * is alive (slow parse), re-arm and keep waiting; probe silent for another
+ * interval without any parse progress → dead, notify.
  */
 function armTerminalWritePipelineWatch(
   terminal: WriteTarget,
@@ -138,14 +139,25 @@ function armTerminalWritePipelineWatch(
     timer: setTimeout(probeForStall, stallCheckMs)
   }
   const certifyDead = (): void => certifyTerminalWritePipelineDead(terminal, watch)
+  function armProbeQuietWindow(quietSinceGeneration: number): void {
+    watch.timer = setTimeout(() => {
+      if (stallWatchByTerminal.get(terminal) !== watch) {
+        return
+      }
+      if (hasTerminalParseProgressSince(terminal, quietSinceGeneration)) {
+        armProbeQuietWindow(captureTerminalParseProgressGeneration(terminal))
+        return
+      }
+      certifyDead()
+    }, stallCheckMs)
+  }
   function probeForStall(): void {
     if (stallWatchByTerminal.get(terminal) !== watch) {
       return
     }
-    let probeParsed = false
+    const probeQueuedAtGeneration = captureTerminalParseProgressGeneration(terminal)
     try {
       terminal.write('', () => {
-        probeParsed = true
         // Why: replay guards share this terminal-scoped generation; even an
         // auxiliary FIFO probe proves the parser is alive and making progress.
         recordTerminalParseProgress(terminal)
@@ -161,11 +173,9 @@ function armTerminalWritePipelineWatch(
       certifyDead()
       return
     }
-    watch.timer = setTimeout(() => {
-      if (!probeParsed) {
-        certifyDead()
-      }
-    }, stallCheckMs)
+    if (stallWatchByTerminal.get(terminal) === watch) {
+      armProbeQuietWindow(probeQueuedAtGeneration)
+    }
   }
   stallWatchByTerminal.set(terminal, watch)
 }

--- a/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.ts
@@ -45,6 +45,7 @@ export function hasTerminalParseProgressSince(terminal: object, generation: numb
 type StallWatch = {
   timer: ReturnType<typeof setTimeout>
   onCertifiedDead?: () => void
+  requireProbe: boolean
 }
 
 const stallWatchByTerminal = new WeakMap<object, StallWatch>()
@@ -112,14 +113,25 @@ export function isTerminalWritePipelineCertifiedDead(terminal: object): boolean 
  */
 export function armTerminalWriteStallWatch(
   terminal: WriteTarget,
-  options: { onCertifiedDead?: () => void; stallCheckMs?: number } = {}
+  options: {
+    onCertifiedDead?: () => void
+    /** Ignore unrelated write completions so user-input health checks reach their FIFO probe. */
+    requireProbe?: boolean
+    stallCheckMs?: number
+  } = {}
 ): void {
-  if (stallWatchByTerminal.has(terminal) || certifiedDeadTerminals.has(terminal)) {
+  if (certifiedDeadTerminals.has(terminal)) {
+    return
+  }
+  const existingWatch = stallWatchByTerminal.get(terminal)
+  if (existingWatch) {
+    existingWatch.requireProbe ||= options.requireProbe === true
     return
   }
   const stallCheckMs = options.stallCheckMs ?? WRITE_PIPELINE_STALL_CHECK_MS
   const watch: StallWatch = {
     onCertifiedDead: options.onCertifiedDead,
+    requireProbe: options.requireProbe === true,
     timer: setTimeout(probeForStall, stallCheckMs)
   }
   const certifyDead = (): void => certifyTerminalWritePipelineDead(terminal, watch)
@@ -165,9 +177,12 @@ export function cancelTerminalWriteStallWatch(terminal: object): void {
   stallWatchByTerminal.delete(terminal)
 }
 
-/** Write completed normally — the pipeline is healthy; drop any pending watch. */
+/** Write completed normally — record progress and drop ordinary write watches. */
 export function settleTerminalWriteStallWatch(terminal: object): void {
   recordTerminalParseProgress(terminal)
+  if (stallWatchByTerminal.get(terminal)?.requireProbe) {
+    return
+  }
   cancelTerminalWriteStallWatch(terminal)
 }
 

--- a/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-write-pipeline-health.ts
@@ -42,10 +42,12 @@ export function hasTerminalParseProgressSince(terminal: object, generation: numb
   return captureTerminalParseProgressGeneration(terminal) !== generation
 }
 
+type StallWatchMode = 'output-completion' | 'fifo-probe'
+
 type StallWatch = {
   timer: ReturnType<typeof setTimeout>
   onCertifiedDead?: () => void
-  requireProbe: boolean
+  mode: StallWatchMode
 }
 
 const stallWatchByTerminal = new WeakMap<object, StallWatch>()
@@ -111,27 +113,28 @@ export function isTerminalWritePipelineCertifiedDead(terminal: object): boolean 
  * alive (slow parse), re-arm and keep waiting; probe silent for another
  * interval → dead, notify.
  */
-export function armTerminalWriteStallWatch(
+function armTerminalWritePipelineWatch(
   terminal: WriteTarget,
   options: {
+    mode: StallWatchMode
     onCertifiedDead?: () => void
-    /** Ignore unrelated write completions so user-input health checks reach their FIFO probe. */
-    requireProbe?: boolean
     stallCheckMs?: number
-  } = {}
+  }
 ): void {
   if (certifiedDeadTerminals.has(terminal)) {
     return
   }
   const existingWatch = stallWatchByTerminal.get(terminal)
   if (existingWatch) {
-    existingWatch.requireProbe ||= options.requireProbe === true
+    if (options.mode === 'fifo-probe') {
+      existingWatch.mode = 'fifo-probe'
+    }
     return
   }
   const stallCheckMs = options.stallCheckMs ?? WRITE_PIPELINE_STALL_CHECK_MS
   const watch: StallWatch = {
+    mode: options.mode,
     onCertifiedDead: options.onCertifiedDead,
-    requireProbe: options.requireProbe === true,
     timer: setTimeout(probeForStall, stallCheckMs)
   }
   const certifyDead = (): void => certifyTerminalWritePipelineDead(terminal, watch)
@@ -167,6 +170,21 @@ export function armTerminalWriteStallWatch(
   stallWatchByTerminal.set(terminal, watch)
 }
 
+export function armTerminalWriteStallWatch(
+  terminal: WriteTarget,
+  options: { onCertifiedDead?: () => void; stallCheckMs?: number } = {}
+): void {
+  armTerminalWritePipelineWatch(terminal, { ...options, mode: 'output-completion' })
+}
+
+/** Require the active watch to reach its FIFO probe before it may settle. */
+export function requestTerminalWritePipelineProbe(
+  terminal: WriteTarget,
+  options: { stallCheckMs?: number } = {}
+): void {
+  armTerminalWritePipelineWatch(terminal, { ...options, mode: 'fifo-probe' })
+}
+
 /** Cancel a pending watch without claiming that any bytes parsed. */
 export function cancelTerminalWriteStallWatch(terminal: object): void {
   const watch = stallWatchByTerminal.get(terminal)
@@ -177,10 +195,10 @@ export function cancelTerminalWriteStallWatch(terminal: object): void {
   stallWatchByTerminal.delete(terminal)
 }
 
-/** Write completed normally — record progress and drop ordinary write watches. */
+/** Write completed normally — the pipeline is healthy; drop any pending watch. */
 export function settleTerminalWriteStallWatch(terminal: object): void {
   recordTerminalParseProgress(terminal)
-  if (stallWatchByTerminal.get(terminal)?.requireProbe) {
+  if (stallWatchByTerminal.get(terminal)?.mode === 'fifo-probe') {
     return
   }
   cancelTerminalWriteStallWatch(terminal)


### PR DESCRIPTION
## Summary

- Request a terminal write-pipeline FIFO probe from the shared accepted-input bookkeeping point, covering all accepted input paths without duplicated branch logic.
- Arm acknowledged input only after the transport confirms acceptance; rejected or unbound input uses transport recovery and never arms the parser watchdog.
- Model one terminal-scoped watchdog with explicit output-completion and fifo-probe modes. Input upgrades the active watch, so completion from earlier queued work cannot cancel the FIFO marker.
- Treat the probe callback as the healthy verdict. If other writes keep parsing while the probe waits behind backlog, extend the quiet deadline instead of remounting a slow terminal.
- Keep one coalesced timer and at most one zero-byte local xterm write per terminal. The probe produces no PTY, SSH, or network traffic.
- Add unit coverage for accepted input without renderer output, rejected acknowledged input, mode upgrades, and parse-progress deadline extension.

## Verification

- `npx oxfmt --check -c .oxfmtrc.json` on all four changed files
- `npx oxlint` on all four changed files
- Node and web TypeScript projects
- Terminal-pane and pane-manager Vitest scope: 238 files passed; 2,977 tests passed; 1 skipped
- `npx electron-vite build --mode e2e`
- Repeated target E2E: 6/6 passed (three wedged-pipeline recoveries and three disposed-terminal recoveries)
- Earlier full repeated run: 5 scenarios passed; one repetition failed before the test body because the initial PaneManager did not mount within 30 seconds
- No changes under `tests/e2e`

## Platform caveat

The repeated E2E ran on macOS, which cannot prove the Linux CI failure is fixed. The exact Linux-specific reason that post-wedge PTY output sometimes fails to reach the renderer remains unconfirmed; the available evidence does not establish either hidden-delivery gating or xvfb focus routing as the trigger.