### PR TITLE
feat(jira): collect required fields for transitions (resolution form)

### DIFF
--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -76,6 +76,17 @@ function normalizeIssueUpdate(value: unknown): JiraIssueUpdate | null {
   if (input.transitionId !== undefined && typeof input.transitionId !== 'string') {
     return null
   }
+  if (
+    input.transitionFields !== undefined &&
+    (input.transitionFields === null ||
+      typeof input.transitionFields !== 'object' ||
+      Array.isArray(input.transitionFields))
+  ) {
+    return null
+  }
+  if (input.transitionComment !== undefined && typeof input.transitionComment !== 'string') {
+    return null
+  }
   return input
 }
 

--- a/src/main/jira/issues.test.ts
+++ b/src/main/jira/issues.test.ts
@@ -295,7 +295,8 @@ describe('Jira issue operations', () => {
         schema: {
           type: 'option',
           custom: 'com.atlassian.jira.plugin.system.customfieldtypes:select',
-          items: undefined
+          items: undefined,
+          system: undefined
         },
         allowedValues: [{ id: 'option-1', value: 'High', name: undefined }]
       }
@@ -474,6 +475,184 @@ describe('Jira issue operations', () => {
         updatedAt: undefined
       }
     ])
+  })
+
+  describe('listTransitions', () => {
+    it('requests expand=transitions.fields and maps required field metadata', async () => {
+      jiraRequestMock.mockResolvedValueOnce({
+        transitions: [
+          {
+            id: '31',
+            name: 'Done',
+            to: {
+              id: '3',
+              name: 'Done',
+              statusCategory: { key: 'done', name: 'Done' }
+            },
+            fields: {
+              resolution: {
+                required: true,
+                name: 'Resolution',
+                schema: { type: 'resolution', system: 'resolution' },
+                allowedValues: [{ id: '10000', name: 'Done' }]
+              },
+              comment: {
+                required: false,
+                name: 'Comment',
+                schema: { type: 'string', system: 'comment' }
+              }
+            }
+          },
+          {
+            id: '11',
+            name: 'In Progress',
+            to: {
+              id: '2',
+              name: 'In Progress',
+              statusCategory: { key: 'indeterminate', name: 'In Progress' }
+            }
+          }
+        ]
+      })
+      const { listTransitions } = await import('./issues')
+
+      await expect(listTransitions('ALP-1', 'site-1')).resolves.toEqual([
+        {
+          id: '31',
+          name: 'Done',
+          to: {
+            id: '3',
+            name: 'Done',
+            categoryKey: 'done',
+            categoryName: 'Done',
+            colorName: undefined
+          },
+          fields: [
+            {
+              key: 'resolution',
+              name: 'Resolution',
+              required: true,
+              schema: {
+                type: 'resolution',
+                system: 'resolution',
+                items: undefined,
+                custom: undefined
+              },
+              allowedValues: [{ id: '10000', name: 'Done', value: undefined }]
+            },
+            {
+              key: 'comment',
+              name: 'Comment',
+              required: false,
+              schema: {
+                type: 'string',
+                system: 'comment',
+                items: undefined,
+                custom: undefined
+              },
+              allowedValues: undefined
+            }
+          ]
+        },
+        {
+          id: '11',
+          name: 'In Progress',
+          to: {
+            id: '2',
+            name: 'In Progress',
+            categoryKey: 'indeterminate',
+            categoryName: 'In Progress',
+            colorName: undefined
+          },
+          fields: undefined
+        }
+      ])
+
+      expect(String(jiraRequestMock.mock.calls[0][1])).toBe(
+        '/rest/api/3/issue/ALP-1/transitions?expand=transitions.fields'
+      )
+    })
+
+    it('degrades to a bare transition list when expand is unavailable', async () => {
+      jiraRequestMock
+        .mockRejectedValueOnce(new Error('expand not supported'))
+        .mockResolvedValueOnce({
+          transitions: [
+            {
+              id: '21',
+              name: 'Close',
+              to: {
+                id: '6',
+                name: 'Closed',
+                statusCategory: { key: 'done', name: 'Done' }
+              }
+            }
+          ]
+        })
+      const { listTransitions } = await import('./issues')
+
+      await expect(listTransitions('ALP-1', 'site-1')).resolves.toMatchObject([
+        { id: '21', name: 'Close', fields: undefined }
+      ])
+      expect(String(jiraRequestMock.mock.calls[1][1])).toBe('/rest/api/3/issue/ALP-1/transitions')
+    })
+
+    it('surfaces listTransitions operational failures to the caller', async () => {
+      jiraRequestMock
+        .mockRejectedValueOnce(new Error('expand failed'))
+        .mockRejectedValueOnce(new Error('Service Unavailable'))
+      const { listTransitions } = await import('./issues')
+
+      await expect(listTransitions('ALP-1', 'site-1')).rejects.toThrow('Service Unavailable')
+    })
+  })
+
+  describe('updateIssue transitions', () => {
+    it('posts transition fields and update.comment when provided', async () => {
+      jiraRequestMock.mockResolvedValue(null)
+      const { updateIssue } = await import('./issues')
+
+      await expect(
+        updateIssue(
+          'ALP-1',
+          {
+            transitionId: '31',
+            transitionFields: { resolution: { id: '10000' } },
+            transitionComment: 'Closing after verification'
+          },
+          'site-1'
+        )
+      ).resolves.toEqual({ ok: true })
+
+      const body = JSON.parse((jiraRequestMock.mock.calls[0][2] as { body: string }).body) as {
+        transition: { id: string }
+        fields: { resolution: { id: string } }
+        update: { comment: { add: { body: unknown } }[] }
+      }
+      expect(body).toMatchObject({
+        transition: { id: '31' },
+        fields: { resolution: { id: '10000' } }
+      })
+      expect(body.update.comment[0].add.body).toMatchObject({
+        type: 'doc',
+        version: 1
+      })
+    })
+
+    it('posts a bare transition id when no fields are supplied', async () => {
+      jiraRequestMock.mockResolvedValue(null)
+      const { updateIssue } = await import('./issues')
+
+      await updateIssue('ALP-1', { transitionId: '11' }, 'site-1')
+
+      expect(jiraRequestMock).toHaveBeenCalledWith(
+        expect.anything(),
+        '/rest/api/3/issue/ALP-1/transitions',
+        expect.objectContaining({
+          body: JSON.stringify({ transition: { id: '11' } })
+        })
+      )
+    })
   })
 
   describe('getProjectStatusOrder', () => {

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -258,10 +258,25 @@ function mapCreateField(value: unknown, fallbackKey = ''): JiraCreateField | nul
     schema: {
       type: asString(schema.type) || undefined,
       items: asString(schema.items) || undefined,
-      custom: asString(schema.custom) || undefined
+      custom: asString(schema.custom) || undefined,
+      system: asString(schema.system) || undefined
     },
     allowedValues
   }
+}
+
+function mapTransitionFields(fields: unknown): JiraCreateField[] | undefined {
+  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) {
+    return undefined
+  }
+  const mapped: JiraCreateField[] = []
+  for (const [key, value] of Object.entries(fields as JiraRecord)) {
+    const field = mapCreateField(value, key)
+    if (field) {
+      mapped.push(field)
+    }
+  }
+  return mapped.length > 0 ? mapped : undefined
 }
 
 function getCreateFieldRecords(response: JiraPagedResponse<JiraRecord>): JiraRecord[] {
@@ -549,9 +564,22 @@ export async function updateIssue(
       })
     }
     if (updates.transitionId) {
+      const transitionBody: JiraRecord = {
+        transition: { id: updates.transitionId }
+      }
+      const transitionFields = updates.transitionFields
+      if (transitionFields && Object.keys(transitionFields).length > 0) {
+        transitionBody.fields = transitionFields
+      }
+      const transitionComment = updates.transitionComment?.trim()
+      if (transitionComment) {
+        transitionBody.update = {
+          comment: [{ add: { body: toBodyText(entry.site, transitionComment) } }]
+        }
+      }
       await jiraRequest(entry, `${issueBase}/transitions`, {
         method: 'POST',
-        body: JSON.stringify({ transition: { id: updates.transitionId } })
+        body: JSON.stringify(transitionBody)
       })
     }
     return { ok: true }
@@ -815,6 +843,15 @@ export async function listAssignableUsers(
   }
 }
 
+function mapTransitions(response: { transitions?: JiraRecord[] }): JiraTransition[] {
+  return (response.transitions ?? []).map((transition) => ({
+    id: asString(transition.id),
+    name: asString(transition.name),
+    to: mapStatus(transition.to),
+    fields: mapTransitionFields(transition.fields)
+  }))
+}
+
 export async function listTransitions(
   key: string,
   siteId?: string | null
@@ -825,22 +862,26 @@ export async function listTransitions(
   }
   await acquire()
   try {
-    const response = await jiraRequest<{ transitions?: JiraRecord[] }>(
-      entry,
-      `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}/transitions`
-    )
-    return (response.transitions ?? []).map((transition) => ({
-      id: asString(transition.id),
-      name: asString(transition.name),
-      to: mapStatus(transition.to)
-    }))
+    const basePath = `${apiBasePath(entry.site)}/issue/${encodeURIComponent(key)}/transitions`
+    const expandedPath = `${basePath}?expand=${encodeURIComponent('transitions.fields')}`
+    try {
+      return mapTransitions(await jiraRequest<{ transitions?: JiraRecord[] }>(entry, expandedPath))
+    } catch (expandError) {
+      // Why: older Jira/permissions may reject expand; degrade to bare IDs.
+      if (isAuthError(expandError)) {
+        clearToken(entry.site.id)
+        throw expandError
+      }
+      console.warn('[jira] listTransitions expand failed, retrying without fields:', expandError)
+      return mapTransitions(await jiraRequest<{ transitions?: JiraRecord[] }>(entry, basePath))
+    }
   } catch (error) {
     if (isAuthError(error)) {
       clearToken(entry.site.id)
       throw error
     }
     console.warn('[jira] listTransitions failed:', error)
-    return []
+    throw error
   } finally {
     release()
   }

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -63,7 +63,9 @@ const IssueUpdate = z.object({
     labels: z.array(z.string()).optional(),
     assigneeAccountId: z.union([z.string(), z.null()]).optional(),
     priorityId: z.union([z.string(), z.null()]).optional(),
-    transitionId: OptionalString
+    transitionId: OptionalString,
+    transitionFields: z.record(z.string(), z.unknown()).optional(),
+    transitionComment: OptionalPlainString
   })
 })
 

--- a/src/renderer/src/components/JiraIssueWorkspace.tsx
+++ b/src/renderer/src/components/JiraIssueWorkspace.tsx
@@ -4,6 +4,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowRight,
+  ChevronDown,
   Clipboard,
   ExternalLink,
   GitBranch,
@@ -42,11 +43,18 @@ import {
 import type {
   JiraComment,
   JiraIssue,
+  JiraIssueUpdate,
   JiraPriority,
   JiraTransition,
   JiraUser
 } from '../../../shared/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
+import {
+  buildResolutionFieldValue,
+  classifyTransitionRequirements,
+  transitionAllowedValueLabel,
+  type JiraTransitionRequirement
+} from '../../../shared/jira-transition-fields'
 import { translate } from '@/i18n/i18n'
 
 type JiraIssueWorkspaceProps = {
@@ -129,6 +137,19 @@ export default function JiraIssueWorkspace({
   const [commentsLoading, setCommentsLoading] = useState(false)
   const [commentsError, setCommentsError] = useState<string | null>(null)
   const [transitions, setTransitions] = useState<JiraTransition[]>([])
+  const [transitionsError, setTransitionsError] = useState<string | null>(null)
+  const [transitionsLoading, setTransitionsLoading] = useState(false)
+  const [statusPopoverOpen, setStatusPopoverOpen] = useState(false)
+  const [transitionForm, setTransitionForm] = useState<{
+    transition: JiraTransition
+    requirement: Extract<JiraTransitionRequirement, { kind: 'form' }>
+  } | null>(null)
+  const [unsupportedTransition, setUnsupportedTransition] = useState<{
+    transition: JiraTransition
+    fields: { key: string; name: string }[]
+  } | null>(null)
+  const [resolutionDraft, setResolutionDraft] = useState('')
+  const [transitionCommentDraft, setTransitionCommentDraft] = useState('')
   const [priorities, setPriorities] = useState<JiraPriority[]>([])
   const [users, setUsers] = useState<JiraUser[]>([])
   const [pendingField, setPendingField] = useState<string | null>(null)
@@ -177,6 +198,13 @@ export default function JiraIssueWorkspace({
       setComments([])
       setCommentsError(null)
       setTransitions([])
+      setTransitionsError(null)
+      setTransitionsLoading(false)
+      setStatusPopoverOpen(false)
+      setTransitionForm(null)
+      setUnsupportedTransition(null)
+      setResolutionDraft('')
+      setTransitionCommentDraft('')
       setPriorities([])
       setUsers([])
       setCommentDraft('')
@@ -192,6 +220,14 @@ export default function JiraIssueWorkspace({
     setLabelsDraft(issue.labels.join(', '))
     setComments([])
     setCommentsError(null)
+    setTransitions([])
+    setTransitionsError(null)
+    setTransitionsLoading(true)
+    setStatusPopoverOpen(false)
+    setTransitionForm(null)
+    setUnsupportedTransition(null)
+    setResolutionDraft('')
+    setTransitionCommentDraft('')
     setIssueLoading(true)
 
     void jiraGetIssue(providerSettings, issue.key, issue.siteId)
@@ -213,19 +249,45 @@ export default function JiraIssueWorkspace({
       })
 
     void Promise.all([
-      jiraListTransitions(providerSettings, issue.key, issue.siteId),
       jiraListPriorities(providerSettings, issue.siteId),
       jiraListAssignableUsers(providerSettings, issue.key, undefined, issue.siteId)
     ])
-      .then(([nextTransitions, nextPriorities, nextUsers]) => {
+      .then(([nextPriorities, nextUsers]) => {
         if (requestId !== requestIdRef.current) {
           return
         }
-        setTransitions(nextTransitions)
         setPriorities(nextPriorities)
         setUsers(nextUsers)
       })
       .catch(() => {})
+
+    void jiraListTransitions(providerSettings, issue.key, issue.siteId)
+      .then((nextTransitions) => {
+        if (requestId !== requestIdRef.current) {
+          return
+        }
+        setTransitions(nextTransitions)
+        setTransitionsError(null)
+      })
+      .catch((error) => {
+        if (requestId !== requestIdRef.current) {
+          return
+        }
+        setTransitions([])
+        setTransitionsError(
+          error instanceof Error
+            ? error.message
+            : translate(
+                'auto.components.JiraIssueWorkspace.transitionsLoadFailed',
+                'Failed to load status transitions.'
+              )
+        )
+      })
+      .finally(() => {
+        if (requestId === requestIdRef.current) {
+          setTransitionsLoading(false)
+        }
+      })
 
     void loadComments(issue, requestId)
   }, [issue, loadComments, providerSettings])
@@ -248,11 +310,11 @@ export default function JiraIssueWorkspace({
   const mutateIssue = useCallback(
     async (
       field: string,
-      updates: Parameters<typeof jiraUpdateIssue>[2],
+      updates: JiraIssueUpdate,
       optimistic?: Partial<JiraIssue>
-    ): Promise<void> => {
+    ): Promise<boolean> => {
       if (!displayed || pendingField) {
-        return
+        return false
       }
       setPendingField(field)
       const previous = displayed
@@ -266,6 +328,7 @@ export default function JiraIssueWorkspace({
           throw new Error(result.error)
         }
         await refreshIssue()
+        return true
       } catch (error) {
         setFullIssue(previous)
         patchJiraIssue(previous.key, previous, { sourceContext })
@@ -277,12 +340,136 @@ export default function JiraIssueWorkspace({
                 'Failed to update Jira issue.'
               )
         )
+        return false
       } finally {
         setPendingField(null)
       }
     },
     [displayed, patchJiraIssue, pendingField, refreshIssue, providerSettings, siteId, sourceContext]
   )
+
+  const resetTransitionPopover = useCallback((): void => {
+    setTransitionForm(null)
+    setUnsupportedTransition(null)
+    setResolutionDraft('')
+    setTransitionCommentDraft('')
+  }, [])
+
+  const reloadTransitions = useCallback(async (): Promise<void> => {
+    if (!displayed) {
+      return
+    }
+    setTransitionsLoading(true)
+    setTransitionsError(null)
+    try {
+      const nextTransitions = await jiraListTransitions(
+        providerSettings,
+        displayed.key,
+        displayed.siteId
+      )
+      setTransitions(nextTransitions)
+      setTransitionsError(null)
+    } catch (error) {
+      setTransitions([])
+      setTransitionsError(
+        error instanceof Error
+          ? error.message
+          : translate(
+              'auto.components.JiraIssueWorkspace.transitionsLoadFailed',
+              'Failed to load status transitions.'
+            )
+      )
+    } finally {
+      setTransitionsLoading(false)
+    }
+  }, [displayed, providerSettings])
+
+  const applyTransition = useCallback(
+    async (transition: JiraTransition, updates?: Partial<JiraIssueUpdate>): Promise<boolean> => {
+      return mutateIssue(
+        'transition',
+        { transitionId: transition.id, ...updates },
+        { status: transition.to }
+      )
+    },
+    [mutateIssue]
+  )
+
+  const handleSelectTransition = useCallback(
+    (transition: JiraTransition): void => {
+      const requirement = classifyTransitionRequirements(transition)
+      if (requirement.kind === 'none') {
+        void applyTransition(transition).then((ok) => {
+          if (ok) {
+            setStatusPopoverOpen(false)
+            resetTransitionPopover()
+          }
+        })
+        return
+      }
+      if (requirement.kind === 'unsupported') {
+        setTransitionForm(null)
+        setUnsupportedTransition({
+          transition,
+          fields: requirement.fields.map((field) => ({ key: field.key, name: field.name }))
+        })
+        return
+      }
+      setUnsupportedTransition(null)
+      setTransitionForm({ transition, requirement })
+      const firstResolution = requirement.resolution?.allowedValues?.[0]
+      setResolutionDraft(
+        firstResolution?.id ?? firstResolution?.name ?? firstResolution?.value ?? ''
+      )
+      setTransitionCommentDraft('')
+    },
+    [applyTransition, resetTransitionPopover]
+  )
+
+  const handleSubmitTransitionForm = useCallback(async (): Promise<void> => {
+    if (!transitionForm) {
+      return
+    }
+    const { transition, requirement } = transitionForm
+    const updates: Partial<JiraIssueUpdate> = {}
+    if (requirement.resolution) {
+      const resolutionValue = buildResolutionFieldValue(requirement.resolution, resolutionDraft)
+      if (!resolutionValue) {
+        toast.error(
+          translate(
+            'auto.components.JiraIssueWorkspace.resolutionRequired',
+            'Select a resolution to continue.'
+          )
+        )
+        return
+      }
+      updates.transitionFields = { resolution: resolutionValue }
+    }
+    const comment = transitionCommentDraft.trim()
+    if (requirement.commentRequired && !comment) {
+      toast.error(
+        translate(
+          'auto.components.JiraIssueWorkspace.transitionCommentRequired',
+          'A comment is required for this transition.'
+        )
+      )
+      return
+    }
+    if (comment) {
+      updates.transitionComment = comment
+    }
+    const ok = await applyTransition(transition, updates)
+    if (ok) {
+      setStatusPopoverOpen(false)
+      resetTransitionPopover()
+    }
+  }, [
+    applyTransition,
+    resetTransitionPopover,
+    resolutionDraft,
+    transitionCommentDraft,
+    transitionForm
+  ])
 
   const handleSaveTitle = useCallback(() => {
     if (!displayed) {
@@ -462,42 +649,198 @@ export default function JiraIssueWorkspace({
             </div>
 
             <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-border/60 px-4 py-2.5">
-              <Popover>
+              <Popover
+                open={statusPopoverOpen}
+                onOpenChange={(open) => {
+                  setStatusPopoverOpen(open)
+                  if (!open) {
+                    resetTransitionPopover()
+                  }
+                }}
+              >
                 <PopoverTrigger asChild>
                   <button
                     type="button"
-                    disabled={pendingField === 'transition' || transitions.length === 0}
+                    title={transitionsError ?? undefined}
+                    disabled={
+                      pendingField === 'transition' ||
+                      (transitions.length === 0 && !transitionsError && !transitionsLoading)
+                    }
                     className={cn(
                       'inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium transition hover:opacity-80 disabled:opacity-50',
-                      jiraStatusClass(displayed.status.categoryKey)
+                      jiraStatusClass(displayed.status.categoryKey),
+                      transitionsError && 'border-destructive/40'
                     )}
                   >
                     {displayed.status.name}
-                    {pendingField === 'transition' ? (
+                    {pendingField === 'transition' || transitionsLoading ? (
                       <LoaderCircle className="size-3 animate-spin" />
-                    ) : null}
+                    ) : (
+                      <ChevronDown className="size-3 opacity-70" />
+                    )}
                   </button>
                 </PopoverTrigger>
                 <PopoverContent
-                  className="popover-scroll-content scrollbar-sleek w-52 p-1"
+                  className={cn(
+                    'popover-scroll-content scrollbar-sleek p-1',
+                    transitionForm || unsupportedTransition || transitionsError ? 'w-72' : 'w-52'
+                  )}
                   align="start"
                 >
-                  {transitions.map((transition) => (
-                    <button
-                      key={transition.id}
-                      type="button"
-                      onClick={() =>
-                        void mutateIssue(
-                          'transition',
-                          { transitionId: transition.id },
-                          { status: transition.to }
-                        )
-                      }
-                      className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
-                    >
-                      {transition.name}
-                    </button>
-                  ))}
+                  {transitionsError ? (
+                    <div className="space-y-2 px-2 py-1.5">
+                      <p className="text-[12px] text-destructive">{transitionsError}</p>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="h-7 w-full text-[12px]"
+                        onClick={() => void reloadTransitions()}
+                        disabled={transitionsLoading}
+                      >
+                        {transitionsLoading ? (
+                          <LoaderCircle className="size-3 animate-spin" />
+                        ) : (
+                          <RefreshCw className="size-3" />
+                        )}
+                        {translate('auto.components.JiraIssueWorkspace.retryTransitions', 'Retry')}
+                      </Button>
+                    </div>
+                  ) : unsupportedTransition ? (
+                    <div className="space-y-2 px-2 py-1.5">
+                      <p className="text-[12px] font-medium text-foreground">
+                        {translate(
+                          'auto.components.JiraIssueWorkspace.unsupportedTransitionTitle',
+                          'Complete “{{value0}}” in Jira',
+                          { value0: unsupportedTransition.transition.name }
+                        )}
+                      </p>
+                      <p className="text-[11px] leading-relaxed text-muted-foreground">
+                        {translate(
+                          'auto.components.JiraIssueWorkspace.unsupportedTransitionBody',
+                          'This transition requires fields Orca cannot collect yet: {{value0}}.',
+                          {
+                            value0: unsupportedTransition.fields
+                              .map((field) => field.name)
+                              .join(', ')
+                          }
+                        )}
+                      </p>
+                      <div className="flex gap-1.5">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 flex-1 text-[12px]"
+                          onClick={() => setUnsupportedTransition(null)}
+                        >
+                          {translate('auto.components.JiraIssueWorkspace.back', 'Back')}
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="h-7 flex-1 gap-1 text-[12px]"
+                          onClick={() => window.api.shell.openUrl(displayed.url)}
+                        >
+                          <ExternalLink className="size-3" />
+                          {translate(
+                            'auto.components.JiraIssueWorkspace.69da9a208c',
+                            'Open in Jira'
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : transitionForm ? (
+                    <div className="space-y-2 px-2 py-1.5">
+                      <p className="text-[12px] font-medium text-foreground">
+                        {transitionForm.transition.name}
+                      </p>
+                      {transitionForm.requirement.resolution ? (
+                        <label className="block space-y-1">
+                          <span className="text-[11px] text-muted-foreground">
+                            {transitionForm.requirement.resolution.name}
+                          </span>
+                          <select
+                            value={resolutionDraft}
+                            onChange={(event) => setResolutionDraft(event.target.value)}
+                            className="h-8 w-full rounded-md border border-input bg-transparent px-2 text-[12px] outline-none focus-visible:border-ring"
+                          >
+                            {(transitionForm.requirement.resolution.allowedValues ?? []).map(
+                              (value) => {
+                                const optionValue = value.id ?? value.value ?? value.name ?? ''
+                                return (
+                                  <option key={optionValue} value={optionValue}>
+                                    {transitionAllowedValueLabel(value)}
+                                  </option>
+                                )
+                              }
+                            )}
+                          </select>
+                        </label>
+                      ) : null}
+                      {transitionForm.requirement.commentRequired ? (
+                        <label className="block space-y-1">
+                          <span className="text-[11px] text-muted-foreground">
+                            {translate(
+                              'auto.components.JiraIssueWorkspace.transitionComment',
+                              'Comment'
+                            )}
+                          </span>
+                          <textarea
+                            value={transitionCommentDraft}
+                            onChange={(event) => setTransitionCommentDraft(event.target.value)}
+                            rows={3}
+                            className="w-full resize-none rounded-md border border-input bg-transparent px-2 py-1.5 text-[12px] outline-none focus-visible:border-ring"
+                          />
+                        </label>
+                      ) : null}
+                      <div className="flex gap-1.5 pt-0.5">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          className="h-7 flex-1 text-[12px]"
+                          onClick={() => resetTransitionPopover()}
+                          disabled={pendingField === 'transition'}
+                        >
+                          {translate('auto.components.JiraIssueWorkspace.back', 'Back')}
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="h-7 flex-1 text-[12px]"
+                          onClick={() => void handleSubmitTransitionForm()}
+                          disabled={pendingField === 'transition'}
+                        >
+                          {pendingField === 'transition' ? (
+                            <LoaderCircle className="size-3 animate-spin" />
+                          ) : null}
+                          {translate(
+                            'auto.components.JiraIssueWorkspace.applyTransition',
+                            'Transition'
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : transitions.length === 0 ? (
+                    <p className="px-2 py-1.5 text-[12px] text-muted-foreground">
+                      {translate(
+                        'auto.components.JiraIssueWorkspace.noTransitions',
+                        'No transitions available.'
+                      )}
+                    </p>
+                  ) : (
+                    transitions.map((transition) => (
+                      <button
+                        key={transition.id}
+                        type="button"
+                        onClick={() => handleSelectTransition(transition)}
+                        className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-[12px] hover:bg-accent"
+                      >
+                        {transition.name}
+                      </button>
+                    ))
+                  )}
                 </PopoverContent>
               </Popover>
 

--- a/src/renderer/src/components/JiraIssueWorkspace.tsx
+++ b/src/renderer/src/components/JiraIssueWorkspace.tsx
@@ -52,6 +52,7 @@ import type { TaskSourceContext } from '../../../shared/task-source-context'
 import {
   buildResolutionFieldValue,
   classifyTransitionRequirements,
+  transitionAllowedValueKey,
   transitionAllowedValueLabel,
   type JiraTransitionRequirement
 } from '../../../shared/jira-transition-fields'
@@ -418,9 +419,7 @@ export default function JiraIssueWorkspace({
       setUnsupportedTransition(null)
       setTransitionForm({ transition, requirement })
       const firstResolution = requirement.resolution?.allowedValues?.[0]
-      setResolutionDraft(
-        firstResolution?.id ?? firstResolution?.name ?? firstResolution?.value ?? ''
-      )
+      setResolutionDraft(firstResolution ? transitionAllowedValueKey(firstResolution) : '')
       setTransitionCommentDraft('')
     },
     [applyTransition, resetTransitionPopover]
@@ -767,7 +766,7 @@ export default function JiraIssueWorkspace({
                           >
                             {(transitionForm.requirement.resolution.allowedValues ?? []).map(
                               (value) => {
-                                const optionValue = value.id ?? value.value ?? value.name ?? ''
+                                const optionValue = transitionAllowedValueKey(value)
                                 return (
                                   <option key={optionValue} value={optionValue}>
                                     {transitionAllowedValueLabel(value)}

--- a/src/shared/jira-transition-fields.test.ts
+++ b/src/shared/jira-transition-fields.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildResolutionFieldValue,
+  classifyTransitionRequirements,
+  requiredTransitionFields,
+  transitionAllowedValueLabel
+} from './jira-transition-fields'
+import type { JiraTransition } from './jira-types'
+
+const baseTo = {
+  id: '3',
+  name: 'Done',
+  categoryKey: 'done',
+  categoryName: 'Done'
+}
+
+function transition(fields: JiraTransition['fields']): JiraTransition {
+  return { id: '31', name: 'Done', to: baseTo, fields }
+}
+
+describe('jira-transition-fields', () => {
+  it('treats transitions without required fields as one-click', () => {
+    expect(classifyTransitionRequirements(transition(undefined))).toEqual({ kind: 'none' })
+    expect(
+      classifyTransitionRequirements(
+        transition([
+          {
+            key: 'comment',
+            name: 'Comment',
+            required: false,
+            schema: { type: 'string', system: 'comment' }
+          }
+        ])
+      )
+    ).toEqual({ kind: 'none' })
+    expect(requiredTransitionFields(transition(undefined))).toEqual([])
+  })
+
+  it('classifies resolution (+ optional required comment) as a supported form', () => {
+    const resolution = {
+      key: 'resolution',
+      name: 'Resolution',
+      required: true,
+      schema: { type: 'resolution', system: 'resolution' },
+      allowedValues: [
+        { id: '10000', name: 'Done' },
+        { id: '10001', name: "Won't Do" }
+      ]
+    }
+    expect(classifyTransitionRequirements(transition([resolution]))).toEqual({
+      kind: 'form',
+      resolution,
+      commentRequired: false
+    })
+    expect(
+      classifyTransitionRequirements(
+        transition([
+          resolution,
+          {
+            key: 'comment',
+            name: 'Comment',
+            required: true,
+            schema: { type: 'string', system: 'comment' }
+          }
+        ])
+      )
+    ).toEqual({
+      kind: 'form',
+      resolution,
+      commentRequired: true
+    })
+  })
+
+  it('flags unsupported required field types without attempting a form', () => {
+    const custom = {
+      key: 'customfield_10050',
+      name: 'Close Reason',
+      required: true,
+      schema: {
+        type: 'option',
+        custom: 'com.atlassian.jira.plugin.system.customfieldtypes:select'
+      },
+      allowedValues: [{ id: '1', value: 'Fixed' }]
+    }
+    expect(
+      classifyTransitionRequirements(
+        transition([
+          custom,
+          {
+            key: 'resolution',
+            name: 'Resolution',
+            required: true,
+            schema: { type: 'resolution' },
+            allowedValues: [{ id: '10000', name: 'Done' }]
+          }
+        ])
+      )
+    ).toEqual({ kind: 'unsupported', fields: [custom] })
+  })
+
+  it('builds resolution payloads from allowed values', () => {
+    const field = {
+      key: 'resolution',
+      name: 'Resolution',
+      required: true,
+      allowedValues: [{ id: '10000', name: 'Done' }, { name: 'Duplicate' }]
+    }
+    expect(buildResolutionFieldValue(field, '10000')).toEqual({ id: '10000' })
+    expect(buildResolutionFieldValue(field, 'Duplicate')).toEqual({ name: 'Duplicate' })
+    expect(buildResolutionFieldValue(field, '  ')).toBeNull()
+    expect(transitionAllowedValueLabel({ id: '1', name: 'Done' })).toBe('Done')
+  })
+})

--- a/src/shared/jira-transition-fields.test.ts
+++ b/src/shared/jira-transition-fields.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildResolutionFieldValue,
+  transitionAllowedValueKey,
   classifyTransitionRequirements,
   requiredTransitionFields,
   transitionAllowedValueLabel
@@ -109,5 +110,9 @@ describe('jira-transition-fields', () => {
     expect(buildResolutionFieldValue(field, 'Duplicate')).toEqual({ name: 'Duplicate' })
     expect(buildResolutionFieldValue(field, '  ')).toBeNull()
     expect(transitionAllowedValueLabel({ id: '1', name: 'Done' })).toBe('Done')
+    // Why: draft seed and <option value> must share this id??value??name precedence.
+    expect(transitionAllowedValueKey({ id: '1', name: 'Done', value: 'done' })).toBe('1')
+    expect(transitionAllowedValueKey({ name: 'Duplicate', value: 'dup' })).toBe('dup')
+    expect(transitionAllowedValueKey({ name: 'OnlyName' })).toBe('OnlyName')
   })
 })

--- a/src/shared/jira-transition-fields.ts
+++ b/src/shared/jira-transition-fields.ts
@@ -59,6 +59,11 @@ export function transitionAllowedValueLabel(value: JiraCreateFieldAllowedValue):
   return value.name ?? value.value ?? value.id ?? 'Option'
 }
 
+/** Stable select value / draft key — keep in sync with option `value` and draft seed. */
+export function transitionAllowedValueKey(value: JiraCreateFieldAllowedValue): string {
+  return value.id ?? value.value ?? value.name ?? ''
+}
+
 export function buildResolutionFieldValue(
   field: JiraCreateField,
   selectedId: string

--- a/src/shared/jira-transition-fields.ts
+++ b/src/shared/jira-transition-fields.ts
@@ -1,0 +1,83 @@
+import type { JiraCreateField, JiraCreateFieldAllowedValue, JiraTransition } from './jira-types'
+
+export type JiraTransitionRequirement =
+  | { kind: 'none' }
+  | {
+      kind: 'form'
+      resolution: JiraCreateField | null
+      commentRequired: boolean
+    }
+  | {
+      kind: 'unsupported'
+      fields: JiraCreateField[]
+    }
+
+function isResolutionField(field: JiraCreateField): boolean {
+  return field.key === 'resolution' || field.schema?.type === 'resolution'
+}
+
+function isCommentField(field: JiraCreateField): boolean {
+  return field.key === 'comment' || field.schema?.system === 'comment'
+}
+
+export function requiredTransitionFields(transition: JiraTransition): JiraCreateField[] {
+  return (transition.fields ?? []).filter((field) => field.required)
+}
+
+export function classifyTransitionRequirements(
+  transition: JiraTransition
+): JiraTransitionRequirement {
+  const required = requiredTransitionFields(transition)
+  if (required.length === 0) {
+    return { kind: 'none' }
+  }
+
+  let resolution: JiraCreateField | null = null
+  let commentRequired = false
+  const unsupported: JiraCreateField[] = []
+
+  for (const field of required) {
+    if (isResolutionField(field)) {
+      resolution = field
+      continue
+    }
+    if (isCommentField(field)) {
+      commentRequired = true
+      continue
+    }
+    unsupported.push(field)
+  }
+
+  if (unsupported.length > 0) {
+    return { kind: 'unsupported', fields: unsupported }
+  }
+
+  return { kind: 'form', resolution, commentRequired }
+}
+
+export function transitionAllowedValueLabel(value: JiraCreateFieldAllowedValue): string {
+  return value.name ?? value.value ?? value.id ?? 'Option'
+}
+
+export function buildResolutionFieldValue(
+  field: JiraCreateField,
+  selectedId: string
+): Record<string, string> | null {
+  const trimmed = selectedId.trim()
+  if (!trimmed) {
+    return null
+  }
+  const match = field.allowedValues?.find(
+    (value) => value.id === trimmed || value.value === trimmed || value.name === trimmed
+  )
+  if (match?.id) {
+    return { id: match.id }
+  }
+  if (match?.name) {
+    return { name: match.name }
+  }
+  if (match?.value) {
+    return { value: match.value }
+  }
+  return { id: trimmed }
+}

--- a/src/shared/jira-types.ts
+++ b/src/shared/jira-types.ts
@@ -62,6 +62,7 @@ export type JiraCreateField = {
     type?: string
     items?: string
     custom?: string
+    system?: string
   }
   allowedValues?: JiraCreateFieldAllowedValue[]
 }
@@ -95,6 +96,8 @@ export type JiraTransition = {
   id: string
   name: string
   to: JiraStatus
+  /** Present when listTransitions requested expand=transitions.fields. */
+  fields?: JiraCreateField[]
 }
 
 export type JiraIssue = {
@@ -130,6 +133,10 @@ export type JiraIssueUpdate = {
   assigneeAccountId?: string | null
   priorityId?: string | null
   transitionId?: string
+  /** Values for transition-required fields (e.g. resolution: { id }). */
+  transitionFields?: Record<string, unknown>
+  /** Comment attached to the transition via update.comment. */
+  transitionComment?: string
 }
 
 export type JiraIssueFilter = 'assigned' | 'reported' | 'all' | 'done'


### PR DESCRIPTION
## Summary
- `listTransitions` requests `expand=transitions.fields` and maps required-field metadata (with bare-list fallback).
- Status pill: one-click for simple transitions; resolution/comment form when required; unsupported required types get a clear message + Open in Jira.
- `updateIssue` posts `fields` / comment update with the transition id.

## Fixes
Closes #10565

## Test plan
- [x] jira issues listTransitions/updateIssue tests, transition-fields unit tests, RPC schema tests
- [ ] Manual: Jira Cloud workflow with resolution-required Close transition

## ELI5

Changing Jira issue status that requires fields like Resolution now prompts for them in Orca instead of failing silently. Simple transitions stay one-click; complex ones get a small form or a clear open-in-Jira path.
