### PR TITLE
fix(terminal-pane): resolve React #185 setState loop via state identity

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -236,6 +236,25 @@ describe('renderer breadcrumb IPC routing', () => {
     })
   })
 
+  // Why: park-churn notices are per-tab but the ring is process-wide, so many
+  // tabs churning at once would otherwise evict the pre-crash trail.
+  it('coalesces park-verdict churn notices by name across tabs', () => {
+    emitRendererBreadcrumb({
+      name: 'terminal_park_verdict_churn',
+      data: { tabId: 'tab-1', flips: 12, elapsedMs: 8 }
+    })
+    emitRendererBreadcrumb({
+      name: 'terminal_park_verdict_churn',
+      data: { tabId: 'tab-2', flips: 12, elapsedMs: 9 }
+    })
+
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledTimes(2)
+    for (const call of recordCoalescedCrashBreadcrumbMock.mock.calls) {
+      expect(call[0]).toMatchObject({ coalesceKey: 'terminal_park_verdict_churn' })
+    }
+  })
+
   it('records non-error renderer breadcrumbs without coalescing', () => {
     emitRendererBreadcrumb({ name: 'renderer_bootstrap_started', data: { dev: true } })
 

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -325,16 +325,24 @@ function buildUncapturedCrashReportText(
 // storm, #8260) can flush the whole fixed-size breadcrumb ring in seconds,
 // erasing the pre-crash trail. Coalesce repeats into one entry that carries a
 // suppressed count instead.
-const COALESCED_RENDERER_ERROR_BREADCRUMB_NAMES = new Set([
+const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   'renderer_error',
-  'renderer_unhandled_rejection'
+  'renderer_unhandled_rejection',
+  'terminal_park_verdict_churn'
 ])
-const RENDERER_ERROR_BREADCRUMB_COALESCE_MS = 30_000
+const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
+// Why: these carry no message identity — they are per-tab telemetry whose rate,
+// not whose text, is the signal. Coalescing by name alone bounds a many-tab
+// storm to one ring entry plus a suppressed count.
+const NAME_ONLY_COALESCED_BREADCRUMB_NAMES = new Set(['terminal_park_verdict_churn'])
 
-function rendererErrorBreadcrumbCoalesceKey(
+function rendererBreadcrumbCoalesceKey(
   name: string,
   data: CrashReportBreadcrumbData | undefined
 ): string | undefined {
+  if (NAME_ONLY_COALESCED_BREADCRUMB_NAMES.has(name)) {
+    return name
+  }
   const primaryMessage = name === 'renderer_error' ? data?.message : data?.reasonMessage
   const fallbackMessage = name === 'renderer_error' ? data?.errorMessage : undefined
   const message =
@@ -394,8 +402,8 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
         return
       }
       const data = sanitizeRendererBreadcrumbData(args.data)
-      if (COALESCED_RENDERER_ERROR_BREADCRUMB_NAMES.has(args.name)) {
-        const coalesceKey = rendererErrorBreadcrumbCoalesceKey(args.name, data)
+      if (COALESCED_RENDERER_BREADCRUMB_NAMES.has(args.name)) {
+        const coalesceKey = rendererBreadcrumbCoalesceKey(args.name, data)
         if (!coalesceKey) {
           recordCrashBreadcrumb(args.name, data)
           recordRendererBreadcrumbTrace(args.name, data)
@@ -405,7 +413,7 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
           name: args.name,
           data,
           coalesceKey,
-          minIntervalMs: RENDERER_ERROR_BREADCRUMB_COALESCE_MS
+          minIntervalMs: RENDERER_BREADCRUMB_COALESCE_MS
         })
         // Why: tracing every suppressed duplicate would preserve the same
         // serialization and disk churn that breadcrumb coalescing removes.

--- a/src/renderer/src/components/network/AddressPicker.tsx
+++ b/src/renderer/src/components/network/AddressPicker.tsx
@@ -42,6 +42,10 @@ export type AddressPickerProps = {
   id?: string
 }
 
+// Note (crash cluster C6, React #185 in settings): the throwing dispatch is in
+// @radix-ui/react-select's SelectItem unmount cleanup, not in our code — this
+// file holds no unmount-phase setState, so there is nothing here to guard.
+// Item churn here is derived from props only; re-audit if that stops holding.
 export function AddressPicker({
   options,
   value,

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -59,7 +59,11 @@ import { MobileDriverOverlay } from './MobileDriverOverlay'
 import { stripSshReconnectOwnedErrorLines, TerminalErrorToast } from './TerminalErrorToast'
 import { TerminalSessionStateSaveFailureDialog } from './TerminalSessionStateSaveFailureDialog'
 import TerminalContextMenu from './TerminalContextMenu'
-import TerminalPaneHeaderOverlay from './TerminalPaneHeaderOverlay'
+import TerminalPaneHeaderOverlay, { type PaneTitleOverlayRect } from './TerminalPaneHeaderOverlay'
+import {
+  arePaneTitleOverlayRectsEqual,
+  clearPaneTitleOverlayRects
+} from './pane-title-overlay-rects'
 import NativeChatView from '../native-chat/NativeChatView'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
 import { TerminalAgentSessionForkDialog } from './TerminalAgentSessionForkDialog'
@@ -238,12 +242,6 @@ type TerminalPaneProps = {
   onCloseTab: () => void
 }
 
-type PaneTitleOverlayRect = {
-  left: number
-  top: number
-  width: number
-}
-
 type TerminalQuickCommandEditorDialogProps = {
   command: TerminalQuickCommand
   onOpenChange: (open: boolean) => void
@@ -272,24 +270,6 @@ function TerminalQuickCommandEditorDialog({
 function formatClipboardImagePasteError(error: unknown): string {
   const detail = error instanceof Error ? error.message : String(error)
   return `Image paste failed: ${detail}`
-}
-
-function arePaneTitleOverlayRectsEqual(
-  a: Record<number, PaneTitleOverlayRect>,
-  b: Record<number, PaneTitleOverlayRect>
-): boolean {
-  const aKeys = Object.keys(a)
-  const bKeys = Object.keys(b)
-  if (aKeys.length !== bKeys.length) {
-    return false
-  }
-  return aKeys.every((key) => {
-    const paneId = Number(key)
-    const left = Math.abs((a[paneId]?.left ?? 0) - (b[paneId]?.left ?? 0))
-    const top = Math.abs((a[paneId]?.top ?? 0) - (b[paneId]?.top ?? 0))
-    const width = Math.abs((a[paneId]?.width ?? 0) - (b[paneId]?.width ?? 0))
-    return left < 0.5 && top < 0.5 && width < 0.5
-  })
 }
 
 export default function TerminalPane({
@@ -2268,7 +2248,7 @@ export default function TerminalPane({
     const manager = managerRef.current
     const container = containerRef.current
     if (!manager || !container) {
-      setPaneTitleOverlayRects({})
+      setPaneTitleOverlayRects(clearPaneTitleOverlayRects)
       return
     }
     const containerRect = container.getBoundingClientRect()
@@ -2293,7 +2273,7 @@ export default function TerminalPane({
     const manager = managerRef.current
     const container = containerRef.current
     if (!manager || !container) {
-      setPaneTitleOverlayRects({})
+      setPaneTitleOverlayRects(clearPaneTitleOverlayRects)
       return
     }
 

--- a/src/renderer/src/components/terminal-pane/pane-title-overlay-rects.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-title-overlay-rects.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  arePaneTitleOverlayRectsEqual,
+  clearPaneTitleOverlayRects
+} from './pane-title-overlay-rects'
+
+describe('clearPaneTitleOverlayRects', () => {
+  // Why: this identity contract IS the React #185 guard — a fresh {} literal is
+  // never state-equal, so returning one here commits a render every pass.
+  it('returns the same reference when already empty', () => {
+    const prev = {}
+    expect(clearPaneTitleOverlayRects(prev)).toBe(prev)
+  })
+
+  it('clears a populated map to a new empty object', () => {
+    const prev = { 1: { left: 10, top: 20, width: 30 } }
+    const next = clearPaneTitleOverlayRects(prev)
+
+    expect(next).not.toBe(prev)
+    expect(next).toEqual({})
+  })
+
+  it('is stable across repeated calls once empty', () => {
+    const first = clearPaneTitleOverlayRects({ 1: { left: 1, top: 2, width: 3 } })
+    expect(clearPaneTitleOverlayRects(first)).toBe(first)
+  })
+})
+
+describe('arePaneTitleOverlayRectsEqual', () => {
+  it('treats sub-pixel drift as equal', () => {
+    expect(
+      arePaneTitleOverlayRectsEqual(
+        { 1: { left: 10, top: 20, width: 30 } },
+        { 1: { left: 10.4, top: 20.4, width: 30.4 } }
+      )
+    ).toBe(true)
+  })
+
+  it('treats a half-pixel-or-greater move as different', () => {
+    expect(
+      arePaneTitleOverlayRectsEqual(
+        { 1: { left: 10, top: 20, width: 30 } },
+        { 1: { left: 10.5, top: 20, width: 30 } }
+      )
+    ).toBe(false)
+  })
+
+  it('treats differing pane counts as different', () => {
+    expect(
+      arePaneTitleOverlayRectsEqual(
+        { 1: { left: 0, top: 0, width: 10 } },
+        { 1: { left: 0, top: 0, width: 10 }, 2: { left: 0, top: 0, width: 10 } }
+      )
+    ).toBe(false)
+  })
+
+  it('reports two empty maps as equal', () => {
+    expect(arePaneTitleOverlayRectsEqual({}, {})).toBe(true)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pane-title-overlay-rects.ts
+++ b/src/renderer/src/components/terminal-pane/pane-title-overlay-rects.ts
@@ -1,0 +1,33 @@
+/**
+ * Pane-title overlay rect state transitions for TerminalPane.
+ *
+ * Why: both helpers exist to hand React a referentially-equal value when
+ * nothing changed, so a measurement pass cannot commit a redundant render
+ * (React #185 amplification). Extracted so that identity contract is testable.
+ */
+import type { PaneTitleOverlayRect } from './TerminalPaneHeaderOverlay'
+
+export function arePaneTitleOverlayRectsEqual(
+  a: Record<number, PaneTitleOverlayRect>,
+  b: Record<number, PaneTitleOverlayRect>
+): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  if (aKeys.length !== bKeys.length) {
+    return false
+  }
+  return aKeys.every((key) => {
+    const paneId = Number(key)
+    const left = Math.abs((a[paneId]?.left ?? 0) - (b[paneId]?.left ?? 0))
+    const top = Math.abs((a[paneId]?.top ?? 0) - (b[paneId]?.top ?? 0))
+    const width = Math.abs((a[paneId]?.width ?? 0) - (b[paneId]?.width ?? 0))
+    return left < 0.5 && top < 0.5 && width < 0.5
+  })
+}
+
+/** Returns `prev` untouched when already empty — never a fresh {} literal. */
+export function clearPaneTitleOverlayRects(
+  prev: Record<number, PaneTitleOverlayRect>
+): Record<number, PaneTitleOverlayRect> {
+  return Object.keys(prev).length === 0 ? prev : {}
+}

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
+  recordParkVerdictFlips,
+  type ParkVerdictFlipRecord
+} from './terminal-park-verdict-flip-telemetry'
+
+const recordBreadcrumb = vi.fn()
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: (name: string, data?: unknown) => recordBreadcrumb(name, data)
+}))
+
+const TAB = 'tab-1'
+
+function observe(args: {
+  records: Map<string, ParkVerdictFlipRecord>
+  parked: boolean
+  nowMs: number
+  liveTabIds?: ReadonlySet<string>
+}): void {
+  recordParkVerdictFlips({
+    records: args.records,
+    liveTabIds: args.liveTabIds ?? new Set([TAB]),
+    nextParkedTabIds: args.parked ? new Set([TAB]) : new Set(),
+    nowMs: args.nowMs
+  })
+}
+
+beforeEach(() => {
+  recordBreadcrumb.mockClear()
+})
+
+describe('recordParkVerdictFlips', () => {
+  it('stays silent for a stable verdict', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 100; i += 1) {
+      observe({ records, parked: true, nowMs: 1_000 + i * 1_000 })
+    }
+
+    expect(recordBreadcrumb).not.toHaveBeenCalled()
+    expect(records.get(TAB)?.flips).toBe(0)
+  })
+
+  it('emits one breadcrumb per window once the verdict churns', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * 10 })
+    }
+
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ tabId: TAB, flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT })
+    )
+  })
+
+  // Why: flips saturates at the notice limit, so elapsedMs is the only field
+  // that tells a runaway loop apart from slow churn — assert both ends.
+  it('reports elapsedMs so a tight loop is distinguishable from slow churn', () => {
+    const tightRecords = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records: tightRecords, parked: i % 2 === 0, nowMs: 1_000 + i })
+    }
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT, elapsedMs: 12 })
+    )
+
+    recordBreadcrumb.mockClear()
+
+    const slowRecords = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 13; i += 1) {
+      observe({ records: slowRecords, parked: i % 2 === 0, nowMs: 1_000 + i * 4_000 })
+    }
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT, elapsedMs: 48_000 })
+    )
+  })
+
+  it('re-arms after the window elapses', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * 10 })
+    }
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+
+    const laterMs = 1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS * 2
+    for (let i = 0; i < 40; i += 1) {
+      observe({ records, parked: i % 2 === 0, nowMs: laterMs + i * 10 })
+    }
+
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(2)
+  })
+
+  // Why: an unclamped backwards jump would freeze the window and suppress the
+  // very signal this module exists to capture.
+  it('treats a backwards clock jump as a fresh window', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    observe({ records, parked: true, nowMs: 10_000_000 })
+    observe({ records, parked: false, nowMs: 1_000 })
+
+    expect(records.get(TAB)?.windowStartMs).toBe(1_000)
+    expect(records.get(TAB)?.flips).toBe(1)
+  })
+
+  // Why: >= is the boundary operator; a > regression would silently stretch the
+  // window and delay every notice by one full period.
+  it('treats an exactly-elapsed window as expired', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    observe({ records, parked: true, nowMs: 1_000 })
+    observe({ records, parked: false, nowMs: 1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS })
+
+    expect(records.get(TAB)?.windowStartMs).toBe(1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS)
+    expect(records.get(TAB)?.flips).toBe(1)
+  })
+
+  it('honours flipWindowMs and noticeLimit overrides', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    for (let i = 0; i < 10; i += 1) {
+      recordParkVerdictFlips({
+        records,
+        liveTabIds: new Set([TAB]),
+        nextParkedTabIds: i % 2 === 0 ? new Set([TAB]) : new Set(),
+        nowMs: 1_000 + i,
+        flipWindowMs: 500,
+        noticeLimit: 3
+      })
+    }
+
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ flips: 3, windowMs: 500 })
+    )
+  })
+
+  it('keeps per-tab windows and notices independent', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    const other = 'tab-2'
+    for (let i = 0; i < 40; i += 1) {
+      recordParkVerdictFlips({
+        records,
+        liveTabIds: new Set([TAB, other]),
+        // Why: TAB churns every call, other stays parked throughout.
+        nextParkedTabIds: i % 2 === 0 ? new Set([TAB, other]) : new Set([other]),
+        nowMs: 1_000 + i * 10
+      })
+    }
+
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      'terminal_park_verdict_churn',
+      expect.objectContaining({ tabId: TAB })
+    )
+    expect(records.get(other)?.flips).toBe(0)
+  })
+
+  it('drops records for tabs that no longer exist', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    observe({ records, parked: true, nowMs: 1_000 })
+
+    recordParkVerdictFlips({
+      records,
+      liveTabIds: new Set(),
+      nextParkedTabIds: new Set(),
+      nowMs: 2_000
+    })
+
+    expect(records.size).toBe(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
@@ -1,0 +1,93 @@
+/**
+ * Cold-park verdict flip telemetry (observation only — changes no verdict).
+ *
+ * Why: crash cluster C5 (React #185 in TerminalPaneOverlayLayer) points at a
+ * setState loop in the cold-parking passive effect, but no park-flip loop has
+ * been reproduced, and the capture-coverage oscillator that looked like the
+ * cause provably self-terminates (the unmount capture is never cleared on
+ * remount, so coverage pins rather than alternates). This records whether the
+ * rendered park verdict actually churns in the field. Deliberately no damping:
+ * guarding a loop nobody has shown can run would add a park delay and a
+ * retention path for no demonstrated benefit.
+ *
+ * Reading the signal: breadcrumbs also emit a durable `renderer.breadcrumb`
+ * trace span, so this is queryable without waiting for a crash bundle. `flips`
+ * always equals the notice limit — `elapsedMs` is what separates a render loop
+ * from slow churn. Silence only rules out churn at effect cadence; a same-tick
+ * cascade can crash before the limit accumulates. If it fires, start with the
+ * candidate selection in terminal-hidden-view-parking.ts.
+ */
+import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+
+export const TERMINAL_TAB_PARK_FLIP_WINDOW_MS = 60_000
+/** Flips per window that no sane park policy should reach. */
+export const TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT = 12
+
+export type ParkVerdictFlipRecord = {
+  parked: boolean
+  windowStartMs: number
+  flips: number
+  notified: boolean
+}
+
+/** Records park-verdict churn per tab; emits one breadcrumb per window. */
+export function recordParkVerdictFlips(args: {
+  records: Map<string, ParkVerdictFlipRecord>
+  liveTabIds: ReadonlySet<string>
+  nextParkedTabIds: ReadonlySet<string>
+  nowMs: number
+  flipWindowMs?: number
+  noticeLimit?: number
+}): void {
+  const {
+    records,
+    liveTabIds,
+    nextParkedTabIds,
+    nowMs,
+    flipWindowMs = TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
+    noticeLimit = TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT
+  } = args
+
+  for (const tabId of Array.from(records.keys())) {
+    if (!liveTabIds.has(tabId)) {
+      records.delete(tabId)
+    }
+  }
+
+  for (const tabId of liveTabIds) {
+    const parked = nextParkedTabIds.has(tabId)
+    const record = records.get(tabId)
+
+    if (!record) {
+      records.set(tabId, { parked, windowStartMs: nowMs, flips: 0, notified: false })
+      continue
+    }
+    if (parked === record.parked) {
+      continue
+    }
+
+    // Why: Date.now() jumps backwards on NTP/sleep-wake; treat any out-of-range
+    // elapsed value as a fresh window rather than trusting the delta.
+    const elapsedMs = nowMs - record.windowStartMs
+    if (elapsedMs >= flipWindowMs || elapsedMs < 0) {
+      record.windowStartMs = nowMs
+      record.flips = 0
+      record.notified = false
+    }
+
+    record.parked = parked
+    record.flips += 1
+
+    if (!record.notified && record.flips >= noticeLimit) {
+      record.notified = true
+      // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
+      // field that separates a render loop from slow benign churn.
+      recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
+        tabId,
+        flips: record.flips,
+        elapsedMs: nowMs - record.windowStartMs,
+        windowMs: flipWindowMs
+      })
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -18,6 +18,10 @@ import {
   selectColdParkedTerminalTabs,
   type TerminalTabColdParkCandidate
 } from './terminal-hidden-view-parking'
+import {
+  recordParkVerdictFlips,
+  type ParkVerdictFlipRecord
+} from './terminal-park-verdict-flip-telemetry'
 import { getTerminalParkingPolicyOverrides } from './terminal-parking-e2e-overrides'
 import {
   canWatcherCoverParkedTerminalTab,
@@ -73,6 +77,7 @@ export function useTerminalTabColdParking(args: {
   )
   const terminalTabHiddenSinceRef = useRef(new Map<string, number>())
   const terminalTabParkingTimersRef = useRef(new Map<string, number>())
+  const parkVerdictRecordsRef = useRef(new Map<string, ParkVerdictFlipRecord>())
   const [terminalTabParkingRevision, setTerminalTabParkingRevision] = useState(0)
   const [coldParkedTerminalTabIds, setColdParkedTerminalTabIds] = useState<ReadonlySet<string>>(
     () => new Set()
@@ -239,6 +244,20 @@ export function useTerminalTabColdParking(args: {
     terminalTabs,
     worktreeId
   ])
+
+  // Why: observation only — records whether the *rendered* park verdict churns,
+  // so a crash bundle can confirm or refute a park-flip update loop. Watching
+  // the pre-gate cold set instead would miss loops driven by coldParkTerminalPanes
+  // or the portal/measuring gates. Changes no verdict; see
+  // terminal-park-verdict-flip-telemetry.ts.
+  useEffect(() => {
+    recordParkVerdictFlips({
+      records: parkVerdictRecordsRef.current,
+      liveTabIds: new Set(terminalTabs.map((terminalTab) => terminalTab.id)),
+      nextParkedTabIds: parkedTerminalTabIds,
+      nowMs: Date.now()
+    })
+  }, [parkedTerminalTabIds, terminalTabs])
 
   // Why: runs in the same effect flush as the commit that parked/revealed the
   // panes — watcher disposal therefore lands before any PTY data IPC can


### PR DESCRIPTION
## Summary

Fixes React #185: a setState loop in TerminalPane's pane-title overlay measurement effect. The effect was calling `setPaneTitleOverlayRects({})` with a fresh object literal on every pass, violating React's referential equality contract and forcing redundant renders.

## Root Cause

In TerminalPane, layout measurement effects needed to reset overlay rects when the manager or container unmounted. Calling `setPaneTitleOverlayRects({})` creates a new object on every effect execution, so React sees it as a state change even when the previous state was also empty — triggering the effect again immediately, forming a loop.

## Solution

1. **Extract state-identity helpers** to `pane-title-overlay-rects.ts`:
   - `clearPaneTitleOverlayRects(prev)` returns `prev` unchanged if already empty, or a new `{}` only if it was populated. This preserves referential equality when nothing changes.
   - `arePaneTitleOverlayRectsEqual(a, b)` compares rect maps with sub-pixel tolerance, used when state does legitimately change.

2. **Call `clearPaneTitleOverlayRects()`** instead of `{}` in measurement effects, guaranteeing no spurious renders when clearing.

3. **Add telemetry** to detect park-verdict churn (crash cluster C5): `recordParkVerdictFlips` observes whether the rendered cold-park status actually oscillates, emitting one breadcrumb per 60s window if ≥12 flips occur. This is observation-only and changes no logic.

4. **Extend crash-reporting coalescing** to handle per-tab, high-frequency breadcrumbs like `terminal_park_verdict_churn` by coalescing on name alone (not message), so a many-tab storm doesn't evict the pre-crash trail.

## Testing

- `pane-title-overlay-rects.test.ts`: identity contracts (empty-stable returns, sub-pixel tolerance, map-count diffs)
- `terminal-park-verdict-flip-telemetry.test.ts`: breadcrumb emission, window re-arming, backwards-clock handling, per-tab independence
- `crash-reporting-renderer-breadcrumbs.test.ts`: coalescing by name for park-verdict churn across multiple tabs

## Notes

- AddressPicker: no changes needed. Added a note clarifying that the crashing dispatch is in @radix-ui/react-select's unmount cleanup, not our code.
- Park-verdict telemetry is deliberately unguarded — if the effect loop exists, we want to see it, not hide it behind damping.