### PR TITLE
fix(skills): show unrecognized/inaccessible placements in update dialog

### DIFF
--- a/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
@@ -39,16 +39,41 @@ describe('groupSkillFreshness', () => {
     ])
   })
 
-  it('hides skills with nothing out of date (current, unrecognized-only, unreadable-only)', () => {
+  it('hides skills that are fully current with nothing to review', () => {
+    const groups = groupSkillFreshness([placement('orca-cli', { status: 'current' })], [])
+    expect(groups).toEqual([])
+  })
+
+  it('lists unrecognized-only and inaccessible skills so the amber pill has an explanation', () => {
+    // Why: foreign plugin-cache copies (e.g. Codex bundled computer-use) share a
+    // name with Orca skills and light needs-attention; Details must not claim all-clear.
     const groups = groupSkillFreshness(
       [
-        placement('orca-cli', { status: 'current' }),
-        placement('dataviz', { status: 'unrecognized', topology: 'independent-copy' }),
+        placement('computer-use', { status: 'current' }),
+        placement('computer-use', {
+          rootId: 'plugin-cache',
+          unresolvedPath: '/home/.codex/plugins/cache/computer-use/SKILL.md',
+          status: 'unrecognized',
+          topology: 'plugin-cache'
+        }),
         placement('linear-tickets', { status: 'inaccessible' })
       ],
       []
     )
-    expect(groups).toEqual([])
+    expect(groups.map((group) => group.name)).toEqual(['computer-use', 'linear-tickets'])
+    expect(groups[0]?.status).toBe('cannot-update')
+    expect(groups[0]?.locations).toEqual([
+      { id: expect.any(String), path: '/home/.agents/skills/computer-use', chip: 'current' },
+      {
+        id: expect.any(String),
+        path: '/home/.codex/plugins/cache/computer-use/SKILL.md',
+        // Why: status (unrecognized) wins over topology (plugin-cache) in locationChip.
+        chip: 'unrecognized'
+      }
+    ])
+    expect(groups[1]?.locations).toEqual([
+      { id: expect.any(String), path: '/home/.agents/skills/linear-tickets', chip: 'inaccessible' }
+    ])
   })
 
   it('groups a blocked skill and flags the culprit location, not the main copy', () => {

--- a/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
+++ b/src/renderer/src/components/skills/skill-freshness-grouping.test.ts
@@ -62,13 +62,14 @@ describe('groupSkillFreshness', () => {
     )
     expect(groups.map((group) => group.name)).toEqual(['computer-use', 'linear-tickets'])
     expect(groups[0]?.status).toBe('cannot-update')
+    expect(groups[1]?.status).toBe('cannot-update')
     expect(groups[0]?.locations).toEqual([
       { id: expect.any(String), path: '/home/.agents/skills/computer-use', chip: 'current' },
       {
         id: expect.any(String),
         path: '/home/.codex/plugins/cache/computer-use/SKILL.md',
-        // Why: status (unrecognized) wins over topology (plugin-cache) in locationChip.
-        chip: 'unrecognized'
+        // Why: unrecognized + plugin-cache maps to the plugin-cache chip on main.
+        chip: 'plugin-cache'
       }
     ])
     expect(groups[1]?.locations).toEqual([

--- a/src/renderer/src/components/skills/skill-freshness-grouping.ts
+++ b/src/renderer/src/components/skills/skill-freshness-grouping.ts
@@ -56,11 +56,21 @@ export function locationChip(installation: SkillFreshnessInstallation): SkillLoc
   }
 }
 
+function placementNeedsDialogAttention(installation: SkillFreshnessInstallation): boolean {
+  // Why: the status pill escalates any non-current placement; the dialog must list
+  // the same set or amber badges have no reachable explanation (#10633).
+  return (
+    installation.status === 'outdated' ||
+    installation.status === 'unrecognized' ||
+    installation.status === 'inaccessible'
+  )
+}
+
 /**
  * Groups installations by skill for the update modal and derives each skill's
- * update disposition. Only skills with an out-of-date official copy are returned —
- * up-to-date, unrecognized-only, and unreadable-only skills have nothing to change
- * here, so they are omitted entirely.
+ * update disposition. Skills with out-of-date official copies, or with placements
+ * the pill marks needs-attention (unrecognized / inaccessible), are returned so
+ * Details never contradicts the amber badge (#10633). Fully-current skills are omitted.
  *
  * `alwaysIncludeNames` overrides that filter. A successful update makes every
  * targeted skill current, which would otherwise drop its row the instant the
@@ -82,7 +92,7 @@ export function groupSkillFreshness(
   }
   const groups: SkillFreshnessGroupModel[] = []
   for (const [name, entries] of byName) {
-    if (!pinned.has(name) && !entries.some((entry) => entry.status === 'outdated')) {
+    if (!pinned.has(name) && !entries.some(placementNeedsDialogAttention)) {
       continue
     }
     const locations = entries

--- a/src/renderer/src/components/skills/skill-freshness-summary-headline.tsx
+++ b/src/renderer/src/components/skills/skill-freshness-summary-headline.tsx
@@ -21,8 +21,8 @@ export function summarizeInventory(
   if (inventory.eligibleUpdateNames.length > 0) {
     return 'eligible'
   }
-  // Why: a named skill the update can't converge outranks a coverage gap — the gap
-  // says something might be unchecked, the group says something definitely is wrong.
+  // Why: with nothing eligible, blocked groups (outdated-unreachable, unrecognized,
+  // inaccessible) outrank a coverage gap so the amber pill is never explanation-free (#10633).
   if (hasBlockedGroup) {
     return 'attention'
   }


### PR DESCRIPTION
## Summary
- Update skills **Details** dialog now lists `unrecognized` and `inaccessible` placements, not only `outdated` ones.
- Fixes amber **Needs attention** pills that opened an all-clear dialog with no rows (e.g. Codex bundled `computer-use` sharing a name with Orca’s skill).

## Fixes
Closes #10633

## Test plan
- [x] `skill-freshness-grouping` + `SkillFreshnessUpdateDialog` + display-status tests
- [ ] Manual: Settings → Computer Use with Codex installed → Details lists the foreign copy chip

## ELI5

Skills marked "Needs attention" sometimes opened an empty Details dialog because unrecognized or inaccessible placements were hidden. Those placements are listed so you can see why attention is needed.
