### PR TITLE
fix(projects): keep the local badge color when a remote host shares the project

### DIFF
--- a/src/renderer/src/store/slices/repos-shared-project-badge-color.test.ts
+++ b/src/renderer/src/store/slices/repos-shared-project-badge-color.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createTestStore } from './store-test-helpers'
+import type { Project, ProjectHostSetup, Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+
+// Mirrors the real report: one project name ("orca") set up on the local Mac and on a
+// remote Orca server, where only the local repo row carries the user's chosen color.
+const SHARED_PROJECT_ID = 'github:stablyai/orca'
+const LOCAL_GREEN = '#22c55e'
+const REMOTE_NEUTRAL = '#737373'
+
+const localRepo: Repo = {
+  id: 'local-repo',
+  path: '/local/orca',
+  displayName: 'orca',
+  badgeColor: LOCAL_GREEN,
+  upstream: { owner: 'stablyai', repo: 'orca' },
+  addedAt: 1
+}
+
+const remoteRepo: Repo = {
+  id: 'remote-repo',
+  path: '/srv/orca',
+  displayName: 'orca',
+  badgeColor: REMOTE_NEUTRAL,
+  upstream: { owner: 'stablyai', repo: 'orca' },
+  addedAt: 1
+}
+
+const localProject: Project = {
+  id: SHARED_PROJECT_ID,
+  displayName: 'orca',
+  badgeColor: LOCAL_GREEN,
+  sourceRepoIds: ['local-repo'],
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const remoteProject: Project = {
+  id: SHARED_PROJECT_ID,
+  displayName: 'orca',
+  badgeColor: REMOTE_NEUTRAL,
+  sourceRepoIds: ['remote-repo'],
+  createdAt: 2,
+  updatedAt: 2
+}
+
+function setup(projectId: string, repoId: string, path: string): ProjectHostSetup {
+  return {
+    id: `${repoId}-setup`,
+    projectId,
+    hostId: 'local',
+    repoId,
+    path,
+    displayName: 'orca',
+    setupState: 'ready',
+    setupMethod: 'imported-existing-folder',
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+const reposList = vi.fn()
+const reposUpdate = vi.fn()
+const projectsList = vi.fn()
+const listHostSetups = vi.fn()
+const runtimeEnvironmentsList = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+function runtimeResult(method: string): unknown {
+  if (method === 'repo.list') {
+    return { repos: [remoteRepo] }
+  }
+  if (method === 'project.list') {
+    return { projects: [remoteProject] }
+  }
+  if (method === 'projectHostSetup.list') {
+    return { setups: [setup(SHARED_PROJECT_ID, 'remote-repo', '/srv/orca')] }
+  }
+  return {}
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  reposList.mockReset()
+  reposUpdate.mockReset()
+  projectsList.mockReset()
+  listHostSetups.mockReset()
+  runtimeEnvironmentsList.mockReset()
+  runtimeEnvironmentCall.mockReset()
+  runtimeEnvironmentTransportCall.mockReset()
+
+  reposList.mockResolvedValue([localRepo])
+  reposUpdate.mockImplementation(({ updates }: { updates: Partial<Repo> }) => ({
+    ...localRepo,
+    ...updates
+  }))
+  projectsList.mockResolvedValue([localProject])
+  listHostSetups.mockResolvedValue([setup(SHARED_PROJECT_ID, 'local-repo', '/local/orca')])
+  runtimeEnvironmentsList.mockResolvedValue([{ id: 'env-1', name: 'awin' }])
+  runtimeEnvironmentCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => ({
+    id: `rpc-${args.method}`,
+    ok: true,
+    result: runtimeResult(args.method),
+    _meta: { runtimeId: 'runtime-remote' }
+  }))
+  runtimeEnvironmentTransportCall.mockImplementation(
+    (args: RuntimeEnvironmentCallRequest) =>
+      createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  )
+
+  vi.stubGlobal('window', {
+    api: {
+      repos: { list: reposList, update: reposUpdate },
+      projects: { list: projectsList, listHostSetups },
+      projectGroups: { list: vi.fn().mockResolvedValue([]) },
+      folderWorkspaces: { list: vi.fn().mockResolvedValue([]) },
+      runtimeEnvironments: {
+        call: runtimeEnvironmentTransportCall,
+        list: runtimeEnvironmentsList
+      }
+    },
+    dispatchEvent: vi.fn()
+  })
+})
+
+function badgeColor(store: ReturnType<typeof createTestStore>): string | undefined {
+  return store.getState().projects.find((project) => project.id === SHARED_PROJECT_ID)?.badgeColor
+}
+
+describe('shared project badge color across hosts', () => {
+  it('keeps the local color when a remote host shares the project name', async () => {
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+
+    expect(badgeColor(store)).toBe(LOCAL_GREEN)
+  })
+
+  it('keeps the local color when a runtime-only refresh lands after startup', async () => {
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+    await store.getState().fetchRuntimeEnvironmentRepos('env-1')
+
+    expect(badgeColor(store)).toBe(LOCAL_GREEN)
+  })
+
+  it('reflects a recolor of the local repo even while the remote host stays connected', async () => {
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+    const recolored = '#ec4899'
+    await store.getState().updateRepo('local-repo', { badgeColor: recolored }, { hostId: 'local' })
+
+    expect(store.getState().repos.find((repo) => repo.id === 'local-repo')?.badgeColor).toBe(
+      recolored
+    )
+    expect(badgeColor(store)).toBe(recolored)
+  })
+
+  it('leaves a remote-only project showing its own host color', async () => {
+    reposList.mockResolvedValue([])
+    projectsList.mockResolvedValue([])
+    listHostSetups.mockResolvedValue([])
+    const store = createTestStore()
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+
+    await store.getState().fetchReposForAllHosts()
+
+    expect(badgeColor(store)).toBe(REMOTE_NEUTRAL)
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -638,6 +638,20 @@ function projectWithCurrentSourceRepoIds(
     : { ...project, sourceRepoIds }
 }
 
+function getLocalHostRepoBadgeColor(
+  project: Project,
+  reposById: ReadonlyMap<string, readonly Repo[]>
+): string | null {
+  for (const repoId of project.sourceRepoIds) {
+    for (const repo of reposById.get(repoId) ?? []) {
+      if (getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID) {
+        return repo.badgeColor
+      }
+    }
+  }
+  return null
+}
+
 function mergePreviousProjectMetadata(
   previous: Project,
   current: Project,
@@ -645,6 +659,12 @@ function mergePreviousProjectMetadata(
   hostId: string
 ): Project {
   const project = mergeProjectCompatibilityProject(previous, current)
+  const sourceRepoIds = getMergedSourceRepoIdsForHostRefresh(previous, current, reposById, hostId)
+  const localBadgeColor = getLocalHostRepoBadgeColor({ ...project, sourceRepoIds }, reposById)
+  if (localBadgeColor !== null) {
+    // Why: badge color is per-host repo metadata; a remote host sharing the project must not repaint the color the user chose locally.
+    project.badgeColor = localBadgeColor
+  }
   if (hostId === LOCAL_EXECUTION_HOST_ID) {
     // Why: localWindowsRuntimePreference belongs to the local host; a local refresh that omits it is authoritative and clears stale renderer state.
     if ('localWindowsRuntimePreference' in current) {
@@ -663,7 +683,7 @@ function mergePreviousProjectMetadata(
   return {
     ...project,
     // Why: fetched project metadata can lag repo.list; track ownership to the reconciled repos so removed-host repos don't linger.
-    sourceRepoIds: getMergedSourceRepoIdsForHostRefresh(previous, current, reposById, hostId)
+    sourceRepoIds
   }
 }
 


### PR DESCRIPTION
## The bug

In the Create-worktree composer, the **Project** badge rendered grey instead of the color chosen for the local project.

Local and remote repos that resolve to the same git identity (`github:stablyai/orca`) collapse into a **single** `Project` via `getProjectIdentityKey`. But `badgeColor` is **per-host repo metadata** — each host's repo row carries its own. `mergePreviousProjectMetadata` spread the fetched project over the previous one:

```ts
const project = mergeProjectCompatibilityProject(previous, current) // {...base, ...overlay}
```

so whichever host's rows landed last won the color. With a remote Orca server sharing a project name, the remote's default grey overwrote the color chosen locally.

This also explains why the mismatch was visible in one place and not another:

| Surface | Reads | Result |
|---|---|---|
| `WorktreeList.tsx:4179` | `row.repo?.badgeColor` (per-host **repo row**) | stayed correct |
| `ProjectCombobox.tsx` | `project.badgeColor` (merged **project**) | went grey |

## The fix

Anchor the merged color to the **local host's repo row** when the project has one, in `mergePreviousProjectMetadata` — which already had a local-wins precedent for `localWindowsRuntimePreference`.

Resolving from the local *repo row* rather than `previous.badgeColor` makes it **order-independent**: it holds no matter which host's fetch lands first. Remote-only projects are untouched and keep their own host color.

## Evidence

Both captures use a **byte-identical seeded profile** — local `orca` `#22c55e`, ssh-host `orca` `#737373`, persisted project color grey, remote row ordered first. Only the fix differs.

**Before** — badge `#737373`, sampled `RGB(115,115,115)`:

![before](https://raw.githubusercontent.com/stablyai/orca/evidence/create-worktree-badge-color/evidence/before-composer-grey.png)

**After** — badge `#22c55e`, sampled `RGB(34,197,94)`:

![after](https://raw.githubusercontent.com/stablyai/orca/evidence/create-worktree-badge-color/evidence/after-composer-green.png)

Side by side:

![before-after](https://raw.githubusercontent.com/stablyai/orca/evidence/create-worktree-badge-color/evidence/before-after-side-by-side.png)

This was also reproduced against a **real paired remote runtime** (a second Orca instance paired over the runtime WebSocket, not a mock): store showed `orca #22c55e host local` + `orca #737373 host runtime:d8614328`, one project with 2 source repos → resolved `#22c55e`.

## Tests

New `repos-shared-project-badge-color.test.ts` (4 cases, mirroring the real data shape):
- local color wins on all-host startup
- local color wins when a runtime-only refresh lands after startup
- a local recolor via `updateRepo` still propagates
- a remote-only project keeps its own host color

With the fix stashed, 2 of the 4 fail — they're bug-specific, not tautological.

`vitest` 21 passed across the touched suites (5073 across the full run), `oxlint` clean, `oxfmt --check` clean, `typecheck:web` clean.

## Notes

- No new `max-lines` entries; the new cases live in a dedicated file rather than growing `repos-all-hosts.test.ts` past the ratchet.
- Covers SSH hosts, runtime environments, and folder workspaces — the resolver keys off `getRepoExecutionHostId`, not a path or provider assumption.

Made with [Orca](https://github.com/stablyai/orca) 🐋
