### PR TITLE
fix(browser): hide Windows console for agent-browser spawns

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -1465,6 +1465,18 @@ describe('AgentBrowserBridge', () => {
     )
     expect(closeCall).toBeTruthy()
     expect(closeCall![1]).toEqual(['--session', 'orca-tab-tab-1', 'close'])
+    // Why: console-subsystem agent-browser must not flash a conhost on Windows (#10488).
+    expect(closeCall![2]).toEqual(expect.objectContaining({ windowsHide: true }))
+  })
+
+  it('hides the agent-browser console window on Windows for ordinary commands', async () => {
+    succeedWith({ snapshot: 'tree' })
+    await bridge.snapshot()
+
+    const snapshotCall = execFileMock.mock.calls.find((call: unknown[]) =>
+      (call[1] as string[]).includes('snapshot')
+    )
+    expect(snapshotCall?.[2]).toEqual(expect.objectContaining({ windowsHide: true }))
   })
 
   it('repairs per-worktree active routing when the active tab closes', async () => {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -2604,7 +2604,9 @@ export class AgentBrowserBridge {
         child = execFile(
           this.agentBrowserBin,
           ['--session', sessionName, 'close'],
-          { timeout: STALE_SESSION_CLOSE_TIMEOUT_MS },
+          // Why: agent-browser is a console-subsystem binary on Windows; without
+          // windowsHide a visible conhost steals focus mid-typing (#10488).
+          { timeout: STALE_SESSION_CLOSE_TIMEOUT_MS, windowsHide: true },
           (error) =>
             finish(
               error
@@ -2664,9 +2666,12 @@ export class AgentBrowserBridge {
         this.agentBrowserBin,
         args,
         // Why: screenshots return large base64 that exceeds Node's default 1MB maxBuffer (ENOBUFS).
+        // windowsHide: agent-browser is console-subsystem on Windows; a visible conhost
+        // steals focus during agent-driven browsing (#10488).
         {
           timeout: execOptions?.timeoutMs ?? EXEC_TIMEOUT_MS,
           maxBuffer: 50 * 1024 * 1024,
+          windowsHide: true,
           env: execOptions?.envOverrides
             ? { ...process.env, ...execOptions.envOverrides }
             : process.env

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -515,6 +515,40 @@ describe('importCookiesFromBrowser Chromium', () => {
     }
   })
 
+  it('hides the DPAPI powershell console window on Windows', async () => {
+    const sourceCookiesPath = join(tmpDir, 'Chrome', 'Default', 'Network', 'Cookies')
+    const targetCookiesPath = join(tmpDir, 'userData', 'Partitions', 'test', 'Network', 'Cookies')
+    createChromiumCookieTestDatabase(sourceCookiesPath, [
+      { name: 'sid', value: '', encryptedValue: Buffer.from('v10-encrypted') }
+    ]).close()
+    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
+    const localState = join(tmpDir, 'localappdata', 'Google', 'Chrome', 'User Data', 'Local State')
+    mkdirSync(join(localState, '..'), { recursive: true })
+    writeFileSync(
+      localState,
+      JSON.stringify({
+        os_crypt: { encrypted_key: Buffer.from('DPAPIsealed-key').toString('base64') }
+      })
+    )
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const previousLocalAppData = process.env.LOCALAPPDATA
+    process.env.LOCALAPPDATA = join(tmpDir, 'localappdata')
+
+    try {
+      await importCookiesFromBrowser(chromeBrowser(sourceCookiesPath), 'persist:test')
+
+      const powershellCall = execFileSyncMock.mock.calls.find(
+        ([command]) => command === 'powershell'
+      )
+      expect(powershellCall).toBeTruthy()
+      // Why: powershell is console-subsystem; an unhidden conhost steals focus mid-typing (#10488).
+      expect(powershellCall![2]).toEqual(expect.objectContaining({ windowsHide: true }))
+    } finally {
+      platformSpy.mockRestore()
+      process.env.LOCALAPPDATA = previousLocalAppData
+    }
+  })
+
   it('removes staging data when the OS key is unavailable', async () => {
     const sourceCookiesPath = join(tmpDir, 'Chrome', 'Default', 'Network', 'Cookies')
     const targetCookiesPath = join(tmpDir, 'userData', 'Partitions', 'test', 'Network', 'Cookies')

--- a/src/main/browser/browser-cookie-import.test.ts
+++ b/src/main/browser/browser-cookie-import.test.ts
@@ -545,7 +545,12 @@ describe('importCookiesFromBrowser Chromium', () => {
       expect(powershellCall![2]).toEqual(expect.objectContaining({ windowsHide: true }))
     } finally {
       platformSpy.mockRestore()
-      process.env.LOCALAPPDATA = previousLocalAppData
+      // Why: assigning undefined sets the string "undefined" and leaks into later tests.
+      if (previousLocalAppData === undefined) {
+        delete process.env.LOCALAPPDATA
+      } else {
+        process.env.LOCALAPPDATA = previousLocalAppData
+      }
     }
   })
 

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1014,7 +1014,8 @@ function getWindowsEncryptionKey(browser: DetectedBrowser): EncryptionKeyResult 
     const result = execFileSync(
       'powershell',
       ['-NoProfile', '-NonInteractive', '-Command', script],
-      { encoding: 'utf-8', timeout: 10_000, input: dpapiData }
+      // Why: powershell is console-subsystem; without windowsHide the import flashes a conhost (#10488).
+      { encoding: 'utf-8', timeout: 10_000, input: dpapiData, windowsHide: true }
     ).trim()
 
     return { key: Buffer.from(result, 'base64'), mode: 'aes-256-gcm' }


### PR DESCRIPTION
## Summary

On Windows, browser automation and browser cookie import flashed a black console window that stole keyboard focus mid-typing. Electron's main process is GUI-subsystem and owns no console, so when it spawns a console-subsystem child (`agent-browser-win32-x64.exe`, `powershell.exe`) Windows allocates a brand-new console and shows its `conhost` window. The fix passes `windowsHide: true` at every such spawn site in `src/main/browser/`, matching the idiom already used across `src/main/ssh/`.

Related to #10488 (remaining agent-browser sites).

## ELI5

Some helper programs Orca runs behind the scenes are text-mode tools. On Windows, when a windowed app starts a text-mode tool, Windows helpfully pops open a black terminal box for it — which jumps in front of whatever you were typing and eats your keystrokes. We now tell Windows "run this one silently, no box." The helpers do exactly the same work; you just stop seeing the flash.

## Proof of fix

**1. Unit tests fail on `main`, pass with this branch.**

Restoring `main`'s `agent-browser-bridge.ts` under this branch's tests:

```
$ git checkout origin/main -- src/main/browser/agent-browser-bridge.ts
$ npx vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts

 ❯ src/main/browser/agent-browser-bridge.test.ts:1471:31
    1471|     expect(snapshotCall?.[2]).toEqual(expect.objectContaining({ window…
       |                               ^
 Test Files  1 failed (1)
      Tests  2 failed | 103 passed (105)
```

With the branch's source restored:

```
$ git checkout HEAD -- src/main/browser/agent-browser-bridge.ts
$ npx vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts

 Test Files  1 passed (1)
      Tests  105 passed (105)
```

Same for the newly-covered cookie-import site — without the source fix:

```
$ npx vitest run --config config/vitest.config.ts src/main/browser/browser-cookie-import.test.ts -t "hides the DPAPI"

- ObjectContaining {
-   "windowsHide": true,
+ {
+   "encoding": "utf-8",
+   "input": "c2VhbGVkLWtleQ==",
+   "timeout": 10000,
  }
 Test Files  1 failed (1)
      Tests  1 failed | 20 skipped (21)
```

**2. Executed on a real Windows 11 box (win32 x64, Node v24.18.0).**

A unit test can only assert the option is passed — it cannot prove Windows honors it. So a standalone script measured the actual OS behavior. Because a probe launched from a PowerShell pane would inherit that pane's console (the wrong baseline), stage 1 relaunches stage 2 with `detached: true` (`DETACHED_PROCESS`), reproducing Electron main's console-less parent. Stage 2 then `execFile`s a child that reports its own `GetConsoleWindow()` handle and `IsWindowVisible()`:

```
node=v24.18.0 platform=win32 arch=x64
agent-browser-win32-x64.exe PE subsystem=3 (3=CUI/console, 2=GUI)

--- parent has NO console (like Electron main); execFile without shell ---
    (this is exactly how agent-browser-bridge.ts spawns agent-browser)
  no windowsHide            -> hwnd=886900262 visible=True   [VISIBLE CONSOLE WINDOW  <-- this is the flash]
  windowsHide: true         -> hwnd=0 visible=False   [NO CONSOLE WINDOW]

--- real agent-browser.exe still works with windowsHide: true ---
  exit=0 output="agent-browser - fast browser automation CLI for AI agents | Usage: agent-browser <command> [args] [options]"
DONE
```

The bug and the fix are both reproduced on real Windows: without the flag the child gets a **visible** console window; with it, `GetConsoleWindow()` returns `0` — no window exists at all, so nothing can flash or take foreground. The binary's exit code and output are unchanged.

**3. The `shell: true` / `.cmd` caveat does not apply here.** `windowsHide` is famously a no-op when a spawn goes through `cmd.exe` or a `.cmd`/`.bat` shim, because the shell creates its own console. That is not this code path:

- `agent-browser-bridge.ts` calls `execFile(...)` with **no `shell` option** (defaults to `false`), so there is no intermediate `cmd.exe`.
- `resolveAgentBrowserBinary()` resolves an **absolute path to a real PE executable**, never the `.js`/`.cmd` npm shim: packaged builds get `agent-browser-win32-x64.exe` (`electron-builder.config.cjs:220`), and dev resolves the same `.exe` under `node_modules/agent-browser/bin/`. Verified above: PE subsystem = 3, a genuine console-subsystem `.exe`.

## Proof of no regressions

Every test file in the touched module, plus typecheck and lint:

```
$ npx vitest run --config config/vitest.config.ts src/main/browser/
 Test Files  28 passed (28)
      Tests  518 passed (518)

$ npx tsc --noEmit -p config/tsconfig.node.json
TYPECHECK_EXIT=0

$ npx oxlint src/main/browser/agent-browser-bridge.ts src/main/browser/agent-browser-bridge.test.ts \
             src/main/browser/browser-cookie-import.ts src/main/browser/browser-cookie-import.test.ts
0 errors  (only pre-existing `no-unsafe-function-type` warnings, identical on main)
```

No user-visible behavior changes beyond the fix. `windowsHide` only controls whether Windows creates a console *window* for the child; it does not alter argv, env, stdio wiring, exit codes, or stdout/stderr capture, all of which the bridge relies on and which the 518 passing tests exercise. There is no debug/verbose code path that deliberately surfaced this console — `grep` for an `AGENT_BROWSER_*`/`BROWSER_DEBUG` escape hatch found none — so no debugging workflow regresses. The new tests assert only the options object passed to a mocked `execFile`/`execFileSync`, with `process.platform` stubbed per-test, so they run and pass identically on Linux and macOS CI.

## Compatibility

- **Platforms:** **Windows** — executed on a real Windows 11 box; captured above that the flag turns a visible console window into no console window, with the real `agent-browser.exe` still exiting 0 and producing identical output. **macOS / Linux** — `windowsHide` is documented as Windows-only and ignored elsewhere; the full 518-test browser suite and both typechecks were run on macOS with no change.
- **SSH / remote:** No impact. These spawn sites run the local `agent-browser` binary and local `powershell` in Electron main; the SSH spawn sites are fixed separately in #10497 and no file under `src/main/ssh/` is touched here. There is no shared spawn helper between the two paths — each call site sets the option inline, which is the existing convention across `src/main/ssh/`.
- **Performance:** No hot-path change. This adds one boolean to an options object already being constructed; process creation count, argv, and I/O are unchanged.

## Screenshots

No UI surface changed. The point of this fix is the *removal* of a transient console window — see the Win32 `GetConsoleWindow()` / `IsWindowVisible()` matrix under **Proof of fix**, captured on a real Windows 11 box.

## Testing

- [ ] `pnpm lint` — not run in full. Ran `npx oxlint` on all four changed files: 0 errors (only pre-existing `no-unsafe-function-type` warnings, identical on `main`).
- [x] `pnpm typecheck` — `npx tsc --noEmit -p config/tsconfig.node.json`, exit 0.
- [ ] `pnpm test` — not run in full (30+ min). Ran the whole touched module: `npx vitest run src/main/browser/` → 28 files, 518 tests passed.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests that would catch regressions — new assertions cover `windowsHide` at the agent-browser spawn site and the previously-uncovered DPAPI cookie-import site; both fail on `main` and pass here (output above).

## AI Review Report

Reviewed with Claude Code (Opus 5) and independently re-verified. Risks checked:

- **Cross-platform (macOS / Linux / Windows):** `windowsHide` is documented Windows-only and ignored elsewhere. Executed on real Windows 11 (win32 x64, Node v24.18.0) to confirm the OS actually honors it rather than trusting the option. The new tests stub `process.platform` per-test and assert only the options object passed to a mocked `execFile`/`execFileSync`, so they pass unchanged on Linux/macOS CI. Full browser suite + node typecheck run on macOS.
- **The `shell: true` / `.cmd` trap:** `windowsHide` does NOT suppress a console when the spawn goes via `cmd.exe` or a `.cmd`/`.bat` shim. Verified this path is unaffected: `execFile` is called with no `shell` option, and `resolveAgentBrowserBinary()` resolves an absolute real PE executable (subsystem 3, confirmed on the box), never the npm `.cmd` shim. Without this check the fix could have been a silent no-op.
- **Spawn-site coverage:** enumerated every `spawn`/`execFile`/`fork` under `src/main/browser/`; the agent-browser spawn and the PowerShell DPAPI cookie-import spawn are both covered.
- **Shell behavior / paths / Electron differences:** no argv, env, stdio wiring, exit code, or stdout/stderr capture changed — the 518 passing tests exercise these, and the real `agent-browser.exe` still exits 0 with identical output under the flag.
- **Debug escape hatch:** grepped for an `AGENT_BROWSER_*` / `BROWSER_DEBUG` path that deliberately surfaced the console; none exists, so no debugging workflow regresses.

Nothing flagged required changes beyond the fix itself.

## Security Audit

- **Input handling:** none added. No new parsing; one boolean added to an existing options object.
- **Command execution:** the set of executables spawned, their argv, and their environment are all unchanged. Notably the fix does *not* introduce `shell: true` — which would have been both a console-flash regression and a quoting/injection surface.
- **Path handling:** unchanged. `resolveAgentBrowserBinary()` already resolved an absolute path to a bundled binary; this PR does not alter resolution.
- **Auth / secrets:** the cookie-import site passes a DPAPI-sealed key to `powershell` via stdin (`input`), unchanged by this PR. Hiding the console arguably reduces incidental on-screen exposure.
- **Dependencies:** none added or changed.
- **IPC:** untouched.

## Notes

- Complementary to #10497, which fixes the same class of flash for SSH config/proxy spawns. Different spawn paths; both can land independently.
- There is no shared spawn-options helper between the browser and SSH paths — each call site sets `windowsHide` inline, matching the existing convention across `src/main/ssh/`. If a maintainer wants these unified into one helper, that is worth a follow-up but is deliberately out of scope here to keep the fix minimal and reviewable.

Original patch by @innocarpe.
