### PR TITLE
fix(worktree): resolve multi-host identity from worktree host without uncaught errors

### DIFF
--- a/src/renderer/src/lib/terminal-worktree-route.test.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.test.ts
@@ -72,6 +72,73 @@ describe('resolveTerminalWorktreeRoute', () => {
   it('does not treat a folder workspace as an unresolved worktree', () => {
     expect(resolveTerminalWorktreeRoute(localState(), folderWorkspaceKey('abc-123'))).not.toBeNull()
   })
+
+  it('routes a focused-host copy when the same worktree id is projected on two hosts (#10491)', () => {
+    const state = localState({
+      settings: { activeRuntimeEnvironmentId: 'hub-a' },
+      runtimeEnvironments: [{ id: 'hub-a' }, { id: 'hub-b' }],
+      worktreesByRepo: {
+        'repo-1': [
+          { id: 'repo-1::/w', repoId: 'repo-1', hostId: 'local' },
+          {
+            id: 'repo-1::/w',
+            repoId: 'repo-1',
+            hostId: 'ssh:private-target',
+            runtimeOwnerEnvironmentId: 'hub-a'
+          }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+    expect(resolveTerminalWorktreeRoute(state, 'repo-1::/w')).toEqual({
+      runtimeEnvironmentId: 'hub-a'
+    })
+  })
+
+  it('fails closed when multi-host projections share an id and focus matches none (#10491)', () => {
+    const state = localState({
+      settings: { activeRuntimeEnvironmentId: 'hub-c' },
+      runtimeEnvironments: [{ id: 'hub-a' }, { id: 'hub-b' }, { id: 'hub-c' }],
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'repo-1::/w',
+            repoId: 'repo-1',
+            hostId: 'ssh:private-a',
+            runtimeOwnerEnvironmentId: 'hub-a'
+          },
+          {
+            id: 'repo-1::/w',
+            repoId: 'repo-1',
+            hostId: 'ssh:private-b',
+            runtimeOwnerEnvironmentId: 'hub-b'
+          }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+    expect(resolveTerminalWorktreeRoute(state, 'repo-1::/w')).toBeNull()
+  })
+
+  it('routes a host-stamped worktree when the project is multi-host (#10634)', () => {
+    const state = localState({
+      repos: [
+        { id: 'repo-1', connectionId: null, executionHostId: 'local' },
+        { id: 'repo-1', connectionId: 'ssh-1', executionHostId: 'ssh:ssh-1' }
+      ],
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'repo-1::/w',
+            repoId: 'repo-1',
+            hostId: 'ssh:ssh-1',
+            runtimeOwnerEnvironmentId: undefined
+          }
+        ]
+      }
+    } as unknown as Partial<AppState>)
+    expect(resolveTerminalWorktreeRoute(state, 'repo-1::/w')).toEqual({
+      runtimeEnvironmentId: null
+    })
+  })
 })
 
 // STA-2639: teardown must follow the PTY's real host while spawn stays free to prefer a focused

--- a/src/renderer/src/lib/worktree-operation-route-focus.ts
+++ b/src/renderer/src/lib/worktree-operation-route-focus.ts
@@ -1,0 +1,72 @@
+import {
+  getSettingsFocusedExecutionHostId,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
+
+export type WorktreeOperationRoute = {
+  executionHostId: ExecutionHostId | null
+  runtimeEnvironmentId: string | null
+}
+
+export type WorktreeOperationRouteResolution =
+  | { kind: 'resolved'; route: WorktreeOperationRoute }
+  | { kind: 'ambiguous' }
+  | { kind: 'missing' }
+
+function routeMatchesFocusedHost(
+  route: WorktreeOperationRoute,
+  focusedHostId: ExecutionHostId
+): boolean {
+  if (route.executionHostId === focusedHostId) {
+    return true
+  }
+  // Why: HUB-owned SSH rows keep executionHostId=ssh:* while transport ownership is the runtime.
+  const focused = parseExecutionHostId(focusedHostId)
+  return (
+    focused?.kind === 'runtime' &&
+    route.runtimeEnvironmentId != null &&
+    route.runtimeEnvironmentId === focused.environmentId
+  )
+}
+
+// Why: same worktree/repo id can project on multiple hosts; only collapse when focus selects one (#10491).
+export function preferFocusedRoute(
+  routes: Iterable<WorktreeOperationRoute>,
+  settings: { activeRuntimeEnvironmentId?: string | null } | null | undefined
+): WorktreeOperationRoute | null {
+  const candidates = [...routes]
+  if (candidates.length === 0) {
+    return null
+  }
+  if (candidates.length === 1) {
+    return candidates[0]
+  }
+  const focusedHostId = getSettingsFocusedExecutionHostId(settings)
+  const focusedMatches = candidates.filter((route) => routeMatchesFocusedHost(route, focusedHostId))
+  return focusedMatches.length === 1 ? focusedMatches[0] : null
+}
+
+export function resolveFromCandidateRoutes(
+  routes: Map<string, WorktreeOperationRoute>,
+  settings: { activeRuntimeEnvironmentId?: string | null } | null | undefined
+): WorktreeOperationRouteResolution {
+  if (routes.size === 0) {
+    return { kind: 'missing' }
+  }
+  const preferred = preferFocusedRoute(routes.values(), settings)
+  if (preferred) {
+    return { kind: 'resolved', route: preferred }
+  }
+  return routes.size > 1 ? { kind: 'ambiguous' } : { kind: 'missing' }
+}
+
+export function addOperationRoute(
+  routes: Map<string, WorktreeOperationRoute>,
+  route: WorktreeOperationRoute | null
+): void {
+  if (!route) {
+    return
+  }
+  routes.set(JSON.stringify(route), route)
+}

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -60,7 +60,7 @@ describe('resolveWorktreeOperationRouteResult', () => {
     })
   })
 
-  it('fails closed when the same SSH worktree is projected by two HUBs', () => {
+  it('prefers the focused HUB when the same SSH worktree is projected by two HUBs (#10491)', () => {
     expect(
       resolveWorktreeOperationRouteResult(
         {
@@ -74,10 +74,66 @@ describe('resolveWorktreeOperationRouteResult', () => {
         },
         WORKTREE_ID
       )
+    ).toEqual({
+      kind: 'resolved',
+      route: {
+        executionHostId: 'ssh:same-private-target',
+        runtimeEnvironmentId: 'hub-a'
+      }
+    })
+  })
+
+  it('fails closed when two HUB projections share an id and focus matches neither', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
+          worktreesByRepo: {
+            'repo-1': [
+              worktree('ssh:same-private-target', 'hub-a'),
+              worktree('ssh:same-private-target', 'hub-b')
+            ]
+          }
+        },
+        WORKTREE_ID
+      )
     ).toEqual({ kind: 'ambiguous' })
   })
 
-  it('resolves a host-stamped SSH worktree when its project also exists locally (#10634)', () => {
+  it('prefers the local projection when local focus selects one of two host copies (#10491)', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          worktreesByRepo: {
+            'repo-1': [worktree('local'), worktree('ssh:ssh-1', 'hub-a')]
+          }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
+  })
+
+  it('prefers the runtime projection when runtime focus selects one of two host copies (#10491)', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          settings: { activeRuntimeEnvironmentId: 'hub-a' } as never,
+          worktreesByRepo: {
+            'repo-1': [worktree('local'), worktree('runtime:hub-a')]
+          }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'runtime:hub-a', runtimeEnvironmentId: 'hub-a' }
+    })
+  })
+
+  it('resolves host-stamped SSH worktree even when the project exists on local + SSH (#10634)', () => {
     expect(
       resolveWorktreeOperationRouteResult(
         {
@@ -94,6 +150,26 @@ describe('resolveWorktreeOperationRouteResult', () => {
     ).toEqual({
       kind: 'resolved',
       route: { executionHostId: 'ssh:ssh-1', runtimeEnvironmentId: null }
+    })
+  })
+
+  it('resolves host-stamped local worktree even when the project exists on local + SSH (#10634)', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          repos: [
+            { id: 'repo-1', executionHostId: 'local' },
+            { id: 'repo-1', connectionId: 'ssh-1', executionHostId: 'ssh:ssh-1' }
+          ],
+          worktreesByRepo: {
+            'repo-1': [worktree('local')]
+          }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
     })
   })
 

--- a/src/renderer/src/lib/worktree-operation-route.test.ts
+++ b/src/renderer/src/lib/worktree-operation-route.test.ts
@@ -153,6 +153,29 @@ describe('resolveWorktreeOperationRouteResult', () => {
     })
   })
 
+  it('scopes explicit-route scan to the worktree repoId (ignores other repos)', () => {
+    expect(
+      resolveWorktreeOperationRouteResult(
+        {
+          worktreesByRepo: {
+            'repo-other': [
+              {
+                id: WORKTREE_ID,
+                repoId: 'repo-other',
+                hostId: 'ssh:wrong-host'
+              } as Worktree
+            ],
+            'repo-1': [worktree('local')]
+          }
+        },
+        WORKTREE_ID
+      )
+    ).toEqual({
+      kind: 'resolved',
+      route: { executionHostId: 'local', runtimeEnvironmentId: null }
+    })
+  })
+
   it('resolves host-stamped local worktree even when the project exists on local + SSH (#10634)', () => {
     expect(
       resolveWorktreeOperationRouteResult(

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -7,22 +7,19 @@ import {
 } from '../../../shared/execution-host'
 import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '@/store/slices/worktree-helpers'
-import { resolveIndexedWorktreeOwner } from './worktree-runtime-owner-index'
 import {
   findFolderWorkspaceOwner,
   getExecutionHostIdForFolderWorkspace,
   type FolderWorkspaceRuntimeOwnerState
 } from './folder-workspace-runtime-owner'
+import {
+  addOperationRoute,
+  resolveFromCandidateRoutes,
+  type WorktreeOperationRoute,
+  type WorktreeOperationRouteResolution
+} from './worktree-operation-route-focus'
 
-export type WorktreeOperationRoute = {
-  executionHostId: ExecutionHostId | null
-  runtimeEnvironmentId: string | null
-}
-
-export type WorktreeOperationRouteResolution =
-  | { kind: 'resolved'; route: WorktreeOperationRoute }
-  | { kind: 'ambiguous' }
-  | { kind: 'missing' }
+export type { WorktreeOperationRoute, WorktreeOperationRouteResolution }
 
 type WorktreeOperationOwnerRecord = {
   id: string
@@ -62,14 +59,35 @@ function routeForOwner(owner: {
   }
 }
 
-function addRoute(
-  routes: Map<string, WorktreeOperationRoute>,
-  route: WorktreeOperationRoute | null
-): void {
-  if (!route) {
-    return
+function collectRepoOperationRoutes(
+  repos: WorktreeOperationRouteState['repos'],
+  repoId: string
+): Map<string, WorktreeOperationRoute> {
+  const routes = new Map<string, WorktreeOperationRoute>()
+  if (!repos) {
+    return routes
   }
-  routes.set(JSON.stringify(route), route)
+  for (const repo of repos) {
+    if (repo.id !== repoId) {
+      continue
+    }
+    if (!repo.executionHostId?.trim() && !repo.connectionId?.trim()) {
+      continue
+    }
+    addOperationRoute(routes, routeForOwner({ hostId: getRepoExecutionHostId(repo) }))
+  }
+  return routes
+}
+
+function resolveRepoOperationRoute(
+  state: WorktreeOperationRouteState,
+  repoId: string
+): WorktreeOperationRouteResolution {
+  const indexed = resolveIndexedRepoOperationRoute(state.repos, repoId)
+  if (indexed.kind !== 'ambiguous') {
+    return indexed
+  }
+  return resolveFromCandidateRoutes(collectRepoOperationRoutes(state.repos, repoId), state.settings)
 }
 
 function resolveRepoRouteForSshOwner(
@@ -88,7 +106,7 @@ function resolveRepoRouteForSshOwner(
     if (getRepoExecutionHostId(repo) !== owner.hostId && connectionHostId !== owner.hostId) {
       continue
     }
-    addRoute(routes, routeForOwner({ hostId: getRepoExecutionHostId(repo) }))
+    addOperationRoute(routes, routeForOwner({ hostId: getRepoExecutionHostId(repo) }))
   }
   const route = routes.values().next().value
   if (routes.size === 1 && route) {
@@ -108,11 +126,9 @@ function resolveExactWorktreeRoute(
   if (route.runtimeEnvironmentId || parseExecutionHostId(route.executionHostId)?.kind !== 'ssh') {
     return { kind: 'resolved', route }
   }
-  // Recover an optional HUB transport only from the repo setup matching the worktree's SSH host.
+  // Why: recover optional HUB transport only from the matching SSH host; never treat multi-host
+  // project as worktree ambiguity when the row already carries its own hostId (#10634).
   const repoRoute = resolveRepoRouteForSshOwner(state.repos, owner)
-  if (repoRoute.kind === 'ambiguous') {
-    return repoRoute
-  }
   if (repoRoute.kind === 'resolved' && repoRoute.route.runtimeEnvironmentId) {
     return {
       kind: 'resolved',
@@ -120,6 +136,28 @@ function resolveExactWorktreeRoute(
     }
   }
   return { kind: 'resolved', route }
+}
+
+function collectOwnerRoutes(
+  state: WorktreeOperationRouteState,
+  owners: Iterable<WorktreeOperationOwnerRecord>,
+  worktreeId: string,
+  exactRoutes: Map<string, WorktreeOperationRoute>,
+  exactRepoIds: Set<string>
+): void {
+  for (const worktree of owners) {
+    if (worktree.id !== worktreeId) {
+      continue
+    }
+    exactRepoIds.add(worktree.repoId)
+    const resolution = resolveExactWorktreeRoute(state, worktree)
+    if (resolution.kind === 'resolved') {
+      addOperationRoute(exactRoutes, resolution.route)
+    } else if (resolution.kind === 'ambiguous') {
+      // Why: bare SSH route when multi-host repo recovery stays ambiguous; focus may still pick.
+      addOperationRoute(exactRoutes, routeForOwner(worktree))
+    }
+  }
 }
 
 export function resolveWorktreeOperationRoute(
@@ -214,59 +252,31 @@ export function resolveExplicitWorktreeOperationRouteResult(
 ): WorktreeOperationRouteResolution {
   const exactRoutes = new Map<string, WorktreeOperationRoute>()
   const exactRepoIds = new Set<string>()
-  const indexedWorktree = resolveIndexedWorktreeOwner(state.worktreesByRepo, worktreeId)
-  if (indexedWorktree.kind === 'ambiguous') {
-    return { kind: 'ambiguous' }
-  }
-  if (indexedWorktree.kind === 'resolved') {
-    exactRepoIds.add(indexedWorktree.owner.repoId)
-    const resolution = resolveExactWorktreeRoute(state, indexedWorktree.owner)
-    if (resolution.kind === 'ambiguous') {
-      return resolution
-    }
-    if (resolution.kind === 'resolved') {
-      addRoute(exactRoutes, resolution.route)
-    }
+  // Why: scan every projection so focus can select the unique active-host owner (#10491).
+  for (const worktrees of Object.values(state.worktreesByRepo ?? {})) {
+    collectOwnerRoutes(state, worktrees, worktreeId, exactRoutes, exactRepoIds)
   }
   for (const result of Object.values(state.detectedWorktreesByRepo ?? {})) {
-    for (const worktree of result.worktrees) {
-      if (worktree.id === worktreeId) {
-        exactRepoIds.add(worktree.repoId)
-        const resolution = resolveExactWorktreeRoute(state, worktree)
-        if (resolution.kind === 'ambiguous') {
-          return resolution
-        }
-        if (resolution.kind === 'resolved') {
-          addRoute(exactRoutes, resolution.route)
-        }
-      }
-    }
+    collectOwnerRoutes(state, result.worktrees, worktreeId, exactRoutes, exactRepoIds)
   }
   if (exactRoutes.size > 0) {
-    const route = exactRoutes.values().next().value
-    return exactRoutes.size === 1 && route ? { kind: 'resolved', route } : { kind: 'ambiguous' }
+    return resolveFromCandidateRoutes(exactRoutes, state.settings)
   }
   if (exactRepoIds.size === 0) {
     exactRepoIds.add(getRepoIdFromWorktreeId(worktreeId))
   }
   const repoRoutes = new Map<string, WorktreeOperationRoute>()
   for (const repoId of exactRepoIds) {
-    const resolution = resolveIndexedRepoOperationRoute(state.repos, repoId)
-    if (resolution.kind === 'ambiguous') {
-      return resolution
-    }
+    const resolution = resolveRepoOperationRoute(state, repoId)
     if (resolution.kind === 'resolved') {
-      addRoute(repoRoutes, resolution.route)
+      addOperationRoute(repoRoutes, resolution.route)
+    } else if (resolution.kind === 'ambiguous') {
+      for (const route of collectRepoOperationRoutes(state.repos, repoId).values()) {
+        addOperationRoute(repoRoutes, route)
+      }
     }
   }
-  const route = repoRoutes.values().next().value
-  if (repoRoutes.size === 1 && route) {
-    return { kind: 'resolved', route }
-  }
-  if (repoRoutes.size > 1) {
-    return { kind: 'ambiguous' }
-  }
-  return { kind: 'missing' }
+  return resolveFromCandidateRoutes(repoRoutes, state.settings)
 }
 
 function resolveIndexedRepoOperationRoute(

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -252,18 +252,21 @@ export function resolveExplicitWorktreeOperationRouteResult(
 ): WorktreeOperationRouteResolution {
   const exactRoutes = new Map<string, WorktreeOperationRoute>()
   const exactRepoIds = new Set<string>()
-  // Why: scan every projection so focus can select the unique active-host owner (#10491).
-  for (const worktrees of Object.values(state.worktreesByRepo ?? {})) {
-    collectOwnerRoutes(state, worktrees, worktreeId, exactRoutes, exactRepoIds)
+  // Why: multi-host dupes share one repoId key; scanning every repo is O(total worktrees) (#10491).
+  const repoId = getRepoIdFromWorktreeId(worktreeId)
+  const ownedWorktrees = state.worktreesByRepo?.[repoId]
+  if (ownedWorktrees) {
+    collectOwnerRoutes(state, ownedWorktrees, worktreeId, exactRoutes, exactRepoIds)
   }
-  for (const result of Object.values(state.detectedWorktreesByRepo ?? {})) {
-    collectOwnerRoutes(state, result.worktrees, worktreeId, exactRoutes, exactRepoIds)
+  const ownedDetected = state.detectedWorktreesByRepo?.[repoId]?.worktrees
+  if (ownedDetected) {
+    collectOwnerRoutes(state, ownedDetected, worktreeId, exactRoutes, exactRepoIds)
   }
   if (exactRoutes.size > 0) {
     return resolveFromCandidateRoutes(exactRoutes, state.settings)
   }
   if (exactRepoIds.size === 0) {
-    exactRepoIds.add(getRepoIdFromWorktreeId(worktreeId))
+    exactRepoIds.add(repoId)
   }
   const repoRoutes = new Map<string, WorktreeOperationRoute>()
   for (const repoId of exactRepoIds) {

--- a/src/renderer/src/lib/worktree-runtime-owner.test.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner.test.ts
@@ -230,9 +230,44 @@ describe('getExplicitRuntimeEnvironmentIdForWorktree', () => {
     )
   })
 
-  it('fails closed for conflicting detected-only HUB ownership', () => {
+  it('prefers the focused HUB for conflicting detected-only ownership (#10491)', () => {
     const ambiguousState: WorktreeRuntimeOwnerState = {
       settings: { activeRuntimeEnvironmentId: 'hub-a' },
+      repos: [],
+      worktreesByRepo: {},
+      detectedWorktreesByRepo: {
+        'repo-a': {
+          worktrees: [
+            {
+              id: 'shared-worktree',
+              repoId: 'repo-a',
+              hostId: 'ssh:private-a',
+              runtimeOwnerEnvironmentId: 'hub-a'
+            }
+          ]
+        },
+        'repo-b': {
+          worktrees: [
+            {
+              id: 'shared-worktree',
+              repoId: 'repo-b',
+              hostId: 'ssh:private-b',
+              runtimeOwnerEnvironmentId: 'hub-b'
+            }
+          ]
+        }
+      }
+    }
+
+    expect(getExplicitRuntimeEnvironmentIdForWorktree(ambiguousState, 'shared-worktree')).toBe(
+      'hub-a'
+    )
+    expect(getExecutionHostIdForWorktree(ambiguousState, 'shared-worktree')).toBe('ssh:private-a')
+  })
+
+  it('fails closed for conflicting detected-only ownership when focus matches neither', () => {
+    const ambiguousState: WorktreeRuntimeOwnerState = {
+      settings: { activeRuntimeEnvironmentId: 'hub-c' },
       repos: [],
       worktreesByRepo: {},
       detectedWorktreesByRepo: {

--- a/src/renderer/src/runtime/file-explorer-delete-owner-provenance.test.ts
+++ b/src/renderer/src/runtime/file-explorer-delete-owner-provenance.test.ts
@@ -379,11 +379,15 @@ describe('file explorer deletion owner provenance', () => {
     expect(fsDeletePath).not.toHaveBeenCalled()
   })
 
-  it('fails closed when an exact worktree ID belongs to multiple hosts', async () => {
+  it('fails closed when an exact worktree ID belongs to multiple hosts and focus matches neither', async () => {
     useAppStore.setState({
-      repos: duplicateHostRepos(),
+      settings: { activeRuntimeEnvironmentId: 'other-hub' } as never,
+      repos: [],
       worktreesByRepo: {
-        [LOCAL_REPO_ID]: [makeWorktree('local'), makeWorktree(`ssh:${SSH_ID}`)]
+        [LOCAL_REPO_ID]: [
+          makeWorktree(`ssh:${SSH_ID}`, 'hub-a'),
+          makeWorktree(`ssh:${SSH_ID}`, 'hub-b')
+        ]
       }
     })
     const owner = getFileExplorerOperationOwner(LOCAL_WORKTREE_ID)
@@ -400,9 +404,13 @@ describe('file explorer deletion owner provenance', () => {
 
   it('does not pop the batch confirm for an unresolved-owner multi-select', async () => {
     useAppStore.setState({
-      repos: duplicateHostRepos(),
+      settings: { activeRuntimeEnvironmentId: 'other-hub' } as never,
+      repos: [],
       worktreesByRepo: {
-        [LOCAL_REPO_ID]: [makeWorktree('local'), makeWorktree(`ssh:${SSH_ID}`)]
+        [LOCAL_REPO_ID]: [
+          makeWorktree(`ssh:${SSH_ID}`, 'hub-a'),
+          makeWorktree(`ssh:${SSH_ID}`, 'hub-b')
+        ]
       }
     })
     const owner = getFileExplorerOperationOwner(LOCAL_WORKTREE_ID)

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -4522,10 +4522,11 @@ describe('worktree remote runtime mutations', () => {
     expect(mockApi.worktrees.remove).not.toHaveBeenCalled()
   })
 
-  it('fails HUB-owned SSH removal closed when the exact id has two HUB owners', async () => {
+  it('fails HUB-owned SSH removal closed when the exact id has two HUB owners and focus matches neither', async () => {
     const store = createTestStore()
     const worktreeId = 'repo-ssh::/srv/same-wt'
     store.setState({
+      settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
       worktreesByRepo: {
         'repo-ssh': [
           makeWorktree({
@@ -4589,25 +4590,45 @@ describe('worktree remote runtime mutations', () => {
     expect(store.getState().worktreesByRepo['repo-ssh']).toEqual([])
   })
 
-  it('fails closed before deleting an exact worktree id owned by multiple hosts', async () => {
+  it('fails closed before deleting an exact worktree id owned by multiple hosts when focus matches neither', async () => {
     const store = createTestStore()
     const worktreeId = 'repo-shared::/same/path'
     store.setState({
+      settings: { activeRuntimeEnvironmentId: 'other-hub' } as never,
       repos: [
-        { id: 'repo-shared', path: '/local', displayName: 'Local', badgeColor: '#000', addedAt: 0 },
         {
           id: 'repo-shared',
-          path: '/remote',
-          displayName: 'SSH',
+          path: '/remote-a',
+          displayName: 'SSH A',
+          badgeColor: '#000',
+          addedAt: 0,
+          connectionId: 'ssh-a',
+          executionHostId: 'runtime:hub-a'
+        },
+        {
+          id: 'repo-shared',
+          path: '/remote-b',
+          displayName: 'SSH B',
           badgeColor: '#111',
           addedAt: 1,
-          connectionId: 'ssh-1'
+          connectionId: 'ssh-b',
+          executionHostId: 'runtime:hub-b'
         }
       ],
       worktreesByRepo: {
         'repo-shared': [
-          makeWorktree({ id: worktreeId, repoId: 'repo-shared', hostId: 'local' }),
-          makeWorktree({ id: worktreeId, repoId: 'repo-shared', hostId: 'ssh:ssh-1' })
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-a',
+            runtimeOwnerEnvironmentId: 'hub-a'
+          }),
+          makeWorktree({
+            id: worktreeId,
+            repoId: 'repo-shared',
+            hostId: 'ssh:ssh-b',
+            runtimeOwnerEnvironmentId: 'hub-b'
+          })
         ]
       }
     } as Partial<AppState>)
@@ -4685,10 +4706,11 @@ describe('worktree remote runtime mutations', () => {
     expect(mockApi.worktrees.forceDeletePreservedBranch).not.toHaveBeenCalled()
   })
 
-  it('fails preserved branch deletion closed for two HUB owners', async () => {
+  it('fails preserved branch deletion closed for two HUB owners when focus matches neither', async () => {
     const store = createTestStore()
     const worktreeId = 'repo-ssh::/srv/same-wt'
     store.setState({
+      settings: { activeRuntimeEnvironmentId: 'hub-c' } as never,
       worktreesByRepo: {
         'repo-ssh': [
           makeWorktree({
@@ -6117,6 +6139,7 @@ describe('worktree unread (show-until-interact)', () => {
 
     expect(() => store.getState().markWorktreeUnread(worktreeId)).not.toThrow()
 
+    // Local UI state still flips even if owner meta cannot be routed.
     expect(store.getState().worktreesByRepo['repo-shared'][0].isUnread).toBe(true)
     expect(mockApi.worktrees.updateMeta).not.toHaveBeenCalled()
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -4404,6 +4404,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
 
     const ownerSettings = trySettingsForWorktreeOwner(get(), worktreeId)
     if (!ownerSettings) {
+      // Why: local activity already updated; skip remote meta when multi-host identity is unresolved (#10634).
       warnAmbiguousOwnerOnce(worktreeId, 'persist worktree activity timestamp')
       return
     }


### PR DESCRIPTION
## Summary
- Host-stamped worktrees resolve to their own `hostId` even when the project is registered on multiple hosts (local + SSH).
- Focused execution host can disambiguate multi-host projections when it uniquely selects one owner.
- Background paths (`markWorktreeUnread` / activity / unread clear) no longer throw uncaught renderer errors when identity is still ambiguous — UI state updates and host persist is skipped with a warn.

## Fixes
Closes #10634

## Related
- Complements focused-host preference work for #10491 / multi-host projects.
- Structural multi-host projects are valid; "Refresh projects" cannot fix them.

## Test plan
- [x] worktree-operation-route / terminal-worktree-route / runtime-owner / worktrees / file-explorer provenance tests
- [ ] Manual: import same repo on local + SSH, run terminal/agent, confirm no uncaught ambiguous identity banner from notifications

## ELI5

Worktrees registered on multiple hosts no longer throw when identity is ambiguous; they resolve via the worktree's own host or focused host, and background updates skip safely instead of crashing the UI.
