### PR TITLE
fix(mobile): show chat/terminal content when Chat UI sessions open

### DIFF
--- a/mobile/src/session/mobile-native-chat-eligibility.test.ts
+++ b/mobile/src/session/mobile-native-chat-eligibility.test.ts
@@ -3,7 +3,8 @@ import type { AgentStatusEntry } from '../../../src/shared/agent-status-types'
 import {
   canShowMobileNativeChat,
   isMobileNativeChatTranscriptReadable,
-  resolveMobileNativeChat
+  resolveMobileNativeChat,
+  shouldShowMobileNativeChatOverlay
 } from './mobile-native-chat-eligibility'
 
 function status(overrides: Partial<AgentStatusEntry> = {}): AgentStatusEntry {
@@ -108,5 +109,25 @@ describe('resolveMobileNativeChat', () => {
   it('canShowMobileNativeChat mirrors resolution', () => {
     expect(canShowMobileNativeChat({ type: 'terminal', launchAgent: 'claude' })).toBe(true)
     expect(canShowMobileNativeChat(null)).toBe(false)
+  })
+
+  // Why: Chat UI without a session id would cover the terminal with a blank
+  // transcript surface; keep the overlay off until the transcript is addressable (#10630).
+  it('only shows the chat overlay once a provider session id is known', () => {
+    expect(shouldShowMobileNativeChatOverlay(null)).toBe(false)
+    expect(
+      shouldShowMobileNativeChatOverlay({
+        agent: 'claude',
+        sessionId: null,
+        transcriptPath: null
+      })
+    ).toBe(false)
+    expect(
+      shouldShowMobileNativeChatOverlay({
+        agent: 'claude',
+        sessionId: 'sess-1',
+        transcriptPath: '/tmp/claude.jsonl'
+      })
+    ).toBe(true)
   })
 })

--- a/mobile/src/session/mobile-native-chat-eligibility.ts
+++ b/mobile/src/session/mobile-native-chat-eligibility.ts
@@ -64,3 +64,10 @@ export function canShowMobileNativeChat(
 ): boolean {
   return resolveMobileNativeChat(tab, nativeChatTranscriptIsLocalReadable) !== null
 }
+
+/** Chat overlay only when the transcript is addressable; otherwise keep the terminal visible. */
+export function shouldShowMobileNativeChatOverlay(
+  resolution: MobileNativeChatResolution | null
+): boolean {
+  return resolution != null && resolution.sessionId != null
+}

--- a/mobile/src/session/use-mobile-native-chat-controller.ts
+++ b/mobile/src/session/use-mobile-native-chat-controller.ts
@@ -13,7 +13,11 @@ import {
   type AskAnswerSelection,
   type AskPrompt
 } from './mobile-native-chat-ask'
-import { type MobileNativeChatTab, resolveMobileNativeChat } from './mobile-native-chat-eligibility'
+import {
+  type MobileNativeChatTab,
+  resolveMobileNativeChat,
+  shouldShowMobileNativeChatOverlay
+} from './mobile-native-chat-eligibility'
 import { detectAgentPermission } from './mobile-native-chat-permission'
 import { parseAgentQuestion } from './mobile-native-chat-question'
 import { openMobileNativeChatFile } from './mobile-native-chat-open-file'
@@ -114,13 +118,14 @@ export function useMobileNativeChatController(args: {
     activeSessionTab && activeSessionTabId && isTabChatView(activeSessionTabId)
       ? resolveMobileNativeChat(activeSessionTab, nativeChatTranscriptIsLocalReadable)
       : null
-  const showNativeChat = activeChatResolution != null
+  const activeChatSessionId = activeChatResolution?.sessionId ?? null
+  // Why: without a provider session id Chat UI cannot subscribe to the transcript;
+  // keep the terminal visible instead of covering it with a permanent blank chat (#10630).
+  const showNativeChat = shouldShowMobileNativeChatOverlay(activeChatResolution)
   const showNativeChatRef = useRef(showNativeChat)
   showNativeChatRef.current = showNativeChat
   const activeChatAgentRef = useRef<string | null>(activeChatResolution?.agent ?? null)
   activeChatAgentRef.current = activeChatResolution?.agent ?? null
-
-  const activeChatSessionId = activeChatResolution?.sessionId ?? null
   const streamIdentity = `${hostId}\0${worktreeId}\0${activeSessionTabId ?? ''}\0${activeChatSessionId ?? ''}\0${activeHandleRef.current ?? ''}`
 
   const nativeChatSession = useMobileNativeChatSession({

--- a/src/renderer/src/runtime/sync-runtime-graph.test.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.test.ts
@@ -434,6 +434,39 @@ describe('getRuntimeMobileSessionSyncKey', () => {
     expect(runtimeMobileSessionSyncKeysEqual(before, after)).toBe(false)
   })
 
+  // Why: Chat UI on mobile keys the transcript on providerSession; same-state
+  // session-id attaches must still invalidate the mobile sync key (#10630).
+  it('changes when providerSession identity attaches on an otherwise identical status', () => {
+    const sharedOverrides = makeSharedOverrides()
+    const paneKey = 'term-1:11111111-1111-4111-8111-111111111111'
+    const beforeAgentStatusByPaneKey = {
+      [paneKey]: makeAgentStatusEntry({ paneKey })
+    }
+    const afterAgentStatusByPaneKey = {
+      [paneKey]: makeAgentStatusEntry({
+        paneKey,
+        providerSession: { key: 'session_id', id: 'claude-session-1' }
+      })
+    }
+
+    const before = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: beforeAgentStatusByPaneKey,
+        agentStatusEpoch: 1
+      })
+    )
+    const after = getRuntimeMobileSessionSyncKey(
+      makeState({
+        ...sharedOverrides,
+        agentStatusByPaneKey: afterAgentStatusByPaneKey,
+        agentStatusEpoch: 1
+      })
+    )
+
+    expect(runtimeMobileSessionSyncKeysEqual(before, after)).toBe(false)
+  })
+
   it('coalesces timestamp-only agent heartbeats inside the same freshness bucket', () => {
     const sharedOverrides = makeSharedOverrides()
     const paneKey = 'term-1:11111111-1111-4111-8111-111111111111'

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -525,7 +525,18 @@ function serializeRuntimeMobileAgentStatusEntry(
     // Why: include so a newly-captured AskUserQuestion prompt re-fires the mobile republish even when no other field changed.
     interactivePrompt: entry.interactivePrompt ?? null,
     lastAssistantMessage: entry.lastAssistantMessage ?? null,
-    interrupted: entry.interrupted ?? null
+    interrupted: entry.interrupted ?? null,
+    // Why: Chat UI on mobile reads the agent transcript via providerSession.id;
+    // omitting it dropped same-state session-id attaches and left chat blank (#10630).
+    providerSession: entry.providerSession
+      ? {
+          key: entry.providerSession.key,
+          id: entry.providerSession.id,
+          ...(entry.providerSession.transcriptPath
+            ? { transcriptPath: entry.providerSession.transcriptPath }
+            : {})
+        }
+      : null
   })
 }
 

--- a/src/renderer/src/store/slices/agent-status-provider-session.test.ts
+++ b/src/renderer/src/store/slices/agent-status-provider-session.test.ts
@@ -41,6 +41,38 @@ describe('recordAgentProviderSession', () => {
     )
   })
 
+  // Why: mobile Chat UI graph sync is gated on agentStatusEpoch; a late
+  // same-state providerSession attach must bump it so the session id ships (#10630).
+  it('bumps agentStatusEpoch when providerSession identity attaches on a same-state ping', () => {
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'write tests', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 10, stateStartedAt: 10 }
+      )
+    const epochBefore = store.getState().agentStatusEpoch
+
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:leaf-1',
+        { state: 'working', prompt: 'write tests', agentType: 'claude' },
+        'Claude',
+        { updatedAt: 11, stateStartedAt: 10 },
+        undefined,
+        { providerSession: { key: 'session_id', id: 'claude-session-1' } }
+      )
+
+    expect(store.getState().agentStatusByPaneKey['tab-1:leaf-1']?.providerSession).toEqual({
+      key: 'session_id',
+      id: 'claude-session-1'
+    })
+    expect(store.getState().agentStatusEpoch).toBeGreaterThan(epochBefore)
+  })
+
   it('uses the session file as part of Pi resume ownership only', () => {
     const base = {
       paneKey: 'tab-1:leaf-1',

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1907,8 +1907,17 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             entry.subagents !== existing.subagents ||
             entry.providerSession !== existing.providerSession ||
             entry.interrupted !== existing.interrupted)
+        // Why: mobile Chat UI needs providerSession identity even on same-state working
+        // pings; without an epoch bump the graph sync can skip the mobile tab republish (#10630).
+        const providerSessionIdentityChanged =
+          (entry.providerSession?.id ?? null) !== (existing?.providerSession?.id ?? null) ||
+          (entry.providerSession?.transcriptPath ?? null) !==
+            (existing?.providerSession?.transcriptPath ?? null)
         const retentionRelevantChange =
-          sortRelevantChange || attributionChanged || doneRetentionFieldsChanged
+          sortRelevantChange ||
+          attributionChanged ||
+          doneRetentionFieldsChanged ||
+          providerSessionIdentityChanged
         // Why: a fresh status means the agent is live again — lift its one-shot retention suppressor.
         // Clone the map only when a suppressor exists, else every high-frequency ping churns the ref.
         const hasSuppressor = paneKey in s.retentionSuppressedPaneKeys


### PR DESCRIPTION
## Summary
- Mobile agent-status projection now includes `providerSession` so Chat UI can subscribe to transcripts.
- Bump `agentStatusEpoch` when provider session id/path attaches (same-state working pings no longer drop the attach).
- Chat UI overlay only covers the terminal when `sessionId` is present; otherwise keep the live terminal visible (matches the reported workaround path without forcing Chat UI off permanently).

## Fixes
Closes #10630

## Notes
- Desktop restart required after deploy so new projection/epoch runs for mobile clients.
- May overlap maintainer WIP around mobile Chat UI readiness; scoped to blank-content root cause.

## Test plan
- [x] sync-runtime-graph + agent-status provider-session + mobile eligibility/controller tests
- [ ] Manual: iOS + Chat UI on + Claude session — messages visible on phone

## ELI5

Opening Chat UI sessions on mobile sometimes showed a blank surface instead of chat or terminal content. Mobile now gets the provider session data it needs, and falls back to the live terminal when chat isn't ready.
