### PR TITLE
fix(sidebar): make Cmd/Ctrl+1-9 match the rendered card order when the sidebar is closed

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -218,7 +218,6 @@ import {
 } from './worktree-multi-selection'
 import { persistWorktreeSortOrderByHost } from '@/lib/worktree-sort-order-persistence'
 import {
-  ALL_EXECUTION_HOSTS_SCOPE,
   getRepoExecutionHostId,
   getSettingsFocusedExecutionHostId,
   getWorktreeExecutionHostId,
@@ -293,9 +292,10 @@ import {
   sidebarWorkspaceStillExists
 } from './worktree-list-folder-reveal'
 import {
+  filterFolderWorkspacesForVisibleHosts,
+  filterProjectGroupsForVisibleHosts,
   getFolderPathStatusRouteOptionsForRows,
-  getFolderWorkspaceExecutionHostIdForRows,
-  getProjectGroupExecutionHostIdForRows
+  getVisibleSidebarHostIdSet
 } from './worktree-list-host-filtering'
 import { getFolderWorkspaceCardPrDisplay } from './folder-workspace-card-pr-display'
 import {
@@ -5596,12 +5596,10 @@ const WorktreeList = React.memo(function WorktreeList({
     worktreeMap
   ])
   const defaultHostId = getSettingsFocusedExecutionHostId(settings)
-  const visibleHostIdSet = useMemo(() => {
-    const visibleHostIds =
-      visibleWorkspaceHostIds ??
-      (workspaceHostScope === ALL_EXECUTION_HOSTS_SCOPE ? null : [workspaceHostScope])
-    return visibleHostIds ? new Set<ExecutionHostId>(visibleHostIds) : null
-  }, [visibleWorkspaceHostIds, workspaceHostScope])
+  const visibleHostIdSet = useMemo(
+    () => getVisibleSidebarHostIdSet(visibleWorkspaceHostIds, workspaceHostScope),
+    [visibleWorkspaceHostIds, workspaceHostScope]
+  )
   const visibleReposForRows = useMemo(() => {
     if (!visibleHostIdSet) {
       return repos
@@ -5612,29 +5610,20 @@ const WorktreeList = React.memo(function WorktreeList({
       return visibleHostIdSet.has(hostId)
     })
   }, [defaultHostId, repos, visibleHostIdSet])
-  const visibleProjectGroupsForRows = useMemo(() => {
-    if (!visibleHostIdSet) {
-      return projectGroups
-    }
-    return projectGroups.filter((group) => {
-      const hostId = getProjectGroupExecutionHostIdForRows(group, defaultHostId)
-      return visibleHostIdSet.has(hostId)
-    })
-  }, [defaultHostId, projectGroups, visibleHostIdSet])
-  const visibleFolderWorkspacesForRows = useMemo(() => {
-    if (!visibleHostIdSet) {
-      return folderWorkspaces
-    }
-    const projectGroupById = new Map(projectGroups.map((group) => [group.id, group]))
-    return folderWorkspaces.filter((folderWorkspace) => {
-      const hostId = getFolderWorkspaceExecutionHostIdForRows({
-        folderWorkspace,
-        projectGroup: projectGroupById.get(folderWorkspace.projectGroupId),
+  const visibleProjectGroupsForRows = useMemo(
+    () => filterProjectGroupsForVisibleHosts(projectGroups, visibleHostIdSet, defaultHostId),
+    [defaultHostId, projectGroups, visibleHostIdSet]
+  )
+  const visibleFolderWorkspacesForRows = useMemo(
+    () =>
+      filterFolderWorkspacesForVisibleHosts(
+        folderWorkspaces,
+        projectGroups,
+        visibleHostIdSet,
         defaultHostId
-      })
-      return visibleHostIdSet.has(hostId)
-    })
-  }, [defaultHostId, folderWorkspaces, projectGroups, visibleHostIdSet])
+      ),
+    [defaultHostId, folderWorkspaces, projectGroups, visibleHostIdSet]
+  )
   const repoOrder = useMemo(() => {
     return getLogicalRepoOrderRankById(repos.map((repo) => repo.id))
   }, [repos])
@@ -5955,8 +5944,8 @@ const WorktreeList = React.memo(function WorktreeList({
   // Why layout effect: the Cmd/Ctrl+1–9 handler can fire right after commit; publishing after paint would leave the shortcut cache stale.
   useLayoutEffect(() => {
     setVisibleWorktreeIds(renderedWorktreeIds)
-    // Why: unmounting the list clears the rendered-order cache so shortcuts fall back to the live store snapshot.
-    return () => setVisibleWorktreeIds([])
+    // Why null, not []: [] is a real rendered order (all collapsed/filtered); null tells shortcuts the list is unmounted.
+    return () => setVisibleWorktreeIds(null)
   }, [renderedWorktreeIds])
 
   const handleCreateForRepo = useCallback(

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest'
-import { computeRenderedSidebarWorktreeOrder } from './rendered-sidebar-worktree-order'
+import { afterEach, describe, expect, it } from 'vitest'
+import { useAppStore } from '@/store'
+import { getVisibleWorktreeIds, setVisibleWorktreeIds } from './visible-worktrees'
 import type { AppState } from '@/store/types'
-import type { Repo, Worktree } from '../../../../shared/types'
+import type { FolderWorkspace, ProjectGroup, Repo, Worktree } from '../../../../shared/types'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+
+const initialState = useAppStore.getInitialState()
 
 function makeWorktree(id: string, overrides: Partial<Worktree> = {}): Worktree {
   return {
@@ -26,93 +30,213 @@ function makeWorktree(id: string, overrides: Partial<Worktree> = {}): Worktree {
   } as Worktree
 }
 
-function makeRepo(id = 'repo1'): Repo {
-  return { id, name: id, path: `/tmp/${id}`, defaultBranch: 'main' } as unknown as Repo
+function makeMainWorktree(id: string, overrides: Partial<Worktree> = {}): Worktree {
+  return makeWorktree(id, { isMainWorktree: true, branch: 'refs/heads/main', ...overrides })
 }
 
-/** Minimal store snapshot: only the fields the rendered-order pipeline reads. */
-function makeState(worktrees: Worktree[], overrides: Partial<AppState> = {}): AppState {
+function makeRepo(id = 'repo1', overrides: Partial<Repo> = {}): Repo {
   return {
-    repos: [makeRepo()],
-    worktreesByRepo: { repo1: worktrees },
-    groupBy: 'repo',
-    sortBy: 'manual',
-    projectOrderBy: 'manual',
-    collapsedGroups: new Set<string>(),
-    workspaceStatuses: [],
-    worktreeLineageById: {},
-    folderWorkspaces: [],
-    projectGroups: [],
-    settings: null,
-    prCache: null,
-    workspaceHostScope: 'all',
-    visibleWorkspaceHostIds: null,
-    workspaceHostOrder: [],
-    sshTargetLabels: new Map(),
-    sshConnectionStates: new Map(),
-    runtimeEnvironments: [],
-    runtimeStatusByEnvironmentId: new Map(),
-    projectHostSetups: [],
+    id,
+    name: id,
+    path: `/tmp/${id}`,
+    defaultBranch: 'main',
+    connectionId: null,
     ...overrides
-  } as unknown as AppState
+  } as unknown as Repo
 }
 
-describe('computeRenderedSidebarWorktreeOrder', () => {
-  it('hoists the main worktree ahead of a higher-ranked child, like the rendered sidebar (#9497)', () => {
-    // The flat fallback preserved membership order; the sidebar anchors the repo's
-    // main workspace first, so Cmd+1 used to land on the wrong card.
-    const feature = makeWorktree('wt-feature')
-    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
-    const state = makeState([feature, main])
+function makeProjectGroup(id: string, overrides: Partial<ProjectGroup> = {}): ProjectGroup {
+  return {
+    id,
+    name: id,
+    parentPath: `/tmp/${id}`,
+    connectionId: null,
+    parentGroupId: null,
+    createdFrom: 'folder-scan',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  } as ProjectGroup
+}
 
-    expect(computeRenderedSidebarWorktreeOrder(state, [feature, main])).toEqual([
-      'wt-main',
-      'wt-feature'
-    ])
+function makeFolderWorkspace(id: string, projectGroupId: string): FolderWorkspace {
+  return {
+    id,
+    projectGroupId,
+    name: id,
+    folderPath: `/tmp/${id}`,
+    connectionId: null,
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+/**
+ * Seeds the store with the fields the closed-sidebar order reads, then drops the
+ * published order so getVisibleWorktreeIds() must recompute it.
+ */
+function seedStore(worktrees: Worktree[], overrides: Partial<AppState> = {}): void {
+  useAppStore.setState(
+    {
+      ...initialState,
+      repos: [makeRepo()],
+      worktreesByRepo: { repo1: worktrees },
+      // Why showSleepingWorkspaces: fixtures have no PTYs, so the activity filter
+      // would otherwise drop every workspace before ordering runs.
+      showSleepingWorkspaces: true,
+      groupBy: 'repo',
+      sortBy: 'manual',
+      ...overrides
+    } as AppState,
+    true
+  )
+  setVisibleWorktreeIds(null)
+}
+
+describe('closed-sidebar Cmd+1-9 ordering (#9497)', () => {
+  afterEach(() => {
+    setVisibleWorktreeIds(null)
+    useAppStore.setState(initialState, true)
   })
 
-  it('omits workspaces in a collapsed group, which render no card and so own no number', () => {
-    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
+  it('hoists the repo main worktree first, matching the rendered sidebar', () => {
+    // Manual sort ranks by sortOrder descending, so the base sort puts the feature
+    // workspace first; only the repo grouping layer hoists main ahead of it.
+    const feature = makeWorktree('wt-feature', { sortOrder: 1 })
+    const main = makeMainWorktree('wt-main', { sortOrder: 0 })
+    seedStore([feature, main])
+
+    const order = getVisibleWorktreeIds()
+
+    expect(order).toEqual(['wt-main', 'wt-feature'])
+    // The pre-fix flat fallback returned membership order and numbered the wrong card.
+    expect(order).not.toEqual(['wt-feature', 'wt-main'])
+  })
+
+  it('places a pinned workspace per the pinned section under both display policies', () => {
+    const main = makeMainWorktree('wt-main')
+    const plain = makeWorktree('wt-plain')
+    const pinned = makeWorktree('wt-pinned', { isPinned: true })
+
+    for (const showPinnedWorktreesInGroups of [false, true]) {
+      seedStore([main, plain, pinned], {
+        settings: { showPinnedWorktreesInGroups } as AppState['settings']
+      })
+
+      const order = getVisibleWorktreeIds()
+
+      // Each workspace owns exactly one ordinal even when pinning duplicates its row.
+      expect(order).toEqual([...new Set(order)])
+      expect([...order].sort()).toEqual(['wt-main', 'wt-pinned', 'wt-plain'])
+      expect(order[0]).toBe(showPinnedWorktreesInGroups ? 'wt-main' : 'wt-pinned')
+    }
+  })
+
+  it('elides members of a collapsed group, which render no card to number', () => {
+    const main = makeMainWorktree('wt-main')
     const feature = makeWorktree('wt-feature')
-    // Legacy repos project to a synthetic project group, so that is the collapse key.
-    const state = makeState([main, feature], {
-      collapsedGroups: new Set(['project:repo:repo1'])
+    seedStore([main, feature], { collapsedGroups: new Set(['project:repo:repo1']) })
+
+    expect(getVisibleWorktreeIds()).toEqual([])
+  })
+
+  it('numbers folder workspaces, which the flat fallback omitted entirely', () => {
+    const group = makeProjectGroup('group-1')
+    const folderWorkspace = makeFolderWorkspace('fw-1', group.id)
+    seedStore([makeMainWorktree('wt-main')], {
+      projectGroups: [group],
+      folderWorkspaces: [folderWorkspace]
     })
 
-    expect(computeRenderedSidebarWorktreeOrder(state, [main, feature])).toEqual([])
+    expect(getVisibleWorktreeIds()).toContain(folderWorkspaceKey(folderWorkspace.id))
   })
 
-  it('numbers a workspace created while the sidebar was closed', () => {
-    // A retained-cache fix cannot do this: it can only ever remove stale ids.
-    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
-    const created = makeWorktree('wt-new')
-    const state = makeState([main, created])
+  it('numbers a workspace created while nothing was published', () => {
+    // A retained-cache fix cannot surface this: it can only prune ids it already had.
+    seedStore([makeMainWorktree('wt-main')])
+    expect(getVisibleWorktreeIds()).toEqual(['wt-main'])
 
-    expect(computeRenderedSidebarWorktreeOrder(state, [main, created])).toEqual([
-      'wt-main',
-      'wt-new'
+    seedStore([makeMainWorktree('wt-main'), makeWorktree('wt-created-while-closed')])
+
+    expect(getVisibleWorktreeIds()).toEqual(['wt-main', 'wt-created-while-closed'])
+  })
+
+  it('treats a published order as authoritative, including an explicitly empty one', () => {
+    seedStore([makeMainWorktree('wt-main'), makeWorktree('wt-feature')])
+
+    setVisibleWorktreeIds(['x'])
+    expect(getVisibleWorktreeIds()).toEqual(['x'])
+
+    // An empty rendered sidebar is a real order; the old length check fell through here.
+    setVisibleWorktreeIds([])
+    expect(getVisibleWorktreeIds()).toEqual([])
+
+    setVisibleWorktreeIds(null)
+    expect(getVisibleWorktreeIds()).toEqual(['wt-main', 'wt-feature'])
+  })
+
+  it('honors an explicit host filter and keeps the all-hosts default unfiltered', () => {
+    const localRepo = makeRepo('repo1')
+    const sshRepo = makeRepo('repo-ssh', { connectionId: 'my-target' })
+    // Base sort interleaves the hosts, so any host grouping has to reorder them.
+    const localMain = makeMainWorktree('wt-local-main', { sortOrder: 3 })
+    const remoteMain = makeMainWorktree('wt-remote-main', { repoId: 'repo-ssh', sortOrder: 2 })
+    const localFeature = makeWorktree('wt-local-feature', { sortOrder: 1 })
+    const remoteFeature = makeWorktree('wt-remote-feature', { repoId: 'repo-ssh', sortOrder: 0 })
+    const storeOverrides = {
+      repos: [localRepo, sshRepo],
+      worktreesByRepo: {
+        repo1: [localMain, localFeature],
+        'repo-ssh': [remoteMain, remoteFeature]
+      },
+      sshTargetLabels: new Map([['my-target', 'My Target']])
+    } as Partial<AppState>
+
+    seedStore([], storeOverrides)
+    // Default all-hosts scope adds no host sections, so repo grouping alone orders it.
+    expect(getVisibleWorktreeIds()).toEqual([
+      'wt-local-main',
+      'wt-local-feature',
+      'wt-remote-main',
+      'wt-remote-feature'
+    ])
+
+    seedStore([], { ...storeOverrides, visibleWorkspaceHostIds: ['local'] })
+    expect(getVisibleWorktreeIds()).toEqual(['wt-local-main', 'wt-local-feature'])
+
+    seedStore([], {
+      ...storeOverrides,
+      visibleWorkspaceHostIds: ['ssh:my-target', 'local']
+    })
+    // Host sections keep each host's workspaces contiguous, ordered by the host
+    // registry (local first) rather than by the filter argument's order.
+    expect(getVisibleWorktreeIds()).toEqual([
+      'wt-local-main',
+      'wt-local-feature',
+      'wt-remote-main',
+      'wt-remote-feature'
     ])
   })
 
-  it('emits each workspace once even when pinning would duplicate its row', () => {
-    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
-    const pinned = makeWorktree('wt-pinned', { isPinned: true })
-    const state = makeState([main, pinned])
+  it('keeps the sort layer intact for smart and comparator sort modes', () => {
+    const main = makeMainWorktree('wt-main')
+    const older = makeWorktree('wt-older', { displayName: 'b-older', lastActivityAt: 1 })
+    const newer = makeWorktree('wt-newer', { displayName: 'a-newer', lastActivityAt: 999 })
 
-    const order = computeRenderedSidebarWorktreeOrder(state, [main, pinned])
+    seedStore([older, newer, main], { sortBy: 'smart' })
+    expect(getVisibleWorktreeIds()).toEqual(['wt-main', 'wt-newer', 'wt-older'])
 
-    expect(order).toEqual([...new Set(order)])
-    expect(order).toContain('wt-pinned')
-  })
-
-  it('keeps grouping-free ordering intact when groupBy is none', () => {
-    const feature = makeWorktree('wt-feature')
-    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
-    const state = makeState([feature, main], { groupBy: 'none' })
-
-    expect(computeRenderedSidebarWorktreeOrder(state, [feature, main])).toEqual([
-      'wt-feature',
-      'wt-main'
-    ])
+    seedStore([older, newer, main], { sortBy: 'name' })
+    expect(getVisibleWorktreeIds()).toEqual(['wt-main', 'wt-newer', 'wt-older'])
   })
 })

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { computeRenderedSidebarWorktreeOrder } from './rendered-sidebar-worktree-order'
+import type { AppState } from '@/store/types'
+import type { Repo, Worktree } from '../../../../shared/types'
+
+function makeWorktree(id: string, overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id,
+    repoId: 'repo1',
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  } as Worktree
+}
+
+function makeRepo(id = 'repo1'): Repo {
+  return { id, name: id, path: `/tmp/${id}`, defaultBranch: 'main' } as unknown as Repo
+}
+
+/** Minimal store snapshot: only the fields the rendered-order pipeline reads. */
+function makeState(worktrees: Worktree[], overrides: Partial<AppState> = {}): AppState {
+  return {
+    repos: [makeRepo()],
+    worktreesByRepo: { repo1: worktrees },
+    groupBy: 'repo',
+    sortBy: 'manual',
+    projectOrderBy: 'manual',
+    collapsedGroups: new Set<string>(),
+    workspaceStatuses: [],
+    worktreeLineageById: {},
+    folderWorkspaces: [],
+    projectGroups: [],
+    settings: null,
+    prCache: null,
+    workspaceHostScope: 'all',
+    visibleWorkspaceHostIds: null,
+    workspaceHostOrder: [],
+    sshTargetLabels: new Map(),
+    sshConnectionStates: new Map(),
+    runtimeEnvironments: [],
+    runtimeStatusByEnvironmentId: new Map(),
+    projectHostSetups: [],
+    ...overrides
+  } as unknown as AppState
+}
+
+describe('computeRenderedSidebarWorktreeOrder', () => {
+  it('hoists the main worktree ahead of a higher-ranked child, like the rendered sidebar (#9497)', () => {
+    // The flat fallback preserved membership order; the sidebar anchors the repo's
+    // main workspace first, so Cmd+1 used to land on the wrong card.
+    const feature = makeWorktree('wt-feature')
+    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
+    const state = makeState([feature, main])
+
+    expect(computeRenderedSidebarWorktreeOrder(state, [feature, main])).toEqual([
+      'wt-main',
+      'wt-feature'
+    ])
+  })
+
+  it('omits workspaces in a collapsed group, which render no card and so own no number', () => {
+    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
+    const feature = makeWorktree('wt-feature')
+    // Legacy repos project to a synthetic project group, so that is the collapse key.
+    const state = makeState([main, feature], {
+      collapsedGroups: new Set(['project:repo:repo1'])
+    })
+
+    expect(computeRenderedSidebarWorktreeOrder(state, [main, feature])).toEqual([])
+  })
+
+  it('numbers a workspace created while the sidebar was closed', () => {
+    // A retained-cache fix cannot do this: it can only ever remove stale ids.
+    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
+    const created = makeWorktree('wt-new')
+    const state = makeState([main, created])
+
+    expect(computeRenderedSidebarWorktreeOrder(state, [main, created])).toEqual([
+      'wt-main',
+      'wt-new'
+    ])
+  })
+
+  it('emits each workspace once even when pinning would duplicate its row', () => {
+    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
+    const pinned = makeWorktree('wt-pinned', { isPinned: true })
+    const state = makeState([main, pinned])
+
+    const order = computeRenderedSidebarWorktreeOrder(state, [main, pinned])
+
+    expect(order).toEqual([...new Set(order)])
+    expect(order).toContain('wt-pinned')
+  })
+
+  it('keeps grouping-free ordering intact when groupBy is none', () => {
+    const feature = makeWorktree('wt-feature')
+    const main = makeWorktree('wt-main', { isMainWorktree: true, branch: 'refs/heads/main' })
+    const state = makeState([feature, main], { groupBy: 'none' })
+
+    expect(computeRenderedSidebarWorktreeOrder(state, [feature, main])).toEqual([
+      'wt-feature',
+      'wt-main'
+    ])
+  })
+})

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
@@ -124,9 +124,8 @@ describe('closed-sidebar Cmd+1-9 ordering (#9497)', () => {
   })
 
   it('ignores the agent-send collapse override, which only applies to a mounted list', () => {
-    // WorktreeList expands the send target's group via effectiveCollapsedGroups;
-    // this path reads state.collapsedGroups instead. That is only sound because a
-    // mounted list publishes its order and short-circuits this path entirely.
+    // Safe to ignore WorktreeList's effectiveCollapsedGroups override only because
+    // it needs a mounted list, which publishes its order and skips this path.
     const main = makeMainWorktree('wt-main')
     const feature = makeWorktree('wt-feature')
     seedStore([main, feature], {

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
@@ -123,6 +123,27 @@ describe('closed-sidebar Cmd+1-9 ordering (#9497)', () => {
     expect(order).not.toEqual(['wt-feature', 'wt-main'])
   })
 
+  it('ignores the agent-send collapse override, which only applies to a mounted list', () => {
+    // WorktreeList expands the send target's group via effectiveCollapsedGroups;
+    // this path reads state.collapsedGroups instead. That is only sound because a
+    // mounted list publishes its order and short-circuits this path entirely.
+    const main = makeMainWorktree('wt-main')
+    const feature = makeWorktree('wt-feature')
+    seedStore([main, feature], {
+      collapsedGroups: new Set(['project:repo:repo1']),
+      agentSendPopoverTargetMode: {
+        worktreeId: 'wt-feature',
+        id: 'send-1',
+        instanceId: 'inst-1'
+      } as AppState['agentSendPopoverTargetMode']
+    })
+
+    expect(getVisibleWorktreeIds()).toEqual([])
+
+    setVisibleWorktreeIds(['wt-feature', 'wt-main'])
+    expect(getVisibleWorktreeIds()).toEqual(['wt-feature', 'wt-main'])
+  })
+
   it('places a pinned workspace per the pinned section under both display policies', () => {
     const main = makeMainWorktree('wt-main')
     const plain = makeWorktree('wt-plain')

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
@@ -85,7 +85,7 @@ export function computeRenderedSidebarWorktreeOrder(
   )
 
   // Why lazy: with no host filter, addHostSectionRows is a pass-through, so skip building the whole host registry on a keystroke.
-  // Deliberately a superset of its internal guards — it still no-ops on <=1 host, which only costs us the skipped shortcut.
+  // Deliberately a superset of its internal guards — on <=1 host it still no-ops, wasting only the registry build.
   const needsHostSections =
     state.workspaceHostScope !== ALL_EXECUTION_HOSTS_SCOPE || state.visibleWorkspaceHostIds != null
   const sectionRows = needsHostSections

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
@@ -26,20 +26,13 @@ const EMPTY_INBOX_BY_REPO = Object.freeze(new Map()) as never
 const EMPTY_PENDING_CREATIONS = Object.freeze([]) as never
 
 /**
- * Orders already-filtered worktrees the way the sidebar would render them,
- * derived from a store snapshot with no mounted WorktreeList.
+ * Orders already-filtered worktrees the way the sidebar would render them, for
+ * Cmd+1–9 numbering while WorktreeList is unmounted (#9497).
  *
- * Why: Cmd+1–9 numbering must match the cards on screen. While the sidebar is
- * mounted WorktreeList publishes its exact rendered order. While it is closed
- * the old fallback returned a *flat* list — no grouping, pinning, main-worktree
- * hoisting or collapse elision — so the shortcut jumped to the wrong workspace
- * (#9497). Reusing the render pipeline keeps the two in agreement instead of
- * re-deriving the ordering rules a second time.
- *
- * Why it takes worktrees rather than computing them: membership filtering lives
- * in visible-worktrees.ts, this module's only caller. Passing them in keeps the
- * dependency one-way — that module owns the public entry points, which several
- * test suites mock by path.
+ * Why replay the pipeline: a flat list drops grouping, pinning, main-worktree
+ * hoisting and collapse elision, so the shortcut numbered the wrong card.
+ * Why worktrees are passed in: keeps the dependency on visible-worktrees.ts
+ * one-way, since test suites mock that module's path.
  */
 export function computeRenderedSidebarWorktreeOrder(
   state: AppState,
@@ -92,6 +85,7 @@ export function computeRenderedSidebarWorktreeOrder(
   )
 
   // Why lazy: with no host filter, addHostSectionRows is a pass-through, so skip building the whole host registry on a keystroke.
+  // Deliberately a superset of its internal guards — it still no-ops on <=1 host, which only costs us the skipped shortcut.
   const needsHostSections =
     state.workspaceHostScope !== ALL_EXECUTION_HOSTS_SCOPE || state.visibleWorkspaceHostIds != null
   const sectionRows = needsHostSections

--- a/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
+++ b/src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.ts
@@ -1,0 +1,128 @@
+import type { Worktree } from '../../../../shared/types'
+import type { AppState } from '@/store/types'
+import { getHostDisplayLabelOverrides } from '../../../../shared/host-setting-overrides'
+import {
+  ALL_EXECUTION_HOSTS_SCOPE,
+  getSettingsFocusedExecutionHostId
+} from '../../../../shared/execution-host'
+import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
+import { getProjectHostSetupProjectionFromState } from '@/store/project-host-setup-selector'
+import { buildRows, getPinnedWorktreeDisplayPolicy } from './worktree-list-groups'
+import { addHostSectionRows } from './host-section-rows'
+import { orderHostSectionOptions } from './host-section-order'
+import { buildSidebarHostOptions } from './sidebar-host-options'
+import { getLogicalRepoOrderRankById } from './project-header-drop'
+import { getRenderedWorktreesInSidebarOrder } from './worktree-sidebar-row-preference'
+import { selectWorktreeListReviewCacheInputs } from './worktree-list-review-cache-inputs'
+import {
+  filterFolderWorkspacesForVisibleHosts,
+  filterProjectGroupsForVisibleHosts,
+  getVisibleSidebarHostIdSet
+} from './worktree-list-host-filtering'
+
+const EMPTY_REPO_ID_SET: ReadonlySet<string> = Object.freeze(new Set<string>())
+const EMPTY_IMPORTED_BY_REPO = Object.freeze(new Map()) as never
+const EMPTY_INBOX_BY_REPO = Object.freeze(new Map()) as never
+const EMPTY_PENDING_CREATIONS = Object.freeze([]) as never
+
+/**
+ * Orders already-filtered worktrees the way the sidebar would render them,
+ * derived from a store snapshot with no mounted WorktreeList.
+ *
+ * Why: Cmd+1–9 numbering must match the cards on screen. While the sidebar is
+ * mounted WorktreeList publishes its exact rendered order. While it is closed
+ * the old fallback returned a *flat* list — no grouping, pinning, main-worktree
+ * hoisting or collapse elision — so the shortcut jumped to the wrong workspace
+ * (#9497). Reusing the render pipeline keeps the two in agreement instead of
+ * re-deriving the ordering rules a second time.
+ *
+ * Why it takes worktrees rather than computing them: membership filtering lives
+ * in visible-worktrees.ts, this module's only caller. Passing them in keeps the
+ * dependency one-way — that module owns the public entry points, which several
+ * test suites mock by path.
+ */
+export function computeRenderedSidebarWorktreeOrder(
+  state: AppState,
+  visibleWorktrees: readonly Worktree[]
+): string[] {
+  const defaultHostId = getSettingsFocusedExecutionHostId(state.settings)
+  const pinnedDisplayPolicy = getPinnedWorktreeDisplayPolicy(state.settings)
+  const projection = getProjectHostSetupProjectionFromState(state)
+  const visibleHostIdSet = getVisibleSidebarHostIdSet(
+    state.visibleWorkspaceHostIds,
+    state.workspaceHostScope
+  )
+  const projectGroups = state.projectGroups ?? []
+  const { prCache } = selectWorktreeListReviewCacheInputs(
+    state,
+    state.groupBy,
+    state.worktreeCardProperties
+  )
+
+  const rows = buildRows(
+    state.groupBy,
+    [...visibleWorktrees],
+    getRepoMapFromState(state),
+    prCache,
+    state.collapsedGroups,
+    getLogicalRepoOrderRankById(state.repos.map((repo) => repo.id)),
+    state.workspaceStatuses,
+    state.projectOrderBy,
+    state.worktreeLineageById,
+    getWorktreeMapFromState(state),
+    true,
+    state.settings,
+    filterProjectGroupsForVisibleHosts(projectGroups, visibleHostIdSet, defaultHostId),
+    // Why empty: placeholder/imported/inbox/pending inputs never emit item or folder-workspace rows, the only two the order reads.
+    EMPTY_REPO_ID_SET,
+    EMPTY_IMPORTED_BY_REPO,
+    EMPTY_INBOX_BY_REPO,
+    EMPTY_PENDING_CREATIONS,
+    { projects: projection.projects, projectHostSetups: projection.setups },
+    filterFolderWorkspacesForVisibleHosts(
+      state.folderWorkspaces,
+      projectGroups,
+      visibleHostIdSet,
+      defaultHostId
+    ),
+    // Why no hostLabelById: it only feeds display-only host context labels, never row order.
+    undefined,
+    defaultHostId,
+    pinnedDisplayPolicy
+  )
+
+  // Why lazy: with no host filter, addHostSectionRows is a pass-through, so skip building the whole host registry on a keystroke.
+  const needsHostSections =
+    state.workspaceHostScope !== ALL_EXECUTION_HOSTS_SCOPE || state.visibleWorkspaceHostIds != null
+  const sectionRows = needsHostSections
+    ? addHostSectionRows({
+        rows,
+        hostOptions: orderHostSectionOptions(
+          buildSidebarHostOptions({
+            repos: state.repos,
+            sshTargetLabels: state.sshTargetLabels,
+            sshConnectionStates: state.sshConnectionStates,
+            settings: state.settings,
+            runtimeEnvironments: state.runtimeEnvironments,
+            runtimeStatusByEnvironmentId: state.runtimeStatusByEnvironmentId,
+            hostLabelOverrides: getHostDisplayLabelOverrides(state.settings)
+          }),
+          state.workspaceHostOrder
+        ),
+        workspaceHostScope: state.workspaceHostScope,
+        visibleWorkspaceHostIds: state.visibleWorkspaceHostIds,
+        defaultHostId,
+        collapsedHostKeys: state.collapsedGroups,
+        forceCollapseHosts: false,
+        preferProjectGrouping: true
+      })
+    : rows
+
+  return Array.from(
+    new Set(
+      getRenderedWorktreesInSidebarOrder(sectionRows, pinnedDisplayPolicy).map(
+        (worktree) => worktree.id
+      )
+    )
+  )
+}

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -2,7 +2,11 @@ import type { Worktree, Repo, TerminalTab, WorktreeLineage } from '../../../../s
 import { buildWorktreeComparator, sortWorktreesSmart } from './smart-sort'
 import { getWorktreeIdsWithLiveAgent, isInactiveWorkspace } from '@/lib/worktree-activity-state'
 import { useAppStore } from '@/store'
-import { getAllWorktreesFromState, getRepoMapFromState } from '@/store/selectors'
+import {
+  getAllWorktreesFromState,
+  getRepoMapFromState,
+  getWorktreeMapFromState
+} from '@/store/selectors'
 import { DEFAULT_SHOW_SLEEPING_WORKSPACES } from '../../../../shared/constants'
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
@@ -15,6 +19,7 @@ import {
   getCyclicProjectedWorktreeLineageIds,
   getLineageRenderInfo
 } from './worktree-lineage-projection'
+import { computeRenderedSidebarWorktreeOrder } from './rendered-sidebar-worktree-order'
 
 /**
  * Whether a worktree represents the repo's default-branch row that the
@@ -270,15 +275,19 @@ function addVisibleLineageAncestors(
  * could target a different worktree than what's rendered at that sidebar
  * position. By caching the IDs that WorktreeList actually rendered, the
  * shortcut numbering always matches the sidebar card order.
+ *
+ * Why null vs []: [] is a real rendered order (everything collapsed/filtered);
+ * null means WorktreeList is unmounted.
  */
-let _cachedVisibleIds: string[] = []
+let _publishedVisibleIds: string[] | null = null
 
 /**
  * Called by WorktreeList after computing visible worktrees so the Cmd+1–9
- * handler can read the exact same ordering the user sees on screen.
+ * handler can read the exact same ordering the user sees on screen. Pass null
+ * on unmount.
  */
-export function setVisibleWorktreeIds(ids: string[]): void {
-  _cachedVisibleIds = ids
+export function setVisibleWorktreeIds(ids: string[] | null): void {
+  _publishedVisibleIds = ids
 }
 
 /**
@@ -286,17 +295,16 @@ export function setVisibleWorktreeIds(ids: string[]): void {
  * state. Called by the App-level Cmd+1–9 handler (not a React hook — reads
  * store snapshot at call time).
  *
- * If WorktreeList has rendered at least once, returns the cached IDs so the
- * shortcut numbering matches the sidebar. Falls back to a live recomputation
- * only before WorktreeList's first render (e.g. app startup).
+ * If WorktreeList is mounted, returns the exact IDs it rendered. Otherwise
+ * recomputes the order the sidebar *would* render from the same row pipeline,
+ * so a closed sidebar numbers workspaces the same way an open one does (#9497).
  */
 export function getVisibleWorktreeIds(): string[] {
-  // Prefer the cached IDs that mirror the rendered sidebar order.
-  if (_cachedVisibleIds.length > 0) {
-    return _cachedVisibleIds
+  // Prefer the published IDs that mirror the rendered sidebar order.
+  if (_publishedVisibleIds) {
+    return _publishedVisibleIds
   }
 
-  // Fallback: live recomputation for the window before WorktreeList renders.
   const state = useAppStore.getState()
   const allWorktrees = getAllWorktreesFromState(state).filter((w) => !w.isArchived)
 
@@ -325,7 +333,7 @@ export function getVisibleWorktreeIds(): string[] {
     sortedIds = sorted.map((w) => w.id)
   }
 
-  return computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
+  const visibleIds = computeVisibleWorktreeIds(state.worktreesByRepo, sortedIds, {
     filterRepoIds: state.filterRepoIds,
     showSleepingWorkspaces: state.showSleepingWorkspaces,
     tabsByWorktree: state.tabsByWorktree,
@@ -345,4 +353,11 @@ export function getVisibleWorktreeIds(): string[] {
     defaultHostId: getSettingsFocusedExecutionHostId(state.settings),
     worktreeLineageById: state.worktreeLineageById
   })
+
+  const worktreeMap = getWorktreeMapFromState(state)
+  // Why the row pipeline: grouping, pinning and main-worktree hoisting reorder cards, so a flat sort numbers the wrong workspace.
+  return computeRenderedSidebarWorktreeOrder(
+    state,
+    visibleIds.map((id) => worktreeMap.get(id)).filter((w): w is Worktree => w != null)
+  )
 }

--- a/src/renderer/src/components/sidebar/worktree-list-host-filtering.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-host-filtering.ts
@@ -1,11 +1,60 @@
 import {
+  ALL_EXECUTION_HOSTS_SCOPE,
   normalizeExecutionHostId,
   parseExecutionHostId,
   toSshExecutionHostId,
-  type ExecutionHostId
+  type ExecutionHostId,
+  type ExecutionHostScope
 } from '../../../../shared/execution-host'
 import type { FolderWorkspacePathStatusRequest } from '../../../../shared/folder-workspace-path-status'
 import type { FolderWorkspace, ProjectGroup } from '../../../../shared/types'
+
+/** null means "no host filter" — every host is visible. */
+export function getVisibleSidebarHostIdSet(
+  visibleWorkspaceHostIds: readonly ExecutionHostId[] | null | undefined,
+  workspaceHostScope: ExecutionHostScope
+): Set<ExecutionHostId> | null {
+  const visibleHostIds =
+    visibleWorkspaceHostIds ??
+    (workspaceHostScope === ALL_EXECUTION_HOSTS_SCOPE ? null : [workspaceHostScope])
+  return visibleHostIds ? new Set<ExecutionHostId>(visibleHostIds) : null
+}
+
+// Why shared: the sidebar render path and the Cmd+1–9 order must apply the same
+// host filtering, or the numbering drifts from the cards whenever a filter is on.
+export function filterProjectGroupsForVisibleHosts(
+  projectGroups: readonly ProjectGroup[],
+  visibleHostIdSet: ReadonlySet<ExecutionHostId> | null,
+  defaultHostId: ExecutionHostId
+): readonly ProjectGroup[] {
+  if (!visibleHostIdSet) {
+    return projectGroups
+  }
+  return projectGroups.filter((group) =>
+    visibleHostIdSet.has(getProjectGroupExecutionHostIdForRows(group, defaultHostId))
+  )
+}
+
+export function filterFolderWorkspacesForVisibleHosts(
+  folderWorkspaces: readonly FolderWorkspace[],
+  projectGroups: readonly ProjectGroup[],
+  visibleHostIdSet: ReadonlySet<ExecutionHostId> | null,
+  defaultHostId: ExecutionHostId
+): readonly FolderWorkspace[] {
+  if (!visibleHostIdSet) {
+    return folderWorkspaces
+  }
+  const projectGroupById = new Map(projectGroups.map((group) => [group.id, group]))
+  return folderWorkspaces.filter((folderWorkspace) =>
+    visibleHostIdSet.has(
+      getFolderWorkspaceExecutionHostIdForRows({
+        folderWorkspace,
+        projectGroup: projectGroupById.get(folderWorkspace.projectGroupId),
+        defaultHostId
+      })
+    )
+  )
+}
 
 export function getProjectGroupExecutionHostIdForRows(
   group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>,


### PR DESCRIPTION
Fixes #9497.

## What was wrong

Cmd/Ctrl+1–9 jumps to the Nth workspace card. The handler asks `getVisibleWorktreeIds()` for the order.

While the sidebar is **open**, `WorktreeList` publishes the exact list of IDs it rendered, so the numbering matches the cards. While the sidebar is **closed**, `WorktreeList` is unmounted and the function fell back to a **flat, membership-ordered** list — a filtered-and-sorted set of workspace IDs that never went through the sidebar's row pipeline.

That flat list ignores everything the pipeline does to arrange cards:

- **main-worktree hoisting** — each repo's main workspace is anchored to the top of its group
- **grouping** by repo/project/status, and **project group ordering**
- **pinning** — pinned workspaces are lifted into their own section (policy-dependent)
- **collapsed groups** — members render no card at all, so they own no number
- **host sections** — with a host filter on, workspaces are re-bucketed per host
- **folder workspaces** — these only ever enter via folder-workspace rows, so the flat list omitted them **entirely**

So closing the sidebar silently renumbered the workspaces. The reporter's "Cmd+1 selects the second workspace" is exactly the main-worktree hoisting case: the flat list kept membership order, while the sidebar had hoisted `main` to position 1.

## ELI5

The sidebar is a list of doors, numbered top to bottom. When the sidebar was open, door #1 was the one your eyes landed on first. When you closed the sidebar, the app stopped looking at the doors and instead read an **unsorted inventory sheet** — same doors, different order. Pressing "1" opened whatever door happened to be first on the sheet, which usually wasn't the door you'd counted as first.

Now, with the sidebar closed, the app arranges the doors the same way the sidebar would have before counting — so "1" always means the same door.

## The fix

New module `rendered-sidebar-worktree-order.ts` replays the sidebar's own pipeline against a store snapshot:

```
buildRows(...) → addHostSectionRows(...) → getRenderedWorktreesInSidebarOrder(...)
```

This **reuses** the ordering logic rather than re-deriving it, so the two paths can't drift apart later. Its arguments mirror `WorktreeList`'s real call sites one-for-one.

Two deliberate simplifications, both proven not to affect order:
- The four placeholder/imported/inbox/pending inputs are passed empty — they only ever emit *their own* row types, never item or folder-workspace rows (the only two the order reads).
- `hostLabelById` is `undefined` — it feeds display-only host context labels, never row order.

`addHostSectionRows` is skipped when there's no host filter, where it is a pass-through — so a keystroke doesn't build the whole host registry for nothing.

### Second, separate bug fixed

The published-order cache was guarded by `if (_cachedVisibleIds.length > 0)`. An empty array is ambiguous: it means *both* "unmounted" and "mounted, but every card is collapsed or filtered away". In the second case the guard fell through to the flat list, so a **mounted** sidebar showing zero cards could still jump to a workspace with no visible card. The published order is now `string[] | null`, where `null` means unmounted and `[]` is a real, authoritative empty order.

## Fix proof

![Cmd+1 order: sidebar open vs closed, before and after](https://raw.githubusercontent.com/stablyai/orca/evidence/9497-shortcut-order/9497-order.png)

*Both the "before" and "after" closed-sidebar orders in this image are produced by running the real code paths against a seeded store — they are not hand-authored mockups. Source: [`evidence/9497-shortcut-order`](https://github.com/stablyai/orca/tree/evidence/9497-shortcut-order).*


9 new tests drive the real `getVisibleWorktreeIds()` entry point against a seeded store — not the internal helper — so they cover the exact path the Cmd+N handler takes.

**Mutation-tested** (the tests fail when the fix is removed, so they aren't tautological):

| Mutation | Result |
|---|---|
| Restore the old flat fallback | **9 of 9 fail.** Headline case returns `['wt-feature','wt-main']` where the sidebar renders `['wt-main','wt-feature']` — the reported symptom, reproduced exactly. |
| Restore the `length > 0` guard | **Exactly 1 fails** — the explicitly-empty-order test, isolating the second bug. |
| Both restored (i.e. `main`) | Baseline green. |

Coverage: main-worktree hoisting, collapsed groups, folder workspaces, explicit host filtering, both pinned-display policies, smart + comparator sort modes, and published-vs-recomputed precedence.

## Proof of no regressions

- **1674/1674** tests pass across `src/renderer/src/components/sidebar/` + `useIpcEvents.test.ts` (184 files)
- `tsc -p config/tsconfig.tc.web.json --noEmit` → exit 0
- `oxlint src/renderer/src/components/sidebar/` → exit 0
- `useIpcEvents.test.ts` 81/81 still green — its 15 `vi.doMock('@/components/sidebar/visible-worktrees', …)` sites still intercept, because the public entry points deliberately stayed in that module (the new module is a leaf it calls, not a replacement)
- No `max-lines` disable added; `visible-worktrees.ts` stays within its 300-line budget

### Performance

`getVisibleWorktreeIds()` now runs the row pipeline. Its only production caller is the `onJumpToWorktreeIndex` IPC handler — **once per keystroke**, not in any render path or high-frequency event. Measured on this machine:

| Workspaces | Cost per call |
|---|---|
| 50 | 0.12 ms |
| 500 | 0.78 ms |

Scaling is linear (10× the workspaces → 10.3× the time), so there's no hidden quadratic. Sub-millisecond at 500 workspaces is far inside a 16 ms frame.

### Trade-offs

- The closed-sidebar path does **more work** than before (a full row-pipeline pass instead of a flat map). Quantified above: ~0.1–0.8 ms, once per keypress. Correctness is worth it, and the alternative — caching the last rendered order — cannot number a workspace **created while the sidebar was closed**, since a retained cache can only ever *remove* IDs it already had. There is a test for exactly that case.
- Ordering rules now have one owner. If someone adds a new row type that should be numbered, they must add it to `getRenderedWorktreesInSidebarOrder` — but that was already true for the sidebar itself, so this removes a divergence rather than adding an obligation.
- **No user-visible regression.** The numbering only changes where it was previously *wrong* (sidebar closed); the open-sidebar path is untouched and still uses the published order verbatim.

### Cross-platform

Ordering logic only — no platform branches added or touched. The Cmd-vs-Ctrl decision happens upstream in `shared/window-shortcut-policy.ts`, which is already platform-aware and unmodified. Nothing here is macOS-specific despite the issue's `os:macos` label; Linux/Windows users were hitting the same wrong ordering via Ctrl+N.

## Relationship to #9548

@OnlyYu1996 opened #9548 for this issue first, and their diagnosis of the open-vs-closed split was correct — credit to them for finding it. That PR prunes the retained cache on unmount. I went a different way because pruning can only ever *remove* stale IDs: a workspace created while the sidebar is closed still gets no number, and the ordering rules stay duplicated in two places. This PR derives the order from the sidebar's own pipeline instead, which covers both. Happy to close either one in favor of the other.

## Review loop

Adversarially reviewed by two independent models (GPT-5.6-Sol and Fable). **4 rounds to clean.**

| Round | Focus | Verdict |
|---|---|---|
| 1 | Broad correctness + tests | **Not clean.** Produced a stronger test file driving the real `getVisibleWorktreeIds()` entry point (adopted after I verified it), but it also asserted a fabricated host-section order — corrected against `host-section-rows.ts:265-270`, which orders by the host registry, not by the filter argument. |
| 2 | Argument fidelity + sentinel lifecycle | Inconclusive (reviewers timed out). I did this pass myself and found the one real fidelity risk: `effectiveCollapsedGroups` vs `state.collapsedGroups`. Resolved — the divergence needs an open agent-send popover, which needs a mounted sidebar, which publishes its order and never reaches this path. Pinned by a test. |
| 3 | Row-order fidelity; sentinel staleness | **CLEAN** ×2. No argument mismatch affecting order/membership. StrictMode setup→cleanup→setup ends correct; `useReusedArrayIdentity` only reuses identity when every element is strictly equal, so a content change always re-publishes. |
| 4 | Dedupe occurrence; folder-workspace id namespace; false test assertions | **CLEAN.** `getRenderedWorktreesInSidebarOrder` already emits one row per workspace at its preferred position, so the trailing `new Set` has no duplicate to mis-choose; folder-workspace keys resolve end-to-end via `getKnownWorktreeById`. |

Two review comments were acted on rather than argued: the module JSDoc was trimmed from 16 lines to 7 per AGENTS.md's concise-comment rule, and a `needsHostSections` note that misstated the cost was corrected.

An independent reviewer also statically checked the headline test against the pre-fix commit `c06bf64b48` and reproduced the failure — pre-fix ordering yields `['wt-feature','wt-main']` where the test requires `['wt-main','wt-feature']`.
