### PR TITLE
perf(relay): stop snapshotting the whole pending-PTY map every drain tick

### DIFF
--- a/src/relay/pty-handler-output-drain-differential.test.ts
+++ b/src/relay/pty-handler-output-drain-differential.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+const { mockPtySpawn, mockPtyInstance } = vi.hoisted(() => ({
+  mockPtySpawn: vi.fn(),
+  mockPtyInstance: {
+    pid: process.pid,
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    clear: vi.fn()
+  }
+}))
+
+vi.mock('node-pty', () => ({ spawn: mockPtySpawn }))
+
+import { PtyHandler } from './pty-handler'
+import type { RelayDispatcher } from './dispatcher'
+
+// Mirrors the relay drain constants; kept local so a constant change fails this oracle loudly.
+const CHUNK_CHARS = 16 * 1024
+const MAX_WRITES = 2
+const BATCH_INTERVAL_MS = 8
+const DRAIN_CONTINUE_MS = 1
+
+type PendingOutput = { data: string; rawLength?: number; seq?: number }
+type DataEvent = { id: string; data: string; seq?: number; rawLength?: number }
+
+/**
+ * The pre-optimization implementation, verbatim in behavior: snapshot the whole pending map each
+ * tick, then consume up to MAX_WRITES from that frozen list. The bounded-prefix capture must match
+ * it event-for-event — including which entry leads each tick.
+ */
+function legacyFlushTick(pendingById: Map<string, PendingOutput>): {
+  events: DataEvent[]
+  writes: number
+  reschedules: boolean
+} {
+  const events: DataEvent[] = []
+  let writes = 0
+  for (const [id, pending] of Array.from(pendingById.entries())) {
+    if (writes >= MAX_WRITES) {
+      break
+    }
+    pendingById.delete(id)
+    const chunk = pending.data.slice(0, CHUNK_CHARS)
+    const remaining = pending.data.slice(CHUNK_CHARS)
+    if (remaining) {
+      pendingById.set(id, {
+        data: remaining,
+        ...(pending.rawLength === undefined ? {} : { rawLength: remaining.length }),
+        seq: pending.seq
+      })
+    }
+    events.push({
+      id,
+      data: chunk,
+      ...(pending.seq === undefined
+        ? {}
+        : { seq: pending.seq - (pending.data.length - chunk.length) }),
+      ...(pending.rawLength === undefined ? {} : { rawLength: chunk.length })
+    })
+    writes += 1
+  }
+  return { events, writes, reschedules: pendingById.size > 0 && writes > 0 }
+}
+
+function legacyTimeline(initial: Map<string, PendingOutput>): DataEvent[] {
+  const pendingById = new Map(initial)
+  const timeline: DataEvent[] = []
+  for (let tick = 0; tick < 500 && pendingById.size > 0; tick++) {
+    const result = legacyFlushTick(pendingById)
+    timeline.push(...result.events)
+    if (!result.reschedules) {
+      break
+    }
+  }
+  return timeline
+}
+
+// xorshift32 — deterministic across platforms, no Math.random.
+function createRandom(seed: number): () => number {
+  let state = seed >>> 0 || 1
+  return () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    state >>>= 0
+    return state / 0x1_0000_0000
+  }
+}
+
+describe('relay PTY output drain — differential vs the pre-optimization snapshot loop', () => {
+  let dispatcher: {
+    notify: ReturnType<typeof vi.fn>
+    callRequest: (method: string, params?: Record<string, unknown>) => Promise<unknown>
+    _notifications: { method: string; params?: Record<string, unknown> }[]
+  }
+  let handler: PtyHandler
+  let dataCallbacks: Map<string, (data: string) => void>
+  let exitCallbacks: Map<string, (event: { exitCode: number }) => void>
+  let onNotifyData: ((frame: { id: string; data: string }) => void) | null
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockPtySpawn.mockReset()
+    dataCallbacks = new Map()
+    exitCallbacks = new Map()
+    onNotifyData = null
+
+    const requestHandlers = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+    const notifications: { method: string; params?: Record<string, unknown> }[] = []
+    let reentering = false
+    dispatcher = {
+      notify: vi.fn((method: string, params?: Record<string, unknown>) => {
+        notifications.push({ method, params })
+        if (method !== 'pty.data' || !onNotifyData || reentering) {
+          return
+        }
+        // Why: the relay sink is a synchronous write; this hook models a sink that re-enters
+        // PTY ingress before the drain returns.
+        reentering = true
+        try {
+          onNotifyData(params as unknown as { id: string; data: string })
+        } finally {
+          reentering = false
+        }
+      }),
+      callRequest: async (method: string, params: Record<string, unknown> = {}) => {
+        const h = requestHandlers.get(method)
+        if (!h) {
+          throw new Error(`No handler for ${method}`)
+        }
+        return h(params)
+      },
+      _notifications: notifications
+    }
+    const full = {
+      onRequest: vi.fn((method: string, h: (params: Record<string, unknown>) => Promise<unknown>) =>
+        requestHandlers.set(method, h)
+      ),
+      onNotification: vi.fn(),
+      notify: dispatcher.notify
+    }
+    handler = new PtyHandler(full as unknown as RelayDispatcher)
+  })
+
+  afterEach(async () => {
+    onNotifyData = null
+    const cleanup = handler.dispose({ waitForPhysicalExit: false })
+    await vi.runAllTimersAsync()
+    await cleanup.catch(() => {})
+    vi.useRealTimers()
+  })
+
+  async function spawnPtys(count: number): Promise<string[]> {
+    const ids: string[] = []
+    for (let i = 0; i < count; i++) {
+      mockPtySpawn.mockReturnValueOnce({
+        ...mockPtyInstance,
+        onData: vi.fn((cb: (data: string) => void) => {
+          dataCallbacks.set(`pty-${i + 1}`, cb)
+        }),
+        onExit: vi.fn((cb: (event: { exitCode: number }) => void) => {
+          exitCallbacks.set(`pty-${i + 1}`, cb)
+        })
+      })
+      const spawned = (await dispatcher.callRequest('pty.spawn', {})) as { id: string }
+      ids.push(spawned.id)
+    }
+    return ids
+  }
+
+  function recordedDataEvents(): DataEvent[] {
+    return dispatcher._notifications
+      .filter((n) => n.method === 'pty.data')
+      .map((n) => n.params as unknown as DataEvent)
+  }
+
+  it('emits the same pty.data timeline as the snapshot loop for multi-PTY multi-chunk drains', async () => {
+    const sessionCount = 4
+    const ids = await spawnPtys(sessionCount)
+
+    const payloads = new Map<string, string>()
+    const expectedPending = new Map<string, PendingOutput>()
+    ids.forEach((id, index) => {
+      // Vary chunk counts so PTYs finish on different ticks.
+      const data = `${String.fromCharCode(97 + index)}`.repeat(CHUNK_CHARS * (index + 1) + index)
+      payloads.set(id, data)
+      expectedPending.set(id, { data })
+    })
+
+    for (const id of ids) {
+      dataCallbacks.get(id)!(payloads.get(id)!)
+    }
+
+    await vi.advanceTimersByTimeAsync(BATCH_INTERVAL_MS)
+    for (let tick = 0; tick < 200; tick++) {
+      await vi.advanceTimersByTimeAsync(DRAIN_CONTINUE_MS)
+    }
+
+    expect(recordedDataEvents()).toEqual(legacyTimeline(expectedPending))
+  })
+
+  it('matches the snapshot loop across randomized session counts and payload sizes', async () => {
+    const random = createRandom(0x5eed)
+    const sessionCount = 5
+    const ids = await spawnPtys(sessionCount)
+
+    const expectedPending = new Map<string, PendingOutput>()
+    for (const id of ids) {
+      const chunks = 1 + Math.floor(random() * 3)
+      const extra = Math.floor(random() * 64)
+      const data = 'z'.repeat(CHUNK_CHARS * chunks + extra)
+      expectedPending.set(id, { data })
+      dataCallbacks.get(id)!(data)
+    }
+
+    await vi.advanceTimersByTimeAsync(BATCH_INTERVAL_MS)
+    for (let tick = 0; tick < 300; tick++) {
+      await vi.advanceTimersByTimeAsync(DRAIN_CONTINUE_MS)
+    }
+
+    expect(recordedDataEvents()).toEqual(legacyTimeline(expectedPending))
+  })
+
+  it('keeps one write per tick when a single PTY drains — pacing a lazy iterator walk breaks', async () => {
+    const [id] = await spawnPtys(1)
+    const first = 'x'.repeat(CHUNK_CHARS)
+    dataCallbacks.get(id)!(`${first}tail`)
+
+    await vi.advanceTimersByTimeAsync(BATCH_INTERVAL_MS)
+    // Iterating the live map lazily would pick the re-queued remainder up again in this same tick.
+    expect(recordedDataEvents()).toEqual([{ id, data: first }])
+
+    await vi.advanceTimersByTimeAsync(DRAIN_CONTINUE_MS)
+    expect(recordedDataEvents()).toEqual([
+      { id, data: first },
+      { id, data: 'tail' }
+    ])
+  })
+
+  it('writes at most two PTYs per tick and rotates the rest to the next tick', async () => {
+    const ids = await spawnPtys(3)
+    for (const id of ids) {
+      dataCallbacks.get(id)!('a'.repeat(CHUNK_CHARS + 4))
+    }
+
+    await vi.advanceTimersByTimeAsync(BATCH_INTERVAL_MS)
+    // First tick writes the two head PTYs only.
+    expect(recordedDataEvents().map((event) => event.id)).toEqual([ids[0], ids[1]])
+
+    await vi.advanceTimersByTimeAsync(DRAIN_CONTINUE_MS)
+    // Third PTY leads the next tick; the two re-queued remainders sit behind it.
+    expect(recordedDataEvents().map((event) => event.id)).toEqual([ids[0], ids[1], ids[2], ids[0]])
+  })
+
+  it('freezes the tick batch before the first send, matching the snapshot loop under re-entrancy', async () => {
+    const ids = await spawnPtys(2)
+    dataCallbacks.get(ids[0])!('first')
+    dataCallbacks.get(ids[1])!('second')
+
+    // Append to the second PTY while the first is being sent. Capturing the batch up front freezes
+    // the same values the whole-map snapshot froze, so this tick's output is unchanged.
+    onNotifyData = (frame) => {
+      if (frame.id === ids[0]) {
+        dataCallbacks.get(ids[1])!('-appended')
+      }
+    }
+
+    await vi.advanceTimersByTimeAsync(BATCH_INTERVAL_MS)
+    expect(recordedDataEvents()).toEqual([
+      { id: ids[0], data: 'first' },
+      { id: ids[1], data: 'second' }
+    ])
+
+    onNotifyData = null
+    await vi.advanceTimersByTimeAsync(BATCH_INTERVAL_MS)
+    await vi.advanceTimersByTimeAsync(BATCH_INTERVAL_MS)
+    // Verbatim pre-change behavior, quirk included: the frozen entry is sent and then deleted, so
+    // bytes appended to it mid-tick are dropped. Reachable only from a sink that re-enters PTY
+    // ingress synchronously; the relay's real sinks are stdout/socket writes that cannot. Asserted
+    // here so the optimization is pinned to "no behavior change" rather than a silent improvement.
+    expect(recordedDataEvents()).toEqual([
+      { id: ids[0], data: 'first' },
+      { id: ids[1], data: 'second' }
+    ])
+  })
+
+  it('flushes pending bytes before pty.exit', async () => {
+    // PTY exit routes through flushPtyOutput (the whole-entry path), not the chunked drain.
+    const [id] = await spawnPtys(1)
+    dataCallbacks.get(id)!('tail bytes')
+    exitCallbacks.get(id)!({ exitCode: 0 })
+
+    const methods = dispatcher._notifications.map((n) => n.method)
+    // Ordering invariant: buffered output must land before the exit frame.
+    expect(methods.indexOf('pty.data')).toBeGreaterThanOrEqual(0)
+    expect(methods.indexOf('pty.data')).toBeLessThan(methods.indexOf('pty.exit'))
+
+    const dataFrames = dispatcher._notifications.filter((n) => n.method === 'pty.data')
+    expect(dataFrames).toHaveLength(1)
+    expect(dataFrames[0].params).toEqual({ id, data: 'tail bytes' })
+  })
+})

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -723,11 +723,21 @@ export class PtyHandler {
 
   private flushPendingOutput(): void {
     this.outputFlushTimer = null
-    let writes = 0
-    for (const [id, pending] of Array.from(this.pendingOutputByPty.entries())) {
-      if (writes >= PTY_OUTPUT_FLUSH_MAX_WRITES) {
+    // Why: the send loop has no skip path and stops at PTY_OUTPUT_FLUSH_MAX_WRITES, so it can never
+    // reach a third entry — `Array.from(entries())` allocated one tuple per session every tick to
+    // consume at most two. Capture only that prefix, and capture it *before* the first send so a
+    // re-entrant sink still reads the values a whole-map snapshot would have frozen.
+    // Why the explicit iterator: `for...of` would advance one tuple past the limit and discard it.
+    const pendingEntries = this.pendingOutputByPty[Symbol.iterator]()
+    const batch: [string, PendingPtyOutput][] = []
+    while (batch.length < PTY_OUTPUT_FLUSH_MAX_WRITES) {
+      const next = pendingEntries.next()
+      if (next.done === true) {
         break
       }
+      batch.push(next.value)
+    }
+    for (const [id, pending] of batch) {
       this.pendingOutputByPty.delete(id)
       const chunk = pending.transformed
         ? pending.data
@@ -754,9 +764,8 @@ export class PtyHandler {
         ...(chunkRawLength === undefined ? {} : { rawLength: chunkRawLength }),
         ...(pending.transformed ? { transformed: true } : {})
       })
-      writes++
     }
-    if (this.pendingOutputByPty.size > 0 && writes > 0) {
+    if (this.pendingOutputByPty.size > 0 && batch.length > 0) {
       // Why: yield between slices of a large chunk so client input and control frames can interleave.
       this.scheduleOutputFlush(PTY_OUTPUT_DRAIN_CONTINUE_MS)
     }


### PR DESCRIPTION
## Description

`PtyHandler.flushPendingOutput()` runs every `PTY_OUTPUT_BATCH_INTERVAL_MS` (8 ms) while any relay PTY has buffered output, and again every `PTY_OUTPUT_DRAIN_CONTINUE_MS` (1 ms) while a large chunk is still draining. It began with:

```ts
for (const [id, pending] of Array.from(this.pendingOutputByPty.entries())) {
  if (writes >= PTY_OUTPUT_FLUSH_MAX_WRITES) break
  ...
}
```

`Array.from(entries())` materializes one `[id, pending]` tuple **per live session**, every tick — but the loop consumes at most `PTY_OUTPUT_FLUSH_MAX_WRITES` (2) of them. At the relay's `MAX_RELAY_PTY_SESSIONS = 50` cap that's 50 tuples allocated to use 2, up to 1000×/s.

This replaces the whole-map snapshot with a **bounded-prefix** capture: walk the map iterator for at most `PTY_OUTPUT_FLUSH_MAX_WRITES` entries into a local array, *before* the first send, then run the unchanged send body over that array. Cost goes from O(sessions) to flat.

The send body is untouched. No new fields, no wire-format change, no new helpers. **+15 / −5 lines** in `flushPendingOutput` plus a differential test.

**Why capture is still needed (vs. a naive live-iterator walk):** the loop `delete`s each entry and `set`s any remainder back, which moves it to the map's tail. A live iterator would revisit that remainder in the *same* tick, so a single draining PTY would emit 2 writes/tick instead of 1 — a real pacing change. Capturing first preserves the legacy write cadence exactly.

**Why capture must precede the first `notify`:** `dispatcher.notify` is synchronous. Freezing before any send is what makes this equivalent to a whole-map snapshot even if a sink were to re-enter PTY ingress.

**Why an explicit `[Symbol.iterator]()` instead of `for...of` + break:** `for...of` pulls one tuple past the limit and discards it, and a `push`-then-`break` form over-writes by one if the constant were ever `0`. The `while (batch.length < MAX)` form tracks the constant correctly at every value — verified at 0/1/2/3 against the legacy loop.

## ELI5

The relay had 50 mailboxes. Every 8 milliseconds it photocopied the address label off **all 50** just to deliver **2** letters, then threw the other 48 copies away. Now it copies the first 2 labels and delivers those. Same 2 letters, same order, same schedule — it just stopped making 48 pieces of garbage a thousand times a second.

## Proof of performance improvement

Microbenchmark, 200k drain ticks per config, legacy snapshot loop vs. bounded prefix (same map contents, same write cap):

| Live PTY sessions | Before (ns/tick) | After (ns/tick) | Change |
| --- | --- | --- | --- |
| 1 | 167 | 48 | −71% |
| 3 | 239 | 97 | −59% |
| 10 | 317 | 101 | −68% |
| 25 | 488 | 69 | −86% |
| 50 (relay cap) | **750** | **98** | **−87%** |

Before scales with session count; after is flat — exactly the expected shape when the per-tick allocation goes from O(N) to O(1). At 50 sessions during a sustained drain (1 ms reschedule) this removes ~1,900 tuple allocations per drain sequence from the relay's hot path, which on a remote host is competing with the SSH socket for the same event loop.

## Proof of no regression

Verification was built around **exact equivalence to the pre-change code**, not "looks fine":

1. **Whole-handler differential.** Built a verbatim copy of the pre-change handler from `git show HEAD:src/relay/pty-handler.ts`, drove both handlers through **600 randomized scenarios** (1–6 concurrent sessions; interleaved data/timer-advance/write/exit; sub-chunk, chunk+1, and multi-chunk payloads) **× 4 synchronous re-entrancy modes** (none / append-to-other-PTY / exit-other-PTY / append-to-self), and compared **every** `pty.data`, `pty.exit`, and `pty.replay` frame. **0 divergences.** Non-vacuity asserted (>50 scenarios per mode). Deterministic xorshift32 PRNG, no `Math.random`.
2. **Exhaustive small-state sweep.** Map sizes 0–5 × per-PTY payload lengths 1–5 = **3,906 cases. 0 divergences, 0 stall states.** A stall is also structurally impossible: the capture loop precedes every mutation, so `batch.length === 0` ⟺ the map was empty ⟺ the `size > 0` reschedule guard is already false.
3. **Oracle fidelity.** The checked-in test's `legacyFlushTick` was diffed line-by-line against HEAD's real `flushPendingOutput` and driven over **4,000 randomized cases including `rawLength`/`seq` metadata**. **0 divergences** — the oracle is faithful, so test #1's green result means something.
4. **Fairness trace.** 3 PTYs × 3 chunks: byte-identical write order *and* reschedule flag on every tick (`A:1,B:4 / C:7,A:2 / B:5,C:8 / A:3,B:6 / C:9`). Round-robin fairness across sessions is preserved.
5. **Cap-constant sweep.** Legacy vs. shipped iterator at `MAX ∈ {0,1,2,3}` × sizes {0,1,2,3,5}: identical at every point.
6. **Mutation testing** (each mutant restored after): lazy one-at-a-time walk without pre-capture → **CAUGHT**; prefix width 3 → **CAUGHT**; dropping the `batch.length > 0` reschedule guard → not caught, **proven an equivalent mutant** (see the stall argument in #2).
7. **Aliasing safety.** `enqueuePtyOutput` always constructs a *fresh* pending object and `set`s it; nothing mutates a pending value in place, so holding batched tuples across sends can't observe a torn value.

**Suites:** relay **874 pass** (2 pre-existing failures in `agent-exec-handler.test.ts`, confirmed failing on clean `main` via `git stash` — unrelated to this change); main-process PTY + SSH consumers **1419 pass / 16 skipped**. `tsc -p config/tsconfig.node.json` EXIT=0. oxlint clean, oxfmt clean, max-lines ratchet OK (354 grandfathered, no new bypasses).

### User-facing regression notes

**None.** Frame-for-frame identical output — same bytes, same order, same `seq`/`rawLength` metadata, same tick pacing, same round-robin fairness across sessions.

One deliberate note for reviewers: the new test pins a **legacy quirk** rather than silently improving it. If a sink synchronously re-enters PTY ingress and appends bytes to an already-frozen entry mid-tick, those bytes are dropped — because the entry is sent and then deleted. This is what the pre-change snapshot loop did, so the test asserts it, keeping the change strictly "no behavior change." It is unreachable in production: the relay's sinks are stdout/socket writes that cannot re-enter. Fixing it is a separate, independently-reviewable change.

## Adversarial review verdict + loop count

**Loop count: 2. Final verdict: CLEAN from both reviewers.**

| Loop | Reviewer | Verdict |
| --- | --- | --- |
| 1 (design) | gpt-5.6-sol | **DESIGN-NEEDS-REVISION** — BLOCKER: the original round/frontier design was over-engineered. Since the send body has no skip path, legacy can never reach a 3rd entry, so a bounded-prefix capture is exactly equivalent *including under re-entrancy* — which frontier could not claim. |
| 1 (impl) | gpt-5.6-sol | CLEAN + 1 NIT (on the now-discarded frontier design) |
| 2 (impl) | gpt-5.6-sol | **CLEAN** — 1 NIT: `for...of` discards one tuple past the limit |
| 2 (impl) | fable | **CLEAN** — same discarded-tuple NIT; independently reproduced the fairness trace and confirmed oracle fidelity + stall impossibility |

The loop-1 design review **changed the implementation**: the frontier design (35+/5− lines, a new `serial` type field, a wire-payload sanitizing helper, an integer-overflow rule, and only *approximate* re-entrant equivalence) was reverted to HEAD and reimplemented as the bounded prefix (15+/5− lines, no new fields, no wire change, no overflow rule, **exact** re-entrant equivalence).

Both loop-2 NITs (the discarded tuple) were fixed via the explicit `[Symbol.iterator]()` form, and the full verification battery above was **re-run against that final post-NIT form**, not just the reviewed version.

Made with [Orca](https://github.com/stablyai/orca) 🐋
