### PR TITLE
fix(window): stop burning macOS GPU on an invisible blur effect (#8482)

### DIFF
--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -311,6 +311,59 @@ describe('createMainWindow', () => {
     }
   })
 
+  it('never requests macOS vibrancy or transparency when window blur is enabled (#8482)', () => {
+    for (const [platform, expected] of [
+      ['darwin', { backgroundMaterial: undefined }],
+      ['win32', { backgroundMaterial: 'acrylic' }],
+      ['linux', { backgroundMaterial: undefined }]
+    ] satisfies [NodeJS.Platform, { backgroundMaterial: string | undefined }][]) {
+      browserWindowMock.mockReset()
+      const webContents = {
+        on: vi.fn(),
+        setZoomLevel: vi.fn(),
+        setBackgroundThrottling: vi.fn(),
+        invalidate: vi.fn(),
+        setWindowOpenHandler: vi.fn(),
+        send: vi.fn(),
+        isDevToolsOpened: vi.fn(),
+        openDevTools: vi.fn(),
+        closeDevTools: vi.fn()
+      }
+      const browserWindowInstance = {
+        webContents,
+        on: vi.fn(),
+        isDestroyed: vi.fn(() => false),
+        isMaximized: vi.fn(() => false),
+        isFullScreen: vi.fn(() => false),
+        getSize: vi.fn(() => [1200, 800]),
+        getBounds: vi.fn(() => ({ x: 10, y: 20, width: 1000, height: 700 })),
+        setSize: vi.fn(),
+        setWindowButtonPosition: vi.fn(),
+        maximize: vi.fn(),
+        show: vi.fn(),
+        loadFile: vi.fn(),
+        loadURL: vi.fn()
+      }
+      browserWindowMock.mockImplementation(function () {
+        return browserWindowInstance
+      })
+
+      withPlatform(platform, () =>
+        createMainWindow({
+          getUI: () => ({}),
+          getSettings: () => ({ windowBackgroundBlur: true }),
+          updateUI: vi.fn()
+        } as never)
+      )
+
+      const browserWindowOptions = browserWindowMock.mock.calls[0]?.[0]
+      expect(browserWindowOptions.vibrancy).toBeUndefined()
+      expect(browserWindowOptions.transparent).toBeUndefined()
+      expect(browserWindowOptions.backgroundMaterial).toBe(expected.backgroundMaterial)
+      expect(browserWindowOptions.backgroundColor).toBe('#ffffff')
+    }
+  })
+
   it('keeps main-window background throttling enabled while repainting macOS visibility transitions', () => {
     vi.useFakeTimers()
     const windowHandlers = new Map<string, ((...args: any[]) => void)[]>()

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -253,14 +253,10 @@ export function createMainWindow(
     return false
   })
   const blur = settings?.windowBackgroundBlur ?? false
-  // Why: blur uses platform APIs (macOS vibrancy+transparent, Windows backgroundMaterial, Linux none) and only applies at creation, needs restart.
-  const platformBlurOptions = blur
-    ? process.platform === 'darwin'
-      ? { vibrancy: 'under-window' as const, transparent: true }
-      : process.platform === 'win32'
-        ? { backgroundMaterial: 'acrylic' as const }
-        : {}
-    : {}
+  // Why: only Windows acrylic is ever visible; macOS vibrancy+transparent sat behind our opaque background yet
+  // forced per-frame WindowServer alpha compositing (#8482). Applies at creation only, so it needs a restart.
+  const platformBlurOptions =
+    blur && process.platform === 'win32' ? { backgroundMaterial: 'acrylic' as const } : {}
 
   const mainWindow = new BrowserWindow({
     width: savedBounds?.width ?? defaultBounds.width,


### PR DESCRIPTION
Fixes #8482

## What was wrong

macOS "Window Background Blur" created the window with `vibrancy: 'under-window'` **and** `transparent: true`. `transparent: true` takes the window off macOS's opaque-window fast path, forcing WindowServer to alpha-composite the full window every frame, and the vibrancy view re-samples and blurs everything behind the window continuously.

**The user never saw any of it.** An opaque `backgroundColor` is always set (`createMainWindow.ts:277`) and the renderer paints an opaque root (`body { @apply bg-background }`, with `--background` = `#fff` / `#0a0a0a` — no alpha). The vibrancy view was fully occluded. Per #8797, `transparent: true` suppresses the vibrancy view on macOS anyway.

So this was pure waste: sustained GPU power and heat, buying zero visible pixels.

## ELI5

We were paying the graphics card to paint a fancy frosted-glass effect *behind* a wall we'd already painted solid. Nobody could see the frosted glass — but the laptop still got hot and the battery still drained. This stops painting the thing nobody can see.

## The fix

```ts
const platformBlurOptions =
  blur && process.platform === 'win32' ? { backgroundMaterial: 'acrylic' as const } : {}
```

Strictly subtractive, main-process only. Windows acrylic and Linux are byte-identical. Nothing added — no `visualEffectState`, no `setVibrancy`, no new window option.

## Fix proof

Reporter's controlled A/B (same ~156 PTYs live, blur toggled + restart):

| Condition | GPU power |
|---|---|
| Blur ON | **5,365 mW** |
| Blur OFF | **804 mW** |
| Window hidden | 589 mW |

The hidden-window number isolates the cost to *visible composition*, which is exactly what the two removed options control. ~85% power delta.

Regression guard — new test `never requests macOS vibrancy or transparency when window blur is enabled (#8482)` asserts across all three platforms that with `windowBackgroundBlur: true`, `vibrancy` and `transparent` are undefined, win32 still gets `acrylic`, and the opaque `backgroundColor` survives.

**Verified the guard is real, not a tautology.** Reverting only the production change:

```
× never requests macOS vibrancy or transparency when window blur is enabled (#8482)
AssertionError: expected 'under-window' to be undefined
  Tests  1 failed | 79 passed (80)
```

Re-applied → `Tests  80 passed (80)`.

## Proof of no regressions

- `pnpm vitest run --config config/vitest.config.ts src/main/window/createMainWindow.test.ts` → **80 passed (80)**
- `pnpm exec tsc --noEmit -p config/tsconfig.node.json` → exit 0
- `pnpm exec oxlint` on both changed files → exit 0
- No existing test asserted `vibrancy` / `transparent` / `backgroundMaterial` (confirmed by grep), so nothing was pinning the old behavior. The pre-existing cross-platform titlebar test was deliberately left untouched so it keeps its `createMainWindow(null)` null-store coverage.

**Perf:** strictly negative cost — this removes per-frame compositing work and adds none. The changed code runs once at window creation.

**Cross-platform:** the whole change is behind `process.platform === 'win32'`. Windows and Linux take the identical path they did before. No filesystem, SSH, folder-workspace, or Git interaction — window creation happens before any workspace logic.

## Trade-offs (please read)

1. **This deletes an effect rather than making it work.** Making blur genuinely render would need an alpha-capable `backgroundColor`, a non-opaque renderer root, and `visualEffectState` tuning — that's feature work with real visual-regression risk, deliberately out of scope for a bug fix.
2. **The macOS setting now does nothing.** The Settings toggle and the ghostty `background-blur-radius` import path (`mapper.ts:141`) remain selectable but are no-ops on macOS. They already produced nothing visible, so this is status quo in user-facing terms. Hiding/annotating the control on macOS is a reasonable follow-up (touches renderer platform detection, copy, i18n keys, onboarding search metadata) and is intentionally not done here.
3. **One small genuine visible change:** dropping `transparent: true` restores the standard macOS window drop shadow for users who had blur enabled. That's a return to normal chrome, not a regression — but it is a visible difference, so I'm calling it out.

## Review loop

Design stage: two independent designs (Claude Fable 5 + GPT-5.6-Sol) → adversarial judge. Both designs converged on this same production edit independently. The judge verified the claims against the tree, rejected the riskier "make blur actually render" option as feature work, and empirically validated both the fix and the regression guard before handing off.

Screenshots: none — the fix's correctness claim is that **appearance is unchanged**, so a before/after screenshot pair would be two identical images. The measurable evidence is the power delta above, which needs macOS hardware and `powermetrics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Orca](https://github.com/stablyai/orca) 🐋
