### PR TITLE
feat(status-bar): add default agent switcher popover

### DIFF
--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -314,10 +314,12 @@ describe('renderer startup runtime routing', () => {
     expect(source).toContain("import('./PortsStatusSegment').then")
     expect(source).toContain("import('./SshStatusSegment').then")
     expect(source).toContain("import('./PetStatusSegment').then")
+    expect(source).toContain("import('./DefaultAgentStatusSegment').then")
     expect(source).not.toContain("from './ResourceUsageStatusSegment'")
     expect(source).not.toContain("from './PortsStatusSegment'")
     expect(source).not.toContain("from './SshStatusSegment'")
     expect(source).not.toContain("from './PetStatusSegment'")
+    expect(source).not.toContain("from './DefaultAgentStatusSegment'")
   })
 
   it('does not eagerly import the status bar shell on startup', () => {

--- a/src/renderer/src/components/status-bar/DefaultAgentStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/DefaultAgentStatusSegment.tsx
@@ -1,0 +1,183 @@
+import React, { useCallback, useEffect, useMemo } from 'react'
+import { Check, Settings2, Sparkles, Terminal } from 'lucide-react'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { AgentIcon, getAgentCatalog, getAgentLabel } from '@/lib/agent-catalog'
+import { useAppStore } from '../../store'
+import { translate } from '@/i18n/i18n'
+import { STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS } from './status-bar-context-menu-policy'
+import {
+  listSelectableDefaultAgents,
+  resolveDefaultAgentSelection,
+  resolveDefaultAgentTriggerLabel,
+  type DefaultAgentChoice
+} from './default-agent-status-selection'
+
+function DefaultAgentStatusSegmentInner({ iconOnly }: { iconOnly: boolean }): React.JSX.Element {
+  const defaultAgent = useAppStore((s) => s.settings?.defaultTuiAgent)
+  const disabledAgents = useAppStore((s) => s.settings?.disabledTuiAgents)
+  const updateSettings = useAppStore((s) => s.updateSettings)
+  const detectedAgentIds = useAppStore((s) => s.detectedAgentIds)
+  const ensureDetectedAgents = useAppStore((s) => s.ensureDetectedAgents)
+  const openSettingsPage = useAppStore((s) => s.openSettingsPage)
+  const openSettingsTarget = useAppStore((s) => s.openSettingsTarget)
+
+  useEffect(() => {
+    void ensureDetectedAgents()
+  }, [ensureDetectedAgents])
+
+  const detectedIds = useMemo(
+    () => (detectedAgentIds === null ? null : new Set(detectedAgentIds)),
+    [detectedAgentIds]
+  )
+
+  const selection = useMemo(
+    () =>
+      resolveDefaultAgentSelection({
+        defaultAgent,
+        detectedIds,
+        disabledAgents
+      }),
+    [defaultAgent, detectedIds, disabledAgents]
+  )
+
+  const selectableAgents = useMemo(
+    () =>
+      listSelectableDefaultAgents({
+        catalog: getAgentCatalog(),
+        detectedIds,
+        disabledAgents
+      }),
+    [detectedIds, disabledAgents]
+  )
+
+  const autoLabel = translate('auto.components.status.bar.DefaultAgentStatusSegment.auto', 'Auto')
+  const blankLabel = translate(
+    'auto.components.status.bar.DefaultAgentStatusSegment.blank',
+    'Blank'
+  )
+  const agentLabel =
+    selection.kind === 'agent' && selection.agentId ? getAgentLabel(selection.agentId) : null
+  const triggerLabel = resolveDefaultAgentTriggerLabel({
+    selection,
+    agentLabel,
+    autoLabel,
+    blankLabel
+  })
+
+  const setDefault = useCallback(
+    (next: DefaultAgentChoice) => {
+      void updateSettings({ defaultTuiAgent: next })
+    },
+    [updateSettings]
+  )
+
+  const openAgentSettings = useCallback(() => {
+    openSettingsTarget({ pane: 'agents', repoId: null })
+    openSettingsPage()
+  }, [openSettingsPage, openSettingsTarget])
+
+  const triggerIcon =
+    selection.kind === 'agent' && selection.agentId ? (
+      <AgentIcon agent={selection.agentId} size={12} />
+    ) : selection.kind === 'blank' ? (
+      <Terminal className="size-3 text-muted-foreground" aria-hidden />
+    ) : (
+      <Sparkles className="size-3 text-muted-foreground" aria-hidden />
+    )
+
+  return (
+    <DropdownMenu>
+      <Tooltip delayDuration={150}>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              {...STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded px-1 py-0.5 hover:bg-accent/70"
+              aria-label={translate(
+                'auto.components.status.bar.DefaultAgentStatusSegment.ariaLabel',
+                'Default agent: {{value0}}',
+                { value0: triggerLabel }
+              )}
+            >
+              {triggerIcon}
+              {!iconOnly ? (
+                <span className="max-w-[7rem] truncate text-[11px] font-medium text-muted-foreground">
+                  {triggerLabel}
+                </span>
+              ) : null}
+            </button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="top" sideOffset={6}>
+          {translate(
+            'auto.components.status.bar.DefaultAgentStatusSegment.tooltip',
+            'Default agent — {{value0}}',
+            { value0: triggerLabel }
+          )}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        {...STATUS_BAR_CONTEXT_MENU_EXEMPT_PROPS}
+        side="top"
+        align="end"
+        sideOffset={8}
+        className="min-w-[220px]"
+      >
+        <DropdownMenuLabel>
+          {translate('auto.components.status.bar.DefaultAgentStatusSegment.title', 'Default Agent')}
+        </DropdownMenuLabel>
+        <DropdownMenuItem onSelect={() => setDefault(null)}>
+          <span className="flex w-4 items-center justify-center">
+            {selection.kind === 'auto' ? <Check className="size-3.5" aria-hidden /> : null}
+          </span>
+          <Sparkles className="size-3.5 text-muted-foreground" aria-hidden />
+          <span className="flex-1">{autoLabel}</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setDefault('blank')}>
+          <span className="flex w-4 items-center justify-center">
+            {selection.kind === 'blank' ? <Check className="size-3.5" aria-hidden /> : null}
+          </span>
+          <Terminal className="size-3.5 text-muted-foreground" aria-hidden />
+          <span className="flex-1">
+            {translate(
+              'auto.components.status.bar.DefaultAgentStatusSegment.blankTerminal',
+              'No agent (blank terminal)'
+            )}
+          </span>
+        </DropdownMenuItem>
+        {selectableAgents.length > 0 ? <DropdownMenuSeparator /> : null}
+        {selectableAgents.map((agent) => {
+          const isActive = selection.kind === 'agent' && selection.agentId === agent.id
+          return (
+            <DropdownMenuItem key={agent.id} onSelect={() => setDefault(agent.id)}>
+              <span className="flex w-4 items-center justify-center">
+                {isActive ? <Check className="size-3.5" aria-hidden /> : null}
+              </span>
+              <AgentIcon agent={agent.id} size={14} />
+              <span className="flex-1 truncate">{agent.label}</span>
+            </DropdownMenuItem>
+          )
+        })}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={openAgentSettings}>
+          <Settings2 className="size-3.5" aria-hidden />
+          {translate(
+            'auto.components.status.bar.DefaultAgentStatusSegment.settings',
+            'Agent settings…'
+          )}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export const DefaultAgentStatusSegment = React.memo(DefaultAgentStatusSegmentInner)

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -110,6 +110,11 @@ type StatusBarProps = {
 const PetStatusSegment = lazyWithRetry(() =>
   import('./PetStatusSegment').then((module) => ({ default: module.PetStatusSegment }))
 )
+const DefaultAgentStatusSegment = lazyWithRetry(() =>
+  import('./DefaultAgentStatusSegment').then((module) => ({
+    default: module.DefaultAgentStatusSegment
+  }))
+)
 const ResourceUsageStatusSegment = lazyWithRetry(() =>
   import('./ResourceUsageStatusSegment').then((module) => ({
     default: module.ResourceUsageStatusSegment
@@ -2354,6 +2359,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
         <SkillUpdateStatusSegment iconOnly={iconOnly} />
         <UpdateStatusSegment compact={compact} iconOnly={iconOnly} />
         <React.Suspense fallback={null}>
+          {/* Why: always on (not statusBarItems) so switching default agent is one click, matching Settings > Agents without a dig through the pane. */}
+          <DefaultAgentStatusSegment iconOnly={iconOnly} />
           {petEnabled ? <PetStatusSegment /> : null}
           {showResourceUsage ? (
             <ResourceUsageStatusSegment compact={compact} iconOnly={iconOnly} />

--- a/src/renderer/src/components/status-bar/default-agent-status-selection.test.ts
+++ b/src/renderer/src/components/status-bar/default-agent-status-selection.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest'
+import {
+  listSelectableDefaultAgents,
+  resolveDefaultAgentSelection,
+  resolveDefaultAgentTriggerLabel
+} from './default-agent-status-selection'
+
+const catalog = [
+  { id: 'claude' as const, label: 'Claude' },
+  { id: 'codex' as const, label: 'Codex' },
+  { id: 'gemini' as const, label: 'Gemini' }
+]
+
+describe('resolveDefaultAgentSelection', () => {
+  it('treats blank as an explicit no-agent choice', () => {
+    expect(
+      resolveDefaultAgentSelection({
+        defaultAgent: 'blank',
+        detectedIds: new Set(['claude']),
+        disabledAgents: []
+      })
+    ).toEqual({ kind: 'blank', agentId: null })
+  })
+
+  it('uses Auto when the default is unset', () => {
+    expect(
+      resolveDefaultAgentSelection({
+        defaultAgent: null,
+        detectedIds: new Set(['claude']),
+        disabledAgents: []
+      })
+    ).toEqual({ kind: 'auto', agentId: null })
+  })
+
+  it('falls back to Auto when the chosen agent is missing from PATH', () => {
+    expect(
+      resolveDefaultAgentSelection({
+        defaultAgent: 'codex',
+        detectedIds: new Set(['claude']),
+        disabledAgents: []
+      })
+    ).toEqual({ kind: 'auto', agentId: null })
+  })
+
+  it('falls back to Auto when the chosen agent is disabled', () => {
+    expect(
+      resolveDefaultAgentSelection({
+        defaultAgent: 'codex',
+        detectedIds: new Set(['codex', 'claude']),
+        disabledAgents: ['codex']
+      })
+    ).toEqual({ kind: 'auto', agentId: null })
+  })
+
+  it('keeps a detected enabled agent as the explicit default', () => {
+    expect(
+      resolveDefaultAgentSelection({
+        defaultAgent: 'codex',
+        detectedIds: new Set(['codex', 'claude']),
+        disabledAgents: []
+      })
+    ).toEqual({ kind: 'agent', agentId: 'codex' })
+  })
+
+  it('does not flash Auto while detection is still in flight', () => {
+    // Why: null detection means "unknown", not "missing" — preserve the stored pick.
+    expect(
+      resolveDefaultAgentSelection({
+        defaultAgent: 'codex',
+        detectedIds: null,
+        disabledAgents: []
+      })
+    ).toEqual({ kind: 'agent', agentId: 'codex' })
+  })
+})
+
+describe('listSelectableDefaultAgents', () => {
+  it('returns nothing while detection is pending', () => {
+    expect(
+      listSelectableDefaultAgents({
+        catalog,
+        detectedIds: null,
+        disabledAgents: []
+      })
+    ).toEqual([])
+  })
+
+  it('filters to enabled detected agents in catalog order', () => {
+    expect(
+      listSelectableDefaultAgents({
+        catalog,
+        detectedIds: new Set(['gemini', 'claude']),
+        disabledAgents: ['gemini']
+      })
+    ).toEqual([{ id: 'claude', label: 'Claude' }])
+  })
+})
+
+describe('resolveDefaultAgentTriggerLabel', () => {
+  it('labels Auto and blank distinctly from a named agent', () => {
+    expect(
+      resolveDefaultAgentTriggerLabel({
+        selection: { kind: 'auto', agentId: null },
+        agentLabel: 'Codex',
+        autoLabel: 'Auto',
+        blankLabel: 'Blank'
+      })
+    ).toBe('Auto')
+    expect(
+      resolveDefaultAgentTriggerLabel({
+        selection: { kind: 'blank', agentId: null },
+        agentLabel: 'Codex',
+        autoLabel: 'Auto',
+        blankLabel: 'Blank'
+      })
+    ).toBe('Blank')
+    expect(
+      resolveDefaultAgentTriggerLabel({
+        selection: { kind: 'agent', agentId: 'codex' },
+        agentLabel: 'Codex',
+        autoLabel: 'Auto',
+        blankLabel: 'Blank'
+      })
+    ).toBe('Codex')
+  })
+})

--- a/src/renderer/src/components/status-bar/default-agent-status-selection.ts
+++ b/src/renderer/src/components/status-bar/default-agent-status-selection.ts
@@ -1,0 +1,66 @@
+import type { TuiAgent } from '../../../../shared/types'
+import { isTuiAgentEnabled } from '../../../../shared/tui-agent-selection'
+
+export type DefaultAgentChoice = TuiAgent | 'blank' | null
+
+export type DefaultAgentSelectionKind = 'auto' | 'blank' | 'agent'
+
+export type DefaultAgentSelection = {
+  kind: DefaultAgentSelectionKind
+  agentId: TuiAgent | null
+}
+
+export type DefaultAgentCatalogEntry = {
+  id: TuiAgent
+  label: string
+}
+
+/** Resolve which default-agent radio is active — mirrors Settings > Agents. */
+export function resolveDefaultAgentSelection(args: {
+  defaultAgent: DefaultAgentChoice | undefined
+  detectedIds: ReadonlySet<string> | null
+  disabledAgents: Iterable<unknown> | null | undefined
+}): DefaultAgentSelection {
+  const { defaultAgent, detectedIds, disabledAgents } = args
+  if (defaultAgent === 'blank') {
+    return { kind: 'blank', agentId: null }
+  }
+  if (
+    defaultAgent == null ||
+    (detectedIds !== null && !detectedIds.has(defaultAgent)) ||
+    !isTuiAgentEnabled(defaultAgent, disabledAgents)
+  ) {
+    return { kind: 'auto', agentId: null }
+  }
+  return { kind: 'agent', agentId: defaultAgent }
+}
+
+/** Enabled + detected agents in catalog order for the status-bar picker. */
+export function listSelectableDefaultAgents(args: {
+  catalog: readonly DefaultAgentCatalogEntry[]
+  detectedIds: ReadonlySet<string> | null
+  disabledAgents: Iterable<unknown> | null | undefined
+}): DefaultAgentCatalogEntry[] {
+  const { catalog, detectedIds, disabledAgents } = args
+  if (detectedIds === null) {
+    return []
+  }
+  return catalog.filter(
+    (entry) => detectedIds.has(entry.id) && isTuiAgentEnabled(entry.id, disabledAgents)
+  )
+}
+
+export function resolveDefaultAgentTriggerLabel(args: {
+  selection: DefaultAgentSelection
+  agentLabel: string | null | undefined
+  autoLabel: string
+  blankLabel: string
+}): string {
+  if (args.selection.kind === 'auto') {
+    return args.autoLabel
+  }
+  if (args.selection.kind === 'blank') {
+    return args.blankLabel
+  }
+  return args.agentLabel?.trim() || args.selection.agentId || args.autoLabel
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3420,6 +3420,15 @@
                 "rssDescription": "Summed resident set size (RSS). Shared or aliased pages can appear in more than one process."
               }
             }
+          },
+          "DefaultAgentStatusSegment": {
+            "auto": "Auto",
+            "blank": "Blank",
+            "ariaLabel": "Default agent: {{value0}}",
+            "tooltip": "Default agent — {{value0}}",
+            "title": "Default Agent",
+            "blankTerminal": "No agent (blank terminal)",
+            "settings": "Agent settings…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -3397,6 +3397,15 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "Stopping the skill update…",
             "stoppingAria": "Stopping the skill update. Click to open details."
+          },
+          "DefaultAgentStatusSegment": {
+            "auto": "Auto",
+            "blank": "Blank",
+            "ariaLabel": "Default agent: {{value0}}",
+            "tooltip": "Default agent — {{value0}}",
+            "title": "Default Agent",
+            "blankTerminal": "No agent (blank terminal)",
+            "settings": "Agent settings…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3397,6 +3397,15 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "Stopping the skill update…",
             "stoppingAria": "Stopping the skill update. Click to open details."
+          },
+          "DefaultAgentStatusSegment": {
+            "auto": "Auto",
+            "blank": "Blank",
+            "ariaLabel": "Default agent: {{value0}}",
+            "tooltip": "Default agent — {{value0}}",
+            "title": "Default Agent",
+            "blankTerminal": "No agent (blank terminal)",
+            "settings": "Agent settings…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -3397,6 +3397,15 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "Stopping the skill update…",
             "stoppingAria": "Stopping the skill update. Click to open details."
+          },
+          "DefaultAgentStatusSegment": {
+            "auto": "Auto",
+            "blank": "Blank",
+            "ariaLabel": "Default agent: {{value0}}",
+            "tooltip": "Default agent — {{value0}}",
+            "title": "Default Agent",
+            "blankTerminal": "No agent (blank terminal)",
+            "settings": "Agent settings…"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -3397,6 +3397,15 @@
             "stoppingLabel": "Stopping update",
             "stoppingTooltip": "Stopping the skill update…",
             "stoppingAria": "Stopping the skill update. Click to open details."
+          },
+          "DefaultAgentStatusSegment": {
+            "auto": "Auto",
+            "blank": "Blank",
+            "ariaLabel": "Default agent: {{value0}}",
+            "tooltip": "Default agent — {{value0}}",
+            "title": "Default Agent",
+            "blankTerminal": "No agent (blank terminal)",
+            "settings": "Agent settings…"
           }
         }
       },


### PR DESCRIPTION
## Summary
- Bottom status bar exposes a default-agent segment (icon + label) with a popover to switch Auto / Blank / installed agents without opening Settings.
- Uses the same `defaultTuiAgent` settings path as Agents settings.
- Locale keys added for en + parity locales.

## Fixes
Closes #10452

## Test plan
- [x] default-agent selection unit tests + app-startup lazy import regression
- [ ] Manual: change default agent from status bar; confirm Settings reflects the change

## ELI5

The bottom status bar gets a default-agent switcher so you can change Auto / Blank / installed agents without opening Settings — same setting, faster access.
