### PR TITLE
fix(crash-reporting): coalesce suppressed process-gone breadcrumbs so a recoverable-service crash loop can't erase the crash trail

### DIFF
--- a/src/main/crash-reporting/durable-crash-breadcrumb.ts
+++ b/src/main/crash-reporting/durable-crash-breadcrumb.ts
@@ -4,29 +4,28 @@ import {
   type CrashReportBreadcrumbData
 } from '../../shared/crash-reporting'
 import { flushActiveSink, startSpan } from '../observability/tracer'
-import { recordCrashBreadcrumb } from './crash-breadcrumb-store'
+import { recordCoalescedCrashBreadcrumb, recordCrashBreadcrumb } from './crash-breadcrumb-store'
 import { getMainProcessLifecycleIdentity } from './main-process-lifecycle-identity'
 
-export function recordDurableCrashBreadcrumb(
-  name: string,
-  data?: CrashReportBreadcrumbData,
-  failureCause?: string
-): void {
-  const sanitizedName = sanitizeCrashReportString(name)
-  const sanitizedData = data ? sanitizeCrashReportDetails(data) : {}
+function buildLifecycleData(data?: CrashReportBreadcrumbData): CrashReportBreadcrumbData {
   // Why: durable events survive renderer replacement, so carrying the main
   // identity here distinguishes renderer recovery from a true app relaunch.
-  const lifecycleData = {
-    ...sanitizedData,
+  return {
+    ...(data ? sanitizeCrashReportDetails(data) : {}),
     ...getMainProcessLifecycleIdentity()
   }
-  recordCrashBreadcrumb(sanitizedName, lifecycleData)
+}
 
+function traceDurableBreadcrumb(
+  name: string,
+  data: CrashReportBreadcrumbData,
+  failureCause?: string
+): void {
   const span = startSpan('crash.breadcrumb', {
     attributes: {
       kind: 'crash-breadcrumb',
-      'breadcrumb.name': sanitizedName,
-      'breadcrumb.data': lifecycleData
+      'breadcrumb.name': name,
+      'breadcrumb.data': data
     }
   })
   if (failureCause) {
@@ -37,4 +36,48 @@ export function recordDurableCrashBreadcrumb(
   // Why: these breadcrumbs explain a missing crash record; losing one to the
   // normal trace batching window would recreate the diagnostic blind spot.
   flushActiveSink()
+}
+
+export function recordDurableCrashBreadcrumb(
+  name: string,
+  data?: CrashReportBreadcrumbData,
+  failureCause?: string
+): void {
+  const sanitizedName = sanitizeCrashReportString(name)
+  const lifecycleData = buildLifecycleData(data)
+  recordCrashBreadcrumb(sanitizedName, lifecycleData)
+  traceDurableBreadcrumb(sanitizedName, lifecycleData, failureCause)
+}
+
+/** Durable counterpart to `recordCoalescedCrashBreadcrumb`: identical repeats
+ *  inside `minIntervalMs` collapse into the next emitted breadcrumb's
+ *  `suppressedSinceLast` instead of each costing a span plus a forced flush. */
+export function recordCoalescedDurableCrashBreadcrumb({
+  name,
+  data,
+  coalesceKey,
+  minIntervalMs
+}: {
+  name: string
+  data?: CrashReportBreadcrumbData
+  coalesceKey: string
+  minIntervalMs: number
+}): void {
+  const sanitizedName = sanitizeCrashReportString(name)
+  const lifecycleData = buildLifecycleData(data)
+  const coalesced = recordCoalescedCrashBreadcrumb({
+    name: sanitizedName,
+    data: lifecycleData,
+    coalesceKey,
+    minIntervalMs
+  })
+  if (!coalesced) {
+    return
+  }
+  traceDurableBreadcrumb(
+    sanitizedName,
+    coalesced.suppressedSinceLast > 0
+      ? { ...lifecycleData, suppressedSinceLast: coalesced.suppressedSinceLast }
+      : lifecycleData
+  )
 }

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -180,6 +180,37 @@ describe('recordProcessGoneCrash', () => {
         data: expect.objectContaining({ suppressedSinceLast: 699 })
       })
     ])
+    // Why: the ring gets this count from the store itself, so only the span proves
+    // the exported telemetry carries it too.
+    expect(sink.records).toEqual([
+      expect.objectContaining({ name: 'crash.breadcrumb' }),
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          'breadcrumb.data': expect.objectContaining({ suppressedSinceLast: 699 })
+        })
+      })
+    ])
+  })
+
+  it('keeps suppressions with different exit codes separate', () => {
+    const dedupe = new ProcessGoneDedupe()
+    const utilityCrash = (exitCode: number) =>
+      event({
+        source: 'child',
+        processType: 'Utility',
+        reason: 'crashed',
+        exitCode,
+        details: { serviceName: 'network.mojom.NetworkService' }
+      })
+
+    recordProcessGoneCrash({ record: vi.fn() } as never, utilityCrash(11), dedupe)
+    recordProcessGoneCrash({ record: vi.fn() } as never, utilityCrash(139), dedupe)
+
+    // Why: a clean shutdown code and a segfault are different failures; collapsing
+    // them would hide the second behind the first for a full window.
+    expect(getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.data?.exitCode)).toEqual([
+      11, 139
+    ])
   })
 
   it('never lets one recoverable service suppress another service evidence', () => {

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -7,7 +7,11 @@ vi.mock('electron', () => ({
   }
 }))
 
-import { clearCrashBreadcrumbsForTest, getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot,
+  recordCrashBreadcrumb
+} from './crash-breadcrumb-store'
 import { ProcessGoneDedupe } from './process-gone-dedupe'
 import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
 import { _resetTracerForTests, setActiveSink, type TracerSink } from '../observability/tracer'
@@ -99,6 +103,110 @@ describe('recordProcessGoneCrash', () => {
       })
     ])
     expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+
+  it('coalesces a recoverable-service crash loop instead of flushing every event', () => {
+    const record = vi.fn()
+    const dedupe = new ProcessGoneDedupe()
+    const networkServiceCrash = event({
+      source: 'child',
+      processType: 'Utility',
+      reason: 'crashed',
+      expectedTeardown: 'none',
+      details: { serviceName: 'network.mojom.NetworkService', type: 'Utility' }
+    })
+
+    // Observed peak in a real diagnostic bundle: 1459 suppressed crashes in one minute.
+    for (let i = 0; i < 1_459; i++) {
+      recordProcessGoneCrash({ record } as never, networkServiceCrash, dedupe)
+    }
+
+    expect(record).not.toHaveBeenCalled()
+    expect(sink.records).toHaveLength(1)
+    expect(sink.flushMock).toHaveBeenCalledOnce()
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({
+        name: 'process_gone_suppressed',
+        data: expect.objectContaining({ serviceName: 'network.mojom.NetworkService' })
+      })
+    ])
+  })
+
+  it('keeps the pre-crash breadcrumb trail through a crash loop', () => {
+    const dedupe = new ProcessGoneDedupe()
+    recordCrashBreadcrumb('renderer_error', { message: 'boom' })
+
+    for (let i = 0; i < 1_459; i++) {
+      recordProcessGoneCrash(
+        { record: vi.fn() } as never,
+        event({
+          source: 'child',
+          processType: 'Utility',
+          reason: 'crashed',
+          details: { serviceName: 'network.mojom.NetworkService' }
+        }),
+        dedupe
+      )
+    }
+
+    // Why: the ring holds 30 entries, so an uncoalesced loop evicts every real breadcrumb.
+    expect(getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.name)).toEqual([
+      'renderer_error',
+      'process_gone_suppressed'
+    ])
+  })
+
+  it('reports how many repeats a coalesced suppression stands for', () => {
+    const dedupe = new ProcessGoneDedupe()
+    const utilityCrash = event({
+      source: 'child',
+      processType: 'Utility',
+      reason: 'crashed',
+      details: { serviceName: 'network.mojom.NetworkService' }
+    })
+    const nowSpy = vi.spyOn(Date, 'now')
+
+    nowSpy.mockReturnValue(0)
+    for (let i = 0; i < 700; i++) {
+      recordProcessGoneCrash({ record: vi.fn() } as never, utilityCrash, dedupe)
+    }
+    nowSpy.mockReturnValue(30_000)
+    recordProcessGoneCrash({ record: vi.fn() } as never, utilityCrash, dedupe)
+
+    expect(getCrashBreadcrumbSnapshot()).toEqual([
+      expect.objectContaining({ name: 'process_gone_suppressed' }),
+      expect.objectContaining({
+        name: 'process_gone_suppressed',
+        data: expect.objectContaining({ suppressedSinceLast: 699 })
+      })
+    ])
+  })
+
+  it('never lets one recoverable service suppress another service evidence', () => {
+    const dedupe = new ProcessGoneDedupe()
+    const utilityCrash = (serviceName: string) =>
+      event({
+        source: 'child',
+        processType: 'Utility',
+        reason: 'crashed',
+        details: { serviceName }
+      })
+
+    recordProcessGoneCrash(
+      { record: vi.fn() } as never,
+      utilityCrash('network.mojom.NetworkService'),
+      dedupe
+    )
+    recordProcessGoneCrash(
+      { record: vi.fn() } as never,
+      utilityCrash('audio.mojom.AudioService'),
+      dedupe
+    )
+
+    expect(getCrashBreadcrumbSnapshot().map((breadcrumb) => breadcrumb.data?.serviceName)).toEqual([
+      'network.mojom.NetworkService',
+      'audio.mojom.AudioService'
+    ])
   })
 
   it('persists a report and flushes the process-gone trace before recovery', async () => {

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -1,9 +1,16 @@
 import os from 'node:os'
 import { app } from 'electron'
-import { isCrashReportReason, sanitizeCrashReportString } from '../../shared/crash-reporting'
+import {
+  isCrashReportReason,
+  sanitizeCrashReportString,
+  type CrashReportBreadcrumbData
+} from '../../shared/crash-reporting'
 import type { CrashReportStore } from './crash-report-store'
 import { getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
-import { recordDurableCrashBreadcrumb } from './durable-crash-breadcrumb'
+import {
+  recordCoalescedDurableCrashBreadcrumb,
+  recordDurableCrashBreadcrumb
+} from './durable-crash-breadcrumb'
 import {
   shouldRecordProcessGoneCrash,
   type ExpectedTeardownScope,
@@ -32,8 +39,27 @@ export type ProcessGoneCrashEvent = {
 
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record'>
 
+// Why: the coalesce map prunes every key against the calling window, so a shorter
+// one here would weaken the other 30s coalescers. Stay uniform with them.
+const SUPPRESSED_PROCESS_GONE_COALESCE_MS = 30_000
+
 function processGoneBreadcrumbData(event: ProcessGoneCrashEvent) {
   return buildSuppressedProcessGoneBreadcrumbData(event)
+}
+
+// Why: key off the emitted breadcrumb, not the crash-report dedupe key, so two
+// different recoverable services can never suppress each other's evidence.
+function suppressedProcessGoneCoalesceKey(data: CrashReportBreadcrumbData): string {
+  return JSON.stringify([
+    data.source,
+    data.processType,
+    data.reason,
+    data.exitCode,
+    data.expectedTeardown,
+    data.serviceName ?? null,
+    data.name ?? null,
+    data.type ?? null
+  ])
 }
 
 function persistFailureData(event: ProcessGoneCrashEvent, error: unknown) {
@@ -68,7 +94,16 @@ export function recordProcessGoneCrash(
       expectedTeardown: event.expectedTeardown
     })
   ) {
-    recordDurableCrashBreadcrumb('process_gone_suppressed', processGoneBreadcrumbData(event))
+    // Why: Chromium can crash-loop a recoverable child (network service seen at
+    // 1459/min) and each suppressed event costs a span plus a forced disk flush,
+    // which both floods the 30-entry ring and evicts the real pre-crash trail.
+    const suppressedData = processGoneBreadcrumbData(event)
+    recordCoalescedDurableCrashBreadcrumb({
+      name: 'process_gone_suppressed',
+      data: suppressedData,
+      coalesceKey: suppressedProcessGoneCoalesceKey(suppressedData),
+      minIntervalMs: SUPPRESSED_PROCESS_GONE_COALESCE_MS
+    })
     return
   }
   if (!store) {


### PR DESCRIPTION
## Description

When Chromium reports that a **recoverable** child process died — the network service, audio service, or GPU process — `shouldRecordProcessGoneCrash()` returns `false` and we deliberately do not raise a crash report. That suppression is correct: those children restart on their own and prompting the user is noise.

The suppressed path still recorded a **durable** breadcrumb, and `recordDurableCrashBreadcrumb()` does three things per call:

1. pushes into the 30-entry crash breadcrumb ring (`MAX_BREADCRUMBS = 30`),
2. starts an OTel span,
3. calls `flushActiveSink()` → a **synchronous `writeSync`** to disk.

That is fine at one event. It is not fine in a crash loop. In real user telemetry `network.mojom.NetworkService` crash-looped at **1,051–1,459 crashes per minute** (median inter-crash gap **0.03 s**) — roughly **24 synchronous main-process disk flushes per second**, for an event we had already decided was not worth reporting.

Two consequences, both of which destroy diagnostics exactly when they matter most:

- **The pre-crash breadcrumb trail is erased.** 30 entries fill in under two seconds. When a real renderer crash landed during the storm, its crash report shipped a ring that was **29/30 `process_gone_suppressed`** — every actual clue was gone.
- **The diagnostic bundle is crowded out.** Bundles are capped at 4 MiB. Two storm bundles were **98%** and **82%** nothing but suppressed-event records. A clean bundle carries a median of **9,272** real records; those two carried **122** and **1,076**.

This is not a single-user anomaly: **32 of 977** cached bundles, spanning **8 app versions** (1.4.139 → 1.4.153-rc.1), contain enough suppressed events to fill the entire ring on their own.

**The fix:** suppression logic is untouched. Only the breadcrumb emitted on that path now coalesces, via a new `recordCoalescedDurableCrashBreadcrumb()` — the durable counterpart to the `recordCoalescedCrashBreadcrumb()` that already exists in this codebase for exactly this reason (renderer error storms, #8260). Identical repeats inside a 30 s window collapse into one breadcrumb carrying a `suppressedSinceLast` count, so the event class stays visible and the volume does not.

## ELI5

Your app has a small notepad with room for 30 lines. It writes down the last few things that happened, so if it crashes, the notepad explains why.

One of Chromium's helper processes (the networking one) can get stuck in a restart loop — dying and respawning ~24 times a second. We already knew those deaths were harmless and chose to ignore them. But we still wrote *"ignored a harmless death"* on the notepad every single time, and re-saved the notepad to disk on every line.

So within two seconds, all 30 lines said *"ignored a harmless death."* Then something actually went wrong — and the notepad had nothing useful left on it.

Now we write that line **once per 30 seconds**, with a tally: *"ignored a harmless death (and 699 more)."* Same information, one line, and 29 lines still free for the thing that actually broke.

## Proof of fix

**1. The defect reproduces exactly, from real field numbers.** Replaying the observed peak rate against the pre-fix code:

```
spans written : 1459
sync flushes  : 1459
ring size     : 30
distinct names: [ 'process_gone_suppressed' ]   ← the entire trail, gone
```

**2. Replay of all 977 real diagnostic bundles** through the new coalescing logic:

```
FLEET: 14994 suppressed events -> 600 spans+flushes  (96.00% reduction)
  F0BK5M6JG5B: 5849 -> 13   (450x fewer, 99.78% cut)
  F0BK8QHTXFX: 5028 ->  9   (559x fewer, 99.82% cut)
  F0BJWPZ4KDK:  620 ->  2   (310x fewer, 99.68% cut)
```

**3. Zero diagnostic classes lost** — the key question for a change that drops records:

```
distinct (bundle,key) pairs BEFORE: 185
distinct (bundle,key) pairs AFTER : 185
event classes lost entirely       : 0
```

Every distinct kind of suppressed event that was visible before is still visible after. Only redundant repeats collapse, and each collapse is counted in `suppressedSinceLast` — with the two bounded exceptions documented under *Regressions* below (LRU eviction past 128 concurrent keys, and a trailing count with no subsequent event), neither of which can hide an event class.

**4. New tests** in `process-gone-recorder.test.ts`, driven by the real 1,459/min figure:
- one storm-minute → 1 span, 1 flush, 1 ring entry (was 1,459 / 1,459 / 30)
- an unrelated `renderer_error` breadcrumb **survives** the full storm
- `suppressedSinceLast: 699` is reported accurately after the window rolls
- `network.mojom.NetworkService` and `audio.mojom.AudioService` never suppress each other

**5. Mutation-tested.** Each mutation was applied alone, run, then reverted and the revert verified. The first pass found **two surviving mutants** — real gaps in my own tests — so I added two tests in `c886527` to close them. All four are now killed:

| Mutation | First pass | After `c886527` |
|---|---|---|
| revert to uncoalesced (`minIntervalMs: 0`) | 3 tests fail | 3 tests fail |
| bypass the emit guard (`if (!coalesced)` → `if (false)`) | 3 tests fail | 3 tests fail |
| drop `serviceName` from the coalesce key | 1 test fails | 1 test fails |
| drop `exitCode` from the coalesce key | **survived** — nothing varied only `exitCode`, so two different failure codes could silently collapse into one | 1 test fails |
| drop the `suppressedSinceLast` spread on the traced span | **survived** — the count assertion read the ring buffer, which the store populates independently, so the *exported telemetry* was never checked | 1 test fails |

The second survivor is worth calling out: the ring buffer and the span get `suppressedSinceLast` from two different places, so the headline "699 repeats are reported accurately" claim was only ever proven for the in-memory ring, not for what actually ships in a bundle. It is now proven for both.

## Proof of zero regressions

**No user-facing regression.** This path is invisible to users by construction — it is the branch we take *specifically because* we decided not to surface anything. No prompt, dialog, notification, or recovery behaviour is reachable from it.

**The genuine-crash path is byte-for-byte unchanged.** The diff touches only the early-return branch taken when `shouldRecordProcessGoneCrash()` returns `false`. Real crashes still get `startSpan('electron.process_gone')`, an unconditional `flushActiveSink()`, `store.record(...)`, and the untouched `processGoneDedupe`. `recordDurableCrashBreadcrumb()` keeps its exact previous behaviour for its other three call sites (`crash_report_store_unavailable`, `crash_report_persist_failed`, and callers in `index.ts`) — it was refactored into two helpers with no semantic change.

**Test results:**

| Scope | Result |
|---|---|
| `src/main/` (full main process) | **15,190 passed**, 47 skipped — 1,094 files, zero failures |
| `src/main/crash-reporting/` | 87 passed (was 80 — 7 new) |
| `tsc --noEmit -p config/tsconfig.node.json` | clean |
| `oxlint src/main/crash-reporting/` | clean |

**Shared-state safety.** `recordCoalescedCrashBreadcrumb` keeps one module-level map shared by all callers, and its prune loop evicts keys using the *calling* invocation's `minIntervalMs`. A shorter window here would therefore weaken the three existing coalescers. I verified this coupling empirically (a 5 s caller does evict a 30 s caller's key early) and chose **30 s to match every existing caller** — `ipc/crash-reporting.ts:332`, `index.ts:288`, `pr-refresh-coordinator.ts:79`, `pr-refresh-validation-backoff.ts:7`. The reason is recorded as a comment at the constant so a future edit doesn't silently break the others.

The `MAX_COALESCE_KEYS = 128` cap is a real — but pre-existing and shared — boundary, and I want to be precise about it rather than claim more than I can prove. Suppressed hits bump a counter but do **not** refresh a key's position in insertion order, so a key can go stale in the LRU while actively coalescing. If 128 *other* distinct keys are live at once, the busy key is evicted and its accumulated count is lost — it re-emits reporting `suppressedSinceLast: 0` instead of the true total. I verified both the boundary and its exact location:

| Other live keys | Outcome for a key with 200 accumulated suppressions |
|---|---|
| 127 | survives; reports `suppressedSinceLast: 200` |
| 128 | evicted; re-emits early reporting `suppressedSinceLast: 0` |

Measured real cardinality is **7 distinct keys per bundle at most, 29 fleet-wide**, so this is far out of reach in practice — but "unreachable at measured cardinality" is the honest claim, not "impossible." The failure mode is also benign: the event class is still emitted, only the *count* is understated. This behavior is inherited from the existing coalescer and is not introduced or worsened by this PR.

One related limit, for completeness: `suppressedSinceLast` is only materialized by the *next* emission for that key. If a storm ends and no further event of that class ever arrives, the trailing suppressions are never reported. The storm's existence is still recorded by the emission that opened it.

## Performance

Decisively cheaper for the observed loop. Measured end-to-end through the real `LocalFileSink`, for one storm-minute (1,459 events):

| | Blocked main-process time | Disk written |
|---|---|---|
| before | **78.5 ms** | 772 KB/min |
| after | **11.5 ms** | 1.1 KB/min |

**85% less main-thread blocking and 700× less disk I/O**, on a main process that is already contending with a failing network stack.

To be exact about where cost is added rather than removed: the reduction applies to repeats. The *first* event of a class, and every event arriving ≥30 s after the last one, pays a small fixed addition — one `JSON.stringify` of eight scalars plus a bounded Map lookup/prune/set — that it did not pay before. That addition measures **0.47 ms per 1,459 calls** (~0.3 µs each), against the ~46 µs per call coalescing removes, and the prune loop is O(n) with n bounded at 128. So a hypothetical workload of only isolated, never-repeating suppressions would be marginally more expensive; the observed workload (1,459 repeats/min) is ~7× cheaper.

Steady state (no storm) is therefore unchanged in practice: a lone suppressed event still emits immediately, plus ~0.3 µs — coalescing only engages on a *repeat* within 30 s.

## Security

No new surface, and one small reduction.

- **No new data is collected.** The breadcrumb payload is identical to before; the only added field is the integer `suppressedSinceLast`.
- **The coalesce key never leaves memory.** It is built from the already-sanitized breadcrumb fields, used solely as an in-memory `Map` key, and is never written to disk, telemetry, or the crash report. Only its *effect* (which breadcrumb is emitted) is observable.
- **Less sensitive data at rest, not more.** Fewer records written means less crash context persisted to the on-disk NDJSON trace.
- **Sanitization is untouched** — `sanitizeCrashReportDetails` / `sanitizeCrashReportString` run exactly as before, via the same shared `buildLifecycleData` helper used by both the coalesced and non-coalesced paths.
- **No change to what is suppressed.** `RECOVERABLE_UTILITY_SERVICE_NAMES` and `shouldRecordProcessGoneCrash()` are not modified, so no crash that was reported before is unreported now.

## Trade-offs

One, stated honestly: **exact per-event timestamps for repeated suppressed events within a 30 s window are no longer individually recorded.** If you needed to reconstruct the precise millisecond arrival pattern of a recoverable-service crash loop from a diagnostic bundle, you now get a count instead of individual records.

I judge this clearly worth it — that per-event precision is what was destroying the surrounding evidence, the rate is still recoverable from `suppressedSinceLast` over the window, and it is the same trade already accepted for renderer error storms.

## Adversarial review

Two independent reviewers (frontier model + verification pass), covering diagnostic loss, the untouched real-crash path, shared-state coupling, security, perf, and `suppressedSinceLast` correctness. Results summarized in a comment below.

## Related

Follows the same pattern established by the renderer-error breadcrumb coalescing added for #8260. Complements #10643 (macOS Graphite) and #10646 (GPU-fallback invariant test) from the same crash-triage sweep.
