### PR TITLE
feat(git): opt-in run glab on SSH execution host

### DIFF
--- a/src/main/git/glab-ssh-execution.test.ts
+++ b/src/main/git/glab-ssh-execution.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { JsonRpcErrorCode } from '../ssh/relay-protocol'
+import { GLAB_EXEC_METHOD } from '../../shared/ssh-types'
+import {
+  clearGlabSshCapabilityStateForTests,
+  setGlabSshExecutionDepsForTests,
+  tryGlabOnSshHost
+} from './glab-ssh-execution'
+
+describe('tryGlabOnSshHost', () => {
+  const requestA = vi.fn()
+  const requestB = vi.fn()
+  const muxA = { request: requestA }
+  const muxB = { request: requestB }
+  const targets = new Map<string, { runGitLabCliOnHost?: boolean }>()
+
+  beforeEach(() => {
+    clearGlabSshCapabilityStateForTests()
+    requestA.mockReset()
+    requestB.mockReset()
+    targets.clear()
+    setGlabSshExecutionDepsForTests({
+      getTarget: (id) => targets.get(id),
+      getMux: (id) => {
+        if (id === 'host-a') {
+          return muxA
+        }
+        if (id === 'host-b') {
+          return muxB
+        }
+        return undefined
+      }
+    })
+  })
+
+  afterEach(() => {
+    setGlabSshExecutionDepsForTests(null)
+    clearGlabSshCapabilityStateForTests()
+  })
+
+  it('returns null when the target flag is off (no relay request)', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: false })
+    await expect(
+      tryGlabOnSshHost(['mr', 'list'], { sshTargetId: 'host-a', remoteCwd: '/repo' })
+    ).resolves.toBeNull()
+    expect(requestA).not.toHaveBeenCalled()
+  })
+
+  it('returns null when the target is missing or disconnected', async () => {
+    await expect(
+      tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'missing' })
+    ).resolves.toBeNull()
+
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    setGlabSshExecutionDepsForTests({
+      getTarget: (id) => targets.get(id),
+      getMux: () => undefined
+    })
+    await expect(
+      tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'host-a' })
+    ).resolves.toBeNull()
+  })
+
+  it('routes glab through the relay when flag is on and connected', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    requestA.mockResolvedValueOnce({
+      stdout: '{"iid":1}',
+      stderr: '',
+      exitCode: 0
+    })
+
+    await expect(
+      tryGlabOnSshHost(['mr', 'view', '1', '--output', 'json'], {
+        sshTargetId: 'host-a',
+        remoteCwd: '/home/user/repo',
+        timeout: 12_000,
+        env: { GITLAB_HOST: 'gitlab.example.com' }
+      })
+    ).resolves.toEqual({ stdout: '{"iid":1}', stderr: '' })
+
+    expect(requestA).toHaveBeenCalledWith(GLAB_EXEC_METHOD, {
+      args: ['mr', 'view', '1', '--output', 'json'],
+      cwd: '/home/user/repo',
+      timeoutMs: 12_000,
+      env: { GITLAB_HOST: 'gitlab.example.com' }
+    })
+  })
+
+  it('falls back to local and caches method-not-found per mux (no repeated probes)', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    const methodNotFound = Object.assign(new Error('Method not found: glab.exec'), {
+      code: JsonRpcErrorCode.MethodNotFound
+    })
+    requestA.mockRejectedValue(methodNotFound)
+
+    await expect(
+      tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'host-a' })
+    ).resolves.toBeNull()
+    await expect(tryGlabOnSshHost(['mr', 'list'], { sshTargetId: 'host-a' })).resolves.toBeNull()
+
+    expect(requestA).toHaveBeenCalledTimes(1)
+  })
+
+  it('isolates capability state across SSH targets', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    targets.set('host-b', { runGitLabCliOnHost: true })
+    const methodNotFound = Object.assign(new Error('Method not found: glab.exec'), {
+      code: JsonRpcErrorCode.MethodNotFound
+    })
+    requestA.mockRejectedValue(methodNotFound)
+    requestB.mockResolvedValue({ stdout: 'ok', stderr: '', exitCode: 0 })
+
+    await expect(
+      tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'host-a' })
+    ).resolves.toBeNull()
+    await expect(tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'host-b' })).resolves.toEqual({
+      stdout: 'ok',
+      stderr: ''
+    })
+
+    expect(requestA).toHaveBeenCalledTimes(1)
+    expect(requestB).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a fresh capability probe after reconnect (new mux object)', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    const methodNotFound = Object.assign(new Error('Method not found: glab.exec'), {
+      code: JsonRpcErrorCode.MethodNotFound
+    })
+    requestA.mockRejectedValueOnce(methodNotFound)
+
+    await expect(
+      tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'host-a' })
+    ).resolves.toBeNull()
+    expect(requestA).toHaveBeenCalledTimes(1)
+
+    const requestA2 = vi.fn().mockResolvedValue({ stdout: 'fresh', stderr: '', exitCode: 0 })
+    const muxA2 = { request: requestA2 }
+    setGlabSshExecutionDepsForTests({
+      getTarget: (id) => targets.get(id),
+      getMux: (id) => (id === 'host-a' ? muxA2 : undefined)
+    })
+
+    await expect(tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'host-a' })).resolves.toEqual({
+      stdout: 'fresh',
+      stderr: ''
+    })
+    expect(requestA2).toHaveBeenCalledTimes(1)
+  })
+
+  it('shares concurrent first probes and does not double-request', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    let resolveRequest!: (value: unknown) => void
+    requestA.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRequest = resolve
+        })
+    )
+
+    const first = tryGlabOnSshHost(['auth', 'status'], { sshTargetId: 'host-a' })
+    const second = tryGlabOnSshHost(['mr', 'list'], { sshTargetId: 'host-a' })
+    // Why: both waiters share the in-flight probe; only the probe issues the first request.
+    await Promise.resolve()
+    expect(requestA).toHaveBeenCalledTimes(1)
+
+    resolveRequest({ stdout: 'p1', stderr: '', exitCode: 0 })
+    // After probe succeeds, the waiter re-runs its own preferred command.
+    requestA.mockResolvedValueOnce({ stdout: 'p2', stderr: '', exitCode: 0 })
+
+    await expect(first).resolves.toEqual({ stdout: 'p1', stderr: '' })
+    await expect(second).resolves.toEqual({ stdout: 'p2', stderr: '' })
+  })
+
+  it('surfaces remote glab failures without local fallback', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    requestA.mockResolvedValueOnce({
+      stdout: '',
+      stderr: 'HTTP 401 Unauthorized',
+      exitCode: 1
+    })
+
+    await expect(tryGlabOnSshHost(['api', 'user'], { sshTargetId: 'host-a' })).rejects.toThrow(
+      /401/
+    )
+    expect(requestA).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/git/glab-ssh-execution.test.ts
+++ b/src/main/git/glab-ssh-execution.test.ts
@@ -78,12 +78,35 @@ describe('tryGlabOnSshHost', () => {
       })
     ).resolves.toEqual({ stdout: '{"iid":1}', stderr: '' })
 
-    expect(requestA).toHaveBeenCalledWith(GLAB_EXEC_METHOD, {
-      args: ['mr', 'view', '1', '--output', 'json'],
-      cwd: '/home/user/repo',
-      timeoutMs: 12_000,
-      env: { GITLAB_HOST: 'gitlab.example.com' }
-    })
+    expect(requestA).toHaveBeenCalledWith(
+      GLAB_EXEC_METHOD,
+      {
+        args: ['mr', 'view', '1', '--output', 'json'],
+        cwd: '/home/user/repo',
+        timeoutMs: 12_000,
+        env: { GITLAB_HOST: 'gitlab.example.com' }
+      },
+      undefined
+    )
+  })
+
+  it('forwards AbortSignal to the mux request so callers can cancel remote glab', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    const controller = new AbortController()
+    requestA.mockResolvedValueOnce({ stdout: 'ok', stderr: '', exitCode: 0 })
+
+    await expect(
+      tryGlabOnSshHost(['auth', 'status'], {
+        sshTargetId: 'host-a',
+        signal: controller.signal
+      })
+    ).resolves.toEqual({ stdout: 'ok', stderr: '' })
+
+    expect(requestA).toHaveBeenCalledWith(
+      GLAB_EXEC_METHOD,
+      { args: ['auth', 'status'] },
+      { signal: controller.signal }
+    )
   })
 
   it('falls back to local and caches method-not-found per mux (no repeated probes)', async () => {

--- a/src/main/git/glab-ssh-execution.test.ts
+++ b/src/main/git/glab-ssh-execution.test.ts
@@ -208,4 +208,20 @@ describe('tryGlabOnSshHost', () => {
     )
     expect(requestA).toHaveBeenCalledTimes(1)
   })
+
+  it('surfaces outputLimitExceeded as a diagnosable error (not code unknown)', async () => {
+    targets.set('host-a', { runGitLabCliOnHost: true })
+    requestA.mockResolvedValueOnce({
+      stdout: 'partial',
+      stderr: '',
+      exitCode: null,
+      timedOut: false,
+      outputLimitExceeded: 'stdout'
+    })
+
+    await expect(
+      tryGlabOnSshHost(['api', 'projects'], { sshTargetId: 'host-a', remoteCwd: '/repo' })
+    ).rejects.toThrow('glab stdout exceeded capture limit on SSH host')
+  })
+
 })

--- a/src/main/git/glab-ssh-execution.ts
+++ b/src/main/git/glab-ssh-execution.ts
@@ -14,7 +14,11 @@ type GlabRemoteExecResult = {
 }
 
 type MuxLike = {
-  request: (method: string, params: Record<string, unknown>) => Promise<unknown>
+  request: (
+    method: string,
+    params: Record<string, unknown>,
+    options?: { signal?: AbortSignal; timeoutMs?: number }
+  ) => Promise<unknown>
 }
 
 export type GlabSshExecutionDeps = {
@@ -99,14 +103,19 @@ async function requestRemoteGlab(
     remoteCwd?: string
     timeout?: number
     env?: NodeJS.ProcessEnv
+    signal?: AbortSignal
   }
 ): Promise<{ stdout: string; stderr: string }> {
-  const result = (await mux.request(GLAB_EXEC_METHOD, {
-    args,
-    ...(options.remoteCwd ? { cwd: options.remoteCwd } : {}),
-    ...(typeof options.timeout === 'number' ? { timeoutMs: options.timeout } : {}),
-    ...(options.env ? { env: options.env } : {})
-  })) as GlabRemoteExecResult
+  const result = (await mux.request(
+    GLAB_EXEC_METHOD,
+    {
+      args,
+      ...(options.remoteCwd ? { cwd: options.remoteCwd } : {}),
+      ...(typeof options.timeout === 'number' ? { timeoutMs: options.timeout } : {}),
+      ...(options.env ? { env: options.env } : {})
+    },
+    options.signal ? { signal: options.signal } : undefined
+  )) as GlabRemoteExecResult
 
   if (typeof result.spawnError === 'string' && result.spawnError.length > 0) {
     throwRemoteGlabFailure(result)
@@ -135,6 +144,7 @@ export async function tryGlabOnSshHost(
     remoteCwd?: string
     timeout?: number
     env?: NodeJS.ProcessEnv
+    signal?: AbortSignal
   }
 ): Promise<{ stdout: string; stderr: string } | null> {
   const target = deps.getTarget(options.sshTargetId)

--- a/src/main/git/glab-ssh-execution.ts
+++ b/src/main/git/glab-ssh-execution.ts
@@ -11,6 +11,7 @@ type GlabRemoteExecResult = {
   exitCode?: unknown
   timedOut?: unknown
   spawnError?: unknown
+  outputLimitExceeded?: unknown
 }
 
 type MuxLike = {
@@ -74,17 +75,26 @@ function asString(value: unknown): string {
   return typeof value === 'string' ? value : ''
 }
 
+function outputLimitExceededStream(
+  value: unknown
+): 'stdout' | 'stderr' | undefined {
+  return value === 'stdout' || value === 'stderr' ? value : undefined
+}
+
 function throwRemoteGlabFailure(result: GlabRemoteExecResult): never {
   const stdout = asString(result.stdout)
   const stderr = asString(result.stderr)
   const spawnError = typeof result.spawnError === 'string' ? result.spawnError : undefined
   const timedOut = result.timedOut === true
+  const outputLimitExceeded = outputLimitExceededStream(result.outputLimitExceeded)
   const exitCode = typeof result.exitCode === 'number' ? result.exitCode : null
   const message =
     spawnError ??
     (timedOut
       ? 'glab timed out on SSH host'
-      : stderr.trim() || `glab exited with code ${exitCode ?? 'unknown'} on SSH host`)
+      : outputLimitExceeded
+        ? `glab ${outputLimitExceeded} exceeded capture limit on SSH host`
+        : stderr.trim() || `glab exited with code ${exitCode ?? 'unknown'} on SSH host`)
   const error = new Error(message) as Error & {
     code?: string | number | null
     stdout?: string
@@ -121,6 +131,9 @@ async function requestRemoteGlab(
     throwRemoteGlabFailure(result)
   }
   if (result.timedOut === true) {
+    throwRemoteGlabFailure(result)
+  }
+  if (outputLimitExceededStream(result.outputLimitExceeded)) {
     throwRemoteGlabFailure(result)
   }
   const exitCode = typeof result.exitCode === 'number' ? result.exitCode : null

--- a/src/main/git/glab-ssh-execution.ts
+++ b/src/main/git/glab-ssh-execution.ts
@@ -1,0 +1,210 @@
+import { GLAB_EXEC_METHOD } from '../../shared/ssh-types'
+import { GIT_CAPABILITY_RETRY_INTERVAL_MS } from '../../shared/git-capability-cache'
+import { JsonRpcErrorCode } from '../ssh/relay-protocol'
+import { getActiveMultiplexer, getSshConnectionStore } from '../ipc/ssh'
+
+export { GLAB_EXEC_METHOD }
+
+type GlabRemoteExecResult = {
+  stdout?: unknown
+  stderr?: unknown
+  exitCode?: unknown
+  timedOut?: unknown
+  spawnError?: unknown
+}
+
+type MuxLike = {
+  request: (method: string, params: Record<string, unknown>) => Promise<unknown>
+}
+
+export type GlabSshExecutionDeps = {
+  getTarget: (id: string) => { runGitLabCliOnHost?: boolean } | undefined
+  getMux: (id: string) => MuxLike | undefined
+}
+
+const defaultDeps: GlabSshExecutionDeps = {
+  getTarget: (id) => getSshConnectionStore()?.getTarget(id),
+  getMux: (id) => getActiveMultiplexer(id)
+}
+
+let deps: GlabSshExecutionDeps = defaultDeps
+
+/** @internal test seam */
+export function setGlabSshExecutionDepsForTests(next: Partial<GlabSshExecutionDeps> | null): void {
+  deps = next ? { ...defaultDeps, ...next } : defaultDeps
+}
+
+type CapabilityProbeOutcome = 'supported' | 'unsupported' | 'unknown'
+
+type GlabRemoteCapabilityState = {
+  supported: boolean
+  unsupportedUntilMs?: number
+  inFlight?: Promise<CapabilityProbeOutcome>
+}
+
+// Why: reconnect replaces the mux object; WeakMap drops stale capability results automatically.
+let capabilitiesByMux = new WeakMap<object, GlabRemoteCapabilityState>()
+
+/** @internal test seam */
+export function clearGlabSshCapabilityStateForTests(): void {
+  capabilitiesByMux = new WeakMap()
+}
+
+function getCapabilityState(mux: object): GlabRemoteCapabilityState {
+  let state = capabilitiesByMux.get(mux)
+  if (!state) {
+    state = { supported: false }
+    capabilitiesByMux.set(mux, state)
+  }
+  return state
+}
+
+function isMethodNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false
+  }
+  return (err as { code?: unknown }).code === JsonRpcErrorCode.MethodNotFound
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function throwRemoteGlabFailure(result: GlabRemoteExecResult): never {
+  const stdout = asString(result.stdout)
+  const stderr = asString(result.stderr)
+  const spawnError = typeof result.spawnError === 'string' ? result.spawnError : undefined
+  const timedOut = result.timedOut === true
+  const exitCode = typeof result.exitCode === 'number' ? result.exitCode : null
+  const message =
+    spawnError ??
+    (timedOut
+      ? 'glab timed out on SSH host'
+      : stderr.trim() || `glab exited with code ${exitCode ?? 'unknown'} on SSH host`)
+  const error = new Error(message) as Error & {
+    code?: string | number | null
+    stdout?: string
+    stderr?: string
+  }
+  error.code = spawnError ? 'ENOENT' : exitCode
+  error.stdout = stdout
+  error.stderr = stderr
+  throw error
+}
+
+async function requestRemoteGlab(
+  mux: MuxLike,
+  args: string[],
+  options: {
+    remoteCwd?: string
+    timeout?: number
+    env?: NodeJS.ProcessEnv
+  }
+): Promise<{ stdout: string; stderr: string }> {
+  const result = (await mux.request(GLAB_EXEC_METHOD, {
+    args,
+    ...(options.remoteCwd ? { cwd: options.remoteCwd } : {}),
+    ...(typeof options.timeout === 'number' ? { timeoutMs: options.timeout } : {}),
+    ...(options.env ? { env: options.env } : {})
+  })) as GlabRemoteExecResult
+
+  if (typeof result.spawnError === 'string' && result.spawnError.length > 0) {
+    throwRemoteGlabFailure(result)
+  }
+  if (result.timedOut === true) {
+    throwRemoteGlabFailure(result)
+  }
+  const exitCode = typeof result.exitCode === 'number' ? result.exitCode : null
+  if (exitCode !== 0) {
+    throwRemoteGlabFailure(result)
+  }
+  return {
+    stdout: asString(result.stdout),
+    stderr: asString(result.stderr)
+  }
+}
+
+/**
+ * When the SSH target opts in and a live mux exists, run glab on the host.
+ * Returns null to signal "use local path" (flag off, disconnected, or capability unavailable).
+ */
+export async function tryGlabOnSshHost(
+  args: string[],
+  options: {
+    sshTargetId: string
+    remoteCwd?: string
+    timeout?: number
+    env?: NodeJS.ProcessEnv
+  }
+): Promise<{ stdout: string; stderr: string } | null> {
+  const target = deps.getTarget(options.sshTargetId)
+  if (!target?.runGitLabCliOnHost) {
+    return null
+  }
+  const mux = deps.getMux(options.sshTargetId)
+  if (!mux) {
+    return null
+  }
+
+  const state = getCapabilityState(mux)
+  const nowMs = Date.now()
+  if (
+    !state.supported &&
+    state.unsupportedUntilMs !== undefined &&
+    nowMs < state.unsupportedUntilMs
+  ) {
+    return null
+  }
+
+  const runPreferred = (): Promise<{ stdout: string; stderr: string }> =>
+    requestRemoteGlab(mux, args, options)
+
+  if (state.supported) {
+    return runPreferred()
+  }
+
+  if (state.inFlight) {
+    const outcome = await state.inFlight
+    if (outcome === 'unsupported') {
+      return null
+    }
+    if (
+      !state.supported &&
+      state.unsupportedUntilMs !== undefined &&
+      Date.now() < state.unsupportedUntilMs
+    ) {
+      return null
+    }
+    return runPreferred()
+  }
+
+  let settleProbe!: (outcome: CapabilityProbeOutcome) => void
+  const probe = new Promise<CapabilityProbeOutcome>((resolve) => {
+    settleProbe = resolve
+  })
+  state.inFlight = probe
+  try {
+    const result = await runPreferred()
+    state.supported = true
+    state.unsupportedUntilMs = undefined
+    settleProbe('supported')
+    return result
+  } catch (error) {
+    if (isMethodNotFoundError(error)) {
+      // Why: old relays lack glab.exec; cache unavailable so we don't re-probe every MR poll.
+      state.supported = false
+      state.unsupportedUntilMs = Date.now() + GIT_CAPABILITY_RETRY_INTERVAL_MS
+      settleProbe('unsupported')
+      return null
+    }
+    // Handler exists; a glab-level failure is not a protocol capability miss.
+    state.supported = true
+    state.unsupportedUntilMs = undefined
+    settleProbe('unknown')
+    throw error
+  } finally {
+    if (state.inFlight === probe) {
+      state.inFlight = undefined
+    }
+  }
+}

--- a/src/main/git/runner-glab-ssh.test.ts
+++ b/src/main/git/runner-glab-ssh.test.ts
@@ -41,11 +41,13 @@ describe('glabExecFileAsync SSH execution host routing', () => {
 
   it('uses remote result when tryGlabOnSshHost succeeds', async () => {
     tryGlabOnSshHostMock.mockResolvedValueOnce({ stdout: 'remote-mr', stderr: '' })
+    const controller = new AbortController()
 
     await expect(
       glabExecFileAsync(['mr', 'view', '1'], {
         sshTargetId: 'ssh-1',
-        remoteCwd: '/remote/repo'
+        remoteCwd: '/remote/repo',
+        signal: controller.signal
       })
     ).resolves.toEqual({ stdout: 'remote-mr', stderr: '' })
 
@@ -53,7 +55,8 @@ describe('glabExecFileAsync SSH execution host routing', () => {
       ['mr', 'view', '1'],
       expect.objectContaining({
         sshTargetId: 'ssh-1',
-        remoteCwd: '/remote/repo'
+        remoteCwd: '/remote/repo',
+        signal: controller.signal
       })
     )
     expect(execFileMock).not.toHaveBeenCalled()

--- a/src/main/git/runner-glab-ssh.test.ts
+++ b/src/main/git/runner-glab-ssh.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, tryGlabOnSshHostMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  tryGlabOnSshHostMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: vi.fn(),
+  spawn: vi.fn()
+}))
+
+vi.mock('./glab-ssh-execution', () => ({
+  tryGlabOnSshHost: tryGlabOnSshHostMock
+}))
+
+import { glabExecFileAsync } from './runner'
+
+describe('glabExecFileAsync SSH execution host routing', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    tryGlabOnSshHostMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the local path when no sshTargetId is provided', async () => {
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, { stdout: 'local', stderr: '' })
+    })
+
+    await expect(glabExecFileAsync(['auth', 'status'])).resolves.toEqual({
+      stdout: 'local',
+      stderr: ''
+    })
+    expect(tryGlabOnSshHostMock).not.toHaveBeenCalled()
+  })
+
+  it('uses remote result when tryGlabOnSshHost succeeds', async () => {
+    tryGlabOnSshHostMock.mockResolvedValueOnce({ stdout: 'remote-mr', stderr: '' })
+
+    await expect(
+      glabExecFileAsync(['mr', 'view', '1'], {
+        sshTargetId: 'ssh-1',
+        remoteCwd: '/remote/repo'
+      })
+    ).resolves.toEqual({ stdout: 'remote-mr', stderr: '' })
+
+    expect(tryGlabOnSshHostMock).toHaveBeenCalledWith(
+      ['mr', 'view', '1'],
+      expect.objectContaining({
+        sshTargetId: 'ssh-1',
+        remoteCwd: '/remote/repo'
+      })
+    )
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to local exec when remote path returns null', async () => {
+    tryGlabOnSshHostMock.mockResolvedValueOnce(null)
+    execFileMock.mockImplementation((_bin, _args, _opts, cb) => {
+      cb(null, { stdout: 'local-fallback', stderr: '' })
+    })
+
+    await expect(
+      glabExecFileAsync(['api', 'user'], { sshTargetId: 'ssh-1', remoteCwd: '/repo' })
+    ).resolves.toEqual({ stdout: 'local-fallback', stderr: '' })
+
+    expect(tryGlabOnSshHostMock).toHaveBeenCalled()
+    expect(execFileMock).toHaveBeenCalled()
+  })
+})

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -43,6 +43,7 @@ import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
 import { endSubprocessStdin } from '../../shared/subprocess-stdin-write'
 // Re-exported for existing importers; lightweight consumers should import from './exec-error' to avoid this heavy module.
 import { extractExecError, parseRetryAfterMs } from './exec-error'
+import { tryGlabOnSshHost } from './glab-ssh-execution'
 export { extractExecError, parseRetryAfterMs }
 
 // ─── Core resolution ────────────────────────────────────────────────
@@ -1497,6 +1498,10 @@ type GlabExecOptions = Omit<GitExecOptions, 'cwd'> & {
   wslDistro?: string
   idempotent?: boolean
   allowDefaultWslFallback?: boolean
+  /** SSH target id (connectionId) for opt-in remote glab via relay. */
+  sshTargetId?: string | null
+  /** Remote worktree/repo path used as cwd when glab runs on the SSH host. */
+  remoteCwd?: string
 }
 
 /** Async glab CLI execution; drop-in for execFileAsync('glab', …). Retry policy mirrors ghExecFileAsync. */
@@ -1527,6 +1532,18 @@ export async function glabExecFileAsync(
   options: GlabExecOptions = {}
 ): Promise<{ stdout: string; stderr: string }> {
   ;({ args, options } = redirectPortedHostnameToEnv(args, options))
+  // Why: repo-scoped SSH workspaces can opt into host-side glab (credentials live on the box).
+  if (options.sshTargetId) {
+    const remote = await tryGlabOnSshHost(args, {
+      sshTargetId: options.sshTargetId,
+      remoteCwd: options.remoteCwd,
+      timeout: options.timeout,
+      env: options.env
+    })
+    if (remote) {
+      return remote
+    }
+  }
   let resolved = resolveCommand('glab', args, options.cwd, options.wslDistro)
   let lastError: unknown
   let attemptedDefaultWslFallback = false

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -1538,7 +1538,8 @@ export async function glabExecFileAsync(
       sshTargetId: options.sshTargetId,
       remoteCwd: options.remoteCwd,
       timeout: options.timeout,
-      env: options.env
+      env: options.env,
+      signal: options.signal
     })
     if (remote) {
       return remote

--- a/src/main/gitlab/gitlab-project-ref-resolution.ts
+++ b/src/main/gitlab/gitlab-project-ref-resolution.ts
@@ -246,9 +246,16 @@ export function glabRepoExecOptions(
   repoPath: string,
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
-): { cwd?: string; wslDistro?: string } {
+): {
+  cwd?: string
+  wslDistro?: string
+  sshTargetId?: string
+  remoteCwd?: string
+} {
+  // Why: sshTargetId lets glabExecFileAsync try host-side glab when the target opts in;
+  // remoteCwd is only used on that path. Local fallback keeps today's no-cwd behavior.
   return connectionId
-    ? {}
+    ? { sshTargetId: connectionId, remoteCwd: repoPath }
     : {
         cwd: repoPath,
         ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1186,12 +1186,14 @@ function normalizeSshTarget(t: SshTarget): SshTarget {
   const currentGracePeriodSeconds = target.relayGracePeriodSeconds
   const legacyGracePeriodSeconds = target.remoteWorkspaceSyncGracePeriodSeconds
   const systemSshConnectionReuse = target.systemSshConnectionReuse
+  const runGitLabCliOnHost = target.runGitLabCliOnHost
   // Why: remote sync now follows the SSH relay lifecycle, so retired per-target sync/grace fields are dropped at disk load.
   delete target.remoteWorkspaceSyncEnabled
   delete target.remoteWorkspaceSyncGracePeriodSeconds
   delete target.relayGracePeriodSeconds
   delete target.systemSshConnectionReuse
   delete target.experimentalPtySourceCreditV1
+  delete target.runGitLabCliOnHost
   // Why: prefer the synced grace over stale relayGracePeriodSeconds so a user's "unlimited" (0) survives migration.
   const relayGracePeriodSeconds =
     legacySyncEnabled === true && typeof legacyGracePeriodSeconds === 'number'
@@ -1210,6 +1212,10 @@ function normalizeSshTarget(t: SshTarget): SshTarget {
   }
   if (systemSshConnectionReuse === false) {
     normalized.systemSshConnectionReuse = false
+  }
+  // Why: opt-in only — omit the field when false so persisted targets stay compact and default-off.
+  if (runGitLabCliOnHost === true) {
+    normalized.runGitLabCliOnHost = true
   }
   return normalized
 }
@@ -6889,6 +6895,9 @@ export class Store {
     }
     if (!Object.hasOwn(normalized, 'systemSshConnectionReuse')) {
       delete target.systemSshConnectionReuse
+    }
+    if (!Object.hasOwn(normalized, 'runGitLabCliOnHost')) {
+      delete target.runGitLabCliOnHost
     }
     this.scheduleSave()
     return { ...target }

--- a/src/relay/glab-exec-handler.test.ts
+++ b/src/relay/glab-exec-handler.test.ts
@@ -121,4 +121,54 @@ describe('GlabExecHandler', () => {
       spawnError: expect.stringContaining('ENOENT')
     })
   })
+
+  it('finishes immediately with outputLimitExceeded when stdout exceeds 4 MiB', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!({
+      args: ['api', 'projects'],
+      timeoutMs: 30_000
+    })
+
+    // Under limit first so partial stdout is retained, then overflow.
+    child.stdout.emit('data', Buffer.from('partial-ok'))
+    child.stdout.emit('data', Buffer.alloc(4 * 1024 * 1024 + 1, 0x61))
+
+    await expect(pending).resolves.toEqual({
+      stdout: 'partial-ok',
+      stderr: '',
+      exitCode: null,
+      timedOut: false,
+      outputLimitExceeded: 'stdout'
+    })
+    expect(child.kill).toHaveBeenCalled()
+
+    // Late close must not overwrite the limit result (finish is settled).
+    child.emit('close', null)
+    await expect(pending).resolves.toMatchObject({ outputLimitExceeded: 'stdout' })
+  })
+
+  it('finishes immediately with outputLimitExceeded when stderr exceeds 4 MiB', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!({
+      args: ['mr', 'list'],
+      timeoutMs: 30_000
+    })
+
+    child.stderr.emit('data', Buffer.alloc(4 * 1024 * 1024 + 1, 0x62))
+
+    await expect(pending).resolves.toEqual({
+      stdout: '',
+      stderr: '',
+      exitCode: null,
+      timedOut: false,
+      outputLimitExceeded: 'stderr'
+    })
+    expect(child.kill).toHaveBeenCalled()
+  })
 })

--- a/src/relay/glab-exec-handler.test.ts
+++ b/src/relay/glab-exec-handler.test.ts
@@ -1,0 +1,124 @@
+import { EventEmitter } from 'node:events'
+import { spawn } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as ChildProcess from 'node:child_process'
+import type { RelayDispatcher } from './dispatcher'
+import { GlabExecHandler } from './glab-exec-handler'
+import { GLAB_EXEC_METHOD } from '../shared/ssh-types'
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof ChildProcess>()
+  return {
+    ...actual,
+    spawn: vi.fn()
+  }
+})
+
+const spawnMock = vi.mocked(spawn)
+
+type FakeChild = EventEmitter & {
+  stdout: EventEmitter
+  stderr: EventEmitter
+  stdin: { end: ReturnType<typeof vi.fn> }
+  pid: number
+  kill: ReturnType<typeof vi.fn>
+}
+
+function createFakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdin = { end: vi.fn() }
+  child.pid = 4242
+  child.kill = vi.fn()
+  return child
+}
+
+function createHandler(): {
+  get: (
+    method: string
+  ) => ((params: Record<string, unknown>, context?: unknown) => Promise<unknown>) | undefined
+} {
+  const handlers = new Map<
+    string,
+    (params: Record<string, unknown>, context?: unknown) => Promise<unknown>
+  >()
+  const dispatcher = {
+    onRequest: (
+      method: string,
+      handler: (params: Record<string, unknown>, context?: unknown) => Promise<unknown>
+    ) => {
+      handlers.set(method, handler)
+    }
+  } as unknown as RelayDispatcher
+  new GlabExecHandler(dispatcher)
+  return { get: (method) => handlers.get(method) }
+}
+
+describe('GlabExecHandler', () => {
+  beforeEach(() => {
+    spawnMock.mockReset()
+  })
+
+  it('spawns exactly glab with argv array (no shell)', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!({
+      args: ['auth', 'status', '--hostname', 'gitlab.com'],
+      cwd: '/home/user/repo',
+      timeoutMs: 5_000
+    })
+
+    child.stdout.emit('data', Buffer.from('{"ok":true}'))
+    child.emit('close', 0)
+
+    await expect(pending).resolves.toEqual({
+      stdout: '{"ok":true}',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    })
+    expect(spawnMock).toHaveBeenCalledWith(
+      'glab',
+      ['auth', 'status', '--hostname', 'gitlab.com'],
+      expect.objectContaining({
+        cwd: '/home/user/repo',
+        shell: false,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        windowsHide: true
+      })
+    )
+  })
+
+  it('never accepts a caller-supplied binary', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!({
+      binary: '/tmp/evil',
+      args: ['version']
+    })
+    child.emit('close', 0)
+    await pending
+
+    expect(spawnMock).toHaveBeenCalledWith('glab', ['version'], expect.any(Object))
+  })
+
+  it('reports spawn errors without throwing', async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('spawn glab ENOENT')
+    })
+    const handlers = createHandler()
+
+    await expect(handlers.get(GLAB_EXEC_METHOD)!({ args: ['version'] })).resolves.toMatchObject({
+      stdout: '',
+      stderr: '',
+      exitCode: null,
+      timedOut: false,
+      spawnError: expect.stringContaining('ENOENT')
+    })
+  })
+})

--- a/src/relay/glab-exec-handler.test.ts
+++ b/src/relay/glab-exec-handler.test.ts
@@ -196,9 +196,7 @@ describe('GlabExecHandler', () => {
     expect(child.kill).toHaveBeenCalled()
   })
 
-  it('terminates glab when the request is already aborted', async () => {
-    const child = createFakeChild()
-    spawnMock.mockReturnValue(child as never)
+  it('does not spawn glab when the request is already aborted', async () => {
     const handlers = createHandler()
     const controller = new AbortController()
     controller.abort()
@@ -208,10 +206,10 @@ describe('GlabExecHandler', () => {
       { signal: controller.signal }
     )
 
-    // Why: abort before spawn still spawns then cancelCurrent kills immediately.
-    expect(child.kill).toHaveBeenCalled()
-    child.emit('close', null)
-    await expect(pending).resolves.toMatchObject({
+    expect(spawnMock).not.toHaveBeenCalled()
+    await expect(pending).resolves.toEqual({
+      stdout: '',
+      stderr: '',
       exitCode: null,
       timedOut: false
     })

--- a/src/relay/glab-exec-handler.test.ts
+++ b/src/relay/glab-exec-handler.test.ts
@@ -92,6 +92,39 @@ describe('GlabExecHandler', () => {
     )
   })
 
+  it('does not let caller env redirect glab executable resolution', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!({
+      args: ['api', 'user'],
+      env: {
+        PATH: '/tmp/attacker-bin',
+        Path: 'C:\\attacker-bin',
+        PATHEXT: '.ATTACK',
+        GITLAB_HOST: 'gitlab.example.com:8443',
+        gitlab_token: 'gitlab-token',
+        GLAB_TOKEN: 'glab-token',
+        OTHER: 'ignored'
+      }
+    })
+    child.emit('close', 0)
+    await pending
+
+    const spawnOptions = spawnMock.mock.calls[0][2] as { env: Record<string, string> }
+    const pathValues = Object.entries(spawnOptions.env)
+      .filter(([key]) => key.toLowerCase() === 'path')
+      .map(([, value]) => value)
+    expect(pathValues).not.toContain('/tmp/attacker-bin')
+    expect(pathValues).not.toContain('C:\\attacker-bin')
+    expect(spawnOptions.env.PATHEXT).not.toBe('.ATTACK')
+    expect(spawnOptions.env.GITLAB_HOST).toBe('gitlab.example.com:8443')
+    expect(spawnOptions.env.GITLAB_TOKEN).toBe('gitlab-token')
+    expect(spawnOptions.env.GLAB_TOKEN).toBe('glab-token')
+    expect(spawnOptions.env.OTHER).toBeUndefined()
+  })
+
   it('never accepts a caller-supplied binary', async () => {
     const child = createFakeChild()
     spawnMock.mockReturnValue(child as never)

--- a/src/relay/glab-exec-handler.test.ts
+++ b/src/relay/glab-exec-handler.test.ts
@@ -195,4 +195,47 @@ describe('GlabExecHandler', () => {
     })
     expect(child.kill).toHaveBeenCalled()
   })
+
+  it('terminates glab when the request is already aborted', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+    const controller = new AbortController()
+    controller.abort()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!(
+      { args: ['version'], timeoutMs: 5_000 },
+      { signal: controller.signal }
+    )
+
+    // Why: abort before spawn still spawns then cancelCurrent kills immediately.
+    expect(child.kill).toHaveBeenCalled()
+    child.emit('close', null)
+    await expect(pending).resolves.toMatchObject({
+      exitCode: null,
+      timedOut: false
+    })
+  })
+
+  it('terminates glab when the request is aborted after spawn', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+    const controller = new AbortController()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!(
+      { args: ['version'], timeoutMs: 5_000 },
+      { signal: controller.signal }
+    )
+
+    expect(child.kill).not.toHaveBeenCalled()
+    controller.abort()
+    expect(child.kill).toHaveBeenCalled()
+    // Why: kill is best-effort; the handler settles only on child close.
+    child.emit('close', null)
+    await expect(pending).resolves.toMatchObject({
+      exitCode: null,
+      timedOut: false
+    })
+  })
 })

--- a/src/relay/glab-exec-handler.test.ts
+++ b/src/relay/glab-exec-handler.test.ts
@@ -150,6 +150,30 @@ describe('GlabExecHandler', () => {
     await expect(pending).resolves.toMatchObject({ outputLimitExceeded: 'stdout' })
   })
 
+  it('preserves a multibyte UTF-8 character split across stream chunks', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child as never)
+    const handlers = createHandler()
+
+    const pending = handlers.get(GLAB_EXEC_METHOD)!({
+      args: ['api', 'user'],
+      timeoutMs: 5_000
+    })
+
+    // € is three bytes (0xE2 0x82 0xAC) — emit split across two data events.
+    const euro = Buffer.from('€', 'utf8')
+    child.stdout.emit('data', euro.subarray(0, 2))
+    child.stdout.emit('data', euro.subarray(2))
+    child.emit('close', 0)
+
+    await expect(pending).resolves.toEqual({
+      stdout: '€',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false
+    })
+  })
+
   it('finishes immediately with outputLimitExceeded when stderr exceeds 4 MiB', async () => {
     const child = createFakeChild()
     spawnMock.mockReturnValue(child as never)

--- a/src/relay/glab-exec-handler.test.ts
+++ b/src/relay/glab-exec-handler.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { spawn } from 'node:child_process'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ChildProcess from 'node:child_process'
 import type { RelayDispatcher } from './dispatcher'
 import { GlabExecHandler } from './glab-exec-handler'
@@ -60,6 +60,10 @@ describe('GlabExecHandler', () => {
     spawnMock.mockReset()
   })
 
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   it('spawns exactly glab with argv array (no shell)', async () => {
     const child = createFakeChild()
     spawnMock.mockReturnValue(child as never)
@@ -96,6 +100,8 @@ describe('GlabExecHandler', () => {
     const child = createFakeChild()
     spawnMock.mockReturnValue(child as never)
     const handlers = createHandler()
+    vi.stubEnv('PATH', '/relay-safe-bin')
+    vi.stubEnv('Path', 'C:\\relay-safe-bin')
 
     const pending = handlers.get(GLAB_EXEC_METHOD)!({
       args: ['api', 'user'],
@@ -116,6 +122,7 @@ describe('GlabExecHandler', () => {
     const pathValues = Object.entries(spawnOptions.env)
       .filter(([key]) => key.toLowerCase() === 'path')
       .map(([, value]) => value)
+    expect(pathValues).toEqual(expect.arrayContaining(['/relay-safe-bin', 'C:\\relay-safe-bin']))
     expect(pathValues).not.toContain('/tmp/attacker-bin')
     expect(pathValues).not.toContain('C:\\attacker-bin')
     expect(spawnOptions.env.PATHEXT).not.toBe('.ATTACK')

--- a/src/relay/glab-exec-handler.ts
+++ b/src/relay/glab-exec-handler.ts
@@ -1,0 +1,157 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import type { RelayDispatcher, RequestContext } from './dispatcher'
+import { terminateRelaySubprocessTree } from './subprocess-tree-termination'
+import { GLAB_EXEC_METHOD } from '../shared/ssh-types'
+
+const DEFAULT_TIMEOUT_MS = 60_000
+const MAX_TIMEOUT_MS = 5 * 60 * 1000
+// Why: glab api payloads can be large, but unbounded capture OOMs the relay.
+const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+const GLAB_BINARY = 'glab'
+
+type GlabExecParams = {
+  args: unknown
+  cwd: unknown
+  timeoutMs: unknown
+  env: unknown
+}
+
+type GlabExecResult = {
+  stdout: string
+  stderr: string
+  exitCode: number | null
+  timedOut: boolean
+  /** Set when `glab` could not be spawned (e.g. ENOENT). */
+  spawnError?: string
+}
+
+/**
+ * Hard-allowlisted remote `glab` exec. Distinct from `agent.execNonInteractive`
+ * so older relays return method-not-found and the desktop can fall back locally.
+ */
+export class GlabExecHandler {
+  constructor(dispatcher: RelayDispatcher) {
+    dispatcher.onRequest(GLAB_EXEC_METHOD, (p, context) => this.exec(p as GlabExecParams, context))
+  }
+
+  private async exec(params: GlabExecParams, context?: RequestContext): Promise<GlabExecResult> {
+    const args = Array.isArray(params.args) ? params.args.map((a) => String(a)) : []
+    const cwd = typeof params.cwd === 'string' && params.cwd.length > 0 ? params.cwd : undefined
+    const requestedTimeout =
+      typeof params.timeoutMs === 'number' ? params.timeoutMs : DEFAULT_TIMEOUT_MS
+    const timeoutMs = Math.max(1_000, Math.min(MAX_TIMEOUT_MS, requestedTimeout))
+    const extraEnv =
+      params.env && typeof params.env === 'object' && !Array.isArray(params.env)
+        ? (params.env as Record<string, string>)
+        : null
+    const spawnEnv = {
+      ...process.env,
+      ...extraEnv
+    } as Record<string, string>
+
+    return new Promise<GlabExecResult>((resolve) => {
+      let child: ChildProcess
+      try {
+        // Why: argv array only — never shell-interpolate user-controlled strings.
+        child = spawn(GLAB_BINARY, args, {
+          cwd,
+          env: spawnEnv,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          windowsHide: true,
+          shell: false
+        })
+      } catch (error) {
+        resolve({
+          stdout: '',
+          stderr: '',
+          exitCode: null,
+          timedOut: false,
+          spawnError: error instanceof Error ? error.message : String(error)
+        })
+        return
+      }
+
+      let stdout = ''
+      let stderr = ''
+      let stdoutBytes = 0
+      let stderrBytes = 0
+      let timedOut = false
+      let settled = false
+      let timer: ReturnType<typeof setTimeout> | null = null
+      let detachChildListeners = (): void => {}
+      let detachRequestAbortListener = (): void => {}
+      const finish = (result: GlabExecResult): void => {
+        if (settled) {
+          return
+        }
+        settled = true
+        if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+        detachRequestAbortListener()
+        detachChildListeners()
+        resolve(result)
+      }
+      const cancelCurrent = (): void => {
+        terminateRelaySubprocessTree(child)
+      }
+
+      timer = setTimeout(() => {
+        timedOut = true
+        terminateRelaySubprocessTree(child)
+        finish({ stdout, stderr, exitCode: null, timedOut })
+      }, timeoutMs)
+
+      const onStdoutData = (chunk: Buffer): void => {
+        stdoutBytes += chunk.byteLength
+        if (stdoutBytes > MAX_OUTPUT_BYTES) {
+          terminateRelaySubprocessTree(child)
+          return
+        }
+        stdout += chunk.toString('utf-8')
+      }
+      const onStderrData = (chunk: Buffer): void => {
+        stderrBytes += chunk.byteLength
+        if (stderrBytes > MAX_OUTPUT_BYTES) {
+          terminateRelaySubprocessTree(child)
+          return
+        }
+        stderr += chunk.toString('utf-8')
+      }
+      const onError = (error: Error): void => {
+        finish({
+          stdout,
+          stderr,
+          exitCode: null,
+          timedOut,
+          spawnError: error.message
+        })
+      }
+      const onClose = (code: number | null): void => {
+        finish({ stdout, stderr, exitCode: code, timedOut })
+      }
+      child.stdout?.on('data', onStdoutData)
+      child.stderr?.on('data', onStderrData)
+      child.on('error', onError)
+      child.on('close', onClose)
+      detachChildListeners = () => {
+        child.stdout?.off('data', onStdoutData)
+        child.stderr?.off('data', onStderrData)
+        child.off('error', onError)
+        child.off('close', onClose)
+      }
+
+      if (context?.signal) {
+        if (context.signal.aborted) {
+          cancelCurrent()
+        } else {
+          context.signal.addEventListener('abort', cancelCurrent, { once: true })
+          detachRequestAbortListener = () => {
+            context.signal?.removeEventListener('abort', cancelCurrent)
+          }
+        }
+      }
+    })
+  }
+}

--- a/src/relay/glab-exec-handler.ts
+++ b/src/relay/glab-exec-handler.ts
@@ -23,6 +23,8 @@ type GlabExecResult = {
   timedOut: boolean
   /** Set when `glab` could not be spawned (e.g. ENOENT). */
   spawnError?: string
+  /** Which stream hit MAX_OUTPUT_BYTES before process close. */
+  outputLimitExceeded?: 'stdout' | 'stderr'
 }
 
 /**
@@ -106,7 +108,16 @@ export class GlabExecHandler {
       const onStdoutData = (chunk: Buffer): void => {
         stdoutBytes += chunk.byteLength
         if (stdoutBytes > MAX_OUTPUT_BYTES) {
+          // Why: finish inline like timeout — deferred onClose yields exitCode null
+          // and "exited with code unknown" with no signal the 4 MiB guard fired.
           terminateRelaySubprocessTree(child)
+          finish({
+            stdout,
+            stderr,
+            exitCode: null,
+            timedOut: false,
+            outputLimitExceeded: 'stdout'
+          })
           return
         }
         stdout += chunk.toString('utf-8')
@@ -115,6 +126,13 @@ export class GlabExecHandler {
         stderrBytes += chunk.byteLength
         if (stderrBytes > MAX_OUTPUT_BYTES) {
           terminateRelaySubprocessTree(child)
+          finish({
+            stdout,
+            stderr,
+            exitCode: null,
+            timedOut: false,
+            outputLimitExceeded: 'stderr'
+          })
           return
         }
         stderr += chunk.toString('utf-8')

--- a/src/relay/glab-exec-handler.ts
+++ b/src/relay/glab-exec-handler.ts
@@ -12,6 +12,11 @@ const MAX_TIMEOUT_MS = 5 * 60 * 1000
 // Why: glab api payloads can be large, but unbounded capture OOMs the relay.
 const MAX_OUTPUT_BYTES = 4 * 1024 * 1024
 const GLAB_BINARY = 'glab'
+const GLAB_ENV_ALLOWLIST = new Map([
+  ['gitlab_host', 'GITLAB_HOST'],
+  ['gitlab_token', 'GITLAB_TOKEN'],
+  ['glab_token', 'GLAB_TOKEN']
+])
 
 type GlabExecParams = {
   args: unknown
@@ -31,6 +36,20 @@ type GlabExecResult = {
   outputLimitExceeded?: 'stdout' | 'stderr'
 }
 
+function pickAllowedGlabEnv(env: Record<string, unknown>): Record<string, string> {
+  const picked: Record<string, string> = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value !== 'string') {
+      continue
+    }
+    const allowedName = GLAB_ENV_ALLOWLIST.get(key.toLowerCase())
+    if (allowedName) {
+      picked[allowedName] = value
+    }
+  }
+  return picked
+}
+
 /**
  * Hard-allowlisted remote `glab` exec. Distinct from `agent.execNonInteractive`
  * so older relays return method-not-found and the desktop can fall back locally.
@@ -48,11 +67,11 @@ export class GlabExecHandler {
     const timeoutMs = Math.max(1_000, Math.min(MAX_TIMEOUT_MS, requestedTimeout))
     const extraEnv =
       params.env && typeof params.env === 'object' && !Array.isArray(params.env)
-        ? (params.env as Record<string, string>)
+        ? (params.env as Record<string, unknown>)
         : null
     const spawnEnv = {
       ...process.env,
-      ...extraEnv
+      ...(extraEnv ? pickAllowedGlabEnv(extraEnv) : {})
     } as Record<string, string>
 
     if (context?.signal?.aborted) {

--- a/src/relay/glab-exec-handler.ts
+++ b/src/relay/glab-exec-handler.ts
@@ -1,7 +1,11 @@
 import { spawn, type ChildProcess } from 'node:child_process'
+import { StringDecoder } from 'node:string_decoder'
 import type { RelayDispatcher, RequestContext } from './dispatcher'
 import { terminateRelaySubprocessTree } from './subprocess-tree-termination'
-import { GLAB_EXEC_METHOD } from '../shared/ssh-types'
+
+// Why: relay is bundled separately from the app — do not import app-side shared
+// modules. Keep this string aligned with src/shared/ssh-types GLAB_EXEC_METHOD.
+const GLAB_EXEC_METHOD = 'glab.exec'
 
 const DEFAULT_TIMEOUT_MS = 60_000
 const MAX_TIMEOUT_MS = 5 * 60 * 1000
@@ -77,6 +81,10 @@ export class GlabExecHandler {
       let stderr = ''
       let stdoutBytes = 0
       let stderrBytes = 0
+      // Why: multibyte UTF-8 can split across stream chunks; per-chunk toString
+      // would inject replacement characters into the captured output.
+      const stdoutDecoder = new StringDecoder('utf8')
+      const stderrDecoder = new StringDecoder('utf8')
       let timedOut = false
       let settled = false
       let timer: ReturnType<typeof setTimeout> | null = null
@@ -95,6 +103,10 @@ export class GlabExecHandler {
         detachChildListeners()
         resolve(result)
       }
+      const flushDecoders = (): { stdout: string; stderr: string } => ({
+        stdout: stdout + stdoutDecoder.end(),
+        stderr: stderr + stderrDecoder.end()
+      })
       const cancelCurrent = (): void => {
         terminateRelaySubprocessTree(child)
       }
@@ -102,7 +114,8 @@ export class GlabExecHandler {
       timer = setTimeout(() => {
         timedOut = true
         terminateRelaySubprocessTree(child)
-        finish({ stdout, stderr, exitCode: null, timedOut })
+        const flushed = flushDecoders()
+        finish({ ...flushed, exitCode: null, timedOut })
       }, timeoutMs)
 
       const onStdoutData = (chunk: Buffer): void => {
@@ -111,43 +124,44 @@ export class GlabExecHandler {
           // Why: finish inline like timeout — deferred onClose yields exitCode null
           // and "exited with code unknown" with no signal the 4 MiB guard fired.
           terminateRelaySubprocessTree(child)
+          const flushed = flushDecoders()
           finish({
-            stdout,
-            stderr,
+            ...flushed,
             exitCode: null,
             timedOut: false,
             outputLimitExceeded: 'stdout'
           })
           return
         }
-        stdout += chunk.toString('utf-8')
+        stdout += stdoutDecoder.write(chunk)
       }
       const onStderrData = (chunk: Buffer): void => {
         stderrBytes += chunk.byteLength
         if (stderrBytes > MAX_OUTPUT_BYTES) {
           terminateRelaySubprocessTree(child)
+          const flushed = flushDecoders()
           finish({
-            stdout,
-            stderr,
+            ...flushed,
             exitCode: null,
             timedOut: false,
             outputLimitExceeded: 'stderr'
           })
           return
         }
-        stderr += chunk.toString('utf-8')
+        stderr += stderrDecoder.write(chunk)
       }
       const onError = (error: Error): void => {
+        const flushed = flushDecoders()
         finish({
-          stdout,
-          stderr,
+          ...flushed,
           exitCode: null,
           timedOut,
           spawnError: error.message
         })
       }
       const onClose = (code: number | null): void => {
-        finish({ stdout, stderr, exitCode: code, timedOut })
+        const flushed = flushDecoders()
+        finish({ ...flushed, exitCode: code, timedOut })
       }
       child.stdout?.on('data', onStdoutData)
       child.stderr?.on('data', onStderrData)

--- a/src/relay/glab-exec-handler.ts
+++ b/src/relay/glab-exec-handler.ts
@@ -55,6 +55,10 @@ export class GlabExecHandler {
       ...extraEnv
     } as Record<string, string>
 
+    if (context?.signal?.aborted) {
+      return { stdout: '', stderr: '', exitCode: null, timedOut: false }
+    }
+
     return new Promise<GlabExecResult>((resolve) => {
       let child: ChildProcess
       try {
@@ -175,13 +179,9 @@ export class GlabExecHandler {
       }
 
       if (context?.signal) {
-        if (context.signal.aborted) {
-          cancelCurrent()
-        } else {
-          context.signal.addEventListener('abort', cancelCurrent, { once: true })
-          detachRequestAbortListener = () => {
-            context.signal?.removeEventListener('abort', cancelCurrent)
-          }
+        context.signal.addEventListener('abort', cancelCurrent, { once: true })
+        detachRequestAbortListener = () => {
+          context.signal?.removeEventListener('abort', cancelCurrent)
         }
       }
     })

--- a/src/relay/relay.ts
+++ b/src/relay/relay.ts
@@ -39,6 +39,7 @@ import { PreflightHandler } from './preflight-handler'
 import { ExternalAutomationsHandler } from './external-automations-handler'
 import { PortScanHandler } from './port-scan-handler'
 import { AgentExecHandler } from './agent-exec-handler'
+import { GlabExecHandler } from './glab-exec-handler'
 import { WorkspaceSessionHandler } from './workspace-session-handler'
 import { AiVaultHandler } from './ai-vault-handler'
 import { endpointDirForRelaySocket, RelayAgentHookServer } from './agent-hook-server'
@@ -719,6 +720,9 @@ async function main(): Promise<void> {
 
   const _agentExecHandler = new AgentExecHandler(dispatcher)
   void _agentExecHandler
+
+  const _glabExecHandler = new GlabExecHandler(dispatcher)
+  void _glabExecHandler
 
   const _workspaceSessionHandler = new WorkspaceSessionHandler(dispatcher)
   void _workspaceSessionHandler

--- a/src/renderer/src/components/settings/SshHostAdvancedFields.tsx
+++ b/src/renderer/src/components/settings/SshHostAdvancedFields.tsx
@@ -117,6 +117,36 @@ export function SshHostAdvancedFields({
             <div className="min-w-0 flex-1 space-y-0.5">
               <Label className="text-xs font-medium">
                 {translate(
+                  'auto.components.settings.SshTargetForm.runGitLabCliOnHost',
+                  'Run GitLab CLI (glab) on this host'
+                )}
+              </Label>
+              <p className="text-muted-foreground">
+                {translate(
+                  'auto.components.settings.SshTargetForm.runGitLabCliOnHostHelp',
+                  'Use when glab credentials live on the remote host. Repo-scoped GitLab features run glab over SSH instead of locally.'
+                )}
+              </p>
+            </div>
+            <SettingsSwitch
+              checked={form.runGitLabCliOnHost}
+              disabled={disabled}
+              onChange={() =>
+                onFormChange((f) => ({
+                  ...f,
+                  runGitLabCliOnHost: !f.runGitLabCliOnHost
+                }))
+              }
+              ariaLabel={translate(
+                'auto.components.settings.SshTargetForm.runGitLabCliOnHost',
+                'Run GitLab CLI (glab) on this host'
+              )}
+            />
+          </div>
+          <div className="flex items-start justify-between gap-4 py-1 text-xs">
+            <div className="min-w-0 flex-1 space-y-0.5">
+              <Label className="text-xs font-medium">
+                {translate(
                   'auto.components.settings.SshTargetForm.71fc546097',
                   'Keep terminals alive until reset'
                 )}

--- a/src/renderer/src/components/settings/ssh-target-draft.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.test.ts
@@ -220,6 +220,28 @@ describe('getEditingTargetForSshTarget', () => {
     expect(draft.systemSshConnectionReuse).toBe(false)
   })
 
+  it('defaults runGitLabCliOnHost off and preserves explicit opt-ins', () => {
+    expect(EMPTY_FORM.runGitLabCliOnHost).toBe(false)
+    const off = getEditingTargetForSshTarget({
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'server.example.com',
+      port: 22,
+      username: 'deploy'
+    })
+    expect(off.runGitLabCliOnHost).toBe(false)
+
+    const on = getEditingTargetForSshTarget({
+      id: 'ssh-2',
+      label: 'GitLab host',
+      host: 'builder.example.com',
+      port: 22,
+      username: 'dev',
+      runGitLabCliOnHost: true
+    })
+    expect(on.runGitLabCliOnHost).toBe(true)
+  })
+
   it('uses the default persistence for targets without an explicit grace period', () => {
     const draft = getEditingTargetForSshTarget({
       id: 'ssh-1',

--- a/src/renderer/src/components/settings/ssh-target-draft.ts
+++ b/src/renderer/src/components/settings/ssh-target-draft.ts
@@ -18,6 +18,7 @@ export type EditingTarget = {
   proxyCommand: string
   jumpHost: string
   systemSshConnectionReuse: boolean
+  runGitLabCliOnHost: boolean
   relayGracePeriodSeconds: string
   relayKeepAliveUntilReset: boolean
 }
@@ -33,6 +34,7 @@ export const EMPTY_FORM: EditingTarget = {
   proxyCommand: '',
   jumpHost: '',
   systemSshConnectionReuse: true,
+  runGitLabCliOnHost: false,
   relayGracePeriodSeconds: String(DEFAULT_BOUNDED_SSH_RELAY_GRACE_PERIOD_SECONDS),
   relayKeepAliveUntilReset: DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS === 0
 }
@@ -52,6 +54,7 @@ export function getEditingTargetForSshTarget(target: SshTarget): EditingTarget {
     proxyCommand: target.proxyCommand ?? '',
     jumpHost: target.jumpHost ?? '',
     systemSshConnectionReuse: target.systemSshConnectionReuse !== false,
+    runGitLabCliOnHost: target.runGitLabCliOnHost === true,
     relayGracePeriodSeconds: String(
       target.relayGracePeriodSeconds === 0
         ? DEFAULT_BOUNDED_SSH_RELAY_GRACE_PERIOD_SECONDS
@@ -165,7 +168,8 @@ export function hasAdvancedConnectionValues(form: EditingTarget): boolean {
   return (
     form.proxyCommand.trim().length > 0 ||
     form.jumpHost.trim().length > 0 ||
-    !form.systemSshConnectionReuse
+    !form.systemSshConnectionReuse ||
+    form.runGitLabCliOnHost
   )
 }
 

--- a/src/renderer/src/components/settings/ssh-target-save-payload.test.ts
+++ b/src/renderer/src/components/settings/ssh-target-save-payload.test.ts
@@ -88,4 +88,32 @@ describe('buildSshTargetSavePayload', () => {
       expect(result.error).toContain('Terminal timeout')
     }
   })
+
+  it('persists runGitLabCliOnHost only when enabled', () => {
+    const off = buildSshTargetSavePayload({
+      ...EMPTY_FORM,
+      host: 'builder.example.com',
+      username: 'dev',
+      runGitLabCliOnHost: false
+    })
+    expect(off.ok).toBe(true)
+    if (!off.ok) {
+      throw new Error(off.error)
+    }
+    expect(off.payload.target).not.toHaveProperty('runGitLabCliOnHost')
+    expect(off.payload.updates.runGitLabCliOnHost).toBeUndefined()
+
+    const on = buildSshTargetSavePayload({
+      ...EMPTY_FORM,
+      host: 'builder.example.com',
+      username: 'dev',
+      runGitLabCliOnHost: true
+    })
+    expect(on.ok).toBe(true)
+    if (!on.ok) {
+      throw new Error(on.error)
+    }
+    expect(on.payload.target.runGitLabCliOnHost).toBe(true)
+    expect(on.payload.updates.runGitLabCliOnHost).toBe(true)
+  })
 })

--- a/src/renderer/src/components/settings/ssh-target-save-payload.ts
+++ b/src/renderer/src/components/settings/ssh-target-save-payload.ts
@@ -54,6 +54,7 @@ export function buildSshTargetSavePayload(form: EditingTarget): SshTargetSavePay
   const proxyCommand = form.proxyCommand.trim() || undefined
   const jumpHost = form.jumpHost.trim() || undefined
   const systemSshConnectionReuse = form.systemSshConnectionReuse ? undefined : false
+  const runGitLabCliOnHost = form.runGitLabCliOnHost ? true : undefined
 
   const target: Omit<SshTarget, 'id'> = {
     label: form.label.trim() || (username ? `${username}@${host}` : configHost),
@@ -66,7 +67,8 @@ export function buildSshTargetSavePayload(form: EditingTarget): SshTargetSavePay
     ...(identityFile ? { identityFile } : {}),
     ...(proxyCommand ? { proxyCommand } : {}),
     ...(jumpHost ? { jumpHost } : {}),
-    ...(systemSshConnectionReuse === false ? { systemSshConnectionReuse } : {})
+    ...(systemSshConnectionReuse === false ? { systemSshConnectionReuse } : {}),
+    ...(runGitLabCliOnHost ? { runGitLabCliOnHost } : {})
   }
 
   return {
@@ -82,6 +84,7 @@ export function buildSshTargetSavePayload(form: EditingTarget): SshTargetSavePay
         proxyCommand,
         jumpHost,
         systemSshConnectionReuse,
+        runGitLabCliOnHost,
         source: 'manual'
       }
     }

--- a/src/shared/ssh-types.test.ts
+++ b/src/shared/ssh-types.test.ts
@@ -19,6 +19,18 @@ describe('SSH types', () => {
     expect(target.host).toBe('myserver.com')
   })
 
+  it('SshTarget accepts optional runGitLabCliOnHost opt-in', () => {
+    const target: SshTarget = {
+      id: 'target-2',
+      label: 'Builder',
+      host: 'builder.example.com',
+      port: 22,
+      username: 'dev',
+      runGitLabCliOnHost: true
+    }
+    expect(target.runGitLabCliOnHost).toBe(true)
+  })
+
   it('SshConnectionStatus covers all expected states', () => {
     const statuses: SshConnectionStatus[] = [
       'disconnected',

--- a/src/shared/ssh-types.ts
+++ b/src/shared/ssh-types.ts
@@ -53,7 +53,13 @@ export type SshTarget = {
   /** Reuse a system OpenSSH connection across setup commands. Undefined means
    *  enabled; false is an explicit per-target compatibility opt-out. */
   systemSshConnectionReuse?: boolean
+  /** When true, repo-scoped `glab` calls for workspaces on this host run on the
+   *  remote via relay (credentials live on the box). Default off / omitted. */
+  runGitLabCliOnHost?: boolean
 }
+
+/** Relay RPC for opt-in remote `glab` execution (additive; older relays → -32601). */
+export const GLAB_EXEC_METHOD = 'glab.exec' as const
 
 /** Public target identity safe to mirror to a paired client. */
 export type SshTargetSummary = Pick<SshTarget, 'id' | 'label'>


### PR DESCRIPTION
## Summary
- Opt-in per SSH target: "Run GitLab CLI (glab) on this host" so forge credentials that live only on the remote box work.
- When enabled, glab runs via relay `glab.exec` (binary allowlist, argv-only, size caps) with capability cache and silent local fallback when the method is unavailable.
- Default remains local/WSL resolution when the flag is off.

## Fixes
Closes #10559

## Test plan
- [x] glab-ssh-execution capability isolation, runner routing, relay handler allowlist, form/save tests
- [ ] Manual: SSH target with glab + GitLab auth only on remote; enable flag; open MR/pipeline actions

## ELI5

For SSH hosts where GitLab credentials only exist on the remote machine, you can opt in to run `glab` on that host instead of locally so forge operations use the right tokens.
