### PR TITLE
test(gpu): pin the win32-only fallback invariant the macOS Graphite fix relies on

### DIFF
--- a/src/main/startup/configure-process.ts
+++ b/src/main/startup/configure-process.ts
@@ -264,6 +264,8 @@ export function enableMainProcessGpuFeatures(): void {
 
   if (process.platform === 'darwin') {
     // Why: Graphite can strand corrupt Metal tiles after idle; Ganesh preserves GPU compositing without the stale surface.
+    // Reached on every macOS launch only because GPU fallback skips this function and is win32-only; if fallback ever
+    // reaches macOS this must move out of this path or Macs silently lose the fix.
     app.commandLine.appendSwitch('disable-skia-graphite')
   }
 

--- a/src/main/startup/gpu-fallback-marker.test.ts
+++ b/src/main/startup/gpu-fallback-marker.test.ts
@@ -79,6 +79,21 @@ describe('gpu-fallback-marker', () => {
     expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
   })
 
+  // Why: enableMainProcessGpuFeatures() is skipped while GPU fallback is active, and that function
+  // carries the macOS disable-skia-graphite fix. A marker that survived on darwin would silently
+  // strip the fix from the Macs it targets, so pin the platform gate for darwin specifically.
+  it('clears an active marker on macOS so the Graphite fix is never skipped', () => {
+    writeGpuFallbackMarker(userDataPath, { engagedAt: 1, crashesInWindow: 4 }, environment)
+
+    expect(
+      readActiveGpuFallbackMarker(userDataPath, {
+        ...environment,
+        platform: 'darwin'
+      })
+    ).toBeNull()
+    expect(existsSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE))).toBe(false)
+  })
+
   it('clears a corrupt or wrong-version marker', () => {
     writeFileSync(join(userDataPath, GPU_FALLBACK_MARKER_FILE), '{ not json')
     expect(readGpuFallbackMarker(userDataPath)).toBeNull()


### PR DESCRIPTION
Follow-up hardening for #10643. **No production behavior change** — one comment and one test.

## Why

#10643 put the macOS `disable-skia-graphite` fix inside `enableMainProcessGpuFeatures()`. That function is **skipped entirely** when GPU crash fallback is active:

```ts
maybeApplyGpuFallbackForThisLaunch()
if (!gpuFallbackActiveThisLaunch) {
  enableMainProcessGpuFeatures()
}
```

This is correct today only because GPU fallback is win32-only. But that invariant is implicit and spread across two files and three redundant layers. If fallback were ever extended to macOS, Macs would silently lose the Graphite fix — the exact machines it targets — with no test failing.

Two independent adversarial reviews of #10643 flagged this same latent coupling as the one worthwhile follow-up.

## What changed

1. **Comment at the call site** (`configure-process.ts`) — states the coupling explicitly. This follows existing convention in the same function: `IntensiveWakeUpThrottling` already documents this identical hazard.
2. **Test for darwin** (`gpu-fallback-marker.test.ts`) — the suite already pinned `linux`, but not `darwin`, so the platform relevant to the Graphite fix was uncovered.

## Proof the test is real

I mutation-tested it rather than trusting a green run. Disabling all three platform layers in `readActiveGpuFallbackMarker` fails it:

```
× clears an active marker outside Windows
× clears an active marker on macOS so the Graphite fix is never skipped
  Tests  2 failed | 6 passed (8)
```

Worth noting: knocking out any *single* layer does **not** fail it, because the layers are genuinely redundant — `marker.platform` is written as `'win32'`, so the `marker.platform !== environment.platform` check independently catches a darwin read. That redundancy is defense in depth working as intended, and the test correctly pins the composed behavior rather than one line.

## Verification

- `src/main/startup/` suite: **163/163 pass** (22 files)
- `oxlint`: clean
- `typecheck:node`: clean

## Risk

None to runtime behavior — the only non-test change is a comment. No perf or security surface is touched.

Made with [Orca](https://github.com/stablyai/orca) 🐋
