### PR TITLE
feat(ports): filter SSH ports by connecting user with show-others toggle

### DIFF
--- a/src/main/ssh/ssh-port-scanner.test.ts
+++ b/src/main/ssh/ssh-port-scanner.test.ts
@@ -169,6 +169,32 @@ describe('PortScanner', () => {
     scanner.dispose()
   })
 
+  it('excludes initial-scan and non-owned ports from auto-forward suggestions', async () => {
+    const harness = createVisibilityHarness(true)
+    let ports: DetectedPort[] = [
+      { port: 3000, host: '127.0.0.1', ownedByConnectingUser: true },
+      { port: 3001, host: '127.0.0.1', ownedByConnectingUser: false, username: 'bob' }
+    ]
+    const { mux } = createMux(() => ports)
+    const scanner = new PortScanner(harness.visibility)
+    scanner.startScanning('t1', mux, vi.fn())
+
+    await vi.advanceTimersByTimeAsync(0)
+    // First scan seeds initialPorts — nothing is a "new" suggestion.
+    expect(scanner.getAutoForwardSuggestionPorts('t1')).toEqual([])
+
+    ports = [
+      { port: 3000, host: '127.0.0.1', ownedByConnectingUser: true },
+      { port: 3001, host: '127.0.0.1', ownedByConnectingUser: false, username: 'bob' },
+      { port: 4000, host: '127.0.0.1', ownedByConnectingUser: true, processName: 'node' },
+      { port: 4001, host: '127.0.0.1', ownedByConnectingUser: false, username: 'bob' }
+    ]
+    await vi.advanceTimersByTimeAsync(BASE)
+    expect(scanner.getAutoForwardSuggestionPorts('t1').map((p) => p.port)).toEqual([4000])
+
+    scanner.dispose()
+  })
+
   it('parks when the window hides mid-run and resumes with an immediate scan on show', async () => {
     const harness = createVisibilityHarness(true)
     let next = 3000

--- a/src/main/ssh/ssh-port-scanner.ts
+++ b/src/main/ssh/ssh-port-scanner.ts
@@ -1,5 +1,6 @@
 import type { SshChannelMultiplexer } from './ssh-channel-multiplexer'
 import type { DetectedPort } from '../../shared/ssh-types'
+import { filterSshAutoForwardCandidates } from '../../shared/ssh-detected-port-ownership'
 
 // Why: every tick walks /proc/*/fd on the remote relay, so cadence is remote
 // CPU, not just a local timer. 12s cuts steady-state request volume 4x vs the
@@ -134,6 +135,18 @@ export class PortScanner {
     return Array.from(handle.previousPorts.values())
   }
 
+  /** Ports eligible for auto-forward: not initial-scan noise, and owned when known. */
+  getAutoForwardSuggestionPorts(targetId: string): DetectedPort[] {
+    const handle = this.handles.get(targetId)
+    if (!handle || handle.initialPorts === null) {
+      return []
+    }
+    return filterSshAutoForwardCandidates(
+      Array.from(handle.previousPorts.values()),
+      handle.initialPorts
+    )
+  }
+
   stopScanning(targetId: string): void {
     const handle = this.handles.get(targetId)
     if (!handle) {
@@ -162,7 +175,13 @@ function portsEqual(a: Map<string, DetectedPort>, b: Map<string, DetectedPort>):
     if (!entryB) {
       return false
     }
-    if (entryA.pid !== entryB.pid || entryA.processName !== entryB.processName) {
+    if (
+      entryA.pid !== entryB.pid ||
+      entryA.processName !== entryB.processName ||
+      entryA.uid !== entryB.uid ||
+      entryA.username !== entryB.username ||
+      entryA.ownedByConnectingUser !== entryB.ownedByConnectingUser
+    ) {
       return false
     }
   }

--- a/src/relay/port-scan-handler.test.ts
+++ b/src/relay/port-scan-handler.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
-import { parseHexAddress } from './port-scan-handler'
+import {
+  ownershipFieldsForSocket,
+  parseHexAddress,
+  parsePasswdUidUsernames,
+  parseProcNetListeningSockets,
+  resolveUsernameForUid
+} from './port-scan-handler'
 import { parseWindowsNetstatOutput, parseWindowsPowerShellPortRows } from './windows-port-scan'
 
 describe('parseHexAddress', () => {
@@ -65,6 +71,66 @@ describe('parseHexAddress', () => {
   it('parses port 3306 (mysql)', () => {
     const result = parseHexAddress('00000000:0CEA')
     expect(result).toEqual({ host: '0.0.0.0', port: 3306 })
+  })
+})
+
+describe('parseProcNetListeningSockets', () => {
+  it('parses listen rows with owner uid', () => {
+    const content = [
+      '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode',
+      '   0: 0100007F:0BB8 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 12345 1 0000000000000000 100 0 0 10 0',
+      '   1: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1001        0 12346 1 0000000000000000 100 0 0 10 0',
+      // ESTABLISHED — ignored
+      '   2: 0100007F:0BB9 0100007F:ABCD 01 00000000:00000000 00:00000000 00000000  1000        0 12347 1 0000000000000000 100 0 0 10 0'
+    ].join('\n')
+
+    expect(parseProcNetListeningSockets(content)).toEqual([
+      { host: '127.0.0.1', port: 3000, inode: 12345, uid: 1000 },
+      { host: '0.0.0.0', port: 8080, inode: 12346, uid: 1001 }
+    ])
+  })
+
+  it('skips rows with invalid uid or inode', () => {
+    const content = [
+      '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode',
+      '   0: 0100007F:0BB8 00000000:0000 0A 00000000:00000000 00:00000000 00000000  notuid     0 12345 1',
+      '   1: 0100007F:0BB9 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 0 1'
+    ].join('\n')
+
+    expect(parseProcNetListeningSockets(content)).toEqual([])
+  })
+})
+
+describe('parsePasswdUidUsernames / ownershipFieldsForSocket', () => {
+  it('resolves usernames from passwd content', () => {
+    const map = parsePasswdUidUsernames(
+      ['root:x:0:0:root:/root:/bin/bash', 'alice:x:1000:1000:Alice:/home/alice:/bin/bash', ''].join(
+        '\n'
+      )
+    )
+    expect(map.get(0)).toBe('root')
+    expect(map.get(1000)).toBe('alice')
+    expect(resolveUsernameForUid(1000, map)).toBe('alice')
+    expect(resolveUsernameForUid(42, map)).toBe('42')
+  })
+
+  it('marks ownership against the connecting uid and falls back to numeric username', () => {
+    const empty = new Map<number, string>()
+    expect(ownershipFieldsForSocket(1000, 1000, empty)).toEqual({
+      uid: 1000,
+      username: '1000',
+      ownedByConnectingUser: true
+    })
+    expect(ownershipFieldsForSocket(1001, 1000, empty)).toEqual({
+      uid: 1001,
+      username: '1001',
+      ownedByConnectingUser: false
+    })
+    // Why: no getuid (e.g. constrained environments) → leave ownership flag unset.
+    expect(ownershipFieldsForSocket(1000, undefined, empty)).toEqual({
+      uid: 1000,
+      username: '1000'
+    })
   })
 })
 

--- a/src/relay/port-scan-handler.test.ts
+++ b/src/relay/port-scan-handler.test.ts
@@ -90,14 +90,16 @@ describe('parseProcNetListeningSockets', () => {
     ])
   })
 
-  it('skips rows with invalid uid or inode', () => {
+  it('keeps listen rows with invalid uid but drops invalid inode', () => {
     const content = [
       '  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode',
       '   0: 0100007F:0BB8 00000000:0000 0A 00000000:00000000 00:00000000 00000000  notuid     0 12345 1',
       '   1: 0100007F:0BB9 00000000:0000 0A 00000000:00000000 00:00000000 00000000  1000        0 0 1'
     ].join('\n')
 
-    expect(parseProcNetListeningSockets(content)).toEqual([])
+    expect(parseProcNetListeningSockets(content)).toEqual([
+      { host: '127.0.0.1', port: 3000, inode: 12345, uid: undefined }
+    ])
   })
 })
 
@@ -131,6 +133,8 @@ describe('parsePasswdUidUsernames / ownershipFieldsForSocket', () => {
       uid: 1000,
       username: '1000'
     })
+    // Why: unparseable /proc uid → surface the port without ownership metadata.
+    expect(ownershipFieldsForSocket(undefined, 1000, empty)).toEqual({})
   })
 })
 

--- a/src/relay/port-scan-handler.ts
+++ b/src/relay/port-scan-handler.ts
@@ -18,7 +18,8 @@ type ProcNetSocket = {
   port: number
   host: string
   inode: number
-  uid: number
+  /** Absent when /proc uid field is malformed — port still surfaces without ownership. */
+  uid?: number
 }
 
 const SYSTEM_PORTS_TO_EXCLUDE = new Set([22])
@@ -218,10 +219,9 @@ export function parseProcNetListeningSockets(content: string): ProcNetSocket[] {
       continue
     }
 
-    const uid = Number.parseInt(fields[7], 10)
-    if (Number.isNaN(uid) || uid < 0) {
-      continue
-    }
+    // Why: degrade uid like pid — keep the listen row when ownership metadata is unparseable.
+    const parsedUid = Number.parseInt(fields[7], 10)
+    const uid = Number.isNaN(parsedUid) || parsedUid < 0 ? undefined : parsedUid
 
     results.push({ port: parsed.port, host: parsed.host, inode, uid })
   }
@@ -255,10 +255,13 @@ export function resolveUsernameForUid(uid: number, uidUsernames: Map<number, str
 }
 
 export function ownershipFieldsForSocket(
-  uid: number,
+  uid: number | undefined,
   connectingUid: number | undefined,
   uidUsernames: Map<number, string>
 ): Pick<DetectedPort, 'uid' | 'username' | 'ownedByConnectingUser'> {
+  if (uid === undefined) {
+    return {}
+  }
   return {
     uid,
     username: resolveUsernameForUid(uid, uidUsernames),

--- a/src/relay/port-scan-handler.ts
+++ b/src/relay/port-scan-handler.ts
@@ -9,6 +9,16 @@ export type DetectedPort = {
   host: string
   pid?: number
   processName?: string
+  uid?: number
+  username?: string
+  ownedByConnectingUser?: boolean
+}
+
+type ProcNetSocket = {
+  port: number
+  host: string
+  inode: number
+  uid: number
 }
 
 const SYSTEM_PORTS_TO_EXCLUDE = new Set([22])
@@ -38,9 +48,10 @@ export class PortScanHandler {
   }
 
   private async scanLinuxListeningPorts(): Promise<DetectedPort[]> {
-    const [tcp4, tcp6] = await Promise.all([
+    const [tcp4, tcp6, uidUsernames] = await Promise.all([
       this.readProcNet('/proc/net/tcp'),
-      this.readProcNet('/proc/net/tcp6')
+      this.readProcNet('/proc/net/tcp6'),
+      this.loadUidUsernameMap()
     ])
 
     const listeningSockets = [...tcp4, ...tcp6]
@@ -55,6 +66,7 @@ export class PortScanHandler {
     const results: DetectedPort[] = []
     const relayPid = process.pid
     const relayParentPid = process.ppid
+    const connectingUid = typeof process.getuid === 'function' ? process.getuid() : undefined
 
     for (const socket of listeningSockets) {
       const key = `${socket.host}:${socket.port}`
@@ -78,11 +90,13 @@ export class PortScanHandler {
         continue
       }
 
+      const ownership = ownershipFieldsForSocket(socket.uid, connectingUid, uidUsernames)
       results.push({
         port: socket.port,
         host: socket.host,
         pid: pid ?? undefined,
-        processName
+        processName,
+        ...ownership
       })
     }
 
@@ -92,45 +106,22 @@ export class PortScanHandler {
     return results.slice(0, MAX_DETECTED_PORTS)
   }
 
-  private async readProcNet(
-    path: string
-  ): Promise<{ port: number; host: string; inode: number }[]> {
+  private async readProcNet(path: string): Promise<ProcNetSocket[]> {
     let content: string
     try {
       content = await readFile(path, 'utf-8')
     } catch {
       return []
     }
+    return parseProcNetListeningSockets(content)
+  }
 
-    const lines = content.split('\n')
-    const results: { port: number; host: string; inode: number }[] = []
-
-    for (let i = 1; i < lines.length; i++) {
-      const fields = getProcessOutputFields(lines[i], 10)
-      if (fields.length < 10) {
-        continue
-      }
-
-      // State field (index 3): 0A = TCP_LISTEN
-      if (fields[3] !== '0A') {
-        continue
-      }
-
-      const localAddress = fields[1]
-      const parsed = parseHexAddress(localAddress)
-      if (!parsed) {
-        continue
-      }
-
-      const inode = Number.parseInt(fields[9], 10)
-      if (Number.isNaN(inode) || inode === 0) {
-        continue
-      }
-
-      results.push({ port: parsed.port, host: parsed.host, inode })
+  private async loadUidUsernameMap(): Promise<Map<number, string>> {
+    try {
+      return parsePasswdUidUsernames(await readFile('/etc/passwd', 'utf-8'))
+    } catch {
+      return new Map()
     }
-
-    return results
   }
 
   private async mapInodesToPids(inodes: Set<number>): Promise<Map<number, number>> {
@@ -197,6 +188,81 @@ export class PortScanHandler {
     } catch {
       return undefined
     }
+  }
+}
+
+/** Parse /proc/net/tcp(6) listen rows including owner uid (field index 7). */
+export function parseProcNetListeningSockets(content: string): ProcNetSocket[] {
+  const lines = content.split('\n')
+  const results: ProcNetSocket[] = []
+
+  for (let i = 1; i < lines.length; i++) {
+    // Why: need through inode (index 9); uid is index 7 on the standard table.
+    const fields = getProcessOutputFields(lines[i], 10)
+    if (fields.length < 10) {
+      continue
+    }
+
+    // State field (index 3): 0A = TCP_LISTEN
+    if (fields[3] !== '0A') {
+      continue
+    }
+
+    const parsed = parseHexAddress(fields[1])
+    if (!parsed) {
+      continue
+    }
+
+    const inode = Number.parseInt(fields[9], 10)
+    if (Number.isNaN(inode) || inode === 0) {
+      continue
+    }
+
+    const uid = Number.parseInt(fields[7], 10)
+    if (Number.isNaN(uid) || uid < 0) {
+      continue
+    }
+
+    results.push({ port: parsed.port, host: parsed.host, inode, uid })
+  }
+
+  return results
+}
+
+/** Map uid → username from /etc/passwd contents. */
+export function parsePasswdUidUsernames(content: string): Map<number, string> {
+  const map = new Map<number, string>()
+  for (const line of content.split('\n')) {
+    if (!line || line.startsWith('#')) {
+      continue
+    }
+    const parts = line.split(':')
+    if (parts.length < 3) {
+      continue
+    }
+    const username = parts[0]
+    const uid = Number.parseInt(parts[2], 10)
+    if (!username || Number.isNaN(uid) || uid < 0) {
+      continue
+    }
+    map.set(uid, username)
+  }
+  return map
+}
+
+export function resolveUsernameForUid(uid: number, uidUsernames: Map<number, string>): string {
+  return uidUsernames.get(uid) ?? String(uid)
+}
+
+export function ownershipFieldsForSocket(
+  uid: number,
+  connectingUid: number | undefined,
+  uidUsernames: Map<number, string>
+): Pick<DetectedPort, 'uid' | 'username' | 'ownedByConnectingUser'> {
+  return {
+    uid,
+    username: resolveUsernameForUid(uid, uidUsernames),
+    ...(connectingUid !== undefined ? { ownedByConnectingUser: uid === connectingUid } : {})
   }
 }
 

--- a/src/renderer/src/components/right-sidebar/PortsPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/PortsPanel.tsx
@@ -57,6 +57,15 @@ import {
 } from '@/components/ui/context-menu'
 import type { PortForwardEntry, EnrichedDetectedPort } from '../../../../shared/ssh-types'
 import type { WorkspacePort } from '../../../../shared/workspace-ports'
+import {
+  shouldIncludeSshDetectedPortInPanel,
+  sshDetectedPortOwnershipFilteringActive
+} from '../../../../shared/ssh-detected-port-ownership'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  readSshPortsShowOtherUsers,
+  writeSshPortsShowOtherUsers
+} from './ssh-ports-other-users-preference'
 import { translate } from '@/i18n/i18n'
 
 export {
@@ -831,6 +840,20 @@ function SshPortsPanel(): React.JSX.Element {
     return set
   }, [allForwards])
 
+  const [showOtherUsers, setShowOtherUsers] = useState(() => readSshPortsShowOtherUsers())
+  const [forwardedCollapsed, setForwardedCollapsed] = useState(false)
+  const [detectedCollapsed, setDetectedCollapsed] = useState(false)
+  const [dialogState, setDialogState] = useState<PortForwardDialogState>({ mode: 'closed' })
+
+  const ownershipFilteringActive = useMemo(() => {
+    if (!activeConnectionId) {
+      return false
+    }
+    return sshDetectedPortOwnershipFilteringActive(
+      detectedPortsByConnection[activeConnectionId] ?? []
+    )
+  }, [detectedPortsByConnection, activeConnectionId])
+
   const allDetected = useMemo(() => {
     if (!activeConnectionId) {
       return []
@@ -838,13 +861,27 @@ function SshPortsPanel(): React.JSX.Element {
     const ports = detectedPortsByConnection[activeConnectionId] ?? []
     return ports
       .filter((p) => !forwardedKeys.has(`${normalizeHost(p.host)}:${p.port}`))
+      .filter((p) =>
+        shouldIncludeSshDetectedPortInPanel(p, {
+          showOtherUsers,
+          ownershipFilteringActive
+        })
+      )
       .map((p) => ({ ...p, targetId: activeConnectionId }))
       .sort((a, b) => a.port - b.port)
-  }, [detectedPortsByConnection, activeConnectionId, forwardedKeys])
+  }, [
+    detectedPortsByConnection,
+    activeConnectionId,
+    forwardedKeys,
+    showOtherUsers,
+    ownershipFilteringActive
+  ])
 
-  const [forwardedCollapsed, setForwardedCollapsed] = useState(false)
-  const [detectedCollapsed, setDetectedCollapsed] = useState(false)
-  const [dialogState, setDialogState] = useState<PortForwardDialogState>({ mode: 'closed' })
+  const handleShowOtherUsersChange = useCallback((checked: boolean | 'indeterminate') => {
+    const next = checked === true
+    setShowOtherUsers(next)
+    writeSshPortsShowOtherUsers(next)
+  }, [])
 
   const handleForwardDetected = useCallback((port: EnrichedDetectedPort & { targetId: string }) => {
     setDialogState({
@@ -961,7 +998,7 @@ function SshPortsPanel(): React.JSX.Element {
       )}
 
       {/* Detected ports */}
-      {allDetected.length > 0 && (
+      {(allDetected.length > 0 || ownershipFilteringActive) && (
         <div className="px-3 pt-2">
           <button
             type="button"
@@ -980,19 +1017,40 @@ function SshPortsPanel(): React.JSX.Element {
             </span>
             <span className="text-[10px] text-muted-foreground/60 ml-1">{allDetected.length}</span>
           </button>
+          {ownershipFilteringActive && !detectedCollapsed && (
+            <label className="mb-1 flex cursor-pointer items-center gap-2 px-1 py-0.5 text-xs text-muted-foreground">
+              <Checkbox
+                checked={showOtherUsers}
+                onCheckedChange={handleShowOtherUsersChange}
+                aria-label={translate(
+                  'auto.components.right.sidebar.PortsPanel.showOtherUsers',
+                  'Show ports from other users'
+                )}
+              />
+              <span>
+                {translate(
+                  'auto.components.right.sidebar.PortsPanel.showOtherUsers',
+                  'Show ports from other users'
+                )}
+              </span>
+            </label>
+          )}
           {!detectedCollapsed &&
             allDetected.map((port) => (
               <DetectedPortRow
                 key={`${port.targetId}-${port.host}-${port.port}`}
                 port={port}
                 onForward={() => handleForwardDetected(port)}
+                showUsername={
+                  ownershipFilteringActive && showOtherUsers && port.ownedByConnectingUser === false
+                }
               />
             ))}
         </div>
       )}
 
-      {/* Empty state */}
-      {allForwards.length === 0 && allDetected.length === 0 && (
+      {/* Empty state — skip when the Detected section is shown (toggle / filtered-empty). */}
+      {allForwards.length === 0 && allDetected.length === 0 && !ownershipFilteringActive && (
         <div className="flex flex-col items-center justify-center flex-1 px-4 text-center text-muted-foreground">
           <p className="text-sm">
             {translate('auto.components.right.sidebar.PortsPanel.1f0d2a24f9', 'No forwarded ports')}
@@ -1194,10 +1252,12 @@ function ForwardedPortRow({
 
 function DetectedPortRow({
   port,
-  onForward
+  onForward,
+  showUsername = false
 }: {
   port: EnrichedDetectedPort & { targetId: string }
   onForward: () => void
+  showUsername?: boolean
 }): React.JSX.Element {
   const advertisedBrowserUrl = advertisedBrowserUrlForDetectedPort(port)
   return (
@@ -1207,6 +1267,9 @@ function DetectedPortRow({
           <span className="text-xs text-foreground">:{port.port}</span>
           {port.processName && (
             <span className="text-xs text-muted-foreground truncate">{port.processName}</span>
+          )}
+          {showUsername && port.username && (
+            <span className="text-[11px] text-muted-foreground/70 truncate">{port.username}</span>
           )}
         </div>
         {advertisedBrowserUrl && (

--- a/src/renderer/src/components/right-sidebar/ssh-ports-other-users-preference.test.ts
+++ b/src/renderer/src/components/right-sidebar/ssh-ports-other-users-preference.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  readSshPortsShowOtherUsers,
+  SSH_PORTS_SHOW_OTHER_USERS_STORAGE_KEY,
+  writeSshPortsShowOtherUsers
+} from './ssh-ports-other-users-preference'
+
+function memoryStorage(initial: Record<string, string> = {}): {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+  store: Record<string, string>
+} {
+  const store = { ...initial }
+  return {
+    store,
+    getItem: (key) => store[key] ?? null,
+    setItem: (key, value) => {
+      store[key] = value
+    }
+  }
+}
+
+describe('ssh-ports-other-users-preference', () => {
+  afterEach(() => {
+    // no global side effects when storage is injected
+  })
+
+  it('defaults to false when unset', () => {
+    expect(readSshPortsShowOtherUsers(memoryStorage())).toBe(false)
+  })
+
+  it('persists the toggle value', () => {
+    const storage = memoryStorage()
+    writeSshPortsShowOtherUsers(true, storage)
+    expect(storage.store[SSH_PORTS_SHOW_OTHER_USERS_STORAGE_KEY]).toBe('true')
+    expect(readSshPortsShowOtherUsers(storage)).toBe(true)
+    writeSshPortsShowOtherUsers(false, storage)
+    expect(readSshPortsShowOtherUsers(storage)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ssh-ports-other-users-preference.ts
+++ b/src/renderer/src/components/right-sidebar/ssh-ports-other-users-preference.ts
@@ -1,0 +1,45 @@
+export const SSH_PORTS_SHOW_OTHER_USERS_STORAGE_KEY = 'orca.sshPorts.showOtherUsers.v1'
+
+type PreferenceStorage = {
+  getItem: (key: string) => string | null
+  setItem: (key: string, value: string) => void
+}
+
+function getRendererStorage(): PreferenceStorage | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+  try {
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+/** Default off: only owned ports until the user opts in. */
+export function readSshPortsShowOtherUsers(
+  storage: PreferenceStorage | null = getRendererStorage()
+): boolean {
+  if (!storage) {
+    return false
+  }
+  try {
+    return storage.getItem(SSH_PORTS_SHOW_OTHER_USERS_STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function writeSshPortsShowOtherUsers(
+  showOtherUsers: boolean,
+  storage: PreferenceStorage | null = getRendererStorage()
+): void {
+  if (!storage) {
+    return
+  }
+  try {
+    storage.setItem(SSH_PORTS_SHOW_OTHER_USERS_STORAGE_KEY, showOtherUsers ? 'true' : 'false')
+  } catch {
+    // localStorage may be unavailable (private mode / quota)
+  }
+}

--- a/src/shared/ssh-detected-port-ownership.test.ts
+++ b/src/shared/ssh-detected-port-ownership.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import type { DetectedPort } from './ssh-types'
+import {
+  filterSshAutoForwardCandidates,
+  isSshAutoForwardOwnedPort,
+  shouldIncludeSshDetectedPortInPanel,
+  sshDetectedPortOwnershipFilteringActive
+} from './ssh-detected-port-ownership'
+
+function port(overrides: Partial<DetectedPort> & Pick<DetectedPort, 'port'>): DetectedPort {
+  return {
+    host: '127.0.0.1',
+    ...overrides
+  }
+}
+
+describe('sshDetectedPortOwnershipFilteringActive', () => {
+  it('is inactive for old-relay / Windows payloads without ownership fields', () => {
+    expect(
+      sshDetectedPortOwnershipFilteringActive([
+        port({ port: 3000 }),
+        port({ port: 3001, processName: 'node' })
+      ])
+    ).toBe(false)
+  })
+
+  it('is active when any row carries ownedByConnectingUser', () => {
+    expect(
+      sshDetectedPortOwnershipFilteringActive([
+        port({ port: 3000 }),
+        port({ port: 3001, ownedByConnectingUser: true })
+      ])
+    ).toBe(true)
+  })
+})
+
+describe('shouldIncludeSshDetectedPortInPanel', () => {
+  it('shows all ports when ownership filtering is inactive', () => {
+    expect(
+      shouldIncludeSshDetectedPortInPanel(port({ port: 3000, ownedByConnectingUser: false }), {
+        showOtherUsers: false,
+        ownershipFilteringActive: false
+      })
+    ).toBe(true)
+  })
+
+  it('defaults to owned ports only; toggle reveals others', () => {
+    const owned = port({ port: 3000, ownedByConnectingUser: true })
+    const other = port({ port: 3001, ownedByConnectingUser: false, username: 'bob' })
+
+    expect(
+      shouldIncludeSshDetectedPortInPanel(owned, {
+        showOtherUsers: false,
+        ownershipFilteringActive: true
+      })
+    ).toBe(true)
+    expect(
+      shouldIncludeSshDetectedPortInPanel(other, {
+        showOtherUsers: false,
+        ownershipFilteringActive: true
+      })
+    ).toBe(false)
+    expect(
+      shouldIncludeSshDetectedPortInPanel(other, {
+        showOtherUsers: true,
+        ownershipFilteringActive: true
+      })
+    ).toBe(true)
+  })
+
+  it('never hides ports with an advertised URL from the user terminal', () => {
+    expect(
+      shouldIncludeSshDetectedPortInPanel(
+        {
+          ...port({ port: 3000, ownedByConnectingUser: false }),
+          advertisedUrl: 'https://app.local:3000'
+        },
+        { showOtherUsers: false, ownershipFilteringActive: true }
+      )
+    ).toBe(true)
+  })
+})
+
+describe('filterSshAutoForwardCandidates', () => {
+  it('ignores non-owned ports and initial-scan keys', () => {
+    const ports: DetectedPort[] = [
+      port({ port: 3000, ownedByConnectingUser: true }),
+      port({ port: 3001, ownedByConnectingUser: false }),
+      port({ port: 3002, ownedByConnectingUser: true }),
+      // Old relay / Windows: ownership unset still eligible (unfiltered degrade)
+      port({ port: 3003 })
+    ]
+    const initial = new Set(['127.0.0.1:3000'])
+
+    expect(filterSshAutoForwardCandidates(ports, initial).map((p) => p.port)).toEqual([3002, 3003])
+  })
+
+  it('treats ownedByConnectingUser === false as ineligible', () => {
+    expect(isSshAutoForwardOwnedPort({ ownedByConnectingUser: false })).toBe(false)
+    expect(isSshAutoForwardOwnedPort({ ownedByConnectingUser: true })).toBe(true)
+    expect(isSshAutoForwardOwnedPort({})).toBe(true)
+  })
+})

--- a/src/shared/ssh-detected-port-ownership.ts
+++ b/src/shared/ssh-detected-port-ownership.ts
@@ -1,0 +1,45 @@
+import type { DetectedPort } from './ssh-types'
+
+/** True when any row carries ownership metadata from a modern Linux relay. */
+export function sshDetectedPortOwnershipFilteringActive(
+  ports: readonly Pick<DetectedPort, 'ownedByConnectingUser'>[]
+): boolean {
+  return ports.some((port) => port.ownedByConnectingUser !== undefined)
+}
+
+/**
+ * Panel visibility for a detected SSH port.
+ * Old relays / Windows leave ownership unset → no filter (show all).
+ * Never hide ports advertised from the user's own terminal.
+ */
+export function shouldIncludeSshDetectedPortInPanel(
+  port: Pick<DetectedPort, 'ownedByConnectingUser'> & { advertisedUrl?: string },
+  options: { showOtherUsers: boolean; ownershipFilteringActive: boolean }
+): boolean {
+  if (!options.ownershipFilteringActive || options.showOtherUsers) {
+    return true
+  }
+  if (port.advertisedUrl) {
+    return true
+  }
+  return port.ownedByConnectingUser !== false
+}
+
+/** Auto-forward may only target owned ports when ownership is known. */
+export function isSshAutoForwardOwnedPort(
+  port: Pick<DetectedPort, 'ownedByConnectingUser'>
+): boolean {
+  return port.ownedByConnectingUser !== false
+}
+
+export function filterSshAutoForwardCandidates(
+  ports: readonly DetectedPort[],
+  initialPorts: ReadonlySet<string>
+): DetectedPort[] {
+  return ports.filter((port) => {
+    if (initialPorts.has(`${port.host}:${port.port}`)) {
+      return false
+    }
+    return isSshAutoForwardOwnedPort(port)
+  })
+}

--- a/src/shared/ssh-retained-payload-admission.test.ts
+++ b/src/shared/ssh-retained-payload-admission.test.ts
@@ -103,4 +103,41 @@ describe('SSH retained payload admission', () => {
       ])
     ).toEqual([{ port: 3001, host: '127.0.0.1', processName: 'node' }])
   })
+
+  it('retains optional ownership fields from modern Linux relays', () => {
+    expect(
+      admitSshDetectedPorts([
+        {
+          port: 3000,
+          host: '127.0.0.1',
+          uid: 1000,
+          username: 'alice',
+          ownedByConnectingUser: true,
+          unexpected: 'drop'
+        },
+        {
+          port: 3001,
+          host: '127.0.0.1',
+          uid: 1001,
+          username: 'bob',
+          ownedByConnectingUser: false
+        }
+      ])
+    ).toEqual([
+      {
+        port: 3000,
+        host: '127.0.0.1',
+        uid: 1000,
+        username: 'alice',
+        ownedByConnectingUser: true
+      },
+      {
+        port: 3001,
+        host: '127.0.0.1',
+        uid: 1001,
+        username: 'bob',
+        ownedByConnectingUser: false
+      }
+    ])
+  })
 })

--- a/src/shared/ssh-retained-payload-admission.ts
+++ b/src/shared/ssh-retained-payload-admission.ts
@@ -8,6 +8,7 @@ export const SSH_DETECTED_PORTS_MAX_ENTRIES = 50
 export const SSH_DETECTED_PORT_HOST_MAX_UTF8_BYTES = 1024
 export const SSH_DETECTED_PORT_PROCESS_NAME_MAX_UTF8_BYTES = 4 * 1024
 export const SSH_DETECTED_PORT_ADVERTISED_URL_MAX_UTF8_BYTES = 2048
+export const SSH_DETECTED_PORT_USERNAME_MAX_UTF8_BYTES = 256
 
 const CONNECTION_STATUSES = new Set<SshConnectionStatus>([
   'disconnected',
@@ -107,6 +108,10 @@ function admitDetectedPort(value: unknown): EnrichedDetectedPort | null {
     typeof input.processName === 'string'
       ? clampUtf8TextPrefix(input.processName, SSH_DETECTED_PORT_PROCESS_NAME_MAX_UTF8_BYTES)
       : undefined
+  const username =
+    typeof input.username === 'string'
+      ? clampUtf8TextPrefix(input.username, SSH_DETECTED_PORT_USERNAME_MAX_UTF8_BYTES)
+      : undefined
   const advertisedUrl = isStringWithinLimit(
     input.advertisedUrl,
     SSH_DETECTED_PORT_ADVERTISED_URL_MAX_UTF8_BYTES
@@ -118,6 +123,11 @@ function admitDetectedPort(value: unknown): EnrichedDetectedPort | null {
     host: input.host,
     ...(isNonNegativeSafeInteger(input.pid) && input.pid > 0 ? { pid: input.pid } : {}),
     ...(processName ? { processName } : {}),
+    ...(isNonNegativeSafeInteger(input.uid) ? { uid: input.uid } : {}),
+    ...(username ? { username } : {}),
+    ...(typeof input.ownedByConnectingUser === 'boolean'
+      ? { ownedByConnectingUser: input.ownedByConnectingUser }
+      : {}),
     ...(advertisedUrl ? { advertisedUrl } : {}),
     ...(input.advertisedProtocol === 'http' || input.advertisedProtocol === 'https'
       ? { advertisedProtocol: input.advertisedProtocol }

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -173,6 +173,12 @@ export type DetectedPort = {
   host: string
   pid?: number
   processName?: string
+  /** Socket owner uid from /proc/net/tcp (Linux only). */
+  uid?: number
+  /** Resolved from /etc/passwd, or numeric uid string when resolution fails. */
+  username?: string
+  /** True when uid matches the relay process uid (connecting SSH user). */
+  ownedByConnectingUser?: boolean
 }
 
 /** A detected SSH port after the main process has mapped terminal-advertised


### PR DESCRIPTION
## Summary
- Linux relay port scan now parses socket owner UID, resolves username via `/etc/passwd`, and marks `ownedByConnectingUser` against the relay process uid.
- Ports panel defaults to owned ports; optional toggle shows other users' ports with usernames.
- Auto-forward suggestions only consider owned ports. Windows / old relays omit fields and stay unfiltered.

## Fixes
Closes #10563

## Test plan
- [x] port-scan-handler, ownership helpers, retained payload admission, ssh-port-scanner, preference unit tests
- [ ] Manual: multi-user Linux SSH host — default list is own ports; toggle reveals others

## ELI5

On shared Linux SSH hosts, the Ports panel can focus on ports you own and optionally show other users' ports by name, so auto-forward suggestions aren't cluttered by everyone else's listeners.
