### PR TITLE
test(e2e): make Codex typing-latency harness measure real echo latency

### DIFF
--- a/tests/e2e/codex-composer-echo-latency-probe.ts
+++ b/tests/e2e/codex-composer-echo-latency-probe.ts
@@ -1,0 +1,203 @@
+import type { Page } from '@stablyai/playwright-test'
+
+export type CodexEchoLatencySample = {
+  index: number
+  char: string
+  /** keydown -> xterm finished parsing the echoed glyph (real echo latency). */
+  keyToParseMs: number
+  /** keydown -> xterm renderer painted the row carrying that glyph. */
+  keyToRenderMs: number | null
+}
+
+export type CodexEchoProbeReport = {
+  samples: CodexEchoLatencySample[]
+  keysObserved: number
+  parseEvents: number
+  renderEvents: number
+  cols: number
+  rows: number
+}
+
+declare global {
+  // oxlint-disable-next-line typescript-eslint/consistent-type-definitions -- declaration merging requires interface
+  interface Window {
+    __codexEchoProbe?: {
+      report(): CodexEchoProbeReport
+      dispose(): void
+    }
+  }
+}
+
+/**
+ * Installs an in-renderer echo-latency recorder on the active terminal pane.
+ *
+ * Why in-page: polling a serialized buffer over CDP adds serialize + IPC +
+ * poll-granularity cost to every sample, which swamped the signal it measured.
+ * Timestamps here are taken inside the renderer with performance.now(), so the
+ * measured window contains no cross-process work at all.
+ */
+export async function installCodexEchoLatencyProbe(page: Page, target: string): Promise<void> {
+  await page.evaluate((target) => {
+    type PendingSample = {
+      index: number
+      char: string
+      expected: string
+      startedAt: number
+      parsedAt: number | null
+    }
+
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('Codex echo probe: no active terminal pane')
+    }
+    const terminal = pane.terminal
+    if (typeof terminal.onWriteParsed !== 'function') {
+      throw new Error('Codex echo probe: xterm build has no onWriteParsed')
+    }
+
+    const samples: CodexEchoLatencySample[] = []
+    const awaitingRender: { sample: CodexEchoLatencySample; startedAt: number }[] = []
+    // Why a queue, not one slot: a slow echo can still be outstanding when the
+    // next key is pressed, and a single slot silently discards that sample.
+    const pending: PendingSample[] = []
+    let keysObserved = 0
+    let parseEvents = 0
+    let renderEvents = 0
+
+    // Why concatenated without a separator: a composer line that wraps splits the
+    // token across rows, and trailing-trimmed rows rejoin exactly at the break.
+    const viewportText = (): string => {
+      const buffer = terminal.buffer.active
+      let text = ''
+      for (let row = 0; row < terminal.rows; row += 1) {
+        text += buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? ''
+      }
+      return text
+    }
+
+    const observeParse = (): void => {
+      parseEvents += 1
+      if (pending.length === 0) {
+        return
+      }
+      const text = viewportText()
+      // Why drain in order: one parse can land several queued keystrokes at
+      // once, and each still gets credited against its own keydown timestamp.
+      while (pending.length > 0 && text.includes(pending[0].expected)) {
+        const entry = pending.shift()
+        if (!entry) {
+          break
+        }
+        entry.parsedAt = performance.now()
+        const sample: CodexEchoLatencySample = {
+          index: entry.index,
+          char: entry.char,
+          keyToParseMs: entry.parsedAt - entry.startedAt,
+          keyToRenderMs: null
+        }
+        samples.push(sample)
+        awaitingRender.push({ sample, startedAt: entry.startedAt })
+      }
+    }
+
+    const observeRender = (): void => {
+      renderEvents += 1
+      const paintedAt = performance.now()
+      for (const entry of awaitingRender.splice(0, awaitingRender.length)) {
+        entry.sample.keyToRenderMs = paintedAt - entry.startedAt
+      }
+    }
+
+    // Why window capture: a listener on an ancestor in the capture phase is
+    // guaranteed to run before xterm's own keydown handler forwards to the PTY,
+    // so t0 is stamped before any of the work being measured starts.
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key.length !== 1 || keysObserved >= target.length) {
+        return
+      }
+      const index = keysObserved
+      keysObserved += 1
+      pending.push({
+        index,
+        char: target[index],
+        expected: target.slice(0, index + 1),
+        startedAt: performance.now(),
+        parsedAt: null
+      })
+    }
+
+    window.addEventListener('keydown', onKeyDown, { capture: true })
+    const parsedDisposable = terminal.onWriteParsed(observeParse)
+    const renderDisposable = terminal.onRender(observeRender)
+
+    window.__codexEchoProbe = {
+      report: () => ({
+        samples: [...samples],
+        keysObserved,
+        parseEvents,
+        renderEvents,
+        cols: terminal.cols,
+        rows: terminal.rows
+      }),
+      dispose: () => {
+        window.removeEventListener('keydown', onKeyDown, { capture: true })
+        parsedDisposable.dispose()
+        renderDisposable.dispose()
+      }
+    }
+  }, target)
+}
+
+/** Drains every recorded sample in a single round-trip once typing has finished. */
+export async function collectCodexEchoLatencyReport(page: Page): Promise<CodexEchoProbeReport> {
+  return page.evaluate(() => {
+    const probe = window.__codexEchoProbe
+    if (!probe) {
+      throw new Error('Codex echo probe was never installed')
+    }
+    const report = probe.report()
+    probe.dispose()
+    return report
+  })
+}
+
+export type LatencyDistribution = {
+  count: number
+  p50: number
+  p95: number
+  max: number
+}
+
+function percentile(sorted: number[], quantile: number): number {
+  if (sorted.length === 0) {
+    return 0
+  }
+  const rank = Math.min(sorted.length - 1, Math.ceil(quantile * sorted.length) - 1)
+  return sorted[Math.max(0, rank)]
+}
+
+export function summarizeLatencies(values: number[]): LatencyDistribution {
+  const sorted = [...values].sort((a, b) => a - b)
+  return {
+    count: sorted.length,
+    p50: percentile(sorted, 0.5),
+    p95: percentile(sorted, 0.95),
+    max: sorted.at(-1) ?? 0
+  }
+}
+
+export function formatDistribution(label: string, distribution: LatencyDistribution): string {
+  return (
+    `${label} n=${distribution.count} p50=${distribution.p50.toFixed(1)}ms ` +
+    `p95=${distribution.p95.toFixed(1)}ms max=${distribution.max.toFixed(1)}ms`
+  )
+}

--- a/tests/e2e/terminal-codex-local-typing-latency.spec.ts
+++ b/tests/e2e/terminal-codex-local-typing-latency.spec.ts
@@ -1,5 +1,5 @@
 import type { Page } from '@stablyai/playwright-test'
-import { randomUUID } from 'node:crypto'
+import { existsSync } from 'node:fs'
 import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
@@ -13,12 +13,37 @@ import {
   analyzeRasterCursorCells,
   type TerminalRasterProbeTarget
 } from './terminal-cursor-raster-probe'
+import {
+  collectCodexEchoLatencyReport,
+  formatDistribution,
+  installCodexEchoLatencyProbe,
+  summarizeLatencies
+} from './codex-composer-echo-latency-probe'
 
-const CODEX_READY_RE = /Ask Codex|OpenAI/i
+// Why: only the live composer draws this status bar. Banner text like "OpenAI's
+// command-line coding agent" also renders on the sign-in screen, and the
+// serialized buffer interleaves ANSI codes through the banner glyphs.
+const CODEX_COMPOSER_READY_RE = /Context \d+% used/i
+const CODEX_SIGN_IN_RE = /Sign in with ChatGPT|Sign in to|press Enter to log in/i
 const CODEX_TRUST_PROMPT_RE = /Do you trust|trust this folder|Trust this/i
 const CODEX_UPDATE_PROMPT_RE = /update available|install update|Skip for now/i
-const MAX_MEDIAN_KEY_LATENCY_MS = 150
-const MAX_WORST_KEY_LATENCY_MS = 500
+// Why lowercase ASCII only: digits/punctuation trigger the composer's slash and
+// file-mention popups, which redraw the whole pane and skew later keystrokes.
+const TYPING_ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
+const TOTAL_KEYSTROKES = 60
+// Why: the first keystrokes pay one-time costs (composer first-paint, WebGL
+// atlas fill), so they measure startup rather than steady-state typing.
+const WARMUP_KEYSTROKES = 10
+const KEYSTROKE_INTERVAL_MS = 60
+const TERMINAL_DUMP_CHARS = 4_000
+// Why these budgets: 10 local runs measured p50 21.6-22.6ms, p95 23.2-41.5ms,
+// max 23.4-58.7ms; each sits ~1.5-2x above the observed spread, so a real
+// regression trips the gate well before 100ms (perceptible lag) without
+// flagging scheduler jitter. A plain-shell control on the same probe reads
+// p50 2ms, so this budget is Codex composer cost, not harness overhead.
+const MAX_P50_ECHO_LATENCY_MS = 35
+const MAX_P95_ECHO_LATENCY_MS = 60
+const MAX_WORST_ECHO_LATENCY_MS = 120
 
 type CodexCursorBlinkSample = {
   elapsedMs: number
@@ -121,10 +146,10 @@ async function sampleCursorBlink(page: Page): Promise<CodexCursorBlinkSample[]> 
 }
 
 async function dismissCodexPromptsIfPresent(page: Page): Promise<void> {
-  const deadline = Date.now() + 15_000
+  const deadline = Date.now() + 20_000
   while (Date.now() < deadline) {
-    const content = await getTerminalContent(page, 12_000)
-    if (CODEX_READY_RE.test(content) && !CODEX_TRUST_PROMPT_RE.test(content)) {
+    const content = await getTerminalContent(page, TERMINAL_DUMP_CHARS)
+    if (CODEX_COMPOSER_READY_RE.test(content)) {
       return
     }
     if (CODEX_TRUST_PROMPT_RE.test(content)) {
@@ -142,29 +167,23 @@ async function dismissCodexPromptsIfPresent(page: Page): Promise<void> {
   }
 }
 
-async function waitForCodexReady(page: Page): Promise<void> {
-  await expect
-    .poll(async () => CODEX_READY_RE.test(await getTerminalContent(page, 12_000)), {
-      timeout: 45_000,
-      message: 'Codex TUI did not render'
-    })
-    .toBe(true)
-}
-
-async function waitForPromptText(page: Page, text: string): Promise<number> {
-  const start = performance.now()
-  while (performance.now() - start < MAX_WORST_KEY_LATENCY_MS) {
-    if ((await getTerminalContent(page, 12_000)).includes(text)) {
-      return performance.now() - start
+// Why the dump: a run that "went ready" on the sign-in screen produced garbage
+// numbers silently before; failures must show what the pane actually rendered.
+async function waitForCodexComposer(page: Page): Promise<string> {
+  const deadline = Date.now() + 60_000
+  let lastContent = ''
+  while (Date.now() < deadline) {
+    lastContent = await getTerminalContent(page, TERMINAL_DUMP_CHARS)
+    const readyMarker = CODEX_COMPOSER_READY_RE.exec(lastContent)
+    if (readyMarker) {
+      return readyMarker[0]
     }
-    await page.waitForTimeout(5)
+    await page.waitForTimeout(250)
   }
-  throw new Error(`Codex prompt did not show ${text}`)
-}
-
-function median(values: number[]): number {
-  const sorted = [...values].sort((a, b) => a - b)
-  return sorted[Math.floor(sorted.length / 2)] ?? 0
+  const reason = CODEX_SIGN_IN_RE.test(lastContent)
+    ? 'Codex stopped on the sign-in screen — CODEX_HOME auth was not visible to the TUI'
+    : 'Codex never reached the composer'
+  throw new Error(`${reason}\n--- terminal tail ---\n${lastContent.slice(-1_500)}\n--- end ---`)
 }
 
 test.describe('local Codex terminal typing latency', () => {
@@ -175,45 +194,71 @@ test.describe('local Codex terminal typing latency', () => {
     )
     test.skip(process.platform === 'win32', 'local Codex command is POSIX-shell oriented')
 
+    const homeDir = process.env.HOME ?? ''
+    const codexSource = path.join(homeDir, 'projects', 'codex')
+    // Why: the E2E profile runs an isolated HOME with a managed CODEX_HOME that
+    // has no auth.json, so an unpinned launch lands on the sign-in screen.
+    const realCodexHome = path.join(homeDir, '.codex')
+    test.skip(
+      !existsSync(path.join(realCodexHome, 'auth.json')),
+      'Codex auth.json is missing; the TUI would render the sign-in screen instead of a composer'
+    )
+    test.skip(!existsSync(codexSource), 'local Codex checkout is missing')
+
     await waitForSessionReady(orcaPage)
     await waitForActiveWorktree(orcaPage)
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage, 30_000)
 
     const ptyId = await waitForActivePanePtyId(orcaPage)
-    const codexSource = path.join(process.env.HOME ?? '', 'projects', 'codex')
     const launchCommand =
-      `cd ${JSON.stringify(codexSource)} && ` +
+      `cd ${JSON.stringify(codexSource)} && CODEX_HOME=${JSON.stringify(realCodexHome)} ` +
       'codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust\r'
 
     try {
       await sendToTerminal(orcaPage, ptyId, launchCommand)
       await dismissCodexPromptsIfPresent(orcaPage)
-      await waitForCodexReady(orcaPage)
+      const composerMarker = await waitForCodexComposer(orcaPage)
+      testInfo.annotations.push({
+        type: 'codex-composer-ready-marker',
+        description: composerMarker
+      })
       await focusActiveTerminalInput(orcaPage)
       await forceCursorProbeTheme(orcaPage)
       const blinkSamples = await sampleCursorBlink(orcaPage)
+      await focusActiveTerminalInput(orcaPage)
 
-      const runId = randomUUID().replaceAll('-', '').slice(0, 8)
-      const prompt = `orca_codex_latency_${runId}`
-      const latencies: number[] = []
-      let typed = ''
-      for (const char of prompt) {
-        typed += char
-        const start = performance.now()
+      const typed = Array.from(
+        { length: TOTAL_KEYSTROKES },
+        (_value, index) => TYPING_ALPHABET[index % TYPING_ALPHABET.length]
+      ).join('')
+      await installCodexEchoLatencyProbe(orcaPage, typed)
+      for (const char of typed) {
         await orcaPage.keyboard.type(char)
-        await waitForPromptText(orcaPage, typed)
-        latencies.push(performance.now() - start)
+        // Why: spacing keys past one frame keeps each sample an isolated echo
+        // instead of measuring a burst the scheduler coalesced into one write.
+        await orcaPage.waitForTimeout(KEYSTROKE_INTERVAL_MS)
       }
+      // Why: the last keystroke's echo can still be in flight when typing ends.
+      await orcaPage.waitForTimeout(1_000)
+      const report = await collectCodexEchoLatencyReport(orcaPage)
 
-      const medianLatency = median(latencies)
-      const worstLatency = Math.max(...latencies)
-      testInfo.annotations.push({
-        type: 'codex-local-typing-latency',
-        description: `median=${medianLatency.toFixed(1)}ms worst=${worstLatency.toFixed(
-          1
-        )}ms samples=${latencies.map((value) => value.toFixed(1)).join(',')}`
-      })
+      const measured = report.samples.filter((sample) => sample.index >= WARMUP_KEYSTROKES)
+      const parseLatencies = measured.map((sample) => sample.keyToParseMs)
+      const renderLatencies = measured
+        .map((sample) => sample.keyToRenderMs)
+        .filter((value): value is number => value !== null)
+      const echo = summarizeLatencies(parseLatencies)
+      const painted = summarizeLatencies(renderLatencies)
+
+      const summary =
+        `${formatDistribution('echo(key->parse)', echo)} | ` +
+        `${formatDistribution('paint(key->render)', painted)} | ` +
+        `keys=${report.keysObserved} parseEvents=${report.parseEvents}`
+      testInfo.annotations.push({ type: 'codex-local-typing-latency', description: summary })
+      // Why stdout too: annotations are invisible in the default list reporter,
+      // and these numbers are the whole point of the run.
+      console.log(`[codex-typing-latency] ready="${composerMarker}" ${summary}`)
       testInfo.annotations.push({
         type: 'codex-local-cursor-blink',
         description: blinkSamples
@@ -223,8 +268,12 @@ test.describe('local Codex terminal typing latency', () => {
 
       expect(blinkSamples.some((sample) => sample.paintedCursorCellCount > 0)).toBe(true)
       expect(blinkSamples.some((sample) => sample.paintedCursorCellCount === 0)).toBe(true)
-      expect(medianLatency).toBeLessThan(MAX_MEDIAN_KEY_LATENCY_MS)
-      expect(worstLatency).toBeLessThan(MAX_WORST_KEY_LATENCY_MS)
+      // Why: a dropped keystroke means the composer stopped echoing, which the
+      // latency percentiles alone would silently hide.
+      expect(report.samples.length).toBe(TOTAL_KEYSTROKES)
+      expect(echo.p50).toBeLessThan(MAX_P50_ECHO_LATENCY_MS)
+      expect(echo.p95).toBeLessThan(MAX_P95_ECHO_LATENCY_MS)
+      expect(echo.max).toBeLessThan(MAX_WORST_ECHO_LATENCY_MS)
     } finally {
       await sendToTerminal(orcaPage, ptyId, '\x03').catch(() => undefined)
     }

--- a/tests/e2e/terminal-codex-local-typing-latency.spec.ts
+++ b/tests/e2e/terminal-codex-local-typing-latency.spec.ts
@@ -36,20 +36,22 @@ const TOTAL_KEYSTROKES = 60
 const WARMUP_KEYSTROKES = 10
 const KEYSTROKE_INTERVAL_MS = 60
 const TERMINAL_DUMP_CHARS = 4_000
-// Why these budgets: 10 local runs measured p50 21.6-22.6ms, p95 23.2-41.5ms,
-// max 23.4-58.7ms; each sits ~1.5-2x above the observed spread, so a real
-// regression trips the gate well before 100ms (perceptible lag) without
-// flagging scheduler jitter. A plain-shell control on the same probe reads
-// p50 2ms, so this budget is Codex composer cost, not harness overhead.
+// Why these budgets: ~20 local runs put p50 in a tight 21.5-22.6ms band with a
+// unimodal per-key distribution and rare isolated spikes to ~90ms. p50 gates the
+// steady state at ~1.6x observed; the tail budgets absorb those spikes so only a
+// sustained shift fails. A plain-shell control on this same probe reads p50 2ms,
+// so the ~22ms is Codex composer redraw cost, not harness overhead.
 const MAX_P50_ECHO_LATENCY_MS = 35
-const MAX_P95_ECHO_LATENCY_MS = 60
-const MAX_WORST_ECHO_LATENCY_MS = 120
+const MAX_P95_ECHO_LATENCY_MS = 80
+const MAX_WORST_ECHO_LATENCY_MS = 150
 
 type CodexCursorBlinkSample = {
   elapsedMs: number
   paintedCursorCellCount: number
 }
 
+// Why the focus assert: a run that types into an unfocused pane records zero
+// echoes and would otherwise fail as an opaque "sample count" mismatch.
 async function focusActiveTerminalInput(page: Page): Promise<void> {
   await page.evaluate(() => {
     const state = window.__store?.getState()
@@ -68,6 +70,11 @@ async function focusActiveTerminalInput(page: Page): Promise<void> {
     }
     pane.terminal.focus()
     textarea.focus()
+    if (document.activeElement !== textarea) {
+      throw new Error(
+        'Terminal helper textarea did not take focus; keystrokes would not reach Codex'
+      )
+    }
   })
 }
 


### PR DESCRIPTION
## Problem

`tests/e2e/terminal-codex-local-typing-latency.spec.ts` was reporting numbers that did not measure Codex typing latency. Four independent defects, all fixed here.

### 1. False-positive readiness detection

`CODEX_READY_RE = /Ask Codex|OpenAI/i` matched **"OpenAI's command-line coding agent"**, which Codex prints on its **sign-in screen**. The test went "ready" against a login prompt and then measured keystrokes into something that was not a composer.

Fixed by gating on the composer status bar, `/Context \d+% used/i` — drawn only once the interactive composer is live. Matching the startup banner is not viable: the serialized buffer interleaves ANSI escapes through those glyphs.

### 2. Missing auth guaranteed the sign-in screen

The E2E profile launches with an isolated `HOME` and a managed `CODEX_HOME` containing no `auth.json`, so Codex could never log in. The launch command now pins the real `~/.codex`, and the test skips with an explicit message when `auth.json` is absent rather than silently measuring a login screen.

### 3. Measurement overhead swamped the signal

`waitForPromptText()` polled `getTerminalContent()` every 5ms. That serializes the **entire** terminal buffer and ships it over CDP, so every sample was:

```
real echo latency + full buffer serialize + IPC round-trip + poll granularity
```

Measurement now happens entirely **in-renderer** (`tests/e2e/codex-composer-echo-latency-probe.ts`):

- `t0` stamped on `keydown` via a **capture-phase** `window` listener, so it runs before xterm forwards the key to the PTY.
- `t1` stamped in xterm's `onWriteParsed` once the echoed glyph is present in the viewport — real echo latency.
- A separate `onRender` timestamp gives **time-to-painted-glyph**, so parse latency and render latency are reported independently.
- All samples are drained in **one** `page.evaluate` after typing ends. Zero CDP round-trips inside the measured window.

The pending-keystroke queue is intentionally a queue, not a single slot: a slow echo can still be outstanding when the next key is pressed, and a single slot silently dropped that sample.

### 4. Thresholds could not catch a regression

`median < 150ms` / `worst < 500ms` against a real p50 of ~22ms would never fail. Replaced with `p50 < 35` / `p95 < 80` / `max < 150`, derived from the measurements below.

## Measurement methodology: before vs after

| | Before | After |
|---|---|---|
| Clock | Node-side `performance.now()` across CDP | In-page `performance.now()` |
| Echo signal | Poll serialized buffer every 5ms | xterm `onWriteParsed` + viewport check |
| Per-key CDP round-trips | ~5-6 | 0 |
| Samples | 24, no warmup discard | 60, first 10 discarded as warmup |
| Reported | single median | p50 / p95 / max, echo **and** paint |
| Ready check | matched the sign-in screen | `Context N% used` composer status bar |

## Measured results (~20 local headless runs, real Codex 0.145.0)

```
echo  (key->parse)   p50 21.2-21.9ms   p95 22.8-24.0ms   max 23.0-32.4ms
paint (key->render)  p50 25.7-28.7ms   p95 34.2-35.3ms
```

p50 sits in a very tight 21.2-21.9ms band and the per-key distribution is unimodal. The ~90-125ms tail spikes I originally recorded turned out to be machine contention from a concurrent E2E batch, not intrinsic jitter (see Stability below); tail budgets still carry headroom for them so the gate survives a loaded CI box.

**Control run — this matters.** The same probe against a plain shell (`cat`, no TUI redraw) reads **p50 2.0ms / p95 3.0ms**. That separates the harness floor from the thing being measured: the ~22ms is genuine Codex composer redraw cost, not instrumentation overhead. The old harness reported ~29-30ms for *everything*, which is what made its numbers meaningless.

## Readiness fix is proven

Every run logs its readiness marker:

```
[codex-typing-latency] ready="Context 0% used" echo(key->parse) n=50 p50=21.9ms ...
```

And the failure path was verified deliberately by pointing `CODEX_HOME` at an empty directory — the harness now fails loudly with a terminal dump instead of measuring a login screen:

```
Error: Codex stopped on the sign-in screen — CODEX_HOME auth was not visible to the TUI
--- terminal tail ---
[Codex ASCII sign-in art]
```

## Also fixed

- **Statistical soundness**: 60 keystrokes (was 24), first 10 discarded as warmup (composer first-paint, WebGL atlas fill), p50/p95/max instead of a lone median.
- **Popup interference**: input is lowercase ASCII only, so the composer's slash-command and file-mention popups cannot redraw the pane and skew later keystrokes.
- **Dropped-keystroke detection**: asserts every keystroke was echoed; percentiles alone would hide a composer that stopped responding.
- **Focus assertion**: verifies the xterm helper textarea actually took focus. One run typed all 60 keys with only 5 parse events because focus was lost, which previously surfaced as an opaque sample-count mismatch.
- Codex is still cleanly `Ctrl-C`'d in `finally`.

## Stability

16 consecutive local runs in a quiet environment: no crashes, no flakes.

An earlier revision of this description claimed a ~1-in-6 pre-existing `Target crashed` in the cursor-blink screenshot sampler. That was wrong and has been removed: another agent's cleanup script was running `pkill -9 -f orca-e2e-userdata`, which matches *every* agent's Playwright profile dir and was killing these runs mid-flight. My A/B control against the unmodified `main` spec ran inside that same window, which is why the crash appeared to reproduce on both sides. In a quiet environment the sampler is stable.

That episode also quantifies how sensitive these numbers are to machine load:

| | p50 | max |
|---|---|---|
| Quiet | 21.2-21.5ms | 23-31ms |
| Concurrent E2E on the same box | 25.5-27.8ms | 35-36ms, with spikes to 90-125ms |

Roughly 25% p50 inflation under contention. **Run this spec on an otherwise idle machine**; the thresholds are set for quiet-machine conditions.

## Verification

- `oxlint` clean on both files; no `max-lines` disables added.
- Run with:
  ```
  ORCA_E2E_REAL_CODEX=1 SKIP_BUILD=1 npx playwright test \
    --config tests/playwright.config.ts \
    tests/e2e/terminal-codex-local-typing-latency.spec.ts \
    --project=electron-headless
  ```
  (note: the config lives at `tests/playwright.config.ts`, not `config/`)
