### PR TITLE
fix(ssh): resync after watcher terminal retry

### DIFF
--- a/src/main/ipc/filesystem-watcher-terminal-resync.test.ts
+++ b/src/main/ipc/filesystem-watcher-terminal-resync.test.ts
@@ -38,13 +38,33 @@ const OVERFLOW_PAYLOAD = {
   events: [{ kind: 'overflow', absolutePath: WORKTREE_PATH }]
 }
 
-function createSender(id: number): {
+type MockSender = {
   isDestroyed: () => boolean
   send: ReturnType<typeof vi.fn>
   once: ReturnType<typeof vi.fn>
   id: number
-} {
-  return { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id }
+  destroy: () => void
+}
+
+function createSender(id: number): MockSender {
+  let destroyed = false
+  const destroyedHandlers: (() => void)[] = []
+  return {
+    isDestroyed: () => destroyed,
+    send: vi.fn(),
+    once: vi.fn((event: string, handler: () => void) => {
+      if (event === 'destroyed') {
+        destroyedHandlers.push(handler)
+      }
+    }),
+    id,
+    destroy: () => {
+      destroyed = true
+      for (const handler of destroyedHandlers) {
+        handler()
+      }
+    }
+  }
 }
 
 describe('remote filesystem watcher terminal retry resync', () => {
@@ -269,14 +289,7 @@ describe('remote filesystem watcher terminal retry resync', () => {
   it('cancels a terminal retry when its renderer is destroyed', async () => {
     vi.useFakeTimers()
     vi.spyOn(console, 'warn').mockImplementation(() => {})
-    let destroyed = false
-    const destroyedHandlers: (() => void)[] = []
-    const sender = {
-      isDestroyed: () => destroyed,
-      send: vi.fn(),
-      once: vi.fn((_event: string, handler: () => void) => destroyedHandlers.push(handler)),
-      id: 1
-    }
+    const sender = createSender(1)
     let terminalError: TerminalErrorHandler = () => {}
     const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
       terminalError = options.onTerminalError
@@ -286,8 +299,7 @@ describe('remote filesystem watcher terminal retry resync', () => {
 
     await handlers['fs:watchWorktree']({ sender }, ARGS)
     terminalError(new Error('relay watcher died'))
-    destroyed = true
-    destroyedHandlers[0]?.()
+    sender.destroy()
     await vi.advanceTimersByTimeAsync(60 * 60_000)
 
     expect(watchMock).toHaveBeenCalledTimes(1)

--- a/src/main/ipc/filesystem-watcher-terminal-resync.test.ts
+++ b/src/main/ipc/filesystem-watcher-terminal-resync.test.ts
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, getSshFilesystemProviderMock, providerRegistrationListeners } = vi.hoisted(
+  () => ({
+    handleMock: vi.fn(),
+    getSshFilesystemProviderMock: vi.fn(),
+    providerRegistrationListeners: new Set<(connectionId: string) => void>()
+  })
+)
+
+vi.mock('electron', () => ({ ipcMain: { handle: handleMock } }))
+vi.mock('fs/promises', () => ({ stat: vi.fn() }))
+vi.mock('@parcel/watcher', () => ({ subscribe: vi.fn() }))
+vi.mock('./filesystem-watcher-wsl', () => ({ createWslWatcher: vi.fn() }))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  getSshFilesystemProvider: getSshFilesystemProviderMock,
+  onSshFilesystemProviderRegistered: (listener: (connectionId: string) => void) => {
+    providerRegistrationListeners.add(listener)
+    return () => providerRegistrationListeners.delete(listener)
+  }
+}))
+
+import {
+  closeAllWatchers,
+  closeRemoteWatcherForWorktreePath,
+  forgetRemoteWatcherRemovalSnapshot,
+  registerFilesystemWatcherHandlers,
+  restoreRemoteWatcherAfterFailedRemoval
+} from './filesystem-watcher'
+
+type HandlerMap = Record<string, (_event: unknown, args: unknown) => Promise<unknown> | unknown>
+type TerminalErrorHandler = (error: Error) => void
+
+const WORKTREE_PATH = '/home/me/repo'
+const ARGS = { worktreePath: WORKTREE_PATH, connectionId: 'conn-1' }
+const OVERFLOW_PAYLOAD = {
+  worktreePath: WORKTREE_PATH,
+  events: [{ kind: 'overflow', absolutePath: WORKTREE_PATH }]
+}
+
+function createSender(id: number): {
+  isDestroyed: () => boolean
+  send: ReturnType<typeof vi.fn>
+  once: ReturnType<typeof vi.fn>
+  id: number
+} {
+  return { isDestroyed: () => false, send: vi.fn(), once: vi.fn(), id }
+}
+
+describe('remote filesystem watcher terminal retry resync', () => {
+  const handlers: HandlerMap = {}
+
+  beforeEach(async () => {
+    vi.useRealTimers()
+    handleMock.mockReset()
+    getSshFilesystemProviderMock.mockReset()
+    for (const key of Object.keys(handlers)) {
+      delete handlers[key]
+    }
+    handleMock.mockImplementation((channel, handler) => {
+      handlers[channel] = handler
+    })
+    registerFilesystemWatcherHandlers()
+    await closeAllWatchers()
+  })
+
+  afterEach(async () => {
+    await closeAllWatchers()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('resyncs only owners still watching when the terminal retry installs', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const senderOne = createSender(1)
+    const senderTwo = createSender(2)
+    let terminalError: TerminalErrorHandler = () => {}
+    let resolveRetry: (unwatch: () => void) => void = () => {}
+    const retryInstall = new Promise<() => void>((resolve) => {
+      resolveRetry = resolve
+    })
+    const watchMock = vi
+      .fn()
+      .mockImplementationOnce((_path, _events, options) => {
+        terminalError = options.onTerminalError
+        return Promise.resolve(vi.fn())
+      })
+      .mockReturnValueOnce(retryInstall)
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree']({ sender: senderOne }, ARGS)
+    await handlers['fs:watchWorktree']({ sender: senderTwo }, ARGS)
+    terminalError(new Error('relay watcher died'))
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(watchMock).toHaveBeenCalledTimes(2)
+
+    handlers['fs:unwatchWorktree']({ sender: senderOne }, ARGS)
+    resolveRetry(vi.fn())
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(senderOne.send).not.toHaveBeenCalled()
+    expect(senderTwo.send).toHaveBeenCalledTimes(1)
+    expect(senderTwo.send).toHaveBeenCalledWith('fs:changed', OVERFLOW_PAYLOAD)
+
+    terminalError(new Error('late stale failure'))
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(watchMock).toHaveBeenCalledTimes(2)
+    expect(senderTwo.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not resync a fast retry for an initial setup failure', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    const watchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('provider not ready'))
+      .mockResolvedValueOnce(vi.fn())
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(watchMock).toHaveBeenCalledTimes(2)
+    expect(sender.send).not.toHaveBeenCalled()
+  })
+
+  it('lets provider registration supersede a pending terminal retry', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    let terminalError: TerminalErrorHandler = () => {}
+    const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalError = options.onTerminalError
+      return Promise.resolve(vi.fn())
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    terminalError(new Error('old relay watcher died'))
+    for (const listener of providerRegistrationListeners) {
+      listener('conn-1')
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(watchMock).toHaveBeenCalledTimes(2)
+    expect(sender.send).toHaveBeenCalledTimes(1)
+    expect(sender.send).toHaveBeenCalledWith('fs:changed', OVERFLOW_PAYLOAD)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(watchMock).toHaveBeenCalledTimes(2)
+    expect(sender.send).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a terminal retry when the last owner unwatches', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    let terminalError: TerminalErrorHandler = () => {}
+    const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalError = options.onTerminalError
+      return Promise.resolve(vi.fn())
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    terminalError(new Error('relay watcher died'))
+    handlers['fs:unwatchWorktree']({ sender }, ARGS)
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+
+    expect(watchMock).toHaveBeenCalledTimes(1)
+    expect(sender.send).not.toHaveBeenCalled()
+  })
+
+  it('cancels a terminal retry when its renderer is destroyed', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let destroyed = false
+    const destroyedHandlers: (() => void)[] = []
+    const sender = {
+      isDestroyed: () => destroyed,
+      send: vi.fn(),
+      once: vi.fn((_event: string, handler: () => void) => destroyedHandlers.push(handler)),
+      id: 1
+    }
+    let terminalError: TerminalErrorHandler = () => {}
+    const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalError = options.onTerminalError
+      return Promise.resolve(vi.fn())
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    terminalError(new Error('relay watcher died'))
+    destroyed = true
+    destroyedHandlers[0]?.()
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+
+    expect(watchMock).toHaveBeenCalledTimes(1)
+    expect(sender.send).not.toHaveBeenCalled()
+  })
+
+  it('does not retry a terminal callback raised during destructive removal', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    let terminalError: TerminalErrorHandler = () => {}
+    let resolveClose: () => void = () => {}
+    const closeWatch = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveClose = resolve
+        })
+    )
+    const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalError = options.onTerminalError
+      return Promise.resolve(vi.fn())
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock, closeWatch })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    const close = closeRemoteWatcherForWorktreePath('conn-1', WORKTREE_PATH)
+    await Promise.resolve()
+    terminalError(new Error('close terminated watcher'))
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(watchMock).toHaveBeenCalledTimes(1)
+    expect(sender.send).not.toHaveBeenCalled()
+
+    resolveClose()
+    await close
+    forgetRemoteWatcherRemovalSnapshot('conn-1', WORKTREE_PATH)
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(watchMock).toHaveBeenCalledTimes(1)
+    expect(sender.send).not.toHaveBeenCalled()
+  })
+
+  it('restores once after removal teardown rejects with a terminal callback', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    let terminalError: TerminalErrorHandler = () => {}
+    let rejectClose: (error: Error) => void = () => {}
+    const closeWatch = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectClose = reject
+        })
+    )
+    const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalError = options.onTerminalError
+      return Promise.resolve(vi.fn())
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock, closeWatch })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    const close = closeRemoteWatcherForWorktreePath('conn-1', WORKTREE_PATH)
+    await Promise.resolve()
+    terminalError(new Error('close terminated watcher'))
+    rejectClose(new Error('close failed'))
+    await expect(close).rejects.toThrow('close failed')
+    await restoreRemoteWatcherAfterFailedRemoval('conn-1', WORKTREE_PATH)
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(watchMock).toHaveBeenCalledTimes(2)
+    expect(sender.send).toHaveBeenCalledTimes(1)
+    expect(sender.send).toHaveBeenCalledWith('fs:changed', OVERFLOW_PAYLOAD)
+  })
+
+  it('does not carry a shutdown terminal callback into a reopened lifecycle', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    let terminalError: TerminalErrorHandler = () => {}
+    const initialWatch = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalError = options.onTerminalError
+      return Promise.resolve(() => terminalError(new Error('shutdown terminated watcher')))
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: initialWatch })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    await closeAllWatchers()
+
+    const reopenedWatch = vi.fn().mockResolvedValue(vi.fn())
+    getSshFilesystemProviderMock.mockReturnValue({ watch: reopenedWatch })
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(initialWatch).toHaveBeenCalledTimes(1)
+    expect(reopenedWatch).toHaveBeenCalledTimes(1)
+    expect(sender.send).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/filesystem-watcher-terminal-resync.test.ts
+++ b/src/main/ipc/filesystem-watcher-terminal-resync.test.ts
@@ -153,6 +153,79 @@ describe('remote filesystem watcher terminal retry resync', () => {
     expect(sender.send).toHaveBeenCalledTimes(1)
   })
 
+  it('aborts an in-flight terminal retry when a replacement provider registers', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    let terminalError: TerminalErrorHandler = () => {}
+    let retrySignal: AbortSignal | undefined
+    let resolveRetry: (unwatch: () => void) => void = () => {}
+    const retryInstall = new Promise<() => void>((resolve) => {
+      resolveRetry = resolve
+    })
+    const retryUnwatch = vi.fn()
+    const staleWatch = vi
+      .fn()
+      .mockImplementationOnce((_path, _events, options) => {
+        terminalError = options.onTerminalError
+        return Promise.resolve(vi.fn())
+      })
+      .mockImplementationOnce((_path, _events, options) => {
+        retrySignal = options.signal
+        return retryInstall
+      })
+    const replacementWatch = vi.fn().mockResolvedValue(vi.fn())
+    getSshFilesystemProviderMock.mockReturnValue({ watch: staleWatch })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    terminalError(new Error('old relay watcher died'))
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(staleWatch).toHaveBeenCalledTimes(2)
+
+    getSshFilesystemProviderMock.mockReturnValue({ watch: replacementWatch })
+    for (const listener of providerRegistrationListeners) {
+      listener('conn-1')
+    }
+    expect(retrySignal?.aborted).toBe(true)
+
+    resolveRetry(retryUnwatch)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(retryUnwatch).toHaveBeenCalledTimes(1)
+    expect(replacementWatch).toHaveBeenCalledTimes(1)
+    expect(sender.send).toHaveBeenCalledTimes(1)
+    expect(sender.send).toHaveBeenCalledWith('fs:changed', OVERFLOW_PAYLOAD)
+  })
+
+  it('coalesces repeated terminal recovery resyncs with a trailing refresh', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    const terminalErrors: TerminalErrorHandler[] = []
+    const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalErrors.push(options.onTerminalError)
+      return Promise.resolve(vi.fn())
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    terminalErrors[0]?.(new Error('first watcher failure'))
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(sender.send).toHaveBeenCalledTimes(1)
+
+    terminalErrors[1]?.(new Error('second watcher failure'))
+    await vi.advanceTimersByTimeAsync(1_000)
+    terminalErrors[2]?.(new Error('third watcher failure'))
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(watchMock).toHaveBeenCalledTimes(4)
+    expect(sender.send).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(3_000)
+    expect(sender.send).toHaveBeenCalledTimes(2)
+    expect(sender.send).toHaveBeenLastCalledWith('fs:changed', OVERFLOW_PAYLOAD)
+  })
+
   it('cancels a terminal retry when the last owner unwatches', async () => {
     vi.useFakeTimers()
     vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -167,6 +240,26 @@ describe('remote filesystem watcher terminal retry resync', () => {
     await handlers['fs:watchWorktree']({ sender }, ARGS)
     terminalError(new Error('relay watcher died'))
     handlers['fs:unwatchWorktree']({ sender }, ARGS)
+    await vi.advanceTimersByTimeAsync(60 * 60_000)
+
+    expect(watchMock).toHaveBeenCalledTimes(1)
+    expect(sender.send).not.toHaveBeenCalled()
+  })
+
+  it('cancels a terminal retry when removal forgets the watcher snapshot', async () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const sender = createSender(1)
+    let terminalError: TerminalErrorHandler = () => {}
+    const watchMock = vi.fn().mockImplementation((_path, _events, options) => {
+      terminalError = options.onTerminalError
+      return Promise.resolve(vi.fn())
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ watch: watchMock })
+
+    await handlers['fs:watchWorktree']({ sender }, ARGS)
+    terminalError(new Error('relay watcher died'))
+    forgetRemoteWatcherRemovalSnapshot('conn-1', WORKTREE_PATH)
     await vi.advanceTimersByTimeAsync(60 * 60_000)
 
     expect(watchMock).toHaveBeenCalledTimes(1)

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -1273,9 +1273,17 @@ function handleRemoteWatcherTerminalError(
   }
   remoteWatchers.delete(key)
   console.warn(`[filesystem-watcher] SSH watcher terminated for ${key}:`, error)
-  for (const listener of state.listeners.values()) {
-    scheduleRemoteWatcherRetry(listener, connectionId, worktreePath)
+  if (remoteWatchersClosed || suspendedRemoteWatcherListeners.has(key)) {
+    return
   }
+  const startedAt = Date.now()
+  for (const listener of state.listeners.values()) {
+    scheduleRemoteWatcherRetry(listener, connectionId, worktreePath, startedAt, true)
+  }
+}
+
+function isCurrentDesiredRemoteWatcher(key: string, listener: WebContents): boolean {
+  return desiredRemoteWatchers.get(key)?.listeners.get(listener.id) === listener
 }
 
 function scheduleRemoteWatcherRetry(
@@ -1310,7 +1318,7 @@ function scheduleRemoteWatcherRetry(
     loggedUnavailableRemoteWatchers.delete(key)
     // Why: handler already resolved so the renderer thinks the watch is live; emit overflow to force a manual refresh instead of waiting forever.
     for (const listener of retry.listeners.values()) {
-      if (listener.isDestroyed()) {
+      if (listener.isDestroyed() || !isCurrentDesiredRemoteWatcher(key, listener)) {
         continue
       }
       console.warn(
@@ -1330,7 +1338,7 @@ function scheduleRemoteWatcherRetry(
     pendingRemoteWatcherRetries.delete(key)
     pendingRemoteWatcherRetryListeners.delete(key)
     const listeners = Array.from(retry.listeners.values()).filter(
-      (listener) => !listener.isDestroyed()
+      (listener) => !listener.isDestroyed() && isCurrentDesiredRemoteWatcher(key, listener)
     )
     void Promise.all(
       listeners.map((listener) => installRemoteWatcher(listener, connectionId, worktreePath))
@@ -1338,7 +1346,11 @@ function scheduleRemoteWatcherRetry(
       .then((results) => {
         if (retry.resyncOnInstall) {
           for (const [index, listener] of listeners.entries()) {
-            if (results[index] === 'installed' && !listener.isDestroyed()) {
+            if (
+              results[index] === 'installed' &&
+              !listener.isDestroyed() &&
+              isCurrentDesiredRemoteWatcher(key, listener)
+            ) {
               listener.send('fs:changed', {
                 worktreePath,
                 events: [{ kind: 'overflow', absolutePath: worktreePath }]
@@ -1564,7 +1576,11 @@ async function rearmDormantRemoteWatcher(
     return
   }
   for (const [index, listener] of listeners.entries()) {
-    if (results[index] !== 'installed' || listener.isDestroyed()) {
+    if (
+      results[index] !== 'installed' ||
+      listener.isDestroyed() ||
+      !isCurrentDesiredRemoteWatcher(key, listener)
+    ) {
       continue
     }
     listener.send('fs:changed', {
@@ -1637,7 +1653,11 @@ function reinstallRemoteWatchersForConnection(connectionId: string): void {
     )
       .then((results) => {
         for (const [index, listener] of listeners.entries()) {
-          if (results[index] !== 'installed' || listener.isDestroyed()) {
+          if (
+            results[index] !== 'installed' ||
+            listener.isDestroyed() ||
+            !isCurrentDesiredRemoteWatcher(key, listener)
+          ) {
             continue
           }
           // Why: events between the transport dropping and this reinstall are gone for good;

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -913,6 +913,13 @@ const pendingRemoteWatcherRetryListeners = new Map<
   string,
   { listeners: Map<number, WebContents>; startedAt: number; resyncOnInstall: boolean }
 >()
+type RemoteWatcherResyncState = {
+  lastSentAt: number
+  listeners: Map<number, WebContents>
+  timer?: ReturnType<typeof setTimeout>
+  worktreePath: string
+}
+const remoteWatcherResyncStates = new Map<string, RemoteWatcherResyncState>()
 // Why: last-listener cleanup aborts relay setup; late success is unwatched rather than installed after the renderer stopped watching.
 const inFlightRemoteInstalls = new Map<string, RemoteWatcherInstallToken>()
 // Why: dedupe concurrent installRemoteWatcher calls per key so overlapping watches share one watcher instead of clobbering per-key state.
@@ -924,6 +931,8 @@ let remoteWatcherLifecycleGeneration = 0
 let unsubscribeFromProviderRegistrations: (() => void) | null = null
 const REMOTE_WATCH_RETRY_MS = 1_000
 const REMOTE_WATCH_RETRY_TIMEOUT_MS = 60_000
+// Why: preserve the first and latest resync while bounding full-tree SSH refreshes during flaps.
+const REMOTE_WATCH_RESYNC_COALESCE_MS = 5_000
 // Why: doubling from a minute to a half-hour ceiling costs a permanently broken remote ~7 fs.watch
 // calls in the first hour and 2/hour after, which a flapping link can absorb.
 const REMOTE_WATCH_DORMANT_RETRY_MS = 60_000
@@ -953,6 +962,7 @@ export async function closeRemoteWatcherForWorktreePath(
   if (suspended.listeners.size > 0) {
     suspendedRemoteWatcherListeners.set(key, suspended)
   }
+  clearRemoteWatcherResync(key)
   const retryTimer = pendingRemoteWatcherRetries.get(key)
   if (retryTimer) {
     clearTimeout(retryTimer)
@@ -1006,6 +1016,13 @@ export function forgetRemoteWatcherRemovalSnapshot(
 ): void {
   const key = remoteWatcherKey(connectionId, worktreePath)
   suspendedRemoteWatcherListeners.delete(key)
+  clearRemoteWatcherResync(key)
+  const retryTimer = pendingRemoteWatcherRetries.get(key)
+  if (retryTimer) {
+    clearTimeout(retryTimer)
+    pendingRemoteWatcherRetries.delete(key)
+  }
+  pendingRemoteWatcherRetryListeners.delete(key)
   // Why: the worktree is gone — keeping the intent lets a reconnect landing before the renderer's
   // unwatch re-watch a deleted path (60s of retries against the host, then a bogus overflow).
   desiredRemoteWatchers.delete(key)
@@ -1286,6 +1303,84 @@ function isCurrentDesiredRemoteWatcher(key: string, listener: WebContents): bool
   return desiredRemoteWatchers.get(key)?.listeners.get(listener.id) === listener
 }
 
+function clearRemoteWatcherResync(key: string): void {
+  const state = remoteWatcherResyncStates.get(key)
+  if (state?.timer) {
+    clearTimeout(state.timer)
+  }
+  remoteWatcherResyncStates.delete(key)
+}
+
+function flushRemoteWatcherResync(key: string): void {
+  const state = remoteWatcherResyncStates.get(key)
+  if (!state) {
+    return
+  }
+  state.timer = undefined
+  if (
+    remoteWatchersClosed ||
+    suspendedRemoteWatcherListeners.has(key) ||
+    !remoteWatchers.has(key)
+  ) {
+    if (!desiredRemoteWatchers.has(key)) {
+      remoteWatcherResyncStates.delete(key)
+    }
+    return
+  }
+  let sent = false
+  for (const listener of state.listeners.values()) {
+    if (listener.isDestroyed() || !isCurrentDesiredRemoteWatcher(key, listener)) {
+      continue
+    }
+    try {
+      listener.send('fs:changed', {
+        worktreePath: state.worktreePath,
+        events: [{ kind: 'overflow', absolutePath: state.worktreePath }]
+      } satisfies FsChangedPayload)
+      sent = true
+    } catch (error) {
+      console.warn(`[filesystem-watcher] failed to send SSH watcher resync for ${key}:`, error)
+    }
+  }
+  state.listeners.clear()
+  if (sent) {
+    state.lastSentAt = Date.now()
+  } else {
+    remoteWatcherResyncStates.delete(key)
+  }
+}
+
+function requestRemoteWatcherResync(
+  key: string,
+  worktreePath: string,
+  listeners: Iterable<WebContents>
+): void {
+  const state = remoteWatcherResyncStates.get(key) ?? {
+    lastSentAt: Number.NEGATIVE_INFINITY,
+    listeners: new Map<number, WebContents>(),
+    worktreePath
+  }
+  state.worktreePath = worktreePath
+  for (const listener of listeners) {
+    if (!listener.isDestroyed() && isCurrentDesiredRemoteWatcher(key, listener)) {
+      state.listeners.set(listener.id, listener)
+    }
+  }
+  if (state.listeners.size === 0) {
+    return
+  }
+  remoteWatcherResyncStates.set(key, state)
+  const delayMs = Math.max(0, state.lastSentAt + REMOTE_WATCH_RESYNC_COALESCE_MS - Date.now())
+  if (delayMs === 0) {
+    flushRemoteWatcherResync(key)
+    return
+  }
+  if (!state.timer) {
+    state.timer = setTimeout(() => flushRemoteWatcherResync(key), delayMs)
+    state.timer.unref?.()
+  }
+}
+
 function scheduleRemoteWatcherRetry(
   sender: WebContents,
   connectionId: string,
@@ -1316,6 +1411,7 @@ function scheduleRemoteWatcherRetry(
     pendingRemoteWatcherRetries.delete(key)
     pendingRemoteWatcherRetryListeners.delete(key)
     loggedUnavailableRemoteWatchers.delete(key)
+    clearRemoteWatcherResync(key)
     // Why: handler already resolved so the renderer thinks the watch is live; emit overflow to force a manual refresh instead of waiting forever.
     for (const listener of retry.listeners.values()) {
       if (listener.isDestroyed() || !isCurrentDesiredRemoteWatcher(key, listener)) {
@@ -1345,18 +1441,11 @@ function scheduleRemoteWatcherRetry(
     )
       .then((results) => {
         if (retry.resyncOnInstall) {
-          for (const [index, listener] of listeners.entries()) {
-            if (
-              results[index] === 'installed' &&
-              !listener.isDestroyed() &&
-              isCurrentDesiredRemoteWatcher(key, listener)
-            ) {
-              listener.send('fs:changed', {
-                worktreePath,
-                events: [{ kind: 'overflow', absolutePath: worktreePath }]
-              } satisfies FsChangedPayload)
-            }
-          }
+          requestRemoteWatcherResync(
+            key,
+            worktreePath,
+            listeners.filter((_, index) => results[index] === 'installed')
+          )
         }
         // Why: don't re-arm on 'cancelled' (renderer stopped watching) — it would fire a stale overflow when the 60s window expires.
         if (results.some((result) => result === 'unavailable')) {
@@ -1500,6 +1589,7 @@ function forgetDesiredRemoteWatcher(key: string, senderId: number): void {
   desired.listeners.delete(senderId)
   if (desired.listeners.size === 0) {
     desiredRemoteWatchers.delete(key)
+    clearRemoteWatcherResync(key)
     clearDormantRemoteWatcher(key)
   }
 }
@@ -1575,19 +1665,11 @@ async function rearmDormantRemoteWatcher(
     scheduleDormantRemoteWatcherRearm(connectionId, worktreePath, nextDormantDelayMs(delayMs))
     return
   }
-  for (const [index, listener] of listeners.entries()) {
-    if (
-      results[index] !== 'installed' ||
-      listener.isDestroyed() ||
-      !isCurrentDesiredRemoteWatcher(key, listener)
-    ) {
-      continue
-    }
-    listener.send('fs:changed', {
-      worktreePath,
-      events: [{ kind: 'overflow', absolutePath: worktreePath }]
-    } satisfies FsChangedPayload)
-  }
+  requestRemoteWatcherResync(
+    key,
+    worktreePath,
+    listeners.filter((_, index) => results[index] === 'installed')
+  )
   // Why: 'cancelled' means shutdown or the last listener left, so only 'unavailable' stays dormant.
   if (results.some((result) => result === 'unavailable')) {
     scheduleDormantRemoteWatcherRearm(connectionId, worktreePath, nextDormantDelayMs(delayMs))
@@ -1641,6 +1723,13 @@ function reinstallRemoteWatchersForConnection(connectionId: string): void {
       pendingRemoteWatcherRetries.delete(key)
       pendingRemoteWatcherRetryListeners.delete(key)
     }
+    // Why: a pending watch belongs to the replaced transport; joiners must retry on the new provider.
+    const inFlight = inFlightRemoteInstalls.get(key)
+    if (inFlight) {
+      inFlight.listeners.clear()
+      inFlight.cancelled = true
+      inFlight.abortController.abort()
+    }
     // Why: this reinstall supersedes the pending backoff; leaving it armed double-installs the key.
     clearDormantRemoteWatcher(key)
     loggedUnavailableRemoteWatchers.delete(key)
@@ -1652,21 +1741,12 @@ function reinstallRemoteWatchersForConnection(connectionId: string): void {
       )
     )
       .then((results) => {
-        for (const [index, listener] of listeners.entries()) {
-          if (
-            results[index] !== 'installed' ||
-            listener.isDestroyed() ||
-            !isCurrentDesiredRemoteWatcher(key, listener)
-          ) {
-            continue
-          }
-          // Why: events between the transport dropping and this reinstall are gone for good;
-          // overflow is the existing "resync, I can't tell you what changed" signal.
-          listener.send('fs:changed', {
-            worktreePath: desired.worktreePath,
-            events: [{ kind: 'overflow', absolutePath: desired.worktreePath }]
-          } satisfies FsChangedPayload)
-        }
+        // Why: events between the transport dropping and this reinstall are gone for good.
+        requestRemoteWatcherResync(
+          key,
+          desired.worktreePath,
+          listeners.filter((_, index) => results[index] === 'installed')
+        )
         if (results.some((result) => result === 'unavailable')) {
           for (const listener of listeners) {
             scheduleRemoteWatcherRetry(
@@ -1721,6 +1801,12 @@ export async function closeAllWatchers(): Promise<void> {
   }
   pendingRemoteWatcherRetries.clear()
   pendingRemoteWatcherRetryListeners.clear()
+  for (const state of remoteWatcherResyncStates.values()) {
+    if (state.timer) {
+      clearTimeout(state.timer)
+    }
+  }
+  remoteWatcherResyncStates.clear()
   for (const dormant of dormantRemoteWatchers.values()) {
     clearTimeout(dormant.timer)
   }

--- a/src/main/ipc/filesystem-watcher.ts
+++ b/src/main/ipc/filesystem-watcher.ts
@@ -1289,10 +1289,10 @@ function handleRemoteWatcherTerminalError(
     return
   }
   remoteWatchers.delete(key)
-  console.warn(`[filesystem-watcher] SSH watcher terminated for ${key}:`, error)
   if (remoteWatchersClosed || suspendedRemoteWatcherListeners.has(key)) {
     return
   }
+  console.warn(`[filesystem-watcher] SSH watcher terminated for ${key}:`, error)
   const startedAt = Date.now()
   for (const listener of state.listeners.values()) {
     scheduleRemoteWatcherRetry(listener, connectionId, worktreePath, startedAt, true)


### PR DESCRIPTION
## Summary

- Resyncs current SSH watcher owners with an overflow event after a terminal-error retry successfully reinstalls the watcher.
- Filters stale owners and suppresses retries across unwatch, renderer destruction, destructive removal, shutdown, and reopen races.
- Preserves provider-registration supersession and existing dormant/reconnect behavior for #10445 and #10470.

## Test plan

- Five focused watcher files: 47/47 tests passed.
- Touched-file oxlint passed.
- pnpm run typecheck:node passed.
- pnpm run check:max-lines-ratchet passed.
- git diff --check passed.

## Release-scan provenance

This PR addresses the pre-existing prod-release-scan P2 finding "SSH watcher fast-retry without overflow resync" documented in /private/tmp/prod-release-worker-reports/FINAL.md and platform.md. Nearby behavior and context are tracked in https://github.com/stablyai/orca/pull/10445 and https://github.com/stablyai/orca/pull/10470.