### PR TITLE
fix(persistence): fsync state writes so a rename is actually durable

### DIFF
--- a/src/main/durable-file-write-syscall-proof.test.ts
+++ b/src/main/durable-file-write-syscall-proof.test.ts
@@ -1,0 +1,33 @@
+// Empirical proof that the durable write fsyncs the file AND its directory. Counted at the module
+// boundary rather than inferred from reading the implementation.
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it, vi } from 'vitest'
+
+const fsyncTargets: ('file' | 'directory')[] = []
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return {
+    ...actual,
+    fsyncSync: (fd: number) => {
+      fsyncTargets.push(actual.fstatSync(fd).isDirectory() ? 'directory' : 'file')
+      return actual.fsyncSync(fd)
+    }
+  }
+})
+
+it('fsyncs the file before rename and the directory after', async () => {
+  const { writeFileDurableSync } = await import('./durable-file-write')
+  const dir = mkdtempSync(join(tmpdir(), 'orca-fsync-'))
+  try {
+    const target = join(dir, 'x.json')
+    writeFileDurableSync(`${target}.tmp`, target, '{"ok":1}')
+    expect(readFileSync(target, 'utf-8')).toBe('{"ok":1}')
+    expect(fsyncTargets).toEqual(['file', 'directory'])
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/src/main/durable-file-write-syscall-proof.test.ts
+++ b/src/main/durable-file-write-syscall-proof.test.ts
@@ -1,32 +1,66 @@
-// Empirical proof that the durable write fsyncs the file AND its directory. Counted at the module
-// boundary rather than inferred from reading the implementation.
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+// Empirical proof that the durable write fsyncs the file, and the directory where the platform
+// allows it. Counted at the module boundary rather than inferred from reading the implementation.
+import { closeSync, fsyncSync, mkdtempSync, openSync, readFileSync, rmSync } from 'node:fs'
 import type * as NodeFs from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, it, vi } from 'vitest'
 
-const fsyncTargets: ('file' | 'directory')[] = []
+/** Why the rename is recorded too: an fsync moved after the rename still fsyncs a file, so a
+ *  fsync-only log reads identically for the correct and the broken order. The rename is the boundary
+ *  the ordering is defined against, so it has to appear in the same sequence. */
+const syscalls: ('fsync:file' | 'fsync:directory' | 'rename')[] = []
 
 vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof NodeFs>('node:fs')
   return {
     ...actual,
     fsyncSync: (fd: number) => {
-      fsyncTargets.push(actual.fstatSync(fd).isDirectory() ? 'directory' : 'file')
+      syscalls.push(actual.fstatSync(fd).isDirectory() ? 'fsync:directory' : 'fsync:file')
       return actual.fsyncSync(fd)
+    },
+    renameSync: (from: NodeFs.PathLike, to: NodeFs.PathLike) => {
+      syscalls.push('rename')
+      return actual.renameSync(from, to)
     }
   }
 })
 
-it('fsyncs the file before rename and the directory after', async () => {
+/** Windows cannot open a directory for fsync, and some filesystems reject it; probe rather than
+ *  assume, so the expectation tracks the real platform instead of a hardcoded OS list. */
+function directoryFsyncSupported(directory: string): boolean {
+  let fd: number | null = null
+  try {
+    fd = openSync(directory, 'r')
+    fsyncSync(fd)
+    return true
+  } catch {
+    return false
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd)
+      } catch {
+        // Nothing actionable in a probe.
+      }
+    }
+  }
+}
+
+it('fsyncs the file before rename, and the directory after where supported', async () => {
   const { writeFileDurableSync } = await import('./durable-file-write')
   const dir = mkdtempSync(join(tmpdir(), 'orca-fsync-'))
   try {
+    const supported = directoryFsyncSupported(dir)
+    syscalls.length = 0 // Discard the probe's own fsync.
     const target = join(dir, 'x.json')
     writeFileDurableSync(`${target}.tmp`, target, '{"ok":1}')
     expect(readFileSync(target, 'utf-8')).toBe('{"ok":1}')
-    expect(fsyncTargets).toEqual(['file', 'directory'])
+    // The data fsync must precede the rename: that ordering is the entire fix. Publishing the name
+    // first is what lets a crash expose a stale or zero-length file.
+    expect(syscalls).toEqual(
+      supported ? ['fsync:file', 'rename', 'fsync:directory'] : ['fsync:file', 'rename']
+    )
   } finally {
     rmSync(dir, { recursive: true, force: true })
   }

--- a/src/main/durable-file-write.test.ts
+++ b/src/main/durable-file-write.test.ts
@@ -1,0 +1,87 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { writeFileDurable, writeFileDurableSync } from './durable-file-write'
+
+describe('durable file write', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-durable-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  for (const [label, write] of [
+    ['async', (t: string, f: string, p: string) => writeFileDurable(t, f, p)],
+    [
+      'sync',
+      (t: string, f: string, p: string) => {
+        writeFileDurableSync(t, f, p)
+        return Promise.resolve()
+      }
+    ]
+  ] as const) {
+    describe(label, () => {
+      it('publishes the payload at the final path', async () => {
+        const final = join(dir, 'state.json')
+        await write(`${final}.tmp`, final, '{"a":1}')
+        expect(readFileSync(final, 'utf-8')).toBe('{"a":1}')
+      })
+
+      it('replaces existing content atomically', async () => {
+        const final = join(dir, 'state.json')
+        writeFileSync(final, 'stale', 'utf-8')
+        await write(`${final}.tmp`, final, 'fresh')
+        expect(readFileSync(final, 'utf-8')).toBe('fresh')
+      })
+
+      it('leaves no temp file behind on success', async () => {
+        const final = join(dir, 'state.json')
+        const tmp = `${final}.tmp`
+        await write(tmp, final, 'x')
+        expect(() => readFileSync(tmp, 'utf-8')).toThrow()
+      })
+
+      it('round-trips a multi-megabyte payload without truncation', async () => {
+        // Why: the real orca-data.json is large; a partial fsync would surface here.
+        const final = join(dir, 'big.json')
+        const payload = JSON.stringify({ blob: 'x'.repeat(4 * 1024 * 1024) })
+        await write(`${final}.tmp`, final, payload)
+        expect(readFileSync(final, 'utf-8')).toHaveLength(payload.length)
+      })
+
+      it('preserves exact bytes for multibyte and escape-sensitive content', async () => {
+        const final = join(dir, 'utf8.json')
+        const payload = JSON.stringify({ s: 'emoji 🚀 + 日本語 + \u0000 + "quotes"' })
+        await write(`${final}.tmp`, final, payload)
+        expect(readFileSync(final, 'utf-8')).toBe(payload)
+      })
+
+      it('surfaces an unwritable temp path instead of silently succeeding', async () => {
+        const final = join(dir, 'state.json')
+        const tmp = join(dir, 'missing-subdir', 'state.json.tmp')
+        // The sync variant throws synchronously and the async one rejects; both must fail loudly
+        // and neither may publish a partial file.
+        let failed = false
+        try {
+          await write(tmp, final, 'x')
+        } catch {
+          failed = true
+        }
+        expect(failed).toBe(true)
+        expect(() => readFileSync(final, 'utf-8')).toThrow()
+      })
+    })
+  }
+
+  it('keeps the last writer when async and sync paths target one file', async () => {
+    const final = join(dir, 'state.json')
+    await writeFileDurable(`${final}.a.tmp`, final, 'from-async')
+    writeFileDurableSync(`${final}.b.tmp`, final, 'from-sync')
+    expect(readFileSync(final, 'utf-8')).toBe('from-sync')
+  })
+})

--- a/src/main/durable-file-write.ts
+++ b/src/main/durable-file-write.ts
@@ -1,0 +1,83 @@
+// Why: rename() is atomic for readers but not durable. Without fsync on the file and its directory,
+// a power loss after a successful rename can leave the old contents, or an empty inode — the same
+// empty-file symptom as issue #1158, from a different cause. The .bak ring recovers it at up to an
+// hour's loss; fsync stops it from happening.
+
+import { closeSync, fsyncSync, openSync, renameSync, writeFileSync } from 'node:fs'
+import { open, rename } from 'node:fs/promises'
+import { dirname } from 'node:path'
+
+/**
+ * fsync a directory so a rename within it is durable. Best-effort by design: Windows cannot open a
+ * directory for fsync, and some filesystems reject it. The file fsync above it is the load-bearing
+ * part; this closes the "rename recorded but not persisted" window where the platform allows it.
+ */
+async function syncDirectory(directory: string): Promise<void> {
+  let handle: Awaited<ReturnType<typeof open>> | null = null
+  try {
+    handle = await open(directory, 'r')
+    await handle.sync()
+  } catch {
+    // Expected on Windows and on filesystems without directory fsync.
+  } finally {
+    await handle?.close().catch(() => {})
+  }
+}
+
+function syncDirectorySync(directory: string): void {
+  let fd: number | null = null
+  try {
+    fd = openSync(directory, 'r')
+    fsyncSync(fd)
+  } catch {
+    // Same platform caveats as syncDirectory.
+  } finally {
+    if (fd !== null) {
+      try {
+        closeSync(fd)
+      } catch {
+        // Nothing actionable; the fsync already happened or the open failed.
+      }
+    }
+  }
+}
+
+/**
+ * Rename and then fsync the containing directory. For callers that already fsynced the temp file
+ * themselves and need the rename made durable.
+ */
+export async function renameDurable(tmpPath: string, finalPath: string): Promise<void> {
+  await rename(tmpPath, finalPath)
+  await syncDirectory(dirname(finalPath))
+}
+
+/** Write `payload` to `tmpPath`, fsync it, then rename onto `finalPath` and fsync the directory. */
+export async function writeFileDurable(
+  tmpPath: string,
+  finalPath: string,
+  payload: string
+): Promise<void> {
+  const handle = await open(tmpPath, 'w')
+  try {
+    await handle.writeFile(payload, 'utf-8')
+    // Why: fsync BEFORE rename. A rename that lands first can expose a zero-length file.
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+  await rename(tmpPath, finalPath)
+  await syncDirectory(dirname(finalPath))
+}
+
+/** Synchronous counterpart for quit and crash paths that cannot await. */
+export function writeFileDurableSync(tmpPath: string, finalPath: string, payload: string): void {
+  writeFileSync(tmpPath, payload, 'utf-8')
+  const fd = openSync(tmpPath, 'r+')
+  try {
+    fsyncSync(fd)
+  } finally {
+    closeSync(fd)
+  }
+  renameSync(tmpPath, finalPath)
+  syncDirectorySync(dirname(finalPath))
+}

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -11,7 +11,8 @@ import {
   statSync,
   realpathSync
 } from 'node:fs'
-import { writeFile, rename, mkdir, rm, copyFile } from 'node:fs/promises'
+import { rename, mkdir, rm, copyFile, open } from 'node:fs/promises'
+import { renameDurable, writeFileDurableSync } from './durable-file-write'
 import { join, dirname, isAbsolute, resolve, sep } from 'node:path'
 import { homedir } from 'node:os'
 import { createHash, randomUUID } from 'node:crypto'
@@ -3686,12 +3687,19 @@ export class Store {
     // Why: on any write/rename failure, remove the tmp file so it doesn't leave a multi-MB orphan.
     let renamed = false
     try {
-      await writeFile(tmpFile, payload, 'utf-8')
+      // Why: fsync before rename, then fsync the directory; see writeFileDurable.
+      const handle = await open(tmpFile, 'w')
+      try {
+        await handle.writeFile(payload, 'utf-8')
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
       // Why: if flush() bumped writeGeneration mid-write, it already wrote fresher state; don't overwrite it.
       if (this.writeGeneration !== gen) {
         return
       }
-      await rename(tmpFile, dataFile)
+      await renameDurable(tmpFile, dataFile)
       renamed = true
       // Why re-check gen: a sync flush during the rename await may have written fresher state; don't record a stale hash over it.
       if (this.writeGeneration === gen) {
@@ -3732,8 +3740,9 @@ export class Store {
     // Why: on any write/rename failure, remove the tmp file so shutdown crashes don't leak orphans.
     let renamed = false
     try {
-      writeFileSync(tmpFile, payload, 'utf-8')
-      renameSync(tmpFile, dataFile)
+      // Why: fsync the temp file and the directory; a bare rename can survive as stale or empty
+      // content after power loss, losing projects/tabs back to the newest usable .bak slot.
+      writeFileDurableSync(tmpFile, dataFile, payload)
       renamed = true
       this.lastWrittenStateHash = stateHash
     } finally {


### PR DESCRIPTION
## The bug

`Store` writes `orca-data.json` to a temp file and renames it over the target. `rename()` is atomic *for readers* — nobody sees a half-written file — but it says nothing about **durability**. Without an fsync, the directory entry can reach disk before the file's data does.

So after a power loss, hard crash, or forced reboot, the file can come back holding the **previous** state, or **zero bytes**. Zero bytes is the bad case: `JSON.parse('')` throws, so an empty file takes the full corrupt-file path rather than degrading gracefully.

`orca-data.json` holds projects, repos, worktrees, tabs, terminal layouts, agent session bindings, and settings, and is rewritten on a 1-second debounce during normal use.

## Why nobody noticed

This is the **same empty-file symptom as #1158, from a different cause.** That issue fixed a logic path that persisted empty state after failed hydration, and added the rolling `.bak` ring as a safety net (`persistence.ts:473`). The ring catches this failure too — `load()` fails to parse, `restoreFromBackup()` validates each slot with `JSON.parse` and restores the newest usable one.

So the realistic user impact is bounded, not catastrophic:

- **Typical case:** Orca comes back with projects and tabs **as of up to an hour ago** (backups are throttled to ≥1h spacing) plus a recovery warning in the log.
- **Worst case:** a user in their **first hour** has no backup slot yet, so they land on defaults — indistinguishable from a fresh install.

Fixing the write is strictly better than relying on the net.

## The fix

Both write paths (async debounced, and the sync variant used at shutdown) now:

1. fsync the temp file **before** the rename
2. rename
3. fsync the containing directory

Extracted into `durable-file-write.ts` so both paths share one implementation.

**Directory fsync is best-effort by design.** Windows cannot open a directory for fsync and some filesystems reject it, so that failure is swallowed. The file fsync is the load-bearing part and works on every platform — macOS, Linux, and Windows.

## Cost

Measured on this machine (APFS SSD), 3 MB payload, 10 writes:

| | per write |
|---|---|
| bare rename | 1.9 ms |
| fsync + rename + dir fsync | 2.1 ms |

**~0.2 ms added**, against a 1-second debounce. The async path doesn't block the main thread.

## Tests

`durable-file-write.test.ts` — 13 tests across both variants: publication, atomic replace, no temp-file leak, a 4 MB payload, exact byte preservation for multibyte/NUL/quote content, and loud failure on an unwritable temp path with no partial publish.

`durable-file-write-syscall-proof.test.ts` mocks `node:fs` and records the fsyncs **and the rename** at the module boundary, asserting `['fsync:file', 'rename', 'fsync:directory']` where directory fsync is supported and `['fsync:file', 'rename']` where it is not (Windows, and filesystems that reject it — the test probes rather than assuming).

Recording the rename is the point: an fsync moved *after* the rename still fsyncs the file, so a fsync-only log reads identically for the correct and the broken order. I verified this by mutation — with the earlier fsync-only assertion the broken order **passed**. With the rename in the sequence it fails, so the ordering claim is backed by the test rather than by a comment.

## Verification

- `pnpm exec tsc --noEmit -p config/tsconfig.node.json` — clean
- `vitest run src/main/persistence src/main/durable-file-write*` — **433 tests pass**
- `oxlint`, `oxfmt`, `check:max-lines-ratchet` — clean

## Note

Found while reviewing durability requirements for an unrelated in-progress design doc, but this stands entirely on its own — it fixes shipping behaviour on `main` today and depends on nothing else.
