### PR TITLE
Implement GPU fallback escalation with driver identity capture

### DIFF
--- a/src/main/crash-reporting/gpu-info-snapshot.test.ts
+++ b/src/main/crash-reporting/gpu-info-snapshot.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  captureGpuInfoSnapshot,
+  getGpuInfoSnapshot,
+  setGpuInfoSnapshotForTesting,
+  summarizeGpuInfo
+} from './gpu-info-snapshot'
+
+const COMPLETE_INFO = {
+  auxAttributes: {
+    glVendor: 'Google Inc. (Intel)',
+    glRenderer: 'ANGLE (Intel, Intel(R) UHD Graphics 620 Direct3D11 vs_5_0 ps_5_0, D3D11)',
+    glVersion: 'OpenGL ES 2.0.0',
+    glImplementation: 'EGL_ANGLE',
+    glExtensions: 'GL_EXT_a '.repeat(500),
+    basicInfoState: 1,
+    contextInfoState: 1,
+    initializationTime: 42.5,
+    inProcessGpu: false,
+    sandboxed: true,
+    directComposition: true,
+    passthroughCmdDecoder: true
+  },
+  gpuDevice: [
+    { active: false, vendorId: 4318, deviceId: 7938, driverVendor: 'NVIDIA' },
+    {
+      active: true,
+      vendorId: 32902,
+      deviceId: 15130,
+      driverVendor: 'Intel Corporation',
+      driverVersion: '31.0.101.2111',
+      deviceString: 'Intel(R) UHD Graphics 620'
+    }
+  ],
+  machineModelName: 'Latitude 5400',
+  machineModelVersion: '1.0'
+}
+
+describe('summarizeGpuInfo', () => {
+  it('flattens the active device and aux attributes', () => {
+    const summary = summarizeGpuInfo(COMPLETE_INFO)
+
+    expect(summary).toMatchObject({
+      gpuInfoAvailable: true,
+      gpuDeviceCount: 2,
+      gpuVendorId: '0x8086',
+      gpuDeviceId: '0x3b1a',
+      gpuDriverVendor: 'Intel Corporation',
+      gpuDriverVersion: '31.0.101.2111',
+      gpuGlVendor: 'Google Inc. (Intel)',
+      gpuAnglePlatform: 'EGL_ANGLE',
+      gpuInProcess: false,
+      gpuSandboxed: true,
+      gpuBasicInfoState: 1,
+      gpuInitializationTimeMs: 42.5,
+      gpuMachineModel: 'Latitude 5400'
+    })
+  })
+
+  // Why: glExtensions is kilobytes long and would dominate every crash report.
+  it('never copies the extension list and bounds long strings', () => {
+    const summary = summarizeGpuInfo(COMPLETE_INFO)
+
+    expect(Object.keys(summary)).not.toContain('gpuGlExtensions')
+    for (const value of Object.values(summary)) {
+      if (typeof value === 'string') {
+        expect(value.length).toBeLessThanOrEqual(160)
+      }
+    }
+  })
+
+  it('falls back to the first device when none is marked active', () => {
+    const summary = summarizeGpuInfo({ gpuDevice: [{ vendorId: 4318, deviceId: 7938 }] })
+    expect(summary).toMatchObject({ gpuVendorId: '0x10de', gpuDeviceCount: 1 })
+  })
+
+  it('reports unavailable for non-object payloads', () => {
+    expect(summarizeGpuInfo(null)).toEqual({ gpuInfoAvailable: false })
+    expect(summarizeGpuInfo('nope')).toEqual({ gpuInfoAvailable: false })
+  })
+
+  it('omits fields the payload does not carry', () => {
+    const summary = summarizeGpuInfo({ gpuDevice: [] })
+    expect(summary).toEqual({ gpuInfoAvailable: true, gpuDeviceCount: 0 })
+  })
+})
+
+describe('captureGpuInfoSnapshot', () => {
+  afterEach(() => {
+    setGpuInfoSnapshotForTesting(null)
+    vi.useRealTimers()
+  })
+
+  it('caches a successful capture', async () => {
+    const snapshot = await captureGpuInfoSnapshot(async () => COMPLETE_INFO, 1_000)
+    expect(snapshot.gpuVendorId).toBe('0x8086')
+    expect(getGpuInfoSnapshot()).toBe(snapshot)
+  })
+
+  it('records the error shape when getGPUInfo rejects', async () => {
+    const snapshot = await captureGpuInfoSnapshot(async () => {
+      throw new Error('GPU process crashed')
+    }, 1_000)
+    expect(snapshot).toMatchObject({ gpuInfoAvailable: false, gpuInfoError: 'GPU process crashed' })
+    expect(getGpuInfoSnapshot()).toBe(snapshot)
+  })
+
+  // Why: on the machines this exists for, the GPU child never initializes and the promise never settles.
+  it('times out instead of hanging forever', async () => {
+    vi.useFakeTimers()
+    const pending = captureGpuInfoSnapshot(() => new Promise(() => {}), 10_000)
+    await vi.advanceTimersByTimeAsync(10_000)
+    await expect(pending).resolves.toEqual({ gpuInfoAvailable: false, gpuInfoError: 'timeout' })
+  })
+})

--- a/src/main/crash-reporting/gpu-info-snapshot.ts
+++ b/src/main/crash-reporting/gpu-info-snapshot.ts
@@ -1,0 +1,143 @@
+import {
+  sanitizeCrashReportDetails,
+  type CrashReportBreadcrumbData
+} from '../../shared/crash-reporting'
+
+/**
+ * Driver identity for crash details.
+ *
+ * Nothing in the main process called app.getGPUInfo() before, so every GPU
+ * crash bundle arrived without a vendor, device or driver version — triage
+ * could not tell a broken driver from a broken machine.
+ */
+
+/** Bounded so a pathological glExtensions-style string can't dominate the report. */
+const MAX_GPU_STRING_LENGTH = 160
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null
+}
+
+function pickString(source: UnknownRecord | null, key: string): string | undefined {
+  const value = source?.[key]
+  return typeof value === 'string' && value.length > 0
+    ? value.slice(0, MAX_GPU_STRING_LENGTH)
+    : undefined
+}
+
+function pickNumber(source: UnknownRecord | null, key: string): number | undefined {
+  const value = source?.[key]
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+function pickBoolean(source: UnknownRecord | null, key: string): boolean | undefined {
+  const value = source?.[key]
+  return typeof value === 'boolean' ? value : undefined
+}
+
+/** Vendor/device ids arrive as numbers; hex is what driver bug reports are indexed by. */
+function formatPciId(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return `0x${Math.trunc(value).toString(16).padStart(4, '0')}`
+  }
+  return typeof value === 'string' && value.length > 0
+    ? value.slice(0, MAX_GPU_STRING_LENGTH)
+    : undefined
+}
+
+function selectGpuDevice(raw: UnknownRecord | null): UnknownRecord | null {
+  const devices = raw?.gpuDevice
+  if (!Array.isArray(devices) || devices.length === 0) {
+    return null
+  }
+  const records = devices.map(asRecord).filter((device): device is UnknownRecord => device !== null)
+  return records.find((device) => device.active === true) ?? records[0] ?? null
+}
+
+/**
+ * Flattens `app.getGPUInfo('complete')` into crash-detail scalars. Pure so the
+ * shape can be tested without an Electron GPU process.
+ */
+export function summarizeGpuInfo(raw: unknown): CrashReportBreadcrumbData {
+  const root = asRecord(raw)
+  if (!root) {
+    return { gpuInfoAvailable: false }
+  }
+  const aux = asRecord(root.auxAttributes)
+  const device = selectGpuDevice(root)
+  const devices = Array.isArray(root.gpuDevice) ? root.gpuDevice.length : 0
+
+  return sanitizeCrashReportDetails({
+    gpuInfoAvailable: true,
+    gpuDeviceCount: devices,
+    gpuVendorId: formatPciId(device?.vendorId),
+    gpuDeviceId: formatPciId(device?.deviceId),
+    gpuDriverVendor: pickString(device, 'driverVendor'),
+    gpuDriverVersion: pickString(device, 'driverVersion'),
+    gpuDeviceString: pickString(device, 'deviceString'),
+    gpuGlVendor: pickString(aux, 'glVendor'),
+    gpuGlRenderer: pickString(aux, 'glRenderer'),
+    gpuGlVersion: pickString(aux, 'glVersion'),
+    gpuAnglePlatform: pickString(aux, 'glImplementation'),
+    gpuBasicInfoState: pickNumber(aux, 'basicInfoState'),
+    gpuContextInfoState: pickNumber(aux, 'contextInfoState'),
+    gpuInitializationTimeMs: pickNumber(aux, 'initializationTime'),
+    gpuInProcess: pickBoolean(aux, 'inProcessGpu'),
+    gpuSandboxed: pickBoolean(aux, 'sandboxed'),
+    gpuDirectComposition: pickBoolean(aux, 'directComposition'),
+    gpuPassthroughCmdDecoder: pickBoolean(aux, 'passthroughCmdDecoder'),
+    gpuMachineModel: pickString(root, 'machineModelName'),
+    gpuMachineModelVersion: pickString(root, 'machineModelVersion')
+  })
+}
+
+let gpuInfoSnapshot: CrashReportBreadcrumbData | null = null
+
+export function getGpuInfoSnapshot(): CrashReportBreadcrumbData | null {
+  return gpuInfoSnapshot
+}
+
+export function setGpuInfoSnapshotForTesting(snapshot: CrashReportBreadcrumbData | null): void {
+  gpuInfoSnapshot = snapshot
+}
+
+/**
+ * Captures the snapshot once, off the startup critical path. On a machine whose
+ * GPU child CHECK-crashes at init this call can hang forever, so it is bounded
+ * and records the failure shape rather than nothing.
+ */
+export async function captureGpuInfoSnapshot(
+  getGpuInfo: () => Promise<unknown>,
+  timeoutMs: number
+): Promise<CrashReportBreadcrumbData> {
+  let timer: NodeJS.Timeout | undefined
+  try {
+    const snapshot = await Promise.race([
+      getGpuInfo().then(summarizeGpuInfo),
+      new Promise<CrashReportBreadcrumbData>((resolve) => {
+        timer = setTimeout(
+          () => resolve({ gpuInfoAvailable: false, gpuInfoError: 'timeout' }),
+          timeoutMs
+        )
+        timer.unref?.()
+      })
+    ])
+    gpuInfoSnapshot = snapshot
+    return snapshot
+  } catch (error) {
+    const snapshot = sanitizeCrashReportDetails({
+      gpuInfoAvailable: false,
+      gpuInfoError: error instanceof Error ? error.message : String(error)
+    })
+    gpuInfoSnapshot = snapshot
+    return snapshot
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  }
+}

--- a/src/main/crash-reporting/process-gone-classification.test.ts
+++ b/src/main/crash-reporting/process-gone-classification.test.ts
@@ -164,6 +164,16 @@ describe('shouldRecordProcessGoneCrash', () => {
     expect(
       shouldRecordProcessGoneCrash({
         source: 'child',
+        processType: 'gpu',
+        reason: 'crashed',
+        exitCode: -2147483645,
+        expectedTeardown: 'none',
+        gpuFallbackActive: false
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
         processType: 'Utility',
         serviceName: 'network.mojom.NetworkService',
         reason: 'killed',
@@ -335,6 +345,60 @@ describe('shouldRecordProcessGoneCrash', () => {
         expectedTeardown: 'renderer-reload'
       })
     ).toBe(true)
+  })
+
+  // Why: suppressing these is why an ineffective GPU fallback stayed invisible —
+  // 20 of 21 crashed launches on the reported machine already ran the fallback.
+  it('records GPU child crashes once the GPU fallback is already applied', () => {
+    for (const reason of ['crashed', 'abnormal-exit'] as const) {
+      expect(
+        shouldRecordProcessGoneCrash({
+          source: 'child',
+          processType: 'GPU',
+          reason,
+          exitCode: -2147483645,
+          expectedTeardown: 'none',
+          gpuFallbackActive: true
+        })
+      ).toBe(true)
+    }
+  })
+
+  it('keeps suppressing GPU exits shaped like teardown even under the fallback', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'gpu',
+        reason: 'killed',
+        exitCode: 15,
+        expectedTeardown: 'none',
+        gpuFallbackActive: true
+      })
+    ).toBe(false)
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'gpu',
+        reason: 'crashed',
+        exitCode: -2147483645,
+        expectedTeardown: 'app-shutdown',
+        gpuFallbackActive: true
+      })
+    ).toBe(false)
+  })
+
+  it('does not widen non-GPU child suppression when the fallback is active', () => {
+    expect(
+      shouldRecordProcessGoneCrash({
+        source: 'child',
+        processType: 'Utility',
+        serviceName: 'network.mojom.NetworkService',
+        reason: 'crashed',
+        exitCode: -1,
+        expectedTeardown: 'none',
+        gpuFallbackActive: true
+      })
+    ).toBe(false)
   })
 })
 

--- a/src/main/crash-reporting/process-gone-classification.ts
+++ b/src/main/crash-reporting/process-gone-classification.ts
@@ -24,12 +24,16 @@ function isRecoverableChromiumChildProcess({
   source,
   processType,
   serviceName,
-  reason
+  reason,
+  expectedTeardown,
+  gpuFallbackActive
 }: {
   source: ProcessGoneSource
   processType?: string
   serviceName?: string
   reason: string
+  expectedTeardown: ExpectedTeardownScope
+  gpuFallbackActive?: boolean
 }): boolean {
   if (source !== 'child') {
     return false
@@ -39,7 +43,14 @@ function isRecoverableChromiumChildProcess({
   }
   const normalizedProcessType = processType?.toLowerCase()
   if (normalizedProcessType && RECOVERABLE_CHILD_PROCESS_TYPES.has(normalizedProcessType)) {
-    return true
+    // Why: a GPU crash while the GPU fallback is already applied is not churn —
+    // the remediation failed, and suppressing it is why this was invisible. Quit
+    // still tears the GPU child down noisily, so app-shutdown stays suppressed.
+    return !(
+      gpuFallbackActive === true &&
+      normalizedProcessType === 'gpu' &&
+      expectedTeardown !== 'app-shutdown'
+    )
   }
   return (
     normalizedProcessType === 'utility' &&
@@ -54,7 +65,8 @@ export function shouldRecordProcessGoneCrash({
   serviceName,
   reason,
   exitCode,
-  expectedTeardown
+  expectedTeardown,
+  gpuFallbackActive
 }: {
   source: ProcessGoneSource
   processType?: string
@@ -62,10 +74,20 @@ export function shouldRecordProcessGoneCrash({
   reason: string
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
+  gpuFallbackActive?: boolean
 }): boolean {
   // Why: GPU, Network Service, and Audio Service exits are recoverable Chromium
   // child-process churn; treating them as app crashes creates noisy user prompts.
-  if (isRecoverableChromiumChildProcess({ source, processType, serviceName, reason })) {
+  if (
+    isRecoverableChromiumChildProcess({
+      source,
+      processType,
+      serviceName,
+      reason,
+      expectedTeardown,
+      gpuFallbackActive
+    })
+  ) {
     return false
   }
   // Why: Electron reports intentional reload/update/quit teardown as `killed`.

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -9,7 +9,11 @@ vi.mock('electron', () => ({
 
 import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
 import { ProcessGoneDedupe } from './process-gone-dedupe'
-import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+import {
+  recordProcessGoneCrash,
+  resetGpuFallbackCrashReportBudgetForTesting,
+  type ProcessGoneCrashEvent
+} from './process-gone-recorder'
 import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
 
 type CapturingSink = TracerSink & { records: unknown[]; flushMock: ReturnType<typeof vi.fn> }
@@ -44,6 +48,7 @@ beforeEach(() => {
   sink = capturingSink()
   setActiveSink(sink)
   clearCrashBreadcrumbsForTest()
+  resetGpuFallbackCrashReportBudgetForTesting()
 })
 
 afterEach(() => {
@@ -204,6 +209,129 @@ describe('recordProcessGoneCrash', () => {
         ])
       )
     )
+  })
+
+  // Why: a GPU crash loop under the fallback must not rewrite crash-reports.json
+  // every dedupe window for the rest of the session.
+  it('caps GPU-under-fallback reports per launch and durably records the overflow', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report' })
+    const dedupe = new ProcessGoneDedupe()
+    const gpuCrash = (exitCode: number): ProcessGoneCrashEvent =>
+      event({
+        source: 'child',
+        processType: 'GPU',
+        reason: 'crashed',
+        exitCode,
+        gpuFallbackActive: true,
+        details: { type: 'GPU' }
+      })
+
+    for (const exitCode of [1, 2, 3]) {
+      recordProcessGoneCrash({ record } as never, gpuCrash(exitCode), dedupe)
+    }
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(3))
+
+    recordProcessGoneCrash({ record } as never, gpuCrash(4), dedupe)
+
+    expect(record).toHaveBeenCalledTimes(3)
+    expect(getCrashBreadcrumbSnapshot()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'process_gone_suppressed',
+          data: expect.objectContaining({ suppressedBy: 'gpu_fallback_report_budget' })
+        })
+      ])
+    )
+  })
+
+  it('does not spend GPU-fallback budget on deduped repeats', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report' })
+    const dedupe = new ProcessGoneDedupe()
+    const gpuCrash = (exitCode: number): ProcessGoneCrashEvent =>
+      event({
+        source: 'child',
+        processType: 'GPU',
+        reason: 'crashed',
+        exitCode,
+        gpuFallbackActive: true,
+        details: { type: 'GPU' }
+      })
+
+    recordProcessGoneCrash({ record } as never, gpuCrash(1), dedupe)
+    recordProcessGoneCrash({ record } as never, gpuCrash(2), dedupe)
+    recordProcessGoneCrash({ record } as never, gpuCrash(2), dedupe)
+    recordProcessGoneCrash({ record } as never, gpuCrash(3), dedupe)
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(3))
+    expect(getCrashBreadcrumbSnapshot()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({ suppressedBy: 'gpu_fallback_report_budget' })
+        })
+      ])
+    )
+  })
+
+  it('releases GPU-fallback budget when persistence fails', async () => {
+    const record = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('disk unavailable'))
+      .mockResolvedValue({ id: 'report' })
+    const dedupe = new ProcessGoneDedupe()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const gpuCrash = (exitCode: number): ProcessGoneCrashEvent =>
+      event({
+        source: 'child',
+        processType: 'GPU',
+        reason: 'crashed',
+        exitCode,
+        gpuFallbackActive: true,
+        details: { type: 'GPU' }
+      })
+
+    recordProcessGoneCrash({ record } as never, gpuCrash(1), dedupe)
+    await vi.waitFor(() =>
+      expect(getCrashBreadcrumbSnapshot()).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'crash_report_persist_failed' })])
+      )
+    )
+
+    for (const exitCode of [2, 3, 4]) {
+      recordProcessGoneCrash({ record } as never, gpuCrash(exitCode), dedupe)
+    }
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(4))
+    expect(getCrashBreadcrumbSnapshot()).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          data: expect.objectContaining({ suppressedBy: 'gpu_fallback_report_budget' })
+        })
+      ])
+    )
+  })
+
+  it('still records renderer crashes after the GPU-fallback budget is spent', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report' })
+    const dedupe = new ProcessGoneDedupe()
+
+    for (const exitCode of [1, 2, 3]) {
+      recordProcessGoneCrash(
+        { record } as never,
+        event({
+          source: 'child',
+          processType: 'GPU',
+          reason: 'crashed',
+          exitCode,
+          gpuFallbackActive: true,
+          details: { type: 'GPU' }
+        }),
+        dedupe
+      )
+    }
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(3))
+
+    recordProcessGoneCrash({ record } as never, event({ gpuFallbackActive: true }), dedupe)
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(4))
   })
 
   it('allows the same renderer crash to retry after persistence fails', async () => {

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -15,6 +15,7 @@ import {
   type ProcessGoneCrashEvent
 } from './process-gone-recorder'
 import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
+import { setGpuInfoSnapshotForTesting } from './gpu-info-snapshot'
 
 type CapturingSink = TracerSink & { records: unknown[]; flushMock: ReturnType<typeof vi.fn> }
 
@@ -55,6 +56,7 @@ afterEach(() => {
   vi.restoreAllMocks()
   _resetTracerForTests()
   clearCrashBreadcrumbsForTest()
+  setGpuInfoSnapshotForTesting(null)
 })
 
 describe('recordProcessGoneCrash', () => {
@@ -332,6 +334,76 @@ describe('recordProcessGoneCrash', () => {
     recordProcessGoneCrash({ record } as never, event({ gpuFallbackActive: true }), dedupe)
 
     await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(4))
+  })
+
+  // Why: driver identity is the whole point of the GPU snapshot — if it stops reaching
+  // crash details, triage silently loses the vendor/device data it was added for.
+  it('attaches the GPU identity snapshot to GPU-child crash details', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report' })
+    setGpuInfoSnapshotForTesting({ gpuInfoAvailable: true, gpuVendorId: '0x10de' })
+
+    recordProcessGoneCrash(
+      { record } as never,
+      event({
+        source: 'child',
+        processType: 'GPU',
+        gpuFallbackActive: true,
+        details: { type: 'GPU', gpuFallbackTier: 2 }
+      }),
+      new ProcessGoneDedupe()
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(1))
+    expect(record.mock.calls[0][0].details).toEqual(
+      expect.objectContaining({ gpuInfoAvailable: true, gpuVendorId: '0x10de' })
+    )
+  })
+
+  it('attaches the GPU identity snapshot to renderer crash details', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report' })
+    setGpuInfoSnapshotForTesting({ gpuInfoAvailable: true, gpuVendorId: '0x10de' })
+
+    recordProcessGoneCrash({ record } as never, event(), new ProcessGoneDedupe())
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(1))
+    expect(record.mock.calls[0][0].details).toEqual(
+      expect.objectContaining({ gpuInfoAvailable: true, gpuVendorId: '0x10de' })
+    )
+  })
+
+  // Why: every other child type would just pad the report.
+  it('omits the GPU identity snapshot for non-GPU child crashes', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report' })
+    setGpuInfoSnapshotForTesting({ gpuInfoAvailable: true, gpuVendorId: '0x10de' })
+
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ source: 'child', processType: 'Utility', details: { type: 'Utility' } }),
+      new ProcessGoneDedupe()
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(1))
+    expect(record.mock.calls[0][0].details).not.toHaveProperty('gpuVendorId')
+  })
+
+  // Why: the reworded crash dialog keys off a numeric gpuFallbackTier; if sanitization
+  // ever dropped or stringified it, isGpuFallbackCrashReport would silently never match.
+  it('preserves gpuFallbackTier as a number through sanitization', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report' })
+
+    recordProcessGoneCrash(
+      { record } as never,
+      event({
+        source: 'child',
+        processType: 'GPU',
+        gpuFallbackActive: true,
+        details: { type: 'GPU', gpuFallbackTier: 2 }
+      }),
+      new ProcessGoneDedupe()
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(1))
+    expect(record.mock.calls[0][0].details.gpuFallbackTier).toBe(2)
   })
 
   it('allows the same renderer crash to retry after persistence fails', async () => {

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -35,6 +35,24 @@ export type ProcessGoneCrashEvent = {
 
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record'>
 
+// Why: a GPU crash loop under the fallback would rewrite crash-reports.json every
+// dedupe window for the rest of the session; the first few reports carry all the
+// triage signal (driver identity, tier), the rest are pure disk churn.
+const MAX_GPU_FALLBACK_CRASH_REPORTS_PER_LAUNCH = 3
+let gpuFallbackCrashReportsThisLaunch = 0
+
+export function resetGpuFallbackCrashReportBudgetForTesting(): void {
+  gpuFallbackCrashReportsThisLaunch = 0
+}
+
+function countsAgainstGpuFallbackReportBudget(event: ProcessGoneCrashEvent): boolean {
+  return (
+    event.gpuFallbackActive === true &&
+    event.source === 'child' &&
+    event.processType.toLowerCase() === 'gpu'
+  )
+}
+
 function processGoneBreadcrumbData(event: ProcessGoneCrashEvent) {
   return buildSuppressedProcessGoneBreadcrumbData(event)
 }
@@ -84,10 +102,25 @@ export function recordProcessGoneCrash(
     return
   }
 
+  const gpuFallbackBudgeted = countsAgainstGpuFallbackReportBudget(event)
+  if (
+    gpuFallbackBudgeted &&
+    gpuFallbackCrashReportsThisLaunch >= MAX_GPU_FALLBACK_CRASH_REPORTS_PER_LAUNCH
+  ) {
+    recordDurableCrashBreadcrumb('process_gone_suppressed', {
+      ...processGoneBreadcrumbData(event),
+      suppressedBy: 'gpu_fallback_report_budget'
+    })
+    return
+  }
+
   const key = getProcessGoneDedupeKey(event.source, event.processType, event.reason, event.exitCode)
   const claim = dedupe.tryClaim(key)
   if (!claim) {
     return
+  }
+  if (gpuFallbackBudgeted) {
+    gpuFallbackCrashReportsThisLaunch += 1
   }
   const mainProcessLifecycle = getMainProcessLifecycleIdentity()
   // Why: GPU and renderer deaths are the ones triage needs driver identity for;
@@ -145,6 +178,9 @@ export function recordProcessGoneCrash(
     })
     .catch((error) => {
       dedupe.release(claim)
+      if (gpuFallbackBudgeted) {
+        gpuFallbackCrashReportsThisLaunch -= 1
+      }
       console.error('[crash-reporting] Failed to persist crash report:', error)
       const data = persistFailureData(event, error)
       recordDurableCrashBreadcrumb(

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -18,6 +18,7 @@ import {
   processGoneDedupe,
   type ProcessGoneDedupe
 } from './process-gone-dedupe'
+import { getGpuInfoSnapshot } from './gpu-info-snapshot'
 import { getMainProcessLifecycleIdentity } from './main-process-lifecycle-identity'
 import { flushActiveSink, startSpan } from '../observability/tracer'
 
@@ -28,6 +29,8 @@ export type ProcessGoneCrashEvent = {
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
   details: Record<string, unknown>
+  /** True when this launch already runs a GPU fallback tier, so GPU deaths stop counting as churn. */
+  gpuFallbackActive?: boolean
 }
 
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record'>
@@ -65,7 +68,8 @@ export function recordProcessGoneCrash(
         typeof event.details.serviceName === 'string' ? event.details.serviceName : undefined,
       reason: event.reason,
       exitCode: event.exitCode,
-      expectedTeardown: event.expectedTeardown
+      expectedTeardown: event.expectedTeardown,
+      gpuFallbackActive: event.gpuFallbackActive
     })
   ) {
     recordDurableCrashBreadcrumb('process_gone_suppressed', processGoneBreadcrumbData(event))
@@ -86,8 +90,15 @@ export function recordProcessGoneCrash(
     return
   }
   const mainProcessLifecycle = getMainProcessLifecycleIdentity()
+  // Why: GPU and renderer deaths are the ones triage needs driver identity for;
+  // every other child type would just pad the report.
+  const gpuIdentity =
+    event.source === 'renderer' || event.processType.toLowerCase() === 'gpu'
+      ? (getGpuInfoSnapshot() ?? {})
+      : {}
   const crashDetails = buildProcessGoneCrashDetails({
     ...event.details,
+    ...gpuIdentity,
     ...mainProcessLifecycle
   })
   const breadcrumbs = getCrashBreadcrumbSnapshot()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -101,7 +101,7 @@ import {
   NO_GPU_FALLBACK_TIER,
   getGpuFallbackTierSwitches,
   resolveGpuFallbackEscalation,
-  type GpuFallbackTier
+  type GpuFallbackTierOrNone
 } from './startup/gpu-fallback-tiers'
 import { purgeGpuCaches } from './startup/gpu-cache-purge'
 import {
@@ -310,7 +310,7 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
 })
 // Why: 0 = hardware path. A non-zero tier is the rung of the fallback ladder this launch is running.
-let gpuFallbackTierThisLaunch: GpuFallbackTier | typeof NO_GPU_FALLBACK_TIER = NO_GPU_FALLBACK_TIER
+let gpuFallbackTierThisLaunch: GpuFallbackTierOrNone = NO_GPU_FALLBACK_TIER
 const GPU_INFO_CAPTURE_TIMEOUT_MS = 10_000
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
@@ -1493,6 +1493,15 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     )
   } catch (error) {
     console.warn('[gpu-fallback] failed to persist marker:', error)
+    // Why: this abandons the tier record, the cache purge and the relaunch; console
+    // output reaches no support bundle, so the escalation would vanish without trace.
+    recordDurableCrashBreadcrumb('gpu_fallback_marker_write_failed', {
+      reason,
+      exitCode,
+      tier: nextTier,
+      previousTier: currentTier,
+      errorMessage: error instanceof Error ? error.message : String(error)
+    })
     return
   }
   // Why: survives the update that invalidates the marker above.
@@ -1509,11 +1518,17 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     failed: purge.failed.join(',')
   })
   isQuitting = true
+  // Why: the breadcrumbs above are in-memory only and this process exits next, so
+  // app_relaunch_requested is the sole durable record of what the escalation did.
   relaunchApp('gpu-fallback', {
     processReason: reason,
     exitCode,
     tier: nextTier,
     previousTier: currentTier,
+    resumedFromHistory,
+    recordedTier: recordedTier ?? null,
+    cachesPurged: purge.removed.join(','),
+    cachePurgeFailed: purge.failed.join(','),
     crashesInWindow: result.crashesInWindow
   })
   app.exit(0)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -104,6 +104,10 @@ import {
   type GpuFallbackTier
 } from './startup/gpu-fallback-tiers'
 import { purgeGpuCaches } from './startup/gpu-cache-purge'
+import {
+  getResumeGpuFallbackTier,
+  recordGpuFallbackRequiredTier
+} from './startup/gpu-fallback-required-tier'
 import { captureGpuInfoSnapshot } from './crash-reporting/gpu-info-snapshot'
 import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
@@ -1434,8 +1438,14 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   if (!result.shouldEngageFallback) {
     return
   }
+  const userDataPath = getGpuFallbackUserDataPath()
   const currentTier = gpuFallbackTierThisLaunch
-  const nextTier = getNextGpuFallbackTier(currentTier)
+  // Why: after an update the build-scoped marker is gone but the machine is not.
+  // Resuming at the tier it already needed is the difference between one relaunch
+  // per update and re-walking the whole ladder every time.
+  const resumeTier =
+    currentTier === NO_GPU_FALLBACK_TIER ? getResumeGpuFallbackTier(userDataPath) : null
+  const nextTier = resumeTier ?? getNextGpuFallbackTier(currentTier)
   if (currentTier !== NO_GPU_FALLBACK_TIER) {
     // Why: 20 of 21 crashed launches on the reported machine already carried
     // gpu_fallback_applied. Without this breadcrumb the failure looked like a fix.
@@ -1463,6 +1473,7 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     exitCode,
     tier: nextTier,
     previousTier: currentTier,
+    resumedFromHistory: resumeTier !== null,
     crashesInWindow: result.crashesInWindow
   })
   const engagedAt = Date.now()
@@ -1470,7 +1481,6 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   if (!environment) {
     return
   }
-  const userDataPath = getGpuFallbackUserDataPath()
   try {
     writeGpuFallbackMarker(
       userDataPath,
@@ -1485,6 +1495,12 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     console.warn('[gpu-fallback] failed to persist marker:', error)
     return
   }
+  // Why: survives the update that invalidates the marker above.
+  const recordedTier = recordGpuFallbackRequiredTier(userDataPath, nextTier, environment, engagedAt)
+  recordCrashBreadcrumb('gpu_fallback_required_tier_recorded', {
+    tier: nextTier,
+    recordedTier: recordedTier ?? null
+  })
   // Why: a shader cache written by the driver that just crashed replays the same
   // crash on the next GPU init, defeating the tier we just escalated to.
   const purge = purgeGpuCaches(userDataPath)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -76,6 +76,7 @@ import {
   configureElectronNetworkCompatibility,
   configureDevUserDataPath,
   configureOrcaUserDataPathEnv,
+  disableIntensiveWakeUpThrottling,
   enableMainProcessGpuFeatures,
   installDevParentDisconnectQuit,
   installDevParentSignalQuit,
@@ -96,6 +97,14 @@ import {
   type GpuFallbackEnvironment,
   type WindowsGpuFallbackEnvironment
 } from './startup/gpu-fallback-marker'
+import {
+  NO_GPU_FALLBACK_TIER,
+  getGpuFallbackTierSwitches,
+  getNextGpuFallbackTier,
+  type GpuFallbackTier
+} from './startup/gpu-fallback-tiers'
+import { purgeGpuCaches } from './startup/gpu-cache-purge'
+import { captureGpuInfoSnapshot } from './crash-reporting/gpu-info-snapshot'
 import {
   DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD,
   DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
@@ -296,7 +305,9 @@ const gpuCrashFallbackTracker = new GpuCrashFallbackTracker({
   windowMs: DEFAULT_GPU_CRASH_FALLBACK_WINDOW_MS,
   threshold: DEFAULT_GPU_CRASH_FALLBACK_THRESHOLD
 })
-let gpuFallbackActiveThisLaunch = false
+// Why: 0 = hardware path. A non-zero tier is the rung of the fallback ladder this launch is running.
+let gpuFallbackTierThisLaunch: GpuFallbackTier | typeof NO_GPU_FALLBACK_TIER = NO_GPU_FALLBACK_TIER
+const GPU_INFO_CAPTURE_TIMEOUT_MS = 10_000
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
@@ -663,9 +674,11 @@ if (hasSingleInstanceLock) {
   configureElectronNetworkCompatibility()
   enableRendererHeapHeadroom()
   maybeApplyGpuFallbackForThisLaunch()
-  if (!gpuFallbackActiveThisLaunch) {
+  if (gpuFallbackTierThisLaunch === NO_GPU_FALLBACK_TIER) {
     enableMainProcessGpuFeatures()
   }
+  // Why: timer throttling is unrelated to the GPU; the fallback path used to drop it too.
+  disableIntensiveWakeUpThrottling()
   // Why: headless serve's offscreen BrowserWindows need an X display (Xvfb) on Linux; the result gates whether the offscreen backend is installed.
   headlessBrowserDisplayAvailable = ensureVirtualDisplayForHeadlessServe({ isServeMode })
 }
@@ -1364,6 +1377,12 @@ function getGpuFallbackEnvironment(): GpuFallbackEnvironment {
   }
 }
 
+// Why: the marker is read pre-whenReady and written post-app.setName('Orca'), and a late
+// app.getPath('userData') resolves differently — the two must agree or the marker "vanishes".
+function getGpuFallbackUserDataPath(): string {
+  return getCanonicalUserDataPath()
+}
+
 function getWindowsGpuFallbackEnvironment(): WindowsGpuFallbackEnvironment | null {
   const environment = getGpuFallbackEnvironment()
   if (environment.platform !== 'win32') {
@@ -1377,31 +1396,73 @@ function maybeApplyGpuFallbackForThisLaunch(): void {
   if (isServeMode || process.platform !== 'win32') {
     return
   }
-  const marker = readActiveGpuFallbackMarker(app.getPath('userData'), getGpuFallbackEnvironment())
+  const { marker, cleared, unreadableErrorCode } = readActiveGpuFallbackMarker(
+    getGpuFallbackUserDataPath(),
+    getGpuFallbackEnvironment()
+  )
+  if (cleared) {
+    // Why: a vanished marker silently re-arms hardware acceleration; that must be visible in triage.
+    recordCrashBreadcrumb('gpu_fallback_marker_cleared', { reason: cleared })
+  }
+  if (unreadableErrorCode) {
+    recordCrashBreadcrumb('gpu_fallback_marker_unreadable', { errorCode: unreadableErrorCode })
+  }
   if (!marker) {
     return
   }
   app.disableHardwareAcceleration()
-  app.commandLine.appendSwitch('disable-gpu')
-  gpuFallbackActiveThisLaunch = true
+  for (const { name, value } of getGpuFallbackTierSwitches(marker.tier)) {
+    if (value === undefined) {
+      app.commandLine.appendSwitch(name)
+    } else {
+      app.commandLine.appendSwitch(name, value)
+    }
+  }
+  gpuFallbackTierThisLaunch = marker.tier
   recordCrashBreadcrumb('gpu_fallback_applied', {
+    tier: marker.tier,
     crashesInWindow: marker.crashesInWindow
   })
 }
 
-// Why: a burst of GPU child crashes right after launch means HW acceleration is unusable — persist a build-scoped marker and relaunch into software rendering.
+// Why: a burst of GPU child crashes right after launch means the current GPU path is unusable — persist a build-scoped tier and relaunch one rung higher.
 function handleGpuChildCrash(reason: string, exitCode: number | null): void {
-  // Software rendering already active or shutting down: nothing more to do.
-  if (gpuFallbackActiveThisLaunch || isQuitting || isServeMode) {
+  if (isQuitting || isServeMode) {
     return
   }
   const result = gpuCrashFallbackTracker.recordGpuCrash(Date.now() - gpuLaunchTimeMs)
   if (!result.shouldEngageFallback) {
     return
   }
+  const currentTier = gpuFallbackTierThisLaunch
+  const nextTier = getNextGpuFallbackTier(currentTier)
+  if (currentTier !== NO_GPU_FALLBACK_TIER) {
+    // Why: 20 of 21 crashed launches on the reported machine already carried
+    // gpu_fallback_applied. Without this breadcrumb the failure looked like a fix.
+    recordCrashBreadcrumb('gpu_fallback_ineffective', {
+      reason,
+      exitCode,
+      tier: currentTier,
+      nextTier: nextTier ?? null,
+      crashesInWindow: result.crashesInWindow
+    })
+  }
+  if (nextTier === null) {
+    // Why: the ladder is bounded per build — keep running degraded rather than
+    // relaunch into a tier that already failed.
+    recordCrashBreadcrumb('gpu_fallback_exhausted', {
+      reason,
+      exitCode,
+      tier: currentTier,
+      crashesInWindow: result.crashesInWindow
+    })
+    return
+  }
   recordCrashBreadcrumb('gpu_fallback_engaged', {
     reason,
     exitCode,
+    tier: nextTier,
+    previousTier: currentTier,
     crashesInWindow: result.crashesInWindow
   })
   const engagedAt = Date.now()
@@ -1409,12 +1470,14 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   if (!environment) {
     return
   }
+  const userDataPath = getGpuFallbackUserDataPath()
   try {
     writeGpuFallbackMarker(
-      app.getPath('userData'),
+      userDataPath,
       {
         engagedAt,
-        crashesInWindow: result.crashesInWindow
+        crashesInWindow: result.crashesInWindow,
+        tier: nextTier
       },
       environment
     )
@@ -1422,10 +1485,19 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     console.warn('[gpu-fallback] failed to persist marker:', error)
     return
   }
+  // Why: a shader cache written by the driver that just crashed replays the same
+  // crash on the next GPU init, defeating the tier we just escalated to.
+  const purge = purgeGpuCaches(userDataPath)
+  recordCrashBreadcrumb('gpu_cache_purged', {
+    removed: purge.removed.join(','),
+    failed: purge.failed.join(',')
+  })
   isQuitting = true
   relaunchApp('gpu-fallback', {
     processReason: reason,
     exitCode,
+    tier: nextTier,
+    previousTier: currentTier,
     crashesInWindow: result.crashesInWindow
   })
   app.exit(0)
@@ -1444,6 +1516,7 @@ function recordProcessGoneCrash(
     processType,
     reason,
     exitCode,
+    gpuFallbackActive: gpuFallbackTierThisLaunch !== NO_GPU_FALLBACK_TIER,
     expectedTeardown: getExpectedTeardownScope(webContentsId),
     details
   })
@@ -1778,6 +1851,13 @@ function shouldSuppressCodexAutoApprovalSyntheticTitleFromHook(args: {
 
 app.whenReady().then(async () => {
   logStartupMilestone('app-ready')
+  // Why: driver identity for crash details. Fire-and-forget and bounded — on the
+  // machines this exists for, the GPU process never initializes and this never resolves.
+  void captureGpuInfoSnapshot(() => app.getGPUInfo('complete'), GPU_INFO_CAPTURE_TIMEOUT_MS).then(
+    (snapshot) => {
+      recordCrashBreadcrumb('gpu_info_captured', snapshot)
+    }
+  )
   // Why: install certificate decisions before any webview or headless window issues its first TLS request.
   app.on(
     'certificate-error',
@@ -2197,7 +2277,8 @@ app.whenReady().then(async () => {
     recordProcessGoneCrash('child', details.type, details.reason, details.exitCode ?? null, {
       name: details.name,
       serviceName: details.serviceName,
-      type: details.type
+      type: details.type,
+      gpuFallbackTier: gpuFallbackTierThisLaunch
     })
     if (
       isGpuFallbackCrashCandidate({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -100,7 +100,7 @@ import {
 import {
   NO_GPU_FALLBACK_TIER,
   getGpuFallbackTierSwitches,
-  getNextGpuFallbackTier,
+  resolveGpuFallbackEscalation,
   type GpuFallbackTier
 } from './startup/gpu-fallback-tiers'
 import { purgeGpuCaches } from './startup/gpu-cache-purge'
@@ -1443,9 +1443,9 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
   // Why: after an update the build-scoped marker is gone but the machine is not.
   // Resuming at the tier it already needed is the difference between one relaunch
   // per update and re-walking the whole ladder every time.
-  const resumeTier =
-    currentTier === NO_GPU_FALLBACK_TIER ? getResumeGpuFallbackTier(userDataPath) : null
-  const nextTier = resumeTier ?? getNextGpuFallbackTier(currentTier)
+  const { nextTier, resumedFromHistory } = resolveGpuFallbackEscalation(currentTier, () =>
+    getResumeGpuFallbackTier(userDataPath)
+  )
   if (currentTier !== NO_GPU_FALLBACK_TIER) {
     // Why: 20 of 21 crashed launches on the reported machine already carried
     // gpu_fallback_applied. Without this breadcrumb the failure looked like a fix.
@@ -1473,7 +1473,7 @@ function handleGpuChildCrash(reason: string, exitCode: number | null): void {
     exitCode,
     tier: nextTier,
     previousTier: currentTier,
-    resumedFromHistory: resumeTier !== null,
+    resumedFromHistory,
     crashesInWindow: result.crashesInWindow
   })
   const engagedAt = Date.now()
@@ -1869,11 +1869,15 @@ app.whenReady().then(async () => {
   logStartupMilestone('app-ready')
   // Why: driver identity for crash details. Fire-and-forget and bounded — on the
   // machines this exists for, the GPU process never initializes and this never resolves.
-  void captureGpuInfoSnapshot(() => app.getGPUInfo('complete'), GPU_INFO_CAPTURE_TIMEOUT_MS).then(
-    (snapshot) => {
-      recordCrashBreadcrumb('gpu_info_captured', snapshot)
-    }
-  )
+  // Skipped in headless serve: no crash dialog to feed, and 'complete' can provoke a
+  // GPU child that Xvfb environments have no reason to spawn.
+  if (!isServeMode) {
+    void captureGpuInfoSnapshot(() => app.getGPUInfo('complete'), GPU_INFO_CAPTURE_TIMEOUT_MS).then(
+      (snapshot) => {
+        recordCrashBreadcrumb('gpu_info_captured', snapshot)
+      }
+    )
+  }
   // Why: install certificate decisions before any webview or headless window issues its first TLS request.
   app.on(
     'certificate-error',

--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -373,13 +373,28 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('enable-unsafe-webgpu')
   })
 
-  it('opts hidden pages out of intensive wake-up throttling', async () => {
+  // Why: throttling is unrelated to the GPU; it must not ride the GPU-gated path,
+  // or the win32 GPU fallback silently costs users timely agent-done notifications.
+  it('does not opt out of wake-up throttling from the GPU path', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')
 
     delete process.env.ORCA_E2E_USER_DATA_DIR
     vi.mocked(app.commandLine.appendSwitch).mockClear()
     enableMainProcessGpuFeatures()
+
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith(
+      'disable-features',
+      expect.stringContaining('IntensiveWakeUpThrottling')
+    )
+  })
+
+  it('opts hidden pages out of intensive wake-up throttling independently', async () => {
+    const { app } = await import('electron')
+    const { disableIntensiveWakeUpThrottling } = await import('./configure-process')
+
+    vi.mocked(app.commandLine.appendSwitch).mockClear()
+    disableIntensiveWakeUpThrottling()
 
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith(
       'disable-features',

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -293,10 +293,18 @@ export function enableMainProcessGpuFeatures(): void {
   if (features) {
     app.commandLine.appendSwitch('enable-features', features)
   }
+}
 
+/**
+ * Timer behavior, deliberately separate from GPU setup.
+ *
+ * IntensiveWakeUpThrottling clamps hidden-page timers to 1/min after 5min,
+ * delaying agent-done/bell notifications ~60s. This used to live inside
+ * enableMainProcessGpuFeatures(), so machines on the GPU fallback path lost
+ * timely notifications for a reason that has nothing to do with the GPU.
+ */
+export function disableIntensiveWakeUpThrottling(): void {
   const existingDisabledFeatures = app.commandLine.getSwitchValue('disable-features')
-  // Why: IntensiveWakeUpThrottling clamps hidden-page timers to 1/min after 5min, delaying agent-done/bell notifications ~60s.
-  // This opt-out is skipped under GPU fallback (win32-only today); if throttling ever reaches Windows it must move out of this path.
   const disabledFeatures = ['IntensiveWakeUpThrottling', existingDisabledFeatures]
     .filter(Boolean)
     .join(',')

--- a/src/main/startup/gpu-cache-purge.test.ts
+++ b/src/main/startup/gpu-cache-purge.test.ts
@@ -1,0 +1,50 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { GPU_CACHE_DIRECTORY_NAMES, purgeGpuCaches } from './gpu-cache-purge'
+
+describe('purgeGpuCaches', () => {
+  let userDataPath: string
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-cache-purge-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('removes populated GPU cache directories', () => {
+    for (const name of GPU_CACHE_DIRECTORY_NAMES) {
+      mkdirSync(join(userDataPath, name, 'nested'), { recursive: true })
+      writeFileSync(join(userDataPath, name, 'nested', 'entry.bin'), 'shader')
+    }
+
+    const result = purgeGpuCaches(userDataPath)
+
+    expect(result.removed).toEqual([...GPU_CACHE_DIRECTORY_NAMES])
+    expect(result.failed).toEqual([])
+    for (const name of GPU_CACHE_DIRECTORY_NAMES) {
+      expect(existsSync(join(userDataPath, name))).toBe(false)
+    }
+  })
+
+  it('reports nothing removed when no caches exist', () => {
+    expect(purgeGpuCaches(userDataPath)).toEqual({ removed: [], failed: [] })
+  })
+
+  it('leaves unrelated userData entries alone', () => {
+    mkdirSync(join(userDataPath, 'GPUCache'), { recursive: true })
+    writeFileSync(join(userDataPath, 'orca-data.json'), '{}')
+
+    purgeGpuCaches(userDataPath)
+
+    expect(existsSync(join(userDataPath, 'orca-data.json'))).toBe(true)
+  })
+
+  // Why: this runs on the path to a relaunch — a missing userData dir must not throw.
+  it('does not throw for a missing userData directory', () => {
+    expect(() => purgeGpuCaches(join(userDataPath, 'absent'))).not.toThrow()
+  })
+})

--- a/src/main/startup/gpu-cache-purge.test.ts
+++ b/src/main/startup/gpu-cache-purge.test.ts
@@ -1,17 +1,37 @@
+import type * as NodeFs from 'node:fs'
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
-import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { basename, join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { GPU_CACHE_DIRECTORY_NAMES, purgeGpuCaches } from './gpu-cache-purge'
+
+// Why: a locked cache directory is a Windows-only failure in the wild; this fakes it
+// so the `failed` bookkeeping is covered without a platform-specific (or root-skipped) test.
+const { unremovableDirectory } = vi.hoisted(() => ({ unremovableDirectory: { name: '' } }))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  return {
+    ...actual,
+    rmSync: (target: Parameters<typeof actual.rmSync>[0], options?: object) => {
+      if (unremovableDirectory.name && basename(String(target)) === unremovableDirectory.name) {
+        throw Object.assign(new Error('EBUSY: resource busy or locked'), { code: 'EBUSY' })
+      }
+      return actual.rmSync(target, options)
+    }
+  }
+})
 
 describe('purgeGpuCaches', () => {
   let userDataPath: string
 
   beforeEach(() => {
     userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-cache-purge-test-'))
+    unremovableDirectory.name = ''
   })
 
   afterEach(() => {
+    unremovableDirectory.name = ''
     rmSync(userDataPath, { recursive: true, force: true })
   })
 
@@ -46,5 +66,29 @@ describe('purgeGpuCaches', () => {
   // Why: this runs on the path to a relaunch — a missing userData dir must not throw.
   it('does not throw for a missing userData directory', () => {
     expect(() => purgeGpuCaches(join(userDataPath, 'absent'))).not.toThrow()
+  })
+
+  it('reports a locked cache directory as failed and still purges the rest', () => {
+    for (const name of GPU_CACHE_DIRECTORY_NAMES) {
+      mkdirSync(join(userDataPath, name), { recursive: true })
+    }
+    unremovableDirectory.name = 'ShaderCache'
+
+    const result = purgeGpuCaches(userDataPath)
+
+    expect(result.failed).toEqual(['ShaderCache'])
+    expect(result.removed).toEqual(
+      GPU_CACHE_DIRECTORY_NAMES.filter((name) => name !== 'ShaderCache')
+    )
+    expect(existsSync(join(userDataPath, 'ShaderCache'))).toBe(true)
+    expect(existsSync(join(userDataPath, 'GPUCache'))).toBe(false)
+  })
+
+  // Why: a locked directory must not abort the relaunch it precedes.
+  it('does not throw when a cache directory cannot be removed', () => {
+    mkdirSync(join(userDataPath, 'GPUCache'), { recursive: true })
+    unremovableDirectory.name = 'GPUCache'
+
+    expect(() => purgeGpuCaches(userDataPath)).not.toThrow()
   })
 })

--- a/src/main/startup/gpu-cache-purge.ts
+++ b/src/main/startup/gpu-cache-purge.ts
@@ -1,0 +1,43 @@
+import { existsSync, rmSync } from 'node:fs'
+import { join } from 'node:path'
+
+/**
+ * Chromium GPU/shader caches under userData.
+ *
+ * A cache written by the driver that just CHECK-crashed is replayed on the next
+ * GPU init, so escalating the fallback tier without purging can reproduce the
+ * same crash on a launch that should have been safe.
+ */
+export const GPU_CACHE_DIRECTORY_NAMES = [
+  'GPUCache',
+  'ShaderCache',
+  'GrShaderCache',
+  'DawnCache',
+  'DawnGraphiteCache',
+  'DawnWebGPUCache'
+] as const
+
+export type GpuCachePurgeResult = {
+  removed: string[]
+  failed: string[]
+}
+
+/** Best effort: a locked cache directory must never block the relaunch that follows. */
+export function purgeGpuCaches(userDataPath: string): GpuCachePurgeResult {
+  const removed: string[] = []
+  const failed: string[] = []
+  for (const name of GPU_CACHE_DIRECTORY_NAMES) {
+    const target = join(userDataPath, name)
+    try {
+      if (!existsSync(target)) {
+        continue
+      }
+      // Why: Windows can hold a brief lock on a cache file the dying GPU child owned.
+      rmSync(target, { recursive: true, force: true, maxRetries: 3, retryDelay: 25 })
+      removed.push(name)
+    } catch {
+      failed.push(name)
+    }
+  }
+  return { removed, failed }
+}

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -49,6 +49,40 @@ describe('gpu-fallback-marker', () => {
     expect(existsSync(join(userDataPath, `${GPU_FALLBACK_MARKER_FILE}.tmp`))).toBe(false)
   })
 
+  // Why: the caller treats a throw as "escalation abandoned", so a failed write must
+  // surface rather than leave a half-written marker or a stray temp file behind.
+  it('throws and leaves no temp file behind when the atomic write fails', () => {
+    const missingUserDataPath = join(userDataPath, 'absent')
+
+    expect(() =>
+      writeGpuFallbackMarker(
+        missingUserDataPath,
+        { engagedAt: 1, crashesInWindow: 3, tier: 2 },
+        environment
+      )
+    ).toThrow()
+
+    expect(existsSync(join(missingUserDataPath, `${GPU_FALLBACK_MARKER_FILE}.tmp`))).toBe(false)
+    expect(existsSync(join(missingUserDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
+  // Why: the rename is the step that actually fails in the wild (a locked or
+  // directory-shaped target), and that is the only path where a temp file can survive.
+  it('cleans up the temp file when the rename fails', () => {
+    mkdirSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), { recursive: true })
+    writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE, 'occupied'), 'x')
+
+    expect(() =>
+      writeGpuFallbackMarker(
+        userDataPath,
+        { engagedAt: 1, crashesInWindow: 3, tier: 2 },
+        environment
+      )
+    ).toThrow()
+
+    expect(existsSync(join(userDataPath, `${GPU_FALLBACK_MARKER_FILE}.tmp`))).toBe(false)
+  })
+
   it('overwrites an existing marker when escalating tiers', () => {
     writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3, tier: 1 }, environment)
     writeGpuFallbackMarker(userDataPath, { engagedAt: 2, crashesInWindow: 4, tier: 2 }, environment)

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
@@ -7,6 +7,7 @@ import {
   clearGpuFallbackMarker,
   readActiveGpuFallbackMarker,
   readGpuFallbackMarker,
+  readGpuFallbackMarkerResult,
   writeGpuFallbackMarker
 } from './gpu-fallback-marker'
 
@@ -27,62 +28,118 @@ describe('gpu-fallback-marker', () => {
   })
 
   it('round-trips a written marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 123, crashesInWindow: 3 }, environment)
+    writeGpuFallbackMarker(
+      userDataPath,
+      { engagedAt: 123, crashesInWindow: 3, tier: 2 },
+      environment
+    )
     expect(readGpuFallbackMarker(userDataPath)).toEqual({
-      schemeVersion: 2,
+      schemeVersion: 3,
       engagedAt: 123,
       crashesInWindow: 3,
+      tier: 2,
       appVersion: '1.2.3',
       electronVersion: '42.3.3',
       platform: 'win32'
     })
   })
 
+  it('leaves no temp file behind after an atomic write', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3, tier: 1 }, environment)
+    expect(existsSync(join(userDataPath, `${GPU_FALLBACK_MARKER_FILE}.tmp`))).toBe(false)
+  })
+
+  it('overwrites an existing marker when escalating tiers', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3, tier: 1 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 2, crashesInWindow: 4, tier: 3 }, environment)
+    expect(readGpuFallbackMarker(userDataPath)?.tier).toBe(3)
+  })
+
   it('returns null when no marker exists', () => {
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
-    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(readGpuFallbackMarkerResult(userDataPath)).toEqual({ status: 'absent' })
+    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toEqual({
+      marker: null,
+      cleared: null,
+      unreadableErrorCode: null
+    })
   })
 
   it('keeps an active marker for repeated launches on the same build', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4, tier: 2 }, environment)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
     const firstRead = readActiveGpuFallbackMarker(userDataPath, environment)
-    expect(firstRead?.crashesInWindow).toBe(4)
+    expect(firstRead.marker?.crashesInWindow).toBe(4)
+    expect(firstRead.marker?.tier).toBe(2)
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(true)
 
-    const secondRead = readActiveGpuFallbackMarker(userDataPath, environment)
-    expect(secondRead?.crashesInWindow).toBe(4)
+    expect(readActiveGpuFallbackMarker(userDataPath, environment).marker?.tier).toBe(2)
+  })
+
+  it('clamps an out-of-range persisted tier onto the ladder', () => {
+    writeFileSync(
+      join(userDataPath, GPU_FALLBACK_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: 3,
+        engagedAt: 1,
+        crashesInWindow: 3,
+        tier: 99,
+        appVersion: '1.2.3',
+        electronVersion: '42.3.3',
+        platform: 'win32'
+      })
+    )
+    expect(readGpuFallbackMarker(userDataPath)?.tier).toBe(3)
+  })
+
+  it('defaults a marker with no tier to the first rung', () => {
+    writeFileSync(
+      join(userDataPath, GPU_FALLBACK_MARKER_FILE),
+      JSON.stringify({
+        schemeVersion: 3,
+        engagedAt: 1,
+        crashesInWindow: 3,
+        appVersion: '1.2.3',
+        electronVersion: '42.3.3',
+        platform: 'win32'
+      })
+    )
+    expect(readGpuFallbackMarker(userDataPath)?.tier).toBe(1)
   })
 
   it('clears an active marker when the app build changes', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4, tier: 1 }, environment)
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
         ...environment,
         appVersion: '1.2.4'
       })
-    ).toBeNull()
+    ).toEqual({ marker: null, cleared: 'stale-build', unreadableErrorCode: null })
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
   it('clears an active marker outside Windows', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4, tier: 1 }, environment)
 
     expect(
       readActiveGpuFallbackMarker(userDataPath, {
         ...environment,
         platform: 'linux'
       })
-    ).toBeNull()
+    ).toEqual({ marker: null, cleared: 'non-windows', unreadableErrorCode: null })
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
   it('clears a corrupt or wrong-version marker', () => {
     writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), '{ not json')
-    expect(readGpuFallbackMarker(userDataPath)).toBeNull()
-    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(readGpuFallbackMarkerResult(userDataPath)).toEqual({ status: 'invalid' })
+    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toEqual({
+      marker: null,
+      cleared: 'invalid',
+      unreadableErrorCode: null
+    })
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
 
     writeFileSync(
@@ -90,12 +147,46 @@ describe('gpu-fallback-marker', () => {
       JSON.stringify({ schemeVersion: 999, engagedAt: 1, crashesInWindow: 1 })
     )
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
-    expect(readActiveGpuFallbackMarker(userDataPath, environment)).toBeNull()
+    expect(readActiveGpuFallbackMarker(userDataPath, environment).cleared).toBe('invalid')
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
+  // Why: deleting an unreadable marker silently re-armed hardware acceleration on
+  // machines that crash on GPU init — the crash loop this whole path exists for.
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'preserves a present-but-unreadable marker',
+    () => {
+      const markerFile = join(userDataPath, GPU_FALLBACK_MARKER_FILE)
+      writeGpuFallbackMarker(
+        userDataPath,
+        { engagedAt: 1, crashesInWindow: 4, tier: 2 },
+        environment
+      )
+      chmodSync(markerFile, 0o000)
+      try {
+        const result = readActiveGpuFallbackMarker(userDataPath, environment)
+        expect(result.marker).toBeNull()
+        expect(result.cleared).toBeNull()
+        expect(result.unreadableErrorCode).toBe('EACCES')
+        expect(existsSync(markerFile)).toBe(true)
+      } finally {
+        chmodSync(markerFile, 0o600)
+      }
+    }
+  )
+
+  it('reports a directory-shaped marker as unreadable rather than deleting it', () => {
+    const markerFile = join(userDataPath, GPU_FALLBACK_MARKER_FILE)
+    mkdirSync(markerFile)
+    const result = readActiveGpuFallbackMarker(userDataPath, environment)
+    expect(result.marker).toBeNull()
+    expect(result.cleared).toBeNull()
+    expect(result.unreadableErrorCode).toBe('EISDIR')
+    expect(existsSync(markerFile)).toBe(true)
+  })
+
   it('can explicitly clear the marker', () => {
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4, tier: 1 }, environment)
     clearGpuFallbackMarker(userDataPath)
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()
   })

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -51,8 +51,8 @@ describe('gpu-fallback-marker', () => {
 
   it('overwrites an existing marker when escalating tiers', () => {
     writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 3, tier: 1 }, environment)
-    writeGpuFallbackMarker(userDataPath, { engagedAt: 2, crashesInWindow: 4, tier: 3 }, environment)
-    expect(readGpuFallbackMarker(userDataPath)?.tier).toBe(3)
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 2, crashesInWindow: 4, tier: 2 }, environment)
+    expect(readGpuFallbackMarker(userDataPath)?.tier).toBe(2)
   })
 
   it('returns null when no marker exists', () => {
@@ -90,7 +90,7 @@ describe('gpu-fallback-marker', () => {
         platform: 'win32'
       })
     )
-    expect(readGpuFallbackMarker(userDataPath)?.tier).toBe(3)
+    expect(readGpuFallbackMarker(userDataPath)?.tier).toBe(2)
   })
 
   it('defaults a marker with no tier to the first rung', () => {

--- a/src/main/startup/gpu-fallback-marker.ts
+++ b/src/main/startup/gpu-fallback-marker.ts
@@ -1,17 +1,23 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { clampGpuFallbackTier, type GpuFallbackTier } from './gpu-fallback-tiers'
 
 /**
- * Persisted "disable hardware acceleration for this build" marker.
+ * Persisted "degrade the GPU path for this build" marker.
  *
  * Why a standalone file (not the Store): app.disableHardwareAcceleration() must
  * be called before app.whenReady() resolves, but the settings Store is only
  * constructed inside whenReady. A tiny JSON marker in userData can be read
  * synchronously during early startup, mirroring windows-user-data-acl.ts.
+ *
+ * The marker is only ever removed when it is provably obsolete. A marker that
+ * exists but cannot be read (EPERM/EBUSY/EACCES) is preserved: deleting it
+ * silently re-armed hardware acceleration on machines that crash on GPU init.
  */
 
 export const GPU_FALLBACK_MARKER_FILE = 'gpu-fallback.json'
-export const GPU_FALLBACK_SCHEME_VERSION = 2
+const GPU_FALLBACK_MARKER_TEMP_FILE = 'gpu-fallback.json.tmp'
+export const GPU_FALLBACK_SCHEME_VERSION = 3
 
 export type GpuFallbackEnvironment = {
   appVersion: string
@@ -25,62 +31,122 @@ export type GpuFallbackMarker = {
   schemeVersion: number
   engagedAt: number
   crashesInWindow: number
+  tier: GpuFallbackTier
   appVersion: string
   electronVersion: string
   platform: 'win32'
 }
 
+export type GpuFallbackMarkerReadResult =
+  | { status: 'ok'; marker: GpuFallbackMarker }
+  | { status: 'absent' }
+  | { status: 'invalid' }
+  | { status: 'unreadable'; errorCode: string }
+
+/** Why the marker did not apply, so callers can breadcrumb the clear instead of losing it silently. */
+export type GpuFallbackMarkerClearedReason = 'invalid' | 'stale-build' | 'non-windows'
+
+export type ActiveGpuFallbackMarkerResult = {
+  marker: GpuFallbackMarker | null
+  cleared: GpuFallbackMarkerClearedReason | null
+  /** Set when the marker exists but could not be read; the file is kept on disk. */
+  unreadableErrorCode: string | null
+}
+
+const ABSENT_ERROR_CODES = new Set(['ENOENT', 'ENOTDIR'])
+
 function markerPath(userDataPath: string): string {
   return join(userDataPath, GPU_FALLBACK_MARKER_FILE)
 }
 
-export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code: unknown }).code)
+    : undefined
+}
+
+export function readGpuFallbackMarkerResult(userDataPath: string): GpuFallbackMarkerReadResult {
+  let contents: string
   try {
-    const parsed = JSON.parse(readFileSync(markerPath(userDataPath), 'utf-8')) as Partial<
-      Record<keyof GpuFallbackMarker, unknown>
-    >
-    if (parsed.schemeVersion !== GPU_FALLBACK_SCHEME_VERSION) {
-      return null
+    contents = readFileSync(markerPath(userDataPath), 'utf-8')
+  } catch (error) {
+    const code = errorCode(error)
+    if (code !== undefined && ABSENT_ERROR_CODES.has(code)) {
+      return { status: 'absent' }
     }
-    if (
-      typeof parsed.engagedAt !== 'number' ||
-      !Number.isFinite(parsed.engagedAt) ||
-      typeof parsed.crashesInWindow !== 'number' ||
-      !Number.isFinite(parsed.crashesInWindow) ||
-      typeof parsed.appVersion !== 'string' ||
-      typeof parsed.electronVersion !== 'string' ||
-      parsed.platform !== 'win32'
-    ) {
-      return null
-    }
-    return {
+    return { status: 'unreadable', errorCode: code ?? 'UNKNOWN' }
+  }
+
+  let parsed: Partial<Record<keyof GpuFallbackMarker, unknown>>
+  try {
+    parsed = JSON.parse(contents) as Partial<Record<keyof GpuFallbackMarker, unknown>>
+  } catch {
+    return { status: 'invalid' }
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    return { status: 'invalid' }
+  }
+  if (parsed.schemeVersion !== GPU_FALLBACK_SCHEME_VERSION) {
+    return { status: 'invalid' }
+  }
+  if (
+    typeof parsed.engagedAt !== 'number' ||
+    !Number.isFinite(parsed.engagedAt) ||
+    typeof parsed.crashesInWindow !== 'number' ||
+    !Number.isFinite(parsed.crashesInWindow) ||
+    typeof parsed.appVersion !== 'string' ||
+    typeof parsed.electronVersion !== 'string' ||
+    parsed.platform !== 'win32'
+  ) {
+    return { status: 'invalid' }
+  }
+  return {
+    status: 'ok',
+    marker: {
       schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
       engagedAt: parsed.engagedAt,
       crashesInWindow: parsed.crashesInWindow,
+      tier: clampGpuFallbackTier(parsed.tier),
       appVersion: parsed.appVersion,
       electronVersion: parsed.electronVersion,
       platform: parsed.platform
     }
-  } catch {
-    // missing or corrupt means no fallback requested
   }
-  return null
+}
+
+export function readGpuFallbackMarker(userDataPath: string): GpuFallbackMarker | null {
+  const result = readGpuFallbackMarkerResult(userDataPath)
+  return result.status === 'ok' ? result.marker : null
 }
 
 export function writeGpuFallbackMarker(
   userDataPath: string,
-  info: { engagedAt: number; crashesInWindow: number },
+  info: { engagedAt: number; crashesInWindow: number; tier: GpuFallbackTier },
   environment: WindowsGpuFallbackEnvironment
 ): void {
   const marker: GpuFallbackMarker = {
     schemeVersion: GPU_FALLBACK_SCHEME_VERSION,
     engagedAt: info.engagedAt,
     crashesInWindow: info.crashesInWindow,
+    tier: info.tier,
     appVersion: environment.appVersion,
     electronVersion: environment.electronVersion,
     platform: 'win32'
   }
-  writeFileSync(markerPath(userDataPath), JSON.stringify(marker))
+  // Why: this write races the crash burst that triggered it — a torn marker
+  // reads as invalid and silently re-arms hardware acceleration next launch.
+  const tempPath = join(userDataPath, GPU_FALLBACK_MARKER_TEMP_FILE)
+  try {
+    writeFileSync(tempPath, JSON.stringify(marker))
+    renameSync(tempPath, markerPath(userDataPath))
+  } catch (error) {
+    try {
+      rmSync(tempPath, { force: true })
+    } catch {
+      // best effort; a stray temp file is inert
+    }
+    throw error
+  }
 }
 
 export function clearGpuFallbackMarker(userDataPath: string): void {
@@ -94,24 +160,33 @@ export function clearGpuFallbackMarker(userDataPath: string): void {
 export function readActiveGpuFallbackMarker(
   userDataPath: string,
   environment: GpuFallbackEnvironment
-): GpuFallbackMarker | null {
-  const marker = readGpuFallbackMarker(userDataPath)
-  if (!marker) {
-    if (existsSync(markerPath(userDataPath))) {
-      clearGpuFallbackMarker(userDataPath)
-    }
-    return null
+): ActiveGpuFallbackMarkerResult {
+  const result = readGpuFallbackMarkerResult(userDataPath)
+  if (result.status === 'absent') {
+    return { marker: null, cleared: null, unreadableErrorCode: null }
+  }
+  if (result.status === 'unreadable') {
+    // Why: keep the file. A transient EPERM/EBUSY must not be read as "this
+    // machine is healthy" — that is what turned the fallback into a crash loop.
+    return { marker: null, cleared: null, unreadableErrorCode: result.errorCode }
+  }
+  if (result.status === 'invalid') {
+    clearGpuFallbackMarker(userDataPath)
+    return { marker: null, cleared: 'invalid', unreadableErrorCode: null }
+  }
+  const { marker } = result
+  if (environment.platform !== 'win32' || marker.platform !== environment.platform) {
+    clearGpuFallbackMarker(userDataPath)
+    return { marker: null, cleared: 'non-windows', unreadableErrorCode: null }
   }
   if (
-    environment.platform !== 'win32' ||
-    marker.platform !== environment.platform ||
     marker.appVersion !== environment.appVersion ||
     marker.electronVersion !== environment.electronVersion
   ) {
     // Why: the marker is sticky only for the build that observed the driver
     // crash burst; updates get one fresh hardware attempt automatically.
     clearGpuFallbackMarker(userDataPath)
-    return null
+    return { marker: null, cleared: 'stale-build', unreadableErrorCode: null }
   }
-  return marker
+  return { marker, cleared: null, unreadableErrorCode: null }
 }

--- a/src/main/startup/gpu-fallback-required-tier.test.ts
+++ b/src/main/startup/gpu-fallback-required-tier.test.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import {
+  GPU_FALLBACK_REQUIRED_TIER_FILE,
+  getResumeGpuFallbackTier,
+  readGpuFallbackRequiredTier,
+  recordGpuFallbackRequiredTier
+} from './gpu-fallback-required-tier'
+
+describe('gpu-fallback-required-tier', () => {
+  let userDataPath: string
+  const environment = { appVersion: '1.4.155', electronVersion: '43.1.0' }
+
+  beforeEach(() => {
+    userDataPath = mkdtempSync(join(os.tmpdir(), 'orca-gpu-required-tier-'))
+  })
+
+  afterEach(() => {
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+
+  it('round-trips a recorded tier', () => {
+    expect(recordGpuFallbackRequiredTier(userDataPath, 2, environment, 1_000)).toBe(2)
+    expect(readGpuFallbackRequiredTier(userDataPath)).toEqual({
+      schemeVersion: 1,
+      requiredTier: 2,
+      recordedAt: 1_000,
+      appVersion: '1.4.155',
+      electronVersion: '43.1.0'
+    })
+  })
+
+  it('reports no resume tier for a machine with no history', () => {
+    expect(getResumeGpuFallbackTier(userDataPath)).toBeNull()
+    expect(readGpuFallbackRequiredTier(userDataPath)).toBeNull()
+  })
+
+  // Why: this is the whole point — the marker is version-scoped, this is not.
+  it('survives an app and Electron version change', () => {
+    recordGpuFallbackRequiredTier(userDataPath, 2, environment, 1_000)
+    expect(getResumeGpuFallbackTier(userDataPath)).toBe(2)
+    expect(readGpuFallbackRequiredTier(userDataPath)?.appVersion).toBe('1.4.155')
+  })
+
+  // Why: a shallower later burst must not talk a known-bad machine back down a rung.
+  it('is monotonic', () => {
+    recordGpuFallbackRequiredTier(userDataPath, 2, environment, 1_000)
+    expect(recordGpuFallbackRequiredTier(userDataPath, 1, environment, 2_000)).toBe(2)
+    expect(readGpuFallbackRequiredTier(userDataPath)?.requiredTier).toBe(2)
+    expect(readGpuFallbackRequiredTier(userDataPath)?.recordedAt).toBe(1_000)
+  })
+
+  it('raises the recorded tier when escalating', () => {
+    recordGpuFallbackRequiredTier(userDataPath, 1, environment, 1_000)
+    expect(recordGpuFallbackRequiredTier(userDataPath, 2, environment, 2_000)).toBe(2)
+    expect(readGpuFallbackRequiredTier(userDataPath)?.requiredTier).toBe(2)
+  })
+
+  it('leaves no temp file behind', () => {
+    recordGpuFallbackRequiredTier(userDataPath, 2, environment, 1_000)
+    expect(existsSync(join(userDataPath, `${GPU_FALLBACK_REQUIRED_TIER_FILE}.tmp`))).toBe(false)
+  })
+
+  // Why: a hint, not an authority — bad input degrades to normal ladder escalation.
+  it('degrades to no history on corrupt, off-ladder, or wrong-version records', () => {
+    const file = join(userDataPath, GPU_FALLBACK_REQUIRED_TIER_FILE)
+
+    writeFileSync(file, '{ not json')
+    expect(getResumeGpuFallbackTier(userDataPath)).toBeNull()
+
+    writeFileSync(file, JSON.stringify({ schemeVersion: 1, requiredTier: 99, recordedAt: 1 }))
+    expect(getResumeGpuFallbackTier(userDataPath)).toBeNull()
+
+    writeFileSync(file, JSON.stringify({ schemeVersion: 99, requiredTier: 2, recordedAt: 1 }))
+    expect(getResumeGpuFallbackTier(userDataPath)).toBeNull()
+
+    writeFileSync(file, JSON.stringify({ schemeVersion: 1, requiredTier: 2 }))
+    expect(getResumeGpuFallbackTier(userDataPath)).toBeNull()
+  })
+
+  it('reports failure rather than throwing when the record cannot be written', () => {
+    expect(
+      recordGpuFallbackRequiredTier(join(userDataPath, 'missing'), 2, environment, 1_000)
+    ).toBeNull()
+  })
+})

--- a/src/main/startup/gpu-fallback-required-tier.ts
+++ b/src/main/startup/gpu-fallback-required-tier.ts
@@ -1,0 +1,112 @@
+import { readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { clampGpuFallbackTier, isGpuFallbackTier, type GpuFallbackTier } from './gpu-fallback-tiers'
+
+/**
+ * Version-independent record of the strongest fallback tier this machine has needed.
+ *
+ * The crash marker is scoped to appVersion+electronVersion so a new build gets a
+ * fresh hardware attempt — deliberate, since a driver or Electron update may fix
+ * the machine. But that scoping also discarded everything we had learned: every
+ * update replayed the entire crash loop from the bottom of the ladder, which is
+ * what made the app repeatedly unusable rather than once-unusable.
+ *
+ * This record survives updates. The post-update hardware probe still happens, but
+ * when it fails the app resumes at the tier it already needed instead of walking
+ * the ladder again.
+ *
+ * It is a hint, not an authority: any read failure degrades to normal escalation,
+ * so a corrupt or unreadable file costs extra relaunches, never correctness.
+ */
+
+export const GPU_FALLBACK_REQUIRED_TIER_FILE = 'gpu-fallback-required-tier.json'
+const GPU_FALLBACK_REQUIRED_TIER_TEMP_FILE = `${GPU_FALLBACK_REQUIRED_TIER_FILE}.tmp`
+export const GPU_FALLBACK_REQUIRED_TIER_SCHEME_VERSION = 1
+
+export type GpuFallbackRequiredTierRecord = {
+  schemeVersion: number
+  requiredTier: GpuFallbackTier
+  recordedAt: number
+  /** Build that last needed this tier. Diagnostic only — it never scopes validity. */
+  appVersion: string
+  electronVersion: string
+}
+
+function recordPath(userDataPath: string): string {
+  return join(userDataPath, GPU_FALLBACK_REQUIRED_TIER_FILE)
+}
+
+export function readGpuFallbackRequiredTier(
+  userDataPath: string
+): GpuFallbackRequiredTierRecord | null {
+  let parsed: Partial<Record<keyof GpuFallbackRequiredTierRecord, unknown>>
+  try {
+    parsed = JSON.parse(readFileSync(recordPath(userDataPath), 'utf-8')) as Partial<
+      Record<keyof GpuFallbackRequiredTierRecord, unknown>
+    >
+  } catch {
+    return null
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== 'object' ||
+    parsed.schemeVersion !== GPU_FALLBACK_REQUIRED_TIER_SCHEME_VERSION ||
+    !isGpuFallbackTier(parsed.requiredTier) ||
+    typeof parsed.recordedAt !== 'number' ||
+    !Number.isFinite(parsed.recordedAt)
+  ) {
+    return null
+  }
+  return {
+    schemeVersion: GPU_FALLBACK_REQUIRED_TIER_SCHEME_VERSION,
+    requiredTier: clampGpuFallbackTier(parsed.requiredTier),
+    recordedAt: parsed.recordedAt,
+    appVersion: typeof parsed.appVersion === 'string' ? parsed.appVersion : '',
+    electronVersion: typeof parsed.electronVersion === 'string' ? parsed.electronVersion : ''
+  }
+}
+
+/**
+ * Raises the recorded tier to `tier`. Monotonic: a machine that once needed tier 2
+ * must not be talked back down to tier 1 by a later, shallower crash burst.
+ * Returns the tier now on disk, or null if it could not be persisted.
+ */
+export function recordGpuFallbackRequiredTier(
+  userDataPath: string,
+  tier: GpuFallbackTier,
+  environment: { appVersion: string; electronVersion: string },
+  now: number
+): GpuFallbackTier | null {
+  const existing = readGpuFallbackRequiredTier(userDataPath)
+  if (existing && existing.requiredTier >= tier) {
+    return existing.requiredTier
+  }
+  const record: GpuFallbackRequiredTierRecord = {
+    schemeVersion: GPU_FALLBACK_REQUIRED_TIER_SCHEME_VERSION,
+    requiredTier: tier,
+    recordedAt: now,
+    appVersion: environment.appVersion,
+    electronVersion: environment.electronVersion
+  }
+  const tempPath = join(userDataPath, GPU_FALLBACK_REQUIRED_TIER_TEMP_FILE)
+  try {
+    writeFileSync(tempPath, JSON.stringify(record))
+    renameSync(tempPath, recordPath(userDataPath))
+    return tier
+  } catch {
+    try {
+      rmSync(tempPath, { force: true })
+    } catch {
+      // best effort; a stray temp file is inert
+    }
+    return null
+  }
+}
+
+/**
+ * Tier to resume at when a hardware launch fails and no build-scoped marker exists,
+ * or null when this machine has no history and should start at the bottom.
+ */
+export function getResumeGpuFallbackTier(userDataPath: string): GpuFallbackTier | null {
+  return readGpuFallbackRequiredTier(userDataPath)?.requiredTier ?? null
+}

--- a/src/main/startup/gpu-fallback-tiers.test.ts
+++ b/src/main/startup/gpu-fallback-tiers.test.ts
@@ -4,7 +4,8 @@ import {
   clampGpuFallbackTier,
   getGpuFallbackTierSwitches,
   getNextGpuFallbackTier,
-  isGpuFallbackTier
+  isGpuFallbackTier,
+  resolveGpuFallbackEscalation
 } from './gpu-fallback-tiers'
 
 describe('gpu-fallback-tiers', () => {
@@ -61,5 +62,44 @@ describe('gpu-fallback-tiers', () => {
         'in-process-gpu'
       )
     }
+  })
+})
+
+describe('resolveGpuFallbackEscalation', () => {
+  it('starts a machine with no history at the bottom of the ladder', () => {
+    expect(resolveGpuFallbackEscalation(0, () => null)).toEqual({
+      nextTier: 1,
+      resumedFromHistory: false
+    })
+  })
+
+  // Why: this is what turns "unusable after every update" into one relaunch per update.
+  it('resumes a hardware launch at the tier the machine already needed', () => {
+    expect(resolveGpuFallbackEscalation(0, () => 2)).toEqual({
+      nextTier: 2,
+      resumedFromHistory: true
+    })
+    expect(resolveGpuFallbackEscalation(0, () => 1)).toEqual({
+      nextTier: 1,
+      resumedFromHistory: true
+    })
+  })
+
+  it('ignores history once a tier is applied and escalates one rung', () => {
+    let historyReads = 0
+    expect(
+      resolveGpuFallbackEscalation(1, () => {
+        historyReads += 1
+        return 2
+      })
+    ).toEqual({ nextTier: 2, resumedFromHistory: false })
+    expect(historyReads).toBe(0)
+  })
+
+  it('reports an exhausted ladder at the top rung', () => {
+    expect(resolveGpuFallbackEscalation(2, () => 2)).toEqual({
+      nextTier: null,
+      resumedFromHistory: false
+    })
   })
 })

--- a/src/main/startup/gpu-fallback-tiers.test.ts
+++ b/src/main/startup/gpu-fallback-tiers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_GPU_FALLBACK_TIER,
+  clampGpuFallbackTier,
+  getGpuFallbackTierSwitches,
+  getNextGpuFallbackTier,
+  isGpuFallbackTier
+} from './gpu-fallback-tiers'
+
+describe('gpu-fallback-tiers', () => {
+  it('escalates one rung at a time and stops at the top', () => {
+    expect(getNextGpuFallbackTier(0)).toBe(1)
+    expect(getNextGpuFallbackTier(1)).toBe(2)
+    expect(getNextGpuFallbackTier(2)).toBe(3)
+    expect(getNextGpuFallbackTier(3)).toBeNull()
+  })
+
+  // Why: null is what bounds relaunches per build; a non-null answer here is a crash loop.
+  it('never escalates past the ladder for out-of-range input', () => {
+    expect(getNextGpuFallbackTier(99)).toBeNull()
+    expect(getNextGpuFallbackTier(Number.POSITIVE_INFINITY)).toBeNull()
+    expect(getNextGpuFallbackTier(Number.NaN)).toBe(1)
+    expect(getNextGpuFallbackTier(-5)).toBe(1)
+  })
+
+  it('clamps untrusted persisted tiers', () => {
+    expect(clampGpuFallbackTier(undefined)).toBe(1)
+    expect(clampGpuFallbackTier('2')).toBe(1)
+    expect(clampGpuFallbackTier(0)).toBe(1)
+    expect(clampGpuFallbackTier(2)).toBe(2)
+    expect(clampGpuFallbackTier(2.7)).toBe(2)
+    expect(clampGpuFallbackTier(999)).toBe(MAX_GPU_FALLBACK_TIER)
+  })
+
+  it('identifies ladder members', () => {
+    expect(isGpuFallbackTier(1)).toBe(true)
+    expect(isGpuFallbackTier(0)).toBe(false)
+    expect(isGpuFallbackTier(4)).toBe(false)
+  })
+
+  // Why: escalating must never drop a switch a lower tier already needed.
+  it('is additive across tiers', () => {
+    const names = ([1, 2, 3] as const).map(
+      (tier) => new Set(getGpuFallbackTierSwitches(tier).map((entry) => entry.name))
+    )
+    for (const name of names[0]) {
+      expect(names[1].has(name)).toBe(true)
+    }
+    for (const name of names[1]) {
+      expect(names[2].has(name)).toBe(true)
+    }
+  })
+
+  it('removes the GPU child process at the top tier', () => {
+    const tier1 = getGpuFallbackTierSwitches(1).map((entry) => entry.name)
+    expect(tier1).toEqual(['disable-gpu'])
+
+    const tier2 = getGpuFallbackTierSwitches(2)
+    expect(tier2.map((entry) => entry.name)).toContain('disable-gpu-compositing')
+    expect(tier2.find((entry) => entry.name === 'use-angle')?.value).toBe('swiftshader')
+
+    expect(getGpuFallbackTierSwitches(3).map((entry) => entry.name)).toContain('in-process-gpu')
+  })
+})

--- a/src/main/startup/gpu-fallback-tiers.test.ts
+++ b/src/main/startup/gpu-fallback-tiers.test.ts
@@ -11,8 +11,7 @@ describe('gpu-fallback-tiers', () => {
   it('escalates one rung at a time and stops at the top', () => {
     expect(getNextGpuFallbackTier(0)).toBe(1)
     expect(getNextGpuFallbackTier(1)).toBe(2)
-    expect(getNextGpuFallbackTier(2)).toBe(3)
-    expect(getNextGpuFallbackTier(3)).toBeNull()
+    expect(getNextGpuFallbackTier(2)).toBeNull()
   })
 
   // Why: null is what bounds relaunches per build; a non-null answer here is a crash loop.
@@ -35,30 +34,32 @@ describe('gpu-fallback-tiers', () => {
   it('identifies ladder members', () => {
     expect(isGpuFallbackTier(1)).toBe(true)
     expect(isGpuFallbackTier(0)).toBe(false)
-    expect(isGpuFallbackTier(4)).toBe(false)
+    expect(isGpuFallbackTier(3)).toBe(false)
   })
 
   // Why: escalating must never drop a switch a lower tier already needed.
   it('is additive across tiers', () => {
-    const names = ([1, 2, 3] as const).map(
-      (tier) => new Set(getGpuFallbackTierSwitches(tier).map((entry) => entry.name))
-    )
-    for (const name of names[0]) {
-      expect(names[1].has(name)).toBe(true)
-    }
-    for (const name of names[1]) {
-      expect(names[2].has(name)).toBe(true)
+    const tier1 = new Set(getGpuFallbackTierSwitches(1).map((entry) => entry.name))
+    const tier2 = new Set(getGpuFallbackTierSwitches(2).map((entry) => entry.name))
+    for (const name of tier1) {
+      expect(tier2.has(name)).toBe(true)
     }
   })
 
-  it('removes the GPU child process at the top tier', () => {
-    const tier1 = getGpuFallbackTierSwitches(1).map((entry) => entry.name)
-    expect(tier1).toEqual(['disable-gpu'])
+  it('takes the compositor off the GPU child and ANGLE off the vendor driver at tier 2', () => {
+    expect(getGpuFallbackTierSwitches(1).map((entry) => entry.name)).toEqual(['disable-gpu'])
 
     const tier2 = getGpuFallbackTierSwitches(2)
     expect(tier2.map((entry) => entry.name)).toContain('disable-gpu-compositing')
     expect(tier2.find((entry) => entry.name === 'use-angle')?.value).toBe('swiftshader')
+  })
 
-    expect(getGpuFallbackTierSwitches(3).map((entry) => entry.name)).toContain('in-process-gpu')
+  // Why: in-process-gpu turns a recoverable child fault into a main-process kill.
+  it('never offers in-process-gpu on any rung', () => {
+    for (const tier of [1, 2] as const) {
+      expect(getGpuFallbackTierSwitches(tier).map((entry) => entry.name)).not.toContain(
+        'in-process-gpu'
+      )
+    }
   })
 })

--- a/src/main/startup/gpu-fallback-tiers.ts
+++ b/src/main/startup/gpu-fallback-tiers.ts
@@ -25,6 +25,9 @@ export const MAX_GPU_FALLBACK_TIER: GpuFallbackTier = 2
 /** Tier 0 means "no fallback applied to this launch". */
 export const NO_GPU_FALLBACK_TIER = 0
 
+/** A rung, or the hardware path. The only values a launch's current tier may hold. */
+export type GpuFallbackTierOrNone = GpuFallbackTier | typeof NO_GPU_FALLBACK_TIER
+
 export type GpuFallbackSwitch = { name: string; value?: string }
 
 const TIER_SWITCHES: Record<GpuFallbackTier, readonly GpuFallbackSwitch[]> = {

--- a/src/main/startup/gpu-fallback-tiers.ts
+++ b/src/main/startup/gpu-fallback-tiers.ts
@@ -1,0 +1,77 @@
+/**
+ * Escalation ladder for the Windows GPU-crash fallback.
+ *
+ * `--disable-gpu` alone does not stop Chromium from spawning a GPU child for the
+ * Viz display compositor, so a driver that CHECK-crashes at GPU init keeps
+ * killing every launch even with the fallback applied. Each tier removes
+ * strictly more of the GPU process from the path; tier 3 removes the child
+ * process entirely, which is the only shape a GPU-init crash cannot survive.
+ *
+ * Tiers are additive on purpose: escalating never drops a switch that a lower
+ * tier already needed.
+ */
+
+export const GPU_FALLBACK_TIERS = [1, 2, 3] as const
+
+export type GpuFallbackTier = (typeof GPU_FALLBACK_TIERS)[number]
+
+export const MIN_GPU_FALLBACK_TIER: GpuFallbackTier = 1
+export const MAX_GPU_FALLBACK_TIER: GpuFallbackTier = 3
+
+/** Tier 0 means "no fallback applied to this launch". */
+export const NO_GPU_FALLBACK_TIER = 0
+
+export type GpuFallbackSwitch = { name: string; value?: string }
+
+const TIER_SWITCHES: Record<GpuFallbackTier, readonly GpuFallbackSwitch[]> = {
+  1: [{ name: 'disable-gpu' }],
+  2: [
+    { name: 'disable-gpu' },
+    // Why: moves the display compositor off the GPU child, which tier 1 still spawned.
+    { name: 'disable-gpu-compositing' },
+    // Why: keeps a broken vendor D3D11 driver DLL out of the process even when Chromium still initializes ANGLE.
+    { name: 'use-angle', value: 'swiftshader' }
+  ],
+  3: [
+    { name: 'disable-gpu' },
+    { name: 'disable-gpu-compositing' },
+    { name: 'use-angle', value: 'swiftshader' },
+    // Why: last resort — no GPU child exists, so a GPU-init CHECK crash can no longer loop the app.
+    { name: 'in-process-gpu' }
+  ]
+}
+
+export function isGpuFallbackTier(value: unknown): value is GpuFallbackTier {
+  return GPU_FALLBACK_TIERS.some((tier) => tier === value)
+}
+
+/** Coerces a persisted/untrusted tier onto the ladder; anything unrecognized starts at tier 1. */
+export function clampGpuFallbackTier(value: unknown): GpuFallbackTier {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return MIN_GPU_FALLBACK_TIER
+  }
+  const rounded = Math.trunc(value)
+  if (rounded <= MIN_GPU_FALLBACK_TIER) {
+    return MIN_GPU_FALLBACK_TIER
+  }
+  return rounded >= MAX_GPU_FALLBACK_TIER ? MAX_GPU_FALLBACK_TIER : (rounded as GpuFallbackTier)
+}
+
+export function getGpuFallbackTierSwitches(tier: GpuFallbackTier): readonly GpuFallbackSwitch[] {
+  return TIER_SWITCHES[tier]
+}
+
+/**
+ * Next rung above `currentTier` (0 = nothing applied yet), or null once the
+ * ladder is exhausted. Null is what bounds relaunches to 3 per build.
+ */
+export function getNextGpuFallbackTier(currentTier: number): GpuFallbackTier | null {
+  if (Number.isNaN(currentTier) || currentTier < MIN_GPU_FALLBACK_TIER) {
+    return MIN_GPU_FALLBACK_TIER
+  }
+  if (currentTier >= MAX_GPU_FALLBACK_TIER) {
+    return null
+  }
+  const next = Math.trunc(currentTier) + 1
+  return isGpuFallbackTier(next) ? next : null
+}

--- a/src/main/startup/gpu-fallback-tiers.ts
+++ b/src/main/startup/gpu-fallback-tiers.ts
@@ -72,3 +72,25 @@ export function getNextGpuFallbackTier(currentTier: number): GpuFallbackTier | n
   const next = Math.trunc(currentTier) + 1
   return isGpuFallbackTier(next) ? next : null
 }
+
+export type GpuFallbackEscalation = {
+  nextTier: GpuFallbackTier | null
+  resumedFromHistory: boolean
+}
+
+/**
+ * Tier for the relaunch after a crash burst. History (the strongest tier this
+ * machine ever needed) is consulted only when no tier is applied this launch —
+ * i.e. the post-update hardware probe just failed. Once on the ladder,
+ * escalation is strictly one rung at a time.
+ */
+export function resolveGpuFallbackEscalation(
+  currentTier: number,
+  readRequiredTierHistory: () => GpuFallbackTier | null
+): GpuFallbackEscalation {
+  const resumeTier = currentTier === NO_GPU_FALLBACK_TIER ? readRequiredTierHistory() : null
+  return {
+    nextTier: resumeTier ?? getNextGpuFallbackTier(currentTier),
+    resumedFromHistory: resumeTier !== null
+  }
+}

--- a/src/main/startup/gpu-fallback-tiers.ts
+++ b/src/main/startup/gpu-fallback-tiers.ts
@@ -3,20 +3,24 @@
  *
  * `--disable-gpu` alone does not stop Chromium from spawning a GPU child for the
  * Viz display compositor, so a driver that CHECK-crashes at GPU init keeps
- * killing every launch even with the fallback applied. Each tier removes
- * strictly more of the GPU process from the path; tier 3 removes the child
- * process entirely, which is the only shape a GPU-init crash cannot survive.
+ * killing every launch even with the fallback applied (20 of 21 crashed launches
+ * in the reported bundle already carried tier 1). Tier 2 takes the compositor off
+ * the GPU child and forces ANGLE onto SwiftShader so the vendor DLL is never loaded.
+ *
+ * The ladder deliberately stops there. `--in-process-gpu` would remove the child
+ * entirely, but it also turns a recoverable child fault into a main-process kill,
+ * and nothing in the evidence says tier 2 is insufficient.
  *
  * Tiers are additive on purpose: escalating never drops a switch that a lower
  * tier already needed.
  */
 
-export const GPU_FALLBACK_TIERS = [1, 2, 3] as const
+export const GPU_FALLBACK_TIERS = [1, 2] as const
 
 export type GpuFallbackTier = (typeof GPU_FALLBACK_TIERS)[number]
 
 export const MIN_GPU_FALLBACK_TIER: GpuFallbackTier = 1
-export const MAX_GPU_FALLBACK_TIER: GpuFallbackTier = 3
+export const MAX_GPU_FALLBACK_TIER: GpuFallbackTier = 2
 
 /** Tier 0 means "no fallback applied to this launch". */
 export const NO_GPU_FALLBACK_TIER = 0
@@ -31,13 +35,6 @@ const TIER_SWITCHES: Record<GpuFallbackTier, readonly GpuFallbackSwitch[]> = {
     { name: 'disable-gpu-compositing' },
     // Why: keeps a broken vendor D3D11 driver DLL out of the process even when Chromium still initializes ANGLE.
     { name: 'use-angle', value: 'swiftshader' }
-  ],
-  3: [
-    { name: 'disable-gpu' },
-    { name: 'disable-gpu-compositing' },
-    { name: 'use-angle', value: 'swiftshader' },
-    // Why: last resort — no GPU child exists, so a GPU-init CHECK crash can no longer loop the app.
-    { name: 'in-process-gpu' }
   ]
 }
 
@@ -63,7 +60,7 @@ export function getGpuFallbackTierSwitches(tier: GpuFallbackTier): readonly GpuF
 
 /**
  * Next rung above `currentTier` (0 = nothing applied yet), or null once the
- * ladder is exhausted. Null is what bounds relaunches to 3 per build.
+ * ladder is exhausted. Null is what bounds relaunches per build.
  */
 export function getNextGpuFallbackTier(currentTier: number): GpuFallbackTier | null {
   if (Number.isNaN(currentTier) || currentTier < MIN_GPU_FALLBACK_TIER) {

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -15,6 +15,7 @@ import { Label } from '@/components/ui/label'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   formatCrashReportText,
+  isGpuFallbackCrashReport,
   isReactErrorBoundaryReport,
   type CrashReportDiagnosticBundle,
   type CrashReportRecord
@@ -34,17 +35,23 @@ function formatSummary(report: CrashReportRecord): string {
     const surface = typeof report.details.surface === 'string' ? report.details.surface : null
     return surface ? `React render error in ${surface}` : 'React render error'
   }
-  return `${report.processType} ${report.reason}${
+  const summary = `${report.processType} ${report.reason}${
     report.exitCode === null ? '' : ` (exit ${report.exitCode})`
   }`
+  return isGpuFallbackCrashReport(report)
+    ? `${summary} — graphics fallback tier ${String(report.details.gpuFallbackTier)}`
+    : summary
 }
 
 function getDialogTitle(report: CrashReportRecord | null): string {
   if (!report) {
     return 'Report a crash'
   }
-  return report && isReactErrorBoundaryReport(report)
-    ? 'Orca hit a recoverable UI error'
+  if (isReactErrorBoundaryReport(report)) {
+    return 'Orca hit a recoverable UI error'
+  }
+  return isGpuFallbackCrashReport(report)
+    ? 'Orca is running with reduced graphics acceleration'
     : 'Orca closed unexpectedly'
 }
 
@@ -52,8 +59,11 @@ function getDialogDescription(report: CrashReportRecord | null): string {
   if (!report) {
     return 'Send a privacy-safe crash report. Recent redacted diagnostic logs are included when available.'
   }
-  return report && isReactErrorBoundaryReport(report)
-    ? 'Send a privacy-safe diagnostic report to help us understand the failed UI surface.'
+  if (isReactErrorBoundaryReport(report)) {
+    return 'Send a privacy-safe diagnostic report to help us understand the failed UI surface.'
+  }
+  return isGpuFallbackCrashReport(report)
+    ? "Your graphics driver keeps crashing Orca's GPU process, so Orca disabled hardware acceleration and restarted. Sending this privacy-safe report tells us which driver is affected."
     : 'Send a privacy-safe diagnostic report to help us understand what happened.'
 }
 
@@ -61,8 +71,11 @@ function getNotesPlaceholder(report: CrashReportRecord | null): string {
   if (!report) {
     return 'Optional: what happened?'
   }
-  return report && isReactErrorBoundaryReport(report)
-    ? 'Optional: what were you doing before this UI error?'
+  if (isReactErrorBoundaryReport(report)) {
+    return 'Optional: what were you doing before this UI error?'
+  }
+  return isGpuFallbackCrashReport(report)
+    ? 'Optional: does anything still look wrong after the restart?'
     : 'Optional: what were you doing before Orca closed?'
 }
 

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -163,6 +163,21 @@ export function isReactErrorBoundaryReport(report: CrashReportRecord): boolean {
   )
 }
 
+/**
+ * A GPU child crash that happened while a GPU fallback tier was already applied.
+ *
+ * Orca is still running here — it relaunched itself into a degraded GPU path —
+ * so the dialog must not claim the app closed unexpectedly.
+ */
+export function isGpuFallbackCrashReport(report: CrashReportRecord): boolean {
+  return (
+    report.source === 'child' &&
+    report.processType.toLowerCase() === 'gpu' &&
+    typeof report.details.gpuFallbackTier === 'number' &&
+    report.details.gpuFallbackTier > 0
+  )
+}
+
 export function sanitizeCrashReportString(
   value: string,
   maxLength = MAX_STRING_DETAIL_LENGTH


### PR DESCRIPTION
## Summary

Implements a tiered GPU fallback system for Windows that escalates through degradation levels when the driver crashes, with persistent driver identity for crash triage.

## Key Changes

- **Fallback Ladder**: Two-rung escalation (tier 1: `--disable-gpu`; tier 2: `--disable-gpu-compositing` + `--use-angle=swiftshader`). Tier 2 removes the compositor from the GPU child and bypasses the vendor driver.
- **Driver Identity in Crash Reports**: Captures `app.getGPUInfo('complete')` at startup and embeds vendor/device/driver version for every crash.
- **Cross-Update Tier Resumption**: Version-independent record survives updates, so machines resume at their known-bad tier instead of re-walking the ladder after each app update.
- **GPU Cache Purge**: Clears shader/GPU caches when escalating tiers, preventing the crashing driver's cached state from repeating the crash.
- **Crash Visibility Fix**: Records GPU crashes once the fallback is applied (previously suppressed). This surfaces ineffective escalations; 20/21 crashed launches in the reported bundle already carried tier 1.
- **Report Budgeting**: Caps GPU-under-fallback reports to 3 per launch to prevent tail I/O churn while keeping triage signal.
- **Reworded Crash Dialog**: GPU fallback crashes show tier and tier-specific prompt language instead of "closed unexpectedly".

## Testing

Comprehensive unit tests added for all modules:
- `gpu-fallback-tiers`: escalation, tier switches, ladders bounds
- `gpu-fallback-required-tier`: monotonic tier persistence, version-independence
- `gpu-fallback-marker`: atomic writes, corruption handling, platform gating
- `gpu-cache-purge`: removal and failure tracking
- `gpu-info-snapshot`: flattening GPU info, timeout handling, string bounding
- Process-gone classification/recorder: crash suppression under fallback, budget accounting, GPU info attachment

## Platform & Scope

- Windows-only (marker lifecycle and ladder escalation gated on `process.platform === 'win32'`).
- `IntensiveWakeUpThrottling` opt-out decoupled from GPU path to preserve timer behavior under fallback.
- In-process-gpu deliberately absent (would mask child crashes as main-process kills).