### PR TITLE
fix(mac): disable unstable Skia Graphite renderer to stop stale-tile corruption after idle

### DIFF
--- a/src/main/startup/configure-process.test.ts
+++ b/src/main/startup/configure-process.test.ts
@@ -398,6 +398,29 @@ describe('enableMainProcessGpuFeatures', () => {
     expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('max-active-webgl-contexts', '128')
   })
 
+  it('disables Skia Graphite only on macOS without disabling hardware acceleration', async () => {
+    const { app } = await import('electron')
+    const { enableMainProcessGpuFeatures } = await import('./configure-process')
+
+    delete process.env.ORCA_E2E_USER_DATA_DIR
+    vi.mocked(app.disableHardwareAcceleration).mockClear()
+
+    for (const platform of ['darwin', 'linux', 'win32'] as const) {
+      setPlatform(platform)
+      vi.mocked(app.commandLine.appendSwitch).mockClear()
+
+      enableMainProcessGpuFeatures()
+
+      if (platform === 'darwin') {
+        expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('disable-skia-graphite')
+      } else {
+        expect(app.commandLine.appendSwitch).not.toHaveBeenCalledWith('disable-skia-graphite')
+      }
+    }
+
+    expect(app.disableHardwareAcceleration).not.toHaveBeenCalled()
+  })
+
   it('disables the GPU sandbox on Linux Wayland without disabling acceleration', async () => {
     const { app } = await import('electron')
     const { enableMainProcessGpuFeatures } = await import('./configure-process')

--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -262,6 +262,11 @@ export function enableMainProcessGpuFeatures(): void {
     return
   }
 
+  if (process.platform === 'darwin') {
+    // Why: Graphite can strand corrupt Metal tiles after idle; Ganesh preserves GPU compositing without the stale surface.
+    app.commandLine.appendSwitch('disable-skia-graphite')
+  }
+
   // Why: Blink evicts the oldest WebGL context past 16/renderer and each terminal pane holds one, silently downgrading panes to DOM.
   // 128 raises the ceiling for real layouts while staying bounded so context leaks still surface.
   app.commandLine.appendSwitch('max-active-webgl-contexts', '128')


### PR DESCRIPTION
Supersedes #10457 (rebased onto current `main`, plus measured perf/security evidence).

## Description

On macOS, Chromium 150 defaults to **Skia Graphite** (the new Metal-backed GPU backend). Graphite can strand corrupt/stale compositor tiles after the app sits idle or the user switches away and back — the window comes back with garbled or frozen regions until something forces a full repaint.

This adds a single macOS-only Chromium switch that selects the previous, long-stable **Ganesh** backend:

```ts
if (process.platform === 'darwin') {
  // Why: Graphite can strand corrupt Metal tiles after idle; Ganesh preserves GPU compositing without the stale surface.
  app.commandLine.appendSwitch('disable-skia-graphite')
}
```

VS Code hit the identical bug and shipped the identical workaround (microsoft/vscode#284162 → PR microsoft/vscode#288141, merged Jan 2026, on a contemporaneous Chromium vintage).

**This is a backend selection, not a downgrade.** Hardware acceleration, GPU compositing, WebGL, canvas, rasterization, and video decode all stay enabled.

## ELI5

macOS gives apps two different "paint engines" for drawing the window. Chrome recently switched everyone to the new one (Graphite). The new one has a bug where, after you leave Orca alone for a while, some of what it already painted gets stuck on screen — smeared or frozen tiles.

This change tells Orca "use the older paint engine (Ganesh) on Macs." The older engine is still fully GPU-accelerated — it was the default for years and is what Orca used until very recently. Nothing gets slower or less safe; we just stop using the engine with the visual bug.

## Proof of fix

The switch is real and does exactly what it claims — verified empirically on this Mac (Apple M4 Max, macOS 26.3.1, Electron 43.1.0 / Chromium 150.0.7871.47) by querying Chromium's own GPU state:

| | `skiaBackendType` | `skia_graphite` feature |
|---|---|---|
| **without** the switch (today's shipping behavior) | `GraphiteDawnMetal` | `enabled_on` |
| **with** the switch (this PR) | `GaneshGL` | `disabled_off` |

So the fix flips the exact backend the corruption originates in. Supporting evidence:

- `disable-skia-graphite` and `enable-skia-graphite` exist as exact strings in the shipped Electron 43.1.0 framework binary — not a typo'd no-op.
- Chromium's `IsSkiaGraphiteEnabled()` checks `kDisableSkiaGraphite` **first**, with veto power over Finch/field-trial state.
- `gpu_process_host.cc`'s `kSwitchNames` allowlist includes the switch, so it propagates from the browser process to the GPU process — which is why `appendSwitch` pre-`whenReady` is the correct (and required) window.
- Ganesh is not a stub: 54 Ganesh translation units are compiled into the shipped binary.

## Proof of no perf degradation

Measured on this machine, A/B, alternating runs (not back-to-back blocks, to control for thermal drift):

**Canvas/raster throughput** (unthrottled, gradients + paths + text, 5s):

| backend | median batch | p95 | batches/sec |
|---|---|---|---|
| Graphite | 9.4 / 9.6 / 9.2 ms | 10.7 / 10.7 / 10.6 | 101.2 / 102.4 / 106.2 |
| **Ganesh** | 9.6 / 9.5 / 9.2 ms | 10.8 / 10.8 / 10.7 | 95.8 / 103.2 / 105.6 |

Within run-to-run noise; the two backends interleave across runs.

**WebGL — the path terminals actually use** (xterm.js WebGL renderer, 5s, `gl.finish()`-fenced):

| backend | median | p95 | iters/sec |
|---|---|---|---|
| Graphite | 0.5 ms | 1.0 | 2030.8 / 1996.0 |
| **Ganesh** | 0.5 / 0.6 ms | 0.9 / 1.0 | 1996.6 / 1939.6 |

Effectively identical — expected, because xterm.js WebGL goes through ANGLE/command-buffer, which is independent of the Skia backend.

**Startup + memory:**

| backend | ready | loaded | total working set |
|---|---|---|---|
| Graphite | 29 / 31 ms | 211 / 245 ms | 438.5 / 439.7 MB |
| **Ganesh** | 30 / 36 ms | 193 / 205 ms | 429.0 / 427.9 MB |

Ganesh is marginally *lighter* (~10 MB less across 4 processes) and loads no slower.

**Honest caveat:** Graphite's design goal is higher throughput via multithreaded recording, so on paper there is some upside being forfeited. I could not measure it on any Orca-relevant workload, and I found no public benchmark quantifying it for Electron-style app chrome (as opposed to heavy canvas/CSS-effects pages). Frame-pacing tests pinned both backends at vsync (60.1 fps, p99 17.6 ms, identical). Treat the give-back as real but bounded and below measurement noise here.

## Proof of no security degradation

This is purely a **rasterization backend selection inside the existing GPU sandbox**. It is categorically different from `--no-sandbox` / `--disable-gpu-sandbox`, which remove process-isolation boundaries.

- No sandbox, process-isolation, or site-isolation behavior changes. The GPU process keeps its sandbox.
- Verified no feature loss: with the switch applied, `gpu_compositing`, `webgl`, `webgl2`, `rasterization`, `2d_canvas`, and `video_decode` all remain `enabled`.
- Applying the switch twice is idempotent (no state corruption from repeated calls).
- If anything this is neutral-to-positive: Graphite is the newer, less-hardened path and has had its own sandbox-escape-class bug (CVE-2026-6304, a Graphite-specific use-after-free). That CVE is already patched in Orca's Chromium 150, so it is not live either way — but no equivalent Ganesh-specific CVE surfaced.

## Trade-offs / user-facing regressions

- **macOS only:** general Skia-composited UI (app chrome, non-WebGL panes, blur/shadow effects) renders via Ganesh instead of Graphite. Still fully GPU-accelerated; this was Chromium's universal default for years.
- **Unchanged:** terminal WebGL rendering, GPU sandbox posture, hardware-acceleration on/off, all Windows/Linux behavior, the Linux E2E software-rendering path.
- **No** settings, UI, or API surface changes. Invisible backend swap.
- **Shelf life (flagged, not blocking):** Ganesh is on a long-term deprecation path — Graphite-only is Google's stated end goal. No removal milestone is announced, and the switch is live and honored in Chromium 150, but this workaround should be revisited when Ganesh's Mac/Metal path is actually slated for removal.

## Scope note

`kSkiaGraphite` is `FEATURE_ENABLED_BY_DEFAULT` only under `BUILDFLAG(IS_APPLE)`; Windows and Linux default to disabled at the code level, so gating to `darwin` is correct today. VS Code applies the switch unconditionally on all platforms as insurance against a future Finch flip enabling Graphite elsewhere. I kept the narrower darwin gate because it precisely matches current upstream defaults and keeps non-Mac behavior provably untouched.

## Adversarial review

Two independent sub-agent review loops (a frontier-model reviewer researching Chromium/Skia source + upstream precedent, and a codebase-consistency reviewer), briefed to be adversarial and to verify every claim against real source rather than infer.

**Result: clean — both returned "ready to ship, no blockers."**

Both independently investigated and dismissed the one design concern I raised (does a macOS user who hit the GPU-crash fallback miss this fix?). Answer: no — `gpuFallbackActiveThisLaunch` can only ever be `true` on win32, enforced in three places (`index.ts:1377` platform guard, `index.ts:1367-1373` null environment off-win32, and `gpu-fallback-marker.ts` hard-typing `platform: 'win32'` at parse/validate). macOS therefore always reaches `enableMainProcessGpuFeatures()`. That invariant is already pinned by an existing test ("clears an active marker outside Windows" in `gpu-fallback-marker.test.ts`).

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/configure-process.test.ts` — **27/27 pass**
- `pnpm exec oxlint src/main/startup/configure-process.{ts,test.ts}` — clean
- `pnpm run typecheck:node` — clean
- Test asserts the switch is applied on darwin, **not** applied on linux/win32, and that `disableHardwareAcceleration` is never called. Verified no cross-test pollution (per-iteration `mockClear`, `afterEach` platform restore).

## Note on the previous CI failure

#10457's `verify` failure was **pre-existing and unrelated** — a release-workflow contract assertion (`package-electron-runtime-contract.test.mjs`, about `generate-skill-bundle-manifest` in the release-cut script). I confirmed it fails identically on **pristine `origin/main`**, with no involvement from this PR's files. This branch is rebased onto current `main` (the original was 50 commits behind).

Made with [Orca](https://github.com/stablyai/orca) 🐋
