### PR TITLE
fix(tasks): refresh GitHub is:open issues without stale cache

### DIFF
--- a/src/main/github/client-issue-source.test.ts
+++ b/src/main/github/client-issue-source.test.ts
@@ -243,6 +243,37 @@ describe('GitHub issue source split', () => {
     })
   })
 
+  // Why: Tasks presets always send is:issue is:open (queried path). #3018 only
+  // busted cache on empty-query listRecentWorkItems; forced reload stayed stale.
+  it('omits gh api cache args for no-cache is:open queried issue lists', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    await listWorkItems('/repo-root', 10, 'is:issue is:open', undefined, undefined, undefined, true)
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(1)
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      issueSearchArgs('stablyai/orca', { noCache: true, query: 'is:issue is:open' }),
+      { cwd: '/repo-root' }
+    )
+  })
+
+  it('keeps gh api cache args for cached is:open queried issue lists', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'fork', repo: 'orca' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+    await listWorkItems('/repo-root', 10, 'is:issue is:open')
+
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      issueSearchArgs('stablyai/orca', { query: 'is:issue is:open' }),
+      { cwd: '/repo-root' }
+    )
+  })
+
   it('lists SSH repo work items with explicit owner/repo and no local cwd', async () => {
     resolveIssueSourceMock.mockResolvedValueOnce({
       source: { owner: 'stablyai', repo: 'orca' },

--- a/src/main/github/client-work-items.test.ts
+++ b/src/main/github/client-work-items.test.ts
@@ -759,6 +759,30 @@ describe('listWorkItems', () => {
     ])
   })
 
+  it('omits gh api --cache on no-cache is:open queried issue search', async () => {
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' }).mockResolvedValueOnce({
+      stdout: '[]'
+    })
+
+    await listWorkItems('/repo-root', 10, 'is:open', undefined, undefined, undefined, true)
+
+    expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
+      [
+        'api',
+        `search/issues?q=${encodeURIComponent('repo:acme/widgets is:issue is:open')}&sort=created&order=desc&per_page=10&page=1`,
+        '--jq',
+        '.items'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['--cache', '120s']),
+      expect.anything()
+    )
+  })
+
   it('marks fork PRs as cross-repository when REST payload only includes head.label', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -1047,8 +1047,10 @@ function buildWorkItemListRequest(args: {
   limit: number
   query: ParsedTaskQuery
   page: number
+  /** Why: forced Tasks refresh must skip gh's 120s search cache (empty + is:open queried paths). */
+  noCache?: boolean
 }): WorkItemListRequest {
-  const { kind, ownerRepo, limit, query, page } = args
+  const { kind, ownerRepo, limit, query, page, noCache } = args
   const searchParts: string[] = []
 
   if (kind === 'issue') {
@@ -1093,11 +1095,12 @@ function buildWorkItemListRequest(args: {
   }
 
   if (kind === 'issue') {
+    // Why: only Search API uses gh --cache; PR list goes through gh pr list (no CLI cache).
+    const cacheArgs = noCache ? [] : ['--cache', '120s']
     return {
       args: [
         'api',
-        '--cache',
-        '120s',
+        ...cacheArgs,
         `search/issues?q=${encodeURIComponent(searchParts.join(' '))}&sort=created&order=desc&per_page=${limit}&page=${page}`,
         '--jq',
         '.items'
@@ -1184,7 +1187,8 @@ async function listRecentWorkItems(
         ownerRepo: issueOwnerRepo,
         limit,
         query: recentQuery,
-        page
+        page,
+        noCache
       })
     : null
   const prRequest = prOwnerRepo
@@ -1196,9 +1200,6 @@ async function listRecentWorkItems(
         page
       })
     : null
-  if (noCache && issueRequest) {
-    issueRequest.args.splice(1, 2)
-  }
   // Why: unresolved sources must stay empty — an unscoped Search API would return other public repos' issues (#9660).
   // Why: allSettled so a 403 on the issue side doesn't zero the PR half (partial results + banner).
   const [issuesSettled, prsSettled] = await Promise.allSettled([
@@ -1267,6 +1268,7 @@ async function listQueriedWorkItems(
   limit: number,
   page?: number,
   connectionId?: string | null,
+  noCache?: boolean,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<PartialWorkItemsResult> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
@@ -1296,7 +1298,8 @@ async function listQueriedWorkItems(
       ownerRepo: issueOwnerRepo,
       limit,
       query,
-      page: page ?? 1
+      page: page ?? 1,
+      noCache
     })
     try {
       const { stdout } = await ghExecFileAsync(request.args, {
@@ -1426,6 +1429,7 @@ export async function listWorkItems(
           limit,
           requestedPage,
           connectionId,
+          noCache,
           localGitOptions
         )
 


### PR DESCRIPTION
## Summary
- Tasks presets always send non-empty queries (`is:issue is:open`, etc.). Those hit `listQueriedWorkItems`, which still used `gh api --cache 120s` even when UI refresh passed `noCache`.
- Thread `noCache` through queried work-item list so manual reload / post-create refresh is not stale for up to 2 minutes.
- Unify recent-list path to the same option (drop fragile argv splice).

## Fixes
Closes #10450

## Test plan
- [x] client-issue-source / client-work-items noCache regressions
- [ ] Manual: Tasks issues filter, create issue on GitHub, reload in Orca within 2 minutes

## ELI5

Refreshing open GitHub issues in Tasks could still show 2-minute-old cache results. Manual reload and post-create refresh now bypass that cache so the list is current.
