### PR TITLE
fix(crash-reporting): record exact V8 heap sizes, not Blink's quantized ones

### DIFF
--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -354,6 +354,7 @@ import type {
   ReactErrorBoundaryReportArgs,
   ReactErrorBoundaryReportResult
 } from '../shared/crash-reporting'
+import type { RendererHeapStatistics } from '../shared/renderer-heap-statistics'
 
 export type {
   ShellOpenExternalEditorRequest,
@@ -1503,6 +1504,8 @@ export type PreloadApi = {
     copyLatestDiagnostics: (
       args?: CrashReportCopyDiagnosticsArgs
     ) => Promise<{ ok: true } | { ok: false; error: string }>
+    /** Exact V8/Blink heap sizes; null when the runtime withholds them. */
+    readHeapStatistics: () => RendererHeapStatistics | null
   }
   export: ExportApi
   gh: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -239,6 +239,7 @@ import type {
   ReactErrorBoundaryReportArgs,
   ReactErrorBoundaryReportResult
 } from '../shared/crash-reporting'
+import type { RendererHeapStatistics } from '../shared/renderer-heap-statistics'
 import type { PreloadApi } from './api-types'
 import {
   createUpdaterQuitAbortRelay,
@@ -423,6 +424,24 @@ document.addEventListener(
 )
 
 const startupDiagnosticsEnabled = process.env.ORCA_STARTUP_DIAGNOSTICS === '1'
+
+// Why: `performance.memory` is bucket-quantized and cached ~20min by Blink, so it
+// cannot observe heap growth. These are exact and available in a sandboxed preload.
+function readRendererHeapStatistics(): RendererHeapStatistics | null {
+  try {
+    const heap = process.getHeapStatistics()
+    return {
+      usedHeapKB: heap.usedHeapSize,
+      totalHeapKB: heap.totalHeapSize,
+      heapLimitKB: heap.heapSizeLimit,
+      mallocedKB: heap.mallocedMemory,
+      blinkAllocatedKB: process.getBlinkMemoryInfo().allocated
+    }
+  } catch {
+    // Why: diagnostics must never break the renderer if Electron drops an API.
+    return null
+  }
+}
 
 // Custom APIs for renderer
 const api = {
@@ -1151,7 +1170,8 @@ const api = {
     submit: (args: CrashReportSubmitArgs): Promise<CrashReportSubmitResult> =>
       ipcRenderer.invoke('crashReports:submit', args),
     copyLatestDiagnostics: (args?: CrashReportCopyDiagnosticsArgs) =>
-      ipcRenderer.invoke('crashReports:copyLatestDiagnostics', args)
+      ipcRenderer.invoke('crashReports:copyLatestDiagnostics', args),
+    readHeapStatistics: (): RendererHeapStatistics | null => readRendererHeapStatistics()
   },
 
   export: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -240,6 +240,7 @@ import type {
   ReactErrorBoundaryReportResult
 } from '../shared/crash-reporting'
 import type { RendererHeapStatistics } from '../shared/renderer-heap-statistics'
+import { readRendererHeapStatistics } from './renderer-heap-statistics-reader'
 import type { PreloadApi } from './api-types'
 import {
   createUpdaterQuitAbortRelay,
@@ -424,24 +425,6 @@ document.addEventListener(
 )
 
 const startupDiagnosticsEnabled = process.env.ORCA_STARTUP_DIAGNOSTICS === '1'
-
-// Why: `performance.memory` is bucket-quantized and cached ~20min by Blink, so it
-// cannot observe heap growth. These are exact and available in a sandboxed preload.
-function readRendererHeapStatistics(): RendererHeapStatistics | null {
-  try {
-    const heap = process.getHeapStatistics()
-    return {
-      usedHeapKB: heap.usedHeapSize,
-      totalHeapKB: heap.totalHeapSize,
-      heapLimitKB: heap.heapSizeLimit,
-      mallocedKB: heap.mallocedMemory,
-      blinkAllocatedKB: process.getBlinkMemoryInfo().allocated
-    }
-  } catch {
-    // Why: diagnostics must never break the renderer if Electron drops an API.
-    return null
-  }
-}
 
 // Custom APIs for renderer
 const api = {

--- a/src/preload/renderer-heap-statistics-reader.test.ts
+++ b/src/preload/renderer-heap-statistics-reader.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readRendererHeapStatistics } from './renderer-heap-statistics-reader'
+
+const heapStatistics = {
+  totalHeapSize: 2048,
+  totalHeapSizeExecutable: 0,
+  totalPhysicalSize: 2048,
+  totalAvailableSize: 4_000_000,
+  usedHeapSize: 1536,
+  heapSizeLimit: 4_292_608,
+  mallocedMemory: 64,
+  peakMallocedMemory: 96,
+  doesZapGarbage: false
+}
+
+const source = (overrides: {
+  heap?: () => Electron.HeapStatistics
+  blink?: () => Electron.BlinkMemoryInfo
+}): Parameters<typeof readRendererHeapStatistics>[0] =>
+  ({
+    getHeapStatistics: overrides.heap ?? ((): Electron.HeapStatistics => heapStatistics),
+    getBlinkMemoryInfo:
+      overrides.blink ?? ((): Electron.BlinkMemoryInfo => ({ allocated: 1227, total: 1280 }))
+  }) as Parameters<typeof readRendererHeapStatistics>[0]
+
+describe('readRendererHeapStatistics', () => {
+  it('reports V8 sizes in the kilobytes Electron returns', () => {
+    expect(readRendererHeapStatistics(source({}))).toEqual({
+      usedHeapKB: 1536,
+      totalHeapKB: 2048,
+      heapLimitKB: 4_292_608,
+      mallocedKB: 64,
+      blinkAllocatedKB: 1227
+    })
+  })
+
+  it('keeps the exact V8 read when only the Blink metric throws', () => {
+    // Why: Blink's number is supplementary. Discarding the V8 read over its
+    // absence would send callers back to the quantized `performance.memory`
+    // this reader exists to replace — silently defeating the whole feature.
+    const result = readRendererHeapStatistics(
+      source({
+        blink: () => {
+          throw new Error('getBlinkMemoryInfo unavailable')
+        }
+      })
+    )
+
+    expect(result).toEqual({
+      usedHeapKB: 1536,
+      totalHeapKB: 2048,
+      heapLimitKB: 4_292_608,
+      mallocedKB: 64,
+      blinkAllocatedKB: undefined
+    })
+  })
+
+  it('returns null only when the primary V8 read fails', () => {
+    const blink = vi.fn()
+
+    expect(
+      readRendererHeapStatistics(
+        source({
+          heap: () => {
+            throw new Error('getHeapStatistics unavailable')
+          },
+          blink: blink as never
+        })
+      )
+    ).toBeNull()
+    // Why: no reason to pay for the auxiliary call once the result is unusable.
+    expect(blink).not.toHaveBeenCalled()
+  })
+})

--- a/src/preload/renderer-heap-statistics-reader.ts
+++ b/src/preload/renderer-heap-statistics-reader.ts
@@ -1,0 +1,37 @@
+import type { RendererHeapStatistics } from '../shared/renderer-heap-statistics'
+
+type HeapStatisticsSource = Pick<NodeJS.Process, 'getHeapStatistics' | 'getBlinkMemoryInfo'>
+
+/**
+ * Reads exact V8 heap sizes, which `performance.memory` cannot express: Blink
+ * quantizes that API and caches it ~20 minutes, so heap growth is invisible to
+ * it. Available in a sandboxed, context-isolated preload.
+ */
+export function readRendererHeapStatistics(
+  source: HeapStatisticsSource = process
+): RendererHeapStatistics | null {
+  let heap: Electron.HeapStatistics
+  try {
+    heap = source.getHeapStatistics()
+  } catch {
+    // Why: diagnostics must never break the renderer if Electron drops an API.
+    return null
+  }
+
+  let blinkAllocatedKB: number | undefined
+  try {
+    // Why a separate try: Blink's number is supplementary. Losing it must not
+    // discard the exact V8 read and send callers back to the quantized metric.
+    blinkAllocatedKB = source.getBlinkMemoryInfo().allocated
+  } catch {
+    blinkAllocatedKB = undefined
+  }
+
+  return {
+    usedHeapKB: heap.usedHeapSize,
+    totalHeapKB: heap.totalHeapSize,
+    heapLimitKB: heap.heapSizeLimit,
+    mallocedKB: heap.mallocedMemory,
+    blinkAllocatedKB
+  }
+}

--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -316,6 +316,26 @@ describe('renderer crash diagnostics', () => {
       })
     })
 
+    it('omits the Blink field instead of emitting a junk value for it', () => {
+      // Why: `undefined * 1024` is NaN. The breadcrumb must carry no
+      // blinkAllocatedMB at all rather than a meaningless number.
+      readHeapStatistics.mockReturnValue({
+        usedHeapKB: 77 * KB,
+        totalHeapKB: 154 * KB,
+        heapLimitKB: 512 * KB,
+        mallocedKB: 3 * KB,
+        blinkAllocatedKB: undefined
+      })
+
+      diagnostics.installRendererCrashDiagnostics()
+
+      const call = recordBreadcrumbMock.mock.calls.find(
+        ([entry]) => (entry as { name: string }).name === 'renderer_memory'
+      )?.[0] as { data: Record<string, unknown> }
+      expect(call.data).toMatchObject({ usedHeapMB: 77, heapSource: 'v8', mallocedMB: 3 })
+      expect(call.data).not.toHaveProperty('blinkAllocatedMB')
+    })
+
     it('falls back to performance.memory when the bridge returns null', () => {
       readHeapStatistics.mockReturnValue(null)
 

--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -81,6 +81,9 @@ describe('renderer crash diagnostics', () => {
         usedHeapMB: 32,
         totalHeapMB: 64,
         heapLimitMB: 512,
+        // Why: without this tag a reader cannot tell an exact heap number from a
+        // Blink-quantized one, which is what made earlier bundles unanalyzable.
+        heapSource: 'quantized',
         browserWebviews: 4,
         registeredBrowserGuests: 3
       }
@@ -241,5 +244,98 @@ describe('renderer crash diagnostics', () => {
         (call) => (call[0] as { name: string }).name === 'renderer_memory_highwater'
       )
     ).toBe(false)
+  })
+
+  describe('exact V8 heap statistics', () => {
+    const KB = 1024
+    let readHeapStatistics: ReturnType<typeof vi.fn>
+
+    const stubHeap = (usedMB: number, limitMB = 512): void => {
+      readHeapStatistics.mockReturnValue({
+        usedHeapKB: usedMB * KB,
+        totalHeapKB: usedMB * KB * 2,
+        heapLimitKB: limitMB * KB,
+        mallocedKB: 3 * KB,
+        blinkAllocatedKB: 7 * KB
+      })
+    }
+
+    beforeEach(() => {
+      readHeapStatistics = vi.fn()
+      ;(window.api.crashReports as unknown as { readHeapStatistics: unknown }).readHeapStatistics =
+        readHeapStatistics
+    })
+
+    it('prefers exact statistics over performance.memory and labels the source', () => {
+      stubHeap(101)
+
+      diagnostics.installRendererCrashDiagnostics()
+
+      // Why: performance.memory still says 32MB here. Reporting 101 proves the
+      // exact reading wins rather than merely being recorded alongside.
+      expect(recordBreadcrumbMock).toHaveBeenCalledWith({
+        name: 'renderer_memory',
+        data: expect.objectContaining({
+          usedHeapMB: 101,
+          heapLimitMB: 512,
+          heapSource: 'v8',
+          mallocedMB: 3,
+          blinkAllocatedMB: 7
+        })
+      })
+    })
+
+    it('observes growth that performance.memory quantizes away', () => {
+      // Why: this is the whole point. Blink pins usedJSHeapSize to a bucket and
+      // caches it ~20min, so a real climb reports byte-identical values and a
+      // highwater threshold never fires. Exact stats must still cross it.
+      const quantized = (window.performance as unknown as { memory: Record<string, number> }).memory
+      quantized.usedJSHeapSize = 32 * 1024 * 1024
+      stubHeap(100)
+      vi.stubGlobal('document', {
+        getElementsByTagName: () => ({ length: 1 }),
+        querySelectorAll: () => ({ length: 0 })
+      })
+
+      diagnostics.installRendererCrashDiagnostics()
+      const highwaterCalls = (): unknown[] =>
+        recordBreadcrumbMock.mock.calls.filter(
+          (call) => (call[0] as { name: string }).name === 'renderer_memory_highwater'
+        )
+      expect(highwaterCalls()).toHaveLength(0)
+
+      stubHeap(400) // 78% of 512 — past the 60% threshold, still below 80%.
+      const tick = setIntervalMock.mock.calls[0][0] as () => void
+      tick()
+
+      expect(quantized.usedJSHeapSize).toBe(32 * 1024 * 1024)
+      expect(highwaterCalls()).toHaveLength(1)
+      expect(recordBreadcrumbMock).toHaveBeenCalledWith({
+        name: 'renderer_memory_highwater',
+        data: expect.objectContaining({ thresholdPct: 60, usedHeapMB: 400, heapSource: 'v8' })
+      })
+    })
+
+    it('falls back to performance.memory when the bridge returns null', () => {
+      readHeapStatistics.mockReturnValue(null)
+
+      diagnostics.installRendererCrashDiagnostics()
+
+      expect(recordBreadcrumbMock).toHaveBeenCalledWith({
+        name: 'renderer_memory',
+        data: expect.objectContaining({ usedHeapMB: 32, heapSource: 'quantized' })
+      })
+    })
+
+    it('samples on an older shell whose preload lacks the bridge', () => {
+      ;(window.api.crashReports as unknown as Record<string, unknown>).readHeapStatistics =
+        undefined
+
+      expect(() => diagnostics.installRendererCrashDiagnostics()).not.toThrow()
+      expect(recordBreadcrumbMock).toHaveBeenCalledWith({
+        name: 'renderer_memory',
+        data: expect.objectContaining({ usedHeapMB: 32, heapSource: 'quantized' })
+      })
+    })
   })
 })

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -217,7 +217,11 @@ function readHeapMetrics(): HeapMetrics | undefined {
       totalJSHeapSize: exact.totalHeapKB * BYTES_PER_KILOBYTE,
       jsHeapSizeLimit: exact.heapLimitKB * BYTES_PER_KILOBYTE,
       mallocedBytes: exact.mallocedKB * BYTES_PER_KILOBYTE,
-      blinkAllocatedBytes: exact.blinkAllocatedKB * BYTES_PER_KILOBYTE,
+      // Why guarded: undefined * 1024 is NaN, which would emit a junk field.
+      blinkAllocatedBytes:
+        exact.blinkAllocatedKB === undefined
+          ? undefined
+          : exact.blinkAllocatedKB * BYTES_PER_KILOBYTE,
       exact: true
     }
   }

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -11,6 +11,7 @@ import { collectRendererMemoryProfileCounts } from './renderer-memory-profile'
 
 const RENDERER_MEMORY_SAMPLE_INTERVAL_MS = 60_000
 const BYTES_PER_MEGABYTE = 1024 * 1024
+const BYTES_PER_KILOBYTE = 1024
 // Why: one detailed breadcrumb per threshold names what grew before an OOM.
 const RENDERER_MEMORY_HIGHWATER_RATIOS = [0.6, 0.8] as const
 
@@ -20,6 +21,13 @@ type BrowserPerformanceMemory = {
   usedJSHeapSize?: number
   totalJSHeapSize?: number
   jsHeapSizeLimit?: number
+}
+
+/** Heap sizes in bytes, tagged with whether they are exact or Blink-quantized. */
+type HeapMetrics = BrowserPerformanceMemory & {
+  mallocedBytes?: number
+  blinkAllocatedBytes?: number
+  exact: boolean
 }
 
 let rendererCrashDiagnosticsInstalled = false
@@ -42,7 +50,7 @@ export function installRendererCrashDiagnostics(surface: RendererSurface = 'main
   window.addEventListener('error', recordRendererError)
   window.addEventListener('unhandledrejection', recordRendererUnhandledRejection)
 
-  if (getPerformanceMemory()) {
+  if (readHeapMetrics()) {
     recordRendererMemory('startup')
     rendererMemoryInterval = window.setInterval(
       () => recordRendererMemory('interval'),
@@ -108,7 +116,7 @@ function recordRendererUnhandledRejection(event: PromiseRejectionEvent): void {
 }
 
 function recordRendererMemory(reason: string): void {
-  const memory = getPerformanceMemory()
+  const memory = readHeapMetrics()
   if (!memory) {
     return
   }
@@ -121,6 +129,9 @@ function recordRendererMemory(reason: string): void {
       usedHeapMB: toMegabytes(memory.usedJSHeapSize),
       totalHeapMB: toMegabytes(memory.totalJSHeapSize),
       heapLimitMB: toMegabytes(memory.jsHeapSizeLimit),
+      heapSource: memory.exact ? 'v8' : 'quantized',
+      mallocedMB: toMegabytes(memory.mallocedBytes),
+      blinkAllocatedMB: toMegabytes(memory.blinkAllocatedBytes),
       browserWebviews: browserWebviews.browserWebviewCount,
       registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount
     })
@@ -129,7 +140,7 @@ function recordRendererMemory(reason: string): void {
 }
 
 function recordRendererMemoryHighwater(
-  memory: BrowserPerformanceMemory,
+  memory: HeapMetrics,
   browserWebviews: BrowserWebviewMemoryProfile
 ): void {
   const used = memory.usedJSHeapSize
@@ -156,6 +167,9 @@ function recordRendererMemoryHighwater(
     usedHeapMB: toMegabytes(used),
     totalHeapMB: toMegabytes(memory.totalJSHeapSize),
     heapLimitMB: toMegabytes(limit),
+    heapSource: memory.exact ? 'v8' : 'quantized',
+    mallocedMB: toMegabytes(memory.mallocedBytes),
+    blinkAllocatedMB: toMegabytes(memory.blinkAllocatedBytes),
     domNodes: document.getElementsByTagName('*').length,
     terminalElements: document.querySelectorAll('.xterm').length,
     browserWebviews: browserWebviews.browserWebviewCount,
@@ -183,6 +197,32 @@ function getPerformanceMemory(): BrowserPerformanceMemory | undefined {
     return undefined
   }
   return (window.performance as Performance & { memory?: BrowserPerformanceMemory }).memory
+}
+
+/**
+ * Prefers V8's exact numbers; falls back to `performance.memory` only when the
+ * preload bridge is unavailable (older shell, or a surface without it).
+ *
+ * Both are normalized to bytes so callers and the emitted MB fields stay
+ * comparable with breadcrumbs recorded before this bridge existed.
+ */
+function readHeapMetrics(): HeapMetrics | undefined {
+  if (typeof window === 'undefined') {
+    return undefined
+  }
+  const exact = window.api?.crashReports?.readHeapStatistics?.()
+  if (exact) {
+    return {
+      usedJSHeapSize: exact.usedHeapKB * BYTES_PER_KILOBYTE,
+      totalJSHeapSize: exact.totalHeapKB * BYTES_PER_KILOBYTE,
+      jsHeapSizeLimit: exact.heapLimitKB * BYTES_PER_KILOBYTE,
+      mallocedBytes: exact.mallocedKB * BYTES_PER_KILOBYTE,
+      blinkAllocatedBytes: exact.blinkAllocatedKB * BYTES_PER_KILOBYTE,
+      exact: true
+    }
+  }
+  const fallback = getPerformanceMemory()
+  return fallback ? { ...fallback, exact: false } : undefined
 }
 
 function describeUnknownValue(

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -677,7 +677,9 @@ function createWebPreloadApi(): Partial<PreloadApi> {
         Promise.resolve({
           ok: false,
           error: translate('auto.web.web.preload.api.fb290366b2', 'Unavailable on web.')
-        })
+        }),
+      // Why: no Electron process on web; the caller falls back to performance.memory.
+      readHeapStatistics: () => null
     },
     diagnostics: {
       getStatus: () =>

--- a/src/shared/renderer-heap-statistics.ts
+++ b/src/shared/renderer-heap-statistics.ts
@@ -16,6 +16,9 @@ export type RendererHeapStatistics = {
   heapLimitKB: number
   /** Off-heap V8 allocations, which `usedJSHeapSize` never included. */
   mallocedKB: number
-  /** Blink's own allocator (DOM, layout), invisible to the V8 heap counters. */
-  blinkAllocatedKB: number
+  /**
+   * Blink's own allocator (DOM, layout), invisible to the V8 heap counters.
+   * Optional: supplementary, so its absence must never discard the V8 numbers.
+   */
+  blinkAllocatedKB?: number
 }

--- a/src/shared/renderer-heap-statistics.ts
+++ b/src/shared/renderer-heap-statistics.ts
@@ -1,0 +1,21 @@
+/**
+ * V8 heap statistics read from the renderer's own process.
+ *
+ * Why this exists rather than `window.performance.memory`: Blink quantizes that
+ * API onto ~100 logarithmic buckets and caches each reading for ~20 minutes as a
+ * Spectre mitigation. Measured here: a renderer climbing 1MB -> 93MB reported an
+ * identical `usedJSHeapSize` on all 7 samples, so heap growth is invisible to it
+ * at any sampling rate. `process.getHeapStatistics()` is exact and uncached, and
+ * works in a sandboxed, context-isolated preload.
+ *
+ * Electron reports these in kilobytes; we keep that unit unconverted here.
+ */
+export type RendererHeapStatistics = {
+  usedHeapKB: number
+  totalHeapKB: number
+  heapLimitKB: number
+  /** Off-heap V8 allocations, which `usedJSHeapSize` never included. */
+  mallocedKB: number
+  /** Blink's own allocator (DOM, layout), invisible to the V8 heap counters. */
+  blinkAllocatedKB: number
+}


### PR DESCRIPTION
## Description

Orca's renderer crash breadcrumbs have always recorded heap size from `window.performance.memory`. Blink both **bucket-quantizes** that API (~100 logarithmic buckets, consecutive ratio `exp(ln 400 / 100)` = 1.06175) and **caches** each reading for ~20 minutes, as a Spectre mitigation.

The practical consequence is stronger than "imprecise": **the metric does not observe heap growth at all.**

This PR reads V8's exact numbers through the preload bridge instead, falling back to `performance.memory` when the bridge is unavailable (web surface, older shell).

## ELI5

We were trying to find a memory leak by watching the fuel gauge. But that gauge only moves in big jumps, and only refreshes every 20 minutes — so it kept reading "tank looks fine" while fuel poured out. This swaps in a gauge that reads the real level.

## Proof of fix

Ran the exact bridge code in a real Electron 43 renderer configured the way Orca configures its own (`sandbox: true`, `contextIsolation: true`, `nodeIntegration: false`), allocating in steps:

| sample | exact `usedHeapMB` | `performance.memory` |
|---|---|---|
| 0 | 1 | 10 |
| 1 | 16 | 10 |
| 3 | 47 | 10 |
| 6 | **93** | **10** |

The real heap climbed **92 MB**. The old metric reported `10` on **all 7 samples**.

### Independent replication

A second agent reproduced the core result with its own harness, its own allocation sizes and sample counts.

- Long-lived renderer, 8 steps x 6 MB of packed doubles: `usedJSHeapSize` stayed **byte-identical (exactly 10,000,000)** across **48.5 MB** of real growth, while `getHeapStatistics()` tracked it to within ~1 MB per step. `totalJSHeapSize` was pinned too.
- Extended run: real heap went **49.7 -> 149.0 -> 1.0 MB** over 110 s; the old metric never moved once across all 31 samples.
- Environment: Electron 43.1.0 / Chromium 150.0.7871.47, `sandboxed: true`, `contextIsolated: true`.

### Correction to an earlier revision of this PR body

An earlier revision cited that agent's **60-fresh-process** run ("real heaps 11.6 -> 102.6 MB, `usedJSHeapSize` identical every time") as the strongest evidence here. **That claim is withdrawn.** The agent identified the flaw itself and I confirmed it by reading its harness (`preload.js:21`): the preload read `performance.memory` at startup, priming each process's cached value at the ~10 MB floor *before* any allocation. It cannot measure bucket ratios or fresh-process behavior.

It remains suggestive of time-caching — a post-allocation read at a 135 MB real heap still returned the value primed at ~1 MB — but it is not the quantization evidence it was presented as. **The case for this PR does not depend on it:** the long-lived-renderer numbers above, plus my own probe (real heap 1 -> 93 MB, `performance.memory` reporting `10` on all 7 samples), establish the defect without that run. My probe's preload does not read `performance.memory`, so it does not share the confound.

I am flagging this rather than quietly editing it because the number was live on this PR for a period and reviewers may have already read it.

### What is and isn't established

- **Directly measured here:** the metric does not reflect real heap growth or shrinkage in a live renderer.
- **From field data (996 crash bundles):** the 16-value quantization ladder, measured consecutive ratio 1.06220 vs Blink's predicted `exp(ln 400 / 100)` = 1.06175.
- **Not independently timed here:** the precise ~20-minute cache interval. Short local runs can only show "no refresh within N minutes." The 20-minute figure comes from Blink's documented `kTwentyMinutesInSeconds` reporting cache and is consistent with the field data's median 14-sample freeze.

### Unit correctness

Electron reports these in KB. Verified empirically rather than assumed — allocating ~64 MB of doubles moved the counter by 98,509:

- read as KB → **96.2 MB** (correct, including array overhead)
- read as bytes → 0.1 MB (absurd)

## Why this matters

Three separate crash investigations tried to localize a suspected renderer memory leak from these bundles and failed. The reason is now clear: the input signal could not express the thing being measured. Prior conclusions drawn from it — leak rate, workload-independence, which container retains memory — do not hold, because they compared a stale, rounded heap number against *live* DOM/store counters.

## Security — no degradation

- **Unreachable from untrusted content.** Browser panes set `webPreferences` with **no `preload` key** (`src/main/browser/browser-manager.ts:172-179`), and guests have no preload at all (`src/main/browser/grab-guest-script.ts:3`). Verified from both the main and renderer side.
- The bridge exposes five integer size readings. No pointers, no addresses, no ASLR-relevant data.
- Sandbox settings are untouched; `getHeapStatistics()` is available *inside* the sandbox, so no privilege is added.
- Callers get `null` rather than an exception if Electron ever drops the API.

## Perf — no degradation (measured)

Benchmarked at 2,000 iterations against a 33 MB heap in a live renderer:

| | per call |
|---|---|
| `readHeapStatistics()` (new) | **1.95 µs** |
| `performance.memory` (old) | 1.15 µs |

**+0.8 µs, once per 60 s.** No GC, no stop-the-world pause — neither API forces collection.

## Trade-offs / user-facing regressions

**No user-facing regressions.** This is diagnostics-only; nothing renders differently.

Two internal behavior changes worth naming:

1. **Highwater threshold denominator changes.** V8 reports a different limit than Blink (4,192 MB vs 3,586 MB in real bundles), so the 60%/80% one-shots fire ~363 MB / ~485 MB later in absolute terms. This is correct: numerator and denominator now come from the same source instead of being mixed. Still one-shot per ratio per session, so no added breadcrumb volume.
2. **`usedHeapMB` changes meaning across versions.** Old bundles carry quantized values, new ones exact. Every sample is therefore tagged `heapSource: 'v8' | 'quantized'` so the two are never silently compared — without it this would be a lasting data-analysis trap.

Also adds `mallocedMB` and `blinkAllocatedMB` (off-heap V8 and Blink/DOM allocations), which the old API never exposed. `compactBreadcrumbData` drops non-finite values, so these fields simply don't appear on the fallback path rather than emitting nulls.

## Adversarial review

**2 loops, independent sub-agents, one real defect found and fixed.**

**Loop 1 (design + security, pre-merge-request):** confirmed the preload is not exposed to untrusted content. Browser panes set `webPreferences` with no `preload` key (`browser-manager.ts:172-179`), guests have none (`grab-guest-script.ts:3`), `createMainWindow.ts:449-474` strips `preload`/`preloadURL`, and `offscreen-browser-backend.ts:34-46` has none. Independently corroborated by a second reviewer. Also verified units, denominator semantics, breadcrumb size, and backward-compat tagging. No defect.

**Loop 2 (post-push):** found one real low-severity defect — `getHeapStatistics()` and `getBlinkMemoryInfo()` shared a single `try`, so a Blink failure would discard the valid V8 statistics and fall back to the quantized `performance.memory` this PR exists to escape. Confirmed by reading the code, then fixed in `7ae6a303a5`: the reads fail independently and `blinkAllocatedKB` is now optional, with a guard against `undefined * 1024` producing a junk `NaN` field.

Worth noting on that fix: my *first* test for it **survived mutation** — 13 passed with and without the guard, because `toMegabytes`/`compactBreadcrumbData` already strip `NaN` downstream. Rather than keep a test that proved nothing, I extracted the reader into `src/preload/renderer-heap-statistics-reader.ts` with an injectable source so the failure is directly reachable, and renamed the renderer test to describe what it actually proves. Reintroducing the shared `try` now fails 1 of 3 tests.

Loop 2 found no other defect.

## Verification

- **16 tests** across `renderer-heap-statistics-reader.test.ts` (3, new) and `crash-diagnostics.test.ts` (13, 5 new): exact-preferred-over-quantized; growth-visible-when-`performance.memory`-is-frozen; V8 read survives Blink failure; null-bridge fallback; older shell missing the bridge entirely.
- **Full suite: 36,250 passed.** The 1 failing file (`src/relay/agent-exec-handler.test.ts`) was confirmed **pre-existing** by stashing these changes and re-running it — fails identically on a clean tree.
- `typecheck` (node + cli + web), `oxlint`, `oxfmt`, `git diff --check` all clean.
- **Mutation-tested** — all four mutants killed: ignore the bridge (2 tests fail), wrong KB→bytes unit (2 fail), always label source `'v8'` (3 fail), shared `try` discarding V8 stats on Blink failure (1 fail).

## What this does NOT do

It does not fix the OOM crashes. It makes the next round of bundles diagnosable. No "leak fix" should ship before exact data comes back from the field, because until then there is no way to tell whether such a fix worked.
