### PR TITLE
feat(terminal): opt-in custom shell wrapper for command launches

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11786,6 +11786,46 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('does not treat a shell command wrapper as Agent Teams setup sequencing', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })
+    const runtimeStore = {
+      ...store,
+      getSettings: () => ({
+        ...store.getSettings(),
+        claudeAgentTeamsMode: 'in-process' as const,
+        shellCommandWrapper: 'devenv shell -- $CMD'
+      })
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: "claude 'hello'",
+      launchAgent: 'claude',
+      launchConfig: {
+        agentCommand: 'claude',
+        agentArgs: '',
+        agentEnv: {}
+      }
+    })
+
+    const launched = spawn.mock.calls[0]?.[0] as {
+      command?: string
+      env?: Record<string, string>
+    }
+
+    // Why: wrapper alone must not queue SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV
+    // (which would spawn the unenhanced source command and drop teammate mode).
+    expect(launched.env?.[SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]).toBeUndefined()
+    expect(launched.command).toBe("devenv shell -- claude --teammate-mode in-process 'hello'")
+    expect(launched.env?.CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS).toBe('1')
+  })
+
   it('restores captured native Claude Agent Teams mode with fresh service env', async () => {
     setPlatform('linux')
     const spawn = vi.fn().mockResolvedValue({ id: 'pty-bg' })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -267,6 +267,7 @@ import {
   buildAgentResumeStartupPlan,
   buildAgentStartupPlan
 } from '../../shared/tui-agent-startup'
+import { applyShellCommandWrapper } from '../../shared/shell-command-wrapper'
 import { repoIsRemote } from '../../shared/agent-launch-remote'
 import {
   isAgentForegroundWrapperProcess,
@@ -21628,7 +21629,24 @@ export class OrcaRuntimeService {
         throw new Error('runtime_unavailable')
       }
       const workspace = await this.resolveTerminalWorkspaceLaunchScope(worktreeSelector)
-      const launchOpts = await this.resolveAgentTerminalCreateOptions(workspace, opts)
+      const resolvedLaunchOpts = await this.resolveAgentTerminalCreateOptions(workspace, opts)
+      // Why: wrap bare/agent launch commands through the opt-in shell template so CLI/mobile
+      // createTerminal paths match renderer queueTabStartupCommand (e.g. devenv shell -- $CMD).
+      // Keep claudeAgentTeamsSourceCommand on the unwrapped agent line so teammate-mode
+      // inference still sees `claude` rather than `devenv shell -- claude`.
+      const launchOpts = {
+        ...resolvedLaunchOpts,
+        ...(resolvedLaunchOpts.command
+          ? {
+              command: applyShellCommandWrapper(
+                this.store?.getSettings?.().shellCommandWrapper,
+                resolvedLaunchOpts.command
+              ),
+              claudeAgentTeamsSourceCommand:
+                resolvedLaunchOpts.claudeAgentTeamsSourceCommand ?? resolvedLaunchOpts.command
+            }
+          : {})
+      }
       let ptySpawnCommitReported = false
       const reportPtySpawnCommitted = (): void => {
         if (ptySpawnCommitReported) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1048,6 +1048,7 @@ type RuntimeStore = {
     terminalMainSideEffectAuthority?: GlobalSettings['terminalMainSideEffectAuthority']
     terminalHiddenDeliveryGate?: GlobalSettings['terminalHiddenDeliveryGate']
     terminalModelQueryAuthority?: GlobalSettings['terminalModelQueryAuthority']
+    shellCommandWrapper?: GlobalSettings['shellCommandWrapper']
   }
   // Why: narrow to `unknown` return so test mocks can return void without
   // a cast. The runtime never reads the return value — the persisted value
@@ -21630,18 +21631,15 @@ export class OrcaRuntimeService {
       }
       const workspace = await this.resolveTerminalWorkspaceLaunchScope(worktreeSelector)
       const resolvedLaunchOpts = await this.resolveAgentTerminalCreateOptions(workspace, opts)
-      // Why: wrap bare/agent launch commands through the opt-in shell template so CLI/mobile
-      // createTerminal paths match renderer queueTabStartupCommand (e.g. devenv shell -- $CMD).
-      // Keep claudeAgentTeamsSourceCommand on the unwrapped agent line so teammate-mode
-      // inference still sees `claude` rather than `devenv shell -- claude`.
+      const shellCommandWrapper = this.store?.getSettings?.().shellCommandWrapper
+      // Why: keep command unwrapped through Agent Teams planning/sequencing so a shell
+      // wrapper alone cannot look like setup sequencing (source !== command). Wrap only
+      // the final spawn command. claudeAgentTeamsSourceCommand stays on the bare agent
+      // line so teammate-mode inference still sees `claude`, not `devenv shell -- claude`.
       const launchOpts = {
         ...resolvedLaunchOpts,
         ...(resolvedLaunchOpts.command
           ? {
-              command: applyShellCommandWrapper(
-                this.store?.getSettings?.().shellCommandWrapper,
-                resolvedLaunchOpts.command
-              ),
               claudeAgentTeamsSourceCommand:
                 resolvedLaunchOpts.claudeAgentTeamsSourceCommand ?? resolvedLaunchOpts.command
             }
@@ -21753,9 +21751,14 @@ export class OrcaRuntimeService {
         cols: 120,
         rows: 40,
         cwd,
-        command: sequencedStartupCommand
-          ? launchOpts.command
-          : (agentTeamsPlan?.command ?? launchOpts.command),
+        // Why: wrap after teams/sequencing so setup-vs-agent distinction stays real and
+        // teammate-enhanced commands still go through the opt-in shell template.
+        command: applyShellCommandWrapper(
+          shellCommandWrapper,
+          sequencedStartupCommand
+            ? launchOpts.command
+            : (agentTeamsPlan?.command ?? launchOpts.command)
+        ),
         launchAgent: launchOpts.launchAgent,
         commandDelivery: 'provider',
         startupCommandDelivery: launchOpts.startupCommandDelivery,

--- a/src/renderer/src/components/settings/TerminalPane.tsx
+++ b/src/renderer/src/components/settings/TerminalPane.tsx
@@ -10,7 +10,8 @@ import {
   getTerminalMacYenSearchEntries,
   getTerminalPaneInteractionSearchEntries,
   getTerminalRenderingSearchEntries,
-  getTerminalSetupScriptSearchEntries
+  getTerminalSetupScriptSearchEntries,
+  getTerminalShellCommandWrapperSearchEntries
 } from './terminal-search'
 import {
   getTerminalRightClickToPasteSearchEntry,
@@ -22,6 +23,7 @@ import { TerminalAdvancedSection } from './TerminalAdvancedSection'
 import { TerminalInteractionSection } from './TerminalInteractionSection'
 import { TerminalRenderingSection } from './TerminalRenderingSection'
 import { TerminalSetupScriptSection } from './TerminalSetupScriptSection'
+import { TerminalShellCommandWrapperSection } from './TerminalShellCommandWrapperSection'
 import { TerminalWindowsShellSection } from './TerminalWindowsShellSection'
 
 type TerminalPaneProps = {
@@ -89,6 +91,13 @@ export function TerminalPane({
     matchesSettingsSearch(searchQuery, getTerminalSetupScriptSearchEntries()) ? (
       <TerminalSetupScriptSection
         key="setup-script"
+        settings={settings}
+        updateSettings={updateSettings}
+      />
+    ) : null,
+    matchesSettingsSearch(searchQuery, getTerminalShellCommandWrapperSearchEntries()) ? (
+      <TerminalShellCommandWrapperSection
+        key="shell-command-wrapper"
         settings={settings}
         updateSettings={updateSettings}
       />

--- a/src/renderer/src/components/settings/TerminalShellCommandWrapperSection.tsx
+++ b/src/renderer/src/components/settings/TerminalShellCommandWrapperSection.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react'
+import type { GlobalSettings } from '../../../../shared/types'
+import { normalizeShellCommandWrapper } from '../../../../shared/shell-command-wrapper'
+import { Input } from '../ui/input'
+import { SettingsRow, SettingsSubsectionHeader } from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+import { translate } from '@/i18n/i18n'
+
+type TerminalShellCommandWrapperSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+type DraftState = {
+  sourceValue: string
+  draft: string
+}
+
+function createDraftState(sourceValue: string | undefined): DraftState {
+  const normalized = sourceValue ?? ''
+  return { sourceValue: normalized, draft: normalized }
+}
+
+function resolveDraftState(state: DraftState, sourceValue: string | undefined): DraftState {
+  const nextSource = sourceValue ?? ''
+  if (state.sourceValue === nextSource) {
+    return state
+  }
+  // Why: external settings updates win only when the field is not mid-edit.
+  if (state.draft === state.sourceValue) {
+    return createDraftState(nextSource)
+  }
+  return { ...state, sourceValue: nextSource }
+}
+
+export function TerminalShellCommandWrapperSection({
+  settings,
+  updateSettings
+}: TerminalShellCommandWrapperSectionProps): React.JSX.Element {
+  const [draftState, setDraftState] = useState(() => createDraftState(settings.shellCommandWrapper))
+  const resolved = resolveDraftState(draftState, settings.shellCommandWrapper)
+  if (resolved !== draftState) {
+    setDraftState(resolved)
+  }
+
+  const commit = (): void => {
+    const normalized = normalizeShellCommandWrapper(resolved.draft) ?? ''
+    setDraftState(createDraftState(normalized))
+    if (normalized !== (settings.shellCommandWrapper ?? '')) {
+      updateSettings({ shellCommandWrapper: normalized })
+    }
+  }
+
+  return (
+    <section key="shell-command-wrapper" className="space-y-3">
+      <SettingsSubsectionHeader
+        title={translate(
+          'auto.components.settings.TerminalShellCommandWrapperSection.title',
+          'Shell Command Wrapper'
+        )}
+        description={translate(
+          'auto.components.settings.TerminalShellCommandWrapperSection.description',
+          'Optional template that wraps agent and terminal launch commands so they run inside a project environment (for example devenv or nix-shell).'
+        )}
+      />
+
+      <div className="divide-y divide-border/40">
+        <SearchableSetting
+          title={translate(
+            'auto.components.settings.TerminalShellCommandWrapperSection.rowTitle',
+            'Command Wrapper'
+          )}
+          description={translate(
+            'auto.components.settings.TerminalShellCommandWrapperSection.rowDescription',
+            'Use $CMD where the launch command should appear. Example: devenv shell -- $CMD'
+          )}
+          keywords={[
+            'shell',
+            'wrapper',
+            'command',
+            'devenv',
+            'nix',
+            'nix-shell',
+            'environment',
+            'launch',
+            'agent',
+            'template',
+            '$CMD',
+            'CMD'
+          ]}
+        >
+          <SettingsRow
+            alignTop
+            label={translate(
+              'auto.components.settings.TerminalShellCommandWrapperSection.rowTitle',
+              'Command Wrapper'
+            )}
+            description={translate(
+              'auto.components.settings.TerminalShellCommandWrapperSection.rowDescription',
+              'Use $CMD where the launch command should appear. Example: devenv shell -- $CMD'
+            )}
+            control={
+              <Input
+                value={resolved.draft}
+                onChange={(e) =>
+                  setDraftState((current) => ({
+                    ...resolveDraftState(current, settings.shellCommandWrapper),
+                    draft: e.target.value
+                  }))
+                }
+                onBlur={commit}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    commit()
+                    e.currentTarget.blur()
+                  }
+                  if (e.key === 'Escape') {
+                    setDraftState(createDraftState(settings.shellCommandWrapper))
+                    e.currentTarget.blur()
+                  }
+                }}
+                placeholder="devenv shell -- $CMD"
+                spellCheck={false}
+                className="h-8 w-[min(28rem,100%)] font-mono text-xs"
+                aria-label={translate(
+                  'auto.components.settings.TerminalShellCommandWrapperSection.rowTitle',
+                  'Command Wrapper'
+                )}
+              />
+            }
+          />
+        </SearchableSetting>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -59,7 +59,8 @@ export {
 export {
   getManageSessionsSearchEntries,
   getTerminalWindowSearchEntries,
-  getTerminalSetupScriptSearchEntries
+  getTerminalSetupScriptSearchEntries,
+  getTerminalShellCommandWrapperSearchEntries
 } from './terminal-window-setup-search'
 
 type TerminalAppearanceSearchOptions = {

--- a/src/renderer/src/components/settings/terminal-window-setup-search.ts
+++ b/src/renderer/src/components/settings/terminal-window-setup-search.ts
@@ -132,6 +132,33 @@ export const getTerminalWindowSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getTerminalShellCommandWrapperSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate(
+      'auto.components.settings.terminal.search.shellCommandWrapperTitle',
+      'Command Wrapper'
+    ),
+    description: translate(
+      'auto.components.settings.terminal.search.shellCommandWrapperDescription',
+      'Optional template that wraps agent and terminal launch commands (for example devenv shell -- $CMD).'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.terminal.search.shellKw', 'shell'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.wrapperKw', 'wrapper'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.commandKw', 'command'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.devenvKw', 'devenv'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.nixKw', 'nix'),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.environmentKw',
+        'environment'
+      ),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.agentKw', 'agent'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.cmdKw', '$CMD'),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.launchKw2', 'launch')
+    ]
+  }
+])
+
 export const getTerminalSetupScriptSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate(

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -43,6 +43,7 @@ import type { ProjectExecutionRuntimeResolution } from '../../../../shared/proje
 import type { StartupCommandDelivery } from '../../../../shared/codex-startup-delivery'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import { resolveLocalWindowsTerminalShellOverrideForTab } from '../../../../shared/local-windows-terminal-runtime'
+import { applyShellCommandWrapper } from '../../../../shared/shell-command-wrapper'
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import type { AgentStartedTelemetry } from '../../lib/worktree-activation'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
@@ -2941,11 +2942,14 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     const launchToken = startup.launchConfig
       ? (startup.launchToken ?? createBrowserUuid())
       : undefined
+    // Why: wrap agent/bare launch commands through the opt-in shell template (e.g. devenv) at the shared queue choke point.
+    const command = applyShellCommandWrapper(get().settings?.shellCommandWrapper, startup.command)
     set((s) => ({
       pendingStartupByTabId: {
         ...s.pendingStartupByTabId,
         [tabId]: {
           ...startup,
+          command,
           ...(launchToken ? { launchToken } : {})
         }
       }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -317,6 +317,8 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     minimaxUsageModels: 'general',
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
+    // Why: empty keeps launches direct; users opt into devenv/nix wrappers via $CMD.
+    shellCommandWrapper: '',
     agentDefaultArgs: { ...DEFAULT_TUI_AGENT_ARGS },
     agentDefaultEnv: { ...DEFAULT_TUI_AGENT_ENV },
     agentYoloDefaultsMigrated: true,

--- a/src/shared/shell-command-wrapper.test.ts
+++ b/src/shared/shell-command-wrapper.test.ts
@@ -54,6 +54,13 @@ describe('applyShellCommandWrapper', () => {
     expect(applyShellCommandWrapper('echo $CMD && $CMD', 'true')).toBe('echo true && true')
   })
 
+  it('replaces every supported placeholder variant in mixed templates', () => {
+    expect(applyShellCommandWrapper('echo $CMD && {command}', 'true')).toBe('echo true && true')
+    expect(applyShellCommandWrapper('log $COMMAND then $CMD then {command}', 'run')).toBe(
+      'log run then run then run'
+    )
+  })
+
   it('exposes placeholders longest-first for callers that mirror the order', () => {
     expect([...SHELL_COMMAND_WRAPPER_PLACEHOLDERS]).toEqual(['$COMMAND', '$CMD', '{command}'])
   })

--- a/src/shared/shell-command-wrapper.test.ts
+++ b/src/shared/shell-command-wrapper.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyShellCommandWrapper,
+  normalizeShellCommandWrapper,
+  SHELL_COMMAND_WRAPPER_PLACEHOLDERS
+} from './shell-command-wrapper'
+
+describe('normalizeShellCommandWrapper', () => {
+  it('trims and drops blank wrappers', () => {
+    expect(normalizeShellCommandWrapper(undefined)).toBeUndefined()
+    expect(normalizeShellCommandWrapper(null)).toBeUndefined()
+    expect(normalizeShellCommandWrapper('')).toBeUndefined()
+    expect(normalizeShellCommandWrapper('   ')).toBeUndefined()
+    expect(normalizeShellCommandWrapper('  devenv shell -- $CMD  ')).toBe('devenv shell -- $CMD')
+  })
+})
+
+describe('applyShellCommandWrapper', () => {
+  it('is a no-op without a wrapper', () => {
+    expect(applyShellCommandWrapper(undefined, "claude 'hello world'")).toBe("claude 'hello world'")
+    expect(applyShellCommandWrapper('', "claude 'hello world'")).toBe("claude 'hello world'")
+    expect(applyShellCommandWrapper('   ', "claude 'hello world'")).toBe("claude 'hello world'")
+  })
+
+  it('is a no-op when the command is blank', () => {
+    expect(applyShellCommandWrapper('devenv shell -- $CMD', '')).toBe('')
+    expect(applyShellCommandWrapper('devenv shell -- $CMD', '   ')).toBe('')
+    expect(applyShellCommandWrapper('devenv shell -- $CMD', null)).toBe('')
+    expect(applyShellCommandWrapper('devenv shell -- $CMD', undefined)).toBe('')
+  })
+
+  it('substitutes $CMD for devenv-style wrappers without re-quoting', () => {
+    expect(applyShellCommandWrapper('devenv shell -- $CMD', "claude --yolo 'fix me'")).toBe(
+      "devenv shell -- claude --yolo 'fix me'"
+    )
+  })
+
+  it('prefers $COMMAND over $CMD so longer placeholder wins', () => {
+    expect(applyShellCommandWrapper('env $COMMAND', 'echo hi')).toBe('env echo hi')
+    expect(applyShellCommandWrapper('run $CMD', 'echo hi')).toBe('run echo hi')
+  })
+
+  it('substitutes {command} placeholder', () => {
+    expect(applyShellCommandWrapper('nix-shell --run {command}', "echo 'a b'")).toBe(
+      "nix-shell --run echo 'a b'"
+    )
+  })
+
+  it('treats templates without a placeholder as a prefix', () => {
+    expect(applyShellCommandWrapper('devenv shell --', 'claude')).toBe('devenv shell -- claude')
+  })
+
+  it('replaces every placeholder occurrence', () => {
+    expect(applyShellCommandWrapper('echo $CMD && $CMD', 'true')).toBe('echo true && true')
+  })
+
+  it('exposes placeholders longest-first for callers that mirror the order', () => {
+    expect([...SHELL_COMMAND_WRAPPER_PLACEHOLDERS]).toEqual(['$COMMAND', '$CMD', '{command}'])
+  })
+})

--- a/src/shared/shell-command-wrapper.ts
+++ b/src/shared/shell-command-wrapper.ts
@@ -1,0 +1,50 @@
+/**
+ * Opt-in template that wraps terminal/agent launch commands, e.g.
+ * `devenv shell -- $CMD` so the project environment owns the process.
+ *
+ * Placeholders (checked longest-first so `$COMMAND` is not split by `$CMD`):
+ * - `$CMD` (issue #10542)
+ * - `$COMMAND`
+ * - `{command}`
+ *
+ * The command is substituted as-is (already shell-quoted by callers). Do not
+ * re-quote: `devenv shell -- $CMD` must expand to multiple argv tokens.
+ * When no placeholder is present, the template is treated as a prefix.
+ */
+
+export const SHELL_COMMAND_WRAPPER_PLACEHOLDERS = ['$COMMAND', '$CMD', '{command}'] as const
+
+export type ShellCommandWrapperPlaceholder = (typeof SHELL_COMMAND_WRAPPER_PLACEHOLDERS)[number]
+
+export function normalizeShellCommandWrapper(
+  wrapper: string | null | undefined
+): string | undefined {
+  const trimmed = wrapper?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+/**
+ * Returns the wrapped command line, or the original command when the wrapper
+ * is unset/blank or the command itself is blank.
+ */
+export function applyShellCommandWrapper(
+  wrapper: string | null | undefined,
+  command: string | null | undefined
+): string {
+  const normalizedCommand = command?.trim() ?? ''
+  if (!normalizedCommand) {
+    return command?.trim() === '' ? '' : (command ?? '')
+  }
+  const normalizedWrapper = normalizeShellCommandWrapper(wrapper)
+  if (!normalizedWrapper) {
+    return normalizedCommand
+  }
+
+  for (const placeholder of SHELL_COMMAND_WRAPPER_PLACEHOLDERS) {
+    if (normalizedWrapper.includes(placeholder)) {
+      return normalizedWrapper.split(placeholder).join(normalizedCommand)
+    }
+  }
+
+  return `${normalizedWrapper} ${normalizedCommand}`
+}

--- a/src/shared/shell-command-wrapper.ts
+++ b/src/shared/shell-command-wrapper.ts
@@ -40,10 +40,13 @@ export function applyShellCommandWrapper(
     return normalizedCommand
   }
 
-  for (const placeholder of SHELL_COMMAND_WRAPPER_PLACEHOLDERS) {
-    if (normalizedWrapper.includes(placeholder)) {
-      return normalizedWrapper.split(placeholder).join(normalizedCommand)
-    }
+  // Why: replace every variant ($CMD, $COMMAND, {command}) — stop-after-first
+  // leaves mixed templates like `echo $CMD && {command}` half-substituted.
+  if (SHELL_COMMAND_WRAPPER_PLACEHOLDERS.some((placeholder) => normalizedWrapper.includes(placeholder))) {
+    return SHELL_COMMAND_WRAPPER_PLACEHOLDERS.reduce(
+      (wrapped, placeholder) => wrapped.split(placeholder).join(normalizedCommand),
+      normalizedWrapper
+    )
   }
 
   return `${normalizedWrapper} ${normalizedCommand}`

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2862,6 +2862,12 @@ export type GlobalSettings = {
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */
   agentCmdOverrides: Partial<Record<TuiAgent, string>>
+  /**
+   * Opt-in shell wrapper template for agent/terminal launch commands.
+   * Use `$CMD` (or `$COMMAND` / `{command}`) where the launch command should
+   * appear, e.g. `devenv shell -- $CMD`. Empty/undefined disables wrapping.
+   */
+  shellCommandWrapper?: string
   /** Custom CODEX_HOME for Codex session-history discovery (defaults to ~/.codex).
    *  History-only: does not change which account/config/hooks Orca uses. */
   codexSessionSourceHome?: {


### PR DESCRIPTION
## Summary
- Global opt-in `shellCommandWrapper` setting (e.g. `devenv shell -- $CMD`).
- Applied at agent/tab startup queue and runtime `createTerminal` spawn choke points.
- Settings → Terminal section + search catalog.

## Fixes
Closes #10542

## Residual
- Empty interactive shells are not re-routed into the wrapper.
- Per-repo / orca.yaml not yet.
- Some non-queue split paths may still bypass.

## Test plan
- [x] shell-command-wrapper unit tests
- [ ] Manual: set `devenv shell -- $CMD`, launch agent, confirm command is wrapped

## ELI5

You can set an optional shell command wrapper (for example devenv) that wraps agent and tab launches, so tools start inside your preferred environment without manual typing.
