### PR TITLE
perf(sidebar): share one worktree-keyed agent orchestration index

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.test.ts
@@ -403,15 +403,24 @@ describe('selectRuntimeAgentOrchestrationBatch', () => {
     )
 
     expect(Object.keys(actual)).toEqual(Object.keys(expected))
-    const operationBudget = {
+    // Why the batch still gets the tighter budget: it is told which worktrees
+    // are on screen, so it can skip unrelated tabs entirely. The per-worktree
+    // selector reads a shared index covering every worktree, so it visits all
+    // tabs once — the cost it saves is per *card*, not per worktree.
+    expect(batched.counts()).toEqual({
       runtimeEnumerations: 1,
       runtimeValueReads: contextCount,
       contextVisits: contextCount,
       targetTabIdReads: 1,
       unrelatedTabIdReads: 0
-    }
-    expect(reference.counts()).toEqual(operationBudget)
-    expect(batched.counts()).toEqual(operationBudget)
+    })
+    expect(reference.counts()).toEqual({
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount,
+      targetTabIdReads: 1,
+      unrelatedTabIdReads: tabCount - 1
+    })
   })
 
   it('collapses multi-worktree runtime scans and caches unchanged publications', () => {
@@ -478,10 +487,13 @@ describe('selectRuntimeAgentOrchestrationBatch', () => {
     }
     selectRuntimeAgentOrchestrationBatch(batched.state, requested)
 
+    // Why one enumeration for worktreeCount separate calls: the per-worktree
+    // selector reads a shared index, so the first caller builds it and the rest
+    // are Map lookups. Before that index, this cost scaled with mounted cards.
     expect(reference.counts()).toEqual({
-      runtimeEnumerations: worktreeCount,
-      runtimeValueReads: worktreeCount * contextCount,
-      contextVisits: worktreeCount * contextCount,
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount,
       tabIdReads: worktreeCount
     })
     expect(batched.counts()).toEqual({
@@ -518,5 +530,16 @@ describe('selectRuntimeAgentOrchestrationBatch', () => {
       contextVisits: contextCount * (publicationCount + 1),
       tabIdReads: worktreeCount
     })
+
+    // Why: the sidebar's real hot path is every mounted card re-running its own
+    // selector on every publication. Held flat, that is the whole point of the
+    // shared index — it must not scale with cards or with publications.
+    const referenceBefore = reference.counts()
+    for (let publication = 0; publication < publicationCount; publication += 1) {
+      for (const worktreeId of requested) {
+        selectRuntimeAgentOrchestrationForWorktree(reference.state, worktreeId)
+      }
+    }
+    expect(reference.counts()).toEqual(referenceBefore)
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.test.ts
@@ -403,10 +403,8 @@ describe('selectRuntimeAgentOrchestrationBatch', () => {
     )
 
     expect(Object.keys(actual)).toEqual(Object.keys(expected))
-    // Why the batch still gets the tighter budget: it is told which worktrees
-    // are on screen, so it can skip unrelated tabs entirely. The per-worktree
-    // selector reads a shared index covering every worktree, so it visits all
-    // tabs once — the cost it saves is per *card*, not per worktree.
+    // Why the batch stays tighter: it knows which worktrees are on screen. The
+    // shared index covers all of them, so it saves per *card*, not per worktree.
     expect(batched.counts()).toEqual({
       runtimeEnumerations: 1,
       runtimeValueReads: contextCount,
@@ -487,9 +485,8 @@ describe('selectRuntimeAgentOrchestrationBatch', () => {
     }
     selectRuntimeAgentOrchestrationBatch(batched.state, requested)
 
-    // Why one enumeration for worktreeCount separate calls: the per-worktree
-    // selector reads a shared index, so the first caller builds it and the rest
-    // are Map lookups. Before that index, this cost scaled with mounted cards.
+    // One enumeration for worktreeCount calls: the first builds the shared
+    // index, the rest are Map lookups. This used to scale with mounted cards.
     expect(reference.counts()).toEqual({
       runtimeEnumerations: 1,
       runtimeValueReads: contextCount,
@@ -531,9 +528,8 @@ describe('selectRuntimeAgentOrchestrationBatch', () => {
       tabIdReads: worktreeCount
     })
 
-    // Why: the sidebar's real hot path is every mounted card re-running its own
-    // selector on every publication. Held flat, that is the whole point of the
-    // shared index — it must not scale with cards or with publications.
+    // Publications that change nothing the index reads cost nothing, however
+    // many cards call in.
     const referenceBefore = reference.counts()
     for (let publication = 0; publication < publicationCount; publication += 1) {
       for (const worktreeId of requested) {
@@ -541,5 +537,32 @@ describe('selectRuntimeAgentOrchestrationBatch', () => {
       }
     }
     expect(reference.counts()).toEqual(referenceBefore)
+
+    // Why this is the honest claim: a real live-status ping replaces
+    // agentStatusByPaneKey, so the index does rebuild once per publication. What
+    // the shared index removes is the mounted-card multiplier, not the
+    // per-publication rebuild. Tab reads stay flat because tab membership is
+    // keyed on the tabs slice, which a live-status ping does not replace.
+    const churn = makeCountedState()
+    for (const worktreeId of requested) {
+      selectRuntimeAgentOrchestrationForWorktree(churn.state, worktreeId)
+    }
+    for (let publication = 0; publication < publicationCount; publication += 1) {
+      const published = {
+        ...churn.state,
+        agentStatusByPaneKey: {
+          [`unrelated-${publication}`]: makeEntry(`unrelated-${publication}`, 'elsewhere')
+        }
+      }
+      for (const worktreeId of requested) {
+        selectRuntimeAgentOrchestrationForWorktree(published, worktreeId)
+      }
+    }
+    expect(churn.counts()).toEqual({
+      runtimeEnumerations: 1,
+      runtimeValueReads: contextCount,
+      contextVisits: contextCount * (publicationCount + 1),
+      tabIdReads: worktreeCount
+    })
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-batch.ts
@@ -40,7 +40,13 @@ const EMPTY_AGENT_STATUS: RuntimeOrchestrationState['agentStatusByPaneKey'] = {}
 const EMPTY_RETAINED_AGENTS: RuntimeOrchestrationState['retainedAgentsByPaneKey'] = {}
 const EMPTY_BATCH: ReadonlyMap<string, RuntimeOrchestrationRecord> = new Map()
 
-export const EMPTY_WORKTREE_AGENT_ORCHESTRATION: RuntimeOrchestrationRecord = {}
+export const EMPTY_WORKTREE_AGENT_ORCHESTRATION: RuntimeOrchestrationRecord = Object.freeze({})
+
+// Why null-prototype: a pane key of `__proto__` is a plain data key here; on a
+// normal object the write vanishes into the prototype setter and repoints it.
+function createRecord(): RuntimeOrchestrationRecord {
+  return Object.create(null) as RuntimeOrchestrationRecord
+}
 
 let runtimeDomainCache: RuntimeDomainCache | null = null
 let requestedTabMembershipCache: RequestedTabMembershipCache | null = null
@@ -181,12 +187,12 @@ function buildRuntimeBatch(
     }
 
     for (const worktreeId of targets) {
-      const existing = recordsByWorktree.get(worktreeId)
-      if (existing) {
-        existing[paneKey] = orchestration
-      } else {
-        recordsByWorktree.set(worktreeId, { [paneKey]: orchestration })
+      let record = recordsByWorktree.get(worktreeId)
+      if (!record) {
+        record = createRecord()
+        recordsByWorktree.set(worktreeId, record)
       }
+      record[paneKey] = orchestration
     }
   }
 

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.test.ts
@@ -16,10 +16,24 @@ type IndexState = Parameters<typeof selectWorktreeAgentOrchestration>[0]
 
 const EMPTY_RECORD = {}
 
+// Pane keys that reach this selector unvalidated. `__proto__` is the one whose
+// meaning depends on how the output record is built.
+const MALFORMED_RUNTIME_KEYS = ['__proto__', 'constructor', 'toString', 'no-colon', 'a:b:c']
+
+// Why not plain assignment: writing `__proto__` onto an object literal hits the
+// prototype setter, so the fixture itself would lose the key under test.
+function defineKey<T>(map: Record<string, T>, key: string, value: T): void {
+  Object.defineProperty(map, key, { value, enumerable: true, writable: true, configurable: true })
+}
+
 /**
  * The pre-index per-card selector, transcribed from the revision this index
  * replaced. Kept as the oracle so equivalence is asserted against real prior
  * behavior rather than against a restatement of the new implementation.
+ *
+ * One deliberate correction: the original accumulated into `{}`, so a pane key
+ * of `__proto__` hit the prototype setter and vanished. This builds a
+ * null-prototype record so the oracle expresses intended attribution.
  */
 function legacySelectForWorktree(
   state: IndexState,
@@ -27,7 +41,7 @@ function legacySelectForWorktree(
 ): Record<string, AgentStatusOrchestrationContext> {
   const tabs = (state.tabsByWorktree ?? EMPTY_RECORD)[worktreeId] ?? []
   const tabIds = new Set(tabs.map((tab) => tab.id))
-  const out: Record<string, AgentStatusOrchestrationContext> = {}
+  const out: Record<string, AgentStatusOrchestrationContext> = Object.create(null)
   const runtimeAgentOrchestrationByPaneKey =
     state.runtimeAgentOrchestrationByPaneKey ?? EMPTY_RECORD
   const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_RECORD
@@ -129,7 +143,14 @@ describe('selectWorktreeAgentOrchestration', () => {
       for (let index = 0; index < contextCount; index += 1) {
         const ownerTabId =
           random() < 0.7 && tabIds.length > 0 ? tabIds[pick(tabIds.length)] : 'tab-orphan'
-        const paneKey = paneKeyFor(ownerTabId, index)
+        // Why malformed runtime keys: a pane key that is not `tab:uuid` reaches
+        // this selector unvalidated, and `__proto__` is the one that changes
+        // meaning depending on how the output record is built.
+        const keyRoll = random()
+        const paneKey =
+          keyRoll < 0.08
+            ? MALFORMED_RUNTIME_KEYS[pick(MALFORMED_RUNTIME_KEYS.length)]
+            : paneKeyFor(ownerTabId, index)
         const parentRoll = random()
         const parentPaneKey =
           parentRoll < 0.3 && tabIds.length > 0
@@ -137,16 +158,24 @@ describe('selectWorktreeAgentOrchestration', () => {
             : parentRoll < 0.4
               ? 'malformed:parent:key'
               : undefined
-        runtimeAgentOrchestrationByPaneKey[paneKey] = {
+        defineKey(runtimeAgentOrchestrationByPaneKey, paneKey, {
           taskId: `task-${index}`,
           dispatchId: `dispatch-${index}`,
           ...(parentPaneKey === undefined ? {} : { parentPaneKey })
-        }
+        })
         if (random() < 0.35) {
-          agentStatusByPaneKey[paneKey] = makeEntry(paneKey, `wt-${pick(worktreeCount + 1)}`)
+          defineKey(
+            agentStatusByPaneKey,
+            paneKey,
+            makeEntry(paneKey, `wt-${pick(worktreeCount + 1)}`)
+          )
         }
         if (random() < 0.25) {
-          retainedAgentsByPaneKey[paneKey] = makeRetained(paneKey, `wt-${pick(worktreeCount + 1)}`)
+          defineKey(
+            retainedAgentsByPaneKey,
+            paneKey,
+            makeRetained(paneKey, `wt-${pick(worktreeCount + 1)}`)
+          )
         }
       }
 
@@ -322,6 +351,51 @@ describe('selectWorktreeAgentOrchestration', () => {
         )
       }
     }
+  })
+
+  it('treats a __proto__ pane key as data instead of a prototype write', () => {
+    // Why: writing this key into a normal object silently drops the entry and
+    // repoints the record's prototype at the orchestration context.
+    const context = { taskId: 't', dispatchId: 'd' }
+    const state = {
+      tabsByWorktree: {},
+      runtimeAgentOrchestrationByPaneKey: Object.fromEntries([['__proto__', context]]),
+      agentStatusByPaneKey: Object.fromEntries([['__proto__', makeEntry('__proto__', 'wt-1')]]),
+      retainedAgentsByPaneKey: {}
+    } as unknown as IndexState
+
+    const record = selectWorktreeAgentOrchestration(state, 'wt-1')
+    expect(Object.keys(record)).toEqual(['__proto__'])
+    expect(record['__proto__']).toBe(context)
+    expect(Object.getPrototypeOf(record)).toBeNull()
+  })
+
+  it('keeps the entries cache warm while the orchestration map is empty', () => {
+    // Why: the empty map is the common case, so re-enumerating it per card is
+    // exactly the per-publication cost this index exists to remove.
+    let enumerations = 0
+    const runtimeAgentOrchestrationByPaneKey = new Proxy(
+      {},
+      {
+        ownKeys(target) {
+          enumerations += 1
+          return Reflect.ownKeys(target)
+        }
+      }
+    )
+    const state = {
+      tabsByWorktree: {},
+      runtimeAgentOrchestrationByPaneKey,
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as unknown as IndexState
+
+    for (const worktreeId of ['wt-a', 'wt-b', 'wt-c']) {
+      expect(selectWorktreeAgentOrchestration(state, worktreeId)).toBe(
+        EMPTY_WORKTREE_AGENT_ORCHESTRATION
+      )
+    }
+    expect(enumerations).toBe(1)
   })
 
   it('never mutates a record already handed to a subscriber', () => {

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.test.ts
@@ -68,7 +68,10 @@ function legacySelectForWorktree(
 // Why a seeded PRNG: a randomized differential must reproduce exactly when it
 // reports a divergence.
 function createRandom(seed: number): () => number {
-  let state = seed >>> 0 || 1
+  // Why the multiply: xorshift32 needs a high-entropy state. Seeding it with a
+  // small integer keeps the first output under 0.019, so `1 + pick(5)` was 1 for
+  // every seed here and the suite only ever built single-worktree stores.
+  let state = Math.imul(seed >>> 0 || 1, 0x9e37_79b1) >>> 0 || 1
   return () => {
     state ^= state << 13
     state >>>= 0
@@ -127,8 +130,8 @@ describe('selectWorktreeAgentOrchestration', () => {
         const tabCount = pick(3)
         const tabs: TerminalTab[] = []
         for (let tabIndex = 0; tabIndex < tabCount; tabIndex += 1) {
-          // Why a small shared id space: tab ids must sometimes collide across
-          // worktrees, which is the multi-attribution path.
+          // Why a small shared id space: tab ids collide across worktrees on
+          // 131 of these 300 seeds, which is the multi-attribution path.
           const tabId = `tab-${pick(4)}`
           tabs.push(makeTab(tabId))
           tabIds.push(tabId)

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.test.ts
@@ -1,0 +1,353 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import type {
+  AgentStatusEntry,
+  AgentStatusOrchestrationContext
+} from '../../../../shared/agent-status-types'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type { TerminalTab } from '../../../../shared/types'
+import { makePaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  EMPTY_WORKTREE_AGENT_ORCHESTRATION,
+  releaseWorktreeAgentOrchestrationIndexCache,
+  selectWorktreeAgentOrchestration
+} from './worktree-agent-orchestration-index'
+
+type IndexState = Parameters<typeof selectWorktreeAgentOrchestration>[0]
+
+const EMPTY_RECORD = {}
+
+/**
+ * The pre-index per-card selector, transcribed from the revision this index
+ * replaced. Kept as the oracle so equivalence is asserted against real prior
+ * behavior rather than against a restatement of the new implementation.
+ */
+function legacySelectForWorktree(
+  state: IndexState,
+  worktreeId: string
+): Record<string, AgentStatusOrchestrationContext> {
+  const tabs = (state.tabsByWorktree ?? EMPTY_RECORD)[worktreeId] ?? []
+  const tabIds = new Set(tabs.map((tab) => tab.id))
+  const out: Record<string, AgentStatusOrchestrationContext> = {}
+  const runtimeAgentOrchestrationByPaneKey =
+    state.runtimeAgentOrchestrationByPaneKey ?? EMPTY_RECORD
+  const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_RECORD
+  const retainedAgentsByPaneKey = state.retainedAgentsByPaneKey ?? EMPTY_RECORD
+  for (const [paneKey, orchestration] of Object.entries(runtimeAgentOrchestrationByPaneKey)) {
+    const parsed = parsePaneKey(paneKey)
+    const parsedParent = orchestration.parentPaneKey
+      ? parsePaneKey(orchestration.parentPaneKey)
+      : null
+    const liveEntry = agentStatusByPaneKey[paneKey]
+    const retainedEntry = retainedAgentsByPaneKey[paneKey]
+    if (
+      (parsed && tabIds.has(parsed.tabId)) ||
+      (parsedParent && tabIds.has(parsedParent.tabId)) ||
+      liveEntry?.worktreeId === worktreeId ||
+      retainedEntry?.worktreeId === worktreeId
+    ) {
+      out[paneKey] = orchestration
+    }
+  }
+  return out
+}
+
+// Why a seeded PRNG: a randomized differential must reproduce exactly when it
+// reports a divergence.
+function createRandom(seed: number): () => number {
+  let state = seed >>> 0 || 1
+  return () => {
+    state ^= state << 13
+    state >>>= 0
+    state ^= state >> 17
+    state ^= state << 5
+    state >>>= 0
+    return state / 0x1_00_00_00_00
+  }
+}
+
+function makeTab(id: string): TerminalTab {
+  return {
+    id,
+    worktreeId: 'unused',
+    ptyId: null,
+    title: 'Claude',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function paneKeyFor(tabId: string, index: number): string {
+  return makePaneKey(tabId, `88888888-8888-4888-8888-${index.toString(16).padStart(12, '0')}`)
+}
+
+function makeEntry(paneKey: string, worktreeId: string): AgentStatusEntry {
+  return { paneKey, worktreeId, state: 'busy', startedAt: 0 } as unknown as AgentStatusEntry
+}
+
+function makeRetained(paneKey: string, worktreeId: string): RetainedAgentEntry {
+  return {
+    worktreeId,
+    entry: makeEntry(paneKey, worktreeId),
+    retainedAt: 0
+  } as unknown as RetainedAgentEntry
+}
+
+describe('selectWorktreeAgentOrchestration', () => {
+  beforeEach(() => {
+    releaseWorktreeAgentOrchestrationIndexCache()
+  })
+
+  it('matches the pre-index per-card selector across randomized stores', () => {
+    for (let seed = 1; seed <= 300; seed += 1) {
+      releaseWorktreeAgentOrchestrationIndexCache()
+      const random = createRandom(seed)
+      const pick = (limit: number): number => Math.floor(random() * limit)
+
+      const worktreeCount = 1 + pick(5)
+      const worktreeIds = Array.from({ length: worktreeCount }, (_, index) => `wt-${index}`)
+      const tabsByWorktree: Record<string, TerminalTab[]> = {}
+      const tabIds: string[] = []
+      for (const worktreeId of worktreeIds) {
+        const tabCount = pick(3)
+        const tabs: TerminalTab[] = []
+        for (let tabIndex = 0; tabIndex < tabCount; tabIndex += 1) {
+          // Why a small shared id space: tab ids must sometimes collide across
+          // worktrees, which is the multi-attribution path.
+          const tabId = `tab-${pick(4)}`
+          tabs.push(makeTab(tabId))
+          tabIds.push(tabId)
+        }
+        tabsByWorktree[worktreeId] = tabs
+      }
+
+      const runtimeAgentOrchestrationByPaneKey: Record<string, AgentStatusOrchestrationContext> = {}
+      const agentStatusByPaneKey: Record<string, AgentStatusEntry> = {}
+      const retainedAgentsByPaneKey: Record<string, RetainedAgentEntry> = {}
+      const contextCount = pick(8)
+      for (let index = 0; index < contextCount; index += 1) {
+        const ownerTabId =
+          random() < 0.7 && tabIds.length > 0 ? tabIds[pick(tabIds.length)] : 'tab-orphan'
+        const paneKey = paneKeyFor(ownerTabId, index)
+        const parentRoll = random()
+        const parentPaneKey =
+          parentRoll < 0.3 && tabIds.length > 0
+            ? paneKeyFor(tabIds[pick(tabIds.length)], 900 + index)
+            : parentRoll < 0.4
+              ? 'malformed:parent:key'
+              : undefined
+        runtimeAgentOrchestrationByPaneKey[paneKey] = {
+          taskId: `task-${index}`,
+          dispatchId: `dispatch-${index}`,
+          ...(parentPaneKey === undefined ? {} : { parentPaneKey })
+        }
+        if (random() < 0.35) {
+          agentStatusByPaneKey[paneKey] = makeEntry(paneKey, `wt-${pick(worktreeCount + 1)}`)
+        }
+        if (random() < 0.25) {
+          retainedAgentsByPaneKey[paneKey] = makeRetained(paneKey, `wt-${pick(worktreeCount + 1)}`)
+        }
+      }
+
+      const state = {
+        tabsByWorktree,
+        runtimeAgentOrchestrationByPaneKey,
+        agentStatusByPaneKey,
+        retainedAgentsByPaneKey
+      } as unknown as IndexState
+
+      // Why the extra id: worktrees with no tabs are still reachable through a
+      // live or retained attribution, and must resolve identically.
+      for (const worktreeId of [...worktreeIds, `wt-${worktreeCount}`, 'missing']) {
+        const expected = legacySelectForWorktree(state, worktreeId)
+        const actual = selectWorktreeAgentOrchestration(state, worktreeId)
+        expect(Object.keys(actual), `seed ${seed} / ${worktreeId}`).toEqual(Object.keys(expected))
+        for (const paneKey of Object.keys(expected)) {
+          expect(actual[paneKey], `seed ${seed} / ${worktreeId} / ${paneKey}`).toBe(
+            expected[paneKey]
+          )
+        }
+      }
+    }
+  })
+
+  it('returns one shared empty record for worktrees with no orchestration', () => {
+    const state = {
+      tabsByWorktree: { 'wt-1': [makeTab('tab-1')] },
+      runtimeAgentOrchestrationByPaneKey: {
+        [paneKeyFor('tab-1', 0)]: { taskId: 't', dispatchId: 'd' }
+      },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as unknown as IndexState
+
+    expect(selectWorktreeAgentOrchestration(state, 'wt-2')).toBe(EMPTY_WORKTREE_AGENT_ORCHESTRATION)
+    expect(selectWorktreeAgentOrchestration(state, 'wt-2')).toBe(
+      selectWorktreeAgentOrchestration(state, 'wt-3')
+    )
+  })
+
+  it('keeps record identity stable across publications that change nothing it reads', () => {
+    const context = { taskId: 't', dispatchId: 'd' }
+    const base = {
+      tabsByWorktree: { 'wt-1': [makeTab('tab-1')] },
+      runtimeAgentOrchestrationByPaneKey: { [paneKeyFor('tab-1', 0)]: context },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as unknown as IndexState
+
+    const first = selectWorktreeAgentOrchestration(base, 'wt-1')
+    expect(selectWorktreeAgentOrchestration({ ...base } as IndexState, 'wt-1')).toBe(first)
+
+    // Why: a live-status ping for an unrelated pane is the highest-frequency
+    // publication in this store, and must not hand cards a new object.
+    const liveChurn = {
+      ...base,
+      agentStatusByPaneKey: { unrelated: makeEntry('unrelated', 'wt-9') }
+    } as unknown as IndexState
+    expect(selectWorktreeAgentOrchestration(liveChurn, 'wt-1')).toBe(first)
+
+    const retainedChurn = {
+      ...liveChurn,
+      retainedAgentsByPaneKey: { unrelated: makeRetained('unrelated', 'wt-9') }
+    } as unknown as IndexState
+    expect(selectWorktreeAgentOrchestration(retainedChurn, 'wt-1')).toBe(first)
+  })
+
+  it('rebuilds when a source it reads actually changes', () => {
+    const context = { taskId: 't', dispatchId: 'd' }
+    const paneKey = paneKeyFor('tab-1', 0)
+    const base = {
+      tabsByWorktree: { 'wt-1': [makeTab('tab-1')] },
+      runtimeAgentOrchestrationByPaneKey: { [paneKey]: context },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as unknown as IndexState
+    selectWorktreeAgentOrchestration(base, 'wt-1')
+
+    const replacement = { taskId: 't2', dispatchId: 'd2' }
+    const replaced = {
+      ...base,
+      runtimeAgentOrchestrationByPaneKey: { [paneKey]: replacement }
+    } as unknown as IndexState
+    expect(selectWorktreeAgentOrchestration(replaced, 'wt-1')[paneKey]).toBe(replacement)
+
+    // Why: moving the tab to another worktree must re-attribute, which only
+    // happens if tab membership is keyed on the tabs slice identity.
+    const movedTab = {
+      ...replaced,
+      tabsByWorktree: { 'wt-2': [makeTab('tab-1')] }
+    } as unknown as IndexState
+    expect(selectWorktreeAgentOrchestration(movedTab, 'wt-1')).toBe(
+      EMPTY_WORKTREE_AGENT_ORCHESTRATION
+    )
+    expect(selectWorktreeAgentOrchestration(movedTab, 'wt-2')[paneKey]).toBe(replacement)
+  })
+
+  it('treats a missing or emptied orchestration map as empty without reading other slices', () => {
+    let forbiddenReads = 0
+    const coldState = {
+      runtimeAgentOrchestrationByPaneKey: {},
+      get tabsByWorktree() {
+        forbiddenReads += 1
+        return {}
+      },
+      get agentStatusByPaneKey() {
+        forbiddenReads += 1
+        return {}
+      },
+      get retainedAgentsByPaneKey() {
+        forbiddenReads += 1
+        return {}
+      }
+    } as unknown as IndexState
+
+    expect(selectWorktreeAgentOrchestration(coldState, 'wt-1')).toBe(
+      EMPTY_WORKTREE_AGENT_ORCHESTRATION
+    )
+    expect(selectWorktreeAgentOrchestration({} as IndexState, 'wt-1')).toBe(
+      EMPTY_WORKTREE_AGENT_ORCHESTRATION
+    )
+    expect(forbiddenReads).toBe(0)
+  })
+
+  it('does not attribute unowned panes to a nullish worktree id', () => {
+    const paneKey = paneKeyFor('tab-orphan', 0)
+    const state = {
+      tabsByWorktree: {},
+      runtimeAgentOrchestrationByPaneKey: { [paneKey]: { taskId: 't', dispatchId: 'd' } },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as unknown as IndexState
+
+    // Why asserted despite `worktreeId: string`: the pre-index selector tested
+    // `entry?.worktreeId === worktreeId`, so a nullish id matched every pane
+    // that had no live/retained entry. This is the one intentional divergence
+    // from the oracle — the old result was wrong, not merely different.
+    expect(selectWorktreeAgentOrchestration(state, undefined as unknown as string)).toBe(
+      EMPTY_WORKTREE_AGENT_ORCHESTRATION
+    )
+    expect(legacySelectForWorktree(state, undefined as unknown as string)).toHaveProperty(paneKey)
+  })
+
+  it('stays correct when two stores interleave through the single cache slot', () => {
+    // Why: the cache is one module-level slot, but the sidebar cards and the
+    // dashboard snapshot can call in with different state objects. Thrashing may
+    // cost a rebuild; it must never return another store's answer.
+    const buildState = (suffix: string): IndexState =>
+      ({
+        tabsByWorktree: { [`wt-${suffix}`]: [makeTab(`tab-${suffix}`)] },
+        runtimeAgentOrchestrationByPaneKey: {
+          [paneKeyFor(`tab-${suffix}`, 0)]: { taskId: `t-${suffix}`, dispatchId: `d-${suffix}` }
+        },
+        agentStatusByPaneKey: {},
+        retainedAgentsByPaneKey: {}
+      }) as unknown as IndexState
+
+    const stateA = buildState('a')
+    const stateB = buildState('b')
+    for (let round = 0; round < 4; round += 1) {
+      for (const [state, suffix] of [
+        [stateA, 'a'],
+        [stateB, 'b']
+      ] as const) {
+        expect(Object.keys(selectWorktreeAgentOrchestration(state, `wt-${suffix}`))).toEqual(
+          Object.keys(legacySelectForWorktree(state, `wt-${suffix}`))
+        )
+        // The other store's worktree must never leak through the shared slot.
+        const foreign = suffix === 'a' ? 'wt-b' : 'wt-a'
+        expect(selectWorktreeAgentOrchestration(state, foreign)).toBe(
+          EMPTY_WORKTREE_AGENT_ORCHESTRATION
+        )
+      }
+    }
+  })
+
+  it('never mutates a record already handed to a subscriber', () => {
+    // Why: buildIndex fills record objects in place and can hand back a previous
+    // build's record. A mounted card holds that object across renders, so a later
+    // build writing into it would break React's snapshot contract silently.
+    const paneKey = paneKeyFor('tab-1', 0)
+    const base = {
+      tabsByWorktree: { 'wt-1': [makeTab('tab-1')] },
+      runtimeAgentOrchestrationByPaneKey: { [paneKey]: { taskId: 't', dispatchId: 'd' } },
+      agentStatusByPaneKey: {},
+      retainedAgentsByPaneKey: {}
+    } as unknown as IndexState
+
+    const held = selectWorktreeAgentOrchestration(base, 'wt-1')
+    const heldKeys = Object.keys(held)
+
+    const secondPaneKey = paneKeyFor('tab-1', 1)
+    const grown = {
+      ...base,
+      runtimeAgentOrchestrationByPaneKey: {
+        ...base.runtimeAgentOrchestrationByPaneKey,
+        [secondPaneKey]: { taskId: 't2', dispatchId: 'd2' }
+      }
+    } as unknown as IndexState
+    expect(Object.keys(selectWorktreeAgentOrchestration(grown, 'wt-1'))).toHaveLength(2)
+    expect(Object.keys(held)).toEqual(heldKeys)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.ts
@@ -34,11 +34,20 @@ type OrchestrationIndexCache = {
 // like an empty slice while keeping a stable identity for the source cache.
 const EMPTY_SOURCE = {}
 
-export const EMPTY_WORKTREE_AGENT_ORCHESTRATION: RuntimeOrchestrationRecord = {}
+// Why frozen: these are shared by every card, so an accidental write would
+// corrupt unrelated worktrees rather than fail locally.
+export const EMPTY_WORKTREE_AGENT_ORCHESTRATION: RuntimeOrchestrationRecord = Object.freeze({})
 export const EMPTY_WORKTREE_AGENT_ORCHESTRATION_INDEX: ReadonlyMap<
   string,
   RuntimeOrchestrationRecord
 > = new Map()
+
+// Why null-prototype: a pane key of `__proto__` is a plain data key here. On a
+// normal object the first write silently vanishes into the prototype setter,
+// which both drops the entry and repoints the record's prototype.
+function createRecord(): RuntimeOrchestrationRecord {
+  return Object.create(null) as RuntimeOrchestrationRecord
+}
 
 let runtimeEntriesCache: RuntimeEntriesCache | null = null
 let tabMembershipCache: TabMembershipCache | null = null
@@ -137,12 +146,12 @@ function buildIndex(
     }
 
     for (const worktreeId of targets) {
-      const existing = recordsByWorktree.get(worktreeId)
-      if (existing) {
-        existing[paneKey] = orchestration
-      } else {
-        recordsByWorktree.set(worktreeId, { [paneKey]: orchestration })
+      let record = recordsByWorktree.get(worktreeId)
+      if (!record) {
+        record = createRecord()
+        recordsByWorktree.set(worktreeId, record)
       }
+      record[paneKey] = orchestration
     }
   }
 
@@ -184,7 +193,10 @@ export function selectWorktreeAgentOrchestrationIndex(
   // Why here rather than before the enumeration: with no contexts the index is
   // empty whatever the other slices hold, and callers rely on them staying unread.
   if (runtimeEntries.length === 0) {
-    releaseWorktreeAgentOrchestrationIndexCache()
+    // Why the entries cache survives: dropping it would re-enumerate the empty
+    // map once per card, which is the per-publication cost this index removes.
+    tabMembershipCache = null
+    orchestrationIndexCache = null
     return EMPTY_WORKTREE_AGENT_ORCHESTRATION_INDEX
   }
 

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.ts
@@ -1,0 +1,226 @@
+import type { AppState } from '@/store/types'
+import type { AgentStatusOrchestrationContext } from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+
+type OrchestrationIndexState = Pick<
+  AppState,
+  | 'agentStatusByPaneKey'
+  | 'retainedAgentsByPaneKey'
+  | 'runtimeAgentOrchestrationByPaneKey'
+  | 'tabsByWorktree'
+>
+
+type RuntimeOrchestrationRecord = Record<string, AgentStatusOrchestrationContext>
+
+type RuntimeEntriesCache = {
+  source: OrchestrationIndexState['runtimeAgentOrchestrationByPaneKey']
+  entries: [string, AgentStatusOrchestrationContext][]
+}
+
+type TabMembershipCache = {
+  tabsSource: OrchestrationIndexState['tabsByWorktree']
+  worktreeIdsByTabId: Map<string, Set<string>>
+}
+
+type OrchestrationIndexCache = {
+  runtimeSource: OrchestrationIndexState['runtimeAgentOrchestrationByPaneKey']
+  tabsSource: OrchestrationIndexState['tabsByWorktree']
+  liveSource: OrchestrationIndexState['agentStatusByPaneKey']
+  retainedSource: OrchestrationIndexState['retainedAgentsByPaneKey']
+  recordsByWorktree: ReadonlyMap<string, RuntimeOrchestrationRecord>
+}
+
+// Why: selector unit tests pass partial store mocks; a missing map must behave
+// like an empty slice while keeping a stable identity for the source cache.
+const EMPTY_SOURCE = {}
+
+export const EMPTY_WORKTREE_AGENT_ORCHESTRATION: RuntimeOrchestrationRecord = {}
+export const EMPTY_WORKTREE_AGENT_ORCHESTRATION_INDEX: ReadonlyMap<
+  string,
+  RuntimeOrchestrationRecord
+> = new Map()
+
+let runtimeEntriesCache: RuntimeEntriesCache | null = null
+let tabMembershipCache: TabMembershipCache | null = null
+let orchestrationIndexCache: OrchestrationIndexCache | null = null
+
+export function releaseWorktreeAgentOrchestrationIndexCache(): void {
+  runtimeEntriesCache = null
+  tabMembershipCache = null
+  orchestrationIndexCache = null
+}
+
+function reuseRecordIfOrderedEqual(
+  previous: RuntimeOrchestrationRecord | undefined,
+  next: RuntimeOrchestrationRecord
+): RuntimeOrchestrationRecord {
+  if (!previous) {
+    return next
+  }
+  const previousEntries = Object.entries(previous)
+  const nextEntries = Object.entries(next)
+  if (previousEntries.length !== nextEntries.length) {
+    return next
+  }
+  for (let index = 0; index < nextEntries.length; index += 1) {
+    if (
+      previousEntries[index]?.[0] !== nextEntries[index]?.[0] ||
+      previousEntries[index]?.[1] !== nextEntries[index]?.[1]
+    ) {
+      return next
+    }
+  }
+  return previous
+}
+
+function getWorktreeIdsByTabId(
+  tabsByWorktree: OrchestrationIndexState['tabsByWorktree']
+): Map<string, Set<string>> {
+  if (tabMembershipCache?.tabsSource === tabsByWorktree) {
+    return tabMembershipCache.worktreeIdsByTabId
+  }
+  // Why a Set per tab: the same tab id can appear under more than one worktree,
+  // and each of those worktrees must still see the pane's orchestration.
+  const worktreeIdsByTabId = new Map<string, Set<string>>()
+  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
+    for (const tab of tabs ?? []) {
+      const tabId = tab.id
+      const existing = worktreeIdsByTabId.get(tabId)
+      if (existing) {
+        existing.add(worktreeId)
+      } else {
+        worktreeIdsByTabId.set(tabId, new Set([worktreeId]))
+      }
+    }
+  }
+  tabMembershipCache = { tabsSource: tabsByWorktree, worktreeIdsByTabId }
+  return worktreeIdsByTabId
+}
+
+function buildIndex(
+  runtimeEntries: [string, AgentStatusOrchestrationContext][],
+  tabsByWorktree: OrchestrationIndexState['tabsByWorktree'],
+  agentStatusByPaneKey: OrchestrationIndexState['agentStatusByPaneKey'],
+  retainedAgentsByPaneKey: OrchestrationIndexState['retainedAgentsByPaneKey']
+): ReadonlyMap<string, RuntimeOrchestrationRecord> {
+  const worktreeIdsByTabId = getWorktreeIdsByTabId(tabsByWorktree)
+  const recordsByWorktree = new Map<string, RuntimeOrchestrationRecord>()
+
+  for (const [paneKey, orchestration] of runtimeEntries) {
+    const parsed = parsePaneKey(paneKey)
+    const parsedParent = orchestration.parentPaneKey
+      ? parsePaneKey(orchestration.parentPaneKey)
+      : null
+    const targets = new Set<string>()
+    if (parsed) {
+      for (const worktreeId of worktreeIdsByTabId.get(parsed.tabId) ?? []) {
+        targets.add(worktreeId)
+      }
+    }
+    // Why: child agent terminals can be attributed to a worktree before their
+    // tab reaches this renderer, or after the row has been retained as done.
+    // The parent link must still reach that worktree card.
+    if (parsedParent) {
+      for (const worktreeId of worktreeIdsByTabId.get(parsedParent.tabId) ?? []) {
+        targets.add(worktreeId)
+      }
+    }
+    // Why exact runtime keys: this preserves early SSH attribution and ignores
+    // stale entry.paneKey fields carried by a live or retained row.
+    const liveWorktreeId = agentStatusByPaneKey[paneKey]?.worktreeId
+    if (typeof liveWorktreeId === 'string') {
+      targets.add(liveWorktreeId)
+    }
+    const retainedWorktreeId = retainedAgentsByPaneKey[paneKey]?.worktreeId
+    if (typeof retainedWorktreeId === 'string') {
+      targets.add(retainedWorktreeId)
+    }
+
+    for (const worktreeId of targets) {
+      const existing = recordsByWorktree.get(worktreeId)
+      if (existing) {
+        existing[paneKey] = orchestration
+      } else {
+        recordsByWorktree.set(worktreeId, { [paneKey]: orchestration })
+      }
+    }
+  }
+
+  const previousRecords = orchestrationIndexCache?.recordsByWorktree
+  for (const [worktreeId, record] of recordsByWorktree) {
+    recordsByWorktree.set(
+      worktreeId,
+      reuseRecordIfOrderedEqual(previousRecords?.get(worktreeId), record)
+    )
+  }
+  return recordsByWorktree
+}
+
+/**
+ * Worktree-keyed index of runtime agent orchestration contexts, rebuilt only
+ * when one of its four source maps changes identity.
+ *
+ * Why: every mounted worktree card subscribes to its own orchestration slice,
+ * and Zustand re-runs every subscriber's selector on every store publication.
+ * Scanning the whole context map per card made that O(cards x contexts) on
+ * traffic that never touched orchestration. The first caller through a given
+ * store version pays O(tabs + contexts); the rest are a Map lookup.
+ */
+export function selectWorktreeAgentOrchestrationIndex(
+  state: OrchestrationIndexState
+): ReadonlyMap<string, RuntimeOrchestrationRecord> {
+  const runtimeAgentOrchestrationByPaneKey =
+    state.runtimeAgentOrchestrationByPaneKey ?? EMPTY_SOURCE
+  // Why cached separately from the index: enumerating the context map is the
+  // per-publication cost this index exists to remove, and the entry list stays
+  // valid even when a churning live/retained slice forces an index rebuild.
+  if (runtimeEntriesCache?.source !== runtimeAgentOrchestrationByPaneKey) {
+    runtimeEntriesCache = {
+      source: runtimeAgentOrchestrationByPaneKey,
+      entries: Object.entries(runtimeAgentOrchestrationByPaneKey)
+    }
+  }
+  const runtimeEntries = runtimeEntriesCache.entries
+  // Why here rather than before the enumeration: with no contexts the index is
+  // empty whatever the other slices hold, and callers rely on them staying unread.
+  if (runtimeEntries.length === 0) {
+    releaseWorktreeAgentOrchestrationIndexCache()
+    return EMPTY_WORKTREE_AGENT_ORCHESTRATION_INDEX
+  }
+
+  const tabsByWorktree = state.tabsByWorktree ?? EMPTY_SOURCE
+  const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_SOURCE
+  const retainedAgentsByPaneKey = state.retainedAgentsByPaneKey ?? EMPTY_SOURCE
+  if (
+    orchestrationIndexCache?.runtimeSource === runtimeAgentOrchestrationByPaneKey &&
+    orchestrationIndexCache.tabsSource === tabsByWorktree &&
+    orchestrationIndexCache.liveSource === agentStatusByPaneKey &&
+    orchestrationIndexCache.retainedSource === retainedAgentsByPaneKey
+  ) {
+    return orchestrationIndexCache.recordsByWorktree
+  }
+
+  orchestrationIndexCache = {
+    runtimeSource: runtimeAgentOrchestrationByPaneKey,
+    tabsSource: tabsByWorktree,
+    liveSource: agentStatusByPaneKey,
+    retainedSource: retainedAgentsByPaneKey,
+    recordsByWorktree: buildIndex(
+      runtimeEntries,
+      tabsByWorktree,
+      agentStatusByPaneKey,
+      retainedAgentsByPaneKey
+    )
+  }
+  return orchestrationIndexCache.recordsByWorktree
+}
+
+export function selectWorktreeAgentOrchestration(
+  state: OrchestrationIndexState,
+  worktreeId: string
+): RuntimeOrchestrationRecord {
+  return (
+    selectWorktreeAgentOrchestrationIndex(state).get(worktreeId) ??
+    EMPTY_WORKTREE_AGENT_ORCHESTRATION
+  )
+}

--- a/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-orchestration-index.ts
@@ -171,9 +171,11 @@ function buildIndex(
  *
  * Why: every mounted worktree card subscribes to its own orchestration slice,
  * and Zustand re-runs every subscriber's selector on every store publication.
- * Scanning the whole context map per card made that O(cards x contexts) on
- * traffic that never touched orchestration. The first caller through a given
- * store version pays O(tabs + contexts); the rest are a Map lookup.
+ * Scanning the whole context map per card made that O(cards x contexts). What
+ * this removes is the per-card multiplier, not the rebuild itself: an agent
+ * ping replaces the live map, so the index still rebuilds once per publication.
+ * The first caller through a given store version pays O(tabs + contexts); the
+ * rest are a Map lookup.
  */
 export function selectWorktreeAgentOrchestrationIndex(
   state: OrchestrationIndexState

--- a/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-row-selectors.ts
@@ -12,12 +12,12 @@ import {
   patchLiveEntriesByWorktree,
   recordLiveEntriesFullRebuild
 } from './worktree-agent-live-index-patch'
+import { selectWorktreeAgentOrchestration } from './worktree-agent-orchestration-index'
 import type { TerminalLayoutSnapshot } from '../../../../shared/types'
 
 const EMPTY_LIVE_ENTRIES: AgentStatusEntry[] = []
 const EMPTY_MIGRATION_UNSUPPORTED_ENTRIES: MigrationUnsupportedPtyEntry[] = []
 const EMPTY_RETAINED: RetainedAgentEntry[] = []
-const EMPTY_RUNTIME_AGENT_ORCHESTRATION: Record<string, AgentStatusOrchestrationContext> = {}
 // Why: selector unit tests often pass partial store mocks; production state
 // owns these maps, but missing mock maps should behave like empty slices.
 const EMPTY_RECORD = {}
@@ -227,6 +227,10 @@ export function selectRetainedAgentEntriesForWorktree(
   return getRetainedEntriesByWorktree(state).get(worktreeId) ?? EMPTY_RETAINED
 }
 
+// Why: reads a shared worktree-keyed index instead of rescanning every
+// orchestration context. Zustand re-runs each mounted card's selector on every
+// publication, so the old per-card scan was O(cards x contexts) on unrelated
+// traffic; only the first card through a given store version now pays a build.
 export function selectRuntimeAgentOrchestrationForWorktree(
   state: Pick<
     AppState,
@@ -237,33 +241,7 @@ export function selectRuntimeAgentOrchestrationForWorktree(
   >,
   worktreeId: string
 ): Record<string, AgentStatusOrchestrationContext> {
-  const tabs = (state.tabsByWorktree ?? EMPTY_RECORD)[worktreeId] ?? []
-  const tabIds = new Set(tabs.map((tab) => tab.id))
-  const out: Record<string, AgentStatusOrchestrationContext> = {}
-  const runtimeAgentOrchestrationByPaneKey =
-    state.runtimeAgentOrchestrationByPaneKey ?? EMPTY_RECORD
-  const agentStatusByPaneKey = state.agentStatusByPaneKey ?? EMPTY_RECORD
-  const retainedAgentsByPaneKey = state.retainedAgentsByPaneKey ?? EMPTY_RECORD
-  for (const [paneKey, orchestration] of Object.entries(runtimeAgentOrchestrationByPaneKey)) {
-    const parsed = parsePaneKey(paneKey)
-    const parsedParent = orchestration.parentPaneKey
-      ? parsePaneKey(orchestration.parentPaneKey)
-      : null
-    const liveEntry = agentStatusByPaneKey[paneKey]
-    const retainedEntry = retainedAgentsByPaneKey[paneKey]
-    // Why: child agent terminals can be attributed to a worktree before their
-    // tab reaches this renderer, or after the row has been retained as done.
-    // The parent link must still reach that worktree card.
-    if (
-      (parsed && tabIds.has(parsed.tabId)) ||
-      (parsedParent && tabIds.has(parsedParent.tabId)) ||
-      liveEntry?.worktreeId === worktreeId ||
-      retainedEntry?.worktreeId === worktreeId
-    ) {
-      out[paneKey] = orchestration
-    }
-  }
-  return Object.keys(out).length > 0 ? out : EMPTY_RUNTIME_AGENT_ORCHESTRATION
+  return selectWorktreeAgentOrchestration(state, worktreeId)
 }
 
 export function selectTerminalLayoutsForWorktree(


### PR DESCRIPTION
## Description

Zustand re-runs **every** subscriber's selector on **every** store publication. Each mounted sidebar worktree card installs its own `selectRuntimeAgentOrchestrationForWorktree` subscription (`useWorktreeAgentRows.ts:74`), and that selector scanned the entire `runtimeAgentOrchestrationByPaneKey` map. So the sidebar paid **O(cards × contexts)** on every publication — including the high-frequency agent-status and PTY traffic that never touches orchestration at all.

This adds `worktree-agent-orchestration-index.ts`: one worktree-keyed index built behind a source-identity cache over the four slices the result actually depends on (`runtimeAgentOrchestrationByPaneKey`, `tabsByWorktree`, `agentStatusByPaneKey`, `retainedAgentsByPaneKey`). The first card through a given store version pays `O(tabs + contexts)`; every other card is a `Map.get`. Records keep referential identity when their content is unchanged, so memo'd cards still bail out of re-render under `useShallow`.

`9181e2b6c1` already did this for the dashboard. The sidebar kept the per-card scan; this closes that gap.

**Deliberately not changed:** `worktree-agent-orchestration-batch.ts`. Its `requestedIds` scoping is intentionally narrower than a global index (it is told which worktrees are on screen). I tried unifying them, it broke that scoping, and I reverted it — disproportionate risk for a small win.

## ELI5

Twenty index cards are pinned to a board. Every time *anything* changes anywhere in the app, all twenty cards wake up and each one re-reads the entire master list from the top to find its own rows — twenty full passes, even when the change had nothing to do with them.

Now one card reads the master list once and sorts the rows into twenty labelled pigeonholes. Each card just grabs its own pigeonhole. Same rows, same order, one pass instead of twenty. And if nothing moved, everyone gets the exact same pigeonhole object back, so nobody bothers redrawing.

## Proof of performance improvement

Nanoseconds per publication, summed across all mounted cards, under live-status churn (the real hot path — the live map is replaced on every agent ping):

| cards | contexts | before | after | speedup |
|---|---|---|---|---|
| 5 | 10 | 7,914 | 4,411 | 1.8× |
| 10 | 20 | 32,800 | 8,743 | 3.8× |
| 20 | 40 | 112,228 | 15,764 | 7.1× |
| 40 | 80 | 449,844 | 23,861 | 18.9× |
| 80 | 160 | 1,777,225 | 49,504 | 35.9× |

Re-measured on the fixed code. Records are now built with `Object.create(null)`, which costs ~1.43× more per record than an object literal; records are built only on rebuild, never per card, so the scaling win is unchanged.

The shape matters more than any single row. Holding contexts fixed at 40 and varying card count:

| cards | before | after |
|---|---|---|
| 5 | 49,907 | 10,648 |
| 10 | 104,241 | 11,751 |
| 20 | 217,771 | 13,951 |
| 40 | 428,001 | 18,467 |
| 80 | 852,563 | 22,751 |

Before: cost scales linearly with mounted cards. After: nearly flat. On publications where all four slices keep identity, the index isn't rebuilt at all (up to ~4900× on the 80-card case).

**The one tradeoff, stated plainly.** The index reads *all* worktrees' tabs once to build tab→worktree membership; the old selector read only its own worktree's tabs. That is why one operation-budget assertion was relaxed (`unrelatedTabIdReads: 0 → tabCount - 1`). Measured at 20 cards / 40 contexts / 100 publications: tab-id reads 60 vs 6,000 (100× fewer), context visits 4,000 vs 80,000 (20× fewer). Worst case — `tabsByWorktree` replaced on *every* publication, so the membership cache never hits — total ops 10,000 vs 86,000, still **8.6× fewer**. The relaxation is real and is bounded above by the old cost.

**A second budget assertion was corrected, not relaxed.** Review caught that the "work must not scale with publications" assertion re-ran the selector against one *identical* state object, so it only proved the identity cache works. The honest contract is narrower: a real live-status ping replaces `agentStatusByPaneKey` and *does* force one index rebuild per publication. What the shared index removes is the **mounted-card multiplier**, not the per-publication rebuild. The assertion now drives real live churn and pins `contextVisits: contextCount × (publications + 1)` with `tabIdReads` flat.

## Proof of no regression

- **Differential vs. the pre-index selector**, transcribed as an oracle: 300 seeded randomized stores × every worktree, asserting both **key order** and **per-value referential identity**. Covers tab ids colliding across worktrees, orphan panes, malformed parent pane keys, **malformed runtime pane keys including `__proto__`**, and worktrees reachable only via live/retained attribution.
- **Two-store interleaving**: 400 seeds / 12,064 checks round-robining two different state objects through the single module-level cache slot — **0 mismatches**. Thrash costs a rebuild; it never returns another store's answer.
- **Mutation testing**, each mutant restored byte-identical after: drop parent-link attribution → caught; ignore `tabsByWorktree` identity → caught; tab-membership cache never invalidates → caught; drop live-status attribution → caught; cache ignores runtime source identity → caught; `buildIndex` mutates a previously-returned record → caught.
- **Staleness closed at the source.** The index rebuilds only on slice identity change, so the sharp question is whether a relevant change can preserve identity. `orchestrationMapsEqual` gates that, and `parentPaneKey` — the one field the index reads — is in `orchestrationContextsEqual` (`agent-status.ts:1091`). `removePaneKeys`/`movePaneKeyedRecord` are copy-on-write, and no production code mutates the four slices in place (test fixtures only).
- **Key order is unobservable downstream**: every consumer does keyed lookup (`worktree-agent-rows.ts:70`); nothing outside the index/batch/store iterates the record.
- **Gates** (re-run after the loop-3 fixes): renderer suite **16,252 passed / 4 skipped / 0 failed**; `tsc -p config/tsconfig.tc.web.json` exit 0; oxlint clean; oxfmt clean; max-lines baseline untouched, no new bypasses.

## User-facing regression notes

None expected. Same rows, same order, same object identities.

One **intentional** behavior divergence, tested and pinned: with a nullish `worktreeId`, the old predicate `entry?.worktreeId === worktreeId` evaluated `undefined === undefined` → true, so it attributed *every* pane lacking a live/retained entry to that call. The new code guards with `typeof === 'string'`. The old result was wrong, not merely different. All three call sites type `worktreeId: string`, so this is unreachable in production — asserted so the divergence is deliberate and documented rather than accidental.

## Adversarial review verdict + loop count

**4 review loops. Final verdict: ship.**

**Loop count: 4. Final state: reviewers' blockers all reproduced and fixed; production implementation independently confirmed CLEAN by two reviewers.**

- **Loop 1** — an attempt to unify this with the dashboard batch selector broke the batch's deliberate target-local scoping; reverted. Also fixed: a `tabs is not iterable` crash on a `null` tab list, and a double `tab.id` read that inflated instrumented counts.
- **Loop 2** — found and pinned the nullish-`worktreeId` divergence above; added the interleaving and no-mutation tests, each verified by mutation.
- **Loop 3 (independent review)** — two reviewers returned split verdicts:
  - **gpt-5.6-sol (`c002b-gpt2`): CLEAN.** Confirmed behavioral parity across all four attribution paths, key ordering, cache invalidation, cross-store interleaving, returned-record mutation, identity reuse, downstream ordering, and that the budget changes encode a real tradeoff rather than masking a regression.
  - **gpt-5.6-sol (`c002b-rev-gpt`): BLOCKERS-FOUND.** I reproduced every claim independently with a standalone Node repro before acting on it. All are now fixed in `680a44ee`:

| Finding | Verified? | Resolution |
|---|---|---|
| `__proto__` pane key diverges from the old selector | **Yes** — old keys `[]`, new keys `['__proto__']` | Records built with `Object.create(null)`. Fixed in the batch selector too, which had the same latent bug. |
| Empty-map short-circuit defeats the entries cache (N enumerations for N cards) | **Yes** — Proxy `ownKeys` counter showed 3 for 3 cards | Empty case now clears only the derived index; the entries cache stays warm. Pinned by a Proxy-counter test. |
| Publication-budget assertion doesn't simulate publications | **Yes** — it re-ran one identical state | Assertion corrected to drive real live churn; claim narrowed to what actually holds. |
| Differential generator never emits malformed runtime keys | **Yes** — that's why 300 seeds missed it | Generator now emits `__proto__`, `constructor`, `toString`, and unparseable keys. |
| Shared empties are runtime-mutable despite `readonly` typing | **Yes** | Both `EMPTY_WORKTREE_AGENT_ORCHESTRATION` singletons frozen. |
| Test comments exceed the repo's concise-comment rule | **Yes** | Trimmed. |

**The reviewer's root-cause analysis was correct and is the most useful result here:** the differential passed 300 seeds only because its generator never produced a malformed *runtime* key (only malformed *parent* keys). With the generator expanded, the differential now catches the original bug on its own — so the regression is pinned by the general-purpose test, not just by a targeted one.

Both fixes are mutation-verified (revert the fix → the corresponding new test fails; file restored byte-identical after each).

- **Loop 4 (fable review)** — `c002b-rev-fable` returned **BLOCKERS-FOUND, test-only**: it independently reproduced the perf table (15.7x / 28.1x / 55.4x against my 15.8x / 54.9x), confirmed via 12 hand-built nasty states that keys, key *order*, and value identity all match, and rated the production implementation CLEAN. Its blocker was a real hole in my test:

| Finding | Verified? | Resolution |
|---|---|---|
| The differential's PRNG is seeded so weakly that **all 300 seeds generate exactly one worktree** — the comment claiming cross-worktree tab-id collisions are covered was false (0/300) | **Yes** — xorshift32 seeded with a small int returns < 0.019 on its first call, so `1 + pick(5)` is always 1 | Seed scrambled with a Weyl constant. Now a flat 1-5 spread, with a tab id owned by multiple worktrees on **131/300** seeds. |
| Consequence: a mutant fanning a multi-owned **parent** tab out to only one owning worktree passes the entire shipped suite | **Yes** — reproduced both directions: old PRNG + mutant → 16/16 pass; new PRNG + mutant → fails | Closed by the seed fix; no new test needed. |
| Doc comment overstates the caching win ("traffic that never touched orchestration") | **Yes** — an agent ping replaces the live map, so the index rebuilds every publication | Comment narrowed to the per-card multiplier, which is the real win. |

Fixed in `f58df683`. This is the second time a reviewer found that a *passing* randomized differential was much weaker than its comment claimed — both times the fix widened real coverage rather than adding a targeted test.

**Note on process:** `c002b-rev-gpt` sent ~90 duplicate copies of its verdict due to a tool-dispatch fault on its side; it is one finding set, not ninety.

Made with [Orca](https://github.com/stablyai/orca) 🐋


