### PR TITLE
fix(win): escalate stubborn agent PTY tree-kills on worktree delete

### DIFF
--- a/src/main/daemon/session-force-kill-escalation.test.ts
+++ b/src/main/daemon/session-force-kill-escalation.test.ts
@@ -67,4 +67,49 @@ describe('Session force-kill escalation (#10475)', () => {
     await shutdown
     expect(session.state).toBe('exited')
   })
+
+  it('on Windows mid-wait escalate is tree-kill-only (no second ConPTY forceKill)', async () => {
+    vi.useFakeTimers()
+    try {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const subprocess: SubprocessHandle = {
+        pid: 5150,
+        getForegroundProcess: () => null,
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        forceKill: (...args: unknown[]) => forceKill(...args),
+        signal: vi.fn(),
+        onData: vi.fn(),
+        onExit: (cb) => {
+          onExitCb = cb
+        },
+        dispose: vi.fn()
+      }
+      session = new Session({
+        sessionId: 'hermes-mid-wait',
+        cols: 80,
+        rows: 24,
+        launchAgent: 'hermes',
+        subprocess,
+        shellReadySupported: false
+      })
+
+      const shutdown = session.forceKillAndWaitForExit(8_000)
+      expect(forceKill).toHaveBeenCalledTimes(1)
+      expect(killWithDescendantSweepMock).toHaveBeenCalledTimes(1)
+
+      // First grace expires without physical exit → mid-wait tree-kill escalate.
+      await vi.advanceTimersByTimeAsync(1_500)
+      expect(killWithDescendantSweepMock).toHaveBeenCalledTimes(2)
+      // Why: ConPTY force already issued; re-resetting forceKillSent is a no-op path.
+      expect(forceKill).toHaveBeenCalledTimes(1)
+
+      onExitCb?.(137)
+      await shutdown
+      expect(session?.state).toBe('exited')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/main/daemon/session-force-kill-escalation.test.ts
+++ b/src/main/daemon/session-force-kill-escalation.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Session, type SubprocessHandle } from './session'
+
+const killWithDescendantSweepMock = vi.hoisted(() => vi.fn())
+vi.mock('../pty-descendant-termination', () => ({
+  killWithDescendantSweep: killWithDescendantSweepMock
+}))
+
+describe('Session force-kill escalation (#10475)', () => {
+  let platformDescriptor: PropertyDescriptor | undefined
+  let session: Session | undefined
+  let forceKill: ReturnType<typeof vi.fn>
+  let onExitCb: ((code: number) => void) | null
+
+  beforeEach(() => {
+    platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    killWithDescendantSweepMock.mockReset()
+    killWithDescendantSweepMock.mockImplementation(async (_pid: number, killRoot: () => void) => {
+      killRoot()
+    })
+    forceKill = vi.fn()
+    onExitCb = null
+  })
+
+  afterEach(() => {
+    session?.dispose()
+    session = undefined
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+    }
+  })
+
+  it('on Windows re-tree-kills when force-escalating a stubborn agent PTY', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const subprocess: SubprocessHandle = {
+      pid: 4242,
+      getForegroundProcess: () => null,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      forceKill: (...args: unknown[]) => forceKill(...args),
+      signal: vi.fn(),
+      onData: vi.fn(),
+      onExit: (cb) => {
+        onExitCb = cb
+      },
+      dispose: vi.fn()
+    }
+    session = new Session({
+      sessionId: 'hermes-force',
+      cols: 80,
+      rows: 24,
+      launchAgent: 'hermes',
+      subprocess,
+      shellReadySupported: false
+    })
+
+    const shutdown = session.forceKillAndWaitForExit()
+    expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+      4242,
+      expect.any(Function),
+      expect.objectContaining({ ownsRoot: expect.any(Function) })
+    )
+    expect(forceKill).toHaveBeenCalled()
+
+    onExitCb?.(137)
+    await shutdown
+    expect(session.state).toBe('exited')
+  })
+})

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -361,8 +361,68 @@ export class Session {
       this.releaseProducerPause({ resume: true })
     }
     // Why: escalate a graceful termination now; waiting for the 5s timer would spend most of the physical-exit budget.
-    await this.requestForceKillWithRetry()
-    await this.waitForPhysicalExit(timeoutMs)
+    // Why (#10475): ConPTY forceKill is a no-op after the first bare kill (`nodePtyKillIssued`), so
+    // stubborn nested agents (Hermes) that ignore soft stop must be re-tree-killed on escalate.
+    await (process.platform === 'win32'
+      ? killWithDescendantSweep(
+          this.subprocess.pid,
+          () => {
+            try {
+              this.requestForceKill()
+            } catch {
+              /* killRoot is best-effort; physical-exit wait owns the failure */
+            }
+          },
+          { ownsRoot: () => this.isAlive }
+        )
+      : this.requestForceKillWithRetry())
+    await this.waitForPhysicalExitWithEscalation(timeoutMs)
+  }
+
+  /**
+   * Wait for OS-confirmed exit, re-issuing a force kill once if the child is
+   * still live after a short grace — agents that trap SIGTERM need the second
+   * SIGKILL/taskkill within the physical-exit budget (#10475).
+   */
+  private async waitForPhysicalExitWithEscalation(timeoutMs: number): Promise<void> {
+    const escalateAfterMs = Math.min(1_500, Math.max(1, Math.floor(timeoutMs / 4)))
+    const startedAt = Date.now()
+    try {
+      await this.physicalExit.waitForExit(
+        escalateAfterMs,
+        () => new Error(`Retrying force-kill for PTY ${this.sessionId}`)
+      )
+      return
+    } catch {
+      if (this._state === 'exited') {
+        return
+      }
+      if (process.platform === 'win32') {
+        await killWithDescendantSweep(
+          this.subprocess.pid,
+          () => {
+            try {
+              // Why: allow a second native force after the mid-wait escalate — the
+              // first requestForceKill may have set forceKillSent while taskkill lagged.
+              this.forceKillSent = false
+              this.requestForceKill()
+            } catch {
+              /* best-effort re-escalate */
+            }
+          },
+          { ownsRoot: () => this.isAlive }
+        )
+      } else {
+        try {
+          this.forceKillSent = false
+          await this.requestForceKillWithRetry()
+        } catch {
+          /* best-effort re-escalate */
+        }
+      }
+    }
+    const remainingMs = Math.max(1, timeoutMs - (Date.now() - startedAt))
+    await this.waitForPhysicalExit(remainingMs)
   }
 
   signal(sig: string): void {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -398,17 +398,12 @@ export class Session {
         return
       }
       if (process.platform === 'win32') {
+        // Why (#10475): ConPTY forceKill is already a no-op after the first bare kill;
+        // mid-wait escalate is taskkill /T only — don't reset forceKillSent.
         await killWithDescendantSweep(
           this.subprocess.pid,
           () => {
-            try {
-              // Why: allow a second native force after the mid-wait escalate — the
-              // first requestForceKill may have set forceKillSent while taskkill lagged.
-              this.forceKillSent = false
-              this.requestForceKill()
-            } catch {
-              /* best-effort re-escalate */
-            }
+            /* tree-kill owns escalate; killRoot already force-killed once */
           },
           { ownsRoot: () => this.isAlive }
         )
@@ -421,7 +416,9 @@ export class Session {
         }
       }
     }
-    const remainingMs = Math.max(1, timeoutMs - (Date.now() - startedAt))
+    // Why: escalate's own taskkill can consume most of timeoutMs; keep a real
+    // post-kill window instead of collapsing to 1ms (#10475 CodeRabbit).
+    const remainingMs = Math.max(escalateAfterMs, timeoutMs - (Date.now() - startedAt))
     await this.waitForPhysicalExit(remainingMs)
   }
 

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -469,7 +469,8 @@ describe('TerminalHost', () => {
         await vi.advanceTimersByTimeAsync(IMMEDIATE_KILL_PHYSICAL_EXIT_TIMEOUT_MS)
         await rejected
 
-        expect(lastSubprocess.forceKill).toHaveBeenCalledTimes(1)
+        // Why (#10475): mid-wait escalate re-issues force-kill once inside the physical-exit budget.
+        expect(lastSubprocess.forceKill).toHaveBeenCalledTimes(2)
         expect(lastSubprocess.dispose).not.toHaveBeenCalled()
         expect(host.listSessions()).toHaveLength(1)
         await expect(

--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -104,6 +104,7 @@ vi.mock('../wsl', () => ({
 
 import {
   _resetLocalPtyProviderStateForTest,
+  LOCAL_PTY_FORCE_ESCALATION_GRACE_MS,
   LOCAL_PTY_FORCE_KILL_RETRY_MS,
   LOCAL_PTY_GRACEFUL_FORCE_TIMEOUT_MS,
   LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS,
@@ -1366,6 +1367,59 @@ describe('LocalPtyProvider', () => {
       await Promise.all([graceful, immediate])
       expect(killSpy).toHaveBeenCalledTimes(1)
       expect(provider.hasPty(id)).toBe(false)
+    })
+
+    it('re-tree-kills when destructive cleanup joins a graceful Windows shutdown (#10475)', async () => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const killSpy = vi.fn()
+      mockProc.kill = killSpy
+      const { id } = await provider.spawn({
+        cols: 80,
+        rows: 24,
+        launchAgent: 'hermes'
+      })
+
+      const graceful = provider.shutdown(id, { immediate: false })
+      expect(killWithDescendantSweepMock).toHaveBeenCalledTimes(1)
+
+      const immediate = provider.shutdown(id, { immediate: true })
+      // Why: ConPTY mode is already force after the first bare kill, so escalate must
+      // re-issue taskkill /T rather than no-op requestTrackedPtyShutdown.
+      await vi.waitFor(() =>
+        expect(killWithDescendantSweepMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+      )
+      expect(killSpy).toHaveBeenCalledTimes(1)
+
+      exitCb?.({ exitCode: 137 })
+      await Promise.all([graceful, immediate])
+      expect(provider.hasPty(id)).toBe(false)
+    })
+
+    it('re-tree-kills mid-wait when an immediate agent shutdown ignores the first kill (#10475)', async () => {
+      vi.useFakeTimers()
+      try {
+        Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+        const killSpy = vi.fn()
+        mockProc.kill = killSpy
+        const { id } = await provider.spawn({
+          cols: 80,
+          rows: 24,
+          launchAgent: 'hermes'
+        })
+
+        const shutdown = provider.shutdown(id, { immediate: true })
+        expect(killWithDescendantSweepMock).toHaveBeenCalledTimes(1)
+
+        await vi.advanceTimersByTimeAsync(LOCAL_PTY_FORCE_ESCALATION_GRACE_MS)
+        expect(killWithDescendantSweepMock.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+        exitCb?.({ exitCode: 137 })
+        await shutdown
+        expect(provider.hasPty(id)).toBe(false)
+        expect(killSpy).toHaveBeenCalledTimes(1)
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('rejects a physical-exit timeout but retains the owner for a successful retry', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -111,6 +111,8 @@ const ptyForceKillTimers = new Map<string, ReturnType<typeof setTimeout>>()
 export const LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS = 8_000
 export const LOCAL_PTY_GRACEFUL_FORCE_TIMEOUT_MS = 5_000
 export const LOCAL_PTY_FORCE_KILL_RETRY_MS = 250
+/** Mid-wait re-tree-kill / SIGKILL budget before the remaining physical-exit wait (#10475). */
+export const LOCAL_PTY_FORCE_ESCALATION_GRACE_MS = 1_500
 
 let loadGeneration = 0
 const ptyLoadGeneration = new Map<string, number>()
@@ -253,12 +255,16 @@ function createPtyPhysicalExit(id: string): void {
   ptyPhysicalExits.set(id, new PhysicalExitTracker())
 }
 
-function waitForPtyPhysicalExit(id: string, physicalExit?: PhysicalExitTracker): Promise<void> {
+function waitForPtyPhysicalExit(
+  id: string,
+  physicalExit?: PhysicalExitTracker,
+  timeoutMs = LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS
+): Promise<void> {
   if (!physicalExit) {
     return Promise.reject(new Error(`PTY "${id}" exit tracking unavailable`))
   }
   return physicalExit.waitForExit(
-    LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS,
+    timeoutMs,
     () => new Error(`Timed out waiting for PTY process exit: ${id}`)
   )
 }
@@ -1079,7 +1085,9 @@ export class LocalPtyProvider implements IPtyProvider {
       if (opts.immediate === true) {
         pending.immediate = true
         if (pending.rootSignalled && ptyProcesses.get(id) === pending.proc) {
-          this.requestTrackedPtyShutdown(id, pending.proc, true)
+          // Why (#10475): ConPTY's first bare kill is already mode=force, so a plain
+          // requestTrackedPtyShutdown re-issue is a no-op; re-tree-kill stubborn agents.
+          await this.forceKillTrackedPtyTree(id, pending.proc)
         }
       }
       await pending.promise
@@ -1139,7 +1147,67 @@ export class LocalPtyProvider implements IPtyProvider {
     } else {
       signalRoot()
     }
-    await waitForPtyPhysicalExit(id, physicalExit)
+    await this.waitForTrackedPtyPhysicalExit(id, proc, physicalExit, operation.immediate)
+  }
+
+  /**
+   * Wait for physical exit; on immediate/agent destructive paths re-issue a tree
+   * force-kill once if the child is still live after a short grace (#10475).
+   */
+  private async waitForTrackedPtyPhysicalExit(
+    id: string,
+    proc: pty.IPty,
+    physicalExit: PhysicalExitTracker | undefined,
+    immediate: boolean
+  ): Promise<void> {
+    const shouldEscalate = immediate || process.platform === 'win32' || ptyAgentSessionIds.has(id)
+    if (!shouldEscalate || !physicalExit) {
+      await waitForPtyPhysicalExit(id, physicalExit)
+      return
+    }
+    const startedAt = Date.now()
+    const escalateAfterMs = Math.min(
+      LOCAL_PTY_FORCE_ESCALATION_GRACE_MS,
+      Math.max(1, Math.floor(LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS / 4))
+    )
+    try {
+      await physicalExit.waitForExit(
+        escalateAfterMs,
+        () => new Error(`Retrying force-kill for PTY ${id}`)
+      )
+      return
+    } catch {
+      if (ptyProcesses.get(id) === proc) {
+        await this.forceKillTrackedPtyTree(id, proc)
+      }
+    }
+    const remainingMs = Math.max(1, LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS - (Date.now() - startedAt))
+    await waitForPtyPhysicalExit(id, physicalExit, remainingMs)
+  }
+
+  /** Tree-kill (Windows taskkill / POSIX descendant sweep) then force the root. */
+  private async forceKillTrackedPtyTree(id: string, proc: pty.IPty): Promise<void> {
+    if (process.platform === 'win32' || ptyAgentSessionIds.has(id)) {
+      await killWithDescendantSweep(
+        proc.pid,
+        () => {
+          if (ptyProcesses.get(id) !== proc) {
+            return
+          }
+          // Why: ConPTY's first bare kill already closed the pseudoconsole; re-issuing
+          // can double-close the native handle. Tree kill (taskkill) is the escalate.
+          if (process.platform === 'win32' && ptyTerminationMode.get(id) === 'force') {
+            return
+          }
+          // Why: POSIX force may have been mode=graceful; clear so SIGKILL can land.
+          ptyTerminationMode.delete(id)
+          this.requestTrackedPtyShutdown(id, proc, true)
+        },
+        { ownsRoot: () => ptyProcesses.get(id) === proc }
+      )
+      return
+    }
+    this.requestTrackedPtyShutdown(id, proc, true)
   }
 
   private requestTrackedPtyShutdown(id: string, proc: pty.IPty, immediate: boolean): void {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -1087,7 +1087,11 @@ export class LocalPtyProvider implements IPtyProvider {
         if (pending.rootSignalled && ptyProcesses.get(id) === pending.proc) {
           // Why (#10475): ConPTY's first bare kill is already mode=force, so a plain
           // requestTrackedPtyShutdown re-issue is a no-op; re-tree-kill stubborn agents.
-          await this.forceKillTrackedPtyTree(id, pending.proc)
+          try {
+            await this.forceKillTrackedPtyTree(id, pending.proc)
+          } catch {
+            /* escalate is best-effort; the physical-exit wait owns the failure */
+          }
         }
       }
       await pending.promise
@@ -1160,7 +1164,10 @@ export class LocalPtyProvider implements IPtyProvider {
     physicalExit: PhysicalExitTracker | undefined,
     immediate: boolean
   ): Promise<void> {
-    const shouldEscalate = immediate || process.platform === 'win32' || ptyAgentSessionIds.has(id)
+    // Why: only agent / immediate (destructive) paths re-tree-kill mid-wait.
+    // Plain Windows shell closes already tree-kill at signal time when immediate;
+    // escalating every graceful close would taskkill /T long-running children (#10475).
+    const shouldEscalate = immediate || ptyAgentSessionIds.has(id)
     if (!shouldEscalate || !physicalExit) {
       await waitForPtyPhysicalExit(id, physicalExit)
       return
@@ -1178,10 +1185,18 @@ export class LocalPtyProvider implements IPtyProvider {
       return
     } catch {
       if (ptyProcesses.get(id) === proc) {
-        await this.forceKillTrackedPtyTree(id, proc)
+        try {
+          await this.forceKillTrackedPtyTree(id, proc)
+        } catch {
+          /* escalate is best-effort; the physical-exit wait owns the failure */
+        }
       }
     }
-    const remainingMs = Math.max(1, LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS - (Date.now() - startedAt))
+    // Why: don't charge a slow escalate against the post-kill wait floor (#10475).
+    const remainingMs = Math.max(
+      escalateAfterMs,
+      LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS - (Date.now() - startedAt)
+    )
     await waitForPtyPhysicalExit(id, physicalExit, remainingMs)
   }
 

--- a/src/main/windows-process-tree-kill.test.ts
+++ b/src/main/windows-process-tree-kill.test.ts
@@ -77,6 +77,45 @@ describe('terminateWindowsProcessTree', () => {
     expect(execFileImpl).toHaveBeenCalledTimes(2)
     expect(delayMs).toHaveBeenCalledWith(WINDOWS_PROCESS_TREE_KILL_RETRY_DELAY_MS)
     expect(aliveChecks).toBe(2)
+    // Why: retry shares the first attempt's budget so escalate cannot double the wait.
+    expect(execFileImpl.mock.calls[1]?.[2]).toEqual(
+      expect.objectContaining({
+        timeout: expect.any(Number),
+        windowsHide: true
+      })
+    )
+    const retryTimeout = (execFileImpl.mock.calls[1]?.[2] as { timeout: number }).timeout
+    expect(retryTimeout).toBeGreaterThan(0)
+    expect(retryTimeout).toBeLessThanOrEqual(WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS)
+  })
+
+  it('skips the live-root retry when the shared budget is already exhausted', async () => {
+    const execFileImpl = vi.fn(
+      (
+        _cmd: string,
+        _args: readonly string[],
+        _options: { timeout?: number; windowsHide?: boolean },
+        callback: (error: Error | null) => void
+      ) => {
+        callback(null)
+      }
+    )
+    // Why: a hung first taskkill can burn the whole budget; don't open a second one.
+    const started = Date.now()
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(started)
+      .mockReturnValue(started + WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS + 1)
+    try {
+      await terminateWindowsProcessTree(9001, {
+        execFileImpl: execFileImpl as never,
+        isProcessAlive: () => true,
+        delayMs: async () => {}
+      })
+      expect(execFileImpl).toHaveBeenCalledTimes(1)
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 
   it('does not retry when the root dies during the settle delay', async () => {

--- a/src/main/windows-process-tree-kill.test.ts
+++ b/src/main/windows-process-tree-kill.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   terminateWindowsProcessTree,
+  WINDOWS_PROCESS_TREE_KILL_RETRY_DELAY_MS,
   WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS
 } from './windows-process-tree-kill'
 
@@ -17,7 +18,8 @@ describe('terminateWindowsProcessTree', () => {
       }
     )
     await terminateWindowsProcessTree(1234, {
-      execFileImpl: execFileImpl as never
+      execFileImpl: execFileImpl as never,
+      isProcessAlive: () => false
     })
     expect(execFileImpl).toHaveBeenCalledWith(
       'taskkill',
@@ -28,6 +30,7 @@ describe('terminateWindowsProcessTree', () => {
       },
       expect.any(Function)
     )
+    expect(execFileImpl).toHaveBeenCalledTimes(1)
   })
 
   it('resolves even when taskkill reports failure (already dead)', async () => {
@@ -42,8 +45,79 @@ describe('terminateWindowsProcessTree', () => {
       }
     )
     await expect(
-      terminateWindowsProcessTree(55, { execFileImpl: execFileImpl as never })
+      terminateWindowsProcessTree(55, {
+        execFileImpl: execFileImpl as never,
+        isProcessAlive: () => false
+      })
     ).resolves.toBeUndefined()
+  })
+
+  it('retries taskkill once when the root is still alive after the first attempt (#10475)', async () => {
+    const execFileImpl = vi.fn(
+      (
+        _cmd: string,
+        _args: readonly string[],
+        _options: { timeout?: number; windowsHide?: boolean },
+        callback: (error: Error | null) => void
+      ) => {
+        callback(null)
+      }
+    )
+    let aliveChecks = 0
+    const delayMs = vi.fn(async () => {})
+    await terminateWindowsProcessTree(4242, {
+      execFileImpl: execFileImpl as never,
+      isProcessAlive: () => {
+        aliveChecks += 1
+        // First post-kill check + post-delay check both see a live root.
+        return true
+      },
+      delayMs
+    })
+    expect(execFileImpl).toHaveBeenCalledTimes(2)
+    expect(delayMs).toHaveBeenCalledWith(WINDOWS_PROCESS_TREE_KILL_RETRY_DELAY_MS)
+    expect(aliveChecks).toBe(2)
+  })
+
+  it('does not retry when the root dies during the settle delay', async () => {
+    const execFileImpl = vi.fn(
+      (
+        _cmd: string,
+        _args: readonly string[],
+        _options: { timeout?: number; windowsHide?: boolean },
+        callback: (error: Error | null) => void
+      ) => {
+        callback(null)
+      }
+    )
+    let alive = true
+    await terminateWindowsProcessTree(77, {
+      execFileImpl: execFileImpl as never,
+      isProcessAlive: () => alive,
+      delayMs: async () => {
+        alive = false
+      }
+    })
+    expect(execFileImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips the live-root retry when retryIfAlive is false', async () => {
+    const execFileImpl = vi.fn(
+      (
+        _cmd: string,
+        _args: readonly string[],
+        _options: { timeout?: number; windowsHide?: boolean },
+        callback: (error: Error | null) => void
+      ) => {
+        callback(null)
+      }
+    )
+    await terminateWindowsProcessTree(88, {
+      execFileImpl: execFileImpl as never,
+      retryIfAlive: false,
+      isProcessAlive: () => true
+    })
+    expect(execFileImpl).toHaveBeenCalledTimes(1)
   })
 
   it('skips taskkill for invalid pids', async () => {

--- a/src/main/windows-process-tree-kill.ts
+++ b/src/main/windows-process-tree-kill.ts
@@ -5,21 +5,38 @@ export type WindowsTreeKiller = (rootPid: number) => Promise<void>
 /** Bound hung taskkill so killRoot still runs in killWithDescendantSweep. */
 export const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 5_000
 
-/**
- * Force-kill a Windows process and every descendant (`taskkill /T /F`).
- * Best-effort: missing/already-dead roots still resolve so callers can finish
- * their own handle cleanup via killRoot.
- */
-export function terminateWindowsProcessTree(
-  rootPid: number,
-  deps: { execFileImpl?: typeof execFile } = {}
-): Promise<void> {
-  if (!Number.isInteger(rootPid) || rootPid <= 0) {
-    return Promise.resolve()
+/** One best-effort re-issue when the first taskkill leaves the root alive (#10475). */
+export const WINDOWS_PROCESS_TREE_KILL_RETRY_DELAY_MS = 150
+
+export type TerminateWindowsProcessTreeDeps = {
+  execFileImpl?: typeof execFile
+  /** Injectable liveness probe; defaults to `process.kill(pid, 0)`. */
+  isProcessAlive?: (pid: number) => boolean
+  /** Injectable delay between a failed first kill and the retry. */
+  delayMs?: (ms: number) => Promise<void>
+  /** When false, skip the live-root retry (default true). */
+  retryIfAlive?: boolean
+}
+
+function defaultIsProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
   }
-  const run = deps.execFileImpl ?? execFile
+}
+
+function defaultDelay(ms: number): Promise<void> {
   return new Promise((resolve) => {
-    run(
+    const timer = setTimeout(resolve, ms)
+    timer.unref?.()
+  })
+}
+
+function runTaskkill(rootPid: number, execFileImpl: typeof execFile): Promise<void> {
+  return new Promise((resolve) => {
+    execFileImpl(
       'taskkill',
       ['/pid', String(rootPid), '/T', '/F'],
       {
@@ -32,4 +49,36 @@ export function terminateWindowsProcessTree(
       }
     )
   })
+}
+
+/**
+ * Force-kill a Windows process and every descendant (`taskkill /T /F`).
+ * Best-effort: missing/already-dead roots still resolve so callers can finish
+ * their own handle cleanup via killRoot. When the first attempt leaves the root
+ * alive (stubborn agent CLIs / nested shells), retries once after a short delay
+ * so worktree delete is not blocked by a single missed taskkill (#10475).
+ */
+export async function terminateWindowsProcessTree(
+  rootPid: number,
+  deps: TerminateWindowsProcessTreeDeps = {}
+): Promise<void> {
+  if (!Number.isInteger(rootPid) || rootPid <= 0) {
+    return
+  }
+  const run = deps.execFileImpl ?? execFile
+  await runTaskkill(rootPid, run)
+  if (deps.retryIfAlive === false) {
+    return
+  }
+  const isAlive = deps.isProcessAlive ?? defaultIsProcessAlive
+  if (!isAlive(rootPid)) {
+    return
+  }
+  // Why: Hermes/Claude idle TUIs can ignore the first soft-adjacent ConPTY close
+  // and survive a racing taskkill; a second /T /F after a brief settle catches them.
+  await (deps.delayMs ?? defaultDelay)(WINDOWS_PROCESS_TREE_KILL_RETRY_DELAY_MS)
+  if (!isAlive(rootPid)) {
+    return
+  }
+  await runTaskkill(rootPid, run)
 }

--- a/src/main/windows-process-tree-kill.ts
+++ b/src/main/windows-process-tree-kill.ts
@@ -2,7 +2,10 @@ import { execFile } from 'node:child_process'
 
 export type WindowsTreeKiller = (rootPid: number) => Promise<void>
 
-/** Bound hung taskkill so killRoot still runs in killWithDescendantSweep. */
+/**
+ * Shared wall-clock budget for the first taskkill and an optional live-root retry.
+ * Why: two full 5s timeouts (~10s) outlive mid-wait escalate budgets (#10475).
+ */
 export const WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS = 5_000
 
 /** One best-effort re-issue when the first taskkill leaves the root alive (#10475). */
@@ -34,14 +37,18 @@ function defaultDelay(ms: number): Promise<void> {
   })
 }
 
-function runTaskkill(rootPid: number, execFileImpl: typeof execFile): Promise<void> {
+function runTaskkill(
+  rootPid: number,
+  execFileImpl: typeof execFile,
+  timeoutMs: number
+): Promise<void> {
   return new Promise((resolve) => {
     execFileImpl(
       'taskkill',
       ['/pid', String(rootPid), '/T', '/F'],
       {
         // Why: a wedged taskkill must not block killRoot forever (#10004 review).
-        timeout: WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS,
+        timeout: timeoutMs,
         windowsHide: true
       },
       () => {
@@ -57,6 +64,7 @@ function runTaskkill(rootPid: number, execFileImpl: typeof execFile): Promise<vo
  * their own handle cleanup via killRoot. When the first attempt leaves the root
  * alive (stubborn agent CLIs / nested shells), retries once after a short delay
  * so worktree delete is not blocked by a single missed taskkill (#10475).
+ * Both attempts share one wall-clock budget so escalate cannot outlive its wait.
  */
 export async function terminateWindowsProcessTree(
   rootPid: number,
@@ -66,7 +74,9 @@ export async function terminateWindowsProcessTree(
     return
   }
   const run = deps.execFileImpl ?? execFile
-  await runTaskkill(rootPid, run)
+  const startedAt = Date.now()
+  const budgetMs = WINDOWS_PROCESS_TREE_KILL_TIMEOUT_MS
+  await runTaskkill(rootPid, run, budgetMs)
   if (deps.retryIfAlive === false) {
     return
   }
@@ -80,5 +90,9 @@ export async function terminateWindowsProcessTree(
   if (!isAlive(rootPid)) {
     return
   }
-  await runTaskkill(rootPid, run)
+  const remainingMs = budgetMs - (Date.now() - startedAt)
+  if (remainingMs <= 0) {
+    return
+  }
+  await runTaskkill(rootPid, run, remainingMs)
 }


### PR DESCRIPTION
## Summary
- Nested agent TUIs (Hermes, etc.) can survive the first ConPTY kill / single taskkill, so worktree delete fails with “Failed to physically stop every PTY”.
- Retry tree-kill when the root is still alive; re-escalate mid-wait during immediate physical stop.

## Fixes
Closes #10475

## Test plan
- [x] windows-process-tree-kill / local-pty-provider / session force-kill escalation tests
- [ ] Manual Windows: idle Hermes worktree → right-click Delete succeeds

## ELI5

On Windows, nested agent processes sometimes survived the first kill, blocking worktree delete. Tree-kill is retried and escalated so stubborn PTYs actually die and delete can finish.
